### PR TITLE
fix: support mixed-case credential names

### DIFF
--- a/internal/util/credentials/credentials.go
+++ b/internal/util/credentials/credentials.go
@@ -21,6 +21,7 @@ package credentials
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -45,8 +46,13 @@ func NewCredentials(conf map[string]string) *Credentials {
 	return &Credentials{conf}
 }
 
+func credentialKey(name, key string) string {
+	// Config keys are case-insensitive and normalized to lowercase.
+	return strings.ToLower(name) + "." + key
+}
+
 func (c *Credentials) GetAPIKeyCredential(name string) (string, error) {
-	k := name + "." + APIKey
+	k := credentialKey(name, APIKey)
 	apikey, exist := c.confMap[k]
 	if !exist {
 		return "", fmt.Errorf("%s is not a apikey crediential, can not find key: %s", name, k)
@@ -55,13 +61,13 @@ func (c *Credentials) GetAPIKeyCredential(name string) (string, error) {
 }
 
 func (c *Credentials) GetAKSKCredential(name string) (string, string, error) {
-	IdKey := name + "." + AccessKeyId
+	IdKey := credentialKey(name, AccessKeyId)
 	accessKeyId, exist := c.confMap[IdKey]
 	if !exist {
 		return "", "", fmt.Errorf("%s is not a aksk crediential, can not find key: %s", name, IdKey)
 	}
 
-	AccessKey := name + "." + SecretAccessKey
+	AccessKey := credentialKey(name, SecretAccessKey)
 	secretAccessKey, exist := c.confMap[AccessKey]
 	if !exist {
 		return "", "", fmt.Errorf("%s is not a aksk crediential, can not find key: %s", name, AccessKey)
@@ -70,7 +76,7 @@ func (c *Credentials) GetAKSKCredential(name string) (string, string, error) {
 }
 
 func (c *Credentials) GetGcpCredential(name string) ([]byte, error) {
-	k := name + "." + CredentialJSON
+	k := credentialKey(name, CredentialJSON)
 	jsonByte, exist := c.confMap[k]
 	if !exist {
 		return nil, fmt.Errorf("%s is not a gcp crediential, can not find key: %s ", name, k)

--- a/internal/util/credentials/credentials_test.go
+++ b/internal/util/credentials/credentials_test.go
@@ -1,0 +1,61 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package credentials
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAPIKeyCredentialWithMixedCaseName(t *testing.T) {
+	credentials := NewCredentials(map[string]string{ //nolint:gosec // not a real credential, test data
+		"aistaffhub_credential.apikey": "mock-api-key",
+	})
+
+	apiKey, err := credentials.GetAPIKeyCredential("aIstaffhub_credential")
+
+	require.NoError(t, err)
+	assert.Equal(t, "mock-api-key", apiKey)
+}
+
+func TestGetAKSKCredentialWithMixedCaseName(t *testing.T) {
+	credentials := NewCredentials(map[string]string{ //nolint:gosec // not real credentials, test data
+		"aistaffhub_credential.access_key_id":     "mock-access-key-id",
+		"aistaffhub_credential.secret_access_key": "mock-secret-access-key",
+	})
+
+	accessKeyID, secretAccessKey, err := credentials.GetAKSKCredential("aIstaffhub_credential")
+
+	require.NoError(t, err)
+	assert.Equal(t, "mock-access-key-id", accessKeyID)
+	assert.Equal(t, "mock-secret-access-key", secretAccessKey)
+}
+
+func TestGetGcpCredentialWithMixedCaseName(t *testing.T) {
+	credentialsJSON := []byte(`{"type":"service_account"}`)
+	credentials := NewCredentials(map[string]string{
+		"aistaffhub_credential.credential_json": base64.StdEncoding.EncodeToString(credentialsJSON),
+	})
+
+	actual, err := credentials.GetGcpCredential("aIstaffhub_credential")
+
+	require.NoError(t, err)
+	assert.Equal(t, credentialsJSON, actual)
+}


### PR DESCRIPTION
https://github.com/milvus-io/milvus/issues/48794
 
 Normalize credential names before building config keys so API key, AK/SK, and GCP credential lookups work when names contain mixed-case characters.

  Add tests covering mixed-case credential names for all supported credential types.