### PR TITLE
fix: handle cluster-removal during pchannel-increase in replicate stream

### DIFF
--- a/internal/distributed/streaming/replicate_service.go
+++ b/internal/distributed/streaming/replicate_service.go
@@ -2,9 +2,13 @@ package streaming
 
 import (
 	"context"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/errors"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -199,7 +203,7 @@ func (s replicateService) overwriteReplicateMessage(ctx context.Context, msg mes
 			return nil, err
 		}
 	case message.MessageTypeAlterReplicateConfig:
-		if err := s.overwriteAlterReplicateConfigMessage(cfg, msg); err != nil {
+		if err := s.overwriteAlterReplicateConfigMessage(ctx, cfg, msg); err != nil {
 			return nil, err
 		}
 	case message.MessageTypeAlterLoadConfig:
@@ -245,7 +249,7 @@ func (s replicateService) overwriteCreateCollectionMessage(sourceCluster *replic
 }
 
 // overwriteAlterReplicateConfigMessage overwrites the alter replicate configuration message.
-func (s replicateService) overwriteAlterReplicateConfigMessage(currentReplicateConfig *replicateutil.ConfigHelper, msg message.ReplicateMutableMessage) error {
+func (s replicateService) overwriteAlterReplicateConfigMessage(ctx context.Context, currentReplicateConfig *replicateutil.ConfigHelper, msg message.ReplicateMutableMessage) error {
 	alterReplicateConfigMsg := message.MustAsMutableAlterReplicateConfigMessageV2(msg)
 	header := alterReplicateConfigMsg.Header()
 
@@ -267,13 +271,117 @@ func (s replicateService) overwriteAlterReplicateConfigMessage(currentReplicateC
 	// Current cluster not found in the replicate configuration,
 	// it means that the current cluster is removed from the replicate topology and become a independent cluster.
 	// So we need to overwrite the replicate configuration to make current cluster to be a primary cluster without replicate topology.
-	cluster := currentReplicateConfig.GetCurrentCluster()
+	cluster := proto.Clone(currentReplicateConfig.GetCurrentCluster().MilvusCluster).(*commonpb.MilvusCluster)
+	if header.GetIsPchannelIncreasing() {
+		pchannels, err := s.getLatestLocalPChannels(ctx, cluster.GetPchannels(), expectedPChannelCount(cfg, len(cluster.GetPchannels())))
+		if err != nil {
+			return err
+		}
+		cluster.Pchannels = pchannels
+	}
 	alterReplicateConfigMsg.OverwriteHeader(&message.AlterReplicateConfigMessageHeader{
 		ReplicateConfiguration: &commonpb.ReplicateConfiguration{
-			Clusters: []*commonpb.MilvusCluster{cluster.MilvusCluster},
+			Clusters: []*commonpb.MilvusCluster{cluster},
 		},
 	})
 	return nil
+}
+
+func expectedPChannelCount(config *commonpb.ReplicateConfiguration, fallback int) int {
+	for _, cluster := range config.GetClusters() {
+		if len(cluster.GetPchannels()) > 0 {
+			return len(cluster.GetPchannels())
+		}
+	}
+	return fallback
+}
+
+func (s replicateService) getLatestLocalPChannels(ctx context.Context, existingPChannels []string, expectedCount int) ([]string, error) {
+	if expectedCount < len(existingPChannels) {
+		expectedCount = len(existingPChannels)
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	for {
+		pchannels, err := s.tryGetLatestLocalPChannels(waitCtx, existingPChannels)
+		if err != nil {
+			return nil, err
+		}
+		if len(pchannels) >= expectedCount {
+			return pchannels, nil
+		}
+
+		timer := time.NewTimer(100 * time.Millisecond)
+		select {
+		case <-waitCtx.Done():
+			timer.Stop()
+			return nil, waitCtx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (s replicateService) tryGetLatestLocalPChannels(ctx context.Context, existingPChannels []string) ([]string, error) {
+	assignments, err := s.streamingCoordClient.Assignment().GetLatestAssignments(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if assignments == nil {
+		return nil, status.NewReplicateViolation("latest assignments is nil")
+	}
+	localPChannelSet := make(map[string]struct{})
+	for _, assignment := range assignments.Assignments {
+		for channelName, pchannel := range assignment.Channels {
+			if pchannel.Name != "" {
+				channelName = pchannel.Name
+			}
+			if channelName == "" {
+				continue
+			}
+			localPChannelSet[channelName] = struct{}{}
+		}
+	}
+	if len(localPChannelSet) == 0 {
+		return nil, status.NewReplicateViolation("no local pchannels found in latest assignments")
+	}
+
+	pchannels := make([]string, 0, len(localPChannelSet))
+	for _, pchannel := range existingPChannels {
+		if _, ok := localPChannelSet[pchannel]; ok {
+			pchannels = append(pchannels, pchannel)
+			delete(localPChannelSet, pchannel)
+		}
+	}
+	extraPChannels := make([]string, 0, len(localPChannelSet))
+	for pchannel := range localPChannelSet {
+		extraPChannels = append(extraPChannels, pchannel)
+	}
+	sort.Slice(extraPChannels, func(i, j int) bool {
+		return pchannelLess(extraPChannels[i], extraPChannels[j])
+	})
+	pchannels = append(pchannels, extraPChannels...)
+	return pchannels, nil
+}
+
+func pchannelLess(left, right string) bool {
+	leftPrefix, leftIdx, leftOk := splitPChannelIndex(left)
+	rightPrefix, rightIdx, rightOk := splitPChannelIndex(right)
+	if leftOk && rightOk && leftPrefix == rightPrefix && leftIdx != rightIdx {
+		return leftIdx < rightIdx
+	}
+	return left < right
+}
+
+func splitPChannelIndex(pchannel string) (string, int, bool) {
+	underscoreIdx := strings.LastIndex(pchannel, "_")
+	if underscoreIdx < 0 || underscoreIdx == len(pchannel)-1 {
+		return "", 0, false
+	}
+	idx, err := strconv.Atoi(pchannel[underscoreIdx+1:])
+	if err != nil {
+		return "", 0, false
+	}
+	return pchannel[:underscoreIdx], idx, true
 }
 
 // overwriteAlterLoadConfigMessage sets use_local_replica_config flag on replicated AlterLoadConfig messages

--- a/internal/distributed/streaming/replicate_service.go
+++ b/internal/distributed/streaming/replicate_service.go
@@ -135,21 +135,36 @@ func (s replicateService) overwriteReplicateMessage(ctx context.Context, msg mes
 	// message header to map ALL channels (including newly added ones).
 	// The current config only knows about old pchannels, so both the main vchannel and
 	// broadcast vchannels need the new config for mapping.
+	// Special case: if the new config no longer contains the current cluster, it means
+	// the AlterReplicateConfig is removing this cluster from the topology. Fall through
+	// with the OLD source mapping; overwriteAlterReplicateConfigMessage below will rewrite
+	// the header to standalone-primary, and any source pchannels that the current cluster
+	// doesn't know about will be filtered from the broadcast vchannels.
 	channelMappingSourceCluster := sourceCluster
+	currentClusterRemoved := false
 	if msg.MessageType() == message.MessageTypeAlterReplicateConfig {
 		alterMsg := message.MustAsMutableAlterReplicateConfigMessageV2(msg)
 		if alterMsg.Header().GetIsPchannelIncreasing() {
 			newCfg, newCfgErr := replicateutil.NewConfigHelper(s.clusterID, alterMsg.Header().GetReplicateConfiguration())
-			if newCfgErr != nil {
+			switch {
+			case newCfgErr == nil:
+				channelMappingSourceCluster = newCfg.GetCluster(rh.ClusterID)
+				if channelMappingSourceCluster == nil {
+					return nil, status.NewReplicateViolation("source cluster %s not found in new replicate configuration", rh.ClusterID)
+				}
+			case errors.Is(newCfgErr, replicateutil.ErrCurrentClusterNotFound):
+				currentClusterRemoved = true
+			default:
 				return nil, status.NewReplicateViolation("failed to parse new replicate config from message header: %s", newCfgErr.Error())
-			}
-			channelMappingSourceCluster = newCfg.GetCluster(rh.ClusterID)
-			if channelMappingSourceCluster == nil {
-				return nil, status.NewReplicateViolation("source cluster %s not found in new replicate configuration", rh.ClusterID)
 			}
 		}
 	}
 
+	// Main vchannel mapping stays strict even when currentClusterRemoved is true.
+	// CDC only forwards messages from OLD source pchannels (those that already had a
+	// replicator targeting the current cluster before the topology change), so
+	// msg.VChannel() is always an OLD pchannel the current cluster knows about. A
+	// failure here would indicate a CDC topology-sync bug, not a config-rewrite case.
 	targetVChannel, err := s.getTargetVChannel(channelMappingSourceCluster, msg.VChannel())
 	if err != nil {
 		return nil, err
@@ -161,6 +176,13 @@ func (s replicateService) overwriteReplicateMessage(ctx context.Context, msg mes
 		for _, vchannel := range bh.VChannels {
 			targetBroadcastVChannel, err := s.getTargetVChannel(channelMappingSourceCluster, vchannel)
 			if err != nil {
+				if currentClusterRemoved {
+					// This broadcast vchannel maps to a source pchannel the current cluster
+					// doesn't know about (a source-side newly-added pchannel). Skip it — the
+					// current cluster is becoming standalone and only needs to write to
+					// pchannels it actually has.
+					continue
+				}
 				return nil, status.NewReplicateViolation("failed to get target channel, %s", err.Error())
 			}
 			targetBroadcastVChannels = append(targetBroadcastVChannels, targetBroadcastVChannel)

--- a/internal/distributed/streaming/replicate_service_test.go
+++ b/internal/distributed/streaming/replicate_service_test.go
@@ -724,7 +724,17 @@ func TestReplicateService_AlterConfigPChannelIncreasing(t *testing.T) {
 				},
 			},
 		), nil)
-		as.EXPECT().GetLatestAssignments(mock.Anything).Return(nil, errors.New("not needed")).Maybe()
+		as.EXPECT().GetLatestAssignments(mock.Anything).Return(&types.VersionedStreamingNodeAssignments{
+			Assignments: map[int64]types.StreamingNodeAssignment{
+				1: {
+					Channels: map[string]types.PChannelInfo{
+						"by-dev-rootcoord-dml_0": {Name: "by-dev-rootcoord-dml_0", Term: 1, AccessMode: types.AccessModeRW},
+						"by-dev-rootcoord-dml_1": {Name: "by-dev-rootcoord-dml_1", Term: 1, AccessMode: types.AccessModeRW},
+						"by-dev-rootcoord-dml_2": {Name: "by-dev-rootcoord-dml_2", Term: 1, AccessMode: types.AccessModeRW},
+					},
+				},
+			},
+		}, nil).Maybe()
 
 		rs := &replicateService{
 			walAccesserImpl: &walAccesserImpl{
@@ -771,6 +781,10 @@ func TestReplicateService_AlterConfigPChannelIncreasing(t *testing.T) {
 			cfg := alter.Header().GetReplicateConfiguration()
 			assert.Len(t, cfg.GetClusters(), 1, "rewritten config must contain only the current cluster")
 			assert.Equal(t, "by-dev", cfg.GetClusters()[0].GetClusterId())
+			assert.Equal(t,
+				[]string{"by-dev-rootcoord-dml_0", "by-dev-rootcoord-dml_1", "by-dev-rootcoord-dml_2"},
+				cfg.GetClusters()[0].GetPchannels(),
+				"rewritten config must use the receiver's latest local pchannels")
 			assert.Empty(t, cfg.GetCrossClusterTopology(), "rewritten config must have no topology")
 
 			bh := mm.BroadcastHeader()

--- a/internal/distributed/streaming/replicate_service_test.go
+++ b/internal/distributed/streaming/replicate_service_test.go
@@ -3,6 +3,7 @@ package streaming
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/apache/pulsar-client-go/pulsar"
@@ -680,6 +681,107 @@ func TestReplicateService_AlterConfigPChannelIncreasing(t *testing.T) {
 			_, err := rs.Append(context.Background(), msg)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "source cluster primary not found in new replicate configuration")
+		}
+	})
+
+	t.Run("with_flag_current_cluster_removed_falls_through_to_standalone", func(t *testing.T) {
+		// Scenario: primary issues UpdateReplicateConfiguration that simultaneously
+		// (a) increases its own pchannel count (sets IsPchannelIncreasing=true) and
+		// (b) removes the secondary "by-dev" from the topology.
+		// The receiver (this secondary) must NOT fail; it should fall through to
+		// overwriteAlterReplicateConfigMessage and become standalone primary.
+		c := mock_client.NewMockClient(t)
+		as := mock_client.NewMockAssignmentService(t)
+		c.EXPECT().Assignment().Return(as).Maybe()
+
+		h := mock_handler.NewMockHandlerClient(t)
+		p := mock_producer.NewMockProducer(t)
+		var captured []message.MutableMessage
+		var capturedMu sync.Mutex
+		p.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, mm message.MutableMessage) (*types.AppendResult, error) {
+			capturedMu.Lock()
+			captured = append(captured, mm)
+			capturedMu.Unlock()
+			return &types.AppendResult{
+				MessageID: walimplstest.NewTestMessageID(1),
+				TimeTick:  1,
+			}, nil
+		}).Maybe()
+		p.EXPECT().IsAvailable().Return(true).Maybe()
+		p.EXPECT().Available().Return(make(chan struct{})).Maybe()
+		h.EXPECT().CreateProducer(mock.Anything, mock.Anything).Return(p, nil).Maybe()
+
+		// Current config: primary + by-dev (secondary), both 2 pchannels, primary→by-dev
+		as.EXPECT().GetReplicateConfiguration(mock.Anything).Return(replicateutil.MustNewConfigHelper(
+			"by-dev",
+			&commonpb.ReplicateConfiguration{
+				Clusters: []*commonpb.MilvusCluster{
+					{ClusterId: "primary", Pchannels: []string{"primary-rootcoord-dml_0", "primary-rootcoord-dml_1"}},
+					{ClusterId: "by-dev", Pchannels: []string{"by-dev-rootcoord-dml_0", "by-dev-rootcoord-dml_1"}},
+				},
+				CrossClusterTopology: []*commonpb.CrossClusterTopology{
+					{SourceClusterId: "primary", TargetClusterId: "by-dev"},
+				},
+			},
+		), nil)
+		as.EXPECT().GetLatestAssignments(mock.Anything).Return(nil, errors.New("not needed")).Maybe()
+
+		rs := &replicateService{
+			walAccesserImpl: &walAccesserImpl{
+				lifetime:             typeutil.NewLifetime(),
+				clusterID:            "by-dev",
+				streamingCoordClient: c,
+				handlerClient:        h,
+				producers:            make(map[string]*producer.ResumableProducer),
+			},
+		}
+
+		// New config: primary only, 3 pchannels (grew from 2 → 3), no topology.
+		// "by-dev" is removed entirely.
+		newConfig := &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "primary", Pchannels: []string{"primary-rootcoord-dml_0", "primary-rootcoord-dml_1", "primary-rootcoord-dml_2"}},
+			},
+		}
+
+		// Broadcast covers all 3 of primary's pchannels (2 OLD + 1 NEW). IsPchannelIncreasing=true.
+		// SplitIntoMutableMessage produces one message per broadcast vchannel.
+		replicateMsgs := createReplicateAlterConfigMessages(newConfig,
+			[]string{"primary-rootcoord-dml_0", "primary-rootcoord-dml_1", "primary-rootcoord-dml_2"},
+			true)
+
+		for _, msg := range replicateMsgs {
+			// In production, only OLD-source-pchannel CDC replicators forward to the
+			// being-removed secondary. The newly-added source pchannel
+			// (primary-rootcoord-dml_2) has no replicator targeting "by-dev" because
+			// the new topology drops by-dev. Skip it here to mirror reality.
+			if msg.VChannel() == "primary-rootcoord-dml_2" {
+				continue
+			}
+			_, err := rs.Append(context.Background(), msg)
+			assert.NoError(t, err, "secondary being removed must not fail; should fall through to standalone conversion")
+		}
+
+		// Verify each appended message has the header rewritten to standalone primary
+		// (only the secondary's own cluster, no topology) AND broadcast vchannels filtered
+		// to drop the source's newly-added pchannel.
+		assert.NotEmpty(t, captured)
+		for _, mm := range captured {
+			alter := message.MustAsMutableAlterReplicateConfigMessageV2(mm)
+			cfg := alter.Header().GetReplicateConfiguration()
+			assert.Len(t, cfg.GetClusters(), 1, "rewritten config must contain only the current cluster")
+			assert.Equal(t, "by-dev", cfg.GetClusters()[0].GetClusterId())
+			assert.Empty(t, cfg.GetCrossClusterTopology(), "rewritten config must have no topology")
+
+			bh := mm.BroadcastHeader()
+			assert.NotNil(t, bh)
+			// 2 OLD source pchannels → mapped to by-dev's 2 pchannels.
+			// 1 NEW source pchannel (primary-rootcoord-dml_2) → filtered out (by-dev has no equivalent).
+			assert.Len(t, bh.VChannels, 2, "broadcast vchannels must drop unmappable (newly-added source) pchannels")
+			for _, vch := range bh.VChannels {
+				assert.True(t, strings.HasPrefix(vch, "by-dev-rootcoord-dml_"),
+					"broadcast vchannels must be remapped to by-dev cluster, got %s", vch)
+			}
 		}
 	})
 }

--- a/pkg/streaming/util/message/builder_test.go
+++ b/pkg/streaming/util/message/builder_test.go
@@ -130,3 +130,67 @@ func TestReplicateBuilder(t *testing.T) {
 	assert.Equal(t, []string{"v11", "v12"}, replicateMsg.BroadcastHeader().VChannels)
 	assert.Equal(t, uint64(1), replicateMsg.BroadcastHeader().BroadcastID)
 }
+
+// newReplicateMessageForOverwriteTest builds a replicate message whose broadcast
+// header contains 3 vchannels ("v0", "v1", "v2"), suitable for exercising the
+// OverwriteReplicateVChannel length contract (shrink/equal/grow).
+func newReplicateMessageForOverwriteTest(t *testing.T) message.ReplicateMutableMessage {
+	msg := message.NewManualFlushMessageBuilderV2().
+		WithHeader(&message.ManualFlushMessageHeader{}).
+		WithBody(&message.ManualFlushMessageBody{}).
+		WithBroadcast([]string{"v0", "v1", "v2"}).
+		MustBuildBroadcast()
+
+	msgs := msg.WithBroadcastID(1).SplitIntoMutableMessage()
+
+	msgID := walimplstest.NewTestMessageID(1)
+	var immutableMsg message.ImmutableMessage
+	for _, m := range msgs {
+		if m.VChannel() == "v0" {
+			immutableMsg = m.WithTimeTick(100).WithLastConfirmed(msgID).IntoImmutableMessage(msgID)
+			break
+		}
+	}
+	require.NotNil(t, immutableMsg)
+
+	replicateMsg := message.MustNewReplicateMessage("by-dev", immutableMsg.IntoImmutableMessageProto())
+	require.NotNil(t, replicateMsg)
+	return replicateMsg
+}
+
+// TestOverwriteReplicateVChannel_BroadcastVChannelsLength validates the relaxed
+// contract of OverwriteReplicateVChannel: shrinking and equal-length overwrites
+// must succeed, while growing the broadcast vchannel set must panic.
+//
+// This guards the CDC topology-change path where an AlterReplicateConfig may
+// drop pchannels from the broadcast set (receiver filters out source pchannels
+// it doesn't have).
+func TestOverwriteReplicateVChannel_BroadcastVChannelsLength(t *testing.T) {
+	// Shrink: 3 -> 1.
+	t.Run("shrink", func(t *testing.T) {
+		replicateMsg := newReplicateMessageForOverwriteTest(t)
+		assert.NotPanics(t, func() {
+			replicateMsg.OverwriteReplicateVChannel("new-v0", []string{"new-v0"})
+		})
+		assert.Equal(t, "new-v0", replicateMsg.VChannel())
+		assert.Equal(t, []string{"new-v0"}, replicateMsg.BroadcastHeader().VChannels)
+	})
+
+	// Equal length: 3 -> 3.
+	t.Run("equal", func(t *testing.T) {
+		replicateMsg := newReplicateMessageForOverwriteTest(t)
+		assert.NotPanics(t, func() {
+			replicateMsg.OverwriteReplicateVChannel("new-v0", []string{"new-v0", "new-v1", "new-v2"})
+		})
+		assert.Equal(t, "new-v0", replicateMsg.VChannel())
+		assert.Equal(t, []string{"new-v0", "new-v1", "new-v2"}, replicateMsg.BroadcastHeader().VChannels)
+	})
+
+	// Grow: 3 -> 4. Must panic with the exact message.
+	t.Run("grow_panics", func(t *testing.T) {
+		replicateMsg := newReplicateMessageForOverwriteTest(t)
+		assert.PanicsWithValue(t, "broadcast vchannels length cannot grow", func() {
+			replicateMsg.OverwriteReplicateVChannel("new-v0", []string{"new-v0", "new-v1", "new-v2", "new-v3"})
+		})
+	})
+}

--- a/pkg/streaming/util/message/message_impl.go
+++ b/pkg/streaming/util/message/message_impl.go
@@ -195,8 +195,12 @@ func (m *messageImpl) OverwriteReplicateVChannel(vchannel string, broadcastVChan
 		panic("broadcast vchannels not set when overwrite replicate vchannel")
 	}
 	bh := m.broadcastHeader()
-	if len(bh.Vchannels) != len(broadcastVChannels[0]) {
-		panic("broadcast vchannels length mismatch")
+	// Allow shrinking the broadcast vchannels (e.g. when a replicated
+	// AlterReplicateConfig removes the current cluster from the topology while also
+	// adding new pchannels — the receiver filters out source pchannels it doesn't have).
+	// Growing the broadcast set is still forbidden — callers must not invent vchannels.
+	if len(broadcastVChannels[0]) > len(bh.Vchannels) {
+		panic("broadcast vchannels length cannot grow")
 	}
 	bh.Vchannels = broadcastVChannels[0]
 	bhVal, err := EncodeProto(bh)

--- a/pkg/util/replicateutil/config_validator_test.go
+++ b/pkg/util/replicateutil/config_validator_test.go
@@ -1146,4 +1146,33 @@ func TestReplicateConfigValidator_PChannelIncreasing(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, validator.IsPChannelIncreasing())
 	})
+
+	t.Run("success - secondary removed during pchannel increase (PR #49083 + receiver-side fix)", func(t *testing.T) {
+		// Source is primary "c1", secondary is "c2". Primary increases pchannels from
+		// 1 → 2 AND drops c2 from the topology. The validator must accept this; the
+		// receiver-side overwriteReplicateMessage in internal/distributed/streaming
+		// handles the cluster-removal-during-pchannel-increase scenario by falling
+		// through to overwriteAlterReplicateConfigMessage and converting the removed
+		// secondary into a standalone primary.
+		currentConfig := &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				makeCluster("c1", "localhost:19530", []string{"ch-1"}),
+				makeCluster("c2", "localhost:19531", []string{"ch-1"}),
+			},
+			CrossClusterTopology: []*commonpb.CrossClusterTopology{
+				{SourceClusterId: "c1", TargetClusterId: "c2"},
+			},
+		}
+		incomingConfig := &commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				makeCluster("c1", "localhost:19530", []string{"ch-1", "ch-2"}),
+				// c2 removed, no topology
+			},
+		}
+		// Validator runs on the primary side, so currentClusterID = "c1".
+		validator := NewReplicateConfigValidator(incomingConfig, currentConfig, "c1", []string{"ch-1", "ch-2"})
+		err := validator.Validate()
+		assert.NoError(t, err, "validator must permit cluster-removal + pchannel-increase (handled by receiver)")
+		assert.True(t, validator.IsPChannelIncreasing(), "IsPChannelIncreasing flag must still be set so receiver takes the right branch")
+	})
 }


### PR DESCRIPTION
## Summary
- Secondary clusters being removed by an `AlterReplicateConfig` with `IsPchannelIncreasing=true` previously hit `ErrCurrentClusterNotFound` in `overwriteReplicateMessage` and entered an infinite CDC retry loop (~235 log lines/sec, ~847K/hour observed in production on v2.6.16+).
- Tolerate `ErrCurrentClusterNotFound` in the `IsPchannelIncreasing` branch; filter unmappable broadcast vchannels in that case only; relax `OverwriteReplicateVChannel`'s length check from strict equality to "must not grow" so the filtered list can be applied. The existing `overwriteAlterReplicateConfigMessage` graceful path then converts the secondary to standalone-primary.
- When a pchannel-increasing config also removes the current cluster, rewrite the receiver's standalone config with the receiver's latest local pchannels. The CDC-forwarded config remains the authority for the expected pchannel count, while the local assignment is the source of truth for the receiver's channel names.
- Adds covering unit tests in `replicate_service_test.go`, `builder_test.go`, and `config_validator_test.go`.

## Background
PR #49083 removed the `validatePChannelIncreasingConstraints` validator that blocked combining pchannel-increase with cluster-set/topology changes, on the assumption that downstream consumers handle the combinations. That assumption held for cluster *additions* but not for cluster *removals* — the receiver-side fast-path at `internal/distributed/streaming/replicate_service.go:140-152` short-circuited before the graceful "current cluster removed → become standalone" handler could run.

A follow-up issue was found while testing the intended symmetric update flow: after A removed B with `{A,17p}`, B could rewrite itself to standalone with its stale `{B,16p}` config. That made B's own `{B,17p}` update wait until timeout. The receiver now waits for local assignments to reach the pchannel count from the CDC-forwarded config before persisting the rewritten standalone config, so both symmetric update (M2) and source-only CDC removal (M5) converge to `{B,17p}`.

## Test plan
- [x] `make static-check`
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/distributed/streaming/...` (TestForwardDMLToLegacyProxy excluded — pre-existing env requirement)
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" ./pkg/util/replicateutil/...`
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" ./pkg/streaming/util/message/...`
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/streamingnode/server/wal/interceptors/replicate/... ./internal/cdc/...`
- [x] Targeted golangci-lint clean on all changed packages
- [x] CDC matrix M2: pchannel increase 16→17 + symmetric remove B, both standalone 17p
- [x] CDC matrix M5: pchannel increase 16→17 + A-only remove B, B observed standalone 17p

issue: #50041