### PR TITLE
fix: Avoid balance batch limit for forced segment assignment

### DIFF
--- a/internal/querycoordv2/assign/assign_policy_roundrobin.go
+++ b/internal/querycoordv2/assign/assign_policy_roundrobin.go
@@ -18,6 +18,7 @@ package assign
 
 import (
 	"context"
+	"math"
 	"sort"
 
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
@@ -57,9 +58,14 @@ func (p *RoundRobinAssignPolicy) AssignSegment(
 	nodes []int64,
 	forceAssign bool,
 ) []SegmentAssignPlan {
+	balanceBatchSize := math.MaxInt64
+
 	// Filter nodes
-	filter := newCommonSegmentNodeFilter(p.nodeManager)
-	nodes = filter.FilterNodes(ctx, nodes, forceAssign)
+	if !forceAssign {
+		filter := newCommonSegmentNodeFilter(p.nodeManager)
+		nodes = filter.FilterNodes(ctx, nodes, forceAssign)
+		balanceBatchSize = paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.GetAsInt()
+	}
 	if len(nodes) == 0 {
 		return nil
 	}
@@ -81,8 +87,6 @@ func (p *RoundRobinAssignPolicy) AssignSegment(
 		return nodes[i] < nodes[j]
 	})
 
-	// Apply batch size limit
-	balanceBatchSize := paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.GetAsInt()
 	ret := make([]SegmentAssignPlan, 0, len(segments))
 
 	// Assign segments in round-robin fashion

--- a/internal/querycoordv2/assign/assign_policy_roundrobin_test.go
+++ b/internal/querycoordv2/assign/assign_policy_roundrobin_test.go
@@ -162,6 +162,51 @@ func TestRoundRobinAssignPolicy_AssignSegment_AllNodesNotNormal(t *testing.T) {
 	assert.Equal(t, 1, len(plansForced))
 }
 
+func TestRoundRobinAssignPolicy_AssignSegment_BatchLimitOnlyForBalance(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.Key, "2")
+	defer paramtable.Get().Reset(paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.Key)
+
+	mockScheduler := task.NewMockScheduler(t)
+	mockScheduler.EXPECT().GetSegmentTaskDelta(mock.Anything, mock.Anything).Return(0).Maybe()
+	mockScheduler.EXPECT().GetChannelTaskDelta(mock.Anything, mock.Anything).Return(0).Maybe()
+
+	nodeManager := session.NewNodeManager()
+	for i := int64(1); i <= 2; i++ {
+		nodeManager.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   i,
+			Address:  "localhost",
+			Hostname: "node",
+		}))
+		nodeManager.Get(i).SetState(session.NodeStateNormal)
+	}
+
+	policy := newRoundRobinAssignPolicy(nodeManager, mockScheduler, nil)
+	segments := make([]*meta.Segment, 5)
+	for i := range segments {
+		segments[i] = &meta.Segment{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:        int64(i + 1),
+				NumOfRows: 1000,
+			},
+		}
+	}
+
+	nodes := []int64{1, 2}
+	balancePlans := policy.AssignSegment(context.Background(), 100, segments, nodes, false)
+	assert.Equal(t, 2, len(balancePlans))
+
+	for i := int64(1); i <= 2; i++ {
+		nodeManager.Get(i).SetState(session.NodeStateStopping)
+	}
+
+	balancePlans = policy.AssignSegment(context.Background(), 100, segments, nodes, false)
+	assert.Nil(t, balancePlans)
+
+	forcePlans := policy.AssignSegment(context.Background(), 100, segments, nodes, true)
+	assert.Equal(t, 5, len(forcePlans))
+}
+
 // TestRoundRobinAssignPolicy_AssignSegment_SingleNode tests with single node
 func TestRoundRobinAssignPolicy_AssignSegment_SingleNode(t *testing.T) {
 	mockScheduler := task.NewMockScheduler(t)

--- a/internal/querycoordv2/assign/assign_policy_rowcount.go
+++ b/internal/querycoordv2/assign/assign_policy_rowcount.go
@@ -18,6 +18,7 @@ package assign
 
 import (
 	"context"
+	"math"
 	"sort"
 	"sync"
 
@@ -104,15 +105,20 @@ func (p *RowCountBasedAssignPolicy) AssignSegment(
 	nodes []int64,
 	forceAssign bool,
 ) []SegmentAssignPlan {
+	balanceBatchSize := math.MaxInt64
+
 	// Filter nodes
-	nodeFilter := newCommonSegmentNodeFilter(p.nodeManager)
-	filteredNodes := nodeFilter.FilterNodes(ctx, nodes, forceAssign)
-	if len(filteredNodes) == 0 {
+	if !forceAssign {
+		nodeFilter := newCommonSegmentNodeFilter(p.nodeManager)
+		nodes = nodeFilter.FilterNodes(ctx, nodes, forceAssign)
+		balanceBatchSize = paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.GetAsInt()
+	}
+	if len(nodes) == 0 {
 		return nil
 	}
 
 	// Convert nodes to node items with row count scores
-	nodeItems := p.convertToNodeItemsBySegment(filteredNodes)
+	nodeItems := p.convertToNodeItemsBySegment(nodes)
 	if len(nodeItems) == 0 {
 		return nil
 	}
@@ -128,8 +134,6 @@ func (p *RowCountBasedAssignPolicy) AssignSegment(
 		return segments[i].GetNumOfRows() > segments[j].GetNumOfRows()
 	})
 
-	// Apply batch size limit
-	balanceBatchSize := paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.GetAsInt()
 	plans := make([]SegmentAssignPlan, 0, len(segments))
 
 	// Assign segments using priority queue

--- a/internal/querycoordv2/assign/assign_policy_rowcount_test.go
+++ b/internal/querycoordv2/assign/assign_policy_rowcount_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/task"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 // TestRowCountBasedAssignPolicy_AssignSegment_PriorityToLeastLoaded tests segments go to least loaded node
@@ -123,6 +124,53 @@ func TestRowCountBasedAssignPolicy_AssignSegment_MultipleSegments(t *testing.T) 
 
 	assert.Equal(t, 2, nodeCount[1], "Node 1 should get 2 segments")
 	assert.Equal(t, 2, nodeCount[2], "Node 2 should get 2 segments")
+}
+
+func TestRowCountBasedAssignPolicy_AssignSegment_BatchLimitOnlyForBalance(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.Key, "2")
+	defer paramtable.Get().Reset(paramtable.Get().QueryCoordCfg.BalanceSegmentBatchSize.Key)
+
+	nodeManager := session.NewNodeManager()
+	mockScheduler := task.NewMockScheduler(t)
+	mockScheduler.EXPECT().GetSegmentTaskDelta(mock.Anything, mock.Anything).Return(0).Maybe()
+	mockScheduler.EXPECT().GetChannelTaskDelta(mock.Anything, mock.Anything).Return(0).Maybe()
+	dist := meta.NewDistributionManager(nodeManager)
+
+	for i := int64(1); i <= 2; i++ {
+		nodeManager.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
+			NodeID:   i,
+			Version:  common.Version,
+			Address:  "localhost",
+			Hostname: "node",
+		}))
+		nodeManager.Get(i).SetState(session.NodeStateNormal)
+	}
+
+	policy := newRowCountBasedAssignPolicy(nodeManager, mockScheduler, dist)
+	segments := make([]*meta.Segment, 5)
+	for i := range segments {
+		segments[i] = &meta.Segment{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:        int64(i + 1),
+				NumOfRows: 1000,
+			},
+		}
+	}
+
+	nodes := []int64{1, 2}
+	balancePlans := policy.AssignSegment(context.Background(), 100, segments, nodes, false)
+	assert.Equal(t, 2, len(balancePlans))
+
+	for i := int64(1); i <= 2; i++ {
+		nodeManager.Get(i).SetState(session.NodeStateStopping)
+	}
+
+	balancePlans = policy.AssignSegment(context.Background(), 100, segments, nodes, false)
+	assert.Nil(t, balancePlans)
+
+	forcePlans := policy.AssignSegment(context.Background(), 100, segments, nodes, true)
+	assert.Equal(t, 5, len(forcePlans))
 }
 
 // TestRowCountBasedAssignPolicy_AssignSegment_EmptyNodes tests with no nodes


### PR DESCRIPTION
issue: #49920

Fixes #49920

This PR aligns round-robin and row-count based segment assignment with the score-based policy for forced segment assignment.

Changes:
- Skip common segment node filtering when `forceAssign=true` in round-robin and row-count policies.
- Apply `queryCoord.balanceSegmentBatchSize` only when `forceAssign=false`.
- Add unit coverage for balance-limited assignment and forced assignment behavior.

Verification:
- `gofumpt -l internal/querycoordv2/assign/assign_policy_roundrobin.go internal/querycoordv2/assign/assign_policy_rowcount.go internal/querycoordv2/assign/assign_policy_roundrobin_test.go internal/querycoordv2/assign/assign_policy_rowcount_test.go`
- `git diff --check`

Not run:
- Build and Go tests were not run per local instruction to avoid compilation in this round.