### PR TITLE
fix: preserve input ID order in search by primary key (#49818)

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -3871,9 +3871,18 @@ func (node *Proxy) handleIfSearchByPK(ctx context.Context, request *milvuspb.Sea
 			fmt.Sprintf("some of the provided primary key IDs do not exist: missing IDs = %v", missingIDs))
 	}
 
+	// reduceRetrieveResults always returns rows sorted by primary key ascending
+	// (see typeutil.SelectMinPK), but search needs the rows in the order the
+	// caller provided IDs — Nq position N must correspond to ids[N]. Reorder
+	// here before we project the placeholder group.
+	reorderedFields, err := funcutil.ReorderFieldDataByInputIDs(queryResult.GetFieldsData(), pkFieldData, ids)
+	if err != nil {
+		return nil, err
+	}
+
 	// Extract the field data from query result
 	// For BM25: extract text field; for vector search: extract vector field
-	fieldData := lo.FindOrElse(queryResult.GetFieldsData(), nil, func(f *schemapb.FieldData) bool {
+	fieldData := lo.FindOrElse(reorderedFields, nil, func(f *schemapb.FieldData) bool {
 		return f.GetFieldName() == fieldToFetch || f.GetType() == schemapb.DataType_ArrayOfStruct
 	})
 

--- a/pkg/util/funcutil/field_data_reorder.go
+++ b/pkg/util/funcutil/field_data_reorder.go
@@ -1,0 +1,77 @@
+package funcutil
+
+import (
+	"fmt"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// ReorderFieldDataByInputIDs returns a new fields-data slice whose rows are
+// laid out in the order of inputIDs.
+//
+// The retrieve / query pipeline always merges per-segment results by primary
+// key ascending (see typeutil.SelectMinPK), so when callers fetch rows by a
+// list of primary keys (e.g. proxy's "search by PK" path) the rows come back
+// sorted by PK, not in the order the caller asked for. Search uses each row
+// in Nq order, so the mismatch corrupts per-query results.
+//
+// pkFieldData must be the PK field already present in src and must have the
+// same row count as src. Every input ID must exist in pkFieldData — duplicate
+// and missing-ID handling is the caller's responsibility.
+func ReorderFieldDataByInputIDs(
+	src []*schemapb.FieldData,
+	pkFieldData *schemapb.FieldData,
+	inputIDs *schemapb.IDs,
+) ([]*schemapb.FieldData, error) {
+	if pkFieldData == nil {
+		return nil, fmt.Errorf("primary key field data is nil")
+	}
+
+	pkToRow := make(map[any]int64)
+	switch pkFieldData.GetType() {
+	case schemapb.DataType_Int64:
+		for i, pk := range pkFieldData.GetScalars().GetLongData().GetData() {
+			pkToRow[pk] = int64(i)
+		}
+	case schemapb.DataType_VarChar:
+		for i, pk := range pkFieldData.GetScalars().GetStringData().GetData() {
+			pkToRow[pk] = int64(i)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported primary key data type: %s", pkFieldData.GetType())
+	}
+
+	n := int64(typeutil.GetSizeOfIDs(inputIDs))
+	dst := typeutil.PrepareResultFieldData(src, n)
+	idxComputer := typeutil.NewFieldDataIdxComputer(src)
+
+	appendByID := func(id any) error {
+		rowIdx, ok := pkToRow[id]
+		if !ok {
+			return fmt.Errorf("primary key %v not found in query result", id)
+		}
+		fieldIdxs := idxComputer.Compute(rowIdx)
+		typeutil.AppendFieldData(dst, src, rowIdx, fieldIdxs...)
+		return nil
+	}
+
+	switch inputIDs.GetIdField().(type) {
+	case *schemapb.IDs_IntId:
+		for _, id := range inputIDs.GetIntId().GetData() {
+			if err := appendByID(id); err != nil {
+				return nil, err
+			}
+		}
+	case *schemapb.IDs_StrId:
+		for _, id := range inputIDs.GetStrId().GetData() {
+			if err := appendByID(id); err != nil {
+				return nil, err
+			}
+		}
+	default:
+		return nil, fmt.Errorf("unsupported input ID field type")
+	}
+
+	return dst, nil
+}

--- a/pkg/util/funcutil/field_data_reorder_test.go
+++ b/pkg/util/funcutil/field_data_reorder_test.go
@@ -1,0 +1,157 @@
+package funcutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+// buildPKAscFieldsData builds a fields-data slice that mimics the output of
+// the query/retrieve reduce step: rows are laid out in primary key ascending
+// order, with a compact float-vector representation that skips rows where
+// validData[i] is false.
+func buildPKAscFieldsData(pkType schemapb.DataType, pkData any, vec [][]float32, dim int64, validData []bool) []*schemapb.FieldData {
+	pkField := &schemapb.FieldData{
+		Type:      pkType,
+		FieldName: "id",
+		FieldId:   100,
+		Field:     &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{}},
+	}
+	switch pkType {
+	case schemapb.DataType_Int64:
+		pkField.GetScalars().Data = &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: pkData.([]int64)}}
+	case schemapb.DataType_VarChar:
+		pkField.GetScalars().Data = &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: pkData.([]string)}}
+	}
+
+	flat := make([]float32, 0, int64(len(vec))*dim)
+	for i, v := range vec {
+		if validData != nil && !validData[i] {
+			continue
+		}
+		flat = append(flat, v...)
+	}
+	vecField := &schemapb.FieldData{
+		Type:      schemapb.DataType_FloatVector,
+		FieldName: "vec",
+		FieldId:   101,
+		ValidData: validData,
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim:  dim,
+				Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: flat}},
+			},
+		},
+	}
+	return []*schemapb.FieldData{pkField, vecField}
+}
+
+func TestReorderFieldDataByInputIDs_Int64PK(t *testing.T) {
+	// Query result is in PK ASC order [pk=1 vec=[1,0], pk=2 vec=[0,1]];
+	// caller asked for ids=[2, 1] and must get rows back in that order.
+	src := buildPKAscFieldsData(
+		schemapb.DataType_Int64,
+		[]int64{1, 2},
+		[][]float32{{1, 0}, {0, 1}},
+		2,
+		nil,
+	)
+	inputIDs := &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{2, 1}}}}
+
+	dst, err := ReorderFieldDataByInputIDs(src, src[0], inputIDs)
+	require.NoError(t, err)
+	require.Len(t, dst, 2)
+
+	assert.Equal(t, []int64{2, 1}, dst[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []float32{0, 1, 1, 0}, dst[1].GetVectors().GetFloatVector().GetData())
+}
+
+func TestReorderFieldDataByInputIDs_VarCharPK(t *testing.T) {
+	src := buildPKAscFieldsData(
+		schemapb.DataType_VarChar,
+		[]string{"a", "b", "c"},
+		[][]float32{{1, 0}, {0, 1}, {1, 1}},
+		2,
+		nil,
+	)
+	inputIDs := &schemapb.IDs{IdField: &schemapb.IDs_StrId{StrId: &schemapb.StringArray{Data: []string{"c", "a", "b"}}}}
+
+	dst, err := ReorderFieldDataByInputIDs(src, src[0], inputIDs)
+	require.NoError(t, err)
+	require.Len(t, dst, 2)
+
+	assert.Equal(t, []string{"c", "a", "b"}, dst[0].GetScalars().GetStringData().GetData())
+	assert.Equal(t, []float32{1, 1, 1, 0, 0, 1}, dst[1].GetVectors().GetFloatVector().GetData())
+}
+
+func TestReorderFieldDataByInputIDs_NullableVector(t *testing.T) {
+	// pk=2 is null. Input order [3, 2, 1] → validData and the compact vector
+	// slice must both follow the input order.
+	src := buildPKAscFieldsData(
+		schemapb.DataType_Int64,
+		[]int64{1, 2, 3},
+		[][]float32{{1, 0}, {9, 9}, {0, 1}}, // {9,9} placeholder, not actually stored
+		2,
+		[]bool{true, false, true},
+	)
+	inputIDs := &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{3, 2, 1}}}}
+
+	dst, err := ReorderFieldDataByInputIDs(src, src[0], inputIDs)
+	require.NoError(t, err)
+	require.Len(t, dst, 2)
+
+	assert.Equal(t, []int64{3, 2, 1}, dst[0].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []bool{true, false, true}, dst[1].GetValidData())
+	assert.Equal(t, []float32{0, 1, 1, 0}, dst[1].GetVectors().GetFloatVector().GetData())
+}
+
+func TestReorderFieldDataByInputIDs_PlaceholderBytesPreserveOrder(t *testing.T) {
+	// End-to-end check matching what handleIfSearchByPK does: reorder the
+	// reduced query result by input IDs, then pack the vector field into a
+	// PlaceholderGroup. Decode the bytes back to confirm vectors are in
+	// input-ID order, not PK-ASC order.
+	src := buildPKAscFieldsData(
+		schemapb.DataType_Int64,
+		[]int64{1, 2},
+		[][]float32{{1, 0}, {0, 1}},
+		2,
+		nil,
+	)
+	inputIDs := &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{2, 1}}}}
+
+	dst, err := ReorderFieldDataByInputIDs(src, src[0], inputIDs)
+	require.NoError(t, err)
+
+	bytes, count, err := FieldDataToPlaceholderGroupBytesWithCount(dst[1])
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+
+	pg := &commonpb.PlaceholderGroup{}
+	require.NoError(t, proto.Unmarshal(bytes, pg))
+	require.Len(t, pg.GetPlaceholders(), 1)
+	values := pg.GetPlaceholders()[0].GetValues()
+	require.Len(t, values, 2)
+	// First placeholder vector must be vec of pk=2 = [0,1] (8 little-endian bytes).
+	require.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0x80, 0x3f}, values[0])
+	// Second is vec of pk=1 = [1,0].
+	require.Equal(t, []byte{0, 0, 0x80, 0x3f, 0, 0, 0, 0}, values[1])
+}
+
+func TestReorderFieldDataByInputIDs_MissingPKReturnsError(t *testing.T) {
+	src := buildPKAscFieldsData(
+		schemapb.DataType_Int64,
+		[]int64{1, 2},
+		[][]float32{{1, 0}, {0, 1}},
+		2,
+		nil,
+	)
+	inputIDs := &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{2, 99}}}}
+
+	_, err := ReorderFieldDataByInputIDs(src, src[0], inputIDs)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- Adds `funcutil.ReorderFieldDataByInputIDs`: maps PK→row from a reduced query result and rebuilds the field-data slice in the caller's input-ID order (validData included, compact vector storage handled via `typeutil.NewFieldDataIdxComputer`).
- Calls it from `handleIfSearchByPK` after the missing-ID check, so the `PlaceholderGroup` and the returned `validData` (consumed by `adjustSearchResultsForNullVectors`) are both in input-ID order.

## Why
`reduceRetrieveResults` merges per-segment results with `typeutil.SelectMinPK` — it always emits rows sorted by primary key ascending. The search-by-PK path then packs the query result into a `PlaceholderGroup` and runs Search, but Search treats the Nq dimension positionally — `result[i]` corresponds to `ids[i]`. Without a reorder step, the rows handed to Search are in PK-ASC order, so a caller asking for `ids=[2, 1]` gets results in the order `[1, 2]` and every per-query result is silently mismatched.

## Test plan
- [x] `go test ./pkg/util/funcutil/ -run TestReorderFieldDataByInputIDs` covers:
  - int64 PK reordered against input order
  - varchar PK reordered against input order
  - nullable vector field — validData and the compact vector slice both follow input order
  - missing input PK → error
  - end-to-end placeholder-bytes check: decoded `PlaceholderGroup.Values` are in input-ID order
- [ ] CI proxy tests (`make test-proxy`) — full proxy build needs C++ deps unavailable in my env.

issue: #49818