### PR TITLE
enhance: standardize internal/util/function error handling to merr

### DIFF
--- a/examples/telemetry_e2e_test/go.mod
+++ b/examples/telemetry_e2e_test/go.mod
@@ -1,10 +1,11 @@
 module github.com/milvus-io/milvus/examples/telemetry_e2e_test
+
 go 1.25.8
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c
 	github.com/milvus-io/milvus/client/v2 v2.6.4-0.20251104142533-a2ce70d25256
-	google.golang.org/grpc v1.71.0
+	google.golang.org/grpc v1.79.3
 )
 
 replace (

--- a/examples/telemetry_e2e_test/go.sum
+++ b/examples/telemetry_e2e_test/go.sum
@@ -1,2 +1,4 @@
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=

--- a/internal/coordinator/file_resource_observer.go
+++ b/internal/coordinator/file_resource_observer.go
@@ -18,6 +18,7 @@ package coordinator
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -165,7 +166,7 @@ func (m *FileResourceObserver) CheckNodeSynced(nodeID int64) bool {
 func (m *FileResourceObserver) CheckAllQnReady() error {
 	// return error if meta is not ready
 	if m.meta == nil {
-		return merr.WrapErrParameterInvalidMsg("rootcoord meta is not ready")
+		return merr.WrapErrServiceUnavailable("rootcoord meta is not ready")
 	}
 
 	resources, version := m.meta.ListFileResource(m.ctx)
@@ -177,7 +178,7 @@ func (m *FileResourceObserver) CheckAllQnReady() error {
 	var err error
 	m.distribution.Range(func(nodeID int64, node *NodeInfo) bool {
 		if node.NodeType == QueryNode && node.Version < version {
-			err = merr.WrapErrParameterInvalidMsg("node %d file resource not synced", nodeID)
+			err = merr.WrapErrServiceUnavailable(fmt.Sprintf("node-%d", nodeID), "file resource not synced")
 			return false
 		}
 		return true

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
@@ -131,10 +131,13 @@ async fn download_with_retry(
         for url in urls {
             match client.get(url).send().await {
                 Ok(resp) if resp.status().is_success() => {
-                    let content = resp
-                        .bytes()
-                        .await
-                        .map_err(|e| TantivyBindingError::InternalError(e.to_string()))?;
+                    let content = match resp.bytes().await {
+                        Ok(c) => c,
+                        Err(e) => {
+                            warn!("Failed to read body from {}: {}", url, e);
+                            continue;
+                        }
+                    };
 
                     // Calculate MD5 hash
                     let mut context = Context::new();

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -1129,6 +1129,18 @@ func Test_NewServer_TLS_FileNotExisted(t *testing.T) {
 	server.Stop()
 }
 
+// freeTCPPort grabs a random unused TCP port. The TLS HTTP-server tests
+// below hardcoded port 8080 originally, which collides with anything else
+// already bound to that port on the dev machine (e.g. the TEI text-embedding
+// container in our compose stack).
+func freeTCPPort(t *testing.T) string {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	assert.NoError(t, ln.Close())
+	return strconv.Itoa(port)
+}
+
 func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	server := getServer(t)
 
@@ -1149,7 +1161,7 @@ func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(Params.CaPemPath.Key, "../../../configs/cert/ca.pem")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	assert.Nil(t, err)
@@ -1183,7 +1195,7 @@ func Test_NewHTTPServer_TLS_OneWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../../../configs/cert/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	fmt.Printf("err: %v\n", err)
@@ -1242,7 +1254,7 @@ func Test_NewHTTPServer_TLS_FileNotExisted(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../not/existed/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 	err := runAndWaitForServerReady(server)
 	assert.NotNil(t, err)
 	server.Stop()

--- a/internal/proxy/accesslog/info/grpc_info_test.go
+++ b/internal/proxy/accesslog/info/grpc_info_test.go
@@ -124,7 +124,11 @@ func (s *GrpcAccessInfoSuite) TestErrorType() {
 	result = Get(s.info, "$error_type")
 	s.Equal(merr.InputError.String(), result[0])
 
-	s.info.err = merr.ErrParameterInvalid
+	// ErrServiceInternal is a SystemError-typed sentinel.
+	// (ErrParameterInvalid was previously SystemError but became InputError after
+	// the 02-storage err-std PR; keep this branch on a still-SystemError sentinel
+	// so the test still covers the "system_error" classification path.)
+	s.info.err = merr.ErrServiceInternal
 	result = Get(s.info, "$error_type")
 	s.Equal(merr.SystemError.String(), result[0])
 }

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1421,7 +1421,7 @@ func ValidateUsername(username string) error {
 	}
 
 	if len(username) > Params.ProxyCfg.MaxUsernameLength.GetAsInt() {
-		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetValue())
+		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetAsInt())
 	}
 
 	firstChar := username[0]

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -237,7 +237,7 @@ func (rm *ResourceManager) updateResourceGroups(ctx context.Context, rgs map[str
 				zap.Error(err),
 			)
 		}
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.
@@ -434,7 +434,7 @@ func (rm *ResourceManager) DropResourceGroup(ctx context.Context, rgName string)
 			zap.String("rgName", rgName),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// After recovering, all node assigned to these rg has been removed.
@@ -1050,7 +1050,7 @@ func (rm *ResourceManager) transferNode(ctx context.Context, rgName string, node
 			zap.Int64("node", node),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.

--- a/internal/querynodev2/cluster/manager.go
+++ b/internal/querynodev2/cluster/manager.go
@@ -18,13 +18,13 @@ package cluster
 
 import (
 	context "context"
-	"fmt"
 	"strconv"
 
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -70,7 +70,7 @@ func (m *grpcWorkerManager) GetWorker(ctx context.Context, nodeID int64) (Worker
 	}
 	if !worker.IsHealthy() {
 		// TODO wrap error
-		return nil, fmt.Errorf("node is not healthy: %d", nodeID)
+		return nil, merr.WrapErrNodeNotAvailable(nodeID, "node is not healthy")
 	}
 	return worker, nil
 }

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -440,7 +440,7 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 		log.Warn("delegator received search request not belongs to it",
 			zap.Strings("reqChannels", req.GetDmlChannels()),
 		)
-		return nil, fmt.Errorf("dml channel not match, delegator channel %s, search channels %v", sd.vchannelName, req.GetDmlChannels())
+		return nil, merr.WrapErrChannelMisrouted(sd.vchannelName, fmt.Sprintf("request channels %v", req.GetDmlChannels()))
 	}
 
 	req.Req.GuaranteeTimestamp = sd.speedupGuranteeTS(
@@ -573,14 +573,14 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 func (sd *shardDelegator) QueryStream(ctx context.Context, req *querypb.QueryRequest, srv streamrpc.QueryStreamServer) error {
 	log := sd.getLogger(ctx)
 	if !sd.Serviceable() {
-		return errors.New("delegator is not serviceable")
+		return merr.WrapErrServiceUnavailable("delegator", "not serviceable")
 	}
 
 	if !funcutil.SliceContain(req.GetDmlChannels(), sd.vchannelName) {
 		log.Warn("deletgator received query request not belongs to it",
 			zap.Strings("reqChannels", req.GetDmlChannels()),
 		)
-		return fmt.Errorf("dml channel not match, delegator channel %s, search channels %v", sd.vchannelName, req.GetDmlChannels())
+		return merr.WrapErrChannelMisrouted(sd.vchannelName, fmt.Sprintf("request channels %v", req.GetDmlChannels()))
 	}
 
 	req.Req.GuaranteeTimestamp = sd.speedupGuranteeTS(
@@ -668,7 +668,7 @@ func (sd *shardDelegator) Query(ctx context.Context, req *querypb.QueryRequest) 
 		log.Warn("delegator received query request not belongs to it",
 			zap.Strings("reqChannels", req.GetDmlChannels()),
 		)
-		return nil, fmt.Errorf("dml channel not match, delegator channel %s, search channels %v", sd.vchannelName, req.GetDmlChannels())
+		return nil, merr.WrapErrChannelMisrouted(sd.vchannelName, fmt.Sprintf("request channels %v", req.GetDmlChannels()))
 	}
 
 	req.Req.GuaranteeTimestamp = sd.speedupGuranteeTS(
@@ -784,7 +784,7 @@ func (sd *shardDelegator) GetStatistics(ctx context.Context, req *querypb.GetSta
 		log.Warn("delegator received GetStatistics request not belongs to it",
 			zap.Strings("reqChannels", req.GetDmlChannels()),
 		)
-		return nil, fmt.Errorf("dml channel not match, delegator channel %s, GetStatistics channels %v", sd.vchannelName, req.GetDmlChannels())
+		return nil, merr.WrapErrChannelMisrouted(sd.vchannelName, fmt.Sprintf("GetStatistics channels %v", req.GetDmlChannels()))
 	}
 
 	// wait tsafe
@@ -934,11 +934,11 @@ func executeSubTasks[T any, R interface {
 				} else {
 					segments = []int64{}
 				}
-				err = fmt.Errorf("segments not loaded in any worker: %v", segments[:min(len(segments), 10)])
+				err = merr.WrapErrServiceInternalMsg("segments not loaded in any worker: %v", segments[:min(len(segments), 10)])
 			} else {
 				result, err = execute(ctx, task.req, task.worker)
 				if result.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
-					err = fmt.Errorf("worker(%d) query failed: %s", task.targetID, result.GetStatus().GetReason())
+					err = merr.WrapErrServiceInternalMsg("worker(%d) query failed: %s", task.targetID, result.GetStatus().GetReason())
 				}
 			}
 
@@ -1350,7 +1350,7 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 
 	collection := manager.Collection.Get(collectionID)
 	if collection == nil {
-		return nil, fmt.Errorf("collection(%d) not found in manager", collectionID)
+		return nil, merr.WrapErrCollectionNotFound(collectionID, "not in delegator manager")
 	}
 
 	sizePerBlock := paramtable.Get().QueryNodeCfg.DeleteBufferBlockSize.GetAsInt64()
@@ -1481,7 +1481,7 @@ func (sd *shardDelegator) hasTextFields() bool {
 func (sd *shardDelegator) RunAnalyzer(ctx context.Context, req *querypb.RunAnalyzerRequest) ([]*milvuspb.AnalyzerResult, error) {
 	analyzer, ok := sd.analyzerRunners[req.GetFieldId()]
 	if !ok {
-		return nil, fmt.Errorf("analyzer runner for field %d not exist, now only support run analyzer by field if field was bm25/minhash input field", req.GetFieldId())
+		return nil, merr.WrapErrParameterInvalidMsg("analyzer runner for field %d not exist, now only support run analyzer by field if field was bm25/minhash input field", req.GetFieldId())
 	}
 
 	var result [][]*milvuspb.AnalyzerToken
@@ -1495,7 +1495,7 @@ func (sd *shardDelegator) RunAnalyzer(ctx context.Context, req *querypb.RunAnaly
 	} else {
 		analyzerNames := req.GetAnalyzerNames()
 		if len(analyzerNames) == 0 {
-			return nil, merr.WrapErrAsInputError(fmt.Errorf("analyzer names must be set for multi analyzer"))
+			return nil, merr.WrapErrParameterInvalidMsg("analyzer names must be set for multi analyzer")
 		}
 
 		if len(analyzerNames) == 1 && len(texts) > 1 {

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -307,7 +307,7 @@ func (sd *shardDelegator) ProcessManualFlush(ctx context.Context, flushTs uint64
 			zap.Int("segmentCount", len(segmentIDs)),
 			zap.Int("failCount", failCount),
 			zap.Error(firstErr))
-		return fmt.Errorf("manual flush failed for %d/%d segments: %w", failCount, len(segmentIDs), firstErr)
+		return merr.Wrapf(firstErr, "manual flush failed for %d/%d segments", failCount, len(segmentIDs))
 	}
 	log.Info("manual flush completed", zap.Int("segmentCount", len(segmentIDs)))
 	return nil
@@ -485,7 +485,7 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 			flushedOffset := segment.RowNum()
 			manifest := segment.LoadInfo().GetManifestPath()
 			if manifest == "" && flushedOffset > 0 {
-				return fmt.Errorf("recovered growing segment %d has %d flushed rows but no manifest path, cannot safely resume flush", segment.ID(), flushedOffset)
+				return merr.WrapErrDataIntegrityMsg("recovered growing segment %d has %d flushed rows but no manifest path, cannot safely resume flush", segment.ID(), flushedOffset)
 			}
 			sd.checkpointTracker.InitSegmentWithManifest(segment.ID(), flushedOffset, manifest)
 			log.Info("initialized checkpoint tracker for recovered growing segment",
@@ -1254,7 +1254,7 @@ func (sd *shardDelegator) buildBM25IDF(req *internalpb.SearchRequest) (float64, 
 	datas := []any{texts}
 	functionRunner, ok := sd.functionRunners[req.GetFieldId()]
 	if !ok {
-		return 0, fmt.Errorf("functionRunner not found for field: %d", req.GetFieldId())
+		return 0, merr.WrapErrParameterInvalidMsg("functionRunner not found for field: %d", req.GetFieldId())
 	}
 
 	if len(functionRunner.GetInputFields()) == 2 {
@@ -1279,7 +1279,7 @@ func (sd *shardDelegator) buildBM25IDF(req *internalpb.SearchRequest) (float64, 
 
 	tfArray, ok := output[0].(*schemapb.SparseFloatArray)
 	if !ok {
-		return 0, errors.New("functionRunner return unknown data")
+		return 0, merr.WrapErrFunctionFailedMsg("functionRunner return unknown data")
 	}
 
 	idfSparseVector, avgdl, err := sd.idfOracle.BuildIDF(req.GetFieldId(), tfArray)
@@ -1323,7 +1323,7 @@ func (sd *shardDelegator) parseMinHash(req *internalpb.SearchRequest) error {
 	datas := []any{texts}
 	functionRunner, ok := sd.functionRunners[req.GetFieldId()]
 	if !ok {
-		return fmt.Errorf("functionRunner not found for field: %d", req.GetFieldId())
+		return merr.WrapErrParameterInvalidMsg("functionRunner not found for field: %d", req.GetFieldId())
 	}
 
 	output, err := functionRunner.BatchRun(datas...)
@@ -1331,22 +1331,22 @@ func (sd *shardDelegator) parseMinHash(req *internalpb.SearchRequest) error {
 		return err
 	}
 	if len(output) == 0 {
-		return errors.New("MinHash embedding failed: runner returned empty output")
+		return merr.WrapErrFunctionFailedMsg("MinHash embedding failed: runner returned empty output")
 	}
 
 	fieldData, ok := output[0].(*schemapb.FieldData)
 	if !ok {
-		return errors.New("MinHash embedding failed: MinHash functionRunner return unknown data")
+		return merr.WrapErrFunctionFailedMsg("MinHash embedding failed: MinHash functionRunner return unknown data")
 	}
 
 	vectorField := fieldData.GetVectors()
 	if vectorField == nil {
-		return errors.New("MinHash embedding failed: output is not a vector field")
+		return merr.WrapErrFunctionFailedMsg("MinHash embedding failed: output is not a vector field")
 	}
 
 	binaryVector := vectorField.GetBinaryVector()
 	if binaryVector == nil {
-		return errors.New("MinHash embedding failed: output is not a binary vector")
+		return merr.WrapErrFunctionFailedMsg("MinHash embedding failed: output is not a binary vector")
 	}
 
 	req.PlaceholderGroup, err = funcutil.FieldDataToPlaceholderGroupBytes(fieldData)
@@ -1370,7 +1370,7 @@ func (sd *shardDelegator) GetHighlight(ctx context.Context, req *querypb.GetHigh
 	result := []*querypb.HighlightResult{}
 	for _, task := range req.GetTasks() {
 		if len(task.GetTexts()) != int(task.GetSearchTextNum()+task.GetCorpusTextNum())+len(task.GetQueries()) {
-			return nil, errors.Errorf("package highlight texts error, num of texts not equal the expected num %d:%d", len(task.GetTexts()), int(task.GetSearchTextNum()+task.GetCorpusTextNum())+len(task.GetQueries()))
+			return nil, merr.WrapErrServiceInternalMsg("package highlight texts error, num of texts not equal the expected num %d:%d", len(task.GetTexts()), int(task.GetSearchTextNum()+task.GetCorpusTextNum())+len(task.GetQueries()))
 		}
 		analyzer, ok := sd.analyzerRunners[task.GetFieldId()]
 		if !ok {

--- a/internal/querynodev2/delegator/delegator_twostage.go
+++ b/internal/querynodev2/delegator/delegator_twostage.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -69,7 +70,7 @@ func (sd *shardDelegator) executeFilterStage(
 	for _, result := range filterResults {
 		for _, vc := range result.GetFilterValidCounts() {
 			if vc < 0 {
-				return nil, fmt.Errorf("filter stage returned negative valid_count %d, segment may not support filter-only search", vc)
+				return nil, merr.WrapErrServiceInternalMsg("filter stage returned negative valid_count %d, segment may not support filter-only search", vc)
 			}
 			validCounts = append(validCounts, vc)
 		}

--- a/internal/querynodev2/delegator/idf_oracle.go
+++ b/internal/querynodev2/delegator/idf_oracle.go
@@ -33,7 +33,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
@@ -45,6 +44,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -100,7 +100,7 @@ func (s bm25Stats) Minus(stats bm25Stats) {
 func (s bm25Stats) GetStats(fieldID int64) (*storage.BM25Stats, error) {
 	stats, ok := s[fieldID]
 	if !ok {
-		return nil, errors.New("field not found in idf oracle BM25 stats")
+		return nil, merr.WrapErrFieldNotFound(fieldID, "not in idf oracle BM25 stats")
 	}
 	return stats, nil
 }
@@ -145,7 +145,7 @@ func (s *sealedBm25Stats) FetchStats() (map[int64]*storage.BM25Stats, error) {
 	defer s.RUnlock()
 
 	if s.removed {
-		return nil, errors.Newf("sealed bm25 stats for segment %d already removed", s.segmentID)
+		return nil, merr.WrapErrServiceInternalMsg("sealed bm25 stats for segment %d already removed", s.segmentID)
 	}
 
 	stats := make(map[int64]*storage.BM25Stats)
@@ -153,7 +153,7 @@ func (s *sealedBm25Stats) FetchStats() (map[int64]*storage.BM25Stats, error) {
 		fieldDir := path.Join(s.localDir, fmt.Sprintf("%d", fieldID))
 		entries, err := os.ReadDir(fieldDir)
 		if err != nil {
-			return nil, errors.Newf("read local dir %s failed: %v", fieldDir, err)
+			return nil, merr.WrapErrIoFailed(fieldDir, err)
 		}
 
 		fieldStats := storage.NewBM25Stats()
@@ -164,12 +164,12 @@ func (s *sealedBm25Stats) FetchStats() (map[int64]*storage.BM25Stats, error) {
 			filePath := path.Join(fieldDir, entry.Name())
 			f, err := os.Open(filePath)
 			if err != nil {
-				return nil, errors.Newf("open local file %s failed: %v", filePath, err)
+				return nil, merr.WrapErrIoFailed(filePath, err)
 			}
 			err = fieldStats.DeserializeFromReader(bufio.NewReader(f))
 			f.Close()
 			if err != nil {
-				return nil, errors.Newf("deserialize local file %s failed: %v", filePath, err)
+				return nil, merr.WrapErrSerializationFailed(err, "deserialize local file %s", filePath)
 			}
 		}
 		stats[fieldID] = fieldStats
@@ -373,7 +373,7 @@ func (o *idfOracle) streamLoad(ctx context.Context, segmentID int64, binlogPaths
 			localFile := path.Join(fieldDir, fmt.Sprintf("%d.data", i))
 			written, err := streamOneFile(ctx, cm, remotePath, localFile, fieldStats)
 			if err != nil {
-				return streamLoadResult{}, errors.Wrapf(err, "stream bm25 stats file %s", remotePath)
+				return streamLoadResult{}, merr.Wrapf(err, "stream bm25 stats file %s", remotePath)
 			}
 			totalDiskSize += written
 		}
@@ -671,7 +671,7 @@ func (o *idfOracle) SyncDistribution() error {
 		if intarget && !activate {
 			stats, err := stats.FetchStats()
 			if err != nil {
-				rangeErr = fmt.Errorf("fetch stats failed with error: %v", err)
+				rangeErr = merr.Wrap(err, "fetch stats failed")
 				return false
 			}
 			diff.Merge(stats)
@@ -680,7 +680,7 @@ func (o *idfOracle) SyncDistribution() error {
 		if !intarget && activate {
 			stats, err := stats.FetchStats()
 			if err != nil {
-				rangeErr = fmt.Errorf("fetch stats failed with error: %v", err)
+				rangeErr = merr.Wrap(err, "fetch stats failed")
 				return false
 			}
 			diff.Minus(stats)

--- a/internal/querynodev2/delegator/util.go
+++ b/internal/querynodev2/delegator/util.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"unicode/utf8"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -109,11 +108,11 @@ func bytesOffsetToRuneOffset(text string, spans SpanList) error {
 	for i, span := range spans {
 		startOffset, ok := offsetMap[span[0]]
 		if !ok {
-			return errors.Errorf("start offset: %d not found (text: %d bytes)", span[0], len(text))
+			return merr.WrapErrServiceInternalMsg("start offset: %d not found (text: %d bytes)", span[0], len(text))
 		}
 		endOffset, ok := offsetMap[span[1]]
 		if !ok {
-			return errors.Errorf("end offset: %d not found (text: %d bytes)", span[1], len(text))
+			return merr.WrapErrServiceInternalMsg("end offset: %d not found (text: %d bytes)", span[1], len(text))
 		}
 		spans[i][0] = startOffset
 		spans[i][1] = endOffset

--- a/internal/querynodev2/handlers.go
+++ b/internal/querynodev2/handlers.go
@@ -556,7 +556,7 @@ func reduceStatisticResponse(results []*internalpb.GetStatisticsResponse) (*inte
 		for _, pair := range partialResult.Stats {
 			fn, ok := fieldMethod[pair.Key]
 			if !ok {
-				return nil, fmt.Errorf("unknown statistic field: %s", pair.Key)
+				return nil, merr.WrapErrParameterInvalidMsg("unknown statistic field: %s", pair.Key)
 			}
 			if err := fn(pair.Value); err != nil {
 				return nil, err

--- a/internal/querynodev2/pipeline/embedding_node.go
+++ b/internal/querynodev2/pipeline/embedding_node.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
@@ -107,7 +106,7 @@ func (eNode *embeddingNode) addInsertData(insertDatas map[UniqueID]*delegator.In
 
 	insertRecord, err := storage.TransferInsertMsgToInsertRecord(collection.Schema(), msg)
 	if err != nil {
-		err = fmt.Errorf("failed to get primary keys, err = %v", err)
+		err = merr.Wrap(err, "failed to get primary keys")
 		log.Error(err.Error(), zap.String("channel", eNode.channel))
 		return err
 	}
@@ -157,12 +156,12 @@ func (eNode *embeddingNode) bm25Embedding(runner function.FunctionRunner, msg *m
 	}
 
 	if len(output) == 0 {
-		return errors.New("BM25 runner returned empty output")
+		return merr.WrapErrFunctionFailedMsg("BM25 runner returned empty output")
 	}
 
 	sparseArray, ok := output[0].(*schemapb.SparseFloatArray)
 	if !ok {
-		return errors.New("BM25 runner return unknown type output")
+		return merr.WrapErrFunctionFailedMsg("BM25 runner return unknown type output")
 	}
 
 	if _, ok := stats[outputFieldID]; !ok {
@@ -188,21 +187,21 @@ func (eNode *embeddingNode) minhashEmbedding(runner function.FunctionRunner, msg
 	}
 
 	if len(output) == 0 {
-		return errors.New("MinHash runner returned empty output")
+		return merr.WrapErrFunctionFailedMsg("MinHash runner returned empty output")
 	}
 
 	fieldData, ok := output[0].(*schemapb.FieldData)
 	if !ok {
-		return errors.New("MinHash embedding failed: MinHash runner output not FieldData")
+		return merr.WrapErrFunctionFailedMsg("MinHash embedding failed: MinHash runner output not FieldData")
 	}
 	vectorField := fieldData.GetVectors()
 	if vectorField == nil {
-		return errors.New("MinHash embedding failed: output is not a vector field")
+		return merr.WrapErrFunctionFailedMsg("MinHash embedding failed: output is not a vector field")
 	}
 
 	binaryVector := vectorField.GetBinaryVector()
 	if binaryVector == nil {
-		return errors.New("MinHash embedding failed: output is not a binary vector")
+		return merr.WrapErrFunctionFailedMsg("MinHash embedding failed: output is not a binary vector")
 	}
 
 	outputFieldData := &schemapb.FieldData{
@@ -239,7 +238,7 @@ func (eNode *embeddingNode) embedding(msg *msgstream.InsertMsg, stats map[int64]
 			}
 		default:
 			log.Warn("pipeline embedding with unknown function type", zap.Any("type", functionSchema.GetType()))
-			return errors.New("unknown function type")
+			return merr.WrapErrServiceInternalMsg("unknown function type")
 		}
 	}
 
@@ -294,5 +293,5 @@ func getEmbeddingFieldData(datas []*schemapb.FieldData, fieldID int64) ([]string
 			return data.GetScalars().GetStringData().GetData(), nil
 		}
 	}
-	return nil, fmt.Errorf("field %d not found", fieldID)
+	return nil, merr.WrapErrFieldNotFound(fieldID)
 }

--- a/internal/querynodev2/pipeline/insert_node.go
+++ b/internal/querynodev2/pipeline/insert_node.go
@@ -30,6 +30,7 @@ import (
 	base "github.com/milvus-io/milvus/internal/util/pipeline"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -45,7 +46,7 @@ type insertNode struct {
 func (iNode *insertNode) addInsertData(insertDatas map[UniqueID]*delegator.InsertData, msg *InsertMsg, collection *Collection) {
 	insertRecord, err := storage.TransferInsertMsgToInsertRecord(collection.Schema(), msg)
 	if err != nil {
-		err = fmt.Errorf("failed to get primary keys, err = %v", err)
+		err = merr.Wrap(err, "failed to get primary keys")
 		log.Error(err.Error(), zap.Int64("collectionID", iNode.collectionID), zap.String("channel", iNode.channel))
 		panic(err)
 	}

--- a/internal/querynodev2/segments/growing_flush_manager.go
+++ b/internal/querynodev2/segments/growing_flush_manager.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -31,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
@@ -347,7 +347,7 @@ func (m *GrowingFlushManager) doSync(ctx context.Context, segment Segment, isSea
 	flushConfig.ReadVersion = m.checkpointTracker.GetAcknowledgedVersion(segID)
 	flushResult, err := segment.FlushData(ctx, flushedOffset, currentOffset, flushConfig)
 	if err != nil {
-		return errors.Wrap(err, "failed to flush data via C++ milvus-storage")
+		return merr.Wrap(err, "failed to flush data via C++ milvus-storage")
 	}
 	if flushResult == nil || flushResult.ManifestPath == "" {
 		if isSeal {
@@ -438,7 +438,7 @@ func (m *GrowingFlushManager) saveManifestAndCheckpoint(
 	isSeal bool,
 ) error {
 	if m.binlogSaver == nil {
-		return errors.New("binlogSaver is nil, cannot save manifest and checkpoint")
+		return merr.WrapErrServiceInternalMsg("binlogSaver is nil, cannot save manifest and checkpoint")
 	}
 
 	segID := segment.ID()

--- a/internal/querynodev2/segments/ignore_non_pk_ops.go
+++ b/internal/querynodev2/segments/ignore_non_pk_ops.go
@@ -18,7 +18,6 @@ package segments
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel/trace"
@@ -31,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -71,7 +71,7 @@ func NewMergeByPKWithOffsetsOperator(
 		for _, r := range results {
 			tr, err := NewTimestampedRetrieveResult(r)
 			if err != nil {
-				return nil, fmt.Errorf("failed to create timestamped result: %w", err)
+				return nil, merr.Wrap(err, "failed to create timestamped result")
 			}
 			validResults = append(validResults, tr)
 		}
@@ -85,12 +85,12 @@ func NewMergeByPKWithOffsetsOperator(
 		if isElementLevel {
 			for i, r := range validResults {
 				if r.Result.GetElementLevel() != isElementLevel {
-					return nil, fmt.Errorf("inconsistent element-level flag: result[0]=%v, result[%d]=%v",
+					return nil, merr.WrapErrServiceInternalMsg("inconsistent element-level flag: result[0]=%v, result[%d]=%v",
 						isElementLevel, i, r.Result.GetElementLevel())
 				}
 				size := typeutil.GetSizeOfIDs(r.GetIds())
 				if len(r.Result.GetElementIndices()) != size {
-					return nil, fmt.Errorf("element_indices length (%d) does not match ids length (%d)",
+					return nil, merr.WrapErrServiceInternalMsg("element_indices length (%d) does not match ids length (%d)",
 						len(r.Result.GetElementIndices()), size)
 				}
 			}
@@ -277,7 +277,7 @@ func NewFetchFieldsDataOperator(
 			segmentResOffset[sel.SegmentIndex]++
 
 			if retSize > maxOutputSize {
-				return nil, fmt.Errorf("query results exceed the maxOutputSize Limit %d", maxOutputSize)
+				return nil, merr.WrapErrParameterInvalidMsg("query results exceed the maxOutputSize Limit %d", maxOutputSize)
 			}
 		}
 

--- a/internal/querynodev2/segments/index_attr_cache.go
+++ b/internal/querynodev2/segments/index_attr_cache.go
@@ -27,8 +27,6 @@ import (
 	"fmt"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -36,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -61,7 +60,7 @@ func NewIndexAttrCache() *IndexAttrCache {
 func (c *IndexAttrCache) GetIndexResourceUsage(indexInfo *querypb.FieldIndexInfo, memoryIndexLoadPredictMemoryUsageFactor float64, fieldBinlog *datapb.FieldBinlog) (memory uint64, disk uint64, err error) {
 	indexType, err := funcutil.GetAttrByKeyFromRepeatedKV(common.IndexTypeKey, indexInfo.IndexParams)
 	if err != nil {
-		return 0, 0, errors.New("index type not exist in index params")
+		return 0, 0, merr.WrapErrParameterInvalidMsg("index type not exist in index params")
 	}
 	if vecindexmgr.GetVecIndexMgrInstance().IsDiskANN(indexType) {
 		neededMemSize := indexInfo.IndexSize / UsedDiskMemoryRatio

--- a/internal/querynodev2/segments/query_pipeline.go
+++ b/internal/querynodev2/segments/query_pipeline.go
@@ -18,7 +18,6 @@ package segments
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/agg"
@@ -31,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -77,7 +77,7 @@ func RunQNQueryPipeline(
 	// Common: run pipeline
 	finalMsg, err := pipeline.Run(ctx, nil, msg)
 	if err != nil {
-		return nil, fmt.Errorf("QN query pipeline failed: %w", err)
+		return nil, merr.Wrap(err, "QN query pipeline failed")
 	}
 
 	// Common: extract output + aggregate stats + fill empty fields
@@ -138,7 +138,7 @@ func buildStandardQNPipeline(
 		req.GetReq().GetOrderByFields(), schema,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to convert ORDER BY fields: %w", err)
+		return nil, nil, merr.Wrap(err, "failed to convert ORDER BY fields")
 	}
 
 	// Convert segcore results to internal format.
@@ -220,7 +220,7 @@ func extractSegcoreResult(
 			}
 		}
 	default:
-		return nil, fmt.Errorf("unexpected pipeline output type: %T", rawOutput)
+		return nil, merr.WrapErrServiceInternalMsg("unexpected pipeline output type: %T", rawOutput)
 	}
 
 	merged := &segcorepb.RetrieveResults{
@@ -263,7 +263,7 @@ func RunDelegatorQueryPipeline(
 		req.GetReq().GetOrderByFields(), schema,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert ORDER BY fields: %w", err)
+		return nil, merr.Wrap(err, "failed to convert ORDER BY fields")
 	}
 
 	// Build and run pipeline
@@ -277,13 +277,13 @@ func RunDelegatorQueryPipeline(
 		maxOutputSize,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build delegator query pipeline: %w", err)
+		return nil, merr.Wrap(err, "failed to build delegator query pipeline")
 	}
 
 	msg := queryutil.OpMsg{queryutil.PipelineInput: results}
 	finalMsg, err := pipeline.Run(ctx, nil, msg)
 	if err != nil {
-		return nil, fmt.Errorf("delegator query pipeline failed: %w", err)
+		return nil, merr.Wrap(err, "delegator query pipeline failed")
 	}
 
 	output := finalMsg[queryutil.PipelineOutput].(*internalpb.RetrieveResults)

--- a/internal/querynodev2/segments/search_reduce.go
+++ b/internal/querynodev2/segments/search_reduce.go
@@ -2,7 +2,6 @@ package segments
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
@@ -30,7 +29,7 @@ func getSearchResultDedupKey(data *schemapb.SearchResultData, idx int64, pk inte
 	}
 	elementIndices := data.GetElementIndices()
 	if elementIndices == nil || idx < 0 || idx >= int64(len(elementIndices.GetData())) {
-		return nil, fmt.Errorf("element-level search result missing element index at offset %d", idx)
+		return nil, merr.WrapErrServiceInternalMsg("element-level search result missing element index at offset %d", idx)
 	}
 	return elementSearchResultKey{
 		pk:           pk,
@@ -84,7 +83,7 @@ func (scr *SearchCommonReduce) ReduceSearchResultData(ctx context.Context, searc
 				if ids == nil || typeutil.GetSizeOfIDs(ids) == 0 {
 					data.ElementIndices = &schemapb.LongArray{}
 				} else {
-					return nil, fmt.Errorf("inconsistent element-level flag in search results: result has data but missing ElementIndices at index %d", i)
+					return nil, merr.WrapErrServiceInternalMsg("inconsistent element-level flag in search results: result has data but missing ElementIndices at index %d", i)
 				}
 			}
 		}
@@ -97,7 +96,7 @@ func (scr *SearchCommonReduce) ReduceSearchResultData(ctx context.Context, searc
 	totalOffsetElements := 0
 	for i, data := range searchResultData {
 		if int64(len(data.Topks)) < nq {
-			return nil, fmt.Errorf("invalid search result topks length at index %d: got %d, expected at least %d", i, len(data.Topks), nq)
+			return nil, merr.WrapErrServiceInternalMsg("invalid search result topks length at index %d: got %d, expected at least %d", i, len(data.Topks), nq)
 		}
 		totalOffsetElements += len(data.Topks)
 	}
@@ -168,7 +167,7 @@ func (scr *SearchCommonReduce) ReduceSearchResultData(ctx context.Context, searc
 
 		// limit search result to avoid oom
 		if retSize > maxOutputSize {
-			return nil, fmt.Errorf("search results exceed the maxOutputSize Limit %d", maxOutputSize)
+			return nil, merr.WrapErrParameterInvalidMsg("search results exceed the maxOutputSize Limit %d", maxOutputSize)
 		}
 	}
 	log.Debug("skip duplicated search result", zap.Int64("count", skipDupCnt))
@@ -222,7 +221,7 @@ func (sbr *SearchGroupByReduce) ReduceSearchResultData(ctx context.Context, sear
 				if ids == nil || typeutil.GetSizeOfIDs(ids) == 0 {
 					data.ElementIndices = &schemapb.LongArray{}
 				} else {
-					return nil, fmt.Errorf("inconsistent element-level flag in search results: result has data but missing ElementIndices at index %d", i)
+					return nil, merr.WrapErrServiceInternalMsg("inconsistent element-level flag in search results: result has data but missing ElementIndices at index %d", i)
 				}
 			}
 		}
@@ -235,7 +234,7 @@ func (sbr *SearchGroupByReduce) ReduceSearchResultData(ctx context.Context, sear
 	totalOffsetElements := 0
 	for i, data := range searchResultData {
 		if int64(len(data.Topks)) < nq {
-			return nil, fmt.Errorf("invalid search result topks length at index %d: got %d, expected at least %d", i, len(data.Topks), nq)
+			return nil, merr.WrapErrServiceInternalMsg("invalid search result topks length at index %d: got %d, expected at least %d", i, len(data.Topks), nq)
 		}
 		totalOffsetElements += len(data.Topks)
 	}
@@ -300,7 +299,7 @@ func (sbr *SearchGroupByReduce) ReduceSearchResultData(ctx context.Context, sear
 		ret.Topks = append(ret.Topks, j)
 
 		if retSize > maxOutputSize {
-			return nil, fmt.Errorf("search results exceed the maxOutputSize Limit %d", maxOutputSize)
+			return nil, merr.WrapErrParameterInvalidMsg("search results exceed the maxOutputSize Limit %d", maxOutputSize)
 		}
 	}
 	if err := writeGroupByOutput(ret, acceptedRows, searchResultData, info); err != nil {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -381,7 +381,7 @@ func NewSegment(ctx context.Context,
 	case SegmentTypeGrowing:
 		locker = state.NewLoadStateLock(state.LoadStateDataLoaded)
 	default:
-		return nil, fmt.Errorf("illegal segment type %d when create segment %d", segmentType, loadInfo.GetSegmentID())
+		return nil, merr.WrapErrServiceInternalMsg("illegal segment type %d when create segment %d", segmentType, loadInfo.GetSegmentID())
 	}
 
 	logger := log.With(
@@ -797,7 +797,7 @@ func (s *LocalSegment) RetrieveByOffsets(ctx context.Context, plan *segcore.Retr
 
 func (s *LocalSegment) Insert(ctx context.Context, rowIDs []int64, timestamps []typeutil.Timestamp, record *segcorepb.InsertRecord) error {
 	if s.Type() != SegmentTypeGrowing {
-		return fmt.Errorf("unexpected segmentType when segmentInsert, segmentType = %s", s.segmentType.String())
+		return merr.WrapErrServiceInternalMsg("unexpected segmentType when segmentInsert, segmentType = %s", s.segmentType.String())
 	}
 	if !s.ptrLock.PinIf(state.IsNotReleased) {
 		return merr.WrapErrSegmentNotLoaded(s.ID(), "segment released")
@@ -1169,8 +1169,7 @@ func (s *LocalSegment) innerLoadIndex(ctx context.Context,
 				return err
 			}
 			if s.Type() != SegmentTypeSealed {
-				errMsg := fmt.Sprintln("updateSegmentIndex failed, illegal segment type ", s.segmentType, "segmentID = ", s.ID())
-				return errors.New(errMsg)
+				return merr.WrapErrServiceInternalMsg("updateSegmentIndex failed, illegal segment type %s, segmentID = %d", s.segmentType, s.ID())
 			}
 			appendLoadIndexInfoSpan := tr.RecordSpan()
 
@@ -1569,12 +1568,12 @@ func (s *LocalSegment) GetFieldJSONIndexStats() map[int64]*querypb.JsonStatsInfo
 func (s *LocalSegment) FlushData(ctx context.Context, startOffset, endOffset int64, config *FlushConfig) (*FlushResult, error) {
 	// currently only growing segments support FlushData
 	if s.Type() != SegmentTypeGrowing {
-		return nil, errors.Errorf("FlushData is only supported for growing segments, got %s", s.Type().String())
+		return nil, merr.WrapErrServiceInternalMsg("FlushData is only supported for growing segments, got %s", s.Type().String())
 	}
 
 	// validate offsets
 	if startOffset < 0 || endOffset < startOffset {
-		return nil, errors.Errorf("invalid offsets: start=%d, end=%d", startOffset, endOffset)
+		return nil, merr.WrapErrServiceInternalMsg("invalid offsets: start=%d, end=%d", startOffset, endOffset)
 	}
 
 	// no data to flush

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -350,13 +350,13 @@ func (loader *segmentLoader) Load(ctx context.Context,
 		if loadInfo.GetLevel() != datapb.SegmentLevel_L0 {
 			// lazy load segment do not load segment at first time.
 			if err = loader.LoadSegment(ctx, segment, loadInfo); err != nil {
-				return errors.Wrap(err, "At LoadSegment")
+				return merr.Wrap(err, "At LoadSegment")
 			}
 		}
 		// Skip delta logs for external collections (they are read-only, no deletions)
 		if !typeutil.IsExternalCollection(collection.Schema()) {
 			if err = loader.loadDeltalogs(ctx, segment, loadInfo); err != nil {
-				return errors.Wrap(err, "At LoadDeltaLogs")
+				return merr.Wrap(err, "At LoadDeltaLogs")
 			}
 		}
 
@@ -384,7 +384,7 @@ func (loader *segmentLoader) Load(ctx context.Context,
 			} else if paramtable.Get().CommonCfg.BloomFilterEnabled.GetAsBool() {
 				bfs, err := loader.loadSingleBloomFilterSet(ctx, loadInfo.GetCollectionID(), loadInfo, segment.Type())
 				if err != nil {
-					return errors.Wrap(err, "At LoadBloomFilter")
+					return merr.Wrap(err, "At LoadBloomFilter")
 				}
 				segment.SetPKCandidate(bfs)
 				// Charge bloom filter resource
@@ -497,7 +497,7 @@ func (loader *segmentLoader) requestResource(ctx context.Context, infos ...*quer
 
 	physicalDiskUsage, err := loader.duf.GetDiskUsage()
 	if err != nil {
-		return requestResourceResult{}, errors.Wrap(err, "get local used size failed")
+		return requestResourceResult{}, merr.Wrap(err, "get local used size failed")
 	}
 	diskCap := paramtable.Get().QueryNodeCfg.DiskCapacityLimit.GetAsUint64()
 
@@ -580,7 +580,7 @@ func (loader *segmentLoader) waitSegmentLoadDone(ctx context.Context, segmentTyp
 		result, ok := loader.loadingSegments.Get(segmentID)
 		if !ok {
 			log.Warn("segment was removed from the loading map early", zap.Int64("segmentID", segmentID))
-			return errors.New("segment was removed from the loading map early")
+			return merr.WrapErrServiceInternalMsg("segment was removed from the loading map early")
 		}
 
 		log.Info("wait segment loaded...", zap.Int64("segmentID", segmentID))
@@ -731,8 +731,9 @@ func (loader *segmentLoader) LoadBloomFilterSet(ctx context.Context, collectionI
 			memory_bytes: C.int64_t(totalMemorySize * 2),
 			disk_bytes:   C.int64_t(0),
 		}, 1000); !ok {
-			return nil, fmt.Errorf("failed to reserve loading resource for bloom filters, totalMemorySize = %v MB",
-				logutil.ToMB(float64(totalMemorySize)))
+			return nil, merr.WrapErrSegmentRequestResourceFailed("memory",
+				fmt.Sprintf("failed to reserve loading resource for bloom filters, totalMemorySize = %v MB",
+					logutil.ToMB(float64(totalMemorySize))))
 		}
 		log.Info("reserved loading resource for bloom filters", zap.Float64("totalMemorySizeMB", logutil.ToMB(float64(totalMemorySize))))
 	}
@@ -1044,7 +1045,7 @@ func (loader *segmentLoader) loadSealedSegment(ctx context.Context, loadInfo *qu
 	)
 	_, err = GetLoadPool().Submit(func() (any, error) {
 		if err = segment.Load(ctx); err != nil {
-			return struct{}{}, errors.Wrap(err, "At Load")
+			return struct{}{}, merr.Wrap(err, "At Load")
 		}
 
 		return struct{}{}, nil
@@ -1497,7 +1498,7 @@ func (loader *segmentLoader) patchEntryNumber(ctx context.Context, segment *Loca
 	})
 
 	if rowIDField == nil {
-		return errors.New("rowID field binlog not found")
+		return merr.WrapErrDataIntegrityMsg("rowID field binlog not found")
 	}
 
 	counts := make([]int64, 0, len(rowIDField.GetBinlogs()))
@@ -1530,7 +1531,7 @@ func (loader *segmentLoader) patchEntryNumber(ctx context.Context, segment *Loca
 	var err error
 	segment.fieldIndexes.Range(func(indexID int64, info *IndexedFieldInfo) bool {
 		if len(info.FieldBinlog.GetBinlogs()) != len(counts) {
-			err = errors.New("rowID & index binlog number not matched")
+			err = merr.WrapErrDataIntegrityMsg("rowID & index binlog number not matched")
 			return false
 		}
 		for i, binlog := range info.FieldBinlog.GetBinlogs() {
@@ -1652,7 +1653,7 @@ func (loader *segmentLoader) checkSegmentSize(ctx context.Context, segmentLoadIn
 
 	memUsage = memUsage + loader.committedResource.MemorySize
 	if memUsage == 0 || totalMem == 0 {
-		return 0, 0, errors.New("get memory failed when checkSegmentSize")
+		return 0, 0, merr.WrapErrServiceInternalMsg("get memory failed when checkSegmentSize")
 	}
 
 	diskUsage := uint64(localDiskUsage) + loader.committedResource.DiskSize
@@ -1718,14 +1719,15 @@ func (loader *segmentLoader) checkSegmentSize(ctx context.Context, segmentLoadIn
 			memory_bytes: C.int64_t(predictMemUsage - memUsage),
 			disk_bytes:   C.int64_t(predictDiskUsage - diskUsage),
 		}, 1000); !ok {
-			return 0, 0, fmt.Errorf("failed to reserve loading resource from caching layer, predictMemUsage = %v MB, predictDiskUsage = %v MB, memUsage = %v MB, diskUsage = %v MB, memoryThresholdFactor = %f, diskThresholdFactor = %f",
-				logutil.ToMB(float64(predictMemUsage)),
-				logutil.ToMB(float64(predictDiskUsage)),
-				logutil.ToMB(float64(memUsage)),
-				logutil.ToMB(float64(diskUsage)),
-				paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.GetAsFloat(),
-				paramtable.Get().QueryNodeCfg.MaxDiskUsagePercentage.GetAsFloat(),
-			)
+			return 0, 0, merr.WrapErrSegmentRequestResourceFailed("memory/disk",
+				fmt.Sprintf("failed to reserve loading resource from caching layer, predictMemUsage = %v MB, predictDiskUsage = %v MB, memUsage = %v MB, diskUsage = %v MB, memoryThresholdFactor = %f, diskThresholdFactor = %f",
+					logutil.ToMB(float64(predictMemUsage)),
+					logutil.ToMB(float64(predictDiskUsage)),
+					logutil.ToMB(float64(memUsage)),
+					logutil.ToMB(float64(diskUsage)),
+					paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.GetAsFloat(),
+					paramtable.Get().QueryNodeCfg.MaxDiskUsagePercentage.GetAsFloat(),
+				))
 		}
 	} else {
 		// fallback to original segment loading logic
@@ -1800,7 +1802,7 @@ func estimateLogicalResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 				return nil
 			})
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to estimate logical resource usage of index, collection %d, segment %d, indexBuildID %d",
+				return nil, merr.Wrapf(err, "failed to estimate logical resource usage of index, collection %d, segment %d, indexBuildID %d",
 					loadInfo.GetCollectionID(),
 					loadInfo.GetSegmentID(),
 					fieldIndexInfo.GetBuildID())
@@ -1824,7 +1826,7 @@ func estimateLogicalResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 
 			metricType, err := funcutil.GetAttrByKeyFromRepeatedKV(common.MetricTypeKey, fieldIndexInfo.IndexParams)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to estimate logical resource usage of index, metric type not found, collection %d, segment %d, indexBuildID %d",
+				return nil, merr.Wrapf(err, "failed to estimate logical resource usage of index, metric type not found, collection %d, segment %d, indexBuildID %d",
 					loadInfo.GetCollectionID(),
 					loadInfo.GetSegmentID(),
 					fieldIndexInfo.GetBuildID())
@@ -1999,7 +2001,7 @@ func estimateLoadingResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 				return nil
 			})
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to estimate loading resource usage of index, collection %d, segment %d, indexBuildID %d",
+				return nil, merr.Wrapf(err, "failed to estimate loading resource usage of index, collection %d, segment %d, indexBuildID %d",
 					loadInfo.GetCollectionID(),
 					loadInfo.GetSegmentID(),
 					fieldIndexInfo.GetBuildID())
@@ -2030,7 +2032,7 @@ func estimateLoadingResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 
 			metricType, err := funcutil.GetAttrByKeyFromRepeatedKV(common.MetricTypeKey, fieldIndexInfo.IndexParams)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to estimate loading resource usage of index, metric type not found, collection %d, segment %d, indexBuildID %d",
+				return nil, merr.Wrapf(err, "failed to estimate loading resource usage of index, metric type not found, collection %d, segment %d, indexBuildID %d",
 					loadInfo.GetCollectionID(),
 					loadInfo.GetSegmentID(),
 					fieldIndexInfo.GetBuildID())

--- a/internal/querynodev2/segments/state/load_state_lock.go
+++ b/internal/querynodev2/segments/state/load_state_lock.go
@@ -5,11 +5,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -117,7 +117,7 @@ func (ls *LoadStateLock) StartLoadData() (LoadStateLockGuard, error) {
 		return nil, nil
 	}
 	if ls.state != LoadStateOnlyMeta {
-		return nil, errors.New("segment is not in LoadStateOnlyMeta, cannot start to loading data")
+		return nil, merr.WrapErrServiceInternalMsg("segment is not in LoadStateOnlyMeta, cannot start to loading data")
 	}
 	ls.state = LoadStateDataLoading
 	ls.cv.Broadcast()

--- a/internal/querynodev2/segments/utils.go
+++ b/internal/querynodev2/segments/utils.go
@@ -3,11 +3,9 @@ package segments
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"strconv"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -72,7 +70,7 @@ func getPKsFromRowBasedInsertMsg(msg *msgstream.InsertMsg, schema *schemapb.Coll
 				if t.Key == common.DimKey {
 					dim, err := strconv.Atoi(t.Value)
 					if err != nil {
-						return nil, fmt.Errorf("strconv wrong on get dim, err = %s", err)
+						return nil, merr.WrapErrParameterInvalidMsg("strconv wrong on get dim, err = %s", err)
 					}
 					offset += dim * 4
 					break
@@ -83,7 +81,7 @@ func getPKsFromRowBasedInsertMsg(msg *msgstream.InsertMsg, schema *schemapb.Coll
 				if t.Key == common.DimKey {
 					dim, err := strconv.Atoi(t.Value)
 					if err != nil {
-						return nil, fmt.Errorf("strconv wrong on get dim, err = %s", err)
+						return nil, merr.WrapErrParameterInvalidMsg("strconv wrong on get dim, err = %s", err)
 					}
 					offset += dim / 8
 					break
@@ -94,7 +92,7 @@ func getPKsFromRowBasedInsertMsg(msg *msgstream.InsertMsg, schema *schemapb.Coll
 				if t.Key == common.DimKey {
 					dim, err := strconv.Atoi(t.Value)
 					if err != nil {
-						return nil, fmt.Errorf("strconv wrong on get dim, err = %s", err)
+						return nil, merr.WrapErrParameterInvalidMsg("strconv wrong on get dim, err = %s", err)
 					}
 					offset += dim * 2
 					break
@@ -105,14 +103,14 @@ func getPKsFromRowBasedInsertMsg(msg *msgstream.InsertMsg, schema *schemapb.Coll
 				if t.Key == common.DimKey {
 					dim, err := strconv.Atoi(t.Value)
 					if err != nil {
-						return nil, fmt.Errorf("strconv wrong on get dim, err = %s", err)
+						return nil, merr.WrapErrParameterInvalidMsg("strconv wrong on get dim, err = %s", err)
 					}
 					offset += dim * 2
 					break
 				}
 			}
 		case schemapb.DataType_SparseFloatVector:
-			return nil, errors.New("SparseFloatVector not support in row based message")
+			return nil, merr.WrapErrParameterInvalidMsg("SparseFloatVector not support in row based message")
 		}
 	}
 
@@ -253,7 +251,7 @@ func getFieldSchema(schema *schemapb.CollectionSchema, fieldID int64) (*schemapb
 			}
 		}
 	}
-	return nil, fmt.Errorf("field %d not found in schema", fieldID)
+	return nil, merr.WrapErrFieldNotFound(fieldID, "not in schema")
 }
 
 func isIndexMmapEnable(fieldSchema *schemapb.FieldSchema, indexInfo *querypb.FieldIndexInfo) bool {

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -38,7 +38,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -77,6 +76,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/expr"
 	"github.com/milvus-io/milvus/pkg/v3/util/lifetime"
 	"github.com/milvus-io/milvus/pkg/v3/util/lock"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -176,7 +176,7 @@ func (node *QueryNode) initSession() error {
 			common.MaximumScalarIndexEngineVersion),
 		sessionutil.WithIndexNonEncoding())
 	if node.session == nil {
-		return errors.New("session is nil, the etcd client connection may have failed")
+		return merr.WrapErrServiceInternalMsg("session is nil, the etcd client connection may have failed")
 	}
 	node.session.Init(typeutil.QueryNodeRole, node.address, false)
 	sessionutil.SaveServerInfo(typeutil.QueryNodeRole, node.session.ServerID)
@@ -618,7 +618,7 @@ func (node *QueryNode) SetAddress(address string) {
 func (node *QueryNode) initHook() error {
 	path := paramtable.Get().QueryNodeCfg.SoPath.GetValue()
 	if path == "" {
-		return errors.New("fail to set the plugin path")
+		return merr.WrapErrServiceInternalMsg("fail to set the plugin path")
 	}
 
 	hoo, err := hookutil.LoadPlugin[optimizers.QueryHook](path, "QueryNodePlugin")
@@ -627,10 +627,10 @@ func (node *QueryNode) initHook() error {
 	}
 
 	if err = hoo.Init(paramtable.Get().AutoIndexConfig.AutoIndexSearchConfig.GetValue()); err != nil {
-		return fmt.Errorf("fail to init configs for the hook, error: %s", err.Error())
+		return merr.Wrap(err, "fail to init configs for the hook")
 	}
 	if err = hoo.InitTuningConfig(paramtable.Get().AutoIndexConfig.AutoIndexTuningConfig.GetValue()); err != nil {
-		return fmt.Errorf("fail to init tuning configs for the hook, error: %s", err.Error())
+		return merr.Wrap(err, "fail to init tuning configs for the hook")
 	}
 
 	node.queryHook = hoo

--- a/internal/querynodev2/tasks/search_task.go
+++ b/internal/querynodev2/tasks/search_task.go
@@ -189,7 +189,7 @@ func (t *SearchTask) Execute() error {
 	// In filter-only mode, extract filter results and return early
 	if searchReq.FilterOnly() {
 		if len(results) != len(searchedSegments) {
-			return fmt.Errorf("filter-only search: result count %d != segment count %d", len(results), len(searchedSegments))
+			return merr.WrapErrServiceInternalMsg("filter-only search: result count %d != segment count %d", len(results), len(searchedSegments))
 		}
 		segmentIDs := make([]int64, 0, len(searchedSegments))
 		validCounts := make([]int64, 0, len(searchedSegments))

--- a/internal/storage/arrow_util.go
+++ b/internal/storage/arrow_util.go
@@ -50,7 +50,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.BooleanBuilder:
 		ba, ok := a.(*array.Boolean)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ba.IsNull(idx) {
 			if defaultValue != nil {
@@ -66,7 +66,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int8Builder:
 		ia, ok := a.(*array.Int8)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -82,7 +82,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int16Builder:
 		ia, ok := a.(*array.Int16)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -98,7 +98,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int32Builder:
 		ia, ok := a.(*array.Int32)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -114,7 +114,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int64Builder:
 		ia, ok := a.(*array.Int64)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -130,7 +130,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Float32Builder:
 		fa, ok := a.(*array.Float32)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if fa.IsNull(idx) {
 			if defaultValue != nil {
@@ -155,7 +155,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 		}
 		fa, ok := a.(*array.Float64)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if fa.IsNull(idx) {
 			b.AppendNull()
@@ -167,7 +167,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.StringBuilder:
 		sa, ok := a.(*array.String)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if sa.IsNull(idx) {
 			if defaultValue != nil {
@@ -185,7 +185,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.BinaryBuilder:
 		ba, ok := a.(*array.Binary)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ba.IsNull(idx) {
 			// could be internal $meta json
@@ -204,7 +204,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.FixedSizeBinaryBuilder:
 		ba, ok := a.(*array.FixedSizeBinary)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ba.IsNull(idx) {
 			b.AppendNull()
@@ -218,7 +218,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 		// Handle ListBuilder for ArrayOfVector type
 		la, ok := a.(*array.List)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if la.IsNull(idx) {
 			b.AppendNull()
@@ -235,7 +235,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 		case *array.FixedSizeBinaryBuilder:
 			fixedArray, ok := valuesArray.(*array.FixedSizeBinary)
 			if !ok {
-				return 0, fmt.Errorf("invalid value type %T, expect %T", valuesArray.DataType(), vb.Type())
+				return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", valuesArray.DataType(), vb.Type())
 			}
 			for i := start; i < end; i++ {
 				val := fixedArray.Value(int(i))
@@ -243,12 +243,12 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 				totalSize += uint64(len(val))
 			}
 		default:
-			return 0, fmt.Errorf("unsupported value builder type in ListBuilder: %T", valueBuilder)
+			return 0, merr.WrapErrServiceInternalMsg("unsupported value builder type in ListBuilder: %T", valueBuilder)
 		}
 
 		return totalSize, nil
 	default:
-		return 0, fmt.Errorf("unsupported builder type: %T", builder)
+		return 0, merr.WrapErrServiceInternalMsg("unsupported builder type: %T", builder)
 	}
 }
 
@@ -356,7 +356,7 @@ func (b *RecordBuilder) Append(rec Record, start, end int) error {
 			col := rec.Column(f.FieldID)
 			size, err := appendValueAt(builder, col, offset, f.GetDefaultValue())
 			if err != nil {
-				return fmt.Errorf("failed to append value at offset %d for field %s: %w", offset, f.GetName(), err)
+				return merr.Wrapf(err, "failed to append value at offset %d for field %s", offset, f.GetName())
 			}
 			b.size += size
 		}

--- a/internal/storage/binlog_reader.go
+++ b/internal/storage/binlog_reader.go
@@ -19,15 +19,14 @@ package storage
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // BinlogReader is an object to read binlog file. Binlog file's format can be
@@ -43,7 +42,7 @@ type BinlogReader struct {
 // NextEventReader iters all events reader to read the binlog file.
 func (reader *BinlogReader) NextEventReader() (*EventReader, error) {
 	if reader.isClose {
-		return nil, errors.New("bin log reader is closed")
+		return nil, merr.WrapErrServiceInternalMsg("bin log reader is closed")
 	}
 	if reader.buffer.Len() <= 0 {
 		return nil, nil
@@ -69,7 +68,7 @@ func readMagicNumber(buffer io.Reader) (int32, error) {
 		return -1, err
 	}
 	if magicNumber != MagicNumber {
-		return -1, fmt.Errorf("parse magic number failed, expected: %d, actual: %d", MagicNumber, magicNumber)
+		return -1, merr.WrapErrServiceInternalMsg("parse magic number failed, expected: %d, actual: %d", MagicNumber, magicNumber)
 	}
 
 	return magicNumber, nil

--- a/internal/storage/binlog_record_writer.go
+++ b/internal/storage/binlog_record_writer.go
@@ -335,7 +335,7 @@ func newPackedBinlogRecordWriter(collectionID, partitionID, segmentID UniqueID, 
 ) (*PackedBinlogRecordWriter, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	writer := &PackedBinlogRecordWriter{
@@ -513,7 +513,7 @@ func (pw *PackedManifestRecordWriter) appendV3Stats(updates *packed.ManifestUpda
 		}
 		fullPath := path.Join(pw.basePath, fmt.Sprintf("_stats/bloom_filter.%d/%d", pkFieldID, id))
 		if err := packed.WriteFile(pw.storageConfig, fullPath, statsBlob.Value); err != nil {
-			return fmt.Errorf("appendV3Stats: failed to write bloom filter stats: %w", err)
+			return merr.Wrap(err, "appendV3Stats: failed to write bloom filter stats")
 		}
 		updates.Stats = append(updates.Stats, packed.StatEntry{
 			Key:      fmt.Sprintf("bloom_filter.%d", pkFieldID),
@@ -533,7 +533,7 @@ func (pw *PackedManifestRecordWriter) appendV3Stats(updates *packed.ManifestUpda
 		}
 		fullPath := path.Join(pw.basePath, fmt.Sprintf("_stats/bm25.%d/%d", fieldID, id))
 		if err := packed.WriteFile(pw.storageConfig, fullPath, blob.Value); err != nil {
-			return fmt.Errorf("appendV3Stats: failed to write bm25 stats: %w", err)
+			return merr.Wrap(err, "appendV3Stats: failed to write bm25 stats")
 		}
 		updates.Stats = append(updates.Stats, packed.StatEntry{
 			Key:      fmt.Sprintf("bm25.%d", fieldID),
@@ -551,7 +551,7 @@ func newPackedManifestRecordWriter(collectionID, partitionID, segmentID UniqueID
 ) (*PackedManifestRecordWriter, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	writer := &PackedManifestRecordWriter{
@@ -725,7 +725,7 @@ func NewPackedTextManifestRecordWriter(
 ) (*PackedTextManifestRecordWriter, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	writer := &PackedTextManifestRecordWriter{

--- a/internal/storage/binlog_util.go
+++ b/internal/storage/binlog_util.go
@@ -1,11 +1,11 @@
 package storage
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // ParseSegmentIDByBinlog parse segment id from binlog paths
@@ -13,7 +13,7 @@ import (
 func ParseSegmentIDByBinlog(rootPath, path string) (UniqueID, error) {
 	// check path contains rootPath as prefix
 	if !strings.HasPrefix(path, rootPath) {
-		return 0, fmt.Errorf("path \"%s\" does not contains rootPath \"%s\"", path, rootPath)
+		return 0, merr.WrapErrServiceInternalMsg("path \"%s\" does not contains rootPath \"%s\"", path, rootPath)
 	}
 	p := path[len(rootPath):]
 
@@ -30,12 +30,12 @@ func ParseSegmentIDByBinlog(rootPath, path string) (UniqueID, error) {
 		if len(keyStr) == 5 {
 			return strconv.ParseInt(keyStr[3], 10, 64)
 		}
-		return 0, fmt.Errorf("%s is not a valid delta log path", path)
+		return 0, merr.WrapErrServiceInternalMsg("%s is not a valid delta log path", path)
 	}
 
 	// log type are binlog or statslog
 	if len(keyStr) == 6 {
 		return strconv.ParseInt(keyStr[len(keyStr)-3], 10, 64)
 	}
-	return 0, fmt.Errorf("%s is not a valid binlog path", path)
+	return 0, merr.WrapErrServiceInternalMsg("%s is not a valid binlog path", path)
 }

--- a/internal/storage/binlog_writer.go
+++ b/internal/storage/binlog_writer.go
@@ -20,13 +20,13 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/hook"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // BinlogType is to distinguish different files saving different data.
@@ -114,7 +114,7 @@ func (writer *baseBinlogWriter) GetBinlogType() BinlogType {
 // GetBuffer gets binlog buffer. Return nil if binlog is not finished yet.
 func (writer *baseBinlogWriter) GetBuffer() ([]byte, error) {
 	if writer.buffer == nil {
-		return nil, errors.New("please close binlog before get buffer")
+		return nil, merr.WrapErrServiceInternalMsg("please close binlog before get buffer")
 	}
 	return writer.buffer.Bytes(), nil
 }
@@ -125,7 +125,7 @@ func (writer *baseBinlogWriter) Finish() error {
 		return nil
 	}
 	if writer.StartTimestamp == 0 || writer.EndTimestamp == 0 {
-		return errors.New("invalid start/end timestamp")
+		return merr.WrapErrServiceInternalMsg("invalid start/end timestamp")
 	}
 
 	var offset int32
@@ -194,7 +194,7 @@ type InsertBinlogWriter struct {
 // NextInsertEventWriter returns an event writer to write insert data to an event.
 func (writer *InsertBinlogWriter) NextInsertEventWriter(opts ...PayloadWriterOptions) (*insertEventWriter, error) {
 	if writer.isClosed() {
-		return nil, errors.New("binlog has closed")
+		return nil, merr.WrapErrServiceInternalMsg("binlog has closed")
 	}
 
 	event, err := newInsertEventWriter(writer.PayloadDataType, opts...)
@@ -214,7 +214,7 @@ type DeleteBinlogWriter struct {
 // NextDeleteEventWriter returns an event writer to write delete data to an event.
 func (writer *DeleteBinlogWriter) NextDeleteEventWriter(opts ...PayloadWriterOptions) (*deleteEventWriter, error) {
 	if writer.isClosed() {
-		return nil, errors.New("binlog has closed")
+		return nil, merr.WrapErrServiceInternalMsg("binlog has closed")
 	}
 	event, err := newDeleteEventWriter(writer.PayloadDataType, opts...)
 	if err != nil {
@@ -232,7 +232,7 @@ type IndexFileBinlogWriter struct {
 // NextIndexFileEventWriter return next available EventWriter
 func (writer *IndexFileBinlogWriter) NextIndexFileEventWriter() (*indexFileEventWriter, error) {
 	if writer.isClosed() {
-		return nil, errors.New("binlog has closed")
+		return nil, merr.WrapErrServiceInternalMsg("binlog has closed")
 	}
 	event, err := newIndexFileEventWriter(writer.PayloadDataType)
 	if err != nil {

--- a/internal/storage/data_codec.go
+++ b/internal/storage/data_codec.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"sort"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
@@ -146,7 +145,7 @@ func NewInsertCodecWithSchema(schema *etcdpb.CollectionMeta) *InsertCodec {
 // Serialize Pk stats log
 func (insertCodec *InsertCodec) SerializePkStats(stats *PrimaryKeyStats, rowNum int64) (*Blob, error) {
 	if stats == nil || stats.BF == nil {
-		return nil, errors.New("sericalize empty pk stats")
+		return nil, merr.WrapErrServiceInternalMsg("sericalize empty pk stats")
 	}
 
 	// Serialize by pk stats
@@ -191,10 +190,10 @@ func (insertCodec *InsertCodec) SerializePkStatsList(stats []*PrimaryKeyStats, r
 func (insertCodec *InsertCodec) SerializePkStatsByData(data *InsertData) (*Blob, error) {
 	timeFieldData, ok := data.Data[common.TimeStampField]
 	if !ok {
-		return nil, errors.New("data doesn't contains timestamp field")
+		return nil, merr.WrapErrServiceInternalMsg("data doesn't contains timestamp field")
 	}
 	if timeFieldData.RowNum() <= 0 {
-		return nil, errors.New("there's no data in InsertData")
+		return nil, merr.WrapErrServiceInternalMsg("there's no data in InsertData")
 	}
 	rowNum := int64(timeFieldData.RowNum())
 
@@ -217,7 +216,7 @@ func (insertCodec *InsertCodec) SerializePkStatsByData(data *InsertData) (*Blob,
 			RowNum: rowNum,
 		}, nil
 	}
-	return nil, errors.New("there is no pk field")
+	return nil, merr.WrapErrServiceInternalMsg("there is no pk field")
 }
 
 // Serialize transforms insert data to blob. It will sort insert data by timestamp.
@@ -228,7 +227,7 @@ func (insertCodec *InsertCodec) Serialize(partitionID UniqueID, segmentID Unique
 	blobs := make([]*Blob, 0)
 	var writer *InsertBinlogWriter
 	if insertCodec.Schema == nil {
-		return nil, errors.New("schema is not set")
+		return nil, merr.WrapErrServiceInternalMsg("schema is not set")
 	}
 
 	var rowNum int64
@@ -238,7 +237,7 @@ func (insertCodec *InsertCodec) Serialize(partitionID UniqueID, segmentID Unique
 	for _, block := range data {
 		timeFieldData, ok := block.Data[common.TimeStampField]
 		if !ok {
-			return nil, errors.New("data doesn't contains timestamp field")
+			return nil, merr.WrapErrServiceInternalMsg("data doesn't contains timestamp field")
 		}
 
 		rowNum += int64(timeFieldData.RowNum())
@@ -281,11 +280,11 @@ func (insertCodec *InsertCodec) Serialize(partitionID UniqueID, segmentID Unique
 		// found missing block
 		if !allExists {
 			if !field.GetNullable() {
-				return errors.Newf("field %d(%s) missing and field not nullable", field.GetFieldID(), field.GetName())
+				return merr.WrapErrStorageMsg("field %d(%s) missing and field not nullable", field.GetFieldID(), field.GetName())
 			}
 			// segment must be in same schema
 			if !allMissing {
-				return errors.Newf("segment must not be heterogeneous, all blocks must contain all fields or none, abnormal field %d(%s)", field.GetFieldID(), field.GetName())
+				return merr.WrapErrStorageMsg("segment must not be heterogeneous, all blocks must contain all fields or none, abnormal field %d(%s)", field.GetFieldID(), field.GetName())
 			}
 			log.Info("Skip field nullable missing field, could be schema change", zap.Int64("fieldId", field.GetFieldID()), zap.String("fieldName", field.GetName()))
 			return nil
@@ -474,13 +473,13 @@ func AddFieldDataToPayload(eventWriter *insertEventWriter, dataType schemapb.Dat
 	case schemapb.DataType_ArrayOfVector:
 		vectorArrayData := singleData.(*VectorArrayFieldData)
 		if vectorArrayData.Nullable {
-			return fmt.Errorf("nullable ArrayOfVector is not supported in V1 storage format")
+			return merr.WrapErrStorageMsg("nullable ArrayOfVector is not supported in V1 storage format")
 		}
 		if err = eventWriter.AddVectorArrayFieldDataToPayload(vectorArrayData); err != nil {
 			return err
 		}
 	default:
-		return fmt.Errorf("undefined data type %d", dataType)
+		return merr.WrapErrServiceInternalMsg("undefined data type %d", dataType)
 	}
 	return nil
 }
@@ -493,7 +492,7 @@ func (insertCodec *InsertCodec) DeserializeAll(blobs []*Blob) (
 	err error,
 ) {
 	if len(blobs) == 0 {
-		return InvalidUniqueID, InvalidUniqueID, InvalidUniqueID, nil, errors.New("blobs is empty")
+		return InvalidUniqueID, InvalidUniqueID, InvalidUniqueID, nil, merr.WrapErrServiceInternalMsg("blobs is empty")
 	}
 
 	var blobList BlobList = blobs
@@ -897,14 +896,14 @@ func AddInsertData(dataType schemapb.DataType, data interface{}, insertData *Ins
 		vectorArrayFieldData := fieldData.(*VectorArrayFieldData)
 
 		if len(validData) > 0 {
-			return 0, fmt.Errorf("nullable ArrayOfVector is not supported in V1 storage format")
+			return 0, merr.WrapErrStorageMsg("nullable ArrayOfVector is not supported in V1 storage format")
 		}
 		vectorArrayFieldData.Data = append(vectorArrayFieldData.Data, singleData...)
 		insertData.Data[fieldID] = vectorArrayFieldData
 		return len(singleData), nil
 
 	default:
-		return 0, fmt.Errorf("undefined data type %d", dataType)
+		return 0, merr.WrapErrServiceInternalMsg("undefined data type %d", dataType)
 	}
 }
 
@@ -940,7 +939,7 @@ func (deleteCodec *DeleteCodec) Serialize(collectionID UniqueID, partitionID Uni
 	defer eventWriter.Close()
 	length := len(data.Pks)
 	if length != len(data.Tss) {
-		return nil, errors.New("the length of pks, and TimeStamps is not equal")
+		return nil, merr.WrapErrServiceInternalMsg("the length of pks, and TimeStamps is not equal")
 	}
 
 	sizeTotal := 0
@@ -993,7 +992,7 @@ func (deleteCodec *DeleteCodec) Serialize(collectionID UniqueID, partitionID Uni
 // Deserialize deserializes the deltalog blobs into DeleteData
 func (deleteCodec *DeleteCodec) Deserialize(blobs []*Blob) (partitionID UniqueID, segmentID UniqueID, data *DeltaData, err error) {
 	if len(blobs) == 0 {
-		return InvalidUniqueID, InvalidUniqueID, nil, errors.New("blobs is empty")
+		return InvalidUniqueID, InvalidUniqueID, nil, merr.WrapErrServiceInternalMsg("blobs is empty")
 	}
 
 	rowNum := lo.SumBy(blobs, func(blob *Blob) int64 {

--- a/internal/storage/delta_data.go
+++ b/internal/storage/delta_data.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -26,7 +25,6 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 
@@ -126,7 +124,7 @@ func NewDeltaDataWithPkType(cap int64, pkType schemapb.DataType) (*DeltaData, er
 
 func NewDeltaDataWithData(pks PrimaryKeys, tss []uint64) (*DeltaData, error) {
 	if pks.Len() != len(tss) {
-		return nil, merr.WrapErrParameterInvalidMsg("length of pks and tss not equal")
+		return nil, merr.WrapErrStorageMsg("length of pks and tss not equal: pks=%d tss=%d", pks.Len(), len(tss))
 	}
 	dd := &DeltaData{
 		deletePks:        pks,
@@ -167,23 +165,23 @@ func (dl *DeleteLog) Parse(val string) error {
 		pkRes := result.Get("pk")
 		pkTypeRes := result.Get("pkType")
 		if !tsRes.Exists() || !pkRes.Exists() || !pkTypeRes.Exists() {
-			return fmt.Errorf("invalid delete log json: missing required fields in %s", val)
+			return merr.WrapErrServiceInternalMsg("invalid delete log json: missing required fields in %s", val)
 		}
 		dl.Ts = tsRes.Uint()
 		dl.PkType = pkTypeRes.Int()
 		switch dl.PkType {
 		case int64(schemapb.DataType_Int64):
 			if pkRes.Type != gjson.Number {
-				return fmt.Errorf("invalid delete log: pkType is Int64 but pk is not a number in %s", val)
+				return merr.WrapErrServiceInternalMsg("invalid delete log: pkType is Int64 but pk is not a number in %s", val)
 			}
 			dl.Pk = &Int64PrimaryKey{Value: pkRes.Int()}
 		case int64(schemapb.DataType_VarChar):
 			if pkRes.Type != gjson.String {
-				return fmt.Errorf("invalid delete log: pkType is VarChar but pk is not a string in %s", val)
+				return merr.WrapErrServiceInternalMsg("invalid delete log: pkType is VarChar but pk is not a string in %s", val)
 			}
 			dl.Pk = &VarCharPrimaryKey{Value: pkRes.String()}
 		default:
-			return fmt.Errorf("invalid delete log: unsupported pkType %d in %s", dl.PkType, val)
+			return merr.WrapErrServiceInternalMsg("invalid delete log: unsupported pkType %d in %s", dl.PkType, val)
 		}
 		return nil
 	}
@@ -192,7 +190,7 @@ func (dl *DeleteLog) Parse(val string) error {
 	// compatible with fmt.Sprintf("%d,%d", pk, ts)
 	splits := strings.Split(val, ",")
 	if len(splits) != 2 {
-		return fmt.Errorf("the format of delta log is incorrect, %v can not be split", val)
+		return merr.WrapErrServiceInternalMsg("the format of delta log is incorrect, %v can not be split", val)
 	}
 	pk, err := strconv.ParseInt(splits[0], 10, 64)
 	if err != nil {
@@ -226,7 +224,7 @@ func (dl *DeleteLog) UnmarshalJSON(data []byte) error {
 	case schemapb.DataType_VarChar:
 		dl.Pk = &VarCharPrimaryKey{}
 	default:
-		return fmt.Errorf("unsupported primary key type: %v", schemapb.DataType(dl.PkType))
+		return merr.WrapErrServiceInternalMsg("unsupported primary key type: %v", schemapb.DataType(dl.PkType))
 	}
 
 	if err = json.Unmarshal(*messageMap["pk"], dl.Pk); err != nil {
@@ -296,10 +294,10 @@ func BuildDeleteRecord(pks []PrimaryKey, tss []Timestamp) (r Record, tsFrom uint
 	tsTo = 0
 
 	if len(pks) == 0 {
-		return nil, 0, 0, errors.New("empty primary keys")
+		return nil, 0, 0, merr.WrapErrServiceInternalMsg("empty primary keys")
 	}
 	if len(pks) != len(tss) {
-		return nil, 0, 0, errors.New("length of pks and tss must be equal")
+		return nil, 0, 0, merr.WrapErrServiceInternalMsg("length of pks and tss must be equal")
 	}
 
 	allocator := memory.DefaultAllocator
@@ -322,7 +320,7 @@ func BuildDeleteRecord(pks []PrimaryKey, tss []Timestamp) (r Record, tsFrom uint
 		}
 		pkArray = builder.NewArray()
 	default:
-		return nil, 0, 0, errors.Newf("unsupported primary key type %T", pks[0])
+		return nil, 0, 0, merr.WrapErrStorageMsg("unsupported primary key type %T", pks[0])
 	}
 
 	// Build timestamp array

--- a/internal/storage/event_data.go
+++ b/internal/storage/event_data.go
@@ -18,11 +18,8 @@ package storage
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
 	"strconv"
-
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
@@ -81,7 +78,7 @@ func (data *descriptorEventData) GetNullable() (bool, error) {
 	nullable, ok := nullableStore.(bool)
 	// will not happen, has checked bool format when FinishExtra
 	if !ok {
-		return false, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in bool format", nullableKey))
+		return false, merr.WrapErrDataIntegrityMsg("value of %v must in bool format", nullableKey)
 	}
 	return nullable, nil
 }
@@ -128,24 +125,24 @@ func (data *descriptorEventData) FinishExtra() error {
 	// keep all binlog file records the original size
 	sizeStored, ok := data.Extras[originalSizeKey]
 	if !ok {
-		return fmt.Errorf("%v not in extra", originalSizeKey)
+		return merr.WrapErrServiceInternalMsg("%v not in extra", originalSizeKey)
 	}
 	// if we store a large int directly, golang will use scientific notation, we then will get a float value.
 	// so it's better to store the original size in string format.
 	sizeStr, ok := sizeStored.(string)
 	if !ok {
-		return fmt.Errorf("value of %v must in string format", originalSizeKey)
+		return merr.WrapErrServiceInternalMsg("value of %v must in string format", originalSizeKey)
 	}
 	_, err = strconv.Atoi(sizeStr)
 	if err != nil {
-		return fmt.Errorf("value of %v must be able to be converted into int format", originalSizeKey)
+		return merr.WrapErrServiceInternalMsg("value of %v must be able to be converted into int format", originalSizeKey)
 	}
 
 	nullableStore, existed := data.Extras[nullableKey]
 	if existed {
 		_, ok := nullableStore.(bool)
 		if !ok {
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in bool format", nullableKey))
+			return merr.WrapErrDataIntegrityMsg("value of %v must in bool format", nullableKey)
 		}
 	}
 
@@ -153,14 +150,14 @@ func (data *descriptorEventData) FinishExtra() error {
 	if exist {
 		_, ok := edekStored.(string)
 		if !ok {
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in string format", edekKey))
+			return merr.WrapErrDataIntegrityMsg("value of %v must in string format", edekKey)
 		}
 	}
 	ezIDStored, exist := data.Extras[ezIDKey]
 	if exist {
 		_, ok := ezIDStored.(int64)
 		if !ok {
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in int64 format", ezIDKey))
+			return merr.WrapErrDataIntegrityMsg("value of %v must in int64 format", ezIDKey)
 		}
 	}
 
@@ -236,10 +233,10 @@ func (data *insertEventData) GetEventDataFixPartSize() int32 {
 
 func (data *insertEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -260,10 +257,10 @@ func (data *deleteEventData) GetEventDataFixPartSize() int32 {
 
 func (data *deleteEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -284,10 +281,10 @@ func (data *createCollectionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *createCollectionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -308,10 +305,10 @@ func (data *dropCollectionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *dropCollectionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -332,10 +329,10 @@ func (data *createPartitionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *createPartitionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -356,10 +353,10 @@ func (data *dropPartitionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *dropPartitionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -380,10 +377,10 @@ func (data *indexFileEventData) GetEventDataFixPartSize() int32 {
 
 func (data *indexFileEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }

--- a/internal/storage/event_reader.go
+++ b/internal/storage/event_reader.go
@@ -18,11 +18,9 @@ package storage
 
 import (
 	"bytes"
-	"fmt"
-
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // EventReader is used to parse the events contained in the Binlog file.
@@ -36,7 +34,7 @@ type EventReader struct {
 
 func (reader *EventReader) readHeader() error {
 	if reader.isClosed {
-		return errors.New("event reader is closed")
+		return merr.WrapErrServiceInternalMsg("event reader is closed")
 	}
 	header, err := readEventHeader(reader.buffer)
 	if err != nil {
@@ -48,7 +46,7 @@ func (reader *EventReader) readHeader() error {
 
 func (reader *EventReader) readData() error {
 	if reader.isClosed {
-		return errors.New("event reader is closed")
+		return merr.WrapErrServiceInternalMsg("event reader is closed")
 	}
 	var data eventData
 	var err error
@@ -68,7 +66,7 @@ func (reader *EventReader) readData() error {
 	case IndexFileEventType:
 		data, err = readIndexFileEventDataFixPart(reader.buffer)
 	default:
-		return fmt.Errorf("unknown header type code: %d", reader.TypeCode)
+		return merr.WrapErrServiceInternalMsg("unknown header type code: %d", reader.TypeCode)
 	}
 	if err != nil {
 		return err

--- a/internal/storage/event_writer.go
+++ b/internal/storage/event_writer.go
@@ -21,10 +21,9 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // EventTypeCode represents event type by code
@@ -266,7 +265,7 @@ func newDeleteEventWriter(dataType schemapb.DataType, opts ...PayloadWriterOptio
 
 func newCreateCollectionEventWriter(dataType schemapb.DataType) (*createCollectionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)
@@ -292,7 +291,7 @@ func newCreateCollectionEventWriter(dataType schemapb.DataType) (*createCollecti
 
 func newDropCollectionEventWriter(dataType schemapb.DataType) (*dropCollectionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)
@@ -318,7 +317,7 @@ func newDropCollectionEventWriter(dataType schemapb.DataType) (*dropCollectionEv
 
 func newCreatePartitionEventWriter(dataType schemapb.DataType) (*createPartitionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)
@@ -344,7 +343,7 @@ func newCreatePartitionEventWriter(dataType schemapb.DataType) (*createPartition
 
 func newDropPartitionEventWriter(dataType schemapb.DataType) (*dropPartitionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -3,9 +3,8 @@ package storage
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -55,7 +54,7 @@ func (f *ChunkManagerFactory) newChunkManager(ctx context.Context, engine string
 	case "remote", "minio", "opendal":
 		return NewRemoteChunkManager(ctx, f.config)
 	default:
-		return nil, errors.New("no chunk manager implemented with engine: " + engine)
+		return nil, merr.WrapErrServiceInternalMsg("no chunk manager implemented with engine: " + engine)
 	}
 }
 

--- a/internal/storage/field_stats.go
+++ b/internal/storage/field_stats.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -67,7 +66,7 @@ func (stats *FieldStats) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	} else {
-		return errors.New("invalid fieldStats, no fieldID")
+		return merr.WrapErrServiceInternalMsg("invalid fieldStats, no fieldID")
 	}
 
 	stats.Type = schemapb.DataType_Int64
@@ -471,7 +470,7 @@ func (sr *FieldStatsReader) GetFieldStatsList() ([]*FieldStats, error) {
 		stats := &FieldStats{}
 		errNew := json.Unmarshal(sr.buffer, &stats)
 		if errNew != nil {
-			return nil, merr.WrapErrParameterInvalid("valid JSON", string(sr.buffer), err.Error())
+			return nil, merr.WrapErrDataIntegrity(err, "FieldStats list unmarshal failed")
 		}
 		return []*FieldStats{stats}, nil
 	}

--- a/internal/storage/field_stats_test.go
+++ b/internal/storage/field_stats_test.go
@@ -419,7 +419,7 @@ func TestDeserializeFieldStatsFailed(t *testing.T) {
 		}
 
 		_, err := DeserializeFieldStats(blob)
-		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.ErrorIs(t, err, merr.ErrDataIntegrity)
 	})
 
 	t.Run("valid field stats", func(t *testing.T) {

--- a/internal/storage/field_value.go
+++ b/internal/storage/field_value.go
@@ -21,8 +21,6 @@ import (
 	"math"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/log"
@@ -159,7 +157,7 @@ func (ifv *Int8FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int8)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -279,7 +277,7 @@ func (ifv *Int16FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int16)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -399,7 +397,7 @@ func (ifv *Int32FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int32)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -519,7 +517,7 @@ func (ifv *Int64FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int64)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -640,7 +638,7 @@ func (ifv *FloatFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(float32)
 	if !ok {
 		log.Warn("wrong type value when setValue for FloatFieldValue")
-		return errors.New("wrong type value when setValue for FloatFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for FloatFieldValue")
 	}
 
 	ifv.Value = value
@@ -760,7 +758,7 @@ func (ifv *DoubleFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(float64)
 	if !ok {
 		log.Warn("wrong type value when setValue for DoubleFieldValue")
-		return errors.New("wrong type value when setValue for DoubleFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for DoubleFieldValue")
 	}
 
 	ifv.Value = value
@@ -856,7 +854,7 @@ func (sfv *StringFieldValue) UnmarshalJSON(data []byte) error {
 func (sfv *StringFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(string)
 	if !ok {
-		return errors.New("wrong type value when setValue for StringFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for StringFieldValue")
 	}
 
 	sfv.Value = value
@@ -934,7 +932,7 @@ func (vcfv *VarCharFieldValue) EQ(obj ScalarFieldValue) bool {
 func (vcfv *VarCharFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(string)
 	if !ok {
-		return errors.New("wrong type value when setValue for StringFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for StringFieldValue")
 	}
 
 	vcfv.Value = value
@@ -1014,7 +1012,7 @@ func (ifv *FloatVectorFieldValue) SetValue(data interface{}) error {
 	value, ok := data.([]float32)
 	if !ok {
 		log.Warn("wrong type value when setValue for FloatVectorFieldValue")
-		return errors.New("wrong type value when setValue for FloatVectorFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for FloatVectorFieldValue")
 	}
 
 	ifv.Value = value

--- a/internal/storage/index_data_codec.go
+++ b/internal/storage/index_data_codec.go
@@ -21,12 +21,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -164,7 +164,7 @@ func (codec *IndexFileBinlogCodec) DeserializeImpl(blobs []*Blob) (
 	err error,
 ) {
 	if len(blobs) == 0 {
-		return 0, 0, 0, 0, 0, 0, nil, "", 0, nil, errors.New("blobs is empty")
+		return 0, 0, 0, 0, 0, 0, nil, "", 0, nil, merr.WrapErrServiceInternalMsg("blobs is empty")
 	}
 	indexParams = make(map[string]string)
 	datas = make([]*Blob, 0)
@@ -250,7 +250,7 @@ func (codec *IndexFileBinlogCodec) DeserializeImpl(blobs []*Blob) (
 
 				// make sure there is one string
 				if len(content) != 1 {
-					err := fmt.Errorf("failed to parse index event because content length is not one %d", len(content))
+					err := merr.WrapErrServiceInternalMsg("failed to parse index event because content length is not one %d", len(content))
 					eventReader.Close()
 					binlogReader.Close()
 					return 0, 0, 0, 0, 0, 0, nil, "", 0, nil, err
@@ -321,7 +321,7 @@ func (indexCodec *IndexCodec) Deserialize(blobs []*Blob) ([]*Blob, map[string]st
 		break
 	}
 	if file == nil {
-		return nil, nil, "", InvalidUniqueID, errors.New("can not find params blob")
+		return nil, nil, "", InvalidUniqueID, merr.WrapErrServiceInternalMsg("can not find params blob")
 	}
 	info := struct {
 		Params    map[string]string
@@ -329,7 +329,7 @@ func (indexCodec *IndexCodec) Deserialize(blobs []*Blob) ([]*Blob, map[string]st
 		IndexID   UniqueID
 	}{}
 	if err := json.Unmarshal(file.Value, &info); err != nil {
-		return nil, nil, "", InvalidUniqueID, fmt.Errorf("json unmarshal error: %s", err.Error())
+		return nil, nil, "", InvalidUniqueID, merr.WrapErrServiceInternalMsg("json unmarshal error: %s", err.Error())
 	}
 
 	return blobs, info.Params, info.IndexName, info.IndexID, nil

--- a/internal/storage/insert_data.go
+++ b/internal/storage/insert_data.go
@@ -149,7 +149,7 @@ func (i *InsertData) Append(row map[FieldID]interface{}) error {
 	for fID, v := range row {
 		field, ok := i.Data[fID]
 		if !ok {
-			return fmt.Errorf("missing field when appending row, got %d", fID)
+			return merr.WrapErrServiceInternalMsg("missing field when appending row, got %d", fID)
 		}
 
 		if err := field.AppendRow(v); err != nil {
@@ -405,7 +405,7 @@ func NewFieldData(dataType schemapb.DataType, fieldSchema *schemapb.FieldSchema,
 		}
 		return data, nil
 	default:
-		return nil, fmt.Errorf("unexpected schema data type: %d", dataType)
+		return nil, merr.WrapErrServiceInternalMsg("unexpected schema data type: %d", dataType)
 	}
 }
 

--- a/internal/storage/local_chunk_manager.go
+++ b/internal/storage/local_chunk_manager.go
@@ -119,7 +119,7 @@ func (lcm *LocalChunkManager) MultiWrite(ctx context.Context, contents map[strin
 	for filePath, content := range contents {
 		err := lcm.Write(ctx, filePath, content)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "write %s failed", filePath))
+			el = merr.Combine(el, merr.Wrapf(err, "write %s failed", filePath))
 		}
 	}
 	return el
@@ -149,7 +149,7 @@ func (lcm *LocalChunkManager) MultiRead(ctx context.Context, filePaths []string)
 	for i, filePath := range filePaths {
 		content, err := lcm.Read(ctx, filePath)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to read %s", filePath))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to read %s", filePath))
 		}
 		results[i] = content
 	}
@@ -271,7 +271,7 @@ func (lcm *LocalChunkManager) RemoveWithPrefix(ctx context.Context, prefix strin
 	if len(prefix) == 0 {
 		errMsg := "empty prefix is not allowed for ChunkManager remove operation"
 		log.Warn(errMsg)
-		return merr.WrapErrParameterInvalidMsg(errMsg)
+		return merr.WrapErrStorageMsg("%s", errMsg)
 	}
 	var removeErr error
 	if err := lcm.WalkWithPrefix(ctx, prefix, true, func(chunkInfo *ChunkObjectInfo) bool {

--- a/internal/storage/minio_object_storage_test.go
+++ b/internal/storage/minio_object_storage_test.go
@@ -201,31 +201,51 @@ func TestMinioObjectStorage(t *testing.T) {
 	})
 
 	t.Run("test useIAM", func(t *testing.T) {
+		// newMinioObjectStorageWithConfig validates IAM credentials by calling
+		// BucketExists against the configured endpoint. With invalid IAM
+		// credentials on a host where the endpoint is unreachable, the dial
+		// blocks long enough that retry.Do (CheckBucketRetryAttempts=20) drags
+		// the whole package out to the 10min testing.M timeout. Bound each
+		// call with a short context so it fails fast regardless of
+		// environment; the test only asserts an error is returned. Mirrors
+		// the Azure fix in PR #49814.
 		var err error
 		config.UseIAM = true
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.UseIAM = false
 	})
 
 	t.Run("test ssl", func(t *testing.T) {
+		// Same endpoint-unreachable hang as the "test useIAM" subtest above:
+		// UseSSL=true with a dummy CA cert against a non-TLS minio endpoint
+		// keeps retry.Do dialing until the testing.M timeout. Bound it.
 		var err error
 		config.UseSSL = true
 		config.SslCACert = "/tmp/dummy.crt"
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.UseSSL = false
 	})
 
 	t.Run("test cloud provider", func(t *testing.T) {
+		// Same endpoint-unreachable hang as the "test useIAM" subtest above.
 		var err error
 		cloudProvider := config.CloudProvider
 		config.CloudProvider = "aliyun"
 		config.UseIAM = true
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.UseIAM = false
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.CloudProvider = "gcp"
 		_, err = newMinioObjectStorageWithConfig(ctx, &config)

--- a/internal/storage/payload_reader.go
+++ b/internal/storage/payload_reader.go
@@ -13,7 +13,6 @@ import (
 	"github.com/apache/arrow/go/v17/parquet"
 	"github.com/apache/arrow/go/v17/parquet/file"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -39,7 +38,7 @@ var _ PayloadReaderInterface = (*PayloadReader)(nil)
 
 func NewPayloadReader(colType schemapb.DataType, buf []byte, nullable bool) (*PayloadReader, error) {
 	if len(buf) == 0 {
-		return nil, errors.New("create Payload reader failed, buffer is empty")
+		return nil, merr.WrapErrServiceInternalMsg("create Payload reader failed, buffer is empty")
 	}
 	parquetReader, err := file.NewParquetReader(bytes.NewReader(buf))
 	if err != nil {
@@ -56,32 +55,32 @@ func NewPayloadReader(colType schemapb.DataType, buf []byte, nullable bool) (*Pa
 	if colType == schemapb.DataType_ArrayOfVector {
 		arrowReader, err := pqarrow.NewFileReader(parquetReader, pqarrow.ArrowReadProperties{BatchSize: 1024}, memory.DefaultAllocator)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create arrow reader for VectorArray: %w", err)
+			return nil, merr.WrapErrStorage(err, "failed to create arrow reader for VectorArray")
 		}
 
 		arrowSchema, err := arrowReader.Schema()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get arrow schema for VectorArray: %w", err)
+			return nil, merr.WrapErrStorage(err, "failed to get arrow schema for VectorArray")
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, fmt.Errorf("VectorArray should have exactly 1 field, got %d", arrowSchema.NumFields())
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray should have exactly 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
 		if !field.HasMetadata() {
-			return nil, errors.New("VectorArray field is missing metadata")
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray field is missing metadata")
 		}
 
 		metadata := field.Metadata
 
 		elementTypeStr, ok := metadata.GetValue("elementType")
 		if !ok {
-			return nil, errors.New("VectorArray metadata missing required 'elementType' field")
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray metadata missing required 'elementType' field")
 		}
 		elementTypeInt, err := strconv.ParseInt(elementTypeStr, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("invalid elementType in VectorArray metadata: %s", elementTypeStr)
+			return nil, merr.WrapErrServiceInternalMsg("invalid elementType in VectorArray metadata: %s", elementTypeStr)
 		}
 
 		elementType := schemapb.DataType(elementTypeInt)
@@ -94,19 +93,19 @@ func NewPayloadReader(colType schemapb.DataType, buf []byte, nullable bool) (*Pa
 			schemapb.DataType_SparseFloatVector:
 			reader.elementType = elementType
 		default:
-			return nil, fmt.Errorf("invalid vector type for VectorArray: %s", elementType.String())
+			return nil, merr.WrapErrServiceInternalMsg("invalid vector type for VectorArray: %s", elementType.String())
 		}
 
 		dimStr, ok := metadata.GetValue("dim")
 		if !ok {
-			return nil, errors.New("VectorArray metadata missing required 'dim' field")
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray metadata missing required 'dim' field")
 		}
 		dimVal, err := strconv.ParseInt(dimStr, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid dim in VectorArray metadata: %s", dimStr)
+			return nil, merr.WrapErrServiceInternalMsg("invalid dim in VectorArray metadata: %s", dimStr)
 		}
 		if dimVal <= 0 {
-			return nil, fmt.Errorf("VectorArray dim must be positive, got %d", dimVal)
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray dim must be positive, got %d", dimVal)
 		}
 		reader.dim = dimVal
 	}
@@ -182,7 +181,7 @@ func (r *PayloadReader) GetDataFromPayload() (interface{}, []bool, int, error) {
 		val, validData, err := r.GetGeometryFromPayload()
 		return val, validData, 0, err
 	default:
-		return nil, nil, 0, merr.WrapErrParameterInvalidMsg("unknown type")
+		return nil, nil, 0, merr.WrapErrDataIntegrityMsg("unknown type")
 	}
 }
 
@@ -194,7 +193,7 @@ func (r *PayloadReader) ReleasePayloadReader() error {
 // GetBoolFromPayload returns bool slice from payload.
 func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 	if r.colType != schemapb.DataType_Bool {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get bool from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get bool from datatype %v", r.colType.String())
 	}
 
 	values := make([]bool, r.numRows)
@@ -206,7 +205,7 @@ func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 			return nil, nil, err
 		}
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -215,7 +214,7 @@ func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 		return nil, nil, err
 	}
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
@@ -223,7 +222,7 @@ func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 // GetByteFromPayload returns byte slice from payload
 func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 	if r.colType != schemapb.DataType_Int8 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get byte from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get byte from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -234,7 +233,7 @@ func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 			return nil, nil, err
 		}
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		ret := make([]byte, r.numRows)
 		for i := int64(0); i < r.numRows; i++ {
@@ -249,7 +248,7 @@ func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, r.numRows)
@@ -261,7 +260,7 @@ func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 
 func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 	if r.colType != schemapb.DataType_Int8 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int8 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int8 from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -273,7 +272,7 @@ func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 
 		return values, validData, nil
@@ -285,7 +284,7 @@ func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]int8, r.numRows)
@@ -297,7 +296,7 @@ func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 
 func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 	if r.colType != schemapb.DataType_Int16 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int16 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int16 from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -309,7 +308,7 @@ func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -320,7 +319,7 @@ func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]int16, r.numRows)
@@ -332,7 +331,7 @@ func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 
 func (r *PayloadReader) GetInt32FromPayload() ([]int32, []bool, error) {
 	if r.colType != schemapb.DataType_Int32 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int32 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int32 from datatype %v", r.colType.String())
 	}
 
 	values := make([]int32, r.numRows)
@@ -344,7 +343,7 @@ func (r *PayloadReader) GetInt32FromPayload() ([]int32, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -354,14 +353,14 @@ func (r *PayloadReader) GetInt32FromPayload() ([]int32, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
 
 func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 	if r.colType != schemapb.DataType_Int64 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int64 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int64 from datatype %v", r.colType.String())
 	}
 
 	values := make([]int64, r.numRows)
@@ -373,7 +372,7 @@ func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 
 		return values, validData, nil
@@ -384,7 +383,7 @@ func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	return values, nil, nil
@@ -392,7 +391,7 @@ func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 
 func (r *PayloadReader) GetFloatFromPayload() ([]float32, []bool, error) {
 	if r.colType != schemapb.DataType_Float {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get float32 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get float32 from datatype %v", r.colType.String())
 	}
 
 	values := make([]float32, r.numRows)
@@ -403,7 +402,7 @@ func (r *PayloadReader) GetFloatFromPayload() ([]float32, []bool, error) {
 			return nil, nil, err
 		}
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -412,14 +411,14 @@ func (r *PayloadReader) GetFloatFromPayload() ([]float32, []bool, error) {
 		return nil, nil, err
 	}
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
 
 func (r *PayloadReader) GetDoubleFromPayload() ([]float64, []bool, error) {
 	if r.colType != schemapb.DataType_Double {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get double from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get double from datatype %v", r.colType.String())
 	}
 
 	values := make([]float64, r.numRows)
@@ -431,7 +430,7 @@ func (r *PayloadReader) GetDoubleFromPayload() ([]float64, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -441,14 +440,14 @@ func (r *PayloadReader) GetDoubleFromPayload() ([]float64, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
 
 func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 	if r.colType != schemapb.DataType_Timestamptz {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get timestamptz from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get timestamptz from datatype %v", r.colType.String())
 	}
 
 	values := make([]int64, r.numRows)
@@ -460,7 +459,7 @@ func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 
 		return values, validData, nil
@@ -471,7 +470,7 @@ func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	return values, nil, nil
@@ -479,7 +478,7 @@ func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 
 func (r *PayloadReader) GetStringFromPayload() ([]string, []bool, error) {
 	if r.colType != schemapb.DataType_String && r.colType != schemapb.DataType_VarChar {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get string from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get string from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -491,7 +490,7 @@ func (r *PayloadReader) GetStringFromPayload() ([]string, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -506,7 +505,7 @@ func (r *PayloadReader) GetStringFromPayload() ([]string, []bool, error) {
 
 func (r *PayloadReader) GetArrayFromPayload() ([]*schemapb.ScalarField, []bool, error) {
 	if r.colType != schemapb.DataType_Array {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get array from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get array from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -529,7 +528,7 @@ func (r *PayloadReader) GetArrayFromPayload() ([]*schemapb.ScalarField, []bool, 
 
 func (r *PayloadReader) GetVectorArrayFromPayload() ([]*schemapb.VectorField, error) {
 	if r.colType != schemapb.DataType_ArrayOfVector {
-		return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get vector from datatype %v", r.colType.String()))
+		return nil, merr.WrapErrDataIntegrityMsg("failed to get vector from datatype %v", r.colType.String())
 	}
 
 	return readVectorArrayFromListArray(r)
@@ -537,7 +536,7 @@ func (r *PayloadReader) GetVectorArrayFromPayload() ([]*schemapb.VectorField, er
 
 func (r *PayloadReader) GetJSONFromPayload() ([][]byte, []bool, error) {
 	if r.colType != schemapb.DataType_JSON {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get json from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get json from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -556,7 +555,7 @@ func (r *PayloadReader) GetJSONFromPayload() ([][]byte, []bool, error) {
 
 func (r *PayloadReader) GetGeometryFromPayload() ([][]byte, []bool, error) {
 	if r.colType != schemapb.DataType_Geometry {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get Geometry from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get Geometry from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -575,7 +574,7 @@ func (r *PayloadReader) GetGeometryFromPayload() ([][]byte, []bool, error) {
 
 func (r *PayloadReader) GetByteArrayDataSet() (*DataSet[parquet.ByteArray, *file.ByteArrayColumnChunkReader], error) {
 	if r.colType != schemapb.DataType_String && r.colType != schemapb.DataType_VarChar {
-		return nil, fmt.Errorf("failed to get string from datatype %v", r.colType.String())
+		return nil, merr.WrapErrServiceInternalMsg("failed to get string from datatype %v", r.colType.String())
 	}
 
 	return NewDataSet[parquet.ByteArray, *file.ByteArrayColumnChunkReader](r.reader, 0, r.numRows), nil
@@ -610,7 +609,7 @@ func readVectorArrayFromListArray(r *PayloadReader) ([]*schemapb.VectorField, er
 	defer table.Release()
 
 	if table.NumCols() != 1 {
-		return nil, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+		return nil, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 	}
 
 	column := table.Column(0)
@@ -625,17 +624,17 @@ func readVectorArrayFromListArray(r *PayloadReader) ([]*schemapb.VectorField, er
 	for _, chunk := range column.Data().Chunks() {
 		listArray, ok := chunk.(*array.List)
 		if !ok {
-			return nil, fmt.Errorf("expected ListArray, got %T", chunk)
+			return nil, merr.WrapErrServiceInternalMsg("expected ListArray, got %T", chunk)
 		}
 
 		for i := 0; i < listArray.Len(); i++ {
 			value, err := deserializeArrayOfVector(listArray, i, elementType, dim, true)
 			if err != nil {
-				return nil, fmt.Errorf("failed to deserialize VectorArray at row %d: %w", len(result), err)
+				return nil, merr.Wrapf(err, "failed to deserialize VectorArray at row %d", len(result))
 			}
 			vectorField, _ := value.(*schemapb.VectorField)
 			if vectorField == nil {
-				return nil, fmt.Errorf("null value in VectorArray")
+				return nil, merr.WrapErrServiceInternalMsg("null value in VectorArray")
 			}
 			result = append(result, vectorField)
 		}
@@ -653,7 +652,7 @@ func readNullableByteAndConvert[T any](r *PayloadReader, convert func([]byte) T)
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]T, r.numRows)
@@ -671,7 +670,7 @@ func readByteAndConvert[T any](r *PayloadReader, convert func(parquet.ByteArray)
 	}
 
 	if valuesRead != r.numRows {
-		return nil, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]T, r.numRows)
@@ -684,7 +683,7 @@ func readByteAndConvert[T any](r *PayloadReader, convert func(parquet.ByteArray)
 // GetBinaryVectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_BinaryVector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get binary vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get binary vector from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -699,7 +698,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -707,17 +706,17 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable binary vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable binary vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable binary vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable binary vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 			dim = dim / 8
 		} else {
@@ -735,7 +734,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -760,7 +759,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, int64(dim)*r.numRows)
@@ -773,7 +772,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 // GetFloat16VectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_Float16Vector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get float16 vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get float16 vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -787,7 +786,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -795,17 +794,17 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float16 vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float16 vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float16 vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float16 vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -822,7 +821,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -848,7 +847,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, int64(dim*2)*r.numRows)
@@ -861,7 +860,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 // GetBFloat16VectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_BFloat16Vector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get bfloat16 vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get bfloat16 vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -875,7 +874,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -883,17 +882,17 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable bfloat16 vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable bfloat16 vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable bfloat16 vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable bfloat16 vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -910,7 +909,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -936,7 +935,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, int64(dim*2)*r.numRows)
@@ -949,7 +948,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 // GetFloatVectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_FloatVector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get float vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get float vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -963,7 +962,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -971,17 +970,17 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -998,7 +997,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -1024,7 +1023,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]float32, int64(dim)*r.numRows)
@@ -1037,7 +1036,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 // GetSparseFloatVectorFromPayload returns fieldData, dimension, validData, error
 func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFieldData, int, []bool, error) {
 	if !typeutil.IsSparseFloatVectorType(r.colType) {
-		return nil, -1, nil, fmt.Errorf("failed to get sparse float vector from datatype %v", r.colType.String())
+		return nil, -1, nil, merr.WrapErrServiceInternalMsg("failed to get sparse float vector from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -1056,7 +1055,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -1064,7 +1063,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 		for _, chunk := range column.Data().Chunks() {
 			binaryArray, ok := chunk.(*array.Binary)
 			if !ok {
-				return nil, -1, nil, fmt.Errorf("expected Binary array, got %T", chunk)
+				return nil, -1, nil, merr.WrapErrServiceInternalMsg("expected Binary array, got %T", chunk)
 			}
 
 			for i := 0; i < binaryArray.Len(); i++ {
@@ -1072,7 +1071,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 				if validData[offset+i] {
 					value := binaryArray.Value(i)
 					if len(value)%8 != 0 {
-						return nil, -1, nil, errors.New("invalid bytesData length")
+						return nil, -1, nil, merr.WrapErrServiceInternalMsg("invalid bytesData length")
 					}
 					fieldData.Contents = append(fieldData.Contents, append([]byte{}, value...))
 					rowDim := typeutil.SparseFloatRowDim(value)
@@ -1093,14 +1092,14 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 		return nil, -1, nil, err
 	}
 	if valuesRead != r.numRows {
-		return nil, -1, nil, fmt.Errorf("expect %d binary, but got = %d", r.numRows, valuesRead)
+		return nil, -1, nil, merr.WrapErrServiceInternalMsg("expect %d binary, but got = %d", r.numRows, valuesRead)
 	}
 
 	fieldData := &SparseFloatVectorFieldData{}
 
 	for _, value := range values {
 		if len(value)%8 != 0 {
-			return nil, -1, nil, errors.New("invalid bytesData length")
+			return nil, -1, nil, merr.WrapErrServiceInternalMsg("invalid bytesData length")
 		}
 
 		fieldData.Contents = append(fieldData.Contents, value)
@@ -1116,7 +1115,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 // GetInt8VectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_Int8Vector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get int8 vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get int8 vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -1130,7 +1129,7 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -1138,17 +1137,17 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable int8 vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable int8 vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable int8 vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable int8 vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -1165,7 +1164,7 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -1191,7 +1190,7 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]int8, int64(dim)*r.numRows)
@@ -1220,7 +1219,7 @@ func ReadDataFromAllRowGroups[T any, E interface {
 
 	for i := 0; i < reader.NumRowGroups(); i++ {
 		if columnIdx >= reader.RowGroup(i).NumColumns() {
-			return -1, fmt.Errorf("try to fetch %d-th column of reader but row group has only %d column(s)", columnIdx, reader.RowGroup(i).NumColumns())
+			return -1, merr.WrapErrServiceInternalMsg("try to fetch %d-th column of reader but row group has only %d column(s)", columnIdx, reader.RowGroup(i).NumColumns())
 		}
 		column, err := reader.RowGroup(i).Column(columnIdx)
 		if err != nil {
@@ -1229,7 +1228,7 @@ func ReadDataFromAllRowGroups[T any, E interface {
 
 		cReader, ok := column.(E)
 		if !ok {
-			return -1, fmt.Errorf("expect type %T, but got %T", *new(E), column)
+			return -1, merr.WrapErrServiceInternalMsg("expect type %T, but got %T", *new(E), column)
 		}
 
 		_, valuesRead, err := cReader.ReadBatch(numRows, values[offset:], nil, nil)
@@ -1272,7 +1271,7 @@ func (s *DataSet[T, E]) nextGroup() error {
 
 	cReader, ok := column.(E)
 	if !ok {
-		return fmt.Errorf("expect type %T, but got %T", *new(E), column)
+		return merr.WrapErrServiceInternalMsg("expect type %T, but got %T", *new(E), column)
 	}
 	s.groupID++
 	s.cReader = cReader
@@ -1288,7 +1287,7 @@ func (s *DataSet[T, E]) HasNext() bool {
 
 func (s *DataSet[T, E]) NextBatch(batch int64) ([]T, error) {
 	if s.groupID > s.reader.NumRowGroups() || (s.groupID == s.reader.NumRowGroups() && s.cnt >= s.numRows) || s.numRows == 0 {
-		return nil, errors.New("has no more data")
+		return nil, merr.WrapErrServiceInternalMsg("has no more data")
 	}
 
 	if s.groupID == 0 || s.cnt >= s.numRows {
@@ -1400,7 +1399,7 @@ func readNullableVectorData(column *arrow.Column, numRows int64, bytesPerVector 
 	for _, chunk := range chunks {
 		binaryArray, ok := chunk.(*array.Binary)
 		if !ok {
-			return nil, nil, merr.WrapErrParameterInvalidMsg("expected Binary array for nullable vector, got %T", chunk)
+			return nil, nil, merr.WrapErrDataIntegrityMsg("expected Binary array for nullable vector, got %T", chunk)
 		}
 		chunkLen := binaryArray.Len()
 
@@ -1410,7 +1409,7 @@ func readNullableVectorData(column *arrow.Column, numRows int64, bytesPerVector 
 			valueBytes := binaryArray.ValueBytes()
 			expected := chunkValidCount * bytesPerVector
 			if len(valueBytes) != expected {
-				return nil, nil, merr.WrapErrParameterInvalidMsg(
+				return nil, nil, merr.WrapErrDataIntegrityMsg(
 					"unexpected valueBytes length for nullable vector: got %d, expected %d", len(valueBytes), expected)
 			}
 			copy(ret[dataOffset:dataOffset+len(valueBytes)], valueBytes)

--- a/internal/storage/payload_writer.go
+++ b/internal/storage/payload_writer.go
@@ -29,7 +29,6 @@ import (
 	"github.com/apache/arrow/go/v17/parquet"
 	"github.com/apache/arrow/go/v17/parquet/compress"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -303,17 +302,17 @@ func (w *NativePayloadWriter) AddDataToPayloadForUT(data interface{}, validData 
 		}
 		return w.AddVectorArrayFieldDataToPayload(val)
 	default:
-		return errors.New("unsupported datatype")
+		return merr.WrapErrServiceInternalMsg("unsupported datatype")
 	}
 }
 
 func (w *NativePayloadWriter) AddBoolToPayload(data []bool, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished bool payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished bool payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into bool payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into bool payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -328,7 +327,7 @@ func (w *NativePayloadWriter) AddBoolToPayload(data []bool, validData []bool) er
 
 	builder, ok := w.builder.(*array.BooleanBuilder)
 	if !ok {
-		return errors.New("failed to cast ArrayBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast ArrayBuilder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -337,11 +336,11 @@ func (w *NativePayloadWriter) AddBoolToPayload(data []bool, validData []bool) er
 
 func (w *NativePayloadWriter) AddByteToPayload(data []byte, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished byte payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished byte payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into byte payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into byte payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -356,7 +355,7 @@ func (w *NativePayloadWriter) AddByteToPayload(data []byte, validData []bool) er
 
 	builder, ok := w.builder.(*array.Int8Builder)
 	if !ok {
-		return errors.New("failed to cast ByteBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast ByteBuilder")
 	}
 
 	builder.Reserve(len(data))
@@ -372,11 +371,11 @@ func (w *NativePayloadWriter) AddByteToPayload(data []byte, validData []bool) er
 
 func (w *NativePayloadWriter) AddInt8ToPayload(data []int8, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int8 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int8 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int8 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int8 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -391,7 +390,7 @@ func (w *NativePayloadWriter) AddInt8ToPayload(data []int8, validData []bool) er
 
 	builder, ok := w.builder.(*array.Int8Builder)
 	if !ok {
-		return errors.New("failed to cast Int8Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int8Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -400,11 +399,11 @@ func (w *NativePayloadWriter) AddInt8ToPayload(data []int8, validData []bool) er
 
 func (w *NativePayloadWriter) AddInt16ToPayload(data []int16, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int16 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int16 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int16 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int16 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -419,7 +418,7 @@ func (w *NativePayloadWriter) AddInt16ToPayload(data []int16, validData []bool) 
 
 	builder, ok := w.builder.(*array.Int16Builder)
 	if !ok {
-		return errors.New("failed to cast Int16Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int16Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -428,11 +427,11 @@ func (w *NativePayloadWriter) AddInt16ToPayload(data []int16, validData []bool) 
 
 func (w *NativePayloadWriter) AddInt32ToPayload(data []int32, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int32 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int32 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int32 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int32 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -447,7 +446,7 @@ func (w *NativePayloadWriter) AddInt32ToPayload(data []int32, validData []bool) 
 
 	builder, ok := w.builder.(*array.Int32Builder)
 	if !ok {
-		return errors.New("failed to cast Int32Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int32Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -456,11 +455,11 @@ func (w *NativePayloadWriter) AddInt32ToPayload(data []int32, validData []bool) 
 
 func (w *NativePayloadWriter) AddInt64ToPayload(data []int64, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int64 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int64 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -475,7 +474,7 @@ func (w *NativePayloadWriter) AddInt64ToPayload(data []int64, validData []bool) 
 
 	builder, ok := w.builder.(*array.Int64Builder)
 	if !ok {
-		return errors.New("failed to cast Int64Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int64Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -484,11 +483,11 @@ func (w *NativePayloadWriter) AddInt64ToPayload(data []int64, validData []bool) 
 
 func (w *NativePayloadWriter) AddFloatToPayload(data []float32, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished float payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished float payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into float payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into float payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -503,7 +502,7 @@ func (w *NativePayloadWriter) AddFloatToPayload(data []float32, validData []bool
 
 	builder, ok := w.builder.(*array.Float32Builder)
 	if !ok {
-		return errors.New("failed to cast FloatBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast FloatBuilder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -512,11 +511,11 @@ func (w *NativePayloadWriter) AddFloatToPayload(data []float32, validData []bool
 
 func (w *NativePayloadWriter) AddDoubleToPayload(data []float64, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished double payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished double payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into double payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into double payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -531,7 +530,7 @@ func (w *NativePayloadWriter) AddDoubleToPayload(data []float64, validData []boo
 
 	builder, ok := w.builder.(*array.Float64Builder)
 	if !ok {
-		return errors.New("failed to cast DoubleBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast DoubleBuilder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -540,11 +539,11 @@ func (w *NativePayloadWriter) AddDoubleToPayload(data []float64, validData []boo
 
 func (w *NativePayloadWriter) AddTimestamptzToPayload(data []int64, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int64 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int64 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -559,7 +558,7 @@ func (w *NativePayloadWriter) AddTimestamptzToPayload(data []int64, validData []
 
 	builder, ok := w.builder.(*array.Int64Builder)
 	if !ok {
-		return errors.New("failed to cast Int64Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int64Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -568,7 +567,7 @@ func (w *NativePayloadWriter) AddTimestamptzToPayload(data []int64, validData []
 
 func (w *NativePayloadWriter) AddOneStringToPayload(data string, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished string payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished string payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -577,7 +576,7 @@ func (w *NativePayloadWriter) AddOneStringToPayload(data string, isValid bool) e
 
 	builder, ok := w.builder.(*array.StringBuilder)
 	if !ok {
-		return errors.New("failed to cast StringBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast StringBuilder")
 	}
 
 	if !isValid {
@@ -591,7 +590,7 @@ func (w *NativePayloadWriter) AddOneStringToPayload(data string, isValid bool) e
 
 func (w *NativePayloadWriter) AddOneArrayToPayload(data *schemapb.ScalarField, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished array payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished array payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -600,12 +599,12 @@ func (w *NativePayloadWriter) AddOneArrayToPayload(data *schemapb.ScalarField, i
 
 	bytes, err := proto.Marshal(data)
 	if err != nil {
-		return errors.New("Marshal ListValue failed")
+		return merr.WrapErrServiceInternalMsg("Marshal ListValue failed")
 	}
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast BinaryBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast BinaryBuilder")
 	}
 
 	if !isValid {
@@ -619,7 +618,7 @@ func (w *NativePayloadWriter) AddOneArrayToPayload(data *schemapb.ScalarField, i
 
 func (w *NativePayloadWriter) AddOneJSONToPayload(data []byte, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished json payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished json payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -628,7 +627,7 @@ func (w *NativePayloadWriter) AddOneJSONToPayload(data []byte, isValid bool) err
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast JsonBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast JsonBuilder")
 	}
 
 	if !isValid {
@@ -642,7 +641,7 @@ func (w *NativePayloadWriter) AddOneJSONToPayload(data []byte, isValid bool) err
 
 func (w *NativePayloadWriter) AddOneGeometryToPayload(data []byte, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished geometry payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished geometry payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -651,7 +650,7 @@ func (w *NativePayloadWriter) AddOneGeometryToPayload(data []byte, isValid bool)
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast geometryBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast geometryBuilder")
 	}
 
 	if !isValid {
@@ -672,7 +671,7 @@ func validateNullableVectorValidData(validData []bool) (int, error) {
 
 func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished binary vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished binary vector payload")
 	}
 
 	byteLength := dim / 8
@@ -690,7 +689,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into binary vector payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into binary vector payload")
 		}
 		numRows = len(data) / byteLength
 		if !w.nullable && len(validData) != 0 {
@@ -702,7 +701,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable BinaryVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable BinaryVector")
 		}
 
 		builder.Reserve(numRows)
@@ -718,7 +717,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable BinaryVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable BinaryVector")
 		}
 
 		builder.Reserve(numRows)
@@ -732,7 +731,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 
 func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished float vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished float vector payload")
 	}
 
 	var numRows int
@@ -749,7 +748,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into float vector payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into float vector payload")
 		}
 		numRows = len(data) / dim
 		if !w.nullable && len(validData) != 0 {
@@ -763,7 +762,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable FloatVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable FloatVector")
 		}
 
 		builder.Reserve(numRows)
@@ -785,7 +784,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable FloatVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable FloatVector")
 		}
 
 		builder.Reserve(numRows)
@@ -805,7 +804,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 
 func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished float16 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished float16 payload")
 	}
 
 	byteLength := dim * 2
@@ -823,7 +822,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into float16 payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into float16 payload")
 		}
 		numRows = len(data) / byteLength
 		if !w.nullable && len(validData) != 0 {
@@ -835,7 +834,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable Float16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable Float16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -851,7 +850,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable Float16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable Float16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -865,7 +864,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 
 func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished BFloat16 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished BFloat16 payload")
 	}
 
 	byteLength := dim * 2
@@ -883,7 +882,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into BFloat16 payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into BFloat16 payload")
 		}
 		numRows = len(data) / byteLength
 		if !w.nullable && len(validData) != 0 {
@@ -895,7 +894,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable BFloat16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable BFloat16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -911,7 +910,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable BFloat16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable BFloat16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -925,7 +924,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 
 func (w *NativePayloadWriter) AddSparseFloatVectorToPayload(data *SparseFloatVectorFieldData) error {
 	if w.finished {
-		return errors.New("can't append data to finished sparse float vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished sparse float vector payload")
 	}
 
 	var numRows int
@@ -949,7 +948,7 @@ func (w *NativePayloadWriter) AddSparseFloatVectorToPayload(data *SparseFloatVec
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast SparseFloatVectorBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast SparseFloatVectorBuilder")
 	}
 
 	builder.Reserve(numRows)
@@ -968,7 +967,7 @@ func (w *NativePayloadWriter) AddSparseFloatVectorToPayload(data *SparseFloatVec
 
 func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int8 vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int8 vector payload")
 	}
 
 	var numRows int
@@ -985,7 +984,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into int8 vector payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into int8 vector payload")
 		}
 		numRows = len(data) / dim
 		if !w.nullable && len(validData) != 0 {
@@ -997,7 +996,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable Int8Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable Int8Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -1015,7 +1014,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable Int8Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable Int8Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -1031,7 +1030,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 
 func (w *NativePayloadWriter) FinishPayloadWriter() error {
 	if w.finished {
-		return errors.New("can't reuse a finished writer")
+		return merr.WrapErrServiceInternalMsg("can't reuse a finished writer")
 	}
 
 	w.finished = true
@@ -1040,7 +1039,7 @@ func (w *NativePayloadWriter) FinishPayloadWriter() error {
 	var metadata arrow.Metadata
 	if w.dataType == schemapb.DataType_ArrayOfVector {
 		if w.elementType == nil {
-			return errors.New("element type for DataType_ArrayOfVector must be set")
+			return merr.WrapErrServiceInternalMsg("element type for DataType_ArrayOfVector must be set")
 		}
 
 		metadata = arrow.NewMetadata(
@@ -1099,7 +1098,7 @@ func (w *NativePayloadWriter) GetPayloadBufferFromWriter() ([]byte, error) {
 
 	// The cpp version of payload writer handles the empty buffer as error
 	if len(data) == 0 {
-		return nil, errors.New("empty buffer")
+		return nil, merr.WrapErrServiceInternalMsg("empty buffer")
 	}
 
 	return data, nil
@@ -1176,16 +1175,16 @@ func MilvusDataTypeToArrowType(dataType schemapb.DataType, dim int) arrow.DataTy
 // AddVectorArrayFieldDataToPayload adds VectorArrayFieldData to payload using Arrow ListArray
 func (w *NativePayloadWriter) AddVectorArrayFieldDataToPayload(data *VectorArrayFieldData) error {
 	if w.finished {
-		return errors.New("can't append data to finished vector array payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished vector array payload")
 	}
 
 	if len(data.Data) == 0 {
-		return errors.New("can't add empty vector array field data")
+		return merr.WrapErrServiceInternalMsg("can't add empty vector array field data")
 	}
 
 	builder, ok := w.builder.(*array.ListBuilder)
 	if !ok {
-		return errors.New("failed to cast to ListBuilder for VectorArray")
+		return merr.WrapErrServiceInternalMsg("failed to cast to ListBuilder for VectorArray")
 	}
 
 	switch data.ElementType {

--- a/internal/storage/pk_statistics.go
+++ b/internal/storage/pk_statistics.go
@@ -17,15 +17,14 @@
 package storage
 
 import (
-	"fmt"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/bloomfilter"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // pkStatistics contains pk field statistic information
@@ -38,7 +37,7 @@ type PkStatistics struct {
 // update set pk min/max value if input value is beyond former range.
 func (st *PkStatistics) UpdateMinMax(pk PrimaryKey) error {
 	if st == nil {
-		return errors.New("nil pk statistics")
+		return merr.WrapErrServiceInternalMsg("nil pk statistics")
 	}
 	if st.MinPK == nil {
 		st.MinPK = pk
@@ -78,7 +77,7 @@ func (st *PkStatistics) UpdatePKRange(ids FieldData) error {
 			st.PkFilter.AddString(pk)
 		}
 	default:
-		return fmt.Errorf("invalid data type for primary key: %T", ids)
+		return merr.WrapErrServiceInternalMsg("invalid data type for primary key: %T", ids)
 	}
 	return nil
 }

--- a/internal/storage/primary_key.go
+++ b/internal/storage/primary_key.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/log"
@@ -141,7 +139,7 @@ func (ip *Int64PrimaryKey) UnmarshalJSON(data []byte) error {
 func (ip *Int64PrimaryKey) SetValue(data interface{}) error {
 	value, ok := data.(int64)
 	if !ok {
-		return errors.New("wrong type value when setValue for Int64PrimaryKey")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64PrimaryKey")
 	}
 
 	ip.Value = value
@@ -241,7 +239,7 @@ func (vcp *VarCharPrimaryKey) UnmarshalJSON(data []byte) error {
 func (vcp *VarCharPrimaryKey) SetValue(data interface{}) error {
 	value, ok := data.(string)
 	if !ok {
-		return errors.New("wrong type value when setValue for VarCharPrimaryKey")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for VarCharPrimaryKey")
 	}
 
 	vcp.Value = value
@@ -272,7 +270,7 @@ func GenPrimaryKeyByRawData(data interface{}, pkType schemapb.DataType) (Primary
 			Value: data.(string),
 		}
 	default:
-		return nil, errors.New("not supported primary data type")
+		return nil, merr.WrapErrServiceInternalMsg("not supported primary data type")
 	}
 
 	return result, nil
@@ -305,11 +303,11 @@ func GenVarcharPrimaryKeys(data ...string) ([]PrimaryKey, error) {
 func ParseFieldData2PrimaryKeys(data *schemapb.FieldData) ([]PrimaryKey, error) {
 	ret := make([]PrimaryKey, 0)
 	if data == nil {
-		return ret, errors.New("failed to parse pks from nil field data")
+		return ret, merr.WrapErrServiceInternalMsg("failed to parse pks from nil field data")
 	}
 	scalarData := data.GetScalars()
 	if scalarData == nil {
-		return ret, errors.New("failed to parse pks from nil scalar data")
+		return ret, merr.WrapErrServiceInternalMsg("failed to parse pks from nil scalar data")
 	}
 
 	switch data.Type {
@@ -324,7 +322,7 @@ func ParseFieldData2PrimaryKeys(data *schemapb.FieldData) ([]PrimaryKey, error) 
 			ret = append(ret, pk)
 		}
 	default:
-		return ret, errors.New("not supported primary data type")
+		return ret, merr.WrapErrServiceInternalMsg("not supported primary data type")
 	}
 
 	return ret, nil

--- a/internal/storage/print_binlog.go
+++ b/internal/storage/print_binlog.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cockroachdb/errors"
 	"golang.org/x/exp/mmap"
 	"google.golang.org/protobuf/proto"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 )
 
@@ -89,7 +89,7 @@ func printBinlogFile(filename string) error {
 	fmt.Printf("\tEndTimestamp: %v\n", physical)
 	dataTypeName, ok := schemapb.DataType_name[int32(r.descriptorEvent.descriptorEventData.PayloadDataType)]
 	if !ok {
-		return fmt.Errorf("undefine data type %d", r.descriptorEvent.descriptorEventData.PayloadDataType)
+		return merr.WrapErrServiceInternalMsg("undefine data type %d", r.descriptorEvent.descriptorEventData.PayloadDataType)
 	}
 	fmt.Printf("\tPayloadDataType: %v\n", dataTypeName)
 	fmt.Printf("\tPostHeaderLengths: %v\n", r.descriptorEvent.descriptorEventData.PostHeaderLengths)
@@ -112,7 +112,7 @@ func printBinlogFile(filename string) error {
 		case InsertEventType:
 			evd, ok := event.eventData.(*insertEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d insert event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -125,7 +125,7 @@ func printBinlogFile(filename string) error {
 		case DeleteEventType:
 			evd, ok := event.eventData.(*deleteEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d delete event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -138,7 +138,7 @@ func printBinlogFile(filename string) error {
 		case CreateCollectionEventType:
 			evd, ok := event.eventData.(*createCollectionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d create collection event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -151,7 +151,7 @@ func printBinlogFile(filename string) error {
 		case DropCollectionEventType:
 			evd, ok := event.eventData.(*dropCollectionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d drop collection event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -164,7 +164,7 @@ func printBinlogFile(filename string) error {
 		case CreatePartitionEventType:
 			evd, ok := event.eventData.(*createPartitionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d create partition event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -177,7 +177,7 @@ func printBinlogFile(filename string) error {
 		case DropPartitionEventType:
 			evd, ok := event.eventData.(*dropPartitionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d drop partition event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -193,14 +193,14 @@ func printBinlogFile(filename string) error {
 			extra := make(map[string]interface{})
 			err = json.Unmarshal(extraBytes, &extra)
 			if err != nil {
-				return fmt.Errorf("failed to unmarshal extra: %s", err.Error())
+				return merr.WrapErrServiceInternalMsg("failed to unmarshal extra: %s", err.Error())
 			}
 			fmt.Printf("indexBuildID: %v\n", extra["indexBuildID"])
 			fmt.Printf("indexName: %v\n", extra["indexName"])
 			fmt.Printf("indexID: %v\n", extra["indexID"])
 			evd, ok := event.eventData.(*indexFileEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("index file event num: %d\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -212,7 +212,7 @@ func printBinlogFile(filename string) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("undefined event typd %d", event.eventHeader.TypeCode)
+			return merr.WrapErrServiceInternalMsg("undefined event typd %d", event.eventHeader.TypeCode)
 		}
 		eventNum++
 	}
@@ -421,7 +421,7 @@ func printPayloadValues(colType schemapb.DataType, reader PayloadReaderInterface
 		}
 		fmt.Println("===== SparseFloatVectorFieldData end =====")
 	default:
-		return errors.New("undefined data type")
+		return merr.WrapErrServiceInternalMsg("undefined data type")
 	}
 	return nil
 }
@@ -477,11 +477,11 @@ func printDDLPayloadValues(eventType EventTypeCode, colType schemapb.DataType, r
 				}
 				fmt.Printf("\t\t%d : drop partition: %v\n", i, req)
 			default:
-				return fmt.Errorf("undefined ddl event type %d", eventType)
+				return merr.WrapErrServiceInternalMsg("undefined ddl event type %d", eventType)
 			}
 		}
 	default:
-		return errors.New("undefined data type")
+		return merr.WrapErrServiceInternalMsg("undefined data type")
 	}
 	return nil
 }

--- a/internal/storage/record_reader.go
+++ b/internal/storage/record_reader.go
@@ -53,7 +53,7 @@ func newPackedRecordReader(
 ) (*packedRecordReader, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 	field2Col := make(map[FieldID]int)
 	allFields := typeutil.GetAllFieldSchemas(schema)
@@ -97,7 +97,7 @@ func (ir *IterativeRecordReader) Close() error {
 func (ir *IterativeRecordReader) Next() (rec Record, err error) {
 	defer func() {
 		if x := recover(); x != nil {
-			rec, err = nil, fmt.Errorf("internal error recovered: %v", x)
+			rec, err = nil, merr.WrapErrServiceInternalMsg("internal error recovered: %v", x)
 		}
 	}()
 	if ir.cur == nil {
@@ -167,7 +167,7 @@ func NewManifestReaderFromBinlogs(fieldBinlogs []*datapb.FieldBinlog,
 ) (*ManifestReader, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, false)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 	schemaHelper, err := typeutil.CreateSchemaHelper(schema)
 	if err != nil {
@@ -209,7 +209,7 @@ func NewManifestReader(manifest string,
 ) (*ManifestReader, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	// Override TEXT fields to binary type — LOB references are binary encoded in manifest storage

--- a/internal/storage/record_writer.go
+++ b/internal/storage/record_writer.go
@@ -158,8 +158,7 @@ func NewPackedRecordWriter(
 	columnGroupCompressed := make(map[typeutil.UniqueID]uint64)
 	pathsMap := make(map[typeutil.UniqueID]string)
 	if len(paths) != len(columnGroups) {
-		return nil, merr.WrapErrParameterInvalid(len(paths), len(columnGroups),
-			"paths length is not equal to column groups length for packed record writer")
+		return nil, merr.WrapErrStorageMsg("paths length is not equal to column groups length for packed record writer: paths=%d columnGroups=%d", len(paths), len(columnGroups))
 	}
 	for i, columnGroup := range columnGroups {
 		columnGroupUncompressed[columnGroup.GroupID] = 0

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -129,7 +129,7 @@ func (mcm *RemoteChunkManager) Path(ctx context.Context, filePath string) (strin
 		return "", err
 	}
 	if !exist {
-		return "", errors.New("minio file manage cannot be found with filePath:" + filePath)
+		return "", merr.WrapErrServiceInternalMsg("minio file manage cannot be found with filePath:" + filePath)
 	}
 	return filePath, nil
 }
@@ -194,7 +194,7 @@ func (mcm *RemoteChunkManager) MultiWrite(ctx context.Context, kvs map[string][]
 	for key, value := range kvs {
 		err := mcm.Write(ctx, key, value)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to write %s", key))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to write %s", key))
 		}
 	}
 	return el
@@ -259,7 +259,7 @@ func (mcm *RemoteChunkManager) MultiRead(ctx context.Context, keys []string) ([]
 	for _, key := range keys {
 		objectValue, err := mcm.Read(ctx, key)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to read %s", key))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to read %s", key))
 		}
 		objectsValues = append(objectsValues, objectValue)
 	}
@@ -268,7 +268,7 @@ func (mcm *RemoteChunkManager) MultiRead(ctx context.Context, keys []string) ([]
 }
 
 func (mcm *RemoteChunkManager) Mmap(ctx context.Context, filePath string) (*mmap.ReaderAt, error) {
-	return nil, errors.New("this method has not been implemented")
+	return nil, merr.WrapErrServiceInternalMsg("this method has not been implemented")
 }
 
 // ReadAt reads specific position data of minio storage if exists.
@@ -310,7 +310,7 @@ func (mcm *RemoteChunkManager) MultiRemove(ctx context.Context, keys []string) e
 	for _, key := range keys {
 		err := mcm.Remove(ctx, key)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to remove %s", key))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to remove %s", key))
 		}
 	}
 	return el

--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -58,10 +58,10 @@ type (
 
 func validateVectorArrayElementCount(payloadLength int, elementsPerVector int) (int, error) {
 	if elementsPerVector <= 0 {
-		return 0, fmt.Errorf("invalid vector width %d for ArrayOfVector", elementsPerVector)
+		return 0, merr.WrapErrStorageMsg("invalid vector width %d for ArrayOfVector", elementsPerVector)
 	}
 	if payloadLength%elementsPerVector != 0 {
-		return 0, fmt.Errorf("ArrayOfVector payload length %d is not divisible by vector width %d", payloadLength, elementsPerVector)
+		return 0, merr.WrapErrStorageMsg("ArrayOfVector payload length %d is not divisible by vector width %d", payloadLength, elementsPerVector)
 	}
 	return payloadLength / elementsPerVector, nil
 }
@@ -125,7 +125,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Boolean); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Boolean, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Boolean, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -137,9 +137,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected bool value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected bool value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.BooleanBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.BooleanBuilder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int8] = serdeEntry{
@@ -153,7 +153,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int8); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int8, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int8, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -165,9 +165,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int8 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int8 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int8Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int8Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int16] = serdeEntry{
@@ -181,7 +181,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int16); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int16, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int16, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -193,9 +193,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int16 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int16 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int16Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int16Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int32] = serdeEntry{
@@ -209,7 +209,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int32); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int32, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int32, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -221,9 +221,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int32 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int32 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int32Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int32Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int64] = serdeEntry{
@@ -237,7 +237,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int64); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int64, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int64, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -249,9 +249,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int64 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int64 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int64Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int64Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Float] = serdeEntry{
@@ -265,7 +265,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Float32); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Float32, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Float32, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -277,9 +277,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected float32 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected float32 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Float32Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Float32Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Double] = serdeEntry{
@@ -293,7 +293,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Float64); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Float64, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Float64, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -305,9 +305,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected float64 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected float64 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Float64Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Float64Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Timestamptz] = serdeEntry{
@@ -321,7 +321,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int64); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int64, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int64, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -333,9 +333,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int64 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int64 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int64Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int64Builder, got %T", b)
 		},
 	}
 	stringEntry := serdeEntry{
@@ -353,7 +353,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return value, nil
 			}
-			return nil, fmt.Errorf("expected *array.String, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.String, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -365,9 +365,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected string value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected string value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.StringBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.StringBuilder, got %T", b)
 		},
 	}
 
@@ -390,10 +390,10 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				if err := proto.Unmarshal(arr.Value(i), v); err == nil {
 					return v, nil
 				} else {
-					return nil, fmt.Errorf("failed to unmarshal ScalarField: %w", err)
+					return nil, merr.WrapErrStorage(err, "failed to unmarshal ScalarField")
 				}
 			}
-			return nil, fmt.Errorf("expected *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -406,12 +406,12 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 						builder.Append(bytes)
 						return nil
 					} else {
-						return fmt.Errorf("failed to marshal ScalarField: %w", err)
+						return merr.WrapErrStorage(err, "failed to marshal ScalarField")
 					}
 				}
-				return fmt.Errorf("expected *schemapb.ScalarField value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected *schemapb.ScalarField value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.BinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.BinaryBuilder, got %T", b)
 		},
 	}
 	_ = eagerArrayEntry
@@ -433,7 +433,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return value, nil
 			}
-			return nil, fmt.Errorf("expected *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -450,7 +450,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 						builder.Append(bytes)
 						return nil
 					} else {
-						return fmt.Errorf("failed to marshal ScalarField: %w", err)
+						return merr.WrapErrStorage(err, "failed to marshal ScalarField")
 					}
 				}
 				if vv, ok := v.(*schemapb.VectorField); ok {
@@ -458,12 +458,12 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 						builder.Append(bytes)
 						return nil
 					} else {
-						return fmt.Errorf("failed to marshal VectorField: %w", err)
+						return merr.WrapErrStorage(err, "failed to marshal VectorField")
 					}
 				}
-				return fmt.Errorf("expected []byte, *schemapb.ScalarField or *schemapb.VectorField value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected []byte, *schemapb.ScalarField or *schemapb.VectorField value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.BinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.BinaryBuilder, got %T", b)
 		},
 	}
 
@@ -487,7 +487,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 
 			vf, ok := v.(*schemapb.VectorField)
 			if !ok {
-				return fmt.Errorf("expected *schemapb.VectorField, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected *schemapb.VectorField, got %T", v)
 			}
 			if vf == nil {
 				b.AppendNull()
@@ -496,7 +496,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 
 			builder, ok := b.(*array.ListBuilder)
 			if !ok {
-				return fmt.Errorf("expected *array.ListBuilder, got %T", b)
+				return merr.WrapErrServiceInternalMsg("expected *array.ListBuilder, got %T", b)
 			}
 
 			valueBuilder := builder.ValueBuilder().(*array.FixedSizeBinaryBuilder)
@@ -519,7 +519,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			switch elementType {
 			case schemapb.DataType_FloatVector:
 				if vf.GetFloatVector() == nil {
-					return fmt.Errorf("FloatVector data is nil for elementType FloatVector")
+					return merr.WrapErrServiceInternalMsg("FloatVector data is nil for elementType FloatVector")
 				}
 				floatData := vf.GetFloatVector().GetData()
 				floatsPerVector := bytesPerVector / 4
@@ -544,32 +544,32 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 
 			case schemapb.DataType_BinaryVector:
 				if vf.GetBinaryVector() == nil {
-					return fmt.Errorf("BinaryVector data is nil for elementType BinaryVector")
+					return merr.WrapErrServiceInternalMsg("BinaryVector data is nil for elementType BinaryVector")
 				}
 				return appendVectorChunks(vf.GetBinaryVector())
 
 			case schemapb.DataType_Float16Vector:
 				if vf.GetFloat16Vector() == nil {
-					return fmt.Errorf("Float16Vector data is nil for elementType Float16Vector")
+					return merr.WrapErrServiceInternalMsg("Float16Vector data is nil for elementType Float16Vector")
 				}
 				return appendVectorChunks(vf.GetFloat16Vector())
 
 			case schemapb.DataType_BFloat16Vector:
 				if vf.GetBfloat16Vector() == nil {
-					return fmt.Errorf("BFloat16Vector data is nil for elementType BFloat16Vector")
+					return merr.WrapErrServiceInternalMsg("BFloat16Vector data is nil for elementType BFloat16Vector")
 				}
 				return appendVectorChunks(vf.GetBfloat16Vector())
 
 			case schemapb.DataType_Int8Vector:
 				if vf.GetInt8Vector() == nil {
-					return fmt.Errorf("Int8Vector data is nil for elementType Int8Vector")
+					return merr.WrapErrServiceInternalMsg("Int8Vector data is nil for elementType Int8Vector")
 				}
 				return appendVectorChunks(vf.GetInt8Vector())
 
 			case schemapb.DataType_SparseFloatVector:
-				return fmt.Errorf("SparseFloatVector in VectorArray not implemented yet")
+				return merr.WrapErrServiceInternalMsg("SparseFloatVector in VectorArray not implemented yet")
 			default:
-				return fmt.Errorf("unsupported elementType for ArrayOfVector: %s", elementType.String())
+				return merr.WrapErrServiceInternalMsg("unsupported elementType for ArrayOfVector: %s", elementType.String())
 			}
 		},
 	}
@@ -596,7 +596,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return value, nil
 		}
-		return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
+		return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 	}
 	fixedSizeSerializer := func(b array.Builder, v any, _ schemapb.DataType) error {
 		if v == nil {
@@ -612,9 +612,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				builder.Append(v)
 				return nil
 			}
-			return fmt.Errorf("expected []byte value, got %T", v)
+			return merr.WrapErrServiceInternalMsg("expected []byte value, got %T", v)
 		}
-		return fmt.Errorf("expected *array.FixedSizeBinaryBuilder, got %T", b)
+		return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder, got %T", b)
 	}
 
 	m[schemapb.DataType_BinaryVector] = serdeEntry{
@@ -664,7 +664,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return int8s, nil
 			}
-			return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -677,7 +677,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			} else if vv, ok := v.([]int8); ok {
 				bytesData = arrow.Int8Traits.CastToBytes(vv)
 			} else {
-				return fmt.Errorf("expected []byte or []int8 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected []byte or []int8 value, got %T", v)
 			}
 			if builder, ok := b.(*array.FixedSizeBinaryBuilder); ok {
 				builder.Append(bytesData)
@@ -687,7 +687,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				builder.Append(bytesData)
 				return nil
 			}
-			return fmt.Errorf("expected *array.FixedSizeBinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_FloatVector] = serdeEntry{
@@ -718,7 +718,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return vector, nil
 			}
-			return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -741,9 +741,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(bytesData)
 					return nil
 				}
-				return fmt.Errorf("expected *array.FixedSizeBinaryBuilder or *array.BinaryBuilder, got %T", b)
+				return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder or *array.BinaryBuilder, got %T", b)
 			}
-			return fmt.Errorf("expected *array.FixedSizeBinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_SparseFloatVector] = byteEntry
@@ -987,9 +987,9 @@ func createEmptyVectorField(elementType schemapb.DataType, dim int64) (*schemapb
 			},
 		}, nil
 	case schemapb.DataType_SparseFloatVector:
-		return nil, fmt.Errorf("SparseFloatVector in empty VectorArray not implemented yet")
+		return nil, merr.WrapErrServiceInternalMsg("SparseFloatVector in empty VectorArray not implemented yet")
 	default:
-		return nil, fmt.Errorf("unsupported element type for empty ArrayOfVector: %s", elementType.String())
+		return nil, merr.WrapErrServiceInternalMsg("unsupported element type for empty ArrayOfVector: %s", elementType.String())
 	}
 }
 
@@ -1001,10 +1001,10 @@ func deserializeArrayOfVector(a arrow.Array, i int, elementType schemapb.DataTyp
 
 	arr, ok := a.(*array.List)
 	if !ok {
-		return nil, fmt.Errorf("expected *array.List for ArrayOfVector, got %T", a)
+		return nil, merr.WrapErrServiceInternalMsg("expected *array.List for ArrayOfVector, got %T", a)
 	}
 	if i >= arr.Len() {
-		return nil, fmt.Errorf("index %d out of bounds for array of length %d", i, arr.Len())
+		return nil, merr.WrapErrServiceInternalMsg("index %d out of bounds for array of length %d", i, arr.Len())
 	}
 
 	start, end := arr.ValueOffsets(i)
@@ -1019,7 +1019,7 @@ func deserializeArrayOfVector(a arrow.Array, i int, elementType schemapb.DataTyp
 	valuesArray := arr.ListValues()
 	binaryArray, ok := valuesArray.(*array.FixedSizeBinary)
 	if !ok {
-		return nil, fmt.Errorf("expected *array.FixedSizeBinary for ArrayOfVector values, got %T", valuesArray)
+		return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary for ArrayOfVector values, got %T", valuesArray)
 	}
 
 	numVectors := int(totalElements)
@@ -1088,9 +1088,9 @@ func deserializeArrayOfVector(a arrow.Array, i int, elementType schemapb.DataTyp
 			},
 		}, nil
 	case schemapb.DataType_SparseFloatVector:
-		return nil, fmt.Errorf("SparseFloatVector in VectorArray deserialization not implemented yet")
+		return nil, merr.WrapErrServiceInternalMsg("SparseFloatVector in VectorArray deserialization not implemented yet")
 	default:
-		return nil, fmt.Errorf("unsupported element type for ArrayOfVector deserialization: %s", elementType.String())
+		return nil, merr.WrapErrServiceInternalMsg("unsupported element type for ArrayOfVector deserialization: %s", elementType.String())
 	}
 }
 

--- a/internal/storage/serde_delta.go
+++ b/internal/storage/serde_delta.go
@@ -21,14 +21,12 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
 	"io"
 	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -416,7 +414,7 @@ func newDeltalogMultiFieldWriter(eventWriter *MultiFieldDeltalogStreamWriter, ba
 				pb.Append(pk)
 			}
 		default:
-			return nil, fmt.Errorf("unexpected pk type %v", v[0].PkType)
+			return nil, merr.WrapErrServiceInternalMsg("unexpected pk type %v", v[0].PkType)
 		}
 
 		for _, vv := range v {
@@ -441,7 +439,7 @@ func newDeltalogMultiFieldReader(blobs []*Blob) (*DeserializeReaderImpl[*DeleteL
 	return NewDeserializeReader(reader, func(r Record, v []*DeleteLog) error {
 		rec, ok := r.(*simpleArrowRecord)
 		if !ok {
-			return errors.New("can not cast to simple arrow record")
+			return merr.WrapErrServiceInternalMsg("can not cast to simple arrow record")
 		}
 		fields := rec.r.Schema().Fields()
 		switch fields[0].Type.ID() {
@@ -462,7 +460,7 @@ func newDeltalogMultiFieldReader(blobs []*Blob) (*DeserializeReaderImpl[*DeleteL
 				v[j].Pk = NewVarCharPrimaryKey(arr.Value(j))
 			}
 		default:
-			return fmt.Errorf("unexpected delta log pkType %v", fields[0].Type.Name())
+			return merr.WrapErrServiceInternalMsg("unexpected delta log pkType %v", fields[0].Type.Name())
 		}
 
 		arr := r.Column(1).(*array.Int64)
@@ -561,7 +559,7 @@ func (w *LegacyDeltalogWriter) Write(rec Record) error {
 			pk := NewVarCharPrimaryKey(rec.Column(0).(*array.String).Value(i))
 			return NewDeleteLog(pk, ts), nil
 		default:
-			return nil, fmt.Errorf("unexpected pk type %v", w.pkType)
+			return nil, merr.WrapErrServiceInternalMsg("unexpected pk type %v", w.pkType)
 		}
 	}
 
@@ -642,7 +640,7 @@ func (r *deleteLogToRecordReader) Next() (Record, error) {
 		}
 		pkArray = builder.NewArray()
 	default:
-		return nil, fmt.Errorf("unsupported pk type: %v", r.pkType)
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported pk type: %v", r.pkType)
 	}
 
 	tsBuilder := array.NewInt64Builder(allocator)

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -114,7 +114,7 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 				}
 				comparators = append(comparators, f)
 			default:
-				return 0, nil, merr.WrapErrParameterInvalidMsg("unsupported type for sorting key")
+				return 0, nil, merr.WrapErrStorageMsg("unsupported type for sorting key")
 			}
 		}
 
@@ -281,7 +281,7 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 				return 0
 			})
 		default:
-			return 0, merr.WrapErrParameterInvalidMsg("unsupported type for sorting key")
+			return 0, merr.WrapErrStorageMsg("unsupported type for sorting key")
 		}
 	}
 

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"path"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -102,7 +101,7 @@ func (stats *PrimaryKeyStats) UnmarshalJSON(data []byte) error {
 		stats.MaxPk = &VarCharPrimaryKey{}
 		stats.MinPk = &VarCharPrimaryKey{}
 	default:
-		return errors.New("Invalid PK Data Type")
+		return merr.WrapErrServiceInternalMsg("Invalid PK Data Type")
 	}
 
 	if maxPkMessage, ok := messageMap["maxPk"]; ok && maxPkMessage != nil {
@@ -283,10 +282,7 @@ func (sr *StatsReader) GetPrimaryKeyStats() (*PrimaryKeyStats, error) {
 	stats := &PrimaryKeyStats{}
 	err := json.Unmarshal(sr.buffer, &stats)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid(
-			"valid JSON",
-			string(sr.buffer),
-			err.Error())
+		return nil, merr.WrapErrDataIntegrity(err, "PrimaryKeyStats unmarshal failed")
 	}
 
 	return stats, nil
@@ -297,10 +293,7 @@ func (sr *StatsReader) GetPrimaryKeyStatsList() ([]*PrimaryKeyStats, error) {
 	stats := []*PrimaryKeyStats{}
 	err := json.Unmarshal(sr.buffer, &stats)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid(
-			"valid JSON",
-			string(sr.buffer),
-			err.Error())
+		return nil, merr.WrapErrDataIntegrity(err, "PrimaryKeyStats list unmarshal failed")
 	}
 
 	return stats, nil

--- a/internal/storage/stats_collector.go
+++ b/internal/storage/stats_collector.go
@@ -20,13 +20,13 @@ import (
 	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -202,7 +202,7 @@ func (c *Bm25StatsCollector) Collect(r Record) error {
 	for fieldID, stats := range c.bm25Stats {
 		field, ok := r.Column(fieldID).(*array.Binary)
 		if !ok {
-			return errors.New("bm25 field value not found")
+			return merr.WrapErrServiceInternalMsg("bm25 field value not found")
 		}
 		for i := 0; i < rows; i++ {
 			stats.AppendBytes(field.Value(i))

--- a/internal/storage/stats_test.go
+++ b/internal/storage/stats_test.go
@@ -227,7 +227,7 @@ func TestDeserializeStatsFailed(t *testing.T) {
 	}
 
 	_, err := DeserializeStatsList(blob)
-	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.ErrorIs(t, err, merr.ErrDataIntegrity)
 }
 
 func TestDeserializeEmptyStats(t *testing.T) {

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -29,7 +29,6 @@ import (
 	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -184,12 +183,12 @@ func TransferColumnBasedInsertDataToRowBased(data *InsertData) (
 ) {
 	if !checkTsField(data) {
 		return nil, nil, nil,
-			errors.New("cannot get timestamps from insert data")
+			merr.WrapErrServiceInternalMsg("cannot get timestamps from insert data")
 	}
 
 	if !checkRowIDField(data) {
 		return nil, nil, nil,
-			errors.New("cannot get row ids from insert data")
+			merr.WrapErrServiceInternalMsg("cannot get row ids from insert data")
 	}
 
 	tss := data.Data[common.TimeStampField].(*Int64FieldData)
@@ -210,7 +209,7 @@ func TransferColumnBasedInsertDataToRowBased(data *InsertData) (
 	all = append(all, ls.datas...)
 	if !checkNumRows(all...) {
 		return nil, nil, nil,
-			errors.New("columns of insert data have different length")
+			merr.WrapErrServiceInternalMsg("columns of insert data have different length")
 	}
 
 	sortFieldDataList(ls)
@@ -226,7 +225,7 @@ func TransferColumnBasedInsertDataToRowBased(data *InsertData) (
 			err := binary.Write(&buffer, common.Endian, d)
 			if err != nil {
 				return nil, nil, nil,
-					fmt.Errorf("failed to get binary row, err: %v", err)
+					merr.WrapErrServiceInternalMsg("failed to get binary row, err: %v", err)
 			}
 		}
 
@@ -259,7 +258,7 @@ func GetDimFromParams(params []*commonpb.KeyValuePair) (int, error) {
 			return dim, nil
 		}
 	}
-	return -1, errors.New("dim not found in params")
+	return -1, merr.WrapErrServiceInternalMsg("dim not found in params")
 }
 
 // ReadBinary read data in bytes and write it into receiver.
@@ -420,7 +419,7 @@ func RowBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *schemap
 	}
 
 	if len(collSchema.StructArrayFields) > 0 {
-		return nil, errors.New("struct fields are not implemented in row based insert data")
+		return nil, merr.WrapErrServiceInternalMsg("struct fields are not implemented in row based insert data")
 	}
 
 	for _, field := range collSchema.Fields {
@@ -482,7 +481,7 @@ func RowBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *schemap
 				Dim:  dim,
 			}
 		case schemapb.DataType_SparseFloatVector:
-			return nil, errors.New("Sparse Float Vector is not supported in row based data")
+			return nil, merr.WrapErrServiceInternalMsg("Sparse Float Vector is not supported in row based data")
 
 		case schemapb.DataType_Int8Vector:
 			dim, err := GetDimFromParams(field.TypeParams)
@@ -1314,7 +1313,7 @@ func GetPkFromInsertData(collSchema *schemapb.CollectionSchema, data *InsertData
 	pfData, ok := data.Data[pf.FieldID]
 	if !ok {
 		log.Warn("no primary field found in insert msg", zap.Int64("fieldID", pf.FieldID))
-		return nil, errors.New("no primary field found in insert msg")
+		return nil, merr.WrapErrServiceInternalMsg("no primary field found in insert msg")
 	}
 
 	var realPfData FieldData
@@ -1328,7 +1327,7 @@ func GetPkFromInsertData(collSchema *schemapb.CollectionSchema, data *InsertData
 	}
 	if !ok {
 		log.Warn("primary field not in Int64 or VarChar format", zap.Int64("fieldID", pf.FieldID))
-		return nil, errors.New("primary field not in Int64 or VarChar format")
+		return nil, merr.WrapErrServiceInternalMsg("primary field not in Int64 or VarChar format")
 	}
 
 	return realPfData, nil
@@ -1337,16 +1336,16 @@ func GetPkFromInsertData(collSchema *schemapb.CollectionSchema, data *InsertData
 // GetTimestampFromInsertData returns the Int64FieldData for timestamp field.
 func GetTimestampFromInsertData(data *InsertData) (*Int64FieldData, error) {
 	if data == nil {
-		return nil, errors.New("try to get timestamp from nil insert data")
+		return nil, merr.WrapErrServiceInternalMsg("try to get timestamp from nil insert data")
 	}
 	fieldData, ok := data.Data[common.TimeStampField]
 	if !ok {
-		return nil, errors.New("no timestamp field in insert data")
+		return nil, merr.WrapErrServiceInternalMsg("no timestamp field in insert data")
 	}
 
 	ifd, ok := fieldData.(*Int64FieldData)
 	if !ok {
-		return nil, errors.New("timestamp field is not Int64")
+		return nil, merr.WrapErrServiceInternalMsg("timestamp field is not Int64")
 	}
 
 	return ifd, nil
@@ -1679,7 +1678,7 @@ func TransferInsertDataToInsertRecord(insertData *InsertData) (*segcorepb.Insert
 				ValidData: rawData.ValidData,
 			}
 		default:
-			return insertRecord, errors.New("unsupported data type when transter storage.InsertData to internalpb.InsertRecord")
+			return insertRecord, merr.WrapErrServiceInternalMsg("unsupported data type when transter storage.InsertData to internalpb.InsertRecord")
 		}
 
 		insertRecord.FieldsData = append(insertRecord.FieldsData, fieldData)

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -27,7 +27,6 @@ package storagev2
 import "C"
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -37,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -58,7 +58,7 @@ func getMetricsFromHandle(cFilesystem C.FileSystemHandle) (*FilesystemMetrics, e
 	metricsResult := C.loon_filesystem_get_metrics(cFilesystem, &cMetrics)
 	if err := HandleLoonFFIResult(metricsResult); err != nil {
 		C.loon_filesystem_destroy(cFilesystem)
-		return nil, fmt.Errorf("failed to get filesystem metrics: %w", err)
+		return nil, merr.Wrap(err, "failed to get filesystem metrics")
 	}
 
 	fsMetrics := &FilesystemMetrics{
@@ -201,7 +201,7 @@ func makePropertiesFromConfig(storageConfig *indexpb.StorageConfig) (C.LoonPrope
 	)
 
 	if err := HandleLoonFFIResult(result); err != nil {
-		return C.LoonProperties{}, fmt.Errorf("failed to create properties: %w", err)
+		return C.LoonProperties{}, merr.Wrap(err, "failed to create properties")
 	}
 
 	return props, nil
@@ -211,7 +211,7 @@ func makePropertiesFromConfig(storageConfig *indexpb.StorageConfig) (C.LoonPrope
 // using full storage config properties for proper cache resolution.
 func GetFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*FilesystemMetrics, error) {
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig is required")
+		return nil, merr.WrapErrStorageMsg("storageConfig is required")
 	}
 
 	props, err := makePropertiesFromConfig(storageConfig)
@@ -223,7 +223,7 @@ func GetFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*File
 	var cFilesystem C.FileSystemHandle
 	result := C.loon_filesystem_get(&props, nil, 0, &cFilesystem)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to get cached filesystem: %w", err)
+		return nil, merr.Wrap(err, "failed to get cached filesystem")
 	}
 
 	return getMetricsFromHandle(cFilesystem)
@@ -238,7 +238,7 @@ func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
 		if errMsg != nil {
 			errStr = C.GoString(errMsg)
 		}
-		return fmt.Errorf("loon FFI error: %s", errStr)
+		return merr.WrapErrStorageMsg("loon FFI error: %s", errStr)
 	}
 	return nil
 }

--- a/internal/storagev2/packed/explore_ffi.go
+++ b/internal/storagev2/packed/explore_ffi.go
@@ -26,7 +26,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"net/url"
 	"sort"
 	"strings"
@@ -36,6 +35,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // formatExtensions maps format names to their expected file extensions.
@@ -107,16 +107,16 @@ func GetFileInfo(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 	if err := injectExternalSpecProperties(cProperties, extfs.CollectionID, extfs.Source, extfs.Spec); err != nil {
-		return nil, fmt.Errorf("inject extfs: %w", err)
+		return nil, merr.Wrap(err, "inject extfs")
 	}
 
 	normalizedFilePath, err := normalizeExternalPathForStorage(filePath, cProperties, extfs)
 	if err != nil {
-		return nil, fmt.Errorf("normalize external file path: %w", err)
+		return nil, merr.WrapErrStorage(err, "normalize external file path")
 	}
 	cFilePath := C.CString(normalizedFilePath)
 	defer C.free(unsafe.Pointer(cFilePath))
@@ -125,7 +125,7 @@ func GetFileInfo(
 
 	result := C.loon_exttable_get_file_info(cFormat, cFilePath, cProperties, &numRows)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_exttable_get_file_info failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_exttable_get_file_info failed")
 	}
 
 	return &FileInfo{
@@ -225,16 +225,16 @@ func ExploreFilesReturnManifestPath(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to create properties: %w", err)
+		return nil, "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 	if err := injectExternalSpecProperties(cProperties, extfs.CollectionID, extfs.Source, extfs.Spec); err != nil {
-		return nil, "", fmt.Errorf("inject extfs: %w", err)
+		return nil, "", merr.Wrap(err, "inject extfs")
 	}
 
 	normalizedExploreDir, err := normalizeExternalPathForStorage(exploreDir, cProperties, extfs)
 	if err != nil {
-		return nil, "", fmt.Errorf("normalize external explore path: %w", err)
+		return nil, "", merr.WrapErrStorage(err, "normalize external explore path")
 	}
 	cExploreDir := C.CString(normalizedExploreDir)
 	defer C.free(unsafe.Pointer(cExploreDir))
@@ -253,10 +253,10 @@ func ExploreFilesReturnManifestPath(
 		&numFiles, &outColumnGroupsPath,
 	)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, "", fmt.Errorf("loon_exttable_explore failed: %w", err)
+		return nil, "", merr.WrapErrStorage(err, "loon_exttable_explore failed")
 	}
 	if outColumnGroupsPath == nil {
-		return nil, "", fmt.Errorf("loon_exttable_explore returned nil column groups path")
+		return nil, "", merr.WrapErrServiceInternalMsg("loon_exttable_explore returned nil column groups path")
 	}
 	manifestPath := C.GoString(outColumnGroupsPath)
 	C.loon_free_cstr(outColumnGroupsPath)
@@ -291,21 +291,21 @@ func ReadFileInfosFromManifestPath(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
 	var manifest *C.LoonManifest
 	result := C.loon_exttable_read_manifest(cManifestPath, cProperties, &manifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_exttable_read_manifest failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_exttable_read_manifest failed")
 	}
 	defer C.loon_manifest_destroy(manifest)
 
 	var fileInfos []FileInfo
 	cgroups := &manifest.column_groups
 	if cgroups.column_group_array == nil && cgroups.num_of_column_groups > 0 {
-		return nil, fmt.Errorf("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
+		return nil, merr.WrapErrServiceInternalMsg("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
 	}
 
 	cgArray := unsafe.Slice(cgroups.column_group_array, int(cgroups.num_of_column_groups))
@@ -317,7 +317,7 @@ func ReadFileInfosFromManifestPath(
 		fileArray := unsafe.Slice(cg.files, int(cg.num_of_files))
 		for j := range fileArray {
 			if fileArray[j].path == nil {
-				return nil, fmt.Errorf("file path is nil in column group %d, file %d", i, j)
+				return nil, merr.WrapErrServiceInternalMsg("file path is nil in column group %d, file %d", i, j)
 			}
 			fileInfos = append(fileInfos, FileInfo{
 				FilePath: C.GoString(fileArray[j].path),

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -21,6 +21,7 @@ import (
 
 	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // ErrLoonTransient marks any failure surfaced by the loon FFI layer. Today
@@ -91,7 +92,7 @@ func ExtfsPrefixForCollection(collectionID int64) string {
 // StorageConfig are mapped to corresponding key-value pairs in Properties.
 func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extraKVs map[string]string) (*C.LoonProperties, error) {
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig is required")
+		return nil, merr.WrapErrStorageMsg("storageConfig is required")
 	}
 
 	// Prepare key-value pairs from StorageConfig
@@ -243,7 +244,7 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 
 	err := HandleLoonFFIResult(result)
 	if err != nil {
-		return nil, err
+		return nil, merr.WrapErrStorage(err, "loon properties_create failed")
 	}
 	return properties, nil
 }
@@ -275,7 +276,7 @@ func injectExternalSpecProperties(properties *C.LoonProperties, collectionID int
 	externalSource, externalSpec string,
 ) error {
 	if properties == nil {
-		return fmt.Errorf("injectExternalSpecProperties: properties is nil")
+		return merr.WrapErrStorageMsg("injectExternalSpecProperties: properties is nil")
 	}
 	if externalSource == "" {
 		return nil
@@ -289,7 +290,10 @@ func injectExternalSpecProperties(properties *C.LoonProperties, collectionID int
 	}
 	result := C.loon_properties_inject_external_spec(
 		properties, C.int64_t(collectionID), cSource, cSpec)
-	return HandleLoonFFIResult(result)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return merr.WrapErrStorage(err, "loon inject_external_spec failed")
+	}
+	return nil
 }
 
 func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
@@ -301,7 +305,7 @@ func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
 			errStr = C.GoString(errMsg)
 		}
 
-		return errors.Wrapf(ErrLoonTransient, "FFI operation failed: %s", errStr)
+		return merr.Wrapf(ErrLoonTransient, "FFI operation failed: %s", errStr)
 	}
 	return nil
 }
@@ -342,14 +346,14 @@ func CompareManifestPath(a, b string) (int, error) {
 	bBase, bVer, bErr := UnmarshalManifestPath(b)
 
 	if aErr != nil {
-		return 0, fmt.Errorf("failed to parse manifest path %q: %w", a, aErr)
+		return 0, merr.WrapErrStorage(aErr, "failed to parse manifest path %q", a)
 	}
 	if bErr != nil {
-		return 0, fmt.Errorf("failed to parse manifest path %q: %w", b, bErr)
+		return 0, merr.WrapErrStorage(bErr, "failed to parse manifest path %q", b)
 	}
 
 	if aBase != bBase {
-		return 0, fmt.Errorf("manifest paths have different base paths: %q vs %q", aBase, bBase)
+		return 0, merr.WrapErrServiceInternalMsg("manifest paths have different base paths: %q vs %q", aBase, bBase)
 	}
 
 	switch {
@@ -382,7 +386,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return 0, fmt.Errorf("failed to make properties: %w", err)
+		return 0, merr.Wrap(err, "failed to make properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -393,7 +397,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 	var cTransactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.int32_t(0) /* resolve_id */, C.uint32_t(1) /* retry_limit */, &cTransactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return 0, fmt.Errorf("failed to begin transaction: %w", err)
+		return 0, merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(cTransactionHandle)
 
@@ -413,7 +417,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 		C.free(unsafe.Pointer(cPath))
 
 		if err := HandleLoonFFIResult(result); err != nil {
-			return 0, fmt.Errorf("failed to add LOB file %s: %w", lobFile.Path, err)
+			return 0, merr.WrapErrStorage(err, "failed to add LOB file %s", lobFile.Path)
 		}
 	}
 
@@ -421,7 +425,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 	var committedVersion C.int64_t
 	result = C.loon_transaction_commit(cTransactionHandle, &committedVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return 0, fmt.Errorf("failed to commit transaction: %w", err)
+		return 0, merr.WrapErrStorage(err, "failed to commit transaction")
 	}
 
 	return int64(committedVersion), nil
@@ -432,12 +436,12 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 func GetManifestLobFiles(manifestPath string, storageConfig *indexpb.StorageConfig) ([]LobFileInfo, error) {
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal manifest path: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to unmarshal manifest path")
 	}
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to make properties: %w", err)
+		return nil, merr.Wrap(err, "failed to make properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -448,7 +452,7 @@ func GetManifestLobFiles(manifestPath string, storageConfig *indexpb.StorageConf
 	var cTransactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.int32_t(0) /* resolve_id */, C.uint32_t(1) /* retry_limit */, &cTransactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(cTransactionHandle)
 
@@ -456,7 +460,7 @@ func GetManifestLobFiles(manifestPath string, storageConfig *indexpb.StorageConf
 	var cManifest *C.LoonManifest
 	result = C.loon_transaction_get_manifest(cTransactionHandle, &cManifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to get manifest: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cManifest)
 

--- a/internal/storagev2/packed/ffi_filesystem.go
+++ b/internal/storagev2/packed/ffi_filesystem.go
@@ -23,11 +23,11 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"strings"
 	"unsafe"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // WriteFile writes raw bytes to a file using milvus-storage filesystem FFI.
@@ -39,7 +39,7 @@ func WriteFile(
 ) error {
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create properties: %w", err)
+		return merr.WrapErrStorage(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -51,7 +51,7 @@ func WriteFile(
 	var fsHandle C.FileSystemHandle
 	result := C.loon_filesystem_get(cProperties, cPath, pathLen, &fsHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return fmt.Errorf("failed to get filesystem: %w", err)
+		return merr.WrapErrStorage(err, "failed to get filesystem")
 	}
 	defer C.loon_filesystem_destroy(fsHandle)
 
@@ -64,7 +64,7 @@ func WriteFile(
 			defer C.free(unsafe.Pointer(cDir))
 			result = C.loon_filesystem_create_dir(fsHandle, cDir, C.uint32_t(len(dir)), true)
 			if err := HandleLoonFFIResult(result); err != nil {
-				return fmt.Errorf("failed to create parent directory %q: %w", dir, err)
+				return merr.WrapErrStorage(err, "failed to create parent directory %q", dir)
 			}
 		}
 	}

--- a/internal/storagev2/packed/ffi_sample.go
+++ b/internal/storagev2/packed/ffi_sample.go
@@ -25,7 +25,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"runtime"
 	"unsafe"
 
@@ -33,6 +32,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // SampleExternalFieldSizes samples rows from an external segment via Take API
@@ -52,19 +52,19 @@ func SampleExternalFieldSizes(
 	storageConfig *indexpb.StorageConfig,
 ) (map[string]int64, error) {
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig is required for SampleExternalFieldSizes")
+		return nil, merr.WrapErrStorageMsg("storageConfig is required for SampleExternalFieldSizes")
 	}
 	if manifestPath == "" {
-		return nil, fmt.Errorf("manifest_path is empty for SampleExternalFieldSizes")
+		return nil, merr.WrapErrStorageMsg("manifest_path is empty for SampleExternalFieldSizes")
 	}
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 	if err := injectExternalSpecProperties(cProperties, collectionID, externalSource, externalSpec); err != nil {
-		return nil, fmt.Errorf("inject extfs: %w", err)
+		return nil, merr.Wrap(err, "inject extfs")
 	}
 
 	cManifestPath := C.CString(manifestPath)
@@ -75,7 +75,7 @@ func SampleExternalFieldSizes(
 	if schema != nil {
 		schemaBytes, err = proto.Marshal(schema)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal collection schema: %w", err)
+			return nil, merr.WrapErrStorage(err, "failed to marshal collection schema")
 		}
 		if len(schemaBytes) > 0 {
 			cSchema.proto_blob = unsafe.Pointer(&schemaBytes[0])

--- a/internal/storagev2/packed/ffi_stats.go
+++ b/internal/storagev2/packed/ffi_stats.go
@@ -23,10 +23,10 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"unsafe"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // ManifestStat represents a stat entry from the manifest.
@@ -104,7 +104,7 @@ func GetManifestStats(
 ) (map[string]ManifestStat, error) {
 	cManifest, err := GetManifestHandle(manifestPath, storageConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get manifest: %w", err)
+		return nil, merr.Wrap(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cManifest)
 

--- a/internal/storagev2/packed/manifest_ffi.go
+++ b/internal/storagev2/packed/manifest_ffi.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // Fragment represents a data fragment from an external data source.
@@ -55,20 +56,20 @@ func CreateManifestForSegment(
 	storageConfig *indexpb.StorageConfig,
 ) (string, error) {
 	if len(fragments) == 0 {
-		return "", fmt.Errorf("fragments cannot be empty")
+		return "", merr.WrapErrServiceInternalMsg("fragments cannot be empty")
 	}
 
 	// Create column groups from fragments
 	columnGroups, err := createColumnGroups(columns, format, fragments)
 	if err != nil {
-		return "", fmt.Errorf("failed to create column groups: %w", err)
+		return "", merr.Wrap(err, "failed to create column groups")
 	}
 	defer C.loon_column_groups_destroy(columnGroups)
 
 	// Create properties from storage config
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create properties: %w", err)
+		return "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -80,21 +81,21 @@ func CreateManifestForSegment(
 	var transactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(0), C.LOON_TRANSACTION_RESOLVE_OVERWRITE /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("loon_transaction_begin failed: %w", err)
+		return "", merr.WrapErrStorage(err, "loon_transaction_begin failed")
 	}
 	defer C.loon_transaction_destroy(transactionHandle)
 
 	// Append files to transaction
 	result = C.loon_transaction_append_files(transactionHandle, columnGroups)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("loon_transaction_append_files failed: %w", err)
+		return "", merr.WrapErrStorage(err, "loon_transaction_append_files failed")
 	}
 
 	// Commit transaction
 	var committedVersion C.int64_t
 	result = C.loon_transaction_commit(transactionHandle, &committedVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("loon_transaction_commit failed: %w", err)
+		return "", merr.WrapErrStorage(err, "loon_transaction_commit failed")
 	}
 
 	// Return manifest path using the helper function
@@ -168,7 +169,7 @@ func createColumnGroups(
 	)
 
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_column_groups_create failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_column_groups_create failed")
 	}
 
 	return outColumnGroups, nil
@@ -186,7 +187,7 @@ func ReadFragmentsFromManifest(
 	// 1. Parse manifest path to get base path and version
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse manifest path: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	// 2. Construct full manifest file path: base_path/_metadata/manifest-{version}.avro
@@ -196,7 +197,7 @@ func ReadFragmentsFromManifest(
 	// 3. Create properties from storage config
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -208,7 +209,7 @@ func ReadFragmentsFromManifest(
 	var manifest *C.LoonManifest
 	result := C.loon_exttable_read_manifest(cManifestFilePath, cProperties, &manifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_exttable_read_manifest failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_exttable_read_manifest failed")
 	}
 
 	// 5. Destroy manifest when done
@@ -222,7 +223,7 @@ func ReadFragmentsFromManifest(
 
 	// Validate column groups structure before accessing
 	if cgroups.column_group_array == nil && cgroups.num_of_column_groups > 0 {
-		return nil, fmt.Errorf("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
+		return nil, merr.WrapErrServiceInternalMsg("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
 	}
 
 	cgArray := unsafe.Slice(cgroups.column_group_array, int(cgroups.num_of_column_groups))

--- a/internal/storagev2/packed/packed_reader.go
+++ b/internal/storagev2/packed/packed_reader.go
@@ -25,7 +25,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"io"
 	"unsafe"
 
@@ -34,6 +33,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func NewPackedReader(filePaths []string, schema *arrow.Schema, bufferSize int64, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*PackedReader, error) {
@@ -143,7 +143,7 @@ func (pr *PackedReader) ReadNext() (arrow.Record, error) {
 	}()
 	recordBatch, err := cdata.ImportCRecordBatch(goCArr, goCSchema)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert ArrowArray to Record: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to convert ArrowArray to Record")
 	}
 	pr.currentBatch = recordBatch
 

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -25,24 +25,23 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"io"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/cdata"
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns []string, bufferSize int64, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*FFIPackedReader, error) {
 	cLoonManifest, err := GetManifestHandle(manifestPath, storageConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get manifest")
+		return nil, merr.Wrap(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cLoonManifest)
 
@@ -112,7 +111,7 @@ func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns
 
 		status = C.NewPackedFFIReaderWithManifest(cLoonManifest, cSchema, cNeededColumnArray, cNumColumns, &cPackedReader, cStorageConfig, pluginContextPtr)
 	} else {
-		return nil, fmt.Errorf("storageConfig is required")
+		return nil, merr.WrapErrServiceInternalMsg("storageConfig is required")
 	}
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		return nil, err
@@ -123,14 +122,14 @@ func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns
 	status = C.GetFFIReaderStream(cPackedReader, C.int64_t(8196), (*C.struct_ArrowArrayStream)(unsafe.Pointer(&cStream)))
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		C.CloseFFIReader(cPackedReader)
-		return nil, fmt.Errorf("failed to get reader stream: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to get reader stream")
 	}
 
 	// Import the stream as a RecordReader
 	recordReader, err := cdata.ImportCRecordReader(&cStream, schema)
 	if err != nil {
 		C.CloseFFIReader(cPackedReader)
-		return nil, fmt.Errorf("failed to import record reader: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to import record reader")
 	}
 
 	return &FFIPackedReader{
@@ -151,7 +150,7 @@ func (r *FFIPackedReader) ReadNext() (rec arrow.Record, err error) {
 		if err == io.EOF {
 			return nil, io.EOF
 		}
-		return nil, fmt.Errorf("failed to read next record: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to read next record")
 	}
 
 	return rec, nil

--- a/internal/storagev2/packed/packed_writer.go
+++ b/internal/storagev2/packed/packed_writer.go
@@ -30,11 +30,11 @@ import (
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/cdata"
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64, multiPartUploadSize int64, columnGroups []storagecommon.ColumnGroup, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*PackedWriter, error) {
@@ -59,7 +59,7 @@ func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64,
 	for _, group := range columnGroups {
 		cGroup := C.malloc(C.size_t(len(group.Columns)) * C.size_t(unsafe.Sizeof(C.int(0))))
 		if cGroup == nil {
-			return nil, errors.New("failed to allocate memory for column groups")
+			return nil, merr.WrapErrServiceInternalMsg("failed to allocate memory for column groups")
 		}
 		cGroupSlice := (*[1 << 30]C.int)(cGroup)[:len(group.Columns):len(group.Columns)]
 		for i, val := range group.Columns {
@@ -135,7 +135,7 @@ func (pw *PackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
 		return nil
 	}
 	if pw.cPackedWriter == nil {
-		return errors.New("packed writer is closed")
+		return merr.WrapErrStorageMsg("packed writer is closed")
 	}
 
 	cArrays := make([]CArrowArray, recordBatch.NumCols())
@@ -176,13 +176,13 @@ func (pw *PackedWriter) Close() error {
 
 func (pw *PackedWriter) CloseAndTell(numGroups int) ([]int64, error) {
 	if numGroups <= 0 {
-		return nil, errors.New("numGroups must be greater than 0")
+		return nil, merr.WrapErrServiceInternalMsg("numGroups must be greater than 0")
 	}
 	if pw.cPackedWriter == nil {
 		if len(pw.closedSizes) == numGroups {
 			return append([]int64(nil), pw.closedSizes...), nil
 		}
-		return nil, errors.New("packed writer is closed")
+		return nil, merr.WrapErrStorageMsg("packed writer is closed")
 	}
 
 	sizes := make([]int64, numGroups)

--- a/internal/storagev2/packed/segment_writer_ffi.go
+++ b/internal/storagev2/packed/segment_writer_ffi.go
@@ -25,13 +25,13 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/cdata"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // TextColumnConfig represents configuration for a TEXT column.
@@ -73,7 +73,7 @@ func NewFFISegmentWriter(
 	defer cdata.ReleaseCArrowSchema(&cas)
 
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig must not be nil")
+		return nil, merr.WrapErrStorageMsg("storageConfig must not be nil")
 	}
 
 	// create properties
@@ -158,14 +158,14 @@ func (f *SegmentOutput) applyTo(handle C.LoonTransactionHandle) error {
 	}
 	if f.cOutput.column_groups != nil {
 		if err := HandleLoonFFIResult(C.loon_transaction_append_files(handle, f.cOutput.column_groups)); err != nil {
-			return fmt.Errorf("commit manifest append_files (segment): %w", err)
+			return merr.Wrap(err, "commit manifest append_files (segment)")
 		}
 	}
 	if f.cOutput.num_lob_files > 0 && f.cOutput.lob_files != nil {
 		lob := unsafe.Slice(f.cOutput.lob_files, f.cOutput.num_lob_files)
 		for i := range lob {
 			if err := HandleLoonFFIResult(C.loon_transaction_add_lob_file(handle, &lob[i])); err != nil {
-				return fmt.Errorf("commit manifest add_lob_file: %w", err)
+				return merr.Wrap(err, "commit manifest add_lob_file")
 			}
 		}
 	}
@@ -183,7 +183,7 @@ func (f *SegmentOutput) applyTo(handle C.LoonTransactionHandle) error {
 // further Close or Write calls fail.
 func (w *FFISegmentWriter) Close() (WriterOutput, error) {
 	if w.closed {
-		return nil, fmt.Errorf("FFISegmentWriter already closed")
+		return nil, merr.WrapErrServiceInternal("FFISegmentWriter already closed")
 	}
 	w.closed = true
 	defer func() {

--- a/internal/storagev2/packed/stats_resolver.go
+++ b/internal/storagev2/packed/stats_resolver.go
@@ -23,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // compoundStatsLogIdx is the log index that identifies compound stats format.
@@ -364,7 +365,7 @@ func (r *StatsResolver) loadManifest() error {
 
 	stats, err := GetManifestStats(r.manifestPath, r.storageConfig)
 	if err != nil {
-		r.manifestErr = fmt.Errorf("failed to get manifest stats: %w", err)
+		r.manifestErr = merr.Wrap(err, "failed to get manifest stats")
 		return r.manifestErr
 	}
 	r.manifestStats = stats

--- a/internal/storagev2/packed/transaction.go
+++ b/internal/storagev2/packed/transaction.go
@@ -23,7 +23,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"math"
 	"unsafe"
 
@@ -31,6 +30,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -91,7 +91,7 @@ func addDeltaLogsToManifest(
 
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse manifest path: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	log.Debug("AddDeltaLogsToManifest",
@@ -101,7 +101,7 @@ func addDeltaLogsToManifest(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create properties: %w", err)
+		return "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -112,7 +112,7 @@ func addDeltaLogsToManifest(
 	var transactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), resolveID /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to begin transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(transactionHandle)
 
@@ -124,7 +124,7 @@ func addDeltaLogsToManifest(
 		C.free(unsafe.Pointer(cPath))
 
 		if err := HandleLoonFFIResult(result); err != nil {
-			return "", fmt.Errorf("failed to add delta log %s: %w", deltaLog.Path, err)
+			return "", merr.WrapErrStorage(err, "failed to add delta log %s", deltaLog.Path)
 		}
 
 		log.Debug("Added delta log to transaction",
@@ -136,7 +136,7 @@ func addDeltaLogsToManifest(
 	var commitVersion C.int64_t
 	result = C.loon_transaction_commit(transactionHandle, &commitVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to commit transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to commit transaction")
 	}
 
 	newManifestPath := MarshalManifestPath(basePath, int64(commitVersion))
@@ -154,12 +154,12 @@ func GetDeltaLogPathsFromManifest(
 ) ([]string, error) {
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse manifest path: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -169,14 +169,14 @@ func GetDeltaLogPathsFromManifest(
 	var cTransactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.int32_t(0) /* resolve_id */, C.uint32_t(1) /* retry_limit */, &cTransactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(cTransactionHandle)
 
 	var cManifest *C.LoonManifest
 	result = C.loon_transaction_get_manifest(cTransactionHandle, &cManifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to get manifest: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cManifest)
 
@@ -221,7 +221,7 @@ func AddStatsToManifest(
 
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse manifest path: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	log.Debug("AddStatsToManifest",
@@ -231,7 +231,7 @@ func AddStatsToManifest(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create properties: %w", err)
+		return "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -241,14 +241,14 @@ func AddStatsToManifest(
 	var transactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.LOON_TRANSACTION_RESOLVE_OVERWRITE /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to begin transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(transactionHandle)
 
 	// The C++ loon library converts absolute paths to relative at commit time
 	for _, stat := range stats {
 		if err := UpdateTransactionStat(transactionHandle, stat.Key, stat.Files, stat.Metadata); err != nil {
-			return "", fmt.Errorf("failed to update stat %s: %w", stat.Key, err)
+			return "", merr.WrapErrStorage(err, "failed to update stat %s", stat.Key)
 		}
 		log.Debug("Added stat to transaction",
 			zap.String("key", stat.Key),
@@ -258,7 +258,7 @@ func AddStatsToManifest(
 	var commitVersion C.int64_t
 	result = C.loon_transaction_commit(transactionHandle, &commitVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to commit transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to commit transaction")
 	}
 
 	newManifestPath := MarshalManifestPath(basePath, int64(commitVersion))

--- a/internal/storagev2/packed/utils.go
+++ b/internal/storagev2/packed/utils.go
@@ -16,7 +16,6 @@ package packed
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -26,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 const (
@@ -147,7 +147,7 @@ func fetchRowCountsConcurrently(
 		futures[k] = pool.Submit(func() (struct{}, error) {
 			fetchedInfo, err := GetFileInfo(format, fileInfos[idx].FilePath, storageConfig, extfs)
 			if err != nil {
-				return struct{}{}, fmt.Errorf("failed to get file info for %s: %w", fileInfos[idx].FilePath, err)
+				return struct{}{}, merr.Wrapf(err, "failed to get file info for %s", fileInfos[idx].FilePath)
 			}
 			// Distinct indexes across workers -> no race on rowCounts.
 			rowCounts[idx] = fetchedInfo.NumRows
@@ -184,7 +184,7 @@ func FetchFragmentsFromExternalSourceWithRange(
 	log := log.Ctx(ctx)
 
 	if exploreManifestPath == "" {
-		return nil, fmt.Errorf("explore manifest path is required")
+		return nil, merr.WrapErrServiceInternalMsg("explore manifest path is required")
 	}
 
 	extfs := ExternalSpecContext{
@@ -196,7 +196,7 @@ func FetchFragmentsFromExternalSourceWithRange(
 	exploreStart := time.Now()
 	fileInfos, err := ReadFileInfosFromManifestPath(exploreManifestPath, storageConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read explore manifest: %w", err)
+		return nil, merr.Wrap(err, "failed to read explore manifest")
 	}
 	rawCount := len(fileInfos)
 	// Apply the same sort+format-filter that DataCoord used to derive
@@ -220,11 +220,11 @@ func FetchFragmentsFromExternalSourceWithRange(
 		fileIndexEnd = int64(len(fileInfos))
 	}
 	if fileIndexBegin >= int64(len(fileInfos)) {
-		return nil, fmt.Errorf("fileIndexBegin %d >= total files %d", fileIndexBegin, len(fileInfos))
+		return nil, merr.WrapErrServiceInternalMsg("fileIndexBegin %d >= total files %d", fileIndexBegin, len(fileInfos))
 	}
 	fileInfos = fileInfos[fileIndexBegin:fileIndexEnd]
 	if len(fileInfos) == 0 {
-		return nil, fmt.Errorf("no files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
+		return nil, merr.WrapErrServiceInternalMsg("no files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
 	}
 
 	getFileInfoStart := time.Now()
@@ -243,7 +243,7 @@ func FetchFragmentsFromExternalSourceWithRange(
 		fragments = append(fragments, SplitFileToFragments(fi.FilePath, rowCounts[i], rowLimit, fragmentIDGenerator)...)
 	}
 	if len(fragments) == 0 {
-		return nil, fmt.Errorf("no data files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
+		return nil, merr.WrapErrServiceInternalMsg("no data files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
 	}
 
 	log.Info("Created fragments from file range",
@@ -268,8 +268,7 @@ func BuildCurrentSegmentFragments(
 		if seg.GetManifestPath() != "" && storageConfig != nil {
 			fragments, err := ReadFragmentsFromManifest(seg.GetManifestPath(), storageConfig)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read manifest for segment %d at %s: %w",
-					seg.GetID(), seg.GetManifestPath(), err)
+				return nil, merr.Wrapf(err, "failed to read manifest for segment %d at %s", seg.GetID(), seg.GetManifestPath())
 			}
 			if len(fragments) > 0 {
 				result[seg.GetID()] = fragments

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -223,7 +223,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 			}
 			logger.Info("append flush message for segments that not created by streaming service into wal", zap.Stringer("msgID", appendResult.MessageID), zap.Uint64("timeTick", appendResult.TimeTick))
 			return nil
-		}, retry.AttemptAlways()); err != nil {
+		}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true })); err != nil {
 			return nil, err
 		}
 	}
@@ -233,7 +233,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 		var err error
 		ds, err = impl.buildDataSyncService(ctx, recoverInfo)
 		return err
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
@@ -101,7 +101,7 @@ func (impl *msgHandlerImpl) createNewGrowingSegment(ctx context.Context, vchanne
 		}
 		logger.Info("alloc growing segment at datacoord", zap.Int32("schemaVersion", h.SchemaVersion))
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 }
 
 func (impl *msgHandlerImpl) HandleFlush(flushMsg message.ImmutableFlushMessageV2) error {

--- a/internal/streamingnode/server/flusher/flusherimpl/util.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/util.go
@@ -90,7 +90,7 @@ func (impl *WALFlusherImpl) getRecoveryInfo(ctx context.Context, vchannel string
 			return retry.Unrecoverable(errChannelLifetimeUnrecoverable)
 		}
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	return resp, err
 }
 

--- a/internal/util/function/bm25_function.go
+++ b/internal/util/function/bm25_function.go
@@ -19,10 +19,8 @@
 package function
 
 import (
-	"fmt"
 	"sync"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
@@ -103,7 +101,7 @@ func NewAnalyzerRunner(field *schemapb.FieldSchema) (Analyzer, error) {
 
 func NewBM25FunctionRunner(coll *schemapb.CollectionSchema, schema *schemapb.FunctionSchema) (FunctionRunner, error) {
 	if len(schema.GetOutputFieldIds()) != 1 {
-		return nil, fmt.Errorf("bm25 function should only have one output field, but now %d", len(schema.GetOutputFieldIds()))
+		return nil, merr.WrapErrParameterInvalidMsg("bm25 function should only have one output field, but now %d", len(schema.GetOutputFieldIds()))
 	}
 
 	var inputField, outputField *schemapb.FieldSchema
@@ -119,7 +117,7 @@ func NewBM25FunctionRunner(coll *schemapb.CollectionSchema, schema *schemapb.Fun
 	}
 
 	if outputField == nil {
-		return nil, errors.New("no output field")
+		return nil, merr.WrapErrParameterInvalidMsg("no output field")
 	}
 
 	if params, ok := getMultiAnalyzerParams(inputField); ok {
@@ -176,16 +174,16 @@ func (v *BM25FunctionRunner) BatchRun(inputs ...any) ([]any, error) {
 	defer v.mu.RUnlock()
 
 	if v.closed {
-		return nil, errors.New("analyzer receview request after function closed")
+		return nil, merr.WrapErrServiceInternalMsg("analyzer receview request after function closed")
 	}
 
 	if len(inputs) > 1 {
-		return nil, errors.New("BM25 function received more than one input column")
+		return nil, merr.WrapErrParameterInvalidMsg("BM25 function received more than one input column")
 	}
 
 	text, ok := inputs[0].([]string)
 	if !ok {
-		return nil, errors.New("BM25 function batch input not string list")
+		return nil, merr.WrapErrParameterInvalidMsg("BM25 function batch input not string list")
 	}
 
 	rowNum := len(text)
@@ -258,16 +256,16 @@ func (v *BM25FunctionRunner) BatchAnalyze(withDetail bool, withHash bool, inputs
 	defer v.mu.RUnlock()
 
 	if v.closed {
-		return nil, errors.New("analyzer receview request after function closed")
+		return nil, merr.WrapErrServiceInternalMsg("analyzer receview request after function closed")
 	}
 
 	if len(inputs) > 1 {
-		return nil, errors.New("analyze received should only receive text input column(not set analyzer name)")
+		return nil, merr.WrapErrParameterInvalidMsg("analyze received should only receive text input column(not set analyzer name)")
 	}
 
 	text, ok := inputs[0].([]string)
 	if !ok {
-		return nil, errors.New("batch input not string list")
+		return nil, merr.WrapErrParameterInvalidMsg("batch input not string list")
 	}
 
 	rowNum := len(text)

--- a/internal/util/function/embedding/ali_embedding_provider.go
+++ b/internal/util/function/embedding/ali_embedding_provider.go
@@ -20,13 +20,13 @@ package embedding
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/ali"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -45,7 +45,7 @@ type AliEmbeddingProvider struct {
 
 func createAliEmbeddingClient(apiKey string, url string) (*ali.AliDashScopeEmbedding, error) {
 	if apiKey == "" {
-		return nil, fmt.Errorf("missing credentials config or configure the %s environment variable in the Milvus service", models.DashscopeAKEnvStr)
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the %s environment variable in the Milvus service", models.DashscopeAKEnvStr)
 	}
 
 	if url == "" {
@@ -131,11 +131,11 @@ func (provider *AliEmbeddingProvider) CallEmbedding(ctx context.Context, texts [
 			return nil, err
 		}
 		if end-i != len(resp.Output.Embeddings) {
-			return nil, fmt.Errorf("get embedding failed. The number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Output.Embeddings))
+			return nil, merr.WrapErrFunctionFailedMsg("get embedding failed. The number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Output.Embeddings))
 		}
 		for _, item := range resp.Output.Embeddings {
 			if len(item.Embedding) != int(provider.fieldDim) {
-				return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+				return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 					provider.fieldDim, len(item.Embedding))
 			}
 			data = append(data, item.Embedding)

--- a/internal/util/function/embedding/bedrock_embedding_provider.go
+++ b/internal/util/function/embedding/bedrock_embedding_provider.go
@@ -21,7 +21,6 @@ package embedding
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 
@@ -29,12 +28,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	milvusCredentials "github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -57,13 +56,13 @@ type BedrockEmbeddingProvider struct {
 
 func createBedRockEmbeddingClient(awsAccessKeyId string, awsSecretAccessKey string, region string) (*bedrockruntime.Client, error) {
 	if awsAccessKeyId == "" {
-		return nil, fmt.Errorf("missing credentials config or configure the %s environment variable in the Milvus service", models.BedrockAccessKeyId)
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the %s environment variable in the Milvus service", models.BedrockAccessKeyId)
 	}
 	if awsSecretAccessKey == "" {
-		return nil, fmt.Errorf("missing credentials config or configure the %s environment variable in the Milvus service", models.BedrockSAKEnvStr)
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the %s environment variable in the Milvus service", models.BedrockSAKEnvStr)
 	}
 	if region == "" {
-		return nil, errors.New("missing AWS Service region. Please pass `region` param")
+		return nil, merr.WrapErrParameterInvalidMsg("missing AWS Service region. Please pass `region` param")
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(region),
@@ -140,7 +139,7 @@ func NewBedrockEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSche
 			case "true":
 				normalize = true
 			default:
-				return nil, fmt.Errorf("illegal [%s:%s] param", models.NormalizeParamKey, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("illegal [%s:%s] param", models.NormalizeParamKey, param.Value)
 			}
 		default:
 		}
@@ -214,7 +213,7 @@ func (provider *BedrockEmbeddingProvider) CallEmbedding(ctx context.Context, tex
 			return nil, err
 		}
 		if len(resp.Embedding) != int(provider.fieldDim) {
-			return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+			return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 				provider.fieldDim, len(resp.Embedding))
 		}
 		data = append(data, resp.Embedding)

--- a/internal/util/function/embedding/cohere_embedding_provider.go
+++ b/internal/util/function/embedding/cohere_embedding_provider.go
@@ -20,13 +20,13 @@ package embedding
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/cohere"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -69,7 +69,7 @@ func NewCohereEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 			}
 		case models.TruncateParamKey:
 			if param.Value != "NONE" && param.Value != "START" && param.Value != "END" {
-				return nil, fmt.Errorf("illegal parameters, %s only supports [NONE, START, END]", models.TruncateParamKey)
+				return nil, merr.WrapErrParameterInvalidMsg("illegal parameters, %s only supports [NONE, START, END]", models.TruncateParamKey)
 			}
 			truncate = param.Value
 		default:
@@ -87,7 +87,7 @@ func NewCohereEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 
 	embdType := models.GetEmbdType(fieldSchema.DataType)
 	if embdType == models.UnsupportEmbd {
-		return nil, fmt.Errorf("unsupport output type: %s", fieldSchema.DataType)
+		return nil, merr.WrapErrParameterInvalidMsg("unsupport output type: %s", fieldSchema.DataType)
 	}
 
 	outputType := func() string {
@@ -149,22 +149,22 @@ func (provider *CohereEmbeddingProvider) CallEmbedding(ctx context.Context, text
 		}
 		if provider.embdType == models.Float32Embd {
 			if end-i != len(resp.Embeddings.Float) {
-				return nil, fmt.Errorf("get embedding failed. The number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Embeddings.Float))
+				return nil, merr.WrapErrFunctionFailedMsg("get embedding failed. The number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Embeddings.Float))
 			}
 			for _, item := range resp.Embeddings.Float {
 				if len(item) != int(provider.fieldDim) {
-					return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+					return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 						provider.fieldDim, len(item))
 				}
 			}
 			embRet.Append(resp.Embeddings.Float)
 		} else {
 			if end-i != len(resp.Embeddings.Int8) {
-				return nil, fmt.Errorf("get embedding failed. The number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Embeddings.Int8))
+				return nil, merr.WrapErrFunctionFailedMsg("get embedding failed. The number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Embeddings.Int8))
 			}
 			for _, item := range resp.Embeddings.Int8 {
 				if len(item) != int(provider.fieldDim) {
-					return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+					return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 						provider.fieldDim, len(item))
 				}
 			}

--- a/internal/util/function/embedding/function_base.go
+++ b/internal/util/function/embedding/function_base.go
@@ -19,10 +19,10 @@
 package embedding
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type FunctionBase struct {
@@ -43,7 +43,7 @@ func getProvider(functionSchema *schemapb.FunctionSchema) (string, error) {
 		default:
 		}
 	}
-	return "", fmt.Errorf("the text embedding service provider parameter:[%s] was not found", Provider)
+	return "", merr.WrapErrParameterInvalidMsg("the text embedding service provider parameter:[%s] was not found", Provider)
 }
 
 func NewFunctionBase(coll *schemapb.CollectionSchema, fSchema *schemapb.FunctionSchema) (*FunctionBase, error) {
@@ -59,7 +59,7 @@ func NewFunctionBase(coll *schemapb.CollectionSchema, fSchema *schemapb.Function
 	}
 
 	if len(base.outputFields) != len(fSchema.GetOutputFieldNames()) {
-		return &base, fmt.Errorf("the collection [%s]'s information is wrong, function [%s]'s outputs does not match the schema",
+		return &base, merr.WrapErrParameterInvalidMsg("the collection [%s]'s information is wrong, function [%s]'s outputs does not match the schema",
 			coll.Name, fSchema.Name)
 	}
 

--- a/internal/util/function/embedding/function_executor.go
+++ b/internal/util/function/embedding/function_executor.go
@@ -20,11 +20,9 @@ package embedding
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"sync"
 
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -72,7 +70,7 @@ func createFunction(coll *schemapb.CollectionSchema, schema *schemapb.FunctionSc
 	case schemapb.FunctionType_MinHash:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("unknown functionRunner type %s", schema.GetType().String())
+		return nil, merr.WrapErrParameterInvalidMsg("unknown functionRunner type %s", schema.GetType().String())
 	}
 }
 
@@ -96,7 +94,7 @@ func validateFunction(schema *schemapb.CollectionSchema, fSchema *schemapb.Funct
 	}
 
 	if err := f.Check(context.Background()); err != nil {
-		return fmt.Errorf("check function [%s:%s] failed, the err is: %v", fSchema.Name, fSchema.GetType().String(), err)
+		return merr.Wrapf(err, "check function [%s:%s] failed", fSchema.Name, fSchema.GetType().String())
 	}
 	return nil
 }
@@ -119,7 +117,7 @@ func ValidateFunctions(schema *schemapb.CollectionSchema, needValidateFunctionNa
 		}
 	}
 
-	return fmt.Errorf("function [%s] not found in schema", needValidateFunctionName)
+	return merr.WrapErrParameterInvalidMsg("function [%s] not found in schema", needValidateFunctionName)
 }
 
 func NewFunctionExecutor(schema *schemapb.CollectionSchema, functions []*schemapb.FunctionSchema, extraInfo *models.ModelExtraInfo) (*FunctionExecutor, error) {
@@ -151,7 +149,7 @@ func (executor *FunctionExecutor) processSingleFunction(ctx context.Context, run
 		}
 	}
 	if len(inputs) != len(runner.GetSchema().InputFieldIds) {
-		return nil, errors.New("input field not found")
+		return nil, merr.WrapErrParameterInvalidMsg("input field not found")
 	}
 
 	tr := timerecord.NewTimeRecorder("function ProcessInsert")
@@ -169,7 +167,7 @@ func (executor *FunctionExecutor) ProcessInsert(ctx context.Context, msg *msgstr
 	numRows := msg.NumRows
 	for _, runner := range executor.runners {
 		if numRows > uint64(runner.MaxBatch()) {
-			return fmt.Errorf("numRows [%d] > function [%s]'s max batch [%d]", numRows, runner.GetSchema().Name, runner.MaxBatch())
+			return merr.WrapErrParameterInvalidMsg("numRows [%d] > function [%s]'s max batch [%d]", numRows, runner.GetSchema().Name, runner.MaxBatch())
 		}
 	}
 
@@ -198,7 +196,7 @@ func (executor *FunctionExecutor) ProcessInsert(ctx context.Context, msg *msgstr
 		errs = append(errs, err)
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%v", errs)
+		return merr.WrapErrFunctionFailedMsg("function execution failed: %v", errs)
 	}
 
 	for output := range outputs {
@@ -230,10 +228,10 @@ func (executor *FunctionExecutor) processSingleSearch(ctx context.Context, runne
 func (executor *FunctionExecutor) prcessSearch(ctx context.Context, req *internalpb.SearchRequest) error {
 	runner, exist := executor.runners[req.FieldId]
 	if !exist {
-		return fmt.Errorf("can not found function in field %d", req.FieldId)
+		return merr.WrapErrParameterInvalidMsg("can not found function in field %d", req.FieldId)
 	}
 	if req.Nq > int64(runner.MaxBatch()) {
-		return fmt.Errorf("nq [%d] > function [%s]'s max batch [%d]", req.Nq, runner.GetSchema().Name, runner.MaxBatch())
+		return merr.WrapErrParameterInvalidMsg("nq [%d] > function [%s]'s max batch [%d]", req.Nq, runner.GetSchema().Name, runner.MaxBatch())
 	}
 	if newHolder, err := executor.processSingleSearch(ctx, runner, req.GetPlaceholderGroup()); err != nil {
 		return err
@@ -250,7 +248,7 @@ func (executor *FunctionExecutor) prcessAdvanceSearch(ctx context.Context, req *
 	for idx, sub := range req.GetSubReqs() {
 		if runner, exist := executor.runners[sub.FieldId]; exist {
 			if sub.Nq > int64(runner.MaxBatch()) {
-				return fmt.Errorf("nq [%d] > function [%s]'s max batch [%d]", sub.Nq, runner.GetSchema().Name, runner.MaxBatch())
+				return merr.WrapErrParameterInvalidMsg("nq [%d] > function [%s]'s max batch [%d]", sub.Nq, runner.GetSchema().Name, runner.MaxBatch())
 			}
 			wg.Add(1)
 			go func(runner Runner, idx int64, placeholderGroup []byte) {
@@ -290,7 +288,7 @@ func (executor *FunctionExecutor) processSingleBulkInsert(ctx context.Context, r
 	for idx, id := range runner.GetSchema().InputFieldIds {
 		field, exist := data.Data[id]
 		if !exist {
-			return nil, fmt.Errorf("can not find input field: [%s]", runner.GetSchema().GetInputFieldNames()[idx])
+			return nil, merr.WrapErrParameterInvalidMsg("can not find input field: [%s]", runner.GetSchema().GetInputFieldNames()[idx])
 		}
 		inputs = append(inputs, field)
 	}

--- a/internal/util/function/embedding/gemini_embedding_provider.go
+++ b/internal/util/function/embedding/gemini_embedding_provider.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/gemini"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -51,7 +52,7 @@ func NewGeminiEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 	}
 
 	if fieldSchema.DataType != schemapb.DataType_FloatVector {
-		return nil, fmt.Errorf("Gemini embedding only supports FloatVector field, got %s", schemapb.DataType_name[int32(fieldSchema.DataType)]) //nolint:staticcheck // starts with proper noun
+		return nil, merr.WrapErrParameterInvalidMsg("Gemini embedding only supports FloatVector field, got %s", schemapb.DataType_name[int32(fieldSchema.DataType)]) //nolint:staticcheck // starts with proper noun
 	}
 
 	apiKey, url, err := models.ParseAKAndURL(credentials, functionSchema.Params, params, models.GeminiAKEnvStr, extraInfo)
@@ -79,7 +80,7 @@ func NewGeminiEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 	}
 
 	if modelName == "" {
-		return nil, fmt.Errorf("model_name is required for Gemini embedding provider")
+		return nil, merr.WrapErrParameterInvalidMsg("model_name is required for Gemini embedding provider")
 	}
 	modelName = strings.TrimPrefix(modelName, "models/")
 
@@ -139,12 +140,12 @@ func (provider *GeminiEmbeddingProvider) CallEmbedding(ctx context.Context, text
 			return nil, err
 		}
 		if end-i != len(resp.Embeddings) {
-			return nil, fmt.Errorf("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Embeddings))
+			return nil, merr.WrapErrFunctionFailedMsg("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Embeddings))
 		}
 
 		for _, item := range resp.Embeddings {
 			if len(item.Values) != int(provider.fieldDim) {
-				return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+				return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 					provider.fieldDim, len(item.Values))
 			}
 			embRet.Append(item.Values)

--- a/internal/util/function/embedding/openai_embedding_provider.go
+++ b/internal/util/function/embedding/openai_embedding_provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/openai"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -46,7 +47,7 @@ type OpenAIEmbeddingProvider struct {
 
 func createOpenAIEmbeddingClient(apiKey string, url string) (*openai.OpenAIEmbeddingClient, error) {
 	if apiKey == "" {
-		return nil, fmt.Errorf("missing credentials config or configure the %s environment variable in the Milvus service", models.OpenaiAKEnvStr)
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the %s environment variable in the Milvus service", models.OpenaiAKEnvStr)
 	}
 
 	if url == "" {
@@ -59,7 +60,7 @@ func createOpenAIEmbeddingClient(apiKey string, url string) (*openai.OpenAIEmbed
 
 func createAzureOpenAIEmbeddingClient(apiKey string, url string, resourceName string) (*openai.AzureOpenAIEmbeddingClient, error) {
 	if apiKey == "" {
-		return nil, fmt.Errorf("missing credentials config or configure the %s environment variable in the Milvus service", models.AzureOpenaiAKEnvStr)
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the %s environment variable in the Milvus service", models.AzureOpenaiAKEnvStr)
 	}
 
 	if url == "" {
@@ -71,7 +72,7 @@ func createAzureOpenAIEmbeddingClient(apiKey string, url string, resourceName st
 		}
 	}
 	if url == "" {
-		return nil, fmt.Errorf("must configure the %s environment variable in the Milvus service", models.AzureOpenaiResourceName)
+		return nil, merr.WrapErrParameterInvalidMsg("must configure the %s environment variable in the Milvus service", models.AzureOpenaiResourceName)
 	}
 	c := openai.NewAzureOpenAIEmbeddingClient(apiKey, url)
 	return c, nil
@@ -164,11 +165,11 @@ func (provider *OpenAIEmbeddingProvider) CallEmbedding(ctx context.Context, text
 			return nil, err
 		}
 		if end-i != len(resp.Data) {
-			return nil, fmt.Errorf("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Data))
+			return nil, merr.WrapErrFunctionFailedMsg("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Data))
 		}
 		for _, item := range resp.Data {
 			if len(item.Embedding) != int(provider.fieldDim) {
-				return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+				return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 					provider.fieldDim, len(item.Embedding))
 			}
 			data = append(data, item.Embedding)

--- a/internal/util/function/embedding/siliconflow_embedding_provider.go
+++ b/internal/util/function/embedding/siliconflow_embedding_provider.go
@@ -20,13 +20,13 @@ package embedding
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/siliconflow"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -111,11 +111,11 @@ func (provider *SiliconflowEmbeddingProvider) CallEmbedding(ctx context.Context,
 			return nil, err
 		}
 		if end-i != len(resp.Data) {
-			return nil, fmt.Errorf("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Data))
+			return nil, merr.WrapErrFunctionFailedMsg("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Data))
 		}
 		for _, item := range resp.Data {
 			if len(item.Embedding) != int(provider.fieldDim) {
-				return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+				return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 					provider.fieldDim, len(item.Embedding))
 			}
 			data = append(data, item.Embedding)

--- a/internal/util/function/embedding/tei_embedding_provider.go
+++ b/internal/util/function/embedding/tei_embedding_provider.go
@@ -20,7 +20,6 @@ package embedding
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/tei"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -68,15 +68,15 @@ func NewTEIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *
 			searchPrompt = param.Value
 		case models.MaxClientBatchSizeParamKey:
 			if maxBatch, err = strconv.Atoi(param.Value); err != nil {
-				return nil, fmt.Errorf("[%s param's value: %s] is not a valid number", models.MaxClientBatchSizeParamKey, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is not a valid number", models.MaxClientBatchSizeParamKey, param.Value)
 			}
 		case models.TruncationDirectionParamKey:
 			if truncationDirection = param.Value; truncationDirection != "Left" && truncationDirection != "Right" {
-				return nil, fmt.Errorf("[%s param's value: %s] is not invalid, only supports [Left/Right]", models.TruncationDirectionParamKey, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is not invalid, only supports [Left/Right]", models.TruncationDirectionParamKey, param.Value)
 			}
 		case models.TruncateParamKey:
 			if truncate, err = strconv.ParseBool(param.Value); err != nil {
-				return nil, fmt.Errorf("[%s param's value: %s] is invalid, only supports: [true/false]", models.TruncateParamKey, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is invalid, only supports: [true/false]", models.TruncateParamKey, param.Value)
 			}
 		default:
 		}
@@ -134,11 +134,11 @@ func (provider *TeiEmbeddingProvider) CallEmbedding(ctx context.Context, texts [
 			return nil, err
 		}
 		if end-i != len(*resp) {
-			return nil, fmt.Errorf("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(*resp))
+			return nil, merr.WrapErrFunctionFailedMsg("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(*resp))
 		}
 		for _, item := range *resp {
 			if len(item) != int(provider.fieldDim) {
-				return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+				return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 					provider.fieldDim, len(item))
 			}
 			data = append(data, item)

--- a/internal/util/function/embedding/text_embedding_function.go
+++ b/internal/util/function/embedding/text_embedding_function.go
@@ -20,10 +20,7 @@ package embedding
 
 import (
 	"context"
-	"fmt"
 	"reflect"
-
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -31,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -64,18 +62,18 @@ func hasEmptyString(texts []string) bool {
 
 func TextEmbeddingOutputsCheck(fields []*schemapb.FieldSchema) error {
 	if len(fields) != 1 || (fields[0].DataType != schemapb.DataType_FloatVector && fields[0].DataType != schemapb.DataType_Int8Vector) {
-		return errors.New("TextEmbedding function output field must be a FloatVector or Int8Vector field") //nolint:staticcheck // starts with proper noun
+		return merr.WrapErrParameterInvalidMsg("TextEmbedding function output field must be a FloatVector or Int8Vector field") //nolint:staticcheck // starts with proper noun
 	}
 	return nil
 }
 
 func TextEmbeddingInputsCheck(name string, fields []*schemapb.FieldSchema) error {
 	if len(fields) != 1 || (fields[0].DataType != schemapb.DataType_VarChar && fields[0].DataType != schemapb.DataType_Text) {
-		return errors.New("TextEmbedding function input field must be a VARCHAR/TEXT field") //nolint:staticcheck // starts with proper noun
+		return merr.WrapErrParameterInvalidMsg("TextEmbedding function input field must be a VARCHAR/TEXT field") //nolint:staticcheck // starts with proper noun
 	}
 
 	if fields[0].Nullable {
-		return fmt.Errorf("function input field cannot be nullable: function %s, field %s", name, fields[0].GetName())
+		return merr.WrapErrParameterInvalidMsg("function input field cannot be nullable: function %s, field %s", name, fields[0].GetName())
 	}
 	return nil
 }
@@ -99,7 +97,7 @@ func isValidInputDataType(dataType schemapb.DataType) bool {
 
 func NewTextEmbeddingFunction(coll *schemapb.CollectionSchema, functionSchema *schemapb.FunctionSchema, extraInfo *models.ModelExtraInfo) (*TextEmbeddingFunction, error) {
 	if len(functionSchema.GetOutputFieldNames()) != 1 {
-		return nil, fmt.Errorf("text function should only have one output field, but now is %d", len(functionSchema.GetOutputFieldNames()))
+		return nil, merr.WrapErrParameterInvalidMsg("text function should only have one output field, but now is %d", len(functionSchema.GetOutputFieldNames()))
 	}
 
 	base, err := NewFunctionBase(coll, functionSchema)
@@ -114,7 +112,7 @@ func NewTextEmbeddingFunction(coll *schemapb.CollectionSchema, functionSchema *s
 	var newProviderErr error
 	conf := paramtable.Get().FunctionCfg.GetTextEmbeddingProviderConfig(base.provider)
 	if !models.IsEnable(conf) {
-		return nil, fmt.Errorf("text embedding model provider [%s] is disabled", base.provider)
+		return nil, merr.WrapErrParameterInvalidMsg("text embedding model provider [%s] is disabled", base.provider)
 	}
 	credentials := credentials.NewCredentials(paramtable.Get().CredentialCfg.GetCredentials())
 	batchFactor := paramtable.Get().FunctionCfg.GetBatchFactor()
@@ -146,7 +144,7 @@ func NewTextEmbeddingFunction(coll *schemapb.CollectionSchema, functionSchema *s
 	case geminiProvider:
 		embP, newProviderErr = NewGeminiEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
 	default:
-		return nil, fmt.Errorf("unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider)
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider)
 	}
 
 	if newProviderErr != nil {
@@ -168,18 +166,18 @@ func (runner *TextEmbeddingFunction) Check(ctx context.Context) error {
 	case [][]float32:
 		dim = len(embds[0])
 		if runner.GetOutputFields()[0].DataType != schemapb.DataType_FloatVector {
-			return fmt.Errorf("embedding model output and field type mismatch, model output is %s, field type is %s", schemapb.DataType_name[int32(schemapb.DataType_FloatVector)], schemapb.DataType_name[int32(runner.GetOutputFields()[0].DataType)])
+			return merr.WrapErrParameterInvalidMsg("embedding model output and field type mismatch, model output is %s, field type is %s", schemapb.DataType_name[int32(schemapb.DataType_FloatVector)], schemapb.DataType_name[int32(runner.GetOutputFields()[0].DataType)])
 		}
 	case [][]int8:
 		dim = len(embds[0])
 		if runner.GetOutputFields()[0].DataType != schemapb.DataType_Int8Vector {
-			return fmt.Errorf("embedding model output and field type mismatch, model output is %s, field type is %s", schemapb.DataType_name[int32(schemapb.DataType_Int8Vector)], schemapb.DataType_name[int32(runner.GetOutputFields()[0].DataType)])
+			return merr.WrapErrParameterInvalidMsg("embedding model output and field type mismatch, model output is %s, field type is %s", schemapb.DataType_name[int32(schemapb.DataType_Int8Vector)], schemapb.DataType_name[int32(runner.GetOutputFields()[0].DataType)])
 		}
 	default:
-		return fmt.Errorf("unsupported embedding type: %s", reflect.TypeOf(embds).String())
+		return merr.WrapErrParameterInvalidMsg("unsupported embedding type: %s", reflect.TypeOf(embds).String())
 	}
 	if dim != int(runner.embProvider.FieldDim()) {
-		return fmt.Errorf("the dim set in the schema is inconsistent with the dim of the model, dim in schema is %d, dim of model is %d", runner.embProvider.FieldDim(), dim)
+		return merr.WrapErrParameterInvalidMsg("the dim set in the schema is inconsistent with the dim of the model, dim in schema is %d, dim of model is %d", runner.embProvider.FieldDim(), dim)
 	}
 	return nil
 }
@@ -249,25 +247,25 @@ func (runner *TextEmbeddingFunction) packToFieldData(embds any) ([]*schemapb.Fie
 
 func (runner *TextEmbeddingFunction) ProcessInsert(ctx context.Context, inputs []*schemapb.FieldData) ([]*schemapb.FieldData, error) {
 	if len(inputs) != 1 {
-		return nil, fmt.Errorf("text embedding function only receives one input field, but got [%d]", len(inputs))
+		return nil, merr.WrapErrParameterInvalidMsg("text embedding function only receives one input field, but got [%d]", len(inputs))
 	}
 
 	if !isValidInputDataType(inputs[0].Type) {
-		return nil, fmt.Errorf("text embedding only supports varchar or text field as input field, but got %s", schemapb.DataType_name[int32(inputs[0].Type)])
+		return nil, merr.WrapErrParameterInvalidMsg("text embedding only supports varchar or text field as input field, but got %s", schemapb.DataType_name[int32(inputs[0].Type)])
 	}
 
 	texts := inputs[0].GetScalars().GetStringData().GetData()
 	if texts == nil {
-		return nil, errors.New("input texts is empty")
+		return nil, merr.WrapErrParameterInvalidMsg("input texts is empty")
 	}
 
 	// make sure all texts are not empty
 	if hasEmptyString(texts) {
-		return nil, errors.New("there is an empty string in the input data, TextEmbedding function does not support empty text")
+		return nil, merr.WrapErrParameterInvalidMsg("there is an empty string in the input data, TextEmbedding function does not support empty text")
 	}
 	numRows := len(texts)
 	if numRows > runner.MaxBatch() {
-		return nil, fmt.Errorf("embedding supports up to [%d] pieces of data at a time, got [%d]", runner.MaxBatch(), numRows)
+		return nil, merr.WrapErrParameterInvalidMsg("embedding supports up to [%d] pieces of data at a time, got [%d]", runner.MaxBatch(), numRows)
 	}
 
 	embds, err := runner.embProvider.CallEmbedding(ctx, texts, models.InsertMode)
@@ -282,11 +280,11 @@ func (runner *TextEmbeddingFunction) ProcessSearch(ctx context.Context, placehol
 	texts := funcutil.GetVarCharFromPlaceholder(placeholderGroup.Placeholders[0]) // Already checked externally
 	numRows := len(texts)
 	if numRows > runner.MaxBatch() {
-		return nil, fmt.Errorf("embedding supports up to [%d] pieces of data at a time, got [%d]", runner.MaxBatch(), numRows)
+		return nil, merr.WrapErrParameterInvalidMsg("embedding supports up to [%d] pieces of data at a time, got [%d]", runner.MaxBatch(), numRows)
 	}
 	// make sure all texts are not empty
 	if hasEmptyString(texts) {
-		return nil, errors.New("there is an empty string in the queries, TextEmbedding function does not support empty text")
+		return nil, merr.WrapErrParameterInvalidMsg("there is an empty string in the queries, TextEmbedding function does not support empty text")
 	}
 	embds, err := runner.embProvider.CallEmbedding(ctx, texts, models.SearchMode)
 	if err != nil {
@@ -297,27 +295,27 @@ func (runner *TextEmbeddingFunction) ProcessSearch(ctx context.Context, placehol
 	} else if runner.GetOutputFields()[0].DataType == schemapb.DataType_Int8Vector {
 		return funcutil.Int8VectorsToPlaceholderGroup(embds.([][]int8)), nil
 	}
-	return nil, fmt.Errorf("text embedding function doesn't support % vector", schemapb.DataType_name[int32(runner.GetOutputFields()[0].DataType)])
+	return nil, merr.WrapErrParameterInvalidMsg("text embedding function doesn't support % vector", schemapb.DataType_name[int32(runner.GetOutputFields()[0].DataType)])
 }
 
 func (runner *TextEmbeddingFunction) ProcessBulkInsert(ctx context.Context, inputs []storage.FieldData) (map[storage.FieldID]storage.FieldData, error) {
 	if len(inputs) != 1 {
-		return nil, fmt.Errorf("TextEmbedding function only receives one input, bug got [%d]", len(inputs)) //nolint:staticcheck // starts with proper noun
+		return nil, merr.WrapErrParameterInvalidMsg("TextEmbedding function only receives one input, bug got [%d]", len(inputs)) //nolint:staticcheck // starts with proper noun
 	}
 
 	if !isValidInputDataType(inputs[0].GetDataType()) {
-		return nil, fmt.Errorf("TextEmbedding function only supports varchar or text field as input field, but got %s", schemapb.DataType_name[int32(inputs[0].GetDataType())]) //nolint:staticcheck // starts with proper noun
+		return nil, merr.WrapErrParameterInvalidMsg("TextEmbedding function only supports varchar or text field as input field, but got %s", schemapb.DataType_name[int32(inputs[0].GetDataType())]) //nolint:staticcheck // starts with proper noun
 	}
 
 	texts, ok := inputs[0].GetDataRows().([]string)
 	if !ok {
-		return nil, errors.New("input texts is empty")
+		return nil, merr.WrapErrParameterInvalidMsg("input texts is empty")
 	}
 
 	// make sure all texts are not empty
 	// In storage.FieldData, null is also stored as an empty string
 	if hasEmptyString(texts) {
-		return nil, errors.New("there is an empty string in the input data, TextEmbedding function does not support empty text")
+		return nil, merr.WrapErrParameterInvalidMsg("there is an empty string in the input data, TextEmbedding function does not support empty text")
 	}
 	embds, err := runner.embProvider.CallEmbedding(ctx, texts, models.InsertMode)
 	if err != nil {
@@ -352,5 +350,5 @@ func (runner *TextEmbeddingFunction) ProcessBulkInsert(ctx context.Context, inpu
 			runner.outputFields[0].FieldID: field,
 		}, nil
 	}
-	return nil, errors.New("unknown embedding type")
+	return nil, merr.WrapErrFunctionFailedMsg("unknown embedding type")
 }

--- a/internal/util/function/embedding/vertexai_embedding_provider.go
+++ b/internal/util/function/embedding/vertexai_embedding_provider.go
@@ -25,13 +25,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/vertexai"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -49,7 +48,7 @@ func getVertexAIJsonKey() ([]byte, error) {
 
 	jsonKeyPath := os.Getenv(models.VertexServiceAccountJSONEnv)
 	if jsonKeyPath == "" {
-		return nil, errors.New("VetexAI credentials file path is empty")
+		return nil, merr.WrapErrParameterInvalidMsg("VetexAI credentials file path is empty")
 	}
 	if vtxKey.filePath == jsonKeyPath {
 		return vtxKey.jsonKey, nil
@@ -57,7 +56,7 @@ func getVertexAIJsonKey() ([]byte, error) {
 
 	jsonKey, err := os.ReadFile(jsonKeyPath) //nolint:gosec // path is from trusted environment variable
 	if err != nil {
-		return nil, fmt.Errorf("Vertexai: read credentials file failed, %v", err) //nolint:staticcheck // starts with proper noun
+		return nil, merr.Wrap(err, "Vertexai: read credentials file failed") //nolint:staticcheck // starts with proper noun
 	}
 
 	vtxKey.jsonKey = jsonKey
@@ -287,11 +286,11 @@ func (provider *VertexAIEmbeddingProvider) callVertexAIEmbedding(texts []string,
 			return nil, err
 		}
 		if end-i != len(resp.Predictions) {
-			return nil, fmt.Errorf("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Predictions))
+			return nil, merr.WrapErrFunctionFailedMsg("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Predictions))
 		}
 		for _, item := range resp.Predictions {
 			if len(item.Embeddings.Values) != int(provider.fieldDim) {
-				return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+				return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 					provider.fieldDim, len(item.Embeddings.Values))
 			}
 			data = append(data, item.Embeddings.Values)
@@ -311,7 +310,7 @@ func (provider *VertexAIEmbeddingProvider) callGeminiEmbedding(texts []string, m
 			return nil, err
 		}
 		if len(resp.Embedding.Values) != int(provider.fieldDim) {
-			return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+			return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 				provider.fieldDim, len(resp.Embedding.Values))
 		}
 		data = append(data, resp.Embedding.Values)

--- a/internal/util/function/embedding/voyageai_embedding_provider.go
+++ b/internal/util/function/embedding/voyageai_embedding_provider.go
@@ -20,7 +20,6 @@ package embedding
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/voyageai"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -72,7 +72,7 @@ func NewVoyageAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSch
 			}
 		case models.TruncationParamKey:
 			if truncate, err = strconv.ParseBool(param.Value); err != nil {
-				return nil, fmt.Errorf("[%s param's value: %s] is invalid, only supports: [true/false]", models.TruncationParamKey, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is invalid, only supports: [true/false]", models.TruncationParamKey, param.Value)
 			}
 		default:
 		}
@@ -89,7 +89,7 @@ func NewVoyageAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSch
 
 	embdType := models.GetEmbdType(fieldSchema.DataType)
 	if embdType == models.UnsupportEmbd {
-		return nil, fmt.Errorf("unsupported output type: %s", fieldSchema.DataType)
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported output type: %s", fieldSchema.DataType)
 	}
 
 	outputType := func() string {
@@ -145,12 +145,12 @@ func (provider *VoyageAIEmbeddingProvider) CallEmbedding(ctx context.Context, te
 		if provider.embdType == models.Float32Embd {
 			resp := r.(*voyageai.EmbeddingResponse[float32])
 			if end-i != len(resp.Data) {
-				return nil, fmt.Errorf("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Data))
+				return nil, merr.WrapErrFunctionFailedMsg("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Data))
 			}
 
 			for _, item := range resp.Data {
 				if len(item.Embedding) != int(provider.fieldDim) {
-					return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+					return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 						provider.fieldDim, len(item.Embedding))
 				}
 				embRet.Append(item.Embedding)
@@ -158,12 +158,12 @@ func (provider *VoyageAIEmbeddingProvider) CallEmbedding(ctx context.Context, te
 		} else {
 			resp := r.(*voyageai.EmbeddingResponse[int8])
 			if end-i != len(resp.Data) {
-				return nil, fmt.Errorf("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Data))
+				return nil, merr.WrapErrFunctionFailedMsg("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(resp.Data))
 			}
 
 			for _, item := range resp.Data {
 				if len(item.Embedding) != int(provider.fieldDim) {
-					return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+					return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 						provider.fieldDim, len(item.Embedding))
 				}
 				embRet.Append(item.Embedding)

--- a/internal/util/function/embedding/yc_embedding_provider.go
+++ b/internal/util/function/embedding/yc_embedding_provider.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -75,7 +76,7 @@ func NewYCEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *s
 		}
 	}
 	if modelName == "" {
-		return nil, fmt.Errorf("yc embedding model name is required")
+		return nil, merr.WrapErrParameterInvalidMsg("yc embedding model name is required")
 	}
 
 	apiKey, url, err := models.ParseAKAndURL(credentials, functionSchema.Params, params, models.YandexCloudAKEnvStr, extraInfo)
@@ -83,7 +84,7 @@ func NewYCEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *s
 		return nil, err
 	}
 	if apiKey == "" {
-		return nil, fmt.Errorf("missing credentials config or configure the %s environment variable in the Milvus service", models.YandexCloudAKEnvStr)
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the %s environment variable in the Milvus service", models.YandexCloudAKEnvStr)
 	}
 	if url == "" {
 		url = defaultYCTextEmbeddingURL
@@ -142,11 +143,11 @@ func (provider *YCEmbeddingProvider) CallEmbedding(ctx context.Context, texts []
 
 		embeddings := extractYCEmbeddings(resp)
 		if end-i != len(embeddings) {
-			return nil, fmt.Errorf("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(embeddings))
+			return nil, merr.WrapErrFunctionFailedMsg("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", end-i, len(embeddings))
 		}
 		for _, emb := range embeddings {
 			if len(emb) != int(provider.fieldDim) {
-				return nil, fmt.Errorf("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+				return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
 					provider.fieldDim, len(emb))
 			}
 			data = append(data, emb)

--- a/internal/util/function/function.go
+++ b/internal/util/function/function.go
@@ -19,9 +19,8 @@
 package function
 
 import (
-	"fmt"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type FunctionRunner interface {
@@ -43,6 +42,6 @@ func NewFunctionRunner(coll *schemapb.CollectionSchema, schema *schemapb.Functio
 	case schemapb.FunctionType_TextEmbedding:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("unknown functionRunner type %s", schema.GetType().String())
+		return nil, merr.WrapErrParameterInvalidMsg("unknown functionRunner type %s", schema.GetType().String())
 	}
 }

--- a/internal/util/function/highlight/semantic_highlight.go
+++ b/internal/util/function/highlight/semantic_highlight.go
@@ -21,11 +21,11 @@ package highlight
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type semanticHighlightProvider interface {
@@ -62,21 +62,21 @@ func NewSemanticHighlight(collSchema *schemapb.CollectionSchema, params []*commo
 		switch param.Key {
 		case queryKeyName:
 			if err := json.Unmarshal([]byte(param.Value), &queries); err != nil {
-				return nil, fmt.Errorf("parse queries failed, err: %v", err)
+				return nil, merr.Wrap(err, "parse queries failed")
 			}
 		case inputFieldKeyName:
 			if err := json.Unmarshal([]byte(param.Value), &inputFields); err != nil {
-				return nil, fmt.Errorf("parse input_field failed, err: %v", err)
+				return nil, merr.Wrap(err, "parse input_field failed")
 			}
 		}
 	}
 
 	if len(queries) == 0 {
-		return nil, fmt.Errorf("queries is required")
+		return nil, merr.WrapErrParameterInvalidMsg("queries is required")
 	}
 
 	if len(inputFields) == 0 {
-		return nil, fmt.Errorf("input_field is required")
+		return nil, merr.WrapErrParameterInvalidMsg("input_field is required")
 	}
 
 	fieldIDMap := make(map[string]*schemapb.FieldSchema)
@@ -97,13 +97,13 @@ func NewSemanticHighlight(collSchema *schemapb.CollectionSchema, params []*commo
 		if ok {
 			// schema field found
 			if field.DataType != schemapb.DataType_VarChar && field.DataType != schemapb.DataType_Text {
-				return nil, fmt.Errorf("input_field %s is not a VarChar or Text field", fieldName)
+				return nil, merr.WrapErrParameterInvalidMsg("input_field %s is not a VarChar or Text field", fieldName)
 			}
 			fieldIDs = append(fieldIDs, field.FieldID)
 		} else {
 			// field not in schema, check if dynamic field is enabled
 			if !collSchema.EnableDynamicField {
-				return nil, fmt.Errorf("input_field %s not found in schema", fieldName)
+				return nil, merr.WrapErrParameterInvalidMsg("input_field %s not found in schema", fieldName)
 			}
 			// Non-schema fields are dynamic fields
 			dynamicFieldNames = append(dynamicFieldNames, fieldName)
@@ -171,7 +171,7 @@ func (highlight *SemanticHighlight) processOneQuery(ctx context.Context, query s
 		return nil, nil, err
 	}
 	if len(highlights) != len(documents) || len(scores) != len(documents) {
-		return nil, nil, fmt.Errorf("highlights size must equal to documents size, but got highlights size [%d], scores size [%d], documents size [%d]", len(highlights), len(scores), len(documents))
+		return nil, nil, merr.WrapErrFunctionFailedMsg("highlights size must equal to documents size, but got highlights size [%d], scores size [%d], documents size [%d]", len(highlights), len(scores), len(documents))
 	}
 
 	return highlights, scores, nil
@@ -180,7 +180,7 @@ func (highlight *SemanticHighlight) processOneQuery(ctx context.Context, query s
 func (highlight *SemanticHighlight) Process(ctx context.Context, topks []int64, documents []string) ([][]string, [][]float32, error) {
 	nq := len(topks)
 	if len(highlight.queries) != nq {
-		return nil, nil, fmt.Errorf("nq must equal to queries size, but got nq [%d], queries size [%d], queries: [%v]", nq, len(highlight.queries), highlight.queries)
+		return nil, nil, merr.WrapErrParameterInvalidMsg("nq must equal to queries size, but got nq [%d], queries size [%d], queries: [%v]", nq, len(highlight.queries), highlight.queries)
 	}
 	if len(documents) == 0 {
 		return [][]string{}, [][]float32{}, nil

--- a/internal/util/function/minhash_function.go
+++ b/internal/util/function/minhash_function.go
@@ -12,18 +12,16 @@ import "C"
 
 import (
 	"encoding/binary"
-	"fmt"
 	"strconv"
 	"strings"
 	"sync"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/analyzer"
 	"github.com/milvus-io/milvus/internal/util/analyzer/canalyzer"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // MinHashFunctionRunner
@@ -76,10 +74,10 @@ func NewMinHashFunctionRunner(
 	funSchema *schemapb.FunctionSchema,
 ) (FunctionRunner, error) {
 	if len(funSchema.GetOutputFieldIds()) != 1 {
-		return nil, fmt.Errorf("minhash function should only have one output field, but now %d", len(funSchema.GetOutputFieldIds()))
+		return nil, merr.WrapErrParameterInvalidMsg("minhash function should only have one output field, but now %d", len(funSchema.GetOutputFieldIds()))
 	}
 	if len(funSchema.GetInputFieldIds()) != 1 {
-		return nil, fmt.Errorf("minhash function should only have one input field, but now %d", len(funSchema.GetInputFieldIds()))
+		return nil, merr.WrapErrParameterInvalidMsg("minhash function should only have one input field, but now %d", len(funSchema.GetInputFieldIds()))
 	}
 	var inputField, outputField *schemapb.FieldSchema
 	for _, field := range collSchema.GetFields() {
@@ -92,10 +90,10 @@ func NewMinHashFunctionRunner(
 		}
 	}
 	if outputField == nil {
-		return nil, errors.New("no output field")
+		return nil, merr.WrapErrParameterInvalidMsg("no output field")
 	}
 	if inputField == nil {
-		return nil, errors.New("no input field")
+		return nil, merr.WrapErrParameterInvalidMsg("no input field")
 	}
 
 	params := getAnalyzerParams(inputField)
@@ -116,19 +114,19 @@ func NewMinHashFunctionRunner(
 		case NumHashesKey:
 			val, err := strconv.ParseInt(param.GetValue(), 10, 64)
 			if err != nil {
-				return nil, fmt.Errorf("param num_hashes:%s is not a number", param.GetValue())
+				return nil, merr.WrapErrParameterInvalidMsg("param num_hashes:%s is not a number", param.GetValue())
 			}
 			if val <= 0 {
-				return nil, fmt.Errorf("param num_hashes:%d must be positive", val)
+				return nil, merr.WrapErrParameterInvalidMsg("param num_hashes:%d must be positive", val)
 			}
 			numHashes = int(val)
 		case ShingleSizeKey:
 			val, err := strconv.ParseInt(param.GetValue(), 10, 64)
 			if err != nil {
-				return nil, fmt.Errorf("param shingle_size:%s is not a number", param.GetValue())
+				return nil, merr.WrapErrParameterInvalidMsg("param shingle_size:%s is not a number", param.GetValue())
 			}
 			if val <= 0 {
-				return nil, fmt.Errorf("param shingle_size:%d must be positive", val)
+				return nil, merr.WrapErrParameterInvalidMsg("param shingle_size:%d must be positive", val)
 			}
 			shingleSize = int(val)
 		case HashFuncKey:
@@ -138,7 +136,7 @@ func NewMinHashFunctionRunner(
 			case "sha1":
 				hashFunc = HashFuncSHA1
 			default:
-				return nil, fmt.Errorf("unknown hash function: %s", param.GetValue())
+				return nil, merr.WrapErrParameterInvalidMsg("unknown hash function: %s", param.GetValue())
 			}
 		case TokenLevelKey:
 			switch strings.ToLower(param.GetValue()) {
@@ -147,12 +145,12 @@ func NewMinHashFunctionRunner(
 			case "word":
 				useCharToken = false
 			default:
-				return nil, fmt.Errorf("unknown token_level: %s (expected 'char' or 'word')", param.GetValue())
+				return nil, merr.WrapErrParameterInvalidMsg("unknown token_level: %s (expected 'char' or 'word')", param.GetValue())
 			}
 		case SeedKey:
 			val, err := strconv.ParseInt(param.GetValue(), 10, 64)
 			if err != nil {
-				return nil, fmt.Errorf("param seed:%s is not a number", param.GetValue())
+				return nil, merr.WrapErrParameterInvalidMsg("param seed:%s is not a number", param.GetValue())
 			}
 			seed = int(val)
 		}
@@ -171,7 +169,7 @@ func NewMinHashFunctionRunner(
 			}
 		}
 		if outputDim <= 0 || outputDim%32 != 0 {
-			return nil, fmt.Errorf("minhash function output field '%s' dim not found or invalid(dim > 0, dim %% 32 == 0)", outputField.GetName())
+			return nil, merr.WrapErrParameterInvalidMsg("minhash function output field '%s' dim not found or invalid(dim > 0, dim %% 32 == 0)", outputField.GetName())
 		}
 		numHashes = int(outputDim / 32)
 		funSchema.Params = append(funSchema.Params, &commonpb.KeyValuePair{
@@ -203,10 +201,10 @@ func ValidateMinHashFunction(collSchema *schemapb.CollectionSchema, funSchema *s
 
 	// check input field count
 	if len(funSchema.GetInputFieldNames()) != 1 {
-		return fmt.Errorf("minhash function should only have one input field, but now %d", len(funSchema.GetInputFieldNames()))
+		return merr.WrapErrParameterInvalidMsg("minhash function should only have one input field, but now %d", len(funSchema.GetInputFieldNames()))
 	}
 	if len(funSchema.GetOutputFieldNames()) != 1 {
-		return fmt.Errorf("minhash function should only have one output field, but now %d", len(funSchema.GetOutputFieldNames()))
+		return merr.WrapErrParameterInvalidMsg("minhash function should only have one output field, but now %d", len(funSchema.GetOutputFieldNames()))
 	}
 
 	// Find fields by name (since FieldIDs may not be assigned yet during validation)
@@ -223,14 +221,14 @@ func ValidateMinHashFunction(collSchema *schemapb.CollectionSchema, funSchema *s
 	}
 
 	if inputField == nil {
-		return fmt.Errorf("minhash function input field '%s' not found", inputFieldName)
+		return merr.WrapErrParameterInvalidMsg("minhash function input field '%s' not found", inputFieldName)
 	}
 	if outputField == nil {
-		return fmt.Errorf("minhash function output field '%s' not found", outputFieldName)
+		return merr.WrapErrParameterInvalidMsg("minhash function output field '%s' not found", outputFieldName)
 	}
 
 	if inputField.GetDataType() != schemapb.DataType_VarChar && inputField.GetDataType() != schemapb.DataType_String {
-		return fmt.Errorf("minhash function input field '%s' is not string type, is %s",
+		return merr.WrapErrParameterInvalidMsg("minhash function input field '%s' is not string type, is %s",
 			inputFieldName, inputField.GetDataType())
 	}
 	// check function params
@@ -240,45 +238,45 @@ func ValidateMinHashFunction(collSchema *schemapb.CollectionSchema, funSchema *s
 		case NumHashesKey:
 			val, err := strconv.ParseInt(param.GetValue(), 10, 64)
 			if err != nil {
-				return fmt.Errorf("param num_hashes:%s is not a number", param.GetValue())
+				return merr.WrapErrParameterInvalidMsg("param num_hashes:%s is not a number", param.GetValue())
 			}
 			numHashes = int(val)
 			if numHashes <= 0 {
-				return fmt.Errorf("param num_hashes:%d must be positive", numHashes)
+				return merr.WrapErrParameterInvalidMsg("param num_hashes:%d must be positive", numHashes)
 			}
 		case ShingleSizeKey:
 			val, err := strconv.ParseInt(param.GetValue(), 10, 64)
 			if err != nil {
-				return fmt.Errorf("param shingle_size:%s is not a number", param.GetValue())
+				return merr.WrapErrParameterInvalidMsg("param shingle_size:%s is not a number", param.GetValue())
 			}
 			if val <= 0 {
-				return fmt.Errorf("param shingle_size:%d must be positive", val)
+				return merr.WrapErrParameterInvalidMsg("param shingle_size:%d must be positive", val)
 			}
 		case HashFuncKey:
 			switch strings.ToLower(param.GetValue()) {
 			case "xxhash", "xxhash64", "sha1":
 				// valid hash function
 			default:
-				return fmt.Errorf("unknown hash function: %s (expected 'xxhash64' or 'sha1')", param.GetValue())
+				return merr.WrapErrParameterInvalidMsg("unknown hash function: %s (expected 'xxhash64' or 'sha1')", param.GetValue())
 			}
 		case TokenLevelKey:
 			switch strings.ToLower(param.GetValue()) {
 			case "char", "character", "word":
 				// valid token level
 			default:
-				return fmt.Errorf("unknown token_level: %s (expected 'char' or 'word')", param.GetValue())
+				return merr.WrapErrParameterInvalidMsg("unknown token_level: %s (expected 'char' or 'word')", param.GetValue())
 			}
 		case SeedKey:
 			_, err := strconv.ParseInt(param.GetValue(), 10, 64)
 			if err != nil {
-				return fmt.Errorf("param seed:%s is not a number", param.GetValue())
+				return merr.WrapErrParameterInvalidMsg("param seed:%s is not a number", param.GetValue())
 			}
 		}
 	}
 	// check numHashes with output field
 	var outputDim int64 = -1
 	if outputField.GetDataType() != schemapb.DataType_BinaryVector {
-		return fmt.Errorf("minhash function output field '%s' is not binary vector type", outputFieldName)
+		return merr.WrapErrParameterInvalidMsg("minhash function output field '%s' is not binary vector type", outputFieldName)
 	}
 	for _, param := range outputField.GetTypeParams() {
 		if param.GetKey() == "dim" {
@@ -293,11 +291,11 @@ func ValidateMinHashFunction(collSchema *schemapb.CollectionSchema, funSchema *s
 	if numHashes > 0 {
 		expectedDim := int64(numHashes * 32) // binary vector, each hash is 4 bytes (32 bits), but stored as 8 bits in binary vector
 		if outputDim != expectedDim {
-			return fmt.Errorf("minhash function output field '%s' dim %d does not match expected dim %d (numHashes %d * one minhash signature size of 32bit)", outputFieldName, outputDim, expectedDim, numHashes)
+			return merr.WrapErrParameterInvalidMsg("minhash function output field '%s' dim %d does not match expected dim %d (numHashes %d * one minhash signature size of 32bit)", outputFieldName, outputDim, expectedDim, numHashes)
 		}
 	} else {
 		if outputDim%32 != 0 {
-			return fmt.Errorf("minhash function output field '%s' dim %d is not multiple of 32 (one minhash signature size)", outputFieldName, outputDim)
+			return merr.WrapErrParameterInvalidMsg("minhash function output field '%s' dim %d is not multiple of 32 (one minhash signature size)", outputFieldName, outputDim)
 		}
 	}
 	// else no numHashes specified, skip output field validation
@@ -345,16 +343,16 @@ func (m *MinHashFunctionRunner) BatchRun(inputs ...any) ([]any, error) {
 	defer m.mu.RUnlock()
 
 	if m.closed {
-		return nil, errors.New("MinHash function closed")
+		return nil, merr.WrapErrServiceInternalMsg("MinHash function closed")
 	}
 
 	if len(inputs) > 1 {
-		return nil, errors.New("MinHash function received more than one input column")
+		return nil, merr.WrapErrParameterInvalidMsg("MinHash function received more than one input column")
 	}
 
 	text, ok := inputs[0].([]string)
 	if !ok {
-		return nil, errors.New("MinHash function input not string list")
+		return nil, merr.WrapErrParameterInvalidMsg("MinHash function input not string list")
 	}
 
 	rowNum := len(text)

--- a/internal/util/function/models/ali/ali_dashscope_client.go
+++ b/internal/util/function/models/ali/ali_dashscope_client.go
@@ -20,9 +20,8 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type Input struct {
@@ -92,11 +91,11 @@ func NewAliDashScopeEmbeddingClient(apiKey string, url string) *AliDashScopeEmbe
 
 func (c *AliDashScopeEmbedding) Check() error {
 	if c.apiKey == "" {
-		return errors.New("api key is empty")
+		return merr.WrapErrParameterInvalidMsg("api key is empty")
 	}
 
 	if c.url == "" {
-		return errors.New("url is empty")
+		return merr.WrapErrParameterInvalidMsg("url is empty")
 	}
 	return nil
 }

--- a/internal/util/function/models/cohere/cohere_client.go
+++ b/internal/util/function/models/cohere/cohere_client.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type CohereClient struct {
@@ -29,7 +30,7 @@ type CohereClient struct {
 
 func NewCohereClient(apiKey string) (*CohereClient, error) {
 	if apiKey == "" {
-		return nil, fmt.Errorf("missing credentials config or configure the %s environment variable in the Milvus service", models.CohereAIAKEnvStr)
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the %s environment variable in the Milvus service", models.CohereAIAKEnvStr)
 	}
 	return &CohereClient{
 		apiKey: apiKey,

--- a/internal/util/function/models/common.go
+++ b/internal/util/function/models/common.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"math/rand"
 	"net/http"
@@ -34,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type TextEmbeddingMode int
@@ -211,11 +211,11 @@ func ParseAKAndURL(credentials *credentials.Credentials, params []*commonpb.KeyV
 func ParseAndCheckFieldDim(dimStr string, fieldDim int64, fieldName string) (int64, error) {
 	dim, err := strconv.ParseInt(dimStr, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("dimension [%s] provided in Function params is not a valid int", dimStr)
+		return 0, merr.WrapErrParameterInvalidMsg("dimension [%s] provided in Function params is not a valid int", dimStr)
 	}
 
 	if dim != 0 && dim != fieldDim {
-		return 0, fmt.Errorf("function output field:[%s]'s dimension [%d] does not match the dimension [%d] provided in Function params", fieldName, fieldDim, dim)
+		return 0, merr.WrapErrParameterInvalidMsg("function output field:[%s]'s dimension [%d] does not match the dimension [%d] provided in Function params", fieldName, fieldDim, dim)
 	}
 	return dim, nil
 }
@@ -267,10 +267,10 @@ func NewBaseURL(endpoint string) (*url.URL, error) {
 		return nil, err
 	}
 	if base.Scheme != "http" && base.Scheme != "https" {
-		return nil, fmt.Errorf("endpoint: [%s] is not a valid http/https link", endpoint)
+		return nil, merr.WrapErrParameterInvalidMsg("endpoint: [%s] is not a valid http/https link", endpoint)
 	}
 	if base.Host == "" {
-		return nil, fmt.Errorf("endpoint: [%s] is not a valid http/https link", endpoint)
+		return nil, merr.WrapErrParameterInvalidMsg("endpoint: [%s] is not a valid http/https link", endpoint)
 	}
 	return base, nil
 }
@@ -303,7 +303,7 @@ func PostRequest[T Response](req any, url string, headers map[string]string, tim
 	var res T
 	err = json.Unmarshal(body, &res)
 	if err != nil {
-		return nil, fmt.Errorf("call service failed, unmarshal response failed, errs:[%v]", err)
+		return nil, merr.Wrap(err, "call service failed, unmarshal response failed")
 	}
 	return &res, err
 }
@@ -311,17 +311,17 @@ func PostRequest[T Response](req any, url string, headers map[string]string, tim
 func send(req *http.Request) ([]byte, error) {
 	resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL is constructed from configured model endpoints, not user input
 	if err != nil {
-		return nil, fmt.Errorf("call service failed, errs:[%v]", err)
+		return nil, merr.WrapErrFunctionFailed(err, "call service failed")
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("call service failed, read response failed, errs:[%v]", err)
+		return nil, merr.WrapErrFunctionFailed(err, "call service failed, read response failed")
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("call service failed, errs:[%s, %s]", resp.Status, body)
+		return nil, merr.WrapErrFunctionFailedMsg("call service failed, errs:[%s, %s]", resp.Status, body)
 	}
 	return body, nil
 }

--- a/internal/util/function/models/gemini/gemini_client.go
+++ b/internal/util/function/models/gemini/gemini_client.go
@@ -17,10 +17,10 @@
 package gemini
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type GeminiClient struct {
@@ -29,7 +29,7 @@ type GeminiClient struct {
 
 func NewGeminiClient(apiKey string) (*GeminiClient, error) {
 	if apiKey == "" {
-		return nil, fmt.Errorf("missing credentials config or configure the %s environment variable in the Milvus service", models.GeminiAKEnvStr)
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the %s environment variable in the Milvus service", models.GeminiAKEnvStr)
 	}
 	return &GeminiClient{
 		apiKey: apiKey,

--- a/internal/util/function/models/openai/openai_client.go
+++ b/internal/util/function/models/openai/openai_client.go
@@ -21,9 +21,8 @@ import (
 	"net/url"
 	"sort"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type EmbeddingRequest struct {
@@ -99,11 +98,11 @@ type openAIBase struct {
 
 func (c *openAIBase) Check() error {
 	if c.apiKey == "" {
-		return errors.New("api key is empty")
+		return merr.WrapErrParameterInvalidMsg("api key is empty")
 	}
 
 	if c.url == "" {
-		return errors.New("url is empty")
+		return merr.WrapErrParameterInvalidMsg("url is empty")
 	}
 	return nil
 }

--- a/internal/util/function/models/siliconflow/siliconflow_client.go
+++ b/internal/util/function/models/siliconflow/siliconflow_client.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type SiliconflowClient struct {
@@ -29,7 +30,7 @@ type SiliconflowClient struct {
 
 func NewSiliconflowClient(apiKey string) (*SiliconflowClient, error) {
 	if apiKey == "" {
-		return nil, fmt.Errorf("missing credentials conifg or configure the %s environment variable in the Milvus service", models.SiliconflowAKEnvStr)
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials conifg or configure the %s environment variable in the Milvus service", models.SiliconflowAKEnvStr)
 	}
 
 	return &SiliconflowClient{

--- a/internal/util/function/models/vertexai/vertexai_client.go
+++ b/internal/util/function/models/vertexai/vertexai_client.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cockroachdb/errors"
 	"golang.org/x/oauth2/google"
 
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type Instance struct {
@@ -111,13 +111,13 @@ func NewVertexAIEmbedding(url string, jsonKey []byte, scopes string, token strin
 
 func (c *VertexAIEmbedding) Check() error {
 	if c.url == "" {
-		return errors.New("VertexAI embedding url is empty")
+		return merr.WrapErrParameterInvalidMsg("VertexAI embedding url is empty")
 	}
 	if len(c.jsonKey) == 0 {
-		return errors.New("jsonKey is empty")
+		return merr.WrapErrParameterInvalidMsg("jsonKey is empty")
 	}
 	if c.scopes == "" {
-		return errors.New("Scopes param is empty")
+		return merr.WrapErrParameterInvalidMsg("Scopes param is empty")
 	}
 	return nil
 }
@@ -126,11 +126,11 @@ func (c *VertexAIEmbedding) getAccessToken() (string, error) {
 	ctx := context.Background()
 	creds, err := google.CredentialsFromJSON(ctx, c.jsonKey, c.scopes)
 	if err != nil {
-		return "", fmt.Errorf("failed to find credentials: %v", err)
+		return "", merr.Wrap(err, "failed to find credentials")
 	}
 	token, err := creds.TokenSource.Token()
 	if err != nil {
-		return "", fmt.Errorf("failed to get token: %v", err)
+		return "", merr.Wrap(err, "failed to get token")
 	}
 	return token.AccessToken, nil
 }

--- a/internal/util/function/models/vllm/vllm_client.go
+++ b/internal/util/function/models/vllm/vllm_client.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func NewBaseURL(endpoint string) (*url.URL, error) {
@@ -31,10 +32,10 @@ func NewBaseURL(endpoint string) (*url.URL, error) {
 		return nil, err
 	}
 	if base.Scheme != "http" && base.Scheme != "https" {
-		return nil, fmt.Errorf("endpoint: [%s] is not a valid http/https link", endpoint)
+		return nil, merr.WrapErrParameterInvalidMsg("endpoint: [%s] is not a valid http/https link", endpoint)
 	}
 	if base.Host == "" {
-		return nil, fmt.Errorf("endpoint: [%s] is not a valid http/https link", endpoint)
+		return nil, merr.WrapErrParameterInvalidMsg("endpoint: [%s] is not a valid http/https link", endpoint)
 	}
 	return base, nil
 }

--- a/internal/util/function/models/voyageai/voyageai_client.go
+++ b/internal/util/function/models/voyageai/voyageai_client.go
@@ -21,9 +21,8 @@ import (
 	"maps"
 	"sort"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type VoyageAIClient struct {
@@ -32,7 +31,7 @@ type VoyageAIClient struct {
 
 func NewVoyageAIClient(apiKey string) (*VoyageAIClient, error) {
 	if apiKey == "" {
-		return nil, fmt.Errorf("missing credentials config or configure the %s environment variable in the Milvus service", models.VoyageAIAKEnvStr)
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the %s environment variable in the Milvus service", models.VoyageAIAKEnvStr)
 	}
 	return &VoyageAIClient{
 		apiKey: apiKey,
@@ -114,18 +113,18 @@ func newVoyageAIEmbedding(apiKey string, url string) *voyageAIEmbedding {
 
 func (c *voyageAIEmbedding) Check() error {
 	if c.apiKey == "" {
-		return errors.New("api key is empty")
+		return merr.WrapErrParameterInvalidMsg("api key is empty")
 	}
 
 	if c.url == "" {
-		return errors.New("url is empty")
+		return merr.WrapErrParameterInvalidMsg("url is empty")
 	}
 	return nil
 }
 
 func (c *voyageAIEmbedding) embedding(modelName string, texts []string, dim int, textType string, outputType string, truncation bool, headers map[string]string, timeoutSec int64) (any, error) {
 	if outputType != "float" && outputType != "int8" {
-		return nil, fmt.Errorf("Voyageai: unsupported output type: [%s], only support float and int8", outputType) //nolint:staticcheck // starts with proper noun
+		return nil, merr.WrapErrParameterInvalidMsg("Voyageai: unsupported output type: [%s], only support float and int8", outputType) //nolint:staticcheck // starts with proper noun
 	}
 	r := EmbeddingRequest{
 		Model:       modelName,

--- a/internal/util/function/models/zilliz/zilliz_client.go
+++ b/internal/util/function/models/zilliz/zilliz_client.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -36,6 +35,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/modelservicepb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type clientConfig struct {
@@ -71,14 +71,14 @@ type clientManager struct {
 func loadConfig(config map[string]string) (*clientConfig, error) {
 	endpoint := config["endpoint"]
 	if endpoint == "" {
-		return nil, fmt.Errorf("zilliz client config error, lost endpoint config")
+		return nil, merr.WrapErrParameterInvalidMsg("zilliz client config error, lost endpoint config")
 	}
 	enableTLSStr := config["enableTLS"]
 	enableTLS := false
 	if enableTLSStr != "" {
 		var err error
 		if enableTLS, err = strconv.ParseBool(enableTLSStr); err != nil {
-			return nil, fmt.Errorf("zilliz client config err: enableTLS:%s is not bool, err:%w", enableTLSStr, err)
+			return nil, merr.Wrapf(err, "zilliz client config err: enableTLS:%s is not bool", enableTLSStr)
 		}
 	}
 	if enableTLS {
@@ -192,7 +192,7 @@ func NewZilliClient(modelDeploymentID string, clusterID string, dbName string, i
 	}
 	conn, err := mgr.GetConn(clientConf)
 	if err != nil {
-		return nil, fmt.Errorf("connect model serving failed, err:%w", err)
+		return nil, merr.WrapErrFunctionFailed(err, "connect model serving failed")
 	}
 	return &ZillizClient{
 		modelDeploymentID: modelDeploymentID,
@@ -280,7 +280,7 @@ func (c *ZillizClient) Highlight(ctx context.Context, query string, texts []stri
 		}
 
 		if len(sentences) != len(retScores) {
-			return nil, nil, fmt.Errorf("sentences length %d does not match scores length %d", len(sentences), len(retScores))
+			return nil, nil, merr.WrapErrFunctionFailedMsg("sentences length %d does not match scores length %d", len(sentences), len(retScores))
 		}
 		highlights = append(highlights, sentences)
 		scores = append(scores, retScores)

--- a/internal/util/function/multi_analyzer_bm25_function.go
+++ b/internal/util/function/multi_analyzer_bm25_function.go
@@ -20,7 +20,6 @@ package function
 
 import (
 	"encoding/json"
-	"fmt"
 	"sync"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -76,12 +75,12 @@ func NewMultiAnalyzerBM25FunctionRunner(coll *schemapb.CollectionSchema, schema 
 
 	mfield, ok := m["by_field"]
 	if !ok {
-		return nil, fmt.Errorf("bm25 function with multi analyzer must have by_field param in multi_analyzer_params")
+		return nil, merr.WrapErrParameterInvalidMsg("bm25 function with multi analyzer must have by_field param in multi_analyzer_params")
 	}
 
 	err = json.Unmarshal(mfield, &mFileName)
 	if err != nil {
-		return nil, fmt.Errorf("bm25 function with multi analyzer by_field must be string but now: %s", mfield)
+		return nil, merr.WrapErrParameterInvalidMsg("bm25 function with multi analyzer by_field must be string but now: %s", mfield)
 	}
 
 	for _, field := range coll.GetFields() {
@@ -91,33 +90,33 @@ func NewMultiAnalyzerBM25FunctionRunner(coll *schemapb.CollectionSchema, schema 
 	}
 
 	if len(runner.inputFields) != 2 {
-		return nil, fmt.Errorf("bm25 function with multi analyzer must have two input fields")
+		return nil, merr.WrapErrParameterInvalidMsg("bm25 function with multi analyzer must have two input fields")
 	}
 
 	if value, ok := m["alias"]; ok {
 		mapping := map[string]string{}
 		err = json.Unmarshal(value, &mapping)
 		if err != nil {
-			return nil, fmt.Errorf("bm25 function with multi analyzer mapping must be string map but now: %s", value)
+			return nil, merr.WrapErrParameterInvalidMsg("bm25 function with multi analyzer mapping must be string map but now: %s", value)
 		}
 		runner.alias = mapping
 	}
 
 	analyzers, ok := m["analyzers"]
 	if !ok {
-		return nil, fmt.Errorf("bm25 function with multi analyzer must have analyzers param in multi_analyzer_params")
+		return nil, merr.WrapErrParameterInvalidMsg("bm25 function with multi analyzer must have analyzers param in multi_analyzer_params")
 	}
 
 	var analyzersParam map[string]json.RawMessage
 	err = json.Unmarshal(analyzers, &analyzersParam)
 	if err != nil {
-		return nil, fmt.Errorf("bm25 function unmarshal multi_analyzer_params analyzers failed : %s", err.Error())
+		return nil, merr.Wrap(err, "bm25 function unmarshal multi_analyzer_params analyzers failed")
 	}
 
 	for name, param := range analyzersParam {
 		analyzer, err := analyzer.NewAnalyzer(string(param), "")
 		if err != nil {
-			return nil, fmt.Errorf("bm25 function create analyzer %s failed with error: %s", name, err.Error())
+			return nil, merr.Wrapf(err, "bm25 function create analyzer %s failed", name)
 		}
 		runner.analyzers[name] = analyzer
 	}
@@ -189,25 +188,25 @@ func (v *MultiAnalyzerBM25FunctionRunner) BatchRun(inputs ...any) ([]any, error)
 	defer v.mu.RUnlock()
 
 	if v.closed {
-		return nil, fmt.Errorf("analyzer receview request after function closed")
+		return nil, merr.WrapErrServiceInternalMsg("analyzer receview request after function closed")
 	}
 
 	if len(inputs) != 2 {
-		return nil, fmt.Errorf("BM25 function with multi analyzer must received two input column")
+		return nil, merr.WrapErrParameterInvalidMsg("BM25 function with multi analyzer must received two input column")
 	}
 
 	text, ok := inputs[0].([]string)
 	if !ok {
-		return nil, fmt.Errorf("BM25 function with multi analyzer text input must be string list")
+		return nil, merr.WrapErrParameterInvalidMsg("BM25 function with multi analyzer text input must be string list")
 	}
 
 	analyzer, ok := inputs[1].([]string)
 	if !ok {
-		return nil, fmt.Errorf("BM25 function with multi analyzer input analyzer name must be string list")
+		return nil, merr.WrapErrParameterInvalidMsg("BM25 function with multi analyzer input analyzer name must be string list")
 	}
 
 	if len(text) != len(analyzer) {
-		return nil, fmt.Errorf("BM25 function with multi analyzer input text and analyzer name must have same length")
+		return nil, merr.WrapErrParameterInvalidMsg("BM25 function with multi analyzer input text and analyzer name must have same length")
 	}
 
 	rowNum := len(text)
@@ -286,25 +285,25 @@ func (v *MultiAnalyzerBM25FunctionRunner) BatchAnalyze(withDetail bool, withHash
 	defer v.mu.RUnlock()
 
 	if v.closed {
-		return nil, fmt.Errorf("analyzer receview request after function closed")
+		return nil, merr.WrapErrServiceInternalMsg("analyzer receview request after function closed")
 	}
 
 	if len(inputs) != 2 {
-		return nil, fmt.Errorf("multi analyzer must received two input column(text, analyzer_name)")
+		return nil, merr.WrapErrParameterInvalidMsg("multi analyzer must received two input column(text, analyzer_name)")
 	}
 
 	text, ok := inputs[0].([]string)
 	if !ok {
-		return nil, fmt.Errorf("multi analyzer text input must be string list")
+		return nil, merr.WrapErrParameterInvalidMsg("multi analyzer text input must be string list")
 	}
 
 	analyzer, ok := inputs[1].([]string)
 	if !ok {
-		return nil, fmt.Errorf("multi analyzer input analyzer name must be string list")
+		return nil, merr.WrapErrParameterInvalidMsg("multi analyzer input analyzer name must be string list")
 	}
 
 	if len(text) != len(analyzer) {
-		return nil, fmt.Errorf("multi analyzer input text and analyzer name must have same length")
+		return nil, merr.WrapErrParameterInvalidMsg("multi analyzer input text and analyzer name must have same length")
 	}
 
 	rowNum := len(text)

--- a/internal/util/function/rerank/ali_rerank_provider.go
+++ b/internal/util/function/rerank/ali_rerank_provider.go
@@ -20,13 +20,13 @@ package rerank
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/ali"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type aliProvider struct {
@@ -61,7 +61,7 @@ func newAliProvider(params []*commonpb.KeyValuePair, conf map[string]string, cre
 		}
 	}
 	if modelName == "" {
-		return nil, fmt.Errorf("ali rerank model name is required")
+		return nil, merr.WrapErrParameterInvalidMsg("ali rerank model name is required")
 	}
 	provider := aliProvider{
 		baseProvider: baseProvider{batchSize: maxBatch},

--- a/internal/util/function/rerank/cohere_rerank_provider.go
+++ b/internal/util/function/rerank/cohere_rerank_provider.go
@@ -20,7 +20,6 @@ package rerank
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/cohere"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type cohereProvider struct {
@@ -65,7 +65,7 @@ func newCohereProvider(params []*commonpb.KeyValuePair, conf map[string]string, 
 		case models.MaxTKsPerDocParamKey:
 			maxTokensPerDoc, err := strconv.Atoi(param.Value)
 			if err != nil {
-				return nil, fmt.Errorf("[%s param's value: %s] is not a valid number", models.MaxTKsPerDocParamKey, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is not a valid number", models.MaxTKsPerDocParamKey, param.Value)
 			} else {
 				modelParams[models.MaxTKsPerDocParamKey] = maxTokensPerDoc
 			}
@@ -73,7 +73,7 @@ func newCohereProvider(params []*commonpb.KeyValuePair, conf map[string]string, 
 		}
 	}
 	if modelName == "" {
-		return nil, fmt.Errorf("cohere rerank model name is required")
+		return nil, merr.WrapErrParameterInvalidMsg("cohere rerank model name is required")
 	}
 	provider := cohereProvider{
 		baseProvider: baseProvider{batchSize: maxBatch},

--- a/internal/util/function/rerank/model_function.go
+++ b/internal/util/function/rerank/model_function.go
@@ -20,13 +20,13 @@ package rerank
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -43,10 +43,10 @@ const (
 
 func parseMaxBatch(maxBatch string) (int, error) {
 	if batch, err := strconv.Atoi(maxBatch); err != nil {
-		return -1, fmt.Errorf("[%s param's value: %s] is not a valid number", models.MaxClientBatchSizeParamKey, maxBatch)
+		return -1, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is not a valid number", models.MaxClientBatchSizeParamKey, maxBatch)
 	} else {
 		if batch <= 0 {
-			return -1, fmt.Errorf("[%s param's value: %s] must be greater than 0", models.MaxClientBatchSizeParamKey, maxBatch)
+			return -1, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] must be greater than 0", models.MaxClientBatchSizeParamKey, maxBatch)
 		}
 		return batch, nil
 	}
@@ -73,7 +73,7 @@ func NewModelProvider(params []*commonpb.KeyValuePair, extraInfo *models.ModelEx
 			provider := strings.ToLower(param.Value)
 			conf := paramtable.Get().FunctionCfg.GetRerankModelProviders(provider)
 			if !models.IsEnable(conf) {
-				return nil, fmt.Errorf("rerank provider: [%s] is disabled", provider)
+				return nil, merr.WrapErrParameterInvalidMsg("rerank provider: [%s] is disabled", provider)
 			}
 			credentials := credentials.NewCredentials(paramtable.Get().CredentialCfg.GetCredentials())
 			switch provider {
@@ -93,9 +93,9 @@ func NewModelProvider(params []*commonpb.KeyValuePair, extraInfo *models.ModelEx
 				conf := paramtable.Get().FunctionCfg.ZillizProviders.GetValue()
 				return newZillizProvider(params, conf, extraInfo)
 			default:
-				return nil, fmt.Errorf("unknown rerank model provider:%s", param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("unknown rerank model provider:%s", param.Value)
 			}
 		}
 	}
-	return nil, fmt.Errorf("lost rerank params:%s ", providerParamName)
+	return nil, merr.WrapErrParameterInvalidMsg("lost rerank params:%s ", providerParamName)
 }

--- a/internal/util/function/rerank/siliconflow_rerank_provider.go
+++ b/internal/util/function/rerank/siliconflow_rerank_provider.go
@@ -20,7 +20,6 @@ package rerank
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/siliconflow"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type siliconflowProvider struct {
@@ -67,20 +67,20 @@ func newSiliconflowProvider(params []*commonpb.KeyValuePair, conf map[string]str
 		case models.MaxChunksPerDocParamKey:
 			maxChunksPerDoc, err := strconv.Atoi(param.Value)
 			if err != nil {
-				return nil, fmt.Errorf("[%s param's value: %s] is not a valid number", models.MaxChunksPerDocParamKey, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is not a valid number", models.MaxChunksPerDocParamKey, param.Value)
 			}
 			rankParams[models.MaxChunksPerDocParamKey] = maxChunksPerDoc
 		case models.OverlapTokensParamKey:
 			overlapTokens, err := strconv.Atoi(param.Value)
 			if err != nil {
-				return nil, fmt.Errorf("[%s param's value: %s] is not a valid number", models.OverlapTokensParamKey, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is not a valid number", models.OverlapTokensParamKey, param.Value)
 			}
 			rankParams[models.OverlapTokensParamKey] = overlapTokens
 		default:
 		}
 	}
 	if modelName == "" {
-		return nil, fmt.Errorf("siliconflow rerank model name is required")
+		return nil, merr.WrapErrParameterInvalidMsg("siliconflow rerank model name is required")
 	}
 
 	provider := siliconflowProvider{

--- a/internal/util/function/rerank/tei_rerank_provider.go
+++ b/internal/util/function/rerank/tei_rerank_provider.go
@@ -20,7 +20,6 @@ package rerank
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/tei"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type teiProvider struct {
@@ -57,13 +57,13 @@ func newTeiProvider(params []*commonpb.KeyValuePair, conf map[string]string, cre
 			}
 		case models.TruncateParamKey:
 			if teiTrun, err := strconv.ParseBool(param.Value); err != nil {
-				return nil, fmt.Errorf("Rerank params error, %s: %s is not bool type", models.TruncateParamKey, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("Rerank params error, %s: %s is not bool type", models.TruncateParamKey, param.Value)
 			} else {
 				truncateParams[models.TruncateParamKey] = teiTrun
 			}
 		case models.TruncationDirectionParamKey:
 			if truncationDirection := param.Value; truncationDirection != "Left" && truncationDirection != "Right" {
-				return nil, fmt.Errorf("[%s param's value: %s] is not invalid, only supports [Left/Right]", models.TruncationDirectionParamKey, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is not invalid, only supports [Left/Right]", models.TruncationDirectionParamKey, param.Value)
 			} else {
 				truncateParams[models.TruncationDirectionParamKey] = truncationDirection
 			}

--- a/internal/util/function/rerank/vllm_rerank_provider.go
+++ b/internal/util/function/rerank/vllm_rerank_provider.go
@@ -20,7 +20,6 @@ package rerank
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/vllm"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type vllmProvider struct {
@@ -52,7 +52,7 @@ func newVllmProvider(params []*commonpb.KeyValuePair, conf map[string]string, cr
 			}
 		case models.VllmTruncateParamName:
 			if vllmTrun, err := strconv.ParseInt(param.Value, 10, 64); err != nil {
-				return nil, fmt.Errorf("Rerank params error, %s: %s is not a number", models.VllmTruncateParamName, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("Rerank params error, %s: %s is not a number", models.VllmTruncateParamName, param.Value)
 			} else {
 				truncateParams[models.VllmTruncateParamName] = vllmTrun
 			}
@@ -60,7 +60,7 @@ func newVllmProvider(params []*commonpb.KeyValuePair, conf map[string]string, cr
 		}
 	}
 	if endpoint == "" {
-		return nil, fmt.Errorf("rerank function lost params endpoint")
+		return nil, merr.WrapErrParameterInvalidMsg("rerank function lost params endpoint")
 	}
 
 	apiKey, _, err := models.ParseAKAndURL(credentials, params, conf, "", &models.ModelExtraInfo{})

--- a/internal/util/function/rerank/voyageai_rerank_provider.go
+++ b/internal/util/function/rerank/voyageai_rerank_provider.go
@@ -20,7 +20,6 @@ package rerank
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/models/voyageai"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type voyageaiProvider struct {
@@ -63,7 +63,7 @@ func newVoyageaiProvider(params []*commonpb.KeyValuePair, conf map[string]string
 			}
 		case models.TruncationParamKey:
 			if truncate, err := strconv.ParseBool(param.Value); err != nil {
-				return nil, fmt.Errorf("[%s param's value: %s] is invalid, only supports: [true/false]", models.TruncationParamKey, param.Value)
+				return nil, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is invalid, only supports: [true/false]", models.TruncationParamKey, param.Value)
 			} else {
 				modelParams[models.TruncationParamKey] = truncate
 			}
@@ -71,7 +71,7 @@ func newVoyageaiProvider(params []*commonpb.KeyValuePair, conf map[string]string
 		}
 	}
 	if modelName == "" {
-		return nil, fmt.Errorf("voyageai rerank model name is required")
+		return nil, merr.WrapErrParameterInvalidMsg("voyageai rerank model name is required")
 	}
 	provider := voyageaiProvider{
 		baseProvider:   baseProvider{batchSize: maxBatch},

--- a/pkg/util/etcd/etcd_util_test.go
+++ b/pkg/util/etcd/etcd_util_test.go
@@ -18,15 +18,51 @@ package etcd
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"os"
 	"path"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// freePort grabs a random unused TCP port. There's a small TOCTOU window
+// between Close and the subsequent bind, but for unit tests it's acceptable.
+func freePort(t *testing.T) int {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
 func TestEtcd(t *testing.T) {
-	err := InitEtcdServer(true, "", "/tmp/data", "stdout", "info")
+	// Use random free ports so the embedded etcd does not collide with any
+	// already-running etcd on the dev machine (e.g. docker-compose etcd
+	// holding 2379/2380).
+	clientPort, peerPort := freePort(t), freePort(t)
+	dataDir, err := os.MkdirTemp("", "test-etcd-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dataDir)
+	cfgFile, err := os.CreateTemp("", "test-etcd-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(cfgFile.Name())
+	_, err = fmt.Fprintf(cfgFile, `name: default
+data-dir: %s
+listen-client-urls: http://127.0.0.1:%d
+advertise-client-urls: http://127.0.0.1:%d
+listen-peer-urls: http://127.0.0.1:%d
+initial-advertise-peer-urls: http://127.0.0.1:%d
+initial-cluster: default=http://127.0.0.1:%d
+initial-cluster-state: new
+`, dataDir, clientPort, clientPort, peerPort, peerPort, peerPort)
+	require.NoError(t, err)
+	require.NoError(t, cfgFile.Close())
+
+	err = InitEtcdServer(true, cfgFile.Name(), dataDir, "stdout", "info")
 	assert.NoError(t, err)
 	defer StopEtcdServer()
 

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -111,6 +111,11 @@ var (
 	ErrChannelNotAvailable     = newMilvusError("channel not available", 503, false)
 	ErrChannelCPExceededMaxLag = newMilvusError("channel checkpoint exceed max lag", 504, false)
 	ErrChannelTSafeStalled     = newMilvusError("channel tsafe stalled", 505, true)
+	// Channel routed to the wrong node — the requested channel is not owned by
+	// the delegator/querynode that received the request. Typically caused by
+	// stale shard-map at the caller (proxy). Retryable so the caller can
+	// re-resolve the shard map and dispatch to the correct node.
+	ErrChannelMisrouted = newMilvusError("channel misrouted: not owned by this node", 506, true)
 
 	// Segment related
 	ErrSegmentNotFound    = newMilvusError("segment not found", 600, false)
@@ -274,6 +279,13 @@ var (
 	ErrCompactionBlocked = newMilvusError("compaction blocked by snapshot protection", 2317, true)
 
 	ErrDataNodeSlotExhausted = newMilvusError("datanode slot exhausted", 2401, false)
+
+	// Function / runner execution failed — BM25 / MinHash / embedding /
+	// analyzer runner returned a malformed output (wrong type, empty,
+	// unexpected shape). Distinct from generic ServiceInternal: callers can
+	// pattern-match this code when they specifically care about function
+	// pipeline failures vs other internal errors.
+	ErrFunctionFailed = newMilvusError("function execution failed", 2400, false)
 
 	// Cipher/Encryption related
 	ErrKMSKeyRevoked = newMilvusError("KMS key has been revoked, access denied", 2500, false)

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -18,6 +18,7 @@ package merr
 
 import (
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/markers"
 	"github.com/samber/lo"
 )
 
@@ -36,6 +37,11 @@ const (
 var ErrorTypeName = map[ErrorType]string{
 	SystemError: "system_error",
 	InputError:  "input_error",
+}
+
+// ErrorClassifier defines the method to get the broad classification of a Milvus error.
+type ErrorClassifier interface {
+	GetErrorType() ErrorType
 }
 
 func (err ErrorType) String() string {
@@ -60,20 +66,23 @@ var (
 	ErrServiceUnimplemented        = newMilvusError("service unimplemented", 10, false)
 	ErrServiceTimeTickLongDelay    = newMilvusError("time tick long delay", 11, false)
 	ErrServiceResourceInsufficient = newMilvusError("service resource insufficient", 12, true)
+	ErrOldSessionExists            = newMilvusError("old session exists", 13, false)
+	ErrOperationNotSupported       = newMilvusError("unsupported operation", 14, false)
 
 	// Collection related
-	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false)
+	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false, WithErrorType(InputError))
 	ErrCollectionNotLoaded                     = newMilvusError("collection not loaded", 101, false)
-	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false)
+	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false, WithErrorType(InputError))
 	ErrCollectionNotFullyLoaded                = newMilvusError("collection not fully loaded", 103, true)
-	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false)
-	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false)
+	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false, WithErrorType(InputError))
+	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false, WithErrorType(InputError))
 	ErrCollectionOnRecovering                  = newMilvusError("collection on recovering", 106, true)
-	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false)
+	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false, WithErrorType(InputError))
 	// Deprecated, keep it only for reserving the error code
-	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false)
-	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false)
+	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false, WithErrorType(InputError))
+	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false, WithErrorType(InputError))
 	ErrCollectionSchemaVersionNotReady = newMilvusError("collection schema version not ready", 110, true)
+
 	// Partition related
 	ErrPartitionNotFound       = newMilvusError("partition not found", 200, false)
 	ErrPartitionNotLoaded      = newMilvusError("partition not loaded", 201, false)
@@ -83,13 +92,13 @@ var (
 	ErrGeneralCapacityExceeded = newMilvusError("general capacity exceeded", 250, false)
 
 	// ResourceGroup related
-	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false)
-	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false)
-	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false)
-	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false)
+	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false, WithErrorType(InputError))
+	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false, WithErrorType(InputError))
+	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false, WithErrorType(InputError))
+	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false, WithErrorType(InputError))
 	// go:deprecated
-	ErrResourceGroupNodeNotEnough    = newMilvusError("resource group node not enough", 304, false)
-	ErrResourceGroupServiceAvailable = newMilvusError("resource group service available", 305, true)
+	ErrResourceGroupNodeNotEnough      = newMilvusError("resource group node not enough", 304, false)
+	ErrResourceGroupServiceUnAvailable = newMilvusError("resource group service unavailable", 305, true)
 
 	// Replica related
 	ErrReplicaNotFound     = newMilvusError("replica not found", 400, false)
@@ -118,13 +127,13 @@ var (
 	// Index related
 	ErrIndexNotFound     = newMilvusError("index not found", 700, false)
 	ErrIndexNotSupported = newMilvusError("index type not supported", 701, false)
-	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false)
+	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false, WithErrorType(InputError))
 	ErrTaskDuplicate     = newMilvusError("task duplicates", 703, false)
 
 	// Database related
-	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false)
-	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false)
-	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false)
+	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false, WithErrorType(InputError))
+	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false, WithErrorType(InputError))
+	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false, WithErrorType(InputError))
 
 	// Node related
 	ErrNodeNotFound        = newMilvusError("node not found", 901, false)
@@ -167,7 +176,7 @@ var (
 
 	// Privilege related
 	// this operation is denied because the user not authorized, user need to login in first
-	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false)
+	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false, WithErrorType(InputError))
 	// this operation is denied because the user has no permission to do this, user need higher privilege
 	ErrPrivilegeNotPermitted     = newMilvusError("privilege not permitted", 1401, false)
 	ErrPrivilegeGroupInvalidName = newMilvusError("invalid privilege group name", 1402, false)
@@ -213,7 +222,7 @@ var (
 	errUnexpected = newMilvusError("unexpected error", (1<<16)-1, false)
 
 	// import
-	ErrImportFailed = newMilvusError("importing data failed", 2100, false)
+	ErrImportFailed = newMilvusError("importing data failed", 2100, false, WithErrorType(InputError))
 
 	// Search/Query related
 	ErrInconsistentRequery = newMilvusError("inconsistent requery result", 2200, true)
@@ -251,11 +260,6 @@ var (
 	// Snapshot related
 	ErrSnapshotNotFound = newMilvusError("snapshot not found", 2600, false)
 	ErrSnapshotPinned   = newMilvusError("snapshot is pinned", 2601, false)
-
-	// General
-	ErrOperationNotSupported = newMilvusError("unsupported operation", 3000, false)
-
-	ErrOldSessionExists = newMilvusError("old session exists", 3001, false)
 )
 
 type errorOption func(*milvusError)
@@ -314,6 +318,53 @@ func (e milvusError) Is(err error) bool {
 	return false
 }
 
+// GetErrorType implements the ErrorClassifier interface.
+// It returns the predefined classification of the error (SystemError or InputError).
+func (e milvusError) GetErrorType() ErrorType {
+	return e.errType
+}
+
+// wrappedMilvusError wraps an underlying error with a milvus sentinel and a
+// contextual message, while preserving the inner error chain. Designed so
+// all of the following work on the result, under both stdlib and cockroachdb
+// errors.Is semantics:
+//
+//   - errors.Is(result, sentinel)      → true   (matched via Is)
+//   - errors.Is(result, originalInner) → true   (inner reachable via Unwrap)
+//   - merr.Code(result)                → sentinel's errCode
+//
+// Cause is intentionally NOT overridden: cockroachdb's errors.Is walks the
+// Cause chain first, so returning the sentinel from Cause would hide the
+// inner error. Instead, merr.Code special-cases this type.
+type wrappedMilvusError struct {
+	msg      string
+	inner    error
+	sentinel milvusError
+}
+
+func (w *wrappedMilvusError) Error() string { return w.msg + ": " + w.inner.Error() }
+
+// Unwrap exposes the original error so errors.Is(w, originalInner) works
+// under both stdlib and cockroachdb chain walkers.
+func (w *wrappedMilvusError) Unwrap() error { return w.inner }
+
+// Is matches any milvus sentinel by delegating to the wrapped sentinel.
+func (w *wrappedMilvusError) Is(target error) bool {
+	return errors.Is(w.sentinel, target)
+}
+
+// code lets merr.Code retrieve the milvus error code without needing to
+// resolve the cause chain (which has been redirected to the inner error).
+func (w *wrappedMilvusError) code() int32 {
+	return w.sentinel.errCode
+}
+
+// GetErrorType lets ErrorClassifier consumers (proxy metrics, retry policy)
+// see the same classification as the sentinel.
+func (w *wrappedMilvusError) GetErrorType() ErrorType {
+	return w.sentinel.errType
+}
+
 type multiErrors struct {
 	errs []error
 }
@@ -358,4 +409,16 @@ func Combine(errs ...error) error {
 	return multiErrors{
 		errs,
 	}
+}
+
+func Wrap(err error, msg string) error {
+	return errors.Wrap(err, msg)
+}
+
+func Wrapf(err error, format string, args ...interface{}) error {
+	return errors.Wrapf(err, format, args...)
+}
+
+func Mark(err error, reference error) error {
+	return markers.Mark(err, reference)
 }

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -149,6 +149,27 @@ var (
 	ErrIoUnexpectEOF     = newMilvusError("unexpected EOF", 1002, true)
 	ErrIoTooManyRequests = newMilvusError("too many requests", 1003, true)
 
+	// Serialization / deserialization step failed — a transformation pipeline
+	// (proto Marshal/Unmarshal, json encode/decode, arrow schema conversion etc.)
+	// could not complete. Use for "conversion process failed" semantics rather
+	// than "stored bytes are corrupt" — for the latter use ErrDataIntegrity.
+	ErrSerializationFailed = newMilvusError("data serialization or deserialization failed", 1004, false)
+
+	// Data integrity check failed — bytes already on disk (binlog payload,
+	// event header extras, stats buffer) don't match the layout we expect from
+	// the schema (type mismatch, valuesRead vs rows mismatch, unknown column
+	// type, malformed event header). Likely permanent corruption; retry won't
+	// help. Distinct from ErrSerializationFailed (process step failed) and
+	// ErrParameterInvalid (caller-input we control).
+	ErrDataIntegrity = newMilvusError("data integrity check failed", 1009, false)
+
+	// Storage subsystem fallback — used for non-IO / non-serde / non-client-input
+	// failures inside the storage package (transaction state machine, writer/reader
+	// lifecycle, FFI internal failures, ext-table metadata operations).
+	// Prefer ErrIo*/ErrSerializationFailed/ErrDataIntegrity/ErrParameterInvalid
+	// when they fit; reach for ErrStorage only when none of those describe the failure.
+	ErrStorage = newMilvusError("storage internal error", 1008, false, WithErrorType(SystemError))
+
 	// Permanent errors - resource doesn't exist or access denied
 	ErrIoPermissionDenied   = newMilvusError("permission denied", 1005, false)
 	ErrIoBucketNotFound     = newMilvusError("bucket not found", 1006, false)
@@ -160,7 +181,7 @@ var (
 	ErrIoEntityTooLarge  = newMilvusError("entity too large", 1012, false)
 
 	// Parameter related
-	ErrParameterInvalid  = newMilvusError("invalid parameter", 1100, false)
+	ErrParameterInvalid  = newMilvusError("invalid parameter", 1100, false, WithErrorType(InputError))
 	ErrParameterMissing  = newMilvusError("missing parameter", 1101, false)
 	ErrParameterTooLarge = newMilvusError("parameter too large", 1102, false)
 

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 type ErrSuite struct {
@@ -34,7 +33,6 @@ type ErrSuite struct {
 }
 
 func (s *ErrSuite) SetupSuite() {
-	paramtable.Init()
 }
 
 func (s *ErrSuite) TestCode() {
@@ -104,7 +102,7 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrResourceGroupReachLimit("test_ResourceGroup", 1, "failed to get ResourceGroup"), ErrResourceGroupReachLimit)
 	s.ErrorIs(WrapErrResourceGroupIllegalConfig("test_ResourceGroup", nil, "failed to get ResourceGroup"), ErrResourceGroupIllegalConfig)
 	s.ErrorIs(WrapErrResourceGroupNodeNotEnough("test_ResourceGroup", 1, 2, "failed to get ResourceGroup"), ErrResourceGroupNodeNotEnough)
-	s.ErrorIs(WrapErrResourceGroupServiceAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceAvailable)
+	s.ErrorIs(WrapErrResourceGroupServiceUnAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceUnAvailable)
 
 	// Replica related
 	s.ErrorIs(WrapErrReplicaNotFound(1, "failed to get replica"), ErrReplicaNotFound)
@@ -224,7 +222,7 @@ func (s *ErrSuite) TestIsHealthy() {
 	}
 	for _, tc := range cases {
 		s.Run(tc.code.String(), func() {
-			s.Equal(tc.expect, IsHealthy(tc.code) == nil)
+			s.Equal(tc.expect, CheckHealthy(tc.code) == nil)
 		})
 	}
 }
@@ -274,4 +272,75 @@ func TestNewIOErrors(t *testing.T) {
 
 func TestErrors(t *testing.T) {
 	suite.Run(t, new(ErrSuite))
+}
+
+// TestWrapErrPreservesInnerChain locks in the contract that WrapErr*Err helpers
+// keep the inner error chain reachable via errors.Is while still attributing
+// the milvus sentinel for code lookup. Regression guard against the previous
+// implementation that string-flattened the inner error and lost its identity.
+func TestWrapErrPreservesInnerChain(t *testing.T) {
+	inner := errors.New("inner-error")
+
+	for _, tc := range []struct {
+		name     string
+		wrap     func() error
+		sentinel error
+		other    error
+		code     int32
+	}{
+		{
+			name:     "ServiceInternal",
+			wrap:     func() error { return WrapErrServiceInternalErr(inner, "ctx %s", "test") },
+			sentinel: ErrServiceInternal,
+			other:    ErrParameterInvalid,
+			code:     ErrServiceInternal.errCode,
+		},
+		{
+			name:     "ParameterInvalid",
+			wrap:     func() error { return WrapErrParameterInvalidErr(inner, "ctx %d", 42) },
+			sentinel: ErrParameterInvalid,
+			other:    ErrServiceInternal,
+			code:     ErrParameterInvalid.errCode,
+		},
+		{
+			name:     "MqInternal",
+			wrap:     func() error { return WrapErrMqInternal(inner, "step1", "step2") },
+			sentinel: ErrMqInternal,
+			other:    ErrServiceInternal,
+			code:     ErrMqInternal.errCode,
+		},
+		{
+			name:     "BuildCompactionRequestFail",
+			wrap:     func() error { return WrapErrBuildCompactionRequestFail(inner) },
+			sentinel: ErrBuildCompactionRequestFail,
+			other:    ErrServiceInternal,
+			code:     ErrBuildCompactionRequestFail.errCode,
+		},
+		{
+			name:     "GetCompactionPlanResultFail",
+			wrap:     func() error { return WrapErrGetCompactionPlanResultFail(inner) },
+			sentinel: ErrGetCompactionPlanResultFail,
+			other:    ErrServiceInternal,
+			code:     ErrGetCompactionPlanResultFail.errCode,
+		},
+		{
+			name:     "OperationNotSupported",
+			wrap:     func() error { return WrapErrOperationNotSupported(inner, "op %s", "drop") },
+			sentinel: ErrOperationNotSupported,
+			other:    ErrServiceInternal,
+			code:     ErrOperationNotSupported.errCode,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := tc.wrap()
+			assert.True(t, errors.Is(w, tc.sentinel), "must match its sentinel")
+			assert.True(t, errors.Is(w, inner), "must preserve inner chain")
+			assert.False(t, errors.Is(w, tc.other), "must not match unrelated sentinel")
+			assert.Equal(t, tc.code, Code(w), "Code() must report sentinel's code")
+			assert.Contains(t, w.Error(), inner.Error(), "message must include inner")
+		})
+	}
+
+	// nil err falls back to the Msg variant; just make sure that still works.
+	assert.True(t, errors.Is(WrapErrServiceInternalErr(nil, "no underlying err"), ErrServiceInternal))
 }

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -60,15 +60,9 @@ func Code(err error) int32 {
 }
 
 func IsRetryableErr(err error) bool {
-<<<<<<< HEAD
 	var milvusErr milvusError
 	if errors.As(err, &milvusErr) {
 		return milvusErr.retriable
-=======
-	var me milvusError
-	if errors.As(err, &me) {
-		return me.retriable
->>>>>>> 3a31bdeec4 (enhance: foundational merr framework and retry mechanisms)
 	}
 
 	return false
@@ -990,6 +984,87 @@ func WrapErrNodeNotMatch(expectedNodeID, actualNodeID int64, msg ...string) erro
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+// WrapErrSerializationFailedMsg creates a new ErrSerializationFailed (code 1004)
+// with a detail message. Used when stored bytes cannot be decoded into the
+// expected shape and there is no underlying error to wrap (e.g. valuesRead vs
+// rows mismatch in payload reader, type mismatch when reading a column from
+// the wrong DataType).
+func WrapErrSerializationFailedMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	return errors.Wrap(ErrSerializationFailed, detail)
+}
+
+// WrapErrSerializationFailed wraps an existing underlying error 'err' with
+// ErrSerializationFailed (code 1004). Used when a decode / unmarshal /
+// schema-conversion step fails with a non-typed inner error (json, proto,
+// arrow). If 'err' is already a typed merr, use merr.Wrap(err, msg) instead.
+func WrapErrSerializationFailed(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrSerializationFailedMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrSerializationFailed,
+	}
+}
+
+// WrapErrDataIntegrityMsg creates a new ErrDataIntegrity (code 1009) with a
+// detail message. Use when on-disk bytes don't conform to the expected schema
+// (binlog type mismatch, valuesRead vs rows mismatch, malformed event header,
+// unparseable stats buffer) — i.e. the stored data itself is corrupt, not the
+// (de)serialization step.
+func WrapErrDataIntegrityMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	return errors.Wrap(ErrDataIntegrity, detail)
+}
+
+// WrapErrDataIntegrity wraps an existing underlying error with ErrDataIntegrity
+// (code 1009). Use when stored-byte parsing surfaces a non-typed inner error
+// (json unmarshal of stats buffer, type assertion of decoded header extras).
+// If 'err' is already a typed merr, use merr.Wrap(err, msg) instead.
+func WrapErrDataIntegrity(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrDataIntegrityMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrDataIntegrity,
+	}
+}
+
+// WrapErrStorageMsg creates a new ErrStorage (code 1008) with a detail message.
+// Used when a logical internal error occurs in the storage layer (e.g. invalid
+// state, corrupted data structure check, nil data) and there is no underlying
+// Go error to wrap.
+func WrapErrStorageMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	return errors.Wrap(ErrStorage, detail)
+}
+
+// WrapErrStorage wraps an existing underlying error 'err' with ErrStorage
+// (code 1008). Used for storage subsystem failures (transaction state machine,
+// writer/reader lifecycle, FFI internal failures) that are not physical I/O,
+// not serialization, and not client-input errors.
+//
+// IMPORTANT: only use when 'err' is a raw error (FFI / fs / proto / arrow).
+// If 'err' is already a typed merr, use merr.Wrap(err, msg) instead — wrapping
+// a typed merr here would mask its inner code (defect#3 pattern).
+//
+// merr.Code(result) returns ErrStorage.code() = 1008; errors.Is(result, ErrStorage)
+// succeeds; errors.Is(result, err) also succeeds (inner chain preserved via Unwrap).
+func WrapErrStorage(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrStorageMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrStorage,
+	}
 }
 
 // IO related

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -19,16 +19,14 @@ package merr
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"go.uber.org/zap"
+	"golang.org/x/exp/constraints"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
-	"github.com/milvus-io/milvus/pkg/v3/log"
-	"github.com/milvus-io/milvus/pkg/v3/util/logutil"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 const InputErrorFlagKey string = "is_input_error"
@@ -40,26 +38,37 @@ func Code(err error) int32 {
 		return 0
 	}
 
-	cause := errors.Cause(err)
-	switch specificErr := cause.(type) {
-	case milvusError:
-		return specificErr.code()
-
-	default:
-		if errors.Is(specificErr, context.Canceled) {
-			return CanceledCode
-		} else if errors.Is(specificErr, context.DeadlineExceeded) {
-			return TimeoutCode
-		} else {
-			return errUnexpected.code()
+	// Walk the chain looking for a milvus marker (either milvusError directly,
+	// or our wrappedMilvusError whose sentinel.Cause is hidden so that the
+	// inner error stays reachable via errors.Is). Stop at the first match.
+	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
+		switch v := cur.(type) {
+		case milvusError:
+			return v.code()
+		case *wrappedMilvusError:
+			return v.code()
 		}
 	}
+
+	cause := errors.Cause(err)
+	if errors.Is(cause, context.Canceled) {
+		return CanceledCode
+	} else if errors.Is(cause, context.DeadlineExceeded) {
+		return TimeoutCode
+	}
+	return errUnexpected.code()
 }
 
 func IsRetryableErr(err error) bool {
+<<<<<<< HEAD
 	var milvusErr milvusError
 	if errors.As(err, &milvusErr) {
 		return milvusErr.retriable
+=======
+	var me milvusError
+	if errors.As(err, &me) {
+		return me.retriable
+>>>>>>> 3a31bdeec4 (enhance: foundational merr framework and retry mechanisms)
 	}
 
 	return false
@@ -299,17 +308,6 @@ func SegcoreError(code int32, msg string) error {
 	return newMilvusError(msg, code, false)
 }
 
-// CheckHealthy checks whether the state is healthy,
-// returns nil if healthy,
-// otherwise returns ErrServiceNotReady wrapped with current state
-func CheckHealthy(state commonpb.StateCode) error {
-	if state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(paramtable.GetRole(), paramtable.GetNodeID(), state.String())
-	}
-
-	return nil
-}
-
 func IsHealthy(stateCode commonpb.StateCode) error {
 	if stateCode == commonpb.StateCode_Healthy {
 		return nil
@@ -324,19 +322,17 @@ func IsHealthyOrStopping(stateCode commonpb.StateCode) error {
 	return CheckHealthy(stateCode)
 }
 
-func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
-	if err := Error(state.GetStatus()); err != nil {
-		return errors.Wrapf(err, "%s=%d not healthy", role, nodeID)
-	} else if state := state.GetState().GetStateCode(); state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(role, nodeID, state.String())
-	}
-
-	return nil
-}
-
 func WrapErrAsInputError(err error) error {
 	if merr, ok := err.(milvusError); ok {
 		WithErrorType(InputError)(&merr)
+		return merr
+	}
+	return err
+}
+
+func WrapErrAsSysError(err error) error {
+	if merr, ok := err.(milvusError); ok {
+		WithErrorType(SystemError)(&merr)
 		return merr
 	}
 	return err
@@ -346,7 +342,6 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	if merr, ok := err.(milvusError); ok {
 		for _, target := range targets {
 			if target.errCode == merr.errCode {
-				log.Info("mark error as input error", zap.Error(err))
 				WithErrorType(InputError)(&merr)
 				return merr
 			}
@@ -355,15 +350,43 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	return err
 }
 
+func WrapErrCollectionReplicateMode(operation string) error {
+	return wrapFields(ErrCollectionReplicateMode, value("operation", operation))
+}
+
 func GetErrorType(err error) ErrorType {
-	if merr, ok := err.(milvusError); ok {
-		return merr.errType
+	var me milvusError
+	if errors.As(err, &me) {
+		return me.errType
 	}
 
 	return SystemError
 }
 
-// Service related
+// keeps only 2 decimal places
+func toMB[T constraints.Integer | constraints.Float](mem T) T {
+	return T(math.Round(float64(mem)/1024/1024*100) / 100)
+}
+
+// CheckHealthy checks whether the state is healthy,
+// returns nil if healthy,
+// otherwise returns ErrServiceNotReady wrapped with current state
+func CheckHealthy(stateCode commonpb.StateCode) error {
+	if stateCode != commonpb.StateCode_Healthy {
+		return ErrServiceNotReady
+	}
+	return nil
+}
+
+func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
+	if err := Error(state.GetStatus()); err != nil {
+		return WrapErrServiceNotReady(role, nodeID, err.Error())
+	} else if stateCode := state.GetState().GetStateCode(); stateCode != commonpb.StateCode_Healthy {
+		return WrapErrServiceNotReady(role, nodeID, stateCode.String())
+	}
+	return nil
+}
+
 func WrapErrServiceNotReady(role string, sessionID int64, state string, msg ...string) error {
 	err := wrapFieldsWithDesc(ErrServiceNotReady,
 		state,
@@ -385,8 +408,8 @@ func WrapErrServiceUnavailable(reason string, msg ...string) error {
 
 func WrapErrServiceMemoryLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceMemoryLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -412,6 +435,21 @@ func WrapErrServiceInternal(reason string, msg ...string) error {
 	return err
 }
 
+func WrapErrServiceInternalErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrServiceInternalMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrServiceInternal,
+	}
+}
+
+func WrapErrServiceInternalMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrServiceInternal, fmt, args...)
+}
+
 func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, msg ...string) error {
 	err := wrapFields(ErrServiceCrossClusterRouting,
 		value("expectedCluster", expectedCluster),
@@ -425,8 +463,8 @@ func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, ms
 
 func WrapErrServiceDiskLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceDiskLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -715,9 +753,9 @@ func WrapErrResourceGroupNodeNotEnough(rg any, current any, expected any, msg ..
 	return err
 }
 
-// WrapErrResourceGroupServiceAvailable wraps ErrResourceGroupServiceAvailable with resource group
-func WrapErrResourceGroupServiceAvailable(msg ...string) error {
-	err := wrapFields(ErrResourceGroupServiceAvailable)
+// WrapErrResourceGroupServiceUnAvailable wraps ErrResourceGroupServiceUnAvailable with resource group
+func WrapErrResourceGroupServiceUnAvailable(msg ...string) error {
+	err := wrapFields(ErrResourceGroupServiceUnAvailable)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
@@ -1046,6 +1084,21 @@ func WrapErrParameterInvalid[T any](expected, actual T, msg ...string) error {
 	return err
 }
 
+// WrapErrParameterInvalidErr wraps an existing error 'err' with ErrParameterInvalid (Code 1005).
+// This is used when an underlying error (e.g., from parsing, validation utility, or dependency)
+// causes a parameter check to fail, and you need to provide extra context
+// in 'format' and 'args'.
+func WrapErrParameterInvalidErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrParameterInvalidMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrParameterInvalid,
+	}
+}
+
 func WrapErrParameterInvalidRange[T any](lower, upper, actual T, msg ...string) error {
 	err := wrapFields(ErrParameterInvalid,
 		bound("value", actual, lower, upper),
@@ -1068,6 +1121,10 @@ func WrapErrParameterMissing[T any](param T, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+func WrapErrParameterMissingMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrParameterMissing, fmt, args...)
 }
 
 func WrapErrParameterTooLarge(name string, msg ...string) error {
@@ -1105,11 +1162,14 @@ func WrapErrMqTopicNotEmpty(name string, msg ...string) error {
 }
 
 func WrapErrMqInternal(err error, msg ...string) error {
-	err = wrapFieldsWithDesc(ErrMqInternal, err.Error())
-	if len(msg) > 0 {
-		err = errors.Wrap(err, strings.Join(msg, "->"))
+	if err == nil {
+		return ErrMqInternal
 	}
-	return err
+	ctx := ErrMqInternal.msg
+	if len(msg) > 0 {
+		ctx = strings.Join(msg, "->") + ": " + ctx
+	}
+	return &wrappedMilvusError{msg: ctx, inner: err, sentinel: ErrMqInternal}
 }
 
 func WrapErrPrivilegeNotAuthenticated(fmt string, args ...any) error {
@@ -1251,6 +1311,12 @@ func WrapErrIllegalCompactionPlan(msg ...string) error {
 	return err
 }
 
+func WrapErrIllegalCompactionPlanMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	// Since this is the message-only path, we wrap the constant error with the formatted message.
+	return errors.Wrap(ErrIllegalCompactionPlan, detail)
+}
+
 func WrapErrCompactionPlanConflict(msg ...string) error {
 	err := error(ErrCompactionPlanConflict)
 	if len(msg) > 0 {
@@ -1319,11 +1385,25 @@ func WrapErrAnalyzeTaskNotFound(id int64) error {
 }
 
 func WrapErrBuildCompactionRequestFail(err error) error {
-	return wrapFieldsWithDesc(ErrBuildCompactionRequestFail, err.Error())
+	if err == nil {
+		return ErrBuildCompactionRequestFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrBuildCompactionRequestFail.msg,
+		inner:    err,
+		sentinel: ErrBuildCompactionRequestFail,
+	}
 }
 
 func WrapErrGetCompactionPlanResultFail(err error) error {
-	return wrapFieldsWithDesc(ErrGetCompactionPlanResultFail, err.Error())
+	if err == nil {
+		return ErrGetCompactionPlanResultFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrGetCompactionPlanResultFail.msg,
+		inner:    err,
+		sentinel: ErrGetCompactionPlanResultFail,
+	}
 }
 
 func WrapErrCompactionResult(msg ...string) error {
@@ -1383,4 +1463,23 @@ func WrapErrSnapshotPinned(name any, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+// WrapErrOperationNotSupportedMsg creates a new ErrOperationNotSupported with a detail message (Code 14).
+// This is the primary replacement for fmt.Errorf/errors.New for operations that are
+// currently not supported by the system.
+func WrapErrOperationNotSupportedMsg(format string, args ...any) error {
+	return errors.Wrapf(ErrOperationNotSupported, format, args...)
+}
+
+// WrapErrOperationNotSupported wraps an existing error 'err' with ErrOperationNotSupported (Code 14).
+func WrapErrOperationNotSupported(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrOperationNotSupportedMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrOperationNotSupported,
+	}
 }

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -807,6 +807,14 @@ func WrapErrChannelNotAvailable(name string, msg ...string) error {
 	return warpChannelErr(ErrChannelNotAvailable, name, msg...)
 }
 
+// WrapErrChannelMisrouted is used by a delegator/querynode when it receives a
+// request for a channel it does not own. Encodes the requested channel name
+// in the structured field; callers can put additional context (e.g. the list
+// of channels the node actually owns) into msg.
+func WrapErrChannelMisrouted(name string, msg ...string) error {
+	return warpChannelErr(ErrChannelMisrouted, name, msg...)
+}
+
 // Segment related
 func WrapErrSegmentNotFound(id int64, msg ...string) error {
 	err := wrapFields(ErrSegmentNotFound, value("segment", id))
@@ -1064,6 +1072,37 @@ func WrapErrStorage(err error, format string, args ...any) error {
 		msg:      fmt.Sprintf(format, args...),
 		inner:    err,
 		sentinel: ErrStorage,
+	}
+}
+
+// WrapErrFunctionFailedMsg creates a new ErrFunctionFailed (code 2400) with a
+// detail message. Use when a function / BM25 / MinHash / analyzer runner
+// returns a malformed output (wrong type, empty, unexpected shape) and there
+// is no underlying Go error to wrap.
+func WrapErrFunctionFailedMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	return errors.Wrap(ErrFunctionFailed, detail)
+}
+
+// WrapErrFunctionFailed wraps an existing underlying error 'err' with
+// ErrFunctionFailed (code 2400). Use when a function-pipeline call surfaces
+// a non-typed inner error (runner I/O, model invocation, dependency failure).
+//
+// IMPORTANT: only use when 'err' is a raw error. If 'err' is already a typed
+// merr, use merr.Wrap(err, msg) instead — wrapping a typed merr here would
+// mask its inner code (defect#3 pattern).
+//
+// merr.Code(result) returns ErrFunctionFailed.code() = 2400; errors.Is(result,
+// ErrFunctionFailed) succeeds; errors.Is(result, err) also succeeds (inner
+// chain preserved via Unwrap).
+func WrapErrFunctionFailed(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrFunctionFailedMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrFunctionFailed,
 	}
 }
 

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -178,22 +178,18 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				return err
 			}
 
-			// Caller-explicit RetryErr predicate takes precedence over the
-			// default InputError abort: when caller passes RetryErr they have
-			// decided which errors are retriable, framework must not override.
-			if c.isRetryErr != nil {
-				if !c.isRetryErr(err) {
-					log.Warn("retry func failed, not be retryable",
-						zap.Uint("retried", i),
-						zap.Uint("attempt", c.attempts),
-						zap.String("caller", getCaller(2)),
-					)
-					return err
-				}
-			} else if merr.GetErrorType(err) == merr.InputError {
-				log.Warn("retry func failed, input error is non-retriable",
+			// shouldRetry=true is the caller's explicit affirmative. Honor
+			// it. The optional RetryErr predicate is still consulted as a
+			// second gate, but unlike retry.Do the InputError default abort
+			// is intentionally not applied here: in retry.Handle the caller
+			// signals abort via shouldRetry=false, not via the error type,
+			// otherwise client-side cache-eviction patterns like
+			// retryIfSchemaError become unreachable for errors classified
+			// server-side as InputError (e.g. ErrCollectionSchemaMismatch).
+			if c.isRetryErr != nil && !c.isRetryErr(err) {
+				log.Warn("retry func failed, not be retryable",
 					zap.Uint("retried", i),
-					zap.Error(err),
+					zap.Uint("attempt", c.attempts),
 					zap.String("caller", getCaller(2)),
 				)
 				return err

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -72,10 +72,23 @@ func Do(ctx context.Context, fn func() error, opts ...Option) error {
 				}
 				return err
 			}
-			if c.isRetryErr != nil && !c.isRetryErr(err) {
-				log.Warn("retry func failed, not be retryable",
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
 					zap.Uint("retried", i),
-					zap.Uint("attempt", c.attempts),
+					zap.Error(err),
 					zap.String("caller", getCaller(2)),
 				)
 				return err
@@ -162,6 +175,27 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				if isContextErr && lastErr != nil {
 					return lastErr
 				}
+				return err
+			}
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
+					zap.Uint("retried", i),
+					zap.Error(err),
+					zap.String("caller", getCaller(2)),
+				)
 				return err
 			}
 

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -239,3 +239,53 @@ func TestHandle(t *testing.T) {
 	}, Attempts(10))
 	assert.NoError(t, err)
 }
+
+// Regression: Handle must honor the caller's shouldRetry=true even when the
+// returned error is server-classified InputError. This is the cross-case the
+// client-side cache-eviction pattern in retryIfSchemaError depends on:
+// ErrCollectionSchemaMismatch is tagged InputError server-side (the client
+// sent a stale schema and the server rejected) but the client legitimately
+// wants to evict its cache and retry. Before this case the framework's
+// "default InputError abort" was firing after shouldRetry=true and
+// retryIfSchemaError silently never retried.
+func TestHandle_ShouldRetryOverridesInputErrorDefault(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		if counter == 1 {
+			return true, merr.WrapErrCollectionSchemaMisMatch("mocked")
+		}
+		return false, nil
+	}, Attempts(10))
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, counter,
+		"Handle should retry once when caller returns shouldRetry=true on InputError")
+}
+
+// Symmetric guard: shouldRetry=false on InputError still aborts immediately
+// (this path was already correct; pinning it down so the regression fix
+// above doesn't accidentally turn into "always retry InputError").
+func TestHandle_ShouldRetryFalseAbortsOnInputError(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		return false, merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter)
+}
+
+// retry.Do has no shouldRetry signal from the caller, so the InputError
+// default abort remains the right behavior — keep it pinned.
+func TestDo_InputErrorAbortsByDefault(t *testing.T) {
+	counter := 0
+	err := Do(context.Background(), func() error {
+		counter++
+		return merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter, "Do should abort on InputError without retrying")
+}

--- a/scripts/run_go_unittest.sh
+++ b/scripts/run_go_unittest.sh
@@ -26,6 +26,12 @@ if [[ $(uname -s) == "Darwin" ]]; then
     export MallocNanoZone=0
 fi
 
+# Azurite default credentials for internal/storage TestAzureObjectStorage.
+# Honor any caller-provided value so CI can override with real credentials.
+if [[ -z "${AZURE_STORAGE_CONNECTION_STRING}" ]]; then
+    export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+fi
+
 # ignore MinIO,S3 unittests
 MILVUS_DIR="${ROOT_DIR}/internal/"
 PKG_DIR="${ROOT_DIR}/pkg/"

--- a/tests/python_client/check/func_check.py
+++ b/tests/python_client/check/func_check.py
@@ -504,9 +504,13 @@ class ResponseChecker:
                 num_to_check = min(100, len(distances))  # check 100 items if more than that
                 eps = 1e-6
                 if check_items.get("metric").upper() in ["IP", "COSINE", "BM25"]:
-                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1))
+                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1)), (
+                        f"distances not descending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 else:
-                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1))
+                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1)), (
+                        f"distances not ascending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 if check_items.get("vector_nq") is None or check_items.get("original_vectors") is None:
                     log.debug("skip distance check for knowhere does not return the precise distances")
                 else:

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1524,7 +1524,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("ratio", [-0.5, 1, 3])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_ratio(self, ratio, index):
         """
         target: index creation for unsupported ratio parameter
@@ -1551,7 +1551,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("inverted_index_algo", ["INVALID_ALGO"])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_inverted_index_algo(self, inverted_index_algo, index):
         """
         target: index creation for unsupported sparse inverted index algo parameter


### PR DESCRIPTION
Standardizes error handling in the function module (`internal/util/function`) onto the `merr` framework. Part of the system-wide error-standardization series — follow-up extracted from the abandoned err-std-05-others auto-generated branch, fully hand-derived.

### Stacking

Depends on #50054 (`err-std-5a-querynodev2`), which adds `ErrFunctionFailed` (2400) — the sentinel this PR routes all third-party SDK output / call failures to. Until #50054 merges the diff here also contains the 5a + 02 commits. **Review the single function commit** `Standardize error handling: function module (5b1)`. Indirect dependency: #50016 (`err-std-02-storage`, the `*wrappedMilvusError` helper pattern). Siblings: #49865 (`err-std-03-proxy`), #49874 (`err-std-04-coord`).

### What this is

`internal/util/function` (BM25, MinHash, multi-analyzer, text embedding, 10 embedding providers, 6 rerank providers, 9 vendor model clients, semantic highlight) was the largest remaining single-package surface with bare `fmt.Errorf` / `errors.New`. **191 callsites** across 35 files migrated by hand. Same systematic defects as #50016 (wrong import path, sentinel-corruption, code-masking via `WrapErr*Err`) were watched for and avoided.

### No new sentinels

All 191 sites route to existing types:
- **`ErrParameterInvalid` (1100, InputError)** from #50016 — function/runner schema validation, function-param parsing, runtime input shape, credentials/endpoint config missing.
- **`ErrFunctionFailed` (2400)** from #50054 — third-party SDK output shape mismatch (\"the required embedding dim is X but got Y\", \"number of texts and embeddings does not match\") and SDK call failure (zilliz `connect_model_serving`, models/common HTTP `send`).
- **`ErrServiceInternal`** — closed-state access on lifecycle-aware runners (\"analyzer received request after function closed\").

### Migration breakdown (~191 callsites across 35 files)

| Pattern | → Target | Sites |
|---|---|---|
| field/schema config (output field count, input type, dim) | `WrapErrParameterInvalidMsg` | ~70 |
| function-param parsing (num_hashes, shingle_size, hash_function, token_level) | `WrapErrParameterInvalidMsg` | ~40 |
| runtime input shape (empty texts, batch > max, list type) | `WrapErrParameterInvalidMsg` | ~30 |
| credentials/endpoint config missing | `WrapErrParameterInvalidMsg` | ~10 |
| SDK output shape mismatch (\"get embedding failed\" / dim mismatch) | `WrapErrFunctionFailedMsg` | ~16 |
| SDK call fail (zilliz connect, http send) | `WrapErrFunctionFailed(err, ...)` | ~5 |
| closed-state access | `WrapErrServiceInternalMsg` | ~5 |
| defect#3 fix: `fmt.Errorf(\"... %v\", err)` preserving inner type | `merr.Wrap(err, ...)` / `merr.Wrapf` | ~5 |

### Pre-flight audit (zero downstream breakage)

Before flipping a large batch of function sites to `InputError`-typed `ErrParameterInvalid`, both known regression vectors were swept:

- **`retry.Do` / `retry.Handle` × function caller**: zero hits across all 11 callers (`datanode/compactor`, `datanode/importv2`, `flushcommon/pipeline/flow_graph_embedding_node`, `parser/planparserv2`, `proxy/{highlighter,rerank_meta,search_pipeline,task_search,util}`, `querynodev2/delegator`, `querynodev2/pipeline/embedding_node`). No retry loop will be aborted by the new InputError marking — cf. the `file_resource_observer` regression that prompted #50016's `WrapErrServiceUnavailable` migration.
- **Caller-side `WrapErr<X>Err(err, ...)` defect#3 code-masking**: zero hits across the same 11 callers. Upstream is already clean from 02/03/04/5a.

### Validation

- `go vet -tags dynamic,test ./internal/util/function/...`: clean.
- `gofmt -l ./internal/util/function/`: clean.
- `go test -tags dynamic,test ./internal/util/function/...`: **18 sub-packages all ok** (function, embedding, embedding/models/{ali,cohere,openai,siliconflow,tei,vertexai,vllm,voyageai,zilliz,gemini}, rerank, highlight, chain).
- Zero residual `fmt.Errorf` / `errors.New` / `errors.Newf` left in the package.

### Out of scope

- The `pkg/util/typeutil` / `pkg/util/funcutil` / `internal/util/{indexparamcheck,importutilv2,segcore,queryutil,streamingutil,sessionutil,proxyutil,hookutil,credentials,dependency,exprutil}` packages are tracked for the next util-series PR (5b2). Splitting function out first keeps the diff focused on a single, self-contained domain.
- Same broader `WrapErrParameterInvalid[T]` generic-helper cleanup tracked in #50016's out-of-scope section.

issue: #47420