### PR TITLE
enhance: [2.6] extend arrow IO thread pool config to DataNode init

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -750,7 +750,7 @@ dataCoord:
     maxImportFileNumPerReq: 1024 # The maximum number of files allowed per single import request.
     maxImportJobNum: 1024 # Maximum number of import jobs that are executing or pending.
     waitForIndex: true # Indicates whether the import operation waits for the completion of index building.
-    fileNumPerSlot: 1 # The files number per slot for pre-import/import task.
+    fileNumPerSlot: 4 # The files number per slot for pre-import/import task.
     memoryLimitPerSlot: 160 # The memory limit (in MB) of buffer size per slot for pre-import/import task.
   gracefulStopTimeout: 5 # seconds. force stop node without graceful stop
   slot:

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -87,6 +87,22 @@ func InitSegcore(nodeID int64) error {
 	cGpuMemoryPoolMaxSize := C.uint32_t(paramtable.Get().GpuConfig.MaxSize.GetAsUint32())
 	C.SegcoreSetKnowhereGpuMemoryPoolSize(cGpuMemoryPoolInitSize, cGpuMemoryPoolMaxSize)
 
+	// Apply Arrow IO thread pool capacity from paramtable. Without this call the
+	// pool stays at Arrow's built-in default (kDefaultNumIoThreads = 8), which is
+	// almost always undersized for DataNode under concurrent storage v2 reads
+	// (sort compaction, import, stats). Mirror of the QueryNode wiring in #49208.
+	C.SetArrowIOThreadPoolCapacity(C.int(initcore.ResolveArrowIOThreadPoolCapacity()))
+
+	// Apply Arrow parquet reader range-coalescing config (hole/range size limits).
+	if err := initcore.InitArrowReaderConfig(paramtable.Get()); err != nil {
+		return err
+	}
+
+	// Wire hot-reload watchers so capacity / coalescing-limit changes take effect
+	// without restart, matching QueryNode behavior.
+	initcore.RegisterArrowIOThreadPoolWatchers(paramtable.Get(), "datanode")
+	initcore.RegisterArrowReaderConfigWatchers(paramtable.Get(), "datanode")
+
 	// init paramtable change callback for core related config
 	initcore.SetupCoreConfigChangelCallback()
 

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -240,18 +240,6 @@ func (node *QueryNode) ReconfigDiskFileWriterParams(evt *config.Event) {
 	}
 }
 
-func (node *QueryNode) ReconfigArrowReaderParams(evt *config.Event) {
-	if evt.HasUpdated {
-		if err := initcore.InitArrowReaderConfig(paramtable.Get()); err != nil {
-			log.Ctx(node.ctx).Warn("QueryNode failed to reconfigure arrow reader params", zap.Error(err))
-			return
-		}
-		log.Ctx(node.ctx).Info("QueryNode reconfig arrow reader params successfully",
-			zap.Int64("holeSizeLimitBytes", paramtable.Get().CommonCfg.ArrowReaderHoleSizeLimitBytes.GetAsInt64()),
-			zap.Int64("rangeSizeLimitBytes", paramtable.Get().CommonCfg.ArrowReaderRangeSizeLimitBytes.GetAsInt64()))
-	}
-}
-
 func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 	pt := paramtable.Get()
 	pt.Watch(pt.CommonCfg.HighPriorityThreadCoreCoefficient.Key,
@@ -280,28 +268,8 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 		config.NewHandler("common.diskWriteRateLimiter.middlePriorityRatio", node.ReconfigDiskFileWriterParams))
 	pt.Watch(pt.CommonCfg.DiskWriteRateLimiterLowPriorityRatio.Key,
 		config.NewHandler("common.diskWriteRateLimiter.lowPriorityRatio", node.ReconfigDiskFileWriterParams))
-	arrowIOThreadHandler := func(key string) func(evt *config.Event) {
-		return func(evt *config.Event) {
-			if !evt.HasUpdated {
-				return
-			}
-			newThreads := initcore.ResolveArrowIOThreadPoolCapacity()
-			initcore.UpdateArrowIOThreadPoolCapacity(newThreads)
-			log.Info("arrow io thread pool capacity updated",
-				zap.String("trigger", key),
-				zap.Int("threads", newThreads))
-		}
-	}
-	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key,
-		config.NewHandler(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key,
-			arrowIOThreadHandler(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key)))
-	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
-		config.NewHandler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
-			arrowIOThreadHandler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key)))
-	pt.Watch(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key,
-		config.NewHandler(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, node.ReconfigArrowReaderParams))
-	pt.Watch(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key,
-		config.NewHandler(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, node.ReconfigArrowReaderParams))
+	initcore.RegisterArrowIOThreadPoolWatchers(pt, "querynode")
+	initcore.RegisterArrowReaderConfigWatchers(pt, "querynode")
 }
 
 func getIndexEngineVersion() (minimal, current, maximum int32) {

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -17,10 +17,12 @@
 package initcore
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus/pkg/v2/config"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -64,6 +66,87 @@ func TestSetupCoreConfigChangeCallback(t *testing.T) {
 
 	assert.NoError(t, pt.Save(pt.CommonCfg.ThreadPoolMaxThreadsSize.Key, "32"))
 	assert.Equal(t, "32", pt.CommonCfg.ThreadPoolMaxThreadsSize.GetValue())
+}
+
+// TestRegisterArrowIOThreadPoolWatchers verifies the lifted helper registers
+// a handler under each of the two watched keys. The sentinel handler we
+// register after the helper fires whenever the dispatcher receives an event
+// for the key, which proves that the dispatcher has an active handler list
+// for the key (and therefore that the helper's Watch calls landed correctly).
+//
+// Note on `HasUpdated`: paramtable's Save() unconditionally sets
+// HasUpdated=true on its synthetic runtime event, so the short-circuit branch
+// inside the helper is exercised only by file/etcd refresh events in
+// production, not by Save() in a unit test. We don't try to assert it here.
+func TestRegisterArrowIOThreadPoolWatchers(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	defer pt.Reset(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key)
+	defer pt.Reset(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key)
+
+	assert.NotPanics(t, func() { RegisterArrowIOThreadPoolWatchers(pt, "test") })
+
+	var coefFires, maxFires atomic.Int32
+	coefSentinel := config.NewHandler("sentinel-coef", func(*config.Event) { coefFires.Add(1) })
+	maxSentinel := config.NewHandler("sentinel-max", func(*config.Event) { maxFires.Add(1) })
+	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key, coefSentinel)
+	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key, maxSentinel)
+	defer pt.Unwatch(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key, coefSentinel)
+	defer pt.Unwatch(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key, maxSentinel)
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key, "2"))
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key, "64"))
+
+	assert.Positive(t, coefFires.Load(),
+		"helper must have registered a handler on ArrowIOThreadPoolCoefficient")
+	assert.Positive(t, maxFires.Load(),
+		"helper must have registered a handler on ArrowIOThreadPoolMaxCapacity")
+}
+
+// TestRegisterArrowReaderConfigWatchers verifies the lifted helper registers
+// a handler under each of the two arrow-reader range/hole keys, using the
+// same sentinel approach as above.
+func TestRegisterArrowReaderConfigWatchers(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	defer pt.Reset(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key)
+	defer pt.Reset(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key)
+
+	assert.NotPanics(t, func() { RegisterArrowReaderConfigWatchers(pt, "test") })
+
+	var holeFires, rangeFires atomic.Int32
+	holeSentinel := config.NewHandler("sentinel-hole", func(*config.Event) { holeFires.Add(1) })
+	rangeSentinel := config.NewHandler("sentinel-range", func(*config.Event) { rangeFires.Add(1) })
+	pt.Watch(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, holeSentinel)
+	pt.Watch(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, rangeSentinel)
+	defer pt.Unwatch(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, holeSentinel)
+	defer pt.Unwatch(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, rangeSentinel)
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, "32768"))
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, "1048576"))
+
+	assert.Positive(t, holeFires.Load(),
+		"helper must have registered a handler on ArrowReaderHoleSizeLimitBytes")
+	assert.Positive(t, rangeFires.Load(),
+		"helper must have registered a handler on ArrowReaderRangeSizeLimitBytes")
+
+	// Drive the handler's error branch: a negative value makes the C-side
+	// InitArrowReaderConfig return ConfigInvalid; the handler must log and
+	// return without panicking. This exercises the `if err != nil` branch.
+	assert.NotPanics(t, func() {
+		_ = pt.Save(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, "-1")
+	})
+}
+
+func TestInitArrowReaderConfig(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+
+	assert.NoError(t, InitArrowReaderConfig(pt))
+
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, "32768"))
+	assert.NoError(t, pt.Save(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, "1048576"))
+	assert.NoError(t, InitArrowReaderConfig(pt))
 }
 
 func TestInitStorageV2FileSystem(t *testing.T) {

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -30,6 +30,10 @@ import (
 	"strings"
 	"unsafe"
 
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/pkg/v2/config"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
@@ -105,6 +109,58 @@ func ResolveArrowIOThreadPoolCapacity() int {
 		threads = maxCap
 	}
 	return threads
+}
+
+// RegisterArrowIOThreadPoolWatchers wires hot-reload of arrow IO pool capacity
+// to paramtable updates on the two coefficient/maxCapacity keys. `source` is
+// included in the log entry so log lines from different components (e.g.
+// "querynode" vs "datanode" in standalone, where both register the same keys)
+// remain distinguishable.
+func RegisterArrowIOThreadPoolWatchers(pt *paramtable.ComponentParam, source string) {
+	handler := func(key string) func(*config.Event) {
+		return func(evt *config.Event) {
+			if !evt.HasUpdated {
+				return
+			}
+			newThreads := ResolveArrowIOThreadPoolCapacity()
+			UpdateArrowIOThreadPoolCapacity(newThreads)
+			log.Info("arrow io thread pool capacity updated",
+				zap.String("source", source),
+				zap.String("trigger", key),
+				zap.Int("threads", newThreads))
+		}
+	}
+	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key,
+		config.NewHandler(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key,
+			handler(pt.CommonCfg.ArrowIOThreadPoolCoefficient.Key)))
+	pt.Watch(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
+		config.NewHandler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key,
+			handler(pt.CommonCfg.ArrowIOThreadPoolMaxCapacity.Key)))
+}
+
+// RegisterArrowReaderConfigWatchers wires hot-reload of arrow parquet reader
+// range-coalescing limits to paramtable updates on the two hole/range size
+// keys. `source` is included in the log entry for the same reason as in
+// RegisterArrowIOThreadPoolWatchers.
+func RegisterArrowReaderConfigWatchers(pt *paramtable.ComponentParam, source string) {
+	handler := func(evt *config.Event) {
+		if !evt.HasUpdated {
+			return
+		}
+		if err := InitArrowReaderConfig(pt); err != nil {
+			log.Warn("failed to reconfigure arrow reader params",
+				zap.String("source", source), zap.Error(err))
+			return
+		}
+		log.Info("arrow reader params reconfigured",
+			zap.String("source", source),
+			zap.Int64("holeSizeLimitBytes", pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.GetAsInt64()),
+			zap.Int64("rangeSizeLimitBytes", pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.GetAsInt64()))
+	}
+	pt.Watch(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key,
+		config.NewHandler(pt.CommonCfg.ArrowReaderHoleSizeLimitBytes.Key, handler))
+	pt.Watch(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key,
+		config.NewHandler(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, handler))
 }
 
 func UpdateDefaultGrowingJSONKeyStatsEnable(enable bool) {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -6035,7 +6035,7 @@ if param targetScalarIndexVersion is not set, the default value is -1, which mea
 		Key:          "dataCoord.import.fileNumPerSlot",
 		Version:      "2.5.15",
 		Doc:          "The files number per slot for pre-import/import task.",
-		DefaultValue: "1",
+		DefaultValue: "4",
 		PanicIfEmpty: false,
 		Export:       true,
 	}

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -580,7 +580,7 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 1024, Params.MaxFilesPerImportReq.GetAsInt())
 		assert.Equal(t, 1024, Params.MaxImportJobNum.GetAsInt())
 		assert.Equal(t, true, Params.WaitForIndex.GetAsBool())
-		assert.Equal(t, 1, Params.ImportFileNumPerSlot.GetAsInt())
+		assert.Equal(t, 4, Params.ImportFileNumPerSlot.GetAsInt())
 		assert.Equal(t, 160*1024*1024, Params.ImportMemoryLimitPerSlot.GetAsInt())
 
 		params.Save("datacoord.gracefulStopTimeout", "100")


### PR DESCRIPTION
issue: #50098
pr: #50099

## Summary

2.6 backport of #50099. Cherry-pick of:
- `cf6dc32687` enhance: extend arrow IO thread pool config to DataNode init
- `dcd82c723a` enhance: raise dataCoord.import.fileNumPerSlot default from 1 to 4

Conflict resolved: import paths re-pointed from `pkg/v3/*` (master) to `pkg/v2/*` (2.6). No behavior change beyond what's in the master PR.

## Why

See #50098 / #50099 for the full reproducer and analysis. Production 2.6.x cluster hit a 1.5M-row sort compaction stalled for >1 hour while CPU sat at 12% — root cause is the DataNode Arrow IO thread pool being stuck at Arrow's hard-coded default of 8 threads, with `common.arrow.ioThreadPoolCoefficient` introduced in 2.6.16 (#49554) having no effect on DataNode because the wiring was never extended there.

## Test plan

- [x] Cherry-pick clean (only conflict was pkg/v3 → pkg/v2 import paths)
- [x] `gofmt` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)