### PR TITLE
fix: retry delta log writes in sync task

### DIFF
--- a/internal/flushcommon/syncmgr/pack_writer.go
+++ b/internal/flushcommon/syncmgr/pack_writer.go
@@ -97,12 +97,9 @@ func (bw *BulkPackWriter) Write(ctx context.Context, pack *SyncPack) (
 	return
 }
 
-func (bw *BulkPackWriter) writeLog(ctx context.Context, blob *storage.Blob,
-	root, p string, pack *SyncPack,
-) (*datapb.Binlog, error) {
-	key := path.Join(bw.chunkManager.RootPath(), root, p)
-	err := retry.Handle(ctx, func() (bool, error) {
-		err := bw.chunkManager.Write(ctx, key, blob.Value)
+func (bw *BulkPackWriter) writeBlob(ctx context.Context, key string, blob []byte) error {
+	return retry.Handle(ctx, func() (bool, error) {
+		err := bw.chunkManager.Write(ctx, key, blob)
 		if err == nil {
 			return false, nil
 		}
@@ -112,7 +109,13 @@ func (bw *BulkPackWriter) writeLog(ctx context.Context, blob *storage.Blob,
 		}
 		return true, err
 	}, bw.writeRetryOpts...)
-	if err != nil {
+}
+
+func (bw *BulkPackWriter) writeLog(ctx context.Context, blob *storage.Blob,
+	root, p string, pack *SyncPack,
+) (*datapb.Binlog, error) {
+	key := path.Join(bw.chunkManager.RootPath(), root, p)
+	if err := bw.writeBlob(ctx, key, blob.Value); err != nil {
 		return nil, err
 	}
 	size := int64(len(blob.GetValue()))
@@ -299,9 +302,9 @@ func (bw *BulkPackWriter) writeDelta(ctx context.Context, pack *SyncPack) (*data
 	writer, err := storage.NewDeltalogWriter(
 		ctx, pack.collectionID, pack.partitionID, pack.segmentID, logID, pkField.DataType, deltaPath,
 		storage.WithVersion(storage.StorageV1),
-		storage.WithUploader(func(ctx context.Context, kvs map[string][]byte) error {
+		storage.WithUploader(func(_ context.Context, kvs map[string][]byte) error {
 			for k, blob := range kvs {
-				return bw.chunkManager.Write(ctx, k, blob)
+				return bw.writeBlob(ctx, k, blob)
 			}
 			return nil
 		}),

--- a/internal/flushcommon/syncmgr/pack_writer_test.go
+++ b/internal/flushcommon/syncmgr/pack_writer_test.go
@@ -169,6 +169,60 @@ func TestBulkPackWriter_Write(t *testing.T) {
 	}
 }
 
+func TestBulkPackWriter_WriteDelta_RetryTransientWriteFailure(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	collectionID := int64(123)
+	partitionID := int64(456)
+	segmentID := int64(789)
+	schema := &schemapb.CollectionSchema{
+		Name: "sync_task_test_col",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: common.RowIDField, DataType: schemapb.DataType_Int64},
+			{FieldID: common.TimeStampField, DataType: schemapb.DataType_Int64},
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		},
+	}
+
+	cm := mocks.NewChunkManager(t)
+	cm.EXPECT().RootPath().Return("files").Maybe()
+	callCount := 0
+	cm.EXPECT().Write(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, key string, data []byte) error {
+			callCount++
+			if callCount == 1 {
+				return errors.New("transient object storage timeout")
+			}
+			return nil
+		})
+
+	deletes := &storage.DeleteData{}
+	for i := 0; i < 10; i++ {
+		pk := storage.NewInt64PrimaryKey(int64(i + 1))
+		ts := uint64(100 + i)
+		deletes.Append(pk, ts)
+	}
+
+	bw := &BulkPackWriter{
+		schema:         schema,
+		chunkManager:   cm,
+		allocator:      allocator.NewLocalAllocator(10000, 100000),
+		writeRetryOpts: []retry.Option{retry.AttemptAlways(), retry.Sleep(time.Millisecond), retry.MaxSleepTime(time.Millisecond)},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, err := bw.writeDelta(ctx, new(SyncPack).
+		WithCollectionID(collectionID).
+		WithPartitionID(partitionID).
+		WithSegmentID(segmentID).
+		WithDeleteData(deletes))
+
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount)
+	require.Equal(t, int64(10), got.GetBinlogs()[0].GetEntriesNum())
+}
+
 func TestValidateStorageV1InsertWritableSchema(t *testing.T) {
 	arrayOfVectorField := func(nullable bool) *schemapb.FieldSchema {
 		return &schemapb.FieldSchema{


### PR DESCRIPTION
issue: #49998

- syncmgr: route delta-log blob uploads through retry-aware object storage writes
- syncmgr tests: cover transient delta-log write failures and non-retryable write errors