### PR TITLE
test: stabilize nightly Python client negative cases

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -3050,9 +3050,8 @@ class TestMilvusClientLoadCollectionInvalid(TestMilvusClientV2Base):
         self.create_index(client, collection_name, index_params)
         # 5. Load with replica_number=3 (should fail if only 2 querynodes available)
         error = {
-            ct.err_code: 999,
-            ct.err_msg: "call query coordinator LoadCollection: when load 3 replica count: "
-            "service resource insufficient[currentStreamingNode=2][expectedStreamingNode=3]",
+            ct.err_code: 65535,
+            ct.err_msg: "when load 3 replica count: service resource insufficient",
         }
         self.load_collection(
             client, collection_name, replica_number=3, check_task=CheckTasks.err_res, check_items=error

--- a/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
@@ -452,9 +452,8 @@ class TestMilvusClientSearchIteratorInValid(TestMilvusClientV2Base):
                                  check_task=CheckTasks.check_describe_collection_property,
                                  check_items={"collection_name": collection_name,
                                               "dim": default_dim,
-                                              "consistency_level": 2})
-        partitions = self.list_partitions(client, collection_name)[0]
-        assert partition_name in partitions
+                                              "consistency_level": 2,
+                                              "num_partitions": 2})
         # 2. insert
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(cf.gen_vectors(1, default_dim)[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]

--- a/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_iterator.py
@@ -452,8 +452,9 @@ class TestMilvusClientSearchIteratorInValid(TestMilvusClientV2Base):
                                  check_task=CheckTasks.check_describe_collection_property,
                                  check_items={"collection_name": collection_name,
                                               "dim": default_dim,
-                                              "consistency_level": 2,
-                                              "num_partitions": 2})
+                                              "consistency_level": 2})
+        partitions = self.list_partitions(client, collection_name)[0]
+        assert partition_name in partitions
         # 2. insert
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(cf.gen_vectors(1, default_dim)[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -4421,8 +4421,9 @@ class TestMilvusClientStructArrayInvalid(TestMilvusClientV2Base):
             max_capacity=100,
         )
         error = {
-            ct.err_code: 999,
-            ct.err_msg: f"nullable is not supported for fields in struct array now, fieldName = {nullable_field}",
+            ct.err_code: 1100,
+            ct.err_msg: f"sub-field in non-nullable struct cannot be nullable individually, "
+            f"set nullable on the struct instead: structName=clips, subFieldName={nullable_field}",
         }
         self.create_collection(
             client,


### PR DESCRIPTION
issue: #49780
issue: #49781
issue: #49782

## Summary

- Update struct array nullable sub-field negative assertions to match the current 1100 invalid-parameter error.
- Relax load replica resource-insufficient assertion so it does not depend on exact streaming node count or stack-trace text.
- Verify search iterator invalid partition-name precondition with `list_partitions()` instead of `describe_collection().num_partitions`.

## Test plan

- [x] `CI_LOG_PATH=/Users/zilliz/workloads/claude/search-iterator-invalid-partition/ci_logs /Users/zilliz/virtual-environment/master/bin/python -m pytest milvus_client/test_milvus_client_search_iterator.py::TestMilvusClientSearchIteratorInValid::test_milvus_client_search_iterator_with_invalid_partition_name --host 10.104.15.195 -s -v --tb=long`
- [x] `CI_LOG_PATH=/Users/zilliz/workloads/claude/load-replica-greater-than-querynodes/ci_logs /Users/zilliz/virtual-environment/master/bin/python -m pytest milvus_client/test_milvus_client_collection.py::TestMilvusClientLoadCollectionInvalid::test_milvus_client_load_replica_greater_than_querynodes --host 10.104.15.195 -s -v --tb=long`
- [x] `CI_LOG_PATH=/Users/zilliz/workloads/claude/struct-array-nullable-field/ci_logs /Users/zilliz/virtual-environment/master/bin/python -m pytest milvus_client/test_milvus_client_struct_array.py::TestMilvusClientStructArrayInvalid::test_struct_array_with_nullable_field --host 10.104.15.195 -s -v --tb=long`

🤖 Generated with [Claude Code](https://claude.com/claude-code)