### PR TITLE
fix: move L0 V3 manifest commit to datacoord

### DIFF
--- a/internal/datacoord/compaction_task_backfill.go
+++ b/internal/datacoord/compaction_task_backfill.go
@@ -31,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
@@ -361,6 +362,9 @@ func (t *backfillCompactionTask) saveSegmentMeta(result *datapb.CompactionPlanRe
 	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()),
 		zap.Int64("PlanID", t.GetTaskProto().GetPlanID()),
 		zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	if err := binlog.CompressCompactionBinlogs(result.GetSegments()); err != nil {
+		return err
+	}
 	newSegments, metricMutation, err := t.meta.CompleteCompactionMutation(context.TODO(), t.GetTaskProto(), result)
 	if err != nil {
 		return err

--- a/internal/datacoord/compaction_task_clustering.go
+++ b/internal/datacoord/compaction_task_clustering.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	globalTask "github.com/milvus-io/milvus/internal/datacoord/task"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
@@ -186,6 +187,11 @@ func (t *clusteringCompactionTask) QueryTaskOnWorker(cluster session.Cluster) {
 		err = t.meta.ValidateSegmentStateBeforeCompleteCompactionMutation(t.GetTaskProto())
 		if err != nil {
 			t.updateAndSaveTaskMeta(setState(datapb.CompactionTaskState_failed), setFailReason(err.Error()))
+			return
+		}
+
+		if err = binlog.CompressCompactionBinlogs(result.GetSegments()); err != nil {
+			log.Warn("compress compaction result binlogs failed", zap.Error(err))
 			return
 		}
 

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
@@ -502,8 +503,28 @@ func buildL0V3DeltaLogEntries(segmentID int64, deltalogs []*datapb.FieldBinlog) 
 	return entries, nil
 }
 
+func compressL0CompactionBinlogs(outputSegs []*datapb.CompactionSegment) error {
+	for _, seg := range outputSegs {
+		if seg.GetManifest() == "" {
+			if err := binlog.CompressCompactionBinlogs([]*datapb.CompactionSegment{seg}); err != nil {
+				return err
+			}
+			continue
+		}
+		for _, fieldBinlog := range seg.GetDeltalogs() {
+			for _, binlog := range fieldBinlog.GetBinlogs() {
+				binlog.LogPath = ""
+			}
+		}
+	}
+	return nil
+}
+
 func (t *l0CompactionTask) saveSegmentMeta(outputSegs []*datapb.CompactionSegment) error {
 	if err := t.commitV3ManifestDeltas(context.TODO(), outputSegs); err != nil {
+		return err
+	}
+	if err := compressL0CompactionBinlogs(outputSegs); err != nil {
 		return err
 	}
 

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -46,7 +47,8 @@ type l0CompactionTask struct {
 	allocator allocator.Allocator
 	meta      CompactionMeta
 
-	times *taskcommon.Times
+	times                *taskcommon.Times
+	committedV3Manifests map[int64]string
 }
 
 func (t *l0CompactionTask) GetTaskID() int64 {
@@ -218,9 +220,10 @@ func (t *l0CompactionTask) GetTaskProto() *datapb.CompactionTask {
 
 func newL0CompactionTask(t *datapb.CompactionTask, allocator allocator.Allocator, meta CompactionMeta) *l0CompactionTask {
 	task := &l0CompactionTask{
-		allocator: allocator,
-		meta:      meta,
-		times:     taskcommon.NewTimes(),
+		allocator:            allocator,
+		meta:                 meta,
+		times:                taskcommon.NewTimes(),
+		committedV3Manifests: make(map[int64]string),
 	}
 	task.taskProto.Store(t)
 	return task
@@ -444,7 +447,66 @@ func (t *l0CompactionTask) saveTaskMeta(task *datapb.CompactionTask) error {
 	return t.meta.SaveCompactionTask(context.TODO(), task)
 }
 
+func (t *l0CompactionTask) commitV3ManifestDeltas(ctx context.Context, outputSegs []*datapb.CompactionSegment) error {
+	if t.committedV3Manifests == nil {
+		t.committedV3Manifests = make(map[int64]string)
+	}
+	for _, seg := range outputSegs {
+		if seg.GetManifest() != "" {
+			t.committedV3Manifests[seg.GetSegmentID()] = seg.GetManifest()
+			continue
+		}
+
+		if manifest, ok := t.committedV3Manifests[seg.GetSegmentID()]; ok {
+			seg.Manifest = manifest
+			continue
+		}
+
+		target := t.meta.GetSegment(ctx, seg.GetSegmentID())
+		if target == nil || target.GetManifestPath() == "" {
+			continue
+		}
+
+		entries, err := buildL0V3DeltaLogEntries(seg.GetSegmentID(), seg.GetDeltalogs())
+		if err != nil {
+			return err
+		}
+		if len(entries) == 0 {
+			continue
+		}
+
+		newManifest, err := packed.AddDeltaLogsToManifestOverwrite(target.GetManifestPath(), compaction.CreateStorageConfig(), entries)
+		if err != nil {
+			return err
+		}
+		seg.Manifest = newManifest
+		t.committedV3Manifests[seg.GetSegmentID()] = newManifest
+	}
+	return nil
+}
+
+func buildL0V3DeltaLogEntries(segmentID int64, deltalogs []*datapb.FieldBinlog) ([]packed.DeltaLogEntry, error) {
+	entries := make([]packed.DeltaLogEntry, 0)
+	for _, fieldBinlog := range deltalogs {
+		for _, binlog := range fieldBinlog.GetBinlogs() {
+			path := binlog.GetLogPath()
+			if path == "" {
+				return nil, merr.WrapErrServiceInternal(fmt.Sprintf("L0 V3 compaction result missing deltalog path for segment %d, logID %d", segmentID, binlog.GetLogID()))
+			}
+			entries = append(entries, packed.DeltaLogEntry{
+				Path:       path,
+				NumEntries: binlog.GetEntriesNum(),
+			})
+		}
+	}
+	return entries, nil
+}
+
 func (t *l0CompactionTask) saveSegmentMeta(outputSegs []*datapb.CompactionSegment) error {
+	if err := t.commitV3ManifestDeltas(context.TODO(), outputSegs); err != nil {
+		return err
+	}
+
 	var operators []UpdateOperator
 	for _, seg := range outputSegs {
 		if seg.GetManifest() != "" {

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
@@ -29,7 +30,10 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -53,6 +57,140 @@ func (s *L0CompactionTaskSuite) SetupTest() {
 
 func (s *L0CompactionTaskSuite) SetupSubTest() {
 	s.SetupTest()
+}
+
+func (s *L0CompactionTaskSuite) TestCommitV3ManifestDeltasOnDataCoord() {
+	basePath := "/tmp/milvus/insert_log/1/10/200"
+	actualDeltaPath := "/tmp/milvus/insert_log/1/10/200/_delta/not-log-id-suffix"
+	oldManifest := packed.MarshalManifestPath(basePath, 7)
+	newManifest := packed.MarshalManifestPath(basePath, 8)
+
+	task := s.generateTestL0Task(datapb.CompactionTaskState_executing)
+	seg := &datapb.CompactionSegment{
+		SegmentID: 200,
+		Deltalogs: []*datapb.FieldBinlog{{
+			Binlogs: []*datapb.Binlog{{
+				LogID:      9001,
+				LogPath:    actualDeltaPath,
+				EntriesNum: 3,
+				MemorySize: 128,
+			}},
+		}},
+	}
+
+	s.mockMeta.EXPECT().GetSegment(mock.Anything, int64(200)).Return(&SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             200,
+			StorageVersion: storage.StorageV3,
+			ManifestPath:   oldManifest,
+		},
+	}).Once()
+
+	patch := mockey.Mock(packed.AddDeltaLogsToManifestOverwrite).To(
+		func(manifestPath string, storageConfig *indexpb.StorageConfig, deltaLogs []packed.DeltaLogEntry) (string, error) {
+			s.Equal(oldManifest, manifestPath)
+			s.NotNil(storageConfig)
+			s.Require().Len(deltaLogs, 1)
+			s.Equal(actualDeltaPath, deltaLogs[0].Path)
+			s.EqualValues(3, deltaLogs[0].NumEntries)
+			return newManifest, nil
+		},
+	).Build()
+	defer patch.UnPatch()
+
+	err := task.commitV3ManifestDeltas(context.Background(), []*datapb.CompactionSegment{seg})
+	s.NoError(err)
+	s.Equal(newManifest, seg.GetManifest())
+}
+
+func (s *L0CompactionTaskSuite) TestCommitV3ManifestDeltasRequiresLogPath() {
+	basePath := "/tmp/milvus/insert_log/1/10/200"
+	oldManifest := packed.MarshalManifestPath(basePath, 7)
+	task := s.generateTestL0Task(datapb.CompactionTaskState_executing)
+	seg := &datapb.CompactionSegment{
+		SegmentID: 200,
+		Deltalogs: []*datapb.FieldBinlog{{
+			Binlogs: []*datapb.Binlog{{LogID: 9001, EntriesNum: 3}},
+		}},
+	}
+
+	s.mockMeta.EXPECT().GetSegment(mock.Anything, int64(200)).Return(&SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{ID: 200, StorageVersion: storage.StorageV3, ManifestPath: oldManifest},
+	}).Once()
+
+	err := task.commitV3ManifestDeltas(context.Background(), []*datapb.CompactionSegment{seg})
+	s.Error(err)
+	s.Contains(err.Error(), "missing deltalog path")
+}
+
+func (s *L0CompactionTaskSuite) TestCommitV3ManifestDeltasReusesCachedManifest() {
+	basePath := "/tmp/milvus/insert_log/1/10/200"
+	actualDeltaPath := "/tmp/milvus/insert_log/1/10/200/_delta/not-log-id-suffix"
+	oldManifest := packed.MarshalManifestPath(basePath, 7)
+	newManifest := packed.MarshalManifestPath(basePath, 8)
+
+	task := s.generateTestL0Task(datapb.CompactionTaskState_executing)
+
+	s.mockMeta.EXPECT().GetSegment(mock.Anything, int64(200)).Return(&SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{ID: 200, StorageVersion: storage.StorageV3, ManifestPath: oldManifest},
+	}).Once()
+
+	calls := 0
+	patch := mockey.Mock(packed.AddDeltaLogsToManifestOverwrite).To(
+		func(manifestPath string, storageConfig *indexpb.StorageConfig, deltaLogs []packed.DeltaLogEntry) (string, error) {
+			calls++
+			return newManifest, nil
+		},
+	).Build()
+	defer patch.UnPatch()
+
+	first := &datapb.CompactionSegment{SegmentID: 200, Deltalogs: []*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{LogID: 9001, LogPath: actualDeltaPath, EntriesNum: 3}}}}}
+	second := &datapb.CompactionSegment{SegmentID: 200, Deltalogs: []*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{LogID: 9001, LogPath: actualDeltaPath, EntriesNum: 3}}}}}
+
+	s.NoError(task.commitV3ManifestDeltas(context.Background(), []*datapb.CompactionSegment{first}))
+	s.NoError(task.commitV3ManifestDeltas(context.Background(), []*datapb.CompactionSegment{second}))
+
+	s.Equal(1, calls)
+	s.Equal(newManifest, first.GetManifest())
+	s.Equal(newManifest, second.GetManifest())
+}
+
+func (s *L0CompactionTaskSuite) TestSaveSegmentMetaCommitsManifestBeforeMetaUpdate() {
+	basePath := "/tmp/milvus/insert_log/1/10/200"
+	actualDeltaPath := "/tmp/milvus/insert_log/1/10/200/_delta/not-log-id-suffix"
+	oldManifest := packed.MarshalManifestPath(basePath, 1)
+	newManifest := packed.MarshalManifestPath(basePath, 2)
+
+	task := s.generateTestL0Task(datapb.CompactionTaskState_executing)
+	output := []*datapb.CompactionSegment{{
+		SegmentID: 200,
+		Deltalogs: []*datapb.FieldBinlog{{
+			Binlogs: []*datapb.Binlog{{LogID: 9001, LogPath: actualDeltaPath, EntriesNum: 3}},
+		}},
+	}}
+
+	s.mockMeta.EXPECT().GetSegment(mock.Anything, int64(200)).Return(&SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{ID: 200, StorageVersion: storage.StorageV3, ManifestPath: oldManifest},
+	}).Once()
+
+	patch := mockey.Mock(packed.AddDeltaLogsToManifestOverwrite).To(
+		func(manifestPath string, storageConfig *indexpb.StorageConfig, deltaLogs []packed.DeltaLogEntry) (string, error) {
+			s.Require().Len(deltaLogs, 1)
+			s.Equal(actualDeltaPath, deltaLogs[0].Path)
+			return newManifest, nil
+		},
+	).Build()
+	defer patch.UnPatch()
+
+	s.mockMeta.EXPECT().UpdateSegmentsInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, operators ...UpdateOperator) error {
+			s.Equal(newManifest, output[0].GetManifest())
+			s.Len(operators, 6)
+			return nil
+		},
+	).Once()
+
+	s.NoError(task.saveSegmentMeta(output))
 }
 
 func (s *L0CompactionTaskSuite) TestProcessRefreshPlan_NormalL0() {

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -185,6 +185,8 @@ func (s *L0CompactionTaskSuite) TestSaveSegmentMetaCommitsManifestBeforeMetaUpda
 	s.mockMeta.EXPECT().UpdateSegmentsInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, operators ...UpdateOperator) error {
 			s.Equal(newManifest, output[0].GetManifest())
+			s.Empty(output[0].GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
+			s.EqualValues(9001, output[0].GetDeltalogs()[0].GetBinlogs()[0].GetLogID())
 			s.Len(operators, 6)
 			return nil
 		},

--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -234,6 +235,9 @@ func (t *mixCompactionTask) SaveTaskMeta() error {
 
 func (t *mixCompactionTask) saveSegmentMeta(result *datapb.CompactionPlanResult) error {
 	log := log.With(zap.Int64("triggerID", t.GetTaskProto().GetTriggerID()), zap.Int64("PlanID", t.GetTaskProto().GetPlanID()), zap.Int64("collectionID", t.GetTaskProto().GetCollectionID()))
+	if err := binlog.CompressCompactionBinlogs(result.GetSegments()); err != nil {
+		return err
+	}
 	// Also prepare metric updates.
 	newSegments, metricMutation, err := t.meta.CompleteCompactionMutation(context.TODO(), t.taskProto.Load().(*datapb.CompactionTask), result)
 	if err != nil {

--- a/internal/datacoord/session/cluster.go
+++ b/internal/datacoord/session/cluster.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
-	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
@@ -245,10 +244,6 @@ func (c *cluster) QueryCompaction(nodeID int64, in *datapb.CompactionStateReques
 		for _, rst := range result.GetResults() {
 			if rst.GetPlanID() != in.GetPlanID() {
 				continue
-			}
-			err = binlog.CompressCompactionBinlogs(rst.GetSegments())
-			if err != nil {
-				return nil, err
 			}
 			ret = rst
 			break

--- a/internal/datacoord/session/cluster_test.go
+++ b/internal/datacoord/session/cluster_test.go
@@ -218,6 +218,9 @@ func TestCluster_Compaction(t *testing.T) {
 					Segments: []*datapb.CompactionSegment{
 						{
 							SegmentID: 1,
+							Deltalogs: []*datapb.FieldBinlog{{
+								Binlogs: []*datapb.Binlog{{LogID: 10, LogPath: "files/insert_log/1/2/3/_delta/not-log-id-suffix"}},
+							}},
 						},
 					},
 				},
@@ -237,6 +240,7 @@ func TestCluster_Compaction(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 		assert.Equal(t, int64(1), result.PlanID)
+		assert.Equal(t, "files/insert_log/1/2/3/_delta/not-log-id-suffix", result.GetSegments()[0].GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
 	})
 
 	t.Run("drop compaction", func(t *testing.T) {

--- a/internal/datanode/compactor/l0_compactor.go
+++ b/internal/datanode/compactor/l0_compactor.go
@@ -307,27 +307,17 @@ func (t *LevelZeroCompactionTask) splitAndWrite(
 
 			log.Info("L0 compaction write record success", zap.String("path", path), zap.Int64("entries", int64(len(deletes.pks))))
 
-			// Check if this is a V2 segment (has manifest)
+			// Check if this is a manifest segment
 			if segment.GetManifest() != "" {
-				// V2: Update manifest with new deltalog
-				newManifest, err := packed.AddDeltaLogsToManifestOverwrite(
-					segment.GetManifest(),
-					t.compactionParams.StorageConfig,
-					[]packed.DeltaLogEntry{{Path: path, NumEntries: int64(len(deletes.pks))}},
-				)
-				if err != nil {
-					log.Warn("L0 compaction update manifest fail", zap.Int64("segmentID", segmentID), zap.Error(err))
-					return nil, err
-				}
 				return &datapb.CompactionSegment{
 					SegmentID: segmentID,
 					Channel:   t.plan.GetChannel(),
-					Manifest:  newManifest,
 					NumOfRows: int64(len(deletes.pks)),
-					// Delta summary for compaction trigger decisions (no path, only stats)
+					// Delta summary for compaction trigger decisions and datacoord manifest commit.
 					Deltalogs: []*datapb.FieldBinlog{{
 						Binlogs: []*datapb.Binlog{{
 							LogID:      logID,
+							LogPath:    path,
 							EntriesNum: int64(len(deletes.pks)),
 							MemorySize: int64(writer.GetWrittenUncompressed()),
 						}},

--- a/internal/datanode/compactor/l0_compactor_test.go
+++ b/internal/datanode/compactor/l0_compactor_test.go
@@ -18,8 +18,10 @@ package compactor
 
 import (
 	"context"
+	"path"
 	"testing"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
@@ -33,9 +35,11 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/mocks/flushcommon/mock_util"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -52,6 +56,20 @@ type LevelZeroCompactionTaskSuite struct {
 	task         *LevelZeroCompactionTask
 
 	dData *storage.DeleteData
+}
+
+type l0TestRecordWriter struct{}
+
+func (w *l0TestRecordWriter) Write(storage.Record) error {
+	return nil
+}
+
+func (w *l0TestRecordWriter) GetWrittenUncompressed() uint64 {
+	return 128
+}
+
+func (w *l0TestRecordWriter) Close() error {
+	return nil
 }
 
 func (s *LevelZeroCompactionTaskSuite) SetupTest() {
@@ -524,6 +542,47 @@ func (s *LevelZeroCompactionTaskSuite) TestSplitAndWrite() {
 
 	// Segment 102 should have PK 3 with its timestamp
 	assertDeltalog(102, []int64{3}, []uint64{20002})
+}
+
+func (s *LevelZeroCompactionTaskSuite) TestSplitAndWriteV3ReturnsDeltaSummaryWithoutManifestCommit() {
+	basePath := path.Join(s.T().TempDir(), "insert_log/1/10/100")
+	oldManifest := packed.MarshalManifestPath(basePath, 7)
+
+	s.task.plan.SegmentBinlogs = []*datapb.CompactionSegmentBinlogs{{
+		SegmentID:    100,
+		CollectionID: 1,
+		PartitionID:  10,
+		Level:        datapb.SegmentLevel_L1,
+		Manifest:     oldManifest,
+	}}
+
+	bf := pkoracle.NewBloomFilterSetWithBatchSize(100)
+	bf.UpdatePKRange(&storage.Int64FieldData{Data: []int64{1, 3}})
+
+	patchWriter := mockey.Mock(storage.NewDeltalogWriter).To(
+		func(ctx context.Context, collectionID, partitionID, segmentID, logID typeutil.UniqueID, pkType schemapb.DataType, deltalogPath string, option ...storage.RwOption) (storage.RecordWriter, error) {
+			s.Equal(path.Join(basePath, "_delta", "200"), deltalogPath)
+			return &l0TestRecordWriter{}, nil
+		},
+	).Build()
+	defer patchWriter.UnPatch()
+
+	patchManifest := mockey.Mock(packed.AddDeltaLogsToManifestOverwrite).To(
+		func(manifestPath string, storageConfig *indexpb.StorageConfig, deltaLogs []packed.DeltaLogEntry) (string, error) {
+			return "", errors.New("DataNode must not commit V3 L0 manifest")
+		},
+	).Build()
+	defer patchManifest.UnPatch()
+
+	segments, err := s.task.splitAndWrite(context.Background(), s.dData, map[int64]*pkoracle.BloomFilterSet{100: bf})
+	s.NoError(err)
+	s.Require().Len(segments, 1)
+	s.Empty(segments[0].GetManifest())
+	s.Require().Len(segments[0].GetDeltalogs(), 1)
+	s.Require().Len(segments[0].GetDeltalogs()[0].GetBinlogs(), 1)
+	s.NotZero(segments[0].GetDeltalogs()[0].GetBinlogs()[0].GetLogID())
+	s.EqualValues(2, segments[0].GetDeltalogs()[0].GetBinlogs()[0].GetEntriesNum())
+	s.Equal(path.Join(basePath, "_delta", "200"), segments[0].GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
 }
 
 func (s *LevelZeroCompactionTaskSuite) TestLoadBF() {


### PR DESCRIPTION
Related to #49706

Transfer storage v3 L0 compaction manifest transaction commit from DataNode to DataCoord so the metadata owner commits deltalogs against the latest segment manifest. DataNode now returns the actual written deltalog path in the compaction result, and DataCoord uses that path to update the manifest before saving segment meta.