### PR TITLE
test: align nightly search checks with master[2.6] 

### DIFF
--- a/tests/python_client/check/param_check.py
+++ b/tests/python_client/check/param_check.py
@@ -463,13 +463,17 @@ def output_field_value_check(search_res, original, pk_name):
                     for order in range(0, len(entity[field]), 4):
                         assert abs(original[field][_id][order] - entity[field][order]) < ct.epsilon
                 elif isinstance(entity[field], dict) and field != ct.default_json_field_name:
-                    # sparse checking, sparse vector must be the last, this is a bit hacky,
-                    # but sparse only supports list data type insertion for now
-                    assert entity[field].keys() == original[-1][_id].keys()
+                    # sparse vector checking: compare keys (indices) of the sparse vector
+                    num = original[original[pk_name] == _id].index.to_list()[0]
+                    assert entity[field].keys() == original[field][num].keys()
+                elif isinstance(entity[field], bytes):
+                    # bfloat16/float16/binary vectors returned as bytes — skip value check
+                    # (numpy dtype 'E' cannot be compared via ufunc 'equal' or converted to buffer)
+                    continue
                 else:
                     num = original[original[pk_name] == _id].index.to_list()[0]
                     expected_val = original[field][num]
-                    # pandas converts None to NaN, while Milvus returns None for nullable fields.
+                    # pandas converts None to NaN, while Milvus returns None for nullable fields
                     if entity[field] is None and (
                         expected_val is None or (isinstance(expected_val, float) and np.isnan(expected_val))
                     ):

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_by_pk.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_by_pk.py
@@ -34,6 +34,7 @@ default_search_mix_exp = 'int64 >= 0 && varchar >= "0"'
 default_json_search_exp = 'json_field["number"] >= 0'
 perfix_expr = 'varchar like "0%"'
 
+fast_create_pk_field = "id"
 default_vector_field_name = "vector"
 
 
@@ -64,8 +65,8 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
         self.binary_vector_index = "BIN_IVF_FLAT"
         self.primary_keys = []
         self.enable_dynamic_field = True
-        self.dyna_filed_name1 = "dyna_filed_name1"
-        self.dyna_filed_name2 = "dyna_filed_name2"
+        self.dyna_field_name1 = "dyna_field_name1"
+        self.dyna_field_name2 = "dyna_field_name2"
         self.datas = []
 
     @pytest.fixture(scope="class", autouse=True)
@@ -119,8 +120,8 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
                     self.binary_vector_field_name: binary_vectors[pk],
                     ct.default_float_field_name: pk * 1.0 if pk % 5 == 0 else None,
                     ct.default_string_field_name: str(pk) if pk % 5 == 0 else None,
-                    self.dyna_filed_name1: f"dyna_value_{pk}",
-                    self.dyna_filed_name2: pk * 1.0,
+                    self.dyna_field_name1: f"dyna_value_{pk}",
+                    self.dyna_field_name2: pk * 1.0,
                 }
                 self.datas.append(row)
 
@@ -316,7 +317,7 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
 
         # Create collection with nullable sparse vector field
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(fast_create_pk_field, DataType.INT64, is_primary=True, auto_id=False)
         schema.add_field("sparse_vec", DataType.SPARSE_FLOAT_VECTOR, nullable=True)
         self.create_collection(client, collection_name, schema=schema)
 
@@ -326,9 +327,9 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
         rows = []
         for i in range(nb):
             if i in null_indices:
-                row = {"id": i, "sparse_vec": None}
+                row = {fast_create_pk_field: i, "sparse_vec": None}
             else:
-                row = {"id": i, "sparse_vec": {i: 1.0, i + 100: 0.5}}
+                row = {fast_create_pk_field: i, "sparse_vec": {i: 1.0, i + 100: 0.5}}
             rows.append(row)
 
         self.insert(client, collection_name, rows)
@@ -597,14 +598,14 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
             search_params=search_params,
             limit=default_limit,
             consistency_level=consistency_level,
-            output_fields=[ct.default_string_field_name, self.dyna_filed_name1, self.dyna_filed_name2],
+            output_fields=[ct.default_string_field_name, self.dyna_field_name1, self.dyna_field_name2],
             check_task=CheckTasks.check_search_results,
             check_items={
                 "enable_milvus_client_api": True,
                 "nq": default_nq,
                 "limit": default_limit,
                 "metric": self.float_vector_metric,
-                "output_fields": [ct.default_string_field_name, self.dyna_filed_name1, self.dyna_filed_name2],
+                "output_fields": [ct.default_string_field_name, self.dyna_field_name1, self.dyna_field_name2],
                 "original_entities": self.datas,
                 "pk_name": self.pk_field_name,
             },
@@ -620,7 +621,7 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = self.collection_name
-        self.describe_collection(client, collection_name)[0]
+        collection_info = self.describe_collection(client, collection_name)[0]
         fields = collection_info.get("fields", None)
         field_names = [field.get("name") for field in fields]
 
@@ -643,7 +644,7 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
                 "nq": default_nq,
                 "limit": default_limit,
                 "metric": self.float_vector_metric,
-                "output_fields": field_names.extend([self.dyna_filed_name1, self.dyna_filed_name2]),
+                "output_fields": field_names + [self.dyna_field_name1, self.dyna_field_name2],
                 "original_entities": self.datas,
                 "pk_name": self.pk_field_name,
             },
@@ -662,7 +663,7 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = self.collection_name
-        self.describe_collection(client, collection_name)[0]
+        collection_info = self.describe_collection(client, collection_name)[0]
         partition_name = self.partition_names[0]
 
         # Generate vectors to search
@@ -671,7 +672,7 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
 
         # search with output fields
         expected_outputs = cf.get_wildcard_output_field_names(collection_info, wildcard_output_fields)
-        expected_outputs.extend([self.dyna_filed_name1, self.dyna_filed_name2])
+        expected_outputs.extend([self.dyna_field_name1, self.dyna_field_name2])
         log.info(f"search with output fields: {wildcard_output_fields}")
         self.search(
             client,
@@ -688,6 +689,7 @@ class TestMilvusClientSearchByPk(TestMilvusClientV2Base):
                 "nq": len(ids_to_search),
                 "pk_name": self.pk_field_name,
                 "limit": default_limit,
+                "metric": "COSINE",
                 "output_fields": expected_outputs,
             },
         )

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_v2_new.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_v2_new.py
@@ -64,8 +64,8 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         self.binary_vector_index = "BIN_IVF_FLAT"
         self.primary_keys = []
         self.enable_dynamic_field = True
-        self.dyna_filed_name1 = "dyna_filed_name1"
-        self.dyna_filed_name2 = "dyna_filed_name2"
+        self.dyna_field_name1 = "dyna_field_name1"
+        self.dyna_field_name2 = "dyna_field_name2"
         self.datas = []
 
     @pytest.fixture(scope="class", autouse=True)
@@ -119,8 +119,8 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
                     self.binary_vector_field_name: binary_vectors[pk],
                     ct.default_float_field_name: pk * 1.0 if pk % 5 == 0 else None,
                     ct.default_string_field_name: str(pk) if pk % 5 == 0 else None,
-                    self.dyna_filed_name1: f"dyna_value_{pk}",
-                    self.dyna_filed_name2: pk * 1.0,
+                    self.dyna_field_name1: f"dyna_value_{pk}",
+                    self.dyna_field_name2: pk * 1.0,
                 }
                 self.datas.append(row)
 
@@ -424,14 +424,14 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
             search_params=search_params,
             limit=default_limit,
             consistency_level=consistency_level,
-            output_fields=[ct.default_string_field_name, self.dyna_filed_name1, self.dyna_filed_name2],
+            output_fields=[ct.default_string_field_name, self.dyna_field_name1, self.dyna_field_name2],
             check_task=CheckTasks.check_search_results,
             check_items={
                 "enable_milvus_client_api": True,
                 "nq": default_nq,
                 "limit": default_limit,
                 "metric": self.float_vector_metric,
-                "output_fields": [ct.default_string_field_name, self.dyna_filed_name1, self.dyna_filed_name2],
+                "output_fields": [ct.default_string_field_name, self.dyna_field_name1, self.dyna_field_name2],
                 "original_entities": self.datas,
                 "pk_name": self.pk_field_name,
             },
@@ -447,7 +447,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = self.collection_name
-        self.describe_collection(client, collection_name)[0]
+        collection_info = self.describe_collection(client, collection_name)[0]
         fields = collection_info.get("fields", None)
         field_names = [field.get("name") for field in fields]
 
@@ -470,7 +470,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
                 "nq": default_nq,
                 "limit": default_limit,
                 "metric": self.float_vector_metric,
-                "output_fields": field_names.extend([self.dyna_filed_name1, self.dyna_filed_name2]),
+                "output_fields": field_names + [self.dyna_field_name1, self.dyna_field_name2],
                 "original_entities": self.datas,
                 "pk_name": self.pk_field_name,
             },
@@ -489,7 +489,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
         """
         client = self._client()
         collection_name = self.collection_name
-        self.describe_collection(client, collection_name)[0]
+        collection_info = self.describe_collection(client, collection_name)[0]
         partition_name = self.partition_names[0]
 
         # Generate vectors to search
@@ -498,7 +498,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
 
         # search with output fields
         expected_outputs = cf.get_wildcard_output_field_names(collection_info, wildcard_output_fields)
-        expected_outputs.extend([self.dyna_filed_name1, self.dyna_filed_name2])
+        expected_outputs.extend([self.dyna_field_name1, self.dyna_field_name2])
         log.info(f"search with output fields: {wildcard_output_fields}")
         search_res, _ = self.search(
             client,
@@ -514,6 +514,7 @@ class TestMilvusClientSearchBasicV2(TestMilvusClientV2Base):
                 "enable_milvus_client_api": True,
                 "nq": default_nq,
                 "pk_name": self.pk_field_name,
+                "metric": self.float_vector_metric,
                 "limit": default_limit,
                 "output_fields": expected_outputs,
             },

--- a/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_ttl.py
@@ -47,20 +47,25 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
         dim = 65
         ttl = 11
         nb = 1000
+        # field name constants
+        pk_field = "id"
+        vec_field = "embeddings"
+        vec_field_2 = "embeddings_2"
+        bool_field = "visible"
         collection_name = cf.gen_collection_name_by_testcase_name()
         schema = self.create_schema(client, enable_dynamic_field=False)[0]
-        schema.add_field("id", DataType.INT64, is_primary=True, auto_id=False)
-        schema.add_field("embeddings", DataType.FLOAT_VECTOR, dim=dim)
-        schema.add_field("embeddings_2", DataType.FLOAT_VECTOR, dim=dim)
-        schema.add_field("visible", DataType.BOOL, nullable=True)
+        schema.add_field(pk_field, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(vec_field, DataType.FLOAT_VECTOR, dim=dim)
+        schema.add_field(vec_field_2, DataType.FLOAT_VECTOR, dim=dim)
+        schema.add_field(bool_field, DataType.BOOL, nullable=True)
         self.create_collection(client, collection_name, schema=schema, properties={"collection.ttl.seconds": ttl})
         collection_info = self.describe_collection(client, collection_name)[0]
         assert collection_info['properties']["collection.ttl.seconds"] == str(ttl)
 
         # create index
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name="embeddings", index_type="IVF_FLAT", metric_type="COSINE", nlist=128)
-        index_params.add_index(field_name="embeddings_2", index_type="IVF_FLAT", metric_type="COSINE", nlist=128)
+        index_params.add_index(field_name=vec_field, index_type="IVF_FLAT", metric_type="COSINE", nlist=128)
+        index_params.add_index(field_name=vec_field_2, index_type="IVF_FLAT", metric_type="COSINE", nlist=128)
         self.create_index(client, collection_name, index_params=index_params)
 
         # load collection
@@ -69,18 +74,10 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
         # insert data
         insert_times = 2
         for i in range(insert_times):
-            vectors = cf.gen_vectors(nb, dim=dim)
-            vectors_2 = cf.gen_vectors(nb, dim=dim)
-            rows = []
             start_id = i * nb
-            for j in range(nb):
-                row = {
-                    "id": start_id + j,
-                    "embeddings": list(vectors[j]),
-                    "embeddings_2": list(vectors_2[j]),
-                    "visible": False
-                }
-                rows.append(row)
+            rows = cf.gen_row_data_by_schema(nb=nb, schema=schema, start=start_id)
+            for row in rows:
+                row[bool_field] = False
             if on_insert is True:
                 self.insert(client, collection_name, rows)
             else:
@@ -94,8 +91,8 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
         query_ttl_effective = False
         hybrid_search_ttl_effective = False
         search_vectors = cf.gen_vectors(nq, dim=dim)
-        sub_search1 = AnnSearchRequest(search_vectors, "embeddings", {"level": 1}, 20)
-        sub_search2 = AnnSearchRequest(search_vectors, "embeddings_2", {"level": 1}, 20)
+        sub_search1 = AnnSearchRequest(search_vectors, vec_field, {"level": 1}, 20)
+        sub_search2 = AnnSearchRequest(search_vectors, vec_field_2, {"level": 1}, 20)
         ranker = WeightedRanker(0.2, 0.8)
         # flush collection if flush_enable is True
         if flush_enable:
@@ -104,8 +101,8 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
             log.info(f"flush completed in {time.time() - t1}s")
         while time.time() - start_time < timeout:
             if search_ttl_effective is False:
-                res1 = self.search(client, collection_name, search_vectors, anns_field='embeddings',
-                                   search_params={}, limit=10, consistency_level=CONSISTENCY_STRONG)[0]
+                res1 = self.search(client, collection_name, search_vectors, anns_field=vec_field,
+                                   search_params={"metric_type": "COSINE"}, limit=10, consistency_level=CONSISTENCY_STRONG)[0]
             if query_ttl_effective is False:
                 res2 = self.query(client, collection_name, filter='',
                                   output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
@@ -138,18 +135,10 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
 
         # insert more data
         for i in range(insert_times):
-            vectors = cf.gen_vectors(nb, dim=dim)
-            vectors_2 = cf.gen_vectors(nb, dim=dim)
-            rows = []
             start_id = (insert_times + i) * nb
-            for j in range(nb):
-                row = {
-                    "id": start_id + j,
-                    "embeddings": list(vectors[j]),
-                    "embeddings_2": list(vectors_2[j]),
-                    "visible": True
-                }
-                rows.append(row)
+            rows = cf.gen_row_data_by_schema(nb=nb, schema=schema, start=start_id)
+            for row in rows:
+                row[bool_field] = True
             if on_insert is True:
                 self.insert(client, collection_name, rows)
             else:
@@ -162,50 +151,70 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
             log.info(f"flush completed in {time.time() - t1}s")
 
         # search data again after insert more data
-        for i in range(15):
-            res = self.search(client, collection_name, search_vectors,
-                              search_params={}, anns_field='embeddings',
-                              limit=10, consistency_level=CONSISTENCY_STRONG)[0]
-            if len(res[0]) > 0:
-                break
-            time.sleep(2)
-        assert len(res[0]) > 0, \
-            "Search with Strong consistency returned 0 results after retries"
-        # query count(*)
-        res = self.query(client, collection_name, filter='',
-                         output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)', None) == nb * insert_times
-        res = self.query(client, collection_name, filter='visible==False',
-                         output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)', None) == 0
-        res = self.query(client, collection_name, filter='visible==True',
-                         output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)', None) == nb * insert_times
-        # hybrid search
-        res = self.hybrid_search(client, collection_name, [sub_search1, sub_search2], ranker,
-                                 limit=10, consistency_level=CONSISTENCY_STRONG)[0]
-        assert len(res[0]) > 0
+        consistency_levels = [CONSISTENCY_EVENTUALLY, CONSISTENCY_BOUNDED, CONSISTENCY_SESSION, CONSISTENCY_STRONG]
+        for consistency_level in consistency_levels:
+            log.debug(f"start to search/query with {consistency_level}")
+            # Poll until search returns results (search visibility may lag behind query)
+            for i in range(15):
+                res = self.search(client, collection_name, search_vectors,
+                                  search_params={"metric_type": "COSINE"}, anns_field=vec_field,
+                                  limit=10, consistency_level=consistency_level)[0]
+                if len(res[0]) > 0:
+                    break
+                time.sleep(2)
+            assert len(res[0]) > 0, \
+                f"Search with {consistency_level} returned 0 results after retries"
+
+            if consistency_level != CONSISTENCY_STRONG:
+                pass
+            else:
+                # query count(*)
+                res = self.query(client, collection_name, filter='',
+                                 output_fields=["count(*)"], consistency_level=consistency_level)[0]
+                assert res[0].get('count(*)', None) == nb * insert_times
+                res = self.query(client, collection_name, filter='visible==False',
+                                 output_fields=["count(*)"], consistency_level=consistency_level)[0]
+                assert res[0].get('count(*)', None) == 0
+                # query count(visible)
+                res = self.query(client, collection_name, filter='visible==True',
+                                 output_fields=["count(*)"], consistency_level=consistency_level)[0]
+                assert res[0].get('count(*)', None) == nb * insert_times
+
+            # hybrid search
+            res = self.hybrid_search(client, collection_name, [sub_search1, sub_search2], ranker,
+                                     limit=10, consistency_level=consistency_level)[0]
+            assert len(res[0]) > 0
 
         # alter ttl to 2000s
         self.alter_collection_properties(client, collection_name, properties={"collection.ttl.seconds": 2000})
-        # search data after alter ttl
-        res = self.search(client, collection_name, search_vectors,
-                          search_params={}, anns_field='embeddings',
-                          filter='visible==False', limit=10, consistency_level=CONSISTENCY_STRONG)[0]
-        assert len(res[0]) > 0
-        # hybrid search data after alter ttl
-        sub_search1 = AnnSearchRequest(search_vectors, "embeddings", {"level": 1}, 20, expr='visible==False')
-        sub_search2 = AnnSearchRequest(search_vectors, "embeddings_2", {"level": 1}, 20, expr='visible==False')
-        res = self.hybrid_search(client, collection_name, [sub_search1, sub_search2], ranker,
-                                 limit=10, consistency_level=CONSISTENCY_STRONG)[0]
-        assert len(res[0]) > 0
-        # query count(*)
-        res = self.query(client, collection_name, filter='visible==False',
-                         output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)', 0) == insert_times * nb
-        res = self.query(client, collection_name, filter='',
-                         output_fields=["count(*)"], consistency_level=CONSISTENCY_STRONG)[0]
-        assert res[0].get('count(*)', 0) == insert_times * nb * 2
+        for consistency_level in consistency_levels:
+            log.debug(f"start to search/query after alter ttl with {consistency_level}")
+            # search data after alter ttl
+            res = self.search(client, collection_name, search_vectors,
+                              search_params={"metric_type": "COSINE"}, anns_field=vec_field,
+                              filter='visible==False', limit=10, consistency_level=consistency_level,
+                              output_fields=[bool_field])[0]
+            assert len(res[0]) > 0
+            for hit in res[0]:
+                assert hit.get(bool_field) == False
+
+            # hybrid search data after alter ttl
+            sub_search1 = AnnSearchRequest(search_vectors, vec_field, {"level": 1}, 20, expr='visible==False')
+            sub_search2 = AnnSearchRequest(search_vectors, vec_field_2, {"level": 1}, 20, expr='visible==False')
+            res = self.hybrid_search(client, collection_name, [sub_search1, sub_search2], ranker,
+                                     limit=10, consistency_level=consistency_level)[0]
+            assert len(res[0]) > 0
+
+            # query count(*)
+            res = self.query(client, collection_name, filter='visible==False',
+                             output_fields=["count(*)"], consistency_level=consistency_level)[0]
+            assert res[0].get('count(*)', 0) == insert_times * nb
+            res = self.query(client, collection_name, filter='',
+                             output_fields=["count(*)"], consistency_level=consistency_level)[0]
+            if consistency_level != CONSISTENCY_STRONG:
+                assert res[0].get('count(*)', 0) >= insert_times * nb
+            else:
+                assert res[0].get('count(*)', 0) == insert_times * nb * 2
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.skip("not stable")
@@ -342,4 +351,3 @@ class TestMilvusClientTTL(TestMilvusClientV2Base):
                 time.sleep(1)
 
         self.drop_collection(client, collection_name)
-


### PR DESCRIPTION
pr: #48347

Related master PRs: #48347, #48345, #48584, #48786
Related issue: #49992

## What this PR does

Backports the master-side Python client test fixes needed by the 2.6 Nightly failures:

- fixes dynamic-field spelling and output-field check setup in search-by-PK/search-v2 cases
- aligns wildcard output-field metric checks with master
- updates TTL default coverage to use generated schema rows and consistency-level checks from master
- updates output-field value checking for sparse vectors and byte-backed vector fields

## Verification

- `python -m py_compile` on the four touched Python files: passed
- Targeted pytest against the 2.6 Nightly environment with `--host 10.104.21.115`: 9 passed, 1 failed

Known remaining failure:

- `test_search_by_pk_nullable_vector_field` still fails with `MilvusException: vector data is not schemapb.VectorField_SparseFloatVector`; tracked by #49992.