### PR TITLE
enhance: [cp2.6]Optimize QueryCoord ChannelDistManager collection filtering

### DIFF
--- a/internal/querycoordv2/balance/balance.go
+++ b/internal/querycoordv2/balance/balance.go
@@ -195,7 +195,7 @@ func (b *RoundRobinBalancer) genChannelPlan(ctx context.Context, replica *meta.R
 	channelsToMove := make([]*meta.DmChannel, 0)
 
 	for _, node := range rwNodes {
-		channels := b.dist.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithNodeID2Channel(node))
+		channels := b.dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(replica.GetCollectionID()), meta.WithNodeID2Channel(node))
 		channels = sortIfChannelAtWALLocated(channels)
 
 		if len(channels) <= average {

--- a/internal/querycoordv2/balance/channel_level_score_balancer.go
+++ b/internal/querycoordv2/balance/channel_level_score_balancer.go
@@ -164,7 +164,7 @@ func (b *ChannelLevelScoreBalancer) BalanceReplica(ctx context.Context, replica 
 func (b *ChannelLevelScoreBalancer) genChannelPlanForOutboundNodes(ctx context.Context, replica *meta.Replica, channelName string, onlineNodes []int64, offlineNodes []int64) []assign.ChannelAssignPlan {
 	channelPlans := make([]assign.ChannelAssignPlan, 0)
 	for _, nodeID := range offlineNodes {
-		dmChannels := b.dist.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithNodeID2Channel(nodeID), meta.WithChannelName2Channel(channelName))
+		dmChannels := b.dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(replica.GetCollectionID()), meta.WithNodeID2Channel(nodeID), meta.WithChannelName2Channel(channelName))
 		plans := b.GetAssignPolicy().AssignChannel(ctx, replica.GetCollectionID(), dmChannels, onlineNodes, false)
 		for i := range plans {
 			plans[i].From = nodeID
@@ -285,7 +285,7 @@ func (b *ChannelLevelScoreBalancer) genChannelPlan(ctx context.Context, replica 
 		nodeWithLessChannel := make([]int64, 0)
 		channelsToMove := make([]*meta.DmChannel, 0)
 		for _, node := range onlineNodes {
-			channels := b.dist.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithNodeID2Channel(node))
+			channels := b.dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(replica.GetCollectionID()), meta.WithNodeID2Channel(node))
 			channels = sortIfChannelAtWALLocated(channels)
 
 			if len(channels) <= average {

--- a/internal/querycoordv2/balance/rowcount_based_balancer.go
+++ b/internal/querycoordv2/balance/rowcount_based_balancer.go
@@ -194,7 +194,7 @@ func (b *RowCountBasedBalancer) genChannelPlan(ctx context.Context, br *balanceR
 		nodeWithLessChannel := make([]int64, 0)
 		channelsToMove := make([]*meta.DmChannel, 0)
 		for _, node := range rwNodes {
-			channels := b.dist.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithNodeID2Channel(node))
+			channels := b.dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(replica.GetCollectionID()), meta.WithNodeID2Channel(node))
 			channels = sortIfChannelAtWALLocated(channels)
 
 			if len(channels) <= average {

--- a/internal/querycoordv2/balance/stopping_balancer.go
+++ b/internal/querycoordv2/balance/stopping_balancer.go
@@ -129,8 +129,8 @@ func (b *StoppingBalancer) genChannelPlan(ctx context.Context, br *balanceReport
 
 	for _, nodeID := range roNodes {
 		// Get all channels on this stopping node
-		dmChannels := b.dist.ChannelDistManager.GetByCollectionAndFilter(
-			replica.GetCollectionID(),
+		dmChannels := b.dist.ChannelDistManager.GetByFilter(
+			meta.WithCollectionID2Channel(replica.GetCollectionID()),
 			meta.WithNodeID2Channel(nodeID),
 		)
 

--- a/internal/querycoordv2/balance/utils.go
+++ b/internal/querycoordv2/balance/utils.go
@@ -193,7 +193,7 @@ func PrintCurrentReplicaDist(replica *meta.Replica,
 	// 3. print stopping nodes channel distribution
 	distInfo += "[stoppingNodesChannelDist:"
 	for stoppingNodeID := range stoppingNodesSegments {
-		stoppingNodeChannels := channelManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithNodeID2Channel(stoppingNodeID))
+		stoppingNodeChannels := channelManager.GetByFilter(meta.WithCollectionID2Channel(replica.GetCollectionID()), meta.WithNodeID2Channel(stoppingNodeID))
 		distInfo += fmt.Sprintf("[nodeID:%d, count:%d,", stoppingNodeID, len(stoppingNodeChannels))
 		distInfo += "channels:["
 		for _, stoppingChan := range stoppingNodeChannels {
@@ -206,7 +206,7 @@ func PrintCurrentReplicaDist(replica *meta.Replica,
 	// 4. print normal nodes channel distribution
 	distInfo += "[normalNodesChannelDist:"
 	for normalNodeID := range nodeSegments {
-		normalNodeChannels := channelManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithNodeID2Channel(normalNodeID))
+		normalNodeChannels := channelManager.GetByFilter(meta.WithCollectionID2Channel(replica.GetCollectionID()), meta.WithNodeID2Channel(normalNodeID))
 		distInfo += fmt.Sprintf("[nodeID:%d, count:%d,", normalNodeID, len(normalNodeChannels))
 		distInfo += "channels:["
 		for _, normalNodeChan := range normalNodeChannels {

--- a/internal/querycoordv2/checkers/balance_checker.go
+++ b/internal/querycoordv2/checkers/balance_checker.go
@@ -254,7 +254,7 @@ func (b *BalanceChecker) constructNormalBalanceQueue(ctx context.Context) *assig
 	// cause segment_checker and channel checker use different assign policy
 	filterServiceableCollections := func(ctx context.Context, cid int64) bool {
 		// Get all channels for this collection from distribution
-		channels := b.dist.ChannelDistManager.GetByCollectionAndFilter(cid)
+		channels := b.dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(cid))
 		if len(channels) == 0 {
 			// No channels in distribution means collection is not ready
 			return false

--- a/internal/querycoordv2/checkers/balance_checker_test.go
+++ b/internal/querycoordv2/checkers/balance_checker_test.go
@@ -1441,9 +1441,9 @@ func TestBalanceChecker_ConstructNormalBalanceQueue_FilterServiceableCollections
 			}).Build()
 		defer mockGetCollection.UnPatch()
 
-		// Mock ChannelDistManager.GetByCollectionAndFilter to return serviceable channels
-		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByCollectionAndFilter).To(
-			func(_ *meta.ChannelDistManager, collectionID int64, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
+		// Mock ChannelDistManager.GetByFilter to return serviceable channels
+		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByFilter).To(
+			func(_ *meta.ChannelDistManager, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
 				// Return serviceable channels for all collections
 				return []*meta.DmChannel{
 					{View: &meta.LeaderView{Status: &querypb.LeaderViewStatus{Serviceable: true}}},
@@ -1521,9 +1521,9 @@ func TestBalanceChecker_ConstructNormalBalanceQueue_FilterServiceableCollections
 			}).Build()
 		defer mockGetCollection.UnPatch()
 
-		// Mock ChannelDistManager.GetByCollectionAndFilter to return serviceable channels
-		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByCollectionAndFilter).To(
-			func(_ *meta.ChannelDistManager, collectionID int64, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
+		// Mock ChannelDistManager.GetByFilter to return serviceable channels
+		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByFilter).To(
+			func(_ *meta.ChannelDistManager, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
 				return []*meta.DmChannel{
 					{View: &meta.LeaderView{Status: &querypb.LeaderViewStatus{Serviceable: true}}},
 				}
@@ -1583,9 +1583,9 @@ func TestBalanceChecker_ConstructNormalBalanceQueue_FilterServiceableCollections
 			}).Build()
 		defer mockGetCollection.UnPatch()
 
-		// Mock ChannelDistManager.GetByCollectionAndFilter to return serviceable channels
-		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByCollectionAndFilter).To(
-			func(_ *meta.ChannelDistManager, collectionID int64, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
+		// Mock ChannelDistManager.GetByFilter to return serviceable channels
+		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByFilter).To(
+			func(_ *meta.ChannelDistManager, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
 				return []*meta.DmChannel{
 					{View: &meta.LeaderView{Status: &querypb.LeaderViewStatus{Serviceable: true}}},
 				}
@@ -1655,9 +1655,9 @@ func TestBalanceChecker_ConstructNormalBalanceQueue_FilterServiceableCollections
 			}).Build()
 		defer mockGetCollection.UnPatch()
 
-		// Mock ChannelDistManager.GetByCollectionAndFilter to return serviceable channels
-		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByCollectionAndFilter).To(
-			func(_ *meta.ChannelDistManager, collectionID int64, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
+		// Mock ChannelDistManager.GetByFilter to return serviceable channels
+		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByFilter).To(
+			func(_ *meta.ChannelDistManager, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
 				return []*meta.DmChannel{
 					{View: &meta.LeaderView{Status: &querypb.LeaderViewStatus{Serviceable: true}}},
 				}
@@ -1724,19 +1724,27 @@ func TestBalanceChecker_ConstructNormalBalanceQueue_FilterServiceableCollections
 			}).Build()
 		defer mockGetCollection.UnPatch()
 
-		// Mock ChannelDistManager.GetByCollectionAndFilter
+		// Mock ChannelDistManager.GetByFilter
 		// Collection 1: all channels serviceable
 		// Collection 2: one channel not serviceable
-		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByCollectionAndFilter).To(
-			func(_ *meta.ChannelDistManager, collectionID int64, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
-				switch collectionID {
-				case 1:
+		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByFilter).To(
+			func(_ *meta.ChannelDistManager, filters ...meta.ChannelDistFilter) []*meta.DmChannel {
+				matchColl := func(cid int64) bool {
+					ch := &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: cid}}
+					for _, f := range filters {
+						if !f.Match(ch) {
+							return false
+						}
+					}
+					return true
+				}
+				if matchColl(1) {
 					// All serviceable
 					return []*meta.DmChannel{
 						{View: &meta.LeaderView{Status: &querypb.LeaderViewStatus{Serviceable: true}}},
 						{View: &meta.LeaderView{Status: &querypb.LeaderViewStatus{Serviceable: true}}},
 					}
-				case 2:
+				} else if matchColl(2) {
 					// One not serviceable
 					return []*meta.DmChannel{
 						{View: &meta.LeaderView{Status: &querypb.LeaderViewStatus{Serviceable: true}}},
@@ -1811,12 +1819,13 @@ func TestBalanceChecker_ConstructNormalBalanceQueue_FilterServiceableCollections
 			}).Build()
 		defer mockGetCollection.UnPatch()
 
-		// Mock ChannelDistManager.GetByCollectionAndFilter
+		// Mock ChannelDistManager.GetByFilter
 		// Collection 1: has serviceable channels
 		// Collection 2: no channels in distribution
-		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByCollectionAndFilter).To(
-			func(_ *meta.ChannelDistManager, collectionID int64, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
-				if collectionID == 1 {
+		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByFilter).To(
+			func(_ *meta.ChannelDistManager, filters ...meta.ChannelDistFilter) []*meta.DmChannel {
+				ch1 := &meta.DmChannel{VchannelInfo: &datapb.VchannelInfo{CollectionID: 1}}
+				if len(filters) > 0 && filters[0].Match(ch1) {
 					return []*meta.DmChannel{
 						{View: &meta.LeaderView{Status: &querypb.LeaderViewStatus{Serviceable: true}}},
 					}
@@ -1890,10 +1899,10 @@ func TestBalanceChecker_ConstructNormalBalanceQueue_FilterServiceableCollections
 			}).Build()
 		defer mockGetCollection.UnPatch()
 
-		// Mock ChannelDistManager.GetByCollectionAndFilter
+		// Mock ChannelDistManager.GetByFilter
 		// Both collections have all serviceable channels
-		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByCollectionAndFilter).To(
-			func(_ *meta.ChannelDistManager, collectionID int64, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
+		mockGetChannels := mockey.Mock((*meta.ChannelDistManager).GetByFilter).To(
+			func(_ *meta.ChannelDistManager, _ ...meta.ChannelDistFilter) []*meta.DmChannel {
 				return []*meta.DmChannel{
 					{View: &meta.LeaderView{Status: &querypb.LeaderViewStatus{Serviceable: true}}},
 					{View: &meta.LeaderView{Status: &querypb.LeaderViewStatus{Serviceable: true}}},

--- a/internal/querycoordv2/checkers/channel_checker.go
+++ b/internal/querycoordv2/checkers/channel_checker.go
@@ -216,7 +216,7 @@ func (c *ChannelChecker) getDmChannelDiff(ctx context.Context, collectionID int6
 		return
 	}
 
-	dist := c.dist.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithReplica2Channel(replica))
+	dist := c.dist.ChannelDistManager.GetByFilter(meta.WithReplica2Channel(replica))
 	distMap := typeutil.NewSet[string]()
 	for _, ch := range dist {
 		distMap.Insert(ch.GetChannelName())
@@ -255,7 +255,7 @@ func (c *ChannelChecker) findRepeatedChannels(ctx context.Context, replicaID int
 		return dupChannels
 	}
 
-	delegatorList := c.dist.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithReplica2Channel(replica))
+	delegatorList := c.dist.ChannelDistManager.GetByFilter(meta.WithReplica2Channel(replica))
 	for _, delegator := range delegatorList {
 		leader := c.dist.ChannelDistManager.GetShardLeader(delegator.GetChannelName(), replica)
 		if leader == nil {

--- a/internal/querycoordv2/checkers/segment_checker.go
+++ b/internal/querycoordv2/checkers/segment_checker.go
@@ -213,7 +213,7 @@ func (c *SegmentChecker) checkReplica(ctx context.Context, replica *meta.Replica
 	ret := make([]task.Task, 0)
 
 	replicaSegmentDist := c.dist.SegmentDistManager.GetByFilter(meta.WithCollectionID(replica.GetCollectionID()), meta.WithReplica(replica))
-	delegatorList := c.dist.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithReplica2Channel(replica))
+	delegatorList := c.dist.ChannelDistManager.GetByFilter(meta.WithReplica2Channel(replica))
 	ch2DelegatorList := lo.GroupBy(delegatorList, func(d *meta.DmChannel) string {
 		return d.View.Channel
 	})

--- a/internal/querycoordv2/checkers/segment_checker_test.go
+++ b/internal/querycoordv2/checkers/segment_checker_test.go
@@ -1041,7 +1041,7 @@ func (suite *SegmentCheckerTestSuite) TestFilterOutExistedOnLeader() {
 
 	// Helper to get ch2DelegatorList
 	getCh2DelegatorList := func() map[string][]*meta.DmChannel {
-		delegatorList := checker.dist.ChannelDistManager.GetByCollectionAndFilter(collectionID, meta.WithReplica2Channel(replica))
+		delegatorList := checker.dist.ChannelDistManager.GetByFilter(meta.WithReplica2Channel(replica))
 		return lo.GroupBy(delegatorList, func(d *meta.DmChannel) string {
 			return d.View.Channel
 		})
@@ -1149,7 +1149,7 @@ func (suite *SegmentCheckerTestSuite) TestFilterOutSegmentInUse() {
 
 	// Helper to get ch2DelegatorList
 	getCh2DelegatorList := func() map[string][]*meta.DmChannel {
-		delegatorList := checker.dist.ChannelDistManager.GetByCollectionAndFilter(collectionID, meta.WithReplica2Channel(replica))
+		delegatorList := checker.dist.ChannelDistManager.GetByFilter(meta.WithReplica2Channel(replica))
 		return lo.GroupBy(delegatorList, func(d *meta.DmChannel) string {
 			return d.View.Channel
 		})

--- a/internal/querycoordv2/job/utils.go
+++ b/internal/querycoordv2/job/utils.go
@@ -58,7 +58,7 @@ func WaitCollectionReleased(ctx context.Context, dist *meta.DistributionManager,
 				return partitionSet.Contain(segment.GetPartitionID())
 			})
 		} else {
-			channels = dist.ChannelDistManager.GetByCollectionAndFilter(collection)
+			channels = dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(collection))
 		}
 
 		currentChannelCount := len(channels)

--- a/internal/querycoordv2/meta/channel_dist_manager.go
+++ b/internal/querycoordv2/meta/channel_dist_manager.go
@@ -203,7 +203,7 @@ type nodeChannels struct {
 	nameChannel map[string]*DmChannel
 }
 
-func (c nodeChannels) Filter(critertion *channelDistCriterion) []*DmChannel {
+func (c nodeChannels) Filter(critertion *channelDistCriterion, filter func(*DmChannel) bool) []*DmChannel {
 	var channels []*DmChannel
 	switch {
 	case critertion.channelName != "":
@@ -216,7 +216,12 @@ func (c nodeChannels) Filter(critertion *channelDistCriterion) []*DmChannel {
 		channels = c.channels
 	}
 
-	return channels // lo.Filter(channels, func(ch *DmChannel, _ int) bool { return mergedFilters(ch) })
+	if critertion.hasOtherFilter {
+		channels = lo.Filter(channels, func(ch *DmChannel, _ int) bool {
+			return filter(ch)
+		})
+	}
+	return channels
 }
 
 func composeNodeChannels(channels ...*DmChannel) nodeChannels {
@@ -229,7 +234,6 @@ func composeNodeChannels(channels ...*DmChannel) nodeChannels {
 
 type ChannelDistManagerInterface interface {
 	GetByFilter(filters ...ChannelDistFilter) []*DmChannel
-	GetByCollectionAndFilter(collectionID int64, filters ...ChannelDistFilter) []*DmChannel
 	Update(nodeID typeutil.UniqueID, channels ...*DmChannel) []*DmChannel
 	GetShardLeader(channelName string, replica *Replica) *DmChannel
 	GetChannelDist(collectionID int64) []*metricsinfo.DmChannel
@@ -243,9 +247,6 @@ type ChannelDistManager struct {
 	// NodeID -> Channels
 	channels map[typeutil.UniqueID]nodeChannels
 
-	// CollectionID -> Channels
-	collectionIndex map[int64][]*DmChannel
-
 	nodeManager *session.NodeManager
 	version     int64
 }
@@ -258,9 +259,8 @@ func (m *ChannelDistManager) GetVersion() int64 {
 
 func NewChannelDistManager(nodeManager *session.NodeManager) *ChannelDistManager {
 	return &ChannelDistManager{
-		channels:        make(map[typeutil.UniqueID]nodeChannels),
-		collectionIndex: make(map[int64][]*DmChannel),
-		nodeManager:     nodeManager,
+		channels:    make(map[typeutil.UniqueID]nodeChannels),
+		nodeManager: nodeManager,
 	}
 }
 
@@ -274,6 +274,15 @@ func (m *ChannelDistManager) GetByFilter(filters ...ChannelDistFilter) []*DmChan
 		filter.AddFilter(criterion)
 	}
 
+	mergedFilters := func(ch *DmChannel) bool {
+		for _, f := range filters {
+			if f != nil && !f.Match(ch) {
+				return false
+			}
+		}
+		return true
+	}
+
 	var candidates []nodeChannels
 	if criterion.nodeIDs != nil {
 		candidates = lo.Map(criterion.nodeIDs.Collect(), func(nodeID int64, _ int) nodeChannels {
@@ -285,32 +294,7 @@ func (m *ChannelDistManager) GetByFilter(filters ...ChannelDistFilter) []*DmChan
 
 	var ret []*DmChannel
 	for _, candidate := range candidates {
-		ret = append(ret, candidate.Filter(criterion)...)
-	}
-	return ret
-}
-
-func (m *ChannelDistManager) GetByCollectionAndFilter(collectionID int64, filters ...ChannelDistFilter) []*DmChannel {
-	m.rwmutex.RLock()
-	defer m.rwmutex.RUnlock()
-
-	mergedFilters := func(ch *DmChannel) bool {
-		for _, fn := range filters {
-			if fn != nil && !fn.Match(ch) {
-				return false
-			}
-		}
-
-		return true
-	}
-
-	ret := make([]*DmChannel, 0)
-
-	// If a collection ID is provided, use the collection index
-	for _, channel := range m.collectionIndex[collectionID] {
-		if mergedFilters(channel) {
-			ret = append(ret, channel)
-		}
+		ret = append(ret, candidate.Filter(criterion, mergedFilters)...)
 	}
 	return ret
 }
@@ -322,7 +306,6 @@ func (m *ChannelDistManager) Update(nodeID typeutil.UniqueID, channels ...*DmCha
 	if len(channels) == 0 {
 		// Node offline, remove entry to avoid memory leak
 		delete(m.channels, nodeID)
-		m.updateCollectionIndex()
 		m.version++
 		return nil
 	}
@@ -338,24 +321,8 @@ func (m *ChannelDistManager) Update(nodeID typeutil.UniqueID, channels ...*DmCha
 	}
 
 	m.channels[nodeID] = composeNodeChannels(channels...)
-	m.updateCollectionIndex()
 	m.version++
 	return newServiceableChannels
-}
-
-// update secondary index for channel distribution
-func (m *ChannelDistManager) updateCollectionIndex() {
-	m.collectionIndex = make(map[int64][]*DmChannel)
-	for _, nodeChannels := range m.channels {
-		for _, channel := range nodeChannels.channels {
-			collectionID := channel.GetCollectionID()
-			if channels, ok := m.collectionIndex[collectionID]; !ok {
-				m.collectionIndex[collectionID] = []*DmChannel{channel}
-			} else {
-				m.collectionIndex[collectionID] = append(channels, channel)
-			}
-		}
-	}
 }
 
 // GetShardLeader return the only one delegator leader which has the highest version in given replica
@@ -365,31 +332,31 @@ func (m *ChannelDistManager) GetShardLeader(channelName string, replica *Replica
 	m.rwmutex.RLock()
 	defer m.rwmutex.RUnlock()
 	var setReason string
-	channels := m.collectionIndex[replica.GetCollectionID()]
-
 	var candidates *DmChannel
-	for _, channel := range channels {
-		if channel.GetChannelName() == channelName && replica.Contains(channel.Node) {
-			if candidates == nil {
-				candidates = channel
-			} else {
-				// Prioritize serviceability first, then version number
-				candidatesServiceable := candidates.IsServiceable()
-				channelServiceable := channel.IsServiceable()
-
-				updateNeeded := false
-				switch {
-				case !candidatesServiceable && channelServiceable:
-					// Current candidate is not serviceable but new channel is
-					updateNeeded = true
-					setReason = "serviceable"
-				case candidatesServiceable == channelServiceable && channel.Version > candidates.Version:
-					// Same service status but higher version
-					updateNeeded = true
-					setReason = "version_updated"
-				}
-				if updateNeeded {
+	for _, nc := range m.channels {
+		for _, channel := range nc.collChannels[replica.GetCollectionID()] {
+			if channel.GetChannelName() == channelName && replica.Contains(channel.Node) {
+				if candidates == nil {
 					candidates = channel
+				} else {
+					// Prioritize serviceability first, then version number
+					candidatesServiceable := candidates.IsServiceable()
+					channelServiceable := channel.IsServiceable()
+
+					updateNeeded := false
+					switch {
+					case !candidatesServiceable && channelServiceable:
+						// Current candidate is not serviceable but new channel is
+						updateNeeded = true
+						setReason = "serviceable"
+					case candidatesServiceable == channelServiceable && channel.Version > candidates.Version:
+						// Same service status but higher version
+						updateNeeded = true
+						setReason = "version_updated"
+					}
+					if updateNeeded {
+						candidates = channel
+					}
 				}
 			}
 		}
@@ -419,18 +386,15 @@ func (m *ChannelDistManager) GetChannelDist(collectionID int64) []*metricsinfo.D
 	defer m.rwmutex.RUnlock()
 
 	var ret []*metricsinfo.DmChannel
-	if collectionID > 0 {
-		if channels, ok := m.collectionIndex[collectionID]; ok {
-			for _, channel := range channels {
+	for _, nc := range m.channels {
+		if collectionID > 0 {
+			for _, channel := range nc.collChannels[collectionID] {
 				ret = append(ret, newDmChannelMetricsFrom(channel))
 			}
-		}
-		return ret
-	}
-
-	for _, channels := range m.collectionIndex {
-		for _, channel := range channels {
-			ret = append(ret, newDmChannelMetricsFrom(channel))
+		} else {
+			for _, channel := range nc.channels {
+				ret = append(ret, newDmChannelMetricsFrom(channel))
+			}
 		}
 	}
 	return ret
@@ -444,18 +408,15 @@ func (m *ChannelDistManager) GetLeaderView(collectionID int64) []*metricsinfo.Le
 	defer m.rwmutex.RUnlock()
 
 	var ret []*metricsinfo.LeaderView
-	if collectionID > 0 {
-		if channels, ok := m.collectionIndex[collectionID]; ok {
-			for _, channel := range channels {
+	for _, nc := range m.channels {
+		if collectionID > 0 {
+			for _, channel := range nc.collChannels[collectionID] {
 				ret = append(ret, newMetricsLeaderViewFrom(channel.View))
 			}
-		}
-		return ret
-	}
-
-	for _, channels := range m.collectionIndex {
-		for _, channel := range channels {
-			ret = append(ret, newMetricsLeaderViewFrom(channel.View))
+		} else {
+			for _, channel := range nc.channels {
+				ret = append(ret, newMetricsLeaderViewFrom(channel.View))
+			}
 		}
 	}
 	return ret

--- a/internal/querycoordv2/meta/channel_dist_manager.go
+++ b/internal/querycoordv2/meta/channel_dist_manager.go
@@ -70,9 +70,12 @@ func (view *LeaderView) Clone() *LeaderView {
 }
 
 type channelDistCriterion struct {
-	nodeIDs        typeutil.Set[int64]
-	collectionID   int64
-	channelName    string
+	// Callers should not combine multiple node-scoped filters in one query.
+	nodes        []int64
+	collectionID int64
+	channelName  string
+	// New filters that cannot be represented by the indexed fields above must
+	// set this flag so Filter runs the extra Match pass.
 	hasOtherFilter bool
 }
 
@@ -102,12 +105,7 @@ func (f nodeChannelFilter) Match(ch *DmChannel) bool {
 }
 
 func (f nodeChannelFilter) AddFilter(criterion *channelDistCriterion) {
-	set := typeutil.NewSet(int64(f))
-	if criterion.nodeIDs == nil {
-		criterion.nodeIDs = set
-	} else {
-		criterion.nodeIDs = criterion.nodeIDs.Intersection(set)
-	}
+	criterion.nodes = []int64{int64(f)}
 }
 
 func WithNodeID2Channel(nodeID int64) ChannelDistFilter {
@@ -124,13 +122,7 @@ func (f replicaChannelFilter) Match(ch *DmChannel) bool {
 
 func (f replicaChannelFilter) AddFilter(criterion *channelDistCriterion) {
 	criterion.collectionID = f.GetCollectionID()
-
-	set := typeutil.NewSet(f.GetNodes()...)
-	if criterion.nodeIDs == nil {
-		criterion.nodeIDs = set
-	} else {
-		criterion.nodeIDs = criterion.nodeIDs.Intersection(set)
-	}
+	criterion.nodes = f.GetNodes()
 }
 
 func WithReplica2Channel(replica *Replica) ChannelDistFilter {
@@ -283,17 +275,15 @@ func (m *ChannelDistManager) GetByFilter(filters ...ChannelDistFilter) []*DmChan
 		return true
 	}
 
-	var candidates []nodeChannels
-	if criterion.nodeIDs != nil {
-		candidates = lo.Map(criterion.nodeIDs.Collect(), func(nodeID int64, _ int) nodeChannels {
-			return m.channels[nodeID]
-		})
-	} else {
-		candidates = lo.Values(m.channels)
+	var ret []*DmChannel
+	if criterion.nodes != nil {
+		for _, nodeID := range criterion.nodes {
+			ret = append(ret, m.channels[nodeID].Filter(criterion, mergedFilters)...)
+		}
+		return ret
 	}
 
-	var ret []*DmChannel
-	for _, candidate := range candidates {
+	for _, candidate := range m.channels {
 		ret = append(ret, candidate.Filter(criterion, mergedFilters)...)
 	}
 	return ret

--- a/internal/querycoordv2/meta/channel_dist_manager_test.go
+++ b/internal/querycoordv2/meta/channel_dist_manager_test.go
@@ -138,26 +138,26 @@ func (suite *ChannelDistManagerSuite) TestGetBy() {
 	}
 
 	// Test GetByCollection
-	channels = dist.GetByCollectionAndFilter(suite.collection)
+	channels = dist.GetByFilter(WithCollectionID2Channel(suite.collection))
 	suite.Len(channels, 4)
 	suite.AssertCollection(channels, suite.collection)
-	channels = dist.GetByCollectionAndFilter(-1)
+	channels = dist.GetByFilter(WithCollectionID2Channel(-1))
 	suite.Len(channels, 0)
 
 	// Test GetByNodeAndCollection
 	// 1. Valid node and valid collection
 	for _, node := range suite.nodes {
-		channels := dist.GetByCollectionAndFilter(suite.collection, WithNodeID2Channel(node))
+		channels := dist.GetByFilter(WithCollectionID2Channel(suite.collection), WithNodeID2Channel(node))
 		suite.AssertNode(channels, node)
 		suite.AssertCollection(channels, suite.collection)
 	}
 
 	// 2. Valid node and invalid collection
-	channels = dist.GetByCollectionAndFilter(-1, WithNodeID2Channel(suite.nodes[1]))
+	channels = dist.GetByFilter(WithCollectionID2Channel(-1), WithNodeID2Channel(suite.nodes[1]))
 	suite.Len(channels, 0)
 
 	// 3. Invalid node and valid collection
-	channels = dist.GetByCollectionAndFilter(suite.collection, WithNodeID2Channel(-1))
+	channels = dist.GetByFilter(WithCollectionID2Channel(suite.collection), WithNodeID2Channel(-1))
 	suite.Len(channels, 0)
 }
 
@@ -434,4 +434,20 @@ func TestGetChannelDistJSON(t *testing.T) {
 	for _, channel := range channels {
 		checkResult(channel)
 	}
+
+	channels = manager.GetChannelDist(100)
+	assert.Len(t, channels, 1)
+	assert.Equal(t, int64(100), channels[0].CollectionID)
+	assert.Equal(t, "channel-1", channels[0].ChannelName)
+
+	views := manager.GetLeaderView(0)
+	assert.Len(t, views, 2)
+
+	views = manager.GetLeaderView(100)
+	assert.Len(t, views, 1)
+	assert.Equal(t, int64(100), views[0].CollectionID)
+	assert.Equal(t, "channel-1", views[0].Channel)
+
+	views = manager.GetLeaderView(300)
+	assert.Len(t, views, 0)
 }

--- a/internal/querycoordv2/meta/segment_dist_manager.go
+++ b/internal/querycoordv2/meta/segment_dist_manager.go
@@ -31,6 +31,7 @@ import (
 )
 
 type segDistCriterion struct {
+	// Callers should not combine multiple node-scoped filters in one query.
 	nodes          []int64
 	collectionID   int64
 	channel        string
@@ -255,17 +256,15 @@ func (m *SegmentDistManager) GetByFilter(filters ...SegmentDistFilter) []*Segmen
 		return true
 	}
 
-	var candidates []nodeSegments
+	var ret []*Segment
 	if criterion.nodes != nil {
-		candidates = lo.Map(criterion.nodes, func(nodeID int64, _ int) nodeSegments {
-			return m.segments[nodeID]
-		})
-	} else {
-		candidates = lo.Values(m.segments)
+		for _, nodeID := range criterion.nodes {
+			ret = append(ret, m.segments[nodeID].Filter(criterion, mergedFilters)...)
+		}
+		return ret
 	}
 
-	var ret []*Segment
-	for _, nodeSegments := range candidates {
+	for _, nodeSegments := range m.segments {
 		ret = append(ret, nodeSegments.Filter(criterion, mergedFilters)...)
 	}
 	return ret

--- a/internal/querycoordv2/observers/replica_observer.go
+++ b/internal/querycoordv2/observers/replica_observer.go
@@ -139,7 +139,7 @@ func (ob *ReplicaObserver) checkStreamingQueryNodesInReplica(sqNodeIDsByRG map[s
 			}
 			removeNodes := make([]int64, 0, len(roSQNodes))
 			for _, node := range roSQNodes {
-				channels := ob.distMgr.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithNodeID2Channel(node))
+				channels := ob.distMgr.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(collectionID), meta.WithNodeID2Channel(node))
 				segments := ob.distMgr.SegmentDistManager.GetByFilter(meta.WithCollectionID(collectionID), meta.WithNodeID(node))
 				if len(channels) == 0 && len(segments) == 0 {
 					removeNodes = append(removeNodes, node)
@@ -204,7 +204,7 @@ func (ob *ReplicaObserver) checkNodesInReplica() {
 			log.RatedInfo(10, "found ro nodes in replica")
 			removeNodes := make([]int64, 0, len(roNodes))
 			for _, node := range roNodes {
-				channels := ob.distMgr.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithNodeID2Channel(node))
+				channels := ob.distMgr.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(collectionID), meta.WithNodeID2Channel(node))
 				segments := ob.distMgr.SegmentDistManager.GetByFilter(meta.WithCollectionID(collectionID), meta.WithNodeID(node))
 				if len(channels) == 0 && len(segments) == 0 {
 					removeNodes = append(removeNodes, node)

--- a/internal/querycoordv2/ops_services.go
+++ b/internal/querycoordv2/ops_services.go
@@ -491,7 +491,7 @@ func (s *Server) TransferChannel(ctx context.Context, req *querypb.TransferChann
 		dstNodeSet.Remove(srcNode)
 
 		// check sealed segment list
-		channels := s.dist.ChannelDistManager.GetByCollectionAndFilter(replica.GetCollectionID(), meta.WithNodeID2Channel(srcNode))
+		channels := s.dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(replica.GetCollectionID()), meta.WithNodeID2Channel(srcNode))
 		toBalance := typeutil.NewSet[*meta.DmChannel]()
 		if req.GetTransferAll() {
 			toBalance.Insert(channels...)

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -915,7 +915,7 @@ func (s *Server) GetLeakedResourcesByCollection(ctx context.Context, collectionI
 			leakedSegments++
 		}
 	}
-	for _, ch := range s.dist.ChannelDistManager.GetByCollectionAndFilter(collectionID) {
+	for _, ch := range s.dist.ChannelDistManager.GetByFilter(meta.WithCollectionID2Channel(collectionID)) {
 		if !validNodes.Contain(ch.Node) {
 			leakedChannels++
 		}


### PR DESCRIPTION
Cherry-pick from master
pr: #49587

## Summary

This PR cherry-picks QueryCoord ChannelDistManager filtering optimizations to the 2.6 branch.

The change removes the global ChannelDistManager collection index and reuses each node's collection-scoped channel index for collection lookups. It also reduces temporary allocations in ChannelDist and SegmentDist filtering paths.

## Code Changes

- Remove the global collectionIndex from ChannelDistManager.
- Use the unified GetByFilter path with WithCollectionID2Channel.
- Reuse per-node nodeChannels.collChannels for collection-scoped lookup.
- Reduce temporary allocations in dist manager filtering paths.
- Update QueryCoord callers and tests for the unified ChannelDist filter path.

issue: #49511

## Test Plan

- git diff --check
- gofumpt -l $(git diff --name-only upstream/2.6..HEAD -- '*.go')
- CMAKE_POLICY_VERSION_MINIMUM=3.5 CONAN_CMD=conan-1 SKIP_3RDPARTY=1 make
- zsh -c 'source scripts/setenv.sh && go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r ${MILVUS_WORK_DIR}/cmake_build/lib -r ${MILVUS_WORK_DIR}/internal/core/output/lib" ./internal/querycoordv2/... -timeout 600s'