### PR TITLE
enhance: [2.6] build text index inline in mixcompaction

### DIFF
--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -459,7 +459,12 @@ func (t *mixCompactionTask) createTextIndex(ctx context.Context,
 		segmentID:        segment.GetSegmentID(),
 		taskID:           t.GetPlanID(),
 		storageVersion:   segment.GetStorageVersion(),
-		insertBinlogs:    segment.GetInsertLogs(),
+		// Pass the output segment's own freshly-written manifest. Under StorageV2
+		// MultiSegmentWriter sets CompactionSegment.Manifest, and BuildTextIndex
+		// consumes it (config[SEGMENT_MANIFEST_KEY] + loon FFI properties), so it
+		// must be forwarded rather than left empty.
+		manifest:      segment.GetManifest(),
+		insertBinlogs: segment.GetInsertLogs(),
 	})
 }
 

--- a/internal/datanode/compactor/mix_compactor.go
+++ b/internal/datanode/compactor/mix_compactor.go
@@ -399,6 +399,42 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 	metrics.DataNodeCompactionLatency.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), t.plan.GetType().String()).Observe(float64(t.tr.ElapseSpan().Milliseconds()))
 	metrics.DataNodeCompactionLatencyInQueue.WithLabelValues(fmt.Sprint(paramtable.GetNodeID())).Observe(float64(durInQueue.Milliseconds()))
 
+	// Build text index inline for each output segment so the segment
+	// arrives at QueryNode with TextStatsLogs populated, avoiding the
+	// CGO_LOAD CreateTextIndex fallback at load time. Mirrors sortCompaction.
+	//
+	// Only sorted outputs get an inline text index. Unsorted mix-compaction
+	// outputs (from mergeSplit) are interim: a later sortcompaction will
+	// re-emit them as sorted and build the text index inline at that step.
+	// Building here would be discarded work, and stats_inspector also skips
+	// unsorted segments in its TextIndexJob filter, so the index would never
+	// be promoted to text_stats_logs in datacoord either.
+	textIndexStart := time.Now()
+	for _, resultSegment := range res {
+		if resultSegment.GetNumOfRows() == 0 {
+			continue
+		}
+		if !resultSegment.GetIsSorted() {
+			continue
+		}
+		textStatsLogs, err := t.createTextIndex(ctx, resultSegment)
+		if err != nil {
+			log.Warn("failed to create text indexes",
+				zap.Int64("targetSegmentID", resultSegment.GetSegmentID()),
+				zap.Error(err))
+			return nil, err
+		}
+		if len(textStatsLogs) == 0 {
+			continue
+		}
+		resultSegment.TextStatsLogs = textStatsLogs
+	}
+	createTextIndexCost := time.Since(textIndexStart)
+	metrics.DataNodeCompactionStageLatency.
+		WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), t.plan.GetType().String(), "create_text_index").
+		Observe(float64(createTextIndexCost.Milliseconds()))
+	log.Info("compact create text index done", zap.Duration("createTextIndexCost", createTextIndexCost))
+
 	planResult := &datapb.CompactionPlanResult{
 		State:    datapb.CompactionTaskState_completed,
 		PlanID:   t.GetPlanID(),
@@ -407,6 +443,24 @@ func (t *mixCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 		Type:     t.plan.GetType(),
 	}
 	return planResult, nil
+}
+
+// createTextIndex delegates to the shared helper buildTextIndexesForSegment
+// after assembling per-segment inputs. The wrapper exists so the per-segment
+// loop in Compact stays compact and so unit tests can mock the helper.
+func (t *mixCompactionTask) createTextIndex(ctx context.Context,
+	segment *datapb.CompactionSegment,
+) (map[int64]*datapb.TextIndexStats, error) {
+	return buildTextIndexesForSegment(ctx, buildTextIndexArgs{
+		plan:             t.plan,
+		compactionParams: t.compactionParams,
+		collectionID:     t.collectionID,
+		partitionID:      t.partitionID,
+		segmentID:        segment.GetSegmentID(),
+		taskID:           t.GetPlanID(),
+		storageVersion:   segment.GetStorageVersion(),
+		insertBinlogs:    segment.GetInsertLogs(),
+	})
 }
 
 func (t *mixCompactionTask) Complete() {

--- a/internal/datanode/compactor/mix_compactor_text_index_test.go
+++ b/internal/datanode/compactor/mix_compactor_text_index_test.go
@@ -22,18 +22,56 @@ import (
 
 	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
-// These tests mock the package-level helper buildTextIndexesForSegment so that
-// they can exercise the mixcompaction inline text-index wiring without invoking
-// the CGO-backed indexcgowrapper.CreateTextIndex path. Mockey is the only
-// viable monkey-patching framework for an unexported package-level function.
+// textMatchSchema returns a schema whose single VarChar field has enable_match.
+func textMatchSchema(fieldID int64) *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  fieldID,
+				Name:     "text_field",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "max_length", Value: "256"},
+					{Key: "enable_match", Value: "true"},
+				},
+			},
+		},
+	}
+}
+
+// capturedBuild holds the last BuildIndexInfo passed to the mocked CreateTextIndex.
+type capturedBuild struct {
+	info *indexcgopb.BuildIndexInfo
+}
+
+// mockCreateTextIndexCGO mocks indexcgowrapper.CreateTextIndex (the CGO leaf used
+// by buildTextIndexesForSegment) so the helper body runs without the real
+// tantivy/indexcgowrapper stack. It captures the last BuildIndexInfo for
+// assertions and returns a cleanup func.
+func mockCreateTextIndexCGO(uploaded map[string]int64) (*capturedBuild, func()) {
+	cap := &capturedBuild{}
+	m := mockey.Mock(indexcgowrapper.CreateTextIndex).To(
+		func(ctx context.Context, info *indexcgopb.BuildIndexInfo) (map[string]int64, error) {
+			cap.info = info
+			return uploaded, nil
+		}).Build()
+	return cap, func() { m.UnPatch() }
+}
+
 func TestMixCompaction_createTextIndex_PopulatesStatsForEnableMatchFields(t *testing.T) {
 	paramtable.Get().Init(paramtable.NewBaseTable())
 
@@ -125,62 +163,224 @@ func TestMixCompaction_createTextIndex_PropagatesError(t *testing.T) {
 	assert.ErrorIs(t, err, assert.AnError)
 }
 
-func TestMixCompaction_inlineTextIndex_AssignsToOutputSegments(t *testing.T) {
+// TestMixCompaction_Compact_InlineTextIndex drives the real mixCompactionTask.Compact()
+// and asserts the inline text-index loop's behavior end to end: sorted outputs get
+// TextStatsLogs while empty and unsorted interim outputs are skipped. mergeSplit,
+// decompress and the CGO-backed build helper are mocked so the focus stays on the
+// loop in Compact().
+func TestMixCompaction_Compact_InlineTextIndex(t *testing.T) {
 	paramtable.Get().Init(paramtable.NewBaseTable())
 
-	// Mix of sorted (build), empty (skip), and non-empty-but-unsorted
-	// (skip - interim mergeSplit output).
-	res := []*datapb.CompactionSegment{
-		{SegmentID: 1, NumOfRows: 100, IsSorted: true},
-		{SegmentID: 2, NumOfRows: 0, IsSorted: true},
-		{SegmentID: 3, NumOfRows: 200, IsSorted: true},
-		{SegmentID: 4, NumOfRows: 50},
+	const fieldID = int64(101)
+
+	mergeOut := []*datapb.CompactionSegment{
+		{SegmentID: 1, NumOfRows: 100, IsSorted: true}, // build
+		{SegmentID: 2, NumOfRows: 0, IsSorted: true},   // skip: empty
+		{SegmentID: 3, NumOfRows: 200, IsSorted: true}, // build
+		{SegmentID: 4, NumOfRows: 50},                  // skip: unsorted interim output
 	}
 
-	statsBySeg := map[int64]map[int64]*datapb.TextIndexStats{
-		1: {101: {FieldID: 101, BuildID: 99, Files: []string{"a"}, LogSize: 1, MemorySize: 1}},
-		3: {101: {FieldID: 101, BuildID: 99, Files: []string{"b"}, LogSize: 2, MemorySize: 2}},
-		4: {101: {FieldID: 101, BuildID: 99, Files: []string{"c"}, LogSize: 3, MemorySize: 3}},
+	statsFor := func(segID int64) map[int64]*datapb.TextIndexStats {
+		return map[int64]*datapb.TextIndexStats{
+			fieldID: {FieldID: fieldID, BuildID: segID, Files: []string{"f"}, LogSize: 1, MemorySize: 1},
+		}
 	}
 
-	mockBuild := mockey.Mock(buildTextIndexesForSegment).
+	buildMock := mockey.Mock(buildTextIndexesForSegment).
 		To(func(_ context.Context, args buildTextIndexArgs) (map[int64]*datapb.TextIndexStats, error) {
-			return statsBySeg[args.segmentID], nil
+			return statsFor(args.segmentID), nil
 		}).Build()
-	defer mockBuild.UnPatch()
+	defer buildMock.UnPatch()
 
-	task := &mixCompactionTask{
-		plan: &datapb.CompactionPlan{
-			PlanID: 99,
-			Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{
-				FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar,
-				TypeParams: []*commonpb.KeyValuePair{{Key: "enable_match", Value: "true"}},
-			}}},
+	mergeMock := mockey.Mock((*mixCompactionTask).mergeSplit).Return(mergeOut, nil).Build()
+	defer mergeMock.UnPatch()
+	decompressMock := mockey.Mock(binlog.DecompressCompactionBinlogsWithRootPath).Return(nil).Build()
+	defer decompressMock.UnPatch()
+
+	params := compaction.GenParams()
+	params.UseMergeSort = false // force the mergeSplit path (which we mock)
+
+	plan := &datapb.CompactionPlan{
+		PlanID:  999,
+		Type:    datapb.CompactionType_MixCompaction,
+		Channel: "ch-1",
+		MaxSize: 64 * 1024 * 1024,
+		Schema:  textMatchSchema(fieldID),
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
+			{
+				CollectionID: 1,
+				PartitionID:  2,
+				SegmentID:    100,
+				FieldBinlogs: []*datapb.FieldBinlog{
+					{FieldID: fieldID, Binlogs: []*datapb.Binlog{{LogID: 1, EntriesNum: 100, MemorySize: 1024}}},
+				},
+			},
 		},
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 20000, End: 30000},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 30000, End: 40000},
+	}
+
+	task := NewMixCompactionTask(context.Background(), nil, plan, params, []int64{fieldID})
+
+	result, err := task.Compact()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, datapb.CompactionTaskState_completed, result.GetState())
+
+	byID := make(map[int64]*datapb.CompactionSegment)
+	for _, s := range result.GetSegments() {
+		byID[s.GetSegmentID()] = s
+	}
+	require.Len(t, byID, 4)
+	assert.Len(t, byID[1].GetTextStatsLogs(), 1, "sorted output gets inline text index")
+	assert.Nil(t, byID[2].GetTextStatsLogs(), "empty output skipped")
+	assert.Len(t, byID[3].GetTextStatsLogs(), 1, "sorted output gets inline text index")
+	assert.Nil(t, byID[4].GetTextStatsLogs(), "unsorted interim output skipped")
+}
+
+// TestMixCompaction_Compact_InlineTextIndex_BuildError ensures a failure from the
+// inline build aborts Compact().
+func TestMixCompaction_Compact_InlineTextIndex_BuildError(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	mergeOut := []*datapb.CompactionSegment{{SegmentID: 1, NumOfRows: 100, IsSorted: true}}
+	buildMock := mockey.Mock(buildTextIndexesForSegment).Return(nil, assert.AnError).Build()
+	defer buildMock.UnPatch()
+	mergeMock := mockey.Mock((*mixCompactionTask).mergeSplit).Return(mergeOut, nil).Build()
+	defer mergeMock.UnPatch()
+	decompressMock := mockey.Mock(binlog.DecompressCompactionBinlogsWithRootPath).Return(nil).Build()
+	defer decompressMock.UnPatch()
+
+	params := compaction.GenParams()
+	params.UseMergeSort = false
+
+	plan := &datapb.CompactionPlan{
+		PlanID:  999,
+		Type:    datapb.CompactionType_MixCompaction,
+		Channel: "ch-1",
+		MaxSize: 64 * 1024 * 1024,
+		Schema:  textMatchSchema(101),
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{
+			{
+				CollectionID: 1, PartitionID: 2, SegmentID: 100,
+				FieldBinlogs: []*datapb.FieldBinlog{
+					{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 1, EntriesNum: 100, MemorySize: 1024}}},
+				},
+			},
+		},
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 20000, End: 30000},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 30000, End: 40000},
+	}
+
+	task := NewMixCompactionTask(context.Background(), nil, plan, params, []int64{101})
+	_, err := task.Compact()
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// TestBuildTextIndexesForSegment_V1 exercises the real helper body for a storage-V1
+// segment: insert files are resolved from binlogs, the index is built (CGO mocked)
+// and TextIndexStats are aggregated.
+func TestBuildTextIndexesForSegment_V1(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	captured, cleanup := mockCreateTextIndexCGO(map[string]int64{"a.idx": 111, "b.idx": 222})
+	defer cleanup()
+
+	args := buildTextIndexArgs{
+		plan:             &datapb.CompactionPlan{PlanID: 5, CurrentScalarIndexVersion: 1, Schema: textMatchSchema(101)},
+		compactionParams: compaction.GenParams(),
 		collectionID:     1,
 		partitionID:      2,
+		segmentID:        3,
+		taskID:           5,
+		storageVersion:   storage.StorageV1,
+		insertBinlogs:    []*datapb.FieldBinlog{{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 9}}}},
+	}
+
+	got, err := buildTextIndexesForSegment(context.Background(), args)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	ts := got[101]
+	require.NotNil(t, ts)
+	assert.Equal(t, int64(101), ts.GetFieldID())
+	assert.Equal(t, int64(5), ts.GetBuildID())
+	assert.Equal(t, int64(333), ts.GetLogSize())
+	assert.Equal(t, int64(333), ts.GetMemorySize())
+	assert.Len(t, ts.GetFiles(), 2)
+
+	// V1: InsertFiles resolved from binlogs, SegmentInsertFiles not set.
+	assert.NotEmpty(t, captured.info.GetInsertFiles())
+	assert.Nil(t, captured.info.GetSegmentInsertFiles())
+}
+
+// TestBuildTextIndexesForSegment_V2 exercises the storage-V2 branch where insert
+// files come from SegmentInsertFiles rather than per-field binlog paths.
+func TestBuildTextIndexesForSegment_V2(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	captured, cleanup := mockCreateTextIndexCGO(map[string]int64{"a.idx": 10})
+	defer cleanup()
+
+	args := buildTextIndexArgs{
+		plan:             &datapb.CompactionPlan{PlanID: 6, Schema: textMatchSchema(101)},
 		compactionParams: compaction.GenParams(),
+		collectionID:     1,
+		partitionID:      2,
+		segmentID:        3,
+		taskID:           6,
+		storageVersion:   storage.StorageV2,
+		insertBinlogs:    []*datapb.FieldBinlog{{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 9}}}},
 	}
 
-	// Mirrors the guards in mixCompactionTask.Compact(): empty segments and
-	// non-sorted outputs (interim mergeSplit results) must not get an inline
-	// text index — they will be rebuilt by the next sortcompaction.
-	for _, seg := range res {
-		if seg.GetNumOfRows() == 0 {
-			continue
-		}
-		if !seg.GetIsSorted() {
-			continue
-		}
-		stats, err := task.createTextIndex(context.Background(), seg)
-		assert.NoError(t, err)
-		seg.TextStatsLogs = stats
+	got, err := buildTextIndexesForSegment(context.Background(), args)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	// V2: getInsertFiles returns empty, SegmentInsertFiles populated instead.
+	assert.Empty(t, captured.info.GetInsertFiles())
+	assert.NotNil(t, captured.info.GetSegmentInsertFiles())
+}
+
+// TestBuildTextIndexesForSegment_CreateError ensures CGO build errors propagate.
+func TestBuildTextIndexesForSegment_CreateError(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	m := mockey.Mock(indexcgowrapper.CreateTextIndex).Return(nil, assert.AnError).Build()
+	defer m.UnPatch()
+
+	args := buildTextIndexArgs{
+		plan:             &datapb.CompactionPlan{PlanID: 9, Schema: textMatchSchema(101)},
+		compactionParams: compaction.GenParams(),
+		collectionID:     1,
+		partitionID:      2,
+		segmentID:        3,
+		taskID:           9,
+		storageVersion:   storage.StorageV2,
+		insertBinlogs:    []*datapb.FieldBinlog{{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 9}}}},
 	}
 
-	assert.Len(t, res[0].GetTextStatsLogs(), 1)
-	assert.Nil(t, res[1].GetTextStatsLogs(), "empty segments must be skipped")
-	assert.Len(t, res[2].GetTextStatsLogs(), 1)
-	assert.Nil(t, res[3].GetTextStatsLogs(), "unsorted segments must be skipped")
+	_, err := buildTextIndexesForSegment(context.Background(), args)
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+// TestBuildTextIndexesForSegment_MissingBinlogError ensures a V1 segment whose
+// enable_match field has no binlog produces an error.
+func TestBuildTextIndexesForSegment_MissingBinlogError(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	args := buildTextIndexArgs{
+		plan:             &datapb.CompactionPlan{PlanID: 10, Schema: textMatchSchema(101)},
+		compactionParams: compaction.GenParams(),
+		collectionID:     1,
+		partitionID:      2,
+		segmentID:        3,
+		taskID:           10,
+		storageVersion:   storage.StorageV1,
+		insertBinlogs:    nil, // no binlog for field 101
+	}
+
+	_, err := buildTextIndexesForSegment(context.Background(), args)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "field binlog not found")
 }
 
 // Direct test of the shared helper for the no-enable_match early-return path —

--- a/internal/datanode/compactor/mix_compactor_text_index_test.go
+++ b/internal/datanode/compactor/mix_compactor_text_index_test.go
@@ -124,6 +124,9 @@ func TestMixCompaction_createTextIndex_PopulatesStatsForEnableMatchFields(t *tes
 			assert.Equal(t, segmentID, args.segmentID)
 			assert.Equal(t, planID, args.taskID)
 			assert.Equal(t, plan, args.plan)
+			// The wrapper must forward the OUTPUT segment's own manifest, which
+			// BuildTextIndex consumes for StorageV2 segments.
+			assert.Equal(t, "out-seg-manifest", args.manifest)
 			return map[int64]*datapb.TextIndexStats{
 				textFieldID: {
 					FieldID:    textFieldID,
@@ -136,7 +139,7 @@ func TestMixCompaction_createTextIndex_PopulatesStatsForEnableMatchFields(t *tes
 		}).Build()
 	defer mockBuild.UnPatch()
 
-	out := &datapb.CompactionSegment{SegmentID: segmentID, NumOfRows: 100}
+	out := &datapb.CompactionSegment{SegmentID: segmentID, NumOfRows: 100, Manifest: "out-seg-manifest"}
 
 	got, err := task.createTextIndex(context.Background(), out)
 	assert.NoError(t, err)
@@ -329,6 +332,7 @@ func TestBuildTextIndexesForSegment_V2(t *testing.T) {
 		segmentID:        3,
 		taskID:           6,
 		storageVersion:   storage.StorageV2,
+		manifest:         "seg-manifest",
 		insertBinlogs:    []*datapb.FieldBinlog{{FieldID: 101, Binlogs: []*datapb.Binlog{{LogID: 9}}}},
 	}
 
@@ -338,6 +342,9 @@ func TestBuildTextIndexesForSegment_V2(t *testing.T) {
 	// V2: getInsertFiles returns empty, SegmentInsertFiles populated instead.
 	assert.Empty(t, captured.info.GetInsertFiles())
 	assert.NotNil(t, captured.info.GetSegmentInsertFiles())
+	// The manifest must be forwarded to BuildIndexInfo — BuildTextIndex consumes
+	// it for StorageV2 (config[SEGMENT_MANIFEST_KEY] + loon FFI properties).
+	assert.Equal(t, "seg-manifest", captured.info.GetManifest())
 }
 
 // TestBuildTextIndexesForSegment_CreateError ensures CGO build errors propagate.

--- a/internal/datanode/compactor/mix_compactor_text_index_test.go
+++ b/internal/datanode/compactor/mix_compactor_text_index_test.go
@@ -1,0 +1,210 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+// These tests mock the package-level helper buildTextIndexesForSegment so that
+// they can exercise the mixcompaction inline text-index wiring without invoking
+// the CGO-backed indexcgowrapper.CreateTextIndex path. Mockey is the only
+// viable monkey-patching framework for an unexported package-level function.
+func TestMixCompaction_createTextIndex_PopulatesStatsForEnableMatchFields(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	const (
+		collectionID  = int64(7001)
+		partitionID   = int64(7002)
+		segmentID     = int64(7003)
+		planID        = int64(42)
+		textFieldID   = int64(101)
+		scalarFieldID = int64(102)
+	)
+
+	schema := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:  textFieldID,
+				Name:     "text_field",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "max_length", Value: "256"},
+					{Key: "enable_match", Value: "true"},
+				},
+			},
+			{
+				FieldID:  scalarFieldID,
+				Name:     "scalar_field",
+				DataType: schemapb.DataType_Int64,
+			},
+		},
+	}
+
+	plan := &datapb.CompactionPlan{
+		PlanID: planID,
+		Schema: schema,
+		Type:   datapb.CompactionType_MixCompaction,
+	}
+
+	task := &mixCompactionTask{
+		plan:             plan,
+		collectionID:     collectionID,
+		partitionID:      partitionID,
+		compactionParams: compaction.GenParams(),
+	}
+
+	mockBuild := mockey.Mock(buildTextIndexesForSegment).
+		To(func(ctx context.Context, args buildTextIndexArgs) (map[int64]*datapb.TextIndexStats, error) {
+			assert.Equal(t, collectionID, args.collectionID)
+			assert.Equal(t, partitionID, args.partitionID)
+			assert.Equal(t, segmentID, args.segmentID)
+			assert.Equal(t, planID, args.taskID)
+			assert.Equal(t, plan, args.plan)
+			return map[int64]*datapb.TextIndexStats{
+				textFieldID: {
+					FieldID:    textFieldID,
+					BuildID:    planID,
+					Files:      []string{"meta.json_0"},
+					LogSize:    1024,
+					MemorySize: 1024,
+				},
+			}, nil
+		}).Build()
+	defer mockBuild.UnPatch()
+
+	out := &datapb.CompactionSegment{SegmentID: segmentID, NumOfRows: 100}
+
+	got, err := task.createTextIndex(context.Background(), out)
+	assert.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Contains(t, got, textFieldID)
+	assert.NotContains(t, got, scalarFieldID)
+}
+
+func TestMixCompaction_createTextIndex_PropagatesError(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	task := &mixCompactionTask{
+		plan:             &datapb.CompactionPlan{PlanID: 1, Schema: &schemapb.CollectionSchema{}},
+		collectionID:     1,
+		partitionID:      2,
+		compactionParams: compaction.GenParams(),
+	}
+
+	mockBuild := mockey.Mock(buildTextIndexesForSegment).
+		Return(nil, assert.AnError).Build()
+	defer mockBuild.UnPatch()
+
+	_, err := task.createTextIndex(context.Background(), &datapb.CompactionSegment{SegmentID: 99})
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestMixCompaction_inlineTextIndex_AssignsToOutputSegments(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	// Mix of sorted (build), empty (skip), and non-empty-but-unsorted
+	// (skip - interim mergeSplit output).
+	res := []*datapb.CompactionSegment{
+		{SegmentID: 1, NumOfRows: 100, IsSorted: true},
+		{SegmentID: 2, NumOfRows: 0, IsSorted: true},
+		{SegmentID: 3, NumOfRows: 200, IsSorted: true},
+		{SegmentID: 4, NumOfRows: 50},
+	}
+
+	statsBySeg := map[int64]map[int64]*datapb.TextIndexStats{
+		1: {101: {FieldID: 101, BuildID: 99, Files: []string{"a"}, LogSize: 1, MemorySize: 1}},
+		3: {101: {FieldID: 101, BuildID: 99, Files: []string{"b"}, LogSize: 2, MemorySize: 2}},
+		4: {101: {FieldID: 101, BuildID: 99, Files: []string{"c"}, LogSize: 3, MemorySize: 3}},
+	}
+
+	mockBuild := mockey.Mock(buildTextIndexesForSegment).
+		To(func(_ context.Context, args buildTextIndexArgs) (map[int64]*datapb.TextIndexStats, error) {
+			return statsBySeg[args.segmentID], nil
+		}).Build()
+	defer mockBuild.UnPatch()
+
+	task := &mixCompactionTask{
+		plan: &datapb.CompactionPlan{
+			PlanID: 99,
+			Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{{
+				FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{{Key: "enable_match", Value: "true"}},
+			}}},
+		},
+		collectionID:     1,
+		partitionID:      2,
+		compactionParams: compaction.GenParams(),
+	}
+
+	// Mirrors the guards in mixCompactionTask.Compact(): empty segments and
+	// non-sorted outputs (interim mergeSplit results) must not get an inline
+	// text index — they will be rebuilt by the next sortcompaction.
+	for _, seg := range res {
+		if seg.GetNumOfRows() == 0 {
+			continue
+		}
+		if !seg.GetIsSorted() {
+			continue
+		}
+		stats, err := task.createTextIndex(context.Background(), seg)
+		assert.NoError(t, err)
+		seg.TextStatsLogs = stats
+	}
+
+	assert.Len(t, res[0].GetTextStatsLogs(), 1)
+	assert.Nil(t, res[1].GetTextStatsLogs(), "empty segments must be skipped")
+	assert.Len(t, res[2].GetTextStatsLogs(), 1)
+	assert.Nil(t, res[3].GetTextStatsLogs(), "unsorted segments must be skipped")
+}
+
+// Direct test of the shared helper for the no-enable_match early-return path —
+// the helper iterates the schema, finds nothing to build, and returns an empty
+// map without touching CGO.
+func TestBuildTextIndexesForSegment_NoEnableMatchFields(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	args := buildTextIndexArgs{
+		plan: &datapb.CompactionPlan{
+			PlanID: 1,
+			Schema: &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "id", DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "varchar_no_match", DataType: schemapb.DataType_VarChar},
+			}},
+		},
+		compactionParams: compaction.GenParams(),
+		collectionID:     1,
+		partitionID:      2,
+		segmentID:        3,
+		taskID:           1,
+	}
+
+	got, err := buildTextIndexesForSegment(context.Background(), args)
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/internal/datanode/compactor/mix_compactor_text_index_test.go
+++ b/internal/datanode/compactor/mix_compactor_text_index_test.go
@@ -415,3 +415,34 @@ func TestBuildTextIndexesForSegment_NoEnableMatchFields(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, got)
 }
+
+// TestSortCompaction_createTextIndex_ForwardsPassedManifest guards the fix that
+// sort builds the text index over the OUTPUT segment's manifest: the wrapper must
+// forward the manifest argument it's given, NOT t.manifest (the INPUT segment's).
+// Under StorageV2 the manifest is the data source, so using the input manifest
+// would index unsorted input rows against the sorted output segment.
+func TestSortCompaction_createTextIndex_ForwardsPassedManifest(t *testing.T) {
+	paramtable.Get().Init(paramtable.NewBaseTable())
+
+	task := &sortCompactionTask{
+		plan:             &datapb.CompactionPlan{PlanID: 1, Schema: textMatchSchema(101)},
+		compactionParams: compaction.GenParams(),
+		collectionID:     1,
+		partitionID:      2,
+		storageVersion:   storage.StorageV2,
+		manifest:         "input-manifest", // INPUT segment manifest — must NOT be used
+	}
+
+	var gotManifest string
+	mockBuild := mockey.Mock(buildTextIndexesForSegment).
+		To(func(_ context.Context, args buildTextIndexArgs) (map[int64]*datapb.TextIndexStats, error) {
+			gotManifest = args.manifest
+			return map[int64]*datapb.TextIndexStats{101: {FieldID: 101}}, nil
+		}).Build()
+	defer mockBuild.UnPatch()
+
+	_, err := task.createTextIndex(context.Background(), 1, 2, 3, 1, "output-manifest", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "output-manifest", gotManifest,
+		"sort must forward the OUTPUT segment manifest passed in, not t.manifest (the input segment's)")
+}

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -20,31 +20,25 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
-	"sync"
 	"time"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/compaction"
-	"github.com/milvus-io/milvus/internal/datanode/util"
 	"github.com/milvus-io/milvus/internal/flushcommon/io"
 	"github.com/milvus-io/milvus/internal/metastore/kv/binlog"
 	"github.com/milvus-io/milvus/internal/storage"
-	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
-	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v2/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
@@ -458,113 +452,15 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 	taskID int64,
 	insertBinlogs []*datapb.FieldBinlog,
 ) (map[int64]*datapb.TextIndexStats, error) {
-	log := log.Ctx(ctx).With(
-		zap.Int64("collectionID", collectionID),
-		zap.Int64("partitionID", partitionID),
-		zap.Int64("segmentID", segmentID),
-	)
-
-	fieldBinlogs := lo.GroupBy(insertBinlogs, func(binlog *datapb.FieldBinlog) int64 {
-		return binlog.GetFieldID()
+	return buildTextIndexesForSegment(ctx, buildTextIndexArgs{
+		plan:             t.plan,
+		compactionParams: t.compactionParams,
+		collectionID:     collectionID,
+		partitionID:      partitionID,
+		segmentID:        segmentID,
+		taskID:           taskID,
+		storageVersion:   t.storageVersion,
+		manifest:         t.manifest,
+		insertBinlogs:    insertBinlogs,
 	})
-
-	getInsertFiles := func(fieldID int64) ([]string, error) {
-		if t.storageVersion == storage.StorageV2 {
-			return []string{}, nil
-		}
-		binlogs, ok := fieldBinlogs[fieldID]
-		if !ok {
-			return nil, merr.WrapErrServiceInternalMsg("field binlog not found for field %d", fieldID)
-		}
-		result := make([]string, 0, len(binlogs))
-		for _, binlog := range binlogs {
-			for _, file := range binlog.GetBinlogs() {
-				result = append(result, metautil.BuildInsertLogPath(t.compactionParams.StorageConfig.GetRootPath(),
-					collectionID, partitionID, segmentID, fieldID, file.GetLogID()))
-			}
-		}
-		return result, nil
-	}
-
-	newStorageConfig, err := util.ParseStorageConfig(t.compactionParams.StorageConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// Concurrent create text index for all match-enabled fields
-	var (
-		mu            sync.Mutex
-		textIndexLogs = make(map[int64]*datapb.TextIndexStats)
-	)
-
-	eg, egCtx := errgroup.WithContext(ctx)
-
-	for _, field := range t.plan.GetSchema().GetFields() {
-		field := field
-		h := typeutil.CreateFieldSchemaHelper(field)
-		if !h.EnableMatch() {
-			continue
-		}
-		log.Info("field enable match, ready to create text index", zap.Int64("field id", field.GetFieldID()))
-
-		eg.Go(func() error {
-			files, err := getInsertFiles(field.GetFieldID())
-			if err != nil {
-				return err
-			}
-
-			buildIndexParams := &indexcgopb.BuildIndexInfo{
-				BuildID:                   t.GetPlanID(),
-				CollectionID:              collectionID,
-				PartitionID:               partitionID,
-				SegmentID:                 segmentID,
-				IndexVersion:              0, // always zero
-				InsertFiles:               files,
-				FieldSchema:               field,
-				StorageConfig:             newStorageConfig,
-				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(t.plan.GetCurrentScalarIndexVersion()),
-				StorageVersion:            t.storageVersion,
-				Manifest:                  t.manifest,
-			}
-
-			if t.storageVersion == storage.StorageV2 {
-				buildIndexParams.SegmentInsertFiles = util.GetSegmentInsertFiles(
-					insertBinlogs,
-					t.compactionParams.StorageConfig,
-					collectionID,
-					partitionID,
-					segmentID)
-			}
-			uploaded, err := indexcgowrapper.CreateTextIndex(egCtx, buildIndexParams)
-			if err != nil {
-				return err
-			}
-
-			mu.Lock()
-			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
-			textIndexLogs[field.GetFieldID()] = &datapb.TextIndexStats{
-				FieldID:                   field.GetFieldID(),
-				Version:                   0,
-				BuildID:                   taskID,
-				Files:                     lo.Keys(uploaded),
-				LogSize:                   totalSize,
-				MemorySize:                totalSize,
-				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(t.plan.GetCurrentScalarIndexVersion()),
-			}
-			mu.Unlock()
-
-			log.Info("field enable match, create text index done",
-				zap.Int64("segmentID", segmentID),
-				zap.Int64("field id", field.GetFieldID()),
-				zap.Strings("files", lo.Keys(uploaded)),
-			)
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		return nil, err
-	}
-
-	return textIndexLogs, nil
 }

--- a/internal/datanode/compactor/sort_compaction.go
+++ b/internal/datanode/compactor/sort_compaction.go
@@ -391,6 +391,7 @@ func (t *sortCompactionTask) Compact() (*datapb.CompactionPlanResult, error) {
 	stepStart = time.Now()
 	textStatsLogs, err := t.createTextIndex(ctx,
 		t.collectionID, t.partitionID, targetSegemntID, t.GetPlanID(),
+		res.GetSegments()[0].GetManifest(),
 		res.GetSegments()[0].GetInsertLogs())
 	if err != nil {
 		log.Warn("failed to create text indexes", zap.Int64("targetSegmentID", targetSegemntID),
@@ -450,6 +451,7 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 	partitionID int64,
 	segmentID int64,
 	taskID int64,
+	manifest string,
 	insertBinlogs []*datapb.FieldBinlog,
 ) (map[int64]*datapb.TextIndexStats, error) {
 	return buildTextIndexesForSegment(ctx, buildTextIndexArgs{
@@ -460,7 +462,11 @@ func (t *sortCompactionTask) createTextIndex(ctx context.Context,
 		segmentID:        segmentID,
 		taskID:           taskID,
 		storageVersion:   t.storageVersion,
-		manifest:         t.manifest,
-		insertBinlogs:    insertBinlogs,
+		// Use the OUTPUT segment's own manifest, not the input segment's
+		// (t.manifest). Under StorageV2 the text-index build reads field data
+		// via the manifest, so the index must reflect the sorted OUTPUT
+		// segment's rows/order, not the unsorted input's.
+		manifest:      manifest,
+		insertBinlogs: insertBinlogs,
 	})
 }

--- a/internal/datanode/compactor/text_index.go
+++ b/internal/datanode/compactor/text_index.go
@@ -1,0 +1,168 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compactor
+
+import (
+	"context"
+	"sync"
+
+	"github.com/samber/lo"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/milvus-io/milvus/internal/compaction"
+	"github.com/milvus-io/milvus/internal/datanode/util"
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/indexcgowrapper"
+	"github.com/milvus-io/milvus/pkg/v2/common"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexcgopb"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/metautil"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+)
+
+// buildTextIndexArgs bundles per-call inputs for buildTextIndexesForSegment.
+// taskID is recorded as the BuildID on each produced TextIndexStats; for both
+// sort_compaction and mix_compaction this is the compaction plan ID.
+type buildTextIndexArgs struct {
+	plan             *datapb.CompactionPlan
+	compactionParams compaction.Params
+	collectionID     int64
+	partitionID      int64
+	segmentID        int64
+	taskID           int64
+	storageVersion   int64
+	manifest         string
+	insertBinlogs    []*datapb.FieldBinlog
+}
+
+// buildTextIndexesForSegment creates text indexes for all enable_match fields
+// on a single compaction output and returns the per-field TextIndexStats. The
+// caller is responsible for assigning the result to the output segment's
+// TextStatsLogs.
+func buildTextIndexesForSegment(ctx context.Context, args buildTextIndexArgs) (map[int64]*datapb.TextIndexStats, error) {
+	log := log.Ctx(ctx).With(
+		zap.Int64("collectionID", args.collectionID),
+		zap.Int64("partitionID", args.partitionID),
+		zap.Int64("segmentID", args.segmentID),
+	)
+
+	fieldBinlogs := lo.GroupBy(args.insertBinlogs, func(binlog *datapb.FieldBinlog) int64 {
+		return binlog.GetFieldID()
+	})
+
+	getInsertFiles := func(fieldID int64) ([]string, error) {
+		if args.storageVersion == storage.StorageV2 {
+			return []string{}, nil
+		}
+		binlogs, ok := fieldBinlogs[fieldID]
+		if !ok {
+			return nil, merr.WrapErrServiceInternalMsg("field binlog not found for field %d", fieldID)
+		}
+		result := make([]string, 0, len(binlogs))
+		for _, binlog := range binlogs {
+			for _, file := range binlog.GetBinlogs() {
+				result = append(result, metautil.BuildInsertLogPath(args.compactionParams.StorageConfig.GetRootPath(),
+					args.collectionID, args.partitionID, args.segmentID, fieldID, file.GetLogID()))
+			}
+		}
+		return result, nil
+	}
+
+	newStorageConfig, err := util.ParseStorageConfig(args.compactionParams.StorageConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		mu            sync.Mutex
+		textIndexLogs = make(map[int64]*datapb.TextIndexStats)
+	)
+
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	for _, field := range args.plan.GetSchema().GetFields() {
+		field := field
+		h := typeutil.CreateFieldSchemaHelper(field)
+		if !h.EnableMatch() {
+			continue
+		}
+		log.Info("field enable match, ready to create text index", zap.Int64("field id", field.GetFieldID()))
+
+		eg.Go(func() error {
+			files, err := getInsertFiles(field.GetFieldID())
+			if err != nil {
+				return err
+			}
+
+			buildIndexParams := &indexcgopb.BuildIndexInfo{
+				BuildID:                   args.taskID,
+				CollectionID:              args.collectionID,
+				PartitionID:               args.partitionID,
+				SegmentID:                 args.segmentID,
+				IndexVersion:              0, // always zero
+				InsertFiles:               files,
+				FieldSchema:               field,
+				StorageConfig:             newStorageConfig,
+				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(args.plan.GetCurrentScalarIndexVersion()),
+				StorageVersion:            args.storageVersion,
+				Manifest:                  args.manifest,
+			}
+
+			if args.storageVersion == storage.StorageV2 {
+				buildIndexParams.SegmentInsertFiles = util.GetSegmentInsertFiles(
+					args.insertBinlogs,
+					args.compactionParams.StorageConfig,
+					args.collectionID,
+					args.partitionID,
+					args.segmentID)
+			}
+			uploaded, err := indexcgowrapper.CreateTextIndex(egCtx, buildIndexParams)
+			if err != nil {
+				return err
+			}
+
+			mu.Lock()
+			totalSize := lo.SumBy(lo.Values(uploaded), func(fileSize int64) int64 { return fileSize })
+			textIndexLogs[field.GetFieldID()] = &datapb.TextIndexStats{
+				FieldID:                   field.GetFieldID(),
+				Version:                   0,
+				BuildID:                   args.taskID,
+				Files:                     lo.Keys(uploaded),
+				LogSize:                   totalSize,
+				MemorySize:                totalSize,
+				CurrentScalarIndexVersion: common.ClampScalarIndexVersion(args.plan.GetCurrentScalarIndexVersion()),
+			}
+			mu.Unlock()
+
+			log.Info("field enable match, create text index done",
+				zap.Int64("segmentID", args.segmentID),
+				zap.Int64("field id", field.GetFieldID()),
+				zap.Strings("files", lo.Keys(uploaded)),
+			)
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	return textIndexLogs, nil
+}


### PR DESCRIPTION
issue: #50145
pr: #50140

## Summary

Backport of #50140 to the 2.6 branch.

Make mixcompaction build text indexes inline for `enable_match` fields (mirroring `sortCompactionTask`) so that mix-compaction output segments arrive at QueryNode already carrying `TextStatsLogs`. Eliminates the CGO_LOAD `CreateTextIndex` fallback observed to take tens of seconds up to 13+ minutes per segment in production. Only sorted output segments get an inline text index; unsorted interim `mergeSplit` outputs are skipped (a later sortcompaction rebuilds them).

## Manifest correctness (StorageV2 / Loon FFI)

Under StorageV2 with `common.storage.useLoonFFI=true`, the text-index build reads the field's raw data **via the segment manifest** (it takes priority over `SegmentInsertFiles` in `cache_raw_data_to_memory_storage_v2`), and `docID` is purely the row-stream position. So the build must use the **output** segment's own manifest, or the index is built over the wrong rows/order.

- **mix**: the wrapper forwards `segment.GetManifest()` (the output segment's freshly-written manifest), consistent with its output binlogs/storageVersion.
- **sort**: previously passed `t.manifest` (the **input** segment's manifest) while passing the output segment's binlogs — under Loon FFI this would index the unsorted input rows against the sorted output segment (docID/row-count mismatch → wrong `text_match` results). Fixed to pass the output segment's manifest, matching master sort. (Pre-existing on 2.6; latent because `useLoonFFI` defaults to false, in which case the manifest is empty and the build reads the output `SegmentInsertFiles`.)

## Differences from master PR

The 2.6 port is intentionally minimal vs the master PR:

- **No manifest-stats rewrite**: master additionally calls `packed.AddStatsToManifest` to register the text-index stats *into* the V3 manifest at commit time. 2.6 only records them in `TextStatsLogs` on the segment, so that step is omitted. (2.6 still *reads* field data via the manifest under Loon FFI — see above.)
- **No FileResources plumbing**: 2.6 does not have the ref-mode `DNFileResourceMode` / FileResources infrastructure in compaction, so master's datacoord-side fix is N/A.
- **No `storage.ChunkManager` plumbing**: 2.6's helper builds via `indexcgowrapper.CreateTextIndex` and only needs the binlog/manifest paths; no `cm` field added to `mixCompactionTask`.

The structural change — extracting the inline build into a shared package-level helper `buildTextIndexesForSegment` so sort and mix compaction share one implementation — is kept in line with the master PR.

## Test plan

- [x] Mockey-based unit tests: helper body (V1/V2 paths, create/missing-binlog errors), `Compact()` inline-loop semantics (sorted built, empty/unsorted skipped), and manifest forwarding for both the mix wrapper and the sort wrapper (`TestSortCompaction_createTextIndex_ForwardsPassedManifest`, asserting the output manifest is used, not `t.manifest`).
- [ ] CI builds and verifies against 2.6 (build not run locally — the worktree's C++ artifacts target master; CI builds 2.6 from a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
