### PR TITLE
fix: [2.6] skip loading BM25 sparse vector fields (#49651)

### DIFF
--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -87,6 +87,15 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
         }
     }
 
+    for (const auto& function : schema_proto.functions()) {
+        if (function.type() != milvus::proto::schema::BM25) {
+            continue;
+        }
+        for (const auto output_field_id : function.output_field_ids()) {
+            schema->bm25_function_output_fields_.emplace(output_field_id);
+        }
+    }
+
     std::tie(schema->has_mmap_setting_, schema->mmap_enabled_) =
         GetBoolFromRepeatedKVs(schema_proto.properties(), MMAP_ENABLED_KEY);
 

--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -358,6 +358,9 @@ class Schema {
 
     bool
     ShouldLoadField(FieldId field_id) {
+        if (bm25_function_output_fields_.count(field_id) > 0) {
+            return false;
+        }
         return load_fields_.empty() || load_fields_.count(field_id) > 0;
     }
 
@@ -447,6 +450,7 @@ class Schema {
     // field partial load list
     // work as hint now
     std::unordered_set<FieldId> load_fields_;
+    std::unordered_set<FieldId> bm25_function_output_fields_;
 
     // schema_version_, currently marked with update timestamp
     uint64_t schema_version_;

--- a/internal/core/src/common/SchemaTest.cpp
+++ b/internal/core/src/common/SchemaTest.cpp
@@ -412,3 +412,31 @@ TEST_F(SchemaTest, WarmupPolicyFallbackToCollectionLevel) {
     EXPECT_TRUE(has_setting2);
     EXPECT_EQ(policy2, "disable");
 }
+
+TEST_F(SchemaTest, ShouldLoadFieldReturnsFalseForBM25FunctionOutput) {
+    milvus::proto::schema::CollectionSchema schema_proto;
+
+    auto* pk_field = schema_proto.add_fields();
+    pk_field->set_fieldid(100);
+    pk_field->set_name("pk");
+    pk_field->set_data_type(milvus::proto::schema::DataType::Int64);
+    pk_field->set_is_primary_key(true);
+
+    auto* bm25_vector = schema_proto.add_fields();
+    bm25_vector->set_fieldid(101);
+    bm25_vector->set_name("sparse");
+    bm25_vector->set_data_type(
+        milvus::proto::schema::DataType::SparseFloatVector);
+
+    auto* function = schema_proto.add_functions();
+    function->set_type(milvus::proto::schema::BM25);
+    function->add_output_field_ids(101);
+
+    auto schema = Schema::ParseFrom(schema_proto);
+
+    EXPECT_TRUE(schema->ShouldLoadField(FieldId(100)));
+    EXPECT_FALSE(schema->ShouldLoadField(FieldId(101)));
+
+    schema->UpdateLoadFields({101});
+    EXPECT_FALSE(schema->ShouldLoadField(FieldId(101)));
+}


### PR DESCRIPTION
relate: https://github.com/milvus-io/milvus/issues/49650
pr: https://github.com/milvus-io/milvus/pull/49651

## Summary
Skip BM25 sparse vector fields in segcore ShouldLoadField decisions so BM25 function outputs are not treated as loadable raw field data.