### PR TITLE
enhance: [hotfix] support HTTP/2 for proxy REST server (#49910)

### DIFF
--- a/internal/distributed/proxy/listener_manager.go
+++ b/internal/distributed/proxy/listener_manager.go
@@ -25,12 +25,15 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/soheilhy/cmux"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
 
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/netutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
+
+var httpServerNextProtos = []string{http2.NextProtoTLS, "http/1.1"}
 
 // newListenerManager creates a new listener
 func newListenerManager(ctx context.Context) (l *listenerManager, err error) {
@@ -98,7 +101,7 @@ func newHTTPListner(ctx context.Context, l *listenerManager) error {
 		l.portShareMode = true
 		l.cmux = cmux.New(l.externalGrpcListener)
 		l.cmuxClosed = make(chan struct{})
-		l.cmuxExternGrpcListener = l.cmux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+		l.cmuxExternHTTP2Listener = l.cmux.Match(cmux.HTTP2())
 		l.cmuxExternHTTPListener = l.cmux.Match(cmux.Any())
 		go func() {
 			defer close(l.cmuxClosed)
@@ -120,7 +123,7 @@ func newHTTPListner(ctx context.Context, l *listenerManager) error {
 			log.Error("proxy can't create creds", zap.Error(err))
 			return err
 		}
-		tlsConf = &tls.Config{Certificates: []tls.Certificate{creds}}
+		tlsConf = &tls.Config{Certificates: []tls.Certificate{creds}, NextProtos: httpServerNextProtos}
 	case 2:
 		cert, err := tls.LoadX509KeyPair(Params.ServerPemPath.GetValue(), Params.ServerKeyPath.GetValue())
 		if err != nil {
@@ -142,6 +145,7 @@ func newHTTPListner(ctx context.Context, l *listenerManager) error {
 			Certificates: []tls.Certificate{cert},
 			ClientCAs:    certPool,
 			MinVersion:   tls.VersionTLS13,
+			NextProtos:   httpServerNextProtos,
 		}
 	}
 
@@ -162,10 +166,10 @@ type listenerManager struct {
 
 	portShareMode bool
 	// portShareMode == true
-	cmux                   cmux.CMux
-	cmuxClosed             chan struct{}
-	cmuxExternGrpcListener net.Listener
-	cmuxExternHTTPListener net.Listener
+	cmux                    cmux.CMux
+	cmuxClosed              chan struct{}
+	cmuxExternHTTP2Listener net.Listener
+	cmuxExternHTTPListener  net.Listener
 
 	// portShareMode == false
 	httpListener *netutil.NetListener
@@ -173,7 +177,7 @@ type listenerManager struct {
 
 func (l *listenerManager) ExternalGrpcListener() net.Listener {
 	if l.portShareMode {
-		return l.cmuxExternGrpcListener
+		return l.cmuxExternHTTP2Listener
 	}
 	return l.externalGrpcListener
 }
@@ -193,13 +197,20 @@ func (l *listenerManager) HTTPListener() net.Listener {
 	return l.httpListener
 }
 
+func (l *listenerManager) HTTP2Listener() net.Listener {
+	if l.portShareMode {
+		return l.cmuxExternHTTP2Listener
+	}
+	return nil
+}
+
 func (l *listenerManager) Close() {
 	log := log.Ctx(context.TODO())
 	if l.portShareMode {
 		if l.cmux != nil {
-			log.Info("Proxy close cmux grpc listener")
-			if err := l.cmuxExternGrpcListener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-				log.Warn("Proxy failed to close cmux grpc listener", zap.Error(err))
+			log.Info("Proxy close cmux http2 listener")
+			if err := l.cmuxExternHTTP2Listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+				log.Warn("Proxy failed to close cmux http2 listener", zap.Error(err))
 			}
 			log.Info("Proxy close cmux http listener")
 			if err := l.cmuxExternHTTPListener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {

--- a/internal/distributed/proxy/service.go
+++ b/internal/distributed/proxy/service.go
@@ -37,6 +37,8 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -95,6 +97,7 @@ type Server struct {
 
 	ctx                context.Context
 	wg                 sync.WaitGroup
+	grpcHTTPWg         sync.WaitGroup
 	proxy              types.ProxyComponent
 	httpListener       net.Listener
 	grpcListener       net.Listener
@@ -183,6 +186,28 @@ func (s *Server) registerHTTPServer() {
 	})
 }
 
+func (s *Server) httpHandler(ginHandler http.Handler) http.Handler {
+	if s.listenerManager == nil || !s.listenerManager.portShareMode {
+		return ginHandler
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			s.grpcHTTPWg.Add(1)
+			defer s.grpcHTTPWg.Done()
+			s.grpcExternalServer.ServeHTTP(w, r)
+			return
+		}
+		ginHandler.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) serveHTTP(listener net.Listener) error {
+	if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, cmux.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
 func (s *Server) startHTTPServer(errChan chan error) {
 	defer s.wg.Done()
 	ginHandler := gin.New()
@@ -200,9 +225,25 @@ func (s *Server) startHTTPServer(errChan chan error) {
 	httpserver.NewHandlersV1(s.proxy).RegisterRoutesToV1(app)
 	appV2 := ginHandler.Group("/v2/vectordb")
 	httpserver.NewHandlersV2(s.proxy).RegisterRoutesToV2(appV2)
-	s.httpServer = &http.Server{Handler: ginHandler, ReadHeaderTimeout: time.Second}
+	http2Server := &http2.Server{}
+	s.httpServer = &http.Server{Handler: h2c.NewHandler(s.httpHandler(ginHandler), http2Server), ReadHeaderTimeout: time.Second}
+	if err := http2.ConfigureServer(s.httpServer, http2Server); err != nil {
+		errChan <- err
+		return
+	}
 	errChan <- nil
-	if err := s.httpServer.Serve(s.listenerManager.HTTPListener()); err != nil && err != cmux.ErrServerClosed {
+	if s.listenerManager.portShareMode {
+		serveErrChan := make(chan error, 2)
+		go func() { serveErrChan <- s.serveHTTP(s.listenerManager.HTTP2Listener()) }()
+		go func() { serveErrChan <- s.serveHTTP(s.listenerManager.HTTPListener()) }()
+		for i := 0; i < 2; i++ {
+			if err := <-serveErrChan; err != nil {
+				log.Ctx(s.ctx).Error("start Proxy http server to listen failed", zap.Error(err))
+				errChan <- err
+				return
+			}
+		}
+	} else if err := s.serveHTTP(s.listenerManager.HTTPListener()); err != nil {
 		log.Ctx(s.ctx).Error("start Proxy http server to listen failed", zap.Error(err))
 		errChan <- err
 		return
@@ -334,6 +375,10 @@ func (s *Server) startExternalGrpc(errChan chan error) {
 		zap.Any("enforcement policy", kaep),
 		zap.Any("server parameters", kasp))
 
+	if s.listenerManager.portShareMode {
+		log.Info("Proxy external grpc server is served by shared http2 server")
+		return
+	}
 	if err := s.grpcExternalServer.Serve(s.listenerManager.ExternalGrpcListener()); err != nil && err != cmux.ErrServerClosed {
 		log.Error("failed to serve on Proxy's listener", zap.Error(err))
 		errChan <- err
@@ -572,14 +617,27 @@ func (s *Server) Stop() (err error) {
 	go func() {
 		defer gracefulWg.Done()
 
-		// try to close grpc server firstly, it has the same root listener with cmux server and
-		// http listener that tls has not been enabled.
-		if s.grpcExternalServer != nil {
-			logger.Info("Proxy stop external grpc server")
-			utils.GracefulStopGRPCServer(s.grpcExternalServer)
+		portShareMode := s.listenerManager != nil && s.listenerManager.portShareMode
+		if portShareMode && s.httpServer != nil {
+			logger.Info("Proxy shutdown http server...")
+			ctx, cancel := context.WithTimeout(context.Background(), paramtable.Get().ProxyGrpcServerCfg.GracefulStopTimeout.GetAsDuration(time.Second))
+			if err := s.httpServer.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, net.ErrClosed) && !errors.Is(err, cmux.ErrServerClosed) {
+				logger.Warn("Proxy failed to shutdown http server", zap.Error(err))
+			}
+			cancel()
 		}
 
-		if s.httpServer != nil {
+		if s.grpcExternalServer != nil {
+			logger.Info("Proxy stop external grpc server")
+			if portShareMode {
+				s.grpcHTTPWg.Wait()
+				s.grpcExternalServer.Stop()
+			} else {
+				utils.GracefulStopGRPCServer(s.grpcExternalServer)
+			}
+		}
+
+		if !portShareMode && s.httpServer != nil {
 			logger.Info("Proxy stop http server...")
 			s.httpServer.Close()
 		}

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -21,6 +21,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"strconv"
@@ -32,7 +35,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -911,6 +916,129 @@ func getServer(t *testing.T) *Server {
 	return server
 }
 
+func expectProxyLifecycle(t *testing.T, server *Server) {
+	t.Helper()
+	mockProxy := server.proxy.(*mocks.MockProxy)
+	mockProxy.EXPECT().Stop().Return(nil)
+	mockProxy.EXPECT().Init().Return(nil)
+	mockProxy.EXPECT().Start().Return(nil)
+	mockProxy.EXPECT().Register().Return(nil)
+	mockProxy.EXPECT().GetRateLimiter().Return(nil, nil)
+	mockProxy.EXPECT().SetMixCoordClient(mock.Anything).Return()
+	mockProxy.EXPECT().UpdateStateCode(mock.Anything).Return()
+	mockProxy.EXPECT().SetAddress(mock.Anything).Return()
+}
+
+func getAvailablePortExcept(excluded ...int) int {
+	for {
+		port := funcutil.GetAvailablePort()
+		duplicated := false
+		for _, excludedPort := range excluded {
+			if port == excludedPort {
+				duplicated = true
+				break
+			}
+		}
+		if !duplicated {
+			return port
+		}
+	}
+}
+
+func configureHTTP2ProxyParams(t *testing.T, tlsMode int, portShare bool) (int, int) {
+	t.Helper()
+	Params := &paramtable.Get().ProxyGrpcServerCfg
+	resetKeys := []string{
+		Params.TLSMode.Key,
+		Params.Port.Key,
+		Params.InternalPort.Key,
+		Params.ServerPemPath.Key,
+		Params.ServerKeyPath.Key,
+		Params.CaPemPath.Key,
+		proxy.Params.HTTPCfg.Enabled.Key,
+		proxy.Params.HTTPCfg.Port.Key,
+	}
+	for _, key := range resetKeys {
+		key := key
+		t.Cleanup(func() { paramtable.Get().Reset(key) })
+	}
+
+	grpcPort := getAvailablePortExcept()
+	internalPort := getAvailablePortExcept(grpcPort)
+	httpPort := grpcPort
+	httpPortValue := ""
+	if !portShare {
+		httpPort = getAvailablePortExcept(grpcPort, internalPort)
+		httpPortValue = strconv.Itoa(httpPort)
+	}
+
+	paramtable.Get().Save(Params.TLSMode.Key, strconv.Itoa(tlsMode))
+	paramtable.Get().Save(Params.Port.Key, strconv.Itoa(grpcPort))
+	paramtable.Get().Save(Params.InternalPort.Key, strconv.Itoa(internalPort))
+	paramtable.Get().Save(Params.ServerPemPath.Key, "../../../configs/cert/server.pem")
+	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
+	paramtable.Get().Save(Params.CaPemPath.Key, "../../../configs/cert/ca.pem")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, httpPortValue)
+	return grpcPort, httpPort
+}
+
+func startHTTP2ProxyServer(t *testing.T, tlsMode int, portShare bool) (*Server, int, int) {
+	t.Helper()
+	server := getServer(t)
+	expectProxyLifecycle(t, server)
+	grpcPort, httpPort := configureHTTP2ProxyParams(t, tlsMode, portShare)
+	t.Cleanup(func() { require.NoError(t, server.Stop()) })
+	require.NoError(t, runAndWaitForServerReady(server))
+	return server, grpcPort, httpPort
+}
+
+func newH2CClient(t *testing.T) *http.Client {
+	t.Helper()
+	transport := &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, network, addr)
+		},
+	}
+	client := &http.Client{Transport: transport}
+	t.Cleanup(client.CloseIdleConnections)
+	return client
+}
+
+func newTLSHTTP2Client(t *testing.T, tlsMode int) *http.Client {
+	t.Helper()
+	certPool := x509.NewCertPool()
+	ca, err := os.ReadFile("../../../configs/cert/ca.pem")
+	require.NoError(t, err)
+	require.True(t, certPool.AppendCertsFromPEM(ca))
+	tlsConf := &tls.Config{
+		RootCAs:    certPool,
+		ServerName: "localhost",
+		NextProtos: []string{http2.NextProtoTLS},
+		MinVersion: tls.VersionTLS12,
+	}
+	if tlsMode == 2 {
+		cert, err := tls.LoadX509KeyPair(clientPemPath, clientKeyPath)
+		require.NoError(t, err)
+		tlsConf.Certificates = []tls.Certificate{cert}
+	}
+	client := &http.Client{Transport: &http2.Transport{TLSClientConfig: tlsConf}}
+	t.Cleanup(client.CloseIdleConnections)
+	return client
+}
+
+func assertHTTP2Response(t *testing.T, client *http.Client, url string) {
+	t.Helper()
+	resp, err := client.Get(url)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "HTTP/2.0", resp.Proto)
+}
+
 func Test_NewServer_TLS_TwoWay(t *testing.T) {
 	server := getServer(t)
 	Params := &paramtable.Get().ProxyGrpcServerCfg
@@ -1068,6 +1196,37 @@ func Test_NewHTTPServer_TLS_OneWay(t *testing.T) {
 	err = runAndWaitForServerReady(server)
 	assert.NotNil(t, err)
 	server.Stop()
+}
+
+func Test_NewHTTPServer_H2C(t *testing.T) {
+	_, _, httpPort := startHTTP2ProxyServer(t, 0, false)
+	assertHTTP2Response(t, newH2CClient(t), fmt.Sprintf("http://localhost:%d/not-found", httpPort))
+}
+
+func Test_NewHTTPServer_TLS_HTTP2(t *testing.T) {
+	for _, tlsMode := range []int{1, 2} {
+		tlsMode := tlsMode
+		t.Run(fmt.Sprintf("tls_mode_%d", tlsMode), func(t *testing.T) {
+			_, _, httpPort := startHTTP2ProxyServer(t, tlsMode, false)
+			assertHTTP2Response(t, newTLSHTTP2Client(t, tlsMode), fmt.Sprintf("https://localhost:%d/not-found", httpPort))
+		})
+	}
+}
+
+func Test_NewHTTPServer_PortShare_H2C(t *testing.T) {
+	enableCustomInterceptor = false
+	t.Cleanup(func() { enableCustomInterceptor = true })
+	_, grpcPort, _ := startHTTP2ProxyServer(t, 0, true)
+	assertHTTP2Response(t, newH2CClient(t), fmt.Sprintf("http://localhost:%d/not-found", grpcPort))
+
+	ctx, cancel := context.WithTimeout(context.Background(), waitDuration)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, fmt.Sprintf("localhost:%d", grpcPort), grpc.WithBlock(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	resp, err := grpc_health_v1.NewHealthClient(conn).Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.GetStatus())
 }
 
 func Test_NewHTTPServer_TLS_FileNotExisted(t *testing.T) {


### PR DESCRIPTION
Cherry-pick from master
pr: #49910
Related to #49909

Enable h2c for the Gin REST server and advertise HTTP/2 through ALPN on TLS REST listeners. Route shared-port HTTP/2 traffic through the REST HTTP server so non-gRPC REST requests and gRPC requests can coexist on the same plaintext port.

---------