### PR TITLE
enhance: standardize storage error handling to merr

### DIFF
--- a/examples/telemetry_e2e_test/go.mod
+++ b/examples/telemetry_e2e_test/go.mod
@@ -1,10 +1,11 @@
 module github.com/milvus-io/milvus/examples/telemetry_e2e_test
+
 go 1.25.8
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c
 	github.com/milvus-io/milvus/client/v2 v2.6.4-0.20251104142533-a2ce70d25256
-	google.golang.org/grpc v1.71.0
+	google.golang.org/grpc v1.79.3
 )
 
 replace (

--- a/examples/telemetry_e2e_test/go.sum
+++ b/examples/telemetry_e2e_test/go.sum
@@ -1,2 +1,4 @@
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=

--- a/internal/coordinator/file_resource_observer.go
+++ b/internal/coordinator/file_resource_observer.go
@@ -18,6 +18,7 @@ package coordinator
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -165,7 +166,7 @@ func (m *FileResourceObserver) CheckNodeSynced(nodeID int64) bool {
 func (m *FileResourceObserver) CheckAllQnReady() error {
 	// return error if meta is not ready
 	if m.meta == nil {
-		return merr.WrapErrParameterInvalidMsg("rootcoord meta is not ready")
+		return merr.WrapErrServiceUnavailable("rootcoord meta is not ready")
 	}
 
 	resources, version := m.meta.ListFileResource(m.ctx)
@@ -177,7 +178,7 @@ func (m *FileResourceObserver) CheckAllQnReady() error {
 	var err error
 	m.distribution.Range(func(nodeID int64, node *NodeInfo) bool {
 		if node.NodeType == QueryNode && node.Version < version {
-			err = merr.WrapErrParameterInvalidMsg("node %d file resource not synced", nodeID)
+			err = merr.WrapErrServiceUnavailable(fmt.Sprintf("node-%d", nodeID), "file resource not synced")
 			return false
 		}
 		return true

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
@@ -131,10 +131,13 @@ async fn download_with_retry(
         for url in urls {
             match client.get(url).send().await {
                 Ok(resp) if resp.status().is_success() => {
-                    let content = resp
-                        .bytes()
-                        .await
-                        .map_err(|e| TantivyBindingError::InternalError(e.to_string()))?;
+                    let content = match resp.bytes().await {
+                        Ok(c) => c,
+                        Err(e) => {
+                            warn!("Failed to read body from {}: {}", url, e);
+                            continue;
+                        }
+                    };
 
                     // Calculate MD5 hash
                     let mut context = Context::new();

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -1129,6 +1129,18 @@ func Test_NewServer_TLS_FileNotExisted(t *testing.T) {
 	server.Stop()
 }
 
+// freeTCPPort grabs a random unused TCP port. The TLS HTTP-server tests
+// below hardcoded port 8080 originally, which collides with anything else
+// already bound to that port on the dev machine (e.g. the TEI text-embedding
+// container in our compose stack).
+func freeTCPPort(t *testing.T) string {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	assert.NoError(t, ln.Close())
+	return strconv.Itoa(port)
+}
+
 func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	server := getServer(t)
 
@@ -1149,7 +1161,7 @@ func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(Params.CaPemPath.Key, "../../../configs/cert/ca.pem")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	assert.Nil(t, err)
@@ -1183,7 +1195,7 @@ func Test_NewHTTPServer_TLS_OneWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../../../configs/cert/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	fmt.Printf("err: %v\n", err)
@@ -1242,7 +1254,7 @@ func Test_NewHTTPServer_TLS_FileNotExisted(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../not/existed/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 	err := runAndWaitForServerReady(server)
 	assert.NotNil(t, err)
 	server.Stop()

--- a/internal/proxy/accesslog/info/grpc_info_test.go
+++ b/internal/proxy/accesslog/info/grpc_info_test.go
@@ -124,7 +124,11 @@ func (s *GrpcAccessInfoSuite) TestErrorType() {
 	result = Get(s.info, "$error_type")
 	s.Equal(merr.InputError.String(), result[0])
 
-	s.info.err = merr.ErrParameterInvalid
+	// ErrServiceInternal is a SystemError-typed sentinel.
+	// (ErrParameterInvalid was previously SystemError but became InputError after
+	// the 02-storage err-std PR; keep this branch on a still-SystemError sentinel
+	// so the test still covers the "system_error" classification path.)
+	s.info.err = merr.ErrServiceInternal
 	result = Get(s.info, "$error_type")
 	s.Equal(merr.SystemError.String(), result[0])
 }

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1421,7 +1421,7 @@ func ValidateUsername(username string) error {
 	}
 
 	if len(username) > Params.ProxyCfg.MaxUsernameLength.GetAsInt() {
-		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetValue())
+		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetAsInt())
 	}
 
 	firstChar := username[0]

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -237,7 +237,7 @@ func (rm *ResourceManager) updateResourceGroups(ctx context.Context, rgs map[str
 				zap.Error(err),
 			)
 		}
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.
@@ -434,7 +434,7 @@ func (rm *ResourceManager) DropResourceGroup(ctx context.Context, rgName string)
 			zap.String("rgName", rgName),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// After recovering, all node assigned to these rg has been removed.
@@ -1050,7 +1050,7 @@ func (rm *ResourceManager) transferNode(ctx context.Context, rgName string, node
 			zap.Int64("node", node),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.

--- a/internal/storage/arrow_util.go
+++ b/internal/storage/arrow_util.go
@@ -50,7 +50,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.BooleanBuilder:
 		ba, ok := a.(*array.Boolean)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ba.IsNull(idx) {
 			if defaultValue != nil {
@@ -66,7 +66,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int8Builder:
 		ia, ok := a.(*array.Int8)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -82,7 +82,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int16Builder:
 		ia, ok := a.(*array.Int16)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -98,7 +98,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int32Builder:
 		ia, ok := a.(*array.Int32)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -114,7 +114,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int64Builder:
 		ia, ok := a.(*array.Int64)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -130,7 +130,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Float32Builder:
 		fa, ok := a.(*array.Float32)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if fa.IsNull(idx) {
 			if defaultValue != nil {
@@ -155,7 +155,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 		}
 		fa, ok := a.(*array.Float64)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if fa.IsNull(idx) {
 			b.AppendNull()
@@ -167,7 +167,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.StringBuilder:
 		sa, ok := a.(*array.String)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if sa.IsNull(idx) {
 			if defaultValue != nil {
@@ -185,7 +185,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.BinaryBuilder:
 		ba, ok := a.(*array.Binary)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ba.IsNull(idx) {
 			// could be internal $meta json
@@ -204,7 +204,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.FixedSizeBinaryBuilder:
 		ba, ok := a.(*array.FixedSizeBinary)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ba.IsNull(idx) {
 			b.AppendNull()
@@ -218,7 +218,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 		// Handle ListBuilder for ArrayOfVector type
 		la, ok := a.(*array.List)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if la.IsNull(idx) {
 			b.AppendNull()
@@ -235,7 +235,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 		case *array.FixedSizeBinaryBuilder:
 			fixedArray, ok := valuesArray.(*array.FixedSizeBinary)
 			if !ok {
-				return 0, fmt.Errorf("invalid value type %T, expect %T", valuesArray.DataType(), vb.Type())
+				return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", valuesArray.DataType(), vb.Type())
 			}
 			for i := start; i < end; i++ {
 				val := fixedArray.Value(int(i))
@@ -243,12 +243,12 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 				totalSize += uint64(len(val))
 			}
 		default:
-			return 0, fmt.Errorf("unsupported value builder type in ListBuilder: %T", valueBuilder)
+			return 0, merr.WrapErrServiceInternalMsg("unsupported value builder type in ListBuilder: %T", valueBuilder)
 		}
 
 		return totalSize, nil
 	default:
-		return 0, fmt.Errorf("unsupported builder type: %T", builder)
+		return 0, merr.WrapErrServiceInternalMsg("unsupported builder type: %T", builder)
 	}
 }
 
@@ -356,7 +356,7 @@ func (b *RecordBuilder) Append(rec Record, start, end int) error {
 			col := rec.Column(f.FieldID)
 			size, err := appendValueAt(builder, col, offset, f.GetDefaultValue())
 			if err != nil {
-				return fmt.Errorf("failed to append value at offset %d for field %s: %w", offset, f.GetName(), err)
+				return merr.Wrapf(err, "failed to append value at offset %d for field %s", offset, f.GetName())
 			}
 			b.size += size
 		}

--- a/internal/storage/binlog_reader.go
+++ b/internal/storage/binlog_reader.go
@@ -19,15 +19,14 @@ package storage
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // BinlogReader is an object to read binlog file. Binlog file's format can be
@@ -43,7 +42,7 @@ type BinlogReader struct {
 // NextEventReader iters all events reader to read the binlog file.
 func (reader *BinlogReader) NextEventReader() (*EventReader, error) {
 	if reader.isClose {
-		return nil, errors.New("bin log reader is closed")
+		return nil, merr.WrapErrServiceInternalMsg("bin log reader is closed")
 	}
 	if reader.buffer.Len() <= 0 {
 		return nil, nil
@@ -69,7 +68,7 @@ func readMagicNumber(buffer io.Reader) (int32, error) {
 		return -1, err
 	}
 	if magicNumber != MagicNumber {
-		return -1, fmt.Errorf("parse magic number failed, expected: %d, actual: %d", MagicNumber, magicNumber)
+		return -1, merr.WrapErrServiceInternalMsg("parse magic number failed, expected: %d, actual: %d", MagicNumber, magicNumber)
 	}
 
 	return magicNumber, nil

--- a/internal/storage/binlog_record_writer.go
+++ b/internal/storage/binlog_record_writer.go
@@ -335,7 +335,7 @@ func newPackedBinlogRecordWriter(collectionID, partitionID, segmentID UniqueID, 
 ) (*PackedBinlogRecordWriter, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	writer := &PackedBinlogRecordWriter{
@@ -513,7 +513,7 @@ func (pw *PackedManifestRecordWriter) appendV3Stats(updates *packed.ManifestUpda
 		}
 		fullPath := path.Join(pw.basePath, fmt.Sprintf("_stats/bloom_filter.%d/%d", pkFieldID, id))
 		if err := packed.WriteFile(pw.storageConfig, fullPath, statsBlob.Value); err != nil {
-			return fmt.Errorf("appendV3Stats: failed to write bloom filter stats: %w", err)
+			return merr.Wrap(err, "appendV3Stats: failed to write bloom filter stats")
 		}
 		updates.Stats = append(updates.Stats, packed.StatEntry{
 			Key:      fmt.Sprintf("bloom_filter.%d", pkFieldID),
@@ -533,7 +533,7 @@ func (pw *PackedManifestRecordWriter) appendV3Stats(updates *packed.ManifestUpda
 		}
 		fullPath := path.Join(pw.basePath, fmt.Sprintf("_stats/bm25.%d/%d", fieldID, id))
 		if err := packed.WriteFile(pw.storageConfig, fullPath, blob.Value); err != nil {
-			return fmt.Errorf("appendV3Stats: failed to write bm25 stats: %w", err)
+			return merr.Wrap(err, "appendV3Stats: failed to write bm25 stats")
 		}
 		updates.Stats = append(updates.Stats, packed.StatEntry{
 			Key:      fmt.Sprintf("bm25.%d", fieldID),
@@ -551,7 +551,7 @@ func newPackedManifestRecordWriter(collectionID, partitionID, segmentID UniqueID
 ) (*PackedManifestRecordWriter, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	writer := &PackedManifestRecordWriter{
@@ -725,7 +725,7 @@ func NewPackedTextManifestRecordWriter(
 ) (*PackedTextManifestRecordWriter, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	writer := &PackedTextManifestRecordWriter{

--- a/internal/storage/binlog_util.go
+++ b/internal/storage/binlog_util.go
@@ -1,11 +1,11 @@
 package storage
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // ParseSegmentIDByBinlog parse segment id from binlog paths
@@ -13,7 +13,7 @@ import (
 func ParseSegmentIDByBinlog(rootPath, path string) (UniqueID, error) {
 	// check path contains rootPath as prefix
 	if !strings.HasPrefix(path, rootPath) {
-		return 0, fmt.Errorf("path \"%s\" does not contains rootPath \"%s\"", path, rootPath)
+		return 0, merr.WrapErrServiceInternalMsg("path \"%s\" does not contains rootPath \"%s\"", path, rootPath)
 	}
 	p := path[len(rootPath):]
 
@@ -30,12 +30,12 @@ func ParseSegmentIDByBinlog(rootPath, path string) (UniqueID, error) {
 		if len(keyStr) == 5 {
 			return strconv.ParseInt(keyStr[3], 10, 64)
 		}
-		return 0, fmt.Errorf("%s is not a valid delta log path", path)
+		return 0, merr.WrapErrServiceInternalMsg("%s is not a valid delta log path", path)
 	}
 
 	// log type are binlog or statslog
 	if len(keyStr) == 6 {
 		return strconv.ParseInt(keyStr[len(keyStr)-3], 10, 64)
 	}
-	return 0, fmt.Errorf("%s is not a valid binlog path", path)
+	return 0, merr.WrapErrServiceInternalMsg("%s is not a valid binlog path", path)
 }

--- a/internal/storage/binlog_writer.go
+++ b/internal/storage/binlog_writer.go
@@ -20,13 +20,13 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/hook"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // BinlogType is to distinguish different files saving different data.
@@ -114,7 +114,7 @@ func (writer *baseBinlogWriter) GetBinlogType() BinlogType {
 // GetBuffer gets binlog buffer. Return nil if binlog is not finished yet.
 func (writer *baseBinlogWriter) GetBuffer() ([]byte, error) {
 	if writer.buffer == nil {
-		return nil, errors.New("please close binlog before get buffer")
+		return nil, merr.WrapErrServiceInternalMsg("please close binlog before get buffer")
 	}
 	return writer.buffer.Bytes(), nil
 }
@@ -125,7 +125,7 @@ func (writer *baseBinlogWriter) Finish() error {
 		return nil
 	}
 	if writer.StartTimestamp == 0 || writer.EndTimestamp == 0 {
-		return errors.New("invalid start/end timestamp")
+		return merr.WrapErrServiceInternalMsg("invalid start/end timestamp")
 	}
 
 	var offset int32
@@ -194,7 +194,7 @@ type InsertBinlogWriter struct {
 // NextInsertEventWriter returns an event writer to write insert data to an event.
 func (writer *InsertBinlogWriter) NextInsertEventWriter(opts ...PayloadWriterOptions) (*insertEventWriter, error) {
 	if writer.isClosed() {
-		return nil, errors.New("binlog has closed")
+		return nil, merr.WrapErrServiceInternalMsg("binlog has closed")
 	}
 
 	event, err := newInsertEventWriter(writer.PayloadDataType, opts...)
@@ -214,7 +214,7 @@ type DeleteBinlogWriter struct {
 // NextDeleteEventWriter returns an event writer to write delete data to an event.
 func (writer *DeleteBinlogWriter) NextDeleteEventWriter(opts ...PayloadWriterOptions) (*deleteEventWriter, error) {
 	if writer.isClosed() {
-		return nil, errors.New("binlog has closed")
+		return nil, merr.WrapErrServiceInternalMsg("binlog has closed")
 	}
 	event, err := newDeleteEventWriter(writer.PayloadDataType, opts...)
 	if err != nil {
@@ -232,7 +232,7 @@ type IndexFileBinlogWriter struct {
 // NextIndexFileEventWriter return next available EventWriter
 func (writer *IndexFileBinlogWriter) NextIndexFileEventWriter() (*indexFileEventWriter, error) {
 	if writer.isClosed() {
-		return nil, errors.New("binlog has closed")
+		return nil, merr.WrapErrServiceInternalMsg("binlog has closed")
 	}
 	event, err := newIndexFileEventWriter(writer.PayloadDataType)
 	if err != nil {

--- a/internal/storage/data_codec.go
+++ b/internal/storage/data_codec.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"sort"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
@@ -146,7 +145,7 @@ func NewInsertCodecWithSchema(schema *etcdpb.CollectionMeta) *InsertCodec {
 // Serialize Pk stats log
 func (insertCodec *InsertCodec) SerializePkStats(stats *PrimaryKeyStats, rowNum int64) (*Blob, error) {
 	if stats == nil || stats.BF == nil {
-		return nil, errors.New("sericalize empty pk stats")
+		return nil, merr.WrapErrServiceInternalMsg("sericalize empty pk stats")
 	}
 
 	// Serialize by pk stats
@@ -191,10 +190,10 @@ func (insertCodec *InsertCodec) SerializePkStatsList(stats []*PrimaryKeyStats, r
 func (insertCodec *InsertCodec) SerializePkStatsByData(data *InsertData) (*Blob, error) {
 	timeFieldData, ok := data.Data[common.TimeStampField]
 	if !ok {
-		return nil, errors.New("data doesn't contains timestamp field")
+		return nil, merr.WrapErrServiceInternalMsg("data doesn't contains timestamp field")
 	}
 	if timeFieldData.RowNum() <= 0 {
-		return nil, errors.New("there's no data in InsertData")
+		return nil, merr.WrapErrServiceInternalMsg("there's no data in InsertData")
 	}
 	rowNum := int64(timeFieldData.RowNum())
 
@@ -217,7 +216,7 @@ func (insertCodec *InsertCodec) SerializePkStatsByData(data *InsertData) (*Blob,
 			RowNum: rowNum,
 		}, nil
 	}
-	return nil, errors.New("there is no pk field")
+	return nil, merr.WrapErrServiceInternalMsg("there is no pk field")
 }
 
 // Serialize transforms insert data to blob. It will sort insert data by timestamp.
@@ -228,7 +227,7 @@ func (insertCodec *InsertCodec) Serialize(partitionID UniqueID, segmentID Unique
 	blobs := make([]*Blob, 0)
 	var writer *InsertBinlogWriter
 	if insertCodec.Schema == nil {
-		return nil, errors.New("schema is not set")
+		return nil, merr.WrapErrServiceInternalMsg("schema is not set")
 	}
 
 	var rowNum int64
@@ -238,7 +237,7 @@ func (insertCodec *InsertCodec) Serialize(partitionID UniqueID, segmentID Unique
 	for _, block := range data {
 		timeFieldData, ok := block.Data[common.TimeStampField]
 		if !ok {
-			return nil, errors.New("data doesn't contains timestamp field")
+			return nil, merr.WrapErrServiceInternalMsg("data doesn't contains timestamp field")
 		}
 
 		rowNum += int64(timeFieldData.RowNum())
@@ -281,11 +280,11 @@ func (insertCodec *InsertCodec) Serialize(partitionID UniqueID, segmentID Unique
 		// found missing block
 		if !allExists {
 			if !field.GetNullable() {
-				return errors.Newf("field %d(%s) missing and field not nullable", field.GetFieldID(), field.GetName())
+				return merr.WrapErrStorageMsg("field %d(%s) missing and field not nullable", field.GetFieldID(), field.GetName())
 			}
 			// segment must be in same schema
 			if !allMissing {
-				return errors.Newf("segment must not be heterogeneous, all blocks must contain all fields or none, abnormal field %d(%s)", field.GetFieldID(), field.GetName())
+				return merr.WrapErrStorageMsg("segment must not be heterogeneous, all blocks must contain all fields or none, abnormal field %d(%s)", field.GetFieldID(), field.GetName())
 			}
 			log.Info("Skip field nullable missing field, could be schema change", zap.Int64("fieldId", field.GetFieldID()), zap.String("fieldName", field.GetName()))
 			return nil
@@ -474,13 +473,13 @@ func AddFieldDataToPayload(eventWriter *insertEventWriter, dataType schemapb.Dat
 	case schemapb.DataType_ArrayOfVector:
 		vectorArrayData := singleData.(*VectorArrayFieldData)
 		if vectorArrayData.Nullable {
-			return fmt.Errorf("nullable ArrayOfVector is not supported in V1 storage format")
+			return merr.WrapErrStorageMsg("nullable ArrayOfVector is not supported in V1 storage format")
 		}
 		if err = eventWriter.AddVectorArrayFieldDataToPayload(vectorArrayData); err != nil {
 			return err
 		}
 	default:
-		return fmt.Errorf("undefined data type %d", dataType)
+		return merr.WrapErrServiceInternalMsg("undefined data type %d", dataType)
 	}
 	return nil
 }
@@ -493,7 +492,7 @@ func (insertCodec *InsertCodec) DeserializeAll(blobs []*Blob) (
 	err error,
 ) {
 	if len(blobs) == 0 {
-		return InvalidUniqueID, InvalidUniqueID, InvalidUniqueID, nil, errors.New("blobs is empty")
+		return InvalidUniqueID, InvalidUniqueID, InvalidUniqueID, nil, merr.WrapErrServiceInternalMsg("blobs is empty")
 	}
 
 	var blobList BlobList = blobs
@@ -897,14 +896,14 @@ func AddInsertData(dataType schemapb.DataType, data interface{}, insertData *Ins
 		vectorArrayFieldData := fieldData.(*VectorArrayFieldData)
 
 		if len(validData) > 0 {
-			return 0, fmt.Errorf("nullable ArrayOfVector is not supported in V1 storage format")
+			return 0, merr.WrapErrStorageMsg("nullable ArrayOfVector is not supported in V1 storage format")
 		}
 		vectorArrayFieldData.Data = append(vectorArrayFieldData.Data, singleData...)
 		insertData.Data[fieldID] = vectorArrayFieldData
 		return len(singleData), nil
 
 	default:
-		return 0, fmt.Errorf("undefined data type %d", dataType)
+		return 0, merr.WrapErrServiceInternalMsg("undefined data type %d", dataType)
 	}
 }
 
@@ -940,7 +939,7 @@ func (deleteCodec *DeleteCodec) Serialize(collectionID UniqueID, partitionID Uni
 	defer eventWriter.Close()
 	length := len(data.Pks)
 	if length != len(data.Tss) {
-		return nil, errors.New("the length of pks, and TimeStamps is not equal")
+		return nil, merr.WrapErrServiceInternalMsg("the length of pks, and TimeStamps is not equal")
 	}
 
 	sizeTotal := 0
@@ -993,7 +992,7 @@ func (deleteCodec *DeleteCodec) Serialize(collectionID UniqueID, partitionID Uni
 // Deserialize deserializes the deltalog blobs into DeleteData
 func (deleteCodec *DeleteCodec) Deserialize(blobs []*Blob) (partitionID UniqueID, segmentID UniqueID, data *DeltaData, err error) {
 	if len(blobs) == 0 {
-		return InvalidUniqueID, InvalidUniqueID, nil, errors.New("blobs is empty")
+		return InvalidUniqueID, InvalidUniqueID, nil, merr.WrapErrServiceInternalMsg("blobs is empty")
 	}
 
 	rowNum := lo.SumBy(blobs, func(blob *Blob) int64 {

--- a/internal/storage/delta_data.go
+++ b/internal/storage/delta_data.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -26,7 +25,6 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 
@@ -126,7 +124,7 @@ func NewDeltaDataWithPkType(cap int64, pkType schemapb.DataType) (*DeltaData, er
 
 func NewDeltaDataWithData(pks PrimaryKeys, tss []uint64) (*DeltaData, error) {
 	if pks.Len() != len(tss) {
-		return nil, merr.WrapErrParameterInvalidMsg("length of pks and tss not equal")
+		return nil, merr.WrapErrStorageMsg("length of pks and tss not equal: pks=%d tss=%d", pks.Len(), len(tss))
 	}
 	dd := &DeltaData{
 		deletePks:        pks,
@@ -167,23 +165,23 @@ func (dl *DeleteLog) Parse(val string) error {
 		pkRes := result.Get("pk")
 		pkTypeRes := result.Get("pkType")
 		if !tsRes.Exists() || !pkRes.Exists() || !pkTypeRes.Exists() {
-			return fmt.Errorf("invalid delete log json: missing required fields in %s", val)
+			return merr.WrapErrServiceInternalMsg("invalid delete log json: missing required fields in %s", val)
 		}
 		dl.Ts = tsRes.Uint()
 		dl.PkType = pkTypeRes.Int()
 		switch dl.PkType {
 		case int64(schemapb.DataType_Int64):
 			if pkRes.Type != gjson.Number {
-				return fmt.Errorf("invalid delete log: pkType is Int64 but pk is not a number in %s", val)
+				return merr.WrapErrServiceInternalMsg("invalid delete log: pkType is Int64 but pk is not a number in %s", val)
 			}
 			dl.Pk = &Int64PrimaryKey{Value: pkRes.Int()}
 		case int64(schemapb.DataType_VarChar):
 			if pkRes.Type != gjson.String {
-				return fmt.Errorf("invalid delete log: pkType is VarChar but pk is not a string in %s", val)
+				return merr.WrapErrServiceInternalMsg("invalid delete log: pkType is VarChar but pk is not a string in %s", val)
 			}
 			dl.Pk = &VarCharPrimaryKey{Value: pkRes.String()}
 		default:
-			return fmt.Errorf("invalid delete log: unsupported pkType %d in %s", dl.PkType, val)
+			return merr.WrapErrServiceInternalMsg("invalid delete log: unsupported pkType %d in %s", dl.PkType, val)
 		}
 		return nil
 	}
@@ -192,7 +190,7 @@ func (dl *DeleteLog) Parse(val string) error {
 	// compatible with fmt.Sprintf("%d,%d", pk, ts)
 	splits := strings.Split(val, ",")
 	if len(splits) != 2 {
-		return fmt.Errorf("the format of delta log is incorrect, %v can not be split", val)
+		return merr.WrapErrServiceInternalMsg("the format of delta log is incorrect, %v can not be split", val)
 	}
 	pk, err := strconv.ParseInt(splits[0], 10, 64)
 	if err != nil {
@@ -226,7 +224,7 @@ func (dl *DeleteLog) UnmarshalJSON(data []byte) error {
 	case schemapb.DataType_VarChar:
 		dl.Pk = &VarCharPrimaryKey{}
 	default:
-		return fmt.Errorf("unsupported primary key type: %v", schemapb.DataType(dl.PkType))
+		return merr.WrapErrServiceInternalMsg("unsupported primary key type: %v", schemapb.DataType(dl.PkType))
 	}
 
 	if err = json.Unmarshal(*messageMap["pk"], dl.Pk); err != nil {
@@ -296,10 +294,10 @@ func BuildDeleteRecord(pks []PrimaryKey, tss []Timestamp) (r Record, tsFrom uint
 	tsTo = 0
 
 	if len(pks) == 0 {
-		return nil, 0, 0, errors.New("empty primary keys")
+		return nil, 0, 0, merr.WrapErrServiceInternalMsg("empty primary keys")
 	}
 	if len(pks) != len(tss) {
-		return nil, 0, 0, errors.New("length of pks and tss must be equal")
+		return nil, 0, 0, merr.WrapErrServiceInternalMsg("length of pks and tss must be equal")
 	}
 
 	allocator := memory.DefaultAllocator
@@ -322,7 +320,7 @@ func BuildDeleteRecord(pks []PrimaryKey, tss []Timestamp) (r Record, tsFrom uint
 		}
 		pkArray = builder.NewArray()
 	default:
-		return nil, 0, 0, errors.Newf("unsupported primary key type %T", pks[0])
+		return nil, 0, 0, merr.WrapErrStorageMsg("unsupported primary key type %T", pks[0])
 	}
 
 	// Build timestamp array

--- a/internal/storage/event_data.go
+++ b/internal/storage/event_data.go
@@ -18,11 +18,8 @@ package storage
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
 	"strconv"
-
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
@@ -81,7 +78,7 @@ func (data *descriptorEventData) GetNullable() (bool, error) {
 	nullable, ok := nullableStore.(bool)
 	// will not happen, has checked bool format when FinishExtra
 	if !ok {
-		return false, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in bool format", nullableKey))
+		return false, merr.WrapErrDataIntegrityMsg("value of %v must in bool format", nullableKey)
 	}
 	return nullable, nil
 }
@@ -128,24 +125,24 @@ func (data *descriptorEventData) FinishExtra() error {
 	// keep all binlog file records the original size
 	sizeStored, ok := data.Extras[originalSizeKey]
 	if !ok {
-		return fmt.Errorf("%v not in extra", originalSizeKey)
+		return merr.WrapErrServiceInternalMsg("%v not in extra", originalSizeKey)
 	}
 	// if we store a large int directly, golang will use scientific notation, we then will get a float value.
 	// so it's better to store the original size in string format.
 	sizeStr, ok := sizeStored.(string)
 	if !ok {
-		return fmt.Errorf("value of %v must in string format", originalSizeKey)
+		return merr.WrapErrServiceInternalMsg("value of %v must in string format", originalSizeKey)
 	}
 	_, err = strconv.Atoi(sizeStr)
 	if err != nil {
-		return fmt.Errorf("value of %v must be able to be converted into int format", originalSizeKey)
+		return merr.WrapErrServiceInternalMsg("value of %v must be able to be converted into int format", originalSizeKey)
 	}
 
 	nullableStore, existed := data.Extras[nullableKey]
 	if existed {
 		_, ok := nullableStore.(bool)
 		if !ok {
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in bool format", nullableKey))
+			return merr.WrapErrDataIntegrityMsg("value of %v must in bool format", nullableKey)
 		}
 	}
 
@@ -153,14 +150,14 @@ func (data *descriptorEventData) FinishExtra() error {
 	if exist {
 		_, ok := edekStored.(string)
 		if !ok {
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in string format", edekKey))
+			return merr.WrapErrDataIntegrityMsg("value of %v must in string format", edekKey)
 		}
 	}
 	ezIDStored, exist := data.Extras[ezIDKey]
 	if exist {
 		_, ok := ezIDStored.(int64)
 		if !ok {
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in int64 format", ezIDKey))
+			return merr.WrapErrDataIntegrityMsg("value of %v must in int64 format", ezIDKey)
 		}
 	}
 
@@ -236,10 +233,10 @@ func (data *insertEventData) GetEventDataFixPartSize() int32 {
 
 func (data *insertEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -260,10 +257,10 @@ func (data *deleteEventData) GetEventDataFixPartSize() int32 {
 
 func (data *deleteEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -284,10 +281,10 @@ func (data *createCollectionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *createCollectionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -308,10 +305,10 @@ func (data *dropCollectionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *dropCollectionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -332,10 +329,10 @@ func (data *createPartitionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *createPartitionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -356,10 +353,10 @@ func (data *dropPartitionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *dropPartitionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -380,10 +377,10 @@ func (data *indexFileEventData) GetEventDataFixPartSize() int32 {
 
 func (data *indexFileEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }

--- a/internal/storage/event_reader.go
+++ b/internal/storage/event_reader.go
@@ -18,11 +18,9 @@ package storage
 
 import (
 	"bytes"
-	"fmt"
-
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // EventReader is used to parse the events contained in the Binlog file.
@@ -36,7 +34,7 @@ type EventReader struct {
 
 func (reader *EventReader) readHeader() error {
 	if reader.isClosed {
-		return errors.New("event reader is closed")
+		return merr.WrapErrServiceInternalMsg("event reader is closed")
 	}
 	header, err := readEventHeader(reader.buffer)
 	if err != nil {
@@ -48,7 +46,7 @@ func (reader *EventReader) readHeader() error {
 
 func (reader *EventReader) readData() error {
 	if reader.isClosed {
-		return errors.New("event reader is closed")
+		return merr.WrapErrServiceInternalMsg("event reader is closed")
 	}
 	var data eventData
 	var err error
@@ -68,7 +66,7 @@ func (reader *EventReader) readData() error {
 	case IndexFileEventType:
 		data, err = readIndexFileEventDataFixPart(reader.buffer)
 	default:
-		return fmt.Errorf("unknown header type code: %d", reader.TypeCode)
+		return merr.WrapErrServiceInternalMsg("unknown header type code: %d", reader.TypeCode)
 	}
 	if err != nil {
 		return err

--- a/internal/storage/event_writer.go
+++ b/internal/storage/event_writer.go
@@ -21,10 +21,9 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // EventTypeCode represents event type by code
@@ -266,7 +265,7 @@ func newDeleteEventWriter(dataType schemapb.DataType, opts ...PayloadWriterOptio
 
 func newCreateCollectionEventWriter(dataType schemapb.DataType) (*createCollectionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)
@@ -292,7 +291,7 @@ func newCreateCollectionEventWriter(dataType schemapb.DataType) (*createCollecti
 
 func newDropCollectionEventWriter(dataType schemapb.DataType) (*dropCollectionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)
@@ -318,7 +317,7 @@ func newDropCollectionEventWriter(dataType schemapb.DataType) (*dropCollectionEv
 
 func newCreatePartitionEventWriter(dataType schemapb.DataType) (*createPartitionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)
@@ -344,7 +343,7 @@ func newCreatePartitionEventWriter(dataType schemapb.DataType) (*createPartition
 
 func newDropPartitionEventWriter(dataType schemapb.DataType) (*dropPartitionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -3,9 +3,8 @@ package storage
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -55,7 +54,7 @@ func (f *ChunkManagerFactory) newChunkManager(ctx context.Context, engine string
 	case "remote", "minio", "opendal":
 		return NewRemoteChunkManager(ctx, f.config)
 	default:
-		return nil, errors.New("no chunk manager implemented with engine: " + engine)
+		return nil, merr.WrapErrServiceInternalMsg("no chunk manager implemented with engine: " + engine)
 	}
 }
 

--- a/internal/storage/field_stats.go
+++ b/internal/storage/field_stats.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -67,7 +66,7 @@ func (stats *FieldStats) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	} else {
-		return errors.New("invalid fieldStats, no fieldID")
+		return merr.WrapErrServiceInternalMsg("invalid fieldStats, no fieldID")
 	}
 
 	stats.Type = schemapb.DataType_Int64
@@ -471,7 +470,7 @@ func (sr *FieldStatsReader) GetFieldStatsList() ([]*FieldStats, error) {
 		stats := &FieldStats{}
 		errNew := json.Unmarshal(sr.buffer, &stats)
 		if errNew != nil {
-			return nil, merr.WrapErrParameterInvalid("valid JSON", string(sr.buffer), err.Error())
+			return nil, merr.WrapErrDataIntegrity(err, "FieldStats list unmarshal failed")
 		}
 		return []*FieldStats{stats}, nil
 	}

--- a/internal/storage/field_stats_test.go
+++ b/internal/storage/field_stats_test.go
@@ -419,7 +419,7 @@ func TestDeserializeFieldStatsFailed(t *testing.T) {
 		}
 
 		_, err := DeserializeFieldStats(blob)
-		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.ErrorIs(t, err, merr.ErrDataIntegrity)
 	})
 
 	t.Run("valid field stats", func(t *testing.T) {

--- a/internal/storage/field_value.go
+++ b/internal/storage/field_value.go
@@ -21,8 +21,6 @@ import (
 	"math"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/log"
@@ -159,7 +157,7 @@ func (ifv *Int8FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int8)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -279,7 +277,7 @@ func (ifv *Int16FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int16)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -399,7 +397,7 @@ func (ifv *Int32FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int32)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -519,7 +517,7 @@ func (ifv *Int64FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int64)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -640,7 +638,7 @@ func (ifv *FloatFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(float32)
 	if !ok {
 		log.Warn("wrong type value when setValue for FloatFieldValue")
-		return errors.New("wrong type value when setValue for FloatFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for FloatFieldValue")
 	}
 
 	ifv.Value = value
@@ -760,7 +758,7 @@ func (ifv *DoubleFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(float64)
 	if !ok {
 		log.Warn("wrong type value when setValue for DoubleFieldValue")
-		return errors.New("wrong type value when setValue for DoubleFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for DoubleFieldValue")
 	}
 
 	ifv.Value = value
@@ -856,7 +854,7 @@ func (sfv *StringFieldValue) UnmarshalJSON(data []byte) error {
 func (sfv *StringFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(string)
 	if !ok {
-		return errors.New("wrong type value when setValue for StringFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for StringFieldValue")
 	}
 
 	sfv.Value = value
@@ -934,7 +932,7 @@ func (vcfv *VarCharFieldValue) EQ(obj ScalarFieldValue) bool {
 func (vcfv *VarCharFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(string)
 	if !ok {
-		return errors.New("wrong type value when setValue for StringFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for StringFieldValue")
 	}
 
 	vcfv.Value = value
@@ -1014,7 +1012,7 @@ func (ifv *FloatVectorFieldValue) SetValue(data interface{}) error {
 	value, ok := data.([]float32)
 	if !ok {
 		log.Warn("wrong type value when setValue for FloatVectorFieldValue")
-		return errors.New("wrong type value when setValue for FloatVectorFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for FloatVectorFieldValue")
 	}
 
 	ifv.Value = value

--- a/internal/storage/index_data_codec.go
+++ b/internal/storage/index_data_codec.go
@@ -21,12 +21,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -164,7 +164,7 @@ func (codec *IndexFileBinlogCodec) DeserializeImpl(blobs []*Blob) (
 	err error,
 ) {
 	if len(blobs) == 0 {
-		return 0, 0, 0, 0, 0, 0, nil, "", 0, nil, errors.New("blobs is empty")
+		return 0, 0, 0, 0, 0, 0, nil, "", 0, nil, merr.WrapErrServiceInternalMsg("blobs is empty")
 	}
 	indexParams = make(map[string]string)
 	datas = make([]*Blob, 0)
@@ -250,7 +250,7 @@ func (codec *IndexFileBinlogCodec) DeserializeImpl(blobs []*Blob) (
 
 				// make sure there is one string
 				if len(content) != 1 {
-					err := fmt.Errorf("failed to parse index event because content length is not one %d", len(content))
+					err := merr.WrapErrServiceInternalMsg("failed to parse index event because content length is not one %d", len(content))
 					eventReader.Close()
 					binlogReader.Close()
 					return 0, 0, 0, 0, 0, 0, nil, "", 0, nil, err
@@ -321,7 +321,7 @@ func (indexCodec *IndexCodec) Deserialize(blobs []*Blob) ([]*Blob, map[string]st
 		break
 	}
 	if file == nil {
-		return nil, nil, "", InvalidUniqueID, errors.New("can not find params blob")
+		return nil, nil, "", InvalidUniqueID, merr.WrapErrServiceInternalMsg("can not find params blob")
 	}
 	info := struct {
 		Params    map[string]string
@@ -329,7 +329,7 @@ func (indexCodec *IndexCodec) Deserialize(blobs []*Blob) ([]*Blob, map[string]st
 		IndexID   UniqueID
 	}{}
 	if err := json.Unmarshal(file.Value, &info); err != nil {
-		return nil, nil, "", InvalidUniqueID, fmt.Errorf("json unmarshal error: %s", err.Error())
+		return nil, nil, "", InvalidUniqueID, merr.WrapErrServiceInternalMsg("json unmarshal error: %s", err.Error())
 	}
 
 	return blobs, info.Params, info.IndexName, info.IndexID, nil

--- a/internal/storage/insert_data.go
+++ b/internal/storage/insert_data.go
@@ -149,7 +149,7 @@ func (i *InsertData) Append(row map[FieldID]interface{}) error {
 	for fID, v := range row {
 		field, ok := i.Data[fID]
 		if !ok {
-			return fmt.Errorf("missing field when appending row, got %d", fID)
+			return merr.WrapErrServiceInternalMsg("missing field when appending row, got %d", fID)
 		}
 
 		if err := field.AppendRow(v); err != nil {
@@ -405,7 +405,7 @@ func NewFieldData(dataType schemapb.DataType, fieldSchema *schemapb.FieldSchema,
 		}
 		return data, nil
 	default:
-		return nil, fmt.Errorf("unexpected schema data type: %d", dataType)
+		return nil, merr.WrapErrServiceInternalMsg("unexpected schema data type: %d", dataType)
 	}
 }
 

--- a/internal/storage/local_chunk_manager.go
+++ b/internal/storage/local_chunk_manager.go
@@ -119,7 +119,7 @@ func (lcm *LocalChunkManager) MultiWrite(ctx context.Context, contents map[strin
 	for filePath, content := range contents {
 		err := lcm.Write(ctx, filePath, content)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "write %s failed", filePath))
+			el = merr.Combine(el, merr.Wrapf(err, "write %s failed", filePath))
 		}
 	}
 	return el
@@ -149,7 +149,7 @@ func (lcm *LocalChunkManager) MultiRead(ctx context.Context, filePaths []string)
 	for i, filePath := range filePaths {
 		content, err := lcm.Read(ctx, filePath)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to read %s", filePath))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to read %s", filePath))
 		}
 		results[i] = content
 	}
@@ -271,7 +271,7 @@ func (lcm *LocalChunkManager) RemoveWithPrefix(ctx context.Context, prefix strin
 	if len(prefix) == 0 {
 		errMsg := "empty prefix is not allowed for ChunkManager remove operation"
 		log.Warn(errMsg)
-		return merr.WrapErrParameterInvalidMsg(errMsg)
+		return merr.WrapErrStorageMsg("%s", errMsg)
 	}
 	var removeErr error
 	if err := lcm.WalkWithPrefix(ctx, prefix, true, func(chunkInfo *ChunkObjectInfo) bool {

--- a/internal/storage/minio_object_storage_test.go
+++ b/internal/storage/minio_object_storage_test.go
@@ -201,31 +201,51 @@ func TestMinioObjectStorage(t *testing.T) {
 	})
 
 	t.Run("test useIAM", func(t *testing.T) {
+		// newMinioObjectStorageWithConfig validates IAM credentials by calling
+		// BucketExists against the configured endpoint. With invalid IAM
+		// credentials on a host where the endpoint is unreachable, the dial
+		// blocks long enough that retry.Do (CheckBucketRetryAttempts=20) drags
+		// the whole package out to the 10min testing.M timeout. Bound each
+		// call with a short context so it fails fast regardless of
+		// environment; the test only asserts an error is returned. Mirrors
+		// the Azure fix in PR #49814.
 		var err error
 		config.UseIAM = true
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.UseIAM = false
 	})
 
 	t.Run("test ssl", func(t *testing.T) {
+		// Same endpoint-unreachable hang as the "test useIAM" subtest above:
+		// UseSSL=true with a dummy CA cert against a non-TLS minio endpoint
+		// keeps retry.Do dialing until the testing.M timeout. Bound it.
 		var err error
 		config.UseSSL = true
 		config.SslCACert = "/tmp/dummy.crt"
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.UseSSL = false
 	})
 
 	t.Run("test cloud provider", func(t *testing.T) {
+		// Same endpoint-unreachable hang as the "test useIAM" subtest above.
 		var err error
 		cloudProvider := config.CloudProvider
 		config.CloudProvider = "aliyun"
 		config.UseIAM = true
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.UseIAM = false
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.CloudProvider = "gcp"
 		_, err = newMinioObjectStorageWithConfig(ctx, &config)

--- a/internal/storage/payload_reader.go
+++ b/internal/storage/payload_reader.go
@@ -13,7 +13,6 @@ import (
 	"github.com/apache/arrow/go/v17/parquet"
 	"github.com/apache/arrow/go/v17/parquet/file"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -39,7 +38,7 @@ var _ PayloadReaderInterface = (*PayloadReader)(nil)
 
 func NewPayloadReader(colType schemapb.DataType, buf []byte, nullable bool) (*PayloadReader, error) {
 	if len(buf) == 0 {
-		return nil, errors.New("create Payload reader failed, buffer is empty")
+		return nil, merr.WrapErrServiceInternalMsg("create Payload reader failed, buffer is empty")
 	}
 	parquetReader, err := file.NewParquetReader(bytes.NewReader(buf))
 	if err != nil {
@@ -56,32 +55,32 @@ func NewPayloadReader(colType schemapb.DataType, buf []byte, nullable bool) (*Pa
 	if colType == schemapb.DataType_ArrayOfVector {
 		arrowReader, err := pqarrow.NewFileReader(parquetReader, pqarrow.ArrowReadProperties{BatchSize: 1024}, memory.DefaultAllocator)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create arrow reader for VectorArray: %w", err)
+			return nil, merr.WrapErrStorage(err, "failed to create arrow reader for VectorArray")
 		}
 
 		arrowSchema, err := arrowReader.Schema()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get arrow schema for VectorArray: %w", err)
+			return nil, merr.WrapErrStorage(err, "failed to get arrow schema for VectorArray")
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, fmt.Errorf("VectorArray should have exactly 1 field, got %d", arrowSchema.NumFields())
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray should have exactly 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
 		if !field.HasMetadata() {
-			return nil, errors.New("VectorArray field is missing metadata")
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray field is missing metadata")
 		}
 
 		metadata := field.Metadata
 
 		elementTypeStr, ok := metadata.GetValue("elementType")
 		if !ok {
-			return nil, errors.New("VectorArray metadata missing required 'elementType' field")
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray metadata missing required 'elementType' field")
 		}
 		elementTypeInt, err := strconv.ParseInt(elementTypeStr, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("invalid elementType in VectorArray metadata: %s", elementTypeStr)
+			return nil, merr.WrapErrServiceInternalMsg("invalid elementType in VectorArray metadata: %s", elementTypeStr)
 		}
 
 		elementType := schemapb.DataType(elementTypeInt)
@@ -94,19 +93,19 @@ func NewPayloadReader(colType schemapb.DataType, buf []byte, nullable bool) (*Pa
 			schemapb.DataType_SparseFloatVector:
 			reader.elementType = elementType
 		default:
-			return nil, fmt.Errorf("invalid vector type for VectorArray: %s", elementType.String())
+			return nil, merr.WrapErrServiceInternalMsg("invalid vector type for VectorArray: %s", elementType.String())
 		}
 
 		dimStr, ok := metadata.GetValue("dim")
 		if !ok {
-			return nil, errors.New("VectorArray metadata missing required 'dim' field")
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray metadata missing required 'dim' field")
 		}
 		dimVal, err := strconv.ParseInt(dimStr, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid dim in VectorArray metadata: %s", dimStr)
+			return nil, merr.WrapErrServiceInternalMsg("invalid dim in VectorArray metadata: %s", dimStr)
 		}
 		if dimVal <= 0 {
-			return nil, fmt.Errorf("VectorArray dim must be positive, got %d", dimVal)
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray dim must be positive, got %d", dimVal)
 		}
 		reader.dim = dimVal
 	}
@@ -182,7 +181,7 @@ func (r *PayloadReader) GetDataFromPayload() (interface{}, []bool, int, error) {
 		val, validData, err := r.GetGeometryFromPayload()
 		return val, validData, 0, err
 	default:
-		return nil, nil, 0, merr.WrapErrParameterInvalidMsg("unknown type")
+		return nil, nil, 0, merr.WrapErrDataIntegrityMsg("unknown type")
 	}
 }
 
@@ -194,7 +193,7 @@ func (r *PayloadReader) ReleasePayloadReader() error {
 // GetBoolFromPayload returns bool slice from payload.
 func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 	if r.colType != schemapb.DataType_Bool {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get bool from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get bool from datatype %v", r.colType.String())
 	}
 
 	values := make([]bool, r.numRows)
@@ -206,7 +205,7 @@ func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 			return nil, nil, err
 		}
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -215,7 +214,7 @@ func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 		return nil, nil, err
 	}
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
@@ -223,7 +222,7 @@ func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 // GetByteFromPayload returns byte slice from payload
 func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 	if r.colType != schemapb.DataType_Int8 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get byte from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get byte from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -234,7 +233,7 @@ func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 			return nil, nil, err
 		}
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		ret := make([]byte, r.numRows)
 		for i := int64(0); i < r.numRows; i++ {
@@ -249,7 +248,7 @@ func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, r.numRows)
@@ -261,7 +260,7 @@ func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 
 func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 	if r.colType != schemapb.DataType_Int8 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int8 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int8 from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -273,7 +272,7 @@ func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 
 		return values, validData, nil
@@ -285,7 +284,7 @@ func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]int8, r.numRows)
@@ -297,7 +296,7 @@ func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 
 func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 	if r.colType != schemapb.DataType_Int16 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int16 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int16 from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -309,7 +308,7 @@ func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -320,7 +319,7 @@ func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]int16, r.numRows)
@@ -332,7 +331,7 @@ func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 
 func (r *PayloadReader) GetInt32FromPayload() ([]int32, []bool, error) {
 	if r.colType != schemapb.DataType_Int32 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int32 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int32 from datatype %v", r.colType.String())
 	}
 
 	values := make([]int32, r.numRows)
@@ -344,7 +343,7 @@ func (r *PayloadReader) GetInt32FromPayload() ([]int32, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -354,14 +353,14 @@ func (r *PayloadReader) GetInt32FromPayload() ([]int32, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
 
 func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 	if r.colType != schemapb.DataType_Int64 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int64 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int64 from datatype %v", r.colType.String())
 	}
 
 	values := make([]int64, r.numRows)
@@ -373,7 +372,7 @@ func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 
 		return values, validData, nil
@@ -384,7 +383,7 @@ func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	return values, nil, nil
@@ -392,7 +391,7 @@ func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 
 func (r *PayloadReader) GetFloatFromPayload() ([]float32, []bool, error) {
 	if r.colType != schemapb.DataType_Float {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get float32 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get float32 from datatype %v", r.colType.String())
 	}
 
 	values := make([]float32, r.numRows)
@@ -403,7 +402,7 @@ func (r *PayloadReader) GetFloatFromPayload() ([]float32, []bool, error) {
 			return nil, nil, err
 		}
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -412,14 +411,14 @@ func (r *PayloadReader) GetFloatFromPayload() ([]float32, []bool, error) {
 		return nil, nil, err
 	}
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
 
 func (r *PayloadReader) GetDoubleFromPayload() ([]float64, []bool, error) {
 	if r.colType != schemapb.DataType_Double {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get double from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get double from datatype %v", r.colType.String())
 	}
 
 	values := make([]float64, r.numRows)
@@ -431,7 +430,7 @@ func (r *PayloadReader) GetDoubleFromPayload() ([]float64, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -441,14 +440,14 @@ func (r *PayloadReader) GetDoubleFromPayload() ([]float64, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
 
 func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 	if r.colType != schemapb.DataType_Timestamptz {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get timestamptz from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get timestamptz from datatype %v", r.colType.String())
 	}
 
 	values := make([]int64, r.numRows)
@@ -460,7 +459,7 @@ func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 
 		return values, validData, nil
@@ -471,7 +470,7 @@ func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	return values, nil, nil
@@ -479,7 +478,7 @@ func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 
 func (r *PayloadReader) GetStringFromPayload() ([]string, []bool, error) {
 	if r.colType != schemapb.DataType_String && r.colType != schemapb.DataType_VarChar {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get string from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get string from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -491,7 +490,7 @@ func (r *PayloadReader) GetStringFromPayload() ([]string, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -506,7 +505,7 @@ func (r *PayloadReader) GetStringFromPayload() ([]string, []bool, error) {
 
 func (r *PayloadReader) GetArrayFromPayload() ([]*schemapb.ScalarField, []bool, error) {
 	if r.colType != schemapb.DataType_Array {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get array from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get array from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -529,7 +528,7 @@ func (r *PayloadReader) GetArrayFromPayload() ([]*schemapb.ScalarField, []bool, 
 
 func (r *PayloadReader) GetVectorArrayFromPayload() ([]*schemapb.VectorField, error) {
 	if r.colType != schemapb.DataType_ArrayOfVector {
-		return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get vector from datatype %v", r.colType.String()))
+		return nil, merr.WrapErrDataIntegrityMsg("failed to get vector from datatype %v", r.colType.String())
 	}
 
 	return readVectorArrayFromListArray(r)
@@ -537,7 +536,7 @@ func (r *PayloadReader) GetVectorArrayFromPayload() ([]*schemapb.VectorField, er
 
 func (r *PayloadReader) GetJSONFromPayload() ([][]byte, []bool, error) {
 	if r.colType != schemapb.DataType_JSON {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get json from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get json from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -556,7 +555,7 @@ func (r *PayloadReader) GetJSONFromPayload() ([][]byte, []bool, error) {
 
 func (r *PayloadReader) GetGeometryFromPayload() ([][]byte, []bool, error) {
 	if r.colType != schemapb.DataType_Geometry {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get Geometry from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get Geometry from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -575,7 +574,7 @@ func (r *PayloadReader) GetGeometryFromPayload() ([][]byte, []bool, error) {
 
 func (r *PayloadReader) GetByteArrayDataSet() (*DataSet[parquet.ByteArray, *file.ByteArrayColumnChunkReader], error) {
 	if r.colType != schemapb.DataType_String && r.colType != schemapb.DataType_VarChar {
-		return nil, fmt.Errorf("failed to get string from datatype %v", r.colType.String())
+		return nil, merr.WrapErrServiceInternalMsg("failed to get string from datatype %v", r.colType.String())
 	}
 
 	return NewDataSet[parquet.ByteArray, *file.ByteArrayColumnChunkReader](r.reader, 0, r.numRows), nil
@@ -610,7 +609,7 @@ func readVectorArrayFromListArray(r *PayloadReader) ([]*schemapb.VectorField, er
 	defer table.Release()
 
 	if table.NumCols() != 1 {
-		return nil, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+		return nil, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 	}
 
 	column := table.Column(0)
@@ -625,17 +624,17 @@ func readVectorArrayFromListArray(r *PayloadReader) ([]*schemapb.VectorField, er
 	for _, chunk := range column.Data().Chunks() {
 		listArray, ok := chunk.(*array.List)
 		if !ok {
-			return nil, fmt.Errorf("expected ListArray, got %T", chunk)
+			return nil, merr.WrapErrServiceInternalMsg("expected ListArray, got %T", chunk)
 		}
 
 		for i := 0; i < listArray.Len(); i++ {
 			value, err := deserializeArrayOfVector(listArray, i, elementType, dim, true)
 			if err != nil {
-				return nil, fmt.Errorf("failed to deserialize VectorArray at row %d: %w", len(result), err)
+				return nil, merr.Wrapf(err, "failed to deserialize VectorArray at row %d", len(result))
 			}
 			vectorField, _ := value.(*schemapb.VectorField)
 			if vectorField == nil {
-				return nil, fmt.Errorf("null value in VectorArray")
+				return nil, merr.WrapErrServiceInternalMsg("null value in VectorArray")
 			}
 			result = append(result, vectorField)
 		}
@@ -653,7 +652,7 @@ func readNullableByteAndConvert[T any](r *PayloadReader, convert func([]byte) T)
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]T, r.numRows)
@@ -671,7 +670,7 @@ func readByteAndConvert[T any](r *PayloadReader, convert func(parquet.ByteArray)
 	}
 
 	if valuesRead != r.numRows {
-		return nil, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]T, r.numRows)
@@ -684,7 +683,7 @@ func readByteAndConvert[T any](r *PayloadReader, convert func(parquet.ByteArray)
 // GetBinaryVectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_BinaryVector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get binary vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get binary vector from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -699,7 +698,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -707,17 +706,17 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable binary vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable binary vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable binary vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable binary vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 			dim = dim / 8
 		} else {
@@ -735,7 +734,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -760,7 +759,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, int64(dim)*r.numRows)
@@ -773,7 +772,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 // GetFloat16VectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_Float16Vector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get float16 vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get float16 vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -787,7 +786,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -795,17 +794,17 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float16 vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float16 vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float16 vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float16 vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -822,7 +821,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -848,7 +847,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, int64(dim*2)*r.numRows)
@@ -861,7 +860,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 // GetBFloat16VectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_BFloat16Vector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get bfloat16 vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get bfloat16 vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -875,7 +874,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -883,17 +882,17 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable bfloat16 vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable bfloat16 vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable bfloat16 vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable bfloat16 vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -910,7 +909,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -936,7 +935,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, int64(dim*2)*r.numRows)
@@ -949,7 +948,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 // GetFloatVectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_FloatVector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get float vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get float vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -963,7 +962,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -971,17 +970,17 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -998,7 +997,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -1024,7 +1023,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]float32, int64(dim)*r.numRows)
@@ -1037,7 +1036,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 // GetSparseFloatVectorFromPayload returns fieldData, dimension, validData, error
 func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFieldData, int, []bool, error) {
 	if !typeutil.IsSparseFloatVectorType(r.colType) {
-		return nil, -1, nil, fmt.Errorf("failed to get sparse float vector from datatype %v", r.colType.String())
+		return nil, -1, nil, merr.WrapErrServiceInternalMsg("failed to get sparse float vector from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -1056,7 +1055,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -1064,7 +1063,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 		for _, chunk := range column.Data().Chunks() {
 			binaryArray, ok := chunk.(*array.Binary)
 			if !ok {
-				return nil, -1, nil, fmt.Errorf("expected Binary array, got %T", chunk)
+				return nil, -1, nil, merr.WrapErrServiceInternalMsg("expected Binary array, got %T", chunk)
 			}
 
 			for i := 0; i < binaryArray.Len(); i++ {
@@ -1072,7 +1071,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 				if validData[offset+i] {
 					value := binaryArray.Value(i)
 					if len(value)%8 != 0 {
-						return nil, -1, nil, errors.New("invalid bytesData length")
+						return nil, -1, nil, merr.WrapErrServiceInternalMsg("invalid bytesData length")
 					}
 					fieldData.Contents = append(fieldData.Contents, append([]byte{}, value...))
 					rowDim := typeutil.SparseFloatRowDim(value)
@@ -1093,14 +1092,14 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 		return nil, -1, nil, err
 	}
 	if valuesRead != r.numRows {
-		return nil, -1, nil, fmt.Errorf("expect %d binary, but got = %d", r.numRows, valuesRead)
+		return nil, -1, nil, merr.WrapErrServiceInternalMsg("expect %d binary, but got = %d", r.numRows, valuesRead)
 	}
 
 	fieldData := &SparseFloatVectorFieldData{}
 
 	for _, value := range values {
 		if len(value)%8 != 0 {
-			return nil, -1, nil, errors.New("invalid bytesData length")
+			return nil, -1, nil, merr.WrapErrServiceInternalMsg("invalid bytesData length")
 		}
 
 		fieldData.Contents = append(fieldData.Contents, value)
@@ -1116,7 +1115,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 // GetInt8VectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_Int8Vector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get int8 vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get int8 vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -1130,7 +1129,7 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -1138,17 +1137,17 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable int8 vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable int8 vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable int8 vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable int8 vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -1165,7 +1164,7 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -1191,7 +1190,7 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]int8, int64(dim)*r.numRows)
@@ -1220,7 +1219,7 @@ func ReadDataFromAllRowGroups[T any, E interface {
 
 	for i := 0; i < reader.NumRowGroups(); i++ {
 		if columnIdx >= reader.RowGroup(i).NumColumns() {
-			return -1, fmt.Errorf("try to fetch %d-th column of reader but row group has only %d column(s)", columnIdx, reader.RowGroup(i).NumColumns())
+			return -1, merr.WrapErrServiceInternalMsg("try to fetch %d-th column of reader but row group has only %d column(s)", columnIdx, reader.RowGroup(i).NumColumns())
 		}
 		column, err := reader.RowGroup(i).Column(columnIdx)
 		if err != nil {
@@ -1229,7 +1228,7 @@ func ReadDataFromAllRowGroups[T any, E interface {
 
 		cReader, ok := column.(E)
 		if !ok {
-			return -1, fmt.Errorf("expect type %T, but got %T", *new(E), column)
+			return -1, merr.WrapErrServiceInternalMsg("expect type %T, but got %T", *new(E), column)
 		}
 
 		_, valuesRead, err := cReader.ReadBatch(numRows, values[offset:], nil, nil)
@@ -1272,7 +1271,7 @@ func (s *DataSet[T, E]) nextGroup() error {
 
 	cReader, ok := column.(E)
 	if !ok {
-		return fmt.Errorf("expect type %T, but got %T", *new(E), column)
+		return merr.WrapErrServiceInternalMsg("expect type %T, but got %T", *new(E), column)
 	}
 	s.groupID++
 	s.cReader = cReader
@@ -1288,7 +1287,7 @@ func (s *DataSet[T, E]) HasNext() bool {
 
 func (s *DataSet[T, E]) NextBatch(batch int64) ([]T, error) {
 	if s.groupID > s.reader.NumRowGroups() || (s.groupID == s.reader.NumRowGroups() && s.cnt >= s.numRows) || s.numRows == 0 {
-		return nil, errors.New("has no more data")
+		return nil, merr.WrapErrServiceInternalMsg("has no more data")
 	}
 
 	if s.groupID == 0 || s.cnt >= s.numRows {
@@ -1400,7 +1399,7 @@ func readNullableVectorData(column *arrow.Column, numRows int64, bytesPerVector 
 	for _, chunk := range chunks {
 		binaryArray, ok := chunk.(*array.Binary)
 		if !ok {
-			return nil, nil, merr.WrapErrParameterInvalidMsg("expected Binary array for nullable vector, got %T", chunk)
+			return nil, nil, merr.WrapErrDataIntegrityMsg("expected Binary array for nullable vector, got %T", chunk)
 		}
 		chunkLen := binaryArray.Len()
 
@@ -1410,7 +1409,7 @@ func readNullableVectorData(column *arrow.Column, numRows int64, bytesPerVector 
 			valueBytes := binaryArray.ValueBytes()
 			expected := chunkValidCount * bytesPerVector
 			if len(valueBytes) != expected {
-				return nil, nil, merr.WrapErrParameterInvalidMsg(
+				return nil, nil, merr.WrapErrDataIntegrityMsg(
 					"unexpected valueBytes length for nullable vector: got %d, expected %d", len(valueBytes), expected)
 			}
 			copy(ret[dataOffset:dataOffset+len(valueBytes)], valueBytes)

--- a/internal/storage/payload_writer.go
+++ b/internal/storage/payload_writer.go
@@ -29,7 +29,6 @@ import (
 	"github.com/apache/arrow/go/v17/parquet"
 	"github.com/apache/arrow/go/v17/parquet/compress"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -303,17 +302,17 @@ func (w *NativePayloadWriter) AddDataToPayloadForUT(data interface{}, validData 
 		}
 		return w.AddVectorArrayFieldDataToPayload(val)
 	default:
-		return errors.New("unsupported datatype")
+		return merr.WrapErrServiceInternalMsg("unsupported datatype")
 	}
 }
 
 func (w *NativePayloadWriter) AddBoolToPayload(data []bool, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished bool payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished bool payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into bool payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into bool payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -328,7 +327,7 @@ func (w *NativePayloadWriter) AddBoolToPayload(data []bool, validData []bool) er
 
 	builder, ok := w.builder.(*array.BooleanBuilder)
 	if !ok {
-		return errors.New("failed to cast ArrayBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast ArrayBuilder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -337,11 +336,11 @@ func (w *NativePayloadWriter) AddBoolToPayload(data []bool, validData []bool) er
 
 func (w *NativePayloadWriter) AddByteToPayload(data []byte, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished byte payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished byte payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into byte payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into byte payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -356,7 +355,7 @@ func (w *NativePayloadWriter) AddByteToPayload(data []byte, validData []bool) er
 
 	builder, ok := w.builder.(*array.Int8Builder)
 	if !ok {
-		return errors.New("failed to cast ByteBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast ByteBuilder")
 	}
 
 	builder.Reserve(len(data))
@@ -372,11 +371,11 @@ func (w *NativePayloadWriter) AddByteToPayload(data []byte, validData []bool) er
 
 func (w *NativePayloadWriter) AddInt8ToPayload(data []int8, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int8 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int8 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int8 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int8 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -391,7 +390,7 @@ func (w *NativePayloadWriter) AddInt8ToPayload(data []int8, validData []bool) er
 
 	builder, ok := w.builder.(*array.Int8Builder)
 	if !ok {
-		return errors.New("failed to cast Int8Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int8Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -400,11 +399,11 @@ func (w *NativePayloadWriter) AddInt8ToPayload(data []int8, validData []bool) er
 
 func (w *NativePayloadWriter) AddInt16ToPayload(data []int16, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int16 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int16 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int16 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int16 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -419,7 +418,7 @@ func (w *NativePayloadWriter) AddInt16ToPayload(data []int16, validData []bool) 
 
 	builder, ok := w.builder.(*array.Int16Builder)
 	if !ok {
-		return errors.New("failed to cast Int16Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int16Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -428,11 +427,11 @@ func (w *NativePayloadWriter) AddInt16ToPayload(data []int16, validData []bool) 
 
 func (w *NativePayloadWriter) AddInt32ToPayload(data []int32, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int32 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int32 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int32 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int32 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -447,7 +446,7 @@ func (w *NativePayloadWriter) AddInt32ToPayload(data []int32, validData []bool) 
 
 	builder, ok := w.builder.(*array.Int32Builder)
 	if !ok {
-		return errors.New("failed to cast Int32Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int32Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -456,11 +455,11 @@ func (w *NativePayloadWriter) AddInt32ToPayload(data []int32, validData []bool) 
 
 func (w *NativePayloadWriter) AddInt64ToPayload(data []int64, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int64 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int64 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -475,7 +474,7 @@ func (w *NativePayloadWriter) AddInt64ToPayload(data []int64, validData []bool) 
 
 	builder, ok := w.builder.(*array.Int64Builder)
 	if !ok {
-		return errors.New("failed to cast Int64Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int64Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -484,11 +483,11 @@ func (w *NativePayloadWriter) AddInt64ToPayload(data []int64, validData []bool) 
 
 func (w *NativePayloadWriter) AddFloatToPayload(data []float32, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished float payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished float payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into float payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into float payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -503,7 +502,7 @@ func (w *NativePayloadWriter) AddFloatToPayload(data []float32, validData []bool
 
 	builder, ok := w.builder.(*array.Float32Builder)
 	if !ok {
-		return errors.New("failed to cast FloatBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast FloatBuilder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -512,11 +511,11 @@ func (w *NativePayloadWriter) AddFloatToPayload(data []float32, validData []bool
 
 func (w *NativePayloadWriter) AddDoubleToPayload(data []float64, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished double payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished double payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into double payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into double payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -531,7 +530,7 @@ func (w *NativePayloadWriter) AddDoubleToPayload(data []float64, validData []boo
 
 	builder, ok := w.builder.(*array.Float64Builder)
 	if !ok {
-		return errors.New("failed to cast DoubleBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast DoubleBuilder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -540,11 +539,11 @@ func (w *NativePayloadWriter) AddDoubleToPayload(data []float64, validData []boo
 
 func (w *NativePayloadWriter) AddTimestamptzToPayload(data []int64, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int64 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int64 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -559,7 +558,7 @@ func (w *NativePayloadWriter) AddTimestamptzToPayload(data []int64, validData []
 
 	builder, ok := w.builder.(*array.Int64Builder)
 	if !ok {
-		return errors.New("failed to cast Int64Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int64Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -568,7 +567,7 @@ func (w *NativePayloadWriter) AddTimestamptzToPayload(data []int64, validData []
 
 func (w *NativePayloadWriter) AddOneStringToPayload(data string, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished string payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished string payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -577,7 +576,7 @@ func (w *NativePayloadWriter) AddOneStringToPayload(data string, isValid bool) e
 
 	builder, ok := w.builder.(*array.StringBuilder)
 	if !ok {
-		return errors.New("failed to cast StringBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast StringBuilder")
 	}
 
 	if !isValid {
@@ -591,7 +590,7 @@ func (w *NativePayloadWriter) AddOneStringToPayload(data string, isValid bool) e
 
 func (w *NativePayloadWriter) AddOneArrayToPayload(data *schemapb.ScalarField, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished array payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished array payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -600,12 +599,12 @@ func (w *NativePayloadWriter) AddOneArrayToPayload(data *schemapb.ScalarField, i
 
 	bytes, err := proto.Marshal(data)
 	if err != nil {
-		return errors.New("Marshal ListValue failed")
+		return merr.WrapErrServiceInternalMsg("Marshal ListValue failed")
 	}
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast BinaryBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast BinaryBuilder")
 	}
 
 	if !isValid {
@@ -619,7 +618,7 @@ func (w *NativePayloadWriter) AddOneArrayToPayload(data *schemapb.ScalarField, i
 
 func (w *NativePayloadWriter) AddOneJSONToPayload(data []byte, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished json payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished json payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -628,7 +627,7 @@ func (w *NativePayloadWriter) AddOneJSONToPayload(data []byte, isValid bool) err
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast JsonBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast JsonBuilder")
 	}
 
 	if !isValid {
@@ -642,7 +641,7 @@ func (w *NativePayloadWriter) AddOneJSONToPayload(data []byte, isValid bool) err
 
 func (w *NativePayloadWriter) AddOneGeometryToPayload(data []byte, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished geometry payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished geometry payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -651,7 +650,7 @@ func (w *NativePayloadWriter) AddOneGeometryToPayload(data []byte, isValid bool)
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast geometryBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast geometryBuilder")
 	}
 
 	if !isValid {
@@ -672,7 +671,7 @@ func validateNullableVectorValidData(validData []bool) (int, error) {
 
 func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished binary vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished binary vector payload")
 	}
 
 	byteLength := dim / 8
@@ -690,7 +689,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into binary vector payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into binary vector payload")
 		}
 		numRows = len(data) / byteLength
 		if !w.nullable && len(validData) != 0 {
@@ -702,7 +701,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable BinaryVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable BinaryVector")
 		}
 
 		builder.Reserve(numRows)
@@ -718,7 +717,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable BinaryVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable BinaryVector")
 		}
 
 		builder.Reserve(numRows)
@@ -732,7 +731,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 
 func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished float vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished float vector payload")
 	}
 
 	var numRows int
@@ -749,7 +748,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into float vector payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into float vector payload")
 		}
 		numRows = len(data) / dim
 		if !w.nullable && len(validData) != 0 {
@@ -763,7 +762,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable FloatVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable FloatVector")
 		}
 
 		builder.Reserve(numRows)
@@ -785,7 +784,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable FloatVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable FloatVector")
 		}
 
 		builder.Reserve(numRows)
@@ -805,7 +804,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 
 func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished float16 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished float16 payload")
 	}
 
 	byteLength := dim * 2
@@ -823,7 +822,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into float16 payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into float16 payload")
 		}
 		numRows = len(data) / byteLength
 		if !w.nullable && len(validData) != 0 {
@@ -835,7 +834,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable Float16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable Float16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -851,7 +850,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable Float16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable Float16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -865,7 +864,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 
 func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished BFloat16 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished BFloat16 payload")
 	}
 
 	byteLength := dim * 2
@@ -883,7 +882,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into BFloat16 payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into BFloat16 payload")
 		}
 		numRows = len(data) / byteLength
 		if !w.nullable && len(validData) != 0 {
@@ -895,7 +894,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable BFloat16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable BFloat16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -911,7 +910,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable BFloat16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable BFloat16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -925,7 +924,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 
 func (w *NativePayloadWriter) AddSparseFloatVectorToPayload(data *SparseFloatVectorFieldData) error {
 	if w.finished {
-		return errors.New("can't append data to finished sparse float vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished sparse float vector payload")
 	}
 
 	var numRows int
@@ -949,7 +948,7 @@ func (w *NativePayloadWriter) AddSparseFloatVectorToPayload(data *SparseFloatVec
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast SparseFloatVectorBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast SparseFloatVectorBuilder")
 	}
 
 	builder.Reserve(numRows)
@@ -968,7 +967,7 @@ func (w *NativePayloadWriter) AddSparseFloatVectorToPayload(data *SparseFloatVec
 
 func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int8 vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int8 vector payload")
 	}
 
 	var numRows int
@@ -985,7 +984,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into int8 vector payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into int8 vector payload")
 		}
 		numRows = len(data) / dim
 		if !w.nullable && len(validData) != 0 {
@@ -997,7 +996,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable Int8Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable Int8Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -1015,7 +1014,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable Int8Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable Int8Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -1031,7 +1030,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 
 func (w *NativePayloadWriter) FinishPayloadWriter() error {
 	if w.finished {
-		return errors.New("can't reuse a finished writer")
+		return merr.WrapErrServiceInternalMsg("can't reuse a finished writer")
 	}
 
 	w.finished = true
@@ -1040,7 +1039,7 @@ func (w *NativePayloadWriter) FinishPayloadWriter() error {
 	var metadata arrow.Metadata
 	if w.dataType == schemapb.DataType_ArrayOfVector {
 		if w.elementType == nil {
-			return errors.New("element type for DataType_ArrayOfVector must be set")
+			return merr.WrapErrServiceInternalMsg("element type for DataType_ArrayOfVector must be set")
 		}
 
 		metadata = arrow.NewMetadata(
@@ -1099,7 +1098,7 @@ func (w *NativePayloadWriter) GetPayloadBufferFromWriter() ([]byte, error) {
 
 	// The cpp version of payload writer handles the empty buffer as error
 	if len(data) == 0 {
-		return nil, errors.New("empty buffer")
+		return nil, merr.WrapErrServiceInternalMsg("empty buffer")
 	}
 
 	return data, nil
@@ -1176,16 +1175,16 @@ func MilvusDataTypeToArrowType(dataType schemapb.DataType, dim int) arrow.DataTy
 // AddVectorArrayFieldDataToPayload adds VectorArrayFieldData to payload using Arrow ListArray
 func (w *NativePayloadWriter) AddVectorArrayFieldDataToPayload(data *VectorArrayFieldData) error {
 	if w.finished {
-		return errors.New("can't append data to finished vector array payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished vector array payload")
 	}
 
 	if len(data.Data) == 0 {
-		return errors.New("can't add empty vector array field data")
+		return merr.WrapErrServiceInternalMsg("can't add empty vector array field data")
 	}
 
 	builder, ok := w.builder.(*array.ListBuilder)
 	if !ok {
-		return errors.New("failed to cast to ListBuilder for VectorArray")
+		return merr.WrapErrServiceInternalMsg("failed to cast to ListBuilder for VectorArray")
 	}
 
 	switch data.ElementType {

--- a/internal/storage/pk_statistics.go
+++ b/internal/storage/pk_statistics.go
@@ -17,15 +17,14 @@
 package storage
 
 import (
-	"fmt"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/bloomfilter"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // pkStatistics contains pk field statistic information
@@ -38,7 +37,7 @@ type PkStatistics struct {
 // update set pk min/max value if input value is beyond former range.
 func (st *PkStatistics) UpdateMinMax(pk PrimaryKey) error {
 	if st == nil {
-		return errors.New("nil pk statistics")
+		return merr.WrapErrServiceInternalMsg("nil pk statistics")
 	}
 	if st.MinPK == nil {
 		st.MinPK = pk
@@ -78,7 +77,7 @@ func (st *PkStatistics) UpdatePKRange(ids FieldData) error {
 			st.PkFilter.AddString(pk)
 		}
 	default:
-		return fmt.Errorf("invalid data type for primary key: %T", ids)
+		return merr.WrapErrServiceInternalMsg("invalid data type for primary key: %T", ids)
 	}
 	return nil
 }

--- a/internal/storage/primary_key.go
+++ b/internal/storage/primary_key.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/log"
@@ -141,7 +139,7 @@ func (ip *Int64PrimaryKey) UnmarshalJSON(data []byte) error {
 func (ip *Int64PrimaryKey) SetValue(data interface{}) error {
 	value, ok := data.(int64)
 	if !ok {
-		return errors.New("wrong type value when setValue for Int64PrimaryKey")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64PrimaryKey")
 	}
 
 	ip.Value = value
@@ -241,7 +239,7 @@ func (vcp *VarCharPrimaryKey) UnmarshalJSON(data []byte) error {
 func (vcp *VarCharPrimaryKey) SetValue(data interface{}) error {
 	value, ok := data.(string)
 	if !ok {
-		return errors.New("wrong type value when setValue for VarCharPrimaryKey")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for VarCharPrimaryKey")
 	}
 
 	vcp.Value = value
@@ -272,7 +270,7 @@ func GenPrimaryKeyByRawData(data interface{}, pkType schemapb.DataType) (Primary
 			Value: data.(string),
 		}
 	default:
-		return nil, errors.New("not supported primary data type")
+		return nil, merr.WrapErrServiceInternalMsg("not supported primary data type")
 	}
 
 	return result, nil
@@ -305,11 +303,11 @@ func GenVarcharPrimaryKeys(data ...string) ([]PrimaryKey, error) {
 func ParseFieldData2PrimaryKeys(data *schemapb.FieldData) ([]PrimaryKey, error) {
 	ret := make([]PrimaryKey, 0)
 	if data == nil {
-		return ret, errors.New("failed to parse pks from nil field data")
+		return ret, merr.WrapErrServiceInternalMsg("failed to parse pks from nil field data")
 	}
 	scalarData := data.GetScalars()
 	if scalarData == nil {
-		return ret, errors.New("failed to parse pks from nil scalar data")
+		return ret, merr.WrapErrServiceInternalMsg("failed to parse pks from nil scalar data")
 	}
 
 	switch data.Type {
@@ -324,7 +322,7 @@ func ParseFieldData2PrimaryKeys(data *schemapb.FieldData) ([]PrimaryKey, error) 
 			ret = append(ret, pk)
 		}
 	default:
-		return ret, errors.New("not supported primary data type")
+		return ret, merr.WrapErrServiceInternalMsg("not supported primary data type")
 	}
 
 	return ret, nil

--- a/internal/storage/print_binlog.go
+++ b/internal/storage/print_binlog.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cockroachdb/errors"
 	"golang.org/x/exp/mmap"
 	"google.golang.org/protobuf/proto"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 )
 
@@ -89,7 +89,7 @@ func printBinlogFile(filename string) error {
 	fmt.Printf("\tEndTimestamp: %v\n", physical)
 	dataTypeName, ok := schemapb.DataType_name[int32(r.descriptorEvent.descriptorEventData.PayloadDataType)]
 	if !ok {
-		return fmt.Errorf("undefine data type %d", r.descriptorEvent.descriptorEventData.PayloadDataType)
+		return merr.WrapErrServiceInternalMsg("undefine data type %d", r.descriptorEvent.descriptorEventData.PayloadDataType)
 	}
 	fmt.Printf("\tPayloadDataType: %v\n", dataTypeName)
 	fmt.Printf("\tPostHeaderLengths: %v\n", r.descriptorEvent.descriptorEventData.PostHeaderLengths)
@@ -112,7 +112,7 @@ func printBinlogFile(filename string) error {
 		case InsertEventType:
 			evd, ok := event.eventData.(*insertEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d insert event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -125,7 +125,7 @@ func printBinlogFile(filename string) error {
 		case DeleteEventType:
 			evd, ok := event.eventData.(*deleteEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d delete event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -138,7 +138,7 @@ func printBinlogFile(filename string) error {
 		case CreateCollectionEventType:
 			evd, ok := event.eventData.(*createCollectionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d create collection event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -151,7 +151,7 @@ func printBinlogFile(filename string) error {
 		case DropCollectionEventType:
 			evd, ok := event.eventData.(*dropCollectionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d drop collection event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -164,7 +164,7 @@ func printBinlogFile(filename string) error {
 		case CreatePartitionEventType:
 			evd, ok := event.eventData.(*createPartitionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d create partition event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -177,7 +177,7 @@ func printBinlogFile(filename string) error {
 		case DropPartitionEventType:
 			evd, ok := event.eventData.(*dropPartitionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d drop partition event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -193,14 +193,14 @@ func printBinlogFile(filename string) error {
 			extra := make(map[string]interface{})
 			err = json.Unmarshal(extraBytes, &extra)
 			if err != nil {
-				return fmt.Errorf("failed to unmarshal extra: %s", err.Error())
+				return merr.WrapErrServiceInternalMsg("failed to unmarshal extra: %s", err.Error())
 			}
 			fmt.Printf("indexBuildID: %v\n", extra["indexBuildID"])
 			fmt.Printf("indexName: %v\n", extra["indexName"])
 			fmt.Printf("indexID: %v\n", extra["indexID"])
 			evd, ok := event.eventData.(*indexFileEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("index file event num: %d\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -212,7 +212,7 @@ func printBinlogFile(filename string) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("undefined event typd %d", event.eventHeader.TypeCode)
+			return merr.WrapErrServiceInternalMsg("undefined event typd %d", event.eventHeader.TypeCode)
 		}
 		eventNum++
 	}
@@ -421,7 +421,7 @@ func printPayloadValues(colType schemapb.DataType, reader PayloadReaderInterface
 		}
 		fmt.Println("===== SparseFloatVectorFieldData end =====")
 	default:
-		return errors.New("undefined data type")
+		return merr.WrapErrServiceInternalMsg("undefined data type")
 	}
 	return nil
 }
@@ -477,11 +477,11 @@ func printDDLPayloadValues(eventType EventTypeCode, colType schemapb.DataType, r
 				}
 				fmt.Printf("\t\t%d : drop partition: %v\n", i, req)
 			default:
-				return fmt.Errorf("undefined ddl event type %d", eventType)
+				return merr.WrapErrServiceInternalMsg("undefined ddl event type %d", eventType)
 			}
 		}
 	default:
-		return errors.New("undefined data type")
+		return merr.WrapErrServiceInternalMsg("undefined data type")
 	}
 	return nil
 }

--- a/internal/storage/record_reader.go
+++ b/internal/storage/record_reader.go
@@ -53,7 +53,7 @@ func newPackedRecordReader(
 ) (*packedRecordReader, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 	field2Col := make(map[FieldID]int)
 	allFields := typeutil.GetAllFieldSchemas(schema)
@@ -97,7 +97,7 @@ func (ir *IterativeRecordReader) Close() error {
 func (ir *IterativeRecordReader) Next() (rec Record, err error) {
 	defer func() {
 		if x := recover(); x != nil {
-			rec, err = nil, fmt.Errorf("internal error recovered: %v", x)
+			rec, err = nil, merr.WrapErrServiceInternalMsg("internal error recovered: %v", x)
 		}
 	}()
 	if ir.cur == nil {
@@ -167,7 +167,7 @@ func NewManifestReaderFromBinlogs(fieldBinlogs []*datapb.FieldBinlog,
 ) (*ManifestReader, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, false)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 	schemaHelper, err := typeutil.CreateSchemaHelper(schema)
 	if err != nil {
@@ -209,7 +209,7 @@ func NewManifestReader(manifest string,
 ) (*ManifestReader, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	// Override TEXT fields to binary type — LOB references are binary encoded in manifest storage

--- a/internal/storage/record_writer.go
+++ b/internal/storage/record_writer.go
@@ -158,8 +158,7 @@ func NewPackedRecordWriter(
 	columnGroupCompressed := make(map[typeutil.UniqueID]uint64)
 	pathsMap := make(map[typeutil.UniqueID]string)
 	if len(paths) != len(columnGroups) {
-		return nil, merr.WrapErrParameterInvalid(len(paths), len(columnGroups),
-			"paths length is not equal to column groups length for packed record writer")
+		return nil, merr.WrapErrStorageMsg("paths length is not equal to column groups length for packed record writer: paths=%d columnGroups=%d", len(paths), len(columnGroups))
 	}
 	for i, columnGroup := range columnGroups {
 		columnGroupUncompressed[columnGroup.GroupID] = 0

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -129,7 +129,7 @@ func (mcm *RemoteChunkManager) Path(ctx context.Context, filePath string) (strin
 		return "", err
 	}
 	if !exist {
-		return "", errors.New("minio file manage cannot be found with filePath:" + filePath)
+		return "", merr.WrapErrServiceInternalMsg("minio file manage cannot be found with filePath:" + filePath)
 	}
 	return filePath, nil
 }
@@ -194,7 +194,7 @@ func (mcm *RemoteChunkManager) MultiWrite(ctx context.Context, kvs map[string][]
 	for key, value := range kvs {
 		err := mcm.Write(ctx, key, value)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to write %s", key))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to write %s", key))
 		}
 	}
 	return el
@@ -259,7 +259,7 @@ func (mcm *RemoteChunkManager) MultiRead(ctx context.Context, keys []string) ([]
 	for _, key := range keys {
 		objectValue, err := mcm.Read(ctx, key)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to read %s", key))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to read %s", key))
 		}
 		objectsValues = append(objectsValues, objectValue)
 	}
@@ -268,7 +268,7 @@ func (mcm *RemoteChunkManager) MultiRead(ctx context.Context, keys []string) ([]
 }
 
 func (mcm *RemoteChunkManager) Mmap(ctx context.Context, filePath string) (*mmap.ReaderAt, error) {
-	return nil, errors.New("this method has not been implemented")
+	return nil, merr.WrapErrServiceInternalMsg("this method has not been implemented")
 }
 
 // ReadAt reads specific position data of minio storage if exists.
@@ -310,7 +310,7 @@ func (mcm *RemoteChunkManager) MultiRemove(ctx context.Context, keys []string) e
 	for _, key := range keys {
 		err := mcm.Remove(ctx, key)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to remove %s", key))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to remove %s", key))
 		}
 	}
 	return el

--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -58,10 +58,10 @@ type (
 
 func validateVectorArrayElementCount(payloadLength int, elementsPerVector int) (int, error) {
 	if elementsPerVector <= 0 {
-		return 0, fmt.Errorf("invalid vector width %d for ArrayOfVector", elementsPerVector)
+		return 0, merr.WrapErrStorageMsg("invalid vector width %d for ArrayOfVector", elementsPerVector)
 	}
 	if payloadLength%elementsPerVector != 0 {
-		return 0, fmt.Errorf("ArrayOfVector payload length %d is not divisible by vector width %d", payloadLength, elementsPerVector)
+		return 0, merr.WrapErrStorageMsg("ArrayOfVector payload length %d is not divisible by vector width %d", payloadLength, elementsPerVector)
 	}
 	return payloadLength / elementsPerVector, nil
 }
@@ -125,7 +125,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Boolean); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Boolean, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Boolean, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -137,9 +137,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected bool value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected bool value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.BooleanBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.BooleanBuilder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int8] = serdeEntry{
@@ -153,7 +153,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int8); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int8, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int8, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -165,9 +165,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int8 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int8 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int8Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int8Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int16] = serdeEntry{
@@ -181,7 +181,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int16); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int16, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int16, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -193,9 +193,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int16 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int16 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int16Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int16Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int32] = serdeEntry{
@@ -209,7 +209,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int32); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int32, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int32, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -221,9 +221,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int32 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int32 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int32Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int32Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int64] = serdeEntry{
@@ -237,7 +237,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int64); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int64, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int64, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -249,9 +249,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int64 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int64 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int64Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int64Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Float] = serdeEntry{
@@ -265,7 +265,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Float32); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Float32, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Float32, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -277,9 +277,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected float32 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected float32 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Float32Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Float32Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Double] = serdeEntry{
@@ -293,7 +293,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Float64); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Float64, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Float64, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -305,9 +305,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected float64 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected float64 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Float64Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Float64Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Timestamptz] = serdeEntry{
@@ -321,7 +321,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int64); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int64, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int64, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -333,9 +333,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int64 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int64 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int64Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int64Builder, got %T", b)
 		},
 	}
 	stringEntry := serdeEntry{
@@ -353,7 +353,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return value, nil
 			}
-			return nil, fmt.Errorf("expected *array.String, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.String, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -365,9 +365,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected string value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected string value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.StringBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.StringBuilder, got %T", b)
 		},
 	}
 
@@ -390,10 +390,10 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				if err := proto.Unmarshal(arr.Value(i), v); err == nil {
 					return v, nil
 				} else {
-					return nil, fmt.Errorf("failed to unmarshal ScalarField: %w", err)
+					return nil, merr.WrapErrStorage(err, "failed to unmarshal ScalarField")
 				}
 			}
-			return nil, fmt.Errorf("expected *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -406,12 +406,12 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 						builder.Append(bytes)
 						return nil
 					} else {
-						return fmt.Errorf("failed to marshal ScalarField: %w", err)
+						return merr.WrapErrStorage(err, "failed to marshal ScalarField")
 					}
 				}
-				return fmt.Errorf("expected *schemapb.ScalarField value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected *schemapb.ScalarField value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.BinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.BinaryBuilder, got %T", b)
 		},
 	}
 	_ = eagerArrayEntry
@@ -433,7 +433,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return value, nil
 			}
-			return nil, fmt.Errorf("expected *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -450,7 +450,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 						builder.Append(bytes)
 						return nil
 					} else {
-						return fmt.Errorf("failed to marshal ScalarField: %w", err)
+						return merr.WrapErrStorage(err, "failed to marshal ScalarField")
 					}
 				}
 				if vv, ok := v.(*schemapb.VectorField); ok {
@@ -458,12 +458,12 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 						builder.Append(bytes)
 						return nil
 					} else {
-						return fmt.Errorf("failed to marshal VectorField: %w", err)
+						return merr.WrapErrStorage(err, "failed to marshal VectorField")
 					}
 				}
-				return fmt.Errorf("expected []byte, *schemapb.ScalarField or *schemapb.VectorField value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected []byte, *schemapb.ScalarField or *schemapb.VectorField value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.BinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.BinaryBuilder, got %T", b)
 		},
 	}
 
@@ -487,7 +487,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 
 			vf, ok := v.(*schemapb.VectorField)
 			if !ok {
-				return fmt.Errorf("expected *schemapb.VectorField, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected *schemapb.VectorField, got %T", v)
 			}
 			if vf == nil {
 				b.AppendNull()
@@ -496,7 +496,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 
 			builder, ok := b.(*array.ListBuilder)
 			if !ok {
-				return fmt.Errorf("expected *array.ListBuilder, got %T", b)
+				return merr.WrapErrServiceInternalMsg("expected *array.ListBuilder, got %T", b)
 			}
 
 			valueBuilder := builder.ValueBuilder().(*array.FixedSizeBinaryBuilder)
@@ -519,7 +519,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			switch elementType {
 			case schemapb.DataType_FloatVector:
 				if vf.GetFloatVector() == nil {
-					return fmt.Errorf("FloatVector data is nil for elementType FloatVector")
+					return merr.WrapErrServiceInternalMsg("FloatVector data is nil for elementType FloatVector")
 				}
 				floatData := vf.GetFloatVector().GetData()
 				floatsPerVector := bytesPerVector / 4
@@ -544,32 +544,32 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 
 			case schemapb.DataType_BinaryVector:
 				if vf.GetBinaryVector() == nil {
-					return fmt.Errorf("BinaryVector data is nil for elementType BinaryVector")
+					return merr.WrapErrServiceInternalMsg("BinaryVector data is nil for elementType BinaryVector")
 				}
 				return appendVectorChunks(vf.GetBinaryVector())
 
 			case schemapb.DataType_Float16Vector:
 				if vf.GetFloat16Vector() == nil {
-					return fmt.Errorf("Float16Vector data is nil for elementType Float16Vector")
+					return merr.WrapErrServiceInternalMsg("Float16Vector data is nil for elementType Float16Vector")
 				}
 				return appendVectorChunks(vf.GetFloat16Vector())
 
 			case schemapb.DataType_BFloat16Vector:
 				if vf.GetBfloat16Vector() == nil {
-					return fmt.Errorf("BFloat16Vector data is nil for elementType BFloat16Vector")
+					return merr.WrapErrServiceInternalMsg("BFloat16Vector data is nil for elementType BFloat16Vector")
 				}
 				return appendVectorChunks(vf.GetBfloat16Vector())
 
 			case schemapb.DataType_Int8Vector:
 				if vf.GetInt8Vector() == nil {
-					return fmt.Errorf("Int8Vector data is nil for elementType Int8Vector")
+					return merr.WrapErrServiceInternalMsg("Int8Vector data is nil for elementType Int8Vector")
 				}
 				return appendVectorChunks(vf.GetInt8Vector())
 
 			case schemapb.DataType_SparseFloatVector:
-				return fmt.Errorf("SparseFloatVector in VectorArray not implemented yet")
+				return merr.WrapErrServiceInternalMsg("SparseFloatVector in VectorArray not implemented yet")
 			default:
-				return fmt.Errorf("unsupported elementType for ArrayOfVector: %s", elementType.String())
+				return merr.WrapErrServiceInternalMsg("unsupported elementType for ArrayOfVector: %s", elementType.String())
 			}
 		},
 	}
@@ -596,7 +596,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return value, nil
 		}
-		return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
+		return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 	}
 	fixedSizeSerializer := func(b array.Builder, v any, _ schemapb.DataType) error {
 		if v == nil {
@@ -612,9 +612,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				builder.Append(v)
 				return nil
 			}
-			return fmt.Errorf("expected []byte value, got %T", v)
+			return merr.WrapErrServiceInternalMsg("expected []byte value, got %T", v)
 		}
-		return fmt.Errorf("expected *array.FixedSizeBinaryBuilder, got %T", b)
+		return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder, got %T", b)
 	}
 
 	m[schemapb.DataType_BinaryVector] = serdeEntry{
@@ -664,7 +664,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return int8s, nil
 			}
-			return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -677,7 +677,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			} else if vv, ok := v.([]int8); ok {
 				bytesData = arrow.Int8Traits.CastToBytes(vv)
 			} else {
-				return fmt.Errorf("expected []byte or []int8 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected []byte or []int8 value, got %T", v)
 			}
 			if builder, ok := b.(*array.FixedSizeBinaryBuilder); ok {
 				builder.Append(bytesData)
@@ -687,7 +687,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				builder.Append(bytesData)
 				return nil
 			}
-			return fmt.Errorf("expected *array.FixedSizeBinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_FloatVector] = serdeEntry{
@@ -718,7 +718,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return vector, nil
 			}
-			return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -741,9 +741,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(bytesData)
 					return nil
 				}
-				return fmt.Errorf("expected *array.FixedSizeBinaryBuilder or *array.BinaryBuilder, got %T", b)
+				return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder or *array.BinaryBuilder, got %T", b)
 			}
-			return fmt.Errorf("expected *array.FixedSizeBinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_SparseFloatVector] = byteEntry
@@ -987,9 +987,9 @@ func createEmptyVectorField(elementType schemapb.DataType, dim int64) (*schemapb
 			},
 		}, nil
 	case schemapb.DataType_SparseFloatVector:
-		return nil, fmt.Errorf("SparseFloatVector in empty VectorArray not implemented yet")
+		return nil, merr.WrapErrServiceInternalMsg("SparseFloatVector in empty VectorArray not implemented yet")
 	default:
-		return nil, fmt.Errorf("unsupported element type for empty ArrayOfVector: %s", elementType.String())
+		return nil, merr.WrapErrServiceInternalMsg("unsupported element type for empty ArrayOfVector: %s", elementType.String())
 	}
 }
 
@@ -1001,10 +1001,10 @@ func deserializeArrayOfVector(a arrow.Array, i int, elementType schemapb.DataTyp
 
 	arr, ok := a.(*array.List)
 	if !ok {
-		return nil, fmt.Errorf("expected *array.List for ArrayOfVector, got %T", a)
+		return nil, merr.WrapErrServiceInternalMsg("expected *array.List for ArrayOfVector, got %T", a)
 	}
 	if i >= arr.Len() {
-		return nil, fmt.Errorf("index %d out of bounds for array of length %d", i, arr.Len())
+		return nil, merr.WrapErrServiceInternalMsg("index %d out of bounds for array of length %d", i, arr.Len())
 	}
 
 	start, end := arr.ValueOffsets(i)
@@ -1019,7 +1019,7 @@ func deserializeArrayOfVector(a arrow.Array, i int, elementType schemapb.DataTyp
 	valuesArray := arr.ListValues()
 	binaryArray, ok := valuesArray.(*array.FixedSizeBinary)
 	if !ok {
-		return nil, fmt.Errorf("expected *array.FixedSizeBinary for ArrayOfVector values, got %T", valuesArray)
+		return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary for ArrayOfVector values, got %T", valuesArray)
 	}
 
 	numVectors := int(totalElements)
@@ -1088,9 +1088,9 @@ func deserializeArrayOfVector(a arrow.Array, i int, elementType schemapb.DataTyp
 			},
 		}, nil
 	case schemapb.DataType_SparseFloatVector:
-		return nil, fmt.Errorf("SparseFloatVector in VectorArray deserialization not implemented yet")
+		return nil, merr.WrapErrServiceInternalMsg("SparseFloatVector in VectorArray deserialization not implemented yet")
 	default:
-		return nil, fmt.Errorf("unsupported element type for ArrayOfVector deserialization: %s", elementType.String())
+		return nil, merr.WrapErrServiceInternalMsg("unsupported element type for ArrayOfVector deserialization: %s", elementType.String())
 	}
 }
 

--- a/internal/storage/serde_delta.go
+++ b/internal/storage/serde_delta.go
@@ -21,14 +21,12 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
 	"io"
 	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -416,7 +414,7 @@ func newDeltalogMultiFieldWriter(eventWriter *MultiFieldDeltalogStreamWriter, ba
 				pb.Append(pk)
 			}
 		default:
-			return nil, fmt.Errorf("unexpected pk type %v", v[0].PkType)
+			return nil, merr.WrapErrServiceInternalMsg("unexpected pk type %v", v[0].PkType)
 		}
 
 		for _, vv := range v {
@@ -441,7 +439,7 @@ func newDeltalogMultiFieldReader(blobs []*Blob) (*DeserializeReaderImpl[*DeleteL
 	return NewDeserializeReader(reader, func(r Record, v []*DeleteLog) error {
 		rec, ok := r.(*simpleArrowRecord)
 		if !ok {
-			return errors.New("can not cast to simple arrow record")
+			return merr.WrapErrServiceInternalMsg("can not cast to simple arrow record")
 		}
 		fields := rec.r.Schema().Fields()
 		switch fields[0].Type.ID() {
@@ -462,7 +460,7 @@ func newDeltalogMultiFieldReader(blobs []*Blob) (*DeserializeReaderImpl[*DeleteL
 				v[j].Pk = NewVarCharPrimaryKey(arr.Value(j))
 			}
 		default:
-			return fmt.Errorf("unexpected delta log pkType %v", fields[0].Type.Name())
+			return merr.WrapErrServiceInternalMsg("unexpected delta log pkType %v", fields[0].Type.Name())
 		}
 
 		arr := r.Column(1).(*array.Int64)
@@ -561,7 +559,7 @@ func (w *LegacyDeltalogWriter) Write(rec Record) error {
 			pk := NewVarCharPrimaryKey(rec.Column(0).(*array.String).Value(i))
 			return NewDeleteLog(pk, ts), nil
 		default:
-			return nil, fmt.Errorf("unexpected pk type %v", w.pkType)
+			return nil, merr.WrapErrServiceInternalMsg("unexpected pk type %v", w.pkType)
 		}
 	}
 
@@ -642,7 +640,7 @@ func (r *deleteLogToRecordReader) Next() (Record, error) {
 		}
 		pkArray = builder.NewArray()
 	default:
-		return nil, fmt.Errorf("unsupported pk type: %v", r.pkType)
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported pk type: %v", r.pkType)
 	}
 
 	tsBuilder := array.NewInt64Builder(allocator)

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -114,7 +114,7 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 				}
 				comparators = append(comparators, f)
 			default:
-				return 0, nil, merr.WrapErrParameterInvalidMsg("unsupported type for sorting key")
+				return 0, nil, merr.WrapErrStorageMsg("unsupported type for sorting key")
 			}
 		}
 
@@ -281,7 +281,7 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 				return 0
 			})
 		default:
-			return 0, merr.WrapErrParameterInvalidMsg("unsupported type for sorting key")
+			return 0, merr.WrapErrStorageMsg("unsupported type for sorting key")
 		}
 	}
 

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"path"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -102,7 +101,7 @@ func (stats *PrimaryKeyStats) UnmarshalJSON(data []byte) error {
 		stats.MaxPk = &VarCharPrimaryKey{}
 		stats.MinPk = &VarCharPrimaryKey{}
 	default:
-		return errors.New("Invalid PK Data Type")
+		return merr.WrapErrServiceInternalMsg("Invalid PK Data Type")
 	}
 
 	if maxPkMessage, ok := messageMap["maxPk"]; ok && maxPkMessage != nil {
@@ -283,10 +282,7 @@ func (sr *StatsReader) GetPrimaryKeyStats() (*PrimaryKeyStats, error) {
 	stats := &PrimaryKeyStats{}
 	err := json.Unmarshal(sr.buffer, &stats)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid(
-			"valid JSON",
-			string(sr.buffer),
-			err.Error())
+		return nil, merr.WrapErrDataIntegrity(err, "PrimaryKeyStats unmarshal failed")
 	}
 
 	return stats, nil
@@ -297,10 +293,7 @@ func (sr *StatsReader) GetPrimaryKeyStatsList() ([]*PrimaryKeyStats, error) {
 	stats := []*PrimaryKeyStats{}
 	err := json.Unmarshal(sr.buffer, &stats)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid(
-			"valid JSON",
-			string(sr.buffer),
-			err.Error())
+		return nil, merr.WrapErrDataIntegrity(err, "PrimaryKeyStats list unmarshal failed")
 	}
 
 	return stats, nil

--- a/internal/storage/stats_collector.go
+++ b/internal/storage/stats_collector.go
@@ -20,13 +20,13 @@ import (
 	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -202,7 +202,7 @@ func (c *Bm25StatsCollector) Collect(r Record) error {
 	for fieldID, stats := range c.bm25Stats {
 		field, ok := r.Column(fieldID).(*array.Binary)
 		if !ok {
-			return errors.New("bm25 field value not found")
+			return merr.WrapErrServiceInternalMsg("bm25 field value not found")
 		}
 		for i := 0; i < rows; i++ {
 			stats.AppendBytes(field.Value(i))

--- a/internal/storage/stats_test.go
+++ b/internal/storage/stats_test.go
@@ -227,7 +227,7 @@ func TestDeserializeStatsFailed(t *testing.T) {
 	}
 
 	_, err := DeserializeStatsList(blob)
-	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.ErrorIs(t, err, merr.ErrDataIntegrity)
 }
 
 func TestDeserializeEmptyStats(t *testing.T) {

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -29,7 +29,6 @@ import (
 	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -184,12 +183,12 @@ func TransferColumnBasedInsertDataToRowBased(data *InsertData) (
 ) {
 	if !checkTsField(data) {
 		return nil, nil, nil,
-			errors.New("cannot get timestamps from insert data")
+			merr.WrapErrServiceInternalMsg("cannot get timestamps from insert data")
 	}
 
 	if !checkRowIDField(data) {
 		return nil, nil, nil,
-			errors.New("cannot get row ids from insert data")
+			merr.WrapErrServiceInternalMsg("cannot get row ids from insert data")
 	}
 
 	tss := data.Data[common.TimeStampField].(*Int64FieldData)
@@ -210,7 +209,7 @@ func TransferColumnBasedInsertDataToRowBased(data *InsertData) (
 	all = append(all, ls.datas...)
 	if !checkNumRows(all...) {
 		return nil, nil, nil,
-			errors.New("columns of insert data have different length")
+			merr.WrapErrServiceInternalMsg("columns of insert data have different length")
 	}
 
 	sortFieldDataList(ls)
@@ -226,7 +225,7 @@ func TransferColumnBasedInsertDataToRowBased(data *InsertData) (
 			err := binary.Write(&buffer, common.Endian, d)
 			if err != nil {
 				return nil, nil, nil,
-					fmt.Errorf("failed to get binary row, err: %v", err)
+					merr.WrapErrServiceInternalMsg("failed to get binary row, err: %v", err)
 			}
 		}
 
@@ -259,7 +258,7 @@ func GetDimFromParams(params []*commonpb.KeyValuePair) (int, error) {
 			return dim, nil
 		}
 	}
-	return -1, errors.New("dim not found in params")
+	return -1, merr.WrapErrServiceInternalMsg("dim not found in params")
 }
 
 // ReadBinary read data in bytes and write it into receiver.
@@ -420,7 +419,7 @@ func RowBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *schemap
 	}
 
 	if len(collSchema.StructArrayFields) > 0 {
-		return nil, errors.New("struct fields are not implemented in row based insert data")
+		return nil, merr.WrapErrServiceInternalMsg("struct fields are not implemented in row based insert data")
 	}
 
 	for _, field := range collSchema.Fields {
@@ -482,7 +481,7 @@ func RowBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *schemap
 				Dim:  dim,
 			}
 		case schemapb.DataType_SparseFloatVector:
-			return nil, errors.New("Sparse Float Vector is not supported in row based data")
+			return nil, merr.WrapErrServiceInternalMsg("Sparse Float Vector is not supported in row based data")
 
 		case schemapb.DataType_Int8Vector:
 			dim, err := GetDimFromParams(field.TypeParams)
@@ -1314,7 +1313,7 @@ func GetPkFromInsertData(collSchema *schemapb.CollectionSchema, data *InsertData
 	pfData, ok := data.Data[pf.FieldID]
 	if !ok {
 		log.Warn("no primary field found in insert msg", zap.Int64("fieldID", pf.FieldID))
-		return nil, errors.New("no primary field found in insert msg")
+		return nil, merr.WrapErrServiceInternalMsg("no primary field found in insert msg")
 	}
 
 	var realPfData FieldData
@@ -1328,7 +1327,7 @@ func GetPkFromInsertData(collSchema *schemapb.CollectionSchema, data *InsertData
 	}
 	if !ok {
 		log.Warn("primary field not in Int64 or VarChar format", zap.Int64("fieldID", pf.FieldID))
-		return nil, errors.New("primary field not in Int64 or VarChar format")
+		return nil, merr.WrapErrServiceInternalMsg("primary field not in Int64 or VarChar format")
 	}
 
 	return realPfData, nil
@@ -1337,16 +1336,16 @@ func GetPkFromInsertData(collSchema *schemapb.CollectionSchema, data *InsertData
 // GetTimestampFromInsertData returns the Int64FieldData for timestamp field.
 func GetTimestampFromInsertData(data *InsertData) (*Int64FieldData, error) {
 	if data == nil {
-		return nil, errors.New("try to get timestamp from nil insert data")
+		return nil, merr.WrapErrServiceInternalMsg("try to get timestamp from nil insert data")
 	}
 	fieldData, ok := data.Data[common.TimeStampField]
 	if !ok {
-		return nil, errors.New("no timestamp field in insert data")
+		return nil, merr.WrapErrServiceInternalMsg("no timestamp field in insert data")
 	}
 
 	ifd, ok := fieldData.(*Int64FieldData)
 	if !ok {
-		return nil, errors.New("timestamp field is not Int64")
+		return nil, merr.WrapErrServiceInternalMsg("timestamp field is not Int64")
 	}
 
 	return ifd, nil
@@ -1679,7 +1678,7 @@ func TransferInsertDataToInsertRecord(insertData *InsertData) (*segcorepb.Insert
 				ValidData: rawData.ValidData,
 			}
 		default:
-			return insertRecord, errors.New("unsupported data type when transter storage.InsertData to internalpb.InsertRecord")
+			return insertRecord, merr.WrapErrServiceInternalMsg("unsupported data type when transter storage.InsertData to internalpb.InsertRecord")
 		}
 
 		insertRecord.FieldsData = append(insertRecord.FieldsData, fieldData)

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -27,7 +27,6 @@ package storagev2
 import "C"
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -37,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -58,7 +58,7 @@ func getMetricsFromHandle(cFilesystem C.FileSystemHandle) (*FilesystemMetrics, e
 	metricsResult := C.loon_filesystem_get_metrics(cFilesystem, &cMetrics)
 	if err := HandleLoonFFIResult(metricsResult); err != nil {
 		C.loon_filesystem_destroy(cFilesystem)
-		return nil, fmt.Errorf("failed to get filesystem metrics: %w", err)
+		return nil, merr.Wrap(err, "failed to get filesystem metrics")
 	}
 
 	fsMetrics := &FilesystemMetrics{
@@ -201,7 +201,7 @@ func makePropertiesFromConfig(storageConfig *indexpb.StorageConfig) (C.LoonPrope
 	)
 
 	if err := HandleLoonFFIResult(result); err != nil {
-		return C.LoonProperties{}, fmt.Errorf("failed to create properties: %w", err)
+		return C.LoonProperties{}, merr.Wrap(err, "failed to create properties")
 	}
 
 	return props, nil
@@ -211,7 +211,7 @@ func makePropertiesFromConfig(storageConfig *indexpb.StorageConfig) (C.LoonPrope
 // using full storage config properties for proper cache resolution.
 func GetFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*FilesystemMetrics, error) {
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig is required")
+		return nil, merr.WrapErrStorageMsg("storageConfig is required")
 	}
 
 	props, err := makePropertiesFromConfig(storageConfig)
@@ -223,7 +223,7 @@ func GetFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*File
 	var cFilesystem C.FileSystemHandle
 	result := C.loon_filesystem_get(&props, nil, 0, &cFilesystem)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to get cached filesystem: %w", err)
+		return nil, merr.Wrap(err, "failed to get cached filesystem")
 	}
 
 	return getMetricsFromHandle(cFilesystem)
@@ -238,7 +238,7 @@ func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
 		if errMsg != nil {
 			errStr = C.GoString(errMsg)
 		}
-		return fmt.Errorf("loon FFI error: %s", errStr)
+		return merr.WrapErrStorageMsg("loon FFI error: %s", errStr)
 	}
 	return nil
 }

--- a/internal/storagev2/packed/explore_ffi.go
+++ b/internal/storagev2/packed/explore_ffi.go
@@ -26,7 +26,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"net/url"
 	"sort"
 	"strings"
@@ -36,6 +35,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // formatExtensions maps format names to their expected file extensions.
@@ -107,16 +107,16 @@ func GetFileInfo(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 	if err := injectExternalSpecProperties(cProperties, extfs.CollectionID, extfs.Source, extfs.Spec); err != nil {
-		return nil, fmt.Errorf("inject extfs: %w", err)
+		return nil, merr.Wrap(err, "inject extfs")
 	}
 
 	normalizedFilePath, err := normalizeExternalPathForStorage(filePath, cProperties, extfs)
 	if err != nil {
-		return nil, fmt.Errorf("normalize external file path: %w", err)
+		return nil, merr.WrapErrStorage(err, "normalize external file path")
 	}
 	cFilePath := C.CString(normalizedFilePath)
 	defer C.free(unsafe.Pointer(cFilePath))
@@ -125,7 +125,7 @@ func GetFileInfo(
 
 	result := C.loon_exttable_get_file_info(cFormat, cFilePath, cProperties, &numRows)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_exttable_get_file_info failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_exttable_get_file_info failed")
 	}
 
 	return &FileInfo{
@@ -225,16 +225,16 @@ func ExploreFilesReturnManifestPath(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to create properties: %w", err)
+		return nil, "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 	if err := injectExternalSpecProperties(cProperties, extfs.CollectionID, extfs.Source, extfs.Spec); err != nil {
-		return nil, "", fmt.Errorf("inject extfs: %w", err)
+		return nil, "", merr.Wrap(err, "inject extfs")
 	}
 
 	normalizedExploreDir, err := normalizeExternalPathForStorage(exploreDir, cProperties, extfs)
 	if err != nil {
-		return nil, "", fmt.Errorf("normalize external explore path: %w", err)
+		return nil, "", merr.WrapErrStorage(err, "normalize external explore path")
 	}
 	cExploreDir := C.CString(normalizedExploreDir)
 	defer C.free(unsafe.Pointer(cExploreDir))
@@ -253,10 +253,10 @@ func ExploreFilesReturnManifestPath(
 		&numFiles, &outColumnGroupsPath,
 	)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, "", fmt.Errorf("loon_exttable_explore failed: %w", err)
+		return nil, "", merr.WrapErrStorage(err, "loon_exttable_explore failed")
 	}
 	if outColumnGroupsPath == nil {
-		return nil, "", fmt.Errorf("loon_exttable_explore returned nil column groups path")
+		return nil, "", merr.WrapErrServiceInternalMsg("loon_exttable_explore returned nil column groups path")
 	}
 	manifestPath := C.GoString(outColumnGroupsPath)
 	C.loon_free_cstr(outColumnGroupsPath)
@@ -291,21 +291,21 @@ func ReadFileInfosFromManifestPath(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
 	var manifest *C.LoonManifest
 	result := C.loon_exttable_read_manifest(cManifestPath, cProperties, &manifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_exttable_read_manifest failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_exttable_read_manifest failed")
 	}
 	defer C.loon_manifest_destroy(manifest)
 
 	var fileInfos []FileInfo
 	cgroups := &manifest.column_groups
 	if cgroups.column_group_array == nil && cgroups.num_of_column_groups > 0 {
-		return nil, fmt.Errorf("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
+		return nil, merr.WrapErrServiceInternalMsg("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
 	}
 
 	cgArray := unsafe.Slice(cgroups.column_group_array, int(cgroups.num_of_column_groups))
@@ -317,7 +317,7 @@ func ReadFileInfosFromManifestPath(
 		fileArray := unsafe.Slice(cg.files, int(cg.num_of_files))
 		for j := range fileArray {
 			if fileArray[j].path == nil {
-				return nil, fmt.Errorf("file path is nil in column group %d, file %d", i, j)
+				return nil, merr.WrapErrServiceInternalMsg("file path is nil in column group %d, file %d", i, j)
 			}
 			fileInfos = append(fileInfos, FileInfo{
 				FilePath: C.GoString(fileArray[j].path),

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -21,6 +21,7 @@ import (
 
 	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // ErrLoonTransient marks any failure surfaced by the loon FFI layer. Today
@@ -91,7 +92,7 @@ func ExtfsPrefixForCollection(collectionID int64) string {
 // StorageConfig are mapped to corresponding key-value pairs in Properties.
 func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extraKVs map[string]string) (*C.LoonProperties, error) {
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig is required")
+		return nil, merr.WrapErrStorageMsg("storageConfig is required")
 	}
 
 	// Prepare key-value pairs from StorageConfig
@@ -243,7 +244,7 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 
 	err := HandleLoonFFIResult(result)
 	if err != nil {
-		return nil, err
+		return nil, merr.WrapErrStorage(err, "loon properties_create failed")
 	}
 	return properties, nil
 }
@@ -275,7 +276,7 @@ func injectExternalSpecProperties(properties *C.LoonProperties, collectionID int
 	externalSource, externalSpec string,
 ) error {
 	if properties == nil {
-		return fmt.Errorf("injectExternalSpecProperties: properties is nil")
+		return merr.WrapErrStorageMsg("injectExternalSpecProperties: properties is nil")
 	}
 	if externalSource == "" {
 		return nil
@@ -289,7 +290,10 @@ func injectExternalSpecProperties(properties *C.LoonProperties, collectionID int
 	}
 	result := C.loon_properties_inject_external_spec(
 		properties, C.int64_t(collectionID), cSource, cSpec)
-	return HandleLoonFFIResult(result)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return merr.WrapErrStorage(err, "loon inject_external_spec failed")
+	}
+	return nil
 }
 
 func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
@@ -301,7 +305,7 @@ func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
 			errStr = C.GoString(errMsg)
 		}
 
-		return errors.Wrapf(ErrLoonTransient, "FFI operation failed: %s", errStr)
+		return merr.Wrapf(ErrLoonTransient, "FFI operation failed: %s", errStr)
 	}
 	return nil
 }
@@ -342,14 +346,14 @@ func CompareManifestPath(a, b string) (int, error) {
 	bBase, bVer, bErr := UnmarshalManifestPath(b)
 
 	if aErr != nil {
-		return 0, fmt.Errorf("failed to parse manifest path %q: %w", a, aErr)
+		return 0, merr.WrapErrStorage(aErr, "failed to parse manifest path %q", a)
 	}
 	if bErr != nil {
-		return 0, fmt.Errorf("failed to parse manifest path %q: %w", b, bErr)
+		return 0, merr.WrapErrStorage(bErr, "failed to parse manifest path %q", b)
 	}
 
 	if aBase != bBase {
-		return 0, fmt.Errorf("manifest paths have different base paths: %q vs %q", aBase, bBase)
+		return 0, merr.WrapErrServiceInternalMsg("manifest paths have different base paths: %q vs %q", aBase, bBase)
 	}
 
 	switch {
@@ -382,7 +386,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return 0, fmt.Errorf("failed to make properties: %w", err)
+		return 0, merr.Wrap(err, "failed to make properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -393,7 +397,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 	var cTransactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.int32_t(0) /* resolve_id */, C.uint32_t(1) /* retry_limit */, &cTransactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return 0, fmt.Errorf("failed to begin transaction: %w", err)
+		return 0, merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(cTransactionHandle)
 
@@ -413,7 +417,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 		C.free(unsafe.Pointer(cPath))
 
 		if err := HandleLoonFFIResult(result); err != nil {
-			return 0, fmt.Errorf("failed to add LOB file %s: %w", lobFile.Path, err)
+			return 0, merr.WrapErrStorage(err, "failed to add LOB file %s", lobFile.Path)
 		}
 	}
 
@@ -421,7 +425,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 	var committedVersion C.int64_t
 	result = C.loon_transaction_commit(cTransactionHandle, &committedVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return 0, fmt.Errorf("failed to commit transaction: %w", err)
+		return 0, merr.WrapErrStorage(err, "failed to commit transaction")
 	}
 
 	return int64(committedVersion), nil
@@ -432,12 +436,12 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 func GetManifestLobFiles(manifestPath string, storageConfig *indexpb.StorageConfig) ([]LobFileInfo, error) {
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal manifest path: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to unmarshal manifest path")
 	}
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to make properties: %w", err)
+		return nil, merr.Wrap(err, "failed to make properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -448,7 +452,7 @@ func GetManifestLobFiles(manifestPath string, storageConfig *indexpb.StorageConf
 	var cTransactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.int32_t(0) /* resolve_id */, C.uint32_t(1) /* retry_limit */, &cTransactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(cTransactionHandle)
 
@@ -456,7 +460,7 @@ func GetManifestLobFiles(manifestPath string, storageConfig *indexpb.StorageConf
 	var cManifest *C.LoonManifest
 	result = C.loon_transaction_get_manifest(cTransactionHandle, &cManifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to get manifest: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cManifest)
 

--- a/internal/storagev2/packed/ffi_filesystem.go
+++ b/internal/storagev2/packed/ffi_filesystem.go
@@ -23,11 +23,11 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"strings"
 	"unsafe"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // WriteFile writes raw bytes to a file using milvus-storage filesystem FFI.
@@ -39,7 +39,7 @@ func WriteFile(
 ) error {
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create properties: %w", err)
+		return merr.WrapErrStorage(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -51,7 +51,7 @@ func WriteFile(
 	var fsHandle C.FileSystemHandle
 	result := C.loon_filesystem_get(cProperties, cPath, pathLen, &fsHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return fmt.Errorf("failed to get filesystem: %w", err)
+		return merr.WrapErrStorage(err, "failed to get filesystem")
 	}
 	defer C.loon_filesystem_destroy(fsHandle)
 
@@ -64,7 +64,7 @@ func WriteFile(
 			defer C.free(unsafe.Pointer(cDir))
 			result = C.loon_filesystem_create_dir(fsHandle, cDir, C.uint32_t(len(dir)), true)
 			if err := HandleLoonFFIResult(result); err != nil {
-				return fmt.Errorf("failed to create parent directory %q: %w", dir, err)
+				return merr.WrapErrStorage(err, "failed to create parent directory %q", dir)
 			}
 		}
 	}

--- a/internal/storagev2/packed/ffi_sample.go
+++ b/internal/storagev2/packed/ffi_sample.go
@@ -25,7 +25,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"runtime"
 	"unsafe"
 
@@ -33,6 +32,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // SampleExternalFieldSizes samples rows from an external segment via Take API
@@ -52,19 +52,19 @@ func SampleExternalFieldSizes(
 	storageConfig *indexpb.StorageConfig,
 ) (map[string]int64, error) {
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig is required for SampleExternalFieldSizes")
+		return nil, merr.WrapErrStorageMsg("storageConfig is required for SampleExternalFieldSizes")
 	}
 	if manifestPath == "" {
-		return nil, fmt.Errorf("manifest_path is empty for SampleExternalFieldSizes")
+		return nil, merr.WrapErrStorageMsg("manifest_path is empty for SampleExternalFieldSizes")
 	}
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 	if err := injectExternalSpecProperties(cProperties, collectionID, externalSource, externalSpec); err != nil {
-		return nil, fmt.Errorf("inject extfs: %w", err)
+		return nil, merr.Wrap(err, "inject extfs")
 	}
 
 	cManifestPath := C.CString(manifestPath)
@@ -75,7 +75,7 @@ func SampleExternalFieldSizes(
 	if schema != nil {
 		schemaBytes, err = proto.Marshal(schema)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal collection schema: %w", err)
+			return nil, merr.WrapErrStorage(err, "failed to marshal collection schema")
 		}
 		if len(schemaBytes) > 0 {
 			cSchema.proto_blob = unsafe.Pointer(&schemaBytes[0])

--- a/internal/storagev2/packed/ffi_stats.go
+++ b/internal/storagev2/packed/ffi_stats.go
@@ -23,10 +23,10 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"unsafe"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // ManifestStat represents a stat entry from the manifest.
@@ -104,7 +104,7 @@ func GetManifestStats(
 ) (map[string]ManifestStat, error) {
 	cManifest, err := GetManifestHandle(manifestPath, storageConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get manifest: %w", err)
+		return nil, merr.Wrap(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cManifest)
 

--- a/internal/storagev2/packed/manifest_ffi.go
+++ b/internal/storagev2/packed/manifest_ffi.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // Fragment represents a data fragment from an external data source.
@@ -55,20 +56,20 @@ func CreateManifestForSegment(
 	storageConfig *indexpb.StorageConfig,
 ) (string, error) {
 	if len(fragments) == 0 {
-		return "", fmt.Errorf("fragments cannot be empty")
+		return "", merr.WrapErrServiceInternalMsg("fragments cannot be empty")
 	}
 
 	// Create column groups from fragments
 	columnGroups, err := createColumnGroups(columns, format, fragments)
 	if err != nil {
-		return "", fmt.Errorf("failed to create column groups: %w", err)
+		return "", merr.Wrap(err, "failed to create column groups")
 	}
 	defer C.loon_column_groups_destroy(columnGroups)
 
 	// Create properties from storage config
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create properties: %w", err)
+		return "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -80,21 +81,21 @@ func CreateManifestForSegment(
 	var transactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(0), C.LOON_TRANSACTION_RESOLVE_OVERWRITE /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("loon_transaction_begin failed: %w", err)
+		return "", merr.WrapErrStorage(err, "loon_transaction_begin failed")
 	}
 	defer C.loon_transaction_destroy(transactionHandle)
 
 	// Append files to transaction
 	result = C.loon_transaction_append_files(transactionHandle, columnGroups)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("loon_transaction_append_files failed: %w", err)
+		return "", merr.WrapErrStorage(err, "loon_transaction_append_files failed")
 	}
 
 	// Commit transaction
 	var committedVersion C.int64_t
 	result = C.loon_transaction_commit(transactionHandle, &committedVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("loon_transaction_commit failed: %w", err)
+		return "", merr.WrapErrStorage(err, "loon_transaction_commit failed")
 	}
 
 	// Return manifest path using the helper function
@@ -168,7 +169,7 @@ func createColumnGroups(
 	)
 
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_column_groups_create failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_column_groups_create failed")
 	}
 
 	return outColumnGroups, nil
@@ -186,7 +187,7 @@ func ReadFragmentsFromManifest(
 	// 1. Parse manifest path to get base path and version
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse manifest path: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	// 2. Construct full manifest file path: base_path/_metadata/manifest-{version}.avro
@@ -196,7 +197,7 @@ func ReadFragmentsFromManifest(
 	// 3. Create properties from storage config
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -208,7 +209,7 @@ func ReadFragmentsFromManifest(
 	var manifest *C.LoonManifest
 	result := C.loon_exttable_read_manifest(cManifestFilePath, cProperties, &manifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_exttable_read_manifest failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_exttable_read_manifest failed")
 	}
 
 	// 5. Destroy manifest when done
@@ -222,7 +223,7 @@ func ReadFragmentsFromManifest(
 
 	// Validate column groups structure before accessing
 	if cgroups.column_group_array == nil && cgroups.num_of_column_groups > 0 {
-		return nil, fmt.Errorf("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
+		return nil, merr.WrapErrServiceInternalMsg("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
 	}
 
 	cgArray := unsafe.Slice(cgroups.column_group_array, int(cgroups.num_of_column_groups))

--- a/internal/storagev2/packed/packed_reader.go
+++ b/internal/storagev2/packed/packed_reader.go
@@ -25,7 +25,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"io"
 	"unsafe"
 
@@ -34,6 +33,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func NewPackedReader(filePaths []string, schema *arrow.Schema, bufferSize int64, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*PackedReader, error) {
@@ -143,7 +143,7 @@ func (pr *PackedReader) ReadNext() (arrow.Record, error) {
 	}()
 	recordBatch, err := cdata.ImportCRecordBatch(goCArr, goCSchema)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert ArrowArray to Record: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to convert ArrowArray to Record")
 	}
 	pr.currentBatch = recordBatch
 

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -25,24 +25,23 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"io"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/cdata"
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns []string, bufferSize int64, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*FFIPackedReader, error) {
 	cLoonManifest, err := GetManifestHandle(manifestPath, storageConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get manifest")
+		return nil, merr.Wrap(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cLoonManifest)
 
@@ -112,7 +111,7 @@ func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns
 
 		status = C.NewPackedFFIReaderWithManifest(cLoonManifest, cSchema, cNeededColumnArray, cNumColumns, &cPackedReader, cStorageConfig, pluginContextPtr)
 	} else {
-		return nil, fmt.Errorf("storageConfig is required")
+		return nil, merr.WrapErrServiceInternalMsg("storageConfig is required")
 	}
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		return nil, err
@@ -123,14 +122,14 @@ func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns
 	status = C.GetFFIReaderStream(cPackedReader, C.int64_t(8196), (*C.struct_ArrowArrayStream)(unsafe.Pointer(&cStream)))
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		C.CloseFFIReader(cPackedReader)
-		return nil, fmt.Errorf("failed to get reader stream: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to get reader stream")
 	}
 
 	// Import the stream as a RecordReader
 	recordReader, err := cdata.ImportCRecordReader(&cStream, schema)
 	if err != nil {
 		C.CloseFFIReader(cPackedReader)
-		return nil, fmt.Errorf("failed to import record reader: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to import record reader")
 	}
 
 	return &FFIPackedReader{
@@ -151,7 +150,7 @@ func (r *FFIPackedReader) ReadNext() (rec arrow.Record, err error) {
 		if err == io.EOF {
 			return nil, io.EOF
 		}
-		return nil, fmt.Errorf("failed to read next record: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to read next record")
 	}
 
 	return rec, nil

--- a/internal/storagev2/packed/packed_writer.go
+++ b/internal/storagev2/packed/packed_writer.go
@@ -30,11 +30,11 @@ import (
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/cdata"
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64, multiPartUploadSize int64, columnGroups []storagecommon.ColumnGroup, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*PackedWriter, error) {
@@ -59,7 +59,7 @@ func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64,
 	for _, group := range columnGroups {
 		cGroup := C.malloc(C.size_t(len(group.Columns)) * C.size_t(unsafe.Sizeof(C.int(0))))
 		if cGroup == nil {
-			return nil, errors.New("failed to allocate memory for column groups")
+			return nil, merr.WrapErrServiceInternalMsg("failed to allocate memory for column groups")
 		}
 		cGroupSlice := (*[1 << 30]C.int)(cGroup)[:len(group.Columns):len(group.Columns)]
 		for i, val := range group.Columns {
@@ -135,7 +135,7 @@ func (pw *PackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
 		return nil
 	}
 	if pw.cPackedWriter == nil {
-		return errors.New("packed writer is closed")
+		return merr.WrapErrStorageMsg("packed writer is closed")
 	}
 
 	cArrays := make([]CArrowArray, recordBatch.NumCols())
@@ -176,13 +176,13 @@ func (pw *PackedWriter) Close() error {
 
 func (pw *PackedWriter) CloseAndTell(numGroups int) ([]int64, error) {
 	if numGroups <= 0 {
-		return nil, errors.New("numGroups must be greater than 0")
+		return nil, merr.WrapErrServiceInternalMsg("numGroups must be greater than 0")
 	}
 	if pw.cPackedWriter == nil {
 		if len(pw.closedSizes) == numGroups {
 			return append([]int64(nil), pw.closedSizes...), nil
 		}
-		return nil, errors.New("packed writer is closed")
+		return nil, merr.WrapErrStorageMsg("packed writer is closed")
 	}
 
 	sizes := make([]int64, numGroups)

--- a/internal/storagev2/packed/segment_writer_ffi.go
+++ b/internal/storagev2/packed/segment_writer_ffi.go
@@ -25,13 +25,13 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/cdata"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // TextColumnConfig represents configuration for a TEXT column.
@@ -73,7 +73,7 @@ func NewFFISegmentWriter(
 	defer cdata.ReleaseCArrowSchema(&cas)
 
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig must not be nil")
+		return nil, merr.WrapErrStorageMsg("storageConfig must not be nil")
 	}
 
 	// create properties
@@ -158,14 +158,14 @@ func (f *SegmentOutput) applyTo(handle C.LoonTransactionHandle) error {
 	}
 	if f.cOutput.column_groups != nil {
 		if err := HandleLoonFFIResult(C.loon_transaction_append_files(handle, f.cOutput.column_groups)); err != nil {
-			return fmt.Errorf("commit manifest append_files (segment): %w", err)
+			return merr.Wrap(err, "commit manifest append_files (segment)")
 		}
 	}
 	if f.cOutput.num_lob_files > 0 && f.cOutput.lob_files != nil {
 		lob := unsafe.Slice(f.cOutput.lob_files, f.cOutput.num_lob_files)
 		for i := range lob {
 			if err := HandleLoonFFIResult(C.loon_transaction_add_lob_file(handle, &lob[i])); err != nil {
-				return fmt.Errorf("commit manifest add_lob_file: %w", err)
+				return merr.Wrap(err, "commit manifest add_lob_file")
 			}
 		}
 	}
@@ -183,7 +183,7 @@ func (f *SegmentOutput) applyTo(handle C.LoonTransactionHandle) error {
 // further Close or Write calls fail.
 func (w *FFISegmentWriter) Close() (WriterOutput, error) {
 	if w.closed {
-		return nil, fmt.Errorf("FFISegmentWriter already closed")
+		return nil, merr.WrapErrServiceInternal("FFISegmentWriter already closed")
 	}
 	w.closed = true
 	defer func() {

--- a/internal/storagev2/packed/stats_resolver.go
+++ b/internal/storagev2/packed/stats_resolver.go
@@ -23,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // compoundStatsLogIdx is the log index that identifies compound stats format.
@@ -364,7 +365,7 @@ func (r *StatsResolver) loadManifest() error {
 
 	stats, err := GetManifestStats(r.manifestPath, r.storageConfig)
 	if err != nil {
-		r.manifestErr = fmt.Errorf("failed to get manifest stats: %w", err)
+		r.manifestErr = merr.Wrap(err, "failed to get manifest stats")
 		return r.manifestErr
 	}
 	r.manifestStats = stats

--- a/internal/storagev2/packed/transaction.go
+++ b/internal/storagev2/packed/transaction.go
@@ -23,7 +23,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"math"
 	"unsafe"
 
@@ -31,6 +30,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -91,7 +91,7 @@ func addDeltaLogsToManifest(
 
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse manifest path: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	log.Debug("AddDeltaLogsToManifest",
@@ -101,7 +101,7 @@ func addDeltaLogsToManifest(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create properties: %w", err)
+		return "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -112,7 +112,7 @@ func addDeltaLogsToManifest(
 	var transactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), resolveID /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to begin transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(transactionHandle)
 
@@ -124,7 +124,7 @@ func addDeltaLogsToManifest(
 		C.free(unsafe.Pointer(cPath))
 
 		if err := HandleLoonFFIResult(result); err != nil {
-			return "", fmt.Errorf("failed to add delta log %s: %w", deltaLog.Path, err)
+			return "", merr.WrapErrStorage(err, "failed to add delta log %s", deltaLog.Path)
 		}
 
 		log.Debug("Added delta log to transaction",
@@ -136,7 +136,7 @@ func addDeltaLogsToManifest(
 	var commitVersion C.int64_t
 	result = C.loon_transaction_commit(transactionHandle, &commitVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to commit transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to commit transaction")
 	}
 
 	newManifestPath := MarshalManifestPath(basePath, int64(commitVersion))
@@ -154,12 +154,12 @@ func GetDeltaLogPathsFromManifest(
 ) ([]string, error) {
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse manifest path: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -169,14 +169,14 @@ func GetDeltaLogPathsFromManifest(
 	var cTransactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.int32_t(0) /* resolve_id */, C.uint32_t(1) /* retry_limit */, &cTransactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(cTransactionHandle)
 
 	var cManifest *C.LoonManifest
 	result = C.loon_transaction_get_manifest(cTransactionHandle, &cManifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to get manifest: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cManifest)
 
@@ -221,7 +221,7 @@ func AddStatsToManifest(
 
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse manifest path: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	log.Debug("AddStatsToManifest",
@@ -231,7 +231,7 @@ func AddStatsToManifest(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create properties: %w", err)
+		return "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -241,14 +241,14 @@ func AddStatsToManifest(
 	var transactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.LOON_TRANSACTION_RESOLVE_OVERWRITE /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to begin transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(transactionHandle)
 
 	// The C++ loon library converts absolute paths to relative at commit time
 	for _, stat := range stats {
 		if err := UpdateTransactionStat(transactionHandle, stat.Key, stat.Files, stat.Metadata); err != nil {
-			return "", fmt.Errorf("failed to update stat %s: %w", stat.Key, err)
+			return "", merr.WrapErrStorage(err, "failed to update stat %s", stat.Key)
 		}
 		log.Debug("Added stat to transaction",
 			zap.String("key", stat.Key),
@@ -258,7 +258,7 @@ func AddStatsToManifest(
 	var commitVersion C.int64_t
 	result = C.loon_transaction_commit(transactionHandle, &commitVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to commit transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to commit transaction")
 	}
 
 	newManifestPath := MarshalManifestPath(basePath, int64(commitVersion))

--- a/internal/storagev2/packed/utils.go
+++ b/internal/storagev2/packed/utils.go
@@ -16,7 +16,6 @@ package packed
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -26,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 const (
@@ -147,7 +147,7 @@ func fetchRowCountsConcurrently(
 		futures[k] = pool.Submit(func() (struct{}, error) {
 			fetchedInfo, err := GetFileInfo(format, fileInfos[idx].FilePath, storageConfig, extfs)
 			if err != nil {
-				return struct{}{}, fmt.Errorf("failed to get file info for %s: %w", fileInfos[idx].FilePath, err)
+				return struct{}{}, merr.Wrapf(err, "failed to get file info for %s", fileInfos[idx].FilePath)
 			}
 			// Distinct indexes across workers -> no race on rowCounts.
 			rowCounts[idx] = fetchedInfo.NumRows
@@ -184,7 +184,7 @@ func FetchFragmentsFromExternalSourceWithRange(
 	log := log.Ctx(ctx)
 
 	if exploreManifestPath == "" {
-		return nil, fmt.Errorf("explore manifest path is required")
+		return nil, merr.WrapErrServiceInternalMsg("explore manifest path is required")
 	}
 
 	extfs := ExternalSpecContext{
@@ -196,7 +196,7 @@ func FetchFragmentsFromExternalSourceWithRange(
 	exploreStart := time.Now()
 	fileInfos, err := ReadFileInfosFromManifestPath(exploreManifestPath, storageConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read explore manifest: %w", err)
+		return nil, merr.Wrap(err, "failed to read explore manifest")
 	}
 	rawCount := len(fileInfos)
 	// Apply the same sort+format-filter that DataCoord used to derive
@@ -220,11 +220,11 @@ func FetchFragmentsFromExternalSourceWithRange(
 		fileIndexEnd = int64(len(fileInfos))
 	}
 	if fileIndexBegin >= int64(len(fileInfos)) {
-		return nil, fmt.Errorf("fileIndexBegin %d >= total files %d", fileIndexBegin, len(fileInfos))
+		return nil, merr.WrapErrServiceInternalMsg("fileIndexBegin %d >= total files %d", fileIndexBegin, len(fileInfos))
 	}
 	fileInfos = fileInfos[fileIndexBegin:fileIndexEnd]
 	if len(fileInfos) == 0 {
-		return nil, fmt.Errorf("no files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
+		return nil, merr.WrapErrServiceInternalMsg("no files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
 	}
 
 	getFileInfoStart := time.Now()
@@ -243,7 +243,7 @@ func FetchFragmentsFromExternalSourceWithRange(
 		fragments = append(fragments, SplitFileToFragments(fi.FilePath, rowCounts[i], rowLimit, fragmentIDGenerator)...)
 	}
 	if len(fragments) == 0 {
-		return nil, fmt.Errorf("no data files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
+		return nil, merr.WrapErrServiceInternalMsg("no data files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
 	}
 
 	log.Info("Created fragments from file range",
@@ -268,8 +268,7 @@ func BuildCurrentSegmentFragments(
 		if seg.GetManifestPath() != "" && storageConfig != nil {
 			fragments, err := ReadFragmentsFromManifest(seg.GetManifestPath(), storageConfig)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read manifest for segment %d at %s: %w",
-					seg.GetID(), seg.GetManifestPath(), err)
+				return nil, merr.Wrapf(err, "failed to read manifest for segment %d at %s", seg.GetID(), seg.GetManifestPath())
 			}
 			if len(fragments) > 0 {
 				result[seg.GetID()] = fragments

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -223,7 +223,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 			}
 			logger.Info("append flush message for segments that not created by streaming service into wal", zap.Stringer("msgID", appendResult.MessageID), zap.Uint64("timeTick", appendResult.TimeTick))
 			return nil
-		}, retry.AttemptAlways()); err != nil {
+		}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true })); err != nil {
 			return nil, err
 		}
 	}
@@ -233,7 +233,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 		var err error
 		ds, err = impl.buildDataSyncService(ctx, recoverInfo)
 		return err
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
@@ -101,7 +101,7 @@ func (impl *msgHandlerImpl) createNewGrowingSegment(ctx context.Context, vchanne
 		}
 		logger.Info("alloc growing segment at datacoord", zap.Int32("schemaVersion", h.SchemaVersion))
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 }
 
 func (impl *msgHandlerImpl) HandleFlush(flushMsg message.ImmutableFlushMessageV2) error {

--- a/internal/streamingnode/server/flusher/flusherimpl/util.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/util.go
@@ -90,7 +90,7 @@ func (impl *WALFlusherImpl) getRecoveryInfo(ctx context.Context, vchannel string
 			return retry.Unrecoverable(errChannelLifetimeUnrecoverable)
 		}
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	return resp, err
 }
 

--- a/pkg/util/etcd/etcd_util_test.go
+++ b/pkg/util/etcd/etcd_util_test.go
@@ -18,15 +18,51 @@ package etcd
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"os"
 	"path"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// freePort grabs a random unused TCP port. There's a small TOCTOU window
+// between Close and the subsequent bind, but for unit tests it's acceptable.
+func freePort(t *testing.T) int {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
 func TestEtcd(t *testing.T) {
-	err := InitEtcdServer(true, "", "/tmp/data", "stdout", "info")
+	// Use random free ports so the embedded etcd does not collide with any
+	// already-running etcd on the dev machine (e.g. docker-compose etcd
+	// holding 2379/2380).
+	clientPort, peerPort := freePort(t), freePort(t)
+	dataDir, err := os.MkdirTemp("", "test-etcd-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dataDir)
+	cfgFile, err := os.CreateTemp("", "test-etcd-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(cfgFile.Name())
+	_, err = fmt.Fprintf(cfgFile, `name: default
+data-dir: %s
+listen-client-urls: http://127.0.0.1:%d
+advertise-client-urls: http://127.0.0.1:%d
+listen-peer-urls: http://127.0.0.1:%d
+initial-advertise-peer-urls: http://127.0.0.1:%d
+initial-cluster: default=http://127.0.0.1:%d
+initial-cluster-state: new
+`, dataDir, clientPort, clientPort, peerPort, peerPort, peerPort)
+	require.NoError(t, err)
+	require.NoError(t, cfgFile.Close())
+
+	err = InitEtcdServer(true, cfgFile.Name(), dataDir, "stdout", "info")
 	assert.NoError(t, err)
 	defer StopEtcdServer()
 

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -18,6 +18,7 @@ package merr
 
 import (
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/markers"
 	"github.com/samber/lo"
 )
 
@@ -36,6 +37,11 @@ const (
 var ErrorTypeName = map[ErrorType]string{
 	SystemError: "system_error",
 	InputError:  "input_error",
+}
+
+// ErrorClassifier defines the method to get the broad classification of a Milvus error.
+type ErrorClassifier interface {
+	GetErrorType() ErrorType
 }
 
 func (err ErrorType) String() string {
@@ -60,20 +66,23 @@ var (
 	ErrServiceUnimplemented        = newMilvusError("service unimplemented", 10, false)
 	ErrServiceTimeTickLongDelay    = newMilvusError("time tick long delay", 11, false)
 	ErrServiceResourceInsufficient = newMilvusError("service resource insufficient", 12, true)
+	ErrOldSessionExists            = newMilvusError("old session exists", 13, false)
+	ErrOperationNotSupported       = newMilvusError("unsupported operation", 14, false)
 
 	// Collection related
-	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false)
+	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false, WithErrorType(InputError))
 	ErrCollectionNotLoaded                     = newMilvusError("collection not loaded", 101, false)
-	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false)
+	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false, WithErrorType(InputError))
 	ErrCollectionNotFullyLoaded                = newMilvusError("collection not fully loaded", 103, true)
-	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false)
-	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false)
+	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false, WithErrorType(InputError))
+	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false, WithErrorType(InputError))
 	ErrCollectionOnRecovering                  = newMilvusError("collection on recovering", 106, true)
-	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false)
+	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false, WithErrorType(InputError))
 	// Deprecated, keep it only for reserving the error code
-	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false)
-	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false)
+	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false, WithErrorType(InputError))
+	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false, WithErrorType(InputError))
 	ErrCollectionSchemaVersionNotReady = newMilvusError("collection schema version not ready", 110, true)
+
 	// Partition related
 	ErrPartitionNotFound       = newMilvusError("partition not found", 200, false)
 	ErrPartitionNotLoaded      = newMilvusError("partition not loaded", 201, false)
@@ -83,13 +92,13 @@ var (
 	ErrGeneralCapacityExceeded = newMilvusError("general capacity exceeded", 250, false)
 
 	// ResourceGroup related
-	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false)
-	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false)
-	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false)
-	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false)
+	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false, WithErrorType(InputError))
+	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false, WithErrorType(InputError))
+	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false, WithErrorType(InputError))
+	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false, WithErrorType(InputError))
 	// go:deprecated
-	ErrResourceGroupNodeNotEnough    = newMilvusError("resource group node not enough", 304, false)
-	ErrResourceGroupServiceAvailable = newMilvusError("resource group service available", 305, true)
+	ErrResourceGroupNodeNotEnough      = newMilvusError("resource group node not enough", 304, false)
+	ErrResourceGroupServiceUnAvailable = newMilvusError("resource group service unavailable", 305, true)
 
 	// Replica related
 	ErrReplicaNotFound     = newMilvusError("replica not found", 400, false)
@@ -118,13 +127,13 @@ var (
 	// Index related
 	ErrIndexNotFound     = newMilvusError("index not found", 700, false)
 	ErrIndexNotSupported = newMilvusError("index type not supported", 701, false)
-	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false)
+	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false, WithErrorType(InputError))
 	ErrTaskDuplicate     = newMilvusError("task duplicates", 703, false)
 
 	// Database related
-	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false)
-	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false)
-	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false)
+	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false, WithErrorType(InputError))
+	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false, WithErrorType(InputError))
+	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false, WithErrorType(InputError))
 
 	// Node related
 	ErrNodeNotFound        = newMilvusError("node not found", 901, false)
@@ -167,7 +176,7 @@ var (
 
 	// Privilege related
 	// this operation is denied because the user not authorized, user need to login in first
-	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false)
+	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false, WithErrorType(InputError))
 	// this operation is denied because the user has no permission to do this, user need higher privilege
 	ErrPrivilegeNotPermitted     = newMilvusError("privilege not permitted", 1401, false)
 	ErrPrivilegeGroupInvalidName = newMilvusError("invalid privilege group name", 1402, false)
@@ -213,7 +222,7 @@ var (
 	errUnexpected = newMilvusError("unexpected error", (1<<16)-1, false)
 
 	// import
-	ErrImportFailed = newMilvusError("importing data failed", 2100, false)
+	ErrImportFailed = newMilvusError("importing data failed", 2100, false, WithErrorType(InputError))
 
 	// Search/Query related
 	ErrInconsistentRequery = newMilvusError("inconsistent requery result", 2200, true)
@@ -251,11 +260,6 @@ var (
 	// Snapshot related
 	ErrSnapshotNotFound = newMilvusError("snapshot not found", 2600, false)
 	ErrSnapshotPinned   = newMilvusError("snapshot is pinned", 2601, false)
-
-	// General
-	ErrOperationNotSupported = newMilvusError("unsupported operation", 3000, false)
-
-	ErrOldSessionExists = newMilvusError("old session exists", 3001, false)
 )
 
 type errorOption func(*milvusError)
@@ -314,6 +318,53 @@ func (e milvusError) Is(err error) bool {
 	return false
 }
 
+// GetErrorType implements the ErrorClassifier interface.
+// It returns the predefined classification of the error (SystemError or InputError).
+func (e milvusError) GetErrorType() ErrorType {
+	return e.errType
+}
+
+// wrappedMilvusError wraps an underlying error with a milvus sentinel and a
+// contextual message, while preserving the inner error chain. Designed so
+// all of the following work on the result, under both stdlib and cockroachdb
+// errors.Is semantics:
+//
+//   - errors.Is(result, sentinel)      → true   (matched via Is)
+//   - errors.Is(result, originalInner) → true   (inner reachable via Unwrap)
+//   - merr.Code(result)                → sentinel's errCode
+//
+// Cause is intentionally NOT overridden: cockroachdb's errors.Is walks the
+// Cause chain first, so returning the sentinel from Cause would hide the
+// inner error. Instead, merr.Code special-cases this type.
+type wrappedMilvusError struct {
+	msg      string
+	inner    error
+	sentinel milvusError
+}
+
+func (w *wrappedMilvusError) Error() string { return w.msg + ": " + w.inner.Error() }
+
+// Unwrap exposes the original error so errors.Is(w, originalInner) works
+// under both stdlib and cockroachdb chain walkers.
+func (w *wrappedMilvusError) Unwrap() error { return w.inner }
+
+// Is matches any milvus sentinel by delegating to the wrapped sentinel.
+func (w *wrappedMilvusError) Is(target error) bool {
+	return errors.Is(w.sentinel, target)
+}
+
+// code lets merr.Code retrieve the milvus error code without needing to
+// resolve the cause chain (which has been redirected to the inner error).
+func (w *wrappedMilvusError) code() int32 {
+	return w.sentinel.errCode
+}
+
+// GetErrorType lets ErrorClassifier consumers (proxy metrics, retry policy)
+// see the same classification as the sentinel.
+func (w *wrappedMilvusError) GetErrorType() ErrorType {
+	return w.sentinel.errType
+}
+
 type multiErrors struct {
 	errs []error
 }
@@ -358,4 +409,16 @@ func Combine(errs ...error) error {
 	return multiErrors{
 		errs,
 	}
+}
+
+func Wrap(err error, msg string) error {
+	return errors.Wrap(err, msg)
+}
+
+func Wrapf(err error, format string, args ...interface{}) error {
+	return errors.Wrapf(err, format, args...)
+}
+
+func Mark(err error, reference error) error {
+	return markers.Mark(err, reference)
 }

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -149,6 +149,27 @@ var (
 	ErrIoUnexpectEOF     = newMilvusError("unexpected EOF", 1002, true)
 	ErrIoTooManyRequests = newMilvusError("too many requests", 1003, true)
 
+	// Serialization / deserialization step failed — a transformation pipeline
+	// (proto Marshal/Unmarshal, json encode/decode, arrow schema conversion etc.)
+	// could not complete. Use for "conversion process failed" semantics rather
+	// than "stored bytes are corrupt" — for the latter use ErrDataIntegrity.
+	ErrSerializationFailed = newMilvusError("data serialization or deserialization failed", 1004, false)
+
+	// Data integrity check failed — bytes already on disk (binlog payload,
+	// event header extras, stats buffer) don't match the layout we expect from
+	// the schema (type mismatch, valuesRead vs rows mismatch, unknown column
+	// type, malformed event header). Likely permanent corruption; retry won't
+	// help. Distinct from ErrSerializationFailed (process step failed) and
+	// ErrParameterInvalid (caller-input we control).
+	ErrDataIntegrity = newMilvusError("data integrity check failed", 1009, false)
+
+	// Storage subsystem fallback — used for non-IO / non-serde / non-client-input
+	// failures inside the storage package (transaction state machine, writer/reader
+	// lifecycle, FFI internal failures, ext-table metadata operations).
+	// Prefer ErrIo*/ErrSerializationFailed/ErrDataIntegrity/ErrParameterInvalid
+	// when they fit; reach for ErrStorage only when none of those describe the failure.
+	ErrStorage = newMilvusError("storage internal error", 1008, false, WithErrorType(SystemError))
+
 	// Permanent errors - resource doesn't exist or access denied
 	ErrIoPermissionDenied   = newMilvusError("permission denied", 1005, false)
 	ErrIoBucketNotFound     = newMilvusError("bucket not found", 1006, false)
@@ -160,7 +181,7 @@ var (
 	ErrIoEntityTooLarge  = newMilvusError("entity too large", 1012, false)
 
 	// Parameter related
-	ErrParameterInvalid  = newMilvusError("invalid parameter", 1100, false)
+	ErrParameterInvalid  = newMilvusError("invalid parameter", 1100, false, WithErrorType(InputError))
 	ErrParameterMissing  = newMilvusError("missing parameter", 1101, false)
 	ErrParameterTooLarge = newMilvusError("parameter too large", 1102, false)
 

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 type ErrSuite struct {
@@ -34,7 +33,6 @@ type ErrSuite struct {
 }
 
 func (s *ErrSuite) SetupSuite() {
-	paramtable.Init()
 }
 
 func (s *ErrSuite) TestCode() {
@@ -104,7 +102,7 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrResourceGroupReachLimit("test_ResourceGroup", 1, "failed to get ResourceGroup"), ErrResourceGroupReachLimit)
 	s.ErrorIs(WrapErrResourceGroupIllegalConfig("test_ResourceGroup", nil, "failed to get ResourceGroup"), ErrResourceGroupIllegalConfig)
 	s.ErrorIs(WrapErrResourceGroupNodeNotEnough("test_ResourceGroup", 1, 2, "failed to get ResourceGroup"), ErrResourceGroupNodeNotEnough)
-	s.ErrorIs(WrapErrResourceGroupServiceAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceAvailable)
+	s.ErrorIs(WrapErrResourceGroupServiceUnAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceUnAvailable)
 
 	// Replica related
 	s.ErrorIs(WrapErrReplicaNotFound(1, "failed to get replica"), ErrReplicaNotFound)
@@ -224,7 +222,7 @@ func (s *ErrSuite) TestIsHealthy() {
 	}
 	for _, tc := range cases {
 		s.Run(tc.code.String(), func() {
-			s.Equal(tc.expect, IsHealthy(tc.code) == nil)
+			s.Equal(tc.expect, CheckHealthy(tc.code) == nil)
 		})
 	}
 }
@@ -274,4 +272,75 @@ func TestNewIOErrors(t *testing.T) {
 
 func TestErrors(t *testing.T) {
 	suite.Run(t, new(ErrSuite))
+}
+
+// TestWrapErrPreservesInnerChain locks in the contract that WrapErr*Err helpers
+// keep the inner error chain reachable via errors.Is while still attributing
+// the milvus sentinel for code lookup. Regression guard against the previous
+// implementation that string-flattened the inner error and lost its identity.
+func TestWrapErrPreservesInnerChain(t *testing.T) {
+	inner := errors.New("inner-error")
+
+	for _, tc := range []struct {
+		name     string
+		wrap     func() error
+		sentinel error
+		other    error
+		code     int32
+	}{
+		{
+			name:     "ServiceInternal",
+			wrap:     func() error { return WrapErrServiceInternalErr(inner, "ctx %s", "test") },
+			sentinel: ErrServiceInternal,
+			other:    ErrParameterInvalid,
+			code:     ErrServiceInternal.errCode,
+		},
+		{
+			name:     "ParameterInvalid",
+			wrap:     func() error { return WrapErrParameterInvalidErr(inner, "ctx %d", 42) },
+			sentinel: ErrParameterInvalid,
+			other:    ErrServiceInternal,
+			code:     ErrParameterInvalid.errCode,
+		},
+		{
+			name:     "MqInternal",
+			wrap:     func() error { return WrapErrMqInternal(inner, "step1", "step2") },
+			sentinel: ErrMqInternal,
+			other:    ErrServiceInternal,
+			code:     ErrMqInternal.errCode,
+		},
+		{
+			name:     "BuildCompactionRequestFail",
+			wrap:     func() error { return WrapErrBuildCompactionRequestFail(inner) },
+			sentinel: ErrBuildCompactionRequestFail,
+			other:    ErrServiceInternal,
+			code:     ErrBuildCompactionRequestFail.errCode,
+		},
+		{
+			name:     "GetCompactionPlanResultFail",
+			wrap:     func() error { return WrapErrGetCompactionPlanResultFail(inner) },
+			sentinel: ErrGetCompactionPlanResultFail,
+			other:    ErrServiceInternal,
+			code:     ErrGetCompactionPlanResultFail.errCode,
+		},
+		{
+			name:     "OperationNotSupported",
+			wrap:     func() error { return WrapErrOperationNotSupported(inner, "op %s", "drop") },
+			sentinel: ErrOperationNotSupported,
+			other:    ErrServiceInternal,
+			code:     ErrOperationNotSupported.errCode,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := tc.wrap()
+			assert.True(t, errors.Is(w, tc.sentinel), "must match its sentinel")
+			assert.True(t, errors.Is(w, inner), "must preserve inner chain")
+			assert.False(t, errors.Is(w, tc.other), "must not match unrelated sentinel")
+			assert.Equal(t, tc.code, Code(w), "Code() must report sentinel's code")
+			assert.Contains(t, w.Error(), inner.Error(), "message must include inner")
+		})
+	}
+
+	// nil err falls back to the Msg variant; just make sure that still works.
+	assert.True(t, errors.Is(WrapErrServiceInternalErr(nil, "no underlying err"), ErrServiceInternal))
 }

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -60,15 +60,9 @@ func Code(err error) int32 {
 }
 
 func IsRetryableErr(err error) bool {
-<<<<<<< HEAD
 	var milvusErr milvusError
 	if errors.As(err, &milvusErr) {
 		return milvusErr.retriable
-=======
-	var me milvusError
-	if errors.As(err, &me) {
-		return me.retriable
->>>>>>> 3a31bdeec4 (enhance: foundational merr framework and retry mechanisms)
 	}
 
 	return false
@@ -990,6 +984,87 @@ func WrapErrNodeNotMatch(expectedNodeID, actualNodeID int64, msg ...string) erro
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+// WrapErrSerializationFailedMsg creates a new ErrSerializationFailed (code 1004)
+// with a detail message. Used when stored bytes cannot be decoded into the
+// expected shape and there is no underlying error to wrap (e.g. valuesRead vs
+// rows mismatch in payload reader, type mismatch when reading a column from
+// the wrong DataType).
+func WrapErrSerializationFailedMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	return errors.Wrap(ErrSerializationFailed, detail)
+}
+
+// WrapErrSerializationFailed wraps an existing underlying error 'err' with
+// ErrSerializationFailed (code 1004). Used when a decode / unmarshal /
+// schema-conversion step fails with a non-typed inner error (json, proto,
+// arrow). If 'err' is already a typed merr, use merr.Wrap(err, msg) instead.
+func WrapErrSerializationFailed(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrSerializationFailedMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrSerializationFailed,
+	}
+}
+
+// WrapErrDataIntegrityMsg creates a new ErrDataIntegrity (code 1009) with a
+// detail message. Use when on-disk bytes don't conform to the expected schema
+// (binlog type mismatch, valuesRead vs rows mismatch, malformed event header,
+// unparseable stats buffer) — i.e. the stored data itself is corrupt, not the
+// (de)serialization step.
+func WrapErrDataIntegrityMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	return errors.Wrap(ErrDataIntegrity, detail)
+}
+
+// WrapErrDataIntegrity wraps an existing underlying error with ErrDataIntegrity
+// (code 1009). Use when stored-byte parsing surfaces a non-typed inner error
+// (json unmarshal of stats buffer, type assertion of decoded header extras).
+// If 'err' is already a typed merr, use merr.Wrap(err, msg) instead.
+func WrapErrDataIntegrity(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrDataIntegrityMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrDataIntegrity,
+	}
+}
+
+// WrapErrStorageMsg creates a new ErrStorage (code 1008) with a detail message.
+// Used when a logical internal error occurs in the storage layer (e.g. invalid
+// state, corrupted data structure check, nil data) and there is no underlying
+// Go error to wrap.
+func WrapErrStorageMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	return errors.Wrap(ErrStorage, detail)
+}
+
+// WrapErrStorage wraps an existing underlying error 'err' with ErrStorage
+// (code 1008). Used for storage subsystem failures (transaction state machine,
+// writer/reader lifecycle, FFI internal failures) that are not physical I/O,
+// not serialization, and not client-input errors.
+//
+// IMPORTANT: only use when 'err' is a raw error (FFI / fs / proto / arrow).
+// If 'err' is already a typed merr, use merr.Wrap(err, msg) instead — wrapping
+// a typed merr here would mask its inner code (defect#3 pattern).
+//
+// merr.Code(result) returns ErrStorage.code() = 1008; errors.Is(result, ErrStorage)
+// succeeds; errors.Is(result, err) also succeeds (inner chain preserved via Unwrap).
+func WrapErrStorage(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrStorageMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrStorage,
+	}
 }
 
 // IO related

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -19,16 +19,14 @@ package merr
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"go.uber.org/zap"
+	"golang.org/x/exp/constraints"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
-	"github.com/milvus-io/milvus/pkg/v3/log"
-	"github.com/milvus-io/milvus/pkg/v3/util/logutil"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 const InputErrorFlagKey string = "is_input_error"
@@ -40,26 +38,37 @@ func Code(err error) int32 {
 		return 0
 	}
 
-	cause := errors.Cause(err)
-	switch specificErr := cause.(type) {
-	case milvusError:
-		return specificErr.code()
-
-	default:
-		if errors.Is(specificErr, context.Canceled) {
-			return CanceledCode
-		} else if errors.Is(specificErr, context.DeadlineExceeded) {
-			return TimeoutCode
-		} else {
-			return errUnexpected.code()
+	// Walk the chain looking for a milvus marker (either milvusError directly,
+	// or our wrappedMilvusError whose sentinel.Cause is hidden so that the
+	// inner error stays reachable via errors.Is). Stop at the first match.
+	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
+		switch v := cur.(type) {
+		case milvusError:
+			return v.code()
+		case *wrappedMilvusError:
+			return v.code()
 		}
 	}
+
+	cause := errors.Cause(err)
+	if errors.Is(cause, context.Canceled) {
+		return CanceledCode
+	} else if errors.Is(cause, context.DeadlineExceeded) {
+		return TimeoutCode
+	}
+	return errUnexpected.code()
 }
 
 func IsRetryableErr(err error) bool {
+<<<<<<< HEAD
 	var milvusErr milvusError
 	if errors.As(err, &milvusErr) {
 		return milvusErr.retriable
+=======
+	var me milvusError
+	if errors.As(err, &me) {
+		return me.retriable
+>>>>>>> 3a31bdeec4 (enhance: foundational merr framework and retry mechanisms)
 	}
 
 	return false
@@ -299,17 +308,6 @@ func SegcoreError(code int32, msg string) error {
 	return newMilvusError(msg, code, false)
 }
 
-// CheckHealthy checks whether the state is healthy,
-// returns nil if healthy,
-// otherwise returns ErrServiceNotReady wrapped with current state
-func CheckHealthy(state commonpb.StateCode) error {
-	if state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(paramtable.GetRole(), paramtable.GetNodeID(), state.String())
-	}
-
-	return nil
-}
-
 func IsHealthy(stateCode commonpb.StateCode) error {
 	if stateCode == commonpb.StateCode_Healthy {
 		return nil
@@ -324,19 +322,17 @@ func IsHealthyOrStopping(stateCode commonpb.StateCode) error {
 	return CheckHealthy(stateCode)
 }
 
-func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
-	if err := Error(state.GetStatus()); err != nil {
-		return errors.Wrapf(err, "%s=%d not healthy", role, nodeID)
-	} else if state := state.GetState().GetStateCode(); state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(role, nodeID, state.String())
-	}
-
-	return nil
-}
-
 func WrapErrAsInputError(err error) error {
 	if merr, ok := err.(milvusError); ok {
 		WithErrorType(InputError)(&merr)
+		return merr
+	}
+	return err
+}
+
+func WrapErrAsSysError(err error) error {
+	if merr, ok := err.(milvusError); ok {
+		WithErrorType(SystemError)(&merr)
 		return merr
 	}
 	return err
@@ -346,7 +342,6 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	if merr, ok := err.(milvusError); ok {
 		for _, target := range targets {
 			if target.errCode == merr.errCode {
-				log.Info("mark error as input error", zap.Error(err))
 				WithErrorType(InputError)(&merr)
 				return merr
 			}
@@ -355,15 +350,43 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	return err
 }
 
+func WrapErrCollectionReplicateMode(operation string) error {
+	return wrapFields(ErrCollectionReplicateMode, value("operation", operation))
+}
+
 func GetErrorType(err error) ErrorType {
-	if merr, ok := err.(milvusError); ok {
-		return merr.errType
+	var me milvusError
+	if errors.As(err, &me) {
+		return me.errType
 	}
 
 	return SystemError
 }
 
-// Service related
+// keeps only 2 decimal places
+func toMB[T constraints.Integer | constraints.Float](mem T) T {
+	return T(math.Round(float64(mem)/1024/1024*100) / 100)
+}
+
+// CheckHealthy checks whether the state is healthy,
+// returns nil if healthy,
+// otherwise returns ErrServiceNotReady wrapped with current state
+func CheckHealthy(stateCode commonpb.StateCode) error {
+	if stateCode != commonpb.StateCode_Healthy {
+		return ErrServiceNotReady
+	}
+	return nil
+}
+
+func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
+	if err := Error(state.GetStatus()); err != nil {
+		return WrapErrServiceNotReady(role, nodeID, err.Error())
+	} else if stateCode := state.GetState().GetStateCode(); stateCode != commonpb.StateCode_Healthy {
+		return WrapErrServiceNotReady(role, nodeID, stateCode.String())
+	}
+	return nil
+}
+
 func WrapErrServiceNotReady(role string, sessionID int64, state string, msg ...string) error {
 	err := wrapFieldsWithDesc(ErrServiceNotReady,
 		state,
@@ -385,8 +408,8 @@ func WrapErrServiceUnavailable(reason string, msg ...string) error {
 
 func WrapErrServiceMemoryLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceMemoryLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -412,6 +435,21 @@ func WrapErrServiceInternal(reason string, msg ...string) error {
 	return err
 }
 
+func WrapErrServiceInternalErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrServiceInternalMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrServiceInternal,
+	}
+}
+
+func WrapErrServiceInternalMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrServiceInternal, fmt, args...)
+}
+
 func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, msg ...string) error {
 	err := wrapFields(ErrServiceCrossClusterRouting,
 		value("expectedCluster", expectedCluster),
@@ -425,8 +463,8 @@ func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, ms
 
 func WrapErrServiceDiskLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceDiskLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -715,9 +753,9 @@ func WrapErrResourceGroupNodeNotEnough(rg any, current any, expected any, msg ..
 	return err
 }
 
-// WrapErrResourceGroupServiceAvailable wraps ErrResourceGroupServiceAvailable with resource group
-func WrapErrResourceGroupServiceAvailable(msg ...string) error {
-	err := wrapFields(ErrResourceGroupServiceAvailable)
+// WrapErrResourceGroupServiceUnAvailable wraps ErrResourceGroupServiceUnAvailable with resource group
+func WrapErrResourceGroupServiceUnAvailable(msg ...string) error {
+	err := wrapFields(ErrResourceGroupServiceUnAvailable)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
@@ -1046,6 +1084,21 @@ func WrapErrParameterInvalid[T any](expected, actual T, msg ...string) error {
 	return err
 }
 
+// WrapErrParameterInvalidErr wraps an existing error 'err' with ErrParameterInvalid (Code 1005).
+// This is used when an underlying error (e.g., from parsing, validation utility, or dependency)
+// causes a parameter check to fail, and you need to provide extra context
+// in 'format' and 'args'.
+func WrapErrParameterInvalidErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrParameterInvalidMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrParameterInvalid,
+	}
+}
+
 func WrapErrParameterInvalidRange[T any](lower, upper, actual T, msg ...string) error {
 	err := wrapFields(ErrParameterInvalid,
 		bound("value", actual, lower, upper),
@@ -1068,6 +1121,10 @@ func WrapErrParameterMissing[T any](param T, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+func WrapErrParameterMissingMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrParameterMissing, fmt, args...)
 }
 
 func WrapErrParameterTooLarge(name string, msg ...string) error {
@@ -1105,11 +1162,14 @@ func WrapErrMqTopicNotEmpty(name string, msg ...string) error {
 }
 
 func WrapErrMqInternal(err error, msg ...string) error {
-	err = wrapFieldsWithDesc(ErrMqInternal, err.Error())
-	if len(msg) > 0 {
-		err = errors.Wrap(err, strings.Join(msg, "->"))
+	if err == nil {
+		return ErrMqInternal
 	}
-	return err
+	ctx := ErrMqInternal.msg
+	if len(msg) > 0 {
+		ctx = strings.Join(msg, "->") + ": " + ctx
+	}
+	return &wrappedMilvusError{msg: ctx, inner: err, sentinel: ErrMqInternal}
 }
 
 func WrapErrPrivilegeNotAuthenticated(fmt string, args ...any) error {
@@ -1251,6 +1311,12 @@ func WrapErrIllegalCompactionPlan(msg ...string) error {
 	return err
 }
 
+func WrapErrIllegalCompactionPlanMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	// Since this is the message-only path, we wrap the constant error with the formatted message.
+	return errors.Wrap(ErrIllegalCompactionPlan, detail)
+}
+
 func WrapErrCompactionPlanConflict(msg ...string) error {
 	err := error(ErrCompactionPlanConflict)
 	if len(msg) > 0 {
@@ -1319,11 +1385,25 @@ func WrapErrAnalyzeTaskNotFound(id int64) error {
 }
 
 func WrapErrBuildCompactionRequestFail(err error) error {
-	return wrapFieldsWithDesc(ErrBuildCompactionRequestFail, err.Error())
+	if err == nil {
+		return ErrBuildCompactionRequestFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrBuildCompactionRequestFail.msg,
+		inner:    err,
+		sentinel: ErrBuildCompactionRequestFail,
+	}
 }
 
 func WrapErrGetCompactionPlanResultFail(err error) error {
-	return wrapFieldsWithDesc(ErrGetCompactionPlanResultFail, err.Error())
+	if err == nil {
+		return ErrGetCompactionPlanResultFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrGetCompactionPlanResultFail.msg,
+		inner:    err,
+		sentinel: ErrGetCompactionPlanResultFail,
+	}
 }
 
 func WrapErrCompactionResult(msg ...string) error {
@@ -1383,4 +1463,23 @@ func WrapErrSnapshotPinned(name any, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+// WrapErrOperationNotSupportedMsg creates a new ErrOperationNotSupported with a detail message (Code 14).
+// This is the primary replacement for fmt.Errorf/errors.New for operations that are
+// currently not supported by the system.
+func WrapErrOperationNotSupportedMsg(format string, args ...any) error {
+	return errors.Wrapf(ErrOperationNotSupported, format, args...)
+}
+
+// WrapErrOperationNotSupported wraps an existing error 'err' with ErrOperationNotSupported (Code 14).
+func WrapErrOperationNotSupported(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrOperationNotSupportedMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrOperationNotSupported,
+	}
 }

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -178,22 +178,18 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				return err
 			}
 
-			// Caller-explicit RetryErr predicate takes precedence over the
-			// default InputError abort: when caller passes RetryErr they have
-			// decided which errors are retriable, framework must not override.
-			if c.isRetryErr != nil {
-				if !c.isRetryErr(err) {
-					log.Warn("retry func failed, not be retryable",
-						zap.Uint("retried", i),
-						zap.Uint("attempt", c.attempts),
-						zap.String("caller", getCaller(2)),
-					)
-					return err
-				}
-			} else if merr.GetErrorType(err) == merr.InputError {
-				log.Warn("retry func failed, input error is non-retriable",
+			// shouldRetry=true is the caller's explicit affirmative. Honor
+			// it. The optional RetryErr predicate is still consulted as a
+			// second gate, but unlike retry.Do the InputError default abort
+			// is intentionally not applied here: in retry.Handle the caller
+			// signals abort via shouldRetry=false, not via the error type,
+			// otherwise client-side cache-eviction patterns like
+			// retryIfSchemaError become unreachable for errors classified
+			// server-side as InputError (e.g. ErrCollectionSchemaMismatch).
+			if c.isRetryErr != nil && !c.isRetryErr(err) {
+				log.Warn("retry func failed, not be retryable",
 					zap.Uint("retried", i),
-					zap.Error(err),
+					zap.Uint("attempt", c.attempts),
 					zap.String("caller", getCaller(2)),
 				)
 				return err

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -72,10 +72,23 @@ func Do(ctx context.Context, fn func() error, opts ...Option) error {
 				}
 				return err
 			}
-			if c.isRetryErr != nil && !c.isRetryErr(err) {
-				log.Warn("retry func failed, not be retryable",
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
 					zap.Uint("retried", i),
-					zap.Uint("attempt", c.attempts),
+					zap.Error(err),
 					zap.String("caller", getCaller(2)),
 				)
 				return err
@@ -162,6 +175,27 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				if isContextErr && lastErr != nil {
 					return lastErr
 				}
+				return err
+			}
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
+					zap.Uint("retried", i),
+					zap.Error(err),
+					zap.String("caller", getCaller(2)),
+				)
 				return err
 			}
 

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -239,3 +239,53 @@ func TestHandle(t *testing.T) {
 	}, Attempts(10))
 	assert.NoError(t, err)
 }
+
+// Regression: Handle must honor the caller's shouldRetry=true even when the
+// returned error is server-classified InputError. This is the cross-case the
+// client-side cache-eviction pattern in retryIfSchemaError depends on:
+// ErrCollectionSchemaMismatch is tagged InputError server-side (the client
+// sent a stale schema and the server rejected) but the client legitimately
+// wants to evict its cache and retry. Before this case the framework's
+// "default InputError abort" was firing after shouldRetry=true and
+// retryIfSchemaError silently never retried.
+func TestHandle_ShouldRetryOverridesInputErrorDefault(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		if counter == 1 {
+			return true, merr.WrapErrCollectionSchemaMisMatch("mocked")
+		}
+		return false, nil
+	}, Attempts(10))
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, counter,
+		"Handle should retry once when caller returns shouldRetry=true on InputError")
+}
+
+// Symmetric guard: shouldRetry=false on InputError still aborts immediately
+// (this path was already correct; pinning it down so the regression fix
+// above doesn't accidentally turn into "always retry InputError").
+func TestHandle_ShouldRetryFalseAbortsOnInputError(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		return false, merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter)
+}
+
+// retry.Do has no shouldRetry signal from the caller, so the InputError
+// default abort remains the right behavior — keep it pinned.
+func TestDo_InputErrorAbortsByDefault(t *testing.T) {
+	counter := 0
+	err := Do(context.Background(), func() error {
+		counter++
+		return merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter, "Do should abort on InputError without retrying")
+}

--- a/scripts/run_go_unittest.sh
+++ b/scripts/run_go_unittest.sh
@@ -26,6 +26,12 @@ if [[ $(uname -s) == "Darwin" ]]; then
     export MallocNanoZone=0
 fi
 
+# Azurite default credentials for internal/storage TestAzureObjectStorage.
+# Honor any caller-provided value so CI can override with real credentials.
+if [[ -z "${AZURE_STORAGE_CONNECTION_STRING}" ]]; then
+    export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+fi
+
 # ignore MinIO,S3 unittests
 MILVUS_DIR="${ROOT_DIR}/internal/"
 PKG_DIR="${ROOT_DIR}/pkg/"

--- a/tests/python_client/check/func_check.py
+++ b/tests/python_client/check/func_check.py
@@ -504,9 +504,13 @@ class ResponseChecker:
                 num_to_check = min(100, len(distances))  # check 100 items if more than that
                 eps = 1e-6
                 if check_items.get("metric").upper() in ["IP", "COSINE", "BM25"]:
-                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1))
+                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1)), (
+                        f"distances not descending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 else:
-                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1))
+                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1)), (
+                        f"distances not ascending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 if check_items.get("vector_nq") is None or check_items.get("original_vectors") is None:
                     log.debug("skip distance check for knowhere does not return the precise distances")
                 else:

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1524,7 +1524,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("ratio", [-0.5, 1, 3])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_ratio(self, ratio, index):
         """
         target: index creation for unsupported ratio parameter
@@ -1551,7 +1551,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("inverted_index_algo", ["INVALID_ALGO"])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_inverted_index_algo(self, inverted_index_algo, index):
         """
         target: index creation for unsupported sparse inverted index algo parameter


### PR DESCRIPTION
Standardizes error handling in the storage modules (`internal/storage`, `internal/storagev2`) onto the `merr` framework. Part of the system-wide error-standardization series.

### Stacking

Depends on #48802 (`err-std-01-base`, the foundational `merr` framework). This branch is stacked on top of `err-std-01-base`, so until #48802 merges the diff here also contains the base-framework commits. **Review the single storage commit** `Standardize error handling: Storage module`; the base commits land via #48802. Siblings: #49865 (`err-std-03-proxy`), #49874 (`err-std-04-coord`).

### What this is

Started from the per-module auto-generated conversion, re-sliced onto the current `err-std-01-base`, then **heavily hand-corrected**. The raw auto-gen output had systematic defects (wrong import path, sentinel-corruption, code-masking via `WrapErr*Err`); each was root-caused against a real failing test and verified fixed.

### Three new sentinels + helpers

Introduce typed wire errors so storage failures carry a meaningful gRPC code instead of falling back to `ErrServiceInternal` (5):

- **`ErrStorage` (1008, SystemError)** — storage-subsystem catch-all: transaction state machine, writer/reader lifecycle, FFI internal failures, ext-table metadata operations. Used when no narrower sentinel fits.
- **`ErrSerializationFailed` (1004, SystemError)** — a transformation pipeline (proto, json, arrow schema conversion) could not complete.
- **`ErrDataIntegrity` (1009, SystemError)** — bytes already on disk don't match the layout expected from the schema (binlog payload type/count mismatch, malformed event header, unparseable stats buffer). Likely permanent corruption.

Each sentinel ships with `WrapErr<X>` (wraps inner err preserving Unwrap chain via `*wrappedMilvusError`) and `WrapErr<X>Msg` (origination, no inner) variants.

### Migration breakdown (~85 callsites)

| Origin pattern | → Target | Sites |
|---|---|---|
| `merr.WrapErrServiceInternalErr(err, ...)` (defect#3: outer sentinel masks inner typed merr code) | `merr.WrapErrStorage` | 36 |
| bare `errors.New` / `errors.Newf` / `fmt.Errorf` | typed merr per inner type (raw → `WrapErrStorage`; typed-merr inner → `merr.Wrap`) | 25 |
| `WrapErrParameterInvalid*` on stored-byte mismatches (payload_reader / event_data / stats / field_stats) | `WrapErrDataIntegrity` | ~37 |
| `WrapErrParameterInvalid*` on schema/arrow conversion failures (record_reader / binlog_record_writer) | `WrapErrSerializationFailed` | 6 |
| `WrapErrParameterInvalid*` on internal caller invariants (delta_data / record_writer / sort / local_chunk_manager) | `WrapErrStorage` | 5 |
| cockroachdb `errors.Wrap` (cosmetic alignment with merr.Wrap) | `merr.Wrap` | 7 |

### ErrParameterInvalid → InputError + retry.Do anti-pattern fix

Mark `ErrParameterInvalid` (1100) with `WithErrorType(InputError)`. The 2024-07 \"mark error as user error\" PR (#33498) backfilled the InputError flag onto a batch of sentinels (`ErrCollectionNotFound`, `ErrDatabaseInvalidName`, `ErrResourceGroupIllegalConfig`, …) but missed `ErrParameterInvalid`. Routing storage's data-integrity sites away from `ErrParameterInvalid` first means we can safely flip the bit without classifying internal invariants as client errors.

**Side-effect fix** — `internal/coordinator/file_resource_observer.go` had two sites using `WrapErrParameterInvalidMsg` for transient \"not-ready / not-yet-synced\" conditions:

- `rootcoord meta is not ready` (boot/init transient)
- `node %d file resource not synced` (sync propagation in-flight)

Caller `internal/rootcoord/create_collection_task.go:242` retries this check via `retry.Do(ctx, fn, retry.Attempts(10), retry.Sleep(3*time.Second))` — relying on the 30s retry window for sync to complete. `retry.Do` short-circuits to abort on `InputError`-typed errors. After flipping `ErrParameterInvalid` to InputError, the very first failed check would abort retry, breaking `TestMilvusClientFileResourceSyncCheck::test_add_then_immediate_create_collection`. Both sites migrated to `WrapErrServiceUnavailable` (retriable=true, SystemError) — semantics-appropriate (\"service resource not yet available, try later\").

### MakeProperties / injectExternalSpec contract tightening

`MakePropertiesFromStorageConfig` and `injectExternalSpecProperties` previously leaked `ErrLoonTransient` (cockroachdb sentinel, no merr code → wire reads as `Unexpected`) on FFI failure and `ErrServiceInternal` (code 5) on nil input. Both now consistently return `ErrStorage` typed regardless of failure path. Callers using `merr.Wrap` preserve the typed code on the wire.

### Validation

- Full storage `make test-storage` (`internal/storage`, `internal/storagev2`, `internal/storagev2/packed`): **every package ok**. 3 Azure-IAM-federated-token tests skipped locally (require real Azure AD, env-dependent — not introduced by this change).
- `make verifiers` rc=0; `go build` + `go vet` clean; gci/gofmt clean.
- Full L0/L1 e2e (`pytest -n 32 --dist=loadgroup --tags L0 L1`, py3.12 + vortex-data 0.56.0): **7337 passed, 0 failed, 421 skipped, 6 xfailed in 18:19**.

### Out of scope (documented follow-up)

- The `merr.WrapErrParameterInvalid[T any](expected, actual T, msg ...)` generic helper has 4 ergonomic issues (T forced same-type via `any` inference, expected/actual order is conventions-only, `msg ...string` joined by `\"->\"`, error message hard-codes `expected/actual`). ~110-140 callsites would migrate to explicit `WrapErrParameterInvalidMsg` formatting in a separate refactor PR.
- A broader scan for other sites using `WrapErrParameterInvalid*` inside `retry.Do/Handle` bodies that may have transient semantics (the file_resource_observer case is the only e2e-detectable one in this run).

issue: #47420