### PR TITLE
fix: cherrypick nullable vector follow-up fixes to 2.6

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -320,7 +320,7 @@ proxy:
       bufSize: 512 # The maximum number of messages can be buffered in the timeTick message stream of the proxy when producing messages.
   maxNameLength: 255 # The maximum length of the name or alias that can be created in Milvus, including the collection name, collection alias, partition name, and field name.
   maxFieldNum: 64 # The maximum number of field can be created when creating in a collection. It is strongly DISCOURAGED to set maxFieldNum >= 64.
-  maxVectorFieldNum: 4 # The maximum number of vector fields that can be specified in a collection
+  maxVectorFieldNum: 10 # The maximum number of vector fields that can be specified in a collection
   maxShardNum: 16 # The maximum number of shards can be created when creating in a collection.
   maxDimension: 32768 # The maximum number of dimensions of a vector can have when creating in a collection.
   # Whether to produce gin logs.\n

--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -27,8 +27,10 @@
 #include <boost/dynamic_bitset.hpp>
 #include <NamedType/named_type.hpp>
 
+#include "common/BitsetView.h"
 #include "common/FieldMeta.h"
 #include "common/OffsetMapping.h"
+#include "common/Types.h"
 #include "pb/schema.pb.h"
 #include "knowhere/index/index_node.h"
 
@@ -274,6 +276,14 @@ struct SearchResult {
         this->vector_iterators_ = vector_iterators;
     }
 
+    BitsetView
+    PinBitset(TargetBitmap&& bitset) {
+        auto pinned = std::make_unique<TargetBitmap>(std::move(bitset));
+        auto view = BitsetView(*pinned);
+        pinned_bitsets_.emplace_back(std::move(pinned));
+        return view;
+    }
+
  public:
     int64_t total_nq_;
     int64_t unity_topK_;
@@ -306,6 +316,7 @@ struct SearchResult {
         vector_iterators_;
     // record the storage usage in search
     StorageCost search_storage_cost_;
+    std::vector<TargetBitmapPtr> pinned_bitsets_{};
 };
 
 using SearchResultPtr = std::shared_ptr<SearchResult>;

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -160,7 +160,6 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
         BitsetView search_bitset = bitset;
         if (offset_mapping.IsEnabled()) {
             transformed_bitset = TransformBitset(bitset, offset_mapping);
-            search_bitset = BitsetView(transformed_bitset);
         }
 
         auto active_count = offset_mapping.IsEnabled()
@@ -177,6 +176,10 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             search_result.total_nq_ = num_queries;
             search_result.unity_topK_ = info.topk_;
             return;
+        }
+        if (offset_mapping.IsEnabled()) {
+            search_bitset =
+                search_result.PinBitset(std::move(transformed_bitset));
         }
 
         if (info.iterator_v2_info_.has_value()) {

--- a/internal/core/src/query/SearchOnIndex.cpp
+++ b/internal/core/src/query/SearchOnIndex.cpp
@@ -35,7 +35,6 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
     BitsetView search_bitset = bitset;
     if (offset_mapping.IsEnabled()) {
         transformed_bitset = TransformBitset(bitset, offset_mapping);
-        search_bitset = BitsetView(transformed_bitset);
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
             auto total_num = num_queries * search_conf.topk_;
@@ -45,6 +44,7 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
             search_result.unity_topK_ = search_conf.topk_;
             return;
         }
+        search_bitset = search_result.PinBitset(std::move(transformed_bitset));
     }
 
     if (milvus::exec::PrepareVectorIteratorsFromIndex(search_conf,

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -80,7 +80,6 @@ SearchOnSealedIndex(const Schema& schema,
     BitsetView search_bitset = bitset;
     if (offset_mapping.IsEnabled()) {
         transformed_bitset = TransformBitset(bitset, offset_mapping);
-        search_bitset = BitsetView(transformed_bitset);
         if (offset_mapping.GetValidCount() == 0) {
             auto total_num = num_queries * topK;
             search_result.seg_offsets_.resize(total_num, INVALID_SEG_OFFSET);
@@ -89,6 +88,7 @@ SearchOnSealedIndex(const Schema& schema,
             search_result.unity_topK_ = topK;
             return;
         }
+        search_bitset = search_result.PinBitset(std::move(transformed_bitset));
     }
 
     if (search_info.iterator_v2_info_.has_value()) {
@@ -164,7 +164,6 @@ SearchOnSealedColumn(const Schema& schema,
             column->EnsureChunkOffsetMapping(c, op_context);
         }
         transformed_bitset = TransformBitset(bitview, offset_mapping);
-        search_bitview = BitsetView(transformed_bitset);
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
             auto total_num = num_queries * search_info.topk_;
@@ -174,6 +173,7 @@ SearchOnSealedColumn(const Schema& schema,
             result.unity_topK_ = search_info.topk_;
             return;
         }
+        search_bitview = result.PinBitset(std::move(transformed_bitset));
     }
 
     if (search_info.iterator_v2_info_.has_value()) {
@@ -194,6 +194,8 @@ SearchOnSealedColumn(const Schema& schema,
         return;
     }
 
+    const bool use_vector_iterator =
+        milvus::exec::UseVectorIterator(search_info);
     auto num_chunk = column->num_chunks();
 
     SubSearchResult final_qr(num_queries,
@@ -224,7 +226,7 @@ SearchOnSealedColumn(const Schema& schema,
             raw_dataset.raw_data_offsets = offsets_pw.get();
         }
 
-        if (milvus::exec::UseVectorIterator(search_info)) {
+        if (use_vector_iterator) {
             AssertInfo(data_type != DataType::VECTOR_ARRAY,
                        "vector array(embedding list) is not supported for "
                        "vector iterator");
@@ -249,7 +251,7 @@ SearchOnSealedColumn(const Schema& schema,
         }
         offset += chunk_size;
     }
-    if (milvus::exec::UseVectorIterator(search_info)) {
+    if (use_vector_iterator) {
         bool larger_is_closer = PositivelyRelated(search_info.metric_type_);
         result.AssembleChunkVectorIterators(num_queries,
                                             num_chunk,

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -1,0 +1,366 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/BitsetView.h"
+#include "common/Chunk.h"
+#include "common/IndexMeta.h"
+#include "common/QueryInfo.h"
+#include "common/QueryResult.h"
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "index/IndexFactory.h"
+#include "index/VectorIndex.h"
+#include "knowhere/comp/index_param.h"
+#include "knowhere/dataset.h"
+#include "mmap/ChunkedColumn.h"
+#include "query/SearchOnGrowing.h"
+#include "query/SearchOnSealed.h"
+#include "segcore/SegmentGrowing.h"
+#include "segcore/SegmentGrowingImpl.h"
+#include "segcore/SealedIndexingRecord.h"
+#include "test_utils/DataGen.h"
+#include "test_utils/cachinglayer_test_utils.h"
+
+namespace milvus::query {
+namespace {
+
+constexpr int64_t kDim = 36;
+constexpr int64_t kTopK = 15;
+
+std::vector<uint8_t>
+MakeLogicalBitsetBytes(int64_t total_count) {
+    std::vector<uint8_t> logical_bitset_bytes((total_count + 7) / 8, 0);
+    for (int64_t i = 0; i < total_count; i += 7) {
+        logical_bitset_bytes[i >> 3] |= 1U << (i & 0x07);
+    }
+    return logical_bitset_bytes;
+}
+
+std::unique_ptr<bool[]>
+MakeValidData(int64_t total_count, int64_t& valid_count) {
+    std::unique_ptr<bool[]> valid_data(new bool[total_count]);
+    valid_count = 0;
+    for (int64_t i = 0; i < total_count; ++i) {
+        valid_data[i] = i % 10 != 9;
+        if (valid_data[i]) {
+            ++valid_count;
+        }
+    }
+    return valid_data;
+}
+
+std::vector<float>
+MakeCompactVectors(int64_t valid_count, int64_t dim) {
+    std::vector<float> vectors(static_cast<size_t>(valid_count * dim));
+    for (size_t i = 0; i < vectors.size(); ++i) {
+        vectors[i] = static_cast<float>((i % 97) + 1) / 97.0F;
+    }
+    return vectors;
+}
+
+SearchInfo
+MakeGroupBySearchInfo(FieldId vector_field,
+                      FieldId group_by_field,
+                      const MetricType& metric_type) {
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = kTopK;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = metric_type;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::indexparam::NPROBE, "32"},
+    };
+    search_info.group_by_field_id_ = group_by_field;
+    return search_info;
+}
+
+void
+AssertVectorIteratorUsableAfterSearchReturns(SearchResult& search_result,
+                                             int64_t max_results) {
+    ASSERT_EQ(search_result.pinned_bitsets_.size(), 1);
+    ASSERT_TRUE(search_result.vector_iterators_.has_value());
+    ASSERT_FALSE(search_result.vector_iterators_->empty());
+
+    auto iterator = search_result.vector_iterators_->at(0);
+    ASSERT_NE(iterator, nullptr);
+
+    int64_t result_count = 0;
+    while (iterator->HasNext() && result_count < max_results) {
+        auto result = iterator->Next();
+        ASSERT_TRUE(result.has_value());
+        ++result_count;
+    }
+    ASSERT_GT(result_count, 0);
+}
+
+const DataArray&
+FindFieldData(const segcore::GeneratedData& dataset, FieldId field_id) {
+    for (const auto& field_data : dataset.raw_->fields_data()) {
+        if (field_data.field_id() == field_id.get()) {
+            return field_data;
+        }
+    }
+    ThrowInfo(FieldIDInvalid, "field id not found: {}", field_id.get());
+}
+
+int64_t
+CountValidRows(const DataArray& data, int64_t total_count) {
+    if (data.valid_data_size() == 0) {
+        return total_count;
+    }
+    return std::count(data.valid_data().begin(), data.valid_data().end(), true);
+}
+
+std::shared_ptr<ChunkedColumn>
+BuildNullableFloatVectorColumn(const FieldMeta& field_meta,
+                               int64_t total_count,
+                               int64_t dim,
+                               const bool* valid_data,
+                               const std::vector<float>& vectors,
+                               std::vector<std::vector<char>>& chunk_buffers) {
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    std::vector<int64_t> num_rows_per_chunk;
+    num_rows_per_chunk.push_back(total_count);
+
+    auto null_bitmap_bytes = (total_count + 7) / 8;
+    auto vector_data_bytes = vectors.size() * sizeof(float);
+    auto buffer_size = null_bitmap_bytes + vector_data_bytes;
+    chunk_buffers.emplace_back(buffer_size, 0);
+    char* buffer = chunk_buffers.back().data();
+
+    for (int64_t i = 0; i < total_count; ++i) {
+        if (valid_data[i]) {
+            buffer[i >> 3] |= 1U << (i & 0x07);
+        }
+    }
+    std::memcpy(buffer + null_bitmap_bytes, vectors.data(), vector_data_bytes);
+
+    auto chunk_mmap_guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    chunks.emplace_back(std::make_unique<FixedWidthChunk>(total_count,
+                                                          dim,
+                                                          buffer,
+                                                          buffer_size,
+                                                          sizeof(float),
+                                                          true,
+                                                          chunk_mmap_guard));
+
+    auto translator = std::make_unique<TestChunkTranslator>(
+        num_rows_per_chunk, "", std::move(chunks));
+    auto slot =
+        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+            std::move(translator), nullptr);
+    auto column = std::make_shared<ChunkedColumn>(std::move(slot), field_meta);
+    column->BuildValidRowIds(nullptr);
+    return column;
+}
+
+std::unique_ptr<index::IndexBase>
+BuildNullableVectorIndex(int64_t total_count,
+                         int64_t dim,
+                         const bool* valid_data,
+                         const std::vector<float>& vectors) {
+    index::CreateIndexInfo create_index_info;
+    create_index_info.field_type = DataType::VECTOR_FLOAT;
+    create_index_info.metric_type = knowhere::metric::COSINE;
+    create_index_info.index_type = knowhere::IndexEnum::INDEX_FAISS_IVFFLAT;
+    create_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+
+    auto index_base = index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, storage::FileManagerContext());
+    auto* vector_index = dynamic_cast<index::VectorIndex*>(index_base.get());
+    if (vector_index == nullptr) {
+        ADD_FAILURE() << "failed to create vector index";
+        return index_base;
+    }
+
+    auto build_dataset =
+        knowhere::GenDataSet(vectors.size() / dim, dim, vectors.data());
+    auto build_conf = knowhere::Json{
+        {knowhere::meta::METRIC_TYPE, knowhere::metric::COSINE},
+        {knowhere::meta::DIM, std::to_string(dim)},
+        {knowhere::indexparam::NLIST, "128"},
+    };
+    index_base->BuildWithDataset(build_dataset, build_conf);
+    vector_index->BuildValidData(valid_data, total_count);
+    return index_base;
+}
+
+}  // namespace
+
+TEST(SearchOnSealedIndexBitsetLifetime,
+     GroupByIteratorMustNotKeepDanglingTransformedBitset) {
+    constexpr int64_t total_count = 10000;
+
+    int64_t valid_count = 0;
+    auto valid_data = MakeValidData(total_count, valid_count);
+    auto vectors = MakeCompactVectors(valid_count, kDim);
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::COSINE, true);
+    auto group_by_field = schema->AddDebugField("group_by", DataType::INT8);
+    schema->set_primary_field_id(group_by_field);
+
+    auto index_base =
+        BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
+    auto* vector_index = dynamic_cast<index::VectorIndex*>(index_base.get());
+    ASSERT_NE(vector_index, nullptr);
+    ASSERT_TRUE(vector_index->GetOffsetMapping().IsEnabled());
+
+    segcore::SealedIndexingRecord indexing_record;
+    indexing_record.append_field_indexing(
+        vector_field,
+        knowhere::metric::COSINE,
+        CreateTestCacheIndex("nullable-vector-bitset-lifetime",
+                             std::move(index_base)));
+
+    auto logical_bitset_bytes = MakeLogicalBitsetBytes(total_count);
+    BitsetView logical_bitset(logical_bitset_bytes.data(), total_count);
+
+    std::vector<float> query(vectors.begin(), vectors.begin() + kDim);
+    auto search_info = MakeGroupBySearchInfo(
+        vector_field, group_by_field, knowhere::metric::COSINE);
+
+    SearchResult search_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        search_info,
+                        query.data(),
+                        nullptr,
+                        1,
+                        logical_bitset,
+                        nullptr,
+                        search_result);
+
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+}
+
+TEST(SearchOnGrowingBitsetLifetime,
+     GroupByIteratorMustNotKeepDanglingTransformedBitset) {
+    constexpr int64_t total_count = 512;
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::L2, true);
+    auto group_by_field = schema->AddDebugField("group_by", DataType::INT64);
+    schema->set_primary_field_id(group_by_field);
+
+    auto dataset = segcore::DataGen(schema,
+                                    total_count,
+                                    /*seed=*/42,
+                                    /*ts_offset=*/0,
+                                    /*repeat_count=*/1,
+                                    /*array_len=*/10,
+                                    /*group_count=*/1,
+                                    /*random_pk=*/false,
+                                    /*random_val=*/true,
+                                    /*random_valid=*/false,
+                                    /*null_percent=*/10);
+    const auto& vector_data = FindFieldData(dataset, vector_field);
+    auto valid_count = CountValidRows(vector_data, total_count);
+    ASSERT_GT(valid_count, 0);
+
+    auto segment = segcore::CreateGrowingSegment(schema, empty_index_meta);
+    auto reserved_offset = segment->PreInsert(total_count);
+    segment->Insert(reserved_offset,
+                    total_count,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+    auto* growing_segment =
+        dynamic_cast<segcore::SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(growing_segment, nullptr);
+
+    auto logical_bitset_bytes = MakeLogicalBitsetBytes(total_count);
+    BitsetView logical_bitset(logical_bitset_bytes.data(), total_count);
+
+    const auto& vectors = vector_data.vectors().float_vector().data();
+    ASSERT_GE(vectors.size(), kDim);
+    auto search_info = MakeGroupBySearchInfo(
+        vector_field, group_by_field, knowhere::metric::L2);
+
+    SearchResult search_result;
+    SearchOnGrowing(*growing_segment,
+                    search_info,
+                    vectors.data(),
+                    nullptr,
+                    1,
+                    MAX_TIMESTAMP,
+                    logical_bitset,
+                    nullptr,
+                    search_result);
+
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+}
+
+TEST(SearchOnSealedColumnBitsetLifetime,
+     GroupByIteratorMustNotKeepDanglingTransformedBitset) {
+    constexpr int64_t total_count = 512;
+
+    int64_t valid_count = 0;
+    auto valid_data = MakeValidData(total_count, valid_count);
+    auto vectors = MakeCompactVectors(valid_count, kDim);
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::L2, true);
+    auto group_by_field = schema->AddDebugField("group_by", DataType::INT8);
+    schema->set_primary_field_id(group_by_field);
+
+    std::vector<std::vector<char>> chunk_buffers;
+    auto column = BuildNullableFloatVectorColumn((*schema)[vector_field],
+                                                 total_count,
+                                                 kDim,
+                                                 valid_data.get(),
+                                                 vectors,
+                                                 chunk_buffers);
+    ASSERT_TRUE(column->GetOffsetMapping().IsEnabled());
+    ASSERT_EQ(column->GetOffsetMapping().GetValidCount(), valid_count);
+
+    auto logical_bitset_bytes = MakeLogicalBitsetBytes(total_count);
+    BitsetView logical_bitset(logical_bitset_bytes.data(), total_count);
+
+    auto search_info = MakeGroupBySearchInfo(
+        vector_field, group_by_field, knowhere::metric::L2);
+
+    SearchResult search_result;
+    SearchOnSealedColumn(*schema,
+                         column.get(),
+                         search_info,
+                         std::map<std::string, std::string>{},
+                         vectors.data(),
+                         nullptr,
+                         1,
+                         total_count,
+                         logical_bitset,
+                         nullptr,
+                         search_result);
+
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+}
+
+}  // namespace milvus::query

--- a/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
@@ -648,6 +648,132 @@ INSTANTIATE_TEST_SUITE_P(MetricTypeParameters,
                          BinlogIndexTest,
                          ::testing::ValuesIn(GenerateTestParams()));
 
+TEST(test_chunk_segment,
+     NullableVectorProjectionFallsBackWhenLoadedIndexHasNoValidData) {
+    auto schema = std::make_shared<Schema>();
+    const int64_t dim = 8;
+    const int64_t data_n = 200;
+    auto vec_field_id = schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2, true);
+    auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
+    schema->set_primary_field_id(i64_fid);
+
+    std::map<std::string, std::string> index_params = {
+        {"index_type", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT},
+        {"metric_type", knowhere::metric::L2},
+        {"nlist", "16"}};
+    std::map<std::string, std::string> type_params = {
+        {"dim", std::to_string(dim)}};
+    FieldIndexMeta field_index_meta(
+        vec_field_id, std::move(index_params), std::move(type_params));
+    IndexMetaPtr collection_index_meta = std::make_shared<CollectionIndexMeta>(
+        226985,
+        std::map<FieldId, FieldIndexMeta>{{vec_field_id, field_index_meta}});
+
+    auto segment = CreateSealedSegment(schema, collection_index_meta);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    std::vector<uint8_t> valid_data((data_n + 7) / 8, 0);
+    int64_t valid_count = 0;
+    for (int64_t i = 0; i < data_n; ++i) {
+        if ((i % 100) >= 50) {
+            valid_data[i >> 3] |= (1 << (i & 0x07));
+            ++valid_count;
+        }
+    }
+    ASSERT_EQ(valid_count, data_n / 2);
+
+    std::vector<float> vec_values(valid_count * dim);
+    for (int64_t i = 0; i < valid_count; ++i) {
+        for (int64_t d = 0; d < dim; ++d) {
+            vec_values[i * dim + d] = static_cast<float>(i * dim + d);
+        }
+    }
+
+    auto vec_field_data = milvus::storage::CreateFieldData(
+        DataType::VECTOR_FLOAT, DataType::NONE, true, dim);
+    auto vec_field_data_impl =
+        std::dynamic_pointer_cast<milvus::FieldData<milvus::FloatVector>>(
+            vec_field_data);
+    ASSERT_NE(vec_field_data_impl, nullptr);
+    vec_field_data_impl->FillFieldData(
+        vec_values.data(), valid_data.data(), data_n, 0);
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_field_info = PrepareSingleFieldInsertBinlog(kCollectionID,
+                                                          kPartitionID,
+                                                          kSegmentID,
+                                                          vec_field_id.get(),
+                                                          {vec_field_data},
+                                                          cm);
+    ASSERT_NO_THROW(segment->LoadFieldData(load_field_info));
+    ASSERT_TRUE(segment->HasFieldData(vec_field_id));
+    ASSERT_EQ(segment->get_row_count(), data_n);
+
+    auto raw_dataset =
+        knowhere::GenDataSet(valid_count, dim, vec_values.data());
+    raw_dataset->SetIsOwner(false);
+
+    milvus::index::CreateIndexInfo create_index_info;
+    create_index_info.field_type = DataType::VECTOR_FLOAT;
+    create_index_info.metric_type = knowhere::metric::L2;
+    create_index_info.index_type = knowhere::IndexEnum::INDEX_FAISS_IVFFLAT;
+    create_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+    auto indexing = milvus::index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, milvus::storage::FileManagerContext());
+
+    auto build_conf =
+        knowhere::Json{{knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
+                       {knowhere::meta::DIM, std::to_string(dim)},
+                       {knowhere::indexparam::NLIST, "16"}};
+    indexing->BuildWithDataset(raw_dataset, build_conf);
+
+    LoadIndexInfo load_info;
+    load_info.field_id = vec_field_id.get();
+    load_info.index_params = GenIndexParams(indexing.get());
+    load_info.cache_index = CreateTestCacheIndex("test", std::move(indexing));
+    load_info.index_params["metric_type"] = knowhere::metric::L2;
+    ASSERT_NO_THROW(segment->LoadIndex(load_info));
+    ASSERT_TRUE(segment->HasIndex(vec_field_id));
+    ASSERT_TRUE(segment->HasFieldData(vec_field_id));
+
+    std::vector<int64_t> null_offsets = {0, 1, 100, 101};
+    auto null_result = sealed->bulk_subscript(
+        nullptr, vec_field_id, null_offsets.data(), null_offsets.size());
+
+    ASSERT_EQ(null_result->valid_data_size(), null_offsets.size());
+    for (int i = 0; i < null_result->valid_data_size(); ++i) {
+        EXPECT_FALSE(null_result->valid_data(i));
+    }
+    EXPECT_TRUE(null_result->vectors().float_vector().data().empty());
+
+    std::vector<int64_t> offsets = {0, 50, 100, 150};
+    auto result = sealed->bulk_subscript(
+        nullptr, vec_field_id, offsets.data(), offsets.size());
+
+    ASSERT_EQ(result->valid_data_size(), offsets.size());
+    EXPECT_FALSE(result->valid_data(0));
+    EXPECT_TRUE(result->valid_data(1));
+    EXPECT_FALSE(result->valid_data(2));
+    EXPECT_TRUE(result->valid_data(3));
+
+    const auto& returned = result->vectors().float_vector().data();
+    ASSERT_EQ(returned.size(), 2 * dim);
+    std::vector<int64_t> expected_physical_offsets = {0, 50};
+    for (int64_t i = 0;
+         i < static_cast<int64_t>(expected_physical_offsets.size());
+         ++i) {
+        auto physical_offset = expected_physical_offsets[i];
+        for (int64_t d = 0; d < dim; ++d) {
+            EXPECT_FLOAT_EQ(returned[i * dim + d],
+                            vec_values[physical_offset * dim + d]);
+        }
+    }
+}
+
 TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
     IndexMetaPtr collection_index_meta = GetCollectionIndexMeta(index_type);
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -171,7 +171,11 @@ ChunkedSegmentSealedImpl::LoadVecIndex(const LoadIndexInfo& info) {
         info.field_id,
         id_);
 
-    if (request.has_raw_data && get_bit(field_data_ready_bitset_, field_id)) {
+    const bool keep_nullable_vector_field_data =
+        field_meta.is_nullable() &&
+        IsVectorDataType(field_meta.get_data_type());
+    if (request.has_raw_data && !keep_nullable_vector_field_data &&
+        get_bit(field_data_ready_bitset_, field_id)) {
         drop_field_data_locked(field_id);
     }
     if (get_bit(binlog_index_bitset_, field_id)) {
@@ -924,6 +928,7 @@ ChunkedSegmentSealedImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
     ValidResult result;
     result.valid_count = count;
 
+    bool got_valid_offsets_from_index = false;
     if (vector_indexings_.is_ready(field_id)) {
         auto field_indexing = vector_indexings_.get_field_indexing(field_id);
         auto cache_index = field_indexing->indexing_;
@@ -946,8 +951,11 @@ ChunkedSegmentSealedImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
                 }
             }
             result.valid_count = result.valid_offsets.size();
+            got_valid_offsets_from_index = true;
         }
-    } else {
+    }
+
+    if (!got_valid_offsets_from_index) {
         auto column = get_column(field_id);
         if (column != nullptr && column->IsNullable()) {
             result.valid_data = std::make_unique<bool[]>(count);
@@ -1018,6 +1026,10 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
                                    filter_result.valid_offsets.data());
             valid_count = filter_result.valid_count;
             valid_data = filter_result.valid_data.get();
+            if (valid_count == 0) {
+                return fill_with_empty(
+                    field_id, count, valid_count, valid_data);
+            }
         } else {
             ids_ds = GenIdsDataset(count, ids);
         }
@@ -1939,6 +1951,9 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
         valid_offsets = filter_result.valid_offsets.data();
     }
     auto ret = fill_with_empty(field_id, count, valid_count, valid_data);
+    if (field_meta.is_vector() && valid_count == 0) {
+        return ret;
+    }
 
     if (!field_meta.is_vector() && column->IsNullable()) {
         auto dst = ret->mutable_valid_data()->mutable_data();
@@ -2696,8 +2711,10 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     // If the interim index doesn't have raw data, we need to keep the field data
     // because the data cannot be retrieved from the index.
     auto iter = index_has_raw_data_.find(field_id);
+    const bool keep_nullable_vector_field_data =
+        column->IsNullable() && IsVectorDataType(data_type);
     if (generated_interim_index && iter != index_has_raw_data_.end() &&
-        iter->second) {
+        iter->second && !keep_nullable_vector_field_data) {
         drop_field_data_locked(field_id);
     }
     if (data_type == DataType::GEOMETRY &&
@@ -3247,6 +3264,7 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         bool has_mmap_setting = false;
         bool mmap_enabled = false;
         bool is_vector = false;
+        bool has_nullable_vector = false;
 
         bool has_warmup_setting = false;
         bool warmup_sync = false;
@@ -3254,6 +3272,8 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
             auto& field_meta = schema_->operator[](child_field_id);
             if (IsVectorDataType(field_meta.get_data_type())) {
                 is_vector = true;
+                has_nullable_vector =
+                    has_nullable_vector || field_meta.is_nullable();
             }
 
             // if field has mmap setting, use it
@@ -3283,8 +3303,9 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         }
 
         auto group_id = field_binlog.fieldid();
-        // Skip if this field has an index with raw data
-        if (index_has_raw_data) {
+        // Nullable vectors may need column offset mapping when an index carries
+        // raw vectors but no valid-data mapping.
+        if (index_has_raw_data && !has_nullable_vector) {
             LOG_INFO(
                 "Skip loading fielddata for segment {} group {} because "
                 "index "

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -755,7 +755,8 @@ func (h *HandlersV1) insert(c *gin.Context) {
 			return nil, RestRequestInterceptorErr
 		}
 		body, _ := c.Get(gin.BodyBytesKey)
-		httpReq.Data, _, err = checkAndSetData(body.([]byte), collSchema, false)
+		var validDataMap map[string][]bool
+		httpReq.Data, validDataMap, err = checkAndSetData(body.([]byte), collSchema, false)
 		if err != nil {
 			log.Warn("high level restful api, fail to deal with insert data", zap.Any("body", body), zap.Error(err))
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
@@ -765,7 +766,7 @@ func (h *HandlersV1) insert(c *gin.Context) {
 			return nil, RestRequestInterceptorErr
 		}
 		insertReq := req.(*milvuspb.InsertRequest)
-		insertReq.FieldsData, err = anyToColumns(httpReq.Data, nil, collSchema, true, false)
+		insertReq.FieldsData, err = anyToColumns(httpReq.Data, validDataMap, collSchema, true, false)
 		if err != nil {
 			log.Warn("high level restful api, fail to deal with insert data", zap.Any("data", httpReq.Data), zap.Error(err))
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
@@ -873,7 +874,8 @@ func (h *HandlersV1) upsert(c *gin.Context) {
 			}
 		}
 		body, _ := c.Get(gin.BodyBytesKey)
-		httpReq.Data, _, err = checkAndSetData(body.([]byte), collSchema, httpReq.PartialUpdate)
+		var validDataMap map[string][]bool
+		httpReq.Data, validDataMap, err = checkAndSetData(body.([]byte), collSchema, httpReq.PartialUpdate)
 		if err != nil {
 			log.Warn("high level restful api, fail to deal with upsert data", zap.Any("body", body), zap.Error(err))
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
@@ -883,7 +885,7 @@ func (h *HandlersV1) upsert(c *gin.Context) {
 			return nil, RestRequestInterceptorErr
 		}
 		upsertReq := req.(*milvuspb.UpsertRequest)
-		upsertReq.FieldsData, err = anyToColumns(httpReq.Data, nil, collSchema, false, httpReq.PartialUpdate)
+		upsertReq.FieldsData, err = anyToColumns(httpReq.Data, validDataMap, collSchema, false, httpReq.PartialUpdate)
 		if err != nil {
 			log.Warn("high level restful api, fail to deal with upsert data", zap.Any("data", httpReq.Data), zap.Error(err))
 			HTTPAbortReturn(c, http.StatusOK, gin.H{

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -386,6 +386,13 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 				}
 				fieldType := field.DataType
 				fieldName := field.Name
+				fieldValue := data.Get(fieldName)
+
+				// For partial update, missing fields mean "do not update this field".
+				// Explicit JSON null is handled below as an update to null for nullable fields.
+				if partialUpdate && !fieldValue.Exists() {
+					continue
+				}
 
 				if field.Nullable || field.DefaultValue != nil {
 					value := gjson.Get(data.Raw, fieldName)
@@ -395,13 +402,6 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 					} else {
 						validDataMap[fieldName] = append(validDataMap[fieldName], true)
 					}
-				}
-
-				// For partial update, check if field exists in the data
-				fieldValue := gjson.Get(data.Raw, fieldName)
-				if partialUpdate && !fieldValue.Exists() {
-					// Skip fields that are not provided in partial update
-					continue
 				}
 
 				dataString := fieldValue.String()
@@ -1042,17 +1042,26 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 	}
 	columns := make([]*schemapb.FieldData, 0, len(nameColumns))
 	for name, column := range nameColumns {
+		validData, hasValidData := validDataMap[name]
 		if fieldLen[name] == 0 && name == pkFieldName && isAutoIDPK {
 			continue
 		}
 		if fieldLen[name] == 0 && partialUpdate {
-			// for partial update, skip update for nullable field
-			// cause we cannot distinguish between missing fields and fields explicitly set to null
-			log.Info("skip empty field for partial update",
-				zap.String("fieldName", name))
-			continue
+			if hasValidData {
+				if len(validData) != rowsLen {
+					log.Info("field len is not equal to rows len",
+						zap.String("fieldName", name),
+						zap.Int("fieldLen", len(validData)),
+						zap.Int("rowsLen", rowsLen))
+					return nil, fmt.Errorf("column %s has length %d, expected %d", name, len(validData), rowsLen)
+				}
+			} else {
+				log.Info("skip empty field for partial update",
+					zap.String("fieldName", name))
+				continue
+			}
 		}
-		if fieldLen[name] != rowsLen && partialUpdate {
+		if fieldLen[name] != rowsLen && partialUpdate && (!hasValidData || len(validData) != rowsLen) {
 			// for partial update, if try to update different field in different rows, return error
 			log.Info("field len is not equal to rows len",
 				zap.String("fieldName", name),
@@ -1467,6 +1476,141 @@ func genDynamicFields(fields []string, list []*schemapb.FieldData) []string {
 	return dynamicFields
 }
 
+func fieldDataRowCount(fieldData *schemapb.FieldData) (int64, error) {
+	if len(fieldData.GetValidData()) > 0 {
+		return int64(len(fieldData.GetValidData())), nil
+	}
+	return fieldDataValueCount(fieldData)
+}
+
+func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
+	switch fieldData.GetType() {
+	case schemapb.DataType_Bool:
+		return int64(len(fieldData.GetScalars().GetBoolData().GetData())), nil
+	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
+		return int64(len(fieldData.GetScalars().GetIntData().GetData())), nil
+	case schemapb.DataType_Int64:
+		return int64(len(fieldData.GetScalars().GetLongData().GetData())), nil
+	case schemapb.DataType_Float:
+		return int64(len(fieldData.GetScalars().GetFloatData().GetData())), nil
+	case schemapb.DataType_Double:
+		return int64(len(fieldData.GetScalars().GetDoubleData().GetData())), nil
+	case schemapb.DataType_Timestamptz:
+		if fieldData.GetScalars().GetTimestamptzData() != nil {
+			return int64(len(fieldData.GetScalars().GetTimestamptzData().GetData())), nil
+		}
+		return int64(len(fieldData.GetScalars().GetStringData().GetData())), nil
+	case schemapb.DataType_String, schemapb.DataType_VarChar:
+		return int64(len(fieldData.GetScalars().GetStringData().GetData())), nil
+	case schemapb.DataType_Array:
+		return int64(len(fieldData.GetScalars().GetArrayData().GetData())), nil
+	case schemapb.DataType_JSON:
+		return int64(len(fieldData.GetScalars().GetJsonData().GetData())), nil
+	case schemapb.DataType_Geometry:
+		if fieldData.GetScalars().GetGeometryData() != nil {
+			return int64(len(fieldData.GetScalars().GetGeometryData().GetData())), nil
+		}
+		return int64(len(fieldData.GetScalars().GetGeometryWktData().GetData())), nil
+	case schemapb.DataType_BinaryVector:
+		dim := fieldData.GetVectors().GetDim()
+		bytesPerRow := dim / 8
+		if bytesPerRow <= 0 {
+			return 0, fmt.Errorf("invalid binary vector dimension %d for field %s", dim, fieldData.GetFieldName())
+		}
+		return int64(len(fieldData.GetVectors().GetBinaryVector())) / bytesPerRow, nil
+	case schemapb.DataType_FloatVector:
+		dim := fieldData.GetVectors().GetDim()
+		if dim <= 0 {
+			return 0, fmt.Errorf("invalid float vector dimension %d for field %s", dim, fieldData.GetFieldName())
+		}
+		return int64(len(fieldData.GetVectors().GetFloatVector().GetData())) / dim, nil
+	case schemapb.DataType_Float16Vector:
+		dim := fieldData.GetVectors().GetDim()
+		bytesPerRow := dim * 2
+		if bytesPerRow <= 0 {
+			return 0, fmt.Errorf("invalid float16 vector dimension %d for field %s", dim, fieldData.GetFieldName())
+		}
+		return int64(len(fieldData.GetVectors().GetFloat16Vector())) / bytesPerRow, nil
+	case schemapb.DataType_BFloat16Vector:
+		dim := fieldData.GetVectors().GetDim()
+		bytesPerRow := dim * 2
+		if bytesPerRow <= 0 {
+			return 0, fmt.Errorf("invalid bfloat16 vector dimension %d for field %s", dim, fieldData.GetFieldName())
+		}
+		return int64(len(fieldData.GetVectors().GetBfloat16Vector())) / bytesPerRow, nil
+	case schemapb.DataType_SparseFloatVector:
+		return int64(len(fieldData.GetVectors().GetSparseFloatVector().GetContents())), nil
+	case schemapb.DataType_Int8Vector:
+		dim := fieldData.GetVectors().GetDim()
+		if dim <= 0 {
+			return 0, fmt.Errorf("invalid int8 vector dimension %d for field %s", dim, fieldData.GetFieldName())
+		}
+		return int64(len(fieldData.GetVectors().GetInt8Vector())) / dim, nil
+	default:
+		return 0, fmt.Errorf("the type(%v) of field(%v) is not supported, use other sdk please", fieldData.GetType(), fieldData.GetFieldName())
+	}
+}
+
+type fieldDataRowAccessor struct {
+	fieldData      *schemapb.FieldData
+	validData      []bool
+	compactIndices []int64
+}
+
+func newFieldDataRowAccessor(fieldData *schemapb.FieldData) (*fieldDataRowAccessor, error) {
+	accessor := &fieldDataRowAccessor{
+		fieldData: fieldData,
+		validData: fieldData.GetValidData(),
+	}
+	if len(accessor.validData) == 0 {
+		return accessor, nil
+	}
+
+	compactIndices := make([]int64, len(accessor.validData))
+	validCount := int64(0)
+	for i, valid := range accessor.validData {
+		if valid {
+			compactIndices[i] = validCount
+			validCount++
+		} else {
+			compactIndices[i] = -1
+		}
+	}
+	if validCount == 0 {
+		accessor.compactIndices = compactIndices
+		return accessor, nil
+	}
+
+	valueCount, err := fieldDataValueCount(fieldData)
+	if err != nil {
+		return nil, err
+	}
+	if valueCount == int64(len(accessor.validData)) {
+		return accessor, nil
+	}
+	if valueCount != validCount {
+		return nil, fmt.Errorf("field %s has %d valid rows, but data length is %d", fieldData.GetFieldName(), validCount, valueCount)
+	}
+	accessor.compactIndices = compactIndices
+	return accessor, nil
+}
+
+func (accessor *fieldDataRowAccessor) rowIndex(rowIdx int64) (int64, bool, error) {
+	if len(accessor.validData) == 0 {
+		return rowIdx, true, nil
+	}
+	if rowIdx >= int64(len(accessor.validData)) {
+		return 0, false, fmt.Errorf("row index %d out of range for field %s valid data length %d", rowIdx, accessor.fieldData.GetFieldName(), len(accessor.validData))
+	}
+	if !accessor.validData[rowIdx] {
+		return 0, false, nil
+	}
+	if accessor.compactIndices != nil {
+		return accessor.compactIndices[rowIdx], true, nil
+	}
+	return rowIdx, true, nil
+}
+
 //nolint:gosec // G602: slice indices are bounded by rowsNum which is derived from the data length
 func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemapb.FieldData, ids *schemapb.IDs,
 	scores []float32, enableInt64 bool, collectionSchema *schemapb.CollectionSchema,
@@ -1474,47 +1618,10 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 	columnNum := len(fieldDataList)
 	if rowsNum == int64(0) { // always
 		if columnNum > 0 {
-			switch fieldDataList[0].GetType() {
-			case schemapb.DataType_Bool:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetBoolData().GetData()))
-			case schemapb.DataType_Int8:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetIntData().GetData()))
-			case schemapb.DataType_Int16:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetIntData().GetData()))
-			case schemapb.DataType_Int32:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetIntData().GetData()))
-			case schemapb.DataType_Int64:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetLongData().GetData()))
-			case schemapb.DataType_Float:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetFloatData().GetData()))
-			case schemapb.DataType_Double:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetDoubleData().GetData()))
-			case schemapb.DataType_Timestamptz:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetStringData().GetData()))
-			case schemapb.DataType_String:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetStringData().GetData()))
-			case schemapb.DataType_VarChar:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetStringData().GetData()))
-			case schemapb.DataType_Array:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetArrayData().GetData()))
-			case schemapb.DataType_JSON:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetJsonData().GetData()))
-			case schemapb.DataType_Geometry:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetGeometryWktData().Data))
-			case schemapb.DataType_BinaryVector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetBinaryVector())*8) / fieldDataList[0].GetVectors().GetDim()
-			case schemapb.DataType_FloatVector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetFloatVector().GetData())) / fieldDataList[0].GetVectors().GetDim()
-			case schemapb.DataType_Float16Vector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetFloat16Vector())/2) / fieldDataList[0].GetVectors().GetDim()
-			case schemapb.DataType_BFloat16Vector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetBfloat16Vector())/2) / fieldDataList[0].GetVectors().GetDim()
-			case schemapb.DataType_SparseFloatVector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetSparseFloatVector().GetContents()))
-			case schemapb.DataType_Int8Vector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetInt8Vector())) / fieldDataList[0].GetVectors().GetDim()
-			default:
-				return nil, fmt.Errorf("the type(%v) of field(%v) is not supported, use other sdk please", fieldDataList[0].GetType(), fieldDataList[0].GetFieldName())
+			var err error
+			rowsNum, err = fieldDataRowCount(fieldDataList[0])
+			if err != nil {
+				return nil, err
 			}
 		} else if ids != nil {
 			switch ids.GetIdField().(type) {
@@ -1531,6 +1638,14 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 	}
 	if rowsNum == int64(0) {
 		return []map[string]interface{}{}, nil
+	}
+	fieldDataAccessors := make([]*fieldDataRowAccessor, 0, columnNum)
+	for _, fieldData := range fieldDataList {
+		accessor, err := newFieldDataRowAccessor(fieldData)
+		if err != nil {
+			return nil, err
+		}
+		fieldDataAccessors = append(fieldDataAccessors, accessor)
 	}
 	queryResp := make([]map[string]interface{}, 0, rowsNum)
 	dynamicOutputFields := genDynamicFields(needFields, fieldDataList)
@@ -1549,101 +1664,68 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 		row := map[string]interface{}{}
 		if columnNum > 0 {
 			for j := 0; j < columnNum; j++ {
+				fieldData := fieldDataList[j]
+				dataIdx, valid, err := fieldDataAccessors[j].rowIndex(i)
+				if err != nil {
+					return nil, err
+				}
+				if !valid {
+					if !fieldData.GetIsDynamic() {
+						row[fieldData.GetFieldName()] = nil
+					}
+					continue
+				}
 				switch fieldDataList[j].GetType() {
 				case schemapb.DataType_Bool:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetBoolData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetBoolData().GetData()[dataIdx]
 				case schemapb.DataType_Int8:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = int8(fieldDataList[j].GetScalars().GetIntData().GetData()[i])
+					row[fieldDataList[j].GetFieldName()] = int8(fieldDataList[j].GetScalars().GetIntData().GetData()[dataIdx])
 				case schemapb.DataType_Int16:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = int16(fieldDataList[j].GetScalars().GetIntData().GetData()[i])
+					row[fieldDataList[j].GetFieldName()] = int16(fieldDataList[j].GetScalars().GetIntData().GetData()[dataIdx])
 				case schemapb.DataType_Int32:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetIntData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetIntData().GetData()[dataIdx]
 				case schemapb.DataType_Int64:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
 					if enableInt64 {
-						row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetLongData().GetData()[i]
+						row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetLongData().GetData()[dataIdx]
 					} else {
-						row[fieldDataList[j].GetFieldName()] = strconv.FormatInt(fieldDataList[j].GetScalars().GetLongData().GetData()[i], 10)
+						row[fieldDataList[j].GetFieldName()] = strconv.FormatInt(fieldDataList[j].GetScalars().GetLongData().GetData()[dataIdx], 10)
 					}
 				case schemapb.DataType_Float:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetFloatData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetFloatData().GetData()[dataIdx]
 				case schemapb.DataType_Double:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetDoubleData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetDoubleData().GetData()[dataIdx]
 				case schemapb.DataType_Timestamptz:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
+					if fieldDataList[j].GetScalars().GetTimestamptzData() != nil {
+						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetTimestamptzData().GetData()[dataIdx]
+					} else {
+						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
 					}
-					row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetStringData().GetData()[i]
 				case schemapb.DataType_String:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
 				case schemapb.DataType_VarChar:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
 				case schemapb.DataType_BinaryVector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetBinaryVector()[i*(fieldDataList[j].GetVectors().GetDim()/8) : (i+1)*(fieldDataList[j].GetVectors().GetDim()/8)]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetBinaryVector()[dataIdx*(fieldDataList[j].GetVectors().GetDim()/8) : (dataIdx+1)*(fieldDataList[j].GetVectors().GetDim()/8)]
 				case schemapb.DataType_FloatVector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetFloatVector().GetData()[i*fieldDataList[j].GetVectors().GetDim() : (i+1)*fieldDataList[j].GetVectors().GetDim()]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetFloatVector().GetData()[dataIdx*fieldDataList[j].GetVectors().GetDim() : (dataIdx+1)*fieldDataList[j].GetVectors().GetDim()]
 				case schemapb.DataType_Float16Vector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetFloat16Vector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetFloat16Vector()[dataIdx*(fieldDataList[j].GetVectors().GetDim()*2) : (dataIdx+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
 				case schemapb.DataType_BFloat16Vector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetBfloat16Vector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetBfloat16Vector()[dataIdx*(fieldDataList[j].GetVectors().GetDim()*2) : (dataIdx+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
 				case schemapb.DataType_SparseFloatVector:
-					row[fieldDataList[j].GetFieldName()] = typeutil.SparseFloatBytesToMap(fieldDataList[j].GetVectors().GetSparseFloatVector().Contents[i])
+					row[fieldDataList[j].GetFieldName()] = typeutil.SparseFloatBytesToMap(fieldDataList[j].GetVectors().GetSparseFloatVector().Contents[dataIdx])
 				case schemapb.DataType_Int8Vector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetInt8Vector()[i*fieldDataList[j].GetVectors().GetDim() : (i+1)*fieldDataList[j].GetVectors().GetDim()]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetInt8Vector()[dataIdx*fieldDataList[j].GetVectors().GetDim() : (dataIdx+1)*fieldDataList[j].GetVectors().GetDim()]
 				case schemapb.DataType_Array:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetArrayData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetArrayData().GetData()[dataIdx]
 				case schemapb.DataType_JSON:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
 					data, ok := fieldDataList[j].GetScalars().GetData().(*schemapb.ScalarField_JsonData)
 					if ok && !fieldDataList[j].GetIsDynamic() {
-						row[fieldDataList[j].GetFieldName()] = string(data.JsonData.GetData()[i])
+						row[fieldDataList[j].GetFieldName()] = string(data.JsonData.GetData()[dataIdx])
 					} else {
 						var dataMap map[string]interface{}
 
-						err := json.Unmarshal(fieldDataList[j].GetScalars().GetJsonData().Data[i], &dataMap)
+						err := json.Unmarshal(fieldDataList[j].GetScalars().GetJsonData().Data[dataIdx], &dataMap)
 						if err != nil {
 							log.Error(fmt.Sprintf("[BuildQueryResp] Unmarshal error %s", err.Error()))
 							return nil, err
@@ -1662,11 +1744,11 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 						}
 					}
 				case schemapb.DataType_Geometry:
-					if len(fieldDataList[j].ValidData) != 0 && !fieldDataList[j].ValidData[i] {
-						row[fieldDataList[j].FieldName] = nil
-						continue
+					if fieldDataList[j].GetScalars().GetGeometryData() != nil {
+						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryData().GetData()[dataIdx]
+					} else {
+						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryWktData().Data[dataIdx]
 					}
-					row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryWktData().Data[i]
 				default:
 					row[fieldDataList[j].GetFieldName()] = ""
 				}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1170,6 +1170,261 @@ func TestInsertWithNullableField(t *testing.T) {
 	assert.Equal(t, len(coll.Fields), len(fieldData))
 }
 
+func TestInsertWithNullableVectorFields(t *testing.T) {
+	testcases := []struct {
+		name        string
+		dataType    schemapb.DataType
+		vectorValue interface{}
+		checkData   func(*testing.T, *schemapb.FieldData)
+	}{
+		{
+			name:        "float vector",
+			dataType:    schemapb.DataType_FloatVector,
+			vectorValue: []float32{0.1, 0.2},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Equal(t, []float32{0.1, 0.2}, fieldData.GetVectors().GetFloatVector().GetData())
+			},
+		},
+		{
+			name:        "binary vector",
+			dataType:    schemapb.DataType_BinaryVector,
+			vectorValue: []byte{1},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Equal(t, []byte{1}, fieldData.GetVectors().GetBinaryVector())
+			},
+		},
+		{
+			name:        "float16 vector",
+			dataType:    schemapb.DataType_Float16Vector,
+			vectorValue: []float32{0.1, 0.2},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Len(t, fieldData.GetVectors().GetFloat16Vector(), 4)
+			},
+		},
+		{
+			name:        "bfloat16 vector",
+			dataType:    schemapb.DataType_BFloat16Vector,
+			vectorValue: []float32{0.1, 0.2},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Len(t, fieldData.GetVectors().GetBfloat16Vector(), 4)
+			},
+		},
+		{
+			name:        "sparse float vector",
+			dataType:    schemapb.DataType_SparseFloatVector,
+			vectorValue: map[uint32]float32{1: 0.1, 2: 0.2},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Len(t, fieldData.GetVectors().GetSparseFloatVector().GetContents(), 1)
+			},
+		},
+		{
+			name:        "int8 vector",
+			dataType:    schemapb.DataType_Int8Vector,
+			vectorValue: []int8{1, 2},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Equal(t, []byte{1, 2}, fieldData.GetVectors().GetInt8Vector())
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			primaryField := generatePrimaryField(schemapb.DataType_Int64, false)
+			vectorField := generateVectorFieldSchema(testcase.dataType)
+			vectorField.Name = FieldBookIntro
+			vectorField.Nullable = true
+			coll := &schemapb.CollectionSchema{
+				Name: DefaultCollectionName,
+				Fields: []*schemapb.FieldSchema{
+					primaryField,
+					vectorField,
+				},
+			}
+			body, err := wrapRequestBody([]map[string]interface{}{
+				{FieldBookID: int64(1), FieldBookIntro: nil},
+				{FieldBookID: int64(2), FieldBookIntro: testcase.vectorValue},
+				{FieldBookID: int64(3), FieldBookIntro: nil},
+			})
+			assert.NoError(t, err)
+
+			rows, validData, err := checkAndSetData(body, coll, false)
+			assert.NoError(t, err)
+			assert.Equal(t, []bool{false, true, false}, validData[FieldBookIntro])
+
+			fieldsData, err := anyToColumns(rows, validData, coll, true, false)
+			assert.NoError(t, err)
+
+			var vectorFieldData *schemapb.FieldData
+			for _, fieldData := range fieldsData {
+				if fieldData.GetFieldName() == FieldBookIntro {
+					vectorFieldData = fieldData
+					break
+				}
+			}
+			assert.NotNil(t, vectorFieldData)
+			assert.Equal(t, []bool{false, true, false}, vectorFieldData.GetValidData())
+			testcase.checkData(t, vectorFieldData)
+		})
+	}
+}
+
+func getFieldDataByName(fieldsData []*schemapb.FieldData, fieldName string) *schemapb.FieldData {
+	for _, fieldData := range fieldsData {
+		if fieldData.GetFieldName() == fieldName {
+			return fieldData
+		}
+	}
+	return nil
+}
+
+func TestPartialUpdateWithNullableExplicitNull(t *testing.T) {
+	t.Run("nullable scalar all null is kept as update", func(t *testing.T) {
+		coll := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				{
+					Name:     "nullable",
+					FieldID:  common.StartOfUserFieldID + 1,
+					DataType: schemapb.DataType_Int64,
+					Nullable: true,
+				},
+			},
+		}
+		body, err := wrapRequestBody([]map[string]interface{}{
+			{FieldBookID: int64(1), "nullable": nil},
+			{FieldBookID: int64(2), "nullable": nil},
+		})
+		assert.NoError(t, err)
+
+		rows, validData, err := checkAndSetData(body, coll, true)
+		assert.NoError(t, err)
+		assert.Equal(t, []bool{false, false}, validData["nullable"])
+
+		fieldsData, err := anyToColumns(rows, validData, coll, false, true)
+		assert.NoError(t, err)
+		nullableField := getFieldDataByName(fieldsData, "nullable")
+		assert.NotNil(t, nullableField)
+		assert.Equal(t, []bool{false, false}, nullableField.GetValidData())
+		assert.Empty(t, nullableField.GetScalars().GetLongData().GetData())
+	})
+
+	t.Run("nullable scalar mixed null and value is kept as compact update", func(t *testing.T) {
+		coll := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				{
+					Name:     "nullable",
+					FieldID:  common.StartOfUserFieldID + 1,
+					DataType: schemapb.DataType_Int64,
+					Nullable: true,
+				},
+			},
+		}
+		body, err := wrapRequestBody([]map[string]interface{}{
+			{FieldBookID: int64(1), "nullable": nil},
+			{FieldBookID: int64(2), "nullable": int64(20)},
+		})
+		assert.NoError(t, err)
+
+		rows, validData, err := checkAndSetData(body, coll, true)
+		assert.NoError(t, err)
+		assert.Equal(t, []bool{false, true}, validData["nullable"])
+
+		fieldsData, err := anyToColumns(rows, validData, coll, false, true)
+		assert.NoError(t, err)
+		nullableField := getFieldDataByName(fieldsData, "nullable")
+		assert.NotNil(t, nullableField)
+		assert.Equal(t, []bool{false, true}, nullableField.GetValidData())
+		assert.Equal(t, []int64{20}, nullableField.GetScalars().GetLongData().GetData())
+	})
+
+	t.Run("missing nullable field is skipped for partial update", func(t *testing.T) {
+		coll := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				{
+					Name:     "nullable",
+					FieldID:  common.StartOfUserFieldID + 1,
+					DataType: schemapb.DataType_Int64,
+					Nullable: true,
+				},
+			},
+		}
+		body, err := wrapRequestBody([]map[string]interface{}{
+			{FieldBookID: int64(1)},
+			{FieldBookID: int64(2)},
+		})
+		assert.NoError(t, err)
+
+		rows, validData, err := checkAndSetData(body, coll, true)
+		assert.NoError(t, err)
+		assert.NotContains(t, validData, "nullable")
+
+		fieldsData, err := anyToColumns(rows, validData, coll, false, true)
+		assert.NoError(t, err)
+		assert.Nil(t, getFieldDataByName(fieldsData, "nullable"))
+	})
+
+	t.Run("mixed missing and null nullable field is rejected for partial update", func(t *testing.T) {
+		coll := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				{
+					Name:     "nullable",
+					FieldID:  common.StartOfUserFieldID + 1,
+					DataType: schemapb.DataType_Int64,
+					Nullable: true,
+				},
+			},
+		}
+		body, err := wrapRequestBody([]map[string]interface{}{
+			{FieldBookID: int64(1)},
+			{FieldBookID: int64(2), "nullable": nil},
+		})
+		assert.NoError(t, err)
+
+		rows, validData, err := checkAndSetData(body, coll, true)
+		assert.NoError(t, err)
+		_, err = anyToColumns(rows, validData, coll, false, true)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "column nullable has length 1, expected 2")
+	})
+
+	t.Run("nullable vector all null is kept as update", func(t *testing.T) {
+		vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+		vectorField.Name = FieldBookIntro
+		vectorField.Nullable = true
+		coll := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				vectorField,
+			},
+		}
+		body, err := wrapRequestBody([]map[string]interface{}{
+			{FieldBookID: int64(1), FieldBookIntro: nil},
+			{FieldBookID: int64(2), FieldBookIntro: nil},
+		})
+		assert.NoError(t, err)
+
+		rows, validData, err := checkAndSetData(body, coll, true)
+		assert.NoError(t, err)
+		assert.Equal(t, []bool{false, false}, validData[FieldBookIntro])
+
+		fieldsData, err := anyToColumns(rows, validData, coll, false, true)
+		assert.NoError(t, err)
+		vectorFieldData := getFieldDataByName(fieldsData, FieldBookIntro)
+		assert.NotNil(t, vectorFieldData)
+		assert.Equal(t, []bool{false, false}, vectorFieldData.GetValidData())
+		assert.Empty(t, vectorFieldData.GetVectors().GetFloatVector().GetData())
+		assert.Equal(t, int64(2), vectorFieldData.GetVectors().GetDim())
+	})
+}
+
 func TestInsertWithDefaultValueField(t *testing.T) {
 	arrayFieldName := "array-int64"
 	coll := generateCollectionSchema(schemapb.DataType_Int64, false, true)
@@ -1595,6 +1850,76 @@ func TestBuildQueryResp(t *testing.T) {
 	assert.Equal(t, nil, err)
 	exceptRows := generateSearchResult(schemapb.DataType_Int64)
 	assert.Equal(t, true, compareRows(rows, exceptRows, compareRow))
+}
+
+func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {
+	t.Run("nullable vector derives logical rows from ValidData", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_FloatVector,
+			FieldName: FieldBookIntro,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{
+							Data: []float32{0.1, 0.2, 0.3, 0.4},
+						},
+					},
+				},
+			},
+			ValidData: []bool{true, false, true},
+		}
+
+		rows, err := buildQueryResp(0, []string{FieldBookIntro}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		assert.NoError(t, err)
+		assert.Len(t, rows, 3)
+		assert.Equal(t, []float32{0.1, 0.2}, rows[0][FieldBookIntro])
+		assert.Nil(t, rows[1][FieldBookIntro])
+		assert.Equal(t, []float32{0.3, 0.4}, rows[2][FieldBookIntro])
+	})
+
+	t.Run("nullable vector all null keeps logical rows", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_FloatVector,
+			FieldName: FieldBookIntro,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{},
+					},
+				},
+			},
+			ValidData: []bool{false, false},
+		}
+
+		rows, err := buildQueryResp(0, []string{FieldBookIntro}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		assert.NoError(t, err)
+		assert.Len(t, rows, 2)
+		assert.Nil(t, rows[0][FieldBookIntro])
+		assert.Nil(t, rows[1][FieldBookIntro])
+	})
+
+	t.Run("nullable scalar compact data uses physical index", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_Int64,
+			FieldName: FieldWordCount,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{20}},
+					},
+				},
+			},
+			ValidData: []bool{false, true},
+		}
+
+		rows, err := buildQueryResp(0, []string{FieldWordCount}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		assert.NoError(t, err)
+		assert.Len(t, rows, 2)
+		assert.Nil(t, rows[0][FieldWordCount])
+		assert.Equal(t, int64(20), rows[1][FieldWordCount])
+	})
 }
 
 func newCollectionSchema(coll *schemapb.CollectionSchema) *schemapb.CollectionSchema {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2130,7 +2130,7 @@ func (p *proxyConfig) init(base *BaseTable) {
 	p.MaxVectorFieldNum = ParamItem{
 		Key:          "proxy.maxVectorFieldNum",
 		Version:      "2.4.0",
-		DefaultValue: "4",
+		DefaultValue: "10",
 		PanicIfEmpty: true,
 		Doc:          "The maximum number of vector fields that can be specified in a collection",
 		Export:       true,

--- a/tests/go_client/common/consts.go
+++ b/tests/go_client/common/consts.go
@@ -71,7 +71,7 @@ const (
 	MaxCapacity             = 4096 // max array capacity
 	DefaultPartitionNum     = 16   // default num_partitions
 	MaxTopK                 = 16384
-	MaxVectorFieldNum       = 4
+	MaxVectorFieldNum       = 10
 	MaxShardNum             = 16
 	DefaultBatchSize        = 1000
 )

--- a/tests/python_client/common/common_type.py
+++ b/tests/python_client/common/common_type.py
@@ -90,7 +90,7 @@ all_scalar_data_types = [
     DataType.DOUBLE,
     DataType.VARCHAR,
     DataType.ARRAY,
-    DataType.JSON, 
+    DataType.JSON,
     DataType.GEOMETRY,
     DataType.TIMESTAMPTZ
     ]
@@ -145,7 +145,7 @@ compact_delta_ratio_reciprocal = 5  # compact_delta_binlog_ratio is 0.2
 compact_retention_duration = 40  # compaction travel time retention range 20s
 max_compaction_interval = 60  # the max time interval (s) from the last compaction
 max_field_num = 64  # Maximum number of fields in a collection
-max_vector_field_num = 4  # Maximum number of vector fields in a collection
+max_vector_field_num = 10  # Maximum number of vector fields in a collection
 max_name_length = 255  # Maximum length of name for a collection or alias
 default_replica_num = 1
 default_graceful_time = 5  #

--- a/tests/python_client/common/common_type.py
+++ b/tests/python_client/common/common_type.py
@@ -24,13 +24,13 @@ max_top_k = 16384
 max_nq = 16384
 max_partition_num = 1024
 max_role_num = 10
-default_partition_num = 16   # default num_partitions for partition key feature
+default_partition_num = 16  # default num_partitions for partition key feature
 default_segment_row_limit = 1000
 default_server_segment_row_limit = 1024 * 512
 default_alias = "default"
 default_user = "root"
 default_password = "Milvus"
-default_primary_field_name = 'pk'
+default_primary_field_name = "pk"
 default_bool_field_name = "bool"
 default_int8_field_name = "int8"
 default_int16_field_name = "int16"
@@ -63,13 +63,13 @@ default_reranker_field_name = "reranker_field"
 default_new_field_name = "field_new"
 
 all_vector_types = [
-        DataType.FLOAT_VECTOR,
-        DataType.FLOAT16_VECTOR,
-        DataType.BFLOAT16_VECTOR,
-        DataType.SPARSE_FLOAT_VECTOR,
-        DataType.INT8_VECTOR,
-        DataType.BINARY_VECTOR,
-    ]
+    DataType.FLOAT_VECTOR,
+    DataType.FLOAT16_VECTOR,
+    DataType.BFLOAT16_VECTOR,
+    DataType.SPARSE_FLOAT_VECTOR,
+    DataType.INT8_VECTOR,
+    DataType.BINARY_VECTOR,
+]
 
 default_metric_for_vector_type = {
     DataType.FLOAT_VECTOR: "COSINE",
@@ -92,33 +92,49 @@ all_scalar_data_types = [
     DataType.ARRAY,
     DataType.JSON,
     DataType.GEOMETRY,
-    DataType.TIMESTAMPTZ
-    ]
+    DataType.TIMESTAMPTZ,
+]
 
 default_field_name_map = {
-            DataType.INT8: default_int8_field_name,
-            DataType.INT16: default_int16_field_name,
-            DataType.INT32: default_int32_field_name,
-            DataType.INT64: default_int64_field_name,
-            DataType.BOOL: default_bool_field_name,
-            DataType.FLOAT: default_float_field_name,
-            DataType.DOUBLE: default_double_field_name,
-            DataType.VARCHAR: default_string_field_name,
-            DataType.ARRAY: default_array_field_name,
-            DataType.JSON: default_json_field_name,
-            DataType.FLOAT_VECTOR: default_float_vec_field_name,
-            DataType.FLOAT16_VECTOR: default_float16_vec_field_name,
-            DataType.BFLOAT16_VECTOR: default_bfloat16_vec_field_name,
-            DataType.SPARSE_FLOAT_VECTOR: default_sparse_vec_field_name,
-            DataType.INT8_VECTOR: default_int8_vec_field_name,
-            DataType.BINARY_VECTOR: default_binary_vec_field_name,
-        }
+    DataType.INT8: default_int8_field_name,
+    DataType.INT16: default_int16_field_name,
+    DataType.INT32: default_int32_field_name,
+    DataType.INT64: default_int64_field_name,
+    DataType.BOOL: default_bool_field_name,
+    DataType.FLOAT: default_float_field_name,
+    DataType.DOUBLE: default_double_field_name,
+    DataType.VARCHAR: default_string_field_name,
+    DataType.ARRAY: default_array_field_name,
+    DataType.JSON: default_json_field_name,
+    DataType.FLOAT_VECTOR: default_float_vec_field_name,
+    DataType.FLOAT16_VECTOR: default_float16_vec_field_name,
+    DataType.BFLOAT16_VECTOR: default_bfloat16_vec_field_name,
+    DataType.SPARSE_FLOAT_VECTOR: default_sparse_vec_field_name,
+    DataType.INT8_VECTOR: default_int8_vec_field_name,
+    DataType.BINARY_VECTOR: default_binary_vec_field_name,
+}
 
-append_vector_type = [DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.SPARSE_FLOAT_VECTOR, DataType.INT8_VECTOR]
-all_dense_vector_types = [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.INT8_VECTOR]
-all_float_vector_dtypes = [DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.SPARSE_FLOAT_VECTOR, DataType.INT8_VECTOR]
+append_vector_type = [
+    DataType.FLOAT16_VECTOR,
+    DataType.BFLOAT16_VECTOR,
+    DataType.SPARSE_FLOAT_VECTOR,
+    DataType.INT8_VECTOR,
+]
+all_dense_vector_types = [
+    DataType.FLOAT_VECTOR,
+    DataType.FLOAT16_VECTOR,
+    DataType.BFLOAT16_VECTOR,
+    DataType.INT8_VECTOR,
+]
+all_float_vector_dtypes = [
+    DataType.FLOAT_VECTOR,
+    DataType.FLOAT16_VECTOR,
+    DataType.BFLOAT16_VECTOR,
+    DataType.SPARSE_FLOAT_VECTOR,
+    DataType.INT8_VECTOR,
+]
 default_partition_name = "_default"
-default_resource_group_name = '__default_resource_group'
+default_resource_group_name = "__default_resource_group"
 default_resource_group_capacity = 1000000
 default_tag = "1970_01_01"
 row_count = "row_count"
@@ -179,43 +195,37 @@ rows_all_data_type_file_path = "/tmp/rows_all_data_type"
 
 """" List of parameters used to pass """
 invalid_resource_names = [
-    None,               # None
-    " ",                # space
-    "",                 # empty
-    "12name",           # start with number
-    "n12 ame",          # contain space
-    "n-ame",            # contain hyphen
-    "nam(e)",           # contain special character
-    "name中文",          # contain Chinese character
-    "name%$#",          # contain special character
-    "".join("a" for i in range(max_name_length + 1))]           # exceed max length
+    None,  # None
+    " ",  # space
+    "",  # empty
+    "12name",  # start with number
+    "n12 ame",  # contain space
+    "n-ame",  # contain hyphen
+    "nam(e)",  # contain special character
+    "name中文",  # contain Chinese character
+    "name%$#",  # contain special character
+    "".join("a" for i in range(max_name_length + 1)),
+]  # exceed max length
 
 valid_resource_names = [
-    "name",             # valid name
-    "_name",            # start with underline
-    "_12name",          # start with underline and contains number
-    "n12ame_",          # end with letter and contains number and underline
-    "nam_e",             # contains underline
-    "".join("a" for i in range(max_name_length))]       # max length
+    "name",  # valid name
+    "_name",  # start with underline
+    "_12name",  # start with underline and contains number
+    "n12ame_",  # end with letter and contains number and underline
+    "nam_e",  # contains underline
+    "".join("a" for i in range(max_name_length)),
+]  # max length
 
-invalid_dims = [min_dim-1, 32.1, -32, "vii", "十六", max_dim+1]
+invalid_dims = [min_dim - 1, 32.1, -32, "vii", "十六", max_dim + 1]
 
-get_not_string = [
-    [],
-    {},
-    None,
-    (1,),
-    1,
-    1.0,
-    [1, "2", 3]
-]
+get_not_string = [[], {}, None, (1,), 1, 1.0, [1, "2", 3]]
 
 get_invalid_vectors = [
     "1*2",
     [1],
     [1, 2],
     [" "],
-    ['a'],
+    ["a"],
     [None],
     None,
     (1, 2),
@@ -225,7 +235,7 @@ get_invalid_vectors = [
     "String",
     " siede ",
     "中文",
-    "a".join("a" for i in range(256))
+    "a".join("a" for i in range(256)),
 ]
 
 get_invalid_ints = [
@@ -239,7 +249,7 @@ get_invalid_ints = [
     "String",
     "=c",
     "中文",
-    "a".join("a" for i in range(256))
+    "a".join("a" for i in range(256)),
 ]
 
 get_invalid_dict = [
@@ -254,7 +264,7 @@ get_invalid_dict = [
     {1: 1},
     {"中文": 1},
     {"%$#": ["a"]},
-    {"a".join("a" for i in range(256)): "a"}
+    {"a".join("a" for i in range(256)): "a"},
 ]
 
 get_invalid_metric_type = [
@@ -269,55 +279,105 @@ get_invalid_metric_type = [
     "(mn)",
     "中文",
     "%$#",
-    "".join("a" for i in range(max_name_length + 1))]
-
-get_dict_without_host_port = [
-    {"host": "host"},
-    {"": ""}
+    "".join("a" for i in range(max_name_length + 1)),
 ]
 
-get_wrong_format_dict = [
-    {"host": "string_host", "port": {}},
-    {"host": 0, "port": 19520}
-]
+get_dict_without_host_port = [{"host": "host"}, {"": ""}]
+
+get_wrong_format_dict = [{"host": "string_host", "port": {}}, {"host": 0, "port": 19520}]
 
 get_all_kind_data_distribution = [
-    1, np.float64(1.0), np.double(1.0), 9707199254740993.0, 9707199254740992,
-    '1', '123', '321', '213', True, False, None, [1, 2], [1.0, 2],  {}, {"a": 1},
-    {'a': 1.0}, {'a': 9707199254740993.0}, {'a': 9707199254740992}, {'a': '1'}, {'a': '123'},
-    {'a': '321'}, {'a': '213'}, {'a': True}, {'a': [1, 2, 3]}, {'a': [1.0, 2, '1']}, {'a': [1.0, 2]},
-    {'a': None}, {'a': {'b': 1}}, {'a': {'b': 1.0}}, {'a': [{'b': 1}, 2.0, np.double(3.0), '4', True, [1, 3.0], None]}
+    1,
+    np.float64(1.0),
+    np.double(1.0),
+    9707199254740993.0,
+    9707199254740992,
+    "1",
+    "123",
+    "321",
+    "213",
+    True,
+    False,
+    None,
+    [1, 2],
+    [1.0, 2],
+    {},
+    {"a": 1},
+    {"a": 1.0},
+    {"a": 9707199254740993.0},
+    {"a": 9707199254740992},
+    {"a": "1"},
+    {"a": "123"},
+    {"a": "321"},
+    {"a": "213"},
+    {"a": True},
+    {"a": [1, 2, 3]},
+    {"a": [1.0, 2, "1"]},
+    {"a": [1.0, 2]},
+    {"a": None},
+    {"a": {"b": 1}},
+    {"a": {"b": 1.0}},
+    {"a": [{"b": 1}, 2.0, np.double(3.0), "4", True, [1, 3.0], None]},
 ]
 
 """ Specially defined list """
 L0_index_types = ["IVF_SQ8", "HNSW", "DISKANN"]
-all_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ",
-                   "IVF_RABITQ",
-                   "HNSW", "SCANN", "DISKANN",
-                   "BIN_FLAT", "BIN_IVF_FLAT",
-                   "SPARSE_INVERTED_INDEX", "SPARSE_WAND",
-                   "GPU_IVF_FLAT", "GPU_IVF_PQ"]
+all_index_types = [
+    "FLAT",
+    "IVF_FLAT",
+    "IVF_SQ8",
+    "IVF_PQ",
+    "IVF_RABITQ",
+    "HNSW",
+    "SCANN",
+    "DISKANN",
+    "BIN_FLAT",
+    "BIN_IVF_FLAT",
+    "SPARSE_INVERTED_INDEX",
+    "SPARSE_WAND",
+    "GPU_IVF_FLAT",
+    "GPU_IVF_PQ",
+]
 
-all_dense_float_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ",
-                               "IVF_RABITQ", "HNSW", "SCANN", "DISKANN"]
+all_dense_float_index_types = ["FLAT", "IVF_FLAT", "IVF_SQ8", "IVF_PQ", "IVF_RABITQ", "HNSW", "SCANN", "DISKANN"]
 
-inverted_index_algo = ['TAAT_NAIVE', 'DAAT_WAND', 'DAAT_MAXSCORE']
+inverted_index_algo = ["TAAT_NAIVE", "DAAT_WAND", "DAAT_MAXSCORE"]
 
 int8_vector_index = ["HNSW"]
 
-default_all_indexes_params = [{}, {"nlist": 128}, {"nlist": 128}, {"nlist": 128, "m": 16, "nbits": 8},
-                              {"nlist": 128, "refine": 'true', "refine_type": "SQ8"},
-                              {"M": 32, "efConstruction": 360}, {"nlist": 128}, {},
-                              {}, {"nlist": 64},
-                              {}, {"drop_ratio_build": 0.2},
-                              {"nlist": 64}, {"nlist": 64, "m": 16, "nbits": 8}]
+default_all_indexes_params = [
+    {},
+    {"nlist": 128},
+    {"nlist": 128},
+    {"nlist": 128, "m": 16, "nbits": 8},
+    {"nlist": 128, "refine": "true", "refine_type": "SQ8"},
+    {"M": 32, "efConstruction": 360},
+    {"nlist": 128},
+    {},
+    {},
+    {"nlist": 64},
+    {},
+    {"drop_ratio_build": 0.2},
+    {"nlist": 64},
+    {"nlist": 64, "m": 16, "nbits": 8},
+]
 
-default_all_search_params_params = [{}, {"nprobe": 32}, {"nprobe": 32}, {"nprobe": 32},
-                                    {"nprobe": 8, "rbq_bits_query": 8, "refine_k": 10.0},
-                                    {"ef": 100}, {"nprobe": 32, "reorder_k": 100}, {"search_list": 30},
-                                    {}, {"nprobe": 32},
-                                    {"drop_ratio_search": "0.2"}, {"drop_ratio_search": "0.2"},
-                                    {}, {}]
+default_all_search_params_params = [
+    {},
+    {"nprobe": 32},
+    {"nprobe": 32},
+    {"nprobe": 32},
+    {"nprobe": 8, "rbq_bits_query": 8, "refine_k": 10.0},
+    {"ef": 100},
+    {"nprobe": 32, "reorder_k": 100},
+    {"search_list": 30},
+    {},
+    {"nprobe": 32},
+    {"drop_ratio_search": "0.2"},
+    {"drop_ratio_search": "0.2"},
+    {},
+    {},
+]
 
 Handler_type = ["GRPC", "HTTP"]
 binary_supported_index_types = ["BIN_FLAT", "BIN_IVF_FLAT"]
@@ -336,10 +396,20 @@ numeric_supported_index_types = ["STL_SORT", "INVERTED", "AUTOINDEX", ""]
 
 default_flat_index = {"index_type": "FLAT", "params": {}, "metric_type": default_L0_metric}
 default_bin_flat_index = {"index_type": "BIN_FLAT", "params": {}, "metric_type": "JACCARD"}
-default_sparse_inverted_index = {"index_type": "SPARSE_INVERTED_INDEX", "metric_type": "IP",
-                                 "params": {"drop_ratio_build": 0.2}}
-default_text_sparse_inverted_index = {"index_type": "SPARSE_INVERTED_INDEX", "metric_type": "BM25",
-                                      "params": {"drop_ratio_build": 0.2, "bm25_k1": 1.5, "bm25_b": 0.75,}}
+default_sparse_inverted_index = {
+    "index_type": "SPARSE_INVERTED_INDEX",
+    "metric_type": "IP",
+    "params": {"drop_ratio_build": 0.2},
+}
+default_text_sparse_inverted_index = {
+    "index_type": "SPARSE_INVERTED_INDEX",
+    "metric_type": "BM25",
+    "params": {
+        "drop_ratio_build": 0.2,
+        "bm25_k1": 1.5,
+        "bm25_b": 0.75,
+    },
+}
 default_search_params = {"params": {"nlist": 128}}
 default_search_ip_params = {"metric_type": "IP", "params": {"nlist": 128}}
 default_search_binary_params = {"metric_type": "JACCARD", "params": {"nprobe": 32}}
@@ -349,46 +419,108 @@ default_diskann_index = {"index_type": "DISKANN", "metric_type": default_L0_metr
 default_diskann_search_params = {"params": {"search_list": 30}}
 default_sparse_search_params = {"metric_type": "IP", "params": {"drop_ratio_search": "0.2"}}
 default_text_sparse_search_params = {"metric_type": "BM25", "params": {}}
-built_in_privilege_groups = ["CollectionReadWrite", "CollectionReadOnly", "CollectionAdmin",
-                             "DatabaseReadWrite", "DatabaseReadOnly", "DatabaseAdmin",
-                             "ClusterReadWrite", "ClusterReadOnly", "ClusterAdmin"]
-privilege_group_privilege_dict = {"Query": False, "Search": False, "GetLoadState": False,
-                                  "GetLoadingProgress": False, "HasPartition": False, "ShowPartitions": False,
-                                  "ShowCollections": False, "ListAliases": False, "ListDatabases": False,
-                                  "DescribeDatabase": False, "DescribeAlias": False, "GetStatistics": False,
-                                  "CreateIndex": False, "DropIndex": False, "CreatePartition": False,
-                                  "DropPartition": False, "Load": False, "Release": False,
-                                  "Insert": False, "Delete": False, "Upsert": False,
-                                  "Import": False, "Flush": False, "Compaction": False,
-                                  "LoadBalance": False, "RenameCollection": False, "CreateAlias": False,
-                                  "DropAlias": False, "CreateCollection": False, "DropCollection": False,
-                                  "CreateOwnership": False, "DropOwnership": False, "SelectOwnership": False,
-                                  "ManageOwnership": False, "UpdateUser": False, "SelectUser": False,
-                                  "CreateResourceGroup": False, "DropResourceGroup": False,
-                                  "UpdateResourceGroups": False,
-                                  "DescribeResourceGroup": False, "ListResourceGroups": False, "TransferNode": False,
-                                  "TransferReplica": False, "CreateDatabase": False, "DropDatabase": False,
-                                  "AlterDatabase": False, "FlushAll": False, "ListPrivilegeGroups": False,
-                                  "CreatePrivilegeGroup": False, "DropPrivilegeGroup": False,
-                                  "OperatePrivilegeGroup": False}
-all_expr_fields = [default_int8_field_name, default_int16_field_name,
-                   default_int32_field_name, default_int64_field_name,
-                   default_float_field_name, default_double_field_name,
-                   default_string_field_name, default_bool_field_name,
-                   default_int8_array_field_name, default_int16_array_field_name,
-                   default_int32_array_field_name, default_int64_array_field_name,
-                   default_bool_array_field_name, default_float_array_field_name,
-                   default_double_array_field_name, default_string_array_field_name]
+built_in_privilege_groups = [
+    "CollectionReadWrite",
+    "CollectionReadOnly",
+    "CollectionAdmin",
+    "DatabaseReadWrite",
+    "DatabaseReadOnly",
+    "DatabaseAdmin",
+    "ClusterReadWrite",
+    "ClusterReadOnly",
+    "ClusterAdmin",
+]
+privilege_group_privilege_dict = {
+    "Query": False,
+    "Search": False,
+    "GetLoadState": False,
+    "GetLoadingProgress": False,
+    "HasPartition": False,
+    "ShowPartitions": False,
+    "ShowCollections": False,
+    "ListAliases": False,
+    "ListDatabases": False,
+    "DescribeDatabase": False,
+    "DescribeAlias": False,
+    "GetStatistics": False,
+    "CreateIndex": False,
+    "DropIndex": False,
+    "CreatePartition": False,
+    "DropPartition": False,
+    "Load": False,
+    "Release": False,
+    "Insert": False,
+    "Delete": False,
+    "Upsert": False,
+    "Import": False,
+    "Flush": False,
+    "Compaction": False,
+    "LoadBalance": False,
+    "RenameCollection": False,
+    "CreateAlias": False,
+    "DropAlias": False,
+    "CreateCollection": False,
+    "DropCollection": False,
+    "CreateOwnership": False,
+    "DropOwnership": False,
+    "SelectOwnership": False,
+    "ManageOwnership": False,
+    "UpdateUser": False,
+    "SelectUser": False,
+    "CreateResourceGroup": False,
+    "DropResourceGroup": False,
+    "UpdateResourceGroups": False,
+    "DescribeResourceGroup": False,
+    "ListResourceGroups": False,
+    "TransferNode": False,
+    "TransferReplica": False,
+    "CreateDatabase": False,
+    "DropDatabase": False,
+    "AlterDatabase": False,
+    "FlushAll": False,
+    "ListPrivilegeGroups": False,
+    "CreatePrivilegeGroup": False,
+    "DropPrivilegeGroup": False,
+    "OperatePrivilegeGroup": False,
+}
+all_expr_fields = [
+    default_int8_field_name,
+    default_int16_field_name,
+    default_int32_field_name,
+    default_int64_field_name,
+    default_float_field_name,
+    default_double_field_name,
+    default_string_field_name,
+    default_bool_field_name,
+    default_int8_array_field_name,
+    default_int16_array_field_name,
+    default_int32_array_field_name,
+    default_int64_array_field_name,
+    default_bool_array_field_name,
+    default_float_array_field_name,
+    default_double_array_field_name,
+    default_string_array_field_name,
+]
 
-not_supported_json_cast_types = [DataType.INT8.name, DataType.INT16.name, DataType.INT32.name,
-                                              DataType.INT64.name, DataType.FLOAT.name,
-                                              DataType.ARRAY.name, DataType.FLOAT_VECTOR.name,
-                                              DataType.FLOAT16_VECTOR.name, DataType.BFLOAT16_VECTOR.name,
-                                              DataType.BINARY_VECTOR.name,
-                                              DataType.SPARSE_FLOAT_VECTOR.name, DataType.INT8_VECTOR.name]
+not_supported_json_cast_types = [
+    DataType.INT8.name,
+    DataType.INT16.name,
+    DataType.INT32.name,
+    DataType.INT64.name,
+    DataType.FLOAT.name,
+    DataType.ARRAY.name,
+    DataType.FLOAT_VECTOR.name,
+    DataType.FLOAT16_VECTOR.name,
+    DataType.BFLOAT16_VECTOR.name,
+    DataType.BINARY_VECTOR.name,
+    DataType.SPARSE_FLOAT_VECTOR.name,
+    DataType.INT8_VECTOR.name,
+]
+
 
 class CheckTasks:
-    """ The name of the method used to check the result """
+    """The name of the method used to check the result"""
+
     check_nothing = "check_nothing"
     err_res = "error_response"
     ccr = "check_connection_result"
@@ -452,6 +584,7 @@ class CaseLabel:
         GPU:
             For GPU supported cases
     """
+
     L0 = "L0"
     L1 = "L1"
     L2 = "L2"

--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -531,7 +531,10 @@ class TestMilvusClientCollectionInvalid(TestMilvusClientV2Base):
         for _ in range(ct.max_vector_field_num + 1):
             schema_2.add_field(cf.gen_unique_str("vector_field_name"), DataType.FLOAT_VECTOR, dim=default_dim)
         schema_2.add_field(ct.default_int64_field_name, DataType.INT64, is_primary=True)
-        error_vector_over = {ct.err_code: 65535, ct.err_msg: "maximum vector field's number should be limited to 4"}
+        error_vector_over = {
+            ct.err_code: 65535,
+            ct.err_msg: f"maximum vector field's number should be limited to {ct.max_vector_field_num}",
+        }
         self.create_collection(
             client,
             collection_name,

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_group_by.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_group_by.py
@@ -1,17 +1,16 @@
+# ruff: noqa: F403, F405
 import json
-import numpy as np
-from pymilvus import AnnSearchRequest, RRFRanker, WeightedRanker
-from pymilvus import (
-    FieldSchema, CollectionSchema, DataType
-)
-from utils.util_pymilvus import *
-from common.common_type import CaseLabel, CheckTasks
-from common import common_type as ct
-from common import common_func as cf
-from utils.util_log import test_log as log
-from base.client_v2_base import TestMilvusClientV2Base
 import random
+
+import numpy as np
 import pytest
+from base.client_v2_base import TestMilvusClientV2Base
+from common import common_func as cf
+from common import common_type as ct
+from common.common_type import CaseLabel, CheckTasks
+from pymilvus import AnnSearchRequest, CollectionSchema, DataType, FieldSchema, RRFRanker, WeightedRanker
+from utils.util_log import test_log as log
+from utils.util_pymilvus import *
 
 epsilon = 0.001
 
@@ -484,7 +483,7 @@ class TestGroupSearch(TestMilvusClientV2Base):
                  ct.err_msg: f"unsupported data type {grpby_unsupported_field} for group by operator"}
         if grpby_unsupported_field == ct.default_float_vec_field_name:
             error = {ct.err_code: 999,
-                     ct.err_msg: f"unsupported data type VECTOR_FLOAT for group by operator"}
+                     ct.err_msg: "unsupported data type VECTOR_FLOAT for group by operator"}
         self.search(client, self.collection_name, data=search_vectors, anns_field=self.float_vector_field_name,
                     search_params=search_params, limit=limit, group_by_field=grpby_unsupported_field,
                     output_fields=[grpby_unsupported_field],
@@ -824,7 +823,7 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
                                         vector_data_type=DataType.FLOAT_VECTOR)
         # verify
         error = {ct.err_code: 1700,
-                 ct.err_msg: f"groupBy field not found in schema"}
+                 ct.err_msg: "groupBy field not found in schema"}
         self.search(client, self.collection_name, data=search_vectors,
                     anns_field=self.float_vector_field_name,
                     search_params=search_params, limit=10,
@@ -857,6 +856,69 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
 
 
 class TestSearchGroupByIndependent(TestMilvusClientV2Base):
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_group_by_nullable_vector(self):
+        """
+        target: test group-by search on an indexed nullable vector field
+        method: create collection with nullable FLOAT_VECTOR, insert mixed null/non-null vectors,
+                build IVF_FLAT index, search with INT8 group-by and is-not-null scalar filter
+        expected: search returns grouped results from non-null scalar groups
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        dim = 36
+        nb = 10000
+        vector_field = ct.default_float_vec_field_name
+        group_by_field = DataType.INT8.name
+
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(field_name=ct.default_primary_field_name, datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name=vector_field, datatype=DataType.FLOAT_VECTOR, dim=dim, nullable=True)
+        schema.add_field(field_name=group_by_field, datatype=DataType.INT8, nullable=True)
+        self.create_collection(client, collection_name, schema=schema)
+
+        vectors = cf.gen_vectors(nb, dim=dim, vector_data_type=DataType.FLOAT_VECTOR)
+        rows = [
+            {
+                ct.default_primary_field_name: i,
+                vector_field: None if i % 10 == 9 else vectors[i],
+                group_by_field: None if i % 5 == 0 else i % 100,
+            }
+            for i in range(nb)
+        ]
+        self.insert(client, collection_name, data=rows)
+        self.flush(client, collection_name)
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(
+            field_name=vector_field, metric_type="COSINE", index_type="IVF_FLAT", params={"nlist": 128}
+        )
+        self.create_index(client, collection_name, index_params=index_params)
+        self.wait_for_index_ready(client, collection_name, index_name=vector_field)
+        self.load_collection(client, collection_name)
+
+        nq = 2
+        limit = 15
+        search_vectors = cf.gen_vectors(nq, dim=dim, vector_data_type=DataType.FLOAT_VECTOR)
+        search_params = {"params": {"nprobe": 32}, "metric_type": "COSINE"}
+        res = self.search(
+            client,
+            collection_name,
+            data=search_vectors,
+            anns_field=vector_field,
+            search_params=search_params,
+            limit=limit,
+            filter=f"{group_by_field} is not null",
+            group_by_field=group_by_field,
+            output_fields=[group_by_field],
+        )[0]
+
+        for hits in res:
+            group_values = [hit.get(group_by_field) for hit in hits]
+            assert len(group_values) == limit
+            assert None not in group_values
+            assert len(group_values) == len(set(group_values))
+
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("metric", ["L2", "IP", "COSINE"])
     def test_search_group_by_flat_index_correctness(self, metric):
@@ -929,7 +991,7 @@ class TestSearchGroupByIndependent(TestMilvusClientV2Base):
         if metric == "L2":
             # For L2, smaller is better
             assert groupby_top_distance <= normal_top_distance + epsilon, \
-                f"GroupBy search should return result with distance <= normal search for L2 metric"
+                "GroupBy search should return result with distance <= normal search for L2 metric"
         else:
             # For IP/COSINE, larger is better
             assert groupby_top_distance >= normal_top_distance - epsilon, \

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_group_by.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_group_by.py
@@ -31,13 +31,16 @@ class TestGroupSearch(TestMilvusClientV2Base):
         self.bfloat16_vector_field_name = "bfloat16_vector"
         self.sparse_vector_field_name = "sparse_vector"
         self.binary_vector_field_name = "binary_vector"
-        self.vector_fields = [self.float_vector_field_name, self.bfloat16_vector_field_name,
-                              self.sparse_vector_field_name, self.binary_vector_field_name]
+        self.vector_fields = [
+            self.float_vector_field_name,
+            self.bfloat16_vector_field_name,
+            self.sparse_vector_field_name,
+            self.binary_vector_field_name,
+        ]
         self.float_vector_dim = 36
         self.bf16_vector_dim = 35
         self.binary_vector_dim = 32
-        self.dims = [self.float_vector_dim, self.bf16_vector_dim,
-                     128, self.binary_vector_dim]
+        self.dims = [self.float_vector_dim, self.bf16_vector_dim, 128, self.binary_vector_dim]
         self.float_vector_metric = "COSINE"
         self.bf16_vector_metric = "L2"
         self.sparse_vector_metric = "IP"
@@ -46,8 +49,12 @@ class TestGroupSearch(TestMilvusClientV2Base):
         self.bf16_vector_index = "DISKANN"
         self.sparse_vector_index = "SPARSE_INVERTED_INDEX"
         self.binary_vector_index = "BIN_IVF_FLAT"
-        self.index_types = [self.float_vector_index, self.bf16_vector_index,
-                            self.sparse_vector_index, self.binary_vector_index]
+        self.index_types = [
+            self.float_vector_index,
+            self.bf16_vector_index,
+            self.sparse_vector_index,
+            self.binary_vector_index,
+        ]
         self.inverted_string_field = inverted_string_field_name
         self.indexed_json_field = indexed_json_field_name
         self.enable_dynamic_field = True
@@ -66,7 +73,8 @@ class TestGroupSearch(TestMilvusClientV2Base):
         fields = []
         fields.append(FieldSchema(name=self.primary_field, dtype=DataType.INT64, is_primary=True, auto_id=True))
         fields.append(
-            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim))
+            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim)
+        )
 
         for data_type in ct.all_scalar_data_types:
             fields.append(cf.gen_scalar_field(data_type, name=data_type.name, nullable=True))
@@ -99,13 +107,16 @@ class TestGroupSearch(TestMilvusClientV2Base):
             int32_value = random.randint(-2147483648, 2147483647)
             for i in range(nb):
                 row = {
-                    self.float_vector_field_name: cf.gen_vectors(1, dim=self.float_vector_dim,
-                                                                 vector_data_type=DataType.FLOAT_VECTOR)[0],
-                    self.bfloat16_vector_field_name: cf.gen_vectors(1, dim=self.bf16_vector_dim,
-                                                                    vector_data_type=DataType.BFLOAT16_VECTOR)[0],
+                    self.float_vector_field_name: cf.gen_vectors(
+                        1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR
+                    )[0],
+                    self.bfloat16_vector_field_name: cf.gen_vectors(
+                        1, dim=self.bf16_vector_dim, vector_data_type=DataType.BFLOAT16_VECTOR
+                    )[0],
                     self.sparse_vector_field_name: cf.gen_sparse_vectors(1, empty_percentage=2)[0],
-                    self.binary_vector_field_name: cf.gen_vectors(1, dim=self.binary_vector_dim,
-                                                                  vector_data_type=DataType.BINARY_VECTOR)[0],
+                    self.binary_vector_field_name: cf.gen_vectors(
+                        1, dim=self.binary_vector_dim, vector_data_type=DataType.BINARY_VECTOR
+                    )[0],
                     DataType.BOOL.name: bool(i % 2) if random.random() < 0.8 else None,
                     DataType.INT8.name: int8_value if random.random() < 0.8 else None,
                     DataType.INT16.name: int16_value if random.random() < 0.8 else None,
@@ -144,24 +155,32 @@ class TestGroupSearch(TestMilvusClientV2Base):
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=self.float_vector_field_name,
-                               metric_type=self.float_vector_metric,
-                               index_type=self.float_vector_index,
-                               params={"nlist": 128})
-        index_params.add_index(field_name=self.bfloat16_vector_field_name,
-                               metric_type=self.bf16_vector_metric,
-                               index_type=self.bf16_vector_index,
-                               params={})
-        index_params.add_index(field_name=self.sparse_vector_field_name,
-                               metric_type=self.sparse_vector_metric,
-                               index_type=self.sparse_vector_index,
-                               params={})
-        index_params.add_index(field_name=self.binary_vector_field_name,
-                               metric_type=self.binary_vector_metric,
-                               index_type=self.binary_vector_index,
-                               params={"nlist": 128})
+        index_params.add_index(
+            field_name=self.float_vector_field_name,
+            metric_type=self.float_vector_metric,
+            index_type=self.float_vector_index,
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name=self.bfloat16_vector_field_name,
+            metric_type=self.bf16_vector_metric,
+            index_type=self.bf16_vector_index,
+            params={},
+        )
+        index_params.add_index(
+            field_name=self.sparse_vector_field_name,
+            metric_type=self.sparse_vector_metric,
+            index_type=self.sparse_vector_index,
+            params={},
+        )
+        index_params.add_index(
+            field_name=self.binary_vector_field_name,
+            metric_type=self.binary_vector_metric,
+            index_type=self.binary_vector_index,
+            params={"nlist": 128},
+        )
         index_params.add_index(field_name=self.inverted_string_field, index_type="INVERTED")
-        index_params.add_index(field_name=self.indexed_json_field, index_type="INVERTED", json_cast_type='json')
+        index_params.add_index(field_name=self.indexed_json_field, index_type="INVERTED", json_cast_type="json")
         self.create_index(client, self.collection_name, index_params=index_params)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.float_vector_field_name)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.bfloat16_vector_field_name)
@@ -175,12 +194,17 @@ class TestGroupSearch(TestMilvusClientV2Base):
         request.addfinalizer(teardown)
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.parametrize("group_by_field", [DataType.VARCHAR.name, inverted_string_field_name
-                                                # TODO: need to run after #46605 $46614 #46616 fixed
-                                                # , DataType.JSON.name, indexed_json_field_name
-                                                # , f"{DataType.JSON.name}['number']"
-                                                # , dyna_filed_name1, f"{dyna_filed_name2}['string']"
-                                                ])
+    @pytest.mark.parametrize(
+        "group_by_field",
+        [
+            DataType.VARCHAR.name,
+            inverted_string_field_name,
+            # TODO: need to run after #46605 $46614 #46616 fixed
+            # , DataType.JSON.name, indexed_json_field_name
+            # , f"{DataType.JSON.name}['number']"
+            # , dyna_filed_name1, f"{dyna_filed_name2}['string']"
+        ],
+    )
     def test_search_group_size(self, group_by_field):
         """
         target:
@@ -203,17 +227,26 @@ class TestGroupSearch(TestMilvusClientV2Base):
             if self.vector_fields[j] == self.binary_vector_field_name:
                 pass
             else:
-                search_vectors = cf.gen_vectors(nq, dim=self.dims[j],
-                                                vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                                  self.vector_fields[
-                                                                                                      j]))
+                search_vectors = cf.gen_vectors(
+                    nq,
+                    dim=self.dims[j],
+                    vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[j]),
+                )
                 search_params = {"params": cf.get_search_params_params(self.index_types[j])}
                 # when strict_group_size=true, it shall return results with entities = limit * group_size
-                res1 = self.search(client, self.collection_name, data=search_vectors, anns_field=self.vector_fields[j],
-                                   search_params=search_params, limit=limit,
-                                   group_by_field=group_by_field, filter=f"{output_field} is not null",
-                                   group_size=group_size, strict_group_size=True,
-                                   output_fields=[output_field])[0]
+                res1 = self.search(
+                    client,
+                    self.collection_name,
+                    data=search_vectors,
+                    anns_field=self.vector_fields[j],
+                    search_params=search_params,
+                    limit=limit,
+                    group_by_field=group_by_field,
+                    filter=f"{output_field} is not null",
+                    group_size=group_size,
+                    strict_group_size=True,
+                    output_fields=[output_field],
+                )[0]
                 for i in range(nq):
                     assert len(res1[i]) == limit * group_size
                     for l in range(limit):
@@ -227,13 +260,19 @@ class TestGroupSearch(TestMilvusClientV2Base):
                             assert len(set(group_values)) == 1
 
                 # when strict_group_size=false, it shall return results with group counts = limit
-                res1 = self.search(client, self.collection_name,
-                                   data=search_vectors,
-                                   anns_field=self.vector_fields[j],
-                                   search_params=search_params, limit=limit,
-                                   group_by_field=group_by_field, filter=f"{output_field} is not null",
-                                   group_size=group_size, strict_group_size=False,
-                                   output_fields=[output_field])[0]
+                res1 = self.search(
+                    client,
+                    self.collection_name,
+                    data=search_vectors,
+                    anns_field=self.vector_fields[j],
+                    search_params=search_params,
+                    limit=limit,
+                    group_by_field=group_by_field,
+                    filter=f"{output_field} is not null",
+                    group_size=group_size,
+                    strict_group_size=False,
+                    output_fields=[output_field],
+                )[0]
                 for i in range(nq):
                     group_values = []
                     for l in range(len(res1[i])):
@@ -261,21 +300,32 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 pass  # not support group by search on binary vector
             else:
                 search_params = {
-                    "data": cf.gen_vectors(nq, dim=self.dims[j],
-                                           vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                             self.vector_fields[j])),
+                    "data": cf.gen_vectors(
+                        nq,
+                        dim=self.dims[j],
+                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[j]),
+                    ),
                     "anns_field": self.vector_fields[j],
                     "param": {"params": cf.get_search_params_params(self.index_types[j])},
                     "limit": limit,
-                    "expr": f"{self.primary_field} > 0"}
+                    "expr": f"{self.primary_field} > 0",
+                }
                 req = AnnSearchRequest(**search_params)
                 req_list.append(req)
         # 4. hybrid search group by
         rank_scorers = ["max", "avg", "sum"]
         for scorer in rank_scorers:
-            res = self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=WeightedRanker(0.1, 0.3, 0.6),
-                                     limit=limit, group_by_field=DataType.VARCHAR.name, group_size=group_size,
-                                     rank_group_scorer=scorer, output_fields=[DataType.VARCHAR.name])[0]
+            res = self.hybrid_search(
+                client,
+                self.collection_name,
+                reqs=req_list,
+                ranker=WeightedRanker(0.1, 0.3, 0.6),
+                limit=limit,
+                group_by_field=DataType.VARCHAR.name,
+                group_size=group_size,
+                rank_group_scorer=scorer,
+                output_fields=[DataType.VARCHAR.name],
+            )[0]
             for i in range(nq):
                 group_values = []
                 for l in range(len(res[i])):
@@ -291,9 +341,9 @@ class TestGroupSearch(TestMilvusClientV2Base):
                     if curr_group_value == next_group_value:
                         group_distances.append(res[i][l + 1].distance)
                     else:
-                        if scorer == 'sum':
+                        if scorer == "sum":
                             assert np.sum(group_distances) <= np.sum(tmp_distances)
-                        elif scorer == 'avg':
+                        elif scorer == "avg":
                             assert np.mean(group_distances) <= np.mean(tmp_distances)
                         else:  # default max
                             assert np.max(group_distances) <= np.max(tmp_distances)
@@ -315,21 +365,30 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 pass  # not support group by search on binary vector
             else:
                 search_param = {
-                    "data": cf.gen_vectors(ct.default_nq, dim=self.dims[i],
-                                           vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                             self.vector_fields[i])),
+                    "data": cf.gen_vectors(
+                        ct.default_nq,
+                        dim=self.dims[i],
+                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[i]),
+                    ),
                     "anns_field": self.vector_fields[i],
                     "param": {},
                     "limit": ct.default_limit,
-                    "expr": f"{self.primary_field} > 0"}
+                    "expr": f"{self.primary_field} > 0",
+                }
                 req = AnnSearchRequest(**search_param)
                 req_list.append(req)
         # 4. hybrid search group by
-        res = self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=WeightedRanker(0.1, 0.9, 0.3),
-                                 limit=ct.default_limit, group_by_field=DataType.VARCHAR.name,
-                                 output_fields=[DataType.VARCHAR.name],
-                                 check_task=CheckTasks.check_search_results,
-                                 check_items={"nq": ct.default_nq, "limit": ct.default_limit})[0]
+        res = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.1, 0.9, 0.3),
+            limit=ct.default_limit,
+            group_by_field=DataType.VARCHAR.name,
+            output_fields=[DataType.VARCHAR.name],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": ct.default_nq, "limit": ct.default_limit},
+        )[0]
         for i in range(ct.default_nq):
             group_values = []
             for l in range(ct.default_limit):
@@ -343,20 +402,29 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 pass  # not support group by search on binary vector
             else:
                 search_param = {
-                    "data": cf.gen_vectors(ct.default_nq, dim=self.dims[i],
-                                           vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                             self.vector_fields[i])),
+                    "data": cf.gen_vectors(
+                        ct.default_nq,
+                        dim=self.dims[i],
+                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[i]),
+                    ),
                     "anns_field": self.vector_fields[i],
                     "param": {},
                     "limit": ct.default_limit,
-                    "expr": f"{self.primary_field} > 0"}
+                    "expr": f"{self.primary_field} > 0",
+                }
                 req = AnnSearchRequest(**search_param)
                 req_list.append(req)
-                self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=RRFRanker(),
-                                   limit=ct.default_limit, group_by_field=self.inverted_string_field,
-                                   output_fields=[self.inverted_string_field],
-                                   check_task=CheckTasks.check_search_results,
-                                   check_items={"nq": ct.default_nq, "limit": ct.default_limit})
+                self.hybrid_search(
+                    client,
+                    self.collection_name,
+                    reqs=req_list,
+                    ranker=RRFRanker(),
+                    limit=ct.default_limit,
+                    group_by_field=self.inverted_string_field,
+                    output_fields=[self.inverted_string_field],
+                    check_task=CheckTasks.check_search_results,
+                    check_items={"nq": ct.default_nq, "limit": ct.default_limit},
+                )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_hybrid_search_group_by_empty_results(self):
@@ -372,21 +440,30 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 pass  # not support group by search on binary vector
             else:
                 search_param = {
-                    "data": cf.gen_vectors(ct.default_nq, dim=self.dims[i],
-                                           vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                             self.vector_fields[i])),
+                    "data": cf.gen_vectors(
+                        ct.default_nq,
+                        dim=self.dims[i],
+                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[i]),
+                    ),
                     "anns_field": self.vector_fields[i],
                     "param": {},
                     "limit": ct.default_limit,
-                    "expr": f"{self.primary_field} < 0"}  # make sure return empty results
+                    "expr": f"{self.primary_field} < 0",
+                }  # make sure return empty results
                 req = AnnSearchRequest(**search_param)
                 req_list.append(req)
         # 4. hybrid search group by empty results
-        self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=WeightedRanker(0.1, 0.9, 0.3),
-                           limit=ct.default_limit, group_by_field=DataType.VARCHAR.name,
-                           output_fields=[DataType.VARCHAR.name],
-                           check_task=CheckTasks.check_search_results,
-                           check_items={"nq": ct.default_nq, "limit": 0})
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.1, 0.9, 0.3),
+            limit=ct.default_limit,
+            group_by_field=DataType.VARCHAR.name,
+            output_fields=[DataType.VARCHAR.name],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": ct.default_nq, "limit": 0},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_group_by_supported_binary_vector(self):
@@ -394,21 +471,28 @@ class TestGroupSearch(TestMilvusClientV2Base):
         verify search group by works with supported binary vector
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.binary_vector_dim,
-                                        vector_data_type=DataType.BINARY_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.binary_vector_dim, vector_data_type=DataType.BINARY_VECTOR)
         search_params = {}
         limit = 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: "not support search_group_by operation based on binary vector"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=self.binary_vector_field_name,
-                    search_params=search_params, limit=limit, group_by_field=DataType.VARCHAR.name,
-                    output_fields=[DataType.VARCHAR.name],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 999, ct.err_msg: "not support search_group_by operation based on binary vector"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.binary_vector_field_name,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=DataType.VARCHAR.name,
+            output_fields=[DataType.VARCHAR.name],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.parametrize("support_field", [DataType.INT8.name, DataType.INT64.name,
-                                               DataType.BOOL.name, DataType.VARCHAR.name,
-                                               DataType.TIMESTAMPTZ.name])
+    @pytest.mark.parametrize(
+        "support_field",
+        [DataType.INT8.name, DataType.INT64.name, DataType.BOOL.name, DataType.VARCHAR.name, DataType.TIMESTAMPTZ.name],
+    )
     def test_search_group_by_supported_scalars(self, support_field):
         """
         verify search group by works with supported scalar fields
@@ -421,16 +505,23 @@ class TestGroupSearch(TestMilvusClientV2Base):
             if self.vector_fields[j] == self.binary_vector_field_name:
                 pass  # not support group by search on binary vector
             else:
-                search_vectors = cf.gen_vectors(nq, dim=self.dims[j],
-                                                vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                                  self.vector_fields[
-                                                                                                      j]))
+                search_vectors = cf.gen_vectors(
+                    nq,
+                    dim=self.dims[j],
+                    vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[j]),
+                )
                 search_params = {"params": cf.get_search_params_params(self.index_types[j])}
-                res1 = self.search(client, self.collection_name, data=search_vectors, anns_field=self.vector_fields[j],
-                                   search_params=search_params, limit=limit,
-                                   filter=f"{support_field} is not null",
-                                   group_by_field=support_field,
-                                   output_fields=[support_field])[0]
+                res1 = self.search(
+                    client,
+                    self.collection_name,
+                    data=search_vectors,
+                    anns_field=self.vector_fields[j],
+                    search_params=search_params,
+                    limit=limit,
+                    filter=f"{support_field} is not null",
+                    group_by_field=support_field,
+                    output_fields=[support_field],
+                )[0]
                 for i in range(nq):
                     grpby_values = []
                     dismatch = 0
@@ -445,17 +536,25 @@ class TestGroupSearch(TestMilvusClientV2Base):
                         if support_field == DataType.TIMESTAMPTZ.name:
                             filter_expr = f"{support_field}== ISO '{top1_grpby_value}'"
                         grpby_values.append(top1_grpby_value)
-                        res_tmp = self.search(client, self.collection_name, data=[search_vectors[i]],
-                                              anns_field=self.vector_fields[j],
-                                              search_params=search_params, limit=1, filter=filter_expr,
-                                              output_fields=[support_field])[0]
+                        res_tmp = self.search(
+                            client,
+                            self.collection_name,
+                            data=[search_vectors[i]],
+                            anns_field=self.vector_fields[j],
+                            search_params=search_params,
+                            limit=1,
+                            filter=filter_expr,
+                            output_fields=[support_field],
+                        )[0]
                         top1_expr_pk = res_tmp[0][0].id
                         if top1_grpby_pk != top1_expr_pk:
                             dismatch += 1
                             log.info(
-                                f"{support_field} on {self.vector_fields[j]} dismatch_item, top1_grpby_dis: {top1.distance}, top1_expr_dis: {res_tmp[0][0].distance}")
+                                f"{support_field} on {self.vector_fields[j]} dismatch_item, top1_grpby_dis: {top1.distance}, top1_expr_dis: {res_tmp[0][0].distance}"
+                            )
                     log.info(
-                        f"{support_field} on {self.vector_fields[j]}  top1_dismatch_num: {dismatch}, results_num: {results_num}, dismatch_rate: {dismatch / results_num}")
+                        f"{support_field} on {self.vector_fields[j]}  top1_dismatch_num: {dismatch}, results_num: {results_num}, dismatch_rate: {dismatch / results_num}"
+                    )
                     baseline = 1 if support_field == DataType.BOOL.name else 0.2  # skip baseline check for boolean
                     assert results_num > 0, "results_num should be greater than 0"
                     assert dismatch / results_num <= baseline
@@ -463,9 +562,10 @@ class TestGroupSearch(TestMilvusClientV2Base):
                     assert len(grpby_values) == len(set(grpby_values))
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("grpby_unsupported_field", [DataType.FLOAT.name, DataType.DOUBLE.name,
-                                                         DataType.GEOMETRY.name,
-                                                         ct.default_float_vec_field_name])
+    @pytest.mark.parametrize(
+        "grpby_unsupported_field",
+        [DataType.FLOAT.name, DataType.DOUBLE.name, DataType.GEOMETRY.name, ct.default_float_vec_field_name],
+    )
     def test_search_group_by_unsupported_field(self, grpby_unsupported_field):
         """
         target: test search group by with the unsupported field
@@ -475,19 +575,24 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 verify: the error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {}
         limit = 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"unsupported data type {grpby_unsupported_field} for group by operator"}
+        error = {ct.err_code: 999, ct.err_msg: f"unsupported data type {grpby_unsupported_field} for group by operator"}
         if grpby_unsupported_field == ct.default_float_vec_field_name:
-            error = {ct.err_code: 999,
-                     ct.err_msg: "unsupported data type VECTOR_FLOAT for group by operator"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=limit, group_by_field=grpby_unsupported_field,
-                    output_fields=[grpby_unsupported_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+            error = {ct.err_code: 999, ct.err_msg: "unsupported data type VECTOR_FLOAT for group by operator"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=grpby_unsupported_field,
+            output_fields=[grpby_unsupported_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_pagination_group_by(self):
@@ -502,32 +607,47 @@ class TestGroupSearch(TestMilvusClientV2Base):
         default_search_exp = f"{self.primary_field} >= 0"
         grpby_field = self.inverted_string_field
         default_search_field = self.vector_fields[1]
-        search_vectors = cf.gen_vectors(1, dim=self.dims[1],
-                                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                          self.vector_fields[1]))
+        search_vectors = cf.gen_vectors(
+            1,
+            dim=self.dims[1],
+            vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[1]),
+        )
         all_pages_ids = []
         all_pages_grpby_field_values = []
         for r in range(page_rounds):
-            page_res = self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                                   search_params=search_param, limit=limit, offset=limit * r,
-                                   filter=default_search_exp, group_by_field=grpby_field,
-                                   output_fields=[grpby_field],
-                                   check_task=CheckTasks.check_search_results,
-                                   check_items={"nq": 1, "limit": limit},
-                                   )[0]
+            page_res = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                anns_field=default_search_field,
+                search_params=search_param,
+                limit=limit,
+                offset=limit * r,
+                filter=default_search_exp,
+                group_by_field=grpby_field,
+                output_fields=[grpby_field],
+                check_task=CheckTasks.check_search_results,
+                check_items={"nq": 1, "limit": limit},
+            )[0]
             for j in range(limit):
                 all_pages_grpby_field_values.append(page_res[0][j].get(grpby_field))
             all_pages_ids += page_res[0].ids
         hit_rate = round(len(set(all_pages_grpby_field_values)) / len(all_pages_grpby_field_values), 3)
         assert hit_rate >= 0.8
 
-        total_res = self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                                search_params=search_param, limit=limit * page_rounds,
-                                filter=default_search_exp, group_by_field=grpby_field,
-                                output_fields=[grpby_field],
-                                check_task=CheckTasks.check_search_results,
-                                check_items={"nq": 1, "limit": limit * page_rounds}
-                                )[0]
+        total_res = self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_param,
+            limit=limit * page_rounds,
+            filter=default_search_exp,
+            group_by_field=grpby_field,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": 1, "limit": limit * page_rounds},
+        )[0]
         hit_num = len(set(total_res[0].ids).intersection(set(all_pages_ids)))
         hit_rate = round(hit_num / (limit * page_rounds), 3)
         assert hit_rate >= 0.8
@@ -553,9 +673,11 @@ class TestGroupSearch(TestMilvusClientV2Base):
         grpby_field = self.inverted_string_field
         default_search_field = self.vector_fields[1]
         ids_to_search = None
-        search_vectors = cf.gen_vectors(1, dim=self.dims[1],
-                                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                          self.vector_fields[1]))
+        search_vectors = cf.gen_vectors(
+            1,
+            dim=self.dims[1],
+            vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[1]),
+        )
         if search_by_pk is True:
             query_res = self.query(client, self.collection_name, limit=1, output_fields=[self.primary_field])[0]
             ids_to_search = [query_res[0].get(self.primary_field)]
@@ -564,42 +686,53 @@ class TestGroupSearch(TestMilvusClientV2Base):
         all_pages_grpby_field_values = []
         res_count = limit * group_size
         for r in range(page_rounds):
-            page_res = self.search(client, self.collection_name,
-                                   data=search_vectors,
-                                   ids=ids_to_search,
-                                   anns_field=default_search_field,
-                                   search_params=search_param, limit=limit, offset=limit * r,
-                                   filter=default_search_exp,
-                                   group_by_field=grpby_field, group_size=group_size,
-                                   strict_group_size=True,
-                                   output_fields=[grpby_field],
-                                   check_task=CheckTasks.check_search_results,
-                                   check_items={"nq": 1, "limit": res_count},
-                                   )[0]
+            page_res = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                ids=ids_to_search,
+                anns_field=default_search_field,
+                search_params=search_param,
+                limit=limit,
+                offset=limit * r,
+                filter=default_search_exp,
+                group_by_field=grpby_field,
+                group_size=group_size,
+                strict_group_size=True,
+                output_fields=[grpby_field],
+                check_task=CheckTasks.check_search_results,
+                check_items={"nq": 1, "limit": res_count},
+            )[0]
             for j in range(res_count):
                 all_pages_grpby_field_values.append(page_res[0][j].get(grpby_field))
             all_pages_ids += page_res[0].ids
 
         hit_rate = round(len(set(all_pages_grpby_field_values)) / len(all_pages_grpby_field_values), 3)
         expect_hit_rate = round(1 / group_size, 3) * 0.7
-        log.info(f"expect_hit_rate :{expect_hit_rate}, hit_rate:{hit_rate}, "
-                 f"unique_group_by_value_count:{len(set(all_pages_grpby_field_values))},"
-                 f"total_group_by_value_count:{len(all_pages_grpby_field_values)}")
+        log.info(
+            f"expect_hit_rate :{expect_hit_rate}, hit_rate:{hit_rate}, "
+            f"unique_group_by_value_count:{len(set(all_pages_grpby_field_values))},"
+            f"total_group_by_value_count:{len(all_pages_grpby_field_values)}"
+        )
         assert hit_rate >= expect_hit_rate
 
         total_count = limit * group_size * page_rounds
-        total_res = self.search(client, self.collection_name,
-                                data=search_vectors,
-                                ids=ids_to_search,
-                                anns_field=default_search_field,
-                                search_params=search_param, limit=limit * page_rounds,
-                                filter=default_search_exp,
-                                group_by_field=grpby_field, group_size=group_size,
-                                strict_group_size=True,
-                                output_fields=[grpby_field],
-                                check_task=CheckTasks.check_search_results,
-                                check_items={"nq": 1, "limit": total_count}
-                                )[0]
+        total_res = self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            ids=ids_to_search,
+            anns_field=default_search_field,
+            search_params=search_param,
+            limit=limit * page_rounds,
+            filter=default_search_exp,
+            group_by_field=grpby_field,
+            group_size=group_size,
+            strict_group_size=True,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": 1, "limit": total_count},
+        )[0]
         hit_num = len(set(total_res[0].ids).intersection(set(all_pages_ids)))
         hit_rate = round(hit_num / (limit * page_rounds), 3)
         assert hit_rate >= 0.8
@@ -619,53 +752,92 @@ class TestGroupSearch(TestMilvusClientV2Base):
         collection_info = self.describe_collection(client, self.collection_name)[0]
         group_by_field = self.inverted_string_field
         default_search_field = self.vector_fields[1]
-        search_vectors = cf.gen_vectors(1, dim=self.dims[1],
-                                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                          self.vector_fields[1]))
+        search_vectors = cf.gen_vectors(
+            1,
+            dim=self.dims[1],
+            vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[1]),
+        )
         search_params = {}
         limit = 10
         max_group_size = 10
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=max_group_size, strict_group_size=True,
-                    output_fields=[group_by_field])
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=max_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+        )
         exceed_max_group_size = max_group_size + 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"input group size:{exceed_max_group_size} exceeds configured max "
-                             f"group size:{max_group_size}"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=exceed_max_group_size, strict_group_size=True,
-                    output_fields=[group_by_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: f"input group size:{exceed_max_group_size} exceeds configured max group size:{max_group_size}",
+        }
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=exceed_max_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
         min_group_size = 1
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=max_group_size, strict_group_size=True,
-                    output_fields=[group_by_field])
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=max_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+        )
         below_min_group_size = min_group_size - 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"input group size:{below_min_group_size} is negative"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=below_min_group_size, strict_group_size=True,
-                    output_fields=[group_by_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 999, ct.err_msg: f"input group size:{below_min_group_size} is negative"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=below_min_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
         below_min_group_size = min_group_size - 10
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"input group size:{below_min_group_size} is negative"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=below_min_group_size, strict_group_size=True,
-                    output_fields=[group_by_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 999, ct.err_msg: f"input group size:{below_min_group_size} is negative"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=below_min_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_iterator_not_support_group_by(self):
@@ -678,17 +850,22 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 verify: error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {}
         grpby_field = DataType.VARCHAR.name
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "Not allowed to do groupBy when doing iteration"}
-        self.search_iterator(client, self.collection_name, data=search_vectors,
-                             anns_field=self.float_vector_field_name,
-                             search_params=search_params, batch_size=10, limit=100,
-                             group_by_field=grpby_field,
-                             check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "Not allowed to do groupBy when doing iteration"}
+        self.search_iterator(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            batch_size=10,
+            limit=100,
+            group_by_field=grpby_field,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_range_search_not_support_group_by(self):
@@ -700,17 +877,21 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 verify: the error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         grpby_field = DataType.VARCHAR.name
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "Not allowed to do range-search when doing search-group-by"}
+        error = {ct.err_code: 1100, ct.err_msg: "Not allowed to do range-search when doing search-group-by"}
         range_search_params = {"metric_type": "COSINE", "params": {"radius": 0.1, "range_filter": 0.5}}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=range_search_params, limit=5,
-                    group_by_field=grpby_field,
-                    check_task=CheckTasks.err_res, check_items=error)
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=range_search_params,
+            limit=5,
+            group_by_field=grpby_field,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("grpby_nonexist_field", ["nonexist_field", 21])
@@ -724,16 +905,20 @@ class TestGroupSearch(TestMilvusClientV2Base):
         """
         client = self._client()
         nq = 2
-        search_vectors = cf.gen_vectors(nq, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(nq, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {}
         limit = 100
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=limit,
-                    group_by_field=grpby_nonexist_field,
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"nq": nq, "limit": limit})
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=grpby_nonexist_field,
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "limit": limit},
+        )
 
 
 @pytest.mark.xdist_group("TestGroupSearchInvalid")
@@ -766,7 +951,8 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
         fields = []
         fields.append(FieldSchema(name=self.primary_field, dtype=DataType.INT64, is_primary=True, auto_id=True))
         fields.append(
-            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim))
+            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim)
+        )
 
         for data_type in ct.all_scalar_data_types:
             fields.append(cf.gen_scalar_field(data_type, name=data_type.name, nullable=True))
@@ -788,14 +974,18 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=self.float_vector_field_name,
-                               metric_type=self.float_vector_metric,
-                               index_type=self.float_vector_index,
-                               params={"nlist": 128})
-        index_params.add_index(field_name=self.int8_vector_field_name,
-                               metric_type=self.int8_vector_metric,
-                               index_type=self.int8_vector_index,
-                               params={"nlist": 128})
+        index_params.add_index(
+            field_name=self.float_vector_field_name,
+            metric_type=self.float_vector_metric,
+            index_type=self.float_vector_index,
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name=self.int8_vector_field_name,
+            metric_type=self.int8_vector_metric,
+            index_type=self.int8_vector_index,
+            params={"nlist": 128},
+        )
         self.create_index(client, self.collection_name, index_params=index_params)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.float_vector_field_name)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.int8_vector_field_name)
@@ -819,17 +1009,21 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
         """
         client = self._client()
         search_params = {}
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         # verify
-        error = {ct.err_code: 1700,
-                 ct.err_msg: "groupBy field not found in schema"}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=10,
-                    group_by_field=[DataType.VARCHAR.name, DataType.INT32.name],
-                    output_fields=[DataType.VARCHAR.name, DataType.INT32.name],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 1700, ct.err_msg: "groupBy field not found in schema"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=10,
+            group_by_field=[DataType.VARCHAR.name, DataType.INT32.name],
+            output_fields=[DataType.VARCHAR.name, DataType.INT32.name],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("grpby_nonexist_field", ["nonexist_field", 21])
@@ -842,17 +1036,24 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
                 verify: the error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {}
         limit = 1
-        error = {ct.err_code: 1700,
-                 ct.err_msg: f"groupBy field not found in schema: field not found[field={grpby_nonexist_field}]"}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=limit,
-                    group_by_field=grpby_nonexist_field,
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            ct.err_code: 1700,
+            ct.err_msg: f"groupBy field not found in schema: field not found[field={grpby_nonexist_field}]",
+        }
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=grpby_nonexist_field,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
 
 class TestSearchGroupByIndependent(TestMilvusClientV2Base):
@@ -964,18 +1165,28 @@ class TestSearchGroupByIndependent(TestMilvusClientV2Base):
         search_params = {}
 
         # normal search to get the best result
-        normal_res = self.search(client, collection_name, data=search_vectors,
-                                 search_params=search_params, limit=limit,
-                                 output_fields=[grpby_field],
-                                 check_task=CheckTasks.check_search_results,
-                                 check_items={"nq": nq, "limit": limit})[0]
+        normal_res = self.search(
+            client,
+            collection_name,
+            data=search_vectors,
+            search_params=search_params,
+            limit=limit,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "limit": limit},
+        )[0]
         # group_by search
-        groupby_res = self.search(client, collection_name, data=search_vectors,
-                                  search_params=search_params, limit=limit,
-                                  group_by_field=grpby_field,
-                                  output_fields=[grpby_field],
-                                  check_task=CheckTasks.check_search_results,
-                                  check_items={"nq": nq, "limit": limit})[0]
+        groupby_res = self.search(
+            client,
+            collection_name,
+            data=search_vectors,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=grpby_field,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "limit": limit},
+        )[0]
         # verify that the top result from group_by search matches the normal search
         # for the same group value, group_by should return the best (closest) result
         normal_top_distance = normal_res[0][0].distance
@@ -990,9 +1201,11 @@ class TestSearchGroupByIndependent(TestMilvusClientV2Base):
         # because group_by returns the best result per group
         if metric == "L2":
             # For L2, smaller is better
-            assert groupby_top_distance <= normal_top_distance + epsilon, \
+            assert groupby_top_distance <= normal_top_distance + epsilon, (
                 "GroupBy search should return result with distance <= normal search for L2 metric"
+            )
         else:
             # For IP/COSINE, larger is better
-            assert groupby_top_distance >= normal_top_distance - epsilon, \
+            assert groupby_top_distance >= normal_top_distance - epsilon, (
                 f"GroupBy search should return result with distance >= normal search for {metric} metric"
+            )


### PR DESCRIPTION
## Summary
- Cherrypick #47866 to raise the default vector field limit from 4 to 10 on 2.6.
- Cherrypick #49751 to support nullable vectors in RESTful insert, upsert, partial update, and response conversion.
- Cherrypick #49756 and #49771 to fix sealed nullable-vector projection and keep transformed nullable-vector bitsets alive for search result iteration.

pr: #47866
pr: #49751
pr: #49756
pr: #49771
issue: #49470

## Test plan
- [x] `git diff --check upstream/2.6...HEAD`
- [x] `GO_DIFF_FILES="internal/distributed/proxy/httpserver/handler_v1.go internal/distributed/proxy/httpserver/utils.go internal/distributed/proxy/httpserver/utils_test.go pkg/util/paramtable/component_param.go tests/go_client/common/consts.go" make fmt`
- [x] `python3 -m py_compile tests/python_client/milvus_client_v2/test_milvus_client_search_group_by.py tests/python_client/common/common_type.py tests/python_client/milvus_client/test_milvus_client_collection.py`
- [x] `python3 -m ruff check tests/python_client/milvus_client_v2/test_milvus_client_search_group_by.py tests/python_client/common/common_type.py tests/python_client/milvus_client/test_milvus_client_collection.py`
- [x] `python3 -m pytest tests/python_client/milvus_client_v2/test_milvus_client_search_group_by.py::TestSearchGroupByIndependent::test_search_group_by_nullable_vector --collect-only -q -o addopts="-p no:locust -v"`
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/distributed/proxy/httpserver -run "TestInsertWithNullableVectorFields|TestPartialUpdateWithNullableExplicitNull|TestBuildQueryRespWithNullableCompactFields" -count=1`
- [x] `cmake_build/bin/all_tests --gtest_filter="test_chunk_segment.NullableVectorProjectionFallsBackWhenLoadedIndexHasNoValidData:SearchOnSealedIndexBitsetLifetime.GroupByIteratorMustNotKeepDanglingTransformedBitset:SearchOnGrowingBitsetLifetime.GroupByIteratorMustNotKeepDanglingTransformedBitset:SearchOnSealedColumnBitsetLifetime.GroupByIteratorMustNotKeepDanglingTransformedBitset"`
- [x] `make cppcheck`