### PR TITLE
feat: support vortex local format

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -541,6 +541,7 @@ queryNode:
     knowhereScoreConsistency: false # Enable knowhere strong consistency score computation logic
     storageV2:
       cellTargetSizeBytes: 4194304 # Target average byte size per storage v2 cache cell. Parquet row groups are greedily packed so that rgs_per_cell * avg_row_group_size ≈ this target. Each cell always contains at least one row group and cells never cross file boundaries. Tune larger for bigger batch IO (fewer cells) or smaller to get finer cache granularity. Default 4 MiB.
+    enableVortexScanPushdown: true # Enable Vortex local-format varchar filter pushdown through row-id scan.
     deleteDumpBatchSize: 10000 # Batch size for delete snapshot dump in segcore.
   loadMemoryUsageFactor: 1 # The multiply factor of calculating the memory usage while loading segments
   enableDisk: false # enable querynode load disk index, and search on disk index

--- a/docs/design-docs/design_docs/20260305-local_format.md
+++ b/docs/design-docs/design_docs/20260305-local_format.md
@@ -1,0 +1,541 @@
+# MEP: Local Format for Storage V3 Scalar Fields
+
+- **Created:** 2026-03-05
+- **Author(s):** @zhicheng
+- **Status:** Under Review
+- **Component:** QueryNode | DataNode | Storage
+- **Related Issues:** milvus-io/milvus#50304
+- **Released:** TBD
+
+## Summary
+
+Add a field-level `local_format` type parameter for sealed segment scalar data
+loaded through Storage V3. The default value is `raw`, which keeps the existing
+Milvus on-node raw chunk layout. The first alternate value is `vortex`, which
+loads Vortex column group files through a cell-based local format path.
+
+The proposal keeps the public field schema model small:
+
+- `local_format=raw`: existing behavior.
+- `local_format=vortex`: use Vortex local format when the Storage V3 manifest
+  also points to a Vortex physical column group for that field.
+
+Vortex local format is a read-path feature for sealed scalar fields. It does not
+change growing segment execution, vector index execution, or the public query
+language. It changes how QueryNode loads and scans sealed scalar column data.
+
+## Motivation
+
+Raw scalar chunks are simple and fast when fully resident, but they require
+Milvus to materialize the field data in its raw on-node layout. This is costly
+for large VARCHAR, JSON, ARRAY, and other scalar fields when a query only needs a
+subset of rows or only needs a predicate result.
+
+Vortex provides compressed, columnar files with row-group metadata and optional
+zone maps. Local format support lets Milvus keep Vortex data in its native file
+layout and materialize only the cells needed by scan or take operations.
+
+The design goals are:
+
+- Reduce sealed scalar field load memory for Storage V3 segments.
+- Keep the existing raw path as the default and avoid adding copies to it.
+- Let expression evaluation consume scalar data through a scan cursor instead
+  of repeatedly materializing chunks.
+- Pin Vortex data at a well-defined cell granularity in the Milvus cache layer.
+- Keep the common `FormatReader` interface stable; Vortex-specific operations
+  are exposed as Vortex extensions.
+- Support normal filter, offset-input filter, and retrieve/requery output paths
+  with clear and separate execution plans.
+
+The non-goals for the initial implementation are:
+
+- Vortex local format for vector fields.
+- Vortex local format for primary-key fields.
+- Changing the query expression language.
+- Full predicate pushdown for every scalar expression.
+- Bitmap/selection pushdown for offset-input execution.
+
+## Public Interfaces
+
+### Field Type Parameter
+
+`local_format` is a field type parameter.
+
+Valid values:
+
+| Value | Meaning |
+|-------|---------|
+| `raw` | Default. Load sealed scalar data into the existing raw local format. |
+| `vortex` | Prefer Vortex local format for this field when the physical Storage V3 column group is Vortex. |
+
+Example schema intent:
+
+```python
+schema.add_field(
+    field_name="description",
+    datatype=DataType.VARCHAR,
+    max_length=65535,
+    type_params={"local_format": "vortex"},
+)
+```
+
+SDKs may expose this as a direct field option, but the Milvus server stores and
+validates it as a field type parameter.
+
+Validation rules:
+
+- Missing `local_format` means `raw`.
+- `local_format=vortex` is accepted for non-primary-key, non-vector fields.
+- Primary-key fields reject `local_format=vortex`.
+- Vector fields reject `local_format=vortex`.
+- Unknown values are rejected. The supported values are `raw` and `vortex`.
+
+### Storage V3 Relationship
+
+`local_format` is only effective for Storage V3 sealed segments.
+
+For write-time column group planning, fields marked `local_format=vortex` are
+partitioned away from fields using the raw local format. A column group whose
+remaining fields all use Vortex local format is written with physical format
+`vortex`; other column groups use the normal fallback storage format.
+
+For read-time loading, Vortex local format is used only when both conditions are
+true:
+
+- all fields in the physical column group have `local_format=vortex`;
+- the Storage V3 manifest says the physical column group file is Vortex.
+
+If either condition is false, the segment uses the existing raw loading path for
+that column group.
+
+## Design Details
+
+### High-Level Architecture
+
+The design introduces `ColumnBasedInterface` as the column-oriented access
+abstraction for sealed scalar fields. This is the main interface shift for
+local format: Vortex data is not naturally owned as Milvus raw chunks, so the
+new path moves callers from `ChunkedBase` chunk access to column-level
+operations.
+
+`Scan` is one operation under `ColumnBasedInterface`, used by expression
+evaluation. Positional take/output operations are also part of the same
+column-based abstraction and are used by retrieve and requery. The Vortex reader
+consumes a sparse local file view behind these column-level operations.
+
+Milvus is in a transition state where two access families coexist:
+
+- `ChunkedBase` remains the raw chunk-oriented path for the existing raw local
+  format and existing chunk consumers.
+- `ColumnBasedInterface` is the local-format-aware path used by Vortex and by
+  scan/take code that should not depend on physical chunk ownership.
+
+Filter scan path:
+
+```text
+Expr
+  -> ColumnBasedInterface::Scan(...)
+  -> VortexColumn
+  -> VortexPlanner
+  -> VortexColumnGroup cache slot pin
+  -> VortexFormatReader::read_with_plan / read_row_ids_with_plan
+  -> Vortex scan builder
+```
+
+Retrieve/requery output path:
+
+```text
+Retrieve output / bulk_subscript
+  -> ColumnBasedInterface positional take
+  -> VortexColumn::Take...
+  -> VortexPlanner::PlanForOffsets
+  -> VortexColumnGroup cache slot pin
+  -> VortexFormatReader::read_with_plan(row indices)
+```
+
+The key ownership split is:
+
+- `milvus-storage` understands the Vortex file layout and maps row ranges,
+  offsets, and predicates to Vortex read plans.
+- Milvus QueryNode owns cache pinning, sparse-file lifecycle, expression cursor
+  consumption, and output conversion.
+
+### Column Group Splitting
+
+Column group splitting partitions fields by `local_format` before subsequent
+split policies finalize physical groups. This prevents raw and Vortex local
+format fields from sharing one physical column group.
+
+The split policy behavior is:
+
+1. Partition pending fields by `local_format`.
+2. Keep the partition's format metadata through later split policies.
+3. Emit physical column groups with `Format=vortex` only for Vortex local format
+   groups.
+4. Leave raw groups with an empty format override so they use the configured
+   fallback storage format.
+
+System, vector, text, average-size, and remanent-short split policies still
+apply after the local-format partitioning. They split within the current local
+format partition instead of mixing formats.
+
+### Cell Semantics
+
+A cell is the cache and loading unit for Vortex local format. Cells are defined
+by the Vortex file layout and exposed through `VortexPlanner`.
+
+Vortex V1:
+
+- There is no stable row-group boundary.
+- A cell corresponds to a full flat physical unit.
+
+Vortex V2:
+
+- Row groups are available.
+- A cell corresponds to a complete row group and its physical segments.
+- Row-group boundaries must align for fields in the same physical column group.
+
+General cell invariants:
+
+- Cell ids are contiguous and start at zero within a file.
+- Cell row ranges are contiguous and cover the file.
+- Cells do not share physical segments.
+- All fields in the same physical column group share a `VortexColumnGroup`; pinning
+  a cell loads the underlying bytes once for all fields in that group.
+
+### Storage-Side Vortex Interfaces
+
+#### `VortexFooterReader`
+
+`VortexFooterReader` reads Vortex file metadata. It is not responsible for data
+scan, take, Milvus cache pinning, or cache lifetime.
+
+Responsibilities:
+
+- Open a Vortex file through a filesystem.
+- Materialize the footer into the sparse local file.
+- Optionally materialize V1/V2 zone-map segments.
+- Expose schema, row count, footer size, field layout, row-group ranges, and
+  physical byte ranges.
+- Prune row groups using zone maps when they are loaded.
+
+Lifecycle:
+
+- `Open(fs, load_zonemap)` succeeds at most once per reader instance.
+- `Open(false)` loads footer metadata only; pruning conservatively keeps all
+  candidate row groups.
+- `Open(true)` loads footer metadata, materializes zone-map bytes, and then
+  reopens the final Vortex file view so Vortex's internal initial-read cache
+  cannot retain sparse zero-filled zone-map bytes.
+
+#### `VortexPlanner`
+
+`VortexPlanner` converts logical Milvus access requests into two outputs:
+
+```cpp
+struct VortexPlan {
+    std::vector<uint64_t> cell_ids;
+    VortexReadPlan read_plan;
+};
+```
+
+- `cell_ids` are used by Milvus to pin Vortex cells through the cache layer.
+- `read_plan` is passed to `VortexFormatReader` for execution.
+
+Supported planning modes:
+
+- `PlanForRowRange(row_start, row_end, predicate)`
+- `PlanForOffsets(offsets)`
+
+For V2 row-group cells and supported predicates, the planner may use zone maps
+to prune cells. For V1 files or unsupported predicates, it returns all candidate
+cells conservatively.
+
+#### `VortexFormatReader`
+
+The common `FormatReader` interface remains compatible with existing callers.
+Vortex local format uses Vortex-specific extensions:
+
+- `read_with_plan(const VortexReadPlan&)`
+- `read_row_ids_with_plan(const VortexReadPlan&)`
+
+`read_with_plan` returns data as an Arrow stream. `read_row_ids_with_plan`
+returns file-local row ids satisfying the predicate in the plan. Predicate state
+is carried by `VortexReadPlan`, not by long-lived reader state. Existing
+`set_predicate` behavior remains for compatibility but is not the local format
+path.
+
+### Milvus-Side Components
+
+#### `FieldMeta`
+
+`FieldMeta` parses `type_params["local_format"]` and defaults to `raw`. It also
+serializes non-default local format back to the field schema.
+
+#### `ColumnBasedInterface`
+
+`ColumnBasedInterface` is the shared access contract for column-oriented scalar
+data. It lets callers express the operation they need without assuming the data
+is backed by raw Milvus chunks.
+
+The interface covers two operation groups:
+
+- scan operations for expression evaluation;
+- positional take/output operations for retrieve, requery, and bulk_subscript.
+
+`Scan` returns a cursor of `ScanBatch` values.
+
+Scan outputs:
+
+| Output | Payload |
+|--------|---------|
+| `ScanOutput::RowIds` | Sparse row ids that satisfy, or may satisfy, a pushed predicate. |
+| `ScanOutput::Data` | Dense values over a row range, plus validity when needed. |
+
+Data scan supports:
+
+- row range;
+- value kind (`FixedWidth`, `StringView`, `JsonView`, `ArrayView`);
+- validity;
+- validity-only projection.
+
+Row-id scan supports:
+
+- unary predicates;
+- binary range predicates;
+- sparse row-id batches.
+
+If a column implementation cannot support a scan mode, it falls back to the
+raw-compatible behavior through the existing chunked path.
+
+#### `VortexColumnGroup`
+
+`VortexColumnGroup` owns shared state for one physical Vortex column group.
+
+Each file state contains:
+
+- source filesystem and resolved source path;
+- sparse filesystem and sparse path;
+- `VortexFooterReader`;
+- group-level `VortexPlanner`;
+- cache slot and translator;
+- row count and memory accounting.
+
+All fields in the same physical group share the same `VortexColumnGroup`.
+
+#### `VortexColumn`
+
+`VortexColumn` is a field-level `ColumnBasedInterface` implementation over a
+shared `VortexColumnGroup`.
+
+Responsibilities:
+
+- Resolve the Vortex field name. External fields use the external column name;
+  internal fields use the field id string.
+- Build a field-level projected Arrow schema.
+- Create field-level planner/reader state.
+- Implement `Scan`.
+- Implement positional take helpers for retrieve output.
+
+### Filter Scan
+
+#### Predicate Pushdown
+
+For supported unary and binary range expressions, expression execution requests
+`ScanOutput::RowIds`.
+
+Example:
+
+```text
+UnaryExpr / BinaryRangeExpr
+  -> ColumnBasedInterface::Scan(ScanOutput::RowIds)
+  -> VortexColumn::Scan
+  -> VortexRowIdScanCursor
+  -> VortexPlanner::PlanForRowRange(predicate)
+  -> pin planned cells
+  -> VortexFormatReader::read_row_ids_with_plan
+  -> bitmap assembly in expression execution
+```
+
+The initial implementation supports a narrow set of predicate strings that can
+be represented safely for the Vortex reader. Unsupported expressions fall back
+to data scan. This keeps correctness independent of pushdown coverage.
+
+#### Data Scan
+
+Unsupported predicates, complex expressions, and expressions that need raw value
+inspection use `ScanOutput::Data`.
+
+Example:
+
+```text
+Expr data path
+  -> ColumnBasedInterface::Scan(ScanOutput::Data)
+  -> VortexDataScanCursor
+  -> VortexPlanner::PlanForRowRange(no predicate)
+  -> pin planned cells
+  -> VortexFormatReader::read_with_plan
+  -> expression layer evaluates predicate
+```
+
+This is the current path for examples such as `LIKE`, `IN`, JSON path
+expressions, and array predicates when they cannot be represented as a Vortex
+predicate.
+
+### Offset Input Execution
+
+Offset-input execution is used when expression evaluation is restricted to a
+known set of segment offsets.
+
+The initial Vortex local format implementation handles dense sorted offsets by
+scanning one continuous range:
+
+```text
+ProcessDataByOffsets
+  -> ProcessSortedDataByOffsetsByScan
+  -> scan [min_offset, max_offset + 1)
+  -> expression layer checks the offset bitmap
+```
+
+Bitmap or selection pushdown into `ColumnBasedInterface::Scan` is left as
+future work. The current strategy avoids many small reads while keeping
+semantics simple.
+
+### Retrieve and Requery
+
+Retrieve/requery output is not filter scan. It reads requested output fields at
+selected row offsets.
+
+```text
+FillTargetEntry / Retrieve output
+  -> bulk_subscript
+  -> ColumnBasedInterface positional take
+  -> VortexColumn::BulkPrimitiveValueAt / BulkRawStringAt / BulkArrayAt
+  -> TakeOwn / TakeStringLikeViews
+  -> VortexPlanner::PlanForOffsets
+  -> pin planned cells
+  -> VortexFormatReader::read_with_plan(row indices)
+  -> restore requested output order
+```
+
+The planner disables predicate semantics for take because retrieve output is
+positional. Random requery over long strings can still touch many cells; this is
+tracked as a separate performance area from filter pushdown.
+
+### Nullable and Validity
+
+The `ColumnBasedInterface` scan API uses `ValidityView` to present nullability
+uniformly.
+
+Rules:
+
+- Non-nullable fields may return all-valid validity.
+- Nullable dense data scans must return validity aligned with the dense row
+  range.
+- Row-id scans may return validity aligned with sparse row ids.
+- Validity-only projection is part of the scan model so callers that only need
+  nullability do not need to materialize full values.
+
+The raw path may adapt its existing `bool*` validity representation into this
+model. Vortex uses Arrow bitmap/null-buffer semantics.
+
+### Sparse Local File and Cache Loading
+
+Vortex local format uses a sparse local file as the file view consumed by the
+Vortex reader.
+
+Flow:
+
+```text
+VortexFooterReader
+  -> materialize footer and optional zone-map bytes into sparse file
+
+VortexPlanner
+  -> choose cell ids and read plan
+
+Milvus cache layer
+  -> pin cells
+  -> Vortex translator loads cell byte ranges into sparse file
+
+VortexFormatReader
+  -> reads the sparse file as a normal file
+```
+
+Properties:
+
+- Loaded byte ranges are written to the sparse file.
+- Missing ranges remain sparse holes and read as zero-filled bytes if an
+  over-wide read crosses them.
+- Footer bytes are always materialized before planning.
+- Zone-map bytes are materialized when pruning is enabled.
+- Cell lifecycle remains controlled by Milvus cache pin/unpin.
+
+### Warmup and Eviction
+
+Vortex local format reuses Milvus cache warmup policy. Warmed scalar fields can
+load their cells during segment load, reducing the first-query penalty. Manual
+eviction and warmup cancellation are implemented at the `VortexColumnGroup`
+level so all field proxies in the same physical group share the same state.
+
+## Compatibility, Deprecation, and Migration Plan
+
+- Backward compatible by default: fields without `local_format` behave as
+  `raw`.
+- Existing non-Vortex segments continue to load through the raw path.
+- A schema can contain both raw and Vortex local format fields; column group
+  splitting keeps them physically separate.
+- During the transition, QueryNode keeps both access paths: raw fields continue
+  to use the `ChunkedBase` chunk-oriented path, while Vortex fields use the
+  `ColumnBasedInterface` column-oriented path.
+- Vortex local format is only used for Storage V3 sealed segments.
+- Rolling upgrades must ensure QueryNodes understand Vortex local format before
+  new Vortex column groups are loaded. Older readers cannot load Vortex physical
+  column groups.
+
+## Test Plan
+
+System and integration validation:
+
+- Create collections with raw fields, Vortex local format fields, and mixed
+  fields; verify insert, flush, load, search, query, and retrieve.
+- Verify `local_format=vortex` is rejected for primary-key and vector fields.
+- Verify Storage V3 manifests with Vortex physical column groups load as
+  `VortexColumnGroup + VortexColumn`.
+- Verify non-Vortex physical files continue to load through the raw path.
+- Run scalar filter benchmark cases for primitive predicates, complex
+  expressions, offset-input execution, and retrieve/requery output.
+
+Unit and component validation:
+
+- `FieldMeta` parse/serialize of `local_format`.
+- Column group split policy keeps raw and Vortex fields separate.
+- `ColumnBasedInterface` scan and positional take behavior.
+- Raw `ChunkedBase` path and Vortex `ColumnBasedInterface` path coexist without
+  changing raw field behavior.
+- `VortexColumn` row-id scan, data scan, validity, and take paths.
+- `VortexFooterReader` footer and optional zone-map lifecycle.
+- `VortexPlanner` row range, offset, and predicate pruning plans.
+- `VortexFormatReader::read_with_plan` and `read_row_ids_with_plan`.
+
+Performance validation:
+
+- Compare Vortex and raw local format for cold and hot retrieve.
+- Compare Vortex and raw local format for primitive filter scan.
+- Track complex data scan cases such as JSON, ARRAY, and `LIKE`.
+- Track random retrieve/requery over long VARCHAR because it exercises take and
+  output conversion rather than filter scan.
+
+## Future Work
+
+- Push offset bitmaps or row selections into `ColumnBasedInterface::Scan`.
+- Expand Vortex predicate construction for more scalar types and expression
+  forms.
+- Optimize long string, JSON, and ARRAY retrieve/take conversion paths.
+- Use validity-only scan in paths that only need nullability.
+
+## References
+
+- [Milvus PR: support vortex local format](https://github.com/milvus-io/milvus/pull/49908)
+- [Milvus issue: vortex local format](https://github.com/milvus-io/milvus/issues/50304)
+- [milvus-storage](https://github.com/milvus-io/milvus-storage)
+- [Vortex project](https://github.com/vortex-data/vortex)

--- a/internal/core/src/CMakeLists.txt
+++ b/internal/core/src/CMakeLists.txt
@@ -98,6 +98,7 @@ endif()
 add_subdirectory( pb )
 add_subdirectory( config )
 add_subdirectory( common )
+add_subdirectory( mmap )
 add_subdirectory( monitor )
 add_subdirectory( storage )
 add_subdirectory( index )
@@ -131,7 +132,7 @@ if (MILVUS_USE_PCH)
     # which are incompatible with PCH compiled under default target features.
     foreach(_target
         milvus_common milvus_config milvus_monitor milvus_storage milvus_index
-        milvus_query milvus_segcore milvus_indexbuilder milvus_clustering
+        milvus_mmap milvus_query milvus_segcore milvus_indexbuilder milvus_clustering
         milvus_exec milvus_futures milvus_rescores
         milvus_plan)
         target_precompile_headers(${_target} PRIVATE ${MILVUS_PCH_HEADERS})
@@ -142,6 +143,7 @@ add_library(milvus_core SHARED
     $<TARGET_OBJECTS:milvus_pb>
     $<TARGET_OBJECTS:milvus_config>
     $<TARGET_OBJECTS:milvus_common>
+    $<TARGET_OBJECTS:milvus_mmap>
     $<TARGET_OBJECTS:milvus_monitor>
     $<TARGET_OBJECTS:milvus_storage>
     $<TARGET_OBJECTS:milvus_index>

--- a/internal/core/src/common/Common.cpp
+++ b/internal/core/src/common/Common.cpp
@@ -44,6 +44,8 @@ std::atomic<bool> CONFIG_PARAM_TYPE_CHECK_ENABLED(
     DEFAULT_CONFIG_PARAM_TYPE_CHECK_ENABLED);
 std::atomic<bool> ENABLE_PARQUET_STATS_SKIP_INDEX(
     DEFAULT_ENABLE_PARQUET_STATS_SKIP_INDEX);
+std::atomic<bool> ENABLE_VORTEX_SCAN_PUSHDOWN(
+    DEFAULT_ENABLE_VORTEX_SCAN_PUSHDOWN);
 
 void
 SetIndexSliceSize(const int64_t size) {
@@ -111,6 +113,13 @@ SetDefaultEnableParquetStatsSkipIndex(bool val) {
     ENABLE_PARQUET_STATS_SKIP_INDEX.store(val);
     LOG_INFO("set default enable parquet stats: {}",
              ENABLE_PARQUET_STATS_SKIP_INDEX.load());
+}
+
+void
+SetDefaultVortexScanPushdownEnable(bool val) {
+    ENABLE_VORTEX_SCAN_PUSHDOWN.store(val);
+    LOG_INFO("set default enable vortex scan pushdown: {}",
+             ENABLE_VORTEX_SCAN_PUSHDOWN.load());
 }
 
 void

--- a/internal/core/src/common/Common.h
+++ b/internal/core/src/common/Common.h
@@ -35,6 +35,7 @@ extern std::atomic<bool> JSON_KEY_STATS_ENABLED;
 extern std::atomic<bool> GROWING_JSON_KEY_STATS_ENABLED;
 extern std::atomic<bool> CONFIG_PARAM_TYPE_CHECK_ENABLED;
 extern std::atomic<bool> ENABLE_PARQUET_STATS_SKIP_INDEX;
+extern std::atomic<bool> ENABLE_VORTEX_SCAN_PUSHDOWN;
 
 void
 SetIndexSliceSize(const int64_t size);
@@ -62,6 +63,9 @@ SetDefaultConfigParamTypeCheck(bool val);
 
 void
 SetDefaultEnableParquetStatsSkipIndex(bool val);
+
+void
+SetDefaultVortexScanPushdownEnable(bool val);
 
 void
 SetEnableLatestDeleteSnapshotOptimization(bool val);

--- a/internal/core/src/common/Consts.h
+++ b/internal/core/src/common/Consts.h
@@ -118,6 +118,7 @@ const bool DEFAULT_JSON_KEY_STATS_ENABLED = true;
 const bool DEFAULT_GROWING_JSON_KEY_STATS_ENABLED = false;
 const bool DEFAULT_CONFIG_PARAM_TYPE_CHECK_ENABLED = true;
 const bool DEFAULT_ENABLE_PARQUET_STATS_SKIP_INDEX = false;
+const bool DEFAULT_ENABLE_VORTEX_SCAN_PUSHDOWN = true;
 
 // skipindex stats related
 const double DEFAULT_BLOOM_FILTER_FALSE_POSITIVE_RATE = 0.01;
@@ -151,6 +152,10 @@ const std::string ELEMENT_TYPE_KEY_FOR_ARROW = "elementType";
 const float EPSILON = 0.0000000119;
 const std::string NAMESPACE_FIELD_NAME = "$namespace_id";
 const std::string MMAP_ENABLED_KEY = "mmap.enabled";
+constexpr const char* LOCAL_FORMAT_KEY = "local_format";
+constexpr const char* LOCAL_FORMAT_RAW = "raw";
+constexpr const char* LOCAL_FORMAT_VORTEX = "vortex";
+constexpr const char* STORAGE_FORMAT_VORTEX = "vortex";
 
 const int64_t LOGICAL_BITS = 18;
 // Warmup policy keys

--- a/internal/core/src/common/FieldMeta.cpp
+++ b/internal/core/src/common/FieldMeta.cpp
@@ -122,6 +122,7 @@ FieldMeta::ToProto() const {
         if (string_info_.has_value()) {
             params = string_info_->params;
         }
+        params.erase(LOCAL_FORMAT_KEY);
         params[MAX_LENGTH] = std::to_string(get_max_len());
         params["enable_match"] = enable_match() ? "true" : "false";
         params["enable_analyzer"] = enable_analyzer() ? "true" : "false";
@@ -130,6 +131,10 @@ FieldMeta::ToProto() const {
         }
     } else if (IsArrayDataType(type_)) {
         // element_type already populated above
+    }
+
+    if (local_format_ != LOCAL_FORMAT_RAW) {
+        add_type_param(LOCAL_FORMAT_KEY, local_format_);
     }
 
     return proto;
@@ -166,10 +171,17 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
         return schema_proto.default_value();
     }();
 
+    auto type_map = RepeatedKeyValToMap(schema_proto.type_params());
+    auto local_format = [&]() -> std::string {
+        if (auto it = type_map.find(LOCAL_FORMAT_KEY); it != type_map.end()) {
+            return it->second;
+        }
+        return LOCAL_FORMAT_RAW;
+    };
+
     if (data_type == DataType::VECTOR_ARRAY) {
         // todo(SpadeA): revisit the code when index build for vector array is ready
         int64_t dim = 0;
-        auto type_map = RepeatedKeyValToMap(schema_proto.type_params());
         AssertInfo(type_map.count("dim"), "dim not found");
         dim = boost::lexical_cast<int64_t>(type_map.at("dim"));
 
@@ -180,13 +192,13 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
                          dim,
                          std::nullopt,
                          nullable,
-                         external_field_mapping};
+                         external_field_mapping,
+                         local_format()};
     }
 
     if (IsVectorDataType(data_type)) {
         AssertInfo(!default_value.has_value(),
                    "vector fields do not support default values");
-        auto type_map = RepeatedKeyValToMap(schema_proto.type_params());
         auto index_map = RepeatedKeyValToMap(schema_proto.index_params());
 
         int64_t dim = 0;
@@ -203,7 +215,8 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
                              std::nullopt,
                              nullable,
                              default_value,
-                             external_field_mapping};
+                             external_field_mapping,
+                             local_format()};
         }
         auto metric_type = index_map.at("metric_type");
         return FieldMeta{name,
@@ -213,11 +226,11 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
                          metric_type,
                          nullable,
                          default_value,
-                         external_field_mapping};
+                         external_field_mapping,
+                         local_format()};
     }
 
     if (IsStringDataType(data_type)) {
-        auto type_map = RepeatedKeyValToMap(schema_proto.type_params());
         int64_t max_len = 0;
         if (type_map.count(MAX_LENGTH)) {
             max_len = boost::lexical_cast<int64_t>(type_map.at(MAX_LENGTH));
@@ -243,6 +256,8 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
 
         bool enable_analyzer = get_bool_value("enable_analyzer");
         bool enable_match = get_bool_value("enable_match");
+        auto string_params = type_map;
+        string_params.erase(LOCAL_FORMAT_KEY);
 
         return FieldMeta{name,
                          field_id,
@@ -251,9 +266,10 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
                          nullable,
                          enable_match,
                          enable_analyzer,
-                         type_map,
+                         string_params,
                          default_value,
-                         external_field_mapping};
+                         external_field_mapping,
+                         local_format()};
     }
 
     if (IsArrayDataType(data_type)) {
@@ -263,7 +279,8 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
                          DataType(schema_proto.element_type()),
                          nullable,
                          default_value,
-                         external_field_mapping};
+                         external_field_mapping,
+                         local_format()};
     }
 
     return FieldMeta{name,
@@ -271,7 +288,8 @@ FieldMeta::ParseFrom(const milvus::proto::schema::FieldSchema& schema_proto) {
                      data_type,
                      nullable,
                      default_value,
-                     external_field_mapping};
+                     external_field_mapping,
+                     local_format()};
 }
 
 }  // namespace milvus

--- a/internal/core/src/common/FieldMeta.h
+++ b/internal/core/src/common/FieldMeta.h
@@ -51,13 +51,15 @@ class FieldMeta {
               DataType type,
               bool nullable,
               std::optional<DefaultValueType> default_value,
-              std::string external_field_mapping = "")
+              std::string external_field_mapping = "",
+              std::string local_format = LOCAL_FORMAT_RAW)
         : name_(std::move(name)),
           id_(id),
           type_(type),
           nullable_(nullable),
           default_value_(std::move(default_value)),
-          external_field_mapping_(std::move(external_field_mapping)) {
+          external_field_mapping_(std::move(external_field_mapping)),
+          local_format_(std::move(local_format)) {
         Assert(!IsVectorDataType(type_));
     }
 
@@ -67,14 +69,16 @@ class FieldMeta {
               int64_t max_length,
               bool nullable,
               std::optional<DefaultValueType> default_value,
-              std::string external_field_mapping = "")
+              std::string external_field_mapping = "",
+              std::string local_format = LOCAL_FORMAT_RAW)
         : name_(std::move(name)),
           id_(id),
           type_(type),
           nullable_(nullable),
           string_info_(StringInfo{max_length}),
           default_value_(std::move(default_value)),
-          external_field_mapping_(std::move(external_field_mapping)) {
+          external_field_mapping_(std::move(external_field_mapping)),
+          local_format_(std::move(local_format)) {
         Assert(IsStringDataType(type_));
     }
 
@@ -87,7 +91,8 @@ class FieldMeta {
               bool enable_analyzer,
               std::map<std::string, std::string>& params,
               std::optional<DefaultValueType> default_value,
-              std::string external_field_mapping = "")
+              std::string external_field_mapping = "",
+              std::string local_format = LOCAL_FORMAT_RAW)
         : name_(std::move(name)),
           id_(id),
           type_(type),
@@ -99,7 +104,8 @@ class FieldMeta {
               std::move(params),
           }),
           default_value_(std::move(default_value)),
-          external_field_mapping_(std::move(external_field_mapping)) {
+          external_field_mapping_(std::move(external_field_mapping)),
+          local_format_(std::move(local_format)) {
         Assert(IsStringDataType(type_));
     }
 
@@ -109,14 +115,16 @@ class FieldMeta {
               DataType element_type,
               bool nullable,
               std::optional<DefaultValueType> default_value,
-              std::string external_field_mapping = "")
+              std::string external_field_mapping = "",
+              std::string local_format = LOCAL_FORMAT_RAW)
         : name_(std::move(name)),
           id_(id),
           type_(type),
           element_type_(element_type),
           nullable_(nullable),
           default_value_(std::move(default_value)),
-          external_field_mapping_(std::move(external_field_mapping)) {
+          external_field_mapping_(std::move(external_field_mapping)),
+          local_format_(std::move(local_format)) {
         Assert(IsArrayDataType(type_));
     }
 
@@ -129,14 +137,16 @@ class FieldMeta {
               std::optional<knowhere::MetricType> metric_type,
               bool nullable,
               std::optional<DefaultValueType> default_value,
-              std::string external_field_mapping = "")
+              std::string external_field_mapping = "",
+              std::string local_format = LOCAL_FORMAT_RAW)
         : name_(std::move(name)),
           id_(id),
           type_(type),
           nullable_(nullable),
           vector_info_(VectorInfo{dim, std::move(metric_type)}),
           default_value_(std::move(default_value)),
-          external_field_mapping_(std::move(external_field_mapping)) {
+          external_field_mapping_(std::move(external_field_mapping)),
+          local_format_(std::move(local_format)) {
         Assert(IsVectorDataType(type_));
         Assert(!default_value_.has_value() &&
                "vector fields do not support default values");
@@ -150,14 +160,16 @@ class FieldMeta {
               int64_t dim,
               std::optional<knowhere::MetricType> metric_type,
               bool nullable,
-              std::string external_field_mapping = "")
+              std::string external_field_mapping = "",
+              std::string local_format = LOCAL_FORMAT_RAW)
         : name_(std::move(name)),
           id_(id),
           type_(type),
           nullable_(nullable),
           element_type_(element_type),
           vector_info_(VectorInfo{dim, std::move(metric_type)}),
-          external_field_mapping_(std::move(external_field_mapping)) {
+          external_field_mapping_(std::move(external_field_mapping)),
+          local_format_(std::move(local_format)) {
         Assert(type_ == DataType::VECTOR_ARRAY);
         Assert(IsVectorDataType(element_type_));
     }
@@ -170,14 +182,16 @@ class FieldMeta {
               DataType type,
               bool nullable,
               std::optional<DefaultValueType> default_value,
-              std::string external_field_mapping = "")
+              std::string external_field_mapping = "",
+              std::string local_format = LOCAL_FORMAT_RAW)
         : name_(std::move(name)),
           id_(id),
           main_field_id_(main_field_id),
           type_(type),
           nullable_(nullable),
           default_value_(std::move(default_value)),
-          external_field_mapping_(std::move(external_field_mapping)) {
+          external_field_mapping_(std::move(external_field_mapping)),
+          local_format_(std::move(local_format)) {
         Assert(!IsVectorDataType(type_));
     }
 
@@ -296,6 +310,11 @@ class FieldMeta {
         external_field_mapping_ = external_field;
     }
 
+    const std::string&
+    get_local_format() const {
+        return local_format_;
+    }
+
     milvus::proto::schema::FieldSchema
     ToProto() const;
 
@@ -349,6 +368,7 @@ class FieldMeta {
     // of collection schema, the field id is the json shredding field id
     int64_t main_field_id_ = INVALID_FIELD_ID;
     std::string external_field_mapping_;
+    std::string local_format_ = LOCAL_FORMAT_RAW;
 };
 
 }  // namespace milvus

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -109,6 +109,11 @@ SetDefaultEnableParquetStatsSkipIndex(bool val) {
 }
 
 void
+SetDefaultVortexScanPushdownEnable(bool val) {
+    milvus::SetDefaultVortexScanPushdownEnable(val);
+}
+
+void
 SetEnableLatestDeleteSnapshotOptimization(bool val) {
     milvus::SetEnableLatestDeleteSnapshotOptimization(val);
 }

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -68,6 +68,9 @@ void
 SetDefaultEnableParquetStatsSkipIndex(bool val);
 
 void
+SetDefaultVortexScanPushdownEnable(bool val);
+
+void
 SetEnableLatestDeleteSnapshotOptimization(bool val);
 
 // dynamic update segcore params

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -479,6 +479,54 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
             processed_size = ProcessDataChunksForElementLevel<T>(
                 execute_sub_batch, skip_index_func, res, valid_res, val1, val2);
         } else {
+            auto make_scan_value = [](const HighPrecisionType& value) {
+                proto::plan::GenericValue scan_value;
+                if constexpr (std::is_same_v<HighPrecisionType, bool>) {
+                    scan_value.set_bool_val(value);
+                } else if constexpr (std::is_integral_v<HighPrecisionType>) {
+                    scan_value.set_int64_val(static_cast<int64_t>(value));
+                } else if constexpr (std::is_floating_point_v<
+                                         HighPrecisionType>) {
+                    scan_value.set_float_val(value);
+                } else if constexpr (std::is_same_v<HighPrecisionType,
+                                                    std::string>) {
+                    scan_value.set_string_val(value);
+                }
+                return scan_value;
+            };
+
+            auto column = segment_->GetChunkedColumn(field_id_);
+            if (!row_id_scan_initialized_) {
+                row_id_scan_initialized_ = true;
+                if (column != nullptr) {
+                    auto options =
+                        ChunkedColumnInterface::ScanOptions::ForBinaryRange(
+                            current_data_global_pos_,
+                            active_count_ - current_data_global_pos_,
+                            make_scan_value(val1),
+                            lower_inclusive,
+                            make_scan_value(val2),
+                            upper_inclusive);
+                    if (column->SupportsScanPushdown(options)) {
+                        row_id_scan_cursor_ = column->Scan(op_ctx_, options);
+                        AssertInfo(row_id_scan_cursor_ != nullptr,
+                                   "row id scan cursor is null for field {}",
+                                   field_id_.get());
+                    }
+                }
+            }
+            if (row_id_scan_cursor_ != nullptr) {
+                auto bitmaps = RowIdScanToBitmaps(row_id_scan_cursor_.get(),
+                                                  buffered_scan_entries_,
+                                                  row_id_scan_batch_,
+                                                  current_data_global_pos_,
+                                                  real_batch_size,
+                                                  bitmap_input);
+                MoveCursor();
+                return std::make_shared<ColumnVector>(
+                    std::move(bitmaps.result), std::move(bitmaps.validity));
+            }
+
             processed_size = ProcessDataChunks<T>(
                 execute_sub_batch, skip_index_func, res, valid_res, val1, val2);
         }

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -20,6 +20,7 @@
 #include <simdjson.h>
 #include <stdint.h>
 #include <cstddef>
+#include <deque>
 #include <memory>
 #include <optional>
 #include <string>
@@ -43,6 +44,7 @@
 #include "expr/ITypeExpr.h"
 #include "index/ScalarIndex.h"
 #include "index/json_stats/bson_inverted.h"
+#include "mmap/ChunkedColumnInterface.h"
 #include "pb/plan.pb.h"
 #include "segcore/SegmentInterface.h"
 #include "simdjson/error.h"
@@ -376,6 +378,11 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
     SingleElement upper_arg_;
     bool arg_inited_{false};
     PinWrapper<index::BsonInvertedIndex*> bson_index_{nullptr};
+    bool row_id_scan_initialized_{false};
+    std::unique_ptr<ChunkedColumnInterface::ScanCursor> row_id_scan_cursor_{
+        nullptr};
+    ChunkedColumnInterface::ScanBatch row_id_scan_batch_;
+    std::deque<RowIdScanEntry> buffered_scan_entries_;
 };
 }  //namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/CompareExpr.cpp
+++ b/internal/core/src/exec/expression/CompareExpr.cpp
@@ -49,11 +49,15 @@ PhyCompareFilterExpr::CanUseBothDataCompare(OffsetVector* input) const {
         return false;
     }
 
-    const auto is_left_string = expr_->left_data_type_ == DataType::VARCHAR ||
-                                expr_->left_data_type_ == DataType::TEXT;
-    const auto is_right_string = expr_->right_data_type_ == DataType::VARCHAR ||
-                                 expr_->right_data_type_ == DataType::TEXT;
-    if (is_left_string || is_right_string) {
+    const auto can_compare_string_type = [](DataType data_type) {
+        return data_type == DataType::VARCHAR || data_type == DataType::STRING;
+    };
+    if (IsStringDataType(expr_->left_data_type_) ||
+        IsStringDataType(expr_->right_data_type_)) {
+        const auto is_left_string =
+            can_compare_string_type(expr_->left_data_type_);
+        const auto is_right_string =
+            can_compare_string_type(expr_->right_data_type_);
         if (!is_left_string || !is_right_string) {
             return false;
         }
@@ -364,8 +368,8 @@ PhyCompareFilterExpr::ExecCompareExprDispatcherForBothDataSegment(
             return ExecCompareLeftType<float>(context);
         case DataType::DOUBLE:
             return ExecCompareLeftType<double>(context);
+        case DataType::STRING:
         case DataType::VARCHAR:
-        case DataType::TEXT:
             return ExecCompareLeftType<std::string_view>(context);
         default:
             ThrowInfo(
@@ -415,8 +419,8 @@ PhyCompareFilterExpr::ExecCompareLeftType(EvalCtx& context) {
                 return ExecCompareRightType<T, double>(context);
             }
             break;
+        case DataType::STRING:
         case DataType::VARCHAR:
-        case DataType::TEXT:
             if constexpr (IsCompareStringViewType<T>) {
                 return ExecCompareRightType<T, std::string_view>(context);
             }

--- a/internal/core/src/exec/expression/CompareExpr.cpp
+++ b/internal/core/src/exec/expression/CompareExpr.cpp
@@ -30,14 +30,51 @@ namespace milvus {
 namespace exec {
 
 bool
-PhyCompareFilterExpr::IsStringExpr() {
-    return expr_->left_data_type_ == DataType::VARCHAR ||
-           expr_->right_data_type_ == DataType::VARCHAR;
+PhyCompareFilterExpr::CanUseBothDataCompare(OffsetVector* input) const {
+    const auto is_supported_compare_op = [&]() {
+        switch (expr_->op_type_) {
+            case OpType::Equal:
+            case OpType::NotEqual:
+            case OpType::GreaterEqual:
+            case OpType::GreaterThan:
+            case OpType::LessEqual:
+            case OpType::LessThan:
+            case OpType::PrefixMatch:
+                return true;
+            default:
+                return false;
+        }
+    }();
+    if (!is_supported_compare_op) {
+        return false;
+    }
+
+    const auto is_left_string = expr_->left_data_type_ == DataType::VARCHAR ||
+                                expr_->left_data_type_ == DataType::TEXT;
+    const auto is_right_string = expr_->right_data_type_ == DataType::VARCHAR ||
+                                 expr_->right_data_type_ == DataType::TEXT;
+    if (is_left_string || is_right_string) {
+        if (!is_left_string || !is_right_string) {
+            return false;
+        }
+        if (input != nullptr &&
+            !IsDenseOffsetInputForScan(input, batch_size_)) {
+            return false;
+        }
+        return segment_chunk_reader_.segment_->GetChunkedColumn(left_field_) !=
+                   nullptr &&
+               segment_chunk_reader_.segment_->GetChunkedColumn(right_field_) !=
+                   nullptr;
+    }
+
+    return expr_->op_type_ != OpType::PrefixMatch;
 }
 
 bool
 PhyCompareFilterExpr::CanUseBothDataFastPath() {
-    if (is_left_indexed_ || is_right_indexed_ || IsStringExpr()) {
+    if (is_left_indexed_ || is_right_indexed_ ||
+        IsStringDataType(expr_->left_data_type_) ||
+        IsStringDataType(expr_->right_data_type_)) {
         return false;
     }
 
@@ -264,9 +301,11 @@ PhyCompareFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
 
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));
-    // For segment both fields has no index, can use SIMD to speed up.
-    // Avoiding too much call stack that blocks SIMD.
-    if (CanUseBothDataFastPath()) {
+    // For unindexed field-field compare, use the direct data path. Fixed-width
+    // values use DataScan when available and fall back to chunk SIMD. String
+    // values require Scan-provided string_view batches.
+    if (!is_left_indexed_ && !is_right_indexed_ &&
+        CanUseBothDataCompare(input)) {
         result = ExecCompareExprDispatcherForBothDataSegment(context);
         return;
     }
@@ -325,6 +364,9 @@ PhyCompareFilterExpr::ExecCompareExprDispatcherForBothDataSegment(
             return ExecCompareLeftType<float>(context);
         case DataType::DOUBLE:
             return ExecCompareLeftType<double>(context);
+        case DataType::VARCHAR:
+        case DataType::TEXT:
+            return ExecCompareLeftType<std::string_view>(context);
         default:
             ThrowInfo(
                 DataTypeInvalid,
@@ -336,27 +378,58 @@ PhyCompareFilterExpr::ExecCompareExprDispatcherForBothDataSegment(
 template <typename T>
 VectorPtr
 PhyCompareFilterExpr::ExecCompareLeftType(EvalCtx& context) {
-    switch (expr_->right_data_type_) {
+    const auto right_type = expr_->right_data_type_;
+    switch (right_type) {
         case DataType::BOOL:
-            return ExecCompareRightType<T, bool>(context);
+            if constexpr (!IsCompareStringViewType<T>) {
+                return ExecCompareRightType<T, bool>(context);
+            }
+            break;
         case DataType::INT8:
-            return ExecCompareRightType<T, int8_t>(context);
+            if constexpr (!IsCompareStringViewType<T>) {
+                return ExecCompareRightType<T, int8_t>(context);
+            }
+            break;
         case DataType::INT16:
-            return ExecCompareRightType<T, int16_t>(context);
+            if constexpr (!IsCompareStringViewType<T>) {
+                return ExecCompareRightType<T, int16_t>(context);
+            }
+            break;
         case DataType::INT32:
-            return ExecCompareRightType<T, int32_t>(context);
+            if constexpr (!IsCompareStringViewType<T>) {
+                return ExecCompareRightType<T, int32_t>(context);
+            }
+            break;
         case DataType::INT64:
-            return ExecCompareRightType<T, int64_t>(context);
+            if constexpr (!IsCompareStringViewType<T>) {
+                return ExecCompareRightType<T, int64_t>(context);
+            }
+            break;
         case DataType::FLOAT:
-            return ExecCompareRightType<T, float>(context);
+            if constexpr (!IsCompareStringViewType<T>) {
+                return ExecCompareRightType<T, float>(context);
+            }
+            break;
         case DataType::DOUBLE:
-            return ExecCompareRightType<T, double>(context);
+            if constexpr (!IsCompareStringViewType<T>) {
+                return ExecCompareRightType<T, double>(context);
+            }
+            break;
+        case DataType::VARCHAR:
+        case DataType::TEXT:
+            if constexpr (IsCompareStringViewType<T>) {
+                return ExecCompareRightType<T, std::string_view>(context);
+            }
+            break;
         default:
             ThrowInfo(
                 DataTypeInvalid,
                 fmt::format("unsupported right datatype:{} of compare expr",
-                            expr_->right_data_type_));
+                            right_type));
     }
+    ThrowInfo(DataTypeInvalid,
+              fmt::format("unsupported right datatype:{} of compare expr",
+                          right_type));
 }
 
 template <typename T, typename U>
@@ -458,6 +531,18 @@ PhyCompareFilterExpr::ExecCompareRightType(EvalCtx& context) {
                      offsets);
                 break;
             }
+            case proto::plan::PrefixMatch: {
+                CompareElementFunc<T, U, proto::plan::PrefixMatch, filter_type>
+                    func;
+                func(left,
+                     right,
+                     size,
+                     res,
+                     bitmap_input,
+                     processed_cursor,
+                     offsets);
+                break;
+            }
             default:
                 ThrowInfo(OpTypeInvalid,
                           fmt::format("unsupported operator type for "
@@ -471,8 +556,15 @@ PhyCompareFilterExpr::ExecCompareRightType(EvalCtx& context) {
         processed_size = ProcessBothDataByOffsets<T, U>(
             execute_sub_batch, input, res, valid_res);
     } else {
-        processed_size = ProcessBothDataChunks<T, U>(
-            execute_sub_batch, input, res, valid_res);
+        processed_size = TryProcessBothDataByScan<T, U>(
+            execute_sub_batch, real_batch_size, res, valid_res);
+        if (processed_size < 0) {
+            if constexpr (!IsCompareStringViewType<T> &&
+                          !IsCompareStringViewType<U>) {
+                processed_size = ProcessBothDataChunks<T, U>(
+                    execute_sub_batch, input, res, valid_res);
+            }
+        }
     }
     AssertInfo(processed_size == real_batch_size,
                "internal error: expr processed rows {} not equal "

--- a/internal/core/src/exec/expression/CompareExpr.h
+++ b/internal/core/src/exec/expression/CompareExpr.h
@@ -17,11 +17,14 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -40,12 +43,47 @@
 #include "exec/expression/Expr.h"
 #include "expr/ITypeExpr.h"
 #include "index/Index.h"
+#include "mmap/ChunkedColumnInterface.h"
 #include "pb/plan.pb.h"
 #include "segcore/SegmentChunkReader.h"
 #include "segcore/SegmentInterface.h"
 
 namespace milvus {
 namespace exec {
+
+template <typename T>
+inline constexpr bool IsCompareStringViewType =
+    std::is_same_v<std::remove_cv_t<T>, std::string_view>;
+
+template <typename T, typename U, proto::plan::OpType op>
+inline bool
+CompareColumnValues(const T& left, const U& right) {
+    if constexpr (op == proto::plan::OpType::Equal) {
+        return left == right;
+    } else if constexpr (op == proto::plan::OpType::NotEqual) {
+        return left != right;
+    } else if constexpr (op == proto::plan::OpType::GreaterThan) {
+        return left > right;
+    } else if constexpr (op == proto::plan::OpType::LessThan) {
+        return left < right;
+    } else if constexpr (op == proto::plan::OpType::GreaterEqual) {
+        return left >= right;
+    } else if constexpr (op == proto::plan::OpType::LessEqual) {
+        return left <= right;
+    } else if constexpr (op == proto::plan::OpType::PrefixMatch) {
+        if constexpr (IsCompareStringViewType<T> &&
+                      IsCompareStringViewType<U>) {
+            return PrefixMatch(left, right);
+        } else {
+            ThrowInfo(OpTypeInvalid,
+                      "PrefixMatch only supports string compare expr");
+        }
+    } else {
+        ThrowInfo(OpTypeInvalid,
+                  fmt::format("unsupported op_type:{} for compare expr", op));
+    }
+    return false;
+}
 
 template <typename T,
           typename U,
@@ -65,25 +103,8 @@ struct CompareElementFunc {
         if constexpr (filter_type == FilterType::random) {
             for (int i = 0; i < size; ++i) {
                 auto offset = (offsets != nullptr) ? offsets[i] : i;
-                if constexpr (op == proto::plan::OpType::Equal) {
-                    res[i] = left[offset] == right[offset];
-                } else if constexpr (op == proto::plan::OpType::NotEqual) {
-                    res[i] = left[offset] != right[offset];
-                } else if constexpr (op == proto::plan::OpType::GreaterThan) {
-                    res[i] = left[offset] > right[offset];
-                } else if constexpr (op == proto::plan::OpType::LessThan) {
-                    res[i] = left[offset] < right[offset];
-                } else if constexpr (op == proto::plan::OpType::GreaterEqual) {
-                    res[i] = left[offset] >= right[offset];
-                } else if constexpr (op == proto::plan::OpType::LessEqual) {
-                    res[i] = left[offset] <= right[offset];
-                } else {
-                    ThrowInfo(
-                        OpTypeInvalid,
-                        fmt::format(
-                            "unsupported op_type:{} for CompareElementFunc",
-                            op));
-                }
+                res[i] =
+                    CompareColumnValues<T, U, op>(left[offset], right[offset]);
             }
             return;
         }
@@ -93,51 +114,54 @@ struct CompareElementFunc {
                 if (!bitmap_input[start_cursor + i]) {
                     continue;
                 }
-                if constexpr (op == proto::plan::OpType::Equal) {
-                    res[i] = left[i] == right[i];
-                } else if constexpr (op == proto::plan::OpType::NotEqual) {
-                    res[i] = left[i] != right[i];
-                } else if constexpr (op == proto::plan::OpType::GreaterThan) {
-                    res[i] = left[i] > right[i];
-                } else if constexpr (op == proto::plan::OpType::LessThan) {
-                    res[i] = left[i] < right[i];
-                } else if constexpr (op == proto::plan::OpType::GreaterEqual) {
-                    res[i] = left[i] >= right[i];
-                } else if constexpr (op == proto::plan::OpType::LessEqual) {
-                    res[i] = left[i] <= right[i];
-                } else {
-                    ThrowInfo(
-                        OpTypeInvalid,
-                        fmt::format(
-                            "unsupported op_type:{} for CompareElementFunc",
-                            op));
-                }
+                res[i] = CompareColumnValues<T, U, op>(left[i], right[i]);
             }
             return;
         }
 
-        if constexpr (op == proto::plan::OpType::Equal) {
-            res.inplace_compare_column<T, U, milvus::bitset::CompareOpType::EQ>(
-                left, right, size);
-        } else if constexpr (op == proto::plan::OpType::NotEqual) {
-            res.inplace_compare_column<T, U, milvus::bitset::CompareOpType::NE>(
-                left, right, size);
-        } else if constexpr (op == proto::plan::OpType::GreaterThan) {
-            res.inplace_compare_column<T, U, milvus::bitset::CompareOpType::GT>(
-                left, right, size);
-        } else if constexpr (op == proto::plan::OpType::LessThan) {
-            res.inplace_compare_column<T, U, milvus::bitset::CompareOpType::LT>(
-                left, right, size);
-        } else if constexpr (op == proto::plan::OpType::GreaterEqual) {
-            res.inplace_compare_column<T, U, milvus::bitset::CompareOpType::GE>(
-                left, right, size);
-        } else if constexpr (op == proto::plan::OpType::LessEqual) {
-            res.inplace_compare_column<T, U, milvus::bitset::CompareOpType::LE>(
-                left, right, size);
+        if constexpr (IsCompareStringViewType<T> ||
+                      IsCompareStringViewType<U>) {
+            for (int i = 0; i < size; ++i) {
+                res[i] = CompareColumnValues<T, U, op>(left[i], right[i]);
+            }
+            return;
         } else {
-            ThrowInfo(OpTypeInvalid,
-                      fmt::format(
-                          "unsupported op_type:{} for CompareElementFunc", op));
+            if constexpr (op == proto::plan::OpType::Equal) {
+                res.inplace_compare_column<T,
+                                           U,
+                                           milvus::bitset::CompareOpType::EQ>(
+                    left, right, size);
+            } else if constexpr (op == proto::plan::OpType::NotEqual) {
+                res.inplace_compare_column<T,
+                                           U,
+                                           milvus::bitset::CompareOpType::NE>(
+                    left, right, size);
+            } else if constexpr (op == proto::plan::OpType::GreaterThan) {
+                res.inplace_compare_column<T,
+                                           U,
+                                           milvus::bitset::CompareOpType::GT>(
+                    left, right, size);
+            } else if constexpr (op == proto::plan::OpType::LessThan) {
+                res.inplace_compare_column<T,
+                                           U,
+                                           milvus::bitset::CompareOpType::LT>(
+                    left, right, size);
+            } else if constexpr (op == proto::plan::OpType::GreaterEqual) {
+                res.inplace_compare_column<T,
+                                           U,
+                                           milvus::bitset::CompareOpType::GE>(
+                    left, right, size);
+            } else if constexpr (op == proto::plan::OpType::LessEqual) {
+                res.inplace_compare_column<T,
+                                           U,
+                                           milvus::bitset::CompareOpType::LE>(
+                    left, right, size);
+            } else {
+                ThrowInfo(
+                    OpTypeInvalid,
+                    fmt::format("unsupported op_type:{} for CompareElementFunc",
+                                op));
+            }
         }
     }
 };
@@ -236,6 +260,7 @@ class PhyCompareFilterExpr : public Expr {
                     num_chunk_,
                     batch_size_);
             }
+            ResetDataScanCursors();
         }
     }
 
@@ -300,10 +325,25 @@ class PhyCompareFilterExpr : public Expr {
     GetNextBatchSize();
 
     bool
-    IsStringExpr();
+    CanUseBothDataCompare(OffsetVector* input) const;
 
     bool
     CanUseBothDataFastPath();
+
+    template <typename T>
+    static ChunkedColumnInterface::ScanValueKind
+    DataScanValueKind() {
+        if constexpr (std::is_same_v<T, std::string_view> ||
+                      std::is_same_v<T, std::string>) {
+            return ChunkedColumnInterface::ScanValueKind::StringView;
+        } else if constexpr (std::is_same_v<T, Json>) {
+            return ChunkedColumnInterface::ScanValueKind::JsonView;
+        } else if constexpr (std::is_same_v<T, ArrayView>) {
+            return ChunkedColumnInterface::ScanValueKind::ArrayView;
+        } else {
+            return ChunkedColumnInterface::ScanValueKind::FixedWidth;
+        }
+    }
 
     template <typename T, typename U, typename FUNC, typename... ValTypes>
     int64_t
@@ -312,25 +352,149 @@ class PhyCompareFilterExpr : public Expr {
                           TargetBitmapView res,
                           TargetBitmapView valid_res,
                           const ValTypes&... values) {
+        (void)input;
         if (segment_chunk_reader_.segment_->is_chunked()) {
             return ProcessBothDataChunksForMultipleChunk<T,
                                                          U,
                                                          FUNC,
                                                          ValTypes...>(
                 func, res, valid_res, values...);
-        } else {
-            return ProcessBothDataChunksForSingleChunk<T, U, FUNC, ValTypes...>(
-                func, res, valid_res, values...);
         }
+        return ProcessBothDataChunksForSingleChunk<T, U, FUNC, ValTypes...>(
+            func, res, valid_res, values...);
+    }
+
+    // Process sorted offsets with one continuous Scan per column.
+    // TODO: push the offset bitmap down into Scan when Vortex supports bitmap scan.
+    template <typename T, typename U, typename FUNC, typename... ValTypes>
+    int64_t
+    ProcessBothSortedDataByOffsets(FUNC func,
+                                   OffsetVector* input,
+                                   TargetBitmapView res,
+                                   TargetBitmapView valid_res,
+                                   const ValTypes&... values) {
+        auto left_column =
+            segment_chunk_reader_.segment_->GetChunkedColumn(left_field_);
+        auto right_column =
+            segment_chunk_reader_.segment_->GetChunkedColumn(right_field_);
+        if (left_column == nullptr || right_column == nullptr) {
+            return -1;
+        }
+        if (input->empty()) {
+            return 0;
+        }
+
+        const auto scan_start = static_cast<int64_t>((*input)[0]);
+        const auto scan_end =
+            static_cast<int64_t>((*input)[input->size() - 1]) + 1;
+        const auto scan_length = scan_end - scan_start;
+        AssertInfo(scan_length > 0,
+                   "invalid compare offset scan range [{}, {})",
+                   scan_start,
+                   scan_end);
+
+        auto left_options = ChunkedColumnInterface::ScanOptions::ForData(
+            scan_start,
+            scan_length,
+            ChunkedColumnInterface::ScanProjection::Data,
+            DataScanValueKind<T>());
+        auto right_options = ChunkedColumnInterface::ScanOptions::ForData(
+            scan_start,
+            scan_length,
+            ChunkedColumnInterface::ScanProjection::Data,
+            DataScanValueKind<U>());
+        auto left_cursor = left_column->Scan(op_ctx_, left_options);
+        auto right_cursor = right_column->Scan(op_ctx_, right_options);
+        if (left_cursor == nullptr || right_cursor == nullptr) {
+            return -1;
+        }
+
+        ChunkedColumnInterface::ScanBatch left_batch;
+        ChunkedColumnInterface::ScanBatch right_batch;
+        int64_t left_batch_pos = 0;
+        int64_t right_batch_pos = 0;
+        size_t processed_offsets = 0;
+        std::vector<int32_t> batch_offsets;
+        batch_offsets.reserve(std::min<int64_t>(batch_size_, input->size()));
+
+        while (processed_offsets < input->size()) {
+            if (!EnsureDataScanBatch(left_cursor, left_batch, left_batch_pos) ||
+                !EnsureDataScanBatch(
+                    right_cursor, right_batch, right_batch_pos)) {
+                break;
+            }
+
+            const auto left_row = left_batch.row_id_start + left_batch_pos;
+            const auto right_row = right_batch.row_id_start + right_batch_pos;
+            const auto interval_start = std::max(left_row, right_row);
+            const auto interval_end =
+                std::min(left_batch.row_id_start + left_batch.size,
+                         right_batch.row_id_start + right_batch.size);
+            AssertInfo(interval_start < interval_end,
+                       "invalid compare offset scan interval [{}, {})",
+                       interval_start,
+                       interval_end);
+
+            const auto group_start = processed_offsets;
+            const auto left_base = interval_start - left_batch.row_id_start;
+            const auto right_base = interval_start - right_batch.row_id_start;
+            batch_offsets.clear();
+            while (processed_offsets < input->size()) {
+                const auto row =
+                    static_cast<int64_t>((*input)[processed_offsets]);
+                if (row >= interval_end) {
+                    break;
+                }
+                AssertInfo(row >= interval_start,
+                           "compare offset {} is before scan interval [{}, {})",
+                           row,
+                           interval_start,
+                           interval_end);
+                batch_offsets.push_back(
+                    static_cast<int32_t>(row - interval_start));
+                ++processed_offsets;
+            }
+
+            const auto group_size =
+                static_cast<int64_t>(processed_offsets - group_start);
+            if (group_size > 0) {
+                func.template operator()<FilterType::random>(
+                    left_batch.values.data_as<T>() + left_base,
+                    right_batch.values.data_as<U>() + right_base,
+                    batch_offsets.data(),
+                    static_cast<int>(group_size),
+                    res + group_start,
+                    values...);
+
+                for (int64_t i = 0; i < group_size; ++i) {
+                    if (!left_batch.validity.IsValid(left_base +
+                                                     batch_offsets[i]) ||
+                        !right_batch.validity.IsValid(right_base +
+                                                      batch_offsets[i])) {
+                        res[group_start + i] = false;
+                        valid_res[group_start + i] = false;
+                    }
+                }
+            }
+
+            left_batch_pos += interval_end - left_row;
+            right_batch_pos += interval_end - right_row;
+        }
+
+        AssertInfo(processed_offsets == input->size(),
+                   "compare offset scan processed {} offsets, expected {}",
+                   processed_offsets,
+                   input->size());
+        return input->size();
     }
 
     template <typename T, typename U, typename FUNC, typename... ValTypes>
     int64_t
-    ProcessBothDataByOffsets(FUNC func,
-                             OffsetVector* input,
-                             TargetBitmapView res,
-                             TargetBitmapView valid_res,
-                             const ValTypes&... values) {
+    ProcessBothDataByOffsetsByChunkFallback(FUNC func,
+                                            OffsetVector* input,
+                                            TargetBitmapView res,
+                                            TargetBitmapView valid_res,
+                                            const ValTypes&... values) {
         int64_t size = input->size();
         int64_t processed_size = 0;
         if (segment_chunk_reader_.segment_->is_chunked() ||
@@ -345,10 +509,9 @@ class PhyCompareFilterExpr : public Expr {
                             segment_chunk_reader_.SizePerChunk();
                         return {offset / size_per_chunk,
                                 offset % size_per_chunk};
-                    } else {
-                        return segment_chunk_reader_.segment_
-                            ->get_chunk_by_offset(field, offset);
                     }
+                    return segment_chunk_reader_.segment_->get_chunk_by_offset(
+                        field, offset);
                 };
 
                 auto [left_chunk_id, left_chunk_offset] =
@@ -388,45 +551,71 @@ class PhyCompareFilterExpr : public Expr {
                 processed_size++;
             }
             return processed_size;
-        } else {
-            auto pw_left = segment_chunk_reader_.segment_->chunk_data<T>(
-                op_ctx_, left_field_, 0);
-            auto left_chunk = pw_left.get();
-            auto pw_right = segment_chunk_reader_.segment_->chunk_data<U>(
-                op_ctx_, right_field_, 0);
-            auto right_chunk = pw_right.get();
-            const T* left_data = left_chunk.data();
-            const U* right_data = right_chunk.data();
-            const bool* left_valid_data = left_chunk.valid_data();
-            const bool* right_valid_data = right_chunk.valid_data();
-            if (left_valid_data || right_valid_data) {
-                for (int i = 0; i < size; ++i) {
-                    auto offset = (*input)[i];
-                    if (left_valid_data && !left_valid_data[offset]) {
-                        res[i] = false;
-                        valid_res[i] = false;
-                        continue;
-                    }
-                    if (right_valid_data && !right_valid_data[offset]) {
-                        res[i] = false;
-                        valid_res[i] = false;
-                        continue;
-                    }
-                    func.template operator()<FilterType::random>(
-                        left_data + offset,
-                        right_data + offset,
-                        nullptr,
-                        1,
-                        res + i,
-                        values...);
+        }
+
+        auto pw_left = segment_chunk_reader_.segment_->chunk_data<T>(
+            op_ctx_, left_field_, 0);
+        auto left_chunk = pw_left.get();
+        auto pw_right = segment_chunk_reader_.segment_->chunk_data<U>(
+            op_ctx_, right_field_, 0);
+        auto right_chunk = pw_right.get();
+        const T* left_data = left_chunk.data();
+        const U* right_data = right_chunk.data();
+        const bool* left_valid_data = left_chunk.valid_data();
+        const bool* right_valid_data = right_chunk.valid_data();
+        if (left_valid_data || right_valid_data) {
+            for (int i = 0; i < size; ++i) {
+                auto offset = (*input)[i];
+                if (left_valid_data && !left_valid_data[offset]) {
+                    res[i] = false;
+                    valid_res[i] = false;
+                    continue;
                 }
-                processed_size += size;
-                return processed_size;
+                if (right_valid_data && !right_valid_data[offset]) {
+                    res[i] = false;
+                    valid_res[i] = false;
+                    continue;
+                }
+                func.template operator()<FilterType::random>(
+                    left_data + offset,
+                    right_data + offset,
+                    nullptr,
+                    1,
+                    res + i,
+                    values...);
             }
-            func.template operator()<FilterType::random>(
-                left_data, right_data, input->data(), size, res, values...);
-            processed_size += size;
-            return processed_size;
+            return size;
+        }
+        func.template operator()<FilterType::random>(
+            left_data, right_data, input->data(), size, res, values...);
+        return size;
+    }
+
+    template <typename T, typename U, typename FUNC, typename... ValTypes>
+    int64_t
+    ProcessBothDataByOffsets(FUNC func,
+                             OffsetVector* input,
+                             TargetBitmapView res,
+                             TargetBitmapView valid_res,
+                             const ValTypes&... values) {
+        if constexpr (IsCompareStringViewType<T> ||
+                      IsCompareStringViewType<U>) {
+            if (IsDenseOffsetInputForScan(input, batch_size_)) {
+                return ProcessBothSortedDataByOffsets<T, U>(
+                    func, input, res, valid_res, values...);
+            }
+            return -1;
+        } else {
+            if (IsDenseOffsetInputForScan(input, batch_size_)) {
+                const auto processed_size =
+                    ProcessBothSortedDataByOffsets<T, U>(
+                        func, input, res, valid_res, values...);
+                if (processed_size >= 0) {
+                    return processed_size;
+                }
+            }
+            return ProcessBothDataByOffsetsByChunkFallback<T, U>(
+                func, input, res, valid_res, values...);
         }
     }
 
@@ -476,7 +665,6 @@ class PhyCompareFilterExpr : public Expr {
                  values...);
             const bool* left_valid_data = left_chunk.valid_data();
             const bool* right_valid_data = right_chunk.valid_data();
-            // mask with valid_data
             for (int i = 0; i < size; ++i) {
                 if (left_valid_data && !left_valid_data[i + data_pos]) {
                     res[processed_size + i] = false;
@@ -508,7 +696,6 @@ class PhyCompareFilterExpr : public Expr {
                                           const ValTypes&... values) {
         int64_t processed_size = 0;
 
-        // only call this function when left and right are not indexed, so they have the same number of chunks
         for (size_t i = left_current_chunk_id_; i < left_num_chunk_; i++) {
             auto pw_left = segment_chunk_reader_.segment_->chunk_data<T>(
                 op_ctx_, left_field_, i);
@@ -518,7 +705,7 @@ class PhyCompareFilterExpr : public Expr {
             auto right_chunk = pw_right.get();
             auto data_pos =
                 (i == left_current_chunk_id_) ? left_current_chunk_pos_ : 0;
-            auto size = 0;
+            int64_t size = 0;
             if (segment_chunk_reader_.segment_->type() ==
                 SegmentType::Growing) {
                 size =
@@ -551,7 +738,6 @@ class PhyCompareFilterExpr : public Expr {
                  values...);
             const bool* left_valid_data = left_chunk.valid_data();
             const bool* right_valid_data = right_chunk.valid_data();
-            // mask with valid_data
             for (int i = 0; i < size; ++i) {
                 if (left_valid_data && !left_valid_data[i + data_pos]) {
                     res[processed_size + i] = false;
@@ -572,6 +758,114 @@ class PhyCompareFilterExpr : public Expr {
             }
         }
 
+        return processed_size;
+    }
+
+    template <typename T, typename U, typename FUNC, typename... ValTypes>
+    int64_t
+    TryProcessBothDataByScan(FUNC func,
+                             int64_t real_batch_size,
+                             TargetBitmapView res,
+                             TargetBitmapView valid_res,
+                             const ValTypes&... values) {
+        if (!data_scan_initialized_) {
+            data_scan_initialized_ = true;
+            auto left_column =
+                segment_chunk_reader_.segment_->GetChunkedColumn(left_field_);
+            auto right_column =
+                segment_chunk_reader_.segment_->GetChunkedColumn(right_field_);
+            if (left_column != nullptr && right_column != nullptr) {
+                const auto start = GetCurrentRows();
+                const auto length = segment_chunk_reader_.active_count_ - start;
+                auto left_options =
+                    ChunkedColumnInterface::ScanOptions::ForData(
+                        start,
+                        length,
+                        ChunkedColumnInterface::ScanProjection::Data,
+                        DataScanValueKind<T>());
+                auto right_options =
+                    ChunkedColumnInterface::ScanOptions::ForData(
+                        start,
+                        length,
+                        ChunkedColumnInterface::ScanProjection::Data,
+                        DataScanValueKind<U>());
+                left_data_cursor_ = left_column->Scan(op_ctx_, left_options);
+                right_data_cursor_ = right_column->Scan(op_ctx_, right_options);
+                if (left_data_cursor_ == nullptr ||
+                    right_data_cursor_ == nullptr) {
+                    left_data_cursor_.reset();
+                    right_data_cursor_.reset();
+                    return -1;
+                }
+            }
+        }
+        if (left_data_cursor_ == nullptr || right_data_cursor_ == nullptr) {
+            return -1;
+        }
+
+        int64_t processed_size = 0;
+        while (processed_size < real_batch_size) {
+            if (!EnsureDataScanBatch(left_data_cursor_,
+                                     left_data_batch_,
+                                     left_data_batch_pos_) ||
+                !EnsureDataScanBatch(right_data_cursor_,
+                                     right_data_batch_,
+                                     right_data_batch_pos_)) {
+                break;
+            }
+
+            const auto left_row =
+                left_data_batch_.row_id_start + left_data_batch_pos_;
+            const auto right_row =
+                right_data_batch_.row_id_start + right_data_batch_pos_;
+            const auto expected_row = GetCurrentRows() + processed_size;
+            AssertInfo(left_row == expected_row && right_row == expected_row,
+                       "compare data scan row mismatch, left {}, right {}, "
+                       "expected {}",
+                       left_row,
+                       right_row,
+                       expected_row);
+
+            auto size = std::min<int64_t>(
+                {real_batch_size - processed_size,
+                 left_data_batch_.size - left_data_batch_pos_,
+                 right_data_batch_.size - right_data_batch_pos_});
+            const auto* left_data =
+                left_data_batch_.values.data_as<T>() + left_data_batch_pos_;
+            const auto* right_data =
+                right_data_batch_.values.data_as<U>() + right_data_batch_pos_;
+
+            func(left_data,
+                 right_data,
+                 nullptr,
+                 size,
+                 res + processed_size,
+                 values...);
+
+            for (int64_t i = 0; i < size; ++i) {
+                if (!left_data_batch_.validity.IsValid(left_data_batch_pos_ +
+                                                       i)) {
+                    res[processed_size + i] = false;
+                    valid_res[processed_size + i] = false;
+                    continue;
+                }
+                if (!right_data_batch_.validity.IsValid(right_data_batch_pos_ +
+                                                        i)) {
+                    res[processed_size + i] = false;
+                    valid_res[processed_size + i] = false;
+                }
+            }
+
+            processed_size += size;
+            left_data_batch_pos_ += size;
+            right_data_batch_pos_ += size;
+        }
+
+        AssertInfo(processed_size == real_batch_size,
+                   "compare data scan processed {} rows, expected {}",
+                   processed_size,
+                   real_batch_size);
+        MoveCursor();
         return processed_size;
     }
 
@@ -616,6 +910,42 @@ class PhyCompareFilterExpr : public Expr {
     std::shared_ptr<const milvus::expr::CompareExpr> expr_;
     std::vector<PinWrapper<const index::IndexBase*>> pinned_index_left_;
     std::vector<PinWrapper<const index::IndexBase*>> pinned_index_right_;
+    bool data_scan_initialized_{false};
+    std::unique_ptr<ChunkedColumnInterface::ScanCursor> left_data_cursor_{
+        nullptr};
+    std::unique_ptr<ChunkedColumnInterface::ScanCursor> right_data_cursor_{
+        nullptr};
+    ChunkedColumnInterface::ScanBatch left_data_batch_;
+    ChunkedColumnInterface::ScanBatch right_data_batch_;
+    int64_t left_data_batch_pos_{0};
+    int64_t right_data_batch_pos_{0};
+
+    void
+    ResetDataScanCursors() {
+        data_scan_initialized_ = false;
+        left_data_cursor_.reset();
+        right_data_cursor_.reset();
+        left_data_batch_ = ChunkedColumnInterface::ScanBatch{};
+        right_data_batch_ = ChunkedColumnInterface::ScanBatch{};
+        left_data_batch_pos_ = 0;
+        right_data_batch_pos_ = 0;
+    }
+
+    bool
+    EnsureDataScanBatch(
+        std::unique_ptr<ChunkedColumnInterface::ScanCursor>& cursor,
+        ChunkedColumnInterface::ScanBatch& batch,
+        int64_t& batch_pos) {
+        while (batch_pos >= batch.size) {
+            batch_pos = 0;
+            if (!cursor->Next(&batch)) {
+                return false;
+            }
+            AssertInfo(!batch.values.empty() && batch.size > 0,
+                       "invalid compare data scan batch");
+        }
+        return true;
+    }
 };
 }  //namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -19,9 +19,12 @@
 #include <algorithm>
 #include <bit>
 #include <chrono>
+#include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include "common/Array.h"
 #include "common/ArrayOffsets.h"
@@ -37,6 +40,7 @@
 #include "index/Index.h"
 #include "index/JsonFlatIndex.h"
 #include "log/Log.h"
+#include "mmap/ChunkedColumnInterface.h"
 #include "query/PlanProto.h"
 #include "segcore/SegmentSealed.h"
 #include "segcore/SegmentInterface.h"
@@ -115,6 +119,152 @@ ApplyValidMask(const bool* valid_data,
             res[i] = valid_res[i] = false;
         }
     }
+}
+
+struct RowIdScanBitmaps {
+    TargetBitmap result;
+    TargetBitmap validity;
+};
+
+struct RowIdScanEntry {
+    int64_t row_id;
+    bool valid;
+};
+
+inline RowIdScanBitmaps
+RowIdScanToBitmaps(ChunkedColumnInterface::ScanCursor* cursor,
+                   std::deque<RowIdScanEntry>& buffered_entries,
+                   ChunkedColumnInterface::ScanBatch& scan_batch,
+                   int64_t batch_start,
+                   int64_t batch_size,
+                   const TargetBitmap& bitmap_input,
+                   bool mask_validity_by_bitmap_input = true) {
+    AssertInfo(cursor != nullptr, "row id scan cursor is null");
+    const int64_t batch_end = batch_start + batch_size;
+    RowIdScanBitmaps bitmaps{TargetBitmap(batch_size, false),
+                             TargetBitmap(batch_size, true)};
+
+    auto apply_entry = [&](const RowIdScanEntry& entry) {
+        const auto row_id = entry.row_id;
+        if (row_id < batch_start || row_id >= batch_end) {
+            return;
+        }
+        const auto local_index = static_cast<size_t>(row_id - batch_start);
+        if (!entry.valid) {
+            if (!mask_validity_by_bitmap_input || bitmap_input.empty() ||
+                bitmap_input[local_index]) {
+                bitmaps.validity[local_index] = false;
+            }
+            return;
+        }
+        if (bitmap_input.empty() || bitmap_input[local_index]) {
+            bitmaps.result[local_index] = true;
+        }
+    };
+
+    auto buffer_scan_batch_entries = [&]() {
+        AssertInfo(scan_batch.values.empty(),
+                   "row id payload scan batch should not contain values");
+        AssertInfo(scan_batch.validity.size ==
+                       static_cast<int64_t>(scan_batch.row_ids.size()),
+                   "row id payload scan validity size {} does not match "
+                   "row ids size {}",
+                   scan_batch.validity.size,
+                   scan_batch.row_ids.size());
+        AssertInfo(
+            scan_batch.size == static_cast<int64_t>(scan_batch.row_ids.size()),
+            "row id payload scan size {} does not match row ids size {}",
+            scan_batch.size,
+            scan_batch.row_ids.size());
+        for (size_t i = 0; i < scan_batch.row_ids.size(); ++i) {
+            const auto row_id = scan_batch.row_ids[i];
+            if (!buffered_entries.empty()) {
+                AssertInfo(buffered_entries.back().row_id <= row_id,
+                           "row id payload is not ordered: {} before {}",
+                           buffered_entries.back().row_id,
+                           row_id);
+            }
+            buffered_entries.push_back(RowIdScanEntry{
+                row_id, scan_batch.validity.IsValid(static_cast<int64_t>(i))});
+        }
+    };
+
+    auto apply_all_valid_scan_batch_entries = [&]() {
+        AssertInfo(scan_batch.values.empty(),
+                   "row id payload scan batch should not contain values");
+        AssertInfo(scan_batch.validity.size ==
+                       static_cast<int64_t>(scan_batch.row_ids.size()),
+                   "row id payload scan validity size {} does not match "
+                   "row ids size {}",
+                   scan_batch.validity.size,
+                   scan_batch.row_ids.size());
+        AssertInfo(
+            scan_batch.size == static_cast<int64_t>(scan_batch.row_ids.size()),
+            "row id payload scan size {} does not match row ids size {}",
+            scan_batch.size,
+            scan_batch.row_ids.size());
+
+        std::optional<int64_t> previous_row_id;
+        size_t i = 0;
+        for (; i < scan_batch.row_ids.size(); ++i) {
+            const auto row_id = scan_batch.row_ids[i];
+            if (previous_row_id.has_value()) {
+                AssertInfo(previous_row_id.value() <= row_id,
+                           "row id payload is not ordered: {} before {}",
+                           previous_row_id.value(),
+                           row_id);
+            }
+            previous_row_id = row_id;
+            if (row_id < batch_start) {
+                continue;
+            }
+            if (row_id >= batch_end) {
+                break;
+            }
+            const auto local_index = static_cast<size_t>(row_id - batch_start);
+            if (bitmap_input.empty() || bitmap_input[local_index]) {
+                bitmaps.result[local_index] = true;
+            }
+        }
+
+        for (; i < scan_batch.row_ids.size(); ++i) {
+            const auto row_id = scan_batch.row_ids[i];
+            if (previous_row_id.has_value()) {
+                AssertInfo(previous_row_id.value() <= row_id,
+                           "row id payload is not ordered: {} before {}",
+                           previous_row_id.value(),
+                           row_id);
+            }
+            previous_row_id = row_id;
+            buffered_entries.push_back(RowIdScanEntry{row_id, true});
+        }
+        return !buffered_entries.empty();
+    };
+
+    while (true) {
+        while (!buffered_entries.empty()) {
+            const auto entry = buffered_entries.front();
+            if (entry.row_id >= batch_end) {
+                return bitmaps;
+            }
+            buffered_entries.pop_front();
+            apply_entry(entry);
+        }
+        if (!cursor->Next(&scan_batch)) {
+            break;
+        }
+        AssertInfo(scan_batch.size > 0, "invalid row id scan batch");
+        if (scan_batch.validity.encoding ==
+                ChunkedColumnInterface::ValidityEncoding::AllValid ||
+            scan_batch.validity.all_valid) {
+            if (apply_all_valid_scan_batch_entries()) {
+                return bitmaps;
+            }
+            continue;
+        }
+        buffer_scan_batch_entries();
+    }
+    return bitmaps;
 }
 
 class Expr {
@@ -204,6 +354,32 @@ class Expr {
     }
 
  protected:
+    static bool
+    IsSortedOffsetInput(const OffsetVector* input) {
+        for (size_t i = 1; i < input->size(); ++i) {
+            if ((*input)[i - 1] > (*input)[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool
+    IsDenseOffsetInputForScan(const OffsetVector* input,
+                              int64_t max_scan_span_hint) {
+        if (input == nullptr || input->empty()) {
+            return false;
+        }
+        if (!IsSortedOffsetInput(input)) {
+            return false;
+        }
+        const auto span = static_cast<int64_t>((*input)[input->size() - 1]) -
+                          static_cast<int64_t>((*input)[0]) + 1;
+        return span <=
+               std::max<int64_t>(max_scan_span_hint,
+                                 4 * static_cast<int64_t>(input->size()));
+    }
+
     DataType type_;
     std::vector<std::shared_ptr<Expr>> inputs_;
     std::string name_;
@@ -329,16 +505,15 @@ class SegmentExpr : public Expr {
             size = std::min(size, batch_size_ - processed_size);
 
             processed_size += size;
+            current_data_chunk_ = i;
+            current_data_chunk_pos_ = data_pos + size;
             if (processed_size >= batch_size_) {
-                current_data_chunk_ = i;
-                current_data_chunk_pos_ = data_pos + size;
-                current_data_global_pos_ =
-                    current_data_global_pos_ + processed_size;
                 break;
             }
-            // }
         }
+        current_data_global_pos_ = current_data_global_pos_ + processed_size;
     }
+
     // Non-chunked segments are always Growing (Sealed is always chunked).
     void
     MoveCursorForDataSingleChunk() {
@@ -354,14 +529,21 @@ class SegmentExpr : public Expr {
             size = std::min(size, batch_size_ - processed_size);
 
             processed_size += size;
+            current_data_chunk_ = i;
+            current_data_chunk_pos_ = data_pos + size;
             if (processed_size >= batch_size_) {
-                current_data_chunk_ = i;
-                current_data_chunk_pos_ = data_pos + size;
-                current_data_global_pos_ =
-                    current_data_global_pos_ + processed_size;
                 break;
             }
         }
+        current_data_global_pos_ = current_data_global_pos_ + processed_size;
+    }
+
+    void
+    ResetDataScanCursor() {
+        data_scan_initialized_ = false;
+        data_scan_cursor_.reset();
+        data_scan_batch_ = ChunkedColumnInterface::ScanBatch{};
+        data_scan_batch_pos_ = 0;
     }
 
     void
@@ -371,6 +553,7 @@ class SegmentExpr : public Expr {
         } else {
             MoveCursorForDataSingleChunk();
         }
+        ResetDataScanCursor();
     }
 
     void
@@ -398,6 +581,123 @@ class SegmentExpr : public Expr {
             } else {
                 // RawData, PkIndex, TextIndex, JsonStats all use data cursor.
                 MoveCursorForData();
+            }
+        }
+    }
+
+    template <typename T>
+    static ChunkedColumnInterface::ScanValueKind
+    DataScanValueKind() {
+        if constexpr (std::is_same_v<T, std::string_view> ||
+                      std::is_same_v<T, std::string>) {
+            return ChunkedColumnInterface::ScanValueKind::StringView;
+        } else if constexpr (std::is_same_v<T, Json>) {
+            return ChunkedColumnInterface::ScanValueKind::JsonView;
+        } else if constexpr (std::is_same_v<T, ArrayView>) {
+            return ChunkedColumnInterface::ScanValueKind::ArrayView;
+        } else {
+            return ChunkedColumnInterface::ScanValueKind::FixedWidth;
+        }
+    }
+
+    template <typename T>
+    bool
+    InitDataScanCursorIfNeeded(
+        ChunkedColumnInterface::ScanProjection projection =
+            ChunkedColumnInterface::ScanProjection::Data) {
+        if (data_scan_initialized_) {
+            return data_scan_cursor_ != nullptr;
+        }
+        data_scan_initialized_ = true;
+        auto column = segment_->GetChunkedColumn(field_id_);
+        if (column == nullptr) {
+            return false;
+        }
+        PrefetchRawDataChunksForScanIfNeeded(column.get());
+        auto options = ChunkedColumnInterface::ScanOptions::ForData(
+            current_data_global_pos_,
+            active_count_ - current_data_global_pos_,
+            projection,
+            DataScanValueKind<T>());
+        data_scan_cursor_ = column->Scan(op_ctx_, options);
+        return data_scan_cursor_ != nullptr;
+    }
+
+    void
+    PrefetchRawDataChunksForScanIfNeeded(const ChunkedColumnInterface* column) {
+        if (column == nullptr ||
+            column->GetLocalFormat() !=
+                ChunkedColumnInterface::LocalFormat::Raw ||
+            prefetched_ || !segment_->is_chunked()) {
+            return;
+        }
+        std::vector<int64_t> chunk_ids;
+        chunk_ids.reserve(num_data_chunk_ - current_data_chunk_);
+        for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
+            chunk_ids.push_back(i);
+        }
+        segment_->prefetch_chunks(op_ctx_, field_id_, chunk_ids);
+        prefetched_ = true;
+    }
+
+    bool
+    EnsureDataScanBatch() {
+        while (data_scan_batch_pos_ >= data_scan_batch_.size) {
+            data_scan_batch_pos_ = 0;
+            if (!data_scan_cursor_->Next(&data_scan_batch_)) {
+                return false;
+            }
+            AssertInfo(data_scan_batch_.size > 0, "invalid data scan batch");
+        }
+        return true;
+    }
+
+    static const bool*
+    BoolValidityData(const ChunkedColumnInterface::ScanBatch& batch,
+                     int64_t batch_pos) {
+        if (batch.validity.encoding !=
+                ChunkedColumnInterface::ValidityEncoding::BoolArray ||
+            batch.validity.all_valid || batch.validity.data == nullptr) {
+            return nullptr;
+        }
+        return static_cast<const bool*>(batch.validity.data) +
+               batch.validity.offset + batch_pos;
+    }
+
+    static void
+    ApplyScanValidity(const ChunkedColumnInterface::ScanBatch& batch,
+                      int64_t batch_pos,
+                      TargetBitmapView res,
+                      TargetBitmapView valid_res,
+                      int64_t size) {
+        if (batch.validity.encoding ==
+                ChunkedColumnInterface::ValidityEncoding::AllValid ||
+            batch.validity.all_valid) {
+            return;
+        }
+        for (int64_t i = 0; i < size; ++i) {
+            if (!batch.validity.IsValid(batch_pos + i)) {
+                res[i] = false;
+                valid_res[i] = false;
+            }
+        }
+    }
+
+    static void
+    ApplyScanValidityByOffsets(const ChunkedColumnInterface::ScanBatch& batch,
+                               const int32_t* offsets,
+                               TargetBitmapView res,
+                               TargetBitmapView valid_res,
+                               int64_t size) {
+        if (batch.validity.encoding ==
+                ChunkedColumnInterface::ValidityEncoding::AllValid ||
+            batch.validity.all_valid) {
+            return;
+        }
+        for (int64_t i = 0; i < size; ++i) {
+            if (!batch.validity.IsValid(offsets[i])) {
+                res[i] = false;
+                valid_res[i] = false;
             }
         }
     }
@@ -737,11 +1037,9 @@ class SegmentExpr : public Expr {
         return batch_size;
     }
 
-    // accept offsets array and process on the scalar data by offsets
-    // stateless! Just check and set bitset as result, does not need to move cursor
     template <typename T, typename FUNC, typename... ValTypes>
     int64_t
-    ProcessDataByOffsets(
+    ProcessDataByOffsetsByChunkFallback(
         FUNC func,
         std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
         OffsetVector* input,
@@ -792,75 +1090,78 @@ class SegmentExpr : public Expr {
                 processed_size++;
             }
             return input->size();
-        } else if (segment_->type() == SegmentType::Sealed) {
-            // raw data scan
-            // sealed segment
-            if (segment_->is_chunked()) {
-                if constexpr (std::is_same_v<T, std::string_view> ||
-                              std::is_same_v<T, Json> ||
-                              std::is_same_v<T, ArrayView>) {
+        } else {
+            if (segment_->type() == SegmentType::Sealed) {
+                // raw data scan
+                // sealed segment
+                if (segment_->is_chunked()) {
+                    if constexpr (std::is_same_v<T, std::string_view> ||
+                                  std::is_same_v<T, Json> ||
+                                  std::is_same_v<T, ArrayView>) {
+                        for (size_t i = 0; i < input->size(); ++i) {
+                            int64_t offset = (*input)[i];
+                            auto [chunk_id, chunk_offset] =
+                                segment_->get_chunk_by_offset(field_id_,
+                                                              offset);
+                            auto pw = segment_->get_views_by_offsets<T>(
+                                op_ctx_,
+                                field_id_,
+                                chunk_id,
+                                {int32_t(chunk_offset)});
+                            auto [data_vec, valid_data] = pw.get();
+                            if (!skip_func ||
+                                !skip_func(skip_index, field_id_, chunk_id)) {
+                                func.template operator()<FilterType::random>(
+                                    data_vec.data(),
+                                    valid_data.data(),
+                                    nullptr,
+                                    1,
+                                    res + processed_size,
+                                    valid_res + processed_size,
+                                    values...);
+                            } else {
+                                ApplyValidData(valid_data.data(),
+                                               res + processed_size,
+                                               valid_res + processed_size,
+                                               1);
+                            }
+                            processed_size++;
+                        }
+                        return input->size();
+                    }
                     for (size_t i = 0; i < input->size(); ++i) {
                         int64_t offset = (*input)[i];
                         auto [chunk_id, chunk_offset] =
                             segment_->get_chunk_by_offset(field_id_, offset);
-                        auto pw = segment_->get_views_by_offsets<T>(
-                            op_ctx_,
-                            field_id_,
-                            chunk_id,
-                            {int32_t(chunk_offset)});
-                        auto [data_vec, valid_data] = pw.get();
+                        auto pw = segment_->chunk_data<T>(
+                            op_ctx_, field_id_, chunk_id);
+                        auto chunk = pw.get();
+                        const T* data = chunk.data() + chunk_offset;
+                        const bool* valid_data = chunk.valid_data();
+                        if (valid_data != nullptr) {
+                            valid_data += chunk_offset;
+                        }
                         if (!skip_func ||
                             !skip_func(skip_index, field_id_, chunk_id)) {
                             func.template operator()<FilterType::random>(
-                                data_vec.data(),
-                                valid_data.data(),
+                                data,
+                                valid_data,
                                 nullptr,
                                 1,
                                 res + processed_size,
                                 valid_res + processed_size,
                                 values...);
                         } else {
-                            if (!valid_data.empty() && !valid_data[0]) {
-                                res[processed_size] =
-                                    valid_res[processed_size] = false;
-                            }
+                            ApplyValidData(valid_data,
+                                           res + processed_size,
+                                           valid_res + processed_size,
+                                           1);
                         }
                         processed_size++;
                     }
                     return input->size();
                 }
-                for (size_t i = 0; i < input->size(); ++i) {
-                    int64_t offset = (*input)[i];
-                    auto [chunk_id, chunk_offset] =
-                        segment_->get_chunk_by_offset(field_id_, offset);
-                    auto pw =
-                        segment_->chunk_data<T>(op_ctx_, field_id_, chunk_id);
-                    auto chunk = pw.get();
-                    const T* data = chunk.data() + chunk_offset;
-                    const bool* valid_data = chunk.valid_data();
-                    if (valid_data != nullptr) {
-                        valid_data += chunk_offset;
-                    }
-                    if (!skip_func ||
-                        !skip_func(skip_index, field_id_, chunk_id)) {
-                        func.template operator()<FilterType::random>(
-                            data,
-                            valid_data,
-                            nullptr,
-                            1,
-                            res + processed_size,
-                            valid_res + processed_size,
-                            values...);
-                    } else {
-                        ApplyValidData(valid_data,
-                                       res + processed_size,
-                                       valid_res + processed_size,
-                                       1);
-                    }
-                    processed_size++;
-                }
-                return input->size();
-            } else {
+
                 if constexpr (std::is_same_v<T, std::string_view> ||
                               std::is_same_v<T, Json> ||
                               std::is_same_v<T, ArrayView>) {
@@ -884,8 +1185,7 @@ class SegmentExpr : public Expr {
                 }
                 return input->size();
             }
-        } else {
-            // growing segment
+
             for (size_t i = 0; i < input->size(); ++i) {
                 int64_t offset = (*input)[i];
                 auto chunk_id = offset / size_per_chunk_;
@@ -914,8 +1214,192 @@ class SegmentExpr : public Expr {
                 }
                 processed_size++;
             }
+            return input->size();
         }
+    }
+
+    // accept sorted offsets array and process with one continuous Scan.
+    // TODO: push the offset bitmap down into Scan when Vortex supports bitmap scan.
+    template <typename T, typename FUNC, typename... ValTypes>
+    int64_t
+    ProcessSortedDataByOffsetsByScan(
+        FUNC func,
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        OffsetVector* input,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const ValTypes&... values) {
+        auto column = segment_->GetChunkedColumn(field_id_);
+        if (column == nullptr) {
+            return -1;
+        }
+        if (input->empty()) {
+            return 0;
+        }
+
+        const auto scan_start = static_cast<int64_t>((*input)[0]);
+        const auto scan_end =
+            static_cast<int64_t>((*input)[input->size() - 1]) + 1;
+        const auto scan_length = scan_end - scan_start;
+        AssertInfo(scan_length > 0,
+                   "invalid offset scan range [{}, {})",
+                   scan_start,
+                   scan_end);
+
+        TargetBitmap offset_bitmap(scan_length, false);
+        for (auto offset : *input) {
+            offset_bitmap[static_cast<size_t>(static_cast<int64_t>(offset) -
+                                              scan_start)] = true;
+        }
+
+        auto options = ChunkedColumnInterface::ScanOptions::ForData(
+            scan_start,
+            scan_length,
+            ChunkedColumnInterface::ScanProjection::Data,
+            DataScanValueKind<T>());
+        auto cursor = column->Scan(op_ctx_, options);
+        if (cursor == nullptr) {
+            return -1;
+        }
+
+        auto& skip_index = segment_->GetSkipIndex();
+        size_t processed_offsets = 0;
+        std::vector<int32_t> batch_offsets;
+        batch_offsets.reserve(std::min<int64_t>(batch_size_, input->size()));
+
+        ChunkedColumnInterface::ScanBatch batch;
+        while (processed_offsets < input->size() && cursor->Next(&batch)) {
+            AssertInfo(!batch.values.empty() && batch.size > 0,
+                       "invalid offset data scan batch");
+
+            int64_t batch_pos = 0;
+            while (batch_pos < batch.size &&
+                   processed_offsets < input->size()) {
+                const auto interval_start = batch.row_id_start + batch_pos;
+                const auto batch_end = batch.row_id_start + batch.size;
+                if (static_cast<int64_t>((*input)[processed_offsets]) >=
+                    batch_end) {
+                    break;
+                }
+
+                auto [chunk_id, _] =
+                    segment_->type() == SegmentType::Growing
+                        ? std::make_pair(interval_start / size_per_chunk_,
+                                         interval_start % size_per_chunk_)
+                        : segment_->get_chunk_by_offset(field_id_,
+                                                        interval_start);
+                const auto chunk_end =
+                    segment_->type() == SegmentType::Growing
+                        ? std::min<int64_t>((chunk_id + 1) * size_per_chunk_,
+                                            active_count_)
+                        : segment_->num_rows_until_chunk(field_id_, chunk_id) +
+                              segment_->chunk_size(field_id_, chunk_id);
+                const auto interval_end = std::min(batch_end, chunk_end);
+                if (static_cast<int64_t>((*input)[processed_offsets]) >=
+                    interval_end) {
+                    batch_pos += interval_end - interval_start;
+                    continue;
+                }
+
+                const bool skipped =
+                    skip_func && skip_func(skip_index, field_id_, chunk_id);
+                const auto group_start = processed_offsets;
+                batch_offsets.clear();
+                for (int64_t row = interval_start;
+                     row < interval_end && processed_offsets < input->size();
+                     ++row) {
+                    const auto bitmap_pos = row - scan_start;
+                    if (!offset_bitmap[static_cast<size_t>(bitmap_pos)]) {
+                        continue;
+                    }
+                    while (processed_offsets < input->size() &&
+                           static_cast<int64_t>((*input)[processed_offsets]) ==
+                               row) {
+                        batch_offsets.push_back(
+                            static_cast<int32_t>(row - batch.row_id_start));
+                        ++processed_offsets;
+                    }
+                }
+
+                const auto group_size =
+                    static_cast<int64_t>(processed_offsets - group_start);
+                if (group_size > 0) {
+                    if (!skipped) {
+                        const auto* data = batch.values.data_as<T>();
+                        const auto* valid_data = BoolValidityData(batch, 0);
+                        func.template operator()<FilterType::random>(
+                            data,
+                            valid_data,
+                            batch_offsets.data(),
+                            static_cast<int>(group_size),
+                            res + group_start,
+                            valid_res + group_start,
+                            values...);
+                        if (valid_data == nullptr) {
+                            ApplyScanValidityByOffsets(batch,
+                                                       batch_offsets.data(),
+                                                       res + group_start,
+                                                       valid_res + group_start,
+                                                       group_size);
+                        }
+                    } else {
+                        ApplyScanValidityByOffsets(batch,
+                                                   batch_offsets.data(),
+                                                   res + group_start,
+                                                   valid_res + group_start,
+                                                   group_size);
+                    }
+                }
+
+                batch_pos += interval_end - interval_start;
+            }
+        }
+
+        AssertInfo(processed_offsets == input->size(),
+                   "offset scan processed {} offsets, expected {}",
+                   processed_offsets,
+                   input->size());
         return input->size();
+    }
+
+    template <typename T, typename FUNC, typename... ValTypes>
+    int64_t
+    ProcessDataByOffsetsByScan(
+        FUNC func,
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        OffsetVector* input,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const ValTypes&... values) {
+        if (IsDenseOffsetInputForScan(input, batch_size_)) {
+            return ProcessSortedDataByOffsetsByScan<T>(
+                func, skip_func, input, res, valid_res, values...);
+        }
+        return -1;
+    }
+
+    template <typename T, typename FUNC, typename... ValTypes>
+    int64_t
+    ProcessDataByOffsets(
+        FUNC func,
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        OffsetVector* input,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const ValTypes&... values) {
+        // index reverse lookup (only for ScalarIndex path)
+        if (UseIndexCursor() && num_data_chunk_ == 0) {
+            return ProcessIndexLookupByOffsets<T>(
+                func, skip_func, input, res, valid_res, values...);
+        }
+
+        const auto processed_size = ProcessDataByOffsetsByScan<T>(
+            func, skip_func, input, res, valid_res, values...);
+        if (processed_size >= 0) {
+            return processed_size;
+        }
+        return ProcessDataByOffsetsByChunkFallback<T>(
+            func, skip_func, input, res, valid_res, values...);
     }
 
     // Process element-level data by element IDs
@@ -1336,7 +1820,6 @@ class SegmentExpr : public Expr {
         return processed_elems;
     }
 
-    // Template parameter to control whether segment offsets are needed (for GIS functions)
     template <typename T,
               bool NeedSegmentOffsets = false,
               typename FUNC,
@@ -1370,8 +1853,9 @@ class SegmentExpr : public Expr {
                     : size_per_chunk_ - data_pos;
 
             size = std::min(size, batch_size_ - processed_size);
-            if (size == 0)
-                continue;  //do not go empty-loop at the bound of the chunk
+            if (size == 0) {
+                continue;
+            }
 
             auto& skip_index = segment_->GetSkipIndex();
             auto process_chunk = [&](const T* data, const bool* valid_data) {
@@ -1480,7 +1964,6 @@ class SegmentExpr : public Expr {
         const ValTypes&... values) {
         int64_t processed_size = 0;
 
-        // prefetch chunks to reduce cache miss latency
         if (!prefetched_) {
             std::vector<int64_t> pf_chunk_ids;
             pf_chunk_ids.reserve(num_data_chunk_ - current_data_chunk_);
@@ -1494,30 +1977,29 @@ class SegmentExpr : public Expr {
         for (size_t i = current_data_chunk_; i < num_data_chunk_; i++) {
             auto data_pos =
                 i == current_data_chunk_ ? current_data_chunk_pos_ : 0;
-
-            // if segment is chunked, type won't be growing
             int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
             size = std::min(size, batch_size_ - processed_size);
 
-            if (size == 0)
-                continue;  //do not go empty-loop at the bound of the chunk
+            if (size == 0) {
+                continue;
+            }
+
             std::vector<int32_t> segment_offsets_array(size);
             auto start_offset =
                 segment_->num_rows_until_chunk(field_id_, i) + data_pos;
             for (int64_t j = 0; j < size; ++j) {
-                int64_t offset = start_offset + j;
-                segment_offsets_array[j] = static_cast<int32_t>(offset);
+                segment_offsets_array[j] =
+                    static_cast<int32_t>(start_offset + j);
             }
+
             auto& skip_index = segment_->GetSkipIndex();
             if (!skip_func || !skip_func(skip_index, field_id_, i)) {
-                bool is_seal = false;
+                bool is_seal_variable_column = false;
                 if constexpr (std::is_same_v<T, std::string_view> ||
                               std::is_same_v<T, Json> ||
                               std::is_same_v<T, ArrayView> ||
                               std::is_same_v<T, VectorArrayView>) {
                     if (segment_->type() == SegmentType::Sealed) {
-                        // first is the raw data, second is valid_data
-                        // use valid_data to see if raw data is null
                         auto pw = segment_->get_batch_views<T>(
                             op_ctx_, field_id_, i, data_pos, size);
                         const auto& [data_vec, valid_data] = pw.get();
@@ -1541,15 +2023,15 @@ class SegmentExpr : public Expr {
                                  values...);
                         }
 
-                        is_seal = true;
+                        is_seal_variable_column = true;
                     }
                 }
                 if constexpr (std::is_same_v<T, VectorArrayView>) {
-                    AssertInfo(is_seal,
+                    AssertInfo(is_seal_variable_column,
                                "VectorArrayView must be read through chunk "
                                "views");
                 } else {
-                    if (!is_seal) {
+                    if (!is_seal_variable_column) {
                         auto pw =
                             segment_->chunk_data<T>(op_ctx_, field_id_, i);
                         auto chunk = pw.get();
@@ -1581,27 +2063,21 @@ class SegmentExpr : public Expr {
                     }
                 }
             } else {
-                // Chunk is skipped by SkipIndex.
-                // We still need to:
-                // 1. Apply valid_data to handle nullable fields
-                // 2. Call func with nullptr to update internal cursors
-                //    (e.g., processed_cursor for bitmap_input indexing)
-                const bool* valid_data;
                 if constexpr (std::is_same_v<T, std::string_view> ||
                               std::is_same_v<T, Json> ||
                               std::is_same_v<T, ArrayView> ||
                               std::is_same_v<T, VectorArrayView>) {
                     auto pw = segment_->get_batch_views<T>(
                         op_ctx_, field_id_, i, data_pos, size);
-                    valid_data = pw.get().second.data();
-                    ApplyValidData(valid_data,
+                    auto views = pw.get();
+                    ApplyValidData(views.second.data(),
                                    res + processed_size,
                                    valid_res + processed_size,
                                    size);
                 } else {
                     auto pw = segment_->chunk_data<T>(op_ctx_, field_id_, i);
                     auto chunk = pw.get();
-                    valid_data = chunk.valid_data();
+                    const bool* valid_data = chunk.valid_data();
                     if (valid_data != nullptr) {
                         valid_data += data_pos;
                     }
@@ -1610,7 +2086,6 @@ class SegmentExpr : public Expr {
                                    valid_res + processed_size,
                                    size);
                 }
-                // Call func with nullptr to update internal cursors
                 if constexpr (NeedSegmentOffsets) {
                     func(nullptr,
                          nullptr,
@@ -1632,7 +2107,6 @@ class SegmentExpr : public Expr {
             }
 
             processed_size += size;
-
             if (processed_size >= batch_size_) {
                 current_data_chunk_ = i;
                 current_data_chunk_pos_ = data_pos + size;
@@ -1648,19 +2122,152 @@ class SegmentExpr : public Expr {
               typename FUNC,
               typename... ValTypes>
     int64_t
+    ProcessDataChunksByScan(
+        FUNC func,
+        std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
+        TargetBitmapView res,
+        TargetBitmapView valid_res,
+        const ValTypes&... values) {
+        if (!InitDataScanCursorIfNeeded<T>()) {
+            return -1;
+        }
+
+        int64_t processed_size = 0;
+        const auto real_batch_size = GetNextBatchSize();
+        auto& skip_index = segment_->GetSkipIndex();
+
+        while (processed_size < real_batch_size) {
+            if (!EnsureDataScanBatch()) {
+                break;
+            }
+
+            const auto row =
+                data_scan_batch_.row_id_start + data_scan_batch_pos_;
+            const auto expected_row = current_data_global_pos_ + processed_size;
+            AssertInfo(row == expected_row,
+                       "data scan row mismatch, got {}, expected {}",
+                       row,
+                       expected_row);
+
+            auto size =
+                std::min<int64_t>(real_batch_size - processed_size,
+                                  data_scan_batch_.size - data_scan_batch_pos_);
+            auto [chunk_id, _] =
+                segment_->type() == SegmentType::Growing
+                    ? std::make_pair(row / size_per_chunk_,
+                                     row % size_per_chunk_)
+                    : segment_->get_chunk_by_offset(field_id_, row);
+            const auto chunk_end =
+                segment_->type() == SegmentType::Growing
+                    ? std::min<int64_t>((chunk_id + 1) * size_per_chunk_,
+                                        active_count_)
+                    : segment_->num_rows_until_chunk(field_id_, chunk_id) +
+                          segment_->chunk_size(field_id_, chunk_id);
+            size = std::min<int64_t>(size, chunk_end - row);
+            const auto* data =
+                data_scan_batch_.values.data_as<T>() + data_scan_batch_pos_;
+            const auto* valid_data =
+                BoolValidityData(data_scan_batch_, data_scan_batch_pos_);
+            const bool skipped =
+                skip_func && skip_func(skip_index, field_id_, chunk_id);
+
+            auto make_segment_offsets = [&]() {
+                std::vector<int32_t> segment_offsets_array(size);
+                for (int64_t i = 0; i < size; ++i) {
+                    segment_offsets_array[i] = static_cast<int32_t>(row + i);
+                }
+                return segment_offsets_array;
+            };
+
+            if (!skipped) {
+                if constexpr (NeedSegmentOffsets) {
+                    auto segment_offsets_array = make_segment_offsets();
+                    func(data,
+                         valid_data,
+                         nullptr,
+                         segment_offsets_array.data(),
+                         size,
+                         res + processed_size,
+                         valid_res + processed_size,
+                         values...);
+                } else {
+                    func(data,
+                         valid_data,
+                         nullptr,
+                         size,
+                         res + processed_size,
+                         valid_res + processed_size,
+                         values...);
+                }
+                if (valid_data == nullptr) {
+                    ApplyScanValidity(data_scan_batch_,
+                                      data_scan_batch_pos_,
+                                      res + processed_size,
+                                      valid_res + processed_size,
+                                      size);
+                }
+            } else {
+                ApplyScanValidity(data_scan_batch_,
+                                  data_scan_batch_pos_,
+                                  res + processed_size,
+                                  valid_res + processed_size,
+                                  size);
+                if constexpr (NeedSegmentOffsets) {
+                    auto segment_offsets_array = make_segment_offsets();
+                    func(nullptr,
+                         nullptr,
+                         nullptr,
+                         segment_offsets_array.data(),
+                         size,
+                         res + processed_size,
+                         valid_res + processed_size,
+                         values...);
+                } else {
+                    func(nullptr,
+                         nullptr,
+                         nullptr,
+                         size,
+                         res + processed_size,
+                         valid_res + processed_size,
+                         values...);
+                }
+            }
+
+            processed_size += size;
+            data_scan_batch_pos_ += size;
+        }
+
+        AssertInfo(processed_size == real_batch_size,
+                   "data scan processed {} rows, expected {}",
+                   processed_size,
+                   real_batch_size);
+        MoveCursor();
+        return processed_size;
+    }
+
+    template <typename T,
+              bool NeedSegmentOffsets = false,
+              typename FUNC,
+              typename... ValTypes>
+    int64_t
     ProcessDataChunks(
         FUNC func,
         std::function<bool(const milvus::SkipIndex&, FieldId, int)> skip_func,
         TargetBitmapView res,
         TargetBitmapView valid_res,
         const ValTypes&... values) {
+        const auto processed_size =
+            ProcessDataChunksByScan<T, NeedSegmentOffsets>(
+                func, skip_func, res, valid_res, values...);
+        if (processed_size >= 0) {
+            return processed_size;
+        }
         if (segment_->is_chunked()) {
             return ProcessDataChunksForMultipleChunk<T, NeedSegmentOffsets>(
                 func, skip_func, res, valid_res, values...);
-        } else {
-            return ProcessDataChunksForSingleChunk<T, NeedSegmentOffsets>(
-                func, skip_func, res, valid_res, values...);
         }
+        return ProcessDataChunksForSingleChunk<T, NeedSegmentOffsets>(
+            func, skip_func, res, valid_res, values...);
     }
 
     // Specialized method for ngram post-filter: processes data in a specific range
@@ -1998,7 +2605,7 @@ class SegmentExpr : public Expr {
 
     template <typename T>
     TargetBitmap
-    ProcessDataChunksForValid() {
+    ProcessDataChunksForValidByChunkFallback() {
         TargetBitmap valid_result(GetNextBatchSize());
         valid_result.set();
         int64_t processed_size = 0;
@@ -2020,8 +2627,9 @@ class SegmentExpr : public Expr {
             }
 
             size = std::min(size, batch_size_ - processed_size);
-            if (size == 0)
-                continue;  //do not go empty-loop at the bound of the chunk
+            if (size == 0) {
+                continue;
+            }
             segment_->ApplyFieldValidData(op_ctx_,
                                           field_id_,
                                           i,
@@ -2036,6 +2644,40 @@ class SegmentExpr : public Expr {
                 break;
             }
         }
+        return valid_result;
+    }
+
+    template <typename T>
+    TargetBitmap
+    ProcessDataChunksForValid() {
+        const auto batch_size = GetNextBatchSize();
+        TargetBitmap valid_result(batch_size);
+        valid_result.set();
+        if (!InitDataScanCursorIfNeeded<T>(
+                ChunkedColumnInterface::ScanProjection::NoData)) {
+            return ProcessDataChunksForValidByChunkFallback<T>();
+        }
+        int64_t processed_size = 0;
+        while (processed_size < batch_size) {
+            if (!EnsureDataScanBatch()) {
+                break;
+            }
+            const auto size =
+                std::min<int64_t>(batch_size - processed_size,
+                                  data_scan_batch_.size - data_scan_batch_pos_);
+            ApplyScanValidity(data_scan_batch_,
+                              data_scan_batch_pos_,
+                              valid_result + processed_size,
+                              valid_result + processed_size,
+                              size);
+            processed_size += size;
+            data_scan_batch_pos_ += size;
+        }
+        AssertInfo(processed_size == batch_size,
+                   "validity scan processed {} rows, expected {}",
+                   processed_size,
+                   batch_size);
+        MoveCursor();
         return valid_result;
     }
 
@@ -2429,6 +3071,11 @@ class SegmentExpr : public Expr {
     int64_t current_index_chunk_{0};
     int64_t current_index_chunk_pos_{0};
     int64_t size_per_chunk_{0};
+    bool data_scan_initialized_{false};
+    std::unique_ptr<ChunkedColumnInterface::ScanCursor> data_scan_cursor_{
+        nullptr};
+    ChunkedColumnInterface::ScanBatch data_scan_batch_;
+    int64_t data_scan_batch_pos_{0};
 
     // Unified cache for all index paths (ScalarIndex, PkIndex, TextIndex, JsonStats).
     // Populated once per segment, then sliced per batch via SliceCachedResult().

--- a/internal/core/src/exec/expression/ExprCompareTest.cpp
+++ b/internal/core/src/exec/expression/ExprCompareTest.cpp
@@ -952,6 +952,9 @@ TEST_P(ExprTest, TestSealedSegmentGetBatchSize) {
     auto str1_fid = schema->AddDebugField("string1", DataType::VARCHAR);
     auto str2_fid = schema->AddDebugField("string2", DataType::VARCHAR);
     auto str3_fid = schema->AddDebugField("string3", DataType::VARCHAR);
+    auto string_fid = schema->AddDebugField("string", DataType::STRING);
+    auto string_1_fid =
+        schema->AddDebugField("string1_internal", DataType::STRING);
     schema->set_primary_field_id(str1_fid);
 
     auto seg = CreateSealedSegment(schema);
@@ -1034,6 +1037,15 @@ TEST_P(ExprTest, TestSealedSegmentGetBatchSize) {
                                                         OpType::LessThan);
                 return compare_expr;
             }
+            case DataType::STRING: {
+                auto compare_expr =
+                    std::make_shared<expr::CompareExpr>(string_fid,
+                                                        string_1_fid,
+                                                        DataType::STRING,
+                                                        DataType::STRING,
+                                                        OpType::LessThan);
+                return compare_expr;
+            }
             default:
                 return std::make_shared<expr::CompareExpr>(int8_fid,
                                                            int8_1_fid,
@@ -1063,6 +1075,12 @@ TEST_P(ExprTest, TestSealedSegmentGetBatchSize) {
     plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
     final = ExecuteQueryExpr(plan, seg.get(), N, MAX_TIMESTAMP);
     expr = build_expr(DataType::DOUBLE);
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+    final = ExecuteQueryExpr(plan, seg.get(), N, MAX_TIMESTAMP);
+    expr = build_expr(DataType::VARCHAR);
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+    final = ExecuteQueryExpr(plan, seg.get(), N, MAX_TIMESTAMP);
+    expr = build_expr(DataType::STRING);
     plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
     final = ExecuteQueryExpr(plan, seg.get(), N, MAX_TIMESTAMP);
 }

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1626,6 +1626,38 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
         return nullptr;
     }
 
+    if (!has_offset_input_ && !expr_->column_.element_level_) {
+        auto column = segment_->GetChunkedColumn(field_id_);
+        if (!row_id_scan_initialized_) {
+            row_id_scan_initialized_ = true;
+            if (column != nullptr) {
+                auto options = ChunkedColumnInterface::ScanOptions::ForUnary(
+                    current_data_global_pos_,
+                    active_count_ - current_data_global_pos_,
+                    expr_->op_type_,
+                    expr_->val_);
+                if (column->SupportsScanPushdown(options)) {
+                    row_id_scan_cursor_ = column->Scan(op_ctx_, options);
+                    AssertInfo(row_id_scan_cursor_ != nullptr,
+                               "row id scan cursor is null for field {}",
+                               field_id_.get());
+                }
+            }
+        }
+        if (row_id_scan_cursor_ != nullptr) {
+            auto bitmaps = RowIdScanToBitmaps(row_id_scan_cursor_.get(),
+                                              buffered_scan_entries_,
+                                              row_id_scan_batch_,
+                                              current_data_global_pos_,
+                                              real_batch_size,
+                                              bitmap_input,
+                                              true);
+            MoveCursor();
+            return std::make_shared<ColumnVector>(std::move(bitmaps.result),
+                                                  std::move(bitmaps.validity));
+        }
+    }
+
     if (!arg_inited_) {
         value_arg_.SetValue<IndexInnerType>(expr_->val_);
         arg_inited_ = true;

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -18,6 +18,7 @@
 
 #include <fmt/core.h>
 
+#include <deque>
 #include <optional>
 #include <utility>
 
@@ -38,6 +39,7 @@
 #include "index/json_stats/bson_inverted.h"
 #include "cachinglayer/CacheSlot.h"
 #include "index/NgramInvertedIndex.h"
+#include "mmap/ChunkedColumnInterface.h"
 
 namespace milvus {
 namespace exec {
@@ -1200,6 +1202,12 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
         auto pattern = GetValueFromProto<std::string>(expr_->val_);
         cached_like_matcher_ = std::make_unique<LikePatternMatcher>(pattern);
     }
+
+    bool row_id_scan_initialized_{false};
+    std::unique_ptr<ChunkedColumnInterface::ScanCursor> row_id_scan_cursor_{
+        nullptr};
+    ChunkedColumnInterface::ScanBatch row_id_scan_batch_;
+    std::deque<RowIdScanEntry> buffered_scan_entries_;
 };
 }  // namespace exec
 }  // namespace milvus

--- a/internal/core/src/mmap/CMakeLists.txt
+++ b/internal/core/src/mmap/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (C) 2019-2020 Zilliz. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under the License
+
+
+add_source_at_current_directory_recursively()
+add_library(milvus_mmap OBJECT ${SOURCE_FILES})
+target_link_libraries(milvus_mmap PUBLIC milvus_conan_deps)

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -175,6 +175,7 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
                     fn(true, i);
                 }
             }
+            return;
         }
         // nullable:
         if (offsets == nullptr) {
@@ -378,6 +379,11 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
     }
 
  protected:
+    std::optional<DataType>
+    GetDefaultScanDataType() const override {
+        return data_type_;
+    }
+
     bool nullable_{false};
     DataType data_type_{DataType::NONE};
     size_t num_rows_{0};

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -255,6 +255,7 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
                     fn(true, i);
                 }
             }
+            return;
         }
         // nullable:
         if (count == 0) {
@@ -724,6 +725,11 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
     }
 
  private:
+    std::optional<DataType>
+    GetDefaultScanDataType() const override {
+        return data_type_;
+    }
+
     std::shared_ptr<ChunkedColumnGroup> group_;
     FieldId field_id_;
     const FieldMeta field_meta_;

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -15,25 +15,60 @@
 // limitations under the License.
 #pragma once
 
+#include <algorithm>
 #include <atomic>
+#include <functional>
+#include <memory>
 #include <mutex>
+#include <optional>
+#include <vector>
 
 #include "cachinglayer/CacheSlot.h"
 #include "common/Chunk.h"
+#include "common/EasyAssert.h"
 #include "common/OffsetMapping.h"
 #include "common/bson_view.h"
+#include "mmap/ChunkedColumnScanCommon.h"
 namespace milvus {
 
 using namespace milvus::cachinglayer;
 
 class ChunkedColumnInterface {
  public:
+    enum class LocalFormat {
+        Raw,
+        Vortex,
+    };
+
+    using ScanValueKind = milvus::ScanValueKind;
+    using ValueEncoding = milvus::ValueEncoding;
+    using ValidityEncoding = milvus::ValidityEncoding;
+    using ValueView = milvus::ValueView;
+    using ValidityView = milvus::ValidityView;
+    using ScanBatch = milvus::ScanBatch;
+    using ScanCursor = milvus::ScanCursor;
+    using ScanOutput = milvus::ScanOutput;
+    using ScanProjection = milvus::ScanProjection;
+    using ScanPredicate = milvus::ScanPredicate;
+    using ScanOptions = milvus::ScanOptions;
+    using ScanResult = milvus::ScanResult;
+
     virtual ~ChunkedColumnInterface() = default;
 
     // Check if this column is part of a multi-field column group.
     // Used to guard DropFieldData from breaking shared storage.
     virtual bool
     IsInMultiFieldColumnGroup() const {
+        return false;
+    }
+
+    virtual LocalFormat
+    GetLocalFormat() const {
+        return LocalFormat::Raw;
+    }
+
+    virtual bool
+    SupportsScanPushdown(const ScanOptions&) const {
         return false;
     }
 
@@ -176,6 +211,9 @@ class ChunkedColumnInterface {
             }
         }
     }
+
+    virtual ScanResult
+    Scan(milvus::OpContext* op_ctx, const ScanOptions& options) const;
 
     // Get number of rows before a specific chunk
     virtual int64_t
@@ -370,6 +408,11 @@ class ChunkedColumnInterface {
     }
 
  protected:
+    virtual std::optional<DataType>
+    GetDefaultScanDataType() const {
+        return std::nullopt;
+    }
+
     FixedVector<bool> valid_data_;
     std::vector<int64_t> valid_count_per_chunk_;
     std::vector<int64_t> num_valid_rows_until_chunk_;

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -51,7 +51,26 @@ struct ColumnSpec {
     std::vector<int64_t> rows_per_chunk;
     std::vector<std::vector<bool>> valid_patterns;  // empty => all valid
     bool nullable{true};
+    DataType data_type{DataType::VECTOR_INT8};
 };
+
+FieldMeta
+MakeTestFieldMeta(const ColumnSpec& spec) {
+    if (IsVectorDataType(spec.data_type)) {
+        return FieldMeta(FieldName("t"),
+                         FieldId(kTestFieldId),
+                         spec.data_type,
+                         kElementSize,
+                         std::nullopt,
+                         spec.nullable,
+                         std::nullopt);
+    }
+    return FieldMeta(FieldName("t"),
+                     FieldId(kTestFieldId),
+                     spec.data_type,
+                     spec.nullable,
+                     std::nullopt);
+}
 
 struct VectorArrayColumnFixture {
     std::shared_ptr<ChunkedColumnInterface> column;
@@ -218,13 +237,7 @@ struct ChunkedColumnFactory {
         auto fetched = std::make_shared<std::set<cachinglayer::cid_t>>();
         auto translator = std::make_unique<CountingChunkTranslator>(
             spec.rows_per_chunk, "cc_iface", std::move(chunks), fetched);
-        FieldMeta fm(FieldName("t"),
-                     FieldId(kTestFieldId),
-                     DataType::VECTOR_INT8,
-                     kElementSize,
-                     std::nullopt,
-                     spec.nullable,
-                     std::nullopt);
+        auto fm = MakeTestFieldMeta(spec);
         auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
             std::move(translator), nullptr);
         auto column = std::make_shared<ChunkedColumn>(std::move(slot), fm);
@@ -267,13 +280,7 @@ struct ProxyChunkColumnFactory {
             fetched);
         auto group =
             std::make_shared<ChunkedColumnGroup>(std::move(translator));
-        FieldMeta fm(FieldName("t"),
-                     FieldId(kTestFieldId),
-                     DataType::VECTOR_INT8,
-                     kElementSize,
-                     std::nullopt,
-                     spec.nullable,
-                     std::nullopt);
+        auto fm = MakeTestFieldMeta(spec);
         auto column = std::make_shared<ProxyChunkColumn>(
             group, FieldId(kTestFieldId), fm);
         return {std::static_pointer_cast<ChunkedColumnInterface>(column),
@@ -502,6 +509,37 @@ TYPED_TEST(VectorArrayColumnInterfaceTest,
         fx.column->BulkVectorArrayAt(
             nullptr, [](VectorFieldProto&&, size_t) {}, null_offset, 1),
         std::exception);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, RawFormatScanDoesNotSupportUnaryRowIds) {
+    ColumnSpec spec{{5}, {{true, false, true, true, false}}, true};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    proto::plan::GenericValue value;
+    value.set_int64_val(3);
+    auto options = ChunkedColumnInterface::ScanOptions::ForUnary(
+        0, 5, proto::plan::OpType::Equal, value);
+
+    EXPECT_FALSE(fx.column->SupportsScanPushdown(options));
+    EXPECT_EQ(fx.column->Scan(nullptr, options), nullptr);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           RawFormatScanDoesNotSupportBinaryRangeRowIds) {
+    ColumnSpec spec{{5}, {{true, false, true, true, false}}, true};
+    spec.data_type = DataType::INT32;
+    auto fx = TypeParam::Create(spec);
+
+    proto::plan::GenericValue lower;
+    proto::plan::GenericValue upper;
+    lower.set_int64_val(1);
+    upper.set_int64_val(10);
+    auto options = ChunkedColumnInterface::ScanOptions::ForBinaryRange(
+        0, 5, lower, true, upper, true);
+
+    EXPECT_FALSE(fx.column->SupportsScanPushdown(options));
+    EXPECT_EQ(fx.column->Scan(nullptr, options), nullptr);
 }
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCommon.h
+++ b/internal/core/src/mmap/ChunkedColumnScanCommon.h
@@ -1,0 +1,259 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "common/Types.h"
+#include "pb/plan.pb.h"
+
+namespace milvus {
+
+enum class ScanValueKind {
+    Default,
+    FixedWidth,
+    StringView,
+    JsonView,
+    ArrayView,
+};
+
+enum class ValueEncoding {
+    Empty,
+    FixedWidth,
+    StringView,
+    JsonView,
+    ArrayView,
+};
+
+enum class ValidityEncoding {
+    AllValid,
+    BoolArray,
+    Bitmap,
+};
+
+struct ValueView {
+    ValueEncoding encoding = ValueEncoding::Empty;
+    ScanValueKind kind = ScanValueKind::Default;
+    DataType physical_type = DataType::NONE;
+    DataType logical_type = DataType::NONE;
+    const void* data = nullptr;
+    int64_t offset = 0;
+    int64_t size = 0;
+    int32_t byte_width = 0;
+
+    bool
+    empty() const {
+        return encoding == ValueEncoding::Empty || data == nullptr;
+    }
+
+    template <typename T>
+    const T*
+    data_as() const {
+        AssertInfo(encoding != ValueEncoding::Empty && data != nullptr,
+                   "scan value view is empty");
+        return static_cast<const T*>(data) + offset;
+    }
+};
+
+struct ValidityView {
+    ValidityEncoding encoding = ValidityEncoding::AllValid;
+    const void* data = nullptr;
+    int64_t offset = 0;
+    int64_t size = 0;
+    bool nullable = false;
+    bool all_valid = true;
+
+    bool
+    IsValid(int64_t i) const {
+        AssertInfo(i >= 0 && (size == 0 || i < size),
+                   "validity offset {} out of range {}",
+                   i,
+                   size);
+        if (encoding == ValidityEncoding::AllValid || all_valid ||
+            data == nullptr) {
+            return true;
+        }
+        const auto pos = offset + i;
+        switch (encoding) {
+            case ValidityEncoding::BoolArray:
+                return static_cast<const bool*>(data)[pos];
+            case ValidityEncoding::Bitmap: {
+                const auto* bitmap = static_cast<const uint8_t*>(data);
+                return (bitmap[pos >> 3] >> (pos & 0x07)) & 1;
+            }
+            case ValidityEncoding::AllValid:
+                return true;
+        }
+        return true;
+    }
+};
+
+struct ScanBatch {
+    // Every batch represents the dense row range
+    // [row_id_start, row_id_start + size) for data scans. Payload fields are
+    // optional based on ScanOptions. For data scans, values and validity are
+    // dense over this range. For filter pushdown scans, row_ids is sparse and
+    // validity, when present, is aligned with row_ids.
+    ValueView values;
+    ValidityView validity;
+    std::vector<int64_t> row_ids;
+    std::shared_ptr<void> owner;
+    int64_t row_id_start = 0;
+    int64_t size = 0;
+};
+
+class ScanCursor {
+ public:
+    virtual ~ScanCursor() = default;
+
+    // Return the next natural batch from the underlying source. ScanOptions
+    // does not carry an upper-layer batch-size hint; callers should consume
+    // the returned batch directly or keep their own position inside it.
+    virtual bool
+    Next(ScanBatch* out) = 0;
+};
+
+enum class ScanOutput {
+    // Filter pushdown payload: ScanBatch::row_ids contains predicate true or
+    // unknown rows; ScanBatch::validity is aligned with row_ids.
+    RowIds,
+    // Dense data payload: ScanBatch::values contains values over the batch
+    // range unless projection asks to omit data.
+    Data,
+};
+
+enum class ScanProjection {
+    // Return ScanBatch::values for dense data scans.
+    Data,
+    // Omit ScanBatch::values. Dense data scans still return validity over the
+    // batch range; filter pushdown scans return row_ids plus row-aligned
+    // validity.
+    NoData,
+};
+
+enum class ScanPredicate {
+    None,
+    Unary,
+    BinaryRange,
+};
+
+struct ScanOptions {
+    ScanOptions() = default;
+
+    ScanOptions(ScanOutput output,
+                ScanPredicate predicate,
+                int64_t start_offset,
+                int64_t length,
+                ScanProjection projection = ScanProjection::Data,
+                ScanValueKind value_kind = ScanValueKind::Default,
+                proto::plan::OpType op_type = proto::plan::OpType::Invalid,
+                proto::plan::GenericValue value = {},
+                proto::plan::GenericValue lower_value = {},
+                proto::plan::GenericValue upper_value = {},
+                bool lower_inclusive = false,
+                bool upper_inclusive = false)
+        : output(output),
+          predicate(predicate),
+          start_offset(start_offset),
+          length(length),
+          projection(projection),
+          value_kind(value_kind),
+          op_type(op_type),
+          value(std::move(value)),
+          lower_value(std::move(lower_value)),
+          upper_value(std::move(upper_value)),
+          lower_inclusive(lower_inclusive),
+          upper_inclusive(upper_inclusive) {
+    }
+
+    static ScanOptions
+    ForData(int64_t start_offset,
+            int64_t length,
+            ScanProjection projection = ScanProjection::Data,
+            ScanValueKind value_kind = ScanValueKind::Default) {
+        return ScanOptions(ScanOutput::Data,
+                           ScanPredicate::None,
+                           start_offset,
+                           length,
+                           projection,
+                           value_kind);
+    }
+
+    static ScanOptions
+    ForNoData(int64_t start_offset,
+              int64_t length,
+              ScanValueKind value_kind = ScanValueKind::Default) {
+        return ForData(
+            start_offset, length, ScanProjection::NoData, value_kind);
+    }
+
+    static ScanOptions
+    ForUnary(int64_t start_offset,
+             int64_t length,
+             proto::plan::OpType op_type,
+             const proto::plan::GenericValue& value) {
+        return ScanOptions(ScanOutput::RowIds,
+                           ScanPredicate::Unary,
+                           start_offset,
+                           length,
+                           ScanProjection::NoData,
+                           ScanValueKind::Default,
+                           op_type,
+                           value);
+    }
+
+    static ScanOptions
+    ForBinaryRange(int64_t start_offset,
+                   int64_t length,
+                   const proto::plan::GenericValue& lower_value,
+                   bool lower_inclusive,
+                   const proto::plan::GenericValue& upper_value,
+                   bool upper_inclusive) {
+        return ScanOptions(ScanOutput::RowIds,
+                           ScanPredicate::BinaryRange,
+                           start_offset,
+                           length,
+                           ScanProjection::NoData,
+                           ScanValueKind::Default,
+                           proto::plan::OpType::Invalid,
+                           {},
+                           lower_value,
+                           upper_value,
+                           lower_inclusive,
+                           upper_inclusive);
+    }
+
+    ScanOutput output = ScanOutput::Data;
+    ScanPredicate predicate = ScanPredicate::None;
+    int64_t start_offset = 0;
+    int64_t length = 0;
+    ScanProjection projection = ScanProjection::Data;
+    ScanValueKind value_kind = ScanValueKind::Default;
+    proto::plan::OpType op_type = proto::plan::OpType::Invalid;
+    proto::plan::GenericValue value;
+    proto::plan::GenericValue lower_value;
+    proto::plan::GenericValue upper_value;
+    bool lower_inclusive = false;
+    bool upper_inclusive = false;
+};
+
+using ScanResult = std::unique_ptr<ScanCursor>;
+
+}  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
+++ b/internal/core/src/mmap/ChunkedColumnScanCursors.cpp
@@ -1,0 +1,1067 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "mmap/ChunkedColumnInterface.h"
+
+namespace milvus {
+
+namespace detail {
+
+inline bool
+IsSupportedUnaryScanOp(proto::plan::OpType op_type) {
+    switch (op_type) {
+        case proto::plan::OpType::GreaterThan:
+        case proto::plan::OpType::GreaterEqual:
+        case proto::plan::OpType::LessThan:
+        case proto::plan::OpType::LessEqual:
+        case proto::plan::OpType::Equal:
+        case proto::plan::OpType::NotEqual:
+            return true;
+        default:
+            return false;
+    }
+}
+
+template <typename T>
+inline bool
+TryGetScanValue(const proto::plan::GenericValue& value, T* out) {
+    if constexpr (std::is_same_v<T, bool>) {
+        if (value.val_case() != proto::plan::GenericValue::kBoolVal) {
+            return false;
+        }
+        *out = value.bool_val();
+        return true;
+    } else if constexpr (std::is_integral_v<T>) {
+        if (value.val_case() != proto::plan::GenericValue::kInt64Val) {
+            return false;
+        }
+        if (value.int64_val() <
+                static_cast<int64_t>(std::numeric_limits<T>::min()) ||
+            value.int64_val() >
+                static_cast<int64_t>(std::numeric_limits<T>::max())) {
+            return false;
+        }
+        *out = static_cast<T>(value.int64_val());
+        return true;
+    } else if constexpr (std::is_floating_point_v<T>) {
+        if (value.val_case() == proto::plan::GenericValue::kFloatVal) {
+            *out = static_cast<T>(value.float_val());
+            return true;
+        }
+        if (value.val_case() == proto::plan::GenericValue::kInt64Val) {
+            *out = static_cast<T>(value.int64_val());
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+template <typename T>
+inline bool
+CanUseScanValue(const proto::plan::GenericValue& value) {
+    T typed_value{};
+    return TryGetScanValue<T>(value, &typed_value);
+}
+
+template <typename T>
+inline bool
+UnaryScanCompare(T lhs, T rhs, proto::plan::OpType op_type) {
+    switch (op_type) {
+        case proto::plan::OpType::GreaterThan:
+            return lhs > rhs;
+        case proto::plan::OpType::GreaterEqual:
+            return lhs >= rhs;
+        case proto::plan::OpType::LessThan:
+            return lhs < rhs;
+        case proto::plan::OpType::LessEqual:
+            return lhs <= rhs;
+        case proto::plan::OpType::Equal:
+            return lhs == rhs;
+        case proto::plan::OpType::NotEqual:
+            return lhs != rhs;
+        default:
+            return false;
+    }
+}
+
+inline void
+ResetRowIdPayloadOutput(ChunkedColumnInterface::ScanBatch* out) {
+    out->values = ChunkedColumnInterface::ValueView{};
+    out->validity = ChunkedColumnInterface::ValidityView{};
+    out->row_ids.clear();
+    out->owner.reset();
+    out->row_id_start = 0;
+    out->size = 0;
+}
+
+inline void
+AppendRowIdPayloadEntry(ChunkedColumnInterface::ScanBatch* out,
+                        FixedVector<bool>* validity,
+                        bool* has_invalid,
+                        int64_t row_id,
+                        bool valid) {
+    AssertInfo(validity != nullptr, "row id payload validity owner is null");
+    AssertInfo(has_invalid != nullptr, "row id payload invalid flag is null");
+    if (!out->row_ids.empty()) {
+        AssertInfo(out->row_ids.back() <= row_id,
+                   "row id payload is not ordered: {} before {}",
+                   out->row_ids.back(),
+                   row_id);
+    }
+    out->row_ids.emplace_back(row_id);
+    validity->push_back(valid);
+    *has_invalid = *has_invalid || !valid;
+}
+
+inline void
+FinalizeRowIdPayloadOutput(ChunkedColumnInterface::ScanBatch* out,
+                           std::shared_ptr<FixedVector<bool>> validity,
+                           bool has_invalid,
+                           bool nullable) {
+    AssertInfo(validity != nullptr, "row id payload validity owner is null");
+    AssertInfo(validity->size() == out->row_ids.size(),
+               "row id payload validity size {} does not match row ids size {}",
+               validity->size(),
+               out->row_ids.size());
+    out->row_id_start = out->row_ids.empty() ? 0 : out->row_ids.front();
+    out->size = static_cast<int64_t>(out->row_ids.size());
+    out->validity.size = out->size;
+    out->validity.nullable = nullable;
+    if (out->row_ids.empty() || !has_invalid) {
+        out->validity.encoding =
+            ChunkedColumnInterface::ValidityEncoding::AllValid;
+        out->validity.all_valid = true;
+        return;
+    }
+    out->validity.encoding =
+        ChunkedColumnInterface::ValidityEncoding::BoolArray;
+    out->validity.data = validity->data();
+    out->validity.offset = 0;
+    out->validity.all_valid = false;
+    out->owner = std::move(validity);
+}
+
+class FixedWidthRowIdScanCursor final
+    : public ChunkedColumnInterface::ScanCursor {
+ public:
+    FixedWidthRowIdScanCursor(const ChunkedColumnInterface* column,
+                              milvus::OpContext* op_ctx,
+                              int64_t start_offset,
+                              int64_t length,
+                              DataType data_type,
+                              proto::plan::OpType op_type,
+                              const proto::plan::GenericValue& value)
+        : column_(column),
+          op_ctx_(op_ctx),
+          data_type_(data_type),
+          op_type_(op_type),
+          value_(value),
+          scan_pos_(start_offset),
+          scan_end_(start_offset + length) {
+        if (start_offset < scan_end_) {
+            auto [chunk_id, offset] = column_->GetChunkIDByOffset(start_offset);
+            current_chunk_id_ = static_cast<int64_t>(chunk_id);
+            current_chunk_offset_ = static_cast<int64_t>(offset);
+        }
+    }
+
+    bool
+    Next(ChunkedColumnInterface::ScanBatch* out) override {
+        AssertInfo(out != nullptr, "row id scan output batch is null");
+        ResetRowIdPayloadOutput(out);
+        if (scan_pos_ >= scan_end_) {
+            return false;
+        }
+
+        while (scan_pos_ < scan_end_) {
+            auto& span = GetCurrentSpan();
+            const auto rows = span.get().row_count();
+            if (current_chunk_offset_ >= rows) {
+                ++current_chunk_id_;
+                current_chunk_offset_ = 0;
+                cached_span_.reset();
+                continue;
+            }
+
+            const auto rows_left_in_chunk = rows - current_chunk_offset_;
+            const auto rows_left_in_scan = scan_end_ - scan_pos_;
+            const auto rows_to_scan =
+                std::min<int64_t>(rows_left_in_chunk, rows_left_in_scan);
+            auto validity = std::make_shared<FixedVector<bool>>();
+            bool has_invalid = false;
+            ScanSpan(
+                span.get(), rows_to_scan, out, validity.get(), &has_invalid);
+
+            scan_pos_ += rows_to_scan;
+            current_chunk_offset_ += rows_to_scan;
+            if (!out->row_ids.empty()) {
+                FinalizeRowIdPayloadOutput(out,
+                                           std::move(validity),
+                                           has_invalid,
+                                           column_->IsNullable());
+                return true;
+            }
+        }
+        return false;
+    }
+
+ private:
+    PinWrapper<SpanBase>&
+    GetCurrentSpan() {
+        if (!cached_span_.has_value() ||
+            cached_chunk_id_ != current_chunk_id_) {
+            cached_span_ = column_->Span(op_ctx_, current_chunk_id_);
+            cached_chunk_id_ = current_chunk_id_;
+        }
+        return cached_span_.value();
+    }
+
+    template <typename T>
+    void
+    ScanTypedSpan(const SpanBase& span,
+                  int64_t rows_to_scan,
+                  ChunkedColumnInterface::ScanBatch* out,
+                  FixedVector<bool>* validity,
+                  bool* has_invalid) {
+        T value{};
+        if (!TryGetScanValue<T>(value_, &value)) {
+            return;
+        }
+
+        const auto* data = static_cast<const T*>(span.data());
+        const auto* valid = span.valid_data();
+        for (int64_t i = 0; i < rows_to_scan; ++i) {
+            const auto local_offset = current_chunk_offset_ + i;
+            if (valid != nullptr && !valid[local_offset]) {
+                AppendRowIdPayloadEntry(
+                    out, validity, has_invalid, scan_pos_ + i, false);
+                continue;
+            }
+            if (UnaryScanCompare<T>(data[local_offset], value, op_type_)) {
+                AppendRowIdPayloadEntry(
+                    out, validity, has_invalid, scan_pos_ + i, true);
+            }
+        }
+    }
+
+    void
+    ScanSpan(const SpanBase& span,
+             int64_t rows_to_scan,
+             ChunkedColumnInterface::ScanBatch* out,
+             FixedVector<bool>* validity,
+             bool* has_invalid) {
+        switch (data_type_) {
+            case DataType::BOOL:
+                ScanTypedSpan<bool>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::INT8:
+                ScanTypedSpan<int8_t>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::INT16:
+                ScanTypedSpan<int16_t>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::INT32:
+                ScanTypedSpan<int32_t>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::INT64:
+            case DataType::TIMESTAMPTZ:
+                ScanTypedSpan<int64_t>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::FLOAT:
+                ScanTypedSpan<float>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::DOUBLE:
+                ScanTypedSpan<double>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            default:
+                break;
+        }
+    }
+
+    const ChunkedColumnInterface* column_;
+    milvus::OpContext* op_ctx_;
+    DataType data_type_;
+    proto::plan::OpType op_type_;
+    proto::plan::GenericValue value_;
+    int64_t scan_pos_;
+    int64_t scan_end_;
+    int64_t current_chunk_id_{0};
+    int64_t current_chunk_offset_{0};
+    int64_t cached_chunk_id_{-1};
+    std::optional<PinWrapper<SpanBase>> cached_span_{std::nullopt};
+};
+
+template <typename T>
+inline bool
+BinaryRangeScanCompare(
+    T value, T lower, bool lower_inclusive, T upper, bool upper_inclusive) {
+    const bool lower_ok = lower_inclusive ? value >= lower : value > lower;
+    const bool upper_ok = upper_inclusive ? value <= upper : value < upper;
+    return lower_ok && upper_ok;
+}
+
+class FixedWidthBinaryRangeRowIdScanCursor final
+    : public ChunkedColumnInterface::ScanCursor {
+ public:
+    FixedWidthBinaryRangeRowIdScanCursor(
+        const ChunkedColumnInterface* column,
+        milvus::OpContext* op_ctx,
+        int64_t start_offset,
+        int64_t length,
+        DataType data_type,
+        const proto::plan::GenericValue& lower_value,
+        bool lower_inclusive,
+        const proto::plan::GenericValue& upper_value,
+        bool upper_inclusive)
+        : column_(column),
+          op_ctx_(op_ctx),
+          data_type_(data_type),
+          lower_value_(lower_value),
+          upper_value_(upper_value),
+          lower_inclusive_(lower_inclusive),
+          upper_inclusive_(upper_inclusive),
+          scan_pos_(start_offset),
+          scan_end_(start_offset + length) {
+        if (start_offset < scan_end_) {
+            auto [chunk_id, offset] = column_->GetChunkIDByOffset(start_offset);
+            current_chunk_id_ = static_cast<int64_t>(chunk_id);
+            current_chunk_offset_ = static_cast<int64_t>(offset);
+        }
+    }
+
+    bool
+    Next(ChunkedColumnInterface::ScanBatch* out) override {
+        AssertInfo(out != nullptr,
+                   "binary range row id scan output batch is null");
+        ResetRowIdPayloadOutput(out);
+        if (scan_pos_ >= scan_end_) {
+            return false;
+        }
+
+        while (scan_pos_ < scan_end_) {
+            auto& span = GetCurrentSpan();
+            const auto rows = span.get().row_count();
+            if (current_chunk_offset_ >= rows) {
+                ++current_chunk_id_;
+                current_chunk_offset_ = 0;
+                cached_span_.reset();
+                continue;
+            }
+
+            const auto rows_left_in_chunk = rows - current_chunk_offset_;
+            const auto rows_left_in_scan = scan_end_ - scan_pos_;
+            const auto rows_to_scan =
+                std::min<int64_t>(rows_left_in_chunk, rows_left_in_scan);
+            auto validity = std::make_shared<FixedVector<bool>>();
+            bool has_invalid = false;
+            ScanSpan(
+                span.get(), rows_to_scan, out, validity.get(), &has_invalid);
+
+            scan_pos_ += rows_to_scan;
+            current_chunk_offset_ += rows_to_scan;
+            if (!out->row_ids.empty()) {
+                FinalizeRowIdPayloadOutput(out,
+                                           std::move(validity),
+                                           has_invalid,
+                                           column_->IsNullable());
+                return true;
+            }
+        }
+        return false;
+    }
+
+ private:
+    PinWrapper<SpanBase>&
+    GetCurrentSpan() {
+        if (!cached_span_.has_value() ||
+            cached_chunk_id_ != current_chunk_id_) {
+            cached_span_ = column_->Span(op_ctx_, current_chunk_id_);
+            cached_chunk_id_ = current_chunk_id_;
+        }
+        return cached_span_.value();
+    }
+
+    template <typename T>
+    void
+    ScanTypedSpan(const SpanBase& span,
+                  int64_t rows_to_scan,
+                  ChunkedColumnInterface::ScanBatch* out,
+                  FixedVector<bool>* validity,
+                  bool* has_invalid) {
+        T lower{};
+        T upper{};
+        if (!TryGetScanValue<T>(lower_value_, &lower) ||
+            !TryGetScanValue<T>(upper_value_, &upper)) {
+            return;
+        }
+
+        const auto* data = static_cast<const T*>(span.data());
+        const auto* valid = span.valid_data();
+        for (int64_t i = 0; i < rows_to_scan; ++i) {
+            const auto local_offset = current_chunk_offset_ + i;
+            if (valid != nullptr && !valid[local_offset]) {
+                AppendRowIdPayloadEntry(
+                    out, validity, has_invalid, scan_pos_ + i, false);
+                continue;
+            }
+            if (BinaryRangeScanCompare<T>(data[local_offset],
+                                          lower,
+                                          lower_inclusive_,
+                                          upper,
+                                          upper_inclusive_)) {
+                AppendRowIdPayloadEntry(
+                    out, validity, has_invalid, scan_pos_ + i, true);
+            }
+        }
+    }
+
+    void
+    ScanSpan(const SpanBase& span,
+             int64_t rows_to_scan,
+             ChunkedColumnInterface::ScanBatch* out,
+             FixedVector<bool>* validity,
+             bool* has_invalid) {
+        switch (data_type_) {
+            case DataType::BOOL:
+                ScanTypedSpan<bool>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::INT8:
+                ScanTypedSpan<int8_t>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::INT16:
+                ScanTypedSpan<int16_t>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::INT32:
+                ScanTypedSpan<int32_t>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::INT64:
+            case DataType::TIMESTAMPTZ:
+                ScanTypedSpan<int64_t>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::FLOAT:
+                ScanTypedSpan<float>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            case DataType::DOUBLE:
+                ScanTypedSpan<double>(
+                    span, rows_to_scan, out, validity, has_invalid);
+                break;
+            default:
+                break;
+        }
+    }
+
+    const ChunkedColumnInterface* column_;
+    milvus::OpContext* op_ctx_;
+    DataType data_type_;
+    proto::plan::GenericValue lower_value_;
+    proto::plan::GenericValue upper_value_;
+    bool lower_inclusive_;
+    bool upper_inclusive_;
+    int64_t scan_pos_;
+    int64_t scan_end_;
+    int64_t current_chunk_id_{0};
+    int64_t current_chunk_offset_{0};
+    int64_t cached_chunk_id_{-1};
+    std::optional<PinWrapper<SpanBase>> cached_span_{std::nullopt};
+};
+
+class FixedWidthDataScanCursor final
+    : public ChunkedColumnInterface::ScanCursor {
+ public:
+    FixedWidthDataScanCursor(const ChunkedColumnInterface* column,
+                             milvus::OpContext* op_ctx,
+                             int64_t start_offset,
+                             int64_t length,
+                             DataType data_type,
+                             ChunkedColumnInterface::ScanProjection projection,
+                             ChunkedColumnInterface::ScanValueKind value_kind)
+        : column_(column),
+          op_ctx_(op_ctx),
+          data_type_(data_type),
+          projection_(projection),
+          value_kind_(value_kind),
+          scan_pos_(start_offset),
+          scan_end_(start_offset + length) {
+        if (start_offset < scan_end_) {
+            auto [chunk_id, offset] = column_->GetChunkIDByOffset(start_offset);
+            current_chunk_id_ = static_cast<int64_t>(chunk_id);
+            current_chunk_offset_ = static_cast<int64_t>(offset);
+        }
+    }
+
+    bool
+    Next(ChunkedColumnInterface::ScanBatch* out) override {
+        AssertInfo(out != nullptr, "data scan output batch is null");
+        out->values = ChunkedColumnInterface::ValueView{};
+        out->validity = ChunkedColumnInterface::ValidityView{};
+        out->row_ids.clear();
+        out->owner.reset();
+        out->row_id_start = 0;
+        out->size = 0;
+        if (scan_pos_ >= scan_end_) {
+            return false;
+        }
+
+        while (scan_pos_ < scan_end_) {
+            auto& span = GetCurrentSpan();
+            const auto rows = span.get().row_count();
+            if (current_chunk_offset_ >= rows) {
+                ++current_chunk_id_;
+                current_chunk_offset_ = 0;
+                cached_span_.reset();
+                continue;
+            }
+
+            const auto rows_left_in_chunk = rows - current_chunk_offset_;
+            const auto rows_left_in_scan = scan_end_ - scan_pos_;
+            const auto rows_to_return =
+                std::min<int64_t>(rows_left_in_chunk, rows_left_in_scan);
+
+            auto owner = std::make_shared<PinWrapper<SpanBase>>(span);
+            if (projection_ != ChunkedColumnInterface::ScanProjection::NoData) {
+                out->values.encoding =
+                    ChunkedColumnInterface::ValueEncoding::FixedWidth;
+                out->values.kind =
+                    value_kind_ ==
+                            ChunkedColumnInterface::ScanValueKind::Default
+                        ? ChunkedColumnInterface::ScanValueKind::FixedWidth
+                        : value_kind_;
+                out->values.physical_type = data_type_;
+                out->values.logical_type = data_type_;
+                out->values.data = span.get().data();
+                out->values.offset = current_chunk_offset_;
+                out->values.size = rows_to_return;
+                out->values.byte_width = span.get().element_sizeof();
+            }
+            out->validity.size = rows_to_return;
+            out->validity.nullable = column_->IsNullable();
+            if (span.get().valid_data() != nullptr) {
+                out->validity.encoding =
+                    ChunkedColumnInterface::ValidityEncoding::BoolArray;
+                out->validity.data = span.get().valid_data();
+                out->validity.offset = current_chunk_offset_;
+                out->validity.all_valid = false;
+            }
+            out->owner = std::move(owner);
+            out->row_id_start = scan_pos_;
+            out->size = rows_to_return;
+
+            scan_pos_ += rows_to_return;
+            current_chunk_offset_ += rows_to_return;
+            return true;
+        }
+        return false;
+    }
+
+ private:
+    PinWrapper<SpanBase>&
+    GetCurrentSpan() {
+        if (!cached_span_.has_value() ||
+            cached_chunk_id_ != current_chunk_id_) {
+            cached_span_ = column_->Span(op_ctx_, current_chunk_id_);
+            cached_chunk_id_ = current_chunk_id_;
+        }
+        return cached_span_.value();
+    }
+
+    const ChunkedColumnInterface* column_;
+    milvus::OpContext* op_ctx_;
+    DataType data_type_;
+    ChunkedColumnInterface::ScanProjection projection_;
+    ChunkedColumnInterface::ScanValueKind value_kind_;
+    int64_t scan_pos_;
+    int64_t scan_end_;
+    int64_t current_chunk_id_{0};
+    int64_t current_chunk_offset_{0};
+    int64_t cached_chunk_id_{-1};
+    std::optional<PinWrapper<SpanBase>> cached_span_{std::nullopt};
+};
+
+class ViewDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
+ public:
+    ViewDataScanCursor(const ChunkedColumnInterface* column,
+                       milvus::OpContext* op_ctx,
+                       int64_t start_offset,
+                       int64_t length,
+                       DataType data_type,
+                       ChunkedColumnInterface::ScanProjection projection,
+                       ChunkedColumnInterface::ScanValueKind value_kind)
+        : column_(column),
+          op_ctx_(op_ctx),
+          data_type_(data_type),
+          projection_(projection),
+          value_kind_(value_kind),
+          scan_pos_(start_offset),
+          scan_end_(start_offset + length) {
+    }
+
+    bool
+    Next(ChunkedColumnInterface::ScanBatch* out) override {
+        AssertInfo(out != nullptr, "view data scan output batch is null");
+        ResetOutput(out);
+        if (scan_pos_ >= scan_end_) {
+            return false;
+        }
+
+        auto [chunk_id, offset] = column_->GetChunkIDByOffset(scan_pos_);
+        const auto chunk_rows = column_->chunk_row_nums(chunk_id);
+        const auto rows_to_return = std::min<int64_t>(
+            {chunk_rows - static_cast<int64_t>(offset), scan_end_ - scan_pos_});
+        AssertInfo(rows_to_return > 0,
+                   "invalid view data scan batch at offset {}",
+                   scan_pos_);
+
+        out->row_id_start = scan_pos_;
+        out->size = rows_to_return;
+        if (projection_ == ChunkedColumnInterface::ScanProjection::NoData) {
+            FillNoDataBatch(chunk_id, offset, out);
+            scan_pos_ += rows_to_return;
+            return true;
+        }
+
+        const auto range =
+            std::make_pair(static_cast<int64_t>(offset), rows_to_return);
+        switch (value_kind_) {
+            case ChunkedColumnInterface::ScanValueKind::StringView:
+                FillStringViewBatch(chunk_id, range, out);
+                break;
+            case ChunkedColumnInterface::ScanValueKind::JsonView:
+                FillJsonViewBatch(chunk_id, range, out);
+                break;
+            case ChunkedColumnInterface::ScanValueKind::ArrayView:
+                FillArrayViewBatch(chunk_id, range, out);
+                break;
+            default:
+                ThrowInfo(ErrorCode::Unsupported,
+                          "unsupported view data scan kind {}",
+                          static_cast<int>(value_kind_));
+        }
+
+        scan_pos_ += rows_to_return;
+        return true;
+    }
+
+ private:
+    using StringViews =
+        std::pair<std::vector<std::string_view>, FixedVector<bool>>;
+    using ArrayViews = std::pair<std::vector<ArrayView>, FixedVector<bool>>;
+
+    struct StringOwner {
+        explicit StringOwner(PinWrapper<StringViews>&& views)
+            : views(std::move(views)) {
+        }
+        PinWrapper<StringViews> views;
+    };
+
+    struct JsonOwner {
+        explicit JsonOwner(PinWrapper<StringViews>&& views)
+            : views(std::move(views)) {
+            auto& strings = this->views.get().first;
+            values.reserve(strings.size());
+            for (const auto& value : strings) {
+                values.emplace_back(Json(value));
+            }
+        }
+        PinWrapper<StringViews> views;
+        std::vector<Json> values;
+    };
+
+    struct ArrayOwner {
+        explicit ArrayOwner(PinWrapper<ArrayViews>&& views)
+            : views(std::move(views)) {
+        }
+        PinWrapper<ArrayViews> views;
+    };
+
+    struct ValidityOwner {
+        explicit ValidityOwner(PinWrapper<Chunk*>&& chunk)
+            : chunk(std::move(chunk)) {
+        }
+        PinWrapper<Chunk*> chunk;
+    };
+
+    static void
+    ResetOutput(ChunkedColumnInterface::ScanBatch* out) {
+        out->values = ChunkedColumnInterface::ValueView{};
+        out->validity = ChunkedColumnInterface::ValidityView{};
+        out->row_ids.clear();
+        out->owner.reset();
+        out->row_id_start = 0;
+        out->size = 0;
+    }
+
+    void
+    FillValidity(const FixedVector<bool>& valid_data,
+                 ChunkedColumnInterface::ScanBatch* out) const {
+        out->validity.size = out->size;
+        out->validity.nullable = column_->IsNullable();
+        if (!column_->IsNullable() || valid_data.empty()) {
+            out->validity.encoding =
+                ChunkedColumnInterface::ValidityEncoding::AllValid;
+            out->validity.all_valid = true;
+            return;
+        }
+        out->validity.encoding =
+            ChunkedColumnInterface::ValidityEncoding::BoolArray;
+        out->validity.data = valid_data.data();
+        out->validity.offset = 0;
+        out->validity.all_valid = false;
+    }
+
+    void
+    FillNoDataBatch(int64_t chunk_id,
+                    int64_t offset,
+                    ChunkedColumnInterface::ScanBatch* out) const {
+        out->validity.size = out->size;
+        out->validity.nullable = column_->IsNullable();
+        if (!column_->IsNullable()) {
+            out->validity.encoding =
+                ChunkedColumnInterface::ValidityEncoding::AllValid;
+            out->validity.all_valid = true;
+            return;
+        }
+
+        auto owner = std::make_shared<ValidityOwner>(
+            column_->GetChunk(op_ctx_, chunk_id));
+        const auto& valid_data = owner->chunk.get()->Valid();
+        if (valid_data.empty()) {
+            out->validity.encoding =
+                ChunkedColumnInterface::ValidityEncoding::AllValid;
+            out->validity.all_valid = true;
+            return;
+        }
+
+        out->validity.encoding =
+            ChunkedColumnInterface::ValidityEncoding::BoolArray;
+        out->validity.data = valid_data.data();
+        out->validity.offset = offset;
+        out->validity.all_valid = false;
+        out->owner = std::move(owner);
+    }
+
+    void
+    FillStringViewBatch(int64_t chunk_id,
+                        std::pair<int64_t, int64_t> range,
+                        ChunkedColumnInterface::ScanBatch* out) const {
+        auto owner = std::make_shared<StringOwner>(
+            column_->StringViews(op_ctx_, chunk_id, range));
+        auto& views = owner->views.get();
+        out->values.encoding =
+            ChunkedColumnInterface::ValueEncoding::StringView;
+        out->values.kind = ChunkedColumnInterface::ScanValueKind::StringView;
+        out->values.physical_type = data_type_;
+        out->values.logical_type = data_type_;
+        out->values.data = views.first.data();
+        out->values.offset = 0;
+        out->values.size = out->size;
+        out->values.byte_width = sizeof(std::string_view);
+        FillValidity(views.second, out);
+        out->owner = std::move(owner);
+    }
+
+    void
+    FillJsonViewBatch(int64_t chunk_id,
+                      std::pair<int64_t, int64_t> range,
+                      ChunkedColumnInterface::ScanBatch* out) const {
+        auto owner = std::make_shared<JsonOwner>(
+            column_->StringViews(op_ctx_, chunk_id, range));
+        out->values.encoding = ChunkedColumnInterface::ValueEncoding::JsonView;
+        out->values.kind = ChunkedColumnInterface::ScanValueKind::JsonView;
+        out->values.physical_type = data_type_;
+        out->values.logical_type = DataType::JSON;
+        out->values.data = owner->values.data();
+        out->values.offset = 0;
+        out->values.size = out->size;
+        out->values.byte_width = sizeof(Json);
+        FillValidity(owner->views.get().second, out);
+        out->owner = std::move(owner);
+    }
+
+    void
+    FillArrayViewBatch(int64_t chunk_id,
+                       std::pair<int64_t, int64_t> range,
+                       ChunkedColumnInterface::ScanBatch* out) const {
+        auto owner = std::make_shared<ArrayOwner>(
+            column_->ArrayViews(op_ctx_, chunk_id, range));
+        auto& views = owner->views.get();
+        out->values.encoding = ChunkedColumnInterface::ValueEncoding::ArrayView;
+        out->values.kind = ChunkedColumnInterface::ScanValueKind::ArrayView;
+        out->values.physical_type = data_type_;
+        out->values.logical_type = DataType::ARRAY;
+        out->values.data = views.first.data();
+        out->values.offset = 0;
+        out->values.size = out->size;
+        out->values.byte_width = sizeof(ArrayView);
+        FillValidity(views.second, out);
+        out->owner = std::move(owner);
+    }
+
+    const ChunkedColumnInterface* column_;
+    milvus::OpContext* op_ctx_;
+    DataType data_type_;
+    ChunkedColumnInterface::ScanProjection projection_;
+    ChunkedColumnInterface::ScanValueKind value_kind_;
+    int64_t scan_pos_;
+    int64_t scan_end_;
+};
+
+inline bool
+CanUseFixedWidthRowIdScan(DataType data_type,
+                          proto::plan::OpType op_type,
+                          const proto::plan::GenericValue& value) {
+    if (!IsSupportedUnaryScanOp(op_type)) {
+        return false;
+    }
+
+    switch (data_type) {
+        case DataType::BOOL:
+            return CanUseScanValue<bool>(value);
+        case DataType::INT8:
+            return CanUseScanValue<int8_t>(value);
+        case DataType::INT16:
+            return CanUseScanValue<int16_t>(value);
+        case DataType::INT32:
+            return CanUseScanValue<int32_t>(value);
+        case DataType::INT64:
+        case DataType::TIMESTAMPTZ:
+            return CanUseScanValue<int64_t>(value);
+        case DataType::FLOAT:
+            return CanUseScanValue<float>(value);
+        case DataType::DOUBLE:
+            return CanUseScanValue<double>(value);
+        default:
+            return false;
+    }
+}
+
+inline bool
+CanUseFixedWidthBinaryRangeRowIdScan(
+    DataType data_type,
+    const proto::plan::GenericValue& lower_value,
+    const proto::plan::GenericValue& upper_value) {
+    switch (data_type) {
+        case DataType::BOOL:
+            return CanUseScanValue<bool>(lower_value) &&
+                   CanUseScanValue<bool>(upper_value);
+        case DataType::INT8:
+            return CanUseScanValue<int8_t>(lower_value) &&
+                   CanUseScanValue<int8_t>(upper_value);
+        case DataType::INT16:
+            return CanUseScanValue<int16_t>(lower_value) &&
+                   CanUseScanValue<int16_t>(upper_value);
+        case DataType::INT32:
+            return CanUseScanValue<int32_t>(lower_value) &&
+                   CanUseScanValue<int32_t>(upper_value);
+        case DataType::INT64:
+        case DataType::TIMESTAMPTZ:
+            return CanUseScanValue<int64_t>(lower_value) &&
+                   CanUseScanValue<int64_t>(upper_value);
+        case DataType::FLOAT:
+            return CanUseScanValue<float>(lower_value) &&
+                   CanUseScanValue<float>(upper_value);
+        case DataType::DOUBLE:
+            return CanUseScanValue<double>(lower_value) &&
+                   CanUseScanValue<double>(upper_value);
+        default:
+            return false;
+    }
+}
+
+inline std::unique_ptr<ChunkedColumnInterface::ScanCursor>
+MakeFixedWidthRowIdScanCursor(const ChunkedColumnInterface* column,
+                              milvus::OpContext* op_ctx,
+                              int64_t start_offset,
+                              int64_t length,
+                              DataType data_type,
+                              proto::plan::OpType op_type,
+                              const proto::plan::GenericValue& value) {
+    AssertInfo(
+        start_offset >= 0 && length >= 0 &&
+            start_offset + length <= static_cast<int64_t>(column->NumRows()),
+        "row id scan range [{}, {}) out of rows {}",
+        start_offset,
+        start_offset + length,
+        column->NumRows());
+    if (!CanUseFixedWidthRowIdScan(data_type, op_type, value)) {
+        return nullptr;
+    }
+    return std::make_unique<FixedWidthRowIdScanCursor>(
+        column, op_ctx, start_offset, length, data_type, op_type, value);
+}
+
+inline std::unique_ptr<ChunkedColumnInterface::ScanCursor>
+MakeFixedWidthBinaryRangeRowIdScanCursor(
+    const ChunkedColumnInterface* column,
+    milvus::OpContext* op_ctx,
+    int64_t start_offset,
+    int64_t length,
+    DataType data_type,
+    const proto::plan::GenericValue& lower_value,
+    bool lower_inclusive,
+    const proto::plan::GenericValue& upper_value,
+    bool upper_inclusive) {
+    AssertInfo(
+        start_offset >= 0 && length >= 0 &&
+            start_offset + length <= static_cast<int64_t>(column->NumRows()),
+        "binary range row id scan range [{}, {}) out of rows {}",
+        start_offset,
+        start_offset + length,
+        column->NumRows());
+    if (!CanUseFixedWidthBinaryRangeRowIdScan(
+            data_type, lower_value, upper_value)) {
+        return nullptr;
+    }
+    return std::make_unique<FixedWidthBinaryRangeRowIdScanCursor>(
+        column,
+        op_ctx,
+        start_offset,
+        length,
+        data_type,
+        lower_value,
+        lower_inclusive,
+        upper_value,
+        upper_inclusive);
+}
+
+inline std::unique_ptr<ChunkedColumnInterface::ScanCursor>
+MakeFixedWidthDataScanCursor(const ChunkedColumnInterface* column,
+                             milvus::OpContext* op_ctx,
+                             int64_t start_offset,
+                             int64_t length,
+                             DataType data_type,
+                             ChunkedColumnInterface::ScanProjection projection,
+                             ChunkedColumnInterface::ScanValueKind value_kind) {
+    AssertInfo(
+        start_offset >= 0 && length >= 0 &&
+            start_offset + length <= static_cast<int64_t>(column->NumRows()),
+        "data scan range [{}, {}) out of rows {}",
+        start_offset,
+        start_offset + length,
+        column->NumRows());
+    if (!ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
+        return nullptr;
+    }
+    return std::make_unique<FixedWidthDataScanCursor>(column,
+                                                      op_ctx,
+                                                      start_offset,
+                                                      length,
+                                                      data_type,
+                                                      projection,
+                                                      value_kind);
+}
+
+inline std::unique_ptr<ChunkedColumnInterface::ScanCursor>
+MakeDataScanCursor(const ChunkedColumnInterface* column,
+                   milvus::OpContext* op_ctx,
+                   int64_t start_offset,
+                   int64_t length,
+                   DataType data_type,
+                   ChunkedColumnInterface::ScanProjection projection,
+                   ChunkedColumnInterface::ScanValueKind value_kind) {
+    auto resolved_kind = value_kind;
+    if (resolved_kind == ChunkedColumnInterface::ScanValueKind::Default) {
+        if (ChunkedColumnInterface::IsPrimitiveDataType(data_type)) {
+            resolved_kind = ChunkedColumnInterface::ScanValueKind::FixedWidth;
+        } else if (data_type == DataType::JSON) {
+            resolved_kind = ChunkedColumnInterface::ScanValueKind::JsonView;
+        } else if (data_type == DataType::STRING ||
+                   data_type == DataType::VARCHAR ||
+                   data_type == DataType::TEXT ||
+                   data_type == DataType::GEOMETRY) {
+            resolved_kind = ChunkedColumnInterface::ScanValueKind::StringView;
+        } else if (data_type == DataType::ARRAY) {
+            resolved_kind = ChunkedColumnInterface::ScanValueKind::ArrayView;
+        }
+    }
+
+    if (resolved_kind == ChunkedColumnInterface::ScanValueKind::FixedWidth) {
+        return MakeFixedWidthDataScanCursor(column,
+                                            op_ctx,
+                                            start_offset,
+                                            length,
+                                            data_type,
+                                            projection,
+                                            resolved_kind);
+    }
+
+    if (resolved_kind == ChunkedColumnInterface::ScanValueKind::StringView ||
+        resolved_kind == ChunkedColumnInterface::ScanValueKind::JsonView ||
+        resolved_kind == ChunkedColumnInterface::ScanValueKind::ArrayView) {
+        AssertInfo(start_offset >= 0 && length >= 0 &&
+                       start_offset + length <=
+                           static_cast<int64_t>(column->NumRows()),
+                   "data scan range [{}, {}) out of rows {}",
+                   start_offset,
+                   start_offset + length,
+                   column->NumRows());
+        return std::make_unique<ViewDataScanCursor>(column,
+                                                    op_ctx,
+                                                    start_offset,
+                                                    length,
+                                                    data_type,
+                                                    projection,
+                                                    resolved_kind);
+    }
+
+    return nullptr;
+}
+
+}  // namespace detail
+
+ChunkedColumnInterface::ScanResult
+ChunkedColumnInterface::Scan(milvus::OpContext* op_ctx,
+                             const ScanOptions& options) const {
+    auto data_type = GetDefaultScanDataType();
+    if (!data_type.has_value()) {
+        return nullptr;
+    }
+
+    if (options.output != ScanOutput::Data ||
+        options.predicate != ScanPredicate::None) {
+        return nullptr;
+    }
+
+    return detail::MakeDataScanCursor(this,
+                                      op_ctx,
+                                      options.start_offset,
+                                      options.length,
+                                      *data_type,
+                                      options.projection,
+                                      options.value_kind);
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/SparseVortexFileSystem.cpp
+++ b/internal/core/src/mmap/SparseVortexFileSystem.cpp
@@ -1,0 +1,496 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "mmap/SparseVortexFileSystem.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <fcntl.h>
+#ifdef __linux__
+#include <linux/falloc.h>
+#endif
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <arrow/buffer.h>
+#include <arrow/filesystem/filesystem.h>
+#include <arrow/io/interfaces.h>
+#include <fmt/format.h>
+
+#include "milvus-storage/format/vortex/vortex_types.h"
+
+namespace milvus {
+
+namespace {
+
+#ifndef MFD_CLOEXEC
+#define MFD_CLOEXEC 0x0001U
+#endif
+
+[[noreturn]] inline void
+ThrowSystemError(std::string_view action) {
+    throw std::runtime_error(
+        fmt::format("{} failed: {}", action, std::strerror(errno)));
+}
+
+inline int
+CreateAnonymousSparseFile(std::string_view name) {
+#ifndef SYS_memfd_create
+    (void)name;
+    errno = ENOSYS;
+    return -1;
+#else
+    auto fd = static_cast<int>(
+        ::syscall(SYS_memfd_create, std::string(name).c_str(), MFD_CLOEXEC));
+    return fd;
+#endif
+}
+
+}  // namespace
+
+class SparseVortexMmapFile final
+    : public milvus_storage::vortex::VortexRangeFile,
+      public std::enable_shared_from_this<SparseVortexMmapFile> {
+ public:
+    explicit SparseVortexMmapFile(std::string name) {
+        fd_ = CreateAnonymousSparseFile(name);
+        if (fd_ < 0) {
+            ThrowSystemError("create vortex sparse file");
+        }
+    }
+
+    ~SparseVortexMmapFile() override {
+        if (mapping_ != nullptr) {
+            ::munmap(mapping_, static_cast<size_t>(mapped_size_));
+        }
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+
+    void
+    Resize(uint64_t size) override {
+        std::unique_lock<std::shared_mutex> lock(mutex_);
+        if (size == size_) {
+            return;
+        }
+        if (size > static_cast<uint64_t>(std::numeric_limits<off_t>::max())) {
+            throw std::runtime_error(fmt::format(
+                "vortex sparse file size {} exceeds off_t limit", size));
+        }
+        if (::ftruncate(fd_, static_cast<off_t>(size)) != 0) {
+            ThrowSystemError("resize vortex sparse file");
+        }
+        size_ = size;
+        RemapLocked();
+    }
+
+    uint64_t
+    Size() const override {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        return size_;
+    }
+
+    arrow::Status
+    WriteAt(const uint64_t& offset,
+            const std::shared_ptr<arrow::Buffer>& data) override {
+        if (!data) {
+            return arrow::Status::Invalid(
+                "VortexRangeFile::WriteAt got null buffer");
+        }
+        const auto length = static_cast<uint64_t>(data->size());
+        if (length == 0) {
+            return arrow::Status::OK();
+        }
+        if (offset > std::numeric_limits<uint64_t>::max() - length) {
+            return arrow::Status::Invalid(
+                "VortexRangeFile::WriteAt range overflows");
+        }
+
+        std::unique_lock<std::shared_mutex> lock(mutex_);
+        if (offset + length > size_) {
+            return arrow::Status::IOError(
+                fmt::format("VortexRangeFile::WriteAt out of range, offset={}, "
+                            "length={}, size={}",
+                            offset,
+                            length,
+                            size_));
+        }
+        if (mapping_ == nullptr) {
+            return arrow::Status::IOError(
+                "VortexRangeFile::WriteAt got empty mapping");
+        }
+
+        std::memcpy(mapping_ + offset, data->data(), length);
+        return arrow::Status::OK();
+    }
+
+    void
+    Punch(uint64_t offset, uint64_t length) override {
+        if (length == 0) {
+            return;
+        }
+        std::unique_lock<std::shared_mutex> lock(mutex_);
+        if (offset >= size_) {
+            return;
+        }
+        length = std::min<uint64_t>(length, size_ - offset);
+        if (length == 0 || mapping_ == nullptr) {
+            return;
+        }
+
+#if defined(FALLOC_FL_PUNCH_HOLE) && defined(SYS_fallocate)
+        if (offset <=
+                static_cast<uint64_t>(std::numeric_limits<off_t>::max()) &&
+            length <=
+                static_cast<uint64_t>(std::numeric_limits<off_t>::max())) {
+            if (::syscall(SYS_fallocate,
+                          fd_,
+                          FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+                          static_cast<off_t>(offset),
+                          static_cast<off_t>(length)) == 0) {
+                return;
+            }
+        }
+#endif
+
+        std::memset(mapping_ + offset, 0, length);
+    }
+
+    arrow::Result<int64_t>
+    ReadAt(int64_t position, int64_t nbytes, void* out) const override {
+        if (position < 0 || nbytes < 0) {
+            return arrow::Status::Invalid(
+                "VortexRangeFile::ReadAt got negative position or length");
+        }
+        if (nbytes == 0) {
+            return 0;
+        }
+        if (out == nullptr) {
+            return arrow::Status::Invalid(
+                "VortexRangeFile::ReadAt got null output");
+        }
+
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        const auto pos = static_cast<uint64_t>(position);
+        if (pos >= size_) {
+            return 0;
+        }
+        const auto available = size_ - pos;
+        const auto read = std::min(static_cast<uint64_t>(nbytes), available);
+        if (read == 0) {
+            return 0;
+        }
+        if (mapping_ == nullptr) {
+            return arrow::Status::IOError(
+                "VortexRangeFile::ReadAt got empty mapping");
+        }
+
+        std::memcpy(out, mapping_ + pos, read);
+        return static_cast<int64_t>(read);
+    }
+
+    arrow::Result<std::shared_ptr<arrow::Buffer>>
+    ReadAt(int64_t position, int64_t nbytes) const override {
+        if (nbytes < 0) {
+            return arrow::Status::Invalid(
+                "VortexRangeFile::ReadAt got negative length");
+        }
+        if (position < 0) {
+            return arrow::Status::Invalid(
+                "VortexRangeFile::ReadAt got negative position");
+        }
+        if (nbytes == 0) {
+            return arrow::Buffer::FromString(std::string());
+        }
+
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        const auto pos = static_cast<uint64_t>(position);
+        if (pos >= size_) {
+            return arrow::Buffer::FromString(std::string());
+        }
+        const auto available = size_ - pos;
+        const auto read = std::min(static_cast<uint64_t>(nbytes), available);
+        if (read == 0) {
+            return arrow::Buffer::FromString(std::string());
+        }
+        if (mapping_ == nullptr) {
+            return arrow::Status::IOError(
+                "VortexRangeFile::ReadAt got empty mapping");
+        }
+        auto owner = shared_from_this();
+        return std::shared_ptr<arrow::Buffer>(
+            new arrow::Buffer(mapping_ + pos, static_cast<int64_t>(read)),
+            [owner = std::move(owner)](arrow::Buffer* buffer) {
+                delete buffer;
+            });
+    }
+
+ private:
+    void
+    RemapLocked() {
+        if (mapping_ != nullptr) {
+            if (::munmap(mapping_, static_cast<size_t>(mapped_size_)) != 0) {
+                ThrowSystemError("unmap vortex sparse file");
+            }
+            mapping_ = nullptr;
+            mapped_size_ = 0;
+        }
+        if (size_ == 0) {
+            return;
+        }
+        if (size_ > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+            throw std::runtime_error(fmt::format(
+                "vortex sparse file size {} exceeds mmap limit", size_));
+        }
+        auto* mapped = ::mmap(nullptr,
+                              static_cast<size_t>(size_),
+                              PROT_READ | PROT_WRITE,
+                              MAP_SHARED,
+                              fd_,
+                              0);
+        if (mapped == MAP_FAILED) {
+            ThrowSystemError("mmap vortex sparse file");
+        }
+        mapping_ = static_cast<uint8_t*>(mapped);
+        mapped_size_ = size_;
+    }
+
+    mutable std::shared_mutex mutex_;
+    int fd_ = -1;
+    uint8_t* mapping_ = nullptr;
+    uint64_t mapped_size_ = 0;
+    uint64_t size_ = 0;
+};
+
+class SparseVortexInputFile final : public arrow::io::RandomAccessFile {
+ public:
+    explicit SparseVortexInputFile(
+        std::shared_ptr<milvus_storage::vortex::VortexRangeFile> file)
+        : file_(std::move(file)) {
+    }
+
+    arrow::Status
+    Close() override {
+        closed_ = true;
+        return arrow::Status::OK();
+    }
+
+    bool
+    closed() const override {
+        return closed_;
+    }
+
+    arrow::Result<int64_t>
+    Tell() const override {
+        return position_;
+    }
+
+    arrow::Status
+    Seek(int64_t position) override {
+        if (position < 0) {
+            return arrow::Status::Invalid(
+                "negative seek in SparseVortexInputFile");
+        }
+        position_ = position;
+        return arrow::Status::OK();
+    }
+
+    arrow::Result<int64_t>
+    Read(int64_t nbytes, void* out) override {
+        ARROW_ASSIGN_OR_RAISE(auto read, ReadAt(position_, nbytes, out));
+        position_ += read;
+        return read;
+    }
+
+    arrow::Result<std::shared_ptr<arrow::Buffer>>
+    Read(int64_t nbytes) override {
+        ARROW_ASSIGN_OR_RAISE(auto buffer, ReadAt(position_, nbytes));
+        position_ += buffer->size();
+        return buffer;
+    }
+
+    arrow::Result<int64_t>
+    ReadAt(int64_t position, int64_t nbytes, void* out) override {
+        if (closed_) {
+            return arrow::Status::IOError("SparseVortexInputFile is closed");
+        }
+        return file_->ReadAt(position, nbytes, out);
+    }
+
+    arrow::Result<std::shared_ptr<arrow::Buffer>>
+    ReadAt(int64_t position, int64_t nbytes) override {
+        if (closed_) {
+            return arrow::Status::IOError("SparseVortexInputFile is closed");
+        }
+        return file_->ReadAt(position, nbytes);
+    }
+
+    arrow::Result<int64_t>
+    GetSize() override {
+        return static_cast<int64_t>(file_->Size());
+    }
+
+ private:
+    std::shared_ptr<milvus_storage::vortex::VortexRangeFile> file_;
+    int64_t position_ = 0;
+    bool closed_ = false;
+};
+
+class SparseVortexFileSystem final
+    : public arrow::fs::FileSystem,
+      public milvus_storage::vortex::VortexRangeFileProvider {
+ public:
+    explicit SparseVortexFileSystem(std::string path)
+        : file_(std::make_shared<SparseVortexMmapFile>(path)),
+          path_(std::move(path)) {
+    }
+
+    std::string
+    type_name() const override {
+        return "vortex-sparse-mmap";
+    }
+
+    bool
+    Equals(const arrow::fs::FileSystem& other) const override {
+        return this == &other;
+    }
+
+    arrow::Result<std::shared_ptr<milvus_storage::vortex::VortexRangeFile>>
+    GetVortexRangeFile(const std::string& path) const override {
+        ARROW_RETURN_NOT_OK(CheckPath(path));
+        return file_;
+    }
+
+    arrow::Result<arrow::fs::FileInfo>
+    GetFileInfo(const std::string& path) override {
+        ARROW_RETURN_NOT_OK(CheckPath(path));
+        arrow::fs::FileInfo info(path.empty() ? path_ : path);
+        info.set_type(arrow::fs::FileType::File);
+        info.set_size(static_cast<int64_t>(file_->Size()));
+        return info;
+    }
+
+    arrow::Result<std::vector<arrow::fs::FileInfo>>
+    GetFileInfo(const arrow::fs::FileSelector& select) override {
+        ARROW_ASSIGN_OR_RAISE(auto info, GetFileInfo(select.base_dir));
+        return std::vector<arrow::fs::FileInfo>{std::move(info)};
+    }
+
+    arrow::Status
+    CreateDir(const std::string&, bool) override {
+        return arrow::Status::OK();
+    }
+
+    arrow::Status
+    DeleteDir(const std::string&) override {
+        return arrow::Status::NotImplemented("DeleteDir");
+    }
+
+    arrow::Status
+    DeleteDirContents(const std::string&, bool) override {
+        return arrow::Status::NotImplemented("DeleteDirContents");
+    }
+
+    arrow::Status
+    DeleteRootDirContents() override {
+        return arrow::Status::NotImplemented("DeleteRootDirContents");
+    }
+
+    arrow::Status
+    DeleteFile(const std::string&) override {
+        return arrow::Status::NotImplemented("DeleteFile");
+    }
+
+    arrow::Status
+    Move(const std::string&, const std::string&) override {
+        return arrow::Status::NotImplemented("Move");
+    }
+
+    arrow::Status
+    CopyFile(const std::string&, const std::string&) override {
+        return arrow::Status::NotImplemented("CopyFile");
+    }
+
+    arrow::Result<std::shared_ptr<arrow::io::InputStream>>
+    OpenInputStream(const std::string& path) override {
+        ARROW_RETURN_NOT_OK(CheckPath(path));
+        return std::static_pointer_cast<arrow::io::InputStream>(
+            std::make_shared<SparseVortexInputFile>(file_));
+    }
+
+    arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>>
+    OpenInputFile(const std::string& path) override {
+        ARROW_RETURN_NOT_OK(CheckPath(path));
+        return std::make_shared<SparseVortexInputFile>(file_);
+    }
+
+    arrow::Result<std::shared_ptr<arrow::io::OutputStream>>
+    OpenOutputStream(
+        const std::string&,
+        const std::shared_ptr<const arrow::KeyValueMetadata>&) override {
+        return arrow::Status::NotImplemented("OpenOutputStream");
+    }
+
+    arrow::Result<std::shared_ptr<arrow::io::OutputStream>>
+    OpenAppendStream(
+        const std::string&,
+        const std::shared_ptr<const arrow::KeyValueMetadata>&) override {
+        return arrow::Status::NotImplemented("OpenAppendStream");
+    }
+
+ private:
+    arrow::Status
+    CheckPath(std::string_view path) const {
+        if (!path.empty() && path != path_) {
+            return arrow::Status::Invalid(
+                fmt::format("SparseVortexFileSystem path mismatch, got {}, "
+                            "expected {}",
+                            path,
+                            path_));
+        }
+        return arrow::Status::OK();
+    }
+
+    std::shared_ptr<milvus_storage::vortex::VortexRangeFile> file_;
+    std::string path_;
+};
+
+std::string
+MakeSparseVortexPath(std::string_view source_path) {
+    return fmt::format("vortex-sparse-{:016x}.vortex",
+                       std::hash<std::string_view>{}(source_path));
+}
+
+std::shared_ptr<arrow::fs::FileSystem>
+MakeSparseVortexFileSystem(std::string path) {
+    return std::make_shared<SparseVortexFileSystem>(std::move(path));
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/SparseVortexFileSystem.h
+++ b/internal/core/src/mmap/SparseVortexFileSystem.h
@@ -1,0 +1,34 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace arrow::fs {
+class FileSystem;
+}  // namespace arrow::fs
+
+namespace milvus {
+
+std::string
+MakeSparseVortexPath(std::string_view source_path);
+
+std::shared_ptr<arrow::fs::FileSystem>
+MakeSparseVortexFileSystem(std::string path);
+
+}  // namespace milvus

--- a/internal/core/src/mmap/VortexColumn.cpp
+++ b/internal/core/src/mmap/VortexColumn.cpp
@@ -1464,7 +1464,6 @@ VortexColumn::SupportsScanPushdown(const ScanOptions& options) const {
     switch (data_type_) {
         case DataType::STRING:
         case DataType::VARCHAR:
-        case DataType::TEXT:
             break;
         default:
             return false;

--- a/internal/core/src/mmap/VortexColumn.cpp
+++ b/internal/core/src/mmap/VortexColumn.cpp
@@ -1,0 +1,2375 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mmap/VortexColumn.h"
+
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+#include "arrow/array.h"
+#include "arrow/array/array_binary.h"
+#include "arrow/c/bridge.h"
+#include "arrow/record_batch.h"
+#include "arrow/table.h"
+#include "cachinglayer/CacheSlot.h"
+#include "cachinglayer/Manager.h"
+#include "cachinglayer/Utils.h"
+#include "common/ChunkWriter.h"
+#include "common/Common.h"
+#include "common/EasyAssert.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/format/vortex/vortex_footer_reader.h"
+#include "milvus-storage/format/vortex/vortex_translater.h"
+#include "storage/Util.h"
+
+namespace milvus {
+
+namespace {
+
+void
+ResetScanBatchOutput(ChunkedColumnInterface::ScanBatch* out) {
+    out->values = ChunkedColumnInterface::ValueView{};
+    out->validity = ChunkedColumnInterface::ValidityView{};
+    out->row_ids.clear();
+    out->owner.reset();
+    out->row_id_start = 0;
+    out->size = 0;
+}
+
+void
+ResetRowIdPayloadOutput(ChunkedColumnInterface::ScanBatch* out) {
+    ResetScanBatchOutput(out);
+}
+
+struct VortexReaderRange {
+    int64_t chunk_id;
+    int64_t local_offset;
+    int64_t length;
+    int64_t chunk_start;
+    int64_t range_start;
+    int64_t range_end;
+};
+
+std::optional<VortexReaderRange>
+NextVortexReaderRange(const VortexColumn* column,
+                      int64_t* scan_pos,
+                      int64_t scan_end) {
+    AssertInfo(column != nullptr, "vortex scan column is null");
+    AssertInfo(scan_pos != nullptr, "vortex scan position is null");
+    while (*scan_pos < scan_end) {
+        auto [chunk_id, local_offset] = column->GetChunkIDByOffset(*scan_pos);
+        const auto chunk_start =
+            static_cast<int64_t>(column->GetNumRowsUntilChunk(chunk_id));
+        const auto chunk_rows =
+            static_cast<int64_t>(column->chunk_row_nums(chunk_id));
+        const auto chunk_end = chunk_start + chunk_rows;
+        const auto local_end =
+            std::min<int64_t>(chunk_end, scan_end) - chunk_start;
+        const auto length = local_end - static_cast<int64_t>(local_offset);
+        if (length == 0) {
+            *scan_pos = chunk_end;
+            continue;
+        }
+        AssertInfo(length > 0,
+                   "invalid vortex scan chunk range, chunk {}, offset {}, "
+                   "end {}",
+                   chunk_id,
+                   local_offset,
+                   local_end);
+        return VortexReaderRange{
+            static_cast<int64_t>(chunk_id),
+            static_cast<int64_t>(local_offset),
+            length,
+            chunk_start,
+            *scan_pos,
+            chunk_start + local_end,
+        };
+    }
+    return std::nullopt;
+}
+
+void
+AppendRowIdPayloadEntry(ChunkedColumnInterface::ScanBatch* out,
+                        FixedVector<bool>* validity,
+                        bool* has_invalid,
+                        int64_t row_id,
+                        bool valid) {
+    AssertInfo(validity != nullptr, "row id payload validity owner is null");
+    AssertInfo(has_invalid != nullptr, "row id payload invalid flag is null");
+    if (!out->row_ids.empty()) {
+        AssertInfo(out->row_ids.back() <= row_id,
+                   "row id payload is not ordered: {} before {}",
+                   out->row_ids.back(),
+                   row_id);
+    }
+    out->row_ids.emplace_back(row_id);
+    validity->push_back(valid);
+    *has_invalid = *has_invalid || !valid;
+}
+
+void
+FinalizeRowIdPayloadOutput(ChunkedColumnInterface::ScanBatch* out,
+                           std::shared_ptr<FixedVector<bool>> validity,
+                           bool has_invalid,
+                           bool nullable) {
+    AssertInfo(validity != nullptr, "row id payload validity owner is null");
+    AssertInfo(validity->size() == out->row_ids.size(),
+               "row id payload validity size {} does not match row ids size {}",
+               validity->size(),
+               out->row_ids.size());
+    out->row_id_start = out->row_ids.empty() ? 0 : out->row_ids.front();
+    out->size = static_cast<int64_t>(out->row_ids.size());
+    out->validity.size = out->size;
+    out->validity.nullable = nullable;
+    if (out->row_ids.empty() || !has_invalid) {
+        out->validity.encoding =
+            ChunkedColumnInterface::ValidityEncoding::AllValid;
+        out->validity.all_valid = true;
+        return;
+    }
+    out->validity.encoding =
+        ChunkedColumnInterface::ValidityEncoding::BoolArray;
+    out->validity.data = validity->data();
+    out->validity.offset = 0;
+    out->validity.all_valid = false;
+    out->owner = std::move(validity);
+}
+
+void
+FinalizeAllValidRowIdPayloadOutput(ChunkedColumnInterface::ScanBatch* out,
+                                   bool nullable) {
+    out->row_id_start = out->row_ids.empty() ? 0 : out->row_ids.front();
+    out->size = static_cast<int64_t>(out->row_ids.size());
+    out->validity.size = out->size;
+    out->validity.nullable = nullable;
+    out->validity.encoding = ChunkedColumnInterface::ValidityEncoding::AllValid;
+    out->validity.all_valid = true;
+}
+
+}  // namespace
+
+struct VortexColumn::ArrowTakeResult {
+    std::shared_ptr<
+        cachinglayer::CellAccessor<milvus_storage::vortex::VortexCellGuard>>
+        pin;
+    std::shared_ptr<arrow::Table> table;
+};
+
+struct VortexColumn::ArrowStringViewHolder {
+    std::vector<std::shared_ptr<
+        cachinglayer::CellAccessor<milvus_storage::vortex::VortexCellGuard>>>
+        pins;
+    std::vector<std::shared_ptr<arrow::Table>> tables;
+    std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+};
+
+class VortexColumn::ArrowStringLikeColumn {
+ public:
+    explicit ArrowStringLikeColumn(const std::shared_ptr<arrow::Table>& table) {
+        AssertInfo(table != nullptr, "vortex take table is null");
+        AssertInfo(table->num_columns() == 1,
+                   "vortex string-like take expects one column, got {}",
+                   table->num_columns());
+        Init(table->column(0)->chunks());
+    }
+
+    explicit ArrowStringLikeColumn(const std::shared_ptr<arrow::Array>& array) {
+        AssertInfo(array != nullptr, "vortex string-like array is null");
+        Init({array});
+    }
+
+    int64_t
+    length() const {
+        return prefix_.empty() ? 0 : prefix_.back();
+    }
+
+    bool
+    IsValid(int64_t row) const {
+        auto [array, offset] = ArrayAt(row);
+        return array->IsValid(offset);
+    }
+
+    std::string_view
+    ValueAt(int64_t row) const {
+        auto [array, offset] = ArrayAt(row);
+        if (!array->IsValid(offset)) {
+            return {};
+        }
+
+        switch (array->type_id()) {
+            case arrow::Type::BINARY: {
+                auto typed =
+                    std::static_pointer_cast<arrow::BinaryArray>(array);
+                auto value = typed->GetView(offset);
+                return {value.data(), static_cast<size_t>(value.size())};
+            }
+            case arrow::Type::STRING: {
+                auto typed =
+                    std::static_pointer_cast<arrow::StringArray>(array);
+                auto value = typed->GetView(offset);
+                return {value.data(), static_cast<size_t>(value.size())};
+            }
+            case arrow::Type::LARGE_BINARY: {
+                auto typed =
+                    std::static_pointer_cast<arrow::LargeBinaryArray>(array);
+                auto value = typed->GetView(offset);
+                return {value.data(), static_cast<size_t>(value.size())};
+            }
+            case arrow::Type::LARGE_STRING: {
+                auto typed =
+                    std::static_pointer_cast<arrow::LargeStringArray>(array);
+                auto value = typed->GetView(offset);
+                return {value.data(), static_cast<size_t>(value.size())};
+            }
+            case arrow::Type::BINARY_VIEW: {
+                auto typed =
+                    std::static_pointer_cast<arrow::BinaryViewArray>(array);
+                auto value = typed->GetView(offset);
+                return {value.data(), static_cast<size_t>(value.size())};
+            }
+            case arrow::Type::STRING_VIEW: {
+                auto typed =
+                    std::static_pointer_cast<arrow::StringViewArray>(array);
+                auto value = typed->GetView(offset);
+                return {value.data(), static_cast<size_t>(value.size())};
+            }
+            default:
+                ThrowInfo(ErrorCode::Unsupported,
+                          "VortexColumn string-like take got unsupported "
+                          "Arrow type {}",
+                          array->type()->ToString());
+                return {};
+        }
+    }
+
+ private:
+    void
+    Init(arrow::ArrayVector chunks) {
+        chunks_ = std::move(chunks);
+        prefix_.reserve(chunks_.size() + 1);
+        prefix_.push_back(0);
+        int64_t rows = 0;
+        for (const auto& chunk : chunks_) {
+            rows += chunk->length();
+            prefix_.push_back(rows);
+        }
+    }
+
+    std::pair<std::shared_ptr<arrow::Array>, int64_t>
+    ArrayAt(int64_t row) const {
+        AssertInfo(row >= 0 && row < length(),
+                   "vortex string-like row {} out of range {}",
+                   row,
+                   length());
+        auto it = std::upper_bound(prefix_.begin(), prefix_.end(), row);
+        auto chunk_idx =
+            static_cast<size_t>(std::distance(prefix_.begin(), it) - 1);
+        return {chunks_[chunk_idx], row - prefix_[chunk_idx]};
+    }
+
+    arrow::ArrayVector chunks_;
+    std::vector<int64_t> prefix_;
+};
+
+class VortexRowIdScanCursor final : public ChunkedColumnInterface::ScanCursor {
+ public:
+    VortexRowIdScanCursor(const VortexColumn* column,
+                          milvus::OpContext* op_ctx,
+                          int64_t start_offset,
+                          int64_t length,
+                          std::string predicate)
+        : column_(column),
+          op_ctx_(op_ctx),
+          predicate_(std::move(predicate)),
+          scan_pos_(start_offset),
+          scan_end_(start_offset + length) {
+        AssertInfo(start_offset >= 0 && length >= 0 &&
+                       start_offset + length <=
+                           static_cast<int64_t>(column_->NumRows()),
+                   "vortex row id scan range [{}, {}) out of rows {}",
+                   start_offset,
+                   start_offset + length,
+                   column_->NumRows());
+    }
+
+    bool
+    Next(ChunkedColumnInterface::ScanBatch* out) override {
+        AssertInfo(out != nullptr, "vortex row id scan output batch is null");
+        ResetRowIdPayloadOutput(out);
+        std::shared_ptr<FixedVector<bool>> validity;
+        bool has_invalid = false;
+        while (out->row_ids.empty() || HasBufferedEntries()) {
+            if (!EnsureActiveReader()) {
+                break;
+            }
+            if (!reader_may_contain_invalids_) {
+                if (!AppendNextMatchedEntries(out)) {
+                    CloseActiveReader();
+                }
+                continue;
+            }
+            if (validity == nullptr) {
+                validity = std::make_shared<FixedVector<bool>>();
+            }
+            if (!AppendNextEntry(out, validity.get(), &has_invalid)) {
+                CloseActiveReader();
+                continue;
+            }
+        }
+
+        if (out->row_ids.empty()) {
+            return false;
+        }
+        if (validity == nullptr) {
+            FinalizeAllValidRowIdPayloadOutput(out, column_->IsNullable());
+            return true;
+        }
+        FinalizeRowIdPayloadOutput(
+            out, std::move(validity), has_invalid, column_->IsNullable());
+        return true;
+    }
+
+ private:
+    bool
+    HasBufferedEntries() const {
+        return matched_pos_ < matched_row_ids_.size() ||
+               invalid_pos_ < invalid_row_ids_.size();
+    }
+
+    bool
+    EnsureActiveReader() {
+        if (reader_active_) {
+            return true;
+        }
+        auto range = NextVortexReaderRange(column_, &scan_pos_, scan_end_);
+        if (!range.has_value()) {
+            return false;
+        }
+
+        reader_active_ = true;
+        reader_chunk_start_ = range->chunk_start;
+        reader_range_start_ = range->range_start;
+        reader_range_end_ = range->range_end;
+        invalid_reader_next_row_id_ = reader_range_start_;
+        matched_row_ids_.clear();
+        invalid_row_ids_.clear();
+        matched_pos_ = 0;
+        invalid_pos_ = 0;
+        reader_may_contain_invalids_ = ReaderNeedsValidityStream();
+        matched_reader_ = column_->OpenRowIdScanForFile(op_ctx_,
+                                                        range->chunk_id,
+                                                        range->local_offset,
+                                                        range->length,
+                                                        predicate_);
+        if (reader_may_contain_invalids_) {
+            invalid_reader_ = column_->OpenDataScanForFile(
+                op_ctx_, range->chunk_id, range->local_offset, range->length);
+        }
+        scan_pos_ = reader_range_end_;
+        return true;
+    }
+
+    bool
+    ReaderNeedsValidityStream() const {
+        // VortexColumn does not build ChunkedColumnInterface's materialized
+        // valid-count mapping. For nullable fields, read the Arrow validity
+        // side-stream and merge it with pushed-down row ids.
+        return column_->IsNullable();
+    }
+
+    void
+    CloseActiveReader() {
+        reader_active_ = false;
+        matched_reader_.reset();
+        invalid_reader_.reset();
+        matched_row_ids_.clear();
+        invalid_row_ids_.clear();
+        matched_pos_ = 0;
+        invalid_pos_ = 0;
+        reader_may_contain_invalids_ = false;
+    }
+
+    bool
+    EnsureMatchedEntry() {
+        while (matched_pos_ >= matched_row_ids_.size() &&
+               matched_reader_.has_value()) {
+            matched_row_ids_.clear();
+            matched_pos_ = 0;
+
+            std::shared_ptr<arrow::RecordBatch> batch;
+            auto status = matched_reader_->get()->ReadNext(&batch);
+            AssertInfo(status.ok(),
+                       "failed to read vortex row id scan batch: {}",
+                       status.ToString());
+            if (batch == nullptr) {
+                matched_reader_.reset();
+                break;
+            }
+            FillMatchedRowIdsFromBatch(batch);
+        }
+        return matched_pos_ < matched_row_ids_.size();
+    }
+
+    bool
+    EnsureInvalidEntry(std::optional<int64_t> row_id_limit) {
+        // Keep the validity side-stream only as far ahead as needed to merge
+        // the next matched row id in order.
+        while (invalid_pos_ >= invalid_row_ids_.size()) {
+            if (!invalid_reader_.has_value()) {
+                break;
+            }
+            if (row_id_limit.has_value() &&
+                invalid_reader_next_row_id_ > row_id_limit.value()) {
+                break;
+            }
+            invalid_row_ids_.clear();
+            invalid_pos_ = 0;
+
+            std::shared_ptr<arrow::RecordBatch> batch;
+            auto status = invalid_reader_->get()->ReadNext(&batch);
+            AssertInfo(status.ok(),
+                       "failed to read vortex row id validity batch: {}",
+                       status.ToString());
+            if (batch == nullptr) {
+                AssertInfo(invalid_reader_next_row_id_ == reader_range_end_,
+                           "vortex row id validity scan ended after row {}, "
+                           "expected {}",
+                           invalid_reader_next_row_id_,
+                           reader_range_end_);
+                invalid_reader_.reset();
+                break;
+            }
+            FillInvalidRowIdsFromBatch(batch);
+        }
+        return invalid_pos_ < invalid_row_ids_.size();
+    }
+
+    bool
+    AppendNextMatchedEntries(ChunkedColumnInterface::ScanBatch* out) {
+        if (!EnsureMatchedEntry()) {
+            return false;
+        }
+
+        const auto rows_to_append = matched_row_ids_.size() - matched_pos_;
+        if (!out->row_ids.empty()) {
+            AssertInfo(out->row_ids.back() <= matched_row_ids_[matched_pos_],
+                       "row id payload is not ordered: {} before {}",
+                       out->row_ids.back(),
+                       matched_row_ids_[matched_pos_]);
+        }
+        out->row_ids.insert(
+            out->row_ids.end(),
+            matched_row_ids_.begin() + static_cast<int64_t>(matched_pos_),
+            matched_row_ids_.begin() +
+                static_cast<int64_t>(matched_pos_ + rows_to_append));
+        matched_pos_ += rows_to_append;
+        return true;
+    }
+
+    bool
+    AppendNextEntry(ChunkedColumnInterface::ScanBatch* out,
+                    FixedVector<bool>* validity,
+                    bool* has_invalid) {
+        const auto has_matched = EnsureMatchedEntry();
+        const auto has_invalid_entry =
+            has_matched ? EnsureInvalidEntry(matched_row_ids_[matched_pos_])
+                        : EnsureInvalidEntry(std::nullopt);
+        if (!has_matched && !has_invalid_entry) {
+            return false;
+        }
+
+        if (has_matched &&
+            (!has_invalid_entry ||
+             matched_row_ids_[matched_pos_] < invalid_row_ids_[invalid_pos_])) {
+            AppendRowIdPayloadEntry(out,
+                                    validity,
+                                    has_invalid,
+                                    matched_row_ids_[matched_pos_++],
+                                    true);
+            return true;
+        }
+
+        if (has_matched &&
+            matched_row_ids_[matched_pos_] == invalid_row_ids_[invalid_pos_]) {
+            ++matched_pos_;
+        }
+        AppendRowIdPayloadEntry(out,
+                                validity,
+                                has_invalid,
+                                invalid_row_ids_[invalid_pos_++],
+                                false);
+        return true;
+    }
+
+    void
+    FillMatchedRowIdsFromBatch(
+        const std::shared_ptr<arrow::RecordBatch>& batch) {
+        AssertInfo(batch != nullptr, "vortex row id scan batch is null");
+        AssertInfo(batch->num_columns() == 1,
+                   "vortex row id scan expects one column, got {}",
+                   batch->num_columns());
+        auto column = batch->column(0);
+        AssertInfo(column->null_count() == 0,
+                   "vortex row id scan returned nullable row id column");
+        matched_row_ids_.reserve(batch->num_rows());
+        if (auto uint64_column =
+                std::dynamic_pointer_cast<arrow::UInt64Array>(column)) {
+            for (int64_t i = 0; i < uint64_column->length(); ++i) {
+                AppendMatchedRowId(
+                    reader_chunk_start_,
+                    static_cast<int64_t>(uint64_column->Value(i)),
+                    reader_range_start_,
+                    reader_range_end_,
+                    &matched_row_ids_);
+            }
+            return;
+        }
+        if (auto int64_column =
+                std::dynamic_pointer_cast<arrow::Int64Array>(column)) {
+            for (int64_t i = 0; i < int64_column->length(); ++i) {
+                AppendMatchedRowId(reader_chunk_start_,
+                                   int64_column->Value(i),
+                                   reader_range_start_,
+                                   reader_range_end_,
+                                   &matched_row_ids_);
+            }
+            return;
+        }
+        ThrowInfo(ErrorCode::UnexpectedError,
+                  "vortex row id scan expects UInt64 or Int64 column, got {}",
+                  column->type()->ToString());
+    }
+
+    void
+    FillInvalidRowIdsFromBatch(
+        const std::shared_ptr<arrow::RecordBatch>& batch) {
+        AssertInfo(batch != nullptr,
+                   "vortex row id validity scan batch is null");
+        AssertInfo(batch->num_columns() == 1,
+                   "vortex row id validity scan expects one column, got {}",
+                   batch->num_columns());
+        auto array = batch->column(0);
+        AssertInfo(array->length() > 0,
+                   "vortex row id validity scan returned empty batch");
+        AssertInfo(
+            invalid_reader_next_row_id_ + array->length() <= reader_range_end_,
+            "vortex row id validity scan returned too many rows");
+        invalid_row_ids_.reserve(array->length());
+        for (int64_t i = 0; i < array->length(); ++i) {
+            if (!array->IsValid(i)) {
+                invalid_row_ids_.emplace_back(invalid_reader_next_row_id_ + i);
+            }
+        }
+        invalid_reader_next_row_id_ += array->length();
+    }
+
+    void
+    AppendMatchedRowId(int64_t chunk_start,
+                       int64_t chunk_local_row_id,
+                       int64_t range_start,
+                       int64_t range_end,
+                       std::vector<int64_t>* row_ids) const {
+        const auto row_id = chunk_start + chunk_local_row_id;
+        AssertInfo(row_id >= range_start && row_id < range_end,
+                   "vortex row id {} outside scan range [{}, {})",
+                   row_id,
+                   range_start,
+                   range_end);
+        if (!row_ids->empty()) {
+            AssertInfo(row_ids->back() <= row_id,
+                       "vortex row ids are not ordered: {} before {}",
+                       row_ids->back(),
+                       row_id);
+        }
+        row_ids->emplace_back(row_id);
+    }
+
+    const VortexColumn* column_;
+    milvus::OpContext* op_ctx_;
+    std::string predicate_;
+    int64_t scan_pos_;
+    int64_t scan_end_;
+    bool reader_active_{false};
+    bool reader_may_contain_invalids_{false};
+    int64_t reader_chunk_start_{0};
+    int64_t reader_range_start_{0};
+    int64_t reader_range_end_{0};
+    std::optional<PinWrapper<std::shared_ptr<arrow::RecordBatchReader>>>
+        matched_reader_;
+    std::optional<PinWrapper<std::shared_ptr<arrow::RecordBatchReader>>>
+        invalid_reader_;
+    int64_t invalid_reader_next_row_id_{0};
+    std::vector<int64_t> matched_row_ids_;
+    std::vector<int64_t> invalid_row_ids_;
+    size_t matched_pos_{0};
+    size_t invalid_pos_{0};
+};
+
+class VortexDataScanCursor final : public ChunkedColumnInterface::ScanCursor {
+ public:
+    VortexDataScanCursor(const VortexColumn* column,
+                         milvus::OpContext* op_ctx,
+                         int64_t start_offset,
+                         int64_t length,
+                         ChunkedColumnInterface::ScanProjection projection,
+                         ChunkedColumnInterface::ScanValueKind value_kind)
+        : column_(column),
+          op_ctx_(op_ctx),
+          projection_(projection),
+          value_kind_(value_kind),
+          scan_pos_(start_offset),
+          scan_end_(start_offset + length) {
+        AssertInfo(start_offset >= 0 && length >= 0 &&
+                       start_offset + length <=
+                           static_cast<int64_t>(column_->NumRows()),
+                   "vortex data scan range [{}, {}) out of rows {}",
+                   start_offset,
+                   start_offset + length,
+                   column_->NumRows());
+    }
+
+    bool
+    Next(ChunkedColumnInterface::ScanBatch* out) override {
+        AssertInfo(out != nullptr, "vortex data scan output batch is null");
+        ResetScanBatchOutput(out);
+        if (scan_pos_ >= scan_end_) {
+            return false;
+        }
+
+        while (scan_pos_ < scan_end_) {
+            if (current_batch_ != nullptr &&
+                current_batch_pos_ < current_batch_->num_rows()) {
+                const auto rows_to_return = std::min<int64_t>(
+                    current_batch_->num_rows() - current_batch_pos_,
+                    scan_end_ - scan_pos_);
+                FillOutputFromCurrentBatch(rows_to_return, out);
+                scan_pos_ += rows_to_return;
+                current_batch_pos_ += rows_to_return;
+                return true;
+            }
+
+            current_batch_.reset();
+            current_batch_pos_ = 0;
+            if (reader_.has_value()) {
+                std::shared_ptr<arrow::RecordBatch> batch;
+                auto status = reader_->get()->ReadNext(&batch);
+                AssertInfo(status.ok(),
+                           "failed to read vortex data scan batch: {}",
+                           status.ToString());
+                if (batch != nullptr) {
+                    AssertInfo(batch->num_columns() == 1,
+                               "vortex data scan expects one column, got {}",
+                               batch->num_columns());
+                    current_batch_ = std::move(batch);
+                    current_batch_row_id_start_ = next_reader_row_id_;
+                    next_reader_row_id_ += current_batch_->num_rows();
+                    continue;
+                }
+                reader_.reset();
+                continue;
+            }
+
+            if (!OpenReaderForScanPos()) {
+                break;
+            }
+        }
+        return false;
+    }
+
+ private:
+    bool
+    OpenReaderForScanPos() {
+        auto range = NextVortexReaderRange(column_, &scan_pos_, scan_end_);
+        if (!range.has_value()) {
+            return false;
+        }
+        reader_ = column_->OpenDataScanForFile(
+            op_ctx_, range->chunk_id, range->local_offset, range->length);
+        next_reader_row_id_ = range->range_start;
+        return true;
+    }
+
+    template <typename ArrowArrayT>
+    const void*
+    RawPrimitiveValues(const std::shared_ptr<arrow::Array>& array) const {
+        auto typed = std::static_pointer_cast<ArrowArrayT>(array);
+        return typed->raw_values();
+    }
+
+    struct BatchOwner {
+        std::optional<PinWrapper<std::shared_ptr<arrow::RecordBatchReader>>>
+            reader;
+        std::shared_ptr<arrow::Array> array;
+        std::shared_ptr<FixedVector<bool>> bool_values;
+        std::shared_ptr<FixedVector<bool>> validity;
+        std::vector<std::string_view> string_views;
+        std::vector<Json> json_values;
+    };
+
+    bool
+    IsStringLikeScan() const {
+        return value_kind_ ==
+                   ChunkedColumnInterface::ScanValueKind::StringView ||
+               value_kind_ == ChunkedColumnInterface::ScanValueKind::JsonView;
+    }
+
+    void
+    FillDataPointer(const std::shared_ptr<arrow::Array>& array,
+                    const std::shared_ptr<BatchOwner>& owner,
+                    ChunkedColumnInterface::ScanBatch* out) const {
+        out->values.encoding =
+            ChunkedColumnInterface::ValueEncoding::FixedWidth;
+        out->values.kind =
+            value_kind_ == ChunkedColumnInterface::ScanValueKind::Default
+                ? ChunkedColumnInterface::ScanValueKind::FixedWidth
+                : value_kind_;
+        out->values.physical_type = column_->data_type_;
+        out->values.logical_type = column_->data_type_;
+        out->values.size = out->size;
+        switch (column_->data_type_) {
+            case DataType::INT8:
+                out->values.data = RawPrimitiveValues<arrow::Int8Array>(array);
+                out->values.byte_width = sizeof(int8_t);
+                break;
+            case DataType::INT16:
+                out->values.data = RawPrimitiveValues<arrow::Int16Array>(array);
+                out->values.byte_width = sizeof(int16_t);
+                break;
+            case DataType::INT32:
+                out->values.data = RawPrimitiveValues<arrow::Int32Array>(array);
+                out->values.byte_width = sizeof(int32_t);
+                break;
+            case DataType::INT64:
+            case DataType::TIMESTAMPTZ:
+                out->values.data = RawPrimitiveValues<arrow::Int64Array>(array);
+                out->values.byte_width = sizeof(int64_t);
+                break;
+            case DataType::FLOAT:
+                out->values.data = RawPrimitiveValues<arrow::FloatArray>(array);
+                out->values.byte_width = sizeof(float);
+                break;
+            case DataType::DOUBLE:
+                out->values.data =
+                    RawPrimitiveValues<arrow::DoubleArray>(array);
+                out->values.byte_width = sizeof(double);
+                break;
+            case DataType::BOOL: {
+                auto typed =
+                    std::static_pointer_cast<arrow::BooleanArray>(array);
+                owner->bool_values = std::make_shared<FixedVector<bool>>();
+                owner->bool_values->resize(array->length());
+                for (int64_t i = 0; i < array->length(); ++i) {
+                    (*owner->bool_values)[i] = typed->Value(i);
+                }
+                out->values.data = owner->bool_values->data();
+                out->values.byte_width = sizeof(bool);
+                break;
+            }
+            default:
+                ThrowInfo(ErrorCode::Unsupported,
+                          "unsupported vortex data scan type {}",
+                          column_->data_type_);
+        }
+    }
+
+    void
+    FillValidityPointer(const std::shared_ptr<arrow::Array>& array,
+                        const std::shared_ptr<BatchOwner>& owner,
+                        ChunkedColumnInterface::ScanBatch* out) const {
+        out->validity.nullable = column_->IsNullable();
+        out->validity.size = out->size;
+        if (!column_->IsNullable() || array->null_count() == 0) {
+            out->validity.encoding =
+                ChunkedColumnInterface::ValidityEncoding::AllValid;
+            out->validity.all_valid = true;
+            return;
+        }
+        owner->validity = std::make_shared<FixedVector<bool>>();
+        owner->validity->resize(array->length());
+        for (int64_t i = 0; i < array->length(); ++i) {
+            (*owner->validity)[i] = array->IsValid(i);
+        }
+        out->validity.encoding =
+            ChunkedColumnInterface::ValidityEncoding::BoolArray;
+        out->validity.data = owner->validity->data();
+        out->validity.offset = current_batch_pos_;
+        out->validity.all_valid = false;
+    }
+
+    void
+    FillStringLikeOutput(const std::shared_ptr<arrow::Array>& array,
+                         const std::shared_ptr<BatchOwner>& owner,
+                         ChunkedColumnInterface::ScanBatch* out) const {
+        out->validity.nullable = column_->IsNullable();
+        out->validity.size = out->size;
+
+        if (projection_ == ChunkedColumnInterface::ScanProjection::NoData) {
+            FillValidityPointer(array, owner, out);
+            return;
+        }
+
+        VortexColumn::ArrowStringLikeColumn string_column(array);
+        const bool emit_valid =
+            column_->field_meta_.is_nullable() && array->null_count() > 0;
+        auto views = column_->BuildStringViewsFromArrow(
+            string_column,
+            std::make_pair(current_batch_pos_, out->size),
+            emit_valid);
+
+        out->values.physical_type = column_->data_type_;
+        out->values.logical_type = column_->data_type_;
+        out->values.offset = 0;
+        out->values.size = out->size;
+
+        if (value_kind_ == ChunkedColumnInterface::ScanValueKind::StringView) {
+            owner->string_views = std::move(views.first);
+            out->values.encoding =
+                ChunkedColumnInterface::ValueEncoding::StringView;
+            out->values.kind =
+                ChunkedColumnInterface::ScanValueKind::StringView;
+            out->values.data = owner->string_views.data();
+            out->values.byte_width = sizeof(std::string_view);
+        } else {
+            owner->string_views = std::move(views.first);
+            owner->json_values.reserve(owner->string_views.size());
+            for (const auto& value : owner->string_views) {
+                owner->json_values.emplace_back(Json(value));
+            }
+            out->values.encoding =
+                ChunkedColumnInterface::ValueEncoding::JsonView;
+            out->values.kind = ChunkedColumnInterface::ScanValueKind::JsonView;
+            out->values.logical_type = DataType::JSON;
+            out->values.data = owner->json_values.data();
+            out->values.byte_width = sizeof(Json);
+        }
+
+        if (emit_valid) {
+            owner->validity =
+                std::make_shared<FixedVector<bool>>(std::move(views.second));
+            out->validity.encoding =
+                ChunkedColumnInterface::ValidityEncoding::BoolArray;
+            out->validity.data = owner->validity->data();
+            out->validity.offset = 0;
+            out->validity.all_valid = false;
+        } else {
+            out->validity.encoding =
+                ChunkedColumnInterface::ValidityEncoding::AllValid;
+            out->validity.all_valid = true;
+        }
+    }
+
+    void
+    FillOutputFromCurrentBatch(int64_t rows_to_return,
+                               ChunkedColumnInterface::ScanBatch* out) const {
+        auto array = current_batch_->column(0);
+        auto owner = std::make_shared<BatchOwner>();
+        AssertInfo(reader_.has_value(),
+                   "vortex data scan batch requires active reader pin");
+        owner->reader = *reader_;
+        owner->array = array;
+        out->row_id_start = current_batch_row_id_start_ + current_batch_pos_;
+        out->size = rows_to_return;
+        if (IsStringLikeScan()) {
+            FillStringLikeOutput(array, owner, out);
+        } else {
+            if (projection_ != ChunkedColumnInterface::ScanProjection::NoData) {
+                FillDataPointer(array, owner, out);
+                out->values.offset = current_batch_pos_;
+            }
+            FillValidityPointer(array, owner, out);
+        }
+        out->owner = std::move(owner);
+    }
+
+    const VortexColumn* column_;
+    milvus::OpContext* op_ctx_;
+    ChunkedColumnInterface::ScanProjection projection_;
+    ChunkedColumnInterface::ScanValueKind value_kind_;
+    int64_t scan_pos_;
+    int64_t scan_end_;
+    std::optional<PinWrapper<std::shared_ptr<arrow::RecordBatchReader>>>
+        reader_;
+    int64_t next_reader_row_id_{0};
+    std::shared_ptr<arrow::RecordBatch> current_batch_;
+    int64_t current_batch_pos_{0};
+    int64_t current_batch_row_id_start_{0};
+};
+
+VortexColumn::VortexColumn(
+    FieldId field_id,
+    FieldMeta field_meta,
+    std::shared_ptr<milvus_storage::api::Properties> properties,
+    std::shared_ptr<VortexColumnGroup> column_group,
+    std::optional<size_t> data_byte_size)
+    : field_id_(field_id),
+      field_meta_(std::move(field_meta)),
+      data_type_(field_meta_.get_data_type()),
+      field_name_(field_meta_.is_external_field()
+                      ? field_meta_.get_external_field()
+                      : std::to_string(field_id_.get())) {
+    AssertInfo(!IsVectorDataType(data_type_),
+               "vortex local_format does not support vector field {}",
+               field_id_.get());
+    AssertInfo(properties != nullptr, "vortex properties is null");
+    AssertInfo(column_group != nullptr, "vortex column group is null");
+
+    local_format_properties_ = MakeVortexReaderProperties(properties);
+    column_group_ = std::move(column_group);
+    data_byte_size_ = data_byte_size.value_or(column_group_->memory_size());
+
+    const auto& group_files = column_group_->files();
+    files_.reserve(group_files.size());
+    for (const auto& group_file : group_files) {
+        files_.emplace_back(BuildFileState(group_file));
+    }
+
+    num_rows_until_chunk_ = column_group_->num_rows_until_chunk();
+    num_rows_ = column_group_->num_rows();
+}
+
+VortexColumn::~VortexColumn() = default;
+
+void
+VortexColumn::ManualEvictCache() const {
+    column_group_->ManualEvictCache();
+}
+
+void
+VortexColumn::CancelWarmup() {
+    column_group_->CancelWarmup();
+}
+
+bool
+VortexColumn::IsInMultiFieldColumnGroup() const {
+    return column_group_->num_fields() > 1;
+}
+
+bool
+VortexColumn::IsNullable() const {
+    return field_meta_.is_nullable();
+}
+
+size_t
+VortexColumn::NumRows() const {
+    return num_rows_;
+}
+
+int64_t
+VortexColumn::num_chunks() const {
+    return static_cast<int64_t>(files_.size());
+}
+
+size_t
+VortexColumn::DataByteSize() const {
+    return data_byte_size_;
+}
+
+int64_t
+VortexColumn::chunk_row_nums(int64_t chunk_id) const {
+    CheckChunkId(chunk_id);
+    return files_[chunk_id].rows;
+}
+
+PinWrapper<const char*>
+VortexColumn::DataOfChunk(milvus::OpContext* op_ctx, int chunk_id) const {
+    auto chunk = MaterializeChunk(op_ctx, chunk_id);
+    return PinWrapper<const char*>(chunk, chunk->Data());
+}
+
+bool
+VortexColumn::IsValid(milvus::OpContext* op_ctx, size_t offset) const {
+    if (!field_meta_.is_nullable()) {
+        return true;
+    }
+    auto [chunk_id, chunk_offset] =
+        GetChunkIDByOffset(static_cast<int64_t>(offset));
+    auto chunk = MaterializeChunk(op_ctx, chunk_id);
+    return chunk->isValid(static_cast<int>(chunk_offset));
+}
+
+void
+VortexColumn::BulkIsValid(milvus::OpContext* op_ctx,
+                          std::function<void(bool, size_t)> fn,
+                          const int64_t* offsets,
+                          int64_t count) const {
+    if (!field_meta_.is_nullable()) {
+        if (offsets == nullptr) {
+            for (int64_t i = 0; i < num_rows_; ++i) {
+                fn(true, i);
+            }
+        } else {
+            for (int64_t i = 0; i < count; ++i) {
+                fn(true, i);
+            }
+        }
+        return;
+    }
+
+    if (offsets == nullptr) {
+        int64_t logical_offset = 0;
+        for (int64_t chunk_id = 0; chunk_id < num_chunks(); ++chunk_id) {
+            auto chunk = MaterializeChunk(op_ctx, chunk_id);
+            for (int64_t i = 0; i < chunk->RowNums(); ++i) {
+                fn(chunk->isValid(static_cast<int>(i)), logical_offset + i);
+            }
+            logical_offset += chunk->RowNums();
+        }
+        return;
+    }
+
+    auto [chunk_ids, offsets_in_chunk] = GetChunkIDsByOffsets(offsets, count);
+    std::unordered_map<int64_t, std::vector<int64_t>> indices_by_chunk;
+    indices_by_chunk.reserve(chunk_ids.size());
+    for (int64_t i = 0; i < count; ++i) {
+        indices_by_chunk[chunk_ids[i]].emplace_back(i);
+    }
+
+    for (const auto& [chunk_id, indices] : indices_by_chunk) {
+        auto chunk = MaterializeChunk(op_ctx, chunk_id);
+        for (const auto index : indices) {
+            fn(chunk->isValid(static_cast<int>(offsets_in_chunk[index])),
+               index);
+        }
+    }
+}
+
+void
+VortexColumn::PrefetchChunks(milvus::OpContext* op_ctx,
+                             const std::vector<int64_t>& chunk_ids) const {
+    for (auto chunk_id : chunk_ids) {
+        CheckChunkId(chunk_id);
+        const auto& file = files_[chunk_id];
+        std::vector<cachinglayer::cid_t> cell_ids;
+        cell_ids.reserve(file.planner->num_cells());
+        for (size_t cell_id = 0; cell_id < file.planner->num_cells();
+             ++cell_id) {
+            cell_ids.emplace_back(static_cast<cachinglayer::cid_t>(cell_id));
+        }
+        cachinglayer::SemiInlineGet(file.slot->PinCells(op_ctx, cell_ids));
+    }
+}
+
+PinWrapper<SpanBase>
+VortexColumn::Span(milvus::OpContext* op_ctx, int64_t chunk_id) const {
+    if (!IsChunkedColumnDataType(data_type_)) {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "VortexColumn::Span only supports fixed-width scalar "
+                  "fields");
+    }
+    auto chunk = MaterializeChunk(op_ctx, chunk_id);
+    auto span = static_cast<FixedWidthChunk*>(chunk.get())->Span();
+    return PinWrapper<SpanBase>(chunk, span);
+}
+
+PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+VortexColumn::StringViews(
+    milvus::OpContext* op_ctx,
+    int64_t chunk_id,
+    std::optional<std::pair<int64_t, int64_t>> offset_len) const {
+    if (!IsChunkedVariableColumnDataType(data_type_)) {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "VortexColumn::StringViews only supports variable fields");
+    }
+    auto [holder, views] =
+        ScanStringLikeViewsFromFile(op_ctx, chunk_id, offset_len);
+    return PinWrapper<
+        std::pair<std::vector<std::string_view>, FixedVector<bool>>>(
+        std::move(holder), std::move(views));
+}
+
+PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+VortexColumn::ArrayViews(
+    milvus::OpContext* op_ctx,
+    int64_t chunk_id,
+    std::optional<std::pair<int64_t, int64_t>> offset_len) const {
+    if (!IsChunkedArrayColumnDataType(data_type_)) {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "VortexColumn::ArrayViews only supports array fields");
+    }
+    auto chunk = MaterializeChunk(op_ctx, chunk_id, offset_len);
+    auto views = static_cast<ArrayChunk*>(chunk.get())->Views({});
+    return PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>(
+        chunk, std::move(views));
+}
+
+PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+VortexColumn::VectorArrayViews(
+    milvus::OpContext*,
+    int64_t,
+    std::optional<std::pair<int64_t, int64_t>>) const {
+    ThrowInfo(ErrorCode::Unsupported,
+              "VortexColumn does not support vector array fields");
+}
+
+PinWrapper<const size_t*>
+VortexColumn::VectorArrayOffsets(milvus::OpContext*, int64_t) const {
+    ThrowInfo(ErrorCode::Unsupported,
+              "VortexColumn does not support vector array fields");
+}
+
+PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+VortexColumn::StringViewsByOffsets(milvus::OpContext* op_ctx,
+                                   int64_t chunk_id,
+                                   const FixedVector<int32_t>& offsets) const {
+    if (!IsChunkedVariableColumnDataType(data_type_)) {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "VortexColumn::StringViewsByOffsets only supports "
+                  "variable fields");
+    }
+    CheckChunkId(chunk_id);
+    auto holder = std::make_shared<ArrowStringViewHolder>();
+    std::pair<std::vector<std::string_view>, FixedVector<bool>> views;
+    views.first.resize(offsets.size());
+    views.second.resize(offsets.size());
+    if (offsets.empty()) {
+        return PinWrapper<
+            std::pair<std::vector<std::string_view>, FixedVector<bool>>>(
+            std::move(views));
+    }
+
+    std::vector<std::pair<int64_t, int64_t>> entries;
+    entries.reserve(offsets.size());
+    for (int64_t i = 0; i < static_cast<int64_t>(offsets.size()); ++i) {
+        auto offset = offsets[i];
+        AssertInfo(offset >= 0 && offset < files_[chunk_id].rows,
+                   "vortex chunk-local offset {} out of chunk {} rows {}",
+                   offset,
+                   chunk_id,
+                   files_[chunk_id].rows);
+        entries.emplace_back(offset, i);
+    }
+    std::sort(entries.begin(), entries.end());
+    std::vector<int64_t> unique_offsets;
+    unique_offsets.reserve(entries.size());
+    for (const auto& [offset, _] : entries) {
+        if (unique_offsets.empty() || unique_offsets.back() != offset) {
+            unique_offsets.emplace_back(offset);
+        }
+    }
+
+    auto take = TakeArrowFromFile(op_ctx, chunk_id, unique_offsets);
+    ArrowStringLikeColumn column(take.table);
+    auto unique_views = BuildStringViewsFromArrow(
+        column, std::nullopt, field_meta_.is_nullable());
+    for (const auto& [offset, original_index] : entries) {
+        auto it = std::lower_bound(
+            unique_offsets.begin(), unique_offsets.end(), offset);
+        auto take_offset = std::distance(unique_offsets.begin(), it);
+        views.first[original_index] = unique_views.first[take_offset];
+        views.second[original_index] =
+            field_meta_.is_nullable() ? unique_views.second[take_offset] : true;
+    }
+    holder->pins.emplace_back(std::move(take.pin));
+    holder->tables.emplace_back(std::move(take.table));
+    return PinWrapper<
+        std::pair<std::vector<std::string_view>, FixedVector<bool>>>(
+        std::move(holder), std::move(views));
+}
+
+PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+VortexColumn::ArrayViewsByOffsets(milvus::OpContext* op_ctx,
+                                  int64_t chunk_id,
+                                  const FixedVector<int32_t>& offsets) const {
+    if (!IsChunkedArrayColumnDataType(data_type_)) {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "VortexColumn::ArrayViewsByOffsets only supports array "
+                  "fields");
+    }
+    CheckChunkId(chunk_id);
+    std::pair<std::vector<ArrayView>, FixedVector<bool>> views;
+    views.first.resize(offsets.size());
+    views.second.resize(offsets.size());
+    if (offsets.empty()) {
+        return PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>(
+            std::move(views));
+    }
+
+    std::vector<std::pair<int64_t, int64_t>> entries;
+    entries.reserve(offsets.size());
+    for (int64_t i = 0; i < static_cast<int64_t>(offsets.size()); ++i) {
+        auto offset = offsets[i];
+        AssertInfo(offset >= 0 && offset < files_[chunk_id].rows,
+                   "vortex chunk-local offset {} out of chunk {} rows {}",
+                   offset,
+                   chunk_id,
+                   files_[chunk_id].rows);
+        entries.emplace_back(offset, i);
+    }
+    std::sort(entries.begin(), entries.end());
+    std::vector<int64_t> unique_offsets;
+    unique_offsets.reserve(entries.size());
+    for (const auto& [offset, _] : entries) {
+        if (unique_offsets.empty() || unique_offsets.back() != offset) {
+            unique_offsets.emplace_back(offset);
+        }
+    }
+
+    auto chunk = TakeFromFile(op_ctx, chunk_id, unique_offsets);
+    auto array_chunk = static_cast<ArrayChunk*>(chunk.get());
+    for (const auto& [offset, original_index] : entries) {
+        auto it = std::lower_bound(
+            unique_offsets.begin(), unique_offsets.end(), offset);
+        auto take_offset =
+            static_cast<int>(std::distance(unique_offsets.begin(), it));
+        views.first[original_index] = array_chunk->View(take_offset);
+        views.second[original_index] = array_chunk->isValid(take_offset);
+    }
+    return PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>(
+        chunk, std::move(views));
+}
+
+std::pair<size_t, size_t>
+VortexColumn::GetChunkIDByOffset(int64_t offset) const {
+    AssertInfo(offset >= 0 && offset < num_rows_,
+               "offset {} is out of range, num_rows: {}",
+               offset,
+               num_rows_);
+    return ::milvus::GetChunkIDByOffset(offset, num_rows_until_chunk_);
+}
+
+std::pair<std::vector<milvus::cachinglayer::cid_t>, std::vector<int64_t>>
+VortexColumn::GetChunkIDsByOffsets(const int64_t* offsets,
+                                   int64_t count) const {
+    return ::milvus::GetChunkIDsByOffsets(
+        offsets, count, num_rows_until_chunk_);
+}
+
+PinWrapper<Chunk*>
+VortexColumn::GetChunk(milvus::OpContext*, int64_t) const {
+    ThrowInfo(ErrorCode::Unsupported,
+              "VortexColumn::GetChunk is disabled because it "
+              "materializes Vortex data; use column view/bulk APIs instead");
+}
+
+std::vector<PinWrapper<Chunk*>>
+VortexColumn::GetAllChunks(milvus::OpContext*) const {
+    ThrowInfo(ErrorCode::Unsupported,
+              "VortexColumn::GetAllChunks is disabled because it "
+              "materializes Vortex data; use column view/bulk APIs instead");
+}
+
+int64_t
+VortexColumn::GetNumRowsUntilChunk(int64_t chunk_id) const {
+    AssertInfo(chunk_id >= 0 && chunk_id < static_cast<int64_t>(
+                                               num_rows_until_chunk_.size()),
+               "vortex chunk_id {} out of prefix range",
+               chunk_id);
+    return num_rows_until_chunk_[chunk_id];
+}
+
+const std::vector<int64_t>&
+VortexColumn::GetNumRowsUntilChunk() const {
+    return num_rows_until_chunk_;
+}
+
+void
+VortexColumn::BulkValueAt(milvus::OpContext* op_ctx,
+                          std::function<void(const char*, size_t)> fn,
+                          const int64_t* offsets,
+                          int64_t count) {
+    auto result = TakeOwn(op_ctx, offsets, count);
+    for (int64_t i = 0; i < count; ++i) {
+        fn(result.chunks[i]->ValueAt(result.offsets[i]), i);
+    }
+}
+
+std::optional<DataType>
+VortexColumn::GetDefaultScanDataType() const {
+    return data_type_;
+}
+
+std::shared_ptr<arrow::Schema>
+VortexColumn::MakeProjectedArrowSchema(
+    const std::shared_ptr<arrow::Schema>& schema,
+    const std::string& field_name) {
+    AssertInfo(schema != nullptr,
+               "vortex projected schema requires a non-null file schema");
+    auto field = schema->GetFieldByName(field_name);
+    AssertInfo(field != nullptr,
+               "vortex file schema does not contain field {}",
+               field_name);
+    return arrow::schema({field});
+}
+
+std::optional<std::string>
+VortexColumn::VortexCompareOp(proto::plan::OpType op_type) {
+    switch (op_type) {
+        case proto::plan::OpType::GreaterThan:
+            return ">";
+        case proto::plan::OpType::GreaterEqual:
+            return ">=";
+        case proto::plan::OpType::LessThan:
+            return "<";
+        case proto::plan::OpType::LessEqual:
+            return "<=";
+        case proto::plan::OpType::Equal:
+            return "=";
+        case proto::plan::OpType::NotEqual:
+            return "!=";
+        default:
+            return std::nullopt;
+    }
+}
+
+std::string
+VortexColumn::QuoteSqlIdentifier(std::string_view value) {
+    std::string out;
+    out.reserve(value.size() + 2);
+    out.push_back('"');
+    for (auto ch : value) {
+        if (ch == '"') {
+            out.push_back('"');
+        }
+        out.push_back(ch);
+    }
+    out.push_back('"');
+    return out;
+}
+
+std::string
+VortexColumn::QuoteSqlStringLiteral(std::string_view value) {
+    std::string out;
+    out.reserve(value.size() + 2);
+    out.push_back('\'');
+    for (auto ch : value) {
+        if (ch == '\'') {
+            out.push_back('\'');
+        }
+        out.push_back(ch);
+    }
+    out.push_back('\'');
+    return out;
+}
+
+bool
+VortexColumn::CanUseVortexPredicateLiteral(
+    DataType data_type, const proto::plan::GenericValue& value) {
+    switch (data_type) {
+        case DataType::BOOL:
+            return value.val_case() == proto::plan::GenericValue::kBoolVal;
+        case DataType::INT8:
+        case DataType::INT16:
+        case DataType::INT32:
+            return false;
+        case DataType::INT64:
+        case DataType::TIMESTAMPTZ:
+            return value.val_case() == proto::plan::GenericValue::kInt64Val;
+        case DataType::FLOAT:
+            return false;
+        case DataType::DOUBLE:
+            return value.val_case() == proto::plan::GenericValue::kFloatVal ||
+                   value.val_case() == proto::plan::GenericValue::kInt64Val;
+        case DataType::STRING:
+        case DataType::VARCHAR:
+        case DataType::TEXT:
+        case DataType::GEOMETRY:
+            return value.val_case() == proto::plan::GenericValue::kStringVal;
+        default:
+            return false;
+    }
+}
+
+std::string
+VortexColumn::FormatVortexDoubleLiteral(double value) {
+    std::ostringstream os;
+    os << std::setprecision(17) << value;
+    auto literal = os.str();
+    if (literal.find_first_of(".eE") == std::string::npos) {
+        literal += ".0";
+    }
+    return literal;
+}
+
+std::optional<std::string>
+VortexColumn::VortexLiteral(DataType data_type,
+                            const proto::plan::GenericValue& value) {
+    if (!CanUseVortexPredicateLiteral(data_type, value)) {
+        return std::nullopt;
+    }
+    switch (data_type) {
+        case DataType::BOOL:
+            return value.bool_val() ? "true" : "false";
+        case DataType::INT8:
+        case DataType::INT16:
+        case DataType::INT32:
+        case DataType::INT64:
+        case DataType::TIMESTAMPTZ:
+            return std::to_string(value.int64_val());
+        case DataType::FLOAT:
+        case DataType::DOUBLE:
+            if (value.val_case() == proto::plan::GenericValue::kFloatVal) {
+                return FormatVortexDoubleLiteral(value.float_val());
+            }
+            return FormatVortexDoubleLiteral(
+                static_cast<double>(value.int64_val()));
+        case DataType::STRING:
+        case DataType::VARCHAR:
+        case DataType::TEXT:
+        case DataType::GEOMETRY:
+            return QuoteSqlStringLiteral(value.string_val());
+        default:
+            return std::nullopt;
+    }
+}
+
+std::optional<std::string>
+VortexColumn::BuildVortexPredicate(const ScanOptions& options) const {
+    const auto field = QuoteSqlIdentifier(field_name_);
+    switch (options.predicate) {
+        case ScanPredicate::Unary: {
+            auto op = VortexCompareOp(options.op_type);
+            auto value = VortexLiteral(data_type_, options.value);
+            if (!op.has_value() || !value.has_value()) {
+                return std::nullopt;
+            }
+            return field + " " + *op + " " + *value;
+        }
+        case ScanPredicate::BinaryRange: {
+            auto lower = VortexLiteral(data_type_, options.lower_value);
+            auto upper = VortexLiteral(data_type_, options.upper_value);
+            if (!lower.has_value() || !upper.has_value()) {
+                return std::nullopt;
+            }
+            return field + (options.lower_inclusive ? " >= " : " > ") + *lower +
+                   " AND " + field +
+                   (options.upper_inclusive ? " <= " : " < ") + *upper;
+        }
+        default:
+            return std::nullopt;
+    }
+}
+
+bool
+VortexColumn::SupportsScanPushdown(const ScanOptions& options) const {
+    if (!ENABLE_VORTEX_SCAN_PUSHDOWN.load()) {
+        return false;
+    }
+
+    switch (data_type_) {
+        case DataType::STRING:
+        case DataType::VARCHAR:
+        case DataType::TEXT:
+            break;
+        default:
+            return false;
+    }
+
+    return options.output == ScanOutput::RowIds &&
+           options.projection == ScanProjection::NoData &&
+           options.predicate != ScanPredicate::None &&
+           BuildVortexPredicate(options).has_value();
+}
+
+milvus_storage::api::Properties
+VortexColumn::MakeVortexReaderProperties(
+    const std::shared_ptr<milvus_storage::api::Properties>& properties) {
+    auto reader_properties = *properties;
+    reader_properties[PROPERTY_READER_VORTEX_SPLIT_ROW_INDICES] =
+        std::string("true");
+    return reader_properties;
+}
+
+std::shared_ptr<milvus_storage::vortex::VortexPlanner>
+VortexColumn::MakeFilePlanner(
+    const VortexColumnGroup::FileState& group_file) const {
+    auto cell_metas_result = milvus_storage::vortex::BuildVortexCellMetas(
+        group_file.footer_reader, field_name_);
+    AssertInfo(cell_metas_result.ok(),
+               "failed to build vortex cell metas for field {} file {}: {}",
+               field_id_.get(),
+               group_file.path,
+               cell_metas_result.status().ToString());
+    auto planner_result = milvus_storage::vortex::VortexPlanner::Make(
+        group_file.footer_reader,
+        field_name_,
+        std::move(cell_metas_result).ValueOrDie());
+    AssertInfo(planner_result.ok(),
+               "failed to create vortex planner for field {} file {}: {}",
+               field_id_.get(),
+               group_file.path,
+               planner_result.status().ToString());
+    return std::move(planner_result).ValueOrDie();
+}
+
+std::shared_ptr<milvus_storage::vortex::VortexFormatReader>
+VortexColumn::OpenFileReader(
+    const VortexColumnGroup::FileState& group_file) const {
+    auto projected_arrow_schema = MakeProjectedArrowSchema(
+        group_file.footer_reader->file_schema(), field_name_);
+    auto reader = std::make_shared<milvus_storage::vortex::VortexFormatReader>(
+        group_file.sparse_fs,
+        projected_arrow_schema,
+        group_file.sparse_path,
+        local_format_properties_,
+        std::vector<std::string>{field_name_},
+        group_file.footer_reader->file_size(),
+        group_file.footer_reader->footer_size());
+    auto status = reader->open();
+    AssertInfo(status.ok(),
+               "failed to open vortex data reader for file {}: {}",
+               group_file.path,
+               status.ToString());
+    return reader;
+}
+
+void
+VortexColumn::ValidateFileState(
+    const FileState& state,
+    const VortexColumnGroup::FileState& group_file) const {
+    AssertInfo(state.rows == group_file.rows,
+               "vortex field {} rows {} does not match column group rows {} "
+               "for file {}",
+               field_id_.get(),
+               state.rows,
+               group_file.rows,
+               group_file.path);
+    AssertInfo(state.planner->num_cells() == group_file.slot->num_cells(),
+               "vortex field {} cells {} does not match column group cells {} "
+               "for file {}",
+               field_id_.get(),
+               state.planner->num_cells(),
+               group_file.slot->num_cells(),
+               group_file.path);
+
+    const auto& field_cells = state.planner->cell_metas();
+    const auto& group_cells = group_file.planner->cell_metas();
+    for (size_t cell_id = 0; cell_id < field_cells.size(); ++cell_id) {
+        AssertInfo(
+            field_cells[cell_id].row_offset ==
+                    group_cells[cell_id].row_offset &&
+                field_cells[cell_id].row_count ==
+                    group_cells[cell_id].row_count,
+            "vortex field {} cell {} row range [{}, {}) does not "
+            "match column group [{}, {}) for file {}",
+            field_id_.get(),
+            cell_id,
+            field_cells[cell_id].row_offset,
+            field_cells[cell_id].row_offset + field_cells[cell_id].row_count,
+            group_cells[cell_id].row_offset,
+            group_cells[cell_id].row_offset + group_cells[cell_id].row_count,
+            group_file.path);
+    }
+}
+
+VortexColumn::FileState
+VortexColumn::BuildFileState(
+    const VortexColumnGroup::FileState& group_file) const {
+    FileState state;
+    state.path = group_file.path;
+    state.planner = MakeFilePlanner(group_file);
+    state.slot = group_file.slot;
+    state.rows = static_cast<int64_t>(state.planner->rows());
+    state.memory_bytes = state.planner->memory_bytes();
+    ValidateFileState(state, group_file);
+    return state;
+}
+
+std::pair<std::vector<std::string_view>, FixedVector<bool>>
+VortexColumn::BuildStringViewsFromArrow(
+    const ArrowStringLikeColumn& column,
+    std::optional<std::pair<int64_t, int64_t>> offset_len,
+    bool emit_valid) const {
+    int64_t start = 0;
+    int64_t length = column.length();
+    if (offset_len.has_value()) {
+        start = offset_len->first;
+        length = offset_len->second;
+        AssertInfo(
+            start >= 0 && length >= 0 && start + length <= column.length(),
+            "vortex string-like view range [{}, {}) out of rows {}",
+            start,
+            start + length,
+            column.length());
+    }
+
+    std::pair<std::vector<std::string_view>, FixedVector<bool>> views;
+    views.first.reserve(length);
+    if (emit_valid) {
+        views.second.reserve(length);
+    }
+    for (int64_t i = 0; i < length; ++i) {
+        const auto row = start + i;
+        views.first.emplace_back(column.ValueAt(row));
+        if (emit_valid) {
+            views.second.emplace_back(column.IsValid(row));
+        }
+    }
+    return views;
+}
+
+void
+VortexColumn::CheckChunkId(int64_t chunk_id) const {
+    AssertInfo(chunk_id >= 0 && chunk_id < num_chunks(),
+               "vortex chunk_id {} out of range {}",
+               chunk_id,
+               num_chunks());
+}
+
+std::shared_ptr<
+    cachinglayer::CellAccessor<milvus_storage::vortex::VortexCellGuard>>
+VortexColumn::PinPlanCells(milvus::OpContext* op_ctx,
+                           const FileState& file,
+                           const std::vector<uint64_t>& cell_ids) const {
+    std::vector<cachinglayer::cid_t> cids;
+    cids.reserve(cell_ids.size());
+    for (auto cell_id : cell_ids) {
+        cids.emplace_back(static_cast<cachinglayer::cid_t>(cell_id));
+    }
+    return cachinglayer::SemiInlineGet(file.slot->PinCells(op_ctx, cids));
+}
+
+milvus_storage::vortex::VortexPlan
+VortexColumn::PlanRowRange(const FileState& file,
+                           uint64_t row_start,
+                           uint64_t row_end,
+                           const std::string& predicate) const {
+    auto result = file.planner->PlanForRowRange(row_start, row_end, predicate);
+    AssertInfo(result.ok(),
+               "failed to plan vortex read for row range [{}, {}): {}",
+               row_start,
+               row_end,
+               result.status().ToString());
+    return std::move(result).ValueOrDie();
+}
+
+milvus_storage::vortex::VortexPlan
+VortexColumn::PlanOffsets(const FileState& file,
+                          const std::vector<int64_t>& offsets) const {
+    auto result = file.planner->PlanForOffsets(offsets);
+    AssertInfo(result.ok(),
+               "failed to plan vortex read for offsets: {}",
+               result.status().ToString());
+    return std::move(result).ValueOrDie();
+}
+
+std::shared_ptr<Chunk>
+VortexColumn::ChunkFromTable(const std::shared_ptr<arrow::Table>& table) const {
+    AssertInfo(table != nullptr, "vortex table is null");
+    AssertInfo(table->num_columns() == 1,
+               "vortex materialization expects one column, got {}",
+               table->num_columns());
+    auto arrays = table->column(0)->chunks();
+    arrays = storage::NormalizeArrowForChunkWriter(arrays, field_meta_);
+    return create_chunk(field_meta_, arrays);
+}
+
+std::shared_ptr<Chunk>
+VortexColumn::MaterializeChunk(
+    milvus::OpContext* op_ctx,
+    int64_t chunk_id,
+    std::optional<std::pair<int64_t, int64_t>> offset_len) const {
+    CheckChunkId(chunk_id);
+    const auto& file = files_[chunk_id];
+    int64_t start = 0;
+    int64_t length = file.rows;
+    if (offset_len.has_value()) {
+        start = offset_len->first;
+        length = offset_len->second;
+        AssertInfo(start >= 0 && length >= 0 && start + length <= file.rows,
+                   "vortex materialize range [{}, {}) out of chunk rows {}",
+                   start,
+                   start + length,
+                   file.rows);
+    }
+
+    auto scan = OpenDataScanForFile(op_ctx, chunk_id, start, length);
+    auto arrays = read_single_column_batches(scan.get());
+    arrays = storage::NormalizeArrowForChunkWriter(arrays, field_meta_);
+    return create_chunk(field_meta_, arrays);
+}
+
+PinWrapper<std::shared_ptr<arrow::RecordBatchReader>>
+VortexColumn::OpenDataScanForFile(milvus::OpContext* op_ctx,
+                                  int64_t chunk_id,
+                                  int64_t start_offset,
+                                  int64_t length) const {
+    CheckChunkId(chunk_id);
+    const auto& file = files_[chunk_id];
+    AssertInfo(
+        start_offset >= 0 && length >= 0 && start_offset + length <= file.rows,
+        "vortex data scan range [{}, {}) out of chunk rows {}",
+        start_offset,
+        start_offset + length,
+        file.rows);
+    auto plan = PlanRowRange(file,
+                             static_cast<uint64_t>(start_offset),
+                             static_cast<uint64_t>(start_offset + length));
+    auto pin = PinPlanCells(op_ctx, file, plan.cell_ids);
+    auto vortex_reader = OpenFileReader(column_group_->files()[chunk_id]);
+    auto stream_result = vortex_reader->read_with_plan(plan.read_plan);
+    AssertInfo(stream_result.ok(),
+               "failed to open vortex data scan field {} chunk {}: {}",
+               field_id_.get(),
+               chunk_id,
+               stream_result.status().ToString());
+    auto array_stream = std::move(stream_result).ValueOrDie();
+    auto reader_result = arrow::ImportRecordBatchReader(&array_stream);
+    AssertInfo(reader_result.ok(),
+               "failed to open vortex data scan field {} chunk {}: {}",
+               field_id_.get(),
+               chunk_id,
+               reader_result.status().ToString());
+    return PinWrapper<std::shared_ptr<arrow::RecordBatchReader>>(
+        pin, std::move(reader_result).ValueOrDie());
+}
+
+PinWrapper<std::shared_ptr<arrow::RecordBatchReader>>
+VortexColumn::OpenRowIdScanForFile(milvus::OpContext* op_ctx,
+                                   int64_t chunk_id,
+                                   int64_t start_offset,
+                                   int64_t length,
+                                   const std::string& predicate) const {
+    CheckChunkId(chunk_id);
+    const auto& file = files_[chunk_id];
+    AssertInfo(
+        start_offset >= 0 && length >= 0 && start_offset + length <= file.rows,
+        "vortex row id scan range [{}, {}) out of chunk rows {}",
+        start_offset,
+        start_offset + length,
+        file.rows);
+    auto plan = PlanRowRange(file,
+                             static_cast<uint64_t>(start_offset),
+                             static_cast<uint64_t>(start_offset + length),
+                             predicate);
+    auto pin = PinPlanCells(op_ctx, file, plan.cell_ids);
+    auto vortex_reader = OpenFileReader(column_group_->files()[chunk_id]);
+    auto stream_result = vortex_reader->read_row_ids_with_plan(plan.read_plan);
+    AssertInfo(stream_result.ok(),
+               "failed to open vortex row id scan field {} chunk {}: {}",
+               field_id_.get(),
+               chunk_id,
+               stream_result.status().ToString());
+    auto array_stream = std::move(stream_result).ValueOrDie();
+    auto reader_result = arrow::ImportRecordBatchReader(&array_stream);
+    AssertInfo(reader_result.ok(),
+               "failed to open vortex row id scan field {} chunk {}: {}",
+               field_id_.get(),
+               chunk_id,
+               reader_result.status().ToString());
+    return PinWrapper<std::shared_ptr<arrow::RecordBatchReader>>(
+        pin, std::move(reader_result).ValueOrDie());
+}
+
+std::pair<std::shared_ptr<VortexColumn::ArrowStringViewHolder>,
+          std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+VortexColumn::ScanStringLikeViewsFromFile(
+    milvus::OpContext* op_ctx,
+    int64_t chunk_id,
+    std::optional<std::pair<int64_t, int64_t>> offset_len) const {
+    CheckChunkId(chunk_id);
+    const auto& file = files_[chunk_id];
+    int64_t start = 0;
+    int64_t length = file.rows;
+    if (offset_len.has_value()) {
+        start = offset_len->first;
+        length = offset_len->second;
+        AssertInfo(
+            start >= 0 && length >= 0 && start + length <= file.rows,
+            "vortex string-like scan range [{}, {}) out of chunk rows {}",
+            start,
+            start + length,
+            file.rows);
+    }
+
+    auto holder = std::make_shared<ArrowStringViewHolder>();
+    std::pair<std::vector<std::string_view>, FixedVector<bool>> views;
+    views.first.reserve(length);
+    if (field_meta_.is_nullable()) {
+        views.second.reserve(length);
+    }
+    if (length == 0) {
+        return {std::move(holder), std::move(views)};
+    }
+
+    auto plan = PlanRowRange(file,
+                             static_cast<uint64_t>(start),
+                             static_cast<uint64_t>(start + length));
+    auto pin = PinPlanCells(op_ctx, file, plan.cell_ids);
+    auto vortex_reader = OpenFileReader(column_group_->files()[chunk_id]);
+    auto stream_result = vortex_reader->read_with_plan(plan.read_plan);
+    AssertInfo(stream_result.ok(),
+               "failed to open vortex string-like scan field {} chunk {}: {}",
+               field_id_.get(),
+               chunk_id,
+               stream_result.status().ToString());
+    auto array_stream = std::move(stream_result).ValueOrDie();
+    auto reader_result = arrow::ImportRecordBatchReader(&array_stream);
+    AssertInfo(reader_result.ok(),
+               "failed to open vortex string-like scan field {} chunk {}: {}",
+               field_id_.get(),
+               chunk_id,
+               reader_result.status().ToString());
+
+    auto reader = std::move(reader_result).ValueOrDie();
+    while (true) {
+        std::shared_ptr<arrow::RecordBatch> batch;
+        auto status = reader->ReadNext(&batch);
+        AssertInfo(status.ok(),
+                   "failed to read vortex string-like scan batch: {}",
+                   status.ToString());
+        if (batch == nullptr) {
+            break;
+        }
+        AssertInfo(batch->num_columns() == 1,
+                   "vortex string-like scan expects one column, got {}",
+                   batch->num_columns());
+        ArrowStringLikeColumn column(batch->column(0));
+        auto batch_views = BuildStringViewsFromArrow(
+            column, std::nullopt, field_meta_.is_nullable());
+        views.first.insert(views.first.end(),
+                           batch_views.first.begin(),
+                           batch_views.first.end());
+        for (auto valid : batch_views.second) {
+            views.second.emplace_back(valid);
+        }
+        holder->batches.emplace_back(std::move(batch));
+    }
+    holder->pins.emplace_back(std::move(pin));
+    AssertInfo(static_cast<int64_t>(views.first.size()) == length,
+               "vortex string-like scan returned {} rows, expected {}",
+               views.first.size(),
+               length);
+    return {std::move(holder), std::move(views)};
+}
+
+std::shared_ptr<Chunk>
+VortexColumn::TakeFromFile(milvus::OpContext* op_ctx,
+                           int64_t chunk_id,
+                           const std::vector<int64_t>& offsets) const {
+    auto take = TakeArrowFromFile(op_ctx, chunk_id, offsets);
+    return ChunkFromTable(take.table);
+}
+
+VortexColumn::ArrowTakeResult
+VortexColumn::TakeArrowFromFile(milvus::OpContext* op_ctx,
+                                int64_t chunk_id,
+                                const std::vector<int64_t>& offsets) const {
+    const auto& file = files_[chunk_id];
+    auto plan = PlanOffsets(file, offsets);
+    auto pin = PinPlanCells(op_ctx, file, plan.cell_ids);
+    auto vortex_reader = OpenFileReader(column_group_->files()[chunk_id]);
+    auto stream_result = vortex_reader->read_with_plan(plan.read_plan);
+    AssertInfo(stream_result.ok(),
+               "failed to take vortex field {} chunk {}: {}",
+               field_id_.get(),
+               chunk_id,
+               stream_result.status().ToString());
+    auto array_stream = std::move(stream_result).ValueOrDie();
+    auto chunked_array_result = arrow::ImportChunkedArray(&array_stream);
+    AssertInfo(chunked_array_result.ok(),
+               "failed to take vortex field {} chunk {}: {}",
+               field_id_.get(),
+               chunk_id,
+               chunked_array_result.status().ToString());
+    auto chunked_array = chunked_array_result.ValueOrDie();
+    std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+    batches.reserve(chunked_array->num_chunks());
+    for (int i = 0; i < chunked_array->num_chunks(); ++i) {
+        auto batch_result =
+            arrow::RecordBatch::FromStructArray(chunked_array->chunk(i));
+        AssertInfo(batch_result.ok(),
+                   "failed to take vortex field {} chunk {}: {}",
+                   field_id_.get(),
+                   chunk_id,
+                   batch_result.status().ToString());
+        batches.emplace_back(batch_result.ValueOrDie());
+    }
+    auto table_result = arrow::Table::FromRecordBatches(batches);
+    AssertInfo(table_result.ok(),
+               "failed to take vortex field {} chunk {}: {}",
+               field_id_.get(),
+               chunk_id,
+               table_result.status().ToString());
+    ArrowTakeResult result;
+    result.pin = std::move(pin);
+    result.table = table_result.ValueOrDie();
+    return result;
+}
+
+std::pair<std::shared_ptr<VortexColumn::ArrowStringViewHolder>,
+          std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+VortexColumn::TakeStringLikeViews(milvus::OpContext* op_ctx,
+                                  const int64_t* offsets,
+                                  int64_t count) const {
+    auto holder = std::make_shared<ArrowStringViewHolder>();
+    std::pair<std::vector<std::string_view>, FixedVector<bool>> views;
+    views.first.resize(count);
+    views.second.resize(count);
+    if (count == 0) {
+        return {std::move(holder), std::move(views)};
+    }
+    AssertInfo(offsets != nullptr,
+               "vortex string-like take requires explicit row offsets");
+
+    std::unordered_map<int64_t, std::vector<std::pair<int64_t, int64_t>>>
+        chunk_entries;
+    for (int64_t i = 0; i < count; ++i) {
+        auto [chunk_id, chunk_offset] = GetChunkIDByOffset(offsets[i]);
+        chunk_entries[static_cast<int64_t>(chunk_id)].push_back(
+            {static_cast<int64_t>(chunk_offset), i});
+    }
+
+    holder->pins.reserve(chunk_entries.size());
+    holder->tables.reserve(chunk_entries.size());
+    for (auto& [chunk_id, entries] : chunk_entries) {
+        std::sort(entries.begin(), entries.end());
+        std::vector<int64_t> unique_offsets;
+        unique_offsets.reserve(entries.size());
+        for (const auto& [chunk_offset, _] : entries) {
+            if (unique_offsets.empty() ||
+                unique_offsets.back() != chunk_offset) {
+                unique_offsets.emplace_back(chunk_offset);
+            }
+        }
+
+        auto take = TakeArrowFromFile(op_ctx, chunk_id, unique_offsets);
+        ArrowStringLikeColumn column(take.table);
+        auto unique_views = BuildStringViewsFromArrow(
+            column, std::nullopt, field_meta_.is_nullable());
+        AssertInfo(static_cast<int64_t>(unique_views.first.size()) ==
+                       static_cast<int64_t>(unique_offsets.size()),
+                   "vortex string-like take returned {} rows, expected {}",
+                   unique_views.first.size(),
+                   unique_offsets.size());
+        for (const auto& [chunk_offset, original_index] : entries) {
+            auto it = std::lower_bound(
+                unique_offsets.begin(), unique_offsets.end(), chunk_offset);
+            auto take_offset = std::distance(unique_offsets.begin(), it);
+            views.first[original_index] = unique_views.first[take_offset];
+            views.second[original_index] =
+                field_meta_.is_nullable() ? unique_views.second[take_offset]
+                                          : true;
+        }
+        holder->pins.emplace_back(std::move(take.pin));
+        holder->tables.emplace_back(std::move(take.table));
+    }
+
+    return {std::move(holder), std::move(views)};
+}
+
+template <typename ArrowArrayT,
+          typename SrcT,
+          typename RawDstT,
+          typename WidenDstT>
+void
+VortexColumn::CopyArrowPrimitiveValues(
+    void* dst,
+    const std::shared_ptr<arrow::Table>& table,
+    const std::vector<std::vector<int64_t>>& original_indices_by_unique,
+    bool small_int_raw_type) const {
+    AssertInfo(table != nullptr, "vortex primitive take table is null");
+    AssertInfo(table->num_columns() == 1,
+               "vortex primitive take expects one column, got {}",
+               table->num_columns());
+    auto column = table->column(0);
+    AssertInfo(column != nullptr, "vortex primitive take column is null");
+    AssertInfo(static_cast<int64_t>(original_indices_by_unique.size()) ==
+                   column->length(),
+               "vortex primitive take returned {} rows, expected {}",
+               column->length(),
+               original_indices_by_unique.size());
+
+    auto raw_dst = static_cast<RawDstT*>(dst);
+    auto widen_dst = static_cast<WidenDstT*>(dst);
+    int64_t table_offset = 0;
+    for (const auto& chunk : column->chunks()) {
+        auto array = std::dynamic_pointer_cast<ArrowArrayT>(chunk);
+        AssertInfo(array != nullptr,
+                   "vortex primitive take field {} expected Arrow array type "
+                   "for {}, got {}",
+                   field_id_.get(),
+                   data_type_,
+                   chunk ? chunk->type()->ToString() : "<null>");
+        for (int64_t i = 0; i < array->length(); ++i) {
+            const auto& output_indices =
+                original_indices_by_unique[static_cast<size_t>(table_offset +
+                                                               i)];
+            auto value = static_cast<SrcT>(array->Value(i));
+            for (auto output_index : output_indices) {
+                if (small_int_raw_type) {
+                    raw_dst[output_index] = static_cast<RawDstT>(value);
+                } else {
+                    widen_dst[output_index] = static_cast<WidenDstT>(value);
+                }
+            }
+        }
+        table_offset += array->length();
+    }
+}
+
+template <typename ArrowArrayT,
+          typename SrcT,
+          typename RawDstT,
+          typename WidenDstT>
+void
+VortexColumn::BulkPrimitiveValueAtFromArrow(milvus::OpContext* op_ctx,
+                                            void* dst,
+                                            const int64_t* offsets,
+                                            int64_t count,
+                                            bool small_int_raw_type) const {
+    if (count == 0) {
+        return;
+    }
+    AssertInfo(offsets != nullptr,
+               "vortex primitive take requires explicit row offsets");
+
+    std::unordered_map<int64_t, std::vector<std::pair<int64_t, int64_t>>>
+        chunk_entries;
+    for (int64_t i = 0; i < count; ++i) {
+        auto [chunk_id, chunk_offset] = GetChunkIDByOffset(offsets[i]);
+        chunk_entries[static_cast<int64_t>(chunk_id)].push_back(
+            {static_cast<int64_t>(chunk_offset), i});
+    }
+
+    for (auto& [chunk_id, entries] : chunk_entries) {
+        std::sort(entries.begin(), entries.end());
+        std::vector<int64_t> unique_offsets;
+        std::vector<std::vector<int64_t>> original_indices_by_offset;
+        unique_offsets.reserve(entries.size());
+        original_indices_by_offset.reserve(entries.size());
+        for (const auto& [chunk_offset, original_index] : entries) {
+            if (unique_offsets.empty() ||
+                unique_offsets.back() != chunk_offset) {
+                unique_offsets.emplace_back(chunk_offset);
+                original_indices_by_offset.emplace_back();
+            }
+            original_indices_by_offset.back().emplace_back(original_index);
+        }
+
+        auto take = TakeArrowFromFile(op_ctx, chunk_id, unique_offsets);
+        CopyArrowPrimitiveValues<ArrowArrayT, SrcT, RawDstT, WidenDstT>(
+            dst, take.table, original_indices_by_offset, small_int_raw_type);
+    }
+}
+
+void
+VortexColumn::BulkPrimitiveValueAt(milvus::OpContext* op_ctx,
+                                   void* dst,
+                                   const int64_t* offsets,
+                                   int64_t count,
+                                   bool small_int_raw_type) {
+    switch (data_type_) {
+        case DataType::INT8: {
+            BulkPrimitiveValueAtFromArrow<arrow::Int8Array,
+                                          int8_t,
+                                          int8_t,
+                                          int32_t>(
+                op_ctx, dst, offsets, count, small_int_raw_type);
+            break;
+        }
+        case DataType::INT16: {
+            BulkPrimitiveValueAtFromArrow<arrow::Int16Array,
+                                          int16_t,
+                                          int16_t,
+                                          int32_t>(
+                op_ctx, dst, offsets, count, small_int_raw_type);
+            break;
+        }
+        case DataType::INT32: {
+            BulkPrimitiveValueAtFromArrow<arrow::Int32Array,
+                                          int32_t,
+                                          int32_t,
+                                          int32_t>(
+                op_ctx, dst, offsets, count, true);
+            break;
+        }
+        case DataType::INT64:
+        case DataType::TIMESTAMPTZ: {
+            BulkPrimitiveValueAtFromArrow<arrow::Int64Array,
+                                          int64_t,
+                                          int64_t,
+                                          int64_t>(
+                op_ctx, dst, offsets, count, true);
+            break;
+        }
+        case DataType::FLOAT: {
+            BulkPrimitiveValueAtFromArrow<arrow::FloatArray,
+                                          float,
+                                          float,
+                                          float>(
+                op_ctx, dst, offsets, count, true);
+            break;
+        }
+        case DataType::DOUBLE: {
+            BulkPrimitiveValueAtFromArrow<arrow::DoubleArray,
+                                          double,
+                                          double,
+                                          double>(
+                op_ctx, dst, offsets, count, true);
+            break;
+        }
+        case DataType::BOOL: {
+            BulkPrimitiveValueAtFromArrow<arrow::BooleanArray,
+                                          bool,
+                                          bool,
+                                          bool>(
+                op_ctx, dst, offsets, count, true);
+            break;
+        }
+        default:
+            ThrowInfo(ErrorCode::Unsupported,
+                      "VortexColumn::BulkPrimitiveValueAt unsupported data "
+                      "type {}",
+                      data_type_);
+    }
+}
+
+void
+VortexColumn::BulkVectorValueAt(
+    milvus::OpContext*, void*, const int64_t*, int64_t, int64_t) {
+    ThrowInfo(ErrorCode::Unsupported,
+              "VortexColumn does not support vector fields");
+}
+
+void
+VortexColumn::BulkRawStringAt(
+    milvus::OpContext* op_ctx,
+    std::function<void(std::string_view, size_t, bool)> fn,
+    const int64_t* offsets,
+    int64_t count) const {
+    if (!IsChunkedVariableColumnDataType(data_type_) ||
+        data_type_ == DataType::JSON) {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "VortexColumn::BulkRawStringAt only supports string fields");
+    }
+    BulkStringLikeAt(op_ctx, fn, offsets, count);
+}
+
+void
+VortexColumn::BulkRawJsonAt(milvus::OpContext* op_ctx,
+                            std::function<void(Json, size_t, bool)> fn,
+                            const int64_t* offsets,
+                            int64_t count) const {
+    if (data_type_ != DataType::JSON) {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "VortexColumn::BulkRawJsonAt only supports JSON fields");
+    }
+    BulkStringLikeAt(
+        op_ctx,
+        [&](std::string_view value, size_t index, bool valid) {
+            fn(Json(value.data(), value.size()), index, valid);
+        },
+        offsets,
+        count);
+}
+
+void
+VortexColumn::BulkRawBsonAt(
+    milvus::OpContext* op_ctx,
+    std::function<void(BsonView, uint32_t, uint32_t)> fn,
+    const uint32_t* row_offsets,
+    const uint32_t* value_offsets,
+    int64_t count) const {
+    AssertInfo(row_offsets != nullptr && value_offsets != nullptr,
+               "row_offsets and value_offsets must be provided");
+    std::vector<int64_t> offsets(count);
+    for (int64_t i = 0; i < count; ++i) {
+        offsets[i] = row_offsets[i];
+    }
+    BulkStringLikeAt(
+        op_ctx,
+        [&](std::string_view value, size_t index, bool) {
+            fn(BsonView(reinterpret_cast<const uint8_t*>(value.data()),
+                        value.size()),
+               row_offsets[index],
+               value_offsets[index]);
+        },
+        offsets.data(),
+        count);
+}
+
+void
+VortexColumn::BulkArrayAt(milvus::OpContext* op_ctx,
+                          std::function<void(const ArrayView&, size_t)> fn,
+                          const int64_t* offsets,
+                          int64_t count) const {
+    if (!IsChunkedArrayColumnDataType(data_type_)) {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "VortexColumn::BulkArrayAt only supports array fields");
+    }
+    auto result = TakeOwn(op_ctx, offsets, count);
+    for (int64_t i = 0; i < count; ++i) {
+        auto view = static_cast<ArrayChunk*>(result.chunks[i].get())
+                        ->View(result.offsets[i]);
+        fn(view, i);
+    }
+}
+
+void
+VortexColumn::BulkVectorArrayAt(milvus::OpContext*,
+                                std::function<void(VectorFieldProto&&, size_t)>,
+                                const int64_t*,
+                                int64_t) const {
+    ThrowInfo(ErrorCode::Unsupported,
+              "VortexColumn does not support vector array fields");
+}
+
+void
+VortexColumn::BulkStringLikeAt(
+    milvus::OpContext* op_ctx,
+    const std::function<void(std::string_view, size_t, bool)>& fn,
+    const int64_t* offsets,
+    int64_t count) const {
+    if (offsets == nullptr) {
+        int64_t global_offset = 0;
+        for (int64_t chunk_id = 0; chunk_id < num_chunks(); ++chunk_id) {
+            auto scan =
+                OpenDataScanForFile(op_ctx, chunk_id, 0, files_[chunk_id].rows);
+            int64_t row_offset = 0;
+            while (true) {
+                std::shared_ptr<arrow::RecordBatch> batch;
+                auto status = scan.get()->ReadNext(&batch);
+                AssertInfo(status.ok(),
+                           "failed to read vortex string-like scan batch: {}",
+                           status.ToString());
+                if (batch == nullptr) {
+                    break;
+                }
+                AssertInfo(batch->num_columns() == 1,
+                           "vortex string-like scan expects one column, got {}",
+                           batch->num_columns());
+                ArrowStringLikeColumn column(batch->column(0));
+                for (int64_t i = 0; i < column.length(); ++i) {
+                    fn(column.ValueAt(i),
+                       global_offset + row_offset + i,
+                       column.IsValid(i));
+                }
+                row_offset += column.length();
+            }
+            global_offset += files_[chunk_id].rows;
+        }
+        return;
+    }
+
+    auto [holder, views] = TakeStringLikeViews(op_ctx, offsets, count);
+    (void)holder;
+    for (int64_t i = 0; i < count; ++i) {
+        fn(views.first[i], i, views.second[i]);
+    }
+}
+
+VortexColumn::TakeResult
+VortexColumn::TakeOwn(milvus::OpContext* op_ctx,
+                      const int64_t* offsets,
+                      int64_t count) const {
+    TakeResult result;
+    result.chunks.resize(count);
+    result.offsets.resize(count);
+    if (count == 0) {
+        return result;
+    }
+    AssertInfo(offsets != nullptr, "vortex take requires explicit row offsets");
+
+    std::unordered_map<int64_t, std::vector<std::pair<int64_t, int64_t>>>
+        chunk_entries;
+    for (int64_t i = 0; i < count; ++i) {
+        auto [chunk_id, chunk_offset] = GetChunkIDByOffset(offsets[i]);
+        chunk_entries[static_cast<int64_t>(chunk_id)].push_back(
+            {static_cast<int64_t>(chunk_offset), i});
+    }
+
+    for (auto& [chunk_id, entries] : chunk_entries) {
+        std::sort(entries.begin(), entries.end());
+        std::vector<int64_t> unique_offsets;
+        unique_offsets.reserve(entries.size());
+        for (const auto& [chunk_offset, _] : entries) {
+            if (unique_offsets.empty() ||
+                unique_offsets.back() != chunk_offset) {
+                unique_offsets.emplace_back(chunk_offset);
+            }
+        }
+
+        auto chunk = TakeFromFile(op_ctx, chunk_id, unique_offsets);
+        for (const auto& [chunk_offset, original_index] : entries) {
+            auto it = std::lower_bound(
+                unique_offsets.begin(), unique_offsets.end(), chunk_offset);
+            result.chunks[original_index] = chunk;
+            result.offsets[original_index] =
+                std::distance(unique_offsets.begin(), it);
+        }
+    }
+
+    return result;
+}
+
+std::shared_ptr<VortexColumn::TakeResult>
+VortexColumn::Take(milvus::OpContext* op_ctx,
+                   const int64_t* offsets,
+                   int64_t count) const {
+    return std::make_shared<TakeResult>(TakeOwn(op_ctx, offsets, count));
+}
+
+ChunkedColumnInterface::ScanResult
+VortexColumn::Scan(milvus::OpContext* op_ctx,
+                   const ScanOptions& options) const {
+    AssertInfo(options.predicate == ScanPredicate::None ||
+                   options.projection == ScanProjection::NoData,
+               "vortex predicate scan must not return data");
+    if (options.output == ScanOutput::Data) {
+        if (options.predicate != ScanPredicate::None) {
+            return nullptr;
+        }
+        if (options.projection == ScanProjection::NoData ||
+            IsPrimitiveDataType(data_type_) ||
+            IsChunkedVariableColumnDataType(data_type_)) {
+            auto value_kind = options.value_kind;
+            if (value_kind == ScanValueKind::Default &&
+                IsChunkedVariableColumnDataType(data_type_)) {
+                value_kind = data_type_ == DataType::JSON
+                                 ? ScanValueKind::JsonView
+                                 : ScanValueKind::StringView;
+            }
+            return std::make_unique<VortexDataScanCursor>(this,
+                                                          op_ctx,
+                                                          options.start_offset,
+                                                          options.length,
+                                                          options.projection,
+                                                          value_kind);
+        }
+        return ChunkedColumnInterface::Scan(op_ctx, options);
+    }
+
+    if (options.predicate == ScanPredicate::None) {
+        return nullptr;
+    }
+
+    if (!SupportsScanPushdown(options)) {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "unsupported vortex row id scan predicate for field {} "
+                  "type {}",
+                  field_id_.get(),
+                  static_cast<int>(data_type_));
+    }
+
+    auto predicate = BuildVortexPredicate(options);
+    if (!predicate.has_value()) {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "unsupported vortex row id scan predicate for field {} "
+                  "type {}",
+                  field_id_.get(),
+                  static_cast<int>(data_type_));
+    }
+    return std::make_unique<VortexRowIdScanCursor>(this,
+                                                   op_ctx,
+                                                   options.start_offset,
+                                                   options.length,
+                                                   std::move(*predicate));
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/VortexColumn.h
+++ b/internal/core/src/mmap/VortexColumn.h
@@ -1,0 +1,406 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "common/FieldMeta.h"
+#include "common/Json.h"
+#include "common/Types.h"
+#include "common/bson_view.h"
+#include "mmap/ChunkedColumn.h"
+#include "mmap/ChunkedColumnInterface.h"
+#include "mmap/VortexColumnGroup.h"
+#include "milvus-storage/format/vortex/vortex_format_reader.h"
+#include "milvus-storage/format/vortex/vortex_planner.h"
+
+namespace arrow {
+class Array;
+class RecordBatchReader;
+class Schema;
+class Table;
+}  // namespace arrow
+
+namespace milvus {
+
+class VortexDataScanCursor;
+class VortexRowIdScanCursor;
+
+class VortexColumn final : public ChunkedColumnInterface {
+    friend class VortexDataScanCursor;
+    friend class VortexRowIdScanCursor;
+
+ public:
+    using FileInfo = VortexColumnFileInfo;
+
+    VortexColumn(FieldId field_id,
+                 FieldMeta field_meta,
+                 std::shared_ptr<milvus_storage::api::Properties> properties,
+                 std::shared_ptr<VortexColumnGroup> column_group,
+                 std::optional<size_t> data_byte_size = std::nullopt);
+
+    ~VortexColumn() override;
+
+    void
+    ManualEvictCache() const override;
+
+    void
+    CancelWarmup() override;
+
+    bool
+    IsInMultiFieldColumnGroup() const override;
+
+    LocalFormat
+    GetLocalFormat() const override {
+        return LocalFormat::Vortex;
+    }
+
+    bool
+    SupportsScanPushdown(const ScanOptions& options) const override;
+
+    bool
+    IsNullable() const override;
+
+    size_t
+    NumRows() const override;
+
+    int64_t
+    num_chunks() const override;
+
+    size_t
+    DataByteSize() const override;
+
+    int64_t
+    chunk_row_nums(int64_t chunk_id) const override;
+
+    PinWrapper<const char*>
+    DataOfChunk(milvus::OpContext* op_ctx, int chunk_id) const override;
+
+    bool
+    IsValid(milvus::OpContext* op_ctx, size_t offset) const override;
+
+    void
+    BulkIsValid(milvus::OpContext* op_ctx,
+                std::function<void(bool, size_t)> fn,
+                const int64_t* offsets,
+                int64_t count) const override;
+
+    void
+    PrefetchChunks(milvus::OpContext* op_ctx,
+                   const std::vector<int64_t>& chunk_ids) const override;
+
+    PinWrapper<SpanBase>
+    Span(milvus::OpContext* op_ctx, int64_t chunk_id) const override;
+
+    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    StringViews(milvus::OpContext* op_ctx,
+                int64_t chunk_id,
+                std::optional<std::pair<int64_t, int64_t>> offset_len =
+                    std::nullopt) const override;
+
+    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    ArrayViews(milvus::OpContext* op_ctx,
+               int64_t chunk_id,
+               std::optional<std::pair<int64_t, int64_t>> offset_len =
+                   std::nullopt) const override;
+
+    PinWrapper<std::pair<std::vector<VectorArrayView>, FixedVector<bool>>>
+    VectorArrayViews(milvus::OpContext* op_ctx,
+                     int64_t chunk_id,
+                     std::optional<std::pair<int64_t, int64_t>> offset_len =
+                         std::nullopt) const override;
+
+    PinWrapper<const size_t*>
+    VectorArrayOffsets(milvus::OpContext* op_ctx,
+                       int64_t chunk_id) const override;
+
+    PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    StringViewsByOffsets(milvus::OpContext* op_ctx,
+                         int64_t chunk_id,
+                         const FixedVector<int32_t>& offsets) const override;
+
+    PinWrapper<std::pair<std::vector<ArrayView>, FixedVector<bool>>>
+    ArrayViewsByOffsets(milvus::OpContext* op_ctx,
+                        int64_t chunk_id,
+                        const FixedVector<int32_t>& offsets) const override;
+
+    std::pair<size_t, size_t>
+    GetChunkIDByOffset(int64_t offset) const override;
+
+    std::pair<std::vector<milvus::cachinglayer::cid_t>, std::vector<int64_t>>
+    GetChunkIDsByOffsets(const int64_t* offsets, int64_t count) const override;
+
+    PinWrapper<Chunk*>
+    GetChunk(milvus::OpContext* op_ctx, int64_t chunk_id) const override;
+
+    std::vector<PinWrapper<Chunk*>>
+    GetAllChunks(milvus::OpContext* op_ctx) const override;
+
+    int64_t
+    GetNumRowsUntilChunk(int64_t chunk_id) const override;
+
+    const std::vector<int64_t>&
+    GetNumRowsUntilChunk() const override;
+
+    void
+    BulkValueAt(milvus::OpContext* op_ctx,
+                std::function<void(const char*, size_t)> fn,
+                const int64_t* offsets,
+                int64_t count) override;
+
+    void
+    BulkPrimitiveValueAt(milvus::OpContext* op_ctx,
+                         void* dst,
+                         const int64_t* offsets,
+                         int64_t count,
+                         bool small_int_raw_type = false) override;
+
+    void
+    BulkVectorValueAt(milvus::OpContext* op_ctx,
+                      void* dst,
+                      const int64_t* offsets,
+                      int64_t count,
+                      int64_t dim) override;
+
+    void
+    BulkRawStringAt(milvus::OpContext* op_ctx,
+                    std::function<void(std::string_view, size_t, bool)> fn,
+                    const int64_t* offsets = nullptr,
+                    int64_t count = 0) const override;
+
+    void
+    BulkRawJsonAt(milvus::OpContext* op_ctx,
+                  std::function<void(Json, size_t, bool)> fn,
+                  const int64_t* offsets,
+                  int64_t count) const override;
+
+    void
+    BulkRawBsonAt(milvus::OpContext* op_ctx,
+                  std::function<void(BsonView, uint32_t, uint32_t)> fn,
+                  const uint32_t* row_offsets,
+                  const uint32_t* value_offsets,
+                  int64_t count) const override;
+
+    void
+    BulkArrayAt(milvus::OpContext* op_ctx,
+                std::function<void(const ArrayView&, size_t)> fn,
+                const int64_t* offsets,
+                int64_t count) const override;
+
+    void
+    BulkVectorArrayAt(milvus::OpContext* op_ctx,
+                      std::function<void(VectorFieldProto&&, size_t)> fn,
+                      const int64_t* offsets,
+                      int64_t count) const override;
+
+    ScanResult
+    Scan(milvus::OpContext* op_ctx, const ScanOptions& options) const override;
+
+    struct TakeResult {
+        std::vector<std::shared_ptr<Chunk>> chunks;
+        std::vector<int64_t> offsets;
+    };
+
+    TakeResult
+    TakeOwn(milvus::OpContext* op_ctx,
+            const int64_t* offsets,
+            int64_t count) const;
+
+    std::shared_ptr<TakeResult>
+    Take(milvus::OpContext* op_ctx,
+         const int64_t* offsets,
+         int64_t count) const;
+
+ private:
+    std::optional<DataType>
+    GetDefaultScanDataType() const override;
+
+    struct FileState {
+        std::string path;
+        std::shared_ptr<milvus_storage::vortex::VortexPlanner> planner;
+        std::shared_ptr<
+            cachinglayer::CacheSlot<milvus_storage::vortex::VortexCellGuard>>
+            slot;
+        int64_t rows = 0;
+        size_t memory_bytes = 0;
+    };
+
+    struct ArrowTakeResult;
+    struct ArrowStringViewHolder;
+    class ArrowStringLikeColumn;
+
+    static std::shared_ptr<arrow::Schema>
+    MakeProjectedArrowSchema(const std::shared_ptr<arrow::Schema>& schema,
+                             const std::string& field_name);
+
+    static std::optional<std::string>
+    VortexCompareOp(proto::plan::OpType op_type);
+
+    static std::string
+    QuoteSqlIdentifier(std::string_view value);
+
+    static std::string
+    QuoteSqlStringLiteral(std::string_view value);
+
+    static bool
+    CanUseVortexPredicateLiteral(DataType data_type,
+                                 const proto::plan::GenericValue& value);
+
+    static std::string
+    FormatVortexDoubleLiteral(double value);
+
+    static std::optional<std::string>
+    VortexLiteral(DataType data_type, const proto::plan::GenericValue& value);
+
+    std::optional<std::string>
+    BuildVortexPredicate(const ScanOptions& options) const;
+
+    static milvus_storage::api::Properties
+    MakeVortexReaderProperties(
+        const std::shared_ptr<milvus_storage::api::Properties>& properties);
+
+    std::shared_ptr<milvus_storage::vortex::VortexPlanner>
+    MakeFilePlanner(const VortexColumnGroup::FileState& group_file) const;
+
+    std::shared_ptr<milvus_storage::vortex::VortexFormatReader>
+    OpenFileReader(const VortexColumnGroup::FileState& group_file) const;
+
+    void
+    ValidateFileState(const FileState& state,
+                      const VortexColumnGroup::FileState& group_file) const;
+
+    FileState
+    BuildFileState(const VortexColumnGroup::FileState& group_file) const;
+
+    std::pair<std::vector<std::string_view>, FixedVector<bool>>
+    BuildStringViewsFromArrow(
+        const ArrowStringLikeColumn& column,
+        std::optional<std::pair<int64_t, int64_t>> offset_len,
+        bool emit_valid) const;
+
+    void
+    CheckChunkId(int64_t chunk_id) const;
+
+    std::shared_ptr<
+        cachinglayer::CellAccessor<milvus_storage::vortex::VortexCellGuard>>
+    PinPlanCells(milvus::OpContext* op_ctx,
+                 const FileState& file,
+                 const std::vector<uint64_t>& cell_ids) const;
+
+    milvus_storage::vortex::VortexPlan
+    PlanRowRange(const FileState& file,
+                 uint64_t row_start,
+                 uint64_t row_end,
+                 const std::string& predicate = "") const;
+
+    milvus_storage::vortex::VortexPlan
+    PlanOffsets(const FileState& file,
+                const std::vector<int64_t>& offsets) const;
+
+    std::shared_ptr<Chunk>
+    ChunkFromTable(const std::shared_ptr<arrow::Table>& table) const;
+
+    std::shared_ptr<Chunk>
+    MaterializeChunk(milvus::OpContext* op_ctx,
+                     int64_t chunk_id,
+                     std::optional<std::pair<int64_t, int64_t>> offset_len =
+                         std::nullopt) const;
+
+    PinWrapper<std::shared_ptr<arrow::RecordBatchReader>>
+    OpenDataScanForFile(milvus::OpContext* op_ctx,
+                        int64_t chunk_id,
+                        int64_t start_offset,
+                        int64_t length) const;
+
+    PinWrapper<std::shared_ptr<arrow::RecordBatchReader>>
+    OpenRowIdScanForFile(milvus::OpContext* op_ctx,
+                         int64_t chunk_id,
+                         int64_t start_offset,
+                         int64_t length,
+                         const std::string& predicate) const;
+
+    std::pair<std::shared_ptr<ArrowStringViewHolder>,
+              std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    ScanStringLikeViewsFromFile(
+        milvus::OpContext* op_ctx,
+        int64_t chunk_id,
+        std::optional<std::pair<int64_t, int64_t>> offset_len) const;
+
+    std::shared_ptr<Chunk>
+    TakeFromFile(milvus::OpContext* op_ctx,
+                 int64_t chunk_id,
+                 const std::vector<int64_t>& offsets) const;
+
+    ArrowTakeResult
+    TakeArrowFromFile(milvus::OpContext* op_ctx,
+                      int64_t chunk_id,
+                      const std::vector<int64_t>& offsets) const;
+
+    std::pair<std::shared_ptr<ArrowStringViewHolder>,
+              std::pair<std::vector<std::string_view>, FixedVector<bool>>>
+    TakeStringLikeViews(milvus::OpContext* op_ctx,
+                        const int64_t* offsets,
+                        int64_t count) const;
+
+    template <typename ArrowArrayT,
+              typename SrcT,
+              typename RawDstT,
+              typename WidenDstT>
+    void
+    CopyArrowPrimitiveValues(
+        void* dst,
+        const std::shared_ptr<arrow::Table>& table,
+        const std::vector<std::vector<int64_t>>& original_indices_by_unique,
+        bool small_int_raw_type) const;
+
+    template <typename ArrowArrayT,
+              typename SrcT,
+              typename RawDstT,
+              typename WidenDstT>
+    void
+    BulkPrimitiveValueAtFromArrow(milvus::OpContext* op_ctx,
+                                  void* dst,
+                                  const int64_t* offsets,
+                                  int64_t count,
+                                  bool small_int_raw_type) const;
+
+    void
+    BulkStringLikeAt(
+        milvus::OpContext* op_ctx,
+        const std::function<void(std::string_view, size_t, bool)>& fn,
+        const int64_t* offsets,
+        int64_t count) const;
+
+    FieldId field_id_;
+    FieldMeta field_meta_;
+    DataType data_type_;
+    std::string field_name_;
+    milvus_storage::api::Properties local_format_properties_;
+    std::shared_ptr<VortexColumnGroup> column_group_;
+    size_t data_byte_size_ = 0;
+    std::vector<FileState> files_;
+    std::vector<int64_t> num_rows_until_chunk_;
+    int64_t num_rows_ = 0;
+};
+
+}  // namespace milvus

--- a/internal/core/src/mmap/VortexColumnGroup.cpp
+++ b/internal/core/src/mmap/VortexColumnGroup.cpp
@@ -1,0 +1,183 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mmap/VortexColumnGroup.h"
+
+#include <memory>
+#include <utility>
+
+#include "arrow/filesystem/filesystem.h"
+#include "cachinglayer/Manager.h"
+#include "cachinglayer/Translator.h"
+#include "common/EasyAssert.h"
+#include "common/OpContext.h"
+#include "mmap/SparseVortexFileSystem.h"
+#include "milvus-storage/filesystem/fs.h"
+#include "milvus-storage/format/vortex/vortex_footer_reader.h"
+#include "milvus-storage/format/vortex/vortex_planner.h"
+#include "milvus-storage/format/vortex/vortex_translater.h"
+
+namespace milvus {
+
+VortexColumnGroup::VortexColumnGroup(
+    const std::vector<VortexColumnFileInfo>& files,
+    std::shared_ptr<milvus_storage::api::Properties> properties,
+    const std::vector<std::string>& field_names,
+    CacheWarmupPolicy cache_warmup_policy,
+    milvus::OpContext* op_ctx)
+    : num_fields_(field_names.size()) {
+    AssertInfo(properties != nullptr, "vortex properties is null");
+    AssertInfo(!files.empty(), "vortex column group has no files");
+    AssertInfo(!field_names.empty(), "vortex column group has no fields");
+    files_.reserve(files.size());
+    num_rows_until_chunk_.reserve(files.size() + 1);
+    num_rows_until_chunk_.push_back(0);
+    int64_t row_prefix = 0;
+
+    for (const auto& file : files) {
+        auto fs_result = milvus_storage::FilesystemCache::getInstance().get(
+            *properties, file.path);
+        AssertInfo(fs_result.ok(),
+                   "failed to get filesystem for vortex file {}: {}",
+                   file.path,
+                   fs_result.status().ToString());
+        auto uri_result = milvus_storage::StorageUri::Parse(file.path);
+        AssertInfo(uri_result.ok(),
+                   "failed to parse vortex file uri {}: {}",
+                   file.path,
+                   uri_result.status().ToString());
+
+        FileState state;
+        state.path = file.path;
+        state.resolved_path = uri_result.ValueOrDie().key;
+        state.source_fs = fs_result.ValueOrDie();
+        state.sparse_path = MakeSparseVortexPath(state.resolved_path);
+        state.sparse_fs = MakeSparseVortexFileSystem(state.sparse_path);
+        state.footer_reader =
+            std::make_shared<milvus_storage::vortex::VortexFooterReader>(
+                state.sparse_fs,
+                state.sparse_path,
+                state.resolved_path,
+                file.file_size,
+                file.footer_size);
+        auto open_status = state.footer_reader->Open(state.source_fs);
+        AssertInfo(open_status.ok(),
+                   "failed to open vortex file {}: {}",
+                   file.path,
+                   open_status.ToString());
+
+        auto cell_metas_result =
+            milvus_storage::vortex::BuildVortexGroupCellMetas(
+                state.footer_reader, field_names);
+        AssertInfo(cell_metas_result.ok(),
+                   "failed to build vortex group cell metas for file {}: {}",
+                   file.path,
+                   cell_metas_result.status().ToString());
+        auto cell_metas = std::move(cell_metas_result).ValueOrDie();
+
+        auto planner_result = milvus_storage::vortex::VortexPlanner::MakeGroup(
+            state.footer_reader, cell_metas);
+        AssertInfo(planner_result.ok(),
+                   "failed to create vortex group planner for file {}: {}",
+                   file.path,
+                   planner_result.status().ToString());
+        auto planner = std::move(planner_result).ValueOrDie();
+
+        auto translater_result = milvus_storage::vortex::VortexTranslater::Make(
+            std::move(cell_metas),
+            state.source_fs,
+            state.resolved_path,
+            state.sparse_fs,
+            state.sparse_path,
+            cache_warmup_policy);
+        AssertInfo(translater_result.ok(),
+                   "failed to create vortex group translater for file {}: {}",
+                   file.path,
+                   translater_result.status().ToString());
+        std::unique_ptr<
+            cachinglayer::Translator<milvus_storage::vortex::VortexCellGuard>>
+            translater = std::move(translater_result).ValueOrDie();
+        state.slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
+            std::move(translater), op_ctx);
+        state.rows = static_cast<int64_t>(planner->rows());
+        state.memory_bytes = planner->memory_bytes();
+        state.planner = planner;
+
+        if (file.end_index > file.start_index) {
+            AssertInfo(file.end_index - file.start_index == state.rows,
+                       "vortex file {} row range [{}, {}) does not match "
+                       "reader rows {}",
+                       state.path,
+                       file.start_index,
+                       file.end_index,
+                       state.rows);
+        }
+
+        row_prefix += state.rows;
+        num_rows_until_chunk_.push_back(row_prefix);
+        files_.emplace_back(std::move(state));
+    }
+    num_rows_ = row_prefix;
+}
+
+VortexColumnGroup::~VortexColumnGroup() {
+    CancelWarmup();
+}
+
+void
+VortexColumnGroup::ManualEvictCache() const {
+    for (const auto& file : files_) {
+        file.slot->ManualEvictAll();
+    }
+}
+
+void
+VortexColumnGroup::CancelWarmup() {
+    for (const auto& file : files_) {
+        file.slot->CancelWarmup();
+    }
+}
+
+const std::vector<VortexColumnGroup::FileState>&
+VortexColumnGroup::files() const {
+    return files_;
+}
+
+const std::vector<int64_t>&
+VortexColumnGroup::num_rows_until_chunk() const {
+    return num_rows_until_chunk_;
+}
+
+int64_t
+VortexColumnGroup::num_rows() const {
+    return num_rows_;
+}
+
+size_t
+VortexColumnGroup::memory_size() const {
+    size_t bytes = 0;
+    for (const auto& file : files_) {
+        bytes += file.memory_bytes;
+    }
+    return bytes;
+}
+
+size_t
+VortexColumnGroup::num_fields() const {
+    return num_fields_;
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/VortexColumnGroup.h
+++ b/internal/core/src/mmap/VortexColumnGroup.h
@@ -1,0 +1,111 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/Types.h"
+#include "milvus-storage/properties.h"
+
+namespace arrow::fs {
+class FileSystem;
+}  // namespace arrow::fs
+
+namespace milvus_storage::vortex {
+class VortexCellGuard;
+class VortexFooterReader;
+class VortexPlanner;
+}  // namespace milvus_storage::vortex
+
+namespace milvus {
+
+class OpContext;
+
+namespace cachinglayer {
+template <typename T>
+class CacheSlot;
+}  // namespace cachinglayer
+
+struct VortexColumnFileInfo {
+    std::string path;
+    int64_t start_index = 0;
+    int64_t end_index = 0;
+    uint64_t file_size = 0;
+    uint64_t footer_size = 0;
+};
+
+class VortexColumnGroup {
+ public:
+    using FileInfo = VortexColumnFileInfo;
+
+    struct FileState {
+        std::string path;
+        std::string resolved_path;
+        std::string sparse_path;
+        std::shared_ptr<arrow::fs::FileSystem> source_fs;
+        std::shared_ptr<arrow::fs::FileSystem> sparse_fs;
+        std::shared_ptr<milvus_storage::vortex::VortexFooterReader>
+            footer_reader;
+        std::shared_ptr<milvus_storage::vortex::VortexPlanner> planner;
+        std::shared_ptr<
+            cachinglayer::CacheSlot<milvus_storage::vortex::VortexCellGuard>>
+            slot;
+        int64_t rows = 0;
+        size_t memory_bytes = 0;
+    };
+
+    VortexColumnGroup(
+        const std::vector<VortexColumnFileInfo>& files,
+        std::shared_ptr<milvus_storage::api::Properties> properties,
+        const std::vector<std::string>& field_names,
+        CacheWarmupPolicy cache_warmup_policy,
+        milvus::OpContext* op_ctx);
+
+    ~VortexColumnGroup();
+
+    void
+    ManualEvictCache() const;
+
+    void
+    CancelWarmup();
+
+    const std::vector<FileState>&
+    files() const;
+
+    const std::vector<int64_t>&
+    num_rows_until_chunk() const;
+
+    int64_t
+    num_rows() const;
+
+    size_t
+    memory_size() const;
+
+    size_t
+    num_fields() const;
+
+ private:
+    std::vector<FileState> files_;
+    std::vector<int64_t> num_rows_until_chunk_;
+    int64_t num_rows_ = 0;
+    size_t num_fields_;
+};
+
+}  // namespace milvus

--- a/internal/core/src/mmap/VortexColumnTest.cpp
+++ b/internal/core/src/mmap/VortexColumnTest.cpp
@@ -197,6 +197,9 @@ ExpectedValid(int64_t row) {
     return row % 4 != 1;
 }
 
+std::string
+ExpectedString(DataType type, int64_t row);
+
 bool
 IsVortexStringPushdownType(DataType type) {
     return type == DataType::STRING || type == DataType::VARCHAR ||

--- a/internal/core/src/mmap/VortexColumnTest.cpp
+++ b/internal/core/src/mmap/VortexColumnTest.cpp
@@ -1,0 +1,1034 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mmap/VortexColumn.h"
+
+#include <cstdint>
+#include <cmath>
+#include <deque>
+#include <exception>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+#include <unistd.h>
+
+#include "arrow/api.h"
+#include "arrow/filesystem/localfs.h"
+#include "common/Common.h"
+#include "common/FieldMeta.h"
+#include "common/ValueOp.h"
+#include "exec/expression/Expr.h"
+#include "gtest/gtest.h"
+#include "milvus-storage/column_groups.h"
+#include "milvus-storage/format/vortex/vortex_writer.h"
+#include "milvus-storage/properties.h"
+
+namespace milvus {
+namespace {
+
+constexpr int64_t kIntFieldId = 101;
+constexpr int64_t kStringFieldId = 102;
+constexpr int64_t kNullableFieldIdBase = 200;
+constexpr int64_t kNullableRows = 16;
+
+std::shared_ptr<arrow::Schema>
+MakeSchema() {
+    return arrow::schema({
+        arrow::field(std::to_string(kIntFieldId), arrow::int32(), false),
+        arrow::field(std::to_string(kStringFieldId), arrow::binary(), false),
+    });
+}
+
+std::shared_ptr<arrow::RecordBatch>
+MakeRecordBatch(int64_t begin, int64_t count) {
+    arrow::Int32Builder int_builder;
+    arrow::BinaryBuilder string_builder;
+    EXPECT_TRUE(int_builder.Reserve(count).ok());
+    EXPECT_TRUE(string_builder.Reserve(count).ok());
+    for (int64_t i = begin; i < begin + count; ++i) {
+        EXPECT_TRUE(int_builder.Append(static_cast<int32_t>(i * 10)).ok());
+        auto value = "v" + std::to_string(i);
+        EXPECT_TRUE(string_builder.Append(value).ok());
+    }
+
+    std::shared_ptr<arrow::Array> int_array;
+    std::shared_ptr<arrow::Array> string_array;
+    EXPECT_TRUE(int_builder.Finish(&int_array).ok());
+    EXPECT_TRUE(string_builder.Finish(&string_array).ok());
+    return arrow::RecordBatch::Make(
+        MakeSchema(), count, {std::move(int_array), std::move(string_array)});
+}
+
+milvus_storage::api::Properties
+MakeProperties() {
+    milvus_storage::api::Properties properties;
+    properties[PROPERTY_FS_STORAGE_TYPE] = std::string("local");
+    properties[PROPERTY_FS_ROOT_PATH] = std::string("/");
+    return properties;
+}
+
+VortexColumn::FileInfo
+WriteVortexFile(const std::string& path,
+                const std::shared_ptr<arrow::Schema>& schema,
+                const milvus_storage::api::Properties& properties,
+                int64_t begin = 0) {
+    auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
+    milvus_storage::vortex::VortexFileWriter writer(
+        fs, schema, path, properties);
+    EXPECT_TRUE(writer.Write(MakeRecordBatch(begin, 8)).ok());
+    EXPECT_TRUE(writer.Write(MakeRecordBatch(begin + 8, 8)).ok());
+    EXPECT_TRUE(writer.Flush().ok());
+    auto close_result = writer.Close();
+    EXPECT_TRUE(close_result.ok());
+    auto cg_file = close_result.ValueOrDie();
+
+    VortexColumn::FileInfo info;
+    info.path = path;
+    info.start_index = begin;
+    info.end_index = begin + 16;
+    info.file_size =
+        cg_file.Get<uint64_t>(milvus_storage::api::kPropertyFileSize, 0);
+    info.footer_size =
+        cg_file.Get<uint64_t>(milvus_storage::api::kPropertyFooterSize, 0);
+    return info;
+}
+
+std::vector<int32_t>
+CollectIntScanValues(VortexColumn& column, int64_t start, int64_t length) {
+    auto options = ChunkedColumnInterface::ScanOptions::ForData(start, length);
+
+    auto result = column.Scan(nullptr, options);
+    EXPECT_NE(result, nullptr);
+    std::vector<int32_t> values;
+    if (result == nullptr) {
+        return values;
+    }
+
+    ChunkedColumnInterface::ScanBatch batch;
+    while (result->Next(&batch)) {
+        const auto* data = batch.values.data_as<int32_t>();
+        values.insert(values.end(), data, data + batch.size);
+    }
+    return values;
+}
+
+std::vector<std::string>
+CollectStringScanValues(VortexColumn& column, int64_t start, int64_t length) {
+    auto options = ChunkedColumnInterface::ScanOptions::ForData(
+        start,
+        length,
+        ChunkedColumnInterface::ScanProjection::Data,
+        ChunkedColumnInterface::ScanValueKind::StringView);
+
+    auto result = column.Scan(nullptr, options);
+    EXPECT_NE(result, nullptr);
+    std::vector<std::string> values;
+    if (result == nullptr) {
+        return values;
+    }
+
+    ChunkedColumnInterface::ScanBatch batch;
+    while (result->Next(&batch)) {
+        const auto* data = batch.values.data_as<std::string_view>();
+        for (int64_t i = 0; i < batch.size; ++i) {
+            values.emplace_back(data[i]);
+        }
+    }
+    return values;
+}
+
+std::vector<int64_t>
+CollectFilteredRowIdPayload(
+    VortexColumn& column, const ChunkedColumnInterface::ScanOptions& options) {
+    auto result = column.Scan(nullptr, options);
+    EXPECT_NE(result, nullptr);
+    std::vector<int64_t> row_ids;
+    if (result == nullptr) {
+        return row_ids;
+    }
+
+    ChunkedColumnInterface::ScanBatch batch;
+    while (result->Next(&batch)) {
+        EXPECT_TRUE(batch.values.empty());
+        EXPECT_EQ(batch.size, static_cast<int64_t>(batch.row_ids.size()));
+        EXPECT_EQ(batch.validity.size,
+                  static_cast<int64_t>(batch.row_ids.size()));
+        for (size_t i = 0; i < batch.row_ids.size(); ++i) {
+            if (i > 0) {
+                EXPECT_LE(batch.row_ids[i - 1], batch.row_ids[i]);
+            }
+        }
+        row_ids.insert(
+            row_ids.end(), batch.row_ids.begin(), batch.row_ids.end());
+    }
+    return row_ids;
+}
+
+proto::plan::GenericValue
+IntValue(int64_t value) {
+    proto::plan::GenericValue generic_value;
+    generic_value.set_int64_val(value);
+    return generic_value;
+}
+
+proto::plan::GenericValue
+StringValue(std::string_view value) {
+    proto::plan::GenericValue generic_value;
+    generic_value.set_string_val(std::string(value));
+    return generic_value;
+}
+
+bool
+ExpectedValid(int64_t row) {
+    return row % 4 != 1;
+}
+
+bool
+IsVortexStringPushdownType(DataType type) {
+    return type == DataType::STRING || type == DataType::VARCHAR ||
+           type == DataType::TEXT;
+}
+
+class ScopedVortexScanPushdownEnable {
+ public:
+    explicit ScopedVortexScanPushdownEnable(bool enable)
+        : old_(ENABLE_VORTEX_SCAN_PUSHDOWN.load()) {
+        SetDefaultVortexScanPushdownEnable(enable);
+    }
+
+    ~ScopedVortexScanPushdownEnable() {
+        SetDefaultVortexScanPushdownEnable(old_);
+    }
+
+ private:
+    bool old_;
+};
+
+void
+CheckNullableFilteredScanReturnsValidity(VortexColumn& column, DataType type) {
+    const auto value = StringValue(ExpectedString(type, 8));
+    auto options = ChunkedColumnInterface::ScanOptions::ForUnary(
+        0, kNullableRows, proto::plan::OpType::Equal, value);
+    EXPECT_TRUE(column.SupportsScanPushdown(options));
+    auto scan_result = column.Scan(nullptr, options);
+    ASSERT_NE(scan_result, nullptr);
+
+    std::vector<int64_t> row_ids;
+    ChunkedColumnInterface::ScanBatch scan_batch;
+    while (scan_result->Next(&scan_batch)) {
+        EXPECT_TRUE(scan_batch.values.empty());
+        EXPECT_EQ(scan_batch.size,
+                  static_cast<int64_t>(scan_batch.row_ids.size()));
+        EXPECT_EQ(scan_batch.validity.size,
+                  static_cast<int64_t>(scan_batch.row_ids.size()));
+        row_ids.insert(row_ids.end(),
+                       scan_batch.row_ids.begin(),
+                       scan_batch.row_ids.end());
+        for (size_t i = 0; i < scan_batch.row_ids.size(); ++i) {
+            if (i > 0) {
+                EXPECT_LE(scan_batch.row_ids[i - 1], scan_batch.row_ids[i]);
+            }
+            const auto row = scan_batch.row_ids[i];
+            EXPECT_EQ(scan_batch.validity.IsValid(static_cast<int64_t>(i)),
+                      ExpectedValid(row))
+                << row;
+        }
+    }
+    EXPECT_EQ(row_ids, (std::vector<int64_t>{1, 5, 8, 9, 13}));
+
+    auto offset_options = ChunkedColumnInterface::ScanOptions::ForUnary(
+        3, 10, proto::plan::OpType::Equal, value);
+    EXPECT_EQ(CollectFilteredRowIdPayload(column, offset_options),
+              (std::vector<int64_t>{5, 8, 9}));
+
+    auto expr_scan_result = column.Scan(nullptr, options);
+    ASSERT_NE(expr_scan_result, nullptr);
+    std::deque<exec::RowIdScanEntry> buffered_entries;
+    ChunkedColumnInterface::ScanBatch expr_batch;
+    auto bitmaps = exec::RowIdScanToBitmaps(expr_scan_result.get(),
+                                            buffered_entries,
+                                            expr_batch,
+                                            0,
+                                            kNullableRows,
+                                            TargetBitmap());
+    EXPECT_FALSE(bitmaps.result[1]);
+    EXPECT_FALSE(bitmaps.validity[1]);
+    EXPECT_FALSE(bitmaps.validity[5]);
+    EXPECT_TRUE(bitmaps.result[8]);
+    EXPECT_FALSE(bitmaps.result[9]);
+    EXPECT_FALSE(bitmaps.validity[9]);
+    EXPECT_FALSE(bitmaps.validity[13]);
+    EXPECT_FALSE(bitmaps.result[10]);
+    EXPECT_TRUE(bitmaps.validity[10]);
+
+    auto vector = std::make_shared<ColumnVector>(std::move(bitmaps.result),
+                                                 std::move(bitmaps.validity));
+    common::ThreeValuedLogicOp::Not(vector);
+    TargetBitmapView data(vector->GetRawData(), vector->size());
+    TargetBitmapView valid(vector->GetValidRawData(), vector->size());
+    EXPECT_TRUE(data[0]);
+    EXPECT_TRUE(valid[0]);
+    EXPECT_FALSE(data[8]);
+    EXPECT_TRUE(valid[8]);
+    EXPECT_FALSE(data[9]);
+    EXPECT_FALSE(valid[9]);
+}
+
+std::string
+ExpectedString(DataType type, int64_t row) {
+    switch (type) {
+        case DataType::STRING:
+            return "string_" + std::to_string(row);
+        case DataType::VARCHAR:
+            return "varchar_" + std::to_string(row);
+        case DataType::TEXT:
+            return "text_" + std::to_string(row);
+        case DataType::JSON:
+            return "{\"row\":" + std::to_string(row) + "}";
+        case DataType::GEOMETRY:
+            return "geometry_wkb_" + std::to_string(row);
+        default:
+            return {};
+    }
+}
+
+FieldMeta
+MakeNullableFieldMeta(FieldId field_id, DataType type) {
+    auto name = FieldName("nullable_" + std::to_string(field_id.get()));
+    switch (type) {
+        case DataType::STRING:
+        case DataType::VARCHAR:
+        case DataType::TEXT:
+            return FieldMeta(name, field_id, type, 256, true, std::nullopt);
+        case DataType::ARRAY:
+            return FieldMeta(
+                name, field_id, type, DataType::INT64, true, std::nullopt);
+        default:
+            return FieldMeta(name, field_id, type, true, std::nullopt);
+    }
+}
+
+std::shared_ptr<arrow::DataType>
+ArrowTypeForNullableField(DataType type) {
+    switch (type) {
+        case DataType::BOOL:
+            return arrow::boolean();
+        case DataType::INT8:
+            return arrow::int8();
+        case DataType::INT16:
+            return arrow::int16();
+        case DataType::INT32:
+            return arrow::int32();
+        case DataType::INT64:
+        case DataType::TIMESTAMPTZ:
+            return arrow::int64();
+        case DataType::FLOAT:
+            return arrow::float32();
+        case DataType::DOUBLE:
+            return arrow::float64();
+        case DataType::STRING:
+        case DataType::VARCHAR:
+        case DataType::TEXT:
+        case DataType::JSON:
+        case DataType::GEOMETRY:
+            return arrow::binary();
+        case DataType::ARRAY:
+            return arrow::list(arrow::int64());
+        default:
+            return arrow::null();
+    }
+}
+
+std::vector<DataType>
+NullableLocalVortexTypes() {
+    return {DataType::BOOL,
+            DataType::INT8,
+            DataType::INT16,
+            DataType::INT32,
+            DataType::INT64,
+            DataType::FLOAT,
+            DataType::DOUBLE,
+            DataType::TIMESTAMPTZ,
+            DataType::STRING,
+            DataType::VARCHAR,
+            DataType::TEXT,
+            DataType::JSON,
+            DataType::GEOMETRY,
+            DataType::ARRAY};
+}
+
+std::shared_ptr<arrow::Schema>
+MakeNullableSchema() {
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    auto types = NullableLocalVortexTypes();
+    fields.reserve(types.size());
+    for (size_t i = 0; i < types.size(); ++i) {
+        const auto field_id = kNullableFieldIdBase + static_cast<int64_t>(i);
+        fields.emplace_back(arrow::field(std::to_string(field_id),
+                                         ArrowTypeForNullableField(types[i]),
+                                         true));
+    }
+    return arrow::schema(std::move(fields));
+}
+
+std::shared_ptr<arrow::Array>
+BuildNullableArray(DataType type, int64_t begin, int64_t count) {
+    switch (type) {
+        case DataType::BOOL: {
+            arrow::BooleanBuilder builder;
+            for (int64_t row = begin; row < begin + count; ++row) {
+                if (!ExpectedValid(row)) {
+                    EXPECT_TRUE(builder.AppendNull().ok());
+                } else {
+                    EXPECT_TRUE(builder.Append(row % 2 == 0).ok());
+                }
+            }
+            std::shared_ptr<arrow::Array> array;
+            EXPECT_TRUE(builder.Finish(&array).ok());
+            return array;
+        }
+        case DataType::INT8: {
+            arrow::Int8Builder builder;
+            for (int64_t row = begin; row < begin + count; ++row) {
+                if (!ExpectedValid(row)) {
+                    EXPECT_TRUE(builder.AppendNull().ok());
+                } else {
+                    EXPECT_TRUE(
+                        builder.Append(static_cast<int8_t>(row - 8)).ok());
+                }
+            }
+            std::shared_ptr<arrow::Array> array;
+            EXPECT_TRUE(builder.Finish(&array).ok());
+            return array;
+        }
+        case DataType::INT16: {
+            arrow::Int16Builder builder;
+            for (int64_t row = begin; row < begin + count; ++row) {
+                if (!ExpectedValid(row)) {
+                    EXPECT_TRUE(builder.AppendNull().ok());
+                } else {
+                    EXPECT_TRUE(
+                        builder.Append(static_cast<int16_t>(row * 10)).ok());
+                }
+            }
+            std::shared_ptr<arrow::Array> array;
+            EXPECT_TRUE(builder.Finish(&array).ok());
+            return array;
+        }
+        case DataType::INT32: {
+            arrow::Int32Builder builder;
+            for (int64_t row = begin; row < begin + count; ++row) {
+                if (!ExpectedValid(row)) {
+                    EXPECT_TRUE(builder.AppendNull().ok());
+                } else {
+                    EXPECT_TRUE(
+                        builder.Append(static_cast<int32_t>(row * 100)).ok());
+                }
+            }
+            std::shared_ptr<arrow::Array> array;
+            EXPECT_TRUE(builder.Finish(&array).ok());
+            return array;
+        }
+        case DataType::INT64:
+        case DataType::TIMESTAMPTZ: {
+            arrow::Int64Builder builder;
+            for (int64_t row = begin; row < begin + count; ++row) {
+                if (!ExpectedValid(row)) {
+                    EXPECT_TRUE(builder.AppendNull().ok());
+                } else {
+                    const auto value = type == DataType::TIMESTAMPTZ
+                                           ? 1700000000000000LL + row
+                                           : row * 1000;
+                    EXPECT_TRUE(builder.Append(value).ok());
+                }
+            }
+            std::shared_ptr<arrow::Array> array;
+            EXPECT_TRUE(builder.Finish(&array).ok());
+            return array;
+        }
+        case DataType::FLOAT: {
+            arrow::FloatBuilder builder;
+            for (int64_t row = begin; row < begin + count; ++row) {
+                if (!ExpectedValid(row)) {
+                    EXPECT_TRUE(builder.AppendNull().ok());
+                } else {
+                    EXPECT_TRUE(
+                        builder.Append(static_cast<float>(row) * 1.5f).ok());
+                }
+            }
+            std::shared_ptr<arrow::Array> array;
+            EXPECT_TRUE(builder.Finish(&array).ok());
+            return array;
+        }
+        case DataType::DOUBLE: {
+            arrow::DoubleBuilder builder;
+            for (int64_t row = begin; row < begin + count; ++row) {
+                if (!ExpectedValid(row)) {
+                    EXPECT_TRUE(builder.AppendNull().ok());
+                } else {
+                    EXPECT_TRUE(
+                        builder.Append(static_cast<double>(row) * 2.25).ok());
+                }
+            }
+            std::shared_ptr<arrow::Array> array;
+            EXPECT_TRUE(builder.Finish(&array).ok());
+            return array;
+        }
+        case DataType::STRING:
+        case DataType::VARCHAR:
+        case DataType::TEXT:
+        case DataType::JSON:
+        case DataType::GEOMETRY: {
+            arrow::BinaryBuilder builder;
+            for (int64_t row = begin; row < begin + count; ++row) {
+                if (!ExpectedValid(row)) {
+                    EXPECT_TRUE(builder.AppendNull().ok());
+                } else {
+                    EXPECT_TRUE(builder.Append(ExpectedString(type, row)).ok());
+                }
+            }
+            std::shared_ptr<arrow::Array> array;
+            EXPECT_TRUE(builder.Finish(&array).ok());
+            return array;
+        }
+        case DataType::ARRAY: {
+            auto value_builder = std::make_shared<arrow::Int64Builder>();
+            arrow::ListBuilder builder(arrow::default_memory_pool(),
+                                       value_builder);
+            auto* values =
+                static_cast<arrow::Int64Builder*>(builder.value_builder());
+            for (int64_t row = begin; row < begin + count; ++row) {
+                if (!ExpectedValid(row)) {
+                    EXPECT_TRUE(builder.AppendNull().ok());
+                } else {
+                    EXPECT_TRUE(builder.Append().ok());
+                    EXPECT_TRUE(values->Append(row).ok());
+                    EXPECT_TRUE(values->Append(row + 1).ok());
+                    EXPECT_TRUE(values->Append(row + 2).ok());
+                }
+            }
+            std::shared_ptr<arrow::Array> array;
+            EXPECT_TRUE(builder.Finish(&array).ok());
+            return array;
+        }
+        default:
+            return nullptr;
+    }
+}
+
+std::shared_ptr<arrow::RecordBatch>
+MakeNullableRecordBatch(int64_t begin, int64_t count) {
+    auto types = NullableLocalVortexTypes();
+    std::vector<std::shared_ptr<arrow::Array>> arrays;
+    arrays.reserve(types.size());
+    for (auto type : types) {
+        arrays.emplace_back(BuildNullableArray(type, begin, count));
+    }
+    return arrow::RecordBatch::Make(
+        MakeNullableSchema(), count, std::move(arrays));
+}
+
+VortexColumn::FileInfo
+WriteNullableVortexFile(const std::string& path,
+                        const std::shared_ptr<arrow::Schema>& schema,
+                        const milvus_storage::api::Properties& properties) {
+    auto fs = std::make_shared<arrow::fs::LocalFileSystem>();
+    milvus_storage::vortex::VortexFileWriter writer(
+        fs, schema, path, properties);
+    EXPECT_TRUE(writer.Write(MakeNullableRecordBatch(0, 8)).ok());
+    EXPECT_TRUE(writer.Write(MakeNullableRecordBatch(8, 8)).ok());
+    EXPECT_TRUE(writer.Flush().ok());
+    auto close_result = writer.Close();
+    EXPECT_TRUE(close_result.ok());
+    auto cg_file = close_result.ValueOrDie();
+
+    VortexColumn::FileInfo info;
+    info.path = path;
+    info.start_index = 0;
+    info.end_index = kNullableRows;
+    info.file_size =
+        cg_file.Get<uint64_t>(milvus_storage::api::kPropertyFileSize, 0);
+    info.footer_size =
+        cg_file.Get<uint64_t>(milvus_storage::api::kPropertyFooterSize, 0);
+    return info;
+}
+
+ChunkedColumnInterface::ScanValueKind
+ScanKindForType(DataType type) {
+    switch (type) {
+        case DataType::JSON:
+            return ChunkedColumnInterface::ScanValueKind::JsonView;
+        case DataType::STRING:
+        case DataType::VARCHAR:
+        case DataType::TEXT:
+        case DataType::GEOMETRY:
+            return ChunkedColumnInterface::ScanValueKind::StringView;
+        case DataType::ARRAY:
+            return ChunkedColumnInterface::ScanValueKind::ArrayView;
+        default:
+            return ChunkedColumnInterface::ScanValueKind::FixedWidth;
+    }
+}
+
+std::shared_ptr<VortexColumnGroup>
+MakeColumnGroup(
+    std::vector<VortexColumn::FileInfo> files,
+    const std::shared_ptr<milvus_storage::api::Properties>& properties,
+    std::vector<std::string> field_names) {
+    return std::make_shared<VortexColumnGroup>(
+        files,
+        properties,
+        field_names,
+        CacheWarmupPolicy::CacheWarmupPolicy_Disable,
+        nullptr);
+}
+
+VortexColumn
+MakeNullableColumn(
+    DataType type,
+    FieldId field_id,
+    const VortexColumn::FileInfo& file_info,
+    const std::shared_ptr<milvus_storage::api::Properties>& properties) {
+    auto column_group = MakeColumnGroup(
+        {file_info}, properties, {std::to_string(field_id.get())});
+    return VortexColumn(field_id,
+                        MakeNullableFieldMeta(field_id, type),
+                        properties,
+                        column_group);
+}
+
+void
+CheckNoDataScan(VortexColumn& column) {
+    auto options =
+        ChunkedColumnInterface::ScanOptions::ForNoData(0, kNullableRows);
+
+    auto result = column.Scan(nullptr, options);
+    ASSERT_NE(result, nullptr);
+    ChunkedColumnInterface::ScanBatch batch;
+    int64_t seen = 0;
+    while (result->Next(&batch)) {
+        EXPECT_TRUE(batch.values.empty());
+        for (int64_t i = 0; i < batch.size; ++i) {
+            const auto row = batch.row_id_start + i;
+            EXPECT_EQ(batch.validity.IsValid(i), ExpectedValid(row)) << row;
+        }
+        seen += batch.size;
+    }
+    EXPECT_EQ(seen, kNullableRows);
+}
+
+template <typename T>
+void
+CheckFixedWidthBatch(DataType type,
+                     const ChunkedColumnInterface::ScanBatch& batch) {
+    const auto* values = batch.values.data_as<T>();
+    for (int64_t i = 0; i < batch.size; ++i) {
+        const auto row = batch.row_id_start + i;
+        EXPECT_EQ(batch.validity.IsValid(i), ExpectedValid(row)) << row;
+        if (!ExpectedValid(row)) {
+            continue;
+        }
+        if constexpr (std::is_same_v<T, bool>) {
+            EXPECT_EQ(values[i], row % 2 == 0) << row;
+        } else if constexpr (std::is_same_v<T, int8_t>) {
+            EXPECT_EQ(values[i], static_cast<int8_t>(row - 8)) << row;
+        } else if constexpr (std::is_same_v<T, int16_t>) {
+            EXPECT_EQ(values[i], static_cast<int16_t>(row * 10)) << row;
+        } else if constexpr (std::is_same_v<T, int32_t>) {
+            EXPECT_EQ(values[i], static_cast<int32_t>(row * 100)) << row;
+        } else if constexpr (std::is_same_v<T, int64_t>) {
+            const auto expected = type == DataType::TIMESTAMPTZ
+                                      ? 1700000000000000LL + row
+                                      : row * 1000;
+            EXPECT_EQ(values[i], expected) << row;
+        } else if constexpr (std::is_same_v<T, float>) {
+            EXPECT_NEAR(values[i], static_cast<float>(row) * 1.5f, 1e-5) << row;
+        } else if constexpr (std::is_same_v<T, double>) {
+            EXPECT_NEAR(values[i], static_cast<double>(row) * 2.25, 1e-9)
+                << row;
+        }
+    }
+}
+
+void
+CheckStringLikeBatch(DataType type,
+                     const ChunkedColumnInterface::ScanBatch& batch) {
+    if (type == DataType::JSON) {
+        const auto* values = batch.values.data_as<Json>();
+        for (int64_t i = 0; i < batch.size; ++i) {
+            const auto row = batch.row_id_start + i;
+            EXPECT_EQ(batch.validity.IsValid(i), ExpectedValid(row)) << row;
+            if (ExpectedValid(row)) {
+                std::string_view view = values[i];
+                EXPECT_EQ(view, ExpectedString(type, row)) << row;
+            }
+        }
+        return;
+    }
+
+    const auto* values = batch.values.data_as<std::string_view>();
+    for (int64_t i = 0; i < batch.size; ++i) {
+        const auto row = batch.row_id_start + i;
+        EXPECT_EQ(batch.validity.IsValid(i), ExpectedValid(row)) << row;
+        if (ExpectedValid(row)) {
+            EXPECT_EQ(values[i], ExpectedString(type, row)) << row;
+        }
+    }
+}
+
+void
+CheckArrayBatch(const ChunkedColumnInterface::ScanBatch& batch) {
+    const auto* values = batch.values.data_as<ArrayView>();
+    for (int64_t i = 0; i < batch.size; ++i) {
+        const auto row = batch.row_id_start + i;
+        EXPECT_EQ(batch.validity.IsValid(i), ExpectedValid(row)) << row;
+        if (!ExpectedValid(row)) {
+            continue;
+        }
+        EXPECT_EQ(values[i].length(), 3) << row;
+        EXPECT_EQ(values[i].get_data<int64_t>(0), row) << row;
+        EXPECT_EQ(values[i].get_data<int64_t>(1), row + 1) << row;
+        EXPECT_EQ(values[i].get_data<int64_t>(2), row + 2) << row;
+    }
+}
+
+void
+CheckDataScan(VortexColumn& column, DataType type) {
+    auto options = ChunkedColumnInterface::ScanOptions::ForData(
+        0,
+        kNullableRows,
+        ChunkedColumnInterface::ScanProjection::Data,
+        ScanKindForType(type));
+
+    auto result = column.Scan(nullptr, options);
+    ASSERT_NE(result, nullptr);
+
+    ChunkedColumnInterface::ScanBatch batch;
+    int64_t seen = 0;
+    while (result->Next(&batch)) {
+        ASSERT_GT(batch.size, 0);
+        EXPECT_TRUE(batch.row_ids.empty());
+        EXPECT_TRUE(batch.validity.nullable);
+        switch (type) {
+            case DataType::BOOL:
+                CheckFixedWidthBatch<bool>(type, batch);
+                break;
+            case DataType::INT8:
+                CheckFixedWidthBatch<int8_t>(type, batch);
+                break;
+            case DataType::INT16:
+                CheckFixedWidthBatch<int16_t>(type, batch);
+                break;
+            case DataType::INT32:
+                CheckFixedWidthBatch<int32_t>(type, batch);
+                break;
+            case DataType::INT64:
+            case DataType::TIMESTAMPTZ:
+                CheckFixedWidthBatch<int64_t>(type, batch);
+                break;
+            case DataType::FLOAT:
+                CheckFixedWidthBatch<float>(type, batch);
+                break;
+            case DataType::DOUBLE:
+                CheckFixedWidthBatch<double>(type, batch);
+                break;
+            case DataType::STRING:
+            case DataType::VARCHAR:
+            case DataType::TEXT:
+            case DataType::JSON:
+            case DataType::GEOMETRY:
+                CheckStringLikeBatch(type, batch);
+                break;
+            case DataType::ARRAY:
+                CheckArrayBatch(batch);
+                break;
+            default:
+                FAIL() << "unexpected data type";
+        }
+        seen += batch.size;
+    }
+    EXPECT_EQ(seen, kNullableRows);
+}
+
+}  // namespace
+
+TEST(VortexColumnTest, ScanAndTake) {
+    auto schema = MakeSchema();
+    auto properties =
+        std::make_shared<milvus_storage::api::Properties>(MakeProperties());
+
+    auto dir =
+        std::filesystem::temp_directory_path() /
+        ("milvus_vortex_column_test_" + std::to_string(::getpid()) + "_" +
+         std::to_string(reinterpret_cast<uintptr_t>(properties.get())));
+    std::filesystem::create_directories(dir);
+    auto path = (dir / "cg0.vx").string();
+
+    auto file_info = WriteVortexFile(path, schema, *properties);
+    auto column_group = MakeColumnGroup(
+        {file_info},
+        properties,
+        {std::to_string(kIntFieldId), std::to_string(kStringFieldId)});
+
+    FieldMeta int_meta(FieldName("int_field"),
+                       FieldId(kIntFieldId),
+                       DataType::INT32,
+                       false,
+                       std::nullopt);
+    VortexColumn int_column(
+        FieldId(kIntFieldId), int_meta, properties, column_group);
+    EXPECT_EQ(int_column.NumRows(), 16);
+    EXPECT_EQ(int_column.num_chunks(), 1);
+
+    std::vector<int64_t> offsets{7, 1, 7, 15};
+    std::vector<int32_t> values(offsets.size());
+    int_column.BulkPrimitiveValueAt(
+        nullptr, values.data(), offsets.data(), offsets.size(), false);
+    EXPECT_EQ(values, (std::vector<int32_t>{70, 10, 70, 150}));
+
+    auto scan_values = CollectIntScanValues(int_column, 3, 5);
+    EXPECT_EQ(scan_values, (std::vector<int32_t>{30, 40, 50, 60, 70}));
+
+    FieldMeta string_meta(FieldName("string_field"),
+                          FieldId(kStringFieldId),
+                          DataType::VARCHAR,
+                          128,
+                          false,
+                          std::nullopt);
+    VortexColumn string_column(
+        FieldId(kStringFieldId), string_meta, properties, column_group);
+
+    std::vector<std::string> strings(offsets.size());
+    string_column.BulkRawStringAt(
+        nullptr,
+        [&](std::string_view value, size_t index, bool valid) {
+            EXPECT_TRUE(valid);
+            strings[index] = std::string(value);
+        },
+        offsets.data(),
+        offsets.size());
+    EXPECT_EQ(strings, (std::vector<std::string>{"v7", "v1", "v7", "v15"}));
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST(VortexColumnTest, UnsupportedInt32FilteredScanThrows) {
+    auto schema = MakeSchema();
+    auto properties =
+        std::make_shared<milvus_storage::api::Properties>(MakeProperties());
+
+    auto dir =
+        std::filesystem::temp_directory_path() /
+        ("milvus_vortex_column_filter_test_" + std::to_string(::getpid()) +
+         "_" + std::to_string(reinterpret_cast<uintptr_t>(properties.get())));
+    std::filesystem::create_directories(dir);
+
+    auto file_info =
+        WriteVortexFile((dir / "cg0.vx").string(), schema, *properties);
+    auto column_group =
+        MakeColumnGroup({file_info}, properties, {std::to_string(kIntFieldId)});
+
+    FieldMeta int_meta(FieldName("int_field"),
+                       FieldId(kIntFieldId),
+                       DataType::INT32,
+                       false,
+                       std::nullopt);
+    VortexColumn int_column(
+        FieldId(kIntFieldId), int_meta, properties, column_group);
+
+    auto unary_options = ChunkedColumnInterface::ScanOptions::ForUnary(
+        3, 10, proto::plan::OpType::GreaterThan, IntValue(80));
+    EXPECT_FALSE(int_column.SupportsScanPushdown(unary_options));
+    EXPECT_THROW(CollectFilteredRowIdPayload(int_column, unary_options),
+                 std::exception);
+
+    auto range_options = ChunkedColumnInterface::ScanOptions::ForBinaryRange(
+        2, 10, IntValue(40), false, IntValue(90), true);
+    EXPECT_FALSE(int_column.SupportsScanPushdown(range_options));
+    EXPECT_THROW(CollectFilteredRowIdPayload(int_column, range_options),
+                 std::exception);
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST(VortexColumnTest, MultiFileTakeAndScan) {
+    auto schema = MakeSchema();
+    auto properties =
+        std::make_shared<milvus_storage::api::Properties>(MakeProperties());
+
+    auto dir =
+        std::filesystem::temp_directory_path() /
+        ("milvus_vortex_column_multifile_test_" + std::to_string(::getpid()) +
+         "_" + std::to_string(reinterpret_cast<uintptr_t>(properties.get())));
+    std::filesystem::create_directories(dir);
+
+    auto file0 =
+        WriteVortexFile((dir / "cg0.vx").string(), schema, *properties, 0);
+    auto file1 =
+        WriteVortexFile((dir / "cg1.vx").string(), schema, *properties, 16);
+    auto column_group = MakeColumnGroup(
+        {file0, file1}, properties, {std::to_string(kIntFieldId)});
+
+    FieldMeta int_meta(FieldName("int_field"),
+                       FieldId(kIntFieldId),
+                       DataType::INT32,
+                       false,
+                       std::nullopt);
+    VortexColumn int_column(
+        FieldId(kIntFieldId), int_meta, properties, column_group);
+    EXPECT_EQ(int_column.NumRows(), 32);
+    EXPECT_EQ(int_column.num_chunks(), 2);
+    EXPECT_EQ(int_column.chunk_row_nums(0), 16);
+    EXPECT_EQ(int_column.chunk_row_nums(1), 16);
+
+    std::vector<int64_t> offsets{0, 15, 16, 17, 31, 16};
+    std::vector<int32_t> values(offsets.size());
+    int_column.BulkPrimitiveValueAt(
+        nullptr, values.data(), offsets.data(), offsets.size(), false);
+    EXPECT_EQ(values, (std::vector<int32_t>{0, 150, 160, 170, 310, 160}));
+
+    auto scan_values = CollectIntScanValues(int_column, 18, 4);
+    EXPECT_EQ(scan_values, (std::vector<int32_t>{180, 190, 200, 210}));
+
+    auto cross_chunk_options =
+        ChunkedColumnInterface::ScanOptions::ForData(14, 5);
+    auto scan_result = int_column.Scan(nullptr, cross_chunk_options);
+    ASSERT_NE(scan_result, nullptr);
+
+    std::vector<int64_t> batch_starts;
+    std::vector<int64_t> batch_sizes;
+    std::vector<int32_t> cross_chunk_values;
+    ChunkedColumnInterface::ScanBatch batch;
+    while (scan_result->Next(&batch)) {
+        batch_starts.emplace_back(batch.row_id_start);
+        batch_sizes.emplace_back(batch.size);
+        const auto* data = batch.values.data_as<int32_t>();
+        cross_chunk_values.insert(
+            cross_chunk_values.end(), data, data + batch.size);
+    }
+    EXPECT_EQ(batch_starts, (std::vector<int64_t>{14, 16}));
+    EXPECT_EQ(batch_sizes, (std::vector<int64_t>{2, 3}));
+    EXPECT_EQ(cross_chunk_values,
+              (std::vector<int32_t>{140, 150, 160, 170, 180}));
+
+    auto filter_options = ChunkedColumnInterface::ScanOptions::ForUnary(
+        14, 6, proto::plan::OpType::GreaterThan, IntValue(160));
+    EXPECT_THROW(CollectFilteredRowIdPayload(int_column, filter_options),
+                 std::exception);
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST(VortexColumnTest, MultiFieldColumnsShareColumnGroup) {
+    auto schema = MakeSchema();
+    auto properties =
+        std::make_shared<milvus_storage::api::Properties>(MakeProperties());
+
+    auto dir =
+        std::filesystem::temp_directory_path() /
+        ("milvus_vortex_column_group_test_" + std::to_string(::getpid()) + "_" +
+         std::to_string(reinterpret_cast<uintptr_t>(properties.get())));
+    std::filesystem::create_directories(dir);
+
+    auto file_info =
+        WriteVortexFile((dir / "cg0.vx").string(), schema, *properties);
+    auto column_group = std::make_shared<VortexColumnGroup>(
+        std::vector<VortexColumn::FileInfo>{file_info},
+        properties,
+        std::vector<std::string>{std::to_string(kIntFieldId),
+                                 std::to_string(kStringFieldId)},
+        CacheWarmupPolicy::CacheWarmupPolicy_Disable,
+        nullptr);
+
+    FieldMeta int_meta(FieldName("int_field"),
+                       FieldId(kIntFieldId),
+                       DataType::INT32,
+                       false,
+                       std::nullopt);
+    VortexColumn int_column(
+        FieldId(kIntFieldId), int_meta, properties, column_group);
+
+    FieldMeta string_meta(FieldName("string_field"),
+                          FieldId(kStringFieldId),
+                          DataType::VARCHAR,
+                          128,
+                          false,
+                          std::nullopt);
+    VortexColumn string_column(
+        FieldId(kStringFieldId), string_meta, properties, column_group);
+
+    EXPECT_EQ(int_column.NumRows(), 16);
+    EXPECT_EQ(string_column.NumRows(), 16);
+    EXPECT_EQ(CollectIntScanValues(int_column, 4, 4),
+              (std::vector<int32_t>{40, 50, 60, 70}));
+    EXPECT_EQ(CollectStringScanValues(string_column, 4, 4),
+              (std::vector<std::string>{"v4", "v5", "v6", "v7"}));
+
+    auto string_filter_options = ChunkedColumnInterface::ScanOptions::ForUnary(
+        0, 16, proto::plan::OpType::Equal, StringValue("v4"));
+    EXPECT_TRUE(string_column.SupportsScanPushdown(string_filter_options));
+    {
+        ScopedVortexScanPushdownEnable disable_pushdown(false);
+        EXPECT_FALSE(string_column.SupportsScanPushdown(string_filter_options));
+        EXPECT_THROW(
+            CollectFilteredRowIdPayload(string_column, string_filter_options),
+            std::exception);
+    }
+    EXPECT_TRUE(string_column.SupportsScanPushdown(string_filter_options));
+
+    auto filter_options = ChunkedColumnInterface::ScanOptions::ForBinaryRange(
+        0, 16, IntValue(30), true, IntValue(60), true);
+    EXPECT_FALSE(int_column.SupportsScanPushdown(filter_options));
+    EXPECT_THROW(CollectFilteredRowIdPayload(int_column, filter_options),
+                 std::exception);
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST(VortexColumnTest, NullableAllScalarTypesScanCorrectness) {
+    auto schema = MakeNullableSchema();
+    auto properties =
+        std::make_shared<milvus_storage::api::Properties>(MakeProperties());
+
+    auto dir =
+        std::filesystem::temp_directory_path() /
+        ("milvus_vortex_column_nullable_test_" + std::to_string(::getpid()) +
+         "_" + std::to_string(reinterpret_cast<uintptr_t>(properties.get())));
+    std::filesystem::create_directories(dir);
+
+    auto file_info = WriteNullableVortexFile(
+        (dir / "nullable.vx").string(), schema, *properties);
+
+    auto types = NullableLocalVortexTypes();
+    for (size_t i = 0; i < types.size(); ++i) {
+        const auto type = types[i];
+        FieldId field_id(kNullableFieldIdBase + static_cast<int64_t>(i));
+        auto column = MakeNullableColumn(type, field_id, file_info, properties);
+
+        ASSERT_EQ(column.NumRows(), kNullableRows);
+        ASSERT_TRUE(column.IsNullable());
+        CheckNoDataScan(column);
+        CheckDataScan(column, type);
+        if (IsVortexStringPushdownType(type)) {
+            CheckNullableFilteredScanReturnsValidity(column, type);
+        }
+    }
+
+    std::filesystem::remove_all(dir);
+}
+
+}  // namespace milvus

--- a/internal/core/src/mmap/VortexColumnTest.cpp
+++ b/internal/core/src/mmap/VortexColumnTest.cpp
@@ -49,14 +49,14 @@ std::shared_ptr<arrow::Schema>
 MakeSchema() {
     return arrow::schema({
         arrow::field(std::to_string(kIntFieldId), arrow::int32(), false),
-        arrow::field(std::to_string(kStringFieldId), arrow::binary(), false),
+        arrow::field(std::to_string(kStringFieldId), arrow::utf8(), false),
     });
 }
 
 std::shared_ptr<arrow::RecordBatch>
 MakeRecordBatch(int64_t begin, int64_t count) {
     arrow::Int32Builder int_builder;
-    arrow::BinaryBuilder string_builder;
+    arrow::StringBuilder string_builder;
     EXPECT_TRUE(int_builder.Reserve(count).ok());
     EXPECT_TRUE(string_builder.Reserve(count).ok());
     for (int64_t i = begin; i < begin + count; ++i) {
@@ -202,8 +202,7 @@ ExpectedString(DataType type, int64_t row);
 
 bool
 IsVortexStringPushdownType(DataType type) {
-    return type == DataType::STRING || type == DataType::VARCHAR ||
-           type == DataType::TEXT;
+    return type == DataType::STRING || type == DataType::VARCHAR;
 }
 
 class ScopedVortexScanPushdownEnable {
@@ -346,6 +345,7 @@ ArrowTypeForNullableField(DataType type) {
         case DataType::STRING:
         case DataType::VARCHAR:
         case DataType::TEXT:
+            return arrow::utf8();
         case DataType::JSON:
         case DataType::GEOMETRY:
             return arrow::binary();
@@ -493,7 +493,19 @@ BuildNullableArray(DataType type, int64_t begin, int64_t count) {
         }
         case DataType::STRING:
         case DataType::VARCHAR:
-        case DataType::TEXT:
+        case DataType::TEXT: {
+            arrow::StringBuilder builder;
+            for (int64_t row = begin; row < begin + count; ++row) {
+                if (!ExpectedValid(row)) {
+                    EXPECT_TRUE(builder.AppendNull().ok());
+                } else {
+                    EXPECT_TRUE(builder.Append(ExpectedString(type, row)).ok());
+                }
+            }
+            std::shared_ptr<arrow::Array> array;
+            EXPECT_TRUE(builder.Finish(&array).ok());
+            return array;
+        }
         case DataType::JSON:
         case DataType::GEOMETRY: {
             arrow::BinaryBuilder builder;
@@ -1028,6 +1040,13 @@ TEST(VortexColumnTest, NullableAllScalarTypesScanCorrectness) {
         CheckDataScan(column, type);
         if (IsVortexStringPushdownType(type)) {
             CheckNullableFilteredScanReturnsValidity(column, type);
+        } else if (type == DataType::TEXT) {
+            auto options = ChunkedColumnInterface::ScanOptions::ForUnary(
+                0,
+                kNullableRows,
+                proto::plan::OpType::Equal,
+                StringValue(ExpectedString(type, 8)));
+            EXPECT_FALSE(column.SupportsScanPushdown(options));
         }
     }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -109,6 +109,7 @@
 #include "mmap/ChunkedColumn.h"
 #include "mmap/ChunkedColumnGroup.h"
 #include "mmap/ChunkedColumnInterface.h"
+#include "mmap/VortexColumn.h"
 #include "mmap/VirtualPKChunkedColumn.h"
 #include "mmap/Types.h"
 #include "common/VirtualPK.h"
@@ -5353,6 +5354,138 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     bool global_use_mmap = is_vector ? mmap_config.GetVectorFieldEnableMmap()
                                      : mmap_config.GetScalarFieldEnableMmap();
     auto use_mmap = has_mmap_setting ? mmap_enabled : global_use_mmap;
+
+    // Storage format and local format are separate layers:
+    // - column_group->format describes the physical file format produced by
+    //   storage v3.
+    // - FieldMeta::local_format selects the Milvus-side column implementation.
+    // A local Vortex column can only be loaded when the whole physical column
+    // group is Vortex and every field in that group opts into local_format=vortex.
+    const bool is_physical_vortex_group =
+        column_group->format == STORAGE_FORMAT_VORTEX;
+    const auto local_vortex_field_ids = [&]() {
+        std::vector<FieldId> field_ids;
+        if (!is_physical_vortex_group) {
+            return field_ids;
+        }
+        field_ids.reserve(milvus_field_ids.size());
+        for (const auto& field_id : milvus_field_ids) {
+            const auto& field_meta = field_metas.at(field_id);
+            if (field_meta.get_local_format() == LOCAL_FORMAT_VORTEX) {
+                field_ids.emplace_back(field_id);
+            }
+        }
+        return field_ids;
+    }();
+    const bool use_local_vortex_group = !local_vortex_field_ids.empty();
+    if (use_local_vortex_group) {
+        AssertInfo(local_vortex_field_ids.size() == milvus_field_ids.size(),
+                   "vortex column group {} mixes vortex local-format fields "
+                   "with non-vortex fields, segment {}",
+                   index,
+                   get_segment_id());
+        for (const auto& field_id : milvus_field_ids) {
+            const auto& field_meta = field_metas.at(field_id);
+            AssertInfo(!IsVectorDataType(field_meta.get_data_type()),
+                       "vortex local_format is not supported for vector field "
+                       "{}",
+                       field_id.get());
+        }
+        AssertInfo(load_info->GetStorageVersion() == STORAGE_V3,
+                   "vortex local_format is only supported for storage v3, "
+                   "segment {}, column group {}, storage version {}",
+                   get_segment_id(),
+                   index,
+                   load_info->GetStorageVersion());
+        AssertInfo(!column_group->files.empty(),
+                   "vortex column group {} has no files, segment {}",
+                   index,
+                   get_segment_id());
+
+        const auto vortex_files = [&]() {
+            std::vector<VortexColumnGroup::FileInfo> files;
+            files.reserve(column_group->files.size());
+            for (const auto& file : column_group->files) {
+                files.emplace_back(VortexColumnGroup::FileInfo{
+                    file.path,
+                    file.start_index,
+                    file.end_index,
+                    file.Get<uint64_t>(milvus_storage::api::kPropertyFileSize,
+                                       0),
+                    file.Get<uint64_t>(milvus_storage::api::kPropertyFooterSize,
+                                       0)});
+            }
+            return files;
+        }();
+
+        auto vortex_field_name = [&](FieldId field_id) {
+            const auto& field_meta = field_metas.at(field_id);
+            return field_meta.is_external_field()
+                       ? field_meta.get_external_field()
+                       : std::to_string(field_id.get());
+        };
+        const auto vortex_field_names = [&]() {
+            std::vector<std::string> field_names;
+            field_names.reserve(local_vortex_field_ids.size());
+            for (const auto& field_id : local_vortex_field_ids) {
+                field_names.emplace_back(vortex_field_name(field_id));
+            }
+            return field_names;
+        }();
+        auto group_cache_warmup_policy = getCacheWarmupPolicy(
+            has_warmup_setting ? aggregated_warmup_policy : "",
+            /*is_vector=*/false,
+            /*is_index=*/false,
+            /*in_load_list=*/eager_load);
+        auto vortex_column_group =
+            std::make_shared<VortexColumnGroup>(vortex_files,
+                                                properties,
+                                                vortex_field_names,
+                                                group_cache_warmup_policy,
+                                                op_ctx);
+        const auto vortex_group_memory_size =
+            vortex_column_group->memory_size();
+        const auto vortex_group_field_count = local_vortex_field_ids.size();
+        const auto base_data_byte_size =
+            vortex_group_memory_size / vortex_group_field_count;
+        const auto data_byte_size_remainder =
+            vortex_group_memory_size % vortex_group_field_count;
+        size_t vortex_field_index = 0;
+        for (const auto& field_id : local_vortex_field_ids) {
+            const auto& field_meta = field_metas.at(field_id);
+            const auto data_byte_size =
+                base_data_byte_size +
+                (vortex_field_index < data_byte_size_remainder ? 1 : 0);
+            ++vortex_field_index;
+            auto column = std::make_shared<VortexColumn>(field_id,
+                                                         field_meta,
+                                                         properties,
+                                                         vortex_column_group,
+                                                         data_byte_size);
+            auto data_type = field_meta.get_data_type();
+            load_field_data_common(field_id,
+                                   column,
+                                   column->NumRows(),
+                                   data_type,
+                                   false,
+                                   true,
+                                   std::nullopt,
+                                   op_ctx,
+                                   is_replace);
+            if (field_id == TimestampFieldID) {
+                init_storage_v2_timestamp_index(column,
+                                                load_info->GetNumOfRows());
+            }
+        }
+        LOG_INFO(
+            "[StorageV3] segment {} loaded vortex column group {} with "
+            "{} fields and {} files",
+            get_segment_id(),
+            index,
+            local_vortex_field_ids.size(),
+            column_group->files.size());
+        return;
+    }
 
     // The set of columns this entry projects is exactly the field_ids the
     // diff handed us. For lazy entries, SegmentLoadInfo::ComputeDiffColumnGroups

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -513,6 +513,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                                  int64_t count,
                                  TargetBitmapView valid_result) const override;
 
+    std::shared_ptr<ChunkedColumnInterface>
+    GetChunkedColumn(FieldId field_id) const override {
+        return get_column(field_id);
+    }
+
  protected:
     // blob and row_count
     PinWrapper<SpanBase>

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -371,6 +371,11 @@ class SegmentInternalInterface : public SegmentInterface {
                                  int64_t count,
                                  TargetBitmapView valid_result) const = 0;
 
+    virtual std::shared_ptr<ChunkedColumnInterface>
+    GetChunkedColumn(FieldId field_id) const {
+        return nullptr;
+    }
+
     template <typename T>
     PinWrapper<Span<T>>
     chunk_data(milvus::OpContext* op_ctx,

--- a/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/SystemIndexTranslator.cpp
@@ -174,16 +174,12 @@ TimestampIndexTranslator::get_cells(
     CheckCancellation(
         ctx, segment_id_, "TimestampIndexTranslator::get_cells()");
 
-    // Pin column chunks temporarily to build the TimestampIndex, then release.
-    // TimestampIndexCell intentionally does NOT hold raw timestamp data or
-    // pins to GroupChunk cells — callers read raw timestamps by pinning the
-    // timestamp column directly. This avoids a DList deadlock where evicting
-    // this cell would unpin GroupChunk cells under the same list_mtx_.
-    auto all_chunks = column_->GetAllChunks(ctx);
+    // Read through Span instead of assuming GetChunk materializes as
+    // FixedWidthChunk. Vortex columns intentionally disable GetChunk paths.
     TimestampIndex index;
-    if (all_chunks.size() == 1) {
-        auto* fixed_chunk = static_cast<FixedWidthChunk*>(all_chunks[0].get());
-        auto span = fixed_chunk->Span();
+    if (column_->num_chunks() == 1) {
+        auto pin = column_->Span(ctx, 0);
+        const auto& span = pin.get();
         auto* ts_ptr = static_cast<const Timestamp*>(span.data());
         AssertInfo(static_cast<int64_t>(span.row_count()) == num_rows_,
                    "timestamp chunk row count {} != expected {}",
@@ -193,13 +189,13 @@ TimestampIndexTranslator::get_cells(
     } else {
         std::vector<Timestamp> temp(num_rows_);
         size_t offset = 0;
-        for (auto& pin : all_chunks) {
-            auto* fixed_chunk = static_cast<FixedWidthChunk*>(pin.get());
-            auto span = fixed_chunk->Span();
-            milvus::fastmem::FastMemcpy(
-                temp.data() + offset,
-                static_cast<const Timestamp*>(span.data()),
-                span.row_count() * sizeof(*temp.data()));
+        for (int64_t chunk_id = 0; chunk_id < column_->num_chunks();
+             ++chunk_id) {
+            auto pin = column_->Span(ctx, chunk_id);
+            const auto& span = pin.get();
+            std::copy_n(static_cast<const Timestamp*>(span.data()),
+                        span.row_count(),
+                        temp.data() + offset);
             offset += span.row_count();
         }
         AssertInfo(static_cast<int64_t>(offset) == num_rows_,

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -19,7 +19,7 @@ set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")
 
-message(STATUS "Building milvus-storage-${milvus-storage_SOURCE_VER} from source")
+message(STATUS "Building milvus-storage-${milvus-storage_VERSION} from source")
 message(STATUS ${CMAKE_BUILD_TYPE})
 
 if ( ENABLE_AZURE_FS STREQUAL "ON" )
@@ -30,6 +30,19 @@ endif ()
 
 # Disable benchmark for milvus-storage (we don't need it and it may have missing deps)
 set(WITH_BENCHMARK OFF CACHE BOOL "" FORCE)
+
+set(WITH_VORTEX ON CACHE BOOL "" FORCE )
+
+# milvus-storage's Rust bridge now depends on crates that require Rust 1.92.
+# The top-level CMake cache may have been initialized by other Rust components
+# that intentionally build with 1.89, so reset Corrosion's cached Rust toolchain
+# before adding milvus-storage. Use rustup's channel name so Corrosion can
+# append the current host triple on Linux and macOS.
+set(Rust_TOOLCHAIN "1.92" CACHE STRING "" FORCE)
+unset(Rust_COMPILER_CACHED CACHE)
+unset(Rust_CARGO_CACHED CACHE)
+unset(_CORROSION_RUSTC CACHE)
+unset(_CORROSION_CARGO CACHE)
 
 # Conan 2.x: CMAKE_PREFIX_PATH is set by conan_toolchain.cmake.
 # find_package(Protobuf) sets Protobuf_PROTOC_EXECUTABLE automatically.

--- a/internal/core/unittest/test_utils/DataGen.h
+++ b/internal/core/unittest/test_utils/DataGen.h
@@ -930,6 +930,7 @@ DataGen(SchemaPtr schema,
                 insert_cols(data, N, field_meta, random_valid);
                 break;
             }
+            case DataType::STRING:
             case DataType::VARCHAR: {
                 vector<std::string> data(N);
                 for (int i = 0; i < N / repeat_count; i++) {
@@ -1597,6 +1598,7 @@ CreateFieldDataFromDataArray(ssize_t raw_count,
                 }
                 break;
             }
+            case DataType::STRING:
             case DataType::VARCHAR: {
                 auto begin = data->scalars().string_data().data().begin();
                 auto end = data->scalars().string_data().data().end();
@@ -1605,10 +1607,11 @@ CreateFieldDataFromDataArray(ssize_t raw_count,
                     auto raw_valid_data = data->valid_data().data();
                     createNullableFieldData(data_raw.data(),
                                             raw_valid_data,
-                                            DataType::VARCHAR,
+                                            field_meta.get_data_type(),
                                             dim);
                 } else {
-                    createFieldData(data_raw.data(), DataType::VARCHAR, dim);
+                    createFieldData(
+                        data_raw.data(), field_meta.get_data_type(), dim);
                 }
                 break;
             }

--- a/internal/flushcommon/syncmgr/task.go
+++ b/internal/flushcommon/syncmgr/task.go
@@ -230,7 +230,7 @@ func (t *SyncTask) getColumnGroups(segmentInfo *metacache.SegmentInfo) []storage
 		for _, cg := range currentSplit {
 			// legacy split found, use legacy policy
 			if len(cg.Fields) == 0 {
-				result := storagecommon.SplitColumns(allFields, map[int64]storagecommon.ColumnStats{}, storagecommon.NewSelectedDataTypePolicy(), storagecommon.NewRemanentShortPolicy(-1))
+				result := storagecommon.SplitColumns(allFields, map[int64]storagecommon.ColumnStats{}, storagecommon.NewLocalFormatPolicy(), storagecommon.NewSelectedDataTypePolicy(), storagecommon.NewRemanentShortPolicy(-1))
 				result = storagecommon.FillColumnGroupFormats(result, paramtable.Get().DataNodeCfg.StorageFormat.GetValue())
 				mlog.Info(context.TODO(), "use legacy split policy", mlog.FieldSegmentID(t.segmentID), mlog.Stringers("columnGroups", result))
 				return result

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -346,6 +346,32 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("primary field rejects vortex local format", func(t *testing.T) {
+		collectionName := funcutil.GenRandomStr()
+		task := createCollectionTask{
+			Req: &milvuspb.CreateCollectionRequest{
+				Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+				CollectionName: collectionName,
+			},
+		}
+		schema := &schemapb.CollectionSchema{
+			Name: collectionName,
+			Fields: []*schemapb.FieldSchema{
+				{
+					Name:         "pk",
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.LocalFormatKey, Value: common.LocalFormatVortex},
+					},
+				},
+			},
+		}
+		err := task.validateSchema(context.TODO(), schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "local_format vortex is not supported for primary key field")
+	})
+
 	t.Run("has system fields", func(t *testing.T) {
 		collectionName := funcutil.GenRandomStr()
 		task := createCollectionTask{

--- a/internal/rootcoord/util.go
+++ b/internal/rootcoord/util.go
@@ -446,6 +446,9 @@ func checkFieldSchema(fieldSchemas []*schemapb.FieldSchema) error {
 		if err := checkDupKvPairs(fieldSchema.GetTypeParams(), "type"); err != nil {
 			return err
 		}
+		if err := validateLocalFormat(fieldSchema); err != nil {
+			return err
+		}
 		if err := checkDupKvPairs(fieldSchema.GetIndexParams(), "index"); err != nil {
 			return err
 		}
@@ -477,6 +480,9 @@ func checkStructArrayFieldSchema(schemas []*schemapb.StructArrayFieldSchema) err
 				return merr.WrapErrParameterInvalidMsg(msg)
 			}
 			if err := checkDupKvPairs(field.GetTypeParams(), "type"); err != nil {
+				return err
+			}
+			if err := validateLocalFormat(field); err != nil {
 				return err
 			}
 			if err := checkDupKvPairs(field.GetIndexParams(), "index"); err != nil {
@@ -543,6 +549,34 @@ func checkDupKvPairs(params []*commonpb.KeyValuePair, paramType string) error {
 			return merr.WrapErrParameterInvalidMsg("duplicated %s param key \"%s\"", paramType, kv.GetKey())
 		}
 		set.Insert(kv.GetKey())
+	}
+	return nil
+}
+
+func validateLocalFormat(fieldSchema *schemapb.FieldSchema) error {
+	for _, kv := range fieldSchema.GetTypeParams() {
+		if kv.GetKey() == common.LocalFormatKey {
+			switch kv.GetValue() {
+			case common.LocalFormatRaw:
+				// valid
+			case common.LocalFormatVortex:
+				if fieldSchema.GetIsPrimaryKey() {
+					return merr.WrapErrParameterInvalidMsg(
+						"local_format vortex is not supported for primary key field '%s'",
+						fieldSchema.GetName())
+				}
+				if typeutil.IsVectorType(fieldSchema.GetDataType()) {
+					return merr.WrapErrParameterInvalidMsg(
+						"local_format vortex is not supported for vector field '%s'",
+						fieldSchema.GetName())
+				}
+			default:
+				return merr.WrapErrParameterInvalidMsg(
+					"invalid local_format '%s' for field '%s', supported: raw, vortex",
+					kv.GetValue(), fieldSchema.GetName())
+			}
+			break
+		}
 	}
 	return nil
 }

--- a/internal/storagecommon/column_group_splitter.go
+++ b/internal/storagecommon/column_group_splitter.go
@@ -79,7 +79,8 @@ func SplitColumns(fields []*schemapb.FieldSchema, stats map[int64]ColumnStats, p
 
 func DefaultPolicies() []ColumnGroupSplitPolicy {
 	paramtable.Init()
-	result := make([]ColumnGroupSplitPolicy, 0, 4)
+	result := make([]ColumnGroupSplitPolicy, 0, 5)
+	result = append(result, NewLocalFormatPolicy())
 	if paramtable.Get().CommonCfg.Stv2SplitSystemColumn.GetAsBool() {
 		result = append(result, NewSystemColumnPolicy(paramtable.Get().CommonCfg.Stv2SystemColumnIncludePK.GetAsBool(),
 			paramtable.Get().CommonCfg.Stv2SystemColumnIncludePartitionKey.GetAsBool(),

--- a/internal/storagecommon/split_policy.go
+++ b/internal/storagecommon/split_policy.go
@@ -37,19 +37,50 @@ type currentSplit struct {
 	nextGroupID   int64
 	outputGroups  []ColumnGroup
 	processFields typeutil.Set[int64]
+	pendingGroups []localFormatGroup
 }
 
 func newCurrentSplit(fields []*schemapb.FieldSchema, stats map[int64]ColumnStats) *currentSplit {
+	pendingGroup := localFormatGroup{
+		fields:      make([]int64, 0, len(fields)),
+		indices:     make([]int, 0, len(fields)),
+		localFormat: "",
+	}
+	for idx, field := range fields {
+		pendingGroup.fields = append(pendingGroup.fields, field.GetFieldID())
+		pendingGroup.indices = append(pendingGroup.indices, idx)
+	}
 	return &currentSplit{
 		fields:        fields,
 		stats:         stats,
 		processFields: typeutil.NewSet[int64](),
+		pendingGroups: []localFormatGroup{pendingGroup},
 	}
 }
 
 func (c *currentSplit) SplitFields(groupID int64, fields []int64, indices []int) {
+	c.SplitFieldsWithFormat(groupID, fields, indices, c.columnGroupFormat(indices))
+}
+
+func (c *currentSplit) SplitFieldsWithFormat(groupID int64, fields []int64, indices []int, format string) {
 	c.processFields.Insert(fields...)
-	c.outputGroups = append(c.outputGroups, ColumnGroup{Columns: indices, GroupID: groupID, Fields: fields})
+	c.outputGroups = append(c.outputGroups, ColumnGroup{Columns: indices, GroupID: groupID, Fields: fields, Format: format})
+}
+
+func (c *currentSplit) columnGroupFormat(indices []int) string {
+	if len(indices) == 0 {
+		return ""
+	}
+	format := fieldLocalFormat(c.fields[indices[0]])
+	if format == common.LocalFormatRaw {
+		return ""
+	}
+	for _, idx := range indices[1:] {
+		if fieldLocalFormat(c.fields[idx]) != format {
+			return ""
+		}
+	}
+	return storageFormatForLocalFormat(format)
 }
 
 func (c *currentSplit) NextGroupID() int64 {
@@ -63,12 +94,70 @@ func (c *currentSplit) Processed(field int64) bool {
 }
 
 func (c *currentSplit) Range(f func(idx int, field *schemapb.FieldSchema)) {
-	for idx, field := range c.fields {
-		if c.Processed(field.GetFieldID()) {
-			continue
+	for _, group := range c.RangeGroups(nil) {
+		for _, idx := range group.indices {
+			f(idx, c.fields[idx])
 		}
-		f(idx, field)
 	}
+}
+
+func (c *currentSplit) RangeGroups(match func(*schemapb.FieldSchema) bool) []localFormatGroup {
+	pendingGroups := c.pendingGroups
+	if len(pendingGroups) == 0 {
+		pendingGroups = []localFormatGroup{{}}
+		for idx, field := range c.fields {
+			pendingGroups[0].fields = append(pendingGroups[0].fields, field.GetFieldID())
+			pendingGroups[0].indices = append(pendingGroups[0].indices, idx)
+		}
+	}
+
+	groups := make([]localFormatGroup, 0, len(pendingGroups))
+	for _, pendingGroup := range pendingGroups {
+		group := localFormatGroup{
+			fields:      make([]int64, 0, len(pendingGroup.fields)),
+			indices:     make([]int, 0, len(pendingGroup.indices)),
+			localFormat: pendingGroup.localFormat,
+		}
+		for _, idx := range pendingGroup.indices {
+			field := c.fields[idx]
+			if c.Processed(field.GetFieldID()) {
+				continue
+			}
+			if match != nil && !match(field) {
+				continue
+			}
+			group.fields = append(group.fields, field.GetFieldID())
+			group.indices = append(group.indices, idx)
+		}
+		if len(group.fields) > 0 {
+			groups = append(groups, group)
+		}
+	}
+	return groups
+}
+
+func (c *currentSplit) PartitionRemainingByLocalFormat() {
+	nextGroups := make([]localFormatGroup, 0, len(c.pendingGroups))
+	for _, pendingGroup := range c.RangeGroups(nil) {
+		groupsByFormat := make(map[string]*localFormatGroup)
+		formats := make([]string, 0, 2)
+		for _, idx := range pendingGroup.indices {
+			field := c.fields[idx]
+			format := fieldLocalFormat(field)
+			group := groupsByFormat[format]
+			if group == nil {
+				formats = append(formats, format)
+				group = &localFormatGroup{localFormat: format}
+				groupsByFormat[format] = group
+			}
+			group.fields = append(group.fields, field.GetFieldID())
+			group.indices = append(group.indices, idx)
+		}
+		for _, format := range formats {
+			nextGroups = append(nextGroups, *groupsByFormat[format])
+		}
+	}
+	c.pendingGroups = nextGroups
 }
 
 // ColumnGroupSplitPolicy interface for column group split policy.
@@ -76,7 +165,7 @@ type ColumnGroupSplitPolicy interface {
 	Split(currentSplit *currentSplit) *currentSplit
 }
 
-// selectedDataTypePolicy split widt datatype (vector, text) to a new column group.
+// selectedDataTypePolicy splits wide data types (vector, text) to new column groups.
 type selectedDataTypePolicy struct{}
 
 func (p *selectedDataTypePolicy) Split(currentSplit *currentSplit) *currentSplit {
@@ -91,6 +180,39 @@ func (p *selectedDataTypePolicy) Split(currentSplit *currentSplit) *currentSplit
 
 func NewSelectedDataTypePolicy() ColumnGroupSplitPolicy {
 	return &selectedDataTypePolicy{}
+}
+
+type localFormatPolicy struct{}
+
+type localFormatGroup struct {
+	fields      []int64
+	indices     []int
+	localFormat string
+}
+
+func fieldLocalFormat(field *schemapb.FieldSchema) string {
+	for _, kv := range field.GetTypeParams() {
+		if kv.GetKey() == common.LocalFormatKey {
+			return kv.GetValue()
+		}
+	}
+	return common.LocalFormatRaw
+}
+
+func storageFormatForLocalFormat(format string) string {
+	if format == common.LocalFormatVortex {
+		return common.LocalFormatVortex
+	}
+	return ""
+}
+
+func (p *localFormatPolicy) Split(currentSplit *currentSplit) *currentSplit {
+	currentSplit.PartitionRemainingByLocalFormat()
+	return currentSplit
+}
+
+func NewLocalFormatPolicy() ColumnGroupSplitPolicy {
+	return &localFormatPolicy{}
 }
 
 // systemColumnPolicy split system columns to a new column group
@@ -110,20 +232,16 @@ func NewSystemColumnPolicy(includePK bool, includePartKey bool, includeClusterin
 }
 
 func (p *systemColumnPolicy) Split(currentSplit *currentSplit) *currentSplit {
-	systemFields := make([]int64, 0, 3)
-	systemFieldIndices := make([]int, 0, 3)
-
-	currentSplit.Range(func(idx int, field *schemapb.FieldSchema) {
-		if field.GetFieldID() < common.StartOfUserFieldID ||
+	groups := currentSplit.RangeGroups(func(field *schemapb.FieldSchema) bool {
+		return field.GetFieldID() < common.StartOfUserFieldID ||
 			(p.includePrimaryKey && field.GetIsPrimaryKey()) ||
 			(p.includePartitionKey && field.GetIsPartitionKey()) ||
-			(p.includeClusteringKey && field.GetIsClusteringKey()) {
-			systemFields = append(systemFields, field.GetFieldID())
-			systemFieldIndices = append(systemFieldIndices, idx)
-		}
+			(p.includeClusteringKey && field.GetIsClusteringKey())
 	})
 
-	currentSplit.SplitFields(currentSplit.NextGroupID(), systemFields, systemFieldIndices)
+	for _, group := range groups {
+		currentSplit.SplitFields(currentSplit.NextGroupID(), group.fields, group.indices)
+	}
 	return currentSplit
 }
 
@@ -137,21 +255,22 @@ func NewRemanentShortPolicy(maxGroupSize int) ColumnGroupSplitPolicy {
 }
 
 func (p *remanentShortPolicy) Split(currentSplit *currentSplit) *currentSplit {
-	var shortFields []int64
-	var shortFieldIndices []int
-
-	currentSplit.Range(func(idx int, field *schemapb.FieldSchema) {
-		shortFields = append(shortFields, field.GetFieldID())
-		shortFieldIndices = append(shortFieldIndices, idx)
-		if p.maxGroupSize > 0 && len(shortFields) >= p.maxGroupSize {
-			currentSplit.SplitFields(currentSplit.NextGroupID(), shortFields, shortFieldIndices)
-			shortFields = make([]int64, 0, p.maxGroupSize)
-			shortFieldIndices = make([]int, 0, p.maxGroupSize)
+	for _, group := range currentSplit.RangeGroups(nil) {
+		shortFields := make([]int64, 0, len(group.fields))
+		shortFieldIndices := make([]int, 0, len(group.indices))
+		for i, fieldID := range group.fields {
+			shortFields = append(shortFields, fieldID)
+			shortFieldIndices = append(shortFieldIndices, group.indices[i])
+			if p.maxGroupSize > 0 && len(shortFields) >= p.maxGroupSize {
+				currentSplit.SplitFields(currentSplit.NextGroupID(), shortFields, shortFieldIndices)
+				shortFields = make([]int64, 0, p.maxGroupSize)
+				shortFieldIndices = make([]int, 0, p.maxGroupSize)
+			}
 		}
-	})
 
-	if len(shortFields) > 0 {
-		currentSplit.SplitFields(currentSplit.NextGroupID(), shortFields, shortFieldIndices)
+		if len(shortFields) > 0 {
+			currentSplit.SplitFields(currentSplit.NextGroupID(), shortFields, shortFieldIndices)
+		}
 	}
 
 	return currentSplit

--- a/internal/storagecommon/split_policy_test.go
+++ b/internal/storagecommon/split_policy_test.go
@@ -21,7 +21,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -39,6 +41,17 @@ func AssertSplitEqual(t *testing.T, expect, actual *currentSplit) {
 		assert.Equal(t, expect.outputGroups[i].GroupID, actual.outputGroups[i].GroupID)
 		assert.Equal(t, expect.outputGroups[i].Columns, actual.outputGroups[i].Columns)
 		assert.Equal(t, expect.outputGroups[i].Fields, actual.outputGroups[i].Fields)
+		assert.Equal(t, expect.outputGroups[i].Format, actual.outputGroups[i].Format)
+	}
+}
+
+func AssertPendingGroupsEqual(t *testing.T, expect []ColumnGroup, actual *currentSplit) {
+	groups := actual.RangeGroups(nil)
+	assert.Equal(t, len(expect), len(groups))
+	for i := range expect {
+		assert.Equal(t, expect[i].Columns, groups[i].indices)
+		assert.Equal(t, expect[i].Fields, groups[i].fields)
+		assert.Equal(t, expect[i].Format, storageFormatForLocalFormat(groups[i].localFormat))
 	}
 }
 
@@ -47,6 +60,15 @@ func TestWideDataTypePolicy(t *testing.T) {
 		tag    string
 		input  *currentSplit
 		expect *currentSplit
+	}
+
+	localFormatParam := func(format string) []*commonpb.KeyValuePair {
+		return []*commonpb.KeyValuePair{
+			{
+				Key:   common.LocalFormatKey,
+				Value: format,
+			},
+		}
 	}
 
 	cases := []testCase{
@@ -73,6 +95,31 @@ func TestWideDataTypePolicy(t *testing.T) {
 						GroupID: 100,
 						Columns: []int{2},
 						Fields:  []int64{100},
+					},
+				},
+			},
+		},
+		{
+			tag: "text_with_vortex_local_format",
+			input: newCurrentSplit([]*schemapb.FieldSchema{
+				{
+					FieldID:  100,
+					DataType: schemapb.DataType_Int64,
+				},
+				{
+					FieldID:    101,
+					DataType:   schemapb.DataType_Text,
+					TypeParams: localFormatParam(common.LocalFormatVortex),
+				},
+			}, nil),
+			expect: &currentSplit{
+				processFields: typeutil.NewSet[int64](101),
+				outputGroups: []ColumnGroup{
+					{
+						GroupID: 101,
+						Columns: []int{1},
+						Fields:  []int64{101},
+						Format:  common.LocalFormatVortex,
 					},
 				},
 			},
@@ -137,6 +184,224 @@ func TestWideDataTypePolicy(t *testing.T) {
 	}
 }
 
+func TestLocalFormatPolicy(t *testing.T) {
+	type testCase struct {
+		tag    string
+		input  *currentSplit
+		expect *currentSplit
+	}
+
+	localFormatParam := func(format string) []*commonpb.KeyValuePair {
+		return []*commonpb.KeyValuePair{
+			{
+				Key:   common.LocalFormatKey,
+				Value: format,
+			},
+		}
+	}
+
+	cases := []testCase{
+		{
+			tag: "mixed_local_formats",
+			input: newCurrentSplit([]*schemapb.FieldSchema{
+				{
+					FieldID:  100,
+					DataType: schemapb.DataType_Int64,
+				},
+				{
+					FieldID:    101,
+					DataType:   schemapb.DataType_VarChar,
+					TypeParams: localFormatParam(common.LocalFormatVortex),
+				},
+				{
+					FieldID:  102,
+					DataType: schemapb.DataType_Double,
+				},
+				{
+					FieldID:    103,
+					DataType:   schemapb.DataType_Int64,
+					TypeParams: localFormatParam(common.LocalFormatVortex),
+				},
+			}, nil),
+			expect: &currentSplit{
+				processFields: typeutil.NewSet[int64](),
+			},
+		},
+		{
+			tag: "single_vortex_local_format_partitions_without_output",
+			input: newCurrentSplit([]*schemapb.FieldSchema{
+				{
+					FieldID:    100,
+					DataType:   schemapb.DataType_Int64,
+					TypeParams: localFormatParam(common.LocalFormatVortex),
+				},
+				{
+					FieldID:    101,
+					DataType:   schemapb.DataType_Double,
+					TypeParams: localFormatParam(common.LocalFormatVortex),
+				},
+			}, nil),
+			expect: &currentSplit{
+				processFields: typeutil.NewSet[int64](),
+			},
+		},
+	}
+
+	policy := NewLocalFormatPolicy()
+	for _, tc := range cases {
+		t.Run(tc.tag, func(t *testing.T) {
+			result := policy.Split(tc.input)
+
+			AssertSplitEqual(t, tc.expect, result)
+			switch tc.tag {
+			case "mixed_local_formats":
+				AssertPendingGroupsEqual(t, []ColumnGroup{
+					{
+						Columns: []int{0, 2},
+						Fields:  []int64{100, 102},
+					},
+					{
+						Columns: []int{1, 3},
+						Fields:  []int64{101, 103},
+						Format:  common.LocalFormatVortex,
+					},
+				}, result)
+			case "single_vortex_local_format_partitions_without_output":
+				AssertPendingGroupsEqual(t, []ColumnGroup{
+					{
+						Columns: []int{0, 1},
+						Fields:  []int64{100, 101},
+						Format:  common.LocalFormatVortex,
+					},
+				}, result)
+			}
+		})
+	}
+}
+
+func TestSplitColumnsSeparatesLocalFormatsBeforeRemanent(t *testing.T) {
+	localFormatParam := func(format string) []*commonpb.KeyValuePair {
+		return []*commonpb.KeyValuePair{
+			{
+				Key:   common.LocalFormatKey,
+				Value: format,
+			},
+		}
+	}
+
+	fields := []*schemapb.FieldSchema{
+		{
+			FieldID:  100,
+			DataType: schemapb.DataType_Int64,
+		},
+		{
+			FieldID:    101,
+			DataType:   schemapb.DataType_Int64,
+			TypeParams: localFormatParam(common.LocalFormatVortex),
+		},
+		{
+			FieldID:  102,
+			DataType: schemapb.DataType_FloatVector,
+		},
+		{
+			FieldID:  103,
+			DataType: schemapb.DataType_Double,
+		},
+		{
+			FieldID:    104,
+			DataType:   schemapb.DataType_Int64,
+			TypeParams: localFormatParam(common.LocalFormatVortex),
+		},
+	}
+
+	result := SplitColumns(fields,
+		map[int64]ColumnStats{},
+		NewLocalFormatPolicy(),
+		NewSelectedDataTypePolicy(),
+		NewRemanentShortPolicy(-1))
+
+	assert.Equal(t, []ColumnGroup{
+		{
+			GroupID: 0,
+			Columns: []int{0, 3},
+			Fields:  []int64{100, 103},
+		},
+		{
+			GroupID: 1,
+			Columns: []int{1, 4},
+			Fields:  []int64{101, 104},
+			Format:  common.LocalFormatVortex,
+		},
+		{
+			GroupID: 102,
+			Columns: []int{2},
+			Fields:  []int64{102},
+		},
+	}, result)
+}
+
+func TestLocalFormatPolicyKeepsLaterSplitsWithinFormat(t *testing.T) {
+	localFormatParam := func(format string) []*commonpb.KeyValuePair {
+		return []*commonpb.KeyValuePair{
+			{
+				Key:   common.LocalFormatKey,
+				Value: format,
+			},
+		}
+	}
+
+	fields := []*schemapb.FieldSchema{
+		{
+			FieldID:  100,
+			DataType: schemapb.DataType_Int64,
+		},
+		{
+			FieldID:    101,
+			DataType:   schemapb.DataType_Int64,
+			TypeParams: localFormatParam(common.LocalFormatVortex),
+		},
+		{
+			FieldID:  102,
+			DataType: schemapb.DataType_Double,
+		},
+		{
+			FieldID:    103,
+			DataType:   schemapb.DataType_Double,
+			TypeParams: localFormatParam(common.LocalFormatVortex),
+		},
+	}
+
+	result := SplitColumns(fields,
+		map[int64]ColumnStats{},
+		NewLocalFormatPolicy(),
+		NewRemanentShortPolicy(1))
+
+	assert.Equal(t, []ColumnGroup{
+		{
+			GroupID: 0,
+			Columns: []int{0},
+			Fields:  []int64{100},
+		},
+		{
+			GroupID: 1,
+			Columns: []int{2},
+			Fields:  []int64{102},
+		},
+		{
+			GroupID: 2,
+			Columns: []int{1},
+			Fields:  []int64{101},
+			Format:  common.LocalFormatVortex,
+		},
+		{
+			GroupID: 3,
+			Columns: []int{3},
+			Fields:  []int64{103},
+			Format:  common.LocalFormatVortex,
+		},
+	}, result)
+}
+
 func TestSystemColumnPolicy(t *testing.T) {
 	type testCase struct {
 		tag                  string
@@ -145,6 +410,15 @@ func TestSystemColumnPolicy(t *testing.T) {
 		includeClusteringKey bool
 		input                *currentSplit
 		expect               *currentSplit
+	}
+
+	localFormatParam := func(format string) []*commonpb.KeyValuePair {
+		return []*commonpb.KeyValuePair{
+			{
+				Key:   common.LocalFormatKey,
+				Value: format,
+			},
+		}
 	}
 
 	cases := []testCase{
@@ -177,6 +451,50 @@ func TestSystemColumnPolicy(t *testing.T) {
 						GroupID: 0,
 						Columns: []int{0, 1, 2},
 						Fields:  []int64{0, 1, 100},
+					},
+				},
+			},
+		},
+		{
+			tag: "include_pk_respects_local_format_partitions",
+			input: func() *currentSplit {
+				split := newCurrentSplit([]*schemapb.FieldSchema{
+					{
+						FieldID:  0,
+						DataType: schemapb.DataType_Int64,
+					},
+					{
+						FieldID:  1,
+						DataType: schemapb.DataType_Int64,
+					},
+					{
+						FieldID:      100,
+						DataType:     schemapb.DataType_Int64,
+						IsPrimaryKey: true,
+						TypeParams:   localFormatParam(common.LocalFormatVortex),
+					},
+					{
+						FieldID:  101,
+						DataType: schemapb.DataType_FloatVector,
+					},
+				}, nil)
+				split.PartitionRemainingByLocalFormat()
+				return split
+			}(),
+			includePK: true,
+			expect: &currentSplit{
+				processFields: typeutil.NewSet[int64](0, 1, 100),
+				outputGroups: []ColumnGroup{
+					{
+						GroupID: 0,
+						Columns: []int{0, 1},
+						Fields:  []int64{0, 1},
+					},
+					{
+						GroupID: 1,
+						Columns: []int{2},
+						Fields:  []int64{100},
+						Format:  common.LocalFormatVortex,
 					},
 				},
 			},
@@ -533,6 +851,42 @@ func TestAvgSizePolicy(t *testing.T) {
 						GroupID: 101,
 						Columns: []int{3},
 						Fields:  []int64{101},
+					},
+				},
+			},
+		},
+		{
+			tag: "over_threshold_preserves_vortex_local_format",
+			input: newCurrentSplit([]*schemapb.FieldSchema{
+				{
+					FieldID:  100,
+					DataType: schemapb.DataType_Int64,
+				},
+				{
+					FieldID:  101,
+					DataType: schemapb.DataType_VarChar,
+					TypeParams: []*commonpb.KeyValuePair{
+						{
+							Key:   common.LocalFormatKey,
+							Value: common.LocalFormatVortex,
+						},
+					},
+				},
+			}, map[int64]ColumnStats{
+				101: {
+					AvgSize: 512,
+					MaxSize: 1024,
+				},
+			}),
+			sizeThreshold: 500,
+			expect: &currentSplit{
+				processFields: typeutil.NewSet[int64](101),
+				outputGroups: []ColumnGroup{
+					{
+						GroupID: 101,
+						Columns: []int{1},
+						Fields:  []int64{101},
+						Format:  common.LocalFormatVortex,
 					},
 				},
 			},

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -60,7 +60,7 @@ var (
 	PropertyFSUseCRC32CChecksum   = C.GoString(C.loon_properties_fs_use_crc32c_checksum)
 
 	PropertyWriterPolicy             = C.GoString(C.loon_properties_writer_policy)
-	PropertyWriterFormat             = "writer.format"
+	PropertyWriterFormat             = C.GoString(C.loon_properties_writer_format)
 	PropertyWriterSchemaBasedPattern = C.GoString(C.loon_properties_writer_schema_base_patterns)
 	PropertyWriterSchemaBasedFormats = "writer.split.schema_based.formats"
 

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -655,6 +655,15 @@ func SetupCoreConfigChangelCallback() {
 			return nil
 		})
 
+		paramtable.Get().QueryNodeCfg.EnableVortexScanPushdown.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+			enable, err := strconv.ParseBool(newValue)
+			if err != nil {
+				return err
+			}
+			UpdateDefaultVortexScanPushdownEnable(enable)
+			return nil
+		})
+
 		paramtable.Get().QueryNodeCfg.EnableLatestDeleteSnapshotOptimization.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
 			enable, err := strconv.ParseBool(newValue)
 			if err != nil {

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -134,6 +134,9 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	cDeleteDumpBatchSize := C.int64_t(paramtable.Get().QueryNodeCfg.DeleteDumpBatchSize.GetAsInt64())
 	C.SetDefaultDeleteDumpBatchSize(cDeleteDumpBatchSize)
 
+	cVortexScanPushdownEnabled := C.bool(paramtable.Get().QueryNodeCfg.EnableVortexScanPushdown.GetAsBool())
+	C.SetDefaultVortexScanPushdownEnable(cVortexScanPushdownEnabled)
+
 	cEnableLatestDeleteSnapshotOptimization := C.bool(paramtable.Get().QueryNodeCfg.EnableLatestDeleteSnapshotOptimization.GetAsBool())
 	C.SetEnableLatestDeleteSnapshotOptimization(cEnableLatestDeleteSnapshotOptimization)
 

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -79,6 +79,10 @@ func UpdateDefaultDeleteDumpBatchSize(size int) {
 	C.SetDefaultDeleteDumpBatchSize(C.int64_t(size))
 }
 
+func UpdateDefaultVortexScanPushdownEnable(enable bool) {
+	C.SetDefaultVortexScanPushdownEnable(C.bool(enable))
+}
+
 func UpdateDefaultOptimizeExprEnable(enable bool) {
 	C.SetDefaultOptimizeExprEnable(C.bool(enable))
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -315,9 +315,16 @@ const (
 	FieldDescriptionKey = "field.description"
 )
 
+// local format type
+const (
+	LocalFormatRaw    = "raw"
+	LocalFormatVortex = "vortex"
+)
+
 // common properties
 const (
 	MmapEnabledKey             = "mmap.enabled"
+	LocalFormatKey             = "local_format"
 	LoadPriorityKey            = "load_priority"
 	PartitionKeyIsolationKey   = "partitionkey.isolation"
 	FieldSkipLoadKey           = "field.skipLoad"

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3658,6 +3658,8 @@ type queryNodeConfig struct {
 	// are packed into cells so rgs_per_cell * avg_rg_size ≈ this value.
 	StorageV2CellTargetSizeBytes ParamItem `refreshable:"true"`
 
+	EnableVortexScanPushdown ParamItem `refreshable:"true"`
+
 	EnableWorkerSQCostMetrics ParamItem `refreshable:"true"`
 
 	ExprEvalBatchSize ParamItem `refreshable:"false"`
@@ -4837,6 +4839,15 @@ user-task-polling:
 		},
 	}
 	p.StorageV2CellTargetSizeBytes.Init(base.mgr)
+
+	p.EnableVortexScanPushdown = ParamItem{
+		Key:          "queryNode.segcore.enableVortexScanPushdown",
+		Version:      "3.0.0",
+		DefaultValue: "true",
+		Doc:          "Enable Vortex local-format varchar filter pushdown through row-id scan.",
+		Export:       true,
+	}
+	p.EnableVortexScanPushdown.Init(base.mgr)
 
 	p.EnableWorkerSQCostMetrics = ParamItem{
 		Key:          "queryNode.enableWorkerSQCostMetrics",


### PR DESCRIPTION
## Summary
Support Vortex as a local scalar field format for V3 sealed segments, including local format metadata propagation, Vortex column loading, and scan-based expression evaluation paths.

Wire the Milvus side to the local milvus-storage Vortex reader path and add generated proto/storage config fields needed to pass the format through the storage stack.

issue: #50304

design doc: docs/design-docs/design_docs/20260305-local_format.md