### PR TITLE
enhance: extend arrow IO thread pool config to DataNode init

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -766,7 +766,7 @@ dataCoord:
     maxImportFileNumPerReq: 1024 # The maximum number of files allowed per single import request.
     maxImportJobNum: 1024 # Maximum number of import jobs that are executing or pending.
     waitForIndex: true # Indicates whether the import operation waits for the completion of index building.
-    fileNumPerSlot: 1 # The files number per slot for pre-import/import task.
+    fileNumPerSlot: 4 # The files number per slot for pre-import/import task.
     memoryLimitPerSlot: 160 # The memory limit (in MB) of buffer size per slot for pre-import/import task.
     maxSegmentsPerCopyTask: 100 # Maximum number of segments that can be grouped into a single copy task during snapshot restore.
   gracefulStopTimeout: 5 # seconds. force stop node without graceful stop

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -89,6 +89,22 @@ func InitSegcore(nodeID int64) error {
 	cGpuMemoryPoolMaxSize := C.uint32_t(paramtable.Get().GpuConfig.MaxSize.GetAsUint32())
 	C.SegcoreSetKnowhereGpuMemoryPoolSize(cGpuMemoryPoolInitSize, cGpuMemoryPoolMaxSize)
 
+	// Apply Arrow IO thread pool capacity from paramtable. Without this call the
+	// pool stays at Arrow's built-in default (kDefaultNumIoThreads = 8), which is
+	// almost always undersized for DataNode under concurrent storage v2 reads
+	// (sort compaction, import, stats). Mirror of the QueryNode wiring in #49208.
+	C.SetArrowIOThreadPoolCapacity(C.int(initcore.ResolveArrowIOThreadPoolCapacity()))
+
+	// Apply Arrow parquet reader range-coalescing config (hole/range size limits).
+	if err := initcore.InitArrowReaderConfig(paramtable.Get()); err != nil {
+		return err
+	}
+
+	// Wire hot-reload watchers so capacity / coalescing-limit changes take effect
+	// without restart, matching QueryNode behavior.
+	initcore.RegisterArrowIOThreadPoolWatchers(paramtable.Get(), "datanode")
+	initcore.RegisterArrowReaderConfigWatchers(paramtable.Get(), "datanode")
+
 	// init paramtable change callback for core related config
 	initcore.SetupCoreConfigChangelCallback()
 

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -248,18 +248,6 @@ func (node *QueryNode) ReconfigDiskFileWriterParams(evt *config.Event) {
 	}
 }
 
-func (node *QueryNode) ReconfigArrowReaderParams(evt *config.Event) {
-	if evt.HasUpdated {
-		if err := initcore.InitArrowReaderConfig(paramtable.Get()); err != nil {
-			log.Ctx(node.ctx).Warn("QueryNode failed to reconfigure arrow reader params", zap.Error(err))
-			return
-		}
-		log.Ctx(node.ctx).Info("QueryNode reconfig arrow reader params successfully",
-			zap.Int64("holeSizeLimitBytes", paramtable.Get().CommonCfg.ArrowReaderHoleSizeLimitBytes.GetAsInt64()),
-			zap.Int64("rangeSizeLimitBytes", paramtable.Get().CommonCfg.ArrowReaderRangeSizeLimitBytes.GetAsInt64()))
-	}
-}
-
 func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 	pt := paramtable.Get()
 	pt.Watch(pt.CommonCfg.HighPriorityThreadCoreCoefficient.Key,
@@ -288,24 +276,7 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 		config.NewHandler("common.diskWriteRateLimiter.middlePriorityRatio", node.ReconfigDiskFileWriterParams))
 	pt.Watch(pt.CommonCfg.DiskWriteRateLimiterLowPriorityRatio.Key,
 		config.NewHandler("common.diskWriteRateLimiter.lowPriorityRatio", node.ReconfigDiskFileWriterParams))
-	arrowIOThreadHandler := func(key string) func(evt *config.Event) {
-		return func(evt *config.Event) {
-			if !evt.HasUpdated {
-				return
-			}
-			newThreads := initcore.ResolveArrowIOThreadPoolCapacity()
-			initcore.UpdateArrowIOThreadPoolCapacity(newThreads)
-			log.Info("arrow io thread pool capacity updated",
-				zap.String("trigger", key),
-				zap.Int("threads", newThreads))
-		}
-	}
-	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key,
-		config.NewHandler(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key,
-			arrowIOThreadHandler(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key)))
-	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
-		config.NewHandler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
-			arrowIOThreadHandler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key)))
+	initcore.RegisterArrowIOThreadPoolWatchers(pt, "querynode")
 	pt.Watch(pt.QueryNodeCfg.StorageV2CellTargetSizeBytes.Key,
 		config.NewHandler("queryNode.segcore.storageV2.cellTargetSizeBytes", func(evt *config.Event) {
 			if !evt.HasUpdated {
@@ -316,10 +287,7 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 			log.Info("queryNode.segcore.storageV2.cellTargetSizeBytes updated",
 				zap.Int64("bytes", newBytes))
 		}))
-	pt.Watch(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key,
-		config.NewHandler(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, node.ReconfigArrowReaderParams))
-	pt.Watch(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key,
-		config.NewHandler(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, node.ReconfigArrowReaderParams))
+	initcore.RegisterArrowReaderConfigWatchers(pt, "querynode")
 }
 
 func getIndexEngineVersion() (minimal, current, maximum int32) {

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -276,8 +276,6 @@ func TestRegisterSegcoreConfigWatcher(t *testing.T) {
 	pt := paramtable.Get()
 	node := &QueryNode{}
 
-	assert.NotPanics(t, func() { node.ReconfigArrowReaderParams(&config.Event{HasUpdated: false}) })
-	assert.NotPanics(t, func() { node.ReconfigArrowReaderParams(&config.Event{HasUpdated: true}) })
 	assert.NotPanics(t, func() { node.RegisterSegcoreConfigWatcher() })
 
 	// verify watchers are triggered by saving config values

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -17,10 +17,12 @@
 package initcore
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
@@ -64,6 +66,76 @@ func TestSetupCoreConfigChangeCallback(t *testing.T) {
 
 	assert.NoError(t, pt.Save(pt.CommonCfg.ThreadPoolMaxThreadsSize.Key, "32"))
 	assert.Equal(t, "32", pt.CommonCfg.ThreadPoolMaxThreadsSize.GetValue())
+}
+
+// TestRegisterArrowIOThreadPoolWatchers verifies the lifted helper registers
+// a handler under each of the two watched keys. The sentinel handler we
+// register after the helper fires whenever the dispatcher receives an event
+// for the key, which proves that the dispatcher has an active handler list
+// for the key (and therefore that the helper's Watch calls landed correctly).
+//
+// Note on `HasUpdated`: paramtable's Save() unconditionally sets
+// HasUpdated=true on its synthetic runtime event, so the short-circuit branch
+// inside the helper is exercised only by file/etcd refresh events in
+// production, not by Save() in a unit test. We don't try to assert it here.
+func TestRegisterArrowIOThreadPoolWatchers(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	defer pt.Reset(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key)
+	defer pt.Reset(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key)
+
+	assert.NotPanics(t, func() { RegisterArrowIOThreadPoolWatchers(pt, "test") })
+
+	var coefFires, maxFires atomic.Int32
+	coefSentinel := config.NewHandler("sentinel-coef", func(*config.Event) { coefFires.Add(1) })
+	maxSentinel := config.NewHandler("sentinel-max", func(*config.Event) { maxFires.Add(1) })
+	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key, coefSentinel)
+	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key, maxSentinel)
+	defer pt.Unwatch(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key, coefSentinel)
+	defer pt.Unwatch(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key, maxSentinel)
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key, "2"))
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key, "64"))
+
+	assert.Positive(t, coefFires.Load(),
+		"helper must have registered a handler on ArrowIOThreadPoolCoefficient")
+	assert.Positive(t, maxFires.Load(),
+		"helper must have registered a handler on ArrowIOThreadPoolMaxCapacity")
+}
+
+// TestRegisterArrowReaderConfigWatchers verifies the lifted helper registers
+// a handler under each of the two arrow-reader range/hole keys, using the
+// same sentinel approach as above.
+func TestRegisterArrowReaderConfigWatchers(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	defer pt.Reset(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key)
+	defer pt.Reset(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key)
+
+	assert.NotPanics(t, func() { RegisterArrowReaderConfigWatchers(pt, "test") })
+
+	var holeFires, rangeFires atomic.Int32
+	holeSentinel := config.NewHandler("sentinel-hole", func(*config.Event) { holeFires.Add(1) })
+	rangeSentinel := config.NewHandler("sentinel-range", func(*config.Event) { rangeFires.Add(1) })
+	pt.Watch(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, holeSentinel)
+	pt.Watch(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, rangeSentinel)
+	defer pt.Unwatch(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, holeSentinel)
+	defer pt.Unwatch(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, rangeSentinel)
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, "32768"))
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, "1048576"))
+
+	assert.Positive(t, holeFires.Load(),
+		"helper must have registered a handler on ArrowReaderHoleSizeLimitBytes")
+	assert.Positive(t, rangeFires.Load(),
+		"helper must have registered a handler on ArrowReaderRangeSizeLimitBytes")
+
+	// Drive the handler's error branch: a negative value makes the C-side
+	// InitArrowReaderConfig return ConfigInvalid; the handler must log and
+	// return without panicking. This exercises the `if err != nil` branch.
+	assert.NotPanics(t, func() {
+		_ = pt.Save(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, "-1")
+	})
 }
 
 func TestInitArrowReaderConfig(t *testing.T) {

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -30,6 +30,10 @@ import (
 	"strings"
 	"unsafe"
 
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v3/config"
+	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -109,6 +113,58 @@ func ResolveArrowIOThreadPoolCapacity() int {
 		threads = maxCap
 	}
 	return threads
+}
+
+// RegisterArrowIOThreadPoolWatchers wires hot-reload of arrow IO pool capacity
+// to paramtable updates on the two coefficient/maxCapacity keys. `source` is
+// included in the log entry so log lines from different components (e.g.
+// "querynode" vs "datanode" in standalone, where both register the same keys)
+// remain distinguishable.
+func RegisterArrowIOThreadPoolWatchers(pt *paramtable.ComponentParam, source string) {
+	handler := func(key string) func(*config.Event) {
+		return func(evt *config.Event) {
+			if !evt.HasUpdated {
+				return
+			}
+			newThreads := ResolveArrowIOThreadPoolCapacity()
+			UpdateArrowIOThreadPoolCapacity(newThreads)
+			log.Info("arrow io thread pool capacity updated",
+				zap.String("source", source),
+				zap.String("trigger", key),
+				zap.Int("threads", newThreads))
+		}
+	}
+	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key,
+		config.NewHandler(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key,
+			handler(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key)))
+	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
+		config.NewHandler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
+			handler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key)))
+}
+
+// RegisterArrowReaderConfigWatchers wires hot-reload of arrow parquet reader
+// range-coalescing limits to paramtable updates on the two hole/range size
+// keys. `source` is included in the log entry for the same reason as in
+// RegisterArrowIOThreadPoolWatchers.
+func RegisterArrowReaderConfigWatchers(pt *paramtable.ComponentParam, source string) {
+	handler := func(evt *config.Event) {
+		if !evt.HasUpdated {
+			return
+		}
+		if err := InitArrowReaderConfig(pt); err != nil {
+			log.Warn("failed to reconfigure arrow reader params",
+				zap.String("source", source), zap.Error(err))
+			return
+		}
+		log.Info("arrow reader params reconfigured",
+			zap.String("source", source),
+			zap.Int64("holeSizeLimitBytes", pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.GetAsInt64()),
+			zap.Int64("rangeSizeLimitBytes", pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.GetAsInt64()))
+	}
+	pt.Watch(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key,
+		config.NewHandler(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, handler))
+	pt.Watch(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key,
+		config.NewHandler(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, handler))
 }
 
 func UpdateStorageV2CellTargetSizeBytes(bytes int64) {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6260,7 +6260,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 		Key:          "dataCoord.import.fileNumPerSlot",
 		Version:      "2.5.15",
 		Doc:          "The files number per slot for pre-import/import task.",
-		DefaultValue: "1",
+		DefaultValue: "4",
 		PanicIfEmpty: false,
 		Export:       true,
 	}

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -581,7 +581,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 1024, Params.MaxFilesPerImportReq.GetAsInt())
 		assert.Equal(t, 1024, Params.MaxImportJobNum.GetAsInt())
 		assert.Equal(t, true, Params.WaitForIndex.GetAsBool())
-		assert.Equal(t, 1, Params.ImportFileNumPerSlot.GetAsInt())
+		assert.Equal(t, 4, Params.ImportFileNumPerSlot.GetAsInt())
 		assert.Equal(t, 160*1024*1024, Params.ImportMemoryLimitPerSlot.GetAsInt())
 
 		params.Save("datacoord.gracefulStopTimeout", "100")


### PR DESCRIPTION
issue: #50098

## Summary

- Apply `common.arrow.ioThreadPoolCoefficient` / `ioThreadPoolMaxCapacity` to DataNode at startup, mirroring the QueryNode wiring from #49208/#49623. Without this, the paramtable keys exist but have no effect on DataNode and the Arrow IO pool stays at Arrow's hard-coded default of 8.
- Also call `initcore.InitArrowReaderConfig` so the parquet reader range-coalescing limits (`hole`/`range` size) apply.
- Register paramtable watchers so capacity changes hot-reload without restart, matching QueryNode behavior.
- Raise `dataCoord.import.fileNumPerSlot` default from 1 to 4 to reduce per-import slot demand by 4x and leave more arrow IO pool headroom for concurrent compactions on the same worker.

## Why

See #50098 for the full reproducer and analysis. Briefly: production observed a 1.5M-row sort compaction taking >1 hour while the worker's CPU sat at 12% and network at 14% of baseline — all 5 large SortCompactions on different pods finished at nearly identical wall times (variance < 1%), the classic shared-pool saturation signature. Local bench at 50ms RTT with 100 concurrent readers:

| ARROW_IO_THREADS | conc=100 wall_ms | per-task p50_ms |
|---|---|---|
| 8 (default) | 36,917 | 35,908 |
| 32 | 18,174 | 16,074 |
| 64 | 17,320 | 15,702 |

## Test plan

- [x] `go test -count=1 -run TestComponentParam ./util/paramtable/` (pkg module)
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 -run TestRegisterArrowIOThreadPoolWatchers ./internal/datanode/index/`
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 -run "TestImport" ./internal/datacoord/`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)