### PR TITLE
fix: reject unsupported search aggregation inputs

### DIFF
--- a/internal/proxy/search_agg/context_builder.go
+++ b/internal/proxy/search_agg/context_builder.go
@@ -275,14 +275,12 @@ func resolveAggregationSpec(groupBy *commonpb.SearchAggregationSpec, schema *sch
 			if err != nil {
 				return fmt.Errorf("invalid group_by field %q: %w", fieldName, err)
 			}
-			// jsonPath plumbing to segcore is not wired for SearchAggregation yet;
-			// reject JSON / dynamic-field group_by up-front so callers get a
-			// deterministic error instead of an empty group-by column downstream.
-			if fs := typeutil.GetFieldByID(schema, fieldID); fs != nil {
-				if fs.GetDataType() == schemapb.DataType_JSON || fs.GetIsDynamic() {
-					return fmt.Errorf("group_by field %q: JSON / dynamic fields are not yet supported with search_aggregation", fieldName)
-				}
-				if fs.GetDataType() == schemapb.DataType_Float || fs.GetDataType() == schemapb.DataType_Double {
+			field, err := validateSearchAggregationFieldSupport(fieldName, fieldID, schema, "group_by field")
+			if err != nil {
+				return err
+			}
+			if field != nil {
+				if field.GetDataType() == schemapb.DataType_Float || field.GetDataType() == schemapb.DataType_Double {
 					return fmt.Errorf("group_by field %q: FLOAT / DOUBLE fields are not supported with search_aggregation (BucketKeyEntry has no float variant; equality on floats is fragile)", fieldName)
 				}
 			}
@@ -388,7 +386,11 @@ func buildMetricSpec(metric *commonpb.MetricAggSpec, schema *schemapb.Collection
 			return MetricSpec{}, 0, err
 		}
 		fieldType := schemapb.DataType_None
-		if field := typeutil.GetFieldByName(schema, fieldName); field != nil {
+		field, err := validateSearchAggregationFieldSupport(fieldName, fieldID, schema, "metric field")
+		if err != nil {
+			return MetricSpec{}, 0, err
+		}
+		if field != nil {
 			fieldType = field.GetDataType()
 		}
 		return MetricSpec{Op: op, FieldID: fieldID, FieldType: fieldType}, fieldID, nil
@@ -436,6 +438,9 @@ func buildTopHitsConfig(topHits *commonpb.TopHitsSpec, schema *schemapb.Collecti
 		fieldID, err := resolveFieldID(fieldName, schema, dynamicField)
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid top_hits.sort field %q: %w", fieldName, err)
+		}
+		if _, err := validateSearchAggregationFieldSupport(fieldName, fieldID, schema, "top_hits.sort field"); err != nil {
+			return nil, nil, err
 		}
 		cfg.Sort = append(cfg.Sort, SortCriterion{FieldID: fieldID, Dir: direction, NullFirst: sortSpec.GetNullFirst()})
 		appendUniqueFieldID(seen, &sortFieldIDs, fieldID)
@@ -488,6 +493,17 @@ func normalizeDirection(direction string, defaultDir string) (string, error) {
 	default:
 		return "", fmt.Errorf("direction must be asc or desc")
 	}
+}
+
+func validateSearchAggregationFieldSupport(fieldName string, fieldID int64, schema *schemapb.CollectionSchema, usage string) (*schemapb.FieldSchema, error) {
+	field := typeutil.GetFieldByID(schema, fieldID)
+	if field == nil {
+		return nil, nil
+	}
+	if field.GetDataType() == schemapb.DataType_JSON || field.GetIsDynamic() {
+		return nil, fmt.Errorf("%s %q: JSON / dynamic fields are not yet supported with search_aggregation", usage, fieldName)
+	}
+	return field, nil
 }
 
 func isJSONPathFieldExpr(fieldExpr string) bool {

--- a/internal/proxy/search_agg/context_builder_test.go
+++ b/internal/proxy/search_agg/context_builder_test.go
@@ -364,14 +364,14 @@ func TestBuildSearchAggregationContextRejectsJSONField(t *testing.T) {
 			Fields: []string{"meta"}, Size: 3,
 		}, schema, 1)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "not yet supported with search_aggregation")
+		require.Contains(t, err.Error(), "group_by field \"meta\": JSON / dynamic fields are not yet supported with search_aggregation")
 	})
 	t.Run("json path", func(t *testing.T) {
 		_, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
 			Fields: []string{"meta['region']"}, Size: 3,
 		}, schema, 1)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "not yet supported with search_aggregation")
+		require.Contains(t, err.Error(), "group_by field \"meta['region']\": JSON / dynamic fields are not yet supported with search_aggregation")
 	})
 }
 
@@ -443,6 +443,7 @@ func TestBuildSearchAggregationContextRejectsDynamicField(t *testing.T) {
 		Name: "agg_test",
 		Fields: []*schemapb.FieldSchema{
 			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "brand", DataType: schemapb.DataType_VarChar},
 			{FieldID: 109, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
 		},
 	}
@@ -450,7 +451,74 @@ func TestBuildSearchAggregationContextRejectsDynamicField(t *testing.T) {
 		Fields: []string{"arbitrary_dyn_field"}, Size: 3,
 	}, schema, 1)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "not yet supported with search_aggregation")
+	require.Contains(t, err.Error(), "group_by field \"arbitrary_dyn_field\": JSON / dynamic fields are not yet supported with search_aggregation")
+}
+
+func TestBuildSearchAggregationContextRejectsJSONDynamicMetricFields(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "agg_test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "brand", DataType: schemapb.DataType_VarChar},
+			{FieldID: 108, Name: "meta", DataType: schemapb.DataType_JSON},
+			{FieldID: 109, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		fieldName string
+	}{
+		{name: "plain json", fieldName: "meta"},
+		{name: "json path", fieldName: "meta['region']"},
+		{name: "dynamic field", fieldName: "dynamic_brand"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+				Fields: []string{"brand"},
+				Metrics: map[string]*commonpb.MetricAggSpec{
+					"field_count": {Op: "count", FieldName: tc.fieldName},
+				},
+			}, schema, 1)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "not yet supported with search_aggregation")
+		})
+	}
+}
+
+func TestBuildSearchAggregationContextRejectsJSONDynamicTopHitsSortFields(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Name: "agg_test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "brand", DataType: schemapb.DataType_VarChar},
+			{FieldID: 108, Name: "meta", DataType: schemapb.DataType_JSON},
+			{FieldID: 109, Name: "$meta", DataType: schemapb.DataType_JSON, IsDynamic: true},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		fieldName string
+	}{
+		{name: "plain json", fieldName: "meta"},
+		{name: "dynamic field", fieldName: "dynamic_brand"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := BuildSearchAggregationContext(&commonpb.SearchAggregationSpec{
+				Fields: []string{"brand"},
+				TopHits: &commonpb.TopHitsSpec{
+					Sort: []*commonpb.SortSpec{{FieldName: tc.fieldName}},
+				},
+			}, schema, 1)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "not yet supported with search_aggregation")
+		})
+	}
 }
 
 func TestBuildSearchAggregationContextValidationMatrix(t *testing.T) {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -799,8 +799,13 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 
 	t.isIterator = isIterator
 	t.Offset = offset
-	if t.aggCtx != nil && t.Offset > 0 {
-		return merr.WrapErrParameterInvalidMsg("offset is not supported with search_aggregation")
+	if t.aggCtx != nil {
+		if t.isIterator {
+			return merr.WrapErrParameterInvalidMsg("search iterator is not supported with search_aggregation")
+		}
+		if t.Offset > 0 {
+			return merr.WrapErrParameterInvalidMsg("offset is not supported with search_aggregation")
+		}
 	}
 	t.FieldId = queryInfo.GetQueryFieldId()
 

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -6473,6 +6473,24 @@ func TestSearchTask_SearchRequeryPolicy(t *testing.T) {
 		assert.False(t, task.needRequery, "only pk output should not trigger requery under outputvector policy")
 	})
 
+	t.Run("search_aggregation_with_iterator_should_fail", func(t *testing.T) {
+		const titleFieldID int64 = 102
+		groupFieldIDs := []int64{titleFieldID}
+		task := buildTask([]string{"title"})
+		task.Nq = 1
+		task.OutputFieldsId = []int64{titleFieldID}
+		task.GroupByFieldIds = groupFieldIDs
+		task.request.SearchParams = append(task.request.SearchParams, &commonpb.KeyValuePair{Key: IteratorField, Value: "True"})
+		aggCtx, err := search_agg.NewContext(1, []search_agg.LevelContext{{OwnFieldIDs: groupFieldIDs, Size: 1}}, groupFieldIDs, nil)
+		require.NoError(t, err)
+		task.aggCtx = aggCtx
+
+		err = task.initSearchRequest(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "search iterator is not supported with search_aggregation")
+	})
+
 	t.Run("search_aggregation_forces_no_requery", func(t *testing.T) {
 		Params.Save(Params.CommonCfg.SearchRequeryPolicy.Key, "Always")
 		defer Params.Save(Params.CommonCfg.SearchRequeryPolicy.Key, "OutputVector")


### PR DESCRIPTION
issue: #49841
issue: #49842

## Summary
- Reject search iterator when search_aggregation is enabled instead of returning an empty page.
- Reject JSON and dynamic fields across search_aggregation context building for group_by, metric sources, and top_hits sort fields.
- Add regression coverage for unsupported iterator and JSON/dynamic aggregation inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)