### PR TITLE
enhance: build text index inline in mixcompaction

### DIFF
--- a/internal/datacoord/compaction_inspector.go
+++ b/internal/datacoord/compaction_inspector.go
@@ -588,7 +588,7 @@ func (c *compactionInspector) createCompactTask(t *datapb.CompactionTask) (Compa
 	case datapb.CompactionType_Level0DeleteCompaction:
 		task = newL0CompactionTask(t, c.allocator, c.meta)
 	case datapb.CompactionType_ClusteringCompaction:
-		task = newClusteringCompactionTask(t, c.allocator, c.meta, c.handler, c.analyzeScheduler)
+		task = newClusteringCompactionTask(t, c.allocator, c.meta, c.handler, c.analyzeScheduler, c.ievm)
 	case datapb.CompactionType_BumpSchemaVersionCompaction:
 		task = newBumpSchemaVersionTask(t, c.allocator, c.meta, c.ievm)
 	default:

--- a/internal/datacoord/compaction_inspector_test.go
+++ b/internal/datacoord/compaction_inspector_test.go
@@ -441,7 +441,7 @@ func (s *CompactionPlanHandlerSuite) TestSchedule_BumpSchemaVersionBlocksCluster
 		Channel:     "ch-1",
 		PartitionID: 10,
 		NodeID:      102,
-	}, nil, s.mockMeta, s.mockHandler, nil)))
+	}, nil, s.mockMeta, s.mockHandler, nil, newMockVersionManager())))
 
 	gotTasks := s.handler.schedule()
 	s.Equal([]UniqueID{1}, lo.Map(gotTasks, func(t CompactionTask, _ int) int64 {
@@ -911,7 +911,7 @@ func (s *CompactionPlanHandlerSuite) TestCleanClusteringCompaction() {
 			NodeID:        1,
 			InputSegments: []UniqueID{1, 2},
 		},
-		nil, s.mockMeta, s.mockHandler, nil)
+		nil, s.mockMeta, s.mockHandler, nil, newMockVersionManager())
 	s.mockMeta.EXPECT().GetHealthySegment(mock.Anything, mock.Anything).Return(nil)
 	s.mockMeta.EXPECT().SetSegmentsCompacting(mock.Anything, mock.Anything, mock.Anything).Return().Once()
 	s.mockMeta.EXPECT().UpdateSegmentsInfo(mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -958,7 +958,7 @@ func (s *CompactionPlanHandlerSuite) TestCleanClusteringCompactionCommitFail() {
 			IsClusteringKey: true,
 		},
 	},
-		nil, s.mockMeta, s.mockHandler, nil)
+		nil, s.mockMeta, s.mockHandler, nil, newMockVersionManager())
 
 	s.mockMeta.EXPECT().GetHealthySegment(mock.Anything, mock.Anything).Return(nil)
 	s.mockMeta.EXPECT().SaveCompactionTask(mock.Anything, mock.Anything).Return(nil)
@@ -1008,7 +1008,7 @@ func (s *CompactionPlanHandlerSuite) TestKeepClean() {
 				NodeID:        1,
 				InputSegments: []UniqueID{1, 2},
 			},
-				nil, s.mockMeta, s.mockHandler, nil),
+				nil, s.mockMeta, s.mockHandler, nil, newMockVersionManager()),
 		},
 	}
 	for _, test := range tests {
@@ -1102,7 +1102,7 @@ func TestCheckDelay(t *testing.T) {
 	handler.checkDelay(t2)
 	t3 := newClusteringCompactionTask(&datapb.CompactionTask{
 		StartTime: time.Now().Add(-100 * time.Minute).Unix(),
-	}, nil, nil, nil, nil)
+	}, nil, nil, nil, nil, newMockVersionManager())
 	handler.checkDelay(t3)
 	t4 := newBumpSchemaVersionTask(&datapb.CompactionTask{
 		StartTime: time.Now().Add(-100 * time.Minute).Unix(),
@@ -1131,7 +1131,7 @@ func TestGetCompactionTasksNum(t *testing.T) {
 			StartTime:    time.Now().Add(-100 * time.Minute).Unix(),
 			CollectionID: 10,
 			Type:         datapb.CompactionType_ClusteringCompaction,
-		}, nil, nil, nil, nil),
+		}, nil, nil, nil, nil, newMockVersionManager()),
 	)
 	executingTasks := make(map[int64]CompactionTask, 0)
 	executingTasks[1] = newMixCompactionTask(&datapb.CompactionTask{

--- a/internal/datacoord/compaction_task_clustering.go
+++ b/internal/datacoord/compaction_task_clustering.go
@@ -34,6 +34,7 @@ import (
 	globalTask "github.com/milvus-io/milvus/internal/datacoord/task"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/fileresource"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -57,6 +58,7 @@ type clusteringCompactionTask struct {
 	meta             CompactionMeta
 	handler          Handler
 	analyzeScheduler globalTask.GlobalScheduler
+	ievm             IndexEngineVersionManager
 
 	maxRetryTimes int32
 
@@ -240,12 +242,13 @@ func (t *clusteringCompactionTask) GetTaskProto() *datapb.CompactionTask {
 	return task.(*datapb.CompactionTask)
 }
 
-func newClusteringCompactionTask(t *datapb.CompactionTask, allocator allocator.Allocator, meta CompactionMeta, handler Handler, analyzeScheduler globalTask.GlobalScheduler) *clusteringCompactionTask {
+func newClusteringCompactionTask(t *datapb.CompactionTask, allocator allocator.Allocator, meta CompactionMeta, handler Handler, analyzeScheduler globalTask.GlobalScheduler, ievm IndexEngineVersionManager) *clusteringCompactionTask {
 	task := &clusteringCompactionTask{
 		allocator:        allocator,
 		meta:             meta,
 		handler:          handler,
 		analyzeScheduler: analyzeScheduler,
+		ievm:             ievm,
 		maxRetryTimes:    3,
 		times:            taskcommon.NewTimes(),
 	}
@@ -344,24 +347,40 @@ func (t *clusteringCompactionTask) BuildCompactionRequest() (*datapb.CompactionP
 		return nil, err
 	}
 	plan := &datapb.CompactionPlan{
-		PlanID:                 taskProto.GetPlanID(),
-		StartTime:              taskProto.GetStartTime(),
-		Type:                   taskProto.GetType(),
-		Channel:                taskProto.GetChannel(),
-		CollectionTtl:          taskProto.GetCollectionTtl(),
-		TotalRows:              taskProto.GetTotalRows(),
-		Schema:                 taskProto.GetSchema(),
-		ClusteringKeyField:     taskProto.GetClusteringKeyField().GetFieldID(),
-		MaxSegmentRows:         taskProto.GetMaxSegmentRows(),
-		PreferSegmentRows:      taskProto.GetPreferSegmentRows(),
-		AnalyzeResultPath:      path.Join(t.meta.(*meta).chunkManager.RootPath(), common.AnalyzeStatsPath, metautil.JoinIDPath(taskProto.AnalyzeTaskID, taskProto.AnalyzeVersion)),
-		AnalyzeSegmentIds:      taskProto.GetInputSegments(),
-		BeginLogID:             logIDRange.Begin, // BeginLogID is deprecated, but still assign it for compatibility.
-		PreAllocatedSegmentIDs: taskProto.GetPreAllocatedSegmentIDs(),
-		PreAllocatedLogIDs:     logIDRange,
-		SlotUsage:              t.GetSlotUsage(),
-		MaxSize:                taskProto.GetMaxSize(),
-		JsonParams:             compactionParams,
+		PlanID:                    taskProto.GetPlanID(),
+		StartTime:                 taskProto.GetStartTime(),
+		Type:                      taskProto.GetType(),
+		Channel:                   taskProto.GetChannel(),
+		CollectionTtl:             taskProto.GetCollectionTtl(),
+		TotalRows:                 taskProto.GetTotalRows(),
+		Schema:                    taskProto.GetSchema(),
+		ClusteringKeyField:        taskProto.GetClusteringKeyField().GetFieldID(),
+		MaxSegmentRows:            taskProto.GetMaxSegmentRows(),
+		PreferSegmentRows:         taskProto.GetPreferSegmentRows(),
+		AnalyzeResultPath:         path.Join(t.meta.(*meta).chunkManager.RootPath(), common.AnalyzeStatsPath, metautil.JoinIDPath(taskProto.AnalyzeTaskID, taskProto.AnalyzeVersion)),
+		AnalyzeSegmentIds:         taskProto.GetInputSegments(),
+		BeginLogID:                logIDRange.Begin, // BeginLogID is deprecated, but still assign it for compatibility.
+		PreAllocatedSegmentIDs:    taskProto.GetPreAllocatedSegmentIDs(),
+		PreAllocatedLogIDs:        logIDRange,
+		SlotUsage:                 t.GetSlotUsage(),
+		MaxSize:                   taskProto.GetMaxSize(),
+		JsonParams:                compactionParams,
+		CurrentScalarIndexVersion: t.ievm.ResolveScalarIndexVersion(),
+	}
+
+	// set analyzer resource for text match index if use ref mode.
+	// Namespace-enabled clustering compaction is routed to the namespace compactor on the
+	// DataNode, which builds the text index inline and needs the analyzer resources.
+	taskSchema := taskProto.GetSchema()
+	if fileresource.IsRefMode(paramtable.Get().CommonCfg.DNFileResourceMode.GetValue()) &&
+		taskSchema.GetEnableNamespace() &&
+		len(taskSchema.GetFileResourceIds()) > 0 {
+		resources, err := t.meta.GetFileResources(context.Background(), taskSchema.GetFileResourceIds()...)
+		if err != nil {
+			mlog.Warn(context.TODO(), "get file resources for clustering compaction failed", mlog.Int64("collectionID", taskProto.GetCollectionID()), mlog.Err(err))
+			return nil, merr.Wrap(err, "get file resources for compaction failed")
+		}
+		plan.FileResources = resources
 	}
 
 	for _, segID := range taskProto.GetInputSegments() {

--- a/internal/datacoord/compaction_task_clustering_test.go
+++ b/internal/datacoord/compaction_task_clustering_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
@@ -41,8 +42,10 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metautil"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func TestClusteringCompactionTaskSuite(t *testing.T) {
@@ -347,9 +350,85 @@ func (s *ClusteringCompactionTaskSuite) generateBasicTask(vectorClusteringKey bo
 		ResultSegments:     []int64{1000, 1100},
 	}
 
-	task := newClusteringCompactionTask(compactionTask, s.mockAlloc, s.meta, s.handler, s.analyzeScheduler)
+	task := newClusteringCompactionTask(compactionTask, s.mockAlloc, s.meta, s.handler, s.analyzeScheduler, newMockVersionManager())
 	task.maxRetryTimes = 0
 	return task
+}
+
+// newNamespaceClusteringTask builds a clustering task whose plan would be routed to the
+// namespace compactor on the DataNode (text index is built inline for sorted-by-namespace outputs).
+func (s *ClusteringCompactionTaskSuite) newNamespaceClusteringTask(enableNamespace bool, fileResourceIDs []int64) *clusteringCompactionTask {
+	for _, segID := range []int64{101, 102} {
+		s.meta.AddSegment(context.TODO(), &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            segID,
+			CollectionID:  1,
+			PartitionID:   10,
+			InsertChannel: "ch-1",
+			State:         commonpb.SegmentState_Flushed,
+			Level:         datapb.SegmentLevel_L1,
+		}})
+	}
+
+	schema := ConstructClusteringSchema("TestNamespaceClustering", 32, true, false)
+	schema.EnableNamespace = enableNamespace
+	schema.FileResourceIds = fileResourceIDs
+
+	compactionTask := &datapb.CompactionTask{
+		PlanID:        1,
+		TriggerID:     19530,
+		CollectionID:  1,
+		PartitionID:   10,
+		Type:          datapb.CompactionType_ClusteringCompaction,
+		NodeID:        1,
+		State:         datapb.CompactionTaskState_pipelining,
+		Schema:        schema,
+		InputSegments: []int64{101, 102},
+		ClusteringKeyField: &schemapb.FieldSchema{
+			FieldID:         100,
+			Name:            Int64Field,
+			IsPrimaryKey:    true,
+			DataType:        schemapb.DataType_Int64,
+			IsClusteringKey: true,
+		},
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 1, End: 100},
+	}
+	return newClusteringCompactionTask(compactionTask, s.mockAlloc, s.meta, s.handler, s.analyzeScheduler, newMockVersionManager())
+}
+
+// TestBuildCompactionRequest_NamespaceFileResourcesInRefMode verifies that a namespace-enabled
+// clustering plan carries both FileResources (for inline text-index analyzer resources in ref mode)
+// and CurrentScalarIndexVersion (issue #50145, PR #50140).
+func (s *ClusteringCompactionTaskSuite) TestBuildCompactionRequest_NamespaceFileResourcesInRefMode() {
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.DNFileResourceMode.Key, "ref")
+	defer pt.Reset(pt.CommonCfg.DNFileResourceMode.Key)
+
+	expectedResources := []*internalpb.FileResourceInfo{
+		{Id: 7, Name: "dict", Path: "dict.jieba"},
+	}
+
+	mockVer := mockey.Mock((*versionManagerImpl).ResolveScalarIndexVersion).Return(int32(42)).Build()
+	defer mockVer.UnPatch()
+
+	s.Run("namespace_enabled", func() {
+		s.NoError(s.meta.UpdateFileResources(context.TODO(), expectedResources, 1))
+		task := s.newNamespaceClusteringTask(true, []int64{7})
+		plan, err := task.BuildCompactionRequest()
+		s.Require().NoError(err)
+		s.Equal(expectedResources, plan.GetFileResources(),
+			"namespace clustering must carry FileResources in ref mode (issue #50145, PR #50140)")
+		s.Equal(int32(42), plan.GetCurrentScalarIndexVersion(),
+			"clustering plan must carry CurrentScalarIndexVersion for inline text index metadata")
+	})
+
+	s.Run("namespace_disabled_skips_file_resources", func() {
+		task := s.newNamespaceClusteringTask(false, []int64{7})
+		plan, err := task.BuildCompactionRequest()
+		s.Require().NoError(err)
+		s.Empty(plan.GetFileResources(),
+			"non-namespace clustering does not build text index inline, so no FileResources are fetched")
+		s.Equal(int32(42), plan.GetCurrentScalarIndexVersion())
+	})
 }
 
 func (s *ClusteringCompactionTaskSuite) TestProcessRetryLogic() {

--- a/internal/datacoord/compaction_task_mix.go
+++ b/internal/datacoord/compaction_task_mix.go
@@ -370,12 +370,15 @@ func (t *mixCompactionTask) BuildCompactionRequest() (*datapb.CompactionPlan, er
 		CurrentScalarIndexVersion: t.ievm.ResolveScalarIndexVersion(),
 	}
 
-	// set analyzer resource for text match index if use ref mode
-	if fileresource.IsRefMode(paramtable.Get().CommonCfg.DNFileResourceMode.GetValue()) && taskProto.GetType() == datapb.CompactionType_SortCompaction && len(taskSchema.GetFileResourceIds()) > 0 {
+	// set analyzer resource for text match index if use ref mode.
+	// Both SortCompaction and MixCompaction build text indexes inline and need the analyzer resources.
+	if fileresource.IsRefMode(paramtable.Get().CommonCfg.DNFileResourceMode.GetValue()) &&
+		(taskProto.GetType() == datapb.CompactionType_SortCompaction || taskProto.GetType() == datapb.CompactionType_MixCompaction) &&
+		len(taskSchema.GetFileResourceIds()) > 0 {
 		resources, err := t.meta.GetFileResources(context.Background(), taskSchema.GetFileResourceIds()...)
 		if err != nil {
 			mlog.Warn(context.TODO(), "get file resources for collection failed", mlog.Int64("collectionID", taskProto.GetCollectionID()), mlog.Err(err))
-			return nil, merr.Wrap(err, "get file resources for sort compaction failed")
+			return nil, merr.Wrap(err, "get file resources for compaction failed")
 		}
 		plan.FileResources = resources
 	}

--- a/internal/datacoord/compaction_task_mix_test.go
+++ b/internal/datacoord/compaction_task_mix_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/taskcommon"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func TestMixCompactionTaskSuite(t *testing.T) {
@@ -67,6 +69,55 @@ func (s *MixCompactionTaskSuite) TestProcessRefreshPlan_NormalMix() {
 		return b.GetSegmentID()
 	})
 	s.ElementsMatch([]int64{200, 201}, segIDs)
+}
+
+// Covers the FileResources branch in BuildCompactionRequest for MixCompaction
+// plans (previously only SortCompaction was wired). Without this, mix-compacted
+// segments with custom analyzers in ref mode would build text indexes using
+// default tokenization → silent search regressions.
+func (s *MixCompactionTaskSuite) TestBuildCompactionRequest_MixFileResourcesInRefMode() {
+	pt := paramtable.Get()
+	pt.Save(pt.CommonCfg.DNFileResourceMode.Key, "ref")
+	defer pt.Reset(pt.CommonCfg.DNFileResourceMode.Key)
+
+	channel := "Ch-1"
+	binLogs := []*datapb.FieldBinlog{getFieldBinlogIDs(101, 3)}
+	s.mockMeta.EXPECT().GetHealthySegment(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, segID int64) *SegmentInfo {
+		return &SegmentInfo{SegmentInfo: &datapb.SegmentInfo{
+			ID:            segID,
+			Level:         datapb.SegmentLevel_L1,
+			InsertChannel: channel,
+			State:         commonpb.SegmentState_Flushed,
+			Binlogs:       binLogs,
+		}}
+	}).Once()
+
+	expectedResources := []*internalpb.FileResourceInfo{
+		{Id: 7, Name: "dict", Path: "dict.jieba"},
+	}
+	s.mockMeta.EXPECT().GetFileResources(mock.Anything, mock.Anything).Return(expectedResources, nil).Once()
+
+	task := newMixCompactionTask(&datapb.CompactionTask{
+		PlanID:        1,
+		TriggerID:     19530,
+		CollectionID:  1,
+		PartitionID:   10,
+		Type:          datapb.CompactionType_MixCompaction,
+		NodeID:        1,
+		State:         datapb.CompactionTaskState_executing,
+		InputSegments: []int64{200},
+		Schema: &schemapb.CollectionSchema{
+			FileResourceIds: []int64{7},
+		},
+	}, nil, s.mockMeta, newMockVersionManager())
+	alloc := allocator.NewMockAllocator(s.T())
+	alloc.EXPECT().AllocN(mock.Anything).Return(100, 200, nil)
+	task.allocator = alloc
+
+	plan, err := task.BuildCompactionRequest()
+	s.Require().NoError(err)
+	s.Equal(expectedResources, plan.GetFileResources(),
+		"FileResources must flow through for MixCompaction plans (issue #50145, PR #50140)")
 }
 
 func (s *MixCompactionTaskSuite) TestProcessRefreshPlan_MixSegmentNotFound() {

--- a/internal/datanode/compactor/clustering_compactor_storage_v3_test.go
+++ b/internal/datanode/compactor/clustering_compactor_storage_v3_test.go
@@ -270,7 +270,8 @@ func (s *MixCompactionTaskStorageV3Suite) SetupTest() {
 
 	pk, err := typeutil.GetPrimaryFieldSchema(s.meta.GetSchema())
 	s.Require().NoError(err)
-	s.task = NewMixCompactionTask(context.Background(), s.mockBinlogIO, plan, compaction.GenParams(), []int64{pk.FieldID})
+	cm := storage.NewLocalChunkManager(objectstorage.RootPath(rootPath))
+	s.task = NewMixCompactionTask(context.Background(), s.mockBinlogIO, cm, plan, compaction.GenParams(), []int64{pk.FieldID})
 }
 
 func (s *MixCompactionTaskStorageV3Suite) TearDownTest() {

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/internal/flushcommon/io"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -49,6 +50,7 @@ import (
 
 type mixCompactionTask struct {
 	binlogIO    io.BinlogIO
+	cm          storage.ChunkManager
 	currentTime time.Time
 
 	plan *datapb.CompactionPlan
@@ -84,6 +86,7 @@ var _ Compactor = (*mixCompactionTask)(nil)
 func NewMixCompactionTask(
 	ctx context.Context,
 	binlogIO io.BinlogIO,
+	cm storage.ChunkManager,
 	plan *datapb.CompactionPlan,
 	compactionParams compaction.Params,
 	sortByFieldIDs []int64,
@@ -93,6 +96,7 @@ func NewMixCompactionTask(
 		ctx:              ctx1,
 		cancel:           cancel,
 		binlogIO:         binlogIO,
+		cm:               cm,
 		plan:             plan,
 		tr:               timerecord.NewTimeRecorder("mergeSplit compaction"),
 		currentTime:      time.Now(),
@@ -481,6 +485,57 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 		return nil, err
 	}
 
+	// Build text index inline for each output segment so the segment arrives at
+	// QueryNode with TextStatsLogs populated, avoiding the CGO_LOAD CreateTextIndex
+	// fallback at load time. Mirrors sortCompaction.
+	//
+	// Only sorted outputs get an inline text index. Unsorted mix-compaction outputs
+	// (from mergeSplit) are interim: a later sortcompaction will re-emit them as
+	// sorted and build the text index inline at that step. Building here would be
+	// discarded work. For non-external collections, stats_inspector also skips
+	// unsorted segments in its TextIndexJob filter, so the index would never be
+	// promoted to text_stats_logs in datacoord either. External collections are the
+	// exception (allowUnsorted = collection.IsExternal() in stats_inspector.go),
+	// where the async TextIndexJob still covers unsorted segments as a fallback.
+	textIndexStart := time.Now()
+	for _, resultSegment := range res {
+		if resultSegment.GetNumOfRows() == 0 {
+			continue
+		}
+		if !resultSegment.GetIsSorted() && !resultSegment.GetIsSortedByNamespace() {
+			continue
+		}
+		textStatsLogs, err := t.createTextIndex(ctx, resultSegment)
+		if err != nil {
+			mlog.Warn(context.TODO(), "failed to create text indexes",
+				mlog.Int64("targetSegmentID", resultSegment.GetSegmentID()), mlog.Err(err))
+			return nil, err
+		}
+		// For V3 segments, register text index stats in manifest.
+		// TextStatsLogs already carries full object keys for mixed-version compatibility;
+		// AddStatsToManifest stores the manifest-relative representation at commit time.
+		if resultSegment.GetManifest() != "" && len(textStatsLogs) > 0 {
+			statEntries := packed.TextIndexStatEntries(textStatsLogs, t.plan.GetCurrentScalarIndexVersion())
+			newManifest, mErr := packed.AddStatsToManifest(
+				resultSegment.GetManifest(), t.compactionParams.StorageConfig, statEntries)
+			if mErr != nil {
+				mlog.Warn(context.TODO(), "failed to add text index stats to manifest",
+					mlog.Int64("targetSegmentID", resultSegment.GetSegmentID()), mlog.Err(mErr))
+				return nil, mErr
+			}
+			resultSegment.Manifest = newManifest
+			// Dual-write: V3 segments store text index stats in both manifest and segment metadata.
+			// Manifest is the source of truth at load time; metadata acts as a placeholder so that
+			// needDoTextIndex() in stats_inspector.go won't trigger a redundant TextIndexJob.
+		}
+		resultSegment.TextStatsLogs = textStatsLogs
+	}
+	createTextIndexCost := time.Since(textIndexStart)
+	metrics.DataNodeCompactionStageLatency.
+		WithLabelValues(paramtable.GetStringNodeID(), t.plan.GetType().String(), "create_text_index").
+		Observe(float64(createTextIndexCost.Milliseconds()))
+	mlog.Info(context.TODO(), "compact create text index done", mlog.Duration("createTextIndexCost", createTextIndexCost))
+
 	planResult := &datapb.CompactionPlanResult{
 		State:    datapb.CompactionTaskState_completed,
 		PlanID:   t.GetPlanID(),
@@ -541,6 +596,16 @@ func GetBM25FieldIDs(coll *schemapb.CollectionSchema) []int64 {
 //   - REUSE_ALL: all TEXT fields reuse existing LOB files, merge LOB file references
 //   - REWRITE_ALL: all TEXT fields are rewritten, LOB files handled by segment writer
 //
+// createTextIndex delegates to the shared package-level createTextIndex helper,
+// sourcing collection/partition from the task and segment-specific fields from the
+// output segment. Mirrors sortCompactionTask.createTextIndex.
+func (t *mixCompactionTask) createTextIndex(ctx context.Context,
+	segment *datapb.CompactionSegment,
+) (map[int64]*datapb.TextIndexStats, error) {
+	return createTextIndex(ctx, t.cm, t.plan, t.compactionParams, segment.GetStorageVersion(),
+		t.collectionID, t.partitionID, segment.GetSegmentID(), t.GetPlanID(), segment)
+}
+
 // NOTE: SetSegmentRowStats() must be called during compaction iteration to track deleted rows per segment.
 func (t *mixCompactionTask) applyLOBCompaction(ctx context.Context, outputSegments []*datapb.CompactionSegment) error {
 	if t.lobContext == nil {

--- a/internal/datanode/compactor/mix_compactor_test.go
+++ b/internal/datanode/compactor/mix_compactor_test.go
@@ -211,7 +211,7 @@ func (s *MixCompactionTaskStorageV1Suite) setupTest() {
 
 	pk, err := typeutil.GetPrimaryFieldSchema(s.meta.GetSchema())
 	s.Require().NoError(err)
-	s.task = NewMixCompactionTask(context.Background(), s.mockBinlogIO, plan, compaction.GenParams(), []int64{pk.FieldID})
+	s.task = NewMixCompactionTask(context.Background(), s.mockBinlogIO, nil, plan, compaction.GenParams(), []int64{pk.FieldID})
 }
 
 func (s *MixCompactionTaskStorageV1Suite) SetupTest() {
@@ -245,7 +245,7 @@ func (s *MixCompactionTaskStorageV1Suite) SetupBM25() {
 
 	pk, err := typeutil.GetPrimaryFieldSchema(s.meta.GetSchema())
 	s.Require().NoError(err)
-	s.task = NewMixCompactionTask(context.Background(), s.mockBinlogIO, plan, compaction.GenParams(), []int64{pk.FieldID})
+	s.task = NewMixCompactionTask(context.Background(), s.mockBinlogIO, nil, plan, compaction.GenParams(), []int64{pk.FieldID})
 }
 
 func (s *MixCompactionTaskStorageV1Suite) SetupSubTest() {

--- a/internal/datanode/compactor/mix_compactor_text_index_test.go
+++ b/internal/datanode/compactor/mix_compactor_text_index_test.go
@@ -1,0 +1,307 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+// textMatchSchema returns a schema whose single VarChar field has enable_match.
+func textMatchSchema(fieldID int64) *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  fieldID,
+				Name:     "text_field",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "max_length", Value: "256"},
+					{Key: "enable_match", Value: "true"},
+				},
+			},
+		},
+	}
+}
+
+// TestMixCompaction_createTextIndex_Delegates verifies the mixCompactionTask
+// wrapper forwards the task- and segment-derived identifiers to the shared
+// package-level createTextIndex helper (which is CGO-backed and therefore mocked).
+func TestMixCompaction_createTextIndex_Delegates(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	const (
+		collectionID = int64(7001)
+		partitionID  = int64(7002)
+		segmentID    = int64(7003)
+		planID       = int64(42)
+		storageVer   = int64(2)
+		textFieldID  = int64(101)
+	)
+
+	plan := &datapb.CompactionPlan{PlanID: planID, Schema: textMatchSchema(textFieldID), Type: datapb.CompactionType_MixCompaction}
+	task := &mixCompactionTask{
+		plan:             plan,
+		collectionID:     collectionID,
+		partitionID:      partitionID,
+		compactionParams: compaction.GenParams(),
+	}
+
+	mockHelper := mockey.Mock(createTextIndex).To(
+		func(_ context.Context, _ storage.ChunkManager, gotPlan *datapb.CompactionPlan, _ compaction.Params,
+			gotStorageVer, gotColl, gotPart, gotSeg, gotTask int64, _ *datapb.CompactionSegment,
+		) (map[int64]*datapb.TextIndexStats, error) {
+			assert.Equal(t, plan, gotPlan)
+			assert.Equal(t, storageVer, gotStorageVer)
+			assert.Equal(t, collectionID, gotColl)
+			assert.Equal(t, partitionID, gotPart)
+			assert.Equal(t, segmentID, gotSeg)
+			assert.Equal(t, planID, gotTask)
+			return map[int64]*datapb.TextIndexStats{
+				textFieldID: {FieldID: textFieldID, BuildID: planID, Files: []string{"meta.json_0"}, LogSize: 1024, MemorySize: 1024},
+			}, nil
+		}).Build()
+	defer mockHelper.UnPatch()
+
+	out := &datapb.CompactionSegment{SegmentID: segmentID, NumOfRows: 100, StorageVersion: storageVer}
+	got, err := task.createTextIndex(context.Background(), out)
+	assert.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Contains(t, got, textFieldID)
+}
+
+func TestMixCompaction_createTextIndex_PropagatesError(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	task := &mixCompactionTask{
+		plan:             &datapb.CompactionPlan{PlanID: 1, Schema: &schemapb.CollectionSchema{}},
+		collectionID:     1,
+		partitionID:      2,
+		compactionParams: compaction.GenParams(),
+	}
+
+	mockHelper := mockey.Mock(createTextIndex).Return(nil, assert.AnError).Build()
+	defer mockHelper.UnPatch()
+
+	_, err := task.createTextIndex(context.Background(), &datapb.CompactionSegment{SegmentID: 99})
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// TestMixCompaction_Compact_InlineTextIndex drives the real mixCompactionTask.Compact()
+// and asserts the inline text-index loop's behavior end to end: sorted outputs get
+// TextStatsLogs, the V3-manifest segment gets its manifest rewritten, while empty and
+// unsorted outputs are skipped. mergeSplit/applyLOBCompaction/decompress, the per-task
+// createTextIndex wrapper, and the packed manifest helpers are mocked so the focus
+// stays on the loop in Compact().
+func TestMixCompaction_Compact_InlineTextIndex(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	const fieldID = int64(101)
+
+	mergeOut := []*datapb.CompactionSegment{
+		{SegmentID: 1, NumOfRows: 100, IsSorted: true},                            // build
+		{SegmentID: 2, NumOfRows: 0, IsSorted: true},                              // skip: empty
+		{SegmentID: 3, NumOfRows: 200, IsSortedByNamespace: true},                 // build
+		{SegmentID: 4, NumOfRows: 50},                                             // skip: unsorted interim output
+		{SegmentID: 5, NumOfRows: 300, IsSorted: true, Manifest: "orig-manifest"}, // build + V3 manifest
+	}
+
+	statsFor := func(segID int64) map[int64]*datapb.TextIndexStats {
+		return map[int64]*datapb.TextIndexStats{
+			fieldID: {FieldID: fieldID, BuildID: segID, Files: []string{"f"}, LogSize: 1, MemorySize: 1},
+		}
+	}
+
+	wrapperMock := mockey.Mock((*mixCompactionTask).createTextIndex).
+		To(func(_ *mixCompactionTask, _ context.Context, segment *datapb.CompactionSegment) (map[int64]*datapb.TextIndexStats, error) {
+			return statsFor(segment.GetSegmentID()), nil
+		}).Build()
+	defer wrapperMock.UnPatch()
+
+	mergeMock := mockey.Mock((*mixCompactionTask).mergeSplit).Return(mergeOut, nil).Build()
+	defer mergeMock.UnPatch()
+	lobMock := mockey.Mock((*mixCompactionTask).applyLOBCompaction).Return(nil).Build()
+	defer lobMock.UnPatch()
+	decompressMock := mockey.Mock(binlog.DecompressCompactionBinlogsWithRootPath).Return(nil).Build()
+	defer decompressMock.UnPatch()
+
+	entriesMock := mockey.Mock(packed.TextIndexStatEntries).
+		Return([]packed.StatEntry{{Key: "text_index.101"}}).Build()
+	defer entriesMock.UnPatch()
+	addManifestCalls := 0
+	addMock := mockey.Mock(packed.AddStatsToManifest).
+		To(func(manifestPath string, _ *indexpb.StorageConfig, _ []packed.StatEntry) (string, error) {
+			addManifestCalls++
+			assert.Equal(t, "orig-manifest", manifestPath)
+			return "new-manifest", nil
+		}).Build()
+	defer addMock.UnPatch()
+
+	params := compaction.GenParams()
+	params.UseMergeSort = false // force the mergeSplit path (which we mock)
+
+	plan := &datapb.CompactionPlan{
+		PlanID:  999,
+		Type:    datapb.CompactionType_MixCompaction,
+		Channel: "ch-1",
+		MaxSize: 64 * 1024 * 1024,
+		Schema:  textMatchSchema(fieldID),
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
+			{
+				CollectionID: 1,
+				PartitionID:  2,
+				SegmentID:    100,
+				FieldBinlogs: []*datapb.FieldBinlog{
+					{FieldID: fieldID, Binlogs: []*datapb.Binlog{{LogID: 1, EntriesNum: 100, MemorySize: 1024}}},
+				},
+			},
+		},
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 20000, End: 30000},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 30000, End: 40000},
+	}
+
+	task := NewMixCompactionTask(context.Background(), nil, nil, plan, params, []int64{fieldID})
+
+	result, err := task.Compact()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, datapb.CompactionTaskState_completed, result.GetState())
+
+	byID := make(map[int64]*datapb.CompactionSegment)
+	for _, s := range result.GetSegments() {
+		byID[s.GetSegmentID()] = s
+	}
+	require.Len(t, byID, 5)
+	assert.Len(t, byID[1].GetTextStatsLogs(), 1, "sorted output gets inline text index")
+	assert.Nil(t, byID[2].GetTextStatsLogs(), "empty output skipped")
+	assert.Len(t, byID[3].GetTextStatsLogs(), 1, "sorted-by-namespace output gets inline text index")
+	assert.Nil(t, byID[4].GetTextStatsLogs(), "unsorted interim output skipped")
+	assert.Len(t, byID[5].GetTextStatsLogs(), 1, "V3 sorted output gets inline text index")
+	assert.Equal(t, "new-manifest", byID[5].GetManifest(), "V3 manifest rewritten")
+	assert.Equal(t, 1, addManifestCalls, "AddStatsToManifest only for the manifest-bearing sorted output")
+}
+
+// TestMixCompaction_Compact_InlineTextIndex_BuildError ensures a failure from the
+// inline build aborts Compact().
+func TestMixCompaction_Compact_InlineTextIndex_BuildError(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	mergeOut := []*datapb.CompactionSegment{{SegmentID: 1, NumOfRows: 100, IsSorted: true}}
+	wrapperMock := mockey.Mock((*mixCompactionTask).createTextIndex).Return(nil, assert.AnError).Build()
+	defer wrapperMock.UnPatch()
+	mergeMock := mockey.Mock((*mixCompactionTask).mergeSplit).Return(mergeOut, nil).Build()
+	defer mergeMock.UnPatch()
+	lobMock := mockey.Mock((*mixCompactionTask).applyLOBCompaction).Return(nil).Build()
+	defer lobMock.UnPatch()
+	decompressMock := mockey.Mock(binlog.DecompressCompactionBinlogsWithRootPath).Return(nil).Build()
+	defer decompressMock.UnPatch()
+
+	params := compaction.GenParams()
+	params.UseMergeSort = false
+
+	plan := &datapb.CompactionPlan{
+		PlanID:  999,
+		Type:    datapb.CompactionType_MixCompaction,
+		Channel: "ch-1",
+		MaxSize: 64 * 1024 * 1024,
+		Schema:  textMatchSchema(101),
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
+			{
+				CollectionID: 1, PartitionID: 2, SegmentID: 100,
+				FieldBinlogs: []*datapb.FieldBinlog{
+					{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 1, EntriesNum: 100, MemorySize: 1024}}},
+				},
+			},
+		},
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 20000, End: 30000},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 30000, End: 40000},
+	}
+
+	task := NewMixCompactionTask(context.Background(), nil, nil, plan, params, []int64{101})
+	_, err := task.Compact()
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// TestMixCompaction_Compact_InlineTextIndex_ManifestError ensures a failure from
+// packed.AddStatsToManifest (the V3 manifest-update branch) aborts Compact().
+func TestMixCompaction_Compact_InlineTextIndex_ManifestError(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	const fieldID = int64(101)
+	mergeOut := []*datapb.CompactionSegment{
+		{SegmentID: 1, NumOfRows: 100, IsSorted: true, Manifest: "orig-manifest"},
+	}
+
+	wrapperMock := mockey.Mock((*mixCompactionTask).createTextIndex).
+		To(func(_ *mixCompactionTask, _ context.Context, segment *datapb.CompactionSegment) (map[int64]*datapb.TextIndexStats, error) {
+			return map[int64]*datapb.TextIndexStats{
+				fieldID: {FieldID: fieldID, BuildID: segment.GetSegmentID(), Files: []string{"f"}, LogSize: 1, MemorySize: 1},
+			}, nil
+		}).Build()
+	defer wrapperMock.UnPatch()
+	mergeMock := mockey.Mock((*mixCompactionTask).mergeSplit).Return(mergeOut, nil).Build()
+	defer mergeMock.UnPatch()
+	lobMock := mockey.Mock((*mixCompactionTask).applyLOBCompaction).Return(nil).Build()
+	defer lobMock.UnPatch()
+	decompressMock := mockey.Mock(binlog.DecompressCompactionBinlogsWithRootPath).Return(nil).Build()
+	defer decompressMock.UnPatch()
+	entriesMock := mockey.Mock(packed.TextIndexStatEntries).
+		Return([]packed.StatEntry{{Key: "text_index.101"}}).Build()
+	defer entriesMock.UnPatch()
+	addMock := mockey.Mock(packed.AddStatsToManifest).Return("", assert.AnError).Build()
+	defer addMock.UnPatch()
+
+	params := compaction.GenParams()
+	params.UseMergeSort = false
+
+	plan := &datapb.CompactionPlan{
+		PlanID:  999,
+		Type:    datapb.CompactionType_MixCompaction,
+		Channel: "ch-1",
+		MaxSize: 64 * 1024 * 1024,
+		Schema:  textMatchSchema(fieldID),
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
+			{
+				CollectionID: 1, PartitionID: 2, SegmentID: 100,
+				FieldBinlogs: []*datapb.FieldBinlog{
+					{FieldID: fieldID, Binlogs: []*datapb.Binlog{{LogID: 1, EntriesNum: 100, MemorySize: 1024}}},
+				},
+			},
+		},
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 20000, End: 30000},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 30000, End: 40000},
+	}
+
+	task := NewMixCompactionTask(context.Background(), nil, nil, plan, params, []int64{fieldID})
+	_, err := task.Compact()
+	assert.ErrorIs(t, err, assert.AnError)
+}

--- a/internal/datanode/compactor/namespace_compactor.go
+++ b/internal/datanode/compactor/namespace_compactor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/compaction"
 	"github.com/milvus-io/milvus/internal/flushcommon/io"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
@@ -36,8 +37,8 @@ func (c *NamespaceCompactor) Compact() (*datapb.CompactionPlanResult, error) {
 	return res, nil
 }
 
-func NewNamespaceCompactor(ctx context.Context, plan *datapb.CompactionPlan, binlogIO io.BinlogIO, compactionParams compaction.Params, sortByFieldIDs []int64) *NamespaceCompactor {
+func NewNamespaceCompactor(ctx context.Context, plan *datapb.CompactionPlan, binlogIO io.BinlogIO, cm storage.ChunkManager, compactionParams compaction.Params, sortByFieldIDs []int64) *NamespaceCompactor {
 	return &NamespaceCompactor{
-		mixCompactionTask: NewMixCompactionTask(ctx, binlogIO, plan, compactionParams, sortByFieldIDs),
+		mixCompactionTask: NewMixCompactionTask(ctx, binlogIO, cm, plan, compactionParams, sortByFieldIDs),
 	}
 }

--- a/internal/datanode/compactor/namespace_compactor_test.go
+++ b/internal/datanode/compactor/namespace_compactor_test.go
@@ -150,7 +150,7 @@ func (s *NamespaceCompactorTestSuite) TestCompactSorted() {
 	params := compaction.GenParams()
 	sortedByFieldIDs := []int64{101, 100}
 
-	c := NewNamespaceCompactor(context.Background(), plan, s.binlogIO, params, sortedByFieldIDs)
+	c := NewNamespaceCompactor(context.Background(), plan, s.binlogIO, nil, params, sortedByFieldIDs)
 	result, err := c.Compact()
 
 	s.Require().NoError(err)

--- a/internal/datanode/services.go
+++ b/internal/datanode/services.go
@@ -249,6 +249,7 @@ func (node *DataNode) CompactionV2(ctx context.Context, req *datapb.CompactionPl
 		task = compactor.NewMixCompactionTask(
 			taskCtx,
 			io.NewBinlogIO(cm),
+			cm,
 			req,
 			compactionParams,
 			sortFields,
@@ -269,7 +270,7 @@ func (node *DataNode) CompactionV2(ctx context.Context, req *datapb.CompactionPl
 				return merr.Status(err), err
 			}
 			sortFields = append(sortFields, pk.GetFieldID())
-			task = compactor.NewNamespaceCompactor(taskCtx, req, binlogIO, compactionParams, sortFields)
+			task = compactor.NewNamespaceCompactor(taskCtx, req, binlogIO, cm, compactionParams, sortFields)
 		} else {
 			task = compactor.NewClusteringCompactionTask(
 				taskCtx,


### PR DESCRIPTION
issue: #50145

## Summary

Make `mixCompactionTask` build text indexes inline for `enable_match` fields (mirroring `sortCompactionTask`) so that mix-compaction output segments arrive at QueryNode already carrying `TextStatsLogs`. This eliminates the CGO_LOAD `CreateTextIndex` fallback path in segcore — observed in production to redundantly rebuild text indexes during segment load for tens of seconds up to 13+ minutes per segment.

## Background

For a freshly mix-compacted segment with text-match fields, the load pipeline currently races:

1. Vector index task completes within ~10s (event-triggered)
2. QueryCoord treats the segment as loadable once the vector index is ready
3. The `TextIndexJob` (stats task) is event-less — only the 60s polling ticker submits it
4. The job itself takes ~2 minutes for typical text-heavy segments
5. QueryNode receives the segment before its persistent text index is written; segcore detects `text_stats_logs == nil` and calls `CreateTextIndex` in-place at load time (`[CGO_LOAD]` scope)

`sortCompactionTask` already avoids this by building the text index inline as part of compaction (`internal/datanode/compactor/sort_compaction.go:469-503`). `mixCompactionTask` did not — this PR closes the gap.

## What changes

- **`internal/datanode/compactor/mix_compactor.go`** — Add `cm storage.ChunkManager` field; constructor takes one extra arg; add a thin `createTextIndex` method wrapper that delegates to the existing package-level `createTextIndex` helper (in `compactor_common.go`, already used by sort compaction); after `applyLOBCompaction`, loop over each non-empty **sorted** output segment, build text indexes, update the V3 manifest, and assign `TextStatsLogs`. Emits a `create_text_index` stage latency metric. (No new shared helper is introduced — this PR reuses `compactor_common.go:createTextIndex` and `sort_compaction.go` is untouched.)
- **`internal/datanode/compactor/namespace_compactor.go`** — Forward `cm` to the inner `mixCompactionTask`.
- **`internal/datanode/services.go`** — Updated call sites (pass `cm`).
- **`internal/datacoord/compaction_task_mix.go`** — Extend the `FileResources` plumbing condition to include `MixCompaction` so custom analyzers (ref mode) reach the inline build. Previously only `SortCompaction` got `FileResources`, which would have caused mix-compacted text indexes to use default tokenization → silent search regressions.
- **`internal/datacoord/compaction_task_clustering.go` / `compaction_inspector.go`** — Namespace-enabled `ClusteringCompaction` is routed on the DataNode to `NewNamespaceCompactor`, which delegates to `mixCompactionTask.Compact()` and now builds the text index inline for sorted-by-namespace outputs. Wire `IndexEngineVersionManager` into `clusteringCompactionTask` and, in `BuildCompactionRequest()`, set `CurrentScalarIndexVersion` (otherwise the inline text index metadata is emitted with version 0) and fetch `FileResources` for namespace-enabled clustering plans in ref mode (otherwise the custom analyzer resources are not downloaded and the text index falls back to the default analyzer). Addresses review feedback from @aoiasd.
- **`internal/datanode/compactor/mix_compactor_test.go` / `namespace_compactor_test.go`** — Updated existing constructor call sites to pass the new `cm` arg.
- **`internal/datanode/compactor/mix_compactor_text_index_test.go` (new)** — Mockey-based unit tests covering: the wrapper's identifier propagation to the package helper, error propagation, and real `Compact()` inline-loop semantics (empty + unsorted segments skipped, `TextStatsLogs` assigned for sorted, V3 manifest rewritten, build/manifest errors abort).
- **`internal/datacoord/compaction_task_mix_test.go`** — Test that `MixCompaction` plans receive `FileResources` in ref mode.

## Test plan

- [x] `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 -run "TestMixCompaction|TestNamespace|TestSort" ./internal/datanode/compactor/...` — PASS (post-rebase)
- [x] `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 -run "TestMixCompaction|TestCompactionTask" ./internal/datacoord/...` — PASS
- [x] New unit tests pass: `TestMixCompaction_createTextIndex_Delegates`, `TestMixCompaction_createTextIndex_PropagatesError`, `TestMixCompaction_Compact_InlineTextIndex`, `TestMixCompaction_Compact_InlineTextIndex_BuildError`, `TestMixCompaction_Compact_InlineTextIndex_ManifestError`, and (datacoord) `TestMixCompactionTaskSuite/TestBuildCompactionRequest_MixFileResourcesInRefMode`, `TestClusteringCompactionTaskSuite/TestBuildCompactionRequest_NamespaceFileResourcesInRefMode`
- [ ] CI builds against fresh C++ artifacts (local worktree build was skipped because the C++ shared libs in this workspace are stale relative to upstream's recent cgo changes — unrelated to this PR's diff)
- [ ] Manual / integration: verify a freshly mix-compacted segment with text-match fields lands on QueryNode with non-empty `text_stats_logs` and does NOT trigger the `[CGO_LOAD] CreateTextIndex` slow path in QueryNode logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)



