### PR TITLE
enhance: support search aggregation search size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/hamba/avro/v2 v2.29.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/magiconair/properties v1.8.7
-	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260514121806-9b60a053353f
+	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260526093827-489331a5a41f
 	github.com/milvus-io/milvus/client/v2 v2.6.2
 	github.com/milvus-io/milvus/pkg/v3 v3.0.0-beta
 	github.com/shirou/gopsutil/v4 v4.25.10

--- a/go.sum
+++ b/go.sum
@@ -793,8 +793,8 @@ github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6 h1:YHMFI6L
 github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZzUfIfYe5qYDBzt4ZYRqzUjTR6CvUzjat8=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
-github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260514121806-9b60a053353f h1:Z2paGeFL0i1a3Dqw82DwRwZ2ix3FtyKU7+u6rR7jbUs=
-github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260514121806-9b60a053353f/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260526093827-489331a5a41f h1:W+paUzc+AA381Rydx2DJffoQuM4l+efVqO+2i9GdfMw=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260526093827-489331a5a41f/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/internal/proxy/search_agg/context_builder.go
+++ b/internal/proxy/search_agg/context_builder.go
@@ -142,7 +142,7 @@ func compileMetricPlans(metrics map[string]MetricSpec) ([]metricPlan, error) {
 // deriveTopKAndGroupSize maps the ES-style nested aggregation sizes into the
 // (topK, groupSize) pair consumed by the Delegator/QN group-reduce algorithm:
 //
-//	topK      = product of every level's Size (distinct composite keys cap)
+//	topK      = product of every level's SearchSize
 //	groupSize = max TopHits.Size across all levels, or 1 when TopHits is absent
 //
 // groupSize is global because upstream group-reduce keeps rows per full
@@ -154,10 +154,17 @@ func normalizeAggregationSize(size int64) int64 {
 	return size
 }
 
+func candidateSize(level LevelContext) int64 {
+	if level.SearchSize > 0 {
+		return level.SearchSize
+	}
+	return normalizeAggregationSize(level.Size)
+}
+
 func deriveTopKAndGroupSize(levels []LevelContext) (topK, groupSize int64) {
 	topK = 1
 	for _, lvl := range levels {
-		topK *= normalizeAggregationSize(lvl.Size)
+		topK *= candidateSize(lvl)
 	}
 	return topK, deriveGroupSize(levels)
 }
@@ -166,7 +173,7 @@ func deriveTopKAndGroupSizeChecked(levels []LevelContext) (topK, groupSize int64
 	topK = 1
 	for _, lvl := range levels {
 		var ok bool
-		topK, ok = checkedMulInt64(topK, normalizeAggregationSize(lvl.Size))
+		topK, ok = checkedMulInt64(topK, candidateSize(lvl))
 		if !ok {
 			return 0, 0, fmt.Errorf("search_aggregation derived topK overflows int64")
 		}
@@ -263,10 +270,23 @@ func resolveAggregationSpec(groupBy *commonpb.SearchAggregationSpec, schema *sch
 		if spec.GetSize() < 0 {
 			return fmt.Errorf("search_aggregation size must be non-negative")
 		}
+		if spec.GetSearchSize() < 0 {
+			return fmt.Errorf("search_aggregation search_size must be non-negative")
+		}
+
+		levelSize := normalizeAggregationSize(spec.GetSize())
+		searchSize := spec.GetSearchSize()
+		if searchSize == 0 {
+			searchSize = levelSize
+		}
+		if searchSize < levelSize {
+			return fmt.Errorf("search_aggregation search_size must be greater than or equal to size")
+		}
 
 		level := LevelContext{
 			OwnFieldIDs: make([]int64, 0, len(spec.GetFields())),
-			Size:        normalizeAggregationSize(spec.GetSize()),
+			Size:        levelSize,
+			SearchSize:  searchSize,
 		}
 
 		levelFieldSeen := make(map[int64]struct{})

--- a/internal/proxy/search_agg/context_builder_test.go
+++ b/internal/proxy/search_agg/context_builder_test.go
@@ -88,11 +88,40 @@ func TestBuildSearchAggregationContextDefaultsOmittedSizeToOne(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, ctx.Levels, 2)
 	require.Equal(t, int64(1), ctx.Levels[0].Size)
+	require.Equal(t, int64(1), ctx.Levels[0].SearchSize)
 	require.Equal(t, int64(1), ctx.Levels[1].Size)
+	require.Equal(t, int64(1), ctx.Levels[1].SearchSize)
 	require.NotNil(t, ctx.Levels[1].TopHits)
 	require.Equal(t, int64(1), ctx.Levels[1].TopHits.Size)
 	require.Equal(t, int64(1), ctx.DerivedTopK)
 	require.Equal(t, int64(1), ctx.DerivedGroupSize)
+}
+
+func TestBuildSearchAggregationContextUsesSearchSizeForDerivedTopK(t *testing.T) {
+	schema := testCollectionSchema()
+	spec := &commonpb.SearchAggregationSpec{
+		Fields:     []string{"brand"},
+		Size:       2,
+		SearchSize: 5,
+		SubAggregation: &commonpb.SearchAggregationSpec{
+			Fields:     []string{"category"},
+			Size:       3,
+			SearchSize: 4,
+			TopHits: &commonpb.TopHitsSpec{
+				Size: 2,
+			},
+		},
+	}
+
+	ctx, err := BuildSearchAggregationContext(spec, schema, 1)
+	require.NoError(t, err)
+	require.Len(t, ctx.Levels, 2)
+	require.Equal(t, int64(2), ctx.Levels[0].Size)
+	require.Equal(t, int64(5), ctx.Levels[0].SearchSize)
+	require.Equal(t, int64(3), ctx.Levels[1].Size)
+	require.Equal(t, int64(4), ctx.Levels[1].SearchSize)
+	require.Equal(t, int64(20), ctx.DerivedTopK)
+	require.Equal(t, int64(2), ctx.DerivedGroupSize)
 }
 
 func TestBuildSearchAggregationContextRejectsNegativeSize(t *testing.T) {
@@ -105,6 +134,26 @@ func TestBuildSearchAggregationContextRejectsNegativeSize(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "search_aggregation size must be non-negative")
+}
+
+func TestBuildSearchAggregationContextRejectsInvalidSearchSize(t *testing.T) {
+	schema := testCollectionSchema()
+
+	_, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+		Fields:     []string{"brand"},
+		Size:       3,
+		SearchSize: -1,
+	}, schema, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "search_aggregation search_size must be non-negative")
+
+	_, err = BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+		Fields:     []string{"brand"},
+		Size:       3,
+		SearchSize: 2,
+	}, schema, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "search_aggregation search_size must be greater than or equal to size")
 }
 
 func TestBuildSearchAggregationContextRejectsNegativeTopHitsSize(t *testing.T) {
@@ -129,6 +178,16 @@ func TestDeriveTopKAndGroupSizeDefaultsZeroSizesToOne(t *testing.T) {
 
 	require.Equal(t, int64(3), topK)
 	require.Equal(t, int64(1), groupSize)
+}
+
+func TestDeriveTopKAndGroupSizeUsesSearchSize(t *testing.T) {
+	topK, groupSize := deriveTopKAndGroupSize([]LevelContext{
+		{Size: 2, SearchSize: 5},
+		{Size: 3, SearchSize: 4, TopHits: &TopHitsConfig{Size: 2}},
+	})
+
+	require.Equal(t, int64(20), topK)
+	require.Equal(t, int64(2), groupSize)
 }
 
 func TestNewContextReturnsMetricCompileError(t *testing.T) {

--- a/internal/proxy/search_agg/types.go
+++ b/internal/proxy/search_agg/types.go
@@ -21,8 +21,7 @@ type SearchAggregationContext struct {
 	UserOutputFieldIDs map[int64]struct{}
 
 	// DerivedTopK is the number of distinct composite keys each NQ retains
-	// downstream, equal to the product of every level's Size (empty / zero
-	// levels treated as 1). Mirrors ES `terms.size` nested product.
+	// downstream, equal to the product of every level's SearchSize.
 	DerivedTopK int64
 
 	// DerivedGroupSize is the per-composite-key doc retention budget. Equal to
@@ -76,6 +75,7 @@ type LevelContext struct {
 	TopHits     *TopHitsConfig
 	Order       []OrderCriterion
 	Size        int64
+	SearchSize  int64
 }
 
 type MetricSpec struct {


### PR DESCRIPTION
## Summary
- Add per-level `search_size` handling for search aggregation context building.
- Preserve `size` as the response bucket limit while using `search_size` for downstream candidate bucket budget derivation.
- Bump the root module milvus-proto dependency to the version that contains `SearchAggregationSpec.search_size`.

## Test Plan
- [x] `git diff --check trunk/master...HEAD`
- [x] `go test -tags dynamic,test -gcflags=\"all=-N -l\" -count=1 ./internal/proxy/search_agg/...`

related: #48971

🤖 Generated with [Claude Code](https://claude.com/claude-code)