### PR TITLE
fix: allow cdc replicate system messages

### DIFF
--- a/internal/distributed/streaming/replicate_service.go
+++ b/internal/distributed/streaming/replicate_service.go
@@ -53,8 +53,7 @@ func (s replicateService) Append(ctx context.Context, rmsg message.ReplicateMuta
 	if err != nil {
 		return nil, err
 	}
-	resp := s.AppendMessages(ctx, msg)
-	return resp.Responses[0].AppendResult, resp.Responses[0].Error
+	return s.appendReplicateMessageToWAL(ctx, msg)
 }
 
 func (s replicateService) UpdateReplicateConfiguration(ctx context.Context, req *milvuspb.UpdateReplicateConfigurationRequest) error {

--- a/internal/distributed/streaming/replicate_service_test.go
+++ b/internal/distributed/streaming/replicate_service_test.go
@@ -90,6 +90,68 @@ func TestReplicateService(t *testing.T) {
 	}
 }
 
+func TestReplicateServiceAppendTxnSystemMessage(t *testing.T) {
+	c := mock_client.NewMockClient(t)
+	as := mock_client.NewMockAssignmentService(t)
+	c.EXPECT().Assignment().Return(as).Maybe()
+
+	h := mock_handler.NewMockHandlerClient(t)
+	p := mock_producer.NewMockProducer(t)
+	var appended bool
+	p.EXPECT().Append(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, mm message.MutableMessage) (*types.AppendResult, error) {
+		appended = true
+		assert.Equal(t, message.MessageTypeBeginTxn, mm.MessageType())
+		assert.Equal(t, "by-dev-rootcoord-dml_0_1v0", mm.VChannel())
+		return &types.AppendResult{
+			MessageID: walimplstest.NewTestMessageID(1),
+			TimeTick:  1,
+		}, nil
+	}).Maybe()
+	p.EXPECT().IsAvailable().Return(true).Maybe()
+	p.EXPECT().Available().Return(make(chan struct{})).Maybe()
+	h.EXPECT().CreateProducer(mock.Anything, mock.Anything).Return(p, nil).Maybe()
+
+	as.EXPECT().GetReplicateConfiguration(mock.Anything).Return(replicateutil.MustNewConfigHelper(
+		"by-dev",
+		&commonpb.ReplicateConfiguration{
+			Clusters: []*commonpb.MilvusCluster{
+				{ClusterId: "primary", Pchannels: []string{"primary-rootcoord-dml_0"}},
+				{ClusterId: "by-dev", Pchannels: []string{"by-dev-rootcoord-dml_0"}},
+			},
+			CrossClusterTopology: []*commonpb.CrossClusterTopology{
+				{SourceClusterId: "primary", TargetClusterId: "by-dev"},
+			},
+		},
+	), nil)
+
+	rs := &replicateService{
+		walAccesserImpl: &walAccesserImpl{
+			lifetime:             typeutil.NewLifetime(),
+			clusterID:            "by-dev",
+			streamingCoordClient: c,
+			handlerClient:        h,
+			producers:            make(map[string]*producer.ResumableProducer),
+		},
+	}
+
+	beginMsg := message.NewBeginTxnMessageBuilderV2().
+		WithHeader(&message.BeginTxnMessageHeader{}).
+		WithBody(&message.BeginTxnMessageBody{}).
+		WithVChannel("primary-rootcoord-dml_0_1v0").
+		MustBuildMutable()
+	immutableMsg := beginMsg.WithLastConfirmedUseMessageID().WithTimeTick(1).IntoImmutableMessage(pulsar2.NewPulsarID(
+		pulsar.NewMessageID(1, 2, 3, 4),
+	))
+	replicateMsg := message.MustNewReplicateMessage("primary", immutableMsg.IntoImmutableMessageProto())
+
+	var err error
+	assert.NotPanics(t, func() {
+		_, err = rs.Append(context.Background(), replicateMsg)
+	})
+	assert.NoError(t, err)
+	assert.True(t, appended)
+}
+
 func TestReplicateService_GetReplicateConfiguration(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		c := mock_client.NewMockClient(t)

--- a/internal/distributed/streaming/util.go
+++ b/internal/distributed/streaming/util.go
@@ -70,6 +70,15 @@ func (w *walAccesserImpl) AppendMessages(ctx context.Context, msgs ...message.Mu
 	return resp
 }
 
+func (w *walAccesserImpl) appendReplicateMessageToWAL(ctx context.Context, msg message.MutableMessage) (*types.AppendResult, error) {
+	guard, err := w.getProducer(msg.VChannel()).BeginProduce(ctx, msg)
+	if err != nil {
+		return nil, err
+	}
+	resp := producer.BatchCommitProduce(ctx, guard)
+	return resp.Responses[0].AppendResult, resp.Responses[0].Error
+}
+
 // dispatchMessages dispatches the messages into different vchannel.
 func (w *walAccesserImpl) dispatchMessages(msgs ...message.MutableMessage) (map[string][]message.MutableMessage, map[string][]int) {
 	dispatchedMessages := make(map[string][]message.MutableMessage, 0)


### PR DESCRIPTION
## Summary

Fixes #50045

CDC replicate append is an internal replay path and can legitimately receive system messages such as `BeginTxn` and `CommitTxn`. It should not reuse the ordinary client `AppendMessages` validation path, which rejects system messages before they reach the WAL replicate handling path.

This PR adds a dedicated replicate append helper that keeps the producer/rate-limit path but bypasses client-only system-message validation.

## Changes

- Route `replicateService.Append()` through a replicate-specific WAL append helper.
- Keep `AppendMessages()` validation unchanged for normal client appends.
- Add a regression test for replicated `BeginTxn` replay.

## Test Plan

- `PKG_CONFIG_PATH=/Users/yihao.dai/workspace/milvus/.worktrees/pr-50043/internal/core/output/lib/pkgconfig:/Users/yihao.dai/workspace/milvus/.worktrees/pr-50043/internal/core/output/lib64/pkgconfig make static-check`

Note: local static-check required an existing generated `cmd/tools/migration/legacy/legacypb/legacy.pb.go` and matching native `milvus_core` pkgconfig output, both used only as local ignored build/check artifacts.