### PR TITLE
fix: Isolate QueryNode segment release from DynamicPool

### DIFF
--- a/internal/querynodev2/segments/pool.go
+++ b/internal/querynodev2/segments/pool.go
@@ -48,14 +48,16 @@ var (
 	// and other operations (insert/delete/statistics/etc.)
 	// since in concurrent situation, there operation may block each other in high payload
 
-	sqp        atomic.Pointer[conc.Pool[any]]
-	sqOnce     sync.Once
-	dp         atomic.Pointer[conc.Pool[any]]
-	dynOnce    sync.Once
-	loadPool   atomic.Pointer[conc.Pool[any]]
-	loadOnce   sync.Once
-	warmupPool atomic.Pointer[conc.Pool[any]]
-	warmupOnce sync.Once
+	sqp         atomic.Pointer[conc.Pool[any]]
+	sqOnce      sync.Once
+	dp          atomic.Pointer[conc.Pool[any]]
+	dynOnce     sync.Once
+	loadPool    atomic.Pointer[conc.Pool[any]]
+	loadOnce    sync.Once
+	warmupPool  atomic.Pointer[conc.Pool[any]]
+	warmupOnce  sync.Once
+	releasePool atomic.Pointer[conc.Pool[any]]
+	releaseOnce sync.Once
 
 	deletePool     atomic.Pointer[conc.Pool[struct{}]]
 	deletePoolOnce sync.Once
@@ -71,6 +73,7 @@ var (
 	cgoTagLoad    = C.CString("CGO_LOAD")
 	cgoTagDynamic = C.CString("CGO_DYN")
 	cgoTagWarmup  = C.CString("CGO_WARMUP")
+	cgoTagRelease = C.CString("CGO_RELEASE")
 )
 
 // initSQPool initialize
@@ -166,6 +169,24 @@ func initWarmupPool() {
 	})
 }
 
+func initReleasePool() {
+	releaseOnce.Do(func() {
+		size := hardware.GetCPUNum()
+		pool := conc.NewPool[any](
+			size,
+			conc.WithPreAlloc(false),
+			conc.WithDisablePurge(false),
+			conc.WithPreHandler(func() {
+				runtime.LockOSThread()
+				C.SetThreadName(cgoTagRelease)
+			}),
+		)
+
+		releasePool.Store(pool)
+		log.Info("init releasePool done", zap.Int("size", size))
+	})
+}
+
 func initBFApplyPool() {
 	bfApplyOnce.Do(func() {
 		pt := paramtable.Get()
@@ -206,6 +227,11 @@ func GetLoadPool() *conc.Pool[any] {
 func GetWarmupPool() *conc.Pool[any] {
 	initWarmupPool()
 	return warmupPool.Load()
+}
+
+func GetReleasePool() *conc.Pool[any] {
+	initReleasePool()
+	return releasePool.Load()
 }
 
 func GetBFApplyPool() *conc.Pool[any] {
@@ -282,6 +308,7 @@ func CollectPoolStats() []metrics.PoolStats {
 		{"DynamicPool", GetDynamicPool()},
 		{"LoadPool", GetLoadPool()},
 		{"WarmupPool", GetWarmupPool()},
+		{"ReleasePool", GetReleasePool()},
 		{"BFApplyPool", GetBFApplyPool()},
 		{"BM25LoadPool", GetBM25LoadPool()},
 		{"DeletePool", GetDeletePool()},

--- a/internal/querynodev2/segments/pool_test.go
+++ b/internal/querynodev2/segments/pool_test.go
@@ -134,3 +134,16 @@ func TestResizePools(t *testing.T) {
 		assert.Equal(t, c, pool.Cap())
 	})
 }
+
+func TestCollectPoolStatsIncludesReleasePool(t *testing.T) {
+	stats := CollectPoolStats()
+
+	for _, stat := range stats {
+		if stat.Name == "ReleasePool" {
+			assert.Equal(t, hardware.GetCPUNum(), stat.Cap)
+			return
+		}
+	}
+
+	assert.Fail(t, "ReleasePool should be reported in pool stats")
+}

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -1464,7 +1464,7 @@ func (s *LocalSegment) Release(ctx context.Context, opts ...releaseOption) {
 		C.ExprResCacheEraseSegment(C.int64_t(s.ID()))
 	}
 
-	GetDynamicPool().Submit(func() (any, error) {
+	GetReleasePool().Submit(func() (any, error) {
 		C.DeleteSegment(ptr)
 		return nil, nil
 	}).Await()
@@ -1488,7 +1488,7 @@ func (s *LocalSegment) Release(ctx context.Context, opts ...releaseOption) {
 
 // ReleaseSegmentData releases the segment data.
 func (s *LocalSegment) ReleaseSegmentData() {
-	GetDynamicPool().Submit(func() (any, error) {
+	GetReleasePool().Submit(func() (any, error) {
 		C.ClearSegmentData(s.ptr)
 		return nil, nil
 	}).Await()


### PR DESCRIPTION
issue: #50142

## What changed

This PR adds a dedicated QueryNode `ReleasePool` for segment release cgo work.

`LocalSegment.Release` now routes `C.DeleteSegment` through `ReleasePool`, and `ReleaseSegmentData` routes `C.ClearSegmentData` through the same pool instead of `DynamicPool`.

The new pool is also included in QueryNode pool stats.

## Why

`DynamicPool` is shared by multiple cgo operations, including index update paths that may block while waiting on segment state. When those workers are occupied, release requests can be delayed before they call `C.DeleteSegment`, which delays reclaiming C++ segment memory.

Isolating release work prevents segment memory release from being starved by unrelated dynamic cgo work.

## Validation

- `git diff --check milvus/master`
- `go test -tags dynamic,test -ldflags="-r ${RPATH}" internal/querynodev2/segments/pool.go internal/querynodev2/segments/pool_test.go -run TestCollectPoolStatsIncludesReleasePool -count=1 -v` blocked before compile because this fresh worktree has no `milvus_core.pc`.
- `make build-cpp` was attempted and stopped after the `mongo-c-driver` clone made no progress.