### PR TITLE
enhance: [cp2.6]Support Arrow FixedSizeList in Parquet import

### DIFF
--- a/internal/util/importutilv2/parquet/field_reader.go
+++ b/internal/util/importutilv2/parquet/field_reader.go
@@ -862,16 +862,34 @@ func ReadBinaryData(pcr *FieldReader, count int64) (any, error) {
 			for i := 0; i < rows; i++ {
 				data = append(data, binaryReader.Value(i)...)
 			}
-		case arrow.LIST:
-			listReader := chunk.(*array.List)
-			if err = checkVectorAligned(listReader.Offsets(), pcr.dim, dataType); err != nil {
+		case arrow.LIST, arrow.FIXED_SIZE_LIST:
+			if chunk.NullN() > 0 {
+				return nil, WrapNullRowErr(pcr.field)
+			}
+			listReader, err := newListLikeArray(chunk, pcr.field)
+			if err != nil {
+				return nil, err
+			}
+			if err = checkListLikeVectorAligned(listReader, pcr.dim, dataType); err != nil {
 				return nil, merr.WrapErrImportFailed(fmt.Sprintf("length of vector is not aligned: %s, data type: %s", err.Error(), dataType.String()))
 			}
 			uint8Reader, ok := listReader.ListValues().(*array.Uint8)
 			if !ok {
 				return nil, WrapTypeErr(pcr.field, listReader.ListValues().DataType().Name())
 			}
-			data = append(data, uint8Reader.Uint8Values()...)
+			if canBulkCopyUint8ListValues(listReader, uint8Reader) {
+				data = append(data, uint8Reader.Uint8Values()...)
+				continue
+			}
+			for i := 0; i < listReader.Len(); i++ {
+				start, end := listReader.ValueOffsets(i)
+				for j := start; j < end; j++ {
+					if uint8Reader.IsNull(int(j)) {
+						return nil, WrapNullElementErr(pcr.field)
+					}
+					data = append(data, uint8Reader.Value(int(j)))
+				}
+			}
 		default:
 			return nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
 		}
@@ -909,21 +927,42 @@ func ReadNullableBinaryData(pcr *FieldReader, count int64) (any, []bool, error) 
 					validData = append(validData, true)
 				}
 			}
-		case arrow.LIST:
-			listReader := chunk.(*array.List)
-			if err = checkNullableVectorAligned(listReader.Offsets(), listReader, pcr.dim, dataType); err != nil {
+		case arrow.LIST, arrow.FIXED_SIZE_LIST:
+			listReader, err := newListLikeArray(chunk, pcr.field)
+			if err != nil {
+				return nil, nil, err
+			}
+			if err = checkNullableListLikeVectorAligned(listReader, pcr.dim, dataType); err != nil {
 				return nil, nil, merr.WrapErrImportFailed(fmt.Sprintf("length of vector is not aligned: %s, data type: %s", err.Error(), dataType.String()))
 			}
 			uint8Reader, ok := listReader.ListValues().(*array.Uint8)
 			if !ok {
 				return nil, nil, WrapTypeErr(pcr.field, listReader.ListValues().DataType().Name())
 			}
+			if canBulkCopyUint8ListValues(listReader, uint8Reader) {
+				values := uint8Reader.Uint8Values()
+				for i := 0; i < rows; i++ {
+					if listReader.IsNull(i) {
+						validData = append(validData, false)
+					} else {
+						start, end := listReader.ValueOffsets(i)
+						data = append(data, values[int(start):int(end)]...)
+						validData = append(validData, true)
+					}
+				}
+				continue
+			}
 			for i := 0; i < rows; i++ {
 				if listReader.IsNull(i) {
 					validData = append(validData, false)
 				} else {
 					start, end := listReader.ValueOffsets(i)
-					data = append(data, uint8Reader.Uint8Values()[start:end]...)
+					for j := start; j < end; j++ {
+						if uint8Reader.IsNull(int(j)) {
+							return nil, nil, WrapNullElementErr(pcr.field)
+						}
+						data = append(data, uint8Reader.Value(int(j)))
+					}
 					validData = append(validData, true)
 				}
 			}
@@ -1214,16 +1253,6 @@ func checkVectorAlignWithDim(offsets []int32, dim int32) error {
 	return nil
 }
 
-func checkNullableVectorAlignWithDim(offsets []int32, listReader *array.List, dim int32) error {
-	for i := 1; i < len(offsets); i++ {
-		length := offsets[i] - offsets[i-1]
-		if !listReader.IsNull(i-1) && length != dim {
-			return fmt.Errorf("expected %d but got %d", dim, length)
-		}
-	}
-	return nil
-}
-
 func checkVectorAligned(offsets []int32, dim int, dataType schemapb.DataType) error {
 	if len(offsets) < 1 {
 		return errors.New("empty offsets")
@@ -1245,61 +1274,6 @@ func checkVectorAligned(offsets []int32, dim int, dataType schemapb.DataType) er
 	}
 }
 
-func checkNullableVectorAligned(offsets []int32, listReader *array.List, dim int, dataType schemapb.DataType) error {
-	if len(offsets) < 1 {
-		return errors.New("empty offsets")
-	}
-	switch dataType {
-	case schemapb.DataType_BinaryVector:
-		return checkNullableVectorAlignWithDim(offsets, listReader, int32(dim/8))
-	case schemapb.DataType_FloatVector:
-		return checkNullableVectorAlignWithDim(offsets, listReader, int32(dim))
-	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
-		return checkNullableVectorAlignWithDim(offsets, listReader, int32(dim*2))
-	case schemapb.DataType_SparseFloatVector:
-		return nil
-	case schemapb.DataType_Int8Vector:
-		return checkNullableVectorAlignWithDim(offsets, listReader, int32(dim))
-	default:
-		return fmt.Errorf("unexpected vector data type %s", dataType.String())
-	}
-}
-
-func getArrayData[T any](offsets []int32, getElement func(int) (T, error), outputArray func(arr []T, valid bool)) error {
-	for i := 1; i < len(offsets); i++ {
-		start, end := offsets[i-1], offsets[i]
-		arrData := make([]T, 0, end-start)
-		for j := start; j < end; j++ {
-			elementVal, err := getElement(int(j))
-			if err != nil {
-				return err
-			}
-			arrData = append(arrData, elementVal)
-		}
-		isValid := (start != end)
-		outputArray(arrData, isValid)
-	}
-	return nil
-}
-
-func getArrayDataNullable[T any](offsets []int32, listReader *array.List, getElement func(int) (T, error), outputArray func(arr []T, valid bool)) error {
-	for i := 1; i < len(offsets); i++ {
-		isValid := !listReader.IsNull(i - 1)
-
-		start, end := offsets[i-1], offsets[i]
-		arrData := make([]T, 0, end-start)
-		for j := start; j < end; j++ {
-			elementVal, err := getElement(int(j))
-			if err != nil {
-				return err
-			}
-			arrData = append(arrData, elementVal)
-		}
-		outputArray(arrData, isValid)
-	}
-	return nil
-}
-
 func ReadBoolArrayData(pcr *FieldReader, count int64) (any, error) {
 	chunked, err := pcr.columnReader.NextBatch(count)
 	if err != nil {
@@ -1311,22 +1285,11 @@ func ReadBoolArrayData(pcr *FieldReader, count int64) (any, error) {
 			// Array field is not nullable, but some arrays are null
 			return nil, WrapNullRowErr(pcr.field)
 		}
-		listReader, ok := chunk.(*array.List)
-		if !ok {
-			return nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
+		listReader, err := newListLikeArray(chunk, pcr.field)
+		if err != nil {
+			return nil, err
 		}
-		boolReader, ok := listReader.ListValues().(*array.Boolean)
-		if !ok {
-			return nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
-		}
-		offsets := listReader.Offsets()
-		err = getArrayData(offsets, func(i int) (bool, error) {
-			if boolReader.IsNull(i) {
-				// array contains null values is not allowed
-				return false, WrapNullElementErr(pcr.field)
-			}
-			return boolReader.Value(i), nil
-		}, func(arr []bool, valid bool) {
+		err = readBoolListLikeData(pcr.field, listReader, func(arr []bool, valid bool) {
 			data = append(data, arr)
 		})
 		if err != nil {
@@ -1347,28 +1310,17 @@ func ReadNullableBoolArrayData(pcr *FieldReader, count int64) (any, []bool, erro
 	data := make([][]bool, 0, count)
 	validData := make([]bool, 0, count)
 	for _, chunk := range chunked.Chunks() {
-		listReader, ok := chunk.(*array.List)
-		if !ok {
+		if _, ok := chunk.(*array.Null); ok {
 			// the chunk type may be *array.Null if the data in chunk is all null
-			_, ok := chunk.(*array.Null)
-			if !ok {
-				return nil, nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
-			}
 			dataNums := chunk.Data().Len()
 			validData = append(validData, make([]bool, dataNums)...)
 			data = append(data, make([][]bool, dataNums)...)
 		} else {
-			boolReader, ok := listReader.ListValues().(*array.Boolean)
-			if !ok {
-				return nil, nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
+			listReader, err := newListLikeArray(chunk, pcr.field)
+			if err != nil {
+				return nil, nil, err
 			}
-			offsets := listReader.Offsets()
-			err = getArrayData(offsets, func(i int) (bool, error) {
-				if boolReader.IsNull(i) {
-					return false, WrapNullElementErr(pcr.field)
-				}
-				return boolReader.Value(i), nil
-			}, func(arr []bool, valid bool) {
+			err = readBoolListLikeData(pcr.field, listReader, func(arr []bool, valid bool) {
 				data = append(data, arr)
 				validData = append(validData, valid)
 			})
@@ -1398,105 +1350,20 @@ func ReadIntegerOrFloatArrayData[T constraints.Integer | constraints.Float](pcr 
 			// Array field is not nullable, but some arrays are null
 			return nil, WrapNullRowErr(pcr.field)
 		}
-		listReader, ok := chunk.(*array.List)
-		if !ok {
-			return nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
+		listReader, err := newListLikeArray(chunk, pcr.field)
+		if err != nil {
+			return nil, err
 		}
-		offsets := listReader.Offsets()
 		dataType := pcr.field.GetDataType()
 		if typeutil.IsVectorType(dataType) {
-			if err = checkVectorAligned(offsets, pcr.dim, dataType); err != nil {
+			if err = checkListLikeVectorAligned(listReader, pcr.dim, dataType); err != nil {
 				return nil, merr.WrapErrImportFailed(fmt.Sprintf("length of vector is not aligned: %s, data type: %s", err.Error(), dataType.String()))
 			}
 		}
-		valueReader := listReader.ListValues()
-		switch valueReader.DataType().ID() {
-		case arrow.INT8:
-			int8Reader := valueReader.(*array.Int8)
-			err = getArrayData(offsets, func(i int) (T, error) {
-				if int8Reader.IsNull(i) {
-					// array contains null values is not allowed
-					return 0, WrapNullElementErr(pcr.field)
-				}
-				return T(int8Reader.Value(i)), nil
-			}, func(arr []T, valid bool) {
-				data = append(data, arr)
-			})
-			if err != nil {
-				return nil, err
-			}
-		case arrow.INT16:
-			int16Reader := valueReader.(*array.Int16)
-			err = getArrayData(offsets, func(i int) (T, error) {
-				if int16Reader.IsNull(i) {
-					// array contains null values is not allowed
-					return 0, WrapNullElementErr(pcr.field)
-				}
-				return T(int16Reader.Value(i)), nil
-			}, func(arr []T, valid bool) {
-				data = append(data, arr)
-			})
-			if err != nil {
-				return nil, err
-			}
-		case arrow.INT32:
-			int32Reader := valueReader.(*array.Int32)
-			err = getArrayData(offsets, func(i int) (T, error) {
-				if int32Reader.IsNull(i) {
-					// array contains null values is not allowed
-					return 0, WrapNullElementErr(pcr.field)
-				}
-				return T(int32Reader.Value(i)), nil
-			}, func(arr []T, valid bool) {
-				data = append(data, arr)
-			})
-			if err != nil {
-				return nil, err
-			}
-		case arrow.INT64:
-			int64Reader := valueReader.(*array.Int64)
-			err = getArrayData(offsets, func(i int) (T, error) {
-				if int64Reader.IsNull(i) {
-					// array contains null values is not allowed
-					return 0, WrapNullElementErr(pcr.field)
-				}
-				return T(int64Reader.Value(i)), nil
-			}, func(arr []T, valid bool) {
-				data = append(data, arr)
-			})
-			if err != nil {
-				return nil, err
-			}
-		case arrow.FLOAT32:
-			float32Reader := valueReader.(*array.Float32)
-			err = getArrayData(offsets, func(i int) (T, error) {
-				if float32Reader.IsNull(i) {
-					// array contains null values is not allowed
-					return 0.0, WrapNullElementErr(pcr.field)
-				}
-				return T(float32Reader.Value(i)), nil
-			}, func(arr []T, valid bool) {
-				data = append(data, arr)
-			})
-			if err != nil {
-				return nil, err
-			}
-		case arrow.FLOAT64:
-			float64Reader := valueReader.(*array.Float64)
-			err = getArrayData(offsets, func(i int) (T, error) {
-				if float64Reader.IsNull(i) {
-					// array contains null values is not allowed
-					return 0.0, WrapNullElementErr(pcr.field)
-				}
-				return T(float64Reader.Value(i)), nil
-			}, func(arr []T, valid bool) {
-				data = append(data, arr)
-			})
-			if err != nil {
-				return nil, err
-			}
-		default:
-			return nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
+		if err = readIntegerOrFloatListLikeData(pcr.field, listReader, func(arr []T, valid bool) {
+			data = append(data, arr)
+		}); err != nil {
+			return nil, err
 		}
 	}
 	if len(data) == 0 {
@@ -1514,118 +1381,27 @@ func ReadNullableIntegerOrFloatArrayData[T constraints.Integer | constraints.Flo
 	validData := make([]bool, 0, count)
 
 	for _, chunk := range chunked.Chunks() {
-		listReader, ok := chunk.(*array.List)
-		if !ok {
+		if _, ok := chunk.(*array.Null); ok {
 			// the chunk type may be *array.Null if the data in chunk is all null
-			_, ok := chunk.(*array.Null)
-			if !ok {
-				return nil, nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
-			}
 			dataNums := chunk.Data().Len()
 			validData = append(validData, make([]bool, dataNums)...)
 			data = append(data, make([][]T, dataNums)...)
 		} else {
-			offsets := listReader.Offsets()
+			listReader, err := newListLikeArray(chunk, pcr.field)
+			if err != nil {
+				return nil, nil, err
+			}
 			dataType := pcr.field.GetDataType()
 			if typeutil.IsVectorType(dataType) {
-				if err = checkVectorAligned(offsets, pcr.dim, dataType); err != nil {
+				if err = checkListLikeVectorAligned(listReader, pcr.dim, dataType); err != nil {
 					return nil, nil, merr.WrapErrImportFailed(fmt.Sprintf("length of vector is not aligned: %s, data type: %s", err.Error(), dataType.String()))
 				}
 			}
-			valueReader := listReader.ListValues()
-			switch valueReader.DataType().ID() {
-			case arrow.INT8:
-				int8Reader := valueReader.(*array.Int8)
-				err = getArrayData(offsets, func(i int) (T, error) {
-					if int8Reader.IsNull(i) {
-						// array contains null values is not allowed
-						return 0, WrapNullElementErr(pcr.field)
-					}
-					return T(int8Reader.Value(i)), nil
-				}, func(arr []T, valid bool) {
-					data = append(data, arr)
-					validData = append(validData, valid)
-				})
-				if err != nil {
-					return nil, nil, err
-				}
-			case arrow.INT16:
-				int16Reader := valueReader.(*array.Int16)
-				err = getArrayData(offsets, func(i int) (T, error) {
-					if int16Reader.IsNull(i) {
-						// array contains null values is not allowed
-						return 0, WrapNullElementErr(pcr.field)
-					}
-					return T(int16Reader.Value(i)), nil
-				}, func(arr []T, valid bool) {
-					data = append(data, arr)
-					validData = append(validData, valid)
-				})
-				if err != nil {
-					return nil, nil, err
-				}
-			case arrow.INT32:
-				int32Reader := valueReader.(*array.Int32)
-				err = getArrayData(offsets, func(i int) (T, error) {
-					if int32Reader.IsNull(i) {
-						// array contains null values is not allowed
-						return 0, WrapNullElementErr(pcr.field)
-					}
-					return T(int32Reader.Value(i)), nil
-				}, func(arr []T, valid bool) {
-					data = append(data, arr)
-					validData = append(validData, valid)
-				})
-				if err != nil {
-					return nil, nil, err
-				}
-			case arrow.INT64:
-				int64Reader := valueReader.(*array.Int64)
-				err = getArrayData(offsets, func(i int) (T, error) {
-					if int64Reader.IsNull(i) {
-						// array contains null values is not allowed
-						return 0, WrapNullElementErr(pcr.field)
-					}
-					return T(int64Reader.Value(i)), nil
-				}, func(arr []T, valid bool) {
-					data = append(data, arr)
-					validData = append(validData, valid)
-				})
-				if err != nil {
-					return nil, nil, err
-				}
-			case arrow.FLOAT32:
-				float32Reader := valueReader.(*array.Float32)
-				err = getArrayData(offsets, func(i int) (T, error) {
-					if float32Reader.IsNull(i) {
-						// array contains null values is not allowed
-						return 0.0, WrapNullElementErr(pcr.field)
-					}
-					return T(float32Reader.Value(i)), nil
-				}, func(arr []T, valid bool) {
-					data = append(data, arr)
-					validData = append(validData, valid)
-				})
-				if err != nil {
-					return nil, nil, err
-				}
-			case arrow.FLOAT64:
-				float64Reader := valueReader.(*array.Float64)
-				err = getArrayData(offsets, func(i int) (T, error) {
-					if float64Reader.IsNull(i) {
-						// array contains null values is not allowed
-						return 0.0, WrapNullElementErr(pcr.field)
-					}
-					return T(float64Reader.Value(i)), nil
-				}, func(arr []T, valid bool) {
-					data = append(data, arr)
-					validData = append(validData, valid)
-				})
-				if err != nil {
-					return nil, nil, err
-				}
-			default:
-				return nil, nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
+			if err = readIntegerOrFloatListLikeData(pcr.field, listReader, func(arr []T, valid bool) {
+				data = append(data, arr)
+				validData = append(validData, valid)
+			}); err != nil {
+				return nil, nil, err
 			}
 		}
 	}
@@ -1647,21 +1423,19 @@ func ReadNullableFloatVectorData(pcr *FieldReader, count int64) (any, []bool, er
 	validData := make([]bool, 0, count)
 
 	for _, chunk := range chunked.Chunks() {
-		listReader, ok := chunk.(*array.List)
-		if !ok {
+		if _, ok := chunk.(*array.Null); ok {
 			// the chunk type may be *array.Null if the data in chunk is all null
-			_, ok := chunk.(*array.Null)
-			if !ok {
-				return nil, nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
-			}
 			dataNums := chunk.Data().Len()
 			validData = append(validData, make([]bool, dataNums)...)
 			continue
 		}
+		listReader, err := newListLikeArray(chunk, pcr.field)
+		if err != nil {
+			return nil, nil, err
+		}
 
 		dataType := pcr.field.GetDataType()
-		offsets := listReader.Offsets()
-		if err = checkNullableVectorAligned(offsets, listReader, pcr.dim, dataType); err != nil {
+		if err = checkNullableListLikeVectorAligned(listReader, pcr.dim, dataType); err != nil {
 			return nil, nil, merr.WrapErrImportFailed(fmt.Sprintf("length of vector is not aligned: %s, data type: %s", err.Error(), dataType.String()))
 		}
 
@@ -1676,8 +1450,11 @@ func ReadNullableFloatVectorData(pcr *FieldReader, count int64) (any, []bool, er
 		for i := 0; i < rows; i++ {
 			validData = append(validData, !listReader.IsNull(i))
 			if !listReader.IsNull(i) {
-				start, end := offsets[i], offsets[i+1]
+				start, end := listReader.ValueOffsets(i)
 				for j := start; j < end; j++ {
+					if float32Reader.IsNull(int(j)) {
+						return nil, nil, WrapNullElementErr(pcr.field)
+					}
 					data = append(data, float32Reader.Value(int(j)))
 				}
 			}
@@ -1698,21 +1475,19 @@ func ReadNullableInt8VectorData(pcr *FieldReader, count int64) (any, []bool, err
 	validData := make([]bool, 0, count)
 
 	for _, chunk := range chunked.Chunks() {
-		listReader, ok := chunk.(*array.List)
-		if !ok {
+		if _, ok := chunk.(*array.Null); ok {
 			// the chunk type may be *array.Null if the data in chunk is all null
-			_, ok := chunk.(*array.Null)
-			if !ok {
-				return nil, nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
-			}
 			dataNums := chunk.Data().Len()
 			validData = append(validData, make([]bool, dataNums)...)
 			continue
 		}
+		listReader, err := newListLikeArray(chunk, pcr.field)
+		if err != nil {
+			return nil, nil, err
+		}
 
 		dataType := pcr.field.GetDataType()
-		offsets := listReader.Offsets()
-		if err = checkNullableVectorAligned(offsets, listReader, pcr.dim, dataType); err != nil {
+		if err = checkNullableListLikeVectorAligned(listReader, pcr.dim, dataType); err != nil {
 			return nil, nil, merr.WrapErrImportFailed(fmt.Sprintf("length of vector is not aligned: %s, data type: %s", err.Error(), dataType.String()))
 		}
 
@@ -1727,8 +1502,11 @@ func ReadNullableInt8VectorData(pcr *FieldReader, count int64) (any, []bool, err
 		for i := 0; i < rows; i++ {
 			validData = append(validData, !listReader.IsNull(i))
 			if !listReader.IsNull(i) {
-				start, end := offsets[i], offsets[i+1]
+				start, end := listReader.ValueOffsets(i)
 				for j := start; j < end; j++ {
+					if int8Reader.IsNull(int(j)) {
+						return nil, nil, WrapNullElementErr(pcr.field)
+					}
 					data = append(data, int8Reader.Value(int(j)))
 				}
 			}
@@ -1755,25 +1533,12 @@ func ReadStringArrayData(pcr *FieldReader, count int64) (any, error) {
 			// Array field is not nullable, but some arrays are null
 			return nil, WrapNullRowErr(pcr.field)
 		}
-		listReader, ok := chunk.(*array.List)
-		if !ok {
-			return nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
+		listReader, err := newListLikeArray(chunk, pcr.field)
+		if err != nil {
+			return nil, err
 		}
-		stringReader, ok := listReader.ListValues().(*array.String)
-		if !ok {
-			return nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
-		}
-		offsets := listReader.Offsets()
-		err = getArrayData(offsets, func(i int) (string, error) {
-			if stringReader.IsNull(i) {
-				// array contains null values is not allowed
-				return "", WrapNullElementErr(pcr.field)
-			}
-			val := stringReader.Value(i)
-			if err = common.CheckValidString(val, maxLength, pcr.field); err != nil {
-				return val, err
-			}
-			return val, nil
+		err = readStringListLikeData(pcr.field, listReader, func(val string) error {
+			return common.CheckValidString(val, maxLength, pcr.field)
 		}, func(arr []string, valid bool) {
 			data = append(data, arr)
 		})
@@ -1799,32 +1564,18 @@ func ReadNullableStringArrayData(pcr *FieldReader, count int64) (any, []bool, er
 	data := make([][]string, 0, count)
 	validData := make([]bool, 0, count)
 	for _, chunk := range chunked.Chunks() {
-		listReader, ok := chunk.(*array.List)
-		if !ok {
+		if _, ok := chunk.(*array.Null); ok {
 			// the chunk type may be *array.Null if the data in chunk is all null
-			_, ok := chunk.(*array.Null)
-			if !ok {
-				return nil, nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
-			}
 			dataNums := chunk.Data().Len()
 			validData = append(validData, make([]bool, dataNums)...)
 			data = append(data, make([][]string, dataNums)...)
 		} else {
-			stringReader, ok := listReader.ListValues().(*array.String)
-			if !ok {
-				return nil, nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
+			listReader, err := newListLikeArray(chunk, pcr.field)
+			if err != nil {
+				return nil, nil, err
 			}
-			offsets := listReader.Offsets()
-			err = getArrayData(offsets, func(i int) (string, error) {
-				if stringReader.IsNull(i) {
-					// array contains null values is not allowed
-					return "", WrapNullElementErr(pcr.field)
-				}
-				val := stringReader.Value(i)
-				if err = common.CheckValidString(val, maxLength, pcr.field); err != nil {
-					return val, err
-				}
-				return val, nil
+			err = readStringListLikeData(pcr.field, listReader, func(val string) error {
+				return common.CheckValidString(val, maxLength, pcr.field)
 			}, func(arr []string, valid bool) {
 				data = append(data, arr)
 				validData = append(validData, valid)

--- a/internal/util/importutilv2/parquet/fixed_size_list_reader_test.go
+++ b/internal/util/importutilv2/parquet/fixed_size_list_reader_test.go
@@ -1,0 +1,574 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parquet
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/apache/arrow/go/v17/parquet"
+	"github.com/apache/arrow/go/v17/parquet/file"
+	"github.com/apache/arrow/go/v17/parquet/pqarrow"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
+)
+
+const (
+	fixedSizeListPKFieldID   = int64(100)
+	fixedSizeListDataFieldID = int64(101)
+)
+
+type fixedSizeInt32Row struct {
+	valid  bool
+	values []*int32
+}
+
+type fixedSizeStringRow struct {
+	valid  bool
+	values []*string
+}
+
+type fixedSizeFloat32Row struct {
+	valid  bool
+	values []*float32
+}
+
+func TestImportFixedSizeList_Int32Array(t *testing.T) {
+	schema := fixedSizeListArraySchema(schemapb.DataType_Int32, 3, false)
+	rows := []fixedSizeInt32Row{
+		{valid: true, values: int32Ptrs(1, 2, 3)},
+		{valid: true, values: int32Ptrs(4, 5, 6)},
+	}
+
+	insertData := readFixedSizeListParquet(t, schema, fixedSizeInt32ListArray(t, 3, rows))
+
+	require.Equal(t, 2, insertData.Data[fixedSizeListDataFieldID].RowNum())
+	require.EqualValues(t, []int32{1, 2, 3}, insertData.Data[fixedSizeListDataFieldID].GetRow(0).(*schemapb.ScalarField).GetIntData().GetData())
+	require.EqualValues(t, []int32{4, 5, 6}, insertData.Data[fixedSizeListDataFieldID].GetRow(1).(*schemapb.ScalarField).GetIntData().GetData())
+}
+
+func TestImportFixedSizeList_StringArray(t *testing.T) {
+	schema := fixedSizeListArraySchema(schemapb.DataType_VarChar, 3, false)
+	rows := []fixedSizeStringRow{
+		{valid: true, values: stringPtrs("red", "green", "blue")},
+		{valid: true, values: stringPtrs("cyan", "magenta", "yellow")},
+	}
+
+	insertData := readFixedSizeListParquet(t, schema, fixedSizeStringListArray(t, 3, rows))
+
+	require.Equal(t, 2, insertData.Data[fixedSizeListDataFieldID].RowNum())
+	require.EqualValues(t, []string{"red", "green", "blue"}, insertData.Data[fixedSizeListDataFieldID].GetRow(0).(*schemapb.ScalarField).GetStringData().GetData())
+	require.EqualValues(t, []string{"cyan", "magenta", "yellow"}, insertData.Data[fixedSizeListDataFieldID].GetRow(1).(*schemapb.ScalarField).GetStringData().GetData())
+}
+
+func TestImportFixedSizeList_FloatVector(t *testing.T) {
+	schema := fixedSizeListFloatVectorSchema(4, false)
+	rows := []fixedSizeFloat32Row{
+		{valid: true, values: float32Ptrs(1, 2, 3, 4)},
+		{valid: true, values: float32Ptrs(5, 6, 7, 8)},
+	}
+
+	insertData := readFixedSizeListParquet(t, schema, fixedSizeFloat32ListArray(t, 4, rows))
+
+	require.Equal(t, 2, insertData.Data[fixedSizeListDataFieldID].RowNum())
+	require.EqualValues(t, []float32{1, 2, 3, 4}, insertData.Data[fixedSizeListDataFieldID].GetRow(0))
+	require.EqualValues(t, []float32{5, 6, 7, 8}, insertData.Data[fixedSizeListDataFieldID].GetRow(1))
+}
+
+func TestImportFixedSizeList_NullableFloatVector(t *testing.T) {
+	schema := fixedSizeListFloatVectorSchema(4, true)
+	rows := []fixedSizeFloat32Row{
+		{valid: true, values: float32Ptrs(1, 2, 3, 4)},
+		{valid: true, values: float32Ptrs(5, 6, 7, 8)},
+		{valid: false},
+	}
+
+	insertData := readFixedSizeListParquet(t, schema, fixedSizeFloat32ListArray(t, 4, rows))
+
+	require.Equal(t, 3, insertData.Data[fixedSizeListDataFieldID].RowNum())
+	require.EqualValues(t, []float32{1, 2, 3, 4}, insertData.Data[fixedSizeListDataFieldID].GetRow(0))
+	require.EqualValues(t, []float32{5, 6, 7, 8}, insertData.Data[fixedSizeListDataFieldID].GetRow(1))
+	require.Nil(t, insertData.Data[fixedSizeListDataFieldID].GetRow(2))
+}
+
+func TestImportFixedSizeList_ArrayCapacityExceeded(t *testing.T) {
+	schema := fixedSizeListArraySchema(schemapb.DataType_Int32, 2, false)
+	rows := []fixedSizeInt32Row{{valid: true, values: int32Ptrs(1, 2, 3)}}
+
+	_, err := tryReadFixedSizeListParquet(t, schema, fixedSizeInt32ListArray(t, 3, rows))
+	require.Error(t, err)
+	require.Contains(t, strings.ReplaceAll(err.Error(), "_", " "), "exceeds max capacity")
+}
+
+func TestImportFixedSizeList_VectorDimMismatch(t *testing.T) {
+	schema := fixedSizeListFloatVectorSchema(4, false)
+	rows := []fixedSizeFloat32Row{{valid: true, values: float32Ptrs(1, 2, 3)}}
+
+	_, err := tryReadFixedSizeListParquet(t, schema, fixedSizeFloat32ListArray(t, 3, rows))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "length of vector is not aligned")
+}
+
+func TestImportFixedSizeList_NullElementRejected(t *testing.T) {
+	schema := fixedSizeListArraySchema(schemapb.DataType_Int32, 3, false)
+	rows := []fixedSizeInt32Row{{valid: true, values: []*int32{int32Ptr(1), nil, int32Ptr(3)}}}
+
+	_, err := tryReadFixedSizeListParquet(t, schema, fixedSizeInt32ListArrayWithNullableElements(t, 3, rows))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "array element is not allowed to be null")
+}
+
+func TestImportFixedSizeList_NullableArrayNullElementRejected(t *testing.T) {
+	schema := fixedSizeListArraySchema(schemapb.DataType_Int32, 3, true)
+	rows := []fixedSizeInt32Row{{valid: true, values: []*int32{int32Ptr(1), nil, int32Ptr(3)}}}
+
+	_, err := tryReadFixedSizeListParquet(t, schema, fixedSizeInt32ListArrayWithNullableElements(t, 3, rows))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "array element is not allowed to be null")
+}
+
+func TestImportFixedSizeList_VectorNullElementRejected(t *testing.T) {
+	schema := fixedSizeListFloatVectorSchema(4, true)
+	rows := []fixedSizeFloat32Row{{valid: true, values: []*float32{float32Ptr(1), nil, float32Ptr(3), float32Ptr(4)}}}
+
+	_, err := tryReadFixedSizeListParquet(t, schema, fixedSizeFloat32ListArrayWithNullableElements(t, 4, rows))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "array element is not allowed to be null")
+}
+
+func TestImportFixedSizeList_WrongElementTypeRejected(t *testing.T) {
+	schema := fixedSizeListArraySchema(schemapb.DataType_Int32, 3, false)
+	rows := []fixedSizeStringRow{{valid: true, values: stringPtrs("1", "2", "3")}}
+
+	_, err := tryReadFixedSizeListParquet(t, schema, fixedSizeStringListArray(t, 3, rows))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "field 'fsl_array' type mis-match")
+	require.Contains(t, err.Error(), "expect arrow type 'list<item: int32")
+	require.Contains(t, err.Error(), "get arrow data type 'fixed_size_list<item: utf8")
+}
+
+func TestImportFixedSizeList_NonNullableNullRowRejected(t *testing.T) {
+	schema := fixedSizeListFloatVectorSchema(4, false)
+	rows := []fixedSizeFloat32Row{
+		{valid: true, values: float32Ptrs(1, 2, 3, 4)},
+		{valid: false},
+	}
+
+	_, err := tryReadFixedSizeListParquet(t, schema, fixedSizeFloat32ListArray(t, 4, rows))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "the field 'fsl_vector' is not nullable but the file contains null value")
+	require.NotContains(t, err.Error(), "array element is not allowed to be null")
+}
+
+func TestCanBulkCopyUint8ListValues(t *testing.T) {
+	field := fixedSizeListFloat16VectorSchema(4, false).Fields[1]
+
+	list := uint8ListArray(t, [][]byte{
+		{1, 2, 3, 4},
+		{5, 6, 7, 8},
+	}, false)
+	defer list.Release()
+	listReader, err := newListLikeArray(list, field)
+	require.NoError(t, err)
+	uint8Reader := listReader.ListValues().(*array.Uint8)
+	require.True(t, canBulkCopyUint8ListValues(listReader, uint8Reader))
+
+	listWithNullElement := uint8ListArray(t, [][]byte{
+		{1, 2, 3, 4},
+		{5, 6, 7, 8},
+	}, true)
+	defer listWithNullElement.Release()
+	listReader, err = newListLikeArray(listWithNullElement, field)
+	require.NoError(t, err)
+	uint8Reader = listReader.ListValues().(*array.Uint8)
+	require.False(t, canBulkCopyUint8ListValues(listReader, uint8Reader))
+
+	fixedSizeList := fixedSizeUint8ListArray(t, 4, [][]byte{
+		{1, 2, 3, 4},
+		{5, 6, 7, 8},
+	})
+	defer fixedSizeList.Release()
+	listReader, err = newListLikeArray(fixedSizeList, field)
+	require.NoError(t, err)
+	uint8Reader = listReader.ListValues().(*array.Uint8)
+	require.False(t, canBulkCopyUint8ListValues(listReader, uint8Reader))
+}
+
+func readFixedSizeListParquet(t *testing.T, schema *schemapb.CollectionSchema, fixedSizeList arrow.Array) *storage.InsertData {
+	insertData, err := tryReadFixedSizeListParquet(t, schema, fixedSizeList)
+	require.NoError(t, err)
+	return insertData
+}
+
+func tryReadFixedSizeListParquet(t *testing.T, schema *schemapb.CollectionSchema, fixedSizeList arrow.Array) (*storage.InsertData, error) {
+	t.Helper()
+
+	filePath := writeFixedSizeListParquet(t, schema, fixedSizeList)
+	ctx := context.Background()
+	factory := storage.NewChunkManagerFactory("local", objectstorage.RootPath(testOutputPath))
+	cm, err := factory.NewPersistentStorageChunkManager(ctx)
+	require.NoError(t, err)
+
+	reader, err := NewReader(ctx, cm, schema, filePath, 64*1024*1024)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	return reader.Read()
+}
+
+func writeFixedSizeListParquet(t *testing.T, schema *schemapb.CollectionSchema, fixedSizeList arrow.Array) string {
+	t.Helper()
+
+	file, err := os.CreateTemp(t.TempDir(), "fixed_size_list_*.parquet")
+	require.NoError(t, err)
+	defer file.Close()
+
+	pk := int64Array(t, fixedSizeList.Len())
+	defer pk.Release()
+	defer fixedSizeList.Release()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "pk", Type: arrow.PrimitiveTypes.Int64},
+		{
+			Name:     schema.Fields[1].GetName(),
+			Type:     fixedSizeList.DataType(),
+			Nullable: true,
+		},
+	}, nil)
+	writer, err := pqarrow.NewFileWriter(
+		arrowSchema,
+		file,
+		parquet.NewWriterProperties(parquet.WithMaxRowGroupLength(int64(fixedSizeList.Len()))),
+		pqarrow.NewArrowWriterProperties(pqarrow.WithStoreSchema()),
+	)
+	require.NoError(t, err)
+
+	record := array.NewRecord(arrowSchema, []arrow.Array{pk, fixedSizeList}, int64(fixedSizeList.Len()))
+	defer record.Release()
+	require.NoError(t, writer.Write(record))
+	require.NoError(t, writer.Close())
+
+	assertFixedSizeListParquetSchema(t, file.Name(), schema.Fields[1].GetName())
+
+	return file.Name()
+}
+
+func assertFixedSizeListParquetSchema(t *testing.T, filePath string, columnName string) {
+	t.Helper()
+
+	rf, err := os.Open(filePath)
+	require.NoError(t, err)
+	defer rf.Close()
+
+	parquetReader, err := file.NewParquetReader(rf)
+	require.NoError(t, err)
+	defer parquetReader.Close()
+
+	arrowReader, err := pqarrow.NewFileReader(parquetReader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
+	require.NoError(t, err)
+
+	readSchema, err := arrowReader.Schema()
+	require.NoError(t, err)
+	fields, ok := readSchema.FieldsByName(columnName)
+	require.True(t, ok)
+	require.Len(t, fields, 1)
+	require.Equal(t, arrow.FIXED_SIZE_LIST, fields[0].Type.ID())
+}
+
+func fixedSizeListArraySchema(elementType schemapb.DataType, maxCapacity int, nullable bool) *schemapb.CollectionSchema {
+	typeParams := []*commonpb.KeyValuePair{
+		{Key: common.MaxCapacityKey, Value: fmt.Sprintf("%d", maxCapacity)},
+	}
+	if elementType == schemapb.DataType_VarChar || elementType == schemapb.DataType_String {
+		typeParams = append(typeParams, &commonpb.KeyValuePair{Key: common.MaxLengthKey, Value: "64"})
+	}
+
+	return fixedSizeListSchema(&schemapb.FieldSchema{
+		FieldID:     fixedSizeListDataFieldID,
+		Name:        "fsl_array",
+		DataType:    schemapb.DataType_Array,
+		ElementType: elementType,
+		TypeParams:  typeParams,
+		Nullable:    nullable,
+	})
+}
+
+func fixedSizeListFloatVectorSchema(dim int, nullable bool) *schemapb.CollectionSchema {
+	return fixedSizeListSchema(&schemapb.FieldSchema{
+		FieldID:  fixedSizeListDataFieldID,
+		Name:     "fsl_vector",
+		DataType: schemapb.DataType_FloatVector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.DimKey, Value: fmt.Sprintf("%d", dim)},
+		},
+		Nullable: nullable,
+	})
+}
+
+func fixedSizeListFloat16VectorSchema(dim int, nullable bool) *schemapb.CollectionSchema {
+	return fixedSizeListSchema(&schemapb.FieldSchema{
+		FieldID:  fixedSizeListDataFieldID,
+		Name:     "fsl_vector",
+		DataType: schemapb.DataType_Float16Vector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.DimKey, Value: fmt.Sprintf("%d", dim)},
+		},
+		Nullable: nullable,
+	})
+}
+
+func fixedSizeListSchema(field *schemapb.FieldSchema) *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      fixedSizeListPKFieldID,
+				Name:         "pk",
+				IsPrimaryKey: true,
+				DataType:     schemapb.DataType_Int64,
+			},
+			field,
+		},
+	}
+}
+
+func int64Array(t *testing.T, rows int) arrow.Array {
+	t.Helper()
+
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	defer builder.Release()
+	for i := 0; i < rows; i++ {
+		builder.Append(int64(i + 1))
+	}
+	return builder.NewArray()
+}
+
+func uint8ListArray(t *testing.T, rows [][]byte, withNullElement bool) arrow.Array {
+	t.Helper()
+
+	builder := array.NewListBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Uint8)
+	defer builder.Release()
+	valueBuilder := builder.ValueBuilder().(*array.Uint8Builder)
+	for _, row := range rows {
+		builder.Append(true)
+		for i, value := range row {
+			if withNullElement && i == 1 {
+				valueBuilder.AppendNull()
+				continue
+			}
+			valueBuilder.Append(value)
+		}
+	}
+	return builder.NewArray()
+}
+
+func fixedSizeUint8ListArray(t *testing.T, listSize int32, rows [][]byte) arrow.Array {
+	t.Helper()
+
+	builder := array.NewFixedSizeListBuilderWithField(memory.DefaultAllocator, listSize, arrow.Field{
+		Name:     "item",
+		Type:     arrow.PrimitiveTypes.Uint8,
+		Nullable: false,
+	})
+	defer builder.Release()
+	valueBuilder := builder.ValueBuilder().(*array.Uint8Builder)
+	validRows := make([]bool, len(rows))
+	for i := range validRows {
+		validRows[i] = true
+	}
+	builder.AppendValues(validRows)
+	for _, row := range rows {
+		require.Len(t, row, int(listSize))
+		for _, value := range row {
+			valueBuilder.Append(value)
+		}
+	}
+	return builder.NewArray()
+}
+
+func fixedSizeInt32ListArray(t *testing.T, listSize int32, rows []fixedSizeInt32Row) arrow.Array {
+	t.Helper()
+
+	return fixedSizeInt32ListArrayWithElementNullability(t, listSize, rows, false)
+}
+
+func fixedSizeInt32ListArrayWithNullableElements(t *testing.T, listSize int32, rows []fixedSizeInt32Row) arrow.Array {
+	t.Helper()
+
+	return fixedSizeInt32ListArrayWithElementNullability(t, listSize, rows, true)
+}
+
+func fixedSizeInt32ListArrayWithElementNullability(t *testing.T, listSize int32, rows []fixedSizeInt32Row, nullableElement bool) arrow.Array {
+	t.Helper()
+
+	builder := array.NewFixedSizeListBuilderWithField(memory.DefaultAllocator, listSize, arrow.Field{
+		Name:     "item",
+		Type:     arrow.PrimitiveTypes.Int32,
+		Nullable: nullableElement,
+	})
+	defer builder.Release()
+	valueBuilder := builder.ValueBuilder().(*array.Int32Builder)
+	validRows := make([]bool, 0, len(rows))
+	for _, row := range rows {
+		validRows = append(validRows, row.valid)
+	}
+	builder.AppendValues(validRows)
+	for _, row := range rows {
+		if row.valid {
+			require.Len(t, row.values, int(listSize))
+		}
+		for _, value := range row.values {
+			if value == nil {
+				require.True(t, nullableElement)
+				valueBuilder.AppendNull()
+				continue
+			}
+			valueBuilder.Append(*value)
+		}
+		for i := len(row.values); i < int(listSize); i++ {
+			valueBuilder.Append(0)
+		}
+	}
+	return builder.NewArray()
+}
+
+func fixedSizeStringListArray(t *testing.T, listSize int32, rows []fixedSizeStringRow) arrow.Array {
+	t.Helper()
+
+	builder := array.NewFixedSizeListBuilderWithField(memory.DefaultAllocator, listSize, arrow.Field{
+		Name:     "item",
+		Type:     arrow.BinaryTypes.String,
+		Nullable: false,
+	})
+	defer builder.Release()
+	valueBuilder := builder.ValueBuilder().(*array.StringBuilder)
+	validRows := make([]bool, 0, len(rows))
+	for _, row := range rows {
+		validRows = append(validRows, row.valid)
+	}
+	builder.AppendValues(validRows)
+	for _, row := range rows {
+		if row.valid {
+			require.Len(t, row.values, int(listSize))
+		}
+		for _, value := range row.values {
+			if value == nil {
+				require.Fail(t, "unexpected null string element")
+				continue
+			}
+			valueBuilder.Append(*value)
+		}
+		for i := len(row.values); i < int(listSize); i++ {
+			valueBuilder.Append("")
+		}
+	}
+	return builder.NewArray()
+}
+
+func fixedSizeFloat32ListArray(t *testing.T, listSize int32, rows []fixedSizeFloat32Row) arrow.Array {
+	t.Helper()
+
+	return fixedSizeFloat32ListArrayWithElementNullability(t, listSize, rows, false)
+}
+
+func fixedSizeFloat32ListArrayWithNullableElements(t *testing.T, listSize int32, rows []fixedSizeFloat32Row) arrow.Array {
+	t.Helper()
+
+	return fixedSizeFloat32ListArrayWithElementNullability(t, listSize, rows, true)
+}
+
+func fixedSizeFloat32ListArrayWithElementNullability(t *testing.T, listSize int32, rows []fixedSizeFloat32Row, nullableElement bool) arrow.Array {
+	t.Helper()
+
+	builder := array.NewFixedSizeListBuilderWithField(memory.DefaultAllocator, listSize, arrow.Field{
+		Name:     "item",
+		Type:     arrow.PrimitiveTypes.Float32,
+		Nullable: nullableElement,
+	})
+	defer builder.Release()
+	valueBuilder := builder.ValueBuilder().(*array.Float32Builder)
+	validRows := make([]bool, 0, len(rows))
+	for _, row := range rows {
+		validRows = append(validRows, row.valid)
+	}
+	builder.AppendValues(validRows)
+	for _, row := range rows {
+		if row.valid {
+			require.Len(t, row.values, int(listSize))
+		}
+		for _, value := range row.values {
+			if value == nil {
+				require.True(t, nullableElement)
+				valueBuilder.AppendNull()
+				continue
+			}
+			valueBuilder.Append(*value)
+		}
+		for i := len(row.values); i < int(listSize); i++ {
+			valueBuilder.Append(0)
+		}
+	}
+	return builder.NewArray()
+}
+
+func int32Ptrs(values ...int32) []*int32 {
+	ptrs := make([]*int32, 0, len(values))
+	for _, value := range values {
+		ptrs = append(ptrs, int32Ptr(value))
+	}
+	return ptrs
+}
+
+func int32Ptr(value int32) *int32 {
+	return &value
+}
+
+func stringPtrs(values ...string) []*string {
+	ptrs := make([]*string, 0, len(values))
+	for _, value := range values {
+		ptrs = append(ptrs, stringPtr(value))
+	}
+	return ptrs
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func float32Ptrs(values ...float32) []*float32 {
+	ptrs := make([]*float32, 0, len(values))
+	for _, value := range values {
+		ptrs = append(ptrs, float32Ptr(value))
+	}
+	return ptrs
+}
+
+func float32Ptr(value float32) *float32 {
+	return &value
+}

--- a/internal/util/importutilv2/parquet/list_like.go
+++ b/internal/util/importutilv2/parquet/list_like.go
@@ -1,0 +1,264 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parquet
+
+import (
+	"fmt"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"golang.org/x/exp/constraints"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+)
+
+type listLikeArray struct {
+	rows      int
+	values    arrow.Array
+	isNull    func(int) bool
+	rangeAt   func(int) (int64, int64)
+	fixedSize int32
+}
+
+func newListLikeArray(chunk arrow.Array, field *schemapb.FieldSchema) (*listLikeArray, error) {
+	switch list := chunk.(type) {
+	case *array.List:
+		return &listLikeArray{
+			rows:   list.Len(),
+			values: list.ListValues(),
+			isNull: list.IsNull,
+			rangeAt: func(i int) (int64, int64) {
+				start, end := list.ValueOffsets(i)
+				return start, end
+			},
+			fixedSize: -1,
+		}, nil
+	case *array.FixedSizeList:
+		fixedSize := list.DataType().(*arrow.FixedSizeListType).Len()
+		return &listLikeArray{
+			rows:      list.Len(),
+			values:    list.ListValues(),
+			isNull:    list.IsNull,
+			rangeAt:   list.ValueOffsets,
+			fixedSize: fixedSize,
+		}, nil
+	default:
+		return nil, WrapTypeErr(field, chunk.DataType().Name())
+	}
+}
+
+func (l *listLikeArray) Len() int {
+	return l.rows
+}
+
+func (l *listLikeArray) IsNull(i int) bool {
+	return l.isNull(i)
+}
+
+func (l *listLikeArray) ListValues() arrow.Array {
+	return l.values
+}
+
+func (l *listLikeArray) ValueOffsets(i int) (int64, int64) {
+	return l.rangeAt(i)
+}
+
+func (l *listLikeArray) FixedSize() (int32, bool) {
+	return l.fixedSize, l.fixedSize >= 0
+}
+
+func canBulkCopyUint8ListValues(listReader *listLikeArray, uint8Reader *array.Uint8) bool {
+	_, fixedSize := listReader.FixedSize()
+	return !fixedSize && uint8Reader.NullN() == 0
+}
+
+func getListLikeArrayData[T any](listReader *listLikeArray, getElement func(int) (T, error), outputArray func(arr []T, valid bool)) error {
+	_, fixedSize := listReader.FixedSize()
+	for i := 0; i < listReader.Len(); i++ {
+		if fixedSize && listReader.IsNull(i) {
+			outputArray(nil, false)
+			continue
+		}
+
+		start, end := listReader.ValueOffsets(i)
+		arrData := make([]T, 0, end-start)
+		for j := start; j < end; j++ {
+			elementVal, err := getElement(int(j))
+			if err != nil {
+				return err
+			}
+			arrData = append(arrData, elementVal)
+		}
+		valid := start != end
+		if fixedSize {
+			valid = !listReader.IsNull(i)
+		}
+		outputArray(arrData, valid)
+	}
+	return nil
+}
+
+func checkListLikeVectorAligned(listReader *listLikeArray, dim int, dataType schemapb.DataType) error {
+	if dataType == schemapb.DataType_SparseFloatVector {
+		return nil
+	}
+
+	if fixedSize, ok := listReader.FixedSize(); ok {
+		expected, err := expectedVectorListLength(dim, dataType)
+		if err != nil {
+			return err
+		}
+		return checkVectorAlignWithDim([]int32{0, fixedSize}, expected)
+	}
+
+	offsets := make([]int32, 0, listReader.Len()+1)
+	for i := 0; i < listReader.Len(); i++ {
+		start, _ := listReader.ValueOffsets(i)
+		offsets = append(offsets, int32(start))
+	}
+	if listReader.Len() > 0 {
+		_, end := listReader.ValueOffsets(listReader.Len() - 1)
+		offsets = append(offsets, int32(end))
+	} else {
+		offsets = append(offsets, 0)
+	}
+	return checkVectorAligned(offsets, dim, dataType)
+}
+
+func checkNullableListLikeVectorAligned(listReader *listLikeArray, dim int, dataType schemapb.DataType) error {
+	if dataType == schemapb.DataType_SparseFloatVector {
+		return nil
+	}
+
+	expected, err := expectedVectorListLength(dim, dataType)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < listReader.Len(); i++ {
+		if listReader.IsNull(i) {
+			continue
+		}
+		start, end := listReader.ValueOffsets(i)
+		if end-start != int64(expected) {
+			return checkVectorAlignWithDim([]int32{0, int32(end - start)}, expected)
+		}
+	}
+	return nil
+}
+
+func expectedVectorListLength(dim int, dataType schemapb.DataType) (int32, error) {
+	switch dataType {
+	case schemapb.DataType_BinaryVector:
+		return int32(dim / 8), nil
+	case schemapb.DataType_FloatVector:
+		return int32(dim), nil
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		return int32(dim * 2), nil
+	case schemapb.DataType_Int8Vector:
+		return int32(dim), nil
+	default:
+		return 0, fmt.Errorf("unexpected vector data type %s", dataType.String())
+	}
+}
+
+func readIntegerOrFloatListLikeData[T constraints.Integer | constraints.Float](field *schemapb.FieldSchema, listReader *listLikeArray, outputArray func(arr []T, valid bool)) error {
+	valueReader := listReader.ListValues()
+	switch valueReader.DataType().ID() {
+	case arrow.INT8:
+		int8Reader := valueReader.(*array.Int8)
+		return getListLikeArrayData(listReader, func(i int) (T, error) {
+			if int8Reader.IsNull(i) {
+				return 0, WrapNullElementErr(field)
+			}
+			return T(int8Reader.Value(i)), nil
+		}, outputArray)
+	case arrow.INT16:
+		int16Reader := valueReader.(*array.Int16)
+		return getListLikeArrayData(listReader, func(i int) (T, error) {
+			if int16Reader.IsNull(i) {
+				return 0, WrapNullElementErr(field)
+			}
+			return T(int16Reader.Value(i)), nil
+		}, outputArray)
+	case arrow.INT32:
+		int32Reader := valueReader.(*array.Int32)
+		return getListLikeArrayData(listReader, func(i int) (T, error) {
+			if int32Reader.IsNull(i) {
+				return 0, WrapNullElementErr(field)
+			}
+			return T(int32Reader.Value(i)), nil
+		}, outputArray)
+	case arrow.INT64:
+		int64Reader := valueReader.(*array.Int64)
+		return getListLikeArrayData(listReader, func(i int) (T, error) {
+			if int64Reader.IsNull(i) {
+				return 0, WrapNullElementErr(field)
+			}
+			return T(int64Reader.Value(i)), nil
+		}, outputArray)
+	case arrow.FLOAT32:
+		float32Reader := valueReader.(*array.Float32)
+		return getListLikeArrayData(listReader, func(i int) (T, error) {
+			if float32Reader.IsNull(i) {
+				return 0, WrapNullElementErr(field)
+			}
+			return T(float32Reader.Value(i)), nil
+		}, outputArray)
+	case arrow.FLOAT64:
+		float64Reader := valueReader.(*array.Float64)
+		return getListLikeArrayData(listReader, func(i int) (T, error) {
+			if float64Reader.IsNull(i) {
+				return 0, WrapNullElementErr(field)
+			}
+			return T(float64Reader.Value(i)), nil
+		}, outputArray)
+	default:
+		return WrapTypeErr(field, valueReader.DataType().Name())
+	}
+}
+
+func readBoolListLikeData(field *schemapb.FieldSchema, listReader *listLikeArray, outputArray func(arr []bool, valid bool)) error {
+	valueReader := listReader.ListValues()
+	boolReader, ok := valueReader.(*array.Boolean)
+	if !ok {
+		return WrapTypeErr(field, valueReader.DataType().Name())
+	}
+	return getListLikeArrayData(listReader, func(i int) (bool, error) {
+		if boolReader.IsNull(i) {
+			return false, WrapNullElementErr(field)
+		}
+		return boolReader.Value(i), nil
+	}, outputArray)
+}
+
+func readStringListLikeData(field *schemapb.FieldSchema, listReader *listLikeArray, checkValue func(string) error, outputArray func(arr []string, valid bool)) error {
+	valueReader := listReader.ListValues()
+	stringReader, ok := valueReader.(*array.String)
+	if !ok {
+		return WrapTypeErr(field, valueReader.DataType().Name())
+	}
+	return getListLikeArrayData(listReader, func(i int) (string, error) {
+		if stringReader.IsNull(i) {
+			return "", WrapNullElementErr(field)
+		}
+		val := stringReader.Value(i)
+		if err := checkValue(val); err != nil {
+			return val, err
+		}
+		return val, nil
+	}, outputArray)
+}

--- a/internal/util/importutilv2/parquet/util.go
+++ b/internal/util/importutilv2/parquet/util.go
@@ -246,7 +246,7 @@ func isArrowArithmeticType(dataType arrow.Type) bool {
 	return isArrowIntegerType(dataType) || isArrowFloatingType(dataType)
 }
 
-func isArrowDataTypeConvertible(src arrow.DataType, dst arrow.DataType, field *schemapb.FieldSchema) bool {
+func isArrowDataTypeConvertible(src arrow.DataType, dst arrow.DataType, field *schemapb.FieldSchema, allowFixedSizeList bool) bool {
 	srcType := src.ID()
 	dstType := dst.ID()
 	switch srcType {
@@ -273,7 +273,11 @@ func isArrowDataTypeConvertible(src arrow.DataType, dst arrow.DataType, field *s
 	case arrow.BINARY:
 		return dstType == arrow.LIST && dst.(*arrow.ListType).Elem().ID() == arrow.UINT8
 	case arrow.LIST:
-		return dstType == arrow.LIST && isArrowDataTypeConvertible(src.(*arrow.ListType).Elem(), dst.(*arrow.ListType).Elem(), field)
+		return dstType == arrow.LIST && isArrowDataTypeConvertible(src.(*arrow.ListType).Elem(), dst.(*arrow.ListType).Elem(), field, false)
+	case arrow.FIXED_SIZE_LIST:
+		return allowFixedSizeList && isFixedSizeListImportTarget(field) &&
+			dstType == arrow.LIST &&
+			isArrowDataTypeConvertible(src.(*arrow.FixedSizeListType).Elem(), dst.(*arrow.ListType).Elem(), field, false)
 	case arrow.NULL:
 		// if nullable==true or has set default_value, can use null type
 		return field.GetNullable() || field.GetDefaultValue() != nil
@@ -285,6 +289,34 @@ func isArrowDataTypeConvertible(src arrow.DataType, dst arrow.DataType, field *s
 		return false
 	case arrow.FIXED_SIZE_BINARY:
 		return dstType == arrow.FIXED_SIZE_BINARY
+	default:
+		return false
+	}
+}
+
+func isFixedSizeListImportTarget(field *schemapb.FieldSchema) bool {
+	switch field.GetDataType() {
+	case schemapb.DataType_Array:
+		switch field.GetElementType() {
+		case schemapb.DataType_Bool,
+			schemapb.DataType_Int8,
+			schemapb.DataType_Int16,
+			schemapb.DataType_Int32,
+			schemapb.DataType_Int64,
+			schemapb.DataType_Float,
+			schemapb.DataType_Double,
+			schemapb.DataType_VarChar,
+			schemapb.DataType_String:
+			return true
+		default:
+			return false
+		}
+	case schemapb.DataType_BinaryVector,
+		schemapb.DataType_FloatVector,
+		schemapb.DataType_Float16Vector,
+		schemapb.DataType_BFloat16Vector,
+		schemapb.DataType_Int8Vector:
+		return true
 	default:
 		return false
 	}
@@ -528,7 +560,7 @@ func isSchemaEqual(schema *schemapb.CollectionSchema, arrSchema *arrow.Schema) e
 		if err != nil {
 			return err
 		}
-		if !isArrowDataTypeConvertible(arrField.Type, toArrDataType, field) {
+		if !isArrowDataTypeConvertible(arrField.Type, toArrDataType, field, true) {
 			return merr.WrapErrImportFailed(fmt.Sprintf("field '%s' type mis-match, expect arrow type '%s', get arrow data type '%s'",
 				field.Name, toArrDataType.String(), arrField.Type.String()))
 		}
@@ -593,7 +625,7 @@ func isSchemaEqual(schema *schemapb.CollectionSchema, arrSchema *arrow.Schema) e
 			}
 
 			// Check if the arrow type is convertible to the expected type
-			if !isArrowDataTypeConvertible(arrowSubField.Type, expectedArrowType, subField) {
+			if !isArrowDataTypeConvertible(arrowSubField.Type, expectedArrowType, subField, false) {
 				return merr.WrapErrImportFailed(fmt.Sprintf("sub-field '%s' in struct '%s' type mis-match, expect arrow type '%s', got '%s'",
 					fieldName, structField.Name, expectedArrowType.String(), arrowSubField.Type.String()))
 			}

--- a/tests/integration/import/import_test.go
+++ b/tests/integration/import/import_test.go
@@ -18,6 +18,7 @@ package importv2
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -331,6 +332,140 @@ func (s *BulkInsertSuite) TestZeroRowCount() {
 	segments, err := c.ShowSegments(collectionName)
 	s.NoError(err)
 	s.Empty(segments)
+}
+
+func (s *BulkInsertSuite) TestImportFixedSizeListParquet() {
+	const (
+		rowCount  = 100
+		arraySize = 3
+		vectorDim = 4
+	)
+
+	c := s.Cluster
+	ctx, cancel := context.WithTimeout(c.GetContext(), 240*time.Second)
+	defer cancel()
+
+	collectionName := "TestBulkInsert_FixedSizeList_" + funcutil.RandomString(8)
+	arrayFieldName := "fsl_array"
+
+	schema := integration.ConstructSchema(collectionName, vectorDim, true,
+		&schemapb.FieldSchema{
+			FieldID:      100,
+			Name:         integration.Int64Field,
+			IsPrimaryKey: true,
+			DataType:     schemapb.DataType_Int64,
+			AutoID:       true,
+		},
+		&schemapb.FieldSchema{
+			FieldID:     101,
+			Name:        arrayFieldName,
+			DataType:    schemapb.DataType_Array,
+			ElementType: schemapb.DataType_Int32,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.MaxCapacityKey, Value: fmt.Sprintf("%d", arraySize)},
+			},
+		},
+		&schemapb.FieldSchema{
+			FieldID:  102,
+			Name:     integration.FloatVecField,
+			DataType: schemapb.DataType_FloatVector,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: fmt.Sprintf("%d", vectorDim)},
+			},
+		},
+	)
+	marshaledSchema, err := proto.Marshal(schema)
+	s.NoError(err)
+
+	createCollectionStatus, err := c.MilvusClient.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		CollectionName: collectionName,
+		Schema:         marshaledSchema,
+		ShardsNum:      common.DefaultShardsNum,
+	})
+	s.NoError(err)
+	s.Equal(commonpb.ErrorCode_Success, createCollectionStatus.GetErrorCode())
+
+	filePath, err := generateFixedSizeListParquetFile(c, arrayFieldName, integration.FloatVecField, rowCount, arraySize, vectorDim)
+	s.NoError(err)
+
+	importResp, err := c.ProxyClient.ImportV2(ctx, &internalpb.ImportRequest{
+		CollectionName: collectionName,
+		Files: []*internalpb.ImportFile{
+			{
+				Paths: []string{filePath},
+			},
+		},
+	})
+	s.NoError(err)
+	s.Equal(int32(0), importResp.GetStatus().GetCode())
+	s.NoError(WaitForImportDone(ctx, c, importResp.GetJobID()))
+
+	segments, err := c.ShowSegments(collectionName)
+	s.NoError(err)
+	s.NotEmpty(segments)
+	for _, segment := range segments {
+		s.NotEmpty(segment.GetBinlogs())
+		s.NoError(CheckLogID(segment.GetBinlogs()))
+		s.NotEmpty(segment.GetStatslogs())
+		s.NoError(CheckLogID(segment.GetStatslogs()))
+	}
+
+	createIndexStatus, err := c.MilvusClient.CreateIndex(ctx, &milvuspb.CreateIndexRequest{
+		CollectionName: collectionName,
+		FieldName:      integration.FloatVecField,
+		IndexName:      "_default",
+		ExtraParams:    integration.ConstructIndexParam(vectorDim, s.indexType, s.metricType),
+	})
+	s.NoError(err)
+	s.Equal(commonpb.ErrorCode_Success, createIndexStatus.GetErrorCode(), createIndexStatus.GetReason())
+	s.WaitForIndexBuilt(ctx, collectionName, integration.FloatVecField)
+
+	loadStatus, err := c.MilvusClient.LoadCollection(ctx, &milvuspb.LoadCollectionRequest{
+		CollectionName: collectionName,
+	})
+	s.NoError(err)
+	s.Equal(commonpb.ErrorCode_Success, loadStatus.GetErrorCode(), loadStatus.GetReason())
+	s.WaitForLoad(ctx, collectionName)
+
+	queryResult, err := c.MilvusClient.Query(ctx, &milvuspb.QueryRequest{
+		CollectionName:   collectionName,
+		Expr:             fmt.Sprintf("%s >= 0", integration.Int64Field),
+		OutputFields:     []string{arrayFieldName, integration.FloatVecField},
+		ConsistencyLevel: commonpb.ConsistencyLevel_Strong,
+	})
+	s.NoError(err)
+	s.Equal(commonpb.ErrorCode_Success, queryResult.GetStatus().GetErrorCode(), queryResult.GetStatus().GetReason())
+
+	var arrayData []*schemapb.ScalarField
+	var vectorData []float32
+	for _, fieldData := range queryResult.GetFieldsData() {
+		switch fieldData.GetFieldName() {
+		case arrayFieldName:
+			arrayData = fieldData.GetScalars().GetArrayData().GetData()
+		case integration.FloatVecField:
+			vectorData = fieldData.GetVectors().GetFloatVector().GetData()
+		}
+	}
+	s.Len(arrayData, rowCount)
+	s.Len(vectorData, rowCount*vectorDim)
+
+	seenRows := make(map[int32]struct{}, rowCount)
+	for i, row := range arrayData {
+		values := row.GetIntData().GetData()
+		s.Len(values, arraySize)
+		expectedRow := values[0]
+		s.EqualValues([]int32{expectedRow, expectedRow + 1, expectedRow + 2}, values)
+		s.Equal(float32(int(expectedRow)*vectorDim), vectorData[i*vectorDim])
+		for col := 1; col < vectorDim; col++ {
+			s.Equal(vectorData[i*vectorDim]+float32(col), vectorData[i*vectorDim+col])
+		}
+		seenRows[expectedRow] = struct{}{}
+	}
+	s.Len(seenRows, rowCount)
+	for row := 0; row < rowCount; row++ {
+		_, ok := seenRows[int32(row)]
+		s.True(ok)
+	}
 }
 
 func (s *BulkInsertSuite) TestDiskQuotaExceeded() {

--- a/tests/integration/import/util_test.go
+++ b/tests/integration/import/util_test.go
@@ -26,7 +26,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/apache/arrow/go/v17/parquet"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
 	"github.com/cockroachdb/errors"
@@ -105,6 +107,98 @@ func searilizeParquetFile(schema *schemapb.CollectionSchema, insertData *storage
 		return nil, err
 	}
 	return buf, nil
+}
+
+func generateFixedSizeListParquetFile(
+	c *cluster.MiniClusterV3,
+	arrayFieldName string,
+	vectorFieldName string,
+	rowCount int,
+	arraySize int,
+	vectorDim int,
+) (string, error) {
+	mem := memory.NewGoAllocator()
+	int32List := buildFixedSizeInt32List(mem, int32(arraySize), rowCount)
+	defer int32List.Release()
+	float32List := buildFixedSizeFloat32List(mem, int32(vectorDim), rowCount)
+	defer float32List.Release()
+
+	pqSchema := arrow.NewSchema([]arrow.Field{
+		{Name: arrayFieldName, Type: int32List.DataType(), Nullable: false},
+		{Name: vectorFieldName, Type: float32List.DataType(), Nullable: false},
+	}, nil)
+
+	buf := bytes.NewBuffer(make([]byte, 0, 10240))
+	fw, err := pqarrow.NewFileWriter(
+		pqSchema,
+		buf,
+		parquet.NewWriterProperties(parquet.WithMaxRowGroupLength(int64(rowCount))),
+		pqarrow.NewArrowWriterProperties(pqarrow.WithStoreSchema()),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	recordBatch := array.NewRecord(pqSchema, []arrow.Array{int32List, float32List}, int64(rowCount))
+	defer recordBatch.Release()
+	if err := fw.Write(recordBatch); err != nil {
+		return "", err
+	}
+	if err := fw.Close(); err != nil {
+		return "", err
+	}
+
+	filePath := path.Join(c.RootPath(), "parquet", uuid.New().String()+".parquet")
+	if err := c.ChunkManager.Write(context.Background(), filePath, buf.Bytes()); err != nil {
+		return "", err
+	}
+	return filePath, nil
+}
+
+func buildFixedSizeInt32List(mem memory.Allocator, listSize int32, rowCount int) arrow.Array {
+	builder := array.NewFixedSizeListBuilderWithField(mem, listSize, arrow.Field{
+		Name:     "item",
+		Type:     arrow.PrimitiveTypes.Int32,
+		Nullable: false,
+	})
+	defer builder.Release()
+
+	validRows := make([]bool, rowCount)
+	for i := range validRows {
+		validRows[i] = true
+	}
+	builder.AppendValues(validRows)
+
+	valueBuilder := builder.ValueBuilder().(*array.Int32Builder)
+	for row := 0; row < rowCount; row++ {
+		for col := 0; col < int(listSize); col++ {
+			valueBuilder.Append(int32(row + col))
+		}
+	}
+	return builder.NewArray()
+}
+
+func buildFixedSizeFloat32List(mem memory.Allocator, listSize int32, rowCount int) arrow.Array {
+	builder := array.NewFixedSizeListBuilderWithField(mem, listSize, arrow.Field{
+		Name:     "item",
+		Type:     arrow.PrimitiveTypes.Float32,
+		Nullable: false,
+	})
+	defer builder.Release()
+
+	validRows := make([]bool, rowCount)
+	for i := range validRows {
+		validRows[i] = true
+	}
+	builder.AppendValues(validRows)
+
+	valueBuilder := builder.ValueBuilder().(*array.Float32Builder)
+	for row := 0; row < rowCount; row++ {
+		for col := 0; col < int(listSize); col++ {
+			valueBuilder.Append(float32(row*int(listSize) + col))
+		}
+	}
+	return builder.NewArray()
 }
 
 func GenerateNumpyFiles(c *cluster.MiniClusterV3, schema *schemapb.CollectionSchema, rowCount int) (*internalpb.ImportFile, error) {


### PR DESCRIPTION
Cherry-pick from master

pr: #49683
issue: #49682

## Summary

Cherry-picked from master PR #49683 (merged).

**2.6 scope adjustment**: Nullable-vector code paths were dropped because 2.6 reverted nullable-vector support in #49838. Only the FixedSizeList enhancement for non-nullable scalar array and dense vector fields lands on 2.6.

## Verification

- [x] File count matches original PR (6 files)
- [x] Per-file diff verified — only intentional deltas: v3→v2 import paths and dropped nullable-vector functions
- [x] No conflict markers
- [x] `go vet ./internal/util/importutilv2/parquet ./tests/integration/import` passes
- [ ] make static-check (skipped by cherry-pick workflow)