### PR TITLE
fix: [cp2.6] enforce nullable vector compact data invariants

### DIFF
--- a/internal/core/src/common/FieldData.cpp
+++ b/internal/core/src/common/FieldData.cpp
@@ -120,7 +120,9 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
     if (element_count == 0) {
         return;
     }
-    null_count_ = array->null_count();
+    if (!IsVectorDataType(data_type_)) {
+        null_count_ = array->null_count();
+    }
     switch (data_type_) {
         case DataType::BOOL: {
             AssertInfo(array->type()->id() == arrow::Type::type::BOOL,
@@ -651,6 +653,9 @@ FieldDataVectorImpl<Type, is_type_entire_row>::FillFieldData(
             this->valid_data_.data(),
             this->length_,
             total_element_count);
+    } else {
+        bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_fill(
+            this->valid_data_.data(), this->length_, total_element_count, true);
     }
 
     // update logical to physical offset mapping
@@ -667,7 +672,7 @@ FieldDataVectorImpl<Type, is_type_entire_row>::FillFieldData(
         this->valid_count_ += valid_count;
     }
 
-    this->null_count_ = total_element_count - valid_count;
+    this->null_count_ += total_element_count - valid_count;
     this->length_ += total_element_count;
 }
 

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -22,6 +22,7 @@
 #include "config/ConfigKnowhere.h"
 #include "index/Meta.h"
 #include "index/Utils.h"
+#include "index/VectorIndexValidDataUtils.h"
 #include "storage/LocalChunkManagerSingleton.h"
 #include "storage/Util.h"
 #include "common/Consts.h"
@@ -36,6 +37,69 @@ namespace milvus::index {
 #define kSearchListMaxValue2 65535  // used for topk > 20
 #define kPrepareDim 100
 #define kPrepareRows 1
+
+namespace {
+
+struct DiskValidData {
+    bool found = false;
+    size_t total_count = 0;
+    size_t valid_count = 0;
+    std::vector<uint8_t> bitmap;
+};
+
+template <typename LocalChunkManagerPtr>
+DiskValidData
+ReadDiskValidData(const LocalChunkManagerPtr& local_chunk_manager,
+                  const std::string& valid_data_path) {
+    DiskValidData valid_data;
+    if (!local_chunk_manager->Exist(valid_data_path)) {
+        return valid_data;
+    }
+
+    valid_data.found = true;
+    auto file_size = local_chunk_manager->Size(valid_data_path);
+    AssertInfo(file_size >= sizeof(uint64_t),
+               "nullable vector disk valid_data file is too small");
+    uint64_t wire_count = 0;
+    local_chunk_manager->Read(
+        valid_data_path, 0, &wire_count, sizeof(uint64_t));
+    valid_data.total_count = FromValidDataCount(wire_count);
+    valid_data.bitmap.resize(GetValidDataBitmapSize(valid_data.total_count));
+    AssertInfo(file_size >= sizeof(uint64_t) + valid_data.bitmap.size(),
+               "nullable vector disk valid_data bitmap file is too small");
+    if (!valid_data.bitmap.empty()) {
+        local_chunk_manager->Read(valid_data_path,
+                                  sizeof(uint64_t),
+                                  valid_data.bitmap.data(),
+                                  valid_data.bitmap.size());
+    }
+    valid_data.valid_count =
+        CountValidDataBitmap(valid_data.total_count, valid_data.bitmap.data());
+    return valid_data;
+}
+
+template <typename LocalChunkManagerPtr>
+void
+WriteDiskValidData(const LocalChunkManagerPtr& local_chunk_manager,
+                   const std::string& valid_data_path,
+                   const OffsetMapping& offset_mapping) {
+    auto total_count = static_cast<size_t>(offset_mapping.GetTotalCount());
+    auto wire_count = ToValidDataCount(total_count);
+    auto packed_data = PackValidDataBitmap(offset_mapping);
+    if (!local_chunk_manager->Exist(valid_data_path)) {
+        local_chunk_manager->CreateFile(valid_data_path);
+    }
+    local_chunk_manager->Write(
+        valid_data_path, 0, &wire_count, sizeof(uint64_t));
+    if (!packed_data.empty()) {
+        local_chunk_manager->Write(valid_data_path,
+                                   sizeof(uint64_t),
+                                   packed_data.data(),
+                                   packed_data.size());
+    }
+}
+
+}  // namespace
 
 template <typename T>
 VectorDiskAnnIndex<T>::VectorDiskAnnIndex(
@@ -110,50 +174,53 @@ VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
         read_file_span->End();
     }
 
-    // start engine load index span
-    auto span_load_engine =
-        milvus::tracer::StartSpan("SegCoreEngineLoadDiskIndex", &ctx);
-    auto engine_scope =
-        milvus::tracer::GetTracer()->WithActiveSpan(span_load_engine);
-    auto stat = index_.Deserialize(knowhere::BinarySet(), load_config);
-    if (stat != knowhere::Status::success)
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to Deserialize index, {}",
-                  KnowhereStatusString(stat));
-    span_load_engine->End();
-
     auto local_chunk_manager =
         storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
 
     auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
-    if (local_chunk_manager->Exist(valid_data_path)) {
-        size_t count;
-        local_chunk_manager->Read(valid_data_path, 0, &count, sizeof(size_t));
-        size_t byte_size = (count + 7) / 8;
-        std::vector<uint8_t> valid_bitmap(byte_size);
-        local_chunk_manager->Read(
-            valid_data_path, sizeof(size_t), valid_bitmap.data(), byte_size);
-        // Convert bitmap to bool array
-        std::unique_ptr<bool[]> valid_data(new bool[count]);
-        for (size_t i = 0; i < count; ++i) {
-            valid_data[i] = (valid_bitmap[i / 8] >> (i % 8)) & 1;
+    auto disk_valid_data =
+        ReadDiskValidData(local_chunk_manager, valid_data_path);
+    bool all_null_nullable = disk_valid_data.found &&
+                             disk_valid_data.total_count > 0 &&
+                             disk_valid_data.valid_count == 0;
+    if (!all_null_nullable) {
+        // start engine load index span
+        auto span_load_engine =
+            milvus::tracer::StartSpan("SegCoreEngineLoadDiskIndex", &ctx);
+        auto engine_scope =
+            milvus::tracer::GetTracer()->WithActiveSpan(span_load_engine);
+        auto stat = index_.Deserialize(knowhere::BinarySet(), load_config);
+        if (stat != knowhere::Status::success)
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to Deserialize index, {}",
+                      KnowhereStatusString(stat));
+        span_load_engine->End();
+        SetDim(index_.Dim());
+    } else {
+        auto dim = GetValueFromConfig<int64_t>(load_config, DIM_KEY);
+        if (dim.has_value()) {
+            SetDim(dim.value());
         }
-        BuildValidData(valid_data.get(), count);
     }
 
-    SetDim(index_.Dim());
+    if (disk_valid_data.found) {
+        BuildValidDataFromBitmap(
+            this, disk_valid_data.total_count, disk_valid_data.bitmap.data());
+    }
 }
 
 template <typename T>
 IndexStatsPtr
 VectorDiskAnnIndex<T>::Upload(const Config& config) {
     BinarySet ret;
-    auto stat = index_.Serialize(ret);
-    if (stat != knowhere::Status::success) {
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to serialize index, {}",
-                  KnowhereStatusString(stat));
+    if (!IsAllNullNullable(offset_mapping_)) {
+        auto stat = index_.Serialize(ret);
+        if (stat != knowhere::Status::success) {
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to serialize index, {}",
+                      KnowhereStatusString(stat));
+        }
     }
     auto remote_paths_to_size = file_manager_->GetRemotePathsToFileSize();
     return IndexStats::NewFromSizeMap(file_manager_->GetAddedTotalFileSize(),
@@ -195,6 +262,25 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
     auto local_data_path =
         file_manager_->CacheRawDataToDisk<T>(config_with_emb_list);
     build_config[DISK_ANN_RAW_DATA_PATH] = local_data_path;
+
+    auto disk_valid_data =
+        ReadDiskValidData(local_chunk_manager, valid_data_path);
+    if (disk_valid_data.found) {
+        BuildValidDataFromBitmap(
+            this, disk_valid_data.total_count, disk_valid_data.bitmap.data());
+        if (disk_valid_data.valid_count == 0) {
+            auto dim = GetValueFromConfig<int64_t>(build_config, DIM_KEY);
+            if (dim.has_value()) {
+                SetDim(dim.value());
+            }
+            file_manager_->AddFile(valid_data_path);
+            local_chunk_manager->RemoveDir(storage::GenFieldRawDataPathPrefix(
+                local_chunk_manager, segment_id, field_id));
+            LOG_INFO("build all-null nullable disk index done, build_id: {}",
+                     config.value("build_id", "unknown"));
+            return;
+        }
+    }
 
     // For VECTOR_ARRAY, verify offsets file exists and pass its path to build_config
     if (is_embedding_list) {
@@ -273,6 +359,19 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
     build_config[DISK_ANN_PREFIX_PATH] = local_index_path_prefix;
 
+    if (HasValidData() && GetValidCount() == 0 &&
+        offset_mapping_.GetTotalCount() > 0) {
+        auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
+        WriteDiskValidData(
+            local_chunk_manager, valid_data_path, offset_mapping_);
+        file_manager_->AddFile(valid_data_path);
+        auto dim = GetValueFromConfig<int64_t>(build_config, DIM_KEY);
+        if (dim.has_value()) {
+            SetDim(dim.value());
+        }
+        return;
+    }
+
     if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
         auto num_threads = GetValueFromConfig<std::string>(
             build_config, DISK_ANN_BUILD_THREAD_NUM);
@@ -350,17 +449,8 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
 
     if (HasValidData()) {
         auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
-        size_t count = offset_mapping_.GetTotalCount();
-        local_chunk_manager->Write(valid_data_path, 0, &count, sizeof(size_t));
-        size_t byte_size = (count + 7) / 8;
-        std::vector<uint8_t> packed_data(byte_size, 0);
-        for (size_t i = 0; i < count; ++i) {
-            if (offset_mapping_.IsValid(i)) {
-                packed_data[i / 8] |= (1 << (i % 8));
-            }
-        }
-        local_chunk_manager->Write(
-            valid_data_path, sizeof(size_t), packed_data.data(), byte_size);
+        WriteDiskValidData(
+            local_chunk_manager, valid_data_path, offset_mapping_);
         file_manager_->AddFile(valid_data_path);
     }
 

--- a/internal/core/src/index/VectorIndexValidDataUtils.h
+++ b/internal/core/src/index/VectorIndexValidDataUtils.h
@@ -1,0 +1,156 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "common/OffsetMapping.h"
+#include "index/VectorIndex.h"
+
+namespace milvus::index {
+
+inline bool
+IsValidDataBinary(const std::string& name) {
+    return name == VALID_DATA_COUNT_KEY || name == VALID_DATA_KEY;
+}
+
+inline bool
+ContainsOnlyValidData(const BinarySet& binary_set) {
+    if (!binary_set.Contains(VALID_DATA_COUNT_KEY) ||
+        !binary_set.Contains(VALID_DATA_KEY)) {
+        return false;
+    }
+    for (const auto& [name, _] : binary_set.binary_map_) {
+        if (!IsValidDataBinary(name)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+inline bool
+IsAllNullNullable(const OffsetMapping& offset_mapping) {
+    return offset_mapping.IsEnabled() && offset_mapping.GetTotalCount() > 0 &&
+           offset_mapping.GetValidCount() == 0;
+}
+
+inline size_t
+GetValidDataBitmapSize(size_t count) {
+    return (count + 7) / 8;
+}
+
+inline uint64_t
+ToValidDataCount(size_t count) {
+    return static_cast<uint64_t>(count);
+}
+
+inline size_t
+FromValidDataCount(uint64_t count) {
+    AssertInfo(count <= std::numeric_limits<size_t>::max(),
+               "nullable vector valid_data count is too large");
+    return static_cast<size_t>(count);
+}
+
+inline size_t
+CountValidDataBitmap(size_t count, const uint8_t* bitmap) {
+    size_t valid_count = 0;
+    for (size_t i = 0; i < count; ++i) {
+        if ((bitmap[i / 8] >> (i % 8)) & 1) {
+            ++valid_count;
+        }
+    }
+    return valid_count;
+}
+
+inline std::vector<uint8_t>
+PackValidDataBitmap(const OffsetMapping& offset_mapping) {
+    auto count = static_cast<size_t>(offset_mapping.GetTotalCount());
+    std::vector<uint8_t> data(GetValidDataBitmapSize(count), 0);
+    for (size_t i = 0; i < count; ++i) {
+        if (offset_mapping.IsValid(i)) {
+            data[i / 8] |= (1 << (i % 8));
+        }
+    }
+    return data;
+}
+
+inline void
+BuildValidDataFromBitmap(VectorIndex* vector_index,
+                         size_t count,
+                         const uint8_t* bitmap) {
+    std::unique_ptr<bool[]> valid_data(new bool[count]);
+    for (size_t i = 0; i < count; ++i) {
+        valid_data[i] = (bitmap[i / 8] >> (i % 8)) & 1;
+    }
+    vector_index->BuildValidData(valid_data.get(), count);
+}
+
+inline void
+AppendValidDataToBinarySet(const OffsetMapping& offset_mapping,
+                           BinarySet& binary_set) {
+    if (!offset_mapping.IsEnabled()) {
+        return;
+    }
+
+    auto count = static_cast<size_t>(offset_mapping.GetTotalCount());
+    auto wire_count = ToValidDataCount(count);
+    std::shared_ptr<uint8_t[]> count_buf(new uint8_t[sizeof(uint64_t)]);
+    std::memcpy(count_buf.get(), &wire_count, sizeof(uint64_t));
+    binary_set.Append(VALID_DATA_COUNT_KEY, count_buf, sizeof(uint64_t));
+
+    auto packed_data = PackValidDataBitmap(offset_mapping);
+    std::shared_ptr<uint8_t[]> data(new uint8_t[packed_data.size()]);
+    if (!packed_data.empty()) {
+        std::memcpy(data.get(), packed_data.data(), packed_data.size());
+    }
+    binary_set.Append(VALID_DATA_KEY, data, packed_data.size());
+}
+
+inline bool
+LoadValidDataFromBinarySet(const BinarySet& binary_set,
+                           VectorIndex* vector_index) {
+    bool has_count = binary_set.Contains(VALID_DATA_COUNT_KEY);
+    bool has_data = binary_set.Contains(VALID_DATA_KEY);
+    if (!has_count && !has_data) {
+        return false;
+    }
+    AssertInfo(has_count && has_data,
+               "nullable vector index valid_data files are incomplete");
+
+    auto count_ptr = binary_set.GetByName(VALID_DATA_COUNT_KEY);
+    AssertInfo(count_ptr != nullptr && count_ptr->size == sizeof(uint64_t),
+               "nullable vector index valid_data count file is invalid");
+    uint64_t wire_count = 0;
+    std::memcpy(&wire_count, count_ptr->data.get(), sizeof(uint64_t));
+    auto count = FromValidDataCount(wire_count);
+
+    auto data_ptr = binary_set.GetByName(VALID_DATA_KEY);
+    AssertInfo(
+        data_ptr != nullptr && data_ptr->size >= GetValidDataBitmapSize(count),
+        "nullable vector index valid_data bitmap file is invalid");
+    BuildValidDataFromBitmap(vector_index, count, data_ptr->data.get());
+    return true;
+}
+
+}  // namespace milvus::index

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -35,6 +35,7 @@
 #include "index/IndexInfo.h"
 #include "index/Meta.h"
 #include "index/Utils.h"
+#include "index/VectorIndexValidDataUtils.h"
 #include "common/EasyAssert.h"
 #include "config/ConfigKnowhere.h"
 #include "knowhere/index/index_factory.h"
@@ -145,32 +146,16 @@ template <typename T>
 BinarySet
 VectorMemIndex<T>::Serialize(const Config& config) {
     knowhere::BinarySet ret;
-    auto stat = index_.Serialize(ret);
-    if (stat != knowhere::Status::success)
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to serialize index: {}",
-                  KnowhereStatusString(stat));
-
-    // Serialize valid_data from offset_mapping if enabled
-    if (offset_mapping_.IsEnabled()) {
-        auto total_count = offset_mapping_.GetTotalCount();
-
-        std::shared_ptr<uint8_t[]> count_buf(new uint8_t[sizeof(size_t)]);
-        size_t count = static_cast<size_t>(total_count);
-        std::memcpy(count_buf.get(), &count, sizeof(size_t));
-        ret.Append(VALID_DATA_COUNT_KEY, count_buf, sizeof(size_t));
-
-        size_t byte_size = (count + 7) / 8;
-        std::shared_ptr<uint8_t[]> data(new uint8_t[byte_size]);
-        std::memset(data.get(), 0, byte_size);
-        for (size_t i = 0; i < count; ++i) {
-            if (offset_mapping_.IsValid(i)) {
-                data[i / 8] |= (1 << (i % 8));
-            }
-        }
-        ret.Append(VALID_DATA_KEY, data, byte_size);
+    bool all_null_nullable = IsAllNullNullable(offset_mapping_);
+    if (!all_null_nullable) {
+        auto stat = index_.Serialize(ret);
+        if (stat != knowhere::Status::success)
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to serialize index: {}",
+                      KnowhereStatusString(stat));
     }
 
+    AppendValidDataToBinarySet(offset_mapping_, ret);
     Disassemble(ret);
 
     return ret;
@@ -180,31 +165,20 @@ template <typename T>
 void
 VectorMemIndex<T>::LoadWithoutAssemble(const BinarySet& binary_set,
                                        const Config& config) {
-    auto stat = index_.Deserialize(binary_set, config);
-    if (stat != knowhere::Status::success)
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to Deserialize index: {}",
-                  KnowhereStatusString(stat));
-
-    // Deserialize valid_data bitmap and rebuild offset_mapping
-    if (binary_set.Contains(VALID_DATA_COUNT_KEY) &&
-        binary_set.Contains(VALID_DATA_KEY)) {
-        knowhere::BinaryPtr ptr;
-        ptr = binary_set.GetByName(VALID_DATA_COUNT_KEY);
-        size_t count;
-        std::memcpy(&count, ptr->data.get(), sizeof(size_t));
-
-        ptr = binary_set.GetByName(VALID_DATA_KEY);
-        // Convert bitmap to bool array
-        std::unique_ptr<bool[]> valid_data(new bool[count]);
-        auto bitmap = ptr->data.get();
-        for (size_t i = 0; i < count; ++i) {
-            valid_data[i] = (bitmap[i / 8] >> (i % 8)) & 1;
+    if (ContainsOnlyValidData(binary_set)) {
+        if (config.contains(DIM_KEY)) {
+            SetDim(GetDimFromConfig(config));
         }
-        BuildValidData(valid_data.get(), count);
+    } else {
+        auto stat = index_.Deserialize(binary_set, config);
+        if (stat != knowhere::Status::success)
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to Deserialize index: {}",
+                      KnowhereStatusString(stat));
+        SetDim(index_.Dim());
     }
 
-    SetDim(index_.Dim());
+    LoadValidDataFromBinarySet(binary_set, this);
 }
 
 template <typename T>
@@ -426,6 +400,11 @@ VectorMemIndex<T>::Build(const Config& config) {
                 total_size += data->Size();
             }
         }
+        if (nullable && total_valid_rows == 0) {
+            SetDim(dim);
+            BuildValidData(valid_data.get(), total_num_rows);
+            return;
+        }
         auto buf = std::shared_ptr<uint8_t[]>(new uint8_t[total_size]);
 
         size_t lim_offset = 0;
@@ -497,6 +476,11 @@ VectorMemIndex<T>::Build(const Config& config) {
                 std::dynamic_pointer_cast<FieldData<SparseFloatVector>>(
                     field_data)
                     ->Dim());
+        }
+        if (nullable && total_valid_rows == 0) {
+            SetDim(dim);
+            BuildValidData(valid_data.get(), total_num_rows);
+            return;
         }
         std::vector<knowhere::sparse::SparseRow<SparseValueType>> vec(
             total_valid_rows);
@@ -734,6 +718,7 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
     std::chrono::duration<double> write_disk_duration_sum;
     std::unique_ptr<storage::DataCodec> valid_data_count_codec;
     std::unique_ptr<storage::DataCodec> valid_data_codec;
+    bool wrote_index_data = false;
     // load files in two parts:
     // 1. EMB_LIST_META: Written separately to embedding_list_meta_writer_ptr (if embedding list type)
     // 2. All other binaries: Merged and written to file_writer, forming a unified index file for knowhere
@@ -778,6 +763,7 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
                     } else {
                         file_writer.Write(data->PayloadData(),
                                           data->PayloadSize());
+                        wrote_index_data = true;
                     }
                     write_disk_duration_sum +=
                         (std::chrono::system_clock::now() - start_write_file);
@@ -823,6 +809,7 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
             } else {
                 file_writer.Write(index_data->PayloadData(),
                                   index_data->PayloadSize());
+                wrote_index_data = true;
             }
         }
         write_disk_duration_sum +=
@@ -840,7 +827,6 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
         embedding_list_meta_writer_ptr->Finish();
     }
 
-    LOG_INFO("load index into Knowhere...");
     auto conf = config;
     conf.erase(MMAP_FILE_PATH);
     conf[ENABLE_MMAP] = true;
@@ -848,21 +834,30 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
         conf["emb_list_meta_file_path"] = embedding_list_meta_path.value();
     }
     auto start_deserialize = std::chrono::system_clock::now();
-    auto stat = index_.DeserializeFromFile(local_filepath.value(), conf);
-    auto deserialize_duration =
-        std::chrono::system_clock::now() - start_deserialize;
-    if (stat != knowhere::Status::success) {
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to Deserialize index: {}",
-                  KnowhereStatusString(stat));
+    std::chrono::duration<double> deserialize_duration{};
+    if (wrote_index_data) {
+        LOG_INFO("load index into Knowhere...");
+        auto stat = index_.DeserializeFromFile(local_filepath.value(), conf);
+        deserialize_duration =
+            std::chrono::system_clock::now() - start_deserialize;
+        if (stat != knowhere::Status::success) {
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to Deserialize index: {}",
+                      KnowhereStatusString(stat));
+        }
+        this->SetDim(index_.Dim());
+    } else {
+        LOG_INFO("load all-null nullable vector index valid data only...");
+        AssertInfo(valid_data_count_codec && valid_data_codec,
+                   "nullable vector index valid_data files are incomplete");
+        if (conf.contains(DIM_KEY)) {
+            this->SetDim(GetDimFromConfig(conf));
+        }
     }
     milvus::monitor::internal_storage_deserialize_duration.Observe(
         std::chrono::duration_cast<std::chrono::milliseconds>(
             deserialize_duration)
             .count());
-
-    auto dim = index_.Dim();
-    this->SetDim(index_.Dim());
 
     // Restore valid_data for nullable vector support
     if (valid_data_count_codec && valid_data_codec) {

--- a/internal/core/src/indexbuilder/VecIndexCreator.cpp
+++ b/internal/core/src/indexbuilder/VecIndexCreator.cpp
@@ -68,12 +68,19 @@ void
 VecIndexCreator::Build(const milvus::DatasetPtr& dataset,
                        const bool* valid_data,
                        const int64_t valid_data_len) {
-    index_->BuildWithDataset(dataset, config_);
     if (valid_data && valid_data_len > 0) {
         auto vec_index = dynamic_cast<index::VectorIndex*>(index_.get());
         AssertInfo(vec_index != nullptr, "failed to cast index to VectorIndex");
+        if (dataset->GetRows() == 0) {
+            vec_index->SetDim(dataset->GetDim());
+            vec_index->BuildValidData(valid_data, valid_data_len);
+            return;
+        }
+        index_->BuildWithDataset(dataset, config_);
         vec_index->BuildValidData(valid_data, valid_data_len);
+        return;
     }
+    index_->BuildWithDataset(dataset, config_);
 }
 
 void

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -158,7 +158,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
 
         TargetBitmap transformed_bitset;
         BitsetView search_bitset = bitset;
-        if (offset_mapping.IsEnabled()) {
+        if (offset_mapping.IsEnabled() && !bitset.empty()) {
             transformed_bitset = TransformBitset(bitset, offset_mapping);
         }
 
@@ -177,7 +177,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             search_result.unity_topK_ = info.topk_;
             return;
         }
-        if (offset_mapping.IsEnabled()) {
+        if (offset_mapping.IsEnabled() && !bitset.empty()) {
             search_bitset =
                 search_result.PinBitset(std::move(transformed_bitset));
         }

--- a/internal/core/src/query/SearchOnIndex.cpp
+++ b/internal/core/src/query/SearchOnIndex.cpp
@@ -34,7 +34,6 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
     TargetBitmap transformed_bitset;
     BitsetView search_bitset = bitset;
     if (offset_mapping.IsEnabled()) {
-        transformed_bitset = TransformBitset(bitset, offset_mapping);
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
             auto total_num = num_queries * search_conf.topk_;
@@ -44,7 +43,11 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
             search_result.unity_topK_ = search_conf.topk_;
             return;
         }
-        search_bitset = search_result.PinBitset(std::move(transformed_bitset));
+        if (!bitset.empty()) {
+            transformed_bitset = TransformBitset(bitset, offset_mapping);
+            search_bitset =
+                search_result.PinBitset(std::move(transformed_bitset));
+        }
     }
 
     if (milvus::exec::PrepareVectorIteratorsFromIndex(search_conf,

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -79,7 +79,6 @@ SearchOnSealedIndex(const Schema& schema,
     TargetBitmap transformed_bitset;
     BitsetView search_bitset = bitset;
     if (offset_mapping.IsEnabled()) {
-        transformed_bitset = TransformBitset(bitset, offset_mapping);
         if (offset_mapping.GetValidCount() == 0) {
             auto total_num = num_queries * topK;
             search_result.seg_offsets_.resize(total_num, INVALID_SEG_OFFSET);
@@ -88,7 +87,11 @@ SearchOnSealedIndex(const Schema& schema,
             search_result.unity_topK_ = topK;
             return;
         }
-        search_bitset = search_result.PinBitset(std::move(transformed_bitset));
+        if (!bitset.empty()) {
+            transformed_bitset = TransformBitset(bitset, offset_mapping);
+            search_bitset =
+                search_result.PinBitset(std::move(transformed_bitset));
+        }
     }
 
     if (search_info.iterator_v2_info_.has_value()) {
@@ -163,7 +166,6 @@ SearchOnSealedColumn(const Schema& schema,
         for (int64_t c = 0; c < column->num_chunks(); ++c) {
             column->EnsureChunkOffsetMapping(c, op_context);
         }
-        transformed_bitset = TransformBitset(bitview, offset_mapping);
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
             auto total_num = num_queries * search_info.topk_;
@@ -173,7 +175,10 @@ SearchOnSealedColumn(const Schema& schema,
             result.unity_topK_ = search_info.topk_;
             return;
         }
-        search_bitview = result.PinBitset(std::move(transformed_bitset));
+        if (!bitview.empty()) {
+            transformed_bitset = TransformBitset(bitview, offset_mapping);
+            search_bitview = result.PinBitset(std::move(transformed_bitset));
+        }
     }
 
     if (search_info.iterator_v2_info_.has_value()) {

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -259,6 +259,117 @@ TEST(SearchOnSealedIndexBitsetLifetime,
     AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
 }
 
+TEST(SearchOnSealedIndexNullableNoFilter,
+     EmptyBitsetMustNotMaskCompactVectorRows) {
+    constexpr int64_t total_count = 1000;
+    constexpr int64_t topk = 10;
+
+    int64_t valid_count = 0;
+    auto valid_data = MakeValidData(total_count, valid_count);
+    auto vectors = MakeCompactVectors(valid_count, kDim);
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::COSINE, true);
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_field);
+
+    auto index_base =
+        BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
+    auto* vector_index = dynamic_cast<index::VectorIndex*>(index_base.get());
+    ASSERT_NE(vector_index, nullptr);
+    ASSERT_TRUE(vector_index->GetOffsetMapping().IsEnabled());
+    ASSERT_EQ(vector_index->GetOffsetMapping().GetValidCount(), valid_count);
+
+    segcore::SealedIndexingRecord indexing_record;
+    indexing_record.append_field_indexing(
+        vector_field,
+        knowhere::metric::COSINE,
+        CreateTestCacheIndex("nullable-vector-empty-bitset",
+                             std::move(index_base)));
+
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = topk;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = knowhere::metric::COSINE;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::indexparam::NPROBE, "32"},
+    };
+
+    SearchResult search_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        search_info,
+                        vectors.data(),
+                        nullptr,
+                        1,
+                        BitsetView{},
+                        nullptr,
+                        search_result);
+
+    ASSERT_EQ(search_result.seg_offsets_.size(), topk);
+    auto valid_results = std::count_if(
+        search_result.seg_offsets_.begin(),
+        search_result.seg_offsets_.end(),
+        [](int64_t offset) { return offset != INVALID_SEG_OFFSET; });
+    EXPECT_GT(valid_results, 0);
+}
+
+TEST(SearchOnSealedIndexNullableIteratorNoFilter,
+     EmptyBitsetMustNotMaskCompactVectorRows) {
+    constexpr int64_t total_count = 1000;
+    constexpr int64_t batch_size = 10;
+
+    int64_t valid_count = 0;
+    auto valid_data = MakeValidData(total_count, valid_count);
+    auto vectors = MakeCompactVectors(valid_count, kDim);
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::COSINE, true);
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_field);
+
+    auto index_base =
+        BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
+    segcore::SealedIndexingRecord indexing_record;
+    indexing_record.append_field_indexing(
+        vector_field,
+        knowhere::metric::COSINE,
+        CreateTestCacheIndex("nullable-vector-empty-bitset-iterator",
+                             std::move(index_base)));
+
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = batch_size;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = knowhere::metric::COSINE;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::indexparam::NPROBE, "32"},
+    };
+    search_info.iterator_v2_info_ =
+        SearchIteratorV2Info{.batch_size = batch_size};
+
+    SearchResult search_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        search_info,
+                        vectors.data(),
+                        nullptr,
+                        1,
+                        BitsetView{},
+                        nullptr,
+                        search_result);
+
+    ASSERT_EQ(search_result.seg_offsets_.size(), batch_size);
+    auto valid_results = std::count_if(
+        search_result.seg_offsets_.begin(),
+        search_result.seg_offsets_.end(),
+        [](int64_t offset) { return offset != INVALID_SEG_OFFSET; });
+    EXPECT_GT(valid_results, 0);
+}
+
 TEST(SearchOnGrowingBitsetLifetime,
      GroupByIteratorMustNotKeepDanglingTransformedBitset) {
     constexpr int64_t total_count = 512;

--- a/internal/core/src/query/Utils.h
+++ b/internal/core/src/query/Utils.h
@@ -23,9 +23,18 @@ namespace milvus::query {
 inline TargetBitmap
 TransformBitset(const BitsetView& bitset,
                 const milvus::OffsetMapping& mapping) {
+    // Empty BitsetView is the Knowhere fast path for "no rows filtered".
+    // Keep it empty after logical-to-physical mapping.
+    if (bitset.empty()) {
+        return {};
+    }
+
+    // bit=true means filtered out. The logical bitset may be shorter than the
+    // full mapping on growing segments because it is sized by query timestamp
+    // visibility. Physical rows outside that logical view are not visible yet.
     TargetBitmap result;
     auto count = mapping.GetValidCount();
-    result.resize(count);
+    result.resize(count, true);
     for (int64_t physical_idx = 0; physical_idx < count; physical_idx++) {
         auto logical_idx = mapping.GetLogicalOffset(physical_idx);
         if (logical_idx >= 0 &&

--- a/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
@@ -24,6 +24,7 @@
 
 #include "test_utils/cachinglayer_test_utils.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/SegcoreConfigUtils.h"
 #include "test_utils/storage_test_utils.h"
 #include "test_utils/GenExprProto.h"
 
@@ -354,15 +355,22 @@ class BinlogIndexTest : public ::testing::TestWithParam<Param> {
         std::map<std::string, std::string> type_params = {{"dim", "4"}};
         FieldIndexMeta fieldIndexMeta(
             vec_field_id, std::move(index_params), std::move(type_params));
-        auto& config = SegcoreConfig::default_config();
-        config.set_chunk_rows(1024);
-        config.set_enable_interim_segment_index(true);
-        config.set_nlist(16);
+        ApplyBinlogInterimIndexConfigForTest();
         std::map<FieldId, FieldIndexMeta> filedMap = {
             {vec_field_id, fieldIndexMeta}};
         IndexMetaPtr metaPtr =
             std::make_shared<CollectionIndexMeta>(226985, std::move(filedMap));
         return std::move(metaPtr);
+    }
+
+    void
+    ApplyBinlogInterimIndexConfigForTest() {
+        InterimIndexConfigForTest options;
+        options.chunk_rows = 1024;
+        options.nlist = 16;
+        options.nprobe = 16;
+        options.dense_vector_interim_index_type = dense_vec_intermin_index_type;
+        ApplyInterimIndexConfigForTest(options);
     }
 
     std::unique_ptr<milvus::index::IndexBase>
@@ -775,18 +783,14 @@ TEST(test_chunk_segment,
 }
 
 TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
+    ScopedSegcoreConfigRestore config_restore;
     IndexMetaPtr collection_index_meta = GetCollectionIndexMeta(index_type);
 
     segment = CreateSealedSegment(schema, collection_index_meta);
     LoadOtherFields();
 
+    ApplyBinlogInterimIndexConfigForTest();
     auto& segcore_config = milvus::segcore::SegcoreConfig::default_config();
-    segcore_config.set_enable_interim_segment_index(true);
-    if (dense_vec_intermin_index_type.has_value()) {
-        segcore_config.set_dense_vector_intermin_index_type(
-            dense_vec_intermin_index_type.value());
-    }
-    segcore_config.set_nprobe(16);
     // 1. load field data, and build binlog index for binlog data
     LoadVectorField();
 
@@ -1050,18 +1054,14 @@ TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
 }
 
 TEST_P(BinlogIndexTest, AccuracyWithMapFieldData) {
+    ScopedSegcoreConfigRestore config_restore;
     IndexMetaPtr collection_index_meta = GetCollectionIndexMeta(index_type);
 
     segment = CreateSealedSegment(schema, collection_index_meta);
     LoadOtherFields();
 
+    ApplyBinlogInterimIndexConfigForTest();
     auto& segcore_config = milvus::segcore::SegcoreConfig::default_config();
-    segcore_config.set_enable_interim_segment_index(true);
-    if (dense_vec_intermin_index_type.has_value()) {
-        segcore_config.set_dense_vector_intermin_index_type(
-            dense_vec_intermin_index_type.value());
-    }
-    segcore_config.set_nprobe(16);
     // 1. load field data, and build binlog index for binlog data
     LoadVectorField("./data/mmap-test");
 

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -171,7 +171,7 @@ VectorFieldIndexing::recreate_index(DataType data_type,
                    "growing segment.");
         knowhere::ViewDataOp view_data = [field_raw_data_ptr =
                                               concurrent_fp32_vec](size_t id) {
-            return (const void*)field_raw_data_ptr->get_element(id);
+            return (const void*)field_raw_data_ptr->get_physical_element(id);
         };
         index_ = std::make_unique<index::VectorMemIndex<float>>(
             DataType::NONE,
@@ -188,7 +188,7 @@ VectorFieldIndexing::recreate_index(DataType data_type,
                    "in growing segment.");
         knowhere::ViewDataOp view_data = [field_raw_data_ptr =
                                               concurrent_fp16_vec](size_t id) {
-            return (const void*)field_raw_data_ptr->get_element(id);
+            return (const void*)field_raw_data_ptr->get_physical_element(id);
         };
         index_ = std::make_unique<index::VectorMemIndex<float16>>(
             DataType::NONE,
@@ -205,7 +205,7 @@ VectorFieldIndexing::recreate_index(DataType data_type,
                    "in growing segment.");
         knowhere::ViewDataOp view_data = [field_raw_data_ptr =
                                               concurrent_bf16_vec](size_t id) {
-            return (const void*)field_raw_data_ptr->get_element(id);
+            return (const void*)field_raw_data_ptr->get_physical_element(id);
         };
         index_ = std::make_unique<index::VectorMemIndex<bfloat16>>(
             DataType::NONE,

--- a/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
@@ -19,6 +19,7 @@
 #include "segcore/SegmentGrowing.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/SegcoreConfigUtils.h"
 #include "index/IndexFactory.h"
 #include "test_utils/indexbuilder_test_utils.h"
 
@@ -172,23 +173,24 @@ TEST_P(GrowingIndexTest, Correctness) {
     FieldIndexMeta fieldIndexMeta(
         vec, std::move(index_params), std::move(type_params));
     auto& config = SegcoreConfig::default_config();
-    config.set_chunk_rows(1024);
-    config.set_enable_interim_segment_index(true);
+    ScopedSegcoreConfigRestore config_restore(config);
+    InterimIndexConfigForTest interim_config;
+    interim_config.chunk_rows = 1024;
     if (dense_vec_intermin_index_type.has_value()) {
-        config.set_dense_vector_intermin_index_type(
-            dense_vec_intermin_index_type.value());
+        interim_config.dense_vector_interim_index_type =
+            dense_vec_intermin_index_type.value();
         if (dense_vec_intermin_index_type.value() ==
             knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR) {
-            auto nlist = config.get_nlist();
-            config.set_sub_dim(4);
-            config.set_nprobe(int(0.4 * nlist));
-            config.set_refine_ratio(4.0);
+            interim_config.sub_dim = 4;
+            interim_config.nprobe = int(0.4 * interim_config.nlist);
+            interim_config.refine_ratio = 4.0;
             if (dense_refine_type.has_value()) {
-                config.set_refine_quant_type(dense_refine_type.value());
-                config.set_refine_with_quant_flag(false);
+                interim_config.refine_quant_type = dense_refine_type.value();
+                interim_config.refine_with_quant_flag = false;
             }
         }
     }
+    ApplyInterimIndexConfigForTest(interim_config, config);
     std::map<FieldId, FieldIndexMeta> filedMap = {{vec, fieldIndexMeta}};
     IndexMetaPtr metaPtr =
         std::make_shared<CollectionIndexMeta>(226985, std::move(filedMap));
@@ -434,6 +436,113 @@ TEST_P(GrowingIndexTest, AddWithoutBuildPool) {
     }
 }
 
+TEST(GrowingIndexNullableVectorTest,
+     ScannDvrRefinerUsesCompactPhysicalVectorIds) {
+    constexpr int64_t dim = 4;
+    constexpr int64_t row_count = 50;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto vec = schema->AddDebugField(
+        "embeddings", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2, true);
+    schema->set_primary_field_id(pk);
+
+    std::map<std::string, std::string> index_params = {
+        {"index_type", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT},
+        {"metric_type", knowhere::metric::L2},
+        {"nlist", "1"}};
+    std::map<std::string, std::string> type_params = {
+        {"dim", std::to_string(dim)}};
+    FieldIndexMeta field_index_meta(
+        vec, std::move(index_params), std::move(type_params));
+
+    auto& config = SegcoreConfig::default_config();
+    ScopedSegcoreConfigRestore config_restore(config);
+    InterimIndexConfigForTest interim_config;
+    interim_config.chunk_rows = 1024;
+    interim_config.nlist = 1;
+    interim_config.nprobe = 1;
+    interim_config.dense_vector_interim_index_type =
+        knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR;
+    interim_config.sub_dim = dim;
+    interim_config.refine_ratio = 1.0F;
+    interim_config.refine_quant_type = "NONE";
+    interim_config.refine_with_quant_flag = false;
+    ApplyInterimIndexConfigForTest(interim_config, config);
+
+    std::map<FieldId, FieldIndexMeta> field_map = {{vec, field_index_meta}};
+    IndexMetaPtr meta =
+        std::make_shared<CollectionIndexMeta>(100, std::move(field_map));
+    auto segment_growing = CreateGrowingSegment(schema, meta, 1, config);
+
+    std::vector<int64_t> pks(row_count);
+    std::vector<idx_t> row_ids(row_count);
+    std::vector<Timestamp> timestamps(row_count, 100);
+    for (int64_t i = 0; i < row_count; ++i) {
+        pks[i] = i;
+        row_ids[i] = i;
+    }
+
+    FixedVector<bool> valid_data(row_count);
+    std::fill(valid_data.begin(), valid_data.end(), true);
+    valid_data[0] = false;
+
+    std::vector<float> compact_vectors((row_count - 1) * dim, 1000.0f);
+    // logical row 1 -> physical 0, intentionally far from the query.
+    compact_vectors[0] = 1000.0f;
+    compact_vectors[1] = 0.0f;
+    compact_vectors[2] = 0.0f;
+    compact_vectors[3] = 0.0f;
+    // logical row 2 -> physical 1, exactly equal to the query.
+    compact_vectors[dim] = 0.0f;
+    compact_vectors[dim + 1] = 0.0f;
+    compact_vectors[dim + 2] = 0.0f;
+    compact_vectors[dim + 3] = 0.0f;
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    auto pk_array =
+        CreateDataArrayFrom(pks.data(), nullptr, row_count, (*schema)[pk]);
+    auto vec_array = CreateVectorDataArrayFrom(compact_vectors.data(),
+                                               valid_data.data(),
+                                               row_count,
+                                               row_count - 1,
+                                               (*schema)[vec]);
+    insert_data->mutable_fields_data()->AddAllocated(pk_array.release());
+    insert_data->mutable_fields_data()->AddAllocated(vec_array.release());
+    insert_data->set_num_rows(row_count);
+
+    auto reserved_offset = segment_growing->PreInsert(row_count);
+    segment_growing->Insert(reserved_offset,
+                            row_count,
+                            row_ids.data(),
+                            timestamps.data(),
+                            insert_data.get());
+
+    milvus::segcore::ScopedSchemaHandle schema_handle(*schema);
+    auto plan_str = schema_handle.ParseSearch(
+        "", "embeddings", 5, knowhere::metric::L2, R"({"nprobe": 1})", -1);
+    auto plan =
+        query::CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
+
+    std::array<float, dim> query = {0.0f, 0.0f, 0.0f, 0.0f};
+    auto ph_group_raw = CreatePlaceholderGroupFromBlob(1, dim, query.data());
+    auto ph_group =
+        ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+
+    auto result = segment_growing->Search(plan.get(), ph_group.get(), 100);
+
+    ASSERT_EQ(result->seg_offsets_.size(), 5);
+    ASSERT_EQ(result->distances_.size(), 5);
+    bool found_exact_query_row = false;
+    for (size_t i = 0; i < result->seg_offsets_.size(); ++i) {
+        if (result->seg_offsets_[i] == 2) {
+            EXPECT_FLOAT_EQ(result->distances_[i], 0.0f);
+            found_exact_query_row = true;
+        }
+    }
+    EXPECT_TRUE(found_exact_query_row);
+}
+
 TEST_P(GrowingIndexTest, MissIndexMeta) {
     auto dim = 4;
     auto schema = std::make_shared<Schema>();
@@ -443,6 +552,7 @@ TEST_P(GrowingIndexTest, MissIndexMeta) {
     schema->set_primary_field_id(pk);
 
     auto& config = SegcoreConfig::default_config();
+    ScopedSegcoreConfigRestore config_restore(config);
     config.set_chunk_rows(1024);
     config.set_enable_interim_segment_index(true);
     auto segment = CreateGrowingSegment(schema, nullptr);
@@ -465,6 +575,7 @@ TEST_P(GrowingIndexTest, GetVector) {
     FieldIndexMeta fieldIndexMeta(
         vec, std::move(index_params), std::move(type_params));
     auto& config = SegcoreConfig::default_config();
+    ScopedSegcoreConfigRestore config_restore(config);
     config.set_chunk_rows(1024);
     config.set_enable_interim_segment_index(true);
     if (dense_vec_intermin_index_type.has_value()) {

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -413,7 +413,7 @@ CreateEmptyVectorDataArray(int64_t count, const FieldMeta& field_meta) {
             break;
         }
         case DataType::VECTOR_SPARSE_U32_F32: {
-            // does nothing here
+            vector_array->mutable_sparse_float_vector();
             break;
         }
         case DataType::VECTOR_INT8: {
@@ -773,13 +773,13 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
             } else if (field_meta.get_data_type() == DataType::VECTOR_FLOAT16) {
                 auto data = VEC_FIELD_DATA(src_field_data, float16);
                 auto obj = vector_array->mutable_float16_vector();
-                obj->assign(data + physical_offset * dim * sizeof(float16),
+                obj->append(data + physical_offset * dim * sizeof(float16),
                             dim * sizeof(float16));
             } else if (field_meta.get_data_type() ==
                        DataType::VECTOR_BFLOAT16) {
                 auto data = VEC_FIELD_DATA(src_field_data, bfloat16);
                 auto obj = vector_array->mutable_bfloat16_vector();
-                obj->assign(data + physical_offset * dim * sizeof(bfloat16),
+                obj->append(data + physical_offset * dim * sizeof(bfloat16),
                             dim * sizeof(bfloat16));
             } else if (field_meta.get_data_type() == DataType::VECTOR_BINARY) {
                 AssertInfo(
@@ -788,7 +788,7 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
                 auto num_bytes = dim / 8;
                 auto data = VEC_FIELD_DATA(src_field_data, binary);
                 auto obj = vector_array->mutable_binary_vector();
-                obj->assign(data + physical_offset * num_bytes, num_bytes);
+                obj->append(data + physical_offset * num_bytes, num_bytes);
             } else if (field_meta.get_data_type() ==
                        DataType::VECTOR_SPARSE_U32_F32) {
                 auto& src_vec = src_field_data->vectors().sparse_float_vector();
@@ -802,7 +802,7 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
             } else if (field_meta.get_data_type() == DataType::VECTOR_INT8) {
                 auto data = VEC_FIELD_DATA(src_field_data, int8);
                 auto obj = vector_array->mutable_int8_vector();
-                obj->assign(data + physical_offset * dim * sizeof(int8),
+                obj->append(data + physical_offset * dim * sizeof(int8),
                             dim * sizeof(int8));
             } else if (field_meta.get_data_type() == DataType::VECTOR_ARRAY) {
                 auto& data = src_field_data->vectors().vector_array();

--- a/internal/core/src/segcore/UtilsTest.cpp
+++ b/internal/core/src/segcore/UtilsTest.cpp
@@ -11,6 +11,11 @@
 
 #include <gtest/gtest.h>
 
+#include <folly/CancellationToken.h>
+#include <folly/FBVector.h>
+#include <array>
+#include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -20,6 +25,11 @@
 #include "common/OpContext.h"
 #include "common/Schema.h"
 #include "common/Types.h"
+#include "common/protobuf_utils.h"
+#include "knowhere/comp/index_param.h"
+#include "pb/schema.pb.h"
+#include "query/Utils.h"
+#include "segcore/AckResponder.h"
 #include "segcore/ConcurrentVector.h"
 #include "segcore/DeletedRecord.h"
 #include "segcore/InsertRecord.h"
@@ -94,6 +104,127 @@ TEST(Util_Segcore, GetDeleteBitmap) {
     BitsetTypeView res_view(res_bitmap);
     delete_record.Query(res_view, insert_barrier, query_timestamp);
     ASSERT_EQ(res_view.count(), 0);
+}
+
+TEST(Util_Segcore, MergeDataArrayWithNullableByteVectorsAppendsRows) {
+    using namespace milvus;
+    using namespace milvus::segcore;
+
+    struct TestCase {
+        DataType data_type;
+        int64_t dim;
+        std::string metric_type;
+        int64_t bytes_per_row;
+    };
+
+    std::vector<TestCase> test_cases = {
+        {DataType::VECTOR_BINARY, 16, knowhere::metric::HAMMING, 2},
+        {DataType::VECTOR_FLOAT16, 2, knowhere::metric::L2, 4},
+        {DataType::VECTOR_BFLOAT16, 2, knowhere::metric::L2, 4},
+        {DataType::VECTOR_INT8, 3, knowhere::metric::L2, 3},
+    };
+
+    for (const auto& test_case : test_cases) {
+        SCOPED_TRACE(fmt::format("data_type={}", test_case.data_type));
+
+        auto schema = std::make_shared<Schema>();
+        auto vec = schema->AddDebugField("embeddings",
+                                         test_case.data_type,
+                                         test_case.dim,
+                                         test_case.metric_type,
+                                         true);
+        auto& field_meta = (*schema)[vec];
+
+        constexpr int64_t total_count = 4;
+        constexpr int64_t valid_count = 3;
+        std::array<bool, total_count> valid_flags = {true, false, true, true};
+
+        std::string compact_data(valid_count * test_case.bytes_per_row, '\0');
+        for (size_t i = 0; i < compact_data.size(); ++i) {
+            compact_data[i] = static_cast<char>(i + 1);
+        }
+
+        auto data_array = CreateVectorDataArrayFrom(compact_data.data(),
+                                                    valid_flags.data(),
+                                                    total_count,
+                                                    valid_count,
+                                                    field_meta);
+
+        std::map<FieldId, std::unique_ptr<milvus::DataArray>>
+            output_fields_data;
+        output_fields_data[vec] = std::move(data_array);
+
+        std::vector<MergeBase> merge_bases;
+        std::array<size_t, total_count> physical_offsets = {0, 0, 1, 2};
+        for (size_t i = 0; i < total_count; ++i) {
+            merge_bases.emplace_back(&output_fields_data, i);
+            if (valid_flags[i]) {
+                merge_bases.back().setValidDataOffset(vec, physical_offsets[i]);
+            }
+        }
+
+        auto merged_result = MergeDataArray(merge_bases, field_meta);
+
+        ASSERT_EQ(merged_result->valid_data().size(), total_count);
+        EXPECT_TRUE(merged_result->valid_data(0));
+        EXPECT_FALSE(merged_result->valid_data(1));
+        EXPECT_TRUE(merged_result->valid_data(2));
+        EXPECT_TRUE(merged_result->valid_data(3));
+
+        std::string actual;
+        switch (test_case.data_type) {
+            case DataType::VECTOR_BINARY:
+                actual = merged_result->vectors().binary_vector();
+                break;
+            case DataType::VECTOR_FLOAT16:
+                actual = merged_result->vectors().float16_vector();
+                break;
+            case DataType::VECTOR_BFLOAT16:
+                actual = merged_result->vectors().bfloat16_vector();
+                break;
+            case DataType::VECTOR_INT8:
+                actual = merged_result->vectors().int8_vector();
+                break;
+            default:
+                ThrowInfo(DataTypeInvalid, "unexpected test vector type");
+        }
+
+        ASSERT_EQ(actual.size(), compact_data.size());
+        EXPECT_EQ(actual, compact_data);
+    }
+}
+
+TEST(Util_Segcore, TransformBitsetMasksNullableVectorRowsOutsideLogicalView) {
+    using namespace milvus;
+
+    std::array<bool, 3> valid_data = {true, true, true};
+    OffsetMapping mapping;
+    mapping.Build(valid_data.data(), valid_data.size());
+
+    // Growing search passes a logical bitset sized by the query timestamp's
+    // active row count. Rows beyond that logical view are not visible yet and
+    // must be masked in the transformed physical bitset.
+    BitsetType logical_bitset(2);
+    BitsetView logical_view(logical_bitset);
+
+    auto physical_bitset = query::TransformBitset(logical_view, mapping);
+
+    ASSERT_EQ(physical_bitset.size(), 3);
+    EXPECT_FALSE(physical_bitset[0]);
+    EXPECT_FALSE(physical_bitset[1]);
+    EXPECT_TRUE(physical_bitset[2]);
+}
+
+TEST(Util_Segcore, TransformBitsetKeepsEmptyViewAsNoFilter) {
+    using namespace milvus;
+
+    std::array<bool, 3> valid_data = {true, false, true};
+    OffsetMapping mapping;
+    mapping.Build(valid_data.data(), valid_data.size());
+
+    auto physical_bitset = query::TransformBitset(BitsetView{}, mapping);
+
+    EXPECT_TRUE(physical_bitset.empty());
 }
 
 // Tests for CheckCancellation utility function
@@ -242,6 +373,8 @@ TEST(Util_Segcore, CreateEmptyVectorDataArrayForNullableVectors) {
     ASSERT_FALSE(sparse_result->valid_data(0));
     ASSERT_FALSE(sparse_result->valid_data(1));
     ASSERT_FALSE(sparse_result->valid_data(2));
+    ASSERT_EQ(sparse_result->vectors().data_case(),
+              proto::schema::VectorField::kSparseFloatVector);
     ASSERT_EQ(sparse_result->vectors().sparse_float_vector().contents_size(),
               0);
 }

--- a/internal/core/src/storage/DataCodecTest.cpp
+++ b/internal/core/src/storage/DataCodecTest.cpp
@@ -31,6 +31,88 @@
 
 using namespace milvus;
 
+TEST(storage, NullableFloatVectorArrowAllValidMaterializesValidData) {
+    std::array<float, 2> row0 = {1.0F, 2.0F};
+    std::array<float, 2> row1 = {3.0F, 4.0F};
+    arrow::BinaryBuilder builder;
+    ASSERT_TRUE(builder
+                    .Append(reinterpret_cast<const uint8_t*>(row0.data()),
+                            sizeof(float) * row0.size())
+                    .ok());
+    ASSERT_TRUE(builder
+                    .Append(reinterpret_cast<const uint8_t*>(row1.data()),
+                            sizeof(float) * row1.size())
+                    .ok());
+    std::shared_ptr<arrow::Array> binary_array;
+    ASSERT_TRUE(builder.Finish(&binary_array).ok());
+    ASSERT_EQ(binary_array->null_count(), 0);
+
+    auto field_data = storage::CreateFieldData(
+        storage::DataType::VECTOR_FLOAT, DataType::NONE, true, 2);
+    auto chunked_array = std::make_shared<arrow::ChunkedArray>(binary_array);
+    ASSERT_NO_THROW(field_data->FillFieldData(chunked_array));
+
+    ASSERT_EQ(field_data->get_num_rows(), 2);
+    ASSERT_EQ(field_data->get_valid_rows(), 2);
+    ASSERT_EQ(field_data->get_null_count(), 0);
+    ASSERT_TRUE(field_data->is_valid(0));
+    ASSERT_TRUE(field_data->is_valid(1));
+
+    auto actual0 = static_cast<const float*>(field_data->RawValue(0));
+    auto actual1 = static_cast<const float*>(field_data->RawValue(1));
+    ASSERT_NE(actual0, nullptr);
+    ASSERT_NE(actual1, nullptr);
+    EXPECT_FLOAT_EQ(actual0[0], row0[0]);
+    EXPECT_FLOAT_EQ(actual0[1], row0[1]);
+    EXPECT_FLOAT_EQ(actual1[0], row1[0]);
+    EXPECT_FLOAT_EQ(actual1[1], row1[1]);
+}
+
+TEST(storage, NullableFloatVectorArrowChunksAccumulateNullCount) {
+    std::array<float, 2> row0 = {1.0F, 2.0F};
+    std::array<float, 2> row3 = {7.0F, 8.0F};
+
+    arrow::BinaryBuilder first_builder;
+    ASSERT_TRUE(first_builder
+                    .Append(reinterpret_cast<const uint8_t*>(row0.data()),
+                            sizeof(float) * row0.size())
+                    .ok());
+    ASSERT_TRUE(first_builder.AppendNull().ok());
+    std::shared_ptr<arrow::Array> first_array;
+    ASSERT_TRUE(first_builder.Finish(&first_array).ok());
+
+    arrow::BinaryBuilder second_builder;
+    ASSERT_TRUE(second_builder.AppendNull().ok());
+    ASSERT_TRUE(second_builder
+                    .Append(reinterpret_cast<const uint8_t*>(row3.data()),
+                            sizeof(float) * row3.size())
+                    .ok());
+    std::shared_ptr<arrow::Array> second_array;
+    ASSERT_TRUE(second_builder.Finish(&second_array).ok());
+
+    auto field_data = storage::CreateFieldData(
+        storage::DataType::VECTOR_FLOAT, DataType::NONE, true, 2);
+    auto chunked_array = std::make_shared<arrow::ChunkedArray>(
+        arrow::ArrayVector{first_array, second_array});
+    ASSERT_NO_THROW(field_data->FillFieldData(chunked_array));
+
+    ASSERT_EQ(field_data->get_num_rows(), 4);
+    ASSERT_EQ(field_data->get_valid_rows(), 2);
+    ASSERT_EQ(field_data->get_null_count(), 2);
+    EXPECT_TRUE(field_data->is_valid(0));
+    EXPECT_FALSE(field_data->is_valid(1));
+    EXPECT_FALSE(field_data->is_valid(2));
+    EXPECT_TRUE(field_data->is_valid(3));
+
+    auto actual0 = static_cast<const float*>(field_data->RawValue(0));
+    auto actual3 = static_cast<const float*>(field_data->RawValue(3));
+    ASSERT_NE(actual0, nullptr);
+    ASSERT_NE(actual3, nullptr);
+    EXPECT_FLOAT_EQ(actual0[0], row0[0]);
+    EXPECT_FLOAT_EQ(actual0[1], row0[1]);
+    EXPECT_FLOAT_EQ(actual3[0], row3[0]);
+    EXPECT_FLOAT_EQ(actual3[1], row3[1]);
+}
 TEST(storage, InsertDataBool) {
     FixedVector<bool> data = {true, false, true, false, true};
     auto field_data = milvus::storage::CreateFieldData(

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -73,6 +73,7 @@
 #include "index/BitmapIndex.h"
 #include "index/StringIndexMarisa.h"
 #include "index/StringIndexSort.h"
+#include "index/VectorDiskIndex.h"
 
 class DiskAnnFileManagerTest_CacheOptFieldToDiskCorrectDOUBLE_Test;
 class DiskAnnFileManagerTest_CacheOptFieldToDiskCorrectFLOAT_Test;
@@ -1148,16 +1149,16 @@ TEST_F(DiskAnnFileManagerTest, CacheRawDataToDiskValidDataFile) {
     ASSERT_TRUE(local_chunk_manager->Exist(valid_data_path))
         << "valid_data file should be created for nullable field";
 
-    size_t read_total_num_rows = 0;
+    uint64_t read_total_num_rows = 0;
     local_chunk_manager->Read(
-        valid_data_path, 0, &read_total_num_rows, sizeof(size_t));
+        valid_data_path, 0, &read_total_num_rows, sizeof(uint64_t));
     EXPECT_EQ(read_total_num_rows, num_rows)
         << "total_num_rows should match original num_rows";
 
     size_t bitmap_size = (num_rows + 7) / 8;
     std::vector<uint8_t> read_bitmap(bitmap_size);
     local_chunk_manager->Read(
-        valid_data_path, sizeof(size_t), read_bitmap.data(), bitmap_size);
+        valid_data_path, sizeof(uint64_t), read_bitmap.data(), bitmap_size);
 
     // Verify bitmap content
     for (int64_t i = 0; i < num_rows; ++i) {
@@ -1170,6 +1171,80 @@ TEST_F(DiskAnnFileManagerTest, CacheRawDataToDiskValidDataFile) {
     local_chunk_manager->Remove(local_data_path);
     local_chunk_manager->Remove(valid_data_path);
     cm_->Remove(insert_file_path);
+}
+
+TEST_F(DiskAnnFileManagerTest, LoadAllNullNullableDiskVectorIndexFromDataset) {
+    const int64_t collection_id = 1;
+    const int64_t partition_id = 2;
+    const int64_t segment_id = 3002;
+    const int64_t field_id = 100;
+    const int64_t dim = 128;
+    const int64_t num_rows = 100;
+
+    FieldDataMeta field_data_meta = {
+        collection_id, partition_id, segment_id, field_id};
+    field_data_meta.field_schema.set_nullable(true);
+
+    IndexMeta index_meta = {segment_id,
+                            field_id,
+                            1000,
+                            1,
+                            "test",
+                            "vec_field",
+                            DataType::VECTOR_FLOAT,
+                            dim};
+    storage::FileManagerContext file_manager_context(
+        field_data_meta, index_meta, cm_, fs_);
+
+    std::vector<std::string> files;
+    {
+        milvus::index::VectorDiskAnnIndex<float> index(
+            DataType::NONE,
+            knowhere::IndexEnum::INDEX_DISKANN,
+            knowhere::metric::L2,
+            knowhere::Version::GetCurrentVersion().VersionNumber(),
+            file_manager_context);
+
+        std::unique_ptr<bool[]> valid_data(new bool[num_rows]);
+        std::fill_n(valid_data.get(), num_rows, false);
+        index.UpdateValidData(valid_data.get(), num_rows);
+
+        std::vector<float> vec_data(dim, 0.0f);
+        auto dataset = knowhere::GenDataSet(0, dim, vec_data.data());
+
+        milvus::Config config;
+        config[DIM_KEY] = dim;
+        config[milvus::index::DISK_ANN_BUILD_THREAD_NUM] = "1";
+
+        index.BuildWithDataset(dataset, config);
+        auto stats = index.Upload(config);
+        files = stats->GetIndexFiles();
+    }
+
+    ASSERT_EQ(files.size(), 1);
+    EXPECT_NE(files[0].find(milvus::index::VALID_DATA_KEY), std::string::npos);
+
+    milvus::index::VectorDiskAnnIndex<float> loaded_index(
+        DataType::NONE,
+        knowhere::IndexEnum::INDEX_DISKANN,
+        knowhere::metric::L2,
+        knowhere::Version::GetCurrentVersion().VersionNumber(),
+        file_manager_context);
+
+    milvus::Config load_config;
+    load_config[DIM_KEY] = dim;
+    load_config[milvus::index::DISK_ANN_LOAD_THREAD_NUM] = "1";
+    load_config["index_files"] = files;
+
+    loaded_index.Load(milvus::tracer::TraceContext{}, load_config);
+    ASSERT_TRUE(loaded_index.GetOffsetMapping().IsEnabled());
+    EXPECT_EQ(loaded_index.GetOffsetMapping().GetTotalCount(), num_rows);
+    EXPECT_EQ(loaded_index.GetOffsetMapping().GetValidCount(), 0);
+    EXPECT_EQ(loaded_index.GetDim(), dim);
+
+    for (const auto& file : files) {
+        cm_->Remove(file);
+    }
 }
 
 TEST_F(DiskAnnFileManagerTest, CacheRawDataToDiskNoValidDataForNonNullable) {

--- a/internal/core/unittest/test_utils/SegcoreConfigUtils.h
+++ b/internal/core/unittest/test_utils/SegcoreConfigUtils.h
@@ -1,0 +1,124 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+// the specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "knowhere/index/index_factory.h"
+#include "segcore/SegcoreConfig.h"
+
+namespace milvus::segcore {
+
+inline std::string
+RefineTypeToConfigStringForTest(knowhere::RefineType refine_type) {
+    if (refine_type == knowhere::RefineType::DATA_VIEW) {
+        return "NONE";
+    }
+    if (refine_type == knowhere::RefineType::BFLOAT16_QUANT) {
+        return "BFLOAT16";
+    }
+    if (refine_type == knowhere::RefineType::FLOAT16_QUANT) {
+        return "FLOAT16";
+    }
+    if (refine_type == knowhere::RefineType::UINT8_QUANT) {
+        return "UINT8";
+    }
+    ThrowInfo(Unsupported, "unsupported refine type for test config restore");
+}
+
+class ScopedSegcoreConfigRestore {
+ public:
+    explicit ScopedSegcoreConfigRestore(
+        SegcoreConfig& config = SegcoreConfig::default_config())
+        : config_(config),
+          chunk_rows_(config.get_chunk_rows()),
+          nlist_(config.get_nlist()),
+          nprobe_(config.get_nprobe()),
+          enable_interim_segment_index_(
+              config.get_enable_interim_segment_index()),
+          sub_dim_(config.get_sub_dim()),
+          refine_ratio_(config.get_refine_ratio()),
+          dense_vector_interim_index_type_(
+              config.get_dense_vector_intermin_index_type()),
+          refine_quant_type_(
+              RefineTypeToConfigStringForTest(config.get_refine_quant_type())),
+          refine_with_quant_flag_(config.get_refine_with_quant_flag()) {
+    }
+
+    ~ScopedSegcoreConfigRestore() {
+        config_.set_chunk_rows(chunk_rows_);
+        config_.set_nlist(nlist_);
+        config_.set_nprobe(nprobe_);
+        config_.set_enable_interim_segment_index(enable_interim_segment_index_);
+        config_.set_sub_dim(sub_dim_);
+        config_.set_refine_ratio(refine_ratio_);
+        config_.set_dense_vector_intermin_index_type(
+            dense_vector_interim_index_type_);
+        config_.set_refine_quant_type(refine_quant_type_);
+        config_.set_refine_with_quant_flag(refine_with_quant_flag_);
+    }
+
+    ScopedSegcoreConfigRestore(const ScopedSegcoreConfigRestore&) = delete;
+    ScopedSegcoreConfigRestore&
+    operator=(const ScopedSegcoreConfigRestore&) = delete;
+
+ private:
+    SegcoreConfig& config_;
+    int64_t chunk_rows_;
+    int64_t nlist_;
+    int64_t nprobe_;
+    bool enable_interim_segment_index_;
+    int64_t sub_dim_;
+    float refine_ratio_;
+    std::string dense_vector_interim_index_type_;
+    std::string refine_quant_type_;
+    bool refine_with_quant_flag_;
+};
+
+struct InterimIndexConfigForTest {
+    bool enable_interim_segment_index = true;
+    int64_t chunk_rows = 32 * 1024;
+    int64_t nlist = 100;
+    int64_t nprobe = 4;
+    std::optional<std::string> dense_vector_interim_index_type = std::nullopt;
+    int64_t sub_dim = 2;
+    float refine_ratio = 3.0F;
+    std::string refine_quant_type = "NONE";
+    bool refine_with_quant_flag = false;
+};
+
+inline void
+ApplyInterimIndexConfigForTest(
+    const InterimIndexConfigForTest& options,
+    SegcoreConfig& config = SegcoreConfig::default_config()) {
+    config.set_chunk_rows(options.chunk_rows);
+    config.set_enable_interim_segment_index(
+        options.enable_interim_segment_index);
+    config.set_nlist(options.nlist);
+    config.set_nprobe(options.nprobe);
+    if (options.dense_vector_interim_index_type.has_value()) {
+        config.set_dense_vector_intermin_index_type(
+            options.dense_vector_interim_index_type.value());
+    }
+
+    if (options.dense_vector_interim_index_type.has_value() &&
+        options.dense_vector_interim_index_type.value() ==
+            knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR) {
+        config.set_sub_dim(options.sub_dim);
+        config.set_refine_ratio(options.refine_ratio);
+        config.set_refine_quant_type(options.refine_quant_type);
+        config.set_refine_with_quant_flag(options.refine_with_quant_flag);
+    }
+}
+
+}  // namespace milvus::segcore

--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -173,7 +173,7 @@ func (it *indexBuildTask) CreateTaskOnWorker(nodeID int64, cluster session.Clust
 	if fieldID := it.meta.indexMeta.GetFieldIDByIndexID(segIndex.CollectionID, segIndex.IndexID); fieldID > 0 {
 		if collectionInfo, err := it.handler.GetCollection(ctx, segIndex.CollectionID); err == nil {
 			for _, f := range typeutil.GetAllFieldSchemas(collectionInfo.Schema) {
-				if f.FieldID == fieldID && f.GetNullable() && typeutil.IsVectorType(f.GetDataType()) {
+				if f.FieldID == fieldID && f.GetNullable() && typeutil.IsSupportedNullableVectorType(f.GetDataType()) {
 					effectiveRows = segmentutil.CalcValidRowCountFromFieldBinLog(segment.SegmentInfo, fieldID)
 					break
 				}

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -1565,6 +1565,7 @@ func newFieldDataRowAccessor(fieldData *schemapb.FieldData) (*fieldDataRowAccess
 	if len(accessor.validData) == 0 {
 		return accessor, nil
 	}
+	isNullableVector := typeutil.IsCompactNullableVectorFieldData(fieldData)
 
 	compactIndices := make([]int64, len(accessor.validData))
 	validCount := int64(0)
@@ -1575,6 +1576,13 @@ func newFieldDataRowAccessor(fieldData *schemapb.FieldData) (*fieldDataRowAccess
 		} else {
 			compactIndices[i] = -1
 		}
+	}
+	if isNullableVector {
+		if err := funcutil.ValidateNullableVectorFieldDataCompact(fieldData, uint64(len(accessor.validData)), true); err != nil {
+			return nil, err
+		}
+		accessor.compactIndices = compactIndices
+		return accessor, nil
 	}
 	if validCount == 0 {
 		accessor.compactIndices = compactIndices

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 	"google.golang.org/protobuf/proto"
 
@@ -1898,6 +1899,130 @@ func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {
 		assert.Len(t, rows, 2)
 		assert.Nil(t, rows[0][FieldBookIntro])
 		assert.Nil(t, rows[1][FieldBookIntro])
+	})
+
+	t.Run("nullable vector rejects full row payload", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_FloatVector,
+			FieldName: FieldBookIntro,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{
+							Data: []float32{
+								0.1, 0.2,
+								0.0, 0.0,
+								0.3, 0.4,
+							},
+						},
+					},
+				},
+			},
+			ValidData: []bool{true, false, true},
+		}
+
+		_, err := buildQueryResp(0, []string{FieldBookIntro}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nullable vector field")
+	})
+
+	t.Run("nullable dense vector rejects partial row payload", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			fieldData *schemapb.FieldData
+		}{
+			{
+				name: "float_vector",
+				fieldData: &schemapb.FieldData{
+					Type:      schemapb.DataType_FloatVector,
+					FieldName: FieldBookIntro,
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 2,
+							Data: &schemapb.VectorField_FloatVector{
+								FloatVector: &schemapb.FloatArray{Data: []float32{0.1, 0.2, 0.3}},
+							},
+						},
+					},
+					ValidData: []bool{true, false},
+				},
+			},
+			{
+				name: "binary_vector",
+				fieldData: &schemapb.FieldData{
+					Type:      schemapb.DataType_BinaryVector,
+					FieldName: FieldBookIntro,
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 16,
+							Data: &schemapb.VectorField_BinaryVector{
+								BinaryVector: []byte{0x01, 0x02, 0x03},
+							},
+						},
+					},
+					ValidData: []bool{true, false},
+				},
+			},
+			{
+				name: "float16_vector",
+				fieldData: &schemapb.FieldData{
+					Type:      schemapb.DataType_Float16Vector,
+					FieldName: FieldBookIntro,
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 2,
+							Data: &schemapb.VectorField_Float16Vector{
+								Float16Vector: []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+							},
+						},
+					},
+					ValidData: []bool{true, false},
+				},
+			},
+			{
+				name: "bfloat16_vector",
+				fieldData: &schemapb.FieldData{
+					Type:      schemapb.DataType_BFloat16Vector,
+					FieldName: FieldBookIntro,
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 2,
+							Data: &schemapb.VectorField_Bfloat16Vector{
+								Bfloat16Vector: []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+							},
+						},
+					},
+					ValidData: []bool{true, false},
+				},
+			},
+			{
+				name: "int8_vector",
+				fieldData: &schemapb.FieldData{
+					Type:      schemapb.DataType_Int8Vector,
+					FieldName: FieldBookIntro,
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 2,
+							Data: &schemapb.VectorField_Int8Vector{
+								Int8Vector: []byte{0x01, 0x02, 0x03},
+							},
+						},
+					},
+					ValidData: []bool{true, false},
+				},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := buildQueryResp(0, []string{FieldBookIntro}, []*schemapb.FieldData{tc.fieldData}, nil, nil, true, nil)
+				require.Error(t, err)
+				assert.True(t,
+					strings.Contains(err.Error(), "row width") || strings.Contains(err.Error(), "divide the dim"),
+					"unexpected error: %s", err.Error())
+			})
+		}
 	})
 
 	t.Run("nullable scalar compact data uses physical index", func(t *testing.T) {

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -343,21 +343,9 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		return err
 	}
 
-	// Two nullable data formats are supported:
-	//
-	//	COMPRESSED FORMAT (SDK format, before validateUtil.fillWithValue processing):
-	//		Logical data: [1, null, 2]
-	//		Storage: Data=[1, 2] + ValidData=[true, false, true]
-	//		- Data array contains only non-null values (compressed)
-	//		- ValidData array tracks null positions for all rows
-	//
-	//	FULL FORMAT (Milvus internal format, after validateUtil.fillWithValue processing):
-	//		Logical data: [1, null, 2]
-	//		Storage: Data=[1, 0, 2] + ValidData=[true, false, true]
-	//		- Data array contains values for all rows (nulls filled with zero/default)
-	//		- ValidData array still tracks null positions
-	//
-	// Note: we will unify the nullable format to FULL FORMAT before executing the merge logic
+	// Scalar nullable payloads are expanded before merge. Nullable vector payloads
+	// must remain compact: ValidData tracks logical rows, and vector data stores
+	// only valid rows.
 	insertIdxInUpsert := make([]int, 0)
 	updateIdxInUpsert := make([]int, 0)
 	// 1. split upsert data into insert and update by query result
@@ -428,7 +416,7 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 
 			dstField := it.insertFieldData[fieldIdx]
 			upsertField := upsertFieldMap[existField.FieldId]
-			isNullableVector := len(existField.GetValidData()) > 0 && typeutil.IsVectorType(existField.GetType())
+			isNullableVector := typeutil.IsCompactNullableVectorFieldData(existField)
 			existComputer := typeutil.NewFieldDataIdxComputer([]*schemapb.FieldData{existField})
 			existSrcIndices := make([]int64, len(updateIdxInUpsert))
 			for i, existIdx := range existIndices {
@@ -530,7 +518,7 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 
 		// Process insert data by column (field), similar to update path
 		for _, srcField := range insertWithNullField {
-			isNullableVector := len(srcField.GetValidData()) > 0 && typeutil.IsVectorType(srcField.GetType())
+			isNullableVector := typeutil.IsCompactNullableVectorFieldData(srcField)
 			srcComputer := typeutil.NewFieldDataIdxComputer([]*schemapb.FieldData{srcField})
 
 			// Find or create destination field in it.insertFieldData
@@ -753,7 +741,8 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 	return nil
 }
 
-// GenNullableFieldData generates nullable field data in FULL FORMAT
+// GenNullableFieldData generates all-null nullable field data.
+// Scalar fields use expanded zero values; vector fields use compact empty data.
 func GenNullableFieldData(field *schemapb.FieldSchema, upsertIDSize int) (*schemapb.FieldData, error) {
 	switch field.DataType {
 	case schemapb.DataType_Bool:

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -721,6 +721,9 @@ func ValidateStructArrayField(structArrayField *schemapb.StructArrayFieldSchema,
 		if err := ValidateFieldsInStruct(subField, schema); err != nil {
 			return err
 		}
+		if subField.GetDataType() == schemapb.DataType_ArrayOfVector && subField.GetNullable() {
+			return merr.WrapErrParameterInvalidMsg("ArrayOfVector does not support nullable, structName=%s, fieldName=%s", structArrayField.GetName(), subField.GetName())
+		}
 	}
 	return nil
 }

--- a/internal/proxy/validate_util.go
+++ b/internal/proxy/validate_util.go
@@ -404,6 +404,16 @@ func (v *validateUtil) checkAligned(data []*schemapb.FieldData, schema *typeutil
 			if err != nil {
 				return err
 			}
+
+			// ArrayOfVector does not support nullable rows, so its per-row
+			// VectorField array must stay aligned with the logical row count.
+			if field.GetVectors() == nil || field.GetVectors().GetVectorArray() == nil {
+				if numRows != 0 {
+					return errNumRowsMismatch(field.GetFieldName(), 0)
+				}
+				continue
+			}
+
 			dim, err := typeutil.GetDim(f)
 			if err != nil {
 				return err
@@ -444,7 +454,8 @@ func (v *validateUtil) checkAligned(data []*schemapb.FieldData, schema *typeutil
 //  2. has default_value,
 //     will fill default_value when passed num_rows not equal to expected num_rows,
 //
-// after fillWithValue, only nullable field will has valid_data, the length of all data will be passed num_rows
+// after fillWithValue, nullable/default fields have ValidData. Scalar nullable
+// payloads are expanded to numRows; nullable vector payloads remain compact.
 func (v *validateUtil) fillWithValue(data []*schemapb.FieldData, schema *typeutil.SchemaHelper, numRows int) error {
 	for _, field := range data {
 		fieldSchema, err := schema.GetFieldFromName(field.GetFieldName())
@@ -554,6 +565,12 @@ func FillWithNullValue(field *schemapb.FieldData, fieldSchema *schemapb.FieldSch
 		}
 
 	case *schemapb.FieldData_Vectors:
+		if field.Type == schemapb.DataType_ArrayOfVector {
+			if len(field.GetValidData()) != 0 {
+				return merr.WrapErrParameterInvalidMsg("ArrayOfVector does not support nullable, field: %s", field.GetFieldName())
+			}
+			return nil
+		}
 	default:
 		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("undefined data type:%s", field.Type.String()))
 	}
@@ -1133,6 +1150,10 @@ func (v *validateUtil) checkArrayFieldData(field *schemapb.FieldData, fieldSchem
 }
 
 func (v *validateUtil) checkArrayOfVectorFieldData(field *schemapb.FieldData, fieldSchema *schemapb.FieldSchema) error {
+	if len(field.GetValidData()) != 0 {
+		return merr.WrapErrParameterInvalidMsg("ArrayOfVector does not support nullable, field: %s", field.GetFieldName())
+	}
+
 	data := field.GetVectors().GetVectorArray()
 	if data == nil {
 		elementTypeStr := fieldSchema.GetElementType().String()

--- a/internal/proxy/validate_util_test.go
+++ b/internal/proxy/validate_util_test.go
@@ -2223,6 +2223,66 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("nullable float16 and bfloat16 vector all null rejects partial row payload", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			dataType schemapb.DataType
+			vector   *schemapb.VectorField
+		}{
+			{
+				name:     "float16",
+				dataType: schemapb.DataType_Float16Vector,
+				vector: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_Float16Vector{
+						Float16Vector: []byte{0x01, 0x02},
+					},
+				},
+			},
+			{
+				name:     "bfloat16",
+				dataType: schemapb.DataType_BFloat16Vector,
+				vector: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_Bfloat16Vector{
+						Bfloat16Vector: []byte{0x01, 0x02},
+					},
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				data := []*schemapb.FieldData{
+					{
+						FieldName: "test",
+						Type:      tc.dataType,
+						ValidData: []bool{false, false},
+						Field: &schemapb.FieldData_Vectors{
+							Vectors: tc.vector,
+						},
+					},
+				}
+
+				schema := &schemapb.CollectionSchema{
+					Fields: []*schemapb.FieldSchema{
+						{
+							Name:       "test",
+							DataType:   tc.dataType,
+							TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+							Nullable:   true,
+						},
+					},
+				}
+				h, err := typeutil.CreateSchemaHelper(schema)
+				require.NoError(t, err)
+
+				err = newValidateUtil().checkAligned(data, h, 2)
+				require.Error(t, err)
+			})
+		}
+	})
+
 	t.Run("nullable int8 vector all null", func(t *testing.T) {
 		data := []*schemapb.FieldData{
 			{
@@ -2302,6 +2362,121 @@ func Test_validateUtil_Validate(t *testing.T) {
 		err := v.Validate(data, nil, 100)
 
 		assert.Error(t, err)
+	})
+
+	t.Run("nullable vector fills missing valid data", func(t *testing.T) {
+		testCases := []struct {
+			name      string
+			dataType  schemapb.DataType
+			dim       string
+			fieldData *schemapb.FieldData
+		}{
+			{
+				name:     "FloatVector",
+				dataType: schemapb.DataType_FloatVector,
+				dim:      "2",
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_FloatVector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim: 2,
+						Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+							Data: []float32{1, 2, 3, 4},
+						}},
+					}},
+				},
+			},
+			{
+				name:     "BinaryVector",
+				dataType: schemapb.DataType_BinaryVector,
+				dim:      "8",
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_BinaryVector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim:  8,
+						Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 2}},
+					}},
+				},
+			},
+			{
+				name:     "Float16Vector",
+				dataType: schemapb.DataType_Float16Vector,
+				dim:      "2",
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_Float16Vector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim:  2,
+						Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+					}},
+				},
+			},
+			{
+				name:     "BFloat16Vector",
+				dataType: schemapb.DataType_BFloat16Vector,
+				dim:      "2",
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_BFloat16Vector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim:  2,
+						Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+					}},
+				},
+			},
+			{
+				name:     "Int8Vector",
+				dataType: schemapb.DataType_Int8Vector,
+				dim:      "2",
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_Int8Vector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim:  2,
+						Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{1, 2, 3, 4}},
+					}},
+				},
+			},
+			{
+				name:     "SparseFloatVector",
+				dataType: schemapb.DataType_SparseFloatVector,
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_SparseFloatVector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+							Contents: [][]byte{
+								typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1}),
+								typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2}),
+							},
+						}},
+					}},
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				fieldSchema := &schemapb.FieldSchema{
+					FieldID:  100,
+					Name:     "vec",
+					DataType: tc.dataType,
+					Nullable: true,
+				}
+				if tc.dim != "" {
+					fieldSchema.TypeParams = []*commonpb.KeyValuePair{{Key: common.DimKey, Value: tc.dim}}
+				}
+				h, err := typeutil.CreateSchemaHelper(&schemapb.CollectionSchema{
+					Fields: []*schemapb.FieldSchema{fieldSchema},
+				})
+				require.NoError(t, err)
+
+				err = newValidateUtil().Validate([]*schemapb.FieldData{tc.fieldData}, h, 2)
+				require.NoError(t, err)
+				assert.Equal(t, []bool{true, true}, tc.fieldData.GetValidData())
+			})
+		}
 	})
 
 	t.Run("not aligned", func(t *testing.T) {
@@ -7765,6 +7940,41 @@ func Test_validateUtil_checkArrayOfVectorFieldData(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("valid data is rejected", func(t *testing.T) {
+		f := &schemapb.FieldData{
+			FieldName: "vec_array",
+			ValidData: []bool{true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_VectorArray{
+						VectorArray: &schemapb.VectorArray{
+							Dim:         2,
+							ElementType: schemapb.DataType_FloatVector,
+							Data: []*schemapb.VectorField{
+								{
+									Data: &schemapb.VectorField_FloatVector{
+										FloatVector: &schemapb.FloatArray{
+											Data: []float32{1, 2},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		fieldSchema := &schemapb.FieldSchema{
+			DataType:    schemapb.DataType_ArrayOfVector,
+			ElementType: schemapb.DataType_FloatVector,
+			TypeParams:  []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+		}
+		v := newValidateUtil()
+		err := v.checkArrayOfVectorFieldData(f, fieldSchema)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ArrayOfVector does not support nullable")
+	})
+
 	t.Run("no check", func(t *testing.T) {
 		f := &schemapb.FieldData{
 			Field: &schemapb.FieldData_Vectors{
@@ -8018,6 +8228,39 @@ func TestFillWithNullValue_Geometry(t *testing.T) {
 		assert.Nil(t, field.GetScalars().GetGeometryData().GetData()[1])
 		assert.Equal(t, []byte{0x03, 0x04}, field.GetScalars().GetGeometryData().GetData()[2])
 		assert.Nil(t, field.GetScalars().GetGeometryData().GetData()[3])
+	})
+
+	t.Run("ArrayOfVector rejects nullable valid data", func(t *testing.T) {
+		field := &schemapb.FieldData{
+			FieldName: "vec_array",
+			Type:      schemapb.DataType_ArrayOfVector,
+			ValidData: []bool{true, false, true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 4,
+					Data: &schemapb.VectorField_VectorArray{
+						VectorArray: &schemapb.VectorArray{
+							Data: []*schemapb.VectorField{
+								{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3, 4}}}},
+								{Dim: 4, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{5, 6, 7, 8}}}},
+							},
+							Dim:         4,
+							ElementType: schemapb.DataType_FloatVector,
+						},
+					},
+				},
+			},
+		}
+
+		fieldSchema := &schemapb.FieldSchema{
+			Name:        "vec_array",
+			DataType:    schemapb.DataType_ArrayOfVector,
+			ElementType: schemapb.DataType_FloatVector,
+			Nullable:    true,
+		}
+		err := FillWithNullValue(field, fieldSchema, 3)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ArrayOfVector does not support nullable")
 	})
 }
 

--- a/internal/rootcoord/constrant.go
+++ b/internal/rootcoord/constrant.go
@@ -28,6 +28,7 @@ const (
 	globalIDAllocatorSubPath  = "gid"
 	globalTSOAllocatorKey     = "timestamp"
 	globalTSOAllocatorSubPath = "tso"
+	defaultMaxArrayCapacity   = 4096
 )
 
 func checkGeneralCapacity(ctx context.Context, newColNum int,

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -674,7 +674,8 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 			},
 		}
 		err := task.validateSchema(context.TODO(), schema)
-		assert.NoError(t, err)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ArrayOfVector does not support nullable")
 	})
 
 	t.Run("struct array field - field with default value", func(t *testing.T) {
@@ -820,6 +821,7 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 							Name:        "nested_array",
 							DataType:    schemapb.DataType_Array,
 							ElementType: schemapb.DataType_Array,
+							TypeParams:  []*commonpb.KeyValuePair{{Key: common.MaxCapacityKey, Value: "100"}},
 						},
 					},
 				},
@@ -848,6 +850,7 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 							Name:        "array_field",
 							DataType:    schemapb.DataType_Array,
 							ElementType: schemapb.DataType_None,
+							TypeParams:  []*commonpb.KeyValuePair{{Key: common.MaxCapacityKey, Value: "100"}},
 						},
 					},
 				},
@@ -878,12 +881,14 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 							ElementType: schemapb.DataType_VarChar,
 							TypeParams: []*commonpb.KeyValuePair{
 								{Key: common.MaxLengthKey, Value: "100"},
+								{Key: common.MaxCapacityKey, Value: "100"},
 							},
 						},
 						{
 							Name:        "int_array",
 							DataType:    schemapb.DataType_Array,
 							ElementType: schemapb.DataType_Int32,
+							TypeParams:  []*commonpb.KeyValuePair{{Key: common.MaxCapacityKey, Value: "100"}},
 						},
 						{
 							Name:        "vector_array",
@@ -891,6 +896,7 @@ func Test_createCollectionTask_validateSchema(t *testing.T) {
 							ElementType: schemapb.DataType_FloatVector,
 							TypeParams: []*commonpb.KeyValuePair{
 								{Key: common.DimKey, Value: "128"},
+								{Key: common.MaxCapacityKey, Value: "100"},
 							},
 						},
 					},

--- a/internal/rootcoord/util.go
+++ b/internal/rootcoord/util.go
@@ -466,6 +466,9 @@ func checkStructArrayFieldSchema(schemas []*schemapb.StructArrayFieldSchema) err
 				msg := fmt.Sprintf("fields in StructArrayField can only be array or array of vector, but field %s is %s", field.Name, field.DataType.String())
 				return merr.WrapErrParameterInvalidMsg(msg)
 			}
+			if field.GetDataType() == schemapb.DataType_ArrayOfVector && field.GetNullable() {
+				return merr.WrapErrParameterInvalidMsg("ArrayOfVector does not support nullable, structName=%s, fieldName=%s", schema.GetName(), field.GetName())
+			}
 
 			if field.IsPartitionKey || field.IsPrimaryKey {
 				msg := fmt.Sprintf("partition key or primary key can not be in struct array field. data type:%s, element type:%s, name:%s",
@@ -483,6 +486,49 @@ func checkStructArrayFieldSchema(schemas []*schemapb.StructArrayFieldSchema) err
 			if err := checkDupKvPairs(field.GetIndexParams(), "index"); err != nil {
 				return err
 			}
+		}
+		if err := checkStructArrayFieldMaxCapacity(schema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getStructSubFieldMaxCapacity(structName string, field *schemapb.FieldSchema) (int64, error) {
+	for _, param := range field.GetTypeParams() {
+		if param.GetKey() != common.MaxCapacityKey {
+			continue
+		}
+		maxCapacity, err := strconv.ParseInt(param.GetValue(), 10, 64)
+		if err != nil {
+			return 0, merr.WrapErrParameterInvalidMsg("the value for %s of field %s in struct array field %s must be an integer",
+				common.MaxCapacityKey, field.GetName(), structName)
+		}
+		if maxCapacity > defaultMaxArrayCapacity || maxCapacity <= 0 {
+			return 0, merr.WrapErrParameterInvalidMsg("the maximum capacity specified for a Array should be in (0, %d]", defaultMaxArrayCapacity)
+		}
+		return maxCapacity, nil
+	}
+	return 0, merr.WrapErrParameterInvalidMsg("type param(%s) should be specified for field %s in struct array field %s",
+		common.MaxCapacityKey, field.GetName(), structName)
+}
+
+func checkStructArrayFieldMaxCapacity(schema *schemapb.StructArrayFieldSchema) error {
+	var expectedMaxCapacity int64
+	hasExpectedMaxCapacity := false
+	for _, field := range schema.GetFields() {
+		maxCapacity, err := getStructSubFieldMaxCapacity(schema.GetName(), field)
+		if err != nil {
+			return err
+		}
+		if !hasExpectedMaxCapacity {
+			expectedMaxCapacity = maxCapacity
+			hasExpectedMaxCapacity = true
+			continue
+		}
+		if maxCapacity != expectedMaxCapacity {
+			return merr.WrapErrParameterInvalidMsg("all sub-fields in struct array field must have the same max_capacity: structName=%s, subFieldName=%s, max_capacity=%d, expected=%d",
+				schema.GetName(), field.GetName(), maxCapacity, expectedMaxCapacity)
 		}
 	}
 	return nil

--- a/internal/rootcoord/util_test.go
+++ b/internal/rootcoord/util_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
@@ -517,4 +518,123 @@ func Test_nextFieldID(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestCheckStructArrayFieldSchema_NullableValidation(t *testing.T) {
+	t.Run("nullable array sub-field passes", func(t *testing.T) {
+		schemas := []*schemapb.StructArrayFieldSchema{
+			{
+				Name: "my_struct",
+				Fields: []*schemapb.FieldSchema{
+					{
+						Name:        "sub_a",
+						DataType:    schemapb.DataType_Array,
+						ElementType: schemapb.DataType_Int32,
+						Nullable:    true,
+						TypeParams:  []*commonpb.KeyValuePair{{Key: "max_capacity", Value: "100"}},
+					},
+				},
+			},
+		}
+		err := checkStructArrayFieldSchema(schemas)
+		assert.NoError(t, err)
+	})
+
+	t.Run("nullable array of vector sub-field is rejected", func(t *testing.T) {
+		schemas := []*schemapb.StructArrayFieldSchema{
+			{
+				Name: "my_struct",
+				Fields: []*schemapb.FieldSchema{
+					{
+						Name:        "sub_vec",
+						DataType:    schemapb.DataType_ArrayOfVector,
+						ElementType: schemapb.DataType_FloatVector,
+						Nullable:    true,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.DimKey, Value: "8"},
+							{Key: common.MaxCapacityKey, Value: "100"},
+						},
+					},
+				},
+			},
+		}
+		err := checkStructArrayFieldSchema(schemas)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ArrayOfVector does not support nullable")
+	})
+
+	t.Run("non-nullable array of vector sub-field passes", func(t *testing.T) {
+		schemas := []*schemapb.StructArrayFieldSchema{
+			{
+				Name: "my_struct",
+				Fields: []*schemapb.FieldSchema{
+					{
+						Name:        "sub_vec",
+						DataType:    schemapb.DataType_ArrayOfVector,
+						ElementType: schemapb.DataType_FloatVector,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.DimKey, Value: "8"},
+							{Key: common.MaxCapacityKey, Value: "100"},
+						},
+					},
+				},
+			},
+		}
+		err := checkStructArrayFieldSchema(schemas)
+		assert.NoError(t, err)
+	})
+}
+
+func TestCheckStructArrayFieldSchema_MaxCapacityValidation(t *testing.T) {
+	t.Run("missing max_capacity is rejected", func(t *testing.T) {
+		schemas := []*schemapb.StructArrayFieldSchema{
+			{
+				Name: "my_struct",
+				Fields: []*schemapb.FieldSchema{
+					{
+						Name:        "sub_a",
+						DataType:    schemapb.DataType_Array,
+						ElementType: schemapb.DataType_Int32,
+					},
+				},
+			},
+		}
+
+		err := checkStructArrayFieldSchema(schemas)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "type param(max_capacity) should be specified")
+		assert.Contains(t, err.Error(), "my_struct")
+		assert.Contains(t, err.Error(), "sub_a")
+	})
+
+	t.Run("different max_capacity values in same struct are rejected", func(t *testing.T) {
+		schemas := []*schemapb.StructArrayFieldSchema{
+			{
+				Name: "my_struct",
+				Fields: []*schemapb.FieldSchema{
+					{
+						Name:        "sub_a",
+						DataType:    schemapb.DataType_Array,
+						ElementType: schemapb.DataType_Int32,
+						TypeParams:  []*commonpb.KeyValuePair{{Key: common.MaxCapacityKey, Value: "100"}},
+					},
+					{
+						Name:        "sub_b",
+						DataType:    schemapb.DataType_ArrayOfVector,
+						ElementType: schemapb.DataType_FloatVector,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.DimKey, Value: "128"},
+							{Key: common.MaxCapacityKey, Value: "200"},
+						},
+					},
+				},
+			},
+		}
+
+		err := checkStructArrayFieldSchema(schemas)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "same max_capacity")
+		assert.Contains(t, err.Error(), "my_struct")
+		assert.Contains(t, err.Error(), "sub_b")
+	})
 }

--- a/internal/storage/arrow_util.go
+++ b/internal/storage/arrow_util.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
@@ -25,9 +26,23 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
+
+func isNullableDenseVectorArrowType(dataType schemapb.DataType) bool {
+	switch dataType {
+	case schemapb.DataType_FloatVector,
+		schemapb.DataType_BinaryVector,
+		schemapb.DataType_Float16Vector,
+		schemapb.DataType_BFloat16Vector,
+		schemapb.DataType_Int8Vector:
+		return true
+	default:
+		return false
+	}
+}
 
 func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *schemapb.ValueField) (uint64, error) {
 	// a could never be nil here
@@ -252,7 +267,11 @@ func GenerateEmptyArrayFromSchema(schema *schemapb.FieldSchema, numRows int) (ar
 	if schema.GetDataType() == schemapb.DataType_ArrayOfVector {
 		elementType = schema.GetElementType()
 	}
-	builder := array.NewBuilder(memory.DefaultAllocator, serdeMap[schema.GetDataType()].arrowType(int(dim), elementType)) // serdeEntry[schema.GetDataType()].newBuilder()
+	arrowType := serdeMap[schema.GetDataType()].arrowType(int(dim), elementType)
+	if schema.GetNullable() && isNullableDenseVectorArrowType(schema.GetDataType()) {
+		arrowType = arrow.BinaryTypes.Binary
+	}
+	builder := array.NewBuilder(memory.DefaultAllocator, arrowType) // serdeEntry[schema.GetDataType()].newBuilder()
 	if schema.GetDefaultValue() != nil {
 		switch schema.GetDataType() {
 		case schemapb.DataType_Bool:
@@ -322,8 +341,9 @@ func GenerateEmptyArrayFromSchema(schema *schemapb.FieldSchema, numRows int) (ar
 // small batch size will cause write performance degradation. To work around this issue, we accumulate
 // records and write them in batches. This requires additional memory copy.
 type RecordBuilder struct {
-	fields   []*schemapb.FieldSchema
-	builders []array.Builder
+	fields      []*schemapb.FieldSchema
+	arrowFields []arrow.Field
+	builders    []array.Builder
 
 	nRows int
 	size  uint64
@@ -361,11 +381,8 @@ func (b *RecordBuilder) Build() Record {
 		arrays[c] = builder.NewArray()
 		f := b.fields[c]
 		fid := f.FieldID
-		fields[c] = arrow.Field{
-			Name:     f.GetName(),
-			Type:     arrays[c].DataType(),
-			Nullable: f.Nullable,
-		}
+		fields[c] = b.arrowFields[c]
+		fields[c].Type = arrays[c].DataType()
 		field2Col[fid] = c
 	}
 
@@ -384,6 +401,7 @@ func NewRecordBuilder(schema *schemapb.CollectionSchema) *RecordBuilder {
 	}
 
 	builders := make([]array.Builder, len(fields))
+	arrowFields := make([]arrow.Field, len(fields))
 	for i, field := range fields {
 		dim, _ := typeutil.GetDim(field)
 
@@ -391,16 +409,44 @@ func NewRecordBuilder(schema *schemapb.CollectionSchema) *RecordBuilder {
 		if field.DataType == schemapb.DataType_ArrayOfVector {
 			elementType = field.GetElementType()
 		}
-		if field.GetNullable() && typeutil.IsVectorType(field.DataType) && !typeutil.IsSparseFloatVectorType(field.DataType) {
+		if field.GetNullable() && isNullableDenseVectorArrowType(field.DataType) {
+			builders[i] = array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+		} else if field.DataType == schemapb.DataType_Text {
+			// TEXT fields are stored as binary (LOB references) in manifest storage,
+			// so the builder must use binary type to match what the reader returns.
 			builders[i] = array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
 		} else {
 			arrowType := serdeMap[field.DataType].arrowType(int(dim), elementType)
 			builders[i] = array.NewBuilder(memory.DefaultAllocator, arrowType)
 		}
+		arrowFields[i] = newRecordBuilderArrowField(field, builders[i].Type(), dim, elementType)
 	}
 
 	return &RecordBuilder{
-		fields:   fields,
-		builders: builders,
+		fields:      fields,
+		arrowFields: arrowFields,
+		builders:    builders,
+	}
+}
+
+func newRecordBuilderArrowField(field *schemapb.FieldSchema, arrowType arrow.DataType, dim int64, elementType schemapb.DataType) arrow.Field {
+	keys := []string{packed.ArrowFieldIdMetadataKey}
+	values := []string{strconv.Itoa(int(field.GetFieldID()))}
+
+	if field.GetNullable() && isNullableDenseVectorArrowType(field.GetDataType()) {
+		keys = append(keys, "dim")
+		values = append(values, strconv.Itoa(int(dim)))
+	}
+
+	if field.GetDataType() == schemapb.DataType_ArrayOfVector {
+		keys = append(keys, "elementType", "dim")
+		values = append(values, strconv.Itoa(int(elementType)), strconv.Itoa(int(dim)))
+	}
+
+	return arrow.Field{
+		Name:     field.GetName(),
+		Type:     arrowType,
+		Nullable: field.GetNullable(),
+		Metadata: arrow.NewMetadata(keys, values),
 	}
 }

--- a/internal/storage/arrow_util_test.go
+++ b/internal/storage/arrow_util_test.go
@@ -20,8 +20,10 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 )
 
@@ -230,4 +232,51 @@ func TestGenerateEmptyArray(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateEmptyArrayFromSchemaNullableDenseVectorUsesBinaryArrow(t *testing.T) {
+	field := &schemapb.FieldSchema{
+		FieldID:  100,
+		Name:     "nullable_float_vector",
+		DataType: schemapb.DataType_FloatVector,
+		Nullable: true,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: "dim", Value: "4"},
+		},
+	}
+
+	arr, err := GenerateEmptyArrayFromSchema(field, 3)
+
+	assert.NoError(t, err)
+	assert.Equal(t, arrow.BinaryTypes.Binary, arr.DataType())
+	assert.Equal(t, 3, arr.Len())
+	for i := 0; i < arr.Len(); i++ {
+		assert.True(t, arr.IsNull(i))
+	}
+}
+
+func TestRecordBuilderNullableDenseVectorPreservesDimMetadata(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  100,
+				Name:     "nullable_float_vector",
+				DataType: schemapb.DataType_FloatVector,
+				Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "4"},
+				},
+			},
+		},
+	}
+
+	rb := NewRecordBuilder(schema)
+	rec := rb.Build()
+	defer rec.Release()
+
+	field := rec.(*simpleArrowRecord).ArrowSchema().Field(0)
+	assert.Equal(t, arrow.BinaryTypes.Binary, field.Type)
+	dim, ok := field.Metadata.GetValue("dim")
+	assert.True(t, ok)
+	assert.Equal(t, "4", dim)
 }

--- a/internal/storage/data_sorter.go
+++ b/internal/storage/data_sorter.go
@@ -24,9 +24,10 @@ import (
 
 // DataSorter sorts insert data
 type DataSorter struct {
-	InsertCodec *InsertCodec
-	InsertData  *InsertData
-	AllFields   []*schemapb.FieldSchema
+	InsertCodec             *InsertCodec
+	InsertData              *InsertData
+	AllFields               []*schemapb.FieldSchema
+	nullableVectorDataRanks map[int64]*nullableVectorRanks
 }
 
 // getRowIDFieldData returns auto generated row id Field
@@ -50,6 +51,152 @@ func (ds *DataSorter) Len() int {
 	return len(fieldData.Data)
 }
 
+func swapValidData(validData []bool, i, j int) {
+	if len(validData) == 0 {
+		return
+	}
+	validData[i], validData[j] = validData[j], validData[i]
+}
+
+func swapFixedRows[T any](data []T, i, j, rowWidth int) {
+	if i == j || rowWidth == 0 {
+		return
+	}
+	for idx := 0; idx < rowWidth; idx++ {
+		data[i*rowWidth+idx], data[j*rowWidth+idx] = data[j*rowWidth+idx], data[i*rowWidth+idx]
+	}
+}
+
+func moveFixedRow[T any](data []T, from, to, rowWidth int) {
+	if from == to || rowWidth == 0 {
+		return
+	}
+	row := make([]T, rowWidth)
+	copy(row, data[from*rowWidth:(from+1)*rowWidth])
+	if from < to {
+		copy(data[from*rowWidth:to*rowWidth], data[(from+1)*rowWidth:(to+1)*rowWidth])
+	} else {
+		copy(data[(to+1)*rowWidth:(from+1)*rowWidth], data[to*rowWidth:from*rowWidth])
+	}
+	copy(data[to*rowWidth:(to+1)*rowWidth], row)
+}
+
+type nullableVectorRanks struct {
+	tree []int
+}
+
+func newNullableVectorRanks(validData []bool) *nullableVectorRanks {
+	ranks := &nullableVectorRanks{tree: make([]int, len(validData)+1)}
+	for i, valid := range validData {
+		if valid {
+			ranks.add(i, 1)
+		}
+	}
+	return ranks
+}
+
+func (r *nullableVectorRanks) add(logicalIdx, delta int) {
+	for idx := logicalIdx + 1; idx < len(r.tree); idx += idx & -idx {
+		r.tree[idx] += delta
+	}
+}
+
+func (r *nullableVectorRanks) rankBefore(logicalIdx int) int {
+	sum := 0
+	for idx := logicalIdx; idx > 0; idx -= idx & -idx {
+		sum += r.tree[idx]
+	}
+	return sum
+}
+
+func (r *nullableVectorRanks) rankOfValid(logicalIdx int) int {
+	return r.rankBefore(logicalIdx+1) - 1
+}
+
+func invalidateNullableVectorMapping(mapping *LogicalToPhysicalMapping) {
+	if mapping == nil {
+		return
+	}
+	mapping.validCount = 0
+	mapping.l2pMap = nil
+}
+
+func (ds *DataSorter) getNullableVectorDataRanks(fieldID int64, validData []bool) *nullableVectorRanks {
+	if ds.nullableVectorDataRanks == nil {
+		ds.nullableVectorDataRanks = make(map[int64]*nullableVectorRanks)
+	}
+	if ranks, ok := ds.nullableVectorDataRanks[fieldID]; ok && len(ranks.tree) == len(validData)+1 {
+		return ranks
+	}
+	ranks := newNullableVectorRanks(validData)
+	ds.nullableVectorDataRanks[fieldID] = ranks
+	return ranks
+}
+
+func moveNullableVectorPhysicalIndex(validData []bool, from, to int, ranks *nullableVectorRanks) (int, int) {
+	srcPhysical := ranks.rankOfValid(from)
+	ranks.add(from, -1)
+	ranks.add(to, 1)
+	dstPhysical := ranks.rankBefore(to)
+	validData[from] = false
+	validData[to] = true
+	return srcPhysical, dstPhysical
+}
+
+func swapCompactNullableFixedRows[T any](data []T, validData []bool, i, j, rowWidth int, mapping *LogicalToPhysicalMapping, ranks *nullableVectorRanks) {
+	if i == j {
+		return
+	}
+	invalidateNullableVectorMapping(mapping)
+
+	validI, validJ := validData[i], validData[j]
+	switch {
+	case validI && validJ:
+		swapFixedRows(data, ranks.rankOfValid(i), ranks.rankOfValid(j), rowWidth)
+	case validI != validJ:
+		fromLogical, toLogical := i, j
+		if !validI {
+			fromLogical, toLogical = j, i
+		}
+		srcPhysical, dstPhysical := moveNullableVectorPhysicalIndex(validData, fromLogical, toLogical, ranks)
+		moveFixedRow(data, srcPhysical, dstPhysical, rowWidth)
+	}
+}
+
+func moveSparseRow(contents [][]byte, from, to int) {
+	if from == to {
+		return
+	}
+	row := contents[from]
+	if from < to {
+		copy(contents[from:to], contents[from+1:to+1])
+	} else {
+		copy(contents[to+1:from+1], contents[to:from])
+	}
+	contents[to] = row
+}
+
+func swapCompactNullableSparseRows(contents [][]byte, validData []bool, i, j int, mapping *LogicalToPhysicalMapping, ranks *nullableVectorRanks) {
+	if i == j {
+		return
+	}
+	invalidateNullableVectorMapping(mapping)
+
+	validI, validJ := validData[i], validData[j]
+	switch {
+	case validI && validJ:
+		physicalI, physicalJ := ranks.rankOfValid(i), ranks.rankOfValid(j)
+		contents[physicalI], contents[physicalJ] = contents[physicalJ], contents[physicalI]
+	case validI != validJ:
+		fromLogical, toLogical := i, j
+		if !validI {
+			fromLogical, toLogical = j, i
+		}
+		srcPhysical, dstPhysical := moveNullableVectorPhysicalIndex(validData, fromLogical, toLogical, ranks)
+		moveSparseRow(contents, srcPhysical, dstPhysical)
+	}
+}
+
 // Swap swaps each field's i-th and j-th element
 func (ds *DataSorter) Swap(i, j int) {
 	if ds.AllFields == nil {
@@ -62,72 +209,127 @@ func (ds *DataSorter) Swap(i, j int) {
 		}
 		switch field.DataType {
 		case schemapb.DataType_Bool:
-			data := singleData.(*BoolFieldData).Data
+			fd := singleData.(*BoolFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Int8:
-			data := singleData.(*Int8FieldData).Data
+			fd := singleData.(*Int8FieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Int16:
-			data := singleData.(*Int16FieldData).Data
+			fd := singleData.(*Int16FieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Int32:
-			data := singleData.(*Int32FieldData).Data
+			fd := singleData.(*Int32FieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Int64:
-			data := singleData.(*Int64FieldData).Data
+			fd := singleData.(*Int64FieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Float:
-			data := singleData.(*FloatFieldData).Data
+			fd := singleData.(*FloatFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Double:
-			data := singleData.(*DoubleFieldData).Data
+			fd := singleData.(*DoubleFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Timestamptz:
-			data := singleData.(*TimestamptzFieldData).Data
+			fd := singleData.(*TimestamptzFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_String, schemapb.DataType_VarChar:
-			data := singleData.(*StringFieldData).Data
+			fd := singleData.(*StringFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_BinaryVector:
-			data := singleData.(*BinaryVectorFieldData).Data
-			dim := singleData.(*BinaryVectorFieldData).Dim
+			fd := singleData.(*BinaryVectorFieldData)
+			data := fd.Data
+			dim := fd.Dim
 			// dim for binary vector must be multiplier of 8, simple verion for swapping:
 			steps := dim / 8
-			for idx := 0; idx < steps; idx++ {
-				data[i*steps+idx], data[j*steps+idx] = data[j*steps+idx], data[i*steps+idx]
+			if len(fd.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fd.ValidData)
+				swapCompactNullableFixedRows(data, fd.ValidData, i, j, steps, &fd.L2PMapping, ranks)
+			} else {
+				swapFixedRows(data, i, j, steps)
 			}
 		case schemapb.DataType_FloatVector:
-			data := singleData.(*FloatVectorFieldData).Data
-			dim := singleData.(*FloatVectorFieldData).Dim
-			for idx := 0; idx < dim; idx++ {
-				data[i*dim+idx], data[j*dim+idx] = data[j*dim+idx], data[i*dim+idx]
+			fd := singleData.(*FloatVectorFieldData)
+			data := fd.Data
+			dim := fd.Dim
+			if len(fd.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fd.ValidData)
+				swapCompactNullableFixedRows(data, fd.ValidData, i, j, dim, &fd.L2PMapping, ranks)
+			} else {
+				swapFixedRows(data, i, j, dim)
 			}
 		case schemapb.DataType_Float16Vector:
-			data := singleData.(*Float16VectorFieldData).Data
-			dim := singleData.(*Float16VectorFieldData).Dim
+			fd := singleData.(*Float16VectorFieldData)
+			data := fd.Data
+			dim := fd.Dim
 			steps := dim * 2
-			for idx := 0; idx < steps; idx++ {
-				data[i*steps+idx], data[j*steps+idx] = data[j*steps+idx], data[i*steps+idx]
+			if len(fd.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fd.ValidData)
+				swapCompactNullableFixedRows(data, fd.ValidData, i, j, steps, &fd.L2PMapping, ranks)
+			} else {
+				swapFixedRows(data, i, j, steps)
 			}
 		case schemapb.DataType_BFloat16Vector:
-			data := singleData.(*BFloat16VectorFieldData).Data
-			dim := singleData.(*BFloat16VectorFieldData).Dim
+			fd := singleData.(*BFloat16VectorFieldData)
+			data := fd.Data
+			dim := fd.Dim
 			steps := dim * 2
-			for idx := 0; idx < steps; idx++ {
-				data[i*steps+idx], data[j*steps+idx] = data[j*steps+idx], data[i*steps+idx]
+			if len(fd.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fd.ValidData)
+				swapCompactNullableFixedRows(data, fd.ValidData, i, j, steps, &fd.L2PMapping, ranks)
+			} else {
+				swapFixedRows(data, i, j, steps)
 			}
 		case schemapb.DataType_Array:
-			data := singleData.(*ArrayFieldData).Data
+			fd := singleData.(*ArrayFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_JSON:
-			data := singleData.(*JSONFieldData).Data
+			fd := singleData.(*JSONFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Geometry:
-			data := singleData.(*GeometryFieldData).Data
+			fd := singleData.(*GeometryFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_SparseFloatVector:
 			fieldData := singleData.(*SparseFloatVectorFieldData)
-			fieldData.Contents[i], fieldData.Contents[j] = fieldData.Contents[j], fieldData.Contents[i]
+			if len(fieldData.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fieldData.ValidData)
+				swapCompactNullableSparseRows(fieldData.Contents, fieldData.ValidData, i, j, &fieldData.L2PMapping, ranks)
+			} else {
+				fieldData.Contents[i], fieldData.Contents[j] = fieldData.Contents[j], fieldData.Contents[i]
+			}
+		case schemapb.DataType_Int8Vector:
+			fd := singleData.(*Int8VectorFieldData)
+			data := fd.Data
+			dim := fd.Dim
+			if len(fd.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fd.ValidData)
+				swapCompactNullableFixedRows(data, fd.ValidData, i, j, dim, &fd.L2PMapping, ranks)
+			} else {
+				swapFixedRows(data, i, j, dim)
+			}
 		case schemapb.DataType_ArrayOfVector:
 			fieldData := singleData.(*VectorArrayFieldData)
 			fieldData.Data[i], fieldData.Data[j] = fieldData.Data[j], fieldData.Data[i]

--- a/internal/storage/data_sorter_test.go
+++ b/internal/storage/data_sorter_test.go
@@ -326,6 +326,254 @@ func TestDataSorter(t *testing.T) {
 		dataSorter.InsertData.Data[114].(*VectorArrayFieldData).Data[2].Data.(*schemapb.VectorField_FloatVector).FloatVector.Data)
 }
 
+func TestDataSorterNullableCompactVectors(t *testing.T) {
+	schema := &etcdpb.CollectionMeta{
+		ID:         1,
+		CreateTime: 1,
+		Schema: &schemapb.CollectionSchema{
+			Name:   "schema",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 0, Name: "row_id", DataType: schemapb.DataType_Int64},
+				{FieldID: 200, Name: "nullable_int64", DataType: schemapb.DataType_Int64, Nullable: true},
+				{FieldID: 201, Name: "binary_vector", DataType: schemapb.DataType_BinaryVector, Nullable: true},
+				{FieldID: 202, Name: "float_vector", DataType: schemapb.DataType_FloatVector, Nullable: true},
+				{FieldID: 203, Name: "float16_vector", DataType: schemapb.DataType_Float16Vector, Nullable: true},
+				{FieldID: 204, Name: "bfloat16_vector", DataType: schemapb.DataType_BFloat16Vector, Nullable: true},
+				{FieldID: 205, Name: "sparse_vector", DataType: schemapb.DataType_SparseFloatVector, Nullable: true},
+				{FieldID: 206, Name: "int8_vector", DataType: schemapb.DataType_Int8Vector, Nullable: true},
+			},
+		},
+	}
+
+	binaryVector := &BinaryVectorFieldData{Dim: 8, Nullable: true}
+	assert.NoError(t, binaryVector.AppendRow([]byte{0x11}))
+	assert.NoError(t, binaryVector.AppendRow(nil))
+	assert.NoError(t, binaryVector.AppendRow([]byte{0x33}))
+
+	floatVector := &FloatVectorFieldData{Dim: 2, Nullable: true}
+	assert.NoError(t, floatVector.AppendRow([]float32{1, 2}))
+	assert.NoError(t, floatVector.AppendRow(nil))
+	assert.NoError(t, floatVector.AppendRow([]float32{5, 6}))
+
+	float16Vector := &Float16VectorFieldData{Dim: 2, Nullable: true}
+	assert.NoError(t, float16Vector.AppendRow([]byte{1, 2, 3, 4}))
+	assert.NoError(t, float16Vector.AppendRow(nil))
+	assert.NoError(t, float16Vector.AppendRow([]byte{5, 6, 7, 8}))
+
+	bfloat16Vector := &BFloat16VectorFieldData{Dim: 2, Nullable: true}
+	assert.NoError(t, bfloat16Vector.AppendRow([]byte{11, 12, 13, 14}))
+	assert.NoError(t, bfloat16Vector.AppendRow(nil))
+	assert.NoError(t, bfloat16Vector.AppendRow([]byte{15, 16, 17, 18}))
+
+	sparseRow0 := typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1})
+	sparseRow2 := typeutil.CreateSparseFloatRow([]uint32{3}, []float32{3})
+	sparseVector := &SparseFloatVectorFieldData{SparseFloatArray: schemapb.SparseFloatArray{Dim: 8}, Nullable: true}
+	assert.NoError(t, sparseVector.AppendRow(sparseRow0))
+	assert.NoError(t, sparseVector.AppendRow(nil))
+	assert.NoError(t, sparseVector.AppendRow(sparseRow2))
+
+	int8Vector := &Int8VectorFieldData{Dim: 2, Nullable: true}
+	assert.NoError(t, int8Vector.AppendRow([]int8{21, 22}))
+	assert.NoError(t, int8Vector.AppendRow(nil))
+	assert.NoError(t, int8Vector.AppendRow([]int8{25, 26}))
+
+	insertData := &InsertData{
+		Data: map[int64]FieldData{
+			0:   &Int64FieldData{Data: []int64{20, 10, 30}},
+			200: &Int64FieldData{Data: []int64{200, 0, 300}, ValidData: []bool{true, false, true}, Nullable: true},
+			201: binaryVector,
+			202: floatVector,
+			203: float16Vector,
+			204: bfloat16Vector,
+			205: sparseVector,
+			206: int8Vector,
+		},
+	}
+
+	dataSorter := &DataSorter{
+		InsertCodec: NewInsertCodecWithSchema(schema),
+		InsertData:  insertData,
+	}
+
+	sort.Sort(dataSorter)
+
+	assert.Equal(t, []int64{10, 20, 30}, insertData.Data[0].(*Int64FieldData).Data)
+
+	int64Field := insertData.Data[200].(*Int64FieldData)
+	assert.Equal(t, []bool{false, true, true}, int64Field.ValidData)
+	assert.Equal(t, []int64{0, 200, 300}, int64Field.Data)
+	assert.Nil(t, int64Field.GetRow(0))
+	assert.Equal(t, int64(200), int64Field.GetRow(1))
+
+	assert.Equal(t, []bool{false, true, true}, binaryVector.ValidData)
+	assert.Equal(t, []byte{0x11, 0x33}, binaryVector.Data)
+	assert.Nil(t, binaryVector.GetRow(0))
+	assert.Equal(t, []byte{0x11}, binaryVector.GetRow(1))
+	assert.Equal(t, []byte{0x33}, binaryVector.GetRow(2))
+
+	assert.Equal(t, []bool{false, true, true}, floatVector.ValidData)
+	assert.Equal(t, []float32{1, 2, 5, 6}, floatVector.Data)
+	assert.Nil(t, floatVector.GetRow(0))
+	assert.Equal(t, []float32{1, 2}, floatVector.GetRow(1))
+	assert.Equal(t, []float32{5, 6}, floatVector.GetRow(2))
+
+	assert.Equal(t, []bool{false, true, true}, float16Vector.ValidData)
+	assert.Equal(t, []byte{1, 2, 3, 4, 5, 6, 7, 8}, float16Vector.Data)
+	assert.Nil(t, float16Vector.GetRow(0))
+	assert.Equal(t, []byte{1, 2, 3, 4}, float16Vector.GetRow(1))
+	assert.Equal(t, []byte{5, 6, 7, 8}, float16Vector.GetRow(2))
+
+	assert.Equal(t, []bool{false, true, true}, bfloat16Vector.ValidData)
+	assert.Equal(t, []byte{11, 12, 13, 14, 15, 16, 17, 18}, bfloat16Vector.Data)
+	assert.Nil(t, bfloat16Vector.GetRow(0))
+	assert.Equal(t, []byte{11, 12, 13, 14}, bfloat16Vector.GetRow(1))
+	assert.Equal(t, []byte{15, 16, 17, 18}, bfloat16Vector.GetRow(2))
+
+	assert.Equal(t, []bool{false, true, true}, sparseVector.ValidData)
+	assert.Equal(t, [][]byte{sparseRow0, sparseRow2}, sparseVector.Contents)
+	assert.Nil(t, sparseVector.GetRow(0))
+	assert.Equal(t, sparseRow0, sparseVector.GetRow(1))
+	assert.Equal(t, sparseRow2, sparseVector.GetRow(2))
+
+	assert.Equal(t, []bool{false, true, true}, int8Vector.ValidData)
+	assert.Equal(t, []int8{21, 22, 25, 26}, int8Vector.Data)
+	assert.Nil(t, int8Vector.GetRow(0))
+	assert.Equal(t, []int8{21, 22}, int8Vector.GetRow(1))
+	assert.Equal(t, []int8{25, 26}, int8Vector.GetRow(2))
+}
+
+func TestDataSorterNullableCompactVectorsInterleavedRows(t *testing.T) {
+	schema := &etcdpb.CollectionMeta{
+		ID:         1,
+		CreateTime: 1,
+		Schema: &schemapb.CollectionSchema{
+			Name:   "schema",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 0, Name: "row_id", DataType: schemapb.DataType_Int64},
+				{FieldID: 201, Name: "float_vector", DataType: schemapb.DataType_FloatVector, Nullable: true},
+				{FieldID: 202, Name: "sparse_vector", DataType: schemapb.DataType_SparseFloatVector, Nullable: true},
+			},
+		},
+	}
+
+	floatVector := &FloatVectorFieldData{Dim: 1, Nullable: true}
+	sparseVector := &SparseFloatVectorFieldData{SparseFloatArray: schemapb.SparseFloatArray{Dim: 8}, Nullable: true}
+	rows := []struct {
+		rowID int64
+		valid bool
+		value float32
+	}{
+		{40, true, 40},
+		{10, false, 0},
+		{30, true, 30},
+		{20, false, 0},
+		{50, true, 50},
+	}
+	for _, row := range rows {
+		if row.valid {
+			assert.NoError(t, floatVector.AppendRow([]float32{row.value}))
+			assert.NoError(t, sparseVector.AppendRow(typeutil.CreateSparseFloatRow([]uint32{uint32(row.value)}, []float32{row.value})))
+		} else {
+			assert.NoError(t, floatVector.AppendRow(nil))
+			assert.NoError(t, sparseVector.AppendRow(nil))
+		}
+	}
+
+	insertData := &InsertData{
+		Data: map[int64]FieldData{
+			0:   &Int64FieldData{Data: []int64{40, 10, 30, 20, 50}},
+			201: floatVector,
+			202: sparseVector,
+		},
+	}
+	sort.Sort(&DataSorter{
+		InsertCodec: NewInsertCodecWithSchema(schema),
+		InsertData:  insertData,
+	})
+
+	assert.Equal(t, []int64{10, 20, 30, 40, 50}, insertData.Data[0].(*Int64FieldData).Data)
+	assert.Equal(t, []bool{false, false, true, true, true}, floatVector.ValidData)
+	assert.Equal(t, []float32{30, 40, 50}, floatVector.Data)
+	assert.Nil(t, floatVector.GetRow(0))
+	assert.Nil(t, floatVector.GetRow(1))
+	assert.Equal(t, []float32{30}, floatVector.GetRow(2))
+	assert.Equal(t, []float32{40}, floatVector.GetRow(3))
+	assert.Equal(t, []float32{50}, floatVector.GetRow(4))
+
+	assert.Equal(t, []bool{false, false, true, true, true}, sparseVector.ValidData)
+	assert.Len(t, sparseVector.Contents, 3)
+	assert.Nil(t, sparseVector.GetRow(0))
+	assert.Nil(t, sparseVector.GetRow(1))
+	assert.Equal(t, typeutil.CreateSparseFloatRow([]uint32{30}, []float32{30}), sparseVector.GetRow(2))
+	assert.Equal(t, typeutil.CreateSparseFloatRow([]uint32{40}, []float32{40}), sparseVector.GetRow(3))
+	assert.Equal(t, typeutil.CreateSparseFloatRow([]uint32{50}, []float32{50}), sparseVector.GetRow(4))
+}
+
+func BenchmarkDataSorterNullableCompactVectorSort(b *testing.B) {
+	const (
+		rowCount = 4096
+		dim      = 8
+	)
+	schema := &etcdpb.CollectionMeta{
+		ID:         1,
+		CreateTime: 1,
+		Schema: &schemapb.CollectionSchema{
+			Name:   "schema",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 0, Name: "row_id", DataType: schemapb.DataType_Int64},
+				{FieldID: 201, Name: "float_vector", DataType: schemapb.DataType_FloatVector, Nullable: true},
+			},
+		},
+	}
+
+	makeInsertData := func() *InsertData {
+		rowIDs := make([]int64, rowCount)
+		vector := &FloatVectorFieldData{Dim: dim, Nullable: true}
+		for i := 0; i < rowCount; i++ {
+			rowIDs[i] = int64(rowCount - i)
+			if i%3 == 0 {
+				assert.NoError(b, vector.AppendRow(nil))
+				continue
+			}
+			row := make([]float32, dim)
+			for j := range row {
+				row[j] = float32(i*dim + j)
+			}
+			assert.NoError(b, vector.AppendRow(row))
+		}
+		return &InsertData{
+			Data: map[int64]FieldData{
+				0:   &Int64FieldData{Data: rowIDs},
+				201: vector,
+			},
+		}
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		insertData := makeInsertData()
+		dataSorter := &DataSorter{
+			InsertCodec: NewInsertCodecWithSchema(schema),
+			InsertData:  insertData,
+		}
+		b.StartTimer()
+		sort.Sort(dataSorter)
+		b.StopTimer()
+		if got := insertData.Data[0].(*Int64FieldData).Data[0]; got != 1 {
+			b.Fatalf("first row id = %d, want 1", got)
+		}
+		if got := insertData.Data[0].(*Int64FieldData).Data[rowCount-1]; got != rowCount {
+			b.Fatalf("last row id = %d, want %d", got, rowCount)
+		}
+		if got := insertData.Data[201].(*FloatVectorFieldData).RowNum(); got != rowCount {
+			b.Fatalf("vector row count = %d, want %d", got, rowCount)
+		}
+	}
+}
+
 func TestDataSorter_Len(t *testing.T) {
 	insertData := &InsertData{
 		Data: map[int64]FieldData{

--- a/internal/storage/insert_data.go
+++ b/internal/storage/insert_data.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -515,6 +516,19 @@ func (m *LogicalToPhysicalMapping) Build(validData []bool, startLogical, totalCo
 	m.validCount = physicalIdx
 }
 
+func getNullableVectorPhysicalOffset(validData []bool, mapping *LogicalToPhysicalMapping, logicalOffset int) int {
+	if mapping != nil && mapping.l2pMap != nil {
+		return mapping.GetPhysicalOffset(logicalOffset)
+	}
+	physicalOffset := 0
+	for i := 0; i < logicalOffset; i++ {
+		if validData[i] {
+			physicalOffset++
+		}
+	}
+	return physicalOffset
+}
+
 type BinaryVectorFieldData struct {
 	Data       []byte
 	ValidData  []bool
@@ -566,9 +580,6 @@ type VectorArrayFieldData struct {
 }
 
 func (dst *SparseFloatVectorFieldData) AppendAllRows(src *SparseFloatVectorFieldData) {
-	if len(src.Contents) == 0 {
-		return
-	}
 	if dst.Dim < src.Dim {
 		dst.Dim = src.Dim
 	}
@@ -731,7 +742,10 @@ func (data *BinaryVectorFieldData) GetRow(i int) any {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Data[physicalIdx*data.Dim/8 : (physicalIdx+1)*data.Dim/8]
 }
 
@@ -739,7 +753,10 @@ func (data *SparseFloatVectorFieldData) GetRow(i int) interface{} {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Contents[physicalIdx]
 }
 
@@ -747,7 +764,10 @@ func (data *FloatVectorFieldData) GetRow(i int) interface{} {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Data[physicalIdx*data.Dim : (physicalIdx+1)*data.Dim]
 }
 
@@ -755,7 +775,10 @@ func (data *Float16VectorFieldData) GetRow(i int) interface{} {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Data[physicalIdx*data.Dim*2 : (physicalIdx+1)*data.Dim*2]
 }
 
@@ -763,7 +786,10 @@ func (data *BFloat16VectorFieldData) GetRow(i int) interface{} {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Data[physicalIdx*data.Dim*2 : (physicalIdx+1)*data.Dim*2]
 }
 
@@ -771,7 +797,10 @@ func (data *Int8VectorFieldData) GetRow(i int) interface{} {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Data[physicalIdx*data.Dim : (physicalIdx+1)*data.Dim]
 }
 
@@ -1227,55 +1256,128 @@ func (data *GeometryFieldData) AppendRows(dataRows interface{}, validDataRows in
 	return data.AppendValidDataRows(validDataRows)
 }
 
+func validateNullableVectorCompactRows(nullable bool, validDataRows interface{}, physicalRows int) error {
+	if !nullable {
+		return nil
+	}
+	validData, ok := validDataRows.([]bool)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]bool", validDataRows, "nullable vector requires valid data")
+	}
+	if err := funcutil.ValidateNullableVectorCompactRows("vector", validData, uint64(physicalRows), 0, true); err != nil {
+		return merr.WrapErrParameterInvalidMsg(err.Error())
+	}
+	return nil
+}
+
+func validateNullableVectorTotalRows(nullable bool, existingValidData []bool, newValidData []bool, physicalRows int) error {
+	if !nullable {
+		return nil
+	}
+	validCount := funcutil.CountValidRows(existingValidData) + funcutil.CountValidRows(newValidData)
+	if uint64(physicalRows) != validCount {
+		return merr.WrapErrParameterInvalidMsg(
+			"nullable vector compact data row count mismatch: physical rows=%d, valid rows=%d",
+			physicalRows,
+			validCount)
+	}
+	return nil
+}
+
 // AppendDataRows appends FLATTEN vectors to field data.
 func (data *BinaryVectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.([]byte)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]byte", dataRows, "Wrong rows type")
+	}
+	rowWidth := data.Dim / 8
+	if len(v)%rowWidth != 0 {
+		return merr.WrapErrParameterInvalid(rowWidth, len(v), "Wrong vector size")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v)/rowWidth); err != nil {
 		return err
 	}
+	data.Data = append(data.Data, v...)
 	return data.AppendValidDataRows(validDataRows)
 }
 
 // AppendDataRows appends FLATTEN vectors to field data.
 func (data *FloatVectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.([]float32)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]float32", dataRows, "Wrong rows type")
+	}
+	if len(v)%(data.Dim) != 0 {
+		return merr.WrapErrParameterInvalid(data.Dim, len(v), "Wrong vector size")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v)/data.Dim); err != nil {
 		return err
 	}
+	data.Data = append(data.Data, v...)
 	return data.AppendValidDataRows(validDataRows)
 }
 
 // AppendDataRows appends FLATTEN vectors to field data.
 func (data *Float16VectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.([]byte)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]byte", dataRows, "Wrong rows type")
+	}
+	rowWidth := data.Dim * 2
+	if len(v)%rowWidth != 0 {
+		return merr.WrapErrParameterInvalid(rowWidth, len(v), "Wrong vector size")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v)/rowWidth); err != nil {
 		return err
 	}
+	data.Data = append(data.Data, v...)
 	return data.AppendValidDataRows(validDataRows)
 }
 
 // AppendDataRows appends FLATTEN vectors to field data.
 func (data *BFloat16VectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.([]byte)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]byte", dataRows, "Wrong rows type")
+	}
+	rowWidth := data.Dim * 2
+	if len(v)%rowWidth != 0 {
+		return merr.WrapErrParameterInvalid(rowWidth, len(v), "Wrong vector size")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v)/rowWidth); err != nil {
 		return err
 	}
+	data.Data = append(data.Data, v...)
 	return data.AppendValidDataRows(validDataRows)
 }
 
 func (data *SparseFloatVectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.(*SparseFloatVectorFieldData)
+	if !ok {
+		return merr.WrapErrParameterInvalid("SparseFloatVectorFieldData", dataRows, "Wrong rows type")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v.Contents)); err != nil {
 		return err
+	}
+	data.Contents = append(data.Contents, v.Contents...)
+	if data.Dim < v.Dim {
+		data.Dim = v.Dim
 	}
 	return data.AppendValidDataRows(validDataRows)
 }
 
 func (data *Int8VectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.([]int8)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]int8", dataRows, "Wrong rows type")
+	}
+	if len(v)%(data.Dim) != 0 {
+		return merr.WrapErrParameterInvalid(data.Dim, len(v), "Wrong vector size")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v)/data.Dim); err != nil {
 		return err
 	}
+	data.Data = append(data.Data, v...)
 	return data.AppendValidDataRows(validDataRows)
 }
 
@@ -1638,6 +1740,9 @@ func (data *BinaryVectorFieldData) AppendValidDataRows(rows interface{}) error {
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
 	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Data)/(data.Dim/8)); err != nil {
+		return err
+	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)
 	return nil
@@ -1665,6 +1770,9 @@ func (data *FloatVectorFieldData) AppendValidDataRows(rows interface{}) error {
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
 	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Data)/data.Dim); err != nil {
+		return err
+	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)
 	return nil
@@ -1678,6 +1786,9 @@ func (data *Float16VectorFieldData) AppendValidDataRows(rows interface{}) error 
 	v, ok := rows.([]bool)
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
+	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Data)/(data.Dim*2)); err != nil {
+		return err
 	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)
@@ -1693,6 +1804,9 @@ func (data *BFloat16VectorFieldData) AppendValidDataRows(rows interface{}) error
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
 	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Data)/(data.Dim*2)); err != nil {
+		return err
+	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)
 	return nil
@@ -1706,6 +1820,9 @@ func (data *SparseFloatVectorFieldData) AppendValidDataRows(rows interface{}) er
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
 	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Contents)); err != nil {
+		return err
+	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)
 	return nil
@@ -1718,6 +1835,9 @@ func (data *Int8VectorFieldData) AppendValidDataRows(rows interface{}) error {
 	v, ok := rows.([]bool)
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
+	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Data)/data.Dim); err != nil {
+		return err
 	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)

--- a/internal/storage/insert_data_test.go
+++ b/internal/storage/insert_data_test.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -475,4 +477,84 @@ func (s *ArrayFieldDataSuite) TestArrayFieldData() {
 	s.Equal(126, insertData.GetMemorySize())
 	s.False(insertData.IsEmpty())
 	s.Equal(115, insertData.GetRowSize(0))
+}
+
+func TestNullableVectorAppendRowsRejectsNonCompactData(t *testing.T) {
+	validData := []bool{true, false, true}
+	sparseRows := &SparseFloatVectorFieldData{
+		SparseFloatArray: schemapb.SparseFloatArray{
+			Dim: 8,
+			Contents: [][]byte{
+				typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1.0}),
+				typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2.0}),
+				typeutil.CreateSparseFloatRow([]uint32{3}, []float32{3.0}),
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		fieldData FieldData
+		rows      any
+	}{
+		{
+			name:      "binary vector",
+			fieldData: &BinaryVectorFieldData{Dim: 8, Nullable: true},
+			rows:      []byte{0x01, 0x02, 0x03},
+		},
+		{
+			name:      "float vector",
+			fieldData: &FloatVectorFieldData{Dim: 2, Nullable: true},
+			rows:      []float32{1, 2, 3, 4, 5, 6},
+		},
+		{
+			name:      "float16 vector",
+			fieldData: &Float16VectorFieldData{Dim: 2, Nullable: true},
+			rows:      []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+		},
+		{
+			name:      "bfloat16 vector",
+			fieldData: &BFloat16VectorFieldData{Dim: 2, Nullable: true},
+			rows:      []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+		},
+		{
+			name:      "sparse vector",
+			fieldData: &SparseFloatVectorFieldData{Nullable: true},
+			rows:      sparseRows,
+		},
+		{
+			name:      "int8 vector",
+			fieldData: &Int8VectorFieldData{Dim: 2, Nullable: true},
+			rows:      []int8{1, 2, 3, 4, 5, 6},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fieldData.AppendRows(tt.rows, validData)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "compact")
+			assert.Equal(t, 0, tt.fieldData.RowNum())
+			assert.Empty(t, nullableVectorValidDataForTest(tt.fieldData))
+		})
+	}
+}
+
+func nullableVectorValidDataForTest(fieldData FieldData) []bool {
+	switch data := fieldData.(type) {
+	case *BinaryVectorFieldData:
+		return data.ValidData
+	case *FloatVectorFieldData:
+		return data.ValidData
+	case *Float16VectorFieldData:
+		return data.ValidData
+	case *BFloat16VectorFieldData:
+		return data.ValidData
+	case *SparseFloatVectorFieldData:
+		return data.ValidData
+	case *Int8VectorFieldData:
+		return data.ValidData
+	default:
+		return nil
+	}
 }

--- a/internal/storage/payload_reader.go
+++ b/internal/storage/payload_reader.go
@@ -1079,8 +1079,6 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 					if rowDim > fieldData.Dim {
 						fieldData.Dim = rowDim
 					}
-				} else {
-					fieldData.Contents = append(fieldData.Contents, nil)
 				}
 			}
 			offset += binaryArray.Len()

--- a/internal/storage/payload_test.go
+++ b/internal/storage/payload_test.go
@@ -1794,6 +1794,39 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 }
 
+func TestNullableSparseFloatVectorPayloadReaderKeepsCompactRows(t *testing.T) {
+	validData := []bool{false, true, false, true}
+	contents := [][]byte{
+		typeutil.CreateSparseFloatRow([]uint32{1, 3}, []float32{1.1, 1.3}),
+		typeutil.CreateSparseFloatRow([]uint32{2, 4}, []float32{2.2, 2.4}),
+	}
+
+	w, err := NewPayloadWriter(schemapb.DataType_SparseFloatVector, WithNullable(true))
+	require.NoError(t, err)
+	err = w.AddSparseFloatVectorToPayload(&SparseFloatVectorFieldData{
+		SparseFloatArray: schemapb.SparseFloatArray{
+			Dim:      5,
+			Contents: contents,
+		},
+		ValidData: validData,
+		Nullable:  true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, w.FinishPayloadWriter())
+
+	buffer, err := w.GetPayloadBufferFromWriter()
+	require.NoError(t, err)
+	r, err := NewPayloadReader(schemapb.DataType_SparseFloatVector, buffer, true)
+	require.NoError(t, err)
+	defer r.ReleasePayloadReader()
+
+	readData, readDim, readValid, err := r.GetSparseFloatVectorFromPayload()
+	require.NoError(t, err)
+	require.Equal(t, 5, readDim)
+	require.Equal(t, validData, readValid)
+	require.Equal(t, contents, readData.Contents)
+}
+
 func TestPayload_NullableReaderAndWriter(t *testing.T) {
 	t.Run("TestBool", func(t *testing.T) {
 		w, err := NewPayloadWriter(schemapb.DataType_Bool, WithNullable(true))
@@ -2728,7 +2761,7 @@ func TestPayload_NullableReaderAndWriter(t *testing.T) {
 			require.NoError(t, err)
 
 			validData := make([]bool, numRows)
-			tc.validDataSetup(validData)
+			validCount := tc.validDataSetup(validData)
 
 			data := &SparseFloatVectorFieldData{
 				SparseFloatArray: schemapb.SparseFloatArray{
@@ -2761,21 +2794,95 @@ func TestPayload_NullableReaderAndWriter(t *testing.T) {
 			readData, _, readValid, err := r.GetSparseFloatVectorFromPayload()
 			require.NoError(t, err)
 			require.Equal(t, numRows, len(readValid))
-			require.Equal(t, numRows, len(readData.Contents))
+			require.Equal(t, validCount, len(readData.Contents))
 
+			dataIdx := 0
 			for i := 0; i < numRows; i++ {
 				require.Equal(t, validData[i], readValid[i])
 				if validData[i] {
-					require.NotNil(t, readData.Contents[i])
-					require.Equal(t, 16, len(readData.Contents[i]))
+					require.NotNil(t, readData.Contents[dataIdx])
+					require.Equal(t, 16, len(readData.Contents[dataIdx]))
 					for j := 0; j < 16; j++ {
-						require.Equal(t, byte((i*10+j)%256), readData.Contents[i][j])
+						require.Equal(t, byte((i*10+j)%256), readData.Contents[dataIdx][j])
 					}
-				} else {
-					require.Nil(t, readData.Contents[i])
+					dataIdx++
 				}
 			}
 		}
+	})
+
+	t.Run("TestNullableVectorRequiresValidData", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			dataTyp schemapb.DataType
+			dim     int
+			add     func(PayloadWriterInterface) error
+		}{
+			{
+				name:    "FloatVector",
+				dataTyp: schemapb.DataType_FloatVector,
+				dim:     2,
+				add: func(w PayloadWriterInterface) error {
+					return w.AddFloatVectorToPayload([]float32{1, 2}, 2, nil)
+				},
+			},
+			{
+				name:    "BinaryVector",
+				dataTyp: schemapb.DataType_BinaryVector,
+				dim:     8,
+				add: func(w PayloadWriterInterface) error {
+					return w.AddBinaryVectorToPayload([]byte{1}, 8, nil)
+				},
+			},
+			{
+				name:    "Float16Vector",
+				dataTyp: schemapb.DataType_Float16Vector,
+				dim:     1,
+				add: func(w PayloadWriterInterface) error {
+					return w.AddFloat16VectorToPayload([]byte{1, 2}, 1, nil)
+				},
+			},
+			{
+				name:    "BFloat16Vector",
+				dataTyp: schemapb.DataType_BFloat16Vector,
+				dim:     1,
+				add: func(w PayloadWriterInterface) error {
+					return w.AddBFloat16VectorToPayload([]byte{1, 2}, 1, nil)
+				},
+			},
+			{
+				name:    "Int8Vector",
+				dataTyp: schemapb.DataType_Int8Vector,
+				dim:     2,
+				add: func(w PayloadWriterInterface) error {
+					return w.AddInt8VectorToPayload([]int8{1, 2}, 2, nil)
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				w, err := NewPayloadWriter(tt.dataTyp, WithDim(tt.dim), WithNullable(true))
+				require.NoError(t, err)
+				defer w.Close()
+
+				err = tt.add(w)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "validData")
+			})
+		}
+
+		t.Run("SparseFloatVector", func(t *testing.T) {
+			w, err := NewPayloadWriter(schemapb.DataType_SparseFloatVector, WithNullable(true))
+			require.NoError(t, err)
+			defer w.Close()
+
+			err = w.AddSparseFloatVectorToPayload(&SparseFloatVectorFieldData{
+				SparseFloatArray: schemapb.SparseFloatArray{Contents: [][]byte{{1}}},
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "validData")
+		})
 	})
 
 	t.Run("TestAddBool with wrong valids", func(t *testing.T) {

--- a/internal/storage/payload_writer.go
+++ b/internal/storage/payload_writer.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	_ "github.com/milvus-io/milvus/internal/storage/compress" // register a custom zstd codec here, to avoid to much memory usage when serializing.
 	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
@@ -122,7 +123,7 @@ func NewPayloadWriter(colType schemapb.DataType, options ...PayloadWriterOptions
 		w.arrowType = arrow.ListOf(elemType)
 		w.builder = array.NewListBuilder(memory.DefaultAllocator, elemType)
 	} else {
-		if w.nullable && typeutil.IsVectorType(colType) && !typeutil.IsSparseFloatVectorType(colType) {
+		if w.nullable && typeutil.IsSupportedNullableVectorType(colType) && !typeutil.IsSparseFloatVectorType(colType) {
 			w.arrowType = &arrow.BinaryType{}
 			w.builder = array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
 		} else {
@@ -662,6 +663,13 @@ func (w *NativePayloadWriter) AddOneGeometryToPayload(data []byte, isValid bool)
 	return nil
 }
 
+func validateNullableVectorValidData(validData []bool) (int, error) {
+	if len(validData) == 0 {
+		return 0, merr.WrapErrParameterInvalidMsg("validData is required for nullable vector payload")
+	}
+	return int(funcutil.CountValidRows(validData)), nil
+}
+
 func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, validData []bool) error {
 	if w.finished {
 		return errors.New("can't append data to finished binary vector payload")
@@ -669,13 +677,11 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 
 	byteLength := dim / 8
 	var numRows int
-	if w.nullable && len(validData) > 0 {
+	if w.nullable {
 		numRows = len(validData)
-		validCount := 0
-		for _, valid := range validData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(validData)
+		if err != nil {
+			return err
 		}
 		expectedDataLen := validCount * byteLength
 		if len(data) != expectedDataLen {
@@ -730,13 +736,11 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 	}
 
 	var numRows int
-	if w.nullable && len(validData) > 0 {
+	if w.nullable {
 		numRows = len(validData)
-		validCount := 0
-		for _, valid := range validData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(validData)
+		if err != nil {
+			return err
 		}
 		expectedDataLen := validCount * dim
 		if len(data) != expectedDataLen {
@@ -806,13 +810,11 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 
 	byteLength := dim * 2
 	var numRows int
-	if w.nullable && len(validData) > 0 {
+	if w.nullable {
 		numRows = len(validData)
-		validCount := 0
-		for _, valid := range validData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(validData)
+		if err != nil {
+			return err
 		}
 		expectedDataLen := validCount * byteLength
 		if len(data) != expectedDataLen {
@@ -868,13 +870,11 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 
 	byteLength := dim * 2
 	var numRows int
-	if w.nullable && len(validData) > 0 {
+	if w.nullable {
 		numRows = len(validData)
-		validCount := 0
-		for _, valid := range validData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(validData)
+		if err != nil {
+			return err
 		}
 		expectedDataLen := validCount * byteLength
 		if len(data) != expectedDataLen {
@@ -929,13 +929,11 @@ func (w *NativePayloadWriter) AddSparseFloatVectorToPayload(data *SparseFloatVec
 	}
 
 	var numRows int
-	if w.nullable && len(data.ValidData) > 0 {
+	if w.nullable {
 		numRows = len(data.ValidData)
-		validCount := 0
-		for _, valid := range data.ValidData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(data.ValidData)
+		if err != nil {
+			return err
 		}
 		if len(data.Contents) != validCount {
 			msg := fmt.Sprintf("when nullable, Contents length(%d) must equal to valid count(%d)", len(data.Contents), validCount)
@@ -973,13 +971,11 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 	}
 
 	var numRows int
-	if w.nullable && len(validData) > 0 {
+	if w.nullable {
 		numRows = len(validData)
-		validCount := 0
-		for _, valid := range validData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(validData)
+		if err != nil {
+			return err
 		}
 		expectedDataLen := validCount * dim
 		if len(data) != expectedDataLen {
@@ -1050,7 +1046,7 @@ func (w *NativePayloadWriter) FinishPayloadWriter() error {
 			[]string{"elementType", "dim"},
 			[]string{fmt.Sprintf("%d", int32(*w.elementType)), fmt.Sprintf("%d", w.dim.GetValue())},
 		)
-	} else if w.nullable && typeutil.IsVectorType(w.dataType) && !typeutil.IsSparseFloatVectorType(w.dataType) {
+	} else if w.nullable && typeutil.IsSupportedNullableVectorType(w.dataType) && !typeutil.IsSparseFloatVectorType(w.dataType) {
 		metadata = arrow.NewMetadata(
 			[]string{"dim"},
 			[]string{fmt.Sprintf("%d", w.dim.GetValue())},
@@ -1078,7 +1074,7 @@ func (w *NativePayloadWriter) FinishPayloadWriter() error {
 
 	arrowWriterProps := pqarrow.DefaultWriterProps()
 	if w.dataType == schemapb.DataType_ArrayOfVector ||
-		(w.nullable && typeutil.IsVectorType(w.dataType) && !typeutil.IsSparseFloatVectorType(w.dataType)) {
+		(w.nullable && typeutil.IsSupportedNullableVectorType(w.dataType) && !typeutil.IsSparseFloatVectorType(w.dataType)) {
 		// Store metadata in the Arrow writer properties
 		arrowWriterProps = pqarrow.NewArrowWriterProperties(
 			pqarrow.WithStoreSchema(),

--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -565,7 +565,16 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return value, nil
 		}
-		return nil, fmt.Errorf("expected *array.FixedSizeBinary, got %T", a)
+		if arr, ok := a.(*array.Binary); ok && i < arr.Len() {
+			value := arr.Value(i)
+			if shouldCopy {
+				result := make([]byte, len(value))
+				copy(result, value)
+				return result, nil
+			}
+			return value, nil
+		}
+		return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 	}
 	fixedSizeSerializer := func(b array.Builder, v any, _ schemapb.DataType) error {
 		if v == nil {
@@ -615,16 +624,25 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if a.IsNull(i) {
 				return nil, nil
 			}
-			if arr, ok := a.(*array.FixedSizeBinary); ok && i < arr.Len() {
-				// convert to []int8
-				bytes := arr.Value(i)
+			var bytes []byte
+			switch arr := a.(type) {
+			case *array.FixedSizeBinary:
+				if i < arr.Len() {
+					bytes = arr.Value(i)
+				}
+			case *array.Binary:
+				if i < arr.Len() {
+					bytes = arr.Value(i)
+				}
+			}
+			if bytes != nil {
 				int8s := make([]int8, len(bytes))
 				for i, b := range bytes {
 					int8s[i] = int8(b)
 				}
 				return int8s, nil
 			}
-			return nil, fmt.Errorf("expected *array.FixedSizeBinary, got %T", a)
+			return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -658,8 +676,19 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if a.IsNull(i) {
 				return nil, nil
 			}
-			if arr, ok := a.(*array.FixedSizeBinary); ok && i < arr.Len() {
-				vector := arrow.Float32Traits.CastFromBytes(arr.Value(i))
+			var bytes []byte
+			switch arr := a.(type) {
+			case *array.FixedSizeBinary:
+				if i < arr.Len() {
+					bytes = arr.Value(i)
+				}
+			case *array.Binary:
+				if i < arr.Len() {
+					bytes = arr.Value(i)
+				}
+			}
+			if bytes != nil {
+				vector := arrow.Float32Traits.CastFromBytes(bytes)
 				if shouldCopy {
 					vectorCopy := make([]float32, len(vector))
 					copy(vectorCopy, vector)
@@ -667,7 +696,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return vector, nil
 			}
-			return nil, fmt.Errorf("expected *array.FixedSizeBinary, got %T", a)
+			return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -1072,7 +1101,7 @@ func newSingleFieldRecordWriter(field *schemapb.FieldSchema, writer io.Writer, o
 		)
 	}
 
-	if field.GetNullable() && typeutil.IsVectorType(field.DataType) && !typeutil.IsSparseFloatVectorType(field.DataType) {
+	if field.GetNullable() && typeutil.IsSupportedNullableVectorType(field.DataType) && !typeutil.IsSparseFloatVectorType(field.DataType) {
 		arrowType = arrow.BinaryTypes.Binary
 		fieldMetadata = arrow.NewMetadata(
 			[]string{"dim"},
@@ -1104,8 +1133,9 @@ func newSingleFieldRecordWriter(field *schemapb.FieldSchema, writer io.Writer, o
 
 	// Use appropriate Arrow writer properties for ArrayOfVector
 	arrowWriterProps := pqarrow.DefaultWriterProps()
-	if field.DataType == schemapb.DataType_ArrayOfVector {
-		// Ensure schema metadata is preserved for ArrayOfVector
+	if field.DataType == schemapb.DataType_ArrayOfVector ||
+		(field.GetNullable() && isNullableDenseVectorArrowType(field.DataType)) {
+		// Preserve dim/elementType metadata required by binary-backed vector layouts.
 		arrowWriterProps = pqarrow.NewArrowWriterProperties(
 			pqarrow.WithStoreSchema(),
 		)
@@ -1292,7 +1322,7 @@ func BuildRecord(b *array.RecordBuilder, data *InsertData, schema *schemapb.Coll
 			elementType = field.GetElementType()
 		}
 
-		if field.GetNullable() && typeutil.IsVectorType(field.DataType) {
+		if field.GetNullable() && typeutil.IsSupportedNullableVectorType(field.DataType) {
 			var validData []bool
 			switch fd := fieldData.(type) {
 			case *FloatVectorFieldData:

--- a/internal/storage/serde_events.go
+++ b/internal/storage/serde_events.go
@@ -425,21 +425,20 @@ func ValueSerializer(v []*Value, schema *schemapb.CollectionSchema) (Record, err
 	for _, structField := range schema.StructArrayFields {
 		allFieldsSchema = append(allFieldsSchema, structField.Fields...)
 	}
+	arrowSchema, err := ConvertToArrowSchema(schema, false)
+	if err != nil {
+		return nil, err
+	}
 
 	builders := make(map[FieldID]array.Builder, len(allFieldsSchema))
 	types := make(map[FieldID]schemapb.DataType, len(allFieldsSchema))
 	elementTypes := make(map[FieldID]schemapb.DataType, len(allFieldsSchema)) // For ArrayOfVector
-	for _, f := range allFieldsSchema {
-		dim, _ := typeutil.GetDim(f)
-
-		elementType := schemapb.DataType_None
+	for i, f := range allFieldsSchema {
 		if f.DataType == schemapb.DataType_ArrayOfVector {
-			elementType = f.GetElementType()
-			elementTypes[f.FieldID] = elementType
+			elementTypes[f.FieldID] = f.GetElementType()
 		}
 
-		arrowType := serdeMap[f.DataType].arrowType(int(dim), elementType)
-		builders[f.FieldID] = array.NewBuilder(memory.DefaultAllocator, arrowType)
+		builders[f.FieldID] = array.NewBuilder(memory.DefaultAllocator, arrowSchema.Field(i).Type)
 		builders[f.FieldID].Reserve(len(v)) // reserve space to avoid copy
 		types[f.FieldID] = f.DataType
 	}
@@ -471,7 +470,7 @@ func ValueSerializer(v []*Value, schema *schemapb.CollectionSchema) (Record, err
 		builder := builders[field.FieldID]
 		arrays[i] = builder.NewArray()
 		builder.Release()
-		fields[i] = ConvertToArrowField(field, arrays[i].DataType(), false)
+		fields[i] = arrowSchema.Field(i)
 		field2Col[field.FieldID] = i
 	}
 	return NewSimpleArrowRecord(array.NewRecord(arrow.NewSchema(fields, nil), arrays, int64(len(v))), field2Col), nil

--- a/internal/storage/serde_events_test.go
+++ b/internal/storage/serde_events_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -181,6 +182,192 @@ func TestBinlogSerializeWriter(t *testing.T) {
 		assert.Equal(t, 18, len(logs))
 		assert.Equal(t, 5, len(logs[0].Binlogs))
 	})
+}
+
+func TestValueDeserializerNullableDenseVectorBinaryRecord(t *testing.T) {
+	for _, tc := range nullableDenseVectorSerdeCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := nullableDenseVectorSerdeSchema(tc.dataType, tc.dim)
+			insertData := nullableDenseVectorSerdeInsertData(t, tc, schema)
+
+			arrowSchema, err := ConvertToArrowSchema(schema, false)
+			require.NoError(t, err)
+			builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+			defer builder.Release()
+			require.NoError(t, BuildRecord(builder, insertData, schema))
+			record := NewSimpleArrowRecord(builder.NewRecord(), map[FieldID]int{
+				common.RowIDField:          0,
+				common.TimeStampField:      1,
+				nullableSerdePKFieldID:     2,
+				nullableSerdeVectorFieldID: 3,
+			})
+			defer record.Release()
+
+			require.IsType(t, &array.Binary{}, record.Column(nullableSerdeVectorFieldID))
+			require.True(t, record.Column(nullableSerdeVectorFieldID).IsNull(1))
+
+			values := make([]*Value, record.Len())
+			err = ValueDeserializerWithSchema(record, values, schema, true)
+			require.NoError(t, err)
+
+			got := values[0].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID]
+			assert.Equal(t, tc.row0, got)
+			assert.Nil(t, values[1].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID])
+			got = values[2].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID]
+			assert.Equal(t, tc.row2, got)
+		})
+	}
+}
+
+func TestValueSerializerNullableDenseVectorUsesBinaryArrow(t *testing.T) {
+	for _, tc := range nullableDenseVectorSerdeCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := nullableDenseVectorSerdeSchema(tc.dataType, tc.dim)
+			values := []*Value{
+				{Value: map[FieldID]any{
+					common.RowIDField:          int64(11),
+					common.TimeStampField:      int64(101),
+					nullableSerdePKFieldID:     int64(1),
+					nullableSerdeVectorFieldID: tc.row0,
+				}},
+				{Value: map[FieldID]any{
+					common.RowIDField:          int64(12),
+					common.TimeStampField:      int64(102),
+					nullableSerdePKFieldID:     int64(2),
+					nullableSerdeVectorFieldID: nil,
+				}},
+				{Value: map[FieldID]any{
+					common.RowIDField:          int64(13),
+					common.TimeStampField:      int64(103),
+					nullableSerdePKFieldID:     int64(3),
+					nullableSerdeVectorFieldID: tc.row2,
+				}},
+			}
+
+			record, err := ValueSerializer(values, schema)
+			require.NoError(t, err)
+			defer record.Release()
+
+			require.IsType(t, &array.Binary{}, record.Column(nullableSerdeVectorFieldID))
+			require.True(t, record.Column(nullableSerdeVectorFieldID).IsNull(1))
+			simpleRecord := record.(*simpleArrowRecord)
+			dim, ok := simpleRecord.r.Schema().Field(3).Metadata.GetValue(common.DimKey)
+			require.True(t, ok)
+			assert.Equal(t, strconv.FormatInt(tc.dim, 10), dim)
+
+			roundTrip := make([]*Value, record.Len())
+			err = ValueDeserializerWithSchema(record, roundTrip, schema, true)
+			require.NoError(t, err)
+			assert.Equal(t, tc.row0, roundTrip[0].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID])
+			assert.Nil(t, roundTrip[1].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID])
+			assert.Equal(t, tc.row2, roundTrip[2].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID])
+		})
+	}
+}
+
+type nullableDenseVectorSerdeCase struct {
+	name     string
+	dataType schemapb.DataType
+	dim      int64
+	row0     any
+	row2     any
+}
+
+const (
+	nullableSerdePKFieldID     FieldID = common.StartOfUserFieldID
+	nullableSerdeVectorFieldID FieldID = common.StartOfUserFieldID + 1
+)
+
+func nullableDenseVectorSerdeCases() []nullableDenseVectorSerdeCase {
+	return []nullableDenseVectorSerdeCase{
+		{
+			name:     "FloatVector",
+			dataType: schemapb.DataType_FloatVector,
+			dim:      2,
+			row0:     []float32{1, 2},
+			row2:     []float32{3, 4},
+		},
+		{
+			name:     "BinaryVector",
+			dataType: schemapb.DataType_BinaryVector,
+			dim:      16,
+			row0:     []byte{0x11, 0x12},
+			row2:     []byte{0x21, 0x22},
+		},
+		{
+			name:     "Float16Vector",
+			dataType: schemapb.DataType_Float16Vector,
+			dim:      2,
+			row0:     []byte{1, 2, 3, 4},
+			row2:     []byte{5, 6, 7, 8},
+		},
+		{
+			name:     "BFloat16Vector",
+			dataType: schemapb.DataType_BFloat16Vector,
+			dim:      2,
+			row0:     []byte{11, 12, 13, 14},
+			row2:     []byte{15, 16, 17, 18},
+		},
+		{
+			name:     "Int8Vector",
+			dataType: schemapb.DataType_Int8Vector,
+			dim:      2,
+			row0:     []int8{1, 2},
+			row2:     []int8{3, 4},
+		},
+	}
+}
+
+func nullableDenseVectorSerdeSchema(dataType schemapb.DataType, dim int64) *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  common.RowIDField,
+				Name:     common.RowIDFieldName,
+				DataType: schemapb.DataType_Int64,
+			},
+			{
+				FieldID:  common.TimeStampField,
+				Name:     common.TimeStampFieldName,
+				DataType: schemapb.DataType_Int64,
+			},
+			{
+				FieldID:      nullableSerdePKFieldID,
+				Name:         "pk",
+				DataType:     schemapb.DataType_Int64,
+				IsPrimaryKey: true,
+			},
+			{
+				FieldID:  nullableSerdeVectorFieldID,
+				Name:     "nullable_vector",
+				DataType: dataType,
+				Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: strconv.FormatInt(dim, 10)},
+				},
+			},
+		},
+	}
+}
+
+func nullableDenseVectorSerdeInsertData(t *testing.T, tc nullableDenseVectorSerdeCase, schema *schemapb.CollectionSchema) *InsertData {
+	t.Helper()
+
+	vectorField := schema.GetFields()[3]
+	vectorData, err := NewFieldData(tc.dataType, vectorField, 3)
+	require.NoError(t, err)
+	require.NoError(t, vectorData.AppendRow(tc.row0))
+	require.NoError(t, vectorData.AppendRow(nil))
+	require.NoError(t, vectorData.AppendRow(tc.row2))
+
+	return &InsertData{
+		Data: map[FieldID]FieldData{
+			common.RowIDField:          &Int64FieldData{Data: []int64{11, 12, 13}},
+			common.TimeStampField:      &Int64FieldData{Data: []int64{101, 102, 103}},
+			nullableSerdePKFieldID:     &Int64FieldData{Data: []int64{1, 2, 3}},
+			nullableSerdeVectorFieldID: vectorData,
+		},
+	}
 }
 
 func TestBinlogValueWriter(t *testing.T) {

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -41,6 +41,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v2/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -536,6 +537,43 @@ func RowBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *schemap
 // This funcion also checks the length of each column. All columns shall have the same length.
 // Also, the InsertData.Infos shall have BlobInfo with this length returned.
 // When the length is not aligned, an error will be returned.
+func validateColumnBasedNullableVectorFieldData(field *schemapb.FieldSchema, srcField *schemapb.FieldData, logicalRows int) error {
+	if !field.GetNullable() || !typeutil.IsSupportedNullableVectorType(field.GetDataType()) {
+		return nil
+	}
+	dim := int64(0)
+	if field.GetDataType() != schemapb.DataType_SparseFloatVector && srcField.GetVectors() != nil && srcField.GetVectors().GetDim() == 0 {
+		fieldDim, err := GetDimFromParams(field.GetTypeParams())
+		if err != nil {
+			return err
+		}
+		dim = int64(fieldDim)
+	}
+	requireValidData := logicalRows > 0 || len(srcField.GetValidData()) > 0
+	if err := funcutil.ValidateNullableVectorFieldDataCompactWithDim(srcField, uint64(logicalRows), requireValidData, dim); err != nil {
+		return merr.WrapErrParameterInvalidMsg(err.Error())
+	}
+	return nil
+}
+
+func validateColumnBasedInsertMsgNullableVectors(schema *schemapb.CollectionSchema, msg *msgstream.InsertMsg) error {
+	srcFields := make(map[int64]*schemapb.FieldData, len(msg.GetFieldsData()))
+	for _, fieldData := range msg.GetFieldsData() {
+		srcFields[fieldData.GetFieldId()] = fieldData
+	}
+
+	for _, field := range typeutil.GetAllFieldSchemas(schema) {
+		srcField, ok := srcFields[field.GetFieldID()]
+		if !ok {
+			continue
+		}
+		if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *schemapb.CollectionSchema) (idata *InsertData, err error) {
 	srcFields := make(map[FieldID]*schemapb.FieldData)
 	for _, field := range msg.FieldsData {
@@ -569,6 +607,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 
 			srcData := srcField.GetVectors().GetFloatVector().GetData()
 			validData := srcField.GetValidData()
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
+			}
 			fd := &FloatVectorFieldData{
 				Data:      srcData,
 				Dim:       dim,
@@ -589,6 +630,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 
 			srcData := srcField.GetVectors().GetBinaryVector()
 			validData := srcField.GetValidData()
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
+			}
 			fd := &BinaryVectorFieldData{
 				Data:      srcData,
 				Dim:       dim,
@@ -609,6 +653,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 
 			srcData := srcField.GetVectors().GetFloat16Vector()
 			validData := srcField.GetValidData()
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
+			}
 			fd := &Float16VectorFieldData{
 				Data:      srcData,
 				Dim:       dim,
@@ -629,6 +676,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 
 			srcData := srcField.GetVectors().GetBfloat16Vector()
 			validData := srcField.GetValidData()
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
+			}
 			fd := &BFloat16VectorFieldData{
 				Data:      srcData,
 				Dim:       dim,
@@ -648,6 +698,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 			if sparseArray != nil {
 				contents = sparseArray.GetContents()
 				dim = sparseArray.GetDim()
+			}
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
 			}
 			fd := &SparseFloatVectorFieldData{
 				SparseFloatArray: schemapb.SparseFloatArray{
@@ -671,6 +724,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 
 			srcData := srcField.GetVectors().GetInt8Vector()
 			validData := srcField.GetValidData()
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
+			}
 			fd := &Int8VectorFieldData{
 				Data:      lo.Map(srcData, func(v byte, _ int) int8 { return int8(v) }),
 				Dim:       dim,
@@ -1596,6 +1652,10 @@ func TransferInsertMsgToInsertRecord(schema *schemapb.CollectionSchema, msg *msg
 	}
 
 	// column base insert msg
+	if err := validateColumnBasedInsertMsgNullableVectors(schema, msg); err != nil {
+		return nil, err
+	}
+
 	insertRecord := &segcorepb.InsertRecord{
 		NumRows:    int64(msg.NumRows),
 		FieldsData: make([]*schemapb.FieldData, 0),

--- a/internal/storage/utils_test.go
+++ b/internal/storage/utils_test.go
@@ -1258,6 +1258,235 @@ func TestColumnBasedInsertMsgToInsertDataNullable(t *testing.T) {
 	}
 }
 
+func TestColumnBasedInsertMsgToInsertDataRejectsNullableVectorNonCompactData(t *testing.T) {
+	validData := []bool{true, false, true}
+	makeSchema := func(dataType schemapb.DataType, dim string) *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Name: "nullable_vector_compact",
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:      100,
+					Name:         "pk",
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+				},
+				{
+					FieldID:  101,
+					Name:     "vec",
+					DataType: dataType,
+					Nullable: true,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: dim},
+					},
+				},
+			},
+		}
+	}
+	makeMsg := func(dataType schemapb.DataType, vectors *schemapb.VectorField) *msgstream.InsertMsg {
+		return &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						Type:      schemapb.DataType_Int64,
+						FieldName: "pk",
+						FieldId:   100,
+						Field: &schemapb.FieldData_Scalars{
+							Scalars: &schemapb.ScalarField{
+								Data: &schemapb.ScalarField_LongData{
+									LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+								},
+							},
+						},
+					},
+					{
+						Type:      dataType,
+						FieldName: "vec",
+						FieldId:   101,
+						ValidData: validData,
+						Field:     &schemapb.FieldData_Vectors{Vectors: vectors},
+					},
+				},
+				NumRows: 3,
+				Version: msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		dataType schemapb.DataType
+		dim      string
+		vectors  *schemapb.VectorField
+	}{
+		{
+			name:     "float vector",
+			dataType: schemapb.DataType_FloatVector,
+			dim:      "2",
+			vectors: &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3, 4, 5, 6}},
+			}},
+		},
+		{
+			name:     "binary vector",
+			dataType: schemapb.DataType_BinaryVector,
+			dim:      "8",
+			vectors:  &schemapb.VectorField{Dim: 8, Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 2, 3}}},
+		},
+		{
+			name:     "float16 vector",
+			dataType: schemapb.DataType_Float16Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}}},
+		},
+		{
+			name:     "bfloat16 vector",
+			dataType: schemapb.DataType_BFloat16Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}}},
+		},
+		{
+			name:     "sparse vector",
+			dataType: schemapb.DataType_SparseFloatVector,
+			dim:      "2",
+			vectors: &schemapb.VectorField{Data: &schemapb.VectorField_SparseFloatVector{
+				SparseFloatVector: &schemapb.SparseFloatArray{Contents: [][]byte{
+					typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1}),
+					typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2}),
+					typeutil.CreateSparseFloatRow([]uint32{3}, []float32{3}),
+				}},
+			}},
+		},
+		{
+			name:     "int8 vector",
+			dataType: schemapb.DataType_Int8Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{1, 2, 3, 4, 5, 6}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := makeMsg(tt.dataType, tt.vectors)
+			schema := makeSchema(tt.dataType, tt.dim)
+
+			_, err := ColumnBasedInsertMsgToInsertData(msg, schema)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "compact")
+
+			_, err = TransferInsertMsgToInsertRecord(schema, msg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "compact")
+		})
+	}
+}
+
+func TestColumnBasedInsertMsgToInsertDataRejectsNullableVectorPartialRowData(t *testing.T) {
+	makeSchema := func(dataType schemapb.DataType, dim string) *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Name: "nullable_vector_partial_row",
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:      100,
+					Name:         "pk",
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+				},
+				{
+					FieldID:  101,
+					Name:     "vec",
+					DataType: dataType,
+					Nullable: true,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: dim},
+					},
+				},
+			},
+		}
+	}
+	makeMsg := func(dataType schemapb.DataType, vectors *schemapb.VectorField) *msgstream.InsertMsg {
+		return &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						Type:      schemapb.DataType_Int64,
+						FieldName: "pk",
+						FieldId:   100,
+						Field: &schemapb.FieldData_Scalars{
+							Scalars: &schemapb.ScalarField{
+								Data: &schemapb.ScalarField_LongData{
+									LongData: &schemapb.LongArray{Data: []int64{1, 2}},
+								},
+							},
+						},
+					},
+					{
+						Type:      dataType,
+						FieldName: "vec",
+						FieldId:   101,
+						ValidData: []bool{true, false},
+						Field:     &schemapb.FieldData_Vectors{Vectors: vectors},
+					},
+				},
+				NumRows: 2,
+				Version: msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		dataType schemapb.DataType
+		dim      string
+		vectors  *schemapb.VectorField
+	}{
+		{
+			name:     "float vector",
+			dataType: schemapb.DataType_FloatVector,
+			dim:      "2",
+			vectors: &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3}},
+			}},
+		},
+		{
+			name:     "binary vector",
+			dataType: schemapb.DataType_BinaryVector,
+			dim:      "16",
+			vectors:  &schemapb.VectorField{Dim: 16, Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 2, 3}}},
+		},
+		{
+			name:     "float16 vector",
+			dataType: schemapb.DataType_Float16Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2, 3, 4, 5}}},
+		},
+		{
+			name:     "bfloat16 vector",
+			dataType: schemapb.DataType_BFloat16Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{1, 2, 3, 4, 5}}},
+		},
+		{
+			name:     "int8 vector",
+			dataType: schemapb.DataType_Int8Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{1, 2, 3}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := makeMsg(tt.dataType, tt.vectors)
+			schema := makeSchema(tt.dataType, tt.dim)
+
+			_, err := ColumnBasedInsertMsgToInsertData(msg, schema)
+			require.Error(t, err)
+
+			_, err = TransferInsertMsgToInsertRecord(schema, msg)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestColumnBasedInsertMsgToInsertFloat16VectorDataError(t *testing.T) {
 	msg := &msgstream.InsertMsg{
 		BaseMsg: msgstream.BaseMsg{
@@ -2834,4 +3063,23 @@ func TestInsertDataWithStructAndMissingField(t *testing.T) {
 	for _, valid := range int64Field.ValidData {
 		assert.False(t, valid, "nullable field should have all null values")
 	}
+}
+
+func TestMergeInsertDataNullableSparseAllNullPreservesValidData(t *testing.T) {
+	buffer := &InsertData{Data: make(map[FieldID]FieldData)}
+	allNull := &InsertData{Data: map[FieldID]FieldData{
+		100: &SparseFloatVectorFieldData{
+			SparseFloatArray: schemapb.SparseFloatArray{Dim: 8},
+			ValidData:        []bool{false, false},
+			Nullable:         true,
+		},
+	}}
+
+	MergeInsertData(buffer, allNull)
+
+	merged := buffer.Data[100].(*SparseFloatVectorFieldData)
+	require.True(t, merged.Nullable)
+	require.Equal(t, []bool{false, false}, merged.ValidData)
+	require.Empty(t, merged.Contents)
+	require.Equal(t, 2, merged.RowNum())
 }

--- a/internal/util/importutilv2/common/util.go
+++ b/internal/util/importutilv2/common/util.go
@@ -109,6 +109,24 @@ func CheckValidString(s string, maxLength int64, field *schemapb.FieldSchema) er
 	return nil
 }
 
+func RejectNullableArrayOfVector(schema *schemapb.CollectionSchema) error {
+	for _, field := range schema.GetFields() {
+		if field.GetDataType() == schemapb.DataType_ArrayOfVector && field.GetNullable() {
+			return fmt.Errorf("ArrayOfVector does not support nullable, fieldName=%s", field.GetName())
+		}
+	}
+
+	for _, structField := range schema.GetStructArrayFields() {
+		for _, field := range structField.GetFields() {
+			if field.GetDataType() == schemapb.DataType_ArrayOfVector && field.GetNullable() {
+				return fmt.Errorf("ArrayOfVector does not support nullable, structName=%s, fieldName=%s",
+					structField.GetName(), field.GetName())
+			}
+		}
+	}
+	return nil
+}
+
 // RemoveUnpopulatedFunctionOutputFields removes function output fields that have no data
 // from the InsertData. These fields are computed downstream (e.g., BM25 sparse vectors),
 // not from the data source.

--- a/internal/util/importutilv2/csv/row_parser.go
+++ b/internal/util/importutilv2/csv/row_parser.go
@@ -53,6 +53,10 @@ type rowParser struct {
 }
 
 func NewRowParser(schema *schemapb.CollectionSchema, header []string, nullkey string) (RowParser, error) {
+	if err := common.RejectNullableArrayOfVector(schema); err != nil {
+		return nil, merr.WrapErrImportFailed(err.Error())
+	}
+
 	pkField, err := typeutil.GetPrimaryFieldSchema(schema)
 	if err != nil {
 		return nil, err

--- a/internal/util/importutilv2/csv/row_parser_test.go
+++ b/internal/util/importutilv2/csv/row_parser_test.go
@@ -866,6 +866,37 @@ func (suite *RowParserSuite) TestFunctionOutputField() {
 	suite.False(hasEmbedding) // embedding not provided, should not be in row
 }
 
+func TestNewRowParserRejectsNullableArrayOfVector(t *testing.T) {
+	rpSuite := &RowParserSuite{autoID: true, hasNullable: true, hasDynamic: true}
+
+	t.Run("nullable top-level ArrayOfVector", func(t *testing.T) {
+		schema := rpSuite.createAllTypesSchema()
+		schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+			FieldID:     2000,
+			Name:        "top_array_of_vector",
+			DataType:    schemapb.DataType_ArrayOfVector,
+			ElementType: schemapb.DataType_FloatVector,
+			Nullable:    true,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "2"},
+			},
+		})
+
+		_, err := NewRowParser(schema, nil, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ArrayOfVector does not support nullable")
+	})
+
+	t.Run("nullable ArrayOfVector subfield", func(t *testing.T) {
+		schema := rpSuite.createAllTypesSchema()
+		schema.StructArrayFields[0].Fields[8].Nullable = true
+
+		_, err := NewRowParser(schema, nil, "")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ArrayOfVector does not support nullable")
+	})
+}
+
 func TestCsvRowParser(t *testing.T) {
 	suite.Run(t, new(RowParserSuite))
 }

--- a/internal/util/importutilv2/json/row_parser.go
+++ b/internal/util/importutilv2/json/row_parser.go
@@ -52,6 +52,10 @@ type rowParser struct {
 }
 
 func NewRowParser(schema *schemapb.CollectionSchema) (RowParser, error) {
+	if err := common.RejectNullableArrayOfVector(schema); err != nil {
+		return nil, merr.WrapErrImportFailed(err.Error())
+	}
+
 	allFields := typeutil.GetAllFieldSchemas(schema)
 
 	id2Field := lo.KeyBy(allFields, func(field *schemapb.FieldSchema) int64 {
@@ -167,12 +171,24 @@ func reconstructArrayForStructArray(raw any) (map[string]any, error) {
 	}
 
 	buf := make(map[string][]any)
+	var expectedKeys map[string]struct{}
 	for _, elem := range rows {
 		row, ok := elem.(map[string]any)
 		if !ok {
 			return nil, merr.WrapErrImportFailed(fmt.Sprintf("invalid element in StructArray, expect map[string]any but got type %T", elem))
 		}
+		if expectedKeys == nil {
+			expectedKeys = make(map[string]struct{}, len(row))
+			for key := range row {
+				expectedKeys[key] = struct{}{}
+			}
+		} else if len(row) != len(expectedKeys) {
+			return nil, merr.WrapErrImportFailed("inconsistent field count in StructArray")
+		}
 		for key, value := range row {
+			if _, ok := expectedKeys[key]; !ok {
+				return nil, merr.WrapErrImportFailed("inconsistent field count in StructArray")
+			}
 			buf[key] = append(buf[key], value)
 		}
 	}
@@ -792,6 +808,9 @@ func (r *rowParser) arrayOfVectorToFieldData(vectors []any, field *schemapb.Fiel
 			vector, ok := vectorAny.([]any)
 			if !ok {
 				return nil, merr.WrapErrImportFailed(fmt.Sprintf("expected slice as vector, but got %T", vectorAny))
+			}
+			if len(vector) != dim {
+				return nil, r.wrapDimError(len(vector), fieldID)
 			}
 			for _, v := range vector {
 				value, ok := v.(json.Number)

--- a/internal/util/importutilv2/json/row_parser_test.go
+++ b/internal/util/importutilv2/json/row_parser_test.go
@@ -752,6 +752,114 @@ func (suite *RowParserSuite) TestParseError() {
 	}
 }
 
+func TestReconstructArrayForStructArray_InconsistentFields(t *testing.T) {
+	// Element missing a field should produce an error
+	raw := []any{
+		map[string]any{"sub_int": 1, "sub_str": "hello"},
+		map[string]any{"sub_int": 2}, // missing "sub_str"
+	}
+	_, err := reconstructArrayForStructArray(raw)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "inconsistent field count in StructArray")
+
+	// Element with an extra field should produce an error
+	raw = []any{
+		map[string]any{"sub_int": 1, "sub_str": "hello"},
+		map[string]any{"sub_int": 2, "sub_str": "world", "sub_extra": true},
+	}
+	_, err = reconstructArrayForStructArray(raw)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "inconsistent field count in StructArray")
+
+	// Consistent fields should succeed
+	raw = []any{
+		map[string]any{"sub_int": 1, "sub_str": "hello1"},
+		map[string]any{"sub_int": 2, "sub_str": "hello2"},
+	}
+	result, err := reconstructArrayForStructArray(raw)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+
+	// Empty array should succeed
+	raw = []any{}
+	result, err = reconstructArrayForStructArray(raw)
+	assert.NoError(t, err)
+	assert.Len(t, result, 0)
+
+	// Single element should succeed
+	raw = []any{
+		map[string]any{"sub_int": 1, "sub_str": "hello"},
+	}
+	result, err = reconstructArrayForStructArray(raw)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+}
+
+func TestArrayOfVectorToFieldData_DimensionMismatch(t *testing.T) {
+	dim := 3
+	fieldID := int64(100)
+	field := &schemapb.FieldSchema{
+		FieldID:     fieldID,
+		Name:        "test_vec",
+		DataType:    schemapb.DataType_ArrayOfVector,
+		ElementType: schemapb.DataType_FloatVector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.DimKey, Value: "3"},
+		},
+	}
+	parser := &rowParser{
+		id2Dim:   map[int64]int{fieldID: dim},
+		id2Field: map[int64]*schemapb.FieldSchema{fieldID: field},
+	}
+
+	// Mismatched dimension: expect 3, got 2
+	vectors := []any{
+		[]any{json.Number("1.0"), json.Number("2.0")}, // dim=2, expected 3
+	}
+	_, err := parser.arrayOfVectorToFieldData(vectors, field)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected dim")
+
+	// Correct dimension should succeed
+	vectors = []any{
+		[]any{json.Number("1.0"), json.Number("2.0"), json.Number("3.0")},
+	}
+	result, err := parser.arrayOfVectorToFieldData(vectors, field)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(dim), result.Dim)
+}
+
+func TestNewRowParserRejectsNullableArrayOfVector(t *testing.T) {
+	rpSuite := &RowParserSuite{autoID: true, hasNullable: true, hasDynamic: true}
+
+	t.Run("nullable top-level ArrayOfVector", func(t *testing.T) {
+		schema := rpSuite.createAllTypesSchema()
+		schema.Fields = append(schema.Fields, &schemapb.FieldSchema{
+			FieldID:     200,
+			Name:        "top_array_of_vector",
+			DataType:    schemapb.DataType_ArrayOfVector,
+			ElementType: schemapb.DataType_FloatVector,
+			Nullable:    true,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.DimKey, Value: "2"},
+			},
+		})
+
+		_, err := NewRowParser(schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ArrayOfVector does not support nullable")
+	})
+
+	t.Run("nullable ArrayOfVector subfield", func(t *testing.T) {
+		schema := rpSuite.createAllTypesSchema()
+		schema.StructArrayFields[0].Fields[0].Nullable = true
+
+		_, err := NewRowParser(schema)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ArrayOfVector does not support nullable")
+	})
+}
+
 func TestJsonRowParser(t *testing.T) {
 	suite.Run(t, new(RowParserSuite))
 }

--- a/internal/util/importutilv2/numpy/field_reader.go
+++ b/internal/util/importutilv2/numpy/field_reader.go
@@ -119,6 +119,21 @@ func (c *FieldReader) getCount(count int64) int64 {
 	return count
 }
 
+func (c *FieldReader) logicalRowCount(readCount int64) int64 {
+	switch c.field.GetDataType() {
+	case schemapb.DataType_BinaryVector:
+		return readCount / (c.dim / 8)
+	case schemapb.DataType_FloatVector:
+		return readCount / c.dim
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		return readCount / (c.dim * 2)
+	case schemapb.DataType_Int8Vector:
+		return readCount / c.dim
+	default:
+		return readCount
+	}
+}
+
 func (c *FieldReader) Next(count int64) (any, any, error) {
 	readCount := c.getCount(count)
 	if readCount == 0 {
@@ -134,8 +149,9 @@ func (c *FieldReader) Next(count int64) (any, any, error) {
 	// construct a bool array with all-true if the field is nullable
 
 	if c.field.GetNullable() || c.field.GetDefaultValue() != nil {
-		validData = make([]bool, 0, readCount)
-		for i := int64(0); i < readCount; i++ {
+		validRows := c.logicalRowCount(readCount)
+		validData = make([]bool, 0, validRows)
+		for i := int64(0); i < validRows; i++ {
 			validData = append(validData, true)
 		}
 	}

--- a/internal/util/importutilv2/numpy/field_reader_test.go
+++ b/internal/util/importutilv2/numpy/field_reader_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
@@ -196,6 +197,82 @@ func TestNormalRead(t *testing.T) {
 
 	checkFn(false)
 	checkFn(true)
+}
+
+func TestNullableVectorValidDataUsesLogicalRows(t *testing.T) {
+	tests := []struct {
+		name      string
+		dataType  schemapb.DataType
+		fieldData storage.FieldData
+	}{
+		{
+			name:     "float vector",
+			dataType: schemapb.DataType_FloatVector,
+			fieldData: &storage.FloatVectorFieldData{
+				Data: make([]float32, 2*dim),
+				Dim:  dim,
+			},
+		},
+		{
+			name:     "float16 vector",
+			dataType: schemapb.DataType_Float16Vector,
+			fieldData: &storage.Float16VectorFieldData{
+				Data: make([]byte, 2*dim*2),
+				Dim:  dim,
+			},
+		},
+		{
+			name:     "bfloat16 vector",
+			dataType: schemapb.DataType_BFloat16Vector,
+			fieldData: &storage.BFloat16VectorFieldData{
+				Data: make([]byte, 2*dim*2),
+				Dim:  dim,
+			},
+		},
+		{
+			name:     "int8 vector",
+			dataType: schemapb.DataType_Int8Vector,
+			fieldData: &storage.Int8VectorFieldData{
+				Data: make([]int8, 2*dim),
+				Dim:  dim,
+			},
+		},
+		{
+			name:     "binary vector",
+			dataType: schemapb.DataType_BinaryVector,
+			fieldData: &storage.BinaryVectorFieldData{
+				Data: make([]byte, 2*dim/8),
+				Dim:  dim,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := &schemapb.FieldSchema{
+				FieldID:  100,
+				Name:     "nullable_vector",
+				DataType: tt.dataType,
+				Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "8"},
+				},
+			}
+			reader, err := createReader(tt.fieldData, tt.dataType)
+			assert.NoError(t, err)
+
+			fr, err := NewFieldReader(reader, field, common.DefaultTimezone)
+			assert.NoError(t, err)
+			data, validData, err := fr.Next(2)
+			assert.NoError(t, err)
+			assert.Len(t, validData.([]bool), 2)
+
+			dst, err := storage.NewFieldData(tt.dataType, field, 0)
+			assert.NoError(t, err)
+			assert.NoError(t, dst.AppendRows(data, validData))
+			assert.Equal(t, 2, dst.RowNum())
+		})
+	}
 }
 
 type ErrReader struct {

--- a/internal/util/importutilv2/parquet/field_reader.go
+++ b/internal/util/importutilv2/parquet/field_reader.go
@@ -234,7 +234,7 @@ func (c *FieldReader) Next(count int64) (any, any, error) {
 		return data, nil, err
 	case schemapb.DataType_ArrayOfVector:
 		if c.field.GetNullable() {
-			return nil, nil, merr.WrapErrParameterInvalidMsg("not support nullable in vector")
+			return nil, nil, merr.WrapErrImportFailed("ArrayOfVector does not support nullable")
 		}
 		data, err := ReadVectorArrayData(c, count)
 		return data, nil, err
@@ -919,11 +919,20 @@ func ReadNullableBinaryData(pcr *FieldReader, count int64) (any, []bool, error) 
 			}
 		case arrow.BINARY:
 			binaryReader := chunk.(*array.Binary)
+			expectedRowWidth, err := expectedVectorListLength(pcr.dim, dataType)
+			if err != nil {
+				return nil, nil, err
+			}
 			for i := 0; i < rows; i++ {
 				if binaryReader.IsNull(i) {
 					validData = append(validData, false)
 				} else {
-					data = append(data, binaryReader.Value(i)...)
+					value := binaryReader.Value(i)
+					if len(value) != int(expectedRowWidth) {
+						return nil, nil, merr.WrapErrImportFailed(fmt.Sprintf("vector row width mismatch: field %s, row %d, expected %d bytes but got %d bytes, data type: %s",
+							pcr.field.GetName(), len(validData), expectedRowWidth, len(value), dataType.String()))
+					}
+					data = append(data, value...)
 					validData = append(validData, true)
 				}
 			}
@@ -997,118 +1006,141 @@ func parseSparseFloatRowVector(str string) ([]byte, uint32, error) {
 // to return one-dim list. We use the start/end position of ValueOffsets() to get the correct sparse vector
 // from ListValues().
 // Note that arrow.Uint32.Value(int i) accepts an int32 value, the max length of indices/values is max value of int32
+func parseSparseFloatVectorStructRow(st map[string]arrow.Array, row int) ([]byte, uint32, error) {
+	indices, ok1 := st[sparseVectorIndice]
+	values, ok2 := st[sparseVectorValues]
+	if !ok1 || !ok2 {
+		return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: 'indices' or 'values' missed")
+	}
+
+	indicesList, ok1 := indices.(*array.List)
+	valuesList, ok2 := values.(*array.List)
+	if !ok1 || !ok2 {
+		return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: 'indices' or 'values' is not list")
+	}
+
+	// Len() is the number of rows in this row group
+	if indices.Len() != values.Len() {
+		msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: number of rows of 'indices' and 'values' mismatched, '%d' vs '%d'", indices.Len(), values.Len())
+		return nil, 0, merr.WrapErrImportFailed(msg)
+	}
+	if row < 0 || row >= indicesList.Len() {
+		msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: row index %d out of range, rows=%d", row, indicesList.Len())
+		return nil, 0, merr.WrapErrImportFailed(msg)
+	}
+	if indicesList.IsNull(row) || valuesList.IsNull(row) {
+		return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: 'indices' or 'values' is null for a valid sparse row")
+	}
+
+	// technically, DataType() of array.List must be arrow.ListType, but we still check here to ensure safety
+	indicesListType, ok1 := indicesList.DataType().(*arrow.ListType)
+	valuesListType, ok2 := valuesList.DataType().(*arrow.ListType)
+	if !ok1 || !ok2 {
+		return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: incorrect arrow type of 'indices' or 'values'")
+	}
+
+	indexDataType := indicesListType.Elem().ID()
+	valueDataType := valuesListType.Elem().ID()
+
+	// The array.Uint32/array.Int64/array.Float32/array.Float64 are derived from arrow.Array
+	// The ListValues() returns arrow.Array interface, but the arrow.Array doesn't have Value(int) interface
+	// To call array.Uint32.Value(int), we need to explicitly cast the ListValues() to array.Uint32
+	// So, we declare two methods here to avoid type casting in the "for" loop
+	type GetIndex func(position int) uint32
+	type GetValue func(position int) float32
+
+	var getIndexFunc GetIndex
+	switch indexDataType {
+	case arrow.INT32:
+		indicesList := indicesList.ListValues().(*array.Int32)
+		getIndexFunc = func(position int) uint32 {
+			return (uint32)(indicesList.Value(position))
+		}
+	case arrow.UINT32:
+		indicesList := indicesList.ListValues().(*array.Uint32)
+		getIndexFunc = func(position int) uint32 {
+			return indicesList.Value(position)
+		}
+	case arrow.INT64:
+		indicesList := indicesList.ListValues().(*array.Int64)
+		getIndexFunc = func(position int) uint32 {
+			return (uint32)(indicesList.Value(position))
+		}
+	case arrow.UINT64:
+		indicesList := indicesList.ListValues().(*array.Uint64)
+		getIndexFunc = func(position int) uint32 {
+			return (uint32)(indicesList.Value(position))
+		}
+	default:
+		msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: index type must be uint32/int32/uint64/int64 but actual type is '%s'", indicesListType.Elem().Name())
+		return nil, 0, merr.WrapErrImportFailed(msg)
+	}
+
+	var getValueFunc GetValue
+	switch valueDataType {
+	case arrow.FLOAT32:
+		valuesList := valuesList.ListValues().(*array.Float32)
+		getValueFunc = func(position int) float32 {
+			return valuesList.Value(position)
+		}
+	case arrow.FLOAT64:
+		valuesList := valuesList.ListValues().(*array.Float64)
+		getValueFunc = func(position int) float32 {
+			return (float32)(valuesList.Value(position))
+		}
+	default:
+		msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: value type must be float32 or float64 but actual type is '%s'", valuesListType.Elem().Name())
+		return nil, 0, merr.WrapErrImportFailed(msg)
+	}
+
+	start, end := indicesList.ValueOffsets(row)
+	start2, end2 := valuesList.ValueOffsets(row)
+	rowLen := (int)(end - start)
+	rowLenValues := (int)(end2 - start2)
+	if rowLenValues != rowLen {
+		msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: number of elements of 'indices' and 'values' mismatched, '%d' vs '%d'", rowLen, rowLenValues)
+		return nil, 0, merr.WrapErrImportFailed(msg)
+	}
+
+	rowIndices := make([]uint32, rowLen)
+	rowValues := make([]float32, rowLen)
+	for i := start; i < end; i++ {
+		rowIndices[i-start] = getIndexFunc((int)(i))
+		rowValues[i-start] = getValueFunc((int)(i))
+	}
+
+	// ensure the indices is sorted
+	sortedIndices, sortedValues := typeutil.SortSparseFloatRow(rowIndices, rowValues)
+	rowVec := typeutil.CreateSparseFloatRow(sortedIndices, sortedValues)
+	if err := typeutil.ValidateSparseFloatRows(rowVec); err != nil {
+		return nil, 0, err
+	}
+
+	maxDim := uint32(0)
+	// set the maxDim as the last value of sortedIndices since it has been sorted
+	if len(sortedIndices) > 0 {
+		maxDim = sortedIndices[len(sortedIndices)-1]
+	}
+	return rowVec, maxDim, nil // rowVec could be an empty sparse
+}
+
 func parseSparseFloatVectorStructs(structs []map[string]arrow.Array) ([][]byte, uint32, error) {
 	byteArr := make([][]byte, 0)
 	maxDim := uint32(0)
 	for _, st := range structs {
-		indices, ok1 := st[sparseVectorIndice]
-		values, ok2 := st[sparseVectorValues]
-		if !ok1 || !ok2 {
+		indices, ok := st[sparseVectorIndice]
+		if !ok {
 			return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: 'indices' or 'values' missed")
 		}
-
-		indicesList, ok1 := indices.(*array.List)
-		valuesList, ok2 := values.(*array.List)
-		if !ok1 || !ok2 {
-			return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: 'indices' or 'values' is not list")
-		}
-
-		// Len() is the number of rows in this row group
-		if indices.Len() != values.Len() {
-			msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: number of rows of 'indices' and 'values' mismatched, '%d' vs '%d'", indices.Len(), values.Len())
-			return nil, 0, merr.WrapErrImportFailed(msg)
-		}
-
-		// technically, DataType() of array.List must be arrow.ListType, but we still check here to ensure safety
-		indicesListType, ok1 := indicesList.DataType().(*arrow.ListType)
-		valuesListType, ok2 := valuesList.DataType().(*arrow.ListType)
-		if !ok1 || !ok2 {
-			return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: incorrect arrow type of 'indices' or 'values'")
-		}
-
-		indexDataType := indicesListType.Elem().ID()
-		valueDataType := valuesListType.Elem().ID()
-
-		// The array.Uint32/array.Int64/array.Float32/array.Float64 are derived from arrow.Array
-		// The ListValues() returns arrow.Array interface, but the arrow.Array doesn't have Value(int) interface
-		// To call array.Uint32.Value(int), we need to explicitly cast the ListValues() to array.Uint32
-		// So, we declare two methods here to avoid type casting in the "for" loop
-		type GetIndex func(position int) uint32
-		type GetValue func(position int) float32
-
-		var getIndexFunc GetIndex
-		switch indexDataType {
-		case arrow.INT32:
-			indicesList := indicesList.ListValues().(*array.Int32)
-			getIndexFunc = func(position int) uint32 {
-				return (uint32)(indicesList.Value(position))
-			}
-		case arrow.UINT32:
-			indicesList := indicesList.ListValues().(*array.Uint32)
-			getIndexFunc = func(position int) uint32 {
-				return indicesList.Value(position)
-			}
-		case arrow.INT64:
-			indicesList := indicesList.ListValues().(*array.Int64)
-			getIndexFunc = func(position int) uint32 {
-				return (uint32)(indicesList.Value(position))
-			}
-		case arrow.UINT64:
-			indicesList := indicesList.ListValues().(*array.Uint64)
-			getIndexFunc = func(position int) uint32 {
-				return (uint32)(indicesList.Value(position))
-			}
-		default:
-			msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: index type must be uint32/int32/uint64/int64 but actual type is '%s'", indicesListType.Elem().Name())
-			return nil, 0, merr.WrapErrImportFailed(msg)
-		}
-
-		var getValueFunc GetValue
-		switch valueDataType {
-		case arrow.FLOAT32:
-			valuesList := valuesList.ListValues().(*array.Float32)
-			getValueFunc = func(position int) float32 {
-				return valuesList.Value(position)
-			}
-		case arrow.FLOAT64:
-			valuesList := valuesList.ListValues().(*array.Float64)
-			getValueFunc = func(position int) float32 {
-				return (float32)(valuesList.Value(position))
-			}
-		default:
-			msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: value type must be float32 or float64 but actual type is '%s'", valuesListType.Elem().Name())
-			return nil, 0, merr.WrapErrImportFailed(msg)
-		}
-
-		for i := 0; i < indicesList.Len(); i++ {
-			start, end := indicesList.ValueOffsets(i)
-			start2, end2 := valuesList.ValueOffsets(i)
-			rowLen := (int)(end - start)
-			rowLenValues := (int)(end2 - start2)
-			if rowLenValues != rowLen {
-				msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: number of elements of 'indices' and 'values' mismatched, '%d' vs '%d'", rowLen, rowLenValues)
-				return nil, 0, merr.WrapErrImportFailed(msg)
-			}
-
-			rowIndices := make([]uint32, rowLen)
-			rowValues := make([]float32, rowLen)
-			for i := start; i < end; i++ {
-				rowIndices[i-start] = getIndexFunc((int)(i))
-				rowValues[i-start] = getValueFunc((int)(i))
-			}
-
-			// ensure the indices is sorted
-			sortedIndices, sortedValues := typeutil.SortSparseFloatRow(rowIndices, rowValues)
-			rowVec := typeutil.CreateSparseFloatRow(sortedIndices, sortedValues)
-			if err := typeutil.ValidateSparseFloatRows(rowVec); err != nil {
+		for i := 0; i < indices.Len(); i++ {
+			rowVec, rowMaxDim, err := parseSparseFloatVectorStructRow(st, i)
+			if err != nil {
 				return byteArr, maxDim, err
 			}
-
-			// set the maxDim as the last value of sortedIndices since it has been sorted
-			if len(sortedIndices) > 0 && sortedIndices[len(sortedIndices)-1] > maxDim {
-				maxDim = sortedIndices[len(sortedIndices)-1]
+			if rowMaxDim > maxDim {
+				maxDim = rowMaxDim
 			}
-			byteArr = append(byteArr, rowVec) // rowVec could be an empty sparse
+			byteArr = append(byteArr, rowVec)
 		}
 	}
 	return byteArr, maxDim, nil
@@ -1207,31 +1239,49 @@ func ReadNullableSparseFloatVectorData(pcr *FieldReader, count int64) (any, []bo
 		}, validData, nil
 	}
 
-	data, validData, err := ReadNullableStructData(pcr, count)
+	chunked, err := pcr.columnReader.NextBatch(count)
 	if err != nil {
 		return nil, nil, err
 	}
-	if data == nil {
+	if chunked == nil || len(chunked.Chunks()) == 0 {
 		return nil, nil, nil
 	}
 
 	// Sparse storage: only store valid rows' data
 	byteArr := make([][]byte, 0, count)
+	validData := make([]bool, 0, count)
 	maxDim := uint32(0)
 
-	for i, structData := range data {
-		if validData[i] {
-			singleByteArr, singleMaxDim, err := parseSparseFloatVectorStructs([]map[string]arrow.Array{structData})
+	for _, chunk := range chunked.Chunks() {
+		structReader, ok := chunk.(*array.Struct)
+		if !ok {
+			return nil, nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
+		}
+
+		structType := structReader.DataType().(*arrow.StructType)
+		st := make(map[string]arrow.Array)
+		for k, field := range structType.Fields() {
+			st[field.Name] = structReader.Field(k)
+		}
+
+		for i := 0; i < structReader.Len(); i++ {
+			valid := !structReader.IsNull(i)
+			validData = append(validData, valid)
+			if !valid {
+				continue
+			}
+			rowVec, rowMaxDim, err := parseSparseFloatVectorStructRow(st, i)
 			if err != nil {
 				return nil, nil, err
 			}
-			if len(singleByteArr) > 0 {
-				byteArr = append(byteArr, singleByteArr[0])
-				if singleMaxDim > maxDim {
-					maxDim = singleMaxDim
-				}
+			byteArr = append(byteArr, rowVec)
+			if rowMaxDim > maxDim {
+				maxDim = rowMaxDim
 			}
 		}
+	}
+	if len(validData) == 0 {
+		return nil, nil, nil
 	}
 
 	return &storage.SparseFloatVectorFieldData{
@@ -2083,4 +2133,8 @@ func ReadVectorArrayData(pcr *FieldReader, count int64) (any, error) {
 	}
 
 	return data, nil
+}
+
+func ReadNullableVectorArrayData(pcr *FieldReader, count int64) (any, []bool, error) {
+	return nil, nil, merr.WrapErrImportFailed("ArrayOfVector does not support nullable")
 }

--- a/internal/util/importutilv2/parquet/field_reader_test.go
+++ b/internal/util/importutilv2/parquet/field_reader_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/apache/arrow/go/v17/parquet/file"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
@@ -168,6 +169,111 @@ func TestParseSparseFloatRowVector(t *testing.T) {
 			} else {
 				assert.Empty(t, rowVec)
 			}
+		})
+	}
+}
+
+func TestReadNullableByteVectorBinaryRowsRejectWrongRowWidth(t *testing.T) {
+	tests := []struct {
+		name      string
+		dataType  schemapb.DataType
+		dim       string
+		firstRow  []byte
+		secondRow []byte
+	}{
+		{
+			name:      "binary_vector",
+			dataType:  schemapb.DataType_BinaryVector,
+			dim:       "16",
+			firstRow:  []byte{1},
+			secondRow: []byte{2, 3, 4},
+		},
+		{
+			name:      "float16_vector",
+			dataType:  schemapb.DataType_Float16Vector,
+			dim:       "2",
+			firstRow:  []byte{1, 2},
+			secondRow: []byte{3, 4, 5, 6, 7, 8},
+		},
+		{
+			name:      "bfloat16_vector",
+			dataType:  schemapb.DataType_BFloat16Vector,
+			dim:       "2",
+			firstRow:  []byte{1, 2},
+			secondRow: []byte{3, 4, 5, 6, 7, 8},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const (
+				pkFieldID  = int64(100)
+				vecFieldID = int64(101)
+				numRows    = int64(2)
+			)
+			schema := &schemapb.CollectionSchema{
+				Fields: []*schemapb.FieldSchema{
+					{
+						FieldID:      pkFieldID,
+						Name:         "pk",
+						DataType:     schemapb.DataType_Int64,
+						IsPrimaryKey: true,
+					},
+					{
+						FieldID:  vecFieldID,
+						Name:     "vec",
+						DataType: tt.dataType,
+						Nullable: true,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.DimKey, Value: tt.dim},
+						},
+					},
+				},
+			}
+
+			filePath := fmt.Sprintf("/tmp/test_nullable_byte_vector_binary_width_%s_%d.parquet", tt.name, rand.Int())
+			defer os.Remove(filePath)
+			wf, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o666)
+			require.NoError(t, err)
+
+			pqSchema := arrow.NewSchema([]arrow.Field{
+				{Name: "pk", Type: arrow.PrimitiveTypes.Int64},
+				{Name: "vec", Type: arrow.BinaryTypes.Binary, Nullable: true},
+			}, nil)
+			fw, err := pqarrow.NewFileWriter(pqSchema, wf,
+				parquet.NewWriterProperties(parquet.WithMaxRowGroupLength(numRows)),
+				pqarrow.DefaultWriterProps())
+			require.NoError(t, err)
+
+			pkBuilder := array.NewInt64Builder(memory.DefaultAllocator)
+			defer pkBuilder.Release()
+			pkBuilder.AppendValues([]int64{1, 2}, nil)
+			pkArr := pkBuilder.NewArray()
+			defer pkArr.Release()
+
+			vecBuilder := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+			defer vecBuilder.Release()
+			vecBuilder.Append(tt.firstRow)
+			vecBuilder.Append(tt.secondRow)
+			vecArr := vecBuilder.NewArray()
+			defer vecArr.Release()
+
+			recordBatch := array.NewRecord(pqSchema, []arrow.Array{pkArr, vecArr}, numRows)
+			defer recordBatch.Release()
+			require.NoError(t, fw.Write(recordBatch))
+			require.NoError(t, fw.Close())
+
+			ctx := context.Background()
+			f := storage.NewChunkManagerFactory("local", objectstorage.RootPath(testOutputPath))
+			cm, err := f.NewPersistentStorageChunkManager(ctx)
+			require.NoError(t, err)
+			reader, err := NewReader(ctx, cm, schema, filePath, 64*1024*1024)
+			require.NoError(t, err)
+			defer reader.Close()
+
+			_, err = reader.Read()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "vector row width mismatch")
 		})
 	}
 }
@@ -342,6 +448,129 @@ func TestParseSparseFloatVectorStructs(t *testing.T) {
 	isValidFunc(genUint64ArrList(indices), genFloat64ArrList(values))
 	isValidFunc(genInt64ArrList(indices), genFloat32ArrList(values))
 	isValidFunc(genInt64ArrList(indices), genFloat64ArrList(values))
+}
+
+func TestReadNullableSparseFloatVectorStructKeepsCompactRows(t *testing.T) {
+	rowA := typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1})
+	rowB := typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2})
+	rowC := typeutil.CreateSparseFloatRow([]uint32{3}, []float32{3})
+
+	tests := []struct {
+		name           string
+		validData      []bool
+		contents       [][]byte
+		rowGroupLength int64
+	}{
+		{
+			name:           "null_first",
+			validData:      []bool{false, true, true},
+			contents:       [][]byte{rowA, rowB},
+			rowGroupLength: 3,
+		},
+		{
+			name:           "valid_null_valid",
+			validData:      []bool{true, false, true},
+			contents:       [][]byte{rowA, rowB},
+			rowGroupLength: 3,
+		},
+		{
+			name:           "all_null",
+			validData:      []bool{false, false},
+			contents:       [][]byte{},
+			rowGroupLength: 2,
+		},
+		{
+			name:           "multi_row_group",
+			validData:      []bool{true, false, true, false, true},
+			contents:       [][]byte{rowA, rowB, rowC},
+			rowGroupLength: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkNullableSparseFloatVectorStructRead(t, tt.validData, tt.contents, tt.rowGroupLength)
+		})
+	}
+}
+
+func checkNullableSparseFloatVectorStructRead(t *testing.T, validData []bool, contents [][]byte, rowGroupLength int64) {
+	const (
+		pkFieldID     = int64(100)
+		sparseFieldID = int64(101)
+	)
+
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: pkFieldID, Name: "pk", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: sparseFieldID, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, Nullable: true},
+		},
+	}
+	sparseFields := []arrow.Field{
+		{Name: sparseVectorIndice, Type: arrow.ListOf(&arrow.Uint32Type{})},
+		{Name: sparseVectorValues, Type: arrow.ListOf(&arrow.Float32Type{})},
+	}
+	pqSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "pk", Type: &arrow.Int64Type{}},
+		{Name: "sparse", Type: arrow.StructOf(sparseFields...), Nullable: true},
+	}, nil)
+
+	numRows := int64(len(validData))
+	filePath := fmt.Sprintf("/tmp/test_%d_nullable_sparse_struct_reader.parquet", rand.Int())
+	defer os.Remove(filePath)
+	wf, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o666)
+	require.NoError(t, err)
+	defer wf.Close()
+	fw, err := pqarrow.NewFileWriter(pqSchema, wf,
+		parquet.NewWriterProperties(parquet.WithMaxRowGroupLength(rowGroupLength)), pqarrow.DefaultWriterProps())
+	require.NoError(t, err)
+
+	mem := memory.NewGoAllocator()
+	pkBuilder := array.NewInt64Builder(mem)
+	pks := make([]int64, len(validData))
+	for i := range pks {
+		pks[i] = int64(i + 1)
+	}
+	pkBuilder.AppendValues(pks, nil)
+	pkArray := pkBuilder.NewArray()
+	defer pkArray.Release()
+	pkBuilder.Release()
+
+	sparseArray, err := testutil.BuildSparseVectorData(mem, contents, pqSchema.Field(1).Type, validData)
+	require.NoError(t, err)
+	defer sparseArray.Release()
+
+	recordBatch := array.NewRecord(pqSchema, []arrow.Array{pkArray, sparseArray}, numRows)
+	require.NoError(t, fw.Write(recordBatch))
+	recordBatch.Release()
+	require.NoError(t, fw.Close())
+
+	ctx := context.Background()
+	f := storage.NewChunkManagerFactory("local", objectstorage.RootPath(testOutputPath))
+	cm, err := f.NewPersistentStorageChunkManager(ctx)
+	require.NoError(t, err)
+	reader, err := NewReader(ctx, cm, schema, filePath, 64*1024*1024)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	gotInsertData, err := reader.Read()
+	require.NoError(t, err)
+	gotSparse := gotInsertData.Data[sparseFieldID].(*storage.SparseFloatVectorFieldData)
+	require.Equal(t, validData, gotSparse.ValidData)
+	require.Len(t, gotSparse.GetContents(), len(contents))
+	if len(contents) > 0 {
+		require.Equal(t, contents, gotSparse.GetContents())
+	}
+
+	physicalIdx := 0
+	for rowIdx, valid := range validData {
+		if !valid {
+			require.Nil(t, gotSparse.GetRow(rowIdx))
+			continue
+		}
+		require.Equal(t, contents[physicalIdx], gotSparse.GetRow(rowIdx))
+		physicalIdx++
+	}
 }
 
 func TestReadFieldData(t *testing.T) {
@@ -851,4 +1080,86 @@ func TestArrayNullElement(t *testing.T) {
 			checkFunc(tt.dataType, tt.elementType)
 		})
 	}
+}
+
+func TestStructFieldReader_toScalarField_TypeMismatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		elementType schemapb.DataType
+		data        []interface{}
+	}{
+		{"Bool_wrong_type", schemapb.DataType_Bool, []interface{}{"not_a_bool"}},
+		{"Int8_wrong_type", schemapb.DataType_Int8, []interface{}{"not_an_int8"}},
+		{"Int16_wrong_type", schemapb.DataType_Int16, []interface{}{3.14}},
+		{"Int32_wrong_type", schemapb.DataType_Int32, []interface{}{true}},
+		{"Int64_wrong_type", schemapb.DataType_Int64, []interface{}{"not_an_int64"}},
+		{"Float_wrong_type", schemapb.DataType_Float, []interface{}{int32(1)}},
+		{"Double_wrong_type", schemapb.DataType_Double, []interface{}{int64(1)}},
+		{"VarChar_wrong_type", schemapb.DataType_VarChar, []interface{}{123}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := &StructFieldReader{
+				field: &schemapb.FieldSchema{
+					Name:        "test_field",
+					DataType:    schemapb.DataType_Array,
+					ElementType: tt.elementType,
+				},
+			}
+			_, err := reader.toScalarField(tt.data)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "expected")
+		})
+	}
+}
+
+func TestStructFieldReader_NullableArrayOfVector(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	structType := arrow.StructOf(arrow.Field{
+		Name:     "vector_array",
+		Type:     arrow.ListOf(arrow.PrimitiveTypes.Float32),
+		Nullable: true,
+	})
+	listBuilder := array.NewListBuilder(mem, structType)
+	structBuilder := listBuilder.ValueBuilder().(*array.StructBuilder)
+	vectorBuilder := structBuilder.FieldBuilder(0).(*array.ListBuilder)
+	floatBuilder := vectorBuilder.ValueBuilder().(*array.Float32Builder)
+
+	appendVector := func(values ...float32) {
+		vectorBuilder.Append(true)
+		floatBuilder.AppendValues(values, nil)
+		structBuilder.Append(true)
+	}
+	listBuilder.Append(true)
+	appendVector(1, 2, 3, 4)
+	appendVector(5, 6, 7, 8)
+	listBuilder.Append(false)
+	listBuilder.Append(true)
+	appendVector(9, 10, 11, 12)
+
+	arr := listBuilder.NewArray()
+	listBuilder.Release()
+	defer arr.Release()
+
+	chunked := arrow.NewChunked(arr.DataType(), []arrow.Array{arr})
+	defer chunked.Release()
+
+	reader := &StructFieldReader{
+		field: &schemapb.FieldSchema{
+			Name:        "struct_array[vector_array]",
+			DataType:    schemapb.DataType_ArrayOfVector,
+			ElementType: schemapb.DataType_FloatVector,
+			Nullable:    true,
+			TypeParams: []*commonpb.KeyValuePair{
+				{Key: common.MaxCapacityKey, Value: "20"},
+			},
+		},
+		fieldIndex: 0,
+		dim:        4,
+	}
+
+	_, _, err := reader.readArrayOfVectorField(chunked)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ArrayOfVector does not support nullable")
 }

--- a/internal/util/importutilv2/parquet/struct_field_reader.go
+++ b/internal/util/importutilv2/parquet/struct_field_reader.go
@@ -110,6 +110,8 @@ func (r *StructFieldReader) toScalarField(data []interface{}) (*schemapb.ScalarF
 		for i, v := range data {
 			if val, ok := v.(bool); ok {
 				boolData[i] = val
+			} else {
+				return nil, merr.WrapErrImportFailed(fmt.Sprintf("expected bool for field '%s' but got %T", r.field.GetName(), v))
 			}
 		}
 		return &schemapb.ScalarField{
@@ -122,6 +124,8 @@ func (r *StructFieldReader) toScalarField(data []interface{}) (*schemapb.ScalarF
 		for i, v := range data {
 			if val, ok := v.(int8); ok {
 				intData[i] = int32(val)
+			} else {
+				return nil, merr.WrapErrImportFailed(fmt.Sprintf("expected int8 for field '%s' but got %T", r.field.GetName(), v))
 			}
 		}
 		return &schemapb.ScalarField{
@@ -134,6 +138,8 @@ func (r *StructFieldReader) toScalarField(data []interface{}) (*schemapb.ScalarF
 		for i, v := range data {
 			if val, ok := v.(int16); ok {
 				intData[i] = int32(val)
+			} else {
+				return nil, merr.WrapErrImportFailed(fmt.Sprintf("expected int16 for field '%s' but got %T", r.field.GetName(), v))
 			}
 		}
 		return &schemapb.ScalarField{
@@ -146,6 +152,8 @@ func (r *StructFieldReader) toScalarField(data []interface{}) (*schemapb.ScalarF
 		for i, v := range data {
 			if val, ok := v.(int32); ok {
 				intData[i] = val
+			} else {
+				return nil, merr.WrapErrImportFailed(fmt.Sprintf("expected int32 for field '%s' but got %T", r.field.GetName(), v))
 			}
 		}
 		return &schemapb.ScalarField{
@@ -158,6 +166,8 @@ func (r *StructFieldReader) toScalarField(data []interface{}) (*schemapb.ScalarF
 		for i, v := range data {
 			if val, ok := v.(int64); ok {
 				intData[i] = val
+			} else {
+				return nil, merr.WrapErrImportFailed(fmt.Sprintf("expected int64 for field '%s' but got %T", r.field.GetName(), v))
 			}
 		}
 		return &schemapb.ScalarField{
@@ -170,6 +180,8 @@ func (r *StructFieldReader) toScalarField(data []interface{}) (*schemapb.ScalarF
 		for i, v := range data {
 			if val, ok := v.(float32); ok {
 				floatData[i] = val
+			} else {
+				return nil, merr.WrapErrImportFailed(fmt.Sprintf("expected float32 for field '%s' but got %T", r.field.GetName(), v))
 			}
 		}
 		return &schemapb.ScalarField{
@@ -182,6 +194,8 @@ func (r *StructFieldReader) toScalarField(data []interface{}) (*schemapb.ScalarF
 		for i, v := range data {
 			if val, ok := v.(float64); ok {
 				floatData[i] = val
+			} else {
+				return nil, merr.WrapErrImportFailed(fmt.Sprintf("expected float64 for field '%s' but got %T", r.field.GetName(), v))
 			}
 		}
 		return &schemapb.ScalarField{
@@ -194,6 +208,8 @@ func (r *StructFieldReader) toScalarField(data []interface{}) (*schemapb.ScalarF
 		for i, v := range data {
 			if val, ok := v.(string); ok {
 				strData[i] = val
+			} else {
+				return nil, merr.WrapErrImportFailed(fmt.Sprintf("expected string for field '%s' but got %T", r.field.GetName(), v))
 			}
 		}
 		return &schemapb.ScalarField{
@@ -279,6 +295,9 @@ func (r *StructFieldReader) readArrayField(chunked *arrow.Chunked) (any, any, er
 }
 
 func (r *StructFieldReader) readArrayOfVectorField(chunked *arrow.Chunked) (any, any, error) {
+	if r.field.GetNullable() {
+		return nil, nil, merr.WrapErrImportFailed("ArrayOfVector does not support nullable")
+	}
 	var result []*schemapb.VectorField
 
 	for _, chunk := range chunked.Chunks() {

--- a/internal/util/indexcgowrapper/index.go
+++ b/internal/util/indexcgowrapper/index.go
@@ -54,6 +54,12 @@ type CgoIndex struct {
 	close    bool
 }
 
+var (
+	emptyFloatVectorPayload = []float32{0}
+	emptyByteVectorPayload  = []byte{0}
+	emptyInt8VectorPayload  = []int8{0}
+)
+
 // used only in test
 // TODO: use proto.Marshal instead of proto.MarshalTextString for better compatibility.
 func NewCgoIndex(dtype schemapb.DataType, typeParams, indexParams map[string]string) (CodecIndex, error) {
@@ -214,6 +220,8 @@ func (index *CgoIndex) Build(dataset *Dataset) error {
 		return index.buildBinaryVecIndex(dataset)
 	case schemapb.DataType_Int8Vector:
 		return index.buildInt8VecIndex(dataset)
+	case schemapb.DataType_SparseFloatVector:
+		return index.buildSparseFloatVecIndex(dataset)
 	case schemapb.DataType_Bool:
 		return index.buildBoolIndex(dataset)
 	case schemapb.DataType_Int8:
@@ -237,18 +245,56 @@ func (index *CgoIndex) Build(dataset *Dataset) error {
 	}
 }
 
+func cFloatPtr(data []float32) *C.float {
+	if len(data) == 0 {
+		return (*C.float)(&emptyFloatVectorPayload[0])
+	}
+	return (*C.float)(&data[0])
+}
+
+func cUint8Ptr(data []byte) *C.uint8_t {
+	if len(data) == 0 {
+		return (*C.uint8_t)(&emptyByteVectorPayload[0])
+	}
+	return (*C.uint8_t)(&data[0])
+}
+
+func cInt8Ptr(data []int8) *C.int8_t {
+	if len(data) == 0 {
+		return (*C.int8_t)(&emptyInt8VectorPayload[0])
+	}
+	return (*C.int8_t)(&data[0])
+}
+
+func cBoolPtr(data []bool) *C.bool {
+	if len(data) == 0 {
+		return nil
+	}
+	return (*C.bool)(&data[0])
+}
+
+func validCount(validData []bool) int64 {
+	count := int64(0)
+	for _, valid := range validData {
+		if valid {
+			count++
+		}
+	}
+	return count
+}
+
 func (index *CgoIndex) buildFloatVecIndex(dataset *Dataset) error {
 	vectors := dataset.Data[keyRawArr].([]float32)
 	if validData, ok := dataset.Data[keyValidArr].([]bool); ok && len(validData) > 0 {
 		status := C.BuildFloatVecIndexWithValidData(
 			index.indexPtr,
 			(C.int64_t)(len(vectors)),
-			(*C.float)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cFloatPtr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build float vector index with valid data")
 	}
-	status := C.BuildFloatVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (*C.float)(&vectors[0]))
+	status := C.BuildFloatVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), cFloatPtr(vectors))
 	return HandleCStatus(&status, "failed to build float vector index")
 }
 
@@ -258,12 +304,12 @@ func (index *CgoIndex) buildFloat16VecIndex(dataset *Dataset) error {
 		status := C.BuildFloat16VecIndexWithValidData(
 			index.indexPtr,
 			(C.int64_t)(len(vectors)),
-			(*C.uint8_t)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cUint8Ptr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build float16 vector index with valid data")
 	}
-	status := C.BuildFloat16VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (*C.uint8_t)(&vectors[0]))
+	status := C.BuildFloat16VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), cUint8Ptr(vectors))
 	return HandleCStatus(&status, "failed to build float16 vector index")
 }
 
@@ -273,28 +319,35 @@ func (index *CgoIndex) buildBFloat16VecIndex(dataset *Dataset) error {
 		status := C.BuildBFloat16VecIndexWithValidData(
 			index.indexPtr,
 			(C.int64_t)(len(vectors)),
-			(*C.uint8_t)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cUint8Ptr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build bfloat16 vector index with valid data")
 	}
-	status := C.BuildBFloat16VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (*C.uint8_t)(&vectors[0]))
+	status := C.BuildBFloat16VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), cUint8Ptr(vectors))
 	return HandleCStatus(&status, "failed to build bfloat16 vector index")
 }
 
 func (index *CgoIndex) buildSparseFloatVecIndex(dataset *Dataset) error {
-	vectors := dataset.Data[keyRawArr].([]byte)
+	vectors, _ := dataset.Data[keyRawArr].([]byte)
 	if validData, ok := dataset.Data[keyValidArr].([]bool); ok && len(validData) > 0 {
+		validRows := validCount(validData)
+		if validRows > 0 && len(vectors) == 0 {
+			return fmt.Errorf("sparse float vector cgo build requires encoded sparse rows")
+		}
 		status := C.BuildSparseFloatVecIndexWithValidData(
 			index.indexPtr,
-			(C.int64_t)(len(validData)),
+			(C.int64_t)(validRows),
 			(C.int64_t)(0),
-			(*C.uint8_t)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cUint8Ptr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build sparse float vector index with valid data")
 	}
-	status := C.BuildSparseFloatVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (C.int64_t)(0), (*C.uint8_t)(&vectors[0]))
+	if len(vectors) == 0 {
+		return fmt.Errorf("sparse float vector cgo build requires encoded sparse rows")
+	}
+	status := C.BuildSparseFloatVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (C.int64_t)(0), cUint8Ptr(vectors))
 	return HandleCStatus(&status, "failed to build sparse float vector index")
 }
 
@@ -304,12 +357,12 @@ func (index *CgoIndex) buildBinaryVecIndex(dataset *Dataset) error {
 		status := C.BuildBinaryVecIndexWithValidData(
 			index.indexPtr,
 			(C.int64_t)(len(vectors)),
-			(*C.uint8_t)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cUint8Ptr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build binary vector index with valid data")
 	}
-	status := C.BuildBinaryVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (*C.uint8_t)(&vectors[0]))
+	status := C.BuildBinaryVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), cUint8Ptr(vectors))
 	return HandleCStatus(&status, "failed to build binary vector index")
 }
 
@@ -319,12 +372,12 @@ func (index *CgoIndex) buildInt8VecIndex(dataset *Dataset) error {
 		status := C.BuildInt8VecIndexWithValidData(
 			index.indexPtr,
 			(C.int64_t)(len(vectors)),
-			(*C.int8_t)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cInt8Ptr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build int8 vector index with valid data")
 	}
-	status := C.BuildInt8VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (*C.int8_t)(&vectors[0]))
+	status := C.BuildInt8VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), cInt8Ptr(vectors))
 	return HandleCStatus(&status, "failed to build int8 vector index")
 }
 

--- a/internal/util/indexcgowrapper/index_test.go
+++ b/internal/util/indexcgowrapper/index_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/pkg/v2/common"
@@ -240,6 +241,105 @@ func TestCIndex_BuildInt8VecIndex(t *testing.T) {
 
 		err = index.Delete()
 		assert.Equal(t, err, nil)
+	}
+}
+
+func TestCIndex_BuildAllNullNullableVectorsDoesNotPanic(t *testing.T) {
+	type testCase struct {
+		name   string
+		dtype  schemapb.DataType
+		raw    any
+		params func() (map[string]string, map[string]string)
+	}
+
+	cases := []testCase{
+		{
+			name:  "float",
+			dtype: schemapb.DataType_FloatVector,
+			raw:   []float32{},
+			params: func() (map[string]string, map[string]string) {
+				return generateParams(IndexFaissIDMap, metric.L2)
+			},
+		},
+		{
+			name:  "binary",
+			dtype: schemapb.DataType_BinaryVector,
+			raw:   []byte{},
+			params: func() (map[string]string, map[string]string) {
+				return generateParams(IndexFaissBinIDMap, metric.JACCARD)
+			},
+		},
+		{
+			name:  "float16",
+			dtype: schemapb.DataType_Float16Vector,
+			raw:   []byte{},
+			params: func() (map[string]string, map[string]string) {
+				return generateParams(IndexFaissIDMap, metric.L2)
+			},
+		},
+		{
+			name:  "bfloat16",
+			dtype: schemapb.DataType_BFloat16Vector,
+			raw:   []byte{},
+			params: func() (map[string]string, map[string]string) {
+				return generateParams(IndexFaissIDMap, metric.L2)
+			},
+		},
+		{
+			name:  "int8",
+			dtype: schemapb.DataType_Int8Vector,
+			raw:   []int8{},
+			params: func() (map[string]string, map[string]string) {
+				return generateParams(IndexHNSW, metric.L2)
+			},
+		},
+		{
+			name:  "sparse",
+			dtype: schemapb.DataType_SparseFloatVector,
+			raw:   []byte{},
+			params: func() (map[string]string, map[string]string) {
+				return map[string]string{}, map[string]string{
+					common.IndexTypeKey:  "SPARSE_INVERTED_INDEX",
+					common.MetricTypeKey: metric.IP,
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			typeParams, indexParams := tc.params()
+			index, err := NewCgoIndex(tc.dtype, typeParams, indexParams)
+			require.NoError(t, err)
+			require.NotNil(t, index)
+			defer func() {
+				require.NoError(t, index.Delete())
+			}()
+
+			dataset := &Dataset{
+				DType: tc.dtype,
+				Data: map[string]any{
+					keyRawArr:   tc.raw,
+					keyValidArr: []bool{false, false, false},
+				},
+			}
+			require.NotPanics(t, func() {
+				err = index.Build(dataset)
+			})
+			require.NoError(t, err)
+
+			blobs, err := index.Serialize()
+			require.NoError(t, err)
+			require.NotEmpty(t, blobs)
+
+			copyIndex, err := NewCgoIndex(tc.dtype, typeParams, indexParams)
+			require.NoError(t, err)
+			require.NotNil(t, copyIndex)
+			defer func() {
+				require.NoError(t, copyIndex.Delete())
+			}()
+			require.NoError(t, copyIndex.Load(blobs))
+		})
 	}
 }
 

--- a/internal/util/testutil/test_util.go
+++ b/internal/util/testutil/test_util.go
@@ -464,17 +464,18 @@ func BuildSparseVectorData(mem *memory.GoAllocator, contents [][]byte, arrowType
 		for i := 0; i < logicalRows; i++ {
 			isValid := len(validData) == 0 || validData[i]
 			builder.Append(isValid)
-			indicesBuilder.Append(isValid)
-			valuesBuilder.Append(isValid)
-			if isValid {
-				rowVecData := contents[physicalIdx]
-				elemCount := len(rowVecData) / 8
-				for j := 0; j < elemCount; j++ {
-					appendIndexFunc(common.Endian.Uint32(rowVecData[j*8:]))
-					appendValueFunc(math.Float32frombits(common.Endian.Uint32(rowVecData[j*8+4:])))
-				}
-				physicalIdx++
+			if !isValid {
+				continue
 			}
+			indicesBuilder.Append(true)
+			valuesBuilder.Append(true)
+			rowVecData := contents[physicalIdx]
+			elemCount := len(rowVecData) / 8
+			for j := 0; j < elemCount; j++ {
+				appendIndexFunc(common.Endian.Uint32(rowVecData[j*8:]))
+				appendValueFunc(math.Float32frombits(common.Endian.Uint32(rowVecData[j*8+4:])))
+			}
+			physicalIdx++
 		}
 		return builder.NewStructArray(), nil
 	}

--- a/pkg/mq/msgstream/msg_test.go
+++ b/pkg/mq/msgstream/msg_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 func TestBaseMsg(t *testing.T) {
@@ -209,6 +210,110 @@ func TestInsertMsg_CheckAligned(t *testing.T) {
 
 	msg1.Version = msgpb.InsertDataVersion_ColumnBased
 	assert.NoError(t, msg1.CheckAligned())
+}
+
+func TestInsertMsg_CheckAlignedRejectsNullableVectorNonCompactData(t *testing.T) {
+	validData := []bool{true, false, true}
+	testCases := []struct {
+		name      string
+		fieldData *schemapb.FieldData
+	}{
+		{
+			name: "float_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_FloatVector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+						Data: []float32{1, 2, 0, 0, 3, 4},
+					}},
+				}},
+			},
+		},
+		{
+			name: "binary_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_BinaryVector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  8,
+					Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 0, 2}},
+				}},
+			},
+		},
+		{
+			name: "float16_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_Float16Vector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2, 3, 4, 0, 0, 0, 0, 5, 6, 7, 8}},
+				}},
+			},
+		},
+		{
+			name: "bfloat16_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_BFloat16Vector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{1, 2, 3, 4, 0, 0, 0, 0, 5, 6, 7, 8}},
+				}},
+			},
+		},
+		{
+			name: "sparse_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_SparseFloatVector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{
+							typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1}),
+							typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2}),
+							typeutil.CreateSparseFloatRow([]uint32{3}, []float32{3}),
+						},
+					}},
+				}},
+			},
+		},
+		{
+			name: "int8_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_Int8Vector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{1, 2, 0, 0, 3, 4}},
+				}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					Timestamps: []uint64{1, 2, 3},
+					RowIDs:     []int64{1, 2, 3},
+					FieldsData: []*schemapb.FieldData{tc.fieldData},
+					NumRows:    3,
+					Version:    msgpb.InsertDataVersion_ColumnBased,
+				},
+			}
+
+			assert.Error(t, msg.CheckAligned())
+		})
+	}
 }
 
 func TestInsertMsg_IndexMsg(t *testing.T) {

--- a/pkg/util/funcutil/func.go
+++ b/pkg/util/funcutil/func.go
@@ -389,10 +389,11 @@ func GetNumRowsOfFloat16VectorField(f16Datas []byte, dim int64) (uint64, error) 
 		return 0, fmt.Errorf("dim(%d) should be greater than 0", dim)
 	}
 	l := len(f16Datas)
-	if int64(l)%dim != 0 {
-		return 0, fmt.Errorf("the length(%d) of float16 data should divide the dim(%d)", l, dim)
+	rowWidth := dim * 2
+	if int64(l)%rowWidth != 0 {
+		return 0, fmt.Errorf("the length(%d) of float16 data should divide the row width(%d)", l, rowWidth)
 	}
-	return uint64((int64(l)) / dim / 2), nil
+	return uint64(int64(l) / rowWidth), nil
 }
 
 func GetNumRowsOfBFloat16VectorField(bf16Datas []byte, dim int64) (uint64, error) {
@@ -400,10 +401,11 @@ func GetNumRowsOfBFloat16VectorField(bf16Datas []byte, dim int64) (uint64, error
 		return 0, fmt.Errorf("dim(%d) should be greater than 0", dim)
 	}
 	l := len(bf16Datas)
-	if int64(l)%dim != 0 {
-		return 0, fmt.Errorf("the length(%d) of bfloat data should divide the dim(%d)", l, dim)
+	rowWidth := dim * 2
+	if int64(l)%rowWidth != 0 {
+		return 0, fmt.Errorf("the length(%d) of bfloat data should divide the row width(%d)", l, rowWidth)
 	}
-	return uint64((int64(l)) / dim / 2), nil
+	return uint64(int64(l) / rowWidth), nil
 }
 
 func GetNumRowsOfInt8VectorField(iDatas []byte, dim int64) (uint64, error) {
@@ -417,6 +419,94 @@ func GetNumRowsOfInt8VectorField(iDatas []byte, dim int64) (uint64, error) {
 	return uint64(int64(l) / dim), nil
 }
 
+func CountValidRows(validData []bool) uint64 {
+	validRows := uint64(0)
+	for _, valid := range validData {
+		if valid {
+			validRows++
+		}
+	}
+	return validRows
+}
+
+func GetVectorFieldPhysicalRows(fieldName string, dataType schemapb.DataType, vectors *schemapb.VectorField) (uint64, error) {
+	if vectors == nil {
+		return 0, fmt.Errorf("nullable vector field %s requires vector data", fieldName)
+	}
+
+	return getVectorFieldPhysicalRowsWithDim(fieldName, dataType, vectors, vectors.GetDim())
+}
+
+func getVectorFieldPhysicalRowsWithDim(fieldName string, dataType schemapb.DataType, vectors *schemapb.VectorField, dim int64) (uint64, error) {
+	switch dataType {
+	case schemapb.DataType_FloatVector:
+		return GetNumRowsOfFloatVectorField(vectors.GetFloatVector().GetData(), dim)
+	case schemapb.DataType_BinaryVector:
+		return GetNumRowsOfBinaryVectorField(vectors.GetBinaryVector(), dim)
+	case schemapb.DataType_Float16Vector:
+		return GetNumRowsOfFloat16VectorField(vectors.GetFloat16Vector(), dim)
+	case schemapb.DataType_BFloat16Vector:
+		return GetNumRowsOfBFloat16VectorField(vectors.GetBfloat16Vector(), dim)
+	case schemapb.DataType_SparseFloatVector:
+		if vectors.GetSparseFloatVector() == nil {
+			return 0, nil
+		}
+		return uint64(len(vectors.GetSparseFloatVector().GetContents())), nil
+	case schemapb.DataType_Int8Vector:
+		return GetNumRowsOfInt8VectorField(vectors.GetInt8Vector(), dim)
+	default:
+		return 0, fmt.Errorf("unsupported nullable vector type %s", dataType)
+	}
+}
+
+func ValidateNullableVectorCompactRows(fieldName string, validData []bool, physicalRows uint64, logicalRows uint64, requireValidData bool) error {
+	if len(validData) == 0 {
+		if requireValidData {
+			return fmt.Errorf("nullable vector field %s requires valid_data", fieldName)
+		}
+		return nil
+	}
+	if logicalRows > 0 && uint64(len(validData)) != logicalRows {
+		return fmt.Errorf("nullable vector field %s valid_data length mismatch: valid_data=%d, logical rows=%d", fieldName, len(validData), logicalRows)
+	}
+	validRows := CountValidRows(validData)
+	if physicalRows != validRows {
+		return fmt.Errorf("nullable vector field %s requires compact payload: valid rows=%d, physical payload rows=%d", fieldName, validRows, physicalRows)
+	}
+	return nil
+}
+
+func ValidateNullableVectorFieldDataCompact(fieldData *schemapb.FieldData, logicalRows uint64, requireValidData bool) error {
+	if fieldData == nil || !typeutil.IsSupportedNullableVectorType(fieldData.GetType()) {
+		return nil
+	}
+	if len(fieldData.GetValidData()) == 0 && !requireValidData {
+		return nil
+	}
+	physicalRows, err := GetVectorFieldPhysicalRows(fieldData.GetFieldName(), fieldData.GetType(), fieldData.GetVectors())
+	if err != nil {
+		return err
+	}
+	return ValidateNullableVectorCompactRows(fieldData.GetFieldName(), fieldData.GetValidData(), physicalRows, logicalRows, requireValidData)
+}
+
+func ValidateNullableVectorFieldDataCompactWithDim(fieldData *schemapb.FieldData, logicalRows uint64, requireValidData bool, dim int64) error {
+	if fieldData == nil || fieldData.GetVectors() == nil || fieldData.GetVectors().GetDim() != 0 || dim <= 0 {
+		return ValidateNullableVectorFieldDataCompact(fieldData, logicalRows, requireValidData)
+	}
+	if !typeutil.IsSupportedNullableVectorType(fieldData.GetType()) {
+		return nil
+	}
+	if len(fieldData.GetValidData()) == 0 && !requireValidData {
+		return nil
+	}
+	physicalRows, err := getVectorFieldPhysicalRowsWithDim(fieldData.GetFieldName(), fieldData.GetType(), fieldData.GetVectors(), dim)
+	if err != nil {
+		return err
+	}
+	return ValidateNullableVectorCompactRows(fieldData.GetFieldName(), fieldData.GetValidData(), physicalRows, logicalRows, requireValidData)
+}
+
 // GetNumRowOfFieldDataWithSchema returns num of rows with schema specification.
 func GetNumRowOfFieldDataWithSchema(fieldData *schemapb.FieldData, helper *typeutil.SchemaHelper) (uint64, error) {
 	var fieldNumRows uint64
@@ -424,6 +514,19 @@ func GetNumRowOfFieldDataWithSchema(fieldData *schemapb.FieldData, helper *typeu
 	fieldSchema, err := helper.GetFieldFromName(fieldData.GetFieldName())
 	if err != nil {
 		return 0, err
+	}
+	if len(fieldData.GetValidData()) > 0 && typeutil.IsSupportedNullableVectorType(fieldSchema.GetDataType()) {
+		dim := fieldData.GetVectors().GetDim()
+		if dim == 0 && fieldSchema.GetDataType() != schemapb.DataType_SparseFloatVector {
+			dim, err = typeutil.GetDim(fieldSchema)
+			if err != nil {
+				return 0, err
+			}
+		}
+		if err := ValidateNullableVectorFieldDataCompactWithDim(fieldData, uint64(len(fieldData.GetValidData())), false, dim); err != nil {
+			return 0, err
+		}
+		return uint64(len(fieldData.GetValidData())), nil
 	}
 	switch fieldSchema.GetDataType() {
 	case schemapb.DataType_Bool:
@@ -510,10 +613,9 @@ func GetNumRowOfFieldDataWithSchema(fieldData *schemapb.FieldData, helper *typeu
 		}
 	case schemapb.DataType_ArrayOfVector:
 		if len(fieldData.GetValidData()) > 0 {
-			fieldNumRows = uint64(len(fieldData.GetValidData()))
-		} else {
-			fieldNumRows = getNumRowsOfArrayVectorField(fieldData.GetVectors().GetVectorArray().GetData())
+			return 0, fmt.Errorf("ArrayOfVector does not support nullable, field: %s", fieldData.GetFieldName())
 		}
+		fieldNumRows = getNumRowsOfArrayVectorField(fieldData.GetVectors().GetVectorArray().GetData())
 	default:
 		return 0, fmt.Errorf("%s is not supported now", fieldSchema.GetDataType())
 	}
@@ -553,10 +655,16 @@ func GetNumRowOfFieldData(fieldData *schemapb.FieldData) (uint64, error) {
 			return 0, fmt.Errorf("%s is not supported now", scalarType)
 		}
 	case *schemapb.FieldData_Vectors:
+		vectorField := fieldData.GetVectors()
+		if _, ok := vectorField.GetData().(*schemapb.VectorField_VectorArray); ok && len(fieldData.GetValidData()) > 0 {
+			return 0, fmt.Errorf("ArrayOfVector does not support nullable, field: %s", fieldData.GetFieldName())
+		}
 		if len(fieldData.GetValidData()) > 0 {
+			if err := ValidateNullableVectorFieldDataCompact(fieldData, uint64(len(fieldData.GetValidData())), false); err != nil {
+				return 0, err
+			}
 			return uint64(len(fieldData.GetValidData())), nil
 		}
-		vectorField := fieldData.GetVectors()
 		switch vectorFieldType := vectorField.Data.(type) {
 		case *schemapb.VectorField_FloatVector:
 			dim := vectorField.GetDim()

--- a/pkg/util/funcutil/func_test.go
+++ b/pkg/util/funcutil/func_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	grpcCodes "google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
@@ -336,6 +337,7 @@ func TestGetNumRowsOfFloat16VectorField(t *testing.T) {
 		{[]byte{}, 128, 0, true},
 		{[]byte{1.0, 2.0}, 1, 1, true},
 		{[]byte{1.0, 2.0, 3.0, 4.0}, 2, 1, true},
+		{[]byte{1.0, 2.0}, 2, 0, false}, // length % (dim * 2) != 0
 	}
 
 	for _, test := range cases {
@@ -364,6 +366,7 @@ func TestGetNumRowsOfBFloat16VectorField(t *testing.T) {
 		{[]byte{}, 128, 0, true},
 		{[]byte{1.0, 2.0}, 1, 1, true},
 		{[]byte{1.0, 2.0, 3.0, 4.0}, 2, 1, true},
+		{[]byte{1.0, 2.0}, 2, 0, false}, // length % (dim * 2) != 0
 	}
 
 	for _, test := range cases {
@@ -438,6 +441,143 @@ func TestGetNumRowsOfInt8VectorField(t *testing.T) {
 			assert.NotEqual(t, nil, err)
 		}
 	}
+}
+
+func TestGetNumRowOfFieldDataRejectsArrayOfVectorValidData(t *testing.T) {
+	fieldData := &schemapb.FieldData{
+		FieldName: "vec_array",
+		Type:      schemapb.DataType_ArrayOfVector,
+		ValidData: []bool{true, false},
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_VectorArray{
+					VectorArray: &schemapb.VectorArray{
+						Data: []*schemapb.VectorField{
+							{Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2}}}},
+							{Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{3, 4}}}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	schema := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{
+				Name:        "vec_array",
+				DataType:    schemapb.DataType_ArrayOfVector,
+				ElementType: schemapb.DataType_FloatVector,
+				TypeParams:  []*commonpb.KeyValuePair{{Key: "dim", Value: "2"}},
+			},
+		},
+	}
+	helper, err := typeutil.CreateSchemaHelper(schema)
+	assert.NoError(t, err)
+
+	_, err = GetNumRowOfFieldDataWithSchema(fieldData, helper)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ArrayOfVector does not support nullable")
+
+	_, err = GetNumRowOfFieldData(fieldData)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ArrayOfVector does not support nullable")
+}
+
+func TestValidateNullableVectorFieldDataCompact(t *testing.T) {
+	t.Run("float vector compact valid", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_FloatVector,
+			ValidData: []bool{true, false, true},
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: 2,
+				Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+					Data: []float32{1, 2, 3, 4},
+				}},
+			}},
+		}
+		require.NoError(t, ValidateNullableVectorFieldDataCompact(fieldData, 3, true))
+	})
+
+	t.Run("full row payload rejected", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_FloatVector,
+			ValidData: []bool{true, false, true},
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: 2,
+				Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+					Data: []float32{1, 2, 3, 4, 5, 6},
+				}},
+			}},
+		}
+		err := ValidateNullableVectorFieldDataCompact(fieldData, 3, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "physical payload rows")
+	})
+
+	t.Run("partial dense row rejected", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_Float16Vector,
+			ValidData: []bool{true, false},
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim:  2,
+				Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2}},
+			}},
+		}
+		err := ValidateNullableVectorFieldDataCompact(fieldData, 2, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "row width")
+	})
+
+	t.Run("sparse vector compact valid", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_SparseFloatVector,
+			ValidData: []bool{false, true, true},
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+					Contents: [][]byte{
+						typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1}),
+						typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2}),
+					},
+				}},
+			}},
+		}
+		require.NoError(t, ValidateNullableVectorFieldDataCompact(fieldData, 3, true))
+	})
+
+	t.Run("missing valid data depends on caller boundary", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_FloatVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: 2,
+				Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+					Data: []float32{1, 2},
+				}},
+			}},
+		}
+		require.NoError(t, ValidateNullableVectorFieldDataCompact(fieldData, 0, false))
+		err := ValidateNullableVectorFieldDataCompact(fieldData, 1, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires valid_data")
+	})
+
+	t.Run("schema dim fallback", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_BinaryVector,
+			ValidData: []bool{true, false},
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{0xff}},
+			}},
+		}
+		require.NoError(t, ValidateNullableVectorFieldDataCompactWithDim(fieldData, 2, true, 8))
+	})
 }
 
 func Test_ReadBinary(t *testing.T) {

--- a/pkg/util/funcutil/placeholdergroup_test.go
+++ b/pkg/util/funcutil/placeholdergroup_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 )
 
 func Test_flattenedBinaryVectorsToByteVectors(t *testing.T) {
@@ -56,4 +58,23 @@ func Test_flattenedInt8VectorsToByteVectors(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, actual)
+}
+
+func TestFieldDataToPlaceholderGroupBytesWithCount_AllNullSparseVector(t *testing.T) {
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_SparseFloatVector,
+		FieldName: "sparse_vec",
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{},
+				},
+			},
+		},
+		ValidData: []bool{false, false, false},
+	}
+
+	_, valueCount, err := FieldDataToPlaceholderGroupBytesWithCount(fieldData)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, valueCount)
 }

--- a/pkg/util/typeutil/nullable_vector.go
+++ b/pkg/util/typeutil/nullable_vector.go
@@ -1,0 +1,54 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typeutil
+
+import "github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+
+// IsSupportedNullableVectorType reports whether this vector type currently
+// supports nullable rows. Supported nullable vector payload data is compact:
+// ValidData has one entry per logical row, while vector data only contains
+// valid rows.
+func IsSupportedNullableVectorType(dataType schemapb.DataType) bool {
+	switch dataType {
+	case schemapb.DataType_FloatVector,
+		schemapb.DataType_BinaryVector,
+		schemapb.DataType_Float16Vector,
+		schemapb.DataType_BFloat16Vector,
+		schemapb.DataType_Int8Vector,
+		schemapb.DataType_SparseFloatVector:
+		return true
+	default:
+		return false
+	}
+}
+
+// BuildNullableVectorDataIndices maps logical row indexes to compact vector
+// payload indexes. Null rows are mapped to -1. The returned validCount is the
+// number of physical vector entries expected in compact payload data.
+func BuildNullableVectorDataIndices(validData []bool) ([]int, int) {
+	indices := make([]int, len(validData))
+	validCount := 0
+	for i, valid := range validData {
+		if valid {
+			indices[i] = validCount
+			validCount++
+		} else {
+			indices[i] = -1
+		}
+	}
+	return indices, validCount
+}

--- a/pkg/util/typeutil/nullable_vector_test.go
+++ b/pkg/util/typeutil/nullable_vector_test.go
@@ -1,0 +1,57 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typeutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+)
+
+func TestIsSupportedNullableVectorType(t *testing.T) {
+	nullableVectorTypes := []schemapb.DataType{
+		schemapb.DataType_FloatVector,
+		schemapb.DataType_BinaryVector,
+		schemapb.DataType_Float16Vector,
+		schemapb.DataType_BFloat16Vector,
+		schemapb.DataType_Int8Vector,
+		schemapb.DataType_SparseFloatVector,
+	}
+	for _, dataType := range nullableVectorTypes {
+		assert.True(t, IsSupportedNullableVectorType(dataType), dataType.String())
+	}
+
+	assert.False(t, IsSupportedNullableVectorType(schemapb.DataType_ArrayOfVector))
+	assert.False(t, IsSupportedNullableVectorType(schemapb.DataType_Int64))
+	assert.False(t, IsSupportedNullableVectorType(schemapb.DataType_JSON))
+}
+
+func TestBuildNullableVectorDataIndices(t *testing.T) {
+	indices, validCount := BuildNullableVectorDataIndices([]bool{true, false, true, false, true})
+	assert.Equal(t, []int{0, -1, 1, -1, 2}, indices)
+	assert.Equal(t, 3, validCount)
+
+	indices, validCount = BuildNullableVectorDataIndices([]bool{false, false})
+	assert.Equal(t, []int{-1, -1}, indices)
+	assert.Equal(t, 0, validCount)
+
+	indices, validCount = BuildNullableVectorDataIndices(nil)
+	assert.Empty(t, indices)
+	assert.Equal(t, 0, validCount)
+}

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -890,10 +890,10 @@ func NewFieldDataIdxComputerWithSchema(fieldsData []*schemapb.FieldData, schema 
 	for i, fieldData := range fieldsData {
 		validData := fieldData.GetValidData()
 		fieldSchema := fieldSchemas[fieldData.GetFieldId()]
-		isVector := IsVectorType(fieldData.GetType())
+		isVector := IsSupportedNullableVectorType(fieldData.GetType())
 		isNullableVector := false
 		if fieldSchema != nil {
-			isVector = IsVectorType(fieldSchema.GetDataType())
+			isVector = IsSupportedNullableVectorType(fieldSchema.GetDataType())
 			isNullableVector = fieldSchema.GetNullable() && isVector
 		}
 		c.isVector[i] = isVector && (len(validData) > 0 || isNullableVector)
@@ -1212,18 +1212,16 @@ func AppendFieldData(dst, src []*schemapb.FieldData, idx int64, fieldIdxs ...int
 					appendSize += int64(unsafe.Sizeof(srcVector.Int8Vector[fieldIdx*dim : (fieldIdx+1)*dim]))
 				}
 			case *schemapb.VectorField_VectorArray:
-				if !isNullRow {
-					if dstVector.GetVectorArray() == nil {
-						dstVector.Data = &schemapb.VectorField_VectorArray{
-							VectorArray: &schemapb.VectorArray{
-								Data:        []*schemapb.VectorField{srcVector.VectorArray.Data[fieldIdx]},
-								Dim:         srcVector.VectorArray.Dim,
-								ElementType: srcVector.VectorArray.ElementType,
-							},
-						}
-					} else {
-						dstVector.GetVectorArray().Data = append(dstVector.GetVectorArray().Data, srcVector.VectorArray.Data[fieldIdx])
+				if dstVector.GetVectorArray() == nil {
+					dstVector.Data = &schemapb.VectorField_VectorArray{
+						VectorArray: &schemapb.VectorArray{
+							Data:        []*schemapb.VectorField{srcVector.VectorArray.Data[fieldIdx]},
+							Dim:         srcVector.VectorArray.Dim,
+							ElementType: srcVector.VectorArray.ElementType,
+						},
 					}
+				} else {
+					dstVector.GetVectorArray().Data = append(dstVector.GetVectorArray().Data, srcVector.VectorArray.Data[fieldIdx])
 				}
 			}
 		}
@@ -1799,6 +1797,9 @@ func UpdateFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, upda
 	if len(baseIndices) != len(updateIndices) {
 		return fmt.Errorf("baseIndices and updateIndices length mismatch: %d vs %d", len(baseIndices), len(updateIndices))
 	}
+	if IsCompactNullableVectorFieldData(base) {
+		return updateCompactNullableVectorFieldDataByColumn(base, update, baseIndices, updateIndices)
+	}
 
 	// Handle ValidData
 	if len(update.GetValidData()) > 0 && len(base.GetValidData()) > 0 {
@@ -1964,6 +1965,224 @@ func UpdateFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, upda
 	}
 
 	return nil
+}
+
+// IsCompactNullableVectorFieldData reports whether field uses compact nullable vector payload.
+func IsCompactNullableVectorFieldData(field *schemapb.FieldData) bool {
+	return len(field.GetValidData()) > 0 && IsSupportedNullableVectorType(field.GetType())
+}
+
+func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, updateIndices []int64) error {
+	if !IsSupportedNullableVectorType(update.GetType()) {
+		return fmt.Errorf("cannot update nullable vector field %s with %s", base.GetType().String(), update.GetType().String())
+	}
+	if update.GetType() != base.GetType() {
+		return fmt.Errorf("cannot update nullable vector field %s with %s", base.GetType().String(), update.GetType().String())
+	}
+
+	baseValidData := base.GetValidData()
+	updateValidData := update.GetValidData()
+	if len(updateValidData) == 0 {
+		return fmt.Errorf("nullable vector field %s missing ValidData", update.GetFieldName())
+	}
+
+	updateByBaseIdx := make(map[int]int, len(baseIndices))
+	for i, baseIdx := range baseIndices {
+		updateIdx := updateIndices[i]
+		if baseIdx < 0 || int(baseIdx) >= len(baseValidData) {
+			return fmt.Errorf("base index %d out of range for nullable vector field %s", baseIdx, base.GetFieldName())
+		}
+		if updateIdx < 0 || int(updateIdx) >= len(updateValidData) {
+			return fmt.Errorf("update index %d out of range for nullable vector field %s", updateIdx, update.GetFieldName())
+		}
+		updateByBaseIdx[int(baseIdx)] = int(updateIdx)
+	}
+
+	basePhysicalIndices, _ := BuildNullableVectorDataIndices(baseValidData)
+	updatePhysicalIndices, _ := BuildNullableVectorDataIndices(updateValidData)
+	newValidData := append([]bool(nil), baseValidData...)
+	for baseIdx, updateIdx := range updateByBaseIdx {
+		newValidData[baseIdx] = updateValidData[updateIdx]
+	}
+
+	baseVector := base.GetVectors()
+	updateVector := update.GetVectors()
+	if baseVector == nil || updateVector == nil {
+		return fmt.Errorf("nullable vector field data is nil")
+	}
+	dim := baseVector.GetDim()
+	if dim == 0 {
+		dim = updateVector.GetDim()
+	}
+	if dim != 0 {
+		baseVector.Dim = dim
+	}
+
+	switch base.GetType() {
+	case schemapb.DataType_BinaryVector:
+		elemSize := dim / 8
+		newData := make([]byte, 0, int64(countValid(newValidData))*elemSize)
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetBinaryVector()
+			start := int64(physicalIdx) * elemSize
+			end := start + elemSize
+			if start < 0 || end > int64(len(data)) {
+				return fmt.Errorf("binary vector physical index %d out of range", physicalIdx)
+			}
+			newData = append(newData, data[start:end]...)
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_BinaryVector{BinaryVector: newData}
+	case schemapb.DataType_FloatVector:
+		newData := make([]float32, 0, int64(countValid(newValidData))*dim)
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetFloatVector().GetData()
+			start := int64(physicalIdx) * dim
+			end := start + dim
+			if start < 0 || end > int64(len(data)) {
+				return fmt.Errorf("float vector physical index %d out of range", physicalIdx)
+			}
+			newData = append(newData, data[start:end]...)
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: newData}}
+	case schemapb.DataType_Float16Vector:
+		elemSize := dim * 2
+		newData := make([]byte, 0, int64(countValid(newValidData))*elemSize)
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetFloat16Vector()
+			start := int64(physicalIdx) * elemSize
+			end := start + elemSize
+			if start < 0 || end > int64(len(data)) {
+				return fmt.Errorf("float16 vector physical index %d out of range", physicalIdx)
+			}
+			newData = append(newData, data[start:end]...)
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_Float16Vector{Float16Vector: newData}
+	case schemapb.DataType_BFloat16Vector:
+		elemSize := dim * 2
+		newData := make([]byte, 0, int64(countValid(newValidData))*elemSize)
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetBfloat16Vector()
+			start := int64(physicalIdx) * elemSize
+			end := start + elemSize
+			if start < 0 || end > int64(len(data)) {
+				return fmt.Errorf("bfloat16 vector physical index %d out of range", physicalIdx)
+			}
+			newData = append(newData, data[start:end]...)
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: newData}
+	case schemapb.DataType_SparseFloatVector:
+		baseSparse := baseVector.GetSparseFloatVector()
+		updateSparse := updateVector.GetSparseFloatVector()
+		if updateSparse == nil {
+			return fmt.Errorf("sparse float vector update data is nil")
+		}
+		baseDim := int64(0)
+		if baseSparse != nil {
+			baseDim = baseSparse.GetDim()
+		}
+		newSparse := &schemapb.SparseFloatArray{
+			Dim:      maxInt64(baseDim, updateSparse.GetDim()),
+			Contents: make([][]byte, 0, countValid(newValidData)),
+		}
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetSparseFloatVector()
+			if data == nil || physicalIdx < 0 || physicalIdx >= len(data.GetContents()) {
+				return fmt.Errorf("sparse vector physical index %d out of range", physicalIdx)
+			}
+			row := data.GetContents()[physicalIdx]
+			newSparse.Contents = append(newSparse.Contents, row)
+			if rowDim := SparseFloatRowDim(row); rowDim > newSparse.Dim {
+				newSparse.Dim = rowDim
+			}
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_SparseFloatVector{SparseFloatVector: newSparse}
+		baseVector.Dim = newSparse.GetDim()
+	case schemapb.DataType_Int8Vector:
+		elemSize := dim
+		newData := make([]byte, 0, int64(countValid(newValidData))*elemSize)
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetInt8Vector()
+			start := int64(physicalIdx) * elemSize
+			end := start + elemSize
+			if start < 0 || end > int64(len(data)) {
+				return fmt.Errorf("int8 vector physical index %d out of range", physicalIdx)
+			}
+			newData = append(newData, data[start:end]...)
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_Int8Vector{Int8Vector: newData}
+	default:
+		return fmt.Errorf("unsupported nullable vector field type %s", base.GetType().String())
+	}
+
+	base.ValidData = newValidData
+	return nil
+}
+
+func rebuildCompactNullableVectorData(
+	validData []bool,
+	updateByBaseIdx map[int]int,
+	basePhysicalIndices []int,
+	updatePhysicalIndices []int,
+	appendRow func(vector *schemapb.VectorField, physicalIdx int) error,
+	baseVector *schemapb.VectorField,
+	updateVector *schemapb.VectorField,
+) error {
+	for logicalIdx, valid := range validData {
+		if !valid {
+			continue
+		}
+		if updateIdx, ok := updateByBaseIdx[logicalIdx]; ok {
+			if err := appendRow(updateVector, updatePhysicalIndices[updateIdx]); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := appendRow(baseVector, basePhysicalIndices[logicalIdx]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func maxInt64(lhs, rhs int64) int64 {
+	if lhs > rhs {
+		return lhs
+	}
+	return rhs
+}
+
+func countValid(validData []bool) int {
+	validCount := 0
+	for _, valid := range validData {
+		if valid {
+			validCount++
+		}
+	}
+	return validCount
 }
 
 // MergeFieldData appends fields data to dst
@@ -2186,12 +2405,12 @@ func MergeFieldData(dst []*schemapb.FieldData, src []*schemapb.FieldData) error 
 	return nil
 }
 
-// GetTotalFieldsNum get total fields number
-// We exclude StructArrayField itself as it does not contain data directly.
+// GetTotalFieldsNum get total fields number, including StructArrayField itself.
 func GetTotalFieldsNum(schema *schemapb.CollectionSchema) int {
 	num := len(schema.GetFields())
 	for _, structArrayField := range schema.GetStructArrayFields() {
-		num += len(structArrayField.GetFields())
+		// +1 for the StructArrayField itself
+		num += len(structArrayField.GetFields()) + 1
 	}
 	return num
 }
@@ -2516,6 +2735,15 @@ func GetPK(data *schemapb.IDs, idx int64) interface{} {
 func GetDataIterator(field *schemapb.FieldData) func(int) any {
 	if field.GetValidData() != nil {
 		validData := field.GetValidData()
+		if IsCompactNullableVectorFieldData(field) {
+			idxs, _ := BuildNullableVectorDataIndices(validData)
+			return func(idx int) any {
+				if idxs[idx] == -1 {
+					return nil
+				}
+				return getData(field, idxs[idx])
+			}
+		}
 		dataLen := getScalarDataLen(field)
 		if dataLen == len(validData) {
 			// Full-size format: data array has the same length as ValidData,
@@ -2527,8 +2755,6 @@ func GetDataIterator(field *schemapb.FieldData) func(int) any {
 				return getData(field, idx)
 			}
 		}
-		// Compact format: data array only contains valid entries.
-		// Build a mapping from logical index to physical index.
 		idxs := make([]int, len(validData))
 		cnt := 0
 		for i, valid := range validData {

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -3159,6 +3159,44 @@ func TestGetDataIterator(t *testing.T) {
 			want: []any{int64(1), nil, int64(2), int64(3)},
 		},
 		{
+			name: "compact nullable float vector",
+			field: &schemapb.FieldData{
+				Type: schemapb.DataType_FloatVector,
+				Field: &schemapb.FieldData_Vectors{
+					Vectors: &schemapb.VectorField{
+						Dim: 2,
+						Data: &schemapb.VectorField_FloatVector{
+							FloatVector: &schemapb.FloatArray{
+								Data: []float32{1, 2, 5, 6},
+							},
+						},
+					},
+				},
+				ValidData: []bool{true, false, true},
+			},
+			want: []any{[]float32{1, 2}, nil, []float32{5, 6}},
+		},
+		{
+			name: "compact nullable sparse vector",
+			field: &schemapb.FieldData{
+				Type: schemapb.DataType_SparseFloatVector,
+				Field: &schemapb.FieldData_Vectors{
+					Vectors: &schemapb.VectorField{
+						Data: &schemapb.VectorField_SparseFloatVector{
+							SparseFloatVector: &schemapb.SparseFloatArray{
+								Contents: [][]byte{
+									CreateSparseFloatRow([]uint32{1}, []float32{1}),
+									CreateSparseFloatRow([]uint32{3}, []float32{3}),
+								},
+							},
+						},
+					},
+				},
+				ValidData: []bool{false, true, false, true},
+			},
+			want: []any{nil, CreateSparseFloatRow([]uint32{1}, []float32{1}), nil, CreateSparseFloatRow([]uint32{3}, []float32{3})},
+		},
+		{
 			name: "ints with nulls full-size",
 			field: &schemapb.FieldData{
 				Type: schemapb.DataType_Int64,
@@ -5491,4 +5529,265 @@ func TestUpdateFieldDataByColumn(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, [][]byte{{10}, {2}, {20}}, base.GetVectors().GetSparseFloatVector().Contents)
 	})
+
+	t.Run("nullable compact float vector changes validity", func(t *testing.T) {
+		dim := int64(2)
+		base := &schemapb.FieldData{
+			Type:      schemapb.DataType_FloatVector,
+			ValidData: []bool{true, false, true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{Data: []float32{
+							1, 1,
+							3, 3,
+						}},
+					},
+				},
+			},
+		}
+		update := &schemapb.FieldData{
+			Type:      schemapb.DataType_FloatVector,
+			ValidData: []bool{false, true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{Data: []float32{20, 20}},
+					},
+				},
+			},
+		}
+
+		err := UpdateFieldDataByColumn(base, update, []int64{0, 1}, []int64{0, 1})
+
+		require.NoError(t, err)
+		assert.Equal(t, []bool{false, true, true}, base.GetValidData())
+		assert.Equal(t, []float32{20, 20, 3, 3}, base.GetVectors().GetFloatVector().GetData())
+	})
+
+	t.Run("nullable compact sparse vector changes validity", func(t *testing.T) {
+		base := &schemapb.FieldData{
+			Type:      schemapb.DataType_SparseFloatVector,
+			ValidData: []bool{true, false, true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: &schemapb.SparseFloatArray{
+							Dim:      100,
+							Contents: [][]byte{CreateSparseFloatRow([]uint32{1}, []float32{1}), CreateSparseFloatRow([]uint32{3}, []float32{3})},
+						},
+					},
+				},
+			},
+		}
+		update := &schemapb.FieldData{
+			Type:      schemapb.DataType_SparseFloatVector,
+			ValidData: []bool{false, true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: &schemapb.SparseFloatArray{
+							Dim:      100,
+							Contents: [][]byte{CreateSparseFloatRow([]uint32{20}, []float32{20})},
+						},
+					},
+				},
+			},
+		}
+
+		err := UpdateFieldDataByColumn(base, update, []int64{0, 1}, []int64{0, 1})
+
+		require.NoError(t, err)
+		assert.Equal(t, []bool{false, true, true}, base.GetValidData())
+		assert.Equal(t, [][]byte{
+			CreateSparseFloatRow([]uint32{20}, []float32{20}),
+			CreateSparseFloatRow([]uint32{3}, []float32{3}),
+		}, base.GetVectors().GetSparseFloatVector().GetContents())
+	})
+
+	t.Run("nullable compact sparse vector all null base accepts valid update", func(t *testing.T) {
+		base := &schemapb.FieldData{
+			Type:      schemapb.DataType_SparseFloatVector,
+			ValidData: []bool{false, false},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{},
+			},
+		}
+		updateRow := CreateSparseFloatRow([]uint32{20}, []float32{20})
+		update := &schemapb.FieldData{
+			Type:      schemapb.DataType_SparseFloatVector,
+			ValidData: []bool{true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: &schemapb.SparseFloatArray{
+							Dim:      100,
+							Contents: [][]byte{updateRow},
+						},
+					},
+				},
+			},
+		}
+
+		err := UpdateFieldDataByColumn(base, update, []int64{1}, []int64{0})
+
+		require.NoError(t, err)
+		assert.Equal(t, []bool{false, true}, base.GetValidData())
+		assert.Equal(t, [][]byte{updateRow}, base.GetVectors().GetSparseFloatVector().GetContents())
+	})
+}
+
+func TestIsClusteringKeyType(t *testing.T) {
+	// Supported scalar types
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int8))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int16))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int32))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Int64))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Float))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_Double))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_VarChar))
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_String))
+
+	// Supported vector types
+	assert.True(t, IsClusteringKeyType(schemapb.DataType_FloatVector))
+
+	// Unsupported types
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_JSON))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Bool))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Array))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Geometry))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Text))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Timestamptz))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_BinaryVector))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_Float16Vector))
+	assert.False(t, IsClusteringKeyType(schemapb.DataType_BFloat16Vector))
+}
+
+func newArrayOfVectorFieldData(fieldID int64, fieldName string, dim int64, elementType schemapb.DataType, rowCount int) *schemapb.FieldData {
+	data := make([]*schemapb.VectorField, rowCount)
+	for i := 0; i < rowCount; i++ {
+		data[i] = &schemapb.VectorField{
+			Dim: dim,
+			Data: &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: []float32{float32(i + 1)}},
+			},
+		}
+	}
+	return &schemapb.FieldData{
+		Type:      schemapb.DataType_ArrayOfVector,
+		FieldName: fieldName,
+		FieldId:   fieldID,
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: dim,
+				Data: &schemapb.VectorField_VectorArray{
+					VectorArray: &schemapb.VectorArray{
+						Data:        data,
+						Dim:         dim,
+						ElementType: elementType,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestFieldDataIdxComputer_ArrayOfVectorIsNonVector(t *testing.T) {
+	scalar := &schemapb.FieldData{
+		Type:    schemapb.DataType_Int64,
+		FieldId: 100,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20, 30, 40}},
+				},
+			},
+		},
+		ValidData: []bool{true, false, true, false},
+	}
+
+	// Compact vector: 2 valid rows out of 4; Data len==2.
+	vec := &schemapb.FieldData{
+		Type:    schemapb.DataType_FloatVector,
+		FieldId: 101,
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: 1,
+				Data: &schemapb.VectorField_FloatVector{
+					FloatVector: &schemapb.FloatArray{Data: []float32{1.0, 2.0}},
+				},
+			},
+		},
+		ValidData: []bool{true, false, true, false},
+	}
+
+	arrVec := newArrayOfVectorFieldData(102, "arrvec", 1, schemapb.DataType_FloatVector, 4)
+
+	c := NewFieldDataIdxComputer([]*schemapb.FieldData{scalar, vec, arrVec})
+
+	// The key invariant: for every row, ArrayOfVector's index must equal rowIdx
+	// (dense/scalar semantics), never the compact index like a regular vector.
+	// Regular vector uses compact indexing, which diverges from rowIdx at row 2:
+	// rowIdx=2 but there's only one valid row before it, so compact index == 1.
+	for rowIdx := int64(0); rowIdx < 4; rowIdx++ {
+		got := c.Compute(rowIdx)
+		assert.Equal(t, rowIdx, got[0], "scalar row %d", rowIdx)
+		assert.Equal(t, rowIdx, got[2], "ArrayOfVector row %d must follow rowIdx", rowIdx)
+	}
+
+	// Reset by calling Compute on a smaller rowIdx.
+	c.Compute(0)
+	// At row 2 (the second valid row), compact vector index is 1, which differs
+	// from rowIdx=2. This confirms ArrayOfVector is NOT using the compact path.
+	got := c.Compute(2)
+	assert.Equal(t, int64(1), got[1], "compact vector at row 2 -> compact index 1")
+	assert.Equal(t, int64(2), got[2], "ArrayOfVector at row 2 -> rowIdx 2")
+}
+
+func TestAppendFieldData_ArrayOfVectorAppendsRows(t *testing.T) {
+	src := newArrayOfVectorFieldData(200, "arrvec", 1, schemapb.DataType_FloatVector, 4)
+
+	// dst is a slice of same length as src, elements will be filled on first append.
+	dst := make([]*schemapb.FieldData, 1)
+
+	// Walk rows 0..3, fieldIdx == rowIdx because IdxComputer treats ArrayOfVector
+	// as non-vector.
+	for i := int64(0); i < 4; i++ {
+		AppendFieldData(dst, []*schemapb.FieldData{src}, i, i)
+	}
+
+	require.NotNil(t, dst[0])
+	got := dst[0].GetVectors().GetVectorArray()
+	require.NotNil(t, got)
+	require.Len(t, got.GetData(), 4)
+	assert.Equal(t, []float32{1}, got.GetData()[0].GetFloatVector().GetData())
+	assert.Equal(t, []float32{2}, got.GetData()[1].GetFloatVector().GetData())
+	assert.Equal(t, []float32{3}, got.GetData()[2].GetFloatVector().GetData())
+	assert.Equal(t, []float32{4}, got.GetData()[3].GetFloatVector().GetData())
+	assert.Empty(t, dst[0].GetValidData())
+	assert.EqualValues(t, 1, got.GetDim())
+	assert.Equal(t, schemapb.DataType_FloatVector, got.GetElementType())
+}
+
+func TestGetTotalFieldsNumIncludesStructParent(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "pk", DataType: schemapb.DataType_Int64},
+			{Name: "scalar", DataType: schemapb.DataType_Bool},
+		},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{
+				Name: "profile",
+				Fields: []*schemapb.FieldSchema{
+					{Name: "profile[ints]", DataType: schemapb.DataType_Array},
+					{Name: "profile[vectors]", DataType: schemapb.DataType_ArrayOfVector},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, 5, GetTotalFieldsNum(schema))
+	assert.Len(t, GetAllFieldSchemas(schema), 4)
 }

--- a/tests/go_client/testcases/nullable_default_value_test.go
+++ b/tests/go_client/testcases/nullable_default_value_test.go
@@ -2148,6 +2148,20 @@ func TestNullableVectorAllNull(t *testing.T) {
 			common.CheckErr(t, err, true)
 			require.EqualValues(t, nb, count, "query should return all %d rows even with 100%% null vectors", nb)
 
+			// query vector output should preserve all-null logical rows after index/load
+			queryVecRes, err := mc.Query(ctx, client.NewQueryOption(collName).WithFilter("int64 < 10").WithOutputFields("vector"))
+			common.CheckErr(t, err, true)
+			require.EqualValues(t, 10, queryVecRes.ResultCount)
+			vecCol := queryVecRes.GetColumn("vector")
+			for i := 0; i < queryVecRes.ResultCount; i++ {
+				isNull, err := vecCol.IsNull(i)
+				require.NoError(t, err)
+				require.True(t, isNull, "all-null vector output row %d should stay null", i)
+				value, err := vecCol.Get(i)
+				require.NoError(t, err)
+				require.Nil(t, value, "all-null vector output row %d should have nil value", i)
+			}
+
 			// clean up
 			err = mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
 			common.CheckErr(t, err, true)


### PR DESCRIPTION
## Summary
- Cherrypick nullable vector compact-storage invariant fixes from #49924 to 2.6.
- Enforce the compact nullable vector contract: `ValidData` tracks logical rows, while vector payloads contain only valid physical rows.
- Cover the affected storage, import, proxy, index build, and segcore paths with regression tests.

pr: #49924
issue: #49881

## Test plan
- [x] `git diff --check HEAD`
- [x] `cd pkg && go test ./util/funcutil ./util/typeutil ./mq/msgstream` targeted nullable compact vector tests

Local full build/static checks were not completed in this workspace:
- `make build-cpp` was blocked by generated v3 proto imports and an existing CMake generator-cache mismatch.
- `make static-check` was blocked by stale/generated canalyzer C header mismatch.
