### PR TITLE
enhance: [Loaddiff] route schema reopen through load diff

### DIFF
--- a/docs/design-docs/design_docs/segcore/20260204-loaddiff_based_segment_load.md
+++ b/docs/design-docs/design_docs/segcore/20260204-loaddiff_based_segment_load.md
@@ -238,19 +238,26 @@ void ChunkedSegmentSealedImpl::Load(
 **Reopen (Incremental Update):**
 ```cpp
 void ChunkedSegmentSealedImpl::Reopen(
-    const milvus::proto::segcore::SegmentLoadInfo& new_load_info) {
+    const milvus::proto::segcore::SegmentLoadInfo& new_load_info,
+    SchemaPtr new_schema) {
 
-    SegmentLoadInfo new_seg_load_info(new_load_info, schema_);
+    auto current = std::atomic_load(&segment_load_info_);
+    SegmentLoadInfo current_mutable(*current);
+    SegmentLoadInfo new_seg_load_info(new_load_info, new_schema);
 
-    // Store old info and update to new
-    SegmentLoadInfo current(segment_load_info_);
-    segment_load_info_ = new_seg_load_info;
-
-    // Compute diff between old and new
-    auto diff = current.ComputeDiff(new_seg_load_info);
+    auto diff = current_mutable.ComputeDiff(new_seg_load_info);
+    std::atomic_store(&segment_load_info_,
+                      std::make_shared<const SegmentLoadInfo>(new_seg_load_info));
+    ApplySchemaForReopen(new_schema);
     ApplyLoadDiff(new_seg_load_info, diff);
 }
 ```
+
+**Schema-aware Reopen:**
+
+Schema changes no longer use a separate sealed-segment path that directly fills missing fields. QueryNode passes the latest collection schema together with `SegmentLoadInfo` into segcore, so `ComputeDiff()` can see newly added or removed fields while computing load/default-fill/drop actions.
+
+For schema-only lazy checks from query/retrieve plans, `Reopen(SchemaPtr)` reuses the current load info and computes a diff against the newer schema. Default-value filling, field data drops, and index drops are therefore represented through `LoadDiff` and executed by `ApplyLoadDiff()`.
 
 ## Storage Mode Support
 
@@ -392,13 +399,17 @@ message SegmentLoadInfo {
 
 The order of operations in `ApplyLoadDiff()` is critical:
 
-1. **Load new indexes** - Can run in parallel
-2. **Reload columns** - MUST happen before dropping indexes
-3. **Drop indexes** - MUST happen after reload to maintain data availability
-4. **Load column groups** - Eager and lazy loading
-5. **Load field binlogs** - For Storage V1/V2
-6. **Fill default values** - For schema evolution
-7. **Drop field data** - Clean up removed fields
+1. **Load/replace indexes** - Load new indexes or replacements first
+2. **Reload columns** - Restore fields that lost raw-data index coverage
+3. **Load/replace column groups** - Eager and lazy loading for Storage V3
+4. **Load/replace field binlogs** - For Storage V1/V2
+5. **Drop indexes** - Drop old indexes only after replacement data/indexes are available
+6. **Load text/JSON stats indexes** - Apply pre-built text and JSON stats changes
+7. **Fill default values** - For schema evolution fields without data sources
+8. **Create text indexes from raw data** - For enable_match fields without pre-built index files
+9. **Drop field data** - Clean up removed fields
+
+Current implementation loads or replaces raw field data before dropping old indexes, so queries can always fall back to a valid data source during index transitions.
 
 ## Testing
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -4356,6 +4356,9 @@ ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
         std::shared_lock lck(mutex_);
         current_schema = schema_;
     }
+    // Schema-only reopen carries no load-info updates, so equal-version input
+    // cannot produce work. Reopen(load_info, schema) still accepts equal schema
+    // versions because load info may have changed independently.
     if (sch->get_schema_version() <= current_schema->get_schema_version()) {
         return;
     }
@@ -4450,14 +4453,20 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
     // TODO: pass trace_ctx separately when needed
     milvus::tracer::TraceContext trace_ctx;
 
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
+
     // Load new indexes (fields without existing index)
     if (!diff.indexes_to_load.empty()) {
         LoadBatchIndexes(trace_ctx, diff.indexes_to_load, op_ctx);
     }
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
+
     // Replace indexes (fields that already have an index loaded)
     if (!diff.indexes_to_replace.empty()) {
         LoadBatchIndexes(trace_ctx, diff.indexes_to_replace, op_ctx, true);
     }
+
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
 
     // reload fields (warmup for fields already in memory)
     if (!diff.fields_to_reload.empty()) {
@@ -4466,6 +4475,8 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
 
     // Load field data from storage BEFORE dropping indexes, so that queries
     // always have a data source available during the transition.
+
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
 
     // load column groups
     if (diff.load_external_manifest) {
@@ -4531,19 +4542,27 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
         }
     }
 
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
+
     // Initialize LOB paths for TEXT fields after any column group loading
     if (segment_load_info.HasManifestPath()) {
         InitTextLobPaths(segment_load_info.GetManifestPath());
     }
 
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
+
     // Load new field binlogs
     if (!diff.binlogs_to_load.empty()) {
         LoadBatchFieldData(trace_ctx, diff.binlogs_to_load, op_ctx);
     }
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
+
     // Replace field binlogs
     if (!diff.binlogs_to_replace.empty()) {
         LoadBatchFieldData(trace_ctx, diff.binlogs_to_replace, op_ctx, true);
     }
+
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
 
     // drop index — field data is already loaded/restored above, so queries
     // can fall back to raw data after the index is dropped.
@@ -4558,10 +4577,14 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
         }
     }
 
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
+
     // load pre-built text indexes
     if (!diff.text_indexes_to_load.empty()) {
         LoadBatchTextIndexes(op_ctx, diff.text_indexes_to_load);
     }
+
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
 
     if (!diff.json_stats_to_load.empty()) {
         LoadBatchJsonKeyIndexes(op_ctx, diff.json_stats_to_load);
@@ -4587,11 +4610,15 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
         }
     }
 
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
+
     // fill default values for fields without data sources (schema evolution)
     if (!diff.fields_to_fill_default.empty()) {
         FillDefaultValueFields(diff.fields_to_fill_default);
         RecordDefaultFieldsFilled(diff.fields_to_fill_default);
     }
+
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
 
     // create text indexes from raw data
     if (!diff.text_indexes_to_create.empty()) {
@@ -4599,6 +4626,8 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
             CreateTextIndex(field_id, op_ctx);
         }
     }
+
+    CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
 
     // Drop field data — only for schema evolution scenarios where
     // the field has been removed from the data source (binlogs/column_groups).
@@ -5293,6 +5322,7 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     auto num_rows = snapshot->GetNumOfRows();
     LOG_INFO("Loading segment {} with {} rows", id_, num_rows);
 
+    // reopen_mutex_ synchronizes this read with all schema_ writers.
     SegmentLoadInfo mutable_copy(snapshot->GetProto(), schema_);
     mutable_copy.SetFieldsFilledWithDefault(
         snapshot->GetFieldsFilledWithDefault());

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2946,6 +2946,25 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id,
 }
 
 void
+ChunkedSegmentSealedImpl::RecordDefaultFieldsFilled(
+    const std::vector<FieldId>& field_ids) {
+    if (field_ids.empty()) {
+        return;
+    }
+
+    auto current = std::atomic_load(&segment_load_info_);
+    std::shared_ptr<const SegmentLoadInfo> next;
+    do {
+        auto copy = std::make_shared<SegmentLoadInfo>(*current);
+        for (auto field_id : field_ids) {
+            copy->SetFieldFilledWithDefault(field_id);
+        }
+        next = std::const_pointer_cast<const SegmentLoadInfo>(copy);
+    } while (!std::atomic_compare_exchange_weak(
+        &segment_load_info_, &current, next));
+}
+
+void
 ChunkedSegmentSealedImpl::RecordTextIndexCreated(FieldId field_id) {
     auto current = std::atomic_load(&segment_load_info_);
     std::shared_ptr<const SegmentLoadInfo> next;
@@ -4292,30 +4311,66 @@ ChunkedSegmentSealedImpl::init_storage_v1_timestamp_index(
 }
 
 void
-ChunkedSegmentSealedImpl::Reopen(SchemaPtr sch) {
+ChunkedSegmentSealedImpl::ApplySchemaForReopen(SchemaPtr sch) {
+    if (!sch) {
+        return;
+    }
+
     std::unique_lock lck(mutex_);
+    if (sch->get_schema_version() <= schema_->get_schema_version()) {
+        return;
+    }
 
     field_data_ready_bitset_.resize(sch->size());
     index_ready_bitset_.resize(sch->size());
     binlog_index_bitset_.resize(sch->size());
+    schema_ = std::move(sch);
+}
 
-    auto absent_fields = sch->AbsentFields(*schema_);
-    for (const auto& field_meta : *absent_fields) {
-        fill_empty_field(field_meta);
+void
+ChunkedSegmentSealedImpl::Reopen(SchemaPtr sch) {
+    if (!sch) {
+        return;
     }
 
-    schema_ = sch;
-
-    auto row_count = num_rows_.value_or(0);
-    for (const auto& field_meta : *absent_fields) {
-        EnsureArrayOffsetsForStructField(field_meta, row_count);
+    milvus::OpContext op_ctx;
+    std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
+    if (sch->get_schema_version() <= schema_->get_schema_version()) {
+        return;
     }
+
+    auto current = std::atomic_load(&segment_load_info_);
+    LoadDiff diff;
+    diff.fields_to_fill_default =
+        current->GetFieldsToFillDefaultForSchema(sch);
+    SegmentLoadInfo new_local(current->GetProto(), sch);
+    new_local.SetFieldsFilledWithDefault(
+        current->GetDefaultFilledFieldsForNewInfo(new_local));
+    LOG_INFO("Schema-only reopen segment {} with diff {}", id_, diff.ToString());
+
+    auto published = std::make_shared<const SegmentLoadInfo>(new_local);
+    std::atomic_store(&segment_load_info_, published);
+    use_take_for_output_.store(published->GetUseTakeForOutput(),
+                               std::memory_order_relaxed);
+
+    ApplySchemaForReopen(sch);
+    ApplyLoadDiff(&op_ctx, new_local, diff);
+
+    LOG_INFO("Schema-only reopen segment {} done", id_);
 }
 
 void
 ChunkedSegmentSealedImpl::Reopen(
     milvus::OpContext* op_ctx,
     const milvus::proto::segcore::SegmentLoadInfo& new_load_info) {
+    Reopen(op_ctx, new_load_info, nullptr);
+}
+
+void
+ChunkedSegmentSealedImpl::Reopen(
+    milvus::OpContext* op_ctx,
+    const milvus::proto::segcore::SegmentLoadInfo& new_load_info,
+    SchemaPtr new_schema) {
     // reopen_mutex_ serializes top-level writers of segment_load_info_.
     // It is held across ApplyLoadDiff so two Reopens never interleave their
     // resource mutations. Readers are unaffected — they snapshot via
@@ -4323,26 +4378,25 @@ ChunkedSegmentSealedImpl::Reopen(
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
 
     auto current = std::atomic_load(&segment_load_info_);
+    auto target_schema = new_schema ? std::move(new_schema) : schema_;
 
-    SegmentLoadInfo new_local(new_load_info, schema_);
-    // Carry runtime-only state forward so subsequent Reopens don't
-    // re-schedule CreateTextIndex on a field whose temp index was built.
+    SegmentLoadInfo current_mutable(*current);
+    SegmentLoadInfo new_local(new_load_info, target_schema);
     for (auto fid : current->GetCreatedTextIndexes()) {
         new_local.SetTextIndexCreated(fid);
     }
 
-    // Publish an independent immutable copy. Subsequent mutations to
-    // `new_local` by ComputeDiff/ApplyLoadDiff do NOT propagate to the
-    // published snapshot.
+    auto diff = current_mutable.ComputeDiff(new_local);
+    new_local.SetFieldsFilledWithDefault(
+        current_mutable.GetDefaultFilledFieldsForNewInfo(new_local));
+    LOG_INFO("Reopen segment {} with diff {}", id_, diff.ToString());
+
     auto published = std::make_shared<const SegmentLoadInfo>(new_local);
     std::atomic_store(&segment_load_info_, published);
     use_take_for_output_.store(published->GetUseTakeForOutput(),
                                std::memory_order_relaxed);
 
-    // compute load diff (ComputeDiff requires non-const receiver; copy current).
-    SegmentLoadInfo current_mutable(*current);
-    auto diff = current_mutable.ComputeDiff(new_local);
-    LOG_INFO("Reopen segment {} with diff {}", id_, diff.ToString());
+    ApplySchemaForReopen(target_schema);
     ApplyLoadDiff(op_ctx, new_local, diff);
 
     LOG_INFO("Reopen segment {} done", id_);
@@ -4495,6 +4549,7 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
     // fill default values for fields without data sources (schema evolution)
     if (!diff.fields_to_fill_default.empty()) {
         FillDefaultValueFields(diff.fields_to_fill_default);
+        RecordDefaultFieldsFilled(diff.fields_to_fill_default);
     }
 
     // create text indexes from raw data
@@ -5189,13 +5244,8 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
 void
 ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
                                milvus::OpContext* op_ctx) {
-    // Serialize with Reopen(pb)/SetLoadInfo. ApplyLoadDiff operates on a
-    // mutable local copy; any updates it needs to publish to
-    // segment_load_info_ (currently only CreatedTextIndexes, via
-    // RecordTextIndexCreated) go through the atomic member directly. We do
-    // NOT re-publish mutable_copy at the end — doing so would clobber those
-    // in-flight RecordTextIndexCreated updates. This matches Reopen(pb)'s
-    // pattern.
+    // Serialize with Reopen(pb)/SetLoadInfo. Runtime-only updates produced by
+    // ApplyLoadDiff are committed through COW helpers after the data is loaded.
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
 
     auto snapshot = std::atomic_load(&segment_load_info_);
@@ -5203,8 +5253,12 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     LOG_INFO("Loading segment {} with {} rows", id_, num_rows);
 
     SegmentLoadInfo mutable_copy(snapshot->GetProto(), schema_);
+    for (auto fid : snapshot->GetCreatedTextIndexes()) {
+        mutable_copy.SetTextIndexCreated(fid);
+    }
     auto diff = mutable_copy.GetLoadDiff();
     LOG_WARN("Load segment {} with diff {}", id_, diff.ToString());
+
     ApplyLoadDiff(op_ctx, mutable_copy, diff);
 
     LOG_INFO("Successfully loaded segment {} with {} rows", id_, num_rows);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -4113,16 +4113,27 @@ ChunkedSegmentSealedImpl::RemoveFieldFile(const FieldId field_id) {
 }
 
 void
-ChunkedSegmentSealedImpl::LazyCheckSchema(SchemaPtr sch) {
-    if (sch->get_schema_version() > schema_->get_schema_version()) {
+ChunkedSegmentSealedImpl::LazyCheckSchema(SchemaPtr sch,
+                                          milvus::OpContext* op_ctx) {
+    if (!sch) {
+        return;
+    }
+
+    uint64_t current_schema_version;
+    {
+        std::shared_lock lck(mutex_);
+        current_schema_version = schema_->get_schema_version();
+    }
+
+    if (sch->get_schema_version() > current_schema_version) {
         LOG_INFO(
             "lazy check schema segment {} found newer schema version, "
             "current "
             "schema version {}, new schema version {}",
             id_,
-            schema_->get_schema_version(),
+            current_schema_version,
             sch->get_schema_version());
-        Reopen(sch);
+        Reopen(op_ctx, std::move(sch));
     }
 }
 
@@ -4329,13 +4340,23 @@ ChunkedSegmentSealedImpl::ApplySchemaForReopen(SchemaPtr sch) {
 
 void
 ChunkedSegmentSealedImpl::Reopen(SchemaPtr sch) {
+    milvus::OpContext op_ctx;
+    Reopen(&op_ctx, std::move(sch));
+}
+
+void
+ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
     if (!sch) {
         return;
     }
 
-    milvus::OpContext op_ctx;
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
-    if (sch->get_schema_version() <= schema_->get_schema_version()) {
+    SchemaPtr current_schema;
+    {
+        std::shared_lock lck(mutex_);
+        current_schema = schema_;
+    }
+    if (sch->get_schema_version() <= current_schema->get_schema_version()) {
         return;
     }
 
@@ -4358,7 +4379,7 @@ ChunkedSegmentSealedImpl::Reopen(SchemaPtr sch) {
                                std::memory_order_relaxed);
 
     ApplySchemaForReopen(sch);
-    ApplyLoadDiff(&op_ctx, new_local, diff);
+    ApplyLoadDiff(op_ctx, new_local, diff);
 
     LOG_INFO("Schema-only reopen segment {} done", id_);
 }
@@ -4381,8 +4402,24 @@ ChunkedSegmentSealedImpl::Reopen(
     // std::atomic_load and never touch this mutex.
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
 
+    SchemaPtr current_schema;
+    {
+        std::shared_lock lck(mutex_);
+        current_schema = schema_;
+    }
+    if (new_schema && new_schema->get_schema_version() <
+                          current_schema->get_schema_version()) {
+        LOG_WARN(
+            "Skip stale reopen segment {}, current schema version {}, incoming "
+            "schema version {}",
+            id_,
+            current_schema->get_schema_version(),
+            new_schema->get_schema_version());
+        return;
+    }
+
     auto current = std::atomic_load(&segment_load_info_);
-    auto target_schema = new_schema ? std::move(new_schema) : schema_;
+    auto target_schema = new_schema ? std::move(new_schema) : current_schema;
 
     SegmentLoadInfo current_mutable(*current);
     SegmentLoadInfo new_local(new_load_info, target_schema);
@@ -5257,6 +5294,8 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     LOG_INFO("Loading segment {} with {} rows", id_, num_rows);
 
     SegmentLoadInfo mutable_copy(snapshot->GetProto(), schema_);
+    mutable_copy.SetFieldsFilledWithDefault(
+        snapshot->GetFieldsFilledWithDefault());
     for (auto fid : snapshot->GetCreatedTextIndexes()) {
         mutable_copy.SetTextIndexCreated(fid);
     }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -4340,13 +4340,17 @@ ChunkedSegmentSealedImpl::Reopen(SchemaPtr sch) {
     }
 
     auto current = std::atomic_load(&segment_load_info_);
-    LoadDiff diff;
-    diff.fields_to_fill_default =
-        current->GetFieldsToFillDefaultForSchema(sch);
+    SegmentLoadInfo current_mutable(*current);
     SegmentLoadInfo new_local(current->GetProto(), sch);
+    for (auto fid : current->GetCreatedTextIndexes()) {
+        new_local.SetTextIndexCreated(fid);
+    }
+
+    auto diff = current_mutable.ComputeDiff(new_local);
     new_local.SetFieldsFilledWithDefault(
-        current->GetDefaultFilledFieldsForNewInfo(new_local));
-    LOG_INFO("Schema-only reopen segment {} with diff {}", id_, diff.ToString());
+        current_mutable.GetDefaultFilledFieldsForNewInfo(new_local));
+    LOG_INFO(
+        "Schema-only reopen segment {} with diff {}", id_, diff.ToString());
 
     auto published = std::make_shared<const SegmentLoadInfo>(new_local);
     std::atomic_store(&segment_load_info_, published);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -278,7 +278,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
            SchemaPtr new_schema) override;
 
     void
-    LazyCheckSchema(SchemaPtr sch) override;
+    LazyCheckSchema(SchemaPtr sch, milvus::OpContext* op_ctx) override;
 
     void
     SetLoadInfo(milvus::proto::segcore::SegmentLoadInfo load_info) override;
@@ -1293,6 +1293,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     ApplyLoadDiff(milvus::OpContext* op_ctx,
                   SegmentLoadInfo& segment_load_info,
                   LoadDiff& load_diff);
+
+    void
+    Reopen(milvus::OpContext* op_ctx, SchemaPtr sch);
 
     void
     ApplySchemaForReopen(SchemaPtr sch);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -273,6 +273,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const milvus::proto::segcore::SegmentLoadInfo& new_load_info) override;
 
     void
+    Reopen(milvus::OpContext* op_ctx,
+           const milvus::proto::segcore::SegmentLoadInfo& new_load_info,
+           SchemaPtr new_schema) override;
+
+    void
     LazyCheckSchema(SchemaPtr sch) override;
 
     void
@@ -1288,6 +1293,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     ApplyLoadDiff(milvus::OpContext* op_ctx,
                   SegmentLoadInfo& segment_load_info,
                   LoadDiff& load_diff);
+
+    void
+    ApplySchemaForReopen(SchemaPtr sch);
+
+    void
+    RecordDefaultFieldsFilled(const std::vector<FieldId>& field_ids);
 
     // Atomically records that a text index has been created for `field_id` in
     // the published segment_load_info_. Uses a CAS loop so it is safe whether

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -2087,7 +2087,8 @@ SegmentGrowingImpl::BulkGetJsonData(
 }
 
 void
-SegmentGrowingImpl::LazyCheckSchema(SchemaPtr sch) {
+SegmentGrowingImpl::LazyCheckSchema(SchemaPtr sch, milvus::OpContext* op_ctx) {
+    (void)op_ctx;
     if (sch->get_schema_version() > schema_->get_schema_version()) {
         LOG_INFO(
             "lazy check schema segment {} found newer schema version, "

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -2133,6 +2133,16 @@ SegmentGrowingImpl::Reopen(
 }
 
 void
+SegmentGrowingImpl::Reopen(
+    milvus::OpContext* op_ctx,
+    const milvus::proto::segcore::SegmentLoadInfo& new_load_info,
+    SchemaPtr new_schema) {
+    ThrowInfo(milvus::UnexpectedError,
+              "Unexpected reopening growing segment {} with load info",
+              id_);
+}
+
+void
 SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
                          milvus::OpContext* op_ctx) {
     // Convert load_info_ (SegmentLoadInfo) to LoadFieldDataInfo

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -155,7 +155,7 @@ class SegmentGrowingImpl : public SegmentGrowing {
            SchemaPtr new_schema) override;
 
     void
-    LazyCheckSchema(SchemaPtr sch) override;
+    LazyCheckSchema(SchemaPtr sch, milvus::OpContext* op_ctx) override;
 
     void
     Load(milvus::tracer::TraceContext& trace_ctx,

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -150,6 +150,11 @@ class SegmentGrowingImpl : public SegmentGrowing {
         const milvus::proto::segcore::SegmentLoadInfo& new_load_info) override;
 
     void
+    Reopen(milvus::OpContext* op_ctx,
+           const milvus::proto::segcore::SegmentLoadInfo& new_load_info,
+           SchemaPtr new_schema) override;
+
+    void
     LazyCheckSchema(SchemaPtr sch) override;
 
     void

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -294,6 +294,11 @@ class SegmentInterface {
            const milvus::proto::segcore::SegmentLoadInfo& new_load_info) = 0;
 
     virtual void
+    Reopen(milvus::OpContext* op_ctx,
+           const milvus::proto::segcore::SegmentLoadInfo& new_load_info,
+           SchemaPtr new_schema) = 0;
+
+    virtual void
     SetLoadInfo(milvus::proto::segcore::SegmentLoadInfo load_info) = 0;
 
     virtual void

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -283,7 +283,7 @@ class SegmentInterface {
     }
 
     virtual void
-    LazyCheckSchema(SchemaPtr sch) = 0;
+    LazyCheckSchema(SchemaPtr sch, milvus::OpContext* op_ctx) = 0;
 
     // reopen segment with new schema
     virtual void

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -627,62 +627,89 @@ SegmentLoadInfo::ComputeDiffReloadFields(LoadDiff& diff,
     }
 }
 
-void
-SegmentLoadInfo::ComputeDiffDefaultFields(LoadDiff& diff,
-                                          SegmentLoadInfo& new_info) {
-    // Helper lambda to collect all field ids with data source
-    auto collect_data_fields = [](SegmentLoadInfo& info) -> std::set<FieldId> {
-        std::set<FieldId> fields;
+std::set<FieldId>
+SegmentLoadInfo::CollectDataFields() const {
+    std::set<FieldId> fields;
 
-        // From binlog paths
-        for (int i = 0; i < info.GetBinlogPathCount(); i++) {
-            auto& binlog = info.GetBinlogPath(i);
-            std::vector<int64_t> child_fields(binlog.child_fields().begin(),
-                                              binlog.child_fields().end());
-            if (child_fields.empty()) {
-                child_fields.emplace_back(binlog.fieldid());
-            }
-            for (auto child_id : child_fields) {
-                fields.emplace(child_id);
-            }
+    for (int i = 0; i < GetBinlogPathCount(); i++) {
+        auto& binlog = GetBinlogPath(i);
+        std::vector<int64_t> child_fields(binlog.child_fields().begin(),
+                                          binlog.child_fields().end());
+        if (child_fields.empty()) {
+            child_fields.emplace_back(binlog.fieldid());
         }
-
-        // From index with raw data
-        for (const auto& field_id : info.field_index_has_raw_data_) {
-            fields.insert(field_id);
+        for (auto child_id : child_fields) {
+            fields.emplace(child_id);
         }
+    }
 
-        // From column groups (manifest mode)
-        if (info.HasManifestPath()) {
-            auto column_groups = info.GetColumnGroups();
-            if (column_groups) {
-                for (size_t i = 0; i < column_groups->size(); i++) {
-                    auto cg = column_groups->at(i);
-                    for (const auto& column : cg->columns) {
-                        fields.emplace(std::stoll(column));
-                    }
+    for (const auto& field_id : field_index_has_raw_data_) {
+        fields.insert(field_id);
+    }
+
+    if (HasManifestPath()) {
+        auto column_groups = GetColumnGroups();
+        if (column_groups) {
+            for (size_t i = 0; i < column_groups->size(); i++) {
+                auto cg = column_groups->at(i);
+                for (const auto& column : cg->columns) {
+                    fields.emplace(std::stoll(column));
                 }
             }
         }
-        return fields;
-    };
-
-    // Collect field ids with data source
-    std::set<FieldId> new_info_fields = collect_data_fields(new_info);
-    std::set<FieldId> current_fields = collect_data_fields(*this);
-
-    new_info.fields_filled_with_default_ = fields_filled_with_default_;
-    for (const auto& field_id : new_info_fields) {
-        new_info.fields_filled_with_default_.erase(field_id);
     }
-    for (auto it = new_info.fields_filled_with_default_.begin();
-         it != new_info.fields_filled_with_default_.end();) {
-        if (!new_info.HasFieldInSchema(*it)) {
-            it = new_info.fields_filled_with_default_.erase(it);
-        } else {
-            ++it;
+    return fields;
+}
+
+std::set<FieldId>
+SegmentLoadInfo::GetDefaultFilledFieldsForNewInfo(
+    const SegmentLoadInfo& new_info) const {
+    auto new_info_fields = new_info.CollectDataFields();
+    std::set<FieldId> fields;
+    for (const auto& field_id : fields_filled_with_default_) {
+        if (!new_info.HasFieldInSchema(field_id)) {
+            continue;
         }
+        if (new_info_fields.count(field_id) > 0) {
+            continue;
+        }
+        fields.insert(field_id);
     }
+    return fields;
+}
+
+std::vector<FieldId>
+SegmentLoadInfo::GetFieldsToFillDefaultForSchema(
+    const SchemaPtr& new_schema) const {
+    if (!new_schema || schema_->is_external_collection() ||
+        new_schema->is_external_collection()) {
+        return {};
+    }
+
+    auto data_fields = CollectDataFields();
+    std::set<FieldId> handled = data_fields;
+    handled.insert(fields_filled_with_default_.begin(),
+                   fields_filled_with_default_.end());
+
+    std::vector<FieldId> fields;
+    for (const auto& field_entry : new_schema->get_fields()) {
+        const auto& field_id = field_entry.first;
+        if (field_id.get() < START_USER_FIELDID) {
+            continue;
+        }
+        if (handled.count(field_id) > 0) {
+            continue;
+        }
+        fields.push_back(field_id);
+    }
+    return fields;
+}
+
+void
+SegmentLoadInfo::ComputeDiffDefaultFields(LoadDiff& diff,
+                                          SegmentLoadInfo& new_info) {
+    std::set<FieldId> new_info_fields = new_info.CollectDataFields();
+    std::set<FieldId> current_fields = CollectDataFields();
 
     // Build "current handled" set:
     // - Fields with data source in current
@@ -702,12 +729,10 @@ SegmentLoadInfo::ComputeDiffDefaultFields(LoadDiff& diff,
         }
 
         if (current_handled.count(field_id)) {
-            new_info.fields_filled_with_default_.insert(field_id);
             continue;
         }
 
         diff.fields_to_fill_default.push_back(field_id);
-        new_info.fields_filled_with_default_.insert(field_id);
     }
 }
 

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -664,6 +664,11 @@ SegmentLoadInfo::CollectDataFields() const {
 std::set<FieldId>
 SegmentLoadInfo::GetDefaultFilledFieldsForNewInfo(
     const SegmentLoadInfo& new_info) const {
+    if (schema_->is_external_collection() ||
+        new_info.schema_->is_external_collection()) {
+        return {};
+    }
+
     auto new_info_fields = new_info.CollectDataFields();
     std::set<FieldId> fields;
     for (const auto& field_id : fields_filled_with_default_) {
@@ -674,33 +679,6 @@ SegmentLoadInfo::GetDefaultFilledFieldsForNewInfo(
             continue;
         }
         fields.insert(field_id);
-    }
-    return fields;
-}
-
-std::vector<FieldId>
-SegmentLoadInfo::GetFieldsToFillDefaultForSchema(
-    const SchemaPtr& new_schema) const {
-    if (!new_schema || schema_->is_external_collection() ||
-        new_schema->is_external_collection()) {
-        return {};
-    }
-
-    auto data_fields = CollectDataFields();
-    std::set<FieldId> handled = data_fields;
-    handled.insert(fields_filled_with_default_.begin(),
-                   fields_filled_with_default_.end());
-
-    std::vector<FieldId> fields;
-    for (const auto& field_entry : new_schema->get_fields()) {
-        const auto& field_id = field_entry.first;
-        if (field_id.get() < START_USER_FIELDID) {
-            continue;
-        }
-        if (handled.count(field_id) > 0) {
-            continue;
-        }
-        fields.push_back(field_id);
     }
     return fields;
 }

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -671,6 +671,19 @@ SegmentLoadInfo::ComputeDiffDefaultFields(LoadDiff& diff,
     std::set<FieldId> new_info_fields = collect_data_fields(new_info);
     std::set<FieldId> current_fields = collect_data_fields(*this);
 
+    new_info.fields_filled_with_default_ = fields_filled_with_default_;
+    for (const auto& field_id : new_info_fields) {
+        new_info.fields_filled_with_default_.erase(field_id);
+    }
+    for (auto it = new_info.fields_filled_with_default_.begin();
+         it != new_info.fields_filled_with_default_.end();) {
+        if (!new_info.HasFieldInSchema(*it)) {
+            it = new_info.fields_filled_with_default_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
     // Build "current handled" set:
     // - Fields with data source in current
     // - Fields already filled with default values

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -420,6 +420,7 @@ class SegmentLoadInfo {
         : info_(other.info_),
           schema_(other.schema_),
           column_groups_(other.column_groups_),
+          fields_filled_with_default_(other.fields_filled_with_default_),
           created_text_indexes_(other.created_text_indexes_) {
         BuildCache();
     }
@@ -435,6 +436,8 @@ class SegmentLoadInfo {
               std::move(other.converted_field_index_cache_)),
           field_binlog_cache_(std::move(other.field_binlog_cache_)),
           column_groups_(std::move(other.column_groups_)),
+          fields_filled_with_default_(
+              std::move(other.fields_filled_with_default_)),
           created_text_indexes_(std::move(other.created_text_indexes_)) {
     }
 
@@ -448,6 +451,7 @@ class SegmentLoadInfo {
             info_ = other.info_;
             schema_ = other.schema_;
             column_groups_ = other.column_groups_;
+            fields_filled_with_default_ = other.fields_filled_with_default_;
             created_text_indexes_ = other.created_text_indexes_;
             BuildCache();
         }
@@ -467,6 +471,8 @@ class SegmentLoadInfo {
                 std::move(other.converted_field_index_cache_);
             field_binlog_cache_ = std::move(other.field_binlog_cache_);
             column_groups_ = std::move(other.column_groups_);
+            fields_filled_with_default_ =
+                std::move(other.fields_filled_with_default_);
             created_text_indexes_ = std::move(other.created_text_indexes_);
         }
         return *this;
@@ -881,6 +887,40 @@ class SegmentLoadInfo {
         return info_.jsonkeystatslogs();
     }
 
+    // ==================== Default-Filled Fields Tracking ====================
+
+    void
+    SetFieldFilledWithDefault(FieldId field_id) {
+        fields_filled_with_default_.insert(field_id);
+    }
+
+    void
+    ClearFieldFilledWithDefault(FieldId field_id) {
+        fields_filled_with_default_.erase(field_id);
+    }
+
+    [[nodiscard]] bool
+    IsFieldFilledWithDefault(FieldId field_id) const {
+        return fields_filled_with_default_.find(field_id) !=
+               fields_filled_with_default_.end();
+    }
+
+    [[nodiscard]] const std::set<FieldId>&
+    GetFieldsFilledWithDefault() const {
+        return fields_filled_with_default_;
+    }
+
+    void
+    SetFieldsFilledWithDefault(const std::set<FieldId>& field_ids) {
+        fields_filled_with_default_ = field_ids;
+    }
+
+    [[nodiscard]] std::set<FieldId>
+    GetDefaultFilledFieldsForNewInfo(const SegmentLoadInfo& new_info) const;
+
+    [[nodiscard]] std::vector<FieldId>
+    GetFieldsToFillDefaultForSchema(const SchemaPtr& new_schema) const;
+
     // ==================== Created Text Indexes Tracking ====================
 
     void
@@ -1086,6 +1126,9 @@ class SegmentLoadInfo {
 
     void
     ComputeDiffJsonKeyStats(LoadDiff& diff, SegmentLoadInfo& new_info);
+
+    [[nodiscard]] std::set<FieldId>
+    CollectDataFields() const;
 
     ProtoType info_;
 

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -434,10 +434,11 @@ class SegmentLoadInfo {
           converted_index_infos_(std::move(other.converted_index_infos_)),
           converted_field_index_cache_(
               std::move(other.converted_field_index_cache_)),
-          field_binlog_cache_(std::move(other.field_binlog_cache_)),
-          column_groups_(std::move(other.column_groups_)),
+          field_index_has_raw_data_(std::move(other.field_index_has_raw_data_)),
           fields_filled_with_default_(
               std::move(other.fields_filled_with_default_)),
+          field_binlog_cache_(std::move(other.field_binlog_cache_)),
+          column_groups_(std::move(other.column_groups_)),
           created_text_indexes_(std::move(other.created_text_indexes_)) {
     }
 
@@ -469,10 +470,12 @@ class SegmentLoadInfo {
             converted_index_infos_ = std::move(other.converted_index_infos_);
             converted_field_index_cache_ =
                 std::move(other.converted_field_index_cache_);
-            field_binlog_cache_ = std::move(other.field_binlog_cache_);
-            column_groups_ = std::move(other.column_groups_);
+            field_index_has_raw_data_ =
+                std::move(other.field_index_has_raw_data_);
             fields_filled_with_default_ =
                 std::move(other.fields_filled_with_default_);
+            field_binlog_cache_ = std::move(other.field_binlog_cache_);
+            column_groups_ = std::move(other.column_groups_);
             created_text_indexes_ = std::move(other.created_text_indexes_);
         }
         return *this;
@@ -917,9 +920,6 @@ class SegmentLoadInfo {
 
     [[nodiscard]] std::set<FieldId>
     GetDefaultFilledFieldsForNewInfo(const SegmentLoadInfo& new_info) const;
-
-    [[nodiscard]] std::vector<FieldId>
-    GetFieldsToFillDefaultForSchema(const SchemaPtr& new_schema) const;
 
     // ==================== Created Text Indexes Tracking ====================
 

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -1073,6 +1073,72 @@ TEST_F(SegmentLoadInfoTest, LoadDiffHasChangesWithDefaultFields) {
     EXPECT_TRUE(diff.HasChanges());
 }
 
+TEST_F(SegmentLoadInfoTest, CopyPreservesDefaultFilledFields) {
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* current_binlog = current_proto.add_binlog_paths();
+    current_binlog->set_fieldid(100);
+    auto* current_log = current_binlog->add_binlogs();
+    current_log->set_log_path("/path/to/pk");
+    current_log->set_entries_num(1000);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    current_info.SetFieldFilledWithDefault(FieldId(101));
+
+    SegmentLoadInfo copied(current_info);
+    EXPECT_TRUE(copied.IsFieldFilledWithDefault(FieldId(101)));
+
+    proto::segcore::SegmentLoadInfo new_proto = current_proto;
+    auto* new_binlog = new_proto.add_binlog_paths();
+    new_binlog->set_fieldid(101);
+    auto* new_log = new_binlog->add_binlogs();
+    new_log->set_log_path("/path/to/field101");
+    new_log->set_entries_num(1000);
+
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = copied.ComputeDiff(new_info);
+
+    bool found_replace = false;
+    for (const auto& [field_ids, binlog] : diff.binlogs_to_replace) {
+        (void)binlog;
+        for (auto field_id : field_ids) {
+            found_replace = found_replace || field_id == FieldId(101);
+        }
+    }
+    EXPECT_TRUE(found_replace);
+}
+
+TEST_F(SegmentLoadInfoTest,
+       ComputeDiffClearsDefaultFilledWhenDataSourceAppears) {
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* current_binlog = current_proto.add_binlog_paths();
+    current_binlog->set_fieldid(100);
+    auto* current_log = current_binlog->add_binlogs();
+    current_log->set_log_path("/path/to/pk");
+    current_log->set_entries_num(1000);
+
+    SegmentLoadInfo current_info(current_proto, schema_);
+    current_info.SetFieldFilledWithDefault(FieldId(101));
+
+    proto::segcore::SegmentLoadInfo new_proto = current_proto;
+    auto* field_binlog = new_proto.add_binlog_paths();
+    field_binlog->set_fieldid(101);
+    auto* field_log = field_binlog->add_binlogs();
+    field_log->set_log_path("/path/to/field101");
+    field_log->set_entries_num(1000);
+
+    SegmentLoadInfo new_info(new_proto, schema_);
+    auto diff = current_info.ComputeDiff(new_info);
+
+    for (const auto& field_id : diff.fields_to_fill_default) {
+        EXPECT_NE(field_id, FieldId(101));
+    }
+    EXPECT_FALSE(new_info.IsFieldFilledWithDefault(FieldId(101)));
+}
+
 // ==================== Text Index Tests ====================
 
 // Helper: create a schema with varchar field that has enable_match=true
@@ -2804,6 +2870,40 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffDropsManifestFieldRemovedFromSchema) {
     EXPECT_TRUE(diff.column_groups_to_replace.empty());
     EXPECT_TRUE(diff.column_groups_to_lazyload.empty());
     EXPECT_TRUE(diff.column_groups_to_lazyreplace.empty());
+}
+
+TEST_F(SegmentLoadInfoTest, SchemaReopenLoadsNewFieldWithBinlog) {
+    proto::segcore::SegmentLoadInfo current_proto;
+    current_proto.set_segmentid(100);
+    current_proto.set_num_of_rows(1000);
+    auto* current_binlog = current_proto.add_binlog_paths();
+    current_binlog->set_fieldid(100);
+    auto* current_log = current_binlog->add_binlogs();
+    current_log->set_log_path("/path/to/pk");
+    current_log->set_entries_num(1000);
+
+    proto::segcore::SegmentLoadInfo new_proto = current_proto;
+    auto* field_binlog = new_proto.add_binlog_paths();
+    field_binlog->set_fieldid(101);
+    auto* field_log = field_binlog->add_binlogs();
+    field_log->set_log_path("/path/to/field101");
+    field_log->set_entries_num(1000);
+
+    SegmentLoadInfo current_info(current_proto, MakeSchemaWithFieldIds({100}));
+    SegmentLoadInfo new_info(new_proto, MakeSchemaWithFieldIds({100, 101}));
+    auto diff = current_info.ComputeDiff(new_info);
+
+    bool found_load = false;
+    for (const auto& [field_ids, binlog] : diff.binlogs_to_load) {
+        (void)binlog;
+        for (auto field_id : field_ids) {
+            found_load = found_load || field_id == FieldId(101);
+        }
+    }
+    EXPECT_TRUE(found_load);
+    for (auto field_id : diff.fields_to_fill_default) {
+        EXPECT_NE(field_id, FieldId(101));
+    }
 }
 
 TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFieldsUsesNewSchema) {

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -836,8 +836,10 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffNoChangesLegacyFormat) {
     log->set_entries_num(500);
 
     SegmentLoadInfo current_info(proto, schema_);
-    // calculate first diff to set default value fields
     auto diff = current_info.GetLoadDiff();
+    for (const auto& field_id : diff.fields_to_fill_default) {
+        current_info.SetFieldFilledWithDefault(field_id);
+    }
     SegmentLoadInfo new_info(proto, schema_);
     diff = current_info.ComputeDiff(new_info);
 
@@ -912,16 +914,18 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFieldsSkipAlreadyFilled) {
 
     // Verify fields were added to fields_to_fill_default
     EXPECT_FALSE(first_diff.fields_to_fill_default.empty());
-    // Second diff: first_new_info -> same proto (simulates reopen)
-    // first_new_info should now have fields_filled_with_default_ populated
+    for (const auto& field_id : first_diff.fields_to_fill_default) {
+        first_new_info.SetFieldFilledWithDefault(field_id);
+    }
+
     SegmentLoadInfo second_new_info(proto, schema_);
     auto second_diff = first_new_info.ComputeDiff(second_new_info);
 
     // All previously filled fields should be skipped
     EXPECT_TRUE(second_diff.fields_to_fill_default.empty());
 
-    // Verify that second_new_info inherited the filled status
-    // by doing a third diff
+    second_new_info.SetFieldsFilledWithDefault(
+        first_new_info.GetDefaultFilledFieldsForNewInfo(second_new_info));
     SegmentLoadInfo third_new_info(proto, schema_);
     auto third_diff = second_new_info.ComputeDiff(third_new_info);
     EXPECT_TRUE(third_diff.fields_to_fill_default.empty());
@@ -2033,8 +2037,10 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffBinlogNoReplace) {
     log->set_entries_num(500);
 
     SegmentLoadInfo current_info(proto, schema_);
-    // First GetLoadDiff to initialize default fields
     auto first_diff = current_info.GetLoadDiff();
+    for (const auto& field_id : first_diff.fields_to_fill_default) {
+        current_info.SetFieldFilledWithDefault(field_id);
+    }
 
     SegmentLoadInfo new_info(proto, schema_);
     auto diff = current_info.ComputeDiff(new_info);
@@ -2110,9 +2116,11 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFilledFieldBecomesReplace) {
     log1->set_entries_num(1000);
 
     SegmentLoadInfo current_info(initial_proto, schema_);
-    // GetLoadDiff populates fields_filled_with_default_ for fields 101-110
     auto initial_diff = current_info.GetLoadDiff();
     EXPECT_FALSE(initial_diff.fields_to_fill_default.empty());
+    for (const auto& field_id : initial_diff.fields_to_fill_default) {
+        current_info.SetFieldFilledWithDefault(field_id);
+    }
 
     // Step 2: New LoadInfo adds binlog for field 101 (was default-filled)
     proto::segcore::SegmentLoadInfo new_proto;
@@ -2484,7 +2492,10 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffNoReloadWhenIndexStaysRaw) {
     param->set_value(milvus::index::ASCENDING_SORT);
 
     SegmentLoadInfo current_info(proto, schema_);
-    (void)current_info.GetLoadDiff();
+    auto initial_diff = current_info.GetLoadDiff();
+    for (const auto& field_id : initial_diff.fields_to_fill_default) {
+        current_info.SetFieldFilledWithDefault(field_id);
+    }
     SegmentLoadInfo new_info(proto, schema_);
     auto diff = current_info.ComputeDiff(new_info);
 

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -1113,6 +1113,43 @@ TEST_F(SegmentLoadInfoTest, CopyPreservesDefaultFilledFields) {
     EXPECT_TRUE(found_replace);
 }
 
+TEST_F(SegmentLoadInfoTest, MovePreservesRawDataIndexFieldsForDefaultDiff) {
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+    auto* binlog = proto.add_binlog_paths();
+    binlog->set_fieldid(100);
+    auto* log = binlog->add_binlogs();
+    log->set_log_path("/path/to/pk");
+    log->set_entries_num(1000);
+
+    auto* index_info = proto.add_index_infos();
+    index_info->set_fieldid(101);
+    index_info->set_indexid(1001);
+    index_info->add_index_file_paths("/path/to/index");
+    auto* index_param = index_info->add_index_params();
+    index_param->set_key("index_type");
+    index_param->set_value(knowhere::IndexEnum::INDEX_FAISS_IDMAP);
+
+    auto assert_field_101_has_data = [](SegmentLoadInfo& info) {
+        auto diff = info.GetLoadDiff();
+        EXPECT_TRUE(diff.indexes_to_load.count(FieldId(101)) > 0);
+        for (const auto& field_id : diff.fields_to_fill_default) {
+            EXPECT_NE(field_id, FieldId(101));
+        }
+    };
+
+    SegmentLoadInfo original(proto, schema_);
+    SegmentLoadInfo moved(std::move(original));
+    assert_field_101_has_data(moved);
+
+    SegmentLoadInfo original_for_assignment(proto, schema_);
+    proto::segcore::SegmentLoadInfo empty_proto;
+    SegmentLoadInfo assigned(empty_proto, schema_);
+    assigned = std::move(original_for_assignment);
+    assert_field_101_has_data(assigned);
+}
+
 TEST_F(SegmentLoadInfoTest,
        ComputeDiffClearsDefaultFilledWhenDataSourceAppears) {
     proto::segcore::SegmentLoadInfo current_proto;
@@ -3017,6 +3054,7 @@ TEST_F(SegmentLoadInfoTest,
 
     SegmentLoadInfo current_info(MakeManifestProto("/manifest/v1"), schema_);
     current_info.SetColumnGroupsForTesting(current_cgs);
+    current_info.SetFieldFilledWithDefault(FieldId(101));
     SegmentLoadInfo new_info(MakeManifestProto("/manifest/v2"), schema_);
     new_info.SetColumnGroupsForTesting(new_cgs);
 
@@ -3029,6 +3067,13 @@ TEST_F(SegmentLoadInfoTest,
     EXPECT_TRUE(diff.column_groups_to_replace.empty());
     EXPECT_TRUE(diff.column_groups_to_lazyload.empty());
     EXPECT_TRUE(diff.column_groups_to_lazyreplace.empty());
+
+    std::set<FieldId> default_fields;
+    EXPECT_NO_THROW({
+        default_fields =
+            current_info.GetDefaultFilledFieldsForNewInfo(new_info);
+    });
+    EXPECT_TRUE(default_fields.empty());
 }
 
 TEST_F(SegmentLoadInfoTest,

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -223,11 +223,7 @@ AsyncReopenSegment(CTraceContext c_trace,
          schema = std::move(schema)](
             folly::CancellationToken cancel_token) -> bool* {
             milvus::OpContext op_ctx(cancel_token);
-            if (schema) {
-                segment->Reopen(&op_ctx, load_info, schema);
-            } else {
-                segment->Reopen(&op_ctx, load_info);
-            }
+            segment->Reopen(&op_ctx, load_info, schema);
             return nullptr;
         },
         milvus::futures::PoolType::kLoad);

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -206,29 +206,49 @@ AsyncReopenSegment(CTraceContext c_trace,
                    const void* schema_blob,
                    const int64_t schema_length,
                    const uint64_t schema_version) {
-    AssertInfo(load_info_blob, "load info is null");
-    milvus::proto::segcore::SegmentLoadInfo load_info;
-    auto suc = load_info.ParseFromArray(load_info_blob, load_info_length);
-    AssertInfo(suc, "unmarshal load info failed");
-    auto schema = ParseReopenSchema(schema_blob, schema_length, schema_version);
+    try {
+        AssertInfo(load_info_blob, "load info is null");
+        milvus::proto::segcore::SegmentLoadInfo load_info;
+        auto suc = load_info.ParseFromArray(load_info_blob, load_info_length);
+        AssertInfo(suc, "unmarshal load info failed");
+        auto schema =
+            ParseReopenSchema(schema_blob, schema_length, schema_version);
 
-    auto segment = static_cast<milvus::segcore::SegmentInterface*>(c_segment);
+        auto segment =
+            static_cast<milvus::segcore::SegmentInterface*>(c_segment);
 
-    auto future = milvus::futures::Future<bool>::async(
-        milvus::futures::getLoadCPUExecutor(),
-        milvus::futures::ExecutePriority::NORMAL,
-        [c_trace,
-         segment,
-         load_info = std::move(load_info),
-         schema = std::move(schema)](
-            folly::CancellationToken cancel_token) -> bool* {
-            milvus::OpContext op_ctx(cancel_token);
-            segment->Reopen(&op_ctx, load_info, schema);
-            return nullptr;
-        },
-        milvus::futures::PoolType::kLoad);
-    return static_cast<CFuture*>(static_cast<void*>(
-        static_cast<milvus::futures::IFuture*>(future.release())));
+        auto future = milvus::futures::Future<bool>::async(
+            milvus::futures::getLoadCPUExecutor(),
+            milvus::futures::ExecutePriority::NORMAL,
+            [c_trace,
+             segment,
+             load_info = std::move(load_info),
+             schema = std::move(schema)](
+                folly::CancellationToken cancel_token) -> bool* {
+                milvus::OpContext op_ctx(cancel_token);
+                segment->Reopen(&op_ctx, load_info, schema);
+                return nullptr;
+            },
+            milvus::futures::PoolType::kLoad);
+        return static_cast<CFuture*>(static_cast<void*>(
+            static_cast<milvus::futures::IFuture*>(future.release())));
+    } catch (std::exception& e) {
+        std::string error_msg = e.what();
+        auto future = milvus::futures::Future<bool>::async(
+            milvus::futures::getLoadCPUExecutor(),
+            milvus::futures::ExecutePriority::NORMAL,
+            [error_msg = std::move(error_msg)](
+                folly::CancellationToken cancel_token) -> bool* {
+                (void)cancel_token;
+                ThrowInfo(milvus::UnexpectedError,
+                          "AsyncReopenSegment preflight failed: {}",
+                          error_msg);
+                return nullptr;
+            },
+            milvus::futures::PoolType::kLoad);
+        return static_cast<CFuture*>(static_cast<void*>(
+            static_cast<milvus::futures::IFuture*>(future.release())));
+    }
 }
 
 CLoadCancellationSource
@@ -370,7 +390,8 @@ AsyncSearch(CTraceContext c_trace,
             auto span = milvus::tracer::StartSpan("SegCoreSearch", &trace_ctx);
             milvus::tracer::SetRootSpan(span);
 
-            segment->LazyCheckSchema(plan->schema_);
+            milvus::OpContext op_ctx(cancel_token);
+            segment->LazyCheckSchema(plan->schema_, &op_ctx);
 
             auto search_result = segment->Search(plan,
                                                  phg_ptr,
@@ -453,7 +474,8 @@ AsyncRetrieve(CTraceContext c_trace,
                 c_trace.traceID, c_trace.spanID, c_trace.traceFlags};
             milvus::tracer::AutoSpan span("SegCoreRetrieve", &trace_ctx, true);
 
-            segment->LazyCheckSchema(plan->schema_);
+            milvus::OpContext op_ctx(cancel_token);
+            segment->LazyCheckSchema(plan->schema_, &op_ctx);
 
             auto retrieve_result =
                 segment->Retrieve(&trace_ctx,

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -183,25 +183,51 @@ NewSegmentWithLoadInfo(CCollection collection,
     }
 }
 
+milvus::SchemaPtr
+ParseReopenSchema(const void* schema_blob,
+                  const int64_t schema_length,
+                  const uint64_t schema_version) {
+    AssertInfo(schema_blob != nullptr, "schema is null");
+    AssertInfo(schema_length > 0, "schema length must be positive");
+
+    milvus::proto::schema::CollectionSchema collection_schema;
+    auto suc = collection_schema.ParseFromArray(schema_blob, schema_length);
+    AssertInfo(suc, "parse schema proto failed");
+    auto schema = milvus::Schema::ParseFrom(collection_schema);
+    schema->set_schema_version(schema_version);
+    return schema;
+}
+
 CFuture*
 AsyncReopenSegment(CTraceContext c_trace,
                    CSegmentInterface c_segment,
                    const uint8_t* load_info_blob,
-                   const int64_t load_info_length) {
+                   const int64_t load_info_length,
+                   const void* schema_blob,
+                   const int64_t schema_length,
+                   const uint64_t schema_version) {
     AssertInfo(load_info_blob, "load info is null");
     milvus::proto::segcore::SegmentLoadInfo load_info;
     auto suc = load_info.ParseFromArray(load_info_blob, load_info_length);
     AssertInfo(suc, "unmarshal load info failed");
+    auto schema = ParseReopenSchema(schema_blob, schema_length, schema_version);
 
     auto segment = static_cast<milvus::segcore::SegmentInterface*>(c_segment);
 
     auto future = milvus::futures::Future<bool>::async(
         milvus::futures::getLoadCPUExecutor(),
         milvus::futures::ExecutePriority::NORMAL,
-        [c_trace, segment, load_info = std::move(load_info)](
+        [c_trace,
+         segment,
+         load_info = std::move(load_info),
+         schema = std::move(schema)](
             folly::CancellationToken cancel_token) -> bool* {
             milvus::OpContext op_ctx(cancel_token);
-            segment->Reopen(&op_ctx, load_info);
+            if (schema) {
+                segment->Reopen(&op_ctx, load_info, schema);
+            } else {
+                segment->Reopen(&op_ctx, load_info);
+            }
             return nullptr;
         },
         milvus::futures::PoolType::kLoad);

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -514,6 +514,9 @@ AsyncRetrieveByOffsets(CTraceContext c_trace,
             milvus::tracer::AutoSpan span(
                 "SegCoreRetrieveByOffsets", &trace_ctx, true);
 
+            milvus::OpContext op_ctx(cancel_token);
+            segment->LazyCheckSchema(plan->schema_, &op_ctx);
+
             auto retrieve_result =
                 segment->Retrieve(&trace_ctx, plan, offsets, len, cancel_token);
 

--- a/internal/core/src/segcore/segment_c.h
+++ b/internal/core/src/segcore/segment_c.h
@@ -115,18 +115,30 @@ CFuture*
 AsyncSegmentLoad(CTraceContext c_trace, CSegmentInterface c_segment);
 
 /**
- * @brief Async reopen segment using Future mechanism with built-in cancellation
- * @param c_trace: tracing context param
- * @param c_segment: segment handle to reopen
- * @param load_info_blob: serialized SegmentLoadInfo protobuf message
- * @param load_info_length: length of load_info_blob in bytes
+ * @brief Async reopen segment using Future mechanism with built-in cancellation.
+ *
+ * Reopen applies a new SegmentLoadInfo and the latest collection schema.
+ * schema_blob/schema_length are required so sealed segments compute LoadDiff
+ * against the new schema and handle schema changes through the same load-diff
+ * framework as manifest/binlog/index updates.
+ *
+ * @param c_trace tracing context param
+ * @param c_segment segment handle to reopen
+ * @param load_info_blob serialized SegmentLoadInfo protobuf message
+ * @param load_info_length length of load_info_blob in bytes
+ * @param schema_blob serialized CollectionSchema protobuf message; must not be null
+ * @param schema_length length of schema_blob in bytes; must be positive
+ * @param schema_version schema version assigned to the parsed schema
  * @return CFuture* that resolves when reopen completes (result pointer is nullptr)
  */
 CFuture*
 AsyncReopenSegment(CTraceContext c_trace,
                    CSegmentInterface c_segment,
                    const uint8_t* load_info_blob,
-                   const int64_t load_info_length);
+                   const int64_t load_info_length,
+                   const void* schema_blob,
+                   const int64_t schema_length,
+                   const uint64_t schema_version);
 
 void
 DeleteSegment(CSegmentInterface c_segment);

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -3174,6 +3174,41 @@ TEST(SealedSegmentReopen, SchemaOnlyReopenPublishesDefaultFilledState) {
     EXPECT_TRUE(snapshot->IsFieldFilledWithDefault(FieldId(101)));
 }
 
+TEST(SealedSegmentReopen, SchemaAwareReopenDiscardsOlderSchema) {
+    auto old_schema = std::make_shared<Schema>();
+    auto pk_id = old_schema->AddDebugField("pk", DataType::INT64);
+    old_schema->set_primary_field_id(pk_id);
+    old_schema->set_schema_version(100);
+
+    auto new_schema = std::make_shared<Schema>();
+    auto new_pk_id = new_schema->AddDebugField("pk", DataType::INT64);
+    auto new_field = new_schema->AddDebugField("new_field", DataType::INT64);
+    new_schema->set_primary_field_id(new_pk_id);
+    new_schema->set_schema_version(200);
+
+    auto stale_schema = std::make_shared<Schema>();
+    auto stale_pk_id = stale_schema->AddDebugField("pk", DataType::INT64);
+    stale_schema->set_primary_field_id(stale_pk_id);
+    stale_schema->set_schema_version(150);
+
+    auto dataset = DataGen(old_schema, 1);
+    auto segment = CreateSealedWithFieldDataLoaded(old_schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    EXPECT_NO_THROW(sealed->Reopen(new_schema));
+    ASSERT_TRUE(sealed->TestGetSegmentLoadInfo()->HasFieldInSchema(new_field));
+
+    proto::segcore::SegmentLoadInfo stale_proto =
+        sealed->TestGetSegmentLoadInfo()->GetProto();
+    milvus::OpContext op_ctx;
+    EXPECT_NO_THROW(sealed->Reopen(&op_ctx, stale_proto, stale_schema));
+
+    auto snapshot = sealed->TestGetSegmentLoadInfo();
+    EXPECT_TRUE(snapshot->HasFieldInSchema(new_field));
+    EXPECT_TRUE(sealed->HasFieldData(new_field));
+}
+
 TEST(SealedSegmentReopen, SchemaOnlyReopenPreservesCreatedTextIndexState) {
     std::map<std::string, std::string> analyzer_params;
     auto old_schema = std::make_shared<Schema>();

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -3174,6 +3174,51 @@ TEST(SealedSegmentReopen, SchemaOnlyReopenPublishesDefaultFilledState) {
     EXPECT_TRUE(snapshot->IsFieldFilledWithDefault(FieldId(101)));
 }
 
+TEST(SealedSegmentReopen, SchemaOnlyReopenPreservesCreatedTextIndexState) {
+    std::map<std::string, std::string> analyzer_params;
+    auto old_schema = std::make_shared<Schema>();
+    auto pk_id = old_schema->AddDebugField("pk", DataType::INT64);
+    auto text_fid = old_schema->AddDebugVarcharField(FieldName("text_field"),
+                                                     DataType::VARCHAR,
+                                                     /*max_length=*/65535,
+                                                     /*nullable=*/false,
+                                                     /*enable_match=*/true,
+                                                     /*enable_analyzer=*/true,
+                                                     analyzer_params,
+                                                     std::nullopt);
+    old_schema->set_primary_field_id(pk_id);
+    old_schema->set_schema_version(100);
+
+    auto new_schema = std::make_shared<Schema>();
+    auto new_pk_id = new_schema->AddDebugField("pk", DataType::INT64);
+    auto new_text_fid =
+        new_schema->AddDebugVarcharField(FieldName("text_field"),
+                                         DataType::VARCHAR,
+                                         /*max_length=*/65535,
+                                         /*nullable=*/false,
+                                         /*enable_match=*/true,
+                                         /*enable_analyzer=*/true,
+                                         analyzer_params,
+                                         std::nullopt);
+    new_schema->AddDebugField("new_field", DataType::INT64);
+    new_schema->set_primary_field_id(new_pk_id);
+    new_schema->set_schema_version(200);
+    ASSERT_EQ(text_fid, new_text_fid);
+
+    auto dataset = DataGen(old_schema, 1);
+    auto segment = CreateSealedWithFieldDataLoaded(old_schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    sealed->TestRecordTextIndexCreated(text_fid);
+    ASSERT_TRUE(
+        sealed->TestGetSegmentLoadInfo()->HasTextIndexCreated(text_fid));
+
+    EXPECT_NO_THROW(sealed->Reopen(new_schema));
+    EXPECT_TRUE(
+        sealed->TestGetSegmentLoadInfo()->HasTextIndexCreated(text_fid));
+}
+
 // Reproducer for issue #49076.
 //
 // Reopen on a sealed segment does:

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -3150,6 +3150,41 @@ TEST(SealedDropFieldData, PKFieldStillDropsBinlogIndex) {
     EXPECT_TRUE(segment->HasFieldData(pk_id));
 }
 
+TEST(SealedSegmentReopen, SchemaOnlyReopenPublishesDefaultFilledState) {
+    auto old_schema = std::make_shared<Schema>();
+    old_schema->AddDebugField("pk", DataType::INT64);
+    old_schema->set_primary_field_id(FieldId(100));
+    old_schema->set_schema_version(100);
+
+    auto new_schema = std::make_shared<Schema>();
+    new_schema->AddDebugField("pk", DataType::INT64);
+    new_schema->AddDebugField("new_field", DataType::INT64);
+    new_schema->set_primary_field_id(FieldId(100));
+    new_schema->set_schema_version(200);
+
+    auto segment = CreateSealedSegment(old_schema);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(50001);
+    proto.set_num_of_rows(1);
+    auto* pk_binlog = proto.add_binlog_paths();
+    pk_binlog->set_fieldid(100);
+    auto* pk_log = pk_binlog->add_binlogs();
+    pk_log->set_log_path("/path/to/pk");
+    pk_log->set_entries_num(1);
+    sealed->SetLoadInfo(proto);
+
+    try {
+        sealed->Reopen(new_schema);
+    } catch (...) {
+    }
+
+    auto snapshot = sealed->TestGetSegmentLoadInfo();
+    EXPECT_TRUE(snapshot->IsFieldFilledWithDefault(FieldId(101)));
+}
+
 // Reproducer for issue #49076.
 //
 // Reopen on a sealed segment does:

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -3162,24 +3162,13 @@ TEST(SealedSegmentReopen, SchemaOnlyReopenPublishesDefaultFilledState) {
     new_schema->set_primary_field_id(FieldId(100));
     new_schema->set_schema_version(200);
 
-    auto segment = CreateSealedSegment(old_schema);
+    auto dataset = DataGen(old_schema, 1);
+    auto segment = CreateSealedWithFieldDataLoaded(old_schema, dataset);
     auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
     ASSERT_NE(sealed, nullptr);
 
-    proto::segcore::SegmentLoadInfo proto;
-    proto.set_segmentid(50001);
-    proto.set_num_of_rows(1);
-    auto* pk_binlog = proto.add_binlog_paths();
-    pk_binlog->set_fieldid(100);
-    auto* pk_log = pk_binlog->add_binlogs();
-    pk_log->set_log_path("/path/to/pk");
-    pk_log->set_entries_num(1);
-    sealed->SetLoadInfo(proto);
-
-    try {
-        sealed->Reopen(new_schema);
-    } catch (...) {
-    }
+    EXPECT_NO_THROW(sealed->Reopen(new_schema));
+    EXPECT_TRUE(sealed->HasFieldData(FieldId(101)));
 
     auto snapshot = sealed->TestGetSegmentLoadInfo();
     EXPECT_TRUE(snapshot->IsFieldFilledWithDefault(FieldId(101)));

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -1489,6 +1489,14 @@ func (s *DelegatorSuite) ResetDelegator() {
 	s.Require().NoError(err)
 }
 
+func (s *DelegatorSuite) nextSchemaVersionLoadMeta() *querypb.LoadMetaInfo {
+	version := uint64(1)
+	if collection := s.manager.Collection.Get(s.collectionID); collection != nil {
+		version = collection.SchemaVersion() + 1
+	}
+	return &querypb.LoadMetaInfo{SchemaVersion: version}
+}
+
 func (s *DelegatorSuite) TestRunAnalyzer() {
 	ctx := context.Background()
 	s.TestCreateDelegatorWithFunction()
@@ -1500,13 +1508,23 @@ func (s *DelegatorSuite) TestRunAnalyzer() {
 	})
 
 	s.Run("normal analyer", func() {
-		s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
+		err := s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
 				{
-					FieldID:    100,
-					Name:       "text",
-					DataType:   schemapb.DataType_VarChar,
-					TypeParams: []*commonpb.KeyValuePair{{Key: "analyzer_params", Value: "{}"}},
+					FieldID:      103,
+					Name:         "id",
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+					AutoID:       true,
+				},
+				{
+					FieldID:  100,
+					Name:     "text",
+					DataType: schemapb.DataType_VarChar,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "256"},
+						{Key: "analyzer_params", Value: "{}"},
+					},
 				},
 				{
 					FieldID:  101,
@@ -1521,7 +1539,8 @@ func (s *DelegatorSuite) TestRunAnalyzer() {
 				OutputFieldNames: []string{"sparse"},
 				OutputFieldIds:   []int64{101},
 			}},
-		}, nil, &querypb.LoadMetaInfo{SchemaVersion: tsoutil.ComposeTSByTime(time.Now(), 0)})
+		}, nil, s.nextSchemaVersionLoadMeta())
+		s.Require().NoError(err)
 		s.ResetDelegator()
 
 		result, err := s.delegator.RunAnalyzer(ctx, &querypb.RunAnalyzerRequest{
@@ -1533,18 +1552,28 @@ func (s *DelegatorSuite) TestRunAnalyzer() {
 	})
 
 	s.Run("multi analyzer", func() {
-		s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
+		err := s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:      103,
+					Name:         "id",
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+					AutoID:       true,
+				},
 				{
 					FieldID:  100,
 					Name:     "text",
 					DataType: schemapb.DataType_VarChar,
-					TypeParams: []*commonpb.KeyValuePair{{Key: "multi_analyzer_params", Value: `{
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "256"},
+						{Key: "multi_analyzer_params", Value: `{
 						"by_field": "analyzer",
     					"analyzers": {
 							"default": {}
 						}
-					}`}},
+					}`},
+					},
 				},
 				{
 					FieldID:  101,
@@ -1552,9 +1581,10 @@ func (s *DelegatorSuite) TestRunAnalyzer() {
 					DataType: schemapb.DataType_SparseFloatVector,
 				},
 				{
-					FieldID:  102,
-					Name:     "analyzer",
-					DataType: schemapb.DataType_VarChar,
+					FieldID:    102,
+					Name:       "analyzer",
+					DataType:   schemapb.DataType_VarChar,
+					TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "256"}},
 				},
 			},
 			Functions: []*schemapb.FunctionSchema{{
@@ -1564,7 +1594,8 @@ func (s *DelegatorSuite) TestRunAnalyzer() {
 				OutputFieldNames: []string{"sparse"},
 				OutputFieldIds:   []int64{101},
 			}},
-		}, nil, &querypb.LoadMetaInfo{SchemaVersion: tsoutil.ComposeTSByTime(time.Now(), 0)})
+		}, nil, s.nextSchemaVersionLoadMeta())
+		s.Require().NoError(err)
 		s.ResetDelegator()
 
 		result, err := s.delegator.RunAnalyzer(ctx, &querypb.RunAnalyzerRequest{
@@ -1578,18 +1609,28 @@ func (s *DelegatorSuite) TestRunAnalyzer() {
 	})
 
 	s.Run("error multi analyzer but no analyzer name", func() {
-		s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
+		err := s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:      103,
+					Name:         "id",
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+					AutoID:       true,
+				},
 				{
 					FieldID:  100,
 					Name:     "text",
 					DataType: schemapb.DataType_VarChar,
-					TypeParams: []*commonpb.KeyValuePair{{Key: "multi_analyzer_params", Value: `{
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "256"},
+						{Key: "multi_analyzer_params", Value: `{
 						"by_field": "analyzer",
     					"analyzers": {
 							"default": {}
 						}
-					}`}},
+					}`},
+					},
 				},
 				{
 					FieldID:  101,
@@ -1597,9 +1638,10 @@ func (s *DelegatorSuite) TestRunAnalyzer() {
 					DataType: schemapb.DataType_SparseFloatVector,
 				},
 				{
-					FieldID:  102,
-					Name:     "analyzer",
-					DataType: schemapb.DataType_VarChar,
+					FieldID:    102,
+					Name:       "analyzer",
+					DataType:   schemapb.DataType_VarChar,
+					TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "256"}},
 				},
 			},
 			Functions: []*schemapb.FunctionSchema{{
@@ -1609,10 +1651,11 @@ func (s *DelegatorSuite) TestRunAnalyzer() {
 				OutputFieldNames: []string{"sparse"},
 				OutputFieldIds:   []int64{101},
 			}},
-		}, nil, &querypb.LoadMetaInfo{SchemaVersion: tsoutil.ComposeTSByTime(time.Now(), 0)})
+		}, nil, s.nextSchemaVersionLoadMeta())
+		s.Require().NoError(err)
 		s.ResetDelegator()
 
-		_, err := s.delegator.RunAnalyzer(ctx, &querypb.RunAnalyzerRequest{
+		_, err = s.delegator.RunAnalyzer(ctx, &querypb.RunAnalyzerRequest{
 			FieldId:     100,
 			Placeholder: [][]byte{[]byte("test doc")},
 		})
@@ -1637,13 +1680,23 @@ func (s *DelegatorSuite) TestGetHighlight() {
 	})
 
 	s.Run("normal highlight with single analyzer", func() {
-		s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
+		err := s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
 				{
-					FieldID:    100,
-					Name:       "text",
-					DataType:   schemapb.DataType_VarChar,
-					TypeParams: []*commonpb.KeyValuePair{{Key: "analyzer_params", Value: "{}"}},
+					FieldID:      103,
+					Name:         "id",
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+					AutoID:       true,
+				},
+				{
+					FieldID:  100,
+					Name:     "text",
+					DataType: schemapb.DataType_VarChar,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "256"},
+						{Key: "analyzer_params", Value: "{}"},
+					},
 				},
 				{
 					FieldID:  101,
@@ -1658,7 +1711,8 @@ func (s *DelegatorSuite) TestGetHighlight() {
 				OutputFieldNames: []string{"sparse"},
 				OutputFieldIds:   []int64{101},
 			}},
-		}, nil, &querypb.LoadMetaInfo{SchemaVersion: tsoutil.ComposeTSByTime(time.Now(), 0)})
+		}, nil, s.nextSchemaVersionLoadMeta())
+		s.Require().NoError(err)
 		s.ResetDelegator()
 
 		result, err := s.delegator.GetHighlight(ctx, &querypb.GetHighlightRequest{
@@ -1680,19 +1734,29 @@ func (s *DelegatorSuite) TestGetHighlight() {
 	})
 
 	s.Run("highlight with multi analyzer", func() {
-		s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
+		err := s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:      103,
+					Name:         "id",
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+					AutoID:       true,
+				},
 				{
 					FieldID:  100,
 					Name:     "text",
 					DataType: schemapb.DataType_VarChar,
-					TypeParams: []*commonpb.KeyValuePair{{Key: "multi_analyzer_params", Value: `{
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "256"},
+						{Key: "multi_analyzer_params", Value: `{
 						"by_field": "analyzer",
     					"analyzers": {
 							"standard": {},
 							"default": {}
 						}
-					}`}},
+					}`},
+					},
 				},
 				{
 					FieldID:  101,
@@ -1700,9 +1764,10 @@ func (s *DelegatorSuite) TestGetHighlight() {
 					DataType: schemapb.DataType_SparseFloatVector,
 				},
 				{
-					FieldID:  102,
-					Name:     "analyzer",
-					DataType: schemapb.DataType_VarChar,
+					FieldID:    102,
+					Name:       "analyzer",
+					DataType:   schemapb.DataType_VarChar,
+					TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "256"}},
 				},
 			},
 			Functions: []*schemapb.FunctionSchema{{
@@ -1712,7 +1777,8 @@ func (s *DelegatorSuite) TestGetHighlight() {
 				OutputFieldNames: []string{"sparse"},
 				OutputFieldIds:   []int64{101},
 			}},
-		}, nil, &querypb.LoadMetaInfo{SchemaVersion: tsoutil.ComposeTSByTime(time.Now(), 0)})
+		}, nil, s.nextSchemaVersionLoadMeta())
+		s.Require().NoError(err)
 		s.ResetDelegator()
 
 		// two target with two analyzer
@@ -1733,13 +1799,23 @@ func (s *DelegatorSuite) TestGetHighlight() {
 	})
 
 	s.Run("empty target texts", func() {
-		s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
+		err := s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
 				{
-					FieldID:    100,
-					Name:       "text",
-					DataType:   schemapb.DataType_VarChar,
-					TypeParams: []*commonpb.KeyValuePair{{Key: "analyzer_params", Value: "{}"}},
+					FieldID:      103,
+					Name:         "id",
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+					AutoID:       true,
+				},
+				{
+					FieldID:  100,
+					Name:     "text",
+					DataType: schemapb.DataType_VarChar,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "256"},
+						{Key: "analyzer_params", Value: "{}"},
+					},
 				},
 				{
 					FieldID:  101,
@@ -1754,7 +1830,8 @@ func (s *DelegatorSuite) TestGetHighlight() {
 				OutputFieldNames: []string{"sparse"},
 				OutputFieldIds:   []int64{101},
 			}},
-		}, nil, &querypb.LoadMetaInfo{SchemaVersion: tsoutil.ComposeTSByTime(time.Now(), 0)})
+		}, nil, s.nextSchemaVersionLoadMeta())
+		s.Require().NoError(err)
 		s.ResetDelegator()
 
 		result, err := s.delegator.GetHighlight(ctx, &querypb.GetHighlightRequest{

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -92,11 +92,11 @@ func (m *collectionManager) PutOrRef(collectionID int64, schema *schemapb.Collec
 	m.mut.Lock()
 	defer m.mut.Unlock()
 	if collection, ok := m.collections[collectionID]; ok {
-		if loadMeta.GetSchemaVersion() > collection.schemaVersion {
+		if loadMeta.GetSchemaVersion() > collection.schemaVersion.Load() {
 			// the schema may be changed even the collection is loaded
 			collection.schema.Store(schema)
 			collection.ccollection.UpdateSchema(schema, loadMeta.GetSchemaVersion())
-			collection.schemaVersion = loadMeta.GetSchemaVersion()
+			collection.schemaVersion.Store(loadMeta.GetSchemaVersion())
 			log.Info("update collection schema",
 				zap.Int64("collectionID", collectionID),
 				zap.Uint64("schemaVersion", loadMeta.GetSchemaVersion()),
@@ -140,6 +140,7 @@ func (m *collectionManager) UpdateSchema(collectionID int64, schema *schemapb.Co
 		return err
 	}
 	collection.schema.Store(schema)
+	collection.schemaVersion.Store(version)
 	return nil
 }
 
@@ -200,7 +201,7 @@ type Collection struct {
 	schema        atomic.Pointer[schemapb.CollectionSchema]
 	isGpuIndex    bool
 	loadFields    typeutil.Set[int64]
-	schemaVersion uint64
+	schemaVersion *atomic.Uint64
 
 	refCount *atomic.Uint32
 }
@@ -232,6 +233,10 @@ func (c *Collection) GetCCollection() *segcore.CCollection {
 // Schema returns the schema of collection
 func (c *Collection) Schema() *schemapb.CollectionSchema {
 	return c.schema.Load()
+}
+
+func (c *Collection) SchemaVersion() uint64 {
+	return c.schemaVersion.Load()
 }
 
 // IsGpuIndex returns a boolean value indicating whether the collection is using a GPU index.
@@ -330,7 +335,7 @@ func NewCollection(collectionID int64, schema *schemapb.CollectionSchema, indexM
 		dbName:        loadMetaInfo.GetDbName(),
 		dbProperties:  loadMetaInfo.GetDbProperties(),
 		resourceGroup: loadMetaInfo.GetResourceGroup(),
-		schemaVersion: loadMetaInfo.GetSchemaVersion(),
+		schemaVersion: atomic.NewUint64(loadMetaInfo.GetSchemaVersion()),
 		refCount:      atomic.NewUint32(0),
 		isGpuIndex:    isGpuIndex,
 		loadFields:    loadFieldIDs,

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -92,11 +92,11 @@ func (m *collectionManager) PutOrRef(collectionID int64, schema *schemapb.Collec
 	m.mut.Lock()
 	defer m.mut.Unlock()
 	if collection, ok := m.collections[collectionID]; ok {
-		if loadMeta.GetSchemaVersion() > collection.schemaVersion.Load() {
-			// the schema may be changed even the collection is loaded
-			collection.schema.Store(schema)
-			collection.ccollection.UpdateSchema(schema, loadMeta.GetSchemaVersion())
-			collection.schemaVersion.Store(loadMeta.GetSchemaVersion())
+		if loadMeta.GetSchemaVersion() > collection.SchemaVersion() {
+			if err := collection.ccollection.UpdateSchema(schema, loadMeta.GetSchemaVersion()); err != nil {
+				return err
+			}
+			collection.setSchema(schema, loadMeta.GetSchemaVersion())
 			log.Info("update collection schema",
 				zap.Int64("collectionID", collectionID),
 				zap.Uint64("schemaVersion", loadMeta.GetSchemaVersion()),
@@ -139,8 +139,7 @@ func (m *collectionManager) UpdateSchema(collectionID int64, schema *schemapb.Co
 	if err := collection.ccollection.UpdateSchema(schema, version); err != nil {
 		return err
 	}
-	collection.schema.Store(schema)
-	collection.schemaVersion.Store(version)
+	collection.setSchema(schema, version)
 	return nil
 }
 
@@ -182,6 +181,11 @@ func (m *collectionManager) Unref(collectionID int64, count uint32) bool {
 	return true
 }
 
+type collectionSchemaSnapshot struct {
+	schema  *schemapb.CollectionSchema
+	version uint64
+}
+
 // Collection is a wrapper of the underlying C-structure C.CCollection
 // In a query node, `Collection` is a replica info of a collection in these query node.
 type Collection struct {
@@ -197,11 +201,10 @@ type Collection struct {
 	// but Collection in Manager will be released before assign new replica of new resource group on these node.
 	// so we don't need to update resource group in Collection.
 	// if resource group is not updated, the reference count of collection manager works failed.
-	metricType    atomic.String // deprecated
-	schema        atomic.Pointer[schemapb.CollectionSchema]
-	isGpuIndex    bool
-	loadFields    typeutil.Set[int64]
-	schemaVersion *atomic.Uint64
+	metricType atomic.String // deprecated
+	schema     atomic.Pointer[collectionSchemaSnapshot]
+	isGpuIndex bool
+	loadFields typeutil.Set[int64]
 
 	refCount *atomic.Uint32
 }
@@ -230,13 +233,27 @@ func (c *Collection) GetCCollection() *segcore.CCollection {
 	return c.ccollection
 }
 
+func (c *Collection) setSchema(schema *schemapb.CollectionSchema, version uint64) {
+	c.schema.Store(&collectionSchemaSnapshot{schema: schema, version: version})
+}
+
+func (c *Collection) SchemaAndVersion() (*schemapb.CollectionSchema, uint64) {
+	snapshot := c.schema.Load()
+	if snapshot == nil {
+		return nil, 0
+	}
+	return snapshot.schema, snapshot.version
+}
+
 // Schema returns the schema of collection
 func (c *Collection) Schema() *schemapb.CollectionSchema {
-	return c.schema.Load()
+	schema, _ := c.SchemaAndVersion()
+	return schema
 }
 
 func (c *Collection) SchemaVersion() uint64 {
-	return c.schemaVersion.Load()
+	_, version := c.SchemaAndVersion()
+	return version
 }
 
 // IsGpuIndex returns a boolean value indicating whether the collection is using a GPU index.
@@ -335,7 +352,6 @@ func NewCollection(collectionID int64, schema *schemapb.CollectionSchema, indexM
 		dbName:        loadMetaInfo.GetDbName(),
 		dbProperties:  loadMetaInfo.GetDbProperties(),
 		resourceGroup: loadMetaInfo.GetResourceGroup(),
-		schemaVersion: atomic.NewUint64(loadMetaInfo.GetSchemaVersion()),
 		refCount:      atomic.NewUint32(0),
 		isGpuIndex:    isGpuIndex,
 		loadFields:    loadFieldIDs,
@@ -343,7 +359,7 @@ func NewCollection(collectionID int64, schema *schemapb.CollectionSchema, indexM
 	for _, partitionID := range loadMetaInfo.GetPartitionIDs() {
 		coll.partitions.Insert(partitionID)
 	}
-	coll.schema.Store(schema)
+	coll.setSchema(schema, loadMetaInfo.GetSchemaVersion())
 
 	return coll, nil
 }
@@ -356,7 +372,7 @@ func NewTestCollection(collectionID int64, loadType querypb.LoadType, schema *sc
 		loadType:   loadType,
 		refCount:   atomic.NewUint32(0),
 	}
-	col.schema.Store(schema)
+	col.setSchema(schema, 0)
 	return col
 }
 
@@ -368,7 +384,7 @@ func NewCollectionWithoutSegcoreForTest(collectionID int64, schema *schemapb.Col
 		partitions: typeutil.NewConcurrentSet[int64](),
 		refCount:   atomic.NewUint32(0),
 	}
-	coll.schema.Store(schema)
+	coll.setSchema(schema, 0)
 	return coll
 }
 

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -136,6 +136,10 @@ func (m *collectionManager) UpdateSchema(collectionID int64, schema *schemapb.Co
 		return merr.WrapErrCollectionNotFound(collectionID, "collection not found in querynode collection manager")
 	}
 
+	if version <= collection.SchemaVersion() {
+		return nil
+	}
+
 	if err := collection.ccollection.UpdateSchema(schema, version); err != nil {
 		return err
 	}

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -59,6 +59,7 @@ func (s *CollectionManagerSuite) TestUpdateSchema() {
 
 		err := s.cm.UpdateSchema(1, schema, 100)
 		s.NoError(err)
+		s.Equal(uint64(100), s.cm.Get(1).SchemaVersion())
 	})
 
 	s.Run("not_exist_collection", func() {

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -17,6 +17,8 @@
 package segments
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -83,6 +85,54 @@ func (s *CollectionManagerSuite) TestUpdateSchema() {
 	})
 }
 
+func (s *CollectionManagerSuite) TestSchemaAndVersionSnapshot() {
+	coll := s.cm.Get(1)
+	schema := mock_segcore.GenTestCollectionSchema("collection_0", schemapb.DataType_Int64, false)
+	coll.setSchema(schema, 0)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	errCh := make(chan string, 1)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+
+			schema, version := coll.SchemaAndVersion()
+			if schema.GetName() != fmt.Sprintf("collection_%d", version) {
+				select {
+				case errCh <- fmt.Sprintf("schema %s does not match version %d", schema.GetName(), version):
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	for i := 1; i <= 1000; i++ {
+		schema := mock_segcore.GenTestCollectionSchema(fmt.Sprintf("collection_%d", i), schemapb.DataType_Int64, false)
+		coll.setSchema(schema, uint64(i))
+	}
+	close(stop)
+	wg.Wait()
+
+	select {
+	case msg := <-errCh:
+		s.Fail(msg)
+	default:
+	}
+
+	schema, version := coll.SchemaAndVersion()
+	s.Equal(uint64(1000), version)
+	s.Equal("collection_1000", schema.GetName())
+}
+
 func (s *CollectionManagerSuite) TestPutOrRefUpdateIndexMeta() {
 	// Verify initial collection has IndexMeta set from SetupTest.
 	coll := s.cm.Get(1)
@@ -121,8 +171,13 @@ func (s *CollectionManagerSuite) TestPutOrRefUpdateIndexMeta() {
 	s.Require().NoError(err)
 	defer s.cm.Unref(1, 1)
 
+	updatedCollection := s.cm.Get(1)
+	updatedSchema, updatedVersion := updatedCollection.SchemaAndVersion()
+	s.Equal(uint64(100), updatedVersion)
+	s.Len(updatedSchema.GetFields(), len(schema.GetFields()))
+
 	// Verify IndexMeta now contains the new field.
-	updatedIndexMeta := s.cm.Get(1).GetCCollection().IndexMeta()
+	updatedIndexMeta := updatedCollection.GetCCollection().IndexMeta()
 	found := false
 	for _, meta := range updatedIndexMeta.GetIndexMetas() {
 		if meta.GetFieldID() == newVecFieldID {

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -64,6 +64,18 @@ func (s *CollectionManagerSuite) TestUpdateSchema() {
 		s.Equal(uint64(100), s.cm.Get(1).SchemaVersion())
 	})
 
+	s.Run("stale_version", func() {
+		currentSchema, currentVersion := s.cm.Get(1).SchemaAndVersion()
+		staleSchema := mock_segcore.GenTestCollectionSchema("stale_collection", schemapb.DataType_Int64, false)
+
+		err := s.cm.UpdateSchema(1, staleSchema, currentVersion-1)
+		s.NoError(err)
+
+		updatedSchema, updatedVersion := s.cm.Get(1).SchemaAndVersion()
+		s.Equal(currentVersion, updatedVersion)
+		s.Same(currentSchema, updatedSchema)
+	})
+
 	s.Run("not_exist_collection", func() {
 		schema := mock_segcore.GenTestCollectionSchema("collection_1", schemapb.DataType_Int64, false)
 		schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
@@ -79,7 +91,7 @@ func (s *CollectionManagerSuite) TestUpdateSchema() {
 
 	s.Run("nil_schema", func() {
 		s.NotPanics(func() {
-			err := s.cm.UpdateSchema(1, nil, 100)
+			err := s.cm.UpdateSchema(1, nil, 101)
 			s.Error(err)
 		})
 	})

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -619,7 +619,7 @@ func (s *LocalSegment) DropIndex(ctx context.Context, indexID int64) error {
 	defer s.ptrLock.Unpin()
 
 	if indexInfo, ok := s.fieldIndexes.Get(indexID); ok {
-		field := typeutil.GetField(s.collection.schema.Load(), indexInfo.IndexInfo.FieldID)
+		field := typeutil.GetField(s.collection.Schema(), indexInfo.IndexInfo.FieldID)
 		if typeutil.IsJSONType(field.GetDataType()) {
 			nestedPath, err := funcutil.GetAttrByKeyFromRepeatedKV(common.JSONPathKey, indexInfo.IndexInfo.GetIndexParams())
 			if err != nil {
@@ -1393,10 +1393,11 @@ func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentL
 	}
 	defer s.ptrLock.Unpin()
 
+	schema, schemaVersion := s.collection.SchemaAndVersion()
 	err := s.csegment.Reopen(ctx, &segcore.ReopenRequest{
 		LoadInfo:      newLoadInfo,
-		Schema:        s.collection.Schema(),
-		SchemaVersion: s.collection.SchemaVersion(),
+		Schema:        schema,
+		SchemaVersion: schemaVersion,
 	})
 	if err != nil {
 		return err

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1394,7 +1394,9 @@ func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentL
 	defer s.ptrLock.Unpin()
 
 	err := s.csegment.Reopen(ctx, &segcore.ReopenRequest{
-		LoadInfo: newLoadInfo,
+		LoadInfo:      newLoadInfo,
+		Schema:        s.collection.Schema(),
+		SchemaVersion: s.collection.SchemaVersion(),
 	})
 	if err != nil {
 		return err

--- a/internal/util/segcore/requests.go
+++ b/internal/util/segcore/requests.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -119,5 +120,7 @@ func (req *cLoadFieldDataRequest) Release() {
 }
 
 type ReopenRequest struct {
-	LoadInfo *querypb.SegmentLoadInfo
+	LoadInfo      *querypb.SegmentLoadInfo
+	Schema        *schemapb.CollectionSchema
+	SchemaVersion uint64
 }

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -336,6 +336,16 @@ func (s *cSegmentImpl) Load(ctx context.Context) error {
 }
 
 func (s *cSegmentImpl) Reopen(ctx context.Context, req *ReopenRequest) error {
+	if req == nil {
+		return errors.New("reopen request is nil")
+	}
+	if req.LoadInfo == nil {
+		return errors.New("reopen load info is nil")
+	}
+	if req.Schema == nil {
+		return errors.New("reopen schema is nil")
+	}
+
 	traceCtx := ParseCTraceContext(ctx)
 	defer runtime.KeepAlive(traceCtx)
 	defer runtime.KeepAlive(req)
@@ -345,28 +355,27 @@ func (s *cSegmentImpl) Reopen(ctx context.Context, req *ReopenRequest) error {
 	if err != nil {
 		return err
 	}
+	if len(loadInfoBlob) == 0 {
+		return errors.New("reopen load info blob is empty")
+	}
 
-	var schemaBlob []byte
-	if req.Schema != nil {
-		schemaBlob, err = proto.Marshal(req.Schema)
-		if err != nil {
-			return err
-		}
+	schemaBlob, err := proto.Marshal(req.Schema)
+	if err != nil {
+		return err
+	}
+	if len(schemaBlob) == 0 {
+		return errors.New("reopen schema blob is empty")
 	}
 	defer runtime.KeepAlive(schemaBlob)
 
 	future := cgo.Async(ctx,
 		func() cgo.CFuturePtr {
-			var schemaPtr unsafe.Pointer
-			if len(schemaBlob) > 0 {
-				schemaPtr = unsafe.Pointer(&schemaBlob[0])
-			}
 			return (cgo.CFuturePtr)(C.AsyncReopenSegment(
 				traceCtx.ctx,
 				s.ptr,
 				(*C.uint8_t)(unsafe.Pointer(&loadInfoBlob[0])),
 				C.int64_t(len(loadInfoBlob)),
-				schemaPtr,
+				unsafe.Pointer(&schemaBlob[0]),
 				C.int64_t(len(schemaBlob)),
 				C.uint64_t(req.SchemaVersion),
 			))

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -346,13 +346,29 @@ func (s *cSegmentImpl) Reopen(ctx context.Context, req *ReopenRequest) error {
 		return err
 	}
 
+	var schemaBlob []byte
+	if req.Schema != nil {
+		schemaBlob, err = proto.Marshal(req.Schema)
+		if err != nil {
+			return err
+		}
+	}
+	defer runtime.KeepAlive(schemaBlob)
+
 	future := cgo.Async(ctx,
 		func() cgo.CFuturePtr {
+			var schemaPtr unsafe.Pointer
+			if len(schemaBlob) > 0 {
+				schemaPtr = unsafe.Pointer(&schemaBlob[0])
+			}
 			return (cgo.CFuturePtr)(C.AsyncReopenSegment(
 				traceCtx.ctx,
 				s.ptr,
 				(*C.uint8_t)(unsafe.Pointer(&loadInfoBlob[0])),
 				C.int64_t(len(loadInfoBlob)),
+				schemaPtr,
+				C.int64_t(len(schemaBlob)),
+				C.uint64_t(req.SchemaVersion),
 			))
 		},
 		cgo.WithName("segment-reopen"),


### PR DESCRIPTION
Related to #46358

Unify sealed segment schema reopen with the LoadDiff path so schema changes use the same diff/apply lifecycle as binlog, manifest, and index updates. This preserves default-filled field state across load info snapshots, passes the latest schema through QueryNode's cgo reopen path, and makes schema-only reopen compute default-fill/load/drop actions through segcore.