### PR TITLE
fix: use np.nan in insert nan test

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_insert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_insert.py
@@ -695,7 +695,7 @@ class TestMilvusClientInsertInvalid(TestMilvusClientV2Base):
                     check_task=CheckTasks.err_res, check_items=error)
 
         # 5. Test np.NAN in vector field
-        rows[0][default_vector_field_name][0] = np.NAN
+        rows[0][default_vector_field_name][0] = np.nan
         self.insert(client, collection_name, data=rows,
                     check_task=CheckTasks.err_res, check_items=error)
 


### PR DESCRIPTION
### What changed

Use `np.nan` instead of removed alias `np.NAN` in `test_insert_with_nan_value`.

### Why

Nightly master trigger 229 failed because the test accesses `np.NAN` with `numpy==2.2.6`, where this alias no longer exists:

```text
AttributeError: module 'numpy' has no attribute 'NAN'. Did you mean: 'NaN'?
```

Nightly downstream examples:

- https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/milvus-e2e-pipeline-4am/24470/consoleText
- https://jenkins-milvus-ci.milvus.io/job/MILVUS-CI-V2-PR-PIPELINES/job/milvus-e2e-pipeline-4am/24473/consoleText
