### PR TITLE
fix: [2.6] use scalar index v3 as the default scalar index version

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -112,7 +112,7 @@ const (
 	// - HYBRID/AUTOINDEX high-cardinality scalar indexes switched from
 	//   INVERTED to STL_SORT
 	MinimalScalarIndexEngineVersion = int32(0)
-	CurrentScalarIndexEngineVersion = int32(2)
+	CurrentScalarIndexEngineVersion = int32(3)
 	MaximumScalarIndexEngineVersion = int32(3)
 )
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/47417
pr: https://github.com/milvus-io/milvus/pull/48552