### PR TITLE
test: support chaos request consistency options

### DIFF
--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -315,13 +315,59 @@ class Op(Enum):
 
 
 timeout = 120
-search_timeout = 30
-query_timeout = 30
+DEFAULT_SEARCH_TIMEOUT = 30
+DEFAULT_QUERY_TIMEOUT = 30
+search_timeout = DEFAULT_SEARCH_TIMEOUT
+query_timeout = DEFAULT_QUERY_TIMEOUT
+search_consistency_level = ""
+query_consistency_level = ""
 
 enable_traceback = False
 DEFAULT_FMT = "[start time:{start_time}][time cost:{elapsed:0.8f}s][operation_name:{operation_name}][collection name:{collection_name}] -> {result!r}"
 
 request_records = RequestRecords()
+
+
+def _parse_timeout(value, default):
+    if value is None or str(value).strip() == "":
+        return default
+    return float(value)
+
+
+def configure_request_options(
+    search_timeout_value=None,
+    query_timeout_value=None,
+    search_consistency_level_value="",
+    query_consistency_level_value="",
+):
+    global search_timeout, query_timeout, search_consistency_level, query_consistency_level
+    search_timeout = _parse_timeout(search_timeout_value, DEFAULT_SEARCH_TIMEOUT)
+    query_timeout = _parse_timeout(query_timeout_value, DEFAULT_QUERY_TIMEOUT)
+    search_consistency_level = (search_consistency_level_value or "").strip()
+    query_consistency_level = (query_consistency_level_value or "").strip()
+
+
+def search_request_options(default_consistency_level=""):
+    opts = {"timeout": search_timeout}
+    consistency_level = search_consistency_level or default_consistency_level
+    if consistency_level:
+        opts["consistency_level"] = consistency_level
+    return opts
+
+
+def query_request_options(default_consistency_level=""):
+    opts = {"timeout": query_timeout}
+    consistency_level = query_consistency_level or default_consistency_level
+    if consistency_level:
+        opts["consistency_level"] = consistency_level
+    return opts
+
+
+def query_consistency_options(default_consistency_level=""):
+    consistency_level = query_consistency_level or default_consistency_level
+    if consistency_level:
+        return {"consistency_level": consistency_level}
+    return {}
 
 
 def create_index_params_from_dict(field_name: str, index_param_dict: dict) -> IndexParams:
@@ -1393,7 +1439,7 @@ class SearchChecker(Checker):
                 search_params=self.search_param,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout,
+                **search_request_options(),
             )
             return res, True
         except Exception as e:
@@ -1452,7 +1498,7 @@ class TensorSearchChecker(Checker):
                 search_params=self.search_param,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout,
+                **search_request_options(),
             )
             return res, True
         except Exception as e:
@@ -1518,7 +1564,7 @@ class FullTextSearchChecker(Checker):
                 search_params=constants.DEFAULT_BM25_SEARCH_PARAM,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout,
+                **search_request_options(),
                 highlighter=highlighter,
             )
             return res, True
@@ -1562,7 +1608,7 @@ class MinHashSearchChecker(Checker):
                 search_params=constants.DEFAULT_MINHASH_SEARCH_PARAM,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout,
+                **search_request_options(),
             )
             return res, True
         except Exception as e:
@@ -1626,7 +1672,7 @@ class HybridSearchChecker(Checker):
                 ranker=RRFRanker(),
                 limit=10,
                 partition_names=self.p_names,
-                timeout=search_timeout,
+                **search_request_options(),
             )
             return res, True
         except Exception as e:
@@ -1768,7 +1814,10 @@ class AddFieldChecker(Checker):
             time.sleep(1)
             _, result = self.insert_data()
             _ = self.milvus_client.query(
-                collection_name=self.c_name, filter=f"{new_field_name} >= 0", output_fields=[new_field_name]
+                collection_name=self.c_name,
+                filter=f"{new_field_name} >= 0",
+                output_fields=[new_field_name],
+                **query_consistency_options(),
             )
             log.debug(f"query with field {new_field_name} success")
             return None, result
@@ -1895,6 +1944,7 @@ class InsertChecker(Checker):
             output_fields=[f"{self.int64_field_name}"],
             limit=len(data_in_client) * 2,
             timeout=timeout,
+            **query_consistency_options(),
         )
 
         data_in_server = []
@@ -1954,6 +2004,7 @@ class InsertFreshnessChecker(Checker):
                     filter=self.term_expr,
                     output_fields=[f"{self.int64_field_name}"],
                     timeout=timeout,
+                    **query_consistency_options(),
                 )
                 result = True
             except Exception as e:
@@ -2055,6 +2106,7 @@ class UpsertFreshnessChecker(Checker):
                     filter=self.term_expr,
                     output_fields=[f"{self.int64_field_name}"],
                     timeout=timeout,
+                    **query_consistency_options(),
                 )
                 result = True
             except Exception as e:
@@ -2495,7 +2547,10 @@ class QueryChecker(Checker):
     def query(self):
         try:
             res = self.milvus_client.query(
-                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+                collection_name=self.c_name,
+                filter=self.term_expr,
+                limit=5,
+                **query_request_options(),
             )
             return res, True
         except Exception as e:
@@ -2547,7 +2602,7 @@ class TextMatchChecker(Checker):
                 filter=self.term_expr,
                 limit=5,
                 output_fields=[self.text_match_field_name],
-                timeout=search_timeout,
+                **search_request_options(),
                 highlighter=highlighter,
             )
             return res, True
@@ -2592,7 +2647,10 @@ class PhraseMatchChecker(Checker):
     def phrase_match(self):
         try:
             res = self.milvus_client.query(
-                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+                collection_name=self.c_name,
+                filter=self.term_expr,
+                limit=5,
+                **query_request_options(),
             )
             return res, True
         except Exception as e:
@@ -2648,7 +2706,10 @@ class JsonQueryChecker(Checker):
     def json_query(self):
         try:
             res = self.milvus_client.query(
-                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+                collection_name=self.c_name,
+                filter=self.term_expr,
+                limit=5,
+                **query_request_options(),
             )
             return res, True
         except Exception as e:
@@ -2691,7 +2752,10 @@ class GeoQueryChecker(Checker):
     def geo_query(self):
         try:
             res = self.milvus_client.query(
-                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+                collection_name=self.c_name,
+                filter=self.term_expr,
+                limit=5,
+                **query_request_options(),
             )
             return res, True
         except Exception as e:
@@ -2727,6 +2791,7 @@ class DeleteChecker(Checker):
             filter=query_expr,
             output_fields=[self.int64_field_name],
             partition_name=self.p_name,
+            **query_consistency_options(),
         )
         self.ids = [r[self.int64_field_name] for r in res]
         self.query_expr = query_expr
@@ -2739,6 +2804,7 @@ class DeleteChecker(Checker):
             filter=self.query_expr,
             output_fields=[self.int64_field_name],
             partition_name=self.p_name,
+            **query_consistency_options(),
         )
         all_ids = [r[self.int64_field_name] for r in res]
         if len(all_ids) < 100:
@@ -2749,6 +2815,7 @@ class DeleteChecker(Checker):
                 filter=self.query_expr,
                 output_fields=[self.int64_field_name],
                 partition_name=self.p_name,
+                **query_consistency_options(),
             )
             all_ids = [r[self.int64_field_name] for r in res]
         delete_ids = all_ids[:3000]  # delete 3000 ids
@@ -2794,6 +2861,7 @@ class DeleteFreshnessChecker(Checker):
             filter=query_expr,
             output_fields=[self.int64_field_name],
             partition_name=self.p_name,
+            **query_consistency_options(),
         )
         self.ids = [r[self.int64_field_name] for r in res]
         self.query_expr = query_expr
@@ -2806,6 +2874,7 @@ class DeleteFreshnessChecker(Checker):
             filter=self.query_expr,
             output_fields=[self.int64_field_name],
             partition_name=self.p_name,
+            **query_consistency_options(),
         )
         all_ids = [r[self.int64_field_name] for r in res]
         if len(all_ids) < 100:
@@ -2816,6 +2885,7 @@ class DeleteFreshnessChecker(Checker):
                 filter=self.query_expr,
                 output_fields=[self.int64_field_name],
                 partition_name=self.p_name,
+                **query_consistency_options(),
             )
             all_ids = [r[self.int64_field_name] for r in res]
         delete_ids = all_ids[: len(all_ids) // 2]  # delete half of ids
@@ -2840,6 +2910,7 @@ class DeleteFreshnessChecker(Checker):
                     filter=self.delete_expr,
                     output_fields=[f"{self.int64_field_name}"],
                     timeout=timeout,
+                    **query_consistency_options(),
                 )
                 if len(res) == 0:
                     break
@@ -3217,6 +3288,7 @@ class SnapshotRestoreChecker(Checker):
             filter=f"{self.int64_field_name} >= 0",
             output_fields=[self.int64_field_name],
             limit=nb,
+            **query_consistency_options(),
         )
         if not res:
             return
@@ -3229,7 +3301,12 @@ class SnapshotRestoreChecker(Checker):
 
     def _do_delete(self, nb=5):
         """Delete rows from the checker's own collection, keeping at least 100 rows."""
-        count_res = self.milvus_client.query(collection_name=self.c_name, filter="", output_fields=["count(*)"])
+        count_res = self.milvus_client.query(
+            collection_name=self.c_name,
+            filter="",
+            output_fields=["count(*)"],
+            **query_consistency_options(),
+        )
         row_count = count_res[0]["count(*)"] if count_res else 0
         if row_count <= 100:
             return
@@ -3238,6 +3315,7 @@ class SnapshotRestoreChecker(Checker):
             filter=f"{self.int64_field_name} >= 0",
             output_fields=[self.int64_field_name],
             limit=nb,
+            **query_consistency_options(),
         )
         if not res:
             return
@@ -3263,7 +3341,10 @@ class SnapshotRestoreChecker(Checker):
         """Capture current collection state after flush."""
         try:
             res = self.milvus_client.query(
-                collection_name=self.c_name, filter="", output_fields=["count(*)"], consistency_level="Strong"
+                collection_name=self.c_name,
+                filter="",
+                output_fields=["count(*)"],
+                **query_consistency_options(default_consistency_level="Strong"),
             )
             self.snapshot_row_count = res[0]["count(*)"] if res else 0
 
@@ -3274,7 +3355,7 @@ class SnapshotRestoreChecker(Checker):
                     filter=f"{self.int64_field_name} >= 0",
                     output_fields=[self.int64_field_name],
                     limit=sample_size,
-                    consistency_level="Strong",
+                    **query_consistency_options(default_consistency_level="Strong"),
                 )
                 self.snapshot_sample_pks = [r[self.int64_field_name] for r in res]
             else:
@@ -3298,7 +3379,10 @@ class SnapshotRestoreChecker(Checker):
 
         try:
             res = self.milvus_client.query(
-                collection_name=restored_name, filter="", output_fields=["count(*)"], consistency_level="Strong"
+                collection_name=restored_name,
+                filter="",
+                output_fields=["count(*)"],
+                **query_consistency_options(default_consistency_level="Strong"),
             )
             actual_count = res[0]["count(*)"] if res else 0
 
@@ -3315,7 +3399,7 @@ class SnapshotRestoreChecker(Checker):
                     collection_name=restored_name,
                     filter=filter_expr,
                     output_fields=[self.int64_field_name],
-                    consistency_level="Strong",
+                    **query_consistency_options(default_consistency_level="Strong"),
                 )
                 found_pks = {r[self.int64_field_name] for r in res}
                 expected_pks = set(self.snapshot_sample_pks)
@@ -3448,7 +3532,7 @@ class NullVectorSearchChecker(Checker):
                 search_params=self.search_param,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout,
+                **search_request_options(),
             )
             return res, True
         except Exception as e:
@@ -3555,7 +3639,7 @@ class NullVectorQueryChecker(Checker):
                     filter=self.term_expr,
                     output_fields=[self.int64_field_name, field_name],
                     limit=500,
-                    timeout=query_timeout,
+                    **query_request_options(),
                 )
                 non_null_pks = [r[self.int64_field_name] for r in res if r.get(field_name) is not None]
                 samples[field_name] = non_null_pks[:sample_size]
@@ -3582,7 +3666,7 @@ class NullVectorQueryChecker(Checker):
                     filter=self.term_expr,
                     output_fields=[self.int64_field_name, vec_field],
                     limit=50,
-                    timeout=query_timeout,
+                    **query_request_options(),
                 )
                 non_null = [r for r in res if r.get(vec_field) is not None]
                 if res and not non_null:
@@ -3596,7 +3680,7 @@ class NullVectorQueryChecker(Checker):
                 collection_name=self.c_name,
                 filter=f"{self.int64_field_name} in {sample_pks}",
                 output_fields=[self.int64_field_name, vec_field],
-                timeout=query_timeout,
+                **query_request_options(),
             )
             if not res:
                 # Empty result — sampled PKs may have been deleted by concurrent DeleteChecker.
@@ -3688,7 +3772,7 @@ class AddVectorFieldChecker(Checker):
                 filter=f"{self.int64_field_name} > 0",
                 output_fields=[new_vec_field],
                 limit=10,
-                timeout=query_timeout,
+                **query_request_options(),
             )
             if len(res) == 0:
                 return "query returned 0 rows after add vector field", False
@@ -3842,8 +3926,7 @@ class EntityTTLChecker(Checker):
                     collection_name=self.c_name,
                     filter=f'bucket == "{bucket_name}"',
                     output_fields=["count(*)"],
-                    consistency_level="Strong",
-                    timeout=query_timeout,
+                    **query_request_options(default_consistency_level="Strong"),
                 )
                 actual_count = res[0].get("count(*)", -1) if res else -1
             except Exception as e:

--- a/tests/python_client/chaos/conftest.py
+++ b/tests/python_client/chaos/conftest.py
@@ -13,6 +13,18 @@ def pytest_addoption(parser):
     parser.addoption("--wait_signal", action="store", type=bool, default=True, help="wait_signal")
     parser.addoption("--enable_import", action="store", type=bool, default=False, help="enable_import")
     parser.addoption(
+        "--search_consistency_level",
+        action="store",
+        default="",
+        help="consistency level for chaos search requests",
+    )
+    parser.addoption(
+        "--query_consistency_level",
+        action="store",
+        default="",
+        help="consistency level for chaos query requests",
+    )
+    parser.addoption(
         "--target_rgs",
         action="store",
         default="",
@@ -37,8 +49,20 @@ def pytest_addoption(parser):
         help="path to external ChaosMesh YAML template (overrides built-in config)",
     )
     parser.addoption("--collection_num", action="store", default="1", help="collection_num")
-    parser.addoption("--search_timeout", action="store", type=float, default=None, help="search API timeout in seconds")
-    parser.addoption("--query_timeout", action="store", type=float, default=None, help="query API timeout in seconds")
+    parser.addoption(
+        "--search_timeout",
+        action="store",
+        type=float,
+        default=None,
+        help="search API timeout in seconds for chaos client requests",
+    )
+    parser.addoption(
+        "--query_timeout",
+        action="store",
+        type=float,
+        default=None,
+        help="query API timeout in seconds for chaos client requests",
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -47,11 +71,14 @@ def configure_client_timeouts(request):
 
     search_timeout = request.config.getoption("--search_timeout")
     query_timeout = request.config.getoption("--query_timeout")
-
-    if search_timeout is not None:
-        checker.search_timeout = search_timeout
-    if query_timeout is not None:
-        checker.query_timeout = query_timeout
+    search_consistency_level = request.config.getoption("--search_consistency_level")
+    query_consistency_level = request.config.getoption("--query_consistency_level")
+    checker.configure_request_options(
+        search_timeout_value=search_timeout,
+        query_timeout_value=query_timeout,
+        search_consistency_level_value=search_consistency_level,
+        query_consistency_level_value=query_consistency_level,
+    )
 
 
 @pytest.fixture
@@ -107,6 +134,26 @@ def wait_signal(request):
 @pytest.fixture
 def enable_import(request):
     return request.config.getoption("--enable_import")
+
+
+@pytest.fixture
+def search_timeout(request):
+    return request.config.getoption("--search_timeout")
+
+
+@pytest.fixture
+def query_timeout(request):
+    return request.config.getoption("--query_timeout")
+
+
+@pytest.fixture
+def search_consistency_level(request):
+    return request.config.getoption("--search_consistency_level")
+
+
+@pytest.fixture
+def query_consistency_level(request):
+    return request.config.getoption("--query_consistency_level")
 
 
 @pytest.fixture

--- a/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
+++ b/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
@@ -23,7 +23,7 @@ def _request_options(timeout_value, consistency_level, default_consistency_level
 
 
 class TestAllCollection:
-    """ Test case of end to end"""
+    """Test case of end to end"""
 
     @pytest.fixture(scope="function", params=get_collections(file_name="chaos_test_all_collections.json"))
     def collection_name(self, request):
@@ -73,7 +73,7 @@ class TestAllCollection:
         collection_info = milvus_client.describe_collection(collection_name=name)
         schema = CollectionSchema.construct_from_dict(collection_info)
         tt = time.time() - t0
-        assert collection_info['collection_name'] == name
+        assert collection_info["collection_name"] == name
 
         # get collection info
         dim = cf.get_dim_by_schema(schema=schema)
@@ -106,7 +106,7 @@ class TestAllCollection:
         res = milvus_client.insert(collection_name=name, data=data)
         tt = time.time() - t0
         log.info(f"assert insert: {tt}")
-        assert res.get('insert_count', 0) > 0
+        assert res.get("insert_count", 0) > 0
 
         # flush
         t0 = time.time()
@@ -122,8 +122,8 @@ class TestAllCollection:
         for idx_name in index_names:
             try:
                 idx_info = milvus_client.describe_index(collection_name=name, index_name=idx_name)
-                if 'field_name' in idx_info:
-                    fields_created_index.append(idx_info['field_name'])
+                if "field_name" in idx_info:
+                    fields_created_index.append(idx_info["field_name"])
             except Exception as e:
                 log.debug(f"Failed to describe index {idx_name}: {e}")
 
@@ -133,15 +133,9 @@ class TestAllCollection:
             if f not in fields_created_index:
                 t0 = time.time()
                 index_params.add_index(
-                    field_name=f,
-                    index_type="HNSW",
-                    metric_type="L2",
-                    params={"M": 48, "efConstruction": 500}
+                    field_name=f, index_type="HNSW", metric_type="L2", params={"M": 48, "efConstruction": 500}
                 )
-                milvus_client.create_index(
-                    collection_name=name,
-                    index_params=index_params
-                )
+                milvus_client.create_index(collection_name=name, index_params=index_params)
                 tt = time.time() - t0
                 log.info(f"create index for field {f} cost: {tt} seconds")
                 index_params = milvus_client.prepare_index_params()  # reset for next field
@@ -187,7 +181,7 @@ class TestAllCollection:
             assert len(res_2) == 1
 
         # query
-        term_expr = f'{int64_field_name} in {[i for i in range(offset, 0)]}'
+        term_expr = f"{int64_field_name} in {[i for i in range(offset, 0)]}"
         t0 = time.time()
         res = milvus_client.query(
             collection_name=name,
@@ -261,7 +255,7 @@ class TestAllCollection:
             assert len(res_2) == 1
 
         # query
-        term_expr = f'{int64_field_name} > -3000'
+        term_expr = f"{int64_field_name} > -3000"
         t0 = time.time()
         res = milvus_client.query(
             collection_name=name,

--- a/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
+++ b/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
@@ -1,12 +1,13 @@
 import time
+
 import pytest
-from faker import Faker
-from pymilvus import MilvusClient, CollectionSchema
 from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel
-from utils.util_log import test_log as log
+from faker import Faker
+from pymilvus import CollectionSchema, MilvusClient
 from utils.util_common import get_collections
+from utils.util_log import test_log as log
 
 fake = Faker()
 
@@ -49,8 +50,7 @@ class TestAllCollection:
 
     def teardown_method(self, method):
         log.info(("*" * 35) + " teardown " + ("*" * 35))
-        log.info("[teardown_method] Start teardown test case %s..." %
-                 method.__name__)
+        log.info(f"[teardown_method] Start teardown test case {method.__name__}...")
         log.info("skip drop collection")
 
     @pytest.mark.tags(CaseLabel.L1)

--- a/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
+++ b/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
@@ -11,6 +11,16 @@ from utils.util_common import get_collections
 fake = Faker()
 
 
+def _request_options(timeout_value, consistency_level, default_consistency_level="Strong"):
+    opts = {}
+    if timeout_value:
+        opts["timeout"] = float(timeout_value)
+    level = consistency_level or default_consistency_level
+    if level:
+        opts["consistency_level"] = level
+    return opts
+
+
 class TestAllCollection:
     """ Test case of end to end"""
 
@@ -44,9 +54,19 @@ class TestAllCollection:
         log.info("skip drop collection")
 
     @pytest.mark.tags(CaseLabel.L1)
-    def test_milvus_default(self, collection_name, milvus_client):
+    def test_milvus_default(
+        self,
+        collection_name,
+        milvus_client,
+        search_timeout,
+        query_timeout,
+        search_consistency_level,
+        query_consistency_level,
+    ):
         # create
         name = collection_name if collection_name else cf.gen_unique_str("Checker_")
+        search_options = _request_options(search_timeout, search_consistency_level)
+        query_options = _request_options(query_timeout, query_consistency_level)
         t0 = time.time()
 
         # Get schema from existing collection
@@ -143,7 +163,7 @@ class TestAllCollection:
             anns_field=float_vector_field_name,
             search_params=dense_search_params,
             limit=1,
-            consistency_level="Strong"
+            **search_options,
         )
         tt = time.time() - t0
         log.info(f"assert search: {tt}")
@@ -160,7 +180,7 @@ class TestAllCollection:
                 anns_field=bm25_vec_field_name_list[0],
                 search_params=bm25_search_params,
                 limit=1,
-                consistency_level="Strong"
+                **search_options,
             )
             tt = time.time() - t0
             log.info(f"assert full text search: {tt}")
@@ -173,7 +193,7 @@ class TestAllCollection:
             collection_name=name,
             filter=term_expr,
             limit=5,
-            consistency_level="Strong"
+            **query_options,
         )
         tt = time.time() - t0
         log.info(f"assert query result {len(res)}: {tt}")
@@ -188,7 +208,7 @@ class TestAllCollection:
                 collection_name=name,
                 filter=expr,
                 limit=5,
-                consistency_level="Strong"
+                **query_options,
             )
             tt = time.time() - t0
             log.info(f"assert text match: {tt}")
@@ -216,7 +236,7 @@ class TestAllCollection:
             anns_field=float_vector_field_name,
             search_params=dense_search_params,
             limit=topk,
-            consistency_level="Strong"
+            **search_options,
         )
         tt = time.time() - t0
         log.info(f"assert search: {tt}")
@@ -234,7 +254,7 @@ class TestAllCollection:
                 anns_field=bm25_vec_field_name_list[0],
                 search_params=bm25_search_params,
                 limit=1,
-                consistency_level="Strong"
+                **search_options,
             )
             tt = time.time() - t0
             log.info(f"assert full text search: {tt}")
@@ -247,7 +267,7 @@ class TestAllCollection:
             collection_name=name,
             filter=term_expr,
             limit=5,
-            consistency_level="Strong"
+            **query_options,
         )
         tt = time.time() - t0
         log.info(f"assert query result {len(res)}: {tt}")
@@ -262,7 +282,7 @@ class TestAllCollection:
                 collection_name=name,
                 filter=expr,
                 limit=5,
-                consistency_level="Strong"
+                **query_options,
             )
             tt = time.time() - t0
             log.info(f"assert text match: {tt}")

--- a/tests/python_client/chaos/testcases/test_concurrent_operation.py
+++ b/tests/python_client/chaos/testcases/test_concurrent_operation.py
@@ -61,14 +61,13 @@ class TestBase:
     expect_compact = constants.SUCC
     expect_search = constants.SUCC
     expect_query = constants.SUCC
-    host = '127.0.0.1'
+    host = "127.0.0.1"
     port = 19530
     _chaos_config = None
     health_checkers = {}
 
 
 class TestOperations(TestBase):
-
     @pytest.fixture(scope="function", autouse=True)
     def connection(self, host, port, user, password, uri, token, milvus_ns):
         # Prioritize uri and token for connection
@@ -83,9 +82,9 @@ class TestOperations(TestBase):
             actual_token = f"{user}:{password}" if user and password else None
 
         if actual_token:
-            connections.connect('default', uri=actual_uri, token=actual_token)
+            connections.connect("default", uri=actual_uri, token=actual_token)
         else:
-            connections.connect('default', uri=actual_uri)
+            connections.connect("default", uri=actual_uri)
 
         if connections.has_connection("default") is False:
             raise Exception("no connections")
@@ -96,7 +95,7 @@ class TestOperations(TestBase):
         self.password = password
         self.uri = actual_uri
         self.token = actual_token
-        self.milvus_sys = MilvusSys(alias='default')
+        self.milvus_sys = MilvusSys(alias="default")
         self.milvus_ns = milvus_ns
         self.release_name = get_milvus_instance_name(self.milvus_ns, milvus_sys=self.milvus_sys)
 
@@ -147,7 +146,7 @@ class TestOperations(TestBase):
     ):
         # start the monitor threads to check the milvus ops
         log.info("*********************Test Start**********************")
-        log.info(connections.get_connection_addr('default'))
+        log.info(connections.get_connection_addr("default"))
         checker.configure_request_options(
             search_timeout_value=search_timeout,
             query_timeout_value=query_timeout,
@@ -166,7 +165,7 @@ class TestOperations(TestBase):
             request_duration = request_duration[:-1]
         request_duration = eval(request_duration)
         for i in range(10):
-            sleep(request_duration//10)
+            sleep(request_duration // 10)
             for k, v in self.health_checkers.items():
                 v.check_result()
                 # log.info(v.check_result())

--- a/tests/python_client/chaos/testcases/test_concurrent_operation.py
+++ b/tests/python_client/chaos/testcases/test_concurrent_operation.py
@@ -28,6 +28,7 @@ from chaos.checker import (InsertChecker,
 from utils.util_k8s import wait_pods_ready, get_milvus_instance_name
 from utils.util_log import test_log as log
 from chaos import chaos_commons as cc
+from chaos import checker
 from common import common_func as cf
 from common.milvus_sys import MilvusSys
 from chaos.chaos_commons import assert_statistic
@@ -133,10 +134,25 @@ class TestOperations(TestBase):
             yield request.param
 
     @pytest.mark.tags(CaseLabel.L3)
-    def test_operations(self, request_duration, is_check, collection_name):
+    def test_operations(
+        self,
+        request_duration,
+        is_check,
+        collection_name,
+        search_timeout,
+        query_timeout,
+        search_consistency_level,
+        query_consistency_level,
+    ):
         # start the monitor threads to check the milvus ops
         log.info("*********************Test Start**********************")
         log.info(connections.get_connection_addr('default'))
+        checker.configure_request_options(
+            search_timeout_value=search_timeout,
+            query_timeout_value=query_timeout,
+            search_consistency_level_value=search_consistency_level,
+            query_consistency_level_value=query_consistency_level,
+        )
         # event_records = EventRecords()
         c_name = collection_name if collection_name else cf.gen_unique_str("Checker_")
         # event_records.insert("init_health_checkers", "start")

--- a/tests/python_client/chaos/testcases/test_concurrent_operation.py
+++ b/tests/python_client/chaos/testcases/test_concurrent_operation.py
@@ -1,45 +1,46 @@
-import time
-import pytest
 import json
+import time
 from time import sleep
-from pymilvus import connections
-from chaos.checker import (InsertChecker,
-                           UpsertChecker,
-                           FlushChecker,
-                           SearchChecker,
-                           FullTextSearchChecker,
-                           MinHashSearchChecker,
-                           HybridSearchChecker,
-                           QueryChecker,
-                           TextMatchChecker,
-                           PhraseMatchChecker,
-                           JsonQueryChecker,
-                           GeoQueryChecker,
-                           DeleteChecker,
-                           AddFieldChecker,
-                           SnapshotChecker,
-                           SnapshotRestoreChecker,
-                           NullVectorSearchChecker,
-                           NullVectorQueryChecker,
-                           AddVectorFieldChecker,
-                           Op,
-                           ResultAnalyzer
-                           )
-from utils.util_k8s import wait_pods_ready, get_milvus_instance_name
-from utils.util_log import test_log as log
+
+import pytest
 from chaos import chaos_commons as cc
-from chaos import checker
-from common import common_func as cf
-from common.milvus_sys import MilvusSys
+from chaos import checker, constants
 from chaos.chaos_commons import assert_statistic
+from chaos.checker import (
+    AddFieldChecker,
+    AddVectorFieldChecker,
+    DeleteChecker,
+    FlushChecker,
+    FullTextSearchChecker,
+    GeoQueryChecker,
+    HybridSearchChecker,
+    InsertChecker,
+    JsonQueryChecker,
+    MinHashSearchChecker,
+    NullVectorQueryChecker,
+    NullVectorSearchChecker,
+    Op,
+    PhraseMatchChecker,
+    QueryChecker,
+    ResultAnalyzer,
+    SearchChecker,
+    SnapshotChecker,
+    SnapshotRestoreChecker,
+    TextMatchChecker,
+    UpsertChecker,
+)
+from common import common_func as cf
 from common.common_type import CaseLabel
-from chaos import constants
+from common.milvus_sys import MilvusSys
 from delayed_assert import assert_expectations
+from pymilvus import connections
+from utils.util_k8s import get_milvus_instance_name, wait_pods_ready
+from utils.util_log import test_log as log
 
 
 def get_all_collections():
     try:
-        with open("/tmp/ci_logs/chaos_test_all_collections.json", "r") as f:
+        with open("/tmp/ci_logs/chaos_test_all_collections.json") as f:
             data = json.load(f)
             all_collections = data["all"]
             log.info(f"all_collections: {all_collections}")

--- a/tests/python_client/chaos/testcases/test_single_request_operation.py
+++ b/tests/python_client/chaos/testcases/test_single_request_operation.py
@@ -50,14 +50,13 @@ class TestBase:
     expect_index = constants.SUCC
     expect_search = constants.SUCC
     expect_query = constants.SUCC
-    host = '127.0.0.1'
+    host = "127.0.0.1"
     port = 19530
     _chaos_config = None
     health_checkers = {}
 
 
 class TestOperations(TestBase):
-
     @pytest.fixture(scope="function", autouse=True)
     def connection(self, host, port, user, password, uri, token, milvus_ns, minio_host, enable_import, minio_bucket):
         # Prioritize uri and token for connection
@@ -72,9 +71,9 @@ class TestOperations(TestBase):
             actual_token = f"{user}:{password}" if user and password else None
 
         if actual_token:
-            connections.connect('default', uri=actual_uri, token=actual_token)
+            connections.connect("default", uri=actual_uri, token=actual_token)
         else:
-            connections.connect('default', uri=actual_uri)
+            connections.connect("default", uri=actual_uri)
 
         if connections.has_connection("default") is False:
             raise Exception("no connections")
@@ -89,7 +88,7 @@ class TestOperations(TestBase):
         self.password = password
         self.uri = actual_uri
         self.token = actual_token
-        self.milvus_sys = MilvusSys(alias='default')
+        self.milvus_sys = MilvusSys(alias="default")
         self.milvus_ns = milvus_ns
         self.release_name = get_milvus_instance_name(self.milvus_ns, milvus_sys=self.milvus_sys)
         self.enable_import = enable_import
@@ -101,7 +100,7 @@ class TestOperations(TestBase):
         checkers = {
             Op.create: CollectionCreateChecker(collection_name=c_name),
             Op.insert: InsertChecker(collection_name=c_name),
-            Op.tensor_search :TensorSearchChecker(collection_name=c_name),
+            Op.tensor_search: TensorSearchChecker(collection_name=c_name),
             Op.upsert: UpsertChecker(collection_name=c_name),
             Op.partial_update: PartialUpdateChecker(collection_name=c_name),
             Op.flush: FlushChecker(collection_name=c_name),
@@ -124,9 +123,9 @@ class TestOperations(TestBase):
             Op.entity_ttl: EntityTTLChecker(),
         }
         if bool(self.enable_import):
-            checkers[Op.bulk_insert] = BulkInsertChecker(collection_name=c_name,
-                                                         bucket_name=self.bucket_name,
-                                                         minio_endpoint=self.minio_endpoint)
+            checkers[Op.bulk_insert] = BulkInsertChecker(
+                collection_name=c_name, bucket_name=self.bucket_name, minio_endpoint=self.minio_endpoint
+            )
         self.health_checkers = checkers
 
     @pytest.mark.tags(CaseLabel.L3)
@@ -141,7 +140,7 @@ class TestOperations(TestBase):
     ):
         # start the monitor threads to check the milvus ops
         log.info("*********************Test Start**********************")
-        log.info(connections.get_connection_addr('default'))
+        log.info(connections.get_connection_addr("default"))
         checker.configure_request_options(
             search_timeout_value=search_timeout,
             query_timeout_value=query_timeout,

--- a/tests/python_client/chaos/testcases/test_single_request_operation.py
+++ b/tests/python_client/chaos/testcases/test_single_request_operation.py
@@ -1,46 +1,46 @@
 import time
-
-import pytest
 from time import sleep
+
 import pymilvus
-from pymilvus import connections, utility
-from chaos.checker import (CollectionCreateChecker,
-                           InsertChecker,
-                           BulkInsertChecker,
-                           UpsertChecker,
-                           PartialUpdateChecker,
-                           FlushChecker,
-                           SearchChecker,
-                           FullTextSearchChecker,
-                           MinHashSearchChecker,
-                           HybridSearchChecker,
-                           QueryChecker,
-                           TextMatchChecker,
-                           PhraseMatchChecker,
-                           JsonQueryChecker,
-                           GeoQueryChecker,
-                           IndexCreateChecker,
-                           DeleteChecker,
-                           CollectionDropChecker,
-                           AlterCollectionChecker,
-                           AddFieldChecker,
-                           CollectionRenameChecker,
-                           TensorSearchChecker,
-                           SnapshotRestoreChecker,
-                           EntityTTLChecker,
-                           Op,
-                           EventRecords,
-                           ResultAnalyzer
-                           )
-from utils.util_log import test_log as log
-from utils.util_k8s import wait_pods_ready, get_milvus_instance_name
+import pytest
 from chaos import chaos_commons as cc
-from chaos import checker
+from chaos import checker, constants
+from chaos.chaos_commons import assert_statistic
+from chaos.checker import (
+    AddFieldChecker,
+    AlterCollectionChecker,
+    BulkInsertChecker,
+    CollectionCreateChecker,
+    CollectionDropChecker,
+    CollectionRenameChecker,
+    DeleteChecker,
+    EntityTTLChecker,
+    EventRecords,
+    FlushChecker,
+    FullTextSearchChecker,
+    GeoQueryChecker,
+    HybridSearchChecker,
+    IndexCreateChecker,
+    InsertChecker,
+    JsonQueryChecker,
+    MinHashSearchChecker,
+    Op,
+    PartialUpdateChecker,
+    PhraseMatchChecker,
+    QueryChecker,
+    ResultAnalyzer,
+    SearchChecker,
+    SnapshotRestoreChecker,
+    TensorSearchChecker,
+    TextMatchChecker,
+    UpsertChecker,
+)
 from common.common_type import CaseLabel
 from common.milvus_sys import MilvusSys
-from chaos.chaos_commons import assert_statistic
-from chaos import constants
 from delayed_assert import assert_expectations
+from pymilvus import connections, utility
+from utils.util_k8s import get_milvus_instance_name, wait_pods_ready
+from utils.util_log import test_log as log
 
 
 class TestBase:
@@ -103,7 +103,7 @@ class TestOperations(TestBase):
             Op.insert: InsertChecker(collection_name=c_name),
             Op.tensor_search :TensorSearchChecker(collection_name=c_name),
             Op.upsert: UpsertChecker(collection_name=c_name),
-            Op.partial_update: PartialUpdateChecker(collection_name=c_name), 
+            Op.partial_update: PartialUpdateChecker(collection_name=c_name),
             Op.flush: FlushChecker(collection_name=c_name),
             Op.index: IndexCreateChecker(collection_name=c_name),
             Op.search: SearchChecker(collection_name=c_name),

--- a/tests/python_client/chaos/testcases/test_single_request_operation.py
+++ b/tests/python_client/chaos/testcases/test_single_request_operation.py
@@ -35,6 +35,7 @@ from chaos.checker import (CollectionCreateChecker,
 from utils.util_log import test_log as log
 from utils.util_k8s import wait_pods_ready, get_milvus_instance_name
 from chaos import chaos_commons as cc
+from chaos import checker
 from common.common_type import CaseLabel
 from common.milvus_sys import MilvusSys
 from chaos.chaos_commons import assert_statistic
@@ -129,10 +130,24 @@ class TestOperations(TestBase):
         self.health_checkers = checkers
 
     @pytest.mark.tags(CaseLabel.L3)
-    def test_operations(self, request_duration, is_check):
+    def test_operations(
+        self,
+        request_duration,
+        is_check,
+        search_timeout,
+        query_timeout,
+        search_consistency_level,
+        query_consistency_level,
+    ):
         # start the monitor threads to check the milvus ops
         log.info("*********************Test Start**********************")
         log.info(connections.get_connection_addr('default'))
+        checker.configure_request_options(
+            search_timeout_value=search_timeout,
+            query_timeout_value=query_timeout,
+            search_consistency_level_value=search_consistency_level,
+            query_consistency_level_value=query_consistency_level,
+        )
         event_records = EventRecords()
         c_name = None
         event_records.insert("init_health_checkers", "start")


### PR DESCRIPTION
issue: #48185

- chaos checker: centralize search/query timeout and consistency request options for chaos clients
- chaos tests: expose pytest options for search/query timeout and consistency level across single, concurrent, and all-collection checks