### PR TITLE
enhance: add named C++ thread active metrics

### DIFF
--- a/deployments/monitor/grafana/milvus-dashboard.json
+++ b/deployments/monitor/grafana/milvus-dashboard.json
@@ -14361,7 +14361,7 @@
           "datasource": {
             "uid": "${datasource}"
           },
-          "description": "Number of OS threads created.",
+          "description": "Process OS thread count and approximate active named C++ thread groups.",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -14399,12 +14399,21 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "go_threads{app_kubernetes_io_name=\"$app_name\", app_kubernetes_io_instance=~\"$instance\"}",
+              "expr": "milvus_thread_num{app_kubernetes_io_name=\"$app_name\", app_kubernetes_io_instance=~\"$instance\", namespace=\"$namespace\"}",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{pod}}",
+              "legendFormat": "os_threads {{pod}}",
               "queryType": "randomWalk",
               "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(milvus_thread_cpu_active_num_by_pool{app_kubernetes_io_name=\"$app_name\", app_kubernetes_io_instance=~\"$instance\", namespace=\"$namespace\"}) by (pod, thread_pool)",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "active {{thread_pool}} {{pod}}",
+              "queryType": "randomWalk",
+              "refId": "B"
             }
           ],
           "thresholds": [],

--- a/internal/core/src/storage/FileWriter.h
+++ b/internal/core/src/storage/FileWriter.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
 #include <algorithm>
 #include <array>
 #include <chrono>
@@ -331,8 +332,10 @@ class FileWriteWorkerPool {
             std::lock_guard<std::mutex> lock(executor_mutex_);
             old_executor = executor_;
             if (nr_worker > 0) {
-                executor_ =
-                    std::make_shared<folly::CPUThreadPoolExecutor>(nr_worker);
+                executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(
+                    nr_worker,
+                    std::make_shared<folly::NamedThreadFactory>(
+                        "MILVUS_FL_WR_"));
             } else {
                 executor_ = nullptr;
             }

--- a/internal/util/metrics/thread.go
+++ b/internal/util/metrics/thread.go
@@ -18,6 +18,10 @@ package metrics
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -36,11 +40,46 @@ type threadWatcher struct {
 	stopOnce  sync.Once
 	wg        sync.WaitGroup
 	ch        chan struct{}
+	samples   map[int32]threadSample
 }
+
+type threadSample struct {
+	group string
+	cpu   uint64
+}
+
+type threadStat struct {
+	tid   int32
+	name  string
+	state byte
+	cpu   uint64
+}
+
+var threadNameGroupRules = []struct {
+	prefix string
+	group  string
+}{
+	{prefix: "knowhere_build", group: "knowhere_build"},
+	{prefix: "knowhere_search", group: "knowhere_search"},
+	{prefix: "knowhere_fetch", group: "knowhere_fetch"},
+	{prefix: "MILVUS_FL_WR", group: "file_write"},
+	{prefix: "MILVUS_SEARCH", group: "milvus_search"},
+	{prefix: "MILVUS_LOAD", group: "milvus_load"},
+	{prefix: "HIGH_SEGC_POOL", group: "segcore_high"},
+	{prefix: "MIDD_SEGC_POOL", group: "segcore_middle"},
+	{prefix: "LOW_SEGC_POOL", group: "segcore_low"},
+	{prefix: "CGO_SQ", group: "cgo_sq"},
+	{prefix: "CGO_LOAD", group: "cgo_load"},
+	{prefix: "CGO_DYN", group: "cgo_dynamic"},
+	{prefix: "CGO_WARMUP", group: "cgo_warmup"},
+}
+
+const threadWatcherInterval = 5 * time.Second
 
 func NewThreadWatcher() *threadWatcher {
 	return &threadWatcher{
-		ch: make(chan struct{}),
+		ch:      make(chan struct{}),
+		samples: make(map[int32]threadSample),
 	}
 }
 
@@ -55,7 +94,7 @@ func (thw *threadWatcher) Start() {
 }
 
 func (thw *threadWatcher) watchThreadNum() {
-	ticker := time.NewTicker(time.Second * 30)
+	ticker := time.NewTicker(threadWatcherInterval)
 	defer ticker.Stop()
 	pid := os.Getpid()
 	p, err := process.NewProcess(int32(pid))
@@ -73,11 +112,119 @@ func (thw *threadWatcher) watchThreadNum() {
 			}
 			log.Debug("thread watcher observe thread num", zap.Int32("threadNum", threadNum))
 			metrics.ThreadNum.Set(float64(threadNum))
+			thw.updateNamedThreadCPUActiveNum()
 		case <-thw.ch:
 			log.Info("thread watcher exit")
 			return
 		}
 	}
+}
+
+func (thw *threadWatcher) updateNamedThreadCPUActiveNum() {
+	if runtime.GOOS != "linux" {
+		return
+	}
+
+	current, err := collectNamedThreadStats()
+	if err != nil {
+		log.Warn("thread watcher failed to collect named thread stats", zap.Error(err))
+		return
+	}
+
+	activeByGroup := make(map[string]int)
+	nextSamples := make(map[int32]threadSample, len(current))
+	for _, stat := range current {
+		group, ok := classifyThreadName(stat.name)
+		if !ok {
+			continue
+		}
+		nextSamples[stat.tid] = threadSample{
+			group: group,
+			cpu:   stat.cpu,
+		}
+
+		previous, existed := thw.samples[stat.tid]
+		if !existed {
+			continue
+		}
+		if previous.group == group && (stat.cpu > previous.cpu || stat.state == 'R' || stat.state == 'D') {
+			activeByGroup[group]++
+		}
+	}
+
+	for _, rule := range threadNameGroupRules {
+		metrics.ThreadCPUActiveNumByPool.WithLabelValues(rule.group).Set(float64(activeByGroup[rule.group]))
+	}
+	thw.samples = nextSamples
+}
+
+func collectNamedThreadStats() ([]threadStat, error) {
+	taskDir := "/proc/self/task"
+	entries, err := os.ReadDir(taskDir)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := make([]threadStat, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		tid64, err := strconv.ParseInt(entry.Name(), 10, 32)
+		if err != nil {
+			continue
+		}
+		tid := int32(tid64)
+		nameBytes, err := os.ReadFile(filepath.Join(taskDir, entry.Name(), "comm"))
+		if err != nil {
+			continue
+		}
+		statBytes, err := os.ReadFile(filepath.Join(taskDir, entry.Name(), "stat"))
+		if err != nil {
+			continue
+		}
+		state, cpu, err := parseThreadStat(string(statBytes))
+		if err != nil {
+			continue
+		}
+		stats = append(stats, threadStat{
+			tid:   tid,
+			name:  strings.TrimSpace(string(nameBytes)),
+			state: state,
+			cpu:   cpu,
+		})
+	}
+	return stats, nil
+}
+
+func parseThreadStat(stat string) (byte, uint64, error) {
+	endComm := strings.LastIndexByte(stat, ')')
+	if endComm < 0 || endComm+2 >= len(stat) {
+		return 0, 0, strconv.ErrSyntax
+	}
+
+	fields := strings.Fields(stat[endComm+2:])
+	if len(fields) <= 12 || len(fields[0]) == 0 {
+		return 0, 0, strconv.ErrSyntax
+	}
+	utime, err := strconv.ParseUint(fields[11], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	stime, err := strconv.ParseUint(fields[12], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	return fields[0][0], utime + stime, nil
+}
+
+func classifyThreadName(name string) (string, bool) {
+	for _, rule := range threadNameGroupRules {
+		if strings.HasPrefix(name, rule.prefix) {
+			return rule.group, true
+		}
+	}
+	return "", false
 }
 
 func (thw *threadWatcher) Stop() {

--- a/internal/util/metrics/thread_test.go
+++ b/internal/util/metrics/thread_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestThreadWatcher(t *testing.T) {
@@ -36,6 +36,30 @@ func TestThreadWatcher(t *testing.T) {
 	select {
 	case <-ch:
 	case <-time.After(time.Second * 5):
-		assert.FailNow(t, "watcher failed to close after 5 seconds")
+		require.FailNow(t, "watcher failed to close after 5 seconds")
 	}
+}
+
+func TestClassifyThreadName(t *testing.T) {
+	group, ok := classifyThreadName("knowhere_search")
+	require.True(t, ok)
+	require.Equal(t, "knowhere_search", group)
+
+	group, ok = classifyThreadName("MILVUS_FL_WR_0")
+	require.True(t, ok)
+	require.Equal(t, "file_write", group)
+
+	group, ok = classifyThreadName("knowhere_fetch_")
+	require.True(t, ok)
+	require.Equal(t, "knowhere_fetch", group)
+
+	_, ok = classifyThreadName("grpc_global_tim")
+	require.False(t, ok)
+}
+
+func TestParseThreadStat(t *testing.T) {
+	state, cpu, err := parseThreadStat("123 (knowhere search) R 1 2 3 4 5 6 7 8 9 10 34 56 0 0 0")
+	require.NoError(t, err)
+	require.Equal(t, byte('R'), state)
+	require.Equal(t, uint64(90), cpu)
 }

--- a/pkg/metrics/info_metrics.go
+++ b/pkg/metrics/info_metrics.go
@@ -43,6 +43,17 @@ var (
 			Help:      "the actual thread number of milvus process",
 		},
 	)
+
+	ThreadCPUActiveNumByPool = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Name:      "thread_cpu_active_num_by_pool",
+			Help:      "the approximate active thread number of milvus process by named OS thread pool CPU time delta",
+		},
+		[]string{
+			"thread_pool",
+		},
+	)
 )
 
 // RegisterMQType registers the type of mq

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -215,5 +215,6 @@ func Register(r prometheus.Registerer) {
 	r.MustRegister(BuildInfo)
 	r.MustRegister(RuntimeInfo)
 	r.MustRegister(ThreadNum)
+	r.MustRegister(ThreadCPUActiveNumByPool)
 	metricRegisterer = r
 }


### PR DESCRIPTION
This PR adds lightweight active thread observability for named C++ thread pools.

- name FileWriteWorkerPool threads with the `MILVUS_FL_WR_` prefix
- sample named OS threads every 5 seconds and export `milvus_thread_cpu_active_num_by_pool`
- classify active named threads by CPU-time delta or runnable/uninterruptible state
- show active named C++ thread pools in the Runtime / OS Threads Grafana panel by `pod` and `thread_pool`
- skip `/proc/self/task` collection on non-Linux platforms

issue: #50066

Performance note for the named thread active sampler:

I measured the cost of one sampling round by creating 128 / 512 / 1024 OS threads and repeatedly running the same `/proc/self/task` based collection path. Each benchmark was run in a separate `go test` process for 10 rounds to avoid OS-thread reuse affecting the result.

- Idle: about 2.1 ms for 128 threads, 7.9 ms for 512 threads, and 16.0 ms for 1024 threads per sampling round.
- Under 64 concurrent search workload: about 5.1 ms for 128 threads, 18.3 ms for 512 threads, and 34.1 ms for 1024 threads per sampling round.

The sampler runs every 5 seconds, so even the 1024-thread case under search load is about 34 ms / 5000 ms, or below 0.7% of one CPU core. The current standalone test process had around 116 OS threads, closer to the 128-thread case. Based on this, the expected runtime overhead is low.

