### PR TITLE
enhance: support take output for internal collections

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2811,6 +2811,27 @@ ChunkedSegmentSealedImpl::bulk_subscript_vector_array_impl(
         count);
 }
 
+static std::vector<std::string>
+ReadTextLobBatch(
+    const std::string& lob_base_path,
+    const std::vector<milvus_storage::lob_column::EncodedRef>& encoded_refs) {
+    if (encoded_refs.empty()) {
+        return {};
+    }
+
+    auto properties = milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+                          .GetProperties();
+    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
+
+    auto& cache = GetGlobalTextColumnCache();
+    return cache.ReadBatch(lob_base_path, fs, *properties, encoded_refs);
+}
+
+static milvus_storage::lob_column::EncodedRef
+MakeTextLobEncodedRef(const void* data, size_t size) {
+    return {static_cast<const uint8_t*>(data), size};
+}
+
 void
 ChunkedSegmentSealedImpl::bulk_subscript_text_impl(
     milvus::OpContext* op_ctx,
@@ -2841,7 +2862,7 @@ ChunkedSegmentSealedImpl::bulk_subscript_text_impl(
                 return;  // skip null values
             }
             encoded_refs.push_back(
-                {reinterpret_cast<const uint8_t*>(value.data()), value.size()});
+                MakeTextLobEncodedRef(value.data(), value.size()));
             valid_indices.push_back(idx);
         },
         seg_offsets,
@@ -2851,12 +2872,7 @@ ChunkedSegmentSealedImpl::bulk_subscript_text_impl(
         return;
     }
 
-    auto properties = milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
-                          .GetProperties();
-    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
-
-    auto& cache = GetGlobalTextColumnCache();
-    auto texts = cache.ReadBatch(lob_base_path, fs, *properties, encoded_refs);
+    auto texts = ReadTextLobBatch(lob_base_path, encoded_refs);
     for (size_t i = 0; i < valid_indices.size() && i < texts.size(); i++) {
         *dst->Mutable(valid_indices[i]) = std::move(texts[i]);
     }
@@ -5517,6 +5533,18 @@ LogTakeFallback(const char* caller_tag,
         field_count);
 }
 
+static bool
+ShouldProjectInternalTakeDynamicField(
+    const Schema& schema,
+    FieldId field_id,
+    const std::vector<std::string>& target_dynamic_fields) {
+    if (schema.is_external_collection() || target_dynamic_fields.empty()) {
+        return false;
+    }
+    auto dynamic_field_id = schema.get_dynamic_field_id();
+    return dynamic_field_id.has_value() && dynamic_field_id.value() == field_id;
+}
+
 ChunkedSegmentSealedImpl::TakeContext
 ChunkedSegmentSealedImpl::BuildTakeContext(const int64_t* offsets,
                                            int64_t size) {
@@ -5554,7 +5582,9 @@ ChunkedSegmentSealedImpl::ArrowToDataArray(
     const std::shared_ptr<arrow::Array>& arr,
     const FieldMeta& field_meta,
     const std::vector<int64_t>& result_mapping,
-    int64_t size) {
+    int64_t size,
+    const std::vector<std::string>* dynamic_field_names,
+    const std::string* text_lob_path) {
     auto data_array = std::make_unique<DataArray>();
     data_array->set_type(
         static_cast<proto::schema::DataType>(field_meta.get_data_type()));
@@ -5618,9 +5648,63 @@ ChunkedSegmentSealedImpl::ArrowToDataArray(
             }
             break;
         }
-        case DataType::VARCHAR:
-        case DataType::STRING:
         case DataType::TEXT: {
+            auto obj = data_array->mutable_scalars()->mutable_string_data();
+            if (text_lob_path != nullptr) {
+                std::vector<milvus_storage::lob_column::EncodedRef>
+                    encoded_refs;
+                encoded_refs.reserve(size);
+                std::vector<std::string> string_refs;
+                string_refs.reserve(size);
+
+                if (arr->type()->id() == arrow::Type::STRING) {
+                    auto typed =
+                        std::static_pointer_cast<arrow::StringArray>(arr);
+                    for (int64_t i = 0; i < size; i++) {
+                        auto idx = result_mapping[i];
+                        if (typed->IsNull(idx)) {
+                            encoded_refs.push_back(
+                                MakeTextLobEncodedRef(nullptr, 0));
+                            continue;
+                        }
+                        string_refs.emplace_back(typed->GetString(idx));
+                        auto& ref = string_refs.back();
+                        encoded_refs.push_back(
+                            MakeTextLobEncodedRef(ref.data(), ref.size()));
+                    }
+                } else if (arr->type()->id() == arrow::Type::BINARY) {
+                    auto typed =
+                        std::static_pointer_cast<arrow::BinaryArray>(arr);
+                    for (int64_t i = 0; i < size; i++) {
+                        auto idx = result_mapping[i];
+                        if (typed->IsNull(idx)) {
+                            encoded_refs.push_back(
+                                MakeTextLobEncodedRef(nullptr, 0));
+                            continue;
+                        }
+                        auto val = typed->Value(idx);
+                        encoded_refs.push_back(MakeTextLobEncodedRef(
+                            val.data(), static_cast<size_t>(val.size())));
+                    }
+                } else {
+                    return nullptr;
+                }
+
+                auto texts = ReadTextLobBatch(*text_lob_path, encoded_refs);
+                for (auto& text : texts) {
+                    obj->add_data(std::move(text));
+                }
+                break;
+            }
+
+            auto typed = std::static_pointer_cast<arrow::StringArray>(arr);
+            for (int64_t i = 0; i < size; i++) {
+                obj->add_data(typed->GetString(result_mapping[i]));
+            }
+            break;
+        }
+        case DataType::VARCHAR:
+        case DataType::STRING: {
             auto typed = std::static_pointer_cast<arrow::StringArray>(arr);
             auto obj = data_array->mutable_scalars()->mutable_string_data();
             for (int64_t i = 0; i < size; i++) {
@@ -5634,7 +5718,17 @@ ChunkedSegmentSealedImpl::ArrowToDataArray(
             auto typed = std::static_pointer_cast<arrow::BinaryArray>(arr);
             for (int64_t i = 0; i < size; i++) {
                 auto val = typed->Value(result_mapping[i]);
-                obj->add_data(val.data(), val.size());
+                if (dynamic_field_names != nullptr &&
+                    !dynamic_field_names->empty()) {
+                    auto projected = ExtractSubJson(
+                        std::string_view(
+                            reinterpret_cast<const char*>(val.data()),
+                            val.size()),
+                        *dynamic_field_names);
+                    obj->add_data(std::move(projected));
+                } else {
+                    obj->add_data(val.data(), val.size());
+                }
             }
             break;
         }
@@ -6065,8 +6159,36 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
             arr = storage::NormalizeExternalArrow(arr, field_meta);
         }
 
-        auto data_array =
-            ArrowToDataArray(arr, field_meta, ctx.result_mapping, size);
+        auto dynamic_field_names =
+            ShouldProjectInternalTakeDynamicField(
+                *schema_, field_id, plan->target_dynamic_fields_)
+                ? &plan->target_dynamic_fields_
+                : nullptr;
+        const std::string* text_lob_path = nullptr;
+        if (!is_external_collection &&
+            field_meta.get_data_type() == DataType::TEXT) {
+            auto path_it = text_lob_paths_.find(field_id);
+            if (path_it == text_lob_paths_.end()) {
+                LogTakeFallback(
+                    "retrieve",
+                    id_,
+                    size,
+                    ctx.unique_offsets.size(),
+                    take_field_ids.size(),
+                    fmt::format("missing TEXT LOB path for field {}",
+                                field_id.get()));
+                results->clear_fields_data();
+                results->clear_ids();
+                return false;
+            }
+            text_lob_path = &path_it->second;
+        }
+        auto data_array = ArrowToDataArray(arr,
+                                           field_meta,
+                                           ctx.result_mapping,
+                                           size,
+                                           dynamic_field_names,
+                                           text_lob_path);
         if (!data_array) {
             LOG_WARN(
                 "[TakeAPI] unsupported data type {} for field '{}', "
@@ -6226,8 +6348,35 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
             arr = storage::NormalizeExternalArrow(arr, field_meta);
         }
 
-        auto data_array =
-            ArrowToDataArray(arr, field_meta, ctx.result_mapping, size);
+        auto dynamic_field_names =
+            ShouldProjectInternalTakeDynamicField(
+                *schema_, field_id, plan->target_dynamic_fields_)
+                ? &plan->target_dynamic_fields_
+                : nullptr;
+        const std::string* text_lob_path = nullptr;
+        if (!is_external_collection &&
+            field_meta.get_data_type() == DataType::TEXT) {
+            auto path_it = text_lob_paths_.find(field_id);
+            if (path_it == text_lob_paths_.end()) {
+                LogTakeFallback(
+                    "search",
+                    id_,
+                    size,
+                    ctx.unique_offsets.size(),
+                    take_field_ids.size(),
+                    fmt::format("missing TEXT LOB path for field {}",
+                                field_id.get()));
+                results.output_fields_data_.clear();
+                return false;
+            }
+            text_lob_path = &path_it->second;
+        }
+        auto data_array = ArrowToDataArray(arr,
+                                           field_meta,
+                                           ctx.result_mapping,
+                                           size,
+                                           dynamic_field_names,
+                                           text_lob_path);
         if (!data_array) {
             LOG_WARN(
                 "[TakeAPI] search: unsupported type {} for '{}', "

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5209,7 +5209,7 @@ ChunkedSegmentSealedImpl::LoadBatchTextIndexes(
                    field_id.get());
         auto future = pool.Submit(
             [this, op_ctx, info = std::move(load_text_index_info)]() mutable
-                -> void { LoadTextIndex(op_ctx, std::move(info)); });
+            -> void { LoadTextIndex(op_ctx, std::move(info)); });
         load_index_futures.emplace_back(std::move(future));
     }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5209,7 +5209,7 @@ ChunkedSegmentSealedImpl::LoadBatchTextIndexes(
                    field_id.get());
         auto future = pool.Submit(
             [this, op_ctx, info = std::move(load_text_index_info)]() mutable
-            -> void { LoadTextIndex(op_ctx, std::move(info)); });
+                -> void { LoadTextIndex(op_ctx, std::move(info)); });
         load_index_futures.emplace_back(std::move(future));
     }
 
@@ -5452,9 +5452,8 @@ ChunkedSegmentSealedImpl::FillTargetEntry(const query::Plan* plan,
 
     segcore::CheckCancellation(op_ctx, get_segment_id(), "FillTargetEntry");
 
-    // Try take() for external fields; fills output_fields_data_ for
-    // external fields only. Non-external fields still go through
-    // bulk_subscript below.
+    // Try take() for eligible output fields. Fields not filled by take still
+    // go through bulk_subscript below.
     bool used_take = TryTakeForSearch(
         plan, results.seg_offsets_.data(), size, results, op_ctx);
 
@@ -5499,6 +5498,24 @@ ChunkedSegmentSealedImpl::FillTargetEntry(const query::Plan* plan,
 }
 
 // ---- Shared helpers for TryTakeForRetrieve / TryTakeForSearch ----
+
+static inline void
+LogTakeFallback(const char* caller_tag,
+                int64_t segment_id,
+                int64_t rows,
+                size_t unique_rows,
+                size_t field_count,
+                std::string_view reason) {
+    LOG_INFO(
+        "[TakeAPI] {} fallback to bulk_subscript for segment {}: "
+        "reason={}, rows={}, unique_rows={}, fields={}",
+        caller_tag,
+        segment_id,
+        reason,
+        rows,
+        unique_rows,
+        field_count);
+}
 
 ChunkedSegmentSealedImpl::TakeContext
 ChunkedSegmentSealedImpl::BuildTakeContext(const int64_t* offsets,
@@ -5873,20 +5890,22 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
     bool ignore_non_pk,
     bool fill_ids,
     milvus::OpContext* op_ctx) const {
-    if (!schema_->is_external_collection() || size == 0 ||
-        !use_take_for_output_.load(std::memory_order_relaxed)) {
+    if (size == 0 || !use_take_for_output_.load(std::memory_order_relaxed)) {
         return false;
     }
+    const bool is_external_collection = schema_->is_external_collection();
 
     auto pk_field_id = plan->schema_->get_primary_field_id();
     auto is_pk_field = [&](const FieldId& fid) {
         return pk_field_id.has_value() && pk_field_id.value() == fid;
     };
 
-    // Collect needed external columns and their field IDs
+    // Collect needed columns and their field IDs. External collections use
+    // user-provided external column names; internal storage v2 uses field-id
+    // strings in the Loon Arrow schema.
     auto needed_columns = std::make_shared<std::vector<std::string>>();
     std::vector<FieldId> take_field_ids;
-    std::vector<const FieldMeta*> take_field_metas;
+    std::vector<std::string> take_column_names;
     for (auto field_id : plan->field_ids_) {
         if (SystemProperty::Instance().IsSystem(field_id)) {
             continue;
@@ -5896,12 +5915,13 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
         }
         auto& field_meta = schema_->operator[](field_id);
         if (!field_meta.is_external_field() &&
-            !schema_->is_function_output(field_id)) {
+            !schema_->is_function_output(field_id) && is_external_collection) {
             continue;
         }
-        needed_columns->push_back(schema_->get_storage_column_name(field_id));
+        auto column_name = schema_->get_storage_column_name(field_id);
+        needed_columns->push_back(column_name);
         take_field_ids.push_back(field_id);
-        take_field_metas.push_back(&field_meta);
+        take_column_names.push_back(std::move(column_name));
     }
     if (take_field_ids.empty()) {
         return false;
@@ -5916,6 +5936,12 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
                              take_elapsed_ms,
                              op_ctx);
     if (!table) {
+        LogTakeFallback("retrieve",
+                        id_,
+                        size,
+                        ctx.unique_offsets.size(),
+                        take_field_ids.size(),
+                        "take returned no table");
         return false;
     }
 
@@ -5929,7 +5955,7 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
     auto fields_data = results->mutable_fields_data();
     auto ids = results->mutable_ids();
 
-    // Build lookup from field_id to index in take_field_ids/take_field_metas
+    // Build lookup from field_id to index in take_field_ids.
     std::unordered_map<int64_t, size_t> ext_field_idx;
     for (size_t fi = 0; fi < take_field_ids.size(); fi++) {
         ext_field_idx[take_field_ids[fi].get()] = fi;
@@ -5939,14 +5965,20 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
     std::vector<std::shared_ptr<arrow::Array>> combined_arrays(
         take_field_ids.size());
     for (size_t fi = 0; fi < take_field_ids.size(); fi++) {
-        auto col_name = schema_->get_storage_column_name(take_field_ids[fi]);
-        auto col = table->GetColumnByName(col_name);
+        auto column_name = take_column_names[fi];
+        auto col = table->GetColumnByName(column_name);
         if (!col || col->num_chunks() == 0) {
             LOG_WARN(
                 "[TakeAPI] column '{}' not found in take result for "
                 "segment {}",
-                col_name,
+                column_name,
                 id_);
+            LogTakeFallback("retrieve",
+                            id_,
+                            size,
+                            ctx.unique_offsets.size(),
+                            take_field_ids.size(),
+                            fmt::format("missing column '{}'", column_name));
             return false;
         }
         if (col->num_chunks() == 1) {
@@ -5956,6 +5988,14 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
             if (!combined_result.ok()) {
                 LOG_WARN("[TakeAPI] concatenate failed: {}",
                          combined_result.status().ToString());
+                LogTakeFallback(
+                    "retrieve",
+                    id_,
+                    size,
+                    ctx.unique_offsets.size(),
+                    take_field_ids.size(),
+                    fmt::format("concatenate failed: {}",
+                                combined_result.status().ToString()));
                 return false;
             }
             combined_arrays[fi] = *combined_result;
@@ -5987,9 +6027,9 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
 
         auto& field_meta = schema_->operator[](field_id);
 
-        // Virtual PK field (not external, not function-output, computed on-the-fly)
+        // External virtual PK field (not external, not function-output).
         if (!field_meta.is_external_field() &&
-            !schema_->is_function_output(field_id)) {
+            !schema_->is_function_output(field_id) && is_external_collection) {
             if (is_pk_field(field_id) &&
                 field_meta.get_data_type() == DataType::INT64) {
                 auto data_array = std::make_unique<DataArray>();
@@ -6012,7 +6052,7 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
             continue;
         }
 
-        // External or function-output field — convert from take() result
+        // Convert from take() result
         auto it = ext_field_idx.find(field_id.get());
         if (it == ext_field_idx.end()) {
             continue;
@@ -6021,22 +6061,57 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
         auto arr = combined_arrays[fi];
 
         // Normalize external arrow types to Milvus internal format.
-        arr = storage::NormalizeExternalArrow(arr, field_meta);
+        if (is_external_collection) {
+            arr = storage::NormalizeExternalArrow(arr, field_meta);
+        }
 
         auto data_array =
             ArrowToDataArray(arr, field_meta, ctx.result_mapping, size);
         if (!data_array) {
-            auto fname = schema_->get_storage_column_name(field_id);
             LOG_WARN(
                 "[TakeAPI] unsupported data type {} for field '{}', "
                 "falling back",
                 static_cast<int>(field_meta.get_data_type()),
-                fname);
+                take_column_names[fi]);
+            LogTakeFallback(
+                "retrieve",
+                id_,
+                size,
+                ctx.unique_offsets.size(),
+                take_field_ids.size(),
+                fmt::format("unsupported data type {} for column '{}'",
+                            static_cast<int>(field_meta.get_data_type()),
+                            take_column_names[fi]));
             results->clear_fields_data();
             results->clear_ids();
             return false;
         }
         data_array->set_field_id(field_id.get());
+
+        if (fill_ids && is_pk_field(field_id)) {
+            switch (field_meta.get_data_type()) {
+                case DataType::INT64: {
+                    auto int_ids = ids->mutable_int_id();
+                    auto& src_data = data_array->scalars().long_data();
+                    int_ids->mutable_data()->Add(src_data.data().begin(),
+                                                 src_data.data().end());
+                    break;
+                }
+                case DataType::VARCHAR: {
+                    auto str_ids = ids->mutable_str_id();
+                    auto& src_data = data_array->scalars().string_data();
+                    for (auto i = 0; i < src_data.data_size(); ++i) {
+                        *(str_ids->mutable_data()->Add()) = src_data.data(i);
+                    }
+                    break;
+                }
+                default: {
+                    ThrowInfo(DataTypeInvalid,
+                              fmt::format("unsupported datatype {}",
+                                          field_meta.get_data_type()));
+                }
+            }
+        }
 
         if (!ignore_non_pk) {
             fields_data->AddAllocated(data_array.release());
@@ -6060,24 +6135,28 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
                                            int64_t size,
                                            SearchResult& results,
                                            milvus::OpContext* op_ctx) const {
-    if (!schema_->is_external_collection() || size == 0 ||
-        !use_take_for_output_.load(std::memory_order_relaxed)) {
+    if (size == 0 || !use_take_for_output_.load(std::memory_order_relaxed)) {
         return false;
     }
+    const bool is_external_collection = schema_->is_external_collection();
 
-    // Collect needed external + function-output columns
+    // Collect needed columns. External collections use external field names;
+    // internal storage v2 uses field-id strings.
     auto needed_columns = std::make_shared<std::vector<std::string>>();
     std::vector<FieldId> take_field_ids;
     std::vector<const FieldMeta*> take_field_metas;
+    std::vector<std::string> take_column_names;
     for (auto field_id : plan->target_entries_) {
         auto& field_meta = schema_->operator[](field_id);
         if (!field_meta.is_external_field() &&
-            !schema_->is_function_output(field_id)) {
+            !schema_->is_function_output(field_id) && is_external_collection) {
             continue;
         }
-        needed_columns->push_back(schema_->get_storage_column_name(field_id));
+        auto column_name = schema_->get_storage_column_name(field_id);
+        needed_columns->push_back(column_name);
         take_field_ids.push_back(field_id);
         take_field_metas.push_back(&field_meta);
+        take_column_names.push_back(std::move(column_name));
     }
     if (take_field_ids.empty()) {
         return false;
@@ -6089,6 +6168,12 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
     auto table = ExecuteTake(
         ctx.unique_offsets, needed_columns, "search", take_elapsed_ms, op_ctx);
     if (!table) {
+        LogTakeFallback("search",
+                        id_,
+                        size,
+                        ctx.unique_offsets.size(),
+                        take_field_ids.size(),
+                        "take returned no table");
         return false;
     }
 
@@ -6102,12 +6187,18 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
     for (size_t fi = 0; fi < take_field_ids.size(); fi++) {
         auto field_id = take_field_ids[fi];
         auto& field_meta = *take_field_metas[fi];
-        auto col_name = schema_->get_storage_column_name(field_id);
-        auto col = table->GetColumnByName(col_name);
+        auto column_name = take_column_names[fi];
+        auto col = table->GetColumnByName(column_name);
         if (!col || col->num_chunks() == 0) {
             LOG_WARN("[TakeAPI] search column '{}' not found for segment {}",
-                     col_name,
+                     column_name,
                      id_);
+            LogTakeFallback("search",
+                            id_,
+                            size,
+                            ctx.unique_offsets.size(),
+                            take_field_ids.size(),
+                            fmt::format("missing column '{}'", column_name));
             return false;
         }
 
@@ -6117,13 +6208,23 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
         } else {
             auto combined_result = arrow::Concatenate(col->chunks());
             if (!combined_result.ok()) {
+                LogTakeFallback(
+                    "search",
+                    id_,
+                    size,
+                    ctx.unique_offsets.size(),
+                    take_field_ids.size(),
+                    fmt::format("concatenate failed: {}",
+                                combined_result.status().ToString()));
                 return false;
             }
             arr = *combined_result;
         }
 
         // Normalize external arrow types to Milvus internal format.
-        arr = storage::NormalizeExternalArrow(arr, field_meta);
+        if (is_external_collection) {
+            arr = storage::NormalizeExternalArrow(arr, field_meta);
+        }
 
         auto data_array =
             ArrowToDataArray(arr, field_meta, ctx.result_mapping, size);
@@ -6132,7 +6233,16 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
                 "[TakeAPI] search: unsupported type {} for '{}', "
                 "falling back",
                 static_cast<int>(field_meta.get_data_type()),
-                col_name);
+                column_name);
+            LogTakeFallback(
+                "search",
+                id_,
+                size,
+                ctx.unique_offsets.size(),
+                take_field_ids.size(),
+                fmt::format("unsupported data type {} for column '{}'",
+                            static_cast<int>(field_meta.get_data_type()),
+                            column_name));
             results.output_fields_data_.clear();
             return false;
         }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -536,7 +536,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                    TargetBitmap& valid_map,
                    bool small_int_raw_type = false) const override;
 
-    // Override to inject take() fast path for Search on external tables.
+    // Override to inject take() fast path for Search output fields.
     // Uses existing vtable slot — no layout change.
     void
     FillTargetEntry(const query::Plan* plan,
@@ -1510,7 +1510,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // 1. will skip index loading for primary key field
     bool is_sorted_by_pk_ = false;
 
-    // When true, use take() API for output field retrieval from external storage.
+    // When true, use take() API for output field retrieval from storage.
     // Published alongside segment_load_info_ by the writer entry points; read
     // lock-free on query hot paths.
     std::atomic<bool> use_take_for_output_{false};

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -562,10 +562,13 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // Converts a combined Arrow array into a proto DataArray using
     // result_mapping for reorder.  Returns nullptr on unsupported type.
     static std::unique_ptr<DataArray>
-    ArrowToDataArray(const std::shared_ptr<arrow::Array>& arr,
-                     const FieldMeta& field_meta,
-                     const std::vector<int64_t>& result_mapping,
-                     int64_t size);
+    ArrowToDataArray(
+        const std::shared_ptr<arrow::Array>& arr,
+        const FieldMeta& field_meta,
+        const std::vector<int64_t>& result_mapping,
+        int64_t size,
+        const std::vector<std::string>* dynamic_field_names = nullptr,
+        const std::string* text_lob_path = nullptr);
 
     // Calls reader_->take() with timing. Returns the table on success,
     // or nullptr on failure (logs a warning). Checks op_ctx for cancellation
@@ -1409,6 +1412,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     SetUseTakeForOutputForTesting(bool val) {
         use_take_for_output_.store(val, std::memory_order_relaxed);
+    }
+
+    // Test-only: inject TEXT LOB base path.
+    void
+    SetTextLobPathForTesting(FieldId field_id, std::string lob_base_path) {
+        text_lob_paths_[field_id] = std::move(lob_base_path);
     }
 
     // Test-only: snapshot access to segment_load_info_ for asserting Reopen

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -447,7 +447,7 @@ SegmentInternalInterface::FillTargetEntry(
     milvus::OpContext* op_ctx) const {
     tracer::AutoSpan span("FillTargetEntry", tracer::GetRootSpan());
 
-    // Fast path: use take() API for external tables with small result sets.
+    // Fast path: use take() API for eligible output fields.
     // Use dynamic_cast to avoid adding new virtual methods (vtable layout
     // change causes SIGSEGV in cgo boundary).
     if (auto* chunked = dynamic_cast<const ChunkedSegmentSealedImpl*>(this)) {

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -49,6 +49,62 @@ namespace {
 
 constexpr int64_t kTestRows = 5;
 constexpr int64_t kVecDim = 4;
+constexpr int64_t kBinaryVecDim = 16;
+
+std::string
+BuildDenseVectorBytes(int row, int byte_width, int seed) {
+    std::string bytes(byte_width, '\0');
+    for (int i = 0; i < byte_width; ++i) {
+        bytes[i] = static_cast<char>((seed + row * byte_width + i) & 0xff);
+    }
+    return bytes;
+}
+
+std::string
+BuildDenseVectorBytesForRows(const std::vector<int>& rows,
+                             int byte_width,
+                             int seed) {
+    std::string bytes;
+    bytes.reserve(rows.size() * byte_width);
+    for (auto row : rows) {
+        bytes += BuildDenseVectorBytes(row, byte_width, seed);
+    }
+    return bytes;
+}
+
+knowhere::sparse::SparseRow<SparseValueType>
+BuildSparseRow(int row) {
+    knowhere::sparse::SparseRow<SparseValueType> sparse_row(2);
+    sparse_row.set_at(0, row, 1.0f + row);
+    sparse_row.set_at(1, row + 10, 2.0f + row);
+    return sparse_row;
+}
+
+std::string
+BuildSparseRowBytes(int row) {
+    auto sparse_row = BuildSparseRow(row);
+    return std::string(reinterpret_cast<const char*>(sparse_row.data()),
+                       sparse_row.data_byte_size());
+}
+
+void
+AppendFixedSizeBinaryRow(arrow::FixedSizeBinaryBuilder& builder,
+                         int row,
+                         int byte_width,
+                         int seed) {
+    auto bytes = BuildDenseVectorBytes(row, byte_width, seed);
+    EXPECT_TRUE(
+        builder.Append(reinterpret_cast<const uint8_t*>(bytes.data())).ok());
+}
+
+void
+AppendSparseRow(arrow::BinaryBuilder& builder, int row) {
+    auto bytes = BuildSparseRowBytes(row);
+    EXPECT_TRUE(builder
+                    .Append(reinterpret_cast<const uint8_t*>(bytes.data()),
+                            static_cast<int32_t>(bytes.size()))
+                    .ok());
+}
 
 ChunkedSegmentSealedImpl*
 CreateExternalSegment(SegmentSealedUPtr& holder,
@@ -476,6 +532,147 @@ AssertNullableSparseVectorTake() {
     EXPECT_EQ(search_sparse.dim(), 8);
 }
 
+struct AdditionalVectorSchemaInfo {
+    SchemaPtr schema;
+    FieldId binary_vec_id;
+    FieldId float16_vec_id;
+    FieldId bfloat16_vec_id;
+    FieldId int8_vec_id;
+    FieldId sparse_vec_id;
+};
+
+AdditionalVectorSchemaInfo
+BuildAdditionalVectorSchema() {
+    auto schema = std::make_shared<Schema>();
+
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    AdditionalVectorSchemaInfo info;
+    auto pk_id = FieldId(200);
+    info.binary_vec_id = FieldId(201);
+    info.float16_vec_id = FieldId(202);
+    info.bfloat16_vec_id = FieldId(203);
+    info.int8_vec_id = FieldId(204);
+    info.sparse_vec_id = FieldId(205);
+
+    schema->AddField(FieldMeta(
+        FieldName("pk"), pk_id, DataType::INT64, false, std::nullopt, "pk"));
+    schema->AddField(FieldMeta(FieldName("binary_vec_col"),
+                               info.binary_vec_id,
+                               DataType::VECTOR_BINARY,
+                               kBinaryVecDim,
+                               knowhere::metric::JACCARD,
+                               true,
+                               std::nullopt,
+                               "binary_vec_col"));
+    schema->AddField(FieldMeta(FieldName("float16_vec_col"),
+                               info.float16_vec_id,
+                               DataType::VECTOR_FLOAT16,
+                               kVecDim,
+                               knowhere::metric::L2,
+                               true,
+                               std::nullopt,
+                               "float16_vec_col"));
+    schema->AddField(FieldMeta(FieldName("bfloat16_vec_col"),
+                               info.bfloat16_vec_id,
+                               DataType::VECTOR_BFLOAT16,
+                               kVecDim,
+                               knowhere::metric::L2,
+                               true,
+                               std::nullopt,
+                               "bfloat16_vec_col"));
+    schema->AddField(FieldMeta(FieldName("int8_vec_col"),
+                               info.int8_vec_id,
+                               DataType::VECTOR_INT8,
+                               kVecDim,
+                               knowhere::metric::L2,
+                               true,
+                               std::nullopt,
+                               "int8_vec_col"));
+    schema->AddField(FieldMeta(FieldName("sparse_vec_col"),
+                               info.sparse_vec_id,
+                               DataType::VECTOR_SPARSE_U32_F32,
+                               0,
+                               knowhere::metric::IP,
+                               true,
+                               std::nullopt,
+                               "sparse_vec_col"));
+
+    schema->set_primary_field_id(pk_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+
+    info.schema = schema;
+    return info;
+}
+
+std::shared_ptr<arrow::Table>
+BuildAdditionalVectorArrowTable() {
+    arrow::Int64Builder pk_builder;
+    for (int i = 0; i < kTestRows; i++) {
+        EXPECT_TRUE(pk_builder.Append(i).ok());
+    }
+    auto pk_arr = pk_builder.Finish().ValueOrDie();
+
+    auto binary_type = arrow::fixed_size_binary(kBinaryVecDim / 8);
+    arrow::FixedSizeBinaryBuilder binary_builder(binary_type);
+    auto float16_type = arrow::fixed_size_binary(kVecDim * 2);
+    arrow::FixedSizeBinaryBuilder float16_builder(float16_type);
+    auto bfloat16_type = arrow::fixed_size_binary(kVecDim * 2);
+    arrow::FixedSizeBinaryBuilder bfloat16_builder(bfloat16_type);
+    auto int8_type = arrow::fixed_size_binary(kVecDim);
+    arrow::FixedSizeBinaryBuilder int8_builder(int8_type);
+    arrow::BinaryBuilder sparse_builder;
+
+    for (int i = 0; i < kTestRows; i++) {
+        AppendFixedSizeBinaryRow(binary_builder, i, kBinaryVecDim / 8, 11);
+        AppendFixedSizeBinaryRow(float16_builder, i, kVecDim * 2, 31);
+        AppendFixedSizeBinaryRow(bfloat16_builder, i, kVecDim * 2, 51);
+        AppendFixedSizeBinaryRow(int8_builder, i, kVecDim, 71);
+        AppendSparseRow(sparse_builder, i);
+    }
+
+    auto binary_arr = binary_builder.Finish().ValueOrDie();
+    auto float16_arr = float16_builder.Finish().ValueOrDie();
+    auto bfloat16_arr = bfloat16_builder.Finish().ValueOrDie();
+    auto int8_arr = int8_builder.Finish().ValueOrDie();
+    auto sparse_arr = sparse_builder.Finish().ValueOrDie();
+
+    auto schema = arrow::schema({
+        arrow::field("pk", arrow::int64()),
+        arrow::field("binary_vec_col", binary_type),
+        arrow::field("float16_vec_col", float16_type),
+        arrow::field("bfloat16_vec_col", bfloat16_type),
+        arrow::field("int8_vec_col", int8_type),
+        arrow::field("sparse_vec_col", arrow::binary()),
+    });
+
+    return arrow::Table::Make(
+        schema,
+        {pk_arr, binary_arr, float16_arr, bfloat16_arr, int8_arr, sparse_arr});
+}
+
+std::shared_ptr<arrow::Table>
+BuildNullableBinaryVectorArrowTable() {
+    auto binary_type = arrow::fixed_size_binary(kBinaryVecDim / 8);
+    arrow::FixedSizeBinaryBuilder binary_builder(binary_type);
+    AppendFixedSizeBinaryRow(binary_builder, 0, kBinaryVecDim / 8, 11);
+    EXPECT_TRUE(binary_builder.AppendNull().ok());
+    AppendFixedSizeBinaryRow(binary_builder, 2, kBinaryVecDim / 8, 11);
+    auto binary_arr = binary_builder.Finish().ValueOrDie();
+
+    auto schema = arrow::schema({
+        arrow::field("binary_vec_col", binary_type),
+    });
+    return arrow::Table::Make(schema, {binary_arr});
+}
+
 // Build an external schema with all supported types.
 // Returns {schema, field_ids} where field_ids are in order:
 // bool, int8, int16, int32, int64, float, double, varchar, vec
@@ -579,6 +776,103 @@ BuildExternalSchema() {
 
     info.schema = schema;
     return info;
+}
+
+ExternalSchemaInfo
+BuildInternalSchemaForTake() {
+    auto info = BuildExternalSchema();
+    auto schema = std::make_shared<Schema>();
+
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    schema->AddField(FieldMeta(FieldName("bool_col"),
+                               info.bool_id,
+                               DataType::BOOL,
+                               true,
+                               std::nullopt));
+    schema->AddField(FieldMeta(FieldName("int8_col"),
+                               info.int8_id,
+                               DataType::INT8,
+                               true,
+                               std::nullopt));
+    schema->AddField(FieldMeta(FieldName("int16_col"),
+                               info.int16_id,
+                               DataType::INT16,
+                               true,
+                               std::nullopt));
+    schema->AddField(FieldMeta(FieldName("int32_col"),
+                               info.int32_id,
+                               DataType::INT32,
+                               true,
+                               std::nullopt));
+    schema->AddField(FieldMeta(FieldName("int64_col"),
+                               info.int64_id,
+                               DataType::INT64,
+                               false,
+                               std::nullopt));
+    schema->AddField(FieldMeta(FieldName("float_col"),
+                               info.float_id,
+                               DataType::FLOAT,
+                               true,
+                               std::nullopt));
+    schema->AddField(FieldMeta(FieldName("double_col"),
+                               info.double_id,
+                               DataType::DOUBLE,
+                               true,
+                               std::nullopt));
+    schema->AddField(FieldMeta(FieldName("varchar_col"),
+                               info.varchar_id,
+                               DataType::VARCHAR,
+                               65535,
+                               true,
+                               std::nullopt));
+    schema->AddField(FieldMeta(FieldName("vec_col"),
+                               info.vec_id,
+                               DataType::VECTOR_FLOAT,
+                               kVecDim,
+                               knowhere::metric::L2,
+                               true,
+                               std::nullopt));
+
+    schema->set_primary_field_id(info.int64_id);
+    info.schema = schema;
+    return info;
+}
+
+std::shared_ptr<arrow::Table>
+BuildInternalTakeArrowTable(const ExternalSchemaInfo& info) {
+    auto external_table = BuildTestArrowTable();
+    std::vector<std::shared_ptr<arrow::Field>> fields;
+    std::vector<std::shared_ptr<arrow::ChunkedArray>> columns;
+    fields.reserve(external_table->num_columns());
+    columns.reserve(external_table->num_columns());
+
+    auto add_column = [&](FieldId field_id, const std::string& external_name) {
+        auto col = external_table->GetColumnByName(external_name);
+        ASSERT_NE(col, nullptr);
+        auto field = external_table->schema()->GetFieldByName(external_name);
+        ASSERT_NE(field, nullptr);
+        fields.push_back(field->WithName(std::to_string(field_id.get())));
+        columns.push_back(col);
+    };
+
+    add_column(info.bool_id, "bool_col");
+    add_column(info.int8_id, "int8_col");
+    add_column(info.int16_id, "int16_col");
+    add_column(info.int32_id, "int32_col");
+    add_column(info.int64_id, "int64_col");
+    add_column(info.float_id, "float_col");
+    add_column(info.double_id, "double_col");
+    add_column(info.varchar_id, "varchar_col");
+    add_column(info.vec_id, "vec_col");
+
+    return arrow::Table::Make(arrow::schema(fields), columns);
 }
 
 // Helper: create a ChunkedSegmentSealedImpl with external schema
@@ -934,6 +1228,94 @@ TEST(ExternalTakeTest, TryTakeForRetrieve_NullableVectorUsesCompactData) {
     EXPECT_FLOAT_EQ(fv.data(7), 11.0f);
 }
 
+TEST(ExternalTakeTest, TryTakeForRetrieve_AdditionalVectorTypes) {
+    auto info = BuildAdditionalVectorSchema();
+    auto table = BuildAdditionalVectorArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::RetrievePlan>(info.schema);
+    plan->field_ids_ = {info.binary_vec_id,
+                        info.float16_vec_id,
+                        info.bfloat16_vec_id,
+                        info.int8_vec_id,
+                        info.sparse_vec_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 2, 4};
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), offsets.size(), false, false);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 5);
+
+    const std::vector<int> rows = {0, 2, 4};
+    auto& binary_vec = results->fields_data(0);
+    ASSERT_EQ(binary_vec.field_id(), info.binary_vec_id.get());
+    ASSERT_EQ(binary_vec.vectors().dim(), kBinaryVecDim);
+    EXPECT_EQ(binary_vec.vectors().binary_vector(),
+              BuildDenseVectorBytesForRows(rows, kBinaryVecDim / 8, 11));
+
+    auto& float16_vec = results->fields_data(1);
+    ASSERT_EQ(float16_vec.field_id(), info.float16_vec_id.get());
+    ASSERT_EQ(float16_vec.vectors().dim(), kVecDim);
+    EXPECT_EQ(float16_vec.vectors().float16_vector(),
+              BuildDenseVectorBytesForRows(rows, kVecDim * 2, 31));
+
+    auto& bfloat16_vec = results->fields_data(2);
+    ASSERT_EQ(bfloat16_vec.field_id(), info.bfloat16_vec_id.get());
+    ASSERT_EQ(bfloat16_vec.vectors().dim(), kVecDim);
+    EXPECT_EQ(bfloat16_vec.vectors().bfloat16_vector(),
+              BuildDenseVectorBytesForRows(rows, kVecDim * 2, 51));
+
+    auto& int8_vec = results->fields_data(3);
+    ASSERT_EQ(int8_vec.field_id(), info.int8_vec_id.get());
+    ASSERT_EQ(int8_vec.vectors().dim(), kVecDim);
+    EXPECT_EQ(int8_vec.vectors().int8_vector(),
+              BuildDenseVectorBytesForRows(rows, kVecDim, 71));
+
+    auto& sparse_vec = results->fields_data(4);
+    ASSERT_EQ(sparse_vec.field_id(), info.sparse_vec_id.get());
+    ASSERT_EQ(sparse_vec.vectors().dim(), 15);
+    auto& sparse_float = sparse_vec.vectors().sparse_float_vector();
+    ASSERT_EQ(sparse_float.contents_size(), rows.size());
+    EXPECT_EQ(sparse_float.contents(0), BuildSparseRowBytes(0));
+    EXPECT_EQ(sparse_float.contents(1), BuildSparseRowBytes(2));
+    EXPECT_EQ(sparse_float.contents(2), BuildSparseRowBytes(4));
+    EXPECT_EQ(sparse_float.dim(), 15);
+}
+
+TEST(ExternalTakeTest, TryTakeForRetrieve_NullableBinaryVectorUsesCompactData) {
+    auto info = BuildAdditionalVectorSchema();
+    auto table = BuildNullableBinaryVectorArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::RetrievePlan>(info.schema);
+    plan->field_ids_ = {info.binary_vec_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 1, 2};
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), offsets.size(), false, false);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 1);
+
+    auto& binary_vec = results->fields_data(0);
+    ASSERT_EQ(binary_vec.field_id(), info.binary_vec_id.get());
+    ASSERT_EQ(binary_vec.valid_data_size(), 3);
+    EXPECT_TRUE(binary_vec.valid_data(0));
+    EXPECT_FALSE(binary_vec.valid_data(1));
+    EXPECT_TRUE(binary_vec.valid_data(2));
+    EXPECT_EQ(binary_vec.vectors().binary_vector(),
+              BuildDenseVectorBytesForRows({0, 2}, kBinaryVecDim / 8, 11));
+}
+
 // Test TryTakeForSearch with all supported data types
 TEST(ExternalTakeTest, TryTakeForSearch_MultiTypes) {
     auto [schema,
@@ -1075,6 +1457,58 @@ TEST(ExternalTakeTest, NullableSparseVectorTakeUsesCompactData) {
     AssertNullableSparseVectorTake();
 }
 
+TEST(ExternalTakeTest, TryTakeForSearch_AdditionalVectorTypes) {
+    auto info = BuildAdditionalVectorSchema();
+    auto table = BuildAdditionalVectorArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::Plan>(info.schema);
+    plan->target_entries_ = {info.binary_vec_id,
+                             info.float16_vec_id,
+                             info.bfloat16_vec_id,
+                             info.int8_vec_id,
+                             info.sparse_vec_id};
+
+    std::vector<int64_t> seg_offsets = {1, 3};
+    SearchResult results;
+    bool ok = segment->TestTryTakeForSearch(
+        plan.get(), seg_offsets.data(), seg_offsets.size(), results);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results.output_fields_data_.size(), 5u);
+
+    const std::vector<int> rows = {1, 3};
+    auto& binary_vec = results.output_fields_data_.at(info.binary_vec_id);
+    ASSERT_EQ(binary_vec->vectors().dim(), kBinaryVecDim);
+    EXPECT_EQ(binary_vec->vectors().binary_vector(),
+              BuildDenseVectorBytesForRows(rows, kBinaryVecDim / 8, 11));
+
+    auto& float16_vec = results.output_fields_data_.at(info.float16_vec_id);
+    ASSERT_EQ(float16_vec->vectors().dim(), kVecDim);
+    EXPECT_EQ(float16_vec->vectors().float16_vector(),
+              BuildDenseVectorBytesForRows(rows, kVecDim * 2, 31));
+
+    auto& bfloat16_vec = results.output_fields_data_.at(info.bfloat16_vec_id);
+    ASSERT_EQ(bfloat16_vec->vectors().dim(), kVecDim);
+    EXPECT_EQ(bfloat16_vec->vectors().bfloat16_vector(),
+              BuildDenseVectorBytesForRows(rows, kVecDim * 2, 51));
+
+    auto& int8_vec = results.output_fields_data_.at(info.int8_vec_id);
+    ASSERT_EQ(int8_vec->vectors().dim(), kVecDim);
+    EXPECT_EQ(int8_vec->vectors().int8_vector(),
+              BuildDenseVectorBytesForRows(rows, kVecDim, 71));
+
+    auto& sparse_vec = results.output_fields_data_.at(info.sparse_vec_id);
+    ASSERT_EQ(sparse_vec->vectors().dim(), 14);
+    auto& sparse_float = sparse_vec->vectors().sparse_float_vector();
+    ASSERT_EQ(sparse_float.contents_size(), rows.size());
+    EXPECT_EQ(sparse_float.contents(0), BuildSparseRowBytes(1));
+    EXPECT_EQ(sparse_float.contents(1), BuildSparseRowBytes(3));
+    EXPECT_EQ(sparse_float.dim(), 14);
+}
+
 // Test fallback: returns false for non-external collection
 TEST(ExternalTakeTest, TryTakeForRetrieve_FallbackNonExternal) {
     auto schema = std::make_shared<Schema>();
@@ -1185,6 +1619,77 @@ TEST(ExternalTakeTest, FillTargetEntry_DelegatesToTake) {
     ASSERT_EQ(str_arr->scalars().string_data().data_size(), 2);
     EXPECT_EQ(str_arr->scalars().string_data().data(0), "row_0");
     EXPECT_EQ(str_arr->scalars().string_data().data(1), "row_3");
+}
+
+TEST(InternalTakeTest, TryTakeForRetrieve_UsesFieldIdColumns) {
+    auto info = BuildInternalSchemaForTake();
+    auto table = BuildInternalTakeArrowTable(info);
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::RetrievePlan>(info.schema);
+    plan->field_ids_ = {info.int64_id, info.varchar_id, info.vec_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {3, 1};
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), offsets.size(), false, true);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 3);
+    ASSERT_EQ(results->ids().int_id().data_size(), 2);
+    EXPECT_EQ(results->ids().int_id().data(0), 30000);
+    EXPECT_EQ(results->ids().int_id().data(1), 10000);
+
+    auto& int64_data = results->fields_data(0);
+    ASSERT_EQ(int64_data.field_id(), info.int64_id.get());
+    ASSERT_EQ(int64_data.scalars().long_data().data_size(), 2);
+    EXPECT_EQ(int64_data.scalars().long_data().data(0), 30000);
+    EXPECT_EQ(int64_data.scalars().long_data().data(1), 10000);
+
+    auto& varchar_data = results->fields_data(1);
+    ASSERT_EQ(varchar_data.field_id(), info.varchar_id.get());
+    ASSERT_EQ(varchar_data.scalars().string_data().data_size(), 2);
+    EXPECT_EQ(varchar_data.scalars().string_data().data(0), "row_3");
+    EXPECT_EQ(varchar_data.scalars().string_data().data(1), "row_1");
+
+    auto& vec_data = results->fields_data(2);
+    ASSERT_EQ(vec_data.field_id(), info.vec_id.get());
+    ASSERT_EQ(vec_data.vectors().dim(), kVecDim);
+    ASSERT_EQ(vec_data.vectors().float_vector().data_size(), 2 * kVecDim);
+    EXPECT_FLOAT_EQ(vec_data.vectors().float_vector().data(0), 12.0f);
+    EXPECT_FLOAT_EQ(vec_data.vectors().float_vector().data(4), 4.0f);
+}
+
+TEST(InternalTakeTest, TryTakeForSearch_UsesFieldIdColumns) {
+    auto info = BuildInternalSchemaForTake();
+    auto table = BuildInternalTakeArrowTable(info);
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::Plan>(info.schema);
+    plan->target_entries_ = {info.int64_id, info.varchar_id};
+
+    SearchResult results;
+    std::vector<int64_t> offsets = {4, 0};
+    bool ok = segment->TestTryTakeForSearch(
+        plan.get(), offsets.data(), offsets.size(), results);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results.output_fields_data_.size(), 2u);
+
+    auto& int64_data = results.output_fields_data_.at(info.int64_id);
+    ASSERT_EQ(int64_data->scalars().long_data().data_size(), 2);
+    EXPECT_EQ(int64_data->scalars().long_data().data(0), 40000);
+    EXPECT_EQ(int64_data->scalars().long_data().data(1), 0);
+
+    auto& varchar_data = results.output_fields_data_.at(info.varchar_id);
+    ASSERT_EQ(varchar_data->scalars().string_data().data_size(), 2);
+    EXPECT_EQ(varchar_data->scalars().string_data().data(0), "row_4");
+    EXPECT_EQ(varchar_data->scalars().string_data().data(1), "row_0");
 }
 
 // ---------- TryTakeForRetrieve: error & edge-case paths ----------

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -34,6 +34,7 @@
 #include "common/VirtualPK.h"
 #include "gtest/gtest.h"
 #include "knowhere/comp/index_param.h"
+#include "milvus-storage/lob_column/lob_reference.h"
 #include "milvus-storage/properties.h"
 #include "milvus-storage/reader.h"
 #include "query/PlanImpl.h"
@@ -875,6 +876,67 @@ BuildInternalTakeArrowTable(const ExternalSchemaInfo& info) {
     return arrow::Table::Make(arrow::schema(fields), columns);
 }
 
+struct InternalSchemaWithTextAndDynamicFields {
+    ExternalSchemaInfo base;
+    FieldId text_id;
+    FieldId dynamic_id;
+};
+
+InternalSchemaWithTextAndDynamicFields
+BuildInternalSchemaWithTextAndDynamicFields() {
+    InternalSchemaWithTextAndDynamicFields info;
+    info.base = BuildInternalSchemaForTake();
+    info.text_id = FieldId(109);
+    info.dynamic_id = FieldId(110);
+
+    info.base.schema->AddField(FieldMeta(FieldName("text_col"),
+                                         info.text_id,
+                                         DataType::TEXT,
+                                         65535,
+                                         true,
+                                         std::nullopt));
+    info.base.schema->AddField(FieldMeta(FieldName("$meta"),
+                                         info.dynamic_id,
+                                         DataType::JSON,
+                                         true,
+                                         std::nullopt));
+    info.base.schema->set_dynamic_field_id(info.dynamic_id);
+    return info;
+}
+
+std::shared_ptr<arrow::Table>
+BuildInternalTakeArrowTableWithTextAndDynamicFields(
+    const InternalSchemaWithTextAndDynamicFields& info) {
+    arrow::Int64Builder int64_b;
+    arrow::BinaryBuilder text_b;
+    arrow::BinaryBuilder dynamic_b;
+    for (int i = 0; i < kTestRows; i++) {
+        EXPECT_TRUE(int64_b.Append(i * 10000).ok());
+        auto text = "text_" + std::to_string(i);
+        auto encoded_text = milvus_storage::lob_column::EncodeInlineText(text);
+        EXPECT_TRUE(text_b
+                        .Append(encoded_text.data(),
+                                static_cast<int32_t>(encoded_text.size()))
+                        .ok());
+        auto dynamic = R"({"foo":)" + std::to_string(i) + R"(,"bar":true})";
+        EXPECT_TRUE(
+            dynamic_b
+                .Append(reinterpret_cast<const uint8_t*>(dynamic.data()),
+                        static_cast<int32_t>(dynamic.size()))
+                .ok());
+    }
+
+    auto int64_arr = int64_b.Finish().ValueOrDie();
+    auto text_arr = text_b.Finish().ValueOrDie();
+    auto dynamic_arr = dynamic_b.Finish().ValueOrDie();
+    auto schema = arrow::schema({
+        arrow::field(std::to_string(info.base.int64_id.get()), arrow::int64()),
+        arrow::field(std::to_string(info.text_id.get()), arrow::binary()),
+        arrow::field(std::to_string(info.dynamic_id.get()), arrow::binary()),
+    });
+    return arrow::Table::Make(schema, {int64_arr, text_arr, dynamic_arr});
+}
+
 // Helper: create a ChunkedSegmentSealedImpl with external schema
 // Note: reader_ must be injected via SetReaderForTesting (MILVUS_UNIT_TEST)
 ChunkedSegmentSealedImpl*
@@ -1690,6 +1752,120 @@ TEST(InternalTakeTest, TryTakeForSearch_UsesFieldIdColumns) {
     ASSERT_EQ(varchar_data->scalars().string_data().data_size(), 2);
     EXPECT_EQ(varchar_data->scalars().string_data().data(0), "row_4");
     EXPECT_EQ(varchar_data->scalars().string_data().data(1), "row_0");
+}
+
+TEST(InternalTakeTest, TryTakeForRetrieve_ResolvesTextOutputField) {
+    auto info = BuildInternalSchemaWithTextAndDynamicFields();
+    auto table = BuildInternalTakeArrowTableWithTextAndDynamicFields(info);
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.base.schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+    segment->SetTextLobPathForTesting(info.text_id, "/tmp/test_lob");
+
+    auto plan = std::make_unique<query::RetrievePlan>(info.base.schema);
+    plan->field_ids_ = {info.base.int64_id, info.text_id};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {3, 1};
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), offsets.size(), false, true);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 2);
+
+    auto& text_data = results->fields_data(1);
+    ASSERT_EQ(text_data.field_id(), info.text_id.get());
+    ASSERT_EQ(text_data.scalars().string_data().data_size(), 2);
+    EXPECT_EQ(text_data.scalars().string_data().data(0), "text_3");
+    EXPECT_EQ(text_data.scalars().string_data().data(1), "text_1");
+}
+
+TEST(InternalTakeTest, TryTakeForRetrieve_ProjectsDynamicField) {
+    auto info = BuildInternalSchemaWithTextAndDynamicFields();
+    auto table = BuildInternalTakeArrowTableWithTextAndDynamicFields(info);
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.base.schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::RetrievePlan>(info.base.schema);
+    plan->field_ids_ = {info.base.int64_id, info.dynamic_id};
+    plan->target_dynamic_fields_ = {"foo"};
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {3, 1};
+
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), offsets.size(), false, true);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 2);
+
+    auto& dynamic_data = results->fields_data(1);
+    ASSERT_EQ(dynamic_data.field_id(), info.dynamic_id.get());
+    ASSERT_EQ(dynamic_data.scalars().json_data().data_size(), 2);
+    EXPECT_EQ(dynamic_data.scalars().json_data().data(0), R"({"foo":3})");
+    EXPECT_EQ(dynamic_data.scalars().json_data().data(1), R"({"foo":1})");
+}
+
+TEST(InternalTakeTest, TryTakeForSearch_ResolvesTextOutputField) {
+    auto info = BuildInternalSchemaWithTextAndDynamicFields();
+    auto table = BuildInternalTakeArrowTableWithTextAndDynamicFields(info);
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.base.schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+    segment->SetTextLobPathForTesting(info.text_id, "/tmp/test_lob");
+
+    auto plan = std::make_unique<query::Plan>(info.base.schema);
+    plan->target_entries_ = {info.base.int64_id, info.text_id};
+
+    SearchResult results;
+    std::vector<int64_t> offsets = {4, 0};
+    bool ok = segment->TestTryTakeForSearch(
+        plan.get(), offsets.data(), offsets.size(), results);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results.output_fields_data_.size(), 2u);
+
+    auto& int64_data = results.output_fields_data_.at(info.base.int64_id);
+    ASSERT_EQ(int64_data->scalars().long_data().data_size(), 2);
+    EXPECT_EQ(int64_data->scalars().long_data().data(0), 40000);
+    EXPECT_EQ(int64_data->scalars().long_data().data(1), 0);
+
+    auto& text_data = results.output_fields_data_.at(info.text_id);
+    ASSERT_EQ(text_data->scalars().string_data().data_size(), 2);
+    EXPECT_EQ(text_data->scalars().string_data().data(0), "text_4");
+    EXPECT_EQ(text_data->scalars().string_data().data(1), "text_0");
+}
+
+TEST(InternalTakeTest, TryTakeForSearch_ProjectsDynamicField) {
+    auto info = BuildInternalSchemaWithTextAndDynamicFields();
+    auto table = BuildInternalTakeArrowTableWithTextAndDynamicFields(info);
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.base.schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::Plan>(info.base.schema);
+    plan->target_entries_ = {info.base.int64_id, info.dynamic_id};
+    plan->target_dynamic_fields_ = {"foo"};
+
+    SearchResult results;
+    std::vector<int64_t> offsets = {4, 0};
+    bool ok = segment->TestTryTakeForSearch(
+        plan.get(), offsets.data(), offsets.size(), results);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results.output_fields_data_.size(), 2u);
+
+    auto& int64_data = results.output_fields_data_.at(info.base.int64_id);
+    ASSERT_EQ(int64_data->scalars().long_data().data_size(), 2);
+    EXPECT_EQ(int64_data->scalars().long_data().data(0), 40000);
+    EXPECT_EQ(int64_data->scalars().long_data().data(1), 0);
+
+    auto& dynamic_data = results.output_fields_data_.at(info.dynamic_id);
+    ASSERT_EQ(dynamic_data->scalars().json_data().data_size(), 2);
+    EXPECT_EQ(dynamic_data->scalars().json_data().data(0), R"({"foo":4})");
+    EXPECT_EQ(dynamic_data->scalars().json_data().data(1), R"({"foo":0})");
 }
 
 // ---------- TryTakeForRetrieve: error & edge-case paths ----------

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -249,6 +249,9 @@ func (loader *segmentLoader) Load(ctx context.Context,
 		log.Warn("failed to get collection", zap.Error(err))
 		return nil, err
 	}
+	for _, segment := range segments {
+		configureUseTakeForOutput(segment, collection.Schema())
+	}
 	// Filter out loaded & loading segments
 	infos := loader.prepare(ctx, segmentType, segments...)
 	defer loader.unregister(infos...)
@@ -455,6 +458,17 @@ func (loader *segmentLoader) prepare(ctx context.Context, segmentType SegmentTyp
 	}
 
 	return infos
+}
+
+func configureUseTakeForOutput(loadInfo *querypb.SegmentLoadInfo, schema *schemapb.CollectionSchema) {
+	if loadInfo == nil {
+		return
+	}
+	if typeutil.IsExternalCollection(schema) {
+		loadInfo.UseTakeForOutput = paramtable.Get().QueryNodeCfg.ExternalCollectionUseTakeForOutput.GetAsBool()
+		return
+	}
+	loadInfo.UseTakeForOutput = paramtable.Get().QueryNodeCfg.InternalCollectionUseTakeForOutput.GetAsBool()
 }
 
 func (loader *segmentLoader) unregister(segments ...*querypb.SegmentLoadInfo) {
@@ -2375,6 +2389,10 @@ func (loader *segmentLoader) ReopenSegments(ctx context.Context,
 		if segment == nil {
 			log.Warn("failed to reopen segment, segment not loaded", zap.Int64("segmentID", info.GetSegmentID()))
 			continue
+		}
+		collection := loader.manager.Collection.Get(info.GetCollectionID())
+		if collection != nil {
+			configureUseTakeForOutput(info, collection.Schema())
 		}
 
 		err := segment.Reopen(ctx, info)

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -1132,6 +1132,52 @@ func (suite *SegmentLoaderDetailSuite) TestWaitSegmentLoadDone() {
 	})
 }
 
+func TestConfigureUseTakeForOutput(t *testing.T) {
+	paramtable.Init()
+	internalKey := paramtable.Get().QueryNodeCfg.InternalCollectionUseTakeForOutput.Key
+	externalKey := paramtable.Get().QueryNodeCfg.ExternalCollectionUseTakeForOutput.Key
+	paramtable.Get().Reset(internalKey)
+	paramtable.Get().Reset(externalKey)
+	defer paramtable.Get().Reset(internalKey)
+	defer paramtable.Get().Reset(externalKey)
+
+	t.Run("nil load info", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			configureUseTakeForOutput(nil, &schemapb.CollectionSchema{})
+		})
+	})
+
+	t.Run("internal collection disabled by default", func(t *testing.T) {
+		loadInfo := &querypb.SegmentLoadInfo{}
+		configureUseTakeForOutput(loadInfo, &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64}},
+		})
+		assert.False(t, loadInfo.GetUseTakeForOutput())
+	})
+
+	t.Run("internal collection uses internal switch", func(t *testing.T) {
+		paramtable.Get().Save(internalKey, "true")
+		defer paramtable.Get().Reset(internalKey)
+
+		loadInfo := &querypb.SegmentLoadInfo{}
+		configureUseTakeForOutput(loadInfo, &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64}},
+		})
+		assert.True(t, loadInfo.GetUseTakeForOutput())
+	})
+
+	t.Run("external collection uses external switch", func(t *testing.T) {
+		paramtable.Get().Save(externalKey, "false")
+		defer paramtable.Get().Reset(externalKey)
+
+		loadInfo := &querypb.SegmentLoadInfo{}
+		configureUseTakeForOutput(loadInfo, &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, ExternalField: "id"}},
+		})
+		assert.False(t, loadInfo.GetUseTakeForOutput())
+	})
+}
+
 func (suite *SegmentLoaderDetailSuite) TestRequestResource() {
 	suite.Run("out_of_memory_zero_info", func() {
 		paramtable.Get().Save(paramtable.Get().QueryNodeCfg.OverloadedMemoryThresholdPercentage.Key, "0")

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -460,7 +460,7 @@ func ConvertToSegcoreSegmentLoadInfo(src *querypb.SegmentLoadInfo) *segcorepb.Se
 		JsonKeyStatsLogs:     convertJSONKeyStats(jsonStats, jsonBasePaths),
 		Priority:             src.GetPriority(),
 		ManifestPath:         src.GetManifestPath(),
-		UseTakeForOutput:     paramtable.Get().QueryNodeCfg.ExternalCollectionUseTakeForOutput.GetAsBool(),
+		UseTakeForOutput:     src.GetUseTakeForOutput(),
 		EstimatedBytesPerRow: src.GetEstimatedBytesPerRow(),
 		CommitTimestamp:      src.GetCommitTimestamp(),
 	}

--- a/internal/util/segcore/segment_test.go
+++ b/internal/util/segcore/segment_test.go
@@ -194,6 +194,7 @@ func TestConvertToSegcoreSegmentLoadInfo(t *testing.T) {
 		assert.Equal(t, int64(0), result.SegmentID)
 		assert.Equal(t, int64(0), result.PartitionID)
 		assert.Equal(t, int64(0), result.CollectionID)
+		assert.False(t, result.UseTakeForOutput)
 	})
 
 	t.Run("full conversion", func(t *testing.T) {
@@ -312,7 +313,8 @@ func TestConvertToSegcoreSegmentLoadInfo(t *testing.T) {
 					JsonKeyStatsDataFormat: 1,
 				},
 			},
-			Priority: commonpb.LoadPriority_HIGH,
+			Priority:         commonpb.LoadPriority_HIGH,
+			UseTakeForOutput: true,
 		}
 
 		// Convert to segcorepb.SegmentLoadInfo
@@ -333,6 +335,7 @@ func TestConvertToSegcoreSegmentLoadInfo(t *testing.T) {
 		assert.Equal(t, src.IsSorted, result.IsSorted)
 		assert.Equal(t, src.Priority, result.Priority)
 		assert.Equal(t, src.CompactionFrom, result.CompactionFrom)
+		assert.Equal(t, src.UseTakeForOutput, result.UseTakeForOutput)
 
 		// Validate BinlogPaths conversion
 		assert.Equal(t, len(src.BinlogPaths), len(result.BinlogPaths))

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3607,7 +3607,8 @@ type queryNodeConfig struct {
 	// partial search
 	PartialResultRequiredDataRatio ParamItem `refreshable:"true"`
 
-	// external collection
+	// output fields take
+	InternalCollectionUseTakeForOutput ParamItem `refreshable:"true"`
 	ExternalCollectionUseTakeForOutput ParamItem `refreshable:"true"`
 	ExternalCollectionSamplePerSegment ParamItem `refreshable:"true"`
 	ExternalCollectionSampleRows       ParamItem `refreshable:"true"`
@@ -4894,6 +4895,15 @@ user-task-polling:
 		Export:       true,
 	}
 	p.PartialResultRequiredDataRatio.Init(base.mgr)
+
+	p.InternalCollectionUseTakeForOutput = ParamItem{
+		Key:          "queryNode.internalCollection.useTakeForOutput",
+		Version:      "3.0.0",
+		DefaultValue: "false",
+		Doc:          `When true, use take() API to fetch output fields from internal storage instead of bulk_subscript`,
+		Export:       false,
+	}
+	p.InternalCollectionUseTakeForOutput.Init(base.mgr)
 
 	p.ExternalCollectionUseTakeForOutput = ParamItem{
 		Key:          "queryNode.externalCollection.useTakeForOutput",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -577,6 +577,13 @@ func TestComponentParam(t *testing.T) {
 		params.Save(Params.PartialResultRequiredDataRatio.Key, "0.8")
 		assert.Equal(t, 0.8, Params.PartialResultRequiredDataRatio.GetAsFloat())
 
+		assert.False(t, Params.InternalCollectionUseTakeForOutput.GetAsBool())
+		params.Save(Params.InternalCollectionUseTakeForOutput.Key, "true")
+		assert.True(t, Params.InternalCollectionUseTakeForOutput.GetAsBool())
+		assert.True(t, Params.ExternalCollectionUseTakeForOutput.GetAsBool())
+		params.Save(Params.ExternalCollectionUseTakeForOutput.Key, "false")
+		assert.False(t, Params.ExternalCollectionUseTakeForOutput.GetAsBool())
+
 		// test CatchUpStreamingDataTsLag parameter
 		assert.Equal(t, 1*time.Second, Params.CatchUpStreamingDataTsLag.GetAsDurationByParse())
 		params.Save(Params.CatchUpStreamingDataTsLag.Key, "5s")

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -13,6 +13,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/apache/arrow/go/v17/parquet/pqarrow"
 	miniogo "github.com/minio/minio-go/v7"
 	miniocreds "github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/stretchr/testify/require"
@@ -228,6 +232,96 @@ func generateParquetBytesWithCompression(schema string, numRows, startID int64, 
 	return data, nil
 }
 
+func externalTakeDenseBytes(row int64, byteWidth int, seed int64) []byte {
+	data := make([]byte, byteWidth)
+	for i := range data {
+		data[i] = byte((seed + row*int64(byteWidth) + int64(i)) % 251)
+	}
+	return data
+}
+
+func externalTakeInt8Vector(row int64) []int8 {
+	data := make([]int8, testVecDim)
+	for i := range data {
+		data[i] = int8((row*3 + int64(i)) % 127)
+	}
+	return data
+}
+
+func externalTakeInt8VectorBytes(row int64) []byte {
+	values := externalTakeInt8Vector(row)
+	data := make([]byte, len(values))
+	for i, value := range values {
+		data[i] = byte(value)
+	}
+	return data
+}
+
+func generateExternalTakeVectorParquetBytes(numRows int64) ([]byte, error) {
+	const binVecDim = 16
+	binVecByteWidth := binVecDim / 8
+	fp16ByteWidth := testVecDim * 2
+	bf16ByteWidth := testVecDim * 2
+
+	arrowSchema := arrow.NewSchema(
+		[]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "bin_vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: binVecByteWidth}},
+			{Name: "fp16_vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: fp16ByteWidth}},
+			{Name: "bf16_vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: bf16ByteWidth}},
+			{Name: "int8_vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: testVecDim}},
+		},
+		nil,
+	)
+
+	var buf bytes.Buffer
+	writer, err := pqarrow.NewFileWriter(arrowSchema, &buf, nil, pqarrow.DefaultWriterProps())
+	if err != nil {
+		return nil, fmt.Errorf("create parquet writer: %w", err)
+	}
+
+	pool := memory.NewGoAllocator()
+	builder := array.NewRecordBuilder(pool, arrowSchema)
+	defer builder.Release()
+
+	idBuilder := builder.Field(0).(*array.Int64Builder)
+	binBuilder := builder.Field(1).(*array.FixedSizeBinaryBuilder)
+	fp16Builder := builder.Field(2).(*array.FixedSizeBinaryBuilder)
+	bf16Builder := builder.Field(3).(*array.FixedSizeBinaryBuilder)
+	int8Builder := builder.Field(4).(*array.FixedSizeBinaryBuilder)
+
+	for row := int64(0); row < numRows; row++ {
+		idBuilder.Append(row)
+		binBuilder.Append(externalTakeDenseBytes(row, binVecByteWidth, 11))
+		fp16Builder.Append(externalTakeDenseBytes(row, fp16ByteWidth, 31))
+		bf16Builder.Append(externalTakeDenseBytes(row, bf16ByteWidth, 51))
+		int8Builder.Append(externalTakeInt8VectorBytes(row))
+	}
+
+	record := builder.NewRecord()
+	defer record.Release()
+
+	if err := writer.Write(record); err != nil {
+		return nil, fmt.Errorf("write record: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("close writer: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// --- Multi-type parquet generation ---
+
+// generateMultiTypeParquetBytes creates a Parquet file with multiple data types:
+//   - id (Int64), bool_val (Boolean), int8_val (Int8), int16_val (Int16),
+//   - int32_val (Int32), float_val (Float32), double_val (Float64),
+//   - embedding (FixedSizeList[Float32, testVecDim])
+//
+// Data formulas for row i (startID+i):
+//
+//	bool_val = (i is even), int8_val = i%100, int16_val = i*10,
+//	int32_val = i*100, float_val = i*1.5, double_val = i*0.01
 const testBinVecDim = 8 // BinaryVector dimension must be multiple of 8
 
 // --- Helpers ---
@@ -1084,6 +1178,149 @@ func TestExternalCollectionNullableFloatVectorTakeOutput(t *testing.T) {
 	assertVector(0, []float32{0, 1, 2, 3})
 	require.True(t, rows[1].isNull, "embedding should be null for id=1")
 	assertVector(2, []float32{8, 9, 10, 11})
+}
+
+func TestExternalCollectionAdditionalVectorTakeOutput(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	require.NoError(t, err)
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible (exists=%v, err=%v), skipping",
+			minioCfg.bucket, exists, err)
+	}
+
+	collName := common.GenRandomString("ext_take_vec", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	const numRows = int64(8)
+	data, err := generateExternalTakeVectorParquetBytes(numRows)
+	require.NoError(t, err, "generate vector take parquet")
+
+	objectKey := fmt.Sprintf("%s/data.parquet", extPath)
+	uploadParquetToMinIO(ctx, t, minioClient, minioCfg.bucket, objectKey, data)
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket,
+			fmt.Sprintf("%s/", extPath))
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extTestURI(minioCfg, extPath)).
+		WithExternalSpec(extTestSpec(minioCfg, "parquet")).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("bin_vec").WithDataType(entity.FieldTypeBinaryVector).
+			WithDim(16).WithExternalField("bin_vec")).
+		WithField(entity.NewField().WithName("fp16_vec").WithDataType(entity.FieldTypeFloat16Vector).
+			WithDim(testVecDim).WithExternalField("fp16_vec")).
+		WithField(entity.NewField().WithName("bf16_vec").WithDataType(entity.FieldTypeBFloat16Vector).
+			WithDim(testVecDim).WithExternalField("bf16_vec")).
+		WithField(entity.NewField().WithName("int8_vec").WithDataType(entity.FieldTypeInt8Vector).
+			WithDim(testVecDim).WithExternalField("int8_vec"))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	refreshAndWait(ctx, t, mc, collName)
+
+	indexes := map[string]index.Index{
+		"bin_vec":  index.NewBinFlatIndex(entity.HAMMING),
+		"fp16_vec": index.NewFlatIndex(entity.L2),
+		"bf16_vec": index.NewFlatIndex(entity.L2),
+		"int8_vec": index.NewGenericIndex("int8_hnsw", map[string]string{
+			index.MetricTypeKey: string(entity.COSINE),
+			index.IndexTypeKey:  "HNSW",
+			"M":                 "8",
+			"efConstruction":    "64",
+		}),
+	}
+	for fieldName, idx := range indexes {
+		idxTask, idxErr := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, fieldName, idx))
+		common.CheckErr(t, idxErr, true)
+		require.NoError(t, idxTask.Await(ctx), "create index on %s", fieldName)
+	}
+
+	loadTask, loadErr := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, loadErr, true)
+	require.NoError(t, loadTask.Await(ctx))
+
+	assertVectorRows := func(result client.ResultSet, context string) {
+		t.Helper()
+		idCol := result.GetColumn("id")
+		require.NotNil(t, idCol, "%s id column", context)
+		for _, fieldName := range []string{"bin_vec", "fp16_vec", "bf16_vec", "int8_vec"} {
+			require.NotNil(t, result.GetColumn(fieldName), "%s %s column", context, fieldName)
+		}
+		for i := 0; i < result.ResultCount; i++ {
+			id, err := idCol.GetAsInt64(i)
+			require.NoError(t, err)
+
+			rawBin, err := result.GetColumn("bin_vec").Get(i)
+			require.NoError(t, err)
+			require.Equal(t, externalTakeDenseBytes(id, 2, 11), []byte(rawBin.(entity.BinaryVector)),
+				"%s bin_vec row id=%d", context, id)
+
+			rawFP16, err := result.GetColumn("fp16_vec").Get(i)
+			require.NoError(t, err)
+			require.Equal(t, externalTakeDenseBytes(id, testVecDim*2, 31), []byte(rawFP16.(entity.Float16Vector)),
+				"%s fp16_vec row id=%d", context, id)
+
+			rawBF16, err := result.GetColumn("bf16_vec").Get(i)
+			require.NoError(t, err)
+			require.Equal(t, externalTakeDenseBytes(id, testVecDim*2, 51), []byte(rawBF16.(entity.BFloat16Vector)),
+				"%s bf16_vec row id=%d", context, id)
+
+			rawInt8, err := result.GetColumn("int8_vec").Get(i)
+			require.NoError(t, err)
+			require.Equal(t, externalTakeInt8Vector(id), []int8(rawInt8.(entity.Int8Vector)),
+				"%s int8_vec row id=%d", context, id)
+		}
+	}
+
+	queryRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id in [1, 3, 5]").
+		WithOutputFields("id", "bin_vec", "fp16_vec", "bf16_vec", "int8_vec"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 3, queryRes.ResultCount)
+	assertVectorRows(queryRes, "query output")
+
+	searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 3,
+		[]entity.Vector{entity.Int8Vector(externalTakeInt8Vector(3))}).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField("int8_vec").
+		WithOutputFields("id", "bin_vec", "fp16_vec", "bf16_vec", "int8_vec"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, len(searchRes))
+	require.Greater(t, searchRes[0].ResultCount, 0)
+	assertVectorRows(searchRes[0], "int8 search output")
+}
+
+func TestExternalCollectionSparseVectorCurrentlyRejected(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	collName := common.GenRandomString("ext_sparse_reject", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extTestURI(minioCfg, extPath)).
+		WithExternalSpec(extTestSpec(minioCfg, "parquet")).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("sparse_vec").WithDataType(entity.FieldTypeSparseVector).
+			WithExternalField("sparse_vec"))
+
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not support field type SparseFloatVector")
 }
 
 // TestExternalCollectionIncrementalRefresh tests that refreshing an external collection

--- a/tests/go_client/testcases/helper/test_setup.go
+++ b/tests/go_client/testcases/helper/test_setup.go
@@ -153,7 +153,8 @@ func AlterServerConfig(key, value string) (string, error) {
 	prev, _ := GetServerConfig(key)
 
 	body, _ := json.Marshal(map[string]string{"key": key, "value": value})
-	resp, err := http.Post(managementBaseURL()+"/management/config/alter",
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Post(managementBaseURL()+"/management/config/alter",
 		"application/json", bytes.NewReader(body))
 	if err != nil {
 		return "", fmt.Errorf("management API unreachable: %w", err)
@@ -169,7 +170,8 @@ func AlterServerConfig(key, value string) (string, error) {
 
 // GetServerConfig reads a config value from the management API.
 func GetServerConfig(key string) (string, error) {
-	resp, err := http.Get(managementBaseURL() + "/management/config/get?keys=" + url.QueryEscape(key))
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Get(managementBaseURL() + "/management/config/get?keys=" + url.QueryEscape(key))
 	if err != nil {
 		return "", err
 	}

--- a/tests/go_client/testcases/helper/test_setup.go
+++ b/tests/go_client/testcases/helper/test_setup.go
@@ -127,11 +127,17 @@ func teardown() {
 // derived from the gRPC addr flag (e.g. http://host:19530 -> http://host:9091).
 func managementBaseURL() string {
 	host := ""
-	if u, err := url.Parse(*addr); err == nil {
+	rawAddr := *addr
+	if u, err := url.Parse(rawAddr); err == nil {
 		host = u.Hostname()
 	}
+	if host == "" && rawAddr != "" && !strings.Contains(rawAddr, "://") {
+		if u, err := url.Parse("http://" + rawAddr); err == nil {
+			host = u.Hostname()
+		}
+	}
 	if host == "" {
-		host = *addr
+		host = rawAddr
 		if h, _, err := net.SplitHostPort(host); err == nil {
 			host = h
 		} else if idx := strings.LastIndexByte(host, ':'); idx >= 0 {
@@ -142,7 +148,7 @@ func managementBaseURL() string {
 	if host == "" {
 		host = "localhost"
 	}
-	return fmt.Sprintf("http://%s:9091", host)
+	return fmt.Sprintf("http://%s", net.JoinHostPort(host, "9091"))
 }
 
 // AlterServerConfig changes a Milvus server config via the management HTTP API.

--- a/tests/go_client/testcases/helper/test_setup.go
+++ b/tests/go_client/testcases/helper/test_setup.go
@@ -127,23 +127,15 @@ func teardown() {
 // derived from the gRPC addr flag (e.g. http://host:19530 -> http://host:9091).
 func managementBaseURL() string {
 	host := ""
-	rawAddr := *addr
-	if u, err := url.Parse(rawAddr); err == nil {
-		host = u.Hostname()
-	}
-	if host == "" && rawAddr != "" && !strings.Contains(rawAddr, "://") {
-		if u, err := url.Parse("http://" + rawAddr); err == nil {
+	rawAddr := strings.TrimSpace(*addr)
+	if rawAddr != "" {
+		parseAddr := rawAddr
+		if !strings.Contains(rawAddr, "://") {
+			parseAddr = "http://" + rawAddr
+		}
+		if u, err := url.Parse(parseAddr); err == nil {
 			host = u.Hostname()
 		}
-	}
-	if host == "" {
-		host = rawAddr
-		if h, _, err := net.SplitHostPort(host); err == nil {
-			host = h
-		} else if idx := strings.LastIndexByte(host, ':'); idx >= 0 {
-			host = host[:idx]
-		}
-		host = strings.Trim(host, "[]")
 	}
 	if host == "" {
 		host = "localhost"

--- a/tests/go_client/testcases/helper/test_setup_test.go
+++ b/tests/go_client/testcases/helper/test_setup_test.go
@@ -1,0 +1,192 @@
+package helper
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func withManagementRoundTripper(t *testing.T, fn roundTripFunc) {
+	t.Helper()
+	prevTransport := http.DefaultTransport
+	http.DefaultTransport = fn
+	t.Cleanup(func() {
+		http.DefaultTransport = prevTransport
+	})
+}
+
+func withTestAddr(t *testing.T, value string) {
+	t.Helper()
+	prevAddr := *addr
+	*addr = value
+	t.Cleanup(func() {
+		*addr = prevAddr
+	})
+}
+
+func managementResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestManagementBaseURL(t *testing.T) {
+	t.Run("uses host from grpc address", func(t *testing.T) {
+		withTestAddr(t, "http://milvus.example:19530")
+
+		require.Equal(t, "http://milvus.example:9091", managementBaseURL())
+	})
+
+	t.Run("falls back to localhost on invalid address", func(t *testing.T) {
+		withTestAddr(t, "http://%zz")
+
+		require.Equal(t, "http://localhost:9091", managementBaseURL())
+	})
+
+	t.Run("falls back to localhost on address without host", func(t *testing.T) {
+		withTestAddr(t, "localhost:19530")
+
+		require.Equal(t, "http://localhost:9091", managementBaseURL())
+	})
+}
+
+func TestGetServerConfig(t *testing.T) {
+	configKey := "queryNode.internalCollection.useTakeForOutput"
+
+	t.Run("success", func(t *testing.T) {
+		withTestAddr(t, "http://milvus.example:19530")
+		withManagementRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, http.MethodGet, req.Method)
+			require.Equal(t, "milvus.example:9091", req.URL.Host)
+			require.Equal(t, "/management/config/get", req.URL.Path)
+			require.Equal(t, configKey, req.URL.Query().Get("keys"))
+			return managementResponse(http.StatusOK,
+				`{"configs":[{"key":"`+configKey+`","value":"true"}]}`), nil
+		})
+
+		value, err := GetServerConfig(configKey)
+		require.NoError(t, err)
+		require.Equal(t, "true", value)
+	})
+
+	t.Run("http error", func(t *testing.T) {
+		withManagementRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+			return managementResponse(http.StatusInternalServerError, "boom"), nil
+		})
+
+		_, err := GetServerConfig(configKey)
+		require.ErrorContains(t, err, "HTTP 500")
+		require.ErrorContains(t, err, "boom")
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		withManagementRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+			return managementResponse(http.StatusOK, "{"), nil
+		})
+
+		_, err := GetServerConfig(configKey)
+		require.Error(t, err)
+	})
+
+	t.Run("missing config", func(t *testing.T) {
+		withManagementRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+			return managementResponse(http.StatusOK, `{"configs":[]}`), nil
+		})
+
+		_, err := GetServerConfig(configKey)
+		require.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("config error", func(t *testing.T) {
+		withManagementRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+			return managementResponse(http.StatusOK,
+				`{"configs":[{"key":"`+configKey+`","error":"unknown key"}]}`), nil
+		})
+
+		_, err := GetServerConfig(configKey)
+		require.ErrorContains(t, err, "unknown key")
+	})
+
+	t.Run("transport error", func(t *testing.T) {
+		withManagementRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("dial failed")
+		})
+
+		_, err := GetServerConfig(configKey)
+		require.ErrorContains(t, err, "dial failed")
+	})
+}
+
+func TestAlterServerConfig(t *testing.T) {
+	configKey := "queryNode.internalCollection.useTakeForOutput"
+
+	t.Run("success returns previous value", func(t *testing.T) {
+		var postSeen bool
+		withTestAddr(t, "http://milvus.example:19530")
+		withManagementRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+			switch req.Method {
+			case http.MethodGet:
+				return managementResponse(http.StatusOK,
+					`{"configs":[{"key":"`+configKey+`","value":"false"}]}`), nil
+			case http.MethodPost:
+				postSeen = true
+				require.Equal(t, "milvus.example:9091", req.URL.Host)
+				require.Equal(t, "/management/config/alter", req.URL.Path)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				require.JSONEq(t,
+					`{"key":"`+configKey+`","value":"true"}`,
+					string(body))
+				return managementResponse(http.StatusOK, "{}"), nil
+			default:
+				require.FailNow(t, "unexpected method", req.Method)
+				return nil, nil
+			}
+		})
+
+		prev, err := AlterServerConfig(configKey, "true")
+		require.NoError(t, err)
+		require.Equal(t, "false", prev)
+		require.True(t, postSeen)
+	})
+
+	t.Run("post http error", func(t *testing.T) {
+		withManagementRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+			if req.Method == http.MethodGet {
+				return managementResponse(http.StatusOK,
+					`{"configs":[{"key":"`+configKey+`","value":"false"}]}`), nil
+			}
+			return managementResponse(http.StatusServiceUnavailable, "not ready"), nil
+		})
+
+		_, err := AlterServerConfig(configKey, "true")
+		require.ErrorContains(t, err, "HTTP 503")
+		require.ErrorContains(t, err, "not ready")
+	})
+
+	t.Run("post transport error", func(t *testing.T) {
+		withManagementRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+			if req.Method == http.MethodGet {
+				return managementResponse(http.StatusOK,
+					`{"configs":[{"key":"`+configKey+`","value":"false"}]}`), nil
+			}
+			return nil, errors.New("connection refused")
+		})
+
+		_, err := AlterServerConfig(configKey, "true")
+		require.ErrorContains(t, err, "management API unreachable")
+		require.ErrorContains(t, err, "connection refused")
+	})
+}

--- a/tests/go_client/testcases/helper/test_setup_test.go
+++ b/tests/go_client/testcases/helper/test_setup_test.go
@@ -1,12 +1,12 @@
 package helper
 
 import (
-	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,10 +55,16 @@ func TestManagementBaseURL(t *testing.T) {
 		require.Equal(t, "http://localhost:9091", managementBaseURL())
 	})
 
-	t.Run("falls back to localhost on address without host", func(t *testing.T) {
+	t.Run("uses host from address without scheme", func(t *testing.T) {
 		withTestAddr(t, "localhost:19530")
 
 		require.Equal(t, "http://localhost:9091", managementBaseURL())
+	})
+
+	t.Run("uses ci service host from address without scheme", func(t *testing.T) {
+		withTestAddr(t, "gosdk-4823-milvus.jenkins-milvus-ci:19530")
+
+		require.Equal(t, "http://gosdk-4823-milvus.jenkins-milvus-ci:9091", managementBaseURL())
 	})
 }
 

--- a/tests/go_client/testcases/search_test.go
+++ b/tests/go_client/testcases/search_test.go
@@ -259,7 +259,7 @@ func TestInternalCollectionTakeOutputFields(t *testing.T) {
 	vectors := make([]entity.Vector, 0, queryRes.ResultCount)
 	for _, vec := range queryRes.GetColumn(common.DefaultFloatVecFieldName).(*column.ColumnFloatVector).Data() {
 		require.Len(t, vec, internalTakeDim)
-		vectors = append(vectors, entity.FloatVector(vec))
+		vectors = append(vectors, vec)
 	}
 
 	searchRes, err := mc.Search(ctx, client.NewSearchOption(schema.CollectionName, 3, vectors).

--- a/tests/go_client/testcases/search_test.go
+++ b/tests/go_client/testcases/search_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -18,6 +19,13 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/tests/go_client/common"
 	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+const (
+	internalTakeDim          = 8
+	internalTakeBinaryDim    = 16
+	internalTakeInt8VecField = "int8Vec"
+	internalTakeTsField      = "ts"
 )
 
 func TestSearchDefault(t *testing.T) {
@@ -188,6 +196,453 @@ func TestSearchPartitions(t *testing.T) {
 		require.Contains(t, searchResult[1].IDs.(*column.ColumnInt64).Data(), _parId0)
 		require.EqualValues(t, searchResult[0].GetColumn(common.DefaultFloatVecFieldName).(*column.ColumnFloatVector).Data()[0], vectors[0])
 		require.EqualValues(t, searchResult[1].GetColumn(common.DefaultFloatVecFieldName).(*column.ColumnFloatVector).Data()[0], vectors[1])
+	}
+}
+
+func TestInternalCollectionTakeOutputFields(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	requireInternalTakeStorageV2(t)
+	enableInternalTakeForOutput(t)
+
+	collName := common.GenRandomString("internal_take_all", 6)
+	schema, outputFields := buildInternalTakeAllTypesSchema(collName)
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
+	})
+
+	data := buildInternalTakeAllTypesData(t, 12)
+	_, err = mc.Insert(ctx, client.NewColumnBasedInsertOption(collName, data.columns...))
+	common.CheckErr(t, err, true)
+
+	flushTask, err := mc.Flush(ctx, client.NewFlushOption(collName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, flushTask.Await(ctx), true)
+
+	indexes := map[string]index.Index{
+		common.DefaultFloatVecFieldName:    index.NewFlatIndex(entity.L2),
+		common.DefaultBinaryVecFieldName:   index.NewBinFlatIndex(entity.HAMMING),
+		common.DefaultFloat16VecFieldName:  index.NewFlatIndex(entity.L2),
+		common.DefaultBFloat16VecFieldName: index.NewFlatIndex(entity.L2),
+		internalTakeInt8VecField: index.NewGenericIndex("int8_hnsw", map[string]string{
+			index.MetricTypeKey: string(entity.COSINE),
+			index.IndexTypeKey:  "HNSW",
+			"M":                 "8",
+			"efConstruction":    "64",
+		}),
+		common.DefaultSparseVecFieldName: index.NewSparseInvertedIndex(entity.IP, 0.3),
+	}
+	for fieldName, idx := range indexes {
+		idxTask, idxErr := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, fieldName, idx))
+		common.CheckErr(t, idxErr, true)
+		require.NoError(t, idxTask.Await(ctx), "create index on %s", fieldName)
+	}
+
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, loadTask.Await(ctx), true)
+
+	expr := fmt.Sprintf("%s in [0, 2, 4]", common.DefaultInt64FieldName)
+	queryRes, err := mc.Query(ctx, client.NewQueryOption(schema.CollectionName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter(expr).
+		WithOutputFields(outputFields...))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 3, queryRes.ResultCount)
+	common.CheckOutputFields(t, outputFields, queryRes.Fields)
+	require.ElementsMatch(t, []int64{0, 2, 4}, queryRes.GetColumn(common.DefaultInt64FieldName).(*column.ColumnInt64).Data())
+	assertInternalTakeAllTypesResult(t, queryRes, data, outputFields)
+
+	vectors := make([]entity.Vector, 0, queryRes.ResultCount)
+	for _, vec := range queryRes.GetColumn(common.DefaultFloatVecFieldName).(*column.ColumnFloatVector).Data() {
+		require.Len(t, vec, internalTakeDim)
+		vectors = append(vectors, entity.FloatVector(vec))
+	}
+
+	searchRes, err := mc.Search(ctx, client.NewSearchOption(schema.CollectionName, 3, vectors).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField(common.DefaultFloatVecFieldName).
+		WithOutputFields(outputFields...))
+	common.CheckErr(t, err, true)
+	common.CheckSearchResult(t, searchRes, len(vectors), 3)
+	for _, result := range searchRes {
+		common.CheckOutputFields(t, outputFields, result.Fields)
+		assertInternalTakeAllTypesResult(t, result, data, outputFields)
+	}
+}
+
+func TestInternalCollectionTakeStructArrayOutputFields(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	requireInternalTakeStorageV2(t)
+	enableInternalTakeForOutput(t)
+
+	collName, _, data := canonicalStructArrayCollection(t, ctx, mc, 32)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(ctx, client.NewDropCollectionOption(collName))
+	})
+
+	queryRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithFilter("id in [0, 2, 4]").
+		WithOutputFields("id", "clips").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 3, queryRes.ResultCount)
+	common.CheckOutputFields(t, []string{"id", "clips"}, queryRes.Fields)
+	assertStructArrayOutput(t, queryRes)
+
+	searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 3,
+		[]entity.Vector{entity.FloatVector(data.NormalVectors[0])}).
+		WithANNSField("normal_vector").
+		WithOutputFields("id", "clips").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	common.CheckSearchResult(t, searchRes, 1, 3)
+	common.CheckOutputFields(t, []string{"id", "clips"}, searchRes[0].Fields)
+	assertStructArrayOutput(t, searchRes[0])
+}
+
+type internalTakeAllTypesData struct {
+	columns       []column.Column
+	bools         []bool
+	int8s         []int8
+	int16s        []int16
+	int32s        []int32
+	int64s        []int64
+	floats        []float32
+	doubles       []float64
+	varchars      []string
+	jsons         [][]byte
+	geometries    []string
+	timestamps    []time.Time
+	boolArrays    [][]bool
+	int8Arrays    [][]int8
+	int16Arrays   [][]int16
+	int32Arrays   [][]int32
+	int64Arrays   [][]int64
+	floatArrays   [][]float32
+	doubleArrays  [][]float64
+	varcharArrays [][]string
+	floatVecs     [][]float32
+	binaryVecs    [][]byte
+	float16Vecs   [][]byte
+	bfloat16Vecs  [][]byte
+	int8Vecs      [][]int8
+	sparseVecs    []entity.SparseEmbedding
+}
+
+func requireInternalTakeStorageV2(t *testing.T) {
+	t.Helper()
+
+	value, err := hp.GetServerConfig("common.storage.useLoonFFI")
+	require.NoError(t, err)
+	if !strings.EqualFold(value, "true") {
+		t.Skipf("internal take requires StorageV2/V3 reader, common.storage.useLoonFFI=%q", value)
+	}
+}
+
+func enableInternalTakeForOutput(t *testing.T) {
+	t.Helper()
+
+	configKey := "queryNode.internalCollection.useTakeForOutput"
+	prevConfig, err := hp.AlterServerConfig(configKey, "true")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if prevConfig == "" {
+			prevConfig = "false"
+		}
+		_, _ = hp.AlterServerConfig(configKey, prevConfig)
+	})
+}
+
+func buildInternalTakeAllTypesSchema(collName string) (*entity.Schema, []string) {
+	outputFields := []string{
+		common.DefaultInt64FieldName,
+		common.DefaultBoolFieldName,
+		common.DefaultInt8FieldName,
+		common.DefaultInt16FieldName,
+		common.DefaultInt32FieldName,
+		common.DefaultFloatFieldName,
+		common.DefaultDoubleFieldName,
+		common.DefaultVarcharFieldName,
+		common.DefaultJSONFieldName,
+		common.DefaultGeometryFieldName,
+		internalTakeTsField,
+		common.DefaultBoolArrayField,
+		common.DefaultInt8ArrayField,
+		common.DefaultInt16ArrayField,
+		common.DefaultInt32ArrayField,
+		common.DefaultInt64ArrayField,
+		common.DefaultFloatArrayField,
+		common.DefaultDoubleArrayField,
+		common.DefaultVarcharArrayField,
+		common.DefaultFloatVecFieldName,
+		common.DefaultBinaryVecFieldName,
+		common.DefaultFloat16VecFieldName,
+		common.DefaultBFloat16VecFieldName,
+		internalTakeInt8VecField,
+		common.DefaultSparseVecFieldName,
+	}
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithField(entity.NewField().WithName(common.DefaultInt64FieldName).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName(common.DefaultBoolFieldName).WithDataType(entity.FieldTypeBool)).
+		WithField(entity.NewField().WithName(common.DefaultInt8FieldName).WithDataType(entity.FieldTypeInt8)).
+		WithField(entity.NewField().WithName(common.DefaultInt16FieldName).WithDataType(entity.FieldTypeInt16)).
+		WithField(entity.NewField().WithName(common.DefaultInt32FieldName).WithDataType(entity.FieldTypeInt32)).
+		WithField(entity.NewField().WithName(common.DefaultFloatFieldName).WithDataType(entity.FieldTypeFloat)).
+		WithField(entity.NewField().WithName(common.DefaultDoubleFieldName).WithDataType(entity.FieldTypeDouble)).
+		WithField(entity.NewField().WithName(common.DefaultVarcharFieldName).WithDataType(entity.FieldTypeVarChar).WithMaxLength(common.TestMaxLen)).
+		WithField(entity.NewField().WithName(common.DefaultJSONFieldName).WithDataType(entity.FieldTypeJSON)).
+		WithField(entity.NewField().WithName(common.DefaultGeometryFieldName).WithDataType(entity.FieldTypeGeometry)).
+		WithField(entity.NewField().WithName(internalTakeTsField).WithDataType(entity.FieldTypeTimestamptz)).
+		WithField(entity.NewField().WithName(common.DefaultBoolArrayField).WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeBool).WithMaxCapacity(common.TestCapacity)).
+		WithField(entity.NewField().WithName(common.DefaultInt8ArrayField).WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeInt8).WithMaxCapacity(common.TestCapacity)).
+		WithField(entity.NewField().WithName(common.DefaultInt16ArrayField).WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeInt16).WithMaxCapacity(common.TestCapacity)).
+		WithField(entity.NewField().WithName(common.DefaultInt32ArrayField).WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeInt32).WithMaxCapacity(common.TestCapacity)).
+		WithField(entity.NewField().WithName(common.DefaultInt64ArrayField).WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeInt64).WithMaxCapacity(common.TestCapacity)).
+		WithField(entity.NewField().WithName(common.DefaultFloatArrayField).WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeFloat).WithMaxCapacity(common.TestCapacity)).
+		WithField(entity.NewField().WithName(common.DefaultDoubleArrayField).WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeDouble).WithMaxCapacity(common.TestCapacity)).
+		WithField(entity.NewField().WithName(common.DefaultVarcharArrayField).WithDataType(entity.FieldTypeArray).WithElementType(entity.FieldTypeVarChar).WithMaxLength(common.TestMaxLen).WithMaxCapacity(common.TestCapacity)).
+		WithField(entity.NewField().WithName(common.DefaultFloatVecFieldName).WithDataType(entity.FieldTypeFloatVector).WithDim(internalTakeDim)).
+		WithField(entity.NewField().WithName(common.DefaultBinaryVecFieldName).WithDataType(entity.FieldTypeBinaryVector).WithDim(internalTakeBinaryDim)).
+		WithField(entity.NewField().WithName(common.DefaultFloat16VecFieldName).WithDataType(entity.FieldTypeFloat16Vector).WithDim(internalTakeDim)).
+		WithField(entity.NewField().WithName(common.DefaultBFloat16VecFieldName).WithDataType(entity.FieldTypeBFloat16Vector).WithDim(internalTakeDim)).
+		WithField(entity.NewField().WithName(internalTakeInt8VecField).WithDataType(entity.FieldTypeInt8Vector).WithDim(internalTakeDim)).
+		WithField(entity.NewField().WithName(common.DefaultSparseVecFieldName).WithDataType(entity.FieldTypeSparseVector))
+	return schema, outputFields
+}
+
+func buildInternalTakeAllTypesData(t *testing.T, nb int) internalTakeAllTypesData {
+	t.Helper()
+
+	data := internalTakeAllTypesData{
+		bools:         make([]bool, 0, nb),
+		int8s:         make([]int8, 0, nb),
+		int16s:        make([]int16, 0, nb),
+		int32s:        make([]int32, 0, nb),
+		int64s:        make([]int64, 0, nb),
+		floats:        make([]float32, 0, nb),
+		doubles:       make([]float64, 0, nb),
+		varchars:      make([]string, 0, nb),
+		jsons:         make([][]byte, 0, nb),
+		geometries:    make([]string, 0, nb),
+		timestamps:    make([]time.Time, 0, nb),
+		boolArrays:    make([][]bool, 0, nb),
+		int8Arrays:    make([][]int8, 0, nb),
+		int16Arrays:   make([][]int16, 0, nb),
+		int32Arrays:   make([][]int32, 0, nb),
+		int64Arrays:   make([][]int64, 0, nb),
+		floatArrays:   make([][]float32, 0, nb),
+		doubleArrays:  make([][]float64, 0, nb),
+		varcharArrays: make([][]string, 0, nb),
+		floatVecs:     make([][]float32, 0, nb),
+		binaryVecs:    make([][]byte, 0, nb),
+		float16Vecs:   make([][]byte, 0, nb),
+		bfloat16Vecs:  make([][]byte, 0, nb),
+		int8Vecs:      make([][]int8, 0, nb),
+		sparseVecs:    make([]entity.SparseEmbedding, 0, nb),
+	}
+	baseTime := time.Date(2026, time.May, 26, 8, 0, 0, 0, time.UTC)
+	for i := 0; i < nb; i++ {
+		id := int64(i)
+		floatVec := internalTakeFloatVector(i)
+		fp16 := entity.FloatVector(floatVec).ToFloat16Vector()
+		bf16 := entity.FloatVector(floatVec).ToBFloat16Vector()
+		sparse, err := entity.NewSliceSparseEmbedding(
+			[]uint32{uint32(i + 1), uint32(i + 17)},
+			[]float32{float32(i) + 0.25, float32(i) + 0.75})
+		require.NoError(t, err)
+
+		data.int64s = append(data.int64s, id)
+		data.bools = append(data.bools, i%2 == 0)
+		data.int8s = append(data.int8s, int8(i-6))
+		data.int16s = append(data.int16s, int16(i*10))
+		data.int32s = append(data.int32s, int32(i*100))
+		data.floats = append(data.floats, float32(i)+0.25)
+		data.doubles = append(data.doubles, float64(i)+0.5)
+		data.varchars = append(data.varchars, fmt.Sprintf("varchar_%02d", i))
+		data.jsons = append(data.jsons, []byte(fmt.Sprintf(`{"id":%d,"tag":"row_%02d"}`, i, i)))
+		data.geometries = append(data.geometries, fmt.Sprintf("POINT (%d %d)", i, i+1))
+		data.timestamps = append(data.timestamps, baseTime.Add(time.Duration(i)*time.Minute))
+		data.boolArrays = append(data.boolArrays, []bool{i%2 == 0, i%3 == 0})
+		data.int8Arrays = append(data.int8Arrays, []int8{int8(i), int8(i + 1)})
+		data.int16Arrays = append(data.int16Arrays, []int16{int16(i * 10), int16(i*10 + 1)})
+		data.int32Arrays = append(data.int32Arrays, []int32{int32(i * 100), int32(i*100 + 1)})
+		data.int64Arrays = append(data.int64Arrays, []int64{id, id + 100})
+		data.floatArrays = append(data.floatArrays, []float32{float32(i) + 0.1, float32(i) + 0.2})
+		data.doubleArrays = append(data.doubleArrays, []float64{float64(i) + 0.01, float64(i) + 0.02})
+		data.varcharArrays = append(data.varcharArrays, []string{fmt.Sprintf("a_%02d", i), fmt.Sprintf("b_%02d", i)})
+		data.floatVecs = append(data.floatVecs, floatVec)
+		data.binaryVecs = append(data.binaryVecs, []byte{byte(i), byte(i + 16)})
+		data.float16Vecs = append(data.float16Vecs, []byte(fp16))
+		data.bfloat16Vecs = append(data.bfloat16Vecs, []byte(bf16))
+		data.int8Vecs = append(data.int8Vecs, internalTakeInt8Vector(i))
+		data.sparseVecs = append(data.sparseVecs, sparse)
+	}
+
+	data.columns = []column.Column{
+		column.NewColumnInt64(common.DefaultInt64FieldName, data.int64s),
+		column.NewColumnBool(common.DefaultBoolFieldName, data.bools),
+		column.NewColumnInt8(common.DefaultInt8FieldName, data.int8s),
+		column.NewColumnInt16(common.DefaultInt16FieldName, data.int16s),
+		column.NewColumnInt32(common.DefaultInt32FieldName, data.int32s),
+		column.NewColumnFloat(common.DefaultFloatFieldName, data.floats),
+		column.NewColumnDouble(common.DefaultDoubleFieldName, data.doubles),
+		column.NewColumnVarChar(common.DefaultVarcharFieldName, data.varchars),
+		column.NewColumnJSONBytes(common.DefaultJSONFieldName, data.jsons),
+		column.NewColumnGeometryWKT(common.DefaultGeometryFieldName, data.geometries),
+		column.NewColumnTimestamptz(internalTakeTsField, data.timestamps),
+		column.NewColumnBoolArray(common.DefaultBoolArrayField, data.boolArrays),
+		column.NewColumnInt8Array(common.DefaultInt8ArrayField, data.int8Arrays),
+		column.NewColumnInt16Array(common.DefaultInt16ArrayField, data.int16Arrays),
+		column.NewColumnInt32Array(common.DefaultInt32ArrayField, data.int32Arrays),
+		column.NewColumnInt64Array(common.DefaultInt64ArrayField, data.int64Arrays),
+		column.NewColumnFloatArray(common.DefaultFloatArrayField, data.floatArrays),
+		column.NewColumnDoubleArray(common.DefaultDoubleArrayField, data.doubleArrays),
+		column.NewColumnVarCharArray(common.DefaultVarcharArrayField, data.varcharArrays),
+		column.NewColumnFloatVector(common.DefaultFloatVecFieldName, internalTakeDim, data.floatVecs),
+		column.NewColumnBinaryVector(common.DefaultBinaryVecFieldName, internalTakeBinaryDim, data.binaryVecs),
+		column.NewColumnFloat16Vector(common.DefaultFloat16VecFieldName, internalTakeDim, data.float16Vecs),
+		column.NewColumnBFloat16Vector(common.DefaultBFloat16VecFieldName, internalTakeDim, data.bfloat16Vecs),
+		column.NewColumnInt8Vector(internalTakeInt8VecField, internalTakeDim, data.int8Vecs),
+		column.NewColumnSparseVectors(common.DefaultSparseVecFieldName, data.sparseVecs),
+	}
+	return data
+}
+
+func internalTakeFloatVector(row int) []float32 {
+	vector := make([]float32, internalTakeDim)
+	for dim := range vector {
+		vector[dim] = float32(row) + float32(dim)/10
+	}
+	return vector
+}
+
+func internalTakeInt8Vector(row int) []int8 {
+	vector := make([]int8, internalTakeDim)
+	for dim := range vector {
+		vector[dim] = int8(row + dim)
+	}
+	return vector
+}
+
+func assertInternalTakeAllTypesResult(t *testing.T, result client.ResultSet, data internalTakeAllTypesData, outputFields []string) {
+	t.Helper()
+
+	for _, fieldName := range outputFields {
+		col := result.GetColumn(fieldName)
+		require.NotNil(t, col, "missing output field %s", fieldName)
+		require.Equal(t, result.ResultCount, col.Len(), "field %s row count", fieldName)
+	}
+	for i := 0; i < result.ResultCount; i++ {
+		id, err := result.GetColumn(common.DefaultInt64FieldName).GetAsInt64(i)
+		require.NoError(t, err)
+		row := int(id)
+		require.GreaterOrEqual(t, row, 0)
+		require.Less(t, row, len(data.int64s))
+
+		boolVal, err := result.GetColumn(common.DefaultBoolFieldName).GetAsBool(i)
+		require.NoError(t, err)
+		require.Equal(t, data.bools[row], boolVal)
+
+		int8Val, err := result.GetColumn(common.DefaultInt8FieldName).GetAsInt64(i)
+		require.NoError(t, err)
+		require.EqualValues(t, data.int8s[row], int8Val)
+
+		int16Val, err := result.GetColumn(common.DefaultInt16FieldName).GetAsInt64(i)
+		require.NoError(t, err)
+		require.EqualValues(t, data.int16s[row], int16Val)
+
+		int32Val, err := result.GetColumn(common.DefaultInt32FieldName).GetAsInt64(i)
+		require.NoError(t, err)
+		require.EqualValues(t, data.int32s[row], int32Val)
+
+		floatVal, err := result.GetColumn(common.DefaultFloatFieldName).GetAsDouble(i)
+		require.NoError(t, err)
+		require.InDelta(t, data.floats[row], floatVal, 1e-6)
+
+		doubleVal, err := result.GetColumn(common.DefaultDoubleFieldName).GetAsDouble(i)
+		require.NoError(t, err)
+		require.InDelta(t, data.doubles[row], doubleVal, 1e-9)
+
+		varcharVal, err := result.GetColumn(common.DefaultVarcharFieldName).GetAsString(i)
+		require.NoError(t, err)
+		require.Equal(t, data.varchars[row], varcharVal)
+
+		jsonRaw, err := result.GetColumn(common.DefaultJSONFieldName).Get(i)
+		require.NoError(t, err)
+		require.Equal(t, data.jsons[row], jsonRaw.([]byte))
+
+		geometryVal, err := result.GetColumn(common.DefaultGeometryFieldName).GetAsString(i)
+		require.NoError(t, err)
+		require.NotEmpty(t, geometryVal)
+
+		tsVal, err := result.GetColumn(internalTakeTsField).GetAsString(i)
+		require.NoError(t, err)
+		require.NotEmpty(t, tsVal)
+
+		assertColumnValue(t, result, common.DefaultBoolArrayField, i, data.boolArrays[row])
+		assertColumnValue(t, result, common.DefaultInt8ArrayField, i, data.int8Arrays[row])
+		assertColumnValue(t, result, common.DefaultInt16ArrayField, i, data.int16Arrays[row])
+		assertColumnValue(t, result, common.DefaultInt32ArrayField, i, data.int32Arrays[row])
+		assertColumnValue(t, result, common.DefaultInt64ArrayField, i, data.int64Arrays[row])
+		assertColumnValue(t, result, common.DefaultFloatArrayField, i, data.floatArrays[row])
+		assertColumnValue(t, result, common.DefaultDoubleArrayField, i, data.doubleArrays[row])
+		assertColumnValue(t, result, common.DefaultVarcharArrayField, i, data.varcharArrays[row])
+
+		floatVecRaw, err := result.GetColumn(common.DefaultFloatVecFieldName).Get(i)
+		require.NoError(t, err)
+		require.Equal(t, data.floatVecs[row], []float32(floatVecRaw.(entity.FloatVector)))
+
+		binaryVecRaw, err := result.GetColumn(common.DefaultBinaryVecFieldName).Get(i)
+		require.NoError(t, err)
+		require.Equal(t, data.binaryVecs[row], []byte(binaryVecRaw.(entity.BinaryVector)))
+
+		fp16Raw, err := result.GetColumn(common.DefaultFloat16VecFieldName).Get(i)
+		require.NoError(t, err)
+		require.Equal(t, data.float16Vecs[row], []byte(fp16Raw.(entity.Float16Vector)))
+
+		bf16Raw, err := result.GetColumn(common.DefaultBFloat16VecFieldName).Get(i)
+		require.NoError(t, err)
+		require.Equal(t, data.bfloat16Vecs[row], []byte(bf16Raw.(entity.BFloat16Vector)))
+
+		int8VecRaw, err := result.GetColumn(internalTakeInt8VecField).Get(i)
+		require.NoError(t, err)
+		require.Equal(t, data.int8Vecs[row], []int8(int8VecRaw.(entity.Int8Vector)))
+
+		sparseRaw, err := result.GetColumn(common.DefaultSparseVecFieldName).Get(i)
+		require.NoError(t, err)
+		require.Equal(t, data.sparseVecs[row].Serialize(), sparseRaw.(entity.SparseEmbedding).Serialize())
+	}
+}
+
+func assertColumnValue(t *testing.T, result client.ResultSet, fieldName string, idx int, expected any) {
+	t.Helper()
+
+	raw, err := result.GetColumn(fieldName).Get(idx)
+	require.NoError(t, err)
+	require.Equal(t, expected, raw)
+}
+
+func assertStructArrayOutput(t *testing.T, result client.ResultSet) {
+	t.Helper()
+
+	clips := result.GetColumn("clips")
+	require.NotNil(t, clips)
+	require.Equal(t, result.ResultCount, clips.Len())
+	for i := 0; i < result.ResultCount; i++ {
+		raw, err := clips.Get(i)
+		require.NoError(t, err)
+		row, ok := raw.(map[string]any)
+		require.Truef(t, ok, "clips row %d has unexpected type %T", i, raw)
+		require.Contains(t, row, "clip_str")
+		require.Contains(t, row, "clip_embedding1")
+		require.Contains(t, row, "clip_embedding2")
 	}
 }
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/50078

This PR supports using the storage `take()` path for internal collection query and search output fields.

What changed:
- Add a separate `queryNode.internalCollection.useTakeForOutput` config and keep it disabled by default.
- Keep external collection take controlled by `queryNode.externalCollection.useTakeForOutput`.
- Let internal collections request StorageV2/V3 field-id columns through `take()`, while external collections keep using external field names.
- Extend Arrow take output conversion for binary, float16, bfloat16, int8, and sparse vector fields.
- Add info logs when take falls back to `bulk_subscript`.
- Add Go client E2E coverage for internal take output fields across scalar, array, vector, sparse vector, and vector-array outputs.

Validation:
- make plan-parser-lib
- make build-cpp
- make build-go
- git diff --check
- go test internal/querynodev2/segments
- go test internal/util/segcore
- go test pkg/v3/util/paramtable
- go test tests/go_client/testcases/helper
- cmake_build/unittest/all_tests with take-related gtest filters
- go_client E2E:
  - TestInternalCollectionTakeOutputFields
  - TestInternalCollectionTakeStructArrayOutputFields
  - TestExternalCollectionMultipleDataTypes
  - TestExternalCollectionAdditionalVectorTakeOutput
  - TestExternalCollectionSparseVectorCurrentlyRejected