### PR TITLE
enhance: standardize proxy error handling to merr

### DIFF
--- a/examples/telemetry_e2e_test/go.mod
+++ b/examples/telemetry_e2e_test/go.mod
@@ -1,10 +1,11 @@
 module github.com/milvus-io/milvus/examples/telemetry_e2e_test
+
 go 1.25.8
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c
 	github.com/milvus-io/milvus/client/v2 v2.6.4-0.20251104142533-a2ce70d25256
-	google.golang.org/grpc v1.71.0
+	google.golang.org/grpc v1.79.3
 )
 
 replace (

--- a/examples/telemetry_e2e_test/go.sum
+++ b/examples/telemetry_e2e_test/go.sum
@@ -1,2 +1,4 @@
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
@@ -131,10 +131,13 @@ async fn download_with_retry(
         for url in urls {
             match client.get(url).send().await {
                 Ok(resp) if resp.status().is_success() => {
-                    let content = resp
-                        .bytes()
-                        .await
-                        .map_err(|e| TantivyBindingError::InternalError(e.to_string()))?;
+                    let content = match resp.bytes().await {
+                        Ok(c) => c,
+                        Err(e) => {
+                            warn!("Failed to read body from {}: {}", url, e);
+                            continue;
+                        }
+                    };
 
                     // Calculate MD5 hash
                     let mut context = Context::new();

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -1129,6 +1129,18 @@ func Test_NewServer_TLS_FileNotExisted(t *testing.T) {
 	server.Stop()
 }
 
+// freeTCPPort grabs a random unused TCP port. The TLS HTTP-server tests
+// below hardcoded port 8080 originally, which collides with anything else
+// already bound to that port on the dev machine (e.g. the TEI text-embedding
+// container in our compose stack).
+func freeTCPPort(t *testing.T) string {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	assert.NoError(t, ln.Close())
+	return strconv.Itoa(port)
+}
+
 func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	server := getServer(t)
 
@@ -1149,7 +1161,7 @@ func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(Params.CaPemPath.Key, "../../../configs/cert/ca.pem")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	assert.Nil(t, err)
@@ -1183,7 +1195,7 @@ func Test_NewHTTPServer_TLS_OneWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../../../configs/cert/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	fmt.Printf("err: %v\n", err)
@@ -1242,7 +1254,7 @@ func Test_NewHTTPServer_TLS_FileNotExisted(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../not/existed/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 	err := runAndWaitForServerReady(server)
 	assert.NotNil(t, err)
 	server.Stop()

--- a/internal/proxy/accesslog/info/util.go
+++ b/internal/proxy/accesslog/info/util.go
@@ -19,10 +19,8 @@ package info
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc/metadata"
 
@@ -31,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/crypto"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 var ClusterPrefix atomic.String
@@ -38,20 +37,20 @@ var ClusterPrefix atomic.String
 func getCurUserFromContext(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", errors.New("fail to get md from the context")
+		return "", merr.WrapErrParameterInvalidMsg("fail to get md from the context")
 	}
 	authorization, ok := md[strings.ToLower(util.HeaderAuthorize)]
 	if !ok || len(authorization) < 1 {
-		return "", fmt.Errorf("fail to get authorization from the md, authorize:[%s]", util.HeaderAuthorize)
+		return "", merr.WrapErrParameterInvalidMsg("fail to get authorization from the md, authorize:[%s]", util.HeaderAuthorize)
 	}
 	token := authorization[0]
 	rawToken, err := crypto.Base64Decode(token)
 	if err != nil {
-		return "", fmt.Errorf("fail to decode the token, token: %s", token)
+		return "", merr.WrapErrParameterInvalidMsg("fail to decode the token, token: %s", token)
 	}
 	secrets := strings.SplitN(rawToken, util.CredentialSeparator, 2)
 	if len(secrets) < 2 {
-		return "", fmt.Errorf("fail to get user info from the raw token, raw token: %s", rawToken)
+		return "", merr.WrapErrParameterInvalidMsg("fail to get user info from the raw token, raw token: %s", rawToken)
 	}
 	username := secrets[0]
 	return username, nil

--- a/internal/proxy/accesslog/minio_handler.go
+++ b/internal/proxy/accesslog/minio_handler.go
@@ -18,7 +18,6 @@ package accesslog
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -30,6 +29,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 )
@@ -144,7 +144,7 @@ func newMinioClient(ctx context.Context, cfg config) (*minio.Client, error) {
 					return err
 				}
 			} else {
-				return fmt.Errorf("bucket %s not Existed", cfg.bucketName)
+				return merr.WrapErrParameterInvalidMsg("bucket %s not Existed", cfg.bucketName)
 			}
 		}
 		return nil

--- a/internal/proxy/accesslog/util.go
+++ b/internal/proxy/accesslog/util.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
 	"google.golang.org/grpc"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/hook"
 	"github.com/milvus-io/milvus/internal/proxy/accesslog/info"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type AccessKey struct{}
@@ -82,10 +82,10 @@ func join(path1, path2 string) string {
 
 func timeFromName(filename, prefix, ext string) (time.Time, error) {
 	if !strings.HasPrefix(filename, prefix) {
-		return time.Time{}, errors.New("mismatched prefix")
+		return time.Time{}, merr.WrapErrParameterInvalidMsg("mismatched prefix")
 	}
 	if !strings.HasSuffix(filename, ext) {
-		return time.Time{}, errors.New("mismatched extension")
+		return time.Time{}, merr.WrapErrParameterInvalidMsg("mismatched extension")
 	}
 	ts := filename[len(prefix) : len(filename)-len(ext)]
 	return time.Parse(timeNameFormat, ts)

--- a/internal/proxy/accesslog/writer.go
+++ b/internal/proxy/accesslog/writer.go
@@ -19,17 +19,16 @@ package accesslog
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"path"
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -79,7 +78,7 @@ func (l *CacheWriter) Write(p []byte) (n int, err error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.closed {
-		return 0, errors.New("write to closed writer")
+		return 0, merr.WrapErrParameterInvalidMsg("write to closed writer")
 	}
 
 	return l.writer.Write(p)
@@ -198,12 +197,12 @@ func (l *RotateWriter) Write(p []byte) (n int, err error) {
 	defer l.mu.Unlock()
 
 	if l.closed {
-		return 0, errors.New("write to closed writer")
+		return 0, merr.WrapErrParameterInvalidMsg("write to closed writer")
 	}
 
 	writeLen := int64(len(p))
 	if writeLen > l.max() {
-		return 0, fmt.Errorf(
+		return 0, merr.WrapErrParameterInvalidMsg(
 			"write length %d exceeds maximum file size %d", writeLen, l.max(),
 		)
 	}
@@ -270,7 +269,7 @@ func (l *RotateWriter) openFileExistingOrNew() error {
 		return l.openNewFile()
 	}
 	if err != nil {
-		return fmt.Errorf("file to get log file info: %s", err)
+		return merr.WrapErrParameterInvalidMsg("file to get log file info: %s", err)
 	}
 
 	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0o644)
@@ -286,7 +285,7 @@ func (l *RotateWriter) openFileExistingOrNew() error {
 func (l *RotateWriter) openNewFile() error {
 	err := os.MkdirAll(l.dir(), 0o744)
 	if err != nil {
-		return fmt.Errorf("make directories for new log file filed: %s", err)
+		return merr.WrapErrParameterInvalidMsg("make directories for new log file filed: %s", err)
 	}
 
 	name := l.filename()
@@ -296,7 +295,7 @@ func (l *RotateWriter) openNewFile() error {
 		mode = info.Mode()
 		newName := l.newBackupName()
 		if err := os.Rename(name, newName); err != nil {
-			return fmt.Errorf("can't rename log file: %s", err)
+			return merr.WrapErrParameterInvalidMsg("can't rename log file: %s", err)
 		}
 		log.Info("seal old log to: " + newName)
 		if l.handler != nil {
@@ -311,7 +310,7 @@ func (l *RotateWriter) openNewFile() error {
 
 	f, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {
-		return fmt.Errorf("can't open new logfile: %s", err)
+		return merr.WrapErrParameterInvalidMsg("can't open new logfile: %s", err)
 	}
 	l.file = f
 	l.size = 0
@@ -429,7 +428,7 @@ func (l *RotateWriter) newBackupName() string {
 func (l *RotateWriter) oldLogFiles() ([]logInfo, error) {
 	files, err := os.ReadDir(l.dir())
 	if err != nil {
-		return nil, fmt.Errorf("can't read log file directory: %s", err)
+		return nil, merr.WrapErrParameterInvalidMsg("can't read log file directory: %s", err)
 	}
 
 	logFiles := []logInfo{}

--- a/internal/proxy/agg_reducer.go
+++ b/internal/proxy/agg_reducer.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -42,7 +41,7 @@ func (reducer *MilvusAggReducer) Reduce(results []*internalpb.RetrieveResults) (
 	for i := 0; i < fieldCount; i++ {
 		indices := reducer.outputMap.IndexesAt(i)
 		if len(indices) == 0 {
-			return nil, fmt.Errorf("no indices found for output field at index %d", i)
+			return nil, merr.WrapErrParameterInvalidMsg("no indices found for output field at index %d", i)
 		} else if len(indices) == 1 {
 			// Single index: direct copy (non-avg aggregation or group-by field)
 			reOrganizedFieldDatas[i] = reducedFieldDatas[indices[0]]
@@ -53,12 +52,12 @@ func (reducer *MilvusAggReducer) Reduce(results []*internalpb.RetrieveResults) (
 			countFieldData := reducedFieldDatas[indices[1]]
 			avgFieldData, err := agg.ComputeAvgFromSumAndCount(sumFieldData, countFieldData)
 			if err != nil {
-				return nil, fmt.Errorf("failed to compute avg for field %s: %w", reducer.outputMap.NameAt(i), err)
+				return nil, merr.WrapErrParameterInvalidMsg("failed to compute avg for field %s: %v", reducer.outputMap.NameAt(i), err)
 			}
 			avgFieldData.FieldName = reducer.outputMap.NameAt(i)
 			reOrganizedFieldDatas[i] = avgFieldData
 		} else {
-			return nil, fmt.Errorf("unexpected number of indices (%d) for output field at index %d, expected 1 or 2", len(indices), i)
+			return nil, merr.WrapErrParameterInvalidMsg("unexpected number of indices (%d) for output field at index %d, expected 1 or 2", len(indices), i)
 		}
 	}
 	return &milvuspb.QueryResults{FieldsData: reOrganizedFieldDatas, Status: merr.Success()}, nil

--- a/internal/proxy/channels_mgr.go
+++ b/internal/proxy/channels_mgr.go
@@ -18,7 +18,6 @@ package proxy
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"sync"
 
@@ -67,7 +66,7 @@ func removeDuplicate(ss []string) []string {
 func newChannels(vchans []vChan, pchans []pChan) (channelInfos, error) {
 	if len(vchans) != len(pchans) {
 		log.Error("physical channels mismatch virtual channels", zap.Int("len(VirtualChannelNames)", len(vchans)), zap.Int("len(PhysicalChannelNames)", len(pchans)))
-		return channelInfos{}, fmt.Errorf("physical channels mismatch virtual channels, len(VirtualChannelNames): %v, len(PhysicalChannelNames): %v", len(vchans), len(pchans))
+		return channelInfos{}, merr.WrapErrParameterInvalidMsg("physical channels mismatch virtual channels, len(VirtualChannelNames): %v, len(PhysicalChannelNames): %v", len(vchans), len(pchans))
 	}
 	/*
 		// remove duplicate physical channels.
@@ -124,7 +123,7 @@ func (mgr *singleTypeChannelsMgr) getAllChannels(collectionID UniqueID) (channel
 		return infos.channelInfos, nil
 	}
 
-	return channelInfos{}, fmt.Errorf("collection not found in channels manager: %d", collectionID)
+	return channelInfos{}, merr.WrapErrParameterInvalidMsg("collection not found in channels manager: %d", collectionID)
 }
 
 func (mgr *singleTypeChannelsMgr) ensureChannels(collectionID UniqueID) (channelInfos, error) {

--- a/internal/proxy/connection/util.go
+++ b/internal/proxy/connection/util.go
@@ -2,10 +2,8 @@ package connection
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -13,6 +11,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func ZapClientInfo(info *commonpb.ClientInfo) []zap.Field {
@@ -34,15 +33,15 @@ func ZapClientInfo(info *commonpb.ClientInfo) []zap.Field {
 func GetIdentifierFromContext(ctx context.Context) (int64, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return 0, errors.New("fail to get metadata from the context")
+		return 0, merr.WrapErrParameterInvalidMsg("fail to get metadata from the context")
 	}
 	identifierContent, ok := md[util.IdentifierKey]
 	if !ok || len(identifierContent) < 1 {
-		return 0, errors.New("no identifier found in metadata")
+		return 0, merr.WrapErrParameterInvalidMsg("no identifier found in metadata")
 	}
 	identifier, err := strconv.ParseInt(identifierContent[0], 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse identifier: %s, error: %s", identifierContent[0], err.Error())
+		return 0, merr.WrapErrParameterInvalidMsg("failed to parse identifier: %s, error: %s", identifierContent[0], err.Error())
 	}
 	return identifier, nil
 }

--- a/internal/proxy/function_task.go
+++ b/internal/proxy/function_task.go
@@ -18,7 +18,6 @@ package proxy
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -85,11 +84,11 @@ func (t *addCollectionFunctionTask) Name() string {
 
 func (t *addCollectionFunctionTask) PreExecute(ctx context.Context) error {
 	if t.FunctionSchema == nil {
-		return fmt.Errorf("function schema is empty")
+		return merr.WrapErrParameterInvalidMsg("function schema is empty")
 	}
 
 	if t.FunctionSchema.Type == schemapb.FunctionType_BM25 {
-		return fmt.Errorf("currently does not support adding BM25 function")
+		return merr.WrapErrParameterInvalidMsg("currently does not support adding BM25 function")
 	}
 	coll, err := getCollectionInfo(ctx, t.GetDbName(), t.GetCollectionName())
 	if err != nil {
@@ -172,13 +171,13 @@ func (t *alterCollectionFunctionTask) Name() string {
 
 func (t *alterCollectionFunctionTask) PreExecute(ctx context.Context) error {
 	if t.FunctionSchema == nil {
-		return fmt.Errorf("function schema is empty")
+		return merr.WrapErrParameterInvalidMsg("function schema is empty")
 	}
 	if t.FunctionSchema.Type == schemapb.FunctionType_BM25 {
-		return fmt.Errorf("currently does not support alter BM25 function")
+		return merr.WrapErrParameterInvalidMsg("currently does not support alter BM25 function")
 	}
 	if t.FunctionName != t.FunctionSchema.Name {
-		return fmt.Errorf("invalid function config, name not match")
+		return merr.WrapErrParameterInvalidMsg("invalid function config, name not match")
 	}
 	coll, err := getCollectionInfo(ctx, t.GetDbName(), t.GetCollectionName())
 	if err != nil {
@@ -193,7 +192,7 @@ func (t *alterCollectionFunctionTask) PreExecute(ctx context.Context) error {
 	for _, fSchema := range coll.schema.Functions {
 		if t.FunctionName == fSchema.Name {
 			if fSchema.Type == schemapb.FunctionType_BM25 {
-				return fmt.Errorf("currently does not support alter BM25 function")
+				return merr.WrapErrParameterInvalidMsg("currently does not support alter BM25 function")
 			}
 			newFunctions = append(newFunctions, t.FunctionSchema)
 			funcExist = true
@@ -202,7 +201,7 @@ func (t *alterCollectionFunctionTask) PreExecute(ctx context.Context) error {
 		}
 	}
 	if !funcExist {
-		return fmt.Errorf("function %s not found", t.FunctionName)
+		return merr.WrapErrParameterInvalidMsg("function %s not found", t.FunctionName)
 	}
 
 	newColl := proto.Clone(coll.schema.CollectionSchema).(*schemapb.CollectionSchema)
@@ -303,7 +302,7 @@ func (t *dropCollectionFunctionTask) Execute(ctx context.Context) error {
 	}
 
 	if t.fSchema.Type == schemapb.FunctionType_BM25 {
-		return fmt.Errorf("currently does not support droping BM25 function")
+		return merr.WrapErrParameterInvalidMsg("currently does not support droping BM25 function")
 	}
 
 	var err error

--- a/internal/proxy/highlighter.go
+++ b/internal/proxy/highlighter.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"go.opentelemetry.io/otel/trace"
@@ -338,7 +337,7 @@ func (op *lexicalHighlightOperator) run(ctx context.Context, span trace.Span, in
 	for _, task := range req.GetTasks() {
 		textFieldDatas, ok := lo.Find(datas, func(data *schemapb.FieldData) bool { return data.FieldId == task.GetFieldId() })
 		if !ok {
-			return nil, errors.Errorf("get highlight failed, text field not in output field %s: %d", task.GetFieldName(), task.GetFieldId())
+			return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, text field not in output field %s: %d", task.GetFieldName(), task.GetFieldId())
 		}
 		texts := textFieldDatas.GetScalars().GetStringData().GetData()
 		task.Texts = append(task.Texts, texts...)
@@ -359,7 +358,7 @@ func (op *lexicalHighlightOperator) run(ctx context.Context, span trace.Span, in
 		if nameFieldID > 0 {
 			analyzerFieldDatas, ok := lo.Find(datas, func(data *schemapb.FieldData) bool { return data.FieldId == nameFieldID })
 			if !ok {
-				return nil, errors.Errorf("get highlight failed, analyzer name field: %d for multi analyzer not in output field", nameFieldID)
+				return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, analyzer name field: %d for multi analyzer not in output field", nameFieldID)
 			}
 			task.AnalyzerNames = append(task.AnalyzerNames, analyzerFieldDatas.GetScalars().GetStringData().GetData()...)
 		}
@@ -475,7 +474,7 @@ func (op *semanticHighlightOperator) run(ctx context.Context, span trace.Span, i
 	for _, fieldID := range op.highlight.FieldIDs() {
 		fieldDatas, ok := lo.Find(datas, func(data *schemapb.FieldData) bool { return data.FieldId == fieldID })
 		if !ok {
-			return nil, errors.Errorf("get highlight failed, text field not in output field %d", fieldID)
+			return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, text field not in output field %d", fieldID)
 		}
 		texts := fieldDatas.GetScalars().GetStringData().GetData()
 		fieldName := op.highlight.GetFieldName(fieldID)
@@ -495,17 +494,17 @@ func (op *semanticHighlightOperator) run(ctx context.Context, span trace.Span, i
 			return data.FieldId == dynamicFieldID || data.FieldName == common.MetaFieldName
 		})
 		if !ok {
-			return nil, errors.Errorf("get highlight failed, dynamic field ($meta) not in output field")
+			return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, dynamic field ($meta) not in output field")
 		}
 
 		// Safely get JSON data with nil checks
 		scalars := metaFieldData.GetScalars()
 		if scalars == nil {
-			return nil, errors.Errorf("get highlight failed, dynamic field ($meta) has no scalar data")
+			return nil, merr.WrapErrServiceInternalMsg("get highlight failed, dynamic field ($meta) has no scalar data")
 		}
 		jsonData := scalars.GetJsonData()
 		if jsonData == nil {
-			return nil, errors.Errorf("get highlight failed, dynamic field ($meta) has no JSON data")
+			return nil, merr.WrapErrServiceInternalMsg("get highlight failed, dynamic field ($meta) has no JSON data")
 		}
 		jsonDataBytes := jsonData.GetData()
 		dynFieldNames := op.highlight.DynamicFieldNames()
@@ -539,7 +538,7 @@ func (op *semanticHighlightOperator) processFieldHighlight(ctx context.Context, 
 	}
 
 	if len(highlights) != len(scores) {
-		return nil, errors.Errorf("Highlights size must equal to scores size, but got highlights size [%d], scores size [%d]", len(highlights), len(scores))
+		return nil, merr.WrapErrServiceInternalMsg("Highlights size must equal to scores size, but got highlights size [%d], scores size [%d]", len(highlights), len(scores))
 	}
 
 	result := &commonpb.HighlightResult{
@@ -567,7 +566,7 @@ func extractMultipleDynamicFieldTexts(jsonDataBytes [][]byte, fieldNames []strin
 		}
 
 		if !gjson.ValidBytes(jsonBytes) {
-			return nil, errors.Errorf("failed to unmarshal JSON at index %d: invalid JSON", i)
+			return nil, merr.WrapErrServiceInternalMsg("failed to unmarshal JSON at index %d: invalid JSON", i)
 		}
 
 		for _, fieldName := range fieldNames {
@@ -578,7 +577,7 @@ func extractMultipleDynamicFieldTexts(jsonDataBytes [][]byte, fieldNames []strin
 			}
 
 			if r.Type != gjson.String {
-				return nil, errors.Errorf("dynamic field %s is not a string type, got %s", fieldName, r.Type.String())
+				return nil, merr.WrapErrParameterInvalidMsg("dynamic field %s is not a string type, got %s", fieldName, r.Type.String())
 			}
 			result[fieldName][i] = r.String()
 		}

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -3760,7 +3760,7 @@ func (node *Proxy) handleIfSearchByPK(ctx context.Context, request *milvuspb.Sea
 	} else {
 		// Vector search: validate and fetch the vector field
 		if !typeutil.IsVectorType(annField.GetDataType()) {
-			return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("field (%s) to search is not of vector data type", annsFieldName))
+			return nil, merr.WrapErrParameterInvalidMsg("field (%s) to search is not of vector data type", annsFieldName)
 		}
 		fieldToFetch = annsFieldName
 	}

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -5793,19 +5793,19 @@ func (node *Proxy) SelectUser(ctx context.Context, req *milvuspb.SelectUserReque
 
 func (node *Proxy) validPrivilegeParams(req *milvuspb.OperatePrivilegeRequest) error {
 	if req.Entity == nil {
-		return errors.New("the entity in the request is nil")
+		return merr.WrapErrParameterInvalidMsg("the entity in the request is nil")
 	}
 	if req.Entity.Grantor == nil {
-		return errors.New("the grantor entity in the grant entity is nil")
+		return merr.WrapErrParameterInvalidMsg("the grantor entity in the grant entity is nil")
 	}
 	if req.Entity.Grantor.Privilege == nil {
-		return errors.New("the privilege entity in the grantor entity is nil")
+		return merr.WrapErrParameterInvalidMsg("the privilege entity in the grantor entity is nil")
 	}
 	if err := ValidatePrivilege(req.Entity.Grantor.Privilege.Name); err != nil {
 		return err
 	}
 	if req.Entity.Object == nil {
-		return errors.New("the resource entity in the grant entity is nil")
+		return merr.WrapErrParameterInvalidMsg("the resource entity in the grant entity is nil")
 	}
 	if err := ValidateObjectType(req.Entity.Object.Name); err != nil {
 		return err
@@ -5814,7 +5814,7 @@ func (node *Proxy) validPrivilegeParams(req *milvuspb.OperatePrivilegeRequest) e
 		return err
 	}
 	if req.Entity.Role == nil {
-		return errors.New("the object entity in the grant entity is nil")
+		return merr.WrapErrParameterInvalidMsg("the object entity in the grant entity is nil")
 	}
 	if err := ValidateRoleName(req.Entity.Role.Name); err != nil {
 		return err

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -5464,7 +5464,7 @@ func (node *Proxy) CreateCredential(ctx context.Context, req *milvuspb.CreateCre
 	if err != nil {
 		log.Error("decode password fail",
 			zap.Error(err))
-		err = errors.Wrap(err, "decode password fail")
+		err = merr.WrapErrParameterInvalidErr(err, "decode password fail")
 		return merr.Status(err), nil
 	}
 	if err = ValidatePassword(rawPassword); err != nil {
@@ -5476,7 +5476,7 @@ func (node *Proxy) CreateCredential(ctx context.Context, req *milvuspb.CreateCre
 	if err != nil {
 		log.Error("encrypt password fail",
 			zap.Error(err))
-		err = errors.Wrap(err, "encrypt password failed")
+		err = merr.WrapErrServiceInternalErr(err, "encrypt password failed")
 		return merr.Status(err), nil
 	}
 	if req.Base == nil {
@@ -5514,14 +5514,14 @@ func (node *Proxy) UpdateCredential(ctx context.Context, req *milvuspb.UpdateCre
 	if err != nil {
 		log.Error("decode old password fail",
 			zap.Error(err))
-		err = errors.Wrap(err, "decode old password failed")
+		err = merr.WrapErrParameterInvalidErr(err, "decode old password failed")
 		return merr.Status(err), nil
 	}
 	rawNewPassword, err := crypto.Base64Decode(req.NewPassword)
 	if err != nil {
 		log.Error("decode password fail",
 			zap.Error(err))
-		err = errors.Wrap(err, "decode password failed")
+		err = merr.WrapErrParameterInvalidErr(err, "decode password failed")
 		return merr.Status(err), nil
 	}
 	// valid new password
@@ -5549,7 +5549,7 @@ func (node *Proxy) UpdateCredential(ctx context.Context, req *milvuspb.UpdateCre
 	if err != nil {
 		log.Error("encrypt password fail",
 			zap.Error(err))
-		err = errors.Wrap(err, "encrypt password failed")
+		err = merr.WrapErrServiceInternalErr(err, "encrypt password failed")
 		return merr.Status(err), nil
 	}
 	if req.Base == nil {

--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -978,7 +978,7 @@ func (m *MetaCache) showPartitions(ctx context.Context, dbName string, collectio
 	}
 
 	if len(partitions.PartitionIDs) != len(partitions.PartitionNames) {
-		return nil, fmt.Errorf("partition ids len: %d doesn't equal Partition name len %d",
+		return nil, merr.WrapErrParameterInvalidMsg("partition ids len: %d doesn't equal Partition name len %d",
 			len(partitions.PartitionIDs), len(partitions.PartitionNames))
 	}
 	if len(partitions.PartitionNames) != len(partitions.CreatedTimestamps) ||

--- a/internal/proxy/meta_cache_testonly.go
+++ b/internal/proxy/meta_cache_testonly.go
@@ -24,7 +24,6 @@ package proxy
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/milvus-io/milvus/internal/mocks"
@@ -54,8 +53,8 @@ func InitEmptyGlobalCache() {
 	var err error
 	emptyMock := common.NewEmptyMockT()
 	mixcoord := mocks.NewMockMixCoordClient(emptyMock)
-	mixcoord.EXPECT().DescribeCollection(mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("collection not found"))
-	mixcoord.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("alias not found"))
+	mixcoord.EXPECT().DescribeCollection(mock.Anything, mock.Anything, mock.Anything).Return(nil, merr.WrapErrParameterInvalidMsg("collection not found"))
+	mixcoord.EXPECT().DescribeAlias(mock.Anything, mock.Anything, mock.Anything).Return(nil, merr.WrapErrParameterInvalidMsg("alias not found"))
 	globalMetaCache, err = NewMetaCache(mixcoord)
 	if err != nil {
 		panic(err)

--- a/internal/proxy/privilege/cache.go
+++ b/internal/proxy/privilege/cache.go
@@ -18,11 +18,9 @@ package privilege
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -198,7 +196,7 @@ func (m *privilegeCache) RefreshPolicyInfo(op typeutil.CacheOp) (err error) {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 		if op.OpKey == "" {
-			return errors.New("empty op key")
+			return merr.WrapErrParameterInvalidMsg("empty op key")
 		}
 	}
 
@@ -216,7 +214,7 @@ func (m *privilegeCache) RefreshPolicyInfo(op typeutil.CacheOp) (err error) {
 	case typeutil.CacheAddUserToRole:
 		user, role, err := funcutil.DecodeUserRoleCache(op.OpKey)
 		if err != nil {
-			return fmt.Errorf("invalid opKey, fail to decode, op_type: %d, op_key: %s", int(op.OpType), op.OpKey)
+			return merr.WrapErrParameterInvalidMsg("invalid opKey, fail to decode, op_type: %d, op_key: %s", int(op.OpType), op.OpKey)
 		}
 		if m.userToRoles[user] == nil {
 			m.userToRoles[user] = make(map[string]struct{})
@@ -225,7 +223,7 @@ func (m *privilegeCache) RefreshPolicyInfo(op typeutil.CacheOp) (err error) {
 	case typeutil.CacheRemoveUserFromRole:
 		user, role, err := funcutil.DecodeUserRoleCache(op.OpKey)
 		if err != nil {
-			return fmt.Errorf("invalid opKey, fail to decode, op_type: %d, op_key: %s", int(op.OpType), op.OpKey)
+			return merr.WrapErrParameterInvalidMsg("invalid opKey, fail to decode, op_type: %d, op_key: %s", int(op.OpType), op.OpKey)
 		}
 		if m.userToRoles[user] != nil {
 			delete(m.userToRoles[user], role)
@@ -262,7 +260,7 @@ func (m *privilegeCache) RefreshPolicyInfo(op typeutil.CacheOp) (err error) {
 		m.privilegeInfos = make(map[string]struct{})
 		m.unsafeInitPolicyInfo(resp.PolicyInfos, resp.UserRoles)
 	default:
-		return fmt.Errorf("invalid opType, op_type: %d, op_key: %s", int(op.OpType), op.OpKey)
+		return merr.WrapErrParameterInvalidMsg("invalid opType, op_type: %d, op_key: %s", int(op.OpType), op.OpKey)
 	}
 	return nil
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"go.uber.org/atomic"
@@ -42,6 +41,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/expr"
 	"github.com/milvus-io/milvus/pkg/v3/util/logutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/ratelimitutil"
@@ -165,7 +165,7 @@ func (node *Proxy) Register() error {
 func (node *Proxy) initSession() error {
 	node.session = sessionutil.NewSession(node.ctx)
 	if node.session == nil {
-		return errors.New("new session failed, maybe etcd cannot be connected")
+		return merr.WrapErrParameterInvalidMsg("new session failed, maybe etcd cannot be connected")
 	}
 	node.session.Init(typeutil.ProxyRole, node.address, false)
 	sessionutil.SaveServerInfo(typeutil.ProxyRole, node.session.ServerID)
@@ -378,7 +378,7 @@ func (node *Proxy) SetQueryNodeCreator(f func(ctx context.Context, addr string, 
 // GetRateLimiter returns the rateLimiter in Proxy.
 func (node *Proxy) GetRateLimiter() (types.Limiter, error) {
 	if node.simpleLimiter == nil {
-		return nil, errors.New("nil rate limiter in Proxy")
+		return nil, merr.WrapErrParameterInvalidMsg("nil rate limiter in Proxy")
 	}
 	return node.simpleLimiter, nil
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -3752,7 +3752,7 @@ func TestProxy(t *testing.T) {
 
 		resp, err := proxy.Upsert(ctx, req)
 		assert.NoError(t, err)
-		assert.Equal(t, commonpb.ErrorCode_UnexpectedError, resp.GetStatus().GetErrorCode())
+		assert.Equal(t, commonpb.ErrorCode_IllegalArgument, resp.GetStatus().GetErrorCode())
 		assert.Equal(t, 0, len(resp.SuccIndex))
 		assert.Equal(t, rowNum, len(resp.ErrIndex))
 		assert.Equal(t, int64(0), resp.UpsertCnt)

--- a/internal/proxy/query_pipeline.go
+++ b/internal/proxy/query_pipeline.go
@@ -18,7 +18,6 @@ package proxy
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -282,7 +281,7 @@ func newReduceByGroupsOperator(
 		for i := 0; i < fieldCount; i++ {
 			indices := outputMap.IndexesAt(i)
 			if len(indices) == 0 {
-				return nil, fmt.Errorf("no indices found for output field '%s'", outputMap.NameAt(i))
+				return nil, merr.WrapErrParameterInvalidMsg("no indices found for output field '%s'", outputMap.NameAt(i))
 			} else if len(indices) == 1 {
 				reOrganizedFieldDatas[i] = reducedFieldDatas[indices[0]]
 				reOrganizedFieldDatas[i].FieldName = outputMap.NameAt(i)
@@ -345,7 +344,7 @@ func newAggRemapOperator(outputMap *agg.AggregationFieldMap) queryutil.Operator 
 		for i := 0; i < fieldCount; i++ {
 			indices := outputMap.IndexesAt(i)
 			if len(indices) == 0 {
-				return nil, fmt.Errorf("no indices found for output field '%s'", outputMap.NameAt(i))
+				return nil, merr.WrapErrParameterInvalidMsg("no indices found for output field '%s'", outputMap.NameAt(i))
 			} else if len(indices) == 1 {
 				remapped[i] = rawFields[indices[0]]
 				remapped[i].FieldName = outputMap.NameAt(i)

--- a/internal/proxy/repack_func.go
+++ b/internal/proxy/repack_func.go
@@ -17,9 +17,8 @@
 package proxy
 
 import (
-	"fmt"
-
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // insertRepackFunc deprecated, use defaultInsertRepackFunc instead.
@@ -28,7 +27,7 @@ func insertRepackFunc(
 	hashKeys [][]int32,
 ) (map[int32]*msgstream.MsgPack, error) {
 	if len(hashKeys) < len(tsMsgs) {
-		return nil, fmt.Errorf(
+		return nil, merr.WrapErrParameterInvalidMsg(
 			"the length of hash keys (%d) is less than the length of messages (%d)",
 			len(hashKeys),
 			len(tsMsgs),
@@ -46,7 +45,7 @@ func insertRepackFunc(
 			}
 			result[key].Msgs = append(result[key].Msgs, request)
 		} else {
-			return nil, fmt.Errorf("no hash key for %dth message", i)
+			return nil, merr.WrapErrParameterInvalidMsg("no hash key for %dth message", i)
 		}
 	}
 
@@ -59,7 +58,7 @@ func defaultInsertRepackFunc(
 	hashKeys [][]int32,
 ) (map[int32]*msgstream.MsgPack, error) {
 	if len(hashKeys) < len(tsMsgs) {
-		return nil, fmt.Errorf(
+		return nil, merr.WrapErrParameterInvalidMsg(
 			"the length of hash keys (%d) is less than the length of messages (%d)",
 			len(hashKeys),
 			len(tsMsgs),
@@ -70,7 +69,7 @@ func defaultInsertRepackFunc(
 	pack := make(map[int32]*msgstream.MsgPack)
 	for idx, msg := range tsMsgs {
 		if len(hashKeys[idx]) <= 0 {
-			return nil, fmt.Errorf("no hash key for %dth message", idx)
+			return nil, merr.WrapErrParameterInvalidMsg("no hash key for %dth message", idx)
 		}
 		key := hashKeys[idx][0]
 		_, ok := pack[key]

--- a/internal/proxy/search_agg/computer.go
+++ b/internal/proxy/search_agg/computer.go
@@ -2,12 +2,12 @@ package search_agg
 
 import (
 	"context"
-	"fmt"
 	"sort"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/agg"
 	"github.com/milvus-io/milvus/internal/util/reduce"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -54,10 +54,10 @@ func NewSearchAggregationComputer(
 
 func (c *SearchAggregationComputer) Compute(ctx context.Context) ([][]*AggBucketResult, error) {
 	if c.ctx == nil {
-		return nil, fmt.Errorf("search aggregation context is nil")
+		return nil, merr.WrapErrServiceInternalMsg("search aggregation context is nil")
 	}
 	if len(c.ctx.Levels) == 0 {
-		return nil, fmt.Errorf("search aggregation context has no levels")
+		return nil, merr.WrapErrServiceInternalMsg("search aggregation context has no levels")
 	}
 
 	output := make([][]*AggBucketResult, c.ctx.NQ)
@@ -74,7 +74,7 @@ func (c *SearchAggregationComputer) Compute(ctx context.Context) ([][]*AggBucket
 func (c *SearchAggregationComputer) computeForQi(ctx context.Context, qi int64) ([]*AggBucketResult, error) {
 	topks := c.data.GetTopks()
 	if qi < 0 || qi >= int64(len(topks)) {
-		return nil, fmt.Errorf("invalid qi %d, topks length=%d", qi, len(topks))
+		return nil, merr.WrapErrServiceInternalMsg("invalid qi %d, topks length=%d", qi, len(topks))
 	}
 	var start int64
 	for i := int64(0); i < qi; i++ {
@@ -90,7 +90,7 @@ func (c *SearchAggregationComputer) computeForQi(ctx context.Context, qi int64) 
 
 func (c *SearchAggregationComputer) computeLevel(ctx context.Context, qi int64, levelIdx int, rows []reduce.RowRef) ([]*AggBucketResult, error) {
 	if levelIdx < 0 || levelIdx >= len(c.ctx.Levels) {
-		return nil, fmt.Errorf("invalid level index %d", levelIdx)
+		return nil, merr.WrapErrServiceInternalMsg("invalid level index %d", levelIdx)
 	}
 	level := c.ctx.Levels[levelIdx]
 	isLeaf := levelIdx == len(c.ctx.Levels)-1
@@ -340,7 +340,7 @@ func (c *SearchAggregationComputer) updateMetrics(bucket *bucketState, ref reduc
 	for _, plan := range plans {
 		targets := bucket.metricStates[plan.alias]
 		if targets == nil {
-			return fmt.Errorf("metric %q: missing bucket state", plan.alias)
+			return merr.WrapErrServiceInternalMsg("metric %q: missing bucket state", plan.alias)
 		}
 
 		var raw any
@@ -362,7 +362,7 @@ func (c *SearchAggregationComputer) updateMetrics(bucket *bucketState, ref reduc
 		}
 
 		if err := plan.aggregate.UpdateState(targets, agg.NewFieldValue(raw)); err != nil {
-			return fmt.Errorf("metric %q update failed: %w", plan.alias, err)
+			return merr.WrapErrServiceInternalMsg("metric %q update failed: %v", plan.alias, err)
 		}
 	}
 	return nil
@@ -370,13 +370,13 @@ func (c *SearchAggregationComputer) updateMetrics(bucket *bucketState, ref reduc
 
 func (c *SearchAggregationComputer) readValueByFieldID(ref reduce.RowRef, fieldID int64) (any, bool, error) {
 	if c.data == nil {
-		return nil, true, fmt.Errorf("nil SearchResultData")
+		return nil, true, merr.WrapErrServiceInternalMsg("nil SearchResultData")
 	}
 
 	if fieldID == ScoreFieldID {
 		scores := c.data.GetScores()
 		if ref.RowIdx < 0 || ref.RowIdx >= int64(len(scores)) {
-			return nil, true, fmt.Errorf("score index %d out of range", ref.RowIdx)
+			return nil, true, merr.WrapErrServiceInternalMsg("score index %d out of range", ref.RowIdx)
 		}
 		return scores[ref.RowIdx], false, nil
 	}
@@ -384,9 +384,9 @@ func (c *SearchAggregationComputer) readValueByFieldID(ref reduce.RowRef, fieldI
 	fd := c.fieldsByID[fieldID]
 	if fd == nil {
 		if c.ctx.IsGroupByField(fieldID) {
-			return nil, true, fmt.Errorf("group-by field %d missing from group_by_field_values", fieldID)
+			return nil, true, merr.WrapErrServiceInternalMsg("group-by field %d missing from group_by_field_values", fieldID)
 		}
-		return nil, true, fmt.Errorf("field %d missing from fields_data", fieldID)
+		return nil, true, merr.WrapErrServiceInternalMsg("field %d missing from fields_data", fieldID)
 	}
 
 	iter := typeutil.GetDataIterator(fd)
@@ -423,11 +423,11 @@ func finalizeMetrics(plans []metricPlan, states map[string][]*agg.FieldValue) (m
 	for _, plan := range plans {
 		slots := states[plan.alias]
 		if plan.aggregate == nil {
-			return nil, fmt.Errorf("metric %q: semantic aggregate is nil", plan.alias)
+			return nil, merr.WrapErrServiceInternalMsg("metric %q: semantic aggregate is nil", plan.alias)
 		}
 		value, err := plan.aggregate.Terminate(slots)
 		if err != nil {
-			return nil, fmt.Errorf("metric %q: %w", plan.alias, err)
+			return nil, merr.WrapErrServiceInternalMsg("metric %q: %v", plan.alias, err)
 		}
 		metrics[plan.alias] = value
 	}
@@ -470,90 +470,90 @@ func compareValues(a, b any) (int, error) {
 	case int:
 		bv, ok := b.(int)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareOrdered(av, bv), nil
 	case int8:
 		bv, ok := b.(int8)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareOrdered(av, bv), nil
 	case int16:
 		bv, ok := b.(int16)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareOrdered(av, bv), nil
 	case int32:
 		bv, ok := b.(int32)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareOrdered(av, bv), nil
 	case int64:
 		bv, ok := b.(int64)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareOrdered(av, bv), nil
 	case uint:
 		bv, ok := b.(uint)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareOrdered(av, bv), nil
 	case uint8:
 		bv, ok := b.(uint8)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareOrdered(av, bv), nil
 	case uint16:
 		bv, ok := b.(uint16)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareOrdered(av, bv), nil
 	case uint32:
 		bv, ok := b.(uint32)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareOrdered(av, bv), nil
 	case uint64:
 		bv, ok := b.(uint64)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareOrdered(av, bv), nil
 	case float32:
 		bv, ok := b.(float32)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareFloat64(float64(av), float64(bv)), nil
 	case float64:
 		bv, ok := b.(float64)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareFloat64(av, bv), nil
 	case bool:
 		bv, ok := b.(bool)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareBool(av, bv), nil
 	case string:
 		bv, ok := b.(string)
 		if !ok {
-			return 0, fmt.Errorf("type mismatch: %T vs %T", a, b)
+			return 0, merr.WrapErrServiceInternalMsg("type mismatch: %T vs %T", a, b)
 		}
 		return compareOrdered(av, bv), nil
 	}
 
-	return 0, fmt.Errorf("unsupported comparable types: %T and %T", a, b)
+	return 0, merr.WrapErrServiceInternalMsg("unsupported comparable types: %T and %T", a, b)
 }
 
 func compareOrdered[T ~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~string](a, b T) int {

--- a/internal/proxy/search_agg/context_builder.go
+++ b/internal/proxy/search_agg/context_builder.go
@@ -1,7 +1,6 @@
 package search_agg
 
 import (
-	"fmt"
 	"math"
 	"sort"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/agg"
 	typeutil2 "github.com/milvus-io/milvus/internal/util/typeutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -87,7 +87,7 @@ func NewContext(
 		}
 		plans, err := compileMetricPlans(levels[i].Metrics)
 		if err != nil {
-			return nil, fmt.Errorf("level %d metric compile failed: %w", i, err)
+			return nil, merr.WrapErrParameterInvalidMsg("level %d metric compile failed: %v", i, err)
 		}
 		levels[i].metricPlans = plans
 	}
@@ -132,7 +132,7 @@ func compileMetricPlans(metrics map[string]MetricSpec) ([]metricPlan, error) {
 	for _, alias := range aliases {
 		plan, err := buildMetricPlan(alias, metrics[alias])
 		if err != nil {
-			return nil, fmt.Errorf("metric %q: %w", alias, err)
+			return nil, merr.WrapErrParameterInvalidMsg("metric %q: %v", alias, err)
 		}
 		plans = append(plans, plan)
 	}
@@ -168,7 +168,7 @@ func deriveTopKAndGroupSizeChecked(levels []LevelContext) (topK, groupSize int64
 		var ok bool
 		topK, ok = checkedMulInt64(topK, normalizeAggregationSize(lvl.Size))
 		if !ok {
-			return 0, 0, fmt.Errorf("search_aggregation derived topK overflows int64")
+			return 0, 0, merr.WrapErrParameterInvalidMsg("search_aggregation derived topK overflows int64")
 		}
 	}
 	return topK, deriveGroupSize(levels), nil
@@ -190,14 +190,14 @@ func validateSearchAggregationResultEntries(nq, topK, groupSize, maxEntries int6
 	}
 	nqTopK, ok := checkedMulInt64(nq, topK)
 	if !ok {
-		return fmt.Errorf("number of search_aggregation result entries is too large")
+		return merr.WrapErrParameterInvalidMsg("number of search_aggregation result entries is too large")
 	}
 	entries, ok := checkedMulInt64(nqTopK, groupSize)
 	if !ok {
-		return fmt.Errorf("number of search_aggregation result entries is too large")
+		return merr.WrapErrParameterInvalidMsg("number of search_aggregation result entries is too large")
 	}
 	if entries > maxEntries {
-		return fmt.Errorf("number of search_aggregation result entries is too large")
+		return merr.WrapErrParameterInvalidMsg("number of search_aggregation result entries is too large")
 	}
 	return nil
 }
@@ -232,17 +232,17 @@ const maxAggregationLevels = 4
 
 func resolveAggregationSpec(groupBy *commonpb.SearchAggregationSpec, schema *schemapb.CollectionSchema) (*resolvedAggregationSpec, error) {
 	if groupBy == nil {
-		return nil, fmt.Errorf("group_by spec is nil")
+		return nil, merr.WrapErrParameterInvalidMsg("group_by spec is nil")
 	}
 	if schema == nil {
-		return nil, fmt.Errorf("collection schema is nil")
+		return nil, merr.WrapErrParameterInvalidMsg("collection schema is nil")
 	}
 
 	depth := 0
 	for cur := groupBy; cur != nil; cur = cur.GetSubAggregation() {
 		depth++
 		if depth > maxAggregationLevels {
-			return nil, fmt.Errorf("search_aggregation nesting exceeds max %d levels", maxAggregationLevels)
+			return nil, merr.WrapErrParameterInvalidMsg("search_aggregation nesting exceeds max %d levels", maxAggregationLevels)
 		}
 	}
 
@@ -258,10 +258,10 @@ func resolveAggregationSpec(groupBy *commonpb.SearchAggregationSpec, schema *sch
 		}
 
 		if len(spec.GetFields()) == 0 {
-			return fmt.Errorf("group_by level has no fields")
+			return merr.WrapErrParameterInvalidMsg("group_by level has no fields")
 		}
 		if spec.GetSize() < 0 {
-			return fmt.Errorf("search_aggregation size must be non-negative")
+			return merr.WrapErrParameterInvalidMsg("search_aggregation size must be non-negative")
 		}
 
 		level := LevelContext{
@@ -273,24 +273,24 @@ func resolveAggregationSpec(groupBy *commonpb.SearchAggregationSpec, schema *sch
 		for _, fieldName := range spec.GetFields() {
 			fieldID, err := resolveFieldID(fieldName, schema, dynamicField)
 			if err != nil {
-				return fmt.Errorf("invalid group_by field %q: %w", fieldName, err)
+				return merr.WrapErrParameterInvalidMsg("invalid group_by field %q: %v", fieldName, err)
 			}
 			// jsonPath plumbing to segcore is not wired for SearchAggregation yet;
 			// reject JSON / dynamic-field group_by up-front so callers get a
 			// deterministic error instead of an empty group-by column downstream.
 			if fs := typeutil.GetFieldByID(schema, fieldID); fs != nil {
 				if fs.GetDataType() == schemapb.DataType_JSON || fs.GetIsDynamic() {
-					return fmt.Errorf("group_by field %q: JSON / dynamic fields are not yet supported with search_aggregation", fieldName)
+					return merr.WrapErrParameterInvalidMsg("group_by field %q: JSON / dynamic fields are not yet supported with search_aggregation", fieldName)
 				}
 				if fs.GetDataType() == schemapb.DataType_Float || fs.GetDataType() == schemapb.DataType_Double {
-					return fmt.Errorf("group_by field %q: FLOAT / DOUBLE fields are not supported with search_aggregation (BucketKeyEntry has no float variant; equality on floats is fragile)", fieldName)
+					return merr.WrapErrParameterInvalidMsg("group_by field %q: FLOAT / DOUBLE fields are not supported with search_aggregation (BucketKeyEntry has no float variant; equality on floats is fragile)", fieldName)
 				}
 			}
 			if _, ok := levelFieldSeen[fieldID]; ok {
-				return fmt.Errorf("duplicated group_by field %q in one level", fieldName)
+				return merr.WrapErrParameterInvalidMsg("duplicated group_by field %q in one level", fieldName)
 			}
 			if _, ok := groupBySeen[fieldID]; ok {
-				return fmt.Errorf("duplicated group_by field %q across levels", fieldName)
+				return merr.WrapErrParameterInvalidMsg("duplicated group_by field %q across levels", fieldName)
 			}
 			levelFieldSeen[fieldID] = struct{}{}
 			groupBySeen[fieldID] = struct{}{}
@@ -311,15 +311,15 @@ func resolveAggregationSpec(groupBy *commonpb.SearchAggregationSpec, schema *sch
 			for _, alias := range aliases {
 				metric := spec.GetMetrics()[alias]
 				if strings.TrimSpace(alias) == "" {
-					return fmt.Errorf("metric alias cannot be empty")
+					return merr.WrapErrParameterInvalidMsg("metric alias cannot be empty")
 				}
 				metricSpec, metricSourceFieldID, err := buildMetricSpec(metric, schema, dynamicField)
 				if err != nil {
-					return fmt.Errorf("invalid metric %q: %w", alias, err)
+					return merr.WrapErrParameterInvalidMsg("invalid metric %q: %v", alias, err)
 				}
 				plan, err := buildMetricPlan(alias, metricSpec)
 				if err != nil {
-					return fmt.Errorf("invalid metric %q: %w", alias, err)
+					return merr.WrapErrParameterInvalidMsg("invalid metric %q: %v", alias, err)
 				}
 				level.Metrics[alias] = metricSpec
 				level.metricPlans = append(level.metricPlans, plan)
@@ -355,19 +355,19 @@ func resolveAggregationSpec(groupBy *commonpb.SearchAggregationSpec, schema *sch
 
 func buildMetricSpec(metric *commonpb.MetricAggSpec, schema *schemapb.CollectionSchema, dynamicField *schemapb.FieldSchema) (MetricSpec, int64, error) {
 	if metric == nil {
-		return MetricSpec{}, 0, fmt.Errorf("metric spec is nil")
+		return MetricSpec{}, 0, merr.WrapErrParameterInvalidMsg("metric spec is nil")
 	}
 
 	op := strings.ToLower(strings.TrimSpace(metric.GetOp()))
 	switch op {
 	case "avg", "sum", "count", "min", "max":
 	default:
-		return MetricSpec{}, 0, fmt.Errorf("unsupported metric op %q", metric.GetOp())
+		return MetricSpec{}, 0, merr.WrapErrParameterInvalidMsg("unsupported metric op %q", metric.GetOp())
 	}
 
 	fieldName := strings.TrimSpace(metric.GetFieldName())
 	if fieldName == "" {
-		return MetricSpec{}, 0, fmt.Errorf("metric field_name is empty")
+		return MetricSpec{}, 0, merr.WrapErrParameterInvalidMsg("metric field_name is empty")
 	}
 
 	switch fieldName {
@@ -377,7 +377,7 @@ func buildMetricSpec(metric *commonpb.MetricAggSpec, schema *schemapb.Collection
 		return MetricSpec{Op: op, FieldID: ScoreFieldID, FieldType: schemapb.DataType_Float}, 0, nil
 	case "*":
 		if op != "count" {
-			return MetricSpec{}, 0, fmt.Errorf("field_name '*' only supports count op")
+			return MetricSpec{}, 0, merr.WrapErrParameterInvalidMsg("field_name '*' only supports count op")
 		}
 		// count(*) has no source field; DataType_None is what internal/agg
 		// expects for the synthetic always-1 input.
@@ -400,7 +400,7 @@ func buildTopHitsConfig(topHits *commonpb.TopHitsSpec, schema *schemapb.Collecti
 		return nil, nil, nil
 	}
 	if topHits.GetSize() < 0 {
-		return nil, nil, fmt.Errorf("top_hits size must be non-negative")
+		return nil, nil, merr.WrapErrParameterInvalidMsg("top_hits size must be non-negative")
 	}
 
 	cfg := &TopHitsConfig{
@@ -412,16 +412,16 @@ func buildTopHitsConfig(topHits *commonpb.TopHitsSpec, schema *schemapb.Collecti
 
 	for _, sortSpec := range topHits.GetSort() {
 		if sortSpec == nil {
-			return nil, nil, fmt.Errorf("top_hits.sort contains nil item")
+			return nil, nil, merr.WrapErrParameterInvalidMsg("top_hits.sort contains nil item")
 		}
 		fieldName := strings.TrimSpace(sortSpec.GetFieldName())
 		if fieldName == "" {
-			return nil, nil, fmt.Errorf("top_hits.sort field_name is empty")
+			return nil, nil, merr.WrapErrParameterInvalidMsg("top_hits.sort field_name is empty")
 		}
 
 		direction, err := normalizeDirection(sortSpec.GetDirection(), "desc")
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid top_hits.sort direction for %q: %w", fieldName, err)
+			return nil, nil, merr.WrapErrParameterInvalidMsg("invalid top_hits.sort direction for %q: %v", fieldName, err)
 		}
 
 		if fieldName == "_score" {
@@ -430,12 +430,12 @@ func buildTopHitsConfig(topHits *commonpb.TopHitsSpec, schema *schemapb.Collecti
 		}
 
 		if isJSONPathFieldExpr(fieldName) {
-			return nil, nil, fmt.Errorf("top_hits.sort JSON path is not yet supported: %q", fieldName)
+			return nil, nil, merr.WrapErrParameterInvalidMsg("top_hits.sort JSON path is not yet supported: %q", fieldName)
 		}
 
 		fieldID, err := resolveFieldID(fieldName, schema, dynamicField)
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid top_hits.sort field %q: %w", fieldName, err)
+			return nil, nil, merr.WrapErrParameterInvalidMsg("invalid top_hits.sort field %q: %v", fieldName, err)
 		}
 		cfg.Sort = append(cfg.Sort, SortCriterion{FieldID: fieldID, Dir: direction, NullFirst: sortSpec.GetNullFirst()})
 		appendUniqueFieldID(seen, &sortFieldIDs, fieldID)
@@ -452,23 +452,23 @@ func buildOrderCriteria(orderSpecs []*commonpb.OrderSpec, metrics map[string]Met
 	order := make([]OrderCriterion, 0, len(orderSpecs))
 	for _, orderSpec := range orderSpecs {
 		if orderSpec == nil {
-			return nil, fmt.Errorf("order contains nil item")
+			return nil, merr.WrapErrParameterInvalidMsg("order contains nil item")
 		}
 
 		key := strings.TrimSpace(orderSpec.GetKey())
 		if key == "" {
-			return nil, fmt.Errorf("order key is empty")
+			return nil, merr.WrapErrParameterInvalidMsg("order key is empty")
 		}
 
 		if key != "_count" && key != "_key" {
 			if _, ok := metrics[key]; !ok {
-				return nil, fmt.Errorf("order key %q is neither reserved key nor metric alias", key)
+				return nil, merr.WrapErrParameterInvalidMsg("order key %q is neither reserved key nor metric alias", key)
 			}
 		}
 
 		direction, err := normalizeDirection(orderSpec.GetDirection(), "desc")
 		if err != nil {
-			return nil, fmt.Errorf("invalid order direction for key %q: %w", key, err)
+			return nil, merr.WrapErrParameterInvalidMsg("invalid order direction for key %q: %v", key, err)
 		}
 		// ES bucket order has no null placement option; OrderSpec.NullFirst is ignored intentionally.
 		order = append(order, OrderCriterion{Key: key, Dir: direction})
@@ -486,7 +486,7 @@ func normalizeDirection(direction string, defaultDir string) (string, error) {
 	case "asc", "desc":
 		return dir, nil
 	default:
-		return "", fmt.Errorf("direction must be asc or desc")
+		return "", merr.WrapErrParameterInvalidMsg("direction must be asc or desc")
 	}
 }
 
@@ -498,7 +498,7 @@ func isJSONPathFieldExpr(fieldExpr string) bool {
 func resolveFieldID(fieldExpr string, schema *schemapb.CollectionSchema, dynamicField *schemapb.FieldSchema) (int64, error) {
 	fieldExpr = strings.TrimSpace(fieldExpr)
 	if fieldExpr == "" {
-		return 0, fmt.Errorf("field is empty")
+		return 0, merr.WrapErrParameterInvalidMsg("field is empty")
 	}
 
 	if field := typeutil.GetFieldByName(schema, fieldExpr); field != nil {
@@ -531,7 +531,7 @@ func resolveFieldID(fieldExpr string, schema *schemapb.CollectionSchema, dynamic
 		}
 	}
 
-	return 0, fmt.Errorf("field %q not found in schema", fieldExpr)
+	return 0, merr.WrapErrParameterInvalidMsg("field %q not found in schema", fieldExpr)
 }
 
 func findDynamicField(schema *schemapb.CollectionSchema) *schemapb.FieldSchema {

--- a/internal/proxy/search_agg/order.go
+++ b/internal/proxy/search_agg/order.go
@@ -1,8 +1,9 @@
 package search_agg
 
 import (
-	"fmt"
 	"sort"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func applyOrderAndSize(buckets []*AggBucketResult, level LevelContext) ([]*AggBucketResult, error) {
@@ -72,7 +73,7 @@ func compareBucketKeys(a, b map[int64]any, ownFieldIDs []int64) (int, error) {
 	for _, fieldID := range ownFieldIDs {
 		cmp, err := compareValues(a[fieldID], b[fieldID])
 		if err != nil {
-			return 0, fmt.Errorf("compare _key field %d failed: %w", fieldID, err)
+			return 0, merr.WrapErrServiceInternalMsg("compare _key field %d failed: %v", fieldID, err)
 		}
 		if cmp != 0 {
 			return cmp, nil

--- a/internal/proxy/search_reduce_util.go
+++ b/internal/proxy/search_reduce_util.go
@@ -2,9 +2,7 @@ package proxy
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/cockroachdb/errors"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -269,13 +267,13 @@ func runSingleFieldGroupByHotLoop(
 		}
 
 		if realTopK != -1 && realTopK != j {
-			log.Ctx(ctx).Warn("Proxy Reduce Search Result", zap.Error(errors.New("the length (topk) between all result of query is different")))
+			log.Ctx(ctx).Warn("Proxy Reduce Search Result", zap.Error(merr.WrapErrServiceInternalMsg("the length (topk) between all result of query is different")))
 		}
 		realTopK = j
 		ret.Results.Topks = append(ret.Results.Topks, realTopK)
 
 		if retSize > maxOutputSize {
-			return nil, fmt.Errorf("search results exceed the maxOutputSize Limit %d", maxOutputSize)
+			return nil, merr.WrapErrParameterInvalidMsg("search results exceed the maxOutputSize Limit %d", maxOutputSize)
 		}
 	}
 
@@ -392,13 +390,13 @@ func runMultiFieldGroupByHotLoop(
 		acceptedRows = append(acceptedRows, perNqAccepted...)
 
 		if realTopK != -1 && realTopK != j {
-			log.Ctx(ctx).Warn("Proxy Reduce Search Result", zap.Error(errors.New("the length (topk) between all result of query is different")))
+			log.Ctx(ctx).Warn("Proxy Reduce Search Result", zap.Error(merr.WrapErrServiceInternalMsg("the length (topk) between all result of query is different")))
 		}
 		realTopK = j
 		ret.Results.Topks = append(ret.Results.Topks, realTopK)
 
 		if retSize > maxOutputSize {
-			return nil, fmt.Errorf("search results exceed the maxOutputSize Limit %d", maxOutputSize)
+			return nil, merr.WrapErrParameterInvalidMsg("search results exceed the maxOutputSize Limit %d", maxOutputSize)
 		}
 	}
 
@@ -736,15 +734,15 @@ func reduceSearchResultDataNoGroupBy(ctx context.Context, subSearchResultData []
 				cursors[subSearchIdx]++
 			}
 			if realTopK != -1 && realTopK != j {
-				log.Ctx(ctx).Warn("Proxy Reduce Search Result", zap.Error(errors.New("the length (topk) between all result of query is different")))
-				// return nil, errors.New("the length (topk) between all result of query is different")
+				log.Ctx(ctx).Warn("Proxy Reduce Search Result", zap.Error(merr.WrapErrParameterInvalidMsg("the length (topk) between all result of query is different")))
+				// return nil, merr.WrapErrParameterInvalidMsg("the length (topk) between all result of query is different")
 			}
 			realTopK = j
 			ret.Results.Topks = append(ret.Results.Topks, realTopK)
 
 			// limit search result to avoid oom
 			if retSize > maxOutputSize {
-				return nil, fmt.Errorf("search results exceed the maxOutputSize Limit %d", maxOutputSize)
+				return nil, merr.WrapErrParameterInvalidMsg("search results exceed the maxOutputSize Limit %d", maxOutputSize)
 			}
 		}
 		ret.Results.TopK = realTopK // realTopK is the topK of the nq-th query
@@ -783,7 +781,7 @@ func setupIdListForSearchResult(searchResult *milvuspb.SearchResults, pkType sch
 			},
 		}
 	default:
-		return errors.New("unsupported pk type")
+		return merr.WrapErrParameterInvalidMsg("unsupported pk type")
 	}
 	return nil
 }
@@ -856,14 +854,14 @@ func decodeSearchResults(ctx context.Context, searchResults []*internalpb.Search
 
 func checkSearchResultData(data *schemapb.SearchResultData, nq int64, topk int64, pkHitNum int) error {
 	if data.NumQueries != nq {
-		return fmt.Errorf("search result's nq(%d) mis-match with %d", data.NumQueries, nq)
+		return merr.WrapErrParameterInvalidMsg("search result's nq(%d) mis-match with %d", data.NumQueries, nq)
 	}
 	if data.TopK != topk {
-		return fmt.Errorf("search result's topk(%d) mis-match with %d", data.TopK, topk)
+		return merr.WrapErrParameterInvalidMsg("search result's topk(%d) mis-match with %d", data.TopK, topk)
 	}
 
 	if len(data.Scores) != pkHitNum {
-		return fmt.Errorf("search result's score length invalid, score length=%d, expectedLength=%d",
+		return merr.WrapErrParameterInvalidMsg("search result's score length invalid, score length=%d, expectedLength=%d",
 			len(data.Scores), pkHitNum)
 	}
 	return nil

--- a/internal/proxy/search_util.go
+++ b/internal/proxy/search_util.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
 	"google.golang.org/protobuf/proto"
@@ -183,7 +182,7 @@ func parseOrderByFields(searchParamsPair []*commonpb.KeyValuePair, schema *schem
 		// e.g., "metadata[\"price\"]:asc" -> fieldSpec="metadata[\"price\"]", direction="asc"
 		fieldSpec, direction := splitOrderByFieldAndDirection(pair)
 		if fieldSpec == "" {
-			return nil, fmt.Errorf("empty field name in order_by_fields")
+			return nil, merr.WrapErrParameterInvalidMsg("empty field name in order_by_fields")
 		}
 
 		// Parse direction
@@ -195,7 +194,7 @@ func parseOrderByFields(searchParamsPair []*commonpb.KeyValuePair, schema *schem
 			case "desc", "descending":
 				ascending = false
 			default:
-				return nil, fmt.Errorf("invalid order direction '%s' for field '%s', expected 'asc' or 'desc'", direction, fieldSpec)
+				return nil, merr.WrapErrParameterInvalidMsg("invalid order direction '%s' for field '%s', expected 'asc' or 'desc'", direction, fieldSpec)
 			}
 		}
 
@@ -278,7 +277,7 @@ func parseOrderByFieldSpec(fieldSpec string, fieldSchemaMap map[string]*schemapb
 				fieldID = field.GetFieldID()
 				jsonPath, err = typeutil2.ParseAndVerifyNestedPath(fieldSpec, schema, fieldID)
 				if err != nil {
-					return "", 0, "", "", false, fmt.Errorf("invalid JSON path in order_by field '%s': %w", fieldSpec, err)
+					return "", 0, "", "", false, merr.WrapErrParameterInvalidMsg("invalid JSON path in order_by field '%s': %v", fieldSpec, err)
 				}
 				outputFieldName = fieldSpec // Explicit $meta["key"] path; single-level, parser accepts it
 				isDynamicField = true
@@ -289,13 +288,13 @@ func parseOrderByFieldSpec(fieldSpec string, fieldSchemaMap map[string]*schemapb
 				fieldID = field.GetFieldID()
 				jsonPath, err = typeutil2.ParseAndVerifyNestedPath(fieldSpec, schema, fieldID)
 				if err != nil {
-					return "", 0, "", "", false, fmt.Errorf("invalid JSON path in order_by field '%s': %w", fieldSpec, err)
+					return "", 0, "", "", false, merr.WrapErrParameterInvalidMsg("invalid JSON path in order_by field '%s': %v", fieldSpec, err)
 				}
 				outputFieldName = baseName // Request the whole JSON field
 				isDynamicField = false
 			} else {
 				// Non-JSON field with brackets - not supported
-				return "", 0, "", "", false, fmt.Errorf("order_by field '%s' has brackets but is not a JSON type", fieldSpec)
+				return "", 0, "", "", false, merr.WrapErrParameterInvalidMsg("order_by field '%s' has brackets but is not a JSON type", fieldSpec)
 			}
 		} else if dynamicField != nil {
 			// Unknown field name with brackets, treat as dynamic field path
@@ -304,13 +303,13 @@ func parseOrderByFieldSpec(fieldSpec string, fieldSchemaMap map[string]*schemapb
 			fieldID = dynamicField.GetFieldID()
 			jsonPath, err = typeutil2.ParseAndVerifyNestedPath(fieldSpec, schema, fieldID)
 			if err != nil {
-				return "", 0, "", "", false, fmt.Errorf("invalid JSON path in order_by field '%s': %w", fieldSpec, err)
+				return "", 0, "", "", false, merr.WrapErrParameterInvalidMsg("invalid JSON path in order_by field '%s': %v", fieldSpec, err)
 			}
 			// Request the base dynamic field; full path is in jsonPath
 			outputFieldName = baseName
 			isDynamicField = true
 		} else {
-			return "", 0, "", "", false, fmt.Errorf("order_by field '%s' not found in schema and no dynamic field available", baseName)
+			return "", 0, "", "", false, merr.WrapErrParameterInvalidMsg("order_by field '%s' not found in schema and no dynamic field available", baseName)
 		}
 	} else {
 		// No brackets - regular field name or dynamic field key
@@ -323,7 +322,7 @@ func parseOrderByFieldSpec(fieldSpec string, fieldSchemaMap map[string]*schemapb
 			isDynamicField = false
 			// Validate sortable type
 			if !isSortableFieldType(field.GetDataType()) {
-				return "", 0, "", "", false, fmt.Errorf("order_by field '%s' has unsortable type %s; supported types: bool, int8/16/32/64, float, double, string, varchar; for JSON fields use path syntax like field[\"key\"]",
+				return "", 0, "", "", false, merr.WrapErrParameterInvalidMsg("order_by field '%s' has unsortable type %s; supported types: bool, int8/16/32/64, float, double, string, varchar; for JSON fields use path syntax like field[\"key\"]",
 					fieldSpec, field.GetDataType().String())
 			}
 		} else if dynamicField != nil {
@@ -332,13 +331,13 @@ func parseOrderByFieldSpec(fieldSpec string, fieldSchemaMap map[string]*schemapb
 			fieldID = dynamicField.GetFieldID()
 			jsonPath, err = typeutil2.ParseAndVerifyNestedPath(fieldSpec, schema, fieldID)
 			if err != nil {
-				return "", 0, "", "", false, fmt.Errorf("invalid dynamic field key '%s': %w", fieldSpec, err)
+				return "", 0, "", "", false, merr.WrapErrParameterInvalidMsg("invalid dynamic field key '%s': %v", fieldSpec, err)
 			}
 			// For dynamic fields, pass the original key so translateOutputFields can extract it
 			outputFieldName = fieldSpec
 			isDynamicField = true
 		} else {
-			return "", 0, "", "", false, fmt.Errorf("order_by field '%s' does not exist in collection schema", fieldSpec)
+			return "", 0, "", "", false, merr.WrapErrParameterInvalidMsg("order_by field '%s' does not exist in collection schema", fieldSpec)
 		}
 	}
 
@@ -375,7 +374,7 @@ func parseSearchIteratorV2Info(searchParamsPair []*commonpb.KeyValuePair, groupB
 
 	// iteratorV1 and iteratorV2 should be set together for compatibility
 	if !isIterator {
-		return nil, fmt.Errorf("both %s and %s must be set in the SDK", IteratorField, SearchIterV2Key)
+		return nil, merr.WrapErrParameterInvalidMsg("both %s and %s must be set in the SDK", IteratorField, SearchIterV2Key)
 	}
 
 	// disable groupBy when doing iteratorV2
@@ -402,22 +401,22 @@ func parseSearchIteratorV2Info(searchParamsPair []*commonpb.KeyValuePair, groupB
 	} else {
 		// Validate existing token is a valid UUID
 		if _, err := uuid.Parse(token); err != nil {
-			return nil, errors.New("invalid token format")
+			return nil, merr.WrapErrParameterInvalidMsg("invalid token format")
 		}
 	}
 
 	// parse batch size, required non-zero value
 	batchSizeStr, _ := funcutil.GetAttrByKeyFromRepeatedKV(SearchIterBatchSizeKey, searchParamsPair)
 	if batchSizeStr == "" {
-		return nil, errors.New("batch size is required")
+		return nil, merr.WrapErrParameterInvalidMsg("batch size is required")
 	}
 	batchSize, err := strconv.ParseInt(batchSizeStr, 0, 64)
 	if err != nil {
-		return nil, fmt.Errorf("batch size is invalid, %w", err)
+		return nil, merr.WrapErrParameterInvalidMsg("batch size is invalid, %v", err)
 	}
 	// use the same validation logic as topk
 	if err := validateLimit(batchSize, largeTopKEnabled); err != nil {
-		return nil, fmt.Errorf("batch size is invalid, %w", err)
+		return nil, merr.WrapErrParameterInvalidMsg("batch size is invalid, %v", err)
 	}
 	*queryTopK = batchSize // for compatibility
 
@@ -432,7 +431,7 @@ func parseSearchIteratorV2Info(searchParamsPair []*commonpb.KeyValuePair, groupB
 	if lastBoundStr != "" {
 		lastBound, err := strconv.ParseFloat(lastBoundStr, 32)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse input last bound, %w", err)
+			return nil, merr.WrapErrParameterInvalidMsg("failed to parse input last bound, %v", err)
 		}
 		lastBoundFloat32 := float32(lastBound)
 		planIteratorV2Info.LastBound = &lastBoundFloat32 // escape pointer
@@ -449,14 +448,14 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 	topKStr, err := funcutil.GetAttrByKeyFromRepeatedKV(TopKKey, searchParamsPair)
 	if err != nil {
 		if externalLimit <= 0 {
-			return nil, fmt.Errorf("%s is required", TopKKey)
+			return nil, merr.WrapErrParameterInvalidMsg("%s is required", TopKKey)
 		}
 		topK = externalLimit
 	} else {
 		topKInParam, err := strconv.ParseInt(topKStr, 0, 64)
 		if err != nil {
 			if externalLimit <= 0 {
-				return nil, fmt.Errorf("%s [%s] is invalid", TopKKey, topKStr)
+				return nil, merr.WrapErrParameterInvalidMsg("%s [%s] is invalid", TopKKey, topKStr)
 			}
 			topK = externalLimit
 		} else {
@@ -480,7 +479,7 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 				topK = Params.QuotaConfig.TopKLimit.GetAsInt64()
 			}
 		} else {
-			return nil, fmt.Errorf("%s [%d] is invalid, %w", TopKKey, topK, err)
+			return nil, merr.WrapErrParameterInvalidMsg("%s [%d] is invalid, %v", TopKKey, topK, err)
 		}
 	}
 
@@ -491,12 +490,12 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 		if err == nil {
 			offset, err = strconv.ParseInt(offsetStr, 0, 64)
 			if err != nil {
-				return nil, fmt.Errorf("%s [%s] is invalid", OffsetKey, offsetStr)
+				return nil, merr.WrapErrParameterInvalidMsg("%s [%s] is invalid", OffsetKey, offsetStr)
 			}
 
 			if offset != 0 {
 				if err := validateLimit(offset, largeTopKEnabled); err != nil {
-					return nil, fmt.Errorf("%s [%d] is invalid, %w", OffsetKey, offset, err)
+					return nil, merr.WrapErrParameterInvalidMsg("%s [%d] is invalid, %v", OffsetKey, offset, err)
 				}
 			}
 		}
@@ -504,7 +503,7 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 
 	queryTopK := topK + offset
 	if err := validateLimit(queryTopK, largeTopKEnabled); err != nil {
-		return nil, fmt.Errorf("%s+%s [%d] is invalid, %w", OffsetKey, TopKKey, queryTopK, err)
+		return nil, merr.WrapErrParameterInvalidMsg("%s+%s [%d] is invalid, %v", OffsetKey, TopKKey, queryTopK, err)
 	}
 
 	// 2. parse metrics type
@@ -526,11 +525,11 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 
 	roundDecimal, err := strconv.ParseInt(roundDecimalStr, 0, 64)
 	if err != nil {
-		return nil, fmt.Errorf("%s [%s] is invalid, should be -1 or an integer in range [0, 6]", RoundDecimalKey, roundDecimalStr)
+		return nil, merr.WrapErrParameterInvalidMsg("%s [%s] is invalid, should be -1 or an integer in range [0, 6]", RoundDecimalKey, roundDecimalStr)
 	}
 
 	if roundDecimal != -1 && (roundDecimal > 6 || roundDecimal < 0) {
-		return nil, fmt.Errorf("%s [%s] is invalid, should be -1 or an integer in range [0, 6]", RoundDecimalKey, roundDecimalStr)
+		return nil, merr.WrapErrParameterInvalidMsg("%s [%s] is invalid, should be -1 or an integer in range [0, 6]", RoundDecimalKey, roundDecimalStr)
 	}
 
 	// 4. parse search param str
@@ -584,7 +583,7 @@ func parseSearchInfo(searchParamsPair []*commonpb.KeyValuePair, schema *schemapb
 
 	planSearchIteratorV2Info, err := parseSearchIteratorV2Info(searchParamsPair, groupByFieldId, isIterator, offset, &queryTopK, largeTopKEnabled)
 	if err != nil {
-		return nil, fmt.Errorf("parse iterator v2 info failed: %w", err)
+		return nil, merr.WrapErrParameterInvalidMsg("parse iterator v2 info failed: %v", err)
 	}
 
 	// 7. parse order_by_fields
@@ -628,7 +627,7 @@ func getOutputFieldIDs(schema *schemaInfo, outputFields []string) (outputFieldID
 	for _, name := range outputFields {
 		id, ok := schema.MapFieldID(name)
 		if !ok {
-			return nil, fmt.Errorf("field %s not exist", name)
+			return nil, merr.WrapErrParameterInvalidMsg("Field %s not exist", name)
 		}
 		outputFieldIDs = append(outputFieldIDs, id)
 	}
@@ -690,7 +689,7 @@ func getPartitionIDs(ctx context.Context, dbName string, collectionName string, 
 			pattern := fmt.Sprintf("^%s$", partitionName)
 			re, err := regexp.Compile(pattern)
 			if err != nil {
-				return nil, fmt.Errorf("invalid partition: %s", partitionName)
+				return nil, merr.WrapErrParameterInvalidMsg("invalid partition: %s", partitionName)
 			}
 			var found bool
 			for name, pID := range partitionsMap {
@@ -700,13 +699,13 @@ func getPartitionIDs(ctx context.Context, dbName string, collectionName string, 
 				}
 			}
 			if !found {
-				return nil, fmt.Errorf("partition name %s not found", partitionName)
+				return nil, merr.WrapErrParameterInvalidMsg("partition name %s not found", partitionName)
 			}
 		} else {
 			partitionID, found := partitionsMap[partitionName]
 			if !found {
 				// TODO change after testcase updated: return nil, merr.WrapErrPartitionNotFound(partitionName)
-				return nil, fmt.Errorf("partition name %s not found", partitionName)
+				return nil, merr.WrapErrParameterInvalidMsg("partition name %s not found", partitionName)
 			}
 			partitionsSet.Insert(partitionID)
 		}
@@ -975,24 +974,24 @@ func parseRankParams(rankParamsPair []*commonpb.KeyValuePair, schema *schemapb.C
 
 	limitStr, err := funcutil.GetAttrByKeyFromRepeatedKV(LimitKey, rankParamsPair)
 	if err != nil {
-		return nil, errors.New(LimitKey + " not found in rank_params")
+		return nil, merr.WrapErrParameterInvalidMsg(LimitKey + " not found in rank_params")
 	}
 	limit, err = strconv.ParseInt(limitStr, 0, 64)
 	if err != nil {
-		return nil, fmt.Errorf("%s [%s] is invalid", LimitKey, limitStr)
+		return nil, merr.WrapErrParameterInvalidMsg("%s [%s] is invalid", LimitKey, limitStr)
 	}
 
 	offsetStr, err := funcutil.GetAttrByKeyFromRepeatedKV(OffsetKey, rankParamsPair)
 	if err == nil {
 		offset, err = strconv.ParseInt(offsetStr, 0, 64)
 		if err != nil {
-			return nil, fmt.Errorf("%s [%s] is invalid", OffsetKey, offsetStr)
+			return nil, merr.WrapErrParameterInvalidMsg("%s [%s] is invalid", OffsetKey, offsetStr)
 		}
 	}
 
 	// validate max result window.
 	if err = validateMaxQueryResultWindow(offset, limit, largeTopKEnabled); err != nil {
-		return nil, fmt.Errorf("invalid max query result window, %w", err)
+		return nil, merr.WrapErrParameterInvalidMsg("invalid max query result window, %v", err)
 	}
 
 	roundDecimalStr, err := funcutil.GetAttrByKeyFromRepeatedKV(RoundDecimalKey, rankParamsPair)
@@ -1002,11 +1001,11 @@ func parseRankParams(rankParamsPair []*commonpb.KeyValuePair, schema *schemapb.C
 
 	roundDecimal, err = strconv.ParseInt(roundDecimalStr, 0, 64)
 	if err != nil {
-		return nil, fmt.Errorf("%s [%s] is invalid, should be -1 or an integer in range [0, 6]", RoundDecimalKey, roundDecimalStr)
+		return nil, merr.WrapErrParameterInvalidMsg("%s [%s] is invalid, should be -1 or an integer in range [0, 6]", RoundDecimalKey, roundDecimalStr)
 	}
 
 	if roundDecimal != -1 && (roundDecimal > 6 || roundDecimal < 0) {
-		return nil, fmt.Errorf("%s [%s] is invalid, should be -1 or an integer in range [0, 6]", RoundDecimalKey, roundDecimalStr)
+		return nil, merr.WrapErrParameterInvalidMsg("%s [%s] is invalid, should be -1 or an integer in range [0, 6]", RoundDecimalKey, roundDecimalStr)
 	}
 
 	// parse group_by parameters from main request body for hybrid search

--- a/internal/proxy/service_provider.go
+++ b/internal/proxy/service_provider.go
@@ -58,7 +58,7 @@ func NewInterceptor[Req Request, Resp Response](proxy *Proxy, method string) (*I
 		}
 		return interface{}(interceptor).(*InterceptorImpl[Req, Resp]), nil
 	default:
-		return nil, fmt.Errorf("method %s not supported", method)
+		return nil, merr.WrapErrParameterInvalidMsg("method %s not supported", method)
 	}
 }
 

--- a/internal/proxy/shardclient/lb_policy.go
+++ b/internal/proxy/shardclient/lb_policy.go
@@ -18,7 +18,6 @@ package shardclient
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -424,7 +423,7 @@ func (lb *LBPolicyImpl) ExecuteOneChannel(ctx context.Context, workload Collecti
 			PreferredNodeID: preferredNodeID(workload, channel),
 		})
 	}
-	return fmt.Errorf("no acitvate sheard leader exist for collection: %s", workload.CollectionName)
+	return merr.WrapErrParameterInvalidMsg("no acitvate sheard leader exist for collection: %s", workload.CollectionName)
 }
 
 func (lb *LBPolicyImpl) UpdateCostMetrics(node int64, cost *internalpb.CostAggregation) {

--- a/internal/proxy/shardclient/shard_client.go
+++ b/internal/proxy/shardclient/shard_client.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -46,7 +47,7 @@ func (n NodeInfo) String() string {
 	return fmt.Sprintf("<NodeID: %d, serviceable: %v, address: %s>", n.NodeID, n.Serviceable, n.Address)
 }
 
-var errClosed = errors.New("client is closed")
+var errClosed = merr.WrapErrParameterInvalidMsg("client is closed")
 
 type shardClient struct {
 	sync.RWMutex
@@ -132,7 +133,7 @@ func (n *shardClient) roundRobinSelectClient() (types.QueryNodeClient, error) {
 	}
 
 	if len(n.clients) == 0 {
-		return nil, errors.New("no available clients")
+		return nil, merr.WrapErrParameterInvalidMsg("no available clients")
 	}
 
 	nextClientIndex := n.idx.Inc() % int64(len(n.clients))

--- a/internal/proxy/simple_rate_limiter.go
+++ b/internal/proxy/simple_rate_limiter.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/proxypb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/ratelimitutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
@@ -284,7 +285,7 @@ func (m *SimpleLimiter) updateLimiterNode(req *proxypb.Limiter, node *rlinternal
 	for _, rate := range req.GetRates() {
 		limit, ok := curLimiters.Get(rate.GetRt())
 		if !ok {
-			return fmt.Errorf("unregister rateLimiter for rateType %s", rate.GetRt().String())
+			return merr.WrapErrParameterInvalidMsg("unregister rateLimiter for rateType %s", rate.GetRt().String())
 		}
 		limit.SetLimit(ratelimitutil.Limit(rate.GetR()))
 		setRateGaugeByRateType(rate.GetRt(), paramtable.GetNodeID(), sourceID, rate.GetR())

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -682,7 +682,7 @@ func (t *addCollectionFieldTask) PreExecute(ctx context.Context) error {
 	// User-added fields must be nullable so that old segments without this field can return
 	// NULL rather than causing a schema inconsistency at query time.
 	if !t.fieldSchema.GetNullable() {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("added field must be nullable, please check it, field name = %s", t.fieldSchema.GetName()))
+		return merr.WrapErrParameterInvalidMsg("added field must be nullable, please check it, field name = %s", t.fieldSchema.GetName())
 	}
 	if err := ValidateField(t.fieldSchema, t.oldSchema); err != nil {
 		return err
@@ -919,7 +919,7 @@ func validateAddFieldRequest(schema *schemapb.CollectionSchema, newFieldSchema *
 		return merr.WrapErrParameterInvalidMsg("The number of fields has reached the maximum value %d", Params.ProxyCfg.MaxFieldNum.GetAsInt())
 	}
 	if fieldList.Contain(newFieldSchema.GetName()) {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("duplicated field name %s", newFieldSchema.GetName()))
+		return merr.WrapErrParameterInvalidMsg("duplicated field name %s", newFieldSchema.GetName())
 	}
 
 	// --- new field property constraints ---
@@ -930,13 +930,13 @@ func validateAddFieldRequest(schema *schemapb.CollectionSchema, newFieldSchema *
 		return merr.WrapErrParameterInvalidMsg("add field operation does not support external field mapping, field name = %s", newFieldSchema.GetName())
 	}
 	if funcutil.SliceContain([]string{common.RowIDFieldName, common.TimeStampFieldName, common.MetaFieldName, common.NamespaceFieldName, common.VirtualPKFieldName}, newFieldSchema.GetName()) {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("not support to add system field, field name = %s", newFieldSchema.GetName()))
+		return merr.WrapErrParameterInvalidMsg("not support to add system field, field name = %s", newFieldSchema.GetName())
 	}
 	if newFieldSchema.GetIsPrimaryKey() {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("not support to add pk field, field name = %s", newFieldSchema.GetName()))
+		return merr.WrapErrParameterInvalidMsg("not support to add pk field, field name = %s", newFieldSchema.GetName())
 	}
 	if newFieldSchema.GetAutoID() {
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("only primary field can speficy AutoID with true, field name = %s", newFieldSchema.GetName()))
+		return merr.WrapErrParameterInvalidMsg("only primary field can speficy AutoID with true, field name = %s", newFieldSchema.GetName())
 	}
 	if newFieldSchema.GetIsPartitionKey() {
 		return merr.WrapErrParameterInvalidMsg("not support to add partition key field, field name  = %s", newFieldSchema.GetName())
@@ -949,7 +949,7 @@ func validateAddFieldRequest(schema *schemapb.CollectionSchema, newFieldSchema *
 		}
 		for _, f := range schema.GetFields() {
 			if f.GetIsClusteringKey() {
-				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("already has another clustering key field, field name: %s", newFieldSchema.GetName()))
+				return merr.WrapErrParameterInvalidMsg("already has another clustering key field, field name: %s", newFieldSchema.GetName())
 			}
 		}
 	}
@@ -975,7 +975,7 @@ func validateAddFieldRequest(schema *schemapb.CollectionSchema, newFieldSchema *
 			newFieldSchema.DataType == schemapb.DataType_BinaryVector ||
 			newFieldSchema.DataType == schemapb.DataType_Int8Vector {
 			if len(newFieldSchema.TypeParams) == 0 {
-				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("vector field must have dimension specified, field name = %s", newFieldSchema.GetName()))
+				return merr.WrapErrParameterInvalidMsg("vector field must have dimension specified, field name = %s", newFieldSchema.GetName())
 			}
 		}
 	}

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -261,11 +261,11 @@ func (t *createCollectionTask) validatePartitionKey(ctx context.Context) error {
 	for i, field := range t.schema.Fields {
 		if field.GetIsPartitionKey() {
 			if idx != -1 {
-				return fmt.Errorf("there are more than one partition key, field name = %s, %s", t.schema.Fields[idx].Name, field.Name)
+				return merr.WrapErrParameterInvalidMsg("there are more than one partition key, field name = %s, %s", t.schema.Fields[idx].Name, field.Name)
 			}
 
 			if field.GetIsPrimaryKey() {
-				return errors.New("the partition key field must not be primary field")
+				return merr.WrapErrParameterInvalidMsg("the partition key field must not be primary field")
 			}
 
 			if field.GetNullable() {
@@ -274,11 +274,11 @@ func (t *createCollectionTask) validatePartitionKey(ctx context.Context) error {
 
 			// The type of the partition key field can only be int64 and varchar
 			if field.DataType != schemapb.DataType_Int64 && field.DataType != schemapb.DataType_VarChar {
-				return errors.New("the data type of partition key should be Int64 or VarChar")
+				return merr.WrapErrParameterInvalidMsg("the data type of partition key should be Int64 or VarChar")
 			}
 
 			if t.GetNumPartitions() < 0 {
-				return errors.New("the specified partitions should be greater than 0 if partition key is used")
+				return merr.WrapErrParameterInvalidMsg("the specified partitions should be greater than 0 if partition key is used")
 			}
 
 			maxPartitionNum := Params.RootCoordCfg.MaxPartitionNum.GetAsInt64()
@@ -318,7 +318,7 @@ func (t *createCollectionTask) validatePartitionKey(ctx context.Context) error {
 
 	if idx == -1 {
 		if t.GetNumPartitions() != 0 {
-			return errors.New("num_partitions should only be specified with partition key field enabled")
+			return merr.WrapErrParameterInvalidMsg("num_partitions should only be specified with partition key field enabled")
 		}
 	} else {
 		log.Ctx(ctx).Info("create collection with partition key mode",
@@ -451,21 +451,21 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 	// External collections must be single-shard: the refresh mechanism assigns all
 	// segments to VChannelNames[0], so multiple shards would leave segments orphaned.
 	if isExternalCollection && t.ShardsNum > 1 {
-		return fmt.Errorf("external collection does not support multiple shards, got ShardsNum=%d", t.ShardsNum)
+		return merr.WrapErrParameterInvalidMsg("external collection does not support multiple shards, got ShardsNum=%d", t.ShardsNum)
 	}
 
 	if t.ShardsNum > Params.ProxyCfg.MaxShardNum.GetAsInt32() {
-		return fmt.Errorf("maximum shards's number should be limited to %d", Params.ProxyCfg.MaxShardNum.GetAsInt())
+		return merr.WrapErrParameterInvalidMsg("maximum shards's number should be limited to %d", Params.ProxyCfg.MaxShardNum.GetAsInt())
 	}
 
 	totalFieldsNum := typeutil.GetTotalFieldsNum(t.schema)
 	if totalFieldsNum > Params.ProxyCfg.MaxFieldNum.GetAsInt() {
-		return fmt.Errorf("maximum field's number should be limited to %d", Params.ProxyCfg.MaxFieldNum.GetAsInt())
+		return merr.WrapErrParameterInvalidMsg("maximum field's number should be limited to %d", Params.ProxyCfg.MaxFieldNum.GetAsInt())
 	}
 
 	vectorFields := len(typeutil.GetVectorFieldSchemas(t.schema))
 	if vectorFields > Params.ProxyCfg.MaxVectorFieldNum.GetAsInt() {
-		return fmt.Errorf("maximum vector field's number should be limited to %d", Params.ProxyCfg.MaxVectorFieldNum.GetAsInt())
+		return merr.WrapErrParameterInvalidMsg("maximum vector field's number should be limited to %d", Params.ProxyCfg.MaxVectorFieldNum.GetAsInt())
 	}
 
 	if vectorFields == 0 {
@@ -578,7 +578,7 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 	// This allows different structs to have fields with the same name
 	err = transformStructFieldNames(t.schema)
 	if err != nil {
-		return fmt.Errorf("failed to transform struct field names: %v", err)
+		return merr.WrapErrParameterInvalidMsg("failed to transform struct field names: %v", err)
 	}
 
 	// validate whether field names duplicates (after transformation)
@@ -916,8 +916,7 @@ func validateAddFieldRequest(schema *schemapb.CollectionSchema, newFieldSchema *
 		fieldList.Insert(structArrayField.GetName())
 	}
 	if typeutil.GetTotalFieldsNum(schema) >= Params.ProxyCfg.MaxFieldNum.GetAsInt() {
-		msg := fmt.Sprintf("The number of fields has reached the maximum value %d", Params.ProxyCfg.MaxFieldNum.GetAsInt())
-		return merr.WrapErrParameterInvalidMsg(msg)
+		return merr.WrapErrParameterInvalidMsg("The number of fields has reached the maximum value %d", Params.ProxyCfg.MaxFieldNum.GetAsInt())
 	}
 	if fieldList.Contain(newFieldSchema.GetName()) {
 		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("duplicated field name %s", newFieldSchema.GetName()))
@@ -957,7 +956,7 @@ func validateAddFieldRequest(schema *schemapb.CollectionSchema, newFieldSchema *
 	if typeutil.IsVectorType(newFieldSchema.DataType) {
 		vectorFields := len(typeutil.GetVectorFieldSchemas(schema))
 		if vectorFields >= Params.ProxyCfg.MaxVectorFieldNum.GetAsInt() {
-			return fmt.Errorf("maximum vector field's number should be limited to %d", Params.ProxyCfg.MaxVectorFieldNum.GetAsInt())
+			return merr.WrapErrParameterInvalidMsg("maximum vector field's number should be limited to %d", Params.ProxyCfg.MaxVectorFieldNum.GetAsInt())
 		}
 	}
 
@@ -1552,7 +1551,7 @@ func (t *describeCollectionTask) Execute(ctx context.Context) error {
 	}
 
 	if err := restoreStructFieldNames(t.result.Schema); err != nil {
-		return fmt.Errorf("failed to restore struct field names: %v", err)
+		return merr.WrapErrParameterInvalidMsg("failed to restore struct field names: %v", err)
 	}
 
 	return nil
@@ -1660,7 +1659,7 @@ func (t *showCollectionsTask) Execute(ctx context.Context) error {
 		}
 
 		if resp == nil {
-			return errors.New("failed to show collections")
+			return merr.WrapErrParameterInvalidMsg("failed to show collections")
 		}
 
 		if resp.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
@@ -1669,7 +1668,7 @@ func (t *showCollectionsTask) Execute(ctx context.Context) error {
 			for _, collectionID := range collectionIDs {
 				newErrorReason = ReplaceID2Name(newErrorReason, collectionID, IDs2Names[collectionID])
 			}
-			return errors.New(newErrorReason)
+			return merr.WrapErrParameterInvalidMsg("%s", newErrorReason)
 		}
 
 		t.result = &milvuspb.ShowCollectionsResponse{
@@ -2421,7 +2420,7 @@ func (t *createPartitionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 	if typeutil.HasPartitionKey(collSchema.CollectionSchema) {
-		return errors.New("disable create partition if partition key mode is used")
+		return merr.WrapErrParameterInvalidMsg("disable create partition if partition key mode is used")
 	}
 
 	if err := validatePartitionTag(partitionTag, true); err != nil {
@@ -2520,7 +2519,7 @@ func (t *dropPartitionTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 	if typeutil.HasPartitionKey(collSchema.CollectionSchema) {
-		return errors.New("disable drop partition if partition key mode is used")
+		return merr.WrapErrParameterInvalidMsg("disable drop partition if partition key mode is used")
 	}
 
 	if err := validatePartitionTag(partitionTag, true); err != nil {
@@ -2549,7 +2548,7 @@ func (t *dropPartitionTask) PreExecute(ctx context.Context) error {
 			return err
 		}
 		if loaded {
-			return errors.New("partition cannot be dropped, partition is loaded, please release it first")
+			return merr.WrapErrParameterInvalidMsg("partition cannot be dropped, partition is loaded, please release it first")
 		}
 	}
 
@@ -2759,7 +2758,7 @@ func (t *showPartitionsTask) Execute(ctx context.Context) error {
 			if !ok {
 				log.Ctx(ctx).Debug("Failed to get partition id.", zap.String("partitionName", partitionName),
 					zap.Int64("requestID", t.Base.MsgID), zap.String("requestType", "showPartitions"))
-				return errors.New("failed to show partitions")
+				return merr.WrapErrParameterInvalidMsg("failed to show partitions")
 			}
 			partitionInfo, err := globalMetaCache.GetPartitionInfo(ctx, t.GetDbName(), collectionName, partitionName)
 			if err != nil {
@@ -2918,7 +2917,7 @@ func (t *loadCollectionTask) Execute(ctx context.Context) (err error) {
 	if len(unindexedVecFields) != 0 {
 		errMsg := fmt.Sprintf("there is no vector index on field: %v, please create index firstly", unindexedVecFields)
 		log.Debug(errMsg)
-		return errors.New(errMsg)
+		return merr.WrapErrParameterInvalidMsg("%s", errMsg)
 	}
 	request := &querypb.LoadCollectionRequest{
 		Base: commonpbutil.UpdateMsgBase(
@@ -2940,7 +2939,7 @@ func (t *loadCollectionTask) Execute(ctx context.Context) (err error) {
 		zap.Int32("priority", int32(request.GetPriority())))
 	t.result, err = t.mixCoord.LoadCollection(ctx, request)
 	if err = merr.CheckRPCCall(t.result, err); err != nil {
-		return fmt.Errorf("call query coordinator LoadCollection: %s", err)
+		return merr.WrapErrParameterInvalidMsg("call query coordinator LoadCollection: %s", err)
 	}
 	return nil
 }
@@ -3109,7 +3108,7 @@ func (t *loadPartitionsTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 	if partitionKeyMode {
-		return errors.New("disable load partitions if partition key mode is used")
+		return merr.WrapErrParameterInvalidMsg("disable load partitions if partition key mode is used")
 	}
 
 	return nil
@@ -3175,7 +3174,7 @@ func (t *loadPartitionsTask) Execute(ctx context.Context) error {
 	if len(unindexedVecFields) != 0 {
 		errMsg := fmt.Sprintf("there is no vector index on field: %v, please create index firstly", unindexedVecFields)
 		log.Ctx(ctx).Debug(errMsg)
-		return errors.New(errMsg)
+		return merr.WrapErrParameterInvalidMsg("%s", errMsg)
 	}
 
 	for _, partitionName := range t.PartitionNames {
@@ -3186,7 +3185,7 @@ func (t *loadPartitionsTask) Execute(ctx context.Context) error {
 		partitionIDs = append(partitionIDs, partitionID)
 	}
 	if len(partitionIDs) == 0 {
-		return errors.New("failed to load partition, due to no partition specified")
+		return merr.WrapErrParameterInvalidMsg("failed to load partition, due to no partition specified")
 	}
 	request := &querypb.LoadPartitionsRequest{
 		Base: commonpbutil.UpdateMsgBase(
@@ -3283,7 +3282,7 @@ func (t *releasePartitionsTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 	if partitionKeyMode {
-		return errors.New("disable release partitions if partition key mode is used")
+		return merr.WrapErrParameterInvalidMsg("disable release partitions if partition key mode is used")
 	}
 
 	return nil
@@ -4055,7 +4054,7 @@ func isIgnoreGrowing(params []*commonpb.KeyValuePair) (bool, error) {
 		if kv.GetKey() == IgnoreGrowingKey {
 			ignoreGrowing, err := strconv.ParseBool(kv.GetValue())
 			if err != nil {
-				return false, errors.New("parse ignore growing field failed")
+				return false, merr.WrapErrParameterInvalidMsg("parse ignore growing field failed")
 			}
 			return ignoreGrowing, nil
 		}

--- a/internal/proxy/task_delete.go
+++ b/internal/proxy/task_delete.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -311,7 +310,7 @@ func (dr *deleteRunner) Init(ctx context.Context) error {
 	partName := dr.req.GetPartitionName()
 	if dr.schema.IsPartitionKeyCollection() {
 		if len(partName) > 0 {
-			return errors.New("not support manually specifying the partition names if partition key mode is used")
+			return merr.WrapErrParameterInvalidMsg("not support manually specifying the partition names if partition key mode is used")
 		}
 		expr, err := exprutil.ParseExprFromPlan(dr.plan)
 		if err != nil {
@@ -641,7 +640,7 @@ func getPrimaryKeysFromUnaryRangeExpr(schema *schemapb.CollectionSchema, unaryRa
 			},
 		}
 	default:
-		return pks, errors.New("invalid field data type specifyed in simple delete expr")
+		return pks, merr.WrapErrParameterInvalidMsg("invalid field data type specifyed in simple delete expr")
 	}
 
 	return pks, nil
@@ -672,7 +671,7 @@ func getPrimaryKeysFromTermExpr(schema *schemapb.CollectionSchema, termExpr *pla
 			},
 		}
 	default:
-		return pks, 0, errors.New("invalid field data type specifyed in simple delete expr")
+		return pks, 0, merr.WrapErrParameterInvalidMsg("invalid field data type specifyed in simple delete expr")
 	}
 
 	return pks, pkCount, nil

--- a/internal/proxy/task_flush_all_streaming.go
+++ b/internal/proxy/task_flush_all_streaming.go
@@ -18,7 +18,6 @@ package proxy
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/samber/lo"
 
@@ -35,7 +34,7 @@ func (t *flushAllTask) Execute(ctx context.Context) error {
 		Base: commonpbutil.NewMsgBase(commonpbutil.WithMsgType(commonpb.MsgType_Flush)),
 	})
 	if err = merr.CheckRPCCall(resp, err); err != nil {
-		return fmt.Errorf("failed to call flush all to data coordinator: %s", err.Error())
+		return merr.WrapErrParameterInvalidMsg("failed to call flush all to data coordinator: %s", err.Error())
 	}
 	t.result = &milvuspb.FlushAllResponse{
 		Status:       merr.Success(),

--- a/internal/proxy/task_flush_streaming.go
+++ b/internal/proxy/task_flush_streaming.go
@@ -18,7 +18,6 @@ package proxy
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/zap"
 
@@ -92,7 +91,7 @@ func (t *flushTask) Execute(ctx context.Context) error {
 		}
 		resp, err := t.mixCoord.Flush(ctx, flushReq)
 		if err = merr.CheckRPCCall(resp, err); err != nil {
-			return fmt.Errorf("failed to call flush to data coordinator: %s", err.Error())
+			return merr.WrapErrParameterInvalidMsg("failed to call flush to data coordinator: %s", err.Error())
 		}
 
 		// Remove the flushed segments from onFlushSegmentIDs

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -548,43 +548,43 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 		}
 		metricType, metricTypeExist := indexParamsMap[common.MetricTypeKey]
 		if !metricTypeExist {
-			return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "metric type not set for vector index")
+			return merr.WrapErrParameterInvalidMsg("%s", "metric type not set for vector index")
 		}
 		if typeutil.IsDenseFloatVectorType(cit.fieldSchema.DataType) {
 			if !funcutil.SliceContain(indexparamcheck.FloatVectorMetrics, metricType) {
-				return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "float vector index does not support metric type: "+metricType)
+				return merr.WrapErrParameterInvalidMsg("%s", "float vector index does not support metric type: "+metricType)
 			}
 		} else if typeutil.IsSparseFloatVectorType(cit.fieldSchema.DataType) {
 			if !funcutil.SliceContain(indexparamcheck.SparseFloatVectorMetrics, metricType) {
-				return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "only IP&BM25 is the supported metric type for sparse index")
+				return merr.WrapErrParameterInvalidMsg("%s", "only IP&BM25 is the supported metric type for sparse index")
 			}
 			if metricType == metric.BM25 && cit.functionSchema.GetType() != schemapb.FunctionType_BM25 {
-				return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "only BM25 Function output field support BM25 metric type")
+				return merr.WrapErrParameterInvalidMsg("%s", "only BM25 Function output field support BM25 metric type")
 			}
 		} else if typeutil.IsBinaryVectorType(cit.fieldSchema.DataType) {
 			if !funcutil.SliceContain(indexparamcheck.BinaryVectorMetrics, metricType) {
-				return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "binary vector index does not support metric type: "+metricType)
+				return merr.WrapErrParameterInvalidMsg("%s", "binary vector index does not support metric type: "+metricType)
 			}
 		} else if typeutil.IsIntVectorType(cit.fieldSchema.DataType) {
 			if !funcutil.SliceContain(indexparamcheck.IntVectorMetrics, metricType) {
-				return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "int vector index does not support metric type: "+metricType)
+				return merr.WrapErrParameterInvalidMsg("%s", "int vector index does not support metric type: "+metricType)
 			}
 		} else if typeutil.IsArrayOfVectorType(cit.fieldSchema.DataType) {
 			if !funcutil.SliceContain(indexparamcheck.EmbListMetrics, metricType) {
 				if typeutil.IsDenseFloatVectorType(cit.fieldSchema.ElementType) {
 					if !funcutil.SliceContain(indexparamcheck.FloatVectorMetrics, metricType) {
-						return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "array of vector with float element type does not support metric type: "+metricType)
+						return merr.WrapErrParameterInvalidMsg("%s", "array of vector with float element type does not support metric type: "+metricType)
 					}
 				} else if typeutil.IsBinaryVectorType(cit.fieldSchema.ElementType) {
 					if !funcutil.SliceContain(indexparamcheck.BinaryVectorMetrics, metricType) {
-						return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "array of vector with binary element type does not support metric type: "+metricType)
+						return merr.WrapErrParameterInvalidMsg("%s", "array of vector with binary element type does not support metric type: "+metricType)
 					}
 				} else if typeutil.IsIntVectorType(cit.fieldSchema.ElementType) {
 					if !funcutil.SliceContain(indexparamcheck.IntVectorMetrics, metricType) {
-						return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "array of vector with int element type does not support metric type: "+metricType)
+						return merr.WrapErrParameterInvalidMsg("%s", "array of vector with int element type does not support metric type: "+metricType)
 					}
 				} else {
-					return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "array of vector index does not support metric type: "+metricType)
+					return merr.WrapErrParameterInvalidMsg("%s", "array of vector index does not support metric type: "+metricType)
 				}
 			}
 		}
@@ -603,7 +603,14 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 
 	err := checkTrain(ctx, cit.fieldSchema, indexParamsMap)
 	if err != nil {
-		return merr.WrapErrParameterInvalid("valid index params", "invalid index params", err.Error())
+		// checkTrain may propagate errors from indexparamcheck (not yet
+		// merr-standardized). Already-merr errors (leaves / fillDimension /
+		// the merr-returning checkers) pass through with their real code;
+		// only legacy plain errors get wrapped once into ParameterInvalid.
+		if merr.IsMilvusError(err) {
+			return err
+		}
+		return merr.WrapErrParameterInvalidMsg("%s", err.Error())
 	}
 
 	typeParams := cit.fieldSchema.GetTypeParams()

--- a/internal/proxy/task_index.go
+++ b/internal/proxy/task_index.go
@@ -235,7 +235,7 @@ func (cit *createIndexTask) parseFunctionParamsToIndex(indexParamsMap map[string
 
 	switch cit.functionSchema.GetType() {
 	case schemapb.FunctionType_Unknown:
-		return errors.New("unknown function type encountered")
+		return merr.WrapErrParameterInvalidMsg("unknown function type encountered")
 
 	case schemapb.FunctionType_BM25:
 		// set default BM25 params if not provided in index params
@@ -254,7 +254,7 @@ func (cit *createIndexTask) parseFunctionParamsToIndex(indexParamsMap map[string
 		if metricType, ok := indexParamsMap["metric_type"]; !ok {
 			indexParamsMap["metric_type"] = metric.BM25
 		} else if metricType != metric.BM25 {
-			return fmt.Errorf("index metric type of BM25 function output field must be BM25, got %s", metricType)
+			return merr.WrapErrParameterInvalidMsg("index metric type of BM25 function output field must be BM25, got %s", metricType)
 		}
 
 	default:
@@ -358,7 +358,7 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 				} else if typeutil.IsGeometryType(dataType) {
 					return Params.AutoIndexConfig.ScalarGeometryIndexType.GetValue(), nil
 				}
-				return "", fmt.Errorf("create auto index on type:%s is not supported", dataType.String())
+				return "", merr.WrapErrParameterInvalidMsg("create auto index on type:%s is not supported", dataType.String())
 			}()
 			if err != nil {
 				return merr.WrapErrParameterInvalid("supported field", err.Error())
@@ -460,12 +460,12 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 				}
 
 				if len(indexParamsMap) > numberParams+1 {
-					return errors.New("only metric type can be passed when use AutoIndex")
+					return merr.WrapErrParameterInvalidMsg("only metric type can be passed when use AutoIndex")
 				}
 
 				if len(indexParamsMap) == numberParams+1 {
 					if !metricTypeExist {
-						return errors.New("only metric type can be passed when use AutoIndex")
+						return merr.WrapErrParameterInvalidMsg("only metric type can be passed when use AutoIndex")
 					}
 
 					// only metric type is passed.
@@ -530,7 +530,7 @@ func (cit *createIndexTask) parseIndexParams(ctx context.Context) error {
 
 		indexType, exist := indexParamsMap[common.IndexTypeKey]
 		if !exist {
-			return errors.New("IndexType not specified")
+			return merr.WrapErrParameterInvalidMsg("IndexType not specified")
 		}
 		//  index parameters defined in the YAML file are merged with the user-provided parameters during create stage
 		if Params.KnowhereConfig.Enable.GetAsBool() {
@@ -635,20 +635,20 @@ func (cit *createIndexTask) getIndexedFieldAndFunction(ctx context.Context) erro
 	schema, err := globalMetaCache.GetCollectionSchema(ctx, cit.req.GetDbName(), cit.req.GetCollectionName())
 	if err != nil {
 		log.Ctx(ctx).Error("failed to get collection schema", zap.Error(err))
-		return fmt.Errorf("failed to get collection schema: %s", err)
+		return merr.WrapErrParameterInvalidMsg("failed to get collection schema: %s", err)
 	}
 
 	field, err := schema.schemaHelper.GetFieldFromNameDefaultJSON(cit.req.GetFieldName())
 	if err != nil {
 		log.Ctx(ctx).Error("create index on non-exist field", zap.Error(err))
-		return fmt.Errorf("cannot create index on non-exist field: %s", cit.req.GetFieldName())
+		return merr.WrapErrParameterInvalidMsg("cannot create index on non-exist field: %s", cit.req.GetFieldName())
 	}
 
 	if field.IsFunctionOutput {
 		function, err := schema.schemaHelper.GetFunctionByOutputField(field)
 		if err != nil {
 			log.Ctx(ctx).Error("create index failed, cannot find function of function output field", zap.Error(err))
-			return fmt.Errorf("create index failed, cannot find function of function output field: %s", cit.req.GetFieldName())
+			return merr.WrapErrParameterInvalidMsg("create index failed, cannot find function of function output field: %s", cit.req.GetFieldName())
 		}
 		cit.functionSchema = function
 	}
@@ -665,12 +665,12 @@ func fillDimension(field *schemapb.FieldSchema, indexParams map[string]string) e
 	params = append(params, field.GetIndexParams()...)
 	dimensionInSchema, err := funcutil.GetAttrByKeyFromRepeatedKV(DimKey, params)
 	if err != nil {
-		return errors.New("dimension not found in schema")
+		return merr.WrapErrParameterInvalidMsg("dimension not found in schema")
 	}
 	dimension, exist := indexParams[DimKey]
 	if exist {
 		if dimensionInSchema != dimension {
-			return fmt.Errorf("dimension mismatch, dimension in schema: %s, dimension: %s", dimensionInSchema, dimension)
+			return merr.WrapErrParameterInvalidMsg("dimension mismatch, dimension in schema: %s, dimension: %s", dimensionInSchema, dimension)
 		}
 	} else {
 		indexParams[DimKey] = dimensionInSchema
@@ -694,7 +694,7 @@ func checkTrain(ctx context.Context, field *schemapb.FieldSchema, indexParams ma
 	checker, err := indexparamcheck.GetIndexCheckerMgrInstance().GetChecker(indexType)
 	if err != nil {
 		log.Ctx(ctx).Warn("Failed to get index checker", zap.String(common.IndexTypeKey, indexType))
-		return fmt.Errorf("invalid index type: %s", indexType)
+		return merr.WrapErrParameterInvalidMsg("invalid index type: %s", indexType)
 	}
 
 	// For ArrayOfVector with non-EmbList metrics (e.g., COSINE, L2, IP), each embedding
@@ -712,7 +712,7 @@ func checkTrain(ctx context.Context, field *schemapb.FieldSchema, indexParams ma
 	if typeutil.IsVectorType(field.DataType) && indexType != indexparamcheck.AutoIndex {
 		exist := CheckVecIndexWithDataTypeExist(indexType, effectiveDataType, effectiveElementType)
 		if !exist {
-			return fmt.Errorf("data type %s can't build with this index %s", schemapb.DataType_name[int32(field.GetDataType())], indexType)
+			return merr.WrapErrParameterInvalidMsg("data type %s can't build with this index %s", schemapb.DataType_name[int32(field.GetDataType())], indexType)
 		}
 	}
 
@@ -1007,7 +1007,7 @@ func (dit *describeIndexTask) Execute(ctx context.Context) error {
 	schema, err := globalMetaCache.GetCollectionSchema(ctx, dit.GetDbName(), dit.GetCollectionName())
 	if err != nil {
 		log.Ctx(ctx).Error("failed to get collection schema", zap.Error(err))
-		return fmt.Errorf("failed to get collection schema: %s", err)
+		return merr.WrapErrParameterInvalidMsg("failed to get collection schema: %s", err)
 	}
 
 	resp, err := dit.mixCoord.DescribeIndex(ctx, &indexpb.DescribeIndexRequest{CollectionID: dit.collectionID, IndexName: dit.IndexName, Timestamp: dit.Timestamp})
@@ -1029,7 +1029,7 @@ func (dit *describeIndexTask) Execute(ctx context.Context) error {
 		field, err := schema.schemaHelper.GetFieldFromID(indexInfo.FieldID)
 		if err != nil {
 			log.Ctx(ctx).Error("failed to get collection field", zap.Error(err))
-			return fmt.Errorf("failed to get collection field: %d", indexInfo.FieldID)
+			return merr.WrapErrParameterInvalidMsg("failed to get collection field: %d", indexInfo.FieldID)
 		}
 		params := indexInfo.GetUserIndexParams()
 		if params == nil {
@@ -1147,7 +1147,7 @@ func (dit *getIndexStatisticsTask) Execute(ctx context.Context) error {
 	schema, err := globalMetaCache.GetCollectionSchema(ctx, dit.GetDbName(), dit.GetCollectionName())
 	if err != nil {
 		log.Ctx(ctx).Error("failed to get collection schema", zap.String("collection_name", dit.GetCollectionName()), zap.Error(err))
-		return fmt.Errorf("failed to get collection schema: %s", dit.GetCollectionName())
+		return merr.WrapErrParameterInvalidMsg("failed to get collection schema: %s", dit.GetCollectionName())
 	}
 	schemaHelper := schema.schemaHelper
 
@@ -1163,7 +1163,7 @@ func (dit *getIndexStatisticsTask) Execute(ctx context.Context) error {
 		field, err := schemaHelper.GetFieldFromID(indexInfo.FieldID)
 		if err != nil {
 			log.Ctx(ctx).Error("failed to get collection field", zap.Int64("field_id", indexInfo.FieldID), zap.Error(err))
-			return fmt.Errorf("failed to get collection field: %d", indexInfo.FieldID)
+			return merr.WrapErrParameterInvalidMsg("failed to get collection field: %d", indexInfo.FieldID)
 		}
 		params := indexInfo.GetUserIndexParams()
 		if params == nil {

--- a/internal/proxy/task_policies.go
+++ b/internal/proxy/task_policies.go
@@ -4,8 +4,7 @@ package proxy
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
-	"go.uber.org/zap"
+		"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/milvus-io/milvus/internal/proxy/shardclient"
@@ -20,7 +19,7 @@ type queryFunc func(context.Context, UniqueID, types.QueryNodeClient, ...string)
 
 type pickShardPolicy func(context.Context, shardclient.ShardClientMgr, queryFunc, map[string][]nodeInfo) error
 
-var errInvalidShardLeaders = errors.New("Invalid shard leader")
+var errInvalidShardLeaders = merr.WrapErrParameterInvalidMsg("Invalid shard leader")
 
 // RoundRobinPolicy do the query with multiple dml channels
 // if request failed, it finds shard leader for failed dml channels

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -151,7 +151,7 @@ func translateGroupByFieldIds(groupByFieldNames []string, schema *schemapb.Colle
 		groupByField = strings.TrimSpace(groupByField)
 		fieldSchema, found := fieldNameToSchema[groupByField]
 		if !found {
-			return nil, fmt.Errorf("field %s not exist", groupByField)
+			return nil, merr.WrapErrParameterInvalidMsg("field %s not exist", groupByField)
 		}
 		if err := validateGroupByFieldSchema(fieldSchema); err != nil {
 			return nil, err
@@ -296,7 +296,7 @@ func translateToOutputFieldIDs(outputFields []string, schema *schemapb.Collectio
 			}
 
 			if !fieldFound {
-				return nil, fmt.Errorf("field %s not exist", reqField)
+				return nil, merr.WrapErrParameterInvalidMsg("field %s not exist", reqField)
 			}
 		}
 
@@ -384,7 +384,7 @@ func parseQueryParams(queryParamsPair []*commonpb.KeyValuePair, largeTopKEnabled
 		isLimitProvided = true
 		limit, err = strconv.ParseInt(limitStr, 0, 64)
 		if err != nil {
-			return nil, fmt.Errorf("%s [%s] is invalid", LimitKey, limitStr)
+			return nil, merr.WrapErrParameterInvalidMsg("%s [%s] is invalid", LimitKey, limitStr)
 		}
 	}
 	if isLimitProvided {
@@ -393,12 +393,12 @@ func parseQueryParams(queryParamsPair []*commonpb.KeyValuePair, largeTopKEnabled
 		if err == nil {
 			offset, err = strconv.ParseInt(offsetStr, 0, 64)
 			if err != nil {
-				return nil, fmt.Errorf("%s [%s] is invalid", OffsetKey, offsetStr)
+				return nil, merr.WrapErrParameterInvalidMsg("%s [%s] is invalid", OffsetKey, offsetStr)
 			}
 		}
 		// validate max result window.
 		if err = validateMaxQueryResultWindow(offset, limit, largeTopKEnabled); err != nil {
-			return nil, fmt.Errorf("invalid max query result window, %w", err)
+			return nil, merr.WrapErrParameterInvalidMsg("invalid max query result window, %v", err)
 		}
 	}
 
@@ -1134,11 +1134,11 @@ func reduceRetrieveResults(ctx context.Context, retrieveResults []*internalpb.Re
 		}
 		// Validate element-level consistency: if any result is element-level, all must be
 		if isElementLevel && !r.GetElementLevel() {
-			return nil, fmt.Errorf("inconsistent element-level flag: expected all results to be element-level")
+			return nil, merr.WrapErrParameterInvalidMsg("inconsistent element-level flag: expected all results to be element-level")
 		}
 		// Validate element_indices length matches ids length for element-level
 		if isElementLevel && len(r.GetElementIndices()) != size {
-			return nil, fmt.Errorf("element_indices length (%d) does not match ids length (%d)", len(r.GetElementIndices()), size)
+			return nil, merr.WrapErrParameterInvalidMsg("element_indices length (%d) does not match ids length (%d)", len(r.GetElementIndices()), size)
 		}
 		validRetrieveResults = append(validRetrieveResults, r)
 		loopEnd += size
@@ -1216,7 +1216,7 @@ func reduceRetrieveResults(ctx context.Context, retrieveResults []*internalpb.Re
 
 		// limit retrieve result to avoid oom
 		if retSize > maxOutputSize {
-			return nil, fmt.Errorf("query results exceed the maxOutputSize Limit %d", maxOutputSize)
+			return nil, merr.WrapErrParameterInvalidMsg("query results exceed the maxOutputSize Limit %d", maxOutputSize)
 		}
 
 		cursors[sel]++

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -225,7 +225,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 
 	if t.GetIsAdvanced() {
 		if len(t.request.GetSubReqs()) > defaultMaxSearchRequest {
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("maximum of ann search requests is %d", defaultMaxSearchRequest))
+			return merr.WrapErrParameterInvalidMsg("maximum of ann search requests is %d", defaultMaxSearchRequest)
 		}
 	}
 
@@ -708,7 +708,7 @@ func (t *searchTask) getBM25SearchTexts(placeholder []byte) ([]string, error) {
 
 	holder := pb.Placeholders[0]
 	if holder.Type != commonpb.PlaceholderType_VarChar {
-		return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("please provide varchar/text for BM25 Function based search, got %s", holder.Type.String()))
+		return nil, merr.WrapErrParameterInvalidMsg("please provide varchar/text for BM25 Function based search, got %s", holder.Type.String())
 	}
 
 	texts := funcutil.GetVarCharFromPlaceholder(holder)

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -190,7 +190,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 		return err
 	}
 	if t.partitionKeyMode && len(t.request.GetPartitionNames()) != 0 {
-		return errors.New("not support manually specifying the partition names if partition key mode is used")
+		return merr.WrapErrParameterInvalidMsg("not support manually specifying the partition names if partition key mode is used")
 	}
 	if t.mustUsePartitionKey && !t.partitionKeyMode {
 		return merr.WrapErrAsInputError(merr.WrapErrParameterInvalidMsg("must use partition key in the search request " +
@@ -218,14 +218,14 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 	}
 	if len(aggs) > 0 {
 		log.Warn("aggregates are not supported in search request", zap.Strings("aggregates", lo.Map(aggs, func(agg agg.AggregateBase, _ int) string { return agg.OriginalName() })))
-		return errors.New("aggregates are not supported in search request")
+		return merr.WrapErrParameterInvalidMsg("aggregates are not supported in search request")
 	}
 	log.Debug("translate output fields",
 		zap.Strings("output fields", t.translatedOutputFields))
 
 	if t.GetIsAdvanced() {
 		if len(t.request.GetSubReqs()) > defaultMaxSearchRequest {
-			return errors.New(fmt.Sprintf("maximum of ann search requests is %d", defaultMaxSearchRequest))
+			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("maximum of ann search requests is %d", defaultMaxSearchRequest))
 		}
 	}
 
@@ -390,7 +390,7 @@ func (t *searchTask) checkNq(ctx context.Context) (int64, error) {
 	// Check if nq is valid:
 	// https://milvus.io/docs/limitations.md
 	if err := validateNQLimit(nq); err != nil {
-		return 0, fmt.Errorf("%s [%d] is invalid, %w", NQKey, nq, err)
+		return 0, merr.WrapErrParameterInvalidMsg("%s [%d] is invalid, %v", NQKey, nq, err)
 	}
 	return nq, nil
 }
@@ -472,7 +472,7 @@ func setQueryInfoIfMvEnable(queryInfo *planpb.QueryInfo, t *searchTask, plan *pl
 			}
 			queryInfo.MaterializedViewInvolved = true
 		} else {
-			return errors.New("partition key field data type is not supported in materialized view")
+			return merr.WrapErrParameterInvalidMsg("partition key field data type is not supported in materialized view")
 		}
 	}
 	return nil
@@ -997,11 +997,11 @@ func (t *searchTask) tryGeneratePlan(params []*commonpb.KeyValuePair, dsl string
 	if err != nil || len(annsFieldName) == 0 {
 		vecFields := typeutil.GetVectorFieldSchemas(t.schema.CollectionSchema)
 		if len(vecFields) == 0 {
-			return nil, nil, 0, false, nil, internalpb.SearchType_DEFAULT, errors.New(AnnsFieldKey + " not found in schema")
+			return nil, nil, 0, false, nil, internalpb.SearchType_DEFAULT, merr.WrapErrParameterInvalidMsg(AnnsFieldKey + " not found in schema")
 		}
 
 		if enableMultipleVectorFields && len(vecFields) > 1 {
-			return nil, nil, 0, false, nil, internalpb.SearchType_DEFAULT, errors.New("multiple anns_fields exist, please specify a anns_field in search_params")
+			return nil, nil, 0, false, nil, internalpb.SearchType_DEFAULT, merr.WrapErrParameterInvalidMsg("multiple anns_fields exist, please specify a anns_field in search_params")
 		}
 		annsFieldName = vecFields[0].Name
 	}
@@ -1016,7 +1016,7 @@ func (t *searchTask) tryGeneratePlan(params []*commonpb.KeyValuePair, dsl string
 
 	annField := typeutil.GetFieldByName(t.schema.CollectionSchema, annsFieldName)
 	if searchInfo.planInfo.GetGroupByFieldId() != -1 && annField.GetDataType() == schemapb.DataType_BinaryVector {
-		return nil, nil, 0, false, nil, internalpb.SearchType_DEFAULT, errors.New("not support search_group_by operation based on binary vector column")
+		return nil, nil, 0, false, nil, internalpb.SearchType_DEFAULT, merr.WrapErrParameterInvalidMsg("not support search_group_by operation based on binary vector column")
 	}
 
 	searchInfo.planInfo.QueryFieldId = annField.GetFieldID()
@@ -1362,7 +1362,7 @@ func (t *searchTask) collectSearchResults(ctx context.Context) ([]*internalpb.Se
 	select {
 	case <-t.TraceCtx().Done():
 		log.Ctx(ctx).Warn("search task wait to finish timeout!")
-		return nil, fmt.Errorf("search task wait to finish timeout, msgID=%d", t.ID())
+		return nil, merr.WrapErrServiceInternalMsg("search task wait to finish timeout, msgID=%d", t.ID())
 	default:
 		toReduceResults := make([]*internalpb.SearchResults, 0)
 		log.Ctx(ctx).Debug("all searches are finished or canceled")

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -3254,7 +3254,7 @@ func TestSearchTask_ErrExecute(t *testing.T) {
 	if enableMultipleVectorFields {
 		err = task.PreExecute(ctx)
 		assert.Error(t, err)
-		assert.Equal(t, err.Error(), "multiple anns_fields exist, please specify a anns_field in search_params")
+		assert.Contains(t, err.Error(), "multiple anns_fields exist, please specify a anns_field in search_params")
 	} else {
 		assert.NoError(t, task.PreExecute(ctx))
 	}

--- a/internal/proxy/task_statistic.go
+++ b/internal/proxy/task_statistic.go
@@ -318,11 +318,11 @@ func checkFullLoaded(ctx context.Context, qc types.QueryCoordClient, dbName stri
 	// TODO: Consider to check if partition loaded from cache to save rpc.
 	info, err := globalMetaCache.GetCollectionInfo(ctx, dbName, collectionName, collectionID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("GetCollectionInfo failed, dbName = %s, collectionName = %s,collectionID = %d, err = %s", dbName, collectionName, collectionID, err)
+		return nil, nil, merr.WrapErrParameterInvalidMsg("GetCollectionInfo failed, dbName = %s, collectionName = %s,collectionID = %d, err = %s", dbName, collectionName, collectionID, err)
 	}
 	partitionInfos, err := globalMetaCache.GetPartitions(ctx, dbName, collectionName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("GetPartitions failed, dbName = %s, collectionName = %s,collectionID = %d, err = %s", dbName, collectionName, collectionID, err)
+		return nil, nil, merr.WrapErrParameterInvalidMsg("GetPartitions failed, dbName = %s, collectionName = %s,collectionID = %d, err = %s", dbName, collectionName, collectionID, err)
 	}
 
 	// If request to search partitions
@@ -336,10 +336,10 @@ func checkFullLoaded(ctx context.Context, qc types.QueryCoordClient, dbName stri
 			PartitionIDs: searchPartitionIDs,
 		})
 		if err != nil {
-			return nil, nil, fmt.Errorf("showPartitions failed, collection = %d, partitionIDs = %v, err = %s", collectionID, searchPartitionIDs, err)
+			return nil, nil, merr.WrapErrParameterInvalidMsg("showPartitions failed, collection = %d, partitionIDs = %v, err = %s", collectionID, searchPartitionIDs, err)
 		}
 		if resp.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
-			return nil, nil, fmt.Errorf("showPartitions failed, collection = %d, partitionIDs = %v, reason = %s", collectionID, searchPartitionIDs, resp.GetStatus().GetReason())
+			return nil, nil, merr.WrapErrParameterInvalidMsg("showPartitions failed, collection = %d, partitionIDs = %v, reason = %s", collectionID, searchPartitionIDs, resp.GetStatus().GetReason())
 		}
 
 		for i, percentage := range resp.GetInMemoryPercentages() {
@@ -361,10 +361,10 @@ func checkFullLoaded(ctx context.Context, qc types.QueryCoordClient, dbName stri
 		CollectionID: info.collID,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("showPartitions failed, collection = %d, partitionIDs = %v, err = %s", collectionID, searchPartitionIDs, err)
+		return nil, nil, merr.WrapErrParameterInvalidMsg("showPartitions failed, collection = %d, partitionIDs = %v, err = %s", collectionID, searchPartitionIDs, err)
 	}
 	if resp.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
-		return nil, nil, fmt.Errorf("showPartitions failed, collection = %d, partitionIDs = %v, reason = %s", collectionID, searchPartitionIDs, resp.GetStatus().GetReason())
+		return nil, nil, merr.WrapErrParameterInvalidMsg("showPartitions failed, collection = %d, partitionIDs = %v, reason = %s", collectionID, searchPartitionIDs, resp.GetStatus().GetReason())
 	}
 
 	loadedMap := make(map[UniqueID]bool)
@@ -389,7 +389,7 @@ func decodeGetStatisticsResults(results []*internalpb.GetStatisticsResponse) ([]
 	ret := make([]map[string]string, len(results))
 	for i, result := range results {
 		if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
-			return nil, fmt.Errorf("fail to decode result, reason=%s", result.GetStatus().GetReason())
+			return nil, merr.WrapErrParameterInvalidMsg("fail to decode result, reason=%s", result.GetStatus().GetReason())
 		}
 		ret[i] = funcutil.KeyValuePair2Map(result.GetStats())
 	}
@@ -747,7 +747,7 @@ func (g *getPartitionStatisticsTask) Execute(ctx context.Context) error {
 
 	result, _ := g.mixCoord.GetPartitionStatistics(ctx, req)
 	if result == nil {
-		return errors.New("get partition statistics resp is nil")
+		return merr.WrapErrParameterInvalidMsg("get partition statistics resp is nil")
 	}
 	if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
 		return merr.Error(result.GetStatus())

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
@@ -1331,7 +1330,7 @@ func (it *upsertTask) PreExecute(ctx context.Context) error {
 	}
 	if it.partitionKeyMode {
 		if len(it.req.GetPartitionName()) > 0 {
-			return errors.New("not support manually specifying the partition names if partition key mode is used")
+			return merr.WrapErrParameterInvalidMsg("not support manually specifying the partition names if partition key mode is used")
 		}
 	} else {
 		// set default partition name if not use partition key

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -248,7 +248,7 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 	primaryFieldData, err := typeutil.GetPrimaryFieldData(it.req.GetFieldsData(), primaryFieldSchema)
 	if err != nil {
 		log.Error("get primary field data failed", zap.Error(err))
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("must assign pk when upsert, primary field: %v", primaryFieldSchema.Name))
+		return merr.WrapErrParameterInvalidMsg("must assign pk when upsert, primary field: %v", primaryFieldSchema.Name)
 	}
 
 	upsertIDs, err := parsePrimaryFieldData2IDs(primaryFieldData)
@@ -409,7 +409,7 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 			oldPK := typeutil.GetPK(upsertIDs, int64(upsertIdx))
 			idx, ok := existPKToIndex[oldPK]
 			if !ok {
-				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("upsert pk %v not found in query result", oldPK))
+				return merr.WrapErrParameterInvalidMsg("upsert pk %v not found in query result", oldPK)
 			}
 			existIndices[i] = int64(idx)
 		}
@@ -751,7 +751,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 			}
 
 		default:
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined data type:%s", field.Type.String()))
+			return merr.WrapErrParameterInvalidMsg("undefined data type:%s", field.Type.String())
 		}
 
 	case *schemapb.FieldData_Vectors:
@@ -759,7 +759,7 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 		return nil
 
 	default:
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined data type:%s", field.Type.String()))
+		return merr.WrapErrParameterInvalidMsg("undefined data type:%s", field.Type.String())
 	}
 
 	return nil
@@ -1056,7 +1056,7 @@ func GenNullableFieldData(field *schemapb.FieldSchema, upsertIDSize int) (*schem
 		}, nil
 
 	default:
-		return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined data type:%s", field.DataType.String()))
+		return nil, merr.WrapErrParameterInvalidMsg("undefined data type:%s", field.DataType.String())
 	}
 }
 

--- a/internal/proxy/task_upsert_partial_op.go
+++ b/internal/proxy/task_upsert_partial_op.go
@@ -166,7 +166,7 @@ func findFieldSchemaByName(schema *schemapb.CollectionSchema, name string) (*sch
 			return f, nil
 		}
 	}
-	return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("field %q not found in collection schema", name))
+	return nil, merr.WrapErrParameterInvalidMsg("field %q not found in collection schema", name)
 }
 
 // checkArrayAppendPayloadWithinCapacity checks that the per-row payload

--- a/internal/proxy/task_validator.go
+++ b/internal/proxy/task_validator.go
@@ -1,9 +1,8 @@
 package proxy
 
 import (
-	"fmt"
-
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -29,7 +28,7 @@ func (v *searchTaskValidator) validateSubSearch(subReq *internalpb.SubSearchRequ
 		nEntries *= subReq.GroupSize
 	}
 	if nEntries > maxResultEntries {
-		return fmt.Errorf("number of result entries is too large")
+		return merr.WrapErrParameterInvalidMsg("number of result entries is too large")
 	}
 	return nil
 }
@@ -46,7 +45,7 @@ func (v *searchTaskValidator) validateSearch(search *searchTask) error {
 		nEntries *= search.GroupSize
 	}
 	if nEntries > maxResultEntries {
-		return fmt.Errorf("number of result entries is too large")
+		return merr.WrapErrParameterInvalidMsg("number of result entries is too large")
 	}
 	return nil
 }

--- a/internal/proxy/timestamp.go
+++ b/internal/proxy/timestamp.go
@@ -18,16 +18,14 @@ package proxy
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
-
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 )
@@ -65,13 +63,13 @@ func (ta *timestampAllocator) alloc(ctx context.Context, count uint32) ([]Timest
 	}()
 
 	if err != nil {
-		return nil, fmt.Errorf("syncTimestamp Failed:%w", err)
+		return nil, merr.WrapErrServiceInternalMsg("syncTimestamp Failed:%v", err)
 	}
 	if resp.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
-		return nil, fmt.Errorf("syncTimeStamp Failed:%s", resp.GetStatus().GetReason())
+		return nil, merr.WrapErrServiceInternalMsg("syncTimeStamp Failed:%s", resp.GetStatus().GetReason())
 	}
 	if resp == nil {
-		return nil, errors.New("empty AllocTimestampResponse")
+		return nil, merr.WrapErrServiceInternalMsg("empty AllocTimestampResponse")
 	}
 	start, cnt := resp.GetTimestamp(), resp.GetCount()
 	ret := make([]Timestamp, cnt)

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2129,7 +2129,7 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 			for _, subField := range structArrays.StructArrays.Fields {
 				for j, v := range subField.ValidData {
 					if v {
-						return fmt.Errorf("sub-field '%s' in struct '%s' claims row %d is valid but no payload is provided",
+						return merr.WrapErrParameterInvalidMsg("sub-field '%s' in struct '%s' claims row %d is valid but no payload is provided",
 							subField.FieldName, structName, j)
 					}
 				}
@@ -2140,7 +2140,7 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 			continue
 		}
 		if hasDataCount != totalSubFields {
-			return fmt.Errorf("inconsistent sub-field data in struct '%s': %d of %d sub-fields have data, all must be present or all absent",
+			return merr.WrapErrParameterInvalidMsg("inconsistent sub-field data in struct '%s': %d of %d sub-fields have data, all must be present or all absent",
 				structName, hasDataCount, totalSubFields)
 		}
 
@@ -2158,12 +2158,12 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 					continue
 				}
 				if len(subField.ValidData) != len(refValidData) {
-					return fmt.Errorf("sub-field ValidData length mismatch in struct '%s': '%s' has %d, '%s' has %d",
+					return merr.WrapErrParameterInvalidMsg("sub-field ValidData length mismatch in struct '%s': '%s' has %d, '%s' has %d",
 						structName, refFieldName, len(refValidData), subField.FieldName, len(subField.ValidData))
 				}
 				for j := range refValidData {
 					if subField.ValidData[j] != refValidData[j] {
-						return fmt.Errorf("sub-field ValidData mismatch in struct '%s' at row %d: '%s'=%v, '%s'=%v",
+						return merr.WrapErrParameterInvalidMsg("sub-field ValidData mismatch in struct '%s' at row %d: '%s'=%v, '%s'=%v",
 							structName, j, refFieldName, refValidData[j], subField.FieldName, subField.ValidData[j])
 					}
 				}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1421,7 +1421,7 @@ func ValidateUsername(username string) error {
 	}
 
 	if len(username) > Params.ProxyCfg.MaxUsernameLength.GetAsInt() {
-		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetValue())
+		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetAsInt())
 	}
 
 	firstChar := username[0]

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -123,20 +123,20 @@ func restoreStructFieldNames(schema *schemapb.CollectionSchema) error {
 func extractOriginalFieldName(transformedName string) (string, error) {
 	idx := strings.Index(transformedName, "[")
 	if idx == -1 {
-		return "", fmt.Errorf("not a transformed struct field name: %s", transformedName)
+		return "", merr.WrapErrParameterInvalidMsg("not a transformed struct field name: %s", transformedName)
 	}
 
 	if !strings.HasSuffix(transformedName, "]") {
-		return "", fmt.Errorf("invalid struct field format: %s, missing closing bracket", transformedName)
+		return "", merr.WrapErrParameterInvalidMsg("invalid struct field format: %s, missing closing bracket", transformedName)
 	}
 
 	if idx == 0 {
-		return "", fmt.Errorf("invalid struct field format: %s, missing struct name", transformedName)
+		return "", merr.WrapErrParameterInvalidMsg("invalid struct field format: %s, missing struct name", transformedName)
 	}
 
 	fieldName := transformedName[idx+1 : len(transformedName)-1]
 	if fieldName == "" {
-		return "", fmt.Errorf("invalid struct field format: %s, empty field name", transformedName)
+		return "", merr.WrapErrParameterInvalidMsg("invalid struct field format: %s, empty field name", transformedName)
 	}
 
 	return fieldName, nil
@@ -161,16 +161,16 @@ func isNumber(c uint8) bool {
 // check run analyzer params when collection name was set
 func validateRunAnalyzer(req *milvuspb.RunAnalyzerRequest) error {
 	if req.GetAnalyzerParams() != "" {
-		return fmt.Errorf("run analyzer can't use analyzer params and (collection,field) in same time")
+		return merr.WrapErrParameterInvalidMsg("run analyzer can't use analyzer params and (collection,field) in same time")
 	}
 
 	if req.GetFieldName() == "" {
-		return fmt.Errorf("must set field name when collection name was set")
+		return merr.WrapErrParameterInvalidMsg("must set field name when collection name was set")
 	}
 
 	if req.GetAnalyzerNames() != nil {
 		if len(req.GetAnalyzerNames()) != 1 && len(req.GetAnalyzerNames()) != len(req.GetPlaceholder()) {
-			return fmt.Errorf("only support set one analyzer name for all text or set analyzer name for each text, but now analzer name num: %d, text num: %d",
+			return merr.WrapErrParameterInvalidMsg("only support set one analyzer name for all text or set analyzer name for each text, but now analzer name num: %d, text num: %d",
 				len(req.GetAnalyzerNames()), len(req.GetPlaceholder()))
 		}
 	}
@@ -180,10 +180,10 @@ func validateRunAnalyzer(req *milvuspb.RunAnalyzerRequest) error {
 
 func validateMaxQueryResultWindow(offset int64, limit int64, largeTopKEnabled bool) error {
 	if offset < 0 {
-		return fmt.Errorf("%s [%d] is invalid, should be gte than 0", OffsetKey, offset)
+		return merr.WrapErrParameterInvalidMsg("%s [%d] is invalid, should be gte than 0", OffsetKey, offset)
 	}
 	if limit <= 0 {
-		return fmt.Errorf("%s [%d] is invalid, should be greater than 0", LimitKey, limit)
+		return merr.WrapErrParameterInvalidMsg("%s [%d] is invalid, should be greater than 0", LimitKey, limit)
 	}
 
 	depth := offset + limit
@@ -192,7 +192,7 @@ func validateMaxQueryResultWindow(offset int64, limit int64, largeTopKEnabled bo
 		maxQueryResultWindow = Params.QuotaConfig.LargeMaxQueryResultWindow.GetAsInt64()
 	}
 	if depth <= 0 || depth > maxQueryResultWindow {
-		return fmt.Errorf("(offset+limit) should be in range [1, %d], but got %d", maxQueryResultWindow, depth)
+		return merr.WrapErrParameterInvalidMsg("(offset+limit) should be in range [1, %d], but got %d", maxQueryResultWindow, depth)
 	}
 	return nil
 }
@@ -203,7 +203,7 @@ func validateLimit(limit int64, largeTopKEnabled bool) error {
 		topKLimit = Params.QuotaConfig.LargeTopKLimit.GetAsInt64()
 	}
 	if limit <= 0 || limit > topKLimit {
-		return fmt.Errorf("it should be in range [1, %d], but got %d", topKLimit, limit)
+		return merr.WrapErrParameterInvalidMsg("it should be in range [1, %d], but got %d", topKLimit, limit)
 	}
 	return nil
 }
@@ -211,7 +211,7 @@ func validateLimit(limit int64, largeTopKEnabled bool) error {
 func validateNQLimit(limit int64) error {
 	nqLimit := Params.QuotaConfig.NQLimit.GetAsInt64()
 	if limit <= 0 || limit > nqLimit {
-		return fmt.Errorf("nq (number of search vector per search request) should be in range [1, %d], but got %d", nqLimit, limit)
+		return merr.WrapErrParameterInvalidMsg("nq (number of search vector per search request) should be in range [1, %d], but got %d", nqLimit, limit)
 	}
 	return nil
 }
@@ -269,7 +269,7 @@ func ValidatePrivilegeGroupName(groupName string) error {
 
 func ValidateResourceGroupName(entity string) error {
 	if entity == "" {
-		return errors.New("resource group name couldn't be empty")
+		return merr.WrapErrParameterInvalidMsg("resource group name couldn't be empty")
 	}
 
 	invalidMsg := fmt.Sprintf("Invalid resource group name %s.", entity)
@@ -333,18 +333,18 @@ func validatePartitionTag(partitionTag string, strictCheck bool) error {
 	invalidMsg := "Invalid partition name: " + partitionTag + ". "
 	if partitionTag == "" {
 		msg := invalidMsg + "Partition name should not be empty."
-		return errors.New(msg)
+		return merr.WrapErrParameterInvalidMsg("%s", msg)
 	}
 	if len(partitionTag) > Params.ProxyCfg.MaxNameLength.GetAsInt() {
 		msg := invalidMsg + "The length of a partition name must be less than " + Params.ProxyCfg.MaxNameLength.GetValue() + " characters."
-		return errors.New(msg)
+		return merr.WrapErrParameterInvalidMsg("%s", msg)
 	}
 
 	if strictCheck {
 		firstChar := partitionTag[0]
 		if firstChar != '_' && !isAlpha(firstChar) && !isNumber(firstChar) {
 			msg := invalidMsg + "The first character of a partition name must be an underscore or letter."
-			return errors.New(msg)
+			return merr.WrapErrParameterInvalidMsg("%s", msg)
 		}
 
 		tagSize := len(partitionTag)
@@ -352,7 +352,7 @@ func validatePartitionTag(partitionTag string, strictCheck bool) error {
 			c := partitionTag[i]
 			if c != '_' && !isAlpha(c) && !isNumber(c) && c != '-' {
 				msg := invalidMsg + "Partition name can only contain numbers, letters and underscores."
-				return errors.New(msg)
+				return merr.WrapErrParameterInvalidMsg("%s", msg)
 			}
 		}
 	}
@@ -411,16 +411,16 @@ func validateDimension(field *schemapb.FieldSchema) error {
 	// for sparse vector field, dim should not be specified
 	if typeutil.IsSparseFloatVectorType(field.DataType) {
 		if exist {
-			return fmt.Errorf("dim should not be specified for sparse vector field %s(%d)", field.GetName(), field.FieldID)
+			return merr.WrapErrParameterInvalidMsg("dim should not be specified for sparse vector field %s(%d)", field.GetName(), field.FieldID)
 		}
 		return nil
 	}
 	if !exist {
-		return errors.Newf("dimension is not defined in field type params of field %s, check type param `dim` for vector field", field.GetName())
+		return merr.WrapErrParameterInvalidMsg("dimension is not defined in field type params of field %s, check type param `dim` for vector field", field.GetName())
 	}
 
 	if dim <= 1 {
-		return fmt.Errorf("invalid dimension: %d. should be in range 2 ~ %d", dim, Params.ProxyCfg.MaxDimension.GetAsInt())
+		return merr.WrapErrParameterInvalidMsg("invalid dimension: %d. should be in range 2 ~ %d", dim, Params.ProxyCfg.MaxDimension.GetAsInt())
 	}
 
 	// for dense vector field, dim will be limited by max_dimension
@@ -428,14 +428,14 @@ func validateDimension(field *schemapb.FieldSchema) error {
 		(field.GetDataType() == schemapb.DataType_ArrayOfVector && typeutil.IsBinaryVectorType(field.GetElementType()))
 	if isBinaryDimension {
 		if dim%8 != 0 {
-			return fmt.Errorf("invalid dimension: %d of field %s. binary vector dimension should be multiple of 8. ", dim, field.GetName())
+			return merr.WrapErrParameterInvalidMsg("invalid dimension: %d of field %s. binary vector dimension should be multiple of 8. ", dim, field.GetName())
 		}
 		if dim > Params.ProxyCfg.MaxDimension.GetAsInt64()*8 {
-			return fmt.Errorf("invalid dimension: %d of field %s. binary vector dimension should be in range 2 ~ %d", dim, field.GetName(), Params.ProxyCfg.MaxDimension.GetAsInt()*8)
+			return merr.WrapErrParameterInvalidMsg("invalid dimension: %d of field %s. binary vector dimension should be in range 2 ~ %d", dim, field.GetName(), Params.ProxyCfg.MaxDimension.GetAsInt()*8)
 		}
 	} else {
 		if dim > Params.ProxyCfg.MaxDimension.GetAsInt64() {
-			return fmt.Errorf("invalid dimension: %d of field %s. float vector dimension should be in range 2 ~ %d", dim, field.GetName(), Params.ProxyCfg.MaxDimension.GetAsInt())
+			return merr.WrapErrParameterInvalidMsg("invalid dimension: %d of field %s. float vector dimension should be in range 2 ~ %d", dim, field.GetName(), Params.ProxyCfg.MaxDimension.GetAsInt())
 		}
 	}
 	return nil
@@ -467,7 +467,7 @@ func validateMaxLengthPerRow(collectionName string, field *schemapb.FieldSchema)
 	}
 	// if not exist type params max_length, return error
 	if !exist {
-		return fmt.Errorf("type param(max_length) should be specified for the field(%s) of collection %s", field.GetName(), collectionName)
+		return merr.WrapErrParameterInvalidMsg("type param(max_length) should be specified for the field(%s) of collection %s", field.GetName(), collectionName)
 	}
 
 	return nil
@@ -484,16 +484,16 @@ func getMaxCapacityPerRow(collectionName string, field *schemapb.FieldSchema) (i
 		var err error
 		maxCapacityPerRow, err = strconv.ParseInt(param.Value, 10, 64)
 		if err != nil {
-			return 0, fmt.Errorf("the value for %s of field %s must be an integer", common.MaxCapacityKey, field.GetName())
+			return 0, merr.WrapErrParameterInvalidMsg("the value for %s of field %s must be an integer", common.MaxCapacityKey, field.GetName())
 		}
 		if maxCapacityPerRow > defaultMaxArrayCapacity || maxCapacityPerRow <= 0 {
-			return 0, errors.New("the maximum capacity specified for a Array should be in (0, 4096]")
+			return 0, merr.WrapErrParameterInvalidMsg("the maximum capacity specified for a Array should be in (0, 4096]")
 		}
 		exist = true
 	}
 	// if not exist type params max_capacity, return error
 	if !exist {
-		return 0, fmt.Errorf("type param(max_capacity) should be specified for array field %s of collection %s", field.GetName(), collectionName)
+		return 0, merr.WrapErrParameterInvalidMsg("type param(max_capacity) should be specified for array field %s of collection %s", field.GetName(), collectionName)
 	}
 	return maxCapacityPerRow, nil
 }
@@ -515,7 +515,7 @@ func validateVectorFieldMetricType(field *schemapb.FieldSchema) error {
 			return nil
 		}
 	}
-	return fmt.Errorf(`index param "metric_type" is not specified for index float vector %s`, field.GetName())
+	return merr.WrapErrParameterInvalidMsg(`index param "metric_type" is not specified for index float vector %s`, field.GetName())
 }
 
 func validateDuplicatedFieldName(schema *schemapb.CollectionSchema) error {
@@ -523,7 +523,7 @@ func validateDuplicatedFieldName(schema *schemapb.CollectionSchema) error {
 	validateFieldNames := func(name string) error {
 		_, ok := names[name]
 		if ok {
-			return errors.Newf("duplicated field name %s found", name)
+			return merr.WrapErrParameterInvalidMsg("duplicated field name %s found", name)
 		}
 		names[name] = true
 		return nil
@@ -553,20 +553,20 @@ func validateElementType(dataType schemapb.DataType) error {
 		schemapb.DataType_Int64, schemapb.DataType_Float, schemapb.DataType_Double, schemapb.DataType_VarChar:
 		return nil
 	case schemapb.DataType_String:
-		return errors.New("string data type not supported yet, please use VarChar type instead")
+		return merr.WrapErrParameterInvalidMsg("string data type not supported yet, please use VarChar type instead")
 	case schemapb.DataType_None:
-		return errors.New("element data type None is not valid")
+		return merr.WrapErrParameterInvalidMsg("element data type None is not valid")
 	}
-	return fmt.Errorf("element type %s is not supported", dataType.String())
+	return merr.WrapErrParameterInvalidMsg("element type %s is not supported", dataType.String())
 }
 
 func validateFieldType(schema *schemapb.CollectionSchema) error {
 	for _, field := range schema.GetFields() {
 		switch field.GetDataType() {
 		case schemapb.DataType_String:
-			return errors.New("string data type not supported yet, please use VarChar type instead")
+			return merr.WrapErrParameterInvalidMsg("string data type not supported yet, please use VarChar type instead")
 		case schemapb.DataType_None:
-			return errors.New("data type None is not valid")
+			return merr.WrapErrParameterInvalidMsg("data type None is not valid")
 		case schemapb.DataType_Array:
 			if err := validateElementType(field.GetElementType()); err != nil {
 				return err
@@ -576,7 +576,7 @@ func validateFieldType(schema *schemapb.CollectionSchema) error {
 	for _, structArrayField := range schema.StructArrayFields {
 		for _, field := range structArrayField.Fields {
 			if field.GetDataType() != schemapb.DataType_Array && field.GetDataType() != schemapb.DataType_ArrayOfVector {
-				return errors.Newf("fields in StructArrayField must be Array or ArrayOfVector, field name = %s, field type = %s",
+				return merr.WrapErrParameterInvalidMsg("fields in StructArrayField must be Array or ArrayOfVector, field name = %s, field type = %s",
 					field.GetName(), field.GetDataType().String())
 			}
 		}
@@ -590,18 +590,18 @@ func ValidateFieldAutoID(coll *schemapb.CollectionSchema) error {
 	for i, field := range coll.Fields {
 		if field.AutoID {
 			if idx != -1 {
-				return fmt.Errorf("only one field can speficy AutoID with true, field name = %s, %s", coll.Fields[idx].Name, field.Name)
+				return merr.WrapErrParameterInvalidMsg("only one field can speficy AutoID with true, field name = %s, %s", coll.Fields[idx].Name, field.Name)
 			}
 			idx = i
 			if !field.IsPrimaryKey {
-				return fmt.Errorf("only primary field can speficy AutoID with true, field name = %s", field.Name)
+				return merr.WrapErrParameterInvalidMsg("only primary field can speficy AutoID with true, field name = %s", field.Name)
 			}
 		}
 	}
 	for _, structArrayField := range coll.StructArrayFields {
 		for _, field := range structArrayField.Fields {
 			if field.AutoID {
-				return errors.Newf("autoID is not supported for struct field, field name = %s", field.Name)
+				return merr.WrapErrParameterInvalidMsg("autoID is not supported for struct field, field name = %s", field.Name)
 			}
 		}
 	}
@@ -640,7 +640,7 @@ func ValidateField(field *schemapb.FieldSchema, schema *schemapb.CollectionSchem
 	}
 
 	if field.DataType == schemapb.DataType_ArrayOfVector {
-		return fmt.Errorf("array of vector can only be in the struct array field, field name: %s", field.Name)
+		return merr.WrapErrParameterInvalidMsg("array of vector can only be in the struct array field, field name: %s", field.Name)
 	}
 
 	// TODO should remove the index params in the field schema
@@ -667,12 +667,12 @@ func ValidateFieldsInStruct(field *schemapb.FieldSchema, schema *schemapb.Collec
 	}
 
 	if field.DataType != schemapb.DataType_Array && field.DataType != schemapb.DataType_ArrayOfVector {
-		return fmt.Errorf("fields in StructArrayField can only be array or array of struct, but field %s is %s", field.Name, field.DataType.String())
+		return merr.WrapErrParameterInvalidMsg("fields in StructArrayField can only be array or array of struct, but field %s is %s", field.Name, field.DataType.String())
 	}
 
 	if field.ElementType == schemapb.DataType_ArrayOfStruct || field.ElementType == schemapb.DataType_ArrayOfVector ||
 		field.ElementType == schemapb.DataType_Array {
-		return fmt.Errorf("nested array is not supported %s", field.Name)
+		return merr.WrapErrParameterInvalidMsg("nested array is not supported %s", field.Name)
 	}
 
 	if field.DataType == schemapb.DataType_Array {
@@ -682,7 +682,7 @@ func ValidateFieldsInStruct(field *schemapb.FieldSchema, schema *schemapb.Collec
 	} else {
 		// ArrayOfVector: support FloatVector, Float16Vector, BFloat16Vector, Int8Vector, BinaryVector
 		if !typeutil.IsFixDimVectorType(field.GetElementType()) {
-			return fmt.Errorf("unsupported element type %s of ArrayOfVector field %s, only fixed dimension vector types are supported", field.GetElementType().String(), field.Name)
+			return merr.WrapErrParameterInvalidMsg("Unsupported element type %s of ArrayOfVector field %s, only fixed dimension vector types are supported", field.GetElementType().String(), field.Name)
 		}
 
 		err = validateDimension(field)
@@ -742,7 +742,7 @@ func validateStructArrayFieldMaxCapacity(structArrayField *schemapb.StructArrayF
 // When the struct is nullable, sub-field schemas are mutated in-place to set Nullable=true.
 func ValidateStructArrayField(structArrayField *schemapb.StructArrayFieldSchema, schema *schemapb.CollectionSchema) error {
 	if len(structArrayField.Fields) == 0 {
-		return fmt.Errorf("struct array field %s has no sub-fields", structArrayField.Name)
+		return merr.WrapErrParameterInvalidMsg("struct array field %s has no sub-fields", structArrayField.Name)
 	}
 
 	// Validate warmup policy if specified in struct field TypeParams
@@ -784,19 +784,19 @@ func validatePrimaryKey(coll *schemapb.CollectionSchema) error {
 	for i, field := range coll.Fields {
 		if field.IsPrimaryKey {
 			if idx != -1 {
-				return fmt.Errorf("there are more than one primary key, field name = %s, %s", coll.Fields[idx].Name, field.Name)
+				return merr.WrapErrParameterInvalidMsg("there are more than one primary key, field name = %s, %s", coll.Fields[idx].Name, field.Name)
 			}
 
 			// The type of the primary key field can only be int64 and varchar
 			if field.DataType != schemapb.DataType_Int64 && field.DataType != schemapb.DataType_VarChar {
-				return errors.New("the data type of primary key should be Int64 or VarChar")
+				return merr.WrapErrParameterInvalidMsg("the data type of primary key should be Int64 or VarChar")
 			}
 
 			// varchar field do not support autoID
 			// If autoID is required, it is recommended to use int64 field as the primary key
 			//if field.DataType == schemapb.DataType_VarChar {
 			//	if field.AutoID {
-			//		return errors.New("autoID is not supported when the VarChar field is the primary key")
+			//		return merr.WrapErrParameterInvalidMsg("autoID is not supported when the VarChar field is the primary key")
 			//	}
 			//}
 
@@ -806,14 +806,14 @@ func validatePrimaryKey(coll *schemapb.CollectionSchema) error {
 	if idx == -1 {
 		// External collections may not have a primary key
 		if !typeutil.IsExternalCollection(coll) {
-			return errors.New("primary key is not specified")
+			return merr.WrapErrParameterInvalidMsg("primary key is not specified")
 		}
 	}
 
 	for _, structArrayField := range coll.StructArrayFields {
 		for _, field := range structArrayField.Fields {
 			if field.IsPrimaryKey {
-				return errors.Newf("primary key is not supported for struct field, field name = %s", field.Name)
+				return merr.WrapErrParameterInvalidMsg("primary key is not supported for struct field, field name = %s", field.Name)
 			}
 		}
 	}
@@ -888,7 +888,7 @@ func injectVirtualPKForExternalCollection(schema *schemapb.CollectionSchema) err
 func validateDynamicField(coll *schemapb.CollectionSchema) error {
 	for _, field := range coll.Fields {
 		if field.IsDynamic {
-			return errors.New("cannot explicitly set a field as a dynamic field")
+			return merr.WrapErrParameterInvalidMsg("cannot explicitly set a field as a dynamic field")
 		}
 	}
 	return nil
@@ -900,7 +900,7 @@ func RepeatedKeyValToMap(kvPairs []*commonpb.KeyValuePair) (map[string]string, e
 	for _, kv := range kvPairs {
 		_, ok := resMap[kv.Key]
 		if ok {
-			return nil, fmt.Errorf("duplicated param key: %s", kv.Key)
+			return nil, merr.WrapErrParameterInvalidMsg("duplicated param key: %s", kv.Key)
 		}
 		resMap[kv.Key] = kv.Value
 	}
@@ -920,7 +920,7 @@ func isVector(dataType schemapb.DataType) (bool, error) {
 		return true, nil
 	}
 
-	return false, fmt.Errorf("invalid data type: %d", dataType)
+	return false, merr.WrapErrParameterInvalidMsg("invalid data type: %d", dataType)
 }
 
 func validateMetricType(dataType schemapb.DataType, metricTypeStrRaw string) error {
@@ -935,7 +935,7 @@ func validateMetricType(dataType schemapb.DataType, metricTypeStrRaw string) err
 			return nil
 		}
 	}
-	return fmt.Errorf("data_type %s mismatch with metric_type %s", dataType.String(), metricTypeStrRaw)
+	return merr.WrapErrParameterInvalidMsg("data_type %s mismatch with metric_type %s", dataType.String(), metricTypeStrRaw)
 }
 
 func validateFunction(coll *schemapb.CollectionSchema, needValidateFunctionName string, disableRuntimeCheck bool) error {
@@ -956,7 +956,7 @@ func validateFunction(coll *schemapb.CollectionSchema, needValidateFunctionName 
 		}
 
 		if usedFunctionName.Contain(function.GetName()) {
-			return fmt.Errorf("duplicate function name: %s", function.GetName())
+			return merr.WrapErrParameterInvalidMsg("duplicate function name: %s", function.GetName())
 		}
 
 		usedFunctionName.Insert(function.GetName())
@@ -964,7 +964,7 @@ func validateFunction(coll *schemapb.CollectionSchema, needValidateFunctionName 
 		for _, name := range function.GetInputFieldNames() {
 			inputField, ok := nameMap[name]
 			if !ok {
-				return fmt.Errorf("function input field not found: %s", name)
+				return merr.WrapErrParameterInvalidMsg("function input field not found: %s", name)
 			}
 			inputFields = append(inputFields, inputField)
 		}
@@ -977,25 +977,25 @@ func validateFunction(coll *schemapb.CollectionSchema, needValidateFunctionName 
 		for i, name := range function.GetOutputFieldNames() {
 			outputField, ok := nameMap[name]
 			if !ok {
-				return fmt.Errorf("function output field not found: %s", name)
+				return merr.WrapErrParameterInvalidMsg("function output field not found: %s", name)
 			}
 
 			if outputField.GetIsPrimaryKey() {
-				return fmt.Errorf("function output field cannot be primary key: function %s, field %s", function.GetName(), outputField.GetName())
+				return merr.WrapErrParameterInvalidMsg("function output field cannot be primary key: function %s, field %s", function.GetName(), outputField.GetName())
 			}
 
 			if outputField.GetIsPartitionKey() || outputField.GetIsClusteringKey() {
-				return fmt.Errorf("function output field cannot be partition key or clustering key: function %s, field %s", function.GetName(), outputField.GetName())
+				return merr.WrapErrParameterInvalidMsg("function output field cannot be partition key or clustering key: function %s, field %s", function.GetName(), outputField.GetName())
 			}
 
 			if outputField.GetNullable() {
-				return fmt.Errorf("function output field cannot be nullable: function %s, field %s", function.GetName(), outputField.GetName())
+				return merr.WrapErrParameterInvalidMsg("function output field cannot be nullable: function %s, field %s", function.GetName(), outputField.GetName())
 			}
 
 			outputField.IsFunctionOutput = true
 			outputFields[i] = outputField
 			if usedOutputField.Contain(name) {
-				return fmt.Errorf("duplicate function output field: function %s, field %s", function.GetName(), name)
+				return merr.WrapErrParameterInvalidMsg("duplicate function output field: function %s, field %s", function.GetName(), name)
 			}
 			usedOutputField.Insert(name)
 		}
@@ -1016,11 +1016,11 @@ func checkFunctionOutputField(fSchema *schemapb.FunctionSchema, fields []*schema
 	switch fSchema.GetType() {
 	case schemapb.FunctionType_BM25:
 		if len(fields) != 1 {
-			return fmt.Errorf("BM25 function only need 1 output field, but got %d", len(fields))
+			return merr.WrapErrParameterInvalidMsg("BM25 function only need 1 output field, but got %d", len(fields))
 		}
 
 		if !typeutil.IsSparseFloatVectorType(fields[0].GetDataType()) {
-			return fmt.Errorf("BM25 function output field must be a SparseFloatVector field, but got %s", fields[0].DataType.String())
+			return merr.WrapErrParameterInvalidMsg("BM25 function output field must be a SparseFloatVector field, but got %s", fields[0].DataType.String())
 		}
 	case schemapb.FunctionType_TextEmbedding:
 		if err := embedding.TextEmbeddingOutputsCheck(fields); err != nil {
@@ -1028,13 +1028,13 @@ func checkFunctionOutputField(fSchema *schemapb.FunctionSchema, fields []*schema
 		}
 	case schemapb.FunctionType_MinHash:
 		if len(fields) != 1 {
-			return fmt.Errorf("MinHash function only need 1 output field, but got %d", len(fields))
+			return merr.WrapErrParameterInvalidMsg("MinHash function only need 1 output field, but got %d", len(fields))
 		}
 		if fields[0].GetDataType() != schemapb.DataType_BinaryVector {
-			return fmt.Errorf("MinHash function output field must be a BinaryVector field, but got %s", fields[0].DataType.String())
+			return merr.WrapErrParameterInvalidMsg("MinHash function output field must be a BinaryVector field, but got %s", fields[0].DataType.String())
 		}
 	default:
-		return errors.New("check output field for unknown function type")
+		return merr.WrapErrParameterInvalidMsg("check output field for unknown function type")
 	}
 	return nil
 }
@@ -1043,12 +1043,12 @@ func checkFunctionInputField(function *schemapb.FunctionSchema, fields []*schema
 	switch function.GetType() {
 	case schemapb.FunctionType_BM25:
 		if len(fields) != 1 || (fields[0].DataType != schemapb.DataType_VarChar && fields[0].DataType != schemapb.DataType_Text) {
-			return fmt.Errorf("BM25 function input field must be a VARCHAR/TEXT field, got %d field with type %s",
+			return merr.WrapErrParameterInvalidMsg("BM25 function input field must be a VARCHAR/TEXT field, got %d field with type %s",
 				len(fields), fields[0].DataType.String())
 		}
 		h := typeutil.CreateFieldSchemaHelper(fields[0])
 		if !h.EnableAnalyzer() {
-			return errors.New("BM25 function input field must set enable_analyzer to true")
+			return merr.WrapErrParameterInvalidMsg("BM25 function input field must set enable_analyzer to true")
 		}
 	case schemapb.FunctionType_TextEmbedding:
 		if err := embedding.TextEmbeddingInputsCheck(function.GetName(), fields); err != nil {
@@ -1056,59 +1056,59 @@ func checkFunctionInputField(function *schemapb.FunctionSchema, fields []*schema
 		}
 	case schemapb.FunctionType_MinHash:
 		if len(fields) != 1 || (fields[0].DataType != schemapb.DataType_VarChar && fields[0].DataType != schemapb.DataType_Text) {
-			return fmt.Errorf("MinHash function input field must be a VARCHAR/TEXT field, got %d field with type %s",
+			return merr.WrapErrParameterInvalidMsg("MinHash function input field must be a VARCHAR/TEXT field, got %d field with type %s",
 				len(fields), fields[0].DataType.String())
 		}
 	default:
-		return errors.New("check input field with unknown function type")
+		return merr.WrapErrParameterInvalidMsg("check input field with unknown function type")
 	}
 	return nil
 }
 
 func checkFunctionBasicParams(function *schemapb.FunctionSchema) error {
 	if function.GetName() == "" {
-		return errors.New("function name cannot be empty")
+		return merr.WrapErrParameterInvalidMsg("function name cannot be empty")
 	}
 	if len(function.GetInputFieldNames()) == 0 {
-		return fmt.Errorf("function input field names cannot be empty, function: %s", function.GetName())
+		return merr.WrapErrParameterInvalidMsg("function input field names cannot be empty, function: %s", function.GetName())
 	}
 	if len(function.GetOutputFieldNames()) == 0 {
-		return fmt.Errorf("function output field names cannot be empty, function: %s", function.GetName())
+		return merr.WrapErrParameterInvalidMsg("function output field names cannot be empty, function: %s", function.GetName())
 	}
 	for _, input := range function.GetInputFieldNames() {
 		if input == "" {
-			return fmt.Errorf("function input field name cannot be empty string, function: %s", function.GetName())
+			return merr.WrapErrParameterInvalidMsg("function input field name cannot be empty string, function: %s", function.GetName())
 		}
 		// if input occurs more than once, error
 		if lo.Count(function.GetInputFieldNames(), input) > 1 {
-			return fmt.Errorf("each function input field should be used exactly once in the same function, function: %s, input field: %s", function.GetName(), input)
+			return merr.WrapErrParameterInvalidMsg("each function input field should be used exactly once in the same function, function: %s, input field: %s", function.GetName(), input)
 		}
 	}
 	for _, output := range function.GetOutputFieldNames() {
 		if output == "" {
-			return fmt.Errorf("function output field name cannot be empty string, function: %s", function.GetName())
+			return merr.WrapErrParameterInvalidMsg("function output field name cannot be empty string, function: %s", function.GetName())
 		}
 		if lo.Count(function.GetInputFieldNames(), output) > 0 {
-			return fmt.Errorf("a single field cannot be both input and output in the same function, function: %s, field: %s", function.GetName(), output)
+			return merr.WrapErrParameterInvalidMsg("a single field cannot be both input and output in the same function, function: %s, field: %s", function.GetName(), output)
 		}
 		if lo.Count(function.GetOutputFieldNames(), output) > 1 {
-			return fmt.Errorf("each function output field should be used exactly once in the same function, function: %s, output field: %s", function.GetName(), output)
+			return merr.WrapErrParameterInvalidMsg("each function output field should be used exactly once in the same function, function: %s, output field: %s", function.GetName(), output)
 		}
 	}
 	switch function.GetType() {
 	case schemapb.FunctionType_BM25:
 		if len(function.GetParams()) != 0 {
-			return errors.New("BM25 function accepts no params")
+			return merr.WrapErrParameterInvalidMsg("BM25 function accepts no params")
 		}
 	case schemapb.FunctionType_TextEmbedding:
 		if len(function.GetParams()) == 0 {
-			return errors.New("TextEmbedding function accepts no params")
+			return merr.WrapErrParameterInvalidMsg("TextEmbedding function accepts no params")
 		}
 	case schemapb.FunctionType_MinHash:
 		// MinHash function can accept optional params
 		return nil
 	default:
-		return errors.New("check function params with unknown function type")
+		return merr.WrapErrParameterInvalidMsg("check function params with unknown function type")
 	}
 	return nil
 }
@@ -1123,7 +1123,7 @@ func validateMultipleVectorFields(schema *schemapb.CollectionSchema) error {
 		dType := schema.Fields[i].DataType
 		isVec := typeutil.IsVectorType(dType)
 		if isVec && vecExist && !enableMultipleVectorFields {
-			return fmt.Errorf(
+			return merr.WrapErrParameterInvalidMsg(
 				"multiple vector fields is not supported, fields name: %s, %s",
 				vecName,
 				name,
@@ -1300,10 +1300,10 @@ func autoGenPrimaryFieldData(fieldSchema *schemapb.FieldSchema, data interface{}
 				},
 			}
 		default:
-			return nil, errors.New("currently only support autoID for int64 and varchar PrimaryField")
+			return nil, merr.WrapErrParameterInvalidMsg("currently only support autoID for int64 and varchar PrimaryField")
 		}
 	default:
-		return nil, errors.New("currently only int64 is supported as the data source for the autoID of a PrimaryField")
+		return nil, merr.WrapErrParameterInvalidMsg("currently only int64 is supported as the data source for the autoID of a PrimaryField")
 	}
 
 	return &fieldData, nil
@@ -1362,7 +1362,7 @@ func validateFieldDataColumns(columns []*schemapb.FieldData, schema *schemaInfo)
 
 	// Validate column count
 	if len(columns) != expectColumnNum {
-		return fmt.Errorf("len(columns) mismatch the expectColumnNum, expectColumnNum: %d, len(columns): %d",
+		return merr.WrapErrParameterInvalidMsg("len(columns) mismatch the expectColumnNum, expectColumnNum: %d, len(columns): %d",
 			expectColumnNum, len(columns))
 	}
 
@@ -1370,7 +1370,7 @@ func validateFieldDataColumns(columns []*schemapb.FieldData, schema *schemaInfo)
 	for _, fieldData := range columns {
 		_, err := schema.schemaHelper.GetFieldFromNameDefaultJSON(fieldData.FieldName)
 		if err != nil {
-			return fmt.Errorf("fieldName %v not exist in collection schema", fieldData.FieldName)
+			return merr.WrapErrParameterInvalidMsg("fieldName %v not exist in collection schema", fieldData.FieldName)
 		}
 	}
 
@@ -1385,7 +1385,7 @@ func fillFieldPropertiesOnly(columns []*schemapb.FieldData, schema *schemaInfo) 
 		// Use schemaHelper to get field schema, automatically handles dynamic fields
 		fieldSchema, err := schema.schemaHelper.GetFieldFromNameDefaultJSON(fieldData.FieldName)
 		if err != nil {
-			return fmt.Errorf("fieldName %v not exist in collection schema", fieldData.FieldName)
+			return merr.WrapErrParameterInvalidMsg("fieldName %v not exist in collection schema", fieldData.FieldName)
 		}
 
 		fieldData.FieldId = fieldSchema.FieldID
@@ -1396,14 +1396,14 @@ func fillFieldPropertiesOnly(columns []*schemapb.FieldData, schema *schemaInfo) 
 		case schemapb.DataType_Array:
 			fd, ok := fieldData.Field.(*schemapb.FieldData_Scalars)
 			if !ok || fd.Scalars.GetArrayData() == nil {
-				return fmt.Errorf("field convert FieldData_Scalars fail in fieldData, fieldName: %s, collectionName: %s",
+				return merr.WrapErrParameterInvalidMsg("field convert FieldData_Scalars fail in fieldData, fieldName: %s, collectionName: %s",
 					fieldData.FieldName, schema.Name)
 			}
 			fd.Scalars.GetArrayData().ElementType = fieldSchema.ElementType
 		case schemapb.DataType_ArrayOfVector:
 			fd, ok := fieldData.Field.(*schemapb.FieldData_Vectors)
 			if !ok || fd.Vectors.GetVectorArray() == nil {
-				return fmt.Errorf("field convert FieldData_Vectors fail in fieldData, fieldName: %s, collectionName: %s",
+				return merr.WrapErrParameterInvalidMsg("field convert FieldData_Vectors fail in fieldData, fieldName: %s, collectionName: %s",
 					fieldData.FieldName, schema.Name)
 			}
 			fd.Vectors.GetVectorArray().ElementType = fieldSchema.ElementType
@@ -1695,7 +1695,7 @@ func recallCal[T string | int64](results []T, gts []T) float32 {
 
 func computeRecall(results *schemapb.SearchResultData, gts *schemapb.SearchResultData) error {
 	if results.GetNumQueries() != gts.GetNumQueries() {
-		return fmt.Errorf("num of queries is inconsistent between search results(%d) and ground truth(%d)", results.GetNumQueries(), gts.GetNumQueries())
+		return merr.WrapErrParameterInvalidMsg("num of queries is inconsistent between search results(%d) and ground truth(%d)", results.GetNumQueries(), gts.GetNumQueries())
 	}
 
 	// When search returns no results, IDs field is nil. Set recalls to 0 for all queries.
@@ -1723,9 +1723,9 @@ func computeRecall(results *schemapb.SearchResultData, gts *schemapb.SearchResul
 			results.Recalls = recalls
 			return nil
 		case *schemapb.IDs_StrId:
-			return errors.New("pk type is inconsistent between search results(int64) and ground truth(string)")
+			return merr.WrapErrParameterInvalidMsg("pk type is inconsistent between search results(int64) and ground truth(string)")
 		default:
-			return errors.New("unsupported pk type")
+			return merr.WrapErrParameterInvalidMsg("unsupported pk type")
 		}
 
 	case *schemapb.IDs_StrId:
@@ -1745,12 +1745,12 @@ func computeRecall(results *schemapb.SearchResultData, gts *schemapb.SearchResul
 			results.Recalls = recalls
 			return nil
 		case *schemapb.IDs_IntId:
-			return errors.New("pk type is inconsistent between search results(string) and ground truth(int64)")
+			return merr.WrapErrParameterInvalidMsg("pk type is inconsistent between search results(string) and ground truth(int64)")
 		default:
-			return errors.New("unsupported pk type")
+			return merr.WrapErrParameterInvalidMsg("unsupported pk type")
 		}
 	default:
-		return errors.New("unsupported pk type")
+		return merr.WrapErrParameterInvalidMsg("unsupported pk type")
 	}
 }
 
@@ -1824,7 +1824,7 @@ func translateOutputFields(outputFields []string, schema *schemaInfo, removePkFi
 				} else if aggFieldName == "*" {
 					// only count(*) is allowed
 					if aggregateName != "count" {
-						return nil, nil, nil, nil, false, fmt.Errorf("%s(*) is not supported, only count(*) is allowed", aggregateName)
+						return nil, nil, nil, nil, false, merr.WrapErrParameterInvalidMsg("%s(*) is not supported, only count(*) is allowed", aggregateName)
 					}
 					if err := agg.ValidateAggFieldType(aggregateName, schemapb.DataType_None); err != nil {
 						return nil, nil, nil, nil, false, err
@@ -1835,7 +1835,7 @@ func translateOutputFields(outputFields []string, schema *schemaInfo, removePkFi
 					}
 					aggregates = append(aggregates, aggFuncs...)
 				} else {
-					return nil, nil, nil, nil, false, fmt.Errorf("target field %s for aggregation:%s does not exist", aggFieldName, aggregateName)
+					return nil, nil, nil, nil, false, merr.WrapErrParameterInvalidMsg("target field %s for aggregation:%s does not exist", aggFieldName, aggregateName)
 				}
 				userOutputFieldsMap[outputFieldName] = true
 				continue
@@ -1852,7 +1852,7 @@ func translateOutputFields(outputFields []string, schema *schemaInfo, removePkFi
 			}
 			if field, ok := allFieldNameMap[outputFieldName]; ok {
 				if !schema.CanRetrieveRawFieldData(field) {
-					return nil, nil, nil, nil, false, fmt.Errorf("not allowed to retrieve raw data of field %s", outputFieldName)
+					return nil, nil, nil, nil, false, merr.WrapErrParameterInvalidMsg("not allowed to retrieve raw data of field %s", outputFieldName)
 				}
 				resultFieldNameMap[outputFieldName] = true
 				userOutputFieldsMap[outputFieldName] = true
@@ -1865,12 +1865,12 @@ func translateOutputFields(outputFields []string, schema *schemaInfo, removePkFi
 						dynamicField, _ := schema.schemaHelper.GetDynamicField()
 						// only $meta["xxx"] is allowed for now
 						if dynamicField.GetFieldID() != columnInfo.GetFieldId() {
-							return errors.New("not support getting subkeys of json field yet")
+							return merr.WrapErrParameterInvalidMsg("not support getting subkeys of json field yet")
 						}
 						nestedPaths := columnInfo.GetNestedPath()
 						// $meta["A"]["B"] not allowed for now
 						if len(nestedPaths) != 1 {
-							return errors.New("not support getting multiple level of dynamic field for now")
+							return merr.WrapErrParameterInvalidMsg("not support getting multiple level of dynamic field for now")
 						}
 						// $meta["dyn_field"], output field name could be:
 						// 1. "dyn_field", outputFieldName == nestedPath
@@ -1883,13 +1883,13 @@ func translateOutputFields(outputFields []string, schema *schemaInfo, removePkFi
 					})
 					if err != nil {
 						log.Info("parse output field name failed", zap.String("field name", outputFieldName), zap.Error(err))
-						return nil, nil, nil, nil, false, fmt.Errorf("parse output field name failed: %s", outputFieldName)
+						return nil, nil, nil, nil, false, merr.WrapErrParameterInvalidMsg("parse output field name failed: %s", outputFieldName)
 					}
 					resultFieldNameMap[common.MetaFieldName] = true
 					userOutputFieldsMap[outputFieldName] = true
 					userDynamicFieldsMap[dynamicNestedPath] = true
 				} else {
-					return nil, nil, nil, nil, false, fmt.Errorf("field %s not exist", outputFieldName)
+					return nil, nil, nil, nil, false, merr.WrapErrParameterInvalidMsg("field %s not exist", outputFieldName)
 				}
 			}
 		}
@@ -1928,13 +1928,13 @@ func validateIndexName(indexName string) error {
 	invalidMsg := "Invalid index name: " + indexName + ". "
 	if len(indexName) > Params.ProxyCfg.MaxNameLength.GetAsInt() {
 		msg := invalidMsg + "The length of a index name must be less than " + Params.ProxyCfg.MaxNameLength.GetValue() + " characters."
-		return errors.New(msg)
+		return merr.WrapErrParameterInvalidMsg("%s", msg)
 	}
 
 	firstChar := indexName[0]
 	if firstChar != '_' && !isAlpha(firstChar) {
 		msg := invalidMsg + "The first character of a index name must be an underscore or letter."
-		return errors.New(msg)
+		return merr.WrapErrParameterInvalidMsg("%s", msg)
 	}
 
 	indexNameSize := len(indexName)
@@ -1942,7 +1942,7 @@ func validateIndexName(indexName string) error {
 		c := indexName[i]
 		if !validCharInIndexName(c) {
 			msg := invalidMsg + "Index name can only contain numbers, letters, and underscores."
-			return errors.New(msg)
+			return merr.WrapErrParameterInvalidMsg("%s", msg)
 		}
 	}
 	return nil
@@ -2097,18 +2097,18 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 		structName := fieldData.FieldName
 		structSchema, ok := structSchemaMap[structName]
 		if !ok {
-			return fmt.Errorf("fieldName %v not exist in collection schema, fieldType %v, fieldId %v", fieldData.FieldName, fieldData.Type, fieldData.FieldId)
+			return merr.WrapErrParameterInvalidMsg("fieldName %v not exist in collection schema, fieldType %v, fieldId %v", fieldData.FieldName, fieldData.Type, fieldData.FieldId)
 		}
 
 		structFieldCount++
 		structArrays, ok := fieldData.Field.(*schemapb.FieldData_StructArrays)
 		if !ok {
-			return fmt.Errorf("field convert FieldData_StructArrays fail in fieldData, fieldName: %s,"+
+			return merr.WrapErrParameterInvalidMsg("field convert FieldData_StructArrays fail in fieldData, fieldName: %s,"+
 				" collectionName:%s", structName, schema.Name)
 		}
 
 		if len(structArrays.StructArrays.Fields) != len(structSchema.GetFields()) {
-			return fmt.Errorf("length of fields of struct field mismatch length of the fields in schema, fieldName: %s,"+
+			return merr.WrapErrParameterInvalidMsg("length of fields of struct field mismatch length of the fields in schema, fieldName: %s,"+
 				" collectionName:%s, fieldData fields length:%d, schema fields length:%d",
 				structName, schema.Name, len(structArrays.StructArrays.Fields), len(structSchema.GetFields()))
 		}
@@ -2255,7 +2255,7 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 						})
 					}
 				} else {
-					return fmt.Errorf("scalar array data is nil in struct field '%s', sub-field '%s'",
+					return merr.WrapErrParameterInvalidMsg("scalar array data is nil in struct field '%s', sub-field '%s'",
 						structName, subField.FieldName)
 				}
 			case *schemapb.FieldData_Vectors:
@@ -2298,18 +2298,18 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 						})
 					}
 				} else {
-					return fmt.Errorf("vector array data is nil in struct field '%s', sub-field '%s'",
+					return merr.WrapErrParameterInvalidMsg("vector array data is nil in struct field '%s', sub-field '%s'",
 						structName, subField.FieldName)
 				}
 			default:
-				return fmt.Errorf("unexpected field data type in struct array field, fieldName: %s", structName)
+				return merr.WrapErrParameterInvalidMsg("unexpected field data type in struct array field, fieldName: %s", structName)
 			}
 
 			if expectedArrayLen == -1 {
 				expectedArrayLen = currentArrayLen
 				firstValidData = subField.GetValidData()
 			} else if currentArrayLen != expectedArrayLen {
-				return fmt.Errorf("inconsistent array length in struct field '%s': expected %d, got %d for sub-field '%s'",
+				return merr.WrapErrParameterInvalidMsg("inconsistent array length in struct field '%s': expected %d, got %d for sub-field '%s'",
 					structName, expectedArrayLen, currentArrayLen, subField.FieldName)
 			}
 		}
@@ -2384,7 +2384,7 @@ func checkAndFlattenStructFieldData(schema *schemapb.CollectionSchema, insertMsg
 	}
 	for _, sf := range schema.GetStructArrayFields() {
 		if !sf.GetNullable() && !seenStructs[sf.Name] {
-			return fmt.Errorf("required struct array field '%s' is missing in insert data", sf.Name)
+			return merr.WrapErrParameterInvalidMsg("required struct array field '%s' is missing in insert data", sf.Name)
 		}
 	}
 
@@ -2522,7 +2522,7 @@ func checkInputUtf8Compatiable(allFields []*schemapb.FieldSchema, insertMsg *msg
 			ok := utf8.ValidString(data)
 			if !ok {
 				log.Warn("string field data not utf-8 format", zap.String("messageVersion", strData.ProtoReflect().Descriptor().Syntax().GoString()))
-				return merr.WrapErrAsInputError(fmt.Errorf("input with analyzer should be utf-8 format, but row: %d not utf-8 format. data: %s", row, data))
+				return merr.WrapErrAsInputError(merr.WrapErrParameterInvalidMsg("input with analyzer should be utf-8 format, but row: %d not utf-8 format. data: %s", row, data))
 			}
 		}
 	}
@@ -2596,7 +2596,7 @@ func checkUpsertPrimaryFieldData(allFields []*schemapb.FieldSchema, schema *sche
 
 func getPartitionKeyFieldData(fieldSchema *schemapb.FieldSchema, insertMsg *msgstream.InsertMsg) (*schemapb.FieldData, error) {
 	if len(insertMsg.GetPartitionName()) > 0 && !Params.ProxyCfg.SkipPartitionKeyCheck.GetAsBool() {
-		return nil, errors.New("not support manually specifying the partition names if partition key mode is used")
+		return nil, merr.WrapErrParameterInvalidMsg("not support manually specifying the partition names if partition key mode is used")
 	}
 
 	for _, fieldData := range insertMsg.GetFieldsData() {
@@ -2605,7 +2605,7 @@ func getPartitionKeyFieldData(fieldSchema *schemapb.FieldSchema, insertMsg *msgs
 		}
 	}
 
-	return nil, errors.New("partition key not specify when insert")
+	return nil, merr.WrapErrParameterInvalidMsg("partition key not specify when insert")
 }
 
 func getCollectionProgress(
@@ -2809,7 +2809,7 @@ func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstr
 	for _, field := range insertMsg.FieldsData {
 		if field.GetFieldName() == common.MetaFieldName {
 			if !schema.EnableDynamicField {
-				return fmt.Errorf("without dynamic schema enabled, the field name cannot be set to %s", common.MetaFieldName)
+				return merr.WrapErrParameterInvalidMsg("without dynamic schema enabled, the field name cannot be set to %s", common.MetaFieldName)
 			}
 			for _, rowData := range field.GetScalars().GetJsonData().GetData() {
 				jsonData := make(map[string]interface{})
@@ -2821,13 +2821,13 @@ func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstr
 					return merr.WrapErrIoFailedReason(err.Error())
 				}
 				if _, ok := jsonData[common.MetaFieldName]; ok {
-					return fmt.Errorf("cannot set json key to: %s", common.MetaFieldName)
+					return merr.WrapErrParameterInvalidMsg("cannot set json key to: %s", common.MetaFieldName)
 				}
 				if !skipStaticFieldNameCheck {
 					for _, f := range schema.GetFields() {
 						if _, ok := jsonData[f.GetName()]; ok {
 							log.Info("dynamic field name include the static field name", zap.String("fieldName", f.GetName()))
-							return fmt.Errorf("dynamic field name cannot include the static field name: %s", f.GetName())
+							return merr.WrapErrParameterInvalidMsg("dynamic field name cannot include the static field name: %s", f.GetName())
 						}
 					}
 				}
@@ -2884,7 +2884,7 @@ func addNamespaceData(schema *schemapb.CollectionSchema, insertMsg *msgstream.In
 	// check namespace field exists
 	namespaceField := typeutil.GetFieldByName(schema, common.NamespaceFieldName)
 	if namespaceField == nil {
-		return fmt.Errorf("namespace field not found")
+		return merr.WrapErrParameterInvalidMsg("namespace field not found")
 	}
 
 	// If namespace field data is already present, validate it instead of rejecting outright.
@@ -2896,15 +2896,15 @@ func addNamespaceData(schema *schemapb.CollectionSchema, insertMsg *msgstream.In
 			}
 			scalars := fieldData.GetScalars()
 			if scalars == nil {
-				return fmt.Errorf("invalid namespace field data layout")
+				return merr.WrapErrParameterInvalidMsg("invalid namespace field data layout")
 			}
 			strData := scalars.GetStringData()
 			if strData == nil {
-				return fmt.Errorf("invalid namespace field data layout")
+				return merr.WrapErrParameterInvalidMsg("invalid namespace field data layout")
 			}
 			for _, v := range strData.GetData() {
 				if v != ns {
-					return fmt.Errorf("namespace field value %q mismatches namespace %q", v, ns)
+					return merr.WrapErrParameterInvalidMsg("namespace field value %q mismatches namespace %q", v, ns)
 				}
 			}
 			// Values are consistent with the namespace; nothing more to do.
@@ -3123,7 +3123,7 @@ func GetRequestInfo(ctx context.Context, req proto.Message) (int64, map[int64][]
 		return util.InvalidDBID, map[int64][]int64{}, internalpb.RateType_DDLDB, 1, nil
 	default: // TODO: support more request
 		if req == nil {
-			return util.InvalidDBID, map[int64][]int64{}, 0, 0, errors.New("null request")
+			return util.InvalidDBID, map[int64][]int64{}, 0, 0, merr.WrapErrParameterInvalidMsg("null request")
 		}
 		log.RatedWarn(60, "not supported request type for rate limiter", zap.String("type", reflect.TypeOf(req).String()))
 		return util.InvalidDBID, map[int64][]int64{}, 0, 0, nil

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1245,7 +1245,7 @@ func CheckDuplicatePkExist(primaryFieldSchema *schemapb.FieldSchema, fieldsData 
 	}
 
 	if primaryFieldData == nil {
-		return false, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("must assign pk when upsert, primary field: %v", primaryFieldSchema.GetName()))
+		return false, merr.WrapErrParameterInvalidMsg("must assign pk when upsert, primary field: %v", primaryFieldSchema.GetName())
 	}
 
 	// check for duplicates based on primary key type
@@ -2428,7 +2428,7 @@ func checkPrimaryFieldData(allFields []*schemapb.FieldSchema, schema *schemapb.C
 	} else {
 		// check primary key data not exist
 		if typeutil.IsPrimaryFieldDataExist(insertMsg.GetFieldsData(), primaryFieldSchema) {
-			return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("can not assign primary field data when auto id enabled and allow_insert_auto_id is false %v", primaryFieldSchema.Name))
+			return nil, merr.WrapErrParameterInvalidMsg("can not assign primary field data when auto id enabled and allow_insert_auto_id is false %v", primaryFieldSchema.Name)
 		}
 		// if autoID == true, currently support autoID for int64 and varchar PrimaryField
 		primaryFieldData, err = autoGenPrimaryFieldData(primaryFieldSchema, insertMsg.GetRowIDs())
@@ -2574,7 +2574,7 @@ func checkUpsertPrimaryFieldData(allFields []*schemapb.FieldSchema, schema *sche
 	}
 	// must assign primary field data when upsert
 	if primaryFieldData == nil {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("must assign pk when upsert, primary field: %v", primaryFieldName))
+		return nil, nil, merr.WrapErrParameterInvalidMsg("must assign pk when upsert, primary field: %v", primaryFieldName)
 	}
 
 	// parse primaryFieldData to result.IDs, and as returned primary keys

--- a/internal/proxy/validate_util.go
+++ b/internal/proxy/validate_util.go
@@ -560,7 +560,7 @@ func FillWithNullValue(field *schemapb.FieldData, fieldSchema *schemapb.FieldSch
 				return err
 			}
 		default:
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined data type:%s", field.Type.String()))
+			return merr.WrapErrParameterInvalidMsg("undefined data type:%s", field.Type.String())
 		}
 
 	case *schemapb.FieldData_Vectors:
@@ -581,7 +581,7 @@ func FillWithNullValue(field *schemapb.FieldData, fieldSchema *schemapb.FieldSch
 			vectorArray.Data = expanded
 		}
 	default:
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined data type:%s", field.Type.String()))
+		return merr.WrapErrParameterInvalidMsg("undefined data type:%s", field.Type.String())
 	}
 
 	return nil
@@ -748,7 +748,7 @@ func FillWithDefaultValue(field *schemapb.FieldData, fieldSchema *schemapb.Field
 			}
 
 		default:
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined data type:%s", field.Type.String()))
+			return merr.WrapErrParameterInvalidMsg("undefined data type:%s", field.Type.String())
 		}
 
 	case *schemapb.FieldData_Vectors:
@@ -756,7 +756,7 @@ func FillWithDefaultValue(field *schemapb.FieldData, fieldSchema *schemapb.Field
 		return merr.WrapErrParameterInvalidMsg("vector type not support default value")
 
 	default:
-		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined data type:%s", field.Type.String()))
+		return merr.WrapErrParameterInvalidMsg("undefined data type:%s", field.Type.String())
 	}
 
 	if !typeutil.IsVectorType(field.Type) {

--- a/internal/proxy/vector_type_convert.go
+++ b/internal/proxy/vector_type_convert.go
@@ -18,13 +18,13 @@ package proxy
 
 import (
 	"encoding/binary"
-	"fmt"
 	"math"
 
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -76,12 +76,12 @@ func validateFloat32ForFloat16(values []float32) error {
 
 		// Check overflow
 		if absV > float16MaxValue {
-			return fmt.Errorf("value at dimension %d (%v) exceeds float16 range [-65504, 65504]", i, v)
+			return merr.WrapErrParameterInvalidMsg("value at dimension %d (%v) exceeds float16 range [-65504, 65504]", i, v)
 		}
 
 		// Check underflow (non-zero values smaller than min positive)
 		if v != 0 && absV < float16MinPositive {
-			return fmt.Errorf("value at dimension %d (%v) underflows float16 precision (min abs value: %v)", i, v, float16MinPositive)
+			return merr.WrapErrParameterInvalidMsg("value at dimension %d (%v) underflows float16 precision (min abs value: %v)", i, v, float16MinPositive)
 		}
 	}
 	return nil
@@ -92,10 +92,10 @@ func validateFloat32ForFloat16(values []float32) error {
 func validateFloat32ForBFloat16(values []float32) error {
 	for i, v := range values {
 		if math.IsInf(float64(v), 0) {
-			return fmt.Errorf("value at dimension %d is infinity, cannot convert to bfloat16", i)
+			return merr.WrapErrParameterInvalidMsg("value at dimension %d is infinity, cannot convert to bfloat16", i)
 		}
 		if math.IsNaN(float64(v)) {
-			return fmt.Errorf("value at dimension %d is NaN, cannot convert to bfloat16", i)
+			return merr.WrapErrParameterInvalidMsg("value at dimension %d is NaN, cannot convert to bfloat16", i)
 		}
 	}
 	return nil
@@ -109,7 +109,7 @@ func validateFloat32ForBFloat16(values []float32) error {
 func ConvertPlaceholderGroup(phgBytes []byte, fieldSchema *schemapb.FieldSchema) ([]byte, commonpb.PlaceholderType, error) {
 	var phg commonpb.PlaceholderGroup
 	if err := proto.Unmarshal(phgBytes, &phg); err != nil {
-		return nil, 0, fmt.Errorf("failed to unmarshal placeholder group: %w", err)
+		return nil, 0, merr.WrapErrParameterInvalidMsg("failed to unmarshal placeholder group: %v", err)
 	}
 
 	if len(phg.Placeholders) == 0 {
@@ -140,7 +140,7 @@ func ConvertPlaceholderGroup(phgBytes []byte, fieldSchema *schemapb.FieldSchema)
 
 	// Check if conversion is supported (fp32 -> fp16/bf16)
 	if placeholder.Type != commonpb.PlaceholderType_FloatVector {
-		return nil, phType, fmt.Errorf("vector type must be the same: field type %s, search type %s",
+		return nil, phType, merr.WrapErrParameterInvalidMsg("vector type must be the same: field type %s, search type %s",
 			fieldType.String(), placeholder.Type.String())
 	}
 
@@ -170,7 +170,7 @@ func convertPlaceholder(
 	for i, valueBytes := range placeholder.Values {
 		floats, err := bytesToFloat32Array(valueBytes)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse float32 vector at index %d: %w", i, err)
+			return nil, merr.WrapErrParameterInvalidMsg("failed to parse float32 vector at index %d: %v", i, err)
 		}
 
 		if err := validateFn(floats); err != nil {
@@ -189,7 +189,7 @@ func convertPlaceholder(
 // bytesToFloat32Array converts byte slice to float32 array.
 func bytesToFloat32Array(data []byte) ([]float32, error) {
 	if len(data)%4 != 0 {
-		return nil, fmt.Errorf("invalid float32 vector data length: %d", len(data))
+		return nil, merr.WrapErrParameterInvalidMsg("invalid float32 vector data length: %d", len(data))
 	}
 
 	dim := len(data) / 4

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -237,7 +237,7 @@ func (rm *ResourceManager) updateResourceGroups(ctx context.Context, rgs map[str
 				zap.Error(err),
 			)
 		}
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.
@@ -434,7 +434,7 @@ func (rm *ResourceManager) DropResourceGroup(ctx context.Context, rgName string)
 			zap.String("rgName", rgName),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// After recovering, all node assigned to these rg has been removed.
@@ -1050,7 +1050,7 @@ func (rm *ResourceManager) transferNode(ctx context.Context, rgName string, node
 			zap.Int64("node", node),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -223,7 +223,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 			}
 			logger.Info("append flush message for segments that not created by streaming service into wal", zap.Stringer("msgID", appendResult.MessageID), zap.Uint64("timeTick", appendResult.TimeTick))
 			return nil
-		}, retry.AttemptAlways()); err != nil {
+		}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true })); err != nil {
 			return nil, err
 		}
 	}
@@ -233,7 +233,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 		var err error
 		ds, err = impl.buildDataSyncService(ctx, recoverInfo)
 		return err
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
@@ -101,7 +101,7 @@ func (impl *msgHandlerImpl) createNewGrowingSegment(ctx context.Context, vchanne
 		}
 		logger.Info("alloc growing segment at datacoord", zap.Int32("schemaVersion", h.SchemaVersion))
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 }
 
 func (impl *msgHandlerImpl) HandleFlush(flushMsg message.ImmutableFlushMessageV2) error {

--- a/internal/streamingnode/server/flusher/flusherimpl/util.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/util.go
@@ -90,7 +90,7 @@ func (impl *WALFlusherImpl) getRecoveryInfo(ctx context.Context, vchannel string
 			return retry.Unrecoverable(errChannelLifetimeUnrecoverable)
 		}
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	return resp, err
 }
 

--- a/pkg/util/etcd/etcd_util_test.go
+++ b/pkg/util/etcd/etcd_util_test.go
@@ -18,15 +18,51 @@ package etcd
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"os"
 	"path"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// freePort grabs a random unused TCP port. There's a small TOCTOU window
+// between Close and the subsequent bind, but for unit tests it's acceptable.
+func freePort(t *testing.T) int {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
 func TestEtcd(t *testing.T) {
-	err := InitEtcdServer(true, "", "/tmp/data", "stdout", "info")
+	// Use random free ports so the embedded etcd does not collide with any
+	// already-running etcd on the dev machine (e.g. docker-compose etcd
+	// holding 2379/2380).
+	clientPort, peerPort := freePort(t), freePort(t)
+	dataDir, err := os.MkdirTemp("", "test-etcd-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dataDir)
+	cfgFile, err := os.CreateTemp("", "test-etcd-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(cfgFile.Name())
+	_, err = fmt.Fprintf(cfgFile, `name: default
+data-dir: %s
+listen-client-urls: http://127.0.0.1:%d
+advertise-client-urls: http://127.0.0.1:%d
+listen-peer-urls: http://127.0.0.1:%d
+initial-advertise-peer-urls: http://127.0.0.1:%d
+initial-cluster: default=http://127.0.0.1:%d
+initial-cluster-state: new
+`, dataDir, clientPort, clientPort, peerPort, peerPort, peerPort)
+	require.NoError(t, err)
+	require.NoError(t, cfgFile.Close())
+
+	err = InitEtcdServer(true, cfgFile.Name(), dataDir, "stdout", "info")
 	assert.NoError(t, err)
 	defer StopEtcdServer()
 

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -18,6 +18,7 @@ package merr
 
 import (
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/markers"
 	"github.com/samber/lo"
 )
 
@@ -36,6 +37,11 @@ const (
 var ErrorTypeName = map[ErrorType]string{
 	SystemError: "system_error",
 	InputError:  "input_error",
+}
+
+// ErrorClassifier defines the method to get the broad classification of a Milvus error.
+type ErrorClassifier interface {
+	GetErrorType() ErrorType
 }
 
 func (err ErrorType) String() string {
@@ -60,20 +66,23 @@ var (
 	ErrServiceUnimplemented        = newMilvusError("service unimplemented", 10, false)
 	ErrServiceTimeTickLongDelay    = newMilvusError("time tick long delay", 11, false)
 	ErrServiceResourceInsufficient = newMilvusError("service resource insufficient", 12, true)
+	ErrOldSessionExists            = newMilvusError("old session exists", 13, false)
+	ErrOperationNotSupported       = newMilvusError("unsupported operation", 14, false)
 
 	// Collection related
-	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false)
+	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false, WithErrorType(InputError))
 	ErrCollectionNotLoaded                     = newMilvusError("collection not loaded", 101, false)
-	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false)
+	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false, WithErrorType(InputError))
 	ErrCollectionNotFullyLoaded                = newMilvusError("collection not fully loaded", 103, true)
-	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false)
-	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false)
+	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false, WithErrorType(InputError))
+	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false, WithErrorType(InputError))
 	ErrCollectionOnRecovering                  = newMilvusError("collection on recovering", 106, true)
-	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false)
+	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false, WithErrorType(InputError))
 	// Deprecated, keep it only for reserving the error code
-	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false)
-	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false)
+	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false, WithErrorType(InputError))
+	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false, WithErrorType(InputError))
 	ErrCollectionSchemaVersionNotReady = newMilvusError("collection schema version not ready", 110, true)
+
 	// Partition related
 	ErrPartitionNotFound       = newMilvusError("partition not found", 200, false)
 	ErrPartitionNotLoaded      = newMilvusError("partition not loaded", 201, false)
@@ -83,13 +92,13 @@ var (
 	ErrGeneralCapacityExceeded = newMilvusError("general capacity exceeded", 250, false)
 
 	// ResourceGroup related
-	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false)
-	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false)
-	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false)
-	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false)
+	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false, WithErrorType(InputError))
+	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false, WithErrorType(InputError))
+	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false, WithErrorType(InputError))
+	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false, WithErrorType(InputError))
 	// go:deprecated
-	ErrResourceGroupNodeNotEnough    = newMilvusError("resource group node not enough", 304, false)
-	ErrResourceGroupServiceAvailable = newMilvusError("resource group service available", 305, true)
+	ErrResourceGroupNodeNotEnough      = newMilvusError("resource group node not enough", 304, false)
+	ErrResourceGroupServiceUnAvailable = newMilvusError("resource group service unavailable", 305, true)
 
 	// Replica related
 	ErrReplicaNotFound     = newMilvusError("replica not found", 400, false)
@@ -118,13 +127,13 @@ var (
 	// Index related
 	ErrIndexNotFound     = newMilvusError("index not found", 700, false)
 	ErrIndexNotSupported = newMilvusError("index type not supported", 701, false)
-	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false)
+	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false, WithErrorType(InputError))
 	ErrTaskDuplicate     = newMilvusError("task duplicates", 703, false)
 
 	// Database related
-	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false)
-	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false)
-	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false)
+	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false, WithErrorType(InputError))
+	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false, WithErrorType(InputError))
+	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false, WithErrorType(InputError))
 
 	// Node related
 	ErrNodeNotFound        = newMilvusError("node not found", 901, false)
@@ -167,7 +176,7 @@ var (
 
 	// Privilege related
 	// this operation is denied because the user not authorized, user need to login in first
-	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false)
+	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false, WithErrorType(InputError))
 	// this operation is denied because the user has no permission to do this, user need higher privilege
 	ErrPrivilegeNotPermitted     = newMilvusError("privilege not permitted", 1401, false)
 	ErrPrivilegeGroupInvalidName = newMilvusError("invalid privilege group name", 1402, false)
@@ -213,7 +222,7 @@ var (
 	errUnexpected = newMilvusError("unexpected error", (1<<16)-1, false)
 
 	// import
-	ErrImportFailed = newMilvusError("importing data failed", 2100, false)
+	ErrImportFailed = newMilvusError("importing data failed", 2100, false, WithErrorType(InputError))
 
 	// Search/Query related
 	ErrInconsistentRequery = newMilvusError("inconsistent requery result", 2200, true)
@@ -251,11 +260,6 @@ var (
 	// Snapshot related
 	ErrSnapshotNotFound = newMilvusError("snapshot not found", 2600, false)
 	ErrSnapshotPinned   = newMilvusError("snapshot is pinned", 2601, false)
-
-	// General
-	ErrOperationNotSupported = newMilvusError("unsupported operation", 3000, false)
-
-	ErrOldSessionExists = newMilvusError("old session exists", 3001, false)
 )
 
 type errorOption func(*milvusError)
@@ -314,6 +318,53 @@ func (e milvusError) Is(err error) bool {
 	return false
 }
 
+// GetErrorType implements the ErrorClassifier interface.
+// It returns the predefined classification of the error (SystemError or InputError).
+func (e milvusError) GetErrorType() ErrorType {
+	return e.errType
+}
+
+// wrappedMilvusError wraps an underlying error with a milvus sentinel and a
+// contextual message, while preserving the inner error chain. Designed so
+// all of the following work on the result, under both stdlib and cockroachdb
+// errors.Is semantics:
+//
+//   - errors.Is(result, sentinel)      → true   (matched via Is)
+//   - errors.Is(result, originalInner) → true   (inner reachable via Unwrap)
+//   - merr.Code(result)                → sentinel's errCode
+//
+// Cause is intentionally NOT overridden: cockroachdb's errors.Is walks the
+// Cause chain first, so returning the sentinel from Cause would hide the
+// inner error. Instead, merr.Code special-cases this type.
+type wrappedMilvusError struct {
+	msg      string
+	inner    error
+	sentinel milvusError
+}
+
+func (w *wrappedMilvusError) Error() string { return w.msg + ": " + w.inner.Error() }
+
+// Unwrap exposes the original error so errors.Is(w, originalInner) works
+// under both stdlib and cockroachdb chain walkers.
+func (w *wrappedMilvusError) Unwrap() error { return w.inner }
+
+// Is matches any milvus sentinel by delegating to the wrapped sentinel.
+func (w *wrappedMilvusError) Is(target error) bool {
+	return errors.Is(w.sentinel, target)
+}
+
+// code lets merr.Code retrieve the milvus error code without needing to
+// resolve the cause chain (which has been redirected to the inner error).
+func (w *wrappedMilvusError) code() int32 {
+	return w.sentinel.errCode
+}
+
+// GetErrorType lets ErrorClassifier consumers (proxy metrics, retry policy)
+// see the same classification as the sentinel.
+func (w *wrappedMilvusError) GetErrorType() ErrorType {
+	return w.sentinel.errType
+}
+
 type multiErrors struct {
 	errs []error
 }
@@ -358,4 +409,16 @@ func Combine(errs ...error) error {
 	return multiErrors{
 		errs,
 	}
+}
+
+func Wrap(err error, msg string) error {
+	return errors.Wrap(err, msg)
+}
+
+func Wrapf(err error, format string, args ...interface{}) error {
+	return errors.Wrapf(err, format, args...)
+}
+
+func Mark(err error, reference error) error {
+	return markers.Mark(err, reference)
 }

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 type ErrSuite struct {
@@ -34,7 +33,6 @@ type ErrSuite struct {
 }
 
 func (s *ErrSuite) SetupSuite() {
-	paramtable.Init()
 }
 
 func (s *ErrSuite) TestCode() {
@@ -104,7 +102,7 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrResourceGroupReachLimit("test_ResourceGroup", 1, "failed to get ResourceGroup"), ErrResourceGroupReachLimit)
 	s.ErrorIs(WrapErrResourceGroupIllegalConfig("test_ResourceGroup", nil, "failed to get ResourceGroup"), ErrResourceGroupIllegalConfig)
 	s.ErrorIs(WrapErrResourceGroupNodeNotEnough("test_ResourceGroup", 1, 2, "failed to get ResourceGroup"), ErrResourceGroupNodeNotEnough)
-	s.ErrorIs(WrapErrResourceGroupServiceAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceAvailable)
+	s.ErrorIs(WrapErrResourceGroupServiceUnAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceUnAvailable)
 
 	// Replica related
 	s.ErrorIs(WrapErrReplicaNotFound(1, "failed to get replica"), ErrReplicaNotFound)
@@ -224,7 +222,7 @@ func (s *ErrSuite) TestIsHealthy() {
 	}
 	for _, tc := range cases {
 		s.Run(tc.code.String(), func() {
-			s.Equal(tc.expect, IsHealthy(tc.code) == nil)
+			s.Equal(tc.expect, CheckHealthy(tc.code) == nil)
 		})
 	}
 }
@@ -274,4 +272,75 @@ func TestNewIOErrors(t *testing.T) {
 
 func TestErrors(t *testing.T) {
 	suite.Run(t, new(ErrSuite))
+}
+
+// TestWrapErrPreservesInnerChain locks in the contract that WrapErr*Err helpers
+// keep the inner error chain reachable via errors.Is while still attributing
+// the milvus sentinel for code lookup. Regression guard against the previous
+// implementation that string-flattened the inner error and lost its identity.
+func TestWrapErrPreservesInnerChain(t *testing.T) {
+	inner := errors.New("inner-error")
+
+	for _, tc := range []struct {
+		name     string
+		wrap     func() error
+		sentinel error
+		other    error
+		code     int32
+	}{
+		{
+			name:     "ServiceInternal",
+			wrap:     func() error { return WrapErrServiceInternalErr(inner, "ctx %s", "test") },
+			sentinel: ErrServiceInternal,
+			other:    ErrParameterInvalid,
+			code:     ErrServiceInternal.errCode,
+		},
+		{
+			name:     "ParameterInvalid",
+			wrap:     func() error { return WrapErrParameterInvalidErr(inner, "ctx %d", 42) },
+			sentinel: ErrParameterInvalid,
+			other:    ErrServiceInternal,
+			code:     ErrParameterInvalid.errCode,
+		},
+		{
+			name:     "MqInternal",
+			wrap:     func() error { return WrapErrMqInternal(inner, "step1", "step2") },
+			sentinel: ErrMqInternal,
+			other:    ErrServiceInternal,
+			code:     ErrMqInternal.errCode,
+		},
+		{
+			name:     "BuildCompactionRequestFail",
+			wrap:     func() error { return WrapErrBuildCompactionRequestFail(inner) },
+			sentinel: ErrBuildCompactionRequestFail,
+			other:    ErrServiceInternal,
+			code:     ErrBuildCompactionRequestFail.errCode,
+		},
+		{
+			name:     "GetCompactionPlanResultFail",
+			wrap:     func() error { return WrapErrGetCompactionPlanResultFail(inner) },
+			sentinel: ErrGetCompactionPlanResultFail,
+			other:    ErrServiceInternal,
+			code:     ErrGetCompactionPlanResultFail.errCode,
+		},
+		{
+			name:     "OperationNotSupported",
+			wrap:     func() error { return WrapErrOperationNotSupported(inner, "op %s", "drop") },
+			sentinel: ErrOperationNotSupported,
+			other:    ErrServiceInternal,
+			code:     ErrOperationNotSupported.errCode,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := tc.wrap()
+			assert.True(t, errors.Is(w, tc.sentinel), "must match its sentinel")
+			assert.True(t, errors.Is(w, inner), "must preserve inner chain")
+			assert.False(t, errors.Is(w, tc.other), "must not match unrelated sentinel")
+			assert.Equal(t, tc.code, Code(w), "Code() must report sentinel's code")
+			assert.Contains(t, w.Error(), inner.Error(), "message must include inner")
+		})
+	}
+
+	// nil err falls back to the Msg variant; just make sure that still works.
+	assert.True(t, errors.Is(WrapErrServiceInternalErr(nil, "no underlying err"), ErrServiceInternal))
 }

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -19,16 +19,14 @@ package merr
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"go.uber.org/zap"
+	"golang.org/x/exp/constraints"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
-	"github.com/milvus-io/milvus/pkg/v3/log"
-	"github.com/milvus-io/milvus/pkg/v3/util/logutil"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 const InputErrorFlagKey string = "is_input_error"
@@ -40,20 +38,25 @@ func Code(err error) int32 {
 		return 0
 	}
 
-	cause := errors.Cause(err)
-	switch specificErr := cause.(type) {
-	case milvusError:
-		return specificErr.code()
-
-	default:
-		if errors.Is(specificErr, context.Canceled) {
-			return CanceledCode
-		} else if errors.Is(specificErr, context.DeadlineExceeded) {
-			return TimeoutCode
-		} else {
-			return errUnexpected.code()
+	// Walk the chain looking for a milvus marker (either milvusError directly,
+	// or our wrappedMilvusError whose sentinel.Cause is hidden so that the
+	// inner error stays reachable via errors.Is). Stop at the first match.
+	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
+		switch v := cur.(type) {
+		case milvusError:
+			return v.code()
+		case *wrappedMilvusError:
+			return v.code()
 		}
 	}
+
+	cause := errors.Cause(err)
+	if errors.Is(cause, context.Canceled) {
+		return CanceledCode
+	} else if errors.Is(cause, context.DeadlineExceeded) {
+		return TimeoutCode
+	}
+	return errUnexpected.code()
 }
 
 func IsRetryableErr(err error) bool {
@@ -299,17 +302,6 @@ func SegcoreError(code int32, msg string) error {
 	return newMilvusError(msg, code, false)
 }
 
-// CheckHealthy checks whether the state is healthy,
-// returns nil if healthy,
-// otherwise returns ErrServiceNotReady wrapped with current state
-func CheckHealthy(state commonpb.StateCode) error {
-	if state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(paramtable.GetRole(), paramtable.GetNodeID(), state.String())
-	}
-
-	return nil
-}
-
 func IsHealthy(stateCode commonpb.StateCode) error {
 	if stateCode == commonpb.StateCode_Healthy {
 		return nil
@@ -324,19 +316,17 @@ func IsHealthyOrStopping(stateCode commonpb.StateCode) error {
 	return CheckHealthy(stateCode)
 }
 
-func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
-	if err := Error(state.GetStatus()); err != nil {
-		return errors.Wrapf(err, "%s=%d not healthy", role, nodeID)
-	} else if state := state.GetState().GetStateCode(); state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(role, nodeID, state.String())
-	}
-
-	return nil
-}
-
 func WrapErrAsInputError(err error) error {
 	if merr, ok := err.(milvusError); ok {
 		WithErrorType(InputError)(&merr)
+		return merr
+	}
+	return err
+}
+
+func WrapErrAsSysError(err error) error {
+	if merr, ok := err.(milvusError); ok {
+		WithErrorType(SystemError)(&merr)
 		return merr
 	}
 	return err
@@ -346,7 +336,6 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	if merr, ok := err.(milvusError); ok {
 		for _, target := range targets {
 			if target.errCode == merr.errCode {
-				log.Info("mark error as input error", zap.Error(err))
 				WithErrorType(InputError)(&merr)
 				return merr
 			}
@@ -355,15 +344,43 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	return err
 }
 
+func WrapErrCollectionReplicateMode(operation string) error {
+	return wrapFields(ErrCollectionReplicateMode, value("operation", operation))
+}
+
 func GetErrorType(err error) ErrorType {
-	if merr, ok := err.(milvusError); ok {
-		return merr.errType
+	var me milvusError
+	if errors.As(err, &me) {
+		return me.errType
 	}
 
 	return SystemError
 }
 
-// Service related
+// keeps only 2 decimal places
+func toMB[T constraints.Integer | constraints.Float](mem T) T {
+	return T(math.Round(float64(mem)/1024/1024*100) / 100)
+}
+
+// CheckHealthy checks whether the state is healthy,
+// returns nil if healthy,
+// otherwise returns ErrServiceNotReady wrapped with current state
+func CheckHealthy(stateCode commonpb.StateCode) error {
+	if stateCode != commonpb.StateCode_Healthy {
+		return ErrServiceNotReady
+	}
+	return nil
+}
+
+func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
+	if err := Error(state.GetStatus()); err != nil {
+		return WrapErrServiceNotReady(role, nodeID, err.Error())
+	} else if stateCode := state.GetState().GetStateCode(); stateCode != commonpb.StateCode_Healthy {
+		return WrapErrServiceNotReady(role, nodeID, stateCode.String())
+	}
+	return nil
+}
+
 func WrapErrServiceNotReady(role string, sessionID int64, state string, msg ...string) error {
 	err := wrapFieldsWithDesc(ErrServiceNotReady,
 		state,
@@ -385,8 +402,8 @@ func WrapErrServiceUnavailable(reason string, msg ...string) error {
 
 func WrapErrServiceMemoryLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceMemoryLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -412,6 +429,21 @@ func WrapErrServiceInternal(reason string, msg ...string) error {
 	return err
 }
 
+func WrapErrServiceInternalErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrServiceInternalMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrServiceInternal,
+	}
+}
+
+func WrapErrServiceInternalMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrServiceInternal, fmt, args...)
+}
+
 func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, msg ...string) error {
 	err := wrapFields(ErrServiceCrossClusterRouting,
 		value("expectedCluster", expectedCluster),
@@ -425,8 +457,8 @@ func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, ms
 
 func WrapErrServiceDiskLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceDiskLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -715,9 +747,9 @@ func WrapErrResourceGroupNodeNotEnough(rg any, current any, expected any, msg ..
 	return err
 }
 
-// WrapErrResourceGroupServiceAvailable wraps ErrResourceGroupServiceAvailable with resource group
-func WrapErrResourceGroupServiceAvailable(msg ...string) error {
-	err := wrapFields(ErrResourceGroupServiceAvailable)
+// WrapErrResourceGroupServiceUnAvailable wraps ErrResourceGroupServiceUnAvailable with resource group
+func WrapErrResourceGroupServiceUnAvailable(msg ...string) error {
+	err := wrapFields(ErrResourceGroupServiceUnAvailable)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
@@ -1046,6 +1078,21 @@ func WrapErrParameterInvalid[T any](expected, actual T, msg ...string) error {
 	return err
 }
 
+// WrapErrParameterInvalidErr wraps an existing error 'err' with ErrParameterInvalid (Code 1005).
+// This is used when an underlying error (e.g., from parsing, validation utility, or dependency)
+// causes a parameter check to fail, and you need to provide extra context
+// in 'format' and 'args'.
+func WrapErrParameterInvalidErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrParameterInvalidMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrParameterInvalid,
+	}
+}
+
 func WrapErrParameterInvalidRange[T any](lower, upper, actual T, msg ...string) error {
 	err := wrapFields(ErrParameterInvalid,
 		bound("value", actual, lower, upper),
@@ -1068,6 +1115,10 @@ func WrapErrParameterMissing[T any](param T, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+func WrapErrParameterMissingMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrParameterMissing, fmt, args...)
 }
 
 func WrapErrParameterTooLarge(name string, msg ...string) error {
@@ -1105,11 +1156,14 @@ func WrapErrMqTopicNotEmpty(name string, msg ...string) error {
 }
 
 func WrapErrMqInternal(err error, msg ...string) error {
-	err = wrapFieldsWithDesc(ErrMqInternal, err.Error())
-	if len(msg) > 0 {
-		err = errors.Wrap(err, strings.Join(msg, "->"))
+	if err == nil {
+		return ErrMqInternal
 	}
-	return err
+	ctx := ErrMqInternal.msg
+	if len(msg) > 0 {
+		ctx = strings.Join(msg, "->") + ": " + ctx
+	}
+	return &wrappedMilvusError{msg: ctx, inner: err, sentinel: ErrMqInternal}
 }
 
 func WrapErrPrivilegeNotAuthenticated(fmt string, args ...any) error {
@@ -1251,6 +1305,12 @@ func WrapErrIllegalCompactionPlan(msg ...string) error {
 	return err
 }
 
+func WrapErrIllegalCompactionPlanMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	// Since this is the message-only path, we wrap the constant error with the formatted message.
+	return errors.Wrap(ErrIllegalCompactionPlan, detail)
+}
+
 func WrapErrCompactionPlanConflict(msg ...string) error {
 	err := error(ErrCompactionPlanConflict)
 	if len(msg) > 0 {
@@ -1319,11 +1379,25 @@ func WrapErrAnalyzeTaskNotFound(id int64) error {
 }
 
 func WrapErrBuildCompactionRequestFail(err error) error {
-	return wrapFieldsWithDesc(ErrBuildCompactionRequestFail, err.Error())
+	if err == nil {
+		return ErrBuildCompactionRequestFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrBuildCompactionRequestFail.msg,
+		inner:    err,
+		sentinel: ErrBuildCompactionRequestFail,
+	}
 }
 
 func WrapErrGetCompactionPlanResultFail(err error) error {
-	return wrapFieldsWithDesc(ErrGetCompactionPlanResultFail, err.Error())
+	if err == nil {
+		return ErrGetCompactionPlanResultFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrGetCompactionPlanResultFail.msg,
+		inner:    err,
+		sentinel: ErrGetCompactionPlanResultFail,
+	}
 }
 
 func WrapErrCompactionResult(msg ...string) error {
@@ -1383,4 +1457,23 @@ func WrapErrSnapshotPinned(name any, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+// WrapErrOperationNotSupportedMsg creates a new ErrOperationNotSupported with a detail message (Code 14).
+// This is the primary replacement for fmt.Errorf/errors.New for operations that are
+// currently not supported by the system.
+func WrapErrOperationNotSupportedMsg(format string, args ...any) error {
+	return errors.Wrapf(ErrOperationNotSupported, format, args...)
+}
+
+// WrapErrOperationNotSupported wraps an existing error 'err' with ErrOperationNotSupported (Code 14).
+func WrapErrOperationNotSupported(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrOperationNotSupportedMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrOperationNotSupported,
+	}
 }

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -178,22 +178,18 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				return err
 			}
 
-			// Caller-explicit RetryErr predicate takes precedence over the
-			// default InputError abort: when caller passes RetryErr they have
-			// decided which errors are retriable, framework must not override.
-			if c.isRetryErr != nil {
-				if !c.isRetryErr(err) {
-					log.Warn("retry func failed, not be retryable",
-						zap.Uint("retried", i),
-						zap.Uint("attempt", c.attempts),
-						zap.String("caller", getCaller(2)),
-					)
-					return err
-				}
-			} else if merr.GetErrorType(err) == merr.InputError {
-				log.Warn("retry func failed, input error is non-retriable",
+			// shouldRetry=true is the caller's explicit affirmative. Honor
+			// it. The optional RetryErr predicate is still consulted as a
+			// second gate, but unlike retry.Do the InputError default abort
+			// is intentionally not applied here: in retry.Handle the caller
+			// signals abort via shouldRetry=false, not via the error type,
+			// otherwise client-side cache-eviction patterns like
+			// retryIfSchemaError become unreachable for errors classified
+			// server-side as InputError (e.g. ErrCollectionSchemaMismatch).
+			if c.isRetryErr != nil && !c.isRetryErr(err) {
+				log.Warn("retry func failed, not be retryable",
 					zap.Uint("retried", i),
-					zap.Error(err),
+					zap.Uint("attempt", c.attempts),
 					zap.String("caller", getCaller(2)),
 				)
 				return err

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -72,10 +72,23 @@ func Do(ctx context.Context, fn func() error, opts ...Option) error {
 				}
 				return err
 			}
-			if c.isRetryErr != nil && !c.isRetryErr(err) {
-				log.Warn("retry func failed, not be retryable",
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
 					zap.Uint("retried", i),
-					zap.Uint("attempt", c.attempts),
+					zap.Error(err),
 					zap.String("caller", getCaller(2)),
 				)
 				return err
@@ -162,6 +175,27 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				if isContextErr && lastErr != nil {
 					return lastErr
 				}
+				return err
+			}
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
+					zap.Uint("retried", i),
+					zap.Error(err),
+					zap.String("caller", getCaller(2)),
+				)
 				return err
 			}
 

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -239,3 +239,53 @@ func TestHandle(t *testing.T) {
 	}, Attempts(10))
 	assert.NoError(t, err)
 }
+
+// Regression: Handle must honor the caller's shouldRetry=true even when the
+// returned error is server-classified InputError. This is the cross-case the
+// client-side cache-eviction pattern in retryIfSchemaError depends on:
+// ErrCollectionSchemaMismatch is tagged InputError server-side (the client
+// sent a stale schema and the server rejected) but the client legitimately
+// wants to evict its cache and retry. Before this case the framework's
+// "default InputError abort" was firing after shouldRetry=true and
+// retryIfSchemaError silently never retried.
+func TestHandle_ShouldRetryOverridesInputErrorDefault(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		if counter == 1 {
+			return true, merr.WrapErrCollectionSchemaMisMatch("mocked")
+		}
+		return false, nil
+	}, Attempts(10))
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, counter,
+		"Handle should retry once when caller returns shouldRetry=true on InputError")
+}
+
+// Symmetric guard: shouldRetry=false on InputError still aborts immediately
+// (this path was already correct; pinning it down so the regression fix
+// above doesn't accidentally turn into "always retry InputError").
+func TestHandle_ShouldRetryFalseAbortsOnInputError(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		return false, merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter)
+}
+
+// retry.Do has no shouldRetry signal from the caller, so the InputError
+// default abort remains the right behavior — keep it pinned.
+func TestDo_InputErrorAbortsByDefault(t *testing.T) {
+	counter := 0
+	err := Do(context.Background(), func() error {
+		counter++
+		return merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter, "Do should abort on InputError without retrying")
+}

--- a/scripts/run_go_unittest.sh
+++ b/scripts/run_go_unittest.sh
@@ -26,6 +26,12 @@ if [[ $(uname -s) == "Darwin" ]]; then
     export MallocNanoZone=0
 fi
 
+# Azurite default credentials for internal/storage TestAzureObjectStorage.
+# Honor any caller-provided value so CI can override with real credentials.
+if [[ -z "${AZURE_STORAGE_CONNECTION_STRING}" ]]; then
+    export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+fi
+
 # ignore MinIO,S3 unittests
 MILVUS_DIR="${ROOT_DIR}/internal/"
 PKG_DIR="${ROOT_DIR}/pkg/"

--- a/scripts/start_cluster_with_replicas.sh
+++ b/scripts/start_cluster_with_replicas.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Licensed to the LF AI & Data foundation under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# start_cluster_with_replicas.sh — start a local cluster with N querynodes
+# and N streamingnodes so that tests with replica_number >= 2 (e.g.
+# test_milvus_client_alter_warmup, test_collection multi-replica) can run.
+#
+# Usage:
+#   bash scripts/start_cluster_with_replicas.sh        # default 2
+#   N_REPLICAS=3 bash scripts/start_cluster_with_replicas.sh
+
+N=${N_REPLICAS:-2}
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  LIBJEMALLOC=$PWD/internal/core/output/lib/libjemalloc.so
+  if test -f "$LIBJEMALLOC"; then
+    export LD_PRELOAD="$LIBJEMALLOC"
+    export MALLOC_CONF=background_thread:true
+  else
+    echo "WARN: Cannot find $LIBJEMALLOC"
+  fi
+  export LD_LIBRARY_PATH=$PWD/internal/core/output/lib/:$LD_LIBRARY_PATH
+fi
+
+echo "Starting mixcoord..."
+nohup ./bin/milvus run mixcoord --run-with-subprocess >/tmp/mixcoord.log 2>&1 &
+
+echo "Starting datanode..."
+nohup ./bin/milvus run datanode --run-with-subprocess >/tmp/datanode.log 2>&1 &
+
+# QueryNode ports: 21123, 21124, 21125, ...
+QN_PORT_BASE=21123
+echo "Starting ${N} querynode(s)..."
+for i in $(seq 1 "$N"); do
+  port=$((QN_PORT_BASE + i - 1))
+  MILVUS_CONF_QUERYNODE_PORT=$port \
+    nohup ./bin/milvus run querynode --run-with-subprocess \
+    >/tmp/querynode_${i}.log 2>&1 &
+  echo "  querynode #$i on port $port (log: /tmp/querynode_${i}.log)"
+done
+
+# StreamingNode ports: 22222, 22223, 22224, ...
+SN_PORT_BASE=22222
+echo "Starting ${N} streamingnode(s)..."
+for i in $(seq 1 "$N"); do
+  port=$((SN_PORT_BASE + i - 1))
+  MILVUS_CONF_STREAMINGNODE_PORT=$port \
+    nohup ./bin/milvus run streamingnode --run-with-subprocess \
+    >/tmp/streamingnode_${i}.log 2>&1 &
+  echo "  streamingnode #$i on port $port (log: /tmp/streamingnode_${i}.log)"
+done
+
+echo "Starting proxy..."
+nohup ./bin/milvus run proxy --run-with-subprocess >/tmp/proxy.log 2>&1 &
+
+echo
+echo "Cluster started with ${N} querynode(s) + ${N} streamingnode(s)."
+echo "Tail logs: /tmp/{mixcoord,datanode,querynode_*,streamingnode_*,proxy}.log"

--- a/tests/python_client/base/client_base.py
+++ b/tests/python_client/base/client_base.py
@@ -31,6 +31,8 @@ class Base:
     field_schema_wrap = None
     database_wrap = None
     tear_down_collection_names = []
+    tear_down_role_names = []
+    tear_down_user_names = []
     resource_group_list = []
     async_milvus_client_wrap = None
     skip_connection = False

--- a/tests/python_client/base/client_v2_base.py
+++ b/tests/python_client/base/client_v2_base.py
@@ -947,6 +947,9 @@ class TestMilvusClientV2Base(Base):
         check_result = ResponseChecker(
             res, func_name, check_task, check_items, check, user_name=user_name, password=password, **kwargs
         ).run()
+        # track for per-instance teardown; avoids cross-worker drops under -n
+        if check is True and check_task is None and user_name not in self.tear_down_user_names:
+            self.tear_down_user_names.append(user_name)
         return res, check_result
 
     @trace()
@@ -1022,6 +1025,9 @@ class TestMilvusClientV2Base(Base):
         check_result = ResponseChecker(
             res, func_name, check_task, check_items, check, role_name=role_name, **kwargs
         ).run()
+        # track for per-instance teardown; avoids cross-worker drops under -n
+        if check is True and check_task is None and role_name not in self.tear_down_role_names:
+            self.tear_down_role_names.append(role_name)
         return res, check_result
 
     @trace()

--- a/tests/python_client/check/func_check.py
+++ b/tests/python_client/check/func_check.py
@@ -504,9 +504,13 @@ class ResponseChecker:
                 num_to_check = min(100, len(distances))  # check 100 items if more than that
                 eps = 1e-6
                 if check_items.get("metric").upper() in ["IP", "COSINE", "BM25"]:
-                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1))
+                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1)), (
+                        f"distances not descending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 else:
-                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1))
+                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1)), (
+                        f"distances not ascending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 if check_items.get("vector_nq") is None or check_items.get("original_vectors") is None:
                     log.debug("skip distance check for knowhere does not return the precise distances")
                 else:

--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -296,8 +296,7 @@ class TestMilvusClientCollectionInvalid(TestMilvusClientV2Base):
         # 1. create collection
         error = {
             ct.err_code: 1100,
-            ct.err_msg: f"float vector index does not support metric type: {metric_type}: "
-            f"invalid parameter[expected=valid index params][actual=invalid index params",
+            ct.err_msg: f"float vector index does not support metric type: {metric_type}",
         }
         self.create_collection(
             client,

--- a/tests/python_client/milvus_client/test_milvus_client_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_index.py
@@ -237,8 +237,7 @@ class TestMilvusClientIndexInvalid(TestMilvusClientV2Base):
         index_params.add_index(field_name="embeddings", index_type=not_supported_index, metric_type="L2")
         # 4. create another index
         error = {ct.err_code: 1100,
-                 ct.err_msg: f"data type Int8Vector can't build with this index {not_supported_index}: "
-                             f"invalid parameter[expected=valid index params][actual=invalid index params]"}
+                 ct.err_msg: f"data type Int8Vector can't build with this index {not_supported_index}"}
         self.create_index(client, collection_name, index_params,
                           check_task=CheckTasks.err_res, check_items=error)
         self.drop_collection(client, collection_name)
@@ -822,9 +821,7 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
         index_params.add_index(field_name=default_vector_field_name, index_type="AUTOINDEX", metric_type="COSINE")
         index_params.add_index(field_name="my_json", index_type="INVERTED")
         # 3. create index
-        error = {ct.err_code: 1100, ct.err_msg: "json index must specify cast type: missing parameter"
-                                                "[missing_param=json_cast_type]: invalid parameter"
-                                                "[expected=valid index params][actual=invalid index params]"}
+        error = {ct.err_code: 1101, ct.err_msg: "json index must specify cast type: missing parameter"}
         self.create_index(client, collection_name, index_params,
                           check_task=CheckTasks.err_res, check_items=error)
         # 4. prepare index params with no json_cast_type
@@ -832,9 +829,7 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
         index_params.add_index(field_name=default_vector_field_name, index_type="AUTOINDEX", metric_type="COSINE")
         index_params.add_index(field_name="my_json", index_type="INVERTED", params={"json_path": "my_json['a']['b']"})
         # 5. create index
-        error = {ct.err_code: 1100, ct.err_msg: "json index must specify cast type: missing parameter"
-                                                "[missing_param=json_cast_type]: invalid parameter"
-                                                "[expected=valid index params][actual=invalid index params]"}
+        error = {ct.err_code: 1101, ct.err_msg: "json index must specify cast type: missing parameter"}
         self.create_index(client, collection_name, index_params,
                           check_task=CheckTasks.err_res, check_items=error)
         # 6. prepare index params with no json_path
@@ -909,8 +904,7 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
             not_supported_varchar_scalar_index = "bitmap index"
             got_json_suffix = ""
         error = {ct.err_code: 1100, ct.err_msg: f"{not_supported_varchar_scalar_index} are only supported on "
-                                                f"{supported_field_type} field{got_json_suffix}: invalid parameter[expected=valid "
-                                                f"index params][actual=invalid index params]"}
+                                                f"{supported_field_type} field{got_json_suffix}"}
         self.create_index(client, collection_name, index_params,
                           check_task=CheckTasks.err_res, check_items=error)
 
@@ -945,7 +939,7 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
                                params={"json_cast_type": invalid_json_cast_type,
                                        "json_path": f"{json_field_name}['a']['b']"})
         # 3. create index
-        error = {ct.err_code: 1100, ct.err_msg: f"index params][actual=invalid index params]"}
+        error = {ct.err_code: 1100, ct.err_msg: "is not supported"}
         self.create_index(client, collection_name, index_params,
                           check_task=CheckTasks.err_res, check_items=error)
 
@@ -980,7 +974,7 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
                                    params={"json_cast_type": cast_type,
                                            "json_path": f"{json_field_name}['a']['b']"})
             # 3. create index
-            error = {ct.err_code: 1100, ct.err_msg: f"index params][actual=invalid index params]"}
+            error = {ct.err_code: 1100, ct.err_msg: "is not supported"}
             self.create_index(client, collection_name, index_params,
                               check_task=CheckTasks.err_res, check_items=error)
 

--- a/tests/python_client/milvus_client/test_milvus_client_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_query.py
@@ -681,7 +681,10 @@ class TestMilvusClientQueryInvalidShared(TestMilvusClientV2Base):
         expected: raise invalid-limit error
         """
         client = self._client()
-        error = {ct.err_code: 1, ct.err_msg: f"limit [{limit}] is invalid"}
+        # milvus strips leading/trailing whitespace before echoing the value
+        # in the error message, so " " becomes "" in `limit [<displayed>] is invalid`
+        displayed = limit.strip() if isinstance(limit, str) else limit
+        error = {ct.err_code: 1, ct.err_msg: f"limit [{displayed}] is invalid"}
         self.query(
             client,
             INVALID_SHARED_COLLECTION,
@@ -729,7 +732,10 @@ class TestMilvusClientQueryInvalidShared(TestMilvusClientV2Base):
         expected: raise invalid-offset error
         """
         client = self._client()
-        error = {ct.err_code: 1, ct.err_msg: f"offset [{offset}] is invalid"}
+        # milvus strips leading/trailing whitespace before echoing the value
+        # in the error message, so " " becomes "" in `offset [<displayed>] is invalid`
+        displayed = offset.strip() if isinstance(offset, str) else offset
+        error = {ct.err_code: 1, ct.err_msg: f"offset [{displayed}] is invalid"}
         self.query(
             client,
             INVALID_SHARED_COLLECTION,

--- a/tests/python_client/milvus_client/test_milvus_client_rbac.py
+++ b/tests/python_client/milvus_client/test_milvus_client_rbac.py
@@ -12,6 +12,14 @@ from common.common_type import CaseLabel, CheckTasks
 from utils.util_pymilvus import *
 
 
+# RBAC test classes share teardown logic that lists and drops every user,
+# role, privilege group, and database on the server. Under pytest-xdist `-n`
+# this cross-deletes objects owned by sibling workers. Pin the whole module
+# to a single xdist worker (loadgroup) so tests run serially without
+# starving other test files of parallelism.
+pytestmark = pytest.mark.xdist_group(name="rbac_serial")
+
+
 prefix = "client_rbac"
 
 
@@ -1473,12 +1481,13 @@ class TestMilvusClientRbacAdvance(TestMilvusClientV2Base):
         # wait for privilege to take effect
         time.sleep(10)
         
-        # create new client with the user credentials
+        # create new client with the user credentials, bind db_name at connection
+        # time to avoid a describe_database call (which requires DescribeDatabase
+        # privilege not granted to this test role)
         uri = f"http://{host}:{port}"
-        user_client, _ = self.init_milvus_client(uri=uri, user=user_name, password=password)
-        
+        user_client, _ = self.init_milvus_client(uri=uri, user=user_name, password=password, db_name=db_name)
+
         # test load privilege
-        self.using_database(user_client, db_name)
         self.load_collection(user_client, collection_name)
         
         # cleanup
@@ -1525,12 +1534,13 @@ class TestMilvusClientRbacAdvance(TestMilvusClientV2Base):
         # wait for privilege to take effect
         time.sleep(10)
         
-        # create new client with the user credentials
+        # create new client with the user credentials, bind db_name at connection
+        # time to avoid a describe_database call (which requires DescribeDatabase
+        # privilege not granted to this test role)
         uri = f"http://{host}:{port}"
-        user_client, _ = self.init_milvus_client(uri=uri, user=user_name, password=password)
-        
+        user_client, _ = self.init_milvus_client(uri=uri, user=user_name, password=password, db_name=db_name)
+
         # test release privilege
-        self.using_database(user_client, db_name)
         self.release_collection(user_client, collection_name)
         
         # cleanup
@@ -1574,12 +1584,13 @@ class TestMilvusClientRbacAdvance(TestMilvusClientV2Base):
         # wait for privilege to take effect
         time.sleep(10)
         
-        # create new client with the user credentials
+        # create new client with the user credentials, bind db_name at connection
+        # time to avoid a describe_database call (which requires DescribeDatabase
+        # privilege not granted to this test role)
         uri = f"http://{host}:{port}"
-        user_client, _ = self.init_milvus_client(uri=uri, user=user_name, password=password)
-        
+        user_client, _ = self.init_milvus_client(uri=uri, user=user_name, password=password, db_name=db_name)
+
         # test insert privilege
-        self.using_database(user_client, db_name)
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
@@ -1626,15 +1637,16 @@ class TestMilvusClientRbacAdvance(TestMilvusClientV2Base):
         # wait for privilege to take effect
         time.sleep(10)
         
-        # create new client with the user credentials
+        # create new client with the user credentials, bind db_name at connection
+        # time to avoid a describe_database call (which requires DescribeDatabase
+        # privilege not granted to this test role)
         uri = f"http://{host}:{port}"
-        user_client, _ = self.init_milvus_client(uri=uri, user=user_name, password=password)
-        
+        user_client, _ = self.init_milvus_client(uri=uri, user=user_name, password=password, db_name=db_name)
+
         # test delete privilege
-        self.using_database(user_client, db_name)
         delete_expr = f'{default_primary_key_field_name} == 0'
         self.delete(user_client, collection_name, filter=delete_expr)
-        
+
         # cleanup
         self.drop_collection(client, collection_name)
         if with_db:

--- a/tests/python_client/milvus_client/test_milvus_client_snapshot.py
+++ b/tests/python_client/milvus_client/test_milvus_client_snapshot.py
@@ -4502,9 +4502,16 @@ class TestMilvusClientSnapshotAlias(TestMilvusClientSnapshotBase):
 
 
 @pytest.mark.tags(CaseLabel.RBAC)
+@pytest.mark.xdist_group(name="snapshot_rbac_serial")
 class TestMilvusClientSnapshotRbac(TestMilvusClientSnapshotBase):
     """
     Test RBAC v2 privilege enforcement for snapshot operations.
+
+    Pinned to a single xdist worker via ``xdist_group`` because the
+    teardown does a global ``list_users()`` / ``list_roles()`` and drops
+    everything non-default. Under ``-n>1`` that cross-deletes objects
+    owned by other workers and causes cascading "role not found" /
+    "role has privileges" failures (same root cause as #49699).
     """
 
     user_pre = "snap_user"

--- a/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
+++ b/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
@@ -1034,7 +1034,7 @@ class TestMilvusClientTimestamptzInvalid(TestMilvusClientV2Base):
         index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
         index_params.add_index(default_timestamp_field_name, index_type="INVERTED")
-        error = {ct.err_code: 1100, ct.err_msg: "INVERTED are not supported on Timestamptz field: invalid parameter[expected=valid index params][actual=invalid index params]"}
+        error = {ct.err_code: 1100, ct.err_msg: "INVERTED are not supported on Timestamptz field"}
         self.create_collection(client, collection_name, default_dim, schema=schema, 
                                consistency_level="Strong", index_params=index_params,
                                check_task=CheckTasks.err_res,

--- a/tests/python_client/testcases/async_milvus_client/test_index_async.py
+++ b/tests/python_client/testcases/async_milvus_client/test_index_async.py
@@ -170,8 +170,7 @@ class TestAsyncMilvusClientIndexInvalid(TestMilvusClientV2Base):
         index_params = async_client.prepare_index_params()[0]
         index_params.add_index(field_name="vector", metric_type=metric)
         # 3. create index
-        error = {ct.err_code: 1100, ct.err_msg: f"float vector index does not support metric type: {metric}: "
-                                                f"invalid parameter[expected=valid index params][actual=invalid index params"}
+        error = {ct.err_code: 1100, ct.err_msg: f"float vector index does not support metric type: {metric}"}
         # It's good to show what the valid index params are
         await async_client.create_index(collection_name, index_params,
                                         check_task=CheckTasks.err_res, 

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1291,7 +1291,7 @@ class TestIndexInvalid(TestcaseBase):
             ct.default_float_vec_field_name,
             index_params=scalar_index_params,
             check_task=CheckTasks.err_res,
-            check_items={ct.err_code: 1100, ct.err_msg: "invalid index params"},
+            check_items={ct.err_code: 1100, ct.err_msg: "metric type not set for vector index"},
         )
 
     @pytest.mark.tags(CaseLabel.L1)

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1524,7 +1524,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("ratio", [-0.5, 1, 3])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_ratio(self, ratio, index):
         """
         target: index creation for unsupported ratio parameter
@@ -1551,7 +1551,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("inverted_index_algo", ["INVALID_ALGO"])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_inverted_index_algo(self, inverted_index_algo, index):
         """
         target: index creation for unsupported sparse inverted index algo parameter


### PR DESCRIPTION
Standardizes error handling in `internal/proxy/` onto the `merr` framework introduced by the err-std base PR. Part of the system-wide error-standardization series.

### Stacking

Depends on #48802 (`err-std-01-base`, the foundational `merr` framework). This branch is stacked on top of `err-std-01-base`, so until #48802 merges the diff here also contains the base-framework commits. **Review only the proxy-specific commits below**; the base commits land via #48802.

### Proxy-specific commits

- `8b2ac17` — Standardize error handling: Proxy module (auto-generated `fmt.Errorf`/`errors.New` → `merr.WrapErr*`).
- `a7e09df` — unwrap `fmt.Sprintf` in `merr.WrapErr*Msg` calls so the format/args are passed natively instead of pre-formatted.
- `dc49bdd` — standardize the remaining hand-written proxy error sites to `merr` (highlighter, util, password handling in impl).
- `b89f20e` — fix a double `ParameterInvalid` wrap in the `createIndex` path and clean the `WrapErrParameterInvalid` misuse:
  - The auto-gen converted `checkTrain`'s leaf errors to `merr.WrapErrParameterInvalidMsg`, but `parseIndexParams` still re-wrapped the result with `WrapErrParameterInvalid("valid index params","invalid index params", err.Error())`, so the client saw a doubled `: invalid parameter` and a `WrapErrParameterMissing`-based checker (json cast type) had its code masked from **1101 → 1100**.
  - The ~10 metric-type sites used the typed `WrapErrParameterInvalid("valid index params","invalid index params", <msg>)` purely as a generic wrapper, emitting a tautological, information-free `[expected=valid index params][actual=invalid index params]` suffix on every index error. Replaced with `WrapErrParameterInvalidMsg` so the message carries the real reason + a single `: invalid parameter`.
  - `parseIndexParams` now normalizes at the proxy ↔ not-yet-merr `indexparamcheck` boundary: an already-`merr` error (incl. `ParameterMissing` 1101) passes through unchanged; only legacy plain errors get wrapped once into `ParameterInvalid`.
- `79c5deb`, `ac8ea51` — accompanying test fixes (RBAC/snapshot xdist pollution; bound `TestAzureObjectStorage/test_useIAM` with a context timeout).

### e2e contract updates

`CheckTasks.err_res` only substring-matches `err_msg` (the `err_code` there is documentation). Index/collection/timestamptz/async-index tests drop the removed `[expected=valid index params][actual=invalid index params]` suffix and assert the meaningful phrase only; the json "must specify cast type" case moves `err_code` 1100 → 1101 (ParameterMissing, now correctly surfaced) with a trimmed message.

### Validation

- `make verifiers` rc=0; `internal/proxy` go unit tests clean in a clean env.
- Full L0/L1 e2e on a binary built from this branch: the affected files went from **141 contract-drift failures → 0** (576 passed); remaining failures are the known TEI-DNS env-only files, unrelated to this change.

issue: #47420
