### PR TITLE
fix: [cphotfix-2.6.17]Update Python client py312 dependencies

### DIFF
--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -3,7 +3,7 @@ pytest-cov==2.8.1
 requests>=2.32.4
 scikit-learn>=1.5.2
 timeout_decorator==0.5.0
-ujson==5.5.0
+ujson==5.10.0
 pytest==8.3.4
 pytest-asyncio==0.24.0
 pytest-assume==2.4.3
@@ -22,7 +22,7 @@ pyasn1
 pytest-html==3.1.1
 delayed-assert==0.3.5
 kubernetes==17.17.0
-PyYAML==6.0
+PyYAML==6.0.2
 pytest-sugar==0.9.5
 pytest-parallel
 pytest-random-order
@@ -43,14 +43,14 @@ npy-append-array==0.9.15
 Faker==19.2.0
 
 # for benchmark
-h5py==3.8.0
+h5py==3.11.0
 
 # for log
 loguru==0.7.0
 
 # util
 psutil==5.9.4
-pandas==1.5.3
+pandas==2.2.3
 numpy==1.26.4
 tenacity==8.1.0
 rich==13.7.0
@@ -61,10 +61,10 @@ deepdiff==8.6.1
 # for test result analyzer
 prettytable==3.8.0
 pyarrow==14.0.1
-fastparquet==2023.7.0
+fastparquet==2024.11.0
 
 # for bf16 datatype
-ml-dtypes==0.2.0
+ml-dtypes==0.5.1
 
 # for full text search
 tantivy==0.22.0


### PR DESCRIPTION
issue: #50013

This PR updates Python client test dependency pins in `tests/python_client/requirements.txt` so `hotfix-2.6.17` can install requirements in the Python 3.12 CI image.

Changes are capped at versions already used by `master`:

- `ujson` 5.5.0 -> 5.10.0
- `PyYAML` 6.0 -> 6.0.2
- `h5py` 3.8.0 -> 3.11.0
- `pandas` 1.5.3 -> 2.2.3
- `fastparquet` 2023.7.0 -> 2024.11.0
- `ml-dtypes` 0.2.0 -> 0.5.1

Verification:

- Checked updated pins do not exceed `origin/master` versions.
- Checked updated pins provide CPython 3.12 Linux x86_64 wheels.
- `git diff --check` passed.

Fixes #50013