### PR TITLE
fix: Support Vortex byte-vector list input

### DIFF
--- a/internal/core/src/storage/DataCodecTest.cpp
+++ b/internal/core/src/storage/DataCodecTest.cpp
@@ -461,7 +461,7 @@ TEST(storage, ExternalNullableVectorArrayPreservesNullRows) {
         storage::NormalizeExternalArrow(list_array, non_nullable_meta));
 }
 
-TEST(storage, ExternalBinaryVectorListNormalizeFails) {
+TEST(storage, ExternalBinaryVectorListNormalizesToFixedSizeBinary) {
     auto value_builder = std::make_shared<arrow::UInt8Builder>();
     arrow::ListBuilder builder(arrow::default_memory_pool(), value_builder);
     auto& byte_builder =
@@ -476,7 +476,14 @@ TEST(storage, ExternalBinaryVectorListNormalizeFails) {
 
     auto field_meta = MakeExternalFieldMetaForTest(
         DataType::VECTOR_BINARY, DataType::NONE, false, 16);
-    EXPECT_ANY_THROW(storage::NormalizeExternalArrow(list_array, field_meta));
+    auto normalized = storage::NormalizeExternalArrow(list_array, field_meta);
+    ASSERT_EQ(normalized->type_id(), arrow::Type::FIXED_SIZE_BINARY);
+
+    auto fsb_array =
+        std::static_pointer_cast<arrow::FixedSizeBinaryArray>(normalized);
+    ASSERT_EQ(fsb_array->byte_width(), 2);
+    const uint8_t expected[] = {0, 1};
+    EXPECT_EQ(memcmp(fsb_array->Value(0), expected, sizeof(expected)), 0);
 }
 
 TEST(storage, ExternalNullableVarCharBinaryPreservesNullCount) {

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1790,6 +1790,9 @@ IsByteVectorListInput(DataType data_type) {
 arrow::Type::type
 ExpectedVectorListElementArrowType(DataType data_type,
                                    const FieldMeta& field_meta) {
+    // This only validates vector columns encoded as List/FixedSizeList input.
+    // FixedSizeBinary and nullable Binary inputs bypass this helper and are
+    // validated by their byte-width checks instead.
     switch (data_type) {
         case DataType::VECTOR_FLOAT:
             return arrow::Type::FLOAT;
@@ -1826,6 +1829,8 @@ ArrowTypeName(arrow::Type::type type) {
 
 int
 ExpectedVectorListLength(DataType data_type, int dim) {
+    // Float-like vector lists are element-counted by dim. Byte vector lists are
+    // raw-byte encoded, so their list length must match the physical byte width.
     if (IsByteVectorListInput(data_type)) {
         return GetDataTypeSize(data_type, dim);
     }

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1781,6 +1781,12 @@ ValidateNoNullValuesInRange(const std::shared_ptr<arrow::Array>& values,
     }
 }
 
+bool
+IsByteVectorListInput(DataType data_type) {
+    return data_type == DataType::VECTOR_BINARY ||
+           data_type == DataType::VECTOR_BFLOAT16;
+}
+
 arrow::Type::type
 ExpectedVectorListElementArrowType(DataType data_type,
                                    const FieldMeta& field_meta) {
@@ -1793,10 +1799,7 @@ ExpectedVectorListElementArrowType(DataType data_type,
             return arrow::Type::HALF_FLOAT;
         case DataType::VECTOR_BINARY:
         case DataType::VECTOR_BFLOAT16:
-            ThrowInfo(ErrorCode::Unsupported,
-                      "vector list input{} is not supported for {}",
-                      FieldErrorSuffix(field_meta),
-                      data_type);
+            return arrow::Type::UINT8;
         default:
             ThrowInfo(ErrorCode::Unsupported,
                       "unsupported vector list input{} for {}",
@@ -1814,9 +1817,19 @@ ArrowTypeName(arrow::Type::type type) {
             return "int8";
         case arrow::Type::HALF_FLOAT:
             return "halffloat";
+        case arrow::Type::UINT8:
+            return "uint8";
         default:
             return "unsupported";
     }
+}
+
+int
+ExpectedVectorListLength(DataType data_type, int dim) {
+    if (IsByteVectorListInput(data_type)) {
+        return GetDataTypeSize(data_type, dim);
+    }
+    return dim;
 }
 
 void
@@ -1854,6 +1867,7 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
         }
 
         int64_t num_rows = array->length();
+        int expected_list_length = ExpectedVectorListLength(data_type, dim);
         auto buffer_result = arrow::AllocateBuffer(num_rows * byte_width);
         AssertInfo(buffer_result.ok(),
                    "Failed to allocate buffer for vector normalization");
@@ -1881,16 +1895,17 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
             for (int64_t i = 0; i < num_rows; i++) {
                 if (array->IsValid(i)) {
                     auto offset = list_array->value_offset(i);
-                    auto actual_dim = list_array->value_offset(i + 1) - offset;
-                    AssertInfo(actual_dim == dim,
-                               "vector dimension mismatch{}, expected {}, "
+                    auto actual_length =
+                        list_array->value_offset(i + 1) - offset;
+                    AssertInfo(actual_length == expected_list_length,
+                               "vector list length mismatch{}, expected {}, "
                                "actual {} at row {}",
                                FieldErrorSuffix(field_meta),
-                               dim,
-                               actual_dim,
+                               expected_list_length,
+                               actual_length,
                                i);
                     ValidateNoNullValuesInRange(
-                        values, offset, offset + actual_dim, "vector list");
+                        values, offset, offset + actual_length, "vector list");
                     memcpy(dst + i * byte_width,
                            raw + offset * elem_byte_size,
                            byte_width);
@@ -1909,18 +1924,20 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
                        FieldErrorSuffix(field_meta),
                        elem_bit_width);
             int elem_byte_size = elem_bit_width / 8;
-            AssertInfo(fsl_array->value_length() == dim,
-                       "vector dimension mismatch{}, expected {}, actual {}",
+            AssertInfo(fsl_array->value_length() == expected_list_length,
+                       "vector list length mismatch{}, expected {}, actual {}",
                        FieldErrorSuffix(field_meta),
-                       dim,
+                       expected_list_length,
                        fsl_array->value_length());
             auto raw = reinterpret_cast<const uint8_t*>(
                 values->data()->buffers[1]->data());
             for (int64_t i = 0; i < num_rows; i++) {
                 if (array->IsValid(i)) {
                     auto offset = fsl_array->value_offset(i);
-                    ValidateNoNullValuesInRange(
-                        values, offset, offset + dim, "vector list");
+                    ValidateNoNullValuesInRange(values,
+                                                offset,
+                                                offset + expected_list_length,
+                                                "vector list");
                     memcpy(dst + i * byte_width,
                            raw + offset * elem_byte_size,
                            byte_width);

--- a/internal/core/unittest/test_arrow_canonicalize.cpp
+++ b/internal/core/unittest/test_arrow_canonicalize.cpp
@@ -15,6 +15,7 @@
 #include <arrow/type.h>
 #include <gtest/gtest.h>
 
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <string>
@@ -598,7 +599,70 @@ TEST(NormalizeVectorArraysToFixedSizeBinary,
                  std::exception);
 }
 
-TEST(NormalizeVectorArraysToFixedSizeBinary, BinaryVectorRejectsFixedSizeList) {
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     BinaryVectorFixedSizeListUInt8NormalizesToFixedSizeBinary) {
+    arrow::UInt8Builder values_builder;
+    ASSERT_TRUE(values_builder.AppendValues({0x01, 0x02, 0x03, 0x04}).ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(values_builder.Finish(&values).ok());
+
+    auto input = std::make_shared<arrow::FixedSizeListArray>(
+        arrow::fixed_size_list(arrow::uint8(), 2), 2, values);
+    auto output = NormalizeVectorArraysToFixedSizeBinaryForTest(
+        {input}, milvus::DataType::VECTOR_BINARY, 16);
+    ASSERT_EQ(output->type_id(), arrow::Type::FIXED_SIZE_BINARY);
+    auto fsb = std::static_pointer_cast<arrow::FixedSizeBinaryArray>(output);
+    ASSERT_EQ(fsb->byte_width(), 2);
+    const uint8_t expected0[] = {0x01, 0x02};
+    const uint8_t expected1[] = {0x03, 0x04};
+    EXPECT_EQ(std::memcmp(fsb->Value(0), expected0, sizeof(expected0)), 0);
+    EXPECT_EQ(std::memcmp(fsb->Value(1), expected1, sizeof(expected1)), 0);
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     BFloat16VectorFixedSizeListUInt8NormalizesToFixedSizeBinary) {
+    arrow::UInt8Builder values_builder;
+    ASSERT_TRUE(values_builder.AppendValues({0x01, 0x02, 0x03, 0x04}).ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(values_builder.Finish(&values).ok());
+
+    auto input = std::make_shared<arrow::FixedSizeListArray>(
+        arrow::fixed_size_list(arrow::uint8(), 4), 1, values);
+    auto output = NormalizeVectorArraysToFixedSizeBinaryForTest(
+        {input}, milvus::DataType::VECTOR_BFLOAT16, 2);
+    ASSERT_EQ(output->type_id(), arrow::Type::FIXED_SIZE_BINARY);
+    auto fsb = std::static_pointer_cast<arrow::FixedSizeBinaryArray>(output);
+    ASSERT_EQ(fsb->byte_width(), 4);
+    const uint8_t expected[] = {0x01, 0x02, 0x03, 0x04};
+    EXPECT_EQ(std::memcmp(fsb->Value(0), expected, sizeof(expected)), 0);
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     BinaryVectorListUInt8NormalizesToFixedSizeBinary) {
+    arrow::UInt8Builder values_builder;
+    ASSERT_TRUE(values_builder.AppendValues({0x01, 0x02, 0x03, 0x04}).ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(values_builder.Finish(&values).ok());
+
+    arrow::Int32Builder offsets_builder;
+    ASSERT_TRUE(offsets_builder.AppendValues({0, 2, 4}).ok());
+    std::shared_ptr<arrow::Array> offsets;
+    ASSERT_TRUE(offsets_builder.Finish(&offsets).ok());
+
+    auto input = *arrow::ListArray::FromArrays(*offsets, *values);
+    auto output = NormalizeVectorArraysToFixedSizeBinaryForTest(
+        {input}, milvus::DataType::VECTOR_BINARY, 16);
+    ASSERT_EQ(output->type_id(), arrow::Type::FIXED_SIZE_BINARY);
+    auto fsb = std::static_pointer_cast<arrow::FixedSizeBinaryArray>(output);
+    ASSERT_EQ(fsb->byte_width(), 2);
+    const uint8_t expected0[] = {0x01, 0x02};
+    const uint8_t expected1[] = {0x03, 0x04};
+    EXPECT_EQ(std::memcmp(fsb->Value(0), expected0, sizeof(expected0)), 0);
+    EXPECT_EQ(std::memcmp(fsb->Value(1), expected1, sizeof(expected1)), 0);
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     BinaryVectorRejectsNonUInt8FixedSizeList) {
     arrow::Int8Builder values_builder;
     ASSERT_TRUE(values_builder.AppendValues({1, 0, 1, 0, 1, 0, 1, 0}).ok());
     std::shared_ptr<arrow::Array> values;
@@ -612,7 +676,7 @@ TEST(NormalizeVectorArraysToFixedSizeBinary, BinaryVectorRejectsFixedSizeList) {
 }
 
 TEST(NormalizeVectorArraysToFixedSizeBinary,
-     BFloat16VectorRejectsFixedSizeList) {
+     BFloat16VectorRejectsNonUInt8FixedSizeList) {
     arrow::Int16Builder values_builder;
     ASSERT_TRUE(values_builder.AppendValues({1, 2}).ok());
     std::shared_ptr<arrow::Array> values;
@@ -622,6 +686,20 @@ TEST(NormalizeVectorArraysToFixedSizeBinary,
         arrow::fixed_size_list(arrow::int16(), 2), 1, values);
     EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
                      {input}, milvus::DataType::VECTOR_BFLOAT16, 2),
+                 std::exception);
+}
+
+TEST(NormalizeVectorArraysToFixedSizeBinary,
+     ByteVectorFixedSizeListWidthMismatchAsserts) {
+    arrow::UInt8Builder values_builder;
+    ASSERT_TRUE(values_builder.AppendValues({0x01, 0x02, 0x03}).ok());
+    std::shared_ptr<arrow::Array> values;
+    ASSERT_TRUE(values_builder.Finish(&values).ok());
+
+    auto input = std::make_shared<arrow::FixedSizeListArray>(
+        arrow::fixed_size_list(arrow::uint8(), 3), 1, values);
+    EXPECT_THROW(NormalizeVectorArraysToFixedSizeBinaryForTest(
+                     {input}, milvus::DataType::VECTOR_BINARY, 16),
                  std::exception);
 }
 

--- a/tests/python_client/milvus_client/test_milvus_client_external_table.py
+++ b/tests/python_client/milvus_client/test_milvus_client_external_table.py
@@ -58,9 +58,6 @@ from tenacity import Retrying, retry_if_result, stop_after_delay, wait_fixed
 from utils.util_log import test_log as log
 
 REFRESH_POLL_INTERVAL_SECONDS = 2
-# Milvus currently rejects Vortex FixedSizeList<UInt8> byte-vector payloads.
-# TODO(https://github.com/milvus-io/milvus/issues/49828): enable these fields.
-VORTEX_FULL_MATRIX_EXCLUDED_FIELDS = ("bf16v", "binv_flat", "binv_ivf")
 
 ALLOWED_EXTERNAL_SOURCE_SCHEMES = (pytest.param("minio", id="minio"),)
 _PLACEHOLDER_SRC = "s3://localhost:9000/milvus-bucket/placeholder/"
@@ -3543,7 +3540,6 @@ class TestMilvusClientExternalTableFullMatrix(ExternalTableTestBase):
             _full_matrix_arrow_columns(
                 FULL_MATRIX_NB,
                 0,
-                excluded_fields=VORTEX_FULL_MATRIX_EXCLUDED_FIELDS,
                 vortex_compatible=True,
             )
         )
@@ -3553,15 +3549,12 @@ class TestMilvusClientExternalTableFullMatrix(ExternalTableTestBase):
             client,
             ext_url,
             ext_spec=build_external_spec(cfg, fmt="vortex"),
-            excluded_fields=VORTEX_FULL_MATRIX_EXCLUDED_FIELDS,
         )
         self.create_collection(client, collection_name=coll, schema=schema)
         self.refresh_and_wait(client, coll)
-        create_full_matrix_indexes(self, client, coll, excluded_fields=VORTEX_FULL_MATRIX_EXCLUDED_FIELDS)
+        create_full_matrix_indexes(self, client, coll)
         self.load_collection(client, coll)
-        _full_matrix_assert_basic(
-            self, client, coll, FULL_MATRIX_NB, excluded_fields=VORTEX_FULL_MATRIX_EXCLUDED_FIELDS
-        )
+        _full_matrix_assert_basic(self, client, coll, FULL_MATRIX_NB)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_external_table_full_matrix_iceberg(self, minio_env, external_prefix):


### PR DESCRIPTION
issue: #49828

## What changed

This PR accepts UInt8 List and FixedSizeList Arrow input for BF16 and
binary vector fields when the list length matches the raw byte width.

It keeps non-UInt8 byte-vector list input rejected, keeps width mismatch
validation, and enables the Vortex full-matrix E2E case for `bf16v`,
`binv_flat`, and `binv_ivf`.

## Why

Vortex writes BF16 and binary vector payloads as UInt8 list values because
it cannot persist them as FixedSizeBinary. Milvus previously rejected those
list encodings, so Vortex external tables could not cover BF16 and binary
vector fields.

## Validation

- `make milvus`
- `all_tests --gtest_filter='NormalizeExternalArrow.*'`
- `all_tests --gtest_filter='NormalizeVectorArraysToFixedSizeBinary.*'`
- `python3 -m py_compile tests/python_client/milvus_client/test_milvus_client_external_table.py`
- `make lint-fix`
- `git diff --check --cached`
- `pytest milvus_client/test_milvus_client_external_table.py -k test_milvus_client_external_table_full_matrix_vortex`
