### PR TITLE
test: Enable storage v3 for CI helm values

### DIFF
--- a/tests/_helm/values/e2e-amd/distributed-pulsar
+++ b/tests/_helm/values/e2e-amd/distributed-pulsar
@@ -79,6 +79,8 @@ extraConfigFiles:
     common:
       storage:
         enablev2: true
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/e2e-amd/standalone
+++ b/tests/_helm/values/e2e-amd/standalone
@@ -36,6 +36,10 @@ log:
   level: debug
 extraConfigFiles:
   user.yaml: |+
+    common:
+      storage:
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/e2e-amd/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-amd/standalone-kafka-mmap
@@ -37,6 +37,8 @@ extraConfigFiles:
     common:
       storage:
         enablev2: true
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/e2e-amd/standalone-one-pod
+++ b/tests/_helm/values/e2e-amd/standalone-one-pod
@@ -33,6 +33,9 @@ extraConfigFiles:
         dir: /var/lib/milvus/etcd
     common:
       storageType: local
+      storage:
+        # enable storage v3
+        useLoonFFI: true
     queryNode:
       segcore:
         exprEvalBatchSize: 512
@@ -40,6 +43,9 @@ extraConfigFiles:
       flushRate:
         collection:
           max: 4
+    indexCoord:
+      scheduler:
+        interval: 100
 image:
   all:
     pullPolicy: Always
@@ -49,11 +55,6 @@ indexCoordinator:
   enabled: false
   gc:
     interval: 1
-extraConfigFiles:
-  user.yaml: |+
-    indexCoord:
-      scheduler:
-        interval: 100
 indexNode:
   enabled: false
   disk:

--- a/tests/_helm/values/e2e-arm/distributed-pulsar
+++ b/tests/_helm/values/e2e-arm/distributed-pulsar
@@ -66,6 +66,8 @@ extraConfigFiles:
     common:
       storage:
         enablev2: true
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/e2e-arm/standalone
+++ b/tests/_helm/values/e2e-arm/standalone
@@ -23,6 +23,10 @@ log:
   level: debug
 extraConfigFiles:
   user.yaml: |+
+    common:
+      storage:
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/e2e-arm/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-arm/standalone-kafka-mmap
@@ -24,6 +24,8 @@ extraConfigFiles:
     common:
       storage:
         enablev2: true
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/e2e-arm/standalone-one-pod
+++ b/tests/_helm/values/e2e-arm/standalone-one-pod
@@ -20,9 +20,15 @@ extraConfigFiles:
         dir: /var/lib/milvus/etcd
     common:
       storageType: local
+      storage:
+        # enable storage v3
+        useLoonFFI: true
     queryNode:
       segcore:
         exprEvalBatchSize: 512
+    indexCoord:
+      scheduler:
+        interval: 100
 image:
   all:
     pullPolicy: Always
@@ -32,11 +38,6 @@ indexCoordinator:
   enabled: false
   gc:
     interval: 1
-extraConfigFiles:
-  user.yaml: |+
-    indexCoord:
-      scheduler:
-        interval: 100
 indexNode:
   enabled: false
   disk:

--- a/tests/_helm/values/e2e/distributed-pulsar
+++ b/tests/_helm/values/e2e/distributed-pulsar
@@ -79,6 +79,8 @@ extraConfigFiles:
     common:
       storage:
         enablev2: true
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/e2e/standalone
+++ b/tests/_helm/values/e2e/standalone
@@ -36,6 +36,10 @@ log:
   level: debug
 extraConfigFiles:
   user.yaml: |+
+    common:
+      storage:
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/e2e/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e/standalone-kafka-mmap
@@ -37,6 +37,8 @@ extraConfigFiles:
     common:
       storage:
         enablev2: true
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/e2e/standalone-one-pod
+++ b/tests/_helm/values/e2e/standalone-one-pod
@@ -33,6 +33,9 @@ extraConfigFiles:
         dir: /var/lib/milvus/etcd
     common:
       storageType: local
+      storage:
+        # enable storage v3
+        useLoonFFI: true
     queryNode:
       segcore:
         exprEvalBatchSize: 512
@@ -40,6 +43,9 @@ extraConfigFiles:
       flushRate:
         collection:
           max: 4
+    indexCoord:
+      scheduler:
+        interval: 100
 image:
   all:
     pullPolicy: Always
@@ -49,11 +55,6 @@ indexCoordinator:
   enabled: false
   gc:
     interval: 1
-extraConfigFiles:
-  user.yaml: |+
-    indexCoord:
-      scheduler:
-        interval: 100
 indexNode:
   enabled: false
   disk:

--- a/tests/_helm/values/nightly/distributed-kafka
+++ b/tests/_helm/values/nightly/distributed-kafka
@@ -81,6 +81,10 @@ log:
   level: debug
 extraConfigFiles:
   user.yaml: |+
+    common:
+      storage:
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/nightly/distributed-pulsar-mmap
+++ b/tests/_helm/values/nightly/distributed-pulsar-mmap
@@ -84,6 +84,8 @@ extraConfigFiles:
     common:
       storage:
         enablev2: true
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/nightly/distributed-woodpecker
+++ b/tests/_helm/values/nightly/distributed-woodpecker
@@ -86,6 +86,8 @@ extraConfigFiles:
     common:
       storage:
         enablev2: true
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800
@@ -176,4 +178,3 @@ image:
     pullPolicy: Always
     repository: harbor.milvus.io/milvus/milvus
     tag: nightly-20240821-ed4eaff
-

--- a/tests/_helm/values/nightly/distributed-woodpecker-service
+++ b/tests/_helm/values/nightly/distributed-woodpecker-service
@@ -95,6 +95,8 @@ extraConfigFiles:
     common:
       storage:
         enablev2: true
+        # enable storage v3
+        useLoonFFI: true
     dataCoord:
       gc:
         interval: 1800

--- a/tests/_helm/values/nightly/standalone-authentication-mmap
+++ b/tests/_helm/values/nightly/standalone-authentication-mmap
@@ -51,6 +51,9 @@ extraConfigFiles:
         scalarIndex: true
         growingMmapEnabled: true
     common:
+      storage:
+        # enable storage v3
+        useLoonFFI: true
       security:
         authorizationEnabled: true
 metrics:

--- a/tests/_helm/values/nightly/standalone-one-pod
+++ b/tests/_helm/values/nightly/standalone-one-pod
@@ -46,6 +46,9 @@ extraConfigFiles:
         dir: /var/lib/milvus/etcd
     common:
       storageType: local
+      storage:
+        # enable storage v3
+        useLoonFFI: true
     queryNode:
       segcore:
         exprEvalBatchSize: 512


### PR DESCRIPTION
## What this PR does

Enable Storage V3 explicitly in CI Helm values by setting `common.storage.useLoonFFI: true` with an inline comment for e2e, e2e-amd, e2e-arm, and nightly deployments.

## Related dev PR

Related to #49880

## Verification

- Parsed all updated values files and their embedded `extraConfigFiles.user.yaml` successfully.
- Verified all 18 target values files set `common.storage.useLoonFFI == true`.
- Ran `git diff --check`.