### PR TITLE
fix: count only available partitions for create partition limit

### DIFF
--- a/internal/rootcoord/ddl_callbacks_collection_test.go
+++ b/internal/rootcoord/ddl_callbacks_collection_test.go
@@ -172,3 +172,68 @@ func TestDDLCallbacksCollectionDDL(t *testing.T) {
 	})
 	require.NoError(t, merr.CheckRPCCall(status, err))
 }
+
+func TestCreatePartitionMaxCountIgnoresDroppedPartitions(t *testing.T) {
+	Params.Save(Params.RootCoordCfg.MaxPartitionNum.Key, "2")
+	defer Params.Reset(Params.RootCoordCfg.MaxPartitionNum.Key)
+
+	core := initStreamingSystemAndCore(t)
+
+	ctx := context.Background()
+	dbName := "testDB" + funcutil.RandomString(10)
+	collectionName := "testCollection" + funcutil.RandomString(10)
+	testSchema := &schemapb.CollectionSchema{
+		Name:   collectionName,
+		AutoID: false,
+		Fields: []*schemapb.FieldSchema{
+			{
+				Name:     "field1",
+				DataType: schemapb.DataType_Int64,
+			},
+		},
+	}
+	schemaBytes, err := proto.Marshal(testSchema)
+	require.NoError(t, err)
+
+	status, err := core.CreateDatabase(ctx, &milvuspb.CreateDatabaseRequest{DbName: dbName})
+	require.NoError(t, merr.CheckRPCCall(status, err))
+	status, err = core.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         schemaBytes,
+	})
+	require.NoError(t, merr.CheckRPCCall(status, err))
+
+	status, err = core.CreatePartition(ctx, &milvuspb.CreatePartitionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		PartitionName:  "partition_1",
+	})
+	require.NoError(t, merr.CheckRPCCall(status, err))
+
+	status, err = core.DropPartition(ctx, &milvuspb.DropPartitionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		PartitionName:  "partition_1",
+	})
+	require.NoError(t, merr.CheckRPCCall(status, err))
+
+	coll, err := core.meta.GetCollectionByName(ctx, dbName, collectionName, typeutil.MaxTimestamp, true)
+	require.NoError(t, err)
+	require.Len(t, coll.Partitions, 2)
+	require.Equal(t, 1, coll.GetPartitionNum(true))
+
+	status, err = core.CreatePartition(ctx, &milvuspb.CreatePartitionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		PartitionName:  "partition_2",
+	})
+	require.NoError(t, merr.CheckRPCCall(status, err))
+
+	status, err = core.CreatePartition(ctx, &milvuspb.CreatePartitionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		PartitionName:  "partition_3",
+	})
+	require.ErrorContains(t, merr.CheckRPCCall(status, err), "partition number (2) exceeds max configuration (2)")
+}

--- a/internal/rootcoord/ddl_callbacks_create_partition.go
+++ b/internal/rootcoord/ddl_callbacks_create_partition.go
@@ -52,9 +52,10 @@ func (c *Core) broadcastCreatePartition(ctx context.Context, in *milvuspb.Create
 		return partitionID, errIgnoerdCreatePartition
 	}
 	cfgMaxPartitionNum := Params.RootCoordCfg.MaxPartitionNum.GetAsInt()
-	if len(collMeta.Partitions) >= cfgMaxPartitionNum {
+	partitionNum := collMeta.GetPartitionNum(true)
+	if partitionNum >= cfgMaxPartitionNum {
 		return 0, fmt.Errorf("partition number (%d) exceeds max configuration (%d), collection: %s",
-			len(collMeta.Partitions), cfgMaxPartitionNum, collMeta.Name)
+			partitionNum, cfgMaxPartitionNum, collMeta.Name)
 	}
 
 	partID, err := c.idAllocator.AllocOne()


### PR DESCRIPTION
### What changed
- Use `collMeta.GetPartitionNum(true)` for the `CreatePartition` max partition limit check so dropped/unavailable partitions are not counted against `RootCoordCfg.MaxPartitionNum`.
- Keep the partition-name index lookup path introduced by #47486.
- Add a RootCoord regression test that drops a partition and verifies a new partition can still be created when only available partitions are below the limit.

### Why
`CreatePartition` loads collection meta with `allowUnavailable=true`, so `collMeta.Partitions` can include dropped partitions. Using `len(collMeta.Partitions)` made dropped partitions count as live partitions and blocked partition creation at the max limit.

issue: #49832

### Verification
- Argo benchmark validation passed with image `fix-rootcoord-create-partition-count-available-20260515-38e7e8cf79-v2-amd64`: [main logs](https://argo-workflows.zilliz.cc/artifacts-by-uid/5fddca83-21ee-42f1-9dc3-122edb5883ef/fouramf-vgtzw-3278604834/main-logs)