### PR TITLE
enhance: add configurable storage writer format

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -852,7 +852,7 @@ dataNode:
     workPoolSize: 8 # worker pool size for one clustering compaction job.
   bloomFilterApplyParallelFactor: 2 # parallel factor when to apply pk to bloom filter, default to 2*CPU_CORE_NUM
   storage:
-    format: vortex # storage format for insert data, options: [parquet, vortex]
+    format: parquet # storage format for insert data, options: [parquet, vortex]
     deltalog: json # deltalog format, options: [json, parquet]
   ip:  # TCP/IP address of dataNode. If not specified, use the first unicastable address
   port: 21124 # TCP port of dataNode

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -852,6 +852,7 @@ dataNode:
     workPoolSize: 8 # worker pool size for one clustering compaction job.
   bloomFilterApplyParallelFactor: 2 # parallel factor when to apply pk to bloom filter, default to 2*CPU_CORE_NUM
   storage:
+    format: vortex # storage format for insert data, options: [parquet, vortex]
     deltalog: json # deltalog format, options: [json, parquet]
   ip:  # TCP/IP address of dataNode. If not specified, use the first unicastable address
   port: 21124 # TCP port of dataNode

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -222,17 +222,28 @@ Schema::ConvertToLoonArrowSchema() const {
 
         std::shared_ptr<arrow::DataType> arrow_data_type = nullptr;
         auto data_type = meta.get_data_type();
-        if (data_type == DataType::VECTOR_ARRAY) {
+        auto is_nullable_dense_vector =
+            meta.is_nullable() && IsVectorDataType(data_type) &&
+            !IsSparseFloatVectorDataType(data_type) &&
+            data_type != DataType::VECTOR_ARRAY;
+        if (is_nullable_dense_vector) {
+            arrow_data_type = arrow::binary();
+        } else if (data_type == DataType::VECTOR_ARRAY) {
             arrow_data_type = GetArrowDataTypeForVectorArray(
                 meta.get_element_type(), meta.get_dim());
         } else {
             arrow_data_type = GetArrowDataType(data_type, dim);
         }
 
+        auto metadata = is_nullable_dense_vector
+                            ? arrow::key_value_metadata(
+                                  {"dim"}, {std::to_string(meta.get_dim())})
+                            : nullptr;
         auto arrow_field =
             std::make_shared<arrow::Field>(std::to_string(field_id.get()),
                                            arrow_data_type,
-                                           meta.is_nullable());
+                                           meta.is_nullable(),
+                                           metadata);
         arrow_fields.push_back(arrow_field);
     }
     return arrow::schema(arrow_fields);

--- a/internal/core/src/common/SchemaTest.cpp
+++ b/internal/core/src/common/SchemaTest.cpp
@@ -17,6 +17,8 @@
 #include <string>
 #include <vector>
 
+#include <arrow/util/key_value_metadata.h>
+
 #include "common/Schema.h"
 #include "common/Types.h"
 #include "filemanager/InputStream.h"
@@ -529,4 +531,27 @@ TEST_F(SchemaTest, ExternalFunctionOutputUsesFieldIdColumnName) {
               columns->end());
     EXPECT_NE(std::find(columns->begin(), columns->end(), "102"),
               columns->end());
+}
+
+TEST_F(SchemaTest, ConvertToLoonArrowSchemaNullableDenseVectorUsesBinary) {
+    auto pk_id = schema_->AddDebugField("pk_field", DataType::INT64, false);
+    schema_->set_primary_field_id(pk_id);
+    auto vector_id = schema_->AddDebugField("nullable_vector",
+                                            DataType::VECTOR_FLOAT,
+                                            128,
+                                            knowhere::metric::L2,
+                                            true);
+
+    auto loon_schema = schema_->ConvertToLoonArrowSchema();
+    auto vector_field =
+        loon_schema->GetFieldByName(std::to_string(vector_id.get()));
+
+    ASSERT_NE(vector_field, nullptr);
+    EXPECT_EQ(vector_field->type()->id(), arrow::Type::BINARY);
+    EXPECT_TRUE(vector_field->nullable());
+    ASSERT_NE(vector_field->metadata(), nullptr);
+    ASSERT_TRUE(vector_field->metadata()->Contains("dim"));
+    auto dim_result = vector_field->metadata()->Get("dim");
+    ASSERT_TRUE(dim_result.ok()) << dim_result.status().ToString();
+    EXPECT_EQ(dim_result.ValueOrDie(), "128");
 }

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -1642,7 +1642,7 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
         // use single column group policy (all columns in one group)
         writer_config.properties[PROPERTY_WRITER_POLICY] =
             std::string(LOON_COLUMN_GROUP_POLICY_SINGLE);
-        writer_config.properties[PROPERTY_FORMAT] =
+        writer_config.properties[PROPERTY_WRITER_FORMAT] =
             std::string(LOON_FORMAT_PARQUET);
 
         // add TEXT column configs

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,8 +14,8 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 0b35d53)
-set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
+set( milvus-storage_VERSION 15bb38f7d970996625d1864cea1dcc0bf453102d)
+set( GIT_REPOSITORY  "https://github.com/jiaqizho/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")
 

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,8 +14,8 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 15bb38f7d970996625d1864cea1dcc0bf453102d)
-set( GIT_REPOSITORY  "https://github.com/jiaqizho/milvus-storage.git")
+set( milvus-storage_VERSION 7c2422a)
+set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")
 

--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func TestExploreFiles_EmptyColumns(t *testing.T) {
@@ -647,6 +648,48 @@ func TestMakePropertiesFromStorageConfig_ExtraKVsOverride(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, props)
 	defer FreeProperties(props)
+}
+
+func TestMakePropertiesFromStorageConfig_UsesConfiguredStorageFormat(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	require.NoError(t, params.Save(params.DataNodeCfg.StorageFormat.Key, "parquet"))
+	t.Cleanup(func() {
+		_ = params.Reset(params.DataNodeCfg.StorageFormat.Key)
+	})
+
+	config := &indexpb.StorageConfig{
+		StorageType: "local",
+		BucketName:  t.TempDir(),
+		RootPath:    t.TempDir(),
+	}
+
+	props, err := MakePropertiesFromStorageConfig(config, nil)
+	require.NoError(t, err)
+	defer FreeProperties(props)
+	assert.Equal(t, "parquet", loonPropertyString(props, PropertyWriterFormat))
+}
+
+func TestMakePropertiesFromStorageConfig_ExtraKVsOverrideStorageFormat(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	require.NoError(t, params.Save(params.DataNodeCfg.StorageFormat.Key, "vortex"))
+	t.Cleanup(func() {
+		_ = params.Reset(params.DataNodeCfg.StorageFormat.Key)
+	})
+
+	config := &indexpb.StorageConfig{
+		StorageType: "local",
+		BucketName:  t.TempDir(),
+		RootPath:    t.TempDir(),
+	}
+
+	props, err := MakePropertiesFromStorageConfig(config, map[string]string{
+		PropertyWriterFormat: "parquet",
+	})
+	require.NoError(t, err)
+	defer FreeProperties(props)
+	assert.Equal(t, "parquet", loonPropertyString(props, PropertyWriterFormat))
 }
 
 func TestNormalizeExternalPathForStorage_UsesInjectedExtfsEndpoint(t *testing.T) {

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -21,6 +21,7 @@ import (
 
 	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 // ErrLoonTransient marks any failure surfaced by the loon FFI layer. Today
@@ -59,6 +60,7 @@ var (
 	PropertyFSUseCRC32CChecksum   = C.GoString(C.loon_properties_fs_use_crc32c_checksum)
 
 	PropertyWriterPolicy             = C.GoString(C.loon_properties_writer_policy)
+	PropertyWriterFormat             = "writer.format"
 	PropertyWriterSchemaBasedPattern = C.GoString(C.loon_properties_writer_schema_base_patterns)
 
 	// CMEK (Customer Managed Encryption Keys) writer properties
@@ -189,6 +191,9 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 	} else {
 		values = append(values, "false")
 	}
+
+	keys = append(keys, PropertyWriterFormat)
+	values = append(values, paramtable.Get().DataNodeCfg.StorageFormat.GetValue())
 
 	// No extfs.default.* properties here. Per-collection extfs properties
 	// (extfs.{collectionID}.*) are injected downstream via

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6672,6 +6672,7 @@ type dataNodeConfig struct {
 
 	BloomFilterApplyParallelFactor ParamItem `refreshable:"true"`
 
+	StorageFormat  ParamItem `refreshable:"false"`
 	DeltalogFormat ParamItem `refreshable:"false"`
 
 	// index services config
@@ -7146,6 +7147,15 @@ if this parameter <= 0, will set it as 10`,
 		Export:       true,
 	}
 	p.BloomFilterApplyParallelFactor.Init(base.mgr)
+
+	p.StorageFormat = ParamItem{
+		Key:          "dataNode.storage.format",
+		Version:      "3.0.0",
+		DefaultValue: "vortex",
+		Doc:          "storage format for insert data, options: [parquet, vortex]",
+		Export:       true,
+	}
+	p.StorageFormat.Init(base.mgr)
 
 	p.DeltalogFormat = ParamItem{
 		Key:          "dataNode.storage.deltalog",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -7151,7 +7151,7 @@ if this parameter <= 0, will set it as 10`,
 	p.StorageFormat = ParamItem{
 		Key:          "dataNode.storage.format",
 		Version:      "3.0.0",
-		DefaultValue: "vortex",
+		DefaultValue: "parquet",
 		Doc:          "storage format for insert data, options: [parquet, vortex]",
 		Export:       true,
 	}

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -703,6 +703,11 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, int64(2), Params.ClusteringCompactionWorkerPoolSize.GetAsInt64())
 
 		assert.Equal(t, 2, Params.BloomFilterApplyParallelFactor.GetAsInt())
+		assert.Equal(t, "dataNode.storage.format", Params.StorageFormat.Key)
+		assert.Equal(t, "vortex", Params.StorageFormat.GetValue())
+		params.Save(Params.StorageFormat.Key, "parquet")
+		assert.Equal(t, "parquet", Params.StorageFormat.GetValue())
+		params.Reset(Params.StorageFormat.Key)
 		assert.Equal(t, 16, Params.WorkerSlotUnit.GetAsInt())
 		assert.Equal(t, 0.25, Params.StandaloneSlotRatio.GetAsFloat())
 	})

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -704,9 +704,9 @@ func TestComponentParam(t *testing.T) {
 
 		assert.Equal(t, 2, Params.BloomFilterApplyParallelFactor.GetAsInt())
 		assert.Equal(t, "dataNode.storage.format", Params.StorageFormat.Key)
-		assert.Equal(t, "vortex", Params.StorageFormat.GetValue())
-		params.Save(Params.StorageFormat.Key, "parquet")
 		assert.Equal(t, "parquet", Params.StorageFormat.GetValue())
+		params.Save(Params.StorageFormat.Key, "vortex")
+		assert.Equal(t, "vortex", Params.StorageFormat.GetValue())
 		params.Reset(Params.StorageFormat.Key)
 		assert.Equal(t, 16, Params.WorkerSlotUnit.GetAsInt())
 		assert.Equal(t, 0.25, Params.StandaloneSlotRatio.GetAsFloat())


### PR DESCRIPTION
issue: #50147

This change pulls the Vortex writer-format switch into its own focused update. The goal is to make the insert data storage format configurable from Milvus config, so we can turn Vortex on for CI validation without mixing it with the unrelated AssertInfo cleanup from the previous PR.

The implementation adds dataNode.storage.format and wires it through paramtable as DataNodeCfg.StorageFormat, with vortex as the current default for this branch. When storagev2 builds milvus-storage properties, it now passes the selected value through writer.format, which matches the updated milvus-storage property contract.

This also updates the C++ writer path to use PROPERTY_WRITER_FORMAT instead of the old PROPERTY_FORMAT key. That keeps the growing-segment flush path aligned with the new storage property naming while still forcing the TEXT flush writer to parquet where that path expects parquet output.