### PR TITLE
enhance: add request timeout to access logs

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -358,15 +358,15 @@ proxy:
     remoteMaxTime: 0 # The time interval allowed for uploading access log files. If the upload time of a log file exceeds this interval, the file will be deleted. Setting the value to 0 disables this feature.
     formatters:
       base:
-        format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost]"
+        format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [timeout: $request_timeout]"
       query:
-        format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [database: $database_name] [collection: $collection_name] [partitions: $partition_name] [expr: $method_expr] [params: $query_params]"
+        format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [timeout: $request_timeout] [database: $database_name] [collection: $collection_name] [partitions: $partition_name] [expr: $method_expr] [params: $query_params]"
         methods: "Query, Delete"
       search:
-        format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [database: $database_name] [collection: $collection_name] [partitions: $partition_name] [expr: $method_expr] [nq: $nq] [params: $search_params]"
+        format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [timeout: $request_timeout] [database: $database_name] [collection: $collection_name] [partitions: $partition_name] [expr: $method_expr] [nq: $nq] [params: $search_params]"
         methods: "HybridSearch, Search"
       upsert:
-        format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [database: $database_name] [collection: $collection_name] [partitions: $partition_name] [partial_update: $partial_update]"
+        format: "[$time_now] [ACCESS] <$user_name: $user_addr> $method_name [status: $method_status] [code: $error_code] [sdk: $sdk_version] [msg: $error_msg] [traceID: $trace_id] [timeCost: $time_cost] [timeout: $request_timeout] [database: $database_name] [collection: $collection_name] [partitions: $partition_name] [partial_update: $partial_update]"
         methods: Upsert
     cacheSize: 0 # Size of log of write cache, in byte. (Close write cache if size was 0)
     cacheFlushInterval: 3 # time interval of auto flush write cache, in seconds. (Close auto flush if interval was 0)

--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -125,6 +125,7 @@ const (
 	HTTPAliasName            = "aliasName"
 	HTTPRequestData          = "data"
 	HTTPRequestDefaultValue  = "defaultValue"
+	ContextRequestTimeout    = "request_timeout"
 	DefaultDbName            = "default"
 	DefaultIndexName         = "vector_idx"
 	DefaultAliasName         = "the_alias"

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -184,6 +184,7 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 		if err == nil {
 			timeout = time.Duration(timeoutSecond) * time.Second
 		}
+		gCtx.Set(ContextRequestTimeout, timeout)
 		finish := make(chan struct{}, 1)
 		panicChan := make(chan interface{}, 1)
 

--- a/internal/proxy/accesslog/info/grpc_info.go
+++ b/internal/proxy/accesslog/info/grpc_info.go
@@ -366,6 +366,23 @@ func (i *GrpcAccessInfo) ClientRequestTime() string {
 	return time.UnixMilli(unixmsec).Format(timeFormat)
 }
 
+func (i *GrpcAccessInfo) RequestTimeout() string {
+	deadline, ok := i.ctx.Deadline()
+	if !ok {
+		return Unknown
+	}
+
+	start := i.start
+	if start.IsZero() {
+		start = time.Now()
+	}
+	timeout := deadline.Sub(start)
+	if timeout < 0 {
+		return "0s"
+	}
+	return timeout.String()
+}
+
 func (i *GrpcAccessInfo) SetActualConsistencyLevel(acl commonpb.ConsistencyLevel) {
 	i.actualConsistencyLevel = &acl
 }

--- a/internal/proxy/accesslog/info/grpc_info_test.go
+++ b/internal/proxy/accesslog/info/grpc_info_test.go
@@ -307,6 +307,18 @@ func (s *GrpcAccessInfoSuite) TestClientRequestTime() {
 	s.NotEqual(Unknown, Get(s.info, "$client_request_time")[0])
 }
 
+func (s *GrpcAccessInfoSuite) TestRequestTimeout() {
+	s.Equal(Unknown, Get(s.info, "$request_timeout")[0])
+
+	start := time.Now()
+	ctx, cancel := context.WithDeadline(context.Background(), start.Add(2*time.Second))
+	defer cancel()
+	s.info.ctx = ctx
+	s.info.start = start
+
+	s.Equal("2s", Get(s.info, "$request_timeout")[0])
+}
+
 func (s *GrpcAccessInfoSuite) TestTemplateValueLength() {
 	// params := []*commonpb.KeyValuePair{{Key: "test_key", Value: "test_value"}}
 	exprTemplValues := map[string]*schemapb.TemplateValue{

--- a/internal/proxy/accesslog/info/info.go
+++ b/internal/proxy/accesslog/info/info.go
@@ -55,6 +55,7 @@ var MetricFuncMap = map[string]getMetricFunc{
 	"$search_params":         getSearchParams,
 	"$query_params":          getQueryParams,
 	"$client_request_time":   getClientRequestTime,
+	"$request_timeout":       getRequestTimeout,
 	"$template_value_length": getTemplateValueLength,
 	"$partial_update":        getPartialUpdate,
 }
@@ -85,6 +86,7 @@ type AccessInfo interface {
 	SearchParams() string
 	QueryParams() string
 	ClientRequestTime() string
+	RequestTimeout() string
 	TemplateValueLength() string
 	PartialUpdate() string
 	SetActualConsistencyLevel(commonpb.ConsistencyLevel)
@@ -205,6 +207,10 @@ func getQueryParams(i AccessInfo) string {
 
 func getClientRequestTime(i AccessInfo) string {
 	return i.ClientRequestTime()
+}
+
+func getRequestTimeout(i AccessInfo) string {
+	return i.RequestTimeout()
 }
 
 func getTemplateValueLength(i AccessInfo) string {

--- a/internal/proxy/accesslog/info/restful_info.go
+++ b/internal/proxy/accesslog/info/restful_info.go
@@ -19,6 +19,7 @@ package info
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,15 +29,18 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	mhttp "github.com/milvus-io/milvus/internal/http"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/requestutil"
 )
 
 const (
-	ContextUsername      = "username"
-	ContextReturnCode    = "code"
-	ContextReturnMessage = "message"
-	ContextRequest       = "request"
-	ContextToken         = "token"
+	ContextUsername       = "username"
+	ContextReturnCode     = "code"
+	ContextReturnMessage  = "message"
+	ContextRequest        = "request"
+	ContextToken          = "token"
+	ContextRequestTimeout = "request_timeout"
 )
 
 type RestfulInfo struct {
@@ -275,6 +279,23 @@ func (i *RestfulInfo) QueryParams() string {
 
 func (i *RestfulInfo) ClientRequestTime() string {
 	return Unknown
+}
+
+func (i *RestfulInfo) RequestTimeout() string {
+	if value, ok := i.ctx.Get(ContextRequestTimeout); ok {
+		if timeout, ok := value.(time.Duration); ok {
+			return timeout.String()
+		}
+	}
+
+	if i.ctx.Request != nil {
+		timeoutSecond, err := strconv.ParseInt(i.ctx.Request.Header.Get(mhttp.HTTPHeaderRequestTimeout), 10, 64)
+		if err == nil {
+			return (time.Duration(timeoutSecond) * time.Second).String()
+		}
+	}
+
+	return paramtable.Get().HTTPCfg.RequestTimeoutMs.GetAsDuration(time.Millisecond).String()
 }
 
 func (i *RestfulInfo) SetActualConsistencyLevel(acl commonpb.ConsistencyLevel) {

--- a/internal/proxy/accesslog/info/restful_info_test.go
+++ b/internal/proxy/accesslog/info/restful_info_test.go
@@ -19,6 +19,7 @@ package info
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	mhttp "github.com/milvus-io/milvus/internal/http"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -268,6 +270,18 @@ func (s *RestfulAccessInfoSuite) TestQueryParams() {
 	}
 
 	s.Equal(kvsToString(params), Get(s.info, "$query_params")[0])
+}
+
+func (s *RestfulAccessInfoSuite) TestRequestTimeout() {
+	s.ctx.Set(ContextRequestTimeout, 2*time.Second)
+	s.Equal("2s", Get(s.info, "$request_timeout")[0])
+
+	ctx := &gin.Context{}
+	req := httptest.NewRequest(http.MethodPost, "/v2/vectordb/entities/search", nil)
+	req.Header.Set(mhttp.HTTPHeaderRequestTimeout, "3")
+	ctx.Request = req
+	info := &RestfulInfo{ctx: ctx}
+	s.Equal("3s", Get(info, "$request_timeout")[0])
 }
 
 func (s *RestfulAccessInfoSuite) TestTemplateValueLength() {


### PR DESCRIPTION
pr: https://github.com/zilliztech/milvus-cloud-plugin/pull/254

## Summary
Add request timeout fields for gRPC and REST access logs, including default formatter output and focused coverage for the new metric.