### PR TITLE
fix: keep text match stats paths compatible

### DIFF
--- a/internal/core/src/index/TextMatchIndex.cpp
+++ b/internal/core/src/index/TextMatchIndex.cpp
@@ -20,6 +20,18 @@
 #include "storage/ThreadPools.h"
 
 namespace milvus::index {
+
+namespace {
+std::string
+StripTextLogPrefix(const std::string& path, const std::string& base_prefix) {
+    if (path.size() > base_prefix.size() &&
+        path.compare(0, base_prefix.size(), base_prefix) == 0) {
+        return path.substr(base_prefix.size());
+    }
+    return path;
+}
+}  // namespace
+
 TextMatchIndex::TextMatchIndex(int64_t commit_interval_in_ms,
                                const char* unique_id,
                                const char* analyzer_name,
@@ -127,26 +139,37 @@ TextMatchIndex::Upload(const Config& config) {
     // This makes the returned paths consistent with JsonKeyStats::Upload()
     // which also returns relative paths.
     auto base_prefix = disk_file_manager_->GetRemoteTextLogPrefix() + "/";
-    auto strip_prefix = [&base_prefix](const std::string& path) -> std::string {
-        if (path.size() > base_prefix.size() &&
-            path.compare(0, base_prefix.size(), base_prefix) == 0) {
-            return path.substr(base_prefix.size());
-        }
-        return path;
-    };
 
     std::vector<SerializedIndexFileInfo> index_files;
     index_files.reserve(remote_paths_to_size.size() +
                         remote_mem_path_to_size.size());
     for (auto& file : remote_paths_to_size) {
-        index_files.emplace_back(strip_prefix(file.first), file.second);
+        index_files.emplace_back(StripTextLogPrefix(file.first, base_prefix),
+                                 file.second);
     }
     for (auto& file : remote_mem_path_to_size) {
-        index_files.emplace_back(strip_prefix(file.first), file.second);
+        index_files.emplace_back(StripTextLogPrefix(file.first, base_prefix),
+                                 file.second);
     }
     return IndexStats::New(this->file_manager_->GetAddedTotalMemSize() +
                                disk_file_manager_->GetAddedTotalFileSize(),
                            std::move(index_files));
+}
+
+IndexStatsPtr
+TextMatchIndex::UploadUnified(const Config& config) {
+    auto stats = ScalarIndex<std::string>::UploadUnified(config);
+
+    auto base_prefix = this->file_manager_->GetRemoteTextLogPrefix() + "/";
+    std::vector<SerializedIndexFileInfo> index_files;
+    const auto& uploaded = stats->GetSerializedIndexFileInfo();
+    index_files.reserve(uploaded.size());
+    for (const auto& file : uploaded) {
+        index_files.emplace_back(
+            StripTextLogPrefix(file.file_name, base_prefix), file.file_size);
+    }
+
+    return IndexStats::New(stats->GetMemSize(), std::move(index_files));
 }
 
 void

--- a/internal/core/src/index/TextMatchIndex.h
+++ b/internal/core/src/index/TextMatchIndex.h
@@ -49,6 +49,9 @@ class TextMatchIndex : public InvertedIndexTantivy<std::string> {
     IndexStatsPtr
     Upload(const Config& config) override;
 
+    IndexStatsPtr
+    UploadUnified(const Config& config) override;
+
     void
     Load(const Config& config);
 

--- a/internal/core/src/index/TextMatchIndexTest.cpp
+++ b/internal/core/src/index/TextMatchIndexTest.cpp
@@ -42,6 +42,7 @@
 #include "expr/ITypeExpr.h"
 #include "filemanager/InputStream.h"
 #include "gtest/gtest.h"
+#include "index/Meta.h"
 #include "index/TextMatchIndex.h"
 #include "index/Utils.h"
 #include "knowhere/comp/index_param.h"
@@ -56,6 +57,7 @@
 #include "segcore/SegmentGrowingImpl.h"
 #include "segcore/SegmentSealed.h"
 #include "segcore/segment_c.h"
+#include "storage/FileManager.h"
 #include "storage/Util.h"
 #include "test_utils/DataGen.h"
 #include "test_utils/GenExprProto.h"
@@ -103,6 +105,49 @@ GenTestSchema(std::map<std::string, std::string> params = {},
     }
     return schema;
 }
+
+storage::FileManagerContext
+CreateTextMatchTestFileManagerContext(int64_t build_id) {
+    auto storage_config = get_default_local_storage_config();
+    auto chunk_manager = storage::CreateChunkManager(storage_config);
+    auto fs = storage::InitArrowFileSystem(storage_config);
+
+    storage::FieldDataMeta field_meta{1, 2, 3, 101};
+    field_meta.field_schema.set_data_type(proto::schema::DataType::VarChar);
+    storage::IndexMeta index_meta{3, 101, build_id, 10000};
+    return storage::FileManagerContext(
+        field_meta, index_meta, chunk_manager, fs);
+}
+
+std::unique_ptr<index::TextMatchIndex>
+BuildTextMatchIndexForUpload(const storage::FileManagerContext& ctx) {
+    auto index = std::make_unique<index::TextMatchIndex>(
+        ctx, index::TANTIVY_INDEX_LATEST_VERSION, "milvus_tokenizer", "{}", "");
+
+    std::vector<std::string> texts = {
+        "football basketball", "swimming football", "table tennis"};
+    auto field_data =
+        storage::CreateFieldData(DataType::VARCHAR, DataType::NONE, false);
+    field_data->FillFieldData(texts.data(), texts.size());
+
+    index->BuildIndexFromFieldData({field_data}, false);
+    return index;
+}
+
+void
+AssertTextMatchUploadReturnsRelativePaths(
+    const std::vector<index::SerializedIndexFileInfo>& files) {
+    ASSERT_FALSE(files.empty());
+    for (const auto& file : files) {
+        ASSERT_FALSE(file.file_name.empty());
+        ASSERT_EQ(file.file_name.find(TestRemotePath), std::string::npos)
+            << file.file_name;
+        ASSERT_EQ(file.file_name.find(TEXT_LOG_ROOT_PATH), std::string::npos)
+            << file.file_name;
+        ASSERT_GT(file.file_size, 0);
+    }
+}
+
 std::shared_ptr<milvus::plan::FilterBitsNode>
 GetMatchExpr(SchemaPtr schema,
              const std::string& query,
@@ -256,6 +301,29 @@ TEST(TextMatch, Index) {
         ASSERT_FALSE(res4[1]);
         ASSERT_TRUE(res4[2]);
     }
+}
+
+TEST(TextMatch, UploadReturnsRelativeTextLogPaths) {
+    auto ctx = CreateTextMatchTestFileManagerContext(1000);
+    auto index = BuildTextMatchIndexForUpload(ctx);
+
+    auto stats = index->Upload({});
+
+    AssertTextMatchUploadReturnsRelativePaths(
+        stats->GetSerializedIndexFileInfo());
+}
+
+TEST(TextMatch, UploadUnifiedReturnsRelativeTextLogPaths) {
+    auto ctx = CreateTextMatchTestFileManagerContext(1001);
+    auto index = BuildTextMatchIndexForUpload(ctx);
+
+    auto stats = index->UploadUnified({});
+
+    AssertTextMatchUploadReturnsRelativePaths(
+        stats->GetSerializedIndexFileInfo());
+    ASSERT_EQ(stats->GetSerializedIndexFileInfo().size(), 1);
+    ASSERT_NE(stats->GetSerializedIndexFileInfo()[0].file_name.find(".v3"),
+              std::string::npos);
 }
 
 // Regression test: BuildIndexFromFieldData with multiple FieldData batches

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -479,24 +479,9 @@ func (t *sortCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 			}, nil
 		}
 		// For V3 segments, register text index stats in manifest.
-		// C++ Upload() returns relative file names; convert to absolute
-		// by prepending statsBasePath before registering with manifest.
+		// TextStatsLogs already carries full object keys for mixed-version compatibility;
+		// AddStatsToManifest stores the manifest-relative representation at commit time.
 		if resultSegment.GetManifest() != "" && len(textStatsLogs) > 0 {
-			basePath, _, bErr := packed.UnmarshalManifestPath(resultSegment.GetManifest())
-			if bErr != nil {
-				log.Warn("failed to unmarshal manifest path for text index stats",
-					zap.Int64("targetSegmentID", targetSegemntID), zap.Error(bErr))
-				return &datapb.CompactionPlanResult{
-					PlanID: t.GetPlanID(),
-					State:  datapb.CompactionTaskState_failed,
-				}, nil
-			}
-			for _, stats := range textStatsLogs {
-				prefix := fmt.Sprintf("%s/_stats/text_index.%d", basePath, stats.GetFieldID())
-				for i, f := range stats.GetFiles() {
-					stats.Files[i] = prefix + "/" + f
-				}
-			}
 			statEntries := packed.TextIndexStatEntries(textStatsLogs, t.plan.GetCurrentScalarIndexVersion())
 			newManifest, mErr := packed.AddStatsToManifest(
 				resultSegment.GetManifest(), t.compactionParams.StorageConfig, statEntries)
@@ -638,8 +623,10 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 				return err
 			}
 
-			// Compute statsBasePath so C++ uploads text index to manifest-compatible location.
-			var statsBasePath string
+			// Compute statsBasePath so C++ uploads text index to the same location
+			// that is returned in TextStatsLogs.Files.
+			statsBasePath := metautil.BuildTextIndexPrefix(t.compactionParams.StorageConfig.GetRootPath(),
+				t.GetPlanID(), 0, collectionID, partitionID, segmentID, field.GetFieldID())
 			if segment.GetManifest() != "" {
 				basePath, _, err := packed.UnmarshalManifestPath(segment.GetManifest())
 				if err != nil {
@@ -695,6 +682,9 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 			for _, info := range indexStats.GetSerializedIndexInfos() {
 				uploaded[info.FileName] = info.FileSize
 			}
+			// TextMatch upload returns relative filenames. Store full paths in
+			// metadata/task results for mixed-version compatibility.
+			files := metautil.BuildStatsFilePaths(statsBasePath, lo.Keys(uploaded))
 
 			mu.Lock()
 			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
@@ -702,7 +692,7 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 				FieldID:                   field.GetFieldID(),
 				Version:                   0,
 				BuildID:                   taskID,
-				Files:                     lo.Keys(uploaded),
+				Files:                     files,
 				LogSize:                   totalSize,
 				MemorySize:                totalSize,
 				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(t.plan.GetCurrentScalarIndexVersion()),
@@ -712,7 +702,7 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 			log.Info("field enable match, create text index done",
 				zap.Int64("segmentID", segmentID),
 				zap.Int64("field id", field.GetFieldID()),
-				zap.Strings("files", lo.Keys(uploaded)),
+				zap.Strings("files", files),
 			)
 			return nil
 		})

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -684,7 +684,7 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 			}
 			// TextMatch upload returns relative filenames. Store full paths in
 			// metadata/task results for mixed-version compatibility.
-			files := metautil.BuildStatsFilePaths(statsBasePath, lo.Keys(uploaded))
+			statsFiles := metautil.BuildStatsFilePaths(statsBasePath, lo.Keys(uploaded))
 
 			mu.Lock()
 			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
@@ -692,7 +692,7 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 				FieldID:                   field.GetFieldID(),
 				Version:                   0,
 				BuildID:                   taskID,
-				Files:                     files,
+				Files:                     statsFiles,
 				LogSize:                   totalSize,
 				MemorySize:                totalSize,
 				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(t.plan.GetCurrentScalarIndexVersion()),
@@ -702,7 +702,7 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 			log.Info("field enable match, create text index done",
 				zap.Int64("segmentID", segmentID),
 				zap.Int64("field id", field.GetFieldID()),
-				zap.Strings("files", files),
+				zap.Strings("files", statsFiles),
 			)
 			return nil
 		})

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -582,7 +582,7 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			}
 			// TextMatch upload returns relative filenames. Store full paths in
 			// metadata/task results for mixed-version compatibility.
-			files := metautil.BuildStatsFilePaths(statsBasePath, lo.Keys(uploaded))
+			statsFiles := metautil.BuildStatsFilePaths(statsBasePath, lo.Keys(uploaded))
 
 			mu.Lock()
 			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
@@ -590,7 +590,7 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 				FieldID:                   field.GetFieldID(),
 				Version:                   version,
 				BuildID:                   taskID,
-				Files:                     files,
+				Files:                     statsFiles,
 				LogSize:                   totalSize,
 				MemorySize:                totalSize,
 				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(st.req.GetCurrentScalarIndexVersion()),
@@ -600,7 +600,7 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			log.Info("field enable match, create text index done",
 				zap.Int64("targetSegmentID", st.req.GetTargetSegmentID()),
 				zap.Int64("field id", field.GetFieldID()),
-				zap.Strings("files", files),
+				zap.Strings("files", statsFiles),
 			)
 			return nil
 		})

--- a/internal/datanode/index/task_stats.go
+++ b/internal/datanode/index/task_stats.go
@@ -580,6 +580,9 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			for _, info := range indexStats.GetSerializedIndexInfos() {
 				uploaded[info.FileName] = info.FileSize
 			}
+			// TextMatch upload returns relative filenames. Store full paths in
+			// metadata/task results for mixed-version compatibility.
+			files := metautil.BuildStatsFilePaths(statsBasePath, lo.Keys(uploaded))
 
 			mu.Lock()
 			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
@@ -587,7 +590,7 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 				FieldID:                   field.GetFieldID(),
 				Version:                   version,
 				BuildID:                   taskID,
-				Files:                     lo.Keys(uploaded),
+				Files:                     files,
 				LogSize:                   totalSize,
 				MemorySize:                totalSize,
 				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(st.req.GetCurrentScalarIndexVersion()),
@@ -597,7 +600,7 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 			log.Info("field enable match, create text index done",
 				zap.Int64("targetSegmentID", st.req.GetTargetSegmentID()),
 				zap.Int64("field id", field.GetFieldID()),
-				zap.Strings("files", lo.Keys(uploaded)),
+				zap.Strings("files", files),
 			)
 			return nil
 		})
@@ -608,24 +611,10 @@ func (st *statsTask) createTextIndex(ctx context.Context,
 	}
 
 	// When manifest_path is set, register text index stats in manifest.
-	// C++ Upload() returns relative paths; convert to absolute by prepending basePath
-	// before registering with manifest (loon library expects absolute paths).
-	// Use a separate copy for manifest so the original stats retain relative paths
-	// for dual-write to etcd (etcd stores relative paths, reconstructed on read).
+	// TextStatsLogs already carries full object keys for mixed-version compatibility;
+	// AddStatsToManifest stores the manifest-relative representation at commit time.
 	if st.manifestPath != "" && len(textIndexLogs) > 0 {
-		manifestStats := make(map[int64]*datapb.TextIndexStats, len(textIndexLogs))
-		for fieldID, stats := range textIndexLogs {
-			cloned := proto.Clone(stats).(*datapb.TextIndexStats)
-			basePath, err := computeStatsBasePath(st.req, st.manifestPath, "text_index", stats.GetFieldID())
-			if err != nil {
-				return err
-			}
-			for i, f := range cloned.GetFiles() {
-				cloned.Files[i] = basePath + "/" + f
-			}
-			manifestStats[fieldID] = cloned
-		}
-		statEntries := packed.TextIndexStatEntries(manifestStats, st.req.GetCurrentScalarIndexVersion())
+		statEntries := packed.TextIndexStatEntries(textIndexLogs, st.req.GetCurrentScalarIndexVersion())
 		newManifest, err := packed.AddStatsToManifest(
 			st.manifestPath, st.req.GetStorageConfig(), statEntries)
 		if err != nil {

--- a/pkg/util/metautil/binlog.go
+++ b/pkg/util/metautil/binlog.go
@@ -131,6 +131,27 @@ func BuildTextIndexPrefix(rootPath string, buildID, version, collectionID, parti
 		strconv.FormatInt(segmentID, 10), strconv.FormatInt(fieldID, 10))
 }
 
+// BuildStatsFilePaths normalizes stats files to full object keys.
+// TextMatch stats upload returns relative filenames; this helper also tolerates
+// already-full paths for compatibility with older/intermediate producers.
+func BuildStatsFilePaths(basePath string, files []string) []string {
+	result := make([]string, 0, len(files))
+	if basePath == "" {
+		return append(result, files...)
+	}
+
+	basePath = strings.TrimSuffix(basePath, pathSep)
+	prefix := basePath + pathSep
+	for _, file := range files {
+		if strings.HasPrefix(file, prefix) {
+			result = append(result, file)
+			continue
+		}
+		result = append(result, path.Join(basePath, strings.TrimPrefix(file, pathSep)))
+	}
+	return result
+}
+
 // BuildJSONKeyStatsPrefix returns the remote base path for JSON key stats files.
 // Format: {rootPath}/json_stats/{dataFormat}/{buildID}/{version}/{collID}/{partID}/{segID}/{fieldID}
 func BuildJSONKeyStatsPrefix(rootPath string, dataFormat, buildID, version, collectionID, partitionID, segmentID, fieldID int64) string {

--- a/pkg/util/metautil/binlog_test.go
+++ b/pkg/util/metautil/binlog_test.go
@@ -227,6 +227,27 @@ func TestBuildTextLogPaths(t *testing.T) {
 	}
 }
 
+func TestBuildStatsFilePaths(t *testing.T) {
+	basePath := "/root/_stats/text_index.100"
+	fullPath := path.Join(basePath, ".managed.json_0")
+
+	got := BuildStatsFilePaths(basePath, []string{".managed.json_0", "nested/file", fullPath})
+	want := []string{
+		fullPath,
+		path.Join(basePath, "nested/file"),
+		fullPath,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("BuildStatsFilePaths() = %v, want %v", got, want)
+	}
+
+	got = BuildStatsFilePaths("", []string{".managed.json_0"})
+	want = []string{".managed.json_0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("BuildStatsFilePaths() with empty basePath = %v, want %v", got, want)
+	}
+}
+
 type mockJSONStatsSegment struct {
 	collectionID int64
 	partitionID  int64


### PR DESCRIPTION
relate: #49907

## Summary
Make TextMatch upload return relative file names consistently, including the unified scalar index path. Restore full object keys in DataNode text stats task results and compaction metadata so mixed-version rolling upgrades remain compatible with older Coord/QueryNode consumers.