### PR TITLE
fix: update minio docker healthcheck

### DIFF
--- a/deployments/docker/cluster-distributed-deployment/roles/deploy-minio/tasks/main.yml
+++ b/deployments/docker/cluster-distributed-deployment/roles/deploy-minio/tasks/main.yml
@@ -13,7 +13,7 @@
       - minio_volume:/data
     command: minio server /data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      test: ["CMD", "mc", "ready", "local"]
       interval: 30s
       timeout: 20s
       retries: 3

--- a/deployments/docker/dev/docker-compose-apple-silicon.yml
+++ b/deployments/docker/dev/docker-compose-apple-silicon.yml
@@ -45,7 +45,7 @@ services:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
     command: minio server /minio_data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "mc", "ready", "local"]
       interval: 30s
       timeout: 20s
       retries: 3

--- a/deployments/docker/dev/docker-compose.yml
+++ b/deployments/docker/dev/docker-compose.yml
@@ -52,9 +52,9 @@ services:
       test:
         [
           "CMD",
-          "curl",
-          "-f",
-          "http://localhost:9000/minio/health/live"
+          "mc",
+          "ready",
+          "local"
         ]
       interval: 30s
       timeout: 20s

--- a/deployments/docker/gpu/standalone/docker-compose.yml
+++ b/deployments/docker/gpu/standalone/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
     command: minio server /minio_data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "mc", "ready", "local"]
       interval: 30s
       timeout: 20s
       retries: 3

--- a/deployments/docker/standalone/docker-compose.yml
+++ b/deployments/docker/standalone/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
     command: minio server /minio_data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "mc", "ready", "local"]
       interval: 30s
       timeout: 20s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       MINIO_SECRET_KEY: minioadmin
     command: minio server /minio_data
     healthcheck:
-      test: [ 'CMD', 'curl', '-f', 'http://localhost:9000/minio/health/live' ]
+      test: [ 'CMD', 'mc', 'ready', 'local' ]
       interval: 30s
       timeout: 20s
       retries: 3


### PR DESCRIPTION
Current health check doesn't work.

Assisted by Codex.

https://github.com/minio/minio/issues/18389