### PR TITLE
enhance: add delete replay stats during segment load

### DIFF
--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -848,18 +848,23 @@ func (sd *shardDelegator) RefreshLevel0DeletionStats() {
 	).Set(float64(totalSize))
 }
 
+type deleteForwardStats struct {
+	readDeleteRowCount    int64
+	forwardDeleteRowCount int64
+}
+
 // processDeleteRecords performs BF checks on delete buffer records and forwards matching deletes
 // via the buffered forwarder. Does NOT require any lock to be held.
 // When candidate has no stats (PkCandidateExist() == false), all deletes are forwarded (broadcast mode).
-// Returns the number of timestamp-hit and bloom-filter-hit rows.
 func (sd *shardDelegator) processDeleteRecords(
 	candidate *pkoracle.BloomFilterSet,
 	records []*deletebuffer.Item,
 	forwarder *BufferForwarder,
-) (tsHit, bfHit int64, err error) {
+) (deleteForwardStats, error) {
+	stats := deleteForwardStats{}
 	for _, entry := range records {
 		for _, record := range entry.Data {
-			tsHit += int64(len(record.DeleteData.Pks))
+			stats.readDeleteRowCount += int64(len(record.DeleteData.Pks))
 			if record.PartitionID != common.AllPartitionsID && candidate.Partition() != record.PartitionID {
 				continue
 			}
@@ -874,9 +879,9 @@ func (sd *shardDelegator) processDeleteRecords(
 				// When BF not initialized (bloom filter disabled), forward all deletes
 				if !candidate.PkCandidateExist() {
 					for i := idx; i < endIdx; i++ {
-						bfHit++
-						if err = forwarder.Buffer(pks[i], record.DeleteData.Tss[i]); err != nil {
-							return tsHit, bfHit, err
+						stats.forwardDeleteRowCount++
+						if err := forwarder.Buffer(pks[i], record.DeleteData.Tss[i]); err != nil {
+							return stats, err
 						}
 					}
 					continue
@@ -886,16 +891,16 @@ func (sd *shardDelegator) processDeleteRecords(
 				hits := candidate.BatchPkExist(lc)
 				for i, hit := range hits {
 					if hit {
-						bfHit++
-						if err = forwarder.Buffer(pks[idx+i], record.DeleteData.Tss[idx+i]); err != nil {
-							return tsHit, bfHit, err
+						stats.forwardDeleteRowCount++
+						if err := forwarder.Buffer(pks[idx+i], record.DeleteData.Tss[idx+i]); err != nil {
+							return stats, err
 						}
 					}
 				}
 			}
 		}
 	}
-	return tsHit, bfHit, nil
+	return stats, nil
 }
 
 // segDeleteSnapshot holds the snapshotted delete buffer entries for a segment,
@@ -970,7 +975,7 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 	for i, info := range infos {
 		candidate := idCandidates[info.GetSegmentID()]
 		start := time.Now()
-		tsHit, bfHit, err := sd.processDeleteRecords(candidate, snapshots[i].records, forwarders[i])
+		stats, err := sd.processDeleteRecords(candidate, snapshots[i].records, forwarders[i])
 		if err != nil {
 			return err
 		}
@@ -978,9 +983,9 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 			zap.String("channel", info.InsertChannel),
 			zap.Int64("segmentID", info.GetSegmentID()),
 			zap.Time("startPosition", tsoutil.PhysicalTime(info.GetStartPosition().GetTimestamp())),
-			zap.Int64("tsHitDeleteRowNum", tsHit),
-			zap.Int64("bfHitDeleteRowNum", bfHit),
-			zap.Int64("bfCost", time.Since(start).Milliseconds()),
+			zap.Int64("readDeleteRowNum", stats.readDeleteRowCount),
+			zap.Int64("forwardDeleteRowNum", stats.forwardDeleteRowCount),
+			zap.Int64("cost", time.Since(start).Milliseconds()),
 		)
 	}
 
@@ -1003,16 +1008,16 @@ func (sd *shardDelegator) loadStreamDelete(ctx context.Context,
 		newRecords := sd.deleteBuffer.ListAfter(catchUpTs)
 		if len(newRecords) > 0 {
 			start := time.Now()
-			tsHit, bfHit, err := sd.processDeleteRecords(candidate, newRecords, forwarders[i])
+			stats, err := sd.processDeleteRecords(candidate, newRecords, forwarders[i])
 			if err != nil {
 				return err
 			}
 			log.Info("forward delete to worker (phase 3: catch-up)...",
 				zap.String("channel", info.InsertChannel),
 				zap.Int64("segmentID", info.GetSegmentID()),
-				zap.Int64("tsHitDeleteRowNum", tsHit),
-				zap.Int64("bfHitDeleteRowNum", bfHit),
-				zap.Int64("bfCost", time.Since(start).Milliseconds()),
+				zap.Int64("readDeleteRowNum", stats.readDeleteRowCount),
+				zap.Int64("forwardDeleteRowNum", stats.forwardDeleteRowCount),
+				zap.Int64("cost", time.Since(start).Milliseconds()),
 			)
 		}
 

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
 	"github.com/milvus-io/milvus/internal/querynodev2/cluster"
+	"github.com/milvus-io/milvus/internal/querynodev2/delegator/deletebuffer"
 	"github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/storage"
@@ -1639,6 +1640,56 @@ func (s *DelegatorDataSuite) TestLevel0Deletions() {
 	delegator.deleteBuffer.UnRegister(uint64(21))
 	pks, _ = delegator.GetLevel0Deletions(partitionID+1, pkoracle.NewCandidateKey(l0.ID(), l0.Partition(), segments.SegmentTypeGrowing))
 	s.Empty(pks)
+}
+
+func (s *DelegatorDataSuite) TestProcessDeleteRecordsReturnsForwardStats() {
+	candidate := pkoracle.NewBloomFilterSet(100, 10, commonpb.SegmentState_Sealed)
+	records := []*deletebuffer.Item{
+		{
+			Ts: 100,
+			Data: []deletebuffer.BufferItem{
+				{
+					PartitionID: 10,
+					DeleteData: storage.DeleteData{
+						Pks: storage.NewInt64PrimaryKeys([]int64{1, 2}),
+						Tss: []uint64{101, 102},
+					},
+				},
+				{
+					PartitionID: 11,
+					DeleteData: storage.DeleteData{
+						Pks: storage.NewInt64PrimaryKeys([]int64{3}),
+						Tss: []uint64{103},
+					},
+				},
+			},
+		},
+		{
+			Ts: 200,
+			Data: []deletebuffer.BufferItem{
+				{
+					PartitionID: common.AllPartitionsID,
+					DeleteData: storage.DeleteData{
+						Pks: storage.NewInt64PrimaryKeys([]int64{4}),
+						Tss: []uint64{104},
+					},
+				},
+			},
+		},
+	}
+
+	var forwardedRows int64
+	forwarder := NewBufferedForwarder(1<<20, func(pks storage.PrimaryKeys, tss []uint64) error {
+		forwardedRows += int64(pks.Len())
+		return nil
+	})
+
+	stats, err := s.delegator.processDeleteRecords(candidate, records, forwarder)
+	s.NoError(err)
+	s.NoError(forwarder.Flush())
+	s.Equal(int64(4), stats.readDeleteRowCount)
+	s.Equal(int64(3), stats.forwardDeleteRowCount)
+	s.Equal(int64(3), forwardedRows)
 }
 
 // TestLoadSegmentsDoesNotBlockProcessDelete verifies that the 3-phase loadStreamDelete


### PR DESCRIPTION
## Summary

- Add per-segment delete replay stats for LoadSegments post-load forwarding.
- Log scanned delete PK count, forwarded delete PK count, and replay cost for phase 2 snapshot and phase 3 catch-up.
- Add unit coverage for the new delete replay stats returned by `processDeleteRecords`.

issue: #49887

## Test plan

- [x] `gofmt -w internal/querynodev2/delegator/delegator_data.go internal/querynodev2/delegator/delegator_data_test.go`
- [x] `git diff --check`
- [ ] `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/delegator/ -run 'TestDelegatorDataSuite/TestProcessDeleteRecordsReturnsForwardStats'` (not run locally: current local C/C++ header environment fails before package tests compile)

Generated with [Claude Code](https://claude.ai/code)