### PR TITLE
enhance: standardize coordinators error handling to merr

### DIFF
--- a/docs/dev/error_sentinel_convention.md
+++ b/docs/dev/error_sentinel_convention.md
@@ -1,0 +1,287 @@
+# Error Sentinel Convention
+
+Milvus error handling has two distinct layers. This document describes the rules
+that separate them, the rationale, and an audit of where the codebase currently
+violates them.
+
+## The two layers
+
+### 1. Typed merr (wire-protocol errors)
+
+Defined in `pkg/util/merr/registry.go` (`ErrCollectionNotFound`,
+`ErrParameterInvalid`, etc.). These carry a numeric error code that is
+serialized into `commonpb.Status{ErrorCode, Reason}` and shipped to the
+client over gRPC. They are the only thing a client (or another Milvus
+component on the receiving end of an RPC) sees.
+
+Creation: `merr.WrapErrXxxMsg(...)` / `merr.WrapErrXxxErr(cause, ...)`
+(origination only — never to add context to a typed merr that already exists,
+see `merr.Wrap`).
+
+### 2. Internal sentinels (single-process control flow)
+
+Created with `errors.New(...)` at package scope (e.g. `errIgnoredAlterAlias`,
+`errReleaseCollectionNotLoaded`, `errNodeNotEnough`). These are signaling
+vocabulary inside a single Go process: a callee tells its caller "this is an
+idempotent no-op" or "the queue is empty" so the caller can branch / retry /
+ignore. They are **not** part of the wire protocol.
+
+The catcher is always `errors.Is(err, sentinelX)` at some boundary in the
+calling stack, and the boundary either:
+
+- translates to `merr.Success()` (idempotency: e.g. drop something that
+  doesn't exist → success), or
+- translates to a typed merr `merr.WrapErrXxxMsg(...)` (e.g. user already
+  exists → `WrapErrParameterInvalid`).
+
+## The hard invariant
+
+> **Any internal sentinel must be `errors.Is`-caught and translated to a
+> typed merr (or `Success`) before crossing any gRPC handler boundary —
+> client-facing or component-to-component.**
+
+Why "any gRPC boundary, not just client-facing": gRPC serializes errors to
+`commonpb.Status{ErrorCode, Reason}`. The Go-level pointer identity that
+`errors.New` sentinels rely on does not survive the wire. The peer's
+`merr.Error(status)` reconstructs a typed merr from the numeric code; the
+sentinel chain is gone forever. So a sentinel that escapes an internal coord
+RPC is just as broken as one that escapes a user-facing RPC — only quieter,
+because no customer sees the resulting `Code=1 Unexpected`.
+
+### What breaks the invariant
+
+The sentinel chain survives `return err` and `errors.Wrap(err, "...")`
+(cockroachdb thin wrap, preserves `Unwrap()`). It is **destroyed** by:
+
+- `merr.WrapErrServiceInternalErr(err, "...")` and any other
+  `merr.WrapErrXxxErr` — these wrap the cause in a
+  `*wrappedMilvusError{sentinel: ErrServiceInternal}` whose `Unwrap()` hides
+  the cause, so `errors.Is(outer, sentinelX)` returns false. (See also
+  [feedback rule](#related-rules) on `merr.Wrap` vs `merr.WrapErr*Err`.)
+- Any custom wrapper that doesn't implement `Unwrap()`.
+
+So the rule "use `merr.Wrap` to add context to an existing err, never
+`merr.WrapErr*Err`" is what keeps the sentinel chain intact end-to-end.
+
+## Naming convention
+
+The convention has two layers, matched to the two error categories:
+
+### Wire-protocol layer (typed merr) — uppercase `Err*` in `pkg/util/merr` only
+
+All errors that may cross any gRPC boundary (client-facing or
+component-to-component) must be `*merr.milvusError` defined in
+`pkg/util/merr/registry.go`. They have:
+
+- A numeric `errorCode` registered in `pkg/util/merr/code.go`
+- A `var ErrXxx = newMilvusError(...)` declaration in `pkg/util/merr/registry.go`
+- An exported `WrapErrXxxMsg` / `WrapErrXxxErr` helper
+
+If an error needs to be visible to the wire, it lives here. No exceptions.
+
+### Internal-sentinel layer — lowercase `errXxx`, same-package only
+
+Internal sentinels live in `internal/...` packages, are created with
+`errors.New(...)`, and are **lowercase / unexported**. The rule:
+
+> **A `var err* = errors.New(...)` declared in `internal/...` may only be
+> referenced inside the same Go package. Cross-package consumers must not
+> see it.**
+
+This makes Go visibility do the enforcement: if you need a signal across
+package boundaries, you either (a) lift it into the wire layer as a typed
+merr, or (b) redesign the API so the signal flows via a return value
+(e.g. `(ignored bool, err error)`), not via the error type.
+
+Example (current code, after the 04-coord cleanup):
+
+```go
+// errFull / errNoSuchElement are INTERNAL sentinels: caught by errors.Is
+// inside the compaction inspector / scheduler loop and never serialized
+// across any gRPC boundary.
+var (
+    errFull          = errors.New("compaction queue is full")
+    errNoSuchElement = errors.New("compaction queue has no element")
+)
+```
+
+### Cross-package idempotency: use a return-value flag, not an exported sentinel
+
+The previous code exported `meta.ErrResourceGroupOperationIgnored` so that
+the parent package `querycoordv2` could catch it via `errors.Is` and
+translate to `merr.Success()`. This was an exported `Err*` in
+`internal/...` — visually indistinguishable from a `merr.ErrXxx` typed
+wire error, easy to misuse.
+
+The current code instead encodes the signal in the return value:
+
+```go
+// meta/resource_manager.go
+func (rm *ResourceManager) CheckIfResourceGroupAddable(...) (ignored bool, err error) {
+    if proto.Equal(rm.groups[rgName].GetConfig(), cfg) {
+        return true, nil   // idempotent no-op
+    }
+    ...
+}
+
+// querycoordv2/ddl_callbacks_alter_resource_group.go (broadcaster)
+func (s *Server) broadcastCreateResourceGroup(...) (ignored bool, err error) {
+    if ignored, err := s.meta.CheckIfResourceGroupAddable(...); err != nil || ignored {
+        return ignored, err
+    }
+    ...
+}
+
+// querycoordv2/services.go (RPC handler)
+ignored, err := s.broadcastCreateResourceGroup(ctx, req)
+if err != nil { return merr.Status(err), nil }
+if ignored { return merr.Success(), nil }
+```
+
+No sentinel crosses the package boundary; the signal travels via a
+structured return value. This is the preferred pattern for any new
+cross-package idempotency case.
+
+## Current state (audit done on err-std-04-coord branch, 2026-05-19)
+
+Across `internal/{datacoord,rootcoord,querycoordv2}` there are 28
+`errors.New(...)` sentinels. Their fates:
+
+| Kind | Count | Examples | Status |
+|---|---|---|---|
+| Idempotency: caught → `merr.Success()` | 13 catch sites, ~12 distinct sentinels | `errIgnoredAlterAlias`, `errIgnoredCreateCollection`, `errReleaseCollectionNotLoaded`, `errUserNotFound`, ... | ✅ compliant |
+| Caught → translated to typed merr | 3 catch sites (`errUserAlreadyExists`, `errRoleAlreadyExists`, `errRoleNotExists`) | client gets `WrapErrParameterInvalidMsg(...)` or `WrapErrServiceInternalMsg(...)` | ✅ compliant (1100 / 5) |
+| Background-only (never enter an RPC handler) | 5 (`errFull`, `errNoSuchElement`, `errNodeNotEnough`, `errDisposed`, `errTypeNotFound`) | compaction queue / resource observer / session lifecycle / checker registry | ✅ compliant |
+| Cross-package idempotency via `(ignored bool, err error)` signature | 1 (resource group create/drop) | meta layer returns `ignored=true`; querycoordv2 RPC handler translates to `merr.Success()` — no sentinel crosses package | ✅ compliant (refactored from exported `ErrResourceGroupOperationIgnored` in this branch) |
+| Dead code (function with 0 callers) | 3 (`errNilResponse`, `errNilStatusResponse`, `errUnknownResponseType` — all only used by `VerifyResponse` in `datacoord/util.go`) | safe to delete | 🪦 cleanup candidate |
+| **Violation**: escapes RPC handler with no catch | **3** (`errEmptyUsername`, `errEmptyRoleName`, `errEmptyPrivilegeGroupName`) | wrapped only by cockroachdb `errors.Wrap`, no `errors.Is` catch; client gets `Code=1 Unexpected, Reason="failed to check if add credential: username is empty"` | ❌ to fix |
+| **Semantic miscategorization**: caught and wrapped but with the wrong typed merr code | 1 (`errTypeNotFound` in `ops_services.go:83,97`) | wrapped as `WrapErrServiceInternal` (code 5) but is really an invalid `CheckerID` from the client → should be `WrapErrParameterInvalidMsg` (code 1100) | ⚠️ to fix |
+
+### Suggested cleanup (not done in this PR)
+
+1. Change `errEmptyUsername` / `errEmptyRoleName` / `errEmptyPrivilegeGroupName`
+   at the origin sites in `internal/rootcoord/meta_table.go` to
+   `merr.WrapErrParameterInvalidMsg("username is empty")` etc. These are
+   client-validation failures, so they belong in the wire layer, not the
+   internal-sentinel layer.
+2. Wrap `errTypeNotFound` at the catcher in `internal/querycoordv2/ops_services.go:83,97`
+   with `merr.WrapErrParameterInvalidMsg("unknown checker type: %d", req.CheckerID)`.
+3. Delete `VerifyResponse` and its three dead-code sentinels
+   (`errNilResponse`, `errNilStatusResponse`, `errUnknownResponseType`).
+
+## Future linter ideas
+
+Three candidates, in order of how cheap they are to implement and how
+hard the enforcement is. **Not yet implemented — recorded here as design
+queue.**
+
+### Tier 1 — exported-sentinel ban (1 hour to write)
+
+The simplest rule: **`internal/...` packages may not declare exported
+`var Err\w+ = errors.New(...)`.** Scan all `internal/...` *.go files,
+fail CI if any match. Two paths to fix a violation:
+
+1. Lowercase it (`var errXxx = errors.New(...)`) — only callable inside the
+   same package. If the lint fails because a cross-package caller needs the
+   signal, see fix 2.
+2. Refactor the API so the signal travels via a return value
+   (e.g. add `ignored bool` to the return tuple) and delete the sentinel.
+
+This makes Go visibility itself the enforcement mechanism: anything that
+needs to look like `merr.ErrXxx` to a reviewer can only exist in
+`pkg/util/merr`. Internal sentinels stay quietly lowercase in their owning
+package.
+
+Lowercase sentinels (`var errXxx = errors.New(...)`) inside `internal/...`
+are still encouraged to carry an `INTERNAL: ...` doc comment for reviewer
+context, but it's not enforced — the visibility rule already prevents the
+worst-case (`Err*` collision with `merr.ErrXxx`).
+
+### Tier 1.5 — bare-usage ban (1 hour grep, half-day AST for 100% precision)
+
+**Hardest enforcement, no exceptions.** `internal/...` packages may not
+use `errors.New(...)` or `errors.Errorf(...)` **inline inside a function
+body**. The only legal site for these calls is a package-level
+`var <Name> = errors.New(...)` (sentinel declaration).
+
+Allow/deny matrix:
+
+| Form | Location | Verdict |
+|---|---|---|
+| `var errInvalid = errors.New("invalid")` | package-level (file top / `var` block) | ✅ allowed |
+| `var ( errA = ...; errB = ... )` | package-level `var` block | ✅ allowed |
+| `return errors.New(...)` | function body | ❌ banned |
+| `x := errors.New(...)` | function body local | ❌ banned |
+| `panic(errors.New(...))` | function body | ❌ banned |
+| `foo(errors.New(...))` | function body argument | ❌ banned |
+
+**Why no exceptions** (even for "local break signal" / "log-only" /
+"panic-bound" cases that look harmless today):
+
+- Today's local var can be hoisted to package-level by tomorrow's refactor
+  and silently start crossing boundaries.
+- A linter with exceptions needs AST-level wire-reachability analysis
+  (expensive); a no-exception linter is one grep.
+- Forces authors to use the right primitive instead of `errors.New` as
+  a universal escape hatch:
+  - **break signal from a callback** → define a `type doneSignal struct{}`
+    that implements `error` and use `errors.As`. Intent is now in the type,
+    not in a string-keyed sentinel.
+  - **"unreachable" assertion** → just `panic(...)`. If caller already
+    does `if err != nil { panic(err) }`, fold it into the callee.
+  - **input validation / config validation** → `merr.WrapErrParameterInvalidMsg(...)`
+    or `status.NewInvaildArgument(...)` depending on layer.
+
+Implementation: grep version covers ~95% true violations in ~1 hour.
+AST version (go/analysis) covers the edge cases (e.g. `init()` body
+assigning to a package var) but needs ~half a day. Start with grep,
+upgrade if false-positive rate exceeds 5%.
+
+```bash
+# grep skeleton
+grep -rnE 'errors\.(New|Errorf)\(' internal/ --include='*.go' \
+  | grep -v _test.go \
+  | grep -vE ':[0-9]+:\s*(var\s+)?[A-Za-z_]+\s*=\s*errors\.(New|Errorf)' \
+  | grep -vE ':[0-9]+:\s*[A-Za-z_]+\s+(\w+\s+)?=\s*errors\.(New|Errorf)'
+# Any remaining line = violation
+```
+
+A `//nolint:err-bare` escape valve with a required justification comment
+handles the genuine outliers (a few `init()` patterns, embedded `errors.Mark`
+usage, etc.).
+
+### Tier 2 — escape-path linter (~1 day, go/analysis based)
+
+For every gRPC handler method (anything matching the
+`internal/{rootcoord,datacoord,querycoordv2}/services.go,root_coord.go,*_handler.go`
+pattern, return type `(*proto.XxxResponse, error)` or `(*commonpb.Status,
+error)`), trace the err-return data-flow. Any error that:
+
+- transitively originates from an `INTERNAL:`-tagged sentinel, **and**
+- reaches a `return Status{Code: merr.Status(err)}` or `return err` without
+  passing through an `errors.Is(err, internalSentinelX) { ... }` branch,
+
+is a violation. Report file:line of the leak.
+
+This catches the actual invariant violation (the 3 RBAC empty sentinels
+would have been flagged), not just naming hygiene. Requires AST analysis;
+worth doing if the cost of one more silent `Code=1` to a client is high.
+
+### Tier 3 (no longer necessary if Tier 2 is in place) — wrap-rule linter
+
+Scan `merr\.WrapErr[A-Za-z]+Err\(err, ` (note: first arg `err`, not a
+fresh string-only origination) and require the cause `err` to not itself be
+a typed merr. This is what
+[`feedback_merr_wrap_rule`](../../) already enforces by convention; Tier 2
+would catch the symptom (sentinel escape) as a side effect.
+
+## Related rules
+
+- `feedback_merr_wrap_rule` (this repo's collaboration memory): "Add context
+  to an existing err with `merr.Wrap` / `merr.Wrapf`, never with
+  `merr.WrapErr*Err` — the latter masks the inner typed code and breaks
+  `errors.Is`."
+- `project_errstd_autogen_defects`: three systematic defects in the
+  auto-generated `errors.Wrap → merr` conversion in this branch series;
+  defects #2 and #3 are direct consequences of violating the rules in
+  this document.

--- a/examples/telemetry_e2e_test/go.mod
+++ b/examples/telemetry_e2e_test/go.mod
@@ -1,10 +1,11 @@
 module github.com/milvus-io/milvus/examples/telemetry_e2e_test
+
 go 1.25.8
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c
 	github.com/milvus-io/milvus/client/v2 v2.6.4-0.20251104142533-a2ce70d25256
-	google.golang.org/grpc v1.71.0
+	google.golang.org/grpc v1.79.3
 )
 
 replace (

--- a/examples/telemetry_e2e_test/go.sum
+++ b/examples/telemetry_e2e_test/go.sum
@@ -1,2 +1,4 @@
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
@@ -131,10 +131,13 @@ async fn download_with_retry(
         for url in urls {
             match client.get(url).send().await {
                 Ok(resp) if resp.status().is_success() => {
-                    let content = resp
-                        .bytes()
-                        .await
-                        .map_err(|e| TantivyBindingError::InternalError(e.to_string()))?;
+                    let content = match resp.bytes().await {
+                        Ok(c) => c,
+                        Err(e) => {
+                            warn!("Failed to read body from {}: {}", url, e);
+                            continue;
+                        }
+                    };
 
                     // Calculate MD5 hash
                     let mut context = Context::new();

--- a/internal/datacoord/analyze_meta.go
+++ b/internal/datacoord/analyze_meta.go
@@ -18,7 +18,6 @@ package datacoord
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"go.uber.org/zap"
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/workerpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 )
 
@@ -117,7 +117,7 @@ func (m *analyzeMeta) UpdateVersion(taskID int64, nodeID int64) error {
 
 	t, ok := m.tasks[taskID]
 	if !ok {
-		return fmt.Errorf("there is no task with taskID: %d", taskID)
+		return merr.WrapErrServiceInternalMsg("there is no task with taskID: %d", taskID)
 	}
 
 	cloneT := proto.Clone(t).(*indexpb.AnalyzeTask)
@@ -134,7 +134,7 @@ func (m *analyzeMeta) BuildingTask(taskID int64) error {
 
 	t, ok := m.tasks[taskID]
 	if !ok {
-		return fmt.Errorf("there is no task with taskID: %d", taskID)
+		return merr.WrapErrServiceInternalMsg("there is no task with taskID: %d", taskID)
 	}
 
 	cloneT := proto.Clone(t).(*indexpb.AnalyzeTask)
@@ -150,7 +150,7 @@ func (m *analyzeMeta) UpdateState(taskID int64, state indexpb.JobState, failReas
 
 	t, ok := m.tasks[taskID]
 	if !ok {
-		return fmt.Errorf("there is no task with taskID: %d", taskID)
+		return merr.WrapErrServiceInternalMsg("there is no task with taskID: %d", taskID)
 	}
 
 	cloneT := proto.Clone(t).(*indexpb.AnalyzeTask)
@@ -168,7 +168,7 @@ func (m *analyzeMeta) FinishTask(taskID int64, result *workerpb.AnalyzeResult) e
 
 	t, ok := m.tasks[taskID]
 	if !ok {
-		return fmt.Errorf("there is no task with taskID: %d", taskID)
+		return merr.WrapErrServiceInternalMsg("there is no task with taskID: %d", taskID)
 	}
 
 	log.Info("finish task meta...", zap.Int64("taskID", taskID), zap.String("state", result.GetState().String()),

--- a/internal/datacoord/backfill_result.go
+++ b/internal/datacoord/backfill_result.go
@@ -21,10 +21,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // BackfillResult is the decoded form of the JSON produced by the Spark
@@ -86,34 +85,34 @@ var knownObjectSchemes = map[string]struct{}{
 //  3. Unknown scheme -> return ErrUnsupportedScheme.
 func normalizeObjectKey(raw, expectedBucket string) (string, error) {
 	if raw == "" {
-		return "", errors.New("empty object path")
+		return "", merr.WrapErrServiceInternalMsg("empty object path")
 	}
 	if !strings.Contains(raw, "://") {
 		key := strings.TrimPrefix(raw, "/")
 		if key == "" {
-			return "", errors.Newf("empty object key in %q", raw)
+			return "", merr.WrapErrServiceInternalMsg("empty object key in %q", raw)
 		}
 		return key, nil
 	}
 	idx := strings.Index(raw, "://")
 	scheme := strings.ToLower(raw[:idx])
 	if _, ok := knownObjectSchemes[scheme]; !ok {
-		return "", errors.Newf("unsupported object URI scheme %q in %q", scheme, raw)
+		return "", merr.WrapErrServiceInternalMsg("unsupported object URI scheme %q in %q", scheme, raw)
 	}
 	rest := raw[idx+3:]
 	slash := strings.Index(rest, "/")
 	if slash < 0 {
-		return "", errors.Newf("malformed object URI %q: missing object key", raw)
+		return "", merr.WrapErrServiceInternalMsg("malformed object URI %q: missing object key", raw)
 	}
 	bucket := rest[:slash]
 	key := rest[slash+1:]
 	if expectedBucket != "" && bucket != expectedBucket {
-		return "", errors.Newf("object URI bucket %q differs from datacoord bucket %q (path=%s)", bucket, expectedBucket, raw)
+		return "", merr.WrapErrServiceInternalMsg("object URI bucket %q differs from datacoord bucket %q (path=%s)", bucket, expectedBucket, raw)
 	}
 	// Reject inputs like "s3a://bucket/" that parse to an empty key -- passing
 	// an empty key to chunkManager.Read has undefined behavior across SDKs.
 	if key == "" {
-		return "", errors.Newf("empty object key in %q", raw)
+		return "", merr.WrapErrServiceInternalMsg("empty object key in %q", raw)
 	}
 	return key, nil
 }
@@ -147,20 +146,20 @@ func buildV2Groups(bucket string, entry *BackfillSegment) (map[int64]*datapb.Fie
 	for i := range entry.ColumnGroups {
 		g := &entry.ColumnGroups[i]
 		if len(g.FieldIDs) != 1 {
-			return nil, errors.Newf("backfill invariant violated: column group has %d field_ids (expected 1)", len(g.FieldIDs))
+			return nil, merr.WrapErrServiceInternalMsg("backfill invariant violated: column group has %d field_ids (expected 1)", len(g.FieldIDs))
 		}
 		n := int64(len(g.BinlogFiles))
 		if n == 0 {
-			return nil, errors.Newf("column group for field %d has no binlog files", g.FieldIDs[0])
+			return nil, merr.WrapErrServiceInternalMsg("column group for field %d has no binlog files", g.FieldIDs[0])
 		}
 		fid := g.FieldIDs[0]
 		if _, dup := out[fid]; dup {
-			return nil, errors.Newf("duplicate column group for field %d", fid)
+			return nil, merr.WrapErrServiceInternalMsg("duplicate column group for field %d", fid)
 		}
 		// row_count flows into EntriesNum; non-positive values are undefined
 		// (zero collapses presence markers, negatives break accounting).
 		if g.RowCount <= 0 {
-			return nil, errors.Newf("column group for field %d has non-positive row_count %d", fid, g.RowCount)
+			return nil, merr.WrapErrServiceInternalMsg("column group for field %d has non-positive row_count %d", fid, g.RowCount)
 		}
 		avg := g.RowCount / n
 		rem := g.RowCount - avg*n
@@ -176,7 +175,7 @@ func buildV2Groups(bucket string, entry *BackfillSegment) (map[int64]*datapb.Fie
 			}
 			logID, ok := parseLogIDFromKey(key)
 			if !ok {
-				return nil, errors.Newf("column group for field %d has binlog file %q with non-numeric trailing segment", fid, p)
+				return nil, merr.WrapErrServiceInternalMsg("column group for field %d has binlog file %q with non-numeric trailing segment", fid, p)
 			}
 			// LogPath must be empty at persistence time -- catalog.checkLogID
 			// rejects any Binlog with LogPath != "" (see

--- a/internal/datacoord/compaction_policy_clustering.go
+++ b/internal/datacoord/compaction_policy_clustering.go
@@ -31,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -245,7 +246,7 @@ func calculateClusteringCompactionConfig(coll *collectionInfo, view CompactionVi
 
 func estimateRowsBySegmentSize(segments []*SegmentView, expectedSegmentSize int64) (int64, error) {
 	if expectedSegmentSize <= 0 {
-		return 0, fmt.Errorf("invalid expected segment size %d", expectedSegmentSize)
+		return 0, merr.WrapErrServiceInternalMsg("invalid expected segment size %d", expectedSegmentSize)
 	}
 
 	var totalSize float64
@@ -262,17 +263,17 @@ func estimateRowsBySegmentSize(segments []*SegmentView, expectedSegmentSize int6
 	}
 
 	if totalRows == 0 || totalSize == 0 {
-		return 0, fmt.Errorf("segment view does not contain size info to estimate row count")
+		return 0, merr.WrapErrServiceInternalMsg("segment view does not contain size info to estimate row count")
 	}
 
 	rowSize := totalSize / float64(totalRows)
 	if rowSize <= 0 {
-		return 0, fmt.Errorf("invalid row size calculated from segment view")
+		return 0, merr.WrapErrServiceInternalMsg("invalid row size calculated from segment view")
 	}
 
 	rows := float64(expectedSegmentSize) / rowSize
 	if rows <= 0 {
-		return 0, fmt.Errorf("estimated max row count is not positive")
+		return 0, merr.WrapErrServiceInternalMsg("estimated max row count is not positive")
 	}
 
 	return int64(rows), nil

--- a/internal/datacoord/compaction_policy_forcemerge.go
+++ b/internal/datacoord/compaction_policy_forcemerge.go
@@ -2,7 +2,6 @@ package datacoord
 
 import (
 	"context"
-	"fmt"
 	"math"
 
 	"github.com/samber/lo"
@@ -103,7 +102,7 @@ func (policy *forceMergeCompactionPolicy) triggerOneCollection(
 
 	configMaxSize := getExpectedSegmentSize(policy.meta, collectionID, collection.Schema)
 	if targetSizeBytes < configMaxSize {
-		return nil, 0, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("targetSize %d MB should be greater than or equal to configMaxSize %d MB", targetSize, configMaxSize/(1024*1024)))
+		return nil, 0, merr.WrapErrParameterInvalidMsg("targetSize %d MB should be greater than or equal to configMaxSize %d MB", targetSize, configMaxSize/(1024*1024))
 	}
 
 	segments := policy.meta.SelectSegments(ctx, WithCollection(collectionID), SegmentFilterFunc(func(segment *SegmentInfo) bool {
@@ -188,7 +187,7 @@ var _ CollectionTopologyQuerier = (*metricsNodeMemoryQuerier)(nil)
 func (q *metricsNodeMemoryQuerier) GetCollectionTopology(ctx context.Context, collectionID int64) (*CollectionTopology, error) {
 	log := log.Ctx(ctx).With(zap.Int64("collectionID", collectionID))
 	if q.mixCoord == nil {
-		return nil, fmt.Errorf("mixCoord not available for topology query")
+		return nil, merr.WrapErrServiceInternalMsg("mixCoord not available for topology query")
 	}
 
 	// 1. Get replica information

--- a/internal/datacoord/compaction_queue.go
+++ b/internal/datacoord/compaction_queue.go
@@ -74,9 +74,12 @@ func (pq *PriorityQueue[T]) Update(item *Item[T], value T, priority int) {
 	heap.Fix(pq, item.index)
 }
 
+// errFull / errNoSuchElement are INTERNAL sentinels: caught by errors.Is
+// inside the compaction inspector / scheduler loop and never serialized
+// across any gRPC boundary. See docs/dev/error_sentinel_convention.md.
 var (
-	ErrFull          = errors.New("compaction queue is full")
-	ErrNoSuchElement = errors.New("compaction queue has no element")
+	errFull          = errors.New("compaction queue is full")
+	errNoSuchElement = errors.New("compaction queue has no element")
 )
 
 type Prioritizer func(t CompactionTask) int
@@ -101,7 +104,7 @@ func (q *CompactionQueue) Enqueue(t CompactionTask) error {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	if q.capacity > 0 && len(q.pq) >= q.capacity {
-		return ErrFull
+		return errFull
 	}
 
 	heap.Push(&q.pq, &Item[CompactionTask]{value: t, priority: q.prioritizer(t)})
@@ -113,7 +116,7 @@ func (q *CompactionQueue) Dequeue() (CompactionTask, error) {
 	defer q.lock.Unlock()
 
 	if len(q.pq) == 0 {
-		return nil, ErrNoSuchElement
+		return nil, errNoSuchElement
 	}
 
 	item := heap.Pop(&q.pq).(*Item[CompactionTask])

--- a/internal/datacoord/compaction_task_clustering.go
+++ b/internal/datacoord/compaction_task_clustering.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -628,7 +627,7 @@ func (t *clusteringCompactionTask) processAnalyzing() error {
 		}
 	case indexpb.JobState_JobStateFailed:
 		log.Warn("analyze task fail", zap.Int64("analyzeID", t.GetTaskProto().GetAnalyzeTaskID()))
-		return errors.New(analyzeTask.FailReason)
+		return merr.WrapErrServiceInternalMsg(analyzeTask.FailReason)
 	default:
 	}
 	return nil

--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -320,7 +320,7 @@ func (t *l0CompactionTask) selectFlushedSegment() ([]*SegmentInfo, []*datapb.Com
 	for _, info := range flushedSegments {
 		// Sealed is unexpected, fail fast
 		if info.GetState() == commonpb.SegmentState_Sealed {
-			return nil, nil, fmt.Errorf("L0 compaction selected invalid sealed segment %d", info.GetID())
+			return nil, nil, merr.WrapErrServiceInternalMsg("L0 compaction selected invalid sealed segment %d", info.GetID())
 		}
 
 		sealedSegBinlogs = append(sealedSegBinlogs, &datapb.CompactionSegmentBinlogs{

--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -393,7 +393,7 @@ func (t *mixCompactionTask) BuildCompactionRequest() (*datapb.CompactionPlan, er
 		resources, err := t.meta.GetFileResources(context.Background(), taskProto.GetSchema().GetFileResourceIds()...)
 		if err != nil {
 			log.Warn("get file resources for collection failed", zap.Int64("collectionID", taskProto.GetCollectionID()), zap.Error(err))
-			return nil, errors.Errorf("get file resources for sort compaction failed: %v", err)
+			return nil, merr.WrapErrServiceInternalErr(err, "get file resources for sort compaction failed")
 		}
 		plan.FileResources = resources
 	}

--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -393,7 +393,7 @@ func (t *mixCompactionTask) BuildCompactionRequest() (*datapb.CompactionPlan, er
 		resources, err := t.meta.GetFileResources(context.Background(), taskProto.GetSchema().GetFileResourceIds()...)
 		if err != nil {
 			log.Warn("get file resources for collection failed", zap.Int64("collectionID", taskProto.GetCollectionID()), zap.Error(err))
-			return nil, merr.WrapErrServiceInternalErr(err, "get file resources for sort compaction failed")
+			return nil, merr.Wrap(err, "get file resources for sort compaction failed")
 		}
 		plan.FileResources = resources
 	}

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -225,7 +225,7 @@ func (t *compactionTrigger) getCollection(collectionID UniqueID) (*collectionInf
 	defer cancel()
 	coll, err := t.handler.GetCollection(ctx, collectionID)
 	if err != nil {
-		return nil, fmt.Errorf("collection ID %d not found, err: %w", collectionID, err)
+		return nil, merr.WrapErrServiceInternalErr(err, "collection ID %d not found, err", collectionID)
 	}
 	return coll, nil
 }

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -225,7 +225,7 @@ func (t *compactionTrigger) getCollection(collectionID UniqueID) (*collectionInf
 	defer cancel()
 	coll, err := t.handler.GetCollection(ctx, collectionID)
 	if err != nil {
-		return nil, merr.WrapErrServiceInternalErr(err, "collection ID %d not found, err", collectionID)
+		return nil, merr.Wrapf(err, "collection ID %d not found", collectionID)
 	}
 	return coll, nil
 }

--- a/internal/datacoord/ddl_callbacks.go
+++ b/internal/datacoord/ddl_callbacks.go
@@ -93,7 +93,7 @@ func (s *Server) startBroadcastWithCollectionID(ctx context.Context, collectionI
 func (s *Server) startBroadcastForRestoreSnapshot(ctx context.Context, collectionID int64, snapshotName string) (broadcaster.BroadcastAPI, error) {
 	coll, err := s.broker.DescribeCollectionInternal(ctx, collectionID)
 	if err != nil {
-		return nil, merr.WrapErrServiceInternalErr(err, "collection %d does not exist", collectionID)
+		return nil, merr.Wrapf(err, "collection %d does not exist", collectionID)
 	}
 	dbName := coll.GetDbName()
 	collectionName := coll.GetCollectionName()
@@ -165,7 +165,7 @@ func (s *Server) validateRestoreSnapshotResources(ctx context.Context, collectio
 	sourceCollectionID := snapshotData.SnapshotInfo.GetCollectionId()
 	snapshot, err := s.meta.snapshotMeta.GetSnapshot(ctx, sourceCollectionID, snapshotData.SnapshotInfo.GetName())
 	if err != nil {
-		return merr.WrapErrServiceInternalErr(err, "snapshot %s does not exist for collection %d",
+		return merr.Wrapf(err, "snapshot %s does not exist for collection %d",
 			snapshotData.SnapshotInfo.GetName(), sourceCollectionID)
 	}
 	log.Info("snapshot validated", zap.String("snapshotName", snapshot.GetName()))
@@ -173,7 +173,7 @@ func (s *Server) validateRestoreSnapshotResources(ctx context.Context, collectio
 	// ========== Validate Collection Exists ==========
 	coll, err := s.broker.DescribeCollectionInternal(ctx, collectionID)
 	if err != nil {
-		return merr.WrapErrServiceInternalErr(err, "collection %d does not exist", collectionID)
+		return merr.Wrapf(err, "collection %d does not exist", collectionID)
 	}
 	dbName := coll.GetDbName()
 	collectionName := coll.GetCollectionName()
@@ -184,7 +184,7 @@ func (s *Server) validateRestoreSnapshotResources(ctx context.Context, collectio
 	// ========== Validate Partitions Exist ==========
 	partitionsResp, err := s.broker.ShowPartitions(ctx, collectionID)
 	if err != nil {
-		return merr.WrapErrServiceInternalErr(err, "failed to get partitions for collection %d", collectionID)
+		return merr.Wrapf(err, "failed to get partitions for collection %d", collectionID)
 	}
 
 	// Build set of existing partition names

--- a/internal/datacoord/ddl_callbacks.go
+++ b/internal/datacoord/ddl_callbacks.go
@@ -18,7 +18,6 @@ package datacoord
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/zap"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // RegisterDDLCallbacks registers the ddl callbacks.
@@ -93,7 +93,7 @@ func (s *Server) startBroadcastWithCollectionID(ctx context.Context, collectionI
 func (s *Server) startBroadcastForRestoreSnapshot(ctx context.Context, collectionID int64, snapshotName string) (broadcaster.BroadcastAPI, error) {
 	coll, err := s.broker.DescribeCollectionInternal(ctx, collectionID)
 	if err != nil {
-		return nil, fmt.Errorf("collection %d does not exist: %w", collectionID, err)
+		return nil, merr.WrapErrServiceInternalErr(err, "collection %d does not exist", collectionID)
 	}
 	dbName := coll.GetDbName()
 	collectionName := coll.GetCollectionName()
@@ -165,15 +165,15 @@ func (s *Server) validateRestoreSnapshotResources(ctx context.Context, collectio
 	sourceCollectionID := snapshotData.SnapshotInfo.GetCollectionId()
 	snapshot, err := s.meta.snapshotMeta.GetSnapshot(ctx, sourceCollectionID, snapshotData.SnapshotInfo.GetName())
 	if err != nil {
-		return fmt.Errorf("snapshot %s does not exist for collection %d: %w",
-			snapshotData.SnapshotInfo.GetName(), sourceCollectionID, err)
+		return merr.WrapErrServiceInternalErr(err, "snapshot %s does not exist for collection %d",
+			snapshotData.SnapshotInfo.GetName(), sourceCollectionID)
 	}
 	log.Info("snapshot validated", zap.String("snapshotName", snapshot.GetName()))
 
 	// ========== Validate Collection Exists ==========
 	coll, err := s.broker.DescribeCollectionInternal(ctx, collectionID)
 	if err != nil {
-		return fmt.Errorf("collection %d does not exist: %w", collectionID, err)
+		return merr.WrapErrServiceInternalErr(err, "collection %d does not exist", collectionID)
 	}
 	dbName := coll.GetDbName()
 	collectionName := coll.GetCollectionName()
@@ -184,7 +184,7 @@ func (s *Server) validateRestoreSnapshotResources(ctx context.Context, collectio
 	// ========== Validate Partitions Exist ==========
 	partitionsResp, err := s.broker.ShowPartitions(ctx, collectionID)
 	if err != nil {
-		return fmt.Errorf("failed to get partitions for collection %d: %w", collectionID, err)
+		return merr.WrapErrServiceInternalErr(err, "failed to get partitions for collection %d", collectionID)
 	}
 
 	// Build set of existing partition names
@@ -196,7 +196,7 @@ func (s *Server) validateRestoreSnapshotResources(ctx context.Context, collectio
 	// Check all snapshot partitions exist
 	for partName := range snapshotData.Collection.GetPartitions() {
 		if !existingPartitions[partName] {
-			return fmt.Errorf("partition %s does not exist in collection %d",
+			return merr.WrapErrServiceInternalMsg("partition %s does not exist in collection %d",
 				partName, collectionID)
 		}
 	}
@@ -215,7 +215,7 @@ func (s *Server) validateRestoreSnapshotResources(ctx context.Context, collectio
 			}
 		}
 		if !indexFound {
-			return fmt.Errorf("index %s for field %d does not exist in collection %d",
+			return merr.WrapErrServiceInternalMsg("index %s for field %d does not exist in collection %d",
 				indexInfo.GetIndexName(), indexInfo.GetFieldID(), collectionID)
 		}
 	}

--- a/internal/datacoord/ddl_callbacks_import.go
+++ b/internal/datacoord/ddl_callbacks_import.go
@@ -148,14 +148,14 @@ func (s *Server) broadcastImport(ctx context.Context,
 
 	// Validate the request before broadcasting
 	if err := s.validateImportRequest(ctx, msgFiles, options); err != nil {
-		return merr.WrapErrServiceInternalErr(err, "failed to validate import request")
+		return merr.Wrap(err, "failed to validate import request")
 	}
 
 	// Get database name from collection metadata via broker
 	// This is safer than extracting from schema which may be stale
 	broadcaster, err := s.startBroadcastWithCollectionID(ctx, collectionID)
 	if err != nil {
-		return merr.WrapErrServiceInternalErr(err, "failed to start broadcast with collection id")
+		return merr.Wrap(err, "failed to start broadcast with collection id")
 	}
 	defer broadcaster.Close()
 

--- a/internal/datacoord/ddl_callbacks_import.go
+++ b/internal/datacoord/ddl_callbacks_import.go
@@ -148,14 +148,14 @@ func (s *Server) broadcastImport(ctx context.Context,
 
 	// Validate the request before broadcasting
 	if err := s.validateImportRequest(ctx, msgFiles, options); err != nil {
-		return errors.Wrap(err, "failed to validate import request")
+		return merr.WrapErrServiceInternalErr(err, "failed to validate import request")
 	}
 
 	// Get database name from collection metadata via broker
 	// This is safer than extracting from schema which may be stale
 	broadcaster, err := s.startBroadcastWithCollectionID(ctx, collectionID)
 	if err != nil {
-		return errors.Wrap(err, "failed to start broadcast with collection id")
+		return merr.WrapErrServiceInternalErr(err, "failed to start broadcast with collection id")
 	}
 	defer broadcaster.Close()
 

--- a/internal/datacoord/errors.go
+++ b/internal/datacoord/errors.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // errors for VerifyResponse
@@ -34,7 +36,7 @@ func msgDataCoordIsUnhealthy(coordID UniqueID) string {
 }
 
 func errDataCoordIsUnhealthy(coordID UniqueID) error {
-	return errors.New(msgDataCoordIsUnhealthy(coordID))
+	return merr.WrapErrServiceInternalMsg(msgDataCoordIsUnhealthy(coordID))
 }
 
 func msgSegmentNotFound(segID UniqueID) string {

--- a/internal/datacoord/external_collection_refresh_manager.go
+++ b/internal/datacoord/external_collection_refresh_manager.go
@@ -871,12 +871,12 @@ func (m *externalCollectionRefreshManager) exploreExternalFiles(
 	// when both present.
 	if job.GetExternalSource() != "" {
 		if err := externalspec.ValidateSourceAndSpec(job.GetExternalSource(), job.GetExternalSpec()); err != nil {
-			return nil, "", merr.WrapErrServiceInternalErr(err, "external source/spec failed revalidation")
+			return nil, "", merr.Wrap(err, "external source/spec failed revalidation")
 		}
 	}
 	spec, err := externalspec.ParseExternalSpec(job.GetExternalSpec())
 	if err != nil {
-		return nil, "", merr.WrapErrServiceInternalErr(err, "failed to parse external spec")
+		return nil, "", merr.Wrap(err, "failed to parse external spec")
 	}
 
 	collInfo := m.mt.GetCollection(job.GetCollectionId())

--- a/internal/datacoord/external_collection_refresh_manager.go
+++ b/internal/datacoord/external_collection_refresh_manager.go
@@ -306,7 +306,7 @@ func (m *externalCollectionRefreshManager) cleanupExploreTempForJob(jobID int64)
 func (m *externalCollectionRefreshManager) applyFinishedJobSegments(ctx context.Context, job *datapb.ExternalCollectionRefreshJob) error {
 	tasks := m.refreshMeta.GetTasksByJobID(job.GetJobId())
 	if len(tasks) == 0 {
-		return fmt.Errorf("job %d has no tasks to apply", job.GetJobId())
+		return merr.WrapErrServiceInternalMsg("job %d has no tasks to apply", job.GetJobId())
 	}
 
 	keptSet := make(map[int64]struct{})
@@ -315,11 +315,11 @@ func (m *externalCollectionRefreshManager) applyFinishedJobSegments(ctx context.
 	updatedSegments := make([]*datapb.SegmentInfo, 0)
 	for _, task := range tasks {
 		if task.GetState() != indexpb.JobState_JobStateFinished {
-			return fmt.Errorf("job %d has non-finished task %d in state %s",
+			return merr.WrapErrServiceInternalMsg("job %d has non-finished task %d in state %s",
 				job.GetJobId(), task.GetTaskId(), task.GetState().String())
 		}
 		if !task.GetResultReady() {
-			return fmt.Errorf("job %d has finished task %d without persisted refresh result; please retry refresh",
+			return merr.WrapErrServiceInternalMsg("job %d has finished task %d without persisted refresh result; please retry refresh",
 				job.GetJobId(), task.GetTaskId())
 		}
 		for _, segmentID := range task.GetKeptSegments() {
@@ -334,7 +334,7 @@ func (m *externalCollectionRefreshManager) applyFinishedJobSegments(ctx context.
 				continue
 			}
 			if _, ok := updatedSet[segment.GetID()]; ok {
-				return fmt.Errorf("job %d has duplicate updated segment %d from task %d",
+				return merr.WrapErrServiceInternalMsg("job %d has duplicate updated segment %d from task %d",
 					job.GetJobId(), segment.GetID(), task.GetTaskId())
 			}
 			updatedSet[segment.GetID()] = struct{}{}
@@ -708,7 +708,7 @@ func (m *externalCollectionRefreshManager) createTasksForJob(
 		if errors.Is(err, packed.ErrLoonTransient) {
 			return nil, newNonRetriableJobError("explore external files failed: %v", err)
 		}
-		return nil, fmt.Errorf("failed to explore external files: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to explore external files")
 	}
 	if len(allFiles) == 0 {
 		return nil, newNonRetriableJobError("no files found in external source: %s", job.GetExternalSource())
@@ -823,7 +823,7 @@ func normalizeRefreshJobProgress(job *datapb.ExternalCollectionRefreshJob, state
 func (m *externalCollectionRefreshManager) GetJobProgress(ctx context.Context, jobID int64) (*datapb.ExternalCollectionRefreshJob, error) {
 	job := m.refreshMeta.GetJob(jobID)
 	if job == nil {
-		return nil, fmt.Errorf("job %d not found", jobID)
+		return nil, merr.WrapErrServiceInternalMsg("job %d not found", jobID)
 	}
 
 	// Aggregate state and progress from tasks
@@ -871,17 +871,17 @@ func (m *externalCollectionRefreshManager) exploreExternalFiles(
 	// when both present.
 	if job.GetExternalSource() != "" {
 		if err := externalspec.ValidateSourceAndSpec(job.GetExternalSource(), job.GetExternalSpec()); err != nil {
-			return nil, "", fmt.Errorf("external source/spec failed revalidation: %w", err)
+			return nil, "", merr.WrapErrServiceInternalErr(err, "external source/spec failed revalidation")
 		}
 	}
 	spec, err := externalspec.ParseExternalSpec(job.GetExternalSpec())
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to parse external spec: %w", err)
+		return nil, "", merr.WrapErrServiceInternalErr(err, "failed to parse external spec")
 	}
 
 	collInfo := m.mt.GetCollection(job.GetCollectionId())
 	if collInfo == nil {
-		return nil, "", fmt.Errorf("collection %d not found", job.GetCollectionId())
+		return nil, "", merr.WrapErrCollectionNotFound(job.GetCollectionId())
 	}
 
 	columns := packed.GetColumnNamesFromSchema(collInfo.Schema)
@@ -902,7 +902,7 @@ func (m *externalCollectionRefreshManager) exploreExternalFiles(
 		extfs,
 	)
 	if err != nil {
-		return nil, "", fmt.Errorf("ExploreFilesReturnManifestPath failed: %w", err)
+		return nil, "", merr.WrapErrServiceInternalErr(err, "failed to explore files returning manifest path")
 	}
 
 	// Convert to proto type

--- a/internal/datacoord/external_collection_refresh_meta.go
+++ b/internal/datacoord/external_collection_refresh_meta.go
@@ -416,7 +416,7 @@ func (m *externalCollectionRefreshMeta) UpdateJobStateWithPreApply(
 				log.Warn("update job state after pre-apply failed",
 					zap.Int64("jobID", jobID),
 					zap.Error(saveErr))
-				return false, merr.WrapErrServiceInternalErr(err, "pre-apply failed; additionally failed to persist Failed job state: %v", saveErr)
+				return false, merr.Wrapf(err, "pre-apply failed; additionally failed to persist Failed job state: %v", saveErr)
 			}
 			m.jobs.Insert(jobID, cloneJob)
 			m.addToCollectionJobs(cloneJob)

--- a/internal/datacoord/external_collection_refresh_meta.go
+++ b/internal/datacoord/external_collection_refresh_meta.go
@@ -18,7 +18,6 @@ package datacoord
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -295,7 +295,7 @@ func (m *externalCollectionRefreshMeta) mutateJob(
 ) (applied bool, err error) {
 	job, ok := m.jobs.Get(jobID)
 	if !ok {
-		return false, fmt.Errorf("job %d not found", jobID)
+		return false, merr.WrapErrServiceInternalMsg("job %d not found", jobID)
 	}
 
 	m.jobLock.Lock(job.GetCollectionId())
@@ -304,7 +304,7 @@ func (m *externalCollectionRefreshMeta) mutateJob(
 	// Re-fetch after lock
 	job, ok = m.jobs.Get(jobID)
 	if !ok {
-		return false, fmt.Errorf("job %d not found", jobID)
+		return false, merr.WrapErrServiceInternalMsg("job %d not found", jobID)
 	}
 
 	cloneJob := proto.Clone(job).(*datapb.ExternalCollectionRefreshJob)
@@ -385,7 +385,7 @@ func (m *externalCollectionRefreshMeta) UpdateJobStateWithPreApply(
 ) (bool, error) {
 	job, ok := m.jobs.Get(jobID)
 	if !ok {
-		return false, fmt.Errorf("job %d not found", jobID)
+		return false, merr.WrapErrServiceInternalMsg("job %d not found", jobID)
 	}
 
 	m.jobLock.Lock(job.GetCollectionId())
@@ -395,7 +395,7 @@ func (m *externalCollectionRefreshMeta) UpdateJobStateWithPreApply(
 	// terminal state owns the one-time side effects.
 	job, ok = m.jobs.Get(jobID)
 	if !ok {
-		return false, fmt.Errorf("job %d not found", jobID)
+		return false, merr.WrapErrServiceInternalMsg("job %d not found", jobID)
 	}
 	if job.GetState() == indexpb.JobState_JobStateFinished ||
 		job.GetState() == indexpb.JobState_JobStateFailed {
@@ -416,7 +416,7 @@ func (m *externalCollectionRefreshMeta) UpdateJobStateWithPreApply(
 				log.Warn("update job state after pre-apply failed",
 					zap.Int64("jobID", jobID),
 					zap.Error(saveErr))
-				return false, fmt.Errorf("pre-apply failed: %w; additionally failed to persist Failed job state: %v", err, saveErr)
+				return false, merr.WrapErrServiceInternalErr(err, "pre-apply failed; additionally failed to persist Failed job state: %v", saveErr)
 			}
 			m.jobs.Insert(jobID, cloneJob)
 			m.addToCollectionJobs(cloneJob)
@@ -613,7 +613,7 @@ func (m *externalCollectionRefreshMeta) mutateTask(
 ) (applied bool, cloned *datapb.ExternalCollectionRefreshTask, err error) {
 	task, ok := m.tasks.Get(taskID)
 	if !ok {
-		return false, nil, fmt.Errorf("task %d not found", taskID)
+		return false, nil, merr.WrapErrServiceInternalMsg("task %d not found", taskID)
 	}
 
 	m.taskLock.Lock(task.GetJobId())
@@ -622,7 +622,7 @@ func (m *externalCollectionRefreshMeta) mutateTask(
 	// Re-fetch after lock
 	task, ok = m.tasks.Get(taskID)
 	if !ok {
-		return false, nil, fmt.Errorf("task %d not found", taskID)
+		return false, nil, merr.WrapErrServiceInternalMsg("task %d not found", taskID)
 	}
 
 	cloneTask := proto.Clone(task).(*datapb.ExternalCollectionRefreshTask)

--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -958,13 +958,13 @@ func (gc *garbageCollector) isExpire(dropts Timestamp) bool {
 // Returns segmentID or error if path doesn't match.
 func parseV3SegmentID(rootPath, filePath string) (int64, error) {
 	if !strings.HasPrefix(filePath, rootPath) {
-		return 0, fmt.Errorf("path %q does not contain rootPath %q", filePath, rootPath)
+		return 0, merr.WrapErrServiceInternalMsg("path %q does not contain rootPath %q", filePath, rootPath)
 	}
 	p := strings.TrimPrefix(filePath[len(rootPath):], "/")
 	parts := strings.Split(p, "/")
 	// Minimum: insert_log/coll/part/seg/something
 	if len(parts) < 5 || parts[0] != common.SegmentInsertLogPath {
-		return 0, fmt.Errorf("not a V3 insert_log path: %s", filePath)
+		return 0, merr.WrapErrServiceInternalMsg("not a V3 insert_log path: %s", filePath)
 	}
 	return strconv.ParseInt(parts[3], 10, 64)
 }

--- a/internal/datacoord/garbage_collector_lob.go
+++ b/internal/datacoord/garbage_collector_lob.go
@@ -18,7 +18,6 @@ package datacoord
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"strings"
 	"sync"
@@ -34,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -271,8 +271,7 @@ func (lobCtx *lobGCContext) collectLOBFilesFromSegment(ctx context.Context, segm
 
 	lobFiles, err := lobCtx.cache.Get(ctx, manifestPath, lobCtx.storageConfig)
 	if err != nil {
-		return fmt.Errorf("failed to get LOB files from manifest for segment %d (path=%s): %w",
-			segment.GetID(), manifestPath, err)
+		return merr.WrapErrServiceInternalErr(err, "failed to get LOB files from manifest for segment %d (path=%s)", segment.GetID(), manifestPath)
 	}
 
 	for _, lobFile := range lobFiles {

--- a/internal/datacoord/index_meta.go
+++ b/internal/datacoord/index_meta.go
@@ -468,7 +468,7 @@ func (m *indexMeta) canCreateIndex(req *indexpb.CreateIndexRequest, isJSON bool)
 					index.IndexName, index.FieldID, index.IndexParams, index.UserIndexParams, index.TypeParams)),
 				zap.String("current index", fmt.Sprintf("{index_name: %s, field_id: %d, index_params: %v, user_params: %v, type_params: %v}",
 					req.GetIndexName(), req.GetFieldID(), req.GetIndexParams(), req.GetUserIndexParams(), req.GetTypeParams())))
-			return 0, fmt.Errorf("CreateIndex failed: %s", errMsg)
+			return 0, merr.WrapErrParameterInvalidMsg("%s", errMsg)
 		}
 		if req.FieldID == index.FieldID {
 			if isJSON {
@@ -484,7 +484,7 @@ func (m *indexMeta) canCreateIndex(req *indexpb.CreateIndexRequest, isJSON bool)
 			// creating multiple indexes on same field is not supported
 			errMsg := "CreateIndex failed: creating multiple indexes on same field is not supported"
 			log.Warn(errMsg)
-			return 0, errors.New(errMsg)
+			return 0, merr.WrapErrServiceInternalMsg(errMsg)
 		}
 	}
 	return 0, nil
@@ -985,7 +985,7 @@ func (m *indexMeta) UpdateVersion(buildID, nodeID UniqueID) error {
 	log.Ctx(m.ctx).Info("IndexCoord metaTable UpdateVersion receive", zap.Int64("buildID", buildID), zap.Int64("nodeID", nodeID))
 	segIdx, ok := m.segmentBuildInfo.Get(buildID)
 	if !ok {
-		return fmt.Errorf("there is no index with buildID: %d", buildID)
+		return merr.WrapErrServiceInternalMsg("there is no index with buildID: %d", buildID)
 	}
 
 	updateFunc := func(segIdx *model.SegmentIndex) error {
@@ -1004,7 +1004,7 @@ func (m *indexMeta) UpdateIndexState(buildID UniqueID, state commonpb.IndexState
 	segIdx, ok := m.segmentBuildInfo.Get(buildID)
 	if !ok {
 		log.Ctx(m.ctx).Warn("there is no index with buildID", zap.Int64("buildID", buildID))
-		return fmt.Errorf("there is no index with buildID: %d", buildID)
+		return merr.WrapErrServiceInternalMsg("there is no index with buildID: %d", buildID)
 	}
 
 	updateFunc := func(segIdx *model.SegmentIndex) error {
@@ -1114,7 +1114,7 @@ func (m *indexMeta) BuildIndex(buildID UniqueID) error {
 
 	segIdx, ok := m.segmentBuildInfo.Get(buildID)
 	if !ok {
-		return fmt.Errorf("there is no index with buildID: %d", buildID)
+		return merr.WrapErrServiceInternalMsg("there is no index with buildID: %d", buildID)
 	}
 
 	updateFunc := func(segIdx *model.SegmentIndex) error {

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -882,12 +882,12 @@ func (p *updateSegmentPack) Validate() error {
 		segmentInMeta := p.meta.segments.GetSegment(segment.ID)
 		if segmentInMeta.State == commonpb.SegmentState_Flushed && segment.State != commonpb.SegmentState_Dropped {
 			// if the segment is flushed, we should not update the segment meta, ignore the operation directly.
-			return merr.WrapErrServiceInternalErr(ErrIgnoredSegmentMetaOperation,
+			return merr.Wrapf(ErrIgnoredSegmentMetaOperation,
 				"segment is flushed, segmentID: %d",
 				segment.ID)
 		}
 		if segment.GetDmlPosition().GetTimestamp() < segmentInMeta.GetDmlPosition().GetTimestamp() {
-			return merr.WrapErrServiceInternalErr(ErrIgnoredSegmentMetaOperation,
+			return merr.Wrapf(ErrIgnoredSegmentMetaOperation,
 				"dml time tick is less than the segment meta, segmentID: %d, new incoming time tick: %d, existing time tick: %d",
 				segment.ID,
 				segment.GetDmlPosition().GetTimestamp(),

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -766,7 +766,7 @@ func (m *meta) GetSegmentsChannels(segmentIDs []UniqueID) (map[int64]string, err
 	for _, segmentID := range segmentIDs {
 		segment := m.segments.GetSegment(segmentID)
 		if segment == nil {
-			return nil, errors.New(fmt.Sprintf("cannot find segment %d", segmentID))
+			return nil, merr.WrapErrServiceInternalMsg("cannot find segment %d", segmentID)
 		}
 		segChannels[segmentID] = segment.GetInsertChannel()
 	}
@@ -790,7 +790,7 @@ func (m *meta) SetState(ctx context.Context, segmentID UniqueID, targetState com
 		if targetState == commonpb.SegmentState_Dropped {
 			return nil
 		}
-		return fmt.Errorf("segment is not exist with ID = %d", segmentID)
+		return merr.WrapErrServiceInternalMsg("segment is not exist with ID = %d", segmentID)
 	}
 	// Persist segment updates first.
 	clonedSegment := curSegInfo.Clone()
@@ -882,12 +882,12 @@ func (p *updateSegmentPack) Validate() error {
 		segmentInMeta := p.meta.segments.GetSegment(segment.ID)
 		if segmentInMeta.State == commonpb.SegmentState_Flushed && segment.State != commonpb.SegmentState_Dropped {
 			// if the segment is flushed, we should not update the segment meta, ignore the operation directly.
-			return errors.Wrapf(ErrIgnoredSegmentMetaOperation,
+			return merr.WrapErrServiceInternalErr(ErrIgnoredSegmentMetaOperation,
 				"segment is flushed, segmentID: %d",
 				segment.ID)
 		}
 		if segment.GetDmlPosition().GetTimestamp() < segmentInMeta.GetDmlPosition().GetTimestamp() {
-			return errors.Wrapf(ErrIgnoredSegmentMetaOperation,
+			return merr.WrapErrServiceInternalErr(ErrIgnoredSegmentMetaOperation,
 				"dml time tick is less than the segment meta, segmentID: %d, new incoming time tick: %d, existing time tick: %d",
 				segment.ID,
 				segment.GetDmlPosition().GetTimestamp(),
@@ -1759,7 +1759,7 @@ func (m *meta) AddAllocation(segmentID UniqueID, allocation *Allocation) error {
 	if curSegInfo == nil {
 		// TODO: Error handling.
 		log.Ctx(m.ctx).Error("meta update: add allocation failed - segment not found", zap.Int64("segmentID", segmentID))
-		return errors.New("meta update: add allocation failed - segment not found")
+		return merr.WrapErrServiceInternalMsg("meta update: add allocation failed - segment not found")
 	}
 	// As we use global segment lastExpire to guarantee data correctness after restart
 	// there is no need to persist allocation to meta store, only update allocation in-memory meta.
@@ -2255,7 +2255,7 @@ func (m *meta) HasSegments(segIDs []UniqueID) (bool, error) {
 
 	for _, segID := range segIDs {
 		if _, ok := m.segments.segments[segID]; !ok {
-			return false, fmt.Errorf("segment is not exist with ID = %d", segID)
+			return false, merr.WrapErrServiceInternalMsg("segment is not exist with ID = %d", segID)
 		}
 	}
 	return true, nil
@@ -2341,7 +2341,7 @@ func (m *meta) collectionHasTextFields(collectionID int64) bool {
 // UpdateChannelCheckpoint updates and saves channel checkpoint.
 func (m *meta) UpdateChannelCheckpoint(ctx context.Context, vChannel string, pos *msgpb.MsgPosition) error {
 	if pos == nil || pos.GetMsgID() == nil {
-		return fmt.Errorf("channelCP is nil, vChannel=%s", vChannel)
+		return merr.WrapErrServiceInternalMsg("channelCP is nil, vChannel=%s", vChannel)
 	}
 
 	// Clamp checkpoint to not advance beyond min growing segment checkpoint.
@@ -3015,7 +3015,7 @@ func (m *meta) GetFileResources(ctx context.Context, resourceIDs ...int64) ([]*i
 		if resource, ok := m.resourceIDMap[id]; ok {
 			resources = append(resources, resource)
 		} else {
-			return nil, errors.Errorf("file resource %d not found", id)
+			return nil, merr.WrapErrServiceInternalMsg("file resource %d not found", id)
 		}
 	}
 	return resources, nil

--- a/internal/datacoord/meta_util.go
+++ b/internal/datacoord/meta_util.go
@@ -17,12 +17,11 @@
 package datacoord
 
 import (
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
-var ErrIgnoredSegmentMetaOperation = errors.New("ignored segment meta operation")
+var ErrIgnoredSegmentMetaOperation = merr.WrapErrServiceInternalMsg("ignored segment meta operation")
 
 // reviseVChannelInfo will revise the datapb.VchannelInfo for upgrade compatibility from 2.0.2
 func reviseVChannelInfo(vChannel *datapb.VchannelInfo) {

--- a/internal/datacoord/metrics_info.go
+++ b/internal/datacoord/metrics_info.go
@@ -18,10 +18,8 @@ package datacoord
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
-	"github.com/cockroachdb/errors"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -138,7 +136,7 @@ func (s *Server) getSegmentsJSON(ctx context.Context, req *milvuspb.GetMetricsRe
 		}
 		return string(bs), nil
 	}
-	return "", fmt.Errorf("invalid param value in=[%s], it should be dc or dn", in)
+	return "", merr.WrapErrServiceInternalMsg("invalid param value in=[%s], it should be dc or dn", in)
 }
 
 func (s *Server) getDistJSON(ctx context.Context, req *milvuspb.GetMetricsRequest) string {
@@ -308,7 +306,7 @@ func (s *Server) getIndexNodeMetrics(ctx context.Context, req *milvuspb.GetMetri
 		},
 	}
 	if node == nil {
-		return infos, errors.New("IndexNode is nil")
+		return infos, merr.WrapErrServiceInternalMsg("index node is nil")
 	}
 
 	metrics, err := node.GetMetrics(ctx, req)

--- a/internal/datacoord/partition_stats_meta.go
+++ b/internal/datacoord/partition_stats_meta.go
@@ -2,7 +2,6 @@ package datacoord
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"go.uber.org/zap"
@@ -183,11 +182,11 @@ func (psm *partitionStatsMeta) innerSaveCurrentPartitionStatsVersion(collectionI
 
 	if _, ok := psm.partitionStatsInfos[vChannel]; !ok {
 		return merr.WrapErrClusteringCompactionMetaError("SaveCurrentPartitionStatsVersion",
-			fmt.Errorf("update current partition stats version failed, there is no partition info exists with collID: %d, partID: %d, vChannel: %s", collectionID, partitionID, vChannel))
+			merr.WrapErrServiceInternalMsg("update current partition stats version failed, there is no partition info exists with collID: %d, partID: %d, vChannel: %s", collectionID, partitionID, vChannel))
 	}
 	if _, ok := psm.partitionStatsInfos[vChannel][partitionID]; !ok {
 		return merr.WrapErrClusteringCompactionMetaError("SaveCurrentPartitionStatsVersion",
-			fmt.Errorf("update current partition stats version failed, there is no partition info exists with collID: %d, partID: %d, vChannel: %s", collectionID, partitionID, vChannel))
+			merr.WrapErrServiceInternalMsg("update current partition stats version failed, there is no partition info exists with collID: %d, partID: %d, vChannel: %s", collectionID, partitionID, vChannel))
 	}
 
 	if err := psm.catalog.SaveCurrentPartitionStatsVersion(psm.ctx, collectionID, partitionID, vChannel, currentPartitionStatsVersion); err != nil {

--- a/internal/datacoord/segment_allocation_policy.go
+++ b/internal/datacoord/segment_allocation_policy.go
@@ -23,12 +23,12 @@ import (
 	"sort"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -38,7 +38,7 @@ type calUpperLimitPolicy func(schema *schemapb.CollectionSchema) (int, error)
 
 func calBySchemaPolicy(schema *schemapb.CollectionSchema) (int, error) {
 	if schema == nil {
-		return -1, errors.New("nil schema")
+		return -1, merr.WrapErrServiceInternalMsg("nil schema")
 	}
 	sizePerRecord, err := typeutil.EstimateSizePerRecord(schema)
 	if err != nil {
@@ -46,7 +46,7 @@ func calBySchemaPolicy(schema *schemapb.CollectionSchema) (int, error) {
 	}
 	// check zero value, preventing panicking
 	if sizePerRecord == 0 {
-		return -1, errors.New("zero size record schema found")
+		return -1, merr.WrapErrServiceInternalMsg("zero size record schema found")
 	}
 	threshold := Params.DataCoordCfg.SegmentMaxSize.GetAsFloat() * 1024 * 1024
 	return int(threshold / float64(sizePerRecord)), nil

--- a/internal/datacoord/segment_manager.go
+++ b/internal/datacoord/segment_manager.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
@@ -36,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
@@ -299,7 +299,7 @@ func (s *SegmentManager) genLastExpireTsForSegments() (Timestamp, error) {
 	}, retry.Attempts(Params.DataCoordCfg.AllocLatestExpireAttempt.GetAsUint()), retry.Sleep(200*time.Millisecond))
 	if allocateErr != nil {
 		log.Warn("cannot allocate latest lastExpire from rootCoord", zap.Error(allocateErr))
-		return 0, errors.New("global max expire ts is unavailable for segment manager")
+		return 0, merr.WrapErrServiceInternalMsg("global max expire ts is unavailable for segment manager")
 	}
 	return latestTs, nil
 }
@@ -466,7 +466,7 @@ func (s *SegmentManager) estimateMaxNumOfRows(collectionID UniqueID) (int, error
 	// it's ok to use meta.GetCollection here, since collection meta is set before using segmentManager
 	collMeta := s.meta.GetCollection(collectionID)
 	if collMeta == nil {
-		return -1, fmt.Errorf("failed to get collection %d", collectionID)
+		return -1, merr.WrapErrServiceInternalMsg("failed to get collection %d", collectionID)
 	}
 	return s.estimatePolicy(collMeta.Schema)
 }

--- a/internal/datacoord/server.go
+++ b/internal/datacoord/server.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"github.com/tikv/client-go/v2/txnkv"
@@ -459,7 +458,7 @@ func (s *Server) SetSession(session sessionutil.SessionInterface) error {
 	s.session = session
 	s.icSession = session
 	if s.session == nil {
-		return errors.New("session is nil, the etcd client connection may have failed")
+		return merr.WrapErrServiceInternalMsg("session is nil, the etcd client connection may have failed")
 	}
 	return nil
 }
@@ -615,7 +614,7 @@ func (s *Server) initKV() error {
 		s.kv = etcdkv.NewEtcdKV(s.etcdCli, s.metaRootPath,
 			etcdkv.WithRequestTimeout(paramtable.Get().EtcdCfg.RequestTimeout.GetAsDuration(time.Millisecond)))
 	default:
-		return retry.Unrecoverable(fmt.Errorf("not supported meta store: %s", metaType))
+		return retry.Unrecoverable(merr.WrapErrServiceInternalMsg("unsupported meta store: %s", metaType))
 	}
 	log.Info("data coordinator successfully connected to metadata store", zap.String("metaType", metaType))
 	return nil
@@ -1024,7 +1023,7 @@ func (s *Server) flushFlushingSegment(ctx context.Context, segmentID UniqueID) e
 				return ctx.Err()
 			}
 			// underlying etcd may return context canceled, so we need to return a error to retry.
-			return errors.New("flush segment complete failed")
+			return merr.WrapErrServiceInternalMsg("flush segment complete failed")
 		}
 		return nil
 	}, retry.AttemptAlways())
@@ -1114,7 +1113,7 @@ func (s *Server) CleanMeta() error {
 	err2 := s.watchClient.RemoveWithPrefix(s.ctx, "")
 	if err2 != nil {
 		if err != nil {
-			err = fmt.Errorf("failed to CleanMeta[metadata cleanup error: %w][watchdata cleanup error: %v]", err, err2)
+			err = merr.WrapErrServiceInternalErr(err, "failed to clean meta (watchdata cleanup error: %v)", err2)
 		} else {
 			err = err2
 		}

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -1255,7 +1255,7 @@ func (s *Server) GetMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest
 		msg := "failed to get metrics"
 		log.Warn(msg, zap.Error(err))
 		return &milvuspb.GetMetricsResponse{
-			Status: merr.Status(merr.WrapErrServiceInternalErr(err, "%s", msg)),
+			Status: merr.Status(merr.Wrap(err, msg)),
 		}, nil
 	}
 

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -137,7 +137,7 @@ func (s *Server) flushCollection(ctx context.Context, collectionID UniqueID, flu
 		for _, channel := range coll.VChannelNames {
 			sealedSegmentIDs, err := s.segmentManager.SealAllSegments(ctx, channel, toFlushSegments)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to flush collection %d", collectionID)
+				return nil, merr.WrapErrServiceInternalErr(err, "failed to flush collection %d", collectionID)
 			}
 			for _, sealedSegmentID := range sealedSegmentIDs {
 				sealedSegmentsIDDict[sealedSegmentID] = true
@@ -1255,7 +1255,7 @@ func (s *Server) GetMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest
 		msg := "failed to get metrics"
 		log.Warn(msg, zap.Error(err))
 		return &milvuspb.GetMetricsResponse{
-			Status: merr.Status(errors.Wrap(err, msg)),
+			Status: merr.Status(merr.WrapErrServiceInternalErr(err, "%s", msg)),
 		}, nil
 	}
 

--- a/internal/datacoord/session/session.go
+++ b/internal/datacoord/session/session.go
@@ -18,12 +18,12 @@ package session
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 var errDisposed = errors.New("client is disposed")
@@ -84,7 +84,7 @@ func (n *Session) GetOrCreateClient(ctx context.Context) (types.DataNodeClient, 
 	}
 
 	if n.clientCreator == nil {
-		return nil, fmt.Errorf("unable to create client for %s because of a nil client creator", n.info.Address)
+		return nil, merr.WrapErrServiceInternalMsg("unable to create client for %s because of a nil client creator", n.info.Address)
 	}
 
 	err := n.initClient(ctx)

--- a/internal/datacoord/snapshot.go
+++ b/internal/datacoord/snapshot.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // S3 snapshot storage path constants.
@@ -115,7 +116,7 @@ func getManifestSchemaByVersion(version int) (avro.Schema, error) {
 	case 2:
 		return getManifestSchema()
 	default:
-		return nil, fmt.Errorf("unsupported manifest schema version: %d", version)
+		return nil, merr.WrapErrServiceInternalMsg("unsupported manifest schema version: %d", version)
 	}
 }
 
@@ -482,22 +483,22 @@ func GetSegmentManifestPath(manifestDir string, segmentID int64) string {
 func (w *SnapshotWriter) Save(ctx context.Context, snapshot *SnapshotData) (string, error) {
 	// Validate input parameters
 	if snapshot == nil {
-		return "", fmt.Errorf("snapshot cannot be nil")
+		return "", merr.WrapErrServiceInternalMsg("snapshot cannot be nil")
 	}
 	if snapshot.SnapshotInfo == nil {
-		return "", fmt.Errorf("snapshot info cannot be nil")
+		return "", merr.WrapErrServiceInternalMsg("snapshot info cannot be nil")
 	}
 	collectionID := snapshot.SnapshotInfo.GetCollectionId()
 	if collectionID <= 0 {
-		return "", fmt.Errorf("invalid collection ID: %d", collectionID)
+		return "", merr.WrapErrServiceInternalMsg("invalid collection ID: %d", collectionID)
 	}
 	if snapshot.Collection == nil {
-		return "", fmt.Errorf("collection description cannot be nil")
+		return "", merr.WrapErrServiceInternalMsg("collection description cannot be nil")
 	}
 
 	snapshotID := snapshot.SnapshotInfo.GetId()
 	if snapshotID <= 0 {
-		return "", fmt.Errorf("invalid snapshot ID: %d", snapshotID)
+		return "", merr.WrapErrServiceInternalMsg("invalid snapshot ID: %d", snapshotID)
 	}
 	manifestDir, metadataPath := GetSnapshotPaths(w.chunkManager.RootPath(), collectionID, snapshotID)
 
@@ -507,7 +508,7 @@ func (w *SnapshotWriter) Save(ctx context.Context, snapshot *SnapshotData) (stri
 	for _, segment := range snapshot.Segments {
 		manifestPath := GetSegmentManifestPath(manifestDir, segment.GetSegmentId())
 		if err := w.writeSegmentManifest(ctx, manifestPath, segment); err != nil {
-			return "", fmt.Errorf("failed to write manifest for segment %d: %w", segment.GetSegmentId(), err)
+			return "", merr.WrapErrServiceInternalErr(err, "failed to write manifest for segment %d", segment.GetSegmentId())
 		}
 		manifestPaths = append(manifestPaths, manifestPath)
 	}
@@ -531,7 +532,7 @@ func (w *SnapshotWriter) Save(ctx context.Context, snapshot *SnapshotData) (stri
 	// Step 3: Write metadata file with all manifest paths
 	// This file is the entry point for reading the snapshot
 	if err := w.writeMetadataFile(ctx, metadataPath, snapshot, manifestPaths, storagev2Manifests); err != nil {
-		return "", fmt.Errorf("failed to write metadata file: %w", err)
+		return "", merr.WrapErrServiceInternalErr(err, "failed to write metadata file")
 	}
 
 	log.Info("Successfully wrote metadata file",
@@ -558,12 +559,12 @@ func (w *SnapshotWriter) writeSegmentManifest(ctx context.Context, manifestPath 
 	// Serialize to Avro binary format (single record per file)
 	avroSchema, err := getManifestSchema()
 	if err != nil {
-		return fmt.Errorf("failed to get manifest schema: %w", err)
+		return merr.WrapErrServiceInternalErr(err, "failed to get manifest schema")
 	}
 
 	binaryData, err := avro.Marshal(avroSchema, entry)
 	if err != nil {
-		return fmt.Errorf("failed to serialize entry to avro: %w", err)
+		return merr.WrapErrServiceInternalErr(err, "failed to serialize entry to avro")
 	}
 
 	// Write to object storage
@@ -608,7 +609,7 @@ func (w *SnapshotWriter) writeMetadataFile(ctx context.Context, metadataPath str
 	}
 	jsonData, err := opts.Marshal(metadata)
 	if err != nil {
-		return fmt.Errorf("failed to marshal metadata to JSON: %w", err)
+		return merr.WrapErrServiceInternalErr(err, "failed to marshal metadata to JSON")
 	}
 
 	// Write to object storage
@@ -637,13 +638,13 @@ func (w *SnapshotWriter) writeMetadataFile(ctx context.Context, metadataPath str
 func (w *SnapshotWriter) Drop(ctx context.Context, metadataFilePath string) error {
 	// Validate input parameter
 	if metadataFilePath == "" {
-		return fmt.Errorf("metadata file path cannot be empty")
+		return merr.WrapErrServiceInternalMsg("metadata file path cannot be empty")
 	}
 
 	// Step 1: Read metadata file to discover manifest file paths
 	metadata, err := w.readMetadataFile(ctx, metadataFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to read metadata file: %w", err)
+		return merr.WrapErrServiceInternalErr(err, "failed to read metadata file")
 	}
 
 	snapshotID := metadata.GetSnapshotInfo().GetId()
@@ -652,7 +653,7 @@ func (w *SnapshotWriter) Drop(ctx context.Context, metadataFilePath string) erro
 	manifestList := metadata.GetManifestList()
 	if len(manifestList) > 0 {
 		if err := w.chunkManager.MultiRemove(ctx, manifestList); err != nil {
-			return fmt.Errorf("failed to remove manifest files: %w", err)
+			return merr.WrapErrServiceInternalErr(err, "failed to remove manifest files")
 		}
 		log.Info("Successfully removed manifest files",
 			zap.Int("count", len(manifestList)),
@@ -661,7 +662,7 @@ func (w *SnapshotWriter) Drop(ctx context.Context, metadataFilePath string) erro
 
 	// Step 3: Remove the metadata file (entry point)
 	if err := w.chunkManager.Remove(ctx, metadataFilePath); err != nil {
-		return fmt.Errorf("failed to remove metadata file: %w", err)
+		return merr.WrapErrServiceInternalErr(err, "failed to remove metadata file")
 	}
 	log.Info("Successfully removed metadata file",
 		zap.String("metadataFilePath", metadataFilePath))
@@ -677,7 +678,7 @@ func (w *SnapshotWriter) readMetadataFile(ctx context.Context, filePath string) 
 	// Read raw JSON content from object storage
 	data, err := w.chunkManager.Read(ctx, filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read metadata file: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to read metadata file")
 	}
 
 	// Use protojson for deserialization to correctly handle protobuf oneof fields
@@ -686,7 +687,7 @@ func (w *SnapshotWriter) readMetadataFile(ctx context.Context, filePath string) 
 		DiscardUnknown: true,
 	}
 	if err := opts.Unmarshal(data, metadata); err != nil {
-		return nil, fmt.Errorf("failed to parse metadata JSON: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to parse metadata JSON")
 	}
 
 	return metadata, nil
@@ -749,13 +750,13 @@ func NewSnapshotReader(cm storage.ChunkManager) *SnapshotReader {
 func (r *SnapshotReader) ReadSnapshot(ctx context.Context, metadataFilePath string, includeSegments bool) (*SnapshotData, error) {
 	// Validate input
 	if metadataFilePath == "" {
-		return nil, fmt.Errorf("metadata file path cannot be empty")
+		return nil, merr.WrapErrServiceInternalMsg("metadata file path cannot be empty")
 	}
 
 	// Step 1: Read metadata file (always required)
 	metadata, err := r.readMetadataFile(ctx, metadataFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read metadata file: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to read metadata file")
 	}
 
 	// Step 2: Optionally read segment details from manifest files
@@ -765,7 +766,7 @@ func (r *SnapshotReader) ReadSnapshot(ctx context.Context, metadataFilePath stri
 		for _, manifestPath := range metadata.GetManifestList() {
 			segments, err := r.readManifestFile(ctx, manifestPath, int(metadata.GetFormatVersion()))
 			if err != nil {
-				return nil, fmt.Errorf("failed to read manifest file %s: %w", manifestPath, err)
+				return nil, merr.WrapErrServiceInternalErr(err, "failed to read manifest file %s", manifestPath)
 			}
 			allSegments = append(allSegments, segments...)
 		}
@@ -804,7 +805,7 @@ func (r *SnapshotReader) readMetadataFile(ctx context.Context, filePath string) 
 	// Read raw JSON content from object storage
 	data, err := r.chunkManager.Read(ctx, filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read metadata file: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to read metadata file")
 	}
 
 	// Use protojson for deserialization to correctly handle protobuf oneof fields
@@ -813,12 +814,12 @@ func (r *SnapshotReader) readMetadataFile(ctx context.Context, filePath string) 
 		DiscardUnknown: true,
 	}
 	if err := opts.Unmarshal(data, metadata); err != nil {
-		return nil, fmt.Errorf("failed to parse metadata JSON: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to parse metadata JSON")
 	}
 
 	// Validate format version compatibility
 	if err := validateFormatVersion(int(metadata.GetFormatVersion())); err != nil {
-		return nil, fmt.Errorf("incompatible snapshot format: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "incompatible snapshot format")
 	}
 
 	return metadata, nil
@@ -839,7 +840,7 @@ func validateFormatVersion(version int) error {
 
 	// Check if version is too new for current code
 	if version > SnapshotFormatVersion {
-		return fmt.Errorf("snapshot format version %d is too new, current supported version: %d (please upgrade Milvus)",
+		return merr.WrapErrServiceInternalMsg("snapshot format version %d is too new, current supported version: %d (please upgrade Milvus)",
 			version, SnapshotFormatVersion)
 	}
 
@@ -862,20 +863,20 @@ func (r *SnapshotReader) readManifestFile(ctx context.Context, filePath string, 
 	// Read raw Avro content from object storage
 	data, err := r.chunkManager.Read(ctx, filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read manifest file: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to read manifest file")
 	}
 
 	// Get Avro schema for the specified format version
 	avroSchema, err := getManifestSchemaByVersion(formatVersion)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get manifest schema for version %d: %w", formatVersion, err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to get manifest schema for version %d", formatVersion)
 	}
 
 	// Deserialize Avro binary data to single ManifestEntry record
 	var record ManifestEntry
 	err = avro.Unmarshal(avroSchema, data, &record)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse avro data: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to parse avro data")
 	}
 
 	// Convert ManifestEntry record to protobuf SegmentDescription
@@ -947,7 +948,7 @@ func (r *SnapshotReader) readManifestFile(ctx context.Context, filePath string, 
 func (r *SnapshotReader) ListSnapshots(ctx context.Context, collectionID int64) ([]*datapb.SnapshotInfo, error) {
 	// Validate input parameters
 	if collectionID <= 0 {
-		return nil, fmt.Errorf("invalid collection ID: %d", collectionID)
+		return nil, merr.WrapErrServiceInternalMsg("invalid collection ID: %d", collectionID)
 	}
 
 	// Construct metadata directory path
@@ -957,7 +958,7 @@ func (r *SnapshotReader) ListSnapshots(ctx context.Context, collectionID int64) 
 	// List all files in the metadata directory
 	files, _, err := storage.ListAllChunkWithPrefix(ctx, r.chunkManager, metadataDir, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list metadata files: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to list metadata files")
 	}
 
 	// Read each metadata file and extract SnapshotInfo

--- a/internal/datacoord/snapshot_manager.go
+++ b/internal/datacoord/snapshot_manager.go
@@ -562,7 +562,7 @@ func (sm *snapshotManager) validateCMEKCompatibility(
 	// Get target database properties first (needed for both encrypted and non-encrypted snapshots)
 	dbResp, err := sm.broker.DescribeDatabase(ctx, targetDbName)
 	if err != nil {
-		return fmt.Errorf("failed to describe target database %s: %w", targetDbName, err)
+		return merr.WrapErrServiceInternalErr(err, "failed to describe target database %s", targetDbName)
 	}
 	targetIsEncrypted := hookutil.IsDBEncrypted(dbResp.GetProperties())
 
@@ -640,7 +640,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 	// ========================================================================
 	phase0Lock, err := startRestoreLock(ctx, sourceCollectionID, snapshotName, targetDbName, targetCollectionName)
 	if err != nil {
-		return 0, fmt.Errorf("failed to acquire restore lock: %w", err)
+		return 0, merr.WrapErrServiceInternalErr(err, "failed to acquire restore lock")
 	}
 
 	// Pin the source snapshot while holding the phase-0 lock. The pin is the
@@ -662,7 +662,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 	pinID, activePins, err := sm.snapshotMeta.PinSnapshot(ctx, sourceCollectionID, snapshotName, pinTTLSeconds)
 	if err != nil {
 		phase0Lock.Close()
-		return 0, fmt.Errorf("failed to pin source snapshot under restore lock: %w", err)
+		return 0, merr.WrapErrServiceInternalErr(err, "failed to pin source snapshot under restore lock")
 	}
 	setSnapshotActivePinsGauge(sourceCollectionID, snapshotName, activePins)
 	phase0Lock.Close()
@@ -691,7 +691,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 	// Phase 1: Read snapshot data (now protected by the refcount guard)
 	snapshotData, err := sm.ReadSnapshotData(ctx, sourceCollectionID, snapshotName)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read snapshot data: %w", err)
+		return 0, merr.WrapErrServiceInternalErr(err, "failed to read snapshot data")
 	}
 	log.Info("snapshot data loaded",
 		zap.Int("segmentCount", len(snapshotData.Segments)),
@@ -707,7 +707,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 	// Phase 2: Restore collection and partitions
 	collectionID, err := sm.RestoreCollection(ctx, snapshotData, targetCollectionName, targetDbName)
 	if err != nil {
-		return 0, fmt.Errorf("failed to restore collection: %w", err)
+		return 0, merr.WrapErrServiceInternalErr(err, "failed to restore collection")
 	}
 	log.Info("collection and partitions restored", zap.Int64("collectionID", collectionID))
 
@@ -718,7 +718,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 		if rollbackErr := rollback(ctx, targetDbName, targetCollectionName); rollbackErr != nil {
 			log.Error("rollback failed", zap.Error(rollbackErr))
 		}
-		return 0, fmt.Errorf("failed to restore indexes: %w", err)
+		return 0, merr.WrapErrServiceInternalErr(err, "failed to restore indexes")
 	}
 	log.Info("indexes restored", zap.Int("indexCount", len(snapshotData.Indexes)))
 
@@ -730,7 +730,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 		if rollbackErr := rollback(ctx, targetDbName, targetCollectionName); rollbackErr != nil {
 			log.Error("rollback failed", zap.Error(rollbackErr))
 		}
-		return 0, fmt.Errorf("failed to allocate job ID: %w", err)
+		return 0, merr.WrapErrServiceInternalErr(err, "failed to allocate job ID")
 	}
 	log.Info("pre-allocated job ID for restore", zap.Int64("jobID", jobID))
 
@@ -741,7 +741,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 		if rollbackErr := rollback(ctx, targetDbName, targetCollectionName); rollbackErr != nil {
 			log.Error("rollback failed", zap.Error(rollbackErr))
 		}
-		return 0, fmt.Errorf("failed to start broadcaster for restore message: %w", err)
+		return 0, merr.WrapErrServiceInternalErr(err, "failed to start broadcaster for restore message")
 	}
 	defer func() {
 		if restoreBroadcaster != nil {
@@ -760,7 +760,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 		if rollbackErr := rollback(ctx, targetDbName, targetCollectionName); rollbackErr != nil {
 			log.Error("rollback failed", zap.Error(rollbackErr))
 		}
-		err = fmt.Errorf("resource validation failed: %w", valErr)
+		err = merr.WrapErrServiceInternalErr(valErr, "resource validation failed")
 		return 0, err
 	}
 
@@ -785,7 +785,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 		if rollbackErr := rollback(ctx, targetDbName, targetCollectionName); rollbackErr != nil {
 			log.Error("rollback failed", zap.Error(rollbackErr))
 		}
-		err = fmt.Errorf("failed to broadcast restore message: %w", bcErr)
+		err = merr.WrapErrServiceInternalErr(bcErr, "failed to broadcast restore message")
 		return 0, err
 	}
 
@@ -872,14 +872,14 @@ func (sm *snapshotManager) RestoreIndexes(
 	// Get collection info for dbId
 	coll, err := sm.broker.DescribeCollectionInternal(ctx, collectionID)
 	if err != nil {
-		return fmt.Errorf("failed to describe collection %d: %w", collectionID, err)
+		return merr.WrapErrServiceInternalErr(err, "failed to describe collection %d", collectionID)
 	}
 
 	for _, indexInfo := range snapshotData.Indexes {
 		// Allocate new index ID
 		indexID, err := sm.allocator.AllocID(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to allocate index ID: %w", err)
+			return merr.WrapErrServiceInternalErr(err, "failed to allocate index ID")
 		}
 
 		// Build index model from snapshot data
@@ -898,19 +898,19 @@ func (sm *snapshotManager) RestoreIndexes(
 
 		// Validate the index params (basic validation without JSON path parsing)
 		if err := ValidateIndexParams(index); err != nil {
-			return fmt.Errorf("failed to validate index %s: %w", indexInfo.GetIndexName(), err)
+			return merr.WrapErrServiceInternalErr(err, "failed to validate index %s", indexInfo.GetIndexName())
 		}
 
 		// Check scalar index engine version for JSON path indexes with new types
 		if err := sm.checkJSONPathIndexVersion(index); err != nil {
-			return fmt.Errorf("failed to validate index %s: %w", indexInfo.GetIndexName(), err)
+			return merr.WrapErrServiceInternalErr(err, "failed to validate index %s", indexInfo.GetIndexName())
 		}
 
 		// Create a new broadcaster for each index
 		// (each broadcaster can only be used once due to resource key lock consumption)
 		b, err := startBroadcaster(ctx, collectionID, snapshotName)
 		if err != nil {
-			return fmt.Errorf("failed to start broadcaster for index %s: %w", indexInfo.GetIndexName(), err)
+			return merr.WrapErrServiceInternalErr(err, "failed to start broadcaster for index %s", indexInfo.GetIndexName())
 		}
 
 		// Broadcast CreateIndex message directly to DDL WAL
@@ -930,7 +930,7 @@ func (sm *snapshotManager) RestoreIndexes(
 		)
 		b.Close()
 		if err != nil {
-			return fmt.Errorf("failed to broadcast create index %s: %w", indexInfo.GetIndexName(), err)
+			return merr.WrapErrServiceInternalErr(err, "failed to broadcast create index %s", indexInfo.GetIndexName())
 		}
 
 		log.Ctx(ctx).Info("index restored via DDL WAL broadcast",
@@ -977,14 +977,14 @@ func (sm *snapshotManager) RestoreData(
 	snapshotData, err := sm.ReadSnapshotData(ctx, sourceCollectionID, snapshotName)
 	if err != nil {
 		log.Error("failed to read snapshot data", zap.Error(err))
-		return 0, fmt.Errorf("failed to read snapshot data: %w", err)
+		return 0, merr.WrapErrServiceInternalErr(err, "failed to read snapshot data")
 	}
 
 	// ========== Phase 2: Build partition mapping ==========
 	partitionMapping, err := sm.buildPartitionMapping(ctx, snapshotData, collectionID)
 	if err != nil {
 		log.Error("failed to build partition mapping", zap.Error(err))
-		return 0, fmt.Errorf("partition mapping failed: %w", err)
+		return 0, merr.WrapErrServiceInternalErr(err, "partition mapping failed")
 	}
 	log.Info("partition mapping built", zap.Any("partitionMapping", partitionMapping))
 
@@ -992,14 +992,14 @@ func (sm *snapshotManager) RestoreData(
 	channelMapping, err := sm.buildChannelMapping(ctx, snapshotData, collectionID)
 	if err != nil {
 		log.Error("failed to build channel mapping", zap.Error(err))
-		return 0, fmt.Errorf("channel mapping failed: %w", err)
+		return 0, merr.WrapErrServiceInternalErr(err, "channel mapping failed")
 	}
 
 	// ========== Phase 4: Create copy segment job ==========
 	// Use the pre-allocated jobID from the WAL message
 	if err := sm.createRestoreJob(ctx, collectionID, channelMapping, partitionMapping, snapshotData, jobID, pinID); err != nil {
 		log.Error("failed to create restore job", zap.Error(err))
-		return 0, fmt.Errorf("restore job creation failed: %w", err)
+		return 0, merr.WrapErrServiceInternalErr(err, "restore job creation failed")
 	}
 
 	log.Info("restore data completed successfully",
@@ -1047,7 +1047,7 @@ func (sm *snapshotManager) restoreUserPartitions(
 		}
 
 		if err := sm.broker.CreatePartition(ctx, req); err != nil {
-			return fmt.Errorf("failed to create partition %s: %w", partitionName, err)
+			return merr.WrapErrServiceInternalErr(err, "failed to create partition %s", partitionName)
 		}
 	}
 

--- a/internal/datacoord/snapshot_manager.go
+++ b/internal/datacoord/snapshot_manager.go
@@ -562,7 +562,7 @@ func (sm *snapshotManager) validateCMEKCompatibility(
 	// Get target database properties first (needed for both encrypted and non-encrypted snapshots)
 	dbResp, err := sm.broker.DescribeDatabase(ctx, targetDbName)
 	if err != nil {
-		return merr.WrapErrServiceInternalErr(err, "failed to describe target database %s", targetDbName)
+		return merr.Wrapf(err, "failed to describe target database %s", targetDbName)
 	}
 	targetIsEncrypted := hookutil.IsDBEncrypted(dbResp.GetProperties())
 
@@ -662,7 +662,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 	pinID, activePins, err := sm.snapshotMeta.PinSnapshot(ctx, sourceCollectionID, snapshotName, pinTTLSeconds)
 	if err != nil {
 		phase0Lock.Close()
-		return 0, merr.WrapErrServiceInternalErr(err, "failed to pin source snapshot under restore lock")
+		return 0, merr.Wrap(err, "failed to pin source snapshot under restore lock")
 	}
 	setSnapshotActivePinsGauge(sourceCollectionID, snapshotName, activePins)
 	phase0Lock.Close()
@@ -691,7 +691,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 	// Phase 1: Read snapshot data (now protected by the refcount guard)
 	snapshotData, err := sm.ReadSnapshotData(ctx, sourceCollectionID, snapshotName)
 	if err != nil {
-		return 0, merr.WrapErrServiceInternalErr(err, "failed to read snapshot data")
+		return 0, merr.Wrap(err, "failed to read snapshot data")
 	}
 	log.Info("snapshot data loaded",
 		zap.Int("segmentCount", len(snapshotData.Segments)),
@@ -707,7 +707,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 	// Phase 2: Restore collection and partitions
 	collectionID, err := sm.RestoreCollection(ctx, snapshotData, targetCollectionName, targetDbName)
 	if err != nil {
-		return 0, merr.WrapErrServiceInternalErr(err, "failed to restore collection")
+		return 0, merr.Wrap(err, "failed to restore collection")
 	}
 	log.Info("collection and partitions restored", zap.Int64("collectionID", collectionID))
 
@@ -718,7 +718,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 		if rollbackErr := rollback(ctx, targetDbName, targetCollectionName); rollbackErr != nil {
 			log.Error("rollback failed", zap.Error(rollbackErr))
 		}
-		return 0, merr.WrapErrServiceInternalErr(err, "failed to restore indexes")
+		return 0, merr.Wrap(err, "failed to restore indexes")
 	}
 	log.Info("indexes restored", zap.Int("indexCount", len(snapshotData.Indexes)))
 
@@ -741,7 +741,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 		if rollbackErr := rollback(ctx, targetDbName, targetCollectionName); rollbackErr != nil {
 			log.Error("rollback failed", zap.Error(rollbackErr))
 		}
-		return 0, merr.WrapErrServiceInternalErr(err, "failed to start broadcaster for restore message")
+		return 0, merr.Wrap(err, "failed to start broadcaster for restore message")
 	}
 	defer func() {
 		if restoreBroadcaster != nil {
@@ -760,7 +760,7 @@ func (sm *snapshotManager) RestoreSnapshot(
 		if rollbackErr := rollback(ctx, targetDbName, targetCollectionName); rollbackErr != nil {
 			log.Error("rollback failed", zap.Error(rollbackErr))
 		}
-		err = merr.WrapErrServiceInternalErr(valErr, "resource validation failed")
+		err = merr.Wrap(valErr, "resource validation failed")
 		return 0, err
 	}
 
@@ -872,7 +872,7 @@ func (sm *snapshotManager) RestoreIndexes(
 	// Get collection info for dbId
 	coll, err := sm.broker.DescribeCollectionInternal(ctx, collectionID)
 	if err != nil {
-		return merr.WrapErrServiceInternalErr(err, "failed to describe collection %d", collectionID)
+		return merr.Wrapf(err, "failed to describe collection %d", collectionID)
 	}
 
 	for _, indexInfo := range snapshotData.Indexes {
@@ -898,12 +898,12 @@ func (sm *snapshotManager) RestoreIndexes(
 
 		// Validate the index params (basic validation without JSON path parsing)
 		if err := ValidateIndexParams(index); err != nil {
-			return merr.WrapErrServiceInternalErr(err, "failed to validate index %s", indexInfo.GetIndexName())
+			return merr.Wrapf(err, "failed to validate index %s", indexInfo.GetIndexName())
 		}
 
 		// Check scalar index engine version for JSON path indexes with new types
 		if err := sm.checkJSONPathIndexVersion(index); err != nil {
-			return merr.WrapErrServiceInternalErr(err, "failed to validate index %s", indexInfo.GetIndexName())
+			return merr.Wrapf(err, "failed to validate index %s", indexInfo.GetIndexName())
 		}
 
 		// Create a new broadcaster for each index
@@ -977,14 +977,14 @@ func (sm *snapshotManager) RestoreData(
 	snapshotData, err := sm.ReadSnapshotData(ctx, sourceCollectionID, snapshotName)
 	if err != nil {
 		log.Error("failed to read snapshot data", zap.Error(err))
-		return 0, merr.WrapErrServiceInternalErr(err, "failed to read snapshot data")
+		return 0, merr.Wrap(err, "failed to read snapshot data")
 	}
 
 	// ========== Phase 2: Build partition mapping ==========
 	partitionMapping, err := sm.buildPartitionMapping(ctx, snapshotData, collectionID)
 	if err != nil {
 		log.Error("failed to build partition mapping", zap.Error(err))
-		return 0, merr.WrapErrServiceInternalErr(err, "partition mapping failed")
+		return 0, merr.Wrap(err, "partition mapping failed")
 	}
 	log.Info("partition mapping built", zap.Any("partitionMapping", partitionMapping))
 
@@ -992,14 +992,14 @@ func (sm *snapshotManager) RestoreData(
 	channelMapping, err := sm.buildChannelMapping(ctx, snapshotData, collectionID)
 	if err != nil {
 		log.Error("failed to build channel mapping", zap.Error(err))
-		return 0, merr.WrapErrServiceInternalErr(err, "channel mapping failed")
+		return 0, merr.Wrap(err, "channel mapping failed")
 	}
 
 	// ========== Phase 4: Create copy segment job ==========
 	// Use the pre-allocated jobID from the WAL message
 	if err := sm.createRestoreJob(ctx, collectionID, channelMapping, partitionMapping, snapshotData, jobID, pinID); err != nil {
 		log.Error("failed to create restore job", zap.Error(err))
-		return 0, merr.WrapErrServiceInternalErr(err, "restore job creation failed")
+		return 0, merr.Wrap(err, "restore job creation failed")
 	}
 
 	log.Info("restore data completed successfully",
@@ -1047,7 +1047,7 @@ func (sm *snapshotManager) restoreUserPartitions(
 		}
 
 		if err := sm.broker.CreatePartition(ctx, req); err != nil {
-			return merr.WrapErrServiceInternalErr(err, "failed to create partition %s", partitionName)
+			return merr.Wrapf(err, "failed to create partition %s", partitionName)
 		}
 	}
 

--- a/internal/datacoord/snapshot_meta.go
+++ b/internal/datacoord/snapshot_meta.go
@@ -572,7 +572,7 @@ func (sm *snapshotMeta) SaveSnapshot(ctx context.Context, snapshot *SnapshotData
 
 	if err := sm.catalog.SaveSnapshot(ctx, snapshot.SnapshotInfo); err != nil {
 		log.Error("failed to save pending snapshot to catalog", zap.Error(err))
-		return fmt.Errorf("failed to save pending snapshot to catalog: %w", err)
+		return merr.WrapErrServiceInternalErr(err, "failed to save pending snapshot to catalog")
 	}
 	log.Info("saved pending snapshot to catalog")
 
@@ -582,7 +582,7 @@ func (sm *snapshotMeta) SaveSnapshot(ctx context.Context, snapshot *SnapshotData
 		// S3 write failed, leave PENDING record for GC to clean up
 		log.Error("failed to save snapshot to S3, pending record left for GC cleanup",
 			zap.Error(err))
-		return fmt.Errorf("failed to save snapshot to S3: %w", err)
+		return merr.WrapErrServiceInternalErr(err, "failed to save snapshot to S3")
 	}
 	snapshot.SnapshotInfo.S3Location = metadataFilePath
 	log.Info("saved snapshot data to S3", zap.String("s3Location", metadataFilePath))
@@ -598,7 +598,7 @@ func (sm *snapshotMeta) SaveSnapshot(ctx context.Context, snapshot *SnapshotData
 		// GC will eventually cleanup via the PENDING marker.
 		log.Error("failed to update snapshot to committed state, pending record left for GC cleanup",
 			zap.Error(err))
-		return fmt.Errorf("failed to update snapshot to committed state: %w", err)
+		return merr.WrapErrServiceInternalErr(err, "failed to update snapshot to committed state")
 	}
 
 	// Catalog committed — safe to insert into in-memory cache and register protection.
@@ -809,8 +809,7 @@ func (sm *snapshotMeta) DropSnapshotsByCollection(ctx context.Context, collectio
 	}
 
 	if len(errs) > 0 {
-		return dropped, fmt.Errorf("failed to drop %d/%d snapshots for collection %d: %w",
-			len(errs), len(snapshotNames), collectionID, merr.Combine(errs...))
+		return dropped, merr.WrapErrServiceInternalErr(merr.Combine(errs...), "failed to drop %d/%d snapshots for collection %d", len(errs), len(snapshotNames), collectionID)
 	}
 
 	return dropped, nil
@@ -1006,7 +1005,7 @@ func (sm *snapshotMeta) GetPendingSnapshots(ctx context.Context, pendingTimeout 
 	// Get all snapshots from catalog (etcd)
 	snapshots, err := sm.catalog.ListSnapshots(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list snapshots from catalog: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to list snapshots from catalog")
 	}
 
 	now := time.Now().UnixMilli()
@@ -1057,7 +1056,7 @@ func (sm *snapshotMeta) CleanupPendingSnapshot(ctx context.Context, snapshot *da
 func (sm *snapshotMeta) GetDeletingSnapshots(ctx context.Context) ([]*datapb.SnapshotInfo, error) {
 	snapshots, err := sm.catalog.ListSnapshots(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list snapshots from catalog: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to list snapshots from catalog")
 	}
 
 	deletingSnapshots := make([]*datapb.SnapshotInfo, 0)
@@ -1774,7 +1773,7 @@ func (sm *snapshotMeta) generatePinID(snapshot *datapb.SnapshotInfo) (int64, err
 	for i := 0; i < 3; i++ {
 		var b [8]byte
 		if _, err := cryptorand.Read(b[:]); err != nil {
-			return 0, fmt.Errorf("failed to generate random pin ID: %w", err)
+			return 0, merr.WrapErrServiceInternalErr(err, "failed to generate random pin ID")
 		}
 		id := int64(binary.BigEndian.Uint64(b[:]) >> 1)
 		if id == 0 {
@@ -1784,5 +1783,5 @@ func (sm *snapshotMeta) generatePinID(snapshot *datapb.SnapshotInfo) (int64, err
 			return id, nil
 		}
 	}
-	return 0, fmt.Errorf("failed to generate unique pin ID after 3 attempts")
+	return 0, merr.WrapErrServiceInternalMsg("failed to generate unique pin ID after 3 attempts")
 }

--- a/internal/datacoord/stats_task_meta.go
+++ b/internal/datacoord/stats_task_meta.go
@@ -182,7 +182,7 @@ func (stm *statsTaskMeta) UpdateVersion(taskID, nodeID int64) error {
 
 	t, ok := stm.tasks.Get(taskID)
 	if !ok {
-		return fmt.Errorf("task %d not found", taskID)
+		return merr.WrapErrServiceInternalMsg("task %d not found", taskID)
 	}
 
 	cloneT := proto.Clone(t).(*indexpb.StatsTask)
@@ -212,7 +212,7 @@ func (stm *statsTaskMeta) UpdateTaskState(taskID int64, state indexpb.JobState, 
 
 	t, ok := stm.tasks.Get(taskID)
 	if !ok {
-		return fmt.Errorf("task %d not found", taskID)
+		return merr.WrapErrServiceInternalMsg("task %d not found", taskID)
 	}
 
 	cloneT := proto.Clone(t).(*indexpb.StatsTask)
@@ -239,7 +239,7 @@ func (stm *statsTaskMeta) UpdateBuildingTask(taskID int64) error {
 
 	t, ok := stm.tasks.Get(taskID)
 	if !ok {
-		return fmt.Errorf("task %d not found", taskID)
+		return merr.WrapErrServiceInternalMsg("task %d not found", taskID)
 	}
 
 	cloneT := proto.Clone(t).(*indexpb.StatsTask)
@@ -267,7 +267,7 @@ func (stm *statsTaskMeta) FinishTask(taskID int64, result *workerpb.StatsResult)
 
 	t, ok := stm.tasks.Get(taskID)
 	if !ok {
-		return fmt.Errorf("task %d not found", taskID)
+		return merr.WrapErrServiceInternalMsg("task %d not found", taskID)
 	}
 
 	cloneT := proto.Clone(t).(*indexpb.StatsTask)
@@ -358,7 +358,7 @@ func (stm *statsTaskMeta) MarkTaskCanRecycle(taskID int64) error {
 
 	t, ok := stm.tasks.Get(taskID)
 	if !ok {
-		return fmt.Errorf("task %d not found", taskID)
+		return merr.WrapErrServiceInternalMsg("task %d not found", taskID)
 	}
 
 	cloneT := proto.Clone(t).(*indexpb.StatsTask)

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -18,7 +18,6 @@ package datacoord
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"time"
 
@@ -241,7 +240,7 @@ func (it *indexBuildTask) prepareJobRequest(ctx context.Context, segment *Segmen
 		var err error
 		params, err = Params.KnowhereConfig.UpdateIndexParams(GetIndexType(params), paramtable.BuildStage, params)
 		if err != nil {
-			return nil, fmt.Errorf("failed to update index build params: %w", err)
+			return nil, merr.WrapErrServiceInternalErr(err, "failed to update index build params")
 		}
 	}
 
@@ -249,14 +248,14 @@ func (it *indexBuildTask) prepareJobRequest(ctx context.Context, segment *Segmen
 		var err error
 		params, err = indexparams.UpdateDiskIndexBuildParams(Params, params)
 		if err != nil {
-			return nil, fmt.Errorf("failed to append index build params: %w", err)
+			return nil, merr.WrapErrServiceInternalErr(err, "failed to append index build params")
 		}
 	}
 
 	// Get collection info and field
 	collectionInfo, err := it.handler.GetCollection(ctx, segment.GetCollectionID())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get collection info: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to get collection info")
 	}
 
 	schema := collectionInfo.Schema
@@ -271,7 +270,7 @@ func (it *indexBuildTask) prepareJobRequest(ctx context.Context, segment *Segmen
 	}
 
 	if field == nil {
-		return nil, fmt.Errorf("field not found with ID %d", fieldID)
+		return nil, merr.WrapErrServiceInternalMsg("field not found with ID %d", fieldID)
 	}
 
 	// Extract dim only for vector types to avoid unnecessary warnings

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -255,7 +255,7 @@ func (it *indexBuildTask) prepareJobRequest(ctx context.Context, segment *Segmen
 	// Get collection info and field
 	collectionInfo, err := it.handler.GetCollection(ctx, segment.GetCollectionID())
 	if err != nil {
-		return nil, merr.WrapErrServiceInternalErr(err, "failed to get collection info")
+		return nil, merr.Wrap(err, "failed to get collection info")
 	}
 
 	schema := collectionInfo.Schema

--- a/internal/datacoord/task_refresh_external_collection.go
+++ b/internal/datacoord/task_refresh_external_collection.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -113,7 +114,7 @@ func (t *refreshExternalCollectionTask) validateSource() error {
 	// Validate against job-level snapshot to isolate in-flight tasks from schema changes.
 	job := t.refreshMeta.GetJob(t.GetJobId())
 	if job == nil {
-		return fmt.Errorf("job %d not found", t.GetJobId())
+		return merr.WrapErrServiceInternalMsg("job %d not found", t.GetJobId())
 	}
 
 	currentSource := job.GetExternalSource()
@@ -123,7 +124,7 @@ func (t *refreshExternalCollectionTask) validateSource() error {
 	taskSpec := t.GetExternalSpec()
 
 	if currentSource != taskSource || currentSpec != taskSpec {
-		return fmt.Errorf(
+		return merr.WrapErrServiceInternalMsg(
 			"task source mismatch: task source=%s/%s, job source=%s/%s (task belongs to a different refresh job)",
 			taskSource, taskSpec, currentSource, currentSpec,
 		)
@@ -213,7 +214,7 @@ func applyExternalCollectionSegmentUpdate(
 	logFields ...zap.Field,
 ) error {
 	if mt == nil {
-		return fmt.Errorf("meta is nil, cannot update segments")
+		return merr.WrapErrServiceInternalMsg("meta is nil, cannot update segments")
 	}
 	fields := append(logFields, zap.Int64("collectionID", collectionID))
 	log := log.Ctx(ctx).With(fields...)
@@ -258,7 +259,7 @@ func applyExternalCollectionSegmentUpdate(
 			zap.Int("activeSegmentCount", activeSegmentCount),
 			zap.Int("keptSegments", len(keptSegmentIDs)),
 			zap.Int("updatedSegments", len(updatedSegments)))
-		return fmt.Errorf("safety check failed: refusing to drop all %d segments without replacement (keptSegments=%d, updatedSegments=%d)",
+		return merr.WrapErrServiceInternalMsg("safety check failed: refusing to drop all %d segments without replacement (keptSegments=%d, updatedSegments=%d)",
 			activeSegmentCount, len(keptSegmentIDs), len(updatedSegments))
 	}
 
@@ -284,15 +285,15 @@ func applyExternalCollectionSegmentUpdate(
 	// These are required for QueryCoord to include segments in its loading target.
 	collInfo := mt.GetCollection(collectionID)
 	if collInfo == nil {
-		return fmt.Errorf("collection %d not found in meta", collectionID)
+		return merr.WrapErrServiceInternalMsg("collection %d not found in meta", collectionID)
 	}
 	// External collections are single-shard, single-partition (enforced at creation).
 	// Assert exactly-one here to catch any invariant violation from data corruption or legacy data.
 	if len(collInfo.VChannelNames) != 1 {
-		return fmt.Errorf("external collection %d expected exactly 1 VChannel, got %d", collectionID, len(collInfo.VChannelNames))
+		return merr.WrapErrServiceInternalMsg("external collection %d expected exactly 1 VChannel, got %d", collectionID, len(collInfo.VChannelNames))
 	}
 	if len(collInfo.Partitions) != 1 {
-		return fmt.Errorf("external collection %d expected exactly 1 partition, got %d", collectionID, len(collInfo.Partitions))
+		return merr.WrapErrServiceInternalMsg("external collection %d expected exactly 1 partition, got %d", collectionID, len(collInfo.Partitions))
 	}
 	insertChannel := collInfo.VChannelNames[0]
 	partitionID := collInfo.Partitions[0]
@@ -417,7 +418,7 @@ func (t *refreshExternalCollectionTask) CreateTaskOnWorker(nodeID int64, cluster
 	log.Info("creating refresh task on worker")
 
 	if t.mt == nil {
-		err = fmt.Errorf("meta is nil, cannot create task on worker")
+		err = merr.WrapErrServiceInternalMsg("meta is nil, cannot create task on worker")
 		return
 	}
 
@@ -430,7 +431,7 @@ func (t *refreshExternalCollectionTask) CreateTaskOnWorker(nodeID int64, cluster
 	// Re-read task from meta to sync in-memory state (nodeID and version)
 	updatedTask := t.refreshMeta.GetTask(t.GetTaskId())
 	if updatedTask == nil {
-		err = fmt.Errorf("task %d not found after version update", t.GetTaskId())
+		err = merr.WrapErrServiceInternalMsg("task %d not found after version update", t.GetTaskId())
 		return
 	}
 	t.ExternalCollectionRefreshTask = updatedTask
@@ -467,7 +468,7 @@ func (t *refreshExternalCollectionTask) CreateTaskOnWorker(nodeID int64, cluster
 	// Get collection schema for column mapping
 	collInfo := t.mt.GetCollection(t.GetCollectionId())
 	if collInfo == nil {
-		err = fmt.Errorf("collection %d not found in meta", t.GetCollectionId())
+		err = merr.WrapErrServiceInternalMsg("collection %d not found in meta", t.GetCollectionId())
 		return
 	}
 	if len(collInfo.Partitions) != 1 {

--- a/internal/datacoord/task_stats.go
+++ b/internal/datacoord/task_stats.go
@@ -299,7 +299,7 @@ func (st *statsTask) handleEmptySegment(ctx context.Context) error {
 func (st *statsTask) prepareJobRequest(ctx context.Context, segment *SegmentInfo) (*workerpb.CreateStatsRequest, error) {
 	collInfo, err := st.handler.GetCollection(ctx, segment.GetCollectionID())
 	if err != nil || collInfo == nil {
-		return nil, merr.WrapErrServiceInternalErr(err, "failed to get collection info")
+		return nil, merr.Wrap(err, "failed to get collection info")
 	}
 	if collInfo.Schema == nil || len(collInfo.Schema.GetFields()) == 0 {
 		return nil, merr.WrapErrServiceInternalMsg("collection schema is nil or has no fields, collectionID: %d", segment.GetCollectionID())

--- a/internal/datacoord/task_stats.go
+++ b/internal/datacoord/task_stats.go
@@ -18,7 +18,6 @@ package datacoord
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -300,10 +299,10 @@ func (st *statsTask) handleEmptySegment(ctx context.Context) error {
 func (st *statsTask) prepareJobRequest(ctx context.Context, segment *SegmentInfo) (*workerpb.CreateStatsRequest, error) {
 	collInfo, err := st.handler.GetCollection(ctx, segment.GetCollectionID())
 	if err != nil || collInfo == nil {
-		return nil, fmt.Errorf("failed to get collection info: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to get collection info")
 	}
 	if collInfo.Schema == nil || len(collInfo.Schema.GetFields()) == 0 {
-		return nil, fmt.Errorf("collection schema is nil or has no fields, collectionID: %d", segment.GetCollectionID())
+		return nil, merr.WrapErrServiceInternalMsg("collection schema is nil or has no fields, collectionID: %d", segment.GetCollectionID())
 	}
 
 	// Calculate binlog allocation
@@ -314,7 +313,7 @@ func (st *statsTask) prepareJobRequest(ctx context.Context, segment *SegmentInfo
 	// Allocate IDs
 	start, end, err := st.allocator.AllocN(binlogNum + int64(len(collInfo.Schema.GetFunctions())) + 1)
 	if err != nil {
-		return nil, fmt.Errorf("failed to allocate log IDs: %w", err)
+		return nil, merr.WrapErrServiceInternalErr(err, "failed to allocate log IDs")
 	}
 
 	// Create the request

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -21,13 +21,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-<<<<<<< HEAD
 	"io"
 	"net"
 	"net/http"
-=======
-	"net"
->>>>>>> 9e452624b8 (test: use random free ports in Test_NewHTTPServer_TLS_* to avoid 8080 collision)
 	"net/http/httptest"
 	"os"
 	"strconv"

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -21,9 +21,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+<<<<<<< HEAD
 	"io"
 	"net"
 	"net/http"
+=======
+	"net"
+>>>>>>> 9e452624b8 (test: use random free ports in Test_NewHTTPServer_TLS_* to avoid 8080 collision)
 	"net/http/httptest"
 	"os"
 	"strconv"
@@ -1129,6 +1133,18 @@ func Test_NewServer_TLS_FileNotExisted(t *testing.T) {
 	server.Stop()
 }
 
+// freeTCPPort grabs a random unused TCP port. The TLS HTTP-server tests
+// below hardcoded port 8080 originally, which collides with anything else
+// already bound to that port on the dev machine (e.g. the TEI text-embedding
+// container in our compose stack).
+func freeTCPPort(t *testing.T) string {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	assert.NoError(t, ln.Close())
+	return strconv.Itoa(port)
+}
+
 func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	server := getServer(t)
 
@@ -1149,7 +1165,7 @@ func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(Params.CaPemPath.Key, "../../../configs/cert/ca.pem")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	assert.Nil(t, err)
@@ -1183,7 +1199,7 @@ func Test_NewHTTPServer_TLS_OneWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../../../configs/cert/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	fmt.Printf("err: %v\n", err)
@@ -1242,7 +1258,7 @@ func Test_NewHTTPServer_TLS_FileNotExisted(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../not/existed/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 	err := runAndWaitForServerReady(server)
 	assert.NotNil(t, err)
 	server.Stop()

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1421,7 +1421,7 @@ func ValidateUsername(username string) error {
 	}
 
 	if len(username) > Params.ProxyCfg.MaxUsernameLength.GetAsInt() {
-		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetValue())
+		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetAsInt())
 	}
 
 	firstChar := username[0]

--- a/internal/querycoordv2/ddl_callbacks.go
+++ b/internal/querycoordv2/ddl_callbacks.go
@@ -25,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -78,7 +79,7 @@ func (c *Server) startBroadcastWithCollectionIDLock(ctx context.Context, collect
 		message.NewExclusiveCollectionNameResourceKey(coll.GetDbName(), coll.GetCollectionName()),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start broadcast with collection lock")
+		return nil, merr.Wrap(err, "failed to start broadcast with collection lock")
 	}
 	return broadcaster, nil
 }

--- a/internal/querycoordv2/ddl_callbacks_alter_resource_group.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_resource_group.go
@@ -32,11 +32,11 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 )
 
-func (s *Server) broadcastCreateResourceGroup(ctx context.Context, req *milvuspb.CreateResourceGroupRequest) error {
+func (s *Server) broadcastCreateResourceGroup(ctx context.Context, req *milvuspb.CreateResourceGroupRequest) (ignored bool, err error) {
 	broadcaster, err := broadcast.StartBroadcastWithResourceKeys(ctx, message.NewExclusiveClusterResourceKey())
 	if err != nil {
 		if !shouldApplyLocallyOnNonPrimary(err, message.MessageTypeAlterResourceGroup) {
-			return err
+			return false, err
 		}
 	}
 	if broadcaster != nil {
@@ -48,8 +48,8 @@ func (s *Server) broadcastCreateResourceGroup(ctx context.Context, req *milvuspb
 		// Use default config if not set, compatible with old client.
 		cfg = meta.NewResourceGroupConfig(0, 0)
 	}
-	if err := s.meta.CheckIfResourceGroupAddable(ctx, req.GetResourceGroup(), cfg); err != nil {
-		return err
+	if ignored, err := s.meta.CheckIfResourceGroupAddable(ctx, req.GetResourceGroup(), cfg); err != nil || ignored {
+		return ignored, err
 	}
 
 	msg := message.NewAlterResourceGroupMessageBuilderV2().
@@ -60,10 +60,10 @@ func (s *Server) broadcastCreateResourceGroup(ctx context.Context, req *milvuspb
 		WithBroadcast([]string{streaming.WAL().ControlChannel()}).
 		MustBuildBroadcast()
 	if broadcaster == nil {
-		return registry.CallMessageAckCallback(ctx, msg, nil)
+		return false, registry.CallMessageAckCallback(ctx, msg, nil)
 	}
 	_, err = broadcaster.Broadcast(ctx, msg)
-	return err
+	return false, err
 }
 
 func (s *Server) broadcastUpdateResourceGroups(ctx context.Context, req *querypb.UpdateResourceGroupsRequest) error {

--- a/internal/querycoordv2/ddl_callbacks_drop_resource_group.go
+++ b/internal/querycoordv2/ddl_callbacks_drop_resource_group.go
@@ -44,8 +44,7 @@ func (s *Server) broadcastDropResourceGroup(ctx context.Context, req *milvuspb.D
 	replicas := s.meta.GetByResourceGroup(ctx, req.GetResourceGroup())
 	if len(replicas) > 0 {
 		err := merr.WrapErrParameterInvalid("empty resource group", fmt.Sprintf("resource group %s has collection %d loaded", req.GetResourceGroup(), replicas[0].GetCollectionID()))
-		return errors.Wrap(err,
-			fmt.Sprintf("some replicas still loaded in resource group[%s], release it first", req.GetResourceGroup()))
+		return errors.Wrapf(err, "some replicas still loaded in resource group[%s], release it first", req.GetResourceGroup())
 	}
 	if err := s.meta.CheckIfResourceGroupDropable(ctx, req.GetResourceGroup()); err != nil {
 		return err

--- a/internal/querycoordv2/ddl_callbacks_drop_resource_group.go
+++ b/internal/querycoordv2/ddl_callbacks_drop_resource_group.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
@@ -30,11 +28,11 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
-func (s *Server) broadcastDropResourceGroup(ctx context.Context, req *milvuspb.DropResourceGroupRequest) error {
+func (s *Server) broadcastDropResourceGroup(ctx context.Context, req *milvuspb.DropResourceGroupRequest) (ignored bool, err error) {
 	broadcaster, err := broadcast.StartBroadcastWithResourceKeys(ctx, message.NewExclusiveClusterResourceKey())
 	if err != nil {
 		if !shouldApplyLocallyOnNonPrimary(err, message.MessageTypeDropResourceGroup) {
-			return err
+			return false, err
 		}
 	}
 	if broadcaster != nil {
@@ -44,10 +42,10 @@ func (s *Server) broadcastDropResourceGroup(ctx context.Context, req *milvuspb.D
 	replicas := s.meta.GetByResourceGroup(ctx, req.GetResourceGroup())
 	if len(replicas) > 0 {
 		err := merr.WrapErrParameterInvalid("empty resource group", fmt.Sprintf("resource group %s has collection %d loaded", req.GetResourceGroup(), replicas[0].GetCollectionID()))
-		return errors.Wrapf(err, "some replicas still loaded in resource group[%s], release it first", req.GetResourceGroup())
+		return false, merr.Wrapf(err, "some replicas still loaded in resource group[%s], release it first", req.GetResourceGroup())
 	}
-	if err := s.meta.CheckIfResourceGroupDropable(ctx, req.GetResourceGroup()); err != nil {
-		return err
+	if ignored, err := s.meta.CheckIfResourceGroupDropable(ctx, req.GetResourceGroup()); err != nil || ignored {
+		return ignored, err
 	}
 
 	msg := message.NewDropResourceGroupMessageBuilderV2().
@@ -58,10 +56,10 @@ func (s *Server) broadcastDropResourceGroup(ctx context.Context, req *milvuspb.D
 		WithBroadcast([]string{streaming.WAL().ControlChannel()}).
 		MustBuildBroadcast()
 	if broadcaster == nil {
-		return registry.CallMessageAckCallback(ctx, msg, nil)
+		return false, registry.CallMessageAckCallback(ctx, msg, nil)
 	}
 	_, err = broadcaster.Broadcast(ctx, msg)
-	return err
+	return false, err
 }
 
 func (c *DDLCallbacks) dropResourceGroupV2AckCallback(ctx context.Context, result message.BroadcastResultDropResourceGroupMessageV2) error {

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -18,7 +18,6 @@ package querycoordv2
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -166,7 +165,7 @@ func (s *Server) balanceSegments(ctx context.Context,
 		if err != nil {
 			msg := "failed to wait all balance task finished"
 			log.Warn(msg, zap.Error(err))
-			return errors.Wrap(err, msg)
+			return errors.Wrapf(err, "%s", msg)
 		}
 	}
 
@@ -246,7 +245,7 @@ func (s *Server) balanceChannels(ctx context.Context,
 		if err != nil {
 			msg := "failed to wait all balance task finished"
 			log.Warn(msg, zap.Error(err))
-			return errors.Wrap(err, msg)
+			return errors.Wrapf(err, "%s", msg)
 		}
 	}
 
@@ -322,7 +321,7 @@ func (s *Server) getSegmentsJSON(ctx context.Context, req *milvuspb.GetMetricsRe
 		}
 		return string(bs), nil
 	}
-	return "", fmt.Errorf("invalid param value in=[%s], it should be qc or qn", in)
+	return "", merr.WrapErrServiceInternalMsg("invalid param value in=[%s], it should be qc or qn", in)
 }
 
 // TODO(dragondriver): add more detail metrics

--- a/internal/querycoordv2/handlers.go
+++ b/internal/querycoordv2/handlers.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
@@ -165,7 +164,7 @@ func (s *Server) balanceSegments(ctx context.Context,
 		if err != nil {
 			msg := "failed to wait all balance task finished"
 			log.Warn(msg, zap.Error(err))
-			return errors.Wrapf(err, "%s", msg)
+			return merr.Wrapf(err, "%s", msg)
 		}
 	}
 
@@ -245,7 +244,7 @@ func (s *Server) balanceChannels(ctx context.Context,
 		if err != nil {
 			msg := "failed to wait all balance task finished"
 			log.Warn(msg, zap.Error(err))
-			return errors.Wrapf(err, "%s", msg)
+			return merr.Wrapf(err, "%s", msg)
 		}
 	}
 

--- a/internal/querycoordv2/job/job_load.go
+++ b/internal/querycoordv2/job/job_load.go
@@ -182,14 +182,14 @@ func (job *LoadCollectionJob) Execute() error {
 	if len(toReleasePartitions) > 0 {
 		job.targetObserver.ReleasePartition(req.GetCollectionId(), toReleasePartitions...)
 		if err := job.meta.RemovePartition(job.ctx, req.GetCollectionId(), toReleasePartitions...); err != nil {
-			return errors.Wrap(err, "failed to remove partitions")
+			return merr.Wrap(err, "failed to remove partitions")
 		}
 	}
 
 	if err = job.meta.PutCollection(job.ctx, collection, partitions...); err != nil {
 		msg := "failed to store collection and partitions"
 		log.Warn(msg, zap.Error(err))
-		return errors.Wrapf(err, "%s", msg)
+		return merr.Wrapf(err, "%s", msg)
 	}
 	eventlog.Record(eventlog.NewRawEvt(eventlog.Level_Info, fmt.Sprintf("Start load collection %d", collection.CollectionID)))
 	metrics.QueryCoordNumPartitions.WithLabelValues().Add(float64(len(partitions)))

--- a/internal/querycoordv2/job/job_load.go
+++ b/internal/querycoordv2/job/job_load.go
@@ -189,7 +189,7 @@ func (job *LoadCollectionJob) Execute() error {
 	if err = job.meta.PutCollection(job.ctx, collection, partitions...); err != nil {
 		msg := "failed to store collection and partitions"
 		log.Warn(msg, zap.Error(err))
-		return errors.Wrap(err, msg)
+		return errors.Wrapf(err, "%s", msg)
 	}
 	eventlog.Record(eventlog.NewRawEvt(eventlog.Level_Info, fmt.Sprintf("Start load collection %d", collection.CollectionID)))
 	metrics.QueryCoordNumPartitions.WithLabelValues().Add(float64(len(partitions)))

--- a/internal/querycoordv2/job/job_release.go
+++ b/internal/querycoordv2/job/job_release.go
@@ -19,7 +19,6 @@ package job
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -31,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/proxypb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type ReleaseCollectionJob struct {
@@ -84,7 +84,7 @@ func (job *ReleaseCollectionJob) Execute() error {
 		if err != nil {
 			msg := "failed to remove collection"
 			log.Warn(msg, zap.Error(err))
-			return errors.Wrapf(err, "%s", msg)
+			return merr.Wrapf(err, "%s", msg)
 		}
 
 		job.targetObserver.ReleaseCollection(collectionID)
@@ -109,13 +109,13 @@ func (job *ReleaseCollectionJob) Execute() error {
 
 	if err := WaitCollectionReleased(job.ctx, job.dist, job.checkerController, collectionID); err != nil {
 		log.Warn("failed to wait collection released", zap.Error(err))
-		return errors.Wrap(err, "failed to wait collection released")
+		return merr.Wrap(err, "failed to wait collection released")
 	}
 
 	if err := job.meta.ReplicaManager.RemoveCollection(job.ctx, collectionID); err != nil {
 		msg := "failed to remove replicas"
 		log.Warn(msg, zap.Error(err))
-		return errors.Wrapf(err, "%s", msg)
+		return merr.Wrapf(err, "%s", msg)
 	}
 	log.Info("release collection job done", zap.Int64("collectionID", collectionID))
 	return nil

--- a/internal/querycoordv2/job/job_release.go
+++ b/internal/querycoordv2/job/job_release.go
@@ -84,7 +84,7 @@ func (job *ReleaseCollectionJob) Execute() error {
 		if err != nil {
 			msg := "failed to remove collection"
 			log.Warn(msg, zap.Error(err))
-			return errors.Wrap(err, msg)
+			return errors.Wrapf(err, "%s", msg)
 		}
 
 		job.targetObserver.ReleaseCollection(collectionID)
@@ -115,7 +115,7 @@ func (job *ReleaseCollectionJob) Execute() error {
 	if err := job.meta.ReplicaManager.RemoveCollection(job.ctx, collectionID); err != nil {
 		msg := "failed to remove replicas"
 		log.Warn(msg, zap.Error(err))
-		return errors.Wrap(err, msg)
+		return errors.Wrapf(err, "%s", msg)
 	}
 	log.Info("release collection job done", zap.Int64("collectionID", collectionID))
 	return nil

--- a/internal/querycoordv2/job/job_sync.go
+++ b/internal/querycoordv2/job/job_sync.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type SyncNewCreatedPartitionJob struct {
@@ -92,7 +92,7 @@ func (job *SyncNewCreatedPartitionJob) Execute() error {
 	if err != nil {
 		msg := "failed to store partitions"
 		log.Warn(msg, zap.Error(err))
-		return errors.Wrapf(err, "%s", msg)
+		return merr.Wrapf(err, "%s", msg)
 	}
 
 	return WaitUpdatePartition(job.ctx, job.targetObserver, job.req.GetCollectionID(), job.req.GetPartitionID())

--- a/internal/querycoordv2/job/job_sync.go
+++ b/internal/querycoordv2/job/job_sync.go
@@ -92,7 +92,7 @@ func (job *SyncNewCreatedPartitionJob) Execute() error {
 	if err != nil {
 		msg := "failed to store partitions"
 		log.Warn(msg, zap.Error(err))
-		return errors.Wrap(err, msg)
+		return errors.Wrapf(err, "%s", msg)
 	}
 
 	return WaitUpdatePartition(job.ctx, job.targetObserver, job.req.GetCollectionID(), job.req.GetPartitionID())

--- a/internal/querycoordv2/job/load_config.go
+++ b/internal/querycoordv2/job/load_config.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"sort"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/proto"
 
@@ -33,7 +32,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
-var ErrIgnoredAlterLoadConfig = errors.New("ignored alter load config")
+var ErrIgnoredAlterLoadConfig = merr.WrapErrServiceInternalMsg("ignored alter load config")
 
 type AlterLoadConfigRequest struct {
 	Meta           *meta.Meta

--- a/internal/querycoordv2/job/utils.go
+++ b/internal/querycoordv2/job/utils.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/observers"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -74,7 +75,7 @@ func WaitCollectionReleased(ctx context.Context, dist *meta.DistributionManager,
 
 		// If release is not in progress for a while, return error
 		if time.Since(lastChangeTime) > waitCollectionReleasedTimeout {
-			return errors.Errorf("wait collection released timeout, collection=%d, channels=%d, segments=%d",
+			return merr.WrapErrServiceInternalMsg("wait collection released timeout, collection=%d, channels=%d, segments=%d",
 				collection, currentChannelCount, currentSegmentCount)
 		}
 
@@ -112,7 +113,7 @@ func WaitCurrentTargetUpdated(ctx context.Context, targetObserver *observers.Tar
 	case <-ctx.Done():
 		return errors.Wrapf(ctx.Err(), "context error while waiting for current target updated, collection=%d", collection)
 	case <-time.After(waitCollectionReleasedTimeout):
-		return errors.Errorf("wait current target updated timeout, collection=%d", collection)
+		return merr.WrapErrServiceInternalMsg("wait current target updated timeout, collection=%d", collection)
 	}
 }
 
@@ -138,6 +139,6 @@ func WaitUpdatePartition(ctx context.Context, targetObserver *observers.TargetOb
 	case <-ctx.Done():
 		return errors.Wrapf(ctx.Err(), "context error while waiting for current target updated, collection=%d", collection)
 	case <-time.After(waitCollectionReleasedTimeout):
-		return errors.Errorf("wait current target updated timeout, collection=%d", collection)
+		return merr.WrapErrServiceInternalMsg("wait current target updated timeout, collection=%d", collection)
 	}
 }

--- a/internal/querycoordv2/job/utils.go
+++ b/internal/querycoordv2/job/utils.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
@@ -47,7 +46,7 @@ func WaitCollectionReleased(ctx context.Context, dist *meta.DistributionManager,
 
 	for {
 		if err := ctx.Err(); err != nil {
-			return errors.Wrapf(err, "context error while waiting for release, collection=%d", collection)
+			return merr.Wrapf(err, "context error while waiting for release, collection=%d", collection)
 		}
 
 		var (
@@ -100,7 +99,7 @@ func WaitCurrentTargetUpdated(ctx context.Context, targetObserver *observers.Tar
 	// manual trigger update next target
 	ready, err := targetObserver.UpdateNextTarget(collection)
 	if err != nil {
-		return errors.Wrapf(err, "failed to update next target, collection=%d", collection)
+		return merr.Wrapf(err, "failed to update next target, collection=%d", collection)
 	}
 
 	// accelerate check
@@ -111,7 +110,7 @@ func WaitCurrentTargetUpdated(ctx context.Context, targetObserver *observers.Tar
 	case <-ready:
 		return nil
 	case <-ctx.Done():
-		return errors.Wrapf(ctx.Err(), "context error while waiting for current target updated, collection=%d", collection)
+		return merr.Wrapf(ctx.Err(), "context error while waiting for current target updated, collection=%d", collection)
 	case <-time.After(waitCollectionReleasedTimeout):
 		return merr.WrapErrServiceInternalMsg("wait current target updated timeout, collection=%d", collection)
 	}
@@ -121,7 +120,7 @@ func WaitUpdatePartition(ctx context.Context, targetObserver *observers.TargetOb
 	// manual trigger update next target
 	ready, err := targetObserver.UpdatePartition(collection, partition)
 	if err != nil {
-		return errors.Wrapf(err, "failed to update next target, collection=%d", collection)
+		return merr.Wrapf(err, "failed to update next target, collection=%d", collection)
 	}
 	select {
 	case <-ready:
@@ -137,7 +136,7 @@ func WaitUpdatePartition(ctx context.Context, targetObserver *observers.TargetOb
 	case <-ready:
 		return nil
 	case <-ctx.Done():
-		return errors.Wrapf(ctx.Err(), "context error while waiting for current target updated, collection=%d", collection)
+		return merr.Wrapf(ctx.Err(), "context error while waiting for current target updated, collection=%d", collection)
 	case <-time.After(waitCollectionReleasedTimeout):
 		return merr.WrapErrServiceInternalMsg("wait current target updated timeout, collection=%d", collection)
 	}

--- a/internal/querycoordv2/meta/coordinator_broker.go
+++ b/internal/querycoordv2/meta/coordinator_broker.go
@@ -274,7 +274,7 @@ func (broker *CoordinatorBroker) GetSegmentInfo(ctx context.Context, ids ...Uniq
 
 		if len(resp.Infos) == 0 {
 			log.Warn("No such segment in DataCoord")
-			return nil, errors.New("no such segment in DataCoord")
+			return nil, merr.WrapErrServiceInternalMsg("no such segment in DataCoord")
 		}
 
 		err = binlog.DecompressMultiBinLogs(resp.GetInfos())

--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -108,7 +108,7 @@ func NewReplicaManager(idAllocator func() (int64, error), catalog metastore.Quer
 func (m *ReplicaManager) Recover(ctx context.Context, collections []int64) error {
 	replicas, err := m.catalog.GetReplicas(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to recover replicas")
+		return merr.Wrap(err, "failed to recover replicas")
 	}
 
 	collectionSet := typeutil.NewUniqueSet(collections...)
@@ -245,10 +245,10 @@ func (m *ReplicaManager) SpawnWithReplicaConfig(ctx context.Context, params Spaw
 		)
 	}
 	if err := m.put(ctx, params.CollectionID, replicas...); err != nil {
-		return nil, errors.Wrap(err, "failed to put replicas")
+		return nil, merr.Wrap(err, "failed to put replicas")
 	}
 	if err := m.removeRedundantReplicas(ctx, params); err != nil {
-		return nil, errors.Wrap(err, "failed to remove redundant replicas")
+		return nil, merr.Wrap(err, "failed to remove redundant replicas")
 	}
 	return replicas, nil
 }

--- a/internal/querycoordv2/meta/replica_manager.go
+++ b/internal/querycoordv2/meta/replica_manager.go
@@ -108,7 +108,7 @@ func NewReplicaManager(idAllocator func() (int64, error), catalog metastore.Quer
 func (m *ReplicaManager) Recover(ctx context.Context, collections []int64) error {
 	replicas, err := m.catalog.GetReplicas(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to recover replicas, err=%w", err)
+		return errors.Wrap(err, "failed to recover replicas")
 	}
 
 	collectionSet := typeutil.NewUniqueSet(collections...)
@@ -760,7 +760,7 @@ func (m *ReplicaManager) validateResourceGroups(rgs map[string]typeutil.UniqueSe
 	for _, rg := range rgs {
 		for id := range rg {
 			if node.Contain(id) {
-				return errors.New("node in resource group is not mutual exclusive")
+				return merr.WrapErrServiceInternalMsg("node in resource group is not mutual exclusive")
 			}
 			node.Insert(id)
 		}
@@ -774,14 +774,14 @@ func (m *ReplicaManager) getCollectionAssignmentHelper(collectionID typeutil.Uni
 	// check if the collection is exist.
 	replicas, ok := m.coll2Replicas.Get(collectionID)
 	if !ok {
-		return nil, errors.Errorf("collection %d not loaded", collectionID)
+		return nil, merr.WrapErrCollectionNotLoaded(collectionID)
 	}
 
 	rgToReplicas := make(map[string][]*Replica)
 	for _, replica := range replicas {
 		rgName := replica.GetResourceGroup()
 		if _, ok := rgs[rgName]; !ok {
-			return nil, errors.Errorf("lost resource group info, collectionID: %d, replicaID: %d, resourceGroup: %s", collectionID, replica.GetID(), rgName)
+			return nil, merr.WrapErrServiceInternalMsg("lost resource group info, collectionID: %d, replicaID: %d, resourceGroup: %s", collectionID, replica.GetID(), rgName)
 		}
 		rgToReplicas[rgName] = append(rgToReplicas[rgName], replica)
 	}
@@ -876,7 +876,7 @@ func (m *ReplicaManager) RecoverSQNodesInCollection(ctx context.Context, collect
 
 	replicas, ok := m.coll2Replicas.Get(collectionID)
 	if !ok {
-		return errors.Errorf("collection %d not loaded", collectionID)
+		return merr.WrapErrCollectionNotLoaded(collectionID)
 	}
 
 	// Build helpers based on whether we can use resource group isolation.

--- a/internal/querycoordv2/meta/resource_group.go
+++ b/internal/querycoordv2/meta/resource_group.go
@@ -1,13 +1,13 @@
 package meta
 
 import (
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/rgpb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -281,7 +281,7 @@ func (rg *ResourceGroup) Snapshot() *ResourceGroup {
 func (rg *ResourceGroup) MeetRequirement() error {
 	// if len(node) is less than requests, new node need to be assigned.
 	if rg.MissingNumOfNodes() > 0 {
-		return errors.Errorf(
+		return merr.WrapErrServiceInternalMsg(
 			"has %d nodes, less than request %d",
 			rg.NodeNum(),
 			rg.cfg.Requests.NodeNum,
@@ -289,7 +289,7 @@ func (rg *ResourceGroup) MeetRequirement() error {
 	}
 	// if len(node) is greater than limits, node need to be removed.
 	if rg.RedundantNumOfNodes() > 0 {
-		return errors.Errorf(
+		return merr.WrapErrServiceInternalMsg(
 			"has %d nodes, greater than limit %d",
 			rg.NodeNum(),
 			rg.cfg.Requests.NodeNum,

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -237,7 +237,7 @@ func (rm *ResourceManager) updateResourceGroups(ctx context.Context, rgs map[str
 				zap.Error(err),
 			)
 		}
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.
@@ -434,7 +434,7 @@ func (rm *ResourceManager) DropResourceGroup(ctx context.Context, rgName string)
 			zap.String("rgName", rgName),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// After recovering, all node assigned to these rg has been removed.
@@ -1050,7 +1050,7 @@ func (rm *ResourceManager) transferNode(ctx context.Context, rgName string, node
 			zap.Int64("node", node),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -43,10 +43,10 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
-var (
-	ErrNodeNotEnough                 = errors.New("nodes not enough")
-	ErrResourceGroupOperationIgnored = errors.New("operation ignored")
-)
+// errNodeNotEnough is an INTERNAL sentinel: observed only inside the
+// resource manager / resource observer recovery loop, never serialized
+// across any gRPC boundary. See docs/dev/error_sentinel_convention.md.
+var errNodeNotEnough = errors.New("nodes not enough")
 
 type ResourceManager struct {
 	incomingNode typeutil.UniqueSet // incomingNode is a temporary set for incoming hangup node,
@@ -91,7 +91,7 @@ func (rm *ResourceManager) Recover(ctx context.Context) error {
 
 	rgs, err := rm.catalog.GetResourceGroups(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to recover resource group from store")
+		return merr.Wrap(err, "failed to recover resource group from store")
 	}
 
 	// Resource group meta upgrade to latest version.
@@ -127,17 +127,21 @@ func (rm *ResourceManager) Recover(ctx context.Context) error {
 }
 
 // Deprecated: only for compatibility with unittest.
-func (rm *ResourceManager) AddResourceGroup(ctx context.Context, rgName string, cfg *rgpb.ResourceGroupConfig) error {
-	if err := rm.CheckIfResourceGroupAddable(ctx, rgName, cfg); err != nil {
-		return err
+// AddResourceGroup adds a resource group. Returns ignored=true if the
+// resource group already exists with the same config (idempotent no-op).
+func (rm *ResourceManager) AddResourceGroup(ctx context.Context, rgName string, cfg *rgpb.ResourceGroupConfig) (ignored bool, err error) {
+	if ignored, err := rm.CheckIfResourceGroupAddable(ctx, rgName, cfg); err != nil || ignored {
+		return ignored, err
 	}
-	return rm.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{rgName: cfg})
+	return false, rm.AlterResourceGroups(ctx, map[string]*rgpb.ResourceGroupConfig{rgName: cfg})
 }
 
 // CheckIfResourceGroupAddable check if a resource group can be added.
-func (rm *ResourceManager) CheckIfResourceGroupAddable(ctx context.Context, rgName string, cfg *rgpb.ResourceGroupConfig) error {
+// Returns ignored=true if the resource group already exists with the
+// same config (idempotent no-op for callers to translate to success).
+func (rm *ResourceManager) CheckIfResourceGroupAddable(ctx context.Context, rgName string, cfg *rgpb.ResourceGroupConfig) (ignored bool, err error) {
 	if len(rgName) == 0 {
-		return merr.WrapErrParameterMissing("resource group name couldn't be empty")
+		return false, merr.WrapErrParameterMissing("resource group name couldn't be empty")
 	}
 
 	rm.rwmutex.Lock()
@@ -146,20 +150,20 @@ func (rm *ResourceManager) CheckIfResourceGroupAddable(ctx context.Context, rgNa
 		// Idempotent promise.
 		// If resource group already exist, check if configuration is the same,
 		if proto.Equal(rm.groups[rgName].GetConfig(), cfg) {
-			return ErrResourceGroupOperationIgnored
+			return true, nil
 		}
-		return merr.WrapErrResourceGroupAlreadyExist(rgName)
+		return false, merr.WrapErrResourceGroupAlreadyExist(rgName)
 	}
 
 	maxResourceGroup := paramtable.Get().QuotaConfig.MaxResourceGroupNumOfQueryNode.GetAsInt()
 	if len(rm.groups) >= maxResourceGroup {
-		return merr.WrapErrResourceGroupReachLimit(rgName, maxResourceGroup)
+		return false, merr.WrapErrResourceGroupReachLimit(rgName, maxResourceGroup)
 	}
 
 	if err := rm.validateResourceGroupConfig(rgName, cfg); err != nil {
-		return err
+		return false, err
 	}
-	return nil
+	return false, nil
 }
 
 // AlterResourceGroups alter resource group configuration.
@@ -387,22 +391,25 @@ func (rm *ResourceManager) CheckIfTransferNode(ctx context.Context, sourceRGName
 
 // Deprecated: only for compatibility with unittest.
 func (rm *ResourceManager) RemoveResourceGroup(ctx context.Context, rgName string) error {
-	if err := rm.CheckIfResourceGroupDropable(ctx, rgName); err != nil {
+	ignored, err := rm.CheckIfResourceGroupDropable(ctx, rgName)
+	if err != nil || ignored {
 		return err
 	}
 	return rm.DropResourceGroup(ctx, rgName)
 }
 
 // CheckIfResourceGroupDropable check if resource group can be dropped.
-func (rm *ResourceManager) CheckIfResourceGroupDropable(ctx context.Context, rgName string) error {
+// Returns ignored=true if the resource group doesn't exist (idempotent
+// no-op for callers to translate to success).
+func (rm *ResourceManager) CheckIfResourceGroupDropable(ctx context.Context, rgName string) (ignored bool, err error) {
 	if rm.groups[rgName] == nil {
 		// Idempotent promise: delete a non-exist rg should be ok
-		return ErrResourceGroupOperationIgnored
+		return true, nil
 	}
 
 	// validateResourceGroupIsDeletable will check if rg is deletable.
 	if err := rm.validateResourceGroupIsDeletable(rgName); err != nil {
-		return err
+		return false, err
 	}
 
 	// Nodes may be still assign to these group,
@@ -413,10 +420,10 @@ func (rm *ResourceManager) CheckIfResourceGroupDropable(ctx context.Context, rgN
 				zap.String("rgName", rgName),
 				zap.Error(err),
 			)
-			return err
+			return false, err
 		}
 	}
-	return nil
+	return false, nil
 }
 
 // DropResourceGroup drop resource group.
@@ -489,7 +496,7 @@ func (rm *ResourceManager) VerifyNodeCount(ctx context.Context, requiredNodeCoun
 			return merr.WrapErrResourceGroupNotFound(rgName)
 		}
 		if rm.groups[rgName].NodeNum() != nodeCount {
-			return ErrNodeNotEnough
+			return errNodeNotEnough
 		}
 	}
 
@@ -729,7 +736,7 @@ func (rm *ResourceManager) recoverMissingNodeRG(ctx context.Context, rgName stri
 		node, sourceRG := rm.selectNodeForMissingRecover(targetRG)
 		if sourceRG == nil {
 			log.Warn("fail to select source resource group", zap.String("rgName", targetRG.GetName()))
-			return ErrNodeNotEnough
+			return errNodeNotEnough
 		}
 
 		err := rm.transferNode(ctx, targetRG.GetName(), node)
@@ -922,7 +929,7 @@ func (rm *ResourceManager) assignIncomingNode(ctx context.Context, nodeInfo *ses
 	// select a resource group to assign incoming node.
 	rg = rm.mustSelectAssignIncomingNodeTargetRG(nodeInfo)
 	if err := rm.transferNode(ctx, rg.GetName(), node); err != nil {
-		return "", errors.Wrap(err, "at finally assign to default resource group")
+		return "", merr.Wrap(err, "at finally assign to default resource group")
 	}
 	return rg.GetName(), nil
 }

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -804,7 +804,7 @@ func (rm *ResourceManager) recoverRedundantNodeRG(ctx context.Context, rgName st
 		if node == -1 {
 			log.Info("failed to select redundant recover target resource group, please check resource group configuration if as expected.",
 				zap.String("rgName", sourceRG.GetName()))
-			return errors.New("all resource group reach limits")
+			return merr.WrapErrServiceInternalMsg("all resource group reach limits")
 		}
 
 		if err := rm.transferNode(ctx, targetRG.GetName(), node); err != nil {
@@ -884,12 +884,12 @@ func (rm *ResourceManager) assignIncomingNodeWithNodeCheck(ctx context.Context, 
 	nodeInfo := rm.nodeMgr.Get(node)
 	if nodeInfo == nil {
 		rm.incomingNode.Remove(node)
-		return "", errors.New("node is not online")
+		return "", merr.WrapErrServiceInternalMsg("node is not online")
 	}
 
 	if nodeInfo.IsStoppingState() {
 		rm.incomingNode.Remove(node)
-		return "", errors.New("node has been stopped")
+		return "", merr.WrapErrServiceInternalMsg("node has been stopped")
 	}
 
 	rgName, err := rm.assignIncomingNode(ctx, nodeInfo)
@@ -1096,7 +1096,7 @@ func (rm *ResourceManager) unassignNode(ctx context.Context, node int64) (string
 		return rg.GetName(), nil
 	}
 
-	return "", errors.Errorf("node %d not found in any resource group", node)
+	return "", merr.WrapErrServiceInternalMsg("node %d not found in any resource group", node)
 }
 
 // validateResourceGroupConfig validate resource group config.

--- a/internal/querycoordv2/meta/resource_manager_test.go
+++ b/internal/querycoordv2/meta/resource_manager_test.go
@@ -116,7 +116,7 @@ func (suite *ResourceManagerSuite) TestValidateConfiguration() {
 	err = suite.manager.validateResourceGroupConfig("rg1", cfg)
 	suite.ErrorIs(err, merr.ErrResourceGroupIllegalConfig)
 
-	err = suite.manager.AddResourceGroup(ctx, "rg2", newResourceGroupConfig(0, 0))
+	_, err = suite.manager.AddResourceGroup(ctx, "rg2", newResourceGroupConfig(0, 0))
 	suite.NoError(err)
 
 	err = suite.manager.RemoveResourceGroup(ctx, "rg2")
@@ -126,7 +126,7 @@ func (suite *ResourceManagerSuite) TestValidateConfiguration() {
 func (suite *ResourceManagerSuite) TestValidateDelete() {
 	ctx := suite.ctx
 	// Non empty resource group can not be removed.
-	err := suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(1, 1))
+	_, err := suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(1, 1))
 	suite.NoError(err)
 
 	err = suite.manager.validateResourceGroupIsDeletable(DefaultResourceGroupName)
@@ -167,31 +167,32 @@ func (suite *ResourceManagerSuite) TestValidateDelete() {
 func (suite *ResourceManagerSuite) TestManipulateResourceGroup() {
 	ctx := suite.ctx
 	// test add rg
-	err := suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(0, 0))
+	_, err := suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(0, 0))
 	suite.NoError(err)
 	suite.True(suite.manager.ContainResourceGroup(ctx, "rg1"))
 	suite.Len(suite.manager.ListResourceGroups(ctx), 2)
 
-	// test add duplicate rg but same configuration is ok
-	err = suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(0, 0))
-	suite.ErrorIs(err, ErrResourceGroupOperationIgnored)
+	// test add duplicate rg but same configuration is ok (signaled via ignored=true)
+	ignored, err := suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(0, 0))
+	suite.NoError(err)
+	suite.True(ignored)
 
-	err = suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(1, 1))
+	_, err = suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(1, 1))
 	suite.Error(err)
 
 	// test delete rg
 	err = suite.manager.RemoveResourceGroup(ctx, "rg1")
 	suite.NoError(err)
 
-	// test delete rg which doesn't exist
+	// test delete rg which doesn't exist — RemoveResourceGroup swallows ignored, returns nil
 	err = suite.manager.RemoveResourceGroup(ctx, "rg1")
-	suite.ErrorIs(err, ErrResourceGroupOperationIgnored)
+	suite.NoError(err)
 	// test delete default rg
 	err = suite.manager.RemoveResourceGroup(ctx, DefaultResourceGroupName)
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
 
 	// test delete a rg not empty.
-	err = suite.manager.AddResourceGroup(ctx, "rg2", newResourceGroupConfig(1, 1))
+	_, err = suite.manager.AddResourceGroup(ctx, "rg2", newResourceGroupConfig(1, 1))
 	suite.NoError(err)
 	err = suite.manager.RemoveResourceGroup(ctx, "rg2")
 	suite.ErrorIs(err, merr.ErrParameterInvalid)
@@ -204,7 +205,7 @@ func (suite *ResourceManagerSuite) TestManipulateResourceGroup() {
 	suite.NoError(err)
 
 	// assign a node to rg.
-	err = suite.manager.AddResourceGroup(ctx, "rg2", newResourceGroupConfig(1, 1))
+	_, err = suite.manager.AddResourceGroup(ctx, "rg2", newResourceGroupConfig(1, 1))
 	suite.NoError(err)
 	suite.manager.nodeMgr.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
 		NodeID:   1,
@@ -252,7 +253,7 @@ func (suite *ResourceManagerSuite) TestNodeUpAndDown() {
 		Address:  "localhost",
 		Hostname: "localhost",
 	}))
-	err := suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(1, 1))
+	_, err := suite.manager.AddResourceGroup(ctx, "rg1", newResourceGroupConfig(1, 1))
 	suite.NoError(err)
 	// test add node to rg
 	suite.manager.HandleNodeUp(ctx, 1)

--- a/internal/querycoordv2/ops_services.go
+++ b/internal/querycoordv2/ops_services.go
@@ -110,7 +110,7 @@ func (s *Server) ListQueryNode(ctx context.Context, req *querypb.ListQueryNodeRe
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		log.Warn(errMsg, zap.Error(err))
 		return &querypb.ListQueryNodeResponse{
-			Status: merr.Status(errors.Wrap(err, errMsg)),
+			Status: merr.Status(errors.Wrapf(err, "%s", errMsg)),
 		}, nil
 	}
 
@@ -157,7 +157,7 @@ func (s *Server) GetQueryNodeDistribution(ctx context.Context, req *querypb.GetQ
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		log.Warn(errMsg, zap.Error(err))
 		return &querypb.GetQueryNodeDistributionResponse{
-			Status: merr.Status(errors.Wrap(err, errMsg)),
+			Status: merr.Status(errors.Wrapf(err, "%s", errMsg)),
 		}, nil
 	}
 
@@ -347,7 +347,7 @@ func (s *Server) ResumeNode(ctx context.Context, req *querypb.ResumeNodeRequest)
 	errMsg := "failed to resume query node"
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		log.Warn(errMsg, zap.Error(err))
-		return merr.Status(errors.Wrap(err, errMsg)), nil
+		return merr.Status(errors.Wrapf(err, "%s", errMsg)), nil
 	}
 
 	info := s.nodeMgr.Get(req.GetNodeID())
@@ -381,7 +381,7 @@ func (s *Server) TransferSegment(ctx context.Context, req *querypb.TransferSegme
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		msg := "failed to load balance"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrap(err, msg)), nil
+		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
 	}
 
 	// check whether srcNode is healthy
@@ -440,7 +440,7 @@ func (s *Server) TransferSegment(ctx context.Context, req *querypb.TransferSegme
 		if err != nil {
 			msg := "failed to balance segments"
 			log.Warn(msg, zap.Error(err))
-			return merr.Status(errors.Wrap(err, msg)), nil
+			return merr.Status(errors.Wrapf(err, "%s", msg)), nil
 		}
 	}
 	return merr.Success(), nil
@@ -460,7 +460,7 @@ func (s *Server) TransferChannel(ctx context.Context, req *querypb.TransferChann
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		msg := "failed to load balance"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrap(err, msg)), nil
+		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
 	}
 
 	// check whether srcNode is healthy
@@ -514,7 +514,7 @@ func (s *Server) TransferChannel(ctx context.Context, req *querypb.TransferChann
 		if err != nil {
 			msg := "failed to balance channels"
 			log.Warn(msg, zap.Error(err))
-			return merr.Status(errors.Wrap(err, msg)), nil
+			return merr.Status(errors.Wrapf(err, "%s", msg)), nil
 		}
 	}
 	return merr.Success(), nil

--- a/internal/querycoordv2/ops_services.go
+++ b/internal/querycoordv2/ops_services.go
@@ -19,7 +19,6 @@ package querycoordv2
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
@@ -110,7 +109,7 @@ func (s *Server) ListQueryNode(ctx context.Context, req *querypb.ListQueryNodeRe
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		log.Warn(errMsg, zap.Error(err))
 		return &querypb.ListQueryNodeResponse{
-			Status: merr.Status(errors.Wrapf(err, "%s", errMsg)),
+			Status: merr.Status(merr.Wrapf(err, "%s", errMsg)),
 		}, nil
 	}
 
@@ -157,7 +156,7 @@ func (s *Server) GetQueryNodeDistribution(ctx context.Context, req *querypb.GetQ
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		log.Warn(errMsg, zap.Error(err))
 		return &querypb.GetQueryNodeDistributionResponse{
-			Status: merr.Status(errors.Wrapf(err, "%s", errMsg)),
+			Status: merr.Status(merr.Wrapf(err, "%s", errMsg)),
 		}, nil
 	}
 
@@ -347,7 +346,7 @@ func (s *Server) ResumeNode(ctx context.Context, req *querypb.ResumeNodeRequest)
 	errMsg := "failed to resume query node"
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		log.Warn(errMsg, zap.Error(err))
-		return merr.Status(errors.Wrapf(err, "%s", errMsg)), nil
+		return merr.Status(merr.Wrapf(err, "%s", errMsg)), nil
 	}
 
 	info := s.nodeMgr.Get(req.GetNodeID())
@@ -381,7 +380,7 @@ func (s *Server) TransferSegment(ctx context.Context, req *querypb.TransferSegme
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		msg := "failed to load balance"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
+		return merr.Status(merr.Wrapf(err, "%s", msg)), nil
 	}
 
 	// check whether srcNode is healthy
@@ -440,7 +439,7 @@ func (s *Server) TransferSegment(ctx context.Context, req *querypb.TransferSegme
 		if err != nil {
 			msg := "failed to balance segments"
 			log.Warn(msg, zap.Error(err))
-			return merr.Status(errors.Wrapf(err, "%s", msg)), nil
+			return merr.Status(merr.Wrapf(err, "%s", msg)), nil
 		}
 	}
 	return merr.Success(), nil
@@ -460,7 +459,7 @@ func (s *Server) TransferChannel(ctx context.Context, req *querypb.TransferChann
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		msg := "failed to load balance"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
+		return merr.Status(merr.Wrapf(err, "%s", msg)), nil
 	}
 
 	// check whether srcNode is healthy
@@ -514,7 +513,7 @@ func (s *Server) TransferChannel(ctx context.Context, req *querypb.TransferChann
 		if err != nil {
 			msg := "failed to balance channels"
 			log.Warn(msg, zap.Error(err))
-			return merr.Status(errors.Wrapf(err, "%s", msg)), nil
+			return merr.Status(merr.Wrapf(err, "%s", msg)), nil
 		}
 	}
 	return merr.Success(), nil

--- a/internal/querycoordv2/params/params.go
+++ b/internal/querycoordv2/params/params.go
@@ -22,15 +22,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cockroachdb/errors"
-
 	kvfactory "github.com/milvus-io/milvus/internal/util/dependency/kv"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 var Params *paramtable.ComponentParam = paramtable.Get()
 
-var ErrFailedAllocateID = errors.New("failed to allocate ID")
+var ErrFailedAllocateID = merr.WrapErrServiceInternalMsg("failed to allocate ID")
 
 // GenerateEtcdConfig returns a etcd config with a random root path,
 // NOTE: for test only

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	"github.com/tikv/client-go/v2/txnkv"
@@ -915,7 +914,7 @@ func (s *Server) checkReplicaServiceable(ctx context.Context, replica *meta.Repl
 				replica.GetID(), replica.GetResourceGroup(), channelName)
 		}
 		if err := utils.CheckDelegatorDataReady(s.nodeMgr, s.targetMgr, leader.View, meta.CurrentTarget); err != nil {
-			return errors.Wrapf(err, "replica %d (rg=%s) channel %s not serviceable", replica.GetID(), replica.GetResourceGroup(), channelName)
+			return merr.Wrapf(err, "replica %d (rg=%s) channel %s not serviceable", replica.GetID(), replica.GetResourceGroup(), channelName)
 		}
 	}
 	return nil

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -60,6 +60,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/expr"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
@@ -161,7 +162,7 @@ func (s *Server) Register() error {
 func (s *Server) SetSession(session sessionutil.SessionInterface) error {
 	s.session = session
 	if s.session == nil {
-		return errors.New("session is nil, the etcd client connection may have failed")
+		return merr.WrapErrServiceInternalMsg("session is nil, the etcd client connection may have failed")
 	}
 	return nil
 }
@@ -281,7 +282,7 @@ func (s *Server) initQueryCoord() error {
 			etcdkv.WithRequestTimeout(paramtable.Get().EtcdCfg.RequestTimeout.GetAsDuration(time.Millisecond)))
 		idAllocatorKV = tsoutil.NewTSOKVBase(s.etcdCli, Params.EtcdCfg.KvRootPath.GetValue(), "querycoord-id-allocator")
 	default:
-		return fmt.Errorf("not supported meta store: %s", metaType)
+		return merr.WrapErrServiceInternalMsg("unsupported meta store: %s", metaType)
 	}
 	log.Info(fmt.Sprintf("query coordinator successfully connected to %s.", metaType))
 
@@ -892,7 +893,7 @@ func (s *Server) GetInternalReplicasByCollection(ctx context.Context, collection
 func (s *Server) CheckAllReplicasServiceable(ctx context.Context, collectionID int64) error {
 	replicas := s.meta.GetByCollection(ctx, collectionID)
 	if len(replicas) == 0 {
-		return errors.New("no replica found")
+		return merr.WrapErrServiceInternalMsg("no replica found")
 	}
 	for _, replica := range replicas {
 		if err := s.checkReplicaServiceable(ctx, replica); err != nil {
@@ -905,17 +906,16 @@ func (s *Server) CheckAllReplicasServiceable(ctx context.Context, collectionID i
 func (s *Server) checkReplicaServiceable(ctx context.Context, replica *meta.Replica) error {
 	channels := s.targetMgr.GetDmChannelsByCollection(ctx, replica.GetCollectionID(), meta.CurrentTarget)
 	if len(channels) == 0 {
-		return errors.New("no channels in current target")
+		return merr.WrapErrServiceInternalMsg("no channels in current target")
 	}
 	for channelName := range channels {
 		leader := s.dist.ChannelDistManager.GetShardLeader(channelName, replica)
 		if leader == nil || leader.View == nil {
-			return fmt.Errorf("replica %d (rg=%s): no leader for channel %s",
+			return merr.WrapErrServiceInternalMsg("replica %d (rg=%s): no leader for channel %s",
 				replica.GetID(), replica.GetResourceGroup(), channelName)
 		}
 		if err := utils.CheckDelegatorDataReady(s.nodeMgr, s.targetMgr, leader.View, meta.CurrentTarget); err != nil {
-			return fmt.Errorf("replica %d (rg=%s) channel %s not serviceable: %w",
-				replica.GetID(), replica.GetResourceGroup(), channelName, err)
+			return errors.Wrapf(err, "replica %d (rg=%s) channel %s not serviceable", replica.GetID(), replica.GetResourceGroup(), channelName)
 		}
 	}
 	return nil

--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -46,13 +46,13 @@ import (
 )
 
 var (
-// ErrRemoveNodeFromRGFailed      = errors.New("failed to remove node from resource group")
-// ErrTransferNodeFailed          = errors.New("failed to transfer node between resource group")
-// ErrTransferReplicaFailed       = errors.New("failed to transfer replica between resource group")
-// ErrListResourceGroupsFailed    = errors.New("failed to list resource group")
-// ErrDescribeResourceGroupFailed = errors.New("failed to describe resource group")
-// ErrLoadUseWrongRG              = errors.New("load operation should use collection's resource group")
-// ErrLoadWithDefaultRG           = errors.New("load operation can't use default resource group and other resource group together")
+// ErrRemoveNodeFromRGFailed      = merr.WrapErrServiceInternalMsg("failed to remove node from resource group")
+// ErrTransferNodeFailed          = merr.WrapErrServiceInternalMsg("failed to transfer node between resource group")
+// ErrTransferReplicaFailed       = merr.WrapErrServiceInternalMsg("failed to transfer replica between resource group")
+// ErrListResourceGroupsFailed    = merr.WrapErrServiceInternalMsg("failed to list resource group")
+// ErrDescribeResourceGroupFailed = merr.WrapErrServiceInternalMsg("failed to describe resource group")
+// ErrLoadUseWrongRG              = merr.WrapErrServiceInternalMsg("load operation should use collection's resource group")
+// ErrLoadWithDefaultRG           = merr.WrapErrServiceInternalMsg("load operation can't use default resource group and other resource group together")
 )
 
 func (s *Server) ShowLoadCollections(ctx context.Context, req *querypb.ShowCollectionsRequest) (*querypb.ShowCollectionsResponse, error) {
@@ -61,7 +61,7 @@ func (s *Server) ShowLoadCollections(ctx context.Context, req *querypb.ShowColle
 		msg := "failed to show collections"
 		log.Warn(msg, zap.Error(err))
 		return &querypb.ShowCollectionsResponse{
-			Status: merr.Status(errors.Wrap(err, msg)),
+			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 	defer meta.GlobalFailedLoadCache.TryExpire()
@@ -138,7 +138,7 @@ func (s *Server) ShowLoadPartitions(ctx context.Context, req *querypb.ShowPartit
 		msg := "failed to show partitions"
 		log.Warn(msg, zap.Error(err))
 		return &querypb.ShowPartitionsResponse{
-			Status: merr.Status(errors.Wrap(err, msg)),
+			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 	defer meta.GlobalFailedLoadCache.TryExpire()
@@ -369,7 +369,7 @@ func (s *Server) GetPartitionStates(ctx context.Context, req *querypb.GetPartiti
 		msg := "failed to get partition states"
 		log.Warn(msg, zap.Error(err))
 		return &querypb.GetPartitionStatesResponse{
-			Status: merr.Status(errors.Wrap(err, msg)),
+			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 
@@ -437,7 +437,7 @@ func (s *Server) GetLoadSegmentInfo(ctx context.Context, req *querypb.GetSegment
 		msg := "failed to get segment info"
 		log.Warn(msg, zap.Error(err))
 		return &querypb.GetSegmentInfoResponse{
-			Status: merr.Status(errors.Wrap(err, msg)),
+			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 
@@ -452,7 +452,7 @@ func (s *Server) GetLoadSegmentInfo(ctx context.Context, req *querypb.GetSegment
 				msg := fmt.Sprintf("segment %v not found in any node", segmentID)
 				log.Warn(msg, zap.Int64("segment", segmentID))
 				return &querypb.GetSegmentInfoResponse{
-					Status: merr.Status(errors.Wrap(err, msg)),
+					Status: merr.Status(errors.Wrapf(err, "%s", msg)),
 				}, nil
 			}
 			info := &querypb.SegmentInfo{}
@@ -621,7 +621,7 @@ func (s *Server) isStoppingNode(ctx context.Context, nodeID int64) error {
 	if isStopping {
 		msg := fmt.Sprintf("failed to balance due to the source/destination node[%d] is stopping", nodeID)
 		log.Ctx(ctx).Warn(msg)
-		return errors.New(msg)
+		return merr.WrapErrServiceInternalMsg(msg)
 	}
 	return nil
 }
@@ -639,7 +639,7 @@ func (s *Server) LoadBalance(ctx context.Context, req *querypb.LoadBalanceReques
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		msg := "failed to load balance"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrap(err, msg)), nil
+		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
 	}
 
 	// Verify request
@@ -664,8 +664,7 @@ func (s *Server) LoadBalance(ctx context.Context, req *querypb.LoadBalanceReques
 		return merr.Status(err), nil
 	}
 	if err := s.isStoppingNode(ctx, srcNode); err != nil {
-		return merr.Status(errors.Wrap(err,
-			fmt.Sprintf("can't balance, because the source node[%d] is invalid", srcNode))), nil
+		return merr.Status(errors.Wrapf(err, "can't balance, because the source node[%d] is invalid", srcNode)), nil
 	}
 
 	// when no dst node specified, default to use all other nodes in same
@@ -686,8 +685,7 @@ func (s *Server) LoadBalance(ctx context.Context, req *querypb.LoadBalanceReques
 	// check whether dstNode is healthy
 	for dstNode := range dstNodeSet {
 		if err := s.isStoppingNode(ctx, dstNode); err != nil {
-			return merr.Status(errors.Wrap(err,
-				fmt.Sprintf("can't balance, because the destination node[%d] is invalid", dstNode))), nil
+			return merr.Status(errors.Wrapf(err, "can't balance, because the destination node[%d] is invalid", dstNode)), nil
 		}
 	}
 
@@ -723,7 +721,7 @@ func (s *Server) LoadBalance(ctx context.Context, req *querypb.LoadBalanceReques
 	if err != nil {
 		msg := "failed to balance segments"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrap(err, msg)), nil
+		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
 	}
 
 	return merr.Success(), nil
@@ -738,7 +736,7 @@ func (s *Server) ShowConfigurations(ctx context.Context, req *internalpb.ShowCon
 		msg := "failed to show configurations"
 		log.Warn(msg, zap.Error(err))
 		return &internalpb.ShowConfigurationsResponse{
-			Status: merr.Status(errors.Wrap(err, msg)),
+			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 	configList := make([]*commonpb.KeyValuePair, 0)
@@ -766,7 +764,7 @@ func (s *Server) GetMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest
 		msg := "failed to get metrics"
 		log.Warn(msg, zap.Error(err))
 		return &milvuspb.GetMetricsResponse{
-			Status: merr.Status(errors.Wrap(err, msg)),
+			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 
@@ -797,7 +795,7 @@ func (s *Server) GetReplicas(ctx context.Context, req *milvuspb.GetReplicasReque
 		msg := "failed to get replicas"
 		log.Warn(msg, zap.Error(err))
 		return &milvuspb.GetReplicasResponse{
-			Status: merr.Status(errors.Wrap(err, msg)),
+			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 
@@ -827,7 +825,7 @@ func (s *Server) GetShardLeaders(ctx context.Context, req *querypb.GetShardLeade
 		msg := "failed to get shard leaders"
 		log.Warn(msg, zap.Error(err))
 		return &querypb.GetShardLeadersResponse{
-			Status: merr.Status(errors.Wrap(err, msg)),
+			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 
@@ -1105,14 +1103,14 @@ func (s *Server) UpdateLoadConfig(ctx context.Context, req *querypb.UpdateLoadCo
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		msg := "failed to update load config"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrap(err, msg)), nil
+		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
 	}
 
 	err := s.updateLoadConfig(ctx, req.GetCollectionIDs(), req.GetReplicaNumber(), req.GetResourceGroups())
 	if err != nil {
 		msg := "failed to update load config"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrap(err, msg)), nil
+		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
 	}
 
 	log.Info("update load config request finished")
@@ -1226,7 +1224,7 @@ func (s *Server) RunAnalyzer(ctx context.Context, req *querypb.RunAnalyzerReques
 
 	if len(nodeIDs) == 0 {
 		return &milvuspb.RunAnalyzerResponse{
-			Status: merr.Status(errors.New("failed to validate analyzer, no delegator")),
+			Status: merr.Status(merr.WrapErrServiceInternalMsg("failed to validate analyzer, no delegator")),
 		}, nil
 	}
 
@@ -1248,7 +1246,7 @@ func (s *Server) ValidateAnalyzer(ctx context.Context, req *querypb.ValidateAnal
 	nodeIDs := snmanager.StaticStreamingNodeManager.GetStreamingQueryNodeIDs().Collect()
 
 	if len(nodeIDs) == 0 {
-		return &querypb.ValidateAnalyzerResponse{Status: merr.Status(errors.New("failed to validate analyzer, no delegator"))}, nil
+		return &querypb.ValidateAnalyzerResponse{Status: merr.Status(merr.WrapErrServiceInternalMsg("failed to validate analyzer, no delegator"))}, nil
 	}
 
 	idx := s.nodeIdx.Inc() % uint32(len(nodeIDs))
@@ -1270,7 +1268,7 @@ func (s *Server) ComputePhraseMatchSlop(ctx context.Context, req *querypb.Comput
 
 	if len(nodeIDs) == 0 {
 		return &querypb.ComputePhraseMatchSlopResponse{
-			Status: merr.Status(errors.New("failed to compute phrase match slop, no query node available")),
+			Status: merr.Status(merr.WrapErrServiceInternalMsg("failed to compute phrase match slop, no query node available")),
 		}, nil
 	}
 

--- a/internal/querycoordv2/services.go
+++ b/internal/querycoordv2/services.go
@@ -61,7 +61,7 @@ func (s *Server) ShowLoadCollections(ctx context.Context, req *querypb.ShowColle
 		msg := "failed to show collections"
 		log.Warn(msg, zap.Error(err))
 		return &querypb.ShowCollectionsResponse{
-			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
+			Status: merr.Status(merr.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 	defer meta.GlobalFailedLoadCache.TryExpire()
@@ -138,7 +138,7 @@ func (s *Server) ShowLoadPartitions(ctx context.Context, req *querypb.ShowPartit
 		msg := "failed to show partitions"
 		log.Warn(msg, zap.Error(err))
 		return &querypb.ShowPartitionsResponse{
-			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
+			Status: merr.Status(merr.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 	defer meta.GlobalFailedLoadCache.TryExpire()
@@ -369,7 +369,7 @@ func (s *Server) GetPartitionStates(ctx context.Context, req *querypb.GetPartiti
 		msg := "failed to get partition states"
 		log.Warn(msg, zap.Error(err))
 		return &querypb.GetPartitionStatesResponse{
-			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
+			Status: merr.Status(merr.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 
@@ -437,7 +437,7 @@ func (s *Server) GetLoadSegmentInfo(ctx context.Context, req *querypb.GetSegment
 		msg := "failed to get segment info"
 		log.Warn(msg, zap.Error(err))
 		return &querypb.GetSegmentInfoResponse{
-			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
+			Status: merr.Status(merr.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 
@@ -452,7 +452,7 @@ func (s *Server) GetLoadSegmentInfo(ctx context.Context, req *querypb.GetSegment
 				msg := fmt.Sprintf("segment %v not found in any node", segmentID)
 				log.Warn(msg, zap.Int64("segment", segmentID))
 				return &querypb.GetSegmentInfoResponse{
-					Status: merr.Status(errors.Wrapf(err, "%s", msg)),
+					Status: merr.Status(merr.Wrapf(err, "%s", msg)),
 				}, nil
 			}
 			info := &querypb.SegmentInfo{}
@@ -639,7 +639,7 @@ func (s *Server) LoadBalance(ctx context.Context, req *querypb.LoadBalanceReques
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		msg := "failed to load balance"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
+		return merr.Status(merr.Wrapf(err, "%s", msg)), nil
 	}
 
 	// Verify request
@@ -664,7 +664,7 @@ func (s *Server) LoadBalance(ctx context.Context, req *querypb.LoadBalanceReques
 		return merr.Status(err), nil
 	}
 	if err := s.isStoppingNode(ctx, srcNode); err != nil {
-		return merr.Status(errors.Wrapf(err, "can't balance, because the source node[%d] is invalid", srcNode)), nil
+		return merr.Status(merr.Wrapf(err, "can't balance, because the source node[%d] is invalid", srcNode)), nil
 	}
 
 	// when no dst node specified, default to use all other nodes in same
@@ -685,7 +685,7 @@ func (s *Server) LoadBalance(ctx context.Context, req *querypb.LoadBalanceReques
 	// check whether dstNode is healthy
 	for dstNode := range dstNodeSet {
 		if err := s.isStoppingNode(ctx, dstNode); err != nil {
-			return merr.Status(errors.Wrapf(err, "can't balance, because the destination node[%d] is invalid", dstNode)), nil
+			return merr.Status(merr.Wrapf(err, "can't balance, because the destination node[%d] is invalid", dstNode)), nil
 		}
 	}
 
@@ -721,7 +721,7 @@ func (s *Server) LoadBalance(ctx context.Context, req *querypb.LoadBalanceReques
 	if err != nil {
 		msg := "failed to balance segments"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
+		return merr.Status(merr.Wrapf(err, "%s", msg)), nil
 	}
 
 	return merr.Success(), nil
@@ -736,7 +736,7 @@ func (s *Server) ShowConfigurations(ctx context.Context, req *internalpb.ShowCon
 		msg := "failed to show configurations"
 		log.Warn(msg, zap.Error(err))
 		return &internalpb.ShowConfigurationsResponse{
-			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
+			Status: merr.Status(merr.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 	configList := make([]*commonpb.KeyValuePair, 0)
@@ -764,7 +764,7 @@ func (s *Server) GetMetrics(ctx context.Context, req *milvuspb.GetMetricsRequest
 		msg := "failed to get metrics"
 		log.Warn(msg, zap.Error(err))
 		return &milvuspb.GetMetricsResponse{
-			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
+			Status: merr.Status(merr.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 
@@ -795,7 +795,7 @@ func (s *Server) GetReplicas(ctx context.Context, req *milvuspb.GetReplicasReque
 		msg := "failed to get replicas"
 		log.Warn(msg, zap.Error(err))
 		return &milvuspb.GetReplicasResponse{
-			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
+			Status: merr.Status(merr.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 
@@ -825,7 +825,7 @@ func (s *Server) GetShardLeaders(ctx context.Context, req *querypb.GetShardLeade
 		msg := "failed to get shard leaders"
 		log.Warn(msg, zap.Error(err))
 		return &querypb.GetShardLeadersResponse{
-			Status: merr.Status(errors.Wrapf(err, "%s", msg)),
+			Status: merr.Status(merr.Wrapf(err, "%s", msg)),
 		}, nil
 	}
 
@@ -901,13 +901,14 @@ func (s *Server) CreateResourceGroup(ctx context.Context, req *milvuspb.CreateRe
 		return merr.Status(err), nil
 	}
 
-	if err := s.broadcastCreateResourceGroup(ctx, req); err != nil {
-		if errors.Is(err, meta.ErrResourceGroupOperationIgnored) {
-			log.Info("create resource group request ignored")
-			return merr.Success(), nil
-		}
+	ignored, err := s.broadcastCreateResourceGroup(ctx, req)
+	if err != nil {
 		log.Warn("failed to create resource group", zap.Error(err))
 		return merr.Status(err), nil
+	}
+	if ignored {
+		log.Info("create resource group request ignored")
+		return merr.Success(), nil
 	}
 	log.Info("create resource group done")
 	return merr.Success(), nil
@@ -943,13 +944,14 @@ func (s *Server) DropResourceGroup(ctx context.Context, req *milvuspb.DropResour
 		return merr.Status(err), nil
 	}
 
-	if err := s.broadcastDropResourceGroup(ctx, req); err != nil {
-		if errors.Is(err, meta.ErrResourceGroupOperationIgnored) {
-			log.Info("drop resource group request ignored")
-			return merr.Success(), nil
-		}
+	ignored, err := s.broadcastDropResourceGroup(ctx, req)
+	if err != nil {
 		log.Warn("failed to drop resource group", zap.Error(err))
 		return merr.Status(err), nil
+	}
+	if ignored {
+		log.Info("drop resource group request ignored")
+		return merr.Success(), nil
 	}
 	log.Info("drop resource group done")
 	return merr.Success(), nil
@@ -1103,14 +1105,14 @@ func (s *Server) UpdateLoadConfig(ctx context.Context, req *querypb.UpdateLoadCo
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		msg := "failed to update load config"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
+		return merr.Status(merr.Wrapf(err, "%s", msg)), nil
 	}
 
 	err := s.updateLoadConfig(ctx, req.GetCollectionIDs(), req.GetReplicaNumber(), req.GetResourceGroups())
 	if err != nil {
 		msg := "failed to update load config"
 		log.Warn(msg, zap.Error(err))
-		return merr.Status(errors.Wrapf(err, "%s", msg)), nil
+		return merr.Status(merr.Wrapf(err, "%s", msg)), nil
 	}
 
 	log.Info("update load config request finished")
@@ -1184,7 +1186,7 @@ func (s *Server) updateLoadConfig(ctx context.Context, collectionIDs []int64, ne
 func (s *Server) ListLoadedSegments(ctx context.Context, req *querypb.ListLoadedSegmentsRequest) (*querypb.ListLoadedSegmentsResponse, error) {
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		return &querypb.ListLoadedSegmentsResponse{
-			Status: merr.Status(errors.Wrap(err, "failed to list loaded segments")),
+			Status: merr.Status(merr.Wrap(err, "failed to list loaded segments")),
 		}, nil
 	}
 	segmentIDs := typeutil.NewUniqueSet()
@@ -1216,7 +1218,7 @@ func (s *Server) ListLoadedSegments(ctx context.Context, req *querypb.ListLoaded
 func (s *Server) RunAnalyzer(ctx context.Context, req *querypb.RunAnalyzerRequest) (*milvuspb.RunAnalyzerResponse, error) {
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		return &milvuspb.RunAnalyzerResponse{
-			Status: merr.Status(errors.Wrap(err, "failed to run analyzer")),
+			Status: merr.Status(merr.Wrap(err, "failed to run analyzer")),
 		}, nil
 	}
 
@@ -1240,7 +1242,7 @@ func (s *Server) RunAnalyzer(ctx context.Context, req *querypb.RunAnalyzerReques
 
 func (s *Server) ValidateAnalyzer(ctx context.Context, req *querypb.ValidateAnalyzerRequest) (*querypb.ValidateAnalyzerResponse, error) {
 	if err := merr.CheckHealthy(s.State()); err != nil {
-		return &querypb.ValidateAnalyzerResponse{Status: merr.Status(errors.Wrap(err, "failed to validate analyzer"))}, nil
+		return &querypb.ValidateAnalyzerResponse{Status: merr.Status(merr.Wrap(err, "failed to validate analyzer"))}, nil
 	}
 
 	nodeIDs := snmanager.StaticStreamingNodeManager.GetStreamingQueryNodeIDs().Collect()
@@ -1260,7 +1262,7 @@ func (s *Server) ValidateAnalyzer(ctx context.Context, req *querypb.ValidateAnal
 func (s *Server) ComputePhraseMatchSlop(ctx context.Context, req *querypb.ComputePhraseMatchSlopRequest) (*querypb.ComputePhraseMatchSlopResponse, error) {
 	if err := merr.CheckHealthy(s.State()); err != nil {
 		return &querypb.ComputePhraseMatchSlopResponse{
-			Status: merr.Status(errors.Wrap(err, "failed to compute phrase match slop")),
+			Status: merr.Status(merr.Wrap(err, "failed to compute phrase match slop")),
 		}, nil
 	}
 

--- a/internal/querycoordv2/services_test.go
+++ b/internal/querycoordv2/services_test.go
@@ -714,12 +714,12 @@ func (suite *ServiceSuite) TestTransferNode() {
 	defer server.resourceObserver.Stop()
 	defer server.replicaObserver.Stop()
 
-	err := server.meta.AddResourceGroup(ctx, "rg1", &rgpb.ResourceGroupConfig{
+	_, err := server.meta.AddResourceGroup(ctx, "rg1", &rgpb.ResourceGroupConfig{
 		Requests: &rgpb.ResourceGroupLimit{NodeNum: 0},
 		Limits:   &rgpb.ResourceGroupLimit{NodeNum: 0},
 	})
 	suite.NoError(err)
-	err = server.meta.AddResourceGroup(ctx, "rg2", &rgpb.ResourceGroupConfig{
+	_, err = server.meta.AddResourceGroup(ctx, "rg2", &rgpb.ResourceGroupConfig{
 		Requests: &rgpb.ResourceGroupLimit{NodeNum: 0},
 		Limits:   &rgpb.ResourceGroupLimit{NodeNum: 0},
 	})
@@ -778,12 +778,12 @@ func (suite *ServiceSuite) TestTransferNode() {
 	suite.NoError(err)
 	suite.Equal(commonpb.ErrorCode_IllegalArgument, resp.ErrorCode)
 
-	err = server.meta.AddResourceGroup(ctx, "rg3", &rgpb.ResourceGroupConfig{
+	_, err = server.meta.AddResourceGroup(ctx, "rg3", &rgpb.ResourceGroupConfig{
 		Requests: &rgpb.ResourceGroupLimit{NodeNum: 4},
 		Limits:   &rgpb.ResourceGroupLimit{NodeNum: 4},
 	})
 	suite.NoError(err)
-	err = server.meta.AddResourceGroup(ctx, "rg4", &rgpb.ResourceGroupConfig{
+	_, err = server.meta.AddResourceGroup(ctx, "rg4", &rgpb.ResourceGroupConfig{
 		Requests: &rgpb.ResourceGroupLimit{NodeNum: 0},
 		Limits:   &rgpb.ResourceGroupLimit{NodeNum: 0},
 	})
@@ -862,17 +862,17 @@ func (suite *ServiceSuite) TestTransferReplica() {
 	suite.loadAll()
 	server := suite.server
 
-	err := server.meta.AddResourceGroup(ctx, "rg1", &rgpb.ResourceGroupConfig{
+	_, err := server.meta.AddResourceGroup(ctx, "rg1", &rgpb.ResourceGroupConfig{
 		Requests: &rgpb.ResourceGroupLimit{NodeNum: 1},
 		Limits:   &rgpb.ResourceGroupLimit{NodeNum: 1},
 	})
 	suite.NoError(err)
-	err = server.meta.AddResourceGroup(ctx, "rg2", &rgpb.ResourceGroupConfig{
+	_, err = server.meta.AddResourceGroup(ctx, "rg2", &rgpb.ResourceGroupConfig{
 		Requests: &rgpb.ResourceGroupLimit{NodeNum: 1},
 		Limits:   &rgpb.ResourceGroupLimit{NodeNum: 1},
 	})
 	suite.NoError(err)
-	err = server.meta.AddResourceGroup(ctx, "rg3", &rgpb.ResourceGroupConfig{
+	_, err = server.meta.AddResourceGroup(ctx, "rg3", &rgpb.ResourceGroupConfig{
 		Requests: &rgpb.ResourceGroupLimit{NodeNum: 3},
 		Limits:   &rgpb.ResourceGroupLimit{NodeNum: 3},
 	})

--- a/internal/querycoordv2/session/cluster.go
+++ b/internal/querycoordv2/session/cluster.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -39,7 +38,7 @@ import (
 var ErrNodeNotFound = merr.WrapErrServiceInternalMsg("node not found")
 
 func WrapErrNodeNotFound(nodeID int64) error {
-	return errors.Wrapf(ErrNodeNotFound, "node %v", nodeID)
+	return merr.Wrapf(ErrNodeNotFound, "node %v", nodeID)
 }
 
 type Cluster interface {

--- a/internal/querycoordv2/session/cluster.go
+++ b/internal/querycoordv2/session/cluster.go
@@ -18,7 +18,6 @@ package session
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -33,13 +32,14 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
-var ErrNodeNotFound = errors.New("NodeNotFound")
+var ErrNodeNotFound = merr.WrapErrServiceInternalMsg("node not found")
 
 func WrapErrNodeNotFound(nodeID int64) error {
-	return fmt.Errorf("%w(%v)", ErrNodeNotFound, nodeID)
+	return errors.Wrapf(ErrNodeNotFound, "node %v", nodeID)
 }
 
 type Cluster interface {

--- a/internal/querycoordv2/session/node_manager.go
+++ b/internal/querycoordv2/session/node_manager.go
@@ -18,7 +18,6 @@ package session
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -78,7 +78,7 @@ func (m *NodeManager) IsStoppingNode(nodeID int64) (bool, error) {
 
 	node := m.nodes[nodeID]
 	if node == nil {
-		return false, fmt.Errorf("nodeID[%d] isn't existed", nodeID)
+		return false, merr.WrapErrServiceInternalMsg("nodeID[%d] isn't existed", nodeID)
 	}
 	return node.IsStoppingState(), nil
 }

--- a/internal/querycoordv2/utils/util.go
+++ b/internal/querycoordv2/utils/util.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
@@ -57,7 +56,7 @@ func CheckDelegatorDataReady(nodeMgr *session.NodeManager, targetMgr meta.Target
 	if info == nil {
 		err := merr.WrapErrNodeOffline(leader.ID)
 		log.Info("leader is not available", zap.Error(err))
-		return errors.Wrap(err, "leader not available")
+		return merr.Wrap(err, "leader not available")
 	}
 
 	// Check if delegator is still catching up with streaming data

--- a/internal/querycoordv2/utils/util.go
+++ b/internal/querycoordv2/utils/util.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
@@ -56,7 +57,7 @@ func CheckDelegatorDataReady(nodeMgr *session.NodeManager, targetMgr meta.Target
 	if info == nil {
 		err := merr.WrapErrNodeOffline(leader.ID)
 		log.Info("leader is not available", zap.Error(err))
-		return fmt.Errorf("leader not available: %w", err)
+		return errors.Wrap(err, "leader not available")
 	}
 
 	// Check if delegator is still catching up with streaming data

--- a/internal/rootcoord/broker.go
+++ b/internal/rootcoord/broker.go
@@ -18,9 +18,7 @@ package rootcoord
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -84,7 +82,7 @@ func (b *ServerBroker) ReleaseCollection(ctx context.Context, collectionID Uniqu
 	}
 
 	if resp.GetErrorCode() != commonpb.ErrorCode_Success {
-		return fmt.Errorf("failed to release collection, code: %s, reason: %s", resp.GetErrorCode(), resp.GetReason())
+		return merr.WrapErrServiceInternalMsg("failed to release collection, code: %s, reason: %s", resp.GetErrorCode(), resp.GetReason())
 	}
 
 	log.Ctx(ctx).Info("done to release collection", zap.Int64("collection", collectionID))
@@ -107,7 +105,7 @@ func (b *ServerBroker) ReleasePartitions(ctx context.Context, collectionID Uniqu
 	}
 
 	if resp.GetErrorCode() != commonpb.ErrorCode_Success {
-		return fmt.Errorf("release partition failed, reason: %s", resp.GetReason())
+		return merr.WrapErrServiceInternalMsg("release partition failed, reason: %s", resp.GetReason())
 	}
 
 	log.Info("release partitions done")
@@ -127,7 +125,7 @@ func (b *ServerBroker) SyncNewCreatedPartition(ctx context.Context, collectionID
 	}
 
 	if resp.GetErrorCode() != commonpb.ErrorCode_Success {
-		return fmt.Errorf("sync new partition failed, reason: %s", resp.GetReason())
+		return merr.WrapErrServiceInternalMsg("sync new partition failed, reason: %s", resp.GetReason())
 	}
 
 	log.Info("sync new partition done")
@@ -182,7 +180,7 @@ func (b *ServerBroker) WatchChannels(ctx context.Context, info *watchInfo) error
 	}
 
 	if resp.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
-		return fmt.Errorf("failed to watch channels, code: %s, reason: %s", resp.GetStatus().GetErrorCode(), resp.GetStatus().GetReason())
+		return merr.WrapErrServiceInternalMsg("failed to watch channels, code: %s, reason: %s", resp.GetStatus().GetErrorCode(), resp.GetStatus().GetReason())
 	}
 
 	log.Ctx(ctx).Info("done to watch channels", zap.Uint64("ts", info.ts), zap.Int64("collection", info.collectionID), zap.Strings("vChannels", info.vChannels))
@@ -211,7 +209,7 @@ func (b *ServerBroker) DropCollectionIndex(ctx context.Context, collID UniqueID,
 		return err
 	}
 	if rsp.ErrorCode != commonpb.ErrorCode_Success {
-		return fmt.Errorf("%s", rsp.Reason)
+		return merr.WrapErrServiceInternalMsg("%s", rsp.Reason)
 	}
 
 	log.Ctx(ctx).Info("done to drop collection index", zap.Int64("collection", collID), zap.Int64s("partitions", partIDs))
@@ -268,7 +266,7 @@ func (b *ServerBroker) BroadcastAlteredCollection(ctx context.Context, collectio
 	}
 
 	if resp.ErrorCode != commonpb.ErrorCode_Success {
-		return errors.New(resp.Reason)
+		return merr.WrapErrServiceInternalMsg(resp.Reason)
 	}
 	log.Ctx(ctx).Info("done to broadcast request to alter collection",
 		zap.String("collectionName", colMeta.Name), zap.Int64("collectionID", dcReq.GetCollectionID()),

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -68,7 +67,7 @@ func (t *createCollectionTask) releaseFileResources() {
 
 func (t *createCollectionTask) validate(ctx context.Context) error {
 	if t.Req == nil {
-		return errors.New("empty requests")
+		return merr.WrapErrServiceInternalMsg("empty requests")
 	}
 	Params := paramtable.Get()
 
@@ -81,12 +80,12 @@ func (t *createCollectionTask) validate(ctx context.Context) error {
 		cfgMaxShardNum = Params.RootCoordCfg.DmlChannelNum.GetAsInt32()
 	}
 	if shardsNum > cfgMaxShardNum {
-		return fmt.Errorf("shard num (%d) exceeds max configuration (%d)", shardsNum, cfgMaxShardNum)
+		return merr.WrapErrServiceInternalMsg("shard num (%d) exceeds max configuration (%d)", shardsNum, cfgMaxShardNum)
 	}
 
 	cfgShardLimit := Params.ProxyCfg.MaxShardNum.GetAsInt32()
 	if shardsNum > cfgShardLimit {
-		return fmt.Errorf("shard num (%d) exceeds system limit (%d)", shardsNum, cfgShardLimit)
+		return merr.WrapErrServiceInternalMsg("shard num (%d) exceeds system limit (%d)", shardsNum, cfgShardLimit)
 	}
 
 	// 2. check db-collection capacity
@@ -145,7 +144,7 @@ func (t *createCollectionTask) checkMaxCollectionsPerDB(ctx context.Context, db2
 		if err != nil {
 			log.Ctx(ctx).Warn("parse value of property fail", zap.String("key", common.DatabaseMaxCollectionsKey),
 				zap.String("value", maxColNumPerDBStr), zap.Error(err))
-			return fmt.Errorf("parse value of property fail, key:%s, value:%s", common.DatabaseMaxCollectionsKey, maxColNumPerDBStr)
+			return merr.WrapErrServiceInternalMsg("parse value of property fail, key:%s, value:%s", common.DatabaseMaxCollectionsKey, maxColNumPerDBStr)
 		}
 		return check(maxColNumPerDB)
 	}
@@ -305,7 +304,7 @@ func (t *createCollectionTask) assignFieldAndFunctionID(schema *schemapb.Collect
 		for idx, name := range function.InputFieldNames {
 			fieldId, ok := name2id[name]
 			if !ok {
-				return fmt.Errorf("input field %s of function %s not found", name, function.GetName())
+				return merr.WrapErrServiceInternalMsg("input field %s of function %s not found", name, function.GetName())
 			}
 			function.InputFieldIds[idx] = fieldId
 		}
@@ -314,7 +313,7 @@ func (t *createCollectionTask) assignFieldAndFunctionID(schema *schemapb.Collect
 		for idx, name := range function.OutputFieldNames {
 			fieldId, ok := name2id[name]
 			if !ok {
-				return fmt.Errorf("output field %s of function %s not found", name, function.GetName())
+				return merr.WrapErrServiceInternalMsg("output field %s of function %s not found", name, function.GetName())
 			}
 			function.OutputFieldIds[idx] = fieldId
 		}
@@ -441,7 +440,7 @@ func (t *createCollectionTask) prepareSchema(ctx context.Context) error {
 		for _, field := range t.body.CollectionSchema.Fields {
 			if field.Name != RowIDFieldName && field.GetFieldID() == 0 {
 				log.Info("field id 0 is not allowed when preserve field ids", zap.String("field", field.Name))
-				return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("field id 0 is not allowed when preserve field ids, field: %s", field.Name))
+				return merr.WrapErrParameterInvalidMsg("field id 0 is not allowed when preserve field ids, field: %s", field.Name)
 			}
 
 			if field.GetName() == MetaFieldName {
@@ -519,12 +518,12 @@ func (t *createCollectionTask) assignPartitionIDs(ctx context.Context) error {
 		partitionNums := t.Req.GetNumPartitions()
 		// double check, default num of physical partitions should be greater than 0
 		if partitionNums <= 0 {
-			return errors.New("the specified partitions should be greater than 0 if partition key is used")
+			return merr.WrapErrServiceInternalMsg("the specified partitions should be greater than 0 if partition key is used")
 		}
 
 		cfgMaxPartitionNum := Params.RootCoordCfg.MaxPartitionNum.GetAsInt64()
 		if partitionNums > cfgMaxPartitionNum {
-			return fmt.Errorf("partition number (%d) exceeds max configuration (%d), collection: %s",
+			return merr.WrapErrServiceInternalMsg("partition number (%d) exceeds max configuration (%d), collection: %s",
 				partitionNums, cfgMaxPartitionNum, t.Req.CollectionName)
 		}
 
@@ -623,7 +622,7 @@ func (t *createCollectionTask) Prepare(ctx context.Context) error {
 func (t *createCollectionTask) validateIfCollectionExists(ctx context.Context) error {
 	// Check if the collection name duplicates an alias.
 	if _, err := t.meta.DescribeAlias(ctx, t.Req.GetDbName(), t.Req.GetCollectionName(), typeutil.MaxTimestamp); err == nil {
-		err2 := fmt.Errorf("collection name [%s] conflicts with an existing alias, please choose a unique name", t.Req.GetCollectionName())
+		err2 := merr.WrapErrServiceInternalMsg("collection name [%s] conflicts with an existing alias, please choose a unique name", t.Req.GetCollectionName())
 		log.Ctx(ctx).Warn("create collection failed", zap.String("database", t.Req.GetDbName()), zap.Error(err2))
 		return err2
 	}
@@ -633,7 +632,7 @@ func (t *createCollectionTask) validateIfCollectionExists(ctx context.Context) e
 	if err == nil {
 		newCollInfo := newCollectionModel(t.header, t.body, 0)
 		if equal := existedCollInfo.Equal(*newCollInfo); !equal {
-			return fmt.Errorf("create duplicate collection with different parameters, collection: %s", t.Req.GetCollectionName())
+			return merr.WrapErrServiceInternalMsg("create duplicate collection with different parameters, collection: %s", t.Req.GetCollectionName())
 		}
 		return errIgnoredCreateCollection
 	}
@@ -652,12 +651,12 @@ func validateMultiAnalyzerParams(params string, coll *schemapb.CollectionSchema,
 
 	mfield, ok := m["by_field"]
 	if !ok {
-		return fmt.Errorf("multi analyzer params now must set by_field to specify with field decide analyzer")
+		return merr.WrapErrServiceInternalMsg("multi analyzer params now must set by_field to specify with field decide analyzer")
 	}
 
 	err = json.Unmarshal(mfield, &mFileName)
 	if err != nil {
-		return fmt.Errorf("multi analyzer params by_field must be string but now: %s", mfield)
+		return merr.WrapErrServiceInternalMsg("multi analyzer params by_field must be string but now: %s", mfield)
 	}
 
 	// check field exist
@@ -666,7 +665,7 @@ func validateMultiAnalyzerParams(params string, coll *schemapb.CollectionSchema,
 		if field.GetName() == mFileName {
 			// only support string field now
 			if field.GetDataType() != schemapb.DataType_VarChar {
-				return fmt.Errorf("multi analyzer params now only support by string field, but field %s is not string", field.GetName())
+				return merr.WrapErrServiceInternalMsg("multi analyzer params now only support by string field, but field %s is not string", field.GetName())
 			}
 			fieldExist = true
 			break
@@ -674,25 +673,25 @@ func validateMultiAnalyzerParams(params string, coll *schemapb.CollectionSchema,
 	}
 
 	if !fieldExist {
-		return fmt.Errorf("multi analyzer dependent field %s not exist in collection %s", string(mfield), coll.GetName())
+		return merr.WrapErrServiceInternalMsg("multi analyzer dependent field %s not exist in collection %s", string(mfield), coll.GetName())
 	}
 
 	if value, ok := m["alias"]; ok {
 		mapping := map[string]string{}
 		err = json.Unmarshal(value, &mapping)
 		if err != nil {
-			return fmt.Errorf("multi analyzer alias must be string map but now: %s", value)
+			return merr.WrapErrServiceInternalMsg("multi analyzer alias must be string map but now: %s", value)
 		}
 	}
 
 	analyzers, ok := m["analyzers"]
 	if !ok {
-		return fmt.Errorf("multi analyzer params must set analyzers ")
+		return merr.WrapErrServiceInternalMsg("multi analyzer params must set analyzers ")
 	}
 
 	err = json.Unmarshal(analyzers, &analyzerMap)
 	if err != nil {
-		return fmt.Errorf("unmarshal analyzers failed: %s", err)
+		return merr.WrapErrServiceInternalMsg("unmarshal analyzers failed: %s", err)
 	}
 
 	hasDefault := false
@@ -708,7 +707,7 @@ func validateMultiAnalyzerParams(params string, coll *schemapb.CollectionSchema,
 	}
 
 	if !hasDefault {
-		return fmt.Errorf("multi analyzer must set default analyzer for all unknown value")
+		return merr.WrapErrServiceInternalMsg("multi analyzer must set default analyzer for all unknown value")
 	}
 	return nil
 }
@@ -720,15 +719,15 @@ func validateAnalyzer(collSchema *schemapb.CollectionSchema, fieldSchema *schema
 	}
 
 	if !h.EnableAnalyzer() {
-		return fmt.Errorf("field %s which has enable_match or is input of BM25 function must also enable_analyzer", fieldSchema.Name)
+		return merr.WrapErrServiceInternalMsg("field %s which has enable_match or is input of BM25 function must also enable_analyzer", fieldSchema.Name)
 	}
 
 	if params, ok := h.GetMultiAnalyzerParams(); ok {
 		if h.EnableMatch() {
-			return fmt.Errorf("multi analyzer now only support for bm25, but now field %s enable match", fieldSchema.Name)
+			return merr.WrapErrServiceInternalMsg("multi analyzer now only support for bm25, but now field %s enable match", fieldSchema.Name)
 		}
 		if h.HasAnalyzerParams() {
-			return fmt.Errorf("field %s analyzer params should be none if has multi analyzer params", fieldSchema.Name)
+			return merr.WrapErrServiceInternalMsg("field %s analyzer params should be none if has multi analyzer params", fieldSchema.Name)
 		}
 
 		return validateMultiAnalyzerParams(params, collSchema, fieldSchema, analyzerInfos)

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -561,7 +561,8 @@ func (t *createCollectionTask) assignChannels(ctx context.Context) error {
 		Num:          int(t.Req.GetShardsNum()),
 	})
 	if err != nil {
-		return err
+		return merr.WrapErrServiceInternalErr(err, "failed to allocate vchannels for collection %d (shards=%d)",
+			t.header.GetCollectionId(), t.Req.GetShardsNum())
 	}
 
 	for _, vchannel := range vchannels {

--- a/internal/rootcoord/ddl_callbacks.go
+++ b/internal/rootcoord/ddl_callbacks.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
@@ -29,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/ce"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -122,7 +121,7 @@ func (c *DDLCallback) ExpireCaches(ctx context.Context, expirations any) error {
 func (c *DDLCallback) expireCache(ctx context.Context, cacheExpiration *message.CacheExpiration) error {
 	ts, err := c.tsoAllocator.GenerateTSO(1)
 	if err != nil {
-		return errors.Wrap(err, "failed to generate timestamp")
+		return merr.Wrap(err, "failed to generate timestamp")
 	}
 	switch cacheExpiration.Cache.(type) {
 	case *messagespb.CacheExpiration_LegacyProxyCollectionMetaCache:
@@ -143,7 +142,7 @@ func (c *DDLCallback) expireCache(ctx context.Context, cacheExpiration *message.
 func startBroadcastWithRBACLock(ctx context.Context) (broadcaster.BroadcastAPI, error) {
 	api, err := broadcast.StartBroadcastWithResourceKeys(ctx, message.NewExclusivePrivilegeResourceKey())
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start broadcast with rbac lock")
+		return nil, merr.Wrap(err, "failed to start broadcast with rbac lock")
 	}
 	return api, nil
 }
@@ -152,7 +151,7 @@ func startBroadcastWithRBACLock(ctx context.Context) (broadcaster.BroadcastAPI, 
 func startBroadcastWithDatabaseLock(ctx context.Context, dbName string) (broadcaster.BroadcastAPI, error) {
 	broadcaster, err := broadcast.StartBroadcastWithResourceKeys(ctx, message.NewExclusiveDBNameResourceKey(dbName))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start broadcast with database lock")
+		return nil, merr.Wrap(err, "failed to start broadcast with database lock")
 	}
 	return broadcaster, nil
 }
@@ -166,7 +165,7 @@ func (*Core) startBroadcastWithCollectionLock(ctx context.Context, dbName string
 		message.NewExclusiveCollectionNameResourceKey(dbName, collectionName),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start broadcast with collection lock")
+		return nil, merr.Wrap(err, "failed to start broadcast with collection lock")
 	}
 	return broadcaster, nil
 }
@@ -177,7 +176,7 @@ func (*Core) startBroadcastWithCollectionLock(ctx context.Context, dbName string
 func (c *Core) startBroadcastWithAliasOrCollectionLock(ctx context.Context, dbName string, collectionNameOrAlias string) (broadcaster.BroadcastAPI, error) {
 	coll, err := c.meta.GetCollectionByName(ctx, dbName, collectionNameOrAlias, typeutil.MaxTimestamp, true)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get collection by name")
+		return nil, merr.Wrap(err, "failed to get collection by name")
 	}
 	return c.startBroadcastWithCollectionLock(ctx, dbName, coll.Name)
 }

--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
@@ -47,7 +47,7 @@ func (c *Core) broadcastAlterCollectionForAddField(ctx context.Context, req *mil
 			timezone = common.DefaultTimezone
 		}
 		if err := timestamptz.CheckAndRewriteTimestampTzDefaultValueForFieldSchema(fieldSchema, timezone); err != nil {
-			return merr.WrapErrParameterInvalidMsg("invalid default value of field, name: %s, err: %w", fieldSchema.Name, err)
+			return merr.WrapErrParameterInvalidErr(err, "invalid default value of field, name: %s", fieldSchema.Name)
 		}
 	}
 

--- a/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_add_field.go
@@ -3,7 +3,6 @@ package rootcoord
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
@@ -36,10 +35,10 @@ func (c *Core) broadcastAlterCollectionForAddField(ctx context.Context, req *mil
 	// check if the field schema is illegal.
 	fieldSchema := &schemapb.FieldSchema{}
 	if err = proto.Unmarshal(req.Schema, fieldSchema); err != nil {
-		return errors.Wrap(err, "failed to unmarshal field schema")
+		return merr.Wrap(err, "failed to unmarshal field schema")
 	}
 	if err := checkFieldSchema([]*schemapb.FieldSchema{fieldSchema}); err != nil {
-		return errors.Wrap(err, "failed to check field schema")
+		return merr.Wrap(err, "failed to check field schema")
 	}
 	if fieldSchema.GetDataType() == schemapb.DataType_Timestamptz {
 		timezone, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, coll.Properties)

--- a/internal/rootcoord/ddl_callbacks_alter_collection_name.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_name.go
@@ -3,7 +3,6 @@ package rootcoord
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -110,12 +109,12 @@ func (c *Core) validateEncryption(ctx context.Context, oldDBName string, newDBNa
 	// old and new DB names are filled in Prepare, shouldn't be empty here
 	originalDB, err := c.meta.GetDatabaseByName(ctx, oldDBName, typeutil.MaxTimestamp)
 	if err != nil {
-		return errors.Wrap(err, "failed to get original database")
+		return merr.Wrap(err, "failed to get original database")
 	}
 
 	targetDB, err := c.meta.GetDatabaseByName(ctx, newDBName, typeutil.MaxTimestamp)
 	if err != nil {
-		return errors.Wrapf(err, "target database %s not found", newDBName)
+		return merr.Wrapf(err, "target database %s not found", newDBName)
 	}
 
 	// Check if either database has encryption enabled

--- a/internal/rootcoord/ddl_callbacks_alter_collection_name.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_name.go
@@ -2,8 +2,8 @@ package rootcoord
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -110,17 +110,17 @@ func (c *Core) validateEncryption(ctx context.Context, oldDBName string, newDBNa
 	// old and new DB names are filled in Prepare, shouldn't be empty here
 	originalDB, err := c.meta.GetDatabaseByName(ctx, oldDBName, typeutil.MaxTimestamp)
 	if err != nil {
-		return fmt.Errorf("failed to get original database: %w", err)
+		return errors.Wrap(err, "failed to get original database")
 	}
 
 	targetDB, err := c.meta.GetDatabaseByName(ctx, newDBName, typeutil.MaxTimestamp)
 	if err != nil {
-		return fmt.Errorf("target database %s not found: %w", newDBName, err)
+		return errors.Wrapf(err, "target database %s not found", newDBName)
 	}
 
 	// Check if either database has encryption enabled
 	if hookutil.IsDBEncrypted(originalDB.Properties) || hookutil.IsDBEncrypted(targetDB.Properties) {
-		return fmt.Errorf("deny to change collection databases due to at least one database enabled encryption, original DB: %s, target DB: %s", oldDBName, newDBName)
+		return merr.WrapErrServiceInternalMsg("deny to change collection databases due to at least one database enabled encryption, original DB: %s, target DB: %s", oldDBName, newDBName)
 	}
 
 	return nil

--- a/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_properties.go
@@ -332,7 +332,7 @@ func (c *DDLCallback) alterCollectionV2AckCallback(ctx context.Context, result m
 			log.Ctx(ctx).Warn("alter a non-existent collection, ignore it", log.FieldMessage(result.Message))
 			return nil
 		}
-		return errors.Wrap(err, "failed to alter collection")
+		return merr.Wrap(err, "failed to alter collection")
 	}
 	if body.Updates.AlterLoadConfig != nil {
 		resp, err := c.mixCoord.UpdateLoadConfig(ctx, &querypb.UpdateLoadConfigRequest{
@@ -341,18 +341,18 @@ func (c *DDLCallback) alterCollectionV2AckCallback(ctx context.Context, result m
 			ResourceGroups: body.Updates.AlterLoadConfig.ResourceGroups,
 		})
 		if err != nil {
-			return errors.Wrap(err, "failed to update load config")
+			return merr.Wrap(err, "failed to update load config")
 		}
 		if err := merr.CheckRPCCall(resp, err); err != nil {
 			if errors.Is(err, merr.ErrResourceGroupNotFound) {
 				log.Ctx(ctx).Warn("failed to update load config due to missing resource group, stop retrying", zap.Error(err))
 				return nil
 			}
-			return errors.Wrap(err, "failed to update load config")
+			return merr.Wrap(err, "failed to update load config")
 		}
 	}
 	if err := c.broker.BroadcastAlteredCollection(ctx, header.CollectionId); err != nil {
-		return errors.Wrap(err, "failed to broadcast altered collection")
+		return merr.Wrap(err, "failed to broadcast altered collection")
 	}
 
 	// If the collection was renamed or moved to a different DB, grants were migrated

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -19,7 +19,6 @@ package rootcoord
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -83,7 +82,7 @@ func (c *Core) broadcastAlterCollectionSchema(ctx context.Context, req *milvuspb
 		fieldSchemas = append(fieldSchemas, fieldSchema)
 	}
 	if err := checkFieldSchema(fieldSchemas); err != nil {
-		return errors.Wrap(err, "failed to check field schema")
+		return merr.Wrap(err, "failed to check field schema")
 	}
 
 	// 3. check if the fields already exist

--- a/internal/rootcoord/ddl_callbacks_alter_database.go
+++ b/internal/rootcoord/ddl_callbacks_alter_database.go
@@ -70,11 +70,11 @@ func (c *Core) broadcastAlterDatabase(ctx context.Context, req *rootcoordpb.Alte
 
 	oldDB, err := c.meta.GetDatabaseByName(ctx, req.GetDbName(), typeutil.MaxTimestamp)
 	if err != nil {
-		return errors.Wrap(err, "failed to get database by name")
+		return merr.Wrap(err, "failed to get database by name")
 	}
 	alterLoadConfig, err := c.getAlterLoadConfigOfAlterDatabase(ctx, req.GetDbName(), oldDB.Properties, req.GetProperties())
 	if err != nil {
-		return errors.Wrap(err, "failed to get alter load config of alter database")
+		return merr.Wrap(err, "failed to get alter load config of alter database")
 	}
 
 	// We only allow to alter or delete properties, not both.
@@ -141,7 +141,7 @@ func (c *DDLCallback) alterDatabaseV1AckCallback(ctx context.Context, result mes
 
 	db := model.NewDatabase(header.DbId, header.DbName, etcdpb.DatabaseState_DatabaseCreated, body.Properties)
 	if err := c.meta.AlterDatabase(ctx, db, result.GetControlChannelResult().TimeTick); err != nil {
-		return errors.Wrap(err, "failed to alter database")
+		return merr.Wrap(err, "failed to alter database")
 	}
 	if body.AlterLoadConfig != nil {
 		resp, err := c.mixCoord.UpdateLoadConfig(ctx, &querypb.UpdateLoadConfigRequest{
@@ -150,14 +150,14 @@ func (c *DDLCallback) alterDatabaseV1AckCallback(ctx context.Context, result mes
 			ResourceGroups: body.AlterLoadConfig.ResourceGroups,
 		})
 		if err != nil {
-			return errors.Wrap(err, "failed to update load config")
+			return merr.Wrap(err, "failed to update load config")
 		}
 		if err := merr.CheckRPCCall(resp, err); err != nil {
 			if errors.Is(err, merr.ErrResourceGroupNotFound) {
 				log.Ctx(ctx).Warn("failed to update load config due to missing resource group, stop retrying", zap.Error(err))
 				return nil
 			}
-			return errors.Wrap(err, "failed to update load config")
+			return merr.Wrap(err, "failed to update load config")
 		}
 	}
 	return c.ExpireCaches(ctx, ce.NewBuilder().

--- a/internal/rootcoord/ddl_callbacks_collection_function.go
+++ b/internal/rootcoord/ddl_callbacks_collection_function.go
@@ -18,7 +18,6 @@ package rootcoord
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -75,7 +74,7 @@ func callAlterCollection(ctx context.Context, c *Core, broadcaster broadcaster.B
 
 func alterFunctionGenNewCollection(ctx context.Context, fSchema *schemapb.FunctionSchema, collection *model.Collection) error {
 	if fSchema == nil {
-		return fmt.Errorf("function schema is empty")
+		return merr.WrapErrParameterInvalidMsg("function schema is empty")
 	}
 	var oldFuncSchema *model.Function
 	newFuncs := []*model.Function{}
@@ -87,7 +86,7 @@ func alterFunctionGenNewCollection(ctx context.Context, fSchema *schemapb.Functi
 		}
 	}
 	if oldFuncSchema == nil {
-		err := fmt.Errorf("function %s not exists", fSchema.Name)
+		err := merr.WrapErrParameterInvalidMsg("function %s not exists", fSchema.Name)
 		log.Ctx(ctx).Error("Alter function failed:", zap.Error(err))
 		return err
 	}
@@ -103,7 +102,7 @@ func alterFunctionGenNewCollection(ctx context.Context, fSchema *schemapb.Functi
 	for _, name := range oldFuncSchema.OutputFieldNames {
 		field, exists := fieldMapping[name]
 		if !exists {
-			return fmt.Errorf("old version function's output field %s not exists", name)
+			return merr.WrapErrParameterInvalidMsg("old version function's output field %s not exists", name)
 		}
 		field.IsFunctionOutput = false
 	}
@@ -111,7 +110,7 @@ func alterFunctionGenNewCollection(ctx context.Context, fSchema *schemapb.Functi
 	for _, name := range fSchema.InputFieldNames {
 		field, exists := fieldMapping[name]
 		if !exists {
-			err := fmt.Errorf("function's input field %s not exists", name)
+			err := merr.WrapErrServiceInternalMsg("function's input field %s not exists", name)
 			log.Ctx(ctx).Error("Incorrect function configuration:", zap.Error(err))
 			return err
 		}
@@ -120,12 +119,12 @@ func alterFunctionGenNewCollection(ctx context.Context, fSchema *schemapb.Functi
 	for _, name := range fSchema.OutputFieldNames {
 		field, exists := fieldMapping[name]
 		if !exists {
-			err := fmt.Errorf("function's output field %s not exists", name)
+			err := merr.WrapErrServiceInternalMsg("function's output field %s not exists", name)
 			log.Ctx(ctx).Error("Incorrect function configuration:", zap.Error(err))
 			return err
 		}
 		if field.IsFunctionOutput {
-			err := fmt.Errorf("function's output field %s is already of other functions", name)
+			err := merr.WrapErrServiceInternalMsg("function's output field %s is already of other functions", name)
 			log.Ctx(ctx).Error("Incorrect function configuration: ", zap.Error(err))
 			return err
 		}
@@ -198,7 +197,7 @@ func (c *Core) broadcastAlterCollectionForDropFunction(ctx context.Context, req 
 	for _, id := range needDelFunc.OutputFieldIDs {
 		field, exists := fieldMapping[id]
 		if !exists {
-			return fmt.Errorf("function's output field %d not exists", id)
+			return merr.WrapErrServiceInternalMsg("function's output field %d not exists", id)
 		}
 		field.IsFunctionOutput = false
 	}
@@ -220,7 +219,7 @@ func (c *Core) broadcastAlterCollectionForAddFunction(ctx context.Context, req *
 	newColl := oldColl.Clone()
 	fSchema := req.FunctionSchema
 	if fSchema == nil {
-		return merr.WrapErrParameterInvalidMsg("Function schema is empty")
+		return merr.WrapErrParameterInvalidMsg("function schema is empty")
 	}
 
 	nextFunctionID := int64(StartOfUserFunctionID)
@@ -239,7 +238,7 @@ func (c *Core) broadcastAlterCollectionForAddFunction(ctx context.Context, req *
 	for _, name := range fSchema.InputFieldNames {
 		field, exists := fieldMapping[name]
 		if !exists {
-			err := fmt.Errorf("function's input field %s not exists", name)
+			err := merr.WrapErrServiceInternalMsg("function's input field %s not exists", name)
 			log.Ctx(ctx).Error("Incorrect function configuration:", zap.Error(err))
 			return err
 		}
@@ -248,12 +247,12 @@ func (c *Core) broadcastAlterCollectionForAddFunction(ctx context.Context, req *
 	for _, name := range fSchema.OutputFieldNames {
 		field, exists := fieldMapping[name]
 		if !exists {
-			err := fmt.Errorf("function's output field %s not exists", name)
+			err := merr.WrapErrServiceInternalMsg("function's output field %s not exists", name)
 			log.Ctx(ctx).Error("Incorrect function configuration:", zap.Error(err))
 			return err
 		}
 		if field.IsFunctionOutput {
-			err := fmt.Errorf("function's output field %s is already of other functions", name)
+			err := merr.WrapErrServiceInternalMsg("function's output field %s is already of other functions", name)
 			log.Ctx(ctx).Error("Incorrect function configuration: ", zap.Error(err))
 			return err
 		}

--- a/internal/rootcoord/ddl_callbacks_create_collection.go
+++ b/internal/rootcoord/ddl_callbacks_create_collection.go
@@ -18,7 +18,6 @@ package rootcoord
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
@@ -228,7 +227,7 @@ func newCollectionModel(header *message.CreateCollectionMessageHeader, body *mes
 func mustConsumeConsistencyLevel(properties []*commonpb.KeyValuePair) (commonpb.ConsistencyLevel, []*commonpb.KeyValuePair) {
 	ok, consistencyLevel := getConsistencyLevel(properties...)
 	if !ok {
-		panic(fmt.Errorf("consistency level not found in properties"))
+		panic(merr.WrapErrServiceInternalMsg("consistency level not found in properties"))
 	}
 	newProperties := make([]*commonpb.KeyValuePair, 0, len(properties)-1)
 	for _, property := range properties {

--- a/internal/rootcoord/ddl_callbacks_create_collection.go
+++ b/internal/rootcoord/ddl_callbacks_create_collection.go
@@ -19,7 +19,6 @@ package rootcoord
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -111,13 +110,13 @@ func (c *DDLCallback) createCollectionV1AckCallback(ctx context.Context, result 
 		if !funcutil.IsControlChannel(vchannel) {
 			// create shard info when virtual channel is created.
 			if err := c.createCollectionShard(ctx, header, body, vchannel, result); err != nil {
-				return errors.Wrap(err, "failed to create collection shard")
+				return merr.Wrap(err, "failed to create collection shard")
 			}
 		}
 	}
 	newCollInfo := newCollectionModelWithMessage(header, body, result)
 	if err := c.meta.AddCollection(ctx, newCollInfo); err != nil {
-		return errors.Wrap(err, "failed to add collection to meta table")
+		return merr.Wrap(err, "failed to add collection to meta table")
 	}
 
 	return c.ExpireCaches(ctx, ce.NewBuilder().WithLegacyProxyCollectionMetaCache(

--- a/internal/rootcoord/ddl_callbacks_create_database.go
+++ b/internal/rootcoord/ddl_callbacks_create_database.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
@@ -50,13 +48,13 @@ func (c *Core) broadcastCreateDatabase(ctx context.Context, req *milvuspb.Create
 
 	dbID, err := c.idAllocator.AllocOne()
 	if err != nil {
-		return errors.Wrap(err, "failed to allocate database id")
+		return merr.Wrap(err, "failed to allocate database id")
 	}
 
 	// Use dbID as ezID because the dbID is unqiue
 	properties, err := hookutil.TidyDBCipherProperties(dbID, req.GetProperties())
 	if err != nil {
-		return errors.Wrap(err, "failed to tidy database cipher properties")
+		return merr.Wrap(err, "failed to tidy database cipher properties")
 	}
 
 	tz, exist := funcutil.TryGetAttrByKeyFromRepeatedKV(common.TimezoneKey, properties)
@@ -65,7 +63,7 @@ func (c *Core) broadcastCreateDatabase(ctx context.Context, req *milvuspb.Create
 	}
 
 	if err := hookutil.CreateEZByDBProperties(properties); err != nil {
-		return errors.Wrap(err, "failed to create ez by db properties")
+		return merr.Wrap(err, "failed to create ez by db properties")
 	}
 
 	msg := message.NewCreateDatabaseMessageBuilderV2().
@@ -86,7 +84,7 @@ func (c *DDLCallback) createDatabaseV1AckCallback(ctx context.Context, result me
 	header := result.Message.Header()
 	db := model.NewDatabase(header.DbId, header.DbName, etcdpb.DatabaseState_DatabaseCreated, result.Message.MustBody().Properties)
 	if err := c.meta.CreateDatabase(ctx, db, result.GetControlChannelResult().TimeTick); err != nil {
-		return errors.Wrap(err, "failed to create database")
+		return merr.Wrap(err, "failed to create database")
 	}
 	return c.ExpireCaches(ctx, ce.NewBuilder().
 		WithLegacyProxyCollectionMetaCache(

--- a/internal/rootcoord/ddl_callbacks_create_partition.go
+++ b/internal/rootcoord/ddl_callbacks_create_partition.go
@@ -19,8 +19,6 @@ package rootcoord
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
@@ -60,7 +58,7 @@ func (c *Core) broadcastCreatePartition(ctx context.Context, in *milvuspb.Create
 
 	partID, err := c.idAllocator.AllocOne()
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to allocate partition ID")
+		return 0, merr.Wrap(err, "failed to allocate partition ID")
 	}
 
 	channels := make([]string, 0, collMeta.ShardsNum+1)
@@ -99,7 +97,7 @@ func (c *DDLCallback) createPartitionV1AckCallback(ctx context.Context, result m
 		State:                     pb.PartitionState_PartitionCreated,
 	}
 	if err := c.meta.AddPartition(ctx, partition); err != nil {
-		return errors.Wrap(err, "failed to add partition meta")
+		return merr.Wrap(err, "failed to add partition meta")
 	}
 	return c.ExpireCaches(ctx, ce.NewBuilder().
 		WithLegacyProxyCollectionMetaCache(

--- a/internal/rootcoord/ddl_callbacks_create_partition.go
+++ b/internal/rootcoord/ddl_callbacks_create_partition.go
@@ -18,7 +18,6 @@ package rootcoord
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/errors"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/ce"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -54,7 +54,7 @@ func (c *Core) broadcastCreatePartition(ctx context.Context, in *milvuspb.Create
 	cfgMaxPartitionNum := Params.RootCoordCfg.MaxPartitionNum.GetAsInt()
 	partitionNum := collMeta.GetPartitionNum(true)
 	if partitionNum >= cfgMaxPartitionNum {
-		return 0, fmt.Errorf("partition number (%d) exceeds max configuration (%d), collection: %s",
+		return 0, merr.WrapErrParameterInvalidMsg("partition number (%d) exceeds max configuration (%d), collection: %s",
 			partitionNum, cfgMaxPartitionNum, collMeta.Name)
 	}
 

--- a/internal/rootcoord/ddl_callbacks_drop_alias.go
+++ b/internal/rootcoord/ddl_callbacks_drop_alias.go
@@ -20,13 +20,12 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/ce"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -61,7 +60,7 @@ func (c *Core) broadcastDropAlias(ctx context.Context, req *milvuspb.DropAliasRe
 
 func (c *DDLCallback) dropAliasV2AckCallback(ctx context.Context, result message.BroadcastResultDropAliasMessageV2) error {
 	if err := c.meta.DropAlias(ctx, result); err != nil {
-		return errors.Wrap(err, "failed to drop alias")
+		return merr.Wrap(err, "failed to drop alias")
 	}
 	return c.ExpireCaches(ctx,
 		ce.NewBuilder().WithLegacyProxyCollectionMetaCache(

--- a/internal/rootcoord/ddl_callbacks_drop_collection.go
+++ b/internal/rootcoord/ddl_callbacks_drop_collection.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -92,7 +91,7 @@ func (c *DDLCallback) dropCollectionV1AckCallback(ctx context.Context, result me
 			if err := registry.CallMessageAckCallback(ctx, dropLoadConfigMsg, map[string]*message.AppendResult{
 				streaming.WAL().ControlChannel(): result,
 			}); err != nil {
-				return errors.Wrap(err, "failed to release collection")
+				return merr.Wrap(err, "failed to release collection")
 			}
 
 			// 2. drop the collection index.
@@ -108,7 +107,7 @@ func (c *DDLCallback) dropCollectionV1AckCallback(ctx context.Context, result me
 			if err := registry.CallMessageAckCallback(ctx, dropIndexMsg, map[string]*message.AppendResult{
 				streaming.WAL().ControlChannel(): result,
 			}); err != nil {
-				return errors.Wrap(err, "failed to drop collection index")
+				return merr.Wrap(err, "failed to drop collection index")
 			}
 
 			// 2.5. best-effort drop all snapshots of this collection
@@ -130,7 +129,7 @@ func (c *DDLCallback) dropCollectionV1AckCallback(ctx context.Context, result me
 
 			// 3. drop the collection meta itself.
 			if err := c.meta.DropCollection(ctx, collectionID, result.TimeTick); err != nil {
-				return errors.Wrap(err, "failed to drop collection")
+				return merr.Wrap(err, "failed to drop collection")
 			}
 			continue
 		}
@@ -142,7 +141,7 @@ func (c *DDLCallback) dropCollectionV1AckCallback(ctx context.Context, result me
 			ChannelName: vchannel,
 		})
 		if err := merr.CheckRPCCall(resp, err); err != nil {
-			return errors.Wrap(err, "failed to drop virtual channel")
+			return merr.Wrap(err, "failed to drop virtual channel")
 		}
 	}
 	// add the collection tombstone to the sweeper.

--- a/internal/rootcoord/ddl_callbacks_drop_database.go
+++ b/internal/rootcoord/ddl_callbacks_drop_database.go
@@ -20,14 +20,13 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/ce"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -45,12 +44,12 @@ func (c *Core) broadcastDropDatabase(ctx context.Context, req *milvuspb.DropData
 
 	db, err := c.meta.GetDatabaseByName(ctx, req.GetDbName(), typeutil.MaxTimestamp)
 	if err != nil {
-		return errors.Wrap(err, "failed to get database name")
+		return merr.Wrap(err, "failed to get database name")
 	}
 
 	// Call back cipher plugin when dropping database succeeded
 	if err := hookutil.RemoveEZByDBProperties(db.Properties); err != nil {
-		return errors.Wrap(err, "failed to remove ez by db properties")
+		return merr.Wrap(err, "failed to remove ez by db properties")
 	}
 
 	msg := message.NewDropDatabaseMessageBuilderV2().
@@ -68,7 +67,7 @@ func (c *Core) broadcastDropDatabase(ctx context.Context, req *milvuspb.DropData
 func (c *DDLCallback) dropDatabaseV1AckCallback(ctx context.Context, result message.BroadcastResultDropDatabaseMessageV2) error {
 	header := result.Message.Header()
 	if err := c.meta.DropDatabase(ctx, header.DbName, result.GetControlChannelResult().TimeTick); err != nil {
-		return errors.Wrap(err, "failed to drop database")
+		return merr.Wrap(err, "failed to drop database")
 	}
 	return c.ExpireCaches(ctx, ce.NewBuilder().
 		WithLegacyProxyCollectionMetaCache(

--- a/internal/rootcoord/ddl_callbacks_drop_partition.go
+++ b/internal/rootcoord/ddl_callbacks_drop_partition.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
@@ -29,12 +27,13 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message/ce"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func (c *Core) broadcastDropPartition(ctx context.Context, in *milvuspb.DropPartitionRequest) error {
 	if in.GetPartitionName() == Params.CommonCfg.DefaultPartitionName.GetValue() {
-		return errors.New("default partition cannot be deleted")
+		return merr.WrapErrServiceInternalMsg("default partition cannot be deleted")
 	}
 
 	broadcaster, err := c.startBroadcastWithAliasOrCollectionLock(ctx, in.GetDbName(), in.GetCollectionName())

--- a/internal/rootcoord/ddl_callbacks_rbac_credential.go
+++ b/internal/rootcoord/ddl_callbacks_rbac_credential.go
@@ -20,13 +20,12 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/proxypb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -40,7 +39,7 @@ func (c *Core) broadcastAlterUserForCreateCredential(ctx context.Context, credIn
 	defer broadcaster.Close()
 
 	if err := c.meta.CheckIfAddCredential(ctx, credInfo); err != nil {
-		return errors.Wrap(err, "failed to check if add credential")
+		return merr.Wrap(err, "failed to check if add credential")
 	}
 
 	msg := message.NewAlterUserMessageBuilderV2().
@@ -66,7 +65,7 @@ func (c *Core) broadcastAlterUserForUpdateCredential(ctx context.Context, credIn
 	defer broadcaster.Close()
 
 	if err := c.meta.CheckIfUpdateCredential(ctx, credInfo); err != nil {
-		return errors.Wrap(err, "failed to check if update credential")
+		return merr.Wrap(err, "failed to check if update credential")
 	}
 
 	msg := message.NewAlterUserMessageBuilderV2().
@@ -86,11 +85,11 @@ func (c *Core) broadcastAlterUserForUpdateCredential(ctx context.Context, credIn
 func (c *DDLCallback) alterUserV2AckCallback(ctx context.Context, result message.BroadcastResultAlterUserMessageV2) error {
 	// insert to db
 	if err := c.meta.AlterCredential(ctx, result); err != nil {
-		return errors.Wrap(err, "failed to alter credential")
+		return merr.Wrap(err, "failed to alter credential")
 	}
 	// update proxy's local cache
 	if err := c.UpdateCredCache(ctx, result.Message.MustBody().CredentialInfo); err != nil {
-		return errors.Wrap(err, "failed to update cred cache")
+		return merr.Wrap(err, "failed to update cred cache")
 	}
 	return nil
 }
@@ -105,7 +104,7 @@ func (c *Core) broadcastDropUserForDeleteCredential(ctx context.Context, in *mil
 	defer broadcaster.Close()
 
 	if err := c.meta.CheckIfDeleteCredential(ctx, in); err != nil {
-		return errors.Wrap(err, "failed to check if delete credential")
+		return merr.Wrap(err, "failed to check if delete credential")
 	}
 
 	msg := message.NewDropUserMessageBuilderV2().
@@ -122,16 +121,16 @@ func (c *Core) broadcastDropUserForDeleteCredential(ctx context.Context, in *mil
 // dropUserV2AckCallback is the ack callback function for the DeleteCredential message
 func (c *DDLCallback) dropUserV2AckCallback(ctx context.Context, result message.BroadcastResultDropUserMessageV2) error {
 	if err := c.meta.DeleteCredential(ctx, result); err != nil {
-		return errors.Wrap(err, "failed to delete credential")
+		return merr.Wrap(err, "failed to delete credential")
 	}
 	if err := c.ExpireCredCache(ctx, result.Message.Header().UserName); err != nil {
-		return errors.Wrap(err, "failed to expire cred cache")
+		return merr.Wrap(err, "failed to expire cred cache")
 	}
 	if err := c.proxyClientManager.RefreshPolicyInfoCache(ctx, &proxypb.RefreshPolicyInfoCacheRequest{
 		OpType: int32(typeutil.CacheDeleteUser),
 		OpKey:  result.Message.Header().UserName,
 	}); err != nil {
-		return errors.Wrap(err, "failed to refresh policy info cache")
+		return merr.Wrap(err, "failed to refresh policy info cache")
 	}
 	return nil
 }

--- a/internal/rootcoord/ddl_callbacks_rbac_privilege.go
+++ b/internal/rootcoord/ddl_callbacks_rbac_privilege.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func (c *Core) broadcastOperatePrivilege(ctx context.Context, in *milvuspb.OperatePrivilegeRequest) error {
@@ -79,7 +80,7 @@ func (c *Core) broadcastOperatePrivilege(ctx context.Context, in *milvuspb.Opera
 			WithBroadcast([]string{streaming.WAL().ControlChannel()}).
 			MustBuildBroadcast()
 	default:
-		return errors.New("invalid operate privilege type")
+		return merr.WrapErrServiceInternalMsg("invalid operate privilege type")
 	}
 	_, err = broadcaster.Broadcast(ctx, msg)
 	return err
@@ -154,7 +155,7 @@ func (c *Core) broadcastOperatePrivilegeGroup(ctx context.Context, in *milvuspb.
 			WithBroadcast([]string{streaming.WAL().ControlChannel()}).
 			MustBuildBroadcast()
 	default:
-		return errors.New("invalid operate privilege group type")
+		return merr.WrapErrServiceInternalMsg("invalid operate privilege group type")
 	}
 	_, err = broadcaster.Broadcast(ctx, msg)
 	return err

--- a/internal/rootcoord/ddl_callbacks_rbac_privilege.go
+++ b/internal/rootcoord/ddl_callbacks_rbac_privilege.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
@@ -38,7 +36,7 @@ func (c *Core) broadcastOperatePrivilege(ctx context.Context, in *milvuspb.Opera
 	defer broadcaster.Close()
 
 	if err := c.operatePrivilegeCommonCheck(ctx, in); err != nil {
-		return errors.Wrap(err, "failed to operate privilege common check")
+		return merr.Wrap(err, "failed to operate privilege common check")
 	}
 	privName := in.Entity.Grantor.Privilege.Name
 	switch in.Version {
@@ -103,7 +101,7 @@ func (c *Core) broadcastCreatePrivilegeGroup(ctx context.Context, in *milvuspb.C
 	defer broadcaster.Close()
 
 	if err := c.meta.CheckIfPrivilegeGroupCreatable(ctx, in); err != nil {
-		return errors.Wrap(err, "failed to check if privilege group creatable")
+		return merr.Wrap(err, "failed to check if privilege group creatable")
 	}
 
 	msg := message.NewAlterPrivilegeGroupMessageBuilderV2().
@@ -127,7 +125,7 @@ func (c *Core) broadcastOperatePrivilegeGroup(ctx context.Context, in *milvuspb.
 	defer broadcaster.Close()
 
 	if err := c.meta.CheckIfPrivilegeGroupAlterable(ctx, in); err != nil {
-		return errors.Wrap(err, "failed to check if privilege group alterable")
+		return merr.Wrap(err, "failed to check if privilege group alterable")
 	}
 
 	var msg message.BroadcastMutableMessage
@@ -176,7 +174,7 @@ func (c *Core) broadcastDropPrivilegeGroup(ctx context.Context, in *milvuspb.Dro
 	defer broadcaster.Close()
 
 	if err := c.meta.CheckIfPrivilegeGroupDropable(ctx, in); err != nil {
-		return errors.Wrap(err, "failed to check if privilege group dropable")
+		return merr.Wrap(err, "failed to check if privilege group dropable")
 	}
 
 	msg := message.NewDropPrivilegeGroupMessageBuilderV2().

--- a/internal/rootcoord/ddl_callbacks_rbac_restore.go
+++ b/internal/rootcoord/ddl_callbacks_rbac_restore.go
@@ -19,13 +19,12 @@ package rootcoord
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/pkg/v3/proto/proxypb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -37,7 +36,7 @@ func (c *Core) broadcastRestoreRBACV2(ctx context.Context, req *milvuspb.Restore
 	defer broadcaster.Close()
 
 	if err := c.meta.CheckIfRBACRestorable(ctx, req); err != nil {
-		return errors.Wrap(err, "failed to check if rbac restorable")
+		return merr.Wrap(err, "failed to check if rbac restorable")
 	}
 
 	msg := message.NewRestoreRBACMessageBuilderV2().
@@ -54,12 +53,12 @@ func (c *Core) broadcastRestoreRBACV2(ctx context.Context, req *milvuspb.Restore
 func (c *DDLCallback) restoreRBACV2AckCallback(ctx context.Context, result message.BroadcastResultRestoreRBACMessageV2) error {
 	meta := result.Message.MustBody().RbacMeta
 	if err := c.meta.RestoreRBAC(ctx, util.DefaultTenant, meta); err != nil {
-		return errors.Wrap(err, "failed to restore rbac meta data")
+		return merr.Wrap(err, "failed to restore rbac meta data")
 	}
 	if err := c.proxyClientManager.RefreshPolicyInfoCache(ctx, &proxypb.RefreshPolicyInfoCacheRequest{
 		OpType: int32(typeutil.CacheRefresh),
 	}); err != nil {
-		return errors.Wrap(err, "failed to refresh policy info cache")
+		return merr.Wrap(err, "failed to refresh policy info cache")
 	}
 	return nil
 }

--- a/internal/rootcoord/ddl_callbacks_rbac_role.go
+++ b/internal/rootcoord/ddl_callbacks_rbac_role.go
@@ -19,8 +19,6 @@ package rootcoord
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/pkg/v3/proto/proxypb"
@@ -39,7 +37,7 @@ func (c *Core) broadcastCreateRole(ctx context.Context, in *milvuspb.CreateRoleR
 	defer broadcaster.Close()
 
 	if err := c.meta.CheckIfCreateRole(ctx, in); err != nil {
-		return errors.Wrap(err, "failed to check if create role")
+		return merr.Wrap(err, "failed to check if create role")
 	}
 
 	msg := message.NewAlterRoleMessageBuilderV2().
@@ -66,7 +64,7 @@ func (c *Core) broadcastDropRole(ctx context.Context, in *milvuspb.DropRoleReque
 	defer broadcaster.Close()
 
 	if err := c.meta.CheckIfDropRole(ctx, in); err != nil {
-		return errors.Wrap(err, "failed to check if drop role")
+		return merr.Wrap(err, "failed to check if drop role")
 	}
 
 	msg := message.NewDropRoleMessageBuilderV2().
@@ -86,16 +84,16 @@ func (c *DDLCallback) dropRoleV2AckCallback(ctx context.Context, result message.
 	msg := result.Message
 	err := c.meta.DropRole(ctx, util.DefaultTenant, msg.Header().RoleName)
 	if err != nil {
-		return errors.Wrap(err, "failed to drop role")
+		return merr.Wrap(err, "failed to drop role")
 	}
 	if err := c.meta.DropGrant(ctx, util.DefaultTenant, &milvuspb.RoleEntity{Name: msg.Header().RoleName}); err != nil {
-		return errors.Wrap(err, "failed to drop grant")
+		return merr.Wrap(err, "failed to drop grant")
 	}
 	if err := c.proxyClientManager.RefreshPolicyInfoCache(ctx, &proxypb.RefreshPolicyInfoCacheRequest{
 		OpType: int32(typeutil.CacheDropRole),
 		OpKey:  msg.Header().RoleName,
 	}); err != nil {
-		return errors.Wrap(err, "failed to refresh policy info cache")
+		return merr.Wrap(err, "failed to refresh policy info cache")
 	}
 	return nil
 }
@@ -108,7 +106,7 @@ func (c *Core) broadcastOperateUserRole(ctx context.Context, in *milvuspb.Operat
 	defer broadcaster.Close()
 
 	if err := c.meta.CheckIfOperateUserRole(ctx, in); err != nil {
-		return errors.Wrap(err, "failed to check if operate user role")
+		return merr.Wrap(err, "failed to check if operate user role")
 	}
 
 	var msg message.BroadcastMutableMessage
@@ -145,13 +143,13 @@ func (c *Core) broadcastOperateUserRole(ctx context.Context, in *milvuspb.Operat
 func (c *DDLCallback) alterUserRoleV2AckCallback(ctx context.Context, result message.BroadcastResultAlterUserRoleMessageV2) error {
 	header := result.Message.Header()
 	if err := c.meta.OperateUserRole(ctx, util.DefaultTenant, header.RoleBinding.UserEntity, header.RoleBinding.RoleEntity, milvuspb.OperateUserRoleType_AddUserToRole); err != nil {
-		return errors.Wrap(err, "failed to operate user role")
+		return merr.Wrap(err, "failed to operate user role")
 	}
 	if err := c.proxyClientManager.RefreshPolicyInfoCache(ctx, &proxypb.RefreshPolicyInfoCacheRequest{
 		OpType: int32(typeutil.CacheAddUserToRole),
 		OpKey:  funcutil.EncodeUserRoleCache(header.RoleBinding.UserEntity.Name, header.RoleBinding.RoleEntity.Name),
 	}); err != nil {
-		return errors.Wrap(err, "failed to refresh policy info cache")
+		return merr.Wrap(err, "failed to refresh policy info cache")
 	}
 	return nil
 }
@@ -159,13 +157,13 @@ func (c *DDLCallback) alterUserRoleV2AckCallback(ctx context.Context, result mes
 func (c *DDLCallback) dropUserRoleV2AckCallback(ctx context.Context, result message.BroadcastResultDropUserRoleMessageV2) error {
 	header := result.Message.Header()
 	if err := c.meta.OperateUserRole(ctx, util.DefaultTenant, header.RoleBinding.UserEntity, header.RoleBinding.RoleEntity, milvuspb.OperateUserRoleType_RemoveUserFromRole); err != nil {
-		return errors.Wrap(err, "failed to operate user role")
+		return merr.Wrap(err, "failed to operate user role")
 	}
 	if err := c.proxyClientManager.RefreshPolicyInfoCache(ctx, &proxypb.RefreshPolicyInfoCacheRequest{
 		OpType: int32(typeutil.CacheRemoveUserFromRole),
 		OpKey:  funcutil.EncodeUserRoleCache(header.RoleBinding.UserEntity.Name, header.RoleBinding.RoleEntity.Name),
 	}); err != nil {
-		return errors.Wrap(err, "failed to refresh policy info cache")
+		return merr.Wrap(err, "failed to refresh policy info cache")
 	}
 	return nil
 }

--- a/internal/rootcoord/ddl_callbacks_rbac_role.go
+++ b/internal/rootcoord/ddl_callbacks_rbac_role.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -135,7 +136,7 @@ func (c *Core) broadcastOperateUserRole(ctx context.Context, in *milvuspb.Operat
 			WithBroadcast([]string{streaming.WAL().ControlChannel()}).
 			MustBuildBroadcast()
 	default:
-		return errors.New("invalid operate user role type")
+		return merr.WrapErrServiceInternalMsg("invalid operate user role type")
 	}
 	_, err = broadcaster.Broadcast(ctx, msg)
 	return err

--- a/internal/rootcoord/ddl_callbacks_truncate_collection.go
+++ b/internal/rootcoord/ddl_callbacks_truncate_collection.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -79,12 +80,12 @@ func (c *DDLCallback) truncateCollectionV2AckCallback(ctx context.Context, resul
 
 	// Drop segments that were updated before the flush timestamp
 	if err := c.mixCoord.DropSegmentsByTime(ctx, header.CollectionId, flushTsList); err != nil {
-		return errors.Wrap(err, "when dropping segments by time")
+		return merr.Wrap(err, "when dropping segments by time")
 	}
 
 	// manually update current target to sync QueryCoord's view
 	if err := c.mixCoord.ManualUpdateCurrentTarget(ctx, header.CollectionId); err != nil {
-		return errors.Wrap(err, "when manually updating current target")
+		return merr.Wrap(err, "when manually updating current target")
 	}
 
 	if err := c.meta.TruncateCollection(ctx, result); err != nil {
@@ -92,12 +93,12 @@ func (c *DDLCallback) truncateCollectionV2AckCallback(ctx context.Context, resul
 			log.Ctx(ctx).Warn("truncate a non-existent collection, ignore it", log.FieldMessage(result.Message))
 			return nil
 		}
-		return errors.Wrap(err, "when truncating collection")
+		return merr.Wrap(err, "when truncating collection")
 	}
 
 	// notify datacoord to update their meta cache
 	if err := c.broker.BroadcastAlteredCollection(ctx, header.CollectionId); err != nil {
-		return errors.Wrap(err, "when broadcasting altered collection")
+		return merr.Wrap(err, "when broadcasting altered collection")
 	}
 	return nil
 }
@@ -117,12 +118,12 @@ func (c *DDLCallback) truncateCollectionV2AckOnceCallback(ctx context.Context, r
 			log.Ctx(ctx).Warn("begin to truncate a non-existent collection, ignore it", log.FieldMessage(result.Message))
 			return nil
 		}
-		return errors.Wrap(err, "when beginning truncate collection")
+		return merr.Wrap(err, "when beginning truncate collection")
 	}
 
 	// notify datacoord to update their meta cache
 	if err := c.broker.BroadcastAlteredCollection(ctx, collectionID); err != nil {
-		return errors.Wrap(err, "when broadcasting altered collection")
+		return merr.Wrap(err, "when broadcasting altered collection")
 	}
 	return nil
 }

--- a/internal/rootcoord/dml_channels.go
+++ b/internal/rootcoord/dml_channels.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/coordinator/snmanager"
@@ -33,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mq/common"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -312,7 +312,7 @@ func (d *dmlChannels) getMsgStreamByName(chanName string) (*dmlMsgStream, error)
 	dms, ok := d.pool.Get(chanName)
 	if !ok {
 		log.Ctx(d.ctx).Error("invalid channelName", zap.String("chanName", chanName))
-		return nil, errors.Newf("invalid channel name: %s", chanName)
+		return nil, merr.WrapErrParameterInvalidMsg("invalid channel name: %s", chanName)
 	}
 	return dms, nil
 }
@@ -361,7 +361,7 @@ func (d *dmlChannels) broadcastMark(chanNames []string, pack *msgstream.MsgPack)
 			}
 		} else {
 			dms.mutex.RUnlock()
-			return nil, errors.Newf("channel not in use: %s", chanName)
+			return nil, merr.WrapErrServiceInternalMsg("channel not in use: %s", chanName)
 		}
 		dms.mutex.RUnlock()
 	}

--- a/internal/rootcoord/drop_collection_task.go
+++ b/internal/rootcoord/drop_collection_task.go
@@ -18,7 +18,6 @@ package rootcoord
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
@@ -42,7 +41,7 @@ type dropCollectionTask struct {
 func (t *dropCollectionTask) validate(ctx context.Context) error {
 	// Critical promise here, also see comment of startBroadcastWithCollectionLock.
 	if t.meta.IsAlias(ctx, t.Req.GetDbName(), t.Req.GetCollectionName()) {
-		return fmt.Errorf("cannot drop the collection via alias = %s", t.Req.CollectionName)
+		return merr.WrapErrServiceInternalMsg("cannot drop the collection via alias = %s", t.Req.CollectionName)
 	}
 
 	// use max ts to check if latest collection exists.
@@ -62,7 +61,7 @@ func (t *dropCollectionTask) validate(ctx context.Context) error {
 
 	// Check if all aliases have been dropped.
 	if len(aliases) > 0 {
-		err = fmt.Errorf("unable to drop the collection [%s] because it has associated aliases %v, please remove all aliases before dropping the collection", t.Req.GetCollectionName(), aliases)
+		err = merr.WrapErrServiceInternalMsg("unable to drop the collection [%s] because it has associated aliases %v, please remove all aliases before dropping the collection", t.Req.GetCollectionName(), aliases)
 		log.Ctx(ctx).Warn("drop collection failed", zap.String("database", t.Req.GetDbName()), zap.Error(err))
 		return err
 	}

--- a/internal/rootcoord/key_manager.go
+++ b/internal/rootcoord/key_manager.go
@@ -18,9 +18,9 @@ package rootcoord
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
+	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type KeyManager struct {
@@ -55,7 +56,7 @@ func NewKeyManager(
 func (km *KeyManager) GetRevokedDatabases() ([]int64, error) {
 	currentStates, err := hookutil.GetEzStates()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get cipher states: %w", err)
+		return nil, errors.Wrap(err, "failed to get cipher states")
 	}
 
 	abnormalDB := make(map[int64]struct{})
@@ -88,7 +89,7 @@ func (km *KeyManager) getDatabaseByEzID(ezID int64) (*model.Database, error) {
 
 	// verify the ezID matches the retrieved DB
 	if db.GetProperty(common.EncryptionEzIDKey) != strconv.FormatInt(ezID, 10) {
-		return nil, fmt.Errorf("db for ezID %d not found", ezID)
+		return nil, merr.WrapErrServiceInternalMsg("db for ezID %d not found", ezID)
 	}
 
 	return db, nil

--- a/internal/rootcoord/key_manager.go
+++ b/internal/rootcoord/key_manager.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
@@ -56,7 +55,7 @@ func NewKeyManager(
 func (km *KeyManager) GetRevokedDatabases() ([]int64, error) {
 	currentStates, err := hookutil.GetEzStates()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get cipher states")
+		return nil, merr.Wrap(err, "failed to get cipher states")
 	}
 
 	abnormalDB := make(map[int64]struct{})

--- a/internal/rootcoord/meta_rbac.go
+++ b/internal/rootcoord/meta_rbac.go
@@ -10,18 +10,14 @@ import (
 )
 
 var (
-	errEmptyUsername     = errors.New("username is empty")
 	errUserNotFound      = errors.New("user not found")
 	errUserAlreadyExists = errors.New("user already exists")
 
-	errEmptyRoleName     = errors.New("role name is empty")
 	errRoleAlreadyExists = errors.New("role already exists")
 	errRoleNotExists     = errors.New("role not exists")
 
 	errEmptyRBACMeta           = errors.New("rbac meta is empty")
 	errNotCustomPrivilegeGroup = errors.New("not a custom privilege group")
-
-	errEmptyPrivilegeGroupName = errors.New("privilege group name is empty")
 )
 
 type RBACChecker interface {

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -410,7 +410,7 @@ func (mt *MetaTable) CheckIfDatabaseCreatable(ctx context.Context, req *milvuspb
 
 	if _, ok := mt.dbName2Meta[dbName]; ok || mt.aliases.exist(dbName) || mt.names.exist(dbName) {
 		// TODO: idempotency check here.
-		return fmt.Errorf("database already exist: %s", dbName)
+		return merr.WrapErrServiceInternalMsg("database already exist: %s", dbName)
 	}
 
 	cfgMaxDatabaseNum := Params.RootCoordCfg.MaxDatabaseNum.GetAsInt()
@@ -464,7 +464,7 @@ func (mt *MetaTable) CheckIfDatabaseDroppable(ctx context.Context, req *milvuspb
 	defer mt.ddLock.RUnlock()
 
 	if dbName == util.DefaultDBName {
-		return errors.New("can not drop default database")
+		return merr.WrapErrServiceInternalMsg("can not drop default database")
 	}
 
 	if _, err := mt.getDatabaseByNameInternal(ctx, dbName, typeutil.MaxTimestamp); err != nil {
@@ -477,7 +477,7 @@ func (mt *MetaTable) CheckIfDatabaseDroppable(ctx context.Context, req *milvuspb
 		return err
 	}
 	if len(colls) > 0 {
-		return fmt.Errorf("database:%s not empty, must drop all collections before drop database", dbName)
+		return merr.WrapErrServiceInternalMsg("database:%s not empty, must drop all collections before drop database", dbName)
 	}
 	return nil
 }
@@ -523,7 +523,7 @@ func (mt *MetaTable) getDatabaseByIDInternal(ctx context.Context, dbID int64, ts
 			return db, nil
 		}
 	}
-	return nil, fmt.Errorf("database dbID:%d not found", dbID)
+	return nil, merr.WrapErrServiceInternalMsg("database dbID:%d not found", dbID)
 }
 
 func (mt *MetaTable) GetDatabaseByName(ctx context.Context, dbName string, ts Timestamp) (*model.Database, error) {
@@ -555,7 +555,7 @@ func (mt *MetaTable) AddCollection(ctx context.Context, coll *model.Collection) 
 	// 1, idempotency check was already done outside;
 	// 2, no need to check time travel logic, since ts should always be the latest;
 	if coll.State != pb.CollectionState_CollectionCreated {
-		return fmt.Errorf("collection state should be created, collection name: %s, collection id: %d, state: %s", coll.Name, coll.CollectionID, coll.State)
+		return merr.WrapErrServiceInternalMsg("collection state should be created, collection name: %s, collection id: %d, state: %s", coll.Name, coll.CollectionID, coll.State)
 	}
 
 	// check if there's a collection meta with the same collection id.
@@ -632,7 +632,7 @@ func (mt *MetaTable) DropCollection(ctx context.Context, collectionID UniqueID, 
 
 	db, err := mt.getDatabaseByIDInternal(ctx, coll.DBID, typeutil.MaxTimestamp)
 	if err != nil {
-		return fmt.Errorf("dbID not found for collection:%d", collectionID)
+		return merr.WrapErrServiceInternalMsg("dbID not found for collection:%d", collectionID)
 	}
 
 	pn := coll.GetPartitionNum(true)
@@ -714,7 +714,7 @@ func (mt *MetaTable) RemoveCollection(ctx context.Context, collectionID UniqueID
 		return nil
 	}
 	if coll.State != pb.CollectionState_CollectionDropping {
-		return fmt.Errorf("remove collection which state is not dropping, collectionID: %d, state: %s", collectionID, coll.State.String())
+		return merr.WrapErrServiceInternalMsg("remove collection which state is not dropping, collectionID: %d, state: %s", collectionID, coll.State.String())
 	}
 
 	ctx1 := contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
@@ -1185,27 +1185,27 @@ func (mt *MetaTable) CheckIfCollectionRenamable(ctx context.Context, dbName stri
 	// get target db
 	targetDB, ok := mt.dbName2Meta[newDBName]
 	if !ok {
-		return fmt.Errorf("target database:%s not found", newDBName)
+		return merr.WrapErrServiceInternalMsg("target database:%s not found", newDBName)
 	}
 
 	// old collection should not be an alias
 	_, ok = mt.aliases.get(dbName, oldName)
 	if ok {
 		log.Warn("unsupported use a alias to rename collection")
-		return fmt.Errorf("unsupported use an alias to rename collection, alias:%s", oldName)
+		return merr.WrapErrServiceInternalMsg("unsupported use an alias to rename collection, alias:%s", oldName)
 	}
 
 	_, ok = mt.aliases.get(newDBName, newName)
 	if ok {
 		log.Warn("cannot rename collection to an existing alias")
-		return fmt.Errorf("cannot rename collection to an existing alias: %s", newName)
+		return merr.WrapErrServiceInternalMsg("cannot rename collection to an existing alias: %s", newName)
 	}
 
 	// check new collection already exists
 	coll, err := mt.getCollectionByNameInternal(ctx, newDBName, newName, typeutil.MaxTimestamp, false)
 	if coll != nil {
 		log.Warn("duplicated new collection name, already taken by another collection or alias.")
-		return fmt.Errorf("duplicated new collection name %s:%s with other collection name or alias", newDBName, newName)
+		return merr.WrapErrServiceInternalMsg("duplicated new collection name %s:%s with other collection name or alias", newDBName, newName)
 	}
 	if err != nil && !errors.Is(err, merr.ErrCollectionNotFound) {
 		log.Warn("fail to check if new collection name is already taken", zap.Error(err))
@@ -1222,7 +1222,7 @@ func (mt *MetaTable) CheckIfCollectionRenamable(ctx context.Context, dbName stri
 	// unsupported rename collection while the collection has aliases
 	aliases := mt.listAliasesByID(oldColl.CollectionID)
 	if len(aliases) > 0 && oldColl.DBID != targetDB.ID {
-		return errors.New("fail to rename db name, must drop all aliases of this collection before rename")
+		return merr.WrapErrServiceInternalMsg("fail to rename db name, must drop all aliases of this collection before rename")
 	}
 	return nil
 }
@@ -1278,11 +1278,11 @@ func (mt *MetaTable) AddPartition(ctx context.Context, partition *model.Partitio
 
 	coll, ok := mt.collID2Meta[partition.CollectionID]
 	if !ok || !coll.Available() {
-		return fmt.Errorf("collection not exists: %d", partition.CollectionID)
+		return merr.WrapErrServiceInternalMsg("collection not exists: %d", partition.CollectionID)
 	}
 
 	if partition.State != pb.PartitionState_PartitionCreated {
-		return fmt.Errorf("partition state is not created, collection: %d, partition: %d, state: %s", partition.CollectionID, partition.PartitionID, partition.State)
+		return merr.WrapErrServiceInternalMsg("partition state is not created, collection: %d, partition: %d, state: %s", partition.CollectionID, partition.PartitionID, partition.State)
 	}
 
 	// idempotency check here.
@@ -1399,7 +1399,7 @@ func (mt *MetaTable) RemovePartition(ctx context.Context, collectionID UniqueID,
 	}
 	partition := coll.Partitions[loc]
 	if partition.State != pb.PartitionState_PartitionDropping {
-		return fmt.Errorf("remove partition which state is not dropping, collection: %d, partition: %d, state: %s", collectionID, partitionID, partition.State.String())
+		return merr.WrapErrServiceInternalMsg("remove partition which state is not dropping, collection: %d, partition: %d, state: %s", collectionID, partitionID, partition.State.String())
 	}
 
 	ctx1 := contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
@@ -1441,7 +1441,7 @@ func (mt *MetaTable) CheckIfAliasCreatable(ctx context.Context, dbName string, a
 	if collID, ok := mt.names.get(dbName, alias); ok {
 		coll, ok := mt.collID2Meta[collID]
 		if !ok {
-			return errors.New("meta error, name mapped non-exist collection id")
+			return merr.WrapErrServiceInternalMsg("meta error, name mapped non-exist collection id")
 		}
 		// allow alias with dropping&dropped
 		if coll.State != pb.CollectionState_CollectionDropping && coll.State != pb.CollectionState_CollectionDropped {
@@ -1731,7 +1731,7 @@ func (mt *MetaTable) CheckIfAddCredential(ctx context.Context, credInfo *interna
 	if len(usernames) >= maxUserNum {
 		errMsg := "unable to add user because the number of users has reached the limit"
 		log.Ctx(ctx).Error(errMsg, zap.Int("maxUserNum", maxUserNum))
-		return errors.New(errMsg)
+		return merr.WrapErrServiceInternalMsg(errMsg)
 	}
 	return nil
 }
@@ -1835,7 +1835,7 @@ func (mt *MetaTable) ListCredentialUsernames(ctx context.Context) (*milvuspb.Lis
 
 	usernames, err := mt.catalog.ListCredentials(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list credential usernames err:%w", err)
+		return nil, errors.Wrap(err, "failed to list credential usernames")
 	}
 	return &milvuspb.ListCredUsersResponse{Usernames: usernames}, nil
 }
@@ -1862,7 +1862,7 @@ func (mt *MetaTable) CheckIfCreateRole(ctx context.Context, in *milvuspb.CreateR
 	if len(results) >= Params.ProxyCfg.MaxRoleNum.GetAsInt() {
 		errMsg := "unable to create role because the number of roles has reached the limit"
 		log.Ctx(ctx).Warn(errMsg, zap.Int("max_role_num", Params.ProxyCfg.MaxRoleNum.GetAsInt()))
-		return errors.New(errMsg)
+		return merr.WrapErrServiceInternalMsg(errMsg)
 	}
 	return nil
 }
@@ -1904,7 +1904,7 @@ func (mt *MetaTable) CheckIfDropRole(ctx context.Context, in *milvuspb.DropRoleR
 	}
 	if len(grantEntities) != 0 {
 		errMsg := "fail to drop the role that it has privileges. Use REVOKE API to revoke privileges"
-		return errors.New(errMsg)
+		return merr.WrapErrServiceInternalMsg(errMsg)
 	}
 	return nil
 }
@@ -1919,10 +1919,10 @@ func (mt *MetaTable) DropRole(ctx context.Context, tenant string, roleName strin
 
 func (mt *MetaTable) CheckIfOperateUserRole(ctx context.Context, req *milvuspb.OperateUserRoleRequest) error {
 	if funcutil.IsEmptyString(req.GetUsername()) {
-		return errors.New("username in the user entity is empty")
+		return merr.WrapErrServiceInternalMsg("username in the user entity is empty")
 	}
 	if funcutil.IsEmptyString(req.GetRoleName()) {
-		return errors.New("role name in the role entity is empty")
+		return merr.WrapErrServiceInternalMsg("role name in the role entity is empty")
 	}
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
@@ -1936,7 +1936,7 @@ func (mt *MetaTable) CheckIfOperateUserRole(ctx context.Context, req *milvuspb.O
 	if req.Type != milvuspb.OperateUserRoleType_RemoveUserFromRole {
 		if _, err := mt.catalog.ListUser(ctx, util.DefaultTenant, &milvuspb.UserEntity{Name: req.Username}, false); err != nil {
 			errMsg := "not found the user, maybe the user isn't existed or internal system error"
-			return errors.New(errMsg)
+			return merr.WrapErrServiceInternalMsg(errMsg)
 		}
 	}
 	return nil
@@ -1973,25 +1973,25 @@ func (mt *MetaTable) SelectUser(ctx context.Context, tenant string, entity *milv
 // OperatePrivilege grant or revoke privilege by setting the operateType param
 func (mt *MetaTable) OperatePrivilege(ctx context.Context, tenant string, entity *milvuspb.GrantEntity, operateType milvuspb.OperatePrivilegeType) error {
 	if funcutil.IsEmptyString(entity.ObjectName) {
-		return errors.New("the object name in the grant entity is empty")
+		return merr.WrapErrServiceInternalMsg("the object name in the grant entity is empty")
 	}
 	if entity.Object == nil || funcutil.IsEmptyString(entity.Object.Name) {
-		return errors.New("the object entity in the grant entity is invalid")
+		return merr.WrapErrServiceInternalMsg("the object entity in the grant entity is invalid")
 	}
 	if entity.Role == nil || funcutil.IsEmptyString(entity.Role.Name) {
-		return errors.New("the role entity in the grant entity is invalid")
+		return merr.WrapErrServiceInternalMsg("the role entity in the grant entity is invalid")
 	}
 	if entity.Grantor == nil {
-		return errors.New("the grantor in the grant entity is empty")
+		return merr.WrapErrServiceInternalMsg("the grantor in the grant entity is empty")
 	}
 	if entity.Grantor.Privilege == nil || funcutil.IsEmptyString(entity.Grantor.Privilege.Name) {
-		return errors.New("the privilege name in the grant entity is empty")
+		return merr.WrapErrServiceInternalMsg("the privilege name in the grant entity is empty")
 	}
 	if entity.Grantor.User == nil || funcutil.IsEmptyString(entity.Grantor.User.Name) {
-		return errors.New("the grantor name in the grant entity is empty")
+		return merr.WrapErrServiceInternalMsg("the grantor name in the grant entity is empty")
 	}
 	if !funcutil.IsRevoke(operateType) && !funcutil.IsGrant(operateType) {
-		return errors.New("the operate type in the grant entity is invalid")
+		return merr.WrapErrServiceInternalMsg("the operate type in the grant entity is invalid")
 	}
 	if entity.DbName == "" {
 		entity.DbName = util.DefaultDBName
@@ -2009,11 +2009,11 @@ func (mt *MetaTable) OperatePrivilege(ctx context.Context, tenant string, entity
 func (mt *MetaTable) SelectGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
 	var entities []*milvuspb.GrantEntity
 	if entity == nil {
-		return entities, errors.New("the grant entity is nil")
+		return entities, merr.WrapErrServiceInternalMsg("the grant entity is nil")
 	}
 
 	if entity.Role == nil || funcutil.IsEmptyString(entity.Role.Name) {
-		return entities, errors.New("the role entity in the grant entity is invalid")
+		return entities, merr.WrapErrServiceInternalMsg("the role entity in the grant entity is invalid")
 	}
 	if entity.DbName == "" {
 		entity.DbName = util.DefaultDBName
@@ -2027,7 +2027,7 @@ func (mt *MetaTable) SelectGrant(ctx context.Context, tenant string, entity *mil
 
 func (mt *MetaTable) DropGrant(ctx context.Context, tenant string, role *milvuspb.RoleEntity) error {
 	if role == nil || funcutil.IsEmptyString(role.Name) {
-		return errors.New("the role entity is invalid when dropping the grant")
+		return merr.WrapErrServiceInternalMsg("the role entity is invalid when dropping the grant")
 	}
 	mt.permissionLock.Lock()
 	defer mt.permissionLock.Unlock()
@@ -2074,7 +2074,7 @@ func (mt *MetaTable) CheckIfRBACRestorable(ctx context.Context, req *milvuspb.Re
 	existRoleAfterRestoreMap := lo.SliceToMap(existRoles, func(entity *milvuspb.RoleResult) (string, struct{}) { return entity.GetRole().GetName(), struct{}{} })
 	for _, role := range meta.GetRoles() {
 		if _, ok := existRoleMap[role.GetName()]; ok {
-			return errors.Newf("role [%s] already exists", role.GetName())
+			return merr.WrapErrParameterInvalidMsg("role [%s] already exists", role.GetName())
 		}
 		existRoleAfterRestoreMap[role.GetName()] = struct{}{}
 	}
@@ -2088,7 +2088,7 @@ func (mt *MetaTable) CheckIfRBACRestorable(ctx context.Context, req *milvuspb.Re
 	existPrivGroupAfterRestoreMap := lo.SliceToMap(existPrivGroups, func(entity *milvuspb.PrivilegeGroupInfo) (string, struct{}) { return entity.GetGroupName(), struct{}{} })
 	for _, group := range meta.GetPrivilegeGroups() {
 		if _, ok := existPrivGroupMap[group.GetGroupName()]; ok {
-			return errors.Newf("privilege group [%s] already exists", group.GetGroupName())
+			return merr.WrapErrParameterInvalidMsg("privilege group [%s] already exists", group.GetGroupName())
 		}
 		existPrivGroupAfterRestoreMap[group.GetGroupName()] = struct{}{}
 	}
@@ -2100,7 +2100,7 @@ func (mt *MetaTable) CheckIfRBACRestorable(ctx context.Context, req *milvuspb.Re
 			continue
 		}
 		if _, ok := existPrivGroupAfterRestoreMap[privName]; !ok && !util.IsPrivilegeNameDefined(privName) {
-			return errors.Newf("privilege [%s] does not exist", privName)
+			return merr.WrapErrParameterInvalidMsg("privilege [%s] does not exist", privName)
 		}
 	}
 
@@ -2112,13 +2112,13 @@ func (mt *MetaTable) CheckIfRBACRestorable(ctx context.Context, req *milvuspb.Re
 	existUserMap := lo.SliceToMap(existUser, func(entity *milvuspb.UserResult) (string, struct{}) { return entity.GetUser().GetName(), struct{}{} })
 	for _, user := range meta.GetUsers() {
 		if _, ok := existUserMap[user.GetUser()]; ok {
-			return errors.Newf("user [%s] already exists", user.GetUser())
+			return merr.WrapErrParameterInvalidMsg("user [%s] already exists", user.GetUser())
 		}
 
 		// check if user-role can be restored
 		for _, role := range user.GetRoles() {
 			if _, ok := existRoleAfterRestoreMap[role.GetName()]; !ok {
-				return errors.Newf("role [%s] does not exist", role.GetName())
+				return merr.WrapErrParameterInvalidMsg("role [%s] does not exist", role.GetName())
 			}
 		}
 	}
@@ -2210,7 +2210,7 @@ func (mt *MetaTable) CheckIfPrivilegeGroupDropable(ctx context.Context, req *mil
 		}
 		for _, grant := range grants {
 			if grant.Grantor.Privilege.Name == req.GetGroupName() {
-				return errors.Newf("privilege group [%s] is used by role [%s], Use REVOKE API to revoke it first", req.GetGroupName(), role.GetName())
+				return merr.WrapErrParameterInvalidMsg("privilege group [%s] is used by role [%s], Use REVOKE API to revoke it first", req.GetGroupName(), role.GetName())
 			}
 		}
 	}
@@ -2300,7 +2300,7 @@ func (mt *MetaTable) OperatePrivilegeGroup(ctx context.Context, groupName string
 		}
 	default:
 		log.Ctx(ctx).Warn("unsupported operate type", zap.Any("operate_type", operateType))
-		return fmt.Errorf("unsupported operate type: %v", operateType)
+		return merr.WrapErrServiceInternalMsg("unsupported operate type: %v", operateType)
 	}
 
 	mergedPrivs := lo.Map(lo.Keys(privSet), func(priv string, _ int) *milvuspb.PrivilegeEntity {
@@ -2315,7 +2315,7 @@ func (mt *MetaTable) OperatePrivilegeGroup(ctx context.Context, groupName string
 
 func (mt *MetaTable) GetPrivilegeGroupRoles(ctx context.Context, groupName string) ([]*milvuspb.RoleEntity, error) {
 	if funcutil.IsEmptyString(groupName) {
-		return nil, errors.New("the privilege group name is empty")
+		return nil, merr.WrapErrServiceInternalMsg("the privilege group name is empty")
 	}
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
@@ -2355,7 +2355,7 @@ func (mt *MetaTable) AddFileResource(ctx context.Context, resource *internalpb.F
 		if old.Path == resource.Path {
 			return nil
 		}
-		return errors.Newf("file resource %s already exists", resource.Name)
+		return merr.WrapErrParameterInvalidMsg("file resource %s already exists", resource.Name)
 	}
 
 	err := mt.catalog.SaveFileResource(ctx, resource, mt.fileResourceVersion+1)
@@ -2375,7 +2375,7 @@ func (mt *MetaTable) RemoveFileResource(ctx context.Context, name string) (error
 
 	if resource, ok := mt.fileResourceName2Meta[name]; ok {
 		if mt.fileResourceRefCnt[resource.Id] > 0 {
-			return errors.Newf("file resource %s is still in use: %d", resource.Name, mt.fileResourceRefCnt[resource.Id]), false
+			return merr.WrapErrParameterInvalidMsg("file resource %s is still in use: %d", resource.Name, mt.fileResourceRefCnt[resource.Id]), false
 		}
 
 		err := mt.catalog.RemoveFileResource(ctx, resource.Id, mt.fileResourceVersion+1)

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -1710,7 +1710,7 @@ func (mt *MetaTable) InitCredential(ctx context.Context) error {
 
 func (mt *MetaTable) CheckIfAddCredential(ctx context.Context, credInfo *internalpb.CredentialInfo) error {
 	if funcutil.IsEmptyString(credInfo.GetUsername()) {
-		return errEmptyUsername
+		return merr.WrapErrParameterInvalidMsg("username is empty")
 	}
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
@@ -1738,7 +1738,7 @@ func (mt *MetaTable) CheckIfAddCredential(ctx context.Context, credInfo *interna
 
 func (mt *MetaTable) CheckIfUpdateCredential(ctx context.Context, credInfo *internalpb.CredentialInfo) error {
 	if funcutil.IsEmptyString(credInfo.GetUsername()) {
-		return errEmptyUsername
+		return merr.WrapErrParameterInvalidMsg("username is empty")
 	}
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
@@ -1792,7 +1792,7 @@ func (mt *MetaTable) GetCredential(ctx context.Context, username string) (*inter
 
 func (mt *MetaTable) CheckIfDeleteCredential(ctx context.Context, req *milvuspb.DeleteCredentialRequest) error {
 	if funcutil.IsEmptyString(req.GetUsername()) {
-		return errEmptyUsername
+		return merr.WrapErrParameterInvalidMsg("username is empty")
 	}
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
@@ -1835,7 +1835,7 @@ func (mt *MetaTable) ListCredentialUsernames(ctx context.Context) (*milvuspb.Lis
 
 	usernames, err := mt.catalog.ListCredentials(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list credential usernames")
+		return nil, merr.Wrap(err, "failed to list credential usernames")
 	}
 	return &milvuspb.ListCredUsersResponse{Usernames: usernames}, nil
 }
@@ -1843,7 +1843,7 @@ func (mt *MetaTable) ListCredentialUsernames(ctx context.Context) (*milvuspb.Lis
 // CheckIfCreateRole checks if the role can be created.
 func (mt *MetaTable) CheckIfCreateRole(ctx context.Context, in *milvuspb.CreateRoleRequest) error {
 	if funcutil.IsEmptyString(in.GetEntity().GetName()) {
-		return errEmptyRoleName
+		return merr.WrapErrParameterInvalidMsg("role name is empty")
 	}
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
@@ -1877,7 +1877,7 @@ func (mt *MetaTable) CreateRole(ctx context.Context, tenant string, entity *milv
 
 func (mt *MetaTable) CheckIfDropRole(ctx context.Context, in *milvuspb.DropRoleRequest) error {
 	if funcutil.IsEmptyString(in.GetRoleName()) {
-		return errEmptyRoleName
+		return merr.WrapErrParameterInvalidMsg("role name is empty")
 	}
 	if util.IsBuiltinRole(in.GetRoleName()) {
 		return merr.WrapErrPrivilegeNotPermitted("the role[%s] is a builtin role, which can't be dropped", in.GetRoleName())
@@ -2148,7 +2148,7 @@ func (mt *MetaTable) IsCustomPrivilegeGroup(ctx context.Context, groupName strin
 
 func (mt *MetaTable) CheckIfPrivilegeGroupCreatable(ctx context.Context, req *milvuspb.CreatePrivilegeGroupRequest) error {
 	if funcutil.IsEmptyString(req.GetGroupName()) {
-		return errEmptyPrivilegeGroupName
+		return merr.WrapErrParameterInvalidMsg("privilege group name is empty")
 	}
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
@@ -2179,7 +2179,7 @@ func (mt *MetaTable) CreatePrivilegeGroup(ctx context.Context, groupName string)
 
 func (mt *MetaTable) CheckIfPrivilegeGroupDropable(ctx context.Context, req *milvuspb.DropPrivilegeGroupRequest) error {
 	if funcutil.IsEmptyString(req.GetGroupName()) {
-		return errEmptyPrivilegeGroupName
+		return merr.WrapErrParameterInvalidMsg("privilege group name is empty")
 	}
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()
@@ -2234,7 +2234,7 @@ func (mt *MetaTable) ListPrivilegeGroups(ctx context.Context) ([]*milvuspb.Privi
 // CheckIfPrivilegeGroupAlterable checks if the privilege group can be altered.
 func (mt *MetaTable) CheckIfPrivilegeGroupAlterable(ctx context.Context, req *milvuspb.OperatePrivilegeGroupRequest) error {
 	if funcutil.IsEmptyString(req.GetGroupName()) {
-		return errEmptyPrivilegeGroupName
+		return merr.WrapErrParameterInvalidMsg("privilege group name is empty")
 	}
 	mt.permissionLock.RLock()
 	defer mt.permissionLock.RUnlock()

--- a/internal/rootcoord/name_db.go
+++ b/internal/rootcoord/name_db.go
@@ -17,11 +17,10 @@
 package rootcoord
 
 import (
-	"fmt"
-
 	"golang.org/x/exp/maps"
 
 	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -86,7 +85,7 @@ func (n *nameDb) listCollections(dbName string) map[string]UniqueID {
 func (n *nameDb) listCollectionID(dbName string) ([]typeutil.UniqueID, error) {
 	name2ID, ok := n.db2Name2ID[dbName]
 	if !ok {
-		return nil, fmt.Errorf("database not exist: %s", dbName)
+		return nil, merr.WrapErrServiceInternalMsg("database not exist: %s", dbName)
 	}
 	return maps.Values(name2ID), nil
 }

--- a/internal/rootcoord/quota_center.go
+++ b/internal/rootcoord/quota_center.go
@@ -943,7 +943,7 @@ func (q *QuotaCenter) calculateWriteRates() error {
 		}
 		collectionLimiter := q.rateLimiter.GetCollectionLimiters(dbID, collection)
 		if collectionLimiter == nil {
-			return fmt.Errorf("collection limiter not found: %d", collection)
+			return merr.WrapErrServiceInternalMsg("collection limiter not found: %d", collection)
 		}
 
 		limiter := collectionLimiter.GetLimiters()
@@ -1439,7 +1439,7 @@ func (q *QuotaCenter) getCollectionMaxLimit(rt internalpb.RateType, collectionID
 	case internalpb.RateType_DQLQuery:
 		return Limit(getCollectionRateLimitConfig(collectionProps, common.CollectionQueryRateMaxKey)), nil
 	default:
-		return 0, fmt.Errorf("unsupportd rate type:%s", rt.String())
+		return 0, merr.WrapErrServiceInternalMsg("unsupportd rate type:%s", rt.String())
 	}
 }
 

--- a/internal/rootcoord/rbac_task.go
+++ b/internal/rootcoord/rbac_task.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/proxypb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -66,7 +67,7 @@ func executeOperatePrivilegeTaskSteps(ctx context.Context, core *Core, entity *m
 			opType = int32(typeutil.CacheRevokePrivilege)
 		default:
 			log.Ctx(ctx).Warn("invalid operate type for the OperatePrivilege api", zap.Any("operate_type", operateType))
-			return errors.New("invalid operate type for the OperatePrivilege api")
+			return merr.WrapErrServiceInternalMsg("invalid operate type for the OperatePrivilege api")
 		}
 		grants := []*milvuspb.GrantEntity{entity}
 
@@ -148,7 +149,7 @@ func executeOperatePrivilegeGroupTaskSteps(ctx context.Context, core *Core, in *
 				newPrivs, _ := lo.Difference(v, in.Privileges)
 				newGroups[k] = newPrivs
 			default:
-				return errors.New("invalid operate type")
+				return merr.WrapErrServiceInternalMsg("invalid operate type")
 			}
 		}
 

--- a/internal/rootcoord/rbac_task.go
+++ b/internal/rootcoord/rbac_task.go
@@ -21,7 +21,6 @@ package rootcoord
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -53,7 +52,7 @@ func executeOperatePrivilegeTaskSteps(ctx context.Context, core *Core, entity *m
 		}
 		return nil
 	}(); err != nil {
-		return errors.Wrap(err, "failed to operate the privilege")
+		return merr.Wrap(err, "failed to operate the privilege")
 	}
 
 	if err := func() error {
@@ -112,7 +111,7 @@ func executeOperatePrivilegeTaskSteps(ctx context.Context, core *Core, entity *m
 		}
 		return nil
 	}(); err != nil {
-		return errors.Wrap(err, "failed to refresh policy info cache")
+		return merr.Wrap(err, "failed to refresh policy info cache")
 	}
 	return nil
 }
@@ -219,11 +218,11 @@ func executeOperatePrivilegeGroupTaskSteps(ctx context.Context, core *Core, in *
 		}
 		return nil
 	}(); err != nil {
-		return errors.Wrap(err, "failed to refresh policy info cache")
+		return merr.Wrap(err, "failed to refresh policy info cache")
 	}
 	if err := core.meta.OperatePrivilegeGroup(ctx, in.GroupName, in.Privileges, operateType); err != nil && !common.IsIgnorableError(err) {
 		log.Ctx(ctx).Warn("fail to operate privilege group", zap.Error(err))
-		return errors.Wrap(err, "failed to operate privilege group")
+		return merr.Wrap(err, "failed to operate privilege group")
 	}
 	return nil
 }

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -88,7 +88,7 @@ func (c *Core) validateResourceGroups(ctx context.Context, properties []*commonp
 	case "collection":
 		rgs, err = common.CollectionLevelResourceGroups(properties)
 	default:
-		return fmt.Errorf("invalid level %s for resource group validation", level)
+		return merr.WrapErrParameterInvalidMsg("invalid level %s for resource group validation", level)
 	}
 
 	if err != nil || len(rgs) == 0 {
@@ -364,7 +364,7 @@ func (c *Core) SetTiKVClient(client *txnkv.Client) {
 func (c *Core) SetSession(session sessionutil.SessionInterface) error {
 	c.session = session
 	if c.session == nil {
-		return errors.New("session is nil, the etcd client connection may have failed")
+		return merr.WrapErrServiceInternalMsg("session is nil, the etcd client connection may have failed")
 	}
 	return nil
 }
@@ -404,7 +404,7 @@ func (c *Core) initMetaTable(initCtx context.Context) error {
 			kvmetastore.StartLegacyTombstoneGC(c.ctx, metaKV)
 			catalog = kvmetastore.NewCatalog(metaKV)
 		default:
-			return retry.Unrecoverable(fmt.Errorf("not supported meta store: %s", Params.MetaStoreCfg.MetaStoreType.GetValue()))
+			return retry.Unrecoverable(merr.WrapErrServiceInternalMsg("not supported meta store: %s", Params.MetaStoreCfg.MetaStoreType.GetValue()))
 		}
 
 		if c.meta, err = NewMetaTable(c.ctx, catalog, c.tsoAllocator); err != nil {
@@ -2204,7 +2204,7 @@ func (c *Core) CreateCredential(ctx context.Context, credInfo *internalpb.Creden
 		ctxLog.Warn("CreateCredential failed", zap.Error(err))
 		metrics.RootCoordDDLReqCounter.WithLabelValues(method, metrics.FailLabel).Inc()
 		if errors.Is(err, errUserAlreadyExists) {
-			return merr.StatusWithErrorCode(errors.Errorf("user already exists: %s", credInfo.Username), commonpb.ErrorCode_CreateCredentialFailure), nil
+			return merr.StatusWithErrorCode(merr.WrapErrParameterInvalidMsg("user already exists: %s", credInfo.Username), commonpb.ErrorCode_CreateCredentialFailure), nil
 		}
 		return merr.StatusWithErrorCode(err, commonpb.ErrorCode_CreateCredentialFailure), nil
 	}
@@ -2347,7 +2347,7 @@ func (c *Core) CreateRole(ctx context.Context, in *milvuspb.CreateRoleRequest) (
 		ctxLog.Warn("fail to create role", zap.Error(err))
 		metrics.RootCoordDDLReqCounter.WithLabelValues(method, metrics.FailLabel).Inc()
 		if errors.Is(err, errRoleAlreadyExists) {
-			return merr.StatusWithErrorCode(errors.Newf("role [%s] already exists", in.GetEntity()), commonpb.ErrorCode_CreateRoleFailure), nil
+			return merr.StatusWithErrorCode(merr.WrapErrParameterInvalidMsg("role [%s] already exists", in.GetEntity()), commonpb.ErrorCode_CreateRoleFailure), nil
 		}
 		return merr.StatusWithErrorCode(err, commonpb.ErrorCode_CreateRoleFailure), nil
 	}
@@ -2380,7 +2380,7 @@ func (c *Core) DropRole(ctx context.Context, in *milvuspb.DropRoleRequest) (*com
 	if err := c.broadcastDropRole(ctx, in); err != nil {
 		ctxLog.Warn("fail to drop role", zap.Error(err))
 		if errors.Is(err, errRoleNotExists) {
-			return merr.StatusWithErrorCode(errors.New("not found the role, maybe the role isn't existed or internal system error"), commonpb.ErrorCode_DropRoleFailure), nil
+			return merr.StatusWithErrorCode(merr.WrapErrServiceInternalMsg("not found the role, maybe the role isn't existed or internal system error"), commonpb.ErrorCode_DropRoleFailure), nil
 		}
 		return merr.StatusWithErrorCode(err, commonpb.ErrorCode_DropRoleFailure), nil
 	}
@@ -2412,7 +2412,7 @@ func (c *Core) OperateUserRole(ctx context.Context, in *milvuspb.OperateUserRole
 	if err := c.broadcastOperateUserRole(ctx, in); err != nil {
 		ctxLog.Warn("fail to operate the user and role", zap.Error(err))
 		if errors.Is(err, errRoleNotExists) {
-			return merr.StatusWithErrorCode(errors.New("not found the role, maybe the role isn't existed or internal system error"), commonpb.ErrorCode_OperateUserRoleFailure), nil
+			return merr.StatusWithErrorCode(merr.WrapErrServiceInternalMsg("not found the role, maybe the role isn't existed or internal system error"), commonpb.ErrorCode_OperateUserRoleFailure), nil
 		}
 		return merr.StatusWithErrorCode(err, commonpb.ErrorCode_OperateUserRoleFailure), nil
 	}
@@ -2448,7 +2448,7 @@ func (c *Core) SelectRole(ctx context.Context, in *milvuspb.SelectRoleRequest) (
 			errMsg := "fail to select the role to check the role name"
 			ctxLog.Warn(errMsg, zap.Error(err))
 			return &milvuspb.SelectRoleResponse{
-				Status: merr.StatusWithErrorCode(errors.New(errMsg), commonpb.ErrorCode_SelectRoleFailure),
+				Status: merr.StatusWithErrorCode(merr.WrapErrServiceInternalMsg(errMsg), commonpb.ErrorCode_SelectRoleFailure),
 			}, nil
 		}
 	}
@@ -2457,7 +2457,7 @@ func (c *Core) SelectRole(ctx context.Context, in *milvuspb.SelectRoleRequest) (
 		errMsg := "fail to select the role"
 		ctxLog.Warn(errMsg, zap.Error(err))
 		return &milvuspb.SelectRoleResponse{
-			Status: merr.StatusWithErrorCode(errors.New(errMsg), commonpb.ErrorCode_SelectRoleFailure),
+			Status: merr.StatusWithErrorCode(merr.WrapErrServiceInternalMsg(errMsg), commonpb.ErrorCode_SelectRoleFailure),
 		}, nil
 	}
 
@@ -2495,7 +2495,7 @@ func (c *Core) SelectUser(ctx context.Context, in *milvuspb.SelectUserRequest) (
 			errMsg := "fail to select the user to check the username"
 			ctxLog.Warn(errMsg, zap.Any("in", in), zap.Error(err))
 			return &milvuspb.SelectUserResponse{
-				Status: merr.StatusWithErrorCode(errors.New(errMsg), commonpb.ErrorCode_SelectUserFailure),
+				Status: merr.StatusWithErrorCode(merr.WrapErrServiceInternalMsg(errMsg), commonpb.ErrorCode_SelectUserFailure),
 			}, nil
 		}
 	}
@@ -2504,7 +2504,7 @@ func (c *Core) SelectUser(ctx context.Context, in *milvuspb.SelectUserRequest) (
 		errMsg := "fail to select the user"
 		ctxLog.Warn(errMsg, zap.Error(err))
 		return &milvuspb.SelectUserResponse{
-			Status: merr.StatusWithErrorCode(errors.New(errMsg), commonpb.ErrorCode_SelectUserFailure),
+			Status: merr.StatusWithErrorCode(merr.WrapErrServiceInternalMsg(errMsg), commonpb.ErrorCode_SelectUserFailure),
 		}, nil
 	}
 
@@ -2519,24 +2519,24 @@ func (c *Core) SelectUser(ctx context.Context, in *milvuspb.SelectUserRequest) (
 
 func (c *Core) isValidRole(ctx context.Context, entity *milvuspb.RoleEntity) error {
 	if entity == nil {
-		return errors.New("the role entity is nil")
+		return merr.WrapErrServiceInternalMsg("the role entity is nil")
 	}
 	if entity.Name == "" {
-		return errors.New("the name in the role entity is empty")
+		return merr.WrapErrServiceInternalMsg("the name in the role entity is empty")
 	}
 	if _, err := c.meta.SelectRole(ctx, util.DefaultTenant, &milvuspb.RoleEntity{Name: entity.Name}, false); err != nil {
 		log.Warn("fail to select the role", zap.String("role_name", entity.Name), zap.Error(err))
-		return errors.New("not found the role, maybe the role isn't existed or internal system error")
+		return merr.WrapErrServiceInternalMsg("not found the role, maybe the role isn't existed or internal system error")
 	}
 	return nil
 }
 
 func (c *Core) isValidObject(entity *milvuspb.ObjectEntity) error {
 	if entity == nil {
-		return errors.New("the object entity is nil")
+		return merr.WrapErrServiceInternalMsg("the object entity is nil")
 	}
 	if _, ok := commonpb.ObjectType_value[entity.Name]; !ok {
-		return fmt.Errorf("not found the object type[name: %s], supported the object types: %v", entity.Name, lo.Keys(commonpb.ObjectType_value))
+		return merr.WrapErrServiceInternalMsg("not found the object type[name: %s], supported the object types: %v", entity.Name, lo.Keys(commonpb.ObjectType_value))
 	}
 	return nil
 }
@@ -2550,16 +2550,16 @@ func (c *Core) isValidPrivilege(ctx context.Context, privilegeName string, objec
 		return err
 	}
 	if customPrivGroup {
-		return fmt.Errorf("can not operate the custom privilege group [%s]", privilegeName)
+		return merr.WrapErrServiceInternalMsg("can not operate the custom privilege group [%s]", privilegeName)
 	}
 	if lo.Contains(Params.RbacConfig.GetDefaultPrivilegeGroupNames(), privilegeName) {
-		return fmt.Errorf("can not operate the built-in privilege group [%s]", privilegeName)
+		return merr.WrapErrServiceInternalMsg("can not operate the built-in privilege group [%s]", privilegeName)
 	}
 	// check object privileges for built-in privileges
 	if util.IsPrivilegeNameDefined(privilegeName) {
 		privileges, ok := util.ObjectPrivileges[object]
 		if !ok {
-			return fmt.Errorf("not found the object type[name: %s], supported the object types: %v", object, lo.Keys(commonpb.ObjectType_value))
+			return merr.WrapErrServiceInternalMsg("not found the object type[name: %s], supported the object types: %v", object, lo.Keys(commonpb.ObjectType_value))
 		}
 		for _, privilege := range privileges {
 			if privilege == privilegeName {
@@ -2567,7 +2567,7 @@ func (c *Core) isValidPrivilege(ctx context.Context, privilegeName string, objec
 			}
 		}
 	}
-	return fmt.Errorf("not found the privilege name[%s] in object[%s]", privilegeName, object)
+	return merr.WrapErrServiceInternalMsg("not found the privilege name[%s] in object[%s]", privilegeName, object)
 }
 
 func (c *Core) isValidPrivilegeV2(ctx context.Context, privilegeName string) error {
@@ -2584,7 +2584,7 @@ func (c *Core) isValidPrivilegeV2(ctx context.Context, privilegeName string) err
 	if util.IsPrivilegeNameDefined(privilegeName) {
 		return nil
 	}
-	return fmt.Errorf("not found the privilege name[%s]", privilegeName)
+	return merr.WrapErrServiceInternalMsg("not found the privilege name[%s]", privilegeName)
 }
 
 // OperatePrivilege operate the privilege, including grant and revoke
@@ -2620,31 +2620,31 @@ func (c *Core) OperatePrivilege(ctx context.Context, in *milvuspb.OperatePrivile
 func (c *Core) operatePrivilegeCommonCheck(ctx context.Context, in *milvuspb.OperatePrivilegeRequest) error {
 	if in.Type != milvuspb.OperatePrivilegeType_Grant && in.Type != milvuspb.OperatePrivilegeType_Revoke {
 		errMsg := fmt.Sprintf("invalid operate privilege type, current type: %s, valid value: [%s, %s]", in.Type, milvuspb.OperatePrivilegeType_Grant, milvuspb.OperatePrivilegeType_Revoke)
-		return errors.New(errMsg)
+		return merr.WrapErrServiceInternalMsg(errMsg)
 	}
 	if in.Entity == nil {
 		errMsg := "the grant entity in the request is nil"
-		return errors.New(errMsg)
+		return merr.WrapErrServiceInternalMsg(errMsg)
 	}
 	if err := c.isValidObject(in.Entity.Object); err != nil {
-		return errors.New("the object entity in the request is nil or invalid")
+		return merr.WrapErrServiceInternalMsg("the object entity in the request is nil or invalid")
 	}
 	if err := c.isValidRole(ctx, in.Entity.Role); err != nil {
 		return err
 	}
 	entity := in.Entity.Grantor
 	if entity == nil {
-		return errors.New("the grantor entity is nil")
+		return merr.WrapErrServiceInternalMsg("the grantor entity is nil")
 	}
 	if entity.User == nil || entity.User.Name == "" {
-		return errors.New("the user entity in the grantor entity is nil or empty")
+		return merr.WrapErrServiceInternalMsg("the user entity in the grantor entity is nil or empty")
 	}
 	if _, err := c.meta.SelectUser(ctx, util.DefaultTenant, &milvuspb.UserEntity{Name: entity.User.Name}, false); err != nil {
 		log.Ctx(ctx).Warn("fail to select the user", zap.String("username", entity.User.Name), zap.Error(err))
-		return errors.New("not found the user, maybe the user isn't existed or internal system error")
+		return merr.WrapErrServiceInternalMsg("not found the user, maybe the user isn't existed or internal system error")
 	}
 	if entity.Privilege == nil {
-		return errors.New("the privilege entity in the grantor entity is nil")
+		return merr.WrapErrServiceInternalMsg("the privilege entity in the grantor entity is nil")
 	}
 	return nil
 }
@@ -2681,7 +2681,7 @@ func (c *Core) validatePrivilegeGroupParams(ctx context.Context, entity string, 
 		}
 		return nil
 	default:
-		return errors.New("not found the privilege level")
+		return merr.WrapErrServiceInternalMsg("not found the privilege level")
 	}
 }
 
@@ -2702,7 +2702,7 @@ func (c *Core) getMetastorePrivilegeName(ctx context.Context, privName string) (
 	if customGroup {
 		return util.PrivilegeGroupNameForMetastore(privName), nil
 	}
-	return "", errors.Newf("not found the privilege name [%s] from metastore", privName)
+	return "", merr.WrapErrServiceInternalMsg("not found the privilege name [%s] from metastore", privName)
 }
 
 // SelectGrant select grant
@@ -2726,7 +2726,7 @@ func (c *Core) SelectGrant(ctx context.Context, in *milvuspb.SelectGrantRequest)
 		errMsg := "the grant entity in the request is nil"
 		ctxLog.Warn(errMsg)
 		return &milvuspb.SelectGrantResponse{
-			Status: merr.StatusWithErrorCode(errors.New(errMsg), commonpb.ErrorCode_SelectGrantFailure),
+			Status: merr.StatusWithErrorCode(merr.WrapErrServiceInternalMsg(errMsg), commonpb.ErrorCode_SelectGrantFailure),
 		}, nil
 	}
 	if err := c.isValidRole(ctx, in.Entity.Role); err != nil {
@@ -2755,7 +2755,7 @@ func (c *Core) SelectGrant(ctx context.Context, in *milvuspb.SelectGrantRequest)
 		errMsg := "fail to select the grant"
 		ctxLog.Warn(errMsg, zap.Error(err))
 		return &milvuspb.SelectGrantResponse{
-			Status: merr.StatusWithErrorCode(errors.New(errMsg), commonpb.ErrorCode_SelectGrantFailure),
+			Status: merr.StatusWithErrorCode(merr.WrapErrServiceInternalMsg(errMsg), commonpb.ErrorCode_SelectGrantFailure),
 		}, nil
 	}
 
@@ -2785,7 +2785,7 @@ func (c *Core) ListPolicy(ctx context.Context, in *internalpb.ListPolicyRequest)
 	if err != nil {
 		ctxLog.Error("fail to list policy", zap.Error(err))
 		return &internalpb.ListPolicyResponse{
-			Status: merr.StatusWithErrorCode(fmt.Errorf("fail to list policy: %s", err.Error()), commonpb.ErrorCode_ListPolicyFailure),
+			Status: merr.StatusWithErrorCode(errors.Wrap(err, "fail to list policy"), commonpb.ErrorCode_ListPolicyFailure),
 		}, nil
 	}
 	// expand privilege groups and turn to policies
@@ -2793,7 +2793,7 @@ func (c *Core) ListPolicy(ctx context.Context, in *internalpb.ListPolicyRequest)
 	if err != nil {
 		ctxLog.Error("fail to get privilege groups", zap.Error(err))
 		return &internalpb.ListPolicyResponse{
-			Status: merr.StatusWithErrorCode(fmt.Errorf("fail to get privilege groups: %s", err.Error()), commonpb.ErrorCode_ListPolicyFailure),
+			Status: merr.StatusWithErrorCode(merr.WrapErrServiceInternalMsg("fail to get privilege groups: %s", err.Error()), commonpb.ErrorCode_ListPolicyFailure),
 		}, nil
 	}
 	groups := lo.SliceToMap(allGroups, func(group *milvuspb.PrivilegeGroupInfo) (string, []*milvuspb.PrivilegeEntity) {
@@ -2803,7 +2803,7 @@ func (c *Core) ListPolicy(ctx context.Context, in *internalpb.ListPolicyRequest)
 	if err != nil {
 		ctxLog.Error("fail to expand privilege groups", zap.Error(err))
 		return &internalpb.ListPolicyResponse{
-			Status: merr.StatusWithErrorCode(fmt.Errorf("fail to expand privilege groups: %s", err.Error()), commonpb.ErrorCode_ListPolicyFailure),
+			Status: merr.StatusWithErrorCode(merr.WrapErrServiceInternalMsg("fail to expand privilege groups: %s", err.Error()), commonpb.ErrorCode_ListPolicyFailure),
 		}, nil
 	}
 	expandPolicies := lo.Map(expandGrants, func(r *milvuspb.GrantEntity, _ int) string {
@@ -2814,7 +2814,7 @@ func (c *Core) ListPolicy(ctx context.Context, in *internalpb.ListPolicyRequest)
 	if err != nil {
 		ctxLog.Error("fail to list user-role", zap.Any("in", in), zap.Error(err))
 		return &internalpb.ListPolicyResponse{
-			Status: merr.StatusWithErrorCode(fmt.Errorf("fail to list user-role: %s", err.Error()), commonpb.ErrorCode_ListPolicyFailure),
+			Status: merr.StatusWithErrorCode(merr.WrapErrServiceInternalMsg("fail to list user-role: %s", err.Error()), commonpb.ErrorCode_ListPolicyFailure),
 		}, nil
 	}
 
@@ -3130,7 +3130,7 @@ func (c *Core) AddFileResource(ctx context.Context, req *milvuspb.AddFileResourc
 	if exist, err := c.storage.Exist(ctx, req.GetPath()); err != nil {
 		return merr.Status(err), nil
 	} else if !exist {
-		return merr.Status(merr.WrapErrAsInputError(errors.Errorf("file resource path not exist"))), nil
+		return merr.Status(merr.WrapErrParameterInvalidMsg("file resource path not exist")), nil
 	}
 
 	id, err := c.tsoAllocator.GenerateTSO(1)
@@ -3483,7 +3483,7 @@ func (c *Core) ClientHeartbeat(ctx context.Context, req *milvuspb.ClientHeartbea
 
 	if c.telemetryMgr == nil {
 		return &milvuspb.ClientHeartbeatResponse{
-			Status: merr.Status(errors.New("telemetry manager not initialized")),
+			Status: merr.Status(merr.WrapErrServiceInternalMsg("telemetry manager not initialized")),
 		}, nil
 	}
 
@@ -3500,7 +3500,7 @@ func (c *Core) GetClientTelemetry(ctx context.Context, req *milvuspb.GetClientTe
 
 	if c.telemetryMgr == nil {
 		return &milvuspb.GetClientTelemetryResponse{
-			Status: merr.Status(errors.New("telemetry manager not initialized")),
+			Status: merr.Status(merr.WrapErrServiceInternalMsg("telemetry manager not initialized")),
 		}, nil
 	}
 
@@ -3517,7 +3517,7 @@ func (c *Core) PushClientCommand(ctx context.Context, req *milvuspb.PushClientCo
 
 	if c.telemetryMgr == nil {
 		return &milvuspb.PushClientCommandResponse{
-			Status: merr.Status(errors.New("telemetry manager not initialized")),
+			Status: merr.Status(merr.WrapErrServiceInternalMsg("telemetry manager not initialized")),
 		}, nil
 	}
 
@@ -3534,7 +3534,7 @@ func (c *Core) DeleteClientCommand(ctx context.Context, req *milvuspb.DeleteClie
 
 	if c.telemetryMgr == nil {
 		return &milvuspb.DeleteClientCommandResponse{
-			Status: merr.Status(errors.New("telemetry manager not initialized")),
+			Status: merr.Status(merr.WrapErrServiceInternalMsg("telemetry manager not initialized")),
 		}, nil
 	}
 

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -584,7 +584,7 @@ func (c *Core) initRbac(initCtx context.Context) error {
 	for _, role := range util.DefaultRoles {
 		err = c.meta.CreateRole(initCtx, util.DefaultTenant, &milvuspb.RoleEntity{Name: role})
 		if err != nil && !common.IsIgnorableError(err) {
-			return errors.Wrap(err, "failed to create role")
+			return merr.Wrap(err, "failed to create role")
 		}
 	}
 
@@ -624,7 +624,7 @@ func (c *Core) initPublicRolePrivilege(initCtx context.Context) error {
 			},
 		}, milvuspb.OperatePrivilegeType_Grant)
 		if err != nil && !common.IsIgnorableError(err) {
-			return errors.Wrap(err, "failed to grant global privilege")
+			return merr.Wrap(err, "failed to grant global privilege")
 		}
 	}
 	for _, collectionPrivilege := range collectionPrivileges {
@@ -639,7 +639,7 @@ func (c *Core) initPublicRolePrivilege(initCtx context.Context) error {
 			},
 		}, milvuspb.OperatePrivilegeType_Grant)
 		if err != nil && !common.IsIgnorableError(err) {
-			return errors.Wrap(err, "failed to grant collection privilege")
+			return merr.Wrap(err, "failed to grant collection privilege")
 		}
 	}
 	return nil
@@ -652,12 +652,12 @@ func (c *Core) initBuiltinRoles(ctx context.Context) error {
 		err := c.meta.CreateRole(ctx, util.DefaultTenant, &milvuspb.RoleEntity{Name: role})
 		if err != nil && !common.IsIgnorableError(err) {
 			log.Error("create a builtin role fail", zap.String("roleName", role), zap.Error(err))
-			return errors.Wrapf(err, "failed to create a builtin role: %s", role)
+			return merr.Wrapf(err, "failed to create a builtin role: %s", role)
 		}
 		for _, privilege := range privilegesJSON[util.RoleConfigPrivileges] {
 			privilegeName, err := c.getMetastorePrivilegeName(ctx, privilege[util.RoleConfigPrivilege])
 			if err != nil {
-				return errors.Wrapf(err, "failed to get metastore privilege name for: %s", privilege[util.RoleConfigPrivilege])
+				return merr.Wrapf(err, "failed to get metastore privilege name for: %s", privilege[util.RoleConfigPrivilege])
 			}
 
 			err = c.meta.OperatePrivilege(ctx, util.DefaultTenant, &milvuspb.GrantEntity{
@@ -672,7 +672,7 @@ func (c *Core) initBuiltinRoles(ctx context.Context) error {
 			}, milvuspb.OperatePrivilegeType_Grant)
 			if err != nil && !common.IsIgnorableError(err) {
 				log.Error("grant privilege to builtin role fail", zap.String("roleName", role), zap.Any("privilege", privilege), zap.Error(err))
-				return errors.Wrapf(err, "failed to grant privilege: <%s, %s, %s> of db: %s to role: %s", privilege[util.RoleConfigObjectType], privilege[util.RoleConfigObjectName], privilege[util.RoleConfigPrivilege], privilege[util.RoleConfigDBName], role)
+				return merr.Wrapf(err, "failed to grant privilege: <%s, %s, %s> of db: %s to role: %s", privilege[util.RoleConfigObjectType], privilege[util.RoleConfigObjectName], privilege[util.RoleConfigPrivilege], privilege[util.RoleConfigDBName], role)
 			}
 		}
 		util.BuiltinRoles = append(util.BuiltinRoles, role)
@@ -2785,7 +2785,7 @@ func (c *Core) ListPolicy(ctx context.Context, in *internalpb.ListPolicyRequest)
 	if err != nil {
 		ctxLog.Error("fail to list policy", zap.Error(err))
 		return &internalpb.ListPolicyResponse{
-			Status: merr.StatusWithErrorCode(errors.Wrap(err, "fail to list policy"), commonpb.ErrorCode_ListPolicyFailure),
+			Status: merr.StatusWithErrorCode(merr.Wrap(err, "fail to list policy"), commonpb.ErrorCode_ListPolicyFailure),
 		}, nil
 	}
 	// expand privilege groups and turn to policies
@@ -3151,7 +3151,7 @@ func (c *Core) AddFileResource(ctx context.Context, req *milvuspb.AddFileResourc
 		err = c.fileResourceObserver.Sync()
 		if err != nil {
 			c.fileResourceObserver.Notify()
-			return merr.Status(errors.Wrap(err, "add file resource success but some node sync failed")), nil
+			return merr.Status(merr.Wrap(err, "add file resource success but some node sync failed")), nil
 		}
 	}
 
@@ -3181,7 +3181,7 @@ func (c *Core) RemoveFileResource(ctx context.Context, req *milvuspb.RemoveFileR
 		err = c.fileResourceObserver.Sync()
 		if err != nil {
 			c.fileResourceObserver.Notify()
-			return merr.Status(errors.Wrap(err, "remove file resource success but some node sync failed")), nil
+			return merr.Status(merr.Wrap(err, "remove file resource success but some node sync failed")), nil
 		}
 	}
 

--- a/internal/rootcoord/root_coord_test.go
+++ b/internal/rootcoord/root_coord_test.go
@@ -1778,7 +1778,7 @@ func TestCore_getMetastorePrivilegeName(t *testing.T) {
 
 	meta.EXPECT().IsCustomPrivilegeGroup(mock.Anything, "unknown").Return(false, nil)
 	_, err = c.getMetastorePrivilegeName(context.Background(), "unknown")
-	assert.Equal(t, err.Error(), "not found the privilege name [unknown] from metastore")
+	assert.ErrorContains(t, err, "not found the privilege name [unknown] from metastore")
 }
 
 func TestCore_expandPrivilegeGroup(t *testing.T) {

--- a/internal/rootcoord/telemetry/command_store.go
+++ b/internal/rootcoord/telemetry/command_store.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -411,7 +410,7 @@ func (s *CommandStore) DeleteCommand(ctx context.Context, commandID string) erro
 
 	if configExists {
 		if err := s.kv.Delete(ctx, s.configPath+commandID); err != nil {
-			return merr.WrapErrIoFailed(commandID, fmt.Errorf("delete failed: %v", err))
+			return merr.WrapErrIoFailed(commandID, merr.WrapErrServiceInternalMsg("delete failed: %v", err))
 		}
 	}
 

--- a/internal/rootcoord/timeticksync.go
+++ b/internal/rootcoord/timeticksync.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -36,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -203,12 +203,12 @@ func (t *timetickSync) updateTimeTick(in *internalpb.ChannelTimeTickMsg, reason 
 		return nil
 	}
 	if len(in.Timestamps) != len(in.ChannelNames) {
-		return errors.New("invalid TimeTickMsg, timestamp and channelname size mismatch")
+		return merr.WrapErrServiceInternalMsg("invalid TimeTickMsg, timestamp and channelname size mismatch")
 	}
 
 	prev, ok := t.sess2ChanTsMap[in.Base.SourceID]
 	if !ok {
-		return fmt.Errorf("skip ChannelTimeTickMsg from un-recognized session %d", in.Base.SourceID)
+		return merr.WrapErrServiceInternalMsg("skip ChannelTimeTickMsg from un-recognized session %d", in.Base.SourceID)
 	}
 
 	if in.Base.SourceID == t.sourceID {

--- a/internal/rootcoord/util.go
+++ b/internal/rootcoord/util.go
@@ -99,7 +99,7 @@ func Int64TupleMapToSlice(s map[int]common.Int64Tuple) []common.Int64Tuple {
 
 func CheckMsgType(got, expect commonpb.MsgType) error {
 	if got != expect {
-		return fmt.Errorf("invalid msg type, expect %s, but got %s", expect, got)
+		return merr.WrapErrServiceInternalMsg("invalid msg type, expect %s, but got %s", expect, got)
 	}
 	return nil
 }
@@ -332,7 +332,7 @@ func CheckTimeTickLagExceeded(ctx context.Context, mixcoord types.MixCoord, maxD
 		errStr += fmt.Sprintf("data max timetick lag:%s on channel:%s", maxLag, maxLagChannel)
 	}
 	if errStr != "" {
-		return fmt.Errorf("max timetick lag execced threhold: %s", errStr)
+		return merr.WrapErrServiceInternalMsg("max timetick lag execced threhold: %s", errStr)
 	}
 
 	return nil
@@ -438,7 +438,7 @@ func checkFieldSchema(fieldSchemas []*schemapb.FieldSchema) error {
 						zap.ByteString("data", defVal),
 						zap.Error(err),
 					)
-					return merr.WrapErrParameterInvalidMsg(err.Error())
+					return merr.WrapErrParameterInvalidErr(err, "invalid default json value, milvus only supports json map")
 				}
 			default:
 				panic("default value unsupport data type")
@@ -564,11 +564,11 @@ func validateStructArrayFieldDataType(fieldSchemas []*schemapb.StructArrayFieldS
 		}
 		for _, subField := range field.GetFields() {
 			if subField.GetDataType() != schemapb.DataType_Array && subField.GetDataType() != schemapb.DataType_ArrayOfVector {
-				return fmt.Errorf("fields in StructArrayField can only be array or array of vector, but field %s is %s", subField.Name, subField.DataType.String())
+				return merr.WrapErrParameterInvalidMsg("fields in StructArrayField can only be array or array of vector, but field %s is %s", subField.Name, subField.DataType.String())
 			}
 			if subField.GetElementType() == schemapb.DataType_ArrayOfStruct || subField.GetElementType() == schemapb.DataType_ArrayOfVector ||
 				subField.GetElementType() == schemapb.DataType_Array {
-				return fmt.Errorf("nested array is not supported %s", subField.Name)
+				return merr.WrapErrParameterInvalidMsg("nested array is not supported for field %s", subField.Name)
 			}
 			if _, ok := schemapb.DataType_name[int32(subField.GetElementType())]; !ok || subField.GetElementType() == schemapb.DataType_None {
 				return merr.WrapErrParameterInvalid("Invalid field", fmt.Sprintf("field data type: %s is not supported", subField.GetElementType()))

--- a/internal/streamingcoord/client/assignment/assignment_impl.go
+++ b/internal/streamingcoord/client/assignment/assignment_impl.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/replicateutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -102,7 +103,7 @@ func (c *AssignmentServiceImpl) ReportAssignmentError(ctx context.Context, pchan
 	// wait for service ready.
 	assignment, err := c.getAssignmentDiscoverOrWait(ctx)
 	if err != nil {
-		return errors.Wrap(err, "at creating assignment service")
+		return merr.Wrap(err, "at creating assignment service")
 	}
 	assignment.ReportAssignmentError(pchannel, assignmentErr)
 	return nil

--- a/internal/streamingcoord/server/balancer/balancer_impl.go
+++ b/internal/streamingcoord/server/balancer/balancer_impl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/replicateutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
@@ -29,6 +30,11 @@ const (
 	versionChecker260 = "<2.6.0-dev"
 	versionChecker265 = "<2.6.6-dev"
 )
+
+// errVersionWatchDone is an INTERNAL break-signal sentinel used by
+// blockUntilRoleGreaterThanVersion to exit the resolver watch callback.
+// Never crosses any gRPC boundary.
+var errVersionWatchDone = errors.New("done")
 
 // RecoverBalancer recover the balancer working.
 func RecoverBalancer(
@@ -43,7 +49,7 @@ func RecoverBalancer(
 	// Recover the channel view from catalog.
 	manager, err := channel.RecoverChannelManager(ctx, provider.GetInitialChannels()...)
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to recover channel manager")
+		return nil, merr.Wrap(err, "fail to recover channel manager")
 	}
 	manager.SetLogger(resource.Resource().Logger().With(log.FieldComponent("channel-manager")))
 	ctx, cancel := context.WithCancelCause(context.Background())
@@ -481,7 +487,6 @@ func (b *balancerImpl) blockUntilExpectedInitialStreamingNodeNumReached(ctx cont
 
 // blockUntilRoleGreaterThanVersion block until the role is greater than 2.6.0 at background.
 func (b *balancerImpl) blockUntilRoleGreaterThanVersion(ctx context.Context, role string, versionChecker string) error {
-	doneErr := errors.New("done")
 	logger := b.Logger().With(zap.String("role", role))
 	logger.Info("start to wait that the nodes is greater than version", zap.String("version", versionChecker))
 	// Check if there's any proxy or data node with version < 2.6.0.
@@ -493,12 +498,12 @@ func (b *balancerImpl) blockUntilRoleGreaterThanVersion(ctx context.Context, rol
 	r := rb.Resolver()
 	err := r.Watch(ctx, func(vs resolver.VersionedState) error {
 		if len(vs.Sessions()) == 0 {
-			return doneErr
+			return errVersionWatchDone
 		}
 		logger.Info("session changes", zap.Int("sessionCount", len(vs.Sessions())))
 		return nil
 	})
-	if err != nil && !errors.Is(err, doneErr) {
+	if err != nil && !errors.Is(err, errVersionWatchDone) {
 		logger.Info("fail to wait that the nodes is greater than version", zap.String("version", versionChecker), zap.Error(err))
 		return err
 	}
@@ -553,14 +558,14 @@ func (b *balancerImpl) balance(ctx context.Context) (bool, error) {
 	currentLayout := generateCurrentLayout(pchannelView, nodeStatus, accessMode)
 	expectedLayout, err := b.policy.Balance(currentLayout)
 	if err != nil {
-		return false, errors.Wrap(err, "fail to balance")
+		return false, merr.Wrap(err, "fail to balance")
 	}
 
 	b.Logger().Info("balance policy generate result success, try to assign...", zap.Stringer("expectedLayout", expectedLayout))
 	// bookkeeping the meta assignment started.
 	modifiedChannels, err := b.channelMetaManager.AssignPChannels(ctx, expectedLayout.ChannelAssignment)
 	if err != nil {
-		return false, errors.Wrap(err, "fail to assign pchannels")
+		return false, merr.Wrap(err, "fail to assign pchannels")
 	}
 
 	if len(modifiedChannels) == 0 {
@@ -574,7 +579,7 @@ func (b *balancerImpl) balance(ctx context.Context) (bool, error) {
 func (b *balancerImpl) fetchStreamingNodeStatus(ctx context.Context, rgName string) (map[int64]*types.StreamingNodeStatus, error) {
 	nodeStatus, err := resource.Resource().StreamingNodeManagerClient().CollectAllStatus(ctx, rgName)
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to collect all status")
+		return nil, merr.Wrap(err, "fail to collect all status")
 	}
 
 	// mark the frozen node as frozen in the node status.

--- a/internal/streamingcoord/server/balancer/channel/manager.go
+++ b/internal/streamingcoord/server/balancer/channel/manager.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
@@ -121,7 +122,7 @@ func recoverCChannelMeta(ctx context.Context, incomingChannel ...string) (*strea
 	}
 	if cchannelMeta == nil {
 		if len(incomingChannel) == 0 {
-			return nil, errors.New("no incoming channel while no control channel meta found")
+			return nil, status.NewInner("no incoming channel while no control channel meta found")
 		}
 		cchannelMeta = &streamingpb.CChannelMeta{
 			Pchannel: incomingChannel[0],
@@ -361,7 +362,7 @@ func (cm *ChannelManager) MarkWALBasedDDLEnabled(ctx context.Context) error {
 	defer cm.cond.L.Unlock()
 
 	if cm.streamingVersion == nil {
-		return errors.New("streaming service is not enabled, cannot mark WAL based DDL enabled")
+		return status.NewInner("streaming service is not enabled, cannot mark WAL based DDL enabled")
 	}
 	if cm.streamingVersion.Version >= StreamingVersion265 {
 		return nil
@@ -394,7 +395,7 @@ func (cm *ChannelManager) AllocVirtualChannels(ctx context.Context, param AllocV
 
 	availableChannels := cm.sortAvailableChannelsByVChannelCount()
 	if len(availableChannels) < param.Num {
-		return nil, errors.Errorf("not enough pchannels to allocate, expected: %d, got: %d", param.Num, len(availableChannels))
+		return nil, status.NewInner("not enough pchannels to allocate, expected: %d, got: %d", param.Num, len(availableChannels))
 	}
 
 	vchannels := make([]string, 0, param.Num)

--- a/internal/streamingcoord/server/balancer/policy/vchannelfair/builder.go
+++ b/internal/streamingcoord/server/balancer/policy/vchannelfair/builder.go
@@ -51,10 +51,15 @@ type policyConfig struct {
 	RebalanceMaxStep   int
 }
 
-// Vaildate validates the vchannel fair policy config.
+// errPolicyConfigNegative is returned by policyConfig.Validate when any
+// numeric field is negative. INTERNAL: caller logs it (caller already
+// dumps cfg via zap.Any), never crosses any gRPC boundary.
+var errPolicyConfigNegative = errors.New("vchannel fair policy config has negative value(s)")
+
+// Validate validates the vchannel fair policy config.
 func (c policyConfig) Validate() error {
 	if c.PChannelWeight < 0 || c.VChannelWeight < 0 || c.AntiAffinityWeight < 0 || c.RebalanceTolerance < 0 || c.RebalanceMaxStep < 0 {
-		return errors.Errorf("invalid vchannel fair policy config, %+v", c)
+		return errPolicyConfigNegative
 	}
 	return nil
 }

--- a/internal/streamingcoord/server/balancer/policy/vchannelfair/vchannel_fair_policy.go
+++ b/internal/streamingcoord/server/balancer/policy/vchannelfair/vchannel_fair_policy.go
@@ -3,11 +3,11 @@ package vchannelfair
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 )
@@ -30,7 +30,7 @@ func (p *policy) Name() string {
 // Balance will balance the load of streaming node by vchannel count.
 func (p *policy) Balance(currentLayout balancer.CurrentLayout) (layout balancer.ExpectedLayout, err error) {
 	if currentLayout.TotalNodes() == 0 {
-		return balancer.ExpectedLayout{}, errors.New("no available streaming node")
+		return balancer.ExpectedLayout{}, status.NewInner("no available streaming node")
 	}
 	// update policy configuration before balancing.
 	p.updatePolicyConfiguration()
@@ -129,7 +129,7 @@ func (p *policy) updatePolicyConfiguration() {
 	// try to fetch latest configuration.
 	newCfg := newVChannelFairPolicyConfig()
 	if err := newCfg.Validate(); err != nil {
-		p.Logger().Warn("invalid new incoming vchannel fair policy config", zap.Any("new", newCfg))
+		p.Logger().Warn("invalid new incoming vchannel fair policy config", zap.Any("new", newCfg), zap.Error(err))
 	} else if p.cfg != newCfg {
 		p.Logger().Info("vchannel fair policy config updated", zap.Any("old", p.cfg), zap.Any("new", newCfg))
 		p.cfg = newCfg

--- a/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/ack_callback_scheduler.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/registry"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
 
@@ -238,7 +238,7 @@ func (s *ackCallbackScheduler) fixIncompleteBroadcastsForForcePromote(ctx contex
 			zap.String("messageType", task.msg.MessageType().String()),
 			zap.Int("pendingVChannels", len(pending.pendingMessages)))
 		if _, err := s.bm.broadcastScheduler.AddTask(ctx, pending); err != nil {
-			return errors.Wrapf(err, "failed to supplement task %d via broadcastScheduler", task.Header().BroadcastID)
+			return merr.Wrapf(err, "failed to supplement task %d via broadcastScheduler", task.Header().BroadcastID)
 		}
 	}
 	s.Logger().Info("All incomplete broadcasts fixed and tombstoned")

--- a/internal/streamingcoord/server/broadcaster/broadcast/singleton.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast/singleton.go
@@ -3,11 +3,10 @@ package broadcast
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
 
@@ -39,7 +38,7 @@ func StartBroadcastWithResourceKeys(ctx context.Context, resourceKeys ...message
 		return nil, err
 	}
 	if err := b.WaitUntilWALbasedDDLReady(ctx); err != nil {
-		return nil, errors.Wrap(err, "failed to wait until WAL based DDL ready")
+		return nil, merr.Wrap(err, "failed to wait until WAL based DDL ready")
 	}
 	return broadcaster.WithResourceKeys(ctx, resourceKeys...)
 }
@@ -57,7 +56,7 @@ func StartBroadcastWithSecondaryClusterResourceKey(ctx context.Context) (broadca
 		return nil, err
 	}
 	if err := b.WaitUntilWALbasedDDLReady(ctx); err != nil {
-		return nil, errors.Wrap(err, "failed to wait until WAL based DDL ready")
+		return nil, merr.Wrap(err, "failed to wait until WAL based DDL ready")
 	}
 	return broadcaster.WithSecondaryClusterResourceKey(ctx)
 }

--- a/internal/streamingcoord/server/broadcaster/broadcast_manager.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_manager.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
@@ -16,6 +15,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/replicateutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -117,7 +117,7 @@ func (bm *broadcastTaskManager) WithResourceKeys(ctx context.Context, resourceKe
 	id, err := resource.Resource().IDAllocator().Allocate(ctx)
 	if err != nil {
 		guards.Unlock()
-		return nil, errors.Wrapf(err, "allocate new id failed")
+		return nil, merr.Wrapf(err, "allocate new id failed")
 	}
 
 	if err := bm.checkClusterRole(ctx); err != nil {
@@ -140,7 +140,7 @@ func (bm *broadcastTaskManager) WithResourceKeys(ctx context.Context, resourceKe
 func (bm *broadcastTaskManager) WithSecondaryClusterResourceKey(ctx context.Context) (BroadcastAPI, error) {
 	id, err := resource.Resource().IDAllocator().Allocate(ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "allocate new id failed")
+		return nil, merr.Wrapf(err, "allocate new id failed")
 	}
 
 	startLockInstant := time.Now()

--- a/internal/streamingcoord/server/broadcaster/broadcast_task.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_task.go
@@ -2,9 +2,9 @@ package broadcaster
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -15,6 +15,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // newBroadcastTaskFromProto creates a new broadcast task from the proto.
@@ -252,7 +253,7 @@ func (b *broadcastTask) MarkIgnore() error {
 	msg := message.NewBroadcastMutableMessageBeforeAppend(b.task.Message.Payload, copiedProps)
 	alterMsg, err := message.AsMutableAlterReplicateConfigMessageV2(msg)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse message as AlterReplicateConfigMessage")
+		return merr.Wrap(err, "failed to parse message as AlterReplicateConfigMessage")
 	}
 
 	// Get current header and set ignore to true
@@ -402,9 +403,9 @@ func (b *broadcastTask) copyAndSetAckedCheckpoints(msgs ...message.ImmutableMess
 	task := proto.Clone(b.task).(*streamingpb.BroadcastTask)
 	for _, msg := range msgs {
 		vchannel := msg.VChannel()
-		idx, err := findIdxOfVChannel(vchannel, b.header().VChannels)
-		if err != nil {
-			panic(err)
+		idx := findIdxOfVChannel(vchannel, b.header().VChannels)
+		if idx < 0 {
+			panic(fmt.Sprintf("broadcast task invariant violated: vchannel %s not in task's own VChannels list", vchannel))
 		}
 		if len(task.AckedVchannelBitmap) == 0 {
 			task.AckedVchannelBitmap = make([]byte, len(b.header().VChannels))
@@ -433,14 +434,17 @@ func (b *broadcastTask) copyAndSetAckedCheckpoints(msgs ...message.ImmutableMess
 	return
 }
 
-// findIdxOfVChannel finds the index of the vchannel in the broadcast task.
-func findIdxOfVChannel(vchannel string, vchannels []string) (int, error) {
+// findIdxOfVChannel finds the index of the vchannel in the broadcast task's
+// VChannels list, returning -1 if not present. By construction the vchannel
+// must be present (it came from the task's own messages); callers panic on
+// -1 because that signals a task-invariant violation.
+func findIdxOfVChannel(vchannel string, vchannels []string) int {
 	for i, channelName := range vchannels {
 		if channelName == vchannel {
-			return i, nil
+			return i
 		}
 	}
-	return -1, errors.Errorf("unreachable: vchannel is %s not found in the broadcast task", vchannel)
+	return -1
 }
 
 // FastAck trigger a fast ack operation when the broadcast operation is done.

--- a/internal/streamingcoord/server/broadcaster/registry/ack_message_callback.go
+++ b/internal/streamingcoord/server/broadcaster/registry/ack_message_callback.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
 
@@ -60,7 +60,7 @@ func CallMessageAckCallback(ctx context.Context, msg message.BroadcastMutableMes
 	}
 	callback, err := callbackFuture.GetWithContext(ctx)
 	if err != nil {
-		return errors.Wrap(err, "when waiting callback registered")
+		return merr.Wrap(err, "when waiting callback registered")
 	}
 	return callback(ctx, msg, result)
 }

--- a/internal/streamingcoord/server/broadcaster/registry/ack_once_message_callback.go
+++ b/internal/streamingcoord/server/broadcaster/registry/ack_once_message_callback.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
 
@@ -86,7 +86,7 @@ func callMessageAckOnceCallback(ctx context.Context, msg message.ImmutableMessag
 	}
 	callback, err := callbackFuture.GetWithContext(ctx)
 	if err != nil {
-		return errors.Wrap(err, "when waiting callback registered")
+		return merr.Wrap(err, "when waiting callback registered")
 	}
 	return callback(ctx, msg)
 }

--- a/internal/streamingcoord/server/broadcaster/resource_key_locker.go
+++ b/internal/streamingcoord/server/broadcaster/resource_key_locker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -99,7 +100,7 @@ func (r *resourceKeyLocker) FastLock(keys ...message.ResourceKey) (*lockGuards, 
 			continue
 		}
 		g.Unlock()
-		return nil, errors.Wrapf(errFastLockFailed, "fast lock failed at resource key %s", key.String())
+		return nil, merr.Wrapf(errFastLockFailed, "fast lock failed at resource key %s", key.String())
 	}
 	return g, nil
 }

--- a/internal/streamingcoord/server/service/assignment.go
+++ b/internal/streamingcoord/server/service/assignment.go
@@ -30,7 +30,13 @@ import (
 
 var _ streamingpb.StreamingCoordAssignmentServiceServer = (*assignmentServiceImpl)(nil)
 
-var errReplicateConfigurationSame = errors.New("same replicate configuration")
+var (
+	errReplicateConfigurationSame = errors.New("same replicate configuration")
+	// errDone is an INTERNAL break-signal sentinel used by
+	// waitUntilPrimaryChangeOrConfigurationSame to exit the watch callback.
+	// Never crosses any gRPC boundary.
+	errDone = errors.New("done")
+)
 
 // NewAssignmentService returns a new assignment service.
 func NewAssignmentService() streamingpb.StreamingCoordAssignmentServiceServer {
@@ -125,7 +131,6 @@ func (s *assignmentServiceImpl) waitUntilPrimaryChangeOrConfigurationSame(ctx co
 	if err != nil {
 		return err
 	}
-	errDone := errors.New("done")
 	err = b.WatchChannelAssignments(ctx, func(param balancer.WatchChannelAssignmentsCallbackParam) error {
 		if proto.Equal(config, param.ReplicateConfiguration) {
 			return errDone

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -223,7 +223,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 			}
 			logger.Info("append flush message for segments that not created by streaming service into wal", zap.Stringer("msgID", appendResult.MessageID), zap.Uint64("timeTick", appendResult.TimeTick))
 			return nil
-		}, retry.AttemptAlways()); err != nil {
+		}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true })); err != nil {
 			return nil, err
 		}
 	}
@@ -233,7 +233,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 		var err error
 		ds, err = impl.buildDataSyncService(ctx, recoverInfo)
 		return err
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
@@ -101,7 +101,7 @@ func (impl *msgHandlerImpl) createNewGrowingSegment(ctx context.Context, vchanne
 		}
 		logger.Info("alloc growing segment at datacoord", zap.Int32("schemaVersion", h.SchemaVersion))
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 }
 
 func (impl *msgHandlerImpl) HandleFlush(flushMsg message.ImmutableFlushMessageV2) error {

--- a/internal/streamingnode/server/flusher/flusherimpl/util.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/util.go
@@ -90,7 +90,7 @@ func (impl *WALFlusherImpl) getRecoveryInfo(ctx context.Context, vchannel string
 			return retry.Unrecoverable(errChannelLifetimeUnrecoverable)
 		}
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	return resp, err
 }
 

--- a/pkg/util/etcd/etcd_util_test.go
+++ b/pkg/util/etcd/etcd_util_test.go
@@ -18,15 +18,51 @@ package etcd
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"os"
 	"path"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// freePort grabs a random unused TCP port. There's a small TOCTOU window
+// between Close and the subsequent bind, but for unit tests it's acceptable.
+func freePort(t *testing.T) int {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
 func TestEtcd(t *testing.T) {
-	err := InitEtcdServer(true, "", "/tmp/data", "stdout", "info")
+	// Use random free ports so the embedded etcd does not collide with any
+	// already-running etcd on the dev machine (e.g. docker-compose etcd
+	// holding 2379/2380).
+	clientPort, peerPort := freePort(t), freePort(t)
+	dataDir, err := os.MkdirTemp("", "test-etcd-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dataDir)
+	cfgFile, err := os.CreateTemp("", "test-etcd-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(cfgFile.Name())
+	_, err = fmt.Fprintf(cfgFile, `name: default
+data-dir: %s
+listen-client-urls: http://127.0.0.1:%d
+advertise-client-urls: http://127.0.0.1:%d
+listen-peer-urls: http://127.0.0.1:%d
+initial-advertise-peer-urls: http://127.0.0.1:%d
+initial-cluster: default=http://127.0.0.1:%d
+initial-cluster-state: new
+`, dataDir, clientPort, clientPort, peerPort, peerPort, peerPort)
+	require.NoError(t, err)
+	require.NoError(t, cfgFile.Close())
+
+	err = InitEtcdServer(true, cfgFile.Name(), dataDir, "stdout", "info")
 	assert.NoError(t, err)
 	defer StopEtcdServer()
 

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -18,6 +18,7 @@ package merr
 
 import (
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/markers"
 	"github.com/samber/lo"
 )
 
@@ -36,6 +37,11 @@ const (
 var ErrorTypeName = map[ErrorType]string{
 	SystemError: "system_error",
 	InputError:  "input_error",
+}
+
+// ErrorClassifier defines the method to get the broad classification of a Milvus error.
+type ErrorClassifier interface {
+	GetErrorType() ErrorType
 }
 
 func (err ErrorType) String() string {
@@ -60,20 +66,23 @@ var (
 	ErrServiceUnimplemented        = newMilvusError("service unimplemented", 10, false)
 	ErrServiceTimeTickLongDelay    = newMilvusError("time tick long delay", 11, false)
 	ErrServiceResourceInsufficient = newMilvusError("service resource insufficient", 12, true)
+	ErrOldSessionExists            = newMilvusError("old session exists", 13, false)
+	ErrOperationNotSupported       = newMilvusError("unsupported operation", 14, false)
 
 	// Collection related
-	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false)
+	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false, WithErrorType(InputError))
 	ErrCollectionNotLoaded                     = newMilvusError("collection not loaded", 101, false)
-	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false)
+	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false, WithErrorType(InputError))
 	ErrCollectionNotFullyLoaded                = newMilvusError("collection not fully loaded", 103, true)
-	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false)
-	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false)
+	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false, WithErrorType(InputError))
+	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false, WithErrorType(InputError))
 	ErrCollectionOnRecovering                  = newMilvusError("collection on recovering", 106, true)
-	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false)
+	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false, WithErrorType(InputError))
 	// Deprecated, keep it only for reserving the error code
-	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false)
-	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false)
+	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false, WithErrorType(InputError))
+	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false, WithErrorType(InputError))
 	ErrCollectionSchemaVersionNotReady = newMilvusError("collection schema version not ready", 110, true)
+
 	// Partition related
 	ErrPartitionNotFound       = newMilvusError("partition not found", 200, false)
 	ErrPartitionNotLoaded      = newMilvusError("partition not loaded", 201, false)
@@ -83,13 +92,13 @@ var (
 	ErrGeneralCapacityExceeded = newMilvusError("general capacity exceeded", 250, false)
 
 	// ResourceGroup related
-	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false)
-	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false)
-	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false)
-	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false)
+	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false, WithErrorType(InputError))
+	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false, WithErrorType(InputError))
+	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false, WithErrorType(InputError))
+	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false, WithErrorType(InputError))
 	// go:deprecated
-	ErrResourceGroupNodeNotEnough    = newMilvusError("resource group node not enough", 304, false)
-	ErrResourceGroupServiceAvailable = newMilvusError("resource group service available", 305, true)
+	ErrResourceGroupNodeNotEnough      = newMilvusError("resource group node not enough", 304, false)
+	ErrResourceGroupServiceUnAvailable = newMilvusError("resource group service unavailable", 305, true)
 
 	// Replica related
 	ErrReplicaNotFound     = newMilvusError("replica not found", 400, false)
@@ -118,13 +127,13 @@ var (
 	// Index related
 	ErrIndexNotFound     = newMilvusError("index not found", 700, false)
 	ErrIndexNotSupported = newMilvusError("index type not supported", 701, false)
-	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false)
+	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false, WithErrorType(InputError))
 	ErrTaskDuplicate     = newMilvusError("task duplicates", 703, false)
 
 	// Database related
-	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false)
-	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false)
-	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false)
+	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false, WithErrorType(InputError))
+	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false, WithErrorType(InputError))
+	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false, WithErrorType(InputError))
 
 	// Node related
 	ErrNodeNotFound        = newMilvusError("node not found", 901, false)
@@ -167,7 +176,7 @@ var (
 
 	// Privilege related
 	// this operation is denied because the user not authorized, user need to login in first
-	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false)
+	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false, WithErrorType(InputError))
 	// this operation is denied because the user has no permission to do this, user need higher privilege
 	ErrPrivilegeNotPermitted     = newMilvusError("privilege not permitted", 1401, false)
 	ErrPrivilegeGroupInvalidName = newMilvusError("invalid privilege group name", 1402, false)
@@ -213,7 +222,7 @@ var (
 	errUnexpected = newMilvusError("unexpected error", (1<<16)-1, false)
 
 	// import
-	ErrImportFailed = newMilvusError("importing data failed", 2100, false)
+	ErrImportFailed = newMilvusError("importing data failed", 2100, false, WithErrorType(InputError))
 
 	// Search/Query related
 	ErrInconsistentRequery = newMilvusError("inconsistent requery result", 2200, true)
@@ -251,11 +260,6 @@ var (
 	// Snapshot related
 	ErrSnapshotNotFound = newMilvusError("snapshot not found", 2600, false)
 	ErrSnapshotPinned   = newMilvusError("snapshot is pinned", 2601, false)
-
-	// General
-	ErrOperationNotSupported = newMilvusError("unsupported operation", 3000, false)
-
-	ErrOldSessionExists = newMilvusError("old session exists", 3001, false)
 )
 
 type errorOption func(*milvusError)
@@ -314,6 +318,53 @@ func (e milvusError) Is(err error) bool {
 	return false
 }
 
+// GetErrorType implements the ErrorClassifier interface.
+// It returns the predefined classification of the error (SystemError or InputError).
+func (e milvusError) GetErrorType() ErrorType {
+	return e.errType
+}
+
+// wrappedMilvusError wraps an underlying error with a milvus sentinel and a
+// contextual message, while preserving the inner error chain. Designed so
+// all of the following work on the result, under both stdlib and cockroachdb
+// errors.Is semantics:
+//
+//   - errors.Is(result, sentinel)      → true   (matched via Is)
+//   - errors.Is(result, originalInner) → true   (inner reachable via Unwrap)
+//   - merr.Code(result)                → sentinel's errCode
+//
+// Cause is intentionally NOT overridden: cockroachdb's errors.Is walks the
+// Cause chain first, so returning the sentinel from Cause would hide the
+// inner error. Instead, merr.Code special-cases this type.
+type wrappedMilvusError struct {
+	msg      string
+	inner    error
+	sentinel milvusError
+}
+
+func (w *wrappedMilvusError) Error() string { return w.msg + ": " + w.inner.Error() }
+
+// Unwrap exposes the original error so errors.Is(w, originalInner) works
+// under both stdlib and cockroachdb chain walkers.
+func (w *wrappedMilvusError) Unwrap() error { return w.inner }
+
+// Is matches any milvus sentinel by delegating to the wrapped sentinel.
+func (w *wrappedMilvusError) Is(target error) bool {
+	return errors.Is(w.sentinel, target)
+}
+
+// code lets merr.Code retrieve the milvus error code without needing to
+// resolve the cause chain (which has been redirected to the inner error).
+func (w *wrappedMilvusError) code() int32 {
+	return w.sentinel.errCode
+}
+
+// GetErrorType lets ErrorClassifier consumers (proxy metrics, retry policy)
+// see the same classification as the sentinel.
+func (w *wrappedMilvusError) GetErrorType() ErrorType {
+	return w.sentinel.errType
+}
+
 type multiErrors struct {
 	errs []error
 }
@@ -358,4 +409,16 @@ func Combine(errs ...error) error {
 	return multiErrors{
 		errs,
 	}
+}
+
+func Wrap(err error, msg string) error {
+	return errors.Wrap(err, msg)
+}
+
+func Wrapf(err error, format string, args ...interface{}) error {
+	return errors.Wrapf(err, format, args...)
+}
+
+func Mark(err error, reference error) error {
+	return markers.Mark(err, reference)
 }

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 type ErrSuite struct {
@@ -34,7 +33,6 @@ type ErrSuite struct {
 }
 
 func (s *ErrSuite) SetupSuite() {
-	paramtable.Init()
 }
 
 func (s *ErrSuite) TestCode() {
@@ -104,7 +102,7 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrResourceGroupReachLimit("test_ResourceGroup", 1, "failed to get ResourceGroup"), ErrResourceGroupReachLimit)
 	s.ErrorIs(WrapErrResourceGroupIllegalConfig("test_ResourceGroup", nil, "failed to get ResourceGroup"), ErrResourceGroupIllegalConfig)
 	s.ErrorIs(WrapErrResourceGroupNodeNotEnough("test_ResourceGroup", 1, 2, "failed to get ResourceGroup"), ErrResourceGroupNodeNotEnough)
-	s.ErrorIs(WrapErrResourceGroupServiceAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceAvailable)
+	s.ErrorIs(WrapErrResourceGroupServiceUnAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceUnAvailable)
 
 	// Replica related
 	s.ErrorIs(WrapErrReplicaNotFound(1, "failed to get replica"), ErrReplicaNotFound)
@@ -224,7 +222,7 @@ func (s *ErrSuite) TestIsHealthy() {
 	}
 	for _, tc := range cases {
 		s.Run(tc.code.String(), func() {
-			s.Equal(tc.expect, IsHealthy(tc.code) == nil)
+			s.Equal(tc.expect, CheckHealthy(tc.code) == nil)
 		})
 	}
 }
@@ -274,4 +272,75 @@ func TestNewIOErrors(t *testing.T) {
 
 func TestErrors(t *testing.T) {
 	suite.Run(t, new(ErrSuite))
+}
+
+// TestWrapErrPreservesInnerChain locks in the contract that WrapErr*Err helpers
+// keep the inner error chain reachable via errors.Is while still attributing
+// the milvus sentinel for code lookup. Regression guard against the previous
+// implementation that string-flattened the inner error and lost its identity.
+func TestWrapErrPreservesInnerChain(t *testing.T) {
+	inner := errors.New("inner-error")
+
+	for _, tc := range []struct {
+		name     string
+		wrap     func() error
+		sentinel error
+		other    error
+		code     int32
+	}{
+		{
+			name:     "ServiceInternal",
+			wrap:     func() error { return WrapErrServiceInternalErr(inner, "ctx %s", "test") },
+			sentinel: ErrServiceInternal,
+			other:    ErrParameterInvalid,
+			code:     ErrServiceInternal.errCode,
+		},
+		{
+			name:     "ParameterInvalid",
+			wrap:     func() error { return WrapErrParameterInvalidErr(inner, "ctx %d", 42) },
+			sentinel: ErrParameterInvalid,
+			other:    ErrServiceInternal,
+			code:     ErrParameterInvalid.errCode,
+		},
+		{
+			name:     "MqInternal",
+			wrap:     func() error { return WrapErrMqInternal(inner, "step1", "step2") },
+			sentinel: ErrMqInternal,
+			other:    ErrServiceInternal,
+			code:     ErrMqInternal.errCode,
+		},
+		{
+			name:     "BuildCompactionRequestFail",
+			wrap:     func() error { return WrapErrBuildCompactionRequestFail(inner) },
+			sentinel: ErrBuildCompactionRequestFail,
+			other:    ErrServiceInternal,
+			code:     ErrBuildCompactionRequestFail.errCode,
+		},
+		{
+			name:     "GetCompactionPlanResultFail",
+			wrap:     func() error { return WrapErrGetCompactionPlanResultFail(inner) },
+			sentinel: ErrGetCompactionPlanResultFail,
+			other:    ErrServiceInternal,
+			code:     ErrGetCompactionPlanResultFail.errCode,
+		},
+		{
+			name:     "OperationNotSupported",
+			wrap:     func() error { return WrapErrOperationNotSupported(inner, "op %s", "drop") },
+			sentinel: ErrOperationNotSupported,
+			other:    ErrServiceInternal,
+			code:     ErrOperationNotSupported.errCode,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := tc.wrap()
+			assert.True(t, errors.Is(w, tc.sentinel), "must match its sentinel")
+			assert.True(t, errors.Is(w, inner), "must preserve inner chain")
+			assert.False(t, errors.Is(w, tc.other), "must not match unrelated sentinel")
+			assert.Equal(t, tc.code, Code(w), "Code() must report sentinel's code")
+			assert.Contains(t, w.Error(), inner.Error(), "message must include inner")
+		})
+	}
+
+	// nil err falls back to the Msg variant; just make sure that still works.
+	assert.True(t, errors.Is(WrapErrServiceInternalErr(nil, "no underlying err"), ErrServiceInternal))
 }

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -19,16 +19,14 @@ package merr
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"go.uber.org/zap"
+	"golang.org/x/exp/constraints"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
-	"github.com/milvus-io/milvus/pkg/v3/log"
-	"github.com/milvus-io/milvus/pkg/v3/util/logutil"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 const InputErrorFlagKey string = "is_input_error"
@@ -40,20 +38,25 @@ func Code(err error) int32 {
 		return 0
 	}
 
-	cause := errors.Cause(err)
-	switch specificErr := cause.(type) {
-	case milvusError:
-		return specificErr.code()
-
-	default:
-		if errors.Is(specificErr, context.Canceled) {
-			return CanceledCode
-		} else if errors.Is(specificErr, context.DeadlineExceeded) {
-			return TimeoutCode
-		} else {
-			return errUnexpected.code()
+	// Walk the chain looking for a milvus marker (either milvusError directly,
+	// or our wrappedMilvusError whose sentinel.Cause is hidden so that the
+	// inner error stays reachable via errors.Is). Stop at the first match.
+	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
+		switch v := cur.(type) {
+		case milvusError:
+			return v.code()
+		case *wrappedMilvusError:
+			return v.code()
 		}
 	}
+
+	cause := errors.Cause(err)
+	if errors.Is(cause, context.Canceled) {
+		return CanceledCode
+	} else if errors.Is(cause, context.DeadlineExceeded) {
+		return TimeoutCode
+	}
+	return errUnexpected.code()
 }
 
 func IsRetryableErr(err error) bool {
@@ -299,17 +302,6 @@ func SegcoreError(code int32, msg string) error {
 	return newMilvusError(msg, code, false)
 }
 
-// CheckHealthy checks whether the state is healthy,
-// returns nil if healthy,
-// otherwise returns ErrServiceNotReady wrapped with current state
-func CheckHealthy(state commonpb.StateCode) error {
-	if state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(paramtable.GetRole(), paramtable.GetNodeID(), state.String())
-	}
-
-	return nil
-}
-
 func IsHealthy(stateCode commonpb.StateCode) error {
 	if stateCode == commonpb.StateCode_Healthy {
 		return nil
@@ -324,19 +316,17 @@ func IsHealthyOrStopping(stateCode commonpb.StateCode) error {
 	return CheckHealthy(stateCode)
 }
 
-func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
-	if err := Error(state.GetStatus()); err != nil {
-		return errors.Wrapf(err, "%s=%d not healthy", role, nodeID)
-	} else if state := state.GetState().GetStateCode(); state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(role, nodeID, state.String())
-	}
-
-	return nil
-}
-
 func WrapErrAsInputError(err error) error {
 	if merr, ok := err.(milvusError); ok {
 		WithErrorType(InputError)(&merr)
+		return merr
+	}
+	return err
+}
+
+func WrapErrAsSysError(err error) error {
+	if merr, ok := err.(milvusError); ok {
+		WithErrorType(SystemError)(&merr)
 		return merr
 	}
 	return err
@@ -346,7 +336,6 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	if merr, ok := err.(milvusError); ok {
 		for _, target := range targets {
 			if target.errCode == merr.errCode {
-				log.Info("mark error as input error", zap.Error(err))
 				WithErrorType(InputError)(&merr)
 				return merr
 			}
@@ -355,15 +344,43 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	return err
 }
 
+func WrapErrCollectionReplicateMode(operation string) error {
+	return wrapFields(ErrCollectionReplicateMode, value("operation", operation))
+}
+
 func GetErrorType(err error) ErrorType {
-	if merr, ok := err.(milvusError); ok {
-		return merr.errType
+	var me milvusError
+	if errors.As(err, &me) {
+		return me.errType
 	}
 
 	return SystemError
 }
 
-// Service related
+// keeps only 2 decimal places
+func toMB[T constraints.Integer | constraints.Float](mem T) T {
+	return T(math.Round(float64(mem)/1024/1024*100) / 100)
+}
+
+// CheckHealthy checks whether the state is healthy,
+// returns nil if healthy,
+// otherwise returns ErrServiceNotReady wrapped with current state
+func CheckHealthy(stateCode commonpb.StateCode) error {
+	if stateCode != commonpb.StateCode_Healthy {
+		return ErrServiceNotReady
+	}
+	return nil
+}
+
+func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
+	if err := Error(state.GetStatus()); err != nil {
+		return WrapErrServiceNotReady(role, nodeID, err.Error())
+	} else if stateCode := state.GetState().GetStateCode(); stateCode != commonpb.StateCode_Healthy {
+		return WrapErrServiceNotReady(role, nodeID, stateCode.String())
+	}
+	return nil
+}
+
 func WrapErrServiceNotReady(role string, sessionID int64, state string, msg ...string) error {
 	err := wrapFieldsWithDesc(ErrServiceNotReady,
 		state,
@@ -385,8 +402,8 @@ func WrapErrServiceUnavailable(reason string, msg ...string) error {
 
 func WrapErrServiceMemoryLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceMemoryLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -412,6 +429,21 @@ func WrapErrServiceInternal(reason string, msg ...string) error {
 	return err
 }
 
+func WrapErrServiceInternalErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrServiceInternalMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrServiceInternal,
+	}
+}
+
+func WrapErrServiceInternalMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrServiceInternal, fmt, args...)
+}
+
 func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, msg ...string) error {
 	err := wrapFields(ErrServiceCrossClusterRouting,
 		value("expectedCluster", expectedCluster),
@@ -425,8 +457,8 @@ func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, ms
 
 func WrapErrServiceDiskLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceDiskLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -715,9 +747,9 @@ func WrapErrResourceGroupNodeNotEnough(rg any, current any, expected any, msg ..
 	return err
 }
 
-// WrapErrResourceGroupServiceAvailable wraps ErrResourceGroupServiceAvailable with resource group
-func WrapErrResourceGroupServiceAvailable(msg ...string) error {
-	err := wrapFields(ErrResourceGroupServiceAvailable)
+// WrapErrResourceGroupServiceUnAvailable wraps ErrResourceGroupServiceUnAvailable with resource group
+func WrapErrResourceGroupServiceUnAvailable(msg ...string) error {
+	err := wrapFields(ErrResourceGroupServiceUnAvailable)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
@@ -1046,6 +1078,21 @@ func WrapErrParameterInvalid[T any](expected, actual T, msg ...string) error {
 	return err
 }
 
+// WrapErrParameterInvalidErr wraps an existing error 'err' with ErrParameterInvalid (Code 1005).
+// This is used when an underlying error (e.g., from parsing, validation utility, or dependency)
+// causes a parameter check to fail, and you need to provide extra context
+// in 'format' and 'args'.
+func WrapErrParameterInvalidErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrParameterInvalidMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrParameterInvalid,
+	}
+}
+
 func WrapErrParameterInvalidRange[T any](lower, upper, actual T, msg ...string) error {
 	err := wrapFields(ErrParameterInvalid,
 		bound("value", actual, lower, upper),
@@ -1068,6 +1115,10 @@ func WrapErrParameterMissing[T any](param T, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+func WrapErrParameterMissingMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrParameterMissing, fmt, args...)
 }
 
 func WrapErrParameterTooLarge(name string, msg ...string) error {
@@ -1105,11 +1156,14 @@ func WrapErrMqTopicNotEmpty(name string, msg ...string) error {
 }
 
 func WrapErrMqInternal(err error, msg ...string) error {
-	err = wrapFieldsWithDesc(ErrMqInternal, err.Error())
-	if len(msg) > 0 {
-		err = errors.Wrap(err, strings.Join(msg, "->"))
+	if err == nil {
+		return ErrMqInternal
 	}
-	return err
+	ctx := ErrMqInternal.msg
+	if len(msg) > 0 {
+		ctx = strings.Join(msg, "->") + ": " + ctx
+	}
+	return &wrappedMilvusError{msg: ctx, inner: err, sentinel: ErrMqInternal}
 }
 
 func WrapErrPrivilegeNotAuthenticated(fmt string, args ...any) error {
@@ -1251,6 +1305,12 @@ func WrapErrIllegalCompactionPlan(msg ...string) error {
 	return err
 }
 
+func WrapErrIllegalCompactionPlanMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	// Since this is the message-only path, we wrap the constant error with the formatted message.
+	return errors.Wrap(ErrIllegalCompactionPlan, detail)
+}
+
 func WrapErrCompactionPlanConflict(msg ...string) error {
 	err := error(ErrCompactionPlanConflict)
 	if len(msg) > 0 {
@@ -1319,11 +1379,25 @@ func WrapErrAnalyzeTaskNotFound(id int64) error {
 }
 
 func WrapErrBuildCompactionRequestFail(err error) error {
-	return wrapFieldsWithDesc(ErrBuildCompactionRequestFail, err.Error())
+	if err == nil {
+		return ErrBuildCompactionRequestFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrBuildCompactionRequestFail.msg,
+		inner:    err,
+		sentinel: ErrBuildCompactionRequestFail,
+	}
 }
 
 func WrapErrGetCompactionPlanResultFail(err error) error {
-	return wrapFieldsWithDesc(ErrGetCompactionPlanResultFail, err.Error())
+	if err == nil {
+		return ErrGetCompactionPlanResultFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrGetCompactionPlanResultFail.msg,
+		inner:    err,
+		sentinel: ErrGetCompactionPlanResultFail,
+	}
 }
 
 func WrapErrCompactionResult(msg ...string) error {
@@ -1383,4 +1457,23 @@ func WrapErrSnapshotPinned(name any, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+// WrapErrOperationNotSupportedMsg creates a new ErrOperationNotSupported with a detail message (Code 14).
+// This is the primary replacement for fmt.Errorf/errors.New for operations that are
+// currently not supported by the system.
+func WrapErrOperationNotSupportedMsg(format string, args ...any) error {
+	return errors.Wrapf(ErrOperationNotSupported, format, args...)
+}
+
+// WrapErrOperationNotSupported wraps an existing error 'err' with ErrOperationNotSupported (Code 14).
+func WrapErrOperationNotSupported(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrOperationNotSupportedMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrOperationNotSupported,
+	}
 }

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -178,22 +178,18 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				return err
 			}
 
-			// Caller-explicit RetryErr predicate takes precedence over the
-			// default InputError abort: when caller passes RetryErr they have
-			// decided which errors are retriable, framework must not override.
-			if c.isRetryErr != nil {
-				if !c.isRetryErr(err) {
-					log.Warn("retry func failed, not be retryable",
-						zap.Uint("retried", i),
-						zap.Uint("attempt", c.attempts),
-						zap.String("caller", getCaller(2)),
-					)
-					return err
-				}
-			} else if merr.GetErrorType(err) == merr.InputError {
-				log.Warn("retry func failed, input error is non-retriable",
+			// shouldRetry=true is the caller's explicit affirmative. Honor
+			// it. The optional RetryErr predicate is still consulted as a
+			// second gate, but unlike retry.Do the InputError default abort
+			// is intentionally not applied here: in retry.Handle the caller
+			// signals abort via shouldRetry=false, not via the error type,
+			// otherwise client-side cache-eviction patterns like
+			// retryIfSchemaError become unreachable for errors classified
+			// server-side as InputError (e.g. ErrCollectionSchemaMismatch).
+			if c.isRetryErr != nil && !c.isRetryErr(err) {
+				log.Warn("retry func failed, not be retryable",
 					zap.Uint("retried", i),
-					zap.Error(err),
+					zap.Uint("attempt", c.attempts),
 					zap.String("caller", getCaller(2)),
 				)
 				return err

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -72,10 +72,23 @@ func Do(ctx context.Context, fn func() error, opts ...Option) error {
 				}
 				return err
 			}
-			if c.isRetryErr != nil && !c.isRetryErr(err) {
-				log.Warn("retry func failed, not be retryable",
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
 					zap.Uint("retried", i),
-					zap.Uint("attempt", c.attempts),
+					zap.Error(err),
 					zap.String("caller", getCaller(2)),
 				)
 				return err
@@ -162,6 +175,27 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				if isContextErr && lastErr != nil {
 					return lastErr
 				}
+				return err
+			}
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
+					zap.Uint("retried", i),
+					zap.Error(err),
+					zap.String("caller", getCaller(2)),
+				)
 				return err
 			}
 

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -239,3 +239,53 @@ func TestHandle(t *testing.T) {
 	}, Attempts(10))
 	assert.NoError(t, err)
 }
+
+// Regression: Handle must honor the caller's shouldRetry=true even when the
+// returned error is server-classified InputError. This is the cross-case the
+// client-side cache-eviction pattern in retryIfSchemaError depends on:
+// ErrCollectionSchemaMismatch is tagged InputError server-side (the client
+// sent a stale schema and the server rejected) but the client legitimately
+// wants to evict its cache and retry. Before this case the framework's
+// "default InputError abort" was firing after shouldRetry=true and
+// retryIfSchemaError silently never retried.
+func TestHandle_ShouldRetryOverridesInputErrorDefault(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		if counter == 1 {
+			return true, merr.WrapErrCollectionSchemaMisMatch("mocked")
+		}
+		return false, nil
+	}, Attempts(10))
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, counter,
+		"Handle should retry once when caller returns shouldRetry=true on InputError")
+}
+
+// Symmetric guard: shouldRetry=false on InputError still aborts immediately
+// (this path was already correct; pinning it down so the regression fix
+// above doesn't accidentally turn into "always retry InputError").
+func TestHandle_ShouldRetryFalseAbortsOnInputError(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		return false, merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter)
+}
+
+// retry.Do has no shouldRetry signal from the caller, so the InputError
+// default abort remains the right behavior — keep it pinned.
+func TestDo_InputErrorAbortsByDefault(t *testing.T) {
+	counter := 0
+	err := Do(context.Background(), func() error {
+		counter++
+		return merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter, "Do should abort on InputError without retrying")
+}

--- a/scripts/run_go_unittest.sh
+++ b/scripts/run_go_unittest.sh
@@ -26,6 +26,12 @@ if [[ $(uname -s) == "Darwin" ]]; then
     export MallocNanoZone=0
 fi
 
+# Azurite default credentials for internal/storage TestAzureObjectStorage.
+# Honor any caller-provided value so CI can override with real credentials.
+if [[ -z "${AZURE_STORAGE_CONNECTION_STRING}" ]]; then
+    export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+fi
+
 # ignore MinIO,S3 unittests
 MILVUS_DIR="${ROOT_DIR}/internal/"
 PKG_DIR="${ROOT_DIR}/pkg/"

--- a/tests/python_client/check/func_check.py
+++ b/tests/python_client/check/func_check.py
@@ -504,9 +504,13 @@ class ResponseChecker:
                 num_to_check = min(100, len(distances))  # check 100 items if more than that
                 eps = 1e-6
                 if check_items.get("metric").upper() in ["IP", "COSINE", "BM25"]:
-                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1))
+                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1)), (
+                        f"distances not descending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 else:
-                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1))
+                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1)), (
+                        f"distances not ascending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 if check_items.get("vector_nq") is None or check_items.get("original_vectors") is None:
                     log.debug("skip distance check for knowhere does not return the precise distances")
                 else:

--- a/tests/python_client/milvus_client/test_milvus_client_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_index.py
@@ -204,7 +204,7 @@ class TestMilvusClientIndexInvalid(TestMilvusClientV2Base):
         index_params = self.prepare_index_params(client)[0]
         index_params.add_index(field_name="vector", index_type="IVF_FLAT", metric_type="L2")
         # 3. create another index
-        error = {ct.err_code: 65535, ct.err_msg: "CreateIndex failed: at most one distinct index is allowed per field"}
+        error = {ct.err_code: 1100, ct.err_msg: "at most one distinct index is allowed per field"}
         self.create_index(client, collection_name, index_params,
                           check_task=CheckTasks.err_res, check_items=error)
         self.drop_collection(client, collection_name)
@@ -1076,7 +1076,7 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
                                index_type=supported_double_scalar_index,
                                params={"json_cast_type": "varchar", "json_path": f"{json_field_name}['a']"})
         # 5. create index
-        error = {ct.err_code: 65535, ct.err_msg: "CreateIndex failed: at most one distinct index is allowed per field"}
+        error = {ct.err_code: 1100, ct.err_msg: "at most one distinct index is allowed per field"}
         self.create_index(client, collection_name, index_params,
                           check_task=CheckTasks.err_res, check_items=error)
 
@@ -1165,7 +1165,7 @@ class TestMilvusClientJsonPathIndexInvalid(TestMilvusClientV2Base):
                                params={"json_cast_type": supported_json_cast_type,
                                        "json_path": f"{json_field_name}"})
         # 4. create index
-        error = {ct.err_code: 65535, ct.err_msg: "CreateIndex failed: at most one distinct index is allowed per field"}
+        error = {ct.err_code: 1100, ct.err_msg: "at most one distinct index is allowed per field"}
         self.create_index(client, collection_name, index_params,
                           check_task=CheckTasks.err_res, check_items=error)
 

--- a/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
+++ b/tests/python_client/milvus_client/test_milvus_client_timestamptz.py
@@ -1122,8 +1122,8 @@ class TestMilvusClientTimestamptzInvalid(TestMilvusClientV2Base):
                                consistency_level="Strong", index_params=index_params)
 
         # step 2: add field with default value for timestamptz field
-        error = {ct.err_code: 1100, 
-                 ct.err_msg: f"invalid default value of field, name: {default_timestamp_field_name}, err: %!w(*errors.errorString=&{{invalid timestamp string: '1234'. Does not match any known format}}): invalid parameter"}
+        error = {ct.err_code: 1100,
+                 ct.err_msg: f"invalid default value of field, name: {default_timestamp_field_name}: invalid timestamp string: '1234'. Does not match any known format"}
         self.add_collection_field(client, collection_name, field_name=default_timestamp_field_name, data_type=DataType.TIMESTAMPTZ,
                                   nullable=True, default_value="1234", check_task=CheckTasks.err_res, check_items=error)
         

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -233,7 +233,7 @@ class TestIndexOperation(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         collection_w = self.init_collection_wrap(name=c_name)
         self.index_wrap.init_index(collection_w.collection, default_field_name, default_index_params)
-        error = {ct.err_code: 65535, ct.err_msg: "CreateIndex failed: at most one distinct index is allowed per field"}
+        error = {ct.err_code: 1100, ct.err_msg: "at most one distinct index is allowed per field"}
         self.index_wrap.init_index(
             collection_w.collection,
             default_field_name,
@@ -1790,7 +1790,7 @@ class TestIndexString(TestcaseBase):
             default_index_params,
             index_name=index_name2,
             check_task=CheckTasks.err_res,
-            check_items={ct.err_code: 1, ct.err_msg: "CreateIndex failed"},
+            check_items={ct.err_code: 1100, ct.err_msg: "at most one distinct index is allowed per field"},
         )
 
     @pytest.mark.tags(CaseLabel.L1)

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1524,7 +1524,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("ratio", [-0.5, 1, 3])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_ratio(self, ratio, index):
         """
         target: index creation for unsupported ratio parameter
@@ -1551,7 +1551,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("inverted_index_algo", ["INVALID_ALGO"])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_inverted_index_algo(self, inverted_index_algo, index):
         """
         target: index creation for unsupported sparse inverted index algo parameter


### PR DESCRIPTION
Standardizes error handling in the coordinators (`internal/datacoord`, `internal/rootcoord`, `internal/querycoordv2`) onto the `merr` framework. Part of the system-wide error-standardization series.

### Stacking

Depends on #48802 (`err-std-01-base`, the foundational `merr` framework). This branch is stacked on top of `err-std-01-base`, so until #48802 merges the diff here also contains the base-framework commits. **Review the single coord commit** `enhance: standardize coordinators error handling to merr`; the base commits land via #48802. Sibling: #49865 (`err-std-03-proxy`).

### What this is

This started from the per-module auto-generated conversion, re-sliced onto the current `err-std-01-base`, then **heavily hand-corrected**. The raw auto-gen output had several *systematic* defects that did not compile and/or silently regressed error semantics; each was root-caused against a real failing coord unit test and verified fixed.

**Compile / API defects**
- Wrong import path `pkg/v2/util/merr` (no such module; the pkg module is `pkg/v3`) → `pkg/v3/util/merr` (36 files).
- Hallucinated API `merr.WrapErrRbacMsg` (does not exist) → real wrappers (the legacy gRPC `ErrorCode` is forced by the enclosing `StatusWithErrorCode`, so the wire code is preserved).
- Stripped `errors`/`fmt` imports left dangling refs (`undefined: errors`); duplicate / unused imports after reverts.
- `go vet` `non-constant format string`: ~30 `WrapErr*Err(err, <var>)` / `WrapErr*Err(err, fmt.Sprintf(...))` (the `*Err` format param is printf-checked).

**Semantic defects (silent behaviour regressions; caught by coord unit tests, would have broken gRPC clients / e2e)**
- **Sentinel corruption**: ~30 package-level sentinel errors (`errIndexOperationIgnored`, `errRoleNotExists`, `errIgnored*`, `ErrFull`, `ErrResourceGroupOperationIgnored`, …) were converted from `errors.New` to `merr.WrapErrServiceInternalMsg`. `merr`'s `Is()` matches by error *code*, so every such sentinel became `errors.Is`-equal to every other `ServiceInternal` error, collapsing all sentinel-based control flow (e.g. a real "multiple indexes" error was swallowed as `errIndexOperationIgnored` → `CreateIndex` returned `nil`). Reverted to `errors.New` — internal control-flow sentinels are not user-facing and must not be `merr`.
- **Code masking**: `errors.Wrap(err, msg)` (context wrap that preserves the cause chain, so `merr.Code` walks to the inner code) was turned into `merr.WrapErrServiceInternalErr(err, msg)`, which adds a `ServiceInternal` layer that *masks* the inner code (e.g. dropping a builtin role: `PrivilegeNotPermitted` 1401 → 5). Reverted the 127 rootcoord/querycoordv2 wrap sites back to `errors.Wrap`/`Wrapf` (== `err-std-01-base` behaviour; wrapping an already-coded error to add context is legitimately `errors.Wrap`, not error origination). datacoord io/meta origination sites keep the `merr` standardization (that is the intended err-std change).

**Message-quality cleanup**
- Reverted capitalized error strings (Go `ST1005`).
- Reclassified clear request-validation errors the auto-gen tagged retriable `ServiceInternal` to `ParameterInvalid` (non-retriable), consistent with adjacent code.
- Kept the specific wrappers the auto-gen had downgraded to generic `ServiceInternal` (`WrapErrSnapshotNotFound`, `WrapErrCollectionNotLoaded`).
- Unwrapped nested `fmt.Sprintf`; fixed `err.Error()`-as-format-string.
- Preserved new-master function bodies over stale auto-gen during the re-slice.

### Validation

- Full coord `make test-go` (datacoord, rootcoord, querycoordv2 + all subpackages): **every package ok, zero failing subtests**.
- `make verifiers` rc=0; `go build` + `go vet` clean; gci/gofmt clean.
- Note: running `-run TestService` *in isolation* panics in `TestLoadBalance*` because new master added a global balancer-factory singleton (`handlers.go`) that `ServiceSuite.SetupTest` does not initialize; in the full-package run (CI behaviour) a sibling test initializes the `factoryOnce` singleton so it passes. This is a pre-existing test-isolation property on `err-std-01-base` (verified by running the same isolated subset on `9e452624b8` — identical panic), unrelated to error standardization and not introduced here.

### Out of scope (documented follow-up)

~24 pre-existing `fmt.Errorf` / `errors.New|Wrap` sites the auto-gen never reached (mostly RBAC `meta_table` role/privilege "already exists"); converting them changes RBAC wire semantics and needs its own e2e-validated change.

issue: #47420
