### PR TITLE
fix: [cp 2.6] defer drop collection observe in flusher

### DIFF
--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -227,8 +227,10 @@ func (impl *WALFlusherImpl) dispatch(msg message.ImmutableMessage) (err error) {
 	}
 	timetick := msg.TimeTick()
 	// TODO: should be removed at 3.0, after merge the flusher logic into recovery storage.
-	// only for truncate api now.
-	if bh := msg.BroadcastHeader(); bh != nil && bh.AckSyncUp {
+	// Only truncate collection needs to observe before the flusher handles the message.
+	// Other messages should keep the deferred order so lifecycle cleanup such as
+	// DropCollection can finish the flowgraph before recovery storage observes it.
+	if msg.MessageType() == message.MessageTypeTruncateCollection {
 		if err := impl.ObserveMessage(impl.notifier.Context(), msg); err != nil {
 			impl.logger.Warn("failed to observe message", zap.Error(err))
 			return err

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
@@ -6,12 +6,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/flushcommon/pipeline"
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/mocks/mock_storage"
 	"github.com/milvus-io/milvus/internal/mocks/streamingnode/server/mock_wal"
@@ -23,6 +26,8 @@ import (
 	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/util"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
@@ -105,6 +110,117 @@ func TestWALFlusher(t *testing.T) {
 	flusher := RecoverWALFlusher(param)
 	time.Sleep(5 * time.Second)
 	flusher.Close()
+}
+
+func TestWALFlusher_DispatchDefersAckSyncUpDropCollectionObserve(t *testing.T) {
+	resource.InitForTest(t, resource.OptChunkManager(mock_storage.NewMockChunkManager(t)))
+
+	rs := mock_recovery.NewMockRecoveryStorage(t)
+
+	flusher := newTestWALFlusher(rs)
+	flusher.flusherComponents.dataServices["vchannel-1"] = newDataSyncServiceWrapper(
+		"vchannel-1",
+		make(chan *msgstream.MsgPack, 1),
+		&pipeline.DataSyncService{},
+		0,
+	)
+	rs.EXPECT().ObserveMessage(mock.Anything, mock.Anything).
+		RunAndReturn(func(context.Context, message.ImmutableMessage) error {
+			_, ok := flusher.flusherComponents.dataServices["vchannel-1"]
+			require.False(t, ok)
+			return errors.New("observe failed")
+		}).
+		Once()
+
+	msg := newAckSyncUpDropCollectionMessage(t, "vchannel-1")
+
+	require.ErrorContains(t, flusher.dispatch(msg), "observe failed")
+}
+
+func TestWALFlusher_DispatchObservesAckSyncUpTruncateCollectionBeforeHandling(t *testing.T) {
+	rs := mock_recovery.NewMockRecoveryStorage(t)
+	rs.EXPECT().ObserveMessage(mock.Anything, mock.Anything).Return(errors.New("observe failed")).Once()
+
+	flusher := newTestWALFlusher(rs)
+	msg := newAckSyncUpTruncateCollectionMessage(t, "vchannel-1")
+
+	require.ErrorContains(t, flusher.dispatch(msg), "observe failed")
+}
+
+func TestWALFlusher_DispatchObservesTruncateCollectionBeforeHandlingWithoutAckSyncUp(t *testing.T) {
+	rs := mock_recovery.NewMockRecoveryStorage(t)
+	rs.EXPECT().ObserveMessage(mock.Anything, mock.Anything).Return(errors.New("observe failed")).Once()
+
+	flusher := newTestWALFlusher(rs)
+	flusher.flusherComponents = nil
+	msg := newTruncateCollectionMessage(t, "vchannel-1")
+
+	require.ErrorContains(t, flusher.dispatch(msg), "observe failed")
+}
+
+func newTestWALFlusher(rs recovery.RecoveryStorage) *WALFlusherImpl {
+	return &WALFlusherImpl{
+		notifier:        syncutil.NewAsyncTaskNotifier[struct{}](),
+		logger:          log.With(),
+		RecoveryStorage: rs,
+		flusherComponents: &flusherComponents{
+			dataServices: make(map[string]*dataSyncServiceWrapper),
+			logger:       log.With(),
+			rs:           rs,
+		},
+	}
+}
+
+func newAckSyncUpDropCollectionMessage(t *testing.T, vchannel string) message.ImmutableMessage {
+	t.Helper()
+	broadcast := message.NewDropCollectionMessageBuilderV1().
+		WithHeader(&message.DropCollectionMessageHeader{
+			CollectionId: 100,
+		}).
+		WithBody(&msgpb.DropCollectionRequest{
+			Base: &commonpb.MsgBase{},
+		}).
+		WithBroadcast([]string{vchannel}, message.OptBuildBroadcastAckSyncUp()).
+		MustBuildBroadcast().
+		WithBroadcastID(1)
+	msgs := broadcast.SplitIntoMutableMessage()
+	require.Len(t, msgs, 1)
+	return msgs[0].
+		WithTimeTick(100).
+		WithLastConfirmed(rmq.NewRmqID(1)).
+		IntoImmutableMessage(rmq.NewRmqID(2))
+}
+
+func newAckSyncUpTruncateCollectionMessage(t *testing.T, vchannel string) message.ImmutableMessage {
+	t.Helper()
+	broadcast := message.NewTruncateCollectionMessageBuilderV2().
+		WithHeader(&message.TruncateCollectionMessageHeader{
+			CollectionId: 100,
+		}).
+		WithBody(&message.TruncateCollectionMessageBody{}).
+		WithBroadcast([]string{vchannel}, message.OptBuildBroadcastAckSyncUp()).
+		MustBuildBroadcast().
+		WithBroadcastID(1)
+	msgs := broadcast.SplitIntoMutableMessage()
+	require.Len(t, msgs, 1)
+	return msgs[0].
+		WithTimeTick(100).
+		WithLastConfirmed(rmq.NewRmqID(1)).
+		IntoImmutableMessage(rmq.NewRmqID(2))
+}
+
+func newTruncateCollectionMessage(t *testing.T, vchannel string) message.ImmutableMessage {
+	t.Helper()
+	return message.NewTruncateCollectionMessageBuilderV2().
+		WithVChannel(vchannel).
+		WithHeader(&message.TruncateCollectionMessageHeader{
+			CollectionId: 100,
+		}).
+		WithBody(&message.TruncateCollectionMessageBody{}).
+		MustBuildMutable().
+		WithTimeTick(100).
+		WithLastConfirmed(rmq.NewRmqID(1)).
+		IntoImmutableMessage(rmq.NewRmqID(2))
 }
 
 func newMockMixcoord(t *testing.T, maybe bool) *mocks.MockMixCoordClient {


### PR DESCRIPTION
issue: #49959
pr: #49961

- streaming flusher: only observe truncate collection before flusher handling, keeping drop collection on the deferred observe path
- streaming flusher tests: cover drop collection cleanup ordering and truncate collection early observe behavior