### PR TITLE
fix: align azure address uri with milvus-storage

### DIFF
--- a/internal/core/src/storage/loon_ffi/util.cpp
+++ b/internal/core/src/storage/loon_ffi/util.cpp
@@ -48,21 +48,10 @@ MakePropertiesFromStorageConfig(CStorageConfig c_storage_config) {
     std::vector<const char*> keys;
     std::vector<const char*> values;
 
-    // Lance's BuildEndpointUrl defaults to HTTPS when no scheme is present.
-    // Prepend http:// when SSL is not enabled so that Lance sets allow_http=true.
-    std::string fs_address;
-    if (c_storage_config.address != nullptr) {
-        fs_address = c_storage_config.address;
-        if (!c_storage_config.useSSL &&
-            fs_address.find("://") == std::string::npos) {
-            fs_address = "http://" + fs_address;
-        }
-    }
-
     // Add non-null string fields
     if (c_storage_config.address != nullptr) {
         keys.emplace_back(PROPERTY_FS_ADDRESS);
-        values.emplace_back(fs_address.c_str());
+        values.emplace_back(c_storage_config.address);
     }
     if (c_storage_config.bucket_name != nullptr) {
         keys.emplace_back(PROPERTY_FS_BUCKET_NAME);
@@ -168,21 +157,10 @@ std::shared_ptr<milvus_storage::api::Properties>
 MakeInternalPropertiesFromStorageConfig(CStorageConfig c_storage_config) {
     auto properties_map = std::make_shared<milvus_storage::api::Properties>();
 
-    // Lance's BuildEndpointUrl defaults to HTTPS when no scheme is present.
-    // Prepend http:// when SSL is not enabled so that Lance sets allow_http=true.
-    std::string fs_address_internal;
-    if (c_storage_config.address != nullptr) {
-        fs_address_internal = c_storage_config.address;
-        if (!c_storage_config.useSSL &&
-            fs_address_internal.find("://") == std::string::npos) {
-            fs_address_internal = "http://" + fs_address_internal;
-        }
-    }
-
     // Add non-null string fields
     if (c_storage_config.address != nullptr) {
         milvus_storage::api::SetValue(
-            *properties_map, PROPERTY_FS_ADDRESS, fs_address_internal.c_str());
+            *properties_map, PROPERTY_FS_ADDRESS, c_storage_config.address);
     }
     if (c_storage_config.bucket_name != nullptr) {
         milvus_storage::api::SetValue(*properties_map,

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -29,7 +29,6 @@ import "C"
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"unsafe"
 
 	"go.uber.org/zap"
@@ -106,9 +105,6 @@ func makePropertiesFromConfig(storageConfig *indexpb.StorageConfig) (C.LoonPrope
 	var values []string
 
 	if addr := storageConfig.GetAddress(); addr != "" {
-		if !storageConfig.GetUseSSL() && !strings.Contains(addr, "://") {
-			addr = "http://" + addr
-		}
 		keys = append(keys, propAddress)
 		values = append(values, addr)
 	}

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -381,58 +381,6 @@ func TestCreateSegmentManifestWithBasePath_CanceledContext(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
-func TestEnsureHTTPScheme(t *testing.T) {
-	tests := []struct {
-		name    string
-		address string
-		useSSL  bool
-		want    string
-	}{
-		{
-			name:    "no scheme, no SSL → prepend http://",
-			address: "localhost:9000",
-			useSSL:  false,
-			want:    "http://localhost:9000",
-		},
-		{
-			name:    "no scheme, with SSL → prepend https://",
-			address: "localhost:9000",
-			useSSL:  true,
-			want:    "https://localhost:9000",
-		},
-		{
-			name:    "has http:// scheme, no SSL → keep as-is",
-			address: "http://localhost:9000",
-			useSSL:  false,
-			want:    "http://localhost:9000",
-		},
-		{
-			name:    "has https:// scheme, no SSL → keep as-is",
-			address: "https://s3.amazonaws.com",
-			useSSL:  false,
-			want:    "https://s3.amazonaws.com",
-		},
-		{
-			name:    "has https:// scheme, with SSL → keep as-is",
-			address: "https://s3.amazonaws.com",
-			useSSL:  true,
-			want:    "https://s3.amazonaws.com",
-		},
-		{
-			name:    "IP address, no SSL → prepend http://",
-			address: "10.0.0.1:9000",
-			useSSL:  false,
-			want:    "http://10.0.0.1:9000",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := ensureHTTPScheme(tt.address, tt.useSSL)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 // The cgo bridge (loon_properties_inject_external_spec) and Tier-1/2 endpoint
 // derivation logic are covered by the C++ gtest suite in test_external_take.cpp.
 // Go-side coverage is exercised indirectly through callers that invoke

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
@@ -68,18 +67,6 @@ var (
 	PropertyWriterEncAlgo   = C.GoString(C.loon_properties_writer_enc_algorithm) // Encryption algorithm (e.g., "AES_GCM_V1")
 )
 
-// ensureHTTPScheme prepends http:// or https:// to a bare address so it stays
-// consistent with use_ssl; leaves addresses that already carry a scheme alone.
-func ensureHTTPScheme(address string, useSSL bool) string {
-	if strings.Contains(address, "://") {
-		return address
-	}
-	if useSSL {
-		return "https://" + address
-	}
-	return "http://" + address
-}
-
 // ExtfsPrefixForCollection returns the per-collection extfs property prefix.
 func ExtfsPrefixForCollection(collectionID int64) string {
 	return fmt.Sprintf("extfs.%d.", collectionID)
@@ -101,7 +88,7 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 	// Add non-empty string fields
 	if storageConfig.GetAddress() != "" {
 		keys = append(keys, PropertyFSAddress)
-		values = append(values, ensureHTTPScheme(storageConfig.GetAddress(), storageConfig.GetUseSSL()))
+		values = append(values, storageConfig.GetAddress())
 	}
 	if storageConfig.GetBucketName() != "" {
 		keys = append(keys, PropertyFSBucketName)


### PR DESCRIPTION
issue: #49931
Azure needs a slightly different endpoint shape than S3-compatible storage when the packed storage path builds properties for Loon. The old flow treated every provider the same and always converted the address into a full HTTP(S) URI, which works for S3 and MinIO but does not match the Azure address format expected by milvus-storage.

This change makes the provider-specific normalization explicit at the FFI boundary. Non-Azure storage keeps the existing useSSL based scheme handling, while Azure addresses are passed as a bare authority by stripping any http:// or https:// prefix from user config. This keeps Azure compatible with milvus-storage without changing the behavior for other object storage providers.