### PR TITLE
test: [cp2.6]Fix chaos checker dimension mismatch and vector field limit handling

### DIFF
--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -1193,8 +1193,14 @@ class HybridSearchChecker(Checker):
 
     def gen_hybrid_search_request(self):
         res = []
-        dim = self.dim
+        # Get actual dimension for each vector field from schema
+        schema_info = self.get_schema()
+        field_dim_map = {}
+        for f in schema_info.get("fields", []):
+            if f.get("type") in (DataType.FLOAT_VECTOR, DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR):
+                field_dim_map[f.get("name")] = f.get("params", {}).get("dim", self.dim)
         for vec_field_name in self.float_vector_field_names:
+            dim = field_dim_map.get(vec_field_name, self.dim)
             search_param = {
                 "data": cf.gen_vectors(1, dim),
                 "anns_field": vec_field_name,
@@ -2913,32 +2919,8 @@ class AddVectorFieldChecker(Checker):
     def add_vector_field(self):
         """Add a nullable FLOAT_VECTOR field, create index, insert data, and query to verify."""
         try:
-            # Check vector field limit before adding
-            schema_info = self.milvus_client.describe_collection(self.c_name)
-            fields = schema_info.get("fields", [])
-            current_vector_fields = sum(
-                1
-                for f in fields
-                if f.get("type")
-                in (
-                    DataType.FLOAT_VECTOR,
-                    DataType.BINARY_VECTOR,
-                    DataType.FLOAT16_VECTOR,
-                    DataType.BFLOAT16_VECTOR,
-                    DataType.INT8_VECTOR,
-                    DataType.SPARSE_FLOAT_VECTOR,
-                )
-            )
-            if current_vector_fields >= 10:
-                log.info(
-                    f"[AddVectorFieldChecker] vector field limit reached "
-                    f"({current_vector_fields}), fallback to insert only"
-                )
-                _, insert_result = self.insert_data()
-                return None, insert_result
-
             new_vec_field = cf.gen_unique_str("new_vec_")
-            dim = 32
+            dim = self.dim
             self.milvus_client.add_collection_field(
                 collection_name=self.c_name,
                 field_name=new_vec_field,
@@ -2980,6 +2962,15 @@ class AddVectorFieldChecker(Checker):
 
             return None, True
         except Exception as e:
+            # When vector field limit is reached, fallback to insert only
+            if "maximum vector field" in str(e):
+                log.info("[AddVectorFieldChecker] vector field limit reached, fallback to insert only")
+                try:
+                    _, insert_result = self.insert_data()
+                    return None, insert_result
+                except Exception as insert_e:
+                    log.error(f"[AddVectorFieldChecker] fallback insert error: {insert_e}")
+                    return str(insert_e), False
             log.error(f"[AddVectorFieldChecker] error: {e}")
             return str(e), False
 


### PR DESCRIPTION
Cherry-pick from master

pr: #48105
issue: #49934

## Summary

Backport the chaos checker fix from #48105 to the 2.6 branch.

This addresses the checker-side failures observed during the 2.6 chaos run analysis:
- Hybrid search used one cached `self.dim` for all vector fields. After `AddVectorFieldChecker` mutates the schema, a collection can contain vector fields with different dimensions, so hybrid search must generate vectors using each field's actual schema dimension.
- `AddVectorFieldChecker` hardcoded new FLOAT_VECTOR fields as `dim=32`, which can diverge from the base collection schema.
- The previous vector-field-count precheck is unreliable under concurrent schema mutation. This backport follows master and falls back to insert-only when the server returns `maximum vector field`.

## Scope

This PR fixes only the Python chaos checker issue. The server crash tracked in #49934 is a separate Milvus 2.6 server bug and should be fixed by backporting #47151.

## Verification

- `python3 -m py_compile tests/python_client/chaos/checker.py`
- `git diff --check`