### PR TITLE
enhance: optimize QueryNode scheduler recovery performance from heavy load

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -577,7 +577,7 @@ queryNode:
       maxPendingTaskPerUser: 1024 # Max pending task per user in scheduler
   grouping:
     maxNQ: 16
-    nqMergeRatio: 3
+    nqMergeRatio: 3 # Maximum ratio between merged total NQ and the smaller task NQ when grouping query node read tasks.
     topKMergeRatio: 20
   search:
     enableResultZeroCopy: false # When true, delegator passes reduced SearchResultData directly instead of re-marshaling to SlicedBlob. Toggle at runtime for instant fallback.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -331,7 +331,7 @@ proxy:
     allowedChars: $ # Additional characters allowed in names beyond underscores, letters and numbers. To allow hyphens in names, add '-' here.
   roleNameValidation:
     allowedChars: $ # Additional characters allowed in role names beyond underscores, letters and numbers. Add '-' to allow hyphens in role names.
-  maxTaskNum: 1024 # The maximum number of tasks in the task queue of the proxy.
+  maxTaskNum: 256 # The maximum number of tasks in the task queue of the proxy.
   ddlConcurrency: 16 # The concurrent execution number of DDL at proxy.
   dclConcurrency: 16 # The concurrent execution number of DCL at proxy.
   mustUsePartitionKey: false # switch for whether proxy must use partition key for the collection

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -553,8 +553,7 @@ queryNode:
     maxDiskUsagePercentageForMmapAlloc: 50 # disk percentage used in mmap chunk manager
   indexOffsetCacheEnabled: false # enable index offset cache for some scalar indexes, now is just for bitmap index, enable this param can improve performance for retrieving raw data from index
   scheduler:
-    receiveChanSize: 10240
-    unsolvedQueueSize: 10240
+    unsolvedQueueSize: 1024
     # maxReadConcurrentRatio is the concurrency ratio of read task (search task and query task).
     # Max read concurrency would be the value of hardware.GetCPUNum * maxReadConcurrentRatio.
     # It defaults to 2.0, which means max read concurrency would be the value of hardware.GetCPUNum * 2.
@@ -570,13 +569,15 @@ queryNode:
       # 	Scheduling is fair on task granularity.
       # 	The policy is based on the username for authentication.
       # 	And an empty username is considered the same user.
-      # 	When there are no multi-users, the policy decay into FIFO"
+      # 	When there are no multi-users, the policy decay into FIFO.
       name: fifo
       taskQueueExpire: 60 # Control how long (many seconds) that queue retains since queue is empty
+      taskDeadlineAdvance: 50ms # Advance duration for cleaning queued query node read tasks before their context deadline. It supports duration strings such as 50ms and 1s. A bare number is interpreted as milliseconds for compatibility.
       enableCrossUserGrouping: false # Enable Cross user grouping when using user-task-polling policy. (Disable it if user's task can not merge each other)
       maxPendingTaskPerUser: 1024 # Max pending task per user in scheduler
   grouping:
-    maxNQ: 1000
+    maxNQ: 16
+    nqMergeRatio: 3
     topKMergeRatio: 20
   search:
     enableResultZeroCopy: false # When true, delegator passes reduced SearchResultData directly instead of re-marshaling to SlicedBlob. Toggle at runtime for instant fallback.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -578,7 +578,7 @@ queryNode:
   grouping:
     maxNQ: 16
     nqMergeRatio: 3 # Maximum ratio between merged total NQ and the smaller task NQ when grouping query node read tasks.
-    maxDeadlineMergeGap: 50ms # Maximum allowed gap between task context deadlines when grouping query node read tasks. Tasks with only one deadline cannot be grouped.
+    maxDeadlineMergeGap: 50ms # Maximum allowed gap between task context deadlines when grouping query node read tasks. Tasks with only one deadline cannot be grouped. Set a negative duration to disable this check.
     topKMergeRatio: 20
   search:
     enableResultZeroCopy: false # When true, delegator passes reduced SearchResultData directly instead of re-marshaling to SlicedBlob. Toggle at runtime for instant fallback.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -331,7 +331,7 @@ proxy:
     allowedChars: $ # Additional characters allowed in names beyond underscores, letters and numbers. To allow hyphens in names, add '-' here.
   roleNameValidation:
     allowedChars: $ # Additional characters allowed in role names beyond underscores, letters and numbers. Add '-' to allow hyphens in role names.
-  maxTaskNum: 256 # The maximum number of tasks in the task queue of the proxy.
+  maxTaskNum: 1024 # The maximum number of tasks in the task queue of the proxy.
   ddlConcurrency: 16 # The concurrent execution number of DDL at proxy.
   dclConcurrency: 16 # The concurrent execution number of DCL at proxy.
   mustUsePartitionKey: false # switch for whether proxy must use partition key for the collection
@@ -578,6 +578,7 @@ queryNode:
   grouping:
     maxNQ: 16
     nqMergeRatio: 3 # Maximum ratio between merged total NQ and the smaller task NQ when grouping query node read tasks.
+    maxDeadlineMergeGap: 50ms # Maximum allowed gap between task context deadlines when grouping query node read tasks. Tasks with only one deadline cannot be grouped.
     topKMergeRatio: 20
   search:
     enableResultZeroCopy: false # When true, delegator passes reduced SearchResultData directly instead of re-marshaling to SlicedBlob. Toggle at runtime for instant fallback.

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -656,23 +656,6 @@ func TestTimeoutMiddlewarePassesDeadline(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestTimeoutMiddlewarePropagatesPanic(t *testing.T) {
-	ginHandler := gin.New()
-	app := ginHandler.Group("")
-	path := "/middleware/timeout/panic"
-	app.POST(path, timeoutMiddleware(func(c *gin.Context) {
-		panic("mock panic")
-	}))
-
-	req := httptest.NewRequest(http.MethodPost, path, nil)
-	w := httptest.NewRecorder()
-
-	assert.Panics(t, func() {
-		ginHandler.ServeHTTP(w, req)
-	})
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
-}
-
 func TestDocInDocOutCreateCollection(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -656,6 +656,23 @@ func TestTimeoutMiddlewarePassesDeadline(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestTimeoutMiddlewarePropagatesPanic(t *testing.T) {
+	ginHandler := gin.New()
+	app := ginHandler.Group("")
+	path := "/middleware/timeout/panic"
+	app.POST(path, timeoutMiddleware(func(c *gin.Context) {
+		panic("mock panic")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	w := httptest.NewRecorder()
+
+	assert.Panics(t, func() {
+		ginHandler.ServeHTTP(w, req)
+	})
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
 func TestDocInDocOutCreateCollection(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -636,6 +636,26 @@ func TestRestfulSizeMiddlewarePreservesRequestContextCancel(t *testing.T) {
 	assert.True(t, errors.Is(<-observed, context.Canceled))
 }
 
+func TestTimeoutMiddlewarePassesDeadline(t *testing.T) {
+	ginHandler := gin.Default()
+	app := ginHandler.Group("")
+	path := "/middleware/timeout/deadline"
+	app.POST(path, timeoutMiddleware(func(c *gin.Context) {
+		deadline, ok := c.Request.Context().Deadline()
+		assert.True(t, ok)
+		assert.LessOrEqual(t, time.Until(deadline), 3*time.Second)
+		assert.Greater(t, time.Until(deadline), time.Second)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	req.Header.Set(mhttp.HTTPHeaderRequestTimeout, "3")
+	w := httptest.NewRecorder()
+
+	ginHandler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 func TestDocInDocOutCreateCollection(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -240,16 +240,16 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 	}
 	bufPool := &BufferPool{}
 	return func(gCtx *gin.Context) {
-		topCtx, cancel := context.WithCancel(gCtx.Request.Context())
-		defer cancel()
-		req := gCtx.Request.WithContext(topCtx)
-		gCtx.Request = req
-
 		timeout := paramtable.Get().HTTPCfg.RequestTimeoutMs.GetAsDuration(time.Millisecond)
 		timeoutSecond, err := strconv.ParseInt(gCtx.Request.Header.Get(mhttp.HTTPHeaderRequestTimeout), 10, 64)
 		if err == nil {
 			timeout = time.Duration(timeoutSecond) * time.Second
 		}
+		topCtx, cancel := context.WithTimeout(gCtx.Request.Context(), timeout)
+		defer cancel()
+		req := gCtx.Request.WithContext(topCtx)
+		gCtx.Request = req
+
 		finish := make(chan struct{}, 1)
 		panicChan := make(chan interface{}, 1)
 

--- a/internal/querynodev2/tasks/query_stream_task.go
+++ b/internal/querynodev2/tasks/query_stream_task.go
@@ -54,6 +54,10 @@ func (t *QueryStreamTask) IsGpuIndex() bool {
 	return false
 }
 
+func (t *QueryStreamTask) Context() context.Context {
+	return t.ctx
+}
+
 // PreExecute the task, only call once.
 func (t *QueryStreamTask) PreExecute() error {
 	return nil
@@ -87,10 +91,6 @@ func (t *QueryStreamTask) Execute() error {
 
 func (t *QueryStreamTask) Done(err error) {
 	t.notifier <- err
-}
-
-func (t *QueryStreamTask) Canceled() error {
-	return t.ctx.Err()
 }
 
 func (t *QueryStreamTask) Wait() error {

--- a/internal/querynodev2/tasks/query_task.go
+++ b/internal/querynodev2/tasks/query_task.go
@@ -68,6 +68,10 @@ func (t *QueryTask) IsGpuIndex() bool {
 	return false
 }
 
+func (t *QueryTask) Context() context.Context {
+	return t.ctx
+}
+
 // PreExecute the task, only call once.
 func (t *QueryTask) PreExecute() error {
 	// Update task wait time metric before execute
@@ -180,10 +184,6 @@ func (t *QueryTask) Execute() error {
 
 func (t *QueryTask) Done(err error) {
 	t.notifier <- err
-}
-
-func (t *QueryTask) Canceled() error {
-	return t.ctx.Err()
 }
 
 func (t *QueryTask) Wait() error {

--- a/internal/querynodev2/tasks/search_task.go
+++ b/internal/querynodev2/tasks/search_task.go
@@ -370,12 +370,6 @@ func (t *SearchTask) Merge(other *SearchTask) bool {
 	maxTopk := funcutil.Max(topk, otherTopk)
 	after := (nq + otherNq) * maxTopk
 	ratio := float64(after) / float64(pre)
-	minNQ := funcutil.Min(t.MinNQ(), other.MinNQ())
-	nqMergeRatio := 0.0
-	if minNQ > 0 {
-		nqMergeRatio = float64(nq+otherNq) / float64(minNQ)
-	}
-	nqMergeRatioLimit := paramtable.Get().QueryNodeCfg.NQMergeRatio.GetAsFloat()
 
 	// Check mergeable
 	if t.req.GetFilterOnly() != other.req.GetFilterOnly() ||
@@ -385,9 +379,6 @@ func (t *SearchTask) Merge(other *SearchTask) bool {
 		t.req.GetReq().GetMvccTimestamp() != other.req.GetReq().GetMvccTimestamp() ||
 		t.req.GetReq().GetDslType() != other.req.GetReq().GetDslType() ||
 		t.req.GetDmlChannels()[0] != other.req.GetDmlChannels()[0] ||
-		nq+otherNq > paramtable.Get().QueryNodeCfg.MaxGroupNQ.GetAsInt64() ||
-		minNQ <= 0 ||
-		(nqMergeRatioLimit > 0 && nqMergeRatio > nqMergeRatioLimit) ||
 		(diffTopk && ratio > paramtable.Get().QueryNodeCfg.TopKMergeRatio.GetAsFloat()) ||
 		!funcutil.SliceSetEqual(t.req.GetReq().GetPartitionIDs(), other.req.GetReq().GetPartitionIDs()) ||
 		!funcutil.SliceSetEqual(t.req.GetSegmentIDs(), other.req.GetSegmentIDs()) ||

--- a/internal/querynodev2/tasks/search_task.go
+++ b/internal/querynodev2/tasks/search_task.go
@@ -96,6 +96,10 @@ func (t *SearchTask) IsGpuIndex() bool {
 	return t.collection.IsGpuIndex()
 }
 
+func (t *SearchTask) Context() context.Context {
+	return t.ctx
+}
+
 func (t *SearchTask) PreExecute() error {
 	// Update task wait time metric before execute
 	nodeID := strconv.FormatInt(t.GetNodeID(), 10)
@@ -366,6 +370,12 @@ func (t *SearchTask) Merge(other *SearchTask) bool {
 	maxTopk := funcutil.Max(topk, otherTopk)
 	after := (nq + otherNq) * maxTopk
 	ratio := float64(after) / float64(pre)
+	minNQ := funcutil.Min(t.MinNQ(), other.MinNQ())
+	nqMergeRatio := 0.0
+	if minNQ > 0 {
+		nqMergeRatio = float64(nq+otherNq) / float64(minNQ)
+	}
+	nqMergeRatioLimit := paramtable.Get().QueryNodeCfg.NQMergeRatio.GetAsFloat()
 
 	// Check mergeable
 	if t.req.GetFilterOnly() != other.req.GetFilterOnly() ||
@@ -376,6 +386,8 @@ func (t *SearchTask) Merge(other *SearchTask) bool {
 		t.req.GetReq().GetDslType() != other.req.GetReq().GetDslType() ||
 		t.req.GetDmlChannels()[0] != other.req.GetDmlChannels()[0] ||
 		nq+otherNq > paramtable.Get().QueryNodeCfg.MaxGroupNQ.GetAsInt64() ||
+		minNQ <= 0 ||
+		nqMergeRatioLimit > 0 && nqMergeRatio > nqMergeRatioLimit ||
 		diffTopk && ratio > paramtable.Get().QueryNodeCfg.TopKMergeRatio.GetAsFloat() ||
 		!funcutil.SliceSetEqual(t.req.GetReq().GetPartitionIDs(), other.req.GetReq().GetPartitionIDs()) ||
 		!funcutil.SliceSetEqual(t.req.GetSegmentIDs(), other.req.GetSegmentIDs()) ||
@@ -407,10 +419,6 @@ func (t *SearchTask) Done(err error) {
 	}
 }
 
-func (t *SearchTask) Canceled() error {
-	return t.ctx.Err()
-}
-
 func (t *SearchTask) Wait() error {
 	return <-t.notifier
 }
@@ -428,6 +436,19 @@ func (t *SearchTask) SearchResult() *internalpb.SearchResults {
 
 func (t *SearchTask) NQ() int64 {
 	return t.nq
+}
+
+func (t *SearchTask) MinNQ() int64 {
+	if len(t.originNqs) == 0 {
+		return t.nq
+	}
+	minNQ := t.originNqs[0]
+	for _, nq := range t.originNqs[1:] {
+		if nq < minNQ {
+			minNQ = nq
+		}
+	}
+	return minNQ
 }
 
 func (t *SearchTask) MergeWith(other scheduler.Task) bool {

--- a/internal/querynodev2/tasks/search_task.go
+++ b/internal/querynodev2/tasks/search_task.go
@@ -387,8 +387,8 @@ func (t *SearchTask) Merge(other *SearchTask) bool {
 		t.req.GetDmlChannels()[0] != other.req.GetDmlChannels()[0] ||
 		nq+otherNq > paramtable.Get().QueryNodeCfg.MaxGroupNQ.GetAsInt64() ||
 		minNQ <= 0 ||
-		nqMergeRatioLimit > 0 && nqMergeRatio > nqMergeRatioLimit ||
-		diffTopk && ratio > paramtable.Get().QueryNodeCfg.TopKMergeRatio.GetAsFloat() ||
+		(nqMergeRatioLimit > 0 && nqMergeRatio > nqMergeRatioLimit) ||
+		(diffTopk && ratio > paramtable.Get().QueryNodeCfg.TopKMergeRatio.GetAsFloat()) ||
 		!funcutil.SliceSetEqual(t.req.GetReq().GetPartitionIDs(), other.req.GetReq().GetPartitionIDs()) ||
 		!funcutil.SliceSetEqual(t.req.GetSegmentIDs(), other.req.GetSegmentIDs()) ||
 		!bytes.Equal(t.req.GetReq().GetSerializedExprPlan(), other.req.GetReq().GetSerializedExprPlan()) {

--- a/internal/querynodev2/tasks/search_task_test.go
+++ b/internal/querynodev2/tasks/search_task_test.go
@@ -318,6 +318,21 @@ func (s *SearchTaskSuite) TestMergeFilterOnly() {
 	})
 }
 
+func (s *SearchTaskSuite) TestSearchTaskMinNQ() {
+	s.Run("fallback_to_total_nq_without_origin", func() {
+		task := &SearchTask{nq: 8}
+		s.Equal(int64(8), task.MinNQ())
+	})
+
+	s.Run("minimum_origin_nq", func() {
+		task := &SearchTask{
+			nq:        11,
+			originNqs: []int64{5, 2, 4},
+		}
+		s.Equal(int64(2), task.MinNQ())
+	})
+}
+
 func TestSearchTask(t *testing.T) {
 	suite.Run(t, new(SearchTaskSuite))
 }

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
@@ -1,8 +1,12 @@
 package scheduler
 
 import (
+	"context"
+	"fmt"
 	"sync"
+	"time"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
@@ -11,22 +15,26 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
 	"github.com/milvus-io/milvus/pkg/v3/util/lifetime"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 const (
 	maxReceiveChanBatchConsumeNum = 100
+
+	readTaskQueueOutcomeScheduled = "scheduled"
+	readTaskQueueOutcomeDropped   = "dropped"
+	readTaskQueueOutcomeExpired   = "expired"
 )
 
 // newScheduler create a scheduler with given schedule policy.
 func newScheduler(policy schedulePolicy) Scheduler {
 	maxReadConcurrency := paramtable.Get().QueryNodeCfg.MaxReadConcurrency.GetAsInt()
-	maxReceiveChanSize := paramtable.Get().QueryNodeCfg.MaxReceiveChanSize.GetAsInt()
 	log.Info("query node use concurrent safe scheduler", zap.Int("max_concurrency", maxReadConcurrency))
 	return &scheduler{
 		policy:           policy,
-		receiveChan:      make(chan addTaskReq, maxReceiveChanSize),
+		receiveChan:      make(chan addTaskReq),
 		execChan:         make(chan Task),
 		pool:             conc.NewPool[any](maxReadConcurrency, conc.WithPreAlloc(true)),
 		gpuPool:          conc.NewPool[any](paramtable.Get().QueryNodeCfg.MaxGpuReadConcurrency.GetAsInt(), conc.WithPreAlloc(true)),
@@ -66,17 +74,20 @@ func (s *scheduler) Add(task Task) (err error) {
 
 	errCh := make(chan error, 1)
 
-	// TODO: add operation should be fast, is UnsolveLen metric unnesscery?
-	metrics.QueryNodeReadTaskUnsolveLen.WithLabelValues(paramtable.GetStringNodeID()).Inc()
-
-	// start a new in queue span and send task to add chan
-	s.receiveChan <- addTaskReq{
+	req := addTaskReq{
 		task: task,
 		err:  errCh,
 	}
-	err = <-errCh
 
-	metrics.QueryNodeReadTaskUnsolveLen.WithLabelValues(paramtable.GetStringNodeID()).Dec()
+	// start a new in queue span and send task to add chan
+	ctx := task.Context()
+	select {
+	case s.receiveChan <- req:
+		err = <-errCh
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
+
 	return
 }
 
@@ -113,23 +124,24 @@ func (s *scheduler) Stop() {
 // schedule the owned task asynchronously and continuously.
 func (s *scheduler) schedule() {
 	defer s.wg.Done()
-	var task Task
+	var task queuedTask
 	for {
 		s.setupReadyLenMetric()
 
 		var execChan chan Task
 		nq := int64(0)
-		task, nq, execChan = s.setupExecListener(task)
+		now := time.Now()
+		task, nq, execChan = s.setupExecListener(task, now)
 
 		select {
 		case req, ok := <-s.receiveChan:
 			if !ok {
 				log.Info("receiveChan closed, processing remaining request")
 				// drain policy maintained task
-				for task != nil {
-					execChan <- task
+				for task.valid() {
+					execChan <- task.Task
 					s.updateWaitingTaskCounter(-1, -nq)
-					task = s.produceExecChan()
+					task = s.produceExecChan(now)
 				}
 				log.Info("all task put into exeChan, schedule worker exit")
 				close(s.execChan)
@@ -137,22 +149,22 @@ func (s *scheduler) schedule() {
 			}
 			// Receive add operation request and return the process result.
 			// And consume recv chan as much as possible.
-			s.consumeRecvChan(req, maxReceiveChanBatchConsumeNum)
-		case execChan <- task:
+			s.consumeRecvChan(req, maxReceiveChanBatchConsumeNum, now)
+		case execChan <- task.Task:
 			// Task sent, drop the ownership of sent task.
 			// Update waiting task counter.
 			s.updateWaitingTaskCounter(-1, -nq)
 			// And produce new task into execChan as much as possible.
-			task = s.produceExecChan()
+			task = s.produceExecChan(now)
 		}
 	}
 }
 
 // consumeRecvChan consume the recv chan as much as possible.
-func (s *scheduler) consumeRecvChan(req addTaskReq, limit int) {
+func (s *scheduler) consumeRecvChan(req addTaskReq, limit int, now time.Time) {
 	// Check the dynamic wait task limit.
 	maxWaitTaskNum := paramtable.Get().QueryNodeCfg.MaxUnsolvedQueueSize.GetAsInt64()
-	if !s.handleAddTaskRequest(req, maxWaitTaskNum) {
+	if !s.handleAddTaskRequest(req, maxWaitTaskNum, now) {
 		return
 	}
 
@@ -163,7 +175,7 @@ func (s *scheduler) consumeRecvChan(req addTaskReq, limit int) {
 			if !ok {
 				return
 			}
-			if !s.handleAddTaskRequest(req, maxWaitTaskNum) {
+			if !s.handleAddTaskRequest(req, maxWaitTaskNum, now) {
 				return
 			}
 		default:
@@ -174,14 +186,23 @@ func (s *scheduler) consumeRecvChan(req addTaskReq, limit int) {
 
 // HandleAddTaskRequest handle a add task request.
 // Return true if the process can be continued.
-func (s *scheduler) handleAddTaskRequest(req addTaskReq, maxWaitTaskNum int64) bool {
-	if err := req.task.Canceled(); err != nil {
+func (s *scheduler) handleAddTaskRequest(req addTaskReq, maxWaitTaskNum int64, now time.Time) bool {
+	s.cleanupExpiredTasks(now)
+
+	if err := req.task.Context().Err(); err != nil {
 		log.Warn("task canceled before enqueue", zap.Error(err))
+		req.err <- err
+	} else if maxWaitTaskNum > 0 && s.GetWaitingTaskTotal() >= maxWaitTaskNum {
+		err := merr.WrapErrTooManyRequests(
+			int32(maxWaitTaskNum),
+			fmt.Sprintf("limit by %s", paramtable.Get().QueryNodeCfg.MaxUnsolvedQueueSize.Key),
+		)
 		req.err <- err
 	} else {
 		// Push the task into the policy to schedule and update the counter of the ready queue.
-		nq := req.task.NQ()
-		newTaskAdded, err := s.policy.Push(req.task)
+		queued := newQueuedTask(req.task, now)
+		nq := queued.NQ()
+		newTaskAdded, err := s.policy.Push(queued)
 		if err == nil {
 			s.updateWaitingTaskCounter(int64(newTaskAdded), nq)
 		}
@@ -189,23 +210,23 @@ func (s *scheduler) handleAddTaskRequest(req addTaskReq, maxWaitTaskNum int64) b
 	}
 
 	// Continue processing if the queue isn't reach the max limit.
-	return s.GetWaitingTaskTotal() < maxWaitTaskNum
+	return maxWaitTaskNum <= 0 || s.GetWaitingTaskTotal() < maxWaitTaskNum
 }
 
 // produceExecChan produce task from scheduler into exec chan as much as possible
-func (s *scheduler) produceExecChan() Task {
-	var task Task
+func (s *scheduler) produceExecChan(now time.Time) queuedTask {
+	var task queuedTask
 	for {
 		var execChan chan Task
 		nq := int64(0)
-		task, nq, execChan = s.setupExecListener(task)
+		task, nq, execChan = s.setupExecListener(task, now)
 
 		select {
-		case execChan <- task:
+		case execChan <- task.Task:
 			// Update waiting task counter.
 			s.updateWaitingTaskCounter(-1, -nq)
 			// Task sent, drop the ownership of sent task.
-			task = nil
+			task = queuedTask{}
 		default:
 			return task
 		}
@@ -223,7 +244,7 @@ func (s *scheduler) exec() {
 			return
 		}
 		// Skip this task if task is canceled.
-		if err := t.Canceled(); err != nil {
+		if err := t.Context().Err(); err != nil {
 			log.Warn("task canceled before executing", zap.Error(err))
 			t.Done(err)
 			continue
@@ -239,7 +260,12 @@ func (s *scheduler) exec() {
 			metrics.QueryNodeReadTaskConcurrency.WithLabelValues(paramtable.GetStringNodeID()).Inc()
 			collector.Counter.Inc(metricsinfo.ExecuteQueueType)
 
+			executeStart := time.Now()
 			err := t.Execute()
+			metrics.QueryNodeReadTaskExecuteDuration.WithLabelValues(
+				paramtable.GetStringNodeID(),
+				readTaskExecuteOutcome(err),
+			).Observe(float64(time.Since(executeStart).Microseconds()) / 1000.0)
 
 			// Update all metric after task finished.
 			metrics.QueryNodeReadTaskConcurrency.WithLabelValues(paramtable.GetStringNodeID()).Dec()
@@ -260,21 +286,55 @@ func (s *scheduler) getPool(t Task) *conc.Pool[any] {
 	return s.pool
 }
 
+func readTaskExecuteOutcome(err error) string {
+	if err == nil {
+		return metrics.SuccessLabel
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return metrics.CancelLabel
+	}
+	return metrics.FailLabel
+}
+
 // setupExecListener setup the execChan and next task to run.
-func (s *scheduler) setupExecListener(lastWaitingTask Task) (Task, int64, chan Task) {
+func (s *scheduler) setupExecListener(lastWaitingTask queuedTask, now time.Time) (queuedTask, int64, chan Task) {
 	var execChan chan Task
 	nq := int64(0)
-	if lastWaitingTask == nil {
+	if !lastWaitingTask.valid() {
 		// No task is waiting to send to execChan, schedule a new one from queue.
-		lastWaitingTask = s.policy.Pop()
+		result := s.policy.Pop(now)
+		s.dropTasks(result.dropped, now)
+		lastWaitingTask = result.task
+		if lastWaitingTask.valid() {
+			s.recordReadTaskQueueDuration(lastWaitingTask, now, readTaskQueueOutcomeScheduled)
+		}
 	}
-	if lastWaitingTask != nil {
+	if lastWaitingTask.valid() {
 		// Try to sent task to execChan if there is a task ready to run.
 		execChan = s.execChan
 		nq = lastWaitingTask.NQ()
 	}
 
 	return lastWaitingTask, nq, execChan
+}
+
+func (s *scheduler) cleanupExpiredTasks(now time.Time) {
+	deadlineAdvance := paramtable.Get().QueryNodeCfg.SchedulePolicyTaskDeadlineAdvance.GetAsDurationByParse()
+	cleanupTime := now.Add(deadlineAdvance)
+	tasks := s.policy.Cleanup(cleanupTime)
+	for _, task := range tasks {
+		s.updateWaitingTaskCounter(-1, -task.NQ())
+		s.recordReadTaskQueueDuration(task, now, readTaskQueueOutcomeExpired)
+		task.Done(cleanupTaskError(task))
+	}
+}
+
+func (s *scheduler) dropTasks(tasks []queuedTask, now time.Time) {
+	for _, task := range tasks {
+		s.updateWaitingTaskCounter(-1, -task.NQ())
+		s.recordReadTaskQueueDuration(task, now, readTaskQueueOutcomeDropped)
+		task.Done(merr.WrapErrTooManyRequests(0, "dropped by query node read schedule policy"))
+	}
 }
 
 // setupReadyLenMetric update the read task ready len metric.
@@ -285,6 +345,17 @@ func (s *scheduler) setupReadyLenMetric() {
 	collector.Counter.Set(metricsinfo.ReadyQueueType, waitingTaskCount)
 	// Record the waiting task length of policy as ready task metric.
 	metrics.QueryNodeReadTaskReadyLen.WithLabelValues(paramtable.GetStringNodeID()).Set(float64(waitingTaskCount))
+	metrics.QueryNodeReadTaskReadyNQ.WithLabelValues(paramtable.GetStringNodeID()).Set(float64(s.GetWaitingTaskTotalNQ()))
+}
+
+func (s *scheduler) recordReadTaskQueueDuration(task queuedTask, now time.Time, outcome string) {
+	if !task.valid() {
+		return
+	}
+	metrics.QueryNodeReadTaskQueueDuration.WithLabelValues(
+		paramtable.GetStringNodeID(),
+		outcome,
+	).Observe(float64(task.queueDuration(now).Microseconds()) / 1000.0)
 }
 
 // scheduler counter implement, concurrent safe.

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
@@ -190,7 +190,9 @@ func (s *scheduler) consumeRecvChan(req addTaskReq, limit int, now time.Time) {
 // HandleAddTaskRequest handle a add task request.
 // Return true if the process can be continued.
 func (s *scheduler) handleAddTaskRequest(req addTaskReq, maxWaitTaskNum int64, now time.Time) bool {
-	s.cleanupExpiredTasks(now)
+	if maxWaitTaskNum > 0 && s.GetWaitingTaskTotal() >= maxWaitTaskNum {
+		s.cleanupExpiredTasks(now)
+	}
 
 	if err := req.task.Context().Err(); err != nil {
 		log.Warn("task canceled before enqueue", zap.Error(err))
@@ -309,9 +311,20 @@ func (s *scheduler) setupExecListener(lastWaitingTask *queuedTask, now time.Time
 	nq := int64(0)
 	if !lastWaitingTask.valid() {
 		// No task is waiting to send to execChan, schedule a new one from queue.
-		lastWaitingTask = s.policy.Pop(now)
-		if lastWaitingTask.valid() {
+		for {
+			lastWaitingTask = s.policy.Pop(now)
+			if !lastWaitingTask.valid() {
+				break
+			}
+			if err := lastWaitingTask.Context().Err(); err != nil {
+				s.updateWaitingTaskCounter(-1, -lastWaitingTask.NQ())
+				s.recordReadTaskQueueDuration(lastWaitingTask, now, readTaskQueueOutcomeExpired)
+				lastWaitingTask.Done(err)
+				lastWaitingTask = nil
+				continue
+			}
 			s.recordReadTaskQueueDuration(lastWaitingTask, now, readTaskQueueOutcomeScheduled)
+			break
 		}
 	}
 	if lastWaitingTask.valid() {

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
@@ -123,14 +123,18 @@ func (s *scheduler) Stop() {
 // schedule the owned task asynchronously and continuously.
 func (s *scheduler) schedule() {
 	defer s.wg.Done()
-	var task queuedTask
+	var task *queuedTask
 	for {
 		s.setupReadyLenMetric()
 
 		var execChan chan Task
+		var execTask Task
 		nq := int64(0)
 		now := time.Now()
 		task, nq, execChan = s.setupExecListener(task, now)
+		if task.valid() {
+			execTask = task.Task
+		}
 
 		select {
 		case req, ok := <-s.receiveChan:
@@ -149,7 +153,7 @@ func (s *scheduler) schedule() {
 			// Receive add operation request and return the process result.
 			// And consume recv chan as much as possible.
 			s.consumeRecvChan(req, maxReceiveChanBatchConsumeNum, now)
-		case execChan <- task.Task:
+		case execChan <- execTask:
 			// Task sent, drop the ownership of sent task.
 			// Update waiting task counter.
 			s.updateWaitingTaskCounter(-1, -nq)
@@ -213,19 +217,23 @@ func (s *scheduler) handleAddTaskRequest(req addTaskReq, maxWaitTaskNum int64, n
 }
 
 // produceExecChan produce task from scheduler into exec chan as much as possible
-func (s *scheduler) produceExecChan(now time.Time) queuedTask {
-	var task queuedTask
+func (s *scheduler) produceExecChan(now time.Time) *queuedTask {
+	var task *queuedTask
 	for {
 		var execChan chan Task
+		var execTask Task
 		nq := int64(0)
 		task, nq, execChan = s.setupExecListener(task, now)
+		if task.valid() {
+			execTask = task.Task
+		}
 
 		select {
-		case execChan <- task.Task:
+		case execChan <- execTask:
 			// Update waiting task counter.
 			s.updateWaitingTaskCounter(-1, -nq)
 			// Task sent, drop the ownership of sent task.
-			task = queuedTask{}
+			task = nil
 		default:
 			return task
 		}
@@ -296,7 +304,7 @@ func readTaskExecuteOutcome(err error) string {
 }
 
 // setupExecListener setup the execChan and next task to run.
-func (s *scheduler) setupExecListener(lastWaitingTask queuedTask, now time.Time) (queuedTask, int64, chan Task) {
+func (s *scheduler) setupExecListener(lastWaitingTask *queuedTask, now time.Time) (*queuedTask, int64, chan Task) {
 	var execChan chan Task
 	nq := int64(0)
 	if !lastWaitingTask.valid() {
@@ -337,7 +345,7 @@ func (s *scheduler) setupReadyLenMetric() {
 	metrics.QueryNodeReadTaskReadyNQ.WithLabelValues(paramtable.GetStringNodeID()).Set(float64(s.GetWaitingTaskTotalNQ()))
 }
 
-func (s *scheduler) recordReadTaskQueueDuration(task queuedTask, now time.Time, outcome string) {
+func (s *scheduler) recordReadTaskQueueDuration(task *queuedTask, now time.Time, outcome string) {
 	if !task.valid() {
 		return
 	}

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler.go
@@ -24,7 +24,6 @@ const (
 	maxReceiveChanBatchConsumeNum = 100
 
 	readTaskQueueOutcomeScheduled = "scheduled"
-	readTaskQueueOutcomeDropped   = "dropped"
 	readTaskQueueOutcomeExpired   = "expired"
 )
 
@@ -302,9 +301,7 @@ func (s *scheduler) setupExecListener(lastWaitingTask queuedTask, now time.Time)
 	nq := int64(0)
 	if !lastWaitingTask.valid() {
 		// No task is waiting to send to execChan, schedule a new one from queue.
-		result := s.policy.Pop(now)
-		s.dropTasks(result.dropped, now)
-		lastWaitingTask = result.task
+		lastWaitingTask = s.policy.Pop(now)
 		if lastWaitingTask.valid() {
 			s.recordReadTaskQueueDuration(lastWaitingTask, now, readTaskQueueOutcomeScheduled)
 		}
@@ -326,14 +323,6 @@ func (s *scheduler) cleanupExpiredTasks(now time.Time) {
 		s.updateWaitingTaskCounter(-1, -task.NQ())
 		s.recordReadTaskQueueDuration(task, now, readTaskQueueOutcomeExpired)
 		task.Done(cleanupTaskError(task))
-	}
-}
-
-func (s *scheduler) dropTasks(tasks []queuedTask, now time.Time) {
-	for _, task := range tasks {
-		s.updateWaitingTaskCounter(-1, -task.NQ())
-		s.recordReadTaskQueueDuration(task, now, readTaskQueueOutcomeDropped)
-		task.Done(merr.WrapErrTooManyRequests(0, "dropped by query node read schedule policy"))
 	}
 }
 

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
@@ -7,12 +7,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
 
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
 	"github.com/milvus-io/milvus/pkg/v3/util/lifetime"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -133,7 +137,236 @@ func (s *SchedulerSuite) TestConsumeRecvChan() {
 			scheduler.consumeRecvChan(addTaskReq{
 				task: task,
 				err:  make(chan error, 1),
-			}, maxReceiveChanBatchConsumeNum)
+			}, maxReceiveChanBatchConsumeNum, time.Now())
 		})
 	})
+}
+
+func (s *SchedulerSuite) TestConsumeRecvChanUsesLoopTimestampForBatch() {
+	now := time.Now()
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		receiveChan:      make(chan addTaskReq, 1),
+		schedulerCounter: schedulerCounter{},
+	}
+
+	firstErrCh := make(chan error, 1)
+	secondErrCh := make(chan error, 1)
+	secondTask := newMockTask(mockTaskConfig{nq: 1})
+	scheduler.receiveChan <- addTaskReq{
+		task: secondTask,
+		err:  secondErrCh,
+	}
+
+	scheduler.consumeRecvChan(addTaskReq{
+		task: newMockTask(mockTaskConfig{nq: 1}),
+		err:  firstErrCh,
+	}, 2, now)
+
+	s.NoError(<-firstErrCh)
+	s.NoError(<-secondErrCh)
+
+	first := scheduler.policy.Pop(now).task
+	second := scheduler.policy.Pop(now).task
+	s.True(first.valid())
+	s.True(second.valid())
+	s.Equal(now, first.enqueueTime)
+	s.Equal(now, second.enqueueTime)
+}
+
+func (s *SchedulerSuite) TestHandleAddTaskRequestRejectsWhenWaitingQueueFull() {
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		schedulerCounter: schedulerCounter{},
+	}
+
+	errCh := make(chan error, 1)
+	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
+		task: newMockTask(mockTaskConfig{nq: 1}),
+		err:  errCh,
+	}, 1, time.Now())
+	s.False(keepConsuming)
+	s.NoError(<-errCh)
+	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
+
+	errCh = make(chan error, 1)
+	keepConsuming = scheduler.handleAddTaskRequest(addTaskReq{
+		task: newMockTask(mockTaskConfig{nq: 1}),
+		err:  errCh,
+	}, 1, time.Now())
+	s.False(keepConsuming)
+	s.ErrorIs(<-errCh, merr.ErrServiceTooManyRequests)
+	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
+}
+
+func (s *SchedulerSuite) TestHandleAddTaskRequestCleansExpiredTasksBeforeQueueLimit() {
+	now := time.Now()
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		schedulerCounter: schedulerCounter{},
+	}
+
+	expiredCtx, cancelExpired := context.WithDeadline(context.Background(), now.Add(-time.Millisecond))
+	defer cancelExpired()
+	expiredTask := newMockTask(mockTaskConfig{ctx: expiredCtx, nq: 1})
+	queued := newQueuedTask(expiredTask, now.Add(-time.Second))
+	added, err := scheduler.policy.Push(queued)
+	s.NoError(err)
+	scheduler.updateWaitingTaskCounter(int64(added), queued.NQ())
+
+	errCh := make(chan error, 1)
+	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
+		task: newMockTask(mockTaskConfig{nq: 1}),
+		err:  errCh,
+	}, 1, now)
+
+	s.False(keepConsuming)
+	s.NoError(<-errCh)
+	s.ErrorIs(expiredTask.Wait(), context.DeadlineExceeded)
+	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
+}
+
+func (s *SchedulerSuite) TestHandleAddTaskRequestCleansTasksNearDeadlineBeforeQueueLimit() {
+	paramtable.Init()
+	old := paramtable.Get().QueryNodeCfg.SchedulePolicyTaskDeadlineAdvance.SwapTempValue("50ms")
+	defer paramtable.Get().QueryNodeCfg.SchedulePolicyTaskDeadlineAdvance.SwapTempValue(old)
+
+	now := time.Now()
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		schedulerCounter: schedulerCounter{},
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), now.Add(30*time.Millisecond))
+	defer cancel()
+	nearDeadlineTask := newMockTask(mockTaskConfig{ctx: ctx, nq: 1})
+	queued := newQueuedTask(nearDeadlineTask, now.Add(-time.Second))
+	added, err := scheduler.policy.Push(queued)
+	s.NoError(err)
+	scheduler.updateWaitingTaskCounter(int64(added), queued.NQ())
+
+	errCh := make(chan error, 1)
+	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
+		task: newMockTask(mockTaskConfig{nq: 1}),
+		err:  errCh,
+	}, 1, now)
+
+	s.False(keepConsuming)
+	s.NoError(<-errCh)
+	s.ErrorIs(nearDeadlineTask.Wait(), context.DeadlineExceeded)
+	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
+}
+
+func (s *SchedulerSuite) TestAddReturnsContextErrorWhenReceiveBlocks() {
+	paramtable.Init()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		receiveChan:      make(chan addTaskReq),
+		schedulerCounter: schedulerCounter{},
+		lifetime:         lifetime.NewLifetime(lifetime.Working),
+	}
+
+	err := scheduler.Add(newMockTask(mockTaskConfig{ctx: ctx, nq: 1}))
+	s.ErrorIs(err, context.DeadlineExceeded)
+}
+
+func (s *SchedulerSuite) TestHandleAddTaskRequestDoesNotRejectByQueueDelayDeadline() {
+	now := time.Now()
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		schedulerCounter: schedulerCounter{},
+	}
+
+	queued := newQueuedTask(newMockTask(mockTaskConfig{nq: 1}), now.Add(-time.Second))
+	newTaskAdded, err := scheduler.policy.Push(queued)
+	s.NoError(err)
+	scheduler.updateWaitingTaskCounter(int64(newTaskAdded), queued.NQ())
+
+	ctx, cancel := context.WithDeadline(context.Background(), now.Add(100*time.Millisecond))
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
+		task: newMockTask(mockTaskConfig{ctx: ctx, nq: 1}),
+		err:  errCh,
+	}, 0, now)
+
+	s.True(keepConsuming)
+	s.NoError(<-errCh)
+	s.Equal(int64(2), scheduler.GetWaitingTaskTotal())
+}
+
+func (s *SchedulerSuite) TestHandleAddTaskRequestAcceptsDeadlineWhenQueueEmpty() {
+	now := time.Now()
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		schedulerCounter: schedulerCounter{},
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), now.Add(100*time.Millisecond))
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
+		task: newMockTask(mockTaskConfig{ctx: ctx, nq: 1}),
+		err:  errCh,
+	}, 0, now)
+
+	s.True(keepConsuming)
+	s.NoError(<-errCh)
+	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
+}
+
+func (s *SchedulerSuite) TestExecRecordsReadTaskExecuteDuration() {
+	paramtable.Init()
+	metrics.QueryNodeReadTaskExecuteDuration.Reset()
+	defer metrics.QueryNodeReadTaskExecuteDuration.Reset()
+
+	scheduler := newScheduler(newFIFOPolicy())
+	scheduler.Start()
+	defer scheduler.Stop()
+
+	successTask := newMockTask(mockTaskConfig{
+		executeCost: time.Millisecond,
+		execution: func(ctx context.Context) error {
+			return nil
+		},
+	})
+	s.NoError(scheduler.Add(successTask))
+	s.NoError(successTask.(*MockTask).Wait())
+
+	expectedErr := errors.New("mock execute failure")
+	failedTask := newMockTask(mockTaskConfig{
+		executeCost: time.Millisecond,
+		execution: func(ctx context.Context) error {
+			return expectedErr
+		},
+	})
+	s.NoError(scheduler.Add(failedTask))
+	s.ErrorIs(failedTask.(*MockTask).Wait(), expectedErr)
+
+	canceledTask := newMockTask(mockTaskConfig{
+		executeCost: time.Millisecond,
+		execution: func(ctx context.Context) error {
+			return context.DeadlineExceeded
+		},
+	})
+	s.NoError(scheduler.Add(canceledTask))
+	s.ErrorIs(canceledTask.(*MockTask).Wait(), context.DeadlineExceeded)
+
+	s.Equal(uint64(1), readTaskExecuteDurationCount(metrics.SuccessLabel))
+	s.Equal(uint64(1), readTaskExecuteDurationCount(metrics.FailLabel))
+	s.Equal(uint64(1), readTaskExecuteDurationCount(metrics.CancelLabel))
+}
+
+func readTaskExecuteDurationCount(outcome string) uint64 {
+	observer := metrics.QueryNodeReadTaskExecuteDuration.WithLabelValues(paramtable.GetStringNodeID(), outcome)
+	metric := &dto.Metric{}
+	if err := observer.(interface{ Write(*dto.Metric) error }).Write(metric); err != nil {
+		return 0
+	}
+	return metric.GetHistogram().GetSampleCount()
 }

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
@@ -364,7 +364,7 @@ func (s *SchedulerSuite) TestExecRecordsReadTaskExecuteDuration() {
 
 func (s *SchedulerSuite) TestQueuedTaskTimingHelpers() {
 	now := time.Now()
-	invalid := queuedTask{}
+	invalid := &queuedTask{}
 	s.Zero(invalid.queueDuration(now))
 	s.False(invalid.cleanupReady(now))
 
@@ -384,7 +384,7 @@ func (s *SchedulerSuite) TestRecordReadTaskQueueDurationSkipsInvalidTask() {
 	defer metrics.QueryNodeReadTaskQueueDuration.Reset()
 
 	scheduler := &scheduler{}
-	scheduler.recordReadTaskQueueDuration(queuedTask{}, time.Now(), readTaskQueueOutcomeScheduled)
+	scheduler.recordReadTaskQueueDuration(&queuedTask{}, time.Now(), readTaskQueueOutcomeScheduled)
 
 	observer := metrics.QueryNodeReadTaskQueueDuration.WithLabelValues(paramtable.GetStringNodeID(), readTaskQueueOutcomeScheduled)
 	metric := &dto.Metric{}

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
@@ -226,6 +226,33 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestCleansExpiredTasksBeforeQueueLi
 	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
 }
 
+func (s *SchedulerSuite) TestHandleAddTaskRequestSkipsCleanupBeforeQueueFull() {
+	now := time.Now()
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		schedulerCounter: schedulerCounter{},
+	}
+
+	expiredCtx, cancelExpired := context.WithDeadline(context.Background(), now.Add(-time.Millisecond))
+	defer cancelExpired()
+	expiredTask := newMockTask(mockTaskConfig{ctx: expiredCtx, nq: 1})
+	queued := newQueuedTask(expiredTask, now.Add(-time.Second))
+	added, err := scheduler.policy.Push(queued)
+	s.NoError(err)
+	scheduler.updateWaitingTaskCounter(int64(added), queued.NQ())
+
+	errCh := make(chan error, 1)
+	keepConsuming := scheduler.handleAddTaskRequest(addTaskReq{
+		task: newMockTask(mockTaskConfig{nq: 1}),
+		err:  errCh,
+	}, 2, now)
+
+	s.False(keepConsuming)
+	s.NoError(<-errCh)
+	s.Equal(int64(2), scheduler.GetWaitingTaskTotal())
+	s.Equal(0, len(expiredTask.(*MockTask).notifier))
+}
+
 func (s *SchedulerSuite) TestHandleAddTaskRequestCleansTasksNearDeadlineBeforeQueueLimit() {
 	paramtable.Init()
 	old := paramtable.Get().QueryNodeCfg.SchedulePolicyTaskDeadlineAdvance.SwapTempValue("50ms")
@@ -320,6 +347,37 @@ func (s *SchedulerSuite) TestHandleAddTaskRequestAcceptsDeadlineWhenQueueEmpty()
 	s.Equal(int64(1), scheduler.GetWaitingTaskTotal())
 }
 
+func (s *SchedulerSuite) TestSetupExecListenerRecordsPoppedExpiredTask() {
+	paramtable.Init()
+	metrics.QueryNodeReadTaskQueueDuration.Reset()
+	defer metrics.QueryNodeReadTaskQueueDuration.Reset()
+
+	now := time.Now()
+	scheduler := &scheduler{
+		policy:           newFIFOPolicy(),
+		execChan:         make(chan Task),
+		schedulerCounter: schedulerCounter{},
+	}
+
+	expiredCtx, cancelExpired := context.WithDeadline(context.Background(), now.Add(-time.Millisecond))
+	defer cancelExpired()
+	expiredTask := newMockTask(mockTaskConfig{ctx: expiredCtx, nq: 1})
+	queued := newQueuedTask(expiredTask, now.Add(-time.Second))
+	added, err := scheduler.policy.Push(queued)
+	s.NoError(err)
+	scheduler.updateWaitingTaskCounter(int64(added), queued.NQ())
+
+	task, nq, execChan := scheduler.setupExecListener(nil, now)
+
+	s.False(task.valid())
+	s.Zero(nq)
+	s.Nil(execChan)
+	s.Equal(int64(0), scheduler.GetWaitingTaskTotal())
+	s.ErrorIs(expiredTask.Wait(), context.DeadlineExceeded)
+	s.Equal(uint64(1), readTaskQueueDurationCount(readTaskQueueOutcomeExpired))
+	s.Equal(uint64(0), readTaskQueueDurationCount(readTaskQueueOutcomeScheduled))
+}
+
 func (s *SchedulerSuite) TestExecRecordsReadTaskExecuteDuration() {
 	paramtable.Init()
 	metrics.QueryNodeReadTaskExecuteDuration.Reset()
@@ -394,6 +452,15 @@ func (s *SchedulerSuite) TestRecordReadTaskQueueDurationSkipsInvalidTask() {
 
 func readTaskExecuteDurationCount(outcome string) uint64 {
 	observer := metrics.QueryNodeReadTaskExecuteDuration.WithLabelValues(paramtable.GetStringNodeID(), outcome)
+	metric := &dto.Metric{}
+	if err := observer.(interface{ Write(*dto.Metric) error }).Write(metric); err != nil {
+		return 0
+	}
+	return metric.GetHistogram().GetSampleCount()
+}
+
+func readTaskQueueDurationCount(outcome string) uint64 {
+	observer := metrics.QueryNodeReadTaskQueueDuration.WithLabelValues(paramtable.GetStringNodeID(), outcome)
 	metric := &dto.Metric{}
 	if err := observer.(interface{ Write(*dto.Metric) error }).Write(metric); err != nil {
 		return 0

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
@@ -166,8 +166,8 @@ func (s *SchedulerSuite) TestConsumeRecvChanUsesLoopTimestampForBatch() {
 	s.NoError(<-firstErrCh)
 	s.NoError(<-secondErrCh)
 
-	first := scheduler.policy.Pop(now).task
-	second := scheduler.policy.Pop(now).task
+	first := scheduler.policy.Pop(now)
+	second := scheduler.policy.Pop(now)
 	s.True(first.valid())
 	s.True(second.valid())
 	s.Equal(now, first.enqueueTime)

--- a/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
+++ b/internal/util/searchutil/scheduler/concurrent_safe_scheduler_test.go
@@ -362,6 +362,36 @@ func (s *SchedulerSuite) TestExecRecordsReadTaskExecuteDuration() {
 	s.Equal(uint64(1), readTaskExecuteDurationCount(metrics.CancelLabel))
 }
 
+func (s *SchedulerSuite) TestQueuedTaskTimingHelpers() {
+	now := time.Now()
+	invalid := queuedTask{}
+	s.Zero(invalid.queueDuration(now))
+	s.False(invalid.cleanupReady(now))
+
+	taskWithoutEnqueueTime := newQueuedTask(newMockTask(mockTaskConfig{nq: 1}), time.Time{})
+	s.Zero(taskWithoutEnqueueTime.queueDuration(now))
+	s.False(taskWithoutEnqueueTime.cleanupReady(now))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	canceledTask := newQueuedTask(newMockTask(mockTaskConfig{ctx: ctx, nq: 1}), now.Add(-time.Millisecond))
+	s.True(canceledTask.cleanupReady(now))
+}
+
+func (s *SchedulerSuite) TestRecordReadTaskQueueDurationSkipsInvalidTask() {
+	paramtable.Init()
+	metrics.QueryNodeReadTaskQueueDuration.Reset()
+	defer metrics.QueryNodeReadTaskQueueDuration.Reset()
+
+	scheduler := &scheduler{}
+	scheduler.recordReadTaskQueueDuration(queuedTask{}, time.Now(), readTaskQueueOutcomeScheduled)
+
+	observer := metrics.QueryNodeReadTaskQueueDuration.WithLabelValues(paramtable.GetStringNodeID(), readTaskQueueOutcomeScheduled)
+	metric := &dto.Metric{}
+	s.NoError(observer.(interface{ Write(*dto.Metric) error }).Write(metric))
+	s.Equal(uint64(0), metric.GetHistogram().GetSampleCount())
+}
+
 func readTaskExecuteDurationCount(outcome string) uint64 {
 	observer := metrics.QueryNodeReadTaskExecuteDuration.WithLabelValues(paramtable.GetStringNodeID(), outcome)
 	metric := &dto.Metric{}

--- a/internal/util/searchutil/scheduler/fifo_policy.go
+++ b/internal/util/searchutil/scheduler/fifo_policy.go
@@ -43,8 +43,8 @@ func (p *fifoPolicy) Push(task queuedTask) (int, error) {
 }
 
 // Pop get the task next ready to run.
-func (p *fifoPolicy) Pop(now time.Time) popResult {
-	return popResult{task: p.queue.pop()}
+func (p *fifoPolicy) Pop(now time.Time) queuedTask {
+	return p.queue.pop()
 }
 
 // Len get ready task counts.

--- a/internal/util/searchutil/scheduler/fifo_policy.go
+++ b/internal/util/searchutil/scheduler/fifo_policy.go
@@ -1,6 +1,8 @@
 package scheduler
 
 import (
+	"time"
+
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -18,14 +20,19 @@ type fifoPolicy struct {
 	queue *mergeTaskQueue
 }
 
+func (p *fifoPolicy) Cleanup(now time.Time) []queuedTask {
+	return p.queue.cleanup(now)
+}
+
 // Push add a new task into scheduler, an error will be returned if scheduler reaches some limit.
-func (p *fifoPolicy) Push(task Task) (int, error) {
+func (p *fifoPolicy) Push(task queuedTask) (int, error) {
 	pt := paramtable.Get()
 
 	// Try to merge task if task can merge.
-	if t := tryIntoMergeTask(task); t != nil {
+	if t := tryIntoMergeTask(task.Task); t != nil {
 		maxNQ := pt.QueryNodeCfg.MaxGroupNQ.GetAsInt64()
-		if p.queue.tryMerge(t, maxNQ) {
+		nqMergeRatio := pt.QueryNodeCfg.NQMergeRatio.GetAsFloat()
+		if p.queue.tryMerge(task, maxNQ, nqMergeRatio) {
 			return 0, nil
 		}
 	}
@@ -36,10 +43,8 @@ func (p *fifoPolicy) Push(task Task) (int, error) {
 }
 
 // Pop get the task next ready to run.
-func (p *fifoPolicy) Pop() Task {
-	task := p.queue.front()
-	p.queue.pop()
-	return task
+func (p *fifoPolicy) Pop(now time.Time) popResult {
+	return popResult{task: p.queue.pop()}
 }
 
 // Len get ready task counts.

--- a/internal/util/searchutil/scheduler/fifo_policy.go
+++ b/internal/util/searchutil/scheduler/fifo_policy.go
@@ -20,12 +20,12 @@ type fifoPolicy struct {
 	queue *mergeTaskQueue
 }
 
-func (p *fifoPolicy) Cleanup(now time.Time) []queuedTask {
+func (p *fifoPolicy) Cleanup(now time.Time) []*queuedTask {
 	return p.queue.cleanup(now)
 }
 
 // Push add a new task into scheduler, an error will be returned if scheduler reaches some limit.
-func (p *fifoPolicy) Push(task queuedTask) (int, error) {
+func (p *fifoPolicy) Push(task *queuedTask) (int, error) {
 	pt := paramtable.Get()
 
 	// Try to merge task if task can merge.
@@ -43,7 +43,7 @@ func (p *fifoPolicy) Push(task queuedTask) (int, error) {
 }
 
 // Pop get the task next ready to run.
-func (p *fifoPolicy) Pop(now time.Time) queuedTask {
+func (p *fifoPolicy) Pop(now time.Time) *queuedTask {
 	return p.queue.pop()
 }
 

--- a/internal/util/searchutil/scheduler/fifo_policy.go
+++ b/internal/util/searchutil/scheduler/fifo_policy.go
@@ -32,7 +32,8 @@ func (p *fifoPolicy) Push(task *queuedTask) (int, error) {
 	if t := tryIntoMergeTask(task.Task); t != nil {
 		maxNQ := pt.QueryNodeCfg.MaxGroupNQ.GetAsInt64()
 		nqMergeRatio := pt.QueryNodeCfg.NQMergeRatio.GetAsFloat()
-		if p.queue.tryMerge(task, maxNQ, nqMergeRatio) {
+		maxDeadlineMergeGap := pt.QueryNodeCfg.MaxDeadlineMergeGap.GetAsDurationByParse()
+		if p.queue.tryMerge(task, maxNQ, nqMergeRatio, maxDeadlineMergeGap) {
 			return 0, nil
 		}
 	}

--- a/internal/util/searchutil/scheduler/mock_task_test.go
+++ b/internal/util/searchutil/scheduler/mock_task_test.go
@@ -39,6 +39,7 @@ func newMockTask(c mockTaskConfig) Task {
 		notifier:    make(chan error, 1),
 		mergeAble:   c.mergeAble,
 		nq:          c.nq,
+		minNQ:       c.nq,
 		username:    c.username,
 		execution:   c.execution,
 		tr:          timerecord.NewTimeRecorderWithTrace(c.ctx, "searchTask"),
@@ -51,6 +52,7 @@ type MockTask struct {
 	notifier    chan error
 	mergeAble   bool
 	nq          int64
+	minNQ       int64
 	username    string
 	execution   func(ctx context.Context) error
 	tr          *timerecord.TimeRecorder
@@ -90,10 +92,6 @@ func (t *MockTask) Done(err error) {
 	t.notifier <- err
 }
 
-func (t *MockTask) Canceled() error {
-	return t.ctx.Err()
-}
-
 func (t *MockTask) Wait() error {
 	return <-t.notifier
 }
@@ -108,6 +106,9 @@ func (t *MockTask) MergeWith(t2 Task) bool {
 	case *MockTask:
 		if t.mergeAble && t2.mergeAble {
 			t.nq += t2.nq
+			if t2.MinNQ() < t.minNQ {
+				t.minNQ = t2.MinNQ()
+			}
 			t.executeCost += t2.executeCost
 			return true
 		}
@@ -121,4 +122,8 @@ func (t *MockTask) SearchResult() *internalpb.SearchResults {
 
 func (t *MockTask) NQ() int64 {
 	return t.nq
+}
+
+func (t *MockTask) MinNQ() int64 {
+	return t.minNQ
 }

--- a/internal/util/searchutil/scheduler/policy_test.go
+++ b/internal/util/searchutil/scheduler/policy_test.go
@@ -1,8 +1,10 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -20,6 +22,54 @@ func TestFIFOPolicy(t *testing.T) {
 	testCommonPolicyOperation(t, newFIFOPolicy())
 }
 
+func TestPolicyCleanupExpiredTasks(t *testing.T) {
+	paramtable.Init()
+	for name, policy := range map[string]schedulePolicy{
+		"fifo":              newFIFOPolicy(),
+		"user-task-polling": newUserTaskPollingPolicy(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			base := time.Now()
+			ctx, cancel := context.WithDeadline(context.Background(), base.Add(10*time.Millisecond))
+			defer cancel()
+
+			added, err := policy.Push(newQueuedTask(newMockTask(mockTaskConfig{ctx: ctx, nq: 1}), base))
+			assert.NoError(t, err)
+			assert.Equal(t, 1, added)
+			assert.Equal(t, 1, policy.Len())
+
+			expired := policy.Cleanup(base.Add(20 * time.Millisecond))
+			assert.Len(t, expired, 1)
+			assert.Equal(t, 0, policy.Len())
+			assert.False(t, policy.Pop(base.Add(20*time.Millisecond)).task.valid())
+		})
+	}
+}
+
+func TestPolicyCleanupCanceledTasks(t *testing.T) {
+	paramtable.Init()
+	for name, policy := range map[string]schedulePolicy{
+		"fifo":              newFIFOPolicy(),
+		"user-task-polling": newUserTaskPollingPolicy(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			base := time.Now()
+			ctx, cancel := context.WithCancel(context.Background())
+
+			added, err := policy.Push(newQueuedTask(newMockTask(mockTaskConfig{ctx: ctx, nq: 1}), base))
+			assert.NoError(t, err)
+			assert.Equal(t, 1, added)
+
+			cancel()
+			removed := policy.Cleanup(base)
+
+			assert.Len(t, removed, 1)
+			assert.Equal(t, 0, policy.Len())
+			assert.False(t, policy.Pop(base).task.valid())
+		})
+	}
+}
+
 func testCrossUserMerge(t *testing.T, policy schedulePolicy) {
 	userN := 10
 	maxNQ := paramtable.Get().QueryNodeCfg.MaxGroupNQ.GetAsInt64()
@@ -32,17 +82,20 @@ func testCrossUserMerge(t *testing.T, policy schedulePolicy) {
 			nq:        maxNQ / 2,
 			mergeAble: true,
 		})
-		policy.Push(task)
+		policy.Push(newQueuedTask(task, time.Now()))
 	}
 	nAfterMerge := n / 2
 	assert.Equal(t, nAfterMerge, policy.Len())
 	for i := 1; i <= nAfterMerge; i++ {
-		assert.NotNil(t, policy.Pop())
+		assert.True(t, policy.Pop(time.Now()).task.valid())
 		assert.Equal(t, nAfterMerge-i, policy.Len())
 	}
 
 	// Open cross user grouping
-	paramtable.Get().QueryNodeCfg.SchedulePolicyEnableCrossUserGrouping.SwapTempValue("true")
+	oldGrouping := paramtable.Get().QueryNodeCfg.SchedulePolicyEnableCrossUserGrouping.SwapTempValue("true")
+	defer paramtable.Get().QueryNodeCfg.SchedulePolicyEnableCrossUserGrouping.SwapTempValue(oldGrouping)
+	oldNQMergeRatio := paramtable.Get().QueryNodeCfg.NQMergeRatio.SwapTempValue("0")
+	defer paramtable.Get().QueryNodeCfg.NQMergeRatio.SwapTempValue(oldNQMergeRatio)
 	for i := 1; i <= n; i++ {
 		username := fmt.Sprintf("user_%d", (i-1)%userN)
 		task := newMockTask(mockTaskConfig{
@@ -50,12 +103,12 @@ func testCrossUserMerge(t *testing.T, policy schedulePolicy) {
 			nq:        maxNQ / 4,
 			mergeAble: true,
 		})
-		policy.Push(task)
+		policy.Push(newQueuedTask(task, time.Now()))
 	}
 	nAfterMerge = n / 4
 	assert.Equal(t, nAfterMerge, policy.Len())
 	for i := 1; i <= nAfterMerge; i++ {
-		assert.NotNil(t, policy.Pop())
+		assert.True(t, policy.Pop(time.Now()).task.valid())
 		assert.Equal(t, nAfterMerge-i, policy.Len())
 	}
 }
@@ -64,7 +117,7 @@ func testCrossUserMerge(t *testing.T, policy schedulePolicy) {
 func testCommonPolicyOperation(t *testing.T, policy schedulePolicy) {
 	// Empty policy assertion.
 	assert.Equal(t, 0, policy.Len())
-	assert.Nil(t, policy.Pop())
+	assert.False(t, policy.Pop(time.Now()).task.valid())
 	assert.Equal(t, 0, policy.Len())
 
 	// Test no merge push pop.
@@ -76,12 +129,12 @@ func testCommonPolicyOperation(t *testing.T, policy schedulePolicy) {
 		task := newMockTask(mockTaskConfig{
 			username: username,
 		})
-		policy.Push(task)
+		policy.Push(newQueuedTask(task, time.Now()))
 		assert.Equal(t, i, policy.Len())
 	}
 	// Test Pop
 	for i := 1; i <= n; i++ {
-		assert.NotNil(t, policy.Pop())
+		assert.True(t, policy.Pop(time.Now()).task.valid())
 		assert.Equal(t, n-i, policy.Len())
 	}
 
@@ -95,11 +148,11 @@ func testCommonPolicyOperation(t *testing.T, policy schedulePolicy) {
 			nq:        maxNQ,
 			mergeAble: true,
 		})
-		policy.Push(task)
+		policy.Push(newQueuedTask(task, time.Now()))
 	}
 	assert.Equal(t, n, policy.Len())
 	for i := 1; i <= n; i++ {
-		assert.NotNil(t, policy.Pop())
+		assert.True(t, policy.Pop(time.Now()).task.valid())
 		assert.Equal(t, n-i, policy.Len())
 	}
 
@@ -112,12 +165,12 @@ func testCommonPolicyOperation(t *testing.T, policy schedulePolicy) {
 			nq:        maxNQ / 2,
 			mergeAble: true,
 		})
-		policy.Push(task)
+		policy.Push(newQueuedTask(task, time.Now()))
 	}
 	nAfterMerge := n / 2
 	assert.Equal(t, nAfterMerge, policy.Len())
 	for i := 1; i <= nAfterMerge; i++ {
-		assert.NotNil(t, policy.Pop())
+		assert.True(t, policy.Pop(time.Now()).task.valid())
 		assert.Equal(t, nAfterMerge-i, policy.Len())
 	}
 }

--- a/internal/util/searchutil/scheduler/policy_test.go
+++ b/internal/util/searchutil/scheduler/policy_test.go
@@ -41,7 +41,7 @@ func TestPolicyCleanupExpiredTasks(t *testing.T) {
 			expired := policy.Cleanup(base.Add(20 * time.Millisecond))
 			assert.Len(t, expired, 1)
 			assert.Equal(t, 0, policy.Len())
-			assert.False(t, policy.Pop(base.Add(20*time.Millisecond)).task.valid())
+			assert.False(t, policy.Pop(base.Add(20*time.Millisecond)).valid())
 		})
 	}
 }
@@ -65,7 +65,7 @@ func TestPolicyCleanupCanceledTasks(t *testing.T) {
 
 			assert.Len(t, removed, 1)
 			assert.Equal(t, 0, policy.Len())
-			assert.False(t, policy.Pop(base).task.valid())
+			assert.False(t, policy.Pop(base).valid())
 		})
 	}
 }
@@ -87,7 +87,7 @@ func testCrossUserMerge(t *testing.T, policy schedulePolicy) {
 	nAfterMerge := n / 2
 	assert.Equal(t, nAfterMerge, policy.Len())
 	for i := 1; i <= nAfterMerge; i++ {
-		assert.True(t, policy.Pop(time.Now()).task.valid())
+		assert.True(t, policy.Pop(time.Now()).valid())
 		assert.Equal(t, nAfterMerge-i, policy.Len())
 	}
 
@@ -108,7 +108,7 @@ func testCrossUserMerge(t *testing.T, policy schedulePolicy) {
 	nAfterMerge = n / 4
 	assert.Equal(t, nAfterMerge, policy.Len())
 	for i := 1; i <= nAfterMerge; i++ {
-		assert.True(t, policy.Pop(time.Now()).task.valid())
+		assert.True(t, policy.Pop(time.Now()).valid())
 		assert.Equal(t, nAfterMerge-i, policy.Len())
 	}
 }
@@ -117,7 +117,7 @@ func testCrossUserMerge(t *testing.T, policy schedulePolicy) {
 func testCommonPolicyOperation(t *testing.T, policy schedulePolicy) {
 	// Empty policy assertion.
 	assert.Equal(t, 0, policy.Len())
-	assert.False(t, policy.Pop(time.Now()).task.valid())
+	assert.False(t, policy.Pop(time.Now()).valid())
 	assert.Equal(t, 0, policy.Len())
 
 	// Test no merge push pop.
@@ -134,7 +134,7 @@ func testCommonPolicyOperation(t *testing.T, policy schedulePolicy) {
 	}
 	// Test Pop
 	for i := 1; i <= n; i++ {
-		assert.True(t, policy.Pop(time.Now()).task.valid())
+		assert.True(t, policy.Pop(time.Now()).valid())
 		assert.Equal(t, n-i, policy.Len())
 	}
 
@@ -152,7 +152,7 @@ func testCommonPolicyOperation(t *testing.T, policy schedulePolicy) {
 	}
 	assert.Equal(t, n, policy.Len())
 	for i := 1; i <= n; i++ {
-		assert.True(t, policy.Pop(time.Now()).task.valid())
+		assert.True(t, policy.Pop(time.Now()).valid())
 		assert.Equal(t, n-i, policy.Len())
 	}
 
@@ -170,7 +170,7 @@ func testCommonPolicyOperation(t *testing.T, policy schedulePolicy) {
 	nAfterMerge := n / 2
 	assert.Equal(t, nAfterMerge, policy.Len())
 	for i := 1; i <= nAfterMerge; i++ {
-		assert.True(t, policy.Pop(time.Now()).task.valid())
+		assert.True(t, policy.Pop(time.Now()).valid())
 		assert.Equal(t, nAfterMerge-i, policy.Len())
 	}
 }

--- a/internal/util/searchutil/scheduler/queues.go
+++ b/internal/util/searchutil/scheduler/queues.go
@@ -8,14 +8,14 @@ import (
 func newMergeTaskQueue(group string) *mergeTaskQueue {
 	return &mergeTaskQueue{
 		name:             group,
-		tasks:            make([]Task, 0),
+		tasks:            make([]queuedTask, 0),
 		cleanupTimestamp: time.Now(),
 	}
 }
 
 type mergeTaskQueue struct {
 	name             string
-	tasks            []Task
+	tasks            []queuedTask
 	cleanupTimestamp time.Time
 }
 
@@ -25,27 +25,65 @@ func (q *mergeTaskQueue) len() int {
 }
 
 // push add a new task to the end of taskQueue.
-func (q *mergeTaskQueue) push(t Task) {
+func (q *mergeTaskQueue) push(t queuedTask) {
 	q.tasks = append(q.tasks, t)
 }
 
-// front returns the first element of taskQueue,
-// returns nil if task queue is empty.
-func (q *mergeTaskQueue) front() Task {
+// front returns the first element of taskQueue.
+func (q *mergeTaskQueue) front() queuedTask {
 	if q.len() > 0 {
 		return q.tasks[0]
 	}
-	return nil
+	return queuedTask{}
 }
 
-// pop pops the first element of taskQueue,
-func (q *mergeTaskQueue) pop() {
+// pop pops the first element of taskQueue.
+func (q *mergeTaskQueue) pop() queuedTask {
 	if q.len() > 0 {
+		task := q.tasks[0]
+		q.tasks[0] = queuedTask{}
 		q.tasks = q.tasks[1:]
 		if q.len() == 0 {
 			q.cleanupTimestamp = time.Now()
 		}
+		return task
 	}
+	return queuedTask{}
+}
+
+func (q *mergeTaskQueue) cleanup(now time.Time) []queuedTask {
+	if q.len() == 0 {
+		return nil
+	}
+
+	firstRemoved := -1
+	for i, task := range q.tasks {
+		if task.cleanupReady(now) {
+			firstRemoved = i
+			break
+		}
+	}
+	if firstRemoved < 0 {
+		return nil
+	}
+
+	removed := []queuedTask{q.tasks[firstRemoved]}
+	write := firstRemoved
+	for read := firstRemoved + 1; read < len(q.tasks); read++ {
+		task := q.tasks[read]
+		if task.cleanupReady(now) {
+			removed = append(removed, task)
+		} else {
+			q.tasks[write] = task
+			write++
+		}
+	}
+	clear(q.tasks[write:])
+	q.tasks = q.tasks[:write]
+	if q.len() == 0 {
+		q.cleanupTimestamp = now
+	}
+	return removed
 }
 
 // Return true if user based task is empty and empty for d time.
@@ -59,17 +97,35 @@ func (q *mergeTaskQueue) expire(d time.Duration) bool {
 	return false
 }
 
+func canMergeNQ(task MergeTask, other MergeTask, maxNQ int64, nqMergeRatio float64) bool {
+	totalNQ := task.NQ() + other.NQ()
+	if totalNQ > maxNQ {
+		return false
+	}
+	if nqMergeRatio <= 0 {
+		return true
+	}
+	minNQ := task.MinNQ()
+	if otherMinNQ := other.MinNQ(); otherMinNQ < minNQ {
+		minNQ = otherMinNQ
+	}
+	return minNQ > 0 && float64(totalNQ)/float64(minNQ) <= nqMergeRatio
+}
+
 // tryMerge try to a new task to any task in queue.
-func (q *mergeTaskQueue) tryMerge(task MergeTask, maxNQ int64) bool {
-	nqRest := maxNQ - task.NQ()
+func (q *mergeTaskQueue) tryMerge(task queuedTask, maxNQ int64, nqMergeRatio float64) bool {
+	mergeTask := tryIntoMergeTask(task.Task)
+	if mergeTask == nil {
+		return false
+	}
 	// No need to perform any merge if task.nq is greater than maxNQ.
-	if nqRest <= 0 {
+	if mergeTask.NQ() >= maxNQ {
 		return false
 	}
 	for i := q.len() - 1; i >= 0; i-- {
-		if taskInQueue := tryIntoMergeTask(q.tasks[i]); taskInQueue != nil {
+		if taskInQueue := tryIntoMergeTask(q.tasks[i].Task); taskInQueue != nil {
 			// Try to merge it if limit of nq is enough.
-			if taskInQueue.NQ() <= nqRest && taskInQueue.MergeWith(task) {
+			if canMergeNQ(taskInQueue, mergeTask, maxNQ, nqMergeRatio) && taskInQueue.MergeWith(mergeTask) {
 				return true
 			}
 		}
@@ -107,7 +163,7 @@ func (q *fairPollingTaskQueue) groupLen(group string) int {
 }
 
 // tryMergeWithOtherGroup try to merge given task into exists tasks in the other group.
-func (q *fairPollingTaskQueue) tryMergeWithOtherGroup(group string, task MergeTask, maxNQ int64) bool {
+func (q *fairPollingTaskQueue) tryMergeWithOtherGroup(group string, task queuedTask, maxNQ int64, nqMergeRatio float64) bool {
 	if q.count == 0 {
 		return false
 	}
@@ -120,7 +176,7 @@ func (q *fairPollingTaskQueue) tryMergeWithOtherGroup(group string, task MergeTa
 		if queue.len() == 0 || queue.name == group {
 			continue
 		}
-		if queue.tryMerge(task, maxNQ) {
+		if queue.tryMerge(task, maxNQ, nqMergeRatio) {
 			return true
 		}
 		node = prev
@@ -129,14 +185,14 @@ func (q *fairPollingTaskQueue) tryMergeWithOtherGroup(group string, task MergeTa
 }
 
 // tryMergeWithSameGroup try to merge given task into exists tasks in the same group.
-func (q *fairPollingTaskQueue) tryMergeWithSameGroup(group string, task MergeTask, maxNQ int64) bool {
+func (q *fairPollingTaskQueue) tryMergeWithSameGroup(group string, task queuedTask, maxNQ int64, nqMergeRatio float64) bool {
 	if q.count == 0 {
 		return false
 	}
 	// Applied to task with same group first.
 	if r, ok := q.route[group]; ok {
 		// Try to merge task into queue.
-		if r.Value.(*mergeTaskQueue).tryMerge(task, maxNQ) {
+		if r.Value.(*mergeTaskQueue).tryMerge(task, maxNQ, nqMergeRatio) {
 			return true
 		}
 	}
@@ -144,7 +200,7 @@ func (q *fairPollingTaskQueue) tryMergeWithSameGroup(group string, task MergeTas
 }
 
 // push add a new task into queue, try merge first.
-func (q *fairPollingTaskQueue) push(group string, task Task) {
+func (q *fairPollingTaskQueue) push(group string, task queuedTask) {
 	// Add a new task.
 	if r, ok := q.route[group]; ok {
 		// Add new task to the back of queue if queue exist.
@@ -167,11 +223,30 @@ func (q *fairPollingTaskQueue) push(group string, task Task) {
 	q.count++
 }
 
+func (q *fairPollingTaskQueue) cleanup(now time.Time) []queuedTask {
+	if q.count == 0 || q.checkpoint == nil {
+		return nil
+	}
+	removed := make([]queuedTask, 0)
+	checkpoint := q.checkpoint
+	queuesLen := q.checkpoint.Len()
+	for i := 0; i < queuesLen; i++ {
+		queue := checkpoint.Value.(*mergeTaskQueue)
+		tasks := queue.cleanup(now)
+		if len(tasks) > 0 {
+			q.count -= len(tasks)
+			removed = append(removed, tasks...)
+		}
+		checkpoint = checkpoint.Next()
+	}
+	return removed
+}
+
 // pop pop next ready task.
-func (q *fairPollingTaskQueue) pop(queueExpire time.Duration) (task Task) {
+func (q *fairPollingTaskQueue) pop(queueExpire time.Duration) queuedTask {
 	// Return directly if there's no task exists.
 	if q.count == 0 {
-		return
+		return queuedTask{}
 	}
 	checkpoint := q.checkpoint
 	queuesLen := q.checkpoint.Len()
@@ -196,14 +271,20 @@ func (q *fairPollingTaskQueue) pop(queueExpire time.Duration) (task Task) {
 			checkpoint = next
 			continue
 		}
-		task = queue.front()
-		queue.pop()
-		q.count--
+		task := queue.pop()
+		if task.valid() {
+			q.count--
+		}
+		if !task.valid() {
+			checkpoint = next
+			continue
+		}
 		checkpoint = next
-		break
+		q.checkpoint = checkpoint
+		return task
 	}
 
 	// Update checkpoint.
 	q.checkpoint = checkpoint
-	return
+	return queuedTask{}
 }

--- a/internal/util/searchutil/scheduler/queues.go
+++ b/internal/util/searchutil/scheduler/queues.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"container/heap"
 	"container/ring"
 	"time"
 )
@@ -8,82 +9,129 @@ import (
 func newMergeTaskQueue(group string) *mergeTaskQueue {
 	return &mergeTaskQueue{
 		name:             group,
-		tasks:            make([]queuedTask, 0),
+		tasks:            make([]*queuedTask, 0),
 		cleanupTimestamp: time.Now(),
 	}
 }
 
 type mergeTaskQueue struct {
 	name             string
-	tasks            []queuedTask
+	tasks            []*queuedTask
+	deadlineTasks    deadlineTaskHeap
+	count            int
 	cleanupTimestamp time.Time
 }
 
 // len returns the length of taskQueue.
 func (q *mergeTaskQueue) len() int {
-	return len(q.tasks)
+	return q.count
 }
 
 // push add a new task to the end of taskQueue.
-func (q *mergeTaskQueue) push(t queuedTask) {
-	q.tasks = append(q.tasks, t)
+func (q *mergeTaskQueue) push(task *queuedTask) {
+	q.tasks = append(q.tasks, task)
+	q.count++
+	if !task.deadline.IsZero() {
+		heap.Push(&q.deadlineTasks, task)
+	}
 }
 
 // front returns the first element of taskQueue.
-func (q *mergeTaskQueue) front() queuedTask {
-	if q.len() > 0 {
+func (q *mergeTaskQueue) front() *queuedTask {
+	q.dropRemovedPrefix()
+	if len(q.tasks) > 0 {
 		return q.tasks[0]
 	}
-	return queuedTask{}
+	return nil
 }
 
 // pop pops the first element of taskQueue.
-func (q *mergeTaskQueue) pop() queuedTask {
-	if q.len() > 0 {
-		task := q.tasks[0]
-		q.tasks[0] = queuedTask{}
-		q.tasks = q.tasks[1:]
-		if q.len() == 0 {
-			q.cleanupTimestamp = time.Now()
+func (q *mergeTaskQueue) pop() *queuedTask {
+	for {
+		q.dropRemovedPrefix()
+		if len(q.tasks) == 0 {
+			return nil
 		}
-		return task
+
+		task := q.tasks[0]
+		q.tasks = q.tasks[1:]
+		if !task.valid() {
+			continue
+		}
+
+		if task.deadlineIndex >= 0 {
+			heap.Remove(&q.deadlineTasks, task.deadlineIndex)
+		}
+		removed := q.markRemoved(task, time.Now())
+		if q.len() == 0 {
+			clear(q.tasks)
+			q.tasks = nil
+		}
+		return removed
 	}
-	return queuedTask{}
 }
 
-func (q *mergeTaskQueue) cleanup(now time.Time) []queuedTask {
+func (q *mergeTaskQueue) cleanup(now time.Time) []*queuedTask {
 	if q.len() == 0 {
 		return nil
 	}
 
-	firstRemoved := -1
-	for i, task := range q.tasks {
-		if task.cleanupReady(now) {
-			firstRemoved = i
+	removed := make([]*queuedTask, 0)
+	for q.deadlineTasks.Len() > 0 {
+		task := q.deadlineTasks[0]
+		if !task.valid() {
+			heap.Pop(&q.deadlineTasks)
+			continue
+		}
+		if !task.cleanupReady(now) {
 			break
 		}
-	}
-	if firstRemoved < 0 {
-		return nil
+		heap.Pop(&q.deadlineTasks)
+		removed = append(removed, q.markRemoved(task, now))
 	}
 
-	removed := []queuedTask{q.tasks[firstRemoved]}
-	write := firstRemoved
-	for read := firstRemoved + 1; read < len(q.tasks); read++ {
-		task := q.tasks[read]
-		if task.cleanupReady(now) {
-			removed = append(removed, task)
-		} else {
-			q.tasks[write] = task
-			write++
+	for _, task := range q.tasks {
+		if !task.valid() {
+			continue
 		}
+		if task.Context().Err() == nil {
+			continue
+		}
+		if task.deadlineIndex >= 0 {
+			heap.Remove(&q.deadlineTasks, task.deadlineIndex)
+		}
+		removed = append(removed, q.markRemoved(task, now))
 	}
-	clear(q.tasks[write:])
-	q.tasks = q.tasks[:write]
+
 	if q.len() == 0 {
-		q.cleanupTimestamp = now
+		clear(q.tasks)
+		q.tasks = nil
 	}
 	return removed
+}
+
+func (q *mergeTaskQueue) markRemoved(task *queuedTask, now time.Time) *queuedTask {
+	if !task.valid() {
+		return nil
+	}
+	removed := *task
+	task.Task = nil
+	q.count--
+	if q.count == 0 {
+		q.cleanupTimestamp = now
+	}
+	return &removed
+}
+
+func (q *mergeTaskQueue) dropRemovedPrefix() {
+	for len(q.tasks) > 0 {
+		task := q.tasks[0]
+		if task.valid() {
+			return
+		}
+		q.tasks[0] = nil
+		q.tasks = q.tasks[1:]
+	}
 }
 
 // Return true if user based task is empty and empty for d time.
@@ -113,7 +161,7 @@ func canMergeNQ(task MergeTask, other MergeTask, maxNQ int64, nqMergeRatio float
 }
 
 // tryMerge try to a new task to any task in queue.
-func (q *mergeTaskQueue) tryMerge(task queuedTask, maxNQ int64, nqMergeRatio float64) bool {
+func (q *mergeTaskQueue) tryMerge(task *queuedTask, maxNQ int64, nqMergeRatio float64) bool {
 	mergeTask := tryIntoMergeTask(task.Task)
 	if mergeTask == nil {
 		return false
@@ -122,8 +170,12 @@ func (q *mergeTaskQueue) tryMerge(task queuedTask, maxNQ int64, nqMergeRatio flo
 	if mergeTask.NQ() >= maxNQ {
 		return false
 	}
-	for i := q.len() - 1; i >= 0; i-- {
-		if taskInQueue := tryIntoMergeTask(q.tasks[i].Task); taskInQueue != nil {
+	for i := len(q.tasks) - 1; i >= 0; i-- {
+		taskInQueue := q.tasks[i]
+		if !taskInQueue.valid() {
+			continue
+		}
+		if taskInQueue := tryIntoMergeTask(taskInQueue.Task); taskInQueue != nil {
 			// Try to merge it if limit of nq is enough.
 			if canMergeNQ(taskInQueue, mergeTask, maxNQ, nqMergeRatio) && taskInQueue.MergeWith(mergeTask) {
 				return true
@@ -131,6 +183,38 @@ func (q *mergeTaskQueue) tryMerge(task queuedTask, maxNQ int64, nqMergeRatio flo
 		}
 	}
 	return false
+}
+
+type deadlineTaskHeap []*queuedTask
+
+func (h deadlineTaskHeap) Len() int {
+	return len(h)
+}
+
+func (h deadlineTaskHeap) Less(i, j int) bool {
+	return h[i].deadline.Before(h[j].deadline)
+}
+
+func (h deadlineTaskHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].deadlineIndex = i
+	h[j].deadlineIndex = j
+}
+
+func (h *deadlineTaskHeap) Push(x any) {
+	entry := x.(*queuedTask)
+	entry.deadlineIndex = len(*h)
+	*h = append(*h, entry)
+}
+
+func (h *deadlineTaskHeap) Pop() any {
+	old := *h
+	n := len(old)
+	entry := old[n-1]
+	old[n-1] = nil
+	entry.deadlineIndex = -1
+	*h = old[:n-1]
+	return entry
 }
 
 // newFairPollingTaskQueue create a fair polling task queue.
@@ -163,7 +247,7 @@ func (q *fairPollingTaskQueue) groupLen(group string) int {
 }
 
 // tryMergeWithOtherGroup try to merge given task into exists tasks in the other group.
-func (q *fairPollingTaskQueue) tryMergeWithOtherGroup(group string, task queuedTask, maxNQ int64, nqMergeRatio float64) bool {
+func (q *fairPollingTaskQueue) tryMergeWithOtherGroup(group string, task *queuedTask, maxNQ int64, nqMergeRatio float64) bool {
 	if q.count == 0 {
 		return false
 	}
@@ -185,7 +269,7 @@ func (q *fairPollingTaskQueue) tryMergeWithOtherGroup(group string, task queuedT
 }
 
 // tryMergeWithSameGroup try to merge given task into exists tasks in the same group.
-func (q *fairPollingTaskQueue) tryMergeWithSameGroup(group string, task queuedTask, maxNQ int64, nqMergeRatio float64) bool {
+func (q *fairPollingTaskQueue) tryMergeWithSameGroup(group string, task *queuedTask, maxNQ int64, nqMergeRatio float64) bool {
 	if q.count == 0 {
 		return false
 	}
@@ -200,7 +284,7 @@ func (q *fairPollingTaskQueue) tryMergeWithSameGroup(group string, task queuedTa
 }
 
 // push add a new task into queue, try merge first.
-func (q *fairPollingTaskQueue) push(group string, task queuedTask) {
+func (q *fairPollingTaskQueue) push(group string, task *queuedTask) {
 	// Add a new task.
 	if r, ok := q.route[group]; ok {
 		// Add new task to the back of queue if queue exist.
@@ -223,11 +307,11 @@ func (q *fairPollingTaskQueue) push(group string, task queuedTask) {
 	q.count++
 }
 
-func (q *fairPollingTaskQueue) cleanup(now time.Time) []queuedTask {
+func (q *fairPollingTaskQueue) cleanup(now time.Time) []*queuedTask {
 	if q.count == 0 || q.checkpoint == nil {
 		return nil
 	}
-	removed := make([]queuedTask, 0)
+	removed := make([]*queuedTask, 0)
 	checkpoint := q.checkpoint
 	queuesLen := q.checkpoint.Len()
 	for i := 0; i < queuesLen; i++ {
@@ -243,10 +327,10 @@ func (q *fairPollingTaskQueue) cleanup(now time.Time) []queuedTask {
 }
 
 // pop pop next ready task.
-func (q *fairPollingTaskQueue) pop(queueExpire time.Duration) queuedTask {
+func (q *fairPollingTaskQueue) pop(queueExpire time.Duration) *queuedTask {
 	// Return directly if there's no task exists.
 	if q.count == 0 {
-		return queuedTask{}
+		return nil
 	}
 	checkpoint := q.checkpoint
 	queuesLen := q.checkpoint.Len()
@@ -286,5 +370,5 @@ func (q *fairPollingTaskQueue) pop(queueExpire time.Duration) queuedTask {
 
 	// Update checkpoint.
 	q.checkpoint = checkpoint
-	return queuedTask{}
+	return nil
 }

--- a/internal/util/searchutil/scheduler/queues.go
+++ b/internal/util/searchutil/scheduler/queues.go
@@ -157,8 +157,26 @@ func canMergeNQ(task MergeTask, other MergeTask, maxNQ int64, nqMergeRatio float
 	return minNQ > 0 && float64(totalNQ)/float64(minNQ) <= nqMergeRatio
 }
 
+func canMergeDeadline(task *queuedTask, other *queuedTask, maxDeadlineMergeGap time.Duration) bool {
+	if maxDeadlineMergeGap < 0 {
+		return true
+	}
+	deadline, ok := task.Context().Deadline()
+	otherDeadline, otherOk := other.Context().Deadline()
+	if !ok && !otherOk {
+		return true
+	}
+	if ok != otherOk {
+		return false
+	}
+	if deadline.After(otherDeadline) {
+		deadline, otherDeadline = otherDeadline, deadline
+	}
+	return otherDeadline.Sub(deadline) <= maxDeadlineMergeGap
+}
+
 // tryMerge try to a new task to any task in queue.
-func (q *mergeTaskQueue) tryMerge(task *queuedTask, maxNQ int64, nqMergeRatio float64) bool {
+func (q *mergeTaskQueue) tryMerge(task *queuedTask, maxNQ int64, nqMergeRatio float64, maxDeadlineMergeGap time.Duration) bool {
 	mergeTask := tryIntoMergeTask(task.Task)
 	if mergeTask == nil {
 		return false
@@ -174,7 +192,9 @@ func (q *mergeTaskQueue) tryMerge(task *queuedTask, maxNQ int64, nqMergeRatio fl
 		}
 		if taskInQueue := tryIntoMergeTask(taskInQueue.Task); taskInQueue != nil {
 			// Try to merge it if limit of nq is enough.
-			if canMergeNQ(taskInQueue, mergeTask, maxNQ, nqMergeRatio) && taskInQueue.MergeWith(mergeTask) {
+			if (canMergeNQ(taskInQueue, mergeTask, maxNQ, nqMergeRatio) &&
+				canMergeDeadline(q.tasks[i], task, maxDeadlineMergeGap)) &&
+				taskInQueue.MergeWith(mergeTask) {
 				return true
 			}
 		}
@@ -225,7 +245,7 @@ func (q *fairPollingTaskQueue) groupLen(group string) int {
 }
 
 // tryMergeWithOtherGroup try to merge given task into exists tasks in the other group.
-func (q *fairPollingTaskQueue) tryMergeWithOtherGroup(group string, task *queuedTask, maxNQ int64, nqMergeRatio float64) bool {
+func (q *fairPollingTaskQueue) tryMergeWithOtherGroup(group string, task *queuedTask, maxNQ int64, nqMergeRatio float64, maxDeadlineMergeGap time.Duration) bool {
 	if q.count == 0 {
 		return false
 	}
@@ -238,7 +258,7 @@ func (q *fairPollingTaskQueue) tryMergeWithOtherGroup(group string, task *queued
 		if queue.len() == 0 || queue.name == group {
 			continue
 		}
-		if queue.tryMerge(task, maxNQ, nqMergeRatio) {
+		if queue.tryMerge(task, maxNQ, nqMergeRatio, maxDeadlineMergeGap) {
 			return true
 		}
 		node = prev
@@ -247,14 +267,14 @@ func (q *fairPollingTaskQueue) tryMergeWithOtherGroup(group string, task *queued
 }
 
 // tryMergeWithSameGroup try to merge given task into exists tasks in the same group.
-func (q *fairPollingTaskQueue) tryMergeWithSameGroup(group string, task *queuedTask, maxNQ int64, nqMergeRatio float64) bool {
+func (q *fairPollingTaskQueue) tryMergeWithSameGroup(group string, task *queuedTask, maxNQ int64, nqMergeRatio float64, maxDeadlineMergeGap time.Duration) bool {
 	if q.count == 0 {
 		return false
 	}
 	// Applied to task with same group first.
 	if r, ok := q.route[group]; ok {
 		// Try to merge task into queue.
-		if r.Value.(*mergeTaskQueue).tryMerge(task, maxNQ, nqMergeRatio) {
+		if r.Value.(*mergeTaskQueue).tryMerge(task, maxNQ, nqMergeRatio, maxDeadlineMergeGap) {
 			return true
 		}
 	}

--- a/internal/util/searchutil/scheduler/queues.go
+++ b/internal/util/searchutil/scheduler/queues.go
@@ -2,17 +2,13 @@ package scheduler
 
 import (
 	"container/ring"
-	"math"
 	"time"
-
-	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func newMergeTaskQueue(group string) *mergeTaskQueue {
 	return &mergeTaskQueue{
 		name:             group,
 		tasks:            make([]*queuedTask, 0),
-		deadlineTasks:    newDeadlineTaskHeap(),
 		cleanupTimestamp: time.Now(),
 	}
 }
@@ -20,7 +16,6 @@ func newMergeTaskQueue(group string) *mergeTaskQueue {
 type mergeTaskQueue struct {
 	name             string
 	tasks            []*queuedTask
-	deadlineTasks    typeutil.Heap[*queuedTask]
 	count            int
 	cleanupTimestamp time.Time
 }
@@ -34,9 +29,6 @@ func (q *mergeTaskQueue) len() int {
 func (q *mergeTaskQueue) push(task *queuedTask) {
 	q.tasks = append(q.tasks, task)
 	q.count++
-	if _, ok := task.Context().Deadline(); ok {
-		q.deadlineTasks.Push(task)
-	}
 }
 
 // front returns the first element of taskQueue.
@@ -77,24 +69,8 @@ func (q *mergeTaskQueue) cleanup(now time.Time) []*queuedTask {
 	}
 
 	removed := make([]*queuedTask, 0)
-	for q.deadlineTasks.Len() > 0 {
-		task := q.deadlineTasks.Peek()
-		if !task.valid() {
-			q.deadlineTasks.Pop()
-			continue
-		}
-		if !task.cleanupReady(now) {
-			break
-		}
-		q.deadlineTasks.Pop()
-		removed = append(removed, q.markRemoved(task, now))
-	}
-
 	for _, task := range q.tasks {
-		if !task.valid() {
-			continue
-		}
-		if task.Context().Err() == nil {
+		if !task.cleanupReady(now) {
 			continue
 		}
 		removed = append(removed, q.markRemoved(task, now))
@@ -200,19 +176,6 @@ func (q *mergeTaskQueue) tryMerge(task *queuedTask, maxNQ int64, nqMergeRatio fl
 		}
 	}
 	return false
-}
-
-func newDeadlineTaskHeap() typeutil.Heap[*queuedTask] {
-	return typeutil.NewObjectArrayBasedMinimumHeap[*queuedTask, int64](nil, func(task *queuedTask) int64 {
-		if !task.valid() {
-			return math.MaxInt64
-		}
-		deadline, ok := task.Context().Deadline()
-		if !ok {
-			return math.MaxInt64
-		}
-		return deadline.UnixNano()
-	})
 }
 
 // newFairPollingTaskQueue create a fair polling task queue.

--- a/internal/util/searchutil/scheduler/queues.go
+++ b/internal/util/searchutil/scheduler/queues.go
@@ -1,15 +1,18 @@
 package scheduler
 
 import (
-	"container/heap"
 	"container/ring"
+	"math"
 	"time"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func newMergeTaskQueue(group string) *mergeTaskQueue {
 	return &mergeTaskQueue{
 		name:             group,
 		tasks:            make([]*queuedTask, 0),
+		deadlineTasks:    newDeadlineTaskHeap(),
 		cleanupTimestamp: time.Now(),
 	}
 }
@@ -17,7 +20,7 @@ func newMergeTaskQueue(group string) *mergeTaskQueue {
 type mergeTaskQueue struct {
 	name             string
 	tasks            []*queuedTask
-	deadlineTasks    deadlineTaskHeap
+	deadlineTasks    typeutil.Heap[*queuedTask]
 	count            int
 	cleanupTimestamp time.Time
 }
@@ -31,8 +34,8 @@ func (q *mergeTaskQueue) len() int {
 func (q *mergeTaskQueue) push(task *queuedTask) {
 	q.tasks = append(q.tasks, task)
 	q.count++
-	if !task.deadline.IsZero() {
-		heap.Push(&q.deadlineTasks, task)
+	if _, ok := task.Context().Deadline(); ok {
+		q.deadlineTasks.Push(task)
 	}
 }
 
@@ -59,9 +62,6 @@ func (q *mergeTaskQueue) pop() *queuedTask {
 			continue
 		}
 
-		if task.deadlineIndex >= 0 {
-			heap.Remove(&q.deadlineTasks, task.deadlineIndex)
-		}
 		removed := q.markRemoved(task, time.Now())
 		if q.len() == 0 {
 			clear(q.tasks)
@@ -78,15 +78,15 @@ func (q *mergeTaskQueue) cleanup(now time.Time) []*queuedTask {
 
 	removed := make([]*queuedTask, 0)
 	for q.deadlineTasks.Len() > 0 {
-		task := q.deadlineTasks[0]
+		task := q.deadlineTasks.Peek()
 		if !task.valid() {
-			heap.Pop(&q.deadlineTasks)
+			q.deadlineTasks.Pop()
 			continue
 		}
 		if !task.cleanupReady(now) {
 			break
 		}
-		heap.Pop(&q.deadlineTasks)
+		q.deadlineTasks.Pop()
 		removed = append(removed, q.markRemoved(task, now))
 	}
 
@@ -96,9 +96,6 @@ func (q *mergeTaskQueue) cleanup(now time.Time) []*queuedTask {
 		}
 		if task.Context().Err() == nil {
 			continue
-		}
-		if task.deadlineIndex >= 0 {
-			heap.Remove(&q.deadlineTasks, task.deadlineIndex)
 		}
 		removed = append(removed, q.markRemoved(task, now))
 	}
@@ -185,36 +182,17 @@ func (q *mergeTaskQueue) tryMerge(task *queuedTask, maxNQ int64, nqMergeRatio fl
 	return false
 }
 
-type deadlineTaskHeap []*queuedTask
-
-func (h deadlineTaskHeap) Len() int {
-	return len(h)
-}
-
-func (h deadlineTaskHeap) Less(i, j int) bool {
-	return h[i].deadline.Before(h[j].deadline)
-}
-
-func (h deadlineTaskHeap) Swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
-	h[i].deadlineIndex = i
-	h[j].deadlineIndex = j
-}
-
-func (h *deadlineTaskHeap) Push(x any) {
-	entry := x.(*queuedTask)
-	entry.deadlineIndex = len(*h)
-	*h = append(*h, entry)
-}
-
-func (h *deadlineTaskHeap) Pop() any {
-	old := *h
-	n := len(old)
-	entry := old[n-1]
-	old[n-1] = nil
-	entry.deadlineIndex = -1
-	*h = old[:n-1]
-	return entry
+func newDeadlineTaskHeap() typeutil.Heap[*queuedTask] {
+	return typeutil.NewObjectArrayBasedMinimumHeap[*queuedTask, int64](nil, func(task *queuedTask) int64 {
+		if !task.valid() {
+			return math.MaxInt64
+		}
+		deadline, ok := task.Context().Deadline()
+		if !ok {
+			return math.MaxInt64
+		}
+		return deadline.UnixNano()
+	})
 }
 
 // newFairPollingTaskQueue create a fair polling task queue.

--- a/internal/util/searchutil/scheduler/queues_test.go
+++ b/internal/util/searchutil/scheduler/queues_test.go
@@ -53,7 +53,7 @@ func TestMergeTaskQueue(t *testing.T) {
 			mergeAble: true,
 			nq:        int64(i),
 		})
-		assert.Equal(t, i <= 10, q.tryMerge(newQueuedTask(task, time.Now()), 56, 0))
+		assert.Equal(t, i <= 10, q.tryMerge(newQueuedTask(task, time.Now()), 56, 0, 0))
 	}
 	for i := 1; i <= 2; i++ {
 		task := newMockTask(mockTaskConfig{
@@ -71,7 +71,7 @@ func TestMergeTaskQueue(t *testing.T) {
 		})
 		// 2 + 1 + ... + 9 < 55
 		// 1 + 10 + 11 + 12 + 13 < 55
-		assert.Equal(t, i <= 13, q.tryMerge(newQueuedTask(task, time.Now()), 55, 0))
+		assert.Equal(t, i <= 13, q.tryMerge(newQueuedTask(task, time.Now()), 55, 0, 0))
 	}
 }
 
@@ -87,14 +87,66 @@ func TestMergeTaskQueueNQMergeRatio(t *testing.T) {
 		username:  "test_user",
 		mergeAble: true,
 		nq:        4,
-	}), time.Now()), 16, 3))
+	}), time.Now()), 16, 3, 0))
 
 	assert.False(t, q.tryMerge(newQueuedTask(newMockTask(mockTaskConfig{
 		username:  "test_user",
 		mergeAble: true,
 		nq:        4,
-	}), time.Now()), 16, 3))
+	}), time.Now()), 16, 3, 0))
 	assert.Equal(t, int64(6), q.front().NQ())
+}
+
+func TestMergeTaskQueueDeadlineMergeGap(t *testing.T) {
+	now := time.Now()
+	baseDeadline := now.Add(time.Second)
+	baseCtx, baseCancel := context.WithDeadline(context.Background(), baseDeadline)
+	defer baseCancel()
+
+	newTask := func(ctx context.Context, nq int64) *queuedTask {
+		return newQueuedTask(newMockTask(mockTaskConfig{
+			ctx:       ctx,
+			username:  "test_user",
+			mergeAble: true,
+			nq:        nq,
+		}), now)
+	}
+
+	t.Run("deadline gap too large", func(t *testing.T) {
+		q := newMergeTaskQueue("test_user")
+		q.push(newTask(baseCtx, 2))
+		shortCtx, shortCancel := context.WithDeadline(context.Background(), baseDeadline.Add(-100*time.Millisecond))
+		defer shortCancel()
+
+		assert.False(t, q.tryMerge(newTask(shortCtx, 2), 16, 0, 50*time.Millisecond))
+		assert.Equal(t, int64(2), q.front().NQ())
+	})
+
+	t.Run("deadline gap within threshold", func(t *testing.T) {
+		q := newMergeTaskQueue("test_user")
+		q.push(newTask(baseCtx, 2))
+		closeCtx, closeCancel := context.WithDeadline(context.Background(), baseDeadline.Add(-40*time.Millisecond))
+		defer closeCancel()
+
+		assert.True(t, q.tryMerge(newTask(closeCtx, 2), 16, 0, 50*time.Millisecond))
+		assert.Equal(t, int64(4), q.front().NQ())
+	})
+
+	t.Run("one side missing deadline", func(t *testing.T) {
+		q := newMergeTaskQueue("test_user")
+		q.push(newTask(baseCtx, 2))
+
+		assert.False(t, q.tryMerge(newTask(context.Background(), 2), 16, 0, 50*time.Millisecond))
+		assert.Equal(t, int64(2), q.front().NQ())
+	})
+
+	t.Run("both sides missing deadline", func(t *testing.T) {
+		q := newMergeTaskQueue("test_user")
+		q.push(newTask(context.Background(), 2))
+
+		assert.True(t, q.tryMerge(newTask(context.Background(), 2), 16, 0, 50*time.Millisecond))
+		assert.Equal(t, int64(4), q.front().NQ())
+	})
 }
 
 func TestMergeTaskQueueCleanupSkipsRewriteWithoutExpiredTask(t *testing.T) {
@@ -206,8 +258,8 @@ func TestFairPollingTaskQueue(t *testing.T) {
 		username:  username,
 		mergeAble: true,
 	})
-	assert.False(t, q.tryMergeWithSameGroup(username, newQueuedTask(task, time.Now()), 1, 0))
-	assert.False(t, q.tryMergeWithOtherGroup(username, newQueuedTask(task, time.Now()), 1, 0))
+	assert.False(t, q.tryMergeWithSameGroup(username, newQueuedTask(task, time.Now()), 1, 0, 0))
+	assert.False(t, q.tryMergeWithOtherGroup(username, newQueuedTask(task, time.Now()), 1, 0, 0))
 
 	// Add basic user info first.
 	for i := 1; i <= userN; i++ {
@@ -228,7 +280,7 @@ func TestFairPollingTaskQueue(t *testing.T) {
 			username:  username,
 			mergeAble: true,
 		})
-		success := q.tryMergeWithSameGroup(username, newQueuedTask(task, time.Now()), int64(n/userN), 0)
+		success := q.tryMergeWithSameGroup(username, newQueuedTask(task, time.Now()), int64(n/userN), 0, 0)
 		assert.Equal(t, i+userN <= n, success)
 		assert.Equal(t, userN, q.len())
 		assert.Equal(t, 1, q.groupLen(username))
@@ -239,7 +291,7 @@ func TestFairPollingTaskQueue(t *testing.T) {
 		username:  username,
 		mergeAble: true,
 	})
-	assert.False(t, q.tryMergeWithOtherGroup(username, newQueuedTask(task, time.Now()), int64(n/userN), 0))
-	assert.True(t, q.tryMergeWithOtherGroup(username, newQueuedTask(task, time.Now()), int64(n/userN)+1, 0))
+	assert.False(t, q.tryMergeWithOtherGroup(username, newQueuedTask(task, time.Now()), int64(n/userN), 0, 0))
+	assert.True(t, q.tryMergeWithOtherGroup(username, newQueuedTask(task, time.Now()), int64(n/userN)+1, 0, 0))
 	assert.Equal(t, 0, q.groupLen(username))
 }

--- a/internal/util/searchutil/scheduler/queues_test.go
+++ b/internal/util/searchutil/scheduler/queues_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -110,6 +111,36 @@ func TestMergeTaskQueueCleanupSkipsRewriteWithoutExpiredTask(t *testing.T) {
 	assert.Empty(t, removed)
 	assert.Equal(t, 3, q.len())
 	assert.Same(t, firstTask, q.tasks[0].Task)
+}
+
+func TestMergeTaskQueueCleanupMarksExpiredTasksInPlace(t *testing.T) {
+	q := newMergeTaskQueue("test_user")
+	now := time.Now()
+	later := now.Add(time.Minute)
+
+	ctx1, cancel1 := context.WithDeadline(context.Background(), later)
+	defer cancel1()
+	ctx2, cancel2 := context.WithDeadline(context.Background(), now.Add(-time.Millisecond))
+	defer cancel2()
+	ctx3, cancel3 := context.WithDeadline(context.Background(), later)
+	defer cancel3()
+
+	q.push(newQueuedTask(newMockTask(mockTaskConfig{ctx: ctx1, username: "test_user"}), now))
+	expiredTask := newMockTask(mockTaskConfig{ctx: ctx2, username: "test_user"})
+	q.push(newQueuedTask(expiredTask, now))
+	q.push(newQueuedTask(newMockTask(mockTaskConfig{ctx: ctx3, username: "test_user"}), now))
+
+	originalQueueLen := len(q.tasks)
+	removed := q.cleanup(now)
+
+	assert.Len(t, removed, 1)
+	assert.Same(t, expiredTask, removed[0].Task)
+	assert.Equal(t, 2, q.len())
+	assert.Equal(t, originalQueueLen, len(q.tasks))
+	assert.True(t, q.pop().valid())
+	assert.True(t, q.pop().valid())
+	assert.False(t, q.pop().valid())
+	assert.Equal(t, 0, q.len())
 }
 
 func TestMergeTaskQueuePopClearsPoppedSlot(t *testing.T) {

--- a/internal/util/searchutil/scheduler/queues_test.go
+++ b/internal/util/searchutil/scheduler/queues_test.go
@@ -11,9 +11,9 @@ import (
 func TestMergeTaskQueue(t *testing.T) {
 	q := newMergeTaskQueue("test_user")
 	assert.Equal(t, 0, q.len())
-	assert.Nil(t, q.front())
+	assert.False(t, q.front().valid())
 	q.pop()
-	assert.Nil(t, q.front())
+	assert.False(t, q.front().valid())
 	assert.Equal(t, 0, q.len())
 	assert.False(t, q.expire(5*time.Second))
 	time.Sleep(1 * time.Second)
@@ -25,7 +25,7 @@ func TestMergeTaskQueue(t *testing.T) {
 		task := newMockTask(mockTaskConfig{
 			username: "test_user",
 		})
-		q.push(task)
+		q.push(newQueuedTask(task, time.Now()))
 		assert.Equal(t, i, q.len())
 		assert.False(t, q.expire(time.Second))
 	}
@@ -45,14 +45,14 @@ func TestMergeTaskQueue(t *testing.T) {
 		mergeAble: true,
 		nq:        1,
 	})
-	q.push(task)
+	q.push(newQueuedTask(task, time.Now()))
 	for i := 1; i <= 20; i++ {
 		task := newMockTask(mockTaskConfig{
 			username:  "test_user",
 			mergeAble: true,
 			nq:        int64(i),
 		})
-		assert.Equal(t, i <= 10, q.tryMerge(tryIntoMergeTask(task), 56))
+		assert.Equal(t, i <= 10, q.tryMerge(newQueuedTask(task, time.Now()), 56, 0))
 	}
 	for i := 1; i <= 2; i++ {
 		task := newMockTask(mockTaskConfig{
@@ -60,7 +60,7 @@ func TestMergeTaskQueue(t *testing.T) {
 			mergeAble: true,
 			nq:        int64(1),
 		})
-		q.push(task)
+		q.push(newQueuedTask(task, time.Now()))
 	}
 	for i := 1; i <= 20; i++ {
 		task := newMockTask(mockTaskConfig{
@@ -70,15 +70,66 @@ func TestMergeTaskQueue(t *testing.T) {
 		})
 		// 2 + 1 + ... + 9 < 55
 		// 1 + 10 + 11 + 12 + 13 < 55
-		assert.Equal(t, i <= 13, q.tryMerge(tryIntoMergeTask(task), 55))
+		assert.Equal(t, i <= 13, q.tryMerge(newQueuedTask(task, time.Now()), 55, 0))
 	}
+}
+
+func TestMergeTaskQueueNQMergeRatio(t *testing.T) {
+	q := newMergeTaskQueue("test_user")
+	q.push(newQueuedTask(newMockTask(mockTaskConfig{
+		username:  "test_user",
+		mergeAble: true,
+		nq:        2,
+	}), time.Now()))
+
+	assert.True(t, q.tryMerge(newQueuedTask(newMockTask(mockTaskConfig{
+		username:  "test_user",
+		mergeAble: true,
+		nq:        4,
+	}), time.Now()), 16, 3))
+
+	assert.False(t, q.tryMerge(newQueuedTask(newMockTask(mockTaskConfig{
+		username:  "test_user",
+		mergeAble: true,
+		nq:        4,
+	}), time.Now()), 16, 3))
+	assert.Equal(t, int64(6), q.front().NQ())
+}
+
+func TestMergeTaskQueueCleanupSkipsRewriteWithoutExpiredTask(t *testing.T) {
+	q := newMergeTaskQueue("test_user")
+	now := time.Now()
+	for i := 0; i < 3; i++ {
+		task := newMockTask(mockTaskConfig{username: "test_user"})
+		q.push(newQueuedTask(task, now))
+	}
+
+	firstTask := q.tasks[0].Task
+	removed := q.cleanup(now)
+
+	assert.Empty(t, removed)
+	assert.Equal(t, 3, q.len())
+	assert.Same(t, firstTask, q.tasks[0].Task)
+}
+
+func TestMergeTaskQueuePopClearsPoppedSlot(t *testing.T) {
+	q := newMergeTaskQueue("test_user")
+	task := newMockTask(mockTaskConfig{username: "test_user"})
+	q.push(newQueuedTask(task, time.Now()))
+
+	tasks := q.tasks
+	popped := q.pop()
+
+	assert.True(t, popped.valid())
+	assert.False(t, tasks[0].valid())
+	assert.Equal(t, 0, q.len())
 }
 
 func TestFairPollingTaskQueue(t *testing.T) {
 	q := newFairPollingTaskQueue()
 	assert.Equal(t, 0, q.len())
 	assert.Equal(t, 0, q.groupLen(""))
-	assert.Nil(t, q.pop(time.Second))
+	assert.False(t, q.pop(time.Second).valid())
 	assert.Equal(t, 0, q.len())
 	assert.Equal(t, 0, q.groupLen(""))
 
@@ -90,7 +141,7 @@ func TestFairPollingTaskQueue(t *testing.T) {
 		task := newMockTask(mockTaskConfig{
 			username: username,
 		})
-		q.push(username, task)
+		q.push(username, newQueuedTask(task, time.Now()))
 		assert.Equal(t, i, q.len())
 		assert.Equal(t, (i-1)/10+1, q.groupLen(username))
 	}
@@ -99,7 +150,7 @@ func TestFairPollingTaskQueue(t *testing.T) {
 	// Test Pop
 	for i := 1; i <= n; i++ {
 		task := q.pop(time.Minute)
-		assert.NotNil(t, task)
+		assert.True(t, task.valid())
 		username := task.Username()
 		expectedUserName := fmt.Sprintf("user_%d", (i-1)%userN)
 		assert.Equal(t, n-i, q.len())
@@ -113,9 +164,9 @@ func TestFairPollingTaskQueue(t *testing.T) {
 	task := newMockTask(mockTaskConfig{
 		username: username,
 	})
-	q.push(username, task)
+	q.push(username, newQueuedTask(task, time.Now()))
 	assert.Equal(t, userN+1, len(q.route))
-	assert.NotNil(t, q.pop(time.Second))
+	assert.True(t, q.pop(time.Second).valid())
 	assert.Equal(t, 1, len(q.route))
 
 	// Test Merge.
@@ -124,8 +175,8 @@ func TestFairPollingTaskQueue(t *testing.T) {
 		username:  username,
 		mergeAble: true,
 	})
-	assert.False(t, q.tryMergeWithSameGroup(username, tryIntoMergeTask(task), 1))
-	assert.False(t, q.tryMergeWithOtherGroup(username, tryIntoMergeTask(task), 1))
+	assert.False(t, q.tryMergeWithSameGroup(username, newQueuedTask(task, time.Now()), 1, 0))
+	assert.False(t, q.tryMergeWithOtherGroup(username, newQueuedTask(task, time.Now()), 1, 0))
 
 	// Add basic user info first.
 	for i := 1; i <= userN; i++ {
@@ -134,7 +185,7 @@ func TestFairPollingTaskQueue(t *testing.T) {
 			username:  username,
 			mergeAble: true,
 		})
-		q.push(username, task)
+		q.push(username, newQueuedTask(task, time.Now()))
 		assert.Equal(t, i, q.len())
 		assert.Equal(t, 1, q.groupLen(username))
 	}
@@ -146,7 +197,7 @@ func TestFairPollingTaskQueue(t *testing.T) {
 			username:  username,
 			mergeAble: true,
 		})
-		success := q.tryMergeWithSameGroup(username, tryIntoMergeTask(task), int64(n/userN))
+		success := q.tryMergeWithSameGroup(username, newQueuedTask(task, time.Now()), int64(n/userN), 0)
 		assert.Equal(t, i+userN <= n, success)
 		assert.Equal(t, userN, q.len())
 		assert.Equal(t, 1, q.groupLen(username))
@@ -157,7 +208,7 @@ func TestFairPollingTaskQueue(t *testing.T) {
 		username:  username,
 		mergeAble: true,
 	})
-	assert.False(t, q.tryMergeWithOtherGroup(username, tryIntoMergeTask(task), int64(n/userN)))
-	assert.True(t, q.tryMergeWithOtherGroup(username, tryIntoMergeTask(task), int64(n/userN)+1))
+	assert.False(t, q.tryMergeWithOtherGroup(username, newQueuedTask(task, time.Now()), int64(n/userN), 0))
+	assert.True(t, q.tryMergeWithOtherGroup(username, newQueuedTask(task, time.Now()), int64(n/userN)+1, 0))
 	assert.Equal(t, 0, q.groupLen(username))
 }

--- a/internal/util/searchutil/scheduler/tasks.go
+++ b/internal/util/searchutil/scheduler/tasks.go
@@ -81,23 +81,14 @@ type schedulePolicy interface {
 type queuedTask struct {
 	Task
 
-	enqueueTime   time.Time
-	deadline      time.Time
-	deadlineIndex int
+	enqueueTime time.Time
 }
 
 func newQueuedTask(task Task, enqueueTime time.Time) *queuedTask {
-	queued := &queuedTask{
-		Task:          task,
-		enqueueTime:   enqueueTime,
-		deadlineIndex: -1,
+	return &queuedTask{
+		Task:        task,
+		enqueueTime: enqueueTime,
 	}
-	if task != nil {
-		if deadline, ok := task.Context().Deadline(); ok {
-			queued.deadline = deadline
-		}
-	}
-	return queued
 }
 
 func (t *queuedTask) queueDuration(now time.Time) time.Duration {

--- a/internal/util/searchutil/scheduler/tasks.go
+++ b/internal/util/searchutil/scheduler/tasks.go
@@ -1,6 +1,11 @@
 package scheduler
 
-import "github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+import (
+	"context"
+	"time"
+
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+)
 
 const (
 	schedulePolicyNameFIFO            = "fifo"
@@ -36,8 +41,8 @@ func tryIntoMergeTask(t Task) MergeTask {
 
 type Scheduler interface {
 	// Add a new task into scheduler, follow some constraints.
-	// 1. It's a non-block operation.
-	// 2. Error will be returned if scheduler reaches some limit.
+	// 1. Error will be returned if scheduler reaches some limit.
+	// 2. Error will be returned if task context is canceled while waiting to be accepted.
 	// 3. Concurrent safe.
 	Add(task Task) error
 
@@ -58,15 +63,66 @@ type Scheduler interface {
 
 // schedulePolicy is the policy of scheduler.
 type schedulePolicy interface {
+	// Cleanup removes queued tasks whose context deadline has been reached.
+	// Removed tasks are returned to scheduler for error notification.
+	Cleanup(now time.Time) []queuedTask
+
 	// Push add a new task into scheduler.
 	// Return the count of new task added (task may be chunked, merged or dropped)
 	// 0 and an error will be returned if scheduler reaches some limit.
-	Push(task Task) (int, error)
+	Push(task queuedTask) (int, error)
 
 	// Pop get the task next ready to run.
-	Pop() Task
+	Pop(now time.Time) popResult
 
 	Len() int
+}
+
+type popResult struct {
+	task    queuedTask
+	dropped []queuedTask
+}
+
+type queuedTask struct {
+	Task
+
+	enqueueTime time.Time
+}
+
+func newQueuedTask(task Task, enqueueTime time.Time) queuedTask {
+	return queuedTask{
+		Task:        task,
+		enqueueTime: enqueueTime,
+	}
+}
+
+func (t queuedTask) queueDuration(now time.Time) time.Duration {
+	if !t.valid() || t.enqueueTime.IsZero() {
+		return 0
+	}
+	return now.Sub(t.enqueueTime)
+}
+
+func (t queuedTask) valid() bool {
+	return t.Task != nil
+}
+
+func (t queuedTask) cleanupReady(now time.Time) bool {
+	if !t.valid() {
+		return false
+	}
+	if t.Context().Err() != nil {
+		return true
+	}
+	deadline, ok := t.Context().Deadline()
+	return ok && !now.Before(deadline)
+}
+
+func cleanupTaskError(task queuedTask) error {
+	if err := task.Context().Err(); err != nil {
+		return err
+	}
+	return context.DeadlineExceeded
 }
 
 // MergeTask is a Task which can be merged with other task
@@ -76,10 +132,15 @@ type MergeTask interface {
 	// MergeWith other task, return true if merge success.
 	// After success, the task merged should be dropped.
 	MergeWith(Task) bool
+
+	// MinNQ returns the minimum NQ among the original tasks in this merged task.
+	MinNQ() int64
 }
 
 // A task is execute unit of scheduler.
 type Task interface {
+	Context() context.Context
+
 	// Return the username which task is belong to.
 	// Return "" if the task do not contain any user info.
 	Username() string
@@ -95,10 +156,6 @@ type Task interface {
 
 	// Done notify the task finished.
 	Done(err error)
-
-	// Check if the Task is canceled.
-	// Concurrent safe.
-	Canceled() error
 
 	// Wait for task finish.
 	// Concurrent safe.

--- a/internal/util/searchutil/scheduler/tasks.go
+++ b/internal/util/searchutil/scheduler/tasks.go
@@ -65,15 +65,15 @@ type Scheduler interface {
 type schedulePolicy interface {
 	// Cleanup removes queued tasks whose context deadline has been reached.
 	// Removed tasks are returned to scheduler for error notification.
-	Cleanup(now time.Time) []queuedTask
+	Cleanup(now time.Time) []*queuedTask
 
 	// Push add a new task into scheduler.
 	// Return the count of new task added (task may be chunked or merged)
 	// 0 and an error will be returned if scheduler reaches some limit.
-	Push(task queuedTask) (int, error)
+	Push(task *queuedTask) (int, error)
 
 	// Pop get the task next ready to run.
-	Pop(now time.Time) queuedTask
+	Pop(now time.Time) *queuedTask
 
 	Len() int
 }
@@ -81,28 +81,37 @@ type schedulePolicy interface {
 type queuedTask struct {
 	Task
 
-	enqueueTime time.Time
+	enqueueTime   time.Time
+	deadline      time.Time
+	deadlineIndex int
 }
 
-func newQueuedTask(task Task, enqueueTime time.Time) queuedTask {
-	return queuedTask{
-		Task:        task,
-		enqueueTime: enqueueTime,
+func newQueuedTask(task Task, enqueueTime time.Time) *queuedTask {
+	queued := &queuedTask{
+		Task:          task,
+		enqueueTime:   enqueueTime,
+		deadlineIndex: -1,
 	}
+	if task != nil {
+		if deadline, ok := task.Context().Deadline(); ok {
+			queued.deadline = deadline
+		}
+	}
+	return queued
 }
 
-func (t queuedTask) queueDuration(now time.Time) time.Duration {
+func (t *queuedTask) queueDuration(now time.Time) time.Duration {
 	if !t.valid() || t.enqueueTime.IsZero() {
 		return 0
 	}
 	return now.Sub(t.enqueueTime)
 }
 
-func (t queuedTask) valid() bool {
-	return t.Task != nil
+func (t *queuedTask) valid() bool {
+	return t != nil && t.Task != nil
 }
 
-func (t queuedTask) cleanupReady(now time.Time) bool {
+func (t *queuedTask) cleanupReady(now time.Time) bool {
 	if !t.valid() {
 		return false
 	}
@@ -113,7 +122,7 @@ func (t queuedTask) cleanupReady(now time.Time) bool {
 	return ok && !now.Before(deadline)
 }
 
-func cleanupTaskError(task queuedTask) error {
+func cleanupTaskError(task *queuedTask) error {
 	if err := task.Context().Err(); err != nil {
 		return err
 	}

--- a/internal/util/searchutil/scheduler/tasks.go
+++ b/internal/util/searchutil/scheduler/tasks.go
@@ -68,19 +68,14 @@ type schedulePolicy interface {
 	Cleanup(now time.Time) []queuedTask
 
 	// Push add a new task into scheduler.
-	// Return the count of new task added (task may be chunked, merged or dropped)
+	// Return the count of new task added (task may be chunked or merged)
 	// 0 and an error will be returned if scheduler reaches some limit.
 	Push(task queuedTask) (int, error)
 
 	// Pop get the task next ready to run.
-	Pop(now time.Time) popResult
+	Pop(now time.Time) queuedTask
 
 	Len() int
-}
-
-type popResult struct {
-	task    queuedTask
-	dropped []queuedTask
 }
 
 type queuedTask struct {

--- a/internal/util/searchutil/scheduler/user_task_polling_policy.go
+++ b/internal/util/searchutil/scheduler/user_task_polling_policy.go
@@ -22,22 +22,27 @@ type userTaskPollingPolicy struct {
 	queue *fairPollingTaskQueue
 }
 
+func (p *userTaskPollingPolicy) Cleanup(now time.Time) []queuedTask {
+	return p.queue.cleanup(now)
+}
+
 // Push add a new task into scheduler, an error will be returned if scheduler reaches some limit.
-func (p *userTaskPollingPolicy) Push(task Task) (int, error) {
+func (p *userTaskPollingPolicy) Push(task queuedTask) (int, error) {
 	pt := paramtable.Get()
 	username := task.Username()
 
 	// Try to merge task if task is mergeable.
-	if t := tryIntoMergeTask(task); t != nil {
+	if t := tryIntoMergeTask(task.Task); t != nil {
 		// Try to merge with same group first.
 		maxNQ := pt.QueryNodeCfg.MaxGroupNQ.GetAsInt64()
-		if p.queue.tryMergeWithSameGroup(username, t, maxNQ) {
+		nqMergeRatio := pt.QueryNodeCfg.NQMergeRatio.GetAsFloat()
+		if p.queue.tryMergeWithSameGroup(username, task, maxNQ, nqMergeRatio) {
 			return 0, nil
 		}
 
 		// Try to merge with other group if option is enabled.
 		enableCrossGroupMerge := pt.QueryNodeCfg.SchedulePolicyEnableCrossUserGrouping.GetAsBool()
-		if enableCrossGroupMerge && p.queue.tryMergeWithOtherGroup(username, t, maxNQ) {
+		if enableCrossGroupMerge && p.queue.tryMergeWithOtherGroup(username, task, maxNQ, nqMergeRatio) {
 			return 0, nil
 		}
 	}
@@ -60,9 +65,9 @@ func (p *userTaskPollingPolicy) Push(task Task) (int, error) {
 }
 
 // Pop get the task next ready to run.
-func (p *userTaskPollingPolicy) Pop() Task {
+func (p *userTaskPollingPolicy) Pop(now time.Time) popResult {
 	expire := paramtable.Get().QueryNodeCfg.SchedulePolicyTaskQueueExpire.GetAsDuration(time.Second)
-	return p.queue.pop(expire)
+	return popResult{task: p.queue.pop(expire)}
 }
 
 // Len get ready task counts.

--- a/internal/util/searchutil/scheduler/user_task_polling_policy.go
+++ b/internal/util/searchutil/scheduler/user_task_polling_policy.go
@@ -22,12 +22,12 @@ type userTaskPollingPolicy struct {
 	queue *fairPollingTaskQueue
 }
 
-func (p *userTaskPollingPolicy) Cleanup(now time.Time) []queuedTask {
+func (p *userTaskPollingPolicy) Cleanup(now time.Time) []*queuedTask {
 	return p.queue.cleanup(now)
 }
 
 // Push add a new task into scheduler, an error will be returned if scheduler reaches some limit.
-func (p *userTaskPollingPolicy) Push(task queuedTask) (int, error) {
+func (p *userTaskPollingPolicy) Push(task *queuedTask) (int, error) {
 	pt := paramtable.Get()
 	username := task.Username()
 
@@ -65,7 +65,7 @@ func (p *userTaskPollingPolicy) Push(task queuedTask) (int, error) {
 }
 
 // Pop get the task next ready to run.
-func (p *userTaskPollingPolicy) Pop(now time.Time) queuedTask {
+func (p *userTaskPollingPolicy) Pop(now time.Time) *queuedTask {
 	expire := paramtable.Get().QueryNodeCfg.SchedulePolicyTaskQueueExpire.GetAsDuration(time.Second)
 	return p.queue.pop(expire)
 }

--- a/internal/util/searchutil/scheduler/user_task_polling_policy.go
+++ b/internal/util/searchutil/scheduler/user_task_polling_policy.go
@@ -65,9 +65,9 @@ func (p *userTaskPollingPolicy) Push(task queuedTask) (int, error) {
 }
 
 // Pop get the task next ready to run.
-func (p *userTaskPollingPolicy) Pop(now time.Time) popResult {
+func (p *userTaskPollingPolicy) Pop(now time.Time) queuedTask {
 	expire := paramtable.Get().QueryNodeCfg.SchedulePolicyTaskQueueExpire.GetAsDuration(time.Second)
-	return popResult{task: p.queue.pop(expire)}
+	return p.queue.pop(expire)
 }
 
 // Len get ready task counts.

--- a/internal/util/searchutil/scheduler/user_task_polling_policy.go
+++ b/internal/util/searchutil/scheduler/user_task_polling_policy.go
@@ -36,13 +36,14 @@ func (p *userTaskPollingPolicy) Push(task *queuedTask) (int, error) {
 		// Try to merge with same group first.
 		maxNQ := pt.QueryNodeCfg.MaxGroupNQ.GetAsInt64()
 		nqMergeRatio := pt.QueryNodeCfg.NQMergeRatio.GetAsFloat()
-		if p.queue.tryMergeWithSameGroup(username, task, maxNQ, nqMergeRatio) {
+		maxDeadlineMergeGap := pt.QueryNodeCfg.MaxDeadlineMergeGap.GetAsDurationByParse()
+		if p.queue.tryMergeWithSameGroup(username, task, maxNQ, nqMergeRatio, maxDeadlineMergeGap) {
 			return 0, nil
 		}
 
 		// Try to merge with other group if option is enabled.
 		enableCrossGroupMerge := pt.QueryNodeCfg.SchedulePolicyEnableCrossUserGrouping.GetAsBool()
-		if enableCrossGroupMerge && p.queue.tryMergeWithOtherGroup(username, task, maxNQ, nqMergeRatio) {
+		if enableCrossGroupMerge && p.queue.tryMergeWithOtherGroup(username, task, maxNQ, nqMergeRatio, maxDeadlineMergeGap) {
 			return 0, nil
 		}
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -142,6 +142,7 @@ const (
 	cgoTypeLabelName               = `cgo_type`
 	queueTypeLabelName             = `queue_type`
 	poolNameLabelName              = "pool_name"
+	outcomeLabelName               = "outcome"
 
 	// model function/UDF labels
 	functionTypeName = "function_type_name"

--- a/pkg/metrics/querynode_metrics.go
+++ b/pkg/metrics/querynode_metrics.go
@@ -267,16 +267,6 @@ var (
 			nodeIDLabelName,
 		})
 
-	QueryNodeReadTaskUnsolveLen = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: milvusNamespace,
-			Subsystem: typeutil.QueryNodeRole,
-			Name:      "read_task_unsolved_len",
-			Help:      "number of unsolved read tasks in unsolvedQueue",
-		}, []string{
-			nodeIDLabelName,
-		})
-
 	QueryNodeReadTaskReadyLen = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: milvusNamespace,
@@ -285,6 +275,40 @@ var (
 			Help:      "number of ready read tasks in readyQueue",
 		}, []string{
 			nodeIDLabelName,
+		})
+
+	QueryNodeReadTaskReadyNQ = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "read_task_ready_nq",
+			Help:      "total NQ of ready read tasks in scheduler queue",
+		}, []string{
+			nodeIDLabelName,
+		})
+
+	QueryNodeReadTaskQueueDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "read_task_queue_duration",
+			Help:      "duration in milliseconds that read tasks stay in scheduler policy queue",
+			Buckets:   subMsBuckets,
+		}, []string{
+			nodeIDLabelName,
+			outcomeLabelName,
+		})
+
+	QueryNodeReadTaskExecuteDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.QueryNodeRole,
+			Name:      "read_task_execute_duration",
+			Help:      "duration in milliseconds that read tasks spend in scheduler execution pool",
+			Buckets:   subMsBuckets,
+		}, []string{
+			nodeIDLabelName,
+			outcomeLabelName,
 		})
 
 	QueryNodeReadTaskConcurrency = prometheus.NewGaugeVec(
@@ -947,8 +971,10 @@ func RegisterQueryNode(registry *prometheus.Registry) {
 	registry.MustRegister(QueryNodeSQSegmentLatencyInCore)
 	registry.MustRegister(QueryNodeReduceLatency)
 	registry.MustRegister(QueryNodeLoadSegmentLatency)
-	registry.MustRegister(QueryNodeReadTaskUnsolveLen)
 	registry.MustRegister(QueryNodeReadTaskReadyLen)
+	registry.MustRegister(QueryNodeReadTaskReadyNQ)
+	registry.MustRegister(QueryNodeReadTaskQueueDuration)
+	registry.MustRegister(QueryNodeReadTaskExecuteDuration)
 	registry.MustRegister(QueryNodeReadTaskConcurrency)
 	registry.MustRegister(QueryNodeEstimateCPUUsage)
 	registry.MustRegister(QueryNodeSearchGroupNQ)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2200,7 +2200,7 @@ func (p *proxyConfig) init(base *BaseTable) {
 	p.MaxTaskNum = ParamItem{
 		Key:          "proxy.maxTaskNum",
 		Version:      "2.2.0",
-		DefaultValue: "256",
+		DefaultValue: "1024",
 		Doc:          "The maximum number of tasks in the task queue of the proxy.",
 		Export:       true,
 	}
@@ -3520,6 +3520,7 @@ type queryNodeConfig struct {
 	MaxGpuReadConcurrency ParamItem `refreshable:"false"`
 	MaxGroupNQ            ParamItem `refreshable:"true"`
 	NQMergeRatio          ParamItem `refreshable:"true"`
+	MaxDeadlineMergeGap   ParamItem `refreshable:"true"`
 	TopKMergeRatio        ParamItem `refreshable:"true"`
 	CPURatio              ParamItem `refreshable:"true"`
 	GracefulStopTimeout   ParamItem `refreshable:"false"`
@@ -4420,6 +4421,16 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 		Export:       true,
 	}
 	p.NQMergeRatio.Init(base.mgr)
+
+	p.MaxDeadlineMergeGap = ParamItem{
+		Key:          "queryNode.grouping.maxDeadlineMergeGap",
+		Version:      "2.6.17",
+		DefaultValue: "50ms",
+		Doc:          "Maximum allowed gap between task context deadlines when grouping query node read tasks. Tasks with only one deadline cannot be grouped. Set a negative duration to disable this check.",
+		Formatter:    formatDurationWithMillisecondFallback,
+		Export:       true,
+	}
+	p.MaxDeadlineMergeGap.Init(base.mgr)
 
 	p.TopKMergeRatio = ParamItem{
 		Key:          "queryNode.grouping.topKMergeRatio",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2200,7 +2200,7 @@ func (p *proxyConfig) init(base *BaseTable) {
 	p.MaxTaskNum = ParamItem{
 		Key:          "proxy.maxTaskNum",
 		Version:      "2.2.0",
-		DefaultValue: "1024",
+		DefaultValue: "256",
 		Doc:          "The maximum number of tasks in the task queue of the proxy.",
 		Export:       true,
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3515,11 +3515,11 @@ type queryNodeConfig struct {
 	ReadAheadPolicy     ParamItem `refreshable:"false"`
 	ChunkCacheWarmingUp ParamItem `refreshable:"true"`
 
-	MaxReceiveChanSize    ParamItem `refreshable:"false"`
 	MaxUnsolvedQueueSize  ParamItem `refreshable:"true"`
 	MaxReadConcurrency    ParamItem `refreshable:"true"`
 	MaxGpuReadConcurrency ParamItem `refreshable:"false"`
 	MaxGroupNQ            ParamItem `refreshable:"true"`
+	NQMergeRatio          ParamItem `refreshable:"true"`
 	TopKMergeRatio        ParamItem `refreshable:"true"`
 	CPURatio              ParamItem `refreshable:"true"`
 	GracefulStopTimeout   ParamItem `refreshable:"false"`
@@ -3551,6 +3551,7 @@ type queryNodeConfig struct {
 	// schedule task policy.
 	SchedulePolicyName                    ParamItem `refreshable:"false"`
 	SchedulePolicyTaskQueueExpire         ParamItem `refreshable:"true"`
+	SchedulePolicyTaskDeadlineAdvance     ParamItem `refreshable:"true"`
 	SchedulePolicyEnableCrossUserGrouping ParamItem `refreshable:"true"`
 	SchedulePolicyMaxPendingTaskPerUser   ParamItem `refreshable:"true"`
 
@@ -3610,6 +3611,20 @@ type queryNodeConfig struct {
 	ExternalCollectionSamplePerSegment ParamItem `refreshable:"true"`
 	ExternalCollectionSampleRows       ParamItem `refreshable:"true"`
 	ExternalCollectionRawDataFactor    ParamItem `refreshable:"true"`
+}
+
+func formatDurationWithMillisecondFallback(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return v
+	}
+	if _, err := time.ParseDuration(v); err == nil {
+		return v
+	}
+	if _, err := strconv.ParseFloat(v, 64); err == nil {
+		return v + "ms"
+	}
+	return v
 }
 
 func (p *queryNodeConfig) init(base *BaseTable) {
@@ -4350,14 +4365,6 @@ However, this optimization may come at the cost of a slight decrease in query la
 	}
 	p.ChunkCacheWarmingUp.Init(base.mgr)
 
-	p.MaxReceiveChanSize = ParamItem{
-		Key:          "queryNode.scheduler.receiveChanSize",
-		Version:      "2.0.0",
-		DefaultValue: "10240",
-		Export:       true,
-	}
-	p.MaxReceiveChanSize.Init(base.mgr)
-
 	p.MaxReadConcurrency = ParamItem{
 		Key:          "queryNode.scheduler.maxReadConcurrentRatio",
 		Version:      "2.0.0",
@@ -4392,7 +4399,7 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 	p.MaxUnsolvedQueueSize = ParamItem{
 		Key:          "queryNode.scheduler.unsolvedQueueSize",
 		Version:      "2.0.0",
-		DefaultValue: "10240",
+		DefaultValue: "4096",
 		Export:       true,
 	}
 	p.MaxUnsolvedQueueSize.Init(base.mgr)
@@ -4400,10 +4407,19 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 	p.MaxGroupNQ = ParamItem{
 		Key:          "queryNode.grouping.maxNQ",
 		Version:      "2.0.0",
-		DefaultValue: "1000",
+		DefaultValue: "16",
 		Export:       true,
 	}
 	p.MaxGroupNQ.Init(base.mgr)
+
+	p.NQMergeRatio = ParamItem{
+		Key:          "queryNode.grouping.nqMergeRatio",
+		Version:      "2.6.17",
+		DefaultValue: "3.0",
+		Doc:          "Maximum ratio between merged total NQ and the smaller task NQ when grouping query node read tasks.",
+		Export:       true,
+	}
+	p.NQMergeRatio.Init(base.mgr)
 
 	p.TopKMergeRatio = ParamItem{
 		Key:          "queryNode.grouping.topKMergeRatio",
@@ -4643,7 +4659,7 @@ user-task-polling:
 	Scheduling is fair on task granularity.
 	The policy is based on the username for authentication.
 	And an empty username is considered the same user.
-	When there are no multi-users, the policy decay into FIFO"`,
+	When there are no multi-users, the policy decay into FIFO.`,
 		Export: true,
 	}
 	p.SchedulePolicyName.Init(base.mgr)
@@ -4655,6 +4671,15 @@ user-task-polling:
 		Export:       true,
 	}
 	p.SchedulePolicyTaskQueueExpire.Init(base.mgr)
+	p.SchedulePolicyTaskDeadlineAdvance = ParamItem{
+		Key:          "queryNode.scheduler.scheduleReadPolicy.taskDeadlineAdvance",
+		Version:      "2.6.17",
+		DefaultValue: "50ms",
+		Doc:          "Advance duration for cleaning queued query node read tasks before their context deadline. It supports duration strings such as 50ms and 1s. A bare number is interpreted as milliseconds for compatibility.",
+		Formatter:    formatDurationWithMillisecondFallback,
+		Export:       true,
+	}
+	p.SchedulePolicyTaskDeadlineAdvance.Init(base.mgr)
 	p.SchedulePolicyEnableCrossUserGrouping = ParamItem{
 		Key:          "queryNode.scheduler.scheduleReadPolicy.enableCrossUserGrouping",
 		Version:      "2.3.0",
@@ -4671,7 +4696,6 @@ user-task-polling:
 		Export:       true,
 	}
 	p.SchedulePolicyMaxPendingTaskPerUser.Init(base.mgr)
-
 	p.CGOPoolSizeRatio = ParamItem{
 		Key:          "queryNode.segcore.cgoPoolSizeRatio",
 		Version:      "2.3.0",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4399,7 +4399,7 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 	p.MaxUnsolvedQueueSize = ParamItem{
 		Key:          "queryNode.scheduler.unsolvedQueueSize",
 		Version:      "2.0.0",
-		DefaultValue: "4096",
+		DefaultValue: "1024",
 		Export:       true,
 	}
 	p.MaxUnsolvedQueueSize.Init(base.mgr)

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -889,6 +889,15 @@ func TestForbiddenItem(t *testing.T) {
 	assert.Equal(t, "by-dev", params.CommonCfg.ClusterPrefix.GetValue())
 }
 
+func TestFormatDurationWithMillisecondFallback(t *testing.T) {
+	assert.Equal(t, "", formatDurationWithMillisecondFallback(""))
+	assert.Equal(t, "", formatDurationWithMillisecondFallback("  "))
+	assert.Equal(t, "100ms", formatDurationWithMillisecondFallback("100"))
+	assert.Equal(t, "1.5ms", formatDurationWithMillisecondFallback("1.5"))
+	assert.Equal(t, "2s", formatDurationWithMillisecondFallback("2s"))
+	assert.Equal(t, "invalid", formatDurationWithMillisecondFallback("invalid"))
+}
+
 func TestCachedParam(t *testing.T) {
 	Init()
 	params := Get()

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -460,8 +460,16 @@ func TestComponentParam(t *testing.T) {
 		nprobe := Params.InterimIndexNProbe.GetAsInt64()
 		assert.Equal(t, int64(16), nprobe)
 
-		assert.Equal(t, int32(10240), Params.MaxReceiveChanSize.GetAsInt32())
-		assert.Equal(t, int32(10240), Params.MaxUnsolvedQueueSize.GetAsInt32())
+		assert.Equal(t, int32(1024), Params.MaxUnsolvedQueueSize.GetAsInt32())
+		assert.Equal(t, int64(16), Params.MaxGroupNQ.GetAsInt64())
+		assert.Equal(t, 3.0, Params.NQMergeRatio.GetAsFloat())
+		assert.Equal(t, "fifo", Params.SchedulePolicyName.GetValue())
+		assert.Equal(t, 50*time.Millisecond, Params.SchedulePolicyTaskDeadlineAdvance.GetAsDurationByParse())
+		defer params.Reset(Params.SchedulePolicyTaskDeadlineAdvance.Key)
+		assert.NoError(t, params.Save(Params.SchedulePolicyTaskDeadlineAdvance.Key, "100ms"))
+		assert.Equal(t, 100*time.Millisecond, Params.SchedulePolicyTaskDeadlineAdvance.GetAsDurationByParse())
+		assert.NoError(t, params.Save(Params.SchedulePolicyTaskDeadlineAdvance.Key, "100"))
+		assert.Equal(t, 100*time.Millisecond, Params.SchedulePolicyTaskDeadlineAdvance.GetAsDurationByParse())
 		assert.Equal(t, 10.0, Params.CPURatio.GetAsFloat())
 		assert.Equal(t, uint32(hardware.GetCPUNum()), Params.KnowhereThreadPoolSize.GetAsUint32())
 

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -462,6 +462,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, int64(16), nprobe)
 
 		assert.Equal(t, int32(1024), Params.MaxUnsolvedQueueSize.GetAsInt32())
+		assert.Equal(t, "1024", Params.MaxUnsolvedQueueSize.DefaultValue)
 		assert.Equal(t, int64(16), Params.MaxGroupNQ.GetAsInt64())
 		assert.Equal(t, 3.0, Params.NQMergeRatio.GetAsFloat())
 		assert.Equal(t, "fifo", Params.SchedulePolicyName.GetValue())

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -218,7 +218,7 @@ func TestComponentParam(t *testing.T) {
 		t.Logf("MaxDimension: %d", Params.MaxDimension.GetAsInt64())
 
 		t.Logf("MaxTaskNum: %d", Params.MaxTaskNum.GetAsInt64())
-		assert.Equal(t, int64(256), Params.MaxTaskNum.GetAsInt64())
+		assert.Equal(t, int64(1024), Params.MaxTaskNum.GetAsInt64())
 
 		t.Logf("AccessLog.Enable: %t", Params.AccessLog.Enable.GetAsBool())
 
@@ -465,6 +465,12 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, "1024", Params.MaxUnsolvedQueueSize.DefaultValue)
 		assert.Equal(t, int64(16), Params.MaxGroupNQ.GetAsInt64())
 		assert.Equal(t, 3.0, Params.NQMergeRatio.GetAsFloat())
+		assert.Equal(t, 50*time.Millisecond, Params.MaxDeadlineMergeGap.GetAsDurationByParse())
+		defer params.Reset(Params.MaxDeadlineMergeGap.Key)
+		assert.NoError(t, params.Save(Params.MaxDeadlineMergeGap.Key, "100ms"))
+		assert.Equal(t, 100*time.Millisecond, Params.MaxDeadlineMergeGap.GetAsDurationByParse())
+		assert.NoError(t, params.Save(Params.MaxDeadlineMergeGap.Key, "100"))
+		assert.Equal(t, 100*time.Millisecond, Params.MaxDeadlineMergeGap.GetAsDurationByParse())
 		assert.Equal(t, "fifo", Params.SchedulePolicyName.GetValue())
 		assert.Equal(t, 50*time.Millisecond, Params.SchedulePolicyTaskDeadlineAdvance.GetAsDurationByParse())
 		defer params.Reset(Params.SchedulePolicyTaskDeadlineAdvance.Key)

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -218,6 +218,7 @@ func TestComponentParam(t *testing.T) {
 		t.Logf("MaxDimension: %d", Params.MaxDimension.GetAsInt64())
 
 		t.Logf("MaxTaskNum: %d", Params.MaxTaskNum.GetAsInt64())
+		assert.Equal(t, int64(256), Params.MaxTaskNum.GetAsInt64())
 
 		t.Logf("AccessLog.Enable: %t", Params.AccessLog.Enable.GetAsBool())
 


### PR DESCRIPTION
issue: #49707

- query node scheduler: make read tasks context-aware, use an unbuffered add path, and cleanup canceled or near-deadline queued tasks before queue limit checks
- query grouping: cap grouped NQ at 16 and add an NQ merge ratio guard to avoid merging small queries into much larger groups
- REST timeout: propagate request timeout as a context deadline so downstream query tasks receive timeout timestamps
- scheduler metrics: add ready NQ plus queue and execution duration metrics while removing obsolete receive queue configuration
- proxy config: reduce the proxy task queue default to 256