### PR TITLE
fix: [hotfix] isolate REST timeout middleware handler context

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -414,6 +414,199 @@ func TestTimeout(t *testing.T) {
 	}
 }
 
+func TestTimeoutResponseRecorderIsolation(t *testing.T) {
+	realResponse := httptest.NewRecorder()
+	realCtx, _ := gin.CreateTestContext(realResponse)
+	buffer := &bytes.Buffer{}
+	recorder := newTimeoutResponseRecorder(buffer)
+
+	recorder.Header().Set("X-Test", "value")
+	recorder.WriteHeader(http.StatusAccepted)
+	recorder.WriteHeaderNow()
+	recorder.Flush()
+	n, err := recorder.WriteString("body")
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Empty(t, realResponse.Body.String())
+	assert.Empty(t, realResponse.Header().Get("X-Test"))
+	assert.Equal(t, http.StatusAccepted, recorder.Status())
+	assert.Equal(t, 4, recorder.Size())
+	assert.True(t, recorder.Written())
+
+	assert.NoError(t, recorder.CommitTo(realCtx.Writer))
+	assert.Equal(t, http.StatusAccepted, realResponse.Code)
+	assert.Equal(t, "value", realResponse.Header().Get("X-Test"))
+	assert.Equal(t, "body", realResponse.Body.String())
+
+	recorder.CloseForTimeout()
+	n, err = recorder.Write([]byte("late"))
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestTimeoutMiddlewareCommitsBufferedResponsesAndMetadata(t *testing.T) {
+	testCases := []struct {
+		name   string
+		status int
+		code   int32
+		write  func(c *gin.Context, code int32, message string)
+	}{
+		{
+			name:   "return",
+			status: http.StatusCreated,
+			code:   11,
+			write: func(c *gin.Context, code int32, message string) {
+				HTTPReturn(c, http.StatusCreated, gin.H{HTTPReturnCode: code, HTTPReturnMessage: message})
+			},
+		},
+		{
+			name:   "stream",
+			status: http.StatusAccepted,
+			code:   12,
+			write: func(c *gin.Context, code int32, message string) {
+				HTTPReturnStream(c, http.StatusAccepted, gin.H{HTTPReturnCode: code, HTTPReturnMessage: message})
+			},
+		},
+		{
+			name:   "abort",
+			status: http.StatusNonAuthoritativeInfo,
+			code:   13,
+			write: func(c *gin.Context, code int32, message string) {
+				HTTPAbortReturn(c, http.StatusNonAuthoritativeInfo, gin.H{HTTPReturnCode: code, HTTPReturnMessage: message})
+			},
+		},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.name, func(t *testing.T) {
+			ginHandler := gin.New()
+			originalCtx := make(chan *gin.Context, 1)
+			path := "/middleware/timeout/commit/" + testcase.name
+
+			ginHandler.Use(func(c *gin.Context) {
+				c.Set(ContextUsername, "root")
+				originalCtx <- c
+				c.Next()
+			})
+			ginHandler.POST(path, timeoutMiddleware(func(c *gin.Context) {
+				username, ok := c.Get(ContextUsername)
+				assert.True(t, ok)
+				assert.Equal(t, "root", username)
+				c.Header("X-Test", testcase.name)
+				c.Set(ContextRequest, "request-"+testcase.name)
+				c.Set(ContextResponse, "response-"+testcase.name)
+				c.Set("traceID", "trace-"+testcase.name)
+				testcase.write(c, testcase.code, testcase.name)
+			}))
+
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			w := httptest.NewRecorder()
+			ginHandler.ServeHTTP(w, req)
+
+			assert.Equal(t, testcase.status, w.Code)
+			assert.Equal(t, testcase.name, w.Header().Get("X-Test"))
+			returnBody := &ReturnErrMsg{}
+			err := json.Unmarshal(w.Body.Bytes(), returnBody)
+			assert.NoError(t, err)
+			assert.Equal(t, testcase.code, returnBody.Code)
+			assert.Equal(t, testcase.name, returnBody.Message)
+
+			ctx := <-originalCtx
+			value, ok := ctx.Get(HTTPReturnCode)
+			assert.True(t, ok)
+			assert.Equal(t, testcase.code, value)
+			value, ok = ctx.Get(HTTPReturnMessage)
+			assert.True(t, ok)
+			assert.Equal(t, testcase.name, value)
+			value, ok = ctx.Get(ContextRequest)
+			assert.True(t, ok)
+			assert.Equal(t, "request-"+testcase.name, value)
+			value, ok = ctx.Get(ContextResponse)
+			assert.True(t, ok)
+			assert.Equal(t, "response-"+testcase.name, value)
+			value, ok = ctx.Get("traceID")
+			assert.True(t, ok)
+			assert.Equal(t, "trace-"+testcase.name, value)
+		})
+	}
+}
+
+func TestTimeoutMiddlewarePropagatesAbortToOriginalContext(t *testing.T) {
+	ginHandler := gin.New()
+	path := "/middleware/timeout/abort-propagation"
+	nextCalled := false
+
+	ginHandler.POST(path, timeoutMiddleware(func(c *gin.Context) {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: int32(100), HTTPReturnMessage: "aborted"})
+	}), func(c *gin.Context) {
+		nextCalled = true
+		HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: int32(200), HTTPReturnMessage: "next"})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	w := httptest.NewRecorder()
+	ginHandler.ServeHTTP(w, req)
+
+	assert.False(t, nextCalled)
+	returnBody := &ReturnErrMsg{}
+	err := json.Unmarshal(w.Body.Bytes(), returnBody)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(100), returnBody.Code)
+	assert.Equal(t, "aborted", returnBody.Message)
+}
+
+func TestTimeoutMiddlewareLateHandlerWritesUseCopiedContext(t *testing.T) {
+	paramtable.Get().Save(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key, "10")
+	t.Cleanup(func() {
+		paramtable.Get().Reset(paramtable.Get().HTTPCfg.RequestTimeoutMs.Key)
+	})
+
+	ginHandler := gin.New()
+	path := "/middleware/timeout/late-write"
+	originalCtx := make(chan *gin.Context, 1)
+	handlerCtx := make(chan *gin.Context, 1)
+	lateWriteDone := make(chan struct{}, 1)
+
+	ginHandler.Use(func(c *gin.Context) {
+		originalCtx <- c
+		c.Next()
+	})
+	ginHandler.POST(path, timeoutMiddleware(func(c *gin.Context) {
+		handlerCtx <- c
+		<-c.Request.Context().Done()
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: int32(12345), HTTPReturnMessage: "late write"})
+		lateWriteDone <- struct{}{}
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	w := httptest.NewRecorder()
+	ginHandler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestTimeout, w.Code)
+	returnBody := &ReturnErrMsg{}
+	err := json.Unmarshal(w.Body.Bytes(), returnBody)
+	assert.NoError(t, err)
+	assert.Equal(t, merr.TimeoutCode, returnBody.Code)
+	assert.Equal(t, "request timeout", returnBody.Message)
+	assert.NotContains(t, w.Body.String(), "late write")
+
+	ctx := <-originalCtx
+	copiedCtx := <-handlerCtx
+	assert.False(t, ctx == copiedCtx)
+	select {
+	case <-lateWriteDone:
+	case <-time.After(time.Second):
+		t.Fatal("late handler write did not finish")
+	}
+
+	value, ok := ctx.Get(HTTPReturnCode)
+	assert.True(t, ok)
+	assert.Equal(t, merr.TimeoutCode, value)
+	value, ok = ctx.Get(HTTPReturnMessage)
+	assert.True(t, ok)
+	assert.Equal(t, "request timeout", value)
+}
+
 func TestRestfulSizeMiddlewarePreservesRequestContextCancel(t *testing.T) {
 	ginHandler := gin.New()
 	app := ginHandler.Group("")

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -17,13 +17,14 @@
 package httpserver
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -62,105 +63,153 @@ type Timeout struct {
 	handler gin.HandlerFunc
 }
 
-// Writer is a writer with memory buffer
-type Writer struct {
-	gin.ResponseWriter
-	body         *bytes.Buffer
-	headers      http.Header
-	mu           sync.Mutex
-	timeout      atomic.Bool
-	wroteHeaders bool
-	code         int
+const timeoutRecorderNoWritten = -1
+
+type timeoutResponseRecorder struct {
+	body        *bytes.Buffer
+	headers     http.Header
+	mu          sync.Mutex
+	closed      bool
+	status      int
+	size        int
+	closeNotify chan bool
 }
 
-// NewWriter will return a timeout.Writer pointer
-func NewWriter(w gin.ResponseWriter, buf *bytes.Buffer) *Writer {
-	return &Writer{ResponseWriter: w, body: buf, headers: make(http.Header)}
+func newTimeoutResponseRecorder(buf *bytes.Buffer) *timeoutResponseRecorder {
+	return &timeoutResponseRecorder{
+		body:        buf,
+		headers:     make(http.Header),
+		status:      http.StatusOK,
+		size:        timeoutRecorderNoWritten,
+		closeNotify: make(chan bool),
+	}
 }
 
-// Write will write data to response body
-func (w *Writer) Write(data []byte) (int, error) {
+func (w *timeoutResponseRecorder) Header() http.Header {
+	return w.headers
+}
+
+func (w *timeoutResponseRecorder) Write(data []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if w.timeout.Load() || w.body == nil {
-		return 0, errors.New("Response writer closed")
+	if w.closed || w.body == nil {
+		return 0, errors.New("response writer closed")
 	}
-	return w.body.Write(data)
+	if !w.written() {
+		w.size = 0
+	}
+	n, err := w.body.Write(data)
+	w.size += n
+	return n, err
 }
 
-// WriteHeader sends an HTTP response header with the provided status code.
-// If the response writer has already written headers or if a timeout has occurred,
-// this method does nothing.
-func (w *Writer) WriteHeader(code int) {
-	// gin is using -1 to skip writing the status code
-	// see https://github.com/gin-gonic/gin/blob/a0acf1df2814fcd828cb2d7128f2f4e2136d3fac/response_writer.go#L61
+func (w *timeoutResponseRecorder) WriteString(s string) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed || w.body == nil {
+		return 0, errors.New("response writer closed")
+	}
+	if !w.written() {
+		w.size = 0
+	}
+	n, err := w.body.WriteString(s)
+	w.size += n
+	return n, err
+}
+
+func (w *timeoutResponseRecorder) WriteHeader(code int) {
 	if code == -1 {
 		return
 	}
-
 	checkWriteHeaderCode(code)
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if w.timeout.Load() || w.wroteHeaders {
+	if w.closed || w.written() {
 		return
 	}
-	w.writeHeader(code)
-	w.ResponseWriter.WriteHeader(code)
+	w.status = code
 }
 
-func (w *Writer) writeHeader(code int) {
-	w.wroteHeaders = true
-	w.code = code
-}
-
-// Header will get response headers
-func (w *Writer) Header() http.Header {
-	return w.headers
-}
-
-// WriteString will write string to response body
-func (w *Writer) WriteString(s string) (int, error) {
-	return w.Write([]byte(s))
-}
-
-// FreeBuffer will release buffer pointer
-func (w *Writer) FreeBuffer() {
-	// if not reset body,old bytes will put in bufPool
-	w.body.Reset()
-	w.body = nil
-}
-
-// Status we must override Status func here,
-// or the http status code returned by gin.Context.Writer.Status()
-// will always be 200 in other custom gin middlewares.
-func (w *Writer) Status() int {
-	if w.code == 0 || w.timeout.Load() {
-		return w.ResponseWriter.Status()
-	}
-	return w.code
-}
-
-// WriteHeaderNow implements gin.ResponseWriter interface to prevent
-// bypassing the mutex when writing headers directly.
-func (w *Writer) WriteHeaderNow() {
+func (w *timeoutResponseRecorder) WriteHeaderNow() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if w.timeout.Load() {
+	if w.closed || w.written() {
 		return
 	}
-	w.ResponseWriter.WriteHeaderNow()
+	w.size = 0
 }
 
-// Flush implements the http.Flusher interface. It guards against
-// flushing after timeout to prevent bypassing the mutex.
-func (w *Writer) Flush() {
+func (w *timeoutResponseRecorder) Status() int {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if w.timeout.Load() {
-		return
+	return w.status
+}
+
+func (w *timeoutResponseRecorder) Size() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.size
+}
+
+func (w *timeoutResponseRecorder) Written() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.written()
+}
+
+func (w *timeoutResponseRecorder) Flush() {}
+
+func (w *timeoutResponseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, errors.New("response writer does not support hijack")
+}
+
+func (w *timeoutResponseRecorder) CloseNotify() <-chan bool {
+	return w.closeNotify
+}
+
+func (w *timeoutResponseRecorder) Pusher() http.Pusher {
+	return nil
+}
+
+func (w *timeoutResponseRecorder) CommitTo(realWriter gin.ResponseWriter) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed || w.body == nil {
+		return errors.New("response writer closed")
 	}
-	w.ResponseWriter.Flush()
+
+	dst := realWriter.Header()
+	for k, vv := range w.headers {
+		dst[k] = append([]string(nil), vv...)
+	}
+	realWriter.WriteHeader(w.status)
+	if w.body.Len() == 0 {
+		if w.written() || w.status != http.StatusOK {
+			realWriter.WriteHeaderNow()
+		}
+		return nil
+	}
+	_, err := realWriter.Write(w.body.Bytes())
+	return err
+}
+
+func (w *timeoutResponseRecorder) Close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.body != nil {
+		w.body.Reset()
+		w.body = nil
+	}
+	w.closed = true
+}
+
+func (w *timeoutResponseRecorder) CloseForTimeout() {
+	w.Close()
+}
+
+func (w *timeoutResponseRecorder) written() bool {
+	return w.size != timeoutRecorderNoWritten
 }
 
 func checkWriteHeaderCode(code int) {
@@ -169,8 +218,24 @@ func checkWriteHeaderCode(code int) {
 	}
 }
 
+var timeoutContextKeysToPropagate = []string{
+	HTTPReturnCode,
+	HTTPReturnMessage,
+	ContextRequest,
+	ContextResponse,
+	"traceID",
+}
+
+func propagateTimeoutContextKeys(dst *gin.Context, src *gin.Context) {
+	for _, key := range timeoutContextKeysToPropagate {
+		if value, ok := src.Get(key); ok {
+			dst.Set(key, value)
+		}
+	}
+}
+
 func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
-	t := &Timeout{
+	timeoutHandler := &Timeout{
 		handler: handler,
 	}
 	bufPool := &BufferPool{}
@@ -182,16 +247,19 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 		}
 		topCtx, cancel := context.WithTimeout(gCtx.Request.Context(), timeout)
 		defer cancel()
-		gCtx.Request = gCtx.Request.WithContext(topCtx)
+		req := gCtx.Request.WithContext(topCtx)
+		gCtx.Request = req
 
 		finish := make(chan struct{}, 1)
 		panicChan := make(chan interface{}, 1)
 
-		w := gCtx.Writer
+		realWriter := gCtx.Writer
 		buffer := bufPool.Get()
-		tw := NewWriter(w, buffer)
-		gCtx.Writer = tw
 		buffer.Reset()
+		recorder := newTimeoutResponseRecorder(buffer)
+		handlerCtx := gCtx.Copy()
+		handlerCtx.Request = req
+		handlerCtx.Writer = recorder
 
 		go func() {
 			defer func() {
@@ -199,53 +267,47 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 					panicChan <- p
 				}
 			}()
-			t.handler(gCtx)
+			timeoutHandler.handler(handlerCtx)
 			finish <- struct{}{}
 		}()
 
-		t := time.NewTimer(timeout)
-		defer t.Stop()
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
 
 		select {
 		case p := <-panicChan:
-			tw.FreeBuffer()
-			gCtx.Writer = w
+			recorder.Close()
+			bufPool.Put(buffer)
 			gCtx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{mhttp.HTTPReturnCode: http.StatusInternalServerError})
 			panic(p)
 
 		case <-finish:
-			gCtx.Next()
-			tw.mu.Lock()
-			defer tw.mu.Unlock()
-			dst := tw.ResponseWriter.Header()
-			for k, vv := range tw.Header() {
-				dst[k] = vv
+			propagateTimeoutContextKeys(gCtx, handlerCtx)
+			if handlerCtx.IsAborted() {
+				gCtx.Abort()
 			}
-
-			if _, err := tw.ResponseWriter.Write(buffer.Bytes()); err != nil {
+			gCtx.Next()
+			if err := recorder.CommitTo(realWriter); err != nil {
 				log.Warn("failed to write response body", zap.Error(err))
-				tw.FreeBuffer()
+				recorder.Close()
 				bufPool.Put(buffer)
 				return
 			}
-			tw.FreeBuffer()
+			recorder.Close()
 			bufPool.Put(buffer)
 
-		case <-t.C:
-			cancel() // cancel context immediately so handler can detect timeout
+		case <-timer.C:
+			cancel()
 			gCtx.Abort()
-			tw.mu.Lock()
-			defer tw.mu.Unlock()
-			tw.timeout.Store(true)
-			tw.FreeBuffer()
+			gCtx.Set(HTTPReturnCode, merr.TimeoutCode)
+			gCtx.Set(HTTPReturnMessage, "request timeout")
+			recorder.CloseForTimeout()
 			bufPool.Put(buffer)
 
-			// Write timeout response directly to the original writer.
-			// Do NOT swap gCtx.Writer — handler goroutine may still be using it.
-			w.Header().Set("Content-Type", "application/json; charset=utf-8")
-			w.WriteHeader(http.StatusRequestTimeout)
+			realWriter.Header().Set("Content-Type", "application/json; charset=utf-8")
+			realWriter.WriteHeader(http.StatusRequestTimeout)
 			body, _ := json.Marshal(gin.H{HTTPReturnCode: merr.TimeoutCode, HTTPReturnMessage: "request timeout"})
-			w.Write(body)
+			realWriter.Write(body)
 		}
 	}
 }

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -60,9 +60,8 @@ func HTTPReturn(c *gin.Context, code int, result gin.H) {
 	c.JSON(code, result)
 }
 
-// HTTPReturnStream uses custom jsonRender that encodes JSON data directly into the response stream,
-// it uses less memory since it does not buffer the entire JSON structure before sending it,
-// unlike c.JSON in HTTPReturn, which serializes the JSON fully in memory before writing it to the response.
+// HTTPReturnStream uses custom jsonRender that encodes JSON data directly into the response writer.
+// Timeout-wrapped REST routes still buffer encoded bytes before committing them to the client.
 func HTTPReturnStream(c *gin.Context, code int, result gin.H) {
 	c.Set(HTTPReturnCode, result[HTTPReturnCode])
 	if errorMsg, ok := result[HTTPReturnMessage]; ok {


### PR DESCRIPTION
Cherry-pick from master
pr: #49982
Related to #49981

The REST timeout middleware could return a timeout response while the handler goroutine continued using the original Gin context. Once Gin recycled that context, late handler writes could race with a later request and trigger concurrent map writes.

Run timeout-wrapped handlers with a copied Gin context and a fully buffered response recorder instead. The original context and real response writer now remain owned by the middleware goroutine, while normal completion explicitly propagates selected metadata and commits the recorder. Timeout closes the recorder and writes the 408 response through the real writer, so late handler writes are discarded safely.

Add tests for recorder isolation, normal buffered commits, metadata and abort propagation, late writes after timeout, and race validation of the late-write timeout path.