### PR TITLE
fix: reject search aggregation with search iterator

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -410,6 +410,14 @@ func (t *searchTask) initSearchAggregation() error {
 		return merr.WrapErrParameterInvalidMsg("highlighter and search_aggregation cannot be used simultaneously")
 	}
 
+	isIteratorStr, _ := funcutil.GetAttrByKeyFromRepeatedKV(IteratorField, t.request.GetSearchParams())
+	isIterator := isIteratorStr == "True" || isIteratorStr == "true"
+	isIteratorV2Str, _ := funcutil.GetAttrByKeyFromRepeatedKV(SearchIterV2Key, t.request.GetSearchParams())
+	isIteratorV2, _ := strconv.ParseBool(isIteratorV2Str)
+	if isIterator || isIteratorV2 {
+		return merr.WrapErrParameterInvalidMsg("search_aggregation is not supported with search iterator")
+	}
+
 	groupByField, err := funcutil.GetAttrByKeyFromRepeatedKV(GroupByFieldKey, t.request.GetSearchParams())
 	if err == nil && strings.TrimSpace(groupByField) != "" {
 		return merr.WrapErrParameterInvalidMsg("group_by_field and search_aggregation cannot be used simultaneously")

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -1073,6 +1073,29 @@ func TestSearchTask_initSearchAggregation(t *testing.T) {
 		assert.Contains(t, err.Error(), "highlighter and search_aggregation cannot be used simultaneously")
 	})
 
+	t.Run("search iterator conflict", func(t *testing.T) {
+		task := &searchTask{
+			SearchRequest: &internalpb.SearchRequest{Nq: 1},
+			request: &milvuspb.SearchRequest{
+				SearchParams: []*commonpb.KeyValuePair{
+					{Key: IteratorField, Value: "True"},
+					{Key: SearchIterV2Key, Value: "True"},
+				},
+				SearchAggregation: &commonpb.SearchAggregationSpec{Fields: []string{"brand"}},
+			},
+			schema: &schemaInfo{
+				CollectionSchema: &schemapb.CollectionSchema{
+					Fields: []*schemapb.FieldSchema{{FieldID: 101, Name: "brand", DataType: schemapb.DataType_VarChar}},
+				},
+			},
+		}
+
+		err := task.initSearchAggregation()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "search_aggregation is not supported with search iterator")
+	})
+
 	t.Run("build agg context and agg info", func(t *testing.T) {
 		task := &searchTask{
 			SearchRequest: &internalpb.SearchRequest{Nq: 1, OutputFieldsId: []int64{102}},


### PR DESCRIPTION
issue: #49841

### What changed
- Reject requests that combine `search_aggregation` with search iterator flags during proxy search aggregation initialization.
- Add a proxy regression test that expects a parameter error instead of allowing the unsupported request to continue.

### Why
`search_iterator` currently accepts `search_aggregation`, but the iterator path does not support returning aggregation buckets. The request can silently produce an empty page without a clear error. Rejecting the combination makes the unsupported behavior explicit.

### Tests
- `GOTOOLCHAIN=go1.25.9 go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy/search_agg`
- `GOTOOLCHAIN=go1.25.9 go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/util/reduce`

Not run locally: `./internal/proxy` targeted test could not build on this Windows environment because native dependencies require `pkg-config`/C toolchain support and `github.com/zilliztech/woodpecker/common/hardware` fails to compile on Windows here.