### PR TITLE
fix: refuse to build QueryCoord target when channel checkpoint is dropped sentinel

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -375,7 +375,7 @@ func (m *meta) reloadFromKV(ctx context.Context, collectionIDs []int64) error {
 		// for 2.2.2 issue https://github.com/milvus-io/milvus/issues/22181
 		pos.ChannelName = vChannel
 		m.channelCPs.checkpoints[vChannel] = pos
-		if pos.Timestamp != math.MaxUint64 {
+		if !funcutil.IsDroppedChannelCheckpoint(pos) {
 			// Should not be set as metric since it's a tombstone value.
 			ts, _ := tsoutil.ParseTS(pos.Timestamp)
 			metrics.DataCoordCheckpointUnixSeconds.WithLabelValues(paramtable.GetStringNodeID(), vChannel).
@@ -2379,15 +2379,17 @@ func (m *meta) UpdateChannelCheckpoint(ctx context.Context, vChannel string, pos
 	return nil
 }
 
-// MarkChannelCheckpointDropped set channel checkpoint to MaxUint64 preventing future update
-// and remove the metrics for channel checkpoint lag.
+// MarkChannelCheckpointDropped writes the dropped-channel sentinel
+// (funcutil.DroppedChannelCheckpointTimestamp) so no later
+// UpdateChannelCheckpoint can overwrite it, and removes the channel-checkpoint
+// lag metric.
 func (m *meta) MarkChannelCheckpointDropped(ctx context.Context, channel string) error {
 	m.channelCPs.Lock()
 	defer m.channelCPs.Unlock()
 
 	cp := &msgpb.MsgPosition{
 		ChannelName: channel,
-		Timestamp:   math.MaxUint64,
+		Timestamp:   funcutil.DroppedChannelCheckpointTimestamp,
 	}
 
 	err := m.catalog.SaveChannelCheckpoints(ctx, []*msgpb.MsgPosition{cp})

--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
@@ -151,6 +152,22 @@ func (mgr *TargetManager) UpdateCollectionNextTarget(ctx context.Context, collec
 	if err != nil {
 		log.Warn("failed to get next targets for collection", zap.Int64("collectionID", collectionID), zap.Error(err))
 		return err
+	}
+
+	// A dropped checkpoint sentinel is not a valid seek position; do not
+	// build a next target that could dispatch WatchDmChannels with it.
+	for _, channelInfo := range vChannelInfos {
+		if funcutil.IsDroppedChannelCheckpoint(channelInfo.GetSeekPosition()) {
+			log.Warn("refuse to build next target: channel checkpoint is a dropped sentinel; sticky until collection meta is fully dropped",
+				zap.Int64("collectionID", collectionID),
+				zap.String("channel", channelInfo.GetChannelName()),
+				zap.Uint64("seekTs", channelInfo.GetSeekPosition().GetTimestamp()),
+			)
+			return merr.WrapErrChannelNotAvailable(
+				channelInfo.GetChannelName(),
+				"channel has dropped checkpoint sentinel; refuse to build next target",
+			)
+		}
 	}
 
 	partitionIDs := mgr.meta.GetPartitionIDsByCollection(ctx, collectionID)

--- a/internal/querycoordv2/meta/target_manager_test.go
+++ b/internal/querycoordv2/meta/target_manager_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus/internal/json"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
 	"github.com/milvus-io/milvus/internal/metastore"
@@ -38,6 +39,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -774,6 +777,132 @@ func (suite *TargetManagerSuite) TestGetTargetJSON() {
 	err = json.Unmarshal([]byte(jsonStr), &currentTarget)
 	suite.NoError(err)
 	assert.Len(suite.T(), currentTarget2, 0)
+}
+
+func (suite *TargetManagerSuite) TestUpdateNextTarget_DroppedSentinelRejected() {
+	ctx := suite.ctx
+	collectionID := int64(2001)
+
+	suite.meta.PutCollection(ctx, &Collection{
+		CollectionLoadInfo: &querypb.CollectionLoadInfo{
+			CollectionID:  collectionID,
+			ReplicaNumber: 1,
+		},
+	})
+	suite.meta.PutPartition(ctx, &Partition{
+		PartitionLoadInfo: &querypb.PartitionLoadInfo{
+			CollectionID: collectionID,
+			PartitionID:  1,
+		},
+	})
+
+	sentinelChannels := []*datapb.VchannelInfo{
+		{
+			CollectionID: collectionID,
+			ChannelName:  "sentinel-channel",
+			SeekPosition: &msgpb.MsgPosition{
+				ChannelName: "sentinel-channel",
+				Timestamp:   funcutil.DroppedChannelCheckpointTimestamp,
+			},
+		},
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).
+		Return(sentinelChannels, nil, nil).Once()
+
+	err := suite.mgr.UpdateCollectionNextTarget(ctx, collectionID)
+	suite.Require().Error(err)
+	suite.True(errors.Is(err, merr.ErrChannelNotAvailable),
+		"error should wrap ErrChannelNotAvailable, got: %v", err)
+	suite.Contains(err.Error(), "sentinel-channel")
+	suite.Contains(err.Error(), "dropped checkpoint sentinel")
+
+	// Next target must NOT be advanced.
+	suite.assertChannels([]string{}, suite.mgr.GetDmChannelsByCollection(ctx, collectionID, NextTarget))
+}
+
+func (suite *TargetManagerSuite) TestUpdateNextTarget_SentinelAmongMultiple() {
+	ctx := suite.ctx
+	collectionID := int64(2002)
+
+	suite.meta.PutCollection(ctx, &Collection{
+		CollectionLoadInfo: &querypb.CollectionLoadInfo{
+			CollectionID:  collectionID,
+			ReplicaNumber: 1,
+		},
+	})
+	suite.meta.PutPartition(ctx, &Partition{
+		PartitionLoadInfo: &querypb.PartitionLoadInfo{
+			CollectionID: collectionID,
+			PartitionID:  1,
+		},
+	})
+
+	mixedChannels := []*datapb.VchannelInfo{
+		{
+			CollectionID: collectionID,
+			ChannelName:  "normal-channel",
+			SeekPosition: &msgpb.MsgPosition{
+				ChannelName: "normal-channel",
+				Timestamp:   450000000000000000,
+			},
+		},
+		{
+			CollectionID: collectionID,
+			ChannelName:  "poisoned-channel",
+			SeekPosition: &msgpb.MsgPosition{
+				ChannelName: "poisoned-channel",
+				Timestamp:   funcutil.DroppedChannelCheckpointTimestamp,
+			},
+		},
+	}
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).
+		Return(mixedChannels, nil, nil).Once()
+
+	err := suite.mgr.UpdateCollectionNextTarget(ctx, collectionID)
+	suite.Require().Error(err)
+	suite.True(errors.Is(err, merr.ErrChannelNotAvailable))
+	suite.Contains(err.Error(), "poisoned-channel")
+
+	// Next target must remain empty — no partial build.
+	suite.assertChannels([]string{}, suite.mgr.GetDmChannelsByCollection(ctx, collectionID, NextTarget))
+}
+
+func (suite *TargetManagerSuite) TestUpdateNextTarget_SentinelDoesNotBurnRetries() {
+	ctx := suite.ctx
+	collectionID := int64(2003)
+
+	suite.meta.PutCollection(ctx, &Collection{
+		CollectionLoadInfo: &querypb.CollectionLoadInfo{
+			CollectionID:  collectionID,
+			ReplicaNumber: 1,
+		},
+	})
+	suite.meta.PutPartition(ctx, &Partition{
+		PartitionLoadInfo: &querypb.PartitionLoadInfo{
+			CollectionID: collectionID,
+			PartitionID:  1,
+		},
+	})
+
+	sentinelChannels := []*datapb.VchannelInfo{
+		{
+			CollectionID: collectionID,
+			ChannelName:  "sentinel-once",
+			SeekPosition: &msgpb.MsgPosition{
+				ChannelName: "sentinel-once",
+				Timestamp:   funcutil.DroppedChannelCheckpointTimestamp,
+			},
+		},
+	}
+
+	// .Once() asserts that GetRecoveryInfoV2 is called exactly once: the
+	// sentinel must not re-enter the retry.Handle loop.
+	suite.broker.EXPECT().GetRecoveryInfoV2(mock.Anything, collectionID).
+		Return(sentinelChannels, nil, nil).Once()
+
+	err := suite.mgr.UpdateCollectionNextTarget(ctx, collectionID)
+	suite.Require().Error(err)
+	suite.broker.AssertExpectations(suite.T())
 }
 
 func BenchmarkTargetManager(b *testing.B) {

--- a/pkg/util/funcutil/checkpoint.go
+++ b/pkg/util/funcutil/checkpoint.go
@@ -1,0 +1,47 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funcutil
+
+import (
+	"math"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+)
+
+// DroppedChannelCheckpointTimestamp is the reserved timestamp value used to
+// mark a channel checkpoint as dropped. No legitimate channel checkpoint may
+// carry this value.
+//
+// The sole writer is datacoord.(*meta).MarkChannelCheckpointDropped, invoked
+// when a vchannel is dropped. The sentinel is sticky:
+// datacoord.(*meta).UpdateChannelCheckpoint refuses to overwrite it because
+// oldTs < newTs fails when oldTs == DroppedChannelCheckpointTimestamp. A
+// sentinel therefore remains visible to readers (e.g. GetRecoveryInfo) until
+// the collection meta is fully dropped, at which point the channel ceases to
+// be returned at all.
+const DroppedChannelCheckpointTimestamp uint64 = math.MaxUint64
+
+// IsDroppedChannelCheckpoint reports whether the given checkpoint position is
+// the dropped-channel sentinel.
+//
+// Callers that consume channel seek positions (notably QueryCoord's target
+// builder) MUST treat a sentinel as an abnormal metadata state — not a normal
+// "start from this position" instruction — and refuse to use it as a seek
+// point.
+func IsDroppedChannelCheckpoint(pos *msgpb.MsgPosition) bool {
+	return pos != nil && pos.GetTimestamp() == DroppedChannelCheckpointTimestamp
+}

--- a/pkg/util/funcutil/checkpoint_test.go
+++ b/pkg/util/funcutil/checkpoint_test.go
@@ -1,0 +1,79 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package funcutil
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+)
+
+func TestIsDroppedChannelCheckpoint(t *testing.T) {
+	cases := []struct {
+		name     string
+		pos      *msgpb.MsgPosition
+		expected bool
+	}{
+		{
+			name:     "nil position is not sentinel",
+			pos:      nil,
+			expected: false,
+		},
+		{
+			name:     "zero timestamp is not sentinel",
+			pos:      &msgpb.MsgPosition{Timestamp: 0},
+			expected: false,
+		},
+		{
+			// A typical Milvus TSO-encoded timestamp (physical ms shifted left 18 bits).
+			name:     "normal recent timestamp is not sentinel",
+			pos:      &msgpb.MsgPosition{Timestamp: 450000000000000000},
+			expected: false,
+		},
+		{
+			name:     "exact sentinel timestamp is sentinel",
+			pos:      &msgpb.MsgPosition{Timestamp: math.MaxUint64},
+			expected: true,
+		},
+		{
+			name:     "sentinel timestamp with MsgID set is still sentinel",
+			pos:      &msgpb.MsgPosition{Timestamp: math.MaxUint64, MsgID: []byte{1, 2, 3}},
+			expected: true,
+		},
+		{
+			name:     "timestamp one below sentinel is not sentinel",
+			pos:      &msgpb.MsgPosition{Timestamp: math.MaxUint64 - 1},
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsDroppedChannelCheckpoint(tc.pos))
+		})
+	}
+}
+
+func TestDroppedChannelCheckpointTimestamp(t *testing.T) {
+	// Contract: the sentinel value is math.MaxUint64. Anything else would
+	// break MarkChannelCheckpointDropped's intent that the sentinel can
+	// never be overwritten by a normal checkpoint update.
+	assert.Equal(t, uint64(math.MaxUint64), DroppedChannelCheckpointTimestamp)
+}


### PR DESCRIPTION
## Summary
- Block dropped-channel checkpoint sentinels (`Timestamp == math.MaxUint64`) at QueryCoord's `UpdateCollectionNextTarget`, before they can be dispatched to QueryNode as a seek position and trigger a streaming-dispatcher panic on secondary clusters.
- Add `funcutil.IsDroppedChannelCheckpoint` so the sentinel contract has a single owner; migrate DataCoord's writer/reader to use it.
- Return `ErrChannelNotAvailable` with explicit "dropped checkpoint sentinel" detail so the abnormal metadata state is visible in logs and to clients.

The sentinel is sticky in DataCoord (`UpdateChannelCheckpoint` cannot overwrite `MaxUint64`); the guard remains in effect until the collection meta is fully dropped, at which point `GetRecoveryInfoV2` returns collection-not-found and the existing path releases the collection.

issue: #49996

## Test plan
- [x] `pkg/util/funcutil` unit tests: `TestIsDroppedChannelCheckpoint` (6 sub-cases) + `TestDroppedChannelCheckpointTimestamp`
- [x] `internal/querycoordv2/meta` `TestTargetManager`: 3 new sub-tests (`TestUpdateNextTarget_DroppedSentinelRejected`, `TestUpdateNextTarget_SentinelAmongMultiple`, `TestUpdateNextTarget_SentinelDoesNotBurnRetries`); all existing sub-tests still pass
- [x] `make static-check` (0 issues across all 4 phases)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)