### PR TITLE
enhance: [cp2.6] improve querycoord task scheduling and dist cleanup

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -446,7 +446,6 @@ queryCoord:
   stoppingBalanceAssignPolicy: ScoreBased # assign policy for stopping balance, options: RoundRobin, RowCount, ScoreBased
   channelExclusiveNodeFactor: 4 # the least node number for enable channel's exclusive mode
   collectionObserverInterval: 200 # the interval of collection observer
-  checkExecutedFlagInterval: 100 # the interval of check executed flag to force to pull dist
   updateCollectionLoadStatusInterval: 5 # 5m, max interval of updating collection loaded status for check health
   channelTaskCapFraction: 0.3 # fraction of total task execution capacity reserved for channel tasks per node (0.0-1.0)
   # Duration (in seconds) that a query node remains marked as resource exhausted after reaching resource limits.

--- a/internal/querycoordv2/dist/dist_controller_test.go
+++ b/internal/querycoordv2/dist/dist_controller_test.go
@@ -80,7 +80,6 @@ func (suite *DistControllerTestSuite) SetupTest() {
 	suite.broker = meta.NewMockBroker(suite.T())
 	targetManager := meta.NewTargetManager(suite.broker, suite.meta)
 	suite.mockScheduler = task.NewMockScheduler(suite.T())
-	suite.mockScheduler.EXPECT().GetExecutedFlag(mock.Anything).Return(nil).Maybe()
 
 	suite.controller = NewDistController(suite.mockCluster, suite.nodeMgr, distManager, targetManager, suite.mockScheduler, func(collectionID ...int64) {})
 }

--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -71,9 +71,6 @@ func (dh *distHandler) start(ctx context.Context) {
 	distInterval := Params.QueryCoordCfg.DistPullInterval.GetAsDuration(time.Millisecond)
 	ticker := time.NewTicker(distInterval)
 	defer ticker.Stop()
-	flagInterval := Params.QueryCoordCfg.CheckExecutedFlagInterval.GetAsDuration(time.Millisecond)
-	checkExecutedFlagTicker := time.NewTicker(flagInterval)
-	defer checkExecutedFlagTicker.Stop()
 	failures := 0
 	for {
 		select {
@@ -83,25 +80,6 @@ func (dh *distHandler) start(ctx context.Context) {
 		case <-dh.c:
 			log.Info("close dist handler")
 			return
-		case <-checkExecutedFlagTicker.C:
-			executedFlagChan := dh.scheduler.GetExecutedFlag(dh.nodeID)
-			if executedFlagChan != nil {
-				select {
-				case <-executedFlagChan:
-					dh.pullDist(ctx, &failures, false)
-				default:
-				}
-			}
-			// only reset when interval updated
-			newFlagInterval := Params.QueryCoordCfg.CheckExecutedFlagInterval.GetAsDuration(time.Millisecond)
-			if newFlagInterval != flagInterval {
-				flagInterval = newFlagInterval
-				select {
-				case <-checkExecutedFlagTicker.C:
-				default:
-				}
-				checkExecutedFlagTicker.Reset(flagInterval)
-			}
 		case <-ticker.C:
 			dh.pullDist(ctx, &failures, true)
 			// only reset when interval updated

--- a/internal/querycoordv2/dist/dist_handler_test.go
+++ b/internal/querycoordv2/dist/dist_handler_test.go
@@ -52,7 +52,6 @@ type DistHandlerSuite struct {
 	nodeManager      *session.NodeManager
 	scheduler        *task.MockScheduler
 	dispatchMockCall *mock.Call
-	executedFlagChan chan struct{}
 	dist             *meta.DistributionManager
 	target           *meta.MockTargetManager
 	handler          *distHandler
@@ -69,8 +68,6 @@ func (suite *DistHandlerSuite) SetupSuite() {
 	suite.target = meta.NewMockTargetManager(suite.T())
 	suite.ctx = context.Background()
 
-	suite.executedFlagChan = make(chan struct{}, 1)
-	suite.scheduler.EXPECT().GetExecutedFlag(mock.Anything).Return(suite.executedFlagChan).Maybe()
 	suite.target.EXPECT().GetSealedSegment(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	suite.target.EXPECT().GetDmChannel(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	suite.target.EXPECT().GetCollectionTargetVersion(mock.Anything, mock.Anything, mock.Anything).Return(1011).Maybe()
@@ -143,54 +140,6 @@ func (suite *DistHandlerSuite) TestGetDistributionFailed() {
 	defer suite.handler.stop()
 
 	time.Sleep(3 * time.Second)
-}
-
-func (suite *DistHandlerSuite) TestForcePullDist() {
-	if suite.dispatchMockCall != nil {
-		suite.dispatchMockCall.Unset()
-		suite.dispatchMockCall = nil
-	}
-
-	suite.target.EXPECT().GetSealedSegmentsByChannel(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(map[int64]*datapb.SegmentInfo{}).Maybe()
-
-	suite.nodeManager.Add(session.NewNodeInfo(session.ImmutableNodeInfo{
-		NodeID:   1,
-		Address:  "localhost",
-		Hostname: "localhost",
-	}))
-	suite.client.EXPECT().GetDataDistribution(mock.Anything, mock.Anything, mock.Anything).Return(&querypb.GetDataDistributionResponse{
-		Status: merr.Success(),
-		NodeID: 1,
-		Channels: []*querypb.ChannelVersionInfo{
-			{
-				Channel:    "test-channel-1",
-				Collection: 1,
-				Version:    1,
-			},
-		},
-		Segments: []*querypb.SegmentVersionInfo{
-			{
-				ID:         1,
-				Collection: 1,
-				Partition:  1,
-				Channel:    "test-channel-1",
-				Version:    1,
-			},
-		},
-
-		LeaderViews: []*querypb.LeaderView{
-			{
-				Collection: 1,
-				Channel:    "test-channel-1",
-			},
-		},
-		LastModifyTs: 1,
-	}, nil)
-	suite.executedFlagChan <- struct{}{}
-	suite.handler = newDistHandler(suite.ctx, suite.nodeID, suite.client, suite.nodeManager, suite.scheduler, suite.dist, suite.target, func(collectionID ...int64) {})
-	defer suite.handler.stop()
-
-	time.Sleep(300 * time.Millisecond)
 }
 
 func (suite *DistHandlerSuite) TestHandlerWithSyncDelegatorChanges() {

--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -70,7 +70,6 @@ type Executor struct {
 	executingTasks    *typeutil.ConcurrentSet[string] // task index
 	channelTaskNum    atomic.Int32                    // channel task pool counter
 	nonChannelTaskNum atomic.Int32                    // non-channel task pool counter
-	executedFlag      chan struct{}
 }
 
 func NewExecutor(nodeID int64,
@@ -92,7 +91,6 @@ func NewExecutor(nodeID int64,
 		nodeMgr:   nodeMgr,
 
 		executingTasks: typeutil.NewConcurrentSet[string](),
-		executedFlag:   make(chan struct{}, 1),
 	}
 }
 
@@ -204,21 +202,12 @@ func (ex *Executor) Execute(task Task, step int) bool {
 	return true
 }
 
-func (ex *Executor) GetExecutedFlag() <-chan struct{} {
-	return ex.executedFlag
-}
-
 func (ex *Executor) removeTask(task Task, step int) {
 	if task.Err() != nil {
 		log.Info("execute action done, remove it",
 			zap.Int64("taskID", task.ID()),
 			zap.Int("step", step),
 			zap.Error(task.Err()))
-	} else {
-		select {
-		case ex.executedFlag <- struct{}{}:
-		default:
-		}
 	}
 
 	ex.executingTasks.Remove(task.Index())

--- a/internal/querycoordv2/task/mock_scheduler.go
+++ b/internal/querycoordv2/task/mock_scheduler.go
@@ -235,54 +235,6 @@ func (_c *MockScheduler_GetChannelTaskNum_Call) RunAndReturn(run func(...TaskFil
 	return _c
 }
 
-// GetExecutedFlag provides a mock function with given fields: nodeID
-func (_m *MockScheduler) GetExecutedFlag(nodeID int64) <-chan struct{} {
-	ret := _m.Called(nodeID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetExecutedFlag")
-	}
-
-	var r0 <-chan struct{}
-	if rf, ok := ret.Get(0).(func(int64) <-chan struct{}); ok {
-		r0 = rf(nodeID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(<-chan struct{})
-		}
-	}
-
-	return r0
-}
-
-// MockScheduler_GetExecutedFlag_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExecutedFlag'
-type MockScheduler_GetExecutedFlag_Call struct {
-	*mock.Call
-}
-
-// GetExecutedFlag is a helper method to define mock.On call
-//   - nodeID int64
-func (_e *MockScheduler_Expecter) GetExecutedFlag(nodeID interface{}) *MockScheduler_GetExecutedFlag_Call {
-	return &MockScheduler_GetExecutedFlag_Call{Call: _e.mock.On("GetExecutedFlag", nodeID)}
-}
-
-func (_c *MockScheduler_GetExecutedFlag_Call) Run(run func(nodeID int64)) *MockScheduler_GetExecutedFlag_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64))
-	})
-	return _c
-}
-
-func (_c *MockScheduler_GetExecutedFlag_Call) Return(_a0 <-chan struct{}) *MockScheduler_GetExecutedFlag_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockScheduler_GetExecutedFlag_Call) RunAndReturn(run func(int64) <-chan struct{}) *MockScheduler_GetExecutedFlag_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetSegmentTaskDelta provides a mock function with given fields: nodeID, collectionID
 func (_m *MockScheduler) GetSegmentTaskDelta(nodeID int64, collectionID int64) int {
 	ret := _m.Called(nodeID, collectionID)
@@ -569,7 +521,8 @@ func (_c *MockScheduler_Stop_Call) RunAndReturn(run func()) *MockScheduler_Stop_
 func NewMockScheduler(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockScheduler {
+},
+) *MockScheduler {
 	mock := &MockScheduler{}
 	mock.Mock.Test(t)
 

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -288,7 +288,6 @@ type Scheduler interface {
 	Add(task Task) error
 	Dispatch(node int64)
 	RemoveByNode(node int64)
-	GetExecutedFlag(nodeID int64) <-chan struct{}
 	GetChannelTaskNum(filters ...TaskFilter) int
 	GetSegmentTaskNum(filters ...TaskFilter) int
 	GetTasksJSON() string
@@ -705,15 +704,6 @@ func (scheduler *taskScheduler) decExecutingTaskDelta(task Task) {
 	case *ChannelTask:
 		scheduler.channelTaskDelta.Sub(task)
 	}
-}
-
-func (scheduler *taskScheduler) GetExecutedFlag(nodeID int64) <-chan struct{} {
-	executor, ok := scheduler.executors.Get(nodeID)
-	if !ok {
-		return nil
-	}
-
-	return executor.GetExecutedFlag()
 }
 
 type TaskFilter func(task Task) bool

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -953,13 +953,8 @@ func (scheduler *taskScheduler) schedule(node int64) {
 
 func (scheduler *taskScheduler) isRelated(task Task, node int64) bool {
 	for _, action := range task.Actions() {
-		if action.Node() == node {
-			return true
-		}
-		// LeaderAction.Node() returns the worker node, but the RPC is sent to the
-		// leader node. Match the leader node as well so that LeaderTasks are
-		// dispatched promptly when the leader reports dist.
-		if la, ok := action.(*LeaderAction); ok && la.GetLeaderID() == node {
+		// For LeaderAction, the worker node and executor node are both related.
+		if action.Node() == node || actionExecutorNode(action) == node {
 			return true
 		}
 	}

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -1129,9 +1129,7 @@ func WrapTaskLog(task Task, fields ...zap.Field) []zap.Field {
 }
 
 func (scheduler *taskScheduler) checkStale(task Task, checkDistExist bool) error {
-	log := log.Ctx(task.Context()).With(
-		zap.String("task", task.String()),
-	)
+	log := log.Ctx(task.Context())
 
 	// Get replica, but only fail if we need it for RO node check
 	// NilReplica (ID=-1) is used for reduce-only tasks like unsubscribe channel
@@ -1139,7 +1137,7 @@ func (scheduler *taskScheduler) checkStale(task Task, checkDistExist bool) error
 	if task.ReplicaID() != -1 {
 		replica = scheduler.meta.Get(scheduler.ctx, task.ReplicaID())
 		if replica == nil {
-			log.Warn("task stale due to replica not found")
+			log.Warn("task stale due to replica not found", zap.String("task", task.String()))
 			return merr.WrapErrReplicaNotFound(task.ReplicaID())
 		}
 	}
@@ -1159,6 +1157,7 @@ func (scheduler *taskScheduler) checkStale(task Task, checkDistExist bool) error
 			)
 			if len(existsInDist) > 0 {
 				log.Info("task stale due to segment already loaded in dist",
+					zap.String("task", task.String()),
 					zap.Int64("segmentID", segmentTask.SegmentID()))
 				return merr.WrapErrServiceInternal("segment already loaded in dist")
 			}
@@ -1183,17 +1182,17 @@ func (scheduler *taskScheduler) checkStale(task Task, checkDistExist bool) error
 
 		nodeInfo := scheduler.nodeMgr.Get(targetNode)
 		if nodeInfo == nil {
-			log.Warn("task stale due to node not found", zap.Int64("nodeID", targetNode))
+			log.Warn("task stale due to node not found", zap.String("task", task.String()), zap.Int64("nodeID", targetNode))
 			return merr.WrapErrNodeNotFound(targetNode)
 		}
 		if action.Type() == ActionTypeGrow {
 			if nodeInfo.IsStoppingState() {
-				log.Warn("task stale due to node offline", zap.Int64("nodeID", targetNode))
+				log.Warn("task stale due to node offline", zap.String("task", task.String()), zap.Int64("nodeID", targetNode))
 				return merr.WrapErrNodeOffline(targetNode)
 			}
 
 			if replica != nil && (replica.ContainRONode(targetNode) || replica.ContainROSQNode(targetNode)) {
-				log.Warn("task stale due to node becomes ro node", zap.Int64("nodeID", targetNode))
+				log.Warn("task stale due to node becomes ro node", zap.String("task", task.String()), zap.Int64("nodeID", targetNode))
 				return merr.WrapErrNodeStateUnexpected(targetNode, "node becomes ro node")
 			}
 		}

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -34,7 +34,6 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
-	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
@@ -127,7 +126,6 @@ func (queue *taskQueue) Len() int {
 	for _, tasks := range queue.buckets {
 		taskNum += len(tasks)
 	}
-
 	return taskNum
 }
 
@@ -151,6 +149,107 @@ func (queue *taskQueue) Range(fn func(task Task) bool) {
 	defer queue.mu.RUnlock()
 	for priority := len(queue.buckets) - 1; priority >= 0; priority-- {
 		for _, task := range queue.buckets[priority] {
+			if !fn(task) {
+				return
+			}
+		}
+	}
+}
+
+type nodeTaskQueue struct {
+	mu sync.RWMutex
+	// NodeID -> TaskPriority -> TaskID -> Task
+	buckets map[int64][]map[int64]Task
+}
+
+func newNodeTaskQueue() *nodeTaskQueue {
+	return &nodeTaskQueue{
+		buckets: make(map[int64][]map[int64]Task),
+	}
+}
+
+// Len returns the total number of unique tasks across all nodes.
+// A task appearing in multiple node buckets (e.g. Move task) is counted once.
+func (queue *nodeTaskQueue) Len() int {
+	queue.mu.RLock()
+	defer queue.mu.RUnlock()
+	seen := make(map[int64]struct{})
+	for _, nodeBuckets := range queue.buckets {
+		for _, bucket := range nodeBuckets {
+			for taskID := range bucket {
+				seen[taskID] = struct{}{}
+			}
+		}
+	}
+	return len(seen)
+}
+
+// LenByNode returns the number of tasks related to the specified node.
+func (queue *nodeTaskQueue) LenByNode(nodeID int64) int {
+	queue.mu.RLock()
+	defer queue.mu.RUnlock()
+	nodeBuckets, ok := queue.buckets[nodeID]
+	if !ok {
+		return 0
+	}
+	n := 0
+	for _, bucket := range nodeBuckets {
+		n += len(bucket)
+	}
+	return n
+}
+
+func (queue *nodeTaskQueue) Add(task Task) {
+	queue.mu.Lock()
+	defer queue.mu.Unlock()
+	for _, action := range task.Actions() {
+		queue.addToBucket(action.Node(), task)
+		if la, ok := action.(*LeaderAction); ok {
+			queue.addToBucket(la.GetLeaderID(), task)
+		}
+	}
+}
+
+func (queue *nodeTaskQueue) Remove(task Task) {
+	queue.mu.Lock()
+	defer queue.mu.Unlock()
+	for _, action := range task.Actions() {
+		queue.removeFromBucket(action.Node(), task)
+		if la, ok := action.(*LeaderAction); ok {
+			queue.removeFromBucket(la.GetLeaderID(), task)
+		}
+	}
+}
+
+func (queue *nodeTaskQueue) addToBucket(nodeID int64, task Task) {
+	nodeBuckets, ok := queue.buckets[nodeID]
+	if !ok {
+		nodeBuckets = make([]map[int64]Task, len(TaskPriorities))
+		for i := range nodeBuckets {
+			nodeBuckets[i] = make(map[int64]Task)
+		}
+		queue.buckets[nodeID] = nodeBuckets
+	}
+	nodeBuckets[task.Priority()][task.ID()] = task
+}
+
+func (queue *nodeTaskQueue) removeFromBucket(nodeID int64, task Task) {
+	if nodeBuckets, ok := queue.buckets[nodeID]; ok {
+		delete(nodeBuckets[task.Priority()], task.ID())
+	}
+}
+
+// RangeByNode iterates tasks related to the specified node,
+// ordered by priority from high to low.
+func (queue *nodeTaskQueue) RangeByNode(nodeID int64, fn func(task Task) bool) {
+	queue.mu.RLock()
+	defer queue.mu.RUnlock()
+	nodeBuckets, ok := queue.buckets[nodeID]
+	if !ok {
+		return
+	}
+	for priority := len(nodeBuckets) - 1; priority >= 0; priority-- {
+		for _, task := range nodeBuckets[priority] {
 			if !fn(task) {
 				return
 			}
@@ -308,12 +407,12 @@ type taskScheduler struct {
 	cluster   session.Cluster
 	nodeMgr   *session.NodeManager
 
-	scheduleMu   sync.Mutex           // guards schedule()
+	scheduleMu   sync.Mutex           // guards schedule() and RemoveByNode()
 	collKeyLock  *lock.KeyLock[int64] // guards Add()
 	tasks        *ConcurrentMap[UniqueID, struct{}]
 	segmentTasks *ConcurrentMap[replicaSegmentIndex, Task]
 	channelTasks *ConcurrentMap[replicaChannelIndex, Task]
-	processQueue *taskQueue
+	processQueue *nodeTaskQueue
 	waitQueue    *taskQueue
 
 	taskStats            *expirable.LRU[UniqueID, Task]
@@ -351,7 +450,7 @@ func NewScheduler(ctx context.Context,
 		tasks:            NewConcurrentMap[UniqueID, struct{}](),
 		segmentTasks:     NewConcurrentMap[replicaSegmentIndex, Task](),
 		channelTasks:     NewConcurrentMap[replicaChannelIndex, Task](),
-		processQueue:     newTaskQueue(),
+		processQueue:     newNodeTaskQueue(),
 		waitQueue:        newTaskQueue(),
 		taskStats:        expirable.NewLRU[UniqueID, Task](256, nil, time.Minute*15),
 		segmentTaskDelta: NewExecutingTaskDelta(),
@@ -796,7 +895,7 @@ func (scheduler *taskScheduler) schedule(node int64) {
 	promoteDur := tr.RecordSpan()
 
 	log.Debug("process tasks related to node",
-		zap.Int("processingTaskNum", scheduler.processQueue.Len()),
+		zap.Int("processingTaskNum", scheduler.processQueue.LenByNode(node)),
 		zap.Int("waitingTaskNum", scheduler.waitQueue.Len()),
 		zap.Int("segmentTaskNum", scheduler.segmentTasks.Len()),
 		zap.Int("channelTaskNum", scheduler.channelTasks.Len()),
@@ -805,11 +904,11 @@ func (scheduler *taskScheduler) schedule(node int64) {
 	// Process tasks
 	toProcess := make([]Task, 0)
 	toRemove := make([]Task, 0)
-	scheduler.processQueue.Range(func(task Task) bool {
-		if scheduler.preProcess(task) && scheduler.isRelated(task, node) {
+	scheduler.processQueue.RangeByNode(node, func(task Task) bool {
+		scheduler.preProcess(task)
+		if task.Status() == TaskStatusStarted {
 			toProcess = append(toProcess, task)
-		}
-		if task.Status() != TaskStatusStarted {
+		} else {
 			toRemove = append(toRemove, task)
 		}
 
@@ -845,7 +944,7 @@ func (scheduler *taskScheduler) schedule(node int64) {
 	)
 
 	log.Info("process tasks related to node done",
-		zap.Int("processingTaskNum", scheduler.processQueue.Len()),
+		zap.Int("processingTaskNum", scheduler.processQueue.LenByNode(node)),
 		zap.Int("waitingTaskNum", scheduler.waitQueue.Len()),
 		zap.Int("segmentTaskNum", scheduler.segmentTasks.Len()),
 		zap.Int("channelTaskNum", scheduler.channelTasks.Len()),
@@ -857,30 +956,21 @@ func (scheduler *taskScheduler) isRelated(task Task, node int64) bool {
 		if action.Node() == node {
 			return true
 		}
-		if task, ok := task.(*SegmentTask); ok {
-			taskType := GetTaskType(task)
-			var segment *datapb.SegmentInfo
-			if taskType == TaskTypeMove || taskType == TaskTypeUpdate {
-				segment = scheduler.targetMgr.GetSealedSegment(task.ctx, task.CollectionID(), task.SegmentID(), meta.CurrentTarget)
-			} else {
-				segment = scheduler.targetMgr.GetSealedSegment(task.ctx, task.CollectionID(), task.SegmentID(), meta.NextTarget)
-			}
-			if segment == nil {
-				continue
-			}
-			if task.replica == nil {
-				continue
-			}
-			leader := scheduler.getReplicaShardLeader(task.Shard(), task.ReplicaID())
-			if leader == nil {
-				continue
-			}
-			if leader.Node == node {
-				return true
-			}
+		// LeaderAction.Node() returns the worker node, but the RPC is sent to the
+		// leader node. Match the leader node as well so that LeaderTasks are
+		// dispatched promptly when the leader reports dist.
+		if la, ok := action.(*LeaderAction); ok && la.GetLeaderID() == node {
+			return true
 		}
 	}
 	return false
+}
+
+func actionExecutorNode(action Action) int64 {
+	if la, ok := action.(*LeaderAction); ok {
+		return la.GetLeaderID()
+	}
+	return action.Node()
 }
 
 // preProcess checks the finished actions of task,
@@ -948,11 +1038,12 @@ func (scheduler *taskScheduler) process(task Task) bool {
 	)
 
 	actions, step := task.Actions(), task.Step()
-	executor, ok := scheduler.executors.Get(actions[step].Node())
+	nodeID := actionExecutorNode(actions[step])
+	executor, ok := scheduler.executors.Get(nodeID)
 	if !ok {
 		log.Warn("no executor for QueryNode",
 			zap.Int("step", step),
-			zap.Int64("nodeID", actions[step].Node()))
+			zap.Int64("nodeID", nodeID))
 		return false
 	}
 
@@ -969,6 +1060,9 @@ func (scheduler *taskScheduler) check(task Task, checkDistExist bool) error {
 }
 
 func (scheduler *taskScheduler) RemoveByNode(node int64) {
+	scheduler.scheduleMu.Lock()
+	defer scheduler.scheduleMu.Unlock()
+
 	scheduler.segmentTasks.Range(func(_ replicaSegmentIndex, task Task) bool {
 		if scheduler.isRelated(task, node) {
 			scheduler.remove(task)

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -499,7 +499,6 @@ func (suite *TaskSuite) TestLoadSegmentTask() {
 
 	// Process tasks
 	suite.dispatchAndWait(targetNode)
-	suite.assertExecutedFlagChan(targetNode)
 	suite.AssertTaskNum(segmentsNum, 0, 0, segmentsNum)
 
 	// Process tasks done
@@ -613,7 +612,6 @@ func (suite *TaskSuite) TestLoadSegmentReopenTask() {
 	suite.AssertTaskNum(0, 1, 0, 1)
 
 	suite.dispatchAndWait(targetNode)
-	suite.assertExecutedFlagChan(targetNode)
 	suite.AssertTaskNum(1, 0, 0, 1)
 
 	suite.dist.ChannelDistManager.Update(targetNode, &meta.DmChannel{
@@ -1530,17 +1528,6 @@ func (suite *TaskSuite) dispatchAndWait(node int64) {
 		time.Sleep(200 * time.Millisecond)
 	}
 	suite.FailNow("executor hangs in executing tasks", "count=%d keys=%+v", count, keys)
-}
-
-func (suite *TaskSuite) assertExecutedFlagChan(targetNode int64) {
-	flagChan := suite.scheduler.GetExecutedFlag(targetNode)
-	if flagChan != nil {
-		select {
-		case <-flagChan:
-		default:
-			suite.FailNow("task not executed")
-		}
-	}
 }
 
 func (suite *TaskSuite) TestLeaderTaskRemove() {

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -1044,7 +1044,7 @@ func (suite *TaskSuite) TestMoveSegmentTask() {
 	suite.AssertTaskNum(0, segmentsNum, 0, segmentsNum)
 
 	// Process tasks
-	suite.dispatchAndWait(leader)
+	suite.dispatchAndWait(targetNode)
 	suite.AssertTaskNum(segmentsNum, 0, 0, segmentsNum)
 
 	// Process tasks, target node contains the segment
@@ -1058,9 +1058,9 @@ func (suite *TaskSuite) TestMoveSegmentTask() {
 
 	suite.dist.SegmentDistManager.Update(targetNode, distSegments...)
 	// First action done, execute the second action
-	suite.dispatchAndWait(leader)
+	suite.dispatchAndWait(sourceNode)
 	// Check second action
-	suite.dispatchAndWait(leader)
+	suite.dispatchAndWait(sourceNode)
 	suite.AssertTaskNum(0, 0, 0, 0)
 
 	for _, task := range tasks {
@@ -1493,6 +1493,55 @@ func (suite *TaskSuite) TestNoExecutor() {
 	suite.AssertTaskNum(0, 0, 0, 0)
 }
 
+func (suite *TaskSuite) TestRemoveByNodeWaitsForSchedule() {
+	ctx := context.Background()
+	targetNode := int64(1)
+
+	task, err := NewSegmentTask(
+		ctx,
+		10*time.Second,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(targetNode, ActionTypeGrow, "ch-0", 999),
+	)
+	suite.NoError(err)
+	suite.NoError(suite.scheduler.Add(task))
+	suite.AssertTaskNum(0, 1, 0, 1)
+
+	suite.scheduler.scheduleMu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			suite.scheduler.scheduleMu.Unlock()
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		suite.scheduler.RemoveByNode(targetNode)
+	}()
+
+	select {
+	case <-done:
+		suite.FailNow("RemoveByNode should wait for scheduleMu")
+	case <-time.After(50 * time.Millisecond):
+	}
+	suite.AssertTaskNum(0, 1, 0, 1)
+
+	suite.scheduler.scheduleMu.Unlock()
+	locked = false
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		suite.FailNow("RemoveByNode blocked after scheduleMu was released")
+	}
+	suite.AssertTaskNum(0, 0, 0, 0)
+}
+
 func (suite *TaskSuite) AssertTaskNum(process, wait, channel, segment int) {
 	scheduler := suite.scheduler
 
@@ -1602,6 +1651,44 @@ func (suite *TaskSuite) TestLeaderTaskRemove() {
 		suite.Equal(TaskStatusSucceeded, task.Status())
 		suite.NoError(task.Err())
 	}
+}
+
+func (suite *TaskSuite) TestLeaderTaskUsesLeaderExecutor() {
+	ctx := context.Background()
+	leaderID := int64(1)
+	workerID := int64(2)
+	segmentID := suite.releaseSegments[0]
+	channel := &datapb.VchannelInfo{
+		CollectionID: suite.collection,
+		ChannelName:  Params.CommonCfg.RootCoordDml.GetValue() + "-leader-executor",
+	}
+
+	suite.scheduler.RemoveExecutor(workerID)
+	suite.cluster.EXPECT().SyncDistribution(mock.Anything, leaderID, mock.MatchedBy(func(req *querypb.SyncDistributionRequest) bool {
+		return req.GetCollectionID() == suite.collection &&
+			req.GetChannel() == channel.GetChannelName() &&
+			len(req.GetActions()) == 1 &&
+			req.GetActions()[0].GetType() == querypb.SyncType_Remove &&
+			req.GetActions()[0].GetSegmentID() == segmentID &&
+			req.GetActions()[0].GetNodeID() == workerID
+	})).Return(merr.Success(), nil).Once()
+
+	task := NewLeaderSegmentTask(
+		ctx,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		leaderID,
+		NewLeaderAction(leaderID, workerID, ActionTypeReduce, channel.GetChannelName(), segmentID, 0),
+	)
+	suite.NoError(suite.scheduler.Add(task))
+
+	suite.dispatchAndWait(leaderID)
+
+	suite.dispatchAndWait(leaderID)
+	suite.Equal(TaskStatusSucceeded, task.Status())
+	suite.NoError(task.Err())
+	suite.AssertTaskNum(0, 0, 0, 0)
 }
 
 func (suite *TaskSuite) newScheduler() *taskScheduler {
@@ -2553,4 +2640,277 @@ func (suite *TaskSuite) TestTaskStaleBySegmentInDist() {
 		suite.scheduler.remove(task)
 		suite.dist.SegmentDistManager.Update(targetNode)
 	})
+}
+
+func (suite *TaskSuite) TestTaskQueueRangePriority() {
+	queue := newTaskQueue()
+	nodeID := int64(1)
+
+	taskLow, err := NewSegmentTask(
+		suite.ctx,
+		5*time.Second,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(nodeID, ActionTypeGrow, "ch-0", 400),
+	)
+	suite.NoError(err)
+	taskLow.SetID(31)
+	taskLow.SetPriority(TaskPriorityLow)
+
+	taskNormal, err := NewSegmentTask(
+		suite.ctx,
+		5*time.Second,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(nodeID, ActionTypeGrow, "ch-0", 401),
+	)
+	suite.NoError(err)
+	taskNormal.SetID(32)
+	taskNormal.SetPriority(TaskPriorityNormal)
+
+	taskHigh, err := NewSegmentTask(
+		suite.ctx,
+		5*time.Second,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(nodeID, ActionTypeGrow, "ch-0", 402),
+	)
+	suite.NoError(err)
+	taskHigh.SetID(33)
+	taskHigh.SetPriority(TaskPriorityHigh)
+
+	queue.Add(taskLow)
+	queue.Add(taskHigh)
+	queue.Add(taskNormal)
+
+	suite.Equal(3, queue.Len())
+
+	var visited []Priority
+	queue.Range(func(t Task) bool {
+		visited = append(visited, t.Priority())
+		return true
+	})
+	suite.Equal([]Priority{TaskPriorityHigh, TaskPriorityNormal, TaskPriorityLow}, visited)
+
+	queue.Remove(taskHigh)
+	suite.Equal(2, queue.Len())
+}
+
+func (suite *TaskSuite) TestNodeTaskQueueNodeBucketing() {
+	queue := newNodeTaskQueue()
+
+	task1, err := NewSegmentTask(
+		suite.ctx,
+		5*time.Second,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(1, ActionTypeGrow, "ch-0", 100),
+	)
+	suite.NoError(err)
+	task1.SetID(1)
+
+	task2, err := NewSegmentTask(
+		suite.ctx,
+		5*time.Second,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(2, ActionTypeGrow, "ch-0", 101),
+	)
+	suite.NoError(err)
+	task2.SetID(2)
+
+	task3, err := NewSegmentTask(
+		suite.ctx,
+		5*time.Second,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(1, ActionTypeGrow, "ch-0", 102),
+	)
+	suite.NoError(err)
+	task3.SetID(3)
+
+	queue.Add(task1)
+	queue.Add(task2)
+	queue.Add(task3)
+
+	suite.Equal(3, queue.Len())
+	suite.Equal(2, queue.LenByNode(1))
+	suite.Equal(1, queue.LenByNode(2))
+	suite.Equal(0, queue.LenByNode(999))
+
+	var node1Tasks []Task
+	queue.RangeByNode(1, func(task Task) bool {
+		node1Tasks = append(node1Tasks, task)
+		return true
+	})
+	suite.Equal(2, len(node1Tasks))
+
+	var node2Tasks []Task
+	queue.RangeByNode(2, func(task Task) bool {
+		node2Tasks = append(node2Tasks, task)
+		return true
+	})
+	suite.Equal(1, len(node2Tasks))
+	suite.Equal(int64(2), node2Tasks[0].ID())
+
+	queue.Remove(task1)
+	suite.Equal(2, queue.Len())
+	suite.Equal(1, queue.LenByNode(1))
+	suite.Equal(1, queue.LenByNode(2))
+}
+
+func (suite *TaskSuite) TestNodeTaskQueueMoveTaskDualNode() {
+	queue := newNodeTaskQueue()
+
+	destNode := int64(1)
+	srcNode := int64(2)
+	segmentID := int64(200)
+
+	task, err := NewSegmentTask(
+		suite.ctx,
+		5*time.Second,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(destNode, ActionTypeGrow, "ch-0", segmentID),
+		NewSegmentAction(srcNode, ActionTypeReduce, "ch-0", segmentID),
+	)
+	suite.NoError(err)
+	task.SetID(10)
+
+	queue.Add(task)
+
+	suite.Equal(1, queue.Len())
+	suite.Equal(1, queue.LenByNode(destNode))
+	suite.Equal(1, queue.LenByNode(srcNode))
+
+	var destTasks []Task
+	queue.RangeByNode(destNode, func(t Task) bool {
+		destTasks = append(destTasks, t)
+		return true
+	})
+	suite.Equal(1, len(destTasks))
+	suite.Equal(int64(10), destTasks[0].ID())
+
+	var srcTasks []Task
+	queue.RangeByNode(srcNode, func(t Task) bool {
+		srcTasks = append(srcTasks, t)
+		return true
+	})
+	suite.Equal(1, len(srcTasks))
+	suite.Equal(int64(10), srcTasks[0].ID())
+
+	queue.Remove(task)
+	suite.Equal(0, queue.Len())
+	suite.Equal(0, queue.LenByNode(destNode))
+	suite.Equal(0, queue.LenByNode(srcNode))
+}
+
+func (suite *TaskSuite) TestNodeTaskQueueLeaderActionDualNode() {
+	queue := newNodeTaskQueue()
+
+	leaderID := int64(1)
+	workerID := int64(2)
+	segmentID := int64(300)
+
+	action := NewLeaderAction(leaderID, workerID, ActionTypeGrow, "ch-0", segmentID, 1)
+	task := NewLeaderSegmentTask(suite.ctx, WrapIDSource(0), suite.collection, suite.replica, leaderID, action)
+	task.SetID(20)
+
+	queue.Add(task)
+
+	suite.Equal(1, queue.Len())
+	suite.Equal(1, queue.LenByNode(workerID))
+	suite.Equal(1, queue.LenByNode(leaderID))
+
+	var workerTasks []Task
+	queue.RangeByNode(workerID, func(t Task) bool {
+		workerTasks = append(workerTasks, t)
+		return true
+	})
+	suite.Equal(1, len(workerTasks))
+	suite.Equal(int64(20), workerTasks[0].ID())
+
+	var leaderTasks []Task
+	queue.RangeByNode(leaderID, func(t Task) bool {
+		leaderTasks = append(leaderTasks, t)
+		return true
+	})
+	suite.Equal(1, len(leaderTasks))
+	suite.Equal(int64(20), leaderTasks[0].ID())
+
+	queue.Remove(task)
+	suite.Equal(0, queue.Len())
+	suite.Equal(0, queue.LenByNode(workerID))
+	suite.Equal(0, queue.LenByNode(leaderID))
+}
+
+func (suite *TaskSuite) TestNodeTaskQueueRangeByNodePriority() {
+	queue := newNodeTaskQueue()
+	nodeID := int64(1)
+
+	taskLow, err := NewSegmentTask(
+		suite.ctx,
+		5*time.Second,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(nodeID, ActionTypeGrow, "ch-0", 400),
+	)
+	suite.NoError(err)
+	taskLow.SetID(31)
+	taskLow.SetPriority(TaskPriorityLow)
+
+	taskNormal, err := NewSegmentTask(
+		suite.ctx,
+		5*time.Second,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(nodeID, ActionTypeGrow, "ch-0", 401),
+	)
+	suite.NoError(err)
+	taskNormal.SetID(32)
+	taskNormal.SetPriority(TaskPriorityNormal)
+
+	taskHigh, err := NewSegmentTask(
+		suite.ctx,
+		5*time.Second,
+		WrapIDSource(0),
+		suite.collection,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentAction(nodeID, ActionTypeGrow, "ch-0", 402),
+	)
+	suite.NoError(err)
+	taskHigh.SetID(33)
+	taskHigh.SetPriority(TaskPriorityHigh)
+
+	queue.Add(taskLow)
+	queue.Add(taskHigh)
+	queue.Add(taskNormal)
+
+	suite.Equal(3, queue.LenByNode(nodeID))
+
+	var visited []Priority
+	queue.RangeByNode(nodeID, func(t Task) bool {
+		visited = append(visited, t.Priority())
+		return true
+	})
+	suite.Equal([]Priority{TaskPriorityHigh, TaskPriorityNormal, TaskPriorityLow}, visited)
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2627,7 +2627,6 @@ type queryCoordConfig struct {
 	ChannelExclusiveNodeFactor     ParamItem `refreshable:"true"`
 
 	CollectionObserverInterval         ParamItem `refreshable:"false"`
-	CheckExecutedFlagInterval          ParamItem `refreshable:"false"`
 	CollectionBalanceSegmentBatchSize  ParamItem `refreshable:"true"`
 	CollectionBalanceChannelBatchSize  ParamItem `refreshable:"true"`
 	UpdateCollectionLoadStatusInterval ParamItem `refreshable:"false"`
@@ -3205,15 +3204,6 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       true,
 	}
 	p.CollectionObserverInterval.Init(base.mgr)
-
-	p.CheckExecutedFlagInterval = ParamItem{
-		Key:          "queryCoord.checkExecutedFlagInterval",
-		Version:      "2.4.4",
-		DefaultValue: "100",
-		Doc:          "the interval of check executed flag to force to pull dist",
-		Export:       true,
-	}
-	p.CheckExecutedFlagInterval.Init(base.mgr)
 
 	p.CollectionBalanceSegmentBatchSize = ParamItem{
 		Key:          "queryCoord.collectionBalanceSegmentBatchSize",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -398,11 +398,6 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 100, Params.CollectionObserverInterval.GetAsInt())
 		params.Reset("queryCoord.collectionObserverInterval")
 
-		assert.Equal(t, 100, Params.CheckExecutedFlagInterval.GetAsInt())
-		params.Save("queryCoord.checkExecutedFlagInterval", "200")
-		assert.Equal(t, 200, Params.CheckExecutedFlagInterval.GetAsInt())
-		params.Reset("queryCoord.checkExecutedFlagInterval")
-
 		assert.Equal(t, 0.1, Params.DelegatorMemoryOverloadFactor.GetAsFloat())
 		assert.Equal(t, 5, Params.CollectionBalanceSegmentBatchSize.GetAsInt())
 		assert.Equal(t, 1, Params.CollectionBalanceChannelBatchSize.GetAsInt())


### PR DESCRIPTION
Cherry-pick from master
pr: #49528

issue: #49512

## Test Plan

- git diff --check
- gofumpt -l internal/querycoordv2/dist/dist_controller_test.go internal/querycoordv2/dist/dist_handler.go internal/querycoordv2/dist/dist_handler_test.go internal/querycoordv2/task/executor.go internal/querycoordv2/task/mock_scheduler.go internal/querycoordv2/task/scheduler.go internal/querycoordv2/task/task_test.go pkg/util/paramtable/component_param.go pkg/util/paramtable/component_param_test.go
- CONAN_CMD=conan-1 make
- zsh -c 'source scripts/setenv.sh && go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r ${MILVUS_WORK_DIR}/cmake_build/lib -r ${MILVUS_WORK_DIR}/internal/core/output/lib" ./internal/querycoordv2/task ./internal/querycoordv2/dist -timeout 600s'
- zsh -c 'cd pkg && go test -v -count=1 ./util/paramtable -timeout 300s'
