### PR TITLE
fix: format AssertInfo messages with explicit args

### DIFF
--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -333,8 +333,8 @@ class Schema {
     operator[](FieldId field_id) const {
         Assert(field_id.get() >= 0);
         AssertInfo(fields_.find(field_id) != fields_.end(),
-                   "Cannot find field with field_id: " +
-                       std::to_string(field_id.get()));
+                   "Cannot find field with field_id: {}",
+                   field_id.get());
         return fields_.at(field_id);
     }
 
@@ -369,7 +369,8 @@ class Schema {
     operator[](const FieldName& field_name) const {
         auto id_iter = name_ids_.find(field_name);
         AssertInfo(id_iter != name_ids_.end(),
-                   "Cannot find field with field_name: " + field_name.get());
+                   "Cannot find field with field_name: {}",
+                   field_name.get());
         return fields_.at(id_iter->second);
     }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -477,9 +477,9 @@ ChunkedSegmentSealedImpl::LoadVecIndex(LoadIndexInfo& info, bool is_replace) {
                  field_id.get(),
                  id_);
     } else {
-        AssertInfo(
-            !get_bit(index_ready_bitset_, field_id),
-            "vector index has been exist at " + std::to_string(field_id.get()));
+        AssertInfo(!get_bit(index_ready_bitset_, field_id),
+                   "vector index has been exist at {}",
+                   field_id.get());
     }
     LOG_INFO(
         "Before setting field_bit for field index, fieldID:{}. "
@@ -548,9 +548,9 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
                  field_id.get(),
                  id_);
     } else {
-        AssertInfo(
-            !get_bit(index_ready_bitset_, field_id),
-            "scalar index has been exist at " + std::to_string(field_id.get()));
+        AssertInfo(!get_bit(index_ready_bitset_, field_id),
+                   "scalar index has been exist at {}",
+                   field_id.get());
     }
 
     if (field_meta.get_data_type() == DataType::JSON) {
@@ -876,8 +876,8 @@ LoadGroupChunkMetadata(const std::vector<std::string>& insert_files,
                 storage::GetReaderProperties(),
                 storage::GetArrowReaderProperties());
             AssertInfo(result.ok(),
-                       "[StorageV2] Failed to create file row group reader: " +
-                           result.status().ToString());
+                       "[StorageV2] Failed to create file row group reader: {}",
+                       result.status().ToString());
 
             auto reader = result.ValueOrDie();
             FileMetadataLoadResult load_result;
@@ -1334,7 +1334,8 @@ ChunkedSegmentSealedImpl::prefetch_chunks(
     const std::vector<int64_t>& chunk_ids) const {
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
-               "Can't get bitset element at " + std::to_string(field_id.get()));
+               "Can't get bitset element at {}",
+               field_id.get());
     if (auto column = get_column(field_id)) {
         column->PrefetchChunks(op_ctx, chunk_ids);
     }
@@ -1346,7 +1347,8 @@ ChunkedSegmentSealedImpl::chunk_data_impl(milvus::OpContext* op_ctx,
                                           int64_t chunk_id) const {
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
-               "Can't get bitset element at " + std::to_string(field_id.get()));
+               "Can't get bitset element at {}",
+               field_id.get());
     if (auto column = get_column(field_id)) {
         return column->Span(op_ctx, chunk_id);
     }
@@ -1362,7 +1364,8 @@ ChunkedSegmentSealedImpl::chunk_array_view_impl(
     std::optional<std::pair<int64_t, int64_t>> offset_len) const {
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
-               "Can't get bitset element at " + std::to_string(field_id.get()));
+               "Can't get bitset element at {}",
+               field_id.get());
     if (auto column = get_column(field_id)) {
         return column->ArrayViews(op_ctx, chunk_id, offset_len);
     }
@@ -1378,7 +1381,8 @@ ChunkedSegmentSealedImpl::chunk_vector_array_view_impl(
     std::optional<std::pair<int64_t, int64_t>> offset_len) const {
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
-               "Can't get bitset element at " + std::to_string(field_id.get()));
+               "Can't get bitset element at {}",
+               field_id.get());
     if (auto column = get_column(field_id)) {
         return column->VectorArrayViews(op_ctx, chunk_id, offset_len);
     }
@@ -1394,7 +1398,8 @@ ChunkedSegmentSealedImpl::chunk_string_view_impl(
     std::optional<std::pair<int64_t, int64_t>> offset_len) const {
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
-               "Can't get bitset element at " + std::to_string(field_id.get()));
+               "Can't get bitset element at {}",
+               field_id.get());
     if (auto column = get_column(field_id)) {
         return column->StringViews(op_ctx, chunk_id, offset_len);
     }
@@ -1410,7 +1415,8 @@ ChunkedSegmentSealedImpl::chunk_string_views_by_offsets(
     const FixedVector<int32_t>& offsets) const {
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
-               "Can't get bitset element at " + std::to_string(field_id.get()));
+               "Can't get bitset element at {}",
+               field_id.get());
     if (auto column = get_column(field_id)) {
         return column->StringViewsByOffsets(op_ctx, chunk_id, offsets);
     }
@@ -1426,7 +1432,8 @@ ChunkedSegmentSealedImpl::chunk_array_views_by_offsets(
     const FixedVector<int32_t>& offsets) const {
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
-               "Can't get bitset element at " + std::to_string(field_id.get()));
+               "Can't get bitset element at {}",
+               field_id.get());
     if (auto column = get_column(field_id)) {
         return column->ArrayViewsByOffsets(op_ctx, chunk_id, offsets);
     }
@@ -1537,8 +1544,8 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
             vec_binlog_config_.at(field_id)->GetSearchConf(search_info);
 
         AssertInfo(vector_indexings_.is_ready(field_id),
-                   "vector indexes isn't ready for field " +
-                       std::to_string(field_id.get()));
+                   "vector indexes isn't ready for field {}",
+                   field_id.get());
         query::SearchOnSealedIndex(*schema_,
                                    vector_indexings_,
                                    binlog_search_info,
@@ -1556,8 +1563,8 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
             search_info.topk_ = GetEffectiveSearchTopk(search_info);
         }
         AssertInfo(vector_indexings_.is_ready(field_id),
-                   "vector indexes isn't ready for field " +
-                       std::to_string(field_id.get()));
+                   "vector indexes isn't ready for field {}",
+                   field_id.get());
         query::SearchOnSealedIndex(*schema_,
                                    vector_indexings_,
                                    search_info,
@@ -1569,9 +1576,9 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
                                    output);
         milvus::tracer::AddEvent("finish_searching_vector_index");
     } else {
-        AssertInfo(
-            get_bit(field_data_ready_bitset_, field_id),
-            "Field Data is not loaded: " + std::to_string(field_id.get()));
+        AssertInfo(get_bit(field_data_ready_bitset_, field_id),
+                   "Field Data is not loaded: {}",
+                   field_id.get());
         AssertInfo(num_rows_.has_value(), "Can't get row count value");
         auto row_count = num_rows_.value();
         auto vec_data = get_column(field_id);
@@ -1861,8 +1868,8 @@ ChunkedSegmentSealedImpl::DropFieldData(const FieldId field_id) {
 void
 ChunkedSegmentSealedImpl::DropIndex(const FieldId field_id) {
     AssertInfo(!SystemProperty::Instance().IsSystem(field_id),
-               "Field id:" + std::to_string(field_id.get()) +
-                   " isn't one of system type when drop index");
+               "Field id:{} isn't one of system type when drop index",
+               field_id.get());
     if (field_exists_in_schema(schema_, field_id)) {
         auto& field_meta = schema_->operator[](field_id);
         AssertInfo(!field_meta.is_vector(), "vector field cannot drop index");
@@ -3732,16 +3739,16 @@ ChunkedSegmentSealedImpl::HasRawData(int64_t field_id) const {
                        "vector index is not ready");
             AssertInfo(
                 index_has_raw_data_.find(fieldID) != index_has_raw_data_.end(),
-                "index_has_raw_data_ is not set for fieldID: " +
-                    std::to_string(fieldID.get()));
+                "index_has_raw_data_ is not set for fieldID: {}",
+                fieldID.get());
             return index_has_raw_data_.at(fieldID);
         } else if (get_bit(binlog_index_bitset_, fieldID)) {
             AssertInfo(vector_indexings_.is_ready(fieldID),
                        "interim index is not ready");
             AssertInfo(
                 index_has_raw_data_.find(fieldID) != index_has_raw_data_.end(),
-                "index_has_raw_data_ is not set for fieldID: " +
-                    std::to_string(fieldID.get()));
+                "index_has_raw_data_ is not set for fieldID: {}",
+                fieldID.get());
             return index_has_raw_data_.at(fieldID) ||
                    get_bit(field_data_ready_bitset_, fieldID);
         }
@@ -3754,8 +3761,8 @@ ChunkedSegmentSealedImpl::HasRawData(int64_t field_id) const {
         if (has_scalar_index) {
             AssertInfo(
                 index_has_raw_data_.find(fieldID) != index_has_raw_data_.end(),
-                "index_has_raw_data_ is not set for fieldID: " +
-                    std::to_string(fieldID.get()));
+                "index_has_raw_data_ is not set for fieldID: {}",
+                fieldID.get());
             return index_has_raw_data_.at(fieldID);
         }
     }

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -1689,10 +1689,11 @@ class InsertRecordGrowing {
     VectorBase*
     get_data_base(FieldId field_id) const {
         AssertInfo(data_.find(field_id) != data_.end(),
-                   "Cannot find field_data with field_id: " +
-                       std::to_string(field_id.get()));
+                   "Cannot find field_data with field_id: {}",
+                   field_id.get());
         AssertInfo(data_.at(field_id) != nullptr,
-                   "data_ at i is null" + std::to_string(field_id.get()));
+                   "field_id {} data is null",
+                   field_id.get());
         return data_.at(field_id).get();
     }
 
@@ -1719,10 +1720,11 @@ class InsertRecordGrowing {
     ThreadSafeValidDataPtr
     get_valid_data(FieldId field_id) const {
         AssertInfo(valid_data_.find(field_id) != valid_data_.end(),
-                   "Cannot find valid_data with field_id: " +
-                       std::to_string(field_id.get()));
+                   "Cannot find valid_data with field_id: {}",
+                   field_id.get());
         AssertInfo(valid_data_.at(field_id) != nullptr,
-                   "valid_data_ at i is null" + std::to_string(field_id.get()));
+                   "field_id {} valid_data is null",
+                   field_id.get());
         return valid_data_.at(field_id);
     }
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -909,8 +909,8 @@ SegmentGrowingImpl::load_column_group_data_internal(
                 storage::GetReaderProperties(),
                 storage::GetArrowReaderProperties());
             AssertInfo(result.ok(),
-                       "[StorageV2] Failed to create file row group reader: " +
-                           result.status().ToString());
+                       "[StorageV2] Failed to create file row group reader: {}",
+                       result.status().ToString());
             auto reader = result.ValueOrDie();
             auto row_group_num =
                 reader->file_metadata()->GetRowGroupMetadataVector().size();

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -119,8 +119,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
     bool
     is_nullable(FieldId field_id) const override {
         AssertInfo(insert_record_.is_data_exist(field_id),
-                   "Cannot find field_data with field_id: " +
-                       std::to_string(field_id.get()));
+                   "Cannot find field_data with field_id: {}",
+                   field_id.get());
         return insert_record_.is_valid_data_exist(field_id);
     };
 

--- a/internal/core/src/segcore/SegmentGrowingStorageV2Test.cpp
+++ b/internal/core/src/segcore/SegmentGrowingStorageV2Test.cpp
@@ -231,15 +231,16 @@ TEST_F(TestGrowingStorageV2, LoadWithStrategy) {
     auto reader_result =
         milvus_storage::FileRowGroupReader::Make(fs_, paths[0]);
     AssertInfo(reader_result.ok(),
-               "[StorageV2] Failed to create file row group reader: " +
-                   reader_result.status().ToString());
+               "[StorageV2] Failed to create file row group reader: {}",
+               reader_result.status().ToString());
     auto fr = reader_result.ValueOrDie();
     auto row_group_metadata = fr->file_metadata()->GetRowGroupMetadataVector();
     auto status = fr->Close();
-    AssertInfo(
-        status.ok(),
-        "failed to close file reader when get row group metadata from file: " +
-            paths[0] + " with error: " + status.ToString());
+    AssertInfo(status.ok(),
+               "failed to close file reader when get row group metadata from "
+               "file: {} with error: {}",
+               paths[0],
+               status.ToString());
     std::vector<int64_t> row_groups(row_group_metadata.size());
     std::iota(row_groups.begin(), row_groups.end(), 0);
     std::vector<std::vector<int64_t>> row_group_lists = {row_groups};

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -365,8 +365,8 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                                                    batch.rg_count,
                                                    reader_memory_limit);
             AssertInfo(tables_result.ok(),
-                       "[StorageV2] Failed to read batch: " +
-                           tables_result.status().ToString());
+                       "[StorageV2] Failed to read batch: {}",
+                       tables_result.status().ToString());
             auto all_tables = std::move(tables_result).ValueOrDie();
             AssertInfo(all_tables.size() == static_cast<size_t>(batch.rg_count),
                        "reader returns less tables than expected, batch rg "

--- a/internal/core/src/segcore/packed_writer_c.cpp
+++ b/internal/core/src/segcore/packed_writer_c.cpp
@@ -130,8 +130,8 @@ NewPackedWriterWithStorageConfig(struct ArrowSchema* schema,
                                                           buffer_size,
                                                           writer_properties);
         AssertInfo(result.ok(),
-                   "[StorageV2] Failed to create packed writer: " +
-                       result.status().ToString());
+                   "[StorageV2] Failed to create packed writer: {}",
+                   result.status().ToString());
         auto writer = result.ValueOrDie();
         *c_packed_writer =
             new std::shared_ptr<milvus_storage::PackedRecordBatchWriter>(
@@ -203,8 +203,8 @@ NewPackedWriter(struct ArrowSchema* schema,
                                                           buffer_size,
                                                           writer_properties);
         AssertInfo(result.ok(),
-                   "[StorageV2] Failed to create packed writer: " +
-                       result.status().ToString());
+                   "[StorageV2] Failed to create packed writer: {}",
+                   result.status().ToString());
         auto writer = result.ValueOrDie();
         *c_packed_writer =
             new std::shared_ptr<milvus_storage::PackedRecordBatchWriter>(

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
@@ -139,8 +139,8 @@ TEST_P(GroupChunkTranslatorTest, TestWithMmap) {
     auto reader_result =
         milvus_storage::FileRowGroupReader::Make(fs_, paths_[0]);
     AssertInfo(reader_result.ok(),
-               "[StorageV2] Failed to create file row group reader: " +
-                   reader_result.status().ToString());
+               "[StorageV2] Failed to create file row group reader: {}",
+               reader_result.status().ToString());
     auto fr = reader_result.ValueOrDie();
     auto row_group_metadata_vector =
         fr->file_metadata()->GetRowGroupMetadataVector();
@@ -273,8 +273,8 @@ TEST_P(GroupChunkTranslatorTest, TestMultipleFiles) {
         auto reader_result =
             milvus_storage::FileRowGroupReader::Make(fs_, file_path);
         AssertInfo(reader_result.ok(),
-                   "[StorageV2] Failed to create file row group reader: " +
-                       reader_result.status().ToString());
+                   "[StorageV2] Failed to create file row group reader: {}",
+                   reader_result.status().ToString());
         auto fr = reader_result.ValueOrDie();
         expected_row_groups_per_file.push_back(
             fr->file_metadata()->GetRowGroupMetadataVector().size());
@@ -379,8 +379,8 @@ TEST_P(GroupChunkTranslatorTest, TestMultipleFiles) {
         auto reader_result = milvus_storage::FileRowGroupReader::Make(
             fs_, multi_file_paths[file_idx]);
         AssertInfo(reader_result.ok(),
-                   "[StorageV2] Failed to create file row group reader: " +
-                       reader_result.status().ToString());
+                   "[StorageV2] Failed to create file row group reader: {}",
+                   reader_result.status().ToString());
         auto fr = reader_result.ValueOrDie();
         all_rg_metas.emplace_back(
             file_idx, fr->file_metadata()->GetRowGroupMetadataVector());

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1454,8 +1454,8 @@ GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
             GetReaderProperties(),
             GetArrowReaderProperties());
         AssertInfo(result.ok(),
-                   "[StorageV2] Failed to create file row group reader: " +
-                       result.status().ToString());
+                   "[StorageV2] Failed to create file row group reader: {}",
+                   result.status().ToString());
         auto reader = result.ValueOrDie();
 
         auto row_group_num =
@@ -1470,8 +1470,9 @@ GetFieldDatasFromStorageV2(std::vector<std::vector<std::string>>& remote_files,
         auto status = reader->Close();
         AssertInfo(status.ok(),
                    "[StorageV2] failed to close file reader when get arrow "
-                   "schema from file: " +
-                       column_group_file + " with error: " + status.ToString());
+                   "schema from file: {} with error: {}",
+                   column_group_file,
+                   status.ToString());
 
         // split row groups for parallel reading
         auto strategy = std::make_unique<segcore::ParallelDegreeSplitStrategy>(
@@ -1600,8 +1601,8 @@ GetFieldDatasFromManifest(
 
     auto reader_result = reader->get_record_batch_reader("");
     AssertInfo(reader_result.ok(),
-               "Failed to get record batch reader: " +
-                   reader_result.status().ToString());
+               "Failed to get record batch reader: {}",
+               reader_result.status().ToString());
 
     auto record_batch_reader = reader_result.ValueOrDie();
 
@@ -1609,8 +1610,8 @@ GetFieldDatasFromManifest(
     while (true) {
         std::shared_ptr<arrow::RecordBatch> batch;
         auto status = record_batch_reader->ReadNext(&batch);
-        AssertInfo(status.ok(),
-                   "Failed to read record batch: " + status.ToString());
+        AssertInfo(
+            status.ok(), "Failed to read record batch: {}", status.ToString());
         if (batch == nullptr) {
             break;
         }
@@ -1705,8 +1706,8 @@ GetFieldIDList(FieldId column_group_id,
         GetReaderProperties(),
         GetArrowReaderProperties());
     AssertInfo(result.ok(),
-               "[StorageV2] Failed to create file row group reader: " +
-                   result.status().ToString());
+               "[StorageV2] Failed to create file row group reader: {}",
+               result.status().ToString());
     auto file_reader = result.ValueOrDie();
     field_id_list =
         file_reader->file_metadata()->GetGroupFieldIDList().GetFieldIDList(
@@ -2053,7 +2054,8 @@ CoerceToBinary(const arrow::ArrayVector& arrays) {
             arrow::BinaryBuilder builder;
             auto status = builder.Reserve(arr->length());
             AssertInfo(status.ok(),
-                       "BinaryBuilder reserve failed: " + status.ToString());
+                       "BinaryBuilder reserve failed: {}",
+                       status.ToString());
             switch (tid) {
                 case arrow::Type::LARGE_BINARY: {
                     auto src =
@@ -2068,8 +2070,8 @@ CoerceToBinary(const arrow::ArrayVector& arrays) {
                                 v.size());
                         }
                         AssertInfo(status.ok(),
-                                   "BinaryBuilder append failed: " +
-                                       status.ToString());
+                                   "BinaryBuilder append failed: {}",
+                                   status.ToString());
                     }
                     break;
                 }
@@ -2086,8 +2088,8 @@ CoerceToBinary(const arrow::ArrayVector& arrays) {
                                 v.size());
                         }
                         AssertInfo(status.ok(),
-                                   "BinaryBuilder append failed: " +
-                                       status.ToString());
+                                   "BinaryBuilder append failed: {}",
+                                   status.ToString());
                     }
                     break;
                 }
@@ -2104,8 +2106,8 @@ CoerceToBinary(const arrow::ArrayVector& arrays) {
                                 v.size());
                         }
                         AssertInfo(status.ok(),
-                                   "BinaryBuilder append failed: " +
-                                       status.ToString());
+                                   "BinaryBuilder append failed: {}",
+                                   status.ToString());
                     }
                     break;
                 }
@@ -2122,8 +2124,8 @@ CoerceToBinary(const arrow::ArrayVector& arrays) {
                                 v.size());
                         }
                         AssertInfo(status.ok(),
-                                   "BinaryBuilder append failed: " +
-                                       status.ToString());
+                                   "BinaryBuilder append failed: {}",
+                                   status.ToString());
                     }
                     break;
                 }
@@ -2133,7 +2135,8 @@ CoerceToBinary(const arrow::ArrayVector& arrays) {
             std::shared_ptr<arrow::Array> out;
             status = builder.Finish(&out);
             AssertInfo(status.ok(),
-                       "BinaryBuilder finish failed: " + status.ToString());
+                       "BinaryBuilder finish failed: {}",
+                       status.ToString());
             result.push_back(out);
             continue;
         }
@@ -2186,7 +2189,8 @@ CoerceToList(const arrow::ArrayVector& arrays) {
         arrow::Int32Builder offset_builder;
         auto status = offset_builder.Reserve(arr->length() + 1);
         AssertInfo(status.ok(),
-                   "CoerceToList: offset reserve failed: " + status.ToString());
+                   "CoerceToList: offset reserve failed: {}",
+                   status.ToString());
         std::vector<std::shared_ptr<arrow::Array>> value_slices;
         int32_t cur = 0;
         status = offset_builder.Append(0);
@@ -2206,7 +2210,8 @@ CoerceToList(const arrow::ArrayVector& arrays) {
         std::shared_ptr<arrow::Array> offsets_arr;
         status = offset_builder.Finish(&offsets_arr);
         AssertInfo(status.ok(),
-                   "CoerceToList: offset finish failed: " + status.ToString());
+                   "CoerceToList: offset finish failed: {}",
+                   status.ToString());
 
         std::shared_ptr<arrow::Array> concat_values;
         if (value_slices.empty()) {
@@ -2215,9 +2220,9 @@ CoerceToList(const arrow::ArrayVector& arrays) {
             concat_values = *empty;
         } else {
             auto concat = arrow::Concatenate(value_slices);
-            AssertInfo(
-                concat.ok(),
-                "CoerceToList: concat failed: " + concat.status().ToString());
+            AssertInfo(concat.ok(),
+                       "CoerceToList: concat failed: {}",
+                       concat.status().ToString());
             concat_values = *concat;
         }
 
@@ -2249,14 +2254,15 @@ RebuildNullBitmap(const std::shared_ptr<arrow::Array>& array) {
     arrow::TypedBufferBuilder<bool> bb;
     auto status = bb.Reserve(array->length());
     AssertInfo(status.ok(),
-               "RebuildNullBitmap: reserve failed: " + status.ToString());
+               "RebuildNullBitmap: reserve failed: {}",
+               status.ToString());
     for (int64_t i = 0; i < array->length(); ++i) {
         bb.UnsafeAppend(!array->IsNull(i));
     }
     std::shared_ptr<arrow::Buffer> buf;
     status = bb.Finish(&buf);
-    AssertInfo(status.ok(),
-               "RebuildNullBitmap: finish failed: " + status.ToString());
+    AssertInfo(
+        status.ok(), "RebuildNullBitmap: finish failed: {}", status.ToString());
     return buf;
 }
 
@@ -2417,7 +2423,7 @@ CanonicalizeArrowVariants(const std::shared_ptr<arrow::Array>& array) {
             concat_values = *empty;
         } else {
             auto concat = arrow::Concatenate(slices);
-            AssertInfo(concat.ok(), "concat: " + concat.status().ToString());
+            AssertInfo(concat.ok(), "concat: {}", concat.status().ToString());
             concat_values = *concat;
         }
 
@@ -2487,8 +2493,8 @@ ConvertWKTStringArrayToWKBBinary(const arrow::ArrayVector& arrays) {
         };
         arrow::BinaryBuilder builder;
         auto status = builder.Reserve(arr->length());
-        AssertInfo(status.ok(),
-                   "BinaryBuilder reserve failed: " + status.ToString());
+        AssertInfo(
+            status.ok(), "BinaryBuilder reserve failed: {}", status.ToString());
         for (int64_t i = 0; i < arr->length(); ++i) {
             if (arr->IsNull(i)) {
                 status = builder.AppendNull();


### PR DESCRIPTION
issue: #49523

AssertInfo always passes its message through fmt::format, so the message has to be treated as a format string instead of a prebuilt string. One bad pattern is leaving a placeholder in the message without passing the matching argument, for example `AssertInfo(ok, "failed: {}")`. That can fail while we are trying to report the original error, so the real storage or Arrow failure gets hidden behind a formatting problem.

Another fragile pattern is building the message with `+`, like `"failed: " + status.ToString()`. That looks harmless, but the final string is still passed into fmt::format. If the dynamic error text contains `{}` or any other brace-like formatting content, fmt will try to parse it as part of the format string. Using `"failed: {}", status.ToString()` keeps the format template stable and treats the dynamic text as data.

This change cleans up the affected AssertInfo call sites in segcore and storage utility code by replacing string concatenation with explicit `{}` placeholders and arguments. It does not change control flow or error handling behavior; it only makes assertion messages safer and more predictable when reporting failures.