### PR TITLE
fix: Fix dangling reference in IndexingRecord

### DIFF
--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -29,6 +29,110 @@
 namespace milvus::segcore {
 using std::unique_ptr;
 
+void
+IndexingRecord::AppendingIndex(int64_t reserved_offset,
+                               int64_t size,
+                               FieldId fieldId,
+                               const DataArray* stream_data,
+                               const InsertRecord<false>& record,
+                               const FieldMeta& field_meta) {
+    // Check if field has indexing created
+    auto it = field_indexings_.find(fieldId);
+    if (it == field_indexings_.end()) {
+        return;
+    }
+
+    FieldIndexing* indexing_ptr = it->second.get();
+    auto type = indexing_ptr->get_data_type();
+    auto field_raw_data = record.get_data_base(fieldId);
+
+    int64_t valid_count = reserved_offset + size;
+    if (field_meta.is_nullable() && field_raw_data->is_mapping_storage()) {
+        valid_count = field_raw_data->get_valid_count();
+    }
+
+    if (type == DataType::VECTOR_FLOAT &&
+        valid_count >= indexing_ptr->get_build_threshold()) {
+        indexing_ptr->AppendSegmentIndexDense(
+            reserved_offset,
+            size,
+            field_raw_data,
+            stream_data->vectors().float_vector().data().data());
+    } else if (type == DataType::VECTOR_FLOAT16 &&
+               valid_count >= indexing_ptr->get_build_threshold()) {
+        indexing_ptr->AppendSegmentIndexDense(
+            reserved_offset,
+            size,
+            field_raw_data,
+            stream_data->vectors().float16_vector().data());
+    } else if (type == DataType::VECTOR_BFLOAT16 &&
+               valid_count >= indexing_ptr->get_build_threshold()) {
+        indexing_ptr->AppendSegmentIndexDense(
+            reserved_offset,
+            size,
+            field_raw_data,
+            stream_data->vectors().bfloat16_vector().data());
+    } else if (type == DataType::VECTOR_SPARSE_U32_F32 &&
+               valid_count >= indexing_ptr->get_build_threshold()) {
+        auto data = SparseBytesToRows(
+            stream_data->vectors().sparse_float_vector().contents());
+        indexing_ptr->AppendSegmentIndexSparse(
+            reserved_offset,
+            size,
+            stream_data->vectors().sparse_float_vector().dim(),
+            field_raw_data,
+            data.get());
+    } else if (type == DataType::GEOMETRY) {
+        // For geometry fields, append data incrementally to RTree index
+        indexing_ptr->AppendSegmentIndex(
+            reserved_offset, size, field_raw_data, stream_data);
+    }
+}
+
+// concurrent, reentrant
+void
+IndexingRecord::AppendingIndex(int64_t reserved_offset,
+                               int64_t size,
+                               FieldId fieldId,
+                               const FieldDataPtr data,
+                               const InsertRecord<false>& record,
+                               const FieldMeta& field_meta) {
+    // Check if field has indexing created
+    auto it = field_indexings_.find(fieldId);
+    if (it == field_indexings_.end()) {
+        return;
+    }
+
+    FieldIndexing* indexing_ptr = it->second.get();
+    auto type = indexing_ptr->get_data_type();
+    const void* p = data->Data();
+    auto vec_base = record.get_data_base(fieldId);
+
+    int64_t valid_count = reserved_offset + size;
+    if (field_meta.is_nullable() && vec_base->is_mapping_storage()) {
+        valid_count = vec_base->get_valid_count();
+    }
+
+    if ((type == DataType::VECTOR_FLOAT || type == DataType::VECTOR_FLOAT16 ||
+         type == DataType::VECTOR_BFLOAT16) &&
+        valid_count >= indexing_ptr->get_build_threshold()) {
+        indexing_ptr->AppendSegmentIndexDense(
+            reserved_offset, size, vec_base, p);
+    } else if (type == DataType::VECTOR_SPARSE_U32_F32 &&
+               valid_count >= indexing_ptr->get_build_threshold()) {
+        indexing_ptr->AppendSegmentIndexSparse(
+            reserved_offset,
+            size,
+            std::dynamic_pointer_cast<const FieldData<SparseFloatVector>>(data)
+                ->Dim(),
+            vec_base,
+            p);
+    } else if (type == DataType::GEOMETRY) {
+        // For geometry fields, append data incrementally to RTree index
+        indexing_ptr->AppendSegmentIndex(reserved_offset, size, vec_base, data);
+    }
+}
+
 VectorFieldIndexing::VectorFieldIndexing(const FieldMeta& field_meta,
                                          const FieldIndexMeta& field_index_meta,
                                          int64_t segment_max_row_count,

--- a/internal/core/src/segcore/FieldIndexing.h
+++ b/internal/core/src/segcore/FieldIndexing.h
@@ -364,19 +364,17 @@ class IndexingRecord {
                             const IndexMetaPtr& indexMetaPtr,
                             const SegcoreConfig& segcore_config,
                             const InsertRecord<false>* insert_record)
-        : schema_(schema),
-          index_meta_(indexMetaPtr),
-          segcore_config_(segcore_config) {
-        Initialize(insert_record);
+        : index_meta_(indexMetaPtr), segcore_config_(segcore_config) {
+        Initialize(schema, insert_record);
     }
 
     void
-    Initialize(const InsertRecord<false>* insert_record) {
+    Initialize(const Schema& schema, const InsertRecord<false>* insert_record) {
         int offset_id = 0;
         auto enable_growing_mmap = storage::MmapManager::GetInstance()
                                        .GetMmapConfig()
                                        .GetEnableGrowingMmap();
-        for (auto& [field_id, field_meta] : schema_.get_fields()) {
+        for (auto& [field_id, field_meta] : schema.get_fields()) {
             ++offset_id;
             if (field_meta.is_vector() &&
                 segcore_config_.get_enable_interim_segment_index() &&
@@ -431,7 +429,7 @@ class IndexingRecord {
                 }
             }
         }
-        assert(offset_id == schema_.size());
+        assert(offset_id == schema.size());
     }
 
     // concurrent, reentrant
@@ -440,49 +438,8 @@ class IndexingRecord {
                    int64_t size,
                    FieldId fieldId,
                    const DataArray* stream_data,
-                   const InsertRecord<false>& record) {
-        if (!is_in(fieldId)) {
-            return;
-        }
-        auto& indexing = field_indexings_.at(fieldId);
-        auto type = indexing->get_data_type();
-        auto field_raw_data = record.get_data_base(fieldId);
-        if (type == DataType::VECTOR_FLOAT &&
-            reserved_offset + size >= indexing->get_build_threshold()) {
-            indexing->AppendSegmentIndexDense(
-                reserved_offset,
-                size,
-                field_raw_data,
-                stream_data->vectors().float_vector().data().data());
-        } else if (type == DataType::VECTOR_FLOAT16 &&
-                   reserved_offset + size >= indexing->get_build_threshold()) {
-            indexing->AppendSegmentIndexDense(
-                reserved_offset,
-                size,
-                field_raw_data,
-                stream_data->vectors().float16_vector().data());
-        } else if (type == DataType::VECTOR_BFLOAT16 &&
-                   reserved_offset + size >= indexing->get_build_threshold()) {
-            indexing->AppendSegmentIndexDense(
-                reserved_offset,
-                size,
-                field_raw_data,
-                stream_data->vectors().bfloat16_vector().data());
-        } else if (type == DataType::VECTOR_SPARSE_U32_F32) {
-            auto data = SparseBytesToRows(
-                stream_data->vectors().sparse_float_vector().contents());
-            indexing->AppendSegmentIndexSparse(
-                reserved_offset,
-                size,
-                stream_data->vectors().sparse_float_vector().dim(),
-                field_raw_data,
-                data.get());
-        } else if (type == DataType::GEOMETRY) {
-            // For geometry fields, append data incrementally to RTree index
-            indexing->AppendSegmentIndex(
-                reserved_offset, size, field_raw_data, stream_data);
-        }
-    }
+                   const InsertRecord<false>& record,
+                   const FieldMeta& field_meta);
 
     // concurrent, reentrant
     void
@@ -490,37 +447,8 @@ class IndexingRecord {
                    int64_t size,
                    FieldId fieldId,
                    const FieldDataPtr data,
-                   const InsertRecord<false>& record) {
-        if (!is_in(fieldId)) {
-            return;
-        }
-        auto& indexing = field_indexings_.at(fieldId);
-        auto type = indexing->get_data_type();
-        const void* p = data->Data();
-
-        if ((type == DataType::VECTOR_FLOAT ||
-             type == DataType::VECTOR_FLOAT16 ||
-             type == DataType::VECTOR_BFLOAT16) &&
-            reserved_offset + size >= indexing->get_build_threshold()) {
-            auto vec_base = record.get_data_base(fieldId);
-            indexing->AppendSegmentIndexDense(
-                reserved_offset, size, vec_base, data->Data());
-        } else if (type == DataType::VECTOR_SPARSE_U32_F32) {
-            auto vec_base = record.get_data_base(fieldId);
-            indexing->AppendSegmentIndexSparse(
-                reserved_offset,
-                size,
-                std::dynamic_pointer_cast<const FieldData<SparseFloatVector>>(
-                    data)
-                    ->Dim(),
-                vec_base,
-                p);
-        } else if (type == DataType::GEOMETRY) {
-            // For geometry fields, append data incrementally to RTree index
-            auto vec_base = record.get_data_base(fieldId);
-            indexing->AppendSegmentIndex(reserved_offset, size, vec_base, data);
-        }
-    }
+                   const InsertRecord<false>& record,
+                   const FieldMeta& field_meta);
 
     // for sparse float vector:
     //   * element_size is not used
@@ -560,7 +488,6 @@ class IndexingRecord {
             const FieldIndexing& indexing = get_field_indexing(fieldId);
             return indexing.has_raw_data();
         }
-        // if this field id not in IndexingRecord or not build index, we should find raw data in InsertRecord instead of IndexingRecord.
         return false;
     }
 
@@ -605,7 +532,6 @@ class IndexingRecord {
     }
 
  private:
-    const Schema& schema_;
     IndexMetaPtr index_meta_;
     const SegcoreConfig& segcore_config_;
 
@@ -613,7 +539,6 @@ class IndexingRecord {
     std::atomic<int64_t> resource_ack_ = 0;
     //    std::atomic<int64_t> finished_ack_ = 0;
     AckResponder finished_ack_;
-    std::mutex mutex_;
 
     // field_offset => indexing
     std::map<FieldId, std::unique_ptr<FieldIndexing>> field_indexings_;

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -377,7 +377,8 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
                 num_rows,
                 field_id,
                 &insert_record_proto->fields_data(data_offset),
-                insert_record_);
+                insert_record_,
+                field_meta);
         }
 
         // index text.
@@ -555,6 +556,8 @@ SegmentGrowingImpl::load_field_data_common(
         return;
     }
 
+    auto field_meta = (*schema_)[field_id];
+
     if (!indexing_record_.HasRawData(field_id)) {
         if (insert_record_.is_valid_data_exist(field_id)) {
             insert_record_.get_valid_data(field_id)->set_data_raw(field_data);
@@ -567,7 +570,7 @@ SegmentGrowingImpl::load_field_data_common(
         for (auto& data : field_data) {
             auto row_count = data->get_num_rows();
             indexing_record_.AppendingIndex(
-                offset, row_count, field_id, data, insert_record_);
+                offset, row_count, field_id, data, insert_record_, field_meta);
             offset += row_count;
         }
     }
@@ -578,7 +581,6 @@ SegmentGrowingImpl::load_field_data_common(
     }
 
     // update average row data size
-    auto field_meta = (*schema_)[field_id];
     if (IsVariableDataType(field_meta.get_data_type())) {
         SegmentInternalInterface::set_field_avg_size(
             field_id, num_rows, storage::GetByteSizeOfFieldDatas(field_data));

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -53,6 +53,7 @@ set(MILVUS_TEST_FILES
         test_storage.cpp
         test_string_expr.cpp
         test_rust_result.cpp
+        test_schema_reopen.cpp
         test_storage_v2_index_raw_data.cpp
         test_group_by_json.cpp
         )

--- a/internal/core/unittest/test_schema_reopen.cpp
+++ b/internal/core/unittest/test_schema_reopen.cpp
@@ -1,0 +1,208 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "common/Schema.h"
+#include "segcore/SegmentGrowingImpl.h"
+#include "test_utils/DataGen.h"
+
+using namespace milvus;
+using namespace milvus::segcore;
+
+/**
+ * Test for Issue #46656: QueryNode panic with "unordered_map::at" during ProcessInsert
+ *
+ * Root Cause:
+ * - IndexingRecord holds a const reference to Schema (schema_)
+ * - When SegmentGrowingImpl::Reopen() updates schema_ to a new Schema object,
+ *   the old Schema object may be destroyed
+ * - IndexingRecord::schema_ becomes a dangling reference
+ * - Accessing schema_.get_fields().at(fieldId) causes undefined behavior:
+ *   - std::out_of_range if the hash table is partially corrupted
+ *   - SIGFPE if the hash table's bucket_count becomes 0
+ *
+ * Fix:
+ * - AppendingIndex no longer accesses internal schema_ reference
+ * - Caller passes in valid field_meta from current schema
+ */
+class SchemaReopenTest : public testing::Test {
+ protected:
+    void
+    SetUp() override {
+        // Create initial schema V1 with vector field
+        schema_v1_ = std::make_shared<Schema>();
+        auto vec_fid = schema_v1_->AddDebugField(
+            "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+        auto pk_fid = schema_v1_->AddDebugField("pk", DataType::INT64);
+        schema_v1_->set_primary_field_id(pk_fid);
+        schema_v1_->set_schema_version(1);
+
+        // Create schema V2 with additional field
+        schema_v2_ = std::make_shared<Schema>();
+        schema_v2_->AddDebugField(
+            "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+        auto pk_fid_v2 = schema_v2_->AddDebugField("pk", DataType::INT64);
+        schema_v2_->AddDebugField("new_field",
+                                  DataType::VARCHAR);  // New field in V2
+        schema_v2_->set_primary_field_id(pk_fid_v2);
+        schema_v2_->set_schema_version(2);
+    }
+
+    SchemaPtr schema_v1_;
+    SchemaPtr schema_v2_;
+};
+
+/**
+ * Test: Insert after Reopen should not crash
+ *
+ * Before fix: This test would crash with std::out_of_range or SIGFPE
+ * because IndexingRecord::AppendingIndex() accessed the dangling schema_ reference.
+ *
+ * After fix: Insert uses caller-provided field_meta, avoiding dangling reference.
+ */
+TEST_F(SchemaReopenTest, InsertAfterReopenShouldNotCrash) {
+    // Step 1: Create segment with schema V1
+    auto segment = CreateGrowingSegment(schema_v1_, nullptr);
+    auto seg_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(seg_impl, nullptr);
+
+    // Step 2: Insert some data with schema V1
+    int N = 100;
+    auto data_v1 = DataGen(schema_v1_, N, /*seed=*/42);
+    segment->PreInsert(N);
+    segment->Insert(0,
+                    N,
+                    data_v1.row_ids_.data(),
+                    data_v1.timestamps_.data(),
+                    data_v1.raw_);
+
+    // Step 3: Reopen with schema V2 (this may destroy old Schema object)
+    seg_impl->Reopen(schema_v2_);
+
+    // Step 4: Insert more data - this should NOT crash
+    // Before fix: This would crash because IndexingRecord::schema_ is dangling
+    // After fix: This works because AppendingIndex uses caller-provided field_meta
+    auto data_v2 = DataGen(schema_v2_, N, /*seed=*/100);
+    segment->PreInsert(N);
+
+    // This insert should complete without crashing
+    EXPECT_NO_THROW({
+        segment->Insert(N,
+                        N,
+                        data_v2.row_ids_.data(),
+                        data_v2.timestamps_.data(),
+                        data_v2.raw_);
+    });
+
+    // Verify segment state is valid
+    EXPECT_EQ(segment->get_row_count(), 2 * N);
+}
+
+/**
+ * Test: Concurrent Insert and Reopen should not crash
+ *
+ * This simulates the chaos testing scenario where Insert and schema updates
+ * happen concurrently after pod recovery.
+ */
+TEST_F(SchemaReopenTest, ConcurrentInsertAndReopenShouldNotCrash) {
+    auto segment = CreateGrowingSegment(schema_v1_, nullptr);
+    auto seg_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(seg_impl, nullptr);
+
+    std::atomic<bool> stop_flag{false};
+    std::atomic<int> insert_count{0};
+    std::vector<std::exception_ptr> exceptions;
+    std::mutex exceptions_mutex;
+
+    // Thread 1: Continuous inserts
+    auto insert_thread = std::thread([&]() {
+        int offset = 0;
+        while (!stop_flag.load()) {
+            try {
+                int N = 10;
+                auto data = DataGen(schema_v1_, N, offset);
+                segment->PreInsert(N);
+                segment->Insert(offset,
+                                N,
+                                data.row_ids_.data(),
+                                data.timestamps_.data(),
+                                data.raw_);
+                offset += N;
+                insert_count.fetch_add(1);
+            } catch (...) {
+                std::lock_guard<std::mutex> lock(exceptions_mutex);
+                exceptions.push_back(std::current_exception());
+                break;
+            }
+        }
+    });
+
+    // Thread 2: Periodic Reopen
+    auto reopen_thread = std::thread([&]() {
+        for (int i = 0; i < 5 && !stop_flag.load(); ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            try {
+                // Alternate between V1 and V2
+                if (i % 2 == 0) {
+                    seg_impl->Reopen(schema_v2_);
+                } else {
+                    seg_impl->Reopen(schema_v1_);
+                }
+            } catch (...) {
+                std::lock_guard<std::mutex> lock(exceptions_mutex);
+                exceptions.push_back(std::current_exception());
+                break;
+            }
+        }
+        stop_flag.store(true);
+    });
+
+    insert_thread.join();
+    reopen_thread.join();
+
+    // Verify no exceptions were thrown
+    EXPECT_TRUE(exceptions.empty())
+        << "Concurrent Insert/Reopen caused exceptions";
+
+    // Verify some inserts completed
+    EXPECT_GT(insert_count.load(), 0) << "Expected some inserts to complete";
+}
+
+/**
+ * Test: Field not in IndexingRecord should be handled gracefully
+ *
+ * When a new field is added via Reopen, it won't exist in IndexingRecord's
+ * field_indexings_ map. The code should handle this gracefully.
+ */
+TEST_F(SchemaReopenTest, NewFieldAfterReopenShouldBeSkipped) {
+    auto segment = CreateGrowingSegment(schema_v1_, nullptr);
+    auto seg_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(seg_impl, nullptr);
+
+    // Reopen with V2 which has a new field
+    seg_impl->Reopen(schema_v2_);
+
+    // Insert data that includes the new field
+    int N = 100;
+    auto data = DataGen(schema_v2_, N, 42);
+    segment->PreInsert(N);
+
+    // This should not crash - new field should be skipped in AppendingIndex
+    // because it doesn't exist in field_indexings_
+    EXPECT_NO_THROW({
+        segment->Insert(
+            0, N, data.row_ids_.data(), data.timestamps_.data(), data.raw_);
+    });
+}

--- a/internal/core/unittest/test_schema_reopen.cpp
+++ b/internal/core/unittest/test_schema_reopen.cpp
@@ -10,7 +10,10 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -43,25 +46,32 @@ class SchemaReopenTest : public testing::Test {
     SetUp() override {
         // Create initial schema V1 with vector field
         schema_v1_ = std::make_shared<Schema>();
-        auto vec_fid = schema_v1_->AddDebugField(
+        vec_fid_ = schema_v1_->AddDebugField(
             "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
-        auto pk_fid = schema_v1_->AddDebugField("pk", DataType::INT64);
-        schema_v1_->set_primary_field_id(pk_fid);
+        pk_fid_ = schema_v1_->AddDebugField("pk", DataType::INT64);
+        schema_v1_->set_primary_field_id(pk_fid_);
         schema_v1_->set_schema_version(1);
 
         // Create schema V2 with additional field
         schema_v2_ = std::make_shared<Schema>();
-        schema_v2_->AddDebugField(
-            "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
-        auto pk_fid_v2 = schema_v2_->AddDebugField("pk", DataType::INT64);
+        schema_v2_->AddField(FieldName("vec"),
+                             vec_fid_,
+                             DataType::VECTOR_FLOAT,
+                             128,
+                             knowhere::metric::L2,
+                             false);
+        schema_v2_->AddField(
+            FieldName("pk"), pk_fid_, DataType::INT64, false, std::nullopt);
         schema_v2_->AddDebugField("new_field",
                                   DataType::VARCHAR);  // New field in V2
-        schema_v2_->set_primary_field_id(pk_fid_v2);
+        schema_v2_->set_primary_field_id(pk_fid_);
         schema_v2_->set_schema_version(2);
     }
 
     SchemaPtr schema_v1_;
     SchemaPtr schema_v2_;
+    FieldId vec_fid_;
+    FieldId pk_fid_;
 };
 
 /**
@@ -89,6 +99,7 @@ TEST_F(SchemaReopenTest, InsertAfterReopenShouldNotCrash) {
                     data_v1.raw_);
 
     // Step 3: Reopen with schema V2 (this may destroy old Schema object)
+    schema_v1_.reset();
     seg_impl->Reopen(schema_v2_);
 
     // Step 4: Insert more data - this should NOT crash
@@ -192,6 +203,7 @@ TEST_F(SchemaReopenTest, NewFieldAfterReopenShouldBeSkipped) {
     ASSERT_NE(seg_impl, nullptr);
 
     // Reopen with V2 which has a new field
+    schema_v1_.reset();
     seg_impl->Reopen(schema_v2_);
 
     // Insert data that includes the new field


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Backport #47151 to hotfix-2.6.17.

Fix dangling reference in `IndexingRecord` after `SegmentGrowingImpl::Reopen()` updates the schema object.

issue: #46656
pr: #47151

## Which issue(s) this PR fixes:

issue: #46656

## Special notes for your reviewer:

Cherry-picked from commit 882d7be8fe39b25d6318f37f8cfc8b986b473507. Conflict resolution was needed in `FieldIndexing.cpp` and `FieldIndexing.h` because hotfix-2.6.17 already had part of the schema-reference removal while keeping `AppendingIndex` inline in the header.

## Test report

- `git diff --check origin/hotfix-2.6.17...HEAD` passed.
- Checked changed files for unresolved conflict markers: none found.
- `make run-test-cpp filter='SchemaReopenTest.*'` could not complete locally because `libmilvus-planparser.so` was not loadable from the existing local C++ test binary.