### PR TITLE
fix: count JSON and dynamic search aggregation metrics

### DIFF
--- a/internal/proxy/search_agg/computer_test.go
+++ b/internal/proxy/search_agg/computer_test.go
@@ -1211,11 +1211,56 @@ func TestCompareValuesErrorPaths(t *testing.T) {
 	// the Compute() surface requires data that violates FieldData type
 	// invariants, which is not something production callers can synthesize.
 
+	t.Run("nil values use legacy nil-first ordering", func(t *testing.T) {
+		t.Parallel()
+		cmp, err := compareValues(nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, cmp)
+
+		cmp, err = compareValues(nil, int64(1))
+		require.NoError(t, err)
+		require.Equal(t, -1, cmp)
+
+		cmp, err = compareValues(int64(1), nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, cmp)
+	})
+
 	t.Run("large int64 values keep integer precision", func(t *testing.T) {
 		t.Parallel()
 		cmp, err := compareValues(int64(1<<53), int64(1<<53+1))
 		require.NoError(t, err)
 		require.Equal(t, -1, cmp)
+	})
+
+	t.Run("float values compare without casting to integers", func(t *testing.T) {
+		t.Parallel()
+		cmp, err := compareValues(float64(1.25), float64(2.5))
+		require.NoError(t, err)
+		require.Equal(t, -1, cmp)
+
+		cmp, err = compareValues(float64(2.5), float64(1.25))
+		require.NoError(t, err)
+		require.Equal(t, 1, cmp)
+
+		cmp, err = compareValues(float64(2.5), float64(2.5))
+		require.NoError(t, err)
+		require.Equal(t, 0, cmp)
+	})
+
+	t.Run("bool values compare false before true", func(t *testing.T) {
+		t.Parallel()
+		cmp, err := compareValues(false, true)
+		require.NoError(t, err)
+		require.Equal(t, -1, cmp)
+
+		cmp, err = compareValues(true, false)
+		require.NoError(t, err)
+		require.Equal(t, 1, cmp)
+
+		cmp, err = compareValues(true, true)
+		require.NoError(t, err)
+		require.Equal(t, 0, cmp)
 	})
 
 	t.Run("large uint64 values keep integer precision", func(t *testing.T) {

--- a/internal/proxy/search_agg/computer_test.go
+++ b/internal/proxy/search_agg/computer_test.go
@@ -811,6 +811,47 @@ func TestSearchAggregationComputerCountAll(t *testing.T) {
 	require.Equal(t, int64(1), n1)
 }
 
+func TestSearchAggregationComputerCountJSONField(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestAggregationContext(t, 1,
+		[]LevelContext{{
+			OwnFieldIDs: []int64{101},
+			Size:        100,
+			Metrics: map[string]MetricSpec{
+				"json_count": {Op: "count", FieldID: 108, FieldType: schemapb.DataType_JSON},
+			},
+			Order: []OrderCriterion{{Key: "_key", Dir: "asc"}},
+		}},
+		nil,
+		[]int64{108},
+	)
+
+	data := &schemapb.SearchResultData{
+		NumQueries: 1,
+		Topks:      []int64{4},
+		Ids:        &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3, 4}}}},
+		Scores:     []float32{0.9, 0.8, 0.7, 0.6},
+		FieldsData: []*schemapb.FieldData{
+			testJSONFieldData(108, [][]byte{
+				[]byte(`{"tag":"a"}`),
+				[]byte(`{"tag":"b"}`),
+				[]byte(`{"tag":"c"}`),
+				[]byte(`{"tag":"d"}`),
+			}),
+		},
+		GroupByFieldValues: []*schemapb.FieldData{
+			testStringFieldData(101, []string{"A", "A", "A", "B"}),
+		},
+	}
+
+	result, err := NewSearchAggregationComputer(data, ctx).Compute(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result[0], 2)
+	require.Equal(t, int64(3), result[0][0].Metrics["json_count"])
+	require.Equal(t, int64(1), result[0][1].Metrics["json_count"])
+}
+
 func TestSearchAggregationComputerScoreMetric(t *testing.T) {
 	t.Parallel()
 	// A metric whose source is the _score column (ScoreFieldID=-1). Exercises
@@ -1423,6 +1464,16 @@ func testNullableLongFieldData(fieldID int64, values []int64, validData []bool) 
 	fd := testLongFieldData(fieldID, values)
 	fd.ValidData = validData
 	return fd
+}
+
+func testJSONFieldData(fieldID int64, values [][]byte) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		FieldId: fieldID,
+		Type:    schemapb.DataType_JSON,
+		Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+			Data: &schemapb.ScalarField_JsonData{JsonData: &schemapb.JSONArray{Data: values}},
+		}},
+	}
 }
 
 func testInt32FieldData(fieldID int64, values []int32) *schemapb.FieldData {

--- a/internal/proxy/search_agg/context_builder.go
+++ b/internal/proxy/search_agg/context_builder.go
@@ -31,7 +31,12 @@ func BuildSearchAggregationContext(
 	if err := validateSearchAggregationResultEntries(nq, topK, groupSize, maxEntries); err != nil {
 		return nil, err
 	}
-	return NewContext(nq, resolved.levels, nil, resolved.extraOutputFieldIDs)
+	ctx, err := NewContext(nq, resolved.levels, nil, resolved.extraOutputFieldIDs)
+	if err != nil {
+		return nil, err
+	}
+	ctx.dynamicOutputFields = resolved.dynamicOutputFields
+	return ctx, nil
 }
 
 // NewContext assembles a SearchAggregationContext from already-resolved levels.
@@ -222,6 +227,8 @@ type resolvedAggregationSpec struct {
 	// metric source fields and top_hits sort fields. These must be appended to
 	// SearchRequest.OutputFieldsId so segcore writes them into fields_data.
 	extraOutputFieldIDs []int64
+	// dynamicOutputFields are dynamic-field keys proxy needs in Plan.DynamicFields.
+	dynamicOutputFields []string
 }
 
 // maxAggregationLevels caps SearchAggregation nesting depth to keep proxy
@@ -249,6 +256,7 @@ func resolveAggregationSpec(groupBy *commonpb.SearchAggregationSpec, schema *sch
 	dynamicField := findDynamicField(schema)
 	groupBySeen := make(map[int64]struct{})
 	extraSeen := make(map[int64]struct{})
+	dynamicSeen := make(map[string]struct{})
 
 	resolved := &resolvedAggregationSpec{}
 	var walk func(spec *commonpb.SearchAggregationSpec) error
@@ -313,7 +321,7 @@ func resolveAggregationSpec(groupBy *commonpb.SearchAggregationSpec, schema *sch
 				if strings.TrimSpace(alias) == "" {
 					return fmt.Errorf("metric alias cannot be empty")
 				}
-				metricSpec, metricSourceFieldID, err := buildMetricSpec(metric, schema, dynamicField)
+				metricSpec, metricSourceFieldID, dynamicOutputField, err := buildMetricSpec(metric, schema, dynamicField)
 				if err != nil {
 					return fmt.Errorf("invalid metric %q: %w", alias, err)
 				}
@@ -324,16 +332,20 @@ func resolveAggregationSpec(groupBy *commonpb.SearchAggregationSpec, schema *sch
 				level.Metrics[alias] = metricSpec
 				level.metricPlans = append(level.metricPlans, plan)
 				appendUniqueFieldID(extraSeen, &resolved.extraOutputFieldIDs, metricSourceFieldID)
+				appendUniqueString(dynamicSeen, &resolved.dynamicOutputFields, dynamicOutputField)
 			}
 		}
 
-		topHits, topHitsFieldIDs, err := buildTopHitsConfig(spec.GetTopHits(), schema, dynamicField)
+		topHits, topHitsFieldIDs, topHitsDynamicFields, err := buildTopHitsConfig(spec.GetTopHits(), schema, dynamicField)
 		if err != nil {
 			return err
 		}
 		level.TopHits = topHits
 		for _, fieldID := range topHitsFieldIDs {
 			appendUniqueFieldID(extraSeen, &resolved.extraOutputFieldIDs, fieldID)
+		}
+		for _, fieldName := range topHitsDynamicFields {
+			appendUniqueString(dynamicSeen, &resolved.dynamicOutputFields, fieldName)
 		}
 
 		order, err := buildOrderCriteria(spec.GetOrder(), level.Metrics)
@@ -349,58 +361,66 @@ func resolveAggregationSpec(groupBy *commonpb.SearchAggregationSpec, schema *sch
 	if err := walk(groupBy); err != nil {
 		return nil, err
 	}
+	sort.Strings(resolved.dynamicOutputFields)
 
 	return resolved, nil
 }
 
-func buildMetricSpec(metric *commonpb.MetricAggSpec, schema *schemapb.CollectionSchema, dynamicField *schemapb.FieldSchema) (MetricSpec, int64, error) {
+func buildMetricSpec(metric *commonpb.MetricAggSpec, schema *schemapb.CollectionSchema, dynamicField *schemapb.FieldSchema) (MetricSpec, int64, string, error) {
 	if metric == nil {
-		return MetricSpec{}, 0, fmt.Errorf("metric spec is nil")
+		return MetricSpec{}, 0, "", fmt.Errorf("metric spec is nil")
 	}
 
 	op := strings.ToLower(strings.TrimSpace(metric.GetOp()))
 	switch op {
 	case "avg", "sum", "count", "min", "max":
 	default:
-		return MetricSpec{}, 0, fmt.Errorf("unsupported metric op %q", metric.GetOp())
+		return MetricSpec{}, 0, "", fmt.Errorf("unsupported metric op %q", metric.GetOp())
 	}
 
 	fieldName := strings.TrimSpace(metric.GetFieldName())
 	if fieldName == "" {
-		return MetricSpec{}, 0, fmt.Errorf("metric field_name is empty")
+		return MetricSpec{}, 0, "", fmt.Errorf("metric field_name is empty")
 	}
 
 	switch fieldName {
 	case "_score":
 		// _score is a float32 produced by the engine; declare as Float so
 		// internal/agg's type check accepts it for sum/avg/min/max.
-		return MetricSpec{Op: op, FieldID: ScoreFieldID, FieldType: schemapb.DataType_Float}, 0, nil
+		return MetricSpec{Op: op, FieldID: ScoreFieldID, FieldType: schemapb.DataType_Float}, 0, "", nil
 	case "*":
 		if op != "count" {
-			return MetricSpec{}, 0, fmt.Errorf("field_name '*' only supports count op")
+			return MetricSpec{}, 0, "", fmt.Errorf("field_name '*' only supports count op")
 		}
 		// count(*) has no source field; DataType_None is what internal/agg
 		// expects for the synthetic always-1 input.
-		return MetricSpec{Op: op, FieldID: CountAllFieldID, FieldType: schemapb.DataType_None}, 0, nil
+		return MetricSpec{Op: op, FieldID: CountAllFieldID, FieldType: schemapb.DataType_None}, 0, "", nil
 	default:
 		fieldID, err := resolveFieldID(fieldName, schema, dynamicField)
 		if err != nil {
-			return MetricSpec{}, 0, err
+			return MetricSpec{}, 0, "", err
+		}
+		if err := rejectUnsupportedJSONPathMetric(fieldName, schema, fieldID, dynamicField); err != nil {
+			return MetricSpec{}, 0, "", err
 		}
 		fieldType := schemapb.DataType_None
 		if field := typeutil.GetFieldByName(schema, fieldName); field != nil {
 			fieldType = field.GetDataType()
 		}
-		return MetricSpec{Op: op, FieldID: fieldID, FieldType: fieldType}, fieldID, nil
+		dynamicOutputField, err := resolveDynamicOutputFieldName(fieldName, schema, dynamicField, fieldID)
+		if err != nil {
+			return MetricSpec{}, 0, "", err
+		}
+		return MetricSpec{Op: op, FieldID: fieldID, FieldType: fieldType}, fieldID, dynamicOutputField, nil
 	}
 }
 
-func buildTopHitsConfig(topHits *commonpb.TopHitsSpec, schema *schemapb.CollectionSchema, dynamicField *schemapb.FieldSchema) (*TopHitsConfig, []int64, error) {
+func buildTopHitsConfig(topHits *commonpb.TopHitsSpec, schema *schemapb.CollectionSchema, dynamicField *schemapb.FieldSchema) (*TopHitsConfig, []int64, []string, error) {
 	if topHits == nil {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 	if topHits.GetSize() < 0 {
-		return nil, nil, fmt.Errorf("top_hits size must be non-negative")
+		return nil, nil, nil, fmt.Errorf("top_hits size must be non-negative")
 	}
 
 	cfg := &TopHitsConfig{
@@ -409,19 +429,21 @@ func buildTopHitsConfig(topHits *commonpb.TopHitsSpec, schema *schemapb.Collecti
 	}
 	sortFieldIDs := make([]int64, 0, len(topHits.GetSort()))
 	seen := make(map[int64]struct{})
+	dynamicSeen := make(map[string]struct{})
+	dynamicFieldNames := make([]string, 0)
 
 	for _, sortSpec := range topHits.GetSort() {
 		if sortSpec == nil {
-			return nil, nil, fmt.Errorf("top_hits.sort contains nil item")
+			return nil, nil, nil, fmt.Errorf("top_hits.sort contains nil item")
 		}
 		fieldName := strings.TrimSpace(sortSpec.GetFieldName())
 		if fieldName == "" {
-			return nil, nil, fmt.Errorf("top_hits.sort field_name is empty")
+			return nil, nil, nil, fmt.Errorf("top_hits.sort field_name is empty")
 		}
 
 		direction, err := normalizeDirection(sortSpec.GetDirection(), "desc")
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid top_hits.sort direction for %q: %w", fieldName, err)
+			return nil, nil, nil, fmt.Errorf("invalid top_hits.sort direction for %q: %w", fieldName, err)
 		}
 
 		if fieldName == "_score" {
@@ -430,18 +452,23 @@ func buildTopHitsConfig(topHits *commonpb.TopHitsSpec, schema *schemapb.Collecti
 		}
 
 		if isJSONPathFieldExpr(fieldName) {
-			return nil, nil, fmt.Errorf("top_hits.sort JSON path is not yet supported: %q", fieldName)
+			return nil, nil, nil, fmt.Errorf("top_hits.sort JSON path is not yet supported: %q", fieldName)
 		}
 
 		fieldID, err := resolveFieldID(fieldName, schema, dynamicField)
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid top_hits.sort field %q: %w", fieldName, err)
+			return nil, nil, nil, fmt.Errorf("invalid top_hits.sort field %q: %w", fieldName, err)
 		}
 		cfg.Sort = append(cfg.Sort, SortCriterion{FieldID: fieldID, Dir: direction, NullFirst: sortSpec.GetNullFirst()})
 		appendUniqueFieldID(seen, &sortFieldIDs, fieldID)
+		dynamicOutputField, err := resolveDynamicOutputFieldName(fieldName, schema, dynamicField, fieldID)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("invalid top_hits.sort field %q: %w", fieldName, err)
+		}
+		appendUniqueString(dynamicSeen, &dynamicFieldNames, dynamicOutputField)
 	}
 
-	return cfg, sortFieldIDs, nil
+	return cfg, sortFieldIDs, dynamicFieldNames, nil
 }
 
 func buildOrderCriteria(orderSpecs []*commonpb.OrderSpec, metrics map[string]MetricSpec) ([]OrderCriterion, error) {
@@ -493,6 +520,43 @@ func normalizeDirection(direction string, defaultDir string) (string, error) {
 func isJSONPathFieldExpr(fieldExpr string) bool {
 	// TODO: Preserve parsed nested path in SortCriterion and extract it in the top_hits comparator.
 	return strings.Contains(fieldExpr, "[") && strings.Contains(fieldExpr, "]")
+}
+
+func rejectUnsupportedJSONPathMetric(fieldExpr string, schema *schemapb.CollectionSchema, fieldID int64, dynamicField *schemapb.FieldSchema) error {
+	if !isJSONPathFieldExpr(fieldExpr) {
+		return nil
+	}
+	field := typeutil.GetFieldByID(schema, fieldID)
+	if field == nil || field.GetDataType() != schemapb.DataType_JSON || (dynamicField != nil && fieldID == dynamicField.GetFieldID()) {
+		return nil
+	}
+	return fmt.Errorf("metric JSON path is not yet supported: %q", fieldExpr)
+}
+
+func resolveDynamicOutputFieldName(fieldExpr string, schema *schemapb.CollectionSchema, dynamicField *schemapb.FieldSchema, fieldID int64) (string, error) {
+	if dynamicField == nil || fieldID != dynamicField.GetFieldID() {
+		return "", nil
+	}
+	if field := typeutil.GetFieldByName(schema, fieldExpr); field != nil {
+		return "", nil
+	}
+	nestedPath, err := typeutil2.ParseAndVerifyNestedPath(fieldExpr, schema, dynamicField.GetFieldID())
+	if err != nil {
+		return "", err
+	}
+	if nestedPath == "" {
+		return "", nil
+	}
+	parts := strings.Split(strings.TrimPrefix(nestedPath, "/"), "/")
+	if len(parts) != 1 || parts[0] == "" {
+		return "", fmt.Errorf("dynamic metric field %q must reference exactly one dynamic key", fieldExpr)
+	}
+	return unescapeJSONPointerToken(parts[0]), nil
+}
+
+func unescapeJSONPointerToken(token string) string {
+	token = strings.ReplaceAll(token, "~1", "/")
+	return strings.ReplaceAll(token, "~0", "~")
 }
 
 func resolveFieldID(fieldExpr string, schema *schemapb.CollectionSchema, dynamicField *schemapb.FieldSchema) (int64, error) {
@@ -552,4 +616,15 @@ func appendUniqueFieldID(seen map[int64]struct{}, fields *[]int64, fieldID int64
 	}
 	seen[fieldID] = struct{}{}
 	*fields = append(*fields, fieldID)
+}
+
+func appendUniqueString(seen map[string]struct{}, fields *[]string, field string) {
+	if field == "" {
+		return
+	}
+	if _, ok := seen[field]; ok {
+		return
+	}
+	seen[field] = struct{}{}
+	*fields = append(*fields, field)
 }

--- a/internal/proxy/search_agg/context_builder_test.go
+++ b/internal/proxy/search_agg/context_builder_test.go
@@ -47,6 +47,7 @@ func TestBuildSearchAggregationContext(t *testing.T) {
 	require.False(t, ctx.IsGroupByField(103))
 	require.False(t, ctx.IsGroupByField(104))
 
+	require.Equal(t, []int64{101, 102}, ctx.AllGroupByFieldIDs())
 	require.Equal(t, []int64{103, 104}, ctx.ExtraOutputFieldIDs())
 	require.Equal(t, ScoreFieldID, ctx.Levels[0].TopHits.Sort[0].FieldID)
 	require.Equal(t, int64(2), ctx.DerivedGroupSize)
@@ -397,6 +398,20 @@ func TestBuildSearchAggregationContextAllowsCountJSONMetric(t *testing.T) {
 	require.Empty(t, ctx.DynamicOutputFields())
 }
 
+func TestBuildSearchAggregationContextAllowsScoreMetric(t *testing.T) {
+	ctx, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+		Fields: []string{"brand"},
+		Metrics: map[string]*commonpb.MetricAggSpec{
+			"avg_score": {Op: "avg", FieldName: "_score"},
+		},
+	}, testCollectionSchema(), 1)
+
+	require.NoError(t, err)
+	require.Empty(t, ctx.ExtraOutputFieldIDs())
+	require.Equal(t, ScoreFieldID, ctx.Levels[0].Metrics["avg_score"].FieldID)
+	require.Equal(t, schemapb.DataType_Float, ctx.Levels[0].Metrics["avg_score"].FieldType)
+}
+
 func TestBuildSearchAggregationContextRejectsTopHitsSortJSONPath(t *testing.T) {
 	schema := &schemapb.CollectionSchema{
 		Name: "agg_test",
@@ -710,6 +725,15 @@ func TestBuildSearchAggregationContextValidationMatrix(t *testing.T) {
 			},
 			schema:  schema,
 			wantErr: "metric field_name is empty",
+		},
+		{
+			name: "unknown metric field",
+			spec: &commonpb.SearchAggregationSpec{
+				Fields:  []string{"brand"},
+				Metrics: map[string]*commonpb.MetricAggSpec{"bad": {Op: "sum", FieldName: "missing"}},
+			},
+			schema:  schema,
+			wantErr: "field \"missing\" not found in schema",
 		},
 		{
 			name: "non count star metric",

--- a/internal/proxy/search_agg/context_builder_test.go
+++ b/internal/proxy/search_agg/context_builder_test.go
@@ -375,6 +375,28 @@ func TestBuildSearchAggregationContextRejectsJSONField(t *testing.T) {
 	})
 }
 
+func TestBuildSearchAggregationContextAllowsCountJSONMetric(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "agg_test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "brand", DataType: schemapb.DataType_VarChar},
+			{FieldID: 108, Name: "meta", DataType: schemapb.DataType_JSON},
+		},
+	}
+
+	ctx, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+		Fields: []string{"brand"},
+		Metrics: map[string]*commonpb.MetricAggSpec{
+			"field_count": {Op: "count", FieldName: "meta"},
+		},
+	}, schema, 1)
+
+	require.NoError(t, err)
+	require.Equal(t, []int64{108}, ctx.ExtraOutputFieldIDs())
+	require.Empty(t, ctx.DynamicOutputFields())
+}
+
 func TestBuildSearchAggregationContextRejectsTopHitsSortJSONPath(t *testing.T) {
 	schema := &schemapb.CollectionSchema{
 		Name: "agg_test",
@@ -451,6 +473,164 @@ func TestBuildSearchAggregationContextRejectsDynamicField(t *testing.T) {
 	}, schema, 1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not yet supported with search_aggregation")
+}
+
+func TestBuildSearchAggregationContextTracksDynamicMetricFields(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name:               "agg_test",
+		EnableDynamicField: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "brand", DataType: schemapb.DataType_VarChar},
+			{FieldID: 109, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+		},
+	}
+
+	for _, fieldName := range []string{"dynamic_brand", "$meta[\"dynamic_brand\"]"} {
+		t.Run(fieldName, func(t *testing.T) {
+			ctx, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+				Fields: []string{"brand"},
+				Metrics: map[string]*commonpb.MetricAggSpec{
+					"field_count": {Op: "count", FieldName: fieldName},
+				},
+			}, schema, 1)
+			require.NoError(t, err)
+			require.Equal(t, []int64{109}, ctx.ExtraOutputFieldIDs())
+			require.Equal(t, []string{"dynamic_brand"}, ctx.DynamicOutputFields())
+		})
+	}
+}
+
+func TestBuildSearchAggregationContextTracksDynamicTopHitsSortFields(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name:               "agg_test",
+		EnableDynamicField: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "brand", DataType: schemapb.DataType_VarChar},
+			{FieldID: 109, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+		},
+	}
+
+	ctx, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+		Fields: []string{"brand"},
+		Metrics: map[string]*commonpb.MetricAggSpec{
+			"field_count": {Op: "count", FieldName: "$meta[\"zeta\"]"},
+		},
+		TopHits: &commonpb.TopHitsSpec{
+			Size: 2,
+			Sort: []*commonpb.SortSpec{
+				{FieldName: "alpha", Direction: "asc"},
+				{FieldName: "beta", Direction: "desc"},
+				{FieldName: "alpha", Direction: "desc"},
+			},
+		},
+	}, schema, 1)
+
+	require.NoError(t, err)
+	require.Equal(t, []int64{109}, ctx.ExtraOutputFieldIDs())
+	require.Equal(t, []string{"alpha", "beta", "zeta"}, ctx.DynamicOutputFields())
+}
+
+func TestBuildSearchAggregationContextRejectsNestedDynamicMetricPath(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name:               "agg_test",
+		EnableDynamicField: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "brand", DataType: schemapb.DataType_VarChar},
+			{FieldID: 109, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+		},
+	}
+
+	_, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+		Fields: []string{"brand"},
+		Metrics: map[string]*commonpb.MetricAggSpec{
+			"field_count": {Op: "count", FieldName: "$meta[\"outer\"][\"inner\"]"},
+		},
+	}, schema, 1)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must reference exactly one dynamic key")
+}
+
+func TestBuildSearchAggregationContextRejectsJSONPathMetric(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "agg_test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "brand", DataType: schemapb.DataType_VarChar},
+			{FieldID: 108, Name: "meta", DataType: schemapb.DataType_JSON},
+		},
+	}
+
+	_, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+		Fields: []string{"brand"},
+		Metrics: map[string]*commonpb.MetricAggSpec{
+			"field_count": {Op: "count", FieldName: "meta[\"category\"]"},
+		},
+	}, schema, 1)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "metric JSON path is not yet supported")
+}
+
+func TestBuildSearchAggregationContextCountDynamicJSONFieldDoesNotRequestKey(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name:               "agg_test",
+		EnableDynamicField: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "brand", DataType: schemapb.DataType_VarChar},
+			{FieldID: 109, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+		},
+	}
+
+	ctx, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+		Fields: []string{"brand"},
+		Metrics: map[string]*commonpb.MetricAggSpec{
+			"field_count": {Op: "count", FieldName: "$meta"},
+		},
+	}, schema, 1)
+
+	require.NoError(t, err)
+	require.Equal(t, []int64{109}, ctx.ExtraOutputFieldIDs())
+	require.Empty(t, ctx.DynamicOutputFields())
+}
+
+func TestMergeDynamicOutputFields(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name:               "agg_test",
+		EnableDynamicField: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "brand", DataType: schemapb.DataType_VarChar},
+			{FieldID: 109, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+		},
+	}
+	ctx, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+		Fields: []string{"brand"},
+		Metrics: map[string]*commonpb.MetricAggSpec{
+			"field_count": {Op: "count", FieldName: "dynamic_brand"},
+		},
+	}, schema, 1)
+	require.NoError(t, err)
+
+	merged := MergeDynamicOutputFields([]string{"user_field", "dynamic_brand"}, ctx)
+
+	require.Equal(t, []string{"user_field", "dynamic_brand"}, merged)
+}
+
+func TestMergeDynamicOutputFieldsHandlesEmptyAndDuplicateFields(t *testing.T) {
+	require.Equal(t, []string{"user_field"}, MergeDynamicOutputFields([]string{"user_field"}, nil))
+	require.Equal(t, []string{"user_field"}, MergeDynamicOutputFields([]string{"user_field"}, &SearchAggregationContext{}))
+
+	ctx := &SearchAggregationContext{
+		dynamicOutputFields: []string{"", "dynamic_brand", "user_field"},
+	}
+	merged := MergeDynamicOutputFields([]string{"", "user_field"}, ctx)
+
+	require.Equal(t, []string{"user_field", "dynamic_brand"}, merged)
 }
 
 func TestBuildSearchAggregationContextValidationMatrix(t *testing.T) {

--- a/internal/proxy/search_agg/types.go
+++ b/internal/proxy/search_agg/types.go
@@ -47,6 +47,11 @@ type SearchAggregationContext struct {
 	// SearchRequest.OutputFieldsId by the caller so segcore writes them.
 	// Stored sorted for deterministic downstream behavior.
 	extraOutputFieldIDs []int64
+
+	// dynamicOutputFields are dynamic-field keys required by metric sources or
+	// top_hits sort. The caller must add these to PlanNode.DynamicFields so
+	// QueryNode extracts the subfields into fields_data.
+	dynamicOutputFields []string
 }
 
 // IsGroupByField reports whether fieldID appears in any level's OwnFieldIDs.
@@ -59,6 +64,38 @@ func (c *SearchAggregationContext) IsGroupByField(fieldID int64) bool {
 // SearchRequest.OutputFieldsId.
 func (c *SearchAggregationContext) ExtraOutputFieldIDs() []int64 {
 	return c.extraOutputFieldIDs
+}
+
+// DynamicOutputFields returns dynamic-field keys required by metric sources or
+// top_hits sort.
+func (c *SearchAggregationContext) DynamicOutputFields() []string {
+	return c.dynamicOutputFields
+}
+
+// MergeDynamicOutputFields appends aggregation-required dynamic keys to a
+// caller-provided dynamic field list while preserving order and removing
+// duplicates.
+func MergeDynamicOutputFields(userDynamicFields []string, ctx *SearchAggregationContext) []string {
+	if ctx == nil || len(ctx.DynamicOutputFields()) == 0 {
+		return userDynamicFields
+	}
+	merged := make([]string, 0, len(userDynamicFields)+len(ctx.DynamicOutputFields()))
+	seen := make(map[string]struct{}, cap(merged))
+	appendUnique := func(fields []string) {
+		for _, field := range fields {
+			if field == "" {
+				continue
+			}
+			if _, ok := seen[field]; ok {
+				continue
+			}
+			seen[field] = struct{}{}
+			merged = append(merged, field)
+		}
+	}
+	appendUnique(userDynamicFields)
+	appendUnique(ctx.DynamicOutputFields())
+	return merged
 }
 
 // AllGroupByFieldIDs returns the flattened composite-key field list in the

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -633,7 +633,7 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 			allFieldIDs.Insert(rerankInputFieldIDs...)
 			allFieldIDs.Insert(primaryFieldSchema.FieldID)
 			plan.OutputFieldIds = allFieldIDs.Collect()
-			plan.DynamicFields = t.userDynamicFields
+			plan.DynamicFields = search_agg.MergeDynamicOutputFields(t.userDynamicFields, t.aggCtx)
 		}
 		plan.Namespace = t.request.Namespace
 
@@ -864,7 +864,7 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 		allFieldIDs.Insert(rerankInputFieldIDs...)
 		allFieldIDs.Insert(primaryFieldSchema.FieldID)
 		plan.OutputFieldIds = allFieldIDs.Collect()
-		plan.DynamicFields = t.userDynamicFields
+		plan.DynamicFields = search_agg.MergeDynamicOutputFields(t.userDynamicFields, t.aggCtx)
 		// Merge highlight dynamic fields into plan.DynamicFields
 		if t.highlighter != nil {
 			highlightDynFields := t.highlighter.DynamicFieldNames()

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -2754,6 +2754,8 @@ func getScalarDataLen(field *schemapb.FieldData) int {
 		return len(field.GetScalars().GetTimestamptzData().GetData())
 	case schemapb.DataType_VarChar, schemapb.DataType_Text:
 		return len(field.GetScalars().GetStringData().GetData())
+	case schemapb.DataType_JSON:
+		return len(field.GetScalars().GetJsonData().GetData())
 	}
 	return -1
 }
@@ -2774,6 +2776,8 @@ func getData(field *schemapb.FieldData, idx int) any {
 		return field.GetScalars().GetTimestamptzData().GetData()[idx]
 	case schemapb.DataType_VarChar, schemapb.DataType_Text:
 		return field.GetScalars().GetStringData().GetData()[idx]
+	case schemapb.DataType_JSON:
+		return field.GetScalars().GetJsonData().GetData()[idx]
 	case schemapb.DataType_FloatVector:
 		dim := int(field.GetVectors().GetDim())
 		return field.GetVectors().GetFloatVector().GetData()[idx*dim : (idx+1)*dim]

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -1775,6 +1775,7 @@ func TestGetDataAndGetDataSize(t *testing.T) {
 	FloatArray := []float32{1.0, 2.0}
 	DoubleArray := []float64{11.0, 22.0}
 	VarCharArray := []string{"a", "b"}
+	JSONArray := [][]byte{[]byte(`{"hello":0}`), []byte(`{"key":1}`)}
 	BinaryVector := []byte{0x12, 0x34}
 	FloatVector := []float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 11.0, 22.0, 33.0, 44.0, 55.0, 66.0, 77.0, 88.0}
 	Float16Vector := []byte{
@@ -1805,6 +1806,7 @@ func TestGetDataAndGetDataSize(t *testing.T) {
 	floatData := genFieldData(fieldName, fieldID, schemapb.DataType_Float, FloatArray, 1)
 	doubleData := genFieldData(fieldName, fieldID, schemapb.DataType_Double, DoubleArray, 1)
 	varCharData := genFieldData(fieldName, fieldID, schemapb.DataType_VarChar, VarCharArray, 1)
+	jsonData := genFieldData(fieldName, fieldID, schemapb.DataType_JSON, JSONArray, 1)
 	binVecData := genFieldData(fieldName, fieldID, schemapb.DataType_BinaryVector, BinaryVector, Dim)
 	floatVecData := genFieldData(fieldName, fieldID, schemapb.DataType_FloatVector, FloatVector, Dim)
 	float16VecData := genFieldData(fieldName, fieldID, schemapb.DataType_Float16Vector, Float16Vector, Dim)
@@ -1832,6 +1834,7 @@ func TestGetDataAndGetDataSize(t *testing.T) {
 		floatDataRes := getData(floatData, 0)
 		doubleDataRes := getData(doubleData, 0)
 		varCharDataRes := getData(varCharData, 0)
+		jsonDataRes := getData(jsonData, 0)
 		binVecDataRes := getData(binVecData, 0)
 		floatVecDataRes := getData(floatVecData, 0)
 		float16VecDataRes := getData(float16VecData, 0)
@@ -1848,6 +1851,7 @@ func TestGetDataAndGetDataSize(t *testing.T) {
 		assert.Equal(t, FloatArray[0], floatDataRes)
 		assert.Equal(t, DoubleArray[0], doubleDataRes)
 		assert.Equal(t, VarCharArray[0], varCharDataRes)
+		assert.Equal(t, JSONArray[0], jsonDataRes)
 		assert.ElementsMatch(t, BinaryVector[:Dim/8], binVecDataRes)
 		assert.ElementsMatch(t, FloatVector[:Dim], floatVecDataRes)
 		assert.ElementsMatch(t, Float16Vector[:2*Dim], float16VecDataRes)
@@ -1855,6 +1859,10 @@ func TestGetDataAndGetDataSize(t *testing.T) {
 		assert.Equal(t, SparseFloatVector.Contents[0], sparseFloatDataRes)
 		assert.ElementsMatch(t, Int8Vector[:Dim], int8VecDataRes)
 		assert.Nil(t, invalidDataRes)
+	})
+
+	t.Run("test getScalarDataLen for JSON", func(t *testing.T) {
+		assert.Equal(t, len(JSONArray), getScalarDataLen(jsonData))
 	})
 }
 


### PR DESCRIPTION
## What changed
- Preserve `count(JSON field)` search aggregation metrics by allowing JSON `FieldData` to be read by the common data iterator.
- Track dynamic metric source keys in the search aggregation context and merge them into `Plan.DynamicFields` so QueryNode extracts dynamic fields needed for aggregation.
- Add regression coverage for `count(meta)`, dynamic `count(dynamic_brand)` source tracking, and dynamic field merge behavior.

## Tests
- `GOTOOLCHAIN=go1.25.9 go test -tags dynamic,test ./internal/proxy/search_agg`
- From `pkg`: `GOTOOLCHAIN=go1.25.9 go test -tags dynamic,test ./util/typeutil`

Fixes #49842