### PR TITLE
enhance: standardize internal/util + pkg/util error handling to merr (5b2)

### DIFF
--- a/examples/telemetry_e2e_test/go.mod
+++ b/examples/telemetry_e2e_test/go.mod
@@ -1,10 +1,11 @@
 module github.com/milvus-io/milvus/examples/telemetry_e2e_test
+
 go 1.25.8
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c
 	github.com/milvus-io/milvus/client/v2 v2.6.4-0.20251104142533-a2ce70d25256
-	google.golang.org/grpc v1.71.0
+	google.golang.org/grpc v1.79.3
 )
 
 replace (

--- a/examples/telemetry_e2e_test/go.sum
+++ b/examples/telemetry_e2e_test/go.sum
@@ -1,2 +1,4 @@
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260304062516-e7e54d966ef2/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.6-0.20260323081523-53649783989c/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=

--- a/internal/coordinator/file_resource_observer.go
+++ b/internal/coordinator/file_resource_observer.go
@@ -18,6 +18,7 @@ package coordinator
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -165,7 +166,7 @@ func (m *FileResourceObserver) CheckNodeSynced(nodeID int64) bool {
 func (m *FileResourceObserver) CheckAllQnReady() error {
 	// return error if meta is not ready
 	if m.meta == nil {
-		return merr.WrapErrParameterInvalidMsg("rootcoord meta is not ready")
+		return merr.WrapErrServiceUnavailable("rootcoord meta is not ready")
 	}
 
 	resources, version := m.meta.ListFileResource(m.ctx)
@@ -177,7 +178,7 @@ func (m *FileResourceObserver) CheckAllQnReady() error {
 	var err error
 	m.distribution.Range(func(nodeID int64, node *NodeInfo) bool {
 		if node.NodeType == QueryNode && node.Version < version {
-			err = merr.WrapErrParameterInvalidMsg("node %d file resource not synced", nodeID)
+			err = merr.WrapErrServiceUnavailable(fmt.Sprintf("node-%d", nodeID), "file resource not synced")
 			return false
 		}
 		return true

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/dict/lindera/fetch.rs
@@ -131,10 +131,13 @@ async fn download_with_retry(
         for url in urls {
             match client.get(url).send().await {
                 Ok(resp) if resp.status().is_success() => {
-                    let content = resp
-                        .bytes()
-                        .await
-                        .map_err(|e| TantivyBindingError::InternalError(e.to_string()))?;
+                    let content = match resp.bytes().await {
+                        Ok(c) => c,
+                        Err(e) => {
+                            warn!("Failed to read body from {}: {}", url, e);
+                            continue;
+                        }
+                    };
 
                     // Calculate MD5 hash
                     let mut context = Context::new();

--- a/internal/distributed/proxy/service_test.go
+++ b/internal/distributed/proxy/service_test.go
@@ -1129,6 +1129,18 @@ func Test_NewServer_TLS_FileNotExisted(t *testing.T) {
 	server.Stop()
 }
 
+// freeTCPPort grabs a random unused TCP port. The TLS HTTP-server tests
+// below hardcoded port 8080 originally, which collides with anything else
+// already bound to that port on the dev machine (e.g. the TEI text-embedding
+// container in our compose stack).
+func freeTCPPort(t *testing.T) string {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	assert.NoError(t, ln.Close())
+	return strconv.Itoa(port)
+}
+
 func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	server := getServer(t)
 
@@ -1149,7 +1161,7 @@ func Test_NewHTTPServer_TLS_TwoWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(Params.CaPemPath.Key, "../../../configs/cert/ca.pem")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	assert.Nil(t, err)
@@ -1183,7 +1195,7 @@ func Test_NewHTTPServer_TLS_OneWay(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../../../configs/cert/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 
 	err := runAndWaitForServerReady(server)
 	fmt.Printf("err: %v\n", err)
@@ -1242,7 +1254,7 @@ func Test_NewHTTPServer_TLS_FileNotExisted(t *testing.T) {
 	paramtable.Get().Save(Params.ServerPemPath.Key, "../not/existed/server.pem")
 	paramtable.Get().Save(Params.ServerKeyPath.Key, "../../../configs/cert/server.key")
 	paramtable.Get().Save(proxy.Params.HTTPCfg.Enabled.Key, "true")
-	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, "8080")
+	paramtable.Get().Save(proxy.Params.HTTPCfg.Port.Key, freeTCPPort(t))
 	err := runAndWaitForServerReady(server)
 	assert.NotNil(t, err)
 	server.Stop()

--- a/internal/proxy/accesslog/info/grpc_info_test.go
+++ b/internal/proxy/accesslog/info/grpc_info_test.go
@@ -124,7 +124,11 @@ func (s *GrpcAccessInfoSuite) TestErrorType() {
 	result = Get(s.info, "$error_type")
 	s.Equal(merr.InputError.String(), result[0])
 
-	s.info.err = merr.ErrParameterInvalid
+	// ErrServiceInternal is a SystemError-typed sentinel.
+	// (ErrParameterInvalid was previously SystemError but became InputError after
+	// the 02-storage err-std PR; keep this branch on a still-SystemError sentinel
+	// so the test still covers the "system_error" classification path.)
+	s.info.err = merr.ErrServiceInternal
 	result = Get(s.info, "$error_type")
 	s.Equal(merr.SystemError.String(), result[0])
 }

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1421,7 +1421,7 @@ func ValidateUsername(username string) error {
 	}
 
 	if len(username) > Params.ProxyCfg.MaxUsernameLength.GetAsInt() {
-		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetValue())
+		return merr.WrapErrParameterInvalidMsg("invalid username %s with length %d, the length of username must be less than %d", username, len(username), Params.ProxyCfg.MaxUsernameLength.GetAsInt())
 	}
 
 	firstChar := username[0]

--- a/internal/querycoordv2/meta/resource_manager.go
+++ b/internal/querycoordv2/meta/resource_manager.go
@@ -237,7 +237,7 @@ func (rm *ResourceManager) updateResourceGroups(ctx context.Context, rgs map[str
 				zap.Error(err),
 			)
 		}
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.
@@ -434,7 +434,7 @@ func (rm *ResourceManager) DropResourceGroup(ctx context.Context, rgName string)
 			zap.String("rgName", rgName),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// After recovering, all node assigned to these rg has been removed.
@@ -1050,7 +1050,7 @@ func (rm *ResourceManager) transferNode(ctx context.Context, rgName string, node
 			zap.Int64("node", node),
 			zap.Error(err),
 		)
-		return merr.WrapErrResourceGroupServiceAvailable()
+		return merr.WrapErrResourceGroupServiceUnAvailable()
 	}
 
 	// Commit updates to memory.

--- a/internal/storage/arrow_util.go
+++ b/internal/storage/arrow_util.go
@@ -50,7 +50,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.BooleanBuilder:
 		ba, ok := a.(*array.Boolean)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ba.IsNull(idx) {
 			if defaultValue != nil {
@@ -66,7 +66,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int8Builder:
 		ia, ok := a.(*array.Int8)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -82,7 +82,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int16Builder:
 		ia, ok := a.(*array.Int16)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -98,7 +98,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int32Builder:
 		ia, ok := a.(*array.Int32)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -114,7 +114,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Int64Builder:
 		ia, ok := a.(*array.Int64)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ia.IsNull(idx) {
 			if defaultValue != nil {
@@ -130,7 +130,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.Float32Builder:
 		fa, ok := a.(*array.Float32)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if fa.IsNull(idx) {
 			if defaultValue != nil {
@@ -155,7 +155,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 		}
 		fa, ok := a.(*array.Float64)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if fa.IsNull(idx) {
 			b.AppendNull()
@@ -167,7 +167,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.StringBuilder:
 		sa, ok := a.(*array.String)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if sa.IsNull(idx) {
 			if defaultValue != nil {
@@ -185,7 +185,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.BinaryBuilder:
 		ba, ok := a.(*array.Binary)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ba.IsNull(idx) {
 			// could be internal $meta json
@@ -204,7 +204,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 	case *array.FixedSizeBinaryBuilder:
 		ba, ok := a.(*array.FixedSizeBinary)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if ba.IsNull(idx) {
 			b.AppendNull()
@@ -218,7 +218,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 		// Handle ListBuilder for ArrayOfVector type
 		la, ok := a.(*array.List)
 		if !ok {
-			return 0, fmt.Errorf("invalid value type %T, expect %T", a.DataType(), builder.Type())
+			return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", a.DataType(), builder.Type())
 		}
 		if la.IsNull(idx) {
 			b.AppendNull()
@@ -235,7 +235,7 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 		case *array.FixedSizeBinaryBuilder:
 			fixedArray, ok := valuesArray.(*array.FixedSizeBinary)
 			if !ok {
-				return 0, fmt.Errorf("invalid value type %T, expect %T", valuesArray.DataType(), vb.Type())
+				return 0, merr.WrapErrServiceInternalMsg("invalid value type %T, expect %T", valuesArray.DataType(), vb.Type())
 			}
 			for i := start; i < end; i++ {
 				val := fixedArray.Value(int(i))
@@ -243,12 +243,12 @@ func appendValueAt(builder array.Builder, a arrow.Array, idx int, defaultValue *
 				totalSize += uint64(len(val))
 			}
 		default:
-			return 0, fmt.Errorf("unsupported value builder type in ListBuilder: %T", valueBuilder)
+			return 0, merr.WrapErrServiceInternalMsg("unsupported value builder type in ListBuilder: %T", valueBuilder)
 		}
 
 		return totalSize, nil
 	default:
-		return 0, fmt.Errorf("unsupported builder type: %T", builder)
+		return 0, merr.WrapErrServiceInternalMsg("unsupported builder type: %T", builder)
 	}
 }
 
@@ -356,7 +356,7 @@ func (b *RecordBuilder) Append(rec Record, start, end int) error {
 			col := rec.Column(f.FieldID)
 			size, err := appendValueAt(builder, col, offset, f.GetDefaultValue())
 			if err != nil {
-				return fmt.Errorf("failed to append value at offset %d for field %s: %w", offset, f.GetName(), err)
+				return merr.Wrapf(err, "failed to append value at offset %d for field %s", offset, f.GetName())
 			}
 			b.size += size
 		}

--- a/internal/storage/binlog_reader.go
+++ b/internal/storage/binlog_reader.go
@@ -19,15 +19,14 @@ package storage
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // BinlogReader is an object to read binlog file. Binlog file's format can be
@@ -43,7 +42,7 @@ type BinlogReader struct {
 // NextEventReader iters all events reader to read the binlog file.
 func (reader *BinlogReader) NextEventReader() (*EventReader, error) {
 	if reader.isClose {
-		return nil, errors.New("bin log reader is closed")
+		return nil, merr.WrapErrServiceInternalMsg("bin log reader is closed")
 	}
 	if reader.buffer.Len() <= 0 {
 		return nil, nil
@@ -69,7 +68,7 @@ func readMagicNumber(buffer io.Reader) (int32, error) {
 		return -1, err
 	}
 	if magicNumber != MagicNumber {
-		return -1, fmt.Errorf("parse magic number failed, expected: %d, actual: %d", MagicNumber, magicNumber)
+		return -1, merr.WrapErrServiceInternalMsg("parse magic number failed, expected: %d, actual: %d", MagicNumber, magicNumber)
 	}
 
 	return magicNumber, nil

--- a/internal/storage/binlog_record_writer.go
+++ b/internal/storage/binlog_record_writer.go
@@ -331,7 +331,7 @@ func newPackedBinlogRecordWriter(collectionID, partitionID, segmentID UniqueID, 
 ) (*PackedBinlogRecordWriter, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	writer := &PackedBinlogRecordWriter{
@@ -487,7 +487,7 @@ func (pw *PackedManifestRecordWriter) Close() error {
 func (pw *PackedManifestRecordWriter) writeStatsV3() error {
 	basePath, _, err := packed.UnmarshalManifestPath(pw.manifest)
 	if err != nil {
-		return fmt.Errorf("writeStatsV3: failed to parse manifest path: %w", err)
+		return merr.WrapErrStorage(err, "writeStatsV3: failed to parse manifest path")
 	}
 
 	// --- Bloom filter (PK) stats ---
@@ -502,7 +502,7 @@ func (pw *PackedManifestRecordWriter) writeStatsV3() error {
 		}
 		fullPath := path.Join(basePath, fmt.Sprintf("_stats/bloom_filter.%d/%d", pkFieldID, id))
 		if err := packed.WriteFile(pw.storageConfig, fullPath, statsBlob.Value); err != nil {
-			return fmt.Errorf("writeStatsV3: failed to write bloom filter stats: %w", err)
+			return merr.Wrap(err, "writeStatsV3: failed to write bloom filter stats")
 		}
 
 		newManifest, err := packed.AddStatsToManifest(pw.manifest, pw.storageConfig, []packed.StatEntry{
@@ -513,7 +513,7 @@ func (pw *PackedManifestRecordWriter) writeStatsV3() error {
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("writeStatsV3: failed to add bloom filter stats to manifest: %w", err)
+			return merr.Wrap(err, "writeStatsV3: failed to add bloom filter stats to manifest")
 		}
 		pw.manifest = newManifest
 		// Stats are stored in the manifest; leave pw.statsLog nil.
@@ -533,7 +533,7 @@ func (pw *PackedManifestRecordWriter) writeStatsV3() error {
 			}
 			fullPath := path.Join(basePath, fmt.Sprintf("_stats/bm25.%d/%d", fieldID, id))
 			if err := packed.WriteFile(pw.storageConfig, fullPath, blob.Value); err != nil {
-				return fmt.Errorf("writeStatsV3: failed to write bm25 stats: %w", err)
+				return merr.Wrap(err, "writeStatsV3: failed to write bm25 stats")
 			}
 			statEntries = append(statEntries, packed.StatEntry{
 				Key:      fmt.Sprintf("bm25.%d", fieldID),
@@ -543,7 +543,7 @@ func (pw *PackedManifestRecordWriter) writeStatsV3() error {
 		}
 		newManifest, err := packed.AddStatsToManifest(pw.manifest, pw.storageConfig, statEntries)
 		if err != nil {
-			return fmt.Errorf("writeStatsV3: failed to add bm25 stats to manifest: %w", err)
+			return merr.Wrap(err, "writeStatsV3: failed to add bm25 stats to manifest")
 		}
 		pw.manifest = newManifest
 		// Stats are stored in the manifest; leave pw.bm25StatsLog nil.
@@ -559,7 +559,7 @@ func newPackedManifestRecordWriter(collectionID, partitionID, segmentID UniqueID
 ) (*PackedManifestRecordWriter, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	writer := &PackedManifestRecordWriter{
@@ -720,7 +720,7 @@ func NewPackedTextManifestRecordWriter(
 ) (*PackedTextManifestRecordWriter, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	writer := &PackedTextManifestRecordWriter{

--- a/internal/storage/binlog_util.go
+++ b/internal/storage/binlog_util.go
@@ -1,11 +1,11 @@
 package storage
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // ParseSegmentIDByBinlog parse segment id from binlog paths
@@ -13,7 +13,7 @@ import (
 func ParseSegmentIDByBinlog(rootPath, path string) (UniqueID, error) {
 	// check path contains rootPath as prefix
 	if !strings.HasPrefix(path, rootPath) {
-		return 0, fmt.Errorf("path \"%s\" does not contains rootPath \"%s\"", path, rootPath)
+		return 0, merr.WrapErrServiceInternalMsg("path \"%s\" does not contains rootPath \"%s\"", path, rootPath)
 	}
 	p := path[len(rootPath):]
 
@@ -30,12 +30,12 @@ func ParseSegmentIDByBinlog(rootPath, path string) (UniqueID, error) {
 		if len(keyStr) == 5 {
 			return strconv.ParseInt(keyStr[3], 10, 64)
 		}
-		return 0, fmt.Errorf("%s is not a valid delta log path", path)
+		return 0, merr.WrapErrServiceInternalMsg("%s is not a valid delta log path", path)
 	}
 
 	// log type are binlog or statslog
 	if len(keyStr) == 6 {
 		return strconv.ParseInt(keyStr[len(keyStr)-3], 10, 64)
 	}
-	return 0, fmt.Errorf("%s is not a valid binlog path", path)
+	return 0, merr.WrapErrServiceInternalMsg("%s is not a valid binlog path", path)
 }

--- a/internal/storage/binlog_writer.go
+++ b/internal/storage/binlog_writer.go
@@ -20,13 +20,13 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/hook"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // BinlogType is to distinguish different files saving different data.
@@ -114,7 +114,7 @@ func (writer *baseBinlogWriter) GetBinlogType() BinlogType {
 // GetBuffer gets binlog buffer. Return nil if binlog is not finished yet.
 func (writer *baseBinlogWriter) GetBuffer() ([]byte, error) {
 	if writer.buffer == nil {
-		return nil, errors.New("please close binlog before get buffer")
+		return nil, merr.WrapErrServiceInternalMsg("please close binlog before get buffer")
 	}
 	return writer.buffer.Bytes(), nil
 }
@@ -125,7 +125,7 @@ func (writer *baseBinlogWriter) Finish() error {
 		return nil
 	}
 	if writer.StartTimestamp == 0 || writer.EndTimestamp == 0 {
-		return errors.New("invalid start/end timestamp")
+		return merr.WrapErrServiceInternalMsg("invalid start/end timestamp")
 	}
 
 	var offset int32
@@ -194,7 +194,7 @@ type InsertBinlogWriter struct {
 // NextInsertEventWriter returns an event writer to write insert data to an event.
 func (writer *InsertBinlogWriter) NextInsertEventWriter(opts ...PayloadWriterOptions) (*insertEventWriter, error) {
 	if writer.isClosed() {
-		return nil, errors.New("binlog has closed")
+		return nil, merr.WrapErrServiceInternalMsg("binlog has closed")
 	}
 
 	event, err := newInsertEventWriter(writer.PayloadDataType, opts...)
@@ -214,7 +214,7 @@ type DeleteBinlogWriter struct {
 // NextDeleteEventWriter returns an event writer to write delete data to an event.
 func (writer *DeleteBinlogWriter) NextDeleteEventWriter(opts ...PayloadWriterOptions) (*deleteEventWriter, error) {
 	if writer.isClosed() {
-		return nil, errors.New("binlog has closed")
+		return nil, merr.WrapErrServiceInternalMsg("binlog has closed")
 	}
 	event, err := newDeleteEventWriter(writer.PayloadDataType, opts...)
 	if err != nil {
@@ -232,7 +232,7 @@ type IndexFileBinlogWriter struct {
 // NextIndexFileEventWriter return next available EventWriter
 func (writer *IndexFileBinlogWriter) NextIndexFileEventWriter() (*indexFileEventWriter, error) {
 	if writer.isClosed() {
-		return nil, errors.New("binlog has closed")
+		return nil, merr.WrapErrServiceInternalMsg("binlog has closed")
 	}
 	event, err := newIndexFileEventWriter(writer.PayloadDataType)
 	if err != nil {

--- a/internal/storage/data_codec.go
+++ b/internal/storage/data_codec.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"sort"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 
@@ -146,7 +145,7 @@ func NewInsertCodecWithSchema(schema *etcdpb.CollectionMeta) *InsertCodec {
 // Serialize Pk stats log
 func (insertCodec *InsertCodec) SerializePkStats(stats *PrimaryKeyStats, rowNum int64) (*Blob, error) {
 	if stats == nil || stats.BF == nil {
-		return nil, errors.New("sericalize empty pk stats")
+		return nil, merr.WrapErrServiceInternalMsg("sericalize empty pk stats")
 	}
 
 	// Serialize by pk stats
@@ -191,10 +190,10 @@ func (insertCodec *InsertCodec) SerializePkStatsList(stats []*PrimaryKeyStats, r
 func (insertCodec *InsertCodec) SerializePkStatsByData(data *InsertData) (*Blob, error) {
 	timeFieldData, ok := data.Data[common.TimeStampField]
 	if !ok {
-		return nil, errors.New("data doesn't contains timestamp field")
+		return nil, merr.WrapErrServiceInternalMsg("data doesn't contains timestamp field")
 	}
 	if timeFieldData.RowNum() <= 0 {
-		return nil, errors.New("there's no data in InsertData")
+		return nil, merr.WrapErrServiceInternalMsg("there's no data in InsertData")
 	}
 	rowNum := int64(timeFieldData.RowNum())
 
@@ -217,7 +216,7 @@ func (insertCodec *InsertCodec) SerializePkStatsByData(data *InsertData) (*Blob,
 			RowNum: rowNum,
 		}, nil
 	}
-	return nil, errors.New("there is no pk field")
+	return nil, merr.WrapErrServiceInternalMsg("there is no pk field")
 }
 
 // Serialize transforms insert data to blob. It will sort insert data by timestamp.
@@ -228,7 +227,7 @@ func (insertCodec *InsertCodec) Serialize(partitionID UniqueID, segmentID Unique
 	blobs := make([]*Blob, 0)
 	var writer *InsertBinlogWriter
 	if insertCodec.Schema == nil {
-		return nil, errors.New("schema is not set")
+		return nil, merr.WrapErrServiceInternalMsg("schema is not set")
 	}
 
 	var rowNum int64
@@ -238,7 +237,7 @@ func (insertCodec *InsertCodec) Serialize(partitionID UniqueID, segmentID Unique
 	for _, block := range data {
 		timeFieldData, ok := block.Data[common.TimeStampField]
 		if !ok {
-			return nil, errors.New("data doesn't contains timestamp field")
+			return nil, merr.WrapErrServiceInternalMsg("data doesn't contains timestamp field")
 		}
 
 		rowNum += int64(timeFieldData.RowNum())
@@ -281,11 +280,11 @@ func (insertCodec *InsertCodec) Serialize(partitionID UniqueID, segmentID Unique
 		// found missing block
 		if !allExists {
 			if !field.GetNullable() {
-				return errors.Newf("field %d(%s) missing and field not nullable", field.GetFieldID(), field.GetName())
+				return merr.WrapErrStorageMsg("field %d(%s) missing and field not nullable", field.GetFieldID(), field.GetName())
 			}
 			// segment must be in same schema
 			if !allMissing {
-				return errors.Newf("segment must not be heterogeneous, all blocks must contain all fields or none, abnormal field %d(%s)", field.GetFieldID(), field.GetName())
+				return merr.WrapErrStorageMsg("segment must not be heterogeneous, all blocks must contain all fields or none, abnormal field %d(%s)", field.GetFieldID(), field.GetName())
 			}
 			log.Info("Skip field nullable missing field, could be schema change", zap.Int64("fieldId", field.GetFieldID()), zap.String("fieldName", field.GetName()))
 			return nil
@@ -474,13 +473,13 @@ func AddFieldDataToPayload(eventWriter *insertEventWriter, dataType schemapb.Dat
 	case schemapb.DataType_ArrayOfVector:
 		vectorArrayData := singleData.(*VectorArrayFieldData)
 		if vectorArrayData.Nullable {
-			return fmt.Errorf("nullable ArrayOfVector is not supported in V1 storage format")
+			return merr.WrapErrStorageMsg("nullable ArrayOfVector is not supported in V1 storage format")
 		}
 		if err = eventWriter.AddVectorArrayFieldDataToPayload(vectorArrayData); err != nil {
 			return err
 		}
 	default:
-		return fmt.Errorf("undefined data type %d", dataType)
+		return merr.WrapErrServiceInternalMsg("undefined data type %d", dataType)
 	}
 	return nil
 }
@@ -493,7 +492,7 @@ func (insertCodec *InsertCodec) DeserializeAll(blobs []*Blob) (
 	err error,
 ) {
 	if len(blobs) == 0 {
-		return InvalidUniqueID, InvalidUniqueID, InvalidUniqueID, nil, errors.New("blobs is empty")
+		return InvalidUniqueID, InvalidUniqueID, InvalidUniqueID, nil, merr.WrapErrServiceInternalMsg("blobs is empty")
 	}
 
 	var blobList BlobList = blobs
@@ -897,14 +896,14 @@ func AddInsertData(dataType schemapb.DataType, data interface{}, insertData *Ins
 		vectorArrayFieldData := fieldData.(*VectorArrayFieldData)
 
 		if len(validData) > 0 {
-			return 0, fmt.Errorf("nullable ArrayOfVector is not supported in V1 storage format")
+			return 0, merr.WrapErrStorageMsg("nullable ArrayOfVector is not supported in V1 storage format")
 		}
 		vectorArrayFieldData.Data = append(vectorArrayFieldData.Data, singleData...)
 		insertData.Data[fieldID] = vectorArrayFieldData
 		return len(singleData), nil
 
 	default:
-		return 0, fmt.Errorf("undefined data type %d", dataType)
+		return 0, merr.WrapErrServiceInternalMsg("undefined data type %d", dataType)
 	}
 }
 
@@ -940,7 +939,7 @@ func (deleteCodec *DeleteCodec) Serialize(collectionID UniqueID, partitionID Uni
 	defer eventWriter.Close()
 	length := len(data.Pks)
 	if length != len(data.Tss) {
-		return nil, errors.New("the length of pks, and TimeStamps is not equal")
+		return nil, merr.WrapErrServiceInternalMsg("the length of pks, and TimeStamps is not equal")
 	}
 
 	sizeTotal := 0
@@ -993,7 +992,7 @@ func (deleteCodec *DeleteCodec) Serialize(collectionID UniqueID, partitionID Uni
 // Deserialize deserializes the deltalog blobs into DeleteData
 func (deleteCodec *DeleteCodec) Deserialize(blobs []*Blob) (partitionID UniqueID, segmentID UniqueID, data *DeltaData, err error) {
 	if len(blobs) == 0 {
-		return InvalidUniqueID, InvalidUniqueID, nil, errors.New("blobs is empty")
+		return InvalidUniqueID, InvalidUniqueID, nil, merr.WrapErrServiceInternalMsg("blobs is empty")
 	}
 
 	rowNum := lo.SumBy(blobs, func(blob *Blob) int64 {

--- a/internal/storage/delta_data.go
+++ b/internal/storage/delta_data.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -26,7 +25,6 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"github.com/tidwall/gjson"
 
@@ -126,7 +124,7 @@ func NewDeltaDataWithPkType(cap int64, pkType schemapb.DataType) (*DeltaData, er
 
 func NewDeltaDataWithData(pks PrimaryKeys, tss []uint64) (*DeltaData, error) {
 	if pks.Len() != len(tss) {
-		return nil, merr.WrapErrParameterInvalidMsg("length of pks and tss not equal")
+		return nil, merr.WrapErrStorageMsg("length of pks and tss not equal: pks=%d tss=%d", pks.Len(), len(tss))
 	}
 	dd := &DeltaData{
 		deletePks:        pks,
@@ -167,23 +165,23 @@ func (dl *DeleteLog) Parse(val string) error {
 		pkRes := result.Get("pk")
 		pkTypeRes := result.Get("pkType")
 		if !tsRes.Exists() || !pkRes.Exists() || !pkTypeRes.Exists() {
-			return fmt.Errorf("invalid delete log json: missing required fields in %s", val)
+			return merr.WrapErrServiceInternalMsg("invalid delete log json: missing required fields in %s", val)
 		}
 		dl.Ts = tsRes.Uint()
 		dl.PkType = pkTypeRes.Int()
 		switch dl.PkType {
 		case int64(schemapb.DataType_Int64):
 			if pkRes.Type != gjson.Number {
-				return fmt.Errorf("invalid delete log: pkType is Int64 but pk is not a number in %s", val)
+				return merr.WrapErrServiceInternalMsg("invalid delete log: pkType is Int64 but pk is not a number in %s", val)
 			}
 			dl.Pk = &Int64PrimaryKey{Value: pkRes.Int()}
 		case int64(schemapb.DataType_VarChar):
 			if pkRes.Type != gjson.String {
-				return fmt.Errorf("invalid delete log: pkType is VarChar but pk is not a string in %s", val)
+				return merr.WrapErrServiceInternalMsg("invalid delete log: pkType is VarChar but pk is not a string in %s", val)
 			}
 			dl.Pk = &VarCharPrimaryKey{Value: pkRes.String()}
 		default:
-			return fmt.Errorf("invalid delete log: unsupported pkType %d in %s", dl.PkType, val)
+			return merr.WrapErrServiceInternalMsg("invalid delete log: unsupported pkType %d in %s", dl.PkType, val)
 		}
 		return nil
 	}
@@ -192,7 +190,7 @@ func (dl *DeleteLog) Parse(val string) error {
 	// compatible with fmt.Sprintf("%d,%d", pk, ts)
 	splits := strings.Split(val, ",")
 	if len(splits) != 2 {
-		return fmt.Errorf("the format of delta log is incorrect, %v can not be split", val)
+		return merr.WrapErrServiceInternalMsg("the format of delta log is incorrect, %v can not be split", val)
 	}
 	pk, err := strconv.ParseInt(splits[0], 10, 64)
 	if err != nil {
@@ -226,7 +224,7 @@ func (dl *DeleteLog) UnmarshalJSON(data []byte) error {
 	case schemapb.DataType_VarChar:
 		dl.Pk = &VarCharPrimaryKey{}
 	default:
-		return fmt.Errorf("unsupported primary key type: %v", schemapb.DataType(dl.PkType))
+		return merr.WrapErrServiceInternalMsg("unsupported primary key type: %v", schemapb.DataType(dl.PkType))
 	}
 
 	if err = json.Unmarshal(*messageMap["pk"], dl.Pk); err != nil {
@@ -296,10 +294,10 @@ func BuildDeleteRecord(pks []PrimaryKey, tss []Timestamp) (r Record, tsFrom uint
 	tsTo = 0
 
 	if len(pks) == 0 {
-		return nil, 0, 0, errors.New("empty primary keys")
+		return nil, 0, 0, merr.WrapErrServiceInternalMsg("empty primary keys")
 	}
 	if len(pks) != len(tss) {
-		return nil, 0, 0, errors.New("length of pks and tss must be equal")
+		return nil, 0, 0, merr.WrapErrServiceInternalMsg("length of pks and tss must be equal")
 	}
 
 	allocator := memory.DefaultAllocator
@@ -322,7 +320,7 @@ func BuildDeleteRecord(pks []PrimaryKey, tss []Timestamp) (r Record, tsFrom uint
 		}
 		pkArray = builder.NewArray()
 	default:
-		return nil, 0, 0, errors.Newf("unsupported primary key type %T", pks[0])
+		return nil, 0, 0, merr.WrapErrStorageMsg("unsupported primary key type %T", pks[0])
 	}
 
 	// Build timestamp array

--- a/internal/storage/event_data.go
+++ b/internal/storage/event_data.go
@@ -18,11 +18,8 @@ package storage
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
 	"strconv"
-
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
@@ -81,7 +78,7 @@ func (data *descriptorEventData) GetNullable() (bool, error) {
 	nullable, ok := nullableStore.(bool)
 	// will not happen, has checked bool format when FinishExtra
 	if !ok {
-		return false, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in bool format", nullableKey))
+		return false, merr.WrapErrDataIntegrityMsg("value of %v must in bool format", nullableKey)
 	}
 	return nullable, nil
 }
@@ -128,24 +125,24 @@ func (data *descriptorEventData) FinishExtra() error {
 	// keep all binlog file records the original size
 	sizeStored, ok := data.Extras[originalSizeKey]
 	if !ok {
-		return fmt.Errorf("%v not in extra", originalSizeKey)
+		return merr.WrapErrServiceInternalMsg("%v not in extra", originalSizeKey)
 	}
 	// if we store a large int directly, golang will use scientific notation, we then will get a float value.
 	// so it's better to store the original size in string format.
 	sizeStr, ok := sizeStored.(string)
 	if !ok {
-		return fmt.Errorf("value of %v must in string format", originalSizeKey)
+		return merr.WrapErrServiceInternalMsg("value of %v must in string format", originalSizeKey)
 	}
 	_, err = strconv.Atoi(sizeStr)
 	if err != nil {
-		return fmt.Errorf("value of %v must be able to be converted into int format", originalSizeKey)
+		return merr.WrapErrServiceInternalMsg("value of %v must be able to be converted into int format", originalSizeKey)
 	}
 
 	nullableStore, existed := data.Extras[nullableKey]
 	if existed {
 		_, ok := nullableStore.(bool)
 		if !ok {
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in bool format", nullableKey))
+			return merr.WrapErrDataIntegrityMsg("value of %v must in bool format", nullableKey)
 		}
 	}
 
@@ -153,14 +150,14 @@ func (data *descriptorEventData) FinishExtra() error {
 	if exist {
 		_, ok := edekStored.(string)
 		if !ok {
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in string format", edekKey))
+			return merr.WrapErrDataIntegrityMsg("value of %v must in string format", edekKey)
 		}
 	}
 	ezIDStored, exist := data.Extras[ezIDKey]
 	if exist {
 		_, ok := ezIDStored.(int64)
 		if !ok {
-			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("value of %v must in int64 format", ezIDKey))
+			return merr.WrapErrDataIntegrityMsg("value of %v must in int64 format", ezIDKey)
 		}
 	}
 
@@ -236,10 +233,10 @@ func (data *insertEventData) GetEventDataFixPartSize() int32 {
 
 func (data *insertEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -260,10 +257,10 @@ func (data *deleteEventData) GetEventDataFixPartSize() int32 {
 
 func (data *deleteEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -284,10 +281,10 @@ func (data *createCollectionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *createCollectionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -308,10 +305,10 @@ func (data *dropCollectionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *dropCollectionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -332,10 +329,10 @@ func (data *createPartitionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *createPartitionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -356,10 +353,10 @@ func (data *dropPartitionEventData) GetEventDataFixPartSize() int32 {
 
 func (data *dropPartitionEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }
@@ -380,10 +377,10 @@ func (data *indexFileEventData) GetEventDataFixPartSize() int32 {
 
 func (data *indexFileEventData) WriteEventData(buffer io.Writer) error {
 	if data.StartTimestamp == 0 {
-		return errors.New("hasn't set start time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set start time stamp")
 	}
 	if data.EndTimestamp == 0 {
-		return errors.New("hasn't set end time stamp")
+		return merr.WrapErrServiceInternalMsg("hasn't set end time stamp")
 	}
 	return binary.Write(buffer, common.Endian, data)
 }

--- a/internal/storage/event_reader.go
+++ b/internal/storage/event_reader.go
@@ -18,11 +18,9 @@ package storage
 
 import (
 	"bytes"
-	"fmt"
-
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // EventReader is used to parse the events contained in the Binlog file.
@@ -36,7 +34,7 @@ type EventReader struct {
 
 func (reader *EventReader) readHeader() error {
 	if reader.isClosed {
-		return errors.New("event reader is closed")
+		return merr.WrapErrServiceInternalMsg("event reader is closed")
 	}
 	header, err := readEventHeader(reader.buffer)
 	if err != nil {
@@ -48,7 +46,7 @@ func (reader *EventReader) readHeader() error {
 
 func (reader *EventReader) readData() error {
 	if reader.isClosed {
-		return errors.New("event reader is closed")
+		return merr.WrapErrServiceInternalMsg("event reader is closed")
 	}
 	var data eventData
 	var err error
@@ -68,7 +66,7 @@ func (reader *EventReader) readData() error {
 	case IndexFileEventType:
 		data, err = readIndexFileEventDataFixPart(reader.buffer)
 	default:
-		return fmt.Errorf("unknown header type code: %d", reader.TypeCode)
+		return merr.WrapErrServiceInternalMsg("unknown header type code: %d", reader.TypeCode)
 	}
 	if err != nil {
 		return err

--- a/internal/storage/event_writer.go
+++ b/internal/storage/event_writer.go
@@ -21,10 +21,9 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // EventTypeCode represents event type by code
@@ -266,7 +265,7 @@ func newDeleteEventWriter(dataType schemapb.DataType, opts ...PayloadWriterOptio
 
 func newCreateCollectionEventWriter(dataType schemapb.DataType) (*createCollectionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)
@@ -292,7 +291,7 @@ func newCreateCollectionEventWriter(dataType schemapb.DataType) (*createCollecti
 
 func newDropCollectionEventWriter(dataType schemapb.DataType) (*dropCollectionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)
@@ -318,7 +317,7 @@ func newDropCollectionEventWriter(dataType schemapb.DataType) (*dropCollectionEv
 
 func newCreatePartitionEventWriter(dataType schemapb.DataType) (*createPartitionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)
@@ -344,7 +343,7 @@ func newCreatePartitionEventWriter(dataType schemapb.DataType) (*createPartition
 
 func newDropPartitionEventWriter(dataType schemapb.DataType) (*dropPartitionEventWriter, error) {
 	if dataType != schemapb.DataType_String && dataType != schemapb.DataType_Int64 {
-		return nil, errors.New("incorrect data type")
+		return nil, merr.WrapErrServiceInternalMsg("incorrect data type")
 	}
 
 	payloadWriter, err := NewPayloadWriter(dataType)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -3,9 +3,8 @@ package storage
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -55,7 +54,7 @@ func (f *ChunkManagerFactory) newChunkManager(ctx context.Context, engine string
 	case "remote", "minio", "opendal":
 		return NewRemoteChunkManager(ctx, f.config)
 	default:
-		return nil, errors.New("no chunk manager implemented with engine: " + engine)
+		return nil, merr.WrapErrServiceInternalMsg("no chunk manager implemented with engine: " + engine)
 	}
 }
 

--- a/internal/storage/field_stats.go
+++ b/internal/storage/field_stats.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -67,7 +66,7 @@ func (stats *FieldStats) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	} else {
-		return errors.New("invalid fieldStats, no fieldID")
+		return merr.WrapErrServiceInternalMsg("invalid fieldStats, no fieldID")
 	}
 
 	stats.Type = schemapb.DataType_Int64
@@ -471,7 +470,7 @@ func (sr *FieldStatsReader) GetFieldStatsList() ([]*FieldStats, error) {
 		stats := &FieldStats{}
 		errNew := json.Unmarshal(sr.buffer, &stats)
 		if errNew != nil {
-			return nil, merr.WrapErrParameterInvalid("valid JSON", string(sr.buffer), err.Error())
+			return nil, merr.WrapErrDataIntegrity(err, "FieldStats list unmarshal failed")
 		}
 		return []*FieldStats{stats}, nil
 	}

--- a/internal/storage/field_stats_test.go
+++ b/internal/storage/field_stats_test.go
@@ -419,7 +419,7 @@ func TestDeserializeFieldStatsFailed(t *testing.T) {
 		}
 
 		_, err := DeserializeFieldStats(blob)
-		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.ErrorIs(t, err, merr.ErrDataIntegrity)
 	})
 
 	t.Run("valid field stats", func(t *testing.T) {

--- a/internal/storage/field_value.go
+++ b/internal/storage/field_value.go
@@ -21,8 +21,6 @@ import (
 	"math"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/log"
@@ -159,7 +157,7 @@ func (ifv *Int8FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int8)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -279,7 +277,7 @@ func (ifv *Int16FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int16)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -399,7 +397,7 @@ func (ifv *Int32FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int32)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -519,7 +517,7 @@ func (ifv *Int64FieldValue) SetValue(data interface{}) error {
 	value, ok := data.(int64)
 	if !ok {
 		log.Warn("wrong type value when setValue for Int64FieldValue")
-		return errors.New("wrong type value when setValue for Int64FieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64FieldValue")
 	}
 
 	ifv.Value = value
@@ -640,7 +638,7 @@ func (ifv *FloatFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(float32)
 	if !ok {
 		log.Warn("wrong type value when setValue for FloatFieldValue")
-		return errors.New("wrong type value when setValue for FloatFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for FloatFieldValue")
 	}
 
 	ifv.Value = value
@@ -760,7 +758,7 @@ func (ifv *DoubleFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(float64)
 	if !ok {
 		log.Warn("wrong type value when setValue for DoubleFieldValue")
-		return errors.New("wrong type value when setValue for DoubleFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for DoubleFieldValue")
 	}
 
 	ifv.Value = value
@@ -856,7 +854,7 @@ func (sfv *StringFieldValue) UnmarshalJSON(data []byte) error {
 func (sfv *StringFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(string)
 	if !ok {
-		return errors.New("wrong type value when setValue for StringFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for StringFieldValue")
 	}
 
 	sfv.Value = value
@@ -934,7 +932,7 @@ func (vcfv *VarCharFieldValue) EQ(obj ScalarFieldValue) bool {
 func (vcfv *VarCharFieldValue) SetValue(data interface{}) error {
 	value, ok := data.(string)
 	if !ok {
-		return errors.New("wrong type value when setValue for StringFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for StringFieldValue")
 	}
 
 	vcfv.Value = value
@@ -1014,7 +1012,7 @@ func (ifv *FloatVectorFieldValue) SetValue(data interface{}) error {
 	value, ok := data.([]float32)
 	if !ok {
 		log.Warn("wrong type value when setValue for FloatVectorFieldValue")
-		return errors.New("wrong type value when setValue for FloatVectorFieldValue")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for FloatVectorFieldValue")
 	}
 
 	ifv.Value = value

--- a/internal/storage/index_data_codec.go
+++ b/internal/storage/index_data_codec.go
@@ -21,12 +21,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -164,7 +164,7 @@ func (codec *IndexFileBinlogCodec) DeserializeImpl(blobs []*Blob) (
 	err error,
 ) {
 	if len(blobs) == 0 {
-		return 0, 0, 0, 0, 0, 0, nil, "", 0, nil, errors.New("blobs is empty")
+		return 0, 0, 0, 0, 0, 0, nil, "", 0, nil, merr.WrapErrServiceInternalMsg("blobs is empty")
 	}
 	indexParams = make(map[string]string)
 	datas = make([]*Blob, 0)
@@ -250,7 +250,7 @@ func (codec *IndexFileBinlogCodec) DeserializeImpl(blobs []*Blob) (
 
 				// make sure there is one string
 				if len(content) != 1 {
-					err := fmt.Errorf("failed to parse index event because content length is not one %d", len(content))
+					err := merr.WrapErrServiceInternalMsg("failed to parse index event because content length is not one %d", len(content))
 					eventReader.Close()
 					binlogReader.Close()
 					return 0, 0, 0, 0, 0, 0, nil, "", 0, nil, err
@@ -321,7 +321,7 @@ func (indexCodec *IndexCodec) Deserialize(blobs []*Blob) ([]*Blob, map[string]st
 		break
 	}
 	if file == nil {
-		return nil, nil, "", InvalidUniqueID, errors.New("can not find params blob")
+		return nil, nil, "", InvalidUniqueID, merr.WrapErrServiceInternalMsg("can not find params blob")
 	}
 	info := struct {
 		Params    map[string]string
@@ -329,7 +329,7 @@ func (indexCodec *IndexCodec) Deserialize(blobs []*Blob) ([]*Blob, map[string]st
 		IndexID   UniqueID
 	}{}
 	if err := json.Unmarshal(file.Value, &info); err != nil {
-		return nil, nil, "", InvalidUniqueID, fmt.Errorf("json unmarshal error: %s", err.Error())
+		return nil, nil, "", InvalidUniqueID, merr.WrapErrServiceInternalMsg("json unmarshal error: %s", err.Error())
 	}
 
 	return blobs, info.Params, info.IndexName, info.IndexID, nil

--- a/internal/storage/insert_data.go
+++ b/internal/storage/insert_data.go
@@ -149,7 +149,7 @@ func (i *InsertData) Append(row map[FieldID]interface{}) error {
 	for fID, v := range row {
 		field, ok := i.Data[fID]
 		if !ok {
-			return fmt.Errorf("missing field when appending row, got %d", fID)
+			return merr.WrapErrServiceInternalMsg("missing field when appending row, got %d", fID)
 		}
 
 		if err := field.AppendRow(v); err != nil {
@@ -405,7 +405,7 @@ func NewFieldData(dataType schemapb.DataType, fieldSchema *schemapb.FieldSchema,
 		}
 		return data, nil
 	default:
-		return nil, fmt.Errorf("unexpected schema data type: %d", dataType)
+		return nil, merr.WrapErrServiceInternalMsg("unexpected schema data type: %d", dataType)
 	}
 }
 

--- a/internal/storage/local_chunk_manager.go
+++ b/internal/storage/local_chunk_manager.go
@@ -119,7 +119,7 @@ func (lcm *LocalChunkManager) MultiWrite(ctx context.Context, contents map[strin
 	for filePath, content := range contents {
 		err := lcm.Write(ctx, filePath, content)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "write %s failed", filePath))
+			el = merr.Combine(el, merr.Wrapf(err, "write %s failed", filePath))
 		}
 	}
 	return el
@@ -149,7 +149,7 @@ func (lcm *LocalChunkManager) MultiRead(ctx context.Context, filePaths []string)
 	for i, filePath := range filePaths {
 		content, err := lcm.Read(ctx, filePath)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to read %s", filePath))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to read %s", filePath))
 		}
 		results[i] = content
 	}
@@ -271,7 +271,7 @@ func (lcm *LocalChunkManager) RemoveWithPrefix(ctx context.Context, prefix strin
 	if len(prefix) == 0 {
 		errMsg := "empty prefix is not allowed for ChunkManager remove operation"
 		log.Warn(errMsg)
-		return merr.WrapErrParameterInvalidMsg(errMsg)
+		return merr.WrapErrStorageMsg("%s", errMsg)
 	}
 	var removeErr error
 	if err := lcm.WalkWithPrefix(ctx, prefix, true, func(chunkInfo *ChunkObjectInfo) bool {

--- a/internal/storage/minio_object_storage_test.go
+++ b/internal/storage/minio_object_storage_test.go
@@ -201,31 +201,51 @@ func TestMinioObjectStorage(t *testing.T) {
 	})
 
 	t.Run("test useIAM", func(t *testing.T) {
+		// newMinioObjectStorageWithConfig validates IAM credentials by calling
+		// BucketExists against the configured endpoint. With invalid IAM
+		// credentials on a host where the endpoint is unreachable, the dial
+		// blocks long enough that retry.Do (CheckBucketRetryAttempts=20) drags
+		// the whole package out to the 10min testing.M timeout. Bound each
+		// call with a short context so it fails fast regardless of
+		// environment; the test only asserts an error is returned. Mirrors
+		// the Azure fix in PR #49814.
 		var err error
 		config.UseIAM = true
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.UseIAM = false
 	})
 
 	t.Run("test ssl", func(t *testing.T) {
+		// Same endpoint-unreachable hang as the "test useIAM" subtest above:
+		// UseSSL=true with a dummy CA cert against a non-TLS minio endpoint
+		// keeps retry.Do dialing until the testing.M timeout. Bound it.
 		var err error
 		config.UseSSL = true
 		config.SslCACert = "/tmp/dummy.crt"
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.UseSSL = false
 	})
 
 	t.Run("test cloud provider", func(t *testing.T) {
+		// Same endpoint-unreachable hang as the "test useIAM" subtest above.
 		var err error
 		cloudProvider := config.CloudProvider
 		config.CloudProvider = "aliyun"
 		config.UseIAM = true
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.UseIAM = false
-		_, err = newMinioObjectStorageWithConfig(ctx, &config)
+		cctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+		_, err = newMinioObjectStorageWithConfig(cctx, &config)
+		cancel()
 		assert.Error(t, err)
 		config.CloudProvider = "gcp"
 		_, err = newMinioObjectStorageWithConfig(ctx, &config)

--- a/internal/storage/payload_reader.go
+++ b/internal/storage/payload_reader.go
@@ -13,7 +13,6 @@ import (
 	"github.com/apache/arrow/go/v17/parquet"
 	"github.com/apache/arrow/go/v17/parquet/file"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -39,7 +38,7 @@ var _ PayloadReaderInterface = (*PayloadReader)(nil)
 
 func NewPayloadReader(colType schemapb.DataType, buf []byte, nullable bool) (*PayloadReader, error) {
 	if len(buf) == 0 {
-		return nil, errors.New("create Payload reader failed, buffer is empty")
+		return nil, merr.WrapErrServiceInternalMsg("create Payload reader failed, buffer is empty")
 	}
 	parquetReader, err := file.NewParquetReader(bytes.NewReader(buf))
 	if err != nil {
@@ -56,32 +55,32 @@ func NewPayloadReader(colType schemapb.DataType, buf []byte, nullable bool) (*Pa
 	if colType == schemapb.DataType_ArrayOfVector {
 		arrowReader, err := pqarrow.NewFileReader(parquetReader, pqarrow.ArrowReadProperties{BatchSize: 1024}, memory.DefaultAllocator)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create arrow reader for VectorArray: %w", err)
+			return nil, merr.WrapErrStorage(err, "failed to create arrow reader for VectorArray")
 		}
 
 		arrowSchema, err := arrowReader.Schema()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get arrow schema for VectorArray: %w", err)
+			return nil, merr.WrapErrStorage(err, "failed to get arrow schema for VectorArray")
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, fmt.Errorf("VectorArray should have exactly 1 field, got %d", arrowSchema.NumFields())
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray should have exactly 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
 		if !field.HasMetadata() {
-			return nil, errors.New("VectorArray field is missing metadata")
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray field is missing metadata")
 		}
 
 		metadata := field.Metadata
 
 		elementTypeStr, ok := metadata.GetValue("elementType")
 		if !ok {
-			return nil, errors.New("VectorArray metadata missing required 'elementType' field")
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray metadata missing required 'elementType' field")
 		}
 		elementTypeInt, err := strconv.ParseInt(elementTypeStr, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("invalid elementType in VectorArray metadata: %s", elementTypeStr)
+			return nil, merr.WrapErrServiceInternalMsg("invalid elementType in VectorArray metadata: %s", elementTypeStr)
 		}
 
 		elementType := schemapb.DataType(elementTypeInt)
@@ -94,19 +93,19 @@ func NewPayloadReader(colType schemapb.DataType, buf []byte, nullable bool) (*Pa
 			schemapb.DataType_SparseFloatVector:
 			reader.elementType = elementType
 		default:
-			return nil, fmt.Errorf("invalid vector type for VectorArray: %s", elementType.String())
+			return nil, merr.WrapErrServiceInternalMsg("invalid vector type for VectorArray: %s", elementType.String())
 		}
 
 		dimStr, ok := metadata.GetValue("dim")
 		if !ok {
-			return nil, errors.New("VectorArray metadata missing required 'dim' field")
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray metadata missing required 'dim' field")
 		}
 		dimVal, err := strconv.ParseInt(dimStr, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid dim in VectorArray metadata: %s", dimStr)
+			return nil, merr.WrapErrServiceInternalMsg("invalid dim in VectorArray metadata: %s", dimStr)
 		}
 		if dimVal <= 0 {
-			return nil, fmt.Errorf("VectorArray dim must be positive, got %d", dimVal)
+			return nil, merr.WrapErrServiceInternalMsg("VectorArray dim must be positive, got %d", dimVal)
 		}
 		reader.dim = dimVal
 	}
@@ -182,7 +181,7 @@ func (r *PayloadReader) GetDataFromPayload() (interface{}, []bool, int, error) {
 		val, validData, err := r.GetGeometryFromPayload()
 		return val, validData, 0, err
 	default:
-		return nil, nil, 0, merr.WrapErrParameterInvalidMsg("unknown type")
+		return nil, nil, 0, merr.WrapErrDataIntegrityMsg("unknown type")
 	}
 }
 
@@ -194,7 +193,7 @@ func (r *PayloadReader) ReleasePayloadReader() error {
 // GetBoolFromPayload returns bool slice from payload.
 func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 	if r.colType != schemapb.DataType_Bool {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get bool from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get bool from datatype %v", r.colType.String())
 	}
 
 	values := make([]bool, r.numRows)
@@ -206,7 +205,7 @@ func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 			return nil, nil, err
 		}
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -215,7 +214,7 @@ func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 		return nil, nil, err
 	}
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
@@ -223,7 +222,7 @@ func (r *PayloadReader) GetBoolFromPayload() ([]bool, []bool, error) {
 // GetByteFromPayload returns byte slice from payload
 func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 	if r.colType != schemapb.DataType_Int8 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get byte from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get byte from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -234,7 +233,7 @@ func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 			return nil, nil, err
 		}
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		ret := make([]byte, r.numRows)
 		for i := int64(0); i < r.numRows; i++ {
@@ -249,7 +248,7 @@ func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, r.numRows)
@@ -261,7 +260,7 @@ func (r *PayloadReader) GetByteFromPayload() ([]byte, []bool, error) {
 
 func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 	if r.colType != schemapb.DataType_Int8 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int8 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int8 from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -273,7 +272,7 @@ func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 
 		return values, validData, nil
@@ -285,7 +284,7 @@ func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]int8, r.numRows)
@@ -297,7 +296,7 @@ func (r *PayloadReader) GetInt8FromPayload() ([]int8, []bool, error) {
 
 func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 	if r.colType != schemapb.DataType_Int16 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int16 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int16 from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -309,7 +308,7 @@ func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -320,7 +319,7 @@ func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]int16, r.numRows)
@@ -332,7 +331,7 @@ func (r *PayloadReader) GetInt16FromPayload() ([]int16, []bool, error) {
 
 func (r *PayloadReader) GetInt32FromPayload() ([]int32, []bool, error) {
 	if r.colType != schemapb.DataType_Int32 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int32 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int32 from datatype %v", r.colType.String())
 	}
 
 	values := make([]int32, r.numRows)
@@ -344,7 +343,7 @@ func (r *PayloadReader) GetInt32FromPayload() ([]int32, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -354,14 +353,14 @@ func (r *PayloadReader) GetInt32FromPayload() ([]int32, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
 
 func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 	if r.colType != schemapb.DataType_Int64 {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get int64 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get int64 from datatype %v", r.colType.String())
 	}
 
 	values := make([]int64, r.numRows)
@@ -373,7 +372,7 @@ func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 
 		return values, validData, nil
@@ -384,7 +383,7 @@ func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	return values, nil, nil
@@ -392,7 +391,7 @@ func (r *PayloadReader) GetInt64FromPayload() ([]int64, []bool, error) {
 
 func (r *PayloadReader) GetFloatFromPayload() ([]float32, []bool, error) {
 	if r.colType != schemapb.DataType_Float {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get float32 from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get float32 from datatype %v", r.colType.String())
 	}
 
 	values := make([]float32, r.numRows)
@@ -403,7 +402,7 @@ func (r *PayloadReader) GetFloatFromPayload() ([]float32, []bool, error) {
 			return nil, nil, err
 		}
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -412,14 +411,14 @@ func (r *PayloadReader) GetFloatFromPayload() ([]float32, []bool, error) {
 		return nil, nil, err
 	}
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
 
 func (r *PayloadReader) GetDoubleFromPayload() ([]float64, []bool, error) {
 	if r.colType != schemapb.DataType_Double {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get double from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get double from datatype %v", r.colType.String())
 	}
 
 	values := make([]float64, r.numRows)
@@ -431,7 +430,7 @@ func (r *PayloadReader) GetDoubleFromPayload() ([]float64, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -441,14 +440,14 @@ func (r *PayloadReader) GetDoubleFromPayload() ([]float64, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 	return values, nil, nil
 }
 
 func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 	if r.colType != schemapb.DataType_Timestamptz {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get timestamptz from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get timestamptz from datatype %v", r.colType.String())
 	}
 
 	values := make([]int64, r.numRows)
@@ -460,7 +459,7 @@ func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 
 		return values, validData, nil
@@ -471,7 +470,7 @@ func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	return values, nil, nil
@@ -479,7 +478,7 @@ func (r *PayloadReader) GetTimestamptzFromPayload() ([]int64, []bool, error) {
 
 func (r *PayloadReader) GetStringFromPayload() ([]string, []bool, error) {
 	if r.colType != schemapb.DataType_String && r.colType != schemapb.DataType_VarChar {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get string from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get string from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -491,7 +490,7 @@ func (r *PayloadReader) GetStringFromPayload() ([]string, []bool, error) {
 		}
 
 		if valuesRead != r.numRows {
-			return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+			return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 		}
 		return values, validData, nil
 	}
@@ -506,7 +505,7 @@ func (r *PayloadReader) GetStringFromPayload() ([]string, []bool, error) {
 
 func (r *PayloadReader) GetArrayFromPayload() ([]*schemapb.ScalarField, []bool, error) {
 	if r.colType != schemapb.DataType_Array {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get array from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get array from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -529,7 +528,7 @@ func (r *PayloadReader) GetArrayFromPayload() ([]*schemapb.ScalarField, []bool, 
 
 func (r *PayloadReader) GetVectorArrayFromPayload() ([]*schemapb.VectorField, error) {
 	if r.colType != schemapb.DataType_ArrayOfVector {
-		return nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get vector from datatype %v", r.colType.String()))
+		return nil, merr.WrapErrDataIntegrityMsg("failed to get vector from datatype %v", r.colType.String())
 	}
 
 	return readVectorArrayFromListArray(r)
@@ -537,7 +536,7 @@ func (r *PayloadReader) GetVectorArrayFromPayload() ([]*schemapb.VectorField, er
 
 func (r *PayloadReader) GetJSONFromPayload() ([][]byte, []bool, error) {
 	if r.colType != schemapb.DataType_JSON {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get json from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get json from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -556,7 +555,7 @@ func (r *PayloadReader) GetJSONFromPayload() ([][]byte, []bool, error) {
 
 func (r *PayloadReader) GetGeometryFromPayload() ([][]byte, []bool, error) {
 	if r.colType != schemapb.DataType_Geometry {
-		return nil, nil, merr.WrapErrParameterInvalidMsg(fmt.Sprintf("failed to get Geometry from datatype %v", r.colType.String()))
+		return nil, nil, merr.WrapErrDataIntegrityMsg("failed to get Geometry from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -575,7 +574,7 @@ func (r *PayloadReader) GetGeometryFromPayload() ([][]byte, []bool, error) {
 
 func (r *PayloadReader) GetByteArrayDataSet() (*DataSet[parquet.ByteArray, *file.ByteArrayColumnChunkReader], error) {
 	if r.colType != schemapb.DataType_String && r.colType != schemapb.DataType_VarChar {
-		return nil, fmt.Errorf("failed to get string from datatype %v", r.colType.String())
+		return nil, merr.WrapErrServiceInternalMsg("failed to get string from datatype %v", r.colType.String())
 	}
 
 	return NewDataSet[parquet.ByteArray, *file.ByteArrayColumnChunkReader](r.reader, 0, r.numRows), nil
@@ -610,7 +609,7 @@ func readVectorArrayFromListArray(r *PayloadReader) ([]*schemapb.VectorField, er
 	defer table.Release()
 
 	if table.NumCols() != 1 {
-		return nil, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+		return nil, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 	}
 
 	column := table.Column(0)
@@ -625,17 +624,17 @@ func readVectorArrayFromListArray(r *PayloadReader) ([]*schemapb.VectorField, er
 	for _, chunk := range column.Data().Chunks() {
 		listArray, ok := chunk.(*array.List)
 		if !ok {
-			return nil, fmt.Errorf("expected ListArray, got %T", chunk)
+			return nil, merr.WrapErrServiceInternalMsg("expected ListArray, got %T", chunk)
 		}
 
 		for i := 0; i < listArray.Len(); i++ {
 			value, err := deserializeArrayOfVector(listArray, i, elementType, dim, true)
 			if err != nil {
-				return nil, fmt.Errorf("failed to deserialize VectorArray at row %d: %w", len(result), err)
+				return nil, merr.Wrapf(err, "failed to deserialize VectorArray at row %d", len(result))
 			}
 			vectorField, _ := value.(*schemapb.VectorField)
 			if vectorField == nil {
-				return nil, fmt.Errorf("null value in VectorArray")
+				return nil, merr.WrapErrServiceInternalMsg("null value in VectorArray")
 			}
 			result = append(result, vectorField)
 		}
@@ -653,7 +652,7 @@ func readNullableByteAndConvert[T any](r *PayloadReader, convert func([]byte) T)
 	}
 
 	if valuesRead != r.numRows {
-		return nil, nil, merr.WrapErrParameterInvalid(r.numRows, valuesRead, "valuesRead is not equal to rows")
+		return nil, nil, merr.WrapErrDataIntegrityMsg("valuesRead is not equal to rows: expected=%d actual=%d", r.numRows, valuesRead)
 	}
 
 	ret := make([]T, r.numRows)
@@ -671,7 +670,7 @@ func readByteAndConvert[T any](r *PayloadReader, convert func(parquet.ByteArray)
 	}
 
 	if valuesRead != r.numRows {
-		return nil, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]T, r.numRows)
@@ -684,7 +683,7 @@ func readByteAndConvert[T any](r *PayloadReader, convert func(parquet.ByteArray)
 // GetBinaryVectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_BinaryVector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get binary vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get binary vector from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -699,7 +698,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -707,17 +706,17 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable binary vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable binary vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable binary vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable binary vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 			dim = dim / 8
 		} else {
@@ -735,7 +734,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -760,7 +759,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, int64(dim)*r.numRows)
@@ -773,7 +772,7 @@ func (r *PayloadReader) GetBinaryVectorFromPayload() ([]byte, int, []bool, int, 
 // GetFloat16VectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_Float16Vector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get float16 vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get float16 vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -787,7 +786,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -795,17 +794,17 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float16 vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float16 vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float16 vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float16 vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -822,7 +821,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -848,7 +847,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, int64(dim*2)*r.numRows)
@@ -861,7 +860,7 @@ func (r *PayloadReader) GetFloat16VectorFromPayload() ([]byte, int, []bool, int,
 // GetBFloat16VectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_BFloat16Vector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get bfloat16 vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get bfloat16 vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -875,7 +874,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -883,17 +882,17 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable bfloat16 vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable bfloat16 vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable bfloat16 vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable bfloat16 vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -910,7 +909,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -936,7 +935,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]byte, int64(dim*2)*r.numRows)
@@ -949,7 +948,7 @@ func (r *PayloadReader) GetBFloat16VectorFromPayload() ([]byte, int, []bool, int
 // GetFloatVectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_FloatVector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get float vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get float vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -963,7 +962,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -971,17 +970,17 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable float vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable float vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -998,7 +997,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -1024,7 +1023,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]float32, int64(dim)*r.numRows)
@@ -1037,7 +1036,7 @@ func (r *PayloadReader) GetFloatVectorFromPayload() ([]float32, int, []bool, int
 // GetSparseFloatVectorFromPayload returns fieldData, dimension, validData, error
 func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFieldData, int, []bool, error) {
 	if !typeutil.IsSparseFloatVectorType(r.colType) {
-		return nil, -1, nil, fmt.Errorf("failed to get sparse float vector from datatype %v", r.colType.String())
+		return nil, -1, nil, merr.WrapErrServiceInternalMsg("failed to get sparse float vector from datatype %v", r.colType.String())
 	}
 
 	if r.nullable {
@@ -1056,7 +1055,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -1064,7 +1063,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 		for _, chunk := range column.Data().Chunks() {
 			binaryArray, ok := chunk.(*array.Binary)
 			if !ok {
-				return nil, -1, nil, fmt.Errorf("expected Binary array, got %T", chunk)
+				return nil, -1, nil, merr.WrapErrServiceInternalMsg("expected Binary array, got %T", chunk)
 			}
 
 			for i := 0; i < binaryArray.Len(); i++ {
@@ -1072,7 +1071,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 				if validData[offset+i] {
 					value := binaryArray.Value(i)
 					if len(value)%8 != 0 {
-						return nil, -1, nil, errors.New("invalid bytesData length")
+						return nil, -1, nil, merr.WrapErrServiceInternalMsg("invalid bytesData length")
 					}
 					fieldData.Contents = append(fieldData.Contents, append([]byte{}, value...))
 					rowDim := typeutil.SparseFloatRowDim(value)
@@ -1093,14 +1092,14 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 		return nil, -1, nil, err
 	}
 	if valuesRead != r.numRows {
-		return nil, -1, nil, fmt.Errorf("expect %d binary, but got = %d", r.numRows, valuesRead)
+		return nil, -1, nil, merr.WrapErrServiceInternalMsg("expect %d binary, but got = %d", r.numRows, valuesRead)
 	}
 
 	fieldData := &SparseFloatVectorFieldData{}
 
 	for _, value := range values {
 		if len(value)%8 != 0 {
-			return nil, -1, nil, errors.New("invalid bytesData length")
+			return nil, -1, nil, merr.WrapErrServiceInternalMsg("invalid bytesData length")
 		}
 
 		fieldData.Contents = append(fieldData.Contents, value)
@@ -1116,7 +1115,7 @@ func (r *PayloadReader) GetSparseFloatVectorFromPayload() (*SparseFloatVectorFie
 // GetInt8VectorFromPayload returns vector, dimension, validData, numRows, error
 func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, error) {
 	if r.colType != schemapb.DataType_Int8Vector {
-		return nil, -1, nil, 0, fmt.Errorf("failed to get int8 vector from datatype %v", r.colType.String())
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("failed to get int8 vector from datatype %v", r.colType.String())
 	}
 	if r.nullable {
 		fileReader, err := pqarrow.NewFileReader(r.reader, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
@@ -1130,7 +1129,7 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 		}
 
 		if arrowSchema.NumFields() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 field, got %d", arrowSchema.NumFields())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 field, got %d", arrowSchema.NumFields())
 		}
 
 		field := arrowSchema.Field(0)
@@ -1138,17 +1137,17 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 
 		if field.Type.ID() == arrow.BINARY {
 			if !field.HasMetadata() {
-				return nil, -1, nil, 0, fmt.Errorf("nullable int8 vector field is missing metadata")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable int8 vector field is missing metadata")
 			}
 			metadata := field.Metadata
 			dimStr, ok := metadata.GetValue("dim")
 			if !ok {
-				return nil, -1, nil, 0, fmt.Errorf("nullable int8 vector metadata missing required 'dim' field")
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("nullable int8 vector metadata missing required 'dim' field")
 			}
 			var err error
 			dim, err = strconv.Atoi(dimStr)
 			if err != nil {
-				return nil, -1, nil, 0, fmt.Errorf("invalid dim value in metadata: %v", err)
+				return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("invalid dim value in metadata: %v", err)
 			}
 		} else {
 			col, err := r.reader.RowGroup(0).Column(0)
@@ -1165,7 +1164,7 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 		defer table.Release()
 
 		if table.NumCols() != 1 {
-			return nil, -1, nil, 0, fmt.Errorf("expected 1 column, got %d", table.NumCols())
+			return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expected 1 column, got %d", table.NumCols())
 		}
 
 		column := table.Column(0)
@@ -1191,7 +1190,7 @@ func (r *PayloadReader) GetInt8VectorFromPayload() ([]int8, int, []bool, int, er
 	}
 
 	if valuesRead != r.numRows {
-		return nil, -1, nil, 0, fmt.Errorf("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
+		return nil, -1, nil, 0, merr.WrapErrServiceInternalMsg("expect %d rows, but got valuesRead = %d", r.numRows, valuesRead)
 	}
 
 	ret := make([]int8, int64(dim)*r.numRows)
@@ -1220,7 +1219,7 @@ func ReadDataFromAllRowGroups[T any, E interface {
 
 	for i := 0; i < reader.NumRowGroups(); i++ {
 		if columnIdx >= reader.RowGroup(i).NumColumns() {
-			return -1, fmt.Errorf("try to fetch %d-th column of reader but row group has only %d column(s)", columnIdx, reader.RowGroup(i).NumColumns())
+			return -1, merr.WrapErrServiceInternalMsg("try to fetch %d-th column of reader but row group has only %d column(s)", columnIdx, reader.RowGroup(i).NumColumns())
 		}
 		column, err := reader.RowGroup(i).Column(columnIdx)
 		if err != nil {
@@ -1229,7 +1228,7 @@ func ReadDataFromAllRowGroups[T any, E interface {
 
 		cReader, ok := column.(E)
 		if !ok {
-			return -1, fmt.Errorf("expect type %T, but got %T", *new(E), column)
+			return -1, merr.WrapErrServiceInternalMsg("expect type %T, but got %T", *new(E), column)
 		}
 
 		_, valuesRead, err := cReader.ReadBatch(numRows, values[offset:], nil, nil)
@@ -1272,7 +1271,7 @@ func (s *DataSet[T, E]) nextGroup() error {
 
 	cReader, ok := column.(E)
 	if !ok {
-		return fmt.Errorf("expect type %T, but got %T", *new(E), column)
+		return merr.WrapErrServiceInternalMsg("expect type %T, but got %T", *new(E), column)
 	}
 	s.groupID++
 	s.cReader = cReader
@@ -1288,7 +1287,7 @@ func (s *DataSet[T, E]) HasNext() bool {
 
 func (s *DataSet[T, E]) NextBatch(batch int64) ([]T, error) {
 	if s.groupID > s.reader.NumRowGroups() || (s.groupID == s.reader.NumRowGroups() && s.cnt >= s.numRows) || s.numRows == 0 {
-		return nil, errors.New("has no more data")
+		return nil, merr.WrapErrServiceInternalMsg("has no more data")
 	}
 
 	if s.groupID == 0 || s.cnt >= s.numRows {
@@ -1400,7 +1399,7 @@ func readNullableVectorData(column *arrow.Column, numRows int64, bytesPerVector 
 	for _, chunk := range chunks {
 		binaryArray, ok := chunk.(*array.Binary)
 		if !ok {
-			return nil, nil, merr.WrapErrParameterInvalidMsg("expected Binary array for nullable vector, got %T", chunk)
+			return nil, nil, merr.WrapErrDataIntegrityMsg("expected Binary array for nullable vector, got %T", chunk)
 		}
 		chunkLen := binaryArray.Len()
 
@@ -1410,7 +1409,7 @@ func readNullableVectorData(column *arrow.Column, numRows int64, bytesPerVector 
 			valueBytes := binaryArray.ValueBytes()
 			expected := chunkValidCount * bytesPerVector
 			if len(valueBytes) != expected {
-				return nil, nil, merr.WrapErrParameterInvalidMsg(
+				return nil, nil, merr.WrapErrDataIntegrityMsg(
 					"unexpected valueBytes length for nullable vector: got %d, expected %d", len(valueBytes), expected)
 			}
 			copy(ret[dataOffset:dataOffset+len(valueBytes)], valueBytes)

--- a/internal/storage/payload_writer.go
+++ b/internal/storage/payload_writer.go
@@ -29,7 +29,6 @@ import (
 	"github.com/apache/arrow/go/v17/parquet"
 	"github.com/apache/arrow/go/v17/parquet/compress"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -303,17 +302,17 @@ func (w *NativePayloadWriter) AddDataToPayloadForUT(data interface{}, validData 
 		}
 		return w.AddVectorArrayFieldDataToPayload(val)
 	default:
-		return errors.New("unsupported datatype")
+		return merr.WrapErrServiceInternalMsg("unsupported datatype")
 	}
 }
 
 func (w *NativePayloadWriter) AddBoolToPayload(data []bool, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished bool payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished bool payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into bool payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into bool payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -328,7 +327,7 @@ func (w *NativePayloadWriter) AddBoolToPayload(data []bool, validData []bool) er
 
 	builder, ok := w.builder.(*array.BooleanBuilder)
 	if !ok {
-		return errors.New("failed to cast ArrayBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast ArrayBuilder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -337,11 +336,11 @@ func (w *NativePayloadWriter) AddBoolToPayload(data []bool, validData []bool) er
 
 func (w *NativePayloadWriter) AddByteToPayload(data []byte, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished byte payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished byte payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into byte payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into byte payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -356,7 +355,7 @@ func (w *NativePayloadWriter) AddByteToPayload(data []byte, validData []bool) er
 
 	builder, ok := w.builder.(*array.Int8Builder)
 	if !ok {
-		return errors.New("failed to cast ByteBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast ByteBuilder")
 	}
 
 	builder.Reserve(len(data))
@@ -372,11 +371,11 @@ func (w *NativePayloadWriter) AddByteToPayload(data []byte, validData []bool) er
 
 func (w *NativePayloadWriter) AddInt8ToPayload(data []int8, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int8 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int8 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int8 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int8 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -391,7 +390,7 @@ func (w *NativePayloadWriter) AddInt8ToPayload(data []int8, validData []bool) er
 
 	builder, ok := w.builder.(*array.Int8Builder)
 	if !ok {
-		return errors.New("failed to cast Int8Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int8Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -400,11 +399,11 @@ func (w *NativePayloadWriter) AddInt8ToPayload(data []int8, validData []bool) er
 
 func (w *NativePayloadWriter) AddInt16ToPayload(data []int16, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int16 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int16 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int16 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int16 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -419,7 +418,7 @@ func (w *NativePayloadWriter) AddInt16ToPayload(data []int16, validData []bool) 
 
 	builder, ok := w.builder.(*array.Int16Builder)
 	if !ok {
-		return errors.New("failed to cast Int16Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int16Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -428,11 +427,11 @@ func (w *NativePayloadWriter) AddInt16ToPayload(data []int16, validData []bool) 
 
 func (w *NativePayloadWriter) AddInt32ToPayload(data []int32, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int32 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int32 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int32 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int32 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -447,7 +446,7 @@ func (w *NativePayloadWriter) AddInt32ToPayload(data []int32, validData []bool) 
 
 	builder, ok := w.builder.(*array.Int32Builder)
 	if !ok {
-		return errors.New("failed to cast Int32Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int32Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -456,11 +455,11 @@ func (w *NativePayloadWriter) AddInt32ToPayload(data []int32, validData []bool) 
 
 func (w *NativePayloadWriter) AddInt64ToPayload(data []int64, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int64 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int64 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -475,7 +474,7 @@ func (w *NativePayloadWriter) AddInt64ToPayload(data []int64, validData []bool) 
 
 	builder, ok := w.builder.(*array.Int64Builder)
 	if !ok {
-		return errors.New("failed to cast Int64Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int64Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -484,11 +483,11 @@ func (w *NativePayloadWriter) AddInt64ToPayload(data []int64, validData []bool) 
 
 func (w *NativePayloadWriter) AddFloatToPayload(data []float32, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished float payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished float payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into float payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into float payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -503,7 +502,7 @@ func (w *NativePayloadWriter) AddFloatToPayload(data []float32, validData []bool
 
 	builder, ok := w.builder.(*array.Float32Builder)
 	if !ok {
-		return errors.New("failed to cast FloatBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast FloatBuilder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -512,11 +511,11 @@ func (w *NativePayloadWriter) AddFloatToPayload(data []float32, validData []bool
 
 func (w *NativePayloadWriter) AddDoubleToPayload(data []float64, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished double payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished double payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into double payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into double payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -531,7 +530,7 @@ func (w *NativePayloadWriter) AddDoubleToPayload(data []float64, validData []boo
 
 	builder, ok := w.builder.(*array.Float64Builder)
 	if !ok {
-		return errors.New("failed to cast DoubleBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast DoubleBuilder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -540,11 +539,11 @@ func (w *NativePayloadWriter) AddDoubleToPayload(data []float64, validData []boo
 
 func (w *NativePayloadWriter) AddTimestamptzToPayload(data []int64, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int64 payload")
 	}
 
 	if len(data) == 0 {
-		return errors.New("can't add empty msgs into int64 payload")
+		return merr.WrapErrServiceInternalMsg("can't add empty msgs into int64 payload")
 	}
 
 	if !w.nullable && len(validData) != 0 {
@@ -559,7 +558,7 @@ func (w *NativePayloadWriter) AddTimestamptzToPayload(data []int64, validData []
 
 	builder, ok := w.builder.(*array.Int64Builder)
 	if !ok {
-		return errors.New("failed to cast Int64Builder")
+		return merr.WrapErrServiceInternalMsg("failed to cast Int64Builder")
 	}
 	builder.AppendValues(data, validData)
 
@@ -568,7 +567,7 @@ func (w *NativePayloadWriter) AddTimestamptzToPayload(data []int64, validData []
 
 func (w *NativePayloadWriter) AddOneStringToPayload(data string, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished string payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished string payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -577,7 +576,7 @@ func (w *NativePayloadWriter) AddOneStringToPayload(data string, isValid bool) e
 
 	builder, ok := w.builder.(*array.StringBuilder)
 	if !ok {
-		return errors.New("failed to cast StringBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast StringBuilder")
 	}
 
 	if !isValid {
@@ -591,7 +590,7 @@ func (w *NativePayloadWriter) AddOneStringToPayload(data string, isValid bool) e
 
 func (w *NativePayloadWriter) AddOneArrayToPayload(data *schemapb.ScalarField, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished array payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished array payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -600,12 +599,12 @@ func (w *NativePayloadWriter) AddOneArrayToPayload(data *schemapb.ScalarField, i
 
 	bytes, err := proto.Marshal(data)
 	if err != nil {
-		return errors.New("Marshal ListValue failed")
+		return merr.WrapErrServiceInternalMsg("Marshal ListValue failed")
 	}
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast BinaryBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast BinaryBuilder")
 	}
 
 	if !isValid {
@@ -619,7 +618,7 @@ func (w *NativePayloadWriter) AddOneArrayToPayload(data *schemapb.ScalarField, i
 
 func (w *NativePayloadWriter) AddOneJSONToPayload(data []byte, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished json payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished json payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -628,7 +627,7 @@ func (w *NativePayloadWriter) AddOneJSONToPayload(data []byte, isValid bool) err
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast JsonBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast JsonBuilder")
 	}
 
 	if !isValid {
@@ -642,7 +641,7 @@ func (w *NativePayloadWriter) AddOneJSONToPayload(data []byte, isValid bool) err
 
 func (w *NativePayloadWriter) AddOneGeometryToPayload(data []byte, isValid bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished geometry payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished geometry payload")
 	}
 
 	if !w.nullable && !isValid {
@@ -651,7 +650,7 @@ func (w *NativePayloadWriter) AddOneGeometryToPayload(data []byte, isValid bool)
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast geometryBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast geometryBuilder")
 	}
 
 	if !isValid {
@@ -672,7 +671,7 @@ func validateNullableVectorValidData(validData []bool) (int, error) {
 
 func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished binary vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished binary vector payload")
 	}
 
 	byteLength := dim / 8
@@ -690,7 +689,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into binary vector payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into binary vector payload")
 		}
 		numRows = len(data) / byteLength
 		if !w.nullable && len(validData) != 0 {
@@ -702,7 +701,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable BinaryVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable BinaryVector")
 		}
 
 		builder.Reserve(numRows)
@@ -718,7 +717,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable BinaryVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable BinaryVector")
 		}
 
 		builder.Reserve(numRows)
@@ -732,7 +731,7 @@ func (w *NativePayloadWriter) AddBinaryVectorToPayload(data []byte, dim int, val
 
 func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished float vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished float vector payload")
 	}
 
 	var numRows int
@@ -749,7 +748,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into float vector payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into float vector payload")
 		}
 		numRows = len(data) / dim
 		if !w.nullable && len(validData) != 0 {
@@ -763,7 +762,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable FloatVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable FloatVector")
 		}
 
 		builder.Reserve(numRows)
@@ -785,7 +784,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable FloatVector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable FloatVector")
 		}
 
 		builder.Reserve(numRows)
@@ -805,7 +804,7 @@ func (w *NativePayloadWriter) AddFloatVectorToPayload(data []float32, dim int, v
 
 func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished float16 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished float16 payload")
 	}
 
 	byteLength := dim * 2
@@ -823,7 +822,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into float16 payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into float16 payload")
 		}
 		numRows = len(data) / byteLength
 		if !w.nullable && len(validData) != 0 {
@@ -835,7 +834,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable Float16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable Float16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -851,7 +850,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable Float16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable Float16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -865,7 +864,7 @@ func (w *NativePayloadWriter) AddFloat16VectorToPayload(data []byte, dim int, va
 
 func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished BFloat16 payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished BFloat16 payload")
 	}
 
 	byteLength := dim * 2
@@ -883,7 +882,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into BFloat16 payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into BFloat16 payload")
 		}
 		numRows = len(data) / byteLength
 		if !w.nullable && len(validData) != 0 {
@@ -895,7 +894,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable BFloat16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable BFloat16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -911,7 +910,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable BFloat16Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable BFloat16Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -925,7 +924,7 @@ func (w *NativePayloadWriter) AddBFloat16VectorToPayload(data []byte, dim int, v
 
 func (w *NativePayloadWriter) AddSparseFloatVectorToPayload(data *SparseFloatVectorFieldData) error {
 	if w.finished {
-		return errors.New("can't append data to finished sparse float vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished sparse float vector payload")
 	}
 
 	var numRows int
@@ -949,7 +948,7 @@ func (w *NativePayloadWriter) AddSparseFloatVectorToPayload(data *SparseFloatVec
 
 	builder, ok := w.builder.(*array.BinaryBuilder)
 	if !ok {
-		return errors.New("failed to cast SparseFloatVectorBuilder")
+		return merr.WrapErrServiceInternalMsg("failed to cast SparseFloatVectorBuilder")
 	}
 
 	builder.Reserve(numRows)
@@ -968,7 +967,7 @@ func (w *NativePayloadWriter) AddSparseFloatVectorToPayload(data *SparseFloatVec
 
 func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, validData []bool) error {
 	if w.finished {
-		return errors.New("can't append data to finished int8 vector payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished int8 vector payload")
 	}
 
 	var numRows int
@@ -985,7 +984,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 		}
 	} else {
 		if len(data) == 0 {
-			return errors.New("can't add empty msgs into int8 vector payload")
+			return merr.WrapErrServiceInternalMsg("can't add empty msgs into int8 vector payload")
 		}
 		numRows = len(data) / dim
 		if !w.nullable && len(validData) != 0 {
@@ -997,7 +996,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 	if w.nullable {
 		builder, ok := w.builder.(*array.BinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to BinaryBuilder for nullable Int8Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to BinaryBuilder for nullable Int8Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -1015,7 +1014,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 	} else {
 		builder, ok := w.builder.(*array.FixedSizeBinaryBuilder)
 		if !ok {
-			return errors.New("failed to cast to FixedSizeBinaryBuilder for non-nullable Int8Vector")
+			return merr.WrapErrServiceInternalMsg("failed to cast to FixedSizeBinaryBuilder for non-nullable Int8Vector")
 		}
 
 		builder.Reserve(numRows)
@@ -1031,7 +1030,7 @@ func (w *NativePayloadWriter) AddInt8VectorToPayload(data []int8, dim int, valid
 
 func (w *NativePayloadWriter) FinishPayloadWriter() error {
 	if w.finished {
-		return errors.New("can't reuse a finished writer")
+		return merr.WrapErrServiceInternalMsg("can't reuse a finished writer")
 	}
 
 	w.finished = true
@@ -1040,7 +1039,7 @@ func (w *NativePayloadWriter) FinishPayloadWriter() error {
 	var metadata arrow.Metadata
 	if w.dataType == schemapb.DataType_ArrayOfVector {
 		if w.elementType == nil {
-			return errors.New("element type for DataType_ArrayOfVector must be set")
+			return merr.WrapErrServiceInternalMsg("element type for DataType_ArrayOfVector must be set")
 		}
 
 		metadata = arrow.NewMetadata(
@@ -1099,7 +1098,7 @@ func (w *NativePayloadWriter) GetPayloadBufferFromWriter() ([]byte, error) {
 
 	// The cpp version of payload writer handles the empty buffer as error
 	if len(data) == 0 {
-		return nil, errors.New("empty buffer")
+		return nil, merr.WrapErrServiceInternalMsg("empty buffer")
 	}
 
 	return data, nil
@@ -1176,16 +1175,16 @@ func MilvusDataTypeToArrowType(dataType schemapb.DataType, dim int) arrow.DataTy
 // AddVectorArrayFieldDataToPayload adds VectorArrayFieldData to payload using Arrow ListArray
 func (w *NativePayloadWriter) AddVectorArrayFieldDataToPayload(data *VectorArrayFieldData) error {
 	if w.finished {
-		return errors.New("can't append data to finished vector array payload")
+		return merr.WrapErrServiceInternalMsg("can't append data to finished vector array payload")
 	}
 
 	if len(data.Data) == 0 {
-		return errors.New("can't add empty vector array field data")
+		return merr.WrapErrServiceInternalMsg("can't add empty vector array field data")
 	}
 
 	builder, ok := w.builder.(*array.ListBuilder)
 	if !ok {
-		return errors.New("failed to cast to ListBuilder for VectorArray")
+		return merr.WrapErrServiceInternalMsg("failed to cast to ListBuilder for VectorArray")
 	}
 
 	switch data.ElementType {

--- a/internal/storage/pk_statistics.go
+++ b/internal/storage/pk_statistics.go
@@ -17,15 +17,14 @@
 package storage
 
 import (
-	"fmt"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/bloomfilter"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // pkStatistics contains pk field statistic information
@@ -38,7 +37,7 @@ type PkStatistics struct {
 // update set pk min/max value if input value is beyond former range.
 func (st *PkStatistics) UpdateMinMax(pk PrimaryKey) error {
 	if st == nil {
-		return errors.New("nil pk statistics")
+		return merr.WrapErrServiceInternalMsg("nil pk statistics")
 	}
 	if st.MinPK == nil {
 		st.MinPK = pk
@@ -78,7 +77,7 @@ func (st *PkStatistics) UpdatePKRange(ids FieldData) error {
 			st.PkFilter.AddString(pk)
 		}
 	default:
-		return fmt.Errorf("invalid data type for primary key: %T", ids)
+		return merr.WrapErrServiceInternalMsg("invalid data type for primary key: %T", ids)
 	}
 	return nil
 }

--- a/internal/storage/primary_key.go
+++ b/internal/storage/primary_key.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/log"
@@ -141,7 +139,7 @@ func (ip *Int64PrimaryKey) UnmarshalJSON(data []byte) error {
 func (ip *Int64PrimaryKey) SetValue(data interface{}) error {
 	value, ok := data.(int64)
 	if !ok {
-		return errors.New("wrong type value when setValue for Int64PrimaryKey")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for Int64PrimaryKey")
 	}
 
 	ip.Value = value
@@ -241,7 +239,7 @@ func (vcp *VarCharPrimaryKey) UnmarshalJSON(data []byte) error {
 func (vcp *VarCharPrimaryKey) SetValue(data interface{}) error {
 	value, ok := data.(string)
 	if !ok {
-		return errors.New("wrong type value when setValue for VarCharPrimaryKey")
+		return merr.WrapErrServiceInternalMsg("wrong type value when setValue for VarCharPrimaryKey")
 	}
 
 	vcp.Value = value
@@ -272,7 +270,7 @@ func GenPrimaryKeyByRawData(data interface{}, pkType schemapb.DataType) (Primary
 			Value: data.(string),
 		}
 	default:
-		return nil, errors.New("not supported primary data type")
+		return nil, merr.WrapErrServiceInternalMsg("not supported primary data type")
 	}
 
 	return result, nil
@@ -305,11 +303,11 @@ func GenVarcharPrimaryKeys(data ...string) ([]PrimaryKey, error) {
 func ParseFieldData2PrimaryKeys(data *schemapb.FieldData) ([]PrimaryKey, error) {
 	ret := make([]PrimaryKey, 0)
 	if data == nil {
-		return ret, errors.New("failed to parse pks from nil field data")
+		return ret, merr.WrapErrServiceInternalMsg("failed to parse pks from nil field data")
 	}
 	scalarData := data.GetScalars()
 	if scalarData == nil {
-		return ret, errors.New("failed to parse pks from nil scalar data")
+		return ret, merr.WrapErrServiceInternalMsg("failed to parse pks from nil scalar data")
 	}
 
 	switch data.Type {
@@ -324,7 +322,7 @@ func ParseFieldData2PrimaryKeys(data *schemapb.FieldData) ([]PrimaryKey, error) 
 			ret = append(ret, pk)
 		}
 	default:
-		return ret, errors.New("not supported primary data type")
+		return ret, merr.WrapErrServiceInternalMsg("not supported primary data type")
 	}
 
 	return ret, nil

--- a/internal/storage/print_binlog.go
+++ b/internal/storage/print_binlog.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cockroachdb/errors"
 	"golang.org/x/exp/mmap"
 	"google.golang.org/protobuf/proto"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 )
 
@@ -89,7 +89,7 @@ func printBinlogFile(filename string) error {
 	fmt.Printf("\tEndTimestamp: %v\n", physical)
 	dataTypeName, ok := schemapb.DataType_name[int32(r.descriptorEvent.descriptorEventData.PayloadDataType)]
 	if !ok {
-		return fmt.Errorf("undefine data type %d", r.descriptorEvent.descriptorEventData.PayloadDataType)
+		return merr.WrapErrServiceInternalMsg("undefine data type %d", r.descriptorEvent.descriptorEventData.PayloadDataType)
 	}
 	fmt.Printf("\tPayloadDataType: %v\n", dataTypeName)
 	fmt.Printf("\tPostHeaderLengths: %v\n", r.descriptorEvent.descriptorEventData.PostHeaderLengths)
@@ -112,7 +112,7 @@ func printBinlogFile(filename string) error {
 		case InsertEventType:
 			evd, ok := event.eventData.(*insertEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d insert event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -125,7 +125,7 @@ func printBinlogFile(filename string) error {
 		case DeleteEventType:
 			evd, ok := event.eventData.(*deleteEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d delete event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -138,7 +138,7 @@ func printBinlogFile(filename string) error {
 		case CreateCollectionEventType:
 			evd, ok := event.eventData.(*createCollectionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d create collection event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -151,7 +151,7 @@ func printBinlogFile(filename string) error {
 		case DropCollectionEventType:
 			evd, ok := event.eventData.(*dropCollectionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d drop collection event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -164,7 +164,7 @@ func printBinlogFile(filename string) error {
 		case CreatePartitionEventType:
 			evd, ok := event.eventData.(*createPartitionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d create partition event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -177,7 +177,7 @@ func printBinlogFile(filename string) error {
 		case DropPartitionEventType:
 			evd, ok := event.eventData.(*dropPartitionEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("event %d drop partition event:\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -193,14 +193,14 @@ func printBinlogFile(filename string) error {
 			extra := make(map[string]interface{})
 			err = json.Unmarshal(extraBytes, &extra)
 			if err != nil {
-				return fmt.Errorf("failed to unmarshal extra: %s", err.Error())
+				return merr.WrapErrServiceInternalMsg("failed to unmarshal extra: %s", err.Error())
 			}
 			fmt.Printf("indexBuildID: %v\n", extra["indexBuildID"])
 			fmt.Printf("indexName: %v\n", extra["indexName"])
 			fmt.Printf("indexID: %v\n", extra["indexID"])
 			evd, ok := event.eventData.(*indexFileEventData)
 			if !ok {
-				return errors.New("incorrect event data type")
+				return merr.WrapErrServiceInternalMsg("incorrect event data type")
 			}
 			fmt.Printf("index file event num: %d\n", eventNum)
 			physical, _ = tsoutil.ParseTS(evd.StartTimestamp)
@@ -212,7 +212,7 @@ func printBinlogFile(filename string) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("undefined event typd %d", event.eventHeader.TypeCode)
+			return merr.WrapErrServiceInternalMsg("undefined event typd %d", event.eventHeader.TypeCode)
 		}
 		eventNum++
 	}
@@ -421,7 +421,7 @@ func printPayloadValues(colType schemapb.DataType, reader PayloadReaderInterface
 		}
 		fmt.Println("===== SparseFloatVectorFieldData end =====")
 	default:
-		return errors.New("undefined data type")
+		return merr.WrapErrServiceInternalMsg("undefined data type")
 	}
 	return nil
 }
@@ -477,11 +477,11 @@ func printDDLPayloadValues(eventType EventTypeCode, colType schemapb.DataType, r
 				}
 				fmt.Printf("\t\t%d : drop partition: %v\n", i, req)
 			default:
-				return fmt.Errorf("undefined ddl event type %d", eventType)
+				return merr.WrapErrServiceInternalMsg("undefined ddl event type %d", eventType)
 			}
 		}
 	default:
-		return errors.New("undefined data type")
+		return merr.WrapErrServiceInternalMsg("undefined data type")
 	}
 	return nil
 }

--- a/internal/storage/record_reader.go
+++ b/internal/storage/record_reader.go
@@ -53,7 +53,7 @@ func newPackedRecordReader(
 ) (*packedRecordReader, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 	field2Col := make(map[FieldID]int)
 	allFields := typeutil.GetAllFieldSchemas(schema)
@@ -97,7 +97,7 @@ func (ir *IterativeRecordReader) Close() error {
 func (ir *IterativeRecordReader) Next() (rec Record, err error) {
 	defer func() {
 		if x := recover(); x != nil {
-			rec, err = nil, fmt.Errorf("internal error recovered: %v", x)
+			rec, err = nil, merr.WrapErrServiceInternalMsg("internal error recovered: %v", x)
 		}
 	}()
 	if ir.cur == nil {
@@ -167,7 +167,7 @@ func NewManifestReaderFromBinlogs(fieldBinlogs []*datapb.FieldBinlog,
 ) (*ManifestReader, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, false)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 	schemaHelper, err := typeutil.CreateSchemaHelper(schema)
 	if err != nil {
@@ -209,7 +209,7 @@ func NewManifestReader(manifest string,
 ) (*ManifestReader, error) {
 	arrowSchema, err := ConvertToArrowSchema(schema, true)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid("convert collection schema [%s] to arrow schema error: %s", schema.Name, err.Error())
+		return nil, merr.WrapErrSerializationFailed(err, "convert collection schema [%s] to arrow schema", schema.Name)
 	}
 
 	// Override TEXT fields to binary type — LOB references are binary encoded in manifest storage

--- a/internal/storage/record_writer.go
+++ b/internal/storage/record_writer.go
@@ -158,8 +158,7 @@ func NewPackedRecordWriter(
 	columnGroupCompressed := make(map[typeutil.UniqueID]uint64)
 	pathsMap := make(map[typeutil.UniqueID]string)
 	if len(paths) != len(columnGroups) {
-		return nil, merr.WrapErrParameterInvalid(len(paths), len(columnGroups),
-			"paths length is not equal to column groups length for packed record writer")
+		return nil, merr.WrapErrStorageMsg("paths length is not equal to column groups length for packed record writer: paths=%d columnGroups=%d", len(paths), len(columnGroups))
 	}
 	for i, columnGroup := range columnGroups {
 		columnGroupUncompressed[columnGroup.GroupID] = 0

--- a/internal/storage/remote_chunk_manager.go
+++ b/internal/storage/remote_chunk_manager.go
@@ -129,7 +129,7 @@ func (mcm *RemoteChunkManager) Path(ctx context.Context, filePath string) (strin
 		return "", err
 	}
 	if !exist {
-		return "", errors.New("minio file manage cannot be found with filePath:" + filePath)
+		return "", merr.WrapErrServiceInternalMsg("minio file manage cannot be found with filePath:" + filePath)
 	}
 	return filePath, nil
 }
@@ -194,7 +194,7 @@ func (mcm *RemoteChunkManager) MultiWrite(ctx context.Context, kvs map[string][]
 	for key, value := range kvs {
 		err := mcm.Write(ctx, key, value)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to write %s", key))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to write %s", key))
 		}
 	}
 	return el
@@ -259,7 +259,7 @@ func (mcm *RemoteChunkManager) MultiRead(ctx context.Context, keys []string) ([]
 	for _, key := range keys {
 		objectValue, err := mcm.Read(ctx, key)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to read %s", key))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to read %s", key))
 		}
 		objectsValues = append(objectsValues, objectValue)
 	}
@@ -268,7 +268,7 @@ func (mcm *RemoteChunkManager) MultiRead(ctx context.Context, keys []string) ([]
 }
 
 func (mcm *RemoteChunkManager) Mmap(ctx context.Context, filePath string) (*mmap.ReaderAt, error) {
-	return nil, errors.New("this method has not been implemented")
+	return nil, merr.WrapErrServiceInternalMsg("this method has not been implemented")
 }
 
 // ReadAt reads specific position data of minio storage if exists.
@@ -310,7 +310,7 @@ func (mcm *RemoteChunkManager) MultiRemove(ctx context.Context, keys []string) e
 	for _, key := range keys {
 		err := mcm.Remove(ctx, key)
 		if err != nil {
-			el = merr.Combine(el, errors.Wrapf(err, "failed to remove %s", key))
+			el = merr.Combine(el, merr.Wrapf(err, "failed to remove %s", key))
 		}
 	}
 	return el

--- a/internal/storage/serde.go
+++ b/internal/storage/serde.go
@@ -58,10 +58,10 @@ type (
 
 func validateVectorArrayElementCount(payloadLength int, elementsPerVector int) (int, error) {
 	if elementsPerVector <= 0 {
-		return 0, fmt.Errorf("invalid vector width %d for ArrayOfVector", elementsPerVector)
+		return 0, merr.WrapErrStorageMsg("invalid vector width %d for ArrayOfVector", elementsPerVector)
 	}
 	if payloadLength%elementsPerVector != 0 {
-		return 0, fmt.Errorf("ArrayOfVector payload length %d is not divisible by vector width %d", payloadLength, elementsPerVector)
+		return 0, merr.WrapErrStorageMsg("ArrayOfVector payload length %d is not divisible by vector width %d", payloadLength, elementsPerVector)
 	}
 	return payloadLength / elementsPerVector, nil
 }
@@ -125,7 +125,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Boolean); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Boolean, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Boolean, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -137,9 +137,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected bool value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected bool value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.BooleanBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.BooleanBuilder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int8] = serdeEntry{
@@ -153,7 +153,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int8); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int8, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int8, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -165,9 +165,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int8 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int8 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int8Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int8Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int16] = serdeEntry{
@@ -181,7 +181,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int16); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int16, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int16, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -193,9 +193,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int16 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int16 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int16Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int16Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int32] = serdeEntry{
@@ -209,7 +209,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int32); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int32, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int32, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -221,9 +221,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int32 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int32 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int32Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int32Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Int64] = serdeEntry{
@@ -237,7 +237,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int64); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int64, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int64, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -249,9 +249,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int64 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int64 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int64Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int64Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Float] = serdeEntry{
@@ -265,7 +265,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Float32); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Float32, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Float32, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -277,9 +277,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected float32 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected float32 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Float32Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Float32Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Double] = serdeEntry{
@@ -293,7 +293,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Float64); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Float64, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Float64, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -305,9 +305,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected float64 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected float64 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Float64Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Float64Builder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_Timestamptz] = serdeEntry{
@@ -321,7 +321,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			if arr, ok := a.(*array.Int64); ok && i < arr.Len() {
 				return arr.Value(i), nil
 			}
-			return nil, fmt.Errorf("expected *array.Int64, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Int64, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -333,9 +333,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected int64 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected int64 value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.Int64Builder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.Int64Builder, got %T", b)
 		},
 	}
 	stringEntry := serdeEntry{
@@ -353,7 +353,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return value, nil
 			}
-			return nil, fmt.Errorf("expected *array.String, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.String, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -365,9 +365,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(v)
 					return nil
 				}
-				return fmt.Errorf("expected string value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected string value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.StringBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.StringBuilder, got %T", b)
 		},
 	}
 
@@ -390,10 +390,10 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				if err := proto.Unmarshal(arr.Value(i), v); err == nil {
 					return v, nil
 				} else {
-					return nil, fmt.Errorf("failed to unmarshal ScalarField: %w", err)
+					return nil, merr.WrapErrStorage(err, "failed to unmarshal ScalarField")
 				}
 			}
-			return nil, fmt.Errorf("expected *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -406,12 +406,12 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 						builder.Append(bytes)
 						return nil
 					} else {
-						return fmt.Errorf("failed to marshal ScalarField: %w", err)
+						return merr.WrapErrStorage(err, "failed to marshal ScalarField")
 					}
 				}
-				return fmt.Errorf("expected *schemapb.ScalarField value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected *schemapb.ScalarField value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.BinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.BinaryBuilder, got %T", b)
 		},
 	}
 	_ = eagerArrayEntry
@@ -433,7 +433,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return value, nil
 			}
-			return nil, fmt.Errorf("expected *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -450,7 +450,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 						builder.Append(bytes)
 						return nil
 					} else {
-						return fmt.Errorf("failed to marshal ScalarField: %w", err)
+						return merr.WrapErrStorage(err, "failed to marshal ScalarField")
 					}
 				}
 				if vv, ok := v.(*schemapb.VectorField); ok {
@@ -458,12 +458,12 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 						builder.Append(bytes)
 						return nil
 					} else {
-						return fmt.Errorf("failed to marshal VectorField: %w", err)
+						return merr.WrapErrStorage(err, "failed to marshal VectorField")
 					}
 				}
-				return fmt.Errorf("expected []byte, *schemapb.ScalarField or *schemapb.VectorField value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected []byte, *schemapb.ScalarField or *schemapb.VectorField value, got %T", v)
 			}
-			return fmt.Errorf("expected *array.BinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.BinaryBuilder, got %T", b)
 		},
 	}
 
@@ -487,7 +487,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 
 			vf, ok := v.(*schemapb.VectorField)
 			if !ok {
-				return fmt.Errorf("expected *schemapb.VectorField, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected *schemapb.VectorField, got %T", v)
 			}
 			if vf == nil {
 				b.AppendNull()
@@ -496,7 +496,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 
 			builder, ok := b.(*array.ListBuilder)
 			if !ok {
-				return fmt.Errorf("expected *array.ListBuilder, got %T", b)
+				return merr.WrapErrServiceInternalMsg("expected *array.ListBuilder, got %T", b)
 			}
 
 			valueBuilder := builder.ValueBuilder().(*array.FixedSizeBinaryBuilder)
@@ -519,7 +519,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			switch elementType {
 			case schemapb.DataType_FloatVector:
 				if vf.GetFloatVector() == nil {
-					return fmt.Errorf("FloatVector data is nil for elementType FloatVector")
+					return merr.WrapErrServiceInternalMsg("FloatVector data is nil for elementType FloatVector")
 				}
 				floatData := vf.GetFloatVector().GetData()
 				floatsPerVector := bytesPerVector / 4
@@ -544,32 +544,32 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 
 			case schemapb.DataType_BinaryVector:
 				if vf.GetBinaryVector() == nil {
-					return fmt.Errorf("BinaryVector data is nil for elementType BinaryVector")
+					return merr.WrapErrServiceInternalMsg("BinaryVector data is nil for elementType BinaryVector")
 				}
 				return appendVectorChunks(vf.GetBinaryVector())
 
 			case schemapb.DataType_Float16Vector:
 				if vf.GetFloat16Vector() == nil {
-					return fmt.Errorf("Float16Vector data is nil for elementType Float16Vector")
+					return merr.WrapErrServiceInternalMsg("Float16Vector data is nil for elementType Float16Vector")
 				}
 				return appendVectorChunks(vf.GetFloat16Vector())
 
 			case schemapb.DataType_BFloat16Vector:
 				if vf.GetBfloat16Vector() == nil {
-					return fmt.Errorf("BFloat16Vector data is nil for elementType BFloat16Vector")
+					return merr.WrapErrServiceInternalMsg("BFloat16Vector data is nil for elementType BFloat16Vector")
 				}
 				return appendVectorChunks(vf.GetBfloat16Vector())
 
 			case schemapb.DataType_Int8Vector:
 				if vf.GetInt8Vector() == nil {
-					return fmt.Errorf("Int8Vector data is nil for elementType Int8Vector")
+					return merr.WrapErrServiceInternalMsg("Int8Vector data is nil for elementType Int8Vector")
 				}
 				return appendVectorChunks(vf.GetInt8Vector())
 
 			case schemapb.DataType_SparseFloatVector:
-				return fmt.Errorf("SparseFloatVector in VectorArray not implemented yet")
+				return merr.WrapErrServiceInternalMsg("SparseFloatVector in VectorArray not implemented yet")
 			default:
-				return fmt.Errorf("unsupported elementType for ArrayOfVector: %s", elementType.String())
+				return merr.WrapErrServiceInternalMsg("unsupported elementType for ArrayOfVector: %s", elementType.String())
 			}
 		},
 	}
@@ -596,7 +596,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			}
 			return value, nil
 		}
-		return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
+		return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 	}
 	fixedSizeSerializer := func(b array.Builder, v any, _ schemapb.DataType) error {
 		if v == nil {
@@ -612,9 +612,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				builder.Append(v)
 				return nil
 			}
-			return fmt.Errorf("expected []byte value, got %T", v)
+			return merr.WrapErrServiceInternalMsg("expected []byte value, got %T", v)
 		}
-		return fmt.Errorf("expected *array.FixedSizeBinaryBuilder, got %T", b)
+		return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder, got %T", b)
 	}
 
 	m[schemapb.DataType_BinaryVector] = serdeEntry{
@@ -664,7 +664,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return int8s, nil
 			}
-			return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -677,7 +677,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 			} else if vv, ok := v.([]int8); ok {
 				bytesData = arrow.Int8Traits.CastToBytes(vv)
 			} else {
-				return fmt.Errorf("expected []byte or []int8 value, got %T", v)
+				return merr.WrapErrServiceInternalMsg("expected []byte or []int8 value, got %T", v)
 			}
 			if builder, ok := b.(*array.FixedSizeBinaryBuilder); ok {
 				builder.Append(bytesData)
@@ -687,7 +687,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				builder.Append(bytesData)
 				return nil
 			}
-			return fmt.Errorf("expected *array.FixedSizeBinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_FloatVector] = serdeEntry{
@@ -718,7 +718,7 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 				}
 				return vector, nil
 			}
-			return nil, fmt.Errorf("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
+			return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary or *array.Binary, got %T", a)
 		},
 		serialize: func(b array.Builder, v any, _ schemapb.DataType) error {
 			if v == nil {
@@ -741,9 +741,9 @@ var serdeMap = func() map[schemapb.DataType]serdeEntry {
 					builder.Append(bytesData)
 					return nil
 				}
-				return fmt.Errorf("expected *array.FixedSizeBinaryBuilder or *array.BinaryBuilder, got %T", b)
+				return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder or *array.BinaryBuilder, got %T", b)
 			}
-			return fmt.Errorf("expected *array.FixedSizeBinaryBuilder, got %T", b)
+			return merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinaryBuilder, got %T", b)
 		},
 	}
 	m[schemapb.DataType_SparseFloatVector] = byteEntry
@@ -987,9 +987,9 @@ func createEmptyVectorField(elementType schemapb.DataType, dim int64) (*schemapb
 			},
 		}, nil
 	case schemapb.DataType_SparseFloatVector:
-		return nil, fmt.Errorf("SparseFloatVector in empty VectorArray not implemented yet")
+		return nil, merr.WrapErrServiceInternalMsg("SparseFloatVector in empty VectorArray not implemented yet")
 	default:
-		return nil, fmt.Errorf("unsupported element type for empty ArrayOfVector: %s", elementType.String())
+		return nil, merr.WrapErrServiceInternalMsg("unsupported element type for empty ArrayOfVector: %s", elementType.String())
 	}
 }
 
@@ -1001,10 +1001,10 @@ func deserializeArrayOfVector(a arrow.Array, i int, elementType schemapb.DataTyp
 
 	arr, ok := a.(*array.List)
 	if !ok {
-		return nil, fmt.Errorf("expected *array.List for ArrayOfVector, got %T", a)
+		return nil, merr.WrapErrServiceInternalMsg("expected *array.List for ArrayOfVector, got %T", a)
 	}
 	if i >= arr.Len() {
-		return nil, fmt.Errorf("index %d out of bounds for array of length %d", i, arr.Len())
+		return nil, merr.WrapErrServiceInternalMsg("index %d out of bounds for array of length %d", i, arr.Len())
 	}
 
 	start, end := arr.ValueOffsets(i)
@@ -1019,7 +1019,7 @@ func deserializeArrayOfVector(a arrow.Array, i int, elementType schemapb.DataTyp
 	valuesArray := arr.ListValues()
 	binaryArray, ok := valuesArray.(*array.FixedSizeBinary)
 	if !ok {
-		return nil, fmt.Errorf("expected *array.FixedSizeBinary for ArrayOfVector values, got %T", valuesArray)
+		return nil, merr.WrapErrServiceInternalMsg("expected *array.FixedSizeBinary for ArrayOfVector values, got %T", valuesArray)
 	}
 
 	numVectors := int(totalElements)
@@ -1088,9 +1088,9 @@ func deserializeArrayOfVector(a arrow.Array, i int, elementType schemapb.DataTyp
 			},
 		}, nil
 	case schemapb.DataType_SparseFloatVector:
-		return nil, fmt.Errorf("SparseFloatVector in VectorArray deserialization not implemented yet")
+		return nil, merr.WrapErrServiceInternalMsg("SparseFloatVector in VectorArray deserialization not implemented yet")
 	default:
-		return nil, fmt.Errorf("unsupported element type for ArrayOfVector deserialization: %s", elementType.String())
+		return nil, merr.WrapErrServiceInternalMsg("unsupported element type for ArrayOfVector deserialization: %s", elementType.String())
 	}
 }
 

--- a/internal/storage/serde_delta.go
+++ b/internal/storage/serde_delta.go
@@ -21,14 +21,12 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
 	"io"
 	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
@@ -416,7 +414,7 @@ func newDeltalogMultiFieldWriter(eventWriter *MultiFieldDeltalogStreamWriter, ba
 				pb.Append(pk)
 			}
 		default:
-			return nil, fmt.Errorf("unexpected pk type %v", v[0].PkType)
+			return nil, merr.WrapErrServiceInternalMsg("unexpected pk type %v", v[0].PkType)
 		}
 
 		for _, vv := range v {
@@ -441,7 +439,7 @@ func newDeltalogMultiFieldReader(blobs []*Blob) (*DeserializeReaderImpl[*DeleteL
 	return NewDeserializeReader(reader, func(r Record, v []*DeleteLog) error {
 		rec, ok := r.(*simpleArrowRecord)
 		if !ok {
-			return errors.New("can not cast to simple arrow record")
+			return merr.WrapErrServiceInternalMsg("can not cast to simple arrow record")
 		}
 		fields := rec.r.Schema().Fields()
 		switch fields[0].Type.ID() {
@@ -462,7 +460,7 @@ func newDeltalogMultiFieldReader(blobs []*Blob) (*DeserializeReaderImpl[*DeleteL
 				v[j].Pk = NewVarCharPrimaryKey(arr.Value(j))
 			}
 		default:
-			return fmt.Errorf("unexpected delta log pkType %v", fields[0].Type.Name())
+			return merr.WrapErrServiceInternalMsg("unexpected delta log pkType %v", fields[0].Type.Name())
 		}
 
 		arr := r.Column(1).(*array.Int64)
@@ -561,7 +559,7 @@ func (w *LegacyDeltalogWriter) Write(rec Record) error {
 			pk := NewVarCharPrimaryKey(rec.Column(0).(*array.String).Value(i))
 			return NewDeleteLog(pk, ts), nil
 		default:
-			return nil, fmt.Errorf("unexpected pk type %v", w.pkType)
+			return nil, merr.WrapErrServiceInternalMsg("unexpected pk type %v", w.pkType)
 		}
 	}
 
@@ -642,7 +640,7 @@ func (r *deleteLogToRecordReader) Next() (Record, error) {
 		}
 		pkArray = builder.NewArray()
 	default:
-		return nil, fmt.Errorf("unsupported pk type: %v", r.pkType)
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported pk type: %v", r.pkType)
 	}
 
 	tsBuilder := array.NewInt64Builder(allocator)

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -114,7 +114,7 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 				}
 				comparators = append(comparators, f)
 			default:
-				return 0, nil, merr.WrapErrParameterInvalidMsg("unsupported type for sorting key")
+				return 0, nil, merr.WrapErrStorageMsg("unsupported type for sorting key")
 			}
 		}
 
@@ -281,7 +281,7 @@ func MergeSort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordR
 				return 0
 			})
 		default:
-			return 0, merr.WrapErrParameterInvalidMsg("unsupported type for sorting key")
+			return 0, merr.WrapErrStorageMsg("unsupported type for sorting key")
 		}
 	}
 

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"path"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -102,7 +101,7 @@ func (stats *PrimaryKeyStats) UnmarshalJSON(data []byte) error {
 		stats.MaxPk = &VarCharPrimaryKey{}
 		stats.MinPk = &VarCharPrimaryKey{}
 	default:
-		return errors.New("Invalid PK Data Type")
+		return merr.WrapErrServiceInternalMsg("Invalid PK Data Type")
 	}
 
 	if maxPkMessage, ok := messageMap["maxPk"]; ok && maxPkMessage != nil {
@@ -283,10 +282,7 @@ func (sr *StatsReader) GetPrimaryKeyStats() (*PrimaryKeyStats, error) {
 	stats := &PrimaryKeyStats{}
 	err := json.Unmarshal(sr.buffer, &stats)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid(
-			"valid JSON",
-			string(sr.buffer),
-			err.Error())
+		return nil, merr.WrapErrDataIntegrity(err, "PrimaryKeyStats unmarshal failed")
 	}
 
 	return stats, nil
@@ -297,10 +293,7 @@ func (sr *StatsReader) GetPrimaryKeyStatsList() ([]*PrimaryKeyStats, error) {
 	stats := []*PrimaryKeyStats{}
 	err := json.Unmarshal(sr.buffer, &stats)
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalid(
-			"valid JSON",
-			string(sr.buffer),
-			err.Error())
+		return nil, merr.WrapErrDataIntegrity(err, "PrimaryKeyStats list unmarshal failed")
 	}
 
 	return stats, nil

--- a/internal/storage/stats_collector.go
+++ b/internal/storage/stats_collector.go
@@ -20,13 +20,13 @@ import (
 	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -202,7 +202,7 @@ func (c *Bm25StatsCollector) Collect(r Record) error {
 	for fieldID, stats := range c.bm25Stats {
 		field, ok := r.Column(fieldID).(*array.Binary)
 		if !ok {
-			return errors.New("bm25 field value not found")
+			return merr.WrapErrServiceInternalMsg("bm25 field value not found")
 		}
 		for i := 0; i < rows; i++ {
 			stats.AppendBytes(field.Value(i))

--- a/internal/storage/stats_test.go
+++ b/internal/storage/stats_test.go
@@ -227,7 +227,7 @@ func TestDeserializeStatsFailed(t *testing.T) {
 	}
 
 	_, err := DeserializeStatsList(blob)
-	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.ErrorIs(t, err, merr.ErrDataIntegrity)
 }
 
 func TestDeserializeEmptyStats(t *testing.T) {

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -29,7 +29,6 @@ import (
 	"strconv"
 
 	"github.com/apache/arrow/go/v17/arrow"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -184,12 +183,12 @@ func TransferColumnBasedInsertDataToRowBased(data *InsertData) (
 ) {
 	if !checkTsField(data) {
 		return nil, nil, nil,
-			errors.New("cannot get timestamps from insert data")
+			merr.WrapErrServiceInternalMsg("cannot get timestamps from insert data")
 	}
 
 	if !checkRowIDField(data) {
 		return nil, nil, nil,
-			errors.New("cannot get row ids from insert data")
+			merr.WrapErrServiceInternalMsg("cannot get row ids from insert data")
 	}
 
 	tss := data.Data[common.TimeStampField].(*Int64FieldData)
@@ -210,7 +209,7 @@ func TransferColumnBasedInsertDataToRowBased(data *InsertData) (
 	all = append(all, ls.datas...)
 	if !checkNumRows(all...) {
 		return nil, nil, nil,
-			errors.New("columns of insert data have different length")
+			merr.WrapErrServiceInternalMsg("columns of insert data have different length")
 	}
 
 	sortFieldDataList(ls)
@@ -226,7 +225,7 @@ func TransferColumnBasedInsertDataToRowBased(data *InsertData) (
 			err := binary.Write(&buffer, common.Endian, d)
 			if err != nil {
 				return nil, nil, nil,
-					fmt.Errorf("failed to get binary row, err: %v", err)
+					merr.WrapErrServiceInternalMsg("failed to get binary row, err: %v", err)
 			}
 		}
 
@@ -259,7 +258,7 @@ func GetDimFromParams(params []*commonpb.KeyValuePair) (int, error) {
 			return dim, nil
 		}
 	}
-	return -1, errors.New("dim not found in params")
+	return -1, merr.WrapErrServiceInternalMsg("dim not found in params")
 }
 
 // ReadBinary read data in bytes and write it into receiver.
@@ -420,7 +419,7 @@ func RowBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *schemap
 	}
 
 	if len(collSchema.StructArrayFields) > 0 {
-		return nil, errors.New("struct fields are not implemented in row based insert data")
+		return nil, merr.WrapErrServiceInternalMsg("struct fields are not implemented in row based insert data")
 	}
 
 	for _, field := range collSchema.Fields {
@@ -482,7 +481,7 @@ func RowBasedInsertMsgToInsertData(msg *msgstream.InsertMsg, collSchema *schemap
 				Dim:  dim,
 			}
 		case schemapb.DataType_SparseFloatVector:
-			return nil, errors.New("Sparse Float Vector is not supported in row based data")
+			return nil, merr.WrapErrServiceInternalMsg("Sparse Float Vector is not supported in row based data")
 
 		case schemapb.DataType_Int8Vector:
 			dim, err := GetDimFromParams(field.TypeParams)
@@ -1314,7 +1313,7 @@ func GetPkFromInsertData(collSchema *schemapb.CollectionSchema, data *InsertData
 	pfData, ok := data.Data[pf.FieldID]
 	if !ok {
 		log.Warn("no primary field found in insert msg", zap.Int64("fieldID", pf.FieldID))
-		return nil, errors.New("no primary field found in insert msg")
+		return nil, merr.WrapErrServiceInternalMsg("no primary field found in insert msg")
 	}
 
 	var realPfData FieldData
@@ -1328,7 +1327,7 @@ func GetPkFromInsertData(collSchema *schemapb.CollectionSchema, data *InsertData
 	}
 	if !ok {
 		log.Warn("primary field not in Int64 or VarChar format", zap.Int64("fieldID", pf.FieldID))
-		return nil, errors.New("primary field not in Int64 or VarChar format")
+		return nil, merr.WrapErrServiceInternalMsg("primary field not in Int64 or VarChar format")
 	}
 
 	return realPfData, nil
@@ -1337,16 +1336,16 @@ func GetPkFromInsertData(collSchema *schemapb.CollectionSchema, data *InsertData
 // GetTimestampFromInsertData returns the Int64FieldData for timestamp field.
 func GetTimestampFromInsertData(data *InsertData) (*Int64FieldData, error) {
 	if data == nil {
-		return nil, errors.New("try to get timestamp from nil insert data")
+		return nil, merr.WrapErrServiceInternalMsg("try to get timestamp from nil insert data")
 	}
 	fieldData, ok := data.Data[common.TimeStampField]
 	if !ok {
-		return nil, errors.New("no timestamp field in insert data")
+		return nil, merr.WrapErrServiceInternalMsg("no timestamp field in insert data")
 	}
 
 	ifd, ok := fieldData.(*Int64FieldData)
 	if !ok {
-		return nil, errors.New("timestamp field is not Int64")
+		return nil, merr.WrapErrServiceInternalMsg("timestamp field is not Int64")
 	}
 
 	return ifd, nil
@@ -1679,7 +1678,7 @@ func TransferInsertDataToInsertRecord(insertData *InsertData) (*segcorepb.Insert
 				ValidData: rawData.ValidData,
 			}
 		default:
-			return insertRecord, errors.New("unsupported data type when transter storage.InsertData to internalpb.InsertRecord")
+			return insertRecord, merr.WrapErrServiceInternalMsg("unsupported data type when transter storage.InsertData to internalpb.InsertRecord")
 		}
 
 		insertRecord.FieldsData = append(insertRecord.FieldsData, fieldData)

--- a/internal/storagev2/filesystem_metrics.go
+++ b/internal/storagev2/filesystem_metrics.go
@@ -27,7 +27,6 @@ package storagev2
 import "C"
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -37,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -58,7 +58,7 @@ func getMetricsFromHandle(cFilesystem C.FileSystemHandle) (*FilesystemMetrics, e
 	metricsResult := C.loon_filesystem_get_metrics(cFilesystem, &cMetrics)
 	if err := HandleLoonFFIResult(metricsResult); err != nil {
 		C.loon_filesystem_destroy(cFilesystem)
-		return nil, fmt.Errorf("failed to get filesystem metrics: %w", err)
+		return nil, merr.Wrap(err, "failed to get filesystem metrics")
 	}
 
 	fsMetrics := &FilesystemMetrics{
@@ -201,7 +201,7 @@ func makePropertiesFromConfig(storageConfig *indexpb.StorageConfig) (C.LoonPrope
 	)
 
 	if err := HandleLoonFFIResult(result); err != nil {
-		return C.LoonProperties{}, fmt.Errorf("failed to create properties: %w", err)
+		return C.LoonProperties{}, merr.Wrap(err, "failed to create properties")
 	}
 
 	return props, nil
@@ -211,7 +211,7 @@ func makePropertiesFromConfig(storageConfig *indexpb.StorageConfig) (C.LoonPrope
 // using full storage config properties for proper cache resolution.
 func GetFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*FilesystemMetrics, error) {
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig is required")
+		return nil, merr.WrapErrStorageMsg("storageConfig is required")
 	}
 
 	props, err := makePropertiesFromConfig(storageConfig)
@@ -223,7 +223,7 @@ func GetFilesystemMetricsWithConfig(storageConfig *indexpb.StorageConfig) (*File
 	var cFilesystem C.FileSystemHandle
 	result := C.loon_filesystem_get(&props, nil, 0, &cFilesystem)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to get cached filesystem: %w", err)
+		return nil, merr.Wrap(err, "failed to get cached filesystem")
 	}
 
 	return getMetricsFromHandle(cFilesystem)
@@ -238,7 +238,7 @@ func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
 		if errMsg != nil {
 			errStr = C.GoString(errMsg)
 		}
-		return fmt.Errorf("loon FFI error: %s", errStr)
+		return merr.WrapErrStorageMsg("loon FFI error: %s", errStr)
 	}
 	return nil
 }

--- a/internal/storagev2/packed/explore_ffi.go
+++ b/internal/storagev2/packed/explore_ffi.go
@@ -26,7 +26,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"net/url"
 	"sort"
 	"strings"
@@ -36,6 +35,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // formatExtensions maps format names to their expected file extensions.
@@ -107,16 +107,16 @@ func GetFileInfo(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 	if err := injectExternalSpecProperties(cProperties, extfs.CollectionID, extfs.Source, extfs.Spec); err != nil {
-		return nil, fmt.Errorf("inject extfs: %w", err)
+		return nil, merr.Wrap(err, "inject extfs")
 	}
 
 	normalizedFilePath, err := normalizeExternalPathForStorage(filePath, cProperties, extfs)
 	if err != nil {
-		return nil, fmt.Errorf("normalize external file path: %w", err)
+		return nil, merr.WrapErrStorage(err, "normalize external file path")
 	}
 	cFilePath := C.CString(normalizedFilePath)
 	defer C.free(unsafe.Pointer(cFilePath))
@@ -125,7 +125,7 @@ func GetFileInfo(
 
 	result := C.loon_exttable_get_file_info(cFormat, cFilePath, cProperties, &numRows)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_exttable_get_file_info failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_exttable_get_file_info failed")
 	}
 
 	return &FileInfo{
@@ -225,16 +225,16 @@ func ExploreFilesReturnManifestPath(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to create properties: %w", err)
+		return nil, "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 	if err := injectExternalSpecProperties(cProperties, extfs.CollectionID, extfs.Source, extfs.Spec); err != nil {
-		return nil, "", fmt.Errorf("inject extfs: %w", err)
+		return nil, "", merr.Wrap(err, "inject extfs")
 	}
 
 	normalizedExploreDir, err := normalizeExternalPathForStorage(exploreDir, cProperties, extfs)
 	if err != nil {
-		return nil, "", fmt.Errorf("normalize external explore path: %w", err)
+		return nil, "", merr.WrapErrStorage(err, "normalize external explore path")
 	}
 	cExploreDir := C.CString(normalizedExploreDir)
 	defer C.free(unsafe.Pointer(cExploreDir))
@@ -253,10 +253,10 @@ func ExploreFilesReturnManifestPath(
 		&numFiles, &outColumnGroupsPath,
 	)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, "", fmt.Errorf("loon_exttable_explore failed: %w", err)
+		return nil, "", merr.WrapErrStorage(err, "loon_exttable_explore failed")
 	}
 	if outColumnGroupsPath == nil {
-		return nil, "", fmt.Errorf("loon_exttable_explore returned nil column groups path")
+		return nil, "", merr.WrapErrServiceInternalMsg("loon_exttable_explore returned nil column groups path")
 	}
 	manifestPath := C.GoString(outColumnGroupsPath)
 	C.loon_free_cstr(outColumnGroupsPath)
@@ -291,21 +291,21 @@ func ReadFileInfosFromManifestPath(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
 	var manifest *C.LoonManifest
 	result := C.loon_exttable_read_manifest(cManifestPath, cProperties, &manifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_exttable_read_manifest failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_exttable_read_manifest failed")
 	}
 	defer C.loon_manifest_destroy(manifest)
 
 	var fileInfos []FileInfo
 	cgroups := &manifest.column_groups
 	if cgroups.column_group_array == nil && cgroups.num_of_column_groups > 0 {
-		return nil, fmt.Errorf("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
+		return nil, merr.WrapErrServiceInternalMsg("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
 	}
 
 	cgArray := unsafe.Slice(cgroups.column_group_array, int(cgroups.num_of_column_groups))
@@ -317,7 +317,7 @@ func ReadFileInfosFromManifestPath(
 		fileArray := unsafe.Slice(cg.files, int(cg.num_of_files))
 		for j := range fileArray {
 			if fileArray[j].path == nil {
-				return nil, fmt.Errorf("file path is nil in column group %d, file %d", i, j)
+				return nil, merr.WrapErrServiceInternalMsg("file path is nil in column group %d, file %d", i, j)
 			}
 			fileInfos = append(fileInfos, FileInfo{
 				FilePath: C.GoString(fileArray[j].path),

--- a/internal/storagev2/packed/ffi_common.go
+++ b/internal/storagev2/packed/ffi_common.go
@@ -21,6 +21,7 @@ import (
 
 	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // ErrLoonTransient marks any failure surfaced by the loon FFI layer. Today
@@ -91,7 +92,7 @@ func ExtfsPrefixForCollection(collectionID int64) string {
 // StorageConfig are mapped to corresponding key-value pairs in Properties.
 func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extraKVs map[string]string) (*C.LoonProperties, error) {
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig is required")
+		return nil, merr.WrapErrStorageMsg("storageConfig is required")
 	}
 
 	// Prepare key-value pairs from StorageConfig
@@ -243,7 +244,7 @@ func MakePropertiesFromStorageConfig(storageConfig *indexpb.StorageConfig, extra
 
 	err := HandleLoonFFIResult(result)
 	if err != nil {
-		return nil, err
+		return nil, merr.WrapErrStorage(err, "loon properties_create failed")
 	}
 	return properties, nil
 }
@@ -275,7 +276,7 @@ func injectExternalSpecProperties(properties *C.LoonProperties, collectionID int
 	externalSource, externalSpec string,
 ) error {
 	if properties == nil {
-		return fmt.Errorf("injectExternalSpecProperties: properties is nil")
+		return merr.WrapErrStorageMsg("injectExternalSpecProperties: properties is nil")
 	}
 	if externalSource == "" {
 		return nil
@@ -289,7 +290,10 @@ func injectExternalSpecProperties(properties *C.LoonProperties, collectionID int
 	}
 	result := C.loon_properties_inject_external_spec(
 		properties, C.int64_t(collectionID), cSource, cSpec)
-	return HandleLoonFFIResult(result)
+	if err := HandleLoonFFIResult(result); err != nil {
+		return merr.WrapErrStorage(err, "loon inject_external_spec failed")
+	}
+	return nil
 }
 
 func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
@@ -301,7 +305,7 @@ func HandleLoonFFIResult(ffiResult C.LoonFFIResult) error {
 			errStr = C.GoString(errMsg)
 		}
 
-		return errors.Wrapf(ErrLoonTransient, "FFI operation failed: %s", errStr)
+		return merr.Wrapf(ErrLoonTransient, "FFI operation failed: %s", errStr)
 	}
 	return nil
 }
@@ -342,14 +346,14 @@ func CompareManifestPath(a, b string) (int, error) {
 	bBase, bVer, bErr := UnmarshalManifestPath(b)
 
 	if aErr != nil {
-		return 0, fmt.Errorf("failed to parse manifest path %q: %w", a, aErr)
+		return 0, merr.WrapErrStorage(aErr, "failed to parse manifest path %q", a)
 	}
 	if bErr != nil {
-		return 0, fmt.Errorf("failed to parse manifest path %q: %w", b, bErr)
+		return 0, merr.WrapErrStorage(bErr, "failed to parse manifest path %q", b)
 	}
 
 	if aBase != bBase {
-		return 0, fmt.Errorf("manifest paths have different base paths: %q vs %q", aBase, bBase)
+		return 0, merr.WrapErrServiceInternalMsg("manifest paths have different base paths: %q vs %q", aBase, bBase)
 	}
 
 	switch {
@@ -382,7 +386,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return 0, fmt.Errorf("failed to make properties: %w", err)
+		return 0, merr.Wrap(err, "failed to make properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -393,7 +397,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 	var cTransactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.int32_t(0) /* resolve_id */, C.uint32_t(1) /* retry_limit */, &cTransactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return 0, fmt.Errorf("failed to begin transaction: %w", err)
+		return 0, merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(cTransactionHandle)
 
@@ -413,7 +417,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 		C.free(unsafe.Pointer(cPath))
 
 		if err := HandleLoonFFIResult(result); err != nil {
-			return 0, fmt.Errorf("failed to add LOB file %s: %w", lobFile.Path, err)
+			return 0, merr.WrapErrStorage(err, "failed to add LOB file %s", lobFile.Path)
 		}
 	}
 
@@ -421,7 +425,7 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 	var committedVersion C.int64_t
 	result = C.loon_transaction_commit(cTransactionHandle, &committedVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return 0, fmt.Errorf("failed to commit transaction: %w", err)
+		return 0, merr.WrapErrStorage(err, "failed to commit transaction")
 	}
 
 	return int64(committedVersion), nil
@@ -432,12 +436,12 @@ func AddLobFilesToTransaction(basePath string, version int64, storageConfig *ind
 func GetManifestLobFiles(manifestPath string, storageConfig *indexpb.StorageConfig) ([]LobFileInfo, error) {
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal manifest path: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to unmarshal manifest path")
 	}
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to make properties: %w", err)
+		return nil, merr.Wrap(err, "failed to make properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -448,7 +452,7 @@ func GetManifestLobFiles(manifestPath string, storageConfig *indexpb.StorageConf
 	var cTransactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.int32_t(0) /* resolve_id */, C.uint32_t(1) /* retry_limit */, &cTransactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(cTransactionHandle)
 
@@ -456,7 +460,7 @@ func GetManifestLobFiles(manifestPath string, storageConfig *indexpb.StorageConf
 	var cManifest *C.LoonManifest
 	result = C.loon_transaction_get_manifest(cTransactionHandle, &cManifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to get manifest: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cManifest)
 

--- a/internal/storagev2/packed/ffi_filesystem.go
+++ b/internal/storagev2/packed/ffi_filesystem.go
@@ -23,11 +23,11 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"strings"
 	"unsafe"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // WriteFile writes raw bytes to a file using milvus-storage filesystem FFI.
@@ -39,7 +39,7 @@ func WriteFile(
 ) error {
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create properties: %w", err)
+		return merr.WrapErrStorage(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -51,7 +51,7 @@ func WriteFile(
 	var fsHandle C.FileSystemHandle
 	result := C.loon_filesystem_get(cProperties, cPath, pathLen, &fsHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return fmt.Errorf("failed to get filesystem: %w", err)
+		return merr.WrapErrStorage(err, "failed to get filesystem")
 	}
 	defer C.loon_filesystem_destroy(fsHandle)
 
@@ -64,7 +64,7 @@ func WriteFile(
 			defer C.free(unsafe.Pointer(cDir))
 			result = C.loon_filesystem_create_dir(fsHandle, cDir, C.uint32_t(len(dir)), true)
 			if err := HandleLoonFFIResult(result); err != nil {
-				return fmt.Errorf("failed to create parent directory %q: %w", dir, err)
+				return merr.WrapErrStorage(err, "failed to create parent directory %q", dir)
 			}
 		}
 	}

--- a/internal/storagev2/packed/ffi_sample.go
+++ b/internal/storagev2/packed/ffi_sample.go
@@ -25,7 +25,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"runtime"
 	"unsafe"
 
@@ -33,6 +32,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // SampleExternalFieldSizes samples rows from an external segment via Take API
@@ -52,19 +52,19 @@ func SampleExternalFieldSizes(
 	storageConfig *indexpb.StorageConfig,
 ) (map[string]int64, error) {
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig is required for SampleExternalFieldSizes")
+		return nil, merr.WrapErrStorageMsg("storageConfig is required for SampleExternalFieldSizes")
 	}
 	if manifestPath == "" {
-		return nil, fmt.Errorf("manifest_path is empty for SampleExternalFieldSizes")
+		return nil, merr.WrapErrStorageMsg("manifest_path is empty for SampleExternalFieldSizes")
 	}
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 	if err := injectExternalSpecProperties(cProperties, collectionID, externalSource, externalSpec); err != nil {
-		return nil, fmt.Errorf("inject extfs: %w", err)
+		return nil, merr.Wrap(err, "inject extfs")
 	}
 
 	cManifestPath := C.CString(manifestPath)
@@ -75,7 +75,7 @@ func SampleExternalFieldSizes(
 	if schema != nil {
 		schemaBytes, err = proto.Marshal(schema)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal collection schema: %w", err)
+			return nil, merr.WrapErrStorage(err, "failed to marshal collection schema")
 		}
 		if len(schemaBytes) > 0 {
 			cSchema.proto_blob = unsafe.Pointer(&schemaBytes[0])

--- a/internal/storagev2/packed/ffi_stats.go
+++ b/internal/storagev2/packed/ffi_stats.go
@@ -23,10 +23,10 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"unsafe"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // ManifestStat represents a stat entry from the manifest.
@@ -104,7 +104,7 @@ func GetManifestStats(
 ) (map[string]ManifestStat, error) {
 	cManifest, err := GetManifestHandle(manifestPath, storageConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get manifest: %w", err)
+		return nil, merr.Wrap(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cManifest)
 

--- a/internal/storagev2/packed/manifest_ffi.go
+++ b/internal/storagev2/packed/manifest_ffi.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // Fragment represents a data fragment from an external data source.
@@ -55,20 +56,20 @@ func CreateManifestForSegment(
 	storageConfig *indexpb.StorageConfig,
 ) (string, error) {
 	if len(fragments) == 0 {
-		return "", fmt.Errorf("fragments cannot be empty")
+		return "", merr.WrapErrServiceInternalMsg("fragments cannot be empty")
 	}
 
 	// Create column groups from fragments
 	columnGroups, err := createColumnGroups(columns, format, fragments)
 	if err != nil {
-		return "", fmt.Errorf("failed to create column groups: %w", err)
+		return "", merr.Wrap(err, "failed to create column groups")
 	}
 	defer C.loon_column_groups_destroy(columnGroups)
 
 	// Create properties from storage config
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create properties: %w", err)
+		return "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -80,21 +81,21 @@ func CreateManifestForSegment(
 	var transactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(0), C.LOON_TRANSACTION_RESOLVE_OVERWRITE /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("loon_transaction_begin failed: %w", err)
+		return "", merr.WrapErrStorage(err, "loon_transaction_begin failed")
 	}
 	defer C.loon_transaction_destroy(transactionHandle)
 
 	// Append files to transaction
 	result = C.loon_transaction_append_files(transactionHandle, columnGroups)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("loon_transaction_append_files failed: %w", err)
+		return "", merr.WrapErrStorage(err, "loon_transaction_append_files failed")
 	}
 
 	// Commit transaction
 	var committedVersion C.int64_t
 	result = C.loon_transaction_commit(transactionHandle, &committedVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("loon_transaction_commit failed: %w", err)
+		return "", merr.WrapErrStorage(err, "loon_transaction_commit failed")
 	}
 
 	// Return manifest path using the helper function
@@ -168,7 +169,7 @@ func createColumnGroups(
 	)
 
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_column_groups_create failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_column_groups_create failed")
 	}
 
 	return outColumnGroups, nil
@@ -186,7 +187,7 @@ func ReadFragmentsFromManifest(
 	// 1. Parse manifest path to get base path and version
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse manifest path: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	// 2. Construct full manifest file path: base_path/_metadata/manifest-{version}.avro
@@ -196,7 +197,7 @@ func ReadFragmentsFromManifest(
 	// 3. Create properties from storage config
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -208,7 +209,7 @@ func ReadFragmentsFromManifest(
 	var manifest *C.LoonManifest
 	result := C.loon_exttable_read_manifest(cManifestFilePath, cProperties, &manifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("loon_exttable_read_manifest failed: %w", err)
+		return nil, merr.WrapErrStorage(err, "loon_exttable_read_manifest failed")
 	}
 
 	// 5. Destroy manifest when done
@@ -222,7 +223,7 @@ func ReadFragmentsFromManifest(
 
 	// Validate column groups structure before accessing
 	if cgroups.column_group_array == nil && cgroups.num_of_column_groups > 0 {
-		return nil, fmt.Errorf("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
+		return nil, merr.WrapErrServiceInternalMsg("column_group_array is nil but num_of_column_groups is %d", cgroups.num_of_column_groups)
 	}
 
 	cgArray := unsafe.Slice(cgroups.column_group_array, int(cgroups.num_of_column_groups))

--- a/internal/storagev2/packed/packed_reader.go
+++ b/internal/storagev2/packed/packed_reader.go
@@ -25,7 +25,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"io"
 	"unsafe"
 
@@ -34,6 +33,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func NewPackedReader(filePaths []string, schema *arrow.Schema, bufferSize int64, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*PackedReader, error) {
@@ -143,7 +143,7 @@ func (pr *PackedReader) ReadNext() (arrow.Record, error) {
 	}()
 	recordBatch, err := cdata.ImportCRecordBatch(goCArr, goCSchema)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert ArrowArray to Record: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to convert ArrowArray to Record")
 	}
 	pr.currentBatch = recordBatch
 

--- a/internal/storagev2/packed/packed_reader_ffi.go
+++ b/internal/storagev2/packed/packed_reader_ffi.go
@@ -25,24 +25,23 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"io"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/cdata"
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns []string, bufferSize int64, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*FFIPackedReader, error) {
 	cLoonManifest, err := GetManifestHandle(manifestPath, storageConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get manifest")
+		return nil, merr.Wrap(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cLoonManifest)
 
@@ -112,7 +111,7 @@ func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns
 
 		status = C.NewPackedFFIReaderWithManifest(cLoonManifest, cSchema, cNeededColumnArray, cNumColumns, &cPackedReader, cStorageConfig, pluginContextPtr)
 	} else {
-		return nil, fmt.Errorf("storageConfig is required")
+		return nil, merr.WrapErrServiceInternalMsg("storageConfig is required")
 	}
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		return nil, err
@@ -123,14 +122,14 @@ func NewFFIPackedReader(manifestPath string, schema *arrow.Schema, neededColumns
 	status = C.GetFFIReaderStream(cPackedReader, C.int64_t(8196), (*C.struct_ArrowArrayStream)(unsafe.Pointer(&cStream)))
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		C.CloseFFIReader(cPackedReader)
-		return nil, fmt.Errorf("failed to get reader stream: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to get reader stream")
 	}
 
 	// Import the stream as a RecordReader
 	recordReader, err := cdata.ImportCRecordReader(&cStream, schema)
 	if err != nil {
 		C.CloseFFIReader(cPackedReader)
-		return nil, fmt.Errorf("failed to import record reader: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to import record reader")
 	}
 
 	return &FFIPackedReader{
@@ -151,7 +150,7 @@ func (r *FFIPackedReader) ReadNext() (rec arrow.Record, err error) {
 		if err == io.EOF {
 			return nil, io.EOF
 		}
-		return nil, fmt.Errorf("failed to read next record: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to read next record")
 	}
 
 	return rec, nil

--- a/internal/storagev2/packed/packed_writer.go
+++ b/internal/storagev2/packed/packed_writer.go
@@ -30,11 +30,11 @@ import (
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/cdata"
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus/internal/storagecommon"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64, multiPartUploadSize int64, columnGroups []storagecommon.ColumnGroup, storageConfig *indexpb.StorageConfig, storagePluginContext *indexcgopb.StoragePluginContext) (*PackedWriter, error) {
@@ -59,7 +59,7 @@ func NewPackedWriter(filePaths []string, schema *arrow.Schema, bufferSize int64,
 	for _, group := range columnGroups {
 		cGroup := C.malloc(C.size_t(len(group.Columns)) * C.size_t(unsafe.Sizeof(C.int(0))))
 		if cGroup == nil {
-			return nil, errors.New("failed to allocate memory for column groups")
+			return nil, merr.WrapErrServiceInternalMsg("failed to allocate memory for column groups")
 		}
 		cGroupSlice := (*[1 << 30]C.int)(cGroup)[:len(group.Columns):len(group.Columns)]
 		for i, val := range group.Columns {
@@ -135,7 +135,7 @@ func (pw *PackedWriter) WriteRecordBatch(recordBatch arrow.Record) error {
 		return nil
 	}
 	if pw.cPackedWriter == nil {
-		return errors.New("packed writer is closed")
+		return merr.WrapErrStorageMsg("packed writer is closed")
 	}
 
 	cArrays := make([]CArrowArray, recordBatch.NumCols())
@@ -176,13 +176,13 @@ func (pw *PackedWriter) Close() error {
 
 func (pw *PackedWriter) CloseAndTell(numGroups int) ([]int64, error) {
 	if numGroups <= 0 {
-		return nil, errors.New("numGroups must be greater than 0")
+		return nil, merr.WrapErrServiceInternalMsg("numGroups must be greater than 0")
 	}
 	if pw.cPackedWriter == nil {
 		if len(pw.closedSizes) == numGroups {
 			return append([]int64(nil), pw.closedSizes...), nil
 		}
-		return nil, errors.New("packed writer is closed")
+		return nil, merr.WrapErrStorageMsg("packed writer is closed")
 	}
 
 	sizes := make([]int64, numGroups)

--- a/internal/storagev2/packed/segment_writer_ffi.go
+++ b/internal/storagev2/packed/segment_writer_ffi.go
@@ -25,13 +25,13 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/cdata"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // TextColumnConfig represents configuration for a TEXT column.
@@ -82,7 +82,7 @@ func NewFFISegmentWriter(
 	defer cdata.ReleaseCArrowSchema(&cas)
 
 	if storageConfig == nil {
-		return nil, fmt.Errorf("storageConfig must not be nil")
+		return nil, merr.WrapErrStorageMsg("storageConfig must not be nil")
 	}
 
 	// create properties

--- a/internal/storagev2/packed/stats_resolver.go
+++ b/internal/storagev2/packed/stats_resolver.go
@@ -23,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // compoundStatsLogIdx is the log index that identifies compound stats format.
@@ -364,7 +365,7 @@ func (r *StatsResolver) loadManifest() error {
 
 	stats, err := GetManifestStats(r.manifestPath, r.storageConfig)
 	if err != nil {
-		r.manifestErr = fmt.Errorf("failed to get manifest stats: %w", err)
+		r.manifestErr = merr.Wrap(err, "failed to get manifest stats")
 		return r.manifestErr
 	}
 	r.manifestStats = stats

--- a/internal/storagev2/packed/transaction.go
+++ b/internal/storagev2/packed/transaction.go
@@ -23,7 +23,6 @@ package packed
 import "C"
 
 import (
-	"fmt"
 	"math"
 	"unsafe"
 
@@ -31,6 +30,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -91,7 +91,7 @@ func addDeltaLogsToManifest(
 
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse manifest path: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	log.Debug("AddDeltaLogsToManifest",
@@ -101,7 +101,7 @@ func addDeltaLogsToManifest(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create properties: %w", err)
+		return "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -112,7 +112,7 @@ func addDeltaLogsToManifest(
 	var transactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), resolveID /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to begin transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(transactionHandle)
 
@@ -124,7 +124,7 @@ func addDeltaLogsToManifest(
 		C.free(unsafe.Pointer(cPath))
 
 		if err := HandleLoonFFIResult(result); err != nil {
-			return "", fmt.Errorf("failed to add delta log %s: %w", deltaLog.Path, err)
+			return "", merr.WrapErrStorage(err, "failed to add delta log %s", deltaLog.Path)
 		}
 
 		log.Debug("Added delta log to transaction",
@@ -136,7 +136,7 @@ func addDeltaLogsToManifest(
 	var commitVersion C.int64_t
 	result = C.loon_transaction_commit(transactionHandle, &commitVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to commit transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to commit transaction")
 	}
 
 	newManifestPath := MarshalManifestPath(basePath, int64(commitVersion))
@@ -154,12 +154,12 @@ func GetDeltaLogPathsFromManifest(
 ) ([]string, error) {
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse manifest path: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create properties: %w", err)
+		return nil, merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -169,14 +169,14 @@ func GetDeltaLogPathsFromManifest(
 	var cTransactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.int32_t(0) /* resolve_id */, C.uint32_t(1) /* retry_limit */, &cTransactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(cTransactionHandle)
 
 	var cManifest *C.LoonManifest
 	result = C.loon_transaction_get_manifest(cTransactionHandle, &cManifest)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return nil, fmt.Errorf("failed to get manifest: %w", err)
+		return nil, merr.WrapErrStorage(err, "failed to get manifest")
 	}
 	defer C.loon_manifest_destroy(cManifest)
 
@@ -221,7 +221,7 @@ func AddStatsToManifest(
 
 	basePath, version, err := UnmarshalManifestPath(manifestPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse manifest path: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to parse manifest path")
 	}
 
 	log.Debug("AddStatsToManifest",
@@ -231,7 +231,7 @@ func AddStatsToManifest(
 
 	cProperties, err := MakePropertiesFromStorageConfig(storageConfig, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create properties: %w", err)
+		return "", merr.Wrap(err, "failed to create properties")
 	}
 	defer C.loon_properties_free(cProperties)
 
@@ -241,14 +241,14 @@ func AddStatsToManifest(
 	var transactionHandle C.LoonTransactionHandle
 	result := C.loon_transaction_begin(cBasePath, cProperties, C.int64_t(version), C.LOON_TRANSACTION_RESOLVE_OVERWRITE /* resolve_id */, getRetryLimit() /* retry_limit */, &transactionHandle)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to begin transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to begin transaction")
 	}
 	defer C.loon_transaction_destroy(transactionHandle)
 
 	// The C++ loon library converts absolute paths to relative at commit time
 	for _, stat := range stats {
 		if err := UpdateTransactionStat(transactionHandle, stat.Key, stat.Files, stat.Metadata); err != nil {
-			return "", fmt.Errorf("failed to update stat %s: %w", stat.Key, err)
+			return "", merr.WrapErrStorage(err, "failed to update stat %s", stat.Key)
 		}
 		log.Debug("Added stat to transaction",
 			zap.String("key", stat.Key),
@@ -258,7 +258,7 @@ func AddStatsToManifest(
 	var commitVersion C.int64_t
 	result = C.loon_transaction_commit(transactionHandle, &commitVersion)
 	if err := HandleLoonFFIResult(result); err != nil {
-		return "", fmt.Errorf("failed to commit transaction: %w", err)
+		return "", merr.WrapErrStorage(err, "failed to commit transaction")
 	}
 
 	newManifestPath := MarshalManifestPath(basePath, int64(commitVersion))

--- a/internal/storagev2/packed/utils.go
+++ b/internal/storagev2/packed/utils.go
@@ -16,7 +16,6 @@ package packed
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -26,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 const (
@@ -147,7 +147,7 @@ func fetchRowCountsConcurrently(
 		futures[k] = pool.Submit(func() (struct{}, error) {
 			fetchedInfo, err := GetFileInfo(format, fileInfos[idx].FilePath, storageConfig, extfs)
 			if err != nil {
-				return struct{}{}, fmt.Errorf("failed to get file info for %s: %w", fileInfos[idx].FilePath, err)
+				return struct{}{}, merr.Wrapf(err, "failed to get file info for %s", fileInfos[idx].FilePath)
 			}
 			// Distinct indexes across workers -> no race on rowCounts.
 			rowCounts[idx] = fetchedInfo.NumRows
@@ -184,7 +184,7 @@ func FetchFragmentsFromExternalSourceWithRange(
 	log := log.Ctx(ctx)
 
 	if exploreManifestPath == "" {
-		return nil, fmt.Errorf("explore manifest path is required")
+		return nil, merr.WrapErrServiceInternalMsg("explore manifest path is required")
 	}
 
 	extfs := ExternalSpecContext{
@@ -196,7 +196,7 @@ func FetchFragmentsFromExternalSourceWithRange(
 	exploreStart := time.Now()
 	fileInfos, err := ReadFileInfosFromManifestPath(exploreManifestPath, storageConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read explore manifest: %w", err)
+		return nil, merr.Wrap(err, "failed to read explore manifest")
 	}
 	rawCount := len(fileInfos)
 	// Apply the same sort+format-filter that DataCoord used to derive
@@ -220,11 +220,11 @@ func FetchFragmentsFromExternalSourceWithRange(
 		fileIndexEnd = int64(len(fileInfos))
 	}
 	if fileIndexBegin >= int64(len(fileInfos)) {
-		return nil, fmt.Errorf("fileIndexBegin %d >= total files %d", fileIndexBegin, len(fileInfos))
+		return nil, merr.WrapErrServiceInternalMsg("fileIndexBegin %d >= total files %d", fileIndexBegin, len(fileInfos))
 	}
 	fileInfos = fileInfos[fileIndexBegin:fileIndexEnd]
 	if len(fileInfos) == 0 {
-		return nil, fmt.Errorf("no files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
+		return nil, merr.WrapErrServiceInternalMsg("no files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
 	}
 
 	getFileInfoStart := time.Now()
@@ -243,7 +243,7 @@ func FetchFragmentsFromExternalSourceWithRange(
 		fragments = append(fragments, SplitFileToFragments(fi.FilePath, rowCounts[i], rowLimit, fragmentIDGenerator)...)
 	}
 	if len(fragments) == 0 {
-		return nil, fmt.Errorf("no data files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
+		return nil, merr.WrapErrServiceInternalMsg("no data files in range [%d, %d)", fileIndexBegin, fileIndexEnd)
 	}
 
 	log.Info("Created fragments from file range",
@@ -268,8 +268,7 @@ func BuildCurrentSegmentFragments(
 		if seg.GetManifestPath() != "" && storageConfig != nil {
 			fragments, err := ReadFragmentsFromManifest(seg.GetManifestPath(), storageConfig)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read manifest for segment %d at %s: %w",
-					seg.GetID(), seg.GetManifestPath(), err)
+				return nil, merr.Wrapf(err, "failed to read manifest for segment %d at %s", seg.GetID(), seg.GetManifestPath())
 			}
 			if len(fragments) > 0 {
 				result[seg.GetID()] = fragments

--- a/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/flusher_components.go
@@ -223,7 +223,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 			}
 			logger.Info("append flush message for segments that not created by streaming service into wal", zap.Stringer("msgID", appendResult.MessageID), zap.Uint64("timeTick", appendResult.TimeTick))
 			return nil
-		}, retry.AttemptAlways()); err != nil {
+		}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true })); err != nil {
 			return nil, err
 		}
 	}
@@ -233,7 +233,7 @@ func (impl *flusherComponents) buildDataSyncServiceWithRetry(ctx context.Context
 		var err error
 		ds, err = impl.buildDataSyncService(ctx, recoverInfo)
 		return err
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/msg_handler_impl.go
@@ -101,7 +101,7 @@ func (impl *msgHandlerImpl) createNewGrowingSegment(ctx context.Context, vchanne
 		}
 		logger.Info("alloc growing segment at datacoord", zap.Int32("schemaVersion", h.SchemaVersion))
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 }
 
 func (impl *msgHandlerImpl) HandleFlush(flushMsg message.ImmutableFlushMessageV2) error {

--- a/internal/streamingnode/server/flusher/flusherimpl/util.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/util.go
@@ -90,7 +90,7 @@ func (impl *WALFlusherImpl) getRecoveryInfo(ctx context.Context, vchannel string
 			return retry.Unrecoverable(errChannelLifetimeUnrecoverable)
 		}
 		return nil
-	}, retry.AttemptAlways())
+	}, retry.AttemptAlways(), retry.RetryErr(func(error) bool { return true }))
 	return resp, err
 }
 

--- a/internal/util/bloomfilter/bloom_filter.go
+++ b/internal/util/bloomfilter/bloom_filter.go
@@ -17,13 +17,13 @@ package bloomfilter
 
 import (
 	"github.com/bits-and-blooms/bloom/v3"
-	"github.com/cockroachdb/errors"
 	"github.com/greatroar/blobloom"
 	"github.com/zeebo/xxh3"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type BFType int
@@ -307,20 +307,20 @@ func UnmarshalJSON(data []byte, bfType BFType) (BloomFilterInterface, error) {
 		bf := &blockedBloomFilter{}
 		err := json.Unmarshal(data, bf)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal blocked bloom filter")
+			return nil, merr.Wrap(err, "failed to unmarshal blocked bloom filter")
 		}
 		return bf, nil
 	case BasicBF:
 		bf := &basicBloomFilter{}
 		err := json.Unmarshal(data, bf)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to unmarshal blocked bloom filter")
+			return nil, merr.Wrap(err, "failed to unmarshal blocked bloom filter")
 		}
 		return bf, nil
 	case AlwaysTrueBF:
 		return AlwaysTrueBloomFilter, nil
 	default:
-		return nil, errors.Errorf("unsupported bloom filter type: %d", bfType)
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported bloom filter type: %d", bfType)
 	}
 }
 

--- a/internal/util/cgo/futures.go
+++ b/internal/util/cgo/futures.go
@@ -29,7 +29,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
-var ErrConsumed = errors.New("future is already consumed")
+var ErrConsumed = merr.WrapErrParameterInvalidMsg("future is already consumed")
 
 // Would put this in futures.go but for the documented issue with
 // exports and functions in preamble

--- a/internal/util/componentutil/componentutil.go
+++ b/internal/util/componentutil/componentutil.go
@@ -18,7 +18,6 @@ package componentutil
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -53,7 +52,7 @@ func WaitForComponentStates[T interface {
 			}
 		}
 		if !meet {
-			return fmt.Errorf(
+			return merr.WrapErrParameterInvalidMsg(
 				"WaitForComponentStates, not meet, %s current state: %s",
 				serviceName,
 				resp.State.StateCode.String())

--- a/internal/util/credentials/credentials.go
+++ b/internal/util/credentials/credentials.go
@@ -20,7 +20,7 @@ package credentials
 
 import (
 	"encoding/base64"
-	"fmt"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 const (
@@ -49,7 +49,7 @@ func (c *Credentials) GetAPIKeyCredential(name string) (string, error) {
 	k := name + "." + APIKey
 	apikey, exist := c.confMap[k]
 	if !exist {
-		return "", fmt.Errorf("%s is not a apikey crediential, can not find key: %s", name, k)
+		return "", merr.WrapErrParameterInvalidMsg("%s is not a apikey crediential, can not find key: %s", name, k)
 	}
 	return apikey, nil
 }
@@ -58,13 +58,13 @@ func (c *Credentials) GetAKSKCredential(name string) (string, string, error) {
 	IdKey := name + "." + AccessKeyId
 	accessKeyId, exist := c.confMap[IdKey]
 	if !exist {
-		return "", "", fmt.Errorf("%s is not a aksk crediential, can not find key: %s", name, IdKey)
+		return "", "", merr.WrapErrParameterInvalidMsg("%s is not a aksk crediential, can not find key: %s", name, IdKey)
 	}
 
 	AccessKey := name + "." + SecretAccessKey
 	secretAccessKey, exist := c.confMap[AccessKey]
 	if !exist {
-		return "", "", fmt.Errorf("%s is not a aksk crediential, can not find key: %s", name, AccessKey)
+		return "", "", merr.WrapErrParameterInvalidMsg("%s is not a aksk crediential, can not find key: %s", name, AccessKey)
 	}
 	return accessKeyId, secretAccessKey, nil
 }
@@ -73,12 +73,12 @@ func (c *Credentials) GetGcpCredential(name string) ([]byte, error) {
 	k := name + "." + CredentialJSON
 	jsonByte, exist := c.confMap[k]
 	if !exist {
-		return nil, fmt.Errorf("%s is not a gcp crediential, can not find key: %s ", name, k)
+		return nil, merr.WrapErrParameterInvalidMsg("%s is not a gcp crediential, can not find key: %s ", name, k)
 	}
 
 	decode, err := base64.StdEncoding.DecodeString(jsonByte)
 	if err != nil {
-		return nil, fmt.Errorf("parse gcp credential:%s faild, err: %s", name, err)
+		return nil, merr.WrapErrParameterInvalidMsg("parse gcp credential:%s faild, err: %s", name, err)
 	}
 	return decode, nil
 }

--- a/internal/util/dependency/factory.go
+++ b/internal/util/dependency/factory.go
@@ -14,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -107,7 +108,7 @@ func (f *DefaultFactory) initMQ(standalone bool, params *paramtable.ComponentPar
 		f.msgStreamFactory = msgstream.NewWpmsFactory(&params.ServiceParam)
 	}
 	if f.msgStreamFactory == nil {
-		return errors.New("failed to create MQ: check the milvus log for initialization failures")
+		return merr.WrapErrServiceInternalMsg("failed to create MQ: check the milvus log for initialization failures")
 	}
 	return nil
 }
@@ -142,10 +143,10 @@ func mustSelectMQType(standalone bool, mqType string, enable mqEnable) string {
 // Validate mq type.
 func validateMQType(standalone bool, mqType string) error {
 	if mqType != mqTypeRocksmq && mqType != mqTypeKafka && mqType != mqTypePulsar && mqType != mqTypeWoodpecker {
-		return errors.Newf("mq type %s is invalid", mqType)
+		return merr.WrapErrParameterInvalidMsg("mq type %s is invalid", mqType)
 	}
 	if !standalone && mqType == mqTypeRocksmq {
-		return errors.Newf("mq %s is only valid in standalone mode")
+		return merr.WrapErrParameterInvalidMsg("mq %s is only valid in standalone mode", mqType)
 	}
 	return nil
 }

--- a/internal/util/exprutil/expr_checker.go
+++ b/internal/util/exprutil/expr_checker.go
@@ -3,11 +3,11 @@ package exprutil
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -22,7 +22,7 @@ func ParseExprFromPlan(plan *planpb.PlanNode) (*planpb.Expr, error) {
 	node := plan.GetNode()
 
 	if node == nil {
-		return nil, errors.New("can't get expr from empty plan node")
+		return nil, merr.WrapErrParameterInvalidMsg("can't get expr from empty plan node")
 	}
 
 	var expr *planpb.Expr
@@ -32,7 +32,7 @@ func ParseExprFromPlan(plan *planpb.PlanNode) (*planpb.Expr, error) {
 	case *planpb.PlanNode_Query:
 		expr = node.Query.GetPredicates()
 	default:
-		return nil, errors.New("unsupported plan node type")
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported plan node type")
 	}
 
 	return expr, nil
@@ -342,7 +342,7 @@ func ValidatePartitionKeyIsolation(expr *planpb.Expr) error {
 		return err
 	}
 	if !foundPartitionKey {
-		return errors.New("partition key not found in expr or the expr is invalid when validating partition key isolation")
+		return merr.WrapErrParameterInvalidMsg("partition key not found in expr or the expr is invalid when validating partition key isolation")
 	}
 	return nil
 }
@@ -389,7 +389,7 @@ func validatePartitionKeyIsolationFromBinaryExpr(expr *planpb.BinaryExpr) (bool,
 		// if either side has partition key, but OR them
 		// e.g. partition_key_field == 1 || other_field > 10
 		if leftRes || rightRes {
-			return true, errors.New("partition key isolation does not support OR")
+			return true, merr.WrapErrParameterInvalidMsg("partition key isolation does not support OR")
 		}
 		// if none of them has partition key
 		return false, nil
@@ -404,7 +404,7 @@ func validatePartitionKeyIsolationFromUnaryExpr(expr *planpb.UnaryExpr) (bool, e
 	}
 	if expr.Op == planpb.UnaryExpr_Not {
 		if res {
-			return true, errors.New("partition key isolation does not support NOT")
+			return true, merr.WrapErrParameterInvalidMsg("partition key isolation does not support NOT")
 		}
 		return false, nil
 	}
@@ -414,7 +414,7 @@ func validatePartitionKeyIsolationFromUnaryExpr(expr *planpb.UnaryExpr) (bool, e
 func validatePartitionKeyIsolationFromTermExpr(expr *planpb.TermExpr) (bool, error) {
 	if expr.GetColumnInfo().GetIsPartitionKey() {
 		// e.g. partition_key_field in [1, 2, 3]
-		return true, errors.New("partition key isolation does not support IN")
+		return true, merr.WrapErrParameterInvalidMsg("partition key isolation does not support IN")
 	}
 	return false, nil
 }
@@ -425,14 +425,14 @@ func validatePartitionKeyIsolationFromRangeExpr(expr *planpb.UnaryRangeExpr) (bo
 			// e.g. partition_key_field == 1
 			return true, nil
 		}
-		return true, errors.Newf("partition key isolation does not support %s", expr.GetOp().String())
+		return true, merr.WrapErrParameterInvalidMsg("partition key isolation does not support %s", expr.GetOp().String())
 	}
 	return false, nil
 }
 
 func validatePartitionKeyIsolationFromBinaryRangeExpr(expr *planpb.BinaryRangeExpr) (bool, error) {
 	if expr.GetColumnInfo().GetIsPartitionKey() {
-		return true, errors.New("partition key isolation does not support BinaryRange")
+		return true, merr.WrapErrParameterInvalidMsg("partition key isolation does not support BinaryRange")
 	}
 	return false, nil
 }

--- a/internal/util/flowgraph/flow_graph.go
+++ b/internal/util/flowgraph/flow_graph.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"go.uber.org/atomic"
 )
 
@@ -56,12 +56,12 @@ func (fg *TimeTickedFlowGraph) SetEdges(nodeName string, out []string) error {
 	currentNode, ok := fg.nodeCtx[nodeName]
 	if !ok {
 		errMsg := "Cannot find node:" + nodeName
-		return errors.New(errMsg)
+		return merr.WrapErrParameterInvalidMsg(errMsg)
 	}
 
 	if len(out) > 1 {
 		errMsg := "Flow graph now support only pipeline mode, with only one or zero output:" + nodeName
-		return errors.New(errMsg)
+		return merr.WrapErrParameterInvalidMsg(errMsg)
 	}
 
 	// init current node's downstream
@@ -70,7 +70,7 @@ func (fg *TimeTickedFlowGraph) SetEdges(nodeName string, out []string) error {
 		outNode, ok := fg.nodeCtx[name]
 		if !ok {
 			errMsg := "Cannot find out node:" + name
-			return errors.New(errMsg)
+			return merr.WrapErrParameterInvalidMsg(errMsg)
 		}
 		maxQueueLength := outNode.node.MaxQueueLength()
 		outNode.inputChannel = make(chan []Msg, maxQueueLength)
@@ -163,7 +163,7 @@ func (fg *TimeTickedFlowGraph) AssembleNodes(orderedNodes ...Node) error {
 			err := fg.SetEdges(node.Name(), []string{orderedNodes[i+1].Name()})
 			if err != nil {
 				errMsg := fmt.Sprintf("set edges failed for flow graph, node=%s", node.Name())
-				return errors.New(errMsg)
+				return merr.WrapErrParameterInvalidMsg(errMsg)
 			}
 		}
 	}

--- a/internal/util/funcutil/count_util.go
+++ b/internal/util/funcutil/count_util.go
@@ -1,18 +1,17 @@
 package funcutil
 
 import (
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func CntOfInternalResult(res *internalpb.RetrieveResults) (int64, error) {
 	if len(res.GetFieldsData()) != 1 {
-		return 0, errors.New("internal count result should only have one column")
+		return 0, merr.WrapErrParameterInvalidMsg("internal count result should only have one column")
 	}
 
 	f := res.GetFieldsData()[0]
@@ -21,7 +20,7 @@ func CntOfInternalResult(res *internalpb.RetrieveResults) (int64, error) {
 
 func CntOfSegCoreResult(res *segcorepb.RetrieveResults) (int64, error) {
 	if len(res.GetFieldsData()) != 1 {
-		return 0, errors.New("segcore count result should only have one column")
+		return 0, merr.WrapErrParameterInvalidMsg("segcore count result should only have one column")
 	}
 
 	f := res.GetFieldsData()[0]
@@ -31,14 +30,14 @@ func CntOfSegCoreResult(res *segcorepb.RetrieveResults) (int64, error) {
 func CntOfFieldData(f *schemapb.FieldData) (int64, error) {
 	scalars := f.GetScalars()
 	if scalars == nil {
-		return 0, errors.New("count result should be scalar")
+		return 0, merr.WrapErrParameterInvalidMsg("count result should be scalar")
 	}
 	data := scalars.GetLongData()
 	if data == nil {
-		return 0, errors.New("count result should be int64 data")
+		return 0, merr.WrapErrParameterInvalidMsg("count result should be int64 data")
 	}
 	if len(data.GetData()) != 1 {
-		return 0, errors.New("count result shoud only have one row")
+		return 0, merr.WrapErrParameterInvalidMsg("count result shoud only have one row")
 	}
 	return data.GetData()[0], nil
 }
@@ -85,7 +84,7 @@ func WrapCntToQueryResults(cnt int64) *milvuspb.QueryResults {
 
 func CntOfQueryResults(res *milvuspb.QueryResults) (int64, error) {
 	if len(res.GetFieldsData()) != 1 {
-		return 0, errors.New("milvus count result should only have one column")
+		return 0, merr.WrapErrParameterInvalidMsg("milvus count result should only have one column")
 	}
 
 	f := res.GetFieldsData()[0]

--- a/internal/util/hookutil/cipher.go
+++ b/internal/util/hookutil/cipher.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -43,7 +44,7 @@ var (
 	Cipher                 atomic.Value
 	initCipherOnce         sync.Once
 	cipherReloadMutex      sync.RWMutex
-	ErrCipherPluginMissing = errors.New("cipher plugin is missing")
+	errCipherPluginMissing = errors.New("cipher plugin is missing")
 )
 
 type BackupInterface interface {
@@ -198,7 +199,7 @@ func TidyDBCipherProperties(ezID int64, dbProperties []*commonpb.KeyValuePair) (
 		case common.EncryptionEnabledKey:
 			value := strings.ToLower(property.Value)
 			if value != "true" && value != "false" {
-				return nil, fmt.Errorf("invalid value for %s: %q, must be \"true\" or \"false\"",
+				return nil, merr.WrapErrParameterInvalidMsg("invalid value for %s: %q, must be \"true\" or \"false\"",
 					common.EncryptionEnabledKey, property.Value)
 			}
 			defaultEncrypt = value == "true"
@@ -213,7 +214,7 @@ func TidyDBCipherProperties(ezID int64, dbProperties []*commonpb.KeyValuePair) (
 	cipher := GetCipher()
 	// If cipher plugin is missing but encryption is requested, return error
 	if cipher == nil && defaultEncrypt {
-		return nil, ErrCipherPluginMissing
+		return nil, errCipherPluginMissing
 	}
 
 	// No plugin or not encrypted
@@ -222,7 +223,7 @@ func TidyDBCipherProperties(ezID int64, dbProperties []*commonpb.KeyValuePair) (
 	}
 
 	if defaultRootKey == "" {
-		return nil, fmt.Errorf("encryption enabled but no key provided and no default key configured")
+		return nil, merr.WrapErrParameterInvalidMsg("encryption enabled but no key provided and no default key configured")
 	}
 
 	result := removeCipherProperties(dbProperties)
@@ -377,7 +378,7 @@ func GetCPluginContextByEzID(ezID int64) (*indexcgopb.StoragePluginContext, erro
 	}
 	key := GetCipher().GetUnsafeKey(ezID, 0)
 	if len(key) == 0 {
-		return nil, errors.Newf("cannot get ez key for ezID=%d", ezID)
+		return nil, merr.WrapErrParameterInvalidMsg("cannot get ez key for ezID=%d", ezID)
 	}
 	return &indexcgopb.StoragePluginContext{
 		EncryptionZoneId: ezID,
@@ -388,12 +389,12 @@ func GetCPluginContextByEzID(ezID int64) (*indexcgopb.StoragePluginContext, erro
 
 func BackupEZKFromDBProperties(dbProperties []*commonpb.KeyValuePair) (string, error) {
 	if !IsDBEncrypted(dbProperties) {
-		return "", fmt.Errorf("not an encryption zone")
+		return "", merr.WrapErrParameterInvalidMsg("not an encryption zone")
 	}
 
 	ezID, hasEzID := ParseEzIDFromProperties(dbProperties)
 	if !hasEzID {
-		return "", fmt.Errorf("encryption enabled but no ezID found")
+		return "", merr.WrapErrServiceInternalMsg("encryption enabled but no ezID found")
 	}
 
 	return BackupEZ(ezID)
@@ -433,7 +434,7 @@ func initCipher() error {
 
 	initConfigs := buildCipherInitConfig()
 	if err = cipherVal.Init(initConfigs); err != nil {
-		return fmt.Errorf("fail to init configs for the cipher plugin, error: %s", err.Error())
+		return merr.Wrap(err, "fail to init configs for the cipher plugin")
 	}
 
 	registerCallback()

--- a/internal/util/hookutil/cipher_test.go
+++ b/internal/util/hookutil/cipher_test.go
@@ -157,7 +157,7 @@ func (s *CipherSuite) TestTidyDBCipherPropertiesError() {
 	}
 	_, err := TidyDBCipherProperties(1, dbProperties)
 	s.Error(err)
-	s.Equal(ErrCipherPluginMissing, err)
+	s.Equal(errCipherPluginMissing, err)
 }
 
 func (s *CipherSuite) TestTidyDBCipherPropertiesInvalidValue() {
@@ -497,7 +497,7 @@ func (s *CipherSuite) TestBackupEZ() {
 	storeCipher(nil)
 	_, err := BackupEZ(123)
 	s.Error(err)
-	s.Equal(ErrCipherPluginMissing, err)
+	s.Equal(errCipherPluginMissing, err)
 
 	InitTestCipher()
 	_, err = BackupEZ(123)
@@ -513,7 +513,7 @@ func (s *CipherSuite) TestBackupEZKFromDBProperties() {
 	}
 	_, err := BackupEZKFromDBProperties(props)
 	s.Error(err)
-	s.Equal(ErrCipherPluginMissing, err)
+	s.Equal(errCipherPluginMissing, err)
 
 	props = []*commonpb.KeyValuePair{
 		{Key: common.EncryptionRootKeyKey, Value: "abc-key"},

--- a/internal/util/hookutil/default.go
+++ b/internal/util/hookutil/default.go
@@ -21,9 +21,8 @@ package hookutil
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/hook"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type DefaultHook struct{}
@@ -31,7 +30,7 @@ type DefaultHook struct{}
 var _ hook.Hook = (*DefaultHook)(nil)
 
 func (d DefaultHook) VerifyAPIKey(key string) (string, error) {
-	return "", errors.New("default hook, can't verify api key")
+	return "", merr.WrapErrParameterInvalidMsg("default hook, can't verify api key")
 }
 
 func (d DefaultHook) Init(params map[string]string) error {

--- a/internal/util/hookutil/ez.go
+++ b/internal/util/hookutil/ez.go
@@ -23,10 +23,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 const (
@@ -46,12 +45,12 @@ func encodeEZContext(ezID int64, key []byte) string {
 func decodeEZContext(encoded string) (ezID int64, key string, err error) {
 	parts := strings.Split(encoded, ":")
 	if len(parts) != 2 {
-		return 0, "", fmt.Errorf("invalid EZ context format: %s", encoded)
+		return 0, "", merr.WrapErrParameterInvalidMsg("invalid EZ context format: %s", encoded)
 	}
 
 	ezID, err = strconv.ParseInt(parts[0], 10, 64)
 	if err != nil {
-		return 0, "", fmt.Errorf("invalid ezID in context: %w", err)
+		return 0, "", merr.Wrap(err, "invalid ezID in context")
 	}
 
 	return ezID, parts[1], nil
@@ -114,12 +113,12 @@ func RemoveEZ(ezID int64) error {
 func BackupEZ(ezID int64) (string, error) {
 	cipher := GetCipher()
 	if cipher == nil {
-		return "", ErrCipherPluginMissing
+		return "", errCipherPluginMissing
 	}
 
 	backupProvider, ok := cipher.(BackupInterface)
 	if !ok {
-		return "", fmt.Errorf("cipher plugin does not support backup operation")
+		return "", merr.WrapErrServiceInternalMsg("cipher plugin does not support backup operation")
 	}
 
 	return backupProvider.Backup(ezID)
@@ -133,7 +132,7 @@ func GetPluginContext(ezID int64, collectionID int64) ([]*commonpb.KeyValuePair,
 
 	key := cipher.GetUnsafeKey(ezID, collectionID)
 	if len(key) == 0 {
-		return nil, errors.Newf("cannot get ez key for ezID=%d, collectionID=%d", ezID, collectionID)
+		return nil, merr.WrapErrParameterInvalidMsg("cannot get ez key for ezID=%d, collectionID=%d", ezID, collectionID)
 	}
 
 	return []*commonpb.KeyValuePair{{
@@ -152,7 +151,7 @@ func ImportEZ(importEzk string) ([]*commonpb.KeyValuePair, error) {
 		CipherConfigImportEZ: importEzk,
 	}
 	if err := cipher.Init(config); err != nil {
-		return nil, fmt.Errorf("failed to import EZK: %w", err)
+		return nil, merr.Wrap(err, "failed to import EZK")
 	}
 
 	ezID, err := GetEzIDByImportEzk(importEzk)
@@ -165,7 +164,7 @@ func ImportEZ(importEzk string) ([]*commonpb.KeyValuePair, error) {
 func GetEzIDByImportEzk(importEzk string) (int64, error) {
 	ezkBytes, err := base64.StdEncoding.DecodeString(importEzk)
 	if err != nil {
-		return 0, fmt.Errorf("failed to decode EZK: %w", err)
+		return 0, merr.Wrap(err, "failed to decode EZK")
 	}
 
 	type EZKData struct {
@@ -173,7 +172,7 @@ func GetEzIDByImportEzk(importEzk string) (int64, error) {
 	}
 	var ezkData EZKData
 	if err := json.Unmarshal(ezkBytes, &ezkData); err != nil {
-		return 0, fmt.Errorf("failed to unmarshal EZK: %w", err)
+		return 0, merr.Wrap(err, "failed to unmarshal EZK")
 	}
 	return ezkData.EzID, nil
 }

--- a/internal/util/hookutil/hook.go
+++ b/internal/util/hookutil/hook.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/hook"
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -81,7 +82,7 @@ func initHook() error {
 	}
 
 	if err = hookVal.Init(paramtable.GetHookParams().SoConfig.GetValue()); err != nil {
-		return fmt.Errorf("fail to init configs for the hook, error: %s", err.Error())
+		return merr.Wrap(err, "fail to init configs for the hook")
 	}
 	storeHook((hookVal))
 	paramtable.GetHookParams().WatchHookWithPrefix("watch_hook", "", func(event *config.Event) {

--- a/internal/util/hookutil/plugin.go
+++ b/internal/util/hookutil/plugin.go
@@ -1,13 +1,13 @@
 package hookutil
 
 import (
-	"fmt"
 	"plugin"
 	"sync"
 
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 var pluginMutex sync.Mutex
@@ -18,7 +18,7 @@ var pluginMutex sync.Mutex
 func LoadPlugin[T any](path string, symbol string) (T, error) {
 	var zero T
 	if path == "" {
-		return zero, fmt.Errorf("empty plugin path for symbol %q", symbol)
+		return zero, merr.WrapErrParameterInvalidMsg("empty plugin path for symbol %q", symbol)
 	}
 
 	log.Info("loading plugin", zap.String("path", path), zap.String("symbol", symbol))
@@ -28,17 +28,17 @@ func LoadPlugin[T any](path string, symbol string) (T, error) {
 
 	p, err := plugin.Open(path)
 	if err != nil {
-		return zero, fmt.Errorf("fail to open plugin %s: %w", path, err)
+		return zero, merr.Wrapf(err, "fail to open plugin %s", path)
 	}
 
 	sym, err := p.Lookup(symbol)
 	if err != nil {
-		return zero, fmt.Errorf("fail to find symbol %q in plugin %s: %w", symbol, path, err)
+		return zero, merr.Wrapf(err, "fail to find symbol %q in plugin %s", symbol, path)
 	}
 
 	val, ok := sym.(T)
 	if !ok {
-		return zero, fmt.Errorf("symbol %q in plugin %s does not implement expected interface", symbol, path)
+		return zero, merr.WrapErrServiceInternalMsg("symbol %q in plugin %s does not implement expected interface", symbol, path)
 	}
 
 	return val, nil

--- a/internal/util/idalloc/basic_allocator.go
+++ b/internal/util/idalloc/basic_allocator.go
@@ -2,7 +2,6 @@ package idalloc
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -11,6 +10,7 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
@@ -87,18 +87,18 @@ func (ta *tsoAllocator) batchAllocate(ctx context.Context, count uint32) (uint64
 
 	mixc, err := ta.mix.GetWithContext(ctx)
 	if err != nil {
-		return 0, 0, fmt.Errorf("get root coordinator client timeout: %w", err)
+		return 0, 0, merr.Wrap(err, "get root coordinator client timeout")
 	}
 
 	resp, err := mixc.AllocTimestamp(ctx, req)
 	if err != nil {
-		return 0, 0, fmt.Errorf("syncTimestamp Failed:%w", err)
+		return 0, 0, merr.Wrap(err, "syncTimestamp Failed")
 	}
 	if resp.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
-		return 0, 0, fmt.Errorf("syncTimeStamp Failed:%s", resp.GetStatus().GetReason())
+		return 0, 0, merr.Wrap(merr.Error(resp.GetStatus()), "syncTimeStamp Failed")
 	}
 	if resp == nil {
-		return 0, 0, errors.New("empty AllocTimestampResponse")
+		return 0, 0, merr.WrapErrServiceInternalMsg("empty AllocTimestampResponse")
 	}
 	return resp.GetTimestamp(), int(resp.GetCount()), nil
 }
@@ -132,18 +132,18 @@ func (ta *idAllocator) batchAllocate(ctx context.Context, count uint32) (uint64,
 
 	mix, err := ta.mix.GetWithContext(ctx)
 	if err != nil {
-		return 0, 0, fmt.Errorf("get root coordinator client timeout: %w", err)
+		return 0, 0, merr.Wrap(err, "get root coordinator client timeout")
 	}
 
 	resp, err := mix.AllocID(ctx, req)
 	if err != nil {
-		return 0, 0, fmt.Errorf("AllocID Failed:%w", err)
+		return 0, 0, merr.Wrap(err, "AllocID Failed")
 	}
 	if resp.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
-		return 0, 0, fmt.Errorf("AllocID Failed:%s", resp.GetStatus().GetReason())
+		return 0, 0, merr.Wrap(merr.Error(resp.GetStatus()), "AllocID Failed")
 	}
 	if resp == nil {
-		return 0, 0, errors.New("empty AllocID")
+		return 0, 0, merr.WrapErrServiceInternalMsg("empty AllocID")
 	}
 	if resp.GetID() < 0 {
 		panic("get unexpected negative id")

--- a/internal/util/importutilv2/common/util.go
+++ b/internal/util/importutilv2/common/util.go
@@ -25,19 +25,20 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 func CheckVarcharLength(str string, maxLength int64, field *schemapb.FieldSchema) error {
 	if (int64)(len(str)) > maxLength {
-		return fmt.Errorf("value length(%d) for field %s exceeds max_length(%d)", len(str), field.GetName(), maxLength)
+		return merr.WrapErrParameterInvalidMsg("value length(%d) for field %s exceeds max_length(%d)", len(str), field.GetName(), maxLength)
 	}
 	return nil
 }
 
 func CheckArrayCapacity(arrLength int, maxCapacity int64, field *schemapb.FieldSchema) error {
 	if (int64)(arrLength) > maxCapacity {
-		return fmt.Errorf("array capacity(%d) for field %s exceeds max_capacity(%d)", arrLength, field.GetName(), maxCapacity)
+		return merr.WrapErrParameterInvalidMsg("array capacity(%d) for field %s exceeds max_capacity(%d)", arrLength, field.GetName(), maxCapacity)
 	}
 	return nil
 }
@@ -48,7 +49,7 @@ func EstimateReadCountPerBatch(bufferSize int, schema *schemapb.CollectionSchema
 		return 0, err
 	}
 	if sizePerRecord <= 0 || bufferSize <= 0 {
-		return 0, fmt.Errorf("invalid size, sizePerRecord=%d, bufferSize=%d", sizePerRecord, bufferSize)
+		return 0, merr.WrapErrParameterInvalidMsg("invalid size, sizePerRecord=%d, bufferSize=%d", sizePerRecord, bufferSize)
 	}
 	if 1000*sizePerRecord <= bufferSize {
 		return 1000, nil
@@ -94,7 +95,7 @@ func CheckValidUTF8(s string, field *schemapb.FieldSchema) error {
 	if !typeutil.IsUTF8(s) {
 		// Use safe string representation to avoid gRPC serialization errors
 		safeValue := SafeStringForErrorWithLimit(s, 100)
-		return fmt.Errorf("field '%s' contains invalid UTF-8 data, value=%s", field.GetName(), safeValue)
+		return merr.WrapErrParameterInvalidMsg("field '%s' contains invalid UTF-8 data, value=%s", field.GetName(), safeValue)
 	}
 	return nil
 }

--- a/internal/util/importutilv2/csv/row_parser.go
+++ b/internal/util/importutilv2/csv/row_parser.go
@@ -627,7 +627,7 @@ func (r *rowParser) arrayToFieldData(arr []interface{}, field *schemapb.FieldSch
 			}
 			num, err := strconv.ParseInt(value.String(), 10, 32)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse int32: %w", err)
+				return nil, merr.Wrap(err, "failed to parse int32")
 			}
 			values[i] = int32(num)
 		}
@@ -648,7 +648,7 @@ func (r *rowParser) arrayToFieldData(arr []interface{}, field *schemapb.FieldSch
 			}
 			num, err := strconv.ParseInt(value.String(), 10, 64)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse int64: %w", err)
+				return nil, merr.Wrap(err, "failed to parse int64")
 			}
 			values[i] = num
 		}
@@ -668,12 +668,12 @@ func (r *rowParser) arrayToFieldData(arr []interface{}, field *schemapb.FieldSch
 			}
 			num, err := strconv.ParseFloat(value.String(), 32)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse float32: %w", err)
+				return nil, merr.Wrap(err, "failed to parse float32")
 			}
 			values[i] = float32(num)
 		}
 		if err := typeutil.VerifyFloats32(values); err != nil {
-			return nil, fmt.Errorf("float32 verification failed: %w", err)
+			return nil, merr.Wrap(err, "float32 verification failed")
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_FloatData{
@@ -691,12 +691,12 @@ func (r *rowParser) arrayToFieldData(arr []interface{}, field *schemapb.FieldSch
 			}
 			num, err := strconv.ParseFloat(value.String(), 64)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse float64: %w", err)
+				return nil, merr.Wrap(err, "failed to parse float64")
 			}
 			values[i] = num
 		}
 		if err := typeutil.VerifyFloats64(values); err != nil {
-			return nil, fmt.Errorf("float64 verification failed: %w", err)
+			return nil, merr.Wrap(err, "float64 verification failed")
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_DoubleData{
@@ -714,7 +714,7 @@ func (r *rowParser) arrayToFieldData(arr []interface{}, field *schemapb.FieldSch
 			}
 			num, err := strconv.ParseInt(value.String(), 10, 64)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse timesamptz: %w", err)
+				return nil, merr.Wrap(err, "failed to parse timesamptz")
 			}
 			values[i] = num
 		}
@@ -778,7 +778,7 @@ func (r *rowParser) arrayOfVectorToFieldData(vectors []any, field *schemapb.Fiel
 				}
 				num, err := strconv.ParseFloat(value.String(), 32)
 				if err != nil {
-					return nil, fmt.Errorf("failed to parse float: %w", err)
+					return nil, merr.Wrap(err, "failed to parse float")
 				}
 				vector[i] = float32(num)
 			}

--- a/internal/util/importutilv2/json/row_parser.go
+++ b/internal/util/importutilv2/json/row_parser.go
@@ -727,7 +727,7 @@ func (r *rowParser) arrayToFieldData(arr []interface{}, field *schemapb.FieldSch
 			}
 			num, err := strconv.ParseInt(value.String(), 0, 32)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse int32: %w", err)
+				return nil, merr.Wrap(err, "failed to parse int32")
 			}
 			values[i] = int32(num)
 		}
@@ -747,7 +747,7 @@ func (r *rowParser) arrayToFieldData(arr []interface{}, field *schemapb.FieldSch
 			}
 			num, err := strconv.ParseInt(value.String(), 0, 64)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse int64: %w", err)
+				return nil, merr.Wrap(err, "failed to parse int64")
 			}
 			values[i] = num
 		}
@@ -767,12 +767,12 @@ func (r *rowParser) arrayToFieldData(arr []interface{}, field *schemapb.FieldSch
 			}
 			num, err := strconv.ParseFloat(value.String(), 32)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse float32: %w", err)
+				return nil, merr.Wrap(err, "failed to parse float32")
 			}
 			values[i] = float32(num)
 		}
 		if err := typeutil.VerifyFloats32(values); err != nil {
-			return nil, fmt.Errorf("float32 verification failed: %w", err)
+			return nil, merr.Wrap(err, "float32 verification failed")
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_FloatData{
@@ -790,12 +790,12 @@ func (r *rowParser) arrayToFieldData(arr []interface{}, field *schemapb.FieldSch
 			}
 			num, err := strconv.ParseFloat(value.String(), 64)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse float64: %w", err)
+				return nil, merr.Wrap(err, "failed to parse float64")
 			}
 			values[i] = num
 		}
 		if err := typeutil.VerifyFloats64(values); err != nil {
-			return nil, fmt.Errorf("float64 verification failed: %w", err)
+			return nil, merr.Wrap(err, "float64 verification failed")
 		}
 		return &schemapb.ScalarField{
 			Data: &schemapb.ScalarField_DoubleData{

--- a/internal/util/importutilv2/numpy/util.go
+++ b/internal/util/importutilv2/numpy/util.go
@@ -261,7 +261,7 @@ func convertNumpyType(typeStr string) (schemapb.DataType, error) {
 			// Note: JSON field and VARCHAR field are using string type numpy
 			return schemapb.DataType_VarChar, nil
 		}
-		return schemapb.DataType_None, fmt.Errorf("the numpy file dtype '%s' is not supported", typeStr)
+		return schemapb.DataType_None, merr.WrapErrParameterInvalidMsg("the numpy file dtype '%s' is not supported", typeStr)
 	}
 }
 

--- a/internal/util/importutilv2/option.go
+++ b/internal/util/importutilv2/option.go
@@ -79,7 +79,7 @@ func GetTimeoutTs(options Options) (uint64, error) {
 		var dur time.Duration
 		dur, err = time.ParseDuration(timeoutStr)
 		if err != nil {
-			return 0, fmt.Errorf("parse timeout failed, err=%w", err)
+			return 0, merr.Wrap(err, "parse timeout failed")
 		}
 		curTs := tsoutil.GetCurrentTime()
 		timeoutTs = tsoutil.AddPhysicalDurationOnTs(curTs, dur)

--- a/internal/util/importutilv2/parquet/field_reader.go
+++ b/internal/util/importutilv2/parquet/field_reader.go
@@ -23,7 +23,6 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/parquet/pqarrow"
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"golang.org/x/exp/constraints"
 
@@ -1298,7 +1297,7 @@ func ReadNullableSparseFloatVectorData(pcr *FieldReader, count int64) (any, []bo
 func checkVectorAlignWithDim(offsets []int32, dim int32) error {
 	for i := 1; i < len(offsets); i++ {
 		if offsets[i]-offsets[i-1] != dim {
-			return fmt.Errorf("expected %d but got %d", dim, offsets[i]-offsets[i-1])
+			return merr.WrapErrParameterInvalidMsg("expected %d but got %d", dim, offsets[i]-offsets[i-1])
 		}
 	}
 	return nil
@@ -1306,7 +1305,7 @@ func checkVectorAlignWithDim(offsets []int32, dim int32) error {
 
 func checkVectorAligned(offsets []int32, dim int, dataType schemapb.DataType) error {
 	if len(offsets) < 1 {
-		return errors.New("empty offsets")
+		return merr.WrapErrParameterInvalidMsg("empty offsets")
 	}
 	switch dataType {
 	case schemapb.DataType_BinaryVector:
@@ -1321,7 +1320,7 @@ func checkVectorAligned(offsets []int32, dim int, dataType schemapb.DataType) er
 	case schemapb.DataType_Int8Vector:
 		return checkVectorAlignWithDim(offsets, int32(dim))
 	default:
-		return fmt.Errorf("unexpected vector data type %s", dataType.String())
+		return merr.WrapErrParameterInvalidMsg("unexpected vector data type %s", dataType.String())
 	}
 }
 
@@ -1766,7 +1765,7 @@ func ReadArrayData(pcr *FieldReader, count int64) (any, error) {
 		}
 		for _, elementArray := range float32Array.([][]float32) {
 			if err := typeutil.VerifyFloats32(elementArray); err != nil {
-				return nil, fmt.Errorf("float32 verification failed: %w", err)
+				return nil, merr.Wrap(err, "float32 verification failed")
 			}
 			if err = common.CheckArrayCapacity(len(elementArray), maxCapacity, pcr.field); err != nil {
 				return nil, err
@@ -1789,7 +1788,7 @@ func ReadArrayData(pcr *FieldReader, count int64) (any, error) {
 		}
 		for _, elementArray := range float64Array.([][]float64) {
 			if err := typeutil.VerifyFloats64(elementArray); err != nil {
-				return nil, fmt.Errorf("float64 verification failed: %w", err)
+				return nil, merr.Wrap(err, "float64 verification failed")
 			}
 			if err = common.CheckArrayCapacity(len(elementArray), maxCapacity, pcr.field); err != nil {
 				return nil, err

--- a/internal/util/importutilv2/parquet/list_like.go
+++ b/internal/util/importutilv2/parquet/list_like.go
@@ -17,13 +17,12 @@
 package parquet
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"golang.org/x/exp/constraints"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type listLikeArray struct {
@@ -171,7 +170,7 @@ func expectedVectorListLength(dim int, dataType schemapb.DataType) (int32, error
 	case schemapb.DataType_Int8Vector:
 		return int32(dim), nil
 	default:
-		return 0, fmt.Errorf("unexpected vector data type %s", dataType.String())
+		return 0, merr.WrapErrParameterInvalidMsg("unexpected vector data type %s", dataType.String())
 	}
 }
 

--- a/internal/util/importutilv2/parquet/struct_field_reader.go
+++ b/internal/util/importutilv2/parquet/struct_field_reader.go
@@ -325,7 +325,7 @@ func (r *StructFieldReader) readArrayField(chunked *arrow.Chunked) (any, any, er
 						}
 						value := field.Value(int(structIdx))
 						if err := typeutil.VerifyFloat(float64(value)); err != nil {
-							return nil, nil, fmt.Errorf("float32 verification failed: %w", err)
+							return nil, nil, merr.Wrap(err, "float32 verification failed")
 						}
 						combinedData = append(combinedData, value)
 					case *array.Float64:
@@ -334,7 +334,7 @@ func (r *StructFieldReader) readArrayField(chunked *arrow.Chunked) (any, any, er
 						}
 						value := field.Value(int(structIdx))
 						if err := typeutil.VerifyFloat(value); err != nil {
-							return nil, nil, fmt.Errorf("float64 verification failed: %w", err)
+							return nil, nil, merr.Wrap(err, "float64 verification failed")
 						}
 						combinedData = append(combinedData, value)
 					case *array.String:

--- a/internal/util/indexcgowrapper/helper.go
+++ b/internal/util/indexcgowrapper/helper.go
@@ -13,8 +13,6 @@ import (
 	"fmt"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
@@ -22,7 +20,7 @@ import (
 func GetBinarySetKeys(cBinarySet C.CBinarySet) ([]string, error) {
 	size := int(C.GetBinarySetSize(cBinarySet))
 	if size == 0 {
-		return nil, errors.New("BinarySet size is zero")
+		return nil, merr.WrapErrParameterInvalidMsg("BinarySet size is zero")
 	}
 	datas := make([]unsafe.Pointer, size)
 
@@ -41,7 +39,7 @@ func GetBinarySetValue(cBinarySet C.CBinarySet, key string) ([]byte, error) {
 	ret := C.GetBinarySetValueSize(cBinarySet, cIndexKey)
 	size := int(ret)
 	if size == 0 {
-		return nil, errors.New("GetBinarySetValueSize size is zero")
+		return nil, merr.WrapErrParameterInvalidMsg("GetBinarySetValueSize size is zero")
 	}
 	value := make([]byte, size)
 	status := C.CopyBinarySetValue(unsafe.Pointer(&value[0]), cIndexKey, cBinarySet)

--- a/internal/util/indexcgowrapper/index.go
+++ b/internal/util/indexcgowrapper/index.go
@@ -11,7 +11,6 @@ import "C"
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"runtime"
 	"unsafe"
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/cgopb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type Blob = storage.Blob
@@ -182,7 +182,7 @@ func CreateJSONKeyStats(ctx context.Context, buildIndexInfo *indexcgopb.BuildInd
 func (index *CgoIndex) Build(dataset *Dataset) error {
 	switch dataset.DType {
 	case schemapb.DataType_None:
-		return fmt.Errorf("build index on supported data type: %s", dataset.DType.String())
+		return merr.WrapErrParameterInvalidMsg("build index on supported data type: %s", dataset.DType.String())
 	case schemapb.DataType_FloatVector:
 		return index.buildFloatVecIndex(dataset)
 	case schemapb.DataType_Float16Vector:
@@ -214,7 +214,7 @@ func (index *CgoIndex) Build(dataset *Dataset) error {
 	case schemapb.DataType_VarChar:
 		return index.buildStringIndex(dataset)
 	default:
-		return fmt.Errorf("build index on unsupported data type: %s", dataset.DType.String())
+		return merr.WrapErrParameterInvalidMsg("build index on unsupported data type: %s", dataset.DType.String())
 	}
 }
 
@@ -306,7 +306,7 @@ func (index *CgoIndex) buildSparseFloatVecIndex(dataset *Dataset) error {
 	if validData, ok := dataset.Data[keyValidArr].([]bool); ok && len(validData) > 0 {
 		validRows := validCount(validData)
 		if validRows > 0 && len(vectors) == 0 {
-			return fmt.Errorf("sparse float vector cgo build requires encoded sparse rows")
+			return merr.WrapErrParameterInvalidMsg("sparse float vector cgo build requires encoded sparse rows")
 		}
 		status := C.BuildSparseFloatVecIndexWithValidData(
 			index.indexPtr,
@@ -318,7 +318,7 @@ func (index *CgoIndex) buildSparseFloatVecIndex(dataset *Dataset) error {
 		return HandleCStatus(&status, "failed to build sparse float vector index with valid data")
 	}
 	if len(vectors) == 0 {
-		return fmt.Errorf("sparse float vector cgo build requires encoded sparse rows")
+		return merr.WrapErrParameterInvalidMsg("sparse float vector cgo build requires encoded sparse rows")
 	}
 	status := C.BuildSparseFloatVecIndex(index.indexPtr, (C.int64_t)(len(vectors)), (C.int64_t)(0), cUint8Ptr(vectors))
 	return HandleCStatus(&status, "failed to build sparse float vector index")

--- a/internal/util/indexparamcheck/base_checker.go
+++ b/internal/util/indexparamcheck/base_checker.go
@@ -17,9 +17,8 @@
 package indexparamcheck
 
 import (
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type baseChecker struct{}
@@ -36,7 +35,7 @@ func (c baseChecker) CheckValidDataType(indexType IndexType, field *schemapb.Fie
 func (c baseChecker) SetDefaultMetricTypeIfNotExist(dType schemapb.DataType, m map[string]string) {}
 
 func (c baseChecker) StaticCheck(dataType schemapb.DataType, elementType schemapb.DataType, params map[string]string) error {
-	return errors.New("unsupported index type")
+	return merr.WrapErrParameterInvalidMsg("unsupported index type")
 }
 
 func newBaseChecker() IndexChecker {

--- a/internal/util/indexparamcheck/bitmap_index_checker.go
+++ b/internal/util/indexparamcheck/bitmap_index_checker.go
@@ -1,7 +1,6 @@
 package indexparamcheck
 
 import (
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -34,7 +33,7 @@ func (c *BITMAPChecker) CheckTrain(dataType schemapb.DataType, elementType schem
 
 func (c *BITMAPChecker) CheckValidDataType(indexType IndexType, field *schemapb.FieldSchema) error {
 	if field.IsPrimaryKey {
-		return errors.New("create bitmap index on primary key not supported")
+		return merr.WrapErrParameterInvalidMsg("create bitmap index on primary key not supported")
 	}
 	mainType := field.GetDataType()
 	elemType := field.GetElementType()
@@ -43,12 +42,12 @@ func (c *BITMAPChecker) CheckValidDataType(indexType IndexType, field *schemapb.
 	}
 	if !typeutil.IsBoolType(mainType) && !typeutil.IsIntegerType(mainType) &&
 		!typeutil.IsStringType(mainType) && !typeutil.IsArrayType(mainType) {
-		return errors.New("bitmap index are only supported on bool, int, string and array field")
+		return merr.WrapErrParameterInvalidMsg("bitmap index are only supported on bool, int, string and array field")
 	}
 	if typeutil.IsArrayType(mainType) {
 		if !typeutil.IsBoolType(elemType) && !typeutil.IsIntegerType(elemType) &&
 			!typeutil.IsStringType(elemType) {
-			return errors.New("bitmap index are only supported on bool, int, string for array field")
+			return merr.WrapErrParameterInvalidMsg("bitmap index are only supported on bool, int, string for array field")
 		}
 	}
 	return nil

--- a/internal/util/indexparamcheck/conf_adapter_mgr.go
+++ b/internal/util/indexparamcheck/conf_adapter_mgr.go
@@ -19,9 +19,8 @@ package indexparamcheck
 import (
 	"sync"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type IndexCheckerMgr interface {
@@ -44,7 +43,7 @@ func (mgr *indexCheckerMgrImpl) GetChecker(indexType string) (IndexChecker, erro
 	if ok {
 		return adapter, nil
 	}
-	return nil, errors.New("Can not find index: " + indexType + " , please check")
+	return nil, merr.WrapErrParameterInvalidMsg("Can not find index: " + indexType + " , please check")
 }
 
 func (mgr *indexCheckerMgrImpl) registerIndexChecker() {

--- a/internal/util/indexparamcheck/hybrid_index_checker.go
+++ b/internal/util/indexparamcheck/hybrid_index_checker.go
@@ -1,9 +1,6 @@
 package indexparamcheck
 
 import (
-	"fmt"
-
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -33,14 +30,14 @@ func (c *HYBRIDChecker) CheckTrain(dataType schemapb.DataType, elementType schem
 		// For JSON, bitmap_cardinality_limit is optional — validate only if present
 		if _, exist := params[common.BitmapCardinalityLimitKey]; exist {
 			if !CheckIntByRange(params, common.BitmapCardinalityLimitKey, 1, MaxBitmapCardinalityLimit) {
-				return fmt.Errorf("failed to check bitmap cardinality limit, should be larger than 0 and smaller than %d",
+				return merr.WrapErrParameterInvalidMsg("failed to check bitmap cardinality limit, should be larger than 0 and smaller than %d",
 					MaxBitmapCardinalityLimit)
 			}
 		}
 		return nil
 	}
 	if !CheckIntByRange(params, common.BitmapCardinalityLimitKey, 1, MaxBitmapCardinalityLimit) {
-		return fmt.Errorf("failed to check bitmap cardinality limit, should be larger than 0 and smaller than %d",
+		return merr.WrapErrParameterInvalidMsg("failed to check bitmap cardinality limit, should be larger than 0 and smaller than %d",
 			MaxBitmapCardinalityLimit)
 	}
 	return c.scalarIndexChecker.CheckTrain(dataType, elementType, params)
@@ -55,12 +52,12 @@ func (c *HYBRIDChecker) CheckValidDataType(indexType IndexType, field *schemapb.
 	if !typeutil.IsBoolType(mainType) && !typeutil.IsIntegerType(mainType) &&
 		!typeutil.IsStringType(mainType) && !typeutil.IsArrayType(mainType) &&
 		!typeutil.IsFloatingType(mainType) {
-		return errors.New("hybrid index are only supported on bool, int, float, string and array field")
+		return merr.WrapErrParameterInvalidMsg("hybrid index are only supported on bool, int, float, string and array field")
 	}
 	if typeutil.IsArrayType(mainType) {
 		if !typeutil.IsBoolType(elemType) && !typeutil.IsIntegerType(elemType) &&
 			!typeutil.IsStringType(elemType) && !typeutil.IsFloatingType(elemType) {
-			return errors.New("hybrid index are only supported on bool, int, float, string for array field")
+			return merr.WrapErrParameterInvalidMsg("hybrid index are only supported on bool, int, float, string for array field")
 		}
 	}
 	return nil

--- a/internal/util/indexparamcheck/index_type.go
+++ b/internal/util/indexparamcheck/index_type.go
@@ -12,11 +12,11 @@
 package indexparamcheck
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // IndexType string.
@@ -76,11 +76,11 @@ func ValidateMmapIndexParams(indexType IndexType, indexParams map[string]string)
 	}
 	enable, err := strconv.ParseBool(mmapEnable)
 	if err != nil {
-		return fmt.Errorf("invalid %s value: %s, expected: true, false", common.MmapEnabledKey, mmapEnable)
+		return merr.WrapErrParameterInvalidMsg("invalid %s value: %s, expected: true, false", common.MmapEnabledKey, mmapEnable)
 	}
 	mmapSupport := indexType == AutoIndex || IsVectorMmapIndex(indexType) || IsScalarMmapIndex(indexType)
 	if enable && !mmapSupport {
-		return fmt.Errorf("index type %s does not support mmap", indexType)
+		return merr.WrapErrParameterInvalidMsg("index type %s does not support mmap", indexType)
 	}
 	return nil
 }
@@ -92,10 +92,10 @@ func ValidateOffsetCacheIndexParams(indexType IndexType, indexParams map[string]
 	}
 	enable, err := strconv.ParseBool(offsetCacheEnable)
 	if err != nil {
-		return fmt.Errorf("invalid %s value: %s, expected: true, false", common.IndexOffsetCacheEnabledKey, offsetCacheEnable)
+		return merr.WrapErrParameterInvalidMsg("invalid %s value: %s, expected: true, false", common.IndexOffsetCacheEnabledKey, offsetCacheEnable)
 	}
 	if enable && !IsOffsetCacheSupported(indexType) {
-		return fmt.Errorf("only bitmap index support %s now", common.IndexOffsetCacheEnabledKey)
+		return merr.WrapErrParameterInvalidMsg("only bitmap index support %s now", common.IndexOffsetCacheEnabledKey)
 	}
 	return nil
 }

--- a/internal/util/indexparamcheck/inverted_checker.go
+++ b/internal/util/indexparamcheck/inverted_checker.go
@@ -1,8 +1,6 @@
 package indexparamcheck
 
 import (
-	"fmt"
-
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -51,7 +49,7 @@ func (c *INVERTEDChecker) CheckValidDataType(indexType IndexType, field *schemap
 	dType := field.GetDataType()
 	if !typeutil.IsBoolType(dType) && !typeutil.IsArithmetic(dType) && !typeutil.IsStringType(dType) &&
 		!typeutil.IsArrayType(dType) && !typeutil.IsJSONType(dType) {
-		return fmt.Errorf("INVERTED are not supported on %s field", dType.String())
+		return merr.WrapErrParameterInvalidMsg("INVERTED are not supported on %s field", dType.String())
 	}
 	return nil
 }

--- a/internal/util/indexparamcheck/ngram_index_checker.go
+++ b/internal/util/indexparamcheck/ngram_index_checker.go
@@ -1,7 +1,6 @@
 package indexparamcheck
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -68,7 +67,7 @@ func (c *NgramIndexChecker) CheckTrain(dataType schemapb.DataType, elementType s
 func (c *NgramIndexChecker) CheckValidDataType(indexType IndexType, field *schemapb.FieldSchema) error {
 	dType := field.GetDataType()
 	if !typeutil.IsStringType(dType) && dType != schemapb.DataType_JSON {
-		return fmt.Errorf("ngram index can only be created on VARCHAR or JSON field")
+		return merr.WrapErrParameterInvalidMsg("ngram index can only be created on VARCHAR or JSON field")
 	}
 	return nil
 }

--- a/internal/util/indexparamcheck/rtree_checker.go
+++ b/internal/util/indexparamcheck/rtree_checker.go
@@ -17,9 +17,8 @@
 package indexparamcheck
 
 import (
-	"fmt"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -30,7 +29,7 @@ type RTREEChecker struct {
 
 func (c *RTREEChecker) CheckTrain(dataType schemapb.DataType, elementType schemapb.DataType, params map[string]string) error {
 	if !typeutil.IsGeometryType(dataType) {
-		return fmt.Errorf("RTREE index can only be built on geometry field")
+		return merr.WrapErrParameterInvalidMsg("RTREE index can only be built on geometry field")
 	}
 
 	return c.scalarIndexChecker.CheckTrain(dataType, elementType, params)
@@ -39,7 +38,7 @@ func (c *RTREEChecker) CheckTrain(dataType schemapb.DataType, elementType schema
 func (c *RTREEChecker) CheckValidDataType(indexType IndexType, field *schemapb.FieldSchema) error {
 	dType := field.GetDataType()
 	if !typeutil.IsGeometryType(dType) {
-		return fmt.Errorf("RTREE index can only be built on geometry field, got %s", dType.String())
+		return merr.WrapErrParameterInvalidMsg("RTREE index can only be built on geometry field, got %s", dType.String())
 	}
 	return nil
 }

--- a/internal/util/indexparamcheck/stl_sort_checker.go
+++ b/internal/util/indexparamcheck/stl_sort_checker.go
@@ -3,7 +3,6 @@ package indexparamcheck
 import (
 	"fmt"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -40,7 +39,7 @@ func (c *STLSORTChecker) CheckValidDataType(indexType IndexType, field *schemapb
 	if typeutil.IsArrayType(dataType) && typeutil.IsStructSubField(field.GetName()) {
 		elemType := field.GetElementType()
 		if !typeutil.IsArithmetic(elemType) && !typeutil.IsStringType(elemType) && !typeutil.IsTimestamptzType(elemType) {
-			return errors.New(fmt.Sprintf("STL_SORT are only supported on numeric, varchar or timestamptz field, got struct sub-field of %s", field.GetElementType()))
+			return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("STL_SORT are only supported on numeric, varchar or timestamptz field, got struct sub-field of %s", field.GetElementType()))
 		}
 		return nil
 	}
@@ -48,7 +47,7 @@ func (c *STLSORTChecker) CheckValidDataType(indexType IndexType, field *schemapb
 		return nil
 	}
 	if !typeutil.IsArithmetic(dataType) && !typeutil.IsStringType(dataType) && !typeutil.IsTimestamptzType(dataType) {
-		return errors.New(fmt.Sprintf("STL_SORT are only supported on numeric, varchar or timestamptz field, got %s", field.GetDataType()))
+		return merr.WrapErrParameterInvalidMsg(fmt.Sprintf("STL_SORT are only supported on numeric, varchar or timestamptz field, got %s", field.GetDataType()))
 	}
 	return nil
 }

--- a/internal/util/indexparamcheck/trie_checker.go
+++ b/internal/util/indexparamcheck/trie_checker.go
@@ -1,9 +1,8 @@
 package indexparamcheck
 
 import (
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -18,7 +17,7 @@ func (c *TRIEChecker) CheckTrain(dataType schemapb.DataType, elementType schemap
 
 func (c *TRIEChecker) CheckValidDataType(indexType IndexType, field *schemapb.FieldSchema) error {
 	if !typeutil.IsStringType(field.GetDataType()) {
-		return errors.New("TRIE are only supported on varchar field")
+		return merr.WrapErrParameterInvalidMsg("TRIE are only supported on varchar field")
 	}
 	return nil
 }

--- a/internal/util/indexparamcheck/utils.go
+++ b/internal/util/indexparamcheck/utils.go
@@ -23,6 +23,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -63,7 +64,7 @@ func CheckStrByValues(params map[string]string, key string, container []string) 
 }
 
 func errOutOfRange(x interface{}, lb interface{}, ub interface{}) error {
-	return fmt.Errorf("%v out of range: [%v, %v]", x, lb, ub)
+	return merr.WrapErrParameterInvalidMsg("%v out of range: [%v, %v]", x, lb, ub)
 }
 
 func setDefaultIfNotExist(params map[string]string, key string, defaultValue string) {

--- a/internal/util/indexparamcheck/vector_index_checker.go
+++ b/internal/util/indexparamcheck/vector_index_checker.go
@@ -9,11 +9,9 @@ package indexparamcheck
 import "C"
 
 import (
-	"fmt"
 	"math"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -22,6 +20,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexcgopb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -38,17 +37,17 @@ func HandleCStatus(status *C.CStatus) error {
 	errorMsg := C.GoString(status.error_msg)
 	defer C.free(unsafe.Pointer(status.error_msg))
 
-	return fmt.Errorf("%s", errorMsg)
+	return merr.WrapErrParameterInvalidMsg("%s", errorMsg)
 }
 
 func (c vecIndexChecker) StaticCheck(dataType schemapb.DataType, elementType schemapb.DataType, params map[string]string) error {
 	if typeutil.IsDenseFloatVectorType(dataType) {
 		if !CheckStrByValues(params, Metric, FloatVectorMetrics) {
-			return fmt.Errorf("metric type %s not found or not supported, supported: %v", params[Metric], FloatVectorMetrics)
+			return merr.WrapErrParameterInvalidMsg("metric type %s not found or not supported, supported: %v", params[Metric], FloatVectorMetrics)
 		}
 	} else if typeutil.IsSparseFloatVectorType(dataType) {
 		if !CheckStrByValues(params, Metric, SparseMetrics) {
-			return fmt.Errorf("metric type not found or not supported, supported: %v", SparseMetrics)
+			return merr.WrapErrParameterInvalidMsg("metric type not found or not supported, supported: %v", SparseMetrics)
 		}
 		// Validate inverted_index_algo if provided. This check is done in Go because
 		// the C++ knowhere library no longer validates this parameter (removed in knowhere fd532fb).
@@ -61,33 +60,33 @@ func (c vecIndexChecker) StaticCheck(dataType schemapb.DataType, elementType sch
 				}
 			}
 			if !validAlgo {
-				return fmt.Errorf("sparse inverted index algo %s not found or not supported, supported: %v", algo, SparseInvertedIndexAlgos)
+				return merr.WrapErrParameterInvalidMsg("sparse inverted index algo %s not found or not supported, supported: %v", algo, SparseInvertedIndexAlgos)
 			}
 		}
 	} else if typeutil.IsBinaryVectorType(dataType) {
 		if !CheckStrByValues(params, Metric, BinaryVectorMetrics) {
-			return fmt.Errorf("metric type %s not found or not supported, supported: %v", params[Metric], BinaryVectorMetrics)
+			return merr.WrapErrParameterInvalidMsg("metric type %s not found or not supported, supported: %v", params[Metric], BinaryVectorMetrics)
 		}
 	} else if typeutil.IsIntVectorType(dataType) {
 		if !CheckStrByValues(params, Metric, IntVectorMetrics) {
-			return fmt.Errorf("metric type %s not found or not supported, supported: %v", params[Metric], IntVectorMetrics)
+			return merr.WrapErrParameterInvalidMsg("metric type %s not found or not supported, supported: %v", params[Metric], IntVectorMetrics)
 		}
 	} else if typeutil.IsArrayOfVectorType(dataType) {
 		if !CheckStrByValues(params, Metric, EmbListMetrics) {
 			if typeutil.IsDenseFloatVectorType(elementType) {
 				if !CheckStrByValues(params, Metric, FloatVectorMetrics) {
-					return fmt.Errorf("metric type %s not found or not supported for array of vector with float element type, supported: %v", params[Metric], FloatVectorMetrics)
+					return merr.WrapErrParameterInvalidMsg("metric type %s not found or not supported for array of vector with float element type, supported: %v", params[Metric], FloatVectorMetrics)
 				}
 			} else if typeutil.IsBinaryVectorType(elementType) {
 				if !CheckStrByValues(params, Metric, BinaryVectorMetrics) {
-					return fmt.Errorf("metric type %s not found or not supported for array of vector with binary element type, supported: %v", params[Metric], BinaryVectorMetrics)
+					return merr.WrapErrParameterInvalidMsg("metric type %s not found or not supported for array of vector with binary element type, supported: %v", params[Metric], BinaryVectorMetrics)
 				}
 			} else if typeutil.IsIntVectorType(elementType) {
 				if !CheckStrByValues(params, Metric, IntVectorMetrics) {
-					return fmt.Errorf("metric type %s not found or not supported for array of vector with int element type, supported: %v", params[Metric], IntVectorMetrics)
+					return merr.WrapErrParameterInvalidMsg("metric type %s not found or not supported for array of vector with int element type, supported: %v", params[Metric], IntVectorMetrics)
 				}
 			} else {
-				return fmt.Errorf("metric type %s not found or not supported for array of vector, supported: %v", params[Metric], EmbListMetrics)
+				return merr.WrapErrParameterInvalidMsg("metric type %s not found or not supported for array of vector, supported: %v", params[Metric], EmbListMetrics)
 			}
 		}
 	}
@@ -95,11 +94,11 @@ func (c vecIndexChecker) StaticCheck(dataType schemapb.DataType, elementType sch
 	indexType, exist := params[common.IndexTypeKey]
 
 	if !exist {
-		return errors.New("no indexType is specified")
+		return merr.WrapErrParameterInvalidMsg("no indexType is specified")
 	}
 
 	if !vecindexmgr.GetVecIndexMgrInstance().IsVecIndex(indexType) {
-		return fmt.Errorf("indexType %s is not supported", indexType)
+		return merr.WrapErrParameterInvalidMsg("indexType %s is not supported", indexType)
 	}
 
 	protoIndexParams := &indexcgopb.IndexParams{
@@ -112,7 +111,7 @@ func (c vecIndexChecker) StaticCheck(dataType schemapb.DataType, elementType sch
 
 	indexParamsBlob, err := proto.Marshal(protoIndexParams)
 	if err != nil {
-		return fmt.Errorf("failed to marshal index params: %s", err)
+		return merr.WrapErrParameterInvalidMsg("failed to marshal index params: %s", err)
 	}
 
 	var status C.CStatus
@@ -133,7 +132,7 @@ func (c vecIndexChecker) CheckTrain(dataType schemapb.DataType, elementType sche
 
 	if typeutil.IsFixDimVectorType(dataType) || (typeutil.IsArrayOfVectorType(dataType) && typeutil.IsFixDimVectorType(elementType)) {
 		if !CheckIntByRange(params, DIM, 1, math.MaxInt) {
-			return errors.New("failed to check vector dimension, should be larger than 0 and smaller than math.MaxInt")
+			return merr.WrapErrParameterInvalidMsg("failed to check vector dimension, should be larger than 0 and smaller than math.MaxInt")
 		}
 	}
 
@@ -142,10 +141,10 @@ func (c vecIndexChecker) CheckTrain(dataType schemapb.DataType, elementType sche
 
 func (c vecIndexChecker) CheckValidDataType(indexType IndexType, field *schemapb.FieldSchema) error {
 	if !typeutil.IsVectorType(field.GetDataType()) {
-		return fmt.Errorf("index %s only supports vector data type", indexType)
+		return merr.WrapErrParameterInvalidMsg("index %s only supports vector data type", indexType)
 	}
 	if !vecindexmgr.GetVecIndexMgrInstance().IsDataTypeSupport(indexType, field.GetDataType(), field.GetElementType()) {
-		return fmt.Errorf("index %s do not support data type: %s", indexType, schemapb.DataType_name[int32(field.GetDataType())])
+		return merr.WrapErrParameterInvalidMsg("index %s do not support data type: %s", indexType, schemapb.DataType_name[int32(field.GetDataType())])
 	}
 	return nil
 }

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -38,7 +38,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -47,6 +46,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/pathutil"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -317,7 +317,7 @@ func ConvertCacheWarmupPolicy(policy string) (C.CacheWarmupPolicy, error) {
 	case "disable":
 		return C.CacheWarmupPolicy_Disable, nil
 	default:
-		return C.CacheWarmupPolicy_Disable, fmt.Errorf("invalid Tiered Storage cache warmup policy: %s", policy)
+		return C.CacheWarmupPolicy_Disable, merr.WrapErrParameterInvalidMsg("invalid Tiered Storage cache warmup policy: %s", policy)
 	}
 }
 
@@ -360,23 +360,23 @@ func InitTieredStorage(params *paramtable.ComponentParam) error {
 	diskMaxRatio := params.QueryNodeCfg.MaxDiskUsagePercentage.GetAsFloat()
 
 	if memoryLowWatermarkRatio > memoryHighWatermarkRatio {
-		return errors.New("memoryLowWatermarkRatio should not be greater than memoryHighWatermarkRatio")
+		return merr.WrapErrParameterInvalidMsg("memoryLowWatermarkRatio should not be greater than memoryHighWatermarkRatio")
 	}
 	if memoryHighWatermarkRatio > memoryMaxRatio {
-		return errors.New("memoryHighWatermarkRatio should not be greater than memoryMaxRatio")
+		return merr.WrapErrParameterInvalidMsg("memoryHighWatermarkRatio should not be greater than memoryMaxRatio")
 	}
 	if memoryMaxRatio >= 1 {
-		return errors.New("memoryMaxRatio should not be greater than 1")
+		return merr.WrapErrParameterInvalidMsg("memoryMaxRatio should not be greater than 1")
 	}
 
 	if diskLowWatermarkRatio > diskHighWatermarkRatio {
-		return errors.New("diskLowWatermarkRatio should not be greater than diskHighWatermarkRatio")
+		return merr.WrapErrParameterInvalidMsg("diskLowWatermarkRatio should not be greater than diskHighWatermarkRatio")
 	}
 	if diskHighWatermarkRatio > diskMaxRatio {
-		return errors.New("diskHighWatermarkRatio should not be greater than diskMaxRatio")
+		return merr.WrapErrParameterInvalidMsg("diskHighWatermarkRatio should not be greater than diskMaxRatio")
 	}
 	if diskMaxRatio >= 1 {
-		return errors.New("diskMaxRatio should not be greater than 1")
+		return merr.WrapErrParameterInvalidMsg("diskMaxRatio should not be greater than 1")
 	}
 
 	memoryLowWatermarkBytes := C.int64_t(memoryLowWatermarkRatio * float64(osMemBytes))
@@ -759,7 +759,7 @@ func HandleCStatus(status *C.CStatus, extraInfo string) error {
 	finalMsg := fmt.Sprintf("[%s] %s", errorName, errorMsg)
 	logMsg := fmt.Sprintf("%s, C Runtime Exception: %s\n", extraInfo, finalMsg)
 	log.Warn(logMsg)
-	return errors.New(finalMsg)
+	return merr.WrapErrParameterInvalidMsg(finalMsg)
 }
 
 // tlsMinVersionForStorage converts minio config's TLS min version value

--- a/internal/util/mock/grpcclient.go
+++ b/internal/util/mock/grpcclient.go
@@ -19,7 +19,6 @@ package mock
 import (
 	"context"
 	"crypto/x509"
-	"fmt"
 	"sync"
 
 	"go.uber.org/zap"
@@ -30,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/tracer"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/generic"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 )
 
@@ -142,7 +142,7 @@ func (c *GRPCClientBase[T]) ReCall(ctx context.Context, caller func(client T) (a
 		return ret, nil
 	}
 
-	traceErr := fmt.Errorf("err: %s\n, %s", err.Error(), tracer.StackTrace())
+	traceErr := merr.WrapErrParameterInvalidMsg("err: %s\n, %s", err.Error(), tracer.StackTrace())
 	log.Warn("GRPCClientBase[T] client grpc first call get error ", zap.Error(traceErr))
 
 	if !funcutil.CheckCtxValid(ctx) {
@@ -151,7 +151,7 @@ func (c *GRPCClientBase[T]) ReCall(ctx context.Context, caller func(client T) (a
 
 	ret, err = c.callOnce(ctx, caller)
 	if err != nil {
-		traceErr = fmt.Errorf("err: %s\n, %s", err.Error(), tracer.StackTrace())
+		traceErr = merr.WrapErrParameterInvalidMsg("err: %s\n, %s", err.Error(), tracer.StackTrace())
 		log.Error("GRPCClientBase[T] client grpc second call get error ", zap.Error(traceErr))
 		return nil, traceErr
 	}

--- a/internal/util/pipeline/errors.go
+++ b/internal/util/pipeline/errors.go
@@ -17,8 +17,6 @@
 package pipeline
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/errors"
 )
 
@@ -29,5 +27,5 @@ var (
 )
 
 func WrapErrRegDispather(err error) error {
-	return fmt.Errorf("%w :%s", ErrRegisterDispather, err)
+	return errors.Mark(err, ErrRegisterDispather)
 }

--- a/internal/util/proxyutil/proxy_client_manager.go
+++ b/internal/util/proxyutil/proxy_client_manager.go
@@ -18,7 +18,6 @@ package proxyutil
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/cockroachdb/errors"
@@ -214,10 +213,10 @@ func (p *ProxyClientManager) InvalidateCollectionMetaCache(ctx context.Context, 
 					return nil
 				}
 
-				return fmt.Errorf("InvalidateCollectionMetaCache failed, proxyID = %d, err = %s", k, err)
+				return merr.Wrapf(err, "InvalidateCollectionMetaCache failed, proxyID = %d", k)
 			}
 			if sta.ErrorCode != commonpb.ErrorCode_Success {
-				return fmt.Errorf("InvalidateCollectionMetaCache failed, proxyID = %d, err = %s", k, sta.Reason)
+				return merr.Wrapf(merr.Error(sta), "InvalidateCollectionMetaCache failed, proxyID = %d", k)
 			}
 			return nil
 		})
@@ -239,10 +238,10 @@ func (p *ProxyClientManager) InvalidateCredentialCache(ctx context.Context, requ
 		group.Go(func() error {
 			sta, err := v.InvalidateCredentialCache(ctx, request)
 			if err != nil {
-				return fmt.Errorf("InvalidateCredentialCache failed, proxyID = %d, err = %s", k, err)
+				return merr.Wrapf(err, "InvalidateCredentialCache failed, proxyID = %d", k)
 			}
 			if sta.ErrorCode != commonpb.ErrorCode_Success {
-				return fmt.Errorf("InvalidateCredentialCache failed, proxyID = %d, err = %s", k, sta.Reason)
+				return merr.Wrapf(merr.Error(sta), "InvalidateCredentialCache failed, proxyID = %d", k)
 			}
 			return nil
 		})
@@ -265,10 +264,10 @@ func (p *ProxyClientManager) UpdateCredentialCache(ctx context.Context, request 
 		group.Go(func() error {
 			sta, err := v.UpdateCredentialCache(ctx, request)
 			if err != nil {
-				return fmt.Errorf("UpdateCredentialCache failed, proxyID = %d, err = %s", k, err)
+				return merr.Wrapf(err, "UpdateCredentialCache failed, proxyID = %d", k)
 			}
 			if sta.ErrorCode != commonpb.ErrorCode_Success {
-				return fmt.Errorf("UpdateCredentialCache failed, proxyID = %d, err = %s", k, sta.Reason)
+				return merr.Wrapf(merr.Error(sta), "UpdateCredentialCache failed, proxyID = %d", k)
 			}
 			return nil
 		})
@@ -290,7 +289,7 @@ func (p *ProxyClientManager) RefreshPolicyInfoCache(ctx context.Context, req *pr
 		group.Go(func() error {
 			status, err := v.RefreshPolicyInfoCache(ctx, req)
 			if err != nil {
-				return fmt.Errorf("RefreshPolicyInfoCache failed, proxyID = %d, err = %s", k, err)
+				return merr.Wrapf(err, "RefreshPolicyInfoCache failed, proxyID = %d", k)
 			}
 			if status.GetErrorCode() != commonpb.ErrorCode_Success {
 				return merr.Error(status)
@@ -322,10 +321,10 @@ func (p *ProxyClientManager) GetProxyMetrics(ctx context.Context) ([]*milvuspb.G
 		group.Go(func() error {
 			rsp, err := v.GetProxyMetrics(ctx, req)
 			if err != nil {
-				return fmt.Errorf("GetMetrics failed, proxyID = %d, err = %s", k, err)
+				return merr.Wrapf(err, "GetMetrics failed, proxyID = %d", k)
 			}
 			if rsp.GetStatus().GetErrorCode() != commonpb.ErrorCode_Success {
-				return fmt.Errorf("GetMetrics failed, proxyID = %d, err = %s", k, rsp.GetStatus().GetReason())
+				return merr.Wrapf(merr.Error(rsp.GetStatus()), "GetMetrics failed, proxyID = %d", k)
 			}
 			metricRspsMu.Lock()
 			metricRsps = append(metricRsps, rsp)
@@ -354,10 +353,10 @@ func (p *ProxyClientManager) SetRates(ctx context.Context, request *proxypb.SetR
 		group.Go(func() error {
 			sta, err := v.SetRates(ctx, request)
 			if err != nil {
-				return fmt.Errorf("SetRates failed, proxyID = %d, err = %s", k, err)
+				return merr.Wrapf(err, "SetRates failed, proxyID = %d", k)
 			}
 			if sta.GetErrorCode() != commonpb.ErrorCode_Success {
-				return fmt.Errorf("SetRates failed, proxyID = %d, err = %s", k, sta.Reason)
+				return merr.Wrapf(merr.Error(sta), "SetRates failed, proxyID = %d", k)
 			}
 			return nil
 		})
@@ -406,10 +405,10 @@ func (p *ProxyClientManager) InvalidateShardLeaderCache(ctx context.Context, req
 					log.Warn("InvalidateShardLeaderCache failed due to proxy service not found", zap.Error(err))
 					return nil
 				}
-				return fmt.Errorf("InvalidateShardLeaderCache failed, proxyID = %d, err = %s", k, err)
+				return merr.Wrapf(err, "InvalidateShardLeaderCache failed, proxyID = %d", k)
 			}
 			if sta.ErrorCode != commonpb.ErrorCode_Success {
-				return fmt.Errorf("InvalidateShardLeaderCache failed, proxyID = %d, err = %s", k, sta.Reason)
+				return merr.Wrapf(merr.Error(sta), "InvalidateShardLeaderCache failed, proxyID = %d", k)
 			}
 			return nil
 		})

--- a/internal/util/proxyutil/proxy_watcher.go
+++ b/internal/util/proxyutil/proxy_watcher.go
@@ -18,7 +18,6 @@ package proxyutil
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"sync"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util/lifetime"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -202,7 +202,7 @@ func (p *ProxyWatcher) getSessionsOnEtcd(ctx context.Context) ([]*sessionutil.Se
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
 	)
 	if err != nil {
-		return nil, 0, fmt.Errorf("proxy manager failed to watch proxy with error %w", err)
+		return nil, 0, merr.Wrapf(err, "proxy manager failed to watch proxy")
 	}
 
 	var sessions []*sessionutil.Session

--- a/internal/util/queryutil/dedup_pk_op.go
+++ b/internal/util/queryutil/dedup_pk_op.go
@@ -18,13 +18,13 @@ package queryutil
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -125,7 +125,7 @@ func (op *DeduplicatePKOperator) Run(ctx context.Context, span trace.Span, input
 			}
 
 			if op.maxOutputSize > 0 && retSize > op.maxOutputSize {
-				return nil, fmt.Errorf("query results exceed the maxOutputSize Limit %d", op.maxOutputSize)
+				return nil, merr.WrapErrParameterInvalidMsg("query results exceed the maxOutputSize Limit %d", op.maxOutputSize)
 			}
 		}
 	}
@@ -216,7 +216,7 @@ func (op *ConcatAndCheckPKOperator) Run(ctx context.Context, span trace.Span, in
 		for j := int64(0); j < int64(idCount); j++ {
 			pk := typeutil.GetPK(r.GetIds(), j)
 			if _, exists := seenPKs[pk]; exists {
-				return nil, fmt.Errorf("duplicate PK %v found across shards, possible data integrity issue", pk)
+				return nil, merr.WrapErrParameterInvalidMsg("duplicate PK %v found across shards, possible data integrity issue", pk)
 			}
 			seenPKs[pk] = struct{}{}
 			selectedRows = append(selectedRows, rowRef{resultIdx: i, rowIdx: j})

--- a/internal/util/queryutil/helpers.go
+++ b/internal/util/queryutil/helpers.go
@@ -17,12 +17,11 @@
 package queryutil
 
 import (
-	"fmt"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -73,7 +72,7 @@ func buildMergedRetrieveResults(results []*internalpb.RetrieveResults, selectedR
 	for _, ref := range selectedRows {
 		refFields := len(results[ref.resultIdx].GetFieldsData())
 		if refFields != numFields {
-			return nil, fmt.Errorf(
+			return nil, merr.WrapErrParameterInvalidMsg(
 				"FieldsData count mismatch: result[%d] has %d fields, expected %d",
 				ref.resultIdx, refFields, numFields)
 		}
@@ -147,7 +146,7 @@ func validateElementLevelConsistency(results []*internalpb.RetrieveResults, _ []
 
 	for i, r := range results {
 		if r.GetElementLevel() != isElementLevel {
-			return fmt.Errorf(
+			return merr.WrapErrParameterInvalidMsg(
 				"inconsistent element-level flag: result[%d] has ElementLevel=%v, expected %v",
 				i, r.GetElementLevel(), isElementLevel)
 		}
@@ -155,7 +154,7 @@ func validateElementLevelConsistency(results []*internalpb.RetrieveResults, _ []
 			idsLen := typeutil.GetSizeOfIDs(r.GetIds())
 			indicesLen := len(r.GetElementIndices())
 			if indicesLen != idsLen {
-				return fmt.Errorf(
+				return merr.WrapErrParameterInvalidMsg(
 					"element_indices length (%d) does not match ids length (%d) in result[%d]",
 					indicesLen, idsLen, i)
 			}
@@ -428,14 +427,14 @@ func buildCompactIndices(results []*internalpb.RetrieveResults, fieldIdx int, is
 		// but that path is unreachable for merge inputs (HasRawData gate + empty IDs filtering).
 		// Therefore empty ValidData here is always a segcore bug, not a legitimate state.
 		if len(vd) == 0 {
-			return nil, fmt.Errorf(
+			return nil, merr.WrapErrParameterInvalidMsg(
 				"buildCompactIndices: nullable vector field fid=%d name=%q has empty ValidData but numRows=%d in result[%d]; "+
 					"segcore must always provide ValidData for nullable fields with rows",
 				fd.GetFieldId(), fd.GetFieldName(), numRows, ri)
 		}
 
 		if len(vd) != numRows {
-			return nil, fmt.Errorf(
+			return nil, merr.WrapErrParameterInvalidMsg(
 				"buildCompactIndices: nullable vector field fid=%d name=%q has len(ValidData)=%d but numRows=%d in result[%d]; "+
 					"segcore violated the nullable contract (len(ValidData) must equal numRows)",
 				fd.GetFieldId(), fd.GetFieldName(), len(vd), numRows, ri)
@@ -449,7 +448,7 @@ func buildCompactIndices(results []*internalpb.RetrieveResults, fieldIdx int, is
 
 func arrayOfVectorRowValid(fd *schemapb.FieldData, rowIdx int64, isNullable bool, numRows int, resultIdx int) (bool, error) {
 	if rowIdx < 0 {
-		return false, fmt.Errorf(
+		return false, merr.WrapErrParameterInvalidMsg(
 			"arrayOfVectorRowValid: field fid=%d name=%q in result[%d] has invalid rowIdx=%d",
 			fd.GetFieldId(), fd.GetFieldName(), resultIdx, rowIdx)
 	}
@@ -457,7 +456,7 @@ func arrayOfVectorRowValid(fd *schemapb.FieldData, rowIdx int64, isNullable bool
 	validData := fd.GetValidData()
 	if len(validData) == 0 {
 		if isNullable {
-			return false, fmt.Errorf(
+			return false, merr.WrapErrParameterInvalidMsg(
 				"arrayOfVectorRowValid: nullable ArrayOfVector field fid=%d name=%q has empty ValidData but numRows=%d in result[%d]; "+
 					"segcore must always provide ValidData for nullable fields with rows",
 				fd.GetFieldId(), fd.GetFieldName(), numRows, resultIdx)
@@ -466,12 +465,12 @@ func arrayOfVectorRowValid(fd *schemapb.FieldData, rowIdx int64, isNullable bool
 	}
 
 	if int(rowIdx) >= len(validData) {
-		return false, fmt.Errorf(
+		return false, merr.WrapErrParameterInvalidMsg(
 			"arrayOfVectorRowValid: ArrayOfVector field fid=%d name=%q in result[%d] has rowIdx=%d outside ValidData bounds len(ValidData)=%d",
 			fd.GetFieldId(), fd.GetFieldName(), resultIdx, rowIdx, len(validData))
 	}
 	if isNullable && numRows > 0 && len(validData) != numRows {
-		return false, fmt.Errorf(
+		return false, merr.WrapErrParameterInvalidMsg(
 			"arrayOfVectorRowValid: nullable ArrayOfVector field fid=%d name=%q has len(ValidData)=%d but numRows=%d in result[%d]; "+
 				"segcore violated the nullable contract (len(ValidData) must equal numRows)",
 			fd.GetFieldId(), fd.GetFieldName(), len(validData), numRows, resultIdx)
@@ -576,7 +575,7 @@ func buildMergedVectorField(results []*internalpb.RetrieveResults, selectedRows 
 	// This indicates segcore returned truncated/malformed vector data.
 	vecDataOOB := func(ref rowRef, di int, dataLen int) error {
 		fd := results[ref.resultIdx].GetFieldsData()[fieldIdx]
-		return fmt.Errorf(
+		return merr.WrapErrParameterInvalidMsg(
 			"buildMergedVectorField: vector data too short for %s field fid=%d name=%q in result[%d]: "+
 				"dataIdx=%d requires offset beyond data length %d (dim=%d, numRows=%d); segcore returned truncated data",
 			dataType, fd.GetFieldId(), fd.GetFieldName(), ref.resultIdx,
@@ -679,7 +678,7 @@ func buildMergedVectorField(results []*internalpb.RetrieveResults, selectedRows 
 			sparse := results[ref.resultIdx].GetFieldsData()[fieldIdx].GetVectors().GetSparseFloatVector()
 			if sparse == nil || di >= len(sparse.GetContents()) {
 				fd := results[ref.resultIdx].GetFieldsData()[fieldIdx]
-				return nil, fmt.Errorf(
+				return nil, merr.WrapErrParameterInvalidMsg(
 					"buildMergedVectorField: sparse vector data missing for field fid=%d name=%q in result[%d]: "+
 						"dataIdx=%d but SparseFloatArray is nil or has only %d contents (numRows=%d); segcore returned truncated data",
 					fd.GetFieldId(), fd.GetFieldName(), ref.resultIdx,
@@ -740,14 +739,14 @@ func buildMergedVectorField(results []*internalpb.RetrieveResults, selectedRows 
 			}
 			va := fd.GetVectors().GetVectorArray()
 			if va == nil || len(va.GetData()) == 0 {
-				return nil, fmt.Errorf(
+				return nil, merr.WrapErrParameterInvalidMsg(
 					"buildMergedVectorField: VectorArray data missing for field fid=%d name=%q in result[%d]: "+
 						"dataIdx=%d but VectorArray is nil or has no entries (numRows=%d); segcore returned truncated data",
 					fd.GetFieldId(), fd.GetFieldName(), ref.resultIdx,
 					di, typeutil.GetSizeOfIDs(results[ref.resultIdx].GetIds()))
 			}
 			if di >= len(va.GetData()) {
-				return nil, fmt.Errorf(
+				return nil, merr.WrapErrParameterInvalidMsg(
 					"buildMergedVectorField: VectorArray data missing for field fid=%d name=%q in result[%d]: "+
 						"dataIdx=%d but VectorArray is nil or has only %d entries (numRows=%d); segcore returned truncated data",
 					fd.GetFieldId(), fd.GetFieldName(), ref.resultIdx,

--- a/internal/util/queryutil/order_op.go
+++ b/internal/util/queryutil/order_op.go
@@ -19,7 +19,6 @@ package queryutil
 import (
 	"container/heap"
 	"context"
-	"fmt"
 	"sort"
 
 	"go.opentelemetry.io/otel"
@@ -28,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/reduce/orderby"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -96,7 +96,7 @@ func (op *OrderByLimitOperator) Run(ctx context.Context, span trace.Span, inputs
 				}
 			}
 			if op.fieldPositions[i] < 0 {
-				return nil, fmt.Errorf("ORDER BY field '%s' (ID=%d) not found in result FieldsData", f.FieldName, f.FieldID)
+				return nil, merr.WrapErrParameterInvalidMsg("ORDER BY field '%s' (ID=%d) not found in result FieldsData", f.FieldName, f.FieldID)
 			}
 		}
 	}

--- a/internal/util/queryutil/pipeline.go
+++ b/internal/util/queryutil/pipeline.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -71,7 +72,7 @@ func (n *Node) unpackInputs(msg OpMsg) ([]any, error) {
 	for i, input := range n.inputs {
 		val, ok := msg[input]
 		if !ok {
-			return nil, fmt.Errorf("node [%s]: input channel '%s' not found", n.name, input)
+			return nil, merr.WrapErrParameterInvalidMsg("node [%s]: input channel '%s' not found", n.name, input)
 		}
 		inputs[i] = val
 	}
@@ -81,7 +82,7 @@ func (n *Node) unpackInputs(msg OpMsg) ([]any, error) {
 // packOutputs stores output values into the message by channel names.
 func (n *Node) packOutputs(outputs []any, msg OpMsg) error {
 	if len(outputs) != len(n.outputs) {
-		return fmt.Errorf("node [%s]: output count mismatch, expected %d, got %d",
+		return merr.WrapErrParameterInvalidMsg("node [%s]: output count mismatch, expected %d, got %d",
 			n.name, len(n.outputs), len(outputs))
 	}
 	for i, output := range n.outputs {
@@ -99,7 +100,7 @@ func (n *Node) Run(ctx context.Context, span trace.Span, msg OpMsg) error {
 
 	outputs, err := n.op.Run(ctx, span, inputs...)
 	if err != nil {
-		return fmt.Errorf("node [%s] operator failed: %w", n.name, err)
+		return merr.Wrapf(err, "node [%s] operator failed", n.name)
 	}
 
 	return n.packOutputs(outputs, msg)
@@ -144,7 +145,7 @@ func (p *Pipeline) Run(ctx context.Context, span trace.Span, initialMsg OpMsg) (
 
 	for _, node := range p.nodes {
 		if err := node.Run(ctx, span, msg); err != nil {
-			return nil, fmt.Errorf("pipeline [%s]: %w", p.name, err)
+			return nil, merr.Wrapf(err, "pipeline [%s]", p.name)
 		}
 	}
 

--- a/internal/util/queryutil/pipeline_builders.go
+++ b/internal/util/queryutil/pipeline_builders.go
@@ -17,12 +17,11 @@
 package queryutil
 
 import (
-	"fmt"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/reduce"
 	"github.com/milvus-io/milvus/internal/util/reduce/orderby"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // BuildQueryReducePipeline builds a pipeline for QN/Delegator query reduction.
@@ -129,7 +128,7 @@ func ComputeGroupByOrderPositions(
 			}
 		}
 		if !found {
-			return nil, fmt.Errorf("ORDER BY field '%s' (ID=%d) not found in GROUP BY columns or aggregates", obf.FieldName, obf.FieldID)
+			return nil, merr.WrapErrParameterInvalidMsg("ORDER BY field '%s' (ID=%d) not found in GROUP BY columns or aggregates", obf.FieldName, obf.FieldID)
 		}
 	}
 	return positions, nil

--- a/internal/util/queryutil/reduce_by_pk_op.go
+++ b/internal/util/queryutil/reduce_by_pk_op.go
@@ -18,7 +18,6 @@ package queryutil
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -26,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/reduce"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -123,7 +123,7 @@ func (op *ReduceByPKOperator) mergeByPK(results []*internalpb.RetrieveResults, h
 			seenPKs[pk] = struct{}{}
 			selectedRows = append(selectedRows, rowRef{resultIdx: sel, rowIdx: cursors[sel]})
 		} else {
-			return nil, fmt.Errorf("duplicate PK %v found across shards, possible data integrity issue", pk)
+			return nil, merr.WrapErrParameterInvalidMsg("duplicate PK %v found across shards, possible data integrity issue", pk)
 		}
 		cursors[sel]++
 	}
@@ -294,7 +294,7 @@ func (op *ReduceByPKWithTimestampOperator) mergeByPKWithTimestamp(results []*tim
 		}
 
 		if op.maxOutputSize > 0 && retSize > op.maxOutputSize {
-			return nil, fmt.Errorf("query results exceed the maxOutputSize Limit %d", op.maxOutputSize)
+			return nil, merr.WrapErrParameterInvalidMsg("query results exceed the maxOutputSize Limit %d", op.maxOutputSize)
 		}
 
 		// Early termination when limit reached

--- a/internal/util/queryutil/remap_op.go
+++ b/internal/util/queryutil/remap_op.go
@@ -18,12 +18,12 @@ package queryutil
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // RemapOperator reorders FieldsData by pre-computed positional indices.
@@ -58,7 +58,7 @@ func (op *RemapOperator) Run(_ context.Context, _ trace.Span, inputs ...any) ([]
 	newFieldsData := make([]*schemapb.FieldData, 0, len(op.outputIndices))
 	for _, pos := range op.outputIndices {
 		if pos < 0 || pos >= len(fieldsData) {
-			return nil, fmt.Errorf("RemapOperator: output index %d out of range [0, %d)", pos, len(fieldsData))
+			return nil, merr.WrapErrParameterInvalidMsg("RemapOperator: output index %d out of range [0, %d)", pos, len(fieldsData))
 		}
 		newFieldsData = append(newFieldsData, fieldsData[pos])
 	}

--- a/internal/util/reduce/field_data.go
+++ b/internal/util/reduce/field_data.go
@@ -1,9 +1,8 @@
 package reduce
 
 import (
-	"fmt"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -39,7 +38,7 @@ func ValidateGroupByFieldsPresent(searchResultData []*schemapb.SearchResultData,
 		}
 		for _, fieldID := range fieldIDs {
 			if FindGroupByFieldData(data, fieldID, allowSingularFallback) == nil {
-				return fmt.Errorf("group-by field %d missing from search result %d", fieldID, resultIdx)
+				return merr.WrapErrParameterInvalidMsg("group-by field %d missing from search result %d", fieldID, resultIdx)
 			}
 		}
 	}
@@ -85,7 +84,7 @@ func WriteGroupByFieldValues(
 			}
 		}
 		if template == nil {
-			return fmt.Errorf("group-by field %d missing from all source shards", fid)
+			return merr.WrapErrParameterInvalidMsg("group-by field %d missing from all source shards", fid)
 		}
 
 		builder, err := typeutil.NewFieldDataBuilder(template.GetType(), true, len(acceptedRows))
@@ -95,7 +94,7 @@ func WriteGroupByFieldValues(
 		for _, row := range acceptedRows {
 			iter := iters[row.ResultIdx]
 			if iter == nil {
-				return fmt.Errorf("group-by field %d missing at source shard index %d", fid, row.ResultIdx)
+				return merr.WrapErrParameterInvalidMsg("group-by field %d missing at source shard index %d", fid, row.ResultIdx)
 			}
 			builder.Add(iter(int(row.RowIdx)))
 		}

--- a/internal/util/reduce/orderby/types.go
+++ b/internal/util/reduce/orderby/types.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // OrderByField defines a single sort key for ORDER BY operations.
@@ -134,7 +135,7 @@ func ParseOrderByFields(orderByStrs []string, schema *schemapb.CollectionSchema)
 			case "asc", "ascending", "":
 				ascending = true
 			default:
-				return nil, fmt.Errorf("invalid order direction '%s' for field '%s', must be 'asc' or 'desc'", dir, fieldName)
+				return nil, merr.WrapErrParameterInvalidMsg("invalid order direction '%s' for field '%s', must be 'asc' or 'desc'", dir, fieldName)
 			}
 		}
 
@@ -150,7 +151,7 @@ func ParseOrderByFields(orderByStrs []string, schema *schemapb.CollectionSchema)
 			case "nulls_last":
 				nullsFirst = false
 			default:
-				return nil, fmt.Errorf("invalid null ordering '%s', must be 'nulls_first' or 'nulls_last'", nullOpt)
+				return nil, merr.WrapErrParameterInvalidMsg("invalid null ordering '%s', must be 'nulls_first' or 'nulls_last'", nullOpt)
 			}
 		}
 
@@ -159,12 +160,12 @@ func ParseOrderByFields(orderByStrs []string, schema *schemapb.CollectionSchema)
 		// so ORDER BY on dynamic fields is not supported in the current version.
 		fieldSchema, found := fieldNameToSchema[fieldName]
 		if !found {
-			return nil, fmt.Errorf("order_by field '%s' does not exist in collection schema", fieldName)
+			return nil, merr.WrapErrParameterInvalidMsg("order_by field '%s' does not exist in collection schema", fieldName)
 		}
 
 		// Validate field type is sortable
 		if !IsSortableType(fieldSchema.DataType) {
-			return nil, fmt.Errorf("order_by field '%s' has type %s which is not sortable",
+			return nil, merr.WrapErrParameterInvalidMsg("order_by field '%s' has type %s which is not sortable",
 				fieldName, fieldSchema.DataType.String())
 		}
 
@@ -196,7 +197,7 @@ func ConvertFromPlanOrderByFields(planFields []*planpb.OrderByField, schema *sch
 	for i, pf := range planFields {
 		fs, ok := fieldIDToSchema[pf.GetFieldId()]
 		if !ok {
-			return nil, fmt.Errorf("ORDER BY field with ID %d not found in schema", pf.GetFieldId())
+			return nil, merr.WrapErrParameterInvalidMsg("ORDER BY field with ID %d not found in schema", pf.GetFieldId())
 		}
 		result[i] = &OrderByField{
 			FieldID:    pf.GetFieldId(),

--- a/internal/util/segcore/collection.go
+++ b/internal/util/segcore/collection.go
@@ -12,7 +12,6 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -35,13 +34,13 @@ type CreateCCollectionRequest struct {
 func CreateCCollection(req *CreateCCollectionRequest) (*CCollection, error) {
 	schemaBlob, err := proto.Marshal(req.Schema)
 	if err != nil {
-		return nil, errors.New("marshal schema failed")
+		return nil, merr.WrapErrSegcoreMsg("marshal schema failed")
 	}
 	var indexMetaBlob []byte
 	if req.IndexMeta != nil {
 		indexMetaBlob, err = proto.Marshal(req.IndexMeta)
 		if err != nil {
-			return nil, errors.New("marshal index meta failed")
+			return nil, merr.WrapErrSegcoreMsg("marshal index meta failed")
 		}
 	}
 	var ptr C.CCollection

--- a/internal/util/segcore/plan.go
+++ b/internal/util/segcore/plan.go
@@ -29,8 +29,6 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -49,12 +47,12 @@ func deletePlaceholderGroup(group unsafe.Pointer) {
 
 func createSearchPlanByExpr(col *CCollection, expr []byte) (*SearchPlan, error) {
 	if len(expr) == 0 {
-		return nil, errors.New("empty expression plan")
+		return nil, merr.WrapErrParameterInvalidMsg("empty expression plan")
 	}
 	var cPlan C.CSearchPlan
 	status := C.CreateSearchPlanByExpr(col.rawPointer(), unsafe.Pointer(&expr[0]), (C.int64_t)(len(expr)), &cPlan)
 	if err := ConsumeCStatusIntoError(&status); err != nil {
-		return nil, errors.Wrap(err, "Create Plan by expr failed")
+		return nil, merr.Wrap(err, "Create Plan by expr failed")
 	}
 	return &SearchPlan{cSearchPlan: cPlan}, nil
 }
@@ -104,7 +102,7 @@ func NewSearchRequest(collection *CCollection, req *querypb.SearchRequest, place
 
 	if len(placeholderGrp) == 0 {
 		plan.delete()
-		return nil, errors.New("empty search request")
+		return nil, merr.WrapErrParameterInvalidMsg("empty search request")
 	}
 
 	metricTypeInPlan := plan.GetMetricType()
@@ -117,7 +115,7 @@ func NewSearchRequest(collection *CCollection, req *querypb.SearchRequest, place
 	status := C.GetFieldID(plan.cSearchPlan, &fieldID)
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		plan.delete()
-		return nil, errors.Wrap(err, "get fieldID from plan failed")
+		return nil, merr.Wrap(err, "get fieldID from plan failed")
 	}
 
 	blobPtr := unsafe.Pointer(&placeholderGrp[0])
@@ -126,7 +124,7 @@ func NewSearchRequest(collection *CCollection, req *querypb.SearchRequest, place
 	status = C.ParsePlaceholderGroup(plan.cSearchPlan, blobPtr, blobSize, &cPlaceholderGroup)
 	if err := ConsumeCStatusIntoError(&status); err != nil {
 		plan.delete()
-		return nil, errors.Wrap(err, "parser searchRequest failed")
+		return nil, merr.Wrap(err, "parser searchRequest failed")
 	}
 
 	cl := req.GetReq().GetConsistencyLevel()
@@ -202,12 +200,12 @@ func NewRetrievePlan(col *CCollection,
 	entityTTLPhysicalTime typeutil.Timestamp,
 ) (*RetrievePlan, error) {
 	if col.rawPointer() == nil {
-		return nil, errors.New("collection is released")
+		return nil, merr.WrapErrServiceInternalMsg("collection is released")
 	}
 	var cPlan C.CRetrievePlan
 	status := C.CreateRetrievePlanByExpr(col.rawPointer(), unsafe.Pointer(&expr[0]), (C.int64_t)(len(expr)), &cPlan)
 	if err := ConsumeCStatusIntoError(&status); err != nil {
-		return nil, errors.Wrap(err, "Create retrieve plan by expr failed")
+		return nil, merr.Wrap(err, "Create retrieve plan by expr failed")
 	}
 	maxLimitSize := paramtable.Get().QuotaConfig.MaxOutputSize.GetAsInt64()
 	return &RetrievePlan{

--- a/internal/util/segcore/reduce.go
+++ b/internal/util/segcore/reduce.go
@@ -26,13 +26,11 @@ import "C"
 
 import (
 	"context"
-	"fmt"
 	"runtime"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/internal/util/cgo"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type SliceInfo struct {
@@ -85,21 +83,21 @@ func ReduceSearchResultsAndFillData(ctx context.Context, plan *SearchPlan, place
 	}
 
 	if plan.cSearchPlan == nil {
-		return nil, errors.New("nil search plan")
+		return nil, merr.WrapErrParameterInvalidMsg("nil search plan")
 	}
 
 	if len(sliceNQs) == 0 {
-		return nil, errors.New("empty slice nqs is not allowed")
+		return nil, merr.WrapErrParameterInvalidMsg("empty slice nqs is not allowed")
 	}
 
 	if len(sliceNQs) != len(sliceTopKs) {
-		return nil, fmt.Errorf("unaligned sliceNQs(len=%d) and sliceTopKs(len=%d)", len(sliceNQs), len(sliceTopKs))
+		return nil, merr.WrapErrParameterInvalidMsg("unaligned sliceNQs(len=%d) and sliceTopKs(len=%d)", len(sliceNQs), len(sliceTopKs))
 	}
 
 	cSearchResults := make([]C.CSearchResult, 0)
 	for _, res := range searchResults {
 		if res == nil {
-			return nil, errors.New("nil searchResult detected when reduceSearchResultsAndFillData")
+			return nil, merr.WrapErrSegcoreMsg("nil searchResult detected when reduceSearchResultsAndFillData")
 		}
 		cSearchResults = append(cSearchResults, res.cSearchResult)
 	}
@@ -134,7 +132,7 @@ func ReduceSearchResultsAndFillData(ctx context.Context, plan *SearchPlan, place
 	defer future.Release()
 	result, err := future.BlockAndLeakyGet()
 	if err != nil {
-		return nil, errors.Wrap(err, "ReduceSearchResultsAndFillData failed")
+		return nil, merr.Wrap(err, "ReduceSearchResultsAndFillData failed")
 	}
 	return SearchResultDataBlobs(result), nil
 }
@@ -145,7 +143,7 @@ func GetSearchResultDataBlob(ctx context.Context, cSearchResultDataBlobs SearchR
 	var scannedTotalBytes C.int64_t
 	status := C.GetSearchResultDataBlob(&blob, &scannedRemoteBytes, &scannedTotalBytes, cSearchResultDataBlobs, C.int32_t(blobIndex))
 	if err := ConsumeCStatusIntoError(&status); err != nil {
-		return nil, StorageCost{ScannedRemoteBytes: 0, ScannedTotalBytes: 0}, errors.Wrap(err, "marshal failed")
+		return nil, StorageCost{ScannedRemoteBytes: 0, ScannedTotalBytes: 0}, merr.Wrap(err, "marshal failed")
 	}
 	return getCProtoBlob(&blob), StorageCost{ScannedRemoteBytes: int64(scannedRemoteBytes), ScannedTotalBytes: int64(scannedTotalBytes)}, nil
 }

--- a/internal/util/segcore/requests.go
+++ b/internal/util/segcore/requests.go
@@ -12,14 +12,13 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -57,7 +56,7 @@ func (req *LoadFieldDataRequest) getCLoadFieldDataRequest() (result *cLoadFieldD
 	var cLoadFieldDataInfo C.CLoadFieldDataInfo
 	status := C.NewLoadFieldDataInfo(&cLoadFieldDataInfo, C.int64_t(req.StorageVersion))
 	if err := ConsumeCStatusIntoError(&status); err != nil {
-		return nil, errors.Wrap(err, "NewLoadFieldDataInfo failed")
+		return nil, merr.Wrap(err, "NewLoadFieldDataInfo failed")
 	}
 	defer func() {
 		if err != nil {
@@ -70,7 +69,7 @@ func (req *LoadFieldDataRequest) getCLoadFieldDataRequest() (result *cLoadFieldD
 		cFieldID := C.int64_t(field.Field.GetFieldID())
 		status = C.AppendLoadFieldInfo(cLoadFieldDataInfo, cFieldID, rowCount)
 		if err := ConsumeCStatusIntoError(&status); err != nil {
-			return nil, errors.Wrapf(err, "AppendLoadFieldInfo failed at fieldID, %d", field.Field.GetFieldID())
+			return nil, merr.Wrapf(err, "AppendLoadFieldInfo failed at fieldID, %d", field.Field.GetFieldID())
 		}
 		for _, binlog := range field.Field.Binlogs {
 			cEntriesNum := C.int64_t(binlog.GetEntriesNum())
@@ -80,7 +79,7 @@ func (req *LoadFieldDataRequest) getCLoadFieldDataRequest() (result *cLoadFieldD
 
 			status = C.AppendLoadFieldDataPath(cLoadFieldDataInfo, cFieldID, cEntriesNum, cMemorySize, cFile)
 			if err := ConsumeCStatusIntoError(&status); err != nil {
-				return nil, errors.Wrapf(err, "AppendLoadFieldDataPath failed at binlog, %d, %s", field.Field.GetFieldID(), binlog.GetLogPath())
+				return nil, merr.Wrapf(err, "AppendLoadFieldDataPath failed at binlog, %d, %s", field.Field.GetFieldID(), binlog.GetLogPath())
 			}
 		}
 
@@ -88,7 +87,7 @@ func (req *LoadFieldDataRequest) getCLoadFieldDataRequest() (result *cLoadFieldD
 		if len(childField) > 0 {
 			status = C.SetLoadFieldInfoChildFields(cLoadFieldDataInfo, cFieldID, (*C.int64_t)(unsafe.Pointer(&childField[0])), C.int64_t(len(childField)))
 			if err := ConsumeCStatusIntoError(&status); err != nil {
-				return nil, errors.Wrapf(err, "SetLoadFieldInfoChildFields failed at binlog, %d", field.Field.GetFieldID())
+				return nil, merr.Wrapf(err, "SetLoadFieldInfoChildFields failed at binlog, %d", field.Field.GetFieldID())
 			}
 		}
 
@@ -98,7 +97,7 @@ func (req *LoadFieldDataRequest) getCLoadFieldDataRequest() (result *cLoadFieldD
 		if len(field.WarmupPolicy) > 0 {
 			fieldWarmupPolicy, err := initcore.ConvertCacheWarmupPolicy(field.WarmupPolicy)
 			if err != nil {
-				return nil, errors.Wrapf(err, "ConvertCacheWarmupPolicy failed at field %d", field.Field.GetFieldID())
+				return nil, merr.Wrapf(err, "ConvertCacheWarmupPolicy failed at field %d", field.Field.GetFieldID())
 			}
 			C.SetFieldWarmupPolicy(cLoadFieldDataInfo, cFieldID, C.CacheWarmupPolicy(fieldWarmupPolicy))
 		}

--- a/internal/util/segcore/segment.go
+++ b/internal/util/segcore/segment.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -249,7 +248,7 @@ func (s *cSegmentImpl) Insert(ctx context.Context, request *InsertRequest) (*Ins
 
 	insertRecordBlob, err := proto.Marshal(request.Record)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal insert record: %s", err)
+		return nil, merr.Wrap(err, "failed to marshal insert record")
 	}
 
 	numOfRow := len(request.RowIDs)
@@ -291,7 +290,7 @@ func (s *cSegmentImpl) Delete(ctx context.Context, request *DeleteRequest) (*Del
 
 	dataBlob, err := proto.Marshal(ids)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal ids: %s", err)
+		return nil, merr.Wrap(err, "failed to marshal ids")
 	}
 	status := C.Delete(s.ptr,
 		cSize,
@@ -312,7 +311,7 @@ func (s *cSegmentImpl) LoadFieldData(ctx context.Context, request *LoadFieldData
 
 	status := C.LoadFieldData(s.ptr, creq.cLoadFieldDataInfo)
 	if err := ConsumeCStatusIntoError(&status); err != nil {
-		return nil, errors.Wrap(err, "failed to load field data")
+		return nil, merr.Wrap(err, "failed to load field data")
 	}
 	return &LoadFieldDataResult{}, nil
 }
@@ -365,7 +364,7 @@ func (s *cSegmentImpl) Reopen(ctx context.Context, req *ReopenRequest) error {
 func (s *cSegmentImpl) DropIndex(ctx context.Context, fieldID int64) error {
 	status := C.DropSealedSegmentIndex(s.ptr, C.int64_t(fieldID))
 	if err := ConsumeCStatusIntoError(&status); err != nil {
-		return errors.Wrap(err, "failed to drop index")
+		return merr.Wrap(err, "failed to drop index")
 	}
 	return nil
 }
@@ -373,7 +372,7 @@ func (s *cSegmentImpl) DropIndex(ctx context.Context, fieldID int64) error {
 func (s *cSegmentImpl) DropJSONIndex(ctx context.Context, fieldID int64, nestedPath string) error {
 	status := C.DropSealedSegmentJSONIndex(s.ptr, C.int64_t(fieldID), C.CString(nestedPath))
 	if err := ConsumeCStatusIntoError(&status); err != nil {
-		return errors.Wrap(err, "failed to drop json index")
+		return merr.Wrap(err, "failed to drop json index")
 	}
 	return nil
 }

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -614,7 +614,7 @@ func (s *Session) processKeepAliveResponse() {
 			newCH, err := s.etcdCli.KeepAlive(s.ctx, *s.LeaseID)
 			if err != nil {
 				s.Logger().Error("failed to keep alive with etcd", zap.Error(err))
-				lastErr = errors.Wrap(err, "failed to keep alive")
+				lastErr = merr.Wrap(err, "failed to keep alive")
 				continue
 			}
 			s.Logger().Info("keep alive...", zap.Int64("leaseID", int64(*s.LeaseID)))
@@ -652,7 +652,7 @@ func (s *Session) checkKeepaliveTTL(nextKeepaliveInstant time.Time) error {
 			log.Cleanup()
 			os.Exit(ExitCodeEtcd)
 		}
-		return errors.Wrap(err, "failed to check TTL")
+		return merr.Wrap(err, "failed to check TTL")
 	}
 	if ttlResp.TTL <= 0 {
 		s.Logger().Error("confirm the lease is expired, the session is expired without activing closing", zap.Error(err))
@@ -726,11 +726,11 @@ func (s *Session) GetSessionsWithVersionRange(prefix string, r semver.Range) (ma
 
 func (s *Session) GoingStop() error {
 	if s == nil || s.etcdCli == nil || s.LeaseID == nil {
-		return errors.New("the session hasn't been init")
+		return merr.WrapErrServiceInternalMsg("the session hasn't been init")
 	}
 
 	if s.Disconnected() {
-		return errors.New("this session has disconnected")
+		return merr.WrapErrServiceUnavailable("this session has disconnected")
 	}
 
 	completeKey := s.getCompleteKey()

--- a/internal/util/streamingutil/service/balancer/balancer.go
+++ b/internal/util/streamingutil/service/balancer/balancer.go
@@ -23,14 +23,17 @@
 package balancer
 
 import (
-	"fmt"
-
-	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/base"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/resolver"
 )
+
+// errProducedZeroAddresses is the resolver-side sentinel reported via
+// ClientConn.ResolverError when address resolution returns zero addresses.
+// Wrapped with merr so the wire code is ServiceUnavailable (transient).
+var errProducedZeroAddresses = merr.WrapErrServiceUnavailable("produced zero addresses")
 
 var (
 	_ balancer.Balancer  = (*baseBalancer)(nil)
@@ -136,7 +139,7 @@ func (b *baseBalancer) UpdateClientConnState(s balancer.ClientConnState) error {
 	// the overall state turns transient failure, the error message will have
 	// the zero address information.
 	if len(s.ResolverState.Addresses) == 0 {
-		b.ResolverError(errors.New("produced zero addresses"))
+		b.ResolverError(errProducedZeroAddresses)
 		return balancer.ErrBadResolverState
 	}
 
@@ -151,12 +154,12 @@ func (b *baseBalancer) mergeErrors() error {
 	// connErr must always be non-nil unless there are no SubConns, in which
 	// case resolverErr must be non-nil.
 	if b.connErr == nil {
-		return fmt.Errorf("last resolver error: %v", b.resolverErr)
+		return merr.Wrap(b.resolverErr, "last resolver error")
 	}
 	if b.resolverErr == nil {
-		return fmt.Errorf("last connection error: %v", b.connErr)
+		return merr.Wrap(b.connErr, "last connection error")
 	}
-	return fmt.Errorf("last connection error: %v; last resolver error: %v", b.connErr, b.resolverErr)
+	return merr.Wrapf(b.connErr, "last connection error; last resolver error: %v", b.resolverErr)
 }
 
 // regeneratePicker takes a snapshot of the balancer, and generates a picker

--- a/internal/util/streamingutil/service/contextutil/cluster_id.go
+++ b/internal/util/streamingutil/service/contextutil/cluster_id.go
@@ -3,7 +3,7 @@ package contextutil
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -18,14 +18,14 @@ func WithClusterID(ctx context.Context, clusterID string) context.Context {
 func GetClusterID(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", errors.New("cluster id not found from context")
+		return "", merr.WrapErrParameterInvalidMsg("cluster id not found from context")
 	}
 	msg := md.Get(clusterIDKey)
 	if len(msg) == 0 {
-		return "", errors.New("cluster id not found in context")
+		return "", merr.WrapErrParameterInvalidMsg("cluster id not found in context")
 	}
 	if msg[0] == "" {
-		return "", errors.New("cluster id is empty")
+		return "", merr.WrapErrParameterInvalidMsg("cluster id is empty")
 	}
 	return msg[0], nil
 }

--- a/internal/util/streamingutil/service/contextutil/create_consumer.go
+++ b/internal/util/streamingutil/service/contextutil/create_consumer.go
@@ -5,11 +5,11 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 const (
@@ -31,21 +31,21 @@ func WithCreateConsumer(ctx context.Context, req *streamingpb.CreateConsumerRequ
 func GetCreateConsumer(ctx context.Context) (*streamingpb.CreateConsumerRequest, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, errors.New("create consumer metadata not found from incoming context")
+		return nil, merr.WrapErrParameterInvalidMsg("create consumer metadata not found from incoming context")
 	}
 	msg := md.Get(createConsumerKey)
 	if len(msg) == 0 {
-		return nil, errors.New("create consumer metadata not found")
+		return nil, merr.WrapErrParameterInvalidMsg("create consumer metadata not found")
 	}
 
 	bytes, err := base64.StdEncoding.DecodeString(msg[0])
 	if err != nil {
-		return nil, errors.Wrap(err, "decode create consumer metadata failed")
+		return nil, merr.Wrap(err, "decode create consumer metadata failed")
 	}
 
 	req := &streamingpb.CreateConsumerRequest{}
 	if err := proto.Unmarshal(bytes, req); err != nil {
-		return nil, errors.Wrap(err, "unmarshal create consumer request failed")
+		return nil, merr.Wrap(err, "unmarshal create consumer request failed")
 	}
 	return req, nil
 }

--- a/internal/util/streamingutil/service/contextutil/create_producer.go
+++ b/internal/util/streamingutil/service/contextutil/create_producer.go
@@ -5,11 +5,11 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 const createProducerKey = "create-producer"
@@ -29,21 +29,21 @@ func WithCreateProducer(ctx context.Context, req *streamingpb.CreateProducerRequ
 func GetCreateProducer(ctx context.Context) (*streamingpb.CreateProducerRequest, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, errors.New("create producer metadata not found from incoming context")
+		return nil, merr.WrapErrParameterInvalidMsg("create producer metadata not found from incoming context")
 	}
 	msg := md.Get(createProducerKey)
 	if len(msg) == 0 {
-		return nil, errors.New("create consumer metadata not found")
+		return nil, merr.WrapErrParameterInvalidMsg("create consumer metadata not found")
 	}
 
 	bytes, err := base64.StdEncoding.DecodeString(msg[0])
 	if err != nil {
-		return nil, errors.Wrap(err, "decode create consumer metadata failed")
+		return nil, merr.Wrap(err, "decode create consumer metadata failed")
 	}
 
 	req := &streamingpb.CreateProducerRequest{}
 	if err := proto.Unmarshal(bytes, req); err != nil {
-		return nil, errors.Wrap(err, "unmarshal create producer request failed")
+		return nil, merr.Wrap(err, "unmarshal create producer request failed")
 	}
 	return req, nil
 }

--- a/internal/util/streamingutil/service/discoverer/session_discoverer.go
+++ b/internal/util/streamingutil/service/discoverer/session_discoverer.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/blang/semver/v4"
-	"github.com/cockroachdb/errors"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/resolver"
@@ -15,6 +14,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/attributes"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -116,11 +116,11 @@ func (sw *sessionDiscoverer) watch(ctx context.Context, cb func(VersionedState) 
 		// Watch the etcd events.
 		select {
 		case <-ctx.Done():
-			return errors.Wrap(ctx.Err(), "cancel the discovery")
+			return merr.Wrap(ctx.Err(), "cancel the discovery")
 		case event, ok := <-eventCh:
 			// Break the loop if the watch is failed.
 			if !ok {
-				return errors.New("etcd watch channel closed unexpectedly")
+				return merr.WrapErrServiceInternalMsg("etcd watch channel closed unexpectedly")
 			}
 			if err := sw.handleETCDEvent(event); err != nil {
 				return err

--- a/internal/util/streamingutil/service/resolver/builder.go
+++ b/internal/util/streamingutil/service/resolver/builder.go
@@ -3,7 +3,6 @@ package resolver
 import (
 	"time"
 
-	"github.com/cockroachdb/errors"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/resolver"
@@ -11,6 +10,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/streamingutil/service/discoverer"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -69,7 +69,7 @@ type builderImpl struct {
 // So build operation just register a new watcher into the existed resolver to share the resolver result.
 func (b *builderImpl) Build(_ resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) (resolver.Resolver, error) {
 	if !b.lifetime.Add(typeutil.LifetimeStateWorking) {
-		return nil, errors.New("builder is closed")
+		return nil, merr.WrapErrServiceInternalMsg("builder is closed")
 	}
 	defer b.lifetime.Done()
 

--- a/internal/util/streamingutil/service/resolver/watch_based_grpc_resolver.go
+++ b/internal/util/streamingutil/service/resolver/watch_based_grpc_resolver.go
@@ -1,11 +1,11 @@
 package resolver
 
 import (
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/resolver"
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -45,7 +45,7 @@ func (r *watchBasedGRPCResolver) Close() {
 // Return error if the resolver is closed.
 func (r *watchBasedGRPCResolver) Update(state VersionedState) error {
 	if !r.lifetime.Add(typeutil.LifetimeStateWorking) {
-		return errors.New("resolver is closed")
+		return merr.WrapErrServiceInternalMsg("resolver is closed")
 	}
 	defer r.lifetime.Done()
 

--- a/internal/util/streamingutil/util/wal_selector.go
+++ b/internal/util/streamingutil/util/wal_selector.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -77,19 +78,19 @@ func mustSelectWALName(standalone bool, mqType string, enable walEnable) message
 func validateWALName(standalone bool, mqType string) (message.WALName, error) {
 	mqName := message.NewWALName(mqType)
 	if mqName == message.WALNameUnknown || mqName == message.WALNameTest {
-		return mqName, errors.Errorf("mq %s is not valid", mqType)
+		return mqName, merr.WrapErrParameterInvalidMsg("mq %s is not valid", mqType)
 	}
 
 	// we may register more mq type by plugin.
 	// so we should not check all mq type here.
 	// only check standalone type.
 	if !standalone && mqName == message.WALNameRocksmq {
-		return mqName, errors.Newf("mq %s is only valid in standalone mode", mqType)
+		return mqName, merr.WrapErrParameterInvalidMsg("mq %s is only valid in standalone mode", mqType)
 	}
 	// woodpecker with local storage cannot work in cluster mode,
 	// because local storage is not shared across nodes.
 	if !standalone && mqName == message.WALNameWoodpecker && paramtable.Get().WoodpeckerCfg.StorageType.GetValue() == "local" && !paramtable.Get().WoodpeckerCfg.ForceLocalStorage.GetAsBool() {
-		return mqName, errors.Newf("woodpecker with local storage is not supported in cluster mode, set woodpecker.storage.forceLocalStorage to true to override")
+		return mqName, merr.WrapErrParameterInvalidMsg("woodpecker with local storage is not supported in cluster mode, set woodpecker.storage.forceLocalStorage to true to override")
 	}
 	return mqName, nil
 }

--- a/internal/util/testutil/test_util.go
+++ b/internal/util/testutil/test_util.go
@@ -935,7 +935,7 @@ func BuildArrayData(schema *schemapb.CollectionSchema, insertData *storage.Inser
 			})
 			fixedSizeBuilder, ok := listBuilder.ValueBuilder().(*array.FixedSizeBinaryBuilder)
 			if !ok {
-				return nil, fmt.Errorf("unexpected list value builder for VectorArray field %s: %T", field.GetName(), listBuilder.ValueBuilder())
+				return nil, merr.WrapErrParameterInvalidMsg("unexpected list value builder for VectorArray field %s: %T", field.GetName(), listBuilder.ValueBuilder())
 			}
 
 			vectorArrayData.Dim = dim
@@ -944,10 +944,10 @@ func BuildArrayData(schema *schemapb.CollectionSchema, insertData *storage.Inser
 
 			appendBinarySlice := func(data []byte, stride int) error {
 				if stride == 0 {
-					return fmt.Errorf("zero stride for VectorArray field %s", field.GetName())
+					return merr.WrapErrParameterInvalidMsg("zero stride for VectorArray field %s", field.GetName())
 				}
 				if len(data)%stride != 0 {
-					return fmt.Errorf("vector array data length %d is not divisible by stride %d for field %s", len(data), stride, field.GetName())
+					return merr.WrapErrParameterInvalidMsg("vector array data length %d is not divisible by stride %d for field %s", len(data), stride, field.GetName())
 				}
 				for offset := 0; offset < len(data); offset += stride {
 					fixedSizeBuilder.Append(data[offset : offset+stride])
@@ -967,14 +967,14 @@ func BuildArrayData(schema *schemapb.CollectionSchema, insertData *storage.Inser
 				case schemapb.DataType_FloatVector:
 					floatArray := vectorField.GetFloatVector()
 					if floatArray == nil {
-						return nil, fmt.Errorf("expected FloatVector data for field %s", field.GetName())
+						return nil, merr.WrapErrParameterInvalidMsg("expected FloatVector data for field %s", field.GetName())
 					}
 					data := floatArray.GetData()
 					if len(data) == 0 {
 						continue
 					}
 					if len(data)%int(dim) != 0 {
-						return nil, fmt.Errorf("float vector data length %d is not divisible by dim %d for field %s", len(data), dim, field.GetName())
+						return nil, merr.WrapErrParameterInvalidMsg("float vector data length %d is not divisible by dim %d for field %s", len(data), dim, field.GetName())
 					}
 					for offset := 0; offset < len(data); offset += int(dim) {
 						vectorBytes := make([]byte, bytesPerVector)
@@ -1017,7 +1017,7 @@ func BuildArrayData(schema *schemapb.CollectionSchema, insertData *storage.Inser
 						return nil, err
 					}
 				default:
-					return nil, fmt.Errorf("unsupported element type in VectorArray: %s", elementType.String())
+					return nil, merr.WrapErrParameterInvalidMsg("unsupported element type in VectorArray: %s", elementType.String())
 				}
 			}
 

--- a/internal/util/typeutil/hash.go
+++ b/internal/util/typeutil/hash.go
@@ -3,10 +3,9 @@ package typeutil
 import (
 	"strconv"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -22,7 +21,7 @@ func HashKey2Partitions(fieldSchema *schemapb.FieldSchema, keys []*planpb.Generi
 				partitionName := partitionNames[value%numPartitions]
 				selectedPartitions[partitionName] = struct{}{}
 			} else {
-				return nil, errors.New("the data type of the data and the schema do not match")
+				return nil, merr.WrapErrParameterInvalidMsg("the data type of the data and the schema do not match")
 			}
 		}
 	case schemapb.DataType_VarChar:
@@ -32,11 +31,11 @@ func HashKey2Partitions(fieldSchema *schemapb.FieldSchema, keys []*planpb.Generi
 				partitionName := partitionNames[value%numPartitions]
 				selectedPartitions[partitionName] = struct{}{}
 			} else {
-				return nil, errors.New("the data type of the data and the schema do not match")
+				return nil, merr.WrapErrParameterInvalidMsg("the data type of the data and the schema do not match")
 			}
 		}
 	default:
-		return nil, errors.New("currently only support DataType Int64 or VarChar as partition keys")
+		return nil, merr.WrapErrParameterInvalidMsg("currently only support DataType Int64 or VarChar as partition keys")
 	}
 
 	result := make([]string, 0)

--- a/internal/util/typeutil/json_util.go
+++ b/internal/util/typeutil/json_util.go
@@ -18,12 +18,12 @@ package typeutil
 import (
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -42,7 +42,7 @@ func ParseAndVerifyNestedPath(identifier string, schema *schemapb.CollectionSche
 		return "", err
 	}
 	if identifierExpr.GetColumnExpr().GetInfo().GetFieldId() != fieldID {
-		return "", errors.New("fieldID not match with field name")
+		return "", merr.WrapErrParameterInvalidMsg("fieldID not match with field name")
 	}
 
 	nestedPath := identifierExpr.GetColumnExpr().GetInfo().GetNestedPath()

--- a/pkg/util/conc/pool.go
+++ b/pkg/util/conc/pool.go
@@ -17,7 +17,6 @@
 package conc
 
 import (
-	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -71,7 +70,7 @@ func (pool *Pool[T]) Submit(method func() (T, error)) *Future[T] {
 		defer close(future.ch)
 		defer func() {
 			if x := recover(); x != nil {
-				future.err = fmt.Errorf("panicked with error: %v", x)
+				future.err = merr.WrapErrParameterInvalidMsg("panicked with error: %v", x)
 				panic(x) // throw panic out
 			}
 		}()

--- a/pkg/util/contextutil/context_util.go
+++ b/pkg/util/contextutil/context_util.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/crypto"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type ctxTenantKey struct{}
@@ -91,20 +91,20 @@ func GetCurUserFromContext(ctx context.Context) (string, error) {
 func GetAuthInfoFromContext(ctx context.Context) (string, string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", "", errors.New("fail to get md from the context")
+		return "", "", merr.WrapErrParameterInvalidMsg("fail to get md from the context")
 	}
 	authorization, ok := md[strings.ToLower(util.HeaderAuthorize)]
 	if !ok || len(authorization) < 1 {
-		return "", "", fmt.Errorf("fail to get authorization from the md, %s:[token]", strings.ToLower(util.HeaderAuthorize))
+		return "", "", merr.WrapErrParameterInvalidMsg("fail to get authorization from the md, %s:[token]", strings.ToLower(util.HeaderAuthorize))
 	}
 	token := authorization[0]
 	rawToken, err := crypto.Base64Decode(token)
 	if err != nil {
-		return "", "", fmt.Errorf("fail to decode the token, token: %s", token)
+		return "", "", merr.WrapErrParameterInvalidMsg("fail to decode the token, token: %s", token)
 	}
 	secrets := strings.SplitN(rawToken, util.CredentialSeparator, 2)
 	if len(secrets) < 2 {
-		return "", "", fmt.Errorf("fail to get user info from the raw token, raw token: %s", rawToken)
+		return "", "", merr.WrapErrParameterInvalidMsg("fail to get user info from the raw token, raw token: %s", rawToken)
 	}
 	// username: secrets[0]
 	// password: secrets[1]

--- a/pkg/util/distance/calc_distance.go
+++ b/pkg/util/distance/calc_distance.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 /**
@@ -62,7 +62,7 @@ var (
 // ValidateMetricType returns metric text or error
 func ValidateMetricType(metric string) (string, error) {
 	if metric == "" {
-		err := errors.New("metric type is empty")
+		err := merr.WrapErrParameterInvalidMsg("metric type is empty")
 		return "", err
 	}
 
@@ -71,14 +71,14 @@ func ValidateMetricType(metric string) (string, error) {
 		return m, nil
 	}
 
-	err := errors.New("invalid metric type")
+	err := merr.WrapErrParameterInvalidMsg("invalid metric type")
 	return metric, err
 }
 
 // ValidateFloatArrayLength is used validate float vector length
 func ValidateFloatArrayLength(dim int64, length int) error {
 	if length == 0 || int64(length)%dim != 0 {
-		err := errors.New("invalid float vector length")
+		err := merr.WrapErrParameterInvalidMsg("invalid float vector length")
 		return err
 	}
 
@@ -106,13 +106,13 @@ func CalcFFBatch(dim int64, left []float32, lIndex int64, right []float32, metri
 // it will checks input, and calculate the distance concurrently
 func CalcFloatDistance(dim int64, left, right []float32, metric string) ([]float32, error) {
 	if dim <= 0 {
-		err := errors.New("invalid dimension")
+		err := merr.WrapErrParameterInvalidMsg("invalid dimension")
 		return nil, err
 	}
 
 	metricUpper := strings.ToUpper(metric)
 	if metricUpper != L2 && metricUpper != IP && metricUpper != COSINE {
-		err := errors.New("invalid metric type")
+		err := merr.WrapErrParameterInvalidMsg("invalid metric type")
 		return nil, err
 	}
 

--- a/pkg/util/etcd/etcd_util.go
+++ b/pkg/util/etcd/etcd_util.go
@@ -36,6 +36,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type ClientOption func(*clientv3.Config)
@@ -123,11 +124,11 @@ func GetRemoteEtcdSSLClientWithCfg(endpoints []string, certFile string, keyFile 
 	cfg.DialTimeout = 5 * time.Second
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return nil, errors.Wrap(err, "load etcd cert key pair error")
+		return nil, merr.Wrap(err, "load etcd cert key pair error")
 	}
 	caCert, err := os.ReadFile(caCertFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "load etcd CACert file error, filename = %s", caCertFile)
+		return nil, merr.Wrapf(err, "load etcd CACert file error, filename = %s", caCertFile)
 	}
 
 	caCertPool := x509.NewCertPool()
@@ -153,7 +154,7 @@ func GetRemoteEtcdSSLClientWithCfg(endpoints []string, certFile string, keyFile 
 	}
 
 	if cfg.TLS.MinVersion == 0 {
-		return nil, errors.Errorf("unknown TLS version,%s", minVersion)
+		return nil, merr.WrapErrParameterInvalidMsg("unknown TLS version,%s", minVersion)
 	}
 
 	cfg.DialOptions = append(cfg.DialOptions, grpc.WithBlock())
@@ -240,13 +241,13 @@ func RemoveByBatchWithLimit(removals []string, limit int, op func(partialKeys []
 
 func buildKvGroup(keys, values []string) (map[string]string, error) {
 	if len(keys) != len(values) {
-		return nil, fmt.Errorf("length of keys (%d) and values (%d) are not equal", len(keys), len(values))
+		return nil, merr.WrapErrParameterInvalidMsg("length of keys (%d) and values (%d) are not equal", len(keys), len(values))
 	}
 	ret := make(map[string]string, len(keys))
 	for i, k := range keys {
 		_, ok := ret[k]
 		if ok {
-			return nil, fmt.Errorf("duplicated key was found: %s", k)
+			return nil, merr.WrapErrParameterInvalidMsg("duplicated key was found: %s", k)
 		}
 		ret[k] = values[i]
 	}

--- a/pkg/util/etcd/etcd_util_test.go
+++ b/pkg/util/etcd/etcd_util_test.go
@@ -18,15 +18,51 @@ package etcd
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"os"
 	"path"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// freePort grabs a random unused TCP port. There's a small TOCTOU window
+// between Close and the subsequent bind, but for unit tests it's acceptable.
+func freePort(t *testing.T) int {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
 func TestEtcd(t *testing.T) {
-	err := InitEtcdServer(true, "", "/tmp/data", "stdout", "info")
+	// Use random free ports so the embedded etcd does not collide with any
+	// already-running etcd on the dev machine (e.g. docker-compose etcd
+	// holding 2379/2380).
+	clientPort, peerPort := freePort(t), freePort(t)
+	dataDir, err := os.MkdirTemp("", "test-etcd-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dataDir)
+	cfgFile, err := os.CreateTemp("", "test-etcd-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(cfgFile.Name())
+	_, err = fmt.Fprintf(cfgFile, `name: default
+data-dir: %s
+listen-client-urls: http://127.0.0.1:%d
+advertise-client-urls: http://127.0.0.1:%d
+listen-peer-urls: http://127.0.0.1:%d
+initial-advertise-peer-urls: http://127.0.0.1:%d
+initial-cluster: default=http://127.0.0.1:%d
+initial-cluster-state: new
+`, dataDir, clientPort, clientPort, peerPort, peerPort, peerPort)
+	require.NoError(t, err)
+	require.NoError(t, cfgFile.Close())
+
+	err = InitEtcdServer(true, cfgFile.Name(), dataDir, "stdout", "info")
 	assert.NoError(t, err)
 	defer StopEtcdServer()
 

--- a/pkg/util/expr/expr.go
+++ b/pkg/util/expr/expr.go
@@ -23,13 +23,13 @@ import (
 	"fmt"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -79,21 +79,21 @@ func HasRegistered(key string) bool {
 func Exec(code, auth string) (res string, err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			err = fmt.Errorf("panic: %v", e)
+			err = merr.WrapErrParameterInvalidMsg("panic: %v", e)
 		}
 	}()
 	if v == nil {
-		return "", errors.New("the expr isn't inited")
+		return "", merr.WrapErrParameterInvalidMsg("the expr isn't inited")
 	}
 	if code == "" {
-		return "", errors.New("the expr code is empty")
+		return "", merr.WrapErrParameterInvalidMsg("the expr code is empty")
 	}
 	if auth == "" {
-		return "", errors.New("the expr auth is empty")
+		return "", merr.WrapErrParameterInvalidMsg("the expr auth is empty")
 	}
 	// Allow bypass when authentication has been verified externally (e.g., by HTTP handler)
 	if auth != AuthBypass && authKey != auth {
-		return "", errors.New("the expr auth is invalid")
+		return "", merr.WrapErrParameterInvalidMsg("the expr auth is invalid")
 	}
 	program, err := expr.Compile(code, expr.Env(env), expr.WithContext("ctx"))
 	if err != nil {

--- a/pkg/util/externalspec/external_spec.go
+++ b/pkg/util/externalspec/external_spec.go
@@ -18,7 +18,6 @@ package externalspec
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/url"
 	"sort"
 	"strconv"
@@ -278,25 +277,25 @@ func sortedKeys(m map[string]bool) []string {
 // minio://<endpoint>/<bucket>/<key>.
 func ValidateExternalSource(source string) error {
 	if source == "" {
-		return fmt.Errorf("external_source is empty")
+		return merr.WrapErrParameterInvalidMsg("external_source is empty")
 	}
 	u, err := url.Parse(source)
 	if err != nil {
-		return fmt.Errorf("invalid external_source URL: %w", err)
+		return merr.Wrap(err, "invalid external_source URL")
 	}
 	scheme := strings.ToLower(u.Scheme)
 	if scheme == "" {
-		return fmt.Errorf("external_source must have an explicit scheme (e.g. s3://, aws://, gs://)")
+		return merr.WrapErrParameterInvalidMsg("external_source must have an explicit scheme (e.g. s3://, aws://, gs://)")
 	}
 	if !allowedExternalSourceSchemes[scheme] {
-		return fmt.Errorf("external_source scheme %q is not allowed; allowed schemes: %s",
+		return merr.WrapErrParameterInvalidMsg("external_source scheme %q is not allowed; allowed schemes: %s",
 			scheme, strings.Join(sortedKeys(allowedExternalSourceSchemes), ", "))
 	}
 	if u.User != nil {
-		return fmt.Errorf("external_source must not embed credentials in the URL (use extfs.access_key_id / extfs.access_key_value instead)")
+		return merr.WrapErrParameterInvalidMsg("external_source must not embed credentials in the URL (use extfs.access_key_id / extfs.access_key_value instead)")
 	}
 	if u.Host == "" {
-		return fmt.Errorf("external_source must have a non-empty host (e.g. s3://bucket/key, s3://endpoint/bucket/key, or minio://endpoint/bucket/key)")
+		return merr.WrapErrParameterInvalidMsg("external_source must have a non-empty host (e.g. s3://bucket/key, s3://endpoint/bucket/key, or minio://endpoint/bucket/key)")
 	}
 	return nil
 }
@@ -340,13 +339,13 @@ func ValidateExtfsComplete(externalSource string, extfs map[string]string) error
 		cp = CloudProviderMinIO
 	}
 	if cp == "" {
-		return fmt.Errorf("extfs.cloud_provider is required: one of [aws, gcp, aliyun, tencent, huawei, azure, minio]; inferring from URI scheme is ambiguous (e.g. s3:// matches both AWS S3 and self-hosted MinIO)")
+		return merr.WrapErrParameterInvalidMsg("extfs.cloud_provider is required: one of [aws, gcp, aliyun, tencent, huawei, azure, minio]; inferring from URI scheme is ambiguous (e.g. s3:// matches both AWS S3 and self-hosted MinIO)")
 	}
 	if !validCloudProviders[cp] {
-		return fmt.Errorf("extfs.cloud_provider=%q is not supported: must be one of [aws, gcp, aliyun, tencent, huawei, azure, minio]", cp)
+		return merr.WrapErrParameterInvalidMsg("extfs.cloud_provider=%q is not supported: must be one of [aws, gcp, aliyun, tencent, huawei, azure, minio]", cp)
 	}
 	if scheme == SchemeMinIO && cp != CloudProviderMinIO {
-		return fmt.Errorf("scheme=minio requires extfs.cloud_provider=%q, got %q", CloudProviderMinIO, cp)
+		return merr.WrapErrParameterInvalidMsg("scheme=minio requires extfs.cloud_provider=%q, got %q", CloudProviderMinIO, cp)
 	}
 
 	hasAKSK := extfs[ExtfsKeyAccessKeyID] != "" && extfs[ExtfsKeyAccessKeyValue] != ""
@@ -357,7 +356,7 @@ func ValidateExtfsComplete(externalSource string, extfs map[string]string) error
 	hasAnonymous := extfs[ExtfsKeyAnonymous] == "true"
 
 	if hasAKOnly {
-		return fmt.Errorf("extfs.access_key_id and extfs.access_key_value must be set together (found one without the other)")
+		return merr.WrapErrParameterInvalidMsg("extfs.access_key_id and extfs.access_key_value must be set together (found one without the other)")
 	}
 
 	modes := 0
@@ -367,34 +366,34 @@ func ValidateExtfsComplete(externalSource string, extfs map[string]string) error
 		}
 	}
 	if modes == 0 {
-		return fmt.Errorf("extfs credential mode missing: set exactly one of {access_key_id+access_key_value}, role_arn, use_iam=true, gcp_target_service_account, or anonymous=true")
+		return merr.WrapErrParameterInvalidMsg("extfs credential mode missing: set exactly one of {access_key_id+access_key_value}, role_arn, use_iam=true, gcp_target_service_account, or anonymous=true")
 	}
 	if modes > 1 {
-		return fmt.Errorf("extfs credential modes are mutually exclusive: set exactly one of AK/SK, role_arn, use_iam=true, gcp_target_service_account, or anonymous=true")
+		return merr.WrapErrParameterInvalidMsg("extfs credential modes are mutually exclusive: set exactly one of AK/SK, role_arn, use_iam=true, gcp_target_service_account, or anonymous=true")
 	}
 
 	if hasGCPImpersonation {
 		if scheme != "" && scheme != SchemeGS && scheme != SchemeGCS && cp != CloudProviderGCP {
-			return fmt.Errorf("extfs.gcp_target_service_account is only valid for GCP (scheme=gs/gcs or cloud_provider=gcp), got scheme=%q cloud_provider=%q", scheme, cp)
+			return merr.WrapErrParameterInvalidMsg("extfs.gcp_target_service_account is only valid for GCP (scheme=gs/gcs or cloud_provider=gcp), got scheme=%q cloud_provider=%q", scheme, cp)
 		}
 		sa := extfs[ExtfsKeyGCPTargetServiceAccount]
 		if !strings.Contains(sa, "@") || !strings.HasSuffix(sa, ".gserviceaccount.com") {
-			return fmt.Errorf("extfs.gcp_target_service_account must be a GCP service account email ending in .gserviceaccount.com, got %q", sa)
+			return merr.WrapErrParameterInvalidMsg("extfs.gcp_target_service_account must be a GCP service account email ending in .gserviceaccount.com, got %q", sa)
 		}
 	}
 
 	if awsFamilyScheme[scheme] && extfs[ExtfsKeyRegion] == "" {
-		return fmt.Errorf("extfs.region is required for scheme %q (AWS-family schemes need region for SigV4 signing)", scheme)
+		return merr.WrapErrParameterInvalidMsg("extfs.region is required for scheme %q (AWS-family schemes need region for SigV4 signing)", scheme)
 	}
 
 	// Azure consistency: scheme=azure requires cloud_provider=azure, and
 	// cloud_provider=azure requires scheme=azure. Pairing guards against
 	// misconfigured dispatch to a non-Azure storage backend.
 	if scheme == SchemeAzure && cp != CloudProviderAzure {
-		return fmt.Errorf("scheme=azure requires extfs.cloud_provider=%q, got %q", CloudProviderAzure, cp)
+		return merr.WrapErrParameterInvalidMsg("scheme=azure requires extfs.cloud_provider=%q, got %q", CloudProviderAzure, cp)
 	}
 	if cp == CloudProviderAzure && scheme != "" && scheme != SchemeAzure {
-		return fmt.Errorf("extfs.cloud_provider=azure requires scheme=azure, got scheme=%q", scheme)
+		return merr.WrapErrParameterInvalidMsg("extfs.cloud_provider=azure requires scheme=azure, got scheme=%q", scheme)
 	}
 
 	// Two-form URI contract: Milvus-form (scheme://endpoint/bucket/key) has
@@ -421,7 +420,7 @@ func ValidateExtfsComplete(externalSource string, extfs map[string]string) error
 			// cloud_provider + region. cp=minio has no canonical endpoint
 			// and must use Milvus-form URI to embed the host explicitly.
 			if DeriveEndpoint(cp, extfs[ExtfsKeyRegion]) == "" {
-				return fmt.Errorf("cannot resolve endpoint for %q with cloud_provider=%q: set extfs.region, or use Milvus-form URI scheme://<endpoint>/<bucket>/<key>", externalSource, cp)
+				return merr.WrapErrParameterInvalidMsg("cannot resolve endpoint for %q with cloud_provider=%q: set extfs.region, or use Milvus-form URI scheme://<endpoint>/<bucket>/<key>", externalSource, cp)
 			}
 		}
 	}

--- a/pkg/util/funcutil/func.go
+++ b/pkg/util/funcutil/func.go
@@ -40,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -80,7 +81,7 @@ func GetIP(ip string) string {
 				}
 			}
 		}
-		panic(errors.New(`Network port does not have an IP address that falls within the given CIDR range`))
+		panic(merr.WrapErrParameterInvalidMsg(`Network port does not have an IP address that falls within the given CIDR range`))
 	}
 
 	netIP := net.ParseIP(ip)
@@ -91,10 +92,10 @@ func GetIP(ip string) string {
 	}
 	// only localhost or unicast is acceptable
 	if netIP.IsUnspecified() {
-		panic(errors.Newf(`"%s" in param table is Unspecified IP address and cannot be used`))
+		panic(merr.WrapErrParameterInvalidMsg(`"%s" in param table is Unspecified IP address and cannot be used`))
 	}
 	if netIP.IsMulticast() || netIP.IsLinkLocalMulticast() || netIP.IsInterfaceLocalMulticast() {
-		panic(errors.Newf(`"%s" in param table is Multicast IP address and cannot be used`))
+		panic(merr.WrapErrParameterInvalidMsg(`"%s" in param table is Multicast IP address and cannot be used`))
 	}
 	return ip
 }
@@ -215,7 +216,7 @@ func JSONToMap(mStr string) (map[string]string, error) {
 	buffer := make(map[string]any)
 	err := json.Unmarshal([]byte(mStr), &buffer)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal params failed, %w", err)
+		return nil, merr.Wrap(err, "unmarshal params failed")
 	}
 	ret := make(map[string]string)
 	for key, value := range buffer {
@@ -238,7 +239,7 @@ func JSONToRoleDetails(mStr string) (map[string](map[string]([](map[string]strin
 	buffer := make(map[string](map[string]([](map[string]string))), 0)
 	err := json.Unmarshal([]byte(mStr), &buffer)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal `builtinRoles.Roles` failed, %w", err)
+		return nil, merr.Wrap(err, "unmarshal `builtinRoles.Roles` failed")
 	}
 	ret := make(map[string](map[string]([](map[string]string))), 0)
 	for role, privilegesJSON := range buffer {
@@ -275,7 +276,7 @@ func GetAttrByKeyFromRepeatedKV(key string, kvs []*commonpb.KeyValuePair) (strin
 		}
 	}
 
-	return "", fmt.Errorf("key %s not found", key)
+	return "", merr.WrapErrParameterInvalidMsg("key %s not found", key)
 }
 
 // TryGetAttrByKeyFromRepeatedKV return the value corresponding to key in kv pair
@@ -413,10 +414,10 @@ func GetVirtualChannel(pchannel string, collectionID int64, idx int) string {
 // ConvertChannelName assembles channel name according to parameters.
 func ConvertChannelName(chanName string, tokenFrom string, tokenTo string) (string, error) {
 	if tokenFrom == "" {
-		return "", errors.New("the tokenFrom is empty")
+		return "", merr.WrapErrParameterInvalidMsg("the tokenFrom is empty")
 	}
 	if !strings.Contains(chanName, tokenFrom) {
-		return "", fmt.Errorf("cannot find token '%s' in '%s'", tokenFrom, chanName)
+		return "", merr.WrapErrParameterInvalidMsg("cannot find token '%s' in '%s'", tokenFrom, chanName)
 	}
 	return strings.Replace(chanName, tokenFrom, tokenTo, 1), nil
 }
@@ -445,60 +446,60 @@ func getNumRowsOfArrayVectorField(datas interface{}) uint64 {
 
 func GetNumRowsOfFloatVectorField(fDatas []float32, dim int64) (uint64, error) {
 	if dim <= 0 {
-		return 0, fmt.Errorf("dim(%d) should be greater than 0", dim)
+		return 0, merr.WrapErrParameterInvalidMsg("dim(%d) should be greater than 0", dim)
 	}
 	l := len(fDatas)
 	if int64(l)%dim != 0 {
-		return 0, fmt.Errorf("the length(%d) of float data should divide the dim(%d)", l, dim)
+		return 0, merr.WrapErrParameterInvalidMsg("the length(%d) of float data should divide the dim(%d)", l, dim)
 	}
 	return uint64(int64(l) / dim), nil
 }
 
 func GetNumRowsOfBinaryVectorField(bDatas []byte, dim int64) (uint64, error) {
 	if dim <= 0 {
-		return 0, fmt.Errorf("dim(%d) should be greater than 0", dim)
+		return 0, merr.WrapErrParameterInvalidMsg("dim(%d) should be greater than 0", dim)
 	}
 	if dim%8 != 0 {
-		return 0, fmt.Errorf("dim(%d) should divide 8", dim)
+		return 0, merr.WrapErrParameterInvalidMsg("dim(%d) should divide 8", dim)
 	}
 	l := len(bDatas)
 	if (8*int64(l))%dim != 0 {
-		return 0, fmt.Errorf("the num(%d) of all bits should divide the dim(%d)", 8*l, dim)
+		return 0, merr.WrapErrParameterInvalidMsg("the num(%d) of all bits should divide the dim(%d)", 8*l, dim)
 	}
 	return uint64((8 * int64(l)) / dim), nil
 }
 
 func GetNumRowsOfFloat16VectorField(f16Datas []byte, dim int64) (uint64, error) {
 	if dim <= 0 {
-		return 0, fmt.Errorf("dim(%d) should be greater than 0", dim)
+		return 0, merr.WrapErrParameterInvalidMsg("dim(%d) should be greater than 0", dim)
 	}
 	l := len(f16Datas)
 	rowWidth := dim * 2
 	if int64(l)%rowWidth != 0 {
-		return 0, fmt.Errorf("the length(%d) of float16 data should divide the row width(%d)", l, rowWidth)
+		return 0, merr.WrapErrParameterInvalidMsg("the length(%d) of float16 data should divide the row width(%d)", l, rowWidth)
 	}
 	return uint64(int64(l) / rowWidth), nil
 }
 
 func GetNumRowsOfBFloat16VectorField(bf16Datas []byte, dim int64) (uint64, error) {
 	if dim <= 0 {
-		return 0, fmt.Errorf("dim(%d) should be greater than 0", dim)
+		return 0, merr.WrapErrParameterInvalidMsg("dim(%d) should be greater than 0", dim)
 	}
 	l := len(bf16Datas)
 	rowWidth := dim * 2
 	if int64(l)%rowWidth != 0 {
-		return 0, fmt.Errorf("the length(%d) of bfloat data should divide the row width(%d)", l, rowWidth)
+		return 0, merr.WrapErrParameterInvalidMsg("the length(%d) of bfloat data should divide the row width(%d)", l, rowWidth)
 	}
 	return uint64(int64(l) / rowWidth), nil
 }
 
 func GetNumRowsOfInt8VectorField(iDatas []byte, dim int64) (uint64, error) {
 	if dim <= 0 {
-		return 0, fmt.Errorf("dim(%d) should be greater than 0", dim)
+		return 0, merr.WrapErrParameterInvalidMsg("dim(%d) should be greater than 0", dim)
 	}
 	l := len(iDatas)
 	if int64(l)%dim != 0 {
-		return 0, fmt.Errorf("the length(%d) of int8 data should divide the dim(%d)", l, dim)
+		return 0, merr.WrapErrParameterInvalidMsg("the length(%d) of int8 data should divide the dim(%d)", l, dim)
 	}
 	return uint64(int64(l) / dim), nil
 }
@@ -515,7 +516,7 @@ func CountValidRows(validData []bool) uint64 {
 
 func GetVectorFieldPhysicalRows(fieldName string, dataType schemapb.DataType, vectors *schemapb.VectorField) (uint64, error) {
 	if vectors == nil {
-		return 0, fmt.Errorf("nullable vector field %s requires vector data", fieldName)
+		return 0, merr.WrapErrParameterInvalidMsg("nullable vector field %s requires vector data", fieldName)
 	}
 
 	return getVectorFieldPhysicalRowsWithDim(fieldName, dataType, vectors, vectors.GetDim())
@@ -539,23 +540,23 @@ func getVectorFieldPhysicalRowsWithDim(fieldName string, dataType schemapb.DataT
 	case schemapb.DataType_Int8Vector:
 		return GetNumRowsOfInt8VectorField(vectors.GetInt8Vector(), dim)
 	default:
-		return 0, fmt.Errorf("unsupported nullable vector type %s", dataType)
+		return 0, merr.WrapErrParameterInvalidMsg("unsupported nullable vector type %s", dataType)
 	}
 }
 
 func ValidateNullableVectorCompactRows(fieldName string, validData []bool, physicalRows uint64, logicalRows uint64, requireValidData bool) error {
 	if len(validData) == 0 {
 		if requireValidData {
-			return fmt.Errorf("nullable vector field %s requires valid_data", fieldName)
+			return merr.WrapErrParameterInvalidMsg("nullable vector field %s requires valid_data", fieldName)
 		}
 		return nil
 	}
 	if logicalRows > 0 && uint64(len(validData)) != logicalRows {
-		return fmt.Errorf("nullable vector field %s valid_data length mismatch: valid_data=%d, logical rows=%d", fieldName, len(validData), logicalRows)
+		return merr.WrapErrParameterInvalidMsg("nullable vector field %s valid_data length mismatch: valid_data=%d, logical rows=%d", fieldName, len(validData), logicalRows)
 	}
 	validRows := CountValidRows(validData)
 	if physicalRows != validRows {
-		return fmt.Errorf("nullable vector field %s has %d valid rows, but compact physical payload rows is %d", fieldName, validRows, physicalRows)
+		return merr.WrapErrParameterInvalidMsg("nullable vector field %s has %d valid rows, but compact physical payload rows is %d", fieldName, validRows, physicalRows)
 	}
 	return nil
 }
@@ -702,7 +703,7 @@ func GetNumRowOfFieldDataWithSchema(fieldData *schemapb.FieldData, helper *typeu
 			fieldNumRows = getNumRowsOfArrayVectorField(fieldData.GetVectors().GetVectorArray().GetData())
 		}
 	default:
-		return 0, fmt.Errorf("%s is not supported now", fieldSchema.GetDataType())
+		return 0, merr.WrapErrParameterInvalidMsg("%s is not supported now", fieldSchema.GetDataType())
 	}
 
 	return fieldNumRows, nil
@@ -737,7 +738,7 @@ func GetNumRowOfFieldData(fieldData *schemapb.FieldData) (uint64, error) {
 		case *schemapb.ScalarField_GeometryData:
 			fieldNumRows = getNumRowsOfScalarField(scalarField.GetGeometryData().Data)
 		default:
-			return 0, fmt.Errorf("%s is not supported now", scalarType)
+			return 0, merr.WrapErrParameterInvalidMsg("%s is not supported now", scalarType)
 		}
 	case *schemapb.FieldData_Vectors:
 		vectorField := fieldData.GetVectors()
@@ -783,10 +784,10 @@ func GetNumRowOfFieldData(fieldData *schemapb.FieldData) (uint64, error) {
 		case *schemapb.VectorField_VectorArray:
 			fieldNumRows = getNumRowsOfArrayVectorField(vectorField.GetVectorArray().Data)
 		default:
-			return 0, fmt.Errorf("%s is not supported now", vectorFieldType)
+			return 0, merr.WrapErrParameterInvalidMsg("%s is not supported now", vectorFieldType)
 		}
 	default:
-		return 0, fmt.Errorf("%s is not supported now", fieldType)
+		return 0, merr.WrapErrParameterInvalidMsg("%s is not supported now", fieldType)
 	}
 
 	return fieldNumRows, nil
@@ -847,7 +848,7 @@ func EncodeUserRoleCache(user string, role string) string {
 func DecodeUserRoleCache(cache string) (string, string, error) {
 	index := strings.LastIndex(cache, "/")
 	if index == -1 {
-		return "", "", fmt.Errorf("invalid param, cache: [%s]", cache)
+		return "", "", merr.WrapErrParameterInvalidMsg("invalid param, cache: [%s]", cache)
 	}
 	user := cache[:index]
 	role := cache[index+1:]

--- a/pkg/util/funcutil/map.go
+++ b/pkg/util/funcutil/map.go
@@ -1,6 +1,6 @@
 package funcutil
 
-import "fmt"
+import "github.com/milvus-io/milvus/pkg/v3/util/merr"
 
 func MapReduce(results []map[string]string, method map[string]func(string) error) error {
 	// TODO: use generic type to reconstruct map[string]string -> [T any] map[string]T
@@ -8,7 +8,7 @@ func MapReduce(results []map[string]string, method map[string]func(string) error
 		for k, v := range result {
 			fn, ok := method[k]
 			if !ok {
-				return fmt.Errorf("unknown field %s", k)
+				return merr.WrapErrParameterInvalidMsg("unknown field %s", k)
 			}
 			if err := fn(v); err != nil {
 				return err

--- a/pkg/util/funcutil/placeholdergroup.go
+++ b/pkg/util/funcutil/placeholdergroup.go
@@ -4,12 +4,12 @@ import (
 	"encoding/binary"
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func SparseVectorDataToPlaceholderGroupBytes(contents [][]byte) []byte {
@@ -83,7 +83,7 @@ func fieldDataToPlaceholderValue(fieldData *schemapb.FieldData) (*commonpb.Place
 		vectors := fieldData.GetVectors()
 		x, ok := vectors.GetData().(*schemapb.VectorField_FloatVector)
 		if !ok {
-			return nil, errors.New("vector data is not schemapb.VectorField_FloatVector")
+			return nil, merr.WrapErrParameterInvalidMsg("vector data is not schemapb.VectorField_FloatVector")
 		}
 
 		placeholderValue := &commonpb.PlaceholderValue{
@@ -96,7 +96,7 @@ func fieldDataToPlaceholderValue(fieldData *schemapb.FieldData) (*commonpb.Place
 		vectors := fieldData.GetVectors()
 		x, ok := vectors.GetData().(*schemapb.VectorField_BinaryVector)
 		if !ok {
-			return nil, errors.New("vector data is not schemapb.VectorField_BinaryVector")
+			return nil, merr.WrapErrParameterInvalidMsg("vector data is not schemapb.VectorField_BinaryVector")
 		}
 		placeholderValue := &commonpb.PlaceholderValue{
 			Tag:    "$0",
@@ -108,7 +108,7 @@ func fieldDataToPlaceholderValue(fieldData *schemapb.FieldData) (*commonpb.Place
 		vectors := fieldData.GetVectors()
 		x, ok := vectors.GetData().(*schemapb.VectorField_Float16Vector)
 		if !ok {
-			return nil, errors.New("vector data is not schemapb.VectorField_Float16Vector")
+			return nil, merr.WrapErrParameterInvalidMsg("vector data is not schemapb.VectorField_Float16Vector")
 		}
 		placeholderValue := &commonpb.PlaceholderValue{
 			Tag:    "$0",
@@ -120,7 +120,7 @@ func fieldDataToPlaceholderValue(fieldData *schemapb.FieldData) (*commonpb.Place
 		vectors := fieldData.GetVectors()
 		x, ok := vectors.GetData().(*schemapb.VectorField_Bfloat16Vector)
 		if !ok {
-			return nil, errors.New("vector data is not schemapb.VectorField_BFloat16Vector")
+			return nil, merr.WrapErrParameterInvalidMsg("vector data is not schemapb.VectorField_BFloat16Vector")
 		}
 		placeholderValue := &commonpb.PlaceholderValue{
 			Tag:    "$0",
@@ -131,7 +131,7 @@ func fieldDataToPlaceholderValue(fieldData *schemapb.FieldData) (*commonpb.Place
 	case schemapb.DataType_SparseFloatVector:
 		vectors, ok := fieldData.GetVectors().GetData().(*schemapb.VectorField_SparseFloatVector)
 		if !ok {
-			return nil, errors.New("vector data is not schemapb.VectorField_SparseFloatVector")
+			return nil, merr.WrapErrParameterInvalidMsg("vector data is not schemapb.VectorField_SparseFloatVector")
 		}
 		vec := vectors.SparseFloatVector
 		placeholderValue := &commonpb.PlaceholderValue{
@@ -144,7 +144,7 @@ func fieldDataToPlaceholderValue(fieldData *schemapb.FieldData) (*commonpb.Place
 		vectors := fieldData.GetVectors()
 		x, ok := vectors.GetData().(*schemapb.VectorField_Int8Vector)
 		if !ok {
-			return nil, errors.New("vector data is not schemapb.VectorField_Int8Vector")
+			return nil, merr.WrapErrParameterInvalidMsg("vector data is not schemapb.VectorField_Int8Vector")
 		}
 
 		placeholderValue := &commonpb.PlaceholderValue{
@@ -162,7 +162,7 @@ func fieldDataToPlaceholderValue(fieldData *schemapb.FieldData) (*commonpb.Place
 		}
 		return placeholderValue, nil
 	default:
-		return nil, errors.New("field is not a vector field")
+		return nil, merr.WrapErrParameterInvalidMsg("field is not a vector field")
 	}
 }
 

--- a/pkg/util/funcutil/policy.go
+++ b/pkg/util/funcutil/policy.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -15,18 +14,19 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func GetVersion(m interface{}) (string, error) {
 	log := log.Ctx(context.TODO())
 	pbMsg, ok := m.(proto.Message)
 	if !ok {
-		err := errors.New("MessageDescriptorProto result is nil")
+		err := merr.WrapErrParameterInvalidMsg("MessageDescriptorProto result is nil")
 		log.RatedInfo(60, "GetVersion failed", zap.Error(err))
 		return "", err
 	}
 	if !proto.HasExtension(pbMsg.ProtoReflect().Descriptor().Options(), milvuspb.E_MilvusExtObj) {
-		err := errors.New("Extension not found")
+		err := merr.WrapErrParameterInvalidMsg("Extension not found")
 		log.Error("GetExtension fail", zap.Error(err))
 		return "", err
 	}
@@ -39,13 +39,13 @@ func GetVersion(m interface{}) (string, error) {
 func GetPrivilegeExtObj(m interface{}) (commonpb.PrivilegeExt, error) {
 	pbMsg, ok := m.(proto.Message)
 	if !ok {
-		err := errors.New("MessageDescriptorProto result is nil")
+		err := merr.WrapErrParameterInvalidMsg("MessageDescriptorProto result is nil")
 		log.RatedInfo(60, "GetPrivilegeExtObj failed", zap.Error(err))
 		return commonpb.PrivilegeExt{}, err
 	}
 
 	if !proto.HasExtension(pbMsg.ProtoReflect().Descriptor().Options(), commonpb.E_PrivilegeExtObj) {
-		err := errors.New("Extension not found")
+		err := merr.WrapErrParameterInvalidMsg("Extension not found")
 		log.RatedWarn(60, "GetPrivilegeExtObj failed", zap.Error(err))
 		return commonpb.PrivilegeExt{}, err
 	}
@@ -69,7 +69,7 @@ func GetObjectName(m interface{}, index int32) string {
 
 	pbMsg, ok := m.(proto.Message)
 	if !ok {
-		err := errors.New("MessageDescriptorProto result is nil")
+		err := merr.WrapErrParameterInvalidMsg("MessageDescriptorProto result is nil")
 		log.RatedInfo(60, "GetObjectName fail", zap.Error(err))
 		return util.AnyWord
 	}
@@ -95,7 +95,7 @@ func GetObjectNames(m interface{}, index int32) []string {
 
 	pbMsg, ok := m.(proto.Message)
 	if !ok {
-		err := errors.New("MessageDescriptorProto result is nil")
+		err := merr.WrapErrParameterInvalidMsg("MessageDescriptorProto result is nil")
 		log.RatedInfo(60, "GetObjectNames fail", zap.Error(err))
 		return []string{}
 	}

--- a/pkg/util/hardware/container_darwin.go
+++ b/pkg/util/hardware/container_darwin.go
@@ -12,15 +12,15 @@
 package hardware
 
 import (
-	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // getContainerMemLimit returns memory limit and error
 func getContainerMemLimit() (uint64, error) {
-	return 0, errors.New("Not supported")
+	return 0, merr.WrapErrParameterInvalidMsg("Not supported")
 }
 
 // getContainerMemUsed returns memory usage and error
 func getContainerMemUsed() (uint64, error) {
-	return 0, errors.New("Not supported")
+	return 0, merr.WrapErrParameterInvalidMsg("Not supported")
 }

--- a/pkg/util/hardware/container_linux.go
+++ b/pkg/util/hardware/container_linux.go
@@ -14,12 +14,12 @@ package hardware
 import (
 	"os"
 
-	"github.com/cockroachdb/errors"
 	"github.com/containerd/cgroups/v3"
 	"github.com/containerd/cgroups/v3/cgroup1"
 	statsv1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	"github.com/containerd/cgroups/v3/cgroup2"
 	statsv2 "github.com/containerd/cgroups/v3/cgroup2/stats"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -35,7 +35,7 @@ func getCgroupV1Stats() (*statsv1.Metrics, error) {
 	}
 
 	if stats.GetMemory() == nil || stats.GetMemory().GetUsage() == nil {
-		return nil, errors.New("cannot find memory usage info from cGroupsv1")
+		return nil, merr.WrapErrParameterInvalidMsg("cannot find memory usage info from cGroupsv1")
 	}
 	return stats, nil
 }
@@ -52,7 +52,7 @@ func getCgroupV2Stats() (*statsv2.Metrics, error) {
 	}
 
 	if stats.GetMemory() == nil {
-		return nil, errors.New("cannot find memory usage info from cGroupsv2")
+		return nil, merr.WrapErrParameterInvalidMsg("cannot find memory usage info from cGroupsv2")
 	}
 	return stats, nil
 }

--- a/pkg/util/hardware/container_windows.go
+++ b/pkg/util/hardware/container_windows.go
@@ -12,15 +12,15 @@
 package hardware
 
 import (
-	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // getContainerMemLimit returns memory limit and error
 func getContainerMemLimit() (uint64, error) {
-	return 0, errors.New("Not supported")
+	return 0, merr.WrapErrParameterInvalidMsg("Not supported")
 }
 
 // getContainerMemUsed returns memory usage and error
 func getContainerMemUsed() (uint64, error) {
-	return 0, errors.New("Not supported")
+	return 0, merr.WrapErrParameterInvalidMsg("Not supported")
 }

--- a/pkg/util/hardware/gpu_mem_info.go
+++ b/pkg/util/hardware/gpu_mem_info.go
@@ -3,7 +3,7 @@
 
 package hardware
 
-import "github.com/cockroachdb/errors"
+import "github.com/milvus-io/milvus/pkg/v3/util/merr"
 
 // GPUMemoryInfo holds information about a GPU's memory
 type GPUMemoryInfo struct {
@@ -14,5 +14,5 @@ type GPUMemoryInfo struct {
 // GetAllGPUMemoryInfo returns mock GPU memory information for non-CUDA builds
 func GetAllGPUMemoryInfo() ([]GPUMemoryInfo, error) {
 	// Mock error to indicate no CUDA support
-	return nil, errors.New("CUDA not supported: failed to retrieve GPU memory info or no GPUs found")
+	return nil, merr.WrapErrParameterInvalidMsg("CUDA not supported: failed to retrieve GPU memory info or no GPUs found")
 }

--- a/pkg/util/hardware/gpu_mem_info_cuda.go
+++ b/pkg/util/hardware/gpu_mem_info_cuda.go
@@ -55,7 +55,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // GPUMemoryInfo represents a single GPU's memory information.
@@ -72,7 +72,7 @@ func GetAllGPUMemoryInfo() ([]GPUMemoryInfo, error) {
 	// Call the C function to retrieve GPU memory info
 	deviceCount := int(C.getAllGPUMemoryInfo(&infos))
 	if deviceCount == 0 {
-		return nil, errors.New("failed to retrieve GPU memory info or no GPUs found")
+		return nil, merr.WrapErrParameterInvalidMsg("failed to retrieve GPU memory info or no GPUs found")
 	}
 	defer C.free(unsafe.Pointer(infos)) // Free the allocated memory
 

--- a/pkg/util/indexparams/index_params.go
+++ b/pkg/util/indexparams/index_params.go
@@ -22,12 +22,11 @@ import (
 	"strconv"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -180,11 +179,11 @@ func FillDiskIndexParams(params *paramtable.ComponentParam, indexParams map[stri
 		var ok bool
 		maxDegree, ok = indexParams[MaxDegreeKey]
 		if !ok {
-			return errors.New("index param max_degree not exist")
+			return merr.WrapErrParameterInvalidMsg("index param max_degree not exist")
 		}
 		searchListSize, ok = indexParams[SearchListSizeKey]
 		if !ok {
-			return errors.New("index param search_list_size not exist")
+			return merr.WrapErrParameterInvalidMsg("index param search_list_size not exist")
 		}
 		extraParams, err := NewBigDataExtraParamsFromJSON(params.AutoIndexConfig.ExtraParams.GetValue())
 		if err != nil {
@@ -227,13 +226,13 @@ func UpdateDiskIndexBuildParams(params *paramtable.ComponentParam, indexParams [
 	if params.AutoIndexConfig.Enable.GetAsBool() {
 		extraParams, err := NewBigDataExtraParamsFromJSON(params.AutoIndexConfig.ExtraParams.GetValue())
 		if err != nil {
-			return indexParams, errors.New("index param search_cache_budget_gb_ratio not exist in AutoIndex Config")
+			return indexParams, merr.WrapErrParameterInvalidMsg("index param search_cache_budget_gb_ratio not exist in AutoIndex Config")
 		}
 		searchCacheBudgetGBRatio = fmt.Sprintf("%f", extraParams.SearchCacheBudgetGBRatio)
 	} else {
 		paramVal, err := strconv.ParseFloat(params.CommonCfg.SearchCacheBudgetGBRatio.GetValue(), 64)
 		if err != nil {
-			return indexParams, errors.New("index param search_cache_budget_gb_ratio not exist in Config")
+			return indexParams, merr.WrapErrParameterInvalidMsg("index param search_cache_budget_gb_ratio not exist in Config")
 		}
 		searchCacheBudgetGBRatio = fmt.Sprintf("%f", paramVal)
 	}
@@ -272,7 +271,7 @@ func UpdateDiskIndexBuildParams(params *paramtable.ComponentParam, indexParams [
 func SetDiskIndexBuildParams(indexParams map[string]string, fieldDataSize int64) error {
 	pqCodeBudgetGBRatioStr, ok := indexParams[PQCodeBudgetRatioKey]
 	if !ok {
-		return errors.New("index param pqCodeBudgetGBRatio not exist")
+		return merr.WrapErrParameterInvalidMsg("index param pqCodeBudgetGBRatio not exist")
 	}
 	pqCodeBudgetGBRatio, err := strconv.ParseFloat(pqCodeBudgetGBRatioStr, 64)
 	if err != nil {
@@ -280,7 +279,7 @@ func SetDiskIndexBuildParams(indexParams map[string]string, fieldDataSize int64)
 	}
 	buildNumThreadsRatioStr, ok := indexParams[NumBuildThreadRatioKey]
 	if !ok {
-		return errors.New("index param buildNumThreadsRatio not exist")
+		return merr.WrapErrParameterInvalidMsg("index param buildNumThreadsRatio not exist")
 	}
 	buildNumThreadsRatio, err := strconv.ParseFloat(buildNumThreadsRatioStr, 64)
 	if err != nil {
@@ -316,7 +315,7 @@ func SetDiskIndexLoadParams(params *paramtable.ComponentParam, indexParams map[s
 	dimStr, ok := indexParams[common.DimKey]
 	if !ok {
 		// type param dim has been put into index params before build index
-		return errors.New("type param dim not exist")
+		return merr.WrapErrParameterInvalidMsg("type param dim not exist")
 	}
 	dim, err := strconv.ParseInt(dimStr, 10, 64)
 	if err != nil {

--- a/pkg/util/lock/metric_mutex.go
+++ b/pkg/util/lock/metric_mutex.go
@@ -4,11 +4,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -74,7 +74,7 @@ func (mRWLock *MetricsRWMutex) maybeLogUnlockDuration(source string, lockType st
 		} else {
 			log.Error("there's no lock history for the source, there may be some defects in codes",
 				zap.String("source", source))
-			return errors.New("unknown source")
+			return merr.WrapErrParameterInvalidMsg("unknown source")
 		}
 	}
 	return nil

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -18,6 +18,7 @@ package merr
 
 import (
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/markers"
 	"github.com/samber/lo"
 )
 
@@ -36,6 +37,11 @@ const (
 var ErrorTypeName = map[ErrorType]string{
 	SystemError: "system_error",
 	InputError:  "input_error",
+}
+
+// ErrorClassifier defines the method to get the broad classification of a Milvus error.
+type ErrorClassifier interface {
+	GetErrorType() ErrorType
 }
 
 func (err ErrorType) String() string {
@@ -60,20 +66,23 @@ var (
 	ErrServiceUnimplemented        = newMilvusError("service unimplemented", 10, false)
 	ErrServiceTimeTickLongDelay    = newMilvusError("time tick long delay", 11, false)
 	ErrServiceResourceInsufficient = newMilvusError("service resource insufficient", 12, true)
+	ErrOldSessionExists            = newMilvusError("old session exists", 13, false)
+	ErrOperationNotSupported       = newMilvusError("unsupported operation", 14, false)
 
 	// Collection related
-	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false)
+	ErrCollectionNotFound                      = newMilvusError("collection not found", 100, false, WithErrorType(InputError))
 	ErrCollectionNotLoaded                     = newMilvusError("collection not loaded", 101, false)
-	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false)
+	ErrCollectionNumLimitExceeded              = newMilvusError("exceeded the limit number of collections", 102, false, WithErrorType(InputError))
 	ErrCollectionNotFullyLoaded                = newMilvusError("collection not fully loaded", 103, true)
-	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false)
-	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false)
+	ErrCollectionLoaded                        = newMilvusError("collection already loaded", 104, false, WithErrorType(InputError))
+	ErrCollectionIllegalSchema                 = newMilvusError("illegal collection schema", 105, false, WithErrorType(InputError))
 	ErrCollectionOnRecovering                  = newMilvusError("collection on recovering", 106, true)
-	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false)
+	ErrCollectionVectorClusteringKeyNotAllowed = newMilvusError("vector clustering key not allowed", 107, false, WithErrorType(InputError))
 	// Deprecated, keep it only for reserving the error code
-	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false)
-	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false)
+	ErrCollectionReplicateMode         = newMilvusError("can't operate on the collection under standby mode", 108, false, WithErrorType(InputError))
+	ErrCollectionSchemaMismatch        = newMilvusError("collection schema mismatch", 109, false, WithErrorType(InputError))
 	ErrCollectionSchemaVersionNotReady = newMilvusError("collection schema version not ready", 110, true)
+
 	// Partition related
 	ErrPartitionNotFound       = newMilvusError("partition not found", 200, false)
 	ErrPartitionNotLoaded      = newMilvusError("partition not loaded", 201, false)
@@ -83,13 +92,13 @@ var (
 	ErrGeneralCapacityExceeded = newMilvusError("general capacity exceeded", 250, false)
 
 	// ResourceGroup related
-	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false)
-	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false)
-	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false)
-	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false)
+	ErrResourceGroupNotFound      = newMilvusError("resource group not found", 300, false, WithErrorType(InputError))
+	ErrResourceGroupAlreadyExist  = newMilvusError("resource group already exist, but create with different config", 301, false, WithErrorType(InputError))
+	ErrResourceGroupReachLimit    = newMilvusError("resource group num reach limit", 302, false, WithErrorType(InputError))
+	ErrResourceGroupIllegalConfig = newMilvusError("resource group illegal config", 303, false, WithErrorType(InputError))
 	// go:deprecated
-	ErrResourceGroupNodeNotEnough    = newMilvusError("resource group node not enough", 304, false)
-	ErrResourceGroupServiceAvailable = newMilvusError("resource group service available", 305, true)
+	ErrResourceGroupNodeNotEnough      = newMilvusError("resource group node not enough", 304, false)
+	ErrResourceGroupServiceUnAvailable = newMilvusError("resource group service unavailable", 305, true)
 
 	// Replica related
 	ErrReplicaNotFound     = newMilvusError("replica not found", 400, false)
@@ -118,13 +127,13 @@ var (
 	// Index related
 	ErrIndexNotFound     = newMilvusError("index not found", 700, false)
 	ErrIndexNotSupported = newMilvusError("index type not supported", 701, false)
-	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false)
+	ErrIndexDuplicate    = newMilvusError("index duplicates", 702, false, WithErrorType(InputError))
 	ErrTaskDuplicate     = newMilvusError("task duplicates", 703, false)
 
 	// Database related
-	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false)
-	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false)
-	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false)
+	ErrDatabaseNotFound         = newMilvusError("database not found", 800, false, WithErrorType(InputError))
+	ErrDatabaseNumLimitExceeded = newMilvusError("exceeded the limit number of database", 801, false, WithErrorType(InputError))
+	ErrDatabaseInvalidName      = newMilvusError("invalid database name", 802, false, WithErrorType(InputError))
 
 	// Node related
 	ErrNodeNotFound        = newMilvusError("node not found", 901, false)
@@ -167,7 +176,7 @@ var (
 
 	// Privilege related
 	// this operation is denied because the user not authorized, user need to login in first
-	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false)
+	ErrPrivilegeNotAuthenticated = newMilvusError("not authenticated", 1400, false, WithErrorType(InputError))
 	// this operation is denied because the user has no permission to do this, user need higher privilege
 	ErrPrivilegeNotPermitted     = newMilvusError("privilege not permitted", 1401, false)
 	ErrPrivilegeGroupInvalidName = newMilvusError("invalid privilege group name", 1402, false)
@@ -213,7 +222,7 @@ var (
 	errUnexpected = newMilvusError("unexpected error", (1<<16)-1, false)
 
 	// import
-	ErrImportFailed = newMilvusError("importing data failed", 2100, false)
+	ErrImportFailed = newMilvusError("importing data failed", 2100, false, WithErrorType(InputError))
 
 	// Search/Query related
 	ErrInconsistentRequery = newMilvusError("inconsistent requery result", 2200, true)
@@ -251,11 +260,6 @@ var (
 	// Snapshot related
 	ErrSnapshotNotFound = newMilvusError("snapshot not found", 2600, false)
 	ErrSnapshotPinned   = newMilvusError("snapshot is pinned", 2601, false)
-
-	// General
-	ErrOperationNotSupported = newMilvusError("unsupported operation", 3000, false)
-
-	ErrOldSessionExists = newMilvusError("old session exists", 3001, false)
 )
 
 type errorOption func(*milvusError)
@@ -314,6 +318,53 @@ func (e milvusError) Is(err error) bool {
 	return false
 }
 
+// GetErrorType implements the ErrorClassifier interface.
+// It returns the predefined classification of the error (SystemError or InputError).
+func (e milvusError) GetErrorType() ErrorType {
+	return e.errType
+}
+
+// wrappedMilvusError wraps an underlying error with a milvus sentinel and a
+// contextual message, while preserving the inner error chain. Designed so
+// all of the following work on the result, under both stdlib and cockroachdb
+// errors.Is semantics:
+//
+//   - errors.Is(result, sentinel)      → true   (matched via Is)
+//   - errors.Is(result, originalInner) → true   (inner reachable via Unwrap)
+//   - merr.Code(result)                → sentinel's errCode
+//
+// Cause is intentionally NOT overridden: cockroachdb's errors.Is walks the
+// Cause chain first, so returning the sentinel from Cause would hide the
+// inner error. Instead, merr.Code special-cases this type.
+type wrappedMilvusError struct {
+	msg      string
+	inner    error
+	sentinel milvusError
+}
+
+func (w *wrappedMilvusError) Error() string { return w.msg + ": " + w.inner.Error() }
+
+// Unwrap exposes the original error so errors.Is(w, originalInner) works
+// under both stdlib and cockroachdb chain walkers.
+func (w *wrappedMilvusError) Unwrap() error { return w.inner }
+
+// Is matches any milvus sentinel by delegating to the wrapped sentinel.
+func (w *wrappedMilvusError) Is(target error) bool {
+	return errors.Is(w.sentinel, target)
+}
+
+// code lets merr.Code retrieve the milvus error code without needing to
+// resolve the cause chain (which has been redirected to the inner error).
+func (w *wrappedMilvusError) code() int32 {
+	return w.sentinel.errCode
+}
+
+// GetErrorType lets ErrorClassifier consumers (proxy metrics, retry policy)
+// see the same classification as the sentinel.
+func (w *wrappedMilvusError) GetErrorType() ErrorType {
+	return w.sentinel.errType
+}
+
 type multiErrors struct {
 	errs []error
 }
@@ -358,4 +409,16 @@ func Combine(errs ...error) error {
 	return multiErrors{
 		errs,
 	}
+}
+
+func Wrap(err error, msg string) error {
+	return errors.Wrap(err, msg)
+}
+
+func Wrapf(err error, format string, args ...interface{}) error {
+	return errors.Wrapf(err, format, args...)
+}
+
+func Mark(err error, reference error) error {
+	return markers.Mark(err, reference)
 }

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -149,6 +149,27 @@ var (
 	ErrIoUnexpectEOF     = newMilvusError("unexpected EOF", 1002, true)
 	ErrIoTooManyRequests = newMilvusError("too many requests", 1003, true)
 
+	// Serialization / deserialization step failed — a transformation pipeline
+	// (proto Marshal/Unmarshal, json encode/decode, arrow schema conversion etc.)
+	// could not complete. Use for "conversion process failed" semantics rather
+	// than "stored bytes are corrupt" — for the latter use ErrDataIntegrity.
+	ErrSerializationFailed = newMilvusError("data serialization or deserialization failed", 1004, false)
+
+	// Data integrity check failed — bytes already on disk (binlog payload,
+	// event header extras, stats buffer) don't match the layout we expect from
+	// the schema (type mismatch, valuesRead vs rows mismatch, unknown column
+	// type, malformed event header). Likely permanent corruption; retry won't
+	// help. Distinct from ErrSerializationFailed (process step failed) and
+	// ErrParameterInvalid (caller-input we control).
+	ErrDataIntegrity = newMilvusError("data integrity check failed", 1009, false)
+
+	// Storage subsystem fallback — used for non-IO / non-serde / non-client-input
+	// failures inside the storage package (transaction state machine, writer/reader
+	// lifecycle, FFI internal failures, ext-table metadata operations).
+	// Prefer ErrIo*/ErrSerializationFailed/ErrDataIntegrity/ErrParameterInvalid
+	// when they fit; reach for ErrStorage only when none of those describe the failure.
+	ErrStorage = newMilvusError("storage internal error", 1008, false, WithErrorType(SystemError))
+
 	// Permanent errors - resource doesn't exist or access denied
 	ErrIoPermissionDenied   = newMilvusError("permission denied", 1005, false)
 	ErrIoBucketNotFound     = newMilvusError("bucket not found", 1006, false)
@@ -160,7 +181,7 @@ var (
 	ErrIoEntityTooLarge  = newMilvusError("entity too large", 1012, false)
 
 	// Parameter related
-	ErrParameterInvalid  = newMilvusError("invalid parameter", 1100, false)
+	ErrParameterInvalid  = newMilvusError("invalid parameter", 1100, false, WithErrorType(InputError))
 	ErrParameterMissing  = newMilvusError("missing parameter", 1101, false)
 	ErrParameterTooLarge = newMilvusError("parameter too large", 1102, false)
 

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 type ErrSuite struct {
@@ -34,7 +33,6 @@ type ErrSuite struct {
 }
 
 func (s *ErrSuite) SetupSuite() {
-	paramtable.Init()
 }
 
 func (s *ErrSuite) TestCode() {
@@ -104,7 +102,7 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrResourceGroupReachLimit("test_ResourceGroup", 1, "failed to get ResourceGroup"), ErrResourceGroupReachLimit)
 	s.ErrorIs(WrapErrResourceGroupIllegalConfig("test_ResourceGroup", nil, "failed to get ResourceGroup"), ErrResourceGroupIllegalConfig)
 	s.ErrorIs(WrapErrResourceGroupNodeNotEnough("test_ResourceGroup", 1, 2, "failed to get ResourceGroup"), ErrResourceGroupNodeNotEnough)
-	s.ErrorIs(WrapErrResourceGroupServiceAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceAvailable)
+	s.ErrorIs(WrapErrResourceGroupServiceUnAvailable("test_ResourceGroup", "failed to get ResourceGroup"), ErrResourceGroupServiceUnAvailable)
 
 	// Replica related
 	s.ErrorIs(WrapErrReplicaNotFound(1, "failed to get replica"), ErrReplicaNotFound)
@@ -224,7 +222,7 @@ func (s *ErrSuite) TestIsHealthy() {
 	}
 	for _, tc := range cases {
 		s.Run(tc.code.String(), func() {
-			s.Equal(tc.expect, IsHealthy(tc.code) == nil)
+			s.Equal(tc.expect, CheckHealthy(tc.code) == nil)
 		})
 	}
 }
@@ -274,4 +272,75 @@ func TestNewIOErrors(t *testing.T) {
 
 func TestErrors(t *testing.T) {
 	suite.Run(t, new(ErrSuite))
+}
+
+// TestWrapErrPreservesInnerChain locks in the contract that WrapErr*Err helpers
+// keep the inner error chain reachable via errors.Is while still attributing
+// the milvus sentinel for code lookup. Regression guard against the previous
+// implementation that string-flattened the inner error and lost its identity.
+func TestWrapErrPreservesInnerChain(t *testing.T) {
+	inner := errors.New("inner-error")
+
+	for _, tc := range []struct {
+		name     string
+		wrap     func() error
+		sentinel error
+		other    error
+		code     int32
+	}{
+		{
+			name:     "ServiceInternal",
+			wrap:     func() error { return WrapErrServiceInternalErr(inner, "ctx %s", "test") },
+			sentinel: ErrServiceInternal,
+			other:    ErrParameterInvalid,
+			code:     ErrServiceInternal.errCode,
+		},
+		{
+			name:     "ParameterInvalid",
+			wrap:     func() error { return WrapErrParameterInvalidErr(inner, "ctx %d", 42) },
+			sentinel: ErrParameterInvalid,
+			other:    ErrServiceInternal,
+			code:     ErrParameterInvalid.errCode,
+		},
+		{
+			name:     "MqInternal",
+			wrap:     func() error { return WrapErrMqInternal(inner, "step1", "step2") },
+			sentinel: ErrMqInternal,
+			other:    ErrServiceInternal,
+			code:     ErrMqInternal.errCode,
+		},
+		{
+			name:     "BuildCompactionRequestFail",
+			wrap:     func() error { return WrapErrBuildCompactionRequestFail(inner) },
+			sentinel: ErrBuildCompactionRequestFail,
+			other:    ErrServiceInternal,
+			code:     ErrBuildCompactionRequestFail.errCode,
+		},
+		{
+			name:     "GetCompactionPlanResultFail",
+			wrap:     func() error { return WrapErrGetCompactionPlanResultFail(inner) },
+			sentinel: ErrGetCompactionPlanResultFail,
+			other:    ErrServiceInternal,
+			code:     ErrGetCompactionPlanResultFail.errCode,
+		},
+		{
+			name:     "OperationNotSupported",
+			wrap:     func() error { return WrapErrOperationNotSupported(inner, "op %s", "drop") },
+			sentinel: ErrOperationNotSupported,
+			other:    ErrServiceInternal,
+			code:     ErrOperationNotSupported.errCode,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := tc.wrap()
+			assert.True(t, errors.Is(w, tc.sentinel), "must match its sentinel")
+			assert.True(t, errors.Is(w, inner), "must preserve inner chain")
+			assert.False(t, errors.Is(w, tc.other), "must not match unrelated sentinel")
+			assert.Equal(t, tc.code, Code(w), "Code() must report sentinel's code")
+			assert.Contains(t, w.Error(), inner.Error(), "message must include inner")
+		})
+	}
+
+	// nil err falls back to the Msg variant; just make sure that still works.
+	assert.True(t, errors.Is(WrapErrServiceInternalErr(nil, "no underlying err"), ErrServiceInternal))
 }

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -60,15 +60,9 @@ func Code(err error) int32 {
 }
 
 func IsRetryableErr(err error) bool {
-<<<<<<< HEAD
 	var milvusErr milvusError
 	if errors.As(err, &milvusErr) {
 		return milvusErr.retriable
-=======
-	var me milvusError
-	if errors.As(err, &me) {
-		return me.retriable
->>>>>>> 3a31bdeec4 (enhance: foundational merr framework and retry mechanisms)
 	}
 
 	return false
@@ -990,6 +984,87 @@ func WrapErrNodeNotMatch(expectedNodeID, actualNodeID int64, msg ...string) erro
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+// WrapErrSerializationFailedMsg creates a new ErrSerializationFailed (code 1004)
+// with a detail message. Used when stored bytes cannot be decoded into the
+// expected shape and there is no underlying error to wrap (e.g. valuesRead vs
+// rows mismatch in payload reader, type mismatch when reading a column from
+// the wrong DataType).
+func WrapErrSerializationFailedMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	return errors.Wrap(ErrSerializationFailed, detail)
+}
+
+// WrapErrSerializationFailed wraps an existing underlying error 'err' with
+// ErrSerializationFailed (code 1004). Used when a decode / unmarshal /
+// schema-conversion step fails with a non-typed inner error (json, proto,
+// arrow). If 'err' is already a typed merr, use merr.Wrap(err, msg) instead.
+func WrapErrSerializationFailed(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrSerializationFailedMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrSerializationFailed,
+	}
+}
+
+// WrapErrDataIntegrityMsg creates a new ErrDataIntegrity (code 1009) with a
+// detail message. Use when on-disk bytes don't conform to the expected schema
+// (binlog type mismatch, valuesRead vs rows mismatch, malformed event header,
+// unparseable stats buffer) — i.e. the stored data itself is corrupt, not the
+// (de)serialization step.
+func WrapErrDataIntegrityMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	return errors.Wrap(ErrDataIntegrity, detail)
+}
+
+// WrapErrDataIntegrity wraps an existing underlying error with ErrDataIntegrity
+// (code 1009). Use when stored-byte parsing surfaces a non-typed inner error
+// (json unmarshal of stats buffer, type assertion of decoded header extras).
+// If 'err' is already a typed merr, use merr.Wrap(err, msg) instead.
+func WrapErrDataIntegrity(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrDataIntegrityMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrDataIntegrity,
+	}
+}
+
+// WrapErrStorageMsg creates a new ErrStorage (code 1008) with a detail message.
+// Used when a logical internal error occurs in the storage layer (e.g. invalid
+// state, corrupted data structure check, nil data) and there is no underlying
+// Go error to wrap.
+func WrapErrStorageMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	return errors.Wrap(ErrStorage, detail)
+}
+
+// WrapErrStorage wraps an existing underlying error 'err' with ErrStorage
+// (code 1008). Used for storage subsystem failures (transaction state machine,
+// writer/reader lifecycle, FFI internal failures) that are not physical I/O,
+// not serialization, and not client-input errors.
+//
+// IMPORTANT: only use when 'err' is a raw error (FFI / fs / proto / arrow).
+// If 'err' is already a typed merr, use merr.Wrap(err, msg) instead — wrapping
+// a typed merr here would mask its inner code (defect#3 pattern).
+//
+// merr.Code(result) returns ErrStorage.code() = 1008; errors.Is(result, ErrStorage)
+// succeeds; errors.Is(result, err) also succeeds (inner chain preserved via Unwrap).
+func WrapErrStorage(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrStorageMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrStorage,
+	}
 }
 
 // IO related

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -1266,6 +1266,13 @@ func WrapErrSegcore(code int32, msg ...string) error {
 	return err
 }
 
+// WrapErrSegcoreMsg creates a new ErrSegcore (2000) with a Sprintf-formatted
+// message. Use for Go-side segcore invariants where there's no C++ errorCode
+// available (otherwise use WrapErrSegcore(code int32, msg ...string)).
+func WrapErrSegcoreMsg(format string, args ...any) error {
+	return errors.Wrap(ErrSegcore, fmt.Sprintf(format, args...))
+}
+
 func WrapErrSegcoreUnsupported(code int32, msg ...string) error {
 	err := wrapFields(ErrSegcoreUnsupported, value("segcoreCode", code))
 	if len(msg) > 0 {

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -19,16 +19,14 @@ package merr
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"go.uber.org/zap"
+	"golang.org/x/exp/constraints"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
-	"github.com/milvus-io/milvus/pkg/v3/log"
-	"github.com/milvus-io/milvus/pkg/v3/util/logutil"
-	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 const InputErrorFlagKey string = "is_input_error"
@@ -40,26 +38,37 @@ func Code(err error) int32 {
 		return 0
 	}
 
-	cause := errors.Cause(err)
-	switch specificErr := cause.(type) {
-	case milvusError:
-		return specificErr.code()
-
-	default:
-		if errors.Is(specificErr, context.Canceled) {
-			return CanceledCode
-		} else if errors.Is(specificErr, context.DeadlineExceeded) {
-			return TimeoutCode
-		} else {
-			return errUnexpected.code()
+	// Walk the chain looking for a milvus marker (either milvusError directly,
+	// or our wrappedMilvusError whose sentinel.Cause is hidden so that the
+	// inner error stays reachable via errors.Is). Stop at the first match.
+	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
+		switch v := cur.(type) {
+		case milvusError:
+			return v.code()
+		case *wrappedMilvusError:
+			return v.code()
 		}
 	}
+
+	cause := errors.Cause(err)
+	if errors.Is(cause, context.Canceled) {
+		return CanceledCode
+	} else if errors.Is(cause, context.DeadlineExceeded) {
+		return TimeoutCode
+	}
+	return errUnexpected.code()
 }
 
 func IsRetryableErr(err error) bool {
+<<<<<<< HEAD
 	var milvusErr milvusError
 	if errors.As(err, &milvusErr) {
 		return milvusErr.retriable
+=======
+	var me milvusError
+	if errors.As(err, &me) {
+		return me.retriable
+>>>>>>> 3a31bdeec4 (enhance: foundational merr framework and retry mechanisms)
 	}
 
 	return false
@@ -299,17 +308,6 @@ func SegcoreError(code int32, msg string) error {
 	return newMilvusError(msg, code, false)
 }
 
-// CheckHealthy checks whether the state is healthy,
-// returns nil if healthy,
-// otherwise returns ErrServiceNotReady wrapped with current state
-func CheckHealthy(state commonpb.StateCode) error {
-	if state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(paramtable.GetRole(), paramtable.GetNodeID(), state.String())
-	}
-
-	return nil
-}
-
 func IsHealthy(stateCode commonpb.StateCode) error {
 	if stateCode == commonpb.StateCode_Healthy {
 		return nil
@@ -324,19 +322,17 @@ func IsHealthyOrStopping(stateCode commonpb.StateCode) error {
 	return CheckHealthy(stateCode)
 }
 
-func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
-	if err := Error(state.GetStatus()); err != nil {
-		return errors.Wrapf(err, "%s=%d not healthy", role, nodeID)
-	} else if state := state.GetState().GetStateCode(); state != commonpb.StateCode_Healthy {
-		return WrapErrServiceNotReady(role, nodeID, state.String())
-	}
-
-	return nil
-}
-
 func WrapErrAsInputError(err error) error {
 	if merr, ok := err.(milvusError); ok {
 		WithErrorType(InputError)(&merr)
+		return merr
+	}
+	return err
+}
+
+func WrapErrAsSysError(err error) error {
+	if merr, ok := err.(milvusError); ok {
+		WithErrorType(SystemError)(&merr)
 		return merr
 	}
 	return err
@@ -346,7 +342,6 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	if merr, ok := err.(milvusError); ok {
 		for _, target := range targets {
 			if target.errCode == merr.errCode {
-				log.Info("mark error as input error", zap.Error(err))
 				WithErrorType(InputError)(&merr)
 				return merr
 			}
@@ -355,15 +350,43 @@ func WrapErrAsInputErrorWhen(err error, targets ...milvusError) error {
 	return err
 }
 
+func WrapErrCollectionReplicateMode(operation string) error {
+	return wrapFields(ErrCollectionReplicateMode, value("operation", operation))
+}
+
 func GetErrorType(err error) ErrorType {
-	if merr, ok := err.(milvusError); ok {
-		return merr.errType
+	var me milvusError
+	if errors.As(err, &me) {
+		return me.errType
 	}
 
 	return SystemError
 }
 
-// Service related
+// keeps only 2 decimal places
+func toMB[T constraints.Integer | constraints.Float](mem T) T {
+	return T(math.Round(float64(mem)/1024/1024*100) / 100)
+}
+
+// CheckHealthy checks whether the state is healthy,
+// returns nil if healthy,
+// otherwise returns ErrServiceNotReady wrapped with current state
+func CheckHealthy(stateCode commonpb.StateCode) error {
+	if stateCode != commonpb.StateCode_Healthy {
+		return ErrServiceNotReady
+	}
+	return nil
+}
+
+func AnalyzeState(role string, nodeID int64, state *milvuspb.ComponentStates) error {
+	if err := Error(state.GetStatus()); err != nil {
+		return WrapErrServiceNotReady(role, nodeID, err.Error())
+	} else if stateCode := state.GetState().GetStateCode(); stateCode != commonpb.StateCode_Healthy {
+		return WrapErrServiceNotReady(role, nodeID, stateCode.String())
+	}
+	return nil
+}
+
 func WrapErrServiceNotReady(role string, sessionID int64, state string, msg ...string) error {
 	err := wrapFieldsWithDesc(ErrServiceNotReady,
 		state,
@@ -385,8 +408,8 @@ func WrapErrServiceUnavailable(reason string, msg ...string) error {
 
 func WrapErrServiceMemoryLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceMemoryLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -412,6 +435,21 @@ func WrapErrServiceInternal(reason string, msg ...string) error {
 	return err
 }
 
+func WrapErrServiceInternalErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrServiceInternalMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrServiceInternal,
+	}
+}
+
+func WrapErrServiceInternalMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrServiceInternal, fmt, args...)
+}
+
 func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, msg ...string) error {
 	err := wrapFields(ErrServiceCrossClusterRouting,
 		value("expectedCluster", expectedCluster),
@@ -425,8 +463,8 @@ func WrapErrServiceCrossClusterRouting(expectedCluster, actualCluster string, ms
 
 func WrapErrServiceDiskLimitExceeded(predict, limit float32, msg ...string) error {
 	err := wrapFields(ErrServiceDiskLimitExceeded,
-		value("predict(MB)", logutil.ToMB(float64(predict))),
-		value("limit(MB)", logutil.ToMB(float64(limit))),
+		value("predict(MB)", toMB(float64(predict))),
+		value("limit(MB)", toMB(float64(limit))),
 	)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
@@ -715,9 +753,9 @@ func WrapErrResourceGroupNodeNotEnough(rg any, current any, expected any, msg ..
 	return err
 }
 
-// WrapErrResourceGroupServiceAvailable wraps ErrResourceGroupServiceAvailable with resource group
-func WrapErrResourceGroupServiceAvailable(msg ...string) error {
-	err := wrapFields(ErrResourceGroupServiceAvailable)
+// WrapErrResourceGroupServiceUnAvailable wraps ErrResourceGroupServiceUnAvailable with resource group
+func WrapErrResourceGroupServiceUnAvailable(msg ...string) error {
+	err := wrapFields(ErrResourceGroupServiceUnAvailable)
 	if len(msg) > 0 {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
@@ -1046,6 +1084,21 @@ func WrapErrParameterInvalid[T any](expected, actual T, msg ...string) error {
 	return err
 }
 
+// WrapErrParameterInvalidErr wraps an existing error 'err' with ErrParameterInvalid (Code 1005).
+// This is used when an underlying error (e.g., from parsing, validation utility, or dependency)
+// causes a parameter check to fail, and you need to provide extra context
+// in 'format' and 'args'.
+func WrapErrParameterInvalidErr(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrParameterInvalidMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrParameterInvalid,
+	}
+}
+
 func WrapErrParameterInvalidRange[T any](lower, upper, actual T, msg ...string) error {
 	err := wrapFields(ErrParameterInvalid,
 		bound("value", actual, lower, upper),
@@ -1068,6 +1121,10 @@ func WrapErrParameterMissing[T any](param T, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+func WrapErrParameterMissingMsg(fmt string, args ...any) error {
+	return errors.Wrapf(ErrParameterMissing, fmt, args...)
 }
 
 func WrapErrParameterTooLarge(name string, msg ...string) error {
@@ -1105,11 +1162,14 @@ func WrapErrMqTopicNotEmpty(name string, msg ...string) error {
 }
 
 func WrapErrMqInternal(err error, msg ...string) error {
-	err = wrapFieldsWithDesc(ErrMqInternal, err.Error())
-	if len(msg) > 0 {
-		err = errors.Wrap(err, strings.Join(msg, "->"))
+	if err == nil {
+		return ErrMqInternal
 	}
-	return err
+	ctx := ErrMqInternal.msg
+	if len(msg) > 0 {
+		ctx = strings.Join(msg, "->") + ": " + ctx
+	}
+	return &wrappedMilvusError{msg: ctx, inner: err, sentinel: ErrMqInternal}
 }
 
 func WrapErrPrivilegeNotAuthenticated(fmt string, args ...any) error {
@@ -1251,6 +1311,12 @@ func WrapErrIllegalCompactionPlan(msg ...string) error {
 	return err
 }
 
+func WrapErrIllegalCompactionPlanMsg(format string, args ...any) error {
+	detail := fmt.Sprintf(format, args...)
+	// Since this is the message-only path, we wrap the constant error with the formatted message.
+	return errors.Wrap(ErrIllegalCompactionPlan, detail)
+}
+
 func WrapErrCompactionPlanConflict(msg ...string) error {
 	err := error(ErrCompactionPlanConflict)
 	if len(msg) > 0 {
@@ -1319,11 +1385,25 @@ func WrapErrAnalyzeTaskNotFound(id int64) error {
 }
 
 func WrapErrBuildCompactionRequestFail(err error) error {
-	return wrapFieldsWithDesc(ErrBuildCompactionRequestFail, err.Error())
+	if err == nil {
+		return ErrBuildCompactionRequestFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrBuildCompactionRequestFail.msg,
+		inner:    err,
+		sentinel: ErrBuildCompactionRequestFail,
+	}
 }
 
 func WrapErrGetCompactionPlanResultFail(err error) error {
-	return wrapFieldsWithDesc(ErrGetCompactionPlanResultFail, err.Error())
+	if err == nil {
+		return ErrGetCompactionPlanResultFail
+	}
+	return &wrappedMilvusError{
+		msg:      ErrGetCompactionPlanResultFail.msg,
+		inner:    err,
+		sentinel: ErrGetCompactionPlanResultFail,
+	}
 }
 
 func WrapErrCompactionResult(msg ...string) error {
@@ -1383,4 +1463,23 @@ func WrapErrSnapshotPinned(name any, msg ...string) error {
 		err = errors.Wrap(err, strings.Join(msg, "->"))
 	}
 	return err
+}
+
+// WrapErrOperationNotSupportedMsg creates a new ErrOperationNotSupported with a detail message (Code 14).
+// This is the primary replacement for fmt.Errorf/errors.New for operations that are
+// currently not supported by the system.
+func WrapErrOperationNotSupportedMsg(format string, args ...any) error {
+	return errors.Wrapf(ErrOperationNotSupported, format, args...)
+}
+
+// WrapErrOperationNotSupported wraps an existing error 'err' with ErrOperationNotSupported (Code 14).
+func WrapErrOperationNotSupported(err error, format string, args ...any) error {
+	if err == nil {
+		return WrapErrOperationNotSupportedMsg(format, args...)
+	}
+	return &wrappedMilvusError{
+		msg:      fmt.Sprintf(format, args...),
+		inner:    err,
+		sentinel: ErrOperationNotSupported,
+	}
 }

--- a/pkg/util/metricsinfo/err.go
+++ b/pkg/util/metricsinfo/err.go
@@ -11,7 +11,7 @@
 
 package metricsinfo
 
-import "github.com/cockroachdb/errors"
+import "github.com/milvus-io/milvus/pkg/v3/util/merr"
 
 const (
 	// MsgUnimplementedMetric represents that user requests an unimplemented metric type
@@ -19,4 +19,4 @@ const (
 	msgInvalidSystemInfosMetricCache = "system infos metric is invalid"
 )
 
-var errInvalidSystemInfosMetricCache = errors.New(msgInvalidSystemInfosMetricCache)
+var errInvalidSystemInfosMetricCache = merr.WrapErrParameterInvalidMsg(msgInvalidSystemInfosMetricCache)

--- a/pkg/util/metricsinfo/metric_request.go
+++ b/pkg/util/metricsinfo/metric_request.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/cockroachdb/errors"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -146,7 +146,7 @@ func (mr *MetricsRequest) ExecuteMetricsRequest(ctx context.Context, req *milvus
 	if !ok {
 		mr.lock.Unlock()
 		log.Warn("unimplemented metric request type", zap.String("req_type", reqType))
-		return "", errors.New(MsgUnimplementedMetric)
+		return "", merr.WrapErrParameterInvalidMsg(MsgUnimplementedMetric)
 	}
 	mr.lock.Unlock()
 
@@ -179,7 +179,7 @@ func ParseMetricRequestType(jsonRet gjson.Result) (string, error) {
 		return v.String(), nil
 	}
 
-	return "", fmt.Errorf("%s or %s not found in request", MetricTypeKey, MetricRequestTypeKey)
+	return "", merr.WrapErrParameterInvalidMsg("%s or %s not found in request", MetricTypeKey, MetricRequestTypeKey)
 }
 
 func ParseMetricProcessInRole(jsonRet gjson.Result) (string, error) {
@@ -188,7 +188,7 @@ func ParseMetricProcessInRole(jsonRet gjson.Result) (string, error) {
 		return v.String(), nil
 	}
 
-	return "", fmt.Errorf("%s not found in request", MetricRequestProcessInRoleKey)
+	return "", merr.WrapErrParameterInvalidMsg("%s not found in request", MetricRequestProcessInRoleKey)
 }
 
 func GetCollectionIDFromRequest(jsonReq gjson.Result) int64 {
@@ -205,7 +205,7 @@ func ConstructRequestByMetricType(metricType string) (*milvuspb.GetMetricsReques
 	m[MetricTypeKey] = metricType
 	binary, err := json.Marshal(m)
 	if err != nil {
-		return nil, fmt.Errorf("failed to construct request by metric type %s: %s", metricType, err.Error())
+		return nil, merr.WrapErrParameterInvalidMsg("failed to construct request by metric type %s: %s", metricType, err.Error())
 	}
 	// TODO:: switch metricType to different msgType and return err when metricType is not supported
 	return &milvuspb.GetMetricsRequest{
@@ -219,7 +219,7 @@ func ConstructRequestByMetricType(metricType string) (*milvuspb.GetMetricsReques
 func ConstructGetMetricsRequest(m map[string]interface{}) (*milvuspb.GetMetricsRequest, error) {
 	binary, err := json.Marshal(m)
 	if err != nil {
-		return nil, fmt.Errorf("failed to construct request: %s", err.Error())
+		return nil, merr.WrapErrParameterInvalidMsg("failed to construct request: %s", err.Error())
 	}
 
 	return &milvuspb.GetMetricsRequest{

--- a/pkg/util/paramtable/autoindex_param.go
+++ b/pkg/util/paramtable/autoindex_param.go
@@ -19,11 +19,10 @@ package paramtable
 import (
 	"strconv"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metric"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -421,7 +420,7 @@ func GetBuildParamFormatter(defaultMetricsType metric.MetricType, tag string) fu
 	return func(originValue string) string {
 		m, err := funcutil.JSONToMap(originValue)
 		if err != nil {
-			panic(errors.Wrapf(err, "failed to parse %s config value", tag))
+			panic(merr.Wrapf(err, "failed to parse %s config value", tag))
 		}
 		_, ok := m[common.MetricTypeKey]
 		if ok {
@@ -430,7 +429,7 @@ func GetBuildParamFormatter(defaultMetricsType metric.MetricType, tag string) fu
 		m[common.MetricTypeKey] = defaultMetricsType
 		ret, err := funcutil.MapToJSON(m)
 		if err != nil {
-			panic(errors.Wrapf(err, "failed to convert updated %s map to json", tag))
+			panic(merr.Wrapf(err, "failed to convert updated %s map to json", tag))
 		}
 		return ret
 	}

--- a/pkg/util/paramtable/grpc_param.go
+++ b/pkg/util/paramtable/grpc_param.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 const (
@@ -616,7 +617,7 @@ func (p *InternalTLSConfig) GetClientCreds(ctx context.Context) (credentials.Tra
 	creds, err := credentials.NewClientTLSFromFile(caPemPath, sni)
 	if err != nil {
 		log.Ctx(ctx).Error("Failed to create internal TLS credentials", zap.Error(err))
-		return nil, fmt.Errorf("failed to create internal TLS credentials: %w", err)
+		return nil, merr.Wrap(err, "failed to create internal TLS credentials")
 	}
 	return creds, nil
 }

--- a/pkg/util/ratelimitutil/rate_collector.go
+++ b/pkg/util/ratelimitutil/rate_collector.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/samber/lo"
 )
 
@@ -54,10 +55,10 @@ func NewRateCollector(window time.Duration, granularity time.Duration, enableSub
 // newRateCollector returns a new RateCollector with given window and granularity.
 func newRateCollector(window time.Duration, granularity time.Duration, now time.Time, enableSubLabel bool) (*RateCollector, error) {
 	if window == 0 || granularity == 0 {
-		return nil, fmt.Errorf("create RateCollector failed, window or granularity cannot be 0, window = %d, granularity = %d", window, granularity)
+		return nil, merr.WrapErrParameterInvalidMsg("create RateCollector failed, window or granularity cannot be 0, window = %d, granularity = %d", window, granularity)
 	}
 	if window < granularity || window%granularity != 0 {
-		return nil, fmt.Errorf("create RateCollector failed, window has to be a multiplier of the granularity, window = %d, granularity = %d", window, granularity)
+		return nil, merr.WrapErrParameterInvalidMsg("create RateCollector failed, window has to be a multiplier of the granularity, window = %d, granularity = %d", window, granularity)
 	}
 	rc := &RateCollector{
 		window:      window,
@@ -233,7 +234,7 @@ func (r *RateCollector) max(label string, now time.Time) (float64, error) {
 		}
 		return max, nil
 	}
-	return 0, fmt.Errorf("RateColletor didn't register for label %s", label)
+	return 0, merr.WrapErrParameterInvalidMsg("RateColletor didn't register for label %s", label)
 }
 
 // Min is shorthand for min(label, time.Now()).
@@ -255,7 +256,7 @@ func (r *RateCollector) min(label string, now time.Time) (float64, error) {
 		}
 		return min, nil
 	}
-	return 0, fmt.Errorf("RateColletor didn't register for label %s", label)
+	return 0, merr.WrapErrParameterInvalidMsg("RateColletor didn't register for label %s", label)
 }
 
 // Rate is shorthand for rate(label, duration, time.Now()).
@@ -308,7 +309,7 @@ func (r *RateCollector) rate(label string, duration time.Duration, now time.Time
 		}
 		return total / float64(size), nil
 	}
-	return 0, fmt.Errorf("RateColletor didn't register for label %s", label)
+	return 0, merr.WrapErrParameterInvalidMsg("RateColletor didn't register for label %s", label)
 }
 
 // update would update position and clear old values.

--- a/pkg/util/replicateutil/config_helper.go
+++ b/pkg/util/replicateutil/config_helper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -101,7 +102,7 @@ func NewConfigHelper(currentClusterID string, cfg *commonpb.ReplicateConfigurati
 		}
 	}
 	if primaryCount != 1 {
-		return nil, errors.Wrap(ErrWrongConfiguration, "primary count is not 1")
+		return nil, merr.Wrap(ErrWrongConfiguration, "primary count is not 1")
 	}
 	if _, ok := vs[currentClusterID]; !ok {
 		return nil, ErrCurrentClusterNotFound
@@ -109,7 +110,7 @@ func NewConfigHelper(currentClusterID string, cfg *commonpb.ReplicateConfigurati
 	pchannels := len(vs[currentClusterID].Pchannels)
 	for _, vertice := range vs {
 		if len(vertice.Pchannels) != pchannels {
-			return nil, errors.Wrap(ErrWrongConfiguration, fmt.Sprintf("pchannel count is not equal for cluster %s", vertice.GetClusterId()))
+			return nil, merr.Wrapf(ErrWrongConfiguration, "pchannel count is not equal for cluster %s", vertice.GetClusterId())
 		}
 	}
 	h.currentClusterID = currentClusterID
@@ -213,11 +214,11 @@ func (v *MilvusCluster) MustGetSourceChannel(pchannel string) string {
 // GetTargetChannel returns the target channel of the current cluster.
 func (v *MilvusCluster) GetTargetChannel(currentClusterPChannel string, targetClusterID string) (string, error) {
 	if !v.targets.Contain(targetClusterID) {
-		return "", errors.Errorf("target cluster %s not found, current cluster is %s", targetClusterID, v.GetClusterId())
+		return "", merr.WrapErrParameterInvalidMsg("target cluster %s not found, current cluster is %s", targetClusterID, v.GetClusterId())
 	}
 	idx, ok := v.idxMap[currentClusterPChannel]
 	if !ok {
-		return "", errors.Errorf("current cluster pchannel %s not found in the graph", currentClusterPChannel)
+		return "", merr.WrapErrServiceInternalMsg("current cluster pchannel %s not found in the graph", currentClusterPChannel)
 	}
 	target := v.h.vs[targetClusterID]
 	return target.Pchannels[idx], nil

--- a/pkg/util/replicateutil/config_validator.go
+++ b/pkg/util/replicateutil/config_validator.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // ReplicateConfigValidator validates ReplicateConfiguration according to business rules
@@ -50,11 +51,11 @@ func NewReplicateConfigValidator(incomingConfig, currentConfig *commonpb.Replica
 // Validate performs all validation checks on the configuration
 func (v *ReplicateConfigValidator) Validate() error {
 	if v.incomingConfig == nil {
-		return fmt.Errorf("config cannot be nil")
+		return merr.WrapErrParameterInvalidMsg("config cannot be nil")
 	}
 	clusters := v.incomingConfig.GetClusters()
 	if len(clusters) == 0 {
-		return fmt.Errorf("clusters list cannot be empty")
+		return merr.WrapErrParameterInvalidMsg("clusters list cannot be empty")
 	}
 	// Perform all validation checks
 	if err := v.validateClusterBasic(clusters); err != nil {
@@ -86,47 +87,47 @@ func (v *ReplicateConfigValidator) validateClusterBasic(clusters []*commonpb.Mil
 	uriSet := make(map[string]string)
 	for i, cluster := range clusters {
 		if cluster == nil {
-			return fmt.Errorf("cluster at index %d is nil", i)
+			return merr.WrapErrParameterInvalidMsg("cluster at index %d is nil", i)
 		}
 		// clusterID validation: non-empty and no whitespace
 		clusterID := cluster.GetClusterId()
 		if clusterID == "" {
-			return fmt.Errorf("cluster at index %d has empty clusterID", i)
+			return merr.WrapErrParameterInvalidMsg("cluster at index %d has empty clusterID", i)
 		}
 		if strings.ContainsAny(clusterID, " \t\n\r") {
-			return fmt.Errorf("cluster at index %d has clusterID '%s' containing whitespace characters", i, clusterID)
+			return merr.WrapErrParameterInvalidMsg("cluster at index %d has clusterID '%s' containing whitespace characters", i, clusterID)
 		}
 		// connection_param.uri validation: non-empty and basic URI format
 		connParam := cluster.GetConnectionParam()
 		if connParam == nil {
-			return fmt.Errorf("cluster '%s' has nil connection_param", clusterID)
+			return merr.WrapErrParameterInvalidMsg("cluster '%s' has nil connection_param", clusterID)
 		}
 		uri := connParam.GetUri()
 		if uri == "" {
-			return fmt.Errorf("cluster '%s' has empty URI", clusterID)
+			return merr.WrapErrParameterInvalidMsg("cluster '%s' has empty URI", clusterID)
 		}
 		_, err := url.ParseRequestURI(uri)
 		if err != nil {
-			return fmt.Errorf("cluster '%s' has invalid URI format: '%s'", clusterID, uri)
+			return merr.WrapErrParameterInvalidMsg("cluster '%s' has invalid URI format: '%s'", clusterID, uri)
 		}
 		// Check URI uniqueness
 		if existingClusterID, exists := uriSet[uri]; exists {
-			return fmt.Errorf("duplicate URI found: '%s' is used by both cluster '%s' and cluster '%s'", uri, existingClusterID, clusterID)
+			return merr.WrapErrParameterInvalidMsg("duplicate URI found: '%s' is used by both cluster '%s' and cluster '%s'", uri, existingClusterID, clusterID)
 		}
 		uriSet[uri] = clusterID
 		// pchannels validation: non-empty
 		pchannels := cluster.GetPchannels()
 		if len(pchannels) == 0 {
-			return fmt.Errorf("cluster '%s' has empty pchannels", clusterID)
+			return merr.WrapErrParameterInvalidMsg("cluster '%s' has empty pchannels", clusterID)
 		}
 		// pchannels uniqueness within cluster
 		pchannelSet := make(map[string]bool)
 		for j, pchannel := range pchannels {
 			if pchannel == "" {
-				return fmt.Errorf("cluster '%s' has empty pchannel at index %d", clusterID, j)
+				return merr.WrapErrParameterInvalidMsg("cluster '%s' has empty pchannel at index %d", clusterID, j)
 			}
 			if pchannelSet[pchannel] {
-				return fmt.Errorf("cluster '%s' has duplicate pchannel: '%s'", clusterID, pchannel)
+				return merr.WrapErrParameterInvalidMsg("cluster '%s' has duplicate pchannel: '%s'", clusterID, pchannel)
 			}
 			pchannelSet[pchannel] = true
 		}
@@ -135,12 +136,12 @@ func (v *ReplicateConfigValidator) validateClusterBasic(clusters []*commonpb.Mil
 			expectedPchannelCount = len(pchannels)
 			firstClusterID = clusterID
 		} else if len(pchannels) != expectedPchannelCount {
-			return fmt.Errorf("cluster '%s' has %d pchannels, but expected %d (same as cluster '%s')",
+			return merr.WrapErrParameterInvalidMsg("cluster '%s' has %d pchannels, but expected %d (same as cluster '%s')",
 				clusterID, len(pchannels), expectedPchannelCount, firstClusterID)
 		}
 		// Build cluster maps
 		if _, exists := v.clusterMap[clusterID]; exists {
-			return fmt.Errorf("duplicate clusterID found: '%s'", clusterID)
+			return merr.WrapErrParameterInvalidMsg("duplicate clusterID found: '%s'", clusterID)
 		}
 		v.clusterMap[clusterID] = cluster
 	}
@@ -151,10 +152,10 @@ func (v *ReplicateConfigValidator) validateClusterBasic(clusters []*commonpb.Mil
 func (v *ReplicateConfigValidator) validateRelevance() error {
 	currentCluster, exists := v.clusterMap[v.currentClusterID]
 	if !exists {
-		return fmt.Errorf("current Milvus cluster '%s' must be included in the clusters list", v.currentClusterID)
+		return merr.WrapErrParameterInvalidMsg("current Milvus cluster '%s' must be included in the clusters list", v.currentClusterID)
 	}
 	if !equalIgnoreOrder(v.currentPChannels, currentCluster.GetPchannels()) {
-		return fmt.Errorf("current pchannels do not match the pchannels in the config, current pchannels: %v, config pchannels: %v", v.currentPChannels, currentCluster.GetPchannels())
+		return merr.WrapErrParameterInvalidMsg("current pchannels do not match the pchannels in the config, current pchannels: %v, config pchannels: %v", v.currentPChannels, currentCluster.GetPchannels())
 	}
 	return nil
 }
@@ -167,21 +168,21 @@ func (v *ReplicateConfigValidator) validateTopologyEdgeUniqueness(topologies []*
 	edgeSet := make(map[string]struct{})
 	for i, topology := range topologies {
 		if topology == nil {
-			return fmt.Errorf("topology at index %d is nil", i)
+			return merr.WrapErrParameterInvalidMsg("topology at index %d is nil", i)
 		}
 		sourceClusterID := topology.GetSourceClusterId()
 		targetClusterID := topology.GetTargetClusterId()
 		// Validate edge endpoints exist
 		if _, exists := v.clusterMap[sourceClusterID]; !exists {
-			return fmt.Errorf("topology at index %d references non-existent source cluster: '%s'", i, sourceClusterID)
+			return merr.WrapErrParameterInvalidMsg("topology at index %d references non-existent source cluster: '%s'", i, sourceClusterID)
 		}
 		if _, exists := v.clusterMap[targetClusterID]; !exists {
-			return fmt.Errorf("topology at index %d references non-existent target cluster: '%s'", i, targetClusterID)
+			return merr.WrapErrParameterInvalidMsg("topology at index %d references non-existent target cluster: '%s'", i, targetClusterID)
 		}
 		// Edge uniqueness
 		edgeKey := fmt.Sprintf("%s->%s", sourceClusterID, targetClusterID)
 		if _, exists := edgeSet[edgeKey]; exists {
-			return fmt.Errorf("duplicate topology relationship found: '%s'", edgeKey)
+			return merr.WrapErrParameterInvalidMsg("duplicate topology relationship found: '%s'", edgeKey)
 		}
 		edgeSet[edgeKey] = struct{}{}
 	}
@@ -215,14 +216,14 @@ func (v *ReplicateConfigValidator) validateTopologyTypeConstraint(topologies []*
 		if outDegree[clusterID] == clusterCount-1 && inDegree[clusterID] == 0 {
 			if centerNode != "" {
 				// Multiple center nodes found
-				return fmt.Errorf("multiple center nodes found, only one center node is allowed in star topology")
+				return merr.WrapErrParameterInvalidMsg("multiple center nodes found, only one center node is allowed in star topology")
 			}
 			centerNode = clusterID
 		}
 	}
 	if centerNode == "" {
 		// No center node found
-		return fmt.Errorf("no center node found, star topology must have exactly one center node")
+		return merr.WrapErrParameterInvalidMsg("no center node found, star topology must have exactly one center node")
 	}
 	// Validate other nodes (in-degree = 1, out-degree = 0)
 	for clusterID := range v.clusterMap {
@@ -230,7 +231,7 @@ func (v *ReplicateConfigValidator) validateTopologyTypeConstraint(topologies []*
 			continue
 		}
 		if inDegree[clusterID] != 1 || outDegree[clusterID] != 0 {
-			return fmt.Errorf("cluster '%s' does not follow star topology pattern (in-degree=%d, out-degree=%d)",
+			return merr.WrapErrParameterInvalidMsg("cluster '%s' does not follow star topology pattern (in-degree=%d, out-degree=%d)",
 				clusterID, inDegree[clusterID], outDegree[clusterID])
 		}
 	}
@@ -272,11 +273,11 @@ func (v *ReplicateConfigValidator) validateClusterConsistency(current, incoming 
 	currentPchannels := current.GetPchannels()
 	incomingPchannels := incoming.GetPchannels()
 	if len(incomingPchannels) < len(currentPchannels) {
-		return fmt.Errorf("cluster '%s' pchannels cannot decrease: current=%d, incoming=%d",
+		return merr.WrapErrParameterInvalidMsg("cluster '%s' pchannels cannot decrease: current=%d, incoming=%d",
 			current.GetClusterId(), len(currentPchannels), len(incomingPchannels))
 	}
 	if !slices.Equal(currentPchannels, incomingPchannels[:len(currentPchannels)]) {
-		return fmt.Errorf("cluster '%s' existing pchannels must be preserved at the same positions: current=%v, incoming=%v",
+		return merr.WrapErrParameterInvalidMsg("cluster '%s' existing pchannels must be preserved at the same positions: current=%v, incoming=%v",
 			current.GetClusterId(), currentPchannels, incomingPchannels)
 	}
 	if len(incomingPchannels) > len(currentPchannels) {
@@ -288,11 +289,11 @@ func (v *ReplicateConfigValidator) validateClusterConsistency(current, incoming 
 	incomingConn := incoming.GetConnectionParam()
 
 	if currentConn.GetUri() != incomingConn.GetUri() {
-		return fmt.Errorf("cluster '%s' connection_param.uri cannot be changed: current=%s, incoming=%s",
+		return merr.WrapErrParameterInvalidMsg("cluster '%s' connection_param.uri cannot be changed: current=%s, incoming=%s",
 			current.GetClusterId(), currentConn.GetUri(), incomingConn.GetUri())
 	}
 	if currentConn.GetToken() != incomingConn.GetToken() {
-		return fmt.Errorf("cluster '%s' connection_param.token cannot be changed",
+		return merr.WrapErrParameterInvalidMsg("cluster '%s' connection_param.token cannot be changed",
 			current.GetClusterId())
 	}
 

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -178,22 +178,18 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				return err
 			}
 
-			// Caller-explicit RetryErr predicate takes precedence over the
-			// default InputError abort: when caller passes RetryErr they have
-			// decided which errors are retriable, framework must not override.
-			if c.isRetryErr != nil {
-				if !c.isRetryErr(err) {
-					log.Warn("retry func failed, not be retryable",
-						zap.Uint("retried", i),
-						zap.Uint("attempt", c.attempts),
-						zap.String("caller", getCaller(2)),
-					)
-					return err
-				}
-			} else if merr.GetErrorType(err) == merr.InputError {
-				log.Warn("retry func failed, input error is non-retriable",
+			// shouldRetry=true is the caller's explicit affirmative. Honor
+			// it. The optional RetryErr predicate is still consulted as a
+			// second gate, but unlike retry.Do the InputError default abort
+			// is intentionally not applied here: in retry.Handle the caller
+			// signals abort via shouldRetry=false, not via the error type,
+			// otherwise client-side cache-eviction patterns like
+			// retryIfSchemaError become unreachable for errors classified
+			// server-side as InputError (e.g. ErrCollectionSchemaMismatch).
+			if c.isRetryErr != nil && !c.isRetryErr(err) {
+				log.Warn("retry func failed, not be retryable",
 					zap.Uint("retried", i),
-					zap.Error(err),
+					zap.Uint("attempt", c.attempts),
 					zap.String("caller", getCaller(2)),
 				)
 				return err

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -72,10 +72,23 @@ func Do(ctx context.Context, fn func() error, opts ...Option) error {
 				}
 				return err
 			}
-			if c.isRetryErr != nil && !c.isRetryErr(err) {
-				log.Warn("retry func failed, not be retryable",
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
 					zap.Uint("retried", i),
-					zap.Uint("attempt", c.attempts),
+					zap.Error(err),
 					zap.String("caller", getCaller(2)),
 				)
 				return err
@@ -162,6 +175,27 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 				if isContextErr && lastErr != nil {
 					return lastErr
 				}
+				return err
+			}
+
+			// Caller-explicit RetryErr predicate takes precedence over the
+			// default InputError abort: when caller passes RetryErr they have
+			// decided which errors are retriable, framework must not override.
+			if c.isRetryErr != nil {
+				if !c.isRetryErr(err) {
+					log.Warn("retry func failed, not be retryable",
+						zap.Uint("retried", i),
+						zap.Uint("attempt", c.attempts),
+						zap.String("caller", getCaller(2)),
+					)
+					return err
+				}
+			} else if merr.GetErrorType(err) == merr.InputError {
+				log.Warn("retry func failed, input error is non-retriable",
+					zap.Uint("retried", i),
+					zap.Error(err),
+					zap.String("caller", getCaller(2)),
+				)
 				return err
 			}
 

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -241,7 +241,7 @@ func Handle(ctx context.Context, fn func() (bool, error), opts ...Option) error 
 }
 
 // errUnrecoverable is error instance for unrecoverable.
-var errUnrecoverable = errors.New("unrecoverable error")
+var errUnrecoverable = merr.WrapErrParameterInvalidMsg("unrecoverable error")
 
 // Unrecoverable method wrap an error to unrecoverableError. This will make retry
 // quick return.

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -239,3 +239,53 @@ func TestHandle(t *testing.T) {
 	}, Attempts(10))
 	assert.NoError(t, err)
 }
+
+// Regression: Handle must honor the caller's shouldRetry=true even when the
+// returned error is server-classified InputError. This is the cross-case the
+// client-side cache-eviction pattern in retryIfSchemaError depends on:
+// ErrCollectionSchemaMismatch is tagged InputError server-side (the client
+// sent a stale schema and the server rejected) but the client legitimately
+// wants to evict its cache and retry. Before this case the framework's
+// "default InputError abort" was firing after shouldRetry=true and
+// retryIfSchemaError silently never retried.
+func TestHandle_ShouldRetryOverridesInputErrorDefault(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		if counter == 1 {
+			return true, merr.WrapErrCollectionSchemaMisMatch("mocked")
+		}
+		return false, nil
+	}, Attempts(10))
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, counter,
+		"Handle should retry once when caller returns shouldRetry=true on InputError")
+}
+
+// Symmetric guard: shouldRetry=false on InputError still aborts immediately
+// (this path was already correct; pinning it down so the regression fix
+// above doesn't accidentally turn into "always retry InputError").
+func TestHandle_ShouldRetryFalseAbortsOnInputError(t *testing.T) {
+	counter := 0
+	err := Handle(context.Background(), func() (bool, error) {
+		counter++
+		return false, merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter)
+}
+
+// retry.Do has no shouldRetry signal from the caller, so the InputError
+// default abort remains the right behavior — keep it pinned.
+func TestDo_InputErrorAbortsByDefault(t *testing.T) {
+	counter := 0
+	err := Do(context.Background(), func() error {
+		counter++
+		return merr.WrapErrCollectionSchemaMisMatch("mocked")
+	}, Attempts(10))
+
+	assert.ErrorIs(t, err, merr.ErrCollectionSchemaMismatch)
+	assert.Equal(t, 1, counter, "Do should abort on InputError without retrying")
+}

--- a/pkg/util/timestamptz/timestamptz.go
+++ b/pkg/util/timestamptz/timestamptz.go
@@ -6,11 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // Define max/min offset boundaries in seconds for validation, exported for external checks if necessary.
@@ -40,7 +39,7 @@ func validateOffset(t time.Time) (time.Time, error) {
 	_, offsetSeconds := t.Zone()
 	if offsetSeconds > MaxOffsetSeconds || offsetSeconds < MinOffsetSeconds {
 		offsetHours := offsetSeconds / 3600
-		return time.Time{}, fmt.Errorf("UTC offset hour %d is out of the valid range [%d, %d]",
+		return time.Time{}, merr.WrapErrParameterInvalidMsg("UTC offset hour %d is out of the valid range [%d, %d]",
 			offsetHours, MinOffsetSeconds/3600, MaxOffsetSeconds/3600)
 	}
 	return t, nil
@@ -73,7 +72,7 @@ func ParseTimeTz(inputStr string, defaultTimezoneStr string) (time.Time, error) 
 
 	loc, err := time.LoadLocation(defaultTimezoneStr)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("invalid default timezone string '%s': %w", defaultTimezoneStr, err)
+		return time.Time{}, merr.Wrapf(err, "invalid default timezone string '%s'", defaultTimezoneStr)
 	}
 
 	// 4. Fallback parsing: Attempt to parse a naive string using NaiveTzLayouts
@@ -89,7 +88,7 @@ func ParseTimeTz(inputStr string, defaultTimezoneStr string) (time.Time, error) 
 	}
 
 	if !parsed {
-		return time.Time{}, fmt.Errorf("invalid timestamp string: '%s'. Does not match any known format", inputStr)
+		return time.Time{}, merr.WrapErrParameterInvalidMsg("invalid timestamp string: '%s'. Does not match any known format", inputStr)
 	}
 
 	// No offset validation needed here: The time was assigned the safe defaultTimezoneStr (loc),
@@ -132,13 +131,13 @@ func CompareUnixMicroTz(ts1 string, ts2 string, defaultTimezoneStr string) (bool
 	// 1. Parse the first timestamp
 	t1, err := ParseTimeTz(ts1, defaultTimezoneStr)
 	if err != nil {
-		return false, fmt.Errorf("error parsing first timestamp '%s': %w", ts1, err)
+		return false, merr.Wrapf(err, "error parsing first timestamp '%s'", ts1)
 	}
 
 	// 2. Parse the second timestamp
 	t2, err := ParseTimeTz(ts2, defaultTimezoneStr)
 	if err != nil {
-		return false, fmt.Errorf("error parsing second timestamp '%s': %w", ts2, err)
+		return false, merr.Wrapf(err, "error parsing second timestamp '%s'", ts2)
 	}
 
 	// 3. Compare their Unix Microsecond values (int64)
@@ -151,7 +150,7 @@ func CompareUnixMicroTz(ts1 string, ts2 string, defaultTimezoneStr string) (bool
 func ConvertUnixMicroToTimezoneString(ts int64, targetTimezoneStr string) (string, error) {
 	loc, err := time.LoadLocation(targetTimezoneStr)
 	if err != nil {
-		return "", fmt.Errorf("invalid target timezone string '%s': %w", targetTimezoneStr, err)
+		return "", merr.Wrapf(err, "invalid target timezone string '%s'", targetTimezoneStr)
 	}
 
 	// 1. Convert Unix Microsecond (UTC) to a time.Time object (still in UTC).
@@ -391,7 +390,7 @@ func RewriteTimestampTzDefaultValueToString(schema *schemapb.CollectionSchema) e
 			// In a real system, you might log the error and use the raw int64 as a fallback string,
 			// but here we'll set a placeholder string to avoid crashing.
 			tzString = fmt.Sprintf("error converting timestamp: %v", err)
-			return errors.Wrap(err, tzString)
+			return merr.Wrap(err, tzString)
 		}
 
 		// 5. Rewrite the default value field in the response schema.

--- a/pkg/util/typeutil/convension.go
+++ b/pkg/util/typeutil/convension.go
@@ -18,7 +18,6 @@ package typeutil
 
 import (
 	"encoding/binary"
-	"fmt"
 	"math"
 	"reflect"
 
@@ -26,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // Generic Clone for proto message
@@ -52,7 +52,7 @@ func BytesToFloat32(bytes []byte) float32 {
 // BytesToInt64 converts a byte slice to uint64.
 func BytesToInt64(b []byte) (int64, error) {
 	if len(b) != 8 {
-		return 0, fmt.Errorf("failed to convert []byte to int64: invalid data, must 8 bytes, but %d", len(b))
+		return 0, merr.WrapErrParameterInvalidMsg("failed to convert []byte to int64: invalid data, must 8 bytes, but %d", len(b))
 	}
 
 	return int64(common.Endian.Uint64(b)), nil
@@ -68,7 +68,7 @@ func Int64ToBytes(v int64) []byte {
 // BigEndianBytesToUint64 converts a byte slice (big endian) to uint64.
 func BigEndianBytesToUint64(b []byte) (uint64, error) {
 	if len(b) != 8 {
-		return 0, fmt.Errorf("failed to convert []byte to uint64: invalid data, must 8 bytes, but %d", len(b))
+		return 0, merr.WrapErrParameterInvalidMsg("failed to convert []byte to uint64: invalid data, must 8 bytes, but %d", len(b))
 	}
 
 	// do not use little or common endian for compatibility issues(the msgid used in rocksmq is using this)
@@ -85,7 +85,7 @@ func Uint64ToBytesBigEndian(v uint64) []byte {
 // BytesToUint64 converts a byte slice to uint64.
 func BytesToUint64(b []byte) (uint64, error) {
 	if len(b) != 8 {
-		return 0, fmt.Errorf("failed to convert []byte to uint64: invalid data, must 8 bytes, but %d", len(b))
+		return 0, merr.WrapErrParameterInvalidMsg("failed to convert []byte to uint64: invalid data, must 8 bytes, but %d", len(b))
 	}
 	return common.Endian.Uint64(b), nil
 }

--- a/pkg/util/typeutil/field_data.go
+++ b/pkg/util/typeutil/field_data.go
@@ -1,9 +1,8 @@
 package typeutil
 
 import (
-	"fmt"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type FieldDataBuilder struct {
@@ -28,7 +27,7 @@ func NewFieldDataBuilder(dt schemapb.DataType, fillZero bool, capacity int) (*Fi
 			fillZero: fillZero,
 		}, nil
 	default:
-		return nil, fmt.Errorf("not supported field type: %s", dt.String())
+		return nil, merr.WrapErrParameterInvalidMsg("not supported field type: %s", dt.String())
 	}
 }
 

--- a/pkg/util/typeutil/field_schema.go
+++ b/pkg/util/typeutil/field_schema.go
@@ -1,13 +1,11 @@
 package typeutil
 
 import (
-	"fmt"
 	"strconv"
-
-	"github.com/cockroachdb/errors"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type FieldSchemaHelper struct {
@@ -18,20 +16,20 @@ type FieldSchemaHelper struct {
 
 func (h *FieldSchemaHelper) GetDim() (int64, error) {
 	if !IsVectorType(h.schema.GetDataType()) {
-		return 0, fmt.Errorf("%s is not of vector type", h.schema.GetDataType())
+		return 0, merr.WrapErrParameterInvalidMsg("%s is not of vector type", h.schema.GetDataType())
 	}
 	if IsSparseFloatVectorType(h.schema.GetDataType()) {
-		return 0, errors.New("typeutil.GetDim should not invoke on sparse vector type")
+		return 0, merr.WrapErrParameterInvalidMsg("typeutil.GetDim should not invoke on sparse vector type")
 	}
 
 	getDim := func(kvPairs *kvPairsHelper[string, string]) (int64, error) {
 		dimStr, err := kvPairs.Get(common.DimKey)
 		if err != nil {
-			return 0, errors.New("dim not found")
+			return 0, merr.WrapErrParameterInvalidMsg("dim not found")
 		}
 		dim, err := strconv.Atoi(dimStr)
 		if err != nil {
-			return 0, fmt.Errorf("invalid dimension: %s", dimStr)
+			return 0, merr.WrapErrParameterInvalidMsg("invalid dimension: %s", dimStr)
 		}
 		return int64(dim), nil
 	}

--- a/pkg/util/typeutil/float_util.go
+++ b/pkg/util/typeutil/float_util.go
@@ -18,10 +18,9 @@ package typeutil
 
 import (
 	"encoding/binary"
-	"fmt"
 	"math"
 
-	"github.com/cockroachdb/errors"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func bfloat16IsNaN(f uint16) bool {
@@ -51,7 +50,7 @@ func float16IsInf(f uint16, sign int) bool {
 func VerifyFloat(value float64) error {
 	// not allow not-a-number and infinity
 	if math.IsNaN(value) || math.IsInf(value, -1) || math.IsInf(value, 1) {
-		return fmt.Errorf("value '%f' is not a number or infinity", value)
+		return merr.WrapErrParameterInvalidMsg("value '%f' is not a number or infinity", value)
 	}
 
 	return nil
@@ -81,13 +80,13 @@ func VerifyFloats64(values []float64) error {
 
 func VerifyFloats16(value []byte) error {
 	if len(value)%2 != 0 {
-		return errors.New("The length of float16 is not aligned to 2.")
+		return merr.WrapErrParameterInvalidMsg("The length of float16 is not aligned to 2.")
 	}
 	dataSize := len(value) / 2
 	for i := 0; i < dataSize; i++ {
 		v := binary.LittleEndian.Uint16(value[i*2:])
 		if float16IsNaN(v) || float16IsInf(v, -1) || float16IsInf(v, 1) {
-			return errors.New("float16 vector contain nan or infinity value.")
+			return merr.WrapErrParameterInvalidMsg("float16 vector contain nan or infinity value.")
 		}
 	}
 	return nil
@@ -95,13 +94,13 @@ func VerifyFloats16(value []byte) error {
 
 func VerifyBFloats16(value []byte) error {
 	if len(value)%2 != 0 {
-		return errors.New("The length of bfloat16 in not aligned to 2")
+		return merr.WrapErrParameterInvalidMsg("The length of bfloat16 in not aligned to 2")
 	}
 	dataSize := len(value) / 2
 	for i := 0; i < dataSize; i++ {
 		v := binary.LittleEndian.Uint16(value[i*2:])
 		if bfloat16IsNaN(v) || bfloat16IsInf(v, -1) || bfloat16IsInf(v, 1) {
-			return errors.New("bfloat16 vector contain nan or infinity value.")
+			return merr.WrapErrParameterInvalidMsg("bfloat16 vector contain nan or infinity value.")
 		}
 	}
 	return nil

--- a/pkg/util/typeutil/gen_empty_field_data.go
+++ b/pkg/util/typeutil/gen_empty_field_data.go
@@ -1,9 +1,8 @@
 package typeutil
 
 import (
-	"fmt"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func genEmptyBoolFieldData(field *schemapb.FieldSchema) *schemapb.FieldData {
@@ -325,6 +324,6 @@ func GenEmptyFieldData(field *schemapb.FieldSchema) (*schemapb.FieldData, error)
 	case schemapb.DataType_ArrayOfVector:
 		return genEmptyArrayOfVectorFieldData(field)
 	default:
-		return nil, fmt.Errorf("unsupported data type: %s", dataType.String())
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported data type: %s", dataType.String())
 	}
 }

--- a/pkg/util/typeutil/hash.go
+++ b/pkg/util/typeutil/hash.go
@@ -17,18 +17,17 @@
 package typeutil
 
 import (
-	"fmt"
 	"hash/crc32"
 	"math"
 	"strconv"
 	"strings"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
 	"github.com/spaolacci/murmur3"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 const substringLengthForCRC = 100
@@ -131,10 +130,10 @@ func HashKey2Partitions(keys *schemapb.FieldData, partitionNames []string) ([]ui
 				hashValues = append(hashValues, value%numPartitions)
 			}
 		default:
-			return nil, errors.New("currently only support DataType Int64 or VarChar as partition key Field")
+			return nil, merr.WrapErrParameterInvalidMsg("currently only support DataType Int64 or VarChar as partition key Field")
 		}
 	default:
-		return nil, errors.New("currently not support vector field as partition keys")
+		return nil, merr.WrapErrParameterInvalidMsg("currently not support vector field as partition keys")
 	}
 
 	return hashValues, nil
@@ -148,14 +147,14 @@ func RearrangePartitionsForPartitionKey(partitions map[string]int64) ([]string, 
 	for partitionName, partitionID := range partitions {
 		splits := strings.Split(partitionName, "_")
 		if len(splits) < 2 {
-			return nil, nil, fmt.Errorf("bad default partion name in partition key mode: %s", partitionName)
+			return nil, nil, merr.WrapErrParameterInvalidMsg("bad default partion name in partition key mode: %s", partitionName)
 		}
 		index, err := strconv.ParseInt(splits[len(splits)-1], 10, 64)
 		if err != nil {
 			return nil, nil, err
 		}
 		if (index >= int64(len(partitions))) || (index < 0) {
-			return nil, nil, fmt.Errorf("illegal partition index in partition key mode: %s", partitionName)
+			return nil, nil, merr.WrapErrParameterInvalidMsg("illegal partition index in partition key mode: %s", partitionName)
 		}
 
 		partitionNames[index] = partitionName

--- a/pkg/util/typeutil/ids_checker.go
+++ b/pkg/util/typeutil/ids_checker.go
@@ -17,9 +17,8 @@
 package typeutil
 
 import (
-	"fmt"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // IDsChecker provides efficient lookup functionality for schema.IDs
@@ -55,7 +54,7 @@ func NewIDsChecker(ids *schemapb.IDs) (*IDsChecker, error) {
 			checker.strIDSet[id] = struct{}{}
 		}
 	default:
-		return nil, fmt.Errorf("unsupported ID type in IDs")
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported ID type in IDs")
 	}
 
 	return checker, nil
@@ -66,13 +65,13 @@ func NewIDsChecker(ids *schemapb.IDs) (*IDsChecker, error) {
 // Returns error if cursor is out of bounds or type mismatch
 func (c *IDsChecker) Contains(idsA *schemapb.IDs, cursor int) (bool, error) {
 	if idsA == nil || idsA.GetIdField() == nil {
-		return false, fmt.Errorf("idsA is nil or empty")
+		return false, merr.WrapErrParameterInvalidMsg("idsA is nil or empty")
 	}
 
 	// Check if cursor is within bounds
 	size := GetSizeOfIDs(idsA)
 	if cursor < 0 || cursor >= size {
-		return false, fmt.Errorf("cursor %d is out of bounds [0, %d)", cursor, size)
+		return false, merr.WrapErrParameterInvalidMsg("cursor %d is out of bounds [0, %d)", cursor, size)
 	}
 
 	// If checker is empty, return false for any query
@@ -83,7 +82,7 @@ func (c *IDsChecker) Contains(idsA *schemapb.IDs, cursor int) (bool, error) {
 	switch idsA.GetIdField().(type) {
 	case *schemapb.IDs_IntId:
 		if c.idType != schemapb.DataType_Int64 {
-			return false, fmt.Errorf("type mismatch: checker expects %v, got Int64", c.idType)
+			return false, merr.WrapErrParameterInvalidMsg("type mismatch: checker expects %v, got Int64", c.idType)
 		}
 		if c.intIDSet == nil {
 			return false, nil
@@ -94,7 +93,7 @@ func (c *IDsChecker) Contains(idsA *schemapb.IDs, cursor int) (bool, error) {
 
 	case *schemapb.IDs_StrId:
 		if c.idType != schemapb.DataType_VarChar {
-			return false, fmt.Errorf("type mismatch: checker expects %v, got VarChar", c.idType)
+			return false, merr.WrapErrParameterInvalidMsg("type mismatch: checker expects %v, got VarChar", c.idType)
 		}
 		if c.strIDSet == nil {
 			return false, nil
@@ -104,7 +103,7 @@ func (c *IDsChecker) Contains(idsA *schemapb.IDs, cursor int) (bool, error) {
 		return exists, nil
 
 	default:
-		return false, fmt.Errorf("unsupported ID type in idsA")
+		return false, merr.WrapErrParameterInvalidMsg("unsupported ID type in idsA")
 	}
 }
 
@@ -112,7 +111,7 @@ func (c *IDsChecker) Contains(idsA *schemapb.IDs, cursor int) (bool, error) {
 // Returns the indices of IDs that exist in the checker
 func (c *IDsChecker) ContainsAny(idsA *schemapb.IDs) ([]int, error) {
 	if idsA == nil || idsA.GetIdField() == nil {
-		return nil, fmt.Errorf("idsA is nil or empty")
+		return nil, merr.WrapErrParameterInvalidMsg("idsA is nil or empty")
 	}
 
 	var result []int
@@ -125,7 +124,7 @@ func (c *IDsChecker) ContainsAny(idsA *schemapb.IDs) ([]int, error) {
 	switch idsA.GetIdField().(type) {
 	case *schemapb.IDs_IntId:
 		if c.idType != schemapb.DataType_Int64 {
-			return nil, fmt.Errorf("type mismatch: checker expects %v, got Int64", c.idType)
+			return nil, merr.WrapErrParameterInvalidMsg("type mismatch: checker expects %v, got Int64", c.idType)
 		}
 		if c.intIDSet == nil {
 			return result, nil
@@ -139,7 +138,7 @@ func (c *IDsChecker) ContainsAny(idsA *schemapb.IDs) ([]int, error) {
 
 	case *schemapb.IDs_StrId:
 		if c.idType != schemapb.DataType_VarChar {
-			return nil, fmt.Errorf("type mismatch: checker expects %v, got VarChar", c.idType)
+			return nil, merr.WrapErrParameterInvalidMsg("type mismatch: checker expects %v, got VarChar", c.idType)
 		}
 		if c.strIDSet == nil {
 			return result, nil
@@ -152,7 +151,7 @@ func (c *IDsChecker) ContainsAny(idsA *schemapb.IDs) ([]int, error) {
 		}
 
 	default:
-		return nil, fmt.Errorf("unsupported ID type in idsA")
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported ID type in idsA")
 	}
 
 	return result, nil
@@ -190,7 +189,7 @@ func (c *IDsChecker) GetIDType() schemapb.DataType {
 // Returns a slice of booleans indicating whether each cursor position exists in the checker
 func (c *IDsChecker) ContainsIDsAtCursors(idsA *schemapb.IDs, cursors []int) ([]bool, error) {
 	if idsA == nil || idsA.GetIdField() == nil {
-		return nil, fmt.Errorf("idsA is nil or empty")
+		return nil, merr.WrapErrParameterInvalidMsg("idsA is nil or empty")
 	}
 
 	size := GetSizeOfIDs(idsA)
@@ -198,7 +197,7 @@ func (c *IDsChecker) ContainsIDsAtCursors(idsA *schemapb.IDs, cursors []int) ([]
 
 	for i, cursor := range cursors {
 		if cursor < 0 || cursor >= size {
-			return nil, fmt.Errorf("cursor %d is out of bounds [0, %d)", cursor, size)
+			return nil, merr.WrapErrParameterInvalidMsg("cursor %d is out of bounds [0, %d)", cursor, size)
 		}
 
 		exists, err := c.Contains(idsA, cursor)

--- a/pkg/util/typeutil/kv_pair_helper.go
+++ b/pkg/util/typeutil/kv_pair_helper.go
@@ -1,9 +1,8 @@
 package typeutil
 
 import (
-	"fmt"
-
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type kvPairsHelper[K comparable, V any] struct {
@@ -13,7 +12,7 @@ type kvPairsHelper[K comparable, V any] struct {
 func (h *kvPairsHelper[K, V]) Get(k K) (V, error) {
 	v, ok := h.kvPairs[k]
 	if !ok {
-		return v, fmt.Errorf("%v not found", k)
+		return v, merr.WrapErrParameterInvalidMsg("%v not found", k)
 	}
 	return v, nil
 }

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -29,12 +29,12 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/cockroachdb/errors"
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 type getVariableFieldLengthPolicy int
@@ -58,7 +58,7 @@ func getVarFieldLength(fieldSchema *schemapb.FieldSchema, policy getVariableFiel
 	case schemapb.DataType_VarChar:
 		maxLengthPerRowValue, ok := paramsMap[common.MaxLengthKey]
 		if !ok {
-			return 0, fmt.Errorf("the max_length was not specified, field type is %s", fieldSchema.DataType.String())
+			return 0, merr.WrapErrParameterInvalidMsg("the max_length was not specified, field type is %s", fieldSchema.DataType.String())
 		}
 		maxLength, err = strconv.Atoi(maxLengthPerRowValue)
 		if err != nil {
@@ -79,7 +79,7 @@ func getVarFieldLength(fieldSchema *schemapb.FieldSchema, policy getVariableFiel
 			}
 			return maxLength, nil
 		default:
-			return 0, fmt.Errorf("unrecognized getVariableFieldLengthPolicy %v", policy)
+			return 0, merr.WrapErrParameterInvalidMsg("unrecognized getVariableFieldLengthPolicy %v", policy)
 		}
 		// Text type does not require max_length, use the same estimate as JSON/Array fields
 	case schemapb.DataType_Text:
@@ -88,7 +88,7 @@ func getVarFieldLength(fieldSchema *schemapb.FieldSchema, policy getVariableFiel
 	case schemapb.DataType_Array, schemapb.DataType_JSON, schemapb.DataType_Geometry:
 		return GetDynamicFieldEstimateLength(), nil
 	default:
-		return 0, fmt.Errorf("field %s is not a variable-length type", fieldSchema.DataType.String())
+		return 0, merr.WrapErrParameterInvalidMsg("field %s is not a variable-length type", fieldSchema.DataType.String())
 	}
 }
 
@@ -197,7 +197,7 @@ func estimateSizeBy(schema *schemapb.CollectionSchema, policy getVariableFieldLe
 			case schemapb.DataType_Int8Vector:
 				res += assumedArrayLen * dim
 			default:
-				return 0, fmt.Errorf("unsupported element type in VectorArray: %s", fs.ElementType.String())
+				return 0, merr.WrapErrParameterInvalidMsg("unsupported element type in VectorArray: %s", fs.ElementType.String())
 			}
 		}
 	}
@@ -289,12 +289,12 @@ func EstimateEntitySize(fieldsData []*schemapb.FieldData, rowOffset int, fieldId
 			res += 8
 		case schemapb.DataType_VarChar, schemapb.DataType_Text:
 			if rowOffset >= len(fs.GetScalars().GetStringData().GetData()) {
-				return 0, errors.New("offset out range of field datas")
+				return 0, merr.WrapErrParameterInvalidMsg("offset out range of field datas")
 			}
 			res += len(fs.GetScalars().GetStringData().Data[rowOffset])
 		case schemapb.DataType_Array:
 			if rowOffset >= len(fs.GetScalars().GetArrayData().GetData()) {
-				return 0, errors.New("offset out range of field datas")
+				return 0, merr.WrapErrParameterInvalidMsg("offset out range of field datas")
 			}
 			array := fs.GetScalars().GetArrayData().GetData()[rowOffset]
 			res += CalcScalarSize(&schemapb.FieldData{
@@ -303,12 +303,12 @@ func EstimateEntitySize(fieldsData []*schemapb.FieldData, rowOffset int, fieldId
 			})
 		case schemapb.DataType_JSON:
 			if rowOffset >= len(fs.GetScalars().GetJsonData().GetData()) {
-				return 0, errors.New("offset out range of field datas")
+				return 0, merr.WrapErrParameterInvalidMsg("offset out range of field datas")
 			}
 			res += len(fs.GetScalars().GetJsonData().GetData()[rowOffset])
 		case schemapb.DataType_Geometry:
 			if rowOffset >= len(fs.GetScalars().GetGeometryData().GetData()) {
-				return 0, fmt.Errorf("offset out range of field datas")
+				return 0, merr.WrapErrParameterInvalidMsg("offset out range of field datas")
 			}
 			res += len(fs.GetScalars().GetGeometryData().GetData()[rowOffset])
 		case schemapb.DataType_BinaryVector,
@@ -342,7 +342,7 @@ func EstimateEntitySize(fieldsData []*schemapb.FieldData, rowOffset int, fieldId
 		case schemapb.DataType_ArrayOfVector:
 			arrayVector := fs.GetVectors().GetVectorArray()
 			if int(fieldIdx) >= len(arrayVector.GetData()) {
-				return 0, errors.New("offset out range of field datas")
+				return 0, merr.WrapErrParameterInvalidMsg("offset out range of field datas")
 			}
 			res += calcVectorSize(arrayVector.GetData()[fieldIdx], arrayVector.GetElementType())
 		default:
@@ -369,7 +369,7 @@ type SchemaHelper struct {
 // CreateSchemaHelper returns a new SchemaHelper object
 func CreateSchemaHelper(schema *schemapb.CollectionSchema) (*SchemaHelper, error) {
 	if schema == nil {
-		return nil, errors.New("schema is nil")
+		return nil, merr.WrapErrParameterInvalidMsg("schema is nil")
 	}
 
 	allFields := GetAllFieldSchemas(schema)
@@ -386,37 +386,37 @@ func CreateSchemaHelper(schema *schemapb.CollectionSchema) (*SchemaHelper, error
 	}
 	for offset, field := range allFields {
 		if _, ok := schemaHelper.nameOffset[field.Name]; ok {
-			return nil, fmt.Errorf("duplicated fieldName: %s", field.Name)
+			return nil, merr.WrapErrParameterInvalidMsg("duplicated fieldName: %s", field.Name)
 		}
 		if _, ok := schemaHelper.idOffset[field.FieldID]; ok {
-			return nil, fmt.Errorf("duplicated fieldID: %d", field.FieldID)
+			return nil, merr.WrapErrParameterInvalidMsg("duplicated fieldID: %d", field.FieldID)
 		}
 		schemaHelper.nameOffset[field.Name] = offset
 		schemaHelper.idOffset[field.FieldID] = offset
 		if field.IsPrimaryKey {
 			if schemaHelper.primaryKeyOffset != -1 {
-				return nil, errors.New("primary key is not unique")
+				return nil, merr.WrapErrParameterInvalidMsg("primary key is not unique")
 			}
 			schemaHelper.primaryKeyOffset = offset
 		}
 
 		if field.IsPartitionKey {
 			if schemaHelper.partitionKeyOffset != -1 {
-				return nil, errors.New("partition key is not unique")
+				return nil, merr.WrapErrParameterInvalidMsg("partition key is not unique")
 			}
 			schemaHelper.partitionKeyOffset = offset
 		}
 
 		if field.IsClusteringKey {
 			if schemaHelper.clusteringKeyOffset != -1 {
-				return nil, errors.New("clustering key is not unique")
+				return nil, merr.WrapErrParameterInvalidMsg("clustering key is not unique")
 			}
 			schemaHelper.clusteringKeyOffset = offset
 		}
 
 		if field.IsDynamic {
 			if schemaHelper.dynamicFieldOffset != -1 {
-				return nil, errors.New("dynamic field is not unique")
+				return nil, merr.WrapErrParameterInvalidMsg("dynamic field is not unique")
 			}
 			schemaHelper.dynamicFieldOffset = offset
 		}
@@ -444,7 +444,7 @@ func (helper *SchemaHelper) GetTimezone() string {
 // GetPrimaryKeyField returns the schema of the primary key
 func (helper *SchemaHelper) GetPrimaryKeyField() (*schemapb.FieldSchema, error) {
 	if helper.primaryKeyOffset == -1 {
-		return nil, errors.New("failed to get primary key field: no primary in schema")
+		return nil, merr.WrapErrParameterInvalidMsg("failed to get primary key field: no primary in schema")
 	}
 	return helper.allFields[helper.primaryKeyOffset], nil
 }
@@ -452,7 +452,7 @@ func (helper *SchemaHelper) GetPrimaryKeyField() (*schemapb.FieldSchema, error) 
 // GetPartitionKeyField returns the schema of the partition key
 func (helper *SchemaHelper) GetPartitionKeyField() (*schemapb.FieldSchema, error) {
 	if helper.partitionKeyOffset == -1 {
-		return nil, errors.New("failed to get partition key field: no partition key in schema")
+		return nil, merr.WrapErrParameterInvalidMsg("failed to get partition key field: no partition key in schema")
 	}
 	return helper.allFields[helper.partitionKeyOffset], nil
 }
@@ -461,7 +461,7 @@ func (helper *SchemaHelper) GetPartitionKeyField() (*schemapb.FieldSchema, error
 // If not found, an error shall be returned.
 func (helper *SchemaHelper) GetClusteringKeyField() (*schemapb.FieldSchema, error) {
 	if helper.clusteringKeyOffset == -1 {
-		return nil, errors.New("failed to get clustering key field: not clustering key in schema")
+		return nil, merr.WrapErrParameterInvalidMsg("failed to get clustering key field: not clustering key in schema")
 	}
 	return helper.allFields[helper.clusteringKeyOffset], nil
 }
@@ -470,7 +470,7 @@ func (helper *SchemaHelper) GetClusteringKeyField() (*schemapb.FieldSchema, erro
 // if there is no dynamic field defined in schema, error will be returned.
 func (helper *SchemaHelper) GetDynamicField() (*schemapb.FieldSchema, error) {
 	if helper.dynamicFieldOffset == -1 {
-		return nil, errors.New("failed to get dynamic field: no dynamic field in schema")
+		return nil, merr.WrapErrParameterInvalidMsg("failed to get dynamic field: no dynamic field in schema")
 	}
 	return helper.allFields[helper.dynamicFieldOffset], nil
 }
@@ -479,7 +479,7 @@ func (helper *SchemaHelper) GetDynamicField() (*schemapb.FieldSchema, error) {
 func (helper *SchemaHelper) GetFieldFromName(fieldName string) (*schemapb.FieldSchema, error) {
 	offset, ok := helper.nameOffset[fieldName]
 	if !ok {
-		return nil, fmt.Errorf("failed to get field schema by name: fieldName(%s) not found", fieldName)
+		return nil, merr.WrapErrParameterInvalidMsg("failed to get field schema by name: fieldName(%s) not found", fieldName)
 	}
 	return helper.allFields[offset], nil
 }
@@ -518,14 +518,14 @@ func (helper *SchemaHelper) getDefaultJSONField(fieldName string) (*schemapb.Fie
 		}
 	}
 	errMsg := fmt.Sprintf("field %s not exist", fieldName)
-	return nil, fmt.Errorf("%s", errMsg)
+	return nil, merr.WrapErrParameterInvalidMsg("%s", errMsg)
 }
 
 // GetFieldFromID returns the schema of specified field
 func (helper *SchemaHelper) GetFieldFromID(fieldID int64) (*schemapb.FieldSchema, error) {
 	offset, ok := helper.idOffset[fieldID]
 	if !ok {
-		return nil, fmt.Errorf("fieldID(%d) not found", fieldID)
+		return nil, merr.WrapErrParameterInvalidMsg("fieldID(%d) not found", fieldID)
 	}
 	return helper.allFields[offset], nil
 }
@@ -537,7 +537,7 @@ func (helper *SchemaHelper) GetVectorDimFromID(fieldID int64) (int, error) {
 		return 0, err
 	}
 	if !IsVectorType(sch.DataType) {
-		return 0, fmt.Errorf("field type = %s not has dim", schemapb.DataType_name[int32(sch.DataType)])
+		return 0, merr.WrapErrParameterInvalidMsg("field type = %s not has dim", schemapb.DataType_name[int32(sch.DataType)])
 	}
 	for _, kv := range sch.TypeParams {
 		if kv.Key == common.DimKey {
@@ -548,7 +548,7 @@ func (helper *SchemaHelper) GetVectorDimFromID(fieldID int64) (int, error) {
 			return dim, nil
 		}
 	}
-	return 0, fmt.Errorf("fieldID(%d) not has dim", fieldID)
+	return 0, merr.WrapErrParameterInvalidMsg("fieldID(%d) not has dim", fieldID)
 }
 
 func (helper *SchemaHelper) GetFunctionByOutputField(field *schemapb.FieldSchema) (*schemapb.FunctionSchema, error) {
@@ -559,7 +559,7 @@ func (helper *SchemaHelper) GetFunctionByOutputField(field *schemapb.FieldSchema
 			}
 		}
 	}
-	return nil, errors.New("function not exist")
+	return nil, merr.WrapErrParameterInvalidMsg("function not exist")
 }
 
 // As of now, only BM25 function output field is not supported to retrieve raw field data
@@ -653,7 +653,7 @@ func NewEmptyArrayOfVectorRow(dim int64, elementType schemapb.DataType) (*schema
 	case schemapb.DataType_Int8Vector:
 		vf.Data = &schemapb.VectorField_Int8Vector{Int8Vector: []byte{}}
 	default:
-		return nil, fmt.Errorf("unsupported ArrayOfVector element type %s", elementType)
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported ArrayOfVector element type %s", elementType)
 	}
 	return vf, nil
 }
@@ -1655,10 +1655,10 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 						var updateMap map[string]interface{}
 						// unmarshal base and update
 						if err := json.Unmarshal(baseData.Data[baseIdx], &baseMap); err != nil {
-							return fmt.Errorf("failed to unmarshal base json: %v", err)
+							return merr.Wrap(err, "failed to unmarshal base json")
 						}
 						if err := json.Unmarshal(updateData.Data[updateIdx], &updateMap); err != nil {
-							return fmt.Errorf("failed to unmarshal update json: %v", err)
+							return merr.Wrap(err, "failed to unmarshal update json")
 						}
 						// merge
 						for k, v := range updateMap {
@@ -1667,7 +1667,7 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 						// marshal back
 						newJSON, err := json.Marshal(baseMap)
 						if err != nil {
-							return fmt.Errorf("failed to marshal merged json: %v", err)
+							return merr.Wrap(err, "failed to marshal merged json")
 						}
 						baseScalar.GetJsonData().Data[baseIdx] = newJSON
 					} else {
@@ -1696,7 +1696,7 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 					baseData.Data[baseIdx] = updateData.Data[updateIdx]
 				}
 			default:
-				return fmt.Errorf("unsupported scalar field type: %s", baseFieldData.Type.String())
+				return merr.WrapErrParameterInvalidMsg("unsupported scalar field type: %s", baseFieldData.Type.String())
 			}
 
 		case *schemapb.FieldData_Vectors:
@@ -1777,10 +1777,10 @@ func UpdateFieldData(base, update []*schemapb.FieldData, baseIdx, updateIdx int6
 					}
 				}
 			default:
-				return fmt.Errorf("unsupported vector field type: %s", baseFieldData.Type.String())
+				return merr.WrapErrParameterInvalidMsg("unsupported vector field type: %s", baseFieldData.Type.String())
 			}
 		default:
-			return fmt.Errorf("unsupported field type: %s", baseFieldData.Type.String())
+			return merr.WrapErrParameterInvalidMsg("unsupported field type: %s", baseFieldData.Type.String())
 		}
 	}
 
@@ -1806,15 +1806,15 @@ func UpdateArrayFieldByColumnWithOp(
 		return nil
 	}
 	if len(baseIndices) != len(updateIndices) {
-		return fmt.Errorf("baseIndices and updateIndices length mismatch: %d vs %d", len(baseIndices), len(updateIndices))
+		return merr.WrapErrParameterInvalidMsg("baseIndices and updateIndices length mismatch: %d vs %d", len(baseIndices), len(updateIndices))
 	}
 	if base.GetType() != schemapb.DataType_Array {
-		return fmt.Errorf("op %s requires Array field, got %s", op.String(), base.GetType().String())
+		return merr.WrapErrParameterInvalidMsg("op %s requires Array field, got %s", op.String(), base.GetType().String())
 	}
 	baseScalar := base.GetScalars()
 	updateScalar := update.GetScalars()
 	if baseScalar.GetArrayData() == nil || updateScalar.GetArrayData() == nil {
-		return fmt.Errorf("op %s requires non-nil ArrayData on both base and update", op.String())
+		return merr.WrapErrParameterInvalidMsg("op %s requires non-nil ArrayData on both base and update", op.String())
 	}
 	baseData := baseScalar.GetArrayData().Data
 	updateData := updateScalar.GetArrayData().Data
@@ -1846,7 +1846,7 @@ func UpdateFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, upda
 		return nil
 	}
 	if len(baseIndices) != len(updateIndices) {
-		return fmt.Errorf("baseIndices and updateIndices length mismatch: %d vs %d", len(baseIndices), len(updateIndices))
+		return merr.WrapErrParameterInvalidMsg("baseIndices and updateIndices length mismatch: %d vs %d", len(baseIndices), len(updateIndices))
 	}
 	if IsCompactNullableVectorFieldData(base) {
 		return updateCompactNullableVectorFieldDataByColumn(base, update, baseIndices, updateIndices)
@@ -1921,10 +1921,10 @@ func UpdateFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, upda
 					var updateMap map[string]interface{}
 					// unmarshal base and update
 					if err := json.Unmarshal(baseData[baseIdx], &baseMap); err != nil {
-						return fmt.Errorf("failed to unmarshal base json: %v", err)
+						return merr.Wrap(err, "failed to unmarshal base json")
 					}
 					if err := json.Unmarshal(updateData[updateIdx], &updateMap); err != nil {
-						return fmt.Errorf("failed to unmarshal update json: %v", err)
+						return merr.Wrap(err, "failed to unmarshal update json")
 					}
 					// merge
 					for k, v := range updateMap {
@@ -1933,7 +1933,7 @@ func UpdateFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, upda
 					// marshal back
 					newJSON, err := json.Marshal(baseMap)
 					if err != nil {
-						return fmt.Errorf("failed to marshal merged json: %v", err)
+						return merr.Wrap(err, "failed to marshal merged json")
 					}
 					baseData[baseIdx] = newJSON
 				}
@@ -2031,26 +2031,26 @@ func IsCompactNullableVectorFieldData(field *schemapb.FieldData) bool {
 
 func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldData, baseIndices, updateIndices []int64) error {
 	if !IsSupportedNullableVectorType(update.GetType()) {
-		return fmt.Errorf("cannot update nullable vector field %s with %s", base.GetType().String(), update.GetType().String())
+		return merr.WrapErrParameterInvalidMsg("cannot update nullable vector field %s with %s", base.GetType().String(), update.GetType().String())
 	}
 	if update.GetType() != base.GetType() {
-		return fmt.Errorf("cannot update nullable vector field %s with %s", base.GetType().String(), update.GetType().String())
+		return merr.WrapErrParameterInvalidMsg("cannot update nullable vector field %s with %s", base.GetType().String(), update.GetType().String())
 	}
 
 	baseValidData := base.GetValidData()
 	updateValidData := update.GetValidData()
 	if len(updateValidData) == 0 {
-		return fmt.Errorf("nullable vector field %s missing ValidData", update.GetFieldName())
+		return merr.WrapErrParameterInvalidMsg("nullable vector field %s missing ValidData", update.GetFieldName())
 	}
 
 	updateByBaseIdx := make(map[int]int, len(baseIndices))
 	for i, baseIdx := range baseIndices {
 		updateIdx := updateIndices[i]
 		if baseIdx < 0 || int(baseIdx) >= len(baseValidData) {
-			return fmt.Errorf("base index %d out of range for nullable vector field %s", baseIdx, base.GetFieldName())
+			return merr.WrapErrParameterInvalidMsg("base index %d out of range for nullable vector field %s", baseIdx, base.GetFieldName())
 		}
 		if updateIdx < 0 || int(updateIdx) >= len(updateValidData) {
-			return fmt.Errorf("update index %d out of range for nullable vector field %s", updateIdx, update.GetFieldName())
+			return merr.WrapErrParameterInvalidMsg("update index %d out of range for nullable vector field %s", updateIdx, update.GetFieldName())
 		}
 		updateByBaseIdx[int(baseIdx)] = int(updateIdx)
 	}
@@ -2065,7 +2065,7 @@ func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldDa
 	baseVector := base.GetVectors()
 	updateVector := update.GetVectors()
 	if baseVector == nil || updateVector == nil {
-		return fmt.Errorf("nullable vector field data is nil")
+		return merr.WrapErrParameterInvalidMsg("nullable vector field data is nil")
 	}
 	dim := baseVector.GetDim()
 	if dim == 0 {
@@ -2084,7 +2084,7 @@ func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldDa
 			start := int64(physicalIdx) * elemSize
 			end := start + elemSize
 			if start < 0 || end > int64(len(data)) {
-				return fmt.Errorf("binary vector physical index %d out of range", physicalIdx)
+				return merr.WrapErrParameterInvalidMsg("binary vector physical index %d out of range", physicalIdx)
 			}
 			newData = append(newData, data[start:end]...)
 			return nil
@@ -2100,7 +2100,7 @@ func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldDa
 			start := int64(physicalIdx) * dim
 			end := start + dim
 			if start < 0 || end > int64(len(data)) {
-				return fmt.Errorf("float vector physical index %d out of range", physicalIdx)
+				return merr.WrapErrParameterInvalidMsg("float vector physical index %d out of range", physicalIdx)
 			}
 			newData = append(newData, data[start:end]...)
 			return nil
@@ -2117,7 +2117,7 @@ func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldDa
 			start := int64(physicalIdx) * elemSize
 			end := start + elemSize
 			if start < 0 || end > int64(len(data)) {
-				return fmt.Errorf("float16 vector physical index %d out of range", physicalIdx)
+				return merr.WrapErrParameterInvalidMsg("float16 vector physical index %d out of range", physicalIdx)
 			}
 			newData = append(newData, data[start:end]...)
 			return nil
@@ -2134,7 +2134,7 @@ func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldDa
 			start := int64(physicalIdx) * elemSize
 			end := start + elemSize
 			if start < 0 || end > int64(len(data)) {
-				return fmt.Errorf("bfloat16 vector physical index %d out of range", physicalIdx)
+				return merr.WrapErrParameterInvalidMsg("bfloat16 vector physical index %d out of range", physicalIdx)
 			}
 			newData = append(newData, data[start:end]...)
 			return nil
@@ -2147,7 +2147,7 @@ func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldDa
 		baseSparse := baseVector.GetSparseFloatVector()
 		updateSparse := updateVector.GetSparseFloatVector()
 		if updateSparse == nil {
-			return fmt.Errorf("sparse float vector update data is nil")
+			return merr.WrapErrParameterInvalidMsg("sparse float vector update data is nil")
 		}
 		baseDim := int64(0)
 		if baseSparse != nil {
@@ -2160,7 +2160,7 @@ func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldDa
 		appendRow := func(vector *schemapb.VectorField, physicalIdx int) error {
 			data := vector.GetSparseFloatVector()
 			if data == nil || physicalIdx < 0 || physicalIdx >= len(data.GetContents()) {
-				return fmt.Errorf("sparse vector physical index %d out of range", physicalIdx)
+				return merr.WrapErrParameterInvalidMsg("sparse vector physical index %d out of range", physicalIdx)
 			}
 			row := data.GetContents()[physicalIdx]
 			newSparse.Contents = append(newSparse.Contents, row)
@@ -2182,7 +2182,7 @@ func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldDa
 			start := int64(physicalIdx) * elemSize
 			end := start + elemSize
 			if start < 0 || end > int64(len(data)) {
-				return fmt.Errorf("int8 vector physical index %d out of range", physicalIdx)
+				return merr.WrapErrParameterInvalidMsg("int8 vector physical index %d out of range", physicalIdx)
 			}
 			newData = append(newData, data[start:end]...)
 			return nil
@@ -2192,7 +2192,7 @@ func updateCompactNullableVectorFieldDataByColumn(base, update *schemapb.FieldDa
 		}
 		baseVector.Data = &schemapb.VectorField_Int8Vector{Int8Vector: newData}
 	default:
-		return fmt.Errorf("unsupported nullable vector field type %s", base.GetType().String())
+		return merr.WrapErrParameterInvalidMsg("unsupported nullable vector field type %s", base.GetType().String())
 	}
 
 	base.ValidData = newValidData
@@ -2256,7 +2256,7 @@ func MergeFieldData(dst []*schemapb.FieldData, src []*schemapb.FieldData) error 
 		switch fieldType := srcFieldData.Field.(type) {
 		case *schemapb.FieldData_Scalars:
 			if _, ok := fieldID2Data[srcFieldData.FieldId]; !ok {
-				return errors.New("fields in src but not in dst: " + srcFieldData.Type.String())
+				return merr.WrapErrParameterInvalidMsg("fields in src but not in dst: " + srcFieldData.Type.String())
 			}
 			fieldData := fieldID2Data[srcFieldData.FieldId]
 			fieldData.ValidData = append(fieldData.ValidData, srcFieldData.GetValidData()...)
@@ -2374,11 +2374,11 @@ func MergeFieldData(dst []*schemapb.FieldData, src []*schemapb.FieldData) error 
 					dstScalar.GetBytesData().Data = append(dstScalar.GetBytesData().Data, srcScalar.BytesData.Data...)
 				}
 			default:
-				return errors.New("unsupported data type: " + srcFieldData.Type.String())
+				return merr.WrapErrParameterInvalidMsg("unsupported data type: " + srcFieldData.Type.String())
 			}
 		case *schemapb.FieldData_Vectors:
 			if _, ok := fieldID2Data[srcFieldData.FieldId]; !ok {
-				return errors.New("fields in src but not in dst: " + srcFieldData.Type.String())
+				return merr.WrapErrParameterInvalidMsg("fields in src but not in dst: " + srcFieldData.Type.String())
 			}
 			fieldData := fieldID2Data[srcFieldData.FieldId]
 			// Merge ValidData for nullable vectors
@@ -2454,7 +2454,7 @@ func MergeFieldData(dst []*schemapb.FieldData, src []*schemapb.FieldData) error 
 			case nil:
 				// nullable vector field where all rows are null — no vector data to merge
 			default:
-				return errors.New("unsupported data type: " + srcFieldData.Type.String())
+				return merr.WrapErrParameterInvalidMsg("unsupported data type: " + srcFieldData.Type.String())
 			}
 		}
 	}
@@ -2535,7 +2535,7 @@ func GetPrimaryFieldSchema(schema *schemapb.CollectionSchema) (*schemapb.FieldSc
 		}
 	}
 
-	return nil, errors.New("primary field is not found")
+	return nil, merr.WrapErrParameterInvalidMsg("primary field is not found")
 }
 
 // NormalizeAndValidateExternalCollectionSchema ensures unsupported features are
@@ -2562,20 +2562,20 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 	srcSet := schema.GetExternalSource() != ""
 	specSet := schema.GetExternalSpec() != ""
 	if srcSet != specSet {
-		return fmt.Errorf("external collection %s requires external_source and external_spec to be both set or both empty (got source=%q, spec=%q)",
+		return merr.WrapErrParameterInvalidMsg("external collection %s requires external_source and external_spec to be both set or both empty (got source=%q, spec=%q)",
 			schema.GetName(), schema.GetExternalSource(), schema.GetExternalSpec())
 	}
 
 	if len(schema.GetFunctions()) > 0 {
-		return fmt.Errorf("external collection %s does not support functions", schema.GetName())
+		return merr.WrapErrParameterInvalidMsg("external collection %s does not support functions", schema.GetName())
 	}
 
 	if schema.GetEnableDynamicField() {
-		return fmt.Errorf("external collection %s does not support dynamic field", schema.GetName())
+		return merr.WrapErrParameterInvalidMsg("external collection %s does not support dynamic field", schema.GetName())
 	}
 
 	if len(schema.GetStructArrayFields()) > 0 {
-		return fmt.Errorf("external collection %s does not support struct fields", schema.GetName())
+		return merr.WrapErrParameterInvalidMsg("external collection %s does not support struct fields", schema.GetName())
 	}
 
 	// Pass 1: validate all user fields. No mutation here so a failure at any
@@ -2587,29 +2587,29 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 		}
 
 		if field.GetIsPrimaryKey() {
-			return fmt.Errorf("external collection %s does not support primary key field %s", schema.GetName(), field.GetName())
+			return merr.WrapErrParameterInvalidMsg("external collection %s does not support primary key field %s", schema.GetName(), field.GetName())
 		}
 		if field.GetIsPartitionKey() {
-			return fmt.Errorf("external collection %s does not support partition key field %s", schema.GetName(), field.GetName())
+			return merr.WrapErrParameterInvalidMsg("external collection %s does not support partition key field %s", schema.GetName(), field.GetName())
 		}
 		if field.GetIsClusteringKey() {
-			return fmt.Errorf("external collection %s does not support clustering key field %s", schema.GetName(), field.GetName())
+			return merr.WrapErrParameterInvalidMsg("external collection %s does not support clustering key field %s", schema.GetName(), field.GetName())
 		}
 		if field.GetAutoID() {
-			return fmt.Errorf("external collection %s does not support auto id on field %s", schema.GetName(), field.GetName())
+			return merr.WrapErrParameterInvalidMsg("external collection %s does not support auto id on field %s", schema.GetName(), field.GetName())
 		}
 
 		helper := CreateFieldSchemaHelper(field)
 		if helper.EnableMatch() {
-			return fmt.Errorf("external collection %s does not support text match on field %s", schema.GetName(), field.GetName())
+			return merr.WrapErrParameterInvalidMsg("external collection %s does not support text match on field %s", schema.GetName(), field.GetName())
 		}
 
 		if field.GetExternalField() == "" {
-			return fmt.Errorf("field '%s' in external collection %s must have external_field mapping", field.GetName(), schema.GetName())
+			return merr.WrapErrParameterInvalidMsg("field '%s' in external collection %s must have external_field mapping", field.GetName(), schema.GetName())
 		}
 
 		if !isExternalFieldTypeSupported(field.GetDataType()) {
-			return fmt.Errorf("external collection %s does not support field type %s on field %s",
+			return merr.WrapErrParameterInvalidMsg("external collection %s does not support field type %s on field %s",
 				schema.GetName(), field.GetDataType().String(), field.GetName())
 		}
 
@@ -2628,7 +2628,7 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 		for _, f := range owners {
 			parts = append(parts, fmt.Sprintf("%s (%s)", f.GetName(), f.GetDataType().String()))
 		}
-		return fmt.Errorf("external_field %q is mapped by multiple fields: %s; each external_field must be referenced by at most one user field",
+		return merr.WrapErrParameterInvalidMsg("external_field %q is mapped by multiple fields: %s; each external_field must be referenced by at most one user field",
 			ext, strings.Join(parts, ", "))
 	}
 
@@ -2703,7 +2703,7 @@ func GetPartitionKeyFieldSchema(schema *schemapb.CollectionSchema) (*schemapb.Fi
 		}
 	}
 
-	return nil, errors.New("partition key field is not found")
+	return nil, merr.WrapErrParameterInvalidMsg("partition key field is not found")
 }
 
 // GetDynamicField returns the dynamic field if it exists.
@@ -2754,7 +2754,7 @@ func GetPrimaryFieldData(datas []*schemapb.FieldData, primaryFieldSchema *schema
 	}
 
 	if primaryFieldData == nil {
-		return nil, fmt.Errorf("can't find data for primary field: %v", primaryFieldName)
+		return nil, merr.WrapErrParameterInvalidMsg("can't find data for primary field: %v", primaryFieldName)
 	}
 
 	return primaryFieldData, nil
@@ -3261,25 +3261,25 @@ func trimSparseFloatArray(vec *schemapb.SparseFloatArray) {
 func ValidateSparseFloatRows(rows ...[]byte) error {
 	for _, row := range rows {
 		if row == nil {
-			return errors.New("nil sparse float vector")
+			return merr.WrapErrParameterInvalidMsg("nil sparse float vector")
 		}
 		if len(row)%8 != 0 {
-			return fmt.Errorf("invalid data length in sparse float vector: %d", len(row))
+			return merr.WrapErrParameterInvalidMsg("invalid data length in sparse float vector: %d", len(row))
 		}
 		for i := 0; i < SparseFloatRowElementCount(row); i++ {
 			idx := SparseFloatRowIndexAt(row, i)
 			if idx == math.MaxUint32 {
-				return errors.New("invalid index in sparse float vector: must be less than 2^32-1")
+				return merr.WrapErrParameterInvalidMsg("invalid index in sparse float vector: must be less than 2^32-1")
 			}
 			if i > 0 && idx <= SparseFloatRowIndexAt(row, i-1) {
-				return errors.New("unsorted or same indices in sparse float vector")
+				return merr.WrapErrParameterInvalidMsg("unsorted or same indices in sparse float vector")
 			}
 			val := SparseFloatRowValueAt(row, i)
 			if err := VerifyFloat(float64(val)); err != nil {
 				return err
 			}
 			if val < 0 {
-				return errors.New("negative value in sparse float vector")
+				return merr.WrapErrParameterInvalidMsg("negative value in sparse float vector")
 			}
 		}
 	}
@@ -3377,16 +3377,16 @@ func CreateSparseFloatRowFromMap(input map[string]interface{}) ([]byte, error) {
 			if num, err := strconv.ParseFloat(v.String(), 64); err == nil {
 				val = num
 			} else {
-				return 0, fmt.Errorf("invalid value type in JSON: %s", reflect.TypeOf(v))
+				return 0, merr.WrapErrParameterInvalidMsg("invalid value type in JSON: %s", reflect.TypeOf(v))
 			}
 		default:
-			return 0, fmt.Errorf("invalid value type in JSON: %s", reflect.TypeOf(key))
+			return 0, merr.WrapErrParameterInvalidMsg("invalid value type in JSON: %s", reflect.TypeOf(key))
 		}
 		if VerifyFloat(val) != nil {
-			return 0, fmt.Errorf("invalid value in JSON: %v", val)
+			return 0, merr.WrapErrParameterInvalidMsg("invalid value in JSON: %v", val)
 		}
 		if val > math.MaxFloat32 {
-			return 0, fmt.Errorf("value too large in JSON: %v", val)
+			return 0, merr.WrapErrParameterInvalidMsg("value too large in JSON: %v", val)
 		}
 		return float32(val), nil
 	}
@@ -3399,7 +3399,7 @@ func CreateSparseFloatRowFromMap(input map[string]interface{}) ([]byte, error) {
 		case float64:
 			// check if the float64 is actually an integer
 			if v != float64(int64(v)) {
-				return 0, fmt.Errorf("invalid index in JSON: %v", v)
+				return 0, merr.WrapErrParameterInvalidMsg("invalid index in JSON: %v", v)
 			}
 			idx = int64(v)
 		case json.Number:
@@ -3409,10 +3409,10 @@ func CreateSparseFloatRowFromMap(input map[string]interface{}) ([]byte, error) {
 				return 0, err
 			}
 		default:
-			return 0, fmt.Errorf("invalid index type in JSON: %s", reflect.TypeOf(key))
+			return 0, merr.WrapErrParameterInvalidMsg("invalid index type in JSON: %s", reflect.TypeOf(key))
 		}
 		if idx >= math.MaxUint32 {
-			return 0, fmt.Errorf("index too large in JSON: %v", idx)
+			return 0, merr.WrapErrParameterInvalidMsg("index too large in JSON: %v", idx)
 		}
 		return uint32(idx), nil
 	}
@@ -3453,11 +3453,11 @@ func CreateSparseFloatRowFromMap(input map[string]interface{}) ([]byte, error) {
 			values = append(values, val)
 		}
 	} else {
-		return nil, errors.New("invalid JSON input")
+		return nil, merr.WrapErrParameterInvalidMsg("invalid JSON input")
 	}
 
 	if len(indices) != len(values) {
-		return nil, errors.New("indices and values length mismatch")
+		return nil, merr.WrapErrParameterInvalidMsg("indices and values length mismatch")
 	}
 
 	sortedIndices, sortedValues := SortSparseFloatRow(indices, values)
@@ -3514,10 +3514,10 @@ func GetNeedProcessFunctions(fieldIDs []int64, functions []*schemapb.FunctionSch
 	for _, fieldID := range fieldIDs {
 		if f, exists := fieldIDFuncMapping[fieldID]; exists {
 			if f.Type == schemapb.FunctionType_BM25 {
-				return nil, fmt.Errorf("attempt to insert bm25 function output field")
+				return nil, merr.WrapErrParameterInvalidMsg("attempt to insert bm25 function output field")
 			}
 			if !allowNonBM25Outputs {
-				return nil, fmt.Errorf("Insert data has function output field, but collection's property `collection.function.allowInsertNonBM25FunctionOutputs` is not enable")
+				return nil, merr.WrapErrParameterInvalidMsg("Insert data has function output field, but collection's property `collection.function.allowInsertNonBM25FunctionOutputs` is not enable")
 			}
 			delete(funCandidate, f.Name)
 		}
@@ -3608,7 +3608,7 @@ func ExtractStructFieldName(fieldName string) (string, error) {
 	} else if len(parts) == 2 {
 		return parts[1][:len(parts[1])-1], nil
 	} else {
-		return "", fmt.Errorf("invalid struct field name: %s, more than one [ found", fieldName)
+		return "", merr.WrapErrParameterInvalidMsg("invalid struct field name: %s, more than one [ found", fieldName)
 	}
 }
 
@@ -3636,7 +3636,7 @@ func ApplyArrayRowOp(
 	case schemapb.FieldPartialUpdateOp_ARRAY_REMOVE:
 		return removeArrayRow(base, update, elementType)
 	default:
-		return nil, fmt.Errorf("unsupported FieldPartialUpdateOp: %s", op.String())
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported FieldPartialUpdateOp: %s", op.String())
 	}
 }
 
@@ -3707,7 +3707,7 @@ func appendArrayRow(
 		}
 		return &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: merged}}}, nil
 	default:
-		return nil, fmt.Errorf("ARRAY_APPEND does not support element type: %s", elementType.String())
+		return nil, merr.WrapErrParameterInvalidMsg("ARRAY_APPEND does not support element type: %s", elementType.String())
 	}
 }
 
@@ -3813,7 +3813,7 @@ func removeArrayRow(
 		}
 		return &schemapb.ScalarField{Data: &schemapb.ScalarField_StringData{StringData: &schemapb.StringArray{Data: out}}}, nil
 	default:
-		return nil, fmt.Errorf("ARRAY_REMOVE does not support element type: %s", elementType.String())
+		return nil, merr.WrapErrParameterInvalidMsg("ARRAY_REMOVE does not support element type: %s", elementType.String())
 	}
 }
 
@@ -3839,5 +3839,5 @@ func containsFloat64(haystack []float64, needle float64) bool {
 }
 
 func newArrayCapacityError(got, max int) error {
-	return fmt.Errorf("array length %d exceeds max_capacity %d", got, max)
+	return merr.WrapErrParameterInvalidMsg("array length %d exceeds max_capacity %d", got, max)
 }

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func TestSchema(t *testing.T) {
@@ -649,7 +650,8 @@ func TestSchema_invalid(t *testing.T) {
 		}
 		_, err := CreateSchemaHelper(schema)
 		assert.Error(t, err)
-		assert.EqualError(t, err, "duplicated fieldName: field_int8")
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "duplicated fieldName: field_int8")
 	})
 	t.Run("Duplicate field id", func(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
@@ -675,7 +677,8 @@ func TestSchema_invalid(t *testing.T) {
 		}
 		_, err := CreateSchemaHelper(schema)
 		assert.Error(t, err)
-		assert.EqualError(t, err, "duplicated fieldID: 100")
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "duplicated fieldID: 100")
 	})
 	t.Run("Duplicated primary key", func(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
@@ -701,7 +704,8 @@ func TestSchema_invalid(t *testing.T) {
 		}
 		_, err := CreateSchemaHelper(schema)
 		assert.Error(t, err)
-		assert.EqualError(t, err, "primary key is not unique")
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "primary key is not unique")
 	})
 	t.Run("field not exist", func(t *testing.T) {
 		schema := &schemapb.CollectionSchema{
@@ -723,15 +727,18 @@ func TestSchema_invalid(t *testing.T) {
 
 		_, err = helper.GetPrimaryKeyField()
 		assert.Error(t, err)
-		assert.EqualError(t, err, "failed to get primary key field: no primary in schema")
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "failed to get primary key field: no primary in schema")
 
 		_, err = helper.GetFieldFromName("none")
 		assert.Error(t, err)
-		assert.EqualError(t, err, "failed to get field schema by name: fieldName(none) not found")
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "failed to get field schema by name: fieldName(none) not found")
 
 		_, err = helper.GetFieldFromID(101)
 		assert.Error(t, err)
-		assert.EqualError(t, err, "fieldID(101) not found")
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "fieldID(101) not found")
 	})
 	t.Run("vector dim not exist", func(t *testing.T) {
 		schema := &schemapb.CollectionSchema{

--- a/pkg/util/typeutil/skip_list.go
+++ b/pkg/util/typeutil/skip_list.go
@@ -17,10 +17,10 @@
 package typeutil
 
 import (
-	"fmt"
 	"math/rand"
 	"sync"
 
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"golang.org/x/exp/constraints"
 )
 
@@ -265,10 +265,10 @@ func NewSkipList[K constraints.Ordered, V any](opts ...SkipListOption) (*SkipLis
 		opt(option)
 	}
 	if option.maxLevel < 1 {
-		return nil, fmt.Errorf("invalid maxlevel %d", option.maxLevel)
+		return nil, merr.WrapErrParameterInvalidMsg("invalid maxlevel %d", option.maxLevel)
 	}
 	if option.skip < 1 {
-		return nil, fmt.Errorf("invalid skip %d", option.skip)
+		return nil, merr.WrapErrParameterInvalidMsg("invalid skip %d", option.skip)
 	}
 
 	return &SkipList[K, V]{

--- a/scripts/run_go_unittest.sh
+++ b/scripts/run_go_unittest.sh
@@ -26,6 +26,12 @@ if [[ $(uname -s) == "Darwin" ]]; then
     export MallocNanoZone=0
 fi
 
+# Azurite default credentials for internal/storage TestAzureObjectStorage.
+# Honor any caller-provided value so CI can override with real credentials.
+if [[ -z "${AZURE_STORAGE_CONNECTION_STRING}" ]]; then
+    export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+fi
+
 # ignore MinIO,S3 unittests
 MILVUS_DIR="${ROOT_DIR}/internal/"
 PKG_DIR="${ROOT_DIR}/pkg/"

--- a/tests/python_client/check/func_check.py
+++ b/tests/python_client/check/func_check.py
@@ -504,9 +504,13 @@ class ResponseChecker:
                 num_to_check = min(100, len(distances))  # check 100 items if more than that
                 eps = 1e-6
                 if check_items.get("metric").upper() in ["IP", "COSINE", "BM25"]:
-                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1))
+                    assert all(distances[i] >= distances[i + 1] - eps for i in range(num_to_check - 1)), (
+                        f"distances not descending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 else:
-                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1))
+                    assert all(distances[i] <= distances[i + 1] + eps for i in range(num_to_check - 1)), (
+                        f"distances not ascending within eps={eps}: {distances[:num_to_check]}"
+                    )
                 if check_items.get("vector_nq") is None or check_items.get("original_vectors") is None:
                     log.debug("skip distance check for knowhere does not return the precise distances")
                 else:

--- a/tests/python_client/testcases/test_index.py
+++ b/tests/python_client/testcases/test_index.py
@@ -1524,7 +1524,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("ratio", [-0.5, 1, 3])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_ratio(self, ratio, index):
         """
         target: index creation for unsupported ratio parameter
@@ -1551,7 +1551,7 @@ class TestIndexInvalid(TestcaseBase):
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize("inverted_index_algo", ["INVALID_ALGO"])
-    @pytest.mark.parametrize("index ", ct.all_index_types[10:12])
+    @pytest.mark.parametrize("index", ct.all_index_types[10:12])
     def test_invalid_sparse_inverted_index_algo(self, inverted_index_algo, index):
         """
         target: index creation for unsupported sparse inverted index algo parameter


### PR DESCRIPTION
Standardizes error handling in the `internal/util/*` + `pkg/util/*` utility packages onto the `merr` framework. Part of the system-wide error-standardization series.

### Stacking

Stacked on #50016 (`err-std-02-storage`), which adds the `*wrappedMilvusError` Wrap helper pattern. Until #50016 merges, the diff here also contains the 02-storage commit. **Review the single util commit** `Standardize error handling: util packages (5b2)`. Siblings: #50054 (`err-std-5a-querynodev2`), #50056 (`err-std-5b1-function`), #49865 (`err-std-03-proxy`), #49874 (`err-std-04-coord`).

### What this is

The `internal/util/*` and `pkg/util/*` packages together held ~555 native error sites — second largest single-PR surface in the err-std series. Function module (`internal/util/function`) was already extracted as 5b1 (#50056). **All 29 remaining util subpackages migrated by hand**, per-subpkg sentinel/retry/panic policy decided after a per-subpkg audit.

### One new helper (no new sentinels)

`ErrSegcore (2000)` family already existed in master (2000-2099 is the segcore-reserved code segment). Added one Go-side helper:

- **`WrapErrSegcoreMsg(format, args)`** — for Go-side segcore invariants where there's no C++ errorCode (`WrapErrSegcore(int32, msg...)` requires a code from a C++ throw). Used by 4 sites in `internal/util/segcore` (`reduce.go` nil-searchResult, `collection.go` proto marshal failures, `plan.go` collection released).

All other ~551 sites route to existing sentinels: `ErrParameterInvalid` (1100, InputError, 02-storage), `ErrServiceInternal` (5), `ErrServiceUnavailable` (2, transient), `ErrIoFailed` (1001), `ErrFunctionFailed` (2400, 5a).

### Decision matrix (29 subpackages)

| Subpkg | sites | Notes |
|---|---|---|
| `pkg/util/typeutil` | 127 | schema/data validation → `ParameterInvalid`; 6 defect#3 → `merr.Wrap`; +6 test assertions migrated from `EqualError` to `ErrorIs(ErrParameterInvalid)` + `Contains(msg)` |
| `pkg/util/funcutil` | 43 | per inner-type; 2 defect#3 → `merr.Wrap`; 3 panic preserved |
| `internal/util/indexparamcheck` | 37 | index param check → `ParameterInvalid` |
| `pkg/util/replicateutil` | 31 | **2 sentinel preserved**: `ErrWrongConfiguration` (internal use) and `ErrCurrentClusterNotFound` (external `errors.Is` in `internal/distributed/streaming/replicate_service.go:241` triggers special overwrite-as-primary fallback) |
| `internal/util/importutilv2` | 28 | 19 defect#3 (`: %w`) → `merr.Wrap` (perl-bulk) |
| `internal/util/segcore` | 25 | 14 cgo-wrap → `merr.Wrap`; 4 invariant → `WrapErrSegcoreMsg` (new helper); 5 `ParameterInvalid`; 2 defect#3 |
| `internal/util/queryutil` | 24 | 2 multi-arg defect#3 → `merr.Wrapf` |
| `internal/util/streamingutil` | 22 | **3 sentinel preserved** (`resolver.ErrCanceled` / `resolver.ErrInterrupted` / `lazygrpc.ErrClosed`) — all in public `Resolver.Watch` / `Conn.GetConn` interface contracts using cockroachdb `errors.Mark` / `errors.Is`. balancer: new package-local `errProducedZeroAddresses = merr.WrapErrServiceUnavailable(...)` sentinel; `mergeErrors()` → `merr.Wrap` preserving inner err. 2 panic preserved (wal_selector init) |
| `internal/util/hookutil` | 20 | 1 sentinel rename `ErrCipherPluginMissing` → `errCipherPluginMissing` (lowercase, only used in-package, 0 external `errors.Is`); per inner-type for rest (defect#3 → `merr.Wrap`, `Param` for config, `ServiceInternal` for invariant) |
| `pkg/util/externalspec` | 18 | 1 defect#3 → `merr.Wrap` |
| `internal/util/proxyutil` | 14 | RPC fan-out err path → `merr.Wrapf(err, ...)`; status path → `merr.Wrapf(merr.Error(sta), ...)` — `merr.Error(sta)` lifts proto Status to typed merr so downstream `errors.Is(err, ErrNodeNotFound/ServiceUnimplemented)` (already used at L208/L213) continues to work across the wire |
| `internal/util/idalloc` | 10 | **2 sentinel preserved** (`errExhausted` / `errFastPathFailed`, package-local `errors.Is` targets); RPC pattern same as proxyutil |
| 14 `pkg/util/*` subpkgs (hardware/indexparams/timestamptz/metricsinfo/ratelimitutil/expr/distance/contextutil/etcd/retry/paramtable/lock/conc) | ~50 | bulk `ParameterInvalid`; few defect#3 → `merr.Wrap`; panic preserved |
| `internal/util/sessionutil` | 5 | **Minimal change** — only L729 (lifecycle precondition → `ServiceInternal`) and L733 (runtime disconnect → `ServiceUnavailable`). 3 sites preserved with explicit reasoning: `errSessionVersionCheckFailure` sentinel + its `retry.RetryErr` predicate, `errSessionExpiredAtClientSide` as `context.WithDeadlineCause` marker (not a wire error), L523 CompareAndSwap inside `retry.Do` body (InputError would abort retry — kept as plain `fmt.Errorf`; will revisit if forbidigo linter activates). |
| `internal/util/dependency` | 5 | 2 panic preserved (factory.go init and kv etcd client) |
| `internal/util/pipeline` | 4 | 3 sentinel preserved (exported, no external `errors.Is` yet but stays for future); `WrapErrRegDispather` rewritten with `errors.Mark` to preserve both sentinel identity (for `errors.Is`) and inner err type |

### Pre-flight audit (zero downstream breakage)

- **`retry.Do/Handle × util caller`** audited per high-risk subpkg (sessionutil/hookutil/dependency: 5+5+4 caller files with retry; streamingutil/proxyutil/segcore/idalloc: 1 each). For each high-risk site, picked sentinel that won't abort retry:
  - `InputError` → only for true caller input validation, never inside `retry.Do` body. Avoided the `file_resource_observer` regression that #50016 had to fix.
  - For transient (etcd CAS, RPC fail, network) — `ServiceUnavailable` or `merr.Wrap` preserving inner `ctx.Canceled` / `DeadlineExceeded`.
- **caller-side `WrapErr<X>Err(err, ...)` defect#3** audited globally — **zero hits** across the whole repo (04-coord's 109-site `errors.Wrap → merr.Wrap` migration cleared this preemptively).
- **Sentinel renames** (lowercase) only on sentinels with zero external `errors.Is` callers; sentinels in public-API interface contracts (streamingutil resolver, pipeline) preserved as exported.

### Validation

- `go vet -tags dynamic,test ./internal/util/... ./pkg/util/...`: clean (only pre-existing `mock_session.go` JSON method signature warnings — unrelated).
- `gofmt -l`: clean across all 106 touched files.
- `go test` per subpkg: all green except 5 pre-existing env-dependent failures (verified by checking out `err-std-02-storage` HEAD and reproducing the same failures with `git stash` workflow):
  - `proxyutil` TestProxyManager (etcd needed)
  - `sessionutil` session_util_test (etcd needed)
  - `streamingutil/discoverer` TestSessionDiscoverer (etcd needed)
  - `segcore` TestReduce (cgo C++ build needed)
  - `indexcgowrapper` test (cgo C++ build needed)
- Zero residual `fmt.Errorf` / `errors.New` / `errors.Newf` / `errors.Errorf` outside of explicitly-preserved sites (panic-ergonomic / package-local sentinel definitions / retry.Do-body sites / `context.WithDeadlineCause` markers / `errors.Mark`-based sentinel-wrap).

### Out of scope

- **Forbidigo linter rule for `fmt.Errorf`** — natural follow-up after 5-series complete; will require sweep of preserved panic sites (with `//nolint:forbidigo` or merr-ification).
- **Segcore C++ throw enum ↔ Go sentinel mapping audit** — segcore reserved range 2000-2099 has gaps (2003-2036, 2041-2098). Likely missing Go-side sentinels for some C++ throw paths. Tracked as separate follow-up.

issue: #47420