### PR TITLE
test: [cp2.6]Add nullable vector field coverage

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -3631,6 +3631,57 @@ class TestMilvusClientStructArrayInvalid(TestMilvusClientV2Base):
         }
         self.create_collection(client, collection_name, schema=schema, check_task=CheckTasks.err_res, check_items=error)
 
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_embedding_list_field_nullable_insert_none_not_supported(self):
+        """
+        target: test embedding list field nullable boundary
+        method: create struct array field with nullable=True and insert None
+        expected: create collection succeeds, but None row value is not supported
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(
+            field_name="normal_vector",
+            datatype=DataType.FLOAT_VECTOR,
+            dim=default_dim,
+        )
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_schema.add_field("label", DataType.VARCHAR, max_length=128)
+
+        schema.add_field(
+            "clips",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=100,
+            nullable=True,
+        )
+        res, check = self.create_collection(client, collection_name, schema=schema)
+        assert check
+
+        data = [
+            {
+                "id": 0,
+                "normal_vector": [random.random() for _ in range(default_dim)],
+                "clips": None,
+            }
+        ]
+        error = {
+            ct.err_code: 1,
+            ct.err_msg: "Expected list, got NoneType",
+        }
+        self.insert(
+            client,
+            collection_name,
+            data,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
+
     @pytest.mark.tags(CaseLabel.L0)
     def test_struct_array_range_search_not_supported(self):
         """

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_pagination.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_pagination.py
@@ -1,3 +1,5 @@
+# ruff: noqa: E712,E731,F401,F403,F405,F541,F841,I001,UP031,UP032,W291,W292,W293
+# fmt: off
 import logging
 
 
@@ -82,9 +84,9 @@ class TestMilvusClientSearchPagination(TestMilvusClientV2Base):
         # Create collection
         collection_schema = self.create_schema(client)[0]
         collection_schema.add_field(default_primary_key_field_name, DataType.INT64, is_primary=True, auto_id=False)
-        collection_schema.add_field(self.float_vector_field_name, DataType.FLOAT_VECTOR, dim=128)
+        collection_schema.add_field(self.float_vector_field_name, DataType.FLOAT_VECTOR, dim=128, nullable=True)
         collection_schema.add_field(self.bfloat16_vector_field_name, DataType.BFLOAT16_VECTOR, dim=200)
-        collection_schema.add_field(self.sparse_vector_field_name, DataType.SPARSE_FLOAT_VECTOR)
+        collection_schema.add_field(self.sparse_vector_field_name, DataType.SPARSE_FLOAT_VECTOR, nullable=True)
         collection_schema.add_field(self.binary_vector_field_name, DataType.BINARY_VECTOR, dim=256)
         collection_schema.add_field(default_float_field_name, DataType.FLOAT)
         collection_schema.add_field(default_string_field_name, DataType.VARCHAR, max_length=256)
@@ -116,9 +118,9 @@ class TestMilvusClientSearchPagination(TestMilvusClientV2Base):
                 pk = i + j * default_nb
                 row = {
                     default_primary_key_field_name: pk,
-                    self.float_vector_field_name: list(float_vectors[pk]),
+                    self.float_vector_field_name: None if pk % 10 == 9 else list(float_vectors[pk]),
                     self.bfloat16_vector_field_name: bfloat16_vectors[pk],
-                    self.sparse_vector_field_name: sparse_vectors[pk], 
+                    self.sparse_vector_field_name: None if pk % 10 == 9 else sparse_vectors[pk],
                     self.binary_vector_field_name: binary_vectors[pk],
                     default_float_field_name: pk * 1.0,
                     default_string_field_name: str(pk),
@@ -462,7 +464,7 @@ class TestMilvusClientSearchPagination(TestMilvusClientV2Base):
             for i, _id in enumerate(self.primary_keys):
                 int64 = total_datas[i][ct.default_int64_field_name]
                 float = total_datas[i][ct.default_float_field_name]
-                if not expr or eval(expr):
+                if (not expr or eval(expr)) and total_datas[i][self.float_vector_field_name] is not None:
                     filter_ids.append(_id)
             # 2. search
             limit = min(default_limit, len(filter_ids))

--- a/tests/python_client/testcases/test_full_text_search.py
+++ b/tests/python_client/testcases/test_full_text_search.py
@@ -1,3 +1,5 @@
+# ruff: noqa: E712,E731,F401,F403,F405,F541,F841,I001,UP031,UP032,W291,W292,W293
+# fmt: off
 import json
 import random
 
@@ -386,6 +388,54 @@ class TestCreateCollectionWithFullTextSearchNegative(TestcaseBase):
             name=cf.gen_unique_str(prefix),
             schema=schema,
             check_task=check_task,
+            check_items=check_items,
+        )
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_create_collection_for_full_text_search_with_nullable_function_output(self):
+        """
+        target: test create collection with nullable BM25 function output
+        method: create collection with BM25 output sparse vector field set nullable
+        expected: create collection failed
+        """
+        analyzer_params = {
+            "tokenizer": "standard",
+        }
+        dim = 128
+        fields = [
+            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+            FieldSchema(
+                name="text",
+                dtype=DataType.VARCHAR,
+                max_length=65535,
+                nullable=True,
+                enable_analyzer=True,
+                analyzer_params=analyzer_params,
+            ),
+            FieldSchema(name="emb", dtype=DataType.FLOAT_VECTOR, dim=dim),
+            FieldSchema(
+                name="text_sparse_emb",
+                dtype=DataType.SPARSE_FLOAT_VECTOR,
+                nullable=True,
+            ),
+        ]
+        schema = CollectionSchema(fields=fields, description="test collection")
+        bm25_function = Function(
+            name="text_bm25_emb",
+            function_type=FunctionType.BM25,
+            input_field_names=["text"],
+            output_field_names=["text_sparse_emb"],
+            params={},
+        )
+        schema.add_function(bm25_function)
+        check_items = {
+            ct.err_code: 65535,
+            ct.err_msg: "function output field cannot be nullable",
+        }
+        self.init_collection_wrap(
+            name=cf.gen_unique_str(prefix),
+            schema=schema,
+            check_task=CheckTasks.err_res,
             check_items=check_items,
         )
 
@@ -2063,6 +2113,83 @@ class TestSearchWithFullTextSearch(TestcaseBase):
       The following cases are used to test search for full text search
     ******************************************************************
     """
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_full_text_search_with_nullable_text_input(self):
+        """
+        target: test full text search with nullable function input
+        method: insert data with None text and search on BM25 sparse field
+        expected: nullable input rows are accepted and not matched by BM25 search
+        """
+        analyzer_params = {
+            "tokenizer": "standard",
+        }
+        dim = 8
+        fields = [
+            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+            FieldSchema(
+                name="text",
+                dtype=DataType.VARCHAR,
+                max_length=65535,
+                nullable=True,
+                enable_analyzer=True,
+                enable_match=True,
+                analyzer_params=analyzer_params,
+            ),
+            FieldSchema(name="emb", dtype=DataType.FLOAT_VECTOR, dim=dim),
+            FieldSchema(name="text_sparse_emb", dtype=DataType.SPARSE_FLOAT_VECTOR),
+        ]
+        schema = CollectionSchema(fields=fields, description="test collection")
+        bm25_function = Function(
+            name="text_bm25_emb",
+            function_type=FunctionType.BM25,
+            input_field_names=["text"],
+            output_field_names=["text_sparse_emb"],
+            params={},
+        )
+        schema.add_function(bm25_function)
+        collection_w = self.init_collection_wrap(
+            name=cf.gen_unique_str(prefix), schema=schema
+        )
+        data = [
+            {"id": 0, "text": "milvus vector database", "emb": [0.1] * dim},
+            {"id": 1, "text": None, "emb": [0.2] * dim},
+            {"id": 2, "text": "", "emb": [0.3] * dim},
+            {"id": 3, "text": "vector search", "emb": [0.4] * dim},
+        ]
+        collection_w.insert(data)
+        collection_w.flush()
+        collection_w.create_index(
+            "emb",
+            {
+                "index_type": "FLAT",
+                "metric_type": "L2",
+            },
+        )
+        collection_w.create_index(
+            "text_sparse_emb",
+            {
+                "index_type": "SPARSE_INVERTED_INDEX",
+                "metric_type": "BM25",
+            },
+        )
+        collection_w.create_index("text", {"index_type": "INVERTED"})
+        collection_w.load()
+
+        query_res, _ = collection_w.query(
+            expr="id in [1]", output_fields=["id", "text"]
+        )
+        assert query_res == [{"id": 1, "text": None}]
+        search_res, _ = collection_w.search(
+            data=["vector"],
+            anns_field="text_sparse_emb",
+            param={},
+            limit=4,
+            output_fields=["id", "text"],
+        )
+        search_ids = [hit.id for hit in search_res[0]]
+        assert len(search_ids) > 0
+        assert 1 not in search_ids
 
     @pytest.mark.tags(CaseLabel.L0)
     @pytest.mark.parametrize("nq", [2])


### PR DESCRIPTION
pr: #49649

Cherry-pick PR #49649 to 2.6.

Changes:
- Add nullable vector/search pagination coverage in 2.6 client v2 tests.
- Add nullable full-text search function input/output coverage.
- Add nullable struct array embedding-list boundary coverage.

Notes:
- Skipped the master sync merge commit from the source PR.
- The group-by nullable vector coverage already exists in the 2.6 milvus_client_v2 test file, so the deleted old-path conflict was resolved by keeping 2.6 layout.