### PR TITLE
fix: Refresh proxy collection cache after partition DDL

### DIFF
--- a/internal/proxy/meta_cache.go
+++ b/internal/proxy/meta_cache.go
@@ -1225,6 +1225,7 @@ func (m *MetaCache) RemovePartition(ctx context.Context, database string, collec
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	staleCollectionInfo := m.shouldStaleCollectionInfoLocked(collectionID, version)
 	names := make(map[string]struct{})
 	realNames := make(map[string]struct{})
 	for _, dbName := range partitionInvalidationDatabases(database) {
@@ -1249,11 +1250,24 @@ func (m *MetaCache) RemovePartition(ctx context.Context, database string, collec
 			}
 		}
 
+		if staleCollectionInfo {
+			// Partition DDL changes collection-level fields such as NumPartitions,
+			// without requiring removeCollectionByID's partition-cache sweep.
+			for name := range names {
+				m.staleCollectionInfoByNameLocked(dbName, name)
+			}
+			if collectionID != 0 {
+				m.sfGlobal.Forget(buildSfKeyById(dbName, collectionID))
+			}
+		}
 		for name := range names {
 			m.stalePartitionCacheLocked(dbName, name, partitionName, version)
 		}
 		clear(names)
 		clear(realNames)
+	}
+	if staleCollectionInfo && collectionID != 0 && version != 0 {
+		m.collectionCacheVersion[collectionID] = version
 	}
 
 	log.Ctx(ctx).Debug("remove partition", zap.String("db", database), zap.Int64("collectionID", collectionID), zap.String("collection", collectionName), zap.String("partition", partitionName), zap.Uint64("version", version))
@@ -1363,6 +1377,21 @@ func (m *MetaCache) stalePartitionCacheLocked(database, collectionName, partitio
 	m.partitionCache.Stale(buildPartitionSfKey(database, collectionName, partitionName), version)
 	m.sfCollLevelPartitionCache.Forget(collectionKey)
 	m.collLevelPartitionCache.Stale(collectionKey, version)
+}
+
+func (m *MetaCache) shouldStaleCollectionInfoLocked(collectionID UniqueID, version uint64) bool {
+	if collectionID == 0 || version == 0 {
+		return true
+	}
+	return m.collectionCacheVersion[collectionID] <= version
+}
+
+func (m *MetaCache) staleCollectionInfoByNameLocked(database, collectionName string) {
+	if db, ok := m.collInfo[database]; ok {
+		delete(db, collectionName)
+	}
+
+	m.sfGlobal.Forget(buildSfKeyByName(database, collectionName))
 }
 
 func (m *MetaCache) backgroundGCLoop(stopCh <-chan struct{}) {

--- a/internal/proxy/meta_cache_test.go
+++ b/internal/proxy/meta_cache_test.go
@@ -2356,6 +2356,93 @@ func TestMetaCache_RemovePartition(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestMetaCache_RemovePartitionInvalidatesCollectionInfo(t *testing.T) {
+	ctx := context.Background()
+	rootCoord := mocks.NewMockMixCoordClient(t)
+
+	rootCoord.EXPECT().ListPolicy(mock.Anything, mock.Anything).Return(&internalpb.ListPolicyResponse{
+		Status: merr.Success(),
+	}, nil).Maybe()
+
+	describeCalls := 0
+	rootCoord.EXPECT().DescribeCollection(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, req *milvuspb.DescribeCollectionRequest, opts ...grpc.CallOption) (*milvuspb.DescribeCollectionResponse, error) {
+			describeCalls++
+			numPartitions := int64(1)
+			requestTime := uint64(1000)
+			if describeCalls > 1 {
+				numPartitions = 2
+				requestTime = 3000
+			}
+			return &milvuspb.DescribeCollectionResponse{
+				Status:        merr.Success(),
+				CollectionID:  1,
+				DbName:        "db",
+				NumPartitions: numPartitions,
+				RequestTime:   requestTime,
+				Schema: &schemapb.CollectionSchema{
+					Name:   "collection",
+					Fields: []*schemapb.FieldSchema{},
+				},
+			}, nil
+		}).Times(2)
+
+	cache, err := NewMetaCache(rootCoord)
+	assert.NoError(t, err)
+	defer cache.Close()
+
+	info, err := cache.GetCollectionInfo(ctx, "db", "collection", 1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), info.numPartitions)
+
+	cache.RemovePartition(ctx, "db", 1, "collection", "par1", 2000)
+
+	info, err = cache.GetCollectionInfo(ctx, "db", "collection", 1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), info.numPartitions)
+}
+
+func TestMetaCache_RemovePartitionKeepsCollectionInfoForStaleVersion(t *testing.T) {
+	ctx := context.Background()
+	rootCoord := mocks.NewMockMixCoordClient(t)
+
+	rootCoord.EXPECT().ListPolicy(mock.Anything, mock.Anything).Return(&internalpb.ListPolicyResponse{
+		Status: merr.Success(),
+	}, nil).Maybe()
+
+	describeCalls := 0
+	rootCoord.EXPECT().DescribeCollection(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, req *milvuspb.DescribeCollectionRequest, opts ...grpc.CallOption) (*milvuspb.DescribeCollectionResponse, error) {
+			describeCalls++
+			return &milvuspb.DescribeCollectionResponse{
+				Status:        merr.Success(),
+				CollectionID:  1,
+				DbName:        "db",
+				NumPartitions: 1,
+				RequestTime:   1000,
+				Schema: &schemapb.CollectionSchema{
+					Name:   "collection",
+					Fields: []*schemapb.FieldSchema{},
+				},
+			}, nil
+		}).Times(1)
+
+	cache, err := NewMetaCache(rootCoord)
+	assert.NoError(t, err)
+	defer cache.Close()
+
+	info, err := cache.GetCollectionInfo(ctx, "db", "collection", 1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), info.numPartitions)
+
+	cache.RemovePartition(ctx, "db", 1, "collection", "par1", 500)
+
+	info, err = cache.GetCollectionInfo(ctx, "db", "collection", 1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), info.numPartitions)
+	assert.Equal(t, 1, describeCalls)
+}
+
 func TestMetaCache_PartitionCache_Concurrent(t *testing.T) {
 	ctx := context.Background()
 	rootCoord := mocks.NewMockMixCoordClient(t)


### PR DESCRIPTION
## Summary

Refresh the proxy collection info cache when partition DDL invalidates partition metadata, so cached `DescribeCollection` reloads `NumPartitions` from RootCoord after create/drop partition.

Fixes #49782

## Changes

- Stale collection info cache alongside partition cache in `RemovePartition`.
- Add a regression test that verifies partition invalidation refreshes cached collection `numPartitions`.

## Test Plan

- `gofumpt -l internal/proxy/meta_cache.go internal/proxy/meta_cache_test.go`
- `git diff --check`
- `go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r ${TEST_LIB_WORK_DIR}/cmake_build/lib -r ${TEST_LIB_WORK_DIR}/internal/core/output/lib" ./internal/proxy -run "TestMetaCache_RemovePartition($|InvalidatesCollectionInfo)" -timeout 300s`