### PR TITLE
fix: size field bitsets by field id range

### DIFF
--- a/internal/core/src/common/Schema.h
+++ b/internal/core/src/common/Schema.h
@@ -290,6 +290,22 @@ class Schema {
         return fields_.size();
     }
 
+    size_t
+    get_field_id_bitset_size() const {
+        size_t bitset_size = 0;
+        for (const auto& field_id : field_ids_) {
+            if (field_id.get() < START_USER_FIELDID) {
+                continue;
+            }
+            auto required_size =
+                static_cast<size_t>(field_id.get() - START_USER_FIELDID + 1);
+            if (required_size > bitset_size) {
+                bitset_size = required_size;
+            }
+        }
+        return bitset_size;
+    }
+
     const FieldMeta&
     operator[](FieldId field_id) const {
         Assert(field_id.get() >= 0);

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -324,7 +324,7 @@ ProtoParser::CreatePlan(const proto::plan::PlanNode& plan_node_proto) {
     auto plan_node = PlanNodeFromProto(plan_node_proto);
     plan->plan_node_ = std::move(plan_node);
     plan->tag2field_["$0"] = plan->plan_node_->search_info_.field_id_;
-    ExtractedPlanInfo extra_info(schema->size());
+    ExtractedPlanInfo extra_info(schema->get_field_id_bitset_size());
     extra_info.add_involved_field(plan->plan_node_->search_info_.field_id_);
     plan->extra_info_opt_ = std::move(extra_info);
 

--- a/internal/core/src/query/PlanProtoTest.cpp
+++ b/internal/core/src/query/PlanProtoTest.cpp
@@ -15,6 +15,12 @@
 #include <vector>
 #include <chrono>
 
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "knowhere/comp/index_param.h"
+#include "pb/plan.pb.h"
+#include "pb/schema.pb.h"
+#include "query/Plan.h"
 #include "query/PlanProto.h"
 
 TEST(PlanProto, NotSetUnsupported) {
@@ -29,4 +35,65 @@ TEST(PlanProto, NotSetUnsupported) {
     proto::plan::Expr expr_pb;
     ProtoParser parser(schema);
     ASSERT_ANY_THROW(parser.ParseExprs(expr_pb));
+}
+
+TEST(PlanProto, VectorArrayFieldIdGapInStructArray) {
+    namespace planpb = milvus::proto::plan;
+    namespace schemapb = milvus::proto::schema;
+
+    schemapb::CollectionSchema schema_proto;
+    auto pk = schema_proto.add_fields();
+    pk->set_name("id");
+    pk->set_fieldid(100);
+    pk->set_is_primary_key(true);
+    pk->set_data_type(schemapb::DataType::Int64);
+
+    auto struct_array = schema_proto.add_struct_array_fields();
+    struct_array->set_name("evidence");
+    struct_array->set_fieldid(146);
+
+    auto evidence_item = struct_array->add_fields();
+    evidence_item->set_name("evidence[evidence_item]");
+    evidence_item->set_fieldid(147);
+    evidence_item->set_data_type(schemapb::DataType::Array);
+    evidence_item->set_element_type(schemapb::DataType::VarChar);
+    auto max_length = evidence_item->add_type_params();
+    max_length->set_key("max_length");
+    max_length->set_value("512");
+    auto max_capacity = evidence_item->add_type_params();
+    max_capacity->set_key("max_capacity");
+    max_capacity->set_value("200");
+
+    auto evidence_vector = struct_array->add_fields();
+    evidence_vector->set_name("evidence[evidence_vector]");
+    evidence_vector->set_fieldid(148);
+    evidence_vector->set_data_type(schemapb::DataType::ArrayOfVector);
+    evidence_vector->set_element_type(schemapb::DataType::FloatVector);
+    auto dim = evidence_vector->add_type_params();
+    dim->set_key("dim");
+    dim->set_value("1024");
+    auto vector_max_capacity = evidence_vector->add_type_params();
+    vector_max_capacity->set_key("max_capacity");
+    vector_max_capacity->set_value("200");
+
+    auto schema = milvus::Schema::ParseFrom(schema_proto);
+    ASSERT_EQ(schema->size(), 3);
+    ASSERT_EQ(schema->get_field_id_bitset_size(), 49);
+
+    planpb::PlanNode plan_node;
+    auto vector_anns = plan_node.mutable_vector_anns();
+    vector_anns->set_vector_type(planpb::VectorType::EmbListFloatVector);
+    vector_anns->set_field_id(148);
+    vector_anns->set_placeholder_tag("$0");
+    auto query_info = vector_anns->mutable_query_info();
+    query_info->set_metric_type("MAX_SIM_COSINE");
+    query_info->set_topk(10);
+    query_info->set_round_decimal(-1);
+    query_info->set_search_params(R"({"ef": 200})");
+
+    auto plan = milvus::query::CreateSearchPlanFromPlanNode(schema, plan_node);
+    ASSERT_TRUE(plan->extra_info_opt_.has_value());
+    const auto& involved_fields = plan->extra_info_opt_->involved_fields_;
+    ASSERT_EQ(involved_fields.size(), 49);
+    EXPECT_TRUE(involved_fields[48]);
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1562,9 +1562,9 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
     int64_t segment_id,
     bool is_sorted_by_pk)
     : segcore_config_(segcore_config),
-      field_data_ready_bitset_(schema->size()),
-      index_ready_bitset_(schema->size()),
-      binlog_index_bitset_(schema->size()),
+      field_data_ready_bitset_(schema->get_field_id_bitset_size()),
+      index_ready_bitset_(schema->get_field_id_bitset_size()),
+      binlog_index_bitset_(schema->get_field_id_bitset_size()),
       ngram_fields_(std::unordered_set<FieldId>(schema->size())),
       scalar_indexings_(std::unordered_map<FieldId, index::CacheIndexBasePtr>(
           schema->size())),
@@ -2796,9 +2796,9 @@ void
 ChunkedSegmentSealedImpl::Reopen(SchemaPtr sch) {
     std::unique_lock lck(mutex_);
 
-    field_data_ready_bitset_.resize(sch->size());
-    index_ready_bitset_.resize(sch->size());
-    binlog_index_bitset_.resize(sch->size());
+    field_data_ready_bitset_.resize(sch->get_field_id_bitset_size());
+    index_ready_bitset_.resize(sch->get_field_id_bitset_size());
+    binlog_index_bitset_.resize(sch->get_field_id_bitset_size());
 
     auto absent_fields = sch->AbsentFields(*schema_);
     for (const auto& field_meta : *absent_fields) {

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -1515,6 +1515,133 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         assert len(struct_search_results[0]) > 0
 
     @pytest.mark.tags(CaseLabel.L0)
+    def test_search_struct_array_last_vector_subfield(self):
+        """
+        target: test search on a vector sub-field after multiple struct array parent fields
+        method: create multiple struct arrays so parent field IDs create gaps, then search the last vector sub-field
+        expected: search returns results
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_search_last_subfield")
+
+        client = self._client()
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim)
+
+        person_schema = client.create_struct_field_schema()
+        person_schema.add_field("name", DataType.VARCHAR, max_length=128)
+        person_schema.add_field("name_vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(
+            "suspects",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=person_schema,
+            max_capacity=20,
+        )
+        schema.add_field(
+            "victims",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=person_schema,
+            max_capacity=20,
+        )
+
+        vehicle_schema = client.create_struct_field_schema()
+        vehicle_schema.add_field("model", DataType.VARCHAR, max_length=128)
+        vehicle_schema.add_field("vehicle_vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(
+            "vehicles",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=vehicle_schema,
+            max_capacity=20,
+        )
+
+        evidence_schema = client.create_struct_field_schema()
+        evidence_schema.add_field("item", DataType.VARCHAR, max_length=128)
+        evidence_schema.add_field("evidence_vector", DataType.FLOAT_VECTOR, dim=default_dim)
+        schema.add_field(
+            "evidence",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=evidence_schema,
+            max_capacity=20,
+        )
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="suspects[name_vector]",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="victims[name_vector]",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="vehicles[vehicle_vector]",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="evidence[evidence_vector]",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params=INDEX_PARAMS,
+        )
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
+
+        data = []
+        for i in range(64):
+            data.append(
+                {
+                    "id": i,
+                    "normal_vector": [random.random() for _ in range(default_dim)],
+                    "suspects": [
+                        {"name": f"suspect_{i}", "name_vector": [random.random() for _ in range(default_dim)]}
+                    ],
+                    "victims": [{"name": f"victim_{i}", "name_vector": [random.random() for _ in range(default_dim)]}],
+                    "vehicles": [
+                        {"model": f"vehicle_{i}", "vehicle_vector": [random.random() for _ in range(default_dim)]}
+                    ],
+                    "evidence": [
+                        {"item": f"evidence_{i}", "evidence_vector": [random.random() for _ in range(default_dim)]}
+                    ],
+                }
+            )
+
+        res, check = self.insert(client, collection_name, data)
+        assert check
+        assert res["insert_count"] == 64
+
+        res, check = self.load_collection(client, collection_name)
+        assert check
+
+        search_tensor = EmbeddingList()
+        search_tensor.add([random.random() for _ in range(default_dim)])
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[search_tensor],
+            anns_field="evidence[evidence_vector]",
+            search_params={"metric_type": "MAX_SIM_COSINE"},
+            limit=10,
+        )
+        assert check
+        assert len(results[0]) > 0
+
+    @pytest.mark.tags(CaseLabel.L0)
     def test_search_struct_array_vector_multiple(self):
         """
         target: test search with multiple vectors (EmbeddingList) in struct array


### PR DESCRIPTION
issue: #50107
pr: #50141

Cherry-pick the StructArray vector search fix to 2.6.

This fixes StructArray vector searches where StructArray parent fields create gaps in user field IDs, while query/sealed-segment bitsets were sized by schema field count.

Validation:
- uvx ruff==0.15.11 format --check --diff tests/python_client/milvus_client/test_milvus_client_struct_array.py
- python3 -m py_compile tests/python_client/milvus_client/test_milvus_client_struct_array.py