### PR TITLE
test: stabilize external collection cancel test

### DIFF
--- a/internal/datanode/external/manager_test.go
+++ b/internal/datanode/external/manager_test.go
@@ -248,9 +248,13 @@ func TestExternalCollectionManager_CancelTask(t *testing.T) {
 		}
 	}, time.Second, 10*time.Millisecond)
 
-	info := manager.Get(clusterID, taskID)
+	var info *TaskInfo
+	require.Eventually(t, func() bool {
+		info = manager.Get(clusterID, taskID)
+		return info != nil && info.State == indexpb.JobState_JobStateFailed
+	}, time.Second, 10*time.Millisecond)
+
 	require.NotNil(t, info)
-	assert.Equal(t, indexpb.JobState_JobStateFailed, info.State)
 	assert.Contains(t, info.FailReason, "context canceled")
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Stabilizes `TestExternalCollectionManager_CancelTask` by waiting for the asynchronous manager state update after cancel is observed by the task function.

`CancelTask` only triggers context cancellation. The task goroutine records `JobStateFailed` after `taskFunc` returns with `context.Canceled`, so reading the task info immediately after observing `ctx.Done()` can race with `UpdateResult` and intermittently see `JobStateInProgress` with an empty failure reason.

This test now waits until the manager snapshot reports `JobStateFailed`, then asserts the failure reason separately for clearer failure output.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

This is a test-only flaky fix.

#### Tests

- `gofumpt -l internal/datanode/external/manager_test.go`
- `git diff --check HEAD~1..HEAD`
- `go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r ${MILVUS_WORK_DIR}/cmake_build/lib -r ${MILVUS_WORK_DIR}/internal/core/output/lib" ./internal/datanode/external -run 'TestExternalCollectionManager_CancelTask' -timeout 300s`
- `go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r ${MILVUS_WORK_DIR}/cmake_build/lib -r ${MILVUS_WORK_DIR}/internal/core/output/lib" ./internal/datanode/external -timeout 300s`
