### PR TITLE
enhance: add retry for s3 flush stream transient error

### DIFF
--- a/internal/core/src/storage/RemoteInputStream.cpp
+++ b/internal/core/src/storage/RemoteInputStream.cpp
@@ -1,9 +1,11 @@
 #include <unistd.h>
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 #include "log/Log.h"
@@ -18,7 +20,7 @@
 namespace milvus::storage {
 namespace {
 
-constexpr int kRemoteInputStreamMaxReadRetries = 2;
+constexpr int kRemoteInputStreamMaxReadRetries = 5;
 constexpr const char* kFailedFlushResponseStreamError =
     "Failed to flush response stream";
 
@@ -39,20 +41,24 @@ ReadWithRetry(const char* operation,
               ResetFunc&& reset_func) {
     auto result = read_func();
     int retries = 0;
+    int64_t sleep_ms = 1;
     for (int retry = 1; !result.ok() && IsRetryableReadError(result.status()) &&
                         retry <= kRemoteInputStreamMaxReadRetries;
          ++retry) {
         retries = retry;
         LOG_WARN(
             "Failed to {} from remote input stream, retry {}/{}, size: {}, "
-            "file size: {}, offset: {}, error is: {}",
+            "file size: {}, offset: {}, error is: {}, sleep {} ms before retry",
             operation,
             retry,
             kRemoteInputStreamMaxReadRetries,
             size,
             file_size,
             offset,
-            result.status().ToString());
+            result.status().ToString(),
+            sleep_ms);
+        std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
+        sleep_ms *= 2;
         auto reset_status = reset_func();
         if (!reset_status.ok()) {
             auto read_status = result.status();

--- a/internal/core/src/storage/RemoteInputStream.cpp
+++ b/internal/core/src/storage/RemoteInputStream.cpp
@@ -1,5 +1,6 @@
 #include <unistd.h>
 #include <algorithm>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -33,26 +34,63 @@ arrow::Result<int64_t>
 ReadWithRetry(const char* operation,
               size_t size,
               size_t file_size,
+              size_t offset,
               ReadFunc&& read_func,
               ResetFunc&& reset_func) {
     auto result = read_func();
+    int retries = 0;
     for (int retry = 1; !result.ok() && IsRetryableReadError(result.status()) &&
                         retry <= kRemoteInputStreamMaxReadRetries;
          ++retry) {
+        retries = retry;
         LOG_WARN(
             "Failed to {} from remote input stream, retry {}/{}, size: {}, "
-            "file size: {}, error is: {}",
+            "file size: {}, offset: {}, error is: {}",
             operation,
             retry,
             kRemoteInputStreamMaxReadRetries,
             size,
             file_size,
+            offset,
             result.status().ToString());
         auto reset_status = reset_func();
         if (!reset_status.ok()) {
-            return reset_status;
+            auto read_status = result.status();
+            LOG_WARN(
+                "Failed to reset remote input stream before retrying {}, "
+                "size: {}, file size: {}, offset: {}, original error is: {}, "
+                "current error is: {}",
+                operation,
+                size,
+                file_size,
+                offset,
+                read_status.ToString(),
+                reset_status.ToString());
+            return reset_status.WithMessage(
+                "Failed to reset remote input stream before retrying ",
+                operation,
+                ", size: ",
+                std::to_string(size),
+                ", file size: ",
+                std::to_string(file_size),
+                ", offset: ",
+                std::to_string(offset),
+                ", original error is: ",
+                read_status.ToString(),
+                ", current error is: ",
+                reset_status.ToString());
         }
         result = read_func();
+    }
+    if (result.ok() && retries > 0) {
+        LOG_INFO(
+            "Succeeded to {} from remote input stream after {} retries, size: "
+            "{}, file size: {}, offset: {}",
+            operation,
+            retries,
+            size,
+            file_size,
+            offset);
     }
     return result;
 }
@@ -74,13 +112,17 @@ RemoteInputStream::Read(void* data, size_t size) {
         "read",
         size,
         file_size_,
+        offset,
         [this, size, data]() { return remote_file_->Read(size, data); },
         [this, offset]() { return remote_file_->Seek(offset); });
     AssertInfo(
         status.ok(),
-        "Failed to read from remote input stream, size: {}, file size: {}",
+        "Failed to read from remote input stream, operation: read, offset: {}, "
+        "size: {}, file size: {}, error: {}",
+        offset,
         size,
-        file_size_);
+        file_size_,
+        status.status().ToString());
     return static_cast<size_t>(status.ValueOrDie());
 }
 
@@ -90,11 +132,18 @@ RemoteInputStream::ReadAt(void* data, size_t offset, size_t size) {
         "read at offset",
         size,
         file_size_,
+        offset,
         [this, offset, size, data]() {
             return remote_file_->ReadAt(offset, size, data);
         },
         []() { return arrow::Status::OK(); });
-    AssertInfo(status.ok(), "Failed to read from input stream");
+    AssertInfo(status.ok(),
+               "Failed to read from remote input stream, operation: read at "
+               "offset, offset: {}, size: {}, file size: {}, error: {}",
+               offset,
+               size,
+               file_size_,
+               status.status().ToString());
     return static_cast<size_t>(status.ValueOrDie());
 }
 
@@ -112,17 +161,44 @@ RemoteInputStream::Read(int fd, size_t size) {
             "read to file",
             read_size,
             file_size_,
+            offset,
             [this, read_size, &data]() {
                 return remote_file_->Read(read_size, data.data());
             },
             [this, offset]() { return remote_file_->Seek(offset); });
-        AssertInfo(status.ok(), "Failed to read from input stream");
-        ssize_t ret = ::write(fd, data.data(), read_size);
-        AssertInfo(ret == static_cast<ssize_t>(read_size),
+        AssertInfo(status.ok(),
+                   "Failed to read from remote input stream, operation: read "
+                   "to file, offset: {}, size: {}, rest size: {}, file size: "
+                   "{}, error: {}",
+                   offset,
+                   read_size,
+                   rest_size,
+                   file_size_,
+                   status.status().ToString());
+        auto bytes_read = status.ValueOrDie();
+        AssertInfo(bytes_read > 0,
+                   "Failed to read from remote input stream, operation: read "
+                   "to file, offset: {}, read zero bytes, rest size: {}, file "
+                   "size: {}",
+                   offset,
+                   rest_size,
+                   file_size_);
+        AssertInfo(bytes_read <= static_cast<int64_t>(read_size),
+                   "Remote input stream returned more bytes than requested, "
+                   "operation: read to file, offset: {}, bytes read: {}, "
+                   "size: {}, file size: {}",
+                   offset,
+                   bytes_read,
+                   read_size,
+                   file_size_);
+        auto bytes_to_write = static_cast<size_t>(bytes_read);
+        ssize_t ret = ::write(fd, data.data(), bytes_to_write);
+        AssertInfo(ret == static_cast<ssize_t>(bytes_to_write),
                    "Failed to write to file");
-        rest_size -= read_size;
+        rest_size -= bytes_to_write;
     }
-    ::fsync(fd);
+    auto fsync_ret = ::fsync(fd);
+    AssertInfo(fsync_ret == 0, "Failed to fsync file, errno: {}", errno);
     return size;
 }
 

--- a/internal/core/src/storage/RemoteInputStream.cpp
+++ b/internal/core/src/storage/RemoteInputStream.cpp
@@ -21,18 +21,20 @@ constexpr int kRemoteInputStreamMaxReadRetries = 2;
 constexpr const char* kFailedFlushResponseStreamError =
     "Failed to flush response stream";
 
+// currently only retry failed flush response stream error
 bool
 IsRetryableReadError(const arrow::Status& status) {
     return status.ToString().find(kFailedFlushResponseStreamError) !=
            std::string::npos;
 }
 
-template <typename ReadFunc>
+template <typename ReadFunc, typename ResetFunc>
 arrow::Result<int64_t>
 ReadWithRetry(const char* operation,
               size_t size,
               size_t file_size,
-              ReadFunc&& read_func) {
+              ReadFunc&& read_func,
+              ResetFunc&& reset_func) {
     auto result = read_func();
     for (int retry = 1; !result.ok() && IsRetryableReadError(result.status()) &&
                         retry <= kRemoteInputStreamMaxReadRetries;
@@ -46,6 +48,10 @@ ReadWithRetry(const char* operation,
             size,
             file_size,
             result.status().ToString());
+        auto reset_status = reset_func();
+        if (!reset_status.ok()) {
+            return reset_status;
+        }
         result = read_func();
     }
     return result;
@@ -63,9 +69,13 @@ RemoteInputStream::RemoteInputStream(
 
 size_t
 RemoteInputStream::Read(void* data, size_t size) {
-    auto status = ReadWithRetry("read", size, file_size_, [this, size, data]() {
-        return remote_file_->Read(size, data);
-    });
+    auto offset = static_cast<int64_t>(Tell());
+    auto status = ReadWithRetry(
+        "read",
+        size,
+        file_size_,
+        [this, size, data]() { return remote_file_->Read(size, data); },
+        [this, offset]() { return remote_file_->Seek(offset); });
     AssertInfo(
         status.ok(),
         "Failed to read from remote input stream, size: {}, file size: {}",
@@ -77,9 +87,13 @@ RemoteInputStream::Read(void* data, size_t size) {
 size_t
 RemoteInputStream::ReadAt(void* data, size_t offset, size_t size) {
     auto status = ReadWithRetry(
-        "read at offset", size, file_size_, [this, offset, size, data]() {
+        "read at offset",
+        size,
+        file_size_,
+        [this, offset, size, data]() {
             return remote_file_->ReadAt(offset, size, data);
-        });
+        },
+        []() { return arrow::Status::OK(); });
     AssertInfo(status.ok(), "Failed to read from input stream");
     return static_cast<size_t>(status.ValueOrDie());
 }
@@ -93,10 +107,15 @@ RemoteInputStream::Read(int fd, size_t size) {
 
     while (rest_size > 0) {
         size_t read_size = std::min(rest_size, read_batch_size);
+        auto offset = static_cast<int64_t>(Tell());
         auto status = ReadWithRetry(
-            "read to file", read_size, file_size_, [this, read_size, &data]() {
+            "read to file",
+            read_size,
+            file_size_,
+            [this, read_size, &data]() {
                 return remote_file_->Read(read_size, data.data());
-            });
+            },
+            [this, offset]() { return remote_file_->Seek(offset); });
         AssertInfo(status.ok(), "Failed to read from input stream");
         ssize_t ret = ::write(fd, data.data(), read_size);
         AssertInfo(ret == static_cast<ssize_t>(read_size),

--- a/internal/core/src/storage/RemoteInputStream.cpp
+++ b/internal/core/src/storage/RemoteInputStream.cpp
@@ -198,7 +198,8 @@ RemoteInputStream::Read(int fd, size_t size) {
         rest_size -= bytes_to_write;
     }
     auto fsync_ret = ::fsync(fd);
-    AssertInfo(fsync_ret == 0, "Failed to fsync file, errno: {}", errno);
+    int saved_errno = errno;
+    AssertInfo(fsync_ret == 0, "Failed to fsync file, errno: {}", saved_errno);
     return size;
 }
 

--- a/internal/core/src/storage/RemoteInputStream.cpp
+++ b/internal/core/src/storage/RemoteInputStream.cpp
@@ -2,8 +2,10 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <utility>
 #include <vector>
+#include "log/Log.h"
 
 #include "RemoteInputStream.h"
 #include "arrow/io/interfaces.h"
@@ -13,6 +15,43 @@
 #include "common/EasyAssert.h"
 
 namespace milvus::storage {
+namespace {
+
+constexpr int kRemoteInputStreamMaxReadRetries = 2;
+constexpr const char* kFailedFlushResponseStreamError =
+    "Failed to flush response stream";
+
+bool
+IsRetryableReadError(const arrow::Status& status) {
+    return status.ToString().find(kFailedFlushResponseStreamError) !=
+           std::string::npos;
+}
+
+template <typename ReadFunc>
+arrow::Result<int64_t>
+ReadWithRetry(const char* operation,
+              size_t size,
+              size_t file_size,
+              ReadFunc&& read_func) {
+    auto result = read_func();
+    for (int retry = 1; !result.ok() && IsRetryableReadError(result.status()) &&
+                        retry <= kRemoteInputStreamMaxReadRetries;
+         ++retry) {
+        LOG_WARN(
+            "Failed to {} from remote input stream, retry {}/{}, size: {}, "
+            "file size: {}, error is: {}",
+            operation,
+            retry,
+            kRemoteInputStreamMaxReadRetries,
+            size,
+            file_size,
+            result.status().ToString());
+        result = read_func();
+    }
+    return result;
+}
+
+}  // namespace
 
 RemoteInputStream::RemoteInputStream(
     std::shared_ptr<arrow::io::RandomAccessFile>&& remote_file)
@@ -24,14 +63,23 @@ RemoteInputStream::RemoteInputStream(
 
 size_t
 RemoteInputStream::Read(void* data, size_t size) {
-    auto status = remote_file_->Read(size, data);
-    AssertInfo(status.ok(), "Failed to read from input stream");
+    auto status = ReadWithRetry("read", size, file_size_, [this, size, data]() {
+        return remote_file_->Read(size, data);
+    });
+    AssertInfo(
+        status.ok(),
+        "Failed to read from remote input stream, size: {}, file size: {}",
+        size,
+        file_size_);
     return static_cast<size_t>(status.ValueOrDie());
 }
 
 size_t
 RemoteInputStream::ReadAt(void* data, size_t offset, size_t size) {
-    auto status = remote_file_->ReadAt(offset, size, data);
+    auto status = ReadWithRetry(
+        "read at offset", size, file_size_, [this, offset, size, data]() {
+            return remote_file_->ReadAt(offset, size, data);
+        });
     AssertInfo(status.ok(), "Failed to read from input stream");
     return static_cast<size_t>(status.ValueOrDie());
 }
@@ -45,7 +93,10 @@ RemoteInputStream::Read(int fd, size_t size) {
 
     while (rest_size > 0) {
         size_t read_size = std::min(rest_size, read_batch_size);
-        auto status = remote_file_->Read(read_size, data.data());
+        auto status = ReadWithRetry(
+            "read to file", read_size, file_size_, [this, read_size, &data]() {
+                return remote_file_->Read(read_size, data.data());
+            });
         AssertInfo(status.ok(), "Failed to read from input stream");
         ssize_t ret = ::write(fd, data.data(), read_size);
         AssertInfo(ret == static_cast<ssize_t>(read_size),

--- a/internal/core/src/storage/RemoteInputStreamTest.cpp
+++ b/internal/core/src/storage/RemoteInputStreamTest.cpp
@@ -1,0 +1,439 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <arrow/buffer.h>
+#include <arrow/io/interfaces.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "storage/RemoteInputStream.h"
+
+namespace milvus::storage {
+namespace {
+
+struct ReadOutcome {
+    arrow::Status status;
+    int64_t bytes_read;
+    bool advance_position_on_error = false;
+    std::string data;
+    int64_t expected_zeroed_bytes = -1;
+};
+
+class FailingRandomAccessFile : public arrow::io::RandomAccessFile {
+ public:
+    explicit FailingRandomAccessFile(
+        std::vector<ReadOutcome> read_outcomes,
+        std::string content = "abcdefghijklmnop",
+        std::vector<arrow::Status> seek_outcomes = {})
+        : read_outcomes_(std::move(read_outcomes)),
+          content_(std::move(content)),
+          seek_outcomes_(std::move(seek_outcomes)) {
+    }
+
+    arrow::Status
+    Close() override {
+        closed_ = true;
+        return arrow::Status::OK();
+    }
+
+    arrow::Result<int64_t>
+    Tell() const override {
+        return position_;
+    }
+
+    bool
+    closed() const override {
+        return closed_;
+    }
+
+    arrow::Status
+    Seek(int64_t position) override {
+        seek_positions_.push_back(position);
+        if (next_seek_outcome_ < seek_outcomes_.size()) {
+            auto outcome = seek_outcomes_[next_seek_outcome_++];
+            if (!outcome.ok()) {
+                return outcome;
+            }
+        }
+        position_ = position;
+        return arrow::Status::OK();
+    }
+
+    arrow::Result<int64_t>
+    Read(int64_t nbytes, void* out) override {
+        ++read_calls_;
+        if (next_outcome_ < read_outcomes_.size()) {
+            auto outcome = read_outcomes_[next_outcome_++];
+            auto status =
+                ValidateZeroedBuffer(outcome.expected_zeroed_bytes, out);
+            if (!status.ok()) {
+                return status;
+            }
+            if (!outcome.status.ok()) {
+                FillBuffer(outcome.bytes_read, out, outcome.data);
+                if (outcome.advance_position_on_error) {
+                    position_ += outcome.bytes_read;
+                }
+                return outcome.status;
+            }
+            return ReadOk(outcome.bytes_read, out, outcome.data);
+        }
+
+        return ReadOk(nbytes, out);
+    }
+
+    arrow::Result<std::shared_ptr<arrow::Buffer>>
+    Read(int64_t) override {
+        return arrow::Status::NotImplemented("buffer reads are not needed");
+    }
+
+    arrow::Result<int64_t>
+    ReadAt(int64_t position, int64_t nbytes, void* out) override {
+        position_ = position;
+        return Read(nbytes, out);
+    }
+
+    arrow::Result<int64_t>
+    GetSize() override {
+        return static_cast<int64_t>(content_.size());
+    }
+
+    int
+    read_calls() const {
+        return read_calls_;
+    }
+
+    const std::vector<int64_t>&
+    seek_positions() const {
+        return seek_positions_;
+    }
+
+ private:
+    arrow::Result<int64_t>
+    ReadOk(int64_t nbytes, void* out, const std::string& override_data = "") {
+        FillBuffer(nbytes, out, override_data);
+        position_ += nbytes;
+        return nbytes;
+    }
+
+    void
+    FillBuffer(int64_t nbytes,
+               void* out,
+               const std::string& override_data = "") const {
+        auto* out_data = static_cast<uint8_t*>(out);
+        for (int64_t i = 0; i < nbytes; ++i) {
+            out_data[i] = static_cast<uint8_t>(
+                override_data.empty()
+                    ? content_[static_cast<size_t>(position_ + i) %
+                               content_.size()]
+                    : override_data[static_cast<size_t>(i) %
+                                    override_data.size()]);
+        }
+    }
+
+    arrow::Status
+    ValidateZeroedBuffer(int64_t nbytes, void* out) const {
+        if (nbytes < 0) {
+            return arrow::Status::OK();
+        }
+        auto* out_data = static_cast<const uint8_t*>(out);
+        for (int64_t i = 0; i < nbytes; ++i) {
+            if (out_data[i] != 0) {
+                return arrow::Status::Invalid(
+                    "buffer was not cleared before read");
+            }
+        }
+        return arrow::Status::OK();
+    }
+
+    std::vector<ReadOutcome> read_outcomes_;
+    std::string content_;
+    std::vector<arrow::Status> seek_outcomes_;
+    std::vector<int64_t> seek_positions_;
+    size_t next_outcome_ = 0;
+    size_t next_seek_outcome_ = 0;
+    int64_t position_ = 0;
+    int read_calls_ = 0;
+    bool closed_ = false;
+};
+
+class TempFile {
+ public:
+    TempFile() {
+        fd_ = ::mkstemp(path_);
+    }
+
+    ~TempFile() {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+        ::unlink(path_);
+    }
+
+    int
+    fd() const {
+        return fd_;
+    }
+
+ private:
+    char path_[48] = "/tmp/milvus_remote_input_stream_test_XXXXXX";
+    int fd_ = -1;
+};
+
+class PipeFile {
+ public:
+    PipeFile() {
+        if (::pipe(fds_) != 0) {
+            fds_[0] = -1;
+            fds_[1] = -1;
+        }
+    }
+
+    ~PipeFile() {
+        if (fds_[0] >= 0) {
+            ::close(fds_[0]);
+        }
+        if (fds_[1] >= 0) {
+            ::close(fds_[1]);
+        }
+    }
+
+    int
+    write_fd() const {
+        return fds_[1];
+    }
+
+ private:
+    int fds_[2] = {-1, -1};
+};
+
+arrow::Status
+InternalFailedFlushStatus() {
+    return arrow::Status::IOError(
+        "google::cloud::Status(INTERNAL: Failed to flush response stream)");
+}
+
+arrow::Status
+UnavailableFailedFlushStatus() {
+    return arrow::Status::IOError(
+        "google::cloud::Status(UNAVAILABLE: Failed to flush response stream)");
+}
+
+arrow::Status
+InternalDifferentStatus() {
+    return arrow::Status::IOError(
+        "google::cloud::Status(INTERNAL: connection reset)");
+}
+
+arrow::Status
+SeekResetStatus() {
+    return arrow::Status::IOError("seek reset failed");
+}
+
+TEST(RemoteInputStreamTest, RetriesInternalFailedFlushError) {
+    auto file =
+        std::make_shared<FailingRandomAccessFile>(std::vector<ReadOutcome>{
+            {InternalFailedFlushStatus(), 0}, {arrow::Status::OK(), 4}});
+    auto* file_ptr = file.get();
+    RemoteInputStream stream(std::move(file));
+
+    std::vector<uint8_t> data(4);
+    EXPECT_EQ(stream.Read(data.data(), data.size()), data.size());
+    EXPECT_EQ(file_ptr->read_calls(), 2);
+}
+
+TEST(RemoteInputStreamTest, RetriesFailedFlushWithoutInternalError) {
+    auto file =
+        std::make_shared<FailingRandomAccessFile>(std::vector<ReadOutcome>{
+            {UnavailableFailedFlushStatus(), 0}, {arrow::Status::OK(), 4}});
+    auto* file_ptr = file.get();
+    RemoteInputStream stream(std::move(file));
+
+    std::vector<uint8_t> data(4);
+    EXPECT_EQ(stream.Read(data.data(), data.size()), data.size());
+    EXPECT_EQ(file_ptr->read_calls(), 2);
+}
+
+TEST(RemoteInputStreamTest, RestoresPositionBeforeRetryingSequentialRead) {
+    auto file =
+        std::make_shared<FailingRandomAccessFile>(std::vector<ReadOutcome>{
+            {InternalFailedFlushStatus(), 2, true}, {arrow::Status::OK(), 4}});
+    auto* file_ptr = file.get();
+    RemoteInputStream stream(std::move(file));
+
+    std::vector<uint8_t> data(4);
+    EXPECT_EQ(stream.Read(data.data(), data.size()), data.size());
+    EXPECT_EQ(std::string(data.begin(), data.end()), "abcd");
+    EXPECT_EQ(stream.Tell(), 4);
+    EXPECT_EQ(file_ptr->read_calls(), 2);
+    EXPECT_EQ(file_ptr->seek_positions(), (std::vector<int64_t>{0}));
+}
+
+TEST(RemoteInputStreamTest, SeeksBackToOriginalOffsetBeforeRetryingRead) {
+    auto file =
+        std::make_shared<FailingRandomAccessFile>(std::vector<ReadOutcome>{
+            {InternalFailedFlushStatus(), 2, true}, {arrow::Status::OK(), 4}});
+    auto* file_ptr = file.get();
+    RemoteInputStream stream(std::move(file));
+    ASSERT_TRUE(stream.Seek(5));
+
+    std::vector<uint8_t> data(4);
+    EXPECT_EQ(stream.Read(data.data(), data.size()), data.size());
+    EXPECT_EQ(std::string(data.begin(), data.end()), "fghi");
+    EXPECT_EQ(stream.Tell(), 9);
+    EXPECT_EQ(file_ptr->read_calls(), 2);
+    EXPECT_EQ(file_ptr->seek_positions(), (std::vector<int64_t>{5, 5}));
+}
+
+TEST(RemoteInputStreamTest, RestoresPositionBeforeRetryingReadToFile) {
+    auto file =
+        std::make_shared<FailingRandomAccessFile>(std::vector<ReadOutcome>{
+            {InternalFailedFlushStatus(), 2, true}, {arrow::Status::OK(), 4}});
+    auto* file_ptr = file.get();
+    RemoteInputStream stream(std::move(file));
+    TempFile temp_file;
+    ASSERT_GE(temp_file.fd(), 0);
+
+    EXPECT_EQ(stream.Read(temp_file.fd(), 4), 4);
+    ASSERT_EQ(::lseek(temp_file.fd(), 0, SEEK_SET), 0);
+
+    std::array<char, 4> data{};
+    ASSERT_EQ(::read(temp_file.fd(), data.data(), data.size()),
+              static_cast<ssize_t>(data.size()));
+    EXPECT_EQ(std::string(data.data(), data.size()), "abcd");
+    EXPECT_EQ(stream.Tell(), 4);
+    EXPECT_EQ(file_ptr->read_calls(), 2);
+    EXPECT_EQ(file_ptr->seek_positions(), (std::vector<int64_t>{0}));
+}
+
+TEST(RemoteInputStreamTest, WritesOnlyActualBytesReadAfterRetryingReadToFile) {
+    auto file =
+        std::make_shared<FailingRandomAccessFile>(std::vector<ReadOutcome>{
+            {InternalFailedFlushStatus(), 4, false, "zzzz"},
+            {arrow::Status::OK(), 2, false, "", 4},
+            {arrow::Status::OK(), 2}});
+    auto* file_ptr = file.get();
+    RemoteInputStream stream(std::move(file));
+    TempFile temp_file;
+    ASSERT_GE(temp_file.fd(), 0);
+
+    EXPECT_EQ(stream.Read(temp_file.fd(), 4), 4);
+    ASSERT_EQ(::lseek(temp_file.fd(), 0, SEEK_SET), 0);
+
+    std::array<char, 4> data{};
+    ASSERT_EQ(::read(temp_file.fd(), data.data(), data.size()),
+              static_cast<ssize_t>(data.size()));
+    EXPECT_EQ(std::string(data.data(), data.size()), "abcd");
+    EXPECT_EQ(stream.Tell(), 4);
+    EXPECT_EQ(file_ptr->read_calls(), 3);
+}
+
+TEST(RemoteInputStreamTest, ThrowsWhenReadToFileMakesNoProgress) {
+    auto file =
+        std::make_shared<FailingRandomAccessFile>(std::vector<ReadOutcome>{
+            {arrow::Status::OK(), 0}, {arrow::Status::OK(), 4}});
+    auto* file_ptr = file.get();
+    RemoteInputStream stream(std::move(file));
+    TempFile temp_file;
+    ASSERT_GE(temp_file.fd(), 0);
+
+    EXPECT_THROW(stream.Read(temp_file.fd(), 4), milvus::SegcoreError);
+    EXPECT_EQ(stream.Tell(), 0);
+    EXPECT_EQ(file_ptr->read_calls(), 1);
+}
+
+TEST(RemoteInputStreamTest, ThrowsWhenReadToFileFsyncFails) {
+    auto file = std::make_shared<FailingRandomAccessFile>(
+        std::vector<ReadOutcome>{{arrow::Status::OK(), 4}});
+    auto* file_ptr = file.get();
+    RemoteInputStream stream(std::move(file));
+    PipeFile pipe_file;
+    ASSERT_GE(pipe_file.write_fd(), 0);
+
+    try {
+        stream.Read(pipe_file.write_fd(), 4);
+        FAIL() << "expected SegcoreError";
+    } catch (const milvus::SegcoreError& e) {
+        std::string message = e.what();
+        EXPECT_NE(message.find("Failed to fsync file"), std::string::npos);
+    }
+    EXPECT_EQ(stream.Tell(), 4);
+    EXPECT_EQ(file_ptr->read_calls(), 1);
+}
+
+TEST(RemoteInputStreamTest, ReportsOriginalReadErrorWhenRetryResetFails) {
+    auto file = std::make_shared<FailingRandomAccessFile>(
+        std::vector<ReadOutcome>{{InternalFailedFlushStatus(), 2, true}},
+        "abcdefghijklmnop",
+        std::vector<arrow::Status>{SeekResetStatus()});
+    RemoteInputStream stream(std::move(file));
+
+    std::vector<uint8_t> data(4);
+    try {
+        stream.Read(data.data(), data.size());
+        FAIL() << "expected SegcoreError";
+    } catch (const milvus::SegcoreError& e) {
+        std::string message = e.what();
+        EXPECT_NE(message.find("seek reset failed"), std::string::npos);
+        EXPECT_NE(message.find("offset: 0"), std::string::npos);
+        EXPECT_NE(message.find("Failed to flush response stream"),
+                  std::string::npos);
+    }
+}
+
+TEST(RemoteInputStreamTest, DoesNotRetryInternalErrorWithoutFailedFlush) {
+    auto file =
+        std::make_shared<FailingRandomAccessFile>(std::vector<ReadOutcome>{
+            {InternalDifferentStatus(), 0}, {arrow::Status::OK(), 4}});
+    auto* file_ptr = file.get();
+    RemoteInputStream stream(std::move(file));
+
+    std::vector<uint8_t> data(4);
+    EXPECT_THROW(stream.Read(data.data(), data.size()), milvus::SegcoreError);
+    EXPECT_EQ(file_ptr->read_calls(), 1);
+}
+
+TEST(RemoteInputStreamTest, RetriesFailedFlushNonIoError) {
+    auto file =
+        std::make_shared<FailingRandomAccessFile>(std::vector<ReadOutcome>{
+            {arrow::Status::Invalid("google::cloud::Status(INTERNAL: Failed to "
+                                    "flush response stream)"),
+             0},
+            {arrow::Status::OK(), 4}});
+    auto* file_ptr = file.get();
+    RemoteInputStream stream(std::move(file));
+
+    std::vector<uint8_t> data(4);
+    EXPECT_EQ(stream.Read(data.data(), data.size()), data.size());
+    EXPECT_EQ(file_ptr->read_calls(), 2);
+}
+
+}  // namespace
+}  // namespace milvus::storage

--- a/internal/core/src/storage/RemoteInputStreamTest.cpp
+++ b/internal/core/src/storage/RemoteInputStreamTest.cpp
@@ -26,7 +26,6 @@
 
 #include <array>
 #include <cstdint>
-#include <cstring>
 #include <memory>
 #include <string>
 #include <utility>
@@ -43,7 +42,6 @@ struct ReadOutcome {
     int64_t bytes_read;
     bool advance_position_on_error = false;
     std::string data;
-    int64_t expected_zeroed_bytes = -1;
 };
 
 class FailingRandomAccessFile : public arrow::io::RandomAccessFile {
@@ -91,11 +89,6 @@ class FailingRandomAccessFile : public arrow::io::RandomAccessFile {
         ++read_calls_;
         if (next_outcome_ < read_outcomes_.size()) {
             auto outcome = read_outcomes_[next_outcome_++];
-            auto status =
-                ValidateZeroedBuffer(outcome.expected_zeroed_bytes, out);
-            if (!status.ok()) {
-                return status;
-            }
             if (!outcome.status.ok()) {
                 FillBuffer(outcome.bytes_read, out, outcome.data);
                 if (outcome.advance_position_on_error) {
@@ -156,21 +149,6 @@ class FailingRandomAccessFile : public arrow::io::RandomAccessFile {
                     : override_data[static_cast<size_t>(i) %
                                     override_data.size()]);
         }
-    }
-
-    arrow::Status
-    ValidateZeroedBuffer(int64_t nbytes, void* out) const {
-        if (nbytes < 0) {
-            return arrow::Status::OK();
-        }
-        auto* out_data = static_cast<const uint8_t*>(out);
-        for (int64_t i = 0; i < nbytes; ++i) {
-            if (out_data[i] != 0) {
-                return arrow::Status::Invalid(
-                    "buffer was not cleared before read");
-            }
-        }
-        return arrow::Status::OK();
     }
 
     std::vector<ReadOutcome> read_outcomes_;
@@ -337,7 +315,7 @@ TEST(RemoteInputStreamTest, WritesOnlyActualBytesReadAfterRetryingReadToFile) {
     auto file =
         std::make_shared<FailingRandomAccessFile>(std::vector<ReadOutcome>{
             {InternalFailedFlushStatus(), 4, false, "zzzz"},
-            {arrow::Status::OK(), 2, false, "", 4},
+            {arrow::Status::OK(), 2},
             {arrow::Status::OK(), 2}});
     auto* file_ptr = file.get();
     RemoteInputStream stream(std::move(file));


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/49963

## What changed

This PR adds a narrow retry path for transient remote read failures in `RemoteInputStream`.

- Retry remote reads only when the error string contains `Failed to flush response stream`.
- Share retry handling across `Read`, `ReadAt`, and `Read(fd, size)`.
- Restore the original stream offset before retrying stateful sequential reads, so a failed read that advances the underlying file position does not skip bytes on retry.
- Keep `ReadAt` retry reset as a no-op because it always reads from an explicit offset.
- Log retry attempts with operation, size, file size, and the original error.

## Why

Object storage reads can fail transiently with `Failed to flush response stream`. Retrying those reads avoids failing index/data load on a recoverable transport error.

For sequential reads, retrying without seeking back is unsafe because some lower layers may advance the file position before returning an error. This PR records the position before each stateful read and seeks back before the next attempt.
