### PR TITLE
enhance: decouple querycoord dispatch from dist pull

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -434,6 +434,7 @@ queryCoord:
   channelTaskTimeout: 60000 # 1 minute
   segmentTaskTimeout: 120000 # 2 minute
   distPullInterval: 500
+  dispatchInterval: 500
   heartbeatAvailableInterval: 10000 # 10s, Only QueryNodes which fetched heartbeats within the duration are available
   loadTimeoutSeconds: 600
   distRequestTimeout: 5000 # the request timeout for querycoord fetching data distribution from querynodes, in milliseconds

--- a/internal/querycoordv2/dist/dist_controller.go
+++ b/internal/querycoordv2/dist/dist_controller.go
@@ -80,7 +80,7 @@ func (dc *ControllerImpl) SyncAll(ctx context.Context) {
 			if err != nil {
 				log.Warn("SyncAll come across err when getting data distribution", zap.Error(err))
 			} else {
-				handler.handleDistResp(ctx, resp, true)
+				handler.handleDistResp(ctx, resp)
 			}
 		}(h)
 	}

--- a/internal/querycoordv2/dist/dist_controller_test.go
+++ b/internal/querycoordv2/dist/dist_controller_test.go
@@ -168,7 +168,7 @@ func (suite *DistControllerTestSuite) TestSyncAll() {
 	).Run(func(args mock.Arguments) {
 		calledSet.Insert(args[1].(int64))
 	})
-	suite.mockScheduler.EXPECT().Dispatch(mock.Anything)
+	suite.mockScheduler.EXPECT().Dispatch(mock.Anything).Maybe()
 
 	// stop inner loop
 	suite.controller.handlers[1].stop()

--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -68,6 +68,21 @@ func (dh *distHandler) start(ctx context.Context) {
 	defer dh.wg.Done()
 	log := log.Ctx(ctx).With(zap.Int64("nodeID", dh.nodeID)).WithRateGroup("qcv2.distHandler", 1, 60)
 	log.Info("start dist handler")
+
+	var loopWG sync.WaitGroup
+	loopWG.Add(2)
+	go func() {
+		defer loopWG.Done()
+		dh.startPullDistLoop(ctx)
+	}()
+	go func() {
+		defer loopWG.Done()
+		dh.startDispatchLoop(ctx)
+	}()
+	loopWG.Wait()
+}
+
+func (dh *distHandler) startPullDistLoop(ctx context.Context) {
 	distInterval := Params.QueryCoordCfg.DistPullInterval.GetAsDuration(time.Millisecond)
 	ticker := time.NewTicker(distInterval)
 	defer ticker.Stop()
@@ -75,13 +90,13 @@ func (dh *distHandler) start(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Info("close dist handler due to context done")
+			log.Ctx(ctx).Info("close dist pull loop due to context done", zap.Int64("nodeID", dh.nodeID))
 			return
 		case <-dh.c:
-			log.Info("close dist handler")
+			log.Ctx(ctx).Info("close dist pull loop", zap.Int64("nodeID", dh.nodeID))
 			return
 		case <-ticker.C:
-			dh.pullDist(ctx, &failures, true)
+			dh.pullDist(ctx, &failures, false)
 			// only reset when interval updated
 			newDistInterval := Params.QueryCoordCfg.DistPullInterval.GetAsDuration(time.Millisecond)
 			if newDistInterval != distInterval {
@@ -91,6 +106,33 @@ func (dh *distHandler) start(ctx context.Context) {
 				default:
 				}
 				ticker.Reset(distInterval)
+			}
+		}
+	}
+}
+
+func (dh *distHandler) startDispatchLoop(ctx context.Context) {
+	dispatchInterval := Params.QueryCoordCfg.DispatchInterval.GetAsDuration(time.Millisecond)
+	ticker := time.NewTicker(dispatchInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Ctx(ctx).Info("close dist dispatch loop due to context done", zap.Int64("nodeID", dh.nodeID))
+			return
+		case <-dh.c:
+			log.Ctx(ctx).Info("close dist dispatch loop", zap.Int64("nodeID", dh.nodeID))
+			return
+		case <-ticker.C:
+			dh.scheduler.Dispatch(dh.nodeID)
+			newDispatchInterval := Params.QueryCoordCfg.DispatchInterval.GetAsDuration(time.Millisecond)
+			if newDispatchInterval != dispatchInterval {
+				dispatchInterval = newDispatchInterval
+				select {
+				case <-ticker.C:
+				default:
+				}
+				ticker.Reset(dispatchInterval)
 			}
 		}
 	}

--- a/internal/querycoordv2/dist/dist_handler.go
+++ b/internal/querycoordv2/dist/dist_handler.go
@@ -96,7 +96,7 @@ func (dh *distHandler) startPullDistLoop(ctx context.Context) {
 			log.Ctx(ctx).Info("close dist pull loop", zap.Int64("nodeID", dh.nodeID))
 			return
 		case <-ticker.C:
-			dh.pullDist(ctx, &failures, false)
+			dh.pullDist(ctx, &failures)
 			// only reset when interval updated
 			newDistInterval := Params.QueryCoordCfg.DistPullInterval.GetAsDuration(time.Millisecond)
 			if newDistInterval != distInterval {
@@ -138,7 +138,7 @@ func (dh *distHandler) startDispatchLoop(ctx context.Context) {
 	}
 }
 
-func (dh *distHandler) pullDist(ctx context.Context, failures *int, dispatchTask bool) {
+func (dh *distHandler) pullDist(ctx context.Context, failures *int) {
 	tr := timerecord.NewTimeRecorder("")
 	resp, err := dh.getDistribution(ctx)
 	d1 := tr.RecordSpan()
@@ -154,14 +154,14 @@ func (dh *distHandler) pullDist(ctx context.Context, failures *int, dispatchTask
 			RatedWarn(30.0, "failed to get data distribution", fields...)
 	} else {
 		*failures = 0
-		dh.handleDistResp(ctx, resp, dispatchTask)
+		dh.handleDistResp(ctx, resp)
 	}
 	log.Ctx(ctx).WithRateGroup("distHandler.pullDist", 1, 120).
 		RatedInfo(120.0, "pull and handle distribution done",
 			zap.Int("respSize", proto.Size(resp)), zap.Duration("pullDur", d1), zap.Duration("handleDur", tr.RecordSpan()))
 }
 
-func (dh *distHandler) handleDistResp(ctx context.Context, resp *querypb.GetDataDistributionResponse, dispatchTask bool) {
+func (dh *distHandler) handleDistResp(ctx context.Context, resp *querypb.GetDataDistributionResponse) {
 	node := dh.nodeManager.Get(resp.GetNodeID())
 	if node == nil {
 		return
@@ -189,10 +189,6 @@ func (dh *distHandler) handleDistResp(ctx context.Context, resp *querypb.GetData
 		)
 		dh.updateSegmentsDistribution(ctx, resp)
 		dh.updateChannelsDistribution(ctx, resp)
-	}
-
-	if dispatchTask {
-		dh.scheduler.Dispatch(dh.nodeID)
 	}
 }
 

--- a/internal/querycoordv2/dist/dist_handler_test.go
+++ b/internal/querycoordv2/dist/dist_handler_test.go
@@ -253,7 +253,7 @@ func TestHeartbeatMetricsRecording(t *testing.T) {
 	}
 
 	// Act: Handle distribution response
-	handler.handleDistResp(ctx, resp, false)
+	handler.handleDistResp(ctx, resp)
 
 	// Assert: Verify our specific metric was recorded with the expected value
 	finalMetricValue := getMetricValueForNode(fmt.Sprint(nodeID))

--- a/internal/querycoordv2/dist/dist_handler_test.go
+++ b/internal/querycoordv2/dist/dist_handler_test.go
@@ -291,6 +291,40 @@ func getMetricValueForNode(nodeID string) float64 {
 	return 0 // Return 0 if metric not found (default value)
 }
 
+func TestDispatchLoopUsesDispatchInterval(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	params.Save(params.QueryCoordCfg.DistPullInterval.Key, "60000")
+	params.Save(params.QueryCoordCfg.DispatchInterval.Key, "10")
+	defer params.Reset(params.QueryCoordCfg.DistPullInterval.Key)
+	defer params.Reset(params.QueryCoordCfg.DispatchInterval.Key)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dispatched := atomic.NewBool(false)
+	scheduler := task.NewMockScheduler(t)
+	scheduler.EXPECT().Dispatch(int64(1)).Run(func(nodeID int64) {
+		dispatched.Store(true)
+		cancel()
+	})
+
+	handler := &distHandler{
+		nodeID:    1,
+		c:         make(chan struct{}),
+		scheduler: scheduler,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.startDispatchLoop(ctx)
+	}()
+
+	assert.Eventually(t, dispatched.Load, time.Second, 10*time.Millisecond)
+	<-done
+}
+
 func TestDistHandlerSuite(t *testing.T) {
 	suite.Run(t, new(DistHandlerSuite))
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2677,6 +2677,7 @@ type queryCoordConfig struct {
 	ChannelTaskTimeout         ParamItem `refreshable:"true"`
 	SegmentTaskTimeout         ParamItem `refreshable:"true"`
 	DistPullInterval           ParamItem `refreshable:"false"`
+	DispatchInterval           ParamItem `refreshable:"false"`
 	HeartbeatAvailableInterval ParamItem `refreshable:"true"`
 	LoadTimeoutSeconds         ParamItem `refreshable:"true"`
 
@@ -3053,6 +3054,15 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       true,
 	}
 	p.DistPullInterval.Init(base.mgr)
+
+	p.DispatchInterval = ParamItem{
+		Key:          "queryCoord.dispatchInterval",
+		Version:      "2.6.0",
+		DefaultValue: "500",
+		PanicIfEmpty: true,
+		Export:       true,
+	}
+	p.DispatchInterval.Init(base.mgr)
 
 	p.LoadTimeoutSeconds = ParamItem{
 		Key:          "queryCoord.loadTimeoutSeconds",


### PR DESCRIPTION
## Summary

Decouple QueryCoord task dispatch from the dist pull loop.

When a QueryNode holds more and more segments, `GetDataDistribution` returns a larger distribution and `pullDist` can take longer. If dispatch only happens after dist pull finishes, QueryCoord task dispatch frequency drops together with pull latency, which can hurt scheduling stability. This PR keeps dispatch cadence independent from dist pull latency.

issue: #50158

## Changes

- Add `queryCoord.dispatchInterval` with a default value of 500ms.
- Start separate dist pull and task dispatch loops in each dist handler.
- Keep `pullDist` and `handleDistResp` focused on updating distribution state.
- Remove the old dispatch flag from dist response handling.

## Tests

- `gofumpt -l internal/querycoordv2/dist/dist_controller.go internal/querycoordv2/dist/dist_controller_test.go internal/querycoordv2/dist/dist_handler.go internal/querycoordv2/dist/dist_handler_test.go pkg/util/paramtable/component_param.go`
- `git diff upstream/master..HEAD --check`
- `go test -count=1 ./util/paramtable`
- `go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r ${MILVUS_WORK_DIR}/cmake_build/lib -r ${MILVUS_WORK_DIR}/internal/core/output/lib" ./internal/querycoordv2/dist -run "TestDistControllerSuite/TestSyncAll|TestDispatchLoopUsesDispatchInterval" -timeout 300s` blocked locally because this worktree has no `internal/core/output/lib/pkgconfig/milvus_core.pc`.
