### PR TITLE
fix: cherrypick nullable vector fixes to 3.0

### DIFF
--- a/internal/core/src/common/FieldData.cpp
+++ b/internal/core/src/common/FieldData.cpp
@@ -128,7 +128,9 @@ FieldDataImpl<Type, is_type_entire_row>::FillFieldData(
     if (element_count == 0) {
         return;
     }
-    null_count_ = array->null_count();
+    if (!IsVectorDataType(data_type_)) {
+        null_count_ = array->null_count();
+    }
     switch (data_type_) {
         case DataType::BOOL: {
             AssertInfo(array->type()->id() == arrow::Type::type::BOOL,
@@ -687,6 +689,9 @@ FieldDataVectorImpl<Type, is_type_entire_row>::FillFieldData(
             this->valid_data_.data(),
             this->length_,
             total_element_count);
+    } else {
+        bitset::detail::ElementWiseBitsetPolicy<uint8_t>::op_fill(
+            this->valid_data_.data(), this->length_, total_element_count, true);
     }
 
     // update logical to physical offset mapping
@@ -703,7 +708,7 @@ FieldDataVectorImpl<Type, is_type_entire_row>::FillFieldData(
         this->valid_count_ += valid_count;
     }
 
-    this->null_count_ = total_element_count - valid_count;
+    this->null_count_ += total_element_count - valid_count;
     this->length_ += total_element_count;
 }
 

--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -27,9 +27,11 @@
 #include <boost/dynamic_bitset.hpp>
 #include <NamedType/named_type.hpp>
 
+#include "common/BitsetView.h"
 #include "common/FieldMeta.h"
 #include "common/ArrayOffsets.h"
 #include "common/OffsetMapping.h"
+#include "common/Types.h"
 #include "pb/schema.pb.h"
 #include "knowhere/index/index_node.h"
 
@@ -277,6 +279,14 @@ struct SearchResult {
         this->vector_iterators_ = vector_iterators;
     }
 
+    BitsetView
+    PinBitset(TargetBitmap&& bitset) {
+        auto pinned = std::make_unique<TargetBitmap>(std::move(bitset));
+        auto view = BitsetView(*pinned);
+        pinned_bitsets_.emplace_back(std::move(pinned));
+        return view;
+    }
+
  public:
     int64_t total_nq_;
     int64_t unity_topK_;
@@ -322,6 +332,7 @@ struct SearchResult {
         element_iterators_;
     std::shared_ptr<const IArrayOffsets> array_offsets_{nullptr};
     std::vector<std::unique_ptr<uint8_t[]>> chunk_buffers_{};
+    std::vector<TargetBitmapPtr> pinned_bitsets_{};
 
     bool
     HasIterators() const {

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -41,6 +41,7 @@
 #include "glog/logging.h"
 #include "index/Meta.h"
 #include "index/Utils.h"
+#include "index/VectorIndexValidDataUtils.h"
 #include "knowhere/binaryset.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/dataset.h"
@@ -62,6 +63,69 @@ namespace milvus::index {
 #define kSearchListMaxValue2 65535  // used for topk > 20
 #define kPrepareDim 100
 #define kPrepareRows 1
+
+namespace {
+
+struct DiskValidData {
+    bool found = false;
+    size_t total_count = 0;
+    size_t valid_count = 0;
+    std::vector<uint8_t> bitmap;
+};
+
+template <typename LocalChunkManagerPtr>
+DiskValidData
+ReadDiskValidData(const LocalChunkManagerPtr& local_chunk_manager,
+                  const std::string& valid_data_path) {
+    DiskValidData valid_data;
+    if (!local_chunk_manager->Exist(valid_data_path)) {
+        return valid_data;
+    }
+
+    valid_data.found = true;
+    auto file_size = local_chunk_manager->Size(valid_data_path);
+    AssertInfo(file_size >= sizeof(uint64_t),
+               "nullable vector disk valid_data file is too small");
+    uint64_t wire_count = 0;
+    local_chunk_manager->Read(
+        valid_data_path, 0, &wire_count, sizeof(uint64_t));
+    valid_data.total_count = FromValidDataCount(wire_count);
+    valid_data.bitmap.resize(GetValidDataBitmapSize(valid_data.total_count));
+    AssertInfo(file_size >= sizeof(uint64_t) + valid_data.bitmap.size(),
+               "nullable vector disk valid_data bitmap file is too small");
+    if (!valid_data.bitmap.empty()) {
+        local_chunk_manager->Read(valid_data_path,
+                                  sizeof(uint64_t),
+                                  valid_data.bitmap.data(),
+                                  valid_data.bitmap.size());
+    }
+    valid_data.valid_count =
+        CountValidDataBitmap(valid_data.total_count, valid_data.bitmap.data());
+    return valid_data;
+}
+
+template <typename LocalChunkManagerPtr>
+void
+WriteDiskValidData(const LocalChunkManagerPtr& local_chunk_manager,
+                   const std::string& valid_data_path,
+                   const OffsetMapping& offset_mapping) {
+    auto total_count = static_cast<size_t>(offset_mapping.GetTotalCount());
+    auto wire_count = ToValidDataCount(total_count);
+    auto packed_data = PackValidDataBitmap(offset_mapping);
+    if (!local_chunk_manager->Exist(valid_data_path)) {
+        local_chunk_manager->CreateFile(valid_data_path);
+    }
+    local_chunk_manager->Write(
+        valid_data_path, 0, &wire_count, sizeof(uint64_t));
+    if (!packed_data.empty()) {
+        local_chunk_manager->Write(valid_data_path,
+                                   sizeof(uint64_t),
+                                   packed_data.data(),
+                                   packed_data.size());
+    }
+}
+
+}  // namespace
 
 template <typename T>
 VectorDiskAnnIndex<T>::VectorDiskAnnIndex(
@@ -138,52 +202,55 @@ VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
         read_file_span->End();
     }
 
-    // start engine load index span
-    auto span_load_engine =
-        milvus::tracer::StartSpan("SegCoreEngineLoadDiskIndex", &ctx);
-    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>
-        nostd_span_load_engine(span_load_engine);
-    auto engine_scope =
-        opentelemetry::trace::Tracer::WithActiveSpan(nostd_span_load_engine);
-    auto stat = index_.Deserialize(knowhere::BinarySet(), load_config);
-    if (stat != knowhere::Status::success)
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to Deserialize index, {}",
-                  KnowhereStatusString(stat));
-    span_load_engine->End();
-
     auto local_chunk_manager =
         storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
 
     auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
-    if (local_chunk_manager->Exist(valid_data_path)) {
-        size_t count;
-        local_chunk_manager->Read(valid_data_path, 0, &count, sizeof(size_t));
-        size_t byte_size = (count + 7) / 8;
-        std::vector<uint8_t> valid_bitmap(byte_size);
-        local_chunk_manager->Read(
-            valid_data_path, sizeof(size_t), valid_bitmap.data(), byte_size);
-        // Convert bitmap to bool array
-        std::unique_ptr<bool[]> valid_data(new bool[count]);
-        for (size_t i = 0; i < count; ++i) {
-            valid_data[i] = (valid_bitmap[i / 8] >> (i % 8)) & 1;
+    auto disk_valid_data =
+        ReadDiskValidData(local_chunk_manager, valid_data_path);
+    bool all_null_nullable = disk_valid_data.found &&
+                             disk_valid_data.total_count > 0 &&
+                             disk_valid_data.valid_count == 0;
+    if (!all_null_nullable) {
+        // start engine load index span
+        auto span_load_engine =
+            milvus::tracer::StartSpan("SegCoreEngineLoadDiskIndex", &ctx);
+        opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>
+            nostd_span_load_engine(span_load_engine);
+        auto engine_scope = opentelemetry::trace::Tracer::WithActiveSpan(
+            nostd_span_load_engine);
+        auto stat = index_.Deserialize(knowhere::BinarySet(), load_config);
+        if (stat != knowhere::Status::success)
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to Deserialize index, {}",
+                      KnowhereStatusString(stat));
+        span_load_engine->End();
+        SetDim(index_.Dim());
+    } else {
+        auto dim = GetValueFromConfig<int64_t>(load_config, DIM_KEY);
+        if (dim.has_value()) {
+            SetDim(dim.value());
         }
-        BuildValidData(valid_data.get(), count);
     }
 
-    SetDim(index_.Dim());
+    if (disk_valid_data.found) {
+        BuildValidDataFromBitmap(
+            this, disk_valid_data.total_count, disk_valid_data.bitmap.data());
+    }
 }
 
 template <typename T>
 IndexStatsPtr
 VectorDiskAnnIndex<T>::Upload(const Config& config) {
     BinarySet ret;
-    auto stat = index_.Serialize(ret);
-    if (stat != knowhere::Status::success) {
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to serialize index, {}",
-                  KnowhereStatusString(stat));
+    if (!IsAllNullNullable(offset_mapping_)) {
+        auto stat = index_.Serialize(ret);
+        if (stat != knowhere::Status::success) {
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to serialize index, {}",
+                      KnowhereStatusString(stat));
+        }
     }
     auto remote_paths_to_size = file_manager_->GetRemotePathsToFileSize();
     return IndexStats::NewFromSizeMap(file_manager_->GetAddedTotalFileSize(),
@@ -225,6 +292,25 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
     auto local_data_path =
         file_manager_->CacheRawDataToDisk<T>(config_with_emb_list);
     build_config[DISK_ANN_RAW_DATA_PATH] = local_data_path;
+
+    auto disk_valid_data =
+        ReadDiskValidData(local_chunk_manager, valid_data_path);
+    if (disk_valid_data.found) {
+        BuildValidDataFromBitmap(
+            this, disk_valid_data.total_count, disk_valid_data.bitmap.data());
+        if (disk_valid_data.valid_count == 0) {
+            auto dim = GetValueFromConfig<int64_t>(build_config, DIM_KEY);
+            if (dim.has_value()) {
+                SetDim(dim.value());
+            }
+            file_manager_->AddFile(valid_data_path);
+            local_chunk_manager->RemoveDir(storage::GenFieldRawDataPathPrefix(
+                local_chunk_manager, segment_id, field_id));
+            LOG_INFO("build all-null nullable disk index done, build_id: {}",
+                     config.value("build_id", "unknown"));
+            return;
+        }
+    }
 
     // For VECTOR_ARRAY, verify offsets file exists and pass its path to build_config
     if (is_embedding_list) {
@@ -303,6 +389,19 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
     build_config[DISK_ANN_PREFIX_PATH] = local_index_path_prefix;
 
+    if (HasValidData() && GetValidCount() == 0 &&
+        offset_mapping_.GetTotalCount() > 0) {
+        auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
+        WriteDiskValidData(
+            local_chunk_manager, valid_data_path, offset_mapping_);
+        file_manager_->AddFile(valid_data_path);
+        auto dim = GetValueFromConfig<int64_t>(build_config, DIM_KEY);
+        if (dim.has_value()) {
+            SetDim(dim.value());
+        }
+        return;
+    }
+
     if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
         auto num_threads = GetValueFromConfig<std::string>(
             build_config, DISK_ANN_BUILD_THREAD_NUM);
@@ -380,17 +479,8 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
 
     if (HasValidData()) {
         auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
-        size_t count = offset_mapping_.GetTotalCount();
-        local_chunk_manager->Write(valid_data_path, 0, &count, sizeof(size_t));
-        size_t byte_size = (count + 7) / 8;
-        std::vector<uint8_t> packed_data(byte_size, 0);
-        for (size_t i = 0; i < count; ++i) {
-            if (offset_mapping_.IsValid(i)) {
-                packed_data[i / 8] |= (1 << (i % 8));
-            }
-        }
-        local_chunk_manager->Write(
-            valid_data_path, sizeof(size_t), packed_data.data(), byte_size);
+        WriteDiskValidData(
+            local_chunk_manager, valid_data_path, offset_mapping_);
         file_manager_->AddFile(valid_data_path);
     }
 

--- a/internal/core/src/index/VectorIndexValidDataUtils.h
+++ b/internal/core/src/index/VectorIndexValidDataUtils.h
@@ -1,0 +1,156 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "common/OffsetMapping.h"
+#include "index/VectorIndex.h"
+
+namespace milvus::index {
+
+inline bool
+IsValidDataBinary(const std::string& name) {
+    return name == VALID_DATA_COUNT_KEY || name == VALID_DATA_KEY;
+}
+
+inline bool
+ContainsOnlyValidData(const BinarySet& binary_set) {
+    if (!binary_set.Contains(VALID_DATA_COUNT_KEY) ||
+        !binary_set.Contains(VALID_DATA_KEY)) {
+        return false;
+    }
+    for (const auto& [name, _] : binary_set.binary_map_) {
+        if (!IsValidDataBinary(name)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+inline bool
+IsAllNullNullable(const OffsetMapping& offset_mapping) {
+    return offset_mapping.IsEnabled() && offset_mapping.GetTotalCount() > 0 &&
+           offset_mapping.GetValidCount() == 0;
+}
+
+inline size_t
+GetValidDataBitmapSize(size_t count) {
+    return (count + 7) / 8;
+}
+
+inline uint64_t
+ToValidDataCount(size_t count) {
+    return static_cast<uint64_t>(count);
+}
+
+inline size_t
+FromValidDataCount(uint64_t count) {
+    AssertInfo(count <= std::numeric_limits<size_t>::max(),
+               "nullable vector valid_data count is too large");
+    return static_cast<size_t>(count);
+}
+
+inline size_t
+CountValidDataBitmap(size_t count, const uint8_t* bitmap) {
+    size_t valid_count = 0;
+    for (size_t i = 0; i < count; ++i) {
+        if ((bitmap[i / 8] >> (i % 8)) & 1) {
+            ++valid_count;
+        }
+    }
+    return valid_count;
+}
+
+inline std::vector<uint8_t>
+PackValidDataBitmap(const OffsetMapping& offset_mapping) {
+    auto count = static_cast<size_t>(offset_mapping.GetTotalCount());
+    std::vector<uint8_t> data(GetValidDataBitmapSize(count), 0);
+    for (size_t i = 0; i < count; ++i) {
+        if (offset_mapping.IsValid(i)) {
+            data[i / 8] |= (1 << (i % 8));
+        }
+    }
+    return data;
+}
+
+inline void
+BuildValidDataFromBitmap(VectorIndex* vector_index,
+                         size_t count,
+                         const uint8_t* bitmap) {
+    std::unique_ptr<bool[]> valid_data(new bool[count]);
+    for (size_t i = 0; i < count; ++i) {
+        valid_data[i] = (bitmap[i / 8] >> (i % 8)) & 1;
+    }
+    vector_index->BuildValidData(valid_data.get(), count);
+}
+
+inline void
+AppendValidDataToBinarySet(const OffsetMapping& offset_mapping,
+                           BinarySet& binary_set) {
+    if (!offset_mapping.IsEnabled()) {
+        return;
+    }
+
+    auto count = static_cast<size_t>(offset_mapping.GetTotalCount());
+    auto wire_count = ToValidDataCount(count);
+    std::shared_ptr<uint8_t[]> count_buf(new uint8_t[sizeof(uint64_t)]);
+    std::memcpy(count_buf.get(), &wire_count, sizeof(uint64_t));
+    binary_set.Append(VALID_DATA_COUNT_KEY, count_buf, sizeof(uint64_t));
+
+    auto packed_data = PackValidDataBitmap(offset_mapping);
+    std::shared_ptr<uint8_t[]> data(new uint8_t[packed_data.size()]);
+    if (!packed_data.empty()) {
+        std::memcpy(data.get(), packed_data.data(), packed_data.size());
+    }
+    binary_set.Append(VALID_DATA_KEY, data, packed_data.size());
+}
+
+inline bool
+LoadValidDataFromBinarySet(const BinarySet& binary_set,
+                           VectorIndex* vector_index) {
+    bool has_count = binary_set.Contains(VALID_DATA_COUNT_KEY);
+    bool has_data = binary_set.Contains(VALID_DATA_KEY);
+    if (!has_count && !has_data) {
+        return false;
+    }
+    AssertInfo(has_count && has_data,
+               "nullable vector index valid_data files are incomplete");
+
+    auto count_ptr = binary_set.GetByName(VALID_DATA_COUNT_KEY);
+    AssertInfo(count_ptr != nullptr && count_ptr->size == sizeof(uint64_t),
+               "nullable vector index valid_data count file is invalid");
+    uint64_t wire_count = 0;
+    std::memcpy(&wire_count, count_ptr->data.get(), sizeof(uint64_t));
+    auto count = FromValidDataCount(wire_count);
+
+    auto data_ptr = binary_set.GetByName(VALID_DATA_KEY);
+    AssertInfo(
+        data_ptr != nullptr && data_ptr->size >= GetValidDataBitmapSize(count),
+        "nullable vector index valid_data bitmap file is invalid");
+    BuildValidDataFromBitmap(vector_index, count, data_ptr->data.get());
+    return true;
+}
+
+}  // namespace milvus::index

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -58,6 +58,7 @@
 #include "glog/logging.h"
 #include "index/Meta.h"
 #include "index/Utils.h"
+#include "index/VectorIndexValidDataUtils.h"
 #include "knowhere/binaryset.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/comp/time_recorder.h"
@@ -166,32 +167,16 @@ template <typename T>
 BinarySet
 VectorMemIndex<T>::Serialize(const Config& config) {
     knowhere::BinarySet ret;
-    auto stat = index_.Serialize(ret);
-    if (stat != knowhere::Status::success)
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to serialize index: {}",
-                  KnowhereStatusString(stat));
-
-    // Serialize valid_data from offset_mapping if enabled
-    if (offset_mapping_.IsEnabled()) {
-        auto total_count = offset_mapping_.GetTotalCount();
-
-        std::shared_ptr<uint8_t[]> count_buf(new uint8_t[sizeof(size_t)]);
-        size_t count = static_cast<size_t>(total_count);
-        std::memcpy(count_buf.get(), &count, sizeof(size_t));
-        ret.Append(VALID_DATA_COUNT_KEY, count_buf, sizeof(size_t));
-
-        size_t byte_size = (count + 7) / 8;
-        std::shared_ptr<uint8_t[]> data(new uint8_t[byte_size]);
-        std::memset(data.get(), 0, byte_size);
-        for (size_t i = 0; i < count; ++i) {
-            if (offset_mapping_.IsValid(i)) {
-                data[i / 8] |= (1 << (i % 8));
-            }
-        }
-        ret.Append(VALID_DATA_KEY, data, byte_size);
+    bool all_null_nullable = IsAllNullNullable(offset_mapping_);
+    if (!all_null_nullable) {
+        auto stat = index_.Serialize(ret);
+        if (stat != knowhere::Status::success)
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to serialize index: {}",
+                      KnowhereStatusString(stat));
     }
 
+    AppendValidDataToBinarySet(offset_mapping_, ret);
     Disassemble(ret);
 
     return ret;
@@ -201,31 +186,20 @@ template <typename T>
 void
 VectorMemIndex<T>::LoadWithoutAssemble(const BinarySet& binary_set,
                                        const Config& config) {
-    auto stat = index_.Deserialize(binary_set, config);
-    if (stat != knowhere::Status::success)
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to Deserialize index: {}",
-                  KnowhereStatusString(stat));
-
-    // Deserialize valid_data bitmap and rebuild offset_mapping
-    if (binary_set.Contains(VALID_DATA_COUNT_KEY) &&
-        binary_set.Contains(VALID_DATA_KEY)) {
-        knowhere::BinaryPtr ptr;
-        ptr = binary_set.GetByName(VALID_DATA_COUNT_KEY);
-        size_t count;
-        std::memcpy(&count, ptr->data.get(), sizeof(size_t));
-
-        ptr = binary_set.GetByName(VALID_DATA_KEY);
-        // Convert bitmap to bool array
-        std::unique_ptr<bool[]> valid_data(new bool[count]);
-        auto bitmap = ptr->data.get();
-        for (size_t i = 0; i < count; ++i) {
-            valid_data[i] = (bitmap[i / 8] >> (i % 8)) & 1;
+    if (ContainsOnlyValidData(binary_set)) {
+        if (config.contains(DIM_KEY)) {
+            SetDim(GetDimFromConfig(config));
         }
-        BuildValidData(valid_data.get(), count);
+    } else {
+        auto stat = index_.Deserialize(binary_set, config);
+        if (stat != knowhere::Status::success)
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to Deserialize index: {}",
+                      KnowhereStatusString(stat));
+        SetDim(index_.Dim());
     }
 
-    SetDim(index_.Dim());
+    LoadValidDataFromBinarySet(binary_set, this);
 }
 
 template <typename T>
@@ -451,6 +425,11 @@ VectorMemIndex<T>::Build(const Config& config) {
                 total_size += data->Size();
             }
         }
+        if (nullable && total_valid_rows == 0) {
+            SetDim(dim);
+            BuildValidData(valid_data.get(), total_num_rows);
+            return;
+        }
         auto buf = std::shared_ptr<uint8_t[]>(new uint8_t[total_size]);
 
         size_t lim_offset = 0;
@@ -522,6 +501,11 @@ VectorMemIndex<T>::Build(const Config& config) {
                 std::dynamic_pointer_cast<FieldData<SparseFloatVector>>(
                     field_data)
                     ->Dim());
+        }
+        if (nullable && total_valid_rows == 0) {
+            SetDim(dim);
+            BuildValidData(valid_data.get(), total_num_rows);
+            return;
         }
         std::vector<knowhere::sparse::SparseRow<SparseValueType>> vec(
             total_valid_rows);
@@ -775,9 +759,27 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
     std::chrono::duration<double> write_disk_duration_sum;
     std::unique_ptr<storage::DataCodec> valid_data_count_codec;
     std::unique_ptr<storage::DataCodec> valid_data_codec;
+    bool wrote_index_data = false;
     // load files in two parts:
-    // 1. EMB_LIST_META: Written separately to embedding_list_meta_writer_ptr (if embedding list type)
-    // 2. All other binaries: Merged and written to file_writer, forming a unified index file for knowhere
+    // 1. Emb-list sidecar files: written separately so knowhere can mmap them.
+    // 2. All other binaries: Merged and written to file_writer, forming a unified index file for knowhere.
+    auto WriteIndexData = [&](const std::string& prefix,
+                              std::unique_ptr<storage::DataCodec>& index_data) {
+        if (prefix == knowhere::meta::EMB_LIST_META &&
+            embedding_list_meta_writer_ptr) {
+            embedding_list_meta_writer_ptr->Write(index_data->PayloadData(),
+                                                  index_data->PayloadSize());
+        } else if (prefix == VALID_DATA_COUNT_KEY) {
+            valid_data_count_codec = std::move(index_data);
+        } else if (prefix == VALID_DATA_KEY) {
+            valid_data_codec = std::move(index_data);
+        } else {
+            file_writer.Write(index_data->PayloadData(),
+                              index_data->PayloadSize());
+            wrote_index_data = true;
+        }
+    };
+
     if (!slice_meta_filepath
              .empty()) {  // load with the slice meta info, then we can load batch by batch
         std::string index_file_prefix = slice_meta_filepath.substr(
@@ -807,18 +809,7 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
                                "lost index slice data");
                     auto&& data = batch_data[file_name];
                     auto start_write_file = std::chrono::system_clock::now();
-                    if (prefix == knowhere::meta::EMB_LIST_META &&
-                        embedding_list_meta_writer_ptr) {
-                        embedding_list_meta_writer_ptr->Write(
-                            data->PayloadData(), data->PayloadSize());
-                    } else if (prefix == VALID_DATA_COUNT_KEY) {
-                        valid_data_count_codec = std::move(data);
-                    } else if (prefix == VALID_DATA_KEY) {
-                        valid_data_codec = std::move(data);
-                    } else {
-                        file_writer.Write(data->PayloadData(),
-                                          data->PayloadSize());
-                    }
+                    WriteIndexData(prefix, data);
                     write_disk_duration_sum +=
                         (std::chrono::system_clock::now() - start_write_file);
                 }
@@ -852,18 +843,7 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
         //2. write data into files
         auto start_write_file = std::chrono::system_clock::now();
         for (auto& [prefix, index_data] : result) {
-            if (prefix == knowhere::meta::EMB_LIST_META &&
-                embedding_list_meta_writer_ptr) {
-                embedding_list_meta_writer_ptr->Write(
-                    index_data->PayloadData(), index_data->PayloadSize());
-            } else if (prefix == VALID_DATA_COUNT_KEY) {
-                valid_data_count_codec = std::move(index_data);
-            } else if (prefix == VALID_DATA_KEY) {
-                valid_data_codec = std::move(index_data);
-            } else {
-                file_writer.Write(index_data->PayloadData(),
-                                  index_data->PayloadSize());
-            }
+            WriteIndexData(prefix, index_data);
         }
         write_disk_duration_sum +=
             (std::chrono::system_clock::now() - start_write_file);
@@ -880,7 +860,6 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
         embedding_list_meta_writer_ptr->Finish();
     }
 
-    LOG_INFO("load index into Knowhere...");
     auto conf = config;
     conf.erase(MMAP_FILE_PATH);
     conf[ENABLE_MMAP] = true;
@@ -888,20 +867,30 @@ void VectorMemIndex<T>::LoadFromFile(const Config& config) {
         conf["emb_list_meta_file_path"] = embedding_list_meta_path.value();
     }
     auto start_deserialize = std::chrono::system_clock::now();
-    auto stat = index_.DeserializeFromFile(local_filepath.value(), conf);
-    auto deserialize_duration =
-        std::chrono::system_clock::now() - start_deserialize;
-    if (stat != knowhere::Status::success) {
-        ThrowInfo(ErrorCode::UnexpectedError,
-                  "failed to Deserialize index: {}",
-                  KnowhereStatusString(stat));
+    std::chrono::duration<double> deserialize_duration{};
+    if (wrote_index_data) {
+        LOG_INFO("load index into Knowhere...");
+        auto stat = index_.DeserializeFromFile(local_filepath.value(), conf);
+        deserialize_duration =
+            std::chrono::system_clock::now() - start_deserialize;
+        if (stat != knowhere::Status::success) {
+            ThrowInfo(ErrorCode::UnexpectedError,
+                      "failed to Deserialize index: {}",
+                      KnowhereStatusString(stat));
+        }
+        this->SetDim(index_.Dim());
+    } else {
+        LOG_INFO("load all-null nullable vector index valid data only...");
+        AssertInfo(valid_data_count_codec && valid_data_codec,
+                   "nullable vector index valid_data files are incomplete");
+        if (conf.contains(DIM_KEY)) {
+            this->SetDim(GetDimFromConfig(conf));
+        }
     }
     milvus::monitor::internal_storage_deserialize_duration.Observe(
         std::chrono::duration_cast<std::chrono::milliseconds>(
             deserialize_duration)
             .count());
-
-    this->SetDim(index_.Dim());
 
     // Restore valid_data for nullable vector support
     if (valid_data_count_codec && valid_data_codec) {

--- a/internal/core/src/indexbuilder/VecIndexCreator.cpp
+++ b/internal/core/src/indexbuilder/VecIndexCreator.cpp
@@ -70,12 +70,19 @@ void
 VecIndexCreator::Build(const milvus::DatasetPtr& dataset,
                        const bool* valid_data,
                        const int64_t valid_data_len) {
-    index_->BuildWithDataset(dataset, config_);
     if (valid_data && valid_data_len > 0) {
         auto vec_index = dynamic_cast<index::VectorIndex*>(index_.get());
         AssertInfo(vec_index != nullptr, "failed to cast index to VectorIndex");
+        if (dataset->GetRows() == 0) {
+            vec_index->SetDim(dataset->GetDim());
+            vec_index->BuildValidData(valid_data, valid_data_len);
+            return;
+        }
+        index_->BuildWithDataset(dataset, config_);
         vec_index->BuildValidData(valid_data, valid_data_len);
+        return;
     }
+    index_->BuildWithDataset(dataset, config_);
 }
 
 void

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -186,7 +186,6 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
         BitsetView search_bitset = bitset;
         if (offset_mapping.IsEnabled()) {
             transformed_bitset = TransformBitset(bitset, offset_mapping);
-            search_bitset = BitsetView(transformed_bitset);
         }
 
         auto active_count = offset_mapping.IsEnabled()
@@ -204,6 +203,10 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             search_result.unity_topK_ = info.topk_;
             return;
         }
+        if (offset_mapping.IsEnabled()) {
+            search_bitset =
+                search_result.PinBitset(std::move(transformed_bitset));
+        }
 
         // Element-level search (embedding-search-embedding): knowhere sees
         // a scalar vector type and the per-chunk size must be measured in
@@ -216,6 +219,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             info.array_offsets_ != nullptr;
         const auto iter_data_type =
             is_element_level_search ? element_type : data_type;
+        const bool use_vector_iterator = milvus::exec::UseVectorIterator(info);
 
         if (info.iterator_v2_info_.has_value()) {
             AssertInfo(iter_data_type != DataType::VECTOR_ARRAY,
@@ -304,7 +308,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 }
             }
 
-            if (milvus::exec::UseVectorIterator(info)) {
+            if (use_vector_iterator) {
                 AssertInfo(iter_data_type != DataType::VECTOR_ARRAY,
                            "vector array(embedding list) is not supported for "
                            "vector iterator");
@@ -333,7 +337,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 final_qr.merge(sub_qr);
             }
         }
-        if (milvus::exec::UseVectorIterator(info)) {
+        if (use_vector_iterator) {
             bool larger_is_closer = PositivelyRelated(info.metric_type_);
             // Element-level search skips row-level mapping (element IDs are
             // not row-aligned); see ChunkMergeIterator ctor.

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -184,7 +184,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
 
         TargetBitmap transformed_bitset;
         BitsetView search_bitset = bitset;
-        if (offset_mapping.IsEnabled()) {
+        if (offset_mapping.IsEnabled() && !bitset.empty()) {
             transformed_bitset = TransformBitset(bitset, offset_mapping);
         }
 
@@ -203,7 +203,7 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
             search_result.unity_topK_ = info.topk_;
             return;
         }
-        if (offset_mapping.IsEnabled()) {
+        if (offset_mapping.IsEnabled() && !bitset.empty()) {
             search_bitset =
                 search_result.PinBitset(std::move(transformed_bitset));
         }

--- a/internal/core/src/query/SearchOnIndex.cpp
+++ b/internal/core/src/query/SearchOnIndex.cpp
@@ -50,7 +50,6 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
     BitsetView search_bitset = bitset;
     if (offset_mapping.IsEnabled()) {
         transformed_bitset = TransformBitset(bitset, offset_mapping);
-        search_bitset = BitsetView(transformed_bitset);
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
             auto total_num = num_queries * search_conf.topk_;
@@ -60,6 +59,7 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
             search_result.unity_topK_ = search_conf.topk_;
             return;
         }
+        search_bitset = search_result.PinBitset(std::move(transformed_bitset));
     }
 
     if (milvus::exec::PrepareVectorIteratorsFromIndex(search_conf,

--- a/internal/core/src/query/SearchOnIndex.cpp
+++ b/internal/core/src/query/SearchOnIndex.cpp
@@ -49,7 +49,6 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
     TargetBitmap transformed_bitset;
     BitsetView search_bitset = bitset;
     if (offset_mapping.IsEnabled()) {
-        transformed_bitset = TransformBitset(bitset, offset_mapping);
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
             auto total_num = num_queries * search_conf.topk_;
@@ -59,7 +58,11 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
             search_result.unity_topK_ = search_conf.topk_;
             return;
         }
-        search_bitset = search_result.PinBitset(std::move(transformed_bitset));
+        if (!bitset.empty()) {
+            transformed_bitset = TransformBitset(bitset, offset_mapping);
+            search_bitset =
+                search_result.PinBitset(std::move(transformed_bitset));
+        }
     }
 
     if (milvus::exec::PrepareVectorIteratorsFromIndex(search_conf,

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -100,7 +100,6 @@ SearchOnSealedIndex(const Schema& schema,
     BitsetView search_bitset = bitset;
     if (offset_mapping.IsEnabled()) {
         transformed_bitset = TransformBitset(bitset, offset_mapping);
-        search_bitset = BitsetView(transformed_bitset);
         if (offset_mapping.GetValidCount() == 0) {
             auto total_num = num_queries * topK;
             search_result.seg_offsets_.resize(total_num, INVALID_SEG_OFFSET);
@@ -109,6 +108,7 @@ SearchOnSealedIndex(const Schema& schema,
             search_result.unity_topK_ = topK;
             return;
         }
+        search_bitset = search_result.PinBitset(std::move(transformed_bitset));
     }
 
     if (search_info.iterator_v2_info_.has_value()) {
@@ -188,7 +188,6 @@ SearchOnSealedColumn(const Schema& schema,
             column->EnsureChunkOffsetMapping(c, op_context);
         }
         transformed_bitset = TransformBitset(bitview, offset_mapping);
-        search_bitview = BitsetView(transformed_bitset);
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
             auto total_num = num_queries * search_info.topk_;
@@ -198,6 +197,7 @@ SearchOnSealedColumn(const Schema& schema,
             result.unity_topK_ = search_info.topk_;
             return;
         }
+        search_bitview = result.PinBitset(std::move(transformed_bitset));
     }
 
     // For element-level search (embedding-search-embedding), the underlying
@@ -231,6 +231,8 @@ SearchOnSealedColumn(const Schema& schema,
         return;
     }
 
+    const bool use_vector_iterator =
+        milvus::exec::UseVectorIterator(search_info);
     auto num_chunk = column->num_chunks();
 
     SubSearchResult final_qr(num_queries,
@@ -269,7 +271,7 @@ SearchOnSealedColumn(const Schema& schema,
             raw_dataset.raw_data_offsets = offsets_pw.get();
         }
 
-        if (milvus::exec::UseVectorIterator(search_info)) {
+        if (use_vector_iterator) {
             AssertInfo(data_type != DataType::VECTOR_ARRAY,
                        "vector array(embedding list) is not supported for "
                        "vector iterator");
@@ -294,7 +296,7 @@ SearchOnSealedColumn(const Schema& schema,
         }
         offset += chunk_size;
     }
-    if (milvus::exec::UseVectorIterator(search_info)) {
+    if (use_vector_iterator) {
         bool larger_is_closer = PositivelyRelated(search_info.metric_type_);
         // Element-level search skips row-level mapping (element IDs are
         // not row-aligned); see ChunkMergeIterator ctor.

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -99,7 +99,6 @@ SearchOnSealedIndex(const Schema& schema,
     TargetBitmap transformed_bitset;
     BitsetView search_bitset = bitset;
     if (offset_mapping.IsEnabled()) {
-        transformed_bitset = TransformBitset(bitset, offset_mapping);
         if (offset_mapping.GetValidCount() == 0) {
             auto total_num = num_queries * topK;
             search_result.seg_offsets_.resize(total_num, INVALID_SEG_OFFSET);
@@ -108,7 +107,11 @@ SearchOnSealedIndex(const Schema& schema,
             search_result.unity_topK_ = topK;
             return;
         }
-        search_bitset = search_result.PinBitset(std::move(transformed_bitset));
+        if (!bitset.empty()) {
+            transformed_bitset = TransformBitset(bitset, offset_mapping);
+            search_bitset =
+                search_result.PinBitset(std::move(transformed_bitset));
+        }
     }
 
     if (search_info.iterator_v2_info_.has_value()) {
@@ -187,7 +190,6 @@ SearchOnSealedColumn(const Schema& schema,
         for (int64_t c = 0; c < column->num_chunks(); ++c) {
             column->EnsureChunkOffsetMapping(c, op_context);
         }
-        transformed_bitset = TransformBitset(bitview, offset_mapping);
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
             auto total_num = num_queries * search_info.topk_;
@@ -197,7 +199,10 @@ SearchOnSealedColumn(const Schema& schema,
             result.unity_topK_ = search_info.topk_;
             return;
         }
-        search_bitview = result.PinBitset(std::move(transformed_bitset));
+        if (!bitview.empty()) {
+            transformed_bitset = TransformBitset(bitview, offset_mapping);
+            search_bitview = result.PinBitset(std::move(transformed_bitset));
+        }
     }
 
     // For element-level search (embedding-search-embedding), the underlying

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -1,0 +1,366 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/BitsetView.h"
+#include "common/Chunk.h"
+#include "common/IndexMeta.h"
+#include "common/QueryInfo.h"
+#include "common/QueryResult.h"
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "index/IndexFactory.h"
+#include "index/VectorIndex.h"
+#include "knowhere/comp/index_param.h"
+#include "knowhere/dataset.h"
+#include "mmap/ChunkedColumn.h"
+#include "query/SearchOnGrowing.h"
+#include "query/SearchOnSealed.h"
+#include "segcore/SegmentGrowing.h"
+#include "segcore/SegmentGrowingImpl.h"
+#include "segcore/SealedIndexingRecord.h"
+#include "test_utils/DataGen.h"
+#include "test_utils/cachinglayer_test_utils.h"
+
+namespace milvus::query {
+namespace {
+
+constexpr int64_t kDim = 36;
+constexpr int64_t kTopK = 15;
+
+std::vector<uint8_t>
+MakeLogicalBitsetBytes(int64_t total_count) {
+    std::vector<uint8_t> logical_bitset_bytes((total_count + 7) / 8, 0);
+    for (int64_t i = 0; i < total_count; i += 7) {
+        logical_bitset_bytes[i >> 3] |= 1U << (i & 0x07);
+    }
+    return logical_bitset_bytes;
+}
+
+std::unique_ptr<bool[]>
+MakeValidData(int64_t total_count, int64_t& valid_count) {
+    std::unique_ptr<bool[]> valid_data(new bool[total_count]);
+    valid_count = 0;
+    for (int64_t i = 0; i < total_count; ++i) {
+        valid_data[i] = i % 10 != 9;
+        if (valid_data[i]) {
+            ++valid_count;
+        }
+    }
+    return valid_data;
+}
+
+std::vector<float>
+MakeCompactVectors(int64_t valid_count, int64_t dim) {
+    std::vector<float> vectors(static_cast<size_t>(valid_count * dim));
+    for (size_t i = 0; i < vectors.size(); ++i) {
+        vectors[i] = static_cast<float>((i % 97) + 1) / 97.0F;
+    }
+    return vectors;
+}
+
+SearchInfo
+MakeGroupBySearchInfo(FieldId vector_field,
+                      FieldId group_by_field,
+                      const MetricType& metric_type) {
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = kTopK;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = metric_type;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::indexparam::NPROBE, "32"},
+    };
+    search_info.group_by_field_ids_.push_back(group_by_field);
+    return search_info;
+}
+
+void
+AssertVectorIteratorUsableAfterSearchReturns(SearchResult& search_result,
+                                             int64_t max_results) {
+    ASSERT_EQ(search_result.pinned_bitsets_.size(), 1);
+    ASSERT_TRUE(search_result.vector_iterators_.has_value());
+    ASSERT_FALSE(search_result.vector_iterators_->empty());
+
+    auto iterator = search_result.vector_iterators_->at(0);
+    ASSERT_NE(iterator, nullptr);
+
+    int64_t result_count = 0;
+    while (iterator->HasNext() && result_count < max_results) {
+        auto result = iterator->Next();
+        ASSERT_TRUE(result.has_value());
+        ++result_count;
+    }
+    ASSERT_GT(result_count, 0);
+}
+
+const DataArray&
+FindFieldData(const segcore::GeneratedData& dataset, FieldId field_id) {
+    for (const auto& field_data : dataset.raw_->fields_data()) {
+        if (field_data.field_id() == field_id.get()) {
+            return field_data;
+        }
+    }
+    ThrowInfo(FieldIDInvalid, "field id not found: {}", field_id.get());
+}
+
+int64_t
+CountValidRows(const DataArray& data, int64_t total_count) {
+    if (data.valid_data_size() == 0) {
+        return total_count;
+    }
+    return std::count(data.valid_data().begin(), data.valid_data().end(), true);
+}
+
+std::shared_ptr<ChunkedColumn>
+BuildNullableFloatVectorColumn(const FieldMeta& field_meta,
+                               int64_t total_count,
+                               int64_t dim,
+                               const bool* valid_data,
+                               const std::vector<float>& vectors,
+                               std::vector<std::vector<char>>& chunk_buffers) {
+    std::vector<std::unique_ptr<Chunk>> chunks;
+    std::vector<int64_t> num_rows_per_chunk;
+    num_rows_per_chunk.push_back(total_count);
+
+    auto null_bitmap_bytes = (total_count + 7) / 8;
+    auto vector_data_bytes = vectors.size() * sizeof(float);
+    auto buffer_size = null_bitmap_bytes + vector_data_bytes;
+    chunk_buffers.emplace_back(buffer_size, 0);
+    char* buffer = chunk_buffers.back().data();
+
+    for (int64_t i = 0; i < total_count; ++i) {
+        if (valid_data[i]) {
+            buffer[i >> 3] |= 1U << (i & 0x07);
+        }
+    }
+    std::memcpy(buffer + null_bitmap_bytes, vectors.data(), vector_data_bytes);
+
+    auto chunk_mmap_guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    chunks.emplace_back(std::make_unique<FixedWidthChunk>(total_count,
+                                                          dim,
+                                                          buffer,
+                                                          buffer_size,
+                                                          sizeof(float),
+                                                          true,
+                                                          chunk_mmap_guard));
+
+    auto translator = std::make_unique<TestChunkTranslator>(
+        num_rows_per_chunk, "", std::move(chunks));
+    auto slot =
+        cachinglayer::Manager::GetInstance().CreateCacheSlot<milvus::Chunk>(
+            std::move(translator), nullptr);
+    auto column = std::make_shared<ChunkedColumn>(std::move(slot), field_meta);
+    column->BuildValidRowIds(nullptr);
+    return column;
+}
+
+std::unique_ptr<index::IndexBase>
+BuildNullableVectorIndex(int64_t total_count,
+                         int64_t dim,
+                         const bool* valid_data,
+                         const std::vector<float>& vectors) {
+    index::CreateIndexInfo create_index_info;
+    create_index_info.field_type = DataType::VECTOR_FLOAT;
+    create_index_info.metric_type = knowhere::metric::COSINE;
+    create_index_info.index_type = knowhere::IndexEnum::INDEX_FAISS_IVFFLAT;
+    create_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+
+    auto index_base = index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, storage::FileManagerContext());
+    auto* vector_index = dynamic_cast<index::VectorIndex*>(index_base.get());
+    if (vector_index == nullptr) {
+        ADD_FAILURE() << "failed to create vector index";
+        return index_base;
+    }
+
+    auto build_dataset =
+        knowhere::GenDataSet(vectors.size() / dim, dim, vectors.data());
+    auto build_conf = knowhere::Json{
+        {knowhere::meta::METRIC_TYPE, knowhere::metric::COSINE},
+        {knowhere::meta::DIM, std::to_string(dim)},
+        {knowhere::indexparam::NLIST, "128"},
+    };
+    index_base->BuildWithDataset(build_dataset, build_conf);
+    vector_index->BuildValidData(valid_data, total_count);
+    return index_base;
+}
+
+}  // namespace
+
+TEST(SearchOnSealedIndexBitsetLifetime,
+     GroupByIteratorMustNotKeepDanglingTransformedBitset) {
+    constexpr int64_t total_count = 10000;
+
+    int64_t valid_count = 0;
+    auto valid_data = MakeValidData(total_count, valid_count);
+    auto vectors = MakeCompactVectors(valid_count, kDim);
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::COSINE, true);
+    auto group_by_field = schema->AddDebugField("group_by", DataType::INT8);
+    schema->set_primary_field_id(group_by_field);
+
+    auto index_base =
+        BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
+    auto* vector_index = dynamic_cast<index::VectorIndex*>(index_base.get());
+    ASSERT_NE(vector_index, nullptr);
+    ASSERT_TRUE(vector_index->GetOffsetMapping().IsEnabled());
+
+    segcore::SealedIndexingRecord indexing_record;
+    indexing_record.append_field_indexing(
+        vector_field,
+        knowhere::metric::COSINE,
+        CreateTestCacheIndex("nullable-vector-bitset-lifetime",
+                             std::move(index_base)));
+
+    auto logical_bitset_bytes = MakeLogicalBitsetBytes(total_count);
+    BitsetView logical_bitset(logical_bitset_bytes.data(), total_count);
+
+    std::vector<float> query(vectors.begin(), vectors.begin() + kDim);
+    auto search_info = MakeGroupBySearchInfo(
+        vector_field, group_by_field, knowhere::metric::COSINE);
+
+    SearchResult search_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        search_info,
+                        query.data(),
+                        nullptr,
+                        1,
+                        logical_bitset,
+                        nullptr,
+                        search_result);
+
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+}
+
+TEST(SearchOnGrowingBitsetLifetime,
+     GroupByIteratorMustNotKeepDanglingTransformedBitset) {
+    constexpr int64_t total_count = 512;
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::L2, true);
+    auto group_by_field = schema->AddDebugField("group_by", DataType::INT64);
+    schema->set_primary_field_id(group_by_field);
+
+    auto dataset = segcore::DataGen(schema,
+                                    total_count,
+                                    /*seed=*/42,
+                                    /*ts_offset=*/0,
+                                    /*repeat_count=*/1,
+                                    /*array_len=*/10,
+                                    /*group_count=*/1,
+                                    /*random_pk=*/false,
+                                    /*random_val=*/true,
+                                    /*random_valid=*/false,
+                                    /*null_percent=*/10);
+    const auto& vector_data = FindFieldData(dataset, vector_field);
+    auto valid_count = CountValidRows(vector_data, total_count);
+    ASSERT_GT(valid_count, 0);
+
+    auto segment = segcore::CreateGrowingSegment(schema, empty_index_meta);
+    auto reserved_offset = segment->PreInsert(total_count);
+    segment->Insert(reserved_offset,
+                    total_count,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+    auto* growing_segment =
+        dynamic_cast<segcore::SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(growing_segment, nullptr);
+
+    auto logical_bitset_bytes = MakeLogicalBitsetBytes(total_count);
+    BitsetView logical_bitset(logical_bitset_bytes.data(), total_count);
+
+    const auto& vectors = vector_data.vectors().float_vector().data();
+    ASSERT_GE(vectors.size(), kDim);
+    auto search_info = MakeGroupBySearchInfo(
+        vector_field, group_by_field, knowhere::metric::L2);
+
+    SearchResult search_result;
+    SearchOnGrowing(*growing_segment,
+                    search_info,
+                    vectors.data(),
+                    nullptr,
+                    1,
+                    MAX_TIMESTAMP,
+                    logical_bitset,
+                    nullptr,
+                    search_result);
+
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+}
+
+TEST(SearchOnSealedColumnBitsetLifetime,
+     GroupByIteratorMustNotKeepDanglingTransformedBitset) {
+    constexpr int64_t total_count = 512;
+
+    int64_t valid_count = 0;
+    auto valid_data = MakeValidData(total_count, valid_count);
+    auto vectors = MakeCompactVectors(valid_count, kDim);
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::L2, true);
+    auto group_by_field = schema->AddDebugField("group_by", DataType::INT8);
+    schema->set_primary_field_id(group_by_field);
+
+    std::vector<std::vector<char>> chunk_buffers;
+    auto column = BuildNullableFloatVectorColumn((*schema)[vector_field],
+                                                 total_count,
+                                                 kDim,
+                                                 valid_data.get(),
+                                                 vectors,
+                                                 chunk_buffers);
+    ASSERT_TRUE(column->GetOffsetMapping().IsEnabled());
+    ASSERT_EQ(column->GetOffsetMapping().GetValidCount(), valid_count);
+
+    auto logical_bitset_bytes = MakeLogicalBitsetBytes(total_count);
+    BitsetView logical_bitset(logical_bitset_bytes.data(), total_count);
+
+    auto search_info = MakeGroupBySearchInfo(
+        vector_field, group_by_field, knowhere::metric::L2);
+
+    SearchResult search_result;
+    SearchOnSealedColumn(*schema,
+                         column.get(),
+                         search_info,
+                         std::map<std::string, std::string>{},
+                         vectors.data(),
+                         nullptr,
+                         1,
+                         total_count,
+                         logical_bitset,
+                         nullptr,
+                         search_result);
+
+    AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+}
+
+}  // namespace milvus::query

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -259,6 +259,117 @@ TEST(SearchOnSealedIndexBitsetLifetime,
     AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
 }
 
+TEST(SearchOnSealedIndexNullableNoFilter,
+     EmptyBitsetMustNotMaskCompactVectorRows) {
+    constexpr int64_t total_count = 1000;
+    constexpr int64_t topk = 10;
+
+    int64_t valid_count = 0;
+    auto valid_data = MakeValidData(total_count, valid_count);
+    auto vectors = MakeCompactVectors(valid_count, kDim);
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::COSINE, true);
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_field);
+
+    auto index_base =
+        BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
+    auto* vector_index = dynamic_cast<index::VectorIndex*>(index_base.get());
+    ASSERT_NE(vector_index, nullptr);
+    ASSERT_TRUE(vector_index->GetOffsetMapping().IsEnabled());
+    ASSERT_EQ(vector_index->GetOffsetMapping().GetValidCount(), valid_count);
+
+    segcore::SealedIndexingRecord indexing_record;
+    indexing_record.append_field_indexing(
+        vector_field,
+        knowhere::metric::COSINE,
+        CreateTestCacheIndex("nullable-vector-empty-bitset",
+                             std::move(index_base)));
+
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = topk;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = knowhere::metric::COSINE;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::indexparam::NPROBE, "32"},
+    };
+
+    SearchResult search_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        search_info,
+                        vectors.data(),
+                        nullptr,
+                        1,
+                        BitsetView{},
+                        nullptr,
+                        search_result);
+
+    ASSERT_EQ(search_result.seg_offsets_.size(), topk);
+    auto valid_results = std::count_if(
+        search_result.seg_offsets_.begin(),
+        search_result.seg_offsets_.end(),
+        [](int64_t offset) { return offset != INVALID_SEG_OFFSET; });
+    EXPECT_GT(valid_results, 0);
+}
+
+TEST(SearchOnSealedIndexNullableIteratorNoFilter,
+     EmptyBitsetMustNotMaskCompactVectorRows) {
+    constexpr int64_t total_count = 1000;
+    constexpr int64_t batch_size = 10;
+
+    int64_t valid_count = 0;
+    auto valid_data = MakeValidData(total_count, valid_count);
+    auto vectors = MakeCompactVectors(valid_count, kDim);
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::COSINE, true);
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_field);
+
+    auto index_base =
+        BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
+    segcore::SealedIndexingRecord indexing_record;
+    indexing_record.append_field_indexing(
+        vector_field,
+        knowhere::metric::COSINE,
+        CreateTestCacheIndex("nullable-vector-empty-bitset-iterator",
+                             std::move(index_base)));
+
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = batch_size;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = knowhere::metric::COSINE;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::indexparam::NPROBE, "32"},
+    };
+    search_info.iterator_v2_info_ =
+        SearchIteratorV2Info{.batch_size = batch_size};
+
+    SearchResult search_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        search_info,
+                        vectors.data(),
+                        nullptr,
+                        1,
+                        BitsetView{},
+                        nullptr,
+                        search_result);
+
+    ASSERT_EQ(search_result.seg_offsets_.size(), batch_size);
+    auto valid_results = std::count_if(
+        search_result.seg_offsets_.begin(),
+        search_result.seg_offsets_.end(),
+        [](int64_t offset) { return offset != INVALID_SEG_OFFSET; });
+    EXPECT_GT(valid_results, 0);
+}
+
 TEST(SearchOnGrowingBitsetLifetime,
      GroupByIteratorMustNotKeepDanglingTransformedBitset) {
     constexpr int64_t total_count = 512;

--- a/internal/core/src/query/Utils.h
+++ b/internal/core/src/query/Utils.h
@@ -55,9 +55,18 @@ ApplyElementIDMapping(const std::vector<int64_t>& element_ids,
 inline TargetBitmap
 TransformBitset(const BitsetView& bitset,
                 const milvus::OffsetMapping& mapping) {
+    // Empty BitsetView is the Knowhere fast path for "no rows filtered".
+    // Keep it empty after logical-to-physical mapping.
+    if (bitset.empty()) {
+        return {};
+    }
+
+    // bit=true means filtered out. The logical bitset may be shorter than the
+    // full mapping on growing segments because it is sized by query timestamp
+    // visibility. Physical rows outside that logical view are not visible yet.
     TargetBitmap result;
     auto count = mapping.GetValidCount();
-    result.resize(count);
+    result.resize(count, true);
     for (int64_t physical_idx = 0; physical_idx < count; physical_idx++) {
         auto logical_idx = mapping.GetLogicalOffset(physical_idx);
         if (logical_idx >= 0 &&

--- a/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
@@ -674,6 +674,145 @@ INSTANTIATE_TEST_SUITE_P(MetricTypeParameters,
                          BinlogIndexTest,
                          ::testing::ValuesIn(GenerateTestParams()));
 
+TEST(test_chunk_segment,
+     NullableVectorProjectionFallsBackWhenLoadedIndexHasNoValidData) {
+    auto schema = std::make_shared<Schema>();
+    const int64_t dim = 8;
+    const int64_t data_n = 200;
+    auto vec_field_id = schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2, true);
+    auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
+    schema->set_primary_field_id(i64_fid);
+
+    std::map<std::string, std::string> index_params = {
+        {"index_type", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT},
+        {"metric_type", knowhere::metric::L2},
+        {"nlist", "16"}};
+    std::map<std::string, std::string> type_params = {
+        {"dim", std::to_string(dim)}};
+    FieldIndexMeta field_index_meta(
+        vec_field_id, std::move(index_params), std::move(type_params));
+    IndexMetaPtr collection_index_meta = std::make_shared<CollectionIndexMeta>(
+        226985,
+        std::map<FieldId, FieldIndexMeta>{{vec_field_id, field_index_meta}});
+
+    auto segment = CreateSealedSegment(schema, collection_index_meta);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    std::vector<uint8_t> valid_data((data_n + 7) / 8, 0);
+    int64_t valid_count = 0;
+    for (int64_t i = 0; i < data_n; ++i) {
+        if ((i % 100) >= 50) {
+            valid_data[i >> 3] |= (1 << (i & 0x07));
+            ++valid_count;
+        }
+    }
+    ASSERT_EQ(valid_count, data_n / 2);
+
+    std::vector<float> vec_values(valid_count * dim);
+    for (int64_t i = 0; i < valid_count; ++i) {
+        for (int64_t d = 0; d < dim; ++d) {
+            vec_values[i * dim + d] = static_cast<float>(i * dim + d);
+        }
+    }
+
+    auto vec_field_data = milvus::storage::CreateFieldData(
+        DataType::VECTOR_FLOAT, DataType::NONE, true, dim);
+    auto vec_field_data_impl =
+        std::dynamic_pointer_cast<milvus::FieldData<milvus::FloatVector>>(
+            vec_field_data);
+    ASSERT_NE(vec_field_data_impl, nullptr);
+    vec_field_data_impl->FillFieldData(
+        vec_values.data(), valid_data.data(), data_n, 0);
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_field_info = PrepareSingleFieldInsertBinlog(kCollectionID,
+                                                          kPartitionID,
+                                                          kSegmentID,
+                                                          vec_field_id.get(),
+                                                          {vec_field_data},
+                                                          cm);
+    ASSERT_NO_THROW(segment->LoadFieldData(load_field_info));
+    ASSERT_TRUE(segment->HasFieldData(vec_field_id));
+    ASSERT_EQ(segment->get_row_count(), data_n);
+
+    auto raw_dataset =
+        knowhere::GenDataSet(valid_count, dim, vec_values.data());
+    raw_dataset->SetIsOwner(false);
+
+    milvus::index::CreateIndexInfo create_index_info;
+    create_index_info.field_type = DataType::VECTOR_FLOAT;
+    create_index_info.metric_type = knowhere::metric::L2;
+    create_index_info.index_type = knowhere::IndexEnum::INDEX_FAISS_IVFFLAT;
+    create_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+    auto indexing = milvus::index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, milvus::storage::FileManagerContext());
+
+    auto build_conf =
+        knowhere::Json{{knowhere::meta::METRIC_TYPE, knowhere::metric::L2},
+                       {knowhere::meta::DIM, std::to_string(dim)},
+                       {knowhere::indexparam::NLIST, "16"}};
+    indexing->BuildWithDataset(raw_dataset, build_conf);
+
+    LoadIndexInfo load_info;
+    load_info.field_id = vec_field_id.get();
+    load_info.index_params = GenIndexParams(indexing.get());
+    load_info.cache_index = CreateTestCacheIndex("test", std::move(indexing));
+    load_info.index_params["metric_type"] = knowhere::metric::L2;
+    ASSERT_NO_THROW(segment->LoadIndex(load_info));
+    ASSERT_TRUE(segment->HasIndex(vec_field_id));
+
+    auto& segcore_config = milvus::segcore::SegcoreConfig::default_config();
+    auto previous_prefer_field_data =
+        segcore_config.get_prefer_field_data_when_index_has_raw_data();
+    struct PreferFieldDataGuard {
+        milvus::segcore::SegcoreConfig& config;
+        bool previous_value;
+
+        ~PreferFieldDataGuard() {
+            config.set_prefer_field_data_when_index_has_raw_data(
+                previous_value);
+        }
+    } prefer_field_data_guard{segcore_config, previous_prefer_field_data};
+    segcore_config.set_prefer_field_data_when_index_has_raw_data(true);
+
+    std::vector<int64_t> null_offsets = {0, 1, 100, 101};
+    auto null_result = sealed->bulk_subscript(
+        nullptr, vec_field_id, null_offsets.data(), null_offsets.size());
+
+    ASSERT_EQ(null_result->valid_data_size(), null_offsets.size());
+    for (int i = 0; i < null_result->valid_data_size(); ++i) {
+        EXPECT_FALSE(null_result->valid_data(i));
+    }
+    EXPECT_TRUE(null_result->vectors().float_vector().data().empty());
+
+    std::vector<int64_t> offsets = {0, 50, 100, 150};
+    auto result = sealed->bulk_subscript(
+        nullptr, vec_field_id, offsets.data(), offsets.size());
+
+    ASSERT_EQ(result->valid_data_size(), offsets.size());
+    EXPECT_FALSE(result->valid_data(0));
+    EXPECT_TRUE(result->valid_data(1));
+    EXPECT_FALSE(result->valid_data(2));
+    EXPECT_TRUE(result->valid_data(3));
+
+    const auto& returned = result->vectors().float_vector().data();
+    ASSERT_EQ(returned.size(), 2 * dim);
+    std::vector<int64_t> expected_physical_offsets = {0, 50};
+    for (int64_t i = 0;
+         i < static_cast<int64_t>(expected_physical_offsets.size());
+         ++i) {
+        auto physical_offset = expected_physical_offsets[i];
+        for (int64_t d = 0; d < dim; ++d) {
+            EXPECT_FLOAT_EQ(returned[i * dim + d],
+                            vec_values[physical_offset * dim + d]);
+        }
+    }
+}
+
 TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
     IndexMetaPtr collection_index_meta = GetCollectionIndexMeta(index_type);
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedBinlogIndexTest.cpp
@@ -68,6 +68,7 @@
 #include "test_utils/Constants.h"
 #include "test_utils/DataGen.h"
 #include "test_utils/GenExprProto.h"
+#include "test_utils/SegcoreConfigUtils.h"
 #include "test_utils/cachinglayer_test_utils.h"
 #include "test_utils/storage_test_utils.h"
 
@@ -398,15 +399,21 @@ class BinlogIndexTest : public ::testing::TestWithParam<Param> {
         std::map<std::string, std::string> type_params = {{"dim", "4"}};
         FieldIndexMeta fieldIndexMeta(
             vec_field_id, std::move(index_params), std::move(type_params));
-        auto& config = SegcoreConfig::default_config();
-        config.set_chunk_rows(1024);
-        config.set_enable_interim_segment_index(true);
-        config.set_nlist(16);
         std::map<FieldId, FieldIndexMeta> filedMap = {
             {vec_field_id, fieldIndexMeta}};
         IndexMetaPtr metaPtr =
             std::make_shared<CollectionIndexMeta>(226985, std::move(filedMap));
         return metaPtr;
+    }
+
+    void
+    ApplyBinlogInterimIndexConfigForTest() {
+        InterimIndexConfigForTest options;
+        options.chunk_rows = 1024;
+        options.nlist = 16;
+        options.nprobe = 16;
+        options.dense_vector_interim_index_type = dense_vec_intermin_index_type;
+        ApplyInterimIndexConfigForTest(options);
     }
 
     void
@@ -814,18 +821,14 @@ TEST(test_chunk_segment,
 }
 
 TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
+    ScopedSegcoreConfigRestore config_restore;
     IndexMetaPtr collection_index_meta = GetCollectionIndexMeta(index_type);
 
     segment = CreateSealedSegment(schema, collection_index_meta);
     LoadOtherFields();
 
+    ApplyBinlogInterimIndexConfigForTest();
     auto& segcore_config = milvus::segcore::SegcoreConfig::default_config();
-    segcore_config.set_enable_interim_segment_index(true);
-    if (dense_vec_intermin_index_type.has_value()) {
-        segcore_config.set_dense_vector_intermin_index_type(
-            dense_vec_intermin_index_type.value());
-    }
-    segcore_config.set_nprobe(16);
     // 1. load field data, and build binlog index for binlog data
     LoadVectorField();
 
@@ -1094,18 +1097,14 @@ TEST_P(BinlogIndexTest, AccuracyWithLoadFieldData) {
 }
 
 TEST_P(BinlogIndexTest, AccuracyWithMapFieldData) {
+    ScopedSegcoreConfigRestore config_restore;
     IndexMetaPtr collection_index_meta = GetCollectionIndexMeta(index_type);
 
     segment = CreateSealedSegment(schema, collection_index_meta);
     LoadOtherFields();
 
+    ApplyBinlogInterimIndexConfigForTest();
     auto& segcore_config = milvus::segcore::SegcoreConfig::default_config();
-    segcore_config.set_enable_interim_segment_index(true);
-    if (dense_vec_intermin_index_type.has_value()) {
-        segcore_config.set_dense_vector_intermin_index_type(
-            dense_vec_intermin_index_type.value());
-    }
-    segcore_config.set_nprobe(16);
     // 1. load field data, and build binlog index for binlog data
     LoadVectorField("./data/mmap-test");
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5354,6 +5354,89 @@ ChunkedSegmentSealedImpl::ArrowToDataArray(
             }
             break;
         }
+        case DataType::VECTOR_BINARY:
+        case DataType::VECTOR_FLOAT16:
+        case DataType::VECTOR_BFLOAT16:
+        case DataType::VECTOR_INT8: {
+            int dim = field_meta.get_dim();
+            auto byte_width = field_meta.get_sizeof();
+            auto vectors = data_array->mutable_vectors();
+            vectors->set_dim(dim);
+            std::string* vector_data = nullptr;
+            switch (field_meta.get_data_type()) {
+                case DataType::VECTOR_BINARY:
+                    vector_data = vectors->mutable_binary_vector();
+                    break;
+                case DataType::VECTOR_FLOAT16:
+                    vector_data = vectors->mutable_float16_vector();
+                    break;
+                case DataType::VECTOR_BFLOAT16:
+                    vector_data = vectors->mutable_bfloat16_vector();
+                    break;
+                case DataType::VECTOR_INT8:
+                    vector_data = vectors->mutable_int8_vector();
+                    break;
+                default:
+                    break;
+            }
+            int64_t valid_count = size;
+            if (field_meta.is_nullable()) {
+                valid_count = 0;
+                for (int64_t i = 0; i < size; i++) {
+                    if (arr->IsValid(result_mapping[i])) {
+                        valid_count++;
+                    }
+                }
+            }
+            vector_data->resize(valid_count * byte_width);
+            int64_t data_pos = 0;
+            for (int64_t i = 0; i < size; i++) {
+                auto idx = result_mapping[i];
+                if (arr->IsNull(idx)) {
+                    continue;
+                }
+                const uint8_t* val = nullptr;
+                if (arr->type_id() == arrow::Type::FIXED_SIZE_BINARY) {
+                    val = std::static_pointer_cast<arrow::FixedSizeBinaryArray>(
+                              arr)
+                              ->Value(idx);
+                } else {
+                    auto bin_val =
+                        std::static_pointer_cast<arrow::BinaryArray>(arr)
+                            ->Value(idx);
+                    AssertInfo(
+                        static_cast<size_t>(bin_val.size()) == byte_width,
+                        "vector byte width mismatch, expected {}, actual {}",
+                        byte_width,
+                        bin_val.size());
+                    val = reinterpret_cast<const uint8_t*>(bin_val.data());
+                }
+                std::memcpy(vector_data->data() + data_pos * byte_width,
+                            val,
+                            byte_width);
+                data_pos++;
+            }
+            break;
+        }
+        case DataType::VECTOR_SPARSE_U32_F32: {
+            auto vectors = data_array->mutable_vectors();
+            auto sparse_data = vectors->mutable_sparse_float_vector();
+            auto typed = std::static_pointer_cast<arrow::BinaryArray>(arr);
+            int64_t max_dim = 0;
+            for (int64_t i = 0; i < size; i++) {
+                auto idx = result_mapping[i];
+                if (arr->IsNull(idx)) {
+                    continue;
+                }
+                auto val = typed->Value(idx);
+                sparse_data->add_contents(val.data(), val.size());
+                auto row = CopyAndWrapSparseRow(val.data(), val.size(), true);
+                max_dim = std::max(max_dim, row.dim());
+            }
+            sparse_data->set_dim(max_dim);
+            vectors->set_dim(sparse_data->dim());
+            break;
+        }
         case DataType::VECTOR_ARRAY: {
             // After normalize, arr is List<FixedSizeBinaryArray>.
             auto outer_list = std::static_pointer_cast<arrow::ListArray>(arr);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1577,6 +1577,7 @@ ChunkedSegmentSealedImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
     ValidResult result;
     result.valid_count = count;
 
+    bool got_valid_offsets_from_index = false;
     if (vector_indexings_.is_ready(field_id)) {
         auto field_indexing = vector_indexings_.get_field_indexing(field_id);
         auto cache_index = field_indexing->indexing_;
@@ -1599,8 +1600,11 @@ ChunkedSegmentSealedImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
                 }
             }
             result.valid_count = result.valid_offsets.size();
+            got_valid_offsets_from_index = true;
         }
-    } else {
+    }
+
+    if (!got_valid_offsets_from_index) {
         auto column = get_column(field_id);
         if (column != nullptr && column->IsNullable()) {
             result.valid_data = std::make_unique<bool[]>(count);
@@ -3106,6 +3110,9 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
         valid_offsets = filter_result.valid_offsets.data();
     }
     auto ret = fill_with_empty(field_id, count, valid_count, valid_data);
+    if (field_meta.is_vector() && valid_count == 0) {
+        return ret;
+    }
 
     if (!field_meta.is_vector() && column->IsNullable()) {
         auto dst = ret->mutable_valid_data()->mutable_data();

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -192,7 +192,7 @@ VectorFieldIndexing::recreate_index(DataType data_type,
                    "growing segment.");
         knowhere::ViewDataOp view_data = [field_raw_data_ptr =
                                               concurrent_fp32_vec](size_t id) {
-            return (const void*)field_raw_data_ptr->get_element(id);
+            return (const void*)field_raw_data_ptr->get_physical_element(id);
         };
         index_ = std::make_unique<index::VectorMemIndex<float>>(
             DataType::NONE,
@@ -209,7 +209,7 @@ VectorFieldIndexing::recreate_index(DataType data_type,
                    "in growing segment.");
         knowhere::ViewDataOp view_data = [field_raw_data_ptr =
                                               concurrent_fp16_vec](size_t id) {
-            return (const void*)field_raw_data_ptr->get_element(id);
+            return (const void*)field_raw_data_ptr->get_physical_element(id);
         };
         index_ = std::make_unique<index::VectorMemIndex<float16>>(
             DataType::NONE,
@@ -226,7 +226,7 @@ VectorFieldIndexing::recreate_index(DataType data_type,
                    "in growing segment.");
         knowhere::ViewDataOp view_data = [field_raw_data_ptr =
                                               concurrent_bf16_vec](size_t id) {
-            return (const void*)field_raw_data_ptr->get_element(id);
+            return (const void*)field_raw_data_ptr->get_physical_element(id);
         };
         index_ = std::make_unique<index::VectorMemIndex<bfloat16>>(
             DataType::NONE,

--- a/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingIndexTest.cpp
@@ -53,6 +53,7 @@
 #include "segcore/SegmentGrowingImpl.h"
 #include "storage/FileManager.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/SegcoreConfigUtils.h"
 #include "test_utils/indexbuilder_test_utils.h"
 
 using namespace milvus;
@@ -204,23 +205,23 @@ TEST_P(GrowingIndexTest, Correctness) {
     FieldIndexMeta fieldIndexMeta(
         vec, std::move(index_params), std::move(type_params));
     auto& config = SegcoreConfig::default_config();
-    config.set_chunk_rows(1024);
-    config.set_enable_interim_segment_index(true);
-    if (dense_vec_intermin_index_type.has_value()) {
-        config.set_dense_vector_intermin_index_type(
-            dense_vec_intermin_index_type.value());
-        if (dense_vec_intermin_index_type.value() ==
+    ScopedSegcoreConfigRestore config_restore(config);
+    InterimIndexConfigForTest interim_config;
+    interim_config.chunk_rows = 1024;
+    interim_config.dense_vector_interim_index_type =
+        dense_vec_intermin_index_type;
+    if (dense_vec_intermin_index_type.has_value() &&
+        dense_vec_intermin_index_type.value() ==
             knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR) {
-            auto nlist = config.get_nlist();
-            config.set_sub_dim(4);
-            config.set_nprobe(int(0.4 * nlist));
-            config.set_refine_ratio(4.0);
-            if (dense_refine_type.has_value()) {
-                config.set_refine_quant_type(dense_refine_type.value());
-                config.set_refine_with_quant_flag(false);
-            }
+        interim_config.nprobe = int(0.4 * config.get_nlist());
+        interim_config.sub_dim = 4;
+        interim_config.refine_ratio = 4.0F;
+        if (dense_refine_type.has_value()) {
+            interim_config.refine_quant_type = dense_refine_type.value();
+            interim_config.refine_with_quant_flag = false;
         }
     }
+    ApplyInterimIndexConfigForTest(interim_config, config);
     std::map<FieldId, FieldIndexMeta> filedMap = {{vec, fieldIndexMeta}};
     IndexMetaPtr metaPtr =
         std::make_shared<CollectionIndexMeta>(226985, std::move(filedMap));
@@ -472,7 +473,117 @@ TEST_P(GrowingIndexTest, AddWithoutBuildPool) {
     }
 }
 
+TEST(GrowingIndexNullableVectorTest,
+     ScannDvrRefinerUsesCompactPhysicalVectorIds) {
+    constexpr int64_t dim = 4;
+    constexpr int64_t row_count = 50;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto vec = schema->AddDebugField(
+        "embeddings", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2, true);
+    schema->set_primary_field_id(pk);
+
+    std::map<std::string, std::string> index_params = {
+        {"index_type", knowhere::IndexEnum::INDEX_FAISS_IVFFLAT},
+        {"metric_type", knowhere::metric::L2},
+        {"nlist", "1"}};
+    std::map<std::string, std::string> type_params = {
+        {"dim", std::to_string(dim)}};
+    FieldIndexMeta field_index_meta(
+        vec, std::move(index_params), std::move(type_params));
+
+    auto& config = SegcoreConfig::default_config();
+    ScopedSegcoreConfigRestore config_restore(config);
+    InterimIndexConfigForTest interim_config;
+    interim_config.chunk_rows = 1024;
+    interim_config.nlist = 1;
+    interim_config.nprobe = 1;
+    interim_config.dense_vector_interim_index_type =
+        knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR;
+    interim_config.sub_dim = dim;
+    interim_config.refine_ratio = 1.0F;
+    interim_config.refine_quant_type = "NONE";
+    interim_config.refine_with_quant_flag = false;
+    ApplyInterimIndexConfigForTest(interim_config, config);
+
+    std::map<FieldId, FieldIndexMeta> field_map = {{vec, field_index_meta}};
+    IndexMetaPtr meta =
+        std::make_shared<CollectionIndexMeta>(100, std::move(field_map));
+    auto segment_growing = CreateGrowingSegment(schema, meta, 1, config);
+
+    std::vector<int64_t> pks(row_count);
+    std::vector<idx_t> row_ids(row_count);
+    std::vector<Timestamp> timestamps(row_count, 100);
+    for (int64_t i = 0; i < row_count; ++i) {
+        pks[i] = i;
+        row_ids[i] = i;
+    }
+
+    FixedVector<bool> valid_data(row_count);
+    std::fill(valid_data.begin(), valid_data.end(), true);
+    valid_data[0] = false;
+
+    std::vector<float> compact_vectors((row_count - 1) * dim, 1000.0f);
+    // logical row 1 -> physical 0, intentionally far from the query.
+    compact_vectors[0] = 1000.0f;
+    compact_vectors[1] = 0.0f;
+    compact_vectors[2] = 0.0f;
+    compact_vectors[3] = 0.0f;
+    // logical row 2 -> physical 1, exactly equal to the query.
+    compact_vectors[dim] = 0.0f;
+    compact_vectors[dim + 1] = 0.0f;
+    compact_vectors[dim + 2] = 0.0f;
+    compact_vectors[dim + 3] = 0.0f;
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    auto pk_array =
+        CreateDataArrayFrom(pks.data(), nullptr, row_count, (*schema)[pk]);
+    auto vec_array = CreateVectorDataArrayFrom(compact_vectors.data(),
+                                               valid_data.data(),
+                                               row_count,
+                                               row_count - 1,
+                                               (*schema)[vec]);
+    insert_data->mutable_fields_data()->AddAllocated(pk_array.release());
+    insert_data->mutable_fields_data()->AddAllocated(vec_array.release());
+    insert_data->set_num_rows(row_count);
+
+    auto reserved_offset = segment_growing->PreInsert(row_count);
+    segment_growing->Insert(reserved_offset,
+                            row_count,
+                            row_ids.data(),
+                            timestamps.data(),
+                            insert_data.get());
+
+    milvus::segcore::ScopedSchemaHandle schema_handle(*schema);
+    auto plan_str = schema_handle.ParseSearch(
+        "", "embeddings", 5, knowhere::metric::L2, R"({"nprobe": 1})", -1);
+    auto plan =
+        query::CreateSearchPlanByExpr(schema, plan_str.data(), plan_str.size());
+
+    std::array<float, dim> query = {0.0f, 0.0f, 0.0f, 0.0f};
+    auto ph_group_raw = CreatePlaceholderGroupFromBlob(1, dim, query.data());
+    auto ph_group =
+        ParsePlaceholderGroup(plan.get(), ph_group_raw.SerializeAsString());
+
+    auto result = segment_growing->Search(plan.get(), ph_group.get(), 100);
+
+    ASSERT_EQ(result->seg_offsets_.size(), 5);
+    ASSERT_EQ(result->distances_.size(), 5);
+    bool found_exact_query_row = false;
+    for (size_t i = 0; i < result->seg_offsets_.size(); ++i) {
+        if (result->seg_offsets_[i] == 2) {
+            EXPECT_FLOAT_EQ(result->distances_[i], 0.0f);
+            found_exact_query_row = true;
+        }
+    }
+    EXPECT_TRUE(found_exact_query_row);
+}
+
 TEST_P(GrowingIndexTest, MissIndexMeta) {
+    auto& config = SegcoreConfig::default_config();
+    ScopedSegcoreConfigRestore config_restore(config);
+
     auto dim = 4;
     auto schema = std::make_shared<Schema>();
     auto pk = schema->AddDebugField("pk", DataType::INT64);
@@ -480,13 +591,15 @@ TEST_P(GrowingIndexTest, MissIndexMeta) {
     schema->AddDebugField("embeddings", data_type, dim, metric_type);
     schema->set_primary_field_id(pk);
 
-    auto& config = SegcoreConfig::default_config();
     config.set_chunk_rows(1024);
     config.set_enable_interim_segment_index(true);
     auto segment = CreateGrowingSegment(schema, nullptr);
 }
 
 TEST_P(GrowingIndexTest, GetVector) {
+    auto& config = SegcoreConfig::default_config();
+    ScopedSegcoreConfigRestore config_restore(config);
+
     auto dim = 4;
     auto schema = std::make_shared<Schema>();
     auto pk = schema->AddDebugField("pk", DataType::INT64);
@@ -502,7 +615,6 @@ TEST_P(GrowingIndexTest, GetVector) {
         {"dim", std::to_string(dim)}};
     FieldIndexMeta fieldIndexMeta(
         vec, std::move(index_params), std::move(type_params));
-    auto& config = SegcoreConfig::default_config();
     config.set_chunk_rows(1024);
     config.set_enable_interim_segment_index(true);
     if (dense_vec_intermin_index_type.has_value()) {

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -490,7 +490,7 @@ CreateEmptyVectorDataArray(int64_t count, const FieldMeta& field_meta) {
             break;
         }
         case DataType::VECTOR_SPARSE_U32_F32: {
-            // does nothing here
+            vector_array->mutable_sparse_float_vector();
             break;
         }
         case DataType::VECTOR_INT8: {
@@ -851,13 +851,13 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
             } else if (field_meta.get_data_type() == DataType::VECTOR_FLOAT16) {
                 auto data = VEC_FIELD_DATA(src_field_data, float16);
                 auto obj = vector_array->mutable_float16_vector();
-                obj->assign(data + physical_offset * dim * sizeof(float16),
+                obj->append(data + physical_offset * dim * sizeof(float16),
                             dim * sizeof(float16));
             } else if (field_meta.get_data_type() ==
                        DataType::VECTOR_BFLOAT16) {
                 auto data = VEC_FIELD_DATA(src_field_data, bfloat16);
                 auto obj = vector_array->mutable_bfloat16_vector();
-                obj->assign(data + physical_offset * dim * sizeof(bfloat16),
+                obj->append(data + physical_offset * dim * sizeof(bfloat16),
                             dim * sizeof(bfloat16));
             } else if (field_meta.get_data_type() == DataType::VECTOR_BINARY) {
                 AssertInfo(
@@ -866,7 +866,7 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
                 auto num_bytes = dim / 8;
                 auto data = VEC_FIELD_DATA(src_field_data, binary);
                 auto obj = vector_array->mutable_binary_vector();
-                obj->assign(data + physical_offset * num_bytes, num_bytes);
+                obj->append(data + physical_offset * num_bytes, num_bytes);
             } else if (field_meta.get_data_type() ==
                        DataType::VECTOR_SPARSE_U32_F32) {
                 auto* mutable_src_vec = src_field_data->mutable_vectors()
@@ -882,7 +882,7 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
             } else if (field_meta.get_data_type() == DataType::VECTOR_INT8) {
                 auto data = VEC_FIELD_DATA(src_field_data, int8);
                 auto obj = vector_array->mutable_int8_vector();
-                obj->assign(data + physical_offset * dim * sizeof(int8),
+                obj->append(data + physical_offset * dim * sizeof(int8),
                             dim * sizeof(int8));
             } else if (field_meta.get_data_type() == DataType::VECTOR_ARRAY) {
                 auto& data = src_field_data->vectors().vector_array();

--- a/internal/core/src/segcore/UtilsTest.cpp
+++ b/internal/core/src/segcore/UtilsTest.cpp
@@ -11,6 +11,7 @@
 
 #include <folly/CancellationToken.h>
 #include <folly/FBVector.h>
+#include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -30,6 +31,7 @@
 #include "gtest/gtest.h"
 #include "knowhere/comp/index_param.h"
 #include "pb/schema.pb.h"
+#include "query/Utils.h"
 #include "segcore/AckResponder.h"
 #include "segcore/ConcurrentVector.h"
 #include "segcore/DeletedRecord.h"
@@ -105,6 +107,40 @@ TEST(Util_Segcore, GetDeleteBitmap) {
     BitsetTypeView res_view(res_bitmap);
     delete_record.Query(res_view, insert_barrier, query_timestamp);
     ASSERT_EQ(res_view.count(), 0);
+}
+
+TEST(Util_Segcore, CreateEmptyVectorDataArrayForNullableVectors) {
+    using namespace milvus;
+    using namespace milvus::segcore;
+
+    auto schema = std::make_shared<Schema>();
+    auto vec = schema->AddDebugField(
+        "embeddings", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2, true);
+    auto sparse_vec = schema->AddDebugField("sparse",
+                                            DataType::VECTOR_SPARSE_U32_F32,
+                                            0,
+                                            knowhere::metric::IP,
+                                            true);
+    std::array<bool, 3> valid_data = {false, false, false};
+
+    auto dense_result =
+        CreateEmptyVectorDataArray(3, 0, valid_data.data(), (*schema)[vec]);
+    ASSERT_EQ(dense_result->valid_data().size(), 3);
+    ASSERT_FALSE(dense_result->valid_data(0));
+    ASSERT_FALSE(dense_result->valid_data(1));
+    ASSERT_FALSE(dense_result->valid_data(2));
+    ASSERT_EQ(dense_result->vectors().float_vector().data_size(), 0);
+
+    auto sparse_result = CreateEmptyVectorDataArray(
+        3, 0, valid_data.data(), (*schema)[sparse_vec]);
+    ASSERT_EQ(sparse_result->valid_data().size(), 3);
+    ASSERT_FALSE(sparse_result->valid_data(0));
+    ASSERT_FALSE(sparse_result->valid_data(1));
+    ASSERT_FALSE(sparse_result->valid_data(2));
+    ASSERT_EQ(sparse_result->vectors().data_case(),
+              proto::schema::VectorField::kSparseFloatVector);
+    ASSERT_EQ(sparse_result->vectors().sparse_float_vector().contents_size(),
+              0);
 }
 
 TEST(Util_Segcore, CreateVectorDataArrayFromNullableVectors) {
@@ -198,6 +234,128 @@ TEST(Util_Segcore, MergeDataArrayWithNullableVectors) {
     ASSERT_TRUE(merged_result->valid_data(2));
     ASSERT_TRUE(merged_result->valid_data(3));
     ASSERT_TRUE(merged_result->valid_data(4));
+}
+
+TEST(Util_Segcore, MergeDataArrayWithNullableByteVectorsAppendsRows) {
+    using namespace milvus;
+    using namespace milvus::segcore;
+
+    struct TestCase {
+        DataType data_type;
+        int64_t dim;
+        std::string metric_type;
+        int64_t bytes_per_row;
+    };
+
+    std::vector<TestCase> test_cases = {
+        {DataType::VECTOR_BINARY, 16, knowhere::metric::HAMMING, 2},
+        {DataType::VECTOR_FLOAT16, 2, knowhere::metric::L2, 4},
+        {DataType::VECTOR_BFLOAT16, 2, knowhere::metric::L2, 4},
+        {DataType::VECTOR_INT8, 3, knowhere::metric::L2, 3},
+    };
+
+    for (const auto& test_case : test_cases) {
+        SCOPED_TRACE(fmt::format("data_type={}", test_case.data_type));
+
+        auto schema = std::make_shared<Schema>();
+        auto vec = schema->AddDebugField("embeddings",
+                                         test_case.data_type,
+                                         test_case.dim,
+                                         test_case.metric_type,
+                                         true);
+        auto& field_meta = (*schema)[vec];
+
+        constexpr int64_t total_count = 4;
+        constexpr int64_t valid_count = 3;
+        std::array<bool, total_count> valid_flags = {true, false, true, true};
+
+        std::string compact_data(valid_count * test_case.bytes_per_row, '\0');
+        for (size_t i = 0; i < compact_data.size(); ++i) {
+            compact_data[i] = static_cast<char>(i + 1);
+        }
+
+        auto data_array = CreateVectorDataArrayFrom(compact_data.data(),
+                                                    valid_flags.data(),
+                                                    total_count,
+                                                    valid_count,
+                                                    field_meta);
+
+        std::map<FieldId, std::unique_ptr<milvus::DataArray>>
+            output_fields_data;
+        output_fields_data[vec] = std::move(data_array);
+
+        std::vector<MergeBase> merge_bases;
+        std::array<size_t, total_count> physical_offsets = {0, 0, 1, 2};
+        for (size_t i = 0; i < total_count; ++i) {
+            merge_bases.emplace_back(&output_fields_data, i);
+            if (valid_flags[i]) {
+                merge_bases.back().setValidDataOffset(vec, physical_offsets[i]);
+            }
+        }
+
+        auto merged_result = MergeDataArray(merge_bases, field_meta);
+
+        ASSERT_EQ(merged_result->valid_data().size(), total_count);
+        EXPECT_TRUE(merged_result->valid_data(0));
+        EXPECT_FALSE(merged_result->valid_data(1));
+        EXPECT_TRUE(merged_result->valid_data(2));
+        EXPECT_TRUE(merged_result->valid_data(3));
+
+        std::string actual;
+        switch (test_case.data_type) {
+            case DataType::VECTOR_BINARY:
+                actual = merged_result->vectors().binary_vector();
+                break;
+            case DataType::VECTOR_FLOAT16:
+                actual = merged_result->vectors().float16_vector();
+                break;
+            case DataType::VECTOR_BFLOAT16:
+                actual = merged_result->vectors().bfloat16_vector();
+                break;
+            case DataType::VECTOR_INT8:
+                actual = merged_result->vectors().int8_vector();
+                break;
+            default:
+                ThrowInfo(DataTypeInvalid, "unexpected test vector type");
+        }
+
+        ASSERT_EQ(actual.size(), compact_data.size());
+        EXPECT_EQ(actual, compact_data);
+    }
+}
+
+TEST(Util_Segcore, TransformBitsetMasksNullableVectorRowsOutsideLogicalView) {
+    using namespace milvus;
+
+    std::array<bool, 3> valid_data = {true, true, true};
+    OffsetMapping mapping;
+    mapping.Build(valid_data.data(), valid_data.size());
+
+    // Growing search passes a logical bitset sized by the query timestamp's
+    // active row count. Rows beyond that logical view are not visible yet and
+    // must be masked in the transformed physical bitset.
+    BitsetType logical_bitset(2);
+    BitsetView logical_view(logical_bitset);
+
+    auto physical_bitset = query::TransformBitset(logical_view, mapping);
+
+    ASSERT_EQ(physical_bitset.size(), 3);
+    EXPECT_FALSE(physical_bitset[0]);
+    EXPECT_FALSE(physical_bitset[1]);
+    EXPECT_TRUE(physical_bitset[2]);
+}
+
+TEST(Util_Segcore, TransformBitsetKeepsEmptyViewAsAllVisibleFastPath) {
+    using namespace milvus;
+
+    std::array<bool, 3> valid_data = {true, true, true};
+    OffsetMapping mapping;
+    mapping.Build(valid_data.data(), valid_data.size());
+
+    BitsetView all_visible;
+    auto physical_bitset = query::TransformBitset(all_visible, mapping);
+
+    EXPECT_TRUE(physical_bitset.empty());
 }
 
 // Tests for CheckCancellation utility function

--- a/internal/core/src/segcore/flush_growing_segment_test.cpp
+++ b/internal/core/src/segcore/flush_growing_segment_test.cpp
@@ -18,6 +18,8 @@
 #include "segcore/SegmentGrowingImpl.h"
 #include "test_utils/c_api_test_utils.h"
 #include "test_utils/DataGen.h"
+#include "storage/Util.h"
+#include "storage/loon_ffi/property_singleton.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/transaction/transaction.h"
 
@@ -46,6 +48,30 @@ class FlushGrowingSegmentTest : public ::testing::Test {
     }
 
     std::string test_dir_;
+
+    std::vector<FieldDataPtr>
+    ReadFlushedFieldData(const std::string& segment_path,
+                         const CFlushResult& result,
+                         FieldId field_id,
+                         DataType data_type,
+                         bool nullable,
+                         int64_t dim,
+                         DataType element_type = DataType::NONE) {
+        auto properties =
+            storage::LoonFFIPropertiesSingleton::GetInstance().GetProperties();
+        EXPECT_NE(properties, nullptr);
+        auto field_meta = gen_field_meta(
+            1, 2, 3, field_id.get(), data_type, element_type, nullable);
+        std::string manifest_json =
+            "{\"base_path\":\"" + segment_path +
+            "\",\"ver\":" + std::to_string(result.committed_version) + "}";
+        return storage::GetFieldDatasFromManifest(manifest_json,
+                                                  properties,
+                                                  field_meta,
+                                                  data_type,
+                                                  dim,
+                                                  element_type);
+    }
 
     void
     AssertManifestHasColumn(const std::string& segment_path,
@@ -360,6 +386,214 @@ TEST_F(FlushGrowingSegmentTest, FlushWithNullableFields) {
     ASSERT_EQ(result.num_rows, N);
 
     // cleanup
+    FreeFlushResult(&result);
+}
+
+TEST_F(FlushGrowingSegmentTest, FlushNullableFloatVectorKeepsCompactMapping) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto vec_fid =
+        schema->AddDebugField("vec", DataType::VECTOR_FLOAT, 2, "L2", true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    ASSERT_NE(segment, nullptr);
+
+    constexpr int N = 3;
+    std::vector<int64_t> row_ids = {0, 1, 2};
+    std::vector<Timestamp> timestamps = {10, 11, 12};
+    std::vector<int64_t> pks = {100, 101, 102};
+    bool valid_data[N] = {false, true, true};
+    std::vector<float> compact_vectors = {1.0F, 2.0F, 3.0F, 4.0F};
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    insert_data->set_num_rows(N);
+    auto pk_array =
+        CreateDataArrayFrom(pks.data(), nullptr, N, (*schema)[pk_fid]);
+    insert_data->mutable_fields_data()->AddAllocated(pk_array.release());
+    auto vec_array = CreateVectorDataArrayFrom(
+        compact_vectors.data(), valid_data, N, 2, (*schema)[vec_fid]);
+    insert_data->mutable_fields_data()->AddAllocated(vec_array.release());
+
+    segment->PreInsert(N);
+    segment->Insert(0, N, row_ids.data(), timestamps.data(), insert_data.get());
+
+    CFlushConfig config;
+    std::string segment_path = test_dir_ + "/segment_nullable_vec";
+    config.segment_path = segment_path.c_str();
+    config.read_version = -1;
+    config.retry_limit = 3;
+    config.text_field_ids = nullptr;
+    config.text_lob_paths = nullptr;
+    config.num_text_columns = 0;
+
+    CFlushResult result;
+    auto status =
+        FlushGrowingSegmentData(segment.get(), 0, N, &config, &result);
+
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_NE(result.manifest_path, nullptr);
+    ASSERT_EQ(result.num_rows, N);
+
+    auto field_datas = ReadFlushedFieldData(
+        segment_path, result, vec_fid, DataType::VECTOR_FLOAT, true, 2);
+    ASSERT_EQ(field_datas.size(), 1);
+    auto field_data = field_datas[0];
+    ASSERT_EQ(field_data->get_num_rows(), N);
+    ASSERT_EQ(field_data->get_valid_rows(), 2);
+    EXPECT_FALSE(field_data->is_valid(0));
+    ASSERT_TRUE(field_data->is_valid(1));
+    ASSERT_TRUE(field_data->is_valid(2));
+
+    auto row1 = static_cast<const float*>(field_data->RawValue(1));
+    auto row2 = static_cast<const float*>(field_data->RawValue(2));
+    ASSERT_NE(row1, nullptr);
+    ASSERT_NE(row2, nullptr);
+    EXPECT_FLOAT_EQ(row1[0], 1.0F);
+    EXPECT_FLOAT_EQ(row1[1], 2.0F);
+    EXPECT_FLOAT_EQ(row2[0], 3.0F);
+    EXPECT_FLOAT_EQ(row2[1], 4.0F);
+
+    FreeFlushResult(&result);
+}
+
+TEST_F(FlushGrowingSegmentTest, FlushNullableInt8VectorKeepsCompactMapping) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto vec_fid =
+        schema->AddDebugField("vec", DataType::VECTOR_INT8, 4, "L2", true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    ASSERT_NE(segment, nullptr);
+
+    constexpr int N = 3;
+    std::vector<int64_t> row_ids = {0, 1, 2};
+    std::vector<Timestamp> timestamps = {10, 11, 12};
+    std::vector<int64_t> pks = {100, 101, 102};
+    bool valid_data[N] = {true, false, true};
+    std::vector<int8> compact_vectors = {1, 2, 3, 4, 5, 6, 7, 8};
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    insert_data->set_num_rows(N);
+    auto pk_array =
+        CreateDataArrayFrom(pks.data(), nullptr, N, (*schema)[pk_fid]);
+    insert_data->mutable_fields_data()->AddAllocated(pk_array.release());
+    auto vec_array = CreateVectorDataArrayFrom(
+        compact_vectors.data(), valid_data, N, 2, (*schema)[vec_fid]);
+    insert_data->mutable_fields_data()->AddAllocated(vec_array.release());
+
+    segment->PreInsert(N);
+    segment->Insert(0, N, row_ids.data(), timestamps.data(), insert_data.get());
+
+    CFlushConfig config;
+    std::string segment_path = test_dir_ + "/segment_int8_vec";
+    config.segment_path = segment_path.c_str();
+    config.read_version = -1;
+    config.retry_limit = 3;
+    config.text_field_ids = nullptr;
+    config.text_lob_paths = nullptr;
+    config.num_text_columns = 0;
+
+    CFlushResult result;
+    auto status =
+        FlushGrowingSegmentData(segment.get(), 0, N, &config, &result);
+
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_EQ(result.num_rows, N);
+
+    auto field_datas = ReadFlushedFieldData(
+        segment_path, result, vec_fid, DataType::VECTOR_INT8, true, 4);
+    ASSERT_EQ(field_datas.size(), 1);
+    auto field_data = field_datas[0];
+    ASSERT_EQ(field_data->get_num_rows(), N);
+    ASSERT_EQ(field_data->get_valid_rows(), 2);
+    ASSERT_TRUE(field_data->is_valid(0));
+    EXPECT_FALSE(field_data->is_valid(1));
+    ASSERT_TRUE(field_data->is_valid(2));
+
+    auto row0 = static_cast<const int8*>(field_data->RawValue(0));
+    auto row2 = static_cast<const int8*>(field_data->RawValue(2));
+    ASSERT_NE(row0, nullptr);
+    ASSERT_NE(row2, nullptr);
+    EXPECT_EQ(std::vector<int8>(row0, row0 + 4),
+              std::vector<int8>({1, 2, 3, 4}));
+    EXPECT_EQ(std::vector<int8>(row2, row2 + 4),
+              std::vector<int8>({5, 6, 7, 8}));
+
+    FreeFlushResult(&result);
+}
+
+TEST_F(FlushGrowingSegmentTest, FlushNullableSparseVectorKeepsCompactMapping) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto vec_fid = schema->AddDebugField(
+        "vec", DataType::VECTOR_SPARSE_U32_F32, 0, std::nullopt, true);
+    schema->set_primary_field_id(pk_fid);
+
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    ASSERT_NE(segment, nullptr);
+
+    constexpr int N = 3;
+    std::vector<int64_t> row_ids = {0, 1, 2};
+    std::vector<Timestamp> timestamps = {10, 11, 12};
+    std::vector<int64_t> pks = {100, 101, 102};
+    bool valid_data[N] = {false, true, true};
+    auto sparse_vectors = GenerateRandomSparseFloatVector(2, 16, 0.5);
+
+    auto insert_data = std::make_unique<InsertRecordProto>();
+    insert_data->set_num_rows(N);
+    auto pk_array =
+        CreateDataArrayFrom(pks.data(), nullptr, N, (*schema)[pk_fid]);
+    insert_data->mutable_fields_data()->AddAllocated(pk_array.release());
+    auto vec_array = CreateVectorDataArrayFrom(
+        sparse_vectors.get(), valid_data, N, 2, (*schema)[vec_fid]);
+    insert_data->mutable_fields_data()->AddAllocated(vec_array.release());
+
+    segment->PreInsert(N);
+    segment->Insert(0, N, row_ids.data(), timestamps.data(), insert_data.get());
+
+    CFlushConfig config;
+    std::string segment_path = test_dir_ + "/segment_sparse_vec";
+    config.segment_path = segment_path.c_str();
+    config.read_version = -1;
+    config.retry_limit = 3;
+    config.text_field_ids = nullptr;
+    config.text_lob_paths = nullptr;
+    config.num_text_columns = 0;
+
+    CFlushResult result;
+    auto status =
+        FlushGrowingSegmentData(segment.get(), 0, N, &config, &result);
+
+    ASSERT_EQ(status.error_code, Success) << status.error_msg;
+    ASSERT_EQ(result.num_rows, N);
+
+    auto field_datas = ReadFlushedFieldData(segment_path,
+                                            result,
+                                            vec_fid,
+                                            DataType::VECTOR_SPARSE_U32_F32,
+                                            true,
+                                            0);
+    ASSERT_EQ(field_datas.size(), 1);
+    auto field_data = field_datas[0];
+    ASSERT_EQ(field_data->get_num_rows(), N);
+    ASSERT_EQ(field_data->get_valid_rows(), 2);
+    EXPECT_FALSE(field_data->is_valid(0));
+    ASSERT_TRUE(field_data->is_valid(1));
+    ASSERT_TRUE(field_data->is_valid(2));
+
+    auto row1 =
+        static_cast<const knowhere::sparse::SparseRow<SparseValueType>*>(
+            field_data->RawValue(1));
+    auto row2 =
+        static_cast<const knowhere::sparse::SparseRow<SparseValueType>*>(
+            field_data->RawValue(2));
+    ASSERT_NE(row1, nullptr);
+    ASSERT_NE(row2, nullptr);
+    EXPECT_EQ(row1->data_byte_size(), sparse_vectors[0].data_byte_size());
+    EXPECT_EQ(row2->data_byte_size(), sparse_vectors[1].data_byte_size());
+
     FreeFlushResult(&result);
 }
 

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "common/Common.h"
+#include "common/Consts.h"
 #include "common/EasyAssert.h"
 #include "common/LoadInfo.h"
 #include "common/OpContext.h"
@@ -904,9 +905,166 @@ GetElementByteWidth(milvus::DataType data_type, int64_t dim) {
             return dim * sizeof(milvus::float16);
         case milvus::DataType::VECTOR_BFLOAT16:
             return dim * sizeof(milvus::bfloat16);
+        case milvus::DataType::VECTOR_INT8:
+            return dim * sizeof(milvus::int8);
         default:
             return 0;  // variable length
     }
+}
+
+bool
+IsSupportedNullableVectorDataType(milvus::DataType data_type) {
+    switch (data_type) {
+        case milvus::DataType::VECTOR_FLOAT:
+        case milvus::DataType::VECTOR_BINARY:
+        case milvus::DataType::VECTOR_FLOAT16:
+        case milvus::DataType::VECTOR_BFLOAT16:
+        case milvus::DataType::VECTOR_INT8:
+        case milvus::DataType::VECTOR_SPARSE_U32_F32:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool
+IsFixedWidthVectorDataType(milvus::DataType data_type) {
+    return data_type == milvus::DataType::VECTOR_FLOAT ||
+           data_type == milvus::DataType::VECTOR_BINARY ||
+           data_type == milvus::DataType::VECTOR_FLOAT16 ||
+           data_type == milvus::DataType::VECTOR_BFLOAT16 ||
+           data_type == milvus::DataType::VECTOR_INT8;
+}
+
+const uint8_t*
+GetPhysicalVectorValue(const milvus::segcore::VectorBase* vec_base,
+                       int64_t physical_offset,
+                       int64_t byte_width) {
+    if (physical_offset < 0) {
+        return nullptr;
+    }
+
+    auto size_per_chunk = vec_base->get_size_per_chunk();
+    auto chunk_id = physical_offset / size_per_chunk;
+    auto offset_in_chunk = physical_offset % size_per_chunk;
+    auto chunk_data = vec_base->get_chunk_data(chunk_id);
+    return static_cast<const uint8_t*>(chunk_data) +
+           offset_in_chunk * byte_width;
+}
+
+arrow::Result<std::shared_ptr<arrow::Array>>
+BuildNullableFixedWidthVectorArray(const FieldInfo& field_info,
+                                   int64_t start_offset,
+                                   int64_t num_rows,
+                                   int64_t byte_width) {
+    if (!field_info.valid_data) {
+        return arrow::Status::Invalid(
+            "nullable vector field missing ValidData");
+    }
+
+    bool all_valid = true;
+    for (int64_t i = 0; i < num_rows; i++) {
+        if (!field_info.valid_data->is_valid(start_offset + i)) {
+            all_valid = false;
+            break;
+        }
+    }
+    if (all_valid && num_rows > 0) {
+        auto physical_offset =
+            field_info.vec_base->get_physical_offset(start_offset);
+        auto size_per_chunk = field_info.vec_base->get_size_per_chunk();
+        if (physical_offset >= 0 &&
+            physical_offset / size_per_chunk ==
+                (physical_offset + num_rows - 1) / size_per_chunk &&
+            num_rows * byte_width <= std::numeric_limits<int32_t>::max()) {
+            auto value = GetPhysicalVectorValue(
+                field_info.vec_base, physical_offset, byte_width);
+            if (value == nullptr) {
+                return arrow::Status::Invalid(
+                    "valid nullable vector row missing physical data");
+            }
+
+            ARROW_ASSIGN_OR_RAISE(
+                auto offsets_buffer,
+                arrow::AllocateBuffer((num_rows + 1) * sizeof(int32_t)));
+            auto offsets =
+                reinterpret_cast<int32_t*>(offsets_buffer->mutable_data());
+            for (int64_t i = 0; i <= num_rows; i++) {
+                offsets[i] = static_cast<int32_t>(i * byte_width);
+            }
+            std::shared_ptr<arrow::Buffer> offsets_buffer_shared(
+                std::move(offsets_buffer));
+            auto data_buffer =
+                arrow::Buffer::Wrap(value, num_rows * byte_width);
+            return std::make_shared<arrow::BinaryArray>(
+                num_rows, offsets_buffer_shared, data_buffer, nullptr, 0);
+        }
+    }
+
+    arrow::BinaryBuilder builder;
+    ARROW_RETURN_NOT_OK(builder.Reserve(num_rows));
+
+    for (int64_t i = 0; i < num_rows; i++) {
+        auto logical_offset = start_offset + i;
+        if (!field_info.valid_data->is_valid(logical_offset)) {
+            ARROW_RETURN_NOT_OK(builder.AppendNull());
+            continue;
+        }
+
+        auto physical_offset =
+            field_info.vec_base->get_physical_offset(logical_offset);
+        auto value = GetPhysicalVectorValue(
+            field_info.vec_base, physical_offset, byte_width);
+        if (value == nullptr) {
+            return arrow::Status::Invalid(
+                "valid nullable vector row missing physical data");
+        }
+        ARROW_RETURN_NOT_OK(builder.Append(value, byte_width));
+    }
+
+    return builder.Finish();
+}
+
+arrow::Result<std::shared_ptr<arrow::Array>>
+BuildSparseFloatVectorArrayForChunk(const FieldInfo& field_info,
+                                    int64_t start_offset,
+                                    int64_t num_rows) {
+    arrow::BinaryBuilder builder;
+    ARROW_RETURN_NOT_OK(builder.Reserve(num_rows));
+
+    for (int64_t i = 0; i < num_rows; i++) {
+        auto logical_offset = start_offset + i;
+        if (field_info.valid_data &&
+            !field_info.valid_data->is_valid(logical_offset)) {
+            ARROW_RETURN_NOT_OK(builder.AppendNull());
+            continue;
+        }
+
+        auto physical_offset =
+            field_info.vec_base->get_physical_offset(logical_offset);
+        if (physical_offset < 0) {
+            return arrow::Status::Invalid(
+                "valid nullable sparse vector row missing physical data");
+        }
+
+        auto size_per_chunk = field_info.vec_base->get_size_per_chunk();
+        auto chunk_id = physical_offset / size_per_chunk;
+        auto offset_in_chunk = physical_offset % size_per_chunk;
+        auto chunk_data = field_info.vec_base->get_chunk_data(chunk_id);
+        auto rows = static_cast<
+            const knowhere::sparse::SparseRow<milvus::SparseValueType>*>(
+            chunk_data);
+        auto row = rows + offset_in_chunk;
+        auto byte_size = row->data_byte_size();
+        if (byte_size == 0) {
+            ARROW_RETURN_NOT_OK(builder.Append(""));
+        } else {
+            ARROW_RETURN_NOT_OK(builder.Append(
+                static_cast<const uint8_t*>(row->data()), byte_size));
+        }
+    }
+
+    return builder.Finish();
 }
 
 // build Arrow Array for a single chunk of fixed-size data (zero-copy when possible)
@@ -1083,42 +1241,67 @@ BuildArrayForChunk(const FieldInfo& field_info,
                    int64_t offset_in_chunk,
                    int64_t num_rows,
                    int64_t global_offset) {
-    const void* chunk_data = field_info.vec_base->get_chunk_data(chunk_id);
     int64_t element_size =
         GetElementByteWidth(field_info.data_type, field_info.dim);
 
-    // adjust data pointer for offset within chunk
-    const uint8_t* data_ptr = static_cast<const uint8_t*>(chunk_data) +
-                              offset_in_chunk * element_size;
+    auto get_data_ptr = [&]() {
+        const void* chunk_data = field_info.vec_base->get_chunk_data(chunk_id);
+        return static_cast<const uint8_t*>(chunk_data) +
+               offset_in_chunk * element_size;
+    };
 
     switch (field_info.data_type) {
         case milvus::DataType::BOOL:
             return BuildBoolArrayForChunk(
-                data_ptr, num_rows, field_info.valid_data, global_offset);
+                get_data_ptr(), num_rows, field_info.valid_data, global_offset);
 
         case milvus::DataType::INT8:
             return WrapChunkAsArrowArray<arrow::Int8Array>(
-                data_ptr, num_rows, 1, field_info.valid_data, global_offset);
+                get_data_ptr(),
+                num_rows,
+                1,
+                field_info.valid_data,
+                global_offset);
 
         case milvus::DataType::INT16:
             return WrapChunkAsArrowArray<arrow::Int16Array>(
-                data_ptr, num_rows, 2, field_info.valid_data, global_offset);
+                get_data_ptr(),
+                num_rows,
+                2,
+                field_info.valid_data,
+                global_offset);
 
         case milvus::DataType::INT32:
             return WrapChunkAsArrowArray<arrow::Int32Array>(
-                data_ptr, num_rows, 4, field_info.valid_data, global_offset);
+                get_data_ptr(),
+                num_rows,
+                4,
+                field_info.valid_data,
+                global_offset);
 
         case milvus::DataType::INT64:
             return WrapChunkAsArrowArray<arrow::Int64Array>(
-                data_ptr, num_rows, 8, field_info.valid_data, global_offset);
+                get_data_ptr(),
+                num_rows,
+                8,
+                field_info.valid_data,
+                global_offset);
 
         case milvus::DataType::FLOAT:
             return WrapChunkAsArrowArray<arrow::FloatArray>(
-                data_ptr, num_rows, 4, field_info.valid_data, global_offset);
+                get_data_ptr(),
+                num_rows,
+                4,
+                field_info.valid_data,
+                global_offset);
 
         case milvus::DataType::DOUBLE:
             return WrapChunkAsArrowArray<arrow::DoubleArray>(
-                data_ptr, num_rows, 8, field_info.valid_data, global_offset);
+                get_data_ptr(),
+                num_rows,
+                8,
+                field_info.valid_data,
+                global_offset);
 
         case milvus::DataType::VARCHAR:
         case milvus::DataType::STRING: {
@@ -1207,16 +1390,25 @@ BuildArrayForChunk(const FieldInfo& field_info,
         case milvus::DataType::VECTOR_FLOAT:
         case milvus::DataType::VECTOR_BINARY:
         case milvus::DataType::VECTOR_FLOAT16:
-        case milvus::DataType::VECTOR_BFLOAT16: {
+        case milvus::DataType::VECTOR_BFLOAT16:
+        case milvus::DataType::VECTOR_INT8: {
+            if (field_info.nullable) {
+                return BuildNullableFixedWidthVectorArray(
+                    field_info, global_offset, num_rows, element_size);
+            }
             auto arrow_type =
                 milvus::GetArrowDataType(field_info.data_type, field_info.dim);
-            return WrapChunkAsFixedSizeBinaryArray(data_ptr,
+            return WrapChunkAsFixedSizeBinaryArray(get_data_ptr(),
                                                    num_rows,
                                                    element_size,
                                                    arrow_type,
                                                    field_info.valid_data,
                                                    global_offset);
         }
+
+        case milvus::DataType::VECTOR_SPARSE_U32_F32:
+            return BuildSparseFloatVectorArrayForChunk(
+                field_info, global_offset, num_rows);
 
         default:
             return arrow::Status::NotImplemented("Unsupported data type");
@@ -1326,16 +1518,23 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
                 }
             }
 
-            auto arrow_type = milvus::GetArrowDataType(
-                field_meta.get_data_type(),
-                field_meta.is_vector() ? field_meta.get_dim() : 0);
+            auto data_type = field_meta.get_data_type();
+            auto dim = field_meta.is_vector() &&
+                               !milvus::IsSparseFloatVectorDataType(data_type)
+                           ? field_meta.get_dim()
+                           : 0;
+            auto arrow_type = milvus::GetArrowDataType(data_type, dim);
+            if (field_meta.is_nullable() &&
+                IsSupportedNullableVectorDataType(data_type)) {
+                arrow_type = arrow::binary();
+            }
 
             FieldInfo info;
             info.field_id = field_id;
             info.field_name = field_meta.get_name().get();
-            info.data_type = field_meta.get_data_type();
+            info.data_type = data_type;
             info.nullable = field_meta.is_nullable();
-            info.dim = field_meta.is_vector() ? field_meta.get_dim() : 0;
+            info.dim = dim;
             info.vec_base = vec_base;
             info.valid_data = nullptr;
             if (field_meta.is_nullable() &&
@@ -1353,9 +1552,17 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
             field_infos.push_back(std::move(info));
 
             // create Arrow field with metadata
-            auto metadata = arrow::KeyValueMetadata::Make(
-                {milvus_storage::ARROW_FIELD_ID_KEY},
-                {std::to_string(field_id.get())});
+            std::vector<std::string> metadata_keys = {
+                milvus_storage::ARROW_FIELD_ID_KEY};
+            std::vector<std::string> metadata_values = {
+                std::to_string(field_id.get())};
+            if (field_meta.is_nullable() &&
+                IsFixedWidthVectorDataType(data_type)) {
+                metadata_keys.push_back(DIM_KEY);
+                metadata_values.push_back(std::to_string(dim));
+            }
+            auto metadata =
+                arrow::KeyValueMetadata::Make(metadata_keys, metadata_values);
             arrow_fields.push_back(arrow::field(std::to_string(field_id.get()),
                                                 arrow_type,
                                                 field_meta.is_nullable(),

--- a/internal/core/src/storage/DataCodecTest.cpp
+++ b/internal/core/src/storage/DataCodecTest.cpp
@@ -329,6 +329,89 @@ TEST(storage, ExternalNullableFloatVectorBinaryIsAccepted) {
     ASSERT_EQ(normalized->type_id(), arrow::Type::BINARY);
 }
 
+TEST(storage, NullableFloatVectorArrowAllValidMaterializesValidData) {
+    std::array<float, 2> row0 = {1.0F, 2.0F};
+    std::array<float, 2> row1 = {3.0F, 4.0F};
+    arrow::BinaryBuilder builder;
+    ASSERT_TRUE(builder
+                    .Append(reinterpret_cast<const uint8_t*>(row0.data()),
+                            sizeof(float) * row0.size())
+                    .ok());
+    ASSERT_TRUE(builder
+                    .Append(reinterpret_cast<const uint8_t*>(row1.data()),
+                            sizeof(float) * row1.size())
+                    .ok());
+    std::shared_ptr<arrow::Array> binary_array;
+    ASSERT_TRUE(builder.Finish(&binary_array).ok());
+    ASSERT_EQ(binary_array->null_count(), 0);
+
+    auto field_data = storage::CreateFieldData(
+        storage::DataType::VECTOR_FLOAT, DataType::NONE, true, 2);
+    auto chunked_array = std::make_shared<arrow::ChunkedArray>(binary_array);
+    ASSERT_NO_THROW(field_data->FillFieldData(chunked_array));
+
+    ASSERT_EQ(field_data->get_num_rows(), 2);
+    ASSERT_EQ(field_data->get_valid_rows(), 2);
+    ASSERT_EQ(field_data->get_null_count(), 0);
+    ASSERT_TRUE(field_data->is_valid(0));
+    ASSERT_TRUE(field_data->is_valid(1));
+
+    auto actual0 = static_cast<const float*>(field_data->RawValue(0));
+    auto actual1 = static_cast<const float*>(field_data->RawValue(1));
+    ASSERT_NE(actual0, nullptr);
+    ASSERT_NE(actual1, nullptr);
+    EXPECT_FLOAT_EQ(actual0[0], row0[0]);
+    EXPECT_FLOAT_EQ(actual0[1], row0[1]);
+    EXPECT_FLOAT_EQ(actual1[0], row1[0]);
+    EXPECT_FLOAT_EQ(actual1[1], row1[1]);
+}
+
+TEST(storage, NullableFloatVectorArrowChunksAccumulateNullCount) {
+    std::array<float, 2> row0 = {1.0F, 2.0F};
+    std::array<float, 2> row3 = {7.0F, 8.0F};
+
+    arrow::BinaryBuilder first_builder;
+    ASSERT_TRUE(first_builder
+                    .Append(reinterpret_cast<const uint8_t*>(row0.data()),
+                            sizeof(float) * row0.size())
+                    .ok());
+    ASSERT_TRUE(first_builder.AppendNull().ok());
+    std::shared_ptr<arrow::Array> first_array;
+    ASSERT_TRUE(first_builder.Finish(&first_array).ok());
+
+    arrow::BinaryBuilder second_builder;
+    ASSERT_TRUE(second_builder.AppendNull().ok());
+    ASSERT_TRUE(second_builder
+                    .Append(reinterpret_cast<const uint8_t*>(row3.data()),
+                            sizeof(float) * row3.size())
+                    .ok());
+    std::shared_ptr<arrow::Array> second_array;
+    ASSERT_TRUE(second_builder.Finish(&second_array).ok());
+
+    auto field_data = storage::CreateFieldData(
+        storage::DataType::VECTOR_FLOAT, DataType::NONE, true, 2);
+    auto chunked_array = std::make_shared<arrow::ChunkedArray>(
+        arrow::ArrayVector{first_array, second_array});
+    ASSERT_NO_THROW(field_data->FillFieldData(chunked_array));
+
+    ASSERT_EQ(field_data->get_num_rows(), 4);
+    ASSERT_EQ(field_data->get_valid_rows(), 2);
+    ASSERT_EQ(field_data->get_null_count(), 2);
+    EXPECT_TRUE(field_data->is_valid(0));
+    EXPECT_FALSE(field_data->is_valid(1));
+    EXPECT_FALSE(field_data->is_valid(2));
+    EXPECT_TRUE(field_data->is_valid(3));
+
+    auto actual0 = static_cast<const float*>(field_data->RawValue(0));
+    auto actual3 = static_cast<const float*>(field_data->RawValue(3));
+    ASSERT_NE(actual0, nullptr);
+    ASSERT_NE(actual3, nullptr);
+    EXPECT_FLOAT_EQ(actual0[0], row0[0]);
+    EXPECT_FLOAT_EQ(actual0[1], row0[1]);
+    EXPECT_FLOAT_EQ(actual3[0], row3[0]);
+    EXPECT_FLOAT_EQ(actual3[1], row3[1]);
+}
+
 TEST(storage, ExternalBinaryVectorListNormalizeFails) {
     auto value_builder = std::make_shared<arrow::UInt8Builder>();
     arrow::ListBuilder builder(arrow::default_memory_pool(), value_builder);

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -74,6 +74,7 @@
 #include "index/BitmapIndex.h"
 #include "index/StringIndexMarisa.h"
 #include "index/StringIndexSort.h"
+#include "index/VectorDiskIndex.h"
 
 class DiskAnnFileManagerTest_CacheOptFieldToDiskCorrectDOUBLE_Test;
 class DiskAnnFileManagerTest_CacheOptFieldToDiskCorrectFLOAT_Test;
@@ -918,6 +919,7 @@ TEST_F(DiskAnnFileManagerTest, CacheRawDataToDiskValidDataFile) {
     storage::InsertData insert_data(payload_reader);
     FieldDataMeta field_data_meta = {
         collection_id, partition_id, segment_id, field_id};
+    field_data_meta.field_schema.set_nullable(true);
     insert_data.SetFieldDataMeta(field_data_meta);
     insert_data.SetTimestamps(0, 100);
 
@@ -956,16 +958,16 @@ TEST_F(DiskAnnFileManagerTest, CacheRawDataToDiskValidDataFile) {
     ASSERT_TRUE(local_chunk_manager->Exist(valid_data_path))
         << "valid_data file should be created for nullable field";
 
-    size_t read_total_num_rows = 0;
+    uint64_t read_total_num_rows = 0;
     local_chunk_manager->Read(
-        valid_data_path, 0, &read_total_num_rows, sizeof(size_t));
+        valid_data_path, 0, &read_total_num_rows, sizeof(uint64_t));
     EXPECT_EQ(read_total_num_rows, num_rows)
         << "total_num_rows should match original num_rows";
 
     size_t bitmap_size = (num_rows + 7) / 8;
     std::vector<uint8_t> read_bitmap(bitmap_size);
     local_chunk_manager->Read(
-        valid_data_path, sizeof(size_t), read_bitmap.data(), bitmap_size);
+        valid_data_path, sizeof(uint64_t), read_bitmap.data(), bitmap_size);
 
     // Verify bitmap content
     for (int64_t i = 0; i < num_rows; ++i) {
@@ -978,6 +980,140 @@ TEST_F(DiskAnnFileManagerTest, CacheRawDataToDiskValidDataFile) {
     local_chunk_manager->Remove(local_data_path);
     local_chunk_manager->Remove(valid_data_path);
     cm_->Remove(insert_file_path);
+}
+
+TEST_F(DiskAnnFileManagerTest, BuildAllNullNullableDiskVectorIndexFromDataset) {
+    const int64_t collection_id = 1;
+    const int64_t partition_id = 2;
+    const int64_t segment_id = 3001;
+    const int64_t field_id = 100;
+    const int64_t dim = 128;
+    const int64_t num_rows = 100;
+
+    FieldDataMeta field_data_meta = {
+        collection_id, partition_id, segment_id, field_id};
+    field_data_meta.field_schema.set_nullable(true);
+
+    IndexMeta index_meta = {segment_id,
+                            field_id,
+                            1000,
+                            1,
+                            "test",
+                            "vec_field",
+                            DataType::VECTOR_FLOAT,
+                            dim};
+    storage::FileManagerContext file_manager_context(
+        field_data_meta, index_meta, cm_, fs_);
+    milvus::index::VectorDiskAnnIndex<float> index(
+        DataType::NONE,
+        knowhere::IndexEnum::INDEX_DISKANN,
+        knowhere::metric::L2,
+        knowhere::Version::GetCurrentVersion().VersionNumber(),
+        file_manager_context);
+
+    std::unique_ptr<bool[]> valid_data(new bool[num_rows]);
+    std::fill_n(valid_data.get(), num_rows, false);
+    index.UpdateValidData(valid_data.get(), num_rows);
+    ASSERT_TRUE(index.GetOffsetMapping().IsEnabled());
+    ASSERT_EQ(index.GetOffsetMapping().GetTotalCount(), num_rows);
+    ASSERT_EQ(index.GetOffsetMapping().GetValidCount(), 0);
+
+    std::vector<float> vec_data(dim, 0.0f);
+    auto dataset = knowhere::GenDataSet(0, dim, vec_data.data());
+
+    milvus::Config config;
+    config[DIM_KEY] = dim;
+    config[milvus::index::DISK_ANN_BUILD_THREAD_NUM] = "1";
+
+    index.BuildWithDataset(dataset, config);
+
+    ASSERT_TRUE(index.GetOffsetMapping().IsEnabled());
+    EXPECT_EQ(index.GetOffsetMapping().GetTotalCount(), num_rows);
+    EXPECT_EQ(index.GetOffsetMapping().GetValidCount(), 0);
+    EXPECT_EQ(index.GetDim(), dim);
+
+    auto stats = index.Upload(config);
+    auto files = stats->GetIndexFiles();
+    ASSERT_EQ(files.size(), 1);
+    EXPECT_NE(files[0].find(milvus::index::VALID_DATA_KEY), std::string::npos);
+
+    for (const auto& file : files) {
+        cm_->Remove(file);
+    }
+}
+
+TEST_F(DiskAnnFileManagerTest, LoadAllNullNullableDiskVectorIndexFromDataset) {
+    const int64_t collection_id = 1;
+    const int64_t partition_id = 2;
+    const int64_t segment_id = 3002;
+    const int64_t field_id = 100;
+    const int64_t dim = 128;
+    const int64_t num_rows = 100;
+
+    FieldDataMeta field_data_meta = {
+        collection_id, partition_id, segment_id, field_id};
+    field_data_meta.field_schema.set_nullable(true);
+
+    IndexMeta index_meta = {segment_id,
+                            field_id,
+                            1000,
+                            1,
+                            "test",
+                            "vec_field",
+                            DataType::VECTOR_FLOAT,
+                            dim};
+    storage::FileManagerContext file_manager_context(
+        field_data_meta, index_meta, cm_, fs_);
+
+    std::vector<std::string> files;
+    {
+        milvus::index::VectorDiskAnnIndex<float> index(
+            DataType::NONE,
+            knowhere::IndexEnum::INDEX_DISKANN,
+            knowhere::metric::L2,
+            knowhere::Version::GetCurrentVersion().VersionNumber(),
+            file_manager_context);
+
+        std::unique_ptr<bool[]> valid_data(new bool[num_rows]);
+        std::fill_n(valid_data.get(), num_rows, false);
+        index.UpdateValidData(valid_data.get(), num_rows);
+
+        std::vector<float> vec_data(dim, 0.0f);
+        auto dataset = knowhere::GenDataSet(0, dim, vec_data.data());
+
+        milvus::Config config;
+        config[DIM_KEY] = dim;
+        config[milvus::index::DISK_ANN_BUILD_THREAD_NUM] = "1";
+
+        index.BuildWithDataset(dataset, config);
+        auto stats = index.Upload(config);
+        files = stats->GetIndexFiles();
+    }
+
+    ASSERT_EQ(files.size(), 1);
+    EXPECT_NE(files[0].find(milvus::index::VALID_DATA_KEY), std::string::npos);
+
+    milvus::index::VectorDiskAnnIndex<float> loaded_index(
+        DataType::NONE,
+        knowhere::IndexEnum::INDEX_DISKANN,
+        knowhere::metric::L2,
+        knowhere::Version::GetCurrentVersion().VersionNumber(),
+        file_manager_context);
+
+    milvus::Config load_config;
+    load_config[DIM_KEY] = dim;
+    load_config[milvus::index::DISK_ANN_LOAD_THREAD_NUM] = "1";
+    load_config["index_files"] = files;
+
+    loaded_index.Load(milvus::tracer::TraceContext{}, load_config);
+    ASSERT_TRUE(loaded_index.GetOffsetMapping().IsEnabled());
+    EXPECT_EQ(loaded_index.GetOffsetMapping().GetTotalCount(), num_rows);
+    EXPECT_EQ(loaded_index.GetOffsetMapping().GetValidCount(), 0);
+    EXPECT_EQ(loaded_index.GetDim(), dim);
+
+    for (const auto& file : files) {
+        cm_->Remove(file);
+    }
 }
 
 TEST_F(DiskAnnFileManagerTest, CacheRawDataToDiskNoValidDataForNonNullable) {

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -29,6 +29,7 @@
 #include "common/FieldMeta.h"
 #include "common/Schema.h"
 #include "common/Types.h"
+#include "common/Utils.h"
 #include "common/VirtualPK.h"
 #include "gtest/gtest.h"
 #include "knowhere/comp/index_param.h"
@@ -47,6 +48,11 @@ namespace {
 
 constexpr int64_t kTestRows = 5;
 constexpr int64_t kVecDim = 4;
+
+ChunkedSegmentSealedImpl*
+CreateExternalSegment(SegmentSealedUPtr& holder,
+                      const SchemaPtr& schema,
+                      int64_t segment_id);
 
 // Mock Reader that returns a pre-built Arrow Table from take().
 class MockTakeReader : public milvus_storage::api::Reader {
@@ -230,6 +236,243 @@ BuildNullableVectorArrowTable() {
         arrow::field("vec_col", fsb_type),
     });
     return arrow::Table::Make(schema, {vec_arr});
+}
+
+struct ExternalNullableVectorSchema {
+    SchemaPtr schema;
+    FieldId pk_id;
+    FieldId vec_id;
+    DataType data_type;
+    int64_t dim;
+};
+
+ExternalNullableVectorSchema
+BuildExternalNullableVectorSchema(DataType data_type, int64_t dim) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    ExternalNullableVectorSchema info;
+    info.pk_id = FieldId(100);
+    info.vec_id = FieldId(101);
+    info.data_type = data_type;
+    info.dim = dim;
+
+    schema->AddField(FieldMeta(FieldName("pk"),
+                               info.pk_id,
+                               DataType::INT64,
+                               false,
+                               std::nullopt,
+                               "pk"));
+    schema->AddField(FieldMeta(FieldName("vec_col"),
+                               info.vec_id,
+                               data_type,
+                               dim,
+                               knowhere::metric::L2,
+                               true,
+                               std::nullopt,
+                               "vec_col"));
+    schema->set_primary_field_id(info.pk_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+    info.schema = schema;
+    return info;
+}
+
+int64_t
+DenseVectorByteWidth(DataType data_type, int64_t dim) {
+    switch (data_type) {
+        case DataType::VECTOR_BINARY:
+            return (dim + 7) / 8;
+        case DataType::VECTOR_FLOAT16:
+        case DataType::VECTOR_BFLOAT16:
+            return dim * 2;
+        case DataType::VECTOR_INT8:
+            return dim;
+        default:
+            return dim * sizeof(float);
+    }
+}
+
+std::string
+MakeBytes(int64_t byte_width, uint8_t start) {
+    std::string bytes;
+    bytes.resize(byte_width);
+    for (int64_t i = 0; i < byte_width; ++i) {
+        bytes[i] = static_cast<char>(start + i);
+    }
+    return bytes;
+}
+
+std::shared_ptr<arrow::Table>
+BuildNullableDenseVectorArrowTable(DataType data_type, int64_t dim) {
+    auto byte_width = DenseVectorByteWidth(data_type, dim);
+    auto fsb_type = arrow::fixed_size_binary(byte_width);
+    arrow::FixedSizeBinaryBuilder builder(fsb_type);
+    auto row0 = MakeBytes(byte_width, 1);
+    auto row2 = MakeBytes(byte_width, 101);
+    EXPECT_TRUE(
+        builder.Append(reinterpret_cast<const uint8_t*>(row0.data())).ok());
+    EXPECT_TRUE(builder.AppendNull().ok());
+    EXPECT_TRUE(
+        builder.Append(reinterpret_cast<const uint8_t*>(row2.data())).ok());
+    auto vec_arr = builder.Finish().ValueOrDie();
+
+    auto schema = arrow::schema({
+        arrow::field("vec_col", fsb_type),
+    });
+    return arrow::Table::Make(schema, {vec_arr});
+}
+
+std::string
+MakeSparseContent(uint32_t id, SparseValueType value) {
+    knowhere::sparse::SparseRow<SparseValueType> row(1);
+    row.set_at(0, id, value);
+    return std::string(reinterpret_cast<const char*>(row.data()),
+                       row.data_byte_size());
+}
+
+std::shared_ptr<arrow::Table>
+BuildNullableSparseVectorArrowTable(std::string* row0, std::string* row2) {
+    *row0 = MakeSparseContent(3, 1.5F);
+    *row2 = MakeSparseContent(7, 2.5F);
+
+    arrow::BinaryBuilder builder;
+    EXPECT_TRUE(builder
+                    .Append(reinterpret_cast<const uint8_t*>(row0->data()),
+                            row0->size())
+                    .ok());
+    EXPECT_TRUE(builder.AppendNull().ok());
+    EXPECT_TRUE(builder
+                    .Append(reinterpret_cast<const uint8_t*>(row2->data()),
+                            row2->size())
+                    .ok());
+    auto vec_arr = builder.Finish().ValueOrDie();
+
+    auto schema = arrow::schema({
+        arrow::field("vec_col", arrow::binary()),
+    });
+    return arrow::Table::Make(schema, {vec_arr});
+}
+
+void
+AssertNullableDenseVectorTake(DataType data_type, int64_t dim) {
+    auto info = BuildExternalNullableVectorSchema(data_type, dim);
+    auto table = BuildNullableDenseVectorArrowTable(data_type, dim);
+    auto byte_width = DenseVectorByteWidth(data_type, dim);
+    auto row0 = MakeBytes(byte_width, 1);
+    auto row2 = MakeBytes(byte_width, 101);
+    auto expected = row0 + row2;
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema, 1);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::RetrievePlan>(info.schema);
+    plan->field_ids_ = {info.vec_id};
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 1, 2};
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), offsets.size(), false, false);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 1);
+
+    const auto& retrieved = results->fields_data(0);
+    ASSERT_EQ(retrieved.valid_data_size(), 3);
+    EXPECT_TRUE(retrieved.valid_data(0));
+    EXPECT_FALSE(retrieved.valid_data(1));
+    EXPECT_TRUE(retrieved.valid_data(2));
+    ASSERT_EQ(retrieved.vectors().dim(), dim);
+
+    std::string actual;
+    switch (data_type) {
+        case DataType::VECTOR_BINARY:
+            actual = retrieved.vectors().binary_vector();
+            break;
+        case DataType::VECTOR_FLOAT16:
+            actual = retrieved.vectors().float16_vector();
+            break;
+        case DataType::VECTOR_BFLOAT16:
+            actual = retrieved.vectors().bfloat16_vector();
+            break;
+        case DataType::VECTOR_INT8:
+            actual = retrieved.vectors().int8_vector();
+            break;
+        default:
+            FAIL() << "unsupported dense vector type";
+    }
+    ASSERT_EQ(actual.size(), expected.size());
+    EXPECT_EQ(actual, expected);
+
+    auto search_plan = std::make_unique<query::Plan>(info.schema);
+    search_plan->target_entries_ = {info.vec_id};
+    SearchResult search_results;
+    ok = segment->TestTryTakeForSearch(
+        search_plan.get(), offsets.data(), offsets.size(), search_results);
+    ASSERT_TRUE(ok);
+    auto& searched = search_results.output_fields_data_.at(info.vec_id);
+    ASSERT_EQ(searched->valid_data_size(), 3);
+    EXPECT_TRUE(searched->valid_data(0));
+    EXPECT_FALSE(searched->valid_data(1));
+    EXPECT_TRUE(searched->valid_data(2));
+    ASSERT_EQ(searched->vectors().dim(), dim);
+}
+
+void
+AssertNullableSparseVectorTake() {
+    auto info =
+        BuildExternalNullableVectorSchema(DataType::VECTOR_SPARSE_U32_F32, 0);
+    std::string row0;
+    std::string row2;
+    auto table = BuildNullableSparseVectorArrowTable(&row0, &row2);
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema, 1);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::RetrievePlan>(info.schema);
+    plan->field_ids_ = {info.vec_id};
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 1, 2};
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), offsets.size(), false, false);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 1);
+
+    const auto& retrieved = results->fields_data(0);
+    ASSERT_EQ(retrieved.valid_data_size(), 3);
+    EXPECT_TRUE(retrieved.valid_data(0));
+    EXPECT_FALSE(retrieved.valid_data(1));
+    EXPECT_TRUE(retrieved.valid_data(2));
+    const auto& sparse = retrieved.vectors().sparse_float_vector();
+    ASSERT_EQ(sparse.contents_size(), 2);
+    EXPECT_EQ(sparse.contents(0), row0);
+    EXPECT_EQ(sparse.contents(1), row2);
+    EXPECT_EQ(sparse.dim(), 8);
+
+    auto search_plan = std::make_unique<query::Plan>(info.schema);
+    search_plan->target_entries_ = {info.vec_id};
+    SearchResult search_results;
+    ok = segment->TestTryTakeForSearch(
+        search_plan.get(), offsets.data(), offsets.size(), search_results);
+    ASSERT_TRUE(ok);
+    auto& searched = search_results.output_fields_data_.at(info.vec_id);
+    ASSERT_EQ(searched->valid_data_size(), 3);
+    EXPECT_TRUE(searched->valid_data(0));
+    EXPECT_FALSE(searched->valid_data(1));
+    EXPECT_TRUE(searched->valid_data(2));
+    const auto& search_sparse = searched->vectors().sparse_float_vector();
+    ASSERT_EQ(search_sparse.contents_size(), 2);
+    EXPECT_EQ(search_sparse.contents(0), row0);
+    EXPECT_EQ(search_sparse.contents(1), row2);
+    EXPECT_EQ(search_sparse.dim(), 8);
 }
 
 // Build an external schema with all supported types.
@@ -809,6 +1052,26 @@ TEST(ExternalTakeTest, TryTakeForSearch_NullableVectorUsesCompactData) {
     EXPECT_FLOAT_EQ(fv.data(5), 9.0f);
     EXPECT_FLOAT_EQ(fv.data(6), 10.0f);
     EXPECT_FLOAT_EQ(fv.data(7), 11.0f);
+}
+
+TEST(ExternalTakeTest, NullableBinaryVectorTakeUsesCompactData) {
+    AssertNullableDenseVectorTake(DataType::VECTOR_BINARY, 16);
+}
+
+TEST(ExternalTakeTest, NullableFloat16VectorTakeUsesCompactData) {
+    AssertNullableDenseVectorTake(DataType::VECTOR_FLOAT16, 4);
+}
+
+TEST(ExternalTakeTest, NullableBFloat16VectorTakeUsesCompactData) {
+    AssertNullableDenseVectorTake(DataType::VECTOR_BFLOAT16, 4);
+}
+
+TEST(ExternalTakeTest, NullableInt8VectorTakeUsesCompactData) {
+    AssertNullableDenseVectorTake(DataType::VECTOR_INT8, 4);
+}
+
+TEST(ExternalTakeTest, NullableSparseVectorTakeUsesCompactData) {
+    AssertNullableSparseVectorTake();
 }
 
 // Test fallback: returns false for non-external collection

--- a/internal/core/unittest/test_utils/SegcoreConfigUtils.h
+++ b/internal/core/unittest/test_utils/SegcoreConfigUtils.h
@@ -1,0 +1,124 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+// the specific language governing permissions and limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "knowhere/index/index_factory.h"
+#include "segcore/SegcoreConfig.h"
+
+namespace milvus::segcore {
+
+inline std::string
+RefineTypeToConfigStringForTest(knowhere::RefineType refine_type) {
+    if (refine_type == knowhere::RefineType::DATA_VIEW) {
+        return "NONE";
+    }
+    if (refine_type == knowhere::RefineType::BFLOAT16_QUANT) {
+        return "BFLOAT16";
+    }
+    if (refine_type == knowhere::RefineType::FLOAT16_QUANT) {
+        return "FLOAT16";
+    }
+    if (refine_type == knowhere::RefineType::UINT8_QUANT) {
+        return "UINT8";
+    }
+    ThrowInfo(Unsupported, "unsupported refine type for test config restore");
+}
+
+class ScopedSegcoreConfigRestore {
+ public:
+    explicit ScopedSegcoreConfigRestore(
+        SegcoreConfig& config = SegcoreConfig::default_config())
+        : config_(config),
+          chunk_rows_(config.get_chunk_rows()),
+          nlist_(config.get_nlist()),
+          nprobe_(config.get_nprobe()),
+          enable_interim_segment_index_(
+              config.get_enable_interim_segment_index()),
+          sub_dim_(config.get_sub_dim()),
+          refine_ratio_(config.get_refine_ratio()),
+          dense_vector_interim_index_type_(
+              config.get_dense_vector_intermin_index_type()),
+          refine_quant_type_(
+              RefineTypeToConfigStringForTest(config.get_refine_quant_type())),
+          refine_with_quant_flag_(config.get_refine_with_quant_flag()) {
+    }
+
+    ~ScopedSegcoreConfigRestore() {
+        config_.set_chunk_rows(chunk_rows_);
+        config_.set_nlist(nlist_);
+        config_.set_nprobe(nprobe_);
+        config_.set_enable_interim_segment_index(enable_interim_segment_index_);
+        config_.set_sub_dim(sub_dim_);
+        config_.set_refine_ratio(refine_ratio_);
+        config_.set_dense_vector_intermin_index_type(
+            dense_vector_interim_index_type_);
+        config_.set_refine_quant_type(refine_quant_type_);
+        config_.set_refine_with_quant_flag(refine_with_quant_flag_);
+    }
+
+    ScopedSegcoreConfigRestore(const ScopedSegcoreConfigRestore&) = delete;
+    ScopedSegcoreConfigRestore&
+    operator=(const ScopedSegcoreConfigRestore&) = delete;
+
+ private:
+    SegcoreConfig& config_;
+    int64_t chunk_rows_;
+    int64_t nlist_;
+    int64_t nprobe_;
+    bool enable_interim_segment_index_;
+    int64_t sub_dim_;
+    float refine_ratio_;
+    std::string dense_vector_interim_index_type_;
+    std::string refine_quant_type_;
+    bool refine_with_quant_flag_;
+};
+
+struct InterimIndexConfigForTest {
+    bool enable_interim_segment_index = true;
+    int64_t chunk_rows = 32 * 1024;
+    int64_t nlist = 100;
+    int64_t nprobe = 4;
+    std::optional<std::string> dense_vector_interim_index_type = std::nullopt;
+    int64_t sub_dim = 2;
+    float refine_ratio = 3.0F;
+    std::string refine_quant_type = "NONE";
+    bool refine_with_quant_flag = false;
+};
+
+inline void
+ApplyInterimIndexConfigForTest(
+    const InterimIndexConfigForTest& options,
+    SegcoreConfig& config = SegcoreConfig::default_config()) {
+    config.set_chunk_rows(options.chunk_rows);
+    config.set_enable_interim_segment_index(
+        options.enable_interim_segment_index);
+    config.set_nlist(options.nlist);
+    config.set_nprobe(options.nprobe);
+    if (options.dense_vector_interim_index_type.has_value()) {
+        config.set_dense_vector_intermin_index_type(
+            options.dense_vector_interim_index_type.value());
+    }
+
+    if (options.dense_vector_interim_index_type.has_value() &&
+        options.dense_vector_interim_index_type.value() ==
+            knowhere::IndexEnum::INDEX_FAISS_SCANN_DVR) {
+        config.set_sub_dim(options.sub_dim);
+        config.set_refine_ratio(options.refine_ratio);
+        config.set_refine_quant_type(options.refine_quant_type);
+        config.set_refine_with_quant_flag(options.refine_with_quant_flag);
+    }
+}
+
+}  // namespace milvus::segcore

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -755,7 +755,8 @@ func (h *HandlersV1) insert(c *gin.Context) {
 			return nil, RestRequestInterceptorErr
 		}
 		body, _ := c.Get(gin.BodyBytesKey)
-		httpReq.Data, _, err = checkAndSetData(body.([]byte), collSchema, false)
+		var validDataMap map[string][]bool
+		httpReq.Data, validDataMap, err = checkAndSetData(body.([]byte), collSchema, false)
 		if err != nil {
 			log.Warn("high level restful api, fail to deal with insert data", zap.Any("body", body), zap.Error(err))
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
@@ -765,7 +766,7 @@ func (h *HandlersV1) insert(c *gin.Context) {
 			return nil, RestRequestInterceptorErr
 		}
 		insertReq := req.(*milvuspb.InsertRequest)
-		insertReq.FieldsData, err = anyToColumns(httpReq.Data, nil, collSchema, true, false)
+		insertReq.FieldsData, err = anyToColumns(httpReq.Data, validDataMap, collSchema, true, false)
 		if err != nil {
 			log.Warn("high level restful api, fail to deal with insert data", zap.Any("data", httpReq.Data), zap.Error(err))
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
@@ -873,7 +874,8 @@ func (h *HandlersV1) upsert(c *gin.Context) {
 			}
 		}
 		body, _ := c.Get(gin.BodyBytesKey)
-		httpReq.Data, _, err = checkAndSetData(body.([]byte), collSchema, httpReq.PartialUpdate)
+		var validDataMap map[string][]bool
+		httpReq.Data, validDataMap, err = checkAndSetData(body.([]byte), collSchema, httpReq.PartialUpdate)
 		if err != nil {
 			log.Warn("high level restful api, fail to deal with upsert data", zap.Any("body", body), zap.Error(err))
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
@@ -883,7 +885,7 @@ func (h *HandlersV1) upsert(c *gin.Context) {
 			return nil, RestRequestInterceptorErr
 		}
 		upsertReq := req.(*milvuspb.UpsertRequest)
-		upsertReq.FieldsData, err = anyToColumns(httpReq.Data, nil, collSchema, false, httpReq.PartialUpdate)
+		upsertReq.FieldsData, err = anyToColumns(httpReq.Data, validDataMap, collSchema, false, httpReq.PartialUpdate)
 		if err != nil {
 			log.Warn("high level restful api, fail to deal with upsert data", zap.Any("data", httpReq.Data), zap.Error(err))
 			HTTPAbortReturn(c, http.StatusOK, gin.H{

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -2967,7 +2967,7 @@ func TestSearchV2(t *testing.T) {
 	queryTestCases = append(queryTestCases, requestBodyTestCase{
 		path:        SearchAction,
 		requestBody: []byte(`{"collectionName": "book", "data": [[0.1, 0.2]], "annsField": "binaryVector", "filter": "book_id in [2, 4, 6, 8]", "limit": 4, "outputFields": ["word_count"]}`),
-		errMsg:      "can only accept json format request, error: Mismatch type uint8",
+		errMsg:      "can only accept json format request, error: Mismatch type",
 		errCode:     1801,
 	})
 	queryTestCases = append(queryTestCases, requestBodyTestCase{

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -1567,6 +1567,7 @@ func newFieldDataRowAccessor(fieldData *schemapb.FieldData) (*fieldDataRowAccess
 	if len(accessor.validData) == 0 {
 		return accessor, nil
 	}
+	isNullableVector := typeutil.IsCompactNullableVectorFieldData(fieldData)
 
 	compactIndices := make([]int64, len(accessor.validData))
 	validCount := int64(0)
@@ -1577,6 +1578,13 @@ func newFieldDataRowAccessor(fieldData *schemapb.FieldData) (*fieldDataRowAccess
 		} else {
 			compactIndices[i] = -1
 		}
+	}
+	if isNullableVector {
+		if err := funcutil.ValidateNullableVectorFieldDataCompact(fieldData, uint64(len(accessor.validData)), true); err != nil {
+			return nil, err
+		}
+		accessor.compactIndices = compactIndices
+		return accessor, nil
 	}
 	if validCount == 0 {
 		accessor.compactIndices = compactIndices

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -389,22 +389,21 @@ func checkAndSetData(body []byte, collSchema *schemapb.CollectionSchema, partial
 				}
 				fieldType := field.DataType
 				fieldName := field.Name
+				fieldValue := gjson.Get(data.Raw, fieldName)
+
+				// For partial update, missing fields mean "do not update this field".
+				// Explicit JSON null is handled below as an update to null for nullable fields.
+				if partialUpdate && !fieldValue.Exists() {
+					continue
+				}
 
 				if field.Nullable || field.DefaultValue != nil {
-					value := gjson.Get(data.Raw, fieldName)
-					if value.Type == gjson.Null {
+					if fieldValue.Type == gjson.Null {
 						validDataMap[fieldName] = append(validDataMap[fieldName], false)
 						continue
 					} else {
 						validDataMap[fieldName] = append(validDataMap[fieldName], true)
 					}
-				}
-
-				// For partial update, check if field exists in the data
-				fieldValue := gjson.Get(data.Raw, fieldName)
-				if partialUpdate && !fieldValue.Exists() {
-					// Skip fields that are not provided in partial update
-					continue
 				}
 
 				dataString := fieldValue.String()
@@ -1045,17 +1044,26 @@ func anyToColumns(rows []map[string]interface{}, validDataMap map[string][]bool,
 	}
 	columns := make([]*schemapb.FieldData, 0, len(nameColumns))
 	for name, column := range nameColumns {
+		validData, hasValidData := validDataMap[name]
 		if fieldLen[name] == 0 && name == pkFieldName && isAutoIDPK {
 			continue
 		}
 		if fieldLen[name] == 0 && partialUpdate {
-			// for partial update, skip update for nullable field
-			// cause we cannot distinguish between missing fields and fields explicitly set to null
-			log.Info("skip empty field for partial update",
-				zap.String("fieldName", name))
-			continue
+			if hasValidData {
+				if len(validData) != rowsLen {
+					log.Info("field len is not equal to rows len",
+						zap.String("fieldName", name),
+						zap.Int("fieldLen", len(validData)),
+						zap.Int("rowsLen", rowsLen))
+					return nil, fmt.Errorf("column %s has length %d, expected %d", name, len(validData), rowsLen)
+				}
+			} else {
+				log.Info("skip empty field for partial update",
+					zap.String("fieldName", name))
+				continue
+			}
 		}
-		if fieldLen[name] != rowsLen && partialUpdate {
+		if fieldLen[name] != rowsLen && partialUpdate && (!hasValidData || len(validData) != rowsLen) {
 			// for partial update, if try to update different field in different rows, return error
 			log.Info("field len is not equal to rows len",
 				zap.String("fieldName", name),
@@ -1470,6 +1478,141 @@ func genDynamicFields(fields []string, list []*schemapb.FieldData) []string {
 	return dynamicFields
 }
 
+func fieldDataRowCount(fieldData *schemapb.FieldData) (int64, error) {
+	if len(fieldData.GetValidData()) > 0 {
+		return int64(len(fieldData.GetValidData())), nil
+	}
+	return fieldDataValueCount(fieldData)
+}
+
+func fieldDataValueCount(fieldData *schemapb.FieldData) (int64, error) {
+	switch fieldData.GetType() {
+	case schemapb.DataType_Bool:
+		return int64(len(fieldData.GetScalars().GetBoolData().GetData())), nil
+	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
+		return int64(len(fieldData.GetScalars().GetIntData().GetData())), nil
+	case schemapb.DataType_Int64:
+		return int64(len(fieldData.GetScalars().GetLongData().GetData())), nil
+	case schemapb.DataType_Float:
+		return int64(len(fieldData.GetScalars().GetFloatData().GetData())), nil
+	case schemapb.DataType_Double:
+		return int64(len(fieldData.GetScalars().GetDoubleData().GetData())), nil
+	case schemapb.DataType_Timestamptz:
+		if fieldData.GetScalars().GetTimestamptzData() != nil {
+			return int64(len(fieldData.GetScalars().GetTimestamptzData().GetData())), nil
+		}
+		return int64(len(fieldData.GetScalars().GetStringData().GetData())), nil
+	case schemapb.DataType_String, schemapb.DataType_VarChar:
+		return int64(len(fieldData.GetScalars().GetStringData().GetData())), nil
+	case schemapb.DataType_Array:
+		return int64(len(fieldData.GetScalars().GetArrayData().GetData())), nil
+	case schemapb.DataType_JSON:
+		return int64(len(fieldData.GetScalars().GetJsonData().GetData())), nil
+	case schemapb.DataType_Geometry:
+		if fieldData.GetScalars().GetGeometryData() != nil {
+			return int64(len(fieldData.GetScalars().GetGeometryData().GetData())), nil
+		}
+		return int64(len(fieldData.GetScalars().GetGeometryWktData().GetData())), nil
+	case schemapb.DataType_BinaryVector:
+		dim := fieldData.GetVectors().GetDim()
+		bytesPerRow := dim / 8
+		if bytesPerRow <= 0 {
+			return 0, fmt.Errorf("invalid binary vector dimension %d for field %s", dim, fieldData.GetFieldName())
+		}
+		return int64(len(fieldData.GetVectors().GetBinaryVector())) / bytesPerRow, nil
+	case schemapb.DataType_FloatVector:
+		dim := fieldData.GetVectors().GetDim()
+		if dim <= 0 {
+			return 0, fmt.Errorf("invalid float vector dimension %d for field %s", dim, fieldData.GetFieldName())
+		}
+		return int64(len(fieldData.GetVectors().GetFloatVector().GetData())) / dim, nil
+	case schemapb.DataType_Float16Vector:
+		dim := fieldData.GetVectors().GetDim()
+		bytesPerRow := dim * 2
+		if bytesPerRow <= 0 {
+			return 0, fmt.Errorf("invalid float16 vector dimension %d for field %s", dim, fieldData.GetFieldName())
+		}
+		return int64(len(fieldData.GetVectors().GetFloat16Vector())) / bytesPerRow, nil
+	case schemapb.DataType_BFloat16Vector:
+		dim := fieldData.GetVectors().GetDim()
+		bytesPerRow := dim * 2
+		if bytesPerRow <= 0 {
+			return 0, fmt.Errorf("invalid bfloat16 vector dimension %d for field %s", dim, fieldData.GetFieldName())
+		}
+		return int64(len(fieldData.GetVectors().GetBfloat16Vector())) / bytesPerRow, nil
+	case schemapb.DataType_SparseFloatVector:
+		return int64(len(fieldData.GetVectors().GetSparseFloatVector().GetContents())), nil
+	case schemapb.DataType_Int8Vector:
+		dim := fieldData.GetVectors().GetDim()
+		if dim <= 0 {
+			return 0, fmt.Errorf("invalid int8 vector dimension %d for field %s", dim, fieldData.GetFieldName())
+		}
+		return int64(len(fieldData.GetVectors().GetInt8Vector())) / dim, nil
+	default:
+		return 0, fmt.Errorf("the type(%v) of field(%v) is not supported, use other sdk please", fieldData.GetType(), fieldData.GetFieldName())
+	}
+}
+
+type fieldDataRowAccessor struct {
+	fieldData      *schemapb.FieldData
+	validData      []bool
+	compactIndices []int64
+}
+
+func newFieldDataRowAccessor(fieldData *schemapb.FieldData) (*fieldDataRowAccessor, error) {
+	accessor := &fieldDataRowAccessor{
+		fieldData: fieldData,
+		validData: fieldData.GetValidData(),
+	}
+	if len(accessor.validData) == 0 {
+		return accessor, nil
+	}
+
+	compactIndices := make([]int64, len(accessor.validData))
+	validCount := int64(0)
+	for i, valid := range accessor.validData {
+		if valid {
+			compactIndices[i] = validCount
+			validCount++
+		} else {
+			compactIndices[i] = -1
+		}
+	}
+	if validCount == 0 {
+		accessor.compactIndices = compactIndices
+		return accessor, nil
+	}
+
+	valueCount, err := fieldDataValueCount(fieldData)
+	if err != nil {
+		return nil, err
+	}
+	if valueCount == int64(len(accessor.validData)) {
+		return accessor, nil
+	}
+	if valueCount != validCount {
+		return nil, fmt.Errorf("field %s has %d valid rows, but data length is %d", fieldData.GetFieldName(), validCount, valueCount)
+	}
+	accessor.compactIndices = compactIndices
+	return accessor, nil
+}
+
+func (accessor *fieldDataRowAccessor) rowIndex(rowIdx int64) (int64, bool, error) {
+	if len(accessor.validData) == 0 {
+		return rowIdx, true, nil
+	}
+	if rowIdx >= int64(len(accessor.validData)) {
+		return 0, false, fmt.Errorf("row index %d out of range for field %s valid data length %d", rowIdx, accessor.fieldData.GetFieldName(), len(accessor.validData))
+	}
+	if !accessor.validData[rowIdx] {
+		return 0, false, nil
+	}
+	if accessor.compactIndices != nil {
+		return accessor.compactIndices[rowIdx], true, nil
+	}
+	return rowIdx, true, nil
+}
+
 //nolint:gosec // G602: slice indices are bounded by rowsNum which is derived from the data length
 func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemapb.FieldData, ids *schemapb.IDs,
 	scores []float32, enableInt64 bool, collectionSchema *schemapb.CollectionSchema,
@@ -1477,47 +1620,10 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 	columnNum := len(fieldDataList)
 	if rowsNum == int64(0) { // always
 		if columnNum > 0 {
-			switch fieldDataList[0].GetType() {
-			case schemapb.DataType_Bool:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetBoolData().GetData()))
-			case schemapb.DataType_Int8:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetIntData().GetData()))
-			case schemapb.DataType_Int16:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetIntData().GetData()))
-			case schemapb.DataType_Int32:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetIntData().GetData()))
-			case schemapb.DataType_Int64:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetLongData().GetData()))
-			case schemapb.DataType_Float:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetFloatData().GetData()))
-			case schemapb.DataType_Double:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetDoubleData().GetData()))
-			case schemapb.DataType_Timestamptz:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetStringData().GetData()))
-			case schemapb.DataType_String:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetStringData().GetData()))
-			case schemapb.DataType_VarChar:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetStringData().GetData()))
-			case schemapb.DataType_Array:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetArrayData().GetData()))
-			case schemapb.DataType_JSON:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetJsonData().GetData()))
-			case schemapb.DataType_Geometry:
-				rowsNum = int64(len(fieldDataList[0].GetScalars().GetGeometryWktData().Data))
-			case schemapb.DataType_BinaryVector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetBinaryVector())*8) / fieldDataList[0].GetVectors().GetDim()
-			case schemapb.DataType_FloatVector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetFloatVector().GetData())) / fieldDataList[0].GetVectors().GetDim()
-			case schemapb.DataType_Float16Vector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetFloat16Vector())/2) / fieldDataList[0].GetVectors().GetDim()
-			case schemapb.DataType_BFloat16Vector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetBfloat16Vector())/2) / fieldDataList[0].GetVectors().GetDim()
-			case schemapb.DataType_SparseFloatVector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetSparseFloatVector().GetContents()))
-			case schemapb.DataType_Int8Vector:
-				rowsNum = int64(len(fieldDataList[0].GetVectors().GetInt8Vector())) / fieldDataList[0].GetVectors().GetDim()
-			default:
-				return nil, fmt.Errorf("the type(%v) of field(%v) is not supported, use other sdk please", fieldDataList[0].GetType(), fieldDataList[0].GetFieldName())
+			var err error
+			rowsNum, err = fieldDataRowCount(fieldDataList[0])
+			if err != nil {
+				return nil, err
 			}
 		} else if ids != nil {
 			switch ids.GetIdField().(type) {
@@ -1534,6 +1640,14 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 	}
 	if rowsNum == int64(0) {
 		return []map[string]interface{}{}, nil
+	}
+	fieldDataAccessors := make([]*fieldDataRowAccessor, 0, columnNum)
+	for _, fieldData := range fieldDataList {
+		accessor, err := newFieldDataRowAccessor(fieldData)
+		if err != nil {
+			return nil, err
+		}
+		fieldDataAccessors = append(fieldDataAccessors, accessor)
 	}
 	queryResp := make([]map[string]interface{}, 0, rowsNum)
 	dynamicOutputFields := genDynamicFields(needFields, fieldDataList)
@@ -1552,101 +1666,68 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 		row := map[string]interface{}{}
 		if columnNum > 0 {
 			for j := 0; j < columnNum; j++ {
+				fieldData := fieldDataList[j]
+				dataIdx, valid, err := fieldDataAccessors[j].rowIndex(i)
+				if err != nil {
+					return nil, err
+				}
+				if !valid {
+					if !fieldData.GetIsDynamic() {
+						row[fieldData.GetFieldName()] = nil
+					}
+					continue
+				}
 				switch fieldDataList[j].GetType() {
 				case schemapb.DataType_Bool:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetBoolData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetBoolData().GetData()[dataIdx]
 				case schemapb.DataType_Int8:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = int8(fieldDataList[j].GetScalars().GetIntData().GetData()[i])
+					row[fieldDataList[j].GetFieldName()] = int8(fieldDataList[j].GetScalars().GetIntData().GetData()[dataIdx])
 				case schemapb.DataType_Int16:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = int16(fieldDataList[j].GetScalars().GetIntData().GetData()[i])
+					row[fieldDataList[j].GetFieldName()] = int16(fieldDataList[j].GetScalars().GetIntData().GetData()[dataIdx])
 				case schemapb.DataType_Int32:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetIntData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetIntData().GetData()[dataIdx]
 				case schemapb.DataType_Int64:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
 					if enableInt64 {
-						row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetLongData().GetData()[i]
+						row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetLongData().GetData()[dataIdx]
 					} else {
-						row[fieldDataList[j].GetFieldName()] = strconv.FormatInt(fieldDataList[j].GetScalars().GetLongData().GetData()[i], 10)
+						row[fieldDataList[j].GetFieldName()] = strconv.FormatInt(fieldDataList[j].GetScalars().GetLongData().GetData()[dataIdx], 10)
 					}
 				case schemapb.DataType_Float:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetFloatData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetFloatData().GetData()[dataIdx]
 				case schemapb.DataType_Double:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetDoubleData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetDoubleData().GetData()[dataIdx]
 				case schemapb.DataType_Timestamptz:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
+					if fieldDataList[j].GetScalars().GetTimestamptzData() != nil {
+						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetTimestamptzData().GetData()[dataIdx]
+					} else {
+						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
 					}
-					row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetStringData().GetData()[i]
 				case schemapb.DataType_String:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
 				case schemapb.DataType_VarChar:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetStringData().GetData()[dataIdx]
 				case schemapb.DataType_BinaryVector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetBinaryVector()[i*(fieldDataList[j].GetVectors().GetDim()/8) : (i+1)*(fieldDataList[j].GetVectors().GetDim()/8)]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetBinaryVector()[dataIdx*(fieldDataList[j].GetVectors().GetDim()/8) : (dataIdx+1)*(fieldDataList[j].GetVectors().GetDim()/8)]
 				case schemapb.DataType_FloatVector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetFloatVector().GetData()[i*fieldDataList[j].GetVectors().GetDim() : (i+1)*fieldDataList[j].GetVectors().GetDim()]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetFloatVector().GetData()[dataIdx*fieldDataList[j].GetVectors().GetDim() : (dataIdx+1)*fieldDataList[j].GetVectors().GetDim()]
 				case schemapb.DataType_Float16Vector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetFloat16Vector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetFloat16Vector()[dataIdx*(fieldDataList[j].GetVectors().GetDim()*2) : (dataIdx+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
 				case schemapb.DataType_BFloat16Vector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetBfloat16Vector()[i*(fieldDataList[j].GetVectors().GetDim()*2) : (i+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetBfloat16Vector()[dataIdx*(fieldDataList[j].GetVectors().GetDim()*2) : (dataIdx+1)*(fieldDataList[j].GetVectors().GetDim()*2)]
 				case schemapb.DataType_SparseFloatVector:
-					row[fieldDataList[j].GetFieldName()] = typeutil.SparseFloatBytesToMap(fieldDataList[j].GetVectors().GetSparseFloatVector().Contents[i])
+					row[fieldDataList[j].GetFieldName()] = typeutil.SparseFloatBytesToMap(fieldDataList[j].GetVectors().GetSparseFloatVector().Contents[dataIdx])
 				case schemapb.DataType_Int8Vector:
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetInt8Vector()[i*fieldDataList[j].GetVectors().GetDim() : (i+1)*fieldDataList[j].GetVectors().GetDim()]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetVectors().GetInt8Vector()[dataIdx*fieldDataList[j].GetVectors().GetDim() : (dataIdx+1)*fieldDataList[j].GetVectors().GetDim()]
 				case schemapb.DataType_Array:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
-					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetArrayData().GetData()[i]
+					row[fieldDataList[j].GetFieldName()] = fieldDataList[j].GetScalars().GetArrayData().GetData()[dataIdx]
 				case schemapb.DataType_JSON:
-					if len(fieldDataList[j].GetValidData()) != 0 && !fieldDataList[j].GetValidData()[i] {
-						row[fieldDataList[j].GetFieldName()] = nil
-						continue
-					}
 					data, ok := fieldDataList[j].GetScalars().GetData().(*schemapb.ScalarField_JsonData)
 					if ok && !fieldDataList[j].GetIsDynamic() {
-						row[fieldDataList[j].GetFieldName()] = string(data.JsonData.GetData()[i])
+						row[fieldDataList[j].GetFieldName()] = string(data.JsonData.GetData()[dataIdx])
 					} else {
 						var dataMap map[string]interface{}
 
-						err := json.Unmarshal(fieldDataList[j].GetScalars().GetJsonData().Data[i], &dataMap)
+						err := json.Unmarshal(fieldDataList[j].GetScalars().GetJsonData().Data[dataIdx], &dataMap)
 						if err != nil {
 							log.Error(fmt.Sprintf("[BuildQueryResp] Unmarshal error %s", err.Error()))
 							return nil, err
@@ -1665,11 +1746,11 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 						}
 					}
 				case schemapb.DataType_Geometry:
-					if len(fieldDataList[j].ValidData) != 0 && !fieldDataList[j].ValidData[i] {
-						row[fieldDataList[j].FieldName] = nil
-						continue
+					if fieldDataList[j].GetScalars().GetGeometryData() != nil {
+						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryData().GetData()[dataIdx]
+					} else {
+						row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryWktData().Data[dataIdx]
 					}
-					row[fieldDataList[j].FieldName] = fieldDataList[j].GetScalars().GetGeometryWktData().Data[i]
 				default:
 					row[fieldDataList[j].GetFieldName()] = ""
 				}

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -1170,6 +1170,261 @@ func TestInsertWithNullableField(t *testing.T) {
 	assert.Equal(t, len(coll.Fields), len(fieldData))
 }
 
+func TestInsertWithNullableVectorFields(t *testing.T) {
+	testcases := []struct {
+		name        string
+		dataType    schemapb.DataType
+		vectorValue interface{}
+		checkData   func(*testing.T, *schemapb.FieldData)
+	}{
+		{
+			name:        "float vector",
+			dataType:    schemapb.DataType_FloatVector,
+			vectorValue: []float32{0.1, 0.2},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Equal(t, []float32{0.1, 0.2}, fieldData.GetVectors().GetFloatVector().GetData())
+			},
+		},
+		{
+			name:        "binary vector",
+			dataType:    schemapb.DataType_BinaryVector,
+			vectorValue: []byte{1},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Equal(t, []byte{1}, fieldData.GetVectors().GetBinaryVector())
+			},
+		},
+		{
+			name:        "float16 vector",
+			dataType:    schemapb.DataType_Float16Vector,
+			vectorValue: []float32{0.1, 0.2},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Len(t, fieldData.GetVectors().GetFloat16Vector(), 4)
+			},
+		},
+		{
+			name:        "bfloat16 vector",
+			dataType:    schemapb.DataType_BFloat16Vector,
+			vectorValue: []float32{0.1, 0.2},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Len(t, fieldData.GetVectors().GetBfloat16Vector(), 4)
+			},
+		},
+		{
+			name:        "sparse float vector",
+			dataType:    schemapb.DataType_SparseFloatVector,
+			vectorValue: map[uint32]float32{1: 0.1, 2: 0.2},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Len(t, fieldData.GetVectors().GetSparseFloatVector().GetContents(), 1)
+			},
+		},
+		{
+			name:        "int8 vector",
+			dataType:    schemapb.DataType_Int8Vector,
+			vectorValue: []int8{1, 2},
+			checkData: func(t *testing.T, fieldData *schemapb.FieldData) {
+				assert.Equal(t, []byte{1, 2}, fieldData.GetVectors().GetInt8Vector())
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			primaryField := generatePrimaryField(schemapb.DataType_Int64, false)
+			vectorField := generateVectorFieldSchema(testcase.dataType)
+			vectorField.Name = FieldBookIntro
+			vectorField.Nullable = true
+			coll := &schemapb.CollectionSchema{
+				Name: DefaultCollectionName,
+				Fields: []*schemapb.FieldSchema{
+					primaryField,
+					vectorField,
+				},
+			}
+			body, err := wrapRequestBody([]map[string]interface{}{
+				{FieldBookID: int64(1), FieldBookIntro: nil},
+				{FieldBookID: int64(2), FieldBookIntro: testcase.vectorValue},
+				{FieldBookID: int64(3), FieldBookIntro: nil},
+			})
+			assert.NoError(t, err)
+
+			rows, validData, err := checkAndSetData(body, coll, false)
+			assert.NoError(t, err)
+			assert.Equal(t, []bool{false, true, false}, validData[FieldBookIntro])
+
+			fieldsData, err := anyToColumns(rows, validData, coll, true, false)
+			assert.NoError(t, err)
+
+			var vectorFieldData *schemapb.FieldData
+			for _, fieldData := range fieldsData {
+				if fieldData.GetFieldName() == FieldBookIntro {
+					vectorFieldData = fieldData
+					break
+				}
+			}
+			assert.NotNil(t, vectorFieldData)
+			assert.Equal(t, []bool{false, true, false}, vectorFieldData.GetValidData())
+			testcase.checkData(t, vectorFieldData)
+		})
+	}
+}
+
+func getFieldDataByName(fieldsData []*schemapb.FieldData, fieldName string) *schemapb.FieldData {
+	for _, fieldData := range fieldsData {
+		if fieldData.GetFieldName() == fieldName {
+			return fieldData
+		}
+	}
+	return nil
+}
+
+func TestPartialUpdateWithNullableExplicitNull(t *testing.T) {
+	t.Run("nullable scalar all null is kept as update", func(t *testing.T) {
+		coll := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				{
+					Name:     "nullable",
+					FieldID:  common.StartOfUserFieldID + 1,
+					DataType: schemapb.DataType_Int64,
+					Nullable: true,
+				},
+			},
+		}
+		body, err := wrapRequestBody([]map[string]interface{}{
+			{FieldBookID: int64(1), "nullable": nil},
+			{FieldBookID: int64(2), "nullable": nil},
+		})
+		assert.NoError(t, err)
+
+		rows, validData, err := checkAndSetData(body, coll, true)
+		assert.NoError(t, err)
+		assert.Equal(t, []bool{false, false}, validData["nullable"])
+
+		fieldsData, err := anyToColumns(rows, validData, coll, false, true)
+		assert.NoError(t, err)
+		nullableField := getFieldDataByName(fieldsData, "nullable")
+		assert.NotNil(t, nullableField)
+		assert.Equal(t, []bool{false, false}, nullableField.GetValidData())
+		assert.Empty(t, nullableField.GetScalars().GetLongData().GetData())
+	})
+
+	t.Run("nullable scalar mixed null and value is kept as compact update", func(t *testing.T) {
+		coll := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				{
+					Name:     "nullable",
+					FieldID:  common.StartOfUserFieldID + 1,
+					DataType: schemapb.DataType_Int64,
+					Nullable: true,
+				},
+			},
+		}
+		body, err := wrapRequestBody([]map[string]interface{}{
+			{FieldBookID: int64(1), "nullable": nil},
+			{FieldBookID: int64(2), "nullable": int64(20)},
+		})
+		assert.NoError(t, err)
+
+		rows, validData, err := checkAndSetData(body, coll, true)
+		assert.NoError(t, err)
+		assert.Equal(t, []bool{false, true}, validData["nullable"])
+
+		fieldsData, err := anyToColumns(rows, validData, coll, false, true)
+		assert.NoError(t, err)
+		nullableField := getFieldDataByName(fieldsData, "nullable")
+		assert.NotNil(t, nullableField)
+		assert.Equal(t, []bool{false, true}, nullableField.GetValidData())
+		assert.Equal(t, []int64{20}, nullableField.GetScalars().GetLongData().GetData())
+	})
+
+	t.Run("missing nullable field is skipped for partial update", func(t *testing.T) {
+		coll := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				{
+					Name:     "nullable",
+					FieldID:  common.StartOfUserFieldID + 1,
+					DataType: schemapb.DataType_Int64,
+					Nullable: true,
+				},
+			},
+		}
+		body, err := wrapRequestBody([]map[string]interface{}{
+			{FieldBookID: int64(1)},
+			{FieldBookID: int64(2)},
+		})
+		assert.NoError(t, err)
+
+		rows, validData, err := checkAndSetData(body, coll, true)
+		assert.NoError(t, err)
+		assert.NotContains(t, validData, "nullable")
+
+		fieldsData, err := anyToColumns(rows, validData, coll, false, true)
+		assert.NoError(t, err)
+		assert.Nil(t, getFieldDataByName(fieldsData, "nullable"))
+	})
+
+	t.Run("mixed missing and null nullable field is rejected for partial update", func(t *testing.T) {
+		coll := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				{
+					Name:     "nullable",
+					FieldID:  common.StartOfUserFieldID + 1,
+					DataType: schemapb.DataType_Int64,
+					Nullable: true,
+				},
+			},
+		}
+		body, err := wrapRequestBody([]map[string]interface{}{
+			{FieldBookID: int64(1)},
+			{FieldBookID: int64(2), "nullable": nil},
+		})
+		assert.NoError(t, err)
+
+		rows, validData, err := checkAndSetData(body, coll, true)
+		assert.NoError(t, err)
+		_, err = anyToColumns(rows, validData, coll, false, true)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "column nullable has length 1, expected 2")
+	})
+
+	t.Run("nullable vector all null is kept as update", func(t *testing.T) {
+		vectorField := generateVectorFieldSchema(schemapb.DataType_FloatVector)
+		vectorField.Name = FieldBookIntro
+		vectorField.Nullable = true
+		coll := &schemapb.CollectionSchema{
+			Name: DefaultCollectionName,
+			Fields: []*schemapb.FieldSchema{
+				generatePrimaryField(schemapb.DataType_Int64, false),
+				vectorField,
+			},
+		}
+		body, err := wrapRequestBody([]map[string]interface{}{
+			{FieldBookID: int64(1), FieldBookIntro: nil},
+			{FieldBookID: int64(2), FieldBookIntro: nil},
+		})
+		assert.NoError(t, err)
+
+		rows, validData, err := checkAndSetData(body, coll, true)
+		assert.NoError(t, err)
+		assert.Equal(t, []bool{false, false}, validData[FieldBookIntro])
+
+		fieldsData, err := anyToColumns(rows, validData, coll, false, true)
+		assert.NoError(t, err)
+		vectorFieldData := getFieldDataByName(fieldsData, FieldBookIntro)
+		assert.NotNil(t, vectorFieldData)
+		assert.Equal(t, []bool{false, false}, vectorFieldData.GetValidData())
+		assert.Empty(t, vectorFieldData.GetVectors().GetFloatVector().GetData())
+		assert.Equal(t, int64(2), vectorFieldData.GetVectors().GetDim())
+	})
+}
+
 func TestInsertWithDefaultValueField(t *testing.T) {
 	arrayFieldName := "array-int64"
 	coll := generateCollectionSchema(schemapb.DataType_Int64, false, true)
@@ -1595,6 +1850,76 @@ func TestBuildQueryResp(t *testing.T) {
 	assert.Equal(t, nil, err)
 	exceptRows := generateSearchResult(schemapb.DataType_Int64)
 	assert.Equal(t, true, compareRows(rows, exceptRows, compareRow))
+}
+
+func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {
+	t.Run("nullable vector derives logical rows from ValidData", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_FloatVector,
+			FieldName: FieldBookIntro,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{
+							Data: []float32{0.1, 0.2, 0.3, 0.4},
+						},
+					},
+				},
+			},
+			ValidData: []bool{true, false, true},
+		}
+
+		rows, err := buildQueryResp(0, []string{FieldBookIntro}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		assert.NoError(t, err)
+		assert.Len(t, rows, 3)
+		assert.Equal(t, []float32{0.1, 0.2}, rows[0][FieldBookIntro])
+		assert.Nil(t, rows[1][FieldBookIntro])
+		assert.Equal(t, []float32{0.3, 0.4}, rows[2][FieldBookIntro])
+	})
+
+	t.Run("nullable vector all null keeps logical rows", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_FloatVector,
+			FieldName: FieldBookIntro,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{},
+					},
+				},
+			},
+			ValidData: []bool{false, false},
+		}
+
+		rows, err := buildQueryResp(0, []string{FieldBookIntro}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		assert.NoError(t, err)
+		assert.Len(t, rows, 2)
+		assert.Nil(t, rows[0][FieldBookIntro])
+		assert.Nil(t, rows[1][FieldBookIntro])
+	})
+
+	t.Run("nullable scalar compact data uses physical index", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_Int64,
+			FieldName: FieldWordCount,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{20}},
+					},
+				},
+			},
+			ValidData: []bool{false, true},
+		}
+
+		rows, err := buildQueryResp(0, []string{FieldWordCount}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		assert.NoError(t, err)
+		assert.Len(t, rows, 2)
+		assert.Nil(t, rows[0][FieldWordCount])
+		assert.Equal(t, int64(20), rows[1][FieldWordCount])
+	})
 }
 
 func newCollectionSchema(coll *schemapb.CollectionSchema) *schemapb.CollectionSchema {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 	"google.golang.org/protobuf/proto"
 
@@ -1898,6 +1899,130 @@ func TestBuildQueryRespWithNullableCompactFields(t *testing.T) {
 		assert.Len(t, rows, 2)
 		assert.Nil(t, rows[0][FieldBookIntro])
 		assert.Nil(t, rows[1][FieldBookIntro])
+	})
+
+	t.Run("nullable vector rejects full row payload", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			Type:      schemapb.DataType_FloatVector,
+			FieldName: FieldBookIntro,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{
+							Data: []float32{
+								0.1, 0.2,
+								0.0, 0.0,
+								0.3, 0.4,
+							},
+						},
+					},
+				},
+			},
+			ValidData: []bool{true, false, true},
+		}
+
+		_, err := buildQueryResp(0, []string{FieldBookIntro}, []*schemapb.FieldData{fieldData}, nil, nil, true, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nullable vector field")
+	})
+
+	t.Run("nullable dense vector rejects partial row payload", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			fieldData *schemapb.FieldData
+		}{
+			{
+				name: "float_vector",
+				fieldData: &schemapb.FieldData{
+					Type:      schemapb.DataType_FloatVector,
+					FieldName: FieldBookIntro,
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 2,
+							Data: &schemapb.VectorField_FloatVector{
+								FloatVector: &schemapb.FloatArray{Data: []float32{0.1, 0.2, 0.3}},
+							},
+						},
+					},
+					ValidData: []bool{true, false},
+				},
+			},
+			{
+				name: "binary_vector",
+				fieldData: &schemapb.FieldData{
+					Type:      schemapb.DataType_BinaryVector,
+					FieldName: FieldBookIntro,
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 16,
+							Data: &schemapb.VectorField_BinaryVector{
+								BinaryVector: []byte{0x01, 0x02, 0x03},
+							},
+						},
+					},
+					ValidData: []bool{true, false},
+				},
+			},
+			{
+				name: "float16_vector",
+				fieldData: &schemapb.FieldData{
+					Type:      schemapb.DataType_Float16Vector,
+					FieldName: FieldBookIntro,
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 2,
+							Data: &schemapb.VectorField_Float16Vector{
+								Float16Vector: []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+							},
+						},
+					},
+					ValidData: []bool{true, false},
+				},
+			},
+			{
+				name: "bfloat16_vector",
+				fieldData: &schemapb.FieldData{
+					Type:      schemapb.DataType_BFloat16Vector,
+					FieldName: FieldBookIntro,
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 2,
+							Data: &schemapb.VectorField_Bfloat16Vector{
+								Bfloat16Vector: []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+							},
+						},
+					},
+					ValidData: []bool{true, false},
+				},
+			},
+			{
+				name: "int8_vector",
+				fieldData: &schemapb.FieldData{
+					Type:      schemapb.DataType_Int8Vector,
+					FieldName: FieldBookIntro,
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 2,
+							Data: &schemapb.VectorField_Int8Vector{
+								Int8Vector: []byte{0x01, 0x02, 0x03},
+							},
+						},
+					},
+					ValidData: []bool{true, false},
+				},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := buildQueryResp(0, []string{FieldBookIntro}, []*schemapb.FieldData{tc.fieldData}, nil, nil, true, nil)
+				require.Error(t, err)
+				assert.True(t,
+					strings.Contains(err.Error(), "row width") || strings.Contains(err.Error(), "divide the dim"),
+					"unexpected error: %s", err.Error())
+			})
+		}
 	})
 
 	t.Run("nullable scalar compact data uses physical index", func(t *testing.T) {

--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -936,6 +936,7 @@ func (op *requeryOperator) requery(ctx context.Context, span trace.Span, ids *sc
 type organizeOperator struct {
 	traceCtx           context.Context
 	primaryFieldSchema *schemapb.FieldSchema
+	schema             *schemapb.CollectionSchema
 	collectionID       int64
 }
 
@@ -947,6 +948,7 @@ func newOrganizeOperator(t *searchTask, _ map[string]any) (operator, error) {
 	return &organizeOperator{
 		traceCtx:           t.TraceCtx(),
 		primaryFieldSchema: pkField,
+		schema:             t.schema.CollectionSchema,
 		collectionID:       t.GetCollectionID(),
 	}, nil
 }
@@ -1012,7 +1014,7 @@ func (op *organizeOperator) run(ctx context.Context, span trace.Span, inputs ...
 			allFieldData[idx] = emptyFields
 			continue
 		}
-		if fieldData, err := pickFieldData(ids, offsets, fields, op.collectionID); err != nil {
+		if fieldData, err := pickFieldData(ids, offsets, fields, op.schema, op.collectionID); err != nil {
 			return nil, err
 		} else {
 			allFieldData[idx] = fieldData
@@ -1021,7 +1023,7 @@ func (op *organizeOperator) run(ctx context.Context, span trace.Span, inputs ...
 	return []any{allFieldData}, nil
 }
 
-func pickFieldData(ids *schemapb.IDs, pkOffset map[any]int, fields []*schemapb.FieldData, collectionID int64) ([]*schemapb.FieldData, error) {
+func pickFieldData(ids *schemapb.IDs, pkOffset map[any]int, fields []*schemapb.FieldData, schema *schemapb.CollectionSchema, collectionID int64) ([]*schemapb.FieldData, error) {
 	// Reorganize Results. The order of query result ids will be altered and differ from queried ids.
 	// We should reorganize query results to keep the order of original queried ids. For example:
 	// ===========================================
@@ -1038,7 +1040,7 @@ func pickFieldData(ids *schemapb.IDs, pkOffset map[any]int, fields []*schemapb.F
 	// v3 v2 v5 v4 v1  (result vectors)
 	// ===========================================
 	fieldsData := make([]*schemapb.FieldData, len(fields))
-	idxComputer := typeutil.NewFieldDataIdxComputer(fields)
+	idxComputer := typeutil.NewFieldDataIdxComputerWithSchema(fields, schema)
 	for i := 0; i < typeutil.GetSizeOfIDs(ids); i++ {
 		id := typeutil.GetPK(ids, int64(i))
 		if _, ok := pkOffset[id]; !ok {
@@ -1861,9 +1863,89 @@ func (op *orderByOperator) reorderResults(result *milvuspb.SearchResults, indice
 	return nil
 }
 
+func prepareNullableFieldDataReorder(field *schemapb.FieldData, indices []int) ([]bool, []int, int, error) {
+	validData := field.GetValidData()
+	if len(validData) == 0 {
+		return nil, nil, 0, nil
+	}
+
+	logicalToPhysical, validCount := typeutil.BuildNullableVectorDataIndices(validData)
+
+	newValidData := make([]bool, len(indices))
+	for newIdx, oldIdx := range indices {
+		if oldIdx < 0 || oldIdx >= len(validData) {
+			return nil, nil, 0, merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: index %d out of bounds for ValidData of field %s (len=%d)", oldIdx, field.GetFieldName(), len(validData)))
+		}
+		newValidData[newIdx] = validData[oldIdx]
+	}
+	return newValidData, logicalToPhysical, validCount, nil
+}
+
+func countValidRows(validData []bool) int {
+	validCount := 0
+	for _, valid := range validData {
+		if valid {
+			validCount++
+		}
+	}
+	return validCount
+}
+
+func reorderNullableFloatVectorData(field *schemapb.FieldData, data []float32, width int, indices []int, newValidData []bool, logicalToPhysical []int, validCount int) ([]float32, error) {
+	expected := validCount * width
+	if len(data) != expected {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: nullable FloatVector field %s has %d elements, expected compact %d (valid=%d, dim=%d)", field.GetFieldName(), len(data), expected, validCount, width))
+	}
+	newData := make([]float32, 0, countValidRows(newValidData)*width)
+	for _, oldIdx := range indices {
+		if !field.ValidData[oldIdx] {
+			continue
+		}
+		physicalIdx := logicalToPhysical[oldIdx]
+		srcStart := physicalIdx * width
+		newData = append(newData, data[srcStart:srcStart+width]...)
+	}
+	return newData, nil
+}
+
+func reorderNullableByteVectorData(field *schemapb.FieldData, typeName string, data []byte, width int, indices []int, newValidData []bool, logicalToPhysical []int, validCount int) ([]byte, error) {
+	expected := validCount * width
+	if len(data) != expected {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: nullable %s field %s has %d bytes, expected compact %d (valid=%d, width=%d)", typeName, field.GetFieldName(), len(data), expected, validCount, width))
+	}
+	newData := make([]byte, 0, countValidRows(newValidData)*width)
+	for _, oldIdx := range indices {
+		if !field.ValidData[oldIdx] {
+			continue
+		}
+		physicalIdx := logicalToPhysical[oldIdx]
+		srcStart := physicalIdx * width
+		newData = append(newData, data[srcStart:srcStart+width]...)
+	}
+	return newData, nil
+}
+
+func reorderNullableSparseVectorData(field *schemapb.FieldData, contents [][]byte, indices []int, newValidData []bool, logicalToPhysical []int, validCount int) ([][]byte, error) {
+	if len(contents) != validCount {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: nullable SparseFloatVector field %s has %d elements, expected compact %d", field.GetFieldName(), len(contents), validCount))
+	}
+	newContents := make([][]byte, 0, countValidRows(newValidData))
+	for _, oldIdx := range indices {
+		if !field.ValidData[oldIdx] {
+			continue
+		}
+		newContents = append(newContents, contents[logicalToPhysical[oldIdx]])
+	}
+	return newContents, nil
+}
+
 // reorderFieldData reorders field data based on indices
 func reorderFieldData(field *schemapb.FieldData, indices []int) error {
 	n := len(indices)
+	newValidData, logicalToPhysical, validCount, err := prepareNullableFieldDataReorder(field, indices)
+	if err != nil {
+		return err
+	}
 	switch field.GetType() {
 	case schemapb.DataType_Int8, schemapb.DataType_Int16, schemapb.DataType_Int32:
 		if data := field.GetScalars().GetIntData(); data != nil && len(data.Data) > 0 {
@@ -1955,12 +2037,23 @@ func reorderFieldData(field *schemapb.FieldData, indices []int) error {
 		}
 	case schemapb.DataType_FloatVector:
 		vectors := field.GetVectors()
-		if vectors != nil && vectors.GetFloatVector() != nil {
+		if vectors != nil && (newValidData != nil || vectors.GetFloatVector() != nil) {
 			dim := int(vectors.GetDim())
 			if dim <= 0 {
 				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: invalid dimension %d for FloatVector field %s", dim, field.GetFieldName()))
 			}
-			data := vectors.GetFloatVector().GetData()
+			var data []float32
+			if vectors.GetFloatVector() != nil {
+				data = vectors.GetFloatVector().GetData()
+			}
+			if newValidData != nil {
+				newData, err := reorderNullableFloatVectorData(field, data, dim, indices, newValidData, logicalToPhysical, validCount)
+				if err != nil {
+					return err
+				}
+				vectors.Data = &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: newData}}
+				break
+			}
 			if len(data) != n*dim {
 				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: FloatVector field %s has %d elements, expected %d (n=%d, dim=%d)", field.GetFieldName(), len(data), n*dim, n, dim))
 			}
@@ -1977,13 +2070,21 @@ func reorderFieldData(field *schemapb.FieldData, indices []int) error {
 		}
 	case schemapb.DataType_BinaryVector:
 		vectors := field.GetVectors()
-		if vectors != nil && len(vectors.GetBinaryVector()) > 0 {
+		if vectors != nil && (newValidData != nil || len(vectors.GetBinaryVector()) > 0) {
 			dim := int(vectors.GetDim())
 			bytesPerVector := dim / 8
 			if bytesPerVector <= 0 {
 				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: invalid dimension %d for BinaryVector field %s", dim, field.GetFieldName()))
 			}
 			data := vectors.GetBinaryVector()
+			if newValidData != nil {
+				newData, err := reorderNullableByteVectorData(field, "BinaryVector", data, bytesPerVector, indices, newValidData, logicalToPhysical, validCount)
+				if err != nil {
+					return err
+				}
+				vectors.Data = &schemapb.VectorField_BinaryVector{BinaryVector: newData}
+				break
+			}
 			if len(data) != n*bytesPerVector {
 				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: BinaryVector field %s has %d bytes, expected %d (n=%d, bytesPerVector=%d)", field.GetFieldName(), len(data), n*bytesPerVector, n, bytesPerVector))
 			}
@@ -2000,13 +2101,21 @@ func reorderFieldData(field *schemapb.FieldData, indices []int) error {
 		}
 	case schemapb.DataType_Float16Vector:
 		vectors := field.GetVectors()
-		if vectors != nil && len(vectors.GetFloat16Vector()) > 0 {
+		if vectors != nil && (newValidData != nil || len(vectors.GetFloat16Vector()) > 0) {
 			dim := int(vectors.GetDim())
 			if dim <= 0 {
 				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: invalid dimension %d for Float16Vector field %s", dim, field.GetFieldName()))
 			}
 			bytesPerVector := dim * 2 // 2 bytes per float16
 			data := vectors.GetFloat16Vector()
+			if newValidData != nil {
+				newData, err := reorderNullableByteVectorData(field, "Float16Vector", data, bytesPerVector, indices, newValidData, logicalToPhysical, validCount)
+				if err != nil {
+					return err
+				}
+				vectors.Data = &schemapb.VectorField_Float16Vector{Float16Vector: newData}
+				break
+			}
 			if len(data) != n*bytesPerVector {
 				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: Float16Vector field %s has %d bytes, expected %d (n=%d, bytesPerVector=%d)", field.GetFieldName(), len(data), n*bytesPerVector, n, bytesPerVector))
 			}
@@ -2023,13 +2132,21 @@ func reorderFieldData(field *schemapb.FieldData, indices []int) error {
 		}
 	case schemapb.DataType_BFloat16Vector:
 		vectors := field.GetVectors()
-		if vectors != nil && len(vectors.GetBfloat16Vector()) > 0 {
+		if vectors != nil && (newValidData != nil || len(vectors.GetBfloat16Vector()) > 0) {
 			dim := int(vectors.GetDim())
 			if dim <= 0 {
 				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: invalid dimension %d for BFloat16Vector field %s", dim, field.GetFieldName()))
 			}
 			bytesPerVector := dim * 2 // 2 bytes per bfloat16
 			data := vectors.GetBfloat16Vector()
+			if newValidData != nil {
+				newData, err := reorderNullableByteVectorData(field, "BFloat16Vector", data, bytesPerVector, indices, newValidData, logicalToPhysical, validCount)
+				if err != nil {
+					return err
+				}
+				vectors.Data = &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: newData}
+				break
+			}
 			if len(data) != n*bytesPerVector {
 				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: BFloat16Vector field %s has %d bytes, expected %d (n=%d, bytesPerVector=%d)", field.GetFieldName(), len(data), n*bytesPerVector, n, bytesPerVector))
 			}
@@ -2046,9 +2163,21 @@ func reorderFieldData(field *schemapb.FieldData, indices []int) error {
 		}
 	case schemapb.DataType_SparseFloatVector:
 		vectors := field.GetVectors()
-		if vectors != nil && vectors.GetSparseFloatVector() != nil {
+		if vectors != nil && (newValidData != nil || vectors.GetSparseFloatVector() != nil) {
 			sparseData := vectors.GetSparseFloatVector()
+			if sparseData == nil {
+				sparseData = &schemapb.SparseFloatArray{Dim: vectors.GetDim()}
+			}
 			contents := sparseData.GetContents()
+			if newValidData != nil {
+				newContents, err := reorderNullableSparseVectorData(field, contents, indices, newValidData, logicalToPhysical, validCount)
+				if err != nil {
+					return err
+				}
+				sparseData.Contents = newContents
+				vectors.Data = &schemapb.VectorField_SparseFloatVector{SparseFloatVector: sparseData}
+				break
+			}
 			if len(contents) != n {
 				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: SparseFloatVector field %s has %d elements, expected %d", field.GetFieldName(), len(contents), n))
 			}
@@ -2063,12 +2192,20 @@ func reorderFieldData(field *schemapb.FieldData, indices []int) error {
 		}
 	case schemapb.DataType_Int8Vector:
 		vectors := field.GetVectors()
-		if vectors != nil && len(vectors.GetInt8Vector()) > 0 {
+		if vectors != nil && (newValidData != nil || len(vectors.GetInt8Vector()) > 0) {
 			dim := int(vectors.GetDim())
 			if dim <= 0 {
 				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: invalid dimension %d for Int8Vector field %s", dim, field.GetFieldName()))
 			}
 			data := vectors.GetInt8Vector()
+			if newValidData != nil {
+				newData, err := reorderNullableByteVectorData(field, "Int8Vector", data, dim, indices, newValidData, logicalToPhysical, validCount)
+				if err != nil {
+					return err
+				}
+				vectors.Data = &schemapb.VectorField_Int8Vector{Int8Vector: newData}
+				break
+			}
 			if len(data) != n*dim {
 				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: Int8Vector field %s has %d bytes, expected %d (n=%d, dim=%d)", field.GetFieldName(), len(data), n*dim, n, dim))
 			}
@@ -2088,14 +2225,7 @@ func reorderFieldData(field *schemapb.FieldData, indices []int) error {
 	}
 
 	// Reorder valid data if present
-	if len(field.ValidData) > 0 {
-		newValidData := make([]bool, n)
-		for newIdx, oldIdx := range indices {
-			if oldIdx < 0 || oldIdx >= len(field.ValidData) {
-				return merr.WrapErrServiceInternal(fmt.Sprintf("reorderFieldData: index %d out of bounds for ValidData of field %s (len=%d)", oldIdx, field.GetFieldName(), len(field.ValidData)))
-			}
-			newValidData[newIdx] = field.ValidData[oldIdx]
-		}
+	if newValidData != nil {
 		field.ValidData = newValidData
 	}
 	return nil

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -340,6 +340,90 @@ func (s *SearchPipelineSuite) TestHybridAssembleOp_MixedFieldsDataLayoutErrors()
 		"error message must mention FieldsData inconsistency")
 }
 
+func (s *SearchPipelineSuite) TestHybridAssembleOpNullableVectorCompactData() {
+	sub0 := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       3,
+			Topks:      []int64{3},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_FloatVector,
+					FieldName: "nullable_vec",
+					FieldId:   101,
+					ValidData: []bool{false, true, true},
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 2,
+							Data: &schemapb.VectorField_FloatVector{
+								FloatVector: &schemapb.FloatArray{Data: []float32{20, 20, 30, 30}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	sub1 := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       2,
+			Topks:      []int64{2},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{40, 50}},
+				},
+			},
+			Scores: []float32{0.6, 0.5},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_FloatVector,
+					FieldName: "nullable_vec",
+					FieldId:   101,
+					ValidData: []bool{true, false},
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 2,
+							Data: &schemapb.VectorField_FloatVector{
+								FloatVector: &schemapb.FloatArray{Data: []float32{40, 40}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	rankResult := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       5,
+			Topks:      []int64{5},
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{30, 10, 50, 40, 20}},
+				},
+			},
+			Scores: []float32{0.95, 0.85, 0.75, 0.65, 0.55},
+		},
+	}
+
+	op := &hybridAssembleOperator{collectionID: 12345}
+	out, err := op.run(context.Background(), s.span, []*milvuspb.SearchResults{sub0, sub1}, rankResult)
+
+	s.NoError(err)
+	result := out[0].(*milvuspb.SearchResults).GetResults()
+	s.Require().Len(result.GetFieldsData(), 1)
+	field := result.GetFieldsData()[0]
+	s.Equal([]bool{true, false, false, true, true}, field.GetValidData())
+	s.Equal([]float32{30, 30, 40, 40, 20, 20}, field.GetVectors().GetFloatVector().GetData())
+}
+
 func (s *SearchPipelineSuite) TestRequeryOp() {
 	f1 := testutils.GenerateScalarFieldData(schemapb.DataType_Int64, "int64", 20)
 	f1.FieldId = 101
@@ -2113,6 +2197,80 @@ func (s *SearchPipelineSuite) TestOrderByOperator() {
 	s.Equal(expectedPrices, actualPrices)
 }
 
+func (s *SearchPipelineSuite) TestOrderByOperatorReordersNullableVectorCompactOutput() {
+	result := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+				},
+			},
+			Scores: []float32{0.9, 0.8, 0.7},
+			Topks:  []int64{3},
+			FieldsData: []*schemapb.FieldData{
+				{
+					Type:      schemapb.DataType_Int64,
+					FieldName: "price",
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{30, 10, 20}},
+							},
+						},
+					},
+				},
+				{
+					Type:      schemapb.DataType_FloatVector,
+					FieldName: "nullable_float_vec",
+					ValidData: []bool{true, false, true},
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 2,
+							Data: &schemapb.VectorField_FloatVector{
+								FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 5, 6}},
+							},
+						},
+					},
+				},
+				{
+					Type:      schemapb.DataType_SparseFloatVector,
+					FieldName: "nullable_sparse_vec",
+					ValidData: []bool{true, false, true},
+					Field: &schemapb.FieldData_Vectors{
+						Vectors: &schemapb.VectorField{
+							Dim: 3,
+							Data: &schemapb.VectorField_SparseFloatVector{
+								SparseFloatVector: &schemapb.SparseFloatArray{
+									Dim:      3,
+									Contents: [][]byte{{0x01}, {0x03}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	op := &orderByOperator{
+		orderByFields: []OrderByField{
+			{FieldName: "price", Ascending: true},
+		},
+		groupByFieldId: -1,
+	}
+
+	outputs, err := op.run(context.Background(), s.span, result)
+	s.NoError(err)
+	sortedResult := outputs[0].(*milvuspb.SearchResults)
+
+	s.Equal([]int64{2, 3, 1}, sortedResult.Results.Ids.GetIntId().Data)
+	s.Equal([]int64{10, 20, 30}, sortedResult.Results.FieldsData[0].GetScalars().GetLongData().Data)
+	s.Equal([]bool{false, true, true}, sortedResult.Results.FieldsData[1].GetValidData())
+	s.Equal([]float32{5, 6, 1, 2}, sortedResult.Results.FieldsData[1].GetVectors().GetFloatVector().GetData())
+	s.Equal([]bool{false, true, true}, sortedResult.Results.FieldsData[2].GetValidData())
+	s.Equal([][]byte{{0x03}, {0x01}}, sortedResult.Results.FieldsData[2].GetVectors().GetSparseFloatVector().GetContents())
+}
+
 // Test orderByOperator with nq>1 (multiple queries)
 // Each query's results should be sorted independently
 func (s *SearchPipelineSuite) TestOrderByOperatorMultipleQueries() {
@@ -3779,6 +3937,231 @@ func (s *SearchPipelineSuite) TestReorderFieldDataInt8Vector() {
 	s.Equal(expected, field.GetVectors().GetInt8Vector())
 }
 
+func (s *SearchPipelineSuite) TestReorderFieldDataNullableVectorCompactData() {
+	indices := []int{2, 0, 1}
+	expectedValidData := []bool{true, true, false}
+
+	tests := []struct {
+		name   string
+		field  *schemapb.FieldData
+		assert func(*schemapb.FieldData)
+	}{
+		{
+			name: "float_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_FloatVector,
+				FieldName: "nullable_float_vec",
+				ValidData: []bool{true, false, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 5, 6}}},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Equal([]float32{5, 6, 1, 2}, field.GetVectors().GetFloatVector().GetData())
+			},
+		},
+		{
+			name: "binary_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_BinaryVector,
+				FieldName: "nullable_binary_vec",
+				ValidData: []bool{true, false, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  16,
+					Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{0x01, 0x02, 0x05, 0x06}},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Equal([]byte{0x05, 0x06, 0x01, 0x02}, field.GetVectors().GetBinaryVector())
+			},
+		},
+		{
+			name: "float16_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_Float16Vector,
+				FieldName: "nullable_float16_vec",
+				ValidData: []bool{true, false, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{0x01, 0x02, 0x03, 0x04, 0x09, 0x0A, 0x0B, 0x0C}},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Equal([]byte{0x09, 0x0A, 0x0B, 0x0C, 0x01, 0x02, 0x03, 0x04}, field.GetVectors().GetFloat16Vector())
+			},
+		},
+		{
+			name: "bfloat16_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_BFloat16Vector,
+				FieldName: "nullable_bfloat16_vec",
+				ValidData: []bool{true, false, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{0x11, 0x12, 0x13, 0x14, 0x31, 0x32, 0x33, 0x34}},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Equal([]byte{0x31, 0x32, 0x33, 0x34, 0x11, 0x12, 0x13, 0x14}, field.GetVectors().GetBfloat16Vector())
+			},
+		},
+		{
+			name: "int8_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_Int8Vector,
+				FieldName: "nullable_int8_vec",
+				ValidData: []bool{true, false, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  4,
+					Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{0x01, 0x02, 0x03, 0x04, 0x09, 0x0A, 0x0B, 0x0C}},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Equal([]byte{0x09, 0x0A, 0x0B, 0x0C, 0x01, 0x02, 0x03, 0x04}, field.GetVectors().GetInt8Vector())
+			},
+		},
+		{
+			name: "sparse_float_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_SparseFloatVector,
+				FieldName: "nullable_sparse_vec",
+				ValidData: []bool{true, false, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim: 3,
+					Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+						Dim:      3,
+						Contents: [][]byte{{0x01}, {0x03}},
+					}},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Equal([][]byte{{0x03}, {0x01}}, field.GetVectors().GetSparseFloatVector().GetContents())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			err := reorderFieldData(tt.field, indices)
+			s.NoError(err)
+			s.Equal(expectedValidData, tt.field.GetValidData())
+			tt.assert(tt.field)
+		})
+	}
+}
+
+func (s *SearchPipelineSuite) TestReorderFieldDataNullableVectorAllNullCompactData() {
+	indices := []int{1, 0}
+	expectedValidData := []bool{false, false}
+
+	tests := []struct {
+		name   string
+		field  *schemapb.FieldData
+		assert func(*schemapb.FieldData)
+	}{
+		{
+			name: "float_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_FloatVector,
+				FieldName: "nullable_float_vec",
+				ValidData: []bool{false, false},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{}},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Empty(field.GetVectors().GetFloatVector().GetData())
+			},
+		},
+		{
+			name: "binary_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_BinaryVector,
+				FieldName: "nullable_binary_vec",
+				ValidData: []bool{false, false},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  16,
+					Data: &schemapb.VectorField_BinaryVector{},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Empty(field.GetVectors().GetBinaryVector())
+			},
+		},
+		{
+			name: "float16_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_Float16Vector,
+				FieldName: "nullable_float16_vec",
+				ValidData: []bool{false, false},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Float16Vector{},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Empty(field.GetVectors().GetFloat16Vector())
+			},
+		},
+		{
+			name: "bfloat16_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_BFloat16Vector,
+				FieldName: "nullable_bfloat16_vec",
+				ValidData: []bool{false, false},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Bfloat16Vector{},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Empty(field.GetVectors().GetBfloat16Vector())
+			},
+		},
+		{
+			name: "int8_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_Int8Vector,
+				FieldName: "nullable_int8_vec",
+				ValidData: []bool{false, false},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  4,
+					Data: &schemapb.VectorField_Int8Vector{},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Empty(field.GetVectors().GetInt8Vector())
+			},
+		},
+		{
+			name: "sparse_float_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_SparseFloatVector,
+				FieldName: "nullable_sparse_vec",
+				ValidData: []bool{false, false},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  3,
+					Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{Dim: 3}},
+				}},
+			},
+			assert: func(field *schemapb.FieldData) {
+				s.Empty(field.GetVectors().GetSparseFloatVector().GetContents())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			err := reorderFieldData(tt.field, indices)
+			s.NoError(err)
+			s.Equal(expectedValidData, tt.field.GetValidData())
+			tt.assert(tt.field)
+		})
+	}
+}
+
 // Test reorderFieldData with ValidData (nullable fields)
 func (s *SearchPipelineSuite) TestReorderFieldDataWithValidData() {
 	field := &schemapb.FieldData{
@@ -4511,7 +4894,7 @@ func (s *SearchPipelineSuite) TestPickFieldDataWithNullableSparseVector() {
 	}
 
 	// Call pickFieldData - this should NOT panic
-	result, err := pickFieldData(searchIDs, pkOffset, queryFields, 12345)
+	result, err := pickFieldData(searchIDs, pkOffset, queryFields, nil, 12345)
 	s.NoError(err)
 	s.NotNil(result)
 	s.Len(result, 2)
@@ -4580,7 +4963,7 @@ func (s *SearchPipelineSuite) TestPickFieldDataWithAllNullSparseVector() {
 		},
 	}
 
-	result, err := pickFieldData(searchIDs, pkOffset, queryFields, 12345)
+	result, err := pickFieldData(searchIDs, pkOffset, queryFields, nil, 12345)
 	s.NoError(err)
 	s.NotNil(result)
 
@@ -4588,4 +4971,64 @@ func (s *SearchPipelineSuite) TestPickFieldDataWithAllNullSparseVector() {
 	sparseValidData := result[1].GetValidData()
 	s.Equal([]bool{false, false}, sparseValidData)
 	s.Len(result[1].GetVectors().GetSparseFloatVector().GetContents(), 0)
+}
+
+func (s *SearchPipelineSuite) TestPickFieldDataWithNullableSparseVectorMissingValidData() {
+	searchIDs := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{2, 1}},
+		},
+	}
+	pkOffset := map[any]int{
+		int64(1): 0,
+		int64(2): 1,
+	}
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:      100,
+				Name:         "pk",
+				DataType:     schemapb.DataType_Int64,
+				IsPrimaryKey: true,
+			},
+			{
+				FieldID:  101,
+				Name:     "sparse_vec",
+				DataType: schemapb.DataType_SparseFloatVector,
+				Nullable: true,
+			},
+		},
+	}
+	queryFields := []*schemapb.FieldData{
+		{
+			Type:      schemapb.DataType_Int64,
+			FieldName: "pk",
+			FieldId:   100,
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{1, 2}},
+					},
+				},
+			},
+		},
+		{
+			Type:      schemapb.DataType_SparseFloatVector,
+			FieldName: "sparse_vec",
+			FieldId:   101,
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: &schemapb.SparseFloatArray{},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := pickFieldData(searchIDs, pkOffset, queryFields, schema, 12345)
+	s.NoError(err)
+	s.Equal([]int64{2, 1}, result[0].GetScalars().GetLongData().GetData())
+	s.Equal([]bool{false, false}, result[1].GetValidData())
+	s.Empty(result[1].GetVectors().GetSparseFloatVector().GetContents())
 }

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -346,21 +346,9 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		return err
 	}
 
-	// Two nullable data formats are supported:
-	//
-	//	COMPRESSED FORMAT (SDK format, before validateUtil.fillWithValue processing):
-	//		Logical data: [1, null, 2]
-	//		Storage: Data=[1, 2] + ValidData=[true, false, true]
-	//		- Data array contains only non-null values (compressed)
-	//		- ValidData array tracks null positions for all rows
-	//
-	//	FULL FORMAT (Milvus internal format, after validateUtil.fillWithValue processing):
-	//		Logical data: [1, null, 2]
-	//		Storage: Data=[1, 0, 2] + ValidData=[true, false, true]
-	//		- Data array contains values for all rows (nulls filled with zero/default)
-	//		- ValidData array still tracks null positions
-	//
-	// Note: we will unify the nullable format to FULL FORMAT before executing the merge logic
+	// Scalar nullable payloads are expanded before merge. Nullable vector payloads
+	// must remain compact: ValidData tracks logical rows, and vector data stores
+	// only valid rows.
 	insertIdxInUpsert := make([]int, 0)
 	updateIdxInUpsert := make([]int, 0)
 	// 1. split upsert data into insert and update by query result
@@ -434,7 +422,7 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 
 			dstField := it.insertFieldData[fieldIdx]
 			upsertField := upsertFieldMap[existField.FieldId]
-			isNullableVector := len(existField.GetValidData()) > 0 && typeutil.IsVectorType(existField.GetType())
+			isNullableVector := typeutil.IsCompactNullableVectorFieldData(existField)
 			existComputer := typeutil.NewFieldDataIdxComputer([]*schemapb.FieldData{existField})
 			existSrcIndices := make([]int64, len(updateIdxInUpsert))
 			for i, existIdx := range existIndices {
@@ -539,7 +527,7 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 
 		// Process insert data by column (field), similar to update path
 		for _, srcField := range insertWithNullField {
-			isNullableVector := len(srcField.GetValidData()) > 0 && typeutil.IsVectorType(srcField.GetType())
+			isNullableVector := typeutil.IsCompactNullableVectorFieldData(srcField)
 			srcComputer := typeutil.NewFieldDataIdxComputer([]*schemapb.FieldData{srcField})
 
 			// Find or create destination field in it.insertFieldData
@@ -762,7 +750,8 @@ func ToCompressedFormatNullable(field *schemapb.FieldData) error {
 	return nil
 }
 
-// GenNullableFieldData generates nullable field data in FULL FORMAT
+// GenNullableFieldData generates all-null nullable field data.
+// Scalar fields use expanded zero values; vector fields use compact empty data.
 func GenNullableFieldData(field *schemapb.FieldSchema, upsertIDSize int) (*schemapb.FieldData, error) {
 	switch field.DataType {
 	case schemapb.DataType_Bool:

--- a/internal/proxy/validate_util_test.go
+++ b/internal/proxy/validate_util_test.go
@@ -2223,6 +2223,66 @@ func Test_validateUtil_checkAligned(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("nullable float16 and bfloat16 vector all null rejects partial row payload", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			dataType schemapb.DataType
+			vector   *schemapb.VectorField
+		}{
+			{
+				name:     "float16",
+				dataType: schemapb.DataType_Float16Vector,
+				vector: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_Float16Vector{
+						Float16Vector: []byte{0x01, 0x02},
+					},
+				},
+			},
+			{
+				name:     "bfloat16",
+				dataType: schemapb.DataType_BFloat16Vector,
+				vector: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_Bfloat16Vector{
+						Bfloat16Vector: []byte{0x01, 0x02},
+					},
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				data := []*schemapb.FieldData{
+					{
+						FieldName: "test",
+						Type:      tc.dataType,
+						ValidData: []bool{false, false},
+						Field: &schemapb.FieldData_Vectors{
+							Vectors: tc.vector,
+						},
+					},
+				}
+
+				schema := &schemapb.CollectionSchema{
+					Fields: []*schemapb.FieldSchema{
+						{
+							Name:       "test",
+							DataType:   tc.dataType,
+							TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "2"}},
+							Nullable:   true,
+						},
+					},
+				}
+				h, err := typeutil.CreateSchemaHelper(schema)
+				require.NoError(t, err)
+
+				err = newValidateUtil().checkAligned(data, h, 2)
+				require.Error(t, err)
+			})
+		}
+	})
+
 	t.Run("nullable int8 vector all null", func(t *testing.T) {
 		data := []*schemapb.FieldData{
 			{
@@ -2302,6 +2362,121 @@ func Test_validateUtil_Validate(t *testing.T) {
 		err := v.Validate(data, nil, 100)
 
 		assert.Error(t, err)
+	})
+
+	t.Run("nullable vector fills missing valid data", func(t *testing.T) {
+		testCases := []struct {
+			name      string
+			dataType  schemapb.DataType
+			dim       string
+			fieldData *schemapb.FieldData
+		}{
+			{
+				name:     "FloatVector",
+				dataType: schemapb.DataType_FloatVector,
+				dim:      "2",
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_FloatVector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim: 2,
+						Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+							Data: []float32{1, 2, 3, 4},
+						}},
+					}},
+				},
+			},
+			{
+				name:     "BinaryVector",
+				dataType: schemapb.DataType_BinaryVector,
+				dim:      "8",
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_BinaryVector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim:  8,
+						Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 2}},
+					}},
+				},
+			},
+			{
+				name:     "Float16Vector",
+				dataType: schemapb.DataType_Float16Vector,
+				dim:      "2",
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_Float16Vector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim:  2,
+						Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+					}},
+				},
+			},
+			{
+				name:     "BFloat16Vector",
+				dataType: schemapb.DataType_BFloat16Vector,
+				dim:      "2",
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_BFloat16Vector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim:  2,
+						Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+					}},
+				},
+			},
+			{
+				name:     "Int8Vector",
+				dataType: schemapb.DataType_Int8Vector,
+				dim:      "2",
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_Int8Vector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Dim:  2,
+						Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{1, 2, 3, 4}},
+					}},
+				},
+			},
+			{
+				name:     "SparseFloatVector",
+				dataType: schemapb.DataType_SparseFloatVector,
+				fieldData: &schemapb.FieldData{
+					FieldName: "vec",
+					Type:      schemapb.DataType_SparseFloatVector,
+					Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+						Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+							Contents: [][]byte{
+								typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1}),
+								typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2}),
+							},
+						}},
+					}},
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				fieldSchema := &schemapb.FieldSchema{
+					FieldID:  100,
+					Name:     "vec",
+					DataType: tc.dataType,
+					Nullable: true,
+				}
+				if tc.dim != "" {
+					fieldSchema.TypeParams = []*commonpb.KeyValuePair{{Key: common.DimKey, Value: tc.dim}}
+				}
+				h, err := typeutil.CreateSchemaHelper(&schemapb.CollectionSchema{
+					Fields: []*schemapb.FieldSchema{fieldSchema},
+				})
+				require.NoError(t, err)
+
+				err = newValidateUtil().Validate([]*schemapb.FieldData{tc.fieldData}, h, 2)
+				require.NoError(t, err)
+				assert.Equal(t, []bool{true, true}, tc.fieldData.GetValidData())
+			})
+		}
 	})
 
 	t.Run("not aligned", func(t *testing.T) {

--- a/internal/storage/arrow_util.go
+++ b/internal/storage/arrow_util.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
@@ -25,9 +26,23 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+func isNullableDenseVectorArrowType(dataType schemapb.DataType) bool {
+	switch dataType {
+	case schemapb.DataType_FloatVector,
+		schemapb.DataType_BinaryVector,
+		schemapb.DataType_Float16Vector,
+		schemapb.DataType_BFloat16Vector,
+		schemapb.DataType_Int8Vector:
+		return true
+	default:
+		return false
+	}
+}
 
 func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *schemapb.ValueField) (uint64, error) {
 	// a could never be nil here
@@ -252,7 +267,11 @@ func GenerateEmptyArrayFromSchema(schema *schemapb.FieldSchema, numRows int) (ar
 	if schema.GetDataType() == schemapb.DataType_ArrayOfVector {
 		elementType = schema.GetElementType()
 	}
-	builder := array.NewBuilder(memory.DefaultAllocator, serdeMap[schema.GetDataType()].arrowType(int(dim), elementType)) // serdeEntry[schema.GetDataType()].newBuilder()
+	arrowType := serdeMap[schema.GetDataType()].arrowType(int(dim), elementType)
+	if schema.GetNullable() && isNullableDenseVectorArrowType(schema.GetDataType()) {
+		arrowType = arrow.BinaryTypes.Binary
+	}
+	builder := array.NewBuilder(memory.DefaultAllocator, arrowType) // serdeEntry[schema.GetDataType()].newBuilder()
 	if schema.GetDefaultValue() != nil {
 		switch schema.GetDataType() {
 		case schemapb.DataType_Bool:
@@ -322,8 +341,9 @@ func GenerateEmptyArrayFromSchema(schema *schemapb.FieldSchema, numRows int) (ar
 // small batch size will cause write performance degradation. To work around this issue, we accumulate
 // records and write them in batches. This requires additional memory copy.
 type RecordBuilder struct {
-	fields   []*schemapb.FieldSchema
-	builders []array.Builder
+	fields      []*schemapb.FieldSchema
+	arrowFields []arrow.Field
+	builders    []array.Builder
 
 	nRows int
 	size  uint64
@@ -361,11 +381,8 @@ func (b *RecordBuilder) Build() Record {
 		arrays[c] = builder.NewArray()
 		f := b.fields[c]
 		fid := f.FieldID
-		fields[c] = arrow.Field{
-			Name:     f.GetName(),
-			Type:     arrays[c].DataType(),
-			Nullable: f.Nullable,
-		}
+		fields[c] = b.arrowFields[c]
+		fields[c].Type = arrays[c].DataType()
 		field2Col[fid] = c
 	}
 
@@ -384,6 +401,7 @@ func NewRecordBuilder(schema *schemapb.CollectionSchema) *RecordBuilder {
 	}
 
 	builders := make([]array.Builder, len(fields))
+	arrowFields := make([]arrow.Field, len(fields))
 	for i, field := range fields {
 		dim, _ := typeutil.GetDim(field)
 
@@ -391,7 +409,7 @@ func NewRecordBuilder(schema *schemapb.CollectionSchema) *RecordBuilder {
 		if field.DataType == schemapb.DataType_ArrayOfVector {
 			elementType = field.GetElementType()
 		}
-		if field.GetNullable() && typeutil.IsVectorType(field.DataType) && !typeutil.IsSparseFloatVectorType(field.DataType) {
+		if field.GetNullable() && isNullableDenseVectorArrowType(field.DataType) {
 			builders[i] = array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
 		} else if field.DataType == schemapb.DataType_Text {
 			// TEXT fields are stored as binary (LOB references) in manifest storage,
@@ -401,10 +419,34 @@ func NewRecordBuilder(schema *schemapb.CollectionSchema) *RecordBuilder {
 			arrowType := serdeMap[field.DataType].arrowType(int(dim), elementType)
 			builders[i] = array.NewBuilder(memory.DefaultAllocator, arrowType)
 		}
+		arrowFields[i] = newRecordBuilderArrowField(field, builders[i].Type(), dim, elementType)
 	}
 
 	return &RecordBuilder{
-		fields:   fields,
-		builders: builders,
+		fields:      fields,
+		arrowFields: arrowFields,
+		builders:    builders,
+	}
+}
+
+func newRecordBuilderArrowField(field *schemapb.FieldSchema, arrowType arrow.DataType, dim int64, elementType schemapb.DataType) arrow.Field {
+	keys := []string{packed.ArrowFieldIdMetadataKey}
+	values := []string{strconv.Itoa(int(field.GetFieldID()))}
+
+	if field.GetNullable() && isNullableDenseVectorArrowType(field.GetDataType()) {
+		keys = append(keys, "dim")
+		values = append(values, strconv.Itoa(int(dim)))
+	}
+
+	if field.GetDataType() == schemapb.DataType_ArrayOfVector {
+		keys = append(keys, "elementType", "dim")
+		values = append(values, strconv.Itoa(int(elementType)), strconv.Itoa(int(dim)))
+	}
+
+	return arrow.Field{
+		Name:     field.GetName(),
+		Type:     arrowType,
+		Nullable: field.GetNullable(),
+		Metadata: arrow.NewMetadata(keys, values),
 	}
 }

--- a/internal/storage/arrow_util_test.go
+++ b/internal/storage/arrow_util_test.go
@@ -20,8 +20,10 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
@@ -230,4 +232,51 @@ func TestGenerateEmptyArray(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateEmptyArrayFromSchemaNullableDenseVectorUsesBinaryArrow(t *testing.T) {
+	field := &schemapb.FieldSchema{
+		FieldID:  100,
+		Name:     "nullable_float_vector",
+		DataType: schemapb.DataType_FloatVector,
+		Nullable: true,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: "dim", Value: "4"},
+		},
+	}
+
+	arr, err := GenerateEmptyArrayFromSchema(field, 3)
+
+	assert.NoError(t, err)
+	assert.Equal(t, arrow.BinaryTypes.Binary, arr.DataType())
+	assert.Equal(t, 3, arr.Len())
+	for i := 0; i < arr.Len(); i++ {
+		assert.True(t, arr.IsNull(i))
+	}
+}
+
+func TestRecordBuilderNullableDenseVectorPreservesDimMetadata(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  100,
+				Name:     "nullable_float_vector",
+				DataType: schemapb.DataType_FloatVector,
+				Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "4"},
+				},
+			},
+		},
+	}
+
+	rb := NewRecordBuilder(schema)
+	rec := rb.Build()
+	defer rec.Release()
+
+	field := rec.(*simpleArrowRecord).ArrowSchema().Field(0)
+	assert.Equal(t, arrow.BinaryTypes.Binary, field.Type)
+	dim, ok := field.Metadata.GetValue("dim")
+	assert.True(t, ok)
+	assert.Equal(t, "4", dim)
 }

--- a/internal/storage/data_codec_test.go
+++ b/internal/storage/data_codec_test.go
@@ -1154,10 +1154,14 @@ func TestInsertCodec(t *testing.T) {
 				Dim:       4,
 				Nullable:  true,
 			},
-			StructSubInt32Field:       &ArrayFieldData{schemapb.DataType_Int32, []*schemapb.ScalarField{}, nil, false},
-			ArrayField:                &ArrayFieldData{schemapb.DataType_Int32, []*schemapb.ScalarField{}, nil, false},
-			JSONField:                 &JSONFieldData{[][]byte{}, nil, false},
-			StructSubFloatVectorField: &VectorArrayFieldData{0, schemapb.DataType_FloatVector, []*schemapb.VectorField{}},
+			StructSubInt32Field: &ArrayFieldData{schemapb.DataType_Int32, []*schemapb.ScalarField{}, nil, false},
+			ArrayField:          &ArrayFieldData{schemapb.DataType_Int32, []*schemapb.ScalarField{}, nil, false},
+			JSONField:           &JSONFieldData{[][]byte{}, nil, false},
+			StructSubFloatVectorField: &VectorArrayFieldData{
+				Dim:         0,
+				ElementType: schemapb.DataType_FloatVector,
+				Data:        []*schemapb.VectorField{},
+			},
 		},
 	}
 	b, err := insertCodec.Serialize(PartitionID, SegmentID, insertDataEmpty)

--- a/internal/storage/data_sorter.go
+++ b/internal/storage/data_sorter.go
@@ -24,9 +24,10 @@ import (
 
 // DataSorter sorts insert data
 type DataSorter struct {
-	InsertCodec *InsertCodec
-	InsertData  *InsertData
-	AllFields   []*schemapb.FieldSchema
+	InsertCodec             *InsertCodec
+	InsertData              *InsertData
+	AllFields               []*schemapb.FieldSchema
+	nullableVectorDataRanks map[int64]*nullableVectorRanks
 }
 
 // getRowIDFieldData returns auto generated row id Field
@@ -50,6 +51,152 @@ func (ds *DataSorter) Len() int {
 	return len(fieldData.Data)
 }
 
+func swapValidData(validData []bool, i, j int) {
+	if len(validData) == 0 {
+		return
+	}
+	validData[i], validData[j] = validData[j], validData[i]
+}
+
+func swapFixedRows[T any](data []T, i, j, rowWidth int) {
+	if i == j || rowWidth == 0 {
+		return
+	}
+	for idx := 0; idx < rowWidth; idx++ {
+		data[i*rowWidth+idx], data[j*rowWidth+idx] = data[j*rowWidth+idx], data[i*rowWidth+idx]
+	}
+}
+
+func moveFixedRow[T any](data []T, from, to, rowWidth int) {
+	if from == to || rowWidth == 0 {
+		return
+	}
+	row := make([]T, rowWidth)
+	copy(row, data[from*rowWidth:(from+1)*rowWidth])
+	if from < to {
+		copy(data[from*rowWidth:to*rowWidth], data[(from+1)*rowWidth:(to+1)*rowWidth])
+	} else {
+		copy(data[(to+1)*rowWidth:(from+1)*rowWidth], data[to*rowWidth:from*rowWidth])
+	}
+	copy(data[to*rowWidth:(to+1)*rowWidth], row)
+}
+
+type nullableVectorRanks struct {
+	tree []int
+}
+
+func newNullableVectorRanks(validData []bool) *nullableVectorRanks {
+	ranks := &nullableVectorRanks{tree: make([]int, len(validData)+1)}
+	for i, valid := range validData {
+		if valid {
+			ranks.add(i, 1)
+		}
+	}
+	return ranks
+}
+
+func (r *nullableVectorRanks) add(logicalIdx, delta int) {
+	for idx := logicalIdx + 1; idx < len(r.tree); idx += idx & -idx {
+		r.tree[idx] += delta
+	}
+}
+
+func (r *nullableVectorRanks) rankBefore(logicalIdx int) int {
+	sum := 0
+	for idx := logicalIdx; idx > 0; idx -= idx & -idx {
+		sum += r.tree[idx]
+	}
+	return sum
+}
+
+func (r *nullableVectorRanks) rankOfValid(logicalIdx int) int {
+	return r.rankBefore(logicalIdx+1) - 1
+}
+
+func invalidateNullableVectorMapping(mapping *LogicalToPhysicalMapping) {
+	if mapping == nil {
+		return
+	}
+	mapping.validCount = 0
+	mapping.l2pMap = nil
+}
+
+func (ds *DataSorter) getNullableVectorDataRanks(fieldID int64, validData []bool) *nullableVectorRanks {
+	if ds.nullableVectorDataRanks == nil {
+		ds.nullableVectorDataRanks = make(map[int64]*nullableVectorRanks)
+	}
+	if ranks, ok := ds.nullableVectorDataRanks[fieldID]; ok && len(ranks.tree) == len(validData)+1 {
+		return ranks
+	}
+	ranks := newNullableVectorRanks(validData)
+	ds.nullableVectorDataRanks[fieldID] = ranks
+	return ranks
+}
+
+func moveNullableVectorPhysicalIndex(validData []bool, from, to int, ranks *nullableVectorRanks) (int, int) {
+	srcPhysical := ranks.rankOfValid(from)
+	ranks.add(from, -1)
+	ranks.add(to, 1)
+	dstPhysical := ranks.rankBefore(to)
+	validData[from] = false
+	validData[to] = true
+	return srcPhysical, dstPhysical
+}
+
+func swapCompactNullableFixedRows[T any](data []T, validData []bool, i, j, rowWidth int, mapping *LogicalToPhysicalMapping, ranks *nullableVectorRanks) {
+	if i == j {
+		return
+	}
+	invalidateNullableVectorMapping(mapping)
+
+	validI, validJ := validData[i], validData[j]
+	switch {
+	case validI && validJ:
+		swapFixedRows(data, ranks.rankOfValid(i), ranks.rankOfValid(j), rowWidth)
+	case validI != validJ:
+		fromLogical, toLogical := i, j
+		if !validI {
+			fromLogical, toLogical = j, i
+		}
+		srcPhysical, dstPhysical := moveNullableVectorPhysicalIndex(validData, fromLogical, toLogical, ranks)
+		moveFixedRow(data, srcPhysical, dstPhysical, rowWidth)
+	}
+}
+
+func moveSparseRow(contents [][]byte, from, to int) {
+	if from == to {
+		return
+	}
+	row := contents[from]
+	if from < to {
+		copy(contents[from:to], contents[from+1:to+1])
+	} else {
+		copy(contents[to+1:from+1], contents[to:from])
+	}
+	contents[to] = row
+}
+
+func swapCompactNullableSparseRows(contents [][]byte, validData []bool, i, j int, mapping *LogicalToPhysicalMapping, ranks *nullableVectorRanks) {
+	if i == j {
+		return
+	}
+	invalidateNullableVectorMapping(mapping)
+
+	validI, validJ := validData[i], validData[j]
+	switch {
+	case validI && validJ:
+		physicalI, physicalJ := ranks.rankOfValid(i), ranks.rankOfValid(j)
+		contents[physicalI], contents[physicalJ] = contents[physicalJ], contents[physicalI]
+	case validI != validJ:
+		fromLogical, toLogical := i, j
+		if !validI {
+			fromLogical, toLogical = j, i
+		}
+		srcPhysical, dstPhysical := moveNullableVectorPhysicalIndex(validData, fromLogical, toLogical, ranks)
+		moveSparseRow(contents, srcPhysical, dstPhysical)
+	}
+}
+
 // Swap swaps each field's i-th and j-th element
 func (ds *DataSorter) Swap(i, j int) {
 	if ds.AllFields == nil {
@@ -62,72 +209,127 @@ func (ds *DataSorter) Swap(i, j int) {
 		}
 		switch field.DataType {
 		case schemapb.DataType_Bool:
-			data := singleData.(*BoolFieldData).Data
+			fd := singleData.(*BoolFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Int8:
-			data := singleData.(*Int8FieldData).Data
+			fd := singleData.(*Int8FieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Int16:
-			data := singleData.(*Int16FieldData).Data
+			fd := singleData.(*Int16FieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Int32:
-			data := singleData.(*Int32FieldData).Data
+			fd := singleData.(*Int32FieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Int64:
-			data := singleData.(*Int64FieldData).Data
+			fd := singleData.(*Int64FieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Float:
-			data := singleData.(*FloatFieldData).Data
+			fd := singleData.(*FloatFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Double:
-			data := singleData.(*DoubleFieldData).Data
+			fd := singleData.(*DoubleFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Timestamptz:
-			data := singleData.(*TimestamptzFieldData).Data
+			fd := singleData.(*TimestamptzFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_String, schemapb.DataType_VarChar:
-			data := singleData.(*StringFieldData).Data
+			fd := singleData.(*StringFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_BinaryVector:
-			data := singleData.(*BinaryVectorFieldData).Data
-			dim := singleData.(*BinaryVectorFieldData).Dim
+			fd := singleData.(*BinaryVectorFieldData)
+			data := fd.Data
+			dim := fd.Dim
 			// dim for binary vector must be multiplier of 8, simple verion for swapping:
 			steps := dim / 8
-			for idx := 0; idx < steps; idx++ {
-				data[i*steps+idx], data[j*steps+idx] = data[j*steps+idx], data[i*steps+idx]
+			if len(fd.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fd.ValidData)
+				swapCompactNullableFixedRows(data, fd.ValidData, i, j, steps, &fd.L2PMapping, ranks)
+			} else {
+				swapFixedRows(data, i, j, steps)
 			}
 		case schemapb.DataType_FloatVector:
-			data := singleData.(*FloatVectorFieldData).Data
-			dim := singleData.(*FloatVectorFieldData).Dim
-			for idx := 0; idx < dim; idx++ {
-				data[i*dim+idx], data[j*dim+idx] = data[j*dim+idx], data[i*dim+idx]
+			fd := singleData.(*FloatVectorFieldData)
+			data := fd.Data
+			dim := fd.Dim
+			if len(fd.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fd.ValidData)
+				swapCompactNullableFixedRows(data, fd.ValidData, i, j, dim, &fd.L2PMapping, ranks)
+			} else {
+				swapFixedRows(data, i, j, dim)
 			}
 		case schemapb.DataType_Float16Vector:
-			data := singleData.(*Float16VectorFieldData).Data
-			dim := singleData.(*Float16VectorFieldData).Dim
+			fd := singleData.(*Float16VectorFieldData)
+			data := fd.Data
+			dim := fd.Dim
 			steps := dim * 2
-			for idx := 0; idx < steps; idx++ {
-				data[i*steps+idx], data[j*steps+idx] = data[j*steps+idx], data[i*steps+idx]
+			if len(fd.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fd.ValidData)
+				swapCompactNullableFixedRows(data, fd.ValidData, i, j, steps, &fd.L2PMapping, ranks)
+			} else {
+				swapFixedRows(data, i, j, steps)
 			}
 		case schemapb.DataType_BFloat16Vector:
-			data := singleData.(*BFloat16VectorFieldData).Data
-			dim := singleData.(*BFloat16VectorFieldData).Dim
+			fd := singleData.(*BFloat16VectorFieldData)
+			data := fd.Data
+			dim := fd.Dim
 			steps := dim * 2
-			for idx := 0; idx < steps; idx++ {
-				data[i*steps+idx], data[j*steps+idx] = data[j*steps+idx], data[i*steps+idx]
+			if len(fd.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fd.ValidData)
+				swapCompactNullableFixedRows(data, fd.ValidData, i, j, steps, &fd.L2PMapping, ranks)
+			} else {
+				swapFixedRows(data, i, j, steps)
 			}
 		case schemapb.DataType_Array:
-			data := singleData.(*ArrayFieldData).Data
+			fd := singleData.(*ArrayFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_JSON:
-			data := singleData.(*JSONFieldData).Data
+			fd := singleData.(*JSONFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_Geometry:
-			data := singleData.(*GeometryFieldData).Data
+			fd := singleData.(*GeometryFieldData)
+			data := fd.Data
 			data[i], data[j] = data[j], data[i]
+			swapValidData(fd.ValidData, i, j)
 		case schemapb.DataType_SparseFloatVector:
 			fieldData := singleData.(*SparseFloatVectorFieldData)
-			fieldData.Contents[i], fieldData.Contents[j] = fieldData.Contents[j], fieldData.Contents[i]
+			if len(fieldData.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fieldData.ValidData)
+				swapCompactNullableSparseRows(fieldData.Contents, fieldData.ValidData, i, j, &fieldData.L2PMapping, ranks)
+			} else {
+				fieldData.Contents[i], fieldData.Contents[j] = fieldData.Contents[j], fieldData.Contents[i]
+			}
+		case schemapb.DataType_Int8Vector:
+			fd := singleData.(*Int8VectorFieldData)
+			data := fd.Data
+			dim := fd.Dim
+			if len(fd.ValidData) > 0 {
+				ranks := ds.getNullableVectorDataRanks(field.FieldID, fd.ValidData)
+				swapCompactNullableFixedRows(data, fd.ValidData, i, j, dim, &fd.L2PMapping, ranks)
+			} else {
+				swapFixedRows(data, i, j, dim)
+			}
 		case schemapb.DataType_ArrayOfVector:
 			fieldData := singleData.(*VectorArrayFieldData)
 			fieldData.Data[i], fieldData.Data[j] = fieldData.Data[j], fieldData.Data[i]

--- a/internal/storage/data_sorter_test.go
+++ b/internal/storage/data_sorter_test.go
@@ -326,6 +326,254 @@ func TestDataSorter(t *testing.T) {
 		dataSorter.InsertData.Data[114].(*VectorArrayFieldData).Data[2].Data.(*schemapb.VectorField_FloatVector).FloatVector.Data)
 }
 
+func TestDataSorterNullableCompactVectors(t *testing.T) {
+	schema := &etcdpb.CollectionMeta{
+		ID:         1,
+		CreateTime: 1,
+		Schema: &schemapb.CollectionSchema{
+			Name:   "schema",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 0, Name: "row_id", DataType: schemapb.DataType_Int64},
+				{FieldID: 200, Name: "nullable_int64", DataType: schemapb.DataType_Int64, Nullable: true},
+				{FieldID: 201, Name: "binary_vector", DataType: schemapb.DataType_BinaryVector, Nullable: true},
+				{FieldID: 202, Name: "float_vector", DataType: schemapb.DataType_FloatVector, Nullable: true},
+				{FieldID: 203, Name: "float16_vector", DataType: schemapb.DataType_Float16Vector, Nullable: true},
+				{FieldID: 204, Name: "bfloat16_vector", DataType: schemapb.DataType_BFloat16Vector, Nullable: true},
+				{FieldID: 205, Name: "sparse_vector", DataType: schemapb.DataType_SparseFloatVector, Nullable: true},
+				{FieldID: 206, Name: "int8_vector", DataType: schemapb.DataType_Int8Vector, Nullable: true},
+			},
+		},
+	}
+
+	binaryVector := &BinaryVectorFieldData{Dim: 8, Nullable: true}
+	assert.NoError(t, binaryVector.AppendRow([]byte{0x11}))
+	assert.NoError(t, binaryVector.AppendRow(nil))
+	assert.NoError(t, binaryVector.AppendRow([]byte{0x33}))
+
+	floatVector := &FloatVectorFieldData{Dim: 2, Nullable: true}
+	assert.NoError(t, floatVector.AppendRow([]float32{1, 2}))
+	assert.NoError(t, floatVector.AppendRow(nil))
+	assert.NoError(t, floatVector.AppendRow([]float32{5, 6}))
+
+	float16Vector := &Float16VectorFieldData{Dim: 2, Nullable: true}
+	assert.NoError(t, float16Vector.AppendRow([]byte{1, 2, 3, 4}))
+	assert.NoError(t, float16Vector.AppendRow(nil))
+	assert.NoError(t, float16Vector.AppendRow([]byte{5, 6, 7, 8}))
+
+	bfloat16Vector := &BFloat16VectorFieldData{Dim: 2, Nullable: true}
+	assert.NoError(t, bfloat16Vector.AppendRow([]byte{11, 12, 13, 14}))
+	assert.NoError(t, bfloat16Vector.AppendRow(nil))
+	assert.NoError(t, bfloat16Vector.AppendRow([]byte{15, 16, 17, 18}))
+
+	sparseRow0 := typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1})
+	sparseRow2 := typeutil.CreateSparseFloatRow([]uint32{3}, []float32{3})
+	sparseVector := &SparseFloatVectorFieldData{SparseFloatArray: schemapb.SparseFloatArray{Dim: 8}, Nullable: true}
+	assert.NoError(t, sparseVector.AppendRow(sparseRow0))
+	assert.NoError(t, sparseVector.AppendRow(nil))
+	assert.NoError(t, sparseVector.AppendRow(sparseRow2))
+
+	int8Vector := &Int8VectorFieldData{Dim: 2, Nullable: true}
+	assert.NoError(t, int8Vector.AppendRow([]int8{21, 22}))
+	assert.NoError(t, int8Vector.AppendRow(nil))
+	assert.NoError(t, int8Vector.AppendRow([]int8{25, 26}))
+
+	insertData := &InsertData{
+		Data: map[int64]FieldData{
+			0:   &Int64FieldData{Data: []int64{20, 10, 30}},
+			200: &Int64FieldData{Data: []int64{200, 0, 300}, ValidData: []bool{true, false, true}, Nullable: true},
+			201: binaryVector,
+			202: floatVector,
+			203: float16Vector,
+			204: bfloat16Vector,
+			205: sparseVector,
+			206: int8Vector,
+		},
+	}
+
+	dataSorter := &DataSorter{
+		InsertCodec: NewInsertCodecWithSchema(schema),
+		InsertData:  insertData,
+	}
+
+	sort.Sort(dataSorter)
+
+	assert.Equal(t, []int64{10, 20, 30}, insertData.Data[0].(*Int64FieldData).Data)
+
+	int64Field := insertData.Data[200].(*Int64FieldData)
+	assert.Equal(t, []bool{false, true, true}, int64Field.ValidData)
+	assert.Equal(t, []int64{0, 200, 300}, int64Field.Data)
+	assert.Nil(t, int64Field.GetRow(0))
+	assert.Equal(t, int64(200), int64Field.GetRow(1))
+
+	assert.Equal(t, []bool{false, true, true}, binaryVector.ValidData)
+	assert.Equal(t, []byte{0x11, 0x33}, binaryVector.Data)
+	assert.Nil(t, binaryVector.GetRow(0))
+	assert.Equal(t, []byte{0x11}, binaryVector.GetRow(1))
+	assert.Equal(t, []byte{0x33}, binaryVector.GetRow(2))
+
+	assert.Equal(t, []bool{false, true, true}, floatVector.ValidData)
+	assert.Equal(t, []float32{1, 2, 5, 6}, floatVector.Data)
+	assert.Nil(t, floatVector.GetRow(0))
+	assert.Equal(t, []float32{1, 2}, floatVector.GetRow(1))
+	assert.Equal(t, []float32{5, 6}, floatVector.GetRow(2))
+
+	assert.Equal(t, []bool{false, true, true}, float16Vector.ValidData)
+	assert.Equal(t, []byte{1, 2, 3, 4, 5, 6, 7, 8}, float16Vector.Data)
+	assert.Nil(t, float16Vector.GetRow(0))
+	assert.Equal(t, []byte{1, 2, 3, 4}, float16Vector.GetRow(1))
+	assert.Equal(t, []byte{5, 6, 7, 8}, float16Vector.GetRow(2))
+
+	assert.Equal(t, []bool{false, true, true}, bfloat16Vector.ValidData)
+	assert.Equal(t, []byte{11, 12, 13, 14, 15, 16, 17, 18}, bfloat16Vector.Data)
+	assert.Nil(t, bfloat16Vector.GetRow(0))
+	assert.Equal(t, []byte{11, 12, 13, 14}, bfloat16Vector.GetRow(1))
+	assert.Equal(t, []byte{15, 16, 17, 18}, bfloat16Vector.GetRow(2))
+
+	assert.Equal(t, []bool{false, true, true}, sparseVector.ValidData)
+	assert.Equal(t, [][]byte{sparseRow0, sparseRow2}, sparseVector.Contents)
+	assert.Nil(t, sparseVector.GetRow(0))
+	assert.Equal(t, sparseRow0, sparseVector.GetRow(1))
+	assert.Equal(t, sparseRow2, sparseVector.GetRow(2))
+
+	assert.Equal(t, []bool{false, true, true}, int8Vector.ValidData)
+	assert.Equal(t, []int8{21, 22, 25, 26}, int8Vector.Data)
+	assert.Nil(t, int8Vector.GetRow(0))
+	assert.Equal(t, []int8{21, 22}, int8Vector.GetRow(1))
+	assert.Equal(t, []int8{25, 26}, int8Vector.GetRow(2))
+}
+
+func TestDataSorterNullableCompactVectorsInterleavedRows(t *testing.T) {
+	schema := &etcdpb.CollectionMeta{
+		ID:         1,
+		CreateTime: 1,
+		Schema: &schemapb.CollectionSchema{
+			Name:   "schema",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 0, Name: "row_id", DataType: schemapb.DataType_Int64},
+				{FieldID: 201, Name: "float_vector", DataType: schemapb.DataType_FloatVector, Nullable: true},
+				{FieldID: 202, Name: "sparse_vector", DataType: schemapb.DataType_SparseFloatVector, Nullable: true},
+			},
+		},
+	}
+
+	floatVector := &FloatVectorFieldData{Dim: 1, Nullable: true}
+	sparseVector := &SparseFloatVectorFieldData{SparseFloatArray: schemapb.SparseFloatArray{Dim: 8}, Nullable: true}
+	rows := []struct {
+		rowID int64
+		valid bool
+		value float32
+	}{
+		{40, true, 40},
+		{10, false, 0},
+		{30, true, 30},
+		{20, false, 0},
+		{50, true, 50},
+	}
+	for _, row := range rows {
+		if row.valid {
+			assert.NoError(t, floatVector.AppendRow([]float32{row.value}))
+			assert.NoError(t, sparseVector.AppendRow(typeutil.CreateSparseFloatRow([]uint32{uint32(row.value)}, []float32{row.value})))
+		} else {
+			assert.NoError(t, floatVector.AppendRow(nil))
+			assert.NoError(t, sparseVector.AppendRow(nil))
+		}
+	}
+
+	insertData := &InsertData{
+		Data: map[int64]FieldData{
+			0:   &Int64FieldData{Data: []int64{40, 10, 30, 20, 50}},
+			201: floatVector,
+			202: sparseVector,
+		},
+	}
+	sort.Sort(&DataSorter{
+		InsertCodec: NewInsertCodecWithSchema(schema),
+		InsertData:  insertData,
+	})
+
+	assert.Equal(t, []int64{10, 20, 30, 40, 50}, insertData.Data[0].(*Int64FieldData).Data)
+	assert.Equal(t, []bool{false, false, true, true, true}, floatVector.ValidData)
+	assert.Equal(t, []float32{30, 40, 50}, floatVector.Data)
+	assert.Nil(t, floatVector.GetRow(0))
+	assert.Nil(t, floatVector.GetRow(1))
+	assert.Equal(t, []float32{30}, floatVector.GetRow(2))
+	assert.Equal(t, []float32{40}, floatVector.GetRow(3))
+	assert.Equal(t, []float32{50}, floatVector.GetRow(4))
+
+	assert.Equal(t, []bool{false, false, true, true, true}, sparseVector.ValidData)
+	assert.Len(t, sparseVector.Contents, 3)
+	assert.Nil(t, sparseVector.GetRow(0))
+	assert.Nil(t, sparseVector.GetRow(1))
+	assert.Equal(t, typeutil.CreateSparseFloatRow([]uint32{30}, []float32{30}), sparseVector.GetRow(2))
+	assert.Equal(t, typeutil.CreateSparseFloatRow([]uint32{40}, []float32{40}), sparseVector.GetRow(3))
+	assert.Equal(t, typeutil.CreateSparseFloatRow([]uint32{50}, []float32{50}), sparseVector.GetRow(4))
+}
+
+func BenchmarkDataSorterNullableCompactVectorSort(b *testing.B) {
+	const (
+		rowCount = 4096
+		dim      = 8
+	)
+	schema := &etcdpb.CollectionMeta{
+		ID:         1,
+		CreateTime: 1,
+		Schema: &schemapb.CollectionSchema{
+			Name:   "schema",
+			AutoID: true,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 0, Name: "row_id", DataType: schemapb.DataType_Int64},
+				{FieldID: 201, Name: "float_vector", DataType: schemapb.DataType_FloatVector, Nullable: true},
+			},
+		},
+	}
+
+	makeInsertData := func() *InsertData {
+		rowIDs := make([]int64, rowCount)
+		vector := &FloatVectorFieldData{Dim: dim, Nullable: true}
+		for i := 0; i < rowCount; i++ {
+			rowIDs[i] = int64(rowCount - i)
+			if i%3 == 0 {
+				assert.NoError(b, vector.AppendRow(nil))
+				continue
+			}
+			row := make([]float32, dim)
+			for j := range row {
+				row[j] = float32(i*dim + j)
+			}
+			assert.NoError(b, vector.AppendRow(row))
+		}
+		return &InsertData{
+			Data: map[int64]FieldData{
+				0:   &Int64FieldData{Data: rowIDs},
+				201: vector,
+			},
+		}
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		insertData := makeInsertData()
+		dataSorter := &DataSorter{
+			InsertCodec: NewInsertCodecWithSchema(schema),
+			InsertData:  insertData,
+		}
+		b.StartTimer()
+		sort.Sort(dataSorter)
+		b.StopTimer()
+		if got := insertData.Data[0].(*Int64FieldData).Data[0]; got != 1 {
+			b.Fatalf("first row id = %d, want 1", got)
+		}
+		if got := insertData.Data[0].(*Int64FieldData).Data[rowCount-1]; got != rowCount {
+			b.Fatalf("last row id = %d, want %d", got, rowCount)
+		}
+		if got := insertData.Data[201].(*FloatVectorFieldData).RowNum(); got != rowCount {
+			b.Fatalf("vector row count = %d, want %d", got, rowCount)
+		}
+	}
+}
+
 func TestDataSorter_Len(t *testing.T) {
 	insertData := &InsertData{
 		Data: map[int64]FieldData{

--- a/internal/storage/field_stats.go
+++ b/internal/storage/field_stats.go
@@ -173,38 +173,32 @@ func (stats *FieldStats) UnmarshalJSON(data []byte) error {
 			stats.BF = bf
 		}
 	} else {
-		stats.initCentroids(data, stats.Type)
-		err = json.Unmarshal(*messageMap["centroids"], &stats.Centroids)
+		centroids, ok := messageMap["centroids"]
+		if !ok || centroids == nil {
+			return nil
+		}
+		var centroidMessages []json.RawMessage
+		err = json.Unmarshal(*centroids, &centroidMessages)
 		if err != nil {
 			return err
+		}
+		stats.Centroids = make([]VectorFieldValue, 0, len(centroidMessages))
+		for _, centroidMessage := range centroidMessages {
+			switch stats.Type {
+			case schemapb.DataType_FloatVector:
+				centroid := &FloatVectorFieldValue{}
+				err = centroid.UnmarshalJSON(centroidMessage)
+				if err != nil {
+					return err
+				}
+				stats.Centroids = append(stats.Centroids, centroid)
+			default:
+				// other vector datatype
+			}
 		}
 	}
 
 	return nil
-}
-
-func (stats *FieldStats) initCentroids(data []byte, dataType schemapb.DataType) {
-	type FieldStatsAux struct {
-		FieldID   int64                            `json:"fieldID"`
-		Type      schemapb.DataType                `json:"type"`
-		Max       json.RawMessage                  `json:"max"`
-		Min       json.RawMessage                  `json:"min"`
-		BF        bloomfilter.BloomFilterInterface `json:"bf"`
-		Centroids []json.RawMessage                `json:"centroids"`
-	}
-	// Unmarshal JSON into the auxiliary struct
-	var aux FieldStatsAux
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return
-	}
-	for i := 0; i < len(aux.Centroids); i++ {
-		switch dataType {
-		case schemapb.DataType_FloatVector:
-			stats.Centroids = append(stats.Centroids, &FloatVectorFieldValue{})
-		default:
-			// other vector datatype
-		}
-	}
 }
 
 func (stats *FieldStats) UpdateByMsgs(msgs FieldData) {

--- a/internal/storage/insert_data.go
+++ b/internal/storage/insert_data.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -515,6 +516,19 @@ func (m *LogicalToPhysicalMapping) Build(validData []bool, startLogical, totalCo
 	m.validCount = physicalIdx
 }
 
+func getNullableVectorPhysicalOffset(validData []bool, mapping *LogicalToPhysicalMapping, logicalOffset int) int {
+	if mapping != nil && mapping.l2pMap != nil {
+		return mapping.GetPhysicalOffset(logicalOffset)
+	}
+	physicalOffset := 0
+	for i := 0; i < logicalOffset; i++ {
+		if validData[i] {
+			physicalOffset++
+		}
+	}
+	return physicalOffset
+}
+
 type BinaryVectorFieldData struct {
 	Data       []byte
 	ValidData  []bool
@@ -566,9 +580,6 @@ type VectorArrayFieldData struct {
 }
 
 func (dst *SparseFloatVectorFieldData) AppendAllRows(src *SparseFloatVectorFieldData) {
-	if len(src.Contents) == 0 {
-		return
-	}
 	if dst.Dim < src.Dim {
 		dst.Dim = src.Dim
 	}
@@ -731,7 +742,10 @@ func (data *BinaryVectorFieldData) GetRow(i int) any {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Data[physicalIdx*data.Dim/8 : (physicalIdx+1)*data.Dim/8]
 }
 
@@ -739,7 +753,10 @@ func (data *SparseFloatVectorFieldData) GetRow(i int) interface{} {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Contents[physicalIdx]
 }
 
@@ -747,7 +764,10 @@ func (data *FloatVectorFieldData) GetRow(i int) interface{} {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Data[physicalIdx*data.Dim : (physicalIdx+1)*data.Dim]
 }
 
@@ -755,7 +775,10 @@ func (data *Float16VectorFieldData) GetRow(i int) interface{} {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Data[physicalIdx*data.Dim*2 : (physicalIdx+1)*data.Dim*2]
 }
 
@@ -763,7 +786,10 @@ func (data *BFloat16VectorFieldData) GetRow(i int) interface{} {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Data[physicalIdx*data.Dim*2 : (physicalIdx+1)*data.Dim*2]
 }
 
@@ -771,7 +797,10 @@ func (data *Int8VectorFieldData) GetRow(i int) interface{} {
 	if data.GetNullable() && !data.ValidData[i] {
 		return nil
 	}
-	physicalIdx := data.L2PMapping.GetPhysicalOffset(i)
+	physicalIdx := i
+	if data.GetNullable() {
+		physicalIdx = getNullableVectorPhysicalOffset(data.ValidData, &data.L2PMapping, i)
+	}
 	return data.Data[physicalIdx*data.Dim : (physicalIdx+1)*data.Dim]
 }
 
@@ -1125,7 +1154,7 @@ func (data *Int8VectorFieldData) AppendRow(row interface{}) error {
 func (data *VectorArrayFieldData) AppendRow(row interface{}) error {
 	v, ok := row.(*schemapb.VectorField)
 	if !ok {
-		return merr.WrapErrParameterInvalid("[]*schemapb.VectorField", row, "Wrong row type")
+		return merr.WrapErrParameterInvalid("*schemapb.VectorField", row, "Wrong row type")
 	}
 	data.Data = append(data.Data, v)
 	return nil
@@ -1227,55 +1256,128 @@ func (data *GeometryFieldData) AppendRows(dataRows interface{}, validDataRows in
 	return data.AppendValidDataRows(validDataRows)
 }
 
+func validateNullableVectorCompactRows(nullable bool, validDataRows interface{}, physicalRows int) error {
+	if !nullable {
+		return nil
+	}
+	validData, ok := validDataRows.([]bool)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]bool", validDataRows, "nullable vector requires valid data")
+	}
+	if err := funcutil.ValidateNullableVectorCompactRows("vector", validData, uint64(physicalRows), 0, true); err != nil {
+		return merr.WrapErrParameterInvalidMsg(err.Error())
+	}
+	return nil
+}
+
+func validateNullableVectorTotalRows(nullable bool, existingValidData []bool, newValidData []bool, physicalRows int) error {
+	if !nullable {
+		return nil
+	}
+	validCount := funcutil.CountValidRows(existingValidData) + funcutil.CountValidRows(newValidData)
+	if uint64(physicalRows) != validCount {
+		return merr.WrapErrParameterInvalidMsg(
+			"nullable vector compact data row count mismatch: physical rows=%d, valid rows=%d",
+			physicalRows,
+			validCount)
+	}
+	return nil
+}
+
 // AppendDataRows appends FLATTEN vectors to field data.
 func (data *BinaryVectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.([]byte)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]byte", dataRows, "Wrong rows type")
+	}
+	rowWidth := data.Dim / 8
+	if len(v)%rowWidth != 0 {
+		return merr.WrapErrParameterInvalid(rowWidth, len(v), "Wrong vector size")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v)/rowWidth); err != nil {
 		return err
 	}
+	data.Data = append(data.Data, v...)
 	return data.AppendValidDataRows(validDataRows)
 }
 
 // AppendDataRows appends FLATTEN vectors to field data.
 func (data *FloatVectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.([]float32)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]float32", dataRows, "Wrong rows type")
+	}
+	if len(v)%(data.Dim) != 0 {
+		return merr.WrapErrParameterInvalid(data.Dim, len(v), "Wrong vector size")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v)/data.Dim); err != nil {
 		return err
 	}
+	data.Data = append(data.Data, v...)
 	return data.AppendValidDataRows(validDataRows)
 }
 
 // AppendDataRows appends FLATTEN vectors to field data.
 func (data *Float16VectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.([]byte)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]byte", dataRows, "Wrong rows type")
+	}
+	rowWidth := data.Dim * 2
+	if len(v)%rowWidth != 0 {
+		return merr.WrapErrParameterInvalid(rowWidth, len(v), "Wrong vector size")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v)/rowWidth); err != nil {
 		return err
 	}
+	data.Data = append(data.Data, v...)
 	return data.AppendValidDataRows(validDataRows)
 }
 
 // AppendDataRows appends FLATTEN vectors to field data.
 func (data *BFloat16VectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.([]byte)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]byte", dataRows, "Wrong rows type")
+	}
+	rowWidth := data.Dim * 2
+	if len(v)%rowWidth != 0 {
+		return merr.WrapErrParameterInvalid(rowWidth, len(v), "Wrong vector size")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v)/rowWidth); err != nil {
 		return err
 	}
+	data.Data = append(data.Data, v...)
 	return data.AppendValidDataRows(validDataRows)
 }
 
 func (data *SparseFloatVectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.(*SparseFloatVectorFieldData)
+	if !ok {
+		return merr.WrapErrParameterInvalid("SparseFloatVectorFieldData", dataRows, "Wrong rows type")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v.Contents)); err != nil {
 		return err
+	}
+	data.Contents = append(data.Contents, v.Contents...)
+	if data.Dim < v.Dim {
+		data.Dim = v.Dim
 	}
 	return data.AppendValidDataRows(validDataRows)
 }
 
 func (data *Int8VectorFieldData) AppendRows(dataRows interface{}, validDataRows interface{}) error {
-	err := data.AppendDataRows(dataRows)
-	if err != nil {
+	v, ok := dataRows.([]int8)
+	if !ok {
+		return merr.WrapErrParameterInvalid("[]int8", dataRows, "Wrong rows type")
+	}
+	if len(v)%(data.Dim) != 0 {
+		return merr.WrapErrParameterInvalid(data.Dim, len(v), "Wrong vector size")
+	}
+	if err := validateNullableVectorCompactRows(data.GetNullable(), validDataRows, len(v)/data.Dim); err != nil {
 		return err
 	}
+	data.Data = append(data.Data, v...)
 	return data.AppendValidDataRows(validDataRows)
 }
 
@@ -1638,6 +1740,9 @@ func (data *BinaryVectorFieldData) AppendValidDataRows(rows interface{}) error {
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
 	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Data)/(data.Dim/8)); err != nil {
+		return err
+	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)
 	return nil
@@ -1649,8 +1754,8 @@ func (data *VectorArrayFieldData) AppendValidDataRows(rows interface{}) error {
 		if !ok {
 			return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
 		}
-		if len(v) != 0 {
-			return merr.WrapErrParameterInvalidMsg("not support Nullable in vector")
+		if len(v) != len(data.Data) {
+			return merr.WrapErrParameterInvalid(len(data.Data), len(v), "Wrong valid data size")
 		}
 	}
 	return nil
@@ -1664,6 +1769,9 @@ func (data *FloatVectorFieldData) AppendValidDataRows(rows interface{}) error {
 	v, ok := rows.([]bool)
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
+	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Data)/data.Dim); err != nil {
+		return err
 	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)
@@ -1679,6 +1787,9 @@ func (data *Float16VectorFieldData) AppendValidDataRows(rows interface{}) error 
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
 	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Data)/(data.Dim*2)); err != nil {
+		return err
+	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)
 	return nil
@@ -1693,6 +1804,9 @@ func (data *BFloat16VectorFieldData) AppendValidDataRows(rows interface{}) error
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
 	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Data)/(data.Dim*2)); err != nil {
+		return err
+	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)
 	return nil
@@ -1706,6 +1820,9 @@ func (data *SparseFloatVectorFieldData) AppendValidDataRows(rows interface{}) er
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
 	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Contents)); err != nil {
+		return err
+	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)
 	return nil
@@ -1718,6 +1835,9 @@ func (data *Int8VectorFieldData) AppendValidDataRows(rows interface{}) error {
 	v, ok := rows.([]bool)
 	if !ok {
 		return merr.WrapErrParameterInvalid("[]bool", rows, "Wrong rows type")
+	}
+	if err := validateNullableVectorTotalRows(data.GetNullable(), data.ValidData, v, len(data.Data)/data.Dim); err != nil {
+		return err
 	}
 	data.L2PMapping.Build(v, len(data.ValidData), len(v))
 	data.ValidData = append(data.ValidData, v...)

--- a/internal/storage/insert_data_test.go
+++ b/internal/storage/insert_data_test.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -475,4 +477,129 @@ func (s *ArrayFieldDataSuite) TestArrayFieldData() {
 	s.Equal(126, insertData.GetMemorySize())
 	s.False(insertData.IsEmpty())
 	s.Equal(115, insertData.GetRowSize(0))
+}
+
+func makeFloatVec(dim int, vals ...float32) *schemapb.VectorField {
+	return &schemapb.VectorField{
+		Dim: int64(dim),
+		Data: &schemapb.VectorField_FloatVector{
+			FloatVector: &schemapb.FloatArray{Data: vals},
+		},
+	}
+}
+
+func TestNullableVectorAppendRowsRejectsNonCompactData(t *testing.T) {
+	validData := []bool{true, false, true}
+	sparseRows := &SparseFloatVectorFieldData{
+		SparseFloatArray: schemapb.SparseFloatArray{
+			Dim: 8,
+			Contents: [][]byte{
+				typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1.0}),
+				typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2.0}),
+				typeutil.CreateSparseFloatRow([]uint32{3}, []float32{3.0}),
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		fieldData FieldData
+		rows      any
+	}{
+		{
+			name:      "binary vector",
+			fieldData: &BinaryVectorFieldData{Dim: 8, Nullable: true},
+			rows:      []byte{0x01, 0x02, 0x03},
+		},
+		{
+			name:      "float vector",
+			fieldData: &FloatVectorFieldData{Dim: 2, Nullable: true},
+			rows:      []float32{1, 2, 3, 4, 5, 6},
+		},
+		{
+			name:      "float16 vector",
+			fieldData: &Float16VectorFieldData{Dim: 2, Nullable: true},
+			rows:      []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+		},
+		{
+			name:      "bfloat16 vector",
+			fieldData: &BFloat16VectorFieldData{Dim: 2, Nullable: true},
+			rows:      []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+		},
+		{
+			name:      "sparse vector",
+			fieldData: &SparseFloatVectorFieldData{Nullable: true},
+			rows:      sparseRows,
+		},
+		{
+			name:      "int8 vector",
+			fieldData: &Int8VectorFieldData{Dim: 2, Nullable: true},
+			rows:      []int8{1, 2, 3, 4, 5, 6},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fieldData.AppendRows(tt.rows, validData)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "compact")
+			assert.Equal(t, 0, tt.fieldData.RowNum())
+			assert.Empty(t, nullableVectorValidDataForTest(tt.fieldData))
+		})
+	}
+}
+
+func nullableVectorValidDataForTest(fieldData FieldData) []bool {
+	switch data := fieldData.(type) {
+	case *BinaryVectorFieldData:
+		return data.ValidData
+	case *FloatVectorFieldData:
+		return data.ValidData
+	case *Float16VectorFieldData:
+		return data.ValidData
+	case *BFloat16VectorFieldData:
+		return data.ValidData
+	case *SparseFloatVectorFieldData:
+		return data.ValidData
+	case *Int8VectorFieldData:
+		return data.ValidData
+	default:
+		return nil
+	}
+}
+
+func TestVectorArrayFieldData_NonNullable(t *testing.T) {
+	fd := &VectorArrayFieldData{
+		Dim:         4,
+		ElementType: schemapb.DataType_FloatVector,
+		Data:        make([]*schemapb.VectorField, 0),
+	}
+
+	vec := makeFloatVec(4, 1, 2, 3, 4)
+	require.NoError(t, fd.AppendRow(vec))
+
+	assert.Equal(t, 1, fd.RowNum())
+	assert.False(t, fd.GetNullable())
+	assert.Nil(t, fd.GetValidData())
+	assert.Equal(t, vec, fd.GetRow(0))
+}
+
+func TestVectorArrayFieldData_AppendValidDataRows(t *testing.T) {
+	fd := &VectorArrayFieldData{
+		Dim:         4,
+		ElementType: schemapb.DataType_FloatVector,
+		Data: []*schemapb.VectorField{
+			makeFloatVec(4, 1, 2, 3, 4),
+			makeFloatVec(4, 5, 6, 7, 8),
+		},
+	}
+
+	err := fd.AppendValidDataRows([]bool{true, true})
+	require.NoError(t, err)
+
+	assert.Nil(t, fd.GetValidData())
+
+	assert.NoError(t, fd.AppendValidDataRows(nil))
+	assert.Error(t, fd.AppendValidDataRows("bad"))
+	assert.Error(t, fd.AppendValidDataRows([]bool{true}))
 }

--- a/internal/storage/payload_reader.go
+++ b/internal/storage/payload_reader.go
@@ -1079,8 +1079,6 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 					if rowDim > fieldData.Dim {
 						fieldData.Dim = rowDim
 					}
-				} else {
-					fieldData.Contents = append(fieldData.Contents, nil)
 				}
 			}
 			offset += binaryArray.Len()

--- a/internal/storage/payload_test.go
+++ b/internal/storage/payload_test.go
@@ -1794,6 +1794,39 @@ func TestPayload_ReaderAndWriter(t *testing.T) {
 	})
 }
 
+func TestNullableSparseFloatVectorPayloadReaderKeepsCompactRows(t *testing.T) {
+	validData := []bool{false, true, false, true}
+	contents := [][]byte{
+		typeutil.CreateSparseFloatRow([]uint32{1, 3}, []float32{1.1, 1.3}),
+		typeutil.CreateSparseFloatRow([]uint32{2, 4}, []float32{2.2, 2.4}),
+	}
+
+	w, err := NewPayloadWriter(schemapb.DataType_SparseFloatVector, WithNullable(true))
+	require.NoError(t, err)
+	err = w.AddSparseFloatVectorToPayload(&SparseFloatVectorFieldData{
+		SparseFloatArray: schemapb.SparseFloatArray{
+			Dim:      5,
+			Contents: contents,
+		},
+		ValidData: validData,
+		Nullable:  true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, w.FinishPayloadWriter())
+
+	buffer, err := w.GetPayloadBufferFromWriter()
+	require.NoError(t, err)
+	r, err := NewPayloadReader(schemapb.DataType_SparseFloatVector, buffer, true)
+	require.NoError(t, err)
+	defer r.ReleasePayloadReader()
+
+	readData, readDim, readValid, err := r.GetSparseFloatVectorFromPayload()
+	require.NoError(t, err)
+	require.Equal(t, 5, readDim)
+	require.Equal(t, validData, readValid)
+	require.Equal(t, contents, readData.Contents)
+}
+
 func TestPayload_NullableReaderAndWriter(t *testing.T) {
 	t.Run("TestBool", func(t *testing.T) {
 		w, err := NewPayloadWriter(schemapb.DataType_Bool, WithNullable(true))
@@ -2728,7 +2761,7 @@ func TestPayload_NullableReaderAndWriter(t *testing.T) {
 			require.NoError(t, err)
 
 			validData := make([]bool, numRows)
-			tc.validDataSetup(validData)
+			validCount := tc.validDataSetup(validData)
 
 			data := &SparseFloatVectorFieldData{
 				SparseFloatArray: schemapb.SparseFloatArray{
@@ -2761,21 +2794,95 @@ func TestPayload_NullableReaderAndWriter(t *testing.T) {
 			readData, _, readValid, err := r.GetSparseFloatVectorFromPayload()
 			require.NoError(t, err)
 			require.Equal(t, numRows, len(readValid))
-			require.Equal(t, numRows, len(readData.Contents))
+			require.Equal(t, validCount, len(readData.Contents))
 
+			dataIdx := 0
 			for i := 0; i < numRows; i++ {
 				require.Equal(t, validData[i], readValid[i])
 				if validData[i] {
-					require.NotNil(t, readData.Contents[i])
-					require.Equal(t, 16, len(readData.Contents[i]))
+					require.NotNil(t, readData.Contents[dataIdx])
+					require.Equal(t, 16, len(readData.Contents[dataIdx]))
 					for j := 0; j < 16; j++ {
-						require.Equal(t, byte((i*10+j)%256), readData.Contents[i][j])
+						require.Equal(t, byte((i*10+j)%256), readData.Contents[dataIdx][j])
 					}
-				} else {
-					require.Nil(t, readData.Contents[i])
+					dataIdx++
 				}
 			}
 		}
+	})
+
+	t.Run("TestNullableVectorRequiresValidData", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			dataTyp schemapb.DataType
+			dim     int
+			add     func(PayloadWriterInterface) error
+		}{
+			{
+				name:    "FloatVector",
+				dataTyp: schemapb.DataType_FloatVector,
+				dim:     2,
+				add: func(w PayloadWriterInterface) error {
+					return w.AddFloatVectorToPayload([]float32{1, 2}, 2, nil)
+				},
+			},
+			{
+				name:    "BinaryVector",
+				dataTyp: schemapb.DataType_BinaryVector,
+				dim:     8,
+				add: func(w PayloadWriterInterface) error {
+					return w.AddBinaryVectorToPayload([]byte{1}, 8, nil)
+				},
+			},
+			{
+				name:    "Float16Vector",
+				dataTyp: schemapb.DataType_Float16Vector,
+				dim:     1,
+				add: func(w PayloadWriterInterface) error {
+					return w.AddFloat16VectorToPayload([]byte{1, 2}, 1, nil)
+				},
+			},
+			{
+				name:    "BFloat16Vector",
+				dataTyp: schemapb.DataType_BFloat16Vector,
+				dim:     1,
+				add: func(w PayloadWriterInterface) error {
+					return w.AddBFloat16VectorToPayload([]byte{1, 2}, 1, nil)
+				},
+			},
+			{
+				name:    "Int8Vector",
+				dataTyp: schemapb.DataType_Int8Vector,
+				dim:     2,
+				add: func(w PayloadWriterInterface) error {
+					return w.AddInt8VectorToPayload([]int8{1, 2}, 2, nil)
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				w, err := NewPayloadWriter(tt.dataTyp, WithDim(tt.dim), WithNullable(true))
+				require.NoError(t, err)
+				defer w.Close()
+
+				err = tt.add(w)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "validData")
+			})
+		}
+
+		t.Run("SparseFloatVector", func(t *testing.T) {
+			w, err := NewPayloadWriter(schemapb.DataType_SparseFloatVector, WithNullable(true))
+			require.NoError(t, err)
+			defer w.Close()
+
+			err = w.AddSparseFloatVectorToPayload(&SparseFloatVectorFieldData{
+				SparseFloatArray: schemapb.SparseFloatArray{Contents: [][]byte{{1}}},
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "validData")
+		})
 	})
 
 	t.Run("TestAddBool with wrong valids", func(t *testing.T) {

--- a/internal/storage/payload_writer.go
+++ b/internal/storage/payload_writer.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	_ "github.com/milvus-io/milvus/internal/storage/compress" // register a custom zstd codec here, to avoid to much memory usage when serializing.
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -122,7 +123,7 @@ func NewPayloadWriter(colType schemapb.DataType, options ...PayloadWriterOptions
 		w.arrowType = arrow.ListOf(elemType)
 		w.builder = array.NewListBuilder(memory.DefaultAllocator, elemType)
 	} else {
-		if w.nullable && typeutil.IsVectorType(colType) && !typeutil.IsSparseFloatVectorType(colType) {
+		if w.nullable && typeutil.IsSupportedNullableVectorType(colType) && !typeutil.IsSparseFloatVectorType(colType) {
 			w.arrowType = &arrow.BinaryType{}
 			w.builder = array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
 		} else {
@@ -662,6 +663,13 @@ func (w *NativePayloadWriter) AddOneGeometryToPayload(data []byte, isValid bool)
 	return nil
 }
 
+func validateNullableVectorValidData(validData []bool) (int, error) {
+	if len(validData) == 0 {
+		return 0, merr.WrapErrParameterInvalidMsg("validData is required for nullable vector payload")
+	}
+	return int(funcutil.CountValidRows(validData)), nil
+}
+
 func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, validData []bool) error {
 	if w.finished {
 		return errors.New("can't append data to finished binary vector payload")
@@ -669,13 +677,11 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 
 	byteLength := dim / 8
 	var numRows int
-	if w.nullable && len(validData) > 0 {
+	if w.nullable {
 		numRows = len(validData)
-		validCount := 0
-		for _, valid := range validData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(validData)
+		if err != nil {
+			return err
 		}
 		expectedDataLen := validCount * byteLength
 		if len(data) != expectedDataLen {
@@ -730,13 +736,11 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 	}
 
 	var numRows int
-	if w.nullable && len(validData) > 0 {
+	if w.nullable {
 		numRows = len(validData)
-		validCount := 0
-		for _, valid := range validData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(validData)
+		if err != nil {
+			return err
 		}
 		expectedDataLen := validCount * dim
 		if len(data) != expectedDataLen {
@@ -806,13 +810,11 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 
 	byteLength := dim * 2
 	var numRows int
-	if w.nullable && len(validData) > 0 {
+	if w.nullable {
 		numRows = len(validData)
-		validCount := 0
-		for _, valid := range validData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(validData)
+		if err != nil {
+			return err
 		}
 		expectedDataLen := validCount * byteLength
 		if len(data) != expectedDataLen {
@@ -868,13 +870,11 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 
 	byteLength := dim * 2
 	var numRows int
-	if w.nullable && len(validData) > 0 {
+	if w.nullable {
 		numRows = len(validData)
-		validCount := 0
-		for _, valid := range validData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(validData)
+		if err != nil {
+			return err
 		}
 		expectedDataLen := validCount * byteLength
 		if len(data) != expectedDataLen {
@@ -929,13 +929,11 @@ func (w *NativePayloadWriter) AddSparseFloatVectorToPayload(data *SparseFloatVec
 	}
 
 	var numRows int
-	if w.nullable && len(data.ValidData) > 0 {
+	if w.nullable {
 		numRows = len(data.ValidData)
-		validCount := 0
-		for _, valid := range data.ValidData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(data.ValidData)
+		if err != nil {
+			return err
 		}
 		if len(data.Contents) != validCount {
 			msg := fmt.Sprintf("when nullable, Contents length(%d) must equal to valid count(%d)", len(data.Contents), validCount)
@@ -974,13 +972,11 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 	}
 
 	var numRows int
-	if w.nullable && len(validData) > 0 {
+	if w.nullable {
 		numRows = len(validData)
-		validCount := 0
-		for _, valid := range validData {
-			if valid {
-				validCount++
-			}
+		validCount, err := validateNullableVectorValidData(validData)
+		if err != nil {
+			return err
 		}
 		expectedDataLen := validCount * dim
 		if len(data) != expectedDataLen {
@@ -1051,7 +1047,7 @@ func (w *NativePayloadWriter) FinishPayloadWriter() error {
 			[]string{"elementType", "dim"},
 			[]string{fmt.Sprintf("%d", int32(*w.elementType)), fmt.Sprintf("%d", w.dim.GetValue())},
 		)
-	} else if w.nullable && typeutil.IsVectorType(w.dataType) && !typeutil.IsSparseFloatVectorType(w.dataType) {
+	} else if w.nullable && typeutil.IsSupportedNullableVectorType(w.dataType) && !typeutil.IsSparseFloatVectorType(w.dataType) {
 		metadata = arrow.NewMetadata(
 			[]string{"dim"},
 			[]string{fmt.Sprintf("%d", w.dim.GetValue())},
@@ -1079,7 +1075,7 @@ func (w *NativePayloadWriter) FinishPayloadWriter() error {
 
 	arrowWriterProps := pqarrow.DefaultWriterProps()
 	if w.dataType == schemapb.DataType_ArrayOfVector ||
-		(w.nullable && typeutil.IsVectorType(w.dataType) && !typeutil.IsSparseFloatVectorType(w.dataType)) {
+		(w.nullable && typeutil.IsSupportedNullableVectorType(w.dataType) && !typeutil.IsSparseFloatVectorType(w.dataType)) {
 		// Store metadata in the Arrow writer properties
 		arrowWriterProps = pqarrow.NewArrowWriterProperties(
 			pqarrow.WithStoreSchema(),

--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -470,14 +470,14 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			return deserializeArrayOfVector(a, i, elementType, int64(dim), shouldCopy)
 		},
 		serialize: func(b array.Builder, v any, elementType schemapb.DataType) error {
+			if v == nil {
+				b.AppendNull()
+				return nil
+			}
+
 			vf, ok := v.(*schemapb.VectorField)
 			if !ok {
 				return fmt.Errorf("expected *schemapb.VectorField, got %T", v)
-			}
-
-			if vf == nil {
-				b.AppendNull()
-				return nil
 			}
 
 			builder, ok := b.(*array.ListBuilder)
@@ -565,7 +565,16 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return value, nil
 		}
-		return nil, fmt.Errorf("expected *array.FixedSizeBinary, got %T", a)
+		if arr, ok := a.(*array.Binary); ok && i < arr.Len() {
+			value := arr.Value(i)
+			if shouldCopy {
+				result := make([]byte, len(value))
+				copy(result, value)
+				return result, nil
+			}
+			return value, nil
+		}
+		return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 	}
 	fixedSizeSerializer := func(b array.Builder, v any, _ schemapb.DataType) error {
 		if v == nil {
@@ -615,16 +624,25 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if a.IsNull(i) {
 				return nil, nil
 			}
-			if arr, ok := a.(*array.FixedSizeBinary); ok && i < arr.Len() {
-				// convert to []int8
-				bytes := arr.Value(i)
+			var bytes []byte
+			switch arr := a.(type) {
+			case *array.FixedSizeBinary:
+				if i < arr.Len() {
+					bytes = arr.Value(i)
+				}
+			case *array.Binary:
+				if i < arr.Len() {
+					bytes = arr.Value(i)
+				}
+			}
+			if bytes != nil {
 				int8s := make([]int8, len(bytes))
 				for i, b := range bytes {
 					int8s[i] = int8(b)
 				}
 				return int8s, nil
 			}
-			return nil, fmt.Errorf("expected *array.FixedSizeBinary, got %T", a)
+			return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -658,8 +676,19 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if a.IsNull(i) {
 				return nil, nil
 			}
-			if arr, ok := a.(*array.FixedSizeBinary); ok && i < arr.Len() {
-				vector := arrow.Float32Traits.CastFromBytes(arr.Value(i))
+			var bytes []byte
+			switch arr := a.(type) {
+			case *array.FixedSizeBinary:
+				if i < arr.Len() {
+					bytes = arr.Value(i)
+				}
+			case *array.Binary:
+				if i < arr.Len() {
+					bytes = arr.Value(i)
+				}
+			}
+			if bytes != nil {
+				vector := arrow.Float32Traits.CastFromBytes(bytes)
 				if shouldCopy {
 					vectorCopy := make([]float32, len(vector))
 					copy(vectorCopy, vector)
@@ -667,7 +696,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return vector, nil
 			}
-			return nil, fmt.Errorf("expected *array.FixedSizeBinary, got %T", a)
+			return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -1074,7 +1103,7 @@ func newSingleFieldRecordWriter(field *schemapb.FieldSchema, writer io.Writer, o
 		)
 	}
 
-	if field.GetNullable() && typeutil.IsVectorType(field.DataType) && !typeutil.IsSparseFloatVectorType(field.DataType) {
+	if field.GetNullable() && typeutil.IsSupportedNullableVectorType(field.DataType) && !typeutil.IsSparseFloatVectorType(field.DataType) {
 		arrowType = arrow.BinaryTypes.Binary
 		fieldMetadata = arrow.NewMetadata(
 			[]string{"dim"},
@@ -1106,8 +1135,9 @@ func newSingleFieldRecordWriter(field *schemapb.FieldSchema, writer io.Writer, o
 
 	// Use appropriate Arrow writer properties for ArrayOfVector
 	arrowWriterProps := pqarrow.DefaultWriterProps()
-	if field.DataType == schemapb.DataType_ArrayOfVector {
-		// Ensure schema metadata is preserved for ArrayOfVector
+	if field.DataType == schemapb.DataType_ArrayOfVector ||
+		(field.GetNullable() && isNullableDenseVectorArrowType(field.DataType)) {
+		// Preserve dim/elementType metadata required by binary-backed vector layouts.
 		arrowWriterProps = pqarrow.NewArrowWriterProperties(
 			pqarrow.WithStoreSchema(),
 		)
@@ -1294,7 +1324,7 @@ func BuildRecord(b *array.RecordBuilder, data *InsertData, schema *schemapb.Coll
 			elementType = field.GetElementType()
 		}
 
-		if field.GetNullable() && typeutil.IsVectorType(field.DataType) {
+		if field.GetNullable() && typeutil.IsSupportedNullableVectorType(field.DataType) {
 			var validData []bool
 			switch fd := fieldData.(type) {
 			case *FloatVectorFieldData:

--- a/internal/storage/serde_events.go
+++ b/internal/storage/serde_events.go
@@ -425,21 +425,20 @@ func ValueSerializer(v []*Value, schema *schemapb.CollectionSchema) (Record, err
 	for _, structField := range schema.StructArrayFields {
 		allFieldsSchema = append(allFieldsSchema, structField.Fields...)
 	}
+	arrowSchema, err := ConvertToArrowSchema(schema, false)
+	if err != nil {
+		return nil, err
+	}
 
 	builders := make(map[FieldID]array.Builder, len(allFieldsSchema))
 	types := make(map[FieldID]schemapb.DataType, len(allFieldsSchema))
 	elementTypes := make(map[FieldID]schemapb.DataType, len(allFieldsSchema)) // For ArrayOfVector
-	for _, f := range allFieldsSchema {
-		dim, _ := typeutil.GetDim(f)
-
-		elementType := schemapb.DataType_None
+	for i, f := range allFieldsSchema {
 		if f.DataType == schemapb.DataType_ArrayOfVector {
-			elementType = f.GetElementType()
-			elementTypes[f.FieldID] = elementType
+			elementTypes[f.FieldID] = f.GetElementType()
 		}
 
-		arrowType := serdeMap[f.DataType].arrowType(int(dim), elementType)
-		builders[f.FieldID] = array.NewBuilder(memory.DefaultAllocator, arrowType)
+		builders[f.FieldID] = array.NewBuilder(memory.DefaultAllocator, arrowSchema.Field(i).Type)
 		builders[f.FieldID].Reserve(len(v)) // reserve space to avoid copy
 		types[f.FieldID] = f.DataType
 	}
@@ -471,7 +470,7 @@ func ValueSerializer(v []*Value, schema *schemapb.CollectionSchema) (Record, err
 		builder := builders[field.FieldID]
 		arrays[i] = builder.NewArray()
 		builder.Release()
-		fields[i] = ConvertToArrowField(field, arrays[i].DataType(), false)
+		fields[i] = arrowSchema.Field(i)
 		field2Col[field.FieldID] = i
 	}
 	return NewSimpleArrowRecord(array.NewRecord(arrow.NewSchema(fields, nil), arrays, int64(len(v))), field2Col), nil

--- a/internal/storage/serde_events_test.go
+++ b/internal/storage/serde_events_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -181,6 +182,192 @@ func TestBinlogSerializeWriter(t *testing.T) {
 		assert.Equal(t, 18, len(logs))
 		assert.Equal(t, 5, len(logs[0].Binlogs))
 	})
+}
+
+func TestValueDeserializerNullableDenseVectorBinaryRecord(t *testing.T) {
+	for _, tc := range nullableDenseVectorSerdeCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := nullableDenseVectorSerdeSchema(tc.dataType, tc.dim)
+			insertData := nullableDenseVectorSerdeInsertData(t, tc, schema)
+
+			arrowSchema, err := ConvertToArrowSchema(schema, false)
+			require.NoError(t, err)
+			builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+			defer builder.Release()
+			require.NoError(t, BuildRecord(builder, insertData, schema))
+			record := NewSimpleArrowRecord(builder.NewRecord(), map[FieldID]int{
+				common.RowIDField:          0,
+				common.TimeStampField:      1,
+				nullableSerdePKFieldID:     2,
+				nullableSerdeVectorFieldID: 3,
+			})
+			defer record.Release()
+
+			require.IsType(t, &array.Binary{}, record.Column(nullableSerdeVectorFieldID))
+			require.True(t, record.Column(nullableSerdeVectorFieldID).IsNull(1))
+
+			values := make([]*Value, record.Len())
+			err = ValueDeserializerWithSchema(record, values, schema, true)
+			require.NoError(t, err)
+
+			got := values[0].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID]
+			assert.Equal(t, tc.row0, got)
+			assert.Nil(t, values[1].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID])
+			got = values[2].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID]
+			assert.Equal(t, tc.row2, got)
+		})
+	}
+}
+
+func TestValueSerializerNullableDenseVectorUsesBinaryArrow(t *testing.T) {
+	for _, tc := range nullableDenseVectorSerdeCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := nullableDenseVectorSerdeSchema(tc.dataType, tc.dim)
+			values := []*Value{
+				{Value: map[FieldID]any{
+					common.RowIDField:          int64(11),
+					common.TimeStampField:      int64(101),
+					nullableSerdePKFieldID:     int64(1),
+					nullableSerdeVectorFieldID: tc.row0,
+				}},
+				{Value: map[FieldID]any{
+					common.RowIDField:          int64(12),
+					common.TimeStampField:      int64(102),
+					nullableSerdePKFieldID:     int64(2),
+					nullableSerdeVectorFieldID: nil,
+				}},
+				{Value: map[FieldID]any{
+					common.RowIDField:          int64(13),
+					common.TimeStampField:      int64(103),
+					nullableSerdePKFieldID:     int64(3),
+					nullableSerdeVectorFieldID: tc.row2,
+				}},
+			}
+
+			record, err := ValueSerializer(values, schema)
+			require.NoError(t, err)
+			defer record.Release()
+
+			require.IsType(t, &array.Binary{}, record.Column(nullableSerdeVectorFieldID))
+			require.True(t, record.Column(nullableSerdeVectorFieldID).IsNull(1))
+			simpleRecord := record.(*simpleArrowRecord)
+			dim, ok := simpleRecord.r.Schema().Field(3).Metadata.GetValue(common.DimKey)
+			require.True(t, ok)
+			assert.Equal(t, strconv.FormatInt(tc.dim, 10), dim)
+
+			roundTrip := make([]*Value, record.Len())
+			err = ValueDeserializerWithSchema(record, roundTrip, schema, true)
+			require.NoError(t, err)
+			assert.Equal(t, tc.row0, roundTrip[0].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID])
+			assert.Nil(t, roundTrip[1].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID])
+			assert.Equal(t, tc.row2, roundTrip[2].Value.(map[FieldID]interface{})[nullableSerdeVectorFieldID])
+		})
+	}
+}
+
+type nullableDenseVectorSerdeCase struct {
+	name     string
+	dataType schemapb.DataType
+	dim      int64
+	row0     any
+	row2     any
+}
+
+const (
+	nullableSerdePKFieldID     FieldID = common.StartOfUserFieldID
+	nullableSerdeVectorFieldID FieldID = common.StartOfUserFieldID + 1
+)
+
+func nullableDenseVectorSerdeCases() []nullableDenseVectorSerdeCase {
+	return []nullableDenseVectorSerdeCase{
+		{
+			name:     "FloatVector",
+			dataType: schemapb.DataType_FloatVector,
+			dim:      2,
+			row0:     []float32{1, 2},
+			row2:     []float32{3, 4},
+		},
+		{
+			name:     "BinaryVector",
+			dataType: schemapb.DataType_BinaryVector,
+			dim:      16,
+			row0:     []byte{0x11, 0x12},
+			row2:     []byte{0x21, 0x22},
+		},
+		{
+			name:     "Float16Vector",
+			dataType: schemapb.DataType_Float16Vector,
+			dim:      2,
+			row0:     []byte{1, 2, 3, 4},
+			row2:     []byte{5, 6, 7, 8},
+		},
+		{
+			name:     "BFloat16Vector",
+			dataType: schemapb.DataType_BFloat16Vector,
+			dim:      2,
+			row0:     []byte{11, 12, 13, 14},
+			row2:     []byte{15, 16, 17, 18},
+		},
+		{
+			name:     "Int8Vector",
+			dataType: schemapb.DataType_Int8Vector,
+			dim:      2,
+			row0:     []int8{1, 2},
+			row2:     []int8{3, 4},
+		},
+	}
+}
+
+func nullableDenseVectorSerdeSchema(dataType schemapb.DataType, dim int64) *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  common.RowIDField,
+				Name:     common.RowIDFieldName,
+				DataType: schemapb.DataType_Int64,
+			},
+			{
+				FieldID:  common.TimeStampField,
+				Name:     common.TimeStampFieldName,
+				DataType: schemapb.DataType_Int64,
+			},
+			{
+				FieldID:      nullableSerdePKFieldID,
+				Name:         "pk",
+				DataType:     schemapb.DataType_Int64,
+				IsPrimaryKey: true,
+			},
+			{
+				FieldID:  nullableSerdeVectorFieldID,
+				Name:     "nullable_vector",
+				DataType: dataType,
+				Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: strconv.FormatInt(dim, 10)},
+				},
+			},
+		},
+	}
+}
+
+func nullableDenseVectorSerdeInsertData(t *testing.T, tc nullableDenseVectorSerdeCase, schema *schemapb.CollectionSchema) *InsertData {
+	t.Helper()
+
+	vectorField := schema.GetFields()[3]
+	vectorData, err := NewFieldData(tc.dataType, vectorField, 3)
+	require.NoError(t, err)
+	require.NoError(t, vectorData.AppendRow(tc.row0))
+	require.NoError(t, vectorData.AppendRow(nil))
+	require.NoError(t, vectorData.AppendRow(tc.row2))
+
+	return &InsertData{
+		Data: map[FieldID]FieldData{
+			common.RowIDField:          &Int64FieldData{Data: []int64{11, 12, 13}},
+			common.TimeStampField:      &Int64FieldData{Data: []int64{101, 102, 103}},
+			nullableSerdePKFieldID:     &Int64FieldData{Data: []int64{1, 2, 3}},
+			nullableSerdeVectorFieldID: vectorData,
+		},
+	}
 }
 
 func TestCompositeBinlogRecordWriter_TTLFieldCollection(t *testing.T) {

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -42,6 +42,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -537,6 +538,43 @@ func RowBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *schemap
 // This funcion also checks the length of each column. All columns shall have the same length.
 // Also, the InsertData.Infos shall have BlobInfo with this length returned.
 // When the length is not aligned, an error will be returned.
+func validateColumnBasedNullableVectorFieldData(field *schemapb.FieldSchema, srcField *schemapb.FieldData, logicalRows int) error {
+	if !field.GetNullable() || !typeutil.IsSupportedNullableVectorType(field.GetDataType()) {
+		return nil
+	}
+	dim := int64(0)
+	if field.GetDataType() != schemapb.DataType_SparseFloatVector && srcField.GetVectors() != nil && srcField.GetVectors().GetDim() == 0 {
+		fieldDim, err := GetDimFromParams(field.GetTypeParams())
+		if err != nil {
+			return err
+		}
+		dim = int64(fieldDim)
+	}
+	requireValidData := logicalRows > 0 || len(srcField.GetValidData()) > 0
+	if err := funcutil.ValidateNullableVectorFieldDataCompactWithDim(srcField, uint64(logicalRows), requireValidData, dim); err != nil {
+		return merr.WrapErrParameterInvalidMsg(err.Error())
+	}
+	return nil
+}
+
+func validateColumnBasedInsertMsgNullableVectors(schema *schemapb.CollectionSchema, msg *msgstream.InsertMsg) error {
+	srcFields := make(map[int64]*schemapb.FieldData, len(msg.GetFieldsData()))
+	for _, fieldData := range msg.GetFieldsData() {
+		srcFields[fieldData.GetFieldId()] = fieldData
+	}
+
+	for _, field := range typeutil.GetAllFieldSchemas(schema) {
+		srcField, ok := srcFields[field.GetFieldID()]
+		if !ok {
+			continue
+		}
+		if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *schemapb.CollectionSchema) (idata *InsertData, err error) {
 	srcFields := make(map[FieldID]*schemapb.FieldData)
 	for _, field := range msg.FieldsData {
@@ -570,6 +608,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 
 			srcData := srcField.GetVectors().GetFloatVector().GetData()
 			validData := srcField.GetValidData()
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
+			}
 			fd := &FloatVectorFieldData{
 				Data:      srcData,
 				Dim:       dim,
@@ -590,6 +631,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 
 			srcData := srcField.GetVectors().GetBinaryVector()
 			validData := srcField.GetValidData()
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
+			}
 			fd := &BinaryVectorFieldData{
 				Data:      srcData,
 				Dim:       dim,
@@ -610,6 +654,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 
 			srcData := srcField.GetVectors().GetFloat16Vector()
 			validData := srcField.GetValidData()
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
+			}
 			fd := &Float16VectorFieldData{
 				Data:      srcData,
 				Dim:       dim,
@@ -630,6 +677,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 
 			srcData := srcField.GetVectors().GetBfloat16Vector()
 			validData := srcField.GetValidData()
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
+			}
 			fd := &BFloat16VectorFieldData{
 				Data:      srcData,
 				Dim:       dim,
@@ -649,6 +699,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 			if sparseArray != nil {
 				contents = sparseArray.GetContents()
 				dim = sparseArray.GetDim()
+			}
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
 			}
 			fd := &SparseFloatVectorFieldData{
 				SparseFloatArray: schemapb.SparseFloatArray{
@@ -672,6 +725,9 @@ func ColumnBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *sche
 
 			srcData := srcField.GetVectors().GetInt8Vector()
 			validData := srcField.GetValidData()
+			if err := validateColumnBasedNullableVectorFieldData(field, srcField, int(msg.GetNumRows())); err != nil {
+				return nil, err
+			}
 			fd := &Int8VectorFieldData{
 				Data:      lo.Map(srcData, func(v byte, _ int) int8 { return int8(v) }),
 				Dim:       dim,
@@ -1597,6 +1653,10 @@ func TransferInsertMsgToInsertRecord(schema *schemapb.CollectionSchema, msg *msg
 	}
 
 	// column base insert msg
+	if err := validateColumnBasedInsertMsgNullableVectors(schema, msg); err != nil {
+		return nil, err
+	}
+
 	insertRecord := &segcorepb.InsertRecord{
 		NumRows:    int64(msg.NumRows),
 		FieldsData: make([]*schemapb.FieldData, 0),

--- a/internal/storage/utils_test.go
+++ b/internal/storage/utils_test.go
@@ -1258,6 +1258,235 @@ func TestColumnBasedInsertMsgToInsertDataNullable(t *testing.T) {
 	}
 }
 
+func TestColumnBasedInsertMsgToInsertDataRejectsNullableVectorNonCompactData(t *testing.T) {
+	validData := []bool{true, false, true}
+	makeSchema := func(dataType schemapb.DataType, dim string) *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Name: "nullable_vector_compact",
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:      100,
+					Name:         "pk",
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+				},
+				{
+					FieldID:  101,
+					Name:     "vec",
+					DataType: dataType,
+					Nullable: true,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: dim},
+					},
+				},
+			},
+		}
+	}
+	makeMsg := func(dataType schemapb.DataType, vectors *schemapb.VectorField) *msgstream.InsertMsg {
+		return &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						Type:      schemapb.DataType_Int64,
+						FieldName: "pk",
+						FieldId:   100,
+						Field: &schemapb.FieldData_Scalars{
+							Scalars: &schemapb.ScalarField{
+								Data: &schemapb.ScalarField_LongData{
+									LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+								},
+							},
+						},
+					},
+					{
+						Type:      dataType,
+						FieldName: "vec",
+						FieldId:   101,
+						ValidData: validData,
+						Field:     &schemapb.FieldData_Vectors{Vectors: vectors},
+					},
+				},
+				NumRows: 3,
+				Version: msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		dataType schemapb.DataType
+		dim      string
+		vectors  *schemapb.VectorField
+	}{
+		{
+			name:     "float vector",
+			dataType: schemapb.DataType_FloatVector,
+			dim:      "2",
+			vectors: &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3, 4, 5, 6}},
+			}},
+		},
+		{
+			name:     "binary vector",
+			dataType: schemapb.DataType_BinaryVector,
+			dim:      "8",
+			vectors:  &schemapb.VectorField{Dim: 8, Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 2, 3}}},
+		},
+		{
+			name:     "float16 vector",
+			dataType: schemapb.DataType_Float16Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}}},
+		},
+		{
+			name:     "bfloat16 vector",
+			dataType: schemapb.DataType_BFloat16Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}}},
+		},
+		{
+			name:     "sparse vector",
+			dataType: schemapb.DataType_SparseFloatVector,
+			dim:      "2",
+			vectors: &schemapb.VectorField{Data: &schemapb.VectorField_SparseFloatVector{
+				SparseFloatVector: &schemapb.SparseFloatArray{Contents: [][]byte{
+					typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1}),
+					typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2}),
+					typeutil.CreateSparseFloatRow([]uint32{3}, []float32{3}),
+				}},
+			}},
+		},
+		{
+			name:     "int8 vector",
+			dataType: schemapb.DataType_Int8Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{1, 2, 3, 4, 5, 6}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := makeMsg(tt.dataType, tt.vectors)
+			schema := makeSchema(tt.dataType, tt.dim)
+
+			_, err := ColumnBasedInsertMsgToInsertData(msg, schema)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "compact")
+
+			_, err = TransferInsertMsgToInsertRecord(schema, msg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "compact")
+		})
+	}
+}
+
+func TestColumnBasedInsertMsgToInsertDataRejectsNullableVectorPartialRowData(t *testing.T) {
+	makeSchema := func(dataType schemapb.DataType, dim string) *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Name: "nullable_vector_partial_row",
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:      100,
+					Name:         "pk",
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+				},
+				{
+					FieldID:  101,
+					Name:     "vec",
+					DataType: dataType,
+					Nullable: true,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: dim},
+					},
+				},
+			},
+		}
+	}
+	makeMsg := func(dataType schemapb.DataType, vectors *schemapb.VectorField) *msgstream.InsertMsg {
+		return &msgstream.InsertMsg{
+			InsertRequest: &msgpb.InsertRequest{
+				FieldsData: []*schemapb.FieldData{
+					{
+						Type:      schemapb.DataType_Int64,
+						FieldName: "pk",
+						FieldId:   100,
+						Field: &schemapb.FieldData_Scalars{
+							Scalars: &schemapb.ScalarField{
+								Data: &schemapb.ScalarField_LongData{
+									LongData: &schemapb.LongArray{Data: []int64{1, 2}},
+								},
+							},
+						},
+					},
+					{
+						Type:      dataType,
+						FieldName: "vec",
+						FieldId:   101,
+						ValidData: []bool{true, false},
+						Field:     &schemapb.FieldData_Vectors{Vectors: vectors},
+					},
+				},
+				NumRows: 2,
+				Version: msgpb.InsertDataVersion_ColumnBased,
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		dataType schemapb.DataType
+		dim      string
+		vectors  *schemapb.VectorField
+	}{
+		{
+			name:     "float vector",
+			dataType: schemapb.DataType_FloatVector,
+			dim:      "2",
+			vectors: &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3}},
+			}},
+		},
+		{
+			name:     "binary vector",
+			dataType: schemapb.DataType_BinaryVector,
+			dim:      "16",
+			vectors:  &schemapb.VectorField{Dim: 16, Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 2, 3}}},
+		},
+		{
+			name:     "float16 vector",
+			dataType: schemapb.DataType_Float16Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2, 3, 4, 5}}},
+		},
+		{
+			name:     "bfloat16 vector",
+			dataType: schemapb.DataType_BFloat16Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{1, 2, 3, 4, 5}}},
+		},
+		{
+			name:     "int8 vector",
+			dataType: schemapb.DataType_Int8Vector,
+			dim:      "2",
+			vectors:  &schemapb.VectorField{Dim: 2, Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{1, 2, 3}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := makeMsg(tt.dataType, tt.vectors)
+			schema := makeSchema(tt.dataType, tt.dim)
+
+			_, err := ColumnBasedInsertMsgToInsertData(msg, schema)
+			require.Error(t, err)
+
+			_, err = TransferInsertMsgToInsertRecord(schema, msg)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestColumnBasedInsertMsgToInsertFloat16VectorDataError(t *testing.T) {
 	msg := &msgstream.InsertMsg{
 		BaseMsg: msgstream.BaseMsg{
@@ -2834,4 +3063,23 @@ func TestInsertDataWithStructAndMissingField(t *testing.T) {
 	for _, valid := range int64Field.ValidData {
 		assert.False(t, valid, "nullable field should have all null values")
 	}
+}
+
+func TestMergeInsertDataNullableSparseAllNullPreservesValidData(t *testing.T) {
+	buffer := &InsertData{Data: make(map[FieldID]FieldData)}
+	allNull := &InsertData{Data: map[FieldID]FieldData{
+		100: &SparseFloatVectorFieldData{
+			SparseFloatArray: schemapb.SparseFloatArray{Dim: 8},
+			ValidData:        []bool{false, false},
+			Nullable:         true,
+		},
+	}}
+
+	MergeInsertData(buffer, allNull)
+
+	merged := buffer.Data[100].(*SparseFloatVectorFieldData)
+	require.True(t, merged.Nullable)
+	require.Equal(t, []bool{false, false}, merged.ValidData)
+	require.Empty(t, merged.Contents)
+	require.Equal(t, 2, merged.RowNum())
 }

--- a/internal/streamingnode/server/wal/adaptor/opener_test.go
+++ b/internal/streamingnode/server/wal/adaptor/opener_test.go
@@ -151,7 +151,8 @@ func TestHandleAlterWALFlushingStagePassesRateLimitComponent(t *testing.T) {
 	var capturedParam *flusherimpl.RecoverWALFlusherParam
 	mockRecoverFlusher := mockey.Mock(flusherimpl.RecoverWALFlusher).
 		To(func(param *flusherimpl.RecoverWALFlusherParam) *flusherimpl.WALFlusherImpl {
-			capturedParam = param
+			captured := *param
+			capturedParam = &captured
 			return &flusherimpl.WALFlusherImpl{}
 		}).
 		Build()
@@ -171,6 +172,8 @@ func TestHandleAlterWALFlushingStagePassesRateLimitComponent(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, capturedParam)
+	require.NotNil(t, capturedParam.RateLimitComponent)
+	require.NotNil(t, capturedParam.WAL)
 	assert.Same(t, rateLimitComponent, capturedParam.RateLimitComponent)
 	assert.Same(t, roWAL, capturedParam.WAL.Get())
 	assert.Same(t, rs, capturedParam.RecoveryStorage)

--- a/internal/util/importutilv2/numpy/field_reader.go
+++ b/internal/util/importutilv2/numpy/field_reader.go
@@ -119,6 +119,21 @@ func (c *FieldReader) getCount(count int64) int64 {
 	return count
 }
 
+func (c *FieldReader) logicalRowCount(readCount int64) int64 {
+	switch c.field.GetDataType() {
+	case schemapb.DataType_BinaryVector:
+		return readCount / (c.dim / 8)
+	case schemapb.DataType_FloatVector:
+		return readCount / c.dim
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		return readCount / (c.dim * 2)
+	case schemapb.DataType_Int8Vector:
+		return readCount / c.dim
+	default:
+		return readCount
+	}
+}
+
 func (c *FieldReader) Next(count int64) (any, any, error) {
 	readCount := c.getCount(count)
 	if readCount == 0 {
@@ -134,8 +149,9 @@ func (c *FieldReader) Next(count int64) (any, any, error) {
 	// construct a bool array with all-true if the field is nullable
 
 	if c.field.GetNullable() || c.field.GetDefaultValue() != nil {
-		validData = make([]bool, 0, readCount)
-		for i := int64(0); i < readCount; i++ {
+		validRows := c.logicalRowCount(readCount)
+		validData = make([]bool, 0, validRows)
+		for i := int64(0); i < validRows; i++ {
 			validData = append(validData, true)
 		}
 	}

--- a/internal/util/importutilv2/numpy/field_reader_test.go
+++ b/internal/util/importutilv2/numpy/field_reader_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/testutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -196,6 +197,82 @@ func TestNormalRead(t *testing.T) {
 
 	checkFn(false)
 	checkFn(true)
+}
+
+func TestNullableVectorValidDataUsesLogicalRows(t *testing.T) {
+	tests := []struct {
+		name      string
+		dataType  schemapb.DataType
+		fieldData storage.FieldData
+	}{
+		{
+			name:     "float vector",
+			dataType: schemapb.DataType_FloatVector,
+			fieldData: &storage.FloatVectorFieldData{
+				Data: make([]float32, 2*dim),
+				Dim:  dim,
+			},
+		},
+		{
+			name:     "float16 vector",
+			dataType: schemapb.DataType_Float16Vector,
+			fieldData: &storage.Float16VectorFieldData{
+				Data: make([]byte, 2*dim*2),
+				Dim:  dim,
+			},
+		},
+		{
+			name:     "bfloat16 vector",
+			dataType: schemapb.DataType_BFloat16Vector,
+			fieldData: &storage.BFloat16VectorFieldData{
+				Data: make([]byte, 2*dim*2),
+				Dim:  dim,
+			},
+		},
+		{
+			name:     "int8 vector",
+			dataType: schemapb.DataType_Int8Vector,
+			fieldData: &storage.Int8VectorFieldData{
+				Data: make([]int8, 2*dim),
+				Dim:  dim,
+			},
+		},
+		{
+			name:     "binary vector",
+			dataType: schemapb.DataType_BinaryVector,
+			fieldData: &storage.BinaryVectorFieldData{
+				Data: make([]byte, 2*dim/8),
+				Dim:  dim,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := &schemapb.FieldSchema{
+				FieldID:  100,
+				Name:     "nullable_vector",
+				DataType: tt.dataType,
+				Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "8"},
+				},
+			}
+			reader, err := createReader(tt.fieldData, tt.dataType)
+			assert.NoError(t, err)
+
+			fr, err := NewFieldReader(reader, field, common.DefaultTimezone)
+			assert.NoError(t, err)
+			data, validData, err := fr.Next(2)
+			assert.NoError(t, err)
+			assert.Len(t, validData.([]bool), 2)
+
+			dst, err := storage.NewFieldData(tt.dataType, field, 0)
+			assert.NoError(t, err)
+			assert.NoError(t, dst.AppendRows(data, validData))
+			assert.Equal(t, 2, dst.RowNum())
+		})
+	}
 }
 
 type ErrReader struct {

--- a/internal/util/importutilv2/parquet/field_reader.go
+++ b/internal/util/importutilv2/parquet/field_reader.go
@@ -902,11 +902,20 @@ func ReadNullableBinaryData(pcr *FieldReader, count int64) (any, []bool, error) 
 			}
 		case arrow.BINARY:
 			binaryReader := chunk.(*array.Binary)
+			expectedRowWidth, err := expectedVectorListLength(pcr.dim, dataType)
+			if err != nil {
+				return nil, nil, err
+			}
 			for i := 0; i < rows; i++ {
 				if binaryReader.IsNull(i) {
 					validData = append(validData, false)
 				} else {
-					data = append(data, binaryReader.Value(i)...)
+					value := binaryReader.Value(i)
+					if len(value) != int(expectedRowWidth) {
+						return nil, nil, merr.WrapErrImportFailed(fmt.Sprintf("vector row width mismatch: field %s, row %d, expected %d bytes but got %d bytes, data type: %s",
+							pcr.field.GetName(), len(validData), expectedRowWidth, len(value), dataType.String()))
+					}
+					data = append(data, value...)
 					validData = append(validData, true)
 				}
 			}
@@ -959,118 +968,141 @@ func parseSparseFloatRowVector(str string) ([]byte, uint32, error) {
 // to return one-dim list. We use the start/end position of ValueOffsets() to get the correct sparse vector
 // from ListValues().
 // Note that arrow.Uint32.Value(int i) accepts an int32 value, the max length of indices/values is max value of int32
+func parseSparseFloatVectorStructRow(st map[string]arrow.Array, row int) ([]byte, uint32, error) {
+	indices, ok1 := st[sparseVectorIndice]
+	values, ok2 := st[sparseVectorValues]
+	if !ok1 || !ok2 {
+		return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: 'indices' or 'values' missed")
+	}
+
+	indicesList, ok1 := indices.(*array.List)
+	valuesList, ok2 := values.(*array.List)
+	if !ok1 || !ok2 {
+		return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: 'indices' or 'values' is not list")
+	}
+
+	// Len() is the number of rows in this row group
+	if indices.Len() != values.Len() {
+		msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: number of rows of 'indices' and 'values' mismatched, '%d' vs '%d'", indices.Len(), values.Len())
+		return nil, 0, merr.WrapErrImportFailed(msg)
+	}
+	if row < 0 || row >= indicesList.Len() {
+		msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: row index %d out of range, rows=%d", row, indicesList.Len())
+		return nil, 0, merr.WrapErrImportFailed(msg)
+	}
+	if indicesList.IsNull(row) || valuesList.IsNull(row) {
+		return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: 'indices' or 'values' is null for a valid sparse row")
+	}
+
+	// technically, DataType() of array.List must be arrow.ListType, but we still check here to ensure safety
+	indicesListType, ok1 := indicesList.DataType().(*arrow.ListType)
+	valuesListType, ok2 := valuesList.DataType().(*arrow.ListType)
+	if !ok1 || !ok2 {
+		return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: incorrect arrow type of 'indices' or 'values'")
+	}
+
+	indexDataType := indicesListType.Elem().ID()
+	valueDataType := valuesListType.Elem().ID()
+
+	// The array.Uint32/array.Int64/array.Float32/array.Float64 are derived from arrow.Array
+	// The ListValues() returns arrow.Array interface, but the arrow.Array doesn't have Value(int) interface
+	// To call array.Uint32.Value(int), we need to explicitly cast the ListValues() to array.Uint32
+	// So, we declare two methods here to avoid type casting in the "for" loop
+	type GetIndex func(position int) uint32
+	type GetValue func(position int) float32
+
+	var getIndexFunc GetIndex
+	switch indexDataType {
+	case arrow.INT32:
+		indicesList := indicesList.ListValues().(*array.Int32)
+		getIndexFunc = func(position int) uint32 {
+			return (uint32)(indicesList.Value(position))
+		}
+	case arrow.UINT32:
+		indicesList := indicesList.ListValues().(*array.Uint32)
+		getIndexFunc = func(position int) uint32 {
+			return indicesList.Value(position)
+		}
+	case arrow.INT64:
+		indicesList := indicesList.ListValues().(*array.Int64)
+		getIndexFunc = func(position int) uint32 {
+			return (uint32)(indicesList.Value(position))
+		}
+	case arrow.UINT64:
+		indicesList := indicesList.ListValues().(*array.Uint64)
+		getIndexFunc = func(position int) uint32 {
+			return (uint32)(indicesList.Value(position))
+		}
+	default:
+		msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: index type must be uint32/int32/uint64/int64 but actual type is '%s'", indicesListType.Elem().Name())
+		return nil, 0, merr.WrapErrImportFailed(msg)
+	}
+
+	var getValueFunc GetValue
+	switch valueDataType {
+	case arrow.FLOAT32:
+		valuesList := valuesList.ListValues().(*array.Float32)
+		getValueFunc = func(position int) float32 {
+			return valuesList.Value(position)
+		}
+	case arrow.FLOAT64:
+		valuesList := valuesList.ListValues().(*array.Float64)
+		getValueFunc = func(position int) float32 {
+			return (float32)(valuesList.Value(position))
+		}
+	default:
+		msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: value type must be float32 or float64 but actual type is '%s'", valuesListType.Elem().Name())
+		return nil, 0, merr.WrapErrImportFailed(msg)
+	}
+
+	start, end := indicesList.ValueOffsets(row)
+	start2, end2 := valuesList.ValueOffsets(row)
+	rowLen := (int)(end - start)
+	rowLenValues := (int)(end2 - start2)
+	if rowLenValues != rowLen {
+		msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: number of elements of 'indices' and 'values' mismatched, '%d' vs '%d'", rowLen, rowLenValues)
+		return nil, 0, merr.WrapErrImportFailed(msg)
+	}
+
+	rowIndices := make([]uint32, rowLen)
+	rowValues := make([]float32, rowLen)
+	for i := start; i < end; i++ {
+		rowIndices[i-start] = getIndexFunc((int)(i))
+		rowValues[i-start] = getValueFunc((int)(i))
+	}
+
+	// ensure the indices is sorted
+	sortedIndices, sortedValues := typeutil.SortSparseFloatRow(rowIndices, rowValues)
+	rowVec := typeutil.CreateSparseFloatRow(sortedIndices, sortedValues)
+	if err := typeutil.ValidateSparseFloatRows(rowVec); err != nil {
+		return nil, 0, err
+	}
+
+	maxDim := uint32(0)
+	// set the maxDim as the last value of sortedIndices since it has been sorted
+	if len(sortedIndices) > 0 {
+		maxDim = sortedIndices[len(sortedIndices)-1]
+	}
+	return rowVec, maxDim, nil // rowVec could be an empty sparse
+}
+
 func parseSparseFloatVectorStructs(structs []map[string]arrow.Array) ([][]byte, uint32, error) {
 	byteArr := make([][]byte, 0)
 	maxDim := uint32(0)
 	for _, st := range structs {
-		indices, ok1 := st[sparseVectorIndice]
-		values, ok2 := st[sparseVectorValues]
-		if !ok1 || !ok2 {
+		indices, ok := st[sparseVectorIndice]
+		if !ok {
 			return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: 'indices' or 'values' missed")
 		}
-
-		indicesList, ok1 := indices.(*array.List)
-		valuesList, ok2 := values.(*array.List)
-		if !ok1 || !ok2 {
-			return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: 'indices' or 'values' is not list")
-		}
-
-		// Len() is the number of rows in this row group
-		if indices.Len() != values.Len() {
-			msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: number of rows of 'indices' and 'values' mismatched, '%d' vs '%d'", indices.Len(), values.Len())
-			return nil, 0, merr.WrapErrImportFailed(msg)
-		}
-
-		// technically, DataType() of array.List must be arrow.ListType, but we still check here to ensure safety
-		indicesListType, ok1 := indicesList.DataType().(*arrow.ListType)
-		valuesListType, ok2 := valuesList.DataType().(*arrow.ListType)
-		if !ok1 || !ok2 {
-			return nil, 0, merr.WrapErrImportFailed("Invalid parquet struct for SparseFloatVector: incorrect arrow type of 'indices' or 'values'")
-		}
-
-		indexDataType := indicesListType.Elem().ID()
-		valueDataType := valuesListType.Elem().ID()
-
-		// The array.Uint32/array.Int64/array.Float32/array.Float64 are derived from arrow.Array
-		// The ListValues() returns arrow.Array interface, but the arrow.Array doesn't have Value(int) interface
-		// To call array.Uint32.Value(int), we need to explicitly cast the ListValues() to array.Uint32
-		// So, we declare two methods here to avoid type casting in the "for" loop
-		type GetIndex func(position int) uint32
-		type GetValue func(position int) float32
-
-		var getIndexFunc GetIndex
-		switch indexDataType {
-		case arrow.INT32:
-			indicesList := indicesList.ListValues().(*array.Int32)
-			getIndexFunc = func(position int) uint32 {
-				return (uint32)(indicesList.Value(position))
-			}
-		case arrow.UINT32:
-			indicesList := indicesList.ListValues().(*array.Uint32)
-			getIndexFunc = func(position int) uint32 {
-				return indicesList.Value(position)
-			}
-		case arrow.INT64:
-			indicesList := indicesList.ListValues().(*array.Int64)
-			getIndexFunc = func(position int) uint32 {
-				return (uint32)(indicesList.Value(position))
-			}
-		case arrow.UINT64:
-			indicesList := indicesList.ListValues().(*array.Uint64)
-			getIndexFunc = func(position int) uint32 {
-				return (uint32)(indicesList.Value(position))
-			}
-		default:
-			msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: index type must be uint32/int32/uint64/int64 but actual type is '%s'", indicesListType.Elem().Name())
-			return nil, 0, merr.WrapErrImportFailed(msg)
-		}
-
-		var getValueFunc GetValue
-		switch valueDataType {
-		case arrow.FLOAT32:
-			valuesList := valuesList.ListValues().(*array.Float32)
-			getValueFunc = func(position int) float32 {
-				return valuesList.Value(position)
-			}
-		case arrow.FLOAT64:
-			valuesList := valuesList.ListValues().(*array.Float64)
-			getValueFunc = func(position int) float32 {
-				return (float32)(valuesList.Value(position))
-			}
-		default:
-			msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: value type must be float32 or float64 but actual type is '%s'", valuesListType.Elem().Name())
-			return nil, 0, merr.WrapErrImportFailed(msg)
-		}
-
-		for i := 0; i < indicesList.Len(); i++ {
-			start, end := indicesList.ValueOffsets(i)
-			start2, end2 := valuesList.ValueOffsets(i)
-			rowLen := (int)(end - start)
-			rowLenValues := (int)(end2 - start2)
-			if rowLenValues != rowLen {
-				msg := fmt.Sprintf("Invalid parquet struct for SparseFloatVector: number of elements of 'indices' and 'values' mismatched, '%d' vs '%d'", rowLen, rowLenValues)
-				return nil, 0, merr.WrapErrImportFailed(msg)
-			}
-
-			rowIndices := make([]uint32, rowLen)
-			rowValues := make([]float32, rowLen)
-			for i := start; i < end; i++ {
-				rowIndices[i-start] = getIndexFunc((int)(i))
-				rowValues[i-start] = getValueFunc((int)(i))
-			}
-
-			// ensure the indices is sorted
-			sortedIndices, sortedValues := typeutil.SortSparseFloatRow(rowIndices, rowValues)
-			rowVec := typeutil.CreateSparseFloatRow(sortedIndices, sortedValues)
-			if err := typeutil.ValidateSparseFloatRows(rowVec); err != nil {
+		for i := 0; i < indices.Len(); i++ {
+			rowVec, rowMaxDim, err := parseSparseFloatVectorStructRow(st, i)
+			if err != nil {
 				return byteArr, maxDim, err
 			}
-
-			// set the maxDim as the last value of sortedIndices since it has been sorted
-			if len(sortedIndices) > 0 && sortedIndices[len(sortedIndices)-1] > maxDim {
-				maxDim = sortedIndices[len(sortedIndices)-1]
+			if rowMaxDim > maxDim {
+				maxDim = rowMaxDim
 			}
-			byteArr = append(byteArr, rowVec) // rowVec could be an empty sparse
+			byteArr = append(byteArr, rowVec)
 		}
 	}
 	return byteArr, maxDim, nil
@@ -1169,31 +1201,49 @@ func ReadNullableSparseFloatVectorData(pcr *FieldReader, count int64) (any, []bo
 		}, validData, nil
 	}
 
-	data, validData, err := ReadNullableStructData(pcr, count)
+	chunked, err := pcr.columnReader.NextBatch(count)
 	if err != nil {
 		return nil, nil, err
 	}
-	if data == nil {
+	if chunked == nil || len(chunked.Chunks()) == 0 {
 		return nil, nil, nil
 	}
 
 	// Sparse storage: only store valid rows' data
 	byteArr := make([][]byte, 0, count)
+	validData := make([]bool, 0, count)
 	maxDim := uint32(0)
 
-	for i, structData := range data {
-		if validData[i] {
-			singleByteArr, singleMaxDim, err := parseSparseFloatVectorStructs([]map[string]arrow.Array{structData})
+	for _, chunk := range chunked.Chunks() {
+		structReader, ok := chunk.(*array.Struct)
+		if !ok {
+			return nil, nil, WrapTypeErr(pcr.field, chunk.DataType().Name())
+		}
+
+		structType := structReader.DataType().(*arrow.StructType)
+		st := make(map[string]arrow.Array)
+		for k, field := range structType.Fields() {
+			st[field.Name] = structReader.Field(k)
+		}
+
+		for i := 0; i < structReader.Len(); i++ {
+			valid := !structReader.IsNull(i)
+			validData = append(validData, valid)
+			if !valid {
+				continue
+			}
+			rowVec, rowMaxDim, err := parseSparseFloatVectorStructRow(st, i)
 			if err != nil {
 				return nil, nil, err
 			}
-			if len(singleByteArr) > 0 {
-				byteArr = append(byteArr, singleByteArr[0])
-				if singleMaxDim > maxDim {
-					maxDim = singleMaxDim
-				}
+			byteArr = append(byteArr, rowVec)
+			if rowMaxDim > maxDim {
+				maxDim = rowMaxDim
 			}
 		}
+	}
+	if len(validData) == 0 {
+		return nil, nil, nil
 	}
 
 	return &storage.SparseFloatVectorFieldData{
@@ -1243,6 +1293,21 @@ func checkVectorAligned(offsets []int32, dim int, dataType schemapb.DataType) er
 		return checkVectorAlignWithDim(offsets, int32(dim))
 	default:
 		return fmt.Errorf("unexpected vector data type %s", dataType.String())
+	}
+}
+
+func expectedVectorListLength(dim int, dataType schemapb.DataType) (int32, error) {
+	switch dataType {
+	case schemapb.DataType_BinaryVector:
+		return int32(dim / 8), nil
+	case schemapb.DataType_FloatVector:
+		return int32(dim), nil
+	case schemapb.DataType_Float16Vector, schemapb.DataType_BFloat16Vector:
+		return int32(dim * 2), nil
+	case schemapb.DataType_Int8Vector:
+		return int32(dim), nil
+	default:
+		return 0, fmt.Errorf("unexpected vector data type %s", dataType.String())
 	}
 }
 

--- a/internal/util/importutilv2/parquet/field_reader_test.go
+++ b/internal/util/importutilv2/parquet/field_reader_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/apache/arrow/go/v17/parquet/file"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -246,6 +247,111 @@ func TestParseSparseFloatRowVector(t *testing.T) {
 	}
 }
 
+func TestReadNullableByteVectorBinaryRowsRejectWrongRowWidth(t *testing.T) {
+	tests := []struct {
+		name      string
+		dataType  schemapb.DataType
+		dim       string
+		firstRow  []byte
+		secondRow []byte
+	}{
+		{
+			name:      "binary_vector",
+			dataType:  schemapb.DataType_BinaryVector,
+			dim:       "16",
+			firstRow:  []byte{1},
+			secondRow: []byte{2, 3, 4},
+		},
+		{
+			name:      "float16_vector",
+			dataType:  schemapb.DataType_Float16Vector,
+			dim:       "2",
+			firstRow:  []byte{1, 2},
+			secondRow: []byte{3, 4, 5, 6, 7, 8},
+		},
+		{
+			name:      "bfloat16_vector",
+			dataType:  schemapb.DataType_BFloat16Vector,
+			dim:       "2",
+			firstRow:  []byte{1, 2},
+			secondRow: []byte{3, 4, 5, 6, 7, 8},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const (
+				pkFieldID  = int64(100)
+				vecFieldID = int64(101)
+				numRows    = int64(2)
+			)
+			schema := &schemapb.CollectionSchema{
+				Fields: []*schemapb.FieldSchema{
+					{
+						FieldID:      pkFieldID,
+						Name:         "pk",
+						DataType:     schemapb.DataType_Int64,
+						IsPrimaryKey: true,
+					},
+					{
+						FieldID:  vecFieldID,
+						Name:     "vec",
+						DataType: tt.dataType,
+						Nullable: true,
+						TypeParams: []*commonpb.KeyValuePair{
+							{Key: common.DimKey, Value: tt.dim},
+						},
+					},
+				},
+			}
+
+			filePath := fmt.Sprintf("/tmp/test_nullable_byte_vector_binary_width_%s_%d.parquet", tt.name, rand.Int())
+			defer os.Remove(filePath)
+			wf, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o666)
+			require.NoError(t, err)
+
+			pqSchema := arrow.NewSchema([]arrow.Field{
+				{Name: "pk", Type: arrow.PrimitiveTypes.Int64},
+				{Name: "vec", Type: arrow.BinaryTypes.Binary, Nullable: true},
+			}, nil)
+			fw, err := pqarrow.NewFileWriter(pqSchema, wf,
+				parquet.NewWriterProperties(parquet.WithMaxRowGroupLength(numRows)),
+				pqarrow.DefaultWriterProps())
+			require.NoError(t, err)
+
+			pkBuilder := array.NewInt64Builder(memory.DefaultAllocator)
+			defer pkBuilder.Release()
+			pkBuilder.AppendValues([]int64{1, 2}, nil)
+			pkArr := pkBuilder.NewArray()
+			defer pkArr.Release()
+
+			vecBuilder := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+			defer vecBuilder.Release()
+			vecBuilder.Append(tt.firstRow)
+			vecBuilder.Append(tt.secondRow)
+			vecArr := vecBuilder.NewArray()
+			defer vecArr.Release()
+
+			recordBatch := array.NewRecord(pqSchema, []arrow.Array{pkArr, vecArr}, numRows)
+			defer recordBatch.Release()
+			require.NoError(t, fw.Write(recordBatch))
+			require.NoError(t, fw.Close())
+
+			ctx := context.Background()
+			f := storage.NewChunkManagerFactory("local", objectstorage.RootPath(testOutputPath))
+			cm, err := f.NewPersistentStorageChunkManager(ctx)
+			require.NoError(t, err)
+			reader, err := NewReader(ctx, cm, schema, filePath, 64*1024*1024)
+			require.NoError(t, err)
+			defer reader.Close()
+
+			_, err = reader.Read()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "vector row width mismatch")
+		})
+	}
+}
+
 func TestParseSparseFloatVectorStructs(t *testing.T) {
 	mem := memory.NewGoAllocator()
 
@@ -416,6 +522,129 @@ func TestParseSparseFloatVectorStructs(t *testing.T) {
 	isValidFunc(genUint64ArrList(indices), genFloat64ArrList(values))
 	isValidFunc(genInt64ArrList(indices), genFloat32ArrList(values))
 	isValidFunc(genInt64ArrList(indices), genFloat64ArrList(values))
+}
+
+func TestReadNullableSparseFloatVectorStructKeepsCompactRows(t *testing.T) {
+	rowA := typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1})
+	rowB := typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2})
+	rowC := typeutil.CreateSparseFloatRow([]uint32{3}, []float32{3})
+
+	tests := []struct {
+		name           string
+		validData      []bool
+		contents       [][]byte
+		rowGroupLength int64
+	}{
+		{
+			name:           "null_first",
+			validData:      []bool{false, true, true},
+			contents:       [][]byte{rowA, rowB},
+			rowGroupLength: 3,
+		},
+		{
+			name:           "valid_null_valid",
+			validData:      []bool{true, false, true},
+			contents:       [][]byte{rowA, rowB},
+			rowGroupLength: 3,
+		},
+		{
+			name:           "all_null",
+			validData:      []bool{false, false},
+			contents:       [][]byte{},
+			rowGroupLength: 2,
+		},
+		{
+			name:           "multi_row_group",
+			validData:      []bool{true, false, true, false, true},
+			contents:       [][]byte{rowA, rowB, rowC},
+			rowGroupLength: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkNullableSparseFloatVectorStructRead(t, tt.validData, tt.contents, tt.rowGroupLength)
+		})
+	}
+}
+
+func checkNullableSparseFloatVectorStructRead(t *testing.T, validData []bool, contents [][]byte, rowGroupLength int64) {
+	const (
+		pkFieldID     = int64(100)
+		sparseFieldID = int64(101)
+	)
+
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: pkFieldID, Name: "pk", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: sparseFieldID, Name: "sparse", DataType: schemapb.DataType_SparseFloatVector, Nullable: true},
+		},
+	}
+	sparseFields := []arrow.Field{
+		{Name: sparseVectorIndice, Type: arrow.ListOf(&arrow.Uint32Type{})},
+		{Name: sparseVectorValues, Type: arrow.ListOf(&arrow.Float32Type{})},
+	}
+	pqSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "pk", Type: &arrow.Int64Type{}},
+		{Name: "sparse", Type: arrow.StructOf(sparseFields...), Nullable: true},
+	}, nil)
+
+	numRows := int64(len(validData))
+	filePath := fmt.Sprintf("/tmp/test_%d_nullable_sparse_struct_reader.parquet", rand.Int())
+	defer os.Remove(filePath)
+	wf, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o666)
+	require.NoError(t, err)
+	defer wf.Close()
+	fw, err := pqarrow.NewFileWriter(pqSchema, wf,
+		parquet.NewWriterProperties(parquet.WithMaxRowGroupLength(rowGroupLength)), pqarrow.DefaultWriterProps())
+	require.NoError(t, err)
+
+	mem := memory.NewGoAllocator()
+	pkBuilder := array.NewInt64Builder(mem)
+	pks := make([]int64, len(validData))
+	for i := range pks {
+		pks[i] = int64(i + 1)
+	}
+	pkBuilder.AppendValues(pks, nil)
+	pkArray := pkBuilder.NewArray()
+	defer pkArray.Release()
+	pkBuilder.Release()
+
+	sparseArray, err := testutil.BuildSparseVectorData(mem, contents, pqSchema.Field(1).Type, validData)
+	require.NoError(t, err)
+	defer sparseArray.Release()
+
+	recordBatch := array.NewRecord(pqSchema, []arrow.Array{pkArray, sparseArray}, numRows)
+	require.NoError(t, fw.Write(recordBatch))
+	recordBatch.Release()
+	require.NoError(t, fw.Close())
+
+	ctx := context.Background()
+	f := storage.NewChunkManagerFactory("local", objectstorage.RootPath(testOutputPath))
+	cm, err := f.NewPersistentStorageChunkManager(ctx)
+	require.NoError(t, err)
+	reader, err := NewReader(ctx, cm, schema, filePath, 64*1024*1024)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	gotInsertData, err := reader.Read()
+	require.NoError(t, err)
+	gotSparse := gotInsertData.Data[sparseFieldID].(*storage.SparseFloatVectorFieldData)
+	require.Equal(t, validData, gotSparse.ValidData)
+	require.Len(t, gotSparse.GetContents(), len(contents))
+	if len(contents) > 0 {
+		require.Equal(t, contents, gotSparse.GetContents())
+	}
+
+	physicalIdx := 0
+	for rowIdx, valid := range validData {
+		if !valid {
+			require.Nil(t, gotSparse.GetRow(rowIdx))
+			continue
+		}
+		require.Equal(t, contents[physicalIdx], gotSparse.GetRow(rowIdx))
+		physicalIdx++
+	}
 }
 
 func TestReadFieldData(t *testing.T) {

--- a/internal/util/indexcgowrapper/index.go
+++ b/internal/util/indexcgowrapper/index.go
@@ -54,6 +54,12 @@ type CgoIndex struct {
 	close    bool
 }
 
+var (
+	emptyFloatVectorPayload = []float32{0}
+	emptyByteVectorPayload  = []byte{0}
+	emptyInt8VectorPayload  = []int8{0}
+)
+
 // used only in test
 // TODO: use proto.Marshal instead of proto.MarshalTextString for better compatibility.
 func NewCgoIndex(dtype schemapb.DataType, typeParams, indexParams map[string]string) (CodecIndex, error) {
@@ -187,6 +193,8 @@ func (index *CgoIndex) Build(dataset *Dataset) error {
 		return index.buildBinaryVecIndex(dataset)
 	case schemapb.DataType_Int8Vector:
 		return index.buildInt8VecIndex(dataset)
+	case schemapb.DataType_SparseFloatVector:
+		return index.buildSparseFloatVecIndex(dataset)
 	case schemapb.DataType_Bool:
 		return index.buildBoolIndex(dataset)
 	case schemapb.DataType_Int8:
@@ -210,18 +218,56 @@ func (index *CgoIndex) Build(dataset *Dataset) error {
 	}
 }
 
+func cFloatPtr(data []float32) *C.float {
+	if len(data) == 0 {
+		return (*C.float)(&emptyFloatVectorPayload[0])
+	}
+	return (*C.float)(&data[0])
+}
+
+func cUint8Ptr(data []byte) *C.uint8_t {
+	if len(data) == 0 {
+		return (*C.uint8_t)(&emptyByteVectorPayload[0])
+	}
+	return (*C.uint8_t)(&data[0])
+}
+
+func cInt8Ptr(data []int8) *C.int8_t {
+	if len(data) == 0 {
+		return (*C.int8_t)(&emptyInt8VectorPayload[0])
+	}
+	return (*C.int8_t)(&data[0])
+}
+
+func cBoolPtr(data []bool) *C.bool {
+	if len(data) == 0 {
+		return nil
+	}
+	return (*C.bool)(&data[0])
+}
+
+func validCount(validData []bool) int64 {
+	count := int64(0)
+	for _, valid := range validData {
+		if valid {
+			count++
+		}
+	}
+	return count
+}
+
 func (index *CgoIndex) buildFloatVecIndex(dataset *Dataset) error {
 	vectors := dataset.Data[keyRawArr].([]float32)
 	if validData, ok := dataset.Data[keyValidArr].([]bool); ok && len(validData) > 0 {
 		status := C.BuildFloatVecIndexWithValidData(
 			index.indexPtr,
 			(C.int64_t)(len(vectors)),
-			(*C.float)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cFloatPtr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build float vector index with valid data")
 	}
-	status := C.BuildFloatVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (*C.float)(&vectors[0]))
+	status := C.BuildFloatVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), cFloatPtr(vectors))
 	return HandleCStatus(&status, "failed to build float vector index")
 }
 
@@ -231,12 +277,12 @@ func (index *CgoIndex) buildFloat16VecIndex(dataset *Dataset) error {
 		status := C.BuildFloat16VecIndexWithValidData(
 			index.indexPtr,
 			(C.int64_t)(len(vectors)),
-			(*C.uint8_t)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cUint8Ptr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build float16 vector index with valid data")
 	}
-	status := C.BuildFloat16VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (*C.uint8_t)(&vectors[0]))
+	status := C.BuildFloat16VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), cUint8Ptr(vectors))
 	return HandleCStatus(&status, "failed to build float16 vector index")
 }
 
@@ -246,28 +292,35 @@ func (index *CgoIndex) buildBFloat16VecIndex(dataset *Dataset) error {
 		status := C.BuildBFloat16VecIndexWithValidData(
 			index.indexPtr,
 			(C.int64_t)(len(vectors)),
-			(*C.uint8_t)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cUint8Ptr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build bfloat16 vector index with valid data")
 	}
-	status := C.BuildBFloat16VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (*C.uint8_t)(&vectors[0]))
+	status := C.BuildBFloat16VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), cUint8Ptr(vectors))
 	return HandleCStatus(&status, "failed to build bfloat16 vector index")
 }
 
 func (index *CgoIndex) buildSparseFloatVecIndex(dataset *Dataset) error {
-	vectors := dataset.Data[keyRawArr].([]byte)
+	vectors, _ := dataset.Data[keyRawArr].([]byte)
 	if validData, ok := dataset.Data[keyValidArr].([]bool); ok && len(validData) > 0 {
+		validRows := validCount(validData)
+		if validRows > 0 && len(vectors) == 0 {
+			return fmt.Errorf("sparse float vector cgo build requires encoded sparse rows")
+		}
 		status := C.BuildSparseFloatVecIndexWithValidData(
 			index.indexPtr,
-			(C.int64_t)(len(validData)),
+			(C.int64_t)(validRows),
 			(C.int64_t)(0),
-			(*C.uint8_t)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cUint8Ptr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build sparse float vector index with valid data")
 	}
-	status := C.BuildSparseFloatVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (C.int64_t)(0), (*C.uint8_t)(&vectors[0]))
+	if len(vectors) == 0 {
+		return fmt.Errorf("sparse float vector cgo build requires encoded sparse rows")
+	}
+	status := C.BuildSparseFloatVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (C.int64_t)(0), cUint8Ptr(vectors))
 	return HandleCStatus(&status, "failed to build sparse float vector index")
 }
 
@@ -277,12 +330,12 @@ func (index *CgoIndex) buildBinaryVecIndex(dataset *Dataset) error {
 		status := C.BuildBinaryVecIndexWithValidData(
 			index.indexPtr,
 			(C.int64_t)(len(vectors)),
-			(*C.uint8_t)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cUint8Ptr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build binary vector index with valid data")
 	}
-	status := C.BuildBinaryVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (*C.uint8_t)(&vectors[0]))
+	status := C.BuildBinaryVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), cUint8Ptr(vectors))
 	return HandleCStatus(&status, "failed to build binary vector index")
 }
 
@@ -292,12 +345,12 @@ func (index *CgoIndex) buildInt8VecIndex(dataset *Dataset) error {
 		status := C.BuildInt8VecIndexWithValidData(
 			index.indexPtr,
 			(C.int64_t)(len(vectors)),
-			(*C.int8_t)(&vectors[0]),
-			(*C.bool)(&validData[0]),
+			cInt8Ptr(vectors),
+			cBoolPtr(validData),
 			(C.int64_t)(len(validData)))
 		return HandleCStatus(&status, "failed to build int8 vector index with valid data")
 	}
-	status := C.BuildInt8VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (*C.int8_t)(&vectors[0]))
+	status := C.BuildInt8VecIndex(index.indexPtr, (C.int64_t)(len(vectors)), cInt8Ptr(vectors))
 	return HandleCStatus(&status, "failed to build int8 vector index")
 }
 

--- a/internal/util/indexcgowrapper/index_test.go
+++ b/internal/util/indexcgowrapper/index_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -240,6 +241,105 @@ func TestCIndex_BuildInt8VecIndex(t *testing.T) {
 
 		err = index.Delete()
 		assert.Equal(t, err, nil)
+	}
+}
+
+func TestCIndex_BuildAllNullNullableVectorsDoesNotPanic(t *testing.T) {
+	type testCase struct {
+		name   string
+		dtype  schemapb.DataType
+		raw    any
+		params func() (map[string]string, map[string]string)
+	}
+
+	cases := []testCase{
+		{
+			name:  "float",
+			dtype: schemapb.DataType_FloatVector,
+			raw:   []float32{},
+			params: func() (map[string]string, map[string]string) {
+				return generateParams(IndexFaissIDMap, metric.L2)
+			},
+		},
+		{
+			name:  "binary",
+			dtype: schemapb.DataType_BinaryVector,
+			raw:   []byte{},
+			params: func() (map[string]string, map[string]string) {
+				return generateParams(IndexFaissBinIDMap, metric.JACCARD)
+			},
+		},
+		{
+			name:  "float16",
+			dtype: schemapb.DataType_Float16Vector,
+			raw:   []byte{},
+			params: func() (map[string]string, map[string]string) {
+				return generateParams(IndexFaissIDMap, metric.L2)
+			},
+		},
+		{
+			name:  "bfloat16",
+			dtype: schemapb.DataType_BFloat16Vector,
+			raw:   []byte{},
+			params: func() (map[string]string, map[string]string) {
+				return generateParams(IndexFaissIDMap, metric.L2)
+			},
+		},
+		{
+			name:  "int8",
+			dtype: schemapb.DataType_Int8Vector,
+			raw:   []int8{},
+			params: func() (map[string]string, map[string]string) {
+				return generateParams(IndexHNSW, metric.L2)
+			},
+		},
+		{
+			name:  "sparse",
+			dtype: schemapb.DataType_SparseFloatVector,
+			raw:   []byte{},
+			params: func() (map[string]string, map[string]string) {
+				return map[string]string{}, map[string]string{
+					common.IndexTypeKey:  "SPARSE_INVERTED_INDEX",
+					common.MetricTypeKey: metric.IP,
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			typeParams, indexParams := tc.params()
+			index, err := NewCgoIndex(tc.dtype, typeParams, indexParams)
+			require.NoError(t, err)
+			require.NotNil(t, index)
+			defer func() {
+				require.NoError(t, index.Delete())
+			}()
+
+			dataset := &Dataset{
+				DType: tc.dtype,
+				Data: map[string]any{
+					keyRawArr:   tc.raw,
+					keyValidArr: []bool{false, false, false},
+				},
+			}
+			require.NotPanics(t, func() {
+				err = index.Build(dataset)
+			})
+			require.NoError(t, err)
+
+			blobs, err := index.Serialize()
+			require.NoError(t, err)
+			require.NotEmpty(t, blobs)
+
+			copyIndex, err := NewCgoIndex(tc.dtype, typeParams, indexParams)
+			require.NoError(t, err)
+			require.NotNil(t, copyIndex)
+			defer func() {
+				require.NoError(t, copyIndex.Delete())
+			}()
+			require.NoError(t, copyIndex.Load(blobs))
+		})
 	}
 }
 

--- a/internal/util/queryutil/dedup_pk_op.go
+++ b/internal/util/queryutil/dedup_pk_op.go
@@ -95,8 +95,10 @@ func (op *DeduplicatePKOperator) Run(ctx context.Context, span trace.Span, input
 	var retSize int64
 
 	origResults := make([]*internalpb.RetrieveResults, len(validResults))
+	rowSizeCalculators := make([]*rowSizeCalculator, len(validResults))
 	for i, v := range validResults {
 		origResults[i] = v.result
+		rowSizeCalculators[i] = newRowSizeCalculator(v.result)
 	}
 
 	for i, v := range validResults {
@@ -107,7 +109,7 @@ func (op *DeduplicatePKOperator) Run(ctx context.Context, span trace.Span, input
 			if v.timestamps != nil && int(j) < len(v.timestamps) {
 				ts = v.timestamps[j]
 			}
-			rowSize := calcRowSize(v.result, j)
+			rowSize := rowSizeCalculators[i].rowSize(j)
 
 			if entry, exists := pkMap[pk]; !exists {
 				pkMap[pk] = pkEntry{rowIndex: len(selectedRows), ts: ts}
@@ -116,7 +118,7 @@ func (op *DeduplicatePKOperator) Run(ctx context.Context, span trace.Span, input
 			} else if ts != 0 && ts > entry.ts {
 				// Duplicate PK with higher timestamp — replace, swap sizes
 				oldRef := selectedRows[entry.rowIndex]
-				oldSize := calcRowSize(origResults[oldRef.resultIdx], oldRef.rowIdx)
+				oldSize := rowSizeCalculators[oldRef.resultIdx].rowSize(oldRef.rowIdx)
 				retSize = retSize - oldSize + rowSize
 				pkMap[pk] = pkEntry{rowIndex: entry.rowIndex, ts: ts}
 				selectedRows[entry.rowIndex] = rowRef{resultIdx: i, rowIdx: j}

--- a/internal/util/queryutil/helpers.go
+++ b/internal/util/queryutil/helpers.go
@@ -440,16 +440,7 @@ func buildCompactIndices(results []*internalpb.RetrieveResults, fieldIdx int, is
 				fd.GetFieldId(), fd.GetFieldName(), len(vd), numRows, ri)
 		}
 
-		idx := make([]int, numRows)
-		dataIdx := 0
-		for i := 0; i < numRows; i++ {
-			if vd[i] {
-				idx[i] = dataIdx
-				dataIdx++
-			} else {
-				idx[i] = -1
-			}
-		}
+		idx, _ := typeutil.BuildNullableVectorDataIndices(vd)
 		indices[ri] = idx
 	}
 	return indices, nil
@@ -824,15 +815,14 @@ func rangeSliceScalarField(sf *schemapb.ScalarField, start, end int) *schemapb.S
 }
 
 // rangeSliceVectorField extracts a contiguous range [start, end) from vector data.
-// validData is the field's ValidData bitmap. For nullable vectors in compact mode,
-// data indices must be computed by counting valid rows, not using logical row indices.
+// Supported nullable vectors use compact payload data, so logical rows must be
+// mapped to physical vector rows through ValidData.
 func rangeSliceVectorField(vf *schemapb.VectorField, start, end int, validData []bool) *schemapb.VectorField {
 	dim := int(vf.GetDim())
 	newVf := &schemapb.VectorField{Dim: vf.GetDim()}
 
-	// For compact mode: convert logical [start, end) to data [dataStart, dataEnd).
 	dataStart, dataEnd := start, end
-	if len(validData) > 0 {
+	if usesCompactNullableVectorData(vf, validData) {
 		dataStart = 0
 		for i := 0; i < start; i++ {
 			if validData[i] {
@@ -1082,27 +1072,16 @@ func sliceScalarField(sf *schemapb.ScalarField, indices []int) *schemapb.ScalarF
 }
 
 // sliceVectorField extracts vector data at the given logical indices.
-// validData is the field's ValidData bitmap for compact mode handling.
+// Supported nullable vectors use compact payload data, so logical rows must be
+// mapped to physical vector rows through ValidData.
 func sliceVectorField(vf *schemapb.VectorField, indices []int, validData []bool) *schemapb.VectorField {
 	dim := int(vf.GetDim())
 	newVf := &schemapb.VectorField{Dim: vf.GetDim()}
 
-	// Pre-compute compact index mapping if nullable.
-	// compactIdx[logicalRow] = data index, or -1 if null.
 	var compactIdx []int
-	if len(validData) > 0 {
-		compactIdx = make([]int, len(validData))
-		di := 0
-		for i, v := range validData {
-			if v {
-				compactIdx[i] = di
-				di++
-			} else {
-				compactIdx[i] = -1
-			}
-		}
+	if usesCompactNullableVectorData(vf, validData) {
+		compactIdx, _ = typeutil.BuildNullableVectorDataIndices(validData)
 	}
-	// toDataIdx converts logical index to data index, skipping null rows.
 	toDataIdx := func(logicalIdx int) int {
 		if compactIdx == nil {
 			return logicalIdx
@@ -1223,22 +1202,73 @@ func sliceVectorField(vf *schemapb.VectorField, indices []int, validData []bool)
 	return newVf
 }
 
+func usesCompactNullableVectorData(vf *schemapb.VectorField, validData []bool) bool {
+	if len(validData) == 0 {
+		return false
+	}
+	switch vf.GetData().(type) {
+	case *schemapb.VectorField_FloatVector,
+		*schemapb.VectorField_BinaryVector,
+		*schemapb.VectorField_Float16Vector,
+		*schemapb.VectorField_Bfloat16Vector,
+		*schemapb.VectorField_Int8Vector,
+		*schemapb.VectorField_SparseFloatVector:
+		return true
+	default:
+		return false
+	}
+}
+
 // calcRowSize computes the size in bytes of a single row in a RetrieveResult
 // by summing the per-element size of each field. This is used during the
 // merge selection phase (Phase 1) to track accumulated output size before
 // the actual memory-copy phase (Phase 2), enabling early termination
 // when maxOutputSize would be exceeded.
-func calcRowSize(result *internalpb.RetrieveResults, rowIdx int64) int64 {
+type rowSizeCalculator struct {
+	result         *internalpb.RetrieveResults
+	compactIndices [][]int
+}
+
+func newRowSizeCalculator(result *internalpb.RetrieveResults) *rowSizeCalculator {
+	fieldsData := result.GetFieldsData()
+	c := &rowSizeCalculator{
+		result:         result,
+		compactIndices: make([][]int, len(fieldsData)),
+	}
+	for fieldIdx, fd := range fieldsData {
+		if typeutil.IsCompactNullableVectorFieldData(fd) {
+			indices, _ := typeutil.BuildNullableVectorDataIndices(fd.GetValidData())
+			c.compactIndices[fieldIdx] = indices
+		}
+	}
+	return c
+}
+
+func (c *rowSizeCalculator) rowSize(rowIdx int64) int64 {
 	var size int64
-	for _, fd := range result.GetFieldsData() {
-		size += calcFieldElementSize(fd, int(rowIdx))
+	for fieldIdx, fd := range c.result.GetFieldsData() {
+		size += calcFieldElementSizeWithCompactIndex(fd, int(rowIdx), c.compactIndices[fieldIdx])
 	}
 	return size
+}
+
+// calcRowSize is a convenience wrapper for one-off checks. Hot merge loops
+// should create one rowSizeCalculator per result and reuse it.
+func calcRowSize(result *internalpb.RetrieveResults, rowIdx int64) int64 {
+	return newRowSizeCalculator(result).rowSize(rowIdx)
 }
 
 // calcFieldElementSize returns the byte size of a single
 // element at rowIdx within a FieldData.
 func calcFieldElementSize(fd *schemapb.FieldData, rowIdx int) int64 {
+	var compactIdx []int
+	if typeutil.IsCompactNullableVectorFieldData(fd) {
+		compactIdx, _ = typeutil.BuildNullableVectorDataIndices(fd.GetValidData())
+	}
+	return calcFieldElementSizeWithCompactIndex(fd, rowIdx, compactIdx)
+}
+
+func calcFieldElementSizeWithCompactIndex(fd *schemapb.FieldData, rowIdx int, compactIdx []int) int64 {
 	if scalars := fd.GetScalars(); scalars != nil {
 		switch data := scalars.GetData().(type) {
 		case *schemapb.ScalarField_BoolData:
@@ -1298,6 +1328,11 @@ func calcFieldElementSize(fd *schemapb.FieldData, rowIdx int) int64 {
 		}
 	}
 	if vectors := fd.GetVectors(); vectors != nil {
+		if compactIdx != nil {
+			if rowIdx < 0 || rowIdx >= len(compactIdx) || compactIdx[rowIdx] < 0 {
+				return 0
+			}
+		}
 		dim := int(vectors.GetDim())
 		switch vectors.GetData().(type) {
 		case *schemapb.VectorField_FloatVector:
@@ -1311,9 +1346,13 @@ func calcFieldElementSize(fd *schemapb.FieldData, rowIdx int) int64 {
 		case *schemapb.VectorField_Int8Vector:
 			return int64(dim)
 		case *schemapb.VectorField_SparseFloatVector:
+			dataIdx := rowIdx
+			if compactIdx != nil {
+				dataIdx = compactIdx[rowIdx]
+			}
 			contents := vectors.GetSparseFloatVector().GetContents()
-			if rowIdx < len(contents) {
-				return int64(len(contents[rowIdx]))
+			if dataIdx < len(contents) {
+				return int64(len(contents[dataIdx]))
 			}
 			return 0
 		case *schemapb.VectorField_VectorArray:
@@ -1401,6 +1440,9 @@ func getRowCount(result *internalpb.RetrieveResults) int {
 	}
 
 	fd := result.GetFieldsData()[0]
+	if len(fd.GetValidData()) > 0 {
+		return len(fd.GetValidData())
+	}
 	if fd.GetScalars() != nil {
 		switch data := fd.GetScalars().GetData().(type) {
 		case *schemapb.ScalarField_BoolData:

--- a/internal/util/queryutil/helpers_test.go
+++ b/internal/util/queryutil/helpers_test.go
@@ -48,6 +48,52 @@ func makeNullableSchema(fieldID int64, dataType schemapb.DataType, dim int64) *s
 	return &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{fs}}
 }
 
+func requireRangeSliceRetrieveResults(t *testing.T, result *internalpb.RetrieveResults, start, end int) *internalpb.RetrieveResults {
+	t.Helper()
+	return rangeSliceRetrieveResults(result, start, end)
+}
+
+func requireRangeSliceFieldData(t *testing.T, fd *schemapb.FieldData, start, end int) *schemapb.FieldData {
+	t.Helper()
+	return rangeSliceFieldData(fd, start, end)
+}
+
+func requireRangeSliceVectorField(t *testing.T, vf *schemapb.VectorField, start, end int, validData []bool) *schemapb.VectorField {
+	t.Helper()
+	return rangeSliceVectorField(vf, start, end, validData)
+}
+
+func requireSliceFieldData(t *testing.T, fd *schemapb.FieldData, indices []int) *schemapb.FieldData {
+	t.Helper()
+	return sliceFieldData(fd, indices)
+}
+
+func requireSliceVectorField(t *testing.T, vf *schemapb.VectorField, indices []int, validData []bool) *schemapb.VectorField {
+	t.Helper()
+	return sliceVectorField(vf, indices, validData)
+}
+
+func TestGetRowCountNullableCompactVectorWithoutIDsUsesLogicalRows(t *testing.T) {
+	result := &internalpb.RetrieveResults{
+		FieldsData: []*schemapb.FieldData{
+			{
+				Type:      schemapb.DataType_FloatVector,
+				FieldName: "nullable_vec",
+				FieldId:   100,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3, 4}},
+					},
+				}},
+				ValidData: []bool{true, false, true},
+			},
+		},
+	}
+
+	assert.Equal(t, 3, getRowCount(result))
+}
+
 // =========================================================================
 // buildMergedFieldData: ValidData preservation
 // =========================================================================
@@ -718,6 +764,137 @@ func TestCalcRowSize_FloatVector(t *testing.T) {
 	// FloatVector: dim * 4 bytes per row = 8 * 4 = 32
 	size := calcRowSize(r, 0)
 	assert.Equal(t, int64(dim*4), size)
+}
+
+func TestCalcRowSize_NullableDenseVectorUsesLogicalValidity(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    *schemapb.FieldData
+		wantSize int64
+	}{
+		{
+			name: "float_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_FloatVector,
+				ValidData: []bool{false, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2}}},
+				}},
+			},
+			wantSize: 8,
+		},
+		{
+			name: "binary_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_BinaryVector,
+				ValidData: []bool{false, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  16,
+					Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{0x01, 0x02}},
+				}},
+			},
+			wantSize: 2,
+		},
+		{
+			name: "float16_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_Float16Vector,
+				ValidData: []bool{false, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{0x01, 0x02, 0x03, 0x04}},
+				}},
+			},
+			wantSize: 4,
+		},
+		{
+			name: "bfloat16_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_BFloat16Vector,
+				ValidData: []bool{false, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{0x01, 0x02, 0x03, 0x04}},
+				}},
+			},
+			wantSize: 4,
+		},
+		{
+			name: "int8_vector",
+			field: &schemapb.FieldData{
+				Type:      schemapb.DataType_Int8Vector,
+				ValidData: []bool{false, true},
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  4,
+					Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{0x01, 0x02, 0x03, 0x04}},
+				}},
+			},
+			wantSize: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &internalpb.RetrieveResults{FieldsData: []*schemapb.FieldData{tt.field}}
+			assert.Equal(t, int64(0), calcRowSize(r, 0))
+			assert.Equal(t, tt.wantSize, calcRowSize(r, 1))
+		})
+	}
+}
+
+func TestCalcRowSize_NullableSparseVectorUsesCompactMapping(t *testing.T) {
+	rowA := makeTestSparseVec(1, 0.5)
+	rowC := makeTestSparseVec(3, 1.5)
+
+	tests := []struct {
+		name      string
+		validData []bool
+		contents  [][]byte
+		wantSizes []int64
+	}{
+		{
+			name:      "null_before_valid",
+			validData: []bool{false, true},
+			contents:  [][]byte{rowA},
+			wantSizes: []int64{0, int64(len(rowA))},
+		},
+		{
+			name:      "valid_null_valid",
+			validData: []bool{true, false, true},
+			contents:  [][]byte{rowA, rowC},
+			wantSizes: []int64{int64(len(rowA)), 0, int64(len(rowC))},
+		},
+		{
+			name:      "all_null",
+			validData: []bool{false, false},
+			contents:  nil,
+			wantSizes: []int64{0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &internalpb.RetrieveResults{
+				FieldsData: []*schemapb.FieldData{
+					{
+						Type:      schemapb.DataType_SparseFloatVector,
+						ValidData: tt.validData,
+						Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+							Dim: 4,
+							Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+								Dim:      4,
+								Contents: tt.contents,
+							}},
+						}},
+					},
+				},
+			}
+			for rowIdx, want := range tt.wantSizes {
+				assert.Equal(t, want, calcRowSize(r, int64(rowIdx)))
+			}
+		})
+	}
 }
 
 func TestCalcRowSize_MultipleFieldTypes(t *testing.T) {
@@ -2442,16 +2619,17 @@ func TestSliceVectorField_NullableCompact_Sparse(t *testing.T) {
 	assert.Equal(t, [][]byte{{0x02}}, sliced.GetSparseFloatVector().GetContents())
 }
 
-func TestSliceVectorField_NullableCompact_VectorArray(t *testing.T) {
+func TestSliceVectorField_NullableVectorArrayUsesLogicalRows(t *testing.T) {
 	dim := int64(2)
 	v1 := &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2}}}}
+	empty := &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: nil}}}
 	v2 := &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{3, 4}}}}
 
 	vf := &schemapb.VectorField{
 		Dim: dim,
 		Data: &schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{
 			Dim:         dim,
-			Data:        []*schemapb.VectorField{v1, v2},
+			Data:        []*schemapb.VectorField{v1, empty, v2},
 			ElementType: schemapb.DataType_FloatVector,
 		}},
 	}
@@ -2545,16 +2723,17 @@ func TestRangeSliceVectorField_NullableCompact_Sparse(t *testing.T) {
 	assert.Equal(t, [][]byte{{0x02}}, sliced.GetSparseFloatVector().GetContents())
 }
 
-func TestRangeSliceVectorField_NullableCompact_VectorArray(t *testing.T) {
+func TestRangeSliceVectorField_NullableVectorArrayUsesLogicalRows(t *testing.T) {
 	dim := int64(2)
 	v1 := &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{1, 2}}}}
+	empty := &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: nil}}}
 	v2 := &schemapb.VectorField{Dim: dim, Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: []float32{3, 4}}}}
 
 	vf := &schemapb.VectorField{
 		Dim: dim,
 		Data: &schemapb.VectorField_VectorArray{VectorArray: &schemapb.VectorArray{
 			Dim:         dim,
-			Data:        []*schemapb.VectorField{v1, v2},
+			Data:        []*schemapb.VectorField{v1, empty, v2},
 			ElementType: schemapb.DataType_FloatVector,
 		}},
 	}

--- a/internal/util/queryutil/order_op_test.go
+++ b/internal/util/queryutil/order_op_test.go
@@ -99,6 +99,50 @@ func TestOrderByLimitOperator_SingleRow(t *testing.T) {
 	assert.Equal(t, int64(1), sorted.GetIds().GetIntId().GetData()[0])
 }
 
+func TestOrderByLimitOperator_NullableCompactVectorWithoutIDsUsesLogicalRows(t *testing.T) {
+	orderByFields := []*orderby.OrderByField{
+		{FieldID: 2, FieldName: "value", Ascending: true, DataType: schemapb.DataType_Int64},
+	}
+	op := NewOrderByLimitOperator(orderByFields, 0)
+	ctx := context.Background()
+
+	result := &internalpb.RetrieveResults{
+		FieldsData: []*schemapb.FieldData{
+			{
+				Type:      schemapb.DataType_FloatVector,
+				FieldName: "nullable_vec",
+				FieldId:   100,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3, 4}},
+					},
+				}},
+				ValidData: []bool{true, false, true},
+			},
+			{
+				Type:      schemapb.DataType_Int64,
+				FieldName: "value",
+				FieldId:   2,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{30, 10, 20}},
+					},
+				}},
+			},
+		},
+	}
+
+	outputs, err := op.Run(ctx, nil, result)
+	require.NoError(t, err)
+
+	sorted := outputs[0].(*internalpb.RetrieveResults)
+	require.Len(t, sorted.GetFieldsData(), 2)
+	assert.Equal(t, []int64{10, 20, 30}, sorted.GetFieldsData()[1].GetScalars().GetLongData().GetData())
+	assert.Equal(t, []bool{false, true, true}, sorted.GetFieldsData()[0].GetValidData())
+	assert.Equal(t, []float32{3, 4, 1, 2}, sorted.GetFieldsData()[0].GetVectors().GetFloatVector().GetData())
+}
+
 func TestOrderByLimitOperator_SortAscending(t *testing.T) {
 	orderByFields := []*orderby.OrderByField{
 		{FieldID: 2, FieldName: "value", Ascending: true, DataType: schemapb.DataType_Int64},

--- a/internal/util/queryutil/reduce_by_pk_op.go
+++ b/internal/util/queryutil/reduce_by_pk_op.go
@@ -225,6 +225,10 @@ func (op *ReduceByPKWithTimestampOperator) Run(ctx context.Context, span trace.S
 // When duplicate PK found with higher timestamp, replaces the previous entry.
 func (op *ReduceByPKWithTimestampOperator) mergeByPKWithTimestamp(results []*timestampedResult, hasMoreResult bool) (*internalpb.RetrieveResults, error) {
 	cursors := make([]int64, len(results))
+	rowSizeCalculators := make([]*rowSizeCalculator, len(results))
+	for i, result := range results {
+		rowSizeCalculators[i] = newRowSizeCalculator(result.result)
+	}
 
 	// Track PK -> (selectedRowIndex, timestamp) for replacement on higher timestamp
 	type pkEntry struct {
@@ -252,7 +256,7 @@ func (op *ReduceByPKWithTimestampOperator) mergeByPKWithTimestamp(results []*tim
 
 		pk := typeutil.GetPK(results[sel].result.GetIds(), cursors[sel])
 		ts := results[sel].getTimestamp(cursors[sel])
-		rowSize := calcRowSize(results[sel].result, cursors[sel])
+		rowSize := rowSizeCalculators[sel].rowSize(cursors[sel])
 
 		// Compute element count for this row
 		var elemCount int64 = 1
@@ -274,7 +278,7 @@ func (op *ReduceByPKWithTimestampOperator) mergeByPKWithTimestamp(results []*tim
 			if ts != 0 && ts > entry.ts {
 				// Replace existing entry — swap row sizes and element counts
 				oldRef := selectedRows[entry.rowIndex]
-				oldSize := calcRowSize(results[oldRef.resultIdx].result, oldRef.rowIdx)
+				oldSize := rowSizeCalculators[oldRef.resultIdx].rowSize(oldRef.rowIdx)
 				retSize = retSize - oldSize + rowSize
 				// Adjust element count for replacement
 				if isElementLevel {

--- a/internal/util/queryutil/slice_op_test.go
+++ b/internal/util/queryutil/slice_op_test.go
@@ -69,6 +69,47 @@ func TestSliceOperator_LimitOnly(t *testing.T) {
 	assert.Equal(t, int64(3), ids[2])
 }
 
+func TestSliceOperator_NullableCompactVectorWithoutIDsUsesLogicalRows(t *testing.T) {
+	op := NewSliceOperator(1, 2)
+	ctx := context.Background()
+
+	result := &internalpb.RetrieveResults{
+		FieldsData: []*schemapb.FieldData{
+			{
+				Type:      schemapb.DataType_FloatVector,
+				FieldName: "nullable_vec",
+				FieldId:   100,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3, 4}},
+					},
+				}},
+				ValidData: []bool{true, false, true},
+			},
+			{
+				Type:      schemapb.DataType_Int64,
+				FieldName: "value",
+				FieldId:   101,
+				Field: &schemapb.FieldData_Scalars{Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: []int64{10, 20, 30}},
+					},
+				}},
+			},
+		},
+	}
+
+	outputs, err := op.Run(ctx, nil, result)
+	require.NoError(t, err)
+
+	sliced := outputs[0].(*internalpb.RetrieveResults)
+	require.Len(t, sliced.GetFieldsData(), 2)
+	assert.Equal(t, []bool{true}, sliced.GetFieldsData()[0].GetValidData())
+	assert.Equal(t, []float32{3, 4}, sliced.GetFieldsData()[0].GetVectors().GetFloatVector().GetData())
+	assert.Equal(t, []int64{30}, sliced.GetFieldsData()[1].GetScalars().GetLongData().GetData())
+}
+
 func TestSliceOperator_OffsetOnly(t *testing.T) {
 	op := NewSliceOperator(-1, 2) // -1 means no limit
 	ctx := context.Background()

--- a/internal/util/testutil/test_util.go
+++ b/internal/util/testutil/test_util.go
@@ -472,17 +472,18 @@ func BuildSparseVectorData(mem *memory.GoAllocator, contents [][]byte, arrowType
 		for i := 0; i < logicalRows; i++ {
 			isValid := len(validData) == 0 || validData[i]
 			builder.Append(isValid)
-			indicesBuilder.Append(isValid)
-			valuesBuilder.Append(isValid)
-			if isValid {
-				rowVecData := contents[physicalIdx]
-				elemCount := len(rowVecData) / 8
-				for j := 0; j < elemCount; j++ {
-					appendIndexFunc(common.Endian.Uint32(rowVecData[j*8:]))
-					appendValueFunc(math.Float32frombits(common.Endian.Uint32(rowVecData[j*8+4:])))
-				}
-				physicalIdx++
+			if !isValid {
+				continue
 			}
+			indicesBuilder.Append(true)
+			valuesBuilder.Append(true)
+			rowVecData := contents[physicalIdx]
+			elemCount := len(rowVecData) / 8
+			for j := 0; j < elemCount; j++ {
+				appendIndexFunc(common.Endian.Uint32(rowVecData[j*8:]))
+				appendValueFunc(math.Float32frombits(common.Endian.Uint32(rowVecData[j*8+4:])))
+			}
+			physicalIdx++
 		}
 		return builder.NewStructArray(), nil
 	}

--- a/pkg/mq/msgstream/msg_test.go
+++ b/pkg/mq/msgstream/msg_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func TestBaseMsg(t *testing.T) {
@@ -209,6 +210,110 @@ func TestInsertMsg_CheckAligned(t *testing.T) {
 
 	msg1.Version = msgpb.InsertDataVersion_ColumnBased
 	assert.NoError(t, msg1.CheckAligned())
+}
+
+func TestInsertMsg_CheckAlignedRejectsNullableVectorNonCompactData(t *testing.T) {
+	validData := []bool{true, false, true}
+	testCases := []struct {
+		name      string
+		fieldData *schemapb.FieldData
+	}{
+		{
+			name: "float_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_FloatVector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim: 2,
+					Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+						Data: []float32{1, 2, 0, 0, 3, 4},
+					}},
+				}},
+			},
+		},
+		{
+			name: "binary_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_BinaryVector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  8,
+					Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 0, 2}},
+				}},
+			},
+		},
+		{
+			name: "float16_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_Float16Vector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2, 3, 4, 0, 0, 0, 0, 5, 6, 7, 8}},
+				}},
+			},
+		},
+		{
+			name: "bfloat16_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_BFloat16Vector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{1, 2, 3, 4, 0, 0, 0, 0, 5, 6, 7, 8}},
+				}},
+			},
+		},
+		{
+			name: "sparse_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_SparseFloatVector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+						Contents: [][]byte{
+							typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1}),
+							typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2}),
+							typeutil.CreateSparseFloatRow([]uint32{3}, []float32{3}),
+						},
+					}},
+				}},
+			},
+		},
+		{
+			name: "int8_vector",
+			fieldData: &schemapb.FieldData{
+				FieldName: "vec",
+				Type:      schemapb.DataType_Int8Vector,
+				ValidData: validData,
+				Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+					Dim:  2,
+					Data: &schemapb.VectorField_Int8Vector{Int8Vector: []byte{1, 2, 0, 0, 3, 4}},
+				}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &InsertMsg{
+				InsertRequest: &msgpb.InsertRequest{
+					Timestamps: []uint64{1, 2, 3},
+					RowIDs:     []int64{1, 2, 3},
+					FieldsData: []*schemapb.FieldData{tc.fieldData},
+					NumRows:    3,
+					Version:    msgpb.InsertDataVersion_ColumnBased,
+				},
+			}
+
+			assert.Error(t, msg.CheckAligned())
+		})
+	}
 }
 
 func TestInsertMsg_IndexMsg(t *testing.T) {

--- a/pkg/util/funcutil/func.go
+++ b/pkg/util/funcutil/func.go
@@ -473,10 +473,11 @@ func GetNumRowsOfFloat16VectorField(f16Datas []byte, dim int64) (uint64, error) 
 		return 0, fmt.Errorf("dim(%d) should be greater than 0", dim)
 	}
 	l := len(f16Datas)
-	if int64(l)%dim != 0 {
-		return 0, fmt.Errorf("the length(%d) of float16 data should divide the dim(%d)", l, dim)
+	rowWidth := dim * 2
+	if int64(l)%rowWidth != 0 {
+		return 0, fmt.Errorf("the length(%d) of float16 data should divide the row width(%d)", l, rowWidth)
 	}
-	return uint64((int64(l)) / dim / 2), nil
+	return uint64(int64(l) / rowWidth), nil
 }
 
 func GetNumRowsOfBFloat16VectorField(bf16Datas []byte, dim int64) (uint64, error) {
@@ -484,10 +485,11 @@ func GetNumRowsOfBFloat16VectorField(bf16Datas []byte, dim int64) (uint64, error
 		return 0, fmt.Errorf("dim(%d) should be greater than 0", dim)
 	}
 	l := len(bf16Datas)
-	if int64(l)%dim != 0 {
-		return 0, fmt.Errorf("the length(%d) of bfloat data should divide the dim(%d)", l, dim)
+	rowWidth := dim * 2
+	if int64(l)%rowWidth != 0 {
+		return 0, fmt.Errorf("the length(%d) of bfloat data should divide the row width(%d)", l, rowWidth)
 	}
-	return uint64((int64(l)) / dim / 2), nil
+	return uint64(int64(l) / rowWidth), nil
 }
 
 func GetNumRowsOfInt8VectorField(iDatas []byte, dim int64) (uint64, error) {
@@ -501,6 +503,94 @@ func GetNumRowsOfInt8VectorField(iDatas []byte, dim int64) (uint64, error) {
 	return uint64(int64(l) / dim), nil
 }
 
+func CountValidRows(validData []bool) uint64 {
+	validRows := uint64(0)
+	for _, valid := range validData {
+		if valid {
+			validRows++
+		}
+	}
+	return validRows
+}
+
+func GetVectorFieldPhysicalRows(fieldName string, dataType schemapb.DataType, vectors *schemapb.VectorField) (uint64, error) {
+	if vectors == nil {
+		return 0, fmt.Errorf("nullable vector field %s requires vector data", fieldName)
+	}
+
+	return getVectorFieldPhysicalRowsWithDim(fieldName, dataType, vectors, vectors.GetDim())
+}
+
+func getVectorFieldPhysicalRowsWithDim(fieldName string, dataType schemapb.DataType, vectors *schemapb.VectorField, dim int64) (uint64, error) {
+	switch dataType {
+	case schemapb.DataType_FloatVector:
+		return GetNumRowsOfFloatVectorField(vectors.GetFloatVector().GetData(), dim)
+	case schemapb.DataType_BinaryVector:
+		return GetNumRowsOfBinaryVectorField(vectors.GetBinaryVector(), dim)
+	case schemapb.DataType_Float16Vector:
+		return GetNumRowsOfFloat16VectorField(vectors.GetFloat16Vector(), dim)
+	case schemapb.DataType_BFloat16Vector:
+		return GetNumRowsOfBFloat16VectorField(vectors.GetBfloat16Vector(), dim)
+	case schemapb.DataType_SparseFloatVector:
+		if vectors.GetSparseFloatVector() == nil {
+			return 0, nil
+		}
+		return uint64(len(vectors.GetSparseFloatVector().GetContents())), nil
+	case schemapb.DataType_Int8Vector:
+		return GetNumRowsOfInt8VectorField(vectors.GetInt8Vector(), dim)
+	default:
+		return 0, fmt.Errorf("unsupported nullable vector type %s", dataType)
+	}
+}
+
+func ValidateNullableVectorCompactRows(fieldName string, validData []bool, physicalRows uint64, logicalRows uint64, requireValidData bool) error {
+	if len(validData) == 0 {
+		if requireValidData {
+			return fmt.Errorf("nullable vector field %s requires valid_data", fieldName)
+		}
+		return nil
+	}
+	if logicalRows > 0 && uint64(len(validData)) != logicalRows {
+		return fmt.Errorf("nullable vector field %s valid_data length mismatch: valid_data=%d, logical rows=%d", fieldName, len(validData), logicalRows)
+	}
+	validRows := CountValidRows(validData)
+	if physicalRows != validRows {
+		return fmt.Errorf("nullable vector field %s has %d valid rows, but compact physical payload rows is %d", fieldName, validRows, physicalRows)
+	}
+	return nil
+}
+
+func ValidateNullableVectorFieldDataCompact(fieldData *schemapb.FieldData, logicalRows uint64, requireValidData bool) error {
+	if fieldData == nil || !typeutil.IsSupportedNullableVectorType(fieldData.GetType()) {
+		return nil
+	}
+	if len(fieldData.GetValidData()) == 0 && !requireValidData {
+		return nil
+	}
+	physicalRows, err := GetVectorFieldPhysicalRows(fieldData.GetFieldName(), fieldData.GetType(), fieldData.GetVectors())
+	if err != nil {
+		return err
+	}
+	return ValidateNullableVectorCompactRows(fieldData.GetFieldName(), fieldData.GetValidData(), physicalRows, logicalRows, requireValidData)
+}
+
+func ValidateNullableVectorFieldDataCompactWithDim(fieldData *schemapb.FieldData, logicalRows uint64, requireValidData bool, dim int64) error {
+	if fieldData == nil || fieldData.GetVectors() == nil || fieldData.GetVectors().GetDim() != 0 || dim <= 0 {
+		return ValidateNullableVectorFieldDataCompact(fieldData, logicalRows, requireValidData)
+	}
+	if !typeutil.IsSupportedNullableVectorType(fieldData.GetType()) {
+		return nil
+	}
+	if len(fieldData.GetValidData()) == 0 && !requireValidData {
+		return nil
+	}
+	physicalRows, err := getVectorFieldPhysicalRowsWithDim(fieldData.GetFieldName(), fieldData.GetType(), fieldData.GetVectors(), dim)
+	if err != nil {
+		return err
+	}
+	return ValidateNullableVectorCompactRows(fieldData.GetFieldName(), fieldData.GetValidData(), physicalRows, logicalRows, requireValidData)
+}
+
 // GetNumRowOfFieldDataWithSchema returns num of rows with schema specification.
 func GetNumRowOfFieldDataWithSchema(fieldData *schemapb.FieldData, helper *typeutil.SchemaHelper) (uint64, error) {
 	var fieldNumRows uint64
@@ -508,6 +598,19 @@ func GetNumRowOfFieldDataWithSchema(fieldData *schemapb.FieldData, helper *typeu
 	fieldSchema, err := helper.GetFieldFromName(fieldData.GetFieldName())
 	if err != nil {
 		return 0, err
+	}
+	if len(fieldData.GetValidData()) > 0 && typeutil.IsSupportedNullableVectorType(fieldSchema.GetDataType()) {
+		dim := fieldData.GetVectors().GetDim()
+		if dim == 0 && fieldSchema.GetDataType() != schemapb.DataType_SparseFloatVector {
+			dim, err = typeutil.GetDim(fieldSchema)
+			if err != nil {
+				return 0, err
+			}
+		}
+		if err := ValidateNullableVectorFieldDataCompactWithDim(fieldData, uint64(len(fieldData.GetValidData())), false, dim); err != nil {
+			return 0, err
+		}
+		return uint64(len(fieldData.GetValidData())), nil
 	}
 	switch fieldSchema.GetDataType() {
 	case schemapb.DataType_Bool:
@@ -637,10 +740,13 @@ func GetNumRowOfFieldData(fieldData *schemapb.FieldData) (uint64, error) {
 			return 0, fmt.Errorf("%s is not supported now", scalarType)
 		}
 	case *schemapb.FieldData_Vectors:
+		vectorField := fieldData.GetVectors()
 		if len(fieldData.GetValidData()) > 0 {
+			if err := ValidateNullableVectorFieldDataCompact(fieldData, uint64(len(fieldData.GetValidData())), false); err != nil {
+				return 0, err
+			}
 			return uint64(len(fieldData.GetValidData())), nil
 		}
-		vectorField := fieldData.GetVectors()
 		switch vectorFieldType := vectorField.Data.(type) {
 		case *schemapb.VectorField_FloatVector:
 			dim := vectorField.GetDim()

--- a/pkg/util/funcutil/func_test.go
+++ b/pkg/util/funcutil/func_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	grpcCodes "google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
@@ -379,6 +380,7 @@ func TestGetNumRowsOfFloat16VectorField(t *testing.T) {
 		{[]byte{}, 128, 0, true},
 		{[]byte{1.0, 2.0}, 1, 1, true},
 		{[]byte{1.0, 2.0, 3.0, 4.0}, 2, 1, true},
+		{[]byte{1.0, 2.0}, 2, 0, false}, // length % (dim * 2) != 0
 	}
 
 	for _, test := range cases {
@@ -407,6 +409,7 @@ func TestGetNumRowsOfBFloat16VectorField(t *testing.T) {
 		{[]byte{}, 128, 0, true},
 		{[]byte{1.0, 2.0}, 1, 1, true},
 		{[]byte{1.0, 2.0, 3.0, 4.0}, 2, 1, true},
+		{[]byte{1.0, 2.0}, 2, 0, false}, // length % (dim * 2) != 0
 	}
 
 	for _, test := range cases {
@@ -481,6 +484,101 @@ func TestGetNumRowsOfInt8VectorField(t *testing.T) {
 			assert.NotEqual(t, nil, err)
 		}
 	}
+}
+
+func TestValidateNullableVectorFieldDataCompact(t *testing.T) {
+	t.Run("float vector compact valid", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_FloatVector,
+			ValidData: []bool{true, false, true},
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: 2,
+				Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+					Data: []float32{1, 2, 3, 4},
+				}},
+			}},
+		}
+		require.NoError(t, ValidateNullableVectorFieldDataCompact(fieldData, 3, true))
+	})
+
+	t.Run("full row payload rejected", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_FloatVector,
+			ValidData: []bool{true, false, true},
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: 2,
+				Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+					Data: []float32{1, 2, 3, 4, 5, 6},
+				}},
+			}},
+		}
+		err := ValidateNullableVectorFieldDataCompact(fieldData, 3, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "physical payload rows")
+	})
+
+	t.Run("partial dense row rejected", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_Float16Vector,
+			ValidData: []bool{true, false},
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim:  2,
+				Data: &schemapb.VectorField_Float16Vector{Float16Vector: []byte{1, 2}},
+			}},
+		}
+		err := ValidateNullableVectorFieldDataCompact(fieldData, 2, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "row width")
+	})
+
+	t.Run("sparse vector compact valid", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_SparseFloatVector,
+			ValidData: []bool{false, true, true},
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{SparseFloatVector: &schemapb.SparseFloatArray{
+					Contents: [][]byte{
+						typeutil.CreateSparseFloatRow([]uint32{1}, []float32{1}),
+						typeutil.CreateSparseFloatRow([]uint32{2}, []float32{2}),
+					},
+				}},
+			}},
+		}
+		require.NoError(t, ValidateNullableVectorFieldDataCompact(fieldData, 3, true))
+	})
+
+	t.Run("missing valid data depends on caller boundary", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_FloatVector,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: 2,
+				Data: &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{
+					Data: []float32{1, 2},
+				}},
+			}},
+		}
+		require.NoError(t, ValidateNullableVectorFieldDataCompact(fieldData, 0, false))
+		err := ValidateNullableVectorFieldDataCompact(fieldData, 1, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "requires valid_data")
+	})
+
+	t.Run("schema dim fallback", func(t *testing.T) {
+		fieldData := &schemapb.FieldData{
+			FieldName: "vec",
+			Type:      schemapb.DataType_BinaryVector,
+			ValidData: []bool{true, false},
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{0xff}},
+			}},
+		}
+		require.NoError(t, ValidateNullableVectorFieldDataCompactWithDim(fieldData, 2, true, 8))
+	})
 }
 
 func Test_ReadBinary(t *testing.T) {

--- a/pkg/util/funcutil/placeholdergroup_test.go
+++ b/pkg/util/funcutil/placeholdergroup_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
 func Test_flattenedBinaryVectorsToByteVectors(t *testing.T) {
@@ -56,4 +58,23 @@ func Test_flattenedInt8VectorsToByteVectors(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, actual)
+}
+
+func TestFieldDataToPlaceholderGroupBytesWithCount_AllNullSparseVector(t *testing.T) {
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_SparseFloatVector,
+		FieldName: "sparse_vec",
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{},
+				},
+			},
+		},
+		ValidData: []bool{false, false, false},
+	}
+
+	_, valueCount, err := FieldDataToPlaceholderGroupBytesWithCount(fieldData)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, valueCount)
 }

--- a/pkg/util/typeutil/nullable_vector.go
+++ b/pkg/util/typeutil/nullable_vector.go
@@ -1,0 +1,54 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typeutil
+
+import "github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+
+// IsSupportedNullableVectorType reports whether this vector type currently
+// supports nullable rows. Supported nullable vector payload data is compact:
+// ValidData has one entry per logical row, while vector data only contains
+// valid rows.
+func IsSupportedNullableVectorType(dataType schemapb.DataType) bool {
+	switch dataType {
+	case schemapb.DataType_FloatVector,
+		schemapb.DataType_BinaryVector,
+		schemapb.DataType_Float16Vector,
+		schemapb.DataType_BFloat16Vector,
+		schemapb.DataType_Int8Vector,
+		schemapb.DataType_SparseFloatVector:
+		return true
+	default:
+		return false
+	}
+}
+
+// BuildNullableVectorDataIndices maps logical row indexes to compact vector
+// payload indexes. Null rows are mapped to -1. The returned validCount is the
+// number of physical vector entries expected in compact payload data.
+func BuildNullableVectorDataIndices(validData []bool) ([]int, int) {
+	indices := make([]int, len(validData))
+	validCount := 0
+	for i, valid := range validData {
+		if valid {
+			indices[i] = validCount
+			validCount++
+		} else {
+			indices[i] = -1
+		}
+	}
+	return indices, validCount
+}

--- a/pkg/util/typeutil/nullable_vector_test.go
+++ b/pkg/util/typeutil/nullable_vector_test.go
@@ -1,0 +1,57 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typeutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+func TestIsSupportedNullableVectorType(t *testing.T) {
+	nullableVectorTypes := []schemapb.DataType{
+		schemapb.DataType_FloatVector,
+		schemapb.DataType_BinaryVector,
+		schemapb.DataType_Float16Vector,
+		schemapb.DataType_BFloat16Vector,
+		schemapb.DataType_Int8Vector,
+		schemapb.DataType_SparseFloatVector,
+	}
+	for _, dataType := range nullableVectorTypes {
+		assert.True(t, IsSupportedNullableVectorType(dataType), dataType.String())
+	}
+
+	assert.False(t, IsSupportedNullableVectorType(schemapb.DataType_ArrayOfVector))
+	assert.False(t, IsSupportedNullableVectorType(schemapb.DataType_Int64))
+	assert.False(t, IsSupportedNullableVectorType(schemapb.DataType_JSON))
+}
+
+func TestBuildNullableVectorDataIndices(t *testing.T) {
+	indices, validCount := BuildNullableVectorDataIndices([]bool{true, false, true, false, true})
+	assert.Equal(t, []int{0, -1, 1, -1, 2}, indices)
+	assert.Equal(t, 3, validCount)
+
+	indices, validCount = BuildNullableVectorDataIndices([]bool{false, false})
+	assert.Equal(t, []int{-1, -1}, indices)
+	assert.Equal(t, 0, validCount)
+
+	indices, validCount = BuildNullableVectorDataIndices(nil)
+	assert.Empty(t, indices)
+	assert.Equal(t, 0, validCount)
+}

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -638,6 +638,26 @@ func IsVectorArrayType(dataType schemapb.DataType) bool {
 	return dataType == schemapb.DataType_ArrayOfVector
 }
 
+// NewEmptyArrayOfVectorRow builds a row-dense ArrayOfVector placeholder for a null row.
+func NewEmptyArrayOfVectorRow(dim int64, elementType schemapb.DataType) (*schemapb.VectorField, error) {
+	vf := &schemapb.VectorField{Dim: dim}
+	switch elementType {
+	case schemapb.DataType_FloatVector:
+		vf.Data = &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{}}
+	case schemapb.DataType_BinaryVector:
+		vf.Data = &schemapb.VectorField_BinaryVector{BinaryVector: []byte{}}
+	case schemapb.DataType_Float16Vector:
+		vf.Data = &schemapb.VectorField_Float16Vector{Float16Vector: []byte{}}
+	case schemapb.DataType_BFloat16Vector:
+		vf.Data = &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: []byte{}}
+	case schemapb.DataType_Int8Vector:
+		vf.Data = &schemapb.VectorField_Int8Vector{Int8Vector: []byte{}}
+	default:
+		return nil, fmt.Errorf("unsupported ArrayOfVector element type %s", elementType)
+	}
+	return vf, nil
+}
+
 // IsClusteringKeyType returns true if the data type is supported as a clustering key.
 // Supported scalar types: Int8, Int16, Int32, Int64, Float, Double, VarChar, String, FloatVector.
 func IsClusteringKeyType(dataType schemapb.DataType) bool {
@@ -874,24 +894,46 @@ func PrepareResultFieldData(sample []*schemapb.FieldData, topK int64) []*schemap
 }
 
 type FieldDataIdxComputer struct {
-	fieldsData   []*schemapb.FieldData
-	lastRowIdx   int64
-	dataIndices  []int64
-	isVector     []bool
-	resultBuffer []int64
+	fieldsData                     []*schemapb.FieldData
+	lastRowIdx                     int64
+	dataIndices                    []int64
+	isVector                       []bool
+	nullableVectorWithoutValidData []bool
+	resultBuffer                   []int64
 }
 
 func NewFieldDataIdxComputer(fieldsData []*schemapb.FieldData) *FieldDataIdxComputer {
+	return NewFieldDataIdxComputerWithSchema(fieldsData, nil)
+}
+
+func NewFieldDataIdxComputerWithSchema(fieldsData []*schemapb.FieldData, schema *schemapb.CollectionSchema) *FieldDataIdxComputer {
 	c := &FieldDataIdxComputer{
-		fieldsData:   fieldsData,
-		lastRowIdx:   0,
-		dataIndices:  make([]int64, len(fieldsData)),
-		isVector:     make([]bool, len(fieldsData)),
-		resultBuffer: make([]int64, len(fieldsData)),
+		fieldsData:                     fieldsData,
+		lastRowIdx:                     0,
+		dataIndices:                    make([]int64, len(fieldsData)),
+		isVector:                       make([]bool, len(fieldsData)),
+		nullableVectorWithoutValidData: make([]bool, len(fieldsData)),
+		resultBuffer:                   make([]int64, len(fieldsData)),
 	}
+
+	fieldSchemas := make(map[int64]*schemapb.FieldSchema)
+	if schema != nil {
+		for _, field := range schema.GetFields() {
+			fieldSchemas[field.GetFieldID()] = field
+		}
+	}
+
 	for i, fieldData := range fieldsData {
 		validData := fieldData.GetValidData()
-		c.isVector[i] = len(validData) > 0 && IsVectorType(fieldData.Type)
+		fieldSchema := fieldSchemas[fieldData.GetFieldId()]
+		isVector := IsSupportedNullableVectorType(fieldData.GetType())
+		isNullableVector := false
+		if fieldSchema != nil {
+			isVector = IsSupportedNullableVectorType(fieldSchema.GetDataType())
+			isNullableVector = fieldSchema.GetNullable() && isVector
+		}
+		c.isVector[i] = isVector && (len(validData) > 0 || isNullableVector)
+		c.nullableVectorWithoutValidData[i] = isNullableVector && len(validData) == 0
 	}
 	return c
 }
@@ -906,6 +948,10 @@ func (c *FieldDataIdxComputer) Compute(rowIdx int64) []int64 {
 
 	for i, fieldData := range c.fieldsData {
 		if c.isVector[i] {
+			if c.nullableVectorWithoutValidData[i] {
+				c.resultBuffer[i] = -1
+				continue
+			}
 			validData := fieldData.GetValidData()
 			for j := c.lastRowIdx; j < rowIdx && j < int64(len(validData)); j++ {
 				if validData[j] {
@@ -951,6 +997,11 @@ func AppendFieldData(dst, src []*schemapb.FieldData, idx int64, fieldIdxs ...int
 			}
 			valid := fieldData.ValidData[idx]
 			dstFieldData.ValidData = append(dstFieldData.ValidData, valid)
+		} else if fieldIdx < 0 {
+			if dstFieldData.ValidData == nil {
+				dstFieldData.ValidData = make([]bool, 0)
+			}
+			dstFieldData.ValidData = append(dstFieldData.ValidData, false)
 		}
 		switch fieldType := fieldData.Field.(type) {
 		case *schemapb.FieldData_Scalars:
@@ -1103,7 +1154,7 @@ func AppendFieldData(dst, src []*schemapb.FieldData, idx int64, fieldIdxs ...int
 				}
 			}
 			dstVector := dstFieldData.GetVectors()
-			isNullRow := len(fieldData.GetValidData()) > 0 && !fieldData.GetValidData()[idx]
+			isNullRow := fieldIdx < 0 || (len(fieldData.GetValidData()) > 0 && !fieldData.GetValidData()[idx])
 
 			switch srcVector := fieldType.Vectors.Data.(type) {
 			case *schemapb.VectorField_BinaryVector:
@@ -1197,18 +1248,16 @@ func AppendFieldData(dst, src []*schemapb.FieldData, idx int64, fieldIdxs ...int
 					appendSize += int64(unsafe.Sizeof(srcVector.Int8Vector[fieldIdx*dim : (fieldIdx+1)*dim]))
 				}
 			case *schemapb.VectorField_VectorArray:
-				if !isNullRow {
-					if dstVector.GetVectorArray() == nil {
-						dstVector.Data = &schemapb.VectorField_VectorArray{
-							VectorArray: &schemapb.VectorArray{
-								Data:        []*schemapb.VectorField{srcVector.VectorArray.Data[fieldIdx]},
-								Dim:         srcVector.VectorArray.Dim,
-								ElementType: srcVector.VectorArray.ElementType,
-							},
-						}
-					} else {
-						dstVector.GetVectorArray().Data = append(dstVector.GetVectorArray().Data, srcVector.VectorArray.Data[fieldIdx])
+				if dstVector.GetVectorArray() == nil {
+					dstVector.Data = &schemapb.VectorField_VectorArray{
+						VectorArray: &schemapb.VectorArray{
+							Data:        []*schemapb.VectorField{srcVector.VectorArray.Data[fieldIdx]},
+							Dim:         srcVector.VectorArray.Dim,
+							ElementType: srcVector.VectorArray.ElementType,
+						},
 					}
+				} else {
+					dstVector.GetVectorArray().Data = append(dstVector.GetVectorArray().Data, srcVector.VectorArray.Data[fieldIdx])
 				}
 			}
 		}
@@ -1783,6 +1832,9 @@ func UpdateFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, upda
 	if len(baseIndices) != len(updateIndices) {
 		return fmt.Errorf("baseIndices and updateIndices length mismatch: %d vs %d", len(baseIndices), len(updateIndices))
 	}
+	if IsCompactNullableVectorFieldData(base) {
+		return updateCompactNullableVectorFieldDataByColumn(base, update, baseIndices, updateIndices)
+	}
 
 	// Handle ValidData
 	if len(update.GetValidData()) > 0 && len(base.GetValidData()) > 0 {
@@ -1944,10 +1996,234 @@ func UpdateFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, upda
 				updateIdx := updateIndices[i]
 				copy(baseData[baseIdx*dim:(baseIdx+1)*dim], updateData[updateIdx*dim:(updateIdx+1)*dim])
 			}
+		case *schemapb.VectorField_VectorArray:
+			baseData := baseVector.GetVectorArray().Data
+			updateData := updateVector.GetVectorArray().Data
+			for i, baseIdx := range baseIndices {
+				baseData[baseIdx] = updateData[updateIndices[i]]
+			}
 		}
 	}
 
 	return nil
+}
+
+// IsCompactNullableVectorFieldData reports whether field uses compact nullable vector payload.
+func IsCompactNullableVectorFieldData(field *schemapb.FieldData) bool {
+	return len(field.GetValidData()) > 0 && IsSupportedNullableVectorType(field.GetType())
+}
+
+func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, updateIndices []int64) error {
+	if !IsSupportedNullableVectorType(update.GetType()) {
+		return fmt.Errorf("cannot update nullable vector field %s with %s", base.GetType().String(), update.GetType().String())
+	}
+	if update.GetType() != base.GetType() {
+		return fmt.Errorf("cannot update nullable vector field %s with %s", base.GetType().String(), update.GetType().String())
+	}
+
+	baseValidData := base.GetValidData()
+	updateValidData := update.GetValidData()
+	if len(updateValidData) == 0 {
+		return fmt.Errorf("nullable vector field %s missing ValidData", update.GetFieldName())
+	}
+
+	updateByBaseIdx := make(map[int]int, len(baseIndices))
+	for i, baseIdx := range baseIndices {
+		updateIdx := updateIndices[i]
+		if baseIdx < 0 || int(baseIdx) >= len(baseValidData) {
+			return fmt.Errorf("base index %d out of range for nullable vector field %s", baseIdx, base.GetFieldName())
+		}
+		if updateIdx < 0 || int(updateIdx) >= len(updateValidData) {
+			return fmt.Errorf("update index %d out of range for nullable vector field %s", updateIdx, update.GetFieldName())
+		}
+		updateByBaseIdx[int(baseIdx)] = int(updateIdx)
+	}
+
+	basePhysicalIndices, _ := BuildNullableVectorDataIndices(baseValidData)
+	updatePhysicalIndices, _ := BuildNullableVectorDataIndices(updateValidData)
+	newValidData := append([]bool(nil), baseValidData...)
+	for baseIdx, updateIdx := range updateByBaseIdx {
+		newValidData[baseIdx] = updateValidData[updateIdx]
+	}
+
+	baseVector := base.GetVectors()
+	updateVector := update.GetVectors()
+	if baseVector == nil || updateVector == nil {
+		return fmt.Errorf("nullable vector field data is nil")
+	}
+	dim := baseVector.GetDim()
+	if dim == 0 {
+		dim = updateVector.GetDim()
+	}
+	if dim != 0 {
+		baseVector.Dim = dim
+	}
+
+	switch base.GetType() {
+	case schemapb.DataType_BinaryVector:
+		elemSize := dim / 8
+		newData := make([]byte, 0, int64(countValid(newValidData))*elemSize)
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetBinaryVector()
+			start := int64(physicalIdx) * elemSize
+			end := start + elemSize
+			if start < 0 || end > int64(len(data)) {
+				return fmt.Errorf("binary vector physical index %d out of range", physicalIdx)
+			}
+			newData = append(newData, data[start:end]...)
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_BinaryVector{BinaryVector: newData}
+	case schemapb.DataType_FloatVector:
+		newData := make([]float32, 0, int64(countValid(newValidData))*dim)
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetFloatVector().GetData()
+			start := int64(physicalIdx) * dim
+			end := start + dim
+			if start < 0 || end > int64(len(data)) {
+				return fmt.Errorf("float vector physical index %d out of range", physicalIdx)
+			}
+			newData = append(newData, data[start:end]...)
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_FloatVector{FloatVector: &schemapb.FloatArray{Data: newData}}
+	case schemapb.DataType_Float16Vector:
+		elemSize := dim * 2
+		newData := make([]byte, 0, int64(countValid(newValidData))*elemSize)
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetFloat16Vector()
+			start := int64(physicalIdx) * elemSize
+			end := start + elemSize
+			if start < 0 || end > int64(len(data)) {
+				return fmt.Errorf("float16 vector physical index %d out of range", physicalIdx)
+			}
+			newData = append(newData, data[start:end]...)
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_Float16Vector{Float16Vector: newData}
+	case schemapb.DataType_BFloat16Vector:
+		elemSize := dim * 2
+		newData := make([]byte, 0, int64(countValid(newValidData))*elemSize)
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetBfloat16Vector()
+			start := int64(physicalIdx) * elemSize
+			end := start + elemSize
+			if start < 0 || end > int64(len(data)) {
+				return fmt.Errorf("bfloat16 vector physical index %d out of range", physicalIdx)
+			}
+			newData = append(newData, data[start:end]...)
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_Bfloat16Vector{Bfloat16Vector: newData}
+	case schemapb.DataType_SparseFloatVector:
+		baseSparse := baseVector.GetSparseFloatVector()
+		updateSparse := updateVector.GetSparseFloatVector()
+		if updateSparse == nil {
+			return fmt.Errorf("sparse float vector update data is nil")
+		}
+		baseDim := int64(0)
+		if baseSparse != nil {
+			baseDim = baseSparse.GetDim()
+		}
+		newSparse := &schemapb.SparseFloatArray{
+			Dim:      maxInt64(baseDim, updateSparse.GetDim()),
+			Contents: make([][]byte, 0, countValid(newValidData)),
+		}
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetSparseFloatVector()
+			if data == nil || physicalIdx < 0 || physicalIdx >= len(data.GetContents()) {
+				return fmt.Errorf("sparse vector physical index %d out of range", physicalIdx)
+			}
+			row := data.GetContents()[physicalIdx]
+			newSparse.Contents = append(newSparse.Contents, row)
+			if rowDim := SparseFloatRowDim(row); rowDim > newSparse.Dim {
+				newSparse.Dim = rowDim
+			}
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_SparseFloatVector{SparseFloatVector: newSparse}
+		baseVector.Dim = newSparse.GetDim()
+	case schemapb.DataType_Int8Vector:
+		elemSize := dim
+		newData := make([]byte, 0, int64(countValid(newValidData))*elemSize)
+		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
+			data := vector.GetInt8Vector()
+			start := int64(physicalIdx) * elemSize
+			end := start + elemSize
+			if start < 0 || end > int64(len(data)) {
+				return fmt.Errorf("int8 vector physical index %d out of range", physicalIdx)
+			}
+			newData = append(newData, data[start:end]...)
+			return nil
+		}
+		if err := rebuildCompactNullableVectorData(newValidData, updateByBaseIdx, basePhysicalIndices, updatePhysicalIndices, appendRow, baseVector, updateVector); err != nil {
+			return err
+		}
+		baseVector.Data = &schemapb.VectorField_Int8Vector{Int8Vector: newData}
+	default:
+		return fmt.Errorf("unsupported nullable vector field type %s", base.GetType().String())
+	}
+
+	base.ValidData = newValidData
+	return nil
+}
+
+func rebuildCompactNullableVectorData(
+	validData []bool,
+	updateByBaseIdx map[int]int,
+	basePhysicalIndices []int,
+	updatePhysicalIndices []int,
+	appendRow func(vector *schemapb.VectorField, physicalIdx int) error,
+	baseVector *schemapb.VectorField,
+	updateVector *schemapb.VectorField,
+) error {
+	for logicalIdx, valid := range validData {
+		if !valid {
+			continue
+		}
+		if updateIdx, ok := updateByBaseIdx[logicalIdx]; ok {
+			if err := appendRow(updateVector, updatePhysicalIndices[updateIdx]); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := appendRow(baseVector, basePhysicalIndices[logicalIdx]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func maxInt64(lhs, rhs int64) int64 {
+	if lhs > rhs {
+		return lhs
+	}
+	return rhs
+}
+
+func countValid(validData []bool) int {
+	validCount := 0
+	for _, valid := range validData {
+		if valid {
+			validCount++
+		}
+	}
+	return validCount
 }
 
 // MergeFieldData appends fields data to dst
@@ -2674,6 +2950,15 @@ func GetPK(data *schemapb.IDs, idx int64) interface{} {
 func GetDataIterator(field *schemapb.FieldData) func(int) any {
 	if field.GetValidData() != nil {
 		validData := field.GetValidData()
+		if IsCompactNullableVectorFieldData(field) {
+			idxs, _ := BuildNullableVectorDataIndices(validData)
+			return func(idx int) any {
+				if idxs[idx] == -1 {
+					return nil
+				}
+				return getData(field, idxs[idx])
+			}
+		}
 		dataLen := getScalarDataLen(field)
 		if dataLen == len(validData) {
 			// Full-size format: data array has the same length as ValidData,
@@ -2686,8 +2971,6 @@ func GetDataIterator(field *schemapb.FieldData) func(int) any {
 			}
 		}
 
-		// Compact format: data array only contains valid entries.
-		// Build a mapping from logical index to physical index.
 		idxs := make([]int, len(validData))
 		cnt := 0
 		for i, valid := range validData {

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -3079,6 +3079,44 @@ func TestGetDataIterator(t *testing.T) {
 			},
 			want: []any{int64(1), nil, int64(2), int64(3)},
 		},
+		{
+			name: "compact nullable float vector",
+			field: &schemapb.FieldData{
+				Type: schemapb.DataType_FloatVector,
+				Field: &schemapb.FieldData_Vectors{
+					Vectors: &schemapb.VectorField{
+						Dim: 2,
+						Data: &schemapb.VectorField_FloatVector{
+							FloatVector: &schemapb.FloatArray{
+								Data: []float32{1, 2, 5, 6},
+							},
+						},
+					},
+				},
+				ValidData: []bool{true, false, true},
+			},
+			want: []any{[]float32{1, 2}, nil, []float32{5, 6}},
+		},
+		{
+			name: "compact nullable sparse vector",
+			field: &schemapb.FieldData{
+				Type: schemapb.DataType_SparseFloatVector,
+				Field: &schemapb.FieldData_Vectors{
+					Vectors: &schemapb.VectorField{
+						Data: &schemapb.VectorField_SparseFloatVector{
+							SparseFloatVector: &schemapb.SparseFloatArray{
+								Contents: [][]byte{
+									CreateSparseFloatRow([]uint32{1}, []float32{1}),
+									CreateSparseFloatRow([]uint32{3}, []float32{3}),
+								},
+							},
+						},
+					},
+				},
+				ValidData: []bool{false, true, false, true},
+			},
+			want: []any{nil, CreateSparseFloatRow([]uint32{1}, []float32{1}), nil, CreateSparseFloatRow([]uint32{3}, []float32{3})},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -5787,6 +5825,132 @@ func TestUpdateFieldDataByColumn(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, [][]byte{{10}, {2}, {20}}, base.GetVectors().GetSparseFloatVector().Contents)
 	})
+
+	t.Run("nullable array of vector stays row-dense", func(t *testing.T) {
+		base := newArrayOfVectorFieldData(200, "arrvec", 1, schemapb.DataType_FloatVector, []bool{true, true, true})
+		update := newArrayOfVectorFieldData(200, "arrvec", 1, schemapb.DataType_FloatVector, []bool{false, true})
+
+		err := UpdateFieldDataByColumn(base, update, []int64{0, 2}, []int64{0, 1})
+
+		require.NoError(t, err)
+		assert.Equal(t, []bool{false, true, true}, base.GetValidData())
+
+		got := base.GetVectors().GetVectorArray()
+		require.NotNil(t, got)
+		require.Len(t, got.GetData(), 3)
+		assert.Empty(t, got.GetData()[0].GetFloatVector().GetData())
+		assert.Equal(t, []float32{2}, got.GetData()[2].GetFloatVector().GetData())
+		assert.EqualValues(t, 1, got.GetDim())
+		assert.Equal(t, schemapb.DataType_FloatVector, got.GetElementType())
+	})
+
+	t.Run("nullable compact float vector changes validity", func(t *testing.T) {
+		dim := int64(2)
+		base := &schemapb.FieldData{
+			Type:      schemapb.DataType_FloatVector,
+			ValidData: []bool{true, false, true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{Data: []float32{
+							1, 1,
+							3, 3,
+						}},
+					},
+				},
+			},
+		}
+		update := &schemapb.FieldData{
+			Type:      schemapb.DataType_FloatVector,
+			ValidData: []bool{false, true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: dim,
+					Data: &schemapb.VectorField_FloatVector{
+						FloatVector: &schemapb.FloatArray{Data: []float32{20, 20}},
+					},
+				},
+			},
+		}
+
+		err := UpdateFieldDataByColumn(base, update, []int64{0, 1}, []int64{0, 1})
+
+		require.NoError(t, err)
+		assert.Equal(t, []bool{false, true, true}, base.GetValidData())
+		assert.Equal(t, []float32{20, 20, 3, 3}, base.GetVectors().GetFloatVector().GetData())
+	})
+
+	t.Run("nullable compact sparse vector changes validity", func(t *testing.T) {
+		base := &schemapb.FieldData{
+			Type:      schemapb.DataType_SparseFloatVector,
+			ValidData: []bool{true, false, true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: &schemapb.SparseFloatArray{
+							Dim:      100,
+							Contents: [][]byte{CreateSparseFloatRow([]uint32{1}, []float32{1}), CreateSparseFloatRow([]uint32{3}, []float32{3})},
+						},
+					},
+				},
+			},
+		}
+		update := &schemapb.FieldData{
+			Type:      schemapb.DataType_SparseFloatVector,
+			ValidData: []bool{false, true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: &schemapb.SparseFloatArray{
+							Dim:      100,
+							Contents: [][]byte{CreateSparseFloatRow([]uint32{20}, []float32{20})},
+						},
+					},
+				},
+			},
+		}
+
+		err := UpdateFieldDataByColumn(base, update, []int64{0, 1}, []int64{0, 1})
+
+		require.NoError(t, err)
+		assert.Equal(t, []bool{false, true, true}, base.GetValidData())
+		assert.Equal(t, [][]byte{
+			CreateSparseFloatRow([]uint32{20}, []float32{20}),
+			CreateSparseFloatRow([]uint32{3}, []float32{3}),
+		}, base.GetVectors().GetSparseFloatVector().GetContents())
+	})
+
+	t.Run("nullable compact sparse vector all null base accepts valid update", func(t *testing.T) {
+		base := &schemapb.FieldData{
+			Type:      schemapb.DataType_SparseFloatVector,
+			ValidData: []bool{false, false},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{},
+			},
+		}
+		updateRow := CreateSparseFloatRow([]uint32{20}, []float32{20})
+		update := &schemapb.FieldData{
+			Type:      schemapb.DataType_SparseFloatVector,
+			ValidData: []bool{true},
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Data: &schemapb.VectorField_SparseFloatVector{
+						SparseFloatVector: &schemapb.SparseFloatArray{
+							Dim:      100,
+							Contents: [][]byte{updateRow},
+						},
+					},
+				},
+			},
+		}
+
+		err := UpdateFieldDataByColumn(base, update, []int64{1}, []int64{0})
+
+		require.NoError(t, err)
+		assert.Equal(t, []bool{false, true}, base.GetValidData())
+		assert.Equal(t, [][]byte{updateRow}, base.GetVectors().GetSparseFloatVector().GetContents())
+	})
 }
 
 func TestIsClusteringKeyType(t *testing.T) {
@@ -5813,4 +5977,268 @@ func TestIsClusteringKeyType(t *testing.T) {
 	assert.False(t, IsClusteringKeyType(schemapb.DataType_BinaryVector))
 	assert.False(t, IsClusteringKeyType(schemapb.DataType_Float16Vector))
 	assert.False(t, IsClusteringKeyType(schemapb.DataType_BFloat16Vector))
+}
+
+func TestAppendFieldDataNullableVectorWithSchemaWithoutValidData(t *testing.T) {
+	const fieldID = int64(101)
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  fieldID,
+				Name:     "nullable_sparse",
+				DataType: schemapb.DataType_SparseFloatVector,
+				Nullable: true,
+			},
+		},
+	}
+	src := []*schemapb.FieldData{
+		{
+			Type:      schemapb.DataType_SparseFloatVector,
+			FieldName: "nullable_sparse",
+			FieldId:   fieldID,
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Data: &schemapb.VectorField_SparseFloatVector{
+					SparseFloatVector: &schemapb.SparseFloatArray{},
+				},
+			}},
+		},
+	}
+	dst := PrepareResultFieldData(src, 1)
+	idxComputer := NewFieldDataIdxComputerWithSchema(src, schema)
+	fieldIdxs := idxComputer.Compute(0)
+
+	require.NotPanics(t, func() {
+		AppendFieldData(dst, src, 0, fieldIdxs...)
+	})
+	require.Len(t, dst, 1)
+	assert.Equal(t, []bool{false}, dst[0].GetValidData())
+	assert.Empty(t, dst[0].GetVectors().GetSparseFloatVector().GetContents())
+}
+
+func TestAppendFieldDataNullableVectorWithSchemaAndValidData(t *testing.T) {
+	const (
+		fieldID = int64(101)
+		dim     = int64(2)
+	)
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  fieldID,
+				Name:     "nullable_float",
+				DataType: schemapb.DataType_FloatVector,
+				Nullable: true,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "2"},
+				},
+			},
+		},
+	}
+	src := []*schemapb.FieldData{
+		{
+			Type:      schemapb.DataType_FloatVector,
+			FieldName: "nullable_float",
+			FieldId:   fieldID,
+			ValidData: []bool{true, false, true},
+			Field: &schemapb.FieldData_Vectors{Vectors: &schemapb.VectorField{
+				Dim: dim,
+				Data: &schemapb.VectorField_FloatVector{
+					FloatVector: &schemapb.FloatArray{Data: []float32{1, 2, 3, 4}},
+				},
+			}},
+		},
+	}
+	dst := PrepareResultFieldData(src, 3)
+	idxComputer := NewFieldDataIdxComputerWithSchema(src, schema)
+	for _, rowIdx := range []int64{0, 1, 2} {
+		fieldIdxs := idxComputer.Compute(rowIdx)
+		AppendFieldData(dst, src, rowIdx, fieldIdxs...)
+	}
+
+	assert.Equal(t, []bool{true, false, true}, dst[0].GetValidData())
+	assert.Equal(t, []float32{1, 2, 3, 4}, dst[0].GetVectors().GetFloatVector().GetData())
+}
+
+func newArrayOfVectorFieldData(fieldID int64, fieldName string, dim int64, elementType schemapb.DataType, rows any) *schemapb.FieldData {
+	var rowCount int
+	var validData []bool
+	switch v := rows.(type) {
+	case int:
+		rowCount = v
+	case []bool:
+		validData = v
+		rowCount = len(v)
+	default:
+		panic("unexpected ArrayOfVector row spec")
+	}
+
+	data := make([]*schemapb.VectorField, rowCount)
+	for i := 0; i < rowCount; i++ {
+		if len(validData) > 0 && !validData[i] {
+			data[i] = &schemapb.VectorField{
+				Dim: dim,
+				Data: &schemapb.VectorField_FloatVector{
+					FloatVector: &schemapb.FloatArray{},
+				},
+			}
+			continue
+		}
+		data[i] = &schemapb.VectorField{
+			Dim: dim,
+			Data: &schemapb.VectorField_FloatVector{
+				FloatVector: &schemapb.FloatArray{Data: []float32{float32(i + 1)}},
+			},
+		}
+	}
+	fd := &schemapb.FieldData{
+		Type:      schemapb.DataType_ArrayOfVector,
+		FieldName: fieldName,
+		FieldId:   fieldID,
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: dim,
+				Data: &schemapb.VectorField_VectorArray{
+					VectorArray: &schemapb.VectorArray{
+						Data:        data,
+						Dim:         dim,
+						ElementType: elementType,
+					},
+				},
+			},
+		},
+	}
+	if len(validData) > 0 {
+		fd.ValidData = validData
+	}
+	return fd
+}
+
+func TestFieldDataIdxComputer_ArrayOfVectorIsNonVector(t *testing.T) {
+	scalar := &schemapb.FieldData{
+		Type:    schemapb.DataType_Int64,
+		FieldId: 100,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{10, 20, 30, 40}},
+				},
+			},
+		},
+		ValidData: []bool{true, false, true, false},
+	}
+
+	// Compact vector: 2 valid rows out of 4; Data len==2.
+	vec := &schemapb.FieldData{
+		Type:    schemapb.DataType_FloatVector,
+		FieldId: 101,
+		Field: &schemapb.FieldData_Vectors{
+			Vectors: &schemapb.VectorField{
+				Dim: 1,
+				Data: &schemapb.VectorField_FloatVector{
+					FloatVector: &schemapb.FloatArray{Data: []float32{1.0, 2.0}},
+				},
+			},
+		},
+		ValidData: []bool{true, false, true, false},
+	}
+
+	arrVec := newArrayOfVectorFieldData(102, "arrvec", 1, schemapb.DataType_FloatVector, []bool{true, false, true, false})
+
+	c := NewFieldDataIdxComputer([]*schemapb.FieldData{scalar, vec, arrVec})
+
+	// The key invariant: for every row, ArrayOfVector's index must equal rowIdx
+	// (dense/scalar semantics), never the compact index like a regular vector.
+	// Regular vector uses compact indexing, which diverges from rowIdx at row 2:
+	// rowIdx=2 but there's only one valid row before it, so compact index == 1.
+	for rowIdx := int64(0); rowIdx < 4; rowIdx++ {
+		got := c.Compute(rowIdx)
+		assert.Equal(t, rowIdx, got[0], "scalar row %d", rowIdx)
+		assert.Equal(t, rowIdx, got[2], "ArrayOfVector row %d must follow rowIdx", rowIdx)
+	}
+
+	// Reset by calling Compute on a smaller rowIdx.
+	c.Compute(0)
+	// At row 2 (the second valid row), compact vector index is 1, which differs
+	// from rowIdx=2. This confirms ArrayOfVector is NOT using the compact path.
+	got := c.Compute(2)
+	assert.Equal(t, int64(1), got[1], "compact vector at row 2 -> compact index 1")
+	assert.Equal(t, int64(2), got[2], "ArrayOfVector at row 2 -> rowIdx 2")
+}
+
+func TestNewEmptyArrayOfVectorRow(t *testing.T) {
+	cases := []struct {
+		name string
+		elem schemapb.DataType
+		data any
+	}{
+		{name: "FloatVector", elem: schemapb.DataType_FloatVector, data: &schemapb.VectorField_FloatVector{}},
+		{name: "BinaryVector", elem: schemapb.DataType_BinaryVector, data: &schemapb.VectorField_BinaryVector{}},
+		{name: "Float16Vector", elem: schemapb.DataType_Float16Vector, data: &schemapb.VectorField_Float16Vector{}},
+		{name: "BFloat16Vector", elem: schemapb.DataType_BFloat16Vector, data: &schemapb.VectorField_Bfloat16Vector{}},
+		{name: "Int8Vector", elem: schemapb.DataType_Int8Vector, data: &schemapb.VectorField_Int8Vector{}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			vf, err := NewEmptyArrayOfVectorRow(8, c.elem)
+			require.NoError(t, err)
+			require.NotNil(t, vf)
+			assert.EqualValues(t, 8, vf.GetDim())
+			assert.IsType(t, c.data, vf.GetData())
+		})
+	}
+
+	t.Run("unsupported element type returns error", func(t *testing.T) {
+		vf, err := NewEmptyArrayOfVectorRow(8, schemapb.DataType_None)
+		require.Error(t, err)
+		assert.Nil(t, vf)
+		assert.Contains(t, err.Error(), "unsupported ArrayOfVector element type")
+	})
+}
+
+func TestAppendFieldData_ArrayOfVectorNullRowAppendsPlaceholder(t *testing.T) {
+	validData := []bool{true, false, true, false}
+	src := newArrayOfVectorFieldData(200, "arrvec", 1, schemapb.DataType_FloatVector, validData)
+
+	// dst is a slice of same length as src, elements will be filled on first append.
+	dst := make([]*schemapb.FieldData, 1)
+
+	// Walk rows 0..3, fieldIdx == rowIdx because IdxComputer treats ArrayOfVector
+	// as non-vector.
+	for i := int64(0); i < 4; i++ {
+		AppendFieldData(dst, []*schemapb.FieldData{src}, i, i)
+	}
+
+	require.NotNil(t, dst[0])
+	got := dst[0].GetVectors().GetVectorArray()
+	require.NotNil(t, got)
+	// All 4 rows must be present — null rows are placeholders, not skipped.
+	require.Len(t, got.GetData(), 4)
+	assert.Equal(t, []float32{1}, got.GetData()[0].GetFloatVector().GetData())
+	assert.Equal(t, []float32{3}, got.GetData()[2].GetFloatVector().GetData())
+	assert.Empty(t, got.GetData()[1].GetFloatVector().GetData())
+	assert.Empty(t, got.GetData()[3].GetFloatVector().GetData())
+	assert.Equal(t, validData, dst[0].GetValidData())
+	assert.EqualValues(t, 1, got.GetDim())
+	assert.Equal(t, schemapb.DataType_FloatVector, got.GetElementType())
+}
+
+func TestGetTotalFieldsNumIncludesStructParent(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "pk", DataType: schemapb.DataType_Int64},
+			{Name: "scalar", DataType: schemapb.DataType_Bool},
+		},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{
+				Name: "profile",
+				Fields: []*schemapb.FieldSchema{
+					{Name: "profile[ints]", DataType: schemapb.DataType_Array},
+					{Name: "profile[vectors]", DataType: schemapb.DataType_ArrayOfVector},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, 4, GetTotalFieldsNum(schema))
+	assert.Len(t, GetAllFieldSchemas(schema), 4)
 }

--- a/tests/go_client/testcases/nullable_default_value_test.go
+++ b/tests/go_client/testcases/nullable_default_value_test.go
@@ -1751,6 +1751,180 @@ func TestNullableVectorAllTypes(t *testing.T) {
 	}
 }
 
+func TestNullableVectorSearchOrderByOutputCompactData(t *testing.T) {
+	t.Parallel()
+
+	vectorTypes := []NullableVectorType{
+		{Name: "FloatVector", FieldType: entity.FieldTypeFloatVector},
+		{Name: "Float16Vector", FieldType: entity.FieldTypeFloat16Vector},
+		{Name: "SparseVector", FieldType: entity.FieldTypeSparseVector},
+	}
+
+	for _, vt := range vectorTypes {
+		t.Run(vt.Name, func(t *testing.T) {
+			ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+			mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+			collName := common.GenRandomString("nullable_vec_order", 5)
+			pkField := entity.NewField().WithName(common.DefaultInt64FieldName).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)
+			queryVecField := entity.NewField().WithName("query_vec").WithDataType(entity.FieldTypeFloatVector).WithDim(common.DefaultDim)
+			scoreField := entity.NewField().WithName("score").WithDataType(entity.FieldTypeInt64)
+			vecField := entity.NewField().WithName("vector").WithDataType(vt.FieldType).WithNullable(true)
+			if vt.FieldType != entity.FieldTypeSparseVector {
+				vecField = vecField.WithDim(common.DefaultDim)
+			}
+			schema := entity.NewSchema().WithName(collName).WithField(pkField).WithField(queryVecField).WithField(scoreField).WithField(vecField)
+
+			err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema).WithConsistencyLevel(entity.ClStrong))
+			common.CheckErr(t, err, true)
+			t.Cleanup(func() {
+				_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+			})
+
+			pkColumn := column.NewColumnInt64(common.DefaultInt64FieldName, []int64{0, 1, 2, 3})
+			scoreColumn := column.NewColumnInt64("score", []int64{40, 10, 30, 20})
+
+			queryVecs := make([][]float32, 4)
+			for i := range queryVecs {
+				queryVecs[i] = make([]float32, common.DefaultDim)
+				for j := range common.DefaultDim {
+					queryVecs[i][j] = float32(i*common.DefaultDim+j) / 10000.0
+				}
+			}
+			queryVecColumn := column.NewColumnFloatVector("query_vec", common.DefaultDim, queryVecs)
+
+			validData := []bool{true, false, true, true}
+			var vecColumn column.Column
+			var expectedFloat map[int64][]float32
+			var expectedBytes map[int64][]byte
+			var expectedSparse map[int64]entity.SparseEmbedding
+
+			switch vt.FieldType {
+			case entity.FieldTypeFloatVector:
+				vectors := make([][]float32, 3)
+				for i := range vectors {
+					vectors[i] = make([]float32, common.DefaultDim)
+					for j := range common.DefaultDim {
+						vectors[i][j] = float32((i+1)*common.DefaultDim + j)
+					}
+				}
+				expectedFloat = map[int64][]float32{
+					0: vectors[0],
+					2: vectors[1],
+					3: vectors[2],
+				}
+				vecColumn, err = column.NewNullableColumnFloatVector("vector", common.DefaultDim, vectors, validData)
+			case entity.FieldTypeFloat16Vector:
+				vectors := [][]byte{
+					common.GenFloat16Vector(common.DefaultDim),
+					common.GenFloat16Vector(common.DefaultDim),
+					common.GenFloat16Vector(common.DefaultDim),
+				}
+				expectedBytes = map[int64][]byte{
+					0: vectors[0],
+					2: vectors[1],
+					3: vectors[2],
+				}
+				vecColumn, err = column.NewNullableColumnFloat16Vector("vector", common.DefaultDim, vectors, validData)
+			case entity.FieldTypeSparseVector:
+				vectors := make([]entity.SparseEmbedding, 3)
+				for i := range vectors {
+					vectors[i], err = entity.NewSliceSparseEmbedding([]uint32{0, uint32(i + 10)}, []float32{1.0, float32(i + 1)})
+					common.CheckErr(t, err, true)
+				}
+				expectedSparse = map[int64]entity.SparseEmbedding{
+					0: vectors[0],
+					2: vectors[1],
+					3: vectors[2],
+				}
+				vecColumn, err = column.NewNullableColumnSparseFloatVector("vector", vectors, validData)
+			}
+			common.CheckErr(t, err, true)
+
+			insertRes, err := mc.Insert(ctx, client.NewColumnBasedInsertOption(collName, pkColumn, queryVecColumn, scoreColumn, vecColumn))
+			common.CheckErr(t, err, true)
+			require.EqualValues(t, 4, insertRes.InsertCount)
+
+			flushTask, err := mc.Flush(ctx, client.NewFlushOption(collName))
+			common.CheckErr(t, err, true)
+			common.CheckErr(t, flushTask.Await(ctx), true)
+
+			queryVecIndex := index.NewFlatIndex(entity.L2)
+			indexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "query_vec", queryVecIndex))
+			common.CheckErr(t, err, true)
+			common.CheckErr(t, indexTask.Await(ctx), true)
+
+			nullableVecIndex := CreateNullableVectorIndexWithFieldName(vt, "vector")
+			indexTask, err = mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, "vector", nullableVecIndex))
+			common.CheckErr(t, err, true)
+			common.CheckErr(t, indexTask.Await(ctx), true)
+
+			loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+			common.CheckErr(t, err, true)
+			common.CheckErr(t, loadTask.Await(ctx), true)
+
+			searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 4, []entity.Vector{entity.FloatVector(queryVecs[0])}).
+				WithANNSField("query_vec").
+				WithConsistencyLevel(entity.ClStrong).
+				WithOutputFields("score", "vector").
+				WithSearchParam("order_by_fields", "score:asc"))
+			common.CheckErr(t, err, true)
+			require.Len(t, searchRes, 1)
+			require.EqualValues(t, 4, searchRes[0].ResultCount)
+
+			ids := searchRes[0].IDs.(*column.ColumnInt64).Data()
+			require.Equal(t, []int64{1, 3, 2, 0}, ids)
+
+			scoreCol := searchRes[0].GetColumn("score")
+			vecCol := searchRes[0].GetColumn("vector")
+			require.NotNil(t, scoreCol)
+			require.NotNil(t, vecCol)
+
+			for i, id := range ids {
+				score, err := scoreCol.GetAsInt64(i)
+				require.NoError(t, err)
+				require.EqualValues(t, []int64{10, 20, 30, 40}[i], score)
+
+				isNull, err := vecCol.IsNull(i)
+				require.NoError(t, err)
+				if id == 1 {
+					require.True(t, isNull, "vector should be null for pk %d", id)
+					continue
+				}
+				require.False(t, isNull, "vector should be valid for pk %d", id)
+				raw, err := vecCol.Get(i)
+				require.NoError(t, err)
+
+				switch vt.FieldType {
+				case entity.FieldTypeFloatVector:
+					actual := []float32(raw.(entity.FloatVector))
+					expected := expectedFloat[id]
+					require.Equal(t, len(expected), len(actual))
+					for j := range expected {
+						require.InDelta(t, expected[j], actual[j], 1e-6)
+					}
+				case entity.FieldTypeFloat16Vector:
+					actual := []byte(raw.(entity.Float16Vector))
+					expected := expectedBytes[id]
+					require.Equal(t, expected, actual)
+				case entity.FieldTypeSparseVector:
+					actual := raw.(entity.SparseEmbedding)
+					expected := expectedSparse[id]
+					require.Equal(t, expected.Len(), actual.Len())
+					for j := 0; j < expected.Len(); j++ {
+						expectedPos, expectedVal, ok := expected.Get(j)
+						require.True(t, ok)
+						actualPos, actualVal, ok := actual.Get(j)
+						require.True(t, ok)
+						require.EqualValues(t, expectedPos, actualPos)
+						require.InDelta(t, expectedVal, actualVal, 1e-6)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestNullableVectorWithScalarFilter(t *testing.T) {
 	t.Parallel()
 
@@ -2369,6 +2543,20 @@ func TestNullableVectorAllNull(t *testing.T) {
 			count, err := queryRes.Fields[0].GetAsInt64(0)
 			common.CheckErr(t, err, true)
 			require.EqualValues(t, nb, count, "query should return all %d rows even with 100%% null vectors", nb)
+
+			// query vector output should preserve all-null logical rows after index/load
+			queryVecRes, err := mc.Query(ctx, client.NewQueryOption(collName).WithFilter("int64 < 10").WithOutputFields("vector"))
+			common.CheckErr(t, err, true)
+			require.EqualValues(t, 10, queryVecRes.ResultCount)
+			vecCol := queryVecRes.GetColumn("vector")
+			for i := 0; i < queryVecRes.ResultCount; i++ {
+				isNull, err := vecCol.IsNull(i)
+				require.NoError(t, err)
+				require.True(t, isNull, "all-null vector output row %d should stay null", i)
+				value, err := vecCol.Get(i)
+				require.NoError(t, err)
+				require.Nil(t, value, "all-null vector output row %d should have nil value", i)
+			}
 
 			// clean up
 			err = mc.DropCollection(ctx, client.NewDropCollectionOption(collName))

--- a/tests/python_client/milvus_client/test_milvus_client_search_group_by.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_group_by.py
@@ -1,20 +1,17 @@
 import json
-import numpy as np
-from pymilvus import AnnSearchRequest, RRFRanker, WeightedRanker
-from pymilvus import (
-    FieldSchema, CollectionSchema, DataType
-)
-from utils.util_pymilvus import *
-from common.common_type import CaseLabel, CheckTasks
-from common import common_type as ct
-from common import common_func as cf
-from utils.util_log import test_log as log
-from base.client_v2_base import TestMilvusClientV2Base
 import random
+
+import numpy as np
 import pytest
+from base.client_v2_base import TestMilvusClientV2Base
+from common import common_func as cf
+from common import common_type as ct
+from common.common_type import CaseLabel, CheckTasks
+from pymilvus import AnnSearchRequest, CollectionSchema, DataType, FieldSchema, RRFRanker, WeightedRanker
+from utils.util_log import test_log as log
+from utils.util_pymilvus import *  # noqa: F403
 
 epsilon = 0.001
-
 
 
 @pytest.mark.xdist_group("TestGroupSearch")
@@ -28,6 +25,7 @@ class TestGroupSearch(TestMilvusClientV2Base):
           scalar values constant within each batch for group-by testing
     Index: IVF_FLAT/COSINE, DISKANN/L2, SPARSE_INVERTED_INDEX/IP, BIN_IVF_FLAT/JACCARD
     """
+
     def setup_class(self):
         super().setup_class(self)
         self.collection_name = "TestGroupSearch" + cf.gen_unique_str("group_by")
@@ -37,13 +35,16 @@ class TestGroupSearch(TestMilvusClientV2Base):
         self.bfloat16_vector_field_name = "bfloat16_vector"
         self.sparse_vector_field_name = "sparse_vector"
         self.binary_vector_field_name = "binary_vector"
-        self.vector_fields = [self.float_vector_field_name, self.bfloat16_vector_field_name,
-                              self.sparse_vector_field_name, self.binary_vector_field_name]
+        self.vector_fields = [
+            self.float_vector_field_name,
+            self.bfloat16_vector_field_name,
+            self.sparse_vector_field_name,
+            self.binary_vector_field_name,
+        ]
         self.float_vector_dim = 36
         self.bf16_vector_dim = 35
         self.binary_vector_dim = 32
-        self.dims = [self.float_vector_dim, self.bf16_vector_dim,
-                     128, self.binary_vector_dim]
+        self.dims = [self.float_vector_dim, self.bf16_vector_dim, 128, self.binary_vector_dim]
         self.float_vector_metric = "COSINE"
         self.bf16_vector_metric = "L2"
         self.sparse_vector_metric = "IP"
@@ -52,10 +53,18 @@ class TestGroupSearch(TestMilvusClientV2Base):
         self.bf16_vector_index = "DISKANN"
         self.sparse_vector_index = "SPARSE_INVERTED_INDEX"
         self.binary_vector_index = "BIN_IVF_FLAT"
-        self.index_types = [self.float_vector_index, self.bf16_vector_index,
-                            self.sparse_vector_index, self.binary_vector_index]
-        self.metric_types = [self.float_vector_metric, self.bf16_vector_metric,
-                             self.sparse_vector_metric, self.binary_vector_metric]
+        self.index_types = [
+            self.float_vector_index,
+            self.bf16_vector_index,
+            self.sparse_vector_index,
+            self.binary_vector_index,
+        ]
+        self.metric_types = [
+            self.float_vector_metric,
+            self.bf16_vector_metric,
+            self.sparse_vector_metric,
+            self.binary_vector_metric,
+        ]
         self.inverted_string_field = "varchar_inverted"
         self.indexed_json_field = "indexed_json"
         self.enable_dynamic_field = True
@@ -74,7 +83,8 @@ class TestGroupSearch(TestMilvusClientV2Base):
         fields = []
         fields.append(FieldSchema(name=self.primary_field, dtype=DataType.INT64, is_primary=True, auto_id=True))
         fields.append(
-            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim))
+            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim)
+        )
 
         for data_type in ct.all_scalar_data_types:
             fields.append(cf.gen_scalar_field(data_type, name=data_type.name, nullable=True))
@@ -154,24 +164,32 @@ class TestGroupSearch(TestMilvusClientV2Base):
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=self.float_vector_field_name,
-                               metric_type=self.float_vector_metric,
-                               index_type=self.float_vector_index,
-                               params={"nlist": 128})
-        index_params.add_index(field_name=self.bfloat16_vector_field_name,
-                               metric_type=self.bf16_vector_metric,
-                               index_type=self.bf16_vector_index,
-                               params={})
-        index_params.add_index(field_name=self.sparse_vector_field_name,
-                               metric_type=self.sparse_vector_metric,
-                               index_type=self.sparse_vector_index,
-                               params={})
-        index_params.add_index(field_name=self.binary_vector_field_name,
-                               metric_type=self.binary_vector_metric,
-                               index_type=self.binary_vector_index,
-                               params={"nlist": 128})
+        index_params.add_index(
+            field_name=self.float_vector_field_name,
+            metric_type=self.float_vector_metric,
+            index_type=self.float_vector_index,
+            params={"nlist": 128},
+        )
+        index_params.add_index(
+            field_name=self.bfloat16_vector_field_name,
+            metric_type=self.bf16_vector_metric,
+            index_type=self.bf16_vector_index,
+            params={},
+        )
+        index_params.add_index(
+            field_name=self.sparse_vector_field_name,
+            metric_type=self.sparse_vector_metric,
+            index_type=self.sparse_vector_index,
+            params={},
+        )
+        index_params.add_index(
+            field_name=self.binary_vector_field_name,
+            metric_type=self.binary_vector_metric,
+            index_type=self.binary_vector_index,
+            params={"nlist": 128},
+        )
         index_params.add_index(field_name=self.inverted_string_field, index_type="INVERTED")
-        index_params.add_index(field_name=self.indexed_json_field, index_type="INVERTED", json_cast_type='json')
+        index_params.add_index(field_name=self.indexed_json_field, index_type="INVERTED", json_cast_type="json")
         self.create_index(client, self.collection_name, index_params=index_params)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.float_vector_field_name)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.bfloat16_vector_field_name)
@@ -185,15 +203,18 @@ class TestGroupSearch(TestMilvusClientV2Base):
         request.addfinalizer(teardown)
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.parametrize("group_by_field, output_field", [
-        (DataType.VARCHAR.name, DataType.VARCHAR.name),
-        ("varchar_inverted", "varchar_inverted"),
-        (DataType.JSON.name, DataType.JSON.name),
-        ("indexed_json", "indexed_json"),
-        (f"{DataType.JSON.name}['number']", DataType.JSON.name),
-        ("dyna_field_name1", "dyna_field_name1"),
-        ("dyna_field_name2['string']", "dyna_field_name2"),
-    ])
+    @pytest.mark.parametrize(
+        "group_by_field, output_field",
+        [
+            (DataType.VARCHAR.name, DataType.VARCHAR.name),
+            ("varchar_inverted", "varchar_inverted"),
+            (DataType.JSON.name, DataType.JSON.name),
+            ("indexed_json", "indexed_json"),
+            (f"{DataType.JSON.name}['number']", DataType.JSON.name),
+            ("dyna_field_name1", "dyna_field_name1"),
+            ("dyna_field_name2['string']", "dyna_field_name2"),
+        ],
+    )
     def test_search_group_size(self, group_by_field, output_field):
         """
         target:
@@ -209,16 +230,24 @@ class TestGroupSearch(TestMilvusClientV2Base):
         for field, dim, idx_type, metric in zip(self.vector_fields, self.dims, self.index_types, self.metric_types):
             if field == self.binary_vector_field_name:
                 continue
-            search_vectors = cf.gen_vectors(nq, dim=dim,
-                                            vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                              field))
+            search_vectors = cf.gen_vectors(
+                nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+            )
             search_params = {"params": cf.get_search_params_params(idx_type), "metric_type": metric}
             # when strict_group_size=true, it shall return results with entities = limit * group_size
-            res1 = self.search(client, self.collection_name, data=search_vectors, anns_field=field,
-                               search_params=search_params, limit=limit,
-                               group_by_field=group_by_field, filter=f"{output_field} is not null",
-                               group_size=group_size, strict_group_size=True,
-                               output_fields=[output_field])[0]
+            res1 = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                anns_field=field,
+                search_params=search_params,
+                limit=limit,
+                group_by_field=group_by_field,
+                filter=f"{output_field} is not null",
+                group_size=group_size,
+                strict_group_size=True,
+                output_fields=[output_field],
+            )[0]
             for i in range(nq):
                 assert len(res1[i]) == limit * group_size
                 for idx in range(limit):
@@ -230,13 +259,19 @@ class TestGroupSearch(TestMilvusClientV2Base):
                     assert len(set(group_values)) == 1
 
             # when strict_group_size=false, it shall return results with group counts = limit
-            res1 = self.search(client, self.collection_name,
-                               data=search_vectors,
-                               anns_field=field,
-                               search_params=search_params, limit=limit,
-                               group_by_field=group_by_field, filter=f"{output_field} is not null",
-                               group_size=group_size, strict_group_size=False,
-                               output_fields=[output_field])[0]
+            res1 = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                anns_field=field,
+                search_params=search_params,
+                limit=limit,
+                group_by_field=group_by_field,
+                filter=f"{output_field} is not null",
+                group_size=group_size,
+                strict_group_size=False,
+                output_fields=[output_field],
+            )[0]
             for i in range(nq):
                 group_values = []
                 for idx in range(len(res1[i])):
@@ -261,23 +296,32 @@ class TestGroupSearch(TestMilvusClientV2Base):
             if field == self.binary_vector_field_name:
                 continue  # not support group by search on binary vector
             search_params = {
-                "data": cf.gen_vectors(nq, dim=dim,
-                                       vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                         field)),
+                "data": cf.gen_vectors(
+                    nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+                ),
                 "anns_field": field,
                 "param": {"params": cf.get_search_params_params(idx_type), "metric_type": metric},
                 "limit": limit,
-                "expr": f"{self.primary_field} > 0"}
+                "expr": f"{self.primary_field} > 0",
+            }
             req = AnnSearchRequest(**search_params)
             req_list.append(req)
         # 4. hybrid search group by
-        #rank_scorers = ["max", "avg", "sum"]
+        # rank_scorers = ["max", "avg", "sum"]
         rank_scorers = ["max"]
         for scorer in rank_scorers:
-            res = self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=WeightedRanker(0.1, 0.3, 0.6),
-                                     limit=limit, group_by_field=DataType.VARCHAR.name, group_size=group_size,
-                                     rank_group_scorer=scorer, output_fields=[DataType.VARCHAR.name],
-                                     pipeline_trace=True)[0]
+            res = self.hybrid_search(
+                client,
+                self.collection_name,
+                reqs=req_list,
+                ranker=WeightedRanker(0.1, 0.3, 0.6),
+                limit=limit,
+                group_by_field=DataType.VARCHAR.name,
+                group_size=group_size,
+                rank_group_scorer=scorer,
+                output_fields=[DataType.VARCHAR.name],
+                pipeline_trace=True,
+            )[0]
             for i in range(nq):
                 group_values = []
                 for idx in range(len(res[i])):
@@ -293,9 +337,9 @@ class TestGroupSearch(TestMilvusClientV2Base):
                     if curr_group_value == next_group_value:
                         group_distances.append(res[i][idx + 1].distance)
                     else:
-                        if scorer == 'sum':
+                        if scorer == "sum":
                             assert np.sum(group_distances) <= np.sum(tmp_distances)
-                        elif scorer == 'avg':
+                        elif scorer == "avg":
                             assert np.mean(group_distances) <= np.mean(tmp_distances)
                         else:  # default max
                             assert np.max(group_distances) <= np.max(tmp_distances)
@@ -316,21 +360,28 @@ class TestGroupSearch(TestMilvusClientV2Base):
             if field == self.binary_vector_field_name:
                 continue  # not support group by search on binary vector
             search_param = {
-                "data": cf.gen_vectors(ct.default_nq, dim=dim,
-                                       vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                         field)),
+                "data": cf.gen_vectors(
+                    ct.default_nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+                ),
                 "anns_field": field,
                 "param": {"metric_type": metric},
                 "limit": ct.default_limit,
-                "expr": f"{self.primary_field} > 0"}
+                "expr": f"{self.primary_field} > 0",
+            }
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
         # 4. hybrid search group by
-        res = self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=WeightedRanker(0.1, 0.9, 0.3),
-                                 limit=ct.default_limit, group_by_field=DataType.VARCHAR.name,
-                                 output_fields=[DataType.VARCHAR.name],
-                                 check_task=CheckTasks.check_search_results,
-                                 check_items={"nq": ct.default_nq, "limit": ct.default_limit})[0]
+        res = self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.1, 0.9, 0.3),
+            limit=ct.default_limit,
+            group_by_field=DataType.VARCHAR.name,
+            output_fields=[DataType.VARCHAR.name],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": ct.default_nq, "limit": ct.default_limit},
+        )[0]
         for i in range(ct.default_nq):
             group_values = []
             for idx in range(ct.default_limit):
@@ -339,24 +390,33 @@ class TestGroupSearch(TestMilvusClientV2Base):
 
         # 5. hybrid search with RRFRanker on one vector field with group by
         req_list = []
-        for field, dim, idx_type, metric in zip(self.vector_fields[1:], self.dims[1:], self.index_types[1:], self.metric_types[1:]):
+        for field, dim, idx_type, metric in zip(
+            self.vector_fields[1:], self.dims[1:], self.index_types[1:], self.metric_types[1:]
+        ):
             if field == self.binary_vector_field_name:
                 continue  # not support group by search on binary vector
             search_param = {
-                "data": cf.gen_vectors(ct.default_nq, dim=dim,
-                                       vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                         field)),
+                "data": cf.gen_vectors(
+                    ct.default_nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+                ),
                 "anns_field": field,
                 "param": {"metric_type": metric},
                 "limit": ct.default_limit,
-                "expr": f"{self.primary_field} > 0"}
+                "expr": f"{self.primary_field} > 0",
+            }
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
-            self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=RRFRanker(),
-                               limit=ct.default_limit, group_by_field=self.inverted_string_field,
-                               output_fields=[self.inverted_string_field],
-                               check_task=CheckTasks.check_search_results,
-                               check_items={"nq": ct.default_nq, "limit": ct.default_limit})
+            self.hybrid_search(
+                client,
+                self.collection_name,
+                reqs=req_list,
+                ranker=RRFRanker(),
+                limit=ct.default_limit,
+                group_by_field=self.inverted_string_field,
+                output_fields=[self.inverted_string_field],
+                check_task=CheckTasks.check_search_results,
+                check_items={"nq": ct.default_nq, "limit": ct.default_limit},
+            )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_hybrid_search_group_by_empty_results(self):
@@ -371,21 +431,28 @@ class TestGroupSearch(TestMilvusClientV2Base):
             if field == self.binary_vector_field_name:
                 continue  # not support group by search on binary vector
             search_param = {
-                "data": cf.gen_vectors(ct.default_nq, dim=dim,
-                                       vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                         field)),
+                "data": cf.gen_vectors(
+                    ct.default_nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+                ),
                 "anns_field": field,
                 "param": {"metric_type": metric},
                 "limit": ct.default_limit,
-                "expr": f"{self.primary_field} < 0"}  # make sure return empty results
+                "expr": f"{self.primary_field} < 0",
+            }  # make sure return empty results
             req = AnnSearchRequest(**search_param)
             req_list.append(req)
         # 4. hybrid search group by empty results
-        self.hybrid_search(client, self.collection_name, reqs=req_list, ranker=WeightedRanker(0.1, 0.9, 0.3),
-                           limit=ct.default_limit, group_by_field=DataType.VARCHAR.name,
-                           output_fields=[DataType.VARCHAR.name],
-                           check_task=CheckTasks.check_search_results,
-                           check_items={"nq": ct.default_nq, "limit": 0})
+        self.hybrid_search(
+            client,
+            self.collection_name,
+            reqs=req_list,
+            ranker=WeightedRanker(0.1, 0.9, 0.3),
+            limit=ct.default_limit,
+            group_by_field=DataType.VARCHAR.name,
+            output_fields=[DataType.VARCHAR.name],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": ct.default_nq, "limit": 0},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_group_by_supported_binary_vector(self):
@@ -393,21 +460,28 @@ class TestGroupSearch(TestMilvusClientV2Base):
         verify search group by works with supported binary vector
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.binary_vector_dim,
-                                        vector_data_type=DataType.BINARY_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.binary_vector_dim, vector_data_type=DataType.BINARY_VECTOR)
         search_params = {"metric_type": self.binary_vector_metric}
         limit = 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: "not support search_group_by operation based on binary vector"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=self.binary_vector_field_name,
-                    search_params=search_params, limit=limit, group_by_field=DataType.VARCHAR.name,
-                    output_fields=[DataType.VARCHAR.name],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 999, ct.err_msg: "not support search_group_by operation based on binary vector"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.binary_vector_field_name,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=DataType.VARCHAR.name,
+            output_fields=[DataType.VARCHAR.name],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.parametrize("support_field", [DataType.INT8.name, DataType.INT64.name,
-                                               DataType.BOOL.name, DataType.VARCHAR.name,
-                                               DataType.TIMESTAMPTZ.name])
+    @pytest.mark.parametrize(
+        "support_field",
+        [DataType.INT8.name, DataType.INT64.name, DataType.BOOL.name, DataType.VARCHAR.name, DataType.TIMESTAMPTZ.name],
+    )
     def test_search_group_by_supported_scalars(self, support_field):
         """
         verify search group by works with supported scalar fields
@@ -419,15 +493,21 @@ class TestGroupSearch(TestMilvusClientV2Base):
         for field, dim, idx_type, metric in zip(self.vector_fields, self.dims, self.index_types, self.metric_types):
             if field == self.binary_vector_field_name:
                 continue  # not support group by search on binary vector
-            search_vectors = cf.gen_vectors(nq, dim=dim,
-                                            vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                              field))
+            search_vectors = cf.gen_vectors(
+                nq, dim=dim, vector_data_type=cf.get_field_dtype_by_field_name(collection_info, field)
+            )
             search_params = {"params": cf.get_search_params_params(idx_type), "metric_type": metric}
-            res1 = self.search(client, self.collection_name, data=search_vectors, anns_field=field,
-                               search_params=search_params, limit=limit,
-                               filter=f"{support_field} is not null",
-                               group_by_field=support_field,
-                               output_fields=[support_field])[0]
+            res1 = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                anns_field=field,
+                search_params=search_params,
+                limit=limit,
+                filter=f"{support_field} is not null",
+                group_by_field=support_field,
+                output_fields=[support_field],
+            )[0]
             for i in range(nq):
                 grpby_values = []
                 mismatch = 0
@@ -445,17 +525,25 @@ class TestGroupSearch(TestMilvusClientV2Base):
                     if support_field == DataType.TIMESTAMPTZ.name:
                         filter_expr = f"{support_field}== ISO '{top1_grpby_value}'"
                     grpby_values.append(top1_grpby_value)
-                    res_tmp = self.search(client, self.collection_name, data=[search_vectors[i]],
-                                          anns_field=field,
-                                          search_params=search_params, limit=1, filter=filter_expr,
-                                          output_fields=[support_field])[0]
+                    res_tmp = self.search(
+                        client,
+                        self.collection_name,
+                        data=[search_vectors[i]],
+                        anns_field=field,
+                        search_params=search_params,
+                        limit=1,
+                        filter=filter_expr,
+                        output_fields=[support_field],
+                    )[0]
                     top1_expr_pk = res_tmp[0][0].id
                     if top1_grpby_pk != top1_expr_pk:
                         mismatch += 1
                         log.info(
-                            f"{support_field} on {field} mismatch_item, top1_grpby_dis: {top1.distance}, top1_expr_dis: {res_tmp[0][0].distance}")
+                            f"{support_field} on {field} mismatch_item, top1_grpby_dis: {top1.distance}, top1_expr_dis: {res_tmp[0][0].distance}"
+                        )
                 log.info(
-                    f"{support_field} on {field}  top1_mismatch_num: {mismatch}, results_num: {results_num}, mismatch_rate: {mismatch / results_num}")
+                    f"{support_field} on {field}  top1_mismatch_num: {mismatch}, results_num: {results_num}, mismatch_rate: {mismatch / results_num}"
+                )
                 baseline = 1 if support_field == DataType.BOOL.name else 0.2  # skip baseline check for boolean
                 assert results_num > 0, "results_num should be greater than 0"
                 assert mismatch / results_num <= baseline
@@ -463,9 +551,10 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 assert len(grpby_values) == len(set(grpby_values))
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("grpby_unsupported_field", [DataType.FLOAT.name, DataType.DOUBLE.name,
-                                                         DataType.GEOMETRY.name,
-                                                         ct.default_float_vec_field_name])
+    @pytest.mark.parametrize(
+        "grpby_unsupported_field",
+        [DataType.FLOAT.name, DataType.DOUBLE.name, DataType.GEOMETRY.name, ct.default_float_vec_field_name],
+    )
     def test_search_group_by_unsupported_field(self, grpby_unsupported_field):
         """
         target: test search group by with the unsupported field
@@ -475,19 +564,24 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 verify: the error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {"metric_type": self.float_vector_metric}
         limit = 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"unsupported data type {grpby_unsupported_field} for group by operator"}
+        error = {ct.err_code: 999, ct.err_msg: f"unsupported data type {grpby_unsupported_field} for group by operator"}
         if grpby_unsupported_field == ct.default_float_vec_field_name:
-            error = {ct.err_code: 999,
-                     ct.err_msg: f"unsupported data type VECTOR_FLOAT for group by operator"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=limit, group_by_field=grpby_unsupported_field,
-                    output_fields=[grpby_unsupported_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+            error = {ct.err_code: 999, ct.err_msg: "unsupported data type VECTOR_FLOAT for group by operator"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=grpby_unsupported_field,
+            output_fields=[grpby_unsupported_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_pagination_group_by(self):
@@ -502,32 +596,47 @@ class TestGroupSearch(TestMilvusClientV2Base):
         default_search_exp = f"{self.primary_field} >= 0"
         grpby_field = self.inverted_string_field
         default_search_field = self.vector_fields[1]
-        search_vectors = cf.gen_vectors(1, dim=self.dims[1],
-                                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                          self.vector_fields[1]))
+        search_vectors = cf.gen_vectors(
+            1,
+            dim=self.dims[1],
+            vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[1]),
+        )
         all_pages_ids = []
         all_pages_grpby_field_values = []
         for r in range(page_rounds):
-            page_res = self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                                   search_params=search_param, limit=limit, offset=limit * r,
-                                   filter=default_search_exp, group_by_field=grpby_field,
-                                   output_fields=[grpby_field],
-                                   check_task=CheckTasks.check_search_results,
-                                   check_items={"nq": 1, "limit": limit},
-                                   )[0]
+            page_res = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                anns_field=default_search_field,
+                search_params=search_param,
+                limit=limit,
+                offset=limit * r,
+                filter=default_search_exp,
+                group_by_field=grpby_field,
+                output_fields=[grpby_field],
+                check_task=CheckTasks.check_search_results,
+                check_items={"nq": 1, "limit": limit},
+            )[0]
             for j in range(limit):
                 all_pages_grpby_field_values.append(page_res[0][j].get(grpby_field))
             all_pages_ids += page_res[0].ids
         hit_rate = round(len(set(all_pages_grpby_field_values)) / len(all_pages_grpby_field_values), 3)
         assert hit_rate >= 0.8
 
-        total_res = self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                                search_params=search_param, limit=limit * page_rounds,
-                                filter=default_search_exp, group_by_field=grpby_field,
-                                output_fields=[grpby_field],
-                                check_task=CheckTasks.check_search_results,
-                                check_items={"nq": 1, "limit": limit * page_rounds}
-                                )[0]
+        total_res = self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_param,
+            limit=limit * page_rounds,
+            filter=default_search_exp,
+            group_by_field=grpby_field,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": 1, "limit": limit * page_rounds},
+        )[0]
         hit_num = len(set(total_res[0].ids).intersection(set(all_pages_ids)))
         hit_rate = round(hit_num / (limit * page_rounds), 3)
         assert hit_rate >= 0.8
@@ -553,9 +662,11 @@ class TestGroupSearch(TestMilvusClientV2Base):
         grpby_field = self.inverted_string_field
         default_search_field = self.vector_fields[1]
         ids_to_search = None
-        search_vectors = cf.gen_vectors(1, dim=self.dims[1],
-                                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                          self.vector_fields[1]))
+        search_vectors = cf.gen_vectors(
+            1,
+            dim=self.dims[1],
+            vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[1]),
+        )
         if search_by_pk is True:
             query_res = self.query(client, self.collection_name, limit=1, output_fields=[self.primary_field])[0]
             ids_to_search = [query_res[0].get(self.primary_field)]
@@ -564,42 +675,53 @@ class TestGroupSearch(TestMilvusClientV2Base):
         all_pages_grpby_field_values = []
         res_count = limit * group_size
         for r in range(page_rounds):
-            page_res = self.search(client, self.collection_name,
-                                   data=search_vectors,
-                                   ids=ids_to_search,
-                                   anns_field=default_search_field,
-                                   search_params=search_param, limit=limit, offset=limit * r,
-                                   filter=default_search_exp,
-                                   group_by_field=grpby_field, group_size=group_size,
-                                   strict_group_size=True,
-                                   output_fields=[grpby_field],
-                                   check_task=CheckTasks.check_search_results,
-                                   check_items={"nq": 1, "limit": res_count},
-                                   )[0]
+            page_res = self.search(
+                client,
+                self.collection_name,
+                data=search_vectors,
+                ids=ids_to_search,
+                anns_field=default_search_field,
+                search_params=search_param,
+                limit=limit,
+                offset=limit * r,
+                filter=default_search_exp,
+                group_by_field=grpby_field,
+                group_size=group_size,
+                strict_group_size=True,
+                output_fields=[grpby_field],
+                check_task=CheckTasks.check_search_results,
+                check_items={"nq": 1, "limit": res_count},
+            )[0]
             for j in range(res_count):
                 all_pages_grpby_field_values.append(page_res[0][j].get(grpby_field))
             all_pages_ids += page_res[0].ids
 
         hit_rate = round(len(set(all_pages_grpby_field_values)) / len(all_pages_grpby_field_values), 3)
         expect_hit_rate = round(1 / group_size, 3) * 0.7
-        log.info(f"expect_hit_rate :{expect_hit_rate}, hit_rate:{hit_rate}, "
-                 f"unique_group_by_value_count:{len(set(all_pages_grpby_field_values))},"
-                 f"total_group_by_value_count:{len(all_pages_grpby_field_values)}")
+        log.info(
+            f"expect_hit_rate :{expect_hit_rate}, hit_rate:{hit_rate}, "
+            f"unique_group_by_value_count:{len(set(all_pages_grpby_field_values))},"
+            f"total_group_by_value_count:{len(all_pages_grpby_field_values)}"
+        )
         assert hit_rate >= expect_hit_rate
 
         total_count = limit * group_size * page_rounds
-        total_res = self.search(client, self.collection_name,
-                                data=search_vectors,
-                                ids=ids_to_search,
-                                anns_field=default_search_field,
-                                search_params=search_param, limit=limit * page_rounds,
-                                filter=default_search_exp,
-                                group_by_field=grpby_field, group_size=group_size,
-                                strict_group_size=True,
-                                output_fields=[grpby_field],
-                                check_task=CheckTasks.check_search_results,
-                                check_items={"nq": 1, "limit": total_count}
-                                )[0]
+        total_res = self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            ids=ids_to_search,
+            anns_field=default_search_field,
+            search_params=search_param,
+            limit=limit * page_rounds,
+            filter=default_search_exp,
+            group_by_field=grpby_field,
+            group_size=group_size,
+            strict_group_size=True,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": 1, "limit": total_count},
+        )[0]
         hit_num = len(set(total_res[0].ids).intersection(set(all_pages_ids)))
         hit_rate = round(hit_num / (limit * page_rounds), 3)
         assert hit_rate >= 0.8
@@ -619,53 +741,92 @@ class TestGroupSearch(TestMilvusClientV2Base):
         collection_info = self.describe_collection(client, self.collection_name)[0]
         group_by_field = self.inverted_string_field
         default_search_field = self.vector_fields[1]
-        search_vectors = cf.gen_vectors(1, dim=self.dims[1],
-                                        vector_data_type=cf.get_field_dtype_by_field_name(collection_info,
-                                                                                          self.vector_fields[1]))
+        search_vectors = cf.gen_vectors(
+            1,
+            dim=self.dims[1],
+            vector_data_type=cf.get_field_dtype_by_field_name(collection_info, self.vector_fields[1]),
+        )
         search_params = {"metric_type": self.bf16_vector_metric}
         limit = 10
         max_group_size = 10
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=max_group_size, strict_group_size=True,
-                    output_fields=[group_by_field])
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=max_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+        )
         exceed_max_group_size = max_group_size + 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"input group size:{exceed_max_group_size} exceeds configured max "
-                             f"group size:{max_group_size}"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=exceed_max_group_size, strict_group_size=True,
-                    output_fields=[group_by_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: f"input group size:{exceed_max_group_size} exceeds configured max group size:{max_group_size}",
+        }
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=exceed_max_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
         min_group_size = 1
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=max_group_size, strict_group_size=True,
-                    output_fields=[group_by_field])
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=max_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+        )
         below_min_group_size = min_group_size - 1
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"input group size:{below_min_group_size} is negative"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=below_min_group_size, strict_group_size=True,
-                    output_fields=[group_by_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 999, ct.err_msg: f"input group size:{below_min_group_size} is negative"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=below_min_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
         below_min_group_size = min_group_size - 10
-        error = {ct.err_code: 999,
-                 ct.err_msg: f"input group size:{below_min_group_size} is negative"}
-        self.search(client, self.collection_name, data=search_vectors, anns_field=default_search_field,
-                    search_params=search_params, limit=limit,
-                    group_by_field=group_by_field,
-                    group_size=below_min_group_size, strict_group_size=True,
-                    output_fields=[group_by_field],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 999, ct.err_msg: f"input group size:{below_min_group_size} is negative"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=default_search_field,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=group_by_field,
+            group_size=below_min_group_size,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_iterator_not_support_group_by(self):
@@ -678,17 +839,22 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 verify: error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {"metric_type": self.float_vector_metric}
         grpby_field = DataType.VARCHAR.name
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "Not allowed to do groupBy when doing iteration"}
-        self.search_iterator(client, self.collection_name, data=search_vectors,
-                             anns_field=self.float_vector_field_name,
-                             search_params=search_params, batch_size=10, limit=100,
-                             group_by_field=grpby_field,
-                             check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 1100, ct.err_msg: "Not allowed to do groupBy when doing iteration"}
+        self.search_iterator(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            batch_size=10,
+            limit=100,
+            group_by_field=grpby_field,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_range_search_not_support_group_by(self):
@@ -700,17 +866,21 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 verify: the error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         grpby_field = DataType.VARCHAR.name
-        error = {ct.err_code: 1100,
-                 ct.err_msg: "Not allowed to do range-search when doing search-group-by"}
+        error = {ct.err_code: 1100, ct.err_msg: "Not allowed to do range-search when doing search-group-by"}
         range_search_params = {"metric_type": "COSINE", "params": {"radius": 0.1, "range_filter": 0.5}}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=range_search_params, limit=5,
-                    group_by_field=grpby_field,
-                    check_task=CheckTasks.err_res, check_items=error)
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=range_search_params,
+            limit=5,
+            group_by_field=grpby_field,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_group_by_nonexistent_field_on_dynamic_enabled_collection(self):
@@ -722,15 +892,19 @@ class TestGroupSearch(TestMilvusClientV2Base):
         """
         client = self._client()
         nq = 2
-        search_vectors = cf.gen_vectors(nq, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(nq, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {"metric_type": self.float_vector_metric}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=100,
-                    group_by_field="nonexist_field",
-                    check_task=CheckTasks.check_search_results,
-                    check_items={"nq": nq, "limit": 1})
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=100,
+            group_by_field="nonexist_field",
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "limit": 1},
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_group_by_invalid_field_type(self):
@@ -740,16 +914,20 @@ class TestGroupSearch(TestMilvusClientV2Base):
         verify: server returns error
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {"metric_type": self.float_vector_metric}
-        error = {ct.err_code: 65535,
-                 ct.err_msg: "cannot parse identifier"}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=100,
-                    group_by_field=21,
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 65535, ct.err_msg: "cannot parse identifier"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=100,
+            group_by_field=21,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
 
 @pytest.mark.xdist_group("TestGroupSearchInvalid")
@@ -761,6 +939,7 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
     Data: 2000 rows
     Index: FLAT/L2, HNSW/COSINE
     """
+
     def setup_class(self):
         super().setup_class(self)
         self.collection_name = "TestGroupSearchInvalid" + cf.gen_unique_str("group_by")
@@ -789,7 +968,8 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
         fields = []
         fields.append(FieldSchema(name=self.primary_field, dtype=DataType.INT64, is_primary=True, auto_id=True))
         fields.append(
-            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim))
+            FieldSchema(name=self.float_vector_field_name, dtype=DataType.FLOAT_VECTOR, dim=self.float_vector_dim)
+        )
 
         for data_type in ct.all_scalar_data_types:
             fields.append(cf.gen_scalar_field(data_type, name=data_type.name, nullable=True))
@@ -811,12 +991,16 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=self.float_vector_field_name,
-                               metric_type=self.float_vector_metric,
-                               index_type=self.float_vector_index)
-        index_params.add_index(field_name=self.int8_vector_field_name,
-                               metric_type=self.int8_vector_metric,
-                               index_type=self.int8_vector_index)
+        index_params.add_index(
+            field_name=self.float_vector_field_name,
+            metric_type=self.float_vector_metric,
+            index_type=self.float_vector_index,
+        )
+        index_params.add_index(
+            field_name=self.int8_vector_field_name,
+            metric_type=self.int8_vector_metric,
+            index_type=self.int8_vector_index,
+        )
         self.create_index(client, self.collection_name, index_params=index_params)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.float_vector_field_name)
         self.wait_for_index_ready(client, self.collection_name, index_name=self.int8_vector_field_name)
@@ -840,17 +1024,21 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
         """
         client = self._client()
         search_params = {"metric_type": self.float_vector_metric}
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         # verify
-        error = {ct.err_code: 1700,
-                 ct.err_msg: f"groupBy field not found in schema"}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=10,
-                    group_by_field=[DataType.VARCHAR.name, DataType.INT32.name],
-                    output_fields=[DataType.VARCHAR.name, DataType.INT32.name],
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {ct.err_code: 1700, ct.err_msg: "groupBy field not found in schema"}
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=10,
+            group_by_field=[DataType.VARCHAR.name, DataType.INT32.name],
+            output_fields=[DataType.VARCHAR.name, DataType.INT32.name],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("grpby_nonexist_field", ["nonexist_field", 21])
@@ -863,20 +1051,90 @@ class TestGroupSearchInvalid(TestMilvusClientV2Base):
                 verify: the error code and msg
         """
         client = self._client()
-        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim,
-                                        vector_data_type=DataType.FLOAT_VECTOR)
+        search_vectors = cf.gen_vectors(1, dim=self.float_vector_dim, vector_data_type=DataType.FLOAT_VECTOR)
         search_params = {"metric_type": self.float_vector_metric}
         limit = 1
-        error = {ct.err_code: 1700,
-                 ct.err_msg: f"groupBy field not found in schema: field not found[field={grpby_nonexist_field}]"}
-        self.search(client, self.collection_name, data=search_vectors,
-                    anns_field=self.float_vector_field_name,
-                    search_params=search_params, limit=limit,
-                    group_by_field=grpby_nonexist_field,
-                    check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            ct.err_code: 1700,
+            ct.err_msg: f"groupBy field not found in schema: field not found[field={grpby_nonexist_field}]",
+        }
+        self.search(
+            client,
+            self.collection_name,
+            data=search_vectors,
+            anns_field=self.float_vector_field_name,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=grpby_nonexist_field,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
 
 class TestSearchGroupByIndependent(TestMilvusClientV2Base):
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_search_group_by_nullable_vector(self):
+        """
+        target: test group-by search on an indexed nullable vector field
+        method: create collection with nullable FLOAT_VECTOR, insert mixed null/non-null vectors,
+                build IVF_FLAT index, search with INT8 group-by and is-not-null scalar filter
+        expected: search returns grouped results from non-null scalar groups
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        dim = 36
+        nb = 10000
+        vector_field = ct.default_float_vec_field_name
+        group_by_field = DataType.INT8.name
+
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(field_name=ct.default_primary_field_name, datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name=vector_field, datatype=DataType.FLOAT_VECTOR, dim=dim, nullable=True)
+        schema.add_field(field_name=group_by_field, datatype=DataType.INT8, nullable=True)
+        self.create_collection(client, collection_name, schema=schema)
+
+        vectors = cf.gen_vectors(nb, dim=dim, vector_data_type=DataType.FLOAT_VECTOR)
+        rows = [
+            {
+                ct.default_primary_field_name: i,
+                vector_field: None if i % 10 == 9 else vectors[i],
+                group_by_field: None if i % 5 == 0 else i % 100,
+            }
+            for i in range(nb)
+        ]
+        self.insert(client, collection_name, data=rows)
+        self.flush(client, collection_name)
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(
+            field_name=vector_field, metric_type="COSINE", index_type="IVF_FLAT", params={"nlist": 128}
+        )
+        self.create_index(client, collection_name, index_params=index_params)
+        self.wait_for_index_ready(client, collection_name, index_name=vector_field)
+        self.load_collection(client, collection_name)
+
+        nq = 2
+        limit = 15
+        search_vectors = cf.gen_vectors(nq, dim=dim, vector_data_type=DataType.FLOAT_VECTOR)
+        search_params = {"params": {"nprobe": 32}, "metric_type": "COSINE"}
+        res = self.search(
+            client,
+            collection_name,
+            data=search_vectors,
+            anns_field=vector_field,
+            search_params=search_params,
+            limit=limit,
+            filter=f"{group_by_field} is not null",
+            group_by_field=group_by_field,
+            output_fields=[group_by_field],
+        )[0]
+
+        for hits in res:
+            group_values = [hit.get(group_by_field) for hit in hits]
+            assert len(group_values) == limit
+            assert None not in group_values
+            assert len(group_values) == len(set(group_values))
+
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("metric", ["L2", "IP", "COSINE"])
     def test_search_group_by_flat_index_correctness(self, metric):
@@ -904,11 +1162,14 @@ class TestSearchGroupByIndependent(TestMilvusClientV2Base):
 
         for _ in range(10):
             all_vectors = cf.gen_vectors(ct.default_nb, dim=ct.default_dim)
-            rows = [{
-                ct.default_primary_field_name: i,
-                ct.default_float_vec_field_name: all_vectors[i],
-                ct.default_int32_field_name: i,
-            } for i in range(ct.default_nb)]
+            rows = [
+                {
+                    ct.default_primary_field_name: i,
+                    ct.default_float_vec_field_name: all_vectors[i],
+                    ct.default_int32_field_name: i,
+                }
+                for i in range(ct.default_nb)
+            ]
             self.insert(client, collection_name, data=rows)
         self.flush(client, collection_name)
 
@@ -920,18 +1181,28 @@ class TestSearchGroupByIndependent(TestMilvusClientV2Base):
         search_params = {"metric_type": metric}
 
         # normal search to get the best result
-        normal_res = self.search(client, collection_name, data=search_vectors,
-                                 search_params=search_params, limit=limit,
-                                 output_fields=[grpby_field],
-                                 check_task=CheckTasks.check_search_results,
-                                 check_items={"nq": nq, "limit": limit})[0]
+        normal_res = self.search(
+            client,
+            collection_name,
+            data=search_vectors,
+            search_params=search_params,
+            limit=limit,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "limit": limit},
+        )[0]
         # group_by search
-        groupby_res = self.search(client, collection_name, data=search_vectors,
-                                  search_params=search_params, limit=limit,
-                                  group_by_field=grpby_field,
-                                  output_fields=[grpby_field],
-                                  check_task=CheckTasks.check_search_results,
-                                  check_items={"nq": nq, "limit": limit})[0]
+        groupby_res = self.search(
+            client,
+            collection_name,
+            data=search_vectors,
+            search_params=search_params,
+            limit=limit,
+            group_by_field=grpby_field,
+            output_fields=[grpby_field],
+            check_task=CheckTasks.check_search_results,
+            check_items={"nq": nq, "limit": limit},
+        )[0]
         # verify that the top result from group_by search matches the normal search
         # for the same group value, group_by should return the best (closest) result
         normal_top_distance = normal_res[0][0].distance
@@ -946,9 +1217,11 @@ class TestSearchGroupByIndependent(TestMilvusClientV2Base):
         # because group_by returns the best result per group
         if metric == "L2":
             # For L2, smaller is better
-            assert groupby_top_distance <= normal_top_distance + epsilon, \
-                f"GroupBy search should return result with distance <= normal search for L2 metric"
+            assert groupby_top_distance <= normal_top_distance + epsilon, (
+                "GroupBy search should return result with distance <= normal search for L2 metric"
+            )
         else:
             # For IP/COSINE, larger is better
-            assert groupby_top_distance >= normal_top_distance - epsilon, \
+            assert groupby_top_distance >= normal_top_distance - epsilon, (
                 f"GroupBy search should return result with distance >= normal search for {metric} metric"
+            )


### PR DESCRIPTION
## Summary
- Cherrypick nullable vector fixes from `master` to `3.0`.
- Include REST nullable vector handling, sealed-segment projection, bitset lifetime, and compact nullable-vector data invariant fixes.
- Resolve 3.0 compatibility conflicts around nullable ArrayOfVector row-dense helpers and queryutil/typeutil call shapes.

pr: #49751
pr: #49756
pr: #49771
pr: #49924
issue: #49881
issue: #49974
issue: #49992

## Test plan
- [x] `git diff --check upstream/3.0..HEAD`
- [x] `rg -n '^<<<<<<<|^=======|^>>>>>>>' .`
- [x] `go test ./internal/util/queryutil`
- [x] `cd pkg && go test ./util/typeutil ./util/funcutil`
- [ ] `go test ./internal/distributed/proxy/httpserver` locally blocked: missing `milvus_core.pc` in `PKG_CONFIG_PATH`
- [ ] `go test ./internal/storage` locally blocked: missing `milvus_core.pc` in `PKG_CONFIG_PATH`
