### PR TITLE
test: [cp 2.6] support chaos request consistency options

### DIFF
--- a/tests/python_client/chaos/checker.py
+++ b/tests/python_client/chaos/checker.py
@@ -315,13 +315,59 @@ class Op(Enum):
 
 
 timeout = 120
-search_timeout = 30
-query_timeout = 30
+DEFAULT_SEARCH_TIMEOUT = 30
+DEFAULT_QUERY_TIMEOUT = 30
+search_timeout = DEFAULT_SEARCH_TIMEOUT
+query_timeout = DEFAULT_QUERY_TIMEOUT
+search_consistency_level = ""
+query_consistency_level = ""
 
 enable_traceback = False
 DEFAULT_FMT = "[start time:{start_time}][time cost:{elapsed:0.8f}s][operation_name:{operation_name}][collection name:{collection_name}] -> {result!r}"
 
 request_records = RequestRecords()
+
+
+def _parse_timeout(value, default):
+    if value is None or str(value).strip() == "":
+        return default
+    return float(value)
+
+
+def configure_request_options(
+    search_timeout_value=None,
+    query_timeout_value=None,
+    search_consistency_level_value="",
+    query_consistency_level_value="",
+):
+    global search_timeout, query_timeout, search_consistency_level, query_consistency_level
+    search_timeout = _parse_timeout(search_timeout_value, DEFAULT_SEARCH_TIMEOUT)
+    query_timeout = _parse_timeout(query_timeout_value, DEFAULT_QUERY_TIMEOUT)
+    search_consistency_level = (search_consistency_level_value or "").strip()
+    query_consistency_level = (query_consistency_level_value or "").strip()
+
+
+def search_request_options(default_consistency_level=""):
+    opts = {"timeout": search_timeout}
+    consistency_level = search_consistency_level or default_consistency_level
+    if consistency_level:
+        opts["consistency_level"] = consistency_level
+    return opts
+
+
+def query_request_options(default_consistency_level=""):
+    opts = {"timeout": query_timeout}
+    consistency_level = query_consistency_level or default_consistency_level
+    if consistency_level:
+        opts["consistency_level"] = consistency_level
+    return opts
+
+
+def query_consistency_options(default_consistency_level=""):
+    consistency_level = query_consistency_level or default_consistency_level
+    if consistency_level:
+        return {"consistency_level": consistency_level}
+    return {}
 
 
 def create_index_params_from_dict(field_name: str, index_param_dict: dict) -> IndexParams:
@@ -1031,7 +1077,7 @@ class SearchChecker(Checker):
                 search_params=self.search_param,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout,
+                **search_request_options(),
             )
             return res, True
         except Exception as e:
@@ -1090,7 +1136,7 @@ class TensorSearchChecker(Checker):
                 search_params=self.search_param,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout,
+                **search_request_options(),
             )
             return res, True
         except Exception as e:
@@ -1156,7 +1202,7 @@ class FullTextSearchChecker(Checker):
                 search_params=constants.DEFAULT_BM25_SEARCH_PARAM,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout,
+                **search_request_options(),
                 highlighter=highlighter,
             )
             return res, True
@@ -1221,7 +1267,7 @@ class HybridSearchChecker(Checker):
                 ranker=RRFRanker(),
                 limit=10,
                 partition_names=self.p_names,
-                timeout=search_timeout,
+                **search_request_options(),
             )
             return res, True
         except Exception as e:
@@ -1364,7 +1410,10 @@ class AddFieldChecker(Checker):
             time.sleep(1)
             _, result = self.insert_data()
             self.milvus_client.query(
-                collection_name=self.c_name, filter=f"{new_field_name} >= 0", output_fields=[new_field_name]
+                collection_name=self.c_name,
+                filter=f"{new_field_name} >= 0",
+                output_fields=[new_field_name],
+                **query_consistency_options(),
             )
             result = True
             if result:
@@ -1493,6 +1542,7 @@ class InsertChecker(Checker):
             output_fields=[f"{self.int64_field_name}"],
             limit=len(data_in_client) * 2,
             timeout=timeout,
+            **query_consistency_options(),
         )
         data_in_server = []
         for r in res:
@@ -1551,6 +1601,7 @@ class InsertFreshnessChecker(Checker):
                     filter=self.term_expr,
                     output_fields=[f"{self.int64_field_name}"],
                     timeout=timeout,
+                    **query_consistency_options(),
                 )
                 result = True
             except Exception as e:
@@ -1652,6 +1703,7 @@ class UpsertFreshnessChecker(Checker):
                     filter=self.term_expr,
                     output_fields=[f"{self.int64_field_name}"],
                     timeout=timeout,
+                    **query_consistency_options(),
                 )
                 result = True
             except Exception as e:
@@ -2092,7 +2144,10 @@ class QueryChecker(Checker):
     def query(self):
         try:
             res = self.milvus_client.query(
-                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+                collection_name=self.c_name,
+                filter=self.term_expr,
+                limit=5,
+                **query_request_options(),
             )
             return res, True
         except Exception as e:
@@ -2144,7 +2199,7 @@ class TextMatchChecker(Checker):
                 filter=self.term_expr,
                 limit=5,
                 output_fields=[self.text_match_field_name],
-                timeout=search_timeout,
+                **search_request_options(),
                 highlighter=highlighter,
             )
             return res, True
@@ -2189,7 +2244,10 @@ class PhraseMatchChecker(Checker):
     def phrase_match(self):
         try:
             res = self.milvus_client.query(
-                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+                collection_name=self.c_name,
+                filter=self.term_expr,
+                limit=5,
+                **query_request_options(),
             )
             return res, True
         except Exception as e:
@@ -2245,7 +2303,10 @@ class JsonQueryChecker(Checker):
     def json_query(self):
         try:
             res = self.milvus_client.query(
-                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+                collection_name=self.c_name,
+                filter=self.term_expr,
+                limit=5,
+                **query_request_options(),
             )
             return res, True
         except Exception as e:
@@ -2288,7 +2349,10 @@ class GeoQueryChecker(Checker):
     def geo_query(self):
         try:
             res = self.milvus_client.query(
-                collection_name=self.c_name, filter=self.term_expr, limit=5, timeout=query_timeout
+                collection_name=self.c_name,
+                filter=self.term_expr,
+                limit=5,
+                **query_request_options(),
             )
             return res, True
         except Exception as e:
@@ -2324,6 +2388,7 @@ class DeleteChecker(Checker):
             filter=query_expr,
             output_fields=[self.int64_field_name],
             partition_name=self.p_name,
+            **query_consistency_options(),
         )
         self.ids = [r[self.int64_field_name] for r in res]
         self.query_expr = query_expr
@@ -2336,6 +2401,7 @@ class DeleteChecker(Checker):
             filter=self.query_expr,
             output_fields=[self.int64_field_name],
             partition_name=self.p_name,
+            **query_consistency_options(),
         )
         all_ids = [r[self.int64_field_name] for r in res]
         if len(all_ids) < 100:
@@ -2346,6 +2412,7 @@ class DeleteChecker(Checker):
                 filter=self.query_expr,
                 output_fields=[self.int64_field_name],
                 partition_name=self.p_name,
+                **query_consistency_options(),
             )
             all_ids = [r[self.int64_field_name] for r in res]
         delete_ids = all_ids[:3000]  # delete 3000 ids
@@ -2391,6 +2458,7 @@ class DeleteFreshnessChecker(Checker):
             filter=query_expr,
             output_fields=[self.int64_field_name],
             partition_name=self.p_name,
+            **query_consistency_options(),
         )
         self.ids = [r[self.int64_field_name] for r in res]
         self.query_expr = query_expr
@@ -2403,6 +2471,7 @@ class DeleteFreshnessChecker(Checker):
             filter=self.query_expr,
             output_fields=[self.int64_field_name],
             partition_name=self.p_name,
+            **query_consistency_options(),
         )
         all_ids = [r[self.int64_field_name] for r in res]
         if len(all_ids) < 100:
@@ -2413,6 +2482,7 @@ class DeleteFreshnessChecker(Checker):
                 filter=self.query_expr,
                 output_fields=[self.int64_field_name],
                 partition_name=self.p_name,
+                **query_consistency_options(),
             )
             all_ids = [r[self.int64_field_name] for r in res]
         delete_ids = all_ids[: len(all_ids) // 2]  # delete half of ids
@@ -2437,6 +2507,7 @@ class DeleteFreshnessChecker(Checker):
                     filter=self.delete_expr,
                     output_fields=[f"{self.int64_field_name}"],
                     timeout=timeout,
+                    **query_consistency_options(),
                 )
                 if len(res) == 0:
                     break
@@ -2729,7 +2800,7 @@ class NullVectorSearchChecker(Checker):
                 search_params=self.search_param,
                 limit=5,
                 partition_names=self.p_names,
-                timeout=search_timeout,
+                **search_request_options(),
             )
             return res, True
         except Exception as e:
@@ -2825,7 +2896,7 @@ class NullVectorQueryChecker(Checker):
                     filter=self.term_expr,
                     output_fields=[self.int64_field_name, field_name],
                     limit=500,
-                    timeout=query_timeout,
+                    **query_request_options(),
                 )
                 non_null_pks = [r[self.int64_field_name] for r in res if r.get(field_name) is not None]
                 samples[field_name] = non_null_pks[:sample_size]
@@ -2849,7 +2920,7 @@ class NullVectorQueryChecker(Checker):
                     collection_name=self.c_name,
                     filter=f"{self.int64_field_name} in {sample_pks}",
                     output_fields=[self.int64_field_name, vec_field],
-                    timeout=query_timeout,
+                    **query_request_options(),
                 )
                 if not res:
                     # Empty result: sampled PKs may have been deleted by concurrent DeleteChecker.
@@ -2878,7 +2949,7 @@ class NullVectorQueryChecker(Checker):
                 filter=self.term_expr,
                 output_fields=[self.int64_field_name, vec_field],
                 limit=50,
-                timeout=query_timeout,
+                **query_request_options(),
             )
             non_null_rows = [r for r in res if r.get(vec_field) is not None]
             log.debug(
@@ -2953,7 +3024,7 @@ class AddVectorFieldChecker(Checker):
                 filter=f"{self.int64_field_name} > 0",
                 output_fields=[new_vec_field],
                 limit=10,
-                timeout=query_timeout,
+                **query_request_options(),
             )
             if len(res) == 0:
                 return "query returned 0 rows after add vector field", False

--- a/tests/python_client/chaos/conftest.py
+++ b/tests/python_client/chaos/conftest.py
@@ -12,13 +12,37 @@ def pytest_addoption(parser):
     parser.addoption("--chaos_interval", action="store", default="2m", help="chaos_interval")
     parser.addoption("--wait_signal", action="store", type=bool, default=True, help="wait_signal")
     parser.addoption("--enable_import", action="store", type=bool, default=False, help="enable_import")
+    parser.addoption(
+        "--search_consistency_level",
+        action="store",
+        default="",
+        help="consistency level for chaos search requests",
+    )
+    parser.addoption(
+        "--query_consistency_level",
+        action="store",
+        default="",
+        help="consistency level for chaos query requests",
+    )
     parser.addoption("--target_rgs", action="store", default="", help="comma-separated resource group names to target for chaos (e.g. rg1,rg2)")
     parser.addoption("--chaos_mode", action="store", default="one", help="chaos mode: 'one' (random single pod) or 'all' (all matching pods)")
     parser.addoption("--target_components", action="store", default="querynode,streamingnode", help="comma-separated components to inject chaos (e.g. querynode,streamingnode)")
     parser.addoption("--chaos_template", action="store", default="", help="path to external ChaosMesh YAML template (overrides built-in config)")
     parser.addoption("--collection_num", action="store", default="1", help="collection_num")
-    parser.addoption("--search_timeout", action="store", type=float, default=None, help="search API timeout in seconds")
-    parser.addoption("--query_timeout", action="store", type=float, default=None, help="query API timeout in seconds")
+    parser.addoption(
+        "--search_timeout",
+        action="store",
+        type=float,
+        default=None,
+        help="search API timeout in seconds for chaos client requests",
+    )
+    parser.addoption(
+        "--query_timeout",
+        action="store",
+        type=float,
+        default=None,
+        help="query API timeout in seconds for chaos client requests",
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -27,11 +51,14 @@ def configure_client_timeouts(request):
 
     search_timeout = request.config.getoption("--search_timeout")
     query_timeout = request.config.getoption("--query_timeout")
-
-    if search_timeout is not None:
-        checker.search_timeout = search_timeout
-    if query_timeout is not None:
-        checker.query_timeout = query_timeout
+    search_consistency_level = request.config.getoption("--search_consistency_level")
+    query_consistency_level = request.config.getoption("--query_consistency_level")
+    checker.configure_request_options(
+        search_timeout_value=search_timeout,
+        query_timeout_value=query_timeout,
+        search_consistency_level_value=search_consistency_level,
+        query_consistency_level_value=query_consistency_level,
+    )
 
 
 @pytest.fixture
@@ -87,6 +114,26 @@ def wait_signal(request):
 @pytest.fixture
 def enable_import(request):
     return request.config.getoption("--enable_import")
+
+
+@pytest.fixture
+def search_timeout(request):
+    return request.config.getoption("--search_timeout")
+
+
+@pytest.fixture
+def query_timeout(request):
+    return request.config.getoption("--query_timeout")
+
+
+@pytest.fixture
+def search_consistency_level(request):
+    return request.config.getoption("--search_consistency_level")
+
+
+@pytest.fixture
+def query_consistency_level(request):
+    return request.config.getoption("--query_consistency_level")
 
 
 @pytest.fixture

--- a/tests/python_client/chaos/conftest.py
+++ b/tests/python_client/chaos/conftest.py
@@ -24,10 +24,30 @@ def pytest_addoption(parser):
         default="",
         help="consistency level for chaos query requests",
     )
-    parser.addoption("--target_rgs", action="store", default="", help="comma-separated resource group names to target for chaos (e.g. rg1,rg2)")
-    parser.addoption("--chaos_mode", action="store", default="one", help="chaos mode: 'one' (random single pod) or 'all' (all matching pods)")
-    parser.addoption("--target_components", action="store", default="querynode,streamingnode", help="comma-separated components to inject chaos (e.g. querynode,streamingnode)")
-    parser.addoption("--chaos_template", action="store", default="", help="path to external ChaosMesh YAML template (overrides built-in config)")
+    parser.addoption(
+        "--target_rgs",
+        action="store",
+        default="",
+        help="comma-separated resource group names to target for chaos (e.g. rg1,rg2)",
+    )
+    parser.addoption(
+        "--chaos_mode",
+        action="store",
+        default="one",
+        help="chaos mode: 'one' (random single pod) or 'all' (all matching pods)",
+    )
+    parser.addoption(
+        "--target_components",
+        action="store",
+        default="querynode,streamingnode",
+        help="comma-separated components to inject chaos (e.g. querynode,streamingnode)",
+    )
+    parser.addoption(
+        "--chaos_template",
+        action="store",
+        default="",
+        help="path to external ChaosMesh YAML template (overrides built-in config)",
+    )
     parser.addoption("--collection_num", action="store", default="1", help="collection_num")
     parser.addoption(
         "--search_timeout",

--- a/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
+++ b/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
@@ -23,7 +23,7 @@ def _request_options(timeout_value, consistency_level, default_consistency_level
 
 
 class TestAllCollection:
-    """ Test case of end to end"""
+    """Test case of end to end"""
 
     @pytest.fixture(scope="function", params=get_collections(file_name="chaos_test_all_collections.json"))
     def collection_name(self, request):
@@ -73,7 +73,7 @@ class TestAllCollection:
         collection_info = milvus_client.describe_collection(collection_name=name)
         schema = CollectionSchema.construct_from_dict(collection_info)
         tt = time.time() - t0
-        assert collection_info['collection_name'] == name
+        assert collection_info["collection_name"] == name
 
         # get collection info
         dim = cf.get_dim_by_schema(schema=schema)
@@ -106,7 +106,7 @@ class TestAllCollection:
         res = milvus_client.insert(collection_name=name, data=data)
         tt = time.time() - t0
         log.info(f"assert insert: {tt}")
-        assert res.get('insert_count', 0) > 0
+        assert res.get("insert_count", 0) > 0
 
         # flush
         t0 = time.time()
@@ -122,8 +122,8 @@ class TestAllCollection:
         for idx_name in index_names:
             try:
                 idx_info = milvus_client.describe_index(collection_name=name, index_name=idx_name)
-                if 'field_name' in idx_info:
-                    fields_created_index.append(idx_info['field_name'])
+                if "field_name" in idx_info:
+                    fields_created_index.append(idx_info["field_name"])
             except Exception as e:
                 log.debug(f"Failed to describe index {idx_name}: {e}")
 
@@ -133,15 +133,9 @@ class TestAllCollection:
             if f not in fields_created_index:
                 t0 = time.time()
                 index_params.add_index(
-                    field_name=f,
-                    index_type="HNSW",
-                    metric_type="L2",
-                    params={"M": 48, "efConstruction": 500}
+                    field_name=f, index_type="HNSW", metric_type="L2", params={"M": 48, "efConstruction": 500}
                 )
-                milvus_client.create_index(
-                    collection_name=name,
-                    index_params=index_params
-                )
+                milvus_client.create_index(collection_name=name, index_params=index_params)
                 tt = time.time() - t0
                 log.info(f"create index for field {f} cost: {tt} seconds")
                 index_params = milvus_client.prepare_index_params()  # reset for next field
@@ -187,7 +181,7 @@ class TestAllCollection:
             assert len(res_2) == 1
 
         # query
-        term_expr = f'{int64_field_name} in {[i for i in range(offset, 0)]}'
+        term_expr = f"{int64_field_name} in {[i for i in range(offset, 0)]}"
         t0 = time.time()
         res = milvus_client.query(
             collection_name=name,
@@ -261,7 +255,7 @@ class TestAllCollection:
             assert len(res_2) == 1
 
         # query
-        term_expr = f'{int64_field_name} > -3000'
+        term_expr = f"{int64_field_name} > -3000"
         t0 = time.time()
         res = milvus_client.query(
             collection_name=name,

--- a/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
+++ b/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
@@ -1,12 +1,13 @@
 import time
+
 import pytest
-from faker import Faker
-from pymilvus import MilvusClient, CollectionSchema
 from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel
-from utils.util_log import test_log as log
+from faker import Faker
+from pymilvus import CollectionSchema, MilvusClient
 from utils.util_common import get_collections
+from utils.util_log import test_log as log
 
 fake = Faker()
 
@@ -49,8 +50,7 @@ class TestAllCollection:
 
     def teardown_method(self, method):
         log.info(("*" * 35) + " teardown " + ("*" * 35))
-        log.info("[teardown_method] Start teardown test case %s..." %
-                 method.__name__)
+        log.info(f"[teardown_method] Start teardown test case {method.__name__}...")
         log.info("skip drop collection")
 
     @pytest.mark.tags(CaseLabel.L1)

--- a/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
+++ b/tests/python_client/chaos/testcases/test_all_collections_after_chaos.py
@@ -11,6 +11,16 @@ from utils.util_common import get_collections
 fake = Faker()
 
 
+def _request_options(timeout_value, consistency_level, default_consistency_level="Strong"):
+    opts = {}
+    if timeout_value:
+        opts["timeout"] = float(timeout_value)
+    level = consistency_level or default_consistency_level
+    if level:
+        opts["consistency_level"] = level
+    return opts
+
+
 class TestAllCollection:
     """ Test case of end to end"""
 
@@ -44,9 +54,19 @@ class TestAllCollection:
         log.info("skip drop collection")
 
     @pytest.mark.tags(CaseLabel.L1)
-    def test_milvus_default(self, collection_name, milvus_client):
+    def test_milvus_default(
+        self,
+        collection_name,
+        milvus_client,
+        search_timeout,
+        query_timeout,
+        search_consistency_level,
+        query_consistency_level,
+    ):
         # create
         name = collection_name if collection_name else cf.gen_unique_str("Checker_")
+        search_options = _request_options(search_timeout, search_consistency_level)
+        query_options = _request_options(query_timeout, query_consistency_level)
         t0 = time.time()
 
         # Get schema from existing collection
@@ -143,7 +163,7 @@ class TestAllCollection:
             anns_field=float_vector_field_name,
             search_params=dense_search_params,
             limit=1,
-            consistency_level="Strong"
+            **search_options,
         )
         tt = time.time() - t0
         log.info(f"assert search: {tt}")
@@ -160,7 +180,7 @@ class TestAllCollection:
                 anns_field=bm25_vec_field_name_list[0],
                 search_params=bm25_search_params,
                 limit=1,
-                consistency_level="Strong"
+                **search_options,
             )
             tt = time.time() - t0
             log.info(f"assert full text search: {tt}")
@@ -173,7 +193,7 @@ class TestAllCollection:
             collection_name=name,
             filter=term_expr,
             limit=5,
-            consistency_level="Strong"
+            **query_options,
         )
         tt = time.time() - t0
         log.info(f"assert query result {len(res)}: {tt}")
@@ -188,7 +208,7 @@ class TestAllCollection:
                 collection_name=name,
                 filter=expr,
                 limit=5,
-                consistency_level="Strong"
+                **query_options,
             )
             tt = time.time() - t0
             log.info(f"assert text match: {tt}")
@@ -216,7 +236,7 @@ class TestAllCollection:
             anns_field=float_vector_field_name,
             search_params=dense_search_params,
             limit=topk,
-            consistency_level="Strong"
+            **search_options,
         )
         tt = time.time() - t0
         log.info(f"assert search: {tt}")
@@ -234,7 +254,7 @@ class TestAllCollection:
                 anns_field=bm25_vec_field_name_list[0],
                 search_params=bm25_search_params,
                 limit=1,
-                consistency_level="Strong"
+                **search_options,
             )
             tt = time.time() - t0
             log.info(f"assert full text search: {tt}")
@@ -247,7 +267,7 @@ class TestAllCollection:
             collection_name=name,
             filter=term_expr,
             limit=5,
-            consistency_level="Strong"
+            **query_options,
         )
         tt = time.time() - t0
         log.info(f"assert query result {len(res)}: {tt}")
@@ -262,7 +282,7 @@ class TestAllCollection:
                 collection_name=name,
                 filter=expr,
                 limit=5,
-                consistency_level="Strong"
+                **query_options,
             )
             tt = time.time() - t0
             log.info(f"assert text match: {tt}")

--- a/tests/python_client/chaos/testcases/test_concurrent_operation.py
+++ b/tests/python_client/chaos/testcases/test_concurrent_operation.py
@@ -4,6 +4,7 @@ from time import sleep
 
 import pytest
 from chaos import chaos_commons as cc
+from chaos import checker
 from chaos import constants
 from chaos.chaos_commons import assert_statistic
 from chaos.checker import (
@@ -128,10 +129,25 @@ class TestOperations(TestBase):
             yield request.param
 
     @pytest.mark.tags(CaseLabel.L3)
-    def test_operations(self, request_duration, is_check, collection_name):
+    def test_operations(
+        self,
+        request_duration,
+        is_check,
+        collection_name,
+        search_timeout,
+        query_timeout,
+        search_consistency_level,
+        query_consistency_level,
+    ):
         # start the monitor threads to check the milvus ops
         log.info("*********************Test Start**********************")
         log.info(connections.get_connection_addr("default"))
+        checker.configure_request_options(
+            search_timeout_value=search_timeout,
+            query_timeout_value=query_timeout,
+            search_consistency_level_value=search_consistency_level,
+            query_consistency_level_value=query_consistency_level,
+        )
         # event_records = EventRecords()
         c_name = collection_name if collection_name else cf.gen_unique_str("Checker_")
         # event_records.insert("init_health_checkers", "start")

--- a/tests/python_client/chaos/testcases/test_concurrent_operation.py
+++ b/tests/python_client/chaos/testcases/test_concurrent_operation.py
@@ -4,8 +4,7 @@ from time import sleep
 
 import pytest
 from chaos import chaos_commons as cc
-from chaos import checker
-from chaos import constants
+from chaos import checker, constants
 from chaos.chaos_commons import assert_statistic
 from chaos.checker import (
     AddFieldChecker,

--- a/tests/python_client/chaos/testcases/test_single_request_operation.py
+++ b/tests/python_client/chaos/testcases/test_single_request_operation.py
@@ -47,14 +47,13 @@ class TestBase:
     expect_index = constants.SUCC
     expect_search = constants.SUCC
     expect_query = constants.SUCC
-    host = '127.0.0.1'
+    host = "127.0.0.1"
     port = 19530
     _chaos_config = None
     health_checkers = {}
 
 
 class TestOperations(TestBase):
-
     @pytest.fixture(scope="function", autouse=True)
     def connection(self, host, port, user, password, uri, token, milvus_ns, minio_host, enable_import, minio_bucket):
         # Prioritize uri and token for connection
@@ -69,9 +68,9 @@ class TestOperations(TestBase):
             actual_token = f"{user}:{password}" if user and password else None
 
         if actual_token:
-            connections.connect('default', uri=actual_uri, token=actual_token)
+            connections.connect("default", uri=actual_uri, token=actual_token)
         else:
-            connections.connect('default', uri=actual_uri)
+            connections.connect("default", uri=actual_uri)
 
         if connections.has_connection("default") is False:
             raise Exception("no connections")
@@ -86,7 +85,7 @@ class TestOperations(TestBase):
         self.password = password
         self.uri = actual_uri
         self.token = actual_token
-        self.milvus_sys = MilvusSys(alias='default')
+        self.milvus_sys = MilvusSys(alias="default")
         self.milvus_ns = milvus_ns
         self.release_name = get_milvus_instance_name(self.milvus_ns, milvus_sys=self.milvus_sys)
         self.enable_import = enable_import
@@ -98,7 +97,7 @@ class TestOperations(TestBase):
         checkers = {
             Op.create: CollectionCreateChecker(collection_name=c_name),
             Op.insert: InsertChecker(collection_name=c_name),
-            Op.tensor_search :TensorSearchChecker(collection_name=c_name),
+            Op.tensor_search: TensorSearchChecker(collection_name=c_name),
             Op.upsert: UpsertChecker(collection_name=c_name),
             Op.partial_update: PartialUpdateChecker(collection_name=c_name),
             Op.flush: FlushChecker(collection_name=c_name),
@@ -115,12 +114,12 @@ class TestOperations(TestBase):
             Op.drop: CollectionDropChecker(collection_name=c_name),
             Op.alter_collection: AlterCollectionChecker(collection_name=c_name),
             Op.add_field: AddFieldChecker(collection_name=c_name),
-            Op.rename_collection: CollectionRenameChecker(collection_name=c_name)
+            Op.rename_collection: CollectionRenameChecker(collection_name=c_name),
         }
         if bool(self.enable_import):
-            checkers[Op.bulk_insert] = BulkInsertChecker(collection_name=c_name,
-                                                         bucket_name=self.bucket_name,
-                                                         minio_endpoint=self.minio_endpoint)
+            checkers[Op.bulk_insert] = BulkInsertChecker(
+                collection_name=c_name, bucket_name=self.bucket_name, minio_endpoint=self.minio_endpoint
+            )
         self.health_checkers = checkers
 
     @pytest.mark.tags(CaseLabel.L3)
@@ -135,7 +134,7 @@ class TestOperations(TestBase):
     ):
         # start the monitor threads to check the milvus ops
         log.info("*********************Test Start**********************")
-        log.info(connections.get_connection_addr('default'))
+        log.info(connections.get_connection_addr("default"))
         checker.configure_request_options(
             search_timeout_value=search_timeout,
             query_timeout_value=query_timeout,

--- a/tests/python_client/chaos/testcases/test_single_request_operation.py
+++ b/tests/python_client/chaos/testcases/test_single_request_operation.py
@@ -32,6 +32,7 @@ from chaos.checker import (CollectionCreateChecker,
 from utils.util_log import test_log as log
 from utils.util_k8s import wait_pods_ready, get_milvus_instance_name
 from chaos import chaos_commons as cc
+from chaos import checker
 from common.common_type import CaseLabel
 from common.milvus_sys import MilvusSys
 from chaos.chaos_commons import assert_statistic
@@ -123,10 +124,24 @@ class TestOperations(TestBase):
         self.health_checkers = checkers
 
     @pytest.mark.tags(CaseLabel.L3)
-    def test_operations(self, request_duration, is_check):
+    def test_operations(
+        self,
+        request_duration,
+        is_check,
+        search_timeout,
+        query_timeout,
+        search_consistency_level,
+        query_consistency_level,
+    ):
         # start the monitor threads to check the milvus ops
         log.info("*********************Test Start**********************")
         log.info(connections.get_connection_addr('default'))
+        checker.configure_request_options(
+            search_timeout_value=search_timeout,
+            query_timeout_value=query_timeout,
+            search_consistency_level_value=search_consistency_level,
+            query_consistency_level_value=query_consistency_level,
+        )
         event_records = EventRecords()
         c_name = None
         event_records.insert("init_health_checkers", "start")

--- a/tests/python_client/chaos/testcases/test_single_request_operation.py
+++ b/tests/python_client/chaos/testcases/test_single_request_operation.py
@@ -1,43 +1,43 @@
 import time
-
-import pytest
 from time import sleep
+
 import pymilvus
-from pymilvus import connections, utility
-from chaos.checker import (CollectionCreateChecker,
-                           InsertChecker,
-                           BulkInsertChecker,
-                           UpsertChecker,
-                           PartialUpdateChecker,
-                           FlushChecker,
-                           SearchChecker,
-                           FullTextSearchChecker,
-                           HybridSearchChecker,
-                           QueryChecker,
-                           TextMatchChecker,
-                           PhraseMatchChecker,
-                           JsonQueryChecker,
-                           GeoQueryChecker,
-                           IndexCreateChecker,
-                           DeleteChecker,
-                           CollectionDropChecker,
-                           AlterCollectionChecker,
-                           AddFieldChecker,
-                           CollectionRenameChecker,
-                           TensorSearchChecker,
-                           Op,
-                           EventRecords,
-                           ResultAnalyzer
-                           )
-from utils.util_log import test_log as log
-from utils.util_k8s import wait_pods_ready, get_milvus_instance_name
+import pytest
 from chaos import chaos_commons as cc
-from chaos import checker
+from chaos import checker, constants
+from chaos.chaos_commons import assert_statistic
+from chaos.checker import (
+    AddFieldChecker,
+    AlterCollectionChecker,
+    BulkInsertChecker,
+    CollectionCreateChecker,
+    CollectionDropChecker,
+    CollectionRenameChecker,
+    DeleteChecker,
+    EventRecords,
+    FlushChecker,
+    FullTextSearchChecker,
+    GeoQueryChecker,
+    HybridSearchChecker,
+    IndexCreateChecker,
+    InsertChecker,
+    JsonQueryChecker,
+    Op,
+    PartialUpdateChecker,
+    PhraseMatchChecker,
+    QueryChecker,
+    ResultAnalyzer,
+    SearchChecker,
+    TensorSearchChecker,
+    TextMatchChecker,
+    UpsertChecker,
+)
 from common.common_type import CaseLabel
 from common.milvus_sys import MilvusSys
-from chaos.chaos_commons import assert_statistic
-from chaos import constants
 from delayed_assert import assert_expectations
+from pymilvus import connections, utility
+from utils.util_k8s import get_milvus_instance_name, wait_pods_ready
+from utils.util_log import test_log as log
 
 
 class TestBase:
@@ -100,7 +100,7 @@ class TestOperations(TestBase):
             Op.insert: InsertChecker(collection_name=c_name),
             Op.tensor_search :TensorSearchChecker(collection_name=c_name),
             Op.upsert: UpsertChecker(collection_name=c_name),
-            Op.partial_update: PartialUpdateChecker(collection_name=c_name), 
+            Op.partial_update: PartialUpdateChecker(collection_name=c_name),
             Op.flush: FlushChecker(collection_name=c_name),
             Op.index: IndexCreateChecker(collection_name=c_name),
             Op.search: SearchChecker(collection_name=c_name),


### PR DESCRIPTION
issue: #48185
pr: #50123

- chaos checker: backport configurable search/query timeout and consistency request options to 2.6 checkers
- chaos tests: expose pytest options for search/query timeout and consistency level on 2.6 chaos workflows