### PR TITLE
fix: [2.6]correct QueryNode segment load span logging

### DIFF
--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -957,6 +957,7 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 			IsLoaded:  true,
 		})
 	}
+	loadDataIndexSpan := tr.RecordSpan()
 
 	// Load text indexes in parallel through LoadPool.
 	futures := make([]*conc.Future[any], 0, len(textIndexes))
@@ -993,9 +994,7 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 	}
 	patchEntryNumberSpan := tr.RecordSpan()
 	log.Info("Finish loading segment",
-		// zap.Duration("loadFieldsIndexSpan", loadFieldsIndexSpan),
-		// zap.Duration("complementScalarDataSpan", complementScalarDataSpan),
-		// zap.Duration("loadRawDataSpan", loadRawDataSpan),
+		zap.Duration("loadDataIndexSpan", loadDataIndexSpan),
 		zap.Duration("patchEntryNumberSpan", patchEntryNumberSpan),
 		zap.Duration("loadTextIndexesSpan", loadTextIndexesSpan),
 		zap.Duration("loadJsonKeyIndexSpan", loadJSONKeyIndexesSpan),


### PR DESCRIPTION
fixes #50031

Record the base data/index loading span before starting text index loading so loadTextIndexesSpan no longer includes earlier segment load work. This makes QueryNode segment load latency logs more accurate for diagnosis.