### PR TITLE
fix: [stv3] serialize L0 V3 manifest delta updates

### DIFF
--- a/internal/datacoord/compaction_task_l0.go
+++ b/internal/datacoord/compaction_task_l0.go
@@ -29,7 +29,6 @@ import (
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
-	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
@@ -450,44 +449,6 @@ func (t *l0CompactionTask) saveTaskMeta(task *datapb.CompactionTask) error {
 	return t.meta.SaveCompactionTask(context.TODO(), task)
 }
 
-func (t *l0CompactionTask) commitV3ManifestDeltas(ctx context.Context, outputSegs []*datapb.CompactionSegment) error {
-	if t.committedV3Manifests == nil {
-		t.committedV3Manifests = make(map[int64]string)
-	}
-	for _, seg := range outputSegs {
-		if seg.GetManifest() != "" {
-			t.committedV3Manifests[seg.GetSegmentID()] = seg.GetManifest()
-			continue
-		}
-
-		if manifest, ok := t.committedV3Manifests[seg.GetSegmentID()]; ok {
-			seg.Manifest = manifest
-			continue
-		}
-
-		target := t.meta.GetSegment(ctx, seg.GetSegmentID())
-		if target == nil || target.GetManifestPath() == "" {
-			continue
-		}
-
-		entries, err := buildL0V3DeltaLogEntries(seg.GetSegmentID(), seg.GetDeltalogs())
-		if err != nil {
-			return err
-		}
-		if len(entries) == 0 {
-			continue
-		}
-
-		newManifest, err := packed.AddDeltaLogsToManifestOverwrite(target.GetManifestPath(), compaction.CreateStorageConfig(), entries)
-		if err != nil {
-			return err
-		}
-		seg.Manifest = newManifest
-		t.committedV3Manifests[seg.GetSegmentID()] = newManifest
-	}
-	return nil
-}
-
 func buildL0V3DeltaLogEntries(segmentID int64, deltalogs []*datapb.FieldBinlog) ([]packed.DeltaLogEntry, error) {
 	entries := make([]packed.DeltaLogEntry, 0)
 	for _, fieldBinlog := range deltalogs {
@@ -505,38 +466,17 @@ func buildL0V3DeltaLogEntries(segmentID int64, deltalogs []*datapb.FieldBinlog) 
 	return entries, nil
 }
 
-func compressL0CompactionBinlogs(outputSegs []*datapb.CompactionSegment) error {
-	for _, seg := range outputSegs {
-		if seg.GetManifest() == "" {
-			if err := binlog.CompressCompactionBinlogs([]*datapb.CompactionSegment{seg}); err != nil {
-				return err
-			}
-			continue
-		}
-		for _, fieldBinlog := range seg.GetDeltalogs() {
-			for _, binlog := range fieldBinlog.GetBinlogs() {
-				binlog.LogPath = ""
-			}
-		}
-	}
-	return nil
-}
-
 func (t *l0CompactionTask) saveSegmentMeta(outputSegs []*datapb.CompactionSegment) error {
-	if err := t.commitV3ManifestDeltas(context.TODO(), outputSegs); err != nil {
-		return err
-	}
-	if err := compressL0CompactionBinlogs(outputSegs); err != nil {
-		return err
-	}
-
 	var operators []UpdateOperator
+	storageConfig := compaction.CreateStorageConfig()
 	for _, seg := range outputSegs {
-		if seg.GetManifest() != "" {
-			operators = append(operators, UpdateManifest(seg.GetSegmentID(), seg.GetManifest()))
-		}
 		if len(seg.GetDeltalogs()) > 0 {
-			operators = append(operators, AddBinlogsOperator(seg.GetSegmentID(), nil, nil, seg.GetDeltalogs(), nil))
+			operators = append(operators, AddL0DeltalogsAndUpdateManifestOperator(
+				seg.GetSegmentID(),
+				seg.GetDeltalogs(),
+				storageConfig,
+				t.committedV3Manifests,
+			))
 		}
 	}
 

--- a/internal/datacoord/compaction_task_l0_test.go
+++ b/internal/datacoord/compaction_task_l0_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -31,10 +30,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
-	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -60,107 +56,8 @@ func (s *L0CompactionTaskSuite) SetupSubTest() {
 	s.SetupTest()
 }
 
-func (s *L0CompactionTaskSuite) TestCommitV3ManifestDeltasOnDataCoord() {
-	basePath := "/tmp/milvus/insert_log/1/10/200"
+func (s *L0CompactionTaskSuite) TestSaveSegmentMetaUsesAtomicDeltalogOperator() {
 	actualDeltaPath := "/tmp/milvus/insert_log/1/10/200/_delta/not-log-id-suffix"
-	oldManifest := packed.MarshalManifestPath(basePath, 7)
-	newManifest := packed.MarshalManifestPath(basePath, 8)
-
-	task := s.generateTestL0Task(datapb.CompactionTaskState_executing)
-	seg := &datapb.CompactionSegment{
-		SegmentID: 200,
-		Deltalogs: []*datapb.FieldBinlog{{
-			Binlogs: []*datapb.Binlog{{
-				LogID:      9001,
-				LogPath:    actualDeltaPath,
-				EntriesNum: 3,
-				MemorySize: 128,
-			}},
-		}},
-	}
-
-	s.mockMeta.EXPECT().GetSegment(mock.Anything, int64(200)).Return(&SegmentInfo{
-		SegmentInfo: &datapb.SegmentInfo{
-			ID:             200,
-			StorageVersion: storage.StorageV3,
-			ManifestPath:   oldManifest,
-		},
-	}).Once()
-
-	patch := mockey.Mock(packed.AddDeltaLogsToManifestOverwrite).To(
-		func(manifestPath string, storageConfig *indexpb.StorageConfig, deltaLogs []packed.DeltaLogEntry) (string, error) {
-			s.Equal(oldManifest, manifestPath)
-			s.NotNil(storageConfig)
-			s.Require().Len(deltaLogs, 1)
-			s.Equal(actualDeltaPath, deltaLogs[0].Path)
-			s.EqualValues(3, deltaLogs[0].NumEntries)
-			return newManifest, nil
-		},
-	).Build()
-	defer patch.UnPatch()
-
-	err := task.commitV3ManifestDeltas(context.Background(), []*datapb.CompactionSegment{seg})
-	s.NoError(err)
-	s.Equal(newManifest, seg.GetManifest())
-}
-
-func (s *L0CompactionTaskSuite) TestCommitV3ManifestDeltasRequiresLogPath() {
-	basePath := "/tmp/milvus/insert_log/1/10/200"
-	oldManifest := packed.MarshalManifestPath(basePath, 7)
-	task := s.generateTestL0Task(datapb.CompactionTaskState_executing)
-	seg := &datapb.CompactionSegment{
-		SegmentID: 200,
-		Deltalogs: []*datapb.FieldBinlog{{
-			Binlogs: []*datapb.Binlog{{LogID: 9001, EntriesNum: 3}},
-		}},
-	}
-
-	s.mockMeta.EXPECT().GetSegment(mock.Anything, int64(200)).Return(&SegmentInfo{
-		SegmentInfo: &datapb.SegmentInfo{ID: 200, StorageVersion: storage.StorageV3, ManifestPath: oldManifest},
-	}).Once()
-
-	err := task.commitV3ManifestDeltas(context.Background(), []*datapb.CompactionSegment{seg})
-	s.Error(err)
-	s.Contains(err.Error(), "missing deltalog path")
-}
-
-func (s *L0CompactionTaskSuite) TestCommitV3ManifestDeltasReusesCachedManifest() {
-	basePath := "/tmp/milvus/insert_log/1/10/200"
-	actualDeltaPath := "/tmp/milvus/insert_log/1/10/200/_delta/not-log-id-suffix"
-	oldManifest := packed.MarshalManifestPath(basePath, 7)
-	newManifest := packed.MarshalManifestPath(basePath, 8)
-
-	task := s.generateTestL0Task(datapb.CompactionTaskState_executing)
-
-	s.mockMeta.EXPECT().GetSegment(mock.Anything, int64(200)).Return(&SegmentInfo{
-		SegmentInfo: &datapb.SegmentInfo{ID: 200, StorageVersion: storage.StorageV3, ManifestPath: oldManifest},
-	}).Once()
-
-	calls := 0
-	patch := mockey.Mock(packed.AddDeltaLogsToManifestOverwrite).To(
-		func(manifestPath string, storageConfig *indexpb.StorageConfig, deltaLogs []packed.DeltaLogEntry) (string, error) {
-			calls++
-			return newManifest, nil
-		},
-	).Build()
-	defer patch.UnPatch()
-
-	first := &datapb.CompactionSegment{SegmentID: 200, Deltalogs: []*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{LogID: 9001, LogPath: actualDeltaPath, EntriesNum: 3}}}}}
-	second := &datapb.CompactionSegment{SegmentID: 200, Deltalogs: []*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{LogID: 9001, LogPath: actualDeltaPath, EntriesNum: 3}}}}}
-
-	s.NoError(task.commitV3ManifestDeltas(context.Background(), []*datapb.CompactionSegment{first}))
-	s.NoError(task.commitV3ManifestDeltas(context.Background(), []*datapb.CompactionSegment{second}))
-
-	s.Equal(1, calls)
-	s.Equal(newManifest, first.GetManifest())
-	s.Equal(newManifest, second.GetManifest())
-}
-
-func (s *L0CompactionTaskSuite) TestSaveSegmentMetaCommitsManifestBeforeMetaUpdate() {
-	basePath := "/tmp/milvus/insert_log/1/10/200"
-	actualDeltaPath := "/tmp/milvus/insert_log/1/10/200/_delta/not-log-id-suffix"
-	oldManifest := packed.MarshalManifestPath(basePath, 1)
-	newManifest := packed.MarshalManifestPath(basePath, 2)
 
 	task := s.generateTestL0Task(datapb.CompactionTaskState_executing)
 	output := []*datapb.CompactionSegment{{
@@ -170,25 +67,11 @@ func (s *L0CompactionTaskSuite) TestSaveSegmentMetaCommitsManifestBeforeMetaUpda
 		}},
 	}}
 
-	s.mockMeta.EXPECT().GetSegment(mock.Anything, int64(200)).Return(&SegmentInfo{
-		SegmentInfo: &datapb.SegmentInfo{ID: 200, StorageVersion: storage.StorageV3, ManifestPath: oldManifest},
-	}).Once()
-
-	patch := mockey.Mock(packed.AddDeltaLogsToManifestOverwrite).To(
-		func(manifestPath string, storageConfig *indexpb.StorageConfig, deltaLogs []packed.DeltaLogEntry) (string, error) {
-			s.Require().Len(deltaLogs, 1)
-			s.Equal(actualDeltaPath, deltaLogs[0].Path)
-			return newManifest, nil
-		},
-	).Build()
-	defer patch.UnPatch()
-
-	s.mockMeta.EXPECT().UpdateSegmentsInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+	s.mockMeta.EXPECT().UpdateSegmentsInfo(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, operators ...UpdateOperator) error {
-			s.Equal(newManifest, output[0].GetManifest())
-			s.Empty(output[0].GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
+			s.Len(operators, 5)
+			s.Equal(actualDeltaPath, output[0].GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
 			s.EqualValues(9001, output[0].GetDeltalogs()[0].GetBinlogs()[0].GetLogID())
-			s.Len(operators, 6)
 			return nil
 		},
 	).Once()

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -870,6 +870,7 @@ type updateSegmentPack struct {
 	// for update segment metric after alter segments
 	metricMutation              *segMetricMutation
 	fromSaveBinlogPathSegmentID int64 // if true, the operator is from save binlog paths
+	l0ManifestUpdates           []*l0ManifestUpdate
 	err                         error
 }
 
@@ -1182,6 +1183,135 @@ func updateManifestPathIfNewer(segment *SegmentInfo, manifestPath string) error 
 	return nil
 }
 
+type l0ManifestUpdate struct {
+	segmentID            int64
+	deltalogs            []*datapb.FieldBinlog
+	storageConfig        *indexpb.StorageConfig
+	committedV3Manifests map[int64]string
+	segment              *SegmentInfo
+	manifestPath         string
+	entries              []packed.DeltaLogEntry
+}
+
+func (u *l0ManifestUpdate) prepare(modPack *updateSegmentPack) bool {
+	u.segment = modPack.Get(u.segmentID)
+	if u.segment == nil {
+		log.Ctx(context.TODO()).Warn("meta update: add L0 deltalog failed - segment not found",
+			zap.Int64("segmentID", u.segmentID))
+		return false
+	}
+	if len(u.deltalogs) == 0 {
+		return false
+	}
+
+	if u.segment.GetManifestPath() == "" {
+		if err := binlog.CompressFieldBinlogs(u.deltalogs); err != nil {
+			return modPack.fail(err)
+		}
+		return true
+	}
+
+	if u.committedV3Manifests != nil {
+		u.manifestPath = u.committedV3Manifests[u.segmentID]
+	}
+	if u.manifestPath != "" {
+		return true
+	}
+
+	entries, err := buildL0V3DeltaLogEntries(u.segmentID, u.deltalogs)
+	if err != nil {
+		return modPack.fail(err)
+	}
+	if len(entries) == 0 {
+		return false
+	}
+	u.entries = entries
+	return true
+}
+
+func (u *l0ManifestUpdate) commitManifest() error {
+	if u.segment.GetManifestPath() == "" || u.manifestPath != "" || len(u.entries) == 0 {
+		return nil
+	}
+	manifestPath, err := packed.AddDeltaLogsToManifestOverwrite(u.segment.GetManifestPath(), u.storageConfig, u.entries)
+	if err != nil {
+		return err
+	}
+	u.manifestPath = manifestPath
+	return nil
+}
+
+func commitL0ManifestUpdates(updates []*l0ManifestUpdate) error {
+	updates = lo.Filter(updates, func(update *l0ManifestUpdate, _ int) bool {
+		return update.segment.GetManifestPath() != ""
+	})
+	if len(updates) == 0 {
+		return nil
+	}
+
+	groups := make(map[int64][]*l0ManifestUpdate)
+	for _, update := range updates {
+		groups[update.segmentID] = append(groups[update.segmentID], update)
+	}
+
+	poolSize := paramtable.Get().DataCoordCfg.L0ManifestUpdatePoolSize.GetAsInt()
+	if poolSize < 1 {
+		poolSize = 1
+	}
+	if poolSize > len(groups) {
+		poolSize = len(groups)
+	}
+
+	pool := conc.NewPool[struct{}](poolSize)
+	defer pool.Release()
+
+	futures := make([]*conc.Future[struct{}], 0, len(groups))
+	for _, group := range groups {
+		group := group
+		futures = append(futures, pool.Submit(func() (struct{}, error) {
+			return struct{}{}, commitL0ManifestUpdateGroup(group)
+		}))
+	}
+	err := conc.BlockOnAll(futures...)
+	for _, update := range updates {
+		if update.committedV3Manifests != nil && update.manifestPath != "" {
+			update.committedV3Manifests[update.segmentID] = update.manifestPath
+		}
+	}
+	return err
+}
+
+func commitL0ManifestUpdateGroup(updates []*l0ManifestUpdate) error {
+	for _, update := range updates {
+		if update.manifestPath != "" {
+			if err := updateManifestPathIfNewer(update.segment, update.manifestPath); err != nil {
+				return err
+			}
+			continue
+		}
+		if len(update.entries) == 0 {
+			continue
+		}
+		if err := update.commitManifest(); err != nil {
+			return err
+		}
+		if err := updateManifestPathIfNewer(update.segment, update.manifestPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (u *l0ManifestUpdate) apply(modPack *updateSegmentPack) bool {
+	if u.segment.GetManifestPath() != "" {
+		if err := updateManifestPathIfNewer(u.segment, u.manifestPath); err != nil {
+			return modPack.fail(err)
+		}
+		clearBinlogPaths(u.deltalogs)
+	}
+	return addDeltalogsToSegment(modPack, u.segmentID, u.segment, u.deltalogs)
+}
+
 func AddL0DeltalogsAndUpdateManifestOperator(
 	segmentID int64,
 	deltalogs []*datapb.FieldBinlog,
@@ -1189,49 +1319,17 @@ func AddL0DeltalogsAndUpdateManifestOperator(
 	committedV3Manifests map[int64]string,
 ) UpdateOperator {
 	return func(modPack *updateSegmentPack) bool {
-		segment := modPack.Get(segmentID)
-		if segment == nil {
-			log.Ctx(context.TODO()).Warn("meta update: add L0 deltalog failed - segment not found",
-				zap.Int64("segmentID", segmentID))
+		update := &l0ManifestUpdate{
+			segmentID:            segmentID,
+			deltalogs:            deltalogs,
+			storageConfig:        storageConfig,
+			committedV3Manifests: committedV3Manifests,
+		}
+		if !update.prepare(modPack) {
 			return false
 		}
-		if len(deltalogs) == 0 {
-			return false
-		}
-
-		if segment.GetManifestPath() == "" {
-			if err := binlog.CompressFieldBinlogs(deltalogs); err != nil {
-				return modPack.fail(err)
-			}
-			return addDeltalogsToSegment(modPack, segmentID, segment, deltalogs)
-		}
-
-		manifestPath := ""
-		if committedV3Manifests != nil {
-			manifestPath = committedV3Manifests[segmentID]
-		}
-		if manifestPath == "" {
-			entries, err := buildL0V3DeltaLogEntries(segmentID, deltalogs)
-			if err != nil {
-				return modPack.fail(err)
-			}
-			if len(entries) == 0 {
-				return false
-			}
-			manifestPath, err = packed.AddDeltaLogsToManifestOverwrite(segment.GetManifestPath(), storageConfig, entries)
-			if err != nil {
-				return modPack.fail(err)
-			}
-			if committedV3Manifests != nil {
-				committedV3Manifests[segmentID] = manifestPath
-			}
-		}
-
-		if err := updateManifestPathIfNewer(segment, manifestPath); err != nil {
-			return modPack.fail(err)
-		}
-		clearBinlogPaths(deltalogs)
-		return addDeltalogsToSegment(modPack, segmentID, segment, deltalogs)
+		modPack.l0ManifestUpdates = append(modPack.l0ManifestUpdates, update)
+		return true
 	}
 }
 
@@ -1658,6 +1756,14 @@ func (m *meta) UpdateSegmentsInfo(ctx context.Context, operators ...UpdateOperat
 	for _, operator := range operators {
 		operator(updatePack)
 		if updatePack.err != nil {
+			return updatePack.err
+		}
+	}
+	if err := commitL0ManifestUpdates(updatePack.l0ManifestUpdates); err != nil {
+		return err
+	}
+	for _, update := range updatePack.l0ManifestUpdates {
+		if !update.apply(updatePack) {
 			return updatePack.err
 		}
 	}

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/broker"
 	"github.com/milvus-io/milvus/internal/metastore"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/segmentutil"
@@ -45,6 +46,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
@@ -868,6 +870,14 @@ type updateSegmentPack struct {
 	// for update segment metric after alter segments
 	metricMutation              *segMetricMutation
 	fromSaveBinlogPathSegmentID int64 // if true, the operator is from save binlog paths
+	err                         error
+}
+
+func (p *updateSegmentPack) fail(err error) bool {
+	if err != nil {
+		p.err = err
+	}
+	return false
 }
 
 func (p *updateSegmentPack) Validate() error {
@@ -1120,6 +1130,108 @@ func AddBinlogsOperator(segmentID int64, binlogs, statslogs, deltalogs, bm25logs
 			},
 		}
 		return true
+	}
+}
+
+func addDeltalogsToSegment(modPack *updateSegmentPack, segmentID int64, segment *SegmentInfo, deltalogs []*datapb.FieldBinlog) bool {
+	if len(deltalogs) == 0 {
+		return false
+	}
+
+	segment.Deltalogs = mergeFieldBinlogs(segment.GetDeltalogs(), deltalogs)
+	segment.deltaRowcount.Store(-1)
+	modPack.increments[segmentID] = metastore.BinlogsIncrement{
+		Segment: segment.SegmentInfo,
+		UpdateMask: metastore.BinlogsUpdateMask{
+			WithoutBinlogs:       true,
+			WithoutDeltalogs:     false,
+			WithoutStatslogs:     true,
+			WithoutBm25Statslogs: true,
+		},
+	}
+	return true
+}
+
+func clearBinlogPaths(fieldBinlogs []*datapb.FieldBinlog) {
+	for _, fieldBinlog := range fieldBinlogs {
+		for _, binlog := range fieldBinlog.GetBinlogs() {
+			binlog.LogPath = ""
+		}
+	}
+}
+
+func updateManifestPathIfNewer(segment *SegmentInfo, manifestPath string) error {
+	if manifestPath == "" || segment.GetManifestPath() == manifestPath {
+		return nil
+	}
+
+	currentBase, currentVersion, err := packed.UnmarshalManifestPath(segment.GetManifestPath())
+	if err != nil {
+		return err
+	}
+	incomingBase, incomingVersion, err := packed.UnmarshalManifestPath(manifestPath)
+	if err != nil {
+		return err
+	}
+	if currentBase != incomingBase {
+		return merr.WrapErrServiceInternal(fmt.Sprintf("manifest base path mismatch for segment %d: current %s, incoming %s", segment.GetID(), currentBase, incomingBase))
+	}
+	if incomingVersion > currentVersion {
+		segment.ManifestPath = manifestPath
+	}
+	return nil
+}
+
+func AddL0DeltalogsAndUpdateManifestOperator(
+	segmentID int64,
+	deltalogs []*datapb.FieldBinlog,
+	storageConfig *indexpb.StorageConfig,
+	committedV3Manifests map[int64]string,
+) UpdateOperator {
+	return func(modPack *updateSegmentPack) bool {
+		segment := modPack.Get(segmentID)
+		if segment == nil {
+			log.Ctx(context.TODO()).Warn("meta update: add L0 deltalog failed - segment not found",
+				zap.Int64("segmentID", segmentID))
+			return false
+		}
+		if len(deltalogs) == 0 {
+			return false
+		}
+
+		if segment.GetManifestPath() == "" {
+			if err := binlog.CompressFieldBinlogs(deltalogs); err != nil {
+				return modPack.fail(err)
+			}
+			return addDeltalogsToSegment(modPack, segmentID, segment, deltalogs)
+		}
+
+		manifestPath := ""
+		if committedV3Manifests != nil {
+			manifestPath = committedV3Manifests[segmentID]
+		}
+		if manifestPath == "" {
+			entries, err := buildL0V3DeltaLogEntries(segmentID, deltalogs)
+			if err != nil {
+				return modPack.fail(err)
+			}
+			if len(entries) == 0 {
+				return false
+			}
+			manifestPath, err = packed.AddDeltaLogsToManifestOverwrite(segment.GetManifestPath(), storageConfig, entries)
+			if err != nil {
+				return modPack.fail(err)
+			}
+			if committedV3Manifests != nil {
+				committedV3Manifests[segmentID] = manifestPath
+			}
+		}
+
+		if err := updateManifestPathIfNewer(segment, manifestPath); err != nil {
+			return modPack.fail(err)
+		}
+		clearBinlogPaths(deltalogs)
+		return addDeltalogsToSegment(modPack, segmentID, segment, deltalogs)
 	}
 }
 
@@ -1545,6 +1657,9 @@ func (m *meta) UpdateSegmentsInfo(ctx context.Context, operators ...UpdateOperat
 
 	for _, operator := range operators {
 		operator(updatePack)
+		if updatePack.err != nil {
+			return updatePack.err
+		}
 	}
 
 	// skip if all segment not exist

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -3101,6 +3101,83 @@ func TestAddL0DeltalogsAndUpdateManifestOperator(t *testing.T) {
 	require.EqualValues(t, 3, updated.GetDeltalogs()[0].GetBinlogs()[0].GetEntriesNum())
 }
 
+func TestAddL0DeltalogsAndUpdateManifestOperatorCommitsManifestsConcurrently(t *testing.T) {
+	basePath1 := "/tmp/milvus/insert_log/1/10/200"
+	basePath2 := "/tmp/milvus/insert_log/1/10/201"
+	oldManifest1 := packed.MarshalManifestPath(basePath1, 7)
+	oldManifest2 := packed.MarshalManifestPath(basePath2, 11)
+	newManifest1 := packed.MarshalManifestPath(basePath1, 8)
+	newManifest2 := packed.MarshalManifestPath(basePath2, 12)
+
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	require.NoError(t, meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:           200,
+		CollectionID: 1,
+		PartitionID:  10,
+		State:        commonpb.SegmentState_Flushed,
+		ManifestPath: oldManifest1,
+	})))
+	require.NoError(t, meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:           201,
+		CollectionID: 1,
+		PartitionID:  10,
+		State:        commonpb.SegmentState_Flushed,
+		ManifestPath: oldManifest2,
+	})))
+
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.L0ManifestUpdatePoolSize.Key, "2")
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.L0ManifestUpdatePoolSize.Key)
+
+	entered := make(chan string, 2)
+	release := make(chan struct{})
+	patch := mockey.Mock(packed.AddDeltaLogsToManifestOverwrite).To(
+		func(manifestPath string, storageConfig *indexpb.StorageConfig, deltaLogs []packed.DeltaLogEntry) (string, error) {
+			entered <- manifestPath
+			<-release
+			switch manifestPath {
+			case oldManifest1:
+				return newManifest1, nil
+			case oldManifest2:
+				return newManifest2, nil
+			default:
+				require.Failf(t, "unexpected manifest", manifestPath)
+				return "", nil
+			}
+		},
+	).Build()
+	defer patch.UnPatch()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- meta.UpdateSegmentsInfo(context.TODO(),
+			AddL0DeltalogsAndUpdateManifestOperator(200, []*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{LogID: 9001, LogPath: basePath1 + "/_delta/9001", EntriesNum: 3}}}}, &indexpb.StorageConfig{}, nil),
+			AddL0DeltalogsAndUpdateManifestOperator(201, []*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{LogID: 9002, LogPath: basePath2 + "/_delta/9002", EntriesNum: 5}}}}, &indexpb.StorageConfig{}, nil),
+		)
+	}()
+
+	got := map[string]struct{}{}
+	for i := 0; i < 2; i++ {
+		select {
+		case manifestPath := <-entered:
+			got[manifestPath] = struct{}{}
+		case <-time.After(time.Second):
+			require.FailNow(t, "manifest updates did not run concurrently")
+		}
+	}
+	require.Contains(t, got, oldManifest1)
+	require.Contains(t, got, oldManifest2)
+	close(release)
+	require.NoError(t, <-errCh)
+
+	updated1 := meta.GetSegment(context.TODO(), 200)
+	require.Equal(t, newManifest1, updated1.GetManifestPath())
+	require.Empty(t, updated1.GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
+	updated2 := meta.GetSegment(context.TODO(), 201)
+	require.Equal(t, newManifest2, updated2.GetManifestPath())
+	require.Empty(t, updated2.GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
+}
+
 func TestAddL0DeltalogsAndUpdateManifestOperatorSerializesConcurrentUpdates(t *testing.T) {
 	basePath := "/tmp/milvus/insert_log/1/10/200"
 	oldManifest := packed.MarshalManifestPath(basePath, 7)

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -51,6 +53,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/kv"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
@@ -3043,7 +3046,214 @@ func TestAlterSegmentsWithRecovery(t *testing.T) {
 	checkVersion(6, 3, 3, 3, 3)
 }
 
+func TestAddL0DeltalogsAndUpdateManifestOperator(t *testing.T) {
+	basePath := "/tmp/milvus/insert_log/1/10/200"
+	oldManifest := packed.MarshalManifestPath(basePath, 7)
+	newManifest := packed.MarshalManifestPath(basePath, 8)
+
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	require.NoError(t, meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:           200,
+		CollectionID: 1,
+		PartitionID:  10,
+		State:        commonpb.SegmentState_Flushed,
+		ManifestPath: oldManifest,
+	})))
+
+	deltalogs := []*datapb.FieldBinlog{{
+		Binlogs: []*datapb.Binlog{{
+			LogID:      9001,
+			LogPath:    basePath + "/_delta/9001",
+			EntriesNum: 3,
+			MemorySize: 128,
+		}},
+	}}
+
+	patch := mockey.Mock(packed.AddDeltaLogsToManifestOverwrite).To(
+		func(manifestPath string, storageConfig *indexpb.StorageConfig, deltaLogs []packed.DeltaLogEntry) (string, error) {
+			require.Equal(t, oldManifest, manifestPath)
+			require.NotNil(t, storageConfig)
+			require.Len(t, deltaLogs, 1)
+			require.Equal(t, basePath+"/_delta/9001", deltaLogs[0].Path)
+			require.EqualValues(t, 3, deltaLogs[0].NumEntries)
+			return newManifest, nil
+		},
+	).Build()
+	defer patch.UnPatch()
+
+	cache := make(map[int64]string)
+	err = meta.UpdateSegmentsInfo(context.TODO(), AddL0DeltalogsAndUpdateManifestOperator(
+		200,
+		deltalogs,
+		&indexpb.StorageConfig{},
+		cache,
+	))
+	require.NoError(t, err)
+
+	updated := meta.GetSegment(context.TODO(), 200)
+	require.Equal(t, newManifest, updated.GetManifestPath())
+	require.Equal(t, newManifest, cache[int64(200)])
+	require.Len(t, updated.GetDeltalogs(), 1)
+	require.Len(t, updated.GetDeltalogs()[0].GetBinlogs(), 1)
+	require.Empty(t, updated.GetDeltalogs()[0].GetBinlogs()[0].GetLogPath())
+	require.EqualValues(t, 9001, updated.GetDeltalogs()[0].GetBinlogs()[0].GetLogID())
+	require.EqualValues(t, 3, updated.GetDeltalogs()[0].GetBinlogs()[0].GetEntriesNum())
+}
+
+func TestAddL0DeltalogsAndUpdateManifestOperatorSerializesConcurrentUpdates(t *testing.T) {
+	basePath := "/tmp/milvus/insert_log/1/10/200"
+	oldManifest := packed.MarshalManifestPath(basePath, 7)
+	manifest8 := packed.MarshalManifestPath(basePath, 8)
+	manifest9 := packed.MarshalManifestPath(basePath, 9)
+
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	require.NoError(t, meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:           200,
+		CollectionID: 1,
+		PartitionID:  10,
+		State:        commonpb.SegmentState_Flushed,
+		ManifestPath: oldManifest,
+	})))
+
+	var mu sync.Mutex
+	calls := make([]string, 0, 2)
+	patch := mockey.Mock(packed.AddDeltaLogsToManifestOverwrite).To(
+		func(manifestPath string, storageConfig *indexpb.StorageConfig, deltaLogs []packed.DeltaLogEntry) (string, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			calls = append(calls, manifestPath)
+			if len(calls) == 1 {
+				return manifest8, nil
+			}
+			return manifest9, nil
+		},
+	).Build()
+	defer patch.UnPatch()
+
+	makeDelta := func(logID int64) []*datapb.FieldBinlog {
+		return []*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{
+			LogID:      logID,
+			LogPath:    fmt.Sprintf("%s/_delta/%d", basePath, logID),
+			EntriesNum: 1,
+		}}}}
+	}
+
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		errs <- meta.UpdateSegmentsInfo(context.TODO(), AddL0DeltalogsAndUpdateManifestOperator(200, makeDelta(9001), &indexpb.StorageConfig{}, nil))
+	}()
+	go func() {
+		defer wg.Done()
+		errs <- meta.UpdateSegmentsInfo(context.TODO(), AddL0DeltalogsAndUpdateManifestOperator(200, makeDelta(9002), &indexpb.StorageConfig{}, nil))
+	}()
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, []string{oldManifest, manifest8}, calls)
+
+	updated := meta.GetSegment(context.TODO(), 200)
+	require.Equal(t, manifest9, updated.GetManifestPath())
+	require.Len(t, updated.GetDeltalogs(), 1)
+	require.Len(t, updated.GetDeltalogs()[0].GetBinlogs(), 2)
+}
+
+func TestAddL0DeltalogsAndUpdateManifestOperatorRequiresLogPath(t *testing.T) {
+	basePath := "/tmp/milvus/insert_log/1/10/200"
+	oldManifest := packed.MarshalManifestPath(basePath, 7)
+
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	require.NoError(t, meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:           200,
+		State:        commonpb.SegmentState_Flushed,
+		ManifestPath: oldManifest,
+	})))
+
+	err = meta.UpdateSegmentsInfo(context.TODO(), AddL0DeltalogsAndUpdateManifestOperator(
+		200,
+		[]*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{LogID: 9001, EntriesNum: 3}}}},
+		&indexpb.StorageConfig{},
+		nil,
+	))
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing deltalog path")
+	updated := meta.GetSegment(context.TODO(), 200)
+	require.Equal(t, oldManifest, updated.GetManifestPath())
+	require.Empty(t, updated.GetDeltalogs())
+}
+
+func TestAddL0DeltalogsAndUpdateManifestOperatorCacheDoesNotRegressManifest(t *testing.T) {
+	basePath := "/tmp/milvus/insert_log/1/10/200"
+	manifest8 := packed.MarshalManifestPath(basePath, 8)
+	manifest9 := packed.MarshalManifestPath(basePath, 9)
+
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	require.NoError(t, meta.AddSegment(context.TODO(), NewSegmentInfo(&datapb.SegmentInfo{
+		ID:           200,
+		State:        commonpb.SegmentState_Flushed,
+		ManifestPath: manifest9,
+	})))
+
+	calls := 0
+	patch := mockey.Mock(packed.AddDeltaLogsToManifestOverwrite).To(
+		func(manifestPath string, storageConfig *indexpb.StorageConfig, deltaLogs []packed.DeltaLogEntry) (string, error) {
+			calls++
+			return "", errors.New("should not be called")
+		},
+	).Build()
+	defer patch.UnPatch()
+
+	cache := map[int64]string{200: manifest8}
+	err = meta.UpdateSegmentsInfo(context.TODO(), AddL0DeltalogsAndUpdateManifestOperator(
+		200,
+		[]*datapb.FieldBinlog{{Binlogs: []*datapb.Binlog{{LogID: 9001, LogPath: basePath + "/_delta/9001", EntriesNum: 3}}}},
+		&indexpb.StorageConfig{},
+		cache,
+	))
+
+	require.NoError(t, err)
+	require.Zero(t, calls)
+	updated := meta.GetSegment(context.TODO(), 200)
+	require.Equal(t, manifest9, updated.GetManifestPath())
+	require.Len(t, updated.GetDeltalogs(), 1)
+}
+
 func TestUpdateSegmentsInfo(t *testing.T) {
+	t.Run("operator error stops update", func(t *testing.T) {
+		meta, err := newMemoryMeta(t)
+		require.NoError(t, err)
+
+		segment := NewSegmentInfo(&datapb.SegmentInfo{
+			ID:    1,
+			State: commonpb.SegmentState_Flushed,
+		})
+		require.NoError(t, meta.AddSegment(context.TODO(), segment))
+
+		expectedErr := errors.New("operator failed")
+		err = meta.UpdateSegmentsInfo(
+			context.TODO(),
+			func(pack *updateSegmentPack) bool {
+				pack.err = expectedErr
+				return false
+			},
+			UpdateStatusOperator(1, commonpb.SegmentState_Dropped),
+		)
+
+		require.ErrorIs(t, err, expectedErr)
+		updated := meta.GetSegment(context.TODO(), 1)
+		require.Equal(t, commonpb.SegmentState_Flushed, updated.GetState())
+	})
+
 	t.Run("normal", func(t *testing.T) {
 		meta, err := newMemoryMeta(t)
 		assert.NoError(t, err)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4994,6 +4994,7 @@ type dataCoordConfig struct {
 	CompactionExpiryTolerance                  ParamItem `refreshable:"true"`
 	BumpSchemaVersionCompactionEnabled         ParamItem `refreshable:"true"`
 	BumpSchemaVersionCompactionTriggerInterval ParamItem `refreshable:"true"`
+	L0ManifestUpdatePoolSize                   ParamItem `refreshable:"true"`
 
 	SingleCompactionRatioThreshold    ParamItem `refreshable:"true"`
 	SingleCompactionDeltaLogMaxSize   ParamItem `refreshable:"true"`
@@ -5379,6 +5380,21 @@ mix is prioritized by level: mix compactions first, then L0 compactions, then cl
 		Export:       true,
 	}
 	p.CompactionMaxParallelTasks.Init(base.mgr)
+
+	p.L0ManifestUpdatePoolSize = ParamItem{
+		Key:          "dataCoord.compaction.levelzero.manifestUpdatePoolSize",
+		Version:      "3.0.0",
+		DefaultValue: "16",
+		Doc:          "The goroutine pool size for committing L0 compaction manifest updates inside DataCoord meta update.",
+		Export:       false,
+		Formatter: func(v string) string {
+			if getAsInt(v) < 1 {
+				return "1"
+			}
+			return v
+		},
+	}
+	p.L0ManifestUpdatePoolSize.Init(base.mgr)
 
 	p.MinSegmentToMerge = ParamItem{
 		Key:          "dataCoord.compaction.min.segment",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -643,6 +643,11 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 5, Params.MixCompactionSlotUsage.GetAsInt())
 		params.Save("dataCoord.slot.l0DeleteCompactionUsage", "4")
 		assert.Equal(t, 4, Params.L0DeleteCompactionSlotUsage.GetAsInt())
+		assert.Equal(t, 16, Params.L0ManifestUpdatePoolSize.GetAsInt())
+		params.Save("dataCoord.compaction.levelzero.manifestUpdatePoolSize", "4")
+		assert.Equal(t, 4, Params.L0ManifestUpdatePoolSize.GetAsInt())
+		params.Save("dataCoord.compaction.levelzero.manifestUpdatePoolSize", "0")
+		assert.Equal(t, 1, Params.L0ManifestUpdatePoolSize.GetAsInt())
 		params.Save("datacoord.scheduler.taskSlowThreshold", "1000")
 		assert.Equal(t, 1000*time.Second, Params.TaskSlowThreshold.GetAsDuration(time.Second))
 


### PR DESCRIPTION
Related to #49706

Move L0 V3 manifest delta commits into the segment meta update path so manifest pointer updates and deltalog metadata appends are protected by the same DataCoord lock under concurrent compaction tasks.