### PR TITLE
fix: [cp2.6] preserve dynamic field data during partial update

### DIFF
--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -17,7 +17,6 @@ package proxy
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -1047,45 +1046,6 @@ func GenNullableFieldData(field *schemapb.FieldSchema, upsertIDSize int) (*schem
 	default:
 		return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined data type:%s", field.DataType.String()))
 	}
-}
-
-// checkDynamicFieldDataForPartialUpdate is a relaxed version of checkDynamicFieldData
-// for partial updates. After schema evolution, $meta may legitimately contain keys
-// matching static field names (e.g., a dynamic field "end_timestamp" that was later
-// added as a static column). This function validates JSON format and rejects the
-// reserved $meta key, but skips the static field name conflict check so that
-// existing dynamic field data is preserved.
-func checkDynamicFieldDataForPartialUpdate(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
-	for _, data := range insertMsg.FieldsData {
-		if data.IsDynamic {
-			data.FieldName = common.MetaFieldName
-			if !schema.EnableDynamicField {
-				return fmt.Errorf("without dynamic schema enabled, the field name cannot be set to %s", common.MetaFieldName)
-			}
-			for _, rowData := range data.GetScalars().GetJsonData().GetData() {
-				jsonData := make(map[string]interface{})
-				if err := json.Unmarshal(rowData, &jsonData); err != nil {
-					return merr.WrapErrIoFailedReason(err.Error())
-				}
-				if _, ok := jsonData[common.MetaFieldName]; ok {
-					return fmt.Errorf("cannot set json key to: %s", common.MetaFieldName)
-				}
-				// Note: we intentionally skip the static field name check here.
-				// For partial updates, merged data from queryPreExecute may contain
-				// $meta keys matching static field names due to schema evolution.
-				// This is expected — the data was already stored and must be preserved.
-			}
-			return nil
-		}
-	}
-	// No dynamic field found — auto-generate empty ones
-	defaultData := make([][]byte, insertMsg.NRows())
-	for i := range defaultData {
-		defaultData[i] = []byte("{}")
-	}
-	dynamicData := autoGenDynamicFieldData(defaultData)
-	insertMsg.FieldsData = append(insertMsg.FieldsData, dynamicData)
-	return nil
 }
 
 func (it *upsertTask) insertPreExecute(ctx context.Context) error {

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -1049,46 +1049,43 @@ func GenNullableFieldData(field *schemapb.FieldSchema, upsertIDSize int) (*schem
 	}
 }
 
-// cleanupDynamicFieldForPartialUpdate removes keys from the $meta dynamic field
-// JSON that conflict with static field names. After schema evolution, existing
-// $meta data may contain keys that now match newly added static columns. Only the
-// conflicting keys are stripped; all other dynamic field data is preserved.
-func cleanupDynamicFieldForPartialUpdate(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) {
-	staticFieldNames := make(map[string]bool)
-	for _, f := range schema.GetFields() {
-		if !f.GetIsDynamic() {
-			staticFieldNames[f.GetName()] = true
+// checkDynamicFieldDataForPartialUpdate is a relaxed version of checkDynamicFieldData
+// for partial updates. After schema evolution, $meta may legitimately contain keys
+// matching static field names (e.g., a dynamic field "end_timestamp" that was later
+// added as a static column). This function validates JSON format and rejects the
+// reserved $meta key, but skips the static field name conflict check so that
+// existing dynamic field data is preserved.
+func checkDynamicFieldDataForPartialUpdate(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
+	for _, data := range insertMsg.FieldsData {
+		if data.IsDynamic {
+			data.FieldName = common.MetaFieldName
+			if !schema.EnableDynamicField {
+				return fmt.Errorf("without dynamic schema enabled, the field name cannot be set to %s", common.MetaFieldName)
+			}
+			for _, rowData := range data.GetScalars().GetJsonData().GetData() {
+				jsonData := make(map[string]interface{})
+				if err := json.Unmarshal(rowData, &jsonData); err != nil {
+					return merr.WrapErrIoFailedReason(err.Error())
+				}
+				if _, ok := jsonData[common.MetaFieldName]; ok {
+					return fmt.Errorf("cannot set json key to: %s", common.MetaFieldName)
+				}
+				// Note: we intentionally skip the static field name check here.
+				// For partial updates, merged data from queryPreExecute may contain
+				// $meta keys matching static field names due to schema evolution.
+				// This is expected — the data was already stored and must be preserved.
+			}
+			return nil
 		}
 	}
-	for _, fieldData := range insertMsg.FieldsData {
-		if !fieldData.GetIsDynamic() {
-			continue
-		}
-		jsonData := fieldData.GetScalars().GetJsonData()
-		if jsonData == nil {
-			continue
-		}
-		for i, rowBytes := range jsonData.Data {
-			var m map[string]interface{}
-			if err := json.Unmarshal(rowBytes, &m); err != nil {
-				continue
-			}
-			changed := false
-			for key := range m {
-				if staticFieldNames[key] {
-					delete(m, key)
-					changed = true
-				}
-			}
-			if changed {
-				newBytes, err := json.Marshal(m)
-				if err != nil {
-					continue
-				}
-				jsonData.Data[i] = newBytes
-			}
-		}
+	// No dynamic field found — auto-generate empty ones
+	defaultData := make([][]byte, insertMsg.NRows())
+	for i := range defaultData {
+		defaultData[i] = []byte("{}")
 	}
+	dynamicData := autoGenDynamicFieldData(defaultData)
+	insertMsg.FieldsData = append(insertMsg.FieldsData, dynamicData)
+	return nil
 }
 
 func (it *upsertTask) insertPreExecute(ctx context.Context) error {
@@ -1143,14 +1140,12 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 	it.result.SuccIndex = sliceIndex
 
 	if it.schema.EnableDynamicField {
+		var err error
 		if it.req.GetPartialUpdate() {
-			// For partial update, merged data from queryPreExecute may contain
-			// $meta keys matching static field names due to schema evolution.
-			// Remove only the conflicting keys so validation passes while
-			// preserving all other dynamic field data.
-			cleanupDynamicFieldForPartialUpdate(it.schema.CollectionSchema, it.upsertMsg.InsertMsg)
+			err = checkDynamicFieldDataForPartialUpdate(it.schema.CollectionSchema, it.upsertMsg.InsertMsg)
+		} else {
+			err = checkDynamicFieldData(it.schema.CollectionSchema, it.upsertMsg.InsertMsg)
 		}
-		err := checkDynamicFieldData(it.schema.CollectionSchema, it.upsertMsg.InsertMsg)
 		if err != nil {
 			return err
 		}

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -17,6 +17,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -1048,6 +1049,48 @@ func GenNullableFieldData(field *schemapb.FieldSchema, upsertIDSize int) (*schem
 	}
 }
 
+// cleanupDynamicFieldForPartialUpdate removes keys from the $meta dynamic field
+// JSON that conflict with static field names. After schema evolution, existing
+// $meta data may contain keys that now match newly added static columns. Only the
+// conflicting keys are stripped; all other dynamic field data is preserved.
+func cleanupDynamicFieldForPartialUpdate(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) {
+	staticFieldNames := make(map[string]bool)
+	for _, f := range schema.GetFields() {
+		if !f.GetIsDynamic() {
+			staticFieldNames[f.GetName()] = true
+		}
+	}
+	for _, fieldData := range insertMsg.FieldsData {
+		if !fieldData.GetIsDynamic() {
+			continue
+		}
+		jsonData := fieldData.GetScalars().GetJsonData()
+		if jsonData == nil {
+			continue
+		}
+		for i, rowBytes := range jsonData.Data {
+			var m map[string]interface{}
+			if err := json.Unmarshal(rowBytes, &m); err != nil {
+				continue
+			}
+			changed := false
+			for key := range m {
+				if staticFieldNames[key] {
+					delete(m, key)
+					changed = true
+				}
+			}
+			if changed {
+				newBytes, err := json.Marshal(m)
+				if err != nil {
+					continue
+				}
+				jsonData.Data[i] = newBytes
+			}
+		}
+	}
+}
+
 func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-Upsert-insertPreExecute")
 	defer sp.End()
@@ -1100,6 +1143,13 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 	it.result.SuccIndex = sliceIndex
 
 	if it.schema.EnableDynamicField {
+		if it.req.GetPartialUpdate() {
+			// For partial update, merged data from queryPreExecute may contain
+			// $meta keys matching static field names due to schema evolution.
+			// Remove only the conflicting keys so validation passes while
+			// preserving all other dynamic field data.
+			cleanupDynamicFieldForPartialUpdate(it.schema.CollectionSchema, it.upsertMsg.InsertMsg)
+		}
 		err := checkDynamicFieldData(it.schema.CollectionSchema, it.upsertMsg.InsertMsg)
 		if err != nil {
 			return err

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -1486,6 +1486,50 @@ func TestUpsertTask_queryPreExecute_ArrayPartialOpSkipsGenericReplace(t *testing
 	assert.Equal(t, []string{"new1"}, noteField.GetScalars().GetStringData().GetData())
 }
 
+func TestCleanupDynamicFieldForPartialUpdate(t *testing.T) {
+	// After schema evolution, $meta may contain keys matching static field names.
+	// cleanupDynamicFieldForPartialUpdate should strip only the conflicting keys
+	// while preserving all other dynamic field data.
+	schema := &schemapb.CollectionSchema{
+		Name:               "test_cleanup_collection",
+		EnableDynamicField: true,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "dfA", DataType: schemapb.DataType_Int64}, // static field matching $meta key
+			{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+		},
+	}
+
+	// $meta contains {"dfA": 111, "dfB": "keep_me", "dfC": 999}
+	// After cleanup, only "dfA" should be removed; "dfB" and "dfC" must remain.
+	metaJSON, _ := json.Marshal(map[string]interface{}{"dfA": 111, "dfB": "keep_me", "dfC": 999})
+	insertMsg := &msgstream.InsertMsg{
+		InsertRequest: &msgpb.InsertRequest{
+			FieldsData: []*schemapb.FieldData{
+				{
+					FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+						JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+					}}},
+				},
+			},
+		},
+	}
+
+	cleanupDynamicFieldForPartialUpdate(schema, insertMsg)
+
+	jsonData := insertMsg.FieldsData[0].GetScalars().GetJsonData().GetData()
+	assert.Len(t, jsonData, 1)
+
+	var m map[string]interface{}
+	err := json.Unmarshal(jsonData[0], &m)
+	assert.NoError(t, err)
+	assert.NotContains(t, m, "dfA", "conflicting static field 'dfA' should be stripped from $meta")
+	assert.Contains(t, m, "dfB", "non-conflicting key 'dfB' should be preserved")
+	assert.Equal(t, "keep_me", m["dfB"])
+	assert.Contains(t, m, "dfC", "non-conflicting key 'dfC' should be preserved")
+}
+
 // Test ToCompressedFormatNullable for Geometry and Timestamptz types
 func TestToCompressedFormatNullable_GeometryAndTimestamptz(t *testing.T) {
 	t.Run("timestamptz with null values", func(t *testing.T) {

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -1486,48 +1486,164 @@ func TestUpsertTask_queryPreExecute_ArrayPartialOpSkipsGenericReplace(t *testing
 	assert.Equal(t, []string{"new1"}, noteField.GetScalars().GetStringData().GetData())
 }
 
-func TestCleanupDynamicFieldForPartialUpdate(t *testing.T) {
-	// After schema evolution, $meta may contain keys matching static field names.
-	// cleanupDynamicFieldForPartialUpdate should strip only the conflicting keys
-	// while preserving all other dynamic field data.
-	schema := &schemapb.CollectionSchema{
-		Name:               "test_cleanup_collection",
-		EnableDynamicField: true,
-		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
-			{FieldID: 101, Name: "dfA", DataType: schemapb.DataType_Int64}, // static field matching $meta key
-			{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
-		},
-	}
+func TestCheckDynamicFieldDataForPartialUpdate(t *testing.T) {
+	t.Run("preserves $meta keys matching static field names after schema evolution", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "dfA", DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
 
-	// $meta contains {"dfA": 111, "dfB": "keep_me", "dfC": 999}
-	// After cleanup, only "dfA" should be removed; "dfB" and "dfC" must remain.
-	metaJSON, _ := json.Marshal(map[string]interface{}{"dfA": 111, "dfB": "keep_me", "dfC": 999})
-	insertMsg := &msgstream.InsertMsg{
-		InsertRequest: &msgpb.InsertRequest{
-			FieldsData: []*schemapb.FieldData{
-				{
-					FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
-					Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
-						JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
-					}}},
+		// $meta contains {"dfA": 111, "dfB": "keep_me", "dfC": 999}
+		// All keys must be preserved — including "dfA" which matches a static field name.
+		metaJSON, _ := json.Marshal(map[string]interface{}{"dfA": 111, "dfB": "keep_me", "dfC": 999})
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+						}}},
+					},
 				},
 			},
-		},
-	}
+		}
 
-	cleanupDynamicFieldForPartialUpdate(schema, insertMsg)
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
 
-	jsonData := insertMsg.FieldsData[0].GetScalars().GetJsonData().GetData()
-	assert.Len(t, jsonData, 1)
+		jsonData := insertMsg.FieldsData[0].GetScalars().GetJsonData().GetData()
+		assert.Len(t, jsonData, 1)
 
-	var m map[string]interface{}
-	err := json.Unmarshal(jsonData[0], &m)
-	assert.NoError(t, err)
-	assert.NotContains(t, m, "dfA", "conflicting static field 'dfA' should be stripped from $meta")
-	assert.Contains(t, m, "dfB", "non-conflicting key 'dfB' should be preserved")
-	assert.Equal(t, "keep_me", m["dfB"])
-	assert.Contains(t, m, "dfC", "non-conflicting key 'dfC' should be preserved")
+		var m map[string]interface{}
+		err = json.Unmarshal(jsonData[0], &m)
+		assert.NoError(t, err)
+		assert.Contains(t, m, "dfA", "key matching static field name must be preserved")
+		assert.Contains(t, m, "dfB", "non-conflicting key must be preserved")
+		assert.Equal(t, "keep_me", m["dfB"])
+		assert.Contains(t, m, "dfC", "non-conflicting key must be preserved")
+	})
+
+	t.Run("rejects $meta key in dynamic field", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		metaJSON := []byte(`{"$meta": "bad_value"}`)
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "$meta")
+	})
+
+	t.Run("rejects malformed JSON", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(`{invalid json`)}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects dynamic field when dynamic schema is disabled", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: false,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			},
+		}
+
+		metaJSON := []byte(`{"key": "value"}`)
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "without dynamic schema enabled")
+	})
+
+	t.Run("auto-generates empty dynamic field when none present", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			},
+		}
+
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				NumRows: 2,
+				Version: msgpb.InsertDataVersion_ColumnBased,
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "id", FieldId: 100, Type: schemapb.DataType_Int64,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_LongData{
+							LongData: &schemapb.LongArray{Data: []int64{1, 2}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
+		// Should have appended a dynamic field
+		assert.Len(t, insertMsg.FieldsData, 2)
+		assert.True(t, insertMsg.FieldsData[1].IsDynamic)
+		assert.Len(t, insertMsg.FieldsData[1].GetScalars().GetJsonData().GetData(), 2)
+	})
 }
 
 // Test ToCompressedFormatNullable for Geometry and Timestamptz types

--- a/internal/proxy/task_upsert_test.go
+++ b/internal/proxy/task_upsert_test.go
@@ -1644,6 +1644,216 @@ func TestCheckDynamicFieldDataForPartialUpdate(t *testing.T) {
 		assert.True(t, insertMsg.FieldsData[1].IsDynamic)
 		assert.Len(t, insertMsg.FieldsData[1].GetScalars().GetJsonData().GetData(), 2)
 	})
+
+	t.Run("strict checkDynamicFieldData rejects what partial update allows", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "end_timestamp", DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		makeMsg := func() *msgstream.InsertMsg {
+			metaJSON := []byte(`{"end_timestamp": 1234, "color": "red"}`)
+			return &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					FieldsData: []*schemapb.FieldData{
+						{
+							FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+							Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+								JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+							}}},
+						},
+					},
+				},
+			}
+		}
+
+		// Strict path must reject: $meta contains "end_timestamp" which is a static field
+		err := checkDynamicFieldData(schema, makeMsg())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "end_timestamp")
+
+		// Partial update path must allow the same data
+		err = checkDynamicFieldDataForPartialUpdate(schema, makeMsg())
+		assert.NoError(t, err)
+	})
+
+	t.Run("multiple rows with mixed dynamic keys", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "status", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		row1 := []byte(`{"status": "active", "color": "red"}`)   // "status" matches static field
+		row2 := []byte(`{"color": "blue", "size": 42}`)          // no conflict
+		row3 := []byte(`{"status": "done", "tag": "important"}`) // "status" matches static field
+
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{row1, row2, row3}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
+
+		// Verify all 3 rows preserved intact
+		jsonRows := insertMsg.FieldsData[0].GetScalars().GetJsonData().GetData()
+		assert.Len(t, jsonRows, 3)
+		for i, row := range jsonRows {
+			var m map[string]interface{}
+			assert.NoError(t, json.Unmarshal(row, &m), "row %d must be valid JSON", i)
+		}
+	})
+
+	t.Run("multiple static fields with overlapping keys in $meta", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "fieldA", DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "fieldB", DataType: schemapb.DataType_VarChar},
+				{FieldID: 103, Name: "fieldC", DataType: schemapb.DataType_Float},
+				{FieldID: 104, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		// $meta contains keys matching ALL 3 static fields plus an extra dynamic key
+		metaJSON := []byte(`{"fieldA": 1, "fieldB": "val", "fieldC": 3.14, "extra": true}`)
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 104, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
+
+		var m map[string]interface{}
+		err = json.Unmarshal(insertMsg.FieldsData[0].GetScalars().GetJsonData().GetData()[0], &m)
+		assert.NoError(t, err)
+		assert.Contains(t, m, "fieldA")
+		assert.Contains(t, m, "fieldB")
+		assert.Contains(t, m, "fieldC")
+		assert.Contains(t, m, "extra")
+	})
+
+	t.Run("sets FieldName to $meta for IsDynamic field", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		metaJSON := []byte(`{"color": "green"}`)
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "original_name", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
+		// The function must normalize FieldName to "$meta"
+		assert.Equal(t, "$meta", insertMsg.FieldsData[0].GetFieldName())
+	})
+
+	t.Run("non-conflicting keys pass both strict and partial update", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "status", DataType: schemapb.DataType_VarChar},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		makeMsg := func() *msgstream.InsertMsg {
+			metaJSON := []byte(`{"color": "blue", "size": 42}`)
+			return &msgstream.InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					FieldsData: []*schemapb.FieldData{
+						{
+							FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+							Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+								JsonData: &schemapb.JSONArray{Data: [][]byte{metaJSON}},
+							}}},
+						},
+					},
+				},
+			}
+		}
+
+		// Both paths must accept $meta with no static field conflicts
+		err := checkDynamicFieldData(schema, makeMsg())
+		assert.NoError(t, err)
+
+		err = checkDynamicFieldDataForPartialUpdate(schema, makeMsg())
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty JSON object in $meta", func(t *testing.T) {
+		schema := &schemapb.CollectionSchema{
+			Name:               "test_collection",
+			EnableDynamicField: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "value", DataType: schemapb.DataType_Int64},
+				{FieldID: 102, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			},
+		}
+
+		insertMsg := &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						FieldName: "$meta", FieldId: 102, Type: schemapb.DataType_JSON, IsDynamic: true,
+						Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{Data: &schemapb.ScalarField_JsonData{
+							JsonData: &schemapb.JSONArray{Data: [][]byte{[]byte(`{}`)}},
+						}}},
+					},
+				},
+			},
+		}
+
+		err := checkDynamicFieldDataForPartialUpdate(schema, insertMsg)
+		assert.NoError(t, err)
+	})
 }
 
 // Test ToCompressedFormatNullable for Geometry and Timestamptz types

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2376,7 +2376,7 @@ func ErrWithLog(logger *log.MLogger, msg string, err error) error {
 	return wrapErr
 }
 
-func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
+func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg, skipStaticFieldNameCheck bool) error {
 	for _, field := range insertMsg.FieldsData {
 		if field.GetFieldName() == common.MetaFieldName {
 			if !schema.EnableDynamicField {
@@ -2394,10 +2394,12 @@ func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstr
 				if _, ok := jsonData[common.MetaFieldName]; ok {
 					return fmt.Errorf("cannot set json key to: %s", common.MetaFieldName)
 				}
-				for _, f := range schema.GetFields() {
-					if _, ok := jsonData[f.GetName()]; ok {
-						log.Info("dynamic field name include the static field name", zap.String("fieldName", f.GetName()))
-						return fmt.Errorf("dynamic field name cannot include the static field name: %s", f.GetName())
+				if !skipStaticFieldNameCheck {
+					for _, f := range schema.GetFields() {
+						if _, ok := jsonData[f.GetName()]; ok {
+							log.Info("dynamic field name include the static field name", zap.String("fieldName", f.GetName()))
+							return fmt.Errorf("dynamic field name cannot include the static field name: %s", f.GetName())
+						}
 					}
 				}
 			}
@@ -2407,11 +2409,15 @@ func verifyDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstr
 	return nil
 }
 
-func checkDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
+// doCheckDynamicFieldData is the shared implementation for dynamic field validation.
+// When skipStaticFieldNameCheck is true, $meta keys matching static field names are
+// allowed — this is needed for partial updates after schema evolution, where $meta
+// may legitimately contain keys that now correspond to static columns.
+func doCheckDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg, skipStaticFieldNameCheck bool) error {
 	for _, data := range insertMsg.FieldsData {
 		if data.IsDynamic {
 			data.FieldName = common.MetaFieldName
-			return verifyDynamicFieldData(schema, insertMsg)
+			return verifyDynamicFieldData(schema, insertMsg, skipStaticFieldNameCheck)
 		}
 	}
 	defaultData := make([][]byte, insertMsg.NRows())
@@ -2421,6 +2427,20 @@ func checkDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstre
 	dynamicData := autoGenDynamicFieldData(schema, defaultData)
 	insertMsg.FieldsData = append(insertMsg.FieldsData, dynamicData)
 	return nil
+}
+
+func checkDynamicFieldData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
+	return doCheckDynamicFieldData(schema, insertMsg, false)
+}
+
+// checkDynamicFieldDataForPartialUpdate is a relaxed version of checkDynamicFieldData
+// for partial updates. After schema evolution, $meta may legitimately contain keys
+// matching static field names (e.g., a dynamic field "end_timestamp" that was later
+// added as a static column). This function validates JSON format and rejects the
+// reserved $meta key, but skips the static field name conflict check so that
+// existing dynamic field data is preserved.
+func checkDynamicFieldDataForPartialUpdate(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {
+	return doCheckDynamicFieldData(schema, insertMsg, true)
 }
 
 func addNamespaceData(schema *schemapb.CollectionSchema, insertMsg *msgstream.InsertMsg) error {

--- a/tests/python_client/milvus_client/test_milvus_client_partial_update.py
+++ b/tests/python_client/milvus_client/test_milvus_client_partial_update.py
@@ -1415,6 +1415,72 @@ class TestMilvusClientPartialUpdateValid(TestMilvusClientV2Base):
 
         self.drop_collection(client, collection_name)
 
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_milvus_client_partial_update_after_schema_evolution_dynamic_to_static(self):
+        """
+        target: test partial update succeeds after a dynamic field name becomes a static column via schema evolution
+        method:
+            1. Create a collection with dynamic fields enabled
+            2. Insert full rows, then partial upsert a dynamic field `end_timestamp`
+            3. Add `end_timestamp` as a static column (schema evolution)
+            4. Partial upsert again with `end_timestamp` — should succeed after fix
+            5. Verify the static field has the new value
+        expected: Step 4 should succeed without "dynamic field name cannot include the static field name" error
+        """
+        # step 1: create collection with dynamic fields
+        client = self._client()
+        schema = self.create_schema(client, enable_dynamic_field=True)[0]
+        schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(default_vector_field_name, DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=64, nullable=True)
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(default_primary_key_field_name, index_type="AUTOINDEX")
+        index_params.add_index(default_vector_field_name, index_type="AUTOINDEX")
+        collection_name = cf.gen_collection_name_by_testcase_name(module_index=1)
+        self.create_collection(client, collection_name, default_dim, schema=schema,
+                               consistency_level="Strong", index_params=index_params)
+
+        # step 2: insert full rows, then partial upsert dynamic field `end_timestamp`
+        nb = 100
+        vectors = cf.gen_vectors(nb, default_dim)
+        rows = [{default_primary_key_field_name: i,
+                 default_vector_field_name: vectors[i],
+                 default_string_field_name: f"row_{i}"} for i in range(nb)]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+
+        partial_rows = [{default_primary_key_field_name: i, "end_timestamp": 1000 + i} for i in range(nb)]
+        self.upsert(client, collection_name, partial_rows, partial_update=True)
+        self.flush(client, collection_name)
+
+        # verify dynamic field was written
+        res = self.query(client, collection_name, filter="id < 5",
+                         output_fields=[default_primary_key_field_name, "end_timestamp"])[0]
+        for r in res:
+            assert "end_timestamp" in r, f"end_timestamp should exist as dynamic field, got {r}"
+
+        # step 3: add `end_timestamp` as a static column (schema evolution)
+        self.add_collection_field(client, collection_name, field_name="end_timestamp",
+                                  data_type=DataType.INT64, nullable=True)
+        self.release_collection(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        # step 4: partial upsert again — this is the operation that used to fail
+        new_ts = 9999
+        partial_rows_2 = [{default_primary_key_field_name: i, "end_timestamp": new_ts + i} for i in range(nb)]
+        self.upsert(client, collection_name, partial_rows_2, partial_update=True)
+        self.flush(client, collection_name)
+
+        # step 5: verify the static field has the new value
+        res = self.query(client, collection_name, filter="id < 5",
+                         output_fields=[default_primary_key_field_name, "end_timestamp"])[0]
+        for r in res:
+            pk = r[default_primary_key_field_name]
+            assert r["end_timestamp"] == new_ts + pk, \
+                f"end_timestamp mismatch for pk={pk}: expected {new_ts + pk}, got {r['end_timestamp']}"
+
+        self.drop_collection(client, collection_name)
+
 
 class TestMilvusClientPartialUpdateInvalid(TestMilvusClientV2Base):
     """Test case of partial update interface"""


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/47857#issuecomment-4486581986
pr: #47725

Cherry-pick PR #47725 to 2.6.

Summary:
- Preserve dynamic $meta keys during partial update after schema evolution.
- Deduplicate partial-update dynamic-field validation.
- Add Go and Python regression coverage.

Test:
- gofmt internal/proxy/task_upsert.go internal/proxy/task_upsert_test.go internal/proxy/util.go
- git diff --check upstream/2.6...HEAD
- go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy -run "TestCheckDynamicFieldDataForPartialUpdate|TestUpsertTask_queryPreExecute_ArrayPartialOpSkipsGenericReplace" (blocked locally: pkg-config cannot find milvus_core.pc or rocksdb.pc)
