### PR TITLE
fix: ack stale alter-load-config on dropped-sentinel channel

### DIFF
--- a/internal/querycoordv2/ddl_callbacks_alter_load_info.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_load_info.go
@@ -19,9 +19,14 @@ package querycoordv2
 import (
 	"context"
 
+	"github.com/cockroachdb/errors"
+	"go.uber.org/zap"
+
 	"github.com/milvus-io/milvus/internal/querycoordv2/job"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
+	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // alterLoadConfigV2AckCallback is called when the put load config message is acknowledged
@@ -30,6 +35,18 @@ func (s *Server) alterLoadConfigV2AckCallback(ctx context.Context, result messag
 	// TODO: after we support query view in 3.0, we should broadcast the put load config message to all vchannels.
 	job := job.NewLoadCollectionJob(ctx, result, s.dist, s.meta, s.broker, s.targetMgr, s.targetObserver, s.collectionObserver, s.checkerController, s.nodeMgr, s.proxyClientManager)
 	if err := job.Execute(); err != nil {
+		// The collection's channel is already in dropped-sentinel state, meaning
+		// a concurrent DropCollection has landed at the channel level on this
+		// cluster (typically on a CDC replica). The load can never succeed; ack
+		// the broadcast so the broadcaster stops retrying forever and the
+		// pending rootcoord meta cleanup can complete. Mirrors the
+		// ErrCollectionNotFound early-return inside LoadCollectionJob.Execute().
+		if errors.Is(err, merr.ErrChannelDroppedSentinel) {
+			log.Ctx(ctx).Warn("ack alter load config: collection channel is dropped sentinel",
+				zap.Int64("collectionID", result.Message.Header().GetCollectionId()),
+				zap.Error(err))
+			return nil
+		}
 		return err
 	}
 	meta.GlobalFailedLoadCache.Remove(result.Message.Header().GetCollectionId())

--- a/internal/querycoordv2/ddl_callbacks_alter_load_info_test.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_load_info_test.go
@@ -1,0 +1,80 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package querycoordv2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/internal/querycoordv2/job"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func buildAlterLoadConfigBroadcastResult(collectionID int64) message.BroadcastResultAlterLoadConfigMessageV2 {
+	controlChannel := "_ctrl_channel"
+	broadcastMsg := message.NewAlterLoadConfigMessageBuilderV2().
+		WithHeader(&messagespb.AlterLoadConfigMessageHeader{
+			CollectionId: collectionID,
+			Replicas: []*messagespb.LoadReplicaConfig{
+				{ReplicaId: 1, ResourceGroupName: "__default_resource_group"},
+			},
+		}).
+		WithBody(&messagespb.AlterLoadConfigMessageBody{}).
+		WithBroadcast([]string{controlChannel}).
+		MustBuildBroadcast()
+
+	return message.BroadcastResultAlterLoadConfigMessageV2{
+		Message: message.MustAsBroadcastAlterLoadConfigMessageV2(broadcastMsg),
+		Results: map[string]*message.AppendResult{
+			controlChannel: {},
+		},
+	}
+}
+
+// TestAlterLoadConfigV2AckCallback verifies that the ack callback swallows the
+// dropped-sentinel error (so the broadcaster stops retrying forever) while still
+// propagating any other error from the load job.
+func TestAlterLoadConfigV2AckCallback(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	s := &Server{}
+	result := buildAlterLoadConfigBroadcastResult(1000)
+
+	mockey.PatchConvey("dropped sentinel is acked with no-op", t, func() {
+		mockey.Mock((*job.LoadCollectionJob).Execute).
+			Return(merr.WrapErrChannelDroppedSentinel("_ctrl_channel")).Build()
+
+		err := s.alterLoadConfigV2AckCallback(ctx, result)
+		assert.NoError(t, err)
+	})
+
+	mockey.PatchConvey("generic error is propagated", t, func() {
+		expectedErr := errors.New("broker unavailable")
+		mockey.Mock((*job.LoadCollectionJob).Execute).Return(expectedErr).Build()
+
+		err := s.alterLoadConfigV2AckCallback(ctx, result)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, expectedErr))
+	})
+}

--- a/internal/querycoordv2/meta/target_manager.go
+++ b/internal/querycoordv2/meta/target_manager.go
@@ -163,9 +163,9 @@ func (mgr *TargetManager) UpdateCollectionNextTarget(ctx context.Context, collec
 				zap.String("channel", channelInfo.GetChannelName()),
 				zap.Uint64("seekTs", channelInfo.GetSeekPosition().GetTimestamp()),
 			)
-			return merr.WrapErrChannelNotAvailable(
+			return merr.WrapErrChannelDroppedSentinel(
 				channelInfo.GetChannelName(),
-				"channel has dropped checkpoint sentinel; refuse to build next target",
+				"refuse to build next target",
 			)
 		}
 	}

--- a/internal/querycoordv2/meta/target_manager_test.go
+++ b/internal/querycoordv2/meta/target_manager_test.go
@@ -811,10 +811,9 @@ func (suite *TargetManagerSuite) TestUpdateNextTarget_DroppedSentinelRejected() 
 
 	err := suite.mgr.UpdateCollectionNextTarget(ctx, collectionID)
 	suite.Require().Error(err)
-	suite.True(errors.Is(err, merr.ErrChannelNotAvailable),
-		"error should wrap ErrChannelNotAvailable, got: %v", err)
+	suite.True(errors.Is(err, merr.ErrChannelDroppedSentinel),
+		"error should wrap ErrChannelDroppedSentinel, got: %v", err)
 	suite.Contains(err.Error(), "sentinel-channel")
-	suite.Contains(err.Error(), "dropped checkpoint sentinel")
 
 	// Next target must NOT be advanced.
 	suite.assertChannels([]string{}, suite.mgr.GetDmChannelsByCollection(ctx, collectionID, NextTarget))
@@ -860,7 +859,7 @@ func (suite *TargetManagerSuite) TestUpdateNextTarget_SentinelAmongMultiple() {
 
 	err := suite.mgr.UpdateCollectionNextTarget(ctx, collectionID)
 	suite.Require().Error(err)
-	suite.True(errors.Is(err, merr.ErrChannelNotAvailable))
+	suite.True(errors.Is(err, merr.ErrChannelDroppedSentinel))
 	suite.Contains(err.Error(), "poisoned-channel")
 
 	// Next target must remain empty — no partial build.

--- a/pkg/util/merr/errors.go
+++ b/pkg/util/merr/errors.go
@@ -102,6 +102,7 @@ var (
 	ErrChannelNotAvailable     = newMilvusError("channel not available", 503, false)
 	ErrChannelCPExceededMaxLag = newMilvusError("channel checkpoint exceed max lag", 504, false)
 	ErrChannelTSafeStalled     = newMilvusError("channel tsafe stalled", 505, true)
+	ErrChannelDroppedSentinel  = newMilvusError("channel checkpoint is dropped sentinel", 506, false)
 
 	// Segment related
 	ErrSegmentNotFound    = newMilvusError("segment not found", 600, false)

--- a/pkg/util/merr/errors_test.go
+++ b/pkg/util/merr/errors_test.go
@@ -114,6 +114,10 @@ func (s *ErrSuite) TestWrap() {
 	s.ErrorIs(WrapErrChannelNotFound("test_Channel", "failed to get Channel"), ErrChannelNotFound)
 	s.ErrorIs(WrapErrChannelLack("test_Channel", "failed to get Channel"), ErrChannelLack)
 	s.ErrorIs(WrapErrChannelReduplicate("test_Channel", "failed to get Channel"), ErrChannelReduplicate)
+	s.ErrorIs(WrapErrChannelDroppedSentinel("test_Channel", "refuse to build next target"), ErrChannelDroppedSentinel)
+	// Dropped-sentinel and not-available are distinct: matching one must not match the other.
+	s.False(errors.Is(WrapErrChannelDroppedSentinel("test_Channel"), ErrChannelNotAvailable))
+	s.False(errors.Is(WrapErrChannelNotAvailable("test_Channel"), ErrChannelDroppedSentinel))
 
 	// Segment related
 	s.ErrorIs(WrapErrSegmentNotFound(1, "failed to get Segment"), ErrSegmentNotFound)

--- a/pkg/util/merr/utils.go
+++ b/pkg/util/merr/utils.go
@@ -191,7 +191,12 @@ func oldCode(code int32) commonpb.ErrorCode {
 	case ErrPartitionNotFound.code(), ErrReplicaNotFound.code():
 		return commonpb.ErrorCode_MetaFailed
 
-	case ErrReplicaNotAvailable.code(), ErrChannelNotAvailable.code(), ErrNodeNotAvailable.code():
+	case ErrReplicaNotAvailable.code(), ErrChannelNotAvailable.code(), ErrChannelDroppedSentinel.code(), ErrNodeNotAvailable.code():
+		// ErrChannelDroppedSentinel is an internal-only signal that is currently
+		// swallowed by the alter-load-config ack callback and never serialized to a
+		// client Status. It is mapped alongside its ErrChannelNotAvailable sibling so
+		// that, if it is ever surfaced to a client, an old SDK keeps seeing
+		// NoReplicaAvailable instead of falling through to UnexpectedError.
 		return commonpb.ErrorCode_NoReplicaAvailable
 
 	case ErrServiceMemoryLimitExceeded.code():
@@ -773,6 +778,10 @@ func WrapErrChannelReduplicate(name string, msg ...string) error {
 
 func WrapErrChannelNotAvailable(name string, msg ...string) error {
 	return warpChannelErr(ErrChannelNotAvailable, name, msg...)
+}
+
+func WrapErrChannelDroppedSentinel(name string, msg ...string) error {
+	return warpChannelErr(ErrChannelDroppedSentinel, name, msg...)
 }
 
 // Segment related


### PR DESCRIPTION
## Summary

Follow-up to #50002.

After #50002 added the dropped-channel-sentinel guard in `TargetManager.UpdateCollectionNextTarget`, the new error bubbles up through `LoadCollectionJob.Execute` and back into the streamingcoord broadcaster's `alterLoadConfigV2AckCallback`. That callback has no terminal condition for "channel was dropped" and therefore retries the broadcast every 5–10 s **forever**, which:

- keeps the broadcast task uncommitted on the secondary,
- blocks rootcoord's collection meta cleanup,
- leaves the half-dropped collection visible in `list_collections` on the CDC replica even after the primary has fully dropped it.

This PR introduces `merr.ErrChannelDroppedSentinel` so the sentinel rejection can be distinguished from other `ChannelNotAvailable` causes, returns it from `TargetManager.UpdateCollectionNextTarget`, and acks-with-no-op in `alterLoadConfigV2AckCallback` when it appears. The behavior mirrors the existing `ErrCollectionNotFound` early-return inside `LoadCollectionJob`, and is safe because `IsDroppedChannelCheckpoint` is sticky — it is only ever written by `datacoord.MarkChannelCheckpointDropped` and `UpdateChannelCheckpoint` refuses to overwrite it (per the design notes of #50002).

### Recovery

The fix is self-healing: the next retry attempt of any stuck `AlterLoadConfig` broadcast on a CDC secondary will hit the new code path, return `nil`, and let the broadcast tombstone. Pending rootcoord meta cleanup then proceeds and the half-dropped collection disappears from `list_collections`. No manual intervention required on existing stuck instances after deploy.

issue: #49996

## Test plan

- [x] `pkg/util/merr` `TestWrap`: adds assertions for `WrapErrChannelDroppedSentinel` and confirms `errors.Is` distinctness from `ErrChannelNotAvailable` (passes locally)
- [x] `internal/querycoordv2/meta` `TestTargetManager`: 3 existing sub-tests from #50002 updated to assert the new error type
- [x] `go build` and `go vet` clean on `internal/querycoordv2/...` and `pkg/util/merr/...`
- [x] `golangci-lint` clean on touched packages (`new-from-rev`)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
