### PR TITLE
enhance: abort packed writers on failed v3 storage writes

### DIFF
--- a/internal/flushcommon/syncmgr/pack_writer_v3.go
+++ b/internal/flushcommon/syncmgr/pack_writer_v3.go
@@ -45,6 +45,7 @@ import (
 // and packedTextManifestWriter used for V3 storage writes.
 type manifestRecordWriter interface {
 	storage.RecordWriter
+	Abort() error
 	GetColumnGroupWrittenCompressed(columnGroup typeutil.UniqueID) uint64
 	GetColumnGroupWrittenUncompressed(columnGroup typeutil.UniqueID) uint64
 	GetWrittenPaths(columnGroup typeutil.UniqueID) string
@@ -238,15 +239,29 @@ func (bw *BulkPackWriterV3) writeInsertsIntoStorage(ctx context.Context,
 	columnGroups := bw.columnGroups
 
 	var err error
-	doWrite := func(w manifestRecordWriter) error {
-		if err = w.Write(rec); err != nil {
-			if closeErr := w.Close(); closeErr != nil {
-				log.Error("failed to close writer after write failed", zap.Error(closeErr))
+	doWrite := func(w manifestRecordWriter) (err error) {
+		closed := false
+		defer func() {
+			if closed {
+				return
 			}
+			if abortErr := w.Abort(); abortErr != nil {
+				log.Error("failed to abort writer before close",
+					zap.Error(abortErr),
+					zap.NamedError("originalError", err))
+				if err == nil {
+					err = abortErr
+				}
+			}
+		}()
+
+		if err = w.Write(rec); err != nil {
 			return err
 		}
 		// close first the get stats & output
-		return w.Close()
+		err = w.Close()
+		closed = true
+		return err
 	}
 
 	var manifestPath string

--- a/internal/storage/record_writer.go
+++ b/internal/storage/record_writer.go
@@ -260,7 +260,10 @@ func (pw *packedRecordManifestWriter) GetWrittenRowNum() int64 {
 
 func (pw *packedRecordManifestWriter) Close() error {
 	if pw.writer != nil {
-		manifest, err := pw.writer.Close()
+		writer := pw.writer
+		pw.writer = nil
+
+		manifest, err := writer.Close()
 		if err != nil {
 			return err
 		}
@@ -270,6 +273,16 @@ func (pw *packedRecordManifestWriter) Close() error {
 		}
 	}
 	return nil
+}
+
+func (pw *packedRecordManifestWriter) Abort() error {
+	if pw.writer == nil {
+		return nil
+	}
+
+	writer := pw.writer
+	pw.writer = nil
+	return writer.Abort()
 }
 
 func NewPackedRecordManifestWriter(
@@ -421,8 +434,10 @@ func (pw *packedTextManifestWriter) GetWrittenRowNum() int64 {
 
 func (pw *packedTextManifestWriter) Close() error {
 	if pw.writer != nil {
-		defer pw.writer.Destroy()
-		result, err := pw.writer.Close()
+		writer := pw.writer
+		pw.writer = nil
+
+		result, err := writer.Close()
 		if err != nil {
 			return err
 		}
@@ -433,6 +448,16 @@ func (pw *packedTextManifestWriter) Close() error {
 		}
 	}
 	return nil
+}
+
+func (pw *packedTextManifestWriter) Abort() error {
+	if pw.writer == nil {
+		return nil
+	}
+
+	writer := pw.writer
+	pw.writer = nil
+	return writer.Abort()
 }
 
 // NewPackedTextManifestWriter creates a new writer that uses FFISegmentWriter with TEXT column support.

--- a/internal/storagev2/packed/packed_writer_ffi.go
+++ b/internal/storagev2/packed/packed_writer_ffi.go
@@ -140,6 +140,7 @@ func NewFFIPackedWriter(basePath string, baseVersion int64, schema *arrow.Schema
 
 	err = HandleLoonFFIResult(result)
 	if err != nil {
+		C.loon_properties_free(cProperties)
 		return nil, err
 	}
 
@@ -176,10 +177,43 @@ func (pw *FFIPackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
 	return HandleLoonFFIResult(result)
 }
 
+// Abort closes the underlying writer and releases resources without committing
+// the returned column groups to the manifest.
+func (pw *FFIPackedWriter) Abort() error {
+	defer func() {
+		if pw.cWriterHandle != 0 {
+			C.loon_writer_destroy(pw.cWriterHandle)
+			pw.cWriterHandle = 0
+		}
+		if pw.cProperties != nil {
+			C.loon_properties_free(pw.cProperties)
+			pw.cProperties = nil
+		}
+	}()
+
+	var cColumnGroups *C.LoonColumnGroups
+	result := C.loon_writer_close(pw.cWriterHandle, nil, nil, 0, &cColumnGroups)
+	defer C.loon_column_groups_destroy(cColumnGroups)
+
+	return HandleLoonFFIResult(result)
+}
+
 func (pw *FFIPackedWriter) Close() (string, error) {
+	defer func() {
+		if pw.cWriterHandle != 0 {
+			C.loon_writer_destroy(pw.cWriterHandle)
+			pw.cWriterHandle = 0
+		}
+		if pw.cProperties != nil {
+			C.loon_properties_free(pw.cProperties)
+			pw.cProperties = nil
+		}
+	}()
+
 	var cColumnGroups *C.LoonColumnGroups
 
 	result := C.loon_writer_close(pw.cWriterHandle, nil, nil, 0, &cColumnGroups)
+	defer C.loon_column_groups_destroy(cColumnGroups)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return "", err
 	}
@@ -222,6 +256,5 @@ func (pw *FFIPackedWriter) Close() (string, error) {
 
 	log.Info("FFI writer closed", zap.Int64("version", int64(cCommitVersion)))
 
-	defer C.loon_properties_free(pw.cProperties)
 	return MarshalManifestPath(pw.basePath, int64(cCommitVersion)), nil
 }

--- a/internal/storagev2/packed/segment_writer_ffi.go
+++ b/internal/storagev2/packed/segment_writer_ffi.go
@@ -133,14 +133,29 @@ func (w *FFISegmentWriter) Flush() error {
 	return HandleLoonFFIResult(result)
 }
 
+// Abort closes the underlying segment writer and releases resources without
+// registering the returned files in a manifest transaction.
+func (w *FFISegmentWriter) Abort() error {
+	defer w.Destroy()
+
+	var cOutput C.LoonSegmentWriteOutput
+	result := C.loon_segment_writer_close(w.handle, &cOutput)
+	defer freeSegmentWriteOutput(&cOutput)
+
+	return HandleLoonFFIResult(result)
+}
+
 // Close closes the writer and commits the manifest via Transaction.
 // Returns SegmentWriterResult with the committed manifest path.
 // Pattern matches FFIPackedWriter.Close(): C++ writer returns ColumnGroups + LobFiles,
 // Go layer handles Transaction begin → append_files → add_lob_files → commit.
 func (w *FFISegmentWriter) Close() (*SegmentWriterResult, error) {
+	defer w.Destroy()
+
 	var cOutput C.LoonSegmentWriteOutput
 
 	result := C.loon_segment_writer_close(w.handle, &cOutput)
+	defer freeSegmentWriteOutput(&cOutput)
 	if err := HandleLoonFFIResult(result); err != nil {
 		return nil, err
 	}
@@ -184,14 +199,22 @@ func (w *FFISegmentWriter) Close() (*SegmentWriterResult, error) {
 		return nil, err
 	}
 
-	// free C output (LOB file strings + array)
-	C.loon_segment_write_output_free(&cOutput)
-
 	return &SegmentWriterResult{
 		ManifestPath:     MarshalManifestPath(w.basePath, int64(cCommitVersion)),
 		CommittedVersion: int64(cCommitVersion),
 		RowsWritten:      rowsWritten,
 	}, nil
+}
+
+func freeSegmentWriteOutput(output *C.LoonSegmentWriteOutput) {
+	if output == nil {
+		return
+	}
+	if output.column_groups != nil {
+		C.loon_column_groups_destroy(output.column_groups)
+		output.column_groups = nil
+	}
+	C.loon_segment_write_output_free(output)
 }
 
 // Destroy destroys the writer and releases resources.


### PR DESCRIPTION
issue: #49931

V3 storage writes need to clean up writer state differently when the write path fails. Previously, a failed write still tried to close the manifest writer, which made the failure path look too much like a successful commit path and could leave partial packed output or native resources around longer than intended.

This change adds an explicit abort flow for the packed manifest writers. Successful writes still close normally and collect manifest output, while failed writes now abort the underlying FFI writer and skip manifest registration. The record and text manifest writers also clear their writer references after close or abort, so repeated cleanup stays idempotent and does not accidentally reuse a closed native handle.

The FFI writers now own their cleanup more consistently. Close and Abort both release native handles, column group output, segment write output, and writer properties through the same lifecycle, including constructor error paths. That keeps packed writer resource management aligned across normal commits, failed writes, and early aborts.