### PR TITLE
fix: cherrypick lazy nullable vector offset mapping fixes

### DIFF
--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -15,6 +15,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -139,7 +142,50 @@ class Chunk {
         return true;
     };
 
+    int64_t
+    PhysicalOffsetOf(int64_t logical_offset) const {
+        AssertInfo(logical_offset >= 0 && logical_offset < row_nums_,
+                   "Logical offset {} out of range, row nums {}",
+                   logical_offset,
+                   row_nums_);
+        if (!nullable_) {
+            return logical_offset;
+        }
+        AssertInfo(valid_[logical_offset],
+                   "Logical offset {} is null",
+                   logical_offset);
+        BuildValidRankBlocks();
+        const auto block_id = logical_offset / kValidRankBlockSize;
+        int64_t physical_offset = valid_rank_blocks_[block_id];
+        const auto block_start = block_id * kValidRankBlockSize;
+        for (int64_t i = block_start; i < logical_offset; ++i) {
+            physical_offset += valid_[i] ? 1 : 0;
+        }
+        return physical_offset;
+    }
+
  protected:
+    void
+    BuildValidRankBlocks() const {
+        std::call_once(valid_rank_blocks_once_, [&]() {
+            const auto num_blocks =
+                (row_nums_ + kValidRankBlockSize - 1) / kValidRankBlockSize;
+            valid_rank_blocks_.resize(num_blocks + 1);
+            int64_t valid_count = 0;
+            for (int64_t block_id = 0; block_id < num_blocks; ++block_id) {
+                valid_rank_blocks_[block_id] = valid_count;
+                const auto block_start = block_id * kValidRankBlockSize;
+                const auto block_end =
+                    std::min(block_start + kValidRankBlockSize, row_nums_);
+                for (int64_t i = block_start; i < block_end; ++i) {
+                    valid_count += valid_[i] ? 1 : 0;
+                }
+            }
+            valid_rank_blocks_[num_blocks] = valid_count;
+        });
+    }
+
+    static constexpr int64_t kValidRankBlockSize = 256;
     char* data_;
     int64_t row_nums_;
     uint64_t size_;
@@ -148,6 +194,8 @@ class Chunk {
         valid_;  // parse null bitmap to valid_ to be compatible with SpanBase
 
     std::shared_ptr<ChunkMmapGuard> chunk_mmap_guard_{nullptr};
+    mutable std::once_flag valid_rank_blocks_once_;
+    mutable std::vector<int64_t> valid_rank_blocks_;
 };
 
 // for fixed size data, includes fixed size array

--- a/internal/core/src/common/OffsetMapping.cpp
+++ b/internal/core/src/common/OffsetMapping.cpp
@@ -1,240 +1,104 @@
 #include "common/OffsetMapping.h"
 
+#include <algorithm>
+#include <mutex>
+#include <shared_mutex>
+
+#include "common/EasyAssert.h"
+
 namespace milvus {
+namespace {
 
-void
-OffsetMapping::Build(const bool* valid_data, int64_t total_count) {
-    constexpr int64_t start_logical = 0;
-    constexpr int64_t start_physical = 0;
-    if (total_count == 0 || valid_data == nullptr) {
-        return;
+bool
+BitsetHasNoFilteredRows(const BitsetView& bitset) {
+    if (bitset.empty()) {
+        return true;
     }
-
-    std::unique_lock<std::shared_mutex> lck(mutex_);
-    enabled_ = true;
-    total_count_ = start_logical + total_count;
-    chunk_built_.clear();
-    valid_count_ = 0;
-    l2p_vec_.clear();
-    p2l_vec_.clear();
-    l2p_map_.clear();
-    p2l_map_.clear();
-
-    // Count valid elements first
-    int64_t valid_count = 0;
-    for (int64_t i = 0; i < total_count; ++i) {
-        if (valid_data[i]) {
-            valid_count++;
-        }
-    }
-
-    // Auto-select storage mode: use map when valid ratio < 10%
-    use_map_ = (valid_count * 10 < total_count);
-
-    if (use_map_) {
-        // Map mode: only store valid entries
-        int64_t physical_idx = start_physical;
-        for (int64_t i = 0; i < total_count; ++i) {
-            if (valid_data[i]) {
-                l2p_map_[start_logical + i] = physical_idx;
-                p2l_map_[physical_idx] = start_logical + i;
-                physical_idx++;
+    if (bitset.has_out_ids()) {
+        for (size_t i = 0; i < bitset.size(); ++i) {
+            if (bitset.test(i)) {
+                return false;
             }
         }
-    } else {
-        // Vec mode: store all entries
-        int64_t required_size = start_logical + total_count;
-        if (static_cast<int64_t>(l2p_vec_.size()) < required_size) {
-            l2p_vec_.resize(required_size, -1);
-        }
-
-        int64_t physical_idx = start_physical;
-        for (int64_t i = 0; i < total_count; ++i) {
-            if (valid_data[i]) {
-                l2p_vec_[start_logical + i] = physical_idx;
-                if (physical_idx >= static_cast<int64_t>(p2l_vec_.size())) {
-                    p2l_vec_.resize(physical_idx + 1, -1);
-                }
-                p2l_vec_[physical_idx] = start_logical + i;
-                physical_idx++;
-            } else {
-                l2p_vec_[start_logical + i] = -1;
-            }
-        }
+        return true;
     }
 
-    valid_count_ = valid_count;
-}
-
-void
-OffsetMapping::Append(const bool* valid_data,
-                      int64_t count,
-                      int64_t start_logical,
-                      int64_t start_physical) {
-    if (count == 0 || valid_data == nullptr) {
-        return;
-    }
-
-    std::unique_lock<std::shared_mutex> lck(mutex_);
-    enabled_ = true;
-    total_count_ = start_logical + count;
-
-    // Incremental builds always use vec mode
-    if (use_map_ && !l2p_map_.empty()) {
-        // Convert from map to vec if needed
-        int64_t max_logical = 0;
-        for (const auto& [logical, physical] : l2p_map_) {
-            if (logical > max_logical) {
-                max_logical = logical;
-            }
-        }
-        l2p_vec_.resize(max_logical + 1, -1);
-        for (const auto& [logical, physical] : l2p_map_) {
-            l2p_vec_[logical] = physical;
-        }
-        int64_t max_physical = 0;
-        for (const auto& [physical, logical] : p2l_map_) {
-            if (physical > max_physical) {
-                max_physical = physical;
-            }
-        }
-        p2l_vec_.resize(max_physical + 1, -1);
-        for (const auto& [physical, logical] : p2l_map_) {
-            p2l_vec_[physical] = logical;
-        }
-        l2p_map_.clear();
-        p2l_map_.clear();
-        use_map_ = false;
-    }
-
-    // Resize l2p_vec if needed
-    int64_t required_size = start_logical + count;
-    if (static_cast<int64_t>(l2p_vec_.size()) < required_size) {
-        l2p_vec_.resize(required_size, -1);
-    }
-
-    int64_t physical_idx = start_physical;
-    for (int64_t i = 0; i < count; ++i) {
-        if (valid_data[i]) {
-            l2p_vec_[start_logical + i] = physical_idx;
-            if (physical_idx >= static_cast<int64_t>(p2l_vec_.size())) {
-                p2l_vec_.resize(physical_idx + 1, -1);
-            }
-            p2l_vec_[physical_idx] = start_logical + i;
-            physical_idx++;
-            valid_count_++;
-        } else {
-            l2p_vec_[start_logical + i] = -1;
+    const auto* data = bitset.data();
+    auto full_bytes = bitset.size() / 8;
+    for (size_t i = 0; i < full_bytes; ++i) {
+        if (data[i] != 0) {
+            return false;
         }
     }
-}
-
-void
-OffsetMapping::Reserve(int64_t total_count,
-                       int64_t valid_count,
-                       size_t num_chunks) {
-    std::unique_lock<std::shared_mutex> lck(mutex_);
-    enabled_ = true;
-    total_count_ = total_count;
-    valid_count_ = valid_count;
-    use_map_ = (valid_count * 10 < total_count);
-    chunk_built_.assign(num_chunks, 0);
-    l2p_map_.clear();
-    p2l_map_.clear();
-    if (use_map_) {
-        l2p_vec_.clear();
-        p2l_vec_.clear();
-    } else {
-        l2p_vec_.assign(total_count, -1);
-        p2l_vec_.assign(valid_count, -1);
+    auto remain_bits = bitset.size() & 7;
+    if (remain_bits == 0) {
+        return true;
     }
-}
-
-void
-OffsetMapping::SetChunk(int64_t chunk_id,
-                        int64_t start_logical,
-                        int64_t start_physical,
-                        const bool* valid_data,
-                        int64_t count) {
-    if (count == 0 || valid_data == nullptr) {
-        return;
-    }
-    std::unique_lock<std::shared_mutex> lck(mutex_);
-    if (chunk_id >= 0 && chunk_id < static_cast<int64_t>(chunk_built_.size()) &&
-        chunk_built_[chunk_id]) {
-        return;
-    }
-    int64_t physical_idx = start_physical;
-    if (use_map_) {
-        for (int64_t i = 0; i < count; ++i) {
-            if (valid_data[i]) {
-                l2p_map_[static_cast<int32_t>(start_logical + i)] =
-                    static_cast<int32_t>(physical_idx);
-                p2l_map_[static_cast<int32_t>(physical_idx)] =
-                    static_cast<int32_t>(start_logical + i);
-                physical_idx++;
-            }
-        }
-    } else {
-        for (int64_t i = 0; i < count; ++i) {
-            if (valid_data[i]) {
-                l2p_vec_[start_logical + i] =
-                    static_cast<int32_t>(physical_idx);
-                p2l_vec_[physical_idx] =
-                    static_cast<int32_t>(start_logical + i);
-                physical_idx++;
-            }
-        }
-    }
-    if (chunk_id >= 0 && chunk_id < static_cast<int64_t>(chunk_built_.size())) {
-        chunk_built_[chunk_id] = 1;
-    }
+    uint8_t mask = static_cast<uint8_t>((1U << remain_bits) - 1U);
+    return (data[full_bytes] & mask) == 0;
 }
 
 bool
-OffsetMapping::IsChunkSet(int64_t chunk_id) const {
-    std::shared_lock<std::shared_mutex> lck(mutex_);
-    return chunk_id >= 0 &&
-           chunk_id < static_cast<int64_t>(chunk_built_.size()) &&
-           chunk_built_[chunk_id] != 0;
+BitsetFiltersAllRows(const BitsetView& bitset) {
+    if (bitset.empty()) {
+        return false;
+    }
+    if (bitset.has_out_ids()) {
+        for (size_t i = 0; i < bitset.size(); ++i) {
+            if (!bitset.test(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    const auto* data = bitset.data();
+    auto full_bytes = bitset.size() / 8;
+    for (size_t i = 0; i < full_bytes; ++i) {
+        if (data[i] != 0xFF) {
+            return false;
+        }
+    }
+    auto remain_bits = bitset.size() & 7;
+    if (remain_bits == 0) {
+        return true;
+    }
+    uint8_t mask = static_cast<uint8_t>((1U << remain_bits) - 1U);
+    return (data[full_bytes] & mask) == mask;
 }
+
+bool
+ShouldSkipBitsetTransform(const BitsetView& bitset,
+                          int64_t total_count,
+                          TargetBitmap& result,
+                          OffsetMapping::BitsetTransformStatus& status) {
+    result.clear();
+    if (bitset.empty()) {
+        status = OffsetMapping::BitsetTransformStatus::NoFilter;
+        return true;
+    }
+    if (BitsetFiltersAllRows(bitset)) {
+        status = OffsetMapping::BitsetTransformStatus::AllFiltered;
+        return true;
+    }
+    if (static_cast<int64_t>(bitset.size()) >= total_count &&
+        BitsetHasNoFilteredRows(bitset)) {
+        status = OffsetMapping::BitsetTransformStatus::NoFilter;
+        return true;
+    }
+    return false;
+}
+
+}  // namespace
 
 int64_t
 OffsetMapping::GetPhysicalOffset(int64_t logical_offset) const {
-    std::shared_lock<std::shared_mutex> lck(mutex_);
-    if (!enabled_) {
-        return logical_offset;
-    }
-    if (use_map_) {
-        auto it = l2p_map_.find(static_cast<int32_t>(logical_offset));
-        if (it != l2p_map_.end()) {
-            return it->second;
-        }
-        return -1;
-    }
-    if (logical_offset < static_cast<int64_t>(l2p_vec_.size())) {
-        return l2p_vec_[logical_offset];
-    }
-    return -1;
+    return logical_offset;
 }
 
 int64_t
 OffsetMapping::GetLogicalOffset(int64_t physical_offset) const {
-    std::shared_lock<std::shared_mutex> lck(mutex_);
-    if (!enabled_) {
-        return physical_offset;
-    }
-    if (use_map_) {
-        auto it = p2l_map_.find(static_cast<int32_t>(physical_offset));
-        if (it != p2l_map_.end()) {
-            return it->second;
-        }
-        return -1;
-    }
-    if (physical_offset < static_cast<int64_t>(p2l_vec_.size())) {
-        return p2l_vec_[physical_offset];
-    }
-    return -1;
+    return physical_offset;
 }
 
 bool
@@ -244,20 +108,416 @@ OffsetMapping::IsValid(int64_t logical_offset) const {
 
 int64_t
 OffsetMapping::GetValidCount() const {
-    std::shared_lock<std::shared_mutex> lck(mutex_);
-    return valid_count_;
+    return 0;
 }
 
 bool
 OffsetMapping::IsEnabled() const {
-    std::shared_lock<std::shared_mutex> lck(mutex_);
-    return enabled_;
+    return false;
 }
 
 int64_t
 OffsetMapping::GetTotalCount() const {
-    std::shared_lock<std::shared_mutex> lck(mutex_);
+    return 0;
+}
+
+OffsetMapping::BitsetTransformStatus
+OffsetMapping::TransformBitset(const BitsetView& bitset,
+                               TargetBitmap& result) const {
+    (void)bitset;
+    result.clear();
+    return BitsetTransformStatus::NoFilter;
+}
+
+void
+OffsetMapping::TransformOffsets(std::vector<int64_t>& offsets) const {
+    (void)offsets;
+}
+
+void
+OffsetMapping::TransformLogicalOffsets(std::vector<int64_t>& offsets) const {
+    (void)offsets;
+}
+
+void
+OffsetMapping::FilterValidLogicalOffsets(
+    const int64_t* logical_offsets,
+    int64_t count,
+    bool* valid_data,
+    std::vector<int64_t>& physical_offsets) const {
+    physical_offsets.clear();
+    physical_offsets.reserve(count);
+    for (int64_t i = 0; i < count; ++i) {
+        const bool valid = logical_offsets[i] >= 0;
+        valid_data[i] = valid;
+        if (valid) {
+            physical_offsets.push_back(logical_offsets[i]);
+        }
+    }
+}
+
+void
+SealedOffsetMapping::Build(const bool* valid_data, int64_t total_count) {
+    constexpr int64_t start_logical = 0;
+    constexpr int64_t start_physical = 0;
+    if (total_count == 0 || valid_data == nullptr) {
+        return;
+    }
+
+    enabled_ = true;
+    total_count_ = start_logical + total_count;
+    valid_count_ = 0;
+    l2p_vec_.clear();
+    p2l_vec_.clear();
+    l2p_map_.clear();
+    p2l_map_.clear();
+
+    int64_t valid_count = 0;
+    for (int64_t i = 0; i < total_count; ++i) {
+        if (valid_data[i]) {
+            ++valid_count;
+        }
+    }
+
+    use_map_ = valid_count * 10 < total_count;
+
+    if (use_map_) {
+        int64_t physical_idx = start_physical;
+        for (int64_t i = 0; i < total_count; ++i) {
+            if (valid_data[i]) {
+                l2p_map_[start_logical + i] = physical_idx;
+                p2l_map_[physical_idx] = start_logical + i;
+                ++physical_idx;
+            }
+        }
+    } else {
+        const int64_t required_size = start_logical + total_count;
+        l2p_vec_.resize(required_size, -1);
+
+        const int64_t required_p2l_size = start_physical + valid_count;
+        p2l_vec_.resize(required_p2l_size, -1);
+
+        int64_t physical_idx = start_physical;
+        for (int64_t i = 0; i < total_count; ++i) {
+            if (valid_data[i]) {
+                l2p_vec_[start_logical + i] = physical_idx;
+                p2l_vec_[physical_idx] = start_logical + i;
+                ++physical_idx;
+            } else {
+                l2p_vec_[start_logical + i] = -1;
+            }
+        }
+    }
+
+    valid_count_ = valid_count;
+}
+
+int64_t
+SealedOffsetMapping::GetPhysicalOffset(int64_t logical_offset) const {
+    return GetPhysicalOffsetInternal(logical_offset);
+}
+
+int64_t
+SealedOffsetMapping::GetPhysicalOffsetInternal(int64_t logical_offset) const {
+    if (!enabled_) {
+        return logical_offset;
+    }
+    if (logical_offset < 0 || logical_offset >= total_count_) {
+        return -1;
+    }
+    if (use_map_) {
+        auto it = l2p_map_.find(static_cast<int32_t>(logical_offset));
+        return it == l2p_map_.end() ? -1 : it->second;
+    }
+    return logical_offset < static_cast<int64_t>(l2p_vec_.size())
+               ? l2p_vec_[logical_offset]
+               : -1;
+}
+
+int64_t
+SealedOffsetMapping::GetLogicalOffset(int64_t physical_offset) const {
+    return GetLogicalOffsetInternal(physical_offset);
+}
+
+int64_t
+SealedOffsetMapping::GetLogicalOffsetInternal(int64_t physical_offset) const {
+    if (!enabled_) {
+        return physical_offset;
+    }
+    if (physical_offset < 0 || physical_offset >= valid_count_) {
+        return -1;
+    }
+    if (use_map_) {
+        auto it = p2l_map_.find(static_cast<int32_t>(physical_offset));
+        return it == p2l_map_.end() ? -1 : it->second;
+    }
+    return physical_offset < static_cast<int64_t>(p2l_vec_.size())
+               ? p2l_vec_[physical_offset]
+               : -1;
+}
+
+int64_t
+SealedOffsetMapping::GetValidCount() const {
+    return valid_count_;
+}
+
+bool
+SealedOffsetMapping::IsEnabled() const {
+    return enabled_;
+}
+
+int64_t
+SealedOffsetMapping::GetTotalCount() const {
     return total_count_;
+}
+
+OffsetMapping::BitsetTransformStatus
+SealedOffsetMapping::TransformBitset(const BitsetView& bitset,
+                                     TargetBitmap& result) const {
+    if (!enabled_) {
+        result.clear();
+        return BitsetTransformStatus::NoFilter;
+    }
+    BitsetTransformStatus status;
+    if (ShouldSkipBitsetTransform(bitset, total_count_, result, status)) {
+        return status;
+    }
+
+    result.resize(valid_count_, true);
+    if (use_map_) {
+        for (int64_t physical_idx = 0; physical_idx < valid_count_;
+             ++physical_idx) {
+            auto it = p2l_map_.find(static_cast<int32_t>(physical_idx));
+            if (it != p2l_map_.end() &&
+                it->second < static_cast<int64_t>(bitset.size())) {
+                result[physical_idx] = bitset.test(it->second);
+            }
+        }
+    } else {
+        for (int64_t physical_idx = 0; physical_idx < valid_count_;
+             ++physical_idx) {
+            auto logical_idx = p2l_vec_[physical_idx];
+            if (logical_idx >= 0 &&
+                logical_idx < static_cast<int64_t>(bitset.size())) {
+                result[physical_idx] = bitset.test(logical_idx);
+            }
+        }
+    }
+    return BitsetTransformStatus::Transformed;
+}
+
+void
+SealedOffsetMapping::TransformOffsets(std::vector<int64_t>& offsets) const {
+    if (!enabled_) {
+        return;
+    }
+    for (auto& offset : offsets) {
+        if (offset >= 0) {
+            offset = GetLogicalOffsetInternal(offset);
+        }
+    }
+}
+
+void
+SealedOffsetMapping::TransformLogicalOffsets(
+    std::vector<int64_t>& offsets) const {
+    if (!enabled_) {
+        return;
+    }
+    for (auto& offset : offsets) {
+        if (offset >= 0) {
+            offset = GetPhysicalOffsetInternal(offset);
+        }
+    }
+}
+
+void
+SealedOffsetMapping::FilterValidLogicalOffsets(
+    const int64_t* logical_offsets,
+    int64_t count,
+    bool* valid_data,
+    std::vector<int64_t>& physical_offsets) const {
+    physical_offsets.clear();
+    physical_offsets.reserve(count);
+    for (int64_t i = 0; i < count; ++i) {
+        const auto physical_offset =
+            GetPhysicalOffsetInternal(logical_offsets[i]);
+        const bool valid = physical_offset >= 0;
+        valid_data[i] = valid;
+        if (valid) {
+            physical_offsets.push_back(physical_offset);
+        }
+    }
+}
+
+void
+GrowingOffsetMapping::Append(const bool* valid_data,
+                             int64_t count,
+                             int64_t start_logical,
+                             int64_t start_physical) {
+    if (count == 0 || valid_data == nullptr) {
+        return;
+    }
+
+    std::unique_lock lock(mutex_);
+    if (start_logical < 0) {
+        start_logical = total_count_;
+    }
+    auto physical_idx = start_physical >= 0 ? start_physical : valid_count_;
+    for (int64_t i = 0; i < count; ++i) {
+        if (valid_data[i]) {
+            const auto logical_offset = start_logical + i;
+            auto l2p_result =
+                l2p_map_.emplace(static_cast<int32_t>(logical_offset),
+                                 static_cast<int32_t>(physical_idx));
+            AssertInfo(l2p_result.second,
+                       "duplicate logical offset {} in growing offset mapping",
+                       logical_offset);
+            auto p2l_result =
+                p2l_map_.emplace(static_cast<int32_t>(physical_idx),
+                                 static_cast<int32_t>(logical_offset));
+            AssertInfo(p2l_result.second,
+                       "duplicate physical offset {} in growing offset mapping",
+                       physical_idx);
+            ++physical_idx;
+        }
+    }
+
+    total_count_ = std::max(total_count_, start_logical + count);
+    valid_count_ = physical_idx;
+    enabled_ = true;
+}
+
+int64_t
+GrowingOffsetMapping::GetPhysicalOffset(int64_t logical_offset) const {
+    std::shared_lock lock(mutex_);
+    if (!enabled_) {
+        return logical_offset;
+    }
+    return GetPhysicalOffsetInternal(logical_offset, total_count_);
+}
+
+int64_t
+GrowingOffsetMapping::GetPhysicalOffsetInternal(int64_t logical_offset,
+                                                int64_t total_count) const {
+    if (logical_offset < 0 || logical_offset >= total_count) {
+        return -1;
+    }
+    auto it = l2p_map_.find(static_cast<int32_t>(logical_offset));
+    return it == l2p_map_.end() ? -1 : it->second;
+}
+
+int64_t
+GrowingOffsetMapping::GetLogicalOffset(int64_t physical_offset) const {
+    std::shared_lock lock(mutex_);
+    if (!enabled_) {
+        return physical_offset;
+    }
+    return GetLogicalOffsetInternal(physical_offset, valid_count_);
+}
+
+int64_t
+GrowingOffsetMapping::GetLogicalOffsetInternal(int64_t physical_offset,
+                                               int64_t valid_count) const {
+    if (physical_offset < 0 || physical_offset >= valid_count) {
+        return -1;
+    }
+    auto it = p2l_map_.find(static_cast<int32_t>(physical_offset));
+    return it == p2l_map_.end() ? -1 : it->second;
+}
+
+int64_t
+GrowingOffsetMapping::GetValidCount() const {
+    std::shared_lock lock(mutex_);
+    return valid_count_;
+}
+
+bool
+GrowingOffsetMapping::IsEnabled() const {
+    std::shared_lock lock(mutex_);
+    return enabled_;
+}
+
+int64_t
+GrowingOffsetMapping::GetTotalCount() const {
+    std::shared_lock lock(mutex_);
+    return total_count_;
+}
+
+OffsetMapping::BitsetTransformStatus
+GrowingOffsetMapping::TransformBitset(const BitsetView& bitset,
+                                      TargetBitmap& result) const {
+    std::shared_lock lock(mutex_);
+    if (!enabled_) {
+        result.clear();
+        return BitsetTransformStatus::NoFilter;
+    }
+    const auto valid_count = valid_count_;
+    const auto total_count = total_count_;
+    BitsetTransformStatus status;
+    if (ShouldSkipBitsetTransform(bitset, total_count, result, status)) {
+        return status;
+    }
+
+    result.resize(valid_count, true);
+    for (int64_t physical_idx = 0; physical_idx < valid_count; ++physical_idx) {
+        auto it = p2l_map_.find(static_cast<int32_t>(physical_idx));
+        if (it != p2l_map_.end() &&
+            it->second < static_cast<int64_t>(bitset.size())) {
+            result[physical_idx] = bitset.test(it->second);
+        }
+    }
+    return BitsetTransformStatus::Transformed;
+}
+
+void
+GrowingOffsetMapping::TransformOffsets(std::vector<int64_t>& offsets) const {
+    std::shared_lock lock(mutex_);
+    if (!enabled_) {
+        return;
+    }
+    const auto valid_count = valid_count_;
+    for (auto& offset : offsets) {
+        if (offset >= 0) {
+            offset = GetLogicalOffsetInternal(offset, valid_count);
+        }
+    }
+}
+
+void
+GrowingOffsetMapping::TransformLogicalOffsets(
+    std::vector<int64_t>& offsets) const {
+    std::shared_lock lock(mutex_);
+    if (!enabled_) {
+        return;
+    }
+    const auto total_count = total_count_;
+    for (auto& offset : offsets) {
+        if (offset >= 0) {
+            offset = GetPhysicalOffsetInternal(offset, total_count);
+        }
+    }
+}
+
+void
+GrowingOffsetMapping::FilterValidLogicalOffsets(
+    const int64_t* logical_offsets,
+    int64_t count,
+    bool* valid_data,
+    std::vector<int64_t>& physical_offsets) const {
+    std::shared_lock lock(mutex_);
+    physical_offsets.clear();
+    physical_offsets.reserve(count);
+    const auto total_count = total_count_;
+    for (int64_t i = 0; i < count; ++i) {
+        const auto physical_offset =
+            GetPhysicalOffsetInternal(logical_offsets[i], total_count);
+        const bool valid = physical_offset >= 0;
+        valid_data[i] = valid;
+        if (valid) {
+            physical_offsets.push_back(physical_offset);
+        }
+    }
 }
 
 }  // namespace milvus

--- a/internal/core/src/common/OffsetMapping.h
+++ b/internal/core/src/common/OffsetMapping.h
@@ -22,85 +22,180 @@
 #include <unordered_map>
 #include <vector>
 
+#include "common/BitsetView.h"
+#include "common/Types.h"
+
 namespace milvus {
 
 // Bidirectional offset mapping for nullable vector storage
-// Maps between logical offsets (with nulls) and physical offsets (only valid data)
-// Supports two storage modes:
-// - vec mode: uses vector for both L2P and P2L, efficient when valid ratio >= 10%
-// - map mode: uses unordered_map for L2P, efficient when valid ratio < 10%
+// Maps between logical offsets (with nulls) and physical offsets (only valid
+// data). This base class is a read-only no-op mapping; real storage is split
+// between sealed and growing subclasses.
 class OffsetMapping {
  public:
+    enum class BitsetTransformStatus {
+        NoFilter,
+        AllFiltered,
+        Transformed,
+    };
+
     OffsetMapping() = default;
-
-    // Build mapping from valid_data (bool array format)
-    // If use_vec is not specified, auto-select based on valid ratio (< 10% uses map)
-    void
-    Build(const bool* valid_data, int64_t total_count);
-
-    // Build mapping incrementally (always uses vec mode for incremental builds)
-    void
-    Append(const bool* valid_data,
-           int64_t count,
-           int64_t start_logical,
-           int64_t start_physical);
-
-    // Allocate shape and lock storage mode without filling per-row entries.
-    void
-    Reserve(int64_t total_count, int64_t valid_count, size_t num_chunks);
-
-    // Idempotent and safe for concurrent calls on distinct chunks.
-    void
-    SetChunk(int64_t chunk_id,
-             int64_t start_logical,
-             int64_t start_physical,
-             const bool* valid_data,
-             int64_t count);
-
-    bool
-    IsChunkSet(int64_t chunk_id) const;
+    virtual ~OffsetMapping() = default;
 
     // Get physical offset from logical offset. Returns -1 if null.
-    int64_t
+    virtual int64_t
     GetPhysicalOffset(int64_t logical_offset) const;
 
     // Get logical offset from physical offset. Returns -1 if not found.
-    int64_t
+    virtual int64_t
     GetLogicalOffset(int64_t physical_offset) const;
 
     // Check if a logical offset is valid (not null)
-    bool
+    virtual bool
     IsValid(int64_t logical_offset) const;
 
     // Get count of valid (non-null) elements
-    int64_t
+    virtual int64_t
     GetValidCount() const;
 
     // Check if mapping is enabled
-    bool
+    virtual bool
     IsEnabled() const;
 
     // Get total logical count (including nulls)
-    int64_t
+    virtual int64_t
     GetTotalCount() const;
 
- private:
-    bool enabled_{false};
-    bool use_map_{false};  // true: use map for L2P, false: use vec
+    virtual BitsetTransformStatus
+    TransformBitset(const BitsetView& bitset, TargetBitmap& result) const;
 
-    // Vec mode storage (uses int32_t to save memory)
+    virtual void
+    TransformOffsets(std::vector<int64_t>& offsets) const;
+
+    virtual void
+    TransformLogicalOffsets(std::vector<int64_t>& offsets) const;
+
+    virtual void
+    FilterValidLogicalOffsets(const int64_t* logical_offsets,
+                              int64_t count,
+                              bool* valid_data,
+                              std::vector<int64_t>& physical_offsets) const;
+};
+
+class SealedOffsetMapping final : public OffsetMapping {
+ public:
+    void
+    Build(const bool* valid_data, int64_t total_count);
+
+    int64_t
+    GetPhysicalOffset(int64_t logical_offset) const override;
+
+    int64_t
+    GetLogicalOffset(int64_t physical_offset) const override;
+
+    int64_t
+    GetValidCount() const override;
+
+    bool
+    IsEnabled() const override;
+
+    int64_t
+    GetTotalCount() const override;
+
+    BitsetTransformStatus
+    TransformBitset(const BitsetView& bitset,
+                    TargetBitmap& result) const override;
+
+    void
+    TransformOffsets(std::vector<int64_t>& offsets) const override;
+
+    void
+    TransformLogicalOffsets(std::vector<int64_t>& offsets) const override;
+
+    void
+    FilterValidLogicalOffsets(
+        const int64_t* logical_offsets,
+        int64_t count,
+        bool* valid_data,
+        std::vector<int64_t>& physical_offsets) const override;
+
+ private:
+    int64_t
+    GetPhysicalOffsetInternal(int64_t logical_offset) const;
+
+    int64_t
+    GetLogicalOffsetInternal(int64_t physical_offset) const;
+
+    bool enabled_{false};
+    bool use_map_{false};
+    // Sealed vec mode storage (uses int32_t to save memory)
     std::vector<int32_t> l2p_vec_;  // logical -> physical, -1 means null
     std::vector<int32_t> p2l_vec_;  // physical -> logical
 
-    // Map mode storage (for sparse valid data)
+    // Sealed map mode storage (for sparse valid data)
     std::unordered_map<int32_t, int32_t> l2p_map_;  // logical -> physical
     std::unordered_map<int32_t, int32_t> p2l_map_;  // physical -> logical
 
-    std::vector<uint8_t> chunk_built_;
-
     int64_t valid_count_{0};
     int64_t total_count_{0};  // total logical count (including nulls)
+};
+
+class GrowingOffsetMapping final : public OffsetMapping {
+ public:
+    void
+    Append(const bool* valid_data,
+           int64_t count,
+           int64_t start_logical = -1,
+           int64_t start_physical = -1);
+
+    int64_t
+    GetPhysicalOffset(int64_t logical_offset) const override;
+
+    int64_t
+    GetLogicalOffset(int64_t physical_offset) const override;
+
+    int64_t
+    GetValidCount() const override;
+
+    bool
+    IsEnabled() const override;
+
+    int64_t
+    GetTotalCount() const override;
+
+    BitsetTransformStatus
+    TransformBitset(const BitsetView& bitset,
+                    TargetBitmap& result) const override;
+
+    void
+    TransformOffsets(std::vector<int64_t>& offsets) const override;
+
+    void
+    TransformLogicalOffsets(std::vector<int64_t>& offsets) const override;
+
+    void
+    FilterValidLogicalOffsets(
+        const int64_t* logical_offsets,
+        int64_t count,
+        bool* valid_data,
+        std::vector<int64_t>& physical_offsets) const override;
+
+ private:
+    int64_t
+    GetPhysicalOffsetInternal(int64_t logical_offset,
+                              int64_t total_count) const;
+
+    int64_t
+    GetLogicalOffsetInternal(int64_t physical_offset,
+                             int64_t valid_count) const;
+
     mutable std::shared_mutex mutex_;
+    std::unordered_map<int32_t, int32_t> l2p_map_;  // logical -> physical
+    std::unordered_map<int32_t, int32_t> p2l_map_;  // physical -> logical
+
+    bool enabled_{false};
+    int64_t valid_count_{0};
+    int64_t total_count_{0};  // total logical count incl nulls
 };
 
 }  // namespace milvus

--- a/internal/core/src/common/OffsetMappingTest.cpp
+++ b/internal/core/src/common/OffsetMappingTest.cpp
@@ -11,8 +11,6 @@
 
 #include <gtest/gtest.h>
 
-#include <atomic>
-#include <thread>
 #include <vector>
 
 #include "common/OffsetMapping.h"
@@ -52,37 +50,10 @@ TEST(OffsetMapping, DefaultIsDisabledAndPassThrough) {
     EXPECT_EQ(mapping.GetLogicalOffset(42), 42);
 }
 
-// ---------- Reserve ----------
-
-TEST(OffsetMapping, ReserveReflectsTotalCounts) {
-    OffsetMapping mapping;
-    mapping.Reserve(10, 8, 2);
-    EXPECT_TRUE(mapping.IsEnabled());
-    EXPECT_EQ(mapping.GetTotalCount(), 10);
-    EXPECT_EQ(mapping.GetValidCount(), 8);
-    EXPECT_FALSE(mapping.IsChunkSet(0));
-    EXPECT_FALSE(mapping.IsChunkSet(1));
-}
-
-TEST(OffsetMapping, ReserveAllValid) {
-    OffsetMapping mapping;
-    mapping.Reserve(5, 5, 1);
-    EXPECT_EQ(mapping.GetValidCount(), 5);
-    EXPECT_EQ(mapping.GetTotalCount(), 5);
-}
-
-TEST(OffsetMapping, ReserveAllNull) {
-    OffsetMapping mapping;
-    mapping.Reserve(5, 0, 1);
-    EXPECT_TRUE(mapping.IsEnabled());
-    EXPECT_EQ(mapping.GetValidCount(), 0);
-    EXPECT_EQ(mapping.GetTotalCount(), 5);
-}
-
 // ---------- Build (eager) ----------
 
 TEST(OffsetMapping, BuildBasicVecMode) {
-    OffsetMapping mapping;
+    SealedOffsetMapping mapping;
     auto valid = ToBoolBytes(MakeValid({1, 0, 1, 1, 0}));
     mapping.Build(reinterpret_cast<const bool*>(valid.data()), 5);
 
@@ -100,7 +71,7 @@ TEST(OffsetMapping, BuildBasicVecMode) {
 }
 
 TEST(OffsetMapping, BuildMapModeOnSparse) {
-    OffsetMapping mapping;
+    SealedOffsetMapping mapping;
     std::vector<uint8_t> valid(100, 0);
     valid[5] = 1;
     valid[50] = 1;
@@ -116,7 +87,7 @@ TEST(OffsetMapping, BuildMapModeOnSparse) {
 }
 
 TEST(OffsetMapping, BuildAllValid) {
-    OffsetMapping mapping;
+    SealedOffsetMapping mapping;
     std::vector<uint8_t> valid(4, 1);
     mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
     EXPECT_EQ(mapping.GetValidCount(), 4);
@@ -127,7 +98,7 @@ TEST(OffsetMapping, BuildAllValid) {
 }
 
 TEST(OffsetMapping, BuildAllNull) {
-    OffsetMapping mapping;
+    SealedOffsetMapping mapping;
     std::vector<uint8_t> valid(4, 0);
     mapping.Build(reinterpret_cast<const bool*>(valid.data()), 4);
     EXPECT_TRUE(mapping.IsEnabled());
@@ -139,7 +110,7 @@ TEST(OffsetMapping, BuildAllNull) {
 }
 
 TEST(OffsetMapping, BuildNoopOnNullOrZero) {
-    OffsetMapping mapping;
+    SealedOffsetMapping mapping;
     mapping.Build(nullptr, 100);
     EXPECT_FALSE(mapping.IsEnabled());
     std::vector<uint8_t> valid(1, 1);
@@ -148,7 +119,7 @@ TEST(OffsetMapping, BuildNoopOnNullOrZero) {
 }
 
 TEST(OffsetMapping, BuildTwiceResetsState) {
-    OffsetMapping mapping;
+    SealedOffsetMapping mapping;
     auto v1 = ToBoolBytes(MakeValid({1, 1, 0, 0, 1}));
     mapping.Build(reinterpret_cast<const bool*>(v1.data()), 5);
     EXPECT_EQ(mapping.GetValidCount(), 3);
@@ -163,172 +134,10 @@ TEST(OffsetMapping, BuildTwiceResetsState) {
     EXPECT_EQ(mapping.GetPhysicalOffset(2), -1);
 }
 
-// Regression: Reserve followed by Build must not double-count valid_count.
-TEST(OffsetMapping, ReserveThenBuildDoesNotDouble) {
-    OffsetMapping mapping;
-    mapping.Reserve(10, 6, 2);
-    EXPECT_EQ(mapping.GetValidCount(), 6);
-
-    auto valid = ToBoolBytes(MakeValid({1, 1, 0, 0, 1, 0, 1, 1, 0, 1}));
-    mapping.Build(reinterpret_cast<const bool*>(valid.data()), 10);
-
-    EXPECT_EQ(mapping.GetValidCount(), 6);
-    EXPECT_EQ(mapping.GetTotalCount(), 10);
-}
-
-// ---------- SetChunk ----------
-
-TEST(OffsetMapping, SetChunkVecModeSingleChunk) {
-    OffsetMapping mapping;
-    mapping.Reserve(5, 3, 1);
-    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 0, 1}));
-    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(valid.data()), 5);
-
-    EXPECT_TRUE(mapping.IsChunkSet(0));
-    EXPECT_EQ(mapping.GetValidCount(), 3);
-    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
-    EXPECT_EQ(mapping.GetPhysicalOffset(1), -1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(2), 1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(3), -1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(4), 2);
-    EXPECT_EQ(mapping.GetLogicalOffset(0), 0);
-    EXPECT_EQ(mapping.GetLogicalOffset(1), 2);
-    EXPECT_EQ(mapping.GetLogicalOffset(2), 4);
-}
-
-TEST(OffsetMapping, SetChunkVecModeMultipleChunksInOrder) {
-    OffsetMapping mapping;
-    mapping.Reserve(10, 6, 2);
-
-    auto c0 = ToBoolBytes(MakeValid({1, 1, 0, 0, 1}));
-    auto c1 = ToBoolBytes(MakeValid({0, 1, 1, 0, 1}));
-
-    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(c0.data()), 5);
-    mapping.SetChunk(1, 5, 3, reinterpret_cast<const bool*>(c1.data()), 5);
-
-    EXPECT_TRUE(mapping.IsChunkSet(0));
-    EXPECT_TRUE(mapping.IsChunkSet(1));
-    EXPECT_EQ(mapping.GetValidCount(), 6);
-
-    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
-    EXPECT_EQ(mapping.GetPhysicalOffset(1), 1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(2), -1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(4), 2);
-    EXPECT_EQ(mapping.GetPhysicalOffset(5), -1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(6), 3);
-    EXPECT_EQ(mapping.GetPhysicalOffset(7), 4);
-    EXPECT_EQ(mapping.GetPhysicalOffset(9), 5);
-    for (int64_t p = 0; p < 6; ++p) {
-        auto l = mapping.GetLogicalOffset(p);
-        EXPECT_GE(l, 0);
-        EXPECT_EQ(mapping.GetPhysicalOffset(l), p);
-    }
-}
-
-TEST(OffsetMapping, SetChunkVecModeOutOfOrder) {
-    OffsetMapping mapping;
-    mapping.Reserve(10, 6, 2);
-
-    auto c0 = ToBoolBytes(MakeValid({1, 1, 0, 0, 1}));
-    auto c1 = ToBoolBytes(MakeValid({0, 1, 1, 0, 1}));
-
-    mapping.SetChunk(1, 5, 3, reinterpret_cast<const bool*>(c1.data()), 5);
-    EXPECT_FALSE(mapping.IsChunkSet(0));
-    EXPECT_EQ(mapping.GetPhysicalOffset(6), 3);
-    EXPECT_EQ(mapping.GetLogicalOffset(3), 6);
-
-    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(c0.data()), 5);
-    EXPECT_TRUE(mapping.IsChunkSet(0));
-    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
-    EXPECT_EQ(mapping.GetLogicalOffset(0), 0);
-    EXPECT_EQ(mapping.GetValidCount(), 6);
-}
-
-TEST(OffsetMapping, SetChunkMapMode) {
-    OffsetMapping mapping;
-    mapping.Reserve(100, 2, 2);
-
-    std::vector<uint8_t> c0(50, 0);
-    c0[10] = 1;
-    std::vector<uint8_t> c1(50, 0);
-    c1[20] = 1;
-
-    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(c0.data()), 50);
-    mapping.SetChunk(1, 50, 1, reinterpret_cast<const bool*>(c1.data()), 50);
-
-    EXPECT_TRUE(mapping.IsChunkSet(0));
-    EXPECT_TRUE(mapping.IsChunkSet(1));
-    EXPECT_EQ(mapping.GetValidCount(), 2);
-    EXPECT_EQ(mapping.GetPhysicalOffset(10), 0);
-    EXPECT_EQ(mapping.GetPhysicalOffset(70), 1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(0), -1);
-    EXPECT_EQ(mapping.GetLogicalOffset(0), 10);
-    EXPECT_EQ(mapping.GetLogicalOffset(1), 70);
-}
-
-TEST(OffsetMapping, SetChunkIdempotent) {
-    OffsetMapping mapping;
-    mapping.Reserve(5, 3, 1);
-    auto valid = ToBoolBytes(MakeValid({1, 0, 1, 0, 1}));
-    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(valid.data()), 5);
-    auto before = mapping.GetValidCount();
-    mapping.SetChunk(0, 0, 0, reinterpret_cast<const bool*>(valid.data()), 5);
-    EXPECT_EQ(mapping.GetValidCount(), before);
-    EXPECT_EQ(mapping.GetPhysicalOffset(0), 0);
-    EXPECT_EQ(mapping.GetPhysicalOffset(2), 1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(4), 2);
-}
-
-TEST(OffsetMapping, ConcurrentSetChunkDifferentChunks) {
-    OffsetMapping mapping;
-    constexpr int kChunks = 8;
-    constexpr int kRowsPerChunk = 32;
-    constexpr int kTotal = kChunks * kRowsPerChunk;
-    mapping.Reserve(kTotal, kTotal / 2, kChunks);
-
-    std::vector<std::vector<uint8_t>> valids(
-        kChunks, std::vector<uint8_t>(kRowsPerChunk));
-    for (int c = 0; c < kChunks; ++c) {
-        for (int r = 0; r < kRowsPerChunk; ++r) {
-            valids[c][r] = (r % 2 == 0) ? 1 : 0;
-        }
-    }
-
-    std::vector<std::thread> threads;
-    threads.reserve(kChunks);
-    for (int c = 0; c < kChunks; ++c) {
-        threads.emplace_back([&, c] {
-            int64_t start_logical = c * kRowsPerChunk;
-            int64_t start_physical = c * (kRowsPerChunk / 2);
-            mapping.SetChunk(c,
-                             start_logical,
-                             start_physical,
-                             reinterpret_cast<const bool*>(valids[c].data()),
-                             kRowsPerChunk);
-        });
-    }
-    for (auto& t : threads) t.join();
-
-    EXPECT_EQ(mapping.GetValidCount(), kTotal / 2);
-    for (int c = 0; c < kChunks; ++c) {
-        EXPECT_TRUE(mapping.IsChunkSet(c));
-    }
-    for (int logical = 0; logical < kTotal; ++logical) {
-        bool expect_valid = (logical % 2 == 0);
-        int64_t phys = mapping.GetPhysicalOffset(logical);
-        if (expect_valid) {
-            EXPECT_GE(phys, 0) << "logical=" << logical;
-            EXPECT_EQ(mapping.GetLogicalOffset(phys), logical);
-        } else {
-            EXPECT_EQ(phys, -1) << "logical=" << logical;
-        }
-    }
-}
-
 // ---------- Append ----------
 
 TEST(OffsetMapping, AppendBasic) {
-    OffsetMapping mapping;
+    GrowingOffsetMapping mapping;
     auto v = ToBoolBytes(MakeValid({1, 0, 1, 1}));
     mapping.Append(reinterpret_cast<const bool*>(v.data()), 4, 0, 0);
 
@@ -341,7 +150,7 @@ TEST(OffsetMapping, AppendBasic) {
 }
 
 TEST(OffsetMapping, AppendMultipleBatches) {
-    OffsetMapping mapping;
+    GrowingOffsetMapping mapping;
     auto b1 = ToBoolBytes(MakeValid({1, 0, 1}));
     mapping.Append(reinterpret_cast<const bool*>(b1.data()), 3, 0, 0);
     EXPECT_EQ(mapping.GetValidCount(), 2);
@@ -362,30 +171,8 @@ TEST(OffsetMapping, AppendMultipleBatches) {
     EXPECT_EQ(mapping.GetLogicalOffset(3), 5);
 }
 
-TEST(OffsetMapping, AppendConvertsMapModeToVec) {
-    OffsetMapping mapping;
-    std::vector<uint8_t> sparse(100, 0);
-    sparse[7] = 1;
-    mapping.Build(reinterpret_cast<const bool*>(sparse.data()), 100);
-    EXPECT_EQ(mapping.GetValidCount(), 1);
-
-    auto b = ToBoolBytes(MakeValid({1, 1, 0}));
-    mapping.Append(reinterpret_cast<const bool*>(b.data()),
-                   3,
-                   mapping.GetTotalCount(),
-                   mapping.GetValidCount());
-
-    EXPECT_EQ(mapping.GetValidCount(), 3);
-    EXPECT_EQ(mapping.GetTotalCount(), 103);
-    EXPECT_EQ(mapping.GetPhysicalOffset(7), 0);
-    EXPECT_EQ(mapping.GetPhysicalOffset(100), 1);
-    EXPECT_EQ(mapping.GetPhysicalOffset(101), 2);
-    EXPECT_EQ(mapping.GetLogicalOffset(0), 7);
-    EXPECT_EQ(mapping.GetLogicalOffset(2), 101);
-}
-
 TEST(OffsetMapping, AppendNoopOnNullOrZero) {
-    OffsetMapping mapping;
+    GrowingOffsetMapping mapping;
     mapping.Append(nullptr, 3, 0, 0);
     EXPECT_FALSE(mapping.IsEnabled());
     std::vector<uint8_t> v(1, 1);
@@ -396,7 +183,7 @@ TEST(OffsetMapping, AppendNoopOnNullOrZero) {
 // ---------- IsValid ----------
 
 TEST(OffsetMapping, IsValidMatchesPhysicalOffsetSign) {
-    OffsetMapping mapping;
+    SealedOffsetMapping mapping;
     auto v = ToBoolBytes(MakeValid({1, 0, 1, 0}));
     mapping.Build(reinterpret_cast<const bool*>(v.data()), 4);
     EXPECT_TRUE(mapping.IsValid(0));
@@ -408,7 +195,7 @@ TEST(OffsetMapping, IsValidMatchesPhysicalOffsetSign) {
 // ---------- Out-of-bounds queries ----------
 
 TEST(OffsetMapping, OutOfBoundsReturnsMinusOne) {
-    OffsetMapping mapping;
+    SealedOffsetMapping mapping;
     auto v = ToBoolBytes(MakeValid({1, 0, 1}));
     mapping.Build(reinterpret_cast<const bool*>(v.data()), 3);
     EXPECT_EQ(mapping.GetPhysicalOffset(99), -1);

--- a/internal/core/src/common/QueryResult.h
+++ b/internal/core/src/common/QueryResult.h
@@ -143,10 +143,10 @@ struct OffsetDisPairComparator {
 struct VectorIterator {
  public:
     VectorIterator(int chunk_count,
-                   const milvus::OffsetMapping& offset_mapping,
+                   const milvus::OffsetMapping* offset_mapping,
                    const std::vector<int64_t>& total_rows_until_chunk = {},
                    bool larger_is_closer = false)
-        : offset_mapping_(&offset_mapping),
+        : offset_mapping_(offset_mapping),
           total_rows_until_chunk_(total_rows_until_chunk),
           larger_is_closer_(larger_is_closer),
           heap_(OffsetDisPairComparator(larger_is_closer)) {
@@ -249,7 +249,7 @@ struct SearchResult {
         int chunk_count,
         const std::vector<int64_t>& total_rows_until_chunk,
         const std::vector<knowhere::IndexNode::IteratorPtr>& kw_iterators,
-        const milvus::OffsetMapping& offset_mapping,
+        const milvus::OffsetMapping* offset_mapping,
         bool larger_is_closer = false) {
         AssertInfo(kw_iterators.size() == nq * chunk_count,
                    "kw_iterators count:{} is not equal to nq*chunk_count:{}, "

--- a/internal/core/src/common/Schema.cpp
+++ b/internal/core/src/common/Schema.cpp
@@ -118,6 +118,52 @@ Schema::ParseFrom(const milvus::proto::schema::CollectionSchema& schema_proto) {
 const FieldMeta FieldMeta::RowIdMeta(
     FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
 
+namespace {
+
+bool
+IsNullableFixedWidthVectorField(const FieldMeta& meta) {
+    if (!meta.is_nullable()) {
+        return false;
+    }
+
+    switch (meta.get_data_type()) {
+        case DataType::VECTOR_FLOAT:
+        case DataType::VECTOR_BINARY:
+        case DataType::VECTOR_FLOAT16:
+        case DataType::VECTOR_BFLOAT16:
+        case DataType::VECTOR_INT8:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::shared_ptr<arrow::DataType>
+GetArrowDataTypeForSchema(const FieldMeta& meta, int dim) {
+    auto data_type = meta.get_data_type();
+    if (data_type == DataType::VECTOR_ARRAY) {
+        return GetArrowDataTypeForVectorArray(meta.get_element_type(),
+                                              meta.get_dim());
+    }
+    if (IsNullableFixedWidthVectorField(meta)) {
+        return arrow::binary();
+    }
+    return GetArrowDataType(data_type, dim);
+}
+
+std::shared_ptr<arrow::KeyValueMetadata>
+BuildArrowFieldMetadata(const FieldMeta& meta, int dim) {
+    auto metadata = std::make_shared<arrow::KeyValueMetadata>();
+    metadata->Append(milvus_storage::ARROW_FIELD_ID_KEY,
+                     std::to_string(meta.get_id().get()));
+    if (IsNullableFixedWidthVectorField(meta)) {
+        metadata->Append(DIM_KEY, std::to_string(dim));
+    }
+    return metadata;
+}
+
+}  // namespace
+
 const ArrowSchemaPtr
 Schema::ConvertToArrowSchema() const {
     arrow::FieldVector arrow_fields;
@@ -129,21 +175,13 @@ Schema::ConvertToArrowSchema() const {
                       ? meta.get_dim()
                       : 1;
 
-        std::shared_ptr<arrow::DataType> arrow_data_type = nullptr;
-        auto data_type = meta.get_data_type();
-        if (data_type == DataType::VECTOR_ARRAY) {
-            arrow_data_type = GetArrowDataTypeForVectorArray(
-                meta.get_element_type(), meta.get_dim());
-        } else {
-            arrow_data_type = GetArrowDataType(data_type, dim);
-        }
+        auto arrow_data_type = GetArrowDataTypeForSchema(meta, dim);
 
-        auto arrow_field = std::make_shared<arrow::Field>(
-            meta.get_name().get(),
-            arrow_data_type,
-            meta.is_nullable(),
-            arrow::key_value_metadata({milvus_storage::ARROW_FIELD_ID_KEY},
-                                      {std::to_string(meta.get_id().get())}));
+        auto arrow_field =
+            std::make_shared<arrow::Field>(meta.get_name().get(),
+                                           arrow_data_type,
+                                           meta.is_nullable(),
+                                           BuildArrowFieldMetadata(meta, dim));
         arrow_fields.push_back(arrow_field);
     }
     return arrow::schema(arrow_fields);

--- a/internal/core/src/common/SchemaTest.cpp
+++ b/internal/core/src/common/SchemaTest.cpp
@@ -11,7 +11,17 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/type.h"
+#include "arrow/util/key_value_metadata.h"
+#include "common/Consts.h"
 #include "common/Schema.h"
+#include "common/Types.h"
+#include "milvus-storage/common/constants.h"
+#include "pb/schema.pb.h"
 
 using namespace milvus;
 
@@ -439,4 +449,60 @@ TEST_F(SchemaTest, ShouldLoadFieldReturnsFalseForBM25FunctionOutput) {
 
     schema->UpdateLoadFields({101});
     EXPECT_FALSE(schema->ShouldLoadField(FieldId(101)));
+}
+
+TEST_F(SchemaTest, NullableFixedWidthVectorUsesBinaryInArrowSchemas) {
+    constexpr int64_t dim = 16;
+    struct VectorCase {
+        std::string name;
+        DataType data_type;
+        int64_t dim;
+        int64_t byte_width;
+    };
+    const std::vector<VectorCase> cases = {
+        {"float_vec", DataType::VECTOR_FLOAT, dim, dim * sizeof(float)},
+        {"binary_vec", DataType::VECTOR_BINARY, 128, 16},
+        {"float16_vec", DataType::VECTOR_FLOAT16, dim, dim * 2},
+        {"bfloat16_vec", DataType::VECTOR_BFLOAT16, dim, dim * 2},
+        {"int8_vec", DataType::VECTOR_INT8, dim, dim},
+    };
+
+    auto pk_id = schema_->AddDebugField("pk_field", DataType::INT64, false);
+    schema_->set_primary_field_id(pk_id);
+
+    std::vector<FieldId> nullable_field_ids;
+    for (const auto& c : cases) {
+        nullable_field_ids.push_back(schema_->AddDebugField(
+            "nullable_" + c.name, c.data_type, c.dim, std::nullopt, true));
+        schema_->AddDebugField(
+            "non_nullable_" + c.name, c.data_type, c.dim, std::nullopt, false);
+    }
+
+    auto arrow_schema = schema_->ConvertToArrowSchema();
+
+    for (size_t i = 0; i < cases.size(); ++i) {
+        const auto& c = cases[i];
+        auto nullable_field =
+            arrow_schema->GetFieldByName("nullable_" + c.name);
+        ASSERT_NE(nullable_field, nullptr);
+        EXPECT_TRUE(nullable_field->type()->Equals(*arrow::binary()))
+            << nullable_field->type()->ToString();
+        ASSERT_NE(nullable_field->metadata(), nullptr);
+        ASSERT_TRUE(nullable_field->metadata()->Contains(DIM_KEY));
+        EXPECT_EQ(nullable_field->metadata()->Get(DIM_KEY).ValueOrDie(),
+                  std::to_string(c.dim));
+        ASSERT_TRUE(nullable_field->metadata()->Contains(
+            milvus_storage::ARROW_FIELD_ID_KEY));
+        EXPECT_EQ(nullable_field->metadata()
+                      ->Get(milvus_storage::ARROW_FIELD_ID_KEY)
+                      .ValueOrDie(),
+                  std::to_string(nullable_field_ids[i].get()));
+
+        auto non_nullable_field =
+            arrow_schema->GetFieldByName("non_nullable_" + c.name);
+        ASSERT_NE(non_nullable_field, nullptr);
+        EXPECT_TRUE(non_nullable_field->type()->Equals(
+            *arrow::fixed_size_binary(c.byte_width)))
+            << non_nullable_field->type()->ToString();
+    }
 }

--- a/internal/core/src/exec/operator/Utils.h
+++ b/internal/core/src/exec/operator/Utils.h
@@ -56,12 +56,20 @@ PrepareVectorIteratorsFromIndex(const SearchInfo& search_info,
             if (iterators_val.has_value()) {
                 bool larger_is_closer =
                     PositivelyRelated(search_info.metric_type_);
+                // Element-level search skips row-level mapping (element IDs
+                // are not row-aligned); see ChunkMergeIterator ctor.
+                const auto& offset_mapping = index.GetOffsetMapping();
+                const milvus::OffsetMapping* iter_offset_mapping =
+                    (search_info.array_offsets_ != nullptr ||
+                     !offset_mapping.IsEnabled())
+                        ? nullptr
+                        : &offset_mapping;
                 search_result.AssembleChunkVectorIterators(
                     nq,
                     1,
                     {0},
                     iterators_val.value(),
-                    index.GetOffsetMapping(),
+                    iter_offset_mapping,
                     larger_is_closer);
             } else {
                 std::string operator_type = "";

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -214,7 +214,8 @@ template <typename T>
 IndexStatsPtr
 VectorDiskAnnIndex<T>::Upload(const Config& config) {
     BinarySet ret;
-    if (!IsAllNullNullable(offset_mapping_)) {
+    const auto& offset_mapping = GetOffsetMapping();
+    if (!IsAllNullNullable(offset_mapping)) {
         auto stat = index_.Serialize(ret);
         if (stat != knowhere::Status::success) {
             ThrowInfo(ErrorCode::UnexpectedError,
@@ -359,11 +360,12 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
     build_config[DISK_ANN_PREFIX_PATH] = local_index_path_prefix;
 
+    const auto& offset_mapping = GetOffsetMapping();
     if (HasValidData() && GetValidCount() == 0 &&
-        offset_mapping_.GetTotalCount() > 0) {
+        offset_mapping.GetTotalCount() > 0) {
         auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
         WriteDiskValidData(
-            local_chunk_manager, valid_data_path, offset_mapping_);
+            local_chunk_manager, valid_data_path, offset_mapping);
         file_manager_->AddFile(valid_data_path);
         auto dim = GetValueFromConfig<int64_t>(build_config, DIM_KEY);
         if (dim.has_value()) {
@@ -450,7 +452,7 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     if (HasValidData()) {
         auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
         WriteDiskValidData(
-            local_chunk_manager, valid_data_path, offset_mapping_);
+            local_chunk_manager, valid_data_path, offset_mapping);
         file_manager_->AddFile(valid_data_path);
     }
 

--- a/internal/core/src/index/VectorIndex.h
+++ b/internal/core/src/index/VectorIndex.h
@@ -43,7 +43,9 @@ class VectorIndex : public IndexBase {
  public:
     explicit VectorIndex(const IndexType& index_type,
                          const MetricType& metric_type)
-        : IndexBase(index_type), metric_type_(metric_type) {
+        : IndexBase(index_type),
+          offset_mapping_(std::make_unique<milvus::GrowingOffsetMapping>()),
+          metric_type_(metric_type) {
     }
 
  public:
@@ -152,52 +154,55 @@ class VectorIndex : public IndexBase {
 
     void
     UpdateValidData(const bool* valid_data, int64_t count) {
-        offset_mapping_.Append(valid_data,
-                               count,
-                               offset_mapping_.GetTotalCount(),
-                               offset_mapping_.GetValidCount());
+        auto* growing_mapping =
+            dynamic_cast<milvus::GrowingOffsetMapping*>(offset_mapping_.get());
+        AssertInfo(growing_mapping != nullptr,
+                   "cannot update growing valid data from sealed mapping");
+        growing_mapping->Append(valid_data, count);
     }
 
     void
     BuildValidData(const bool* valid_data, int64_t total_count) {
-        offset_mapping_.Build(valid_data, total_count);
+        auto sealed_mapping = std::make_unique<milvus::SealedOffsetMapping>();
+        sealed_mapping->Build(valid_data, total_count);
+        offset_mapping_ = std::move(sealed_mapping);
     }
 
     bool
     IsRowValid(int64_t logical_offset) const {
-        if (!offset_mapping_.IsEnabled()) {
+        if (!offset_mapping_->IsEnabled()) {
             return true;
         }
-        return offset_mapping_.IsValid(logical_offset);
+        return offset_mapping_->IsValid(logical_offset);
     }
 
     bool
     HasValidData() const {
-        return offset_mapping_.IsEnabled();
+        return offset_mapping_->IsEnabled();
     }
 
     int64_t
     GetValidCount() const {
-        return offset_mapping_.GetValidCount();
+        return offset_mapping_->GetValidCount();
     }
 
     int64_t
     GetPhysicalOffset(int64_t logical_offset) const {
-        return offset_mapping_.GetPhysicalOffset(logical_offset);
+        return offset_mapping_->GetPhysicalOffset(logical_offset);
     }
 
     int64_t
     GetLogicalOffset(int64_t physical_offset) const {
-        return offset_mapping_.GetLogicalOffset(physical_offset);
+        return offset_mapping_->GetLogicalOffset(physical_offset);
     }
 
     const milvus::OffsetMapping&
     GetOffsetMapping() const {
-        return offset_mapping_;
+        return *offset_mapping_;
     }
 
  protected:
-    milvus::OffsetMapping offset_mapping_;
+    std::unique_ptr<milvus::OffsetMapping> offset_mapping_;
 
  private:
     MetricType metric_type_;

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -146,7 +146,8 @@ template <typename T>
 BinarySet
 VectorMemIndex<T>::Serialize(const Config& config) {
     knowhere::BinarySet ret;
-    bool all_null_nullable = IsAllNullNullable(offset_mapping_);
+    const auto& offset_mapping = GetOffsetMapping();
+    bool all_null_nullable = IsAllNullNullable(offset_mapping);
     if (!all_null_nullable) {
         auto stat = index_.Serialize(ret);
         if (stat != knowhere::Status::success)
@@ -155,7 +156,7 @@ VectorMemIndex<T>::Serialize(const Config& config) {
                       KnowhereStatusString(stat));
     }
 
-    AppendValidDataToBinarySet(offset_mapping_, ret);
+    AppendValidDataToBinarySet(offset_mapping, ret);
     Disassemble(ret);
 
     return ret;

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -384,12 +384,15 @@ class ChunkedColumn : public ChunkedColumnBase {
                 std::function<void(const char*, size_t)> fn,
                 const int64_t* offsets,
                 int64_t count) override {
-        auto [cids, offsets_in_chunk] =
-            nullable_ ? ToChunkIdAndOffsetByPhysical(offsets, count)
-                      : ToChunkIdAndOffset(offsets, count);
+        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
         auto ca = SemiInlineGet(slot_->PinCells(op_ctx, cids));
         for (int64_t i = 0; i < count; i++) {
-            fn(ca->get_cell_of(cids[i])->ValueAt(offsets_in_chunk[i]), i);
+            auto chunk = ca->get_cell_of(cids[i]);
+            auto offset = offsets_in_chunk[i];
+            if (nullable_ && IsVectorDataType(data_type_)) {
+                offset = chunk->PhysicalOffsetOf(offset);
+            }
+            fn(chunk->ValueAt(offset), i);
         }
     }
 
@@ -473,14 +476,16 @@ class ChunkedColumn : public ChunkedColumnBase {
                       const int64_t* offsets,
                       int64_t element_sizeof,
                       int64_t count) override {
-        auto [cids, offsets_in_chunk] =
-            nullable_ ? ToChunkIdAndOffsetByPhysical(offsets, count)
-                      : ToChunkIdAndOffset(offsets, count);
+        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
         auto ca = SemiInlineGet(slot_->PinCells(op_ctx, cids));
         auto dst_vec = reinterpret_cast<char*>(dst);
         for (int64_t i = 0; i < count; i++) {
             auto chunk = ca->get_cell_of(cids[i]);
-            auto value = chunk->ValueAt(offsets_in_chunk[i]);
+            auto offset = offsets_in_chunk[i];
+            if (nullable_) {
+                offset = chunk->PhysicalOffsetOf(offset);
+            }
+            auto value = chunk->ValueAt(offset);
             memcpy(dst_vec + i * element_sizeof, value, element_sizeof);
         }
     }
@@ -674,10 +679,13 @@ class ChunkedVectorArrayColumn : public ChunkedColumnBase {
         auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
         auto ca = SemiInlineGet(slot_->PinCells(op_ctx, cids));
         for (int64_t i = 0; i < count; i++) {
-            auto array =
-                static_cast<VectorArrayChunk*>(ca->get_cell_of(cids[i]))
-                    ->View(offsets_in_chunk[i])
-                    .output_data();
+            auto chunk =
+                static_cast<VectorArrayChunk*>(ca->get_cell_of(cids[i]));
+            auto offset = offsets_in_chunk[i];
+            if (nullable_) {
+                offset = chunk->PhysicalOffsetOf(offset);
+            }
+            auto array = chunk->View(offset).output_data();
             fn(std::move(array), i);
         }
     }

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -415,15 +415,16 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
                 std::function<void(const char*, size_t)> fn,
                 const int64_t* offsets,
                 int64_t count) override {
-        auto [cids, offsets_in_chunk] =
-            field_meta_.is_nullable()
-                ? ToChunkIdAndOffsetByPhysical(offsets, count)
-                : ToChunkIdAndOffset(offsets, count);
+        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
         auto ca = group_->GetGroupChunks(op_ctx, cids);
         for (int64_t i = 0; i < count; i++) {
             auto* group_chunk = ca->get_cell_of(cids[i]);
             auto chunk = group_chunk->GetChunk(field_id_);
-            fn(chunk->ValueAt(offsets_in_chunk[i]), i);
+            auto offset = offsets_in_chunk[i];
+            if (field_meta_.is_nullable() && IsVectorDataType(data_type_)) {
+                offset = chunk->PhysicalOffsetOf(offset);
+            }
+            fn(chunk->ValueAt(offset), i);
         }
     }
 
@@ -508,16 +509,17 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
                       const int64_t* offsets,
                       int64_t element_sizeof,
                       int64_t count) override {
-        auto [cids, offsets_in_chunk] =
-            field_meta_.is_nullable()
-                ? ToChunkIdAndOffsetByPhysical(offsets, count)
-                : ToChunkIdAndOffset(offsets, count);
+        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
         auto ca = group_->GetGroupChunks(op_ctx, cids);
         auto dst_vec = reinterpret_cast<char*>(dst);
         for (int64_t i = 0; i < count; i++) {
             auto* group_chunk = ca->get_cell_of(cids[i]);
             auto chunk = group_chunk->GetChunk(field_id_);
-            auto value = chunk->ValueAt(offsets_in_chunk[i]);
+            auto offset = offsets_in_chunk[i];
+            if (field_meta_.is_nullable()) {
+                offset = chunk->PhysicalOffsetOf(offset);
+            }
+            auto value = chunk->ValueAt(offset);
             memcpy(dst_vec + i * element_sizeof, value, element_sizeof);
         }
     }
@@ -659,8 +661,12 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         for (int64_t i = 0; i < count; i++) {
             auto* group_chunk = ca->get_cell_of(cids[i]);
             auto chunk = group_chunk->GetChunk(field_id_);
+            auto offset = offsets_in_chunk[i];
+            if (field_meta_.is_nullable()) {
+                offset = chunk->PhysicalOffsetOf(offset);
+            }
             auto array = static_cast<VectorArrayChunk*>(chunk.get())
-                             ->View(offsets_in_chunk[i])
+                             ->View(offset)
                              .output_data();
             fn(std::move(array), i);
         }

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -15,6 +15,7 @@
 // limitations under the License.
 #pragma once
 
+#include <atomic>
 #include <mutex>
 
 #include "cachinglayer/CacheSlot.h"
@@ -137,25 +138,25 @@ class ChunkedColumnInterface {
     virtual const std::vector<int64_t>&
     GetNumRowsUntilChunk() const = 0;
 
-    // Get vector of valid (non-null) row counts before each chunk
-    // For nullable columns, this tracks cumulative physical offsets
-    // For non-nullable columns, this equals GetNumRowsUntilChunk()
-    const std::vector<int64_t>&
-    GetNumValidRowsUntilChunk() const {
-        if (!num_valid_rows_until_chunk_.empty()) {
-            return num_valid_rows_until_chunk_;
-        }
-        return GetNumRowsUntilChunk();
-    }
-
     const FixedVector<bool>&
     GetValidData() const {
         return valid_data_;
     }
 
-    const std::vector<int64_t>&
-    GetValidCountPerChunk() const {
-        return valid_count_per_chunk_;
+    int64_t
+    GetValidCountInChunk(int64_t chunk_id) const {
+        if (!IsNullable()) {
+            return chunk_row_nums(chunk_id);
+        }
+        AssertInfo(!valid_count_per_chunk_.empty(),
+                   "Valid row mapping is not built for nullable column");
+        AssertInfo(
+            chunk_id >= 0 &&
+                chunk_id < static_cast<int64_t>(valid_count_per_chunk_.size()),
+            "Chunk id {} out of range, valid count chunks {}",
+            chunk_id,
+            valid_count_per_chunk_.size());
+        return valid_count_per_chunk_[chunk_id];
     }
 
     const OffsetMapping&
@@ -166,6 +167,13 @@ class ChunkedColumnInterface {
     virtual void
     BuildValidRowIds(milvus::OpContext* op_ctx) {
         if (!IsNullable()) {
+            return;
+        }
+        if (valid_row_ids_built_.load(std::memory_order_acquire)) {
+            return;
+        }
+        std::lock_guard<std::mutex> lock(offset_mapping_build_mutex_);
+        if (valid_row_ids_built_.load(std::memory_order_relaxed)) {
             return;
         }
         const auto total_chunks = num_chunks();
@@ -196,107 +204,8 @@ class ChunkedColumnInterface {
             num_valid_rows_until_chunk_.push_back(
                 num_valid_rows_until_chunk_.back() + valid_count_per_chunk_[i]);
         }
-        if (chunk_build_flags_.empty()) {
-            BuildOffsetMapping();
-        }
-    }
-
-    // Returns false if stats can't be aligned to chunks; caller falls back to eager.
-    template <typename GetRgRows, typename GetRgNulls>
-    bool
-    TryInitValidRowIdsFromRowGroups(size_t num_row_groups,
-                                    GetRgRows&& rg_rows,
-                                    GetRgNulls&& rg_nulls) {
-        const auto num_chunks = static_cast<int64_t>(this->num_chunks());
-        if (num_chunks == 0) {
-            return false;
-        }
-        const auto& chunk_bounds = GetNumRowsUntilChunk();
-        if (static_cast<int64_t>(chunk_bounds.size()) != num_chunks + 1) {
-            return false;
-        }
-        std::vector<int64_t> counts(num_chunks, 0);
-        int64_t chunk_idx = 0;
-        int64_t accumulated_rows = 0;
-        for (size_t i = 0; i < num_row_groups; ++i) {
-            const int64_t rows = rg_rows(i);
-            const int64_t nulls = rg_nulls(i);
-            if (rows < 0 || nulls < 0 || nulls > rows) {
-                return false;
-            }
-            if (chunk_idx >= num_chunks) {
-                return false;
-            }
-            counts[chunk_idx] += rows - nulls;
-            accumulated_rows += rows;
-            if (chunk_idx + 1 < num_chunks &&
-                accumulated_rows >= chunk_bounds[chunk_idx + 1]) {
-                if (accumulated_rows != chunk_bounds[chunk_idx + 1]) {
-                    return false;
-                }
-                chunk_idx++;
-            }
-        }
-        if (accumulated_rows != chunk_bounds[num_chunks]) {
-            return false;
-        }
-        InitValidRowIds(counts);
-        return true;
-    }
-
-    // Lazy counterpart of BuildValidRowIds: populates counts from metadata
-    // without pinning any chunk.
-    void
-    InitValidRowIds(const std::vector<int64_t>& valid_count_per_chunk) {
-        if (!IsNullable()) {
-            return;
-        }
-        valid_count_per_chunk_ = valid_count_per_chunk;
-        num_valid_rows_until_chunk_.clear();
-        num_valid_rows_until_chunk_.reserve(valid_count_per_chunk.size() + 1);
-        num_valid_rows_until_chunk_.push_back(0);
-        int64_t total_valid = 0;
-        for (auto c : valid_count_per_chunk) {
-            total_valid += c;
-            num_valid_rows_until_chunk_.push_back(total_valid);
-        }
-        offset_mapping_.Reserve(static_cast<int64_t>(NumRows()),
-                                total_valid,
-                                valid_count_per_chunk.size());
-        chunk_build_flags_ =
-            std::vector<std::once_flag>(valid_count_per_chunk.size());
-    }
-
-    void
-    EnsureChunkOffsetMapping(int64_t chunk_id, milvus::OpContext* op_ctx) {
-        if (!IsNullable() || chunk_build_flags_.empty()) {
-            return;
-        }
-        if (chunk_id < 0 ||
-            chunk_id >= static_cast<int64_t>(chunk_build_flags_.size())) {
-            return;
-        }
-        if (offset_mapping_.IsChunkSet(chunk_id)) {
-            return;
-        }
-        std::call_once(chunk_build_flags_[chunk_id], [&]() {
-            auto pw = GetChunk(op_ctx, chunk_id);
-            auto chunk = pw.get();
-            const int64_t rows = chunk_row_nums(chunk_id);
-            std::vector<uint8_t> valid_bytes(rows);
-            for (int64_t j = 0; j < rows; ++j) {
-                valid_bytes[j] = chunk->isValid(j) ? 1 : 0;
-            }
-            const int64_t start_logical = GetNumRowsUntilChunk()[chunk_id];
-            const int64_t start_physical =
-                num_valid_rows_until_chunk_[chunk_id];
-            offset_mapping_.SetChunk(
-                chunk_id,
-                start_logical,
-                start_physical,
-                reinterpret_cast<const bool*>(valid_bytes.data()),
-                rows);
-        });
+        BuildOffsetMapping();
+        valid_row_ids_built_.store(true, std::memory_order_release);
     }
 
     // Build offset mapping from valid_data
@@ -416,8 +325,9 @@ class ChunkedColumnInterface {
     FixedVector<bool> valid_data_;
     std::vector<int64_t> valid_count_per_chunk_;
     std::vector<int64_t> num_valid_rows_until_chunk_;
-    OffsetMapping offset_mapping_;
-    std::vector<std::once_flag> chunk_build_flags_;
+    SealedOffsetMapping offset_mapping_;
+    std::atomic<bool> valid_row_ids_built_{false};
+    std::mutex offset_mapping_build_mutex_;
 
     std::pair<std::vector<milvus::cachinglayer::cid_t>, std::vector<int64_t>>
     ToChunkIdAndOffset(const int64_t* offsets, int64_t count) const {
@@ -446,35 +356,6 @@ class ChunkedColumnInterface {
         for (int64_t i = 0; i < count; i++) {
             auto [chunk_id, offset_in_chunk] = GetChunkIDByOffset(offsets[i]);
             cids.push_back(chunk_id);
-            offsets_in_chunk.push_back(offset_in_chunk);
-        }
-        return std::make_pair(std::move(cids), std::move(offsets_in_chunk));
-    }
-
-    std::pair<std::vector<milvus::cachinglayer::cid_t>, std::vector<int64_t>>
-    ToChunkIdAndOffsetByPhysical(const int64_t* physical_offsets,
-                                 int64_t count) const {
-        AssertInfo(physical_offsets != nullptr,
-                   "Physical offsets cannot be nullptr");
-        const auto& num_valid_rows_until_chunk = GetNumValidRowsUntilChunk();
-        std::vector<milvus::cachinglayer::cid_t> cids;
-        cids.reserve(count);
-        std::vector<int64_t> offsets_in_chunk;
-        offsets_in_chunk.reserve(count);
-
-        for (int64_t i = 0; i < count; i++) {
-            auto offset = physical_offsets[i];
-            auto iter = std::upper_bound(num_valid_rows_until_chunk.begin(),
-                                         num_valid_rows_until_chunk.end(),
-                                         offset);
-            AssertInfo(iter != num_valid_rows_until_chunk.begin(),
-                       "Physical offset {} is invalid",
-                       offset);
-            size_t chunk_idx =
-                std::distance(num_valid_rows_until_chunk.begin(), iter) - 1;
-            int64_t offset_in_chunk =
-                offset - num_valid_rows_until_chunk[chunk_idx];
-            cids.push_back(chunk_idx);
             offsets_in_chunk.push_back(offset_in_chunk);
         }
         return std::make_pair(std::move(cids), std::move(offsets_in_chunk));

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+#include <iterator>
 #include <memory>
 #include <set>
 #include <unordered_map>
@@ -50,15 +52,30 @@ struct ColumnSpec {
 std::vector<char>
 BuildChunkBuffer(int64_t row_num,
                  const std::vector<bool>* pattern,
-                 bool nullable) {
+                 bool nullable,
+                 int64_t start_logical_offset) {
     const int32_t bitmap_bytes = nullable ? (row_num + 7) / 8 : 0;
     std::vector<char> buf(bitmap_bytes + row_num * kElementSize, 0);
+    int64_t physical_offset = 0;
     if (nullable) {
         for (int64_t j = 0; j < row_num; ++j) {
             const bool v = pattern ? (*pattern)[j] : true;
             if (v) {
                 buf[j >> 3] |= (1 << (j & 0x07));
+                const int32_t value = start_logical_offset + j;
+                std::memcpy(
+                    buf.data() + bitmap_bytes + physical_offset * kElementSize,
+                    &value,
+                    sizeof(value));
+                ++physical_offset;
             }
+        }
+    } else {
+        for (int64_t j = 0; j < row_num; ++j) {
+            const int32_t value = start_logical_offset + j;
+            std::memcpy(buf.data() + bitmap_bytes + j * kElementSize,
+                        &value,
+                        sizeof(value));
         }
     }
     return buf;
@@ -129,22 +146,27 @@ struct ChunkedColumnFactory {
         auto buffers = std::make_shared<std::vector<std::vector<char>>>(n);
         std::vector<std::unique_ptr<Chunk>> chunks;
         chunks.reserve(n);
+        int64_t start_logical_offset = 0;
         for (size_t i = 0; i < n; ++i) {
             (*buffers)[i] = BuildChunkBuffer(
                 spec.rows_per_chunk[i],
                 spec.valid_patterns.empty() ? nullptr : &spec.valid_patterns[i],
-                spec.nullable);
+                spec.nullable,
+                start_logical_offset);
             chunks.push_back(MakeFixedChunk(spec.rows_per_chunk[i],
                                             spec.nullable,
                                             (*buffers)[i].data(),
                                             (*buffers)[i].size()));
+            start_logical_offset += spec.rows_per_chunk[i];
         }
         auto fetched = std::make_shared<std::set<cachinglayer::cid_t>>();
         auto translator = std::make_unique<CountingChunkTranslator>(
             spec.rows_per_chunk, "cc_iface", std::move(chunks), fetched);
         FieldMeta fm(FieldName("t"),
                      FieldId(kTestFieldId),
-                     DataType::INT32,
+                     DataType::VECTOR_INT8,
+                     kElementSize,
+                     std::nullopt,
                      spec.nullable,
                      std::nullopt);
         auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
@@ -163,11 +185,13 @@ struct ProxyChunkColumnFactory {
         auto buffers = std::make_shared<std::vector<std::vector<char>>>(n);
         std::vector<std::unique_ptr<GroupChunk>> group_chunks;
         group_chunks.reserve(n);
+        int64_t start_logical_offset = 0;
         for (size_t i = 0; i < n; ++i) {
             (*buffers)[i] = BuildChunkBuffer(
                 spec.rows_per_chunk[i],
                 spec.valid_patterns.empty() ? nullptr : &spec.valid_patterns[i],
-                spec.nullable);
+                spec.nullable,
+                start_logical_offset);
             std::shared_ptr<Chunk> chunk =
                 MakeFixedChunk(spec.rows_per_chunk[i],
                                spec.nullable,
@@ -176,6 +200,7 @@ struct ProxyChunkColumnFactory {
             std::unordered_map<FieldId, std::shared_ptr<Chunk>> fields;
             fields[FieldId(kTestFieldId)] = std::move(chunk);
             group_chunks.push_back(std::make_unique<GroupChunk>(fields));
+            start_logical_offset += spec.rows_per_chunk[i];
         }
         auto fetched = std::make_shared<std::set<cachinglayer::cid_t>>();
         auto translator = std::make_unique<CountingGroupChunkTranslator>(
@@ -188,7 +213,9 @@ struct ProxyChunkColumnFactory {
             std::make_shared<ChunkedColumnGroup>(std::move(translator));
         FieldMeta fm(FieldName("t"),
                      FieldId(kTestFieldId),
-                     DataType::INT32,
+                     DataType::VECTOR_INT8,
+                     kElementSize,
+                     std::nullopt,
                      spec.nullable,
                      std::nullopt);
         auto column = std::make_shared<ProxyChunkColumn>(
@@ -208,8 +235,7 @@ using Factories =
     ::testing::Types<ChunkedColumnFactory, ProxyChunkColumnFactory>;
 TYPED_TEST_SUITE(ChunkedColumnInterfaceTest, Factories);
 
-TYPED_TEST(ChunkedColumnInterfaceTest,
-           InitValidRowIdsPopulatesCountsWithoutPin) {
+TYPED_TEST(ChunkedColumnInterfaceTest, BuildValidRowIdsBuildsFullMapping) {
     ColumnSpec spec{{5, 3, 4},
                     {{true, false, true, true, false},
                      {false, false, false},
@@ -217,34 +243,46 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
                     true};
     auto fx = TypeParam::Create(spec);
 
-    fx.column->InitValidRowIds({3, 0, 4});
-
     EXPECT_TRUE(fx.fetched->empty());
 
-    const auto& cum = fx.column->GetNumValidRowsUntilChunk();
-    ASSERT_EQ(cum.size(), 4u);
-    EXPECT_EQ(cum[0], 0);
-    EXPECT_EQ(cum[1], 3);
-    EXPECT_EQ(cum[2], 3);
-    EXPECT_EQ(cum[3], 7);
+    fx.column->BuildValidRowIds(nullptr);
+    EXPECT_EQ(fx.fetched->size(), 3u);
+    EXPECT_EQ(fx.fetched->count(0), 1u);
+    EXPECT_EQ(fx.fetched->count(1), 1u);
+    EXPECT_EQ(fx.fetched->count(2), 1u);
 
-    const auto& per_chunk = fx.column->GetValidCountPerChunk();
-    ASSERT_EQ(per_chunk.size(), 3u);
-    EXPECT_EQ(per_chunk[0], 3);
-    EXPECT_EQ(per_chunk[1], 0);
-    EXPECT_EQ(per_chunk[2], 4);
+    EXPECT_EQ(fx.column->GetValidCountInChunk(0), 3);
+    EXPECT_EQ(fx.column->GetValidCountInChunk(1), 0);
+    EXPECT_EQ(fx.column->GetValidCountInChunk(2), 4);
 
     const auto& m = fx.column->GetOffsetMapping();
     EXPECT_TRUE(m.IsEnabled());
     EXPECT_EQ(m.GetTotalCount(), 12);
     EXPECT_EQ(m.GetValidCount(), 7);
-    for (int64_t c = 0; c < 3; ++c) {
-        EXPECT_FALSE(m.IsChunkSet(c)) << "chunk " << c;
-    }
+    EXPECT_EQ(m.GetPhysicalOffset(0), 0);
+    EXPECT_EQ(m.GetPhysicalOffset(2), 1);
+    EXPECT_EQ(m.GetPhysicalOffset(3), 2);
+    EXPECT_EQ(m.GetPhysicalOffset(1), -1);
+    EXPECT_EQ(m.GetPhysicalOffset(4), -1);
+    EXPECT_EQ(m.GetPhysicalOffset(8), 3);
+    EXPECT_EQ(m.GetPhysicalOffset(9), 4);
+    EXPECT_EQ(m.GetPhysicalOffset(10), 5);
+    EXPECT_EQ(m.GetPhysicalOffset(11), 6);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, BuildValidRowIdsNonNullableIsNoop) {
+    ColumnSpec spec{{5, 5}, {}, /*nullable=*/false};
+    auto fx = TypeParam::Create(spec);
+
+    fx.column->BuildValidRowIds(nullptr);
+
+    EXPECT_FALSE(fx.column->GetOffsetMapping().IsEnabled());
+    EXPECT_EQ(fx.column->GetValidCountInChunk(0), 5);
+    EXPECT_TRUE(fx.fetched->empty());
 }
 
 TYPED_TEST(ChunkedColumnInterfaceTest,
-           EnsureChunkOffsetMappingFillsOnlyTouched) {
+           BulkVectorValueAtDefaultsToLogicalOffsetsForNullableColumn) {
     ColumnSpec spec{{5, 3, 4},
                     {{true, false, true, true, false},
                      {false, false, false},
@@ -252,61 +290,56 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
                     true};
     auto fx = TypeParam::Create(spec);
 
-    fx.column->InitValidRowIds({3, 0, 4});
-    const auto& m = fx.column->GetOffsetMapping();
+    const int64_t offsets[] = {0, 2, 3, 8, 11};
+    std::vector<int32_t> values(std::size(offsets));
+    fx.column->BulkVectorValueAt(
+        nullptr, values.data(), offsets, kElementSize, std::size(offsets));
 
-    fx.column->EnsureChunkOffsetMapping(2, nullptr);
-    EXPECT_FALSE(m.IsChunkSet(0));
-    EXPECT_FALSE(m.IsChunkSet(1));
-    EXPECT_TRUE(m.IsChunkSet(2));
-    EXPECT_EQ(fx.fetched->size(), 1u);
-    EXPECT_EQ(fx.fetched->count(2), 1u);
-
-    EXPECT_EQ(m.GetPhysicalOffset(8), 3);
-    EXPECT_EQ(m.GetPhysicalOffset(9), 4);
-    EXPECT_EQ(m.GetPhysicalOffset(10), 5);
-    EXPECT_EQ(m.GetPhysicalOffset(11), 6);
-    EXPECT_EQ(m.GetPhysicalOffset(0), -1);
-
-    fx.column->EnsureChunkOffsetMapping(0, nullptr);
-    EXPECT_TRUE(m.IsChunkSet(0));
-    EXPECT_EQ(m.GetPhysicalOffset(0), 0);
-    EXPECT_EQ(m.GetPhysicalOffset(2), 1);
-    EXPECT_EQ(m.GetPhysicalOffset(3), 2);
-    EXPECT_EQ(m.GetPhysicalOffset(1), -1);
-    EXPECT_EQ(m.GetPhysicalOffset(4), -1);
-    EXPECT_EQ(fx.fetched->size(), 2u);
-    EXPECT_EQ(fx.fetched->count(1), 0u);
-
-    // Idempotent.
-    fx.column->EnsureChunkOffsetMapping(0, nullptr);
-    EXPECT_EQ(fx.fetched->size(), 2u);
-}
-
-TYPED_TEST(ChunkedColumnInterfaceTest, EnsureChunkNoopOnEagerPath) {
-    ColumnSpec spec{{4}, {{true, false, true, false}}, true};
-    auto fx = TypeParam::Create(spec);
-
-    fx.column->BuildValidRowIds(nullptr);
-    const auto before = fx.column->GetOffsetMapping().GetValidCount();
-    const auto fetched_before = fx.fetched->size();
-
-    fx.column->EnsureChunkOffsetMapping(0, nullptr);
-
-    EXPECT_EQ(fx.column->GetOffsetMapping().GetValidCount(), before);
-    EXPECT_EQ(before, 2);
-    EXPECT_EQ(fx.fetched->size(), fetched_before);
-}
-
-TYPED_TEST(ChunkedColumnInterfaceTest, InitValidRowIdsNonNullableIsNoop) {
-    ColumnSpec spec{{5, 5}, {}, /*nullable=*/false};
-    auto fx = TypeParam::Create(spec);
-
-    fx.column->InitValidRowIds({5, 5});
-
+    EXPECT_EQ(values, (std::vector<int32_t>{0, 2, 3, 8, 11}));
     EXPECT_FALSE(fx.column->GetOffsetMapping().IsEnabled());
-    EXPECT_TRUE(fx.column->GetValidCountPerChunk().empty());
-    EXPECT_TRUE(fx.fetched->empty());
+    EXPECT_TRUE(fx.column->GetValidData().empty());
+    EXPECT_EQ(fx.fetched->size(), 2u);
+    EXPECT_EQ(fx.fetched->count(0), 1u);
+    EXPECT_EQ(fx.fetched->count(2), 1u);
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           BulkValueAtDefaultsToLogicalOffsetsForNullableColumn) {
+    ColumnSpec spec{{5, 3, 4},
+                    {{true, false, true, true, false},
+                     {false, false, false},
+                     {true, true, true, true}},
+                    true};
+    auto fx = TypeParam::Create(spec);
+
+    const int64_t offsets[] = {0, 2, 3, 8, 11};
+    std::vector<int32_t> values;
+    fx.column->BulkValueAt(
+        nullptr,
+        [&](const char* value, size_t i) {
+            int32_t decoded = 0;
+            std::memcpy(&decoded, value, sizeof(decoded));
+            values.push_back(decoded);
+        },
+        offsets,
+        std::size(offsets));
+
+    EXPECT_EQ(values, (std::vector<int32_t>{0, 2, 3, 8, 11}));
+    EXPECT_FALSE(fx.column->GetOffsetMapping().IsEnabled());
+    EXPECT_TRUE(fx.column->GetValidData().empty());
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest,
+           BulkVectorValueAtLogicalOffsetRejectsNullRow) {
+    ColumnSpec spec{{5}, {{true, false, true, true, false}}, true};
+    auto fx = TypeParam::Create(spec);
+
+    const int64_t null_offset[] = {1};
+    int32_t value = 0;
+    EXPECT_THROW(fx.column->BulkVectorValueAt(
+                     nullptr, &value, null_offset, kElementSize, 1),
+                 std::exception);
+    EXPECT_FALSE(fx.column->GetOffsetMapping().IsEnabled());
 }
 
 }  // namespace milvus

--- a/internal/core/src/mmap/ChunkedColumnTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnTest.cpp
@@ -107,21 +107,10 @@ TEST(test_chunked_column, test_nullable_build_valid_row_ids) {
     // Call BuildValidRowIds to populate valid row tracking
     column.BuildValidRowIds(nullptr);
 
-    // Verify GetNumValidRowsUntilChunk()
-    // Expected cumulative valid counts: [0, 3, 3, 7]
-    auto& num_valid_rows = column.GetNumValidRowsUntilChunk();
-    ASSERT_EQ(num_valid_rows.size(), num_chunks + 1);
-    EXPECT_EQ(num_valid_rows[0], 0);
-    EXPECT_EQ(num_valid_rows[1], 3);  // chunk 0 has 3 valid
-    EXPECT_EQ(num_valid_rows[2], 3);  // chunk 1 has 0 valid
-    EXPECT_EQ(num_valid_rows[3], 7);  // chunk 2 has 4 valid
-
-    // Verify GetValidCountPerChunk()
-    auto& valid_counts = column.GetValidCountPerChunk();
-    ASSERT_EQ(valid_counts.size(), num_chunks);
-    EXPECT_EQ(valid_counts[0], 3);
-    EXPECT_EQ(valid_counts[1], 0);
-    EXPECT_EQ(valid_counts[2], 4);
+    // Verify GetValidCountInChunk()
+    EXPECT_EQ(column.GetValidCountInChunk(0), 3);
+    EXPECT_EQ(column.GetValidCountInChunk(1), 0);
+    EXPECT_EQ(column.GetValidCountInChunk(2), 4);
 
     // Verify GetValidData() matches the patterns
     auto& valid_data = column.GetValidData();
@@ -138,9 +127,8 @@ TEST(test_chunked_column, test_nullable_build_valid_row_ids) {
     }
 }
 
-TEST(test_chunked_column, test_nullable_get_num_valid_rows_non_nullable) {
-    // For non-nullable columns, GetNumValidRowsUntilChunk() should
-    // fall back to GetNumRowsUntilChunk()
+TEST(test_chunked_column, test_nullable_get_valid_count_non_nullable) {
+    // For non-nullable columns, valid count should equal chunk row count.
     std::vector<int64_t> num_rows_per_chunk = {10, 20, 30};
     auto num_chunks = num_rows_per_chunk.size();
     std::vector<std::unique_ptr<Chunk>> chunks;
@@ -161,13 +149,8 @@ TEST(test_chunked_column, test_nullable_get_num_valid_rows_non_nullable) {
             std::move(translator), nullptr);
     ChunkedColumn column(std::move(slot), field_meta);
 
-    // For non-nullable, GetNumValidRowsUntilChunk should equal
-    // GetNumRowsUntilChunk
-    auto& valid_rows = column.GetNumValidRowsUntilChunk();
-    auto& total_rows = column.GetNumRowsUntilChunk();
-    ASSERT_EQ(valid_rows.size(), total_rows.size());
-    for (size_t i = 0; i < valid_rows.size(); i++) {
-        EXPECT_EQ(valid_rows[i], total_rows[i]);
+    for (size_t i = 0; i < num_chunks; i++) {
+        EXPECT_EQ(column.GetValidCountInChunk(i), num_rows_per_chunk[i]);
     }
 }
 
@@ -217,19 +200,9 @@ TEST(test_chunked_column, test_nullable_all_valid) {
 
     column.BuildValidRowIds(nullptr);
 
-    // When all rows are valid, num_valid_rows_until_chunk should equal
-    // num_rows_until_chunk
-    auto& num_valid_rows = column.GetNumValidRowsUntilChunk();
-    auto& num_rows = column.GetNumRowsUntilChunk();
-    ASSERT_EQ(num_valid_rows.size(), num_rows.size());
-    for (size_t i = 0; i < num_valid_rows.size(); i++) {
-        EXPECT_EQ(num_valid_rows[i], num_rows[i]);
-    }
-
     // All valid counts should equal row counts
-    auto& valid_counts = column.GetValidCountPerChunk();
-    EXPECT_EQ(valid_counts[0], 4);
-    EXPECT_EQ(valid_counts[1], 6);
+    EXPECT_EQ(column.GetValidCountInChunk(0), 4);
+    EXPECT_EQ(column.GetValidCountInChunk(1), 6);
 }
 
 TEST(test_chunked_column, test_nullable_all_null) {
@@ -272,16 +245,8 @@ TEST(test_chunked_column, test_nullable_all_null) {
 
     column.BuildValidRowIds(nullptr);
 
-    auto& num_valid_rows = column.GetNumValidRowsUntilChunk();
-    ASSERT_EQ(num_valid_rows.size(), num_chunks + 1);
-    // All cumulative valid counts should be 0
-    for (size_t i = 0; i <= num_chunks; i++) {
-        EXPECT_EQ(num_valid_rows[i], 0);
-    }
-
-    auto& valid_counts = column.GetValidCountPerChunk();
     for (size_t i = 0; i < num_chunks; i++) {
-        EXPECT_EQ(valid_counts[i], 0);
+        EXPECT_EQ(column.GetValidCountInChunk(i), 0);
     }
 }
 

--- a/internal/core/src/query/CachedSearchIterator.cpp
+++ b/internal/core/src/query/CachedSearchIterator.cpp
@@ -146,9 +146,8 @@ CachedSearchIterator::CachedSearchIterator(
                           });
             int64_t chunk_size = column->chunk_row_nums(chunk_id);
             const auto& offset_mapping = column->GetOffsetMapping();
-            const auto& valid_count_per_chunk = column->GetValidCountPerChunk();
-            if (offset_mapping.IsEnabled() && !valid_count_per_chunk.empty()) {
-                chunk_size = valid_count_per_chunk[chunk_id];
+            if (offset_mapping.IsEnabled()) {
+                chunk_size = column->GetValidCountInChunk(chunk_id);
             }
             // pw guarantees chunk_data is kept alive.
             auto chunk_data = pw.get();

--- a/internal/core/src/query/SearchOnGrowing.cpp
+++ b/internal/core/src/query/SearchOnGrowing.cpp
@@ -155,14 +155,23 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
         // step 3: brute force search where small indexing is unavailable
         auto vec_ptr = record.get_data_base(vecfield_id);
         const auto& offset_mapping = vec_ptr->get_offset_mapping();
+        const auto has_offset_mapping = offset_mapping.IsEnabled();
 
         TargetBitmap transformed_bitset;
         BitsetView search_bitset = bitset;
-        if (offset_mapping.IsEnabled() && !bitset.empty()) {
-            transformed_bitset = TransformBitset(bitset, offset_mapping);
+        if (has_offset_mapping && !bitset.empty()) {
+            auto status =
+                offset_mapping.TransformBitset(bitset, transformed_bitset);
+            if (status == OffsetMapping::BitsetTransformStatus::AllFiltered) {
+                FillEmptySearchResult(search_result, num_queries, info.topk_);
+                return;
+            }
+            if (status == OffsetMapping::BitsetTransformStatus::NoFilter) {
+                search_bitset = BitsetView{};
+            }
         }
 
-        auto active_count = offset_mapping.IsEnabled()
+        auto active_count = has_offset_mapping
                                 ? offset_mapping.GetValidCount()
                                 : std::min(int64_t(bitset.size()),
                                            segment.get_active_count(timestamp));
@@ -170,14 +179,11 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
         // Check for nullable vector field with all null values
         if (active_count == 0) {
             // All vectors are null, return empty result
-            auto total_num = num_queries * info.topk_;
-            search_result.seg_offsets_.resize(total_num, INVALID_SEG_OFFSET);
-            search_result.distances_.resize(total_num, 0.0f);
-            search_result.total_nq_ = num_queries;
-            search_result.unity_topK_ = info.topk_;
+            FillEmptySearchResult(search_result, num_queries, info.topk_);
             return;
         }
-        if (offset_mapping.IsEnabled() && !bitset.empty()) {
+        if (has_offset_mapping && !bitset.empty() &&
+            !transformed_bitset.empty()) {
             search_bitset =
                 search_result.PinBitset(std::move(transformed_bitset));
         }
@@ -195,9 +201,8 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                                              search_bitset,
                                              data_type);
             cached_iter.NextBatch(info, search_result);
-            if (offset_mapping.IsEnabled()) {
-                TransformOffset(search_result.seg_offsets_, offset_mapping);
-            }
+            FinalizeVectorSearchOffsets(
+                search_result, offset_mapping, info.array_offsets_.get());
             return;
         }
 
@@ -285,6 +290,10 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                            "vector array(embedding list) is not supported for "
                            "vector iterator");
 
+                if (buf != nullptr) {
+                    search_result.chunk_buffers_.emplace_back(std::move(buf));
+                }
+
                 auto sub_qr = PackBruteForceSearchIteratorsIntoSubResult(
                     search_dataset,
                     sub_data,
@@ -311,12 +320,17 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 chunk_rows[i] = i * vec_size_per_chunk;
             }
             bool larger_is_closer = PositivelyRelated(info.metric_type_);
+            // Element-level search skips row-level mapping (element IDs are
+            // not row-aligned); see ChunkMergeIterator ctor.
+            const milvus::OffsetMapping* iter_offset_mapping =
+                (element_level_search || !has_offset_mapping) ? nullptr
+                                                              : &offset_mapping;
             search_result.AssembleChunkVectorIterators(
                 num_queries,
                 max_chunk,
                 chunk_rows,
                 final_qr.chunk_iterators(),
-                offset_mapping,
+                iter_offset_mapping,
                 larger_is_closer);
         } else {
             if (element_level_search) {
@@ -327,11 +341,12 @@ SearchOnGrowing(const segcore::SegmentGrowingImpl& segment,
                 search_result.element_indices_ = std::move(element_indices);
                 search_result.element_level_ = true;
             } else {
+                if (has_offset_mapping) {
+                    offset_mapping.TransformOffsets(
+                        final_qr.mutable_seg_offsets());
+                }
                 search_result.seg_offsets_ =
                     std::move(final_qr.mutable_seg_offsets());
-                if (offset_mapping.IsEnabled()) {
-                    TransformOffset(search_result.seg_offsets_, offset_mapping);
-                }
             }
             search_result.distances_ = std::move(final_qr.mutable_distances());
         }

--- a/internal/core/src/query/SearchOnIndex.cpp
+++ b/internal/core/src/query/SearchOnIndex.cpp
@@ -33,20 +33,26 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
     const auto& offset_mapping = indexing.GetOffsetMapping();
     TargetBitmap transformed_bitset;
     BitsetView search_bitset = bitset;
-    if (offset_mapping.IsEnabled()) {
+    const auto has_offset_mapping = offset_mapping.IsEnabled();
+    if (has_offset_mapping) {
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
-            auto total_num = num_queries * search_conf.topk_;
-            search_result.seg_offsets_.resize(total_num, INVALID_SEG_OFFSET);
-            search_result.distances_.resize(total_num, 0.0f);
-            search_result.total_nq_ = num_queries;
-            search_result.unity_topK_ = search_conf.topk_;
+            FillEmptySearchResult(
+                search_result, num_queries, search_conf.topk_);
             return;
         }
         if (!bitset.empty()) {
-            transformed_bitset = TransformBitset(bitset, offset_mapping);
+            auto status =
+                offset_mapping.TransformBitset(bitset, transformed_bitset);
+            if (status == OffsetMapping::BitsetTransformStatus::AllFiltered) {
+                FillEmptySearchResult(
+                    search_result, num_queries, search_conf.topk_);
+                return;
+            }
             search_bitset =
-                search_result.PinBitset(std::move(transformed_bitset));
+                status == OffsetMapping::BitsetTransformStatus::NoFilter
+                    ? BitsetView{}
+                    : search_result.PinBitset(std::move(transformed_bitset));
         }
     }
 
@@ -63,16 +69,16 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
         auto iter =
             CachedSearchIterator(indexing, dataset, search_conf, search_bitset);
         iter.NextBatch(search_conf, search_result);
-        if (offset_mapping.IsEnabled()) {
-            TransformOffset(search_result.seg_offsets_, offset_mapping);
+        if (has_offset_mapping) {
+            offset_mapping.TransformOffsets(search_result.seg_offsets_);
         }
         return;
     }
 
     indexing.Query(
         dataset, search_conf, search_bitset, op_context, search_result);
-    if (offset_mapping.IsEnabled()) {
-        TransformOffset(search_result.seg_offsets_, offset_mapping);
+    if (has_offset_mapping) {
+        offset_mapping.TransformOffsets(search_result.seg_offsets_);
     }
 }
 

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -78,29 +78,32 @@ SearchOnSealedIndex(const Schema& schema,
     const auto& offset_mapping = vec_index->GetOffsetMapping();
     TargetBitmap transformed_bitset;
     BitsetView search_bitset = bitset;
-    if (offset_mapping.IsEnabled()) {
+    const auto has_offset_mapping = offset_mapping.IsEnabled();
+    if (has_offset_mapping) {
         if (offset_mapping.GetValidCount() == 0) {
-            auto total_num = num_queries * topK;
-            search_result.seg_offsets_.resize(total_num, INVALID_SEG_OFFSET);
-            search_result.distances_.resize(total_num, 0.0f);
-            search_result.total_nq_ = num_queries;
-            search_result.unity_topK_ = topK;
+            FillEmptySearchResult(search_result, num_queries, topK);
             return;
         }
         if (!bitset.empty()) {
-            transformed_bitset = TransformBitset(bitset, offset_mapping);
+            auto status =
+                offset_mapping.TransformBitset(bitset, transformed_bitset);
+            if (status == OffsetMapping::BitsetTransformStatus::AllFiltered) {
+                FillEmptySearchResult(search_result, num_queries, topK);
+                return;
+            }
             search_bitset =
-                search_result.PinBitset(std::move(transformed_bitset));
+                status == OffsetMapping::BitsetTransformStatus::NoFilter
+                    ? BitsetView{}
+                    : search_result.PinBitset(std::move(transformed_bitset));
         }
     }
 
     if (search_info.iterator_v2_info_.has_value()) {
-        AssertInfo(search_info.array_offsets_ == nullptr,
-                   "element-level search is not supported for search iterator");
         CachedSearchIterator cached_iter(
             *vec_index, dataset, search_info, search_bitset);
         cached_iter.NextBatch(search_info, search_result);
-        TransformOffset(search_result.seg_offsets_, offset_mapping);
+        FinalizeVectorSearchOffsets(
+            search_result, offset_mapping, search_info.array_offsets_.get());
         return;
     }
 
@@ -127,29 +130,11 @@ SearchOnSealedIndex(const Schema& schema,
                     std::round(distances[i] * multiplier) / multiplier;
             }
         }
-        if (search_info.array_offsets_ != nullptr) {
-            std::vector<int64_t> element_ids =
-                std::move(search_result.seg_offsets_);
-            search_result.seg_offsets_.resize(element_ids.size());
-            search_result.element_indices_.resize(element_ids.size());
-            for (size_t i = 0; i < element_ids.size(); i++) {
-                if (element_ids[i] == INVALID_SEG_OFFSET) {
-                    search_result.seg_offsets_[i] = INVALID_SEG_OFFSET;
-                    search_result.element_indices_[i] = -1;
-                } else {
-                    auto [doc_id, elem_index] =
-                        search_info.array_offsets_->ElementIDToRowID(
-                            element_ids[i]);
-                    search_result.seg_offsets_[i] = doc_id;
-                    search_result.element_indices_[i] = elem_index;
-                }
-            }
-            search_result.element_level_ = true;
-        }
     }
-    if (!search_result.element_level_) {
-        TransformOffset(search_result.seg_offsets_, offset_mapping);
-    }
+    FinalizeVectorSearchOffsets(
+        search_result,
+        offset_mapping,
+        use_iterator ? nullptr : search_info.array_offsets_.get());
     search_result.total_nq_ = num_queries;
     search_result.unity_topK_ = topK;
 }
@@ -185,26 +170,32 @@ SearchOnSealedColumn(const Schema& schema,
 
     CheckBruteForceSearchParam(field, search_info);
 
+    if (column->IsNullable()) {
+        column->BuildValidRowIds(op_context);
+    }
+
     // Check for nullable vector field with all null values - must be done before creating iterators
     const auto& offset_mapping = column->GetOffsetMapping();
     TargetBitmap transformed_bitset;
     BitsetView search_bitview = bitview;
-    if (offset_mapping.IsEnabled()) {
-        for (int64_t c = 0; c < column->num_chunks(); ++c) {
-            column->EnsureChunkOffsetMapping(c, op_context);
-        }
+    const auto has_offset_mapping = offset_mapping.IsEnabled();
+    if (has_offset_mapping) {
         if (offset_mapping.GetValidCount() == 0) {
             // All vectors are null, return empty result
-            auto total_num = num_queries * search_info.topk_;
-            result.seg_offsets_.resize(total_num, INVALID_SEG_OFFSET);
-            result.distances_.resize(total_num, 0.0f);
-            result.total_nq_ = num_queries;
-            result.unity_topK_ = search_info.topk_;
+            FillEmptySearchResult(result, num_queries, search_info.topk_);
             return;
         }
         if (!bitview.empty()) {
-            transformed_bitset = TransformBitset(bitview, offset_mapping);
-            search_bitview = result.PinBitset(std::move(transformed_bitset));
+            auto status =
+                offset_mapping.TransformBitset(bitview, transformed_bitset);
+            if (status == OffsetMapping::BitsetTransformStatus::AllFiltered) {
+                FillEmptySearchResult(result, num_queries, search_info.topk_);
+                return;
+            }
+            search_bitview =
+                status == OffsetMapping::BitsetTransformStatus::NoFilter
+                    ? BitsetView{}
+                    : result.PinBitset(std::move(transformed_bitset));
         }
     }
 
@@ -220,9 +211,8 @@ SearchOnSealedColumn(const Schema& schema,
                                          search_bitview,
                                          data_type);
         cached_iter.NextBatch(search_info, result);
-        if (offset_mapping.IsEnabled()) {
-            TransformOffset(result.seg_offsets_, offset_mapping);
-        }
+        FinalizeVectorSearchOffsets(
+            result, offset_mapping, search_info.array_offsets_.get());
         return;
     }
 
@@ -246,14 +236,13 @@ SearchOnSealedColumn(const Schema& schema,
 
     int64_t offset = 0;
     auto vector_chunks = column->GetAllChunks(op_context);
-    const auto& valid_count_per_chunk = column->GetValidCountPerChunk();
     for (int i = 0; i < num_chunk; ++i) {
         auto pw = vector_chunks[i];
         auto vec_data = pw.get()->Data();
         auto row_count_in_chunk = column->chunk_row_nums(i);
         auto chunk_size = row_count_in_chunk;
-        if (offset_mapping.IsEnabled() && !valid_count_per_chunk.empty()) {
-            chunk_size = valid_count_per_chunk[i];
+        if (has_offset_mapping) {
+            chunk_size = column->GetValidCountInChunk(i);
         }
         auto raw_dataset =
             query::dataset::RawDataset{offset, dim, chunk_size, vec_data};
@@ -303,11 +292,17 @@ SearchOnSealedColumn(const Schema& schema,
     }
     if (use_vector_iterator) {
         bool larger_is_closer = PositivelyRelated(search_info.metric_type_);
+        // Element-level search skips row-level mapping (element IDs are
+        // not row-aligned); see ChunkMergeIterator ctor.
+        const milvus::OffsetMapping* iter_offset_mapping =
+            (search_info.array_offsets_ != nullptr || !has_offset_mapping)
+                ? nullptr
+                : &offset_mapping;
         result.AssembleChunkVectorIterators(num_queries,
                                             num_chunk,
                                             column->GetNumRowsUntilChunk(),
                                             final_qr.chunk_iterators(),
-                                            offset_mapping,
+                                            iter_offset_mapping,
                                             larger_is_closer);
     } else {
         if (is_element_level_search) {
@@ -318,10 +313,10 @@ SearchOnSealedColumn(const Schema& schema,
             result.element_indices_ = std::move(element_indices);
             result.element_level_ = true;
         } else {
-            result.seg_offsets_ = std::move(final_qr.mutable_seg_offsets());
-            if (offset_mapping.IsEnabled()) {
-                TransformOffset(result.seg_offsets_, offset_mapping);
+            if (has_offset_mapping) {
+                offset_mapping.TransformOffsets(final_qr.mutable_seg_offsets());
             }
+            result.seg_offsets_ = std::move(final_qr.mutable_seg_offsets());
         }
         result.distances_ = std::move(final_qr.mutable_distances());
     }

--- a/internal/core/src/query/Utils.h
+++ b/internal/core/src/query/Utils.h
@@ -13,44 +13,81 @@
 
 #include <limits>
 #include <string>
+#include <utility>
+#include <vector>
 
+#include "common/ArrayOffsets.h"
 #include "common/BitsetView.h"
+#include "common/Consts.h"
 #include "common/OffsetMapping.h"
+#include "common/QueryResult.h"
 #include "common/Types.h"
 #include "common/Utils.h"
 
 namespace milvus::query {
-inline TargetBitmap
-TransformBitset(const BitsetView& bitset,
-                const milvus::OffsetMapping& mapping) {
-    // Empty BitsetView is the Knowhere fast path for "no rows filtered".
-    // Keep it empty after logical-to-physical mapping.
-    if (bitset.empty()) {
-        return {};
-    }
-
-    // bit=true means filtered out. The logical bitset may be shorter than the
-    // full mapping on growing segments because it is sized by query timestamp
-    // visibility. Physical rows outside that logical view are not visible yet.
-    TargetBitmap result;
-    auto count = mapping.GetValidCount();
-    result.resize(count, true);
-    for (int64_t physical_idx = 0; physical_idx < count; physical_idx++) {
-        auto logical_idx = mapping.GetLogicalOffset(physical_idx);
-        if (logical_idx >= 0 &&
-            logical_idx < static_cast<int64_t>(bitset.size())) {
-            result[physical_idx] = bitset.test(logical_idx);
-        }
-    }
-    return result;
+inline void
+FillEmptySearchResult(SearchResult& result, int64_t num_queries, int64_t topk) {
+    auto total_num = num_queries * topk;
+    result.seg_offsets_.resize(total_num, INVALID_SEG_OFFSET);
+    result.distances_.resize(total_num, 0.0f);
+    result.total_nq_ = num_queries;
+    result.unity_topK_ = topk;
 }
 
+// Map logical element IDs returned by knowhere to (doc_id, elem_idx) pairs
+// via ArrayOffsets. Caller must ensure the input `element_ids` are already
+// in logical space (i.e. apply OffsetMapping::TransformOffsets first when
+// offset_mapping is enabled), since ArrayOffsets::ElementIDToRowID is keyed
+// on logical element IDs.
+inline std::pair<std::vector<int64_t>, std::vector<int32_t>>
+ApplyElementIDMapping(const std::vector<int64_t>& element_ids,
+                      const milvus::IArrayOffsets& array_offsets) {
+    std::vector<int64_t> doc_offsets;
+    std::vector<int32_t> element_indices;
+    doc_offsets.reserve(element_ids.size());
+    element_indices.reserve(element_ids.size());
+    for (size_t i = 0; i < element_ids.size(); i++) {
+        if (element_ids[i] == INVALID_SEG_OFFSET) {
+            doc_offsets.push_back(INVALID_SEG_OFFSET);
+            element_indices.push_back(-1);
+        } else {
+            auto [doc_id, elem_index] =
+                array_offsets.ElementIDToRowID(element_ids[i]);
+            doc_offsets.push_back(doc_id);
+            element_indices.push_back(elem_index);
+        }
+    }
+    return std::make_pair(std::move(doc_offsets), std::move(element_indices));
+}
+
+// Map knowhere's raw offsets back to logical space. The two inputs are
+// mutually exclusive:
+//
+// - array_offsets != nullptr (VECTOR_ARRAY element-level search):
+//   knowhere returns physical element IDs. ArrayOffsets is built by
+//   walking every row in the segment and advancing the row counter on
+//   every row (including empty/null rows, which occupy a zero-length
+//   element range), so ElementIDToRowID produces (logical_row_id,
+//   elem_idx) directly. No OffsetMapping pass is needed.
+//
+// - array_offsets == nullptr (plain vector field): when OffsetMapping is
+//   enabled, the index/chunk was built over valid rows only, so
+//   knowhere's physical row IDs must be remapped to logical via
+//   OffsetMapping. When OffsetMapping is disabled, TransformOffsets is a
+//   no-op.
 inline void
-TransformOffset(std::vector<int64_t>& seg_offsets,
-                const milvus::OffsetMapping& mapping) {
-    for (auto& seg_offset : seg_offsets) {
-        if (seg_offset >= 0) {
-            seg_offset = mapping.GetLogicalOffset(seg_offset);
+FinalizeVectorSearchOffsets(SearchResult& result,
+                            const milvus::OffsetMapping& offset_mapping,
+                            const milvus::IArrayOffsets* array_offsets) {
+    if (array_offsets != nullptr) {
+        auto [doc_offsets, elem_indices] =
+            ApplyElementIDMapping(result.seg_offsets_, *array_offsets);
+        result.seg_offsets_ = std::move(doc_offsets);
+        result.element_indices_ = std::move(elem_indices);
+        result.element_level_ = true;
+    } else {
+        if (offset_mapping.IsEnabled()) {
+            offset_mapping.TransformOffsets(result.seg_offsets_);
         }
     }
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -931,70 +931,52 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
 }
 
 ChunkedSegmentSealedImpl::ValidResult
-ChunkedSegmentSealedImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
-                                                   FieldId field_id,
-                                                   const int64_t* seg_offsets,
-                                                   int64_t count) const {
+ChunkedSegmentSealedImpl::FilterVectorValidOffsetsFromIndex(
+    milvus::OpContext* op_ctx,
+    FieldId field_id,
+    const int64_t* seg_offsets,
+    int64_t count) const {
     ValidResult result;
     result.valid_count = count;
 
-    bool got_valid_offsets_from_index = false;
-    if (vector_indexings_.is_ready(field_id)) {
-        auto field_indexing = vector_indexings_.get_field_indexing(field_id);
-        auto cache_index = field_indexing->indexing_;
-        auto ca = SemiInlineGet(cache_index->PinCells(op_ctx, {0}));
-        auto vec_index = dynamic_cast<index::VectorIndex*>(ca->get_cell_of(0));
+    AssertInfo(vector_indexings_.is_ready(field_id),
+               "vector index is not ready");
+    auto field_indexing = vector_indexings_.get_field_indexing(field_id);
+    auto cache_index = field_indexing->indexing_;
+    auto ca = SemiInlineGet(cache_index->PinCells(op_ctx, {0}));
+    auto vec_index = dynamic_cast<index::VectorIndex*>(ca->get_cell_of(0));
+    AssertInfo(vec_index != nullptr, "invalid vector indexing");
+    AssertInfo(vec_index->HasValidData(),
+               "nullable vector index does not contain valid data");
 
-        if (vec_index != nullptr && vec_index->HasValidData()) {
-            result.valid_data = std::make_unique<bool[]>(count);
-            result.valid_offsets.reserve(count);
+    result.valid_data = std::make_unique<bool[]>(count);
+    vec_index->GetOffsetMapping().FilterValidLogicalOffsets(
+        seg_offsets, count, result.valid_data.get(), result.valid_offsets);
+    result.valid_count = result.valid_offsets.size();
+    return result;
+}
 
-            for (int64_t i = 0; i < count; ++i) {
-                bool is_valid = vec_index->IsRowValid(seg_offsets[i]);
-                result.valid_data[i] = is_valid;
-                if (is_valid) {
-                    int64_t physical_offset =
-                        vec_index->GetPhysicalOffset(seg_offsets[i]);
-                    if (physical_offset >= 0) {
-                        result.valid_offsets.push_back(physical_offset);
-                    }
-                }
+ChunkedSegmentSealedImpl::ValidResult
+ChunkedSegmentSealedImpl::FilterVectorValidOffsetsFromColumn(
+    milvus::OpContext* op_ctx,
+    const ChunkedColumnInterface* column,
+    const int64_t* seg_offsets,
+    int64_t count) const {
+    ValidResult result;
+    result.valid_data = std::make_unique<bool[]>(count);
+    result.valid_offsets.reserve(count);
+
+    column->BulkIsValid(
+        op_ctx,
+        [&](bool is_valid, size_t offset) {
+            result.valid_data[offset] = is_valid;
+            if (is_valid) {
+                result.valid_offsets.push_back(seg_offsets[offset]);
             }
-            result.valid_count = result.valid_offsets.size();
-            got_valid_offsets_from_index = true;
-        }
-    }
-
-    if (!got_valid_offsets_from_index) {
-        auto column = get_column(field_id);
-        if (column != nullptr && column->IsNullable()) {
-            result.valid_data = std::make_unique<bool[]>(count);
-            result.valid_offsets.reserve(count);
-
-            std::unordered_set<int64_t> touched_chunks;
-            for (int64_t i = 0; i < count; ++i) {
-                auto [chunk_id, _] = column->GetChunkIDByOffset(seg_offsets[i]);
-                touched_chunks.insert(static_cast<int64_t>(chunk_id));
-            }
-            for (int64_t c : touched_chunks) {
-                column->EnsureChunkOffsetMapping(c, op_ctx);
-            }
-
-            const auto& offset_mapping = column->GetOffsetMapping();
-            for (int64_t i = 0; i < count; ++i) {
-                bool is_valid = offset_mapping.IsValid(seg_offsets[i]);
-                result.valid_data[i] = is_valid;
-                if (is_valid) {
-                    int64_t physical_offset =
-                        offset_mapping.GetPhysicalOffset(seg_offsets[i]);
-                    if (physical_offset >= 0) {
-                        result.valid_offsets.push_back(physical_offset);
-                    }
-                }
-            }
-            result.valid_count = result.valid_offsets.size();
-        }
-    }
+        },
+        seg_offsets,
+        count);
+    result.valid_count = result.valid_offsets.size();
     return result;
 }
 
@@ -1030,8 +1012,18 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
         int64_t valid_count = count;
         const bool* valid_data = nullptr;
         if (field_meta.is_nullable()) {
+            if (!vec_index->HasValidData()) {
+                auto column = get_column(field_id);
+                if (column != nullptr) {
+                    return get_raw_data(
+                        op_ctx, field_id, field_meta, ids, count);
+                }
+                ThrowInfo(ErrorCode::UnexpectedError,
+                          "nullable vector index has raw data but no valid "
+                          "data, and field data is unavailable");
+            }
             filter_result =
-                FilterVectorValidOffsets(op_ctx, field_id, ids, count);
+                FilterVectorValidOffsetsFromIndex(op_ctx, field_id, ids, count);
             ids_ds = GenIdsDataset(filter_result.valid_count,
                                    filter_result.valid_offsets.data());
             valid_count = filter_result.valid_count;
@@ -1953,9 +1945,11 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
     const int64_t* valid_offsets = seg_offsets;
     ValidResult filter_result;
 
-    if (field_meta.is_vector() && field_meta.is_nullable()) {
-        filter_result =
-            FilterVectorValidOffsets(op_ctx, field_id, seg_offsets, count);
+    const bool nullable_vector =
+        field_meta.is_vector() && field_meta.is_nullable();
+    if (nullable_vector) {
+        filter_result = FilterVectorValidOffsetsFromColumn(
+            op_ctx, column.get(), seg_offsets, count);
         valid_count = filter_result.valid_count;
         valid_data = filter_result.valid_data.get();
         valid_offsets = filter_result.valid_offsets.data();
@@ -2185,12 +2179,31 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
             break;
         }
         case DataType::VECTOR_ARRAY: {
-            bulk_subscript_vector_array_impl(
-                op_ctx,
-                column.get(),
-                valid_offsets,
-                valid_count,
-                ret->mutable_vectors()->mutable_vector_array()->mutable_data());
+            auto dst =
+                ret->mutable_vectors()->mutable_vector_array()->mutable_data();
+            if (nullable_vector) {
+                if (valid_count == 0) {
+                    break;
+                }
+                std::vector<int64_t> valid_logical_offsets;
+                valid_logical_offsets.reserve(valid_count);
+                for (int64_t i = 0; i < count; ++i) {
+                    if (valid_data[i]) {
+                        valid_logical_offsets.push_back(i);
+                    }
+                }
+                column->BulkVectorArrayAt(
+                    op_ctx,
+                    [dst, &valid_logical_offsets](VectorFieldProto&& array,
+                                                  size_t i) {
+                        dst->at(valid_logical_offsets[i]) = std::move(array);
+                    },
+                    valid_offsets,
+                    valid_count);
+            } else {
+                bulk_subscript_vector_array_impl(
+                    op_ctx, column.get(), seg_offsets, count, dst);
+            }
             break;
         }
         default: {
@@ -2505,7 +2518,8 @@ ChunkedSegmentSealedImpl::mask_with_timestamps(BitsetTypeView& bitset_chunk,
 
 bool
 ChunkedSegmentSealedImpl::generate_interim_index(const FieldId field_id,
-                                                 int64_t num_rows) {
+                                                 int64_t num_rows,
+                                                 milvus::OpContext* op_ctx) {
     if (col_index_meta_ == nullptr || !col_index_meta_->HasField(field_id)) {
         return false;
     }
@@ -2552,9 +2566,15 @@ ChunkedSegmentSealedImpl::generate_interim_index(const FieldId field_id,
         std::shared_ptr<ChunkedColumnInterface> vec_data = get_column(field_id);
         AssertInfo(
             vec_data != nullptr, "vector field {} not loaded", field_id.get());
-        int64_t row_count = field_meta.is_nullable()
-                                ? vec_data->GetOffsetMapping().GetValidCount()
-                                : num_rows;
+        int64_t row_count = num_rows;
+        if (field_meta.is_nullable()) {
+            vec_data->BuildValidRowIds(op_ctx);
+            const auto& offset_mapping = vec_data->GetOffsetMapping();
+            if (!offset_mapping.IsEnabled()) {
+                return false;
+            }
+            row_count = offset_mapping.GetValidCount();
+        }
 
         // generate index params
         auto field_binlog_config = std::unique_ptr<VecIndexConfig>(
@@ -2681,10 +2701,6 @@ ChunkedSegmentSealedImpl::load_field_data_common(
         return;
     }
 
-    if (column->IsNullable() && IsVectorDataType(data_type)) {
-        column->BuildValidRowIds(op_ctx);
-    }
-
     if (!enable_mmap) {
         if (!is_proxy_column ||
             is_proxy_column &&
@@ -2709,7 +2725,10 @@ ChunkedSegmentSealedImpl::load_field_data_common(
         insert_record_.seal_pks();
     }
 
-    bool generated_interim_index = generate_interim_index(field_id, num_rows);
+    // now interim index does not touch column warmup
+    bool generated_interim_index =
+        generate_interim_index(field_id, num_rows, op_ctx);
+
     std::string struct_name;
     const FieldMeta* field_meta_ptr = nullptr;
     bool should_drop_field_data = false;
@@ -2962,44 +2981,7 @@ ChunkedSegmentSealedImpl::fill_empty_field(const FieldMeta& field_meta) {
             mmap_config.GetMmapPopulate());
     auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot(
         std::move(translator), nullptr);
-    std::shared_ptr<milvus::ChunkedColumnBase> column{};
-    switch (field_meta.get_data_type()) {
-        case milvus::DataType::STRING:
-        case milvus::DataType::VARCHAR:
-        case milvus::DataType::TEXT: {
-            column = std::make_shared<ChunkedVariableColumn<std::string>>(
-                std::move(slot), field_meta);
-            break;
-        }
-        case milvus::DataType::JSON: {
-            column = std::make_shared<ChunkedVariableColumn<milvus::Json>>(
-                std::move(slot), field_meta);
-            break;
-        }
-        case milvus::DataType::GEOMETRY: {
-            column = std::make_shared<ChunkedVariableColumn<std::string>>(
-                std::move(slot), field_meta);
-            break;
-        }
-        case milvus::DataType::ARRAY: {
-            column = std::make_shared<ChunkedArrayColumn>(std::move(slot),
-                                                          field_meta);
-            break;
-        }
-        case milvus::DataType::VECTOR_ARRAY: {
-            column = std::make_shared<ChunkedVectorArrayColumn>(std::move(slot),
-                                                                field_meta);
-            break;
-        }
-        default: {
-            column =
-                std::make_shared<ChunkedColumn>(std::move(slot), field_meta);
-            break;
-        }
-    }
-    if (column->IsNullable() && IsVectorDataType(data_type)) {
-        column->BuildValidRowIds(nullptr);
-    }
+    auto column = MakeChunkedColumnBase(data_type, std::move(slot), field_meta);
 
     fields_.wlock()->emplace(field_id, column);
     set_bit(field_data_ready_bitset_, field_id, true);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -909,10 +909,16 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     };
 
     ValidResult
-    FilterVectorValidOffsets(milvus::OpContext* op_ctx,
-                             FieldId field_id,
-                             const int64_t* seg_offsets,
-                             int64_t count) const;
+    FilterVectorValidOffsetsFromIndex(milvus::OpContext* op_ctx,
+                                      FieldId field_id,
+                                      const int64_t* seg_offsets,
+                                      int64_t count) const;
+
+    ValidResult
+    FilterVectorValidOffsetsFromColumn(milvus::OpContext* op_ctx,
+                                       const ChunkedColumnInterface* column,
+                                       const int64_t* seg_offsets,
+                                       int64_t count) const;
 
     void
     update_row_count(int64_t row_count) {
@@ -955,7 +961,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     LoadScalarIndex(const LoadIndexInfo& info);
 
     bool
-    generate_interim_index(const FieldId field_id, int64_t num_rows);
+    generate_interim_index(const FieldId field_id,
+                           int64_t num_rows,
+                           milvus::OpContext* op_ctx);
 
     void
     fill_empty_field(const FieldMeta& field_meta);

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -538,10 +538,8 @@ TEST(test_chunk_segment, TestSearchIteratorOnSealedWithPartialNullVectors) {
     // 50% valid: 50 per chunk * 2 chunks = 100
     ASSERT_EQ(offset_mapping.GetValidCount(), total_valid);
 
-    const auto& valid_count_per_chunk = column->GetValidCountPerChunk();
-    ASSERT_EQ(valid_count_per_chunk.size(), chunk_num);
     for (int i = 0; i < chunk_num; i++) {
-        ASSERT_EQ(valid_count_per_chunk[i], valid_per_chunk);
+        ASSERT_EQ(column->GetValidCountInChunk(i), valid_per_chunk);
     }
 
     SearchInfo search_info;

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -526,7 +526,7 @@ class ConcurrentVectorImpl : public VectorBase {
     ThreadSafeValidDataPtr valid_data_ptr_ = nullptr;
 
     const bool use_mapping_storage_;
-    milvus::OffsetMapping offset_mapping_;
+    milvus::GrowingOffsetMapping offset_mapping_;
 };
 
 template <typename Type>

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -2091,19 +2091,11 @@ SegmentGrowingImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
 
         if (vec_index != nullptr && vec_index->HasValidData()) {
             result.valid_data = std::make_unique<bool[]>(count);
-            result.valid_offsets.reserve(count);
-
-            for (int64_t i = 0; i < count; ++i) {
-                bool is_valid = vec_index->IsRowValid(seg_offsets[i]);
-                result.valid_data[i] = is_valid;
-                if (is_valid) {
-                    int64_t physical_offset =
-                        vec_index->GetPhysicalOffset(seg_offsets[i]);
-                    if (physical_offset >= 0) {
-                        result.valid_offsets.push_back(physical_offset);
-                    }
-                }
-            }
+            vec_index->GetOffsetMapping().FilterValidLogicalOffsets(
+                seg_offsets,
+                count,
+                result.valid_data.get(),
+                result.valid_offsets);
             result.valid_count = result.valid_offsets.size();
         }
     } else {
@@ -2113,23 +2105,22 @@ SegmentGrowingImpl::FilterVectorValidOffsets(milvus::OpContext* op_ctx,
             bool is_mapping_storage = vec_base->is_mapping_storage();
             if (!valid_data_vec.empty()) {
                 result.valid_data = std::make_unique<bool[]>(count);
-                result.valid_offsets.reserve(count);
 
-                for (int64_t i = 0; i < count; ++i) {
-                    auto offset = seg_offsets[i];
-                    bool is_valid =
-                        offset >= 0 &&
-                        offset < static_cast<int64_t>(valid_data_vec.size()) &&
-                        valid_data_vec[offset];
-                    result.valid_data[i] = is_valid;
-                    if (is_valid) {
-                        if (is_mapping_storage) {
-                            int64_t physical_offset =
-                                vec_base->get_physical_offset(offset);
-                            if (physical_offset >= 0) {
-                                result.valid_offsets.push_back(physical_offset);
-                            }
-                        }
+                if (is_mapping_storage) {
+                    vec_base->get_offset_mapping().FilterValidLogicalOffsets(
+                        seg_offsets,
+                        count,
+                        result.valid_data.get(),
+                        result.valid_offsets);
+                } else {
+                    result.valid_offsets.reserve(count);
+                    for (int64_t i = 0; i < count; ++i) {
+                        auto offset = seg_offsets[i];
+                        bool is_valid = offset >= 0 &&
+                                        offset < static_cast<int64_t>(
+                                                     valid_data_vec.size()) &&
+                                        valid_data_vec[offset];
+                        result.valid_data[i] = is_valid;
                     }
                 }
                 result.valid_count = result.valid_offsets.size();

--- a/internal/core/src/segcore/UtilsTest.cpp
+++ b/internal/core/src/segcore/UtilsTest.cpp
@@ -198,8 +198,8 @@ TEST(Util_Segcore, TransformBitsetMasksNullableVectorRowsOutsideLogicalView) {
     using namespace milvus;
 
     std::array<bool, 3> valid_data = {true, true, true};
-    OffsetMapping mapping;
-    mapping.Build(valid_data.data(), valid_data.size());
+    GrowingOffsetMapping mapping;
+    mapping.Append(valid_data.data(), valid_data.size(), 0, 0);
 
     // Growing search passes a logical bitset sized by the query timestamp's
     // active row count. Rows beyond that logical view are not visible yet and
@@ -207,8 +207,10 @@ TEST(Util_Segcore, TransformBitsetMasksNullableVectorRowsOutsideLogicalView) {
     BitsetType logical_bitset(2);
     BitsetView logical_view(logical_bitset);
 
-    auto physical_bitset = query::TransformBitset(logical_view, mapping);
+    TargetBitmap physical_bitset;
+    auto status = mapping.TransformBitset(logical_view, physical_bitset);
 
+    EXPECT_EQ(status, OffsetMapping::BitsetTransformStatus::Transformed);
     ASSERT_EQ(physical_bitset.size(), 3);
     EXPECT_FALSE(physical_bitset[0]);
     EXPECT_FALSE(physical_bitset[1]);
@@ -218,12 +220,15 @@ TEST(Util_Segcore, TransformBitsetMasksNullableVectorRowsOutsideLogicalView) {
 TEST(Util_Segcore, TransformBitsetKeepsEmptyViewAsNoFilter) {
     using namespace milvus;
 
-    std::array<bool, 3> valid_data = {true, false, true};
-    OffsetMapping mapping;
+    std::array<bool, 3> valid_data = {true, true, true};
+    SealedOffsetMapping mapping;
     mapping.Build(valid_data.data(), valid_data.size());
 
-    auto physical_bitset = query::TransformBitset(BitsetView{}, mapping);
+    BitsetView all_visible;
+    TargetBitmap physical_bitset;
+    auto status = mapping.TransformBitset(all_visible, physical_bitset);
 
+    EXPECT_EQ(status, OffsetMapping::BitsetTransformStatus::NoFilter);
     EXPECT_TRUE(physical_bitset.empty());
 }
 

--- a/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
@@ -1,11 +1,31 @@
 #include "segcore/storagev1translator/InterimSealedIndexTranslator.h"
 
+#include <algorithm>
+#include <exception>
+#include <map>
+#include <memory>
+#include <optional>
+#include <type_traits>
+
+#include "cachinglayer/CacheSlot.h"
+#include "common/Chunk.h"
+#include "common/OffsetMapping.h"
+#include "fmt/core.h"
+#include "folly/FBVector.h"
+#include "index/Index.h"
+#include "index/Utils.h"
+#include "index/VectorIndex.h"
 #include "index/VectorMemIndex.h"
-#include "segcore/Utils.h"
+#include "knowhere/dataset.h"
+#include "knowhere/expected.h"
+#include "knowhere/object.h"
+#include "knowhere/operands.h"
+#include "knowhere/version.h"
+#include "mmap/ChunkedColumnInterface.h"
+#include "nlohmann/json.hpp"
 #include "segcore/Utils.h"
 
 namespace milvus::segcore::storagev1translator {
-
 InterimSealedIndexTranslator::InterimSealedIndexTranslator(
     std::shared_ptr<ChunkedColumnInterface> vec_data,
     int64_t segment_id,
@@ -101,20 +121,43 @@ InterimSealedIndexTranslator::get_cells(
         ctx, segment_id_, "InterimSealedIndexTranslator::get_cells()");
 
     std::unique_ptr<index::VectorIndex> vec_index = nullptr;
-    if (!is_sparse_) {
-        knowhere::ViewDataOp view_data = [field_raw_data_ptr =
-                                              vec_data_](size_t id) {
-            const void* data;
-            int64_t data_id = id;
+    auto num_chunk = vec_data_->num_chunks();
+    if (vec_data_->IsNullable()) {
+        vec_data_->BuildValidRowIds(ctx);
+    }
+    const auto& offset_mapping = vec_data_->GetOffsetMapping();
+    bool nullable = offset_mapping.IsEnabled();
 
-            field_raw_data_ptr->BulkValueAt(
-                nullptr,
-                [&data, &data_id](const char* value, size_t i) {
-                    data = static_cast<const void*>(value);
-                },
-                &data_id,
-                1);
-            return data;
+    if (!is_sparse_) {
+        auto rows_until_chunk = std::make_shared<std::vector<int64_t>>();
+        rows_until_chunk->reserve(num_chunk + 1);
+        rows_until_chunk->push_back(0);
+        for (int64_t chunk_id = 0; chunk_id < num_chunk; ++chunk_id) {
+            const auto chunk_rows =
+                nullable ? vec_data_->GetValidCountInChunk(chunk_id)
+                         : vec_data_->chunk_row_nums(chunk_id);
+            rows_until_chunk->push_back(rows_until_chunk->back() + chunk_rows);
+        }
+
+        knowhere::ViewDataOp view_data = [field_raw_data_ptr = vec_data_,
+                                          rows_until_chunk,
+                                          num_chunk](size_t id) {
+            auto compact_offset = static_cast<int64_t>(id);
+            auto it = std::upper_bound(rows_until_chunk->begin(),
+                                       rows_until_chunk->end(),
+                                       compact_offset);
+            AssertInfo(it != rows_until_chunk->begin(),
+                       "Compact offset {} is out of range",
+                       id);
+            const auto chunk_id =
+                std::distance(rows_until_chunk->begin(), it) - 1;
+            AssertInfo(
+                chunk_id < num_chunk, "Compact offset {} is out of range", id);
+            compact_offset -= (*rows_until_chunk)[chunk_id];
+
+            auto pw = field_raw_data_ptr->GetChunk(nullptr, chunk_id);
+            auto chunk = pw.get();
+            return static_cast<const void*>(chunk->ValueAt(compact_offset));
         };
 
         if (vec_data_type_ == DataType::VECTOR_FLOAT) {
@@ -152,16 +195,6 @@ InterimSealedIndexTranslator::get_cells(
             false);
     }
 
-    auto num_chunk = vec_data_->num_chunks();
-    // Interim index is a scan-the-world consumer: needs full valid_data_.
-    if (vec_data_->IsNullable() && vec_data_->GetValidData().empty()) {
-        vec_data_->BuildValidRowIds(ctx);
-    }
-    const auto& offset_mapping = vec_data_->GetOffsetMapping();
-    bool nullable = offset_mapping.IsEnabled();
-    const auto& valid_count_per_chunk =
-        nullable ? vec_data_->GetValidCountPerChunk() : std::vector<int64_t>{};
-
     int64_t total_valid_count =
         nullable ? offset_mapping.GetValidCount() : vec_data_->NumRows();
 
@@ -181,8 +214,8 @@ InterimSealedIndexTranslator::get_cells(
         auto pw = vec_data_->GetChunk(nullptr, i);
         auto chunk = pw.get();
 
-        int64_t actual_row_count =
-            nullable ? valid_count_per_chunk[i] : vec_data_->chunk_row_nums(i);
+        int64_t actual_row_count = nullable ? vec_data_->GetValidCountInChunk(i)
+                                            : vec_data_->chunk_row_nums(i);
 
         if (actual_row_count == 0) {
             continue;


### PR DESCRIPTION
## Summary
- Cherrypick nullable vector lazy offset mapping fixes from #50085 to 2.6.
- Keep growing nullable-vector offset mapping stable during valid-data updates and use lock-free sealed offset mapping.
- Batch nullable-vector bitset/offset conversion and skip conversion for fast-path/non-nullable cases.
- Store nullable fixed-width vector Arrow schema fields as binary with dimension metadata.

pr: #50085
issue: #50122

Note: source master PR #50085 is currently open, so the release gate may wait for it to merge.

## Test plan
- [x] `git diff --check upstream/2.6..HEAD`
- [x] `make cppcheck`
- [x] `env CONAN_CMD=/tmp/conan1 make build-cpp-with-unittest`
- [x] `env LD_LIBRARY_PATH=cmake_build/src:cmake_build/lib:internal/core/output/lib cmake_build/bin/all_tests --gtest_filter=OffsetMapping.*:SchemaTest.NullableFixedWidthVectorUsesBinaryInArrowSchemas:ChunkedColumnInterfaceTest*.*:ChunkedColumnTest.*:ChunkedColumnGroupTest.*:SearchOnSealedColumnBitsetLifetime.*:SearchOnSealedIndexNullableNoFilter.*:SearchOnSealedIndexNullableIteratorNoFilter.*`