### PR TITLE
enhance: support fp32 conversion for float16/bfloat16 vectors

### DIFF
--- a/internal/proxy/task_insert.go
+++ b/internal/proxy/task_insert.go
@@ -246,6 +246,11 @@ func (it *insertTask) PreExecute(ctx context.Context) error {
 		log.Info("fill field properties failed", zap.Error(err))
 		return err
 	}
+	err = normalizeFP32ToFP16BF16VectorFieldData(it.insertMsg.GetFieldsData(), schema)
+	if err != nil {
+		log.Info("normalize fp32 to fp16/bf16 vector field data failed", zap.Error(err))
+		return err
+	}
 
 	partitionKeyMode, err := isPartitionKeyMode(ctx, it.insertMsg.GetDbName(), collectionName)
 	if err != nil {

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -1161,6 +1161,11 @@ func (it *upsertTask) insertPreExecute(ctx context.Context) error {
 		log.Warn("fill field properties failed when upsert", zap.Error(err))
 		return merr.WrapErrAsInputErrorWhen(err, merr.ErrParameterInvalid)
 	}
+	err = normalizeFP32ToFP16BF16VectorFieldData(it.upsertMsg.InsertMsg.GetFieldsData(), it.schema)
+	if err != nil {
+		log.Warn("normalize fp32 to fp16/bf16 vector field data failed when upsert", zap.Error(err))
+		return merr.WrapErrAsInputErrorWhen(err, merr.ErrParameterInvalid)
+	}
 
 	if it.partitionKeyMode {
 		fieldSchema, _ := typeutil.GetPartitionKeyFieldSchema(it.schema.CollectionSchema)

--- a/internal/proxy/vector_type_convert.go
+++ b/internal/proxy/vector_type_convert.go
@@ -61,46 +61,6 @@ func isVectorTypeMatch(placeholderType commonpb.PlaceholderType, fieldType schem
 	return expectedDataType == fieldType
 }
 
-const (
-	// float16MaxValue is the maximum representable value in float16
-	float16MaxValue = 65504.0
-	// float16MinPositive is the minimum positive normal value in float16
-	float16MinPositive = 6.103515625e-5
-)
-
-// validateFloat32ForFloat16 checks if all float32 values can be safely converted to float16.
-// Returns error if any value exceeds float16 range or underflows.
-func validateFloat32ForFloat16(values []float32) error {
-	for i, v := range values {
-		absV := math.Abs(float64(v))
-
-		// Check overflow
-		if absV > float16MaxValue {
-			return fmt.Errorf("value at dimension %d (%v) exceeds float16 range [-65504, 65504]", i, v)
-		}
-
-		// Check underflow (non-zero values smaller than min positive)
-		if v != 0 && absV < float16MinPositive {
-			return fmt.Errorf("value at dimension %d (%v) underflows float16 precision (min abs value: %v)", i, v, float16MinPositive)
-		}
-	}
-	return nil
-}
-
-// validateFloat32ForBFloat16 checks if all float32 values can be safely converted to bfloat16.
-// BFloat16 has the same exponent range as float32, so only need to check for Inf/NaN.
-func validateFloat32ForBFloat16(values []float32) error {
-	for i, v := range values {
-		if math.IsInf(float64(v), 0) {
-			return fmt.Errorf("value at dimension %d is infinity, cannot convert to bfloat16", i)
-		}
-		if math.IsNaN(float64(v)) {
-			return fmt.Errorf("value at dimension %d is NaN, cannot convert to bfloat16", i)
-		}
-	}
-	return nil
-}
-
 // ConvertPlaceholderGroup checks and converts placeholder group vector types if needed.
 // If the placeholder type matches the field type, returns the original bytes unchanged.
 // If the placeholder is fp32 and field is fp16/bf16, converts the vectors.
@@ -146,10 +106,10 @@ func ConvertPlaceholderGroup(phgBytes []byte, fieldSchema *schemapb.FieldSchema)
 
 	switch fieldType {
 	case schemapb.DataType_Float16Vector:
-		converted, err := convertPlaceholder(&phg, validateFloat32ForFloat16, typeutil.Float32ArrayToFloat16Bytes, commonpb.PlaceholderType_Float16Vector)
+		converted, err := convertPlaceholder(&phg, fieldType, commonpb.PlaceholderType_Float16Vector)
 		return converted, phType, err
 	case schemapb.DataType_BFloat16Vector:
-		converted, err := convertPlaceholder(&phg, validateFloat32ForBFloat16, typeutil.Float32ArrayToBFloat16Bytes, commonpb.PlaceholderType_BFloat16Vector)
+		converted, err := convertPlaceholder(&phg, fieldType, commonpb.PlaceholderType_BFloat16Vector)
 		return converted, phType, err
 	default:
 		// This should never be reached due to the check above, but keep for safety
@@ -160,8 +120,7 @@ func ConvertPlaceholderGroup(phgBytes []byte, fieldSchema *schemapb.FieldSchema)
 // convertPlaceholder converts fp32 vectors in placeholder to the target type.
 func convertPlaceholder(
 	phg *commonpb.PlaceholderGroup,
-	validateFn func([]float32) error,
-	convertFn func([]float32) []byte,
+	fieldType schemapb.DataType,
 	targetType commonpb.PlaceholderType,
 ) ([]byte, error) {
 	placeholder := phg.Placeholders[0]
@@ -173,17 +132,51 @@ func convertPlaceholder(
 			return nil, fmt.Errorf("failed to parse float32 vector at index %d: %w", i, err)
 		}
 
-		if err := validateFn(floats); err != nil {
+		convertedValues[i], err = typeutil.ConvertFloat32ToFP16BF16Bytes(floats, fieldType)
+		if err != nil {
 			return nil, err
 		}
-
-		convertedValues[i] = convertFn(floats)
 	}
 
 	placeholder.Type = targetType
 	placeholder.Values = convertedValues
 
 	return proto.Marshal(phg)
+}
+
+func normalizeFP32ToFP16BF16VectorFieldData(columns []*schemapb.FieldData, schema *schemaInfo) error {
+	for _, fieldData := range columns {
+		fieldSchema, err := schema.schemaHelper.GetFieldFromNameDefaultJSON(fieldData.GetFieldName())
+		if err != nil {
+			return err
+		}
+		if err := normalizeFP32ToFP16BF16VectorField(fieldData, fieldSchema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeFP32ToFP16BF16VectorField(fieldData *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+	fieldType := fieldSchema.GetDataType()
+	if fieldType != schemapb.DataType_Float16Vector && fieldType != schemapb.DataType_BFloat16Vector {
+		return nil
+	}
+	vectors := fieldData.GetVectors()
+	if vectors == nil || vectors.GetFloatVector() == nil {
+		return nil
+	}
+	converted, err := typeutil.ConvertFloat32ToFP16BF16Bytes(vectors.GetFloatVector().GetData(), fieldType)
+	if err != nil {
+		return err
+	}
+	switch fieldType {
+	case schemapb.DataType_Float16Vector:
+		vectors.Data = &schemapb.VectorField_Float16Vector{Float16Vector: converted}
+	case schemapb.DataType_BFloat16Vector:
+		vectors.Data = &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: converted}
+	}
+	return nil
 }
 
 // bytesToFloat32Array converts byte slice to float32 array.

--- a/internal/proxy/vector_type_convert_test.go
+++ b/internal/proxy/vector_type_convert_test.go
@@ -17,6 +17,7 @@
 package proxy
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -54,114 +55,114 @@ func TestIsVectorTypeMatch(t *testing.T) {
 	}
 }
 
-func TestValidateFloat32ForFloat16(t *testing.T) {
-	tests := []struct {
+func TestConvertPlaceholderGroupAllowsFloat16Underflow(t *testing.T) {
+	vectors := [][]float32{{0.0, 1e-9, -1e-9, 0.5}}
+	phgBytes := createFloat32PlaceholderGroup(vectors)
+	fieldSchema := &schemapb.FieldSchema{DataType: schemapb.DataType_Float16Vector}
+
+	convertedBytes, _, err := ConvertPlaceholderGroup(phgBytes, fieldSchema)
+	assert.NoError(t, err)
+
+	var resultPhg commonpb.PlaceholderGroup
+	assert.NoError(t, proto.Unmarshal(convertedBytes, &resultPhg))
+	assertPlaceholderVectorsMatchFloat32(t, commonpb.PlaceholderType_Float16Vector, schemapb.DataType_Float16Vector, resultPhg.Placeholders, vectors)
+}
+
+func TestConvertPlaceholderGroupRejectsInvalidFloatInput(t *testing.T) {
+	for _, tt := range []struct {
 		name      string
-		values    []float32
-		expectErr bool
-		errMsg    string
+		dataType  schemapb.DataType
+		vectors   [][]float32
+		errSubstr string
 	}{
 		{
-			name:      "normal values",
-			values:    []float32{0.0, 1.0, -1.0, 0.5, -0.5},
-			expectErr: false,
+			name:      "float16 rejects NaN",
+			dataType:  schemapb.DataType_Float16Vector,
+			vectors:   [][]float32{{0.0, float32(math.NaN())}},
+			errSubstr: "not a number or infinity",
 		},
 		{
-			name:      "max boundary",
-			values:    []float32{65504.0, -65504.0},
-			expectErr: false,
+			name:      "bfloat16 rejects infinity",
+			dataType:  schemapb.DataType_BFloat16Vector,
+			vectors:   [][]float32{{0.0, float32(math.Inf(1))}},
+			errSubstr: "not a number or infinity",
 		},
-		{
-			name:      "overflow positive",
-			values:    []float32{0.0, 65505.0},
-			expectErr: true,
-			errMsg:    "exceeds float16 range",
-		},
-		{
-			name:      "overflow negative",
-			values:    []float32{-65505.0, 0.0},
-			expectErr: true,
-			errMsg:    "exceeds float16 range",
-		},
-		{
-			name:      "underflow",
-			values:    []float32{0.0, 1e-9},
-			expectErr: true,
-			errMsg:    "underflows float16",
-		},
-		{
-			name:      "zero is valid",
-			values:    []float32{0.0, 0.0, 0.0},
-			expectErr: false,
-		},
-		{
-			name:      "min positive normal",
-			values:    []float32{6.104e-5},
-			expectErr: false,
-		},
-	}
-
-	for _, tt := range tests {
+	} {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateFloat32ForFloat16(tt.values)
-			if tt.expectErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errMsg)
-			} else {
-				assert.NoError(t, err)
-			}
+			phgBytes := createFloat32PlaceholderGroup(tt.vectors)
+			fieldSchema := &schemapb.FieldSchema{DataType: tt.dataType}
+
+			_, _, err := ConvertPlaceholderGroup(phgBytes, fieldSchema)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errSubstr)
 		})
 	}
 }
 
-func TestValidateFloat32ForBFloat16(t *testing.T) {
-	tests := []struct {
-		name      string
-		values    []float32
-		expectErr bool
-	}{
-		{
-			name:      "normal values",
-			values:    []float32{0.0, 1.0, -1.0, 0.5, -0.5},
-			expectErr: false,
-		},
-		{
-			name:      "large values within float32 range",
-			values:    []float32{1e38, -1e38},
-			expectErr: false,
-		},
-		{
-			name:      "very small values",
-			values:    []float32{1e-38, -1e-38},
-			expectErr: false,
-		},
-		{
-			name:      "infinity",
-			values:    []float32{float32(math.Inf(1))},
-			expectErr: true,
-		},
-		{
-			name:      "negative infinity",
-			values:    []float32{float32(math.Inf(-1))},
-			expectErr: true,
-		},
-		{
-			name:      "NaN",
-			values:    []float32{float32(math.NaN())},
-			expectErr: true,
-		},
+func assertFP16BF16BytesMatchFloat32(
+	t *testing.T,
+	dataType schemapb.DataType,
+	floatData []float32,
+	got []byte,
+) {
+	t.Helper()
+	var want []byte
+	var decoded []float32
+	var tolerance float64
+	switch dataType {
+	case schemapb.DataType_Float16Vector:
+		want = typeutil.Float32ArrayToFloat16Bytes(floatData)
+		decoded = typeutil.Float16BytesToFloat32Vector(got)
+		tolerance = 1e-3
+	case schemapb.DataType_BFloat16Vector:
+		want = typeutil.Float32ArrayToBFloat16Bytes(floatData)
+		decoded = typeutil.BFloat16BytesToFloat32Vector(got)
+		tolerance = 1e-2
+	default:
+		t.Fatalf("unsupported data type: %s", dataType.String())
 	}
+	assert.Equal(t, want, got)
+	assert.InDeltaSlice(t, floatData, decoded, tolerance)
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateFloat32ForBFloat16(tt.values)
-			if tt.expectErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
+func assertPlaceholderVectorsMatchFloat32(
+	t *testing.T,
+	placeholderType commonpb.PlaceholderType,
+	fieldType schemapb.DataType,
+	placeholders []*commonpb.PlaceholderValue,
+	inputs [][]float32,
+) {
+	t.Helper()
+	assert.Len(t, placeholders, 1)
+	placeholder := placeholders[0]
+	assert.Equal(t, placeholderType, placeholder.GetType())
+	assert.Len(t, placeholder.GetValues(), len(inputs))
+	for i, input := range inputs {
+		switch fieldType {
+		case schemapb.DataType_Float16Vector:
+			assertFP16BF16BytesMatchFloat32(t, fieldType, input, placeholder.GetValues()[i])
+		case schemapb.DataType_BFloat16Vector:
+			assertFP16BF16BytesMatchFloat32(t, fieldType, input, placeholder.GetValues()[i])
+		default:
+			assert.Equal(t, typeutil.Float32ArrayToBytes(input), placeholder.GetValues()[i])
+		}
 	}
+}
+
+func fp16BF16SchemaInfo(dataType schemapb.DataType, dim int64) *schemaInfo {
+	return newSchemaInfo(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  100,
+				Name:     "vector",
+				DataType: dataType,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: fmt.Sprintf("%d", dim)},
+				},
+			},
+		},
+	})
 }
 
 func createFloat32PlaceholderGroup(vectors [][]float32) []byte {
@@ -280,7 +281,7 @@ func TestConvertPlaceholderGroupNoConversionNeeded(t *testing.T) {
 	assert.Equal(t, phgBytes, convertedBytes)
 }
 
-func TestConvertPlaceholderGroupOutOfRange(t *testing.T) {
+func TestConvertPlaceholderGroupOverflowToFloat16Infinity(t *testing.T) {
 	vectors := [][]float32{{0.1, 100000.0, 0.3, 0.4}}
 	phgBytes := createFloat32PlaceholderGroup(vectors)
 
@@ -290,7 +291,108 @@ func TestConvertPlaceholderGroupOutOfRange(t *testing.T) {
 
 	_, _, err := ConvertPlaceholderGroup(phgBytes, fieldSchema)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "exceeds float16 range")
+	assert.Contains(t, err.Error(), "nan or infinity")
+}
+
+func TestNormalizeFp32ToFp16Bf16VectorFieldData(t *testing.T) {
+	newTestSchema := func(dataType schemapb.DataType) *schemaInfo {
+		return newSchemaInfo(&schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:  100,
+					Name:     "vector",
+					DataType: dataType,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: "dim", Value: "2"},
+					},
+				},
+			},
+		})
+	}
+
+	for _, tt := range []struct {
+		name      string
+		dataType  schemapb.DataType
+		fieldData *schemapb.FieldData
+		wantBytes func([]float32) []byte
+	}{
+		{
+			name:      "float16",
+			dataType:  schemapb.DataType_Float16Vector,
+			fieldData: testFloatVectorFieldData("vector", []float32{0.1, 0.2, 0.3, 0.4}, 2),
+			wantBytes: typeutil.Float32ArrayToFloat16Bytes,
+		},
+		{
+			name:      "bfloat16",
+			dataType:  schemapb.DataType_BFloat16Vector,
+			fieldData: testFloatVectorFieldData("vector", []float32{0.1, 0.2, 0.3, 0.4}, 2),
+			wantBytes: typeutil.Float32ArrayToBFloat16Bytes,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			floatData := append([]float32(nil), tt.fieldData.GetVectors().GetFloatVector().GetData()...)
+			schema := newTestSchema(tt.dataType)
+			err := fillFieldPropertiesOnly([]*schemapb.FieldData{tt.fieldData}, schema)
+			assert.NoError(t, err)
+
+			err = normalizeFP32ToFP16BF16VectorFieldData([]*schemapb.FieldData{tt.fieldData}, schema)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.dataType, tt.fieldData.GetType())
+			assert.Equal(t, int64(2), tt.fieldData.GetVectors().GetDim())
+			if tt.dataType == schemapb.DataType_Float16Vector {
+				assert.Equal(t, tt.wantBytes(floatData), tt.fieldData.GetVectors().GetFloat16Vector())
+			} else {
+				assert.Equal(t, tt.wantBytes(floatData), tt.fieldData.GetVectors().GetBfloat16Vector())
+			}
+		})
+	}
+
+	t.Run("skip non fp16 bf16 schema field", func(t *testing.T) {
+		fieldData := testFloatVectorFieldData("vector", []float32{0.1, 0.2}, 2)
+		schema := newTestSchema(schemapb.DataType_FloatVector)
+		err := fillFieldPropertiesOnly([]*schemapb.FieldData{fieldData}, schema)
+		assert.NoError(t, err)
+		err = normalizeFP32ToFP16BF16VectorFieldData([]*schemapb.FieldData{fieldData}, schema)
+		assert.NoError(t, err)
+		assert.NotNil(t, fieldData.GetVectors().GetFloatVector())
+	})
+
+	t.Run("skip non float vector payload", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{FieldName: "vector"}
+		schema := newTestSchema(schemapb.DataType_Float16Vector)
+		err := normalizeFP32ToFP16BF16VectorFieldData([]*schemapb.FieldData{fieldData}, schema)
+		assert.NoError(t, err)
+	})
+
+	t.Run("unknown field", func(t *testing.T) {
+		fieldData := testFloatVectorFieldData("missing", []float32{0.1, 0.2}, 2)
+		err := normalizeFP32ToFP16BF16VectorFieldData([]*schemapb.FieldData{fieldData}, newTestSchema(schemapb.DataType_Float16Vector))
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid fp32 value", func(t *testing.T) {
+		fieldData := testFloatVectorFieldData("vector", []float32{float32(math.Inf(1)), 0.2}, 2)
+		schema := newTestSchema(schemapb.DataType_Float16Vector)
+		err := fillFieldPropertiesOnly([]*schemapb.FieldData{fieldData}, schema)
+		assert.NoError(t, err)
+		err = normalizeFP32ToFP16BF16VectorFieldData([]*schemapb.FieldData{fieldData}, schema)
+		assert.Error(t, err)
+	})
+}
+
+func testFloatVectorFieldData(fieldName string, data []float32, dim int64) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		FieldName: fieldName,
+		Type:      schemapb.DataType_FloatVector,
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: dim,
+				Data: &schemapb.VectorField_FloatVector{
+					FloatVector: &schemapb.FloatArray{Data: data},
+				},
+			},
+		},
+	}
 }
 
 func TestConvertPlaceholderGroupIntegration(t *testing.T) {

--- a/internal/util/importutilv2/numpy/field_reader.go
+++ b/internal/util/importutilv2/numpy/field_reader.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"unicode/utf8"
 
-	"github.com/samber/lo"
 	"github.com/sbinet/npyio"
 	"github.com/sbinet/npyio/npy"
 
@@ -109,7 +108,12 @@ func (c *FieldReader) getCount(count int64) int64 {
 	case schemapb.DataType_FloatVector:
 		count *= c.dim
 	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
-		count *= c.dim * 2
+		elementType, err := convertNumpyType(c.npyReader.Header.Descr.Type)
+		if err == nil && (elementType == schemapb.DataType_Float || elementType == schemapb.DataType_Double) {
+			count *= c.dim
+		} else {
+			count *= c.dim * 2
+		}
 	case schemapb.DataType_Int8Vector:
 		count *= c.dim
 	}
@@ -126,6 +130,10 @@ func (c *FieldReader) logicalRowCount(readCount int64) int64 {
 	case schemapb.DataType_FloatVector:
 		return readCount / c.dim
 	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		elementType, err := convertNumpyType(c.npyReader.Header.Descr.Type)
+		if err == nil && (elementType == schemapb.DataType_Float || elementType == schemapb.DataType_Double) {
+			return readCount / c.dim
+		}
 		return readCount / (c.dim * 2)
 	case schemapb.DataType_Int8Vector:
 		return readCount / c.dim
@@ -265,8 +273,14 @@ func (c *FieldReader) Next(count int64) (any, any, error) {
 		}
 		data = byteArr
 		c.readPosition += int(readCount)
-	case schemapb.DataType_BinaryVector, schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+	case schemapb.DataType_BinaryVector:
 		data, err = ReadN[uint8](c.reader, c.order, readCount)
+		if err != nil {
+			return nil, nil, err
+		}
+		c.readPosition += int(readCount)
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		data, err = c.readFP16BF16Vector(readCount)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -303,15 +317,49 @@ func (c *FieldReader) Next(count int64) (any, any, error) {
 			if err != nil {
 				return nil, nil, err
 			}
-			data = lo.Map(data64, func(f float64, _ int) float32 {
-				return float32(f)
-			})
+			data32 := make([]float32, len(data64))
+			for i, f := range data64 {
+				data32[i] = float32(f)
+			}
+			data = data32
 		}
 		c.readPosition += int(readCount)
 	default:
 		return nil, nil, merr.WrapErrImportFailed(fmt.Sprintf("unsupported data type: %s", dt.String()))
 	}
 	return data, validData, nil
+}
+
+func (c *FieldReader) readFP16BF16Vector(readCount int64) ([]byte, error) {
+	elementType, err := convertNumpyType(c.npyReader.Header.Descr.Type)
+	if err != nil {
+		return nil, err
+	}
+	switch elementType {
+	case schemapb.DataType_BinaryVector:
+		return ReadN[uint8](c.reader, c.order, readCount)
+	case schemapb.DataType_Float:
+		floatData, err := ReadN[float32](c.reader, c.order, readCount)
+		if err != nil {
+			return nil, err
+		}
+		return typeutil.ConvertFloat32ToFP16BF16Bytes(floatData, c.field.GetDataType())
+	case schemapb.DataType_Double:
+		data64, err := ReadN[float64](c.reader, c.order, readCount)
+		if err != nil {
+			return nil, err
+		}
+		if err := typeutil.VerifyFloats64(data64); err != nil {
+			return nil, err
+		}
+		floatData := make([]float32, len(data64))
+		for i, f := range data64 {
+			floatData[i] = float32(f)
+		}
+		return typeutil.ConvertFloat32ToFP16BF16Bytes(floatData, c.field.GetDataType())
+	default:
+		return nil, merr.WrapErrImportFailed(fmt.Sprintf("unsupported numpy element type %s for field '%s'", elementType.String(), c.field.GetName()))
+	}
 }
 
 // setByteOrder sets BigEndian/LittleEndian, the logic of this method is copied from npyio lib

--- a/internal/util/importutilv2/numpy/field_reader_test.go
+++ b/internal/util/importutilv2/numpy/field_reader_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sbinet/npyio"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/encoding/simplifiedchinese"
 	"golang.org/x/text/transform"
@@ -34,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func init() {
@@ -422,6 +424,179 @@ func TestNumpyFieldReaderError(t *testing.T) {
 			assert.Error(t, err)
 			assert.Nil(t, data)
 			assert.Nil(t, validData)
+		})
+	}
+}
+
+func TestReadFP16BF16VectorFromFloatNumpy(t *testing.T) {
+	const (
+		fieldID  = int64(100)
+		rowCount = 2
+	)
+	makeField := func(dataType schemapb.DataType) *schemapb.FieldSchema {
+		return &schemapb.FieldSchema{
+			FieldID:  fieldID,
+			Name:     "vector",
+			DataType: dataType,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: "dim", Value: "8"},
+			},
+		}
+	}
+
+	t.Run("float32 source", func(t *testing.T) {
+		sourceSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{makeField(schemapb.DataType_FloatVector)}}
+		insertData, err := testutil.CreateInsertData(sourceSchema, rowCount)
+		assert.NoError(t, err)
+		floatData := append([]float32(nil), insertData.Data[fieldID].GetDataRows().([]float32)...)
+		reader, err := createReader(insertData.Data[fieldID], schemapb.DataType_FloatVector)
+		assert.NoError(t, err)
+
+		for _, tt := range []struct {
+			name     string
+			dataType schemapb.DataType
+			expected []byte
+		}{
+			{"float16", schemapb.DataType_Float16Vector, typeutil.Float32ArrayToFloat16Bytes(floatData)},
+			{"bfloat16", schemapb.DataType_BFloat16Vector, typeutil.Float32ArrayToBFloat16Bytes(floatData)},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				fr, err := NewFieldReader(reader, makeField(tt.dataType), common.DefaultTimezone)
+				assert.NoError(t, err)
+				data, validData, err := fr.Next(rowCount)
+				assert.NoError(t, err)
+				assert.Nil(t, validData)
+				assert.Equal(t, tt.expected, data.([]byte))
+			})
+			reader, err = createReader(insertData.Data[fieldID], schemapb.DataType_FloatVector)
+			assert.NoError(t, err)
+		}
+	})
+	t.Run("float64 source", func(t *testing.T) {
+		rows := [][dim]float64{
+			{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8},
+			{0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6},
+		}
+		floatData := make([]float32, 0, rowCount*dim)
+		for _, row := range rows {
+			for _, value := range row {
+				floatData = append(floatData, float32(value))
+			}
+		}
+		buf := new(bytes.Buffer)
+		err := npyio.Write(buf, rows)
+		assert.NoError(t, err)
+
+		for _, tt := range []struct {
+			name     string
+			dataType schemapb.DataType
+			expected []byte
+		}{
+			{"float16", schemapb.DataType_Float16Vector, typeutil.Float32ArrayToFloat16Bytes(floatData)},
+			{"bfloat16", schemapb.DataType_BFloat16Vector, typeutil.Float32ArrayToBFloat16Bytes(floatData)},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				fr, err := NewFieldReader(bytes.NewReader(buf.Bytes()), makeField(tt.dataType), common.DefaultTimezone)
+				assert.NoError(t, err)
+				data, validData, err := fr.Next(rowCount)
+				assert.NoError(t, err)
+				assert.Nil(t, validData)
+				assert.Equal(t, tt.expected, data.([]byte))
+			})
+		}
+	})
+
+	t.Run("unsupported source type", func(t *testing.T) {
+		sourceSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{makeField(schemapb.DataType_Int8Vector)}}
+		insertData, err := testutil.CreateInsertData(sourceSchema, rowCount)
+		assert.NoError(t, err)
+		reader, err := createReader(insertData.Data[fieldID], schemapb.DataType_Int8Vector)
+		assert.NoError(t, err)
+
+		fr, err := NewFieldReader(reader, makeField(schemapb.DataType_Float16Vector), common.DefaultTimezone)
+		assert.Error(t, err)
+		assert.Nil(t, fr)
+		assert.Contains(t, err.Error(), "expected element type")
+	})
+}
+
+func TestNullableFP16BF16VectorFromFloatNumpyUsesLogicalRows(t *testing.T) {
+	const (
+		fieldID  = int64(100)
+		rowCount = 2
+	)
+	makeField := func(dataType schemapb.DataType, nullable bool, defaultValue *schemapb.ValueField) *schemapb.FieldSchema {
+		return &schemapb.FieldSchema{
+			FieldID:      fieldID,
+			Name:         "vector",
+			DataType:     dataType,
+			Nullable:     nullable,
+			DefaultValue: defaultValue,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: "dim", Value: "8"},
+			},
+		}
+	}
+	writeRows := func(t *testing.T, rows any) []byte {
+		buf := new(bytes.Buffer)
+		assert.NoError(t, npyio.Write(buf, rows))
+		return buf.Bytes()
+	}
+
+	float32Rows := [][dim]float32{
+		{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8},
+		{0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6},
+	}
+	float64Rows := [][dim]float64{
+		{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8},
+		{0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6},
+	}
+
+	for _, tt := range []struct {
+		name       string
+		sourceData []byte
+		field      *schemapb.FieldSchema
+	}{
+		{
+			name:       "nullable float32 to float16",
+			sourceData: writeRows(t, float32Rows),
+			field:      makeField(schemapb.DataType_Float16Vector, true, nil),
+		},
+		{
+			name:       "nullable float64 to float16",
+			sourceData: writeRows(t, float64Rows),
+			field:      makeField(schemapb.DataType_Float16Vector, true, nil),
+		},
+		{
+			name:       "nullable float32 to bfloat16",
+			sourceData: writeRows(t, float32Rows),
+			field:      makeField(schemapb.DataType_BFloat16Vector, true, nil),
+		},
+		{
+			name:       "nullable float64 to bfloat16",
+			sourceData: writeRows(t, float64Rows),
+			field:      makeField(schemapb.DataType_BFloat16Vector, true, nil),
+		},
+		{
+			name:       "default float32 to float16",
+			sourceData: writeRows(t, float32Rows),
+			field:      makeField(schemapb.DataType_Float16Vector, false, &schemapb.ValueField{}),
+		},
+		{
+			name:       "default float64 to bfloat16",
+			sourceData: writeRows(t, float64Rows),
+			field:      makeField(schemapb.DataType_BFloat16Vector, false, &schemapb.ValueField{}),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fr, err := NewFieldReader(bytes.NewReader(tt.sourceData), tt.field, common.DefaultTimezone)
+			assert.NoError(t, err)
+
+			data, validData, err := fr.Next(rowCount)
+
+			assert.NoError(t, err)
+			assert.Len(t, data.([]byte), rowCount*dim*2)
+			assert.Equal(t, []bool{true, true}, validData.([]bool))
 		})
 	}
 }

--- a/internal/util/importutilv2/numpy/util.go
+++ b/internal/util/importutilv2/numpy/util.go
@@ -300,15 +300,18 @@ func validateHeader(npyReader *npy.Reader, field *schemapb.FieldSchema, dim int)
 			return wrapDimError(shape[1], dim, field)
 		}
 	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
-		// TODO: need a better way to check the element type for float16/bfloat16
-		if elementType != schemapb.DataType_BinaryVector {
+		if elementType != schemapb.DataType_BinaryVector && elementType != schemapb.DataType_Float && elementType != schemapb.DataType_Double {
 			return wrapElementTypeError(elementType, field)
 		}
 		if len(shape) != 2 {
 			return wrapShapeError(len(shape), 2, field)
 		}
-		if shape[1] != dim*2 {
-			return wrapDimError(shape[1], dim, field)
+		expectedDim := dim
+		if elementType == schemapb.DataType_BinaryVector {
+			expectedDim = dim * 2
+		}
+		if shape[1] != expectedDim {
+			return wrapDimError(shape[1], expectedDim, field)
 		}
 	case schemapb.DataType_BinaryVector:
 		if elementType != schemapb.DataType_BinaryVector {

--- a/internal/util/importutilv2/parquet/field_reader.go
+++ b/internal/util/importutilv2/parquet/field_reader.go
@@ -187,10 +187,24 @@ func (c *FieldReader) Next(count int64) (any, any, error) {
 		}
 		data, err := ReadTimestamptzData(c, count)
 		return data, nil, err
-	case schemapb.DataType_BinaryVector, schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+	case schemapb.DataType_BinaryVector:
 		// vector not support default_value
 		if c.field.GetNullable() {
 			return ReadNullableBinaryData(c, count)
+		}
+		data, err := ReadBinaryData(c, count)
+		return data, nil, err
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		// vector not support default_value
+		if c.field.GetNullable() {
+			if isFP16BF16FloatArrowType(c.columnReader.Field().Type) {
+				return ReadNullableFP16BF16FloatVectorData(c, count)
+			}
+			return ReadNullableBinaryData(c, count)
+		}
+		if isFP16BF16FloatArrowType(c.columnReader.Field().Type) {
+			data, err := ReadFP16BF16FloatVectorData(c, count)
+			return data, nil, err
 		}
 		data, err := ReadBinaryData(c, count)
 		return data, nil, err
@@ -1515,6 +1529,119 @@ func ReadNullableFloatVectorData(pcr *FieldReader, count int64) (any, []bool, er
 		return nil, nil, nil
 	}
 	return data, validData, typeutil.VerifyFloats32(data)
+}
+
+func isFP16BF16FloatArrowType(dataType arrow.DataType) bool {
+	switch dataType.ID() {
+	case arrow.LIST:
+		elemType := dataType.(*arrow.ListType).Elem().ID()
+		return elemType == arrow.FLOAT32 || elemType == arrow.FLOAT64
+	case arrow.FIXED_SIZE_LIST:
+		elemType := dataType.(*arrow.FixedSizeListType).Elem().ID()
+		return elemType == arrow.FLOAT32 || elemType == arrow.FLOAT64
+	default:
+		return false
+	}
+}
+
+func readFloatListLikeDataAsFloat32(field *schemapb.FieldSchema, listReader *listLikeArray, outputArray func(arr []float32, valid bool)) error {
+	valueReader := listReader.ListValues()
+	switch valueReader.DataType().ID() {
+	case arrow.FLOAT32:
+		float32Reader := valueReader.(*array.Float32)
+		return getListLikeArrayData(listReader, func(i int) (float32, error) {
+			if float32Reader.IsNull(i) {
+				return 0, WrapNullElementErr(field)
+			}
+			return float32Reader.Value(i), nil
+		}, outputArray)
+	case arrow.FLOAT64:
+		float64Reader := valueReader.(*array.Float64)
+		return getListLikeArrayData(listReader, func(i int) (float32, error) {
+			if float64Reader.IsNull(i) {
+				return 0, WrapNullElementErr(field)
+			}
+			return float32(float64Reader.Value(i)), nil
+		}, outputArray)
+	default:
+		return WrapTypeErr(field, valueReader.DataType().Name())
+	}
+}
+
+func ReadFP16BF16FloatVectorData(pcr *FieldReader, count int64) (any, error) {
+	chunked, err := pcr.columnReader.NextBatch(count)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]byte, 0, int(count)*pcr.dim*2)
+	for _, chunk := range chunked.Chunks() {
+		if chunk.NullN() > 0 {
+			return nil, WrapNullRowErr(pcr.field)
+		}
+		listReader, err := newListLikeArray(chunk, pcr.field)
+		if err != nil {
+			return nil, err
+		}
+		if err = checkListLikeVectorAlignedWithExpected(listReader, int32(pcr.dim)); err != nil {
+			return nil, merr.WrapErrImportFailed(fmt.Sprintf("length of vector is not aligned: %s, data type: %s", err.Error(), pcr.field.GetDataType().String()))
+		}
+		floatRows := make([][]float32, 0, int(count))
+		if err = readFloatListLikeDataAsFloat32(pcr.field, listReader, func(arr []float32, valid bool) {
+			floatRows = append(floatRows, arr)
+		}); err != nil {
+			return nil, err
+		}
+		converted, err := typeutil.ConvertFloat32ToFP16BF16Bytes(lo.Flatten(floatRows), pcr.field.GetDataType())
+		if err != nil {
+			return nil, err
+		}
+		data = append(data, converted...)
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	return data, nil
+}
+
+func ReadNullableFP16BF16FloatVectorData(pcr *FieldReader, count int64) (any, []bool, error) {
+	chunked, err := pcr.columnReader.NextBatch(count)
+	if err != nil {
+		return nil, nil, err
+	}
+	data := make([]byte, 0, int(count)*pcr.dim*2)
+	validData := make([]bool, 0, count)
+	for _, chunk := range chunked.Chunks() {
+		if _, ok := chunk.(*array.Null); ok {
+			rows := chunk.Data().Len()
+			validData = append(validData, make([]bool, rows)...)
+			continue
+		}
+		listReader, err := newListLikeArray(chunk, pcr.field)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err = checkNullableListLikeVectorAlignedWithExpected(listReader, int32(pcr.dim)); err != nil {
+			return nil, nil, merr.WrapErrImportFailed(fmt.Sprintf("length of vector is not aligned: %s, data type: %s", err.Error(), pcr.field.GetDataType().String()))
+		}
+		floatRows := make([][]float32, 0, int(count))
+		if err = readFloatListLikeDataAsFloat32(pcr.field, listReader, func(arr []float32, valid bool) {
+			validData = append(validData, valid)
+			if valid {
+				floatRows = append(floatRows, arr)
+			}
+		}); err != nil {
+			return nil, nil, err
+		}
+		converted, err := typeutil.ConvertFloat32ToFP16BF16Bytes(lo.Flatten(floatRows), pcr.field.GetDataType())
+		if err != nil {
+			return nil, nil, err
+		}
+		data = append(data, converted...)
+	}
+	if len(data) == 0 && len(validData) == 0 {
+		return nil, nil, nil
+	}
+	return data, validData, nil
 }
 
 func ReadNullableInt8VectorData(pcr *FieldReader, count int64) (any, []bool, error) {

--- a/internal/util/importutilv2/parquet/field_reader_test.go
+++ b/internal/util/importutilv2/parquet/field_reader_test.go
@@ -999,6 +999,174 @@ func TestTypeMismatch(t *testing.T) {
 	}
 }
 
+func TestReadFP16BF16VectorFromFloatParquet(t *testing.T) {
+	const (
+		fieldID  = int64(100)
+		rowCount = 2
+		dim      = 4
+	)
+	rows := [][]float32{
+		{0.1, 0.2, 0.3, 0.4},
+		{0.5, 0.6, 0.7, 0.8},
+	}
+	flattened := []float32{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8}
+	makeField := func(dataType schemapb.DataType) *schemapb.FieldSchema {
+		return &schemapb.FieldSchema{
+			FieldID:  fieldID,
+			Name:     "vector",
+			DataType: dataType,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: "dim", Value: "4"},
+			},
+		}
+	}
+	buildArray := func(t *testing.T, elemType arrow.DataType, fixedSize bool, validData []bool) arrow.Array {
+		mem := memory.NewGoAllocator()
+		if fixedSize {
+			builder := array.NewFixedSizeListBuilder(mem, dim, elemType)
+			switch elemType.ID() {
+			case arrow.FLOAT32:
+				valueBuilder := builder.ValueBuilder().(*array.Float32Builder)
+				for i, row := range rows {
+					valid := validData == nil || validData[i]
+					builder.Append(valid)
+					if valid {
+						valueBuilder.AppendValues(row, nil)
+					}
+				}
+			case arrow.FLOAT64:
+				valueBuilder := builder.ValueBuilder().(*array.Float64Builder)
+				for i, row := range rows {
+					valid := validData == nil || validData[i]
+					builder.Append(valid)
+					if valid {
+						for _, value := range row {
+							valueBuilder.Append(float64(value))
+						}
+					}
+				}
+			}
+			return builder.NewArray()
+		}
+
+		builder := array.NewListBuilder(mem, elemType)
+		switch elemType.ID() {
+		case arrow.FLOAT32:
+			valueBuilder := builder.ValueBuilder().(*array.Float32Builder)
+			for i, row := range rows {
+				valid := validData == nil || validData[i]
+				builder.Append(valid)
+				if valid {
+					valueBuilder.AppendValues(row, nil)
+				}
+			}
+		case arrow.FLOAT64:
+			valueBuilder := builder.ValueBuilder().(*array.Float64Builder)
+			for i, row := range rows {
+				valid := validData == nil || validData[i]
+				builder.Append(valid)
+				if valid {
+					for _, value := range row {
+						valueBuilder.Append(float64(value))
+					}
+				}
+			}
+		}
+		return builder.NewArray()
+	}
+
+	for _, tt := range []struct {
+		name      string
+		dataType  schemapb.DataType
+		elemType  arrow.DataType
+		fixedSize bool
+		expected  []byte
+	}{
+		{"list float32 to float16", schemapb.DataType_Float16Vector, arrow.PrimitiveTypes.Float32, false, typeutil.Float32ArrayToFloat16Bytes(flattened)},
+		{"list float32 to bfloat16", schemapb.DataType_BFloat16Vector, arrow.PrimitiveTypes.Float32, false, typeutil.Float32ArrayToBFloat16Bytes(flattened)},
+		{"list float64 to float16", schemapb.DataType_Float16Vector, arrow.PrimitiveTypes.Float64, false, typeutil.Float32ArrayToFloat16Bytes(flattened)},
+		{"list float64 to bfloat16", schemapb.DataType_BFloat16Vector, arrow.PrimitiveTypes.Float64, false, typeutil.Float32ArrayToBFloat16Bytes(flattened)},
+		{"fixed size list float32 to float16", schemapb.DataType_Float16Vector, arrow.PrimitiveTypes.Float32, true, typeutil.Float32ArrayToFloat16Bytes(flattened)},
+		{"fixed size list float32 to bfloat16", schemapb.DataType_BFloat16Vector, arrow.PrimitiveTypes.Float32, true, typeutil.Float32ArrayToBFloat16Bytes(flattened)},
+		{"fixed size list float64 to float16", schemapb.DataType_Float16Vector, arrow.PrimitiveTypes.Float64, true, typeutil.Float32ArrayToFloat16Bytes(flattened)},
+		{"fixed size list float64 to bfloat16", schemapb.DataType_BFloat16Vector, arrow.PrimitiveTypes.Float64, true, typeutil.Float32ArrayToBFloat16Bytes(flattened)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			field := makeField(tt.dataType)
+			schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{field}}
+			arr := buildArray(t, tt.elemType, tt.fixedSize, nil)
+			defer arr.Release()
+			var arrType arrow.DataType = arrow.ListOf(tt.elemType)
+			if tt.fixedSize {
+				arrType = arrow.FixedSizeListOf(dim, tt.elemType)
+			}
+			pqSchema := arrow.NewSchema([]arrow.Field{{Name: field.GetName(), Type: arrType, Nullable: true}}, nil)
+
+			filePath := fmt.Sprintf("/tmp/test_%d_low_precision_reader.parquet", rand.Int())
+			defer os.Remove(filePath)
+			wf, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o666)
+			assert.NoError(t, err)
+			fw, err := pqarrow.NewFileWriter(pqSchema, wf,
+				parquet.NewWriterProperties(parquet.WithMaxRowGroupLength(rowCount)), pqarrow.DefaultWriterProps())
+			assert.NoError(t, err)
+			recordBatch := array.NewRecord(pqSchema, []arrow.Array{arr}, rowCount)
+			defer recordBatch.Release()
+			err = fw.Write(recordBatch)
+			assert.NoError(t, err)
+			assert.NoError(t, fw.Close())
+
+			ctx := context.Background()
+			f := storage.NewChunkManagerFactory("local", objectstorage.RootPath(testOutputPath))
+			cm, err := f.NewPersistentStorageChunkManager(ctx)
+			assert.NoError(t, err)
+			reader, err := NewReader(ctx, cm, schema, filePath, 64*1024*1024)
+			assert.NoError(t, err)
+			defer reader.Close()
+
+			insertData, err := reader.Read()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, insertData.Data[fieldID].GetDataRows().([]byte))
+		})
+	}
+
+	t.Run("nullable float64 list to bfloat16", func(t *testing.T) {
+		validData := []bool{true, false}
+		expectedRows := []float32{0.1, 0.2, 0.3, 0.4}
+		field := makeField(schemapb.DataType_BFloat16Vector)
+		field.Nullable = true
+		schema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{field}}
+		arr := buildArray(t, arrow.PrimitiveTypes.Float64, false, validData)
+		defer arr.Release()
+		pqSchema := arrow.NewSchema([]arrow.Field{{Name: field.GetName(), Type: arrow.ListOf(arrow.PrimitiveTypes.Float64), Nullable: true}}, nil)
+
+		filePath := fmt.Sprintf("/tmp/test_%d_nullable_fp16bf16_reader.parquet", rand.Int())
+		defer os.Remove(filePath)
+		wf, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o666)
+		assert.NoError(t, err)
+		fw, err := pqarrow.NewFileWriter(pqSchema, wf,
+			parquet.NewWriterProperties(parquet.WithMaxRowGroupLength(rowCount)), pqarrow.DefaultWriterProps())
+		assert.NoError(t, err)
+		recordBatch := array.NewRecord(pqSchema, []arrow.Array{arr}, rowCount)
+		defer recordBatch.Release()
+		assert.NoError(t, fw.Write(recordBatch))
+		assert.NoError(t, fw.Close())
+
+		ctx := context.Background()
+		f := storage.NewChunkManagerFactory("local", objectstorage.RootPath(testOutputPath))
+		cm, err := f.NewPersistentStorageChunkManager(ctx)
+		assert.NoError(t, err)
+		reader, err := NewReader(ctx, cm, schema, filePath, 64*1024*1024)
+		assert.NoError(t, err)
+		defer reader.Close()
+
+		insertData, err := reader.Read()
+		assert.NoError(t, err)
+		fieldData := insertData.Data[fieldID].(*storage.BFloat16VectorFieldData)
+		assert.Equal(t, typeutil.Float32ArrayToBFloat16Bytes(expectedRows), fieldData.Data)
+		assert.Equal(t, validData, fieldData.ValidData)
+	})
+}
+
 func TestArrayNullElement(t *testing.T) {
 	checkFunc := func(dataType schemapb.DataType, elementType schemapb.DataType) {
 		fieldName := "test_field"

--- a/internal/util/importutilv2/parquet/list_like.go
+++ b/internal/util/importutilv2/parquet/list_like.go
@@ -148,6 +148,28 @@ func checkNullableListLikeVectorAligned(listReader *listLikeArray, dim int, data
 	if err != nil {
 		return err
 	}
+	return checkNullableListLikeVectorAlignedWithExpected(listReader, expected)
+}
+
+func checkListLikeVectorAlignedWithExpected(listReader *listLikeArray, expected int32) error {
+	if fixedSize, ok := listReader.FixedSize(); ok {
+		return checkVectorAlignWithDim([]int32{0, fixedSize}, expected)
+	}
+	offsets := make([]int32, 0, listReader.Len()+1)
+	for i := 0; i < listReader.Len(); i++ {
+		start, _ := listReader.ValueOffsets(i)
+		offsets = append(offsets, int32(start))
+	}
+	if listReader.Len() > 0 {
+		_, end := listReader.ValueOffsets(listReader.Len() - 1)
+		offsets = append(offsets, int32(end))
+	} else {
+		offsets = append(offsets, 0)
+	}
+	return checkVectorAlignWithDim(offsets, expected)
+}
+
+func checkNullableListLikeVectorAlignedWithExpected(listReader *listLikeArray, expected int32) error {
 	for i := 0; i < listReader.Len(); i++ {
 		if listReader.IsNull(i) {
 			continue

--- a/internal/util/importutilv2/parquet/util.go
+++ b/internal/util/importutilv2/parquet/util.go
@@ -272,6 +272,10 @@ func isArrowArithmeticType(dataType arrow.Type) bool {
 func isArrowDataTypeConvertible(src arrow.DataType, dst arrow.DataType, field *schemapb.FieldSchema, allowFixedSizeList bool) bool {
 	srcType := src.ID()
 	dstType := dst.ID()
+	// arrow.UINT8 is the byte-backed Arrow representation for fp16/bf16 vectors, not INT8_VECTOR.
+	if isFP16BF16VectorField(field) && dstType == arrow.UINT8 && isArrowFloatingType(srcType) {
+		return true
+	}
 	switch srcType {
 	case arrow.BOOL:
 		return dstType == arrow.BOOL
@@ -315,6 +319,10 @@ func isArrowDataTypeConvertible(src arrow.DataType, dst arrow.DataType, field *s
 	default:
 		return false
 	}
+}
+
+func isFP16BF16VectorField(field *schemapb.FieldSchema) bool {
+	return field.GetDataType() == schemapb.DataType_Float16Vector || field.GetDataType() == schemapb.DataType_BFloat16Vector
 }
 
 func isFixedSizeListImportTarget(field *schemapb.FieldSchema) bool {

--- a/pkg/util/typeutil/float_util.go
+++ b/pkg/util/typeutil/float_util.go
@@ -22,6 +22,8 @@ import (
 	"math"
 
 	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
 func bfloat16IsNaN(f uint16) bool {
@@ -105,4 +107,20 @@ func VerifyBFloats16(value []byte) error {
 		}
 	}
 	return nil
+}
+
+func ConvertFloat32ToFP16BF16Bytes(floatData []float32, dataType schemapb.DataType) ([]byte, error) {
+	if err := VerifyFloats32(floatData); err != nil {
+		return nil, err
+	}
+	switch dataType {
+	case schemapb.DataType_Float16Vector:
+		converted := Float32ArrayToFloat16Bytes(floatData)
+		return converted, VerifyFloats16(converted)
+	case schemapb.DataType_BFloat16Vector:
+		converted := Float32ArrayToBFloat16Bytes(floatData)
+		return converted, VerifyBFloats16(converted)
+	default:
+		return nil, fmt.Errorf("unsupported fp16/bf16 vector type: %s", dataType.String())
+	}
 }

--- a/pkg/util/typeutil/float_util_test.go
+++ b/pkg/util/typeutil/float_util_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
 func Test_VerifyFloat(t *testing.T) {
@@ -74,4 +76,29 @@ func Test_VerifyFloats64(t *testing.T) {
 	data = []float64{2.5, 32.2, 53.254, math.Inf(-1)}
 	err = VerifyFloats64(data)
 	assert.Error(t, err)
+}
+
+func Test_ConvertFloat32ToFP16BF16BytesAllowsTinyValues(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		dataType schemapb.DataType
+		values   []float32
+	}{
+		{
+			name:     "float16 tiny values",
+			dataType: schemapb.DataType_Float16Vector,
+			values:   []float32{0, 1e-9, -1e-9},
+		},
+		{
+			name:     "bfloat16 tiny values",
+			dataType: schemapb.DataType_BFloat16Vector,
+			values:   []float32{0, 1e-38, -1e-38},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := ConvertFloat32ToFP16BF16Bytes(tt.values, tt.dataType)
+			assert.NoError(t, err)
+			assert.Len(t, data, len(tt.values)*2)
+		})
+	}
 }


### PR DESCRIPTION
issue：https://github.com/milvus-io/milvus/issues/50083
Normalize fp32 insert payloads to float16/bfloat16 in proxy, convert fp32 search placeholders per placeholder entry,  and import float32/float64 list columns from numpy/parquet.