### PR TITLE
enhance: Add V3 entry streaming reader

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -960,7 +960,6 @@ common:
   defaultIndexName: _default_idx # Name of the index when it is created with name unspecified
   indexSliceSize: 16 # Index slice size in MB
   indexEntryStream:
-    chunkSize: 2097152 # Default chunk size in bytes for streaming V3 index entry reads
     scalarIndexBudgetRatio: 3.0 # Multiplier for scalar index stream transient memory budget, relative to CPU core count
   threadCoreCoefficient:
     highPriority: 10 # This parameter specify how many times the number of threads is the number of cores in high priority pool

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -959,8 +959,8 @@ common:
   defaultPartitionName: _default # Name of the default partition when a collection is created
   defaultIndexName: _default_idx # Name of the index when it is created with name unspecified
   indexSliceSize: 16 # Index slice size in MB
-  indexEntryStream:
-    scalarIndexBudgetRatio: 3 # Multiplier for scalar index stream transient memory budget, relative to CPU core count
+  entryStream:
+    streamBudgetRatio: 3 # Multiplier for entry stream transient memory budget, relative to CPU core count
   threadCoreCoefficient:
     highPriority: 10 # This parameter specify how many times the number of threads is the number of cores in high priority pool
     middlePriority: 5 # This parameter specify how many times the number of threads is the number of cores in middle priority pool

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -960,7 +960,7 @@ common:
   defaultIndexName: _default_idx # Name of the index when it is created with name unspecified
   indexSliceSize: 16 # Index slice size in MB
   indexEntryStream:
-    scalarIndexBudgetRatio: 3.0 # Multiplier for scalar index stream transient memory budget, relative to CPU core count
+    scalarIndexBudgetRatio: 3 # Multiplier for scalar index stream transient memory budget, relative to CPU core count
   threadCoreCoefficient:
     highPriority: 10 # This parameter specify how many times the number of threads is the number of cores in high priority pool
     middlePriority: 5 # This parameter specify how many times the number of threads is the number of cores in middle priority pool

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -959,6 +959,9 @@ common:
   defaultPartitionName: _default # Name of the default partition when a collection is created
   defaultIndexName: _default_idx # Name of the index when it is created with name unspecified
   indexSliceSize: 16 # Index slice size in MB
+  indexEntryStream:
+    chunkSize: 2097152 # Default chunk size in bytes for streaming V3 index entry reads
+    scalarIndexBudgetRatio: 3.0 # Multiplier for scalar index stream transient memory budget, relative to CPU core count
   threadCoreCoefficient:
     highPriority: 10 # This parameter specify how many times the number of threads is the number of cores in high priority pool
     middlePriority: 5 # This parameter specify how many times the number of threads is the number of cores in middle priority pool

--- a/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
+++ b/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
@@ -402,8 +402,8 @@ Streaming read behavior:
 - CRC-32C is verified incrementally as chunks are consumed.
 - Consumers may receive partial data before a later chunk error is reported.
 - Slow consumers keep their chunk budget until the callback returns, which can block other streams.
-- For plain entries, `chunk_size` controls range splitting. The default is 16MB, aligned with the encrypted slice size and existing V3 unencrypted range size. Explicit values below 64KB are rejected.
-- For encrypted entries, streaming follows encryption slice boundaries and ignores `chunk_size`.
+- Streaming uses slice-sized chunks. For plain entries, the reader self-splits by `chunk_size`; the default is 16MB, aligned with the encrypted slice size and existing V3 unencrypted range size. Explicit values below 64KB are rejected.
+- For encrypted entries, the reader uses the plaintext slice boundaries stored in the V3 directory. With the default writer settings, this is also 16MB.
 
 Streaming load configuration:
 

--- a/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
+++ b/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
@@ -220,7 +220,7 @@ class IndexEntryDirectStreamWriter : public IndexEntryWriter {
 };
 ```
 
-Constructor writes Magic. `WriteEntry()` computes CRC-32C incrementally (`crc32c_update` per chunk as data streams through) and records the final checksum in the directory entry. For fd-based entries, CRC is updated per 16MB read chunk — no extra memory. `Finish()` writes the Meta Entry (as the last regular entry), then Directory Table JSON, then 32-byte Footer (`version` + `meta_entry_size` + `directory_table_size`), computes `total_bytes_written_`, closes stream.
+Constructor writes Magic. `WriteEntry()` computes CRC-32C incrementally (`crc32c_update` as data streams through) and records the final checksum in the directory entry. For fd-based entries, CRC is updated per 16MB read buffer — no extra memory. `Finish()` writes the Meta Entry (as the last regular entry), then Directory Table JSON, then 32-byte Footer (`version` + `meta_entry_size` + `directory_table_size`), computes `total_bytes_written_`, closes stream.
 
 ### 3.4 IndexEntryEncryptedLocalWriter (Encrypted)
 
@@ -398,11 +398,11 @@ Large scalar data entries should use `IndexEntryReader::ReadEntryStream()` inste
 
 Streaming read behavior:
 
-- Chunks are delivered to the consumer in entry order.
-- CRC-32C is verified incrementally as chunks are consumed.
-- Consumers may receive partial data before a later chunk error is reported.
-- Slow consumers keep their chunk budget until the callback returns, which can block other streams.
-- Streaming uses slice-sized chunks. For plain entries, the reader self-splits by `chunk_size`; the default is 16MB, aligned with the encrypted slice size and existing V3 unencrypted range size. Explicit values below 64KB are rejected.
+- Slices are delivered to the consumer in entry order.
+- CRC-32C is verified incrementally as slices are consumed.
+- Consumers may receive partial data before a later slice error is reported.
+- Slow consumers keep their slice budget until the callback returns, which can block other streams.
+- Plain entries are read as 16MB slices by default, aligned with the encrypted slice size and existing V3 unencrypted range size. Explicit `slice_size` values below 64KB are rejected.
 - For encrypted entries, the reader uses the plaintext slice boundaries stored in the V3 directory. With the default writer settings, this is also 16MB.
 
 Streaming load configuration:
@@ -417,7 +417,7 @@ The default scalar stream budget is:
 CPU cores × common.indexEntryStream.scalarIndexBudgetRatio × 16MB
 ```
 
-With default values, an 8-core node gets `8 × 3.0 × 16MB = 384MB` of transient scalar stream budget. This admits about 8 encrypted slices concurrently because each encrypted slice budgets ciphertext + decrypted plaintext + returned chunk. Oversized chunks are allowed to run exclusively to guarantee progress.
+With default values, an 8-core node gets `8 × 3.0 × 16MB = 384MB` of transient scalar stream budget. This admits about 8 encrypted slices concurrently because each encrypted slice budgets ciphertext + decrypted plaintext + returned slice. Oversized slices are allowed to run exclusively to guarantee progress.
 
 ### 5.3 Meta Packing
 
@@ -473,7 +473,7 @@ All thread pools reuse V2 `ThreadPools::GetThreadPool(priority)`, no custom pool
 ### Upload — Unencrypted
 
 ```
-Main thread: [read chunk → crc32c_update → Write to RemoteOutputStream] ──→ sequential fill
+Main thread: [read buffer → crc32c_update → Write to RemoteOutputStream] ──→ sequential fill
 RemoteOutputStream:  background_writes parallel upload Part 0, 1, 2...  ──→ S3
 ```
 
@@ -535,7 +535,7 @@ Main thread (after all tasks complete, combine in sequential order):
 | Download, to memory | N × `range_size` + `original_size` |
 | Download, to file | N × `range_size` (reusable) |
 | Streaming load, unencrypted | bounded by scalar stream budget |
-| Streaming load, encrypted | bounded by scalar stream budget; each active slice budgets ciphertext + decrypted plaintext + returned chunk |
+| Streaming load, encrypted | bounded by scalar stream budget; each active slice budgets ciphertext + decrypted plaintext + returned slice |
 
 Consistent with V2: peak determined by concurrency × slice size, does not grow with entry size.
 

--- a/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
+++ b/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
@@ -394,7 +394,7 @@ protected:
 
 ### 5.2 Streaming Read
 
-Large scalar data entries should use `IndexEntryReader::ReadEntryStream()` instead of `ReadEntry()` when the index implementation can consume bytes incrementally.
+Large V3 data entries should use `IndexEntryReader::ReadEntryStream()` instead of `ReadEntry()` when the implementation can consume bytes incrementally.
 
 Streaming read behavior:
 
@@ -409,15 +409,15 @@ Streaming load configuration:
 
 | Parameter | Key | Default | Description |
 |-----------|-----|---------|-------------|
-| `ScalarIndexEntryStreamBudgetRatio` | `common.indexEntryStream.scalarIndexBudgetRatio` | `3.0` | Dynamic scalar index stream transient memory budget multiplier, relative to CPU core count. |
+| `StreamBudgetRatio` | `common.entryStream.streamBudgetRatio` | `3.0` | Dynamic entry stream transient memory budget multiplier, relative to CPU core count. |
 
-The default scalar stream budget is:
+The default entry stream budget is:
 
 ```
-CPU cores × common.indexEntryStream.scalarIndexBudgetRatio × 16MB
+CPU cores × common.entryStream.streamBudgetRatio × 16MB
 ```
 
-With default values, an 8-core node gets `8 × 3.0 × 16MB = 384MB` of transient scalar stream budget. This admits about 8 encrypted slices concurrently because each encrypted slice budgets ciphertext + decrypted plaintext + returned slice. Oversized slices are allowed to run exclusively to guarantee progress.
+With default values, an 8-core node gets `8 × 3.0 × 16MB = 384MB` of transient entry stream budget. This admits about 8 encrypted slices concurrently because each encrypted slice budgets ciphertext + decrypted plaintext + returned slice. Oversized slices are allowed to run exclusively to guarantee progress.
 
 ### 5.3 Meta Packing
 
@@ -534,8 +534,8 @@ Main thread (after all tasks complete, combine in sequential order):
 | Upload, encrypted, disk entry | W × `slice_size` × 2 |
 | Download, to memory | N × `range_size` + `original_size` |
 | Download, to file | N × `range_size` (reusable) |
-| Streaming load, unencrypted | bounded by scalar stream budget |
-| Streaming load, encrypted | bounded by scalar stream budget; each active slice budgets ciphertext + decrypted plaintext + returned slice |
+| Streaming load, unencrypted | bounded by entry stream budget |
+| Streaming load, encrypted | bounded by entry stream budget; each active slice budgets ciphertext + decrypted plaintext + returned slice |
 
 Consistent with V2: peak determined by concurrency × slice size, does not grow with entry size.
 

--- a/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
+++ b/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
@@ -392,7 +392,34 @@ protected:
 3. Create `IndexEntryReader::Open(input, file_size, collection_id)`.
 4. Call `LoadEntries(*reader, config)`.
 
-### 5.2 Meta Packing
+### 5.2 Streaming Read
+
+Large scalar data entries should use `IndexEntryReader::ReadEntryStream()` instead of `ReadEntry()` when the index implementation can consume bytes incrementally.
+
+Streaming read behavior:
+
+- Chunks are delivered to the consumer in entry order.
+- CRC-32C is verified incrementally as chunks are consumed.
+- Consumers may receive partial data before a later chunk error is reported.
+- Slow consumers keep their chunk budget until the callback returns, which can block other streams.
+- For plain entries, `chunk_size` controls range splitting. The default is 16MB, aligned with the encrypted slice size and existing V3 unencrypted range size. Explicit values below 64KB are rejected.
+- For encrypted entries, streaming follows encryption slice boundaries and ignores `chunk_size`.
+
+Streaming load configuration:
+
+| Parameter | Key | Default | Description |
+|-----------|-----|---------|-------------|
+| `ScalarIndexEntryStreamBudgetRatio` | `common.indexEntryStream.scalarIndexBudgetRatio` | `3.0` | Scalar index stream transient memory budget multiplier, relative to CPU core count. |
+
+The default scalar stream budget is:
+
+```
+CPU cores × common.indexEntryStream.scalarIndexBudgetRatio × 16MB
+```
+
+With default values, an 8-core node gets `8 × 3.0 × 16MB = 384MB` of transient scalar stream budget. This admits about 8 encrypted slices concurrently because each encrypted slice budgets ciphertext + decrypted plaintext + returned chunk. Oversized chunks are allowed to run exclusively to guarantee progress.
+
+### 5.3 Meta Packing
 
 Each index packs all O(1) metadata into a **single meta entry**, eliminating multiple small IOs by design.
 
@@ -420,7 +447,7 @@ Meta structure definitions:
 // Hybrid:           {"index_type": uint8}
 ```
 
-### 5.3 Inheritance Patterns
+### 5.4 Inheritance Patterns
 
 **InvertedIndexTantivy** provides `BuildTantivyMeta()` as a virtual hook. Subclasses extend by:
 
@@ -507,6 +534,8 @@ Main thread (after all tasks complete, combine in sequential order):
 | Upload, encrypted, disk entry | W × `slice_size` × 2 |
 | Download, to memory | N × `range_size` + `original_size` |
 | Download, to file | N × `range_size` (reusable) |
+| Streaming load, unencrypted | bounded by scalar stream budget |
+| Streaming load, encrypted | bounded by scalar stream budget; each active slice budgets ciphertext + decrypted plaintext + returned chunk |
 
 Consistent with V2: peak determined by concurrency × slice size, does not grow with entry size.
 

--- a/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
+++ b/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
@@ -405,20 +405,6 @@ Streaming read behavior:
 - Plain entries are read as 16MB slices by default, aligned with the encrypted slice size and existing V3 unencrypted range size. Explicit `slice_size` values below 64KB are rejected.
 - For encrypted entries, the reader uses the plaintext slice boundaries stored in the V3 directory. With the default writer settings, this is also 16MB.
 
-Streaming load configuration:
-
-| Parameter | Key | Default | Description |
-|-----------|-----|---------|-------------|
-| `StreamBudgetRatio` | `common.entryStream.streamBudgetRatio` | `3.0` | Dynamic entry stream transient memory budget multiplier, relative to CPU core count. |
-
-The default entry stream budget is:
-
-```
-CPU cores × common.entryStream.streamBudgetRatio × 16MB
-```
-
-With default values, an 8-core node gets `8 × 3.0 × 16MB = 384MB` of transient entry stream budget. This admits about 8 encrypted slices concurrently because each encrypted slice budgets ciphertext + decrypted plaintext + returned slice. Oversized slices are allowed to run exclusively to guarantee progress.
-
 ### 5.3 Meta Packing
 
 Each index packs all O(1) metadata into a **single meta entry**, eliminating multiple small IOs by design.

--- a/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
+++ b/docs/design-docs/design_docs/20260209-scalar-index-unified-format.md
@@ -409,7 +409,7 @@ Streaming load configuration:
 
 | Parameter | Key | Default | Description |
 |-----------|-----|---------|-------------|
-| `ScalarIndexEntryStreamBudgetRatio` | `common.indexEntryStream.scalarIndexBudgetRatio` | `3.0` | Scalar index stream transient memory budget multiplier, relative to CPU core count. |
+| `ScalarIndexEntryStreamBudgetRatio` | `common.indexEntryStream.scalarIndexBudgetRatio` | `3.0` | Dynamic scalar index stream transient memory budget multiplier, relative to CPU core count. |
 
 The default scalar stream budget is:
 

--- a/internal/core/src/common/Common.cpp
+++ b/internal/core/src/common/Common.cpp
@@ -22,6 +22,7 @@
 #include "gflags/gflags.h"
 #include "glog/logging.h"
 #include "log/Log.h"
+#include "storage/EntryStreamUtils.h"
 #include "tantivy-binding.h"
 
 namespace milvus {
@@ -58,6 +59,8 @@ SetScalarIndexEntryStreamBudgetRatio(const double ratio) {
         return;
     }
     SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.store(ratio);
+    storage::TransientMemoryBudget::GetScalarIndexStreamBudget()
+        .NotifyCapacityUpdated();
     LOG_INFO("set scalar index entry stream budget ratio: {}",
              SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.load());
 }

--- a/internal/core/src/common/Common.cpp
+++ b/internal/core/src/common/Common.cpp
@@ -27,6 +27,8 @@
 namespace milvus {
 
 std::atomic<int64_t> FILE_SLICE_SIZE(DEFAULT_INDEX_FILE_SLICE_SIZE);
+std::atomic<int64_t> INDEX_ENTRY_STREAM_CHUNK_SIZE(2 * 1024 * 1024);
+std::atomic<double> SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO(3.0);
 std::atomic<int64_t> EXEC_EVAL_EXPR_BATCH_SIZE(
     DEFAULT_EXEC_EVAL_EXPR_BATCH_SIZE);
 std::atomic<int64_t> DELETE_DUMP_BATCH_SIZE(DEFAULT_DELETE_DUMP_BATCH_SIZE);
@@ -47,6 +49,29 @@ void
 SetIndexSliceSize(const int64_t size) {
     FILE_SLICE_SIZE.store(size << 20);
     LOG_INFO("set config index slice size (byte): {}", FILE_SLICE_SIZE.load());
+}
+
+void
+SetIndexEntryStreamChunkSize(const int64_t size) {
+    if (size <= 0) {
+        LOG_WARN("ignore invalid index entry stream chunk size: {}", size);
+        return;
+    }
+    INDEX_ENTRY_STREAM_CHUNK_SIZE.store(size);
+    LOG_INFO("set index entry stream chunk size (byte): {}",
+             INDEX_ENTRY_STREAM_CHUNK_SIZE.load());
+}
+
+void
+SetScalarIndexEntryStreamBudgetRatio(const double ratio) {
+    if (ratio <= 0) {
+        LOG_WARN("ignore invalid scalar index entry stream budget ratio: {}",
+                 ratio);
+        return;
+    }
+    SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.store(ratio);
+    LOG_INFO("set scalar index entry stream budget ratio: {}",
+             SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.load());
 }
 
 void

--- a/internal/core/src/common/Common.cpp
+++ b/internal/core/src/common/Common.cpp
@@ -28,7 +28,7 @@
 namespace milvus {
 
 std::atomic<int64_t> FILE_SLICE_SIZE(DEFAULT_INDEX_FILE_SLICE_SIZE);
-std::atomic<double> SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO(3.0);
+std::atomic<double> ENTRY_STREAM_BUDGET_RATIO(3.0);
 std::atomic<int64_t> EXEC_EVAL_EXPR_BATCH_SIZE(
     DEFAULT_EXEC_EVAL_EXPR_BATCH_SIZE);
 std::atomic<int64_t> DELETE_DUMP_BATCH_SIZE(DEFAULT_DELETE_DUMP_BATCH_SIZE);
@@ -52,17 +52,16 @@ SetIndexSliceSize(const int64_t size) {
 }
 
 void
-SetScalarIndexEntryStreamBudgetRatio(const double ratio) {
+SetStreamBudgetRatio(const double ratio) {
     if (ratio <= 0) {
-        LOG_WARN("ignore invalid scalar index entry stream budget ratio: {}",
-                 ratio);
+        LOG_WARN("ignore invalid entry stream budget ratio: {}", ratio);
         return;
     }
-    SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.store(ratio);
-    storage::TransientMemoryBudget::GetScalarIndexStreamBudget()
+    ENTRY_STREAM_BUDGET_RATIO.store(ratio);
+    storage::TransientMemoryBudget::GetEntryStreamBudget()
         .NotifyCapacityUpdated();
-    LOG_INFO("set scalar index entry stream budget ratio: {}",
-             SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.load());
+    LOG_INFO("set entry stream budget ratio: {}",
+             ENTRY_STREAM_BUDGET_RATIO.load());
 }
 
 void

--- a/internal/core/src/common/Common.cpp
+++ b/internal/core/src/common/Common.cpp
@@ -27,7 +27,6 @@
 namespace milvus {
 
 std::atomic<int64_t> FILE_SLICE_SIZE(DEFAULT_INDEX_FILE_SLICE_SIZE);
-std::atomic<int64_t> INDEX_ENTRY_STREAM_CHUNK_SIZE(2 * 1024 * 1024);
 std::atomic<double> SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO(3.0);
 std::atomic<int64_t> EXEC_EVAL_EXPR_BATCH_SIZE(
     DEFAULT_EXEC_EVAL_EXPR_BATCH_SIZE);
@@ -49,17 +48,6 @@ void
 SetIndexSliceSize(const int64_t size) {
     FILE_SLICE_SIZE.store(size << 20);
     LOG_INFO("set config index slice size (byte): {}", FILE_SLICE_SIZE.load());
-}
-
-void
-SetIndexEntryStreamChunkSize(const int64_t size) {
-    if (size <= 0) {
-        LOG_WARN("ignore invalid index entry stream chunk size: {}", size);
-        return;
-    }
-    INDEX_ENTRY_STREAM_CHUNK_SIZE.store(size);
-    LOG_INFO("set index entry stream chunk size (byte): {}",
-             INDEX_ENTRY_STREAM_CHUNK_SIZE.load());
 }
 
 void

--- a/internal/core/src/common/Common.h
+++ b/internal/core/src/common/Common.h
@@ -26,7 +26,6 @@
 namespace milvus {
 
 extern std::atomic<int64_t> FILE_SLICE_SIZE;
-extern std::atomic<int64_t> INDEX_ENTRY_STREAM_CHUNK_SIZE;
 extern std::atomic<double> SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO;
 extern std::atomic<int64_t> EXEC_EVAL_EXPR_BATCH_SIZE;
 extern std::atomic<int64_t> DELETE_DUMP_BATCH_SIZE;
@@ -39,9 +38,6 @@ extern std::atomic<bool> ENABLE_PARQUET_STATS_SKIP_INDEX;
 
 void
 SetIndexSliceSize(const int64_t size);
-
-void
-SetIndexEntryStreamChunkSize(const int64_t size);
 
 void
 SetScalarIndexEntryStreamBudgetRatio(const double ratio);

--- a/internal/core/src/common/Common.h
+++ b/internal/core/src/common/Common.h
@@ -26,7 +26,7 @@
 namespace milvus {
 
 extern std::atomic<int64_t> FILE_SLICE_SIZE;
-extern std::atomic<double> SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO;
+extern std::atomic<double> ENTRY_STREAM_BUDGET_RATIO;
 extern std::atomic<int64_t> EXEC_EVAL_EXPR_BATCH_SIZE;
 extern std::atomic<int64_t> DELETE_DUMP_BATCH_SIZE;
 extern std::atomic<bool> ENABLE_LATEST_DELETE_SNAPSHOT_OPTIMIZATION;
@@ -40,7 +40,7 @@ void
 SetIndexSliceSize(const int64_t size);
 
 void
-SetScalarIndexEntryStreamBudgetRatio(const double ratio);
+SetStreamBudgetRatio(const double ratio);
 
 void
 SetDefaultExecEvalExprBatchSize(int64_t val);

--- a/internal/core/src/common/Common.h
+++ b/internal/core/src/common/Common.h
@@ -26,6 +26,8 @@
 namespace milvus {
 
 extern std::atomic<int64_t> FILE_SLICE_SIZE;
+extern std::atomic<int64_t> INDEX_ENTRY_STREAM_CHUNK_SIZE;
+extern std::atomic<double> SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO;
 extern std::atomic<int64_t> EXEC_EVAL_EXPR_BATCH_SIZE;
 extern std::atomic<int64_t> DELETE_DUMP_BATCH_SIZE;
 extern std::atomic<bool> ENABLE_LATEST_DELETE_SNAPSHOT_OPTIMIZATION;
@@ -37,6 +39,12 @@ extern std::atomic<bool> ENABLE_PARQUET_STATS_SKIP_INDEX;
 
 void
 SetIndexSliceSize(const int64_t size);
+
+void
+SetIndexEntryStreamChunkSize(const int64_t size);
+
+void
+SetScalarIndexEntryStreamBudgetRatio(const double ratio);
 
 void
 SetDefaultExecEvalExprBatchSize(int64_t val);

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -43,6 +43,16 @@ SetIndexSliceSize(const int64_t size) {
 }
 
 void
+SetIndexEntryStreamChunkSize(const int64_t size) {
+    milvus::SetIndexEntryStreamChunkSize(size);
+}
+
+void
+SetScalarIndexEntryStreamBudgetRatio(const double ratio) {
+    milvus::SetScalarIndexEntryStreamBudgetRatio(ratio);
+}
+
+void
 SetHighPriorityThreadCoreCoefficient(const float value) {
     milvus::SetHighPriorityThreadCoreCoefficient(value);
 }

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -43,11 +43,6 @@ SetIndexSliceSize(const int64_t size) {
 }
 
 void
-SetIndexEntryStreamChunkSize(const int64_t size) {
-    milvus::SetIndexEntryStreamChunkSize(size);
-}
-
-void
 SetScalarIndexEntryStreamBudgetRatio(const double ratio) {
     milvus::SetScalarIndexEntryStreamBudgetRatio(ratio);
 }

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -43,8 +43,8 @@ SetIndexSliceSize(const int64_t size) {
 }
 
 void
-SetScalarIndexEntryStreamBudgetRatio(const double ratio) {
-    milvus::SetScalarIndexEntryStreamBudgetRatio(ratio);
+SetStreamBudgetRatio(const double ratio) {
+    milvus::SetStreamBudgetRatio(ratio);
 }
 
 void

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -32,9 +32,6 @@ void
 SetIndexSliceSize(const int64_t);
 
 void
-SetIndexEntryStreamChunkSize(const int64_t);
-
-void
 SetScalarIndexEntryStreamBudgetRatio(const double);
 
 void

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -32,6 +32,12 @@ void
 SetIndexSliceSize(const int64_t);
 
 void
+SetIndexEntryStreamChunkSize(const int64_t);
+
+void
+SetScalarIndexEntryStreamBudgetRatio(const double);
+
+void
 SetHighPriorityThreadCoreCoefficient(const float);
 
 void

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -32,7 +32,7 @@ void
 SetIndexSliceSize(const int64_t);
 
 void
-SetScalarIndexEntryStreamBudgetRatio(const double);
+SetStreamBudgetRatio(const double);
 
 void
 SetHighPriorityThreadCoreCoefficient(const float);

--- a/internal/core/src/storage/ChunkStreamUtils.h
+++ b/internal/core/src/storage/ChunkStreamUtils.h
@@ -1,0 +1,125 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "storage/ThreadPools.h"
+
+namespace milvus::storage {
+
+/// Default chunk size for ReadEntryStream (2 MB).
+constexpr size_t kDefaultStreamChunkSize = 2 * 1024 * 1024;
+
+/// Capacity multiplier relative to thread pool size.
+/// Matches the kChannelCapacityMultiplier used by ManifestGroupTranslator.
+constexpr double kStreamChannelCapacityMultiplier = 1.5;
+
+/// A chunk downloaded from a V3 entry, carrying a sequence number for
+/// reordering on the consumer side. `error` carries an exception captured in
+/// the producer task so the consumer can rethrow instead of hanging on pop.
+struct ChunkResult {
+    size_t seq;
+    std::vector<uint8_t> data;
+    std::exception_ptr error = nullptr;
+};
+
+/// Global inflight chunk counter shared by all scalar index ReadEntryStream
+/// calls. Limits total memory used by in-flight chunks across all concurrent
+/// index loads.
+///
+/// Usage:
+///   - Call Acquire() to block until a slot is available (for initial fill).
+///   - Call TryAcquire() for non-blocking attempt (for replenish in slide loop).
+///   - Call Release() after the chunk has been consumed (callback done).
+///   - Inflight slots are bounded by pool_size * kStreamChannelCapacityMultiplier.
+///
+/// Capacity is derived once from the HIGH-priority pool on first use. Streams
+/// that submit to a smaller pool (LOW/MIDDLE) share the same budget; they may
+/// therefore keep fewer slots in flight than the budget allows, which only
+/// under-utilizes the bound rather than violating it. The singleton is
+/// process-wide, so concurrent streams at any priority contend on the same
+/// counter — the practical ceiling is HIGH pool size regardless of the pool
+/// actually used by a given caller.
+class ChunkInflightBudget {
+ public:
+    static ChunkInflightBudget&
+    GetInstance() {
+        static ChunkInflightBudget instance;
+        return instance;
+    }
+
+    /// Block until a slot is available. Uses condition_variable for efficient
+    /// waiting. Safe to call when the calling thread has no inflight tasks
+    /// (no risk of deadlock with channel pop).
+    void
+    Acquire() {
+        std::unique_lock<std::mutex> lock(mu_);
+        cv_.wait(lock, [this] { return inflight_ < max_inflight_; });
+        inflight_++;
+    }
+
+    /// Try to claim a slot. Returns true if under budget.
+    /// Used in the slide loop where blocking could cause deadlock.
+    bool
+    TryAcquire() {
+        std::lock_guard<std::mutex> lock(mu_);
+        if (inflight_ < max_inflight_) {
+            inflight_++;
+            return true;
+        }
+        return false;
+    }
+
+    void
+    Release() {
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            inflight_--;
+        }
+        cv_.notify_one();
+    }
+
+    size_t
+    MaxInflight() const {
+        return max_inflight_;
+    }
+
+ private:
+    ChunkInflightBudget() {
+        auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::HIGH);
+        max_inflight_ = static_cast<size_t>(pool.GetMaxThreadNum() *
+                                            kStreamChannelCapacityMultiplier);
+        if (max_inflight_ == 0) {
+            max_inflight_ = 1;
+        }
+    }
+
+    std::mutex mu_;
+    std::condition_variable cv_;
+    size_t inflight_{0};
+    size_t max_inflight_;
+};
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/ChunkStreamUtils.h
+++ b/internal/core/src/storage/ChunkStreamUtils.h
@@ -25,15 +25,21 @@
 #include <mutex>
 #include <vector>
 
-#include "storage/ThreadPools.h"
+#include "common/Common.h"
 
 namespace milvus::storage {
 
-/// Default chunk size for ReadEntryStream (2 MB).
-constexpr size_t kDefaultStreamChunkSize = 2 * 1024 * 1024;
+inline size_t
+DefaultStreamChunkSize() {
+    auto chunk_size = milvus::INDEX_ENTRY_STREAM_CHUNK_SIZE.load();
+    return chunk_size > 0 ? static_cast<size_t>(chunk_size) : 1;
+}
 
-/// Budget multiplier relative to thread pool size.
-constexpr double kScalarIndexChunkBudgetMultiplier = 1.5;
+inline double
+ScalarIndexChunkBudgetRatio() {
+    auto ratio = milvus::SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.load();
+    return ratio > 0 ? ratio : 1.0;
+}
 
 /// A chunk downloaded from a V3 entry, carrying a sequence number for
 /// reordering on the consumer side. `error` carries an exception captured in
@@ -108,11 +114,11 @@ class TransientMemoryBudget {
 
     static size_t
     DefaultScalarIndexChunkBudgetBytes() {
-        auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::HIGH);
-        auto capacity = static_cast<size_t>(pool.GetMaxThreadNum() *
-                                            kScalarIndexChunkBudgetMultiplier) *
-                        kDefaultStreamChunkSize;
-        return std::max<size_t>(capacity, kDefaultStreamChunkSize);
+        auto core_num = std::max(1, milvus::CPU_NUM);
+        auto capacity =
+            static_cast<size_t>(core_num * ScalarIndexChunkBudgetRatio()) *
+            DefaultStreamChunkSize();
+        return std::max<size_t>(capacity, DefaultStreamChunkSize());
     }
 
     bool

--- a/internal/core/src/storage/ChunkStreamUtils.h
+++ b/internal/core/src/storage/ChunkStreamUtils.h
@@ -26,13 +26,15 @@
 #include <vector>
 
 #include "common/Common.h"
+#include "common/EasyAssert.h"
 
 namespace milvus::storage {
 
+constexpr size_t kMinStreamChunkSize = 64 * 1024;
+
 inline size_t
 DefaultStreamChunkSize() {
-    auto chunk_size = milvus::INDEX_ENTRY_STREAM_CHUNK_SIZE.load();
-    return chunk_size > 0 ? static_cast<size_t>(chunk_size) : 1;
+    return DEFAULT_INDEX_FILE_SLICE_SIZE;
 }
 
 inline double
@@ -41,11 +43,9 @@ ScalarIndexChunkBudgetRatio() {
     return ratio > 0 ? ratio : 1.0;
 }
 
-/// A chunk downloaded from a V3 entry, carrying a sequence number for
-/// reordering on the consumer side. `error` carries an exception captured in
-/// the producer task so the consumer can rethrow instead of hanging on pop.
+/// A chunk downloaded from a V3 entry. `error` carries an exception captured in
+/// the producer task so the consumer can rethrow instead of hanging.
 struct ChunkResult {
-    size_t seq{0};
     size_t budget_bytes{0};
     std::vector<uint8_t> data;
     std::exception_ptr error = nullptr;
@@ -93,11 +93,12 @@ class TransientMemoryBudget {
     Release(size_t bytes) {
         {
             std::lock_guard<std::mutex> lock(mu_);
-            if (bytes >= inflight_bytes_) {
-                inflight_bytes_ = 0;
-            } else {
-                inflight_bytes_ -= bytes;
-            }
+            AssertInfo(bytes <= inflight_bytes_,
+                       "Transient memory budget over-release: release {}, "
+                       "inflight {}",
+                       bytes,
+                       inflight_bytes_);
+            inflight_bytes_ -= bytes;
         }
         cv_.notify_all();
     }

--- a/internal/core/src/storage/ChunkStreamUtils.h
+++ b/internal/core/src/storage/ChunkStreamUtils.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <atomic>
+#include <algorithm>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -32,94 +32,102 @@ namespace milvus::storage {
 /// Default chunk size for ReadEntryStream (2 MB).
 constexpr size_t kDefaultStreamChunkSize = 2 * 1024 * 1024;
 
-/// Capacity multiplier relative to thread pool size.
-/// Matches the kChannelCapacityMultiplier used by ManifestGroupTranslator.
-constexpr double kStreamChannelCapacityMultiplier = 1.5;
+/// Budget multiplier relative to thread pool size.
+constexpr double kScalarIndexChunkBudgetMultiplier = 1.5;
 
 /// A chunk downloaded from a V3 entry, carrying a sequence number for
 /// reordering on the consumer side. `error` carries an exception captured in
 /// the producer task so the consumer can rethrow instead of hanging on pop.
 struct ChunkResult {
-    size_t seq;
+    size_t seq{0};
+    size_t budget_bytes{0};
     std::vector<uint8_t> data;
     std::exception_ptr error = nullptr;
 };
 
-/// Global inflight chunk counter shared by all scalar index ReadEntryStream
-/// calls. Limits total memory used by in-flight chunks across all concurrent
-/// index loads.
+/// Byte budget for transient data that has been submitted for async work but
+/// has not been consumed yet.
 ///
 /// Usage:
-///   - Call Acquire() to block until a slot is available (for initial fill).
-///   - Call TryAcquire() for non-blocking attempt (for replenish in slide loop).
-///   - Call Release() after the chunk has been consumed (callback done).
-///   - Inflight slots are bounded by pool_size * kStreamChannelCapacityMultiplier.
-///
-/// Capacity is derived once from the HIGH-priority pool on first use. Streams
-/// that submit to a smaller pool (LOW/MIDDLE) share the same budget; they may
-/// therefore keep fewer slots in flight than the budget allows, which only
-/// under-utilizes the bound rather than violating it. The singleton is
-/// process-wide, so concurrent streams at any priority contend on the same
-/// counter — the practical ceiling is HIGH pool size regardless of the pool
-/// actually used by a given caller.
-class ChunkInflightBudget {
+///   - Call Acquire(bytes) to block until budget is available.
+///   - Call TryAcquire(bytes) for non-blocking replenish in slide loops.
+///   - Call Release(bytes) after the transient data has been consumed.
+///   - Oversized requests are allowed to run exclusively to guarantee progress.
+class TransientMemoryBudget {
  public:
-    static ChunkInflightBudget&
-    GetInstance() {
-        static ChunkInflightBudget instance;
+    static TransientMemoryBudget&
+    GetScalarIndexChunkBudget() {
+        static TransientMemoryBudget instance(
+            DefaultScalarIndexChunkBudgetBytes());
         return instance;
     }
 
-    /// Block until a slot is available. Uses condition_variable for efficient
-    /// waiting. Safe to call when the calling thread has no inflight tasks
-    /// (no risk of deadlock with channel pop).
+    /// Block until enough budget is available. Safe to call when the calling
+    /// thread has no inflight tasks (no risk of deadlock with channel pop).
     void
-    Acquire() {
+    Acquire(size_t bytes) {
         std::unique_lock<std::mutex> lock(mu_);
-        cv_.wait(lock, [this] { return inflight_ < max_inflight_; });
-        inflight_++;
+        cv_.wait(lock, [this, bytes] { return CanAcquireLocked(bytes); });
+        inflight_bytes_ += bytes;
     }
 
-    /// Try to claim a slot. Returns true if under budget.
+    /// Try to claim budget. Returns true if under budget.
     /// Used in the slide loop where blocking could cause deadlock.
     bool
-    TryAcquire() {
+    TryAcquire(size_t bytes) {
         std::lock_guard<std::mutex> lock(mu_);
-        if (inflight_ < max_inflight_) {
-            inflight_++;
+        if (CanAcquireLocked(bytes)) {
+            inflight_bytes_ += bytes;
             return true;
         }
         return false;
     }
 
     void
-    Release() {
+    Release(size_t bytes) {
         {
             std::lock_guard<std::mutex> lock(mu_);
-            inflight_--;
+            if (bytes >= inflight_bytes_) {
+                inflight_bytes_ = 0;
+            } else {
+                inflight_bytes_ -= bytes;
+            }
         }
-        cv_.notify_one();
+        cv_.notify_all();
     }
 
     size_t
-    MaxInflight() const {
-        return max_inflight_;
+    CapacityBytes() const {
+        return capacity_bytes_;
     }
 
  private:
-    ChunkInflightBudget() {
+    explicit TransientMemoryBudget(size_t capacity_bytes)
+        : capacity_bytes_(std::max<size_t>(capacity_bytes, 1)) {
+    }
+
+    static size_t
+    DefaultScalarIndexChunkBudgetBytes() {
         auto& pool = ThreadPools::GetThreadPool(ThreadPoolPriority::HIGH);
-        max_inflight_ = static_cast<size_t>(pool.GetMaxThreadNum() *
-                                            kStreamChannelCapacityMultiplier);
-        if (max_inflight_ == 0) {
-            max_inflight_ = 1;
+        auto capacity = static_cast<size_t>(pool.GetMaxThreadNum() *
+                                            kScalarIndexChunkBudgetMultiplier) *
+                        kDefaultStreamChunkSize;
+        return std::max<size_t>(capacity, kDefaultStreamChunkSize);
+    }
+
+    bool
+    CanAcquireLocked(size_t bytes) const {
+        if (bytes > capacity_bytes_) {
+            return inflight_bytes_ == 0;
         }
+        return inflight_bytes_ <= capacity_bytes_ &&
+               bytes <= capacity_bytes_ - inflight_bytes_;
     }
 
     std::mutex mu_;
     std::condition_variable cv_;
-    size_t inflight_{0};
-    size_t max_inflight_;
+    size_t inflight_bytes_{0};
+    size_t capacity_bytes_;
 };
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -38,8 +38,8 @@ DefaultStreamSliceSize() {
 }
 
 inline double
-ScalarIndexStreamBudgetRatio() {
-    auto ratio = milvus::SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.load();
+StreamBudgetRatio() {
+    auto ratio = milvus::ENTRY_STREAM_BUDGET_RATIO.load();
     return ratio > 0 ? ratio : 1.0;
 }
 
@@ -62,7 +62,7 @@ struct StreamSliceResult {
 class TransientMemoryBudget {
  public:
     static TransientMemoryBudget&
-    GetScalarIndexStreamBudget() {
+    GetEntryStreamBudget() {
         static TransientMemoryBudget instance;
         return instance;
     }
@@ -104,7 +104,7 @@ class TransientMemoryBudget {
 
     size_t
     CapacityBytes() const {
-        return ScalarIndexStreamBudgetBytes();
+        return EntryStreamBudgetBytes();
     }
 
     void
@@ -116,11 +116,10 @@ class TransientMemoryBudget {
     TransientMemoryBudget() = default;
 
     static size_t
-    ScalarIndexStreamBudgetBytes() {
+    EntryStreamBudgetBytes() {
         auto core_num = std::max(1, milvus::CPU_NUM);
-        auto capacity =
-            static_cast<size_t>(core_num * ScalarIndexStreamBudgetRatio()) *
-            DefaultStreamSliceSize();
+        auto capacity = static_cast<size_t>(core_num * StreamBudgetRatio()) *
+                        DefaultStreamSliceSize();
         return std::max<size_t>(capacity, DefaultStreamSliceSize());
     }
 

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -63,8 +63,7 @@ class TransientMemoryBudget {
  public:
     static TransientMemoryBudget&
     GetScalarIndexStreamBudget() {
-        static TransientMemoryBudget instance(
-            DefaultScalarIndexSliceBudgetBytes());
+        static TransientMemoryBudget instance;
         return instance;
     }
 
@@ -105,16 +104,19 @@ class TransientMemoryBudget {
 
     size_t
     CapacityBytes() const {
-        return capacity_bytes_;
+        return ScalarIndexStreamBudgetBytes();
+    }
+
+    void
+    NotifyCapacityUpdated() {
+        cv_.notify_all();
     }
 
  private:
-    explicit TransientMemoryBudget(size_t capacity_bytes)
-        : capacity_bytes_(std::max<size_t>(capacity_bytes, 1)) {
-    }
+    TransientMemoryBudget() = default;
 
     static size_t
-    DefaultScalarIndexSliceBudgetBytes() {
+    ScalarIndexStreamBudgetBytes() {
         auto core_num = std::max(1, milvus::CPU_NUM);
         auto capacity =
             static_cast<size_t>(core_num * ScalarIndexStreamBudgetRatio()) *
@@ -124,17 +126,17 @@ class TransientMemoryBudget {
 
     bool
     CanAcquireLocked(size_t bytes) const {
-        if (bytes > capacity_bytes_) {
+        auto capacity_bytes = CapacityBytes();
+        if (bytes > capacity_bytes) {
             return inflight_bytes_ == 0;
         }
-        return inflight_bytes_ <= capacity_bytes_ &&
-               bytes <= capacity_bytes_ - inflight_bytes_;
+        return inflight_bytes_ <= capacity_bytes &&
+               bytes <= capacity_bytes - inflight_bytes_;
     }
 
     std::mutex mu_;
     std::condition_variable cv_;
     size_t inflight_bytes_{0};
-    size_t capacity_bytes_;
 };
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -30,22 +30,22 @@
 
 namespace milvus::storage {
 
-constexpr size_t kMinStreamChunkSize = 64 * 1024;
+constexpr size_t kMinStreamSliceSize = 64 * 1024;
 
 inline size_t
-DefaultStreamChunkSize() {
+DefaultStreamSliceSize() {
     return DEFAULT_INDEX_FILE_SLICE_SIZE;
 }
 
 inline double
-ScalarIndexChunkBudgetRatio() {
+ScalarIndexStreamBudgetRatio() {
     auto ratio = milvus::SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.load();
     return ratio > 0 ? ratio : 1.0;
 }
 
-/// A chunk downloaded from a V3 entry. `error` carries an exception captured in
+/// A slice read from a V3 entry. `error` carries an exception captured in
 /// the producer task so the consumer can rethrow instead of hanging.
-struct ChunkResult {
+struct StreamSliceResult {
     size_t budget_bytes{0};
     std::vector<uint8_t> data;
     std::exception_ptr error = nullptr;
@@ -56,15 +56,15 @@ struct ChunkResult {
 ///
 /// Usage:
 ///   - Call Acquire(bytes) to block until budget is available.
-///   - Call TryAcquire(bytes) for non-blocking replenish in slide loops.
+///   - Call TryAcquire(bytes) for non-blocking replenish in refill loops.
 ///   - Call Release(bytes) after the transient data has been consumed.
 ///   - Oversized requests are allowed to run exclusively to guarantee progress.
 class TransientMemoryBudget {
  public:
     static TransientMemoryBudget&
-    GetScalarIndexChunkBudget() {
+    GetScalarIndexStreamBudget() {
         static TransientMemoryBudget instance(
-            DefaultScalarIndexChunkBudgetBytes());
+            DefaultScalarIndexSliceBudgetBytes());
         return instance;
     }
 
@@ -78,7 +78,7 @@ class TransientMemoryBudget {
     }
 
     /// Try to claim budget. Returns true if under budget.
-    /// Used in the slide loop where blocking could cause deadlock.
+    /// Used in the refill loop where blocking could cause deadlock.
     bool
     TryAcquire(size_t bytes) {
         std::lock_guard<std::mutex> lock(mu_);
@@ -114,12 +114,12 @@ class TransientMemoryBudget {
     }
 
     static size_t
-    DefaultScalarIndexChunkBudgetBytes() {
+    DefaultScalarIndexSliceBudgetBytes() {
         auto core_num = std::max(1, milvus::CPU_NUM);
         auto capacity =
-            static_cast<size_t>(core_num * ScalarIndexChunkBudgetRatio()) *
-            DefaultStreamChunkSize();
-        return std::max<size_t>(capacity, DefaultStreamChunkSize());
+            static_cast<size_t>(core_num * ScalarIndexStreamBudgetRatio()) *
+            DefaultStreamSliceSize();
+        return std::max<size_t>(capacity, DefaultStreamSliceSize());
     }
 
     bool

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -23,13 +23,17 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <future>
+#include <map>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "common/Channel.h"
 #include "common/EasyAssert.h"
 #include "nlohmann/json.hpp"
+#include "storage/ChunkStreamUtils.h"
 #include "storage/Crc32cUtil.h"
 #include "storage/PluginLoader.h"
 
@@ -547,6 +551,297 @@ IndexEntryReader::ReadEntriesToFiles(
         close_all_fds();
         throw;
     }
+}
+
+size_t
+IndexEntryReader::GetEntrySize(const std::string& name) const {
+    auto it = entry_index_.find(name);
+    AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
+    if (it->second.encrypted) {
+        return it->second.enc.original_size;
+    }
+    return it->second.plain.size;
+}
+
+void
+IndexEntryReader::ReadEntryStream(
+    const std::string& name,
+    std::function<void(const uint8_t* data, size_t len)> callback,
+    size_t chunk_size) {
+    auto it = entry_index_.find(name);
+    AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
+    const auto& meta = it->second;
+
+    if (meta.encrypted) {
+        ReadEncryptedEntryStream(meta.enc, callback);
+    } else {
+        ReadPlainEntryStream(meta.plain, callback, chunk_size);
+    }
+}
+
+void
+IndexEntryReader::ReadPlainEntryStream(
+    const PlainEntryMeta& pm,
+    const std::function<void(const uint8_t* data, size_t len)>& callback,
+    size_t chunk_size) {
+    size_t num_chunks = (pm.size + chunk_size - 1) / chunk_size;
+    if (num_chunks == 0) {
+        return;
+    }
+
+    auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto& budget = ChunkInflightBudget::GetInstance();
+    auto channel = std::make_shared<Channel<std::shared_ptr<ChunkResult>>>(
+        budget.MaxInflight());
+
+    size_t next_submit = 0;
+    size_t next_consume = 0;
+    size_t local_inflight = 0;
+
+    auto submitOne = [&]() {
+        size_t seq = next_submit;
+        size_t off = seq * chunk_size;
+        size_t len = std::min<size_t>(chunk_size, pm.size - off);
+        size_t src = pm.offset + off;
+
+        pool.Submit([this, channel, seq, src, len]() {
+            auto r = std::make_shared<ChunkResult>();
+            r->seq = seq;
+            try {
+                r->data.resize(len);
+                size_t n = input_->ReadAt(
+                    r->data.data(), MILVUS_V3_MAGIC_SIZE + src, len);
+                AssertInfo(n == len, "Failed to read entry chunk");
+            } catch (...) {
+                r->error = std::current_exception();
+            }
+            channel->push(std::move(r));
+        });
+
+        next_submit++;
+        local_inflight++;
+    };
+
+    // 1. Fill window: block for first slot, then try-acquire remaining.
+    if (next_submit < num_chunks) {
+        budget.Acquire();
+        submitOne();
+    }
+    while (next_submit < num_chunks && budget.TryAcquire()) {
+        submitOne();
+    }
+
+    // 2. Slide: consume one, submit next
+    uint32_t running_crc = 0;
+    bool first = true;
+    std::map<size_t, std::shared_ptr<ChunkResult>> reorder_buf;
+    std::exception_ptr first_error = nullptr;
+
+    auto deliverChunk = [&](const std::shared_ptr<ChunkResult>& c) {
+        uint32_t chunk_crc = Crc32cValue(c->data.data(), c->data.size());
+        running_crc =
+            first ? chunk_crc
+                  : Crc32cCombine(running_crc, chunk_crc, c->data.size());
+        first = false;
+        callback(c->data.data(), c->data.size());
+        budget.Release();
+        next_consume++;
+        local_inflight--;
+    };
+
+    while (next_consume < num_chunks && local_inflight > 0) {
+        std::shared_ptr<ChunkResult> chunk;
+        bool ok = channel->pop(chunk);
+        AssertInfo(ok, "Channel closed unexpectedly");
+
+        if (chunk->error) {
+            if (!first_error) {
+                first_error = chunk->error;
+            }
+            budget.Release();
+            local_inflight--;
+            continue;
+        }
+
+        if (first_error) {
+            // Drain mode: release slot, do not deliver or submit more.
+            budget.Release();
+            local_inflight--;
+            continue;
+        }
+
+        if (chunk->seq == next_consume) {
+            deliverChunk(chunk);
+        } else {
+            reorder_buf[chunk->seq] = std::move(chunk);
+        }
+
+        // Deliver any consecutive buffered chunks
+        while (reorder_buf.count(next_consume)) {
+            auto node = reorder_buf.extract(next_consume);
+            deliverChunk(node.mapped());
+        }
+
+        // Replenish: try non-blocking first
+        while (next_submit < num_chunks && budget.TryAcquire()) {
+            submitOne();
+        }
+
+        // If nothing inflight but still work to do, must block-acquire
+        // to guarantee progress. Safe because channel is empty here.
+        if (local_inflight == 0 && next_submit < num_chunks) {
+            budget.Acquire();
+            submitOne();
+        }
+    }
+
+    // Release budget held by any chunks still sitting in reorder_buf
+    // (possible when an error shortened the normal delivery path).
+    for (size_t i = 0; i < reorder_buf.size(); ++i) {
+        budget.Release();
+    }
+    local_inflight -= reorder_buf.size();
+    reorder_buf.clear();
+
+    if (first_error) {
+        std::rethrow_exception(first_error);
+    }
+
+    AssertInfo(running_crc == pm.crc32,
+               "CRC-32C mismatch in stream read: expected {}, got {}",
+               Crc32cToHex(pm.crc32),
+               Crc32cToHex(running_crc));
+}
+
+void
+IndexEntryReader::ReadEncryptedEntryStream(
+    const EncryptedEntryMeta& em,
+    const std::function<void(const uint8_t* data, size_t len)>& callback) {
+    size_t num_slices = em.slices.size();
+    if (num_slices == 0) {
+        return;
+    }
+
+    auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto& budget = ChunkInflightBudget::GetInstance();
+    auto channel = std::make_shared<Channel<std::shared_ptr<ChunkResult>>>(
+        budget.MaxInflight());
+
+    size_t next_submit = 0;
+    size_t next_consume = 0;
+    size_t local_inflight = 0;
+
+    auto submitOne = [&]() {
+        size_t seq = next_submit;
+        const auto& slice = em.slices[seq];
+
+        pool.Submit([this, channel, seq, slice]() {
+            auto r = std::make_shared<ChunkResult>();
+            r->seq = seq;
+            try {
+                std::vector<uint8_t> cipher(slice.size);
+                size_t n = input_->ReadAt(cipher.data(),
+                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
+                                          slice.size);
+                AssertInfo(n == slice.size, "Failed to read encrypted slice");
+
+                auto dec =
+                    cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
+                auto plain = dec->Decrypt(cipher.data(), cipher.size());
+
+                r->data.assign(reinterpret_cast<const uint8_t*>(plain.data()),
+                               reinterpret_cast<const uint8_t*>(plain.data()) +
+                                   plain.size());
+            } catch (...) {
+                r->error = std::current_exception();
+            }
+            channel->push(std::move(r));
+        });
+
+        next_submit++;
+        local_inflight++;
+    };
+
+    // Fill window: block for first slot, then try-acquire remaining
+    if (next_submit < num_slices) {
+        budget.Acquire();
+        submitOne();
+    }
+    while (next_submit < num_slices && budget.TryAcquire()) {
+        submitOne();
+    }
+
+    // Slide: consume + replenish
+    uint32_t running_crc = 0;
+    bool first = true;
+    std::map<size_t, std::shared_ptr<ChunkResult>> reorder_buf;
+    std::exception_ptr first_error = nullptr;
+
+    auto deliverChunk = [&](const std::shared_ptr<ChunkResult>& c) {
+        uint32_t chunk_crc = Crc32cValue(c->data.data(), c->data.size());
+        running_crc =
+            first ? chunk_crc
+                  : Crc32cCombine(running_crc, chunk_crc, c->data.size());
+        first = false;
+        callback(c->data.data(), c->data.size());
+        budget.Release();
+        next_consume++;
+        local_inflight--;
+    };
+
+    while (next_consume < num_slices && local_inflight > 0) {
+        std::shared_ptr<ChunkResult> chunk;
+        bool ok = channel->pop(chunk);
+        AssertInfo(ok, "Channel closed unexpectedly");
+
+        if (chunk->error) {
+            if (!first_error) {
+                first_error = chunk->error;
+            }
+            budget.Release();
+            local_inflight--;
+            continue;
+        }
+
+        if (first_error) {
+            budget.Release();
+            local_inflight--;
+            continue;
+        }
+
+        if (chunk->seq == next_consume) {
+            deliverChunk(chunk);
+        } else {
+            reorder_buf[chunk->seq] = std::move(chunk);
+        }
+
+        while (reorder_buf.count(next_consume)) {
+            auto node = reorder_buf.extract(next_consume);
+            deliverChunk(node.mapped());
+        }
+
+        while (next_submit < num_slices && budget.TryAcquire()) {
+            submitOne();
+        }
+
+        if (local_inflight == 0 && next_submit < num_slices) {
+            budget.Acquire();
+            submitOne();
+        }
+    }
+
+    for (size_t i = 0; i < reorder_buf.size(); ++i) {
+        budget.Release();
+    }
+    local_inflight -= reorder_buf.size();
+    reorder_buf.clear();
+
+    if (first_error) {
+        std::rethrow_exception(first_error);
+    }
+
+    AssertInfo(running_crc == em.crc32,
+               "CRC-32C mismatch in encrypted stream read");
 }
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -42,6 +42,7 @@ namespace milvus::storage {
 namespace {
 
 using ChunkLoader = std::function<std::vector<uint8_t>(size_t seq)>;
+using ChunkBudgetBytes = std::function<size_t(size_t seq)>;
 
 class FutureWaiter {
  public:
@@ -68,15 +69,15 @@ ReadOrderedEntryStream(
     const std::string& crc_error_message,
     ThreadPoolPriority priority,
     const std::function<void(const uint8_t* data, size_t len)>& callback,
+    const ChunkBudgetBytes& chunk_budget_bytes,
     const ChunkLoader& load_chunk) {
     if (num_chunks == 0) {
         return;
     }
 
     auto& pool = ThreadPools::GetThreadPool(priority);
-    auto& budget = ChunkInflightBudget::GetInstance();
-    auto channel = std::make_shared<Channel<std::shared_ptr<ChunkResult>>>(
-        budget.MaxInflight());
+    auto& budget = TransientMemoryBudget::GetScalarIndexChunkBudget();
+    auto channel = std::make_shared<Channel<std::shared_ptr<ChunkResult>>>();
 
     std::vector<std::future<void>> futures;
     futures.reserve(num_chunks);
@@ -91,8 +92,8 @@ ReadOrderedEntryStream(
     std::exception_ptr first_error = nullptr;
 
     auto releaseBuffered = [&]() {
-        for (size_t i = 0; i < reorder_buf.size(); ++i) {
-            budget.Release();
+        for (const auto& [_, chunk] : reorder_buf) {
+            budget.Release(chunk->budget_bytes);
             local_inflight--;
         }
         reorder_buf.clear();
@@ -107,20 +108,23 @@ ReadOrderedEntryStream(
 
     auto submitOne = [&]() -> bool {
         size_t seq = next_submit;
+        size_t budget_bytes = chunk_budget_bytes(seq);
         try {
-            auto future = pool.Submit([channel, load_chunk, seq]() {
-                auto r = std::make_shared<ChunkResult>();
-                r->seq = seq;
-                try {
-                    r->data = load_chunk(seq);
-                } catch (...) {
-                    r->error = std::current_exception();
-                }
-                channel->push(std::move(r));
-            });
+            auto future =
+                pool.Submit([channel, load_chunk, seq, budget_bytes]() {
+                    auto r = std::make_shared<ChunkResult>();
+                    r->seq = seq;
+                    r->budget_bytes = budget_bytes;
+                    try {
+                        r->data = load_chunk(seq);
+                    } catch (...) {
+                        r->error = std::current_exception();
+                    }
+                    channel->push(std::move(r));
+                });
             futures.push_back(std::move(future));
         } catch (...) {
-            budget.Release();
+            budget.Release(budget_bytes);
             rememberError(std::current_exception());
             return false;
         }
@@ -144,7 +148,7 @@ ReadOrderedEntryStream(
             }
         }
 
-        budget.Release();
+        budget.Release(c->budget_bytes);
         next_consume++;
         local_inflight--;
 
@@ -156,10 +160,11 @@ ReadOrderedEntryStream(
     };
 
     if (next_submit < num_chunks) {
-        budget.Acquire();
+        budget.Acquire(chunk_budget_bytes(next_submit));
         submitOne();
     }
-    while (!first_error && next_submit < num_chunks && budget.TryAcquire()) {
+    while (!first_error && next_submit < num_chunks &&
+           budget.TryAcquire(chunk_budget_bytes(next_submit))) {
         submitOne();
     }
 
@@ -175,13 +180,13 @@ ReadOrderedEntryStream(
 
         if (chunk->error) {
             rememberError(chunk->error);
-            budget.Release();
+            budget.Release(chunk->budget_bytes);
             local_inflight--;
             continue;
         }
 
         if (first_error) {
-            budget.Release();
+            budget.Release(chunk->budget_bytes);
             local_inflight--;
             continue;
         }
@@ -202,12 +207,12 @@ ReadOrderedEntryStream(
         }
 
         while (!first_error && next_submit < num_chunks &&
-               budget.TryAcquire()) {
+               budget.TryAcquire(chunk_budget_bytes(next_submit))) {
             submitOne();
         }
 
         if (!first_error && local_inflight == 0 && next_submit < num_chunks) {
-            budget.Acquire();
+            budget.Acquire(chunk_budget_bytes(next_submit));
             submitOne();
         }
     }
@@ -781,10 +786,14 @@ IndexEntryReader::ReadPlainEntryStream(
     const std::function<void(const uint8_t* data, size_t len)>& callback,
     size_t chunk_size) {
     size_t num_chunks = (pm.size + chunk_size - 1) / chunk_size;
-    auto input = input_;
-    auto load_chunk = [input, pm, chunk_size](size_t seq) {
+    auto chunkBytes = [pm, chunk_size](size_t seq) {
         size_t off = seq * chunk_size;
-        size_t len = std::min<size_t>(chunk_size, pm.size - off);
+        return std::min<size_t>(chunk_size, pm.size - off);
+    };
+    auto input = input_;
+    auto load_chunk = [input, pm, chunk_size, chunkBytes](size_t seq) {
+        size_t off = seq * chunk_size;
+        size_t len = chunkBytes(seq);
         size_t src = pm.offset + off;
         std::vector<uint8_t> data(len);
         size_t n = input->ReadAt(data.data(), MILVUS_V3_MAGIC_SIZE + src, len);
@@ -799,6 +808,7 @@ IndexEntryReader::ReadPlainEntryStream(
                     Crc32cToHex(pm.crc32)),
         priority_,
         callback,
+        chunkBytes,
         load_chunk);
 }
 
@@ -807,6 +817,7 @@ IndexEntryReader::ReadEncryptedEntryStream(
     const EncryptedEntryMeta& em,
     const std::function<void(const uint8_t* data, size_t len)>& callback) {
     size_t num_slices = em.slices.size();
+    auto sliceBudgetBytes = [&](size_t seq) { return em.slices[seq].size; };
     auto input = input_;
     auto cipher_plugin = cipher_plugin_;
     int64_t ez_id = ez_id_;
@@ -832,6 +843,7 @@ IndexEntryReader::ReadEncryptedEntryStream(
                            "CRC-32C mismatch in encrypted stream read",
                            priority_,
                            callback,
+                           sliceBudgetBytes,
                            load_chunk);
 }
 

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -26,6 +26,7 @@
 #include <functional>
 #include <future>
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -38,6 +39,201 @@
 #include "storage/PluginLoader.h"
 
 namespace milvus::storage {
+namespace {
+
+using ChunkLoader = std::function<std::vector<uint8_t>(size_t seq)>;
+
+class FutureWaiter {
+ public:
+    explicit FutureWaiter(std::vector<std::future<void>>& futures)
+        : futures_(futures) {
+    }
+
+    ~FutureWaiter() {
+        for (auto& future : futures_) {
+            if (future.valid()) {
+                future.wait();
+            }
+        }
+    }
+
+ private:
+    std::vector<std::future<void>>& futures_;
+};
+
+void
+ReadOrderedEntryStream(
+    size_t num_chunks,
+    uint32_t expected_crc,
+    const std::string& crc_error_message,
+    ThreadPoolPriority priority,
+    const std::function<void(const uint8_t* data, size_t len)>& callback,
+    const ChunkLoader& load_chunk) {
+    if (num_chunks == 0) {
+        return;
+    }
+
+    auto& pool = ThreadPools::GetThreadPool(priority);
+    auto& budget = ChunkInflightBudget::GetInstance();
+    auto channel = std::make_shared<Channel<std::shared_ptr<ChunkResult>>>(
+        budget.MaxInflight());
+
+    std::vector<std::future<void>> futures;
+    futures.reserve(num_chunks);
+    FutureWaiter wait_on_exit(futures);
+
+    size_t next_submit = 0;
+    size_t next_consume = 0;
+    size_t local_inflight = 0;
+    uint32_t running_crc = 0;
+    bool first = true;
+    std::map<size_t, std::shared_ptr<ChunkResult>> reorder_buf;
+    std::exception_ptr first_error = nullptr;
+
+    auto releaseBuffered = [&]() {
+        for (size_t i = 0; i < reorder_buf.size(); ++i) {
+            budget.Release();
+            local_inflight--;
+        }
+        reorder_buf.clear();
+    };
+
+    auto rememberError = [&](std::exception_ptr error) {
+        if (!first_error) {
+            first_error = std::move(error);
+        }
+        releaseBuffered();
+    };
+
+    auto submitOne = [&]() -> bool {
+        size_t seq = next_submit;
+        try {
+            auto future = pool.Submit([channel, load_chunk, seq]() {
+                auto r = std::make_shared<ChunkResult>();
+                r->seq = seq;
+                try {
+                    r->data = load_chunk(seq);
+                } catch (...) {
+                    r->error = std::current_exception();
+                }
+                channel->push(std::move(r));
+            });
+            futures.push_back(std::move(future));
+        } catch (...) {
+            budget.Release();
+            rememberError(std::current_exception());
+            return false;
+        }
+
+        next_submit++;
+        local_inflight++;
+        return true;
+    };
+
+    auto deliverChunk = [&](const std::shared_ptr<ChunkResult>& c) -> bool {
+        try {
+            uint32_t chunk_crc = Crc32cValue(c->data.data(), c->data.size());
+            running_crc =
+                first ? chunk_crc
+                      : Crc32cCombine(running_crc, chunk_crc, c->data.size());
+            first = false;
+            callback(c->data.data(), c->data.size());
+        } catch (...) {
+            if (!first_error) {
+                first_error = std::current_exception();
+            }
+        }
+
+        budget.Release();
+        next_consume++;
+        local_inflight--;
+
+        if (first_error) {
+            releaseBuffered();
+            return false;
+        }
+        return true;
+    };
+
+    if (next_submit < num_chunks) {
+        budget.Acquire();
+        submitOne();
+    }
+    while (!first_error && next_submit < num_chunks && budget.TryAcquire()) {
+        submitOne();
+    }
+
+    while (local_inflight > 0) {
+        std::shared_ptr<ChunkResult> chunk;
+        try {
+            bool ok = channel->pop(chunk);
+            AssertInfo(ok, "Channel closed unexpectedly");
+        } catch (...) {
+            rememberError(std::current_exception());
+            break;
+        }
+
+        if (chunk->error) {
+            rememberError(chunk->error);
+            budget.Release();
+            local_inflight--;
+            continue;
+        }
+
+        if (first_error) {
+            budget.Release();
+            local_inflight--;
+            continue;
+        }
+
+        if (chunk->seq == next_consume) {
+            if (!deliverChunk(chunk)) {
+                continue;
+            }
+        } else {
+            reorder_buf[chunk->seq] = std::move(chunk);
+        }
+
+        while (!first_error && reorder_buf.count(next_consume)) {
+            auto node = reorder_buf.extract(next_consume);
+            if (!deliverChunk(node.mapped())) {
+                break;
+            }
+        }
+
+        while (!first_error && next_submit < num_chunks &&
+               budget.TryAcquire()) {
+            submitOne();
+        }
+
+        if (!first_error && local_inflight == 0 && next_submit < num_chunks) {
+            budget.Acquire();
+            submitOne();
+        }
+    }
+
+    releaseBuffered();
+
+    for (auto& future : futures) {
+        if (future.valid()) {
+            try {
+                future.get();
+            } catch (...) {
+                if (!first_error) {
+                    first_error = std::current_exception();
+                }
+            }
+        }
+    }
+
+    if (first_error) {
+        std::rethrow_exception(first_error);
+    }
+
+    AssertInfo(running_crc == expected_crc, crc_error_message);
+}
+
+}  // namespace
 
 std::unique_ptr<IndexEntryReader>
 IndexEntryReader::Open(std::shared_ptr<milvus::InputStream> input,
@@ -585,132 +781,25 @@ IndexEntryReader::ReadPlainEntryStream(
     const std::function<void(const uint8_t* data, size_t len)>& callback,
     size_t chunk_size) {
     size_t num_chunks = (pm.size + chunk_size - 1) / chunk_size;
-    if (num_chunks == 0) {
-        return;
-    }
-
-    auto& pool = ThreadPools::GetThreadPool(priority_);
-    auto& budget = ChunkInflightBudget::GetInstance();
-    auto channel = std::make_shared<Channel<std::shared_ptr<ChunkResult>>>(
-        budget.MaxInflight());
-
-    size_t next_submit = 0;
-    size_t next_consume = 0;
-    size_t local_inflight = 0;
-
-    auto submitOne = [&]() {
-        size_t seq = next_submit;
+    auto input = input_;
+    auto load_chunk = [input, pm, chunk_size](size_t seq) {
         size_t off = seq * chunk_size;
         size_t len = std::min<size_t>(chunk_size, pm.size - off);
         size_t src = pm.offset + off;
-
-        pool.Submit([this, channel, seq, src, len]() {
-            auto r = std::make_shared<ChunkResult>();
-            r->seq = seq;
-            try {
-                r->data.resize(len);
-                size_t n = input_->ReadAt(
-                    r->data.data(), MILVUS_V3_MAGIC_SIZE + src, len);
-                AssertInfo(n == len, "Failed to read entry chunk");
-            } catch (...) {
-                r->error = std::current_exception();
-            }
-            channel->push(std::move(r));
-        });
-
-        next_submit++;
-        local_inflight++;
+        std::vector<uint8_t> data(len);
+        size_t n = input->ReadAt(data.data(), MILVUS_V3_MAGIC_SIZE + src, len);
+        AssertInfo(n == len, "Failed to read entry chunk");
+        return data;
     };
 
-    // 1. Fill window: block for first slot, then try-acquire remaining.
-    if (next_submit < num_chunks) {
-        budget.Acquire();
-        submitOne();
-    }
-    while (next_submit < num_chunks && budget.TryAcquire()) {
-        submitOne();
-    }
-
-    // 2. Slide: consume one, submit next
-    uint32_t running_crc = 0;
-    bool first = true;
-    std::map<size_t, std::shared_ptr<ChunkResult>> reorder_buf;
-    std::exception_ptr first_error = nullptr;
-
-    auto deliverChunk = [&](const std::shared_ptr<ChunkResult>& c) {
-        uint32_t chunk_crc = Crc32cValue(c->data.data(), c->data.size());
-        running_crc =
-            first ? chunk_crc
-                  : Crc32cCombine(running_crc, chunk_crc, c->data.size());
-        first = false;
-        callback(c->data.data(), c->data.size());
-        budget.Release();
-        next_consume++;
-        local_inflight--;
-    };
-
-    while (next_consume < num_chunks && local_inflight > 0) {
-        std::shared_ptr<ChunkResult> chunk;
-        bool ok = channel->pop(chunk);
-        AssertInfo(ok, "Channel closed unexpectedly");
-
-        if (chunk->error) {
-            if (!first_error) {
-                first_error = chunk->error;
-            }
-            budget.Release();
-            local_inflight--;
-            continue;
-        }
-
-        if (first_error) {
-            // Drain mode: release slot, do not deliver or submit more.
-            budget.Release();
-            local_inflight--;
-            continue;
-        }
-
-        if (chunk->seq == next_consume) {
-            deliverChunk(chunk);
-        } else {
-            reorder_buf[chunk->seq] = std::move(chunk);
-        }
-
-        // Deliver any consecutive buffered chunks
-        while (reorder_buf.count(next_consume)) {
-            auto node = reorder_buf.extract(next_consume);
-            deliverChunk(node.mapped());
-        }
-
-        // Replenish: try non-blocking first
-        while (next_submit < num_chunks && budget.TryAcquire()) {
-            submitOne();
-        }
-
-        // If nothing inflight but still work to do, must block-acquire
-        // to guarantee progress. Safe because channel is empty here.
-        if (local_inflight == 0 && next_submit < num_chunks) {
-            budget.Acquire();
-            submitOne();
-        }
-    }
-
-    // Release budget held by any chunks still sitting in reorder_buf
-    // (possible when an error shortened the normal delivery path).
-    for (size_t i = 0; i < reorder_buf.size(); ++i) {
-        budget.Release();
-    }
-    local_inflight -= reorder_buf.size();
-    reorder_buf.clear();
-
-    if (first_error) {
-        std::rethrow_exception(first_error);
-    }
-
-    AssertInfo(running_crc == pm.crc32,
-               "CRC-32C mismatch in stream read: expected {}, got {}",
-               Crc32cToHex(pm.crc32),
-               Crc32cToHex(running_crc));
+    ReadOrderedEntryStream(
+        num_chunks,
+        pm.crc32,
+        fmt::format("CRC-32C mismatch in stream read: expected {}",
+                    Crc32cToHex(pm.crc32)),
+        priority_,
+        callback,
+        load_chunk);
 }
 
 void
@@ -718,130 +807,32 @@ IndexEntryReader::ReadEncryptedEntryStream(
     const EncryptedEntryMeta& em,
     const std::function<void(const uint8_t* data, size_t len)>& callback) {
     size_t num_slices = em.slices.size();
-    if (num_slices == 0) {
-        return;
-    }
+    auto input = input_;
+    auto cipher_plugin = cipher_plugin_;
+    int64_t ez_id = ez_id_;
+    int64_t collection_id = collection_id_;
+    auto edek = edek_;
+    auto load_chunk =
+        [input, cipher_plugin, ez_id, collection_id, edek, &em](size_t seq) {
+            const auto& slice = em.slices[seq];
+            std::vector<uint8_t> cipher(slice.size);
+            size_t n = input->ReadAt(
+                cipher.data(), MILVUS_V3_MAGIC_SIZE + slice.offset, slice.size);
+            AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
-    auto& pool = ThreadPools::GetThreadPool(priority_);
-    auto& budget = ChunkInflightBudget::GetInstance();
-    auto channel = std::make_shared<Channel<std::shared_ptr<ChunkResult>>>(
-        budget.MaxInflight());
+            auto dec = cipher_plugin->GetDecryptor(ez_id, collection_id, edek);
+            auto plain = dec->Decrypt(cipher.data(), cipher.size());
+            return std::vector<uint8_t>(
+                reinterpret_cast<const uint8_t*>(plain.data()),
+                reinterpret_cast<const uint8_t*>(plain.data()) + plain.size());
+        };
 
-    size_t next_submit = 0;
-    size_t next_consume = 0;
-    size_t local_inflight = 0;
-
-    auto submitOne = [&]() {
-        size_t seq = next_submit;
-        const auto& slice = em.slices[seq];
-
-        pool.Submit([this, channel, seq, slice]() {
-            auto r = std::make_shared<ChunkResult>();
-            r->seq = seq;
-            try {
-                std::vector<uint8_t> cipher(slice.size);
-                size_t n = input_->ReadAt(cipher.data(),
-                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
-                                          slice.size);
-                AssertInfo(n == slice.size, "Failed to read encrypted slice");
-
-                auto dec =
-                    cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
-                auto plain = dec->Decrypt(cipher.data(), cipher.size());
-
-                r->data.assign(reinterpret_cast<const uint8_t*>(plain.data()),
-                               reinterpret_cast<const uint8_t*>(plain.data()) +
-                                   plain.size());
-            } catch (...) {
-                r->error = std::current_exception();
-            }
-            channel->push(std::move(r));
-        });
-
-        next_submit++;
-        local_inflight++;
-    };
-
-    // Fill window: block for first slot, then try-acquire remaining
-    if (next_submit < num_slices) {
-        budget.Acquire();
-        submitOne();
-    }
-    while (next_submit < num_slices && budget.TryAcquire()) {
-        submitOne();
-    }
-
-    // Slide: consume + replenish
-    uint32_t running_crc = 0;
-    bool first = true;
-    std::map<size_t, std::shared_ptr<ChunkResult>> reorder_buf;
-    std::exception_ptr first_error = nullptr;
-
-    auto deliverChunk = [&](const std::shared_ptr<ChunkResult>& c) {
-        uint32_t chunk_crc = Crc32cValue(c->data.data(), c->data.size());
-        running_crc =
-            first ? chunk_crc
-                  : Crc32cCombine(running_crc, chunk_crc, c->data.size());
-        first = false;
-        callback(c->data.data(), c->data.size());
-        budget.Release();
-        next_consume++;
-        local_inflight--;
-    };
-
-    while (next_consume < num_slices && local_inflight > 0) {
-        std::shared_ptr<ChunkResult> chunk;
-        bool ok = channel->pop(chunk);
-        AssertInfo(ok, "Channel closed unexpectedly");
-
-        if (chunk->error) {
-            if (!first_error) {
-                first_error = chunk->error;
-            }
-            budget.Release();
-            local_inflight--;
-            continue;
-        }
-
-        if (first_error) {
-            budget.Release();
-            local_inflight--;
-            continue;
-        }
-
-        if (chunk->seq == next_consume) {
-            deliverChunk(chunk);
-        } else {
-            reorder_buf[chunk->seq] = std::move(chunk);
-        }
-
-        while (reorder_buf.count(next_consume)) {
-            auto node = reorder_buf.extract(next_consume);
-            deliverChunk(node.mapped());
-        }
-
-        while (next_submit < num_slices && budget.TryAcquire()) {
-            submitOne();
-        }
-
-        if (local_inflight == 0 && next_submit < num_slices) {
-            budget.Acquire();
-            submitOne();
-        }
-    }
-
-    for (size_t i = 0; i < reorder_buf.size(); ++i) {
-        budget.Release();
-    }
-    local_inflight -= reorder_buf.size();
-    reorder_buf.clear();
-
-    if (first_error) {
-        std::rethrow_exception(first_error);
-    }
-
-    AssertInfo(running_crc == em.crc32,
-               "CRC-32C mismatch in encrypted stream read");
+    ReadOrderedEntryStream(num_slices,
+                           em.crc32,
+                           "CRC-32C mismatch in encrypted stream read",
+                           priority_,
+                           callback,
+                           load_chunk);
 }
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -34,32 +34,32 @@
 
 #include "common/EasyAssert.h"
 #include "nlohmann/json.hpp"
-#include "storage/ChunkStreamUtils.h"
+#include "storage/EntryStreamUtils.h"
 #include "storage/Crc32cUtil.h"
 #include "storage/PluginLoader.h"
 
 namespace milvus::storage {
 namespace {
 
-using ChunkLoader = std::function<std::vector<uint8_t>(size_t seq)>;
-using ChunkBudgetBytes = std::function<size_t(size_t seq)>;
+using SliceLoader = std::function<std::vector<uint8_t>(size_t seq)>;
+using SliceBudgetBytes = std::function<size_t(size_t seq)>;
 
-struct ActiveChunkTask {
+struct ActiveSliceTask {
     size_t budget_bytes{0};
-    std::shared_ptr<ChunkResult> result;
+    std::shared_ptr<StreamSliceResult> result;
     std::future<void> future;
 };
 
 void
 ReadOrderedEntryStream(
-    size_t num_chunks,
+    size_t num_slices,
     uint32_t expected_crc,
     const std::string& crc_error_context,
     ThreadPoolPriority priority,
-    const std::function<void(const uint8_t* data, size_t len)>& chunk_consumer,
-    const ChunkBudgetBytes& chunk_budget_bytes,
-    const ChunkLoader& load_chunk) {
-    if (num_chunks == 0) {
+    const std::function<void(const uint8_t* data, size_t len)>& slice_consumer,
+    const SliceBudgetBytes& slice_budget_bytes,
+    const SliceLoader& load_slice) {
+    if (num_slices == 0) {
         auto actual_crc = Crc32cValue(nullptr, 0);
         AssertInfo(actual_crc == expected_crc,
                    "{}: expected {}, actual {}",
@@ -70,14 +70,14 @@ ReadOrderedEntryStream(
     }
 
     auto& pool = ThreadPools::GetThreadPool(priority);
-    auto& budget = TransientMemoryBudget::GetScalarIndexChunkBudget();
+    auto& budget = TransientMemoryBudget::GetScalarIndexStreamBudget();
     size_t max_active_tasks =
-        std::min(num_chunks, std::max<size_t>(1, pool.GetMaxThreadNum()));
+        std::min(num_slices, std::max<size_t>(1, pool.GetMaxThreadNum()));
 
     size_t next_submit = 0;
     uint32_t running_crc = 0;
     bool first = true;
-    std::deque<ActiveChunkTask> active_tasks;
+    std::deque<ActiveSliceTask> active_tasks;
     std::exception_ptr first_error = nullptr;
 
     auto rememberError = [&](std::exception_ptr error) {
@@ -104,10 +104,10 @@ ReadOrderedEntryStream(
     auto submitOne = [&](bool block_for_budget) -> bool {
         size_t seq = next_submit;
         size_t budget_bytes = 0;
-        std::shared_ptr<ChunkResult> result;
+        std::shared_ptr<StreamSliceResult> result;
         try {
-            budget_bytes = chunk_budget_bytes(seq);
-            result = std::make_shared<ChunkResult>();
+            budget_bytes = slice_budget_bytes(seq);
+            result = std::make_shared<StreamSliceResult>();
             result->budget_bytes = budget_bytes;
         } catch (...) {
             rememberError(std::current_exception());
@@ -122,11 +122,11 @@ ReadOrderedEntryStream(
 
         try {
             active_tasks.push_back(
-                ActiveChunkTask{budget_bytes, result, std::future<void>()});
+                ActiveSliceTask{budget_bytes, result, std::future<void>()});
             active_tasks.back().future =
-                pool.Submit([result, load_chunk, seq]() {
+                pool.Submit([result, load_slice, seq]() {
                     try {
-                        result->data = load_chunk(seq);
+                        result->data = load_slice(seq);
                     } catch (...) {
                         result->error = std::current_exception();
                     }
@@ -146,7 +146,7 @@ ReadOrderedEntryStream(
     };
 
     auto refill = [&]() {
-        while (!first_error && next_submit < num_chunks &&
+        while (!first_error && next_submit < num_slices &&
                active_tasks.size() < max_active_tasks) {
             bool block_for_budget = active_tasks.empty();
             if (!submitOne(block_for_budget)) {
@@ -155,14 +155,14 @@ ReadOrderedEntryStream(
         }
     };
 
-    auto deliverChunk = [&](const std::shared_ptr<ChunkResult>& c) {
+    auto deliverSlice = [&](const std::shared_ptr<StreamSliceResult>& c) {
         try {
-            uint32_t chunk_crc = Crc32cValue(c->data.data(), c->data.size());
+            uint32_t slice_crc = Crc32cValue(c->data.data(), c->data.size());
             running_crc =
-                first ? chunk_crc
-                      : Crc32cCombine(running_crc, chunk_crc, c->data.size());
+                first ? slice_crc
+                      : Crc32cCombine(running_crc, slice_crc, c->data.size());
             first = false;
-            chunk_consumer(c->data.data(), c->data.size());
+            slice_consumer(c->data.data(), c->data.size());
         } catch (...) {
             rememberError(std::current_exception());
         }
@@ -185,7 +185,7 @@ ReadOrderedEntryStream(
         }
 
         if (!first_error) {
-            deliverChunk(task.result);
+            deliverSlice(task.result);
         }
 
         budget.Release(task.budget_bytes);
@@ -212,8 +212,8 @@ ReadOrderedEntryStream(
 }  // namespace
 
 size_t
-DefaultEntryStreamChunkSize() {
-    return DefaultStreamChunkSize();
+DefaultEntryStreamSliceSize() {
+    return DefaultStreamSliceSize();
 }
 
 std::unique_ptr<IndexEntryReader>
@@ -743,59 +743,59 @@ IndexEntryReader::GetEntrySize(const std::string& name) const {
 void
 IndexEntryReader::ReadEntryStream(
     const std::string& name,
-    std::function<void(const uint8_t* data, size_t len)> chunk_consumer,
-    size_t chunk_size) {
+    std::function<void(const uint8_t* data, size_t len)> slice_consumer,
+    size_t slice_size) {
     auto it = entry_index_.find(name);
     AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
     const auto& meta = it->second;
 
     if (meta.encrypted) {
-        ReadEncryptedEntryStream(meta.enc, chunk_consumer);
+        ReadEncryptedEntryStream(meta.enc, slice_consumer);
     } else {
-        ReadPlainEntryStream(meta.plain, chunk_consumer, chunk_size);
+        ReadPlainEntryStream(meta.plain, slice_consumer, slice_size);
     }
 }
 
 void
 IndexEntryReader::ReadPlainEntryStream(
     const PlainEntryMeta& pm,
-    const std::function<void(const uint8_t* data, size_t len)>& chunk_consumer,
-    size_t chunk_size) {
-    AssertInfo(chunk_size >= kMinStreamChunkSize,
-               "ReadEntryStream chunk_size must be at least {} bytes, got {}",
-               kMinStreamChunkSize,
-               chunk_size);
-    size_t num_chunks =
-        pm.size == 0 ? 0 : 1 + (static_cast<size_t>(pm.size) - 1) / chunk_size;
-    auto chunkBytes = [pm, chunk_size](size_t seq) {
-        size_t off = seq * chunk_size;
-        return std::min<size_t>(chunk_size, pm.size - off);
+    const std::function<void(const uint8_t* data, size_t len)>& slice_consumer,
+    size_t slice_size) {
+    AssertInfo(slice_size >= kMinStreamSliceSize,
+               "ReadEntryStream slice_size must be at least {} bytes, got {}",
+               kMinStreamSliceSize,
+               slice_size);
+    size_t num_slices =
+        pm.size == 0 ? 0 : 1 + (static_cast<size_t>(pm.size) - 1) / slice_size;
+    auto sliceBytes = [pm, slice_size](size_t seq) {
+        size_t off = seq * slice_size;
+        return std::min<size_t>(slice_size, pm.size - off);
     };
     auto input = input_;
-    auto load_chunk = [input, pm, chunk_size, chunkBytes](size_t seq) {
-        size_t off = seq * chunk_size;
-        size_t len = chunkBytes(seq);
+    auto load_slice = [input, pm, slice_size, sliceBytes](size_t seq) {
+        size_t off = seq * slice_size;
+        size_t len = sliceBytes(seq);
         size_t src = pm.offset + off;
         std::vector<uint8_t> data(len);
         size_t n = input->ReadAt(data.data(), MILVUS_V3_MAGIC_SIZE + src, len);
-        AssertInfo(n == len, "Failed to read entry chunk");
+        AssertInfo(n == len, "Failed to read entry slice");
         return data;
     };
 
-    ReadOrderedEntryStream(num_chunks,
+    ReadOrderedEntryStream(num_slices,
                            pm.crc32,
                            "CRC-32C mismatch in stream read",
                            priority_,
-                           chunk_consumer,
-                           chunkBytes,
-                           load_chunk);
+                           slice_consumer,
+                           sliceBytes,
+                           load_slice);
 }
 
 void
 IndexEntryReader::ReadEncryptedEntryStream(
     const EncryptedEntryMeta& em,
     const std::function<void(const uint8_t* data, size_t len)>&
-        chunk_consumer) {
+        slice_consumer) {
     size_t num_slices = em.slices.size();
     auto slicePlainBytes = [this, &em](size_t seq) {
         size_t output_offset = seq * slice_size_;
@@ -820,7 +820,7 @@ IndexEntryReader::ReadEncryptedEntryStream(
     int64_t ez_id = ez_id_;
     int64_t collection_id = collection_id_;
     auto edek = edek_;
-    auto load_chunk = [input,
+    auto load_slice = [input,
                        cipher_plugin,
                        ez_id,
                        collection_id,
@@ -853,9 +853,9 @@ IndexEntryReader::ReadEncryptedEntryStream(
                            em.crc32,
                            "CRC-32C mismatch in encrypted stream read",
                            priority_,
-                           chunk_consumer,
+                           slice_consumer,
                            sliceBudgetBytes,
-                           load_chunk);
+                           load_slice);
 }
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -70,7 +70,7 @@ ReadOrderedEntryStream(
     }
 
     auto& pool = ThreadPools::GetThreadPool(priority);
-    auto& budget = TransientMemoryBudget::GetScalarIndexStreamBudget();
+    auto& budget = TransientMemoryBudget::GetEntryStreamBudget();
     size_t max_active_tasks =
         std::min(num_slices, std::max<size_t>(1, pool.GetMaxThreadNum()));
 

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -68,7 +68,7 @@ ReadOrderedEntryStream(
     uint32_t expected_crc,
     const std::string& crc_error_message,
     ThreadPoolPriority priority,
-    const std::function<void(const uint8_t* data, size_t len)>& callback,
+    const std::function<void(const uint8_t* data, size_t len)>& chunk_consumer,
     const ChunkBudgetBytes& chunk_budget_bytes,
     const ChunkLoader& load_chunk) {
     if (num_chunks == 0) {
@@ -141,7 +141,7 @@ ReadOrderedEntryStream(
                 first ? chunk_crc
                       : Crc32cCombine(running_crc, chunk_crc, c->data.size());
             first = false;
-            callback(c->data.data(), c->data.size());
+            chunk_consumer(c->data.data(), c->data.size());
         } catch (...) {
             if (!first_error) {
                 first_error = std::current_exception();
@@ -767,23 +767,23 @@ IndexEntryReader::GetEntrySize(const std::string& name) const {
 void
 IndexEntryReader::ReadEntryStream(
     const std::string& name,
-    std::function<void(const uint8_t* data, size_t len)> callback,
+    std::function<void(const uint8_t* data, size_t len)> chunk_consumer,
     size_t chunk_size) {
     auto it = entry_index_.find(name);
     AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
     const auto& meta = it->second;
 
     if (meta.encrypted) {
-        ReadEncryptedEntryStream(meta.enc, callback);
+        ReadEncryptedEntryStream(meta.enc, chunk_consumer);
     } else {
-        ReadPlainEntryStream(meta.plain, callback, chunk_size);
+        ReadPlainEntryStream(meta.plain, chunk_consumer, chunk_size);
     }
 }
 
 void
 IndexEntryReader::ReadPlainEntryStream(
     const PlainEntryMeta& pm,
-    const std::function<void(const uint8_t* data, size_t len)>& callback,
+    const std::function<void(const uint8_t* data, size_t len)>& chunk_consumer,
     size_t chunk_size) {
     size_t num_chunks = (pm.size + chunk_size - 1) / chunk_size;
     auto chunkBytes = [pm, chunk_size](size_t seq) {
@@ -807,7 +807,7 @@ IndexEntryReader::ReadPlainEntryStream(
         fmt::format("CRC-32C mismatch in stream read: expected {}",
                     Crc32cToHex(pm.crc32)),
         priority_,
-        callback,
+        chunk_consumer,
         chunkBytes,
         load_chunk);
 }
@@ -815,7 +815,8 @@ IndexEntryReader::ReadPlainEntryStream(
 void
 IndexEntryReader::ReadEncryptedEntryStream(
     const EncryptedEntryMeta& em,
-    const std::function<void(const uint8_t* data, size_t len)>& callback) {
+    const std::function<void(const uint8_t* data, size_t len)>&
+        chunk_consumer) {
     size_t num_slices = em.slices.size();
     auto sliceBudgetBytes = [&](size_t seq) { return em.slices[seq].size; };
     auto input = input_;
@@ -842,7 +843,7 @@ IndexEntryReader::ReadEncryptedEntryStream(
                            em.crc32,
                            "CRC-32C mismatch in encrypted stream read",
                            priority_,
-                           callback,
+                           chunk_consumer,
                            sliceBudgetBytes,
                            load_chunk);
 }

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -23,15 +23,15 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <deque>
 #include <functional>
 #include <future>
-#include <map>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "common/Channel.h"
 #include "common/EasyAssert.h"
 #include "nlohmann/json.hpp"
 #include "storage/ChunkStreamUtils.h"
@@ -44,97 +44,118 @@ namespace {
 using ChunkLoader = std::function<std::vector<uint8_t>(size_t seq)>;
 using ChunkBudgetBytes = std::function<size_t(size_t seq)>;
 
-class FutureWaiter {
- public:
-    explicit FutureWaiter(std::vector<std::future<void>>& futures)
-        : futures_(futures) {
-    }
-
-    ~FutureWaiter() {
-        for (auto& future : futures_) {
-            if (future.valid()) {
-                future.wait();
-            }
-        }
-    }
-
- private:
-    std::vector<std::future<void>>& futures_;
+struct ActiveChunkTask {
+    size_t budget_bytes{0};
+    std::shared_ptr<ChunkResult> result;
+    std::future<void> future;
 };
 
 void
 ReadOrderedEntryStream(
     size_t num_chunks,
     uint32_t expected_crc,
-    const std::string& crc_error_message,
+    const std::string& crc_error_context,
     ThreadPoolPriority priority,
     const std::function<void(const uint8_t* data, size_t len)>& chunk_consumer,
     const ChunkBudgetBytes& chunk_budget_bytes,
     const ChunkLoader& load_chunk) {
     if (num_chunks == 0) {
+        auto actual_crc = Crc32cValue(nullptr, 0);
+        AssertInfo(actual_crc == expected_crc,
+                   "{}: expected {}, actual {}",
+                   crc_error_context,
+                   Crc32cToHex(expected_crc),
+                   Crc32cToHex(actual_crc));
         return;
     }
 
     auto& pool = ThreadPools::GetThreadPool(priority);
     auto& budget = TransientMemoryBudget::GetScalarIndexChunkBudget();
-    auto channel = std::make_shared<Channel<std::shared_ptr<ChunkResult>>>();
-
-    std::vector<std::future<void>> futures;
-    futures.reserve(num_chunks);
-    FutureWaiter wait_on_exit(futures);
+    size_t max_active_tasks =
+        std::min(num_chunks, std::max<size_t>(1, pool.GetMaxThreadNum()));
 
     size_t next_submit = 0;
-    size_t next_consume = 0;
-    size_t local_inflight = 0;
     uint32_t running_crc = 0;
     bool first = true;
-    std::map<size_t, std::shared_ptr<ChunkResult>> reorder_buf;
+    std::deque<ActiveChunkTask> active_tasks;
     std::exception_ptr first_error = nullptr;
-
-    auto releaseBuffered = [&]() {
-        for (const auto& [_, chunk] : reorder_buf) {
-            budget.Release(chunk->budget_bytes);
-            local_inflight--;
-        }
-        reorder_buf.clear();
-    };
 
     auto rememberError = [&](std::exception_ptr error) {
         if (!first_error) {
             first_error = std::move(error);
         }
-        releaseBuffered();
     };
 
-    auto submitOne = [&]() -> bool {
+    auto drainActiveTasks = [&]() {
+        while (!active_tasks.empty()) {
+            auto task = std::move(active_tasks.front());
+            active_tasks.pop_front();
+            if (task.future.valid()) {
+                try {
+                    task.future.get();
+                } catch (...) {
+                    rememberError(std::current_exception());
+                }
+            }
+            budget.Release(task.budget_bytes);
+        }
+    };
+
+    auto submitOne = [&](bool block_for_budget) -> bool {
         size_t seq = next_submit;
-        size_t budget_bytes = chunk_budget_bytes(seq);
+        size_t budget_bytes = 0;
+        std::shared_ptr<ChunkResult> result;
         try {
-            auto future =
-                pool.Submit([channel, load_chunk, seq, budget_bytes]() {
-                    auto r = std::make_shared<ChunkResult>();
-                    r->seq = seq;
-                    r->budget_bytes = budget_bytes;
-                    try {
-                        r->data = load_chunk(seq);
-                    } catch (...) {
-                        r->error = std::current_exception();
-                    }
-                    channel->push(std::move(r));
-                });
-            futures.push_back(std::move(future));
+            budget_bytes = chunk_budget_bytes(seq);
+            result = std::make_shared<ChunkResult>();
+            result->budget_bytes = budget_bytes;
         } catch (...) {
+            rememberError(std::current_exception());
+            return false;
+        }
+
+        if (block_for_budget) {
+            budget.Acquire(budget_bytes);
+        } else if (!budget.TryAcquire(budget_bytes)) {
+            return false;
+        }
+
+        try {
+            active_tasks.push_back(
+                ActiveChunkTask{budget_bytes, result, std::future<void>()});
+            active_tasks.back().future =
+                pool.Submit([result, load_chunk, seq]() {
+                    try {
+                        result->data = load_chunk(seq);
+                    } catch (...) {
+                        result->error = std::current_exception();
+                    }
+                });
+        } catch (...) {
+            if (!active_tasks.empty() && active_tasks.back().result == result &&
+                !active_tasks.back().future.valid()) {
+                active_tasks.pop_back();
+            }
             budget.Release(budget_bytes);
             rememberError(std::current_exception());
             return false;
         }
 
         next_submit++;
-        local_inflight++;
         return true;
     };
 
-    auto deliverChunk = [&](const std::shared_ptr<ChunkResult>& c) -> bool {
+    auto refill = [&]() {
+        while (!first_error && next_submit < num_chunks &&
+               active_tasks.size() < max_active_tasks) {
+            bool block_for_budget = active_tasks.empty();
+            if (!submitOne(block_for_budget)) {
+                break;
+            }
+        }
+    };
+
+    auto deliverChunk = [&](const std::shared_ptr<ChunkResult>& c) {
         try {
             uint32_t chunk_crc = Crc32cValue(c->data.data(), c->data.size());
             running_crc =
@@ -143,102 +164,57 @@ ReadOrderedEntryStream(
             first = false;
             chunk_consumer(c->data.data(), c->data.size());
         } catch (...) {
-            if (!first_error) {
-                first_error = std::current_exception();
-            }
+            rememberError(std::current_exception());
         }
-
-        budget.Release(c->budget_bytes);
-        next_consume++;
-        local_inflight--;
-
-        if (first_error) {
-            releaseBuffered();
-            return false;
-        }
-        return true;
     };
 
-    if (next_submit < num_chunks) {
-        budget.Acquire(chunk_budget_bytes(next_submit));
-        submitOne();
-    }
-    while (!first_error && next_submit < num_chunks &&
-           budget.TryAcquire(chunk_budget_bytes(next_submit))) {
-        submitOne();
-    }
+    refill();
 
-    while (local_inflight > 0) {
-        std::shared_ptr<ChunkResult> chunk;
+    while (!active_tasks.empty()) {
+        auto task = std::move(active_tasks.front());
+        active_tasks.pop_front();
+
         try {
-            bool ok = channel->pop(chunk);
-            AssertInfo(ok, "Channel closed unexpectedly");
+            task.future.get();
         } catch (...) {
             rememberError(std::current_exception());
+        }
+
+        if (!first_error && task.result->error) {
+            rememberError(task.result->error);
+        }
+
+        if (!first_error) {
+            deliverChunk(task.result);
+        }
+
+        budget.Release(task.budget_bytes);
+
+        if (first_error) {
+            drainActiveTasks();
             break;
         }
 
-        if (chunk->error) {
-            rememberError(chunk->error);
-            budget.Release(chunk->budget_bytes);
-            local_inflight--;
-            continue;
-        }
-
-        if (first_error) {
-            budget.Release(chunk->budget_bytes);
-            local_inflight--;
-            continue;
-        }
-
-        if (chunk->seq == next_consume) {
-            if (!deliverChunk(chunk)) {
-                continue;
-            }
-        } else {
-            reorder_buf[chunk->seq] = std::move(chunk);
-        }
-
-        while (!first_error && reorder_buf.count(next_consume)) {
-            auto node = reorder_buf.extract(next_consume);
-            if (!deliverChunk(node.mapped())) {
-                break;
-            }
-        }
-
-        while (!first_error && next_submit < num_chunks &&
-               budget.TryAcquire(chunk_budget_bytes(next_submit))) {
-            submitOne();
-        }
-
-        if (!first_error && local_inflight == 0 && next_submit < num_chunks) {
-            budget.Acquire(chunk_budget_bytes(next_submit));
-            submitOne();
-        }
-    }
-
-    releaseBuffered();
-
-    for (auto& future : futures) {
-        if (future.valid()) {
-            try {
-                future.get();
-            } catch (...) {
-                if (!first_error) {
-                    first_error = std::current_exception();
-                }
-            }
-        }
+        refill();
     }
 
     if (first_error) {
         std::rethrow_exception(first_error);
     }
 
-    AssertInfo(running_crc == expected_crc, crc_error_message);
+    AssertInfo(running_crc == expected_crc,
+               "{}: expected {}, actual {}",
+               crc_error_context,
+               Crc32cToHex(expected_crc),
+               Crc32cToHex(running_crc));
 }
 
 }  // namespace
+
+size_t
+DefaultEntryStreamChunkSize() {
+    return DefaultStreamChunkSize();
+}
 
 std::unique_ptr<IndexEntryReader>
 IndexEntryReader::Open(std::shared_ptr<milvus::InputStream> input,
@@ -785,7 +761,12 @@ IndexEntryReader::ReadPlainEntryStream(
     const PlainEntryMeta& pm,
     const std::function<void(const uint8_t* data, size_t len)>& chunk_consumer,
     size_t chunk_size) {
-    size_t num_chunks = (pm.size + chunk_size - 1) / chunk_size;
+    AssertInfo(chunk_size >= kMinStreamChunkSize,
+               "ReadEntryStream chunk_size must be at least {} bytes, got {}",
+               kMinStreamChunkSize,
+               chunk_size);
+    size_t num_chunks =
+        pm.size == 0 ? 0 : 1 + (static_cast<size_t>(pm.size) - 1) / chunk_size;
     auto chunkBytes = [pm, chunk_size](size_t seq) {
         size_t off = seq * chunk_size;
         return std::min<size_t>(chunk_size, pm.size - off);
@@ -801,15 +782,13 @@ IndexEntryReader::ReadPlainEntryStream(
         return data;
     };
 
-    ReadOrderedEntryStream(
-        num_chunks,
-        pm.crc32,
-        fmt::format("CRC-32C mismatch in stream read: expected {}",
-                    Crc32cToHex(pm.crc32)),
-        priority_,
-        chunk_consumer,
-        chunkBytes,
-        load_chunk);
+    ReadOrderedEntryStream(num_chunks,
+                           pm.crc32,
+                           "CRC-32C mismatch in stream read",
+                           priority_,
+                           chunk_consumer,
+                           chunkBytes,
+                           load_chunk);
 }
 
 void
@@ -818,26 +797,57 @@ IndexEntryReader::ReadEncryptedEntryStream(
     const std::function<void(const uint8_t* data, size_t len)>&
         chunk_consumer) {
     size_t num_slices = em.slices.size();
-    auto sliceBudgetBytes = [&](size_t seq) { return em.slices[seq].size; };
+    auto slicePlainBytes = [this, &em](size_t seq) {
+        size_t output_offset = seq * slice_size_;
+        AssertInfo(output_offset < em.original_size,
+                   "Encrypted slice {} exceeds original entry size {}",
+                   seq,
+                   em.original_size);
+        size_t remaining = em.original_size - output_offset;
+        return std::min(remaining, slice_size_);
+    };
+    auto sliceBudgetBytes = [&](size_t seq) {
+        auto plain_len = slicePlainBytes(seq);
+        auto cipher_len = em.slices[seq].size;
+        AssertInfo(plain_len <= (std::numeric_limits<size_t>::max() / 2) &&
+                       cipher_len <=
+                           std::numeric_limits<size_t>::max() - 2 * plain_len,
+                   "Encrypted stream budget size overflow");
+        return cipher_len + 2 * plain_len;
+    };
     auto input = input_;
     auto cipher_plugin = cipher_plugin_;
     int64_t ez_id = ez_id_;
     int64_t collection_id = collection_id_;
     auto edek = edek_;
-    auto load_chunk =
-        [input, cipher_plugin, ez_id, collection_id, edek, &em](size_t seq) {
-            const auto& slice = em.slices[seq];
+    auto load_chunk = [input,
+                       cipher_plugin,
+                       ez_id,
+                       collection_id,
+                       edek,
+                       &em,
+                       slicePlainBytes](size_t seq) {
+        const auto& slice = em.slices[seq];
+        auto expected_plain_len = slicePlainBytes(seq);
+
+        std::string plain;
+        {
             std::vector<uint8_t> cipher(slice.size);
             size_t n = input->ReadAt(
                 cipher.data(), MILVUS_V3_MAGIC_SIZE + slice.offset, slice.size);
             AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
             auto dec = cipher_plugin->GetDecryptor(ez_id, collection_id, edek);
-            auto plain = dec->Decrypt(cipher.data(), cipher.size());
-            return std::vector<uint8_t>(
-                reinterpret_cast<const uint8_t*>(plain.data()),
-                reinterpret_cast<const uint8_t*>(plain.data()) + plain.size());
-        };
+            plain = dec->Decrypt(cipher.data(), cipher.size());
+        }
+        AssertInfo(plain.size() == expected_plain_len,
+                   "Decrypted size mismatch: expected {}, got {}",
+                   expected_plain_len,
+                   plain.size());
+        return std::vector<uint8_t>(
+            reinterpret_cast<const uint8_t*>(plain.data()),
+            reinterpret_cast<const uint8_t*>(plain.data()) + plain.size());
+    };
 
     ReadOrderedEntryStream(num_slices,
                            em.crc32,

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -18,6 +18,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <future>
 #include <memory>
 #include <string>
@@ -27,6 +28,7 @@
 #include "common/EasyAssert.h"
 #include "filemanager/InputStream.h"
 #include "nlohmann/json.hpp"
+#include "storage/ChunkStreamUtils.h"
 #include "storage/IndexEntryWriter.h"
 #include "storage/ThreadPools.h"
 #include "storage/plugin/PluginInterface.h"
@@ -57,6 +59,21 @@ class IndexEntryReader {
     void
     ReadEntriesToFiles(const std::vector<std::pair<std::string, std::string>>&
                            name_path_pairs);
+
+    /// Stream entry data via bounded channel with sliding window.
+    /// Downloads are concurrent (full bandwidth). Chunks delivered in order
+    /// to the callback. Global ChunkInflightBudget controls total inflight
+    /// chunks across all concurrent scalar index loads.
+    /// CRC32c is verified incrementally.
+    void
+    ReadEntryStream(
+        const std::string& name,
+        std::function<void(const uint8_t* data, size_t len)> callback,
+        size_t chunk_size = kDefaultStreamChunkSize);
+
+    /// Return the uncompressed data size of an entry without reading it.
+    size_t
+    GetEntrySize(const std::string& name) const;
 
     template <typename T>
     T
@@ -113,6 +130,17 @@ class IndexEntryReader {
     ReadPlainEntry(const EntryMeta& meta);
     Entry
     ReadEncryptedEntry(const EntryMeta& meta);
+
+    void
+    ReadPlainEntryStream(
+        const PlainEntryMeta& pm,
+        const std::function<void(const uint8_t* data, size_t len)>& callback,
+        size_t chunk_size);
+
+    void
+    ReadEncryptedEntryStream(
+        const EncryptedEntryMeta& em,
+        const std::function<void(const uint8_t* data, size_t len)>& callback);
 
     void
     VerifyCrc32c(uint32_t expected,

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -61,14 +61,15 @@ class IndexEntryReader {
                            name_path_pairs);
 
     /// Stream entry data via transient memory budget.
-    /// Downloads are concurrent (full bandwidth). Chunks delivered in order
-    /// to the callback. Global TransientMemoryBudget controls total inflight
-    /// chunk bytes across all concurrent scalar index loads.
+    /// Downloads are concurrent (full bandwidth). Chunks are delivered in entry
+    /// order to `chunk_consumer`; the data pointer is valid only for the
+    /// duration of that call. Global TransientMemoryBudget controls total
+    /// inflight chunk bytes across all concurrent scalar index loads.
     /// CRC32c is verified incrementally.
     void
     ReadEntryStream(
         const std::string& name,
-        std::function<void(const uint8_t* data, size_t len)> callback,
+        std::function<void(const uint8_t* data, size_t len)> chunk_consumer,
         size_t chunk_size = kDefaultStreamChunkSize);
 
     /// Return the uncompressed data size of an entry without reading it.
@@ -138,15 +139,16 @@ class IndexEntryReader {
     ReadEncryptedEntry(const EntryMeta& meta);
 
     void
-    ReadPlainEntryStream(
-        const PlainEntryMeta& pm,
-        const std::function<void(const uint8_t* data, size_t len)>& callback,
-        size_t chunk_size);
+    ReadPlainEntryStream(const PlainEntryMeta& pm,
+                         const std::function<void(const uint8_t* data,
+                                                  size_t len)>& chunk_consumer,
+                         size_t chunk_size);
 
     void
     ReadEncryptedEntryStream(
         const EncryptedEntryMeta& em,
-        const std::function<void(const uint8_t* data, size_t len)>& callback);
+        const std::function<void(const uint8_t* data, size_t len)>&
+            chunk_consumer);
 
     void
     VerifyCrc32c(uint32_t expected,

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -28,12 +28,14 @@
 #include "common/EasyAssert.h"
 #include "filemanager/InputStream.h"
 #include "nlohmann/json.hpp"
-#include "storage/ChunkStreamUtils.h"
 #include "storage/IndexEntryWriter.h"
 #include "storage/ThreadPools.h"
 #include "storage/plugin/PluginInterface.h"
 
 namespace milvus::storage {
+
+size_t
+DefaultEntryStreamChunkSize();
 
 struct Entry {
     std::vector<uint8_t> data;
@@ -65,12 +67,16 @@ class IndexEntryReader {
     /// order to `chunk_consumer`; the data pointer is valid only for the
     /// duration of that call. Global TransientMemoryBudget controls total
     /// inflight chunk bytes across all concurrent scalar index loads.
-    /// CRC32c is verified incrementally.
+    /// CRC32c is verified incrementally. Consumers may receive partial data
+    /// before a later chunk error is reported. Slow consumers keep their chunk
+    /// budget until the callback returns, which can block other streams.
+    /// `chunk_size` applies only to plain entries; encrypted entries stream by
+    /// encryption slice boundaries.
     void
     ReadEntryStream(
         const std::string& name,
         std::function<void(const uint8_t* data, size_t len)> chunk_consumer,
-        size_t chunk_size = DefaultStreamChunkSize());
+        size_t chunk_size = DefaultEntryStreamChunkSize());
 
     /// Return the uncompressed data size of an entry without reading it.
     size_t

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -66,12 +66,13 @@ class IndexEntryReader {
     /// Downloads are concurrent (full bandwidth). Slices are delivered in entry
     /// order to `slice_consumer`; the data pointer is valid only for the
     /// duration of that call. Global TransientMemoryBudget controls total
-    /// inflight slice bytes across all concurrent scalar index loads.
+    /// inflight slice bytes across all concurrent entry streams.
     /// CRC32c is verified incrementally. Consumers may receive partial data
     /// before a later slice error is reported. Slow consumers keep their slice
     /// budget until the callback returns, which can block other streams.
-    /// Plain entries are split into `slice_size` byte slices; encrypted entries
-    /// use the slice boundaries stored in the V3 directory.
+    /// Plain entries are split into `slice_size` byte slices. Encrypted entries
+    /// ignore `slice_size` and use the slice boundaries stored in the V3
+    /// directory.
     void
     ReadEntryStream(
         const std::string& name,

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -70,7 +70,7 @@ class IndexEntryReader {
     ReadEntryStream(
         const std::string& name,
         std::function<void(const uint8_t* data, size_t len)> chunk_consumer,
-        size_t chunk_size = kDefaultStreamChunkSize);
+        size_t chunk_size = DefaultStreamChunkSize());
 
     /// Return the uncompressed data size of an entry without reading it.
     size_t

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -70,8 +70,9 @@ class IndexEntryReader {
     /// CRC32c is verified incrementally. Consumers may receive partial data
     /// before a later chunk error is reported. Slow consumers keep their chunk
     /// budget until the callback returns, which can block other streams.
-    /// `chunk_size` applies only to plain entries; encrypted entries stream by
-    /// encryption slice boundaries.
+    /// Streaming uses slice-sized chunks. Plain entries are split by
+    /// `chunk_size`; encrypted entries use the slice boundaries stored in the
+    /// V3 directory.
     void
     ReadEntryStream(
         const std::string& name,

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -35,7 +35,7 @@
 namespace milvus::storage {
 
 size_t
-DefaultEntryStreamChunkSize();
+DefaultEntryStreamSliceSize();
 
 struct Entry {
     std::vector<uint8_t> data;
@@ -63,21 +63,20 @@ class IndexEntryReader {
                            name_path_pairs);
 
     /// Stream entry data via transient memory budget.
-    /// Downloads are concurrent (full bandwidth). Chunks are delivered in entry
-    /// order to `chunk_consumer`; the data pointer is valid only for the
+    /// Downloads are concurrent (full bandwidth). Slices are delivered in entry
+    /// order to `slice_consumer`; the data pointer is valid only for the
     /// duration of that call. Global TransientMemoryBudget controls total
-    /// inflight chunk bytes across all concurrent scalar index loads.
+    /// inflight slice bytes across all concurrent scalar index loads.
     /// CRC32c is verified incrementally. Consumers may receive partial data
-    /// before a later chunk error is reported. Slow consumers keep their chunk
+    /// before a later slice error is reported. Slow consumers keep their slice
     /// budget until the callback returns, which can block other streams.
-    /// Streaming uses slice-sized chunks. Plain entries are split by
-    /// `chunk_size`; encrypted entries use the slice boundaries stored in the
-    /// V3 directory.
+    /// Plain entries are split into `slice_size` byte slices; encrypted entries
+    /// use the slice boundaries stored in the V3 directory.
     void
     ReadEntryStream(
         const std::string& name,
-        std::function<void(const uint8_t* data, size_t len)> chunk_consumer,
-        size_t chunk_size = DefaultEntryStreamChunkSize());
+        std::function<void(const uint8_t* data, size_t len)> slice_consumer,
+        size_t slice_size = DefaultEntryStreamSliceSize());
 
     /// Return the uncompressed data size of an entry without reading it.
     size_t
@@ -148,14 +147,14 @@ class IndexEntryReader {
     void
     ReadPlainEntryStream(const PlainEntryMeta& pm,
                          const std::function<void(const uint8_t* data,
-                                                  size_t len)>& chunk_consumer,
-                         size_t chunk_size);
+                                                  size_t len)>& slice_consumer,
+                         size_t slice_size);
 
     void
     ReadEncryptedEntryStream(
         const EncryptedEntryMeta& em,
         const std::function<void(const uint8_t* data, size_t len)>&
-            chunk_consumer);
+            slice_consumer);
 
     void
     VerifyCrc32c(uint32_t expected,

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -60,10 +60,10 @@ class IndexEntryReader {
     ReadEntriesToFiles(const std::vector<std::pair<std::string, std::string>>&
                            name_path_pairs);
 
-    /// Stream entry data via bounded channel with sliding window.
+    /// Stream entry data via transient memory budget.
     /// Downloads are concurrent (full bandwidth). Chunks delivered in order
-    /// to the callback. Global ChunkInflightBudget controls total inflight
-    /// chunks across all concurrent scalar index loads.
+    /// to the callback. Global TransientMemoryBudget controls total inflight
+    /// chunk bytes across all concurrent scalar index loads.
     /// CRC32c is verified incrementally.
     void
     ReadEntryStream(
@@ -74,6 +74,12 @@ class IndexEntryReader {
     /// Return the uncompressed data size of an entry without reading it.
     size_t
     GetEntrySize(const std::string& name) const;
+
+    /// Check if an entry exists in the index file.
+    bool
+    HasEntry(const std::string& name) const {
+        return entry_index_.find(name) != entry_index_.end();
+    }
 
     template <typename T>
     T

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -915,3 +915,115 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedFdEntryMultiSlice) {
 
     ::unlink(tmp_absolute.c_str());
 }
+
+// ---- ReadEntryStream tests ----
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamLarge) {
+    const std::string file_path = kV3FilePath + "_stream_large";
+    const size_t entry_size = 4 * 1024 * 1024;  // 4MB
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("test_data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    std::vector<uint8_t> reassembled;
+    size_t callback_count = 0;
+    reader->ReadEntryStream(
+        "test_data",
+        [&](const uint8_t* d, size_t len) {
+            reassembled.insert(reassembled.end(), d, d + len);
+            callback_count++;
+        },
+        1 * 1024 * 1024);  // 1MB chunks
+
+    ASSERT_EQ(reassembled.size(), entry_size);
+    VerifyPattern(reassembled, entry_size);
+    ASSERT_EQ(callback_count, 4);  // 4MB / 1MB = 4 chunks
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamSmall) {
+    const std::string file_path = kV3FilePath + "_stream_small";
+    const size_t entry_size = 1024;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("small_data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    std::vector<uint8_t> reassembled;
+    size_t callback_count = 0;
+    reader->ReadEntryStream("small_data", [&](const uint8_t* d, size_t len) {
+        reassembled.insert(reassembled.end(), d, d + len);
+        callback_count++;
+    });
+
+    ASSERT_EQ(reassembled.size(), entry_size);
+    VerifyPattern(reassembled, entry_size);
+    ASSERT_EQ(callback_count, 1);  // single chunk (1KB < 2MB default)
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMatchesReadEntry) {
+    const std::string file_path = kV3FilePath + "_stream_match";
+    const size_t entry_size = 5 * 1024 * 1024;  // 5MB, non-aligned
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    // Read via ReadEntry
+    auto entry = reader->ReadEntry("data");
+
+    // Read via ReadEntryStream
+    std::vector<uint8_t> streamed;
+    reader->ReadEntryStream(
+        "data",
+        [&](const uint8_t* d, size_t len) {
+            streamed.insert(streamed.end(), d, d + len);
+        },
+        512 * 1024);  // 512KB chunks
+
+    ASSERT_EQ(entry.data.size(), streamed.size());
+    EXPECT_EQ(entry.data, streamed);
+}
+
+TEST_F(IndexEntryWriterV3Test, GetEntrySize) {
+    const std::string file_path = kV3FilePath + "_entry_size";
+    const size_t entry_size = 3 * 1024 * 1024;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("sized_entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    ASSERT_EQ(reader->GetEntrySize("sized_entry"), entry_size);
+}

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -33,6 +33,7 @@
 #include "storage/IndexEntryDirectStreamWriter.h"
 #include "storage/IndexEntryEncryptedLocalWriter.h"
 #include "storage/IndexEntryReader.h"
+#include "storage/ChunkStreamUtils.h"
 #include "storage/PluginLoader.h"
 #include "storage/RemoteInputStream.h"
 #include "storage/RemoteOutputStream.h"
@@ -44,17 +45,14 @@ namespace {
 class IndexEntryStreamConfigGuard {
  public:
     IndexEntryStreamConfigGuard()
-        : chunk_size_(milvus::INDEX_ENTRY_STREAM_CHUNK_SIZE.load()),
-          budget_ratio_(milvus::SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.load()) {
+        : budget_ratio_(milvus::SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.load()) {
     }
 
     ~IndexEntryStreamConfigGuard() {
-        milvus::SetIndexEntryStreamChunkSize(chunk_size_);
         milvus::SetScalarIndexEntryStreamBudgetRatio(budget_ratio_);
     }
 
  private:
-    int64_t chunk_size_;
     double budget_ratio_;
 };
 
@@ -1058,18 +1056,43 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamSmall) {
 
     ASSERT_EQ(reassembled.size(), entry_size);
     VerifyPattern(reassembled, entry_size);
-    ASSERT_EQ(chunk_count, 1);  // single chunk (1KB < 2MB default)
+    ASSERT_EQ(chunk_count, 1);  // single chunk (1KB < default chunk size)
 }
 
-TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesConfiguredDefaultChunkSize) {
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamRejectsInvalidChunkSize) {
+    const std::string file_path = kV3FilePath + "_stream_invalid_chunk";
+    const size_t entry_size = kMinStreamChunkSize;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    EXPECT_THROW(reader->ReadEntryStream(
+                     "data", [](const uint8_t*, size_t) {}, 0),
+                 milvus::SegcoreError);
+    EXPECT_THROW(
+        reader->ReadEntryStream(
+            "data", [](const uint8_t*, size_t) {}, kMinStreamChunkSize - 1),
+        milvus::SegcoreError);
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultChunkSize) {
     IndexEntryStreamConfigGuard guard;
-    milvus::SetIndexEntryStreamChunkSize(7);
     milvus::SetScalarIndexEntryStreamBudgetRatio(2.5);
-    ASSERT_EQ(DefaultStreamChunkSize(), 7);
+    const size_t chunk_size = DEFAULT_INDEX_FILE_SLICE_SIZE;
+    ASSERT_EQ(DefaultStreamChunkSize(), chunk_size);
     ASSERT_DOUBLE_EQ(ScalarIndexChunkBudgetRatio(), 2.5);
 
     const std::string file_path = kV3FilePath + "_stream_configured_default";
-    const size_t entry_size = 20;
+    const size_t entry_size = 2 * chunk_size + 17;
     auto data = GeneratePattern(entry_size);
 
     {
@@ -1091,7 +1114,28 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesConfiguredDefaultChunkSize) {
     });
 
     ASSERT_EQ(reassembled, data);
-    ASSERT_EQ(chunk_sizes, (std::vector<size_t>{7, 7, 6}));
+    ASSERT_EQ(chunk_sizes, (std::vector<size_t>{chunk_size, chunk_size, 17}));
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamEmptyEntryVerifiesCrc) {
+    const std::string file_path = kV3FilePath + "_stream_empty";
+    std::vector<uint8_t> data;
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("empty", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    size_t chunk_count = 0;
+    reader->ReadEntryStream("empty",
+                            [&](const uint8_t*, size_t) { chunk_count++; });
+    ASSERT_EQ(chunk_count, 0);
 }
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMatchesReadEntry) {
@@ -1164,8 +1208,8 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamConsumerExceptionDoesNotLeak) {
     EXPECT_EQ(streamed, data);
 }
 
-TEST_F(IndexEntryWriterV3Test, ReadEntryStreamDrainsReorderBufferAfterError) {
-    const std::string file_path = kV3FilePath + "_stream_reorder_error";
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamDrainsActiveTasksAfterError) {
+    const std::string file_path = kV3FilePath + "_stream_active_task_error";
     const size_t chunk_size = 64 * 1024;
     const size_t entry_size = 3 * chunk_size;
     auto data = GeneratePattern(entry_size);
@@ -1194,7 +1238,7 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamDrainsReorderBufferAfterError) {
         reader->ReadEntryStream(
             "data", [&](const uint8_t*, size_t) { chunk_count++; }, chunk_size),
         milvus::SegcoreError);
-    EXPECT_LE(chunk_count, 1);
+    EXPECT_EQ(chunk_count, 1);
 
     auto clean_input = CreateInputStream(file_path);
     auto clean_reader = IndexEntryReader::Open(clean_input, file_size);

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -55,6 +56,14 @@ class IndexEntryStreamConfigGuard {
  private:
     double budget_ratio_;
 };
+
+size_t
+ExpectedScalarIndexStreamBudgetBytes(double ratio) {
+    auto slice_size = DefaultStreamSliceSize();
+    auto core_num = std::max(1, milvus::CPU_NUM);
+    auto capacity = static_cast<size_t>(core_num * ratio) * slice_size;
+    return std::max(capacity, slice_size);
+}
 
 // Simple XOR-based mock cipher for testing (NOT for production use!)
 class MockEncryptor : public plugin::IEncryptor {
@@ -1090,6 +1099,15 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultSliceSize) {
     const size_t slice_size = DEFAULT_INDEX_FILE_SLICE_SIZE;
     ASSERT_EQ(DefaultStreamSliceSize(), slice_size);
     ASSERT_DOUBLE_EQ(ScalarIndexStreamBudgetRatio(), 2.5);
+    ASSERT_EQ(
+        TransientMemoryBudget::GetScalarIndexStreamBudget().CapacityBytes(),
+        ExpectedScalarIndexStreamBudgetBytes(2.5));
+
+    milvus::SetScalarIndexEntryStreamBudgetRatio(3.5);
+    ASSERT_DOUBLE_EQ(ScalarIndexStreamBudgetRatio(), 3.5);
+    ASSERT_EQ(
+        TransientMemoryBudget::GetScalarIndexStreamBudget().CapacityBytes(),
+        ExpectedScalarIndexStreamBudgetBytes(3.5));
 
     const std::string file_path = kV3FilePath + "_stream_configured_default";
     const size_t entry_size = 2 * slice_size + 17;

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/Common.h"
 #include "common/EasyAssert.h"
 #include "filemanager/InputStream.h"
 #include "test_utils/Constants.h"
@@ -39,6 +40,23 @@
 using namespace milvus::storage;
 
 namespace {
+
+class IndexEntryStreamConfigGuard {
+ public:
+    IndexEntryStreamConfigGuard()
+        : chunk_size_(milvus::INDEX_ENTRY_STREAM_CHUNK_SIZE.load()),
+          budget_ratio_(milvus::SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.load()) {
+    }
+
+    ~IndexEntryStreamConfigGuard() {
+        milvus::SetIndexEntryStreamChunkSize(chunk_size_);
+        milvus::SetScalarIndexEntryStreamBudgetRatio(budget_ratio_);
+    }
+
+ private:
+    int64_t chunk_size_;
+    double budget_ratio_;
+};
 
 // Simple XOR-based mock cipher for testing (NOT for production use!)
 class MockEncryptor : public plugin::IEncryptor {
@@ -1041,6 +1059,39 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamSmall) {
     ASSERT_EQ(reassembled.size(), entry_size);
     VerifyPattern(reassembled, entry_size);
     ASSERT_EQ(chunk_count, 1);  // single chunk (1KB < 2MB default)
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesConfiguredDefaultChunkSize) {
+    IndexEntryStreamConfigGuard guard;
+    milvus::SetIndexEntryStreamChunkSize(7);
+    milvus::SetScalarIndexEntryStreamBudgetRatio(2.5);
+    ASSERT_EQ(DefaultStreamChunkSize(), 7);
+    ASSERT_DOUBLE_EQ(ScalarIndexChunkBudgetRatio(), 2.5);
+
+    const std::string file_path = kV3FilePath + "_stream_configured_default";
+    const size_t entry_size = 20;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    std::vector<size_t> chunk_sizes;
+    std::vector<uint8_t> reassembled;
+    reader->ReadEntryStream("data", [&](const uint8_t* d, size_t len) {
+        chunk_sizes.push_back(len);
+        reassembled.insert(reassembled.end(), d, d + len);
+    });
+
+    ASSERT_EQ(reassembled, data);
+    ASSERT_EQ(chunk_sizes, (std::vector<size_t>{7, 7, 6}));
 }
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMatchesReadEntry) {

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -33,7 +33,7 @@
 #include "storage/IndexEntryDirectStreamWriter.h"
 #include "storage/IndexEntryEncryptedLocalWriter.h"
 #include "storage/IndexEntryReader.h"
-#include "storage/ChunkStreamUtils.h"
+#include "storage/EntryStreamUtils.h"
 #include "storage/PluginLoader.h"
 #include "storage/RemoteInputStream.h"
 #include "storage/RemoteOutputStream.h"
@@ -1017,18 +1017,18 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamLarge) {
     auto reader = IndexEntryReader::Open(input, file_size);
 
     std::vector<uint8_t> reassembled;
-    size_t chunk_count = 0;
+    size_t slice_count = 0;
     reader->ReadEntryStream(
         "test_data",
         [&](const uint8_t* d, size_t len) {
             reassembled.insert(reassembled.end(), d, d + len);
-            chunk_count++;
+            slice_count++;
         },
-        1 * 1024 * 1024);  // 1MB chunks
+        1 * 1024 * 1024);  // 1MB slices
 
     ASSERT_EQ(reassembled.size(), entry_size);
     VerifyPattern(reassembled, entry_size);
-    ASSERT_EQ(chunk_count, 4);  // 4MB / 1MB = 4 chunks
+    ASSERT_EQ(slice_count, 4);  // 4MB / 1MB = 4 slices
 }
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamSmall) {
@@ -1048,20 +1048,20 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamSmall) {
     auto reader = IndexEntryReader::Open(input, file_size);
 
     std::vector<uint8_t> reassembled;
-    size_t chunk_count = 0;
+    size_t slice_count = 0;
     reader->ReadEntryStream("small_data", [&](const uint8_t* d, size_t len) {
         reassembled.insert(reassembled.end(), d, d + len);
-        chunk_count++;
+        slice_count++;
     });
 
     ASSERT_EQ(reassembled.size(), entry_size);
     VerifyPattern(reassembled, entry_size);
-    ASSERT_EQ(chunk_count, 1);  // single chunk (1KB < default chunk size)
+    ASSERT_EQ(slice_count, 1);  // single slice (1KB < default slice size)
 }
 
-TEST_F(IndexEntryWriterV3Test, ReadEntryStreamRejectsInvalidChunkSize) {
-    const std::string file_path = kV3FilePath + "_stream_invalid_chunk";
-    const size_t entry_size = kMinStreamChunkSize;
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamRejectsInvalidSliceSize) {
+    const std::string file_path = kV3FilePath + "_stream_invalid_slice";
+    const size_t entry_size = kMinStreamSliceSize;
     auto data = GeneratePattern(entry_size);
 
     {
@@ -1080,19 +1080,19 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamRejectsInvalidChunkSize) {
                  milvus::SegcoreError);
     EXPECT_THROW(
         reader->ReadEntryStream(
-            "data", [](const uint8_t*, size_t) {}, kMinStreamChunkSize - 1),
+            "data", [](const uint8_t*, size_t) {}, kMinStreamSliceSize - 1),
         milvus::SegcoreError);
 }
 
-TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultChunkSize) {
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultSliceSize) {
     IndexEntryStreamConfigGuard guard;
     milvus::SetScalarIndexEntryStreamBudgetRatio(2.5);
-    const size_t chunk_size = DEFAULT_INDEX_FILE_SLICE_SIZE;
-    ASSERT_EQ(DefaultStreamChunkSize(), chunk_size);
-    ASSERT_DOUBLE_EQ(ScalarIndexChunkBudgetRatio(), 2.5);
+    const size_t slice_size = DEFAULT_INDEX_FILE_SLICE_SIZE;
+    ASSERT_EQ(DefaultStreamSliceSize(), slice_size);
+    ASSERT_DOUBLE_EQ(ScalarIndexStreamBudgetRatio(), 2.5);
 
     const std::string file_path = kV3FilePath + "_stream_configured_default";
-    const size_t entry_size = 2 * chunk_size + 17;
+    const size_t entry_size = 2 * slice_size + 17;
     auto data = GeneratePattern(entry_size);
 
     {
@@ -1106,15 +1106,15 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultChunkSize) {
     int64_t file_size = GetFileSize(file_path);
     auto reader = IndexEntryReader::Open(input, file_size);
 
-    std::vector<size_t> chunk_sizes;
+    std::vector<size_t> slice_sizes;
     std::vector<uint8_t> reassembled;
     reader->ReadEntryStream("data", [&](const uint8_t* d, size_t len) {
-        chunk_sizes.push_back(len);
+        slice_sizes.push_back(len);
         reassembled.insert(reassembled.end(), d, d + len);
     });
 
     ASSERT_EQ(reassembled, data);
-    ASSERT_EQ(chunk_sizes, (std::vector<size_t>{chunk_size, chunk_size, 17}));
+    ASSERT_EQ(slice_sizes, (std::vector<size_t>{slice_size, slice_size, 17}));
 }
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamEmptyEntryVerifiesCrc) {
@@ -1132,10 +1132,10 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamEmptyEntryVerifiesCrc) {
     int64_t file_size = GetFileSize(file_path);
     auto reader = IndexEntryReader::Open(input, file_size);
 
-    size_t chunk_count = 0;
+    size_t slice_count = 0;
     reader->ReadEntryStream("empty",
-                            [&](const uint8_t*, size_t) { chunk_count++; });
-    ASSERT_EQ(chunk_count, 0);
+                            [&](const uint8_t*, size_t) { slice_count++; });
+    ASSERT_EQ(slice_count, 0);
 }
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMatchesReadEntry) {
@@ -1164,7 +1164,7 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMatchesReadEntry) {
         [&](const uint8_t* d, size_t len) {
             streamed.insert(streamed.end(), d, d + len);
         },
-        512 * 1024);  // 512KB chunks
+        512 * 1024);  // 512KB slices
 
     ASSERT_EQ(entry.data.size(), streamed.size());
     EXPECT_EQ(entry.data, streamed);
@@ -1172,8 +1172,8 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMatchesReadEntry) {
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamConsumerExceptionDoesNotLeak) {
     const std::string file_path = kV3FilePath + "_stream_consumer_throw";
-    const size_t chunk_size = 64 * 1024;
-    const size_t entry_size = 4 * chunk_size;
+    const size_t slice_size = 64 * 1024;
+    const size_t entry_size = 4 * slice_size;
     auto data = GeneratePattern(entry_size);
 
     {
@@ -1187,16 +1187,16 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamConsumerExceptionDoesNotLeak) {
     int64_t file_size = GetFileSize(file_path);
     auto reader = IndexEntryReader::Open(input, file_size);
 
-    size_t chunk_count = 0;
+    size_t slice_count = 0;
     EXPECT_THROW(reader->ReadEntryStream(
                      "data",
                      [&](const uint8_t*, size_t) {
-                         chunk_count++;
+                         slice_count++;
                          throw std::runtime_error("stop stream");
                      },
-                     chunk_size),
+                     slice_size),
                  std::runtime_error);
-    EXPECT_EQ(chunk_count, 1);
+    EXPECT_EQ(slice_count, 1);
 
     std::vector<uint8_t> streamed;
     reader->ReadEntryStream(
@@ -1204,14 +1204,14 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamConsumerExceptionDoesNotLeak) {
         [&](const uint8_t* d, size_t len) {
             streamed.insert(streamed.end(), d, d + len);
         },
-        chunk_size);
+        slice_size);
     EXPECT_EQ(streamed, data);
 }
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamDrainsActiveTasksAfterError) {
     const std::string file_path = kV3FilePath + "_stream_active_task_error";
-    const size_t chunk_size = 64 * 1024;
-    const size_t entry_size = 3 * chunk_size;
+    const size_t slice_size = 64 * 1024;
+    const size_t entry_size = 3 * slice_size;
     auto data = GeneratePattern(entry_size);
 
     {
@@ -1226,19 +1226,19 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamDrainsActiveTasksAfterError) {
         base_input,
         std::vector<DelayedFailingInputStream::Rule>{
             {MILVUS_V3_MAGIC_SIZE, std::chrono::milliseconds(80), false},
-            {MILVUS_V3_MAGIC_SIZE + chunk_size,
+            {MILVUS_V3_MAGIC_SIZE + slice_size,
              std::chrono::milliseconds(40),
              true},
         });
     int64_t file_size = GetFileSize(file_path);
     auto reader = IndexEntryReader::Open(input, file_size);
 
-    size_t chunk_count = 0;
+    size_t slice_count = 0;
     EXPECT_THROW(
         reader->ReadEntryStream(
-            "data", [&](const uint8_t*, size_t) { chunk_count++; }, chunk_size),
+            "data", [&](const uint8_t*, size_t) { slice_count++; }, slice_size),
         milvus::SegcoreError);
-    EXPECT_EQ(chunk_count, 1);
+    EXPECT_EQ(slice_count, 1);
 
     auto clean_input = CreateInputStream(file_path);
     auto clean_reader = IndexEntryReader::Open(clean_input, file_size);
@@ -1248,7 +1248,7 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamDrainsActiveTasksAfterError) {
         [&](const uint8_t* d, size_t len) {
             streamed.insert(streamed.end(), d, d + len);
         },
-        chunk_size);
+        slice_size);
     EXPECT_EQ(streamed, data);
 }
 

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -46,11 +46,11 @@ namespace {
 class IndexEntryStreamConfigGuard {
  public:
     IndexEntryStreamConfigGuard()
-        : budget_ratio_(milvus::SCALAR_INDEX_ENTRY_STREAM_BUDGET_RATIO.load()) {
+        : budget_ratio_(milvus::ENTRY_STREAM_BUDGET_RATIO.load()) {
     }
 
     ~IndexEntryStreamConfigGuard() {
-        milvus::SetScalarIndexEntryStreamBudgetRatio(budget_ratio_);
+        milvus::SetStreamBudgetRatio(budget_ratio_);
     }
 
  private:
@@ -58,7 +58,7 @@ class IndexEntryStreamConfigGuard {
 };
 
 size_t
-ExpectedScalarIndexStreamBudgetBytes(double ratio) {
+ExpectedEntryStreamBudgetBytes(double ratio) {
     auto slice_size = DefaultStreamSliceSize();
     auto core_num = std::max(1, milvus::CPU_NUM);
     auto capacity = static_cast<size_t>(core_num * ratio) * slice_size;
@@ -1095,19 +1095,17 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamRejectsInvalidSliceSize) {
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultSliceSize) {
     IndexEntryStreamConfigGuard guard;
-    milvus::SetScalarIndexEntryStreamBudgetRatio(2.5);
+    milvus::SetStreamBudgetRatio(2.5);
     const size_t slice_size = DEFAULT_INDEX_FILE_SLICE_SIZE;
     ASSERT_EQ(DefaultStreamSliceSize(), slice_size);
-    ASSERT_DOUBLE_EQ(ScalarIndexStreamBudgetRatio(), 2.5);
-    ASSERT_EQ(
-        TransientMemoryBudget::GetScalarIndexStreamBudget().CapacityBytes(),
-        ExpectedScalarIndexStreamBudgetBytes(2.5));
+    ASSERT_DOUBLE_EQ(StreamBudgetRatio(), 2.5);
+    ASSERT_EQ(TransientMemoryBudget::GetEntryStreamBudget().CapacityBytes(),
+              ExpectedEntryStreamBudgetBytes(2.5));
 
-    milvus::SetScalarIndexEntryStreamBudgetRatio(3.5);
-    ASSERT_DOUBLE_EQ(ScalarIndexStreamBudgetRatio(), 3.5);
-    ASSERT_EQ(
-        TransientMemoryBudget::GetScalarIndexStreamBudget().CapacityBytes(),
-        ExpectedScalarIndexStreamBudgetBytes(3.5));
+    milvus::SetStreamBudgetRatio(3.5);
+    ASSERT_DOUBLE_EQ(StreamBudgetRatio(), 3.5);
+    ASSERT_EQ(TransientMemoryBudget::GetEntryStreamBudget().CapacityBytes(),
+              ExpectedEntryStreamBudgetBytes(3.5));
 
     const std::string file_path = kV3FilePath + "_stream_configured_default";
     const size_t entry_size = 2 * slice_size + 17;

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -13,16 +13,20 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
 #include "common/EasyAssert.h"
+#include "filemanager/InputStream.h"
 #include "test_utils/Constants.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "storage/IndexEntryDirectStreamWriter.h"
@@ -127,6 +131,68 @@ class MockCipherPlugin : public plugin::ICipherPlugin {
     GetDecryptor(int64_t, int64_t, const std::string&) const override {
         return std::make_shared<MockDecryptor>();
     }
+};
+
+class DelayedFailingInputStream : public milvus::InputStream {
+ public:
+    struct Rule {
+        size_t offset;
+        std::chrono::milliseconds delay;
+        bool fail;
+    };
+
+    DelayedFailingInputStream(std::shared_ptr<milvus::InputStream> base,
+                              std::vector<Rule> rules)
+        : base_(std::move(base)), rules_(std::move(rules)) {
+    }
+
+    size_t
+    Size() const override {
+        return base_->Size();
+    }
+
+    bool
+    Seek(int64_t offset) override {
+        return base_->Seek(offset);
+    }
+
+    size_t
+    Tell() const override {
+        return base_->Tell();
+    }
+
+    bool
+    Eof() const override {
+        return base_->Eof();
+    }
+
+    size_t
+    Read(void* ptr, size_t size) override {
+        return base_->Read(ptr, size);
+    }
+
+    size_t
+    ReadAt(void* ptr, size_t offset, size_t size) override {
+        for (const auto& rule : rules_) {
+            if (rule.offset == offset) {
+                std::this_thread::sleep_for(rule.delay);
+                if (rule.fail) {
+                    return 0;
+                }
+                break;
+            }
+        }
+        return base_->ReadAt(ptr, offset, size);
+    }
+
+    size_t
+    Read(int fd, size_t size) override {
+        return base_->Read(fd, size);
+    }
+
+ private:
+    std::shared_ptr<milvus::InputStream> base_;
+    std::vector<Rule> rules_;
 };
 
 }  // namespace
@@ -1007,6 +1073,89 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMatchesReadEntry) {
 
     ASSERT_EQ(entry.data.size(), streamed.size());
     EXPECT_EQ(entry.data, streamed);
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamCallbackExceptionDoesNotLeak) {
+    const std::string file_path = kV3FilePath + "_stream_callback_throw";
+    const size_t chunk_size = 64 * 1024;
+    const size_t entry_size = 4 * chunk_size;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    size_t callback_count = 0;
+    EXPECT_THROW(reader->ReadEntryStream(
+                     "data",
+                     [&](const uint8_t*, size_t) {
+                         callback_count++;
+                         throw std::runtime_error("stop stream");
+                     },
+                     chunk_size),
+                 std::runtime_error);
+    EXPECT_EQ(callback_count, 1);
+
+    std::vector<uint8_t> streamed;
+    reader->ReadEntryStream(
+        "data",
+        [&](const uint8_t* d, size_t len) {
+            streamed.insert(streamed.end(), d, d + len);
+        },
+        chunk_size);
+    EXPECT_EQ(streamed, data);
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamDrainsReorderBufferAfterError) {
+    const std::string file_path = kV3FilePath + "_stream_reorder_error";
+    const size_t chunk_size = 64 * 1024;
+    const size_t entry_size = 3 * chunk_size;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto base_input = CreateInputStream(file_path);
+    auto input = std::make_shared<DelayedFailingInputStream>(
+        base_input,
+        std::vector<DelayedFailingInputStream::Rule>{
+            {MILVUS_V3_MAGIC_SIZE, std::chrono::milliseconds(80), false},
+            {MILVUS_V3_MAGIC_SIZE + chunk_size,
+             std::chrono::milliseconds(40),
+             true},
+        });
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    size_t callback_count = 0;
+    EXPECT_THROW(reader->ReadEntryStream(
+                     "data",
+                     [&](const uint8_t*, size_t) { callback_count++; },
+                     chunk_size),
+                 milvus::SegcoreError);
+    EXPECT_LE(callback_count, 1);
+
+    auto clean_input = CreateInputStream(file_path);
+    auto clean_reader = IndexEntryReader::Open(clean_input, file_size);
+    std::vector<uint8_t> streamed;
+    clean_reader->ReadEntryStream(
+        "data",
+        [&](const uint8_t* d, size_t len) {
+            streamed.insert(streamed.end(), d, d + len);
+        },
+        chunk_size);
+    EXPECT_EQ(streamed, data);
 }
 
 TEST_F(IndexEntryWriterV3Test, GetEntrySize) {

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -1001,18 +1001,18 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamLarge) {
     auto reader = IndexEntryReader::Open(input, file_size);
 
     std::vector<uint8_t> reassembled;
-    size_t callback_count = 0;
+    size_t chunk_count = 0;
     reader->ReadEntryStream(
         "test_data",
         [&](const uint8_t* d, size_t len) {
             reassembled.insert(reassembled.end(), d, d + len);
-            callback_count++;
+            chunk_count++;
         },
         1 * 1024 * 1024);  // 1MB chunks
 
     ASSERT_EQ(reassembled.size(), entry_size);
     VerifyPattern(reassembled, entry_size);
-    ASSERT_EQ(callback_count, 4);  // 4MB / 1MB = 4 chunks
+    ASSERT_EQ(chunk_count, 4);  // 4MB / 1MB = 4 chunks
 }
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamSmall) {
@@ -1032,15 +1032,15 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamSmall) {
     auto reader = IndexEntryReader::Open(input, file_size);
 
     std::vector<uint8_t> reassembled;
-    size_t callback_count = 0;
+    size_t chunk_count = 0;
     reader->ReadEntryStream("small_data", [&](const uint8_t* d, size_t len) {
         reassembled.insert(reassembled.end(), d, d + len);
-        callback_count++;
+        chunk_count++;
     });
 
     ASSERT_EQ(reassembled.size(), entry_size);
     VerifyPattern(reassembled, entry_size);
-    ASSERT_EQ(callback_count, 1);  // single chunk (1KB < 2MB default)
+    ASSERT_EQ(chunk_count, 1);  // single chunk (1KB < 2MB default)
 }
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMatchesReadEntry) {
@@ -1075,8 +1075,8 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMatchesReadEntry) {
     EXPECT_EQ(entry.data, streamed);
 }
 
-TEST_F(IndexEntryWriterV3Test, ReadEntryStreamCallbackExceptionDoesNotLeak) {
-    const std::string file_path = kV3FilePath + "_stream_callback_throw";
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamConsumerExceptionDoesNotLeak) {
+    const std::string file_path = kV3FilePath + "_stream_consumer_throw";
     const size_t chunk_size = 64 * 1024;
     const size_t entry_size = 4 * chunk_size;
     auto data = GeneratePattern(entry_size);
@@ -1092,16 +1092,16 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamCallbackExceptionDoesNotLeak) {
     int64_t file_size = GetFileSize(file_path);
     auto reader = IndexEntryReader::Open(input, file_size);
 
-    size_t callback_count = 0;
+    size_t chunk_count = 0;
     EXPECT_THROW(reader->ReadEntryStream(
                      "data",
                      [&](const uint8_t*, size_t) {
-                         callback_count++;
+                         chunk_count++;
                          throw std::runtime_error("stop stream");
                      },
                      chunk_size),
                  std::runtime_error);
-    EXPECT_EQ(callback_count, 1);
+    EXPECT_EQ(chunk_count, 1);
 
     std::vector<uint8_t> streamed;
     reader->ReadEntryStream(
@@ -1138,13 +1138,12 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamDrainsReorderBufferAfterError) {
     int64_t file_size = GetFileSize(file_path);
     auto reader = IndexEntryReader::Open(input, file_size);
 
-    size_t callback_count = 0;
-    EXPECT_THROW(reader->ReadEntryStream(
-                     "data",
-                     [&](const uint8_t*, size_t) { callback_count++; },
-                     chunk_size),
-                 milvus::SegcoreError);
-    EXPECT_LE(callback_count, 1);
+    size_t chunk_count = 0;
+    EXPECT_THROW(
+        reader->ReadEntryStream(
+            "data", [&](const uint8_t*, size_t) { chunk_count++; }, chunk_size),
+        milvus::SegcoreError);
+    EXPECT_LE(chunk_count, 1);
 
     auto clean_input = CreateInputStream(file_path);
     auto clean_reader = IndexEntryReader::Open(clean_input, file_size);

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -57,6 +57,10 @@ func InitSegcore(nodeID int64) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
+	cIndexEntryStreamChunkSize := C.int64_t(paramtable.Get().CommonCfg.IndexEntryStreamChunkSize.GetAsInt64())
+	C.SetIndexEntryStreamChunkSize(cIndexEntryStreamChunkSize)
+	cScalarIndexEntryStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.ScalarIndexEntryStreamBudgetRatio.GetAsFloat())
+	C.SetScalarIndexEntryStreamBudgetRatio(cScalarIndexEntryStreamBudgetRatio)
 
 	// set up thread pool for different priorities
 	cHighPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.HighPriorityThreadCoreCoefficient.GetAsFloat())

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -57,8 +57,8 @@ func InitSegcore(nodeID int64) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
-	cScalarIndexEntryStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.ScalarIndexEntryStreamBudgetRatio.GetAsFloat())
-	C.SetScalarIndexEntryStreamBudgetRatio(cScalarIndexEntryStreamBudgetRatio)
+	cStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.StreamBudgetRatio.GetAsFloat())
+	C.SetStreamBudgetRatio(cStreamBudgetRatio)
 
 	// set up thread pool for different priorities
 	cHighPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.HighPriorityThreadCoreCoefficient.GetAsFloat())

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -57,8 +57,6 @@ func InitSegcore(nodeID int64) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
-	cIndexEntryStreamChunkSize := C.int64_t(paramtable.Get().CommonCfg.IndexEntryStreamChunkSize.GetAsInt64())
-	C.SetIndexEntryStreamChunkSize(cIndexEntryStreamChunkSize)
 	cScalarIndexEntryStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.ScalarIndexEntryStreamBudgetRatio.GetAsFloat())
 	C.SetScalarIndexEntryStreamBudgetRatio(cScalarIndexEntryStreamBudgetRatio)
 

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -524,12 +524,12 @@ func SetupCoreConfigChangelCallback() {
 			return nil
 		})
 
-		paramtable.Get().CommonCfg.ScalarIndexEntryStreamBudgetRatio.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+		paramtable.Get().CommonCfg.StreamBudgetRatio.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
 			ratio, err := strconv.ParseFloat(newValue, 64)
 			if err != nil {
 				return err
 			}
-			UpdateScalarIndexEntryStreamBudgetRatio(ratio)
+			UpdateStreamBudgetRatio(ratio)
 			return nil
 		})
 

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -524,6 +524,15 @@ func SetupCoreConfigChangelCallback() {
 			return nil
 		})
 
+		paramtable.Get().CommonCfg.ScalarIndexEntryStreamBudgetRatio.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+			ratio, err := strconv.ParseFloat(newValue, 64)
+			if err != nil {
+				return err
+			}
+			UpdateScalarIndexEntryStreamBudgetRatio(ratio)
+			return nil
+		})
+
 		paramtable.Get().QueryNodeCfg.KnowhereThreadPoolSize.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
 			factor, err := strconv.ParseFloat(newValue, 64)
 			if err != nil {

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -105,8 +105,6 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
-	cIndexEntryStreamChunkSize := C.int64_t(paramtable.Get().CommonCfg.IndexEntryStreamChunkSize.GetAsInt64())
-	C.SetIndexEntryStreamChunkSize(cIndexEntryStreamChunkSize)
 	cScalarIndexEntryStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.ScalarIndexEntryStreamBudgetRatio.GetAsFloat())
 	C.SetScalarIndexEntryStreamBudgetRatio(cScalarIndexEntryStreamBudgetRatio)
 

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -105,6 +105,10 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
+	cIndexEntryStreamChunkSize := C.int64_t(paramtable.Get().CommonCfg.IndexEntryStreamChunkSize.GetAsInt64())
+	C.SetIndexEntryStreamChunkSize(cIndexEntryStreamChunkSize)
+	cScalarIndexEntryStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.ScalarIndexEntryStreamBudgetRatio.GetAsFloat())
+	C.SetScalarIndexEntryStreamBudgetRatio(cScalarIndexEntryStreamBudgetRatio)
 
 	// set up thread pool for different priorities
 	cHighPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.HighPriorityThreadCoreCoefficient.GetAsFloat())

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -105,8 +105,8 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
-	cScalarIndexEntryStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.ScalarIndexEntryStreamBudgetRatio.GetAsFloat())
-	C.SetScalarIndexEntryStreamBudgetRatio(cScalarIndexEntryStreamBudgetRatio)
+	cStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.StreamBudgetRatio.GetAsFloat())
+	C.SetStreamBudgetRatio(cStreamBudgetRatio)
 
 	// set up thread pool for different priorities
 	cHighPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.HighPriorityThreadCoreCoefficient.GetAsFloat())

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -47,6 +47,10 @@ func UpdateIndexSliceSize(size int) {
 	C.SetIndexSliceSize(C.int64_t(size))
 }
 
+func UpdateScalarIndexEntryStreamBudgetRatio(ratio float64) {
+	C.SetScalarIndexEntryStreamBudgetRatio(C.double(ratio))
+}
+
 func UpdateHighPriorityThreadCoreCoefficient(coefficient float64) {
 	C.SetHighPriorityThreadCoreCoefficient(C.float(coefficient))
 }

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -47,8 +47,8 @@ func UpdateIndexSliceSize(size int) {
 	C.SetIndexSliceSize(C.int64_t(size))
 }
 
-func UpdateScalarIndexEntryStreamBudgetRatio(ratio float64) {
-	C.SetScalarIndexEntryStreamBudgetRatio(C.double(ratio))
+func UpdateStreamBudgetRatio(ratio float64) {
+	C.SetStreamBudgetRatio(C.double(ratio))
 }
 
 func UpdateHighPriorityThreadCoreCoefficient(coefficient float64) {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -41,7 +41,6 @@ import (
 const (
 	// DefaultIndexSliceSize defines the default slice size of index file when serializing.
 	DefaultIndexSliceSize                      = 16
-	DefaultIndexEntryStreamChunkSize           = 2 * 1024 * 1024
 	DefaultScalarIndexEntryStreamBudgetRatio   = 3.0
 	DefaultGracefulTime                        = 5000 // ms
 	DefaultGracefulStopTimeout                 = 1800 // s, for node
@@ -229,7 +228,6 @@ type commonConfig struct {
 	DefaultIndexName     ParamItem `refreshable:"true"`
 
 	IndexSliceSize                      ParamItem `refreshable:"false"`
-	IndexEntryStreamChunkSize           ParamItem `refreshable:"false"`
 	ScalarIndexEntryStreamBudgetRatio   ParamItem `refreshable:"false"`
 	HighPriorityThreadCoreCoefficient   ParamItem `refreshable:"true"`
 	MiddlePriorityThreadCoreCoefficient ParamItem `refreshable:"true"`
@@ -553,15 +551,6 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export:       true,
 	}
 	p.IndexSliceSize.Init(base.mgr)
-
-	p.IndexEntryStreamChunkSize = ParamItem{
-		Key:          "common.indexEntryStream.chunkSize",
-		Version:      "3.0.0",
-		DefaultValue: strconv.Itoa(DefaultIndexEntryStreamChunkSize),
-		Doc:          "Default chunk size in bytes for streaming V3 index entry reads",
-		Export:       true,
-	}
-	p.IndexEntryStreamChunkSize.Init(base.mgr)
 
 	p.ScalarIndexEntryStreamBudgetRatio = ParamItem{
 		Key:          "common.indexEntryStream.scalarIndexBudgetRatio",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -41,6 +41,8 @@ import (
 const (
 	// DefaultIndexSliceSize defines the default slice size of index file when serializing.
 	DefaultIndexSliceSize                      = 16
+	DefaultIndexEntryStreamChunkSize           = 2 * 1024 * 1024
+	DefaultScalarIndexEntryStreamBudgetRatio   = 3.0
 	DefaultGracefulTime                        = 5000 // ms
 	DefaultGracefulStopTimeout                 = 1800 // s, for node
 	DefaultProxyGracefulStopTimeout            = 30   // s，for proxy
@@ -227,6 +229,8 @@ type commonConfig struct {
 	DefaultIndexName     ParamItem `refreshable:"true"`
 
 	IndexSliceSize                      ParamItem `refreshable:"false"`
+	IndexEntryStreamChunkSize           ParamItem `refreshable:"false"`
+	ScalarIndexEntryStreamBudgetRatio   ParamItem `refreshable:"false"`
 	HighPriorityThreadCoreCoefficient   ParamItem `refreshable:"true"`
 	MiddlePriorityThreadCoreCoefficient ParamItem `refreshable:"true"`
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`
@@ -549,6 +553,24 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export:       true,
 	}
 	p.IndexSliceSize.Init(base.mgr)
+
+	p.IndexEntryStreamChunkSize = ParamItem{
+		Key:          "common.indexEntryStream.chunkSize",
+		Version:      "3.0.0",
+		DefaultValue: strconv.Itoa(DefaultIndexEntryStreamChunkSize),
+		Doc:          "Default chunk size in bytes for streaming V3 index entry reads",
+		Export:       true,
+	}
+	p.IndexEntryStreamChunkSize.Init(base.mgr)
+
+	p.ScalarIndexEntryStreamBudgetRatio = ParamItem{
+		Key:          "common.indexEntryStream.scalarIndexBudgetRatio",
+		Version:      "3.0.0",
+		DefaultValue: fmt.Sprintf("%f", DefaultScalarIndexEntryStreamBudgetRatio),
+		Doc:          "Multiplier for scalar index stream transient memory budget, relative to CPU core count",
+		Export:       true,
+	}
+	p.ScalarIndexEntryStreamBudgetRatio.Init(base.mgr)
 
 	p.EnableMaterializedView = ParamItem{
 		Key:          "common.materializedView.enabled",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -41,7 +41,7 @@ import (
 const (
 	// DefaultIndexSliceSize defines the default slice size of index file when serializing.
 	DefaultIndexSliceSize                      = 16
-	DefaultScalarIndexEntryStreamBudgetRatio   = 3.0
+	DefaultStreamBudgetRatio                   = 3.0
 	DefaultGracefulTime                        = 5000 // ms
 	DefaultGracefulStopTimeout                 = 1800 // s, for node
 	DefaultProxyGracefulStopTimeout            = 30   // s，for proxy
@@ -228,7 +228,7 @@ type commonConfig struct {
 	DefaultIndexName     ParamItem `refreshable:"true"`
 
 	IndexSliceSize                      ParamItem `refreshable:"false"`
-	ScalarIndexEntryStreamBudgetRatio   ParamItem `refreshable:"true"`
+	StreamBudgetRatio                   ParamItem `refreshable:"true"`
 	HighPriorityThreadCoreCoefficient   ParamItem `refreshable:"true"`
 	MiddlePriorityThreadCoreCoefficient ParamItem `refreshable:"true"`
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`
@@ -552,14 +552,14 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 	}
 	p.IndexSliceSize.Init(base.mgr)
 
-	p.ScalarIndexEntryStreamBudgetRatio = ParamItem{
-		Key:          "common.indexEntryStream.scalarIndexBudgetRatio",
+	p.StreamBudgetRatio = ParamItem{
+		Key:          "common.entryStream.streamBudgetRatio",
 		Version:      "3.0.0",
-		DefaultValue: fmt.Sprintf("%f", DefaultScalarIndexEntryStreamBudgetRatio),
-		Doc:          "Multiplier for scalar index stream transient memory budget, relative to CPU core count",
+		DefaultValue: fmt.Sprintf("%f", DefaultStreamBudgetRatio),
+		Doc:          "Multiplier for entry stream transient memory budget, relative to CPU core count",
 		Export:       true,
 	}
-	p.ScalarIndexEntryStreamBudgetRatio.Init(base.mgr)
+	p.StreamBudgetRatio.Init(base.mgr)
 
 	p.EnableMaterializedView = ParamItem{
 		Key:          "common.materializedView.enabled",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -228,7 +228,7 @@ type commonConfig struct {
 	DefaultIndexName     ParamItem `refreshable:"true"`
 
 	IndexSliceSize                      ParamItem `refreshable:"false"`
-	ScalarIndexEntryStreamBudgetRatio   ParamItem `refreshable:"false"`
+	ScalarIndexEntryStreamBudgetRatio   ParamItem `refreshable:"true"`
 	HighPriorityThreadCoreCoefficient   ParamItem `refreshable:"true"`
 	MiddlePriorityThreadCoreCoefficient ParamItem `refreshable:"true"`
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -55,11 +55,8 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, Params.IndexSliceSize.GetAsInt64(), int64(DefaultIndexSliceSize))
 		t.Logf("knowhere index slice size = %d", Params.IndexSliceSize.GetAsInt64())
 
-		assert.Equal(t, int64(DefaultIndexEntryStreamChunkSize), Params.IndexEntryStreamChunkSize.GetAsInt64())
 		assert.InDelta(t, DefaultScalarIndexEntryStreamBudgetRatio, Params.ScalarIndexEntryStreamBudgetRatio.GetAsFloat(), 0.0001)
-		params.Save(Params.IndexEntryStreamChunkSize.Key, "4194304")
 		params.Save(Params.ScalarIndexEntryStreamBudgetRatio.Key, "2.5")
-		assert.Equal(t, int64(4194304), Params.IndexEntryStreamChunkSize.GetAsInt64())
 		assert.InDelta(t, 2.5, Params.ScalarIndexEntryStreamBudgetRatio.GetAsFloat(), 0.0001)
 
 		assert.Equal(t, int64(0), Params.ArrowReaderHoleSizeLimitBytes.GetAsInt64())

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -55,6 +55,13 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, Params.IndexSliceSize.GetAsInt64(), int64(DefaultIndexSliceSize))
 		t.Logf("knowhere index slice size = %d", Params.IndexSliceSize.GetAsInt64())
 
+		assert.Equal(t, int64(DefaultIndexEntryStreamChunkSize), Params.IndexEntryStreamChunkSize.GetAsInt64())
+		assert.InDelta(t, DefaultScalarIndexEntryStreamBudgetRatio, Params.ScalarIndexEntryStreamBudgetRatio.GetAsFloat(), 0.0001)
+		params.Save(Params.IndexEntryStreamChunkSize.Key, "4194304")
+		params.Save(Params.ScalarIndexEntryStreamBudgetRatio.Key, "2.5")
+		assert.Equal(t, int64(4194304), Params.IndexEntryStreamChunkSize.GetAsInt64())
+		assert.InDelta(t, 2.5, Params.ScalarIndexEntryStreamBudgetRatio.GetAsFloat(), 0.0001)
+
 		assert.Equal(t, int64(0), Params.ArrowReaderHoleSizeLimitBytes.GetAsInt64())
 		assert.Equal(t, int64(0), Params.ArrowReaderRangeSizeLimitBytes.GetAsInt64())
 		params.Save(Params.ArrowReaderHoleSizeLimitBytes.Key, "1048576")

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -55,9 +55,9 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, Params.IndexSliceSize.GetAsInt64(), int64(DefaultIndexSliceSize))
 		t.Logf("knowhere index slice size = %d", Params.IndexSliceSize.GetAsInt64())
 
-		assert.InDelta(t, DefaultScalarIndexEntryStreamBudgetRatio, Params.ScalarIndexEntryStreamBudgetRatio.GetAsFloat(), 0.0001)
-		params.Save(Params.ScalarIndexEntryStreamBudgetRatio.Key, "2.5")
-		assert.InDelta(t, 2.5, Params.ScalarIndexEntryStreamBudgetRatio.GetAsFloat(), 0.0001)
+		assert.InDelta(t, DefaultStreamBudgetRatio, Params.StreamBudgetRatio.GetAsFloat(), 0.0001)
+		params.Save(Params.StreamBudgetRatio.Key, "2.5")
+		assert.InDelta(t, 2.5, Params.StreamBudgetRatio.GetAsFloat(), 0.0001)
 
 		assert.Equal(t, int64(0), Params.ArrowReaderHoleSizeLimitBytes.GetAsInt64())
 		assert.Equal(t, int64(0), Params.ArrowReaderRangeSizeLimitBytes.GetAsInt64())


### PR DESCRIPTION
issue: #48957

- Add `IndexEntryReader::ReadEntryStream`, `GetEntrySize`, and `HasEntry` for V3 entries.
- Stream plain and encrypted entries through ordered slices with incremental CRC32c verification.
- Bound transient stream memory with a process-wide entry stream budget.
- Add dynamically refreshable `common.entryStream.streamBudgetRatio` to tune the shared entry stream budget for current scalar index loading and later field data loading.
- Use 16MB stream slices by default, aligned with the encrypted slice size and existing V3 range size.
- Derive the entry stream budget from CPU core count: `CPU cores * streamBudgetRatio * 16MB`.
- Harden stream error handling:
  - keep active futures bounded by the thread pool size
  - reject zero or too-small explicit slice sizes
  - use overflow-safe slice count calculation
  - verify CRC for empty entries
  - release budget when callbacks throw or task submission fails
  - wait for active workers before returning on abnormal exits
  - validate decrypted slice length and include actual/expected CRC in stream errors
- Document V3 streaming read behavior and shared budget configuration.