### PR TITLE
fix: symlink conan to ~/.local/bin on macOS

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -130,7 +130,14 @@ install_conan() {
 
     # Try direct user install first (works on Ubuntu 20.04/22.04)
     if $pip_cmd install --user "conan==${CONAN_VERSION}" 2>/dev/null; then
-        :
+        if [ ! -x "${HOME}/.local/bin/conan" ]; then
+            local user_bin
+            user_bin=$(python3 -c "import site; print(site.USER_BASE + '/bin')" 2>/dev/null)
+            if [ -x "${user_bin}/conan" ]; then
+                mkdir -p "${HOME}/.local/bin"
+                ln -sf "${user_bin}/conan" "${HOME}/.local/bin/conan"
+            fi
+        fi
     else
         # Ubuntu 24.04+ enforces PEP 668 — use an isolated venv instead
         print_info "System pip blocked (PEP 668). Installing Conan in isolated venv..."

--- a/scripts/stop_graceful.sh
+++ b/scripts/stop_graceful.sh
@@ -25,23 +25,25 @@ if [ ! -z "$1" ]; then
   timeout=$1
 fi
 
-if [ -z $(get_milvus_process) ]; then
+pids=$(get_milvus_process)
+if [ -z "$pids" ]; then
   echo "No milvus process"
   exit 0
 fi
-kill -15 $(get_milvus_process)
+kill -15 $pids
 
 start=$(date +%s)
 while :
 do
   sleep 1
-  if [ -z $(get_milvus_process) ]; then
+  pids=$(get_milvus_process)
+  if [ -z "$pids" ]; then
     echo "Milvus stopped"
     break
   fi
-  if [ $(( $(date +%s) - $start )) -gt $timeout ]; then
+  if [ $(( $(date +%s) - start )) -gt "$timeout" ]; then
     echo "Milvus timeout stopped"
-    kill -15 $(get_milvus_process)
+    kill -15 $pids
     break
   fi
 done


### PR DESCRIPTION
close #50055 

## Changes

- After `pip install --user conan` succeeds, check if `~/.local/bin/conan` is accessible
- If not, locate the actual install path via `site.USER_BASE/bin` and create a symlink to `~/.local/bin/conan`

## else

When running in cluster mode, get_milvus_process returns multiple PIDs.
The unquoted $(get_milvus_process) expands into multiple arguments,
causing `[ -z ... ]` to fail with "too many arguments":

Stopping milvus...
./scripts/stop_graceful.sh: line 28: [: too many arguments
Milvus stopped

Fix by caching the result in $pids and quoting it properly.
