### PR TITLE
test: [cp2.6] add container-kill chaos coverage (#49800)

### DIFF
--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_datacoord_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_datacoord_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-datacoord-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -16,9 +16,9 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: milvus
-        component: standalone
+        component: datacoord
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - datacoord

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_datanode_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_datanode_container_kill.yaml
@@ -1,18 +1,24 @@
+kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
-kind: PodChaos
 metadata:
   name: test-datanode-container-kill
   namespace: chaos-testing
 spec:
-  action: container-kill
-  mode: one
-  containerName: 'datanode'
-  selector:
-    namespaces:
-      - chaos-testing         # target namespace of milvus deployment
-    labelSelectors:
-      app.kubernetes.io/instance: milvus-chaos
-      app.kubernetes.io/name: milvus
-      component: datanode
-  scheduler:
-    cron: '@every 2s'
+  schedule: '*/5 * * * * *'
+  startingDeadlineSeconds: 60
+  concurrencyPolicy: Forbid
+  historyLimit: 1
+  type: PodChaos
+  podChaos:
+    selector:
+      namespaces:
+        - chaos-testing
+      labelSelectors:
+        app.kubernetes.io/instance: milvus-chaos
+        app.kubernetes.io/name: milvus
+        component: datanode
+    mode: fixed
+    value: "1"
+    action: container-kill
+    containerNames:
+      - datanode

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_etcd_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_etcd_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-etcd-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -15,10 +15,9 @@ spec:
         - chaos-testing
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
-        app.kubernetes.io/name: milvus
-        component: standalone
+        app.kubernetes.io/name: etcd
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - etcd

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_indexcoord_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_indexcoord_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-indexcoord-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -16,9 +16,9 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: milvus
-        component: standalone
+        component: indexcoord
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - indexcoord

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_indexnode_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_indexnode_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-indexnode-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -16,9 +16,9 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: milvus
-        component: standalone
+        component: indexnode
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - indexnode

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_kafka_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_kafka_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-kafka-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -15,10 +15,9 @@ spec:
         - chaos-testing
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
-        app.kubernetes.io/name: milvus
-        component: standalone
+        app.kubernetes.io/name: kafka
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - kafka

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_minio_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_minio_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-minio-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -14,11 +14,10 @@ spec:
       namespaces:
         - chaos-testing
       labelSelectors:
-        app.kubernetes.io/instance: milvus-chaos
-        app.kubernetes.io/name: milvus
-        component: standalone
+        release: milvus-chaos
+        app: minio
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - minio

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_mixcoord_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_mixcoord_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-mixcoord-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -16,9 +16,9 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: milvus
-        component: standalone
+        component: mixcoord
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - mixcoord

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_proxy_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_proxy_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-proxy-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -16,9 +16,9 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: milvus
-        component: standalone
+        component: proxy
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - proxy

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_pulsar_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_pulsar_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-pulsar-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -14,11 +14,8 @@ spec:
       namespaces:
         - chaos-testing
       labelSelectors:
-        app.kubernetes.io/instance: milvus-chaos
-        app.kubernetes.io/name: milvus
-        component: standalone
+        release: milvus-chaos
+        app: pulsarv3
     mode: fixed
     value: "1"
     action: container-kill
-    containerNames:
-      - standalone

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_querycoord_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_querycoord_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-querycoord-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -16,9 +16,9 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: milvus
-        component: standalone
+        component: querycoord
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - querycoord

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_querynode_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_querynode_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-querynode-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -16,9 +16,9 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: milvus
-        component: standalone
+        component: querynode
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - querynode

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_rootcoord_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_rootcoord_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-rootcoord-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -16,9 +16,9 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: milvus
-        component: standalone
+        component: rootcoord
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - rootcoord

--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_streamingnode_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_streamingnode_container_kill.yaml
@@ -1,7 +1,7 @@
 kind: Schedule
 apiVersion: chaos-mesh.org/v1alpha1
 metadata:
-  name: test-standalone-container-kill
+  name: test-streamingnode-container-kill
   namespace: chaos-testing
 spec:
   schedule: '*/5 * * * * *'
@@ -16,9 +16,9 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: milvus
-        component: standalone
+        component: streamingnode
     mode: fixed
     value: "1"
     action: container-kill
     containerNames:
-      - standalone
+      - streamingnode

--- a/tests/python_client/chaos/chaos_objects/container_kill/testcases.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/testcases.yaml
@@ -1,14 +1,28 @@
-# Testcases All-in-one
-#   pod kill
-#     standalone
-#       3 pods(standalone-ha-blabla, etcd, minio)
-#     cluster-1-node
-#       11 pods(proxy, rootcoord, querynode, querycoord, datanode, datacoord,
-#               indexnode, indexcoord, pulsar, etcd, minio)
-#     cluster-n-nodes
-#       11 pods* n: kill one and kill all
+# Container Kill Testcases All-in-one
 
 Collections:
+  -
+    testcase:
+      name: test_querynode_container_kill
+      chaos: chaos_querynode_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          search: fail
+          query: fail
+        cluster_n_nodes:
+          search: degrade
+          query: degrade
+  -
+    testcase:
+      name: test_querycoord_container_kill
+      chaos: chaos_querycoord_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          search: fail
+          query: fail
+        cluster_n_nodes:
+          search: degrade
+          query: degrade
   -
     testcase:
       name: test_datanode_container_kill
@@ -19,14 +33,139 @@ Collections:
           flush: fail
         cluster_n_nodes:
           insert: degrade
-
   -
     testcase:
-      name: test_standalone_container_kill
-      chaos: chaos_standalone_container_kill.yaml
+      name: test_datacoord_container_kill
+      chaos: chaos_datacoord_container_kill.yaml
       expectation:
         cluster_1_node:
           insert: succ
           flush: fail
         cluster_n_nodes:
           insert: degrade
+  -
+    testcase:
+      name: test_indexnode_container_kill
+      chaos: chaos_indexnode_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          index: fail
+        cluster_n_nodes:
+          index: degrade
+  -
+    testcase:
+      name: test_indexcoord_container_kill
+      chaos: chaos_indexcoord_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          index: fail
+        cluster_n_nodes:
+          insert: degrade
+  -
+    testcase:
+      name: test_proxy_container_kill
+      chaos: chaos_proxy_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail
+        cluster_n_nodes:
+          insert: fail
+  -
+    testcase:
+      name: test_rootcoord_container_kill
+      chaos: chaos_rootcoord_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail
+        cluster_n_nodes:
+          insert: degrade
+  -
+    testcase:
+      name: test_etcd_container_kill
+      chaos: chaos_etcd_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail
+  -
+    testcase:
+      name: test_minio_container_kill
+      chaos: chaos_minio_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail
+  -
+    testcase:
+      name: test_pulsar_container_kill
+      chaos: chaos_pulsar_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail
+  -
+    testcase:
+      name: test_kafka_container_kill
+      chaos: chaos_kafka_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail
+  -
+    testcase:
+      name: test_standalone_container_kill
+      chaos: chaos_standalone_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail
+  -
+    testcase:
+      name: test_mixcoord_container_kill
+      chaos: chaos_mixcoord_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          create: fail
+          insert: fail
+          flush: fail
+          index: fail
+          search: fail
+          query: fail
+  -
+    testcase:
+      name: test_streamingnode_container_kill
+      chaos: chaos_streamingnode_container_kill.yaml
+      expectation:
+        cluster_1_node:
+          search: fail
+          query: fail

--- a/tests/python_client/chaos/chaos_objects/template/container-kill-by-pod-list.yaml
+++ b/tests/python_client/chaos/chaos_objects/template/container-kill-by-pod-list.yaml
@@ -1,0 +1,14 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: test-container-kill-by-pod-list
+  namespace: chaos-testing
+spec:
+  selector:
+    pods:
+      chaos-testing:
+        - milvus-chaos-etcd-0
+  mode: all
+  action: container-kill
+  containerNames:
+    - etcd

--- a/tests/python_client/chaos/test_chaos_apply.py
+++ b/tests/python_client/chaos/test_chaos_apply.py
@@ -1,27 +1,115 @@
-import threading
-import pytest
-import time
-from time import sleep
-from pathlib import Path
+import copy
 import json
-from pymilvus import connections
+import random
+import time
+from datetime import datetime
+from pathlib import Path
+from time import sleep
+
+import constants
+import pytest
 from common.cus_resource_opts import CustomResourceOperations as CusResource
 from common.milvus_sys import MilvusSys
+from pymilvus import connections
+from utils.util_common import gen_experiment_config, update_key_name, update_key_value, wait_signal_to_apply_chaos
+from utils.util_k8s import (
+    get_milvus_deploy_tool,
+    get_milvus_instance_name,
+    get_pod_container_names,
+    get_pod_list,
+    wait_pods_ready,
+)
 from utils.util_log import test_log as log
-from datetime import datetime
-from utils.util_k8s import wait_pods_ready, get_milvus_instance_name, get_milvus_deploy_tool
-from utils.util_common import update_key_value, update_key_name, gen_experiment_config, wait_signal_to_apply_chaos
-import constants
+
+
+def get_pod_chaos_spec(chaos_config):
+    spec = chaos_config.get("spec", {})
+    return spec.get("podChaos", spec)
+
+
+def normalize_container_kill_config(chaos_config):
+    target = get_pod_chaos_spec(chaos_config)
+    if target.get("action") != "container-kill":
+        return chaos_config
+    if "containerName" in target:
+        target["containerNames"] = [target.pop("containerName")]
+    return chaos_config
+
+
+def build_label_selector(label_selectors):
+    return ",".join([f"{key}={value}" for key, value in label_selectors.items()])
+
+
+def get_selector_namespace(selector, default_namespace):
+    namespaces = selector.get("namespaces") or [default_namespace]
+    return namespaces[0]
+
+
+def split_container_kill_configs_by_pod_containers(chaos_config, default_namespace):
+    normalize_container_kill_config(chaos_config)
+    target = get_pod_chaos_spec(chaos_config)
+    if target.get("action") != "container-kill":
+        return [chaos_config]
+
+    selector = target.get("selector", {})
+    label_selectors = selector.get("labelSelectors")
+    if not label_selectors:
+        return [chaos_config]
+
+    namespace = get_selector_namespace(selector, default_namespace)
+    pods = get_pod_list(namespace, build_label_selector(label_selectors))
+    pod_names = [pod.metadata.name for pod in pods]
+    if not pod_names:
+        raise Exception(f"no pods matched selector {label_selectors} in namespace {namespace}")
+
+    pod_container_names = get_pod_container_names(namespace, pod_names)
+    configured_container_names = target.get("containerNames")
+    if configured_container_names:
+        configured = set(configured_container_names)
+        invalid_pods = {
+            pod_name: container_names
+            for pod_name, container_names in pod_container_names.items()
+            if not configured.intersection(container_names)
+        }
+        if invalid_pods:
+            raise Exception(
+                f"configured containerNames {configured_container_names} do not match containers "
+                f"in selected pods: {invalid_pods}"
+            )
+        return [chaos_config]
+
+    pods_by_containers = {}
+    for pod_name, container_names in pod_container_names.items():
+        pods_by_containers.setdefault(tuple(container_names), []).append(pod_name)
+
+    if len(pods_by_containers) == 1:
+        target["containerNames"] = list(next(iter(pods_by_containers.keys())))
+        return [chaos_config]
+
+    if target.get("mode") == "fixed" and target.get("value") == "1":
+        pod_name = random.choice(pod_names)
+        target["containerNames"] = pod_container_names[pod_name]
+        target["selector"] = {"pods": {namespace: [pod_name]}}
+        return [chaos_config]
+
+    configs = []
+    for idx, (container_names, grouped_pods) in enumerate(pods_by_containers.items(), start=1):
+        grouped_config = copy.deepcopy(chaos_config)
+        grouped_target = get_pod_chaos_spec(grouped_config)
+        grouped_target["containerNames"] = list(container_names)
+        grouped_target["selector"] = {"pods": {namespace: grouped_pods}}
+        grouped_config["metadata"]["name"] = f"{chaos_config['metadata']['name']}-{idx}"
+        configs.append(grouped_config)
+    return configs
 
 
 class TestChaosApply:
-
     @pytest.fixture(scope="function", autouse=True)
     def init_env(self, host, port, user, password, milvus_ns):
         if user and password:
-            connections.connect('default', host=host, port=port, user=user, password=password)
+            connections.connect("default", host=host, port=port, user=user, password=password)
         else:
-            connections.connect('default', host=host, port=port)
+            connections.connect("default", host=host, port=port)
         if connections.has_connection("default") is False:
             raise Exception("no connections")
         #
@@ -29,7 +117,7 @@ class TestChaosApply:
         self.port = port
         self.user = user
         self.password = password
-        self.milvus_sys = MilvusSys(alias='default')
+        self.milvus_sys = MilvusSys(alias="default")
         self.chaos_ns = constants.CHAOS_NAMESPACE
         self.milvus_ns = milvus_ns
         self.release_name = get_milvus_instance_name(self.milvus_ns, milvus_sys=self.milvus_sys)
@@ -37,24 +125,29 @@ class TestChaosApply:
 
     def reconnect(self):
         if self.user and self.password:
-            connections.connect('default', host=self.host, port=self.port,
-                                user=self.user,
-                                password=self.password)
+            connections.connect("default", host=self.host, port=self.port, user=self.user, password=self.password)
         else:
-            connections.connect('default', host=self.host, port=self.port)
+            connections.connect("default", host=self.host, port=self.port)
         if connections.has_connection("default") is False:
             raise Exception("no connections")
 
     def teardown(self):
-        chaos_res = CusResource(kind=self.chaos_config['kind'],
-                                group=constants.CHAOS_GROUP,
-                                version=constants.CHAOS_VERSION,
-                                namespace=constants.CHAOS_NAMESPACE)
-        meta_name = self.chaos_config.get('metadata', None).get('name', None)
-        chaos_res.delete(meta_name, raise_ex=False)
+        for chaos_config in getattr(self, "chaos_configs", [getattr(self, "chaos_config", {})]):
+            if not chaos_config:
+                continue
+            chaos_res = CusResource(
+                kind=chaos_config["kind"],
+                group=constants.CHAOS_GROUP,
+                version=constants.CHAOS_VERSION,
+                namespace=constants.CHAOS_NAMESPACE,
+            )
+            meta_name = chaos_config.get("metadata", None).get("name", None)
+            chaos_res.delete(meta_name, raise_ex=False)
         sleep(2)
 
-    def test_chaos_apply(self, chaos_type, target_component, target_scope, target_number, chaos_duration, chaos_interval, wait_signal):
+    def test_chaos_apply(
+        self, chaos_type, target_component, target_scope, target_number, chaos_duration, chaos_interval, wait_signal
+    ):
         # start the monitor threads to check the milvus ops
         log.info("*********************Chaos Test Start**********************")
         if wait_signal:
@@ -64,13 +157,13 @@ class TestChaosApply:
                 log.info("get the signal to apply chaos timeout")
             else:
                 log.info("get the signal to apply chaos")
-        log.info(connections.get_connection_addr('default'))
+        log.info(connections.get_connection_addr("default"))
         release_name = self.release_name
         chaos_config = gen_experiment_config(
-            f"{str(Path(__file__).absolute().parent)}/chaos_objects/{chaos_type.replace('-', '_')}/chaos_{target_component}_{chaos_type.replace('-', '_')}.yaml")
-        chaos_config['metadata']['name'] = f"test-{target_component}-{chaos_type.replace('_','-')}-{int(time.time())}"
-        chaos_config['metadata']['namespace'] = self.chaos_ns
-        meta_name = chaos_config.get('metadata', None).get('name', None)
+            f"{str(Path(__file__).absolute().parent)}/chaos_objects/{chaos_type.replace('-', '_')}/chaos_{target_component}_{chaos_type.replace('-', '_')}.yaml"
+        )
+        chaos_config["metadata"]["name"] = f"test-{target_component}-{chaos_type.replace('_', '-')}-{int(time.time())}"
+        chaos_config["metadata"]["namespace"] = self.chaos_ns
         update_key_value(chaos_config, "release", release_name)
         update_key_value(chaos_config, "app.kubernetes.io/instance", release_name)
         update_key_value(chaos_config, "namespaces", [self.milvus_ns])
@@ -83,60 +176,94 @@ class TestChaosApply:
             schedule = f"00 */{chaos_interval[:-1]} * * * *"
         update_key_value(chaos_config, "schedule", schedule)
         # update chaos_duration from string to int with unit second
-        chaos_duration = chaos_duration.replace('h', '*3600+').replace('m', '*60+').replace('s', '*1+') + '+0'
+        chaos_duration = chaos_duration.replace("h", "*3600+").replace("m", "*60+").replace("s", "*1+") + "+0"
         chaos_duration = eval(chaos_duration)
-        update_key_value(chaos_config, "duration", f"{chaos_duration//60}m")
+        update_key_value(chaos_config, "duration", f"{chaos_duration // 60}m")
         if self.deploy_by == "milvus-operator":
             update_key_name(chaos_config, "component", "app.kubernetes.io/component")
-        self._chaos_config = chaos_config  # cache the chaos config for tear down
-        log.info(f"chaos_config: {chaos_config}")
+        chaos_configs = split_container_kill_configs_by_pod_containers(chaos_config, self.milvus_ns)
+        self.chaos_configs = chaos_configs
+        self.chaos_config = chaos_configs[0]
+        self._chaos_config = self.chaos_config  # cache the chaos config for tear down
+        log.info(f"chaos_configs: {chaos_configs}")
         # apply chaos object
-        chaos_res = CusResource(kind=chaos_config['kind'],
-                                group=constants.CHAOS_GROUP,
-                                version=constants.CHAOS_VERSION,
-                                namespace=constants.CHAOS_NAMESPACE)
-        chaos_res.create(chaos_config)
-        create_time = datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f')
+        for item in chaos_configs:
+            chaos_res = CusResource(
+                kind=item["kind"],
+                group=constants.CHAOS_GROUP,
+                version=constants.CHAOS_VERSION,
+                namespace=constants.CHAOS_NAMESPACE,
+            )
+            chaos_res.create(item)
+        create_time = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S.%f")
         log.info("chaos injected")
-        res = chaos_res.list_all()
-        chaos_list = [r['metadata']['name'] for r in res['items']]
-        assert meta_name in chaos_list
-        res = chaos_res.get(meta_name)
-        log.info(f"chaos inject result: {res['kind']}, {res['metadata']['name']}")
+        meta_names = [item.get("metadata", None).get("name", None) for item in chaos_configs]
+        for item in chaos_configs:
+            chaos_res = CusResource(
+                kind=item["kind"],
+                group=constants.CHAOS_GROUP,
+                version=constants.CHAOS_VERSION,
+                namespace=constants.CHAOS_NAMESPACE,
+            )
+            res = chaos_res.list_all()
+            chaos_list = [r["metadata"]["name"] for r in res["items"]]
+            assert item["metadata"]["name"] in chaos_list
+            res = chaos_res.get(item["metadata"]["name"])
+            log.info(f"chaos inject result: {res['kind']}, {res['metadata']['name']}")
         sleep(chaos_duration)
         # delete chaos
-        chaos_res.delete(meta_name)
-        delete_time = datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f')
+        for item in chaos_configs:
+            chaos_res = CusResource(
+                kind=item["kind"],
+                group=constants.CHAOS_GROUP,
+                version=constants.CHAOS_VERSION,
+                namespace=constants.CHAOS_NAMESPACE,
+            )
+            chaos_res.delete(item["metadata"]["name"])
+        delete_time = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S.%f")
         log.info("chaos deleted")
-        res = chaos_res.list_all()
-        chaos_list = [r['metadata']['name'] for r in res['items']]
         # verify the chaos is deleted in 60s
         t0 = time.time()
-        while meta_name in chaos_list and time.time() - t0 < 60:
-            sleep(10)
-            res = chaos_res.list_all()
-            chaos_list = [r['metadata']['name'] for r in res['items']]
-        assert meta_name not in chaos_list
+        deleted = False
+        while not deleted and time.time() - t0 < 60:
+            deleted = True
+            for item in chaos_configs:
+                chaos_res = CusResource(
+                    kind=item["kind"],
+                    group=constants.CHAOS_GROUP,
+                    version=constants.CHAOS_VERSION,
+                    namespace=constants.CHAOS_NAMESPACE,
+                )
+                res = chaos_res.list_all()
+                chaos_list = [r["metadata"]["name"] for r in res["items"]]
+                if item["metadata"]["name"] in chaos_list:
+                    deleted = False
+                    break
+            if not deleted:
+                sleep(10)
+        assert deleted
         # wait all pods ready
         t0 = time.time()
-        log.info(f"wait for pods in namespace {constants.CHAOS_NAMESPACE} with label app.kubernetes.io/instance={release_name}")
+        log.info(
+            f"wait for pods in namespace {constants.CHAOS_NAMESPACE} with label app.kubernetes.io/instance={release_name}"
+        )
         wait_pods_ready(constants.CHAOS_NAMESPACE, f"app.kubernetes.io/instance={release_name}")
         log.info(f"wait for pods in namespace {constants.CHAOS_NAMESPACE} with label release={release_name}")
         wait_pods_ready(constants.CHAOS_NAMESPACE, f"release={release_name}")
         log.info("all pods are ready")
         pods_ready_time = time.time() - t0
         log.info(f"pods ready time: {pods_ready_time}")
-        recovery_time = datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f')
+        recovery_time = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S.%f")
         event_records = {
             "chaos_type": chaos_type,
             "target_component": target_component,
-            "meta_name": meta_name,
+            "meta_name": ",".join(meta_names),
             "create_time": create_time,
             "delete_time": delete_time,
-            "recovery_time": recovery_time
+            "recovery_time": recovery_time,
         }
         # save event records to json file
-        with open(constants.CHAOS_INFO_SAVE_PATH, 'w') as f:
+        with open(constants.CHAOS_INFO_SAVE_PATH, "w") as f:
             json.dump(event_records, f)
         # reconnect to test the service healthy
         start_time = time.time()

--- a/tests/python_client/chaos/test_chaos_apply_to_determined_pod.py
+++ b/tests/python_client/chaos/test_chaos_apply_to_determined_pod.py
@@ -1,29 +1,35 @@
-import pytest
-import time
-from time import sleep
-from pathlib import Path
-from datetime import datetime
 import json
-from pymilvus import connections
+import logging as log
+import time
+from datetime import datetime
+from pathlib import Path
+from time import sleep
+
+import constants
+import pytest
+from chaos import chaos_commons as cc
 from common.cus_resource_opts import CustomResourceOperations as CusResource
 from common.milvus_sys import MilvusSys
-from chaos import chaos_commons as cc
-import logging as log
-from utils.util_k8s import (wait_pods_ready, get_milvus_instance_name,
-                            get_milvus_deploy_tool, get_etcd_leader, get_etcd_followers)
+from pymilvus import connections
 from utils.util_common import wait_signal_to_apply_chaos
-import constants
+from utils.util_k8s import (
+    get_etcd_followers,
+    get_etcd_leader,
+    get_milvus_deploy_tool,
+    get_milvus_instance_name,
+    get_pod_container_names,
+    wait_pods_ready,
+)
 
 
 class TestChaosApply:
-
     @pytest.fixture(scope="function", autouse=True)
     def init_env(self, host, port, user, password, milvus_ns):
         if user and password:
             # log.info(f"connect to {host}:{port} with user {user} and password {password}")
-            connections.connect('default', host=host, port=port, user=user, password=password)
+            connections.connect("default", host=host, port=port, user=user, password=password)
         else:
-            connections.connect('default', host=host, port=port)
+            connections.connect("default", host=host, port=port)
         if connections.has_connection("default") is False:
             raise Exception("no connections")
         #
@@ -31,7 +37,7 @@ class TestChaosApply:
         self.port = port
         self.user = user
         self.password = password
-        self.milvus_sys = MilvusSys(alias='default')
+        self.milvus_sys = MilvusSys(alias="default")
         self.chaos_ns = constants.CHAOS_NAMESPACE
         self.milvus_ns = milvus_ns
         self.release_name = get_milvus_instance_name(self.milvus_ns, milvus_sys=self.milvus_sys)
@@ -39,21 +45,23 @@ class TestChaosApply:
 
     def reconnect(self):
         if self.user and self.password:
-            connections.connect('default', host=self.host, port=self.port,
-                                user=self.user,
-                                password=self.password)
+            connections.connect("default", host=self.host, port=self.port, user=self.user, password=self.password)
         else:
-            connections.connect('default', host=self.host, port=self.port)
+            connections.connect("default", host=self.host, port=self.port)
         if connections.has_connection("default") is False:
             raise Exception("no connections")
 
     def teardown(self):
-        chaos_res = CusResource(kind=self.chaos_config['kind'],
-                                group=constants.CHAOS_GROUP,
-                                version=constants.CHAOS_VERSION,
-                                namespace=constants.CHAOS_NAMESPACE)
-        meta_name = self.chaos_config.get('metadata', None).get('name', None)
-        chaos_res.delete(meta_name, raise_ex=False)
+        chaos_config = getattr(self, "chaos_config", None)
+        if chaos_config:
+            chaos_res = CusResource(
+                kind=chaos_config["kind"],
+                group=constants.CHAOS_GROUP,
+                version=constants.CHAOS_VERSION,
+                namespace=constants.CHAOS_NAMESPACE,
+            )
+            meta_name = chaos_config.get("metadata", None).get("name", None)
+            chaos_res.delete(meta_name, raise_ex=False)
         sleep(2)
 
     def test_chaos_apply(self, chaos_type, target_pod, chaos_duration, chaos_interval, wait_signal):
@@ -66,61 +74,77 @@ class TestChaosApply:
                 log.info("did not get the signal to apply chaos")
             else:
                 log.info("get the signal to apply chaos")
-        log.info(connections.get_connection_addr('default'))
+        log.info(connections.get_connection_addr("default"))
         release_name = self.release_name
         deploy_tool = get_milvus_deploy_tool(self.milvus_ns, self.milvus_sys)
         target_pod_list = []
-        if target_pod in ['etcd_leader', 'etcd-leader']:
+        if target_pod in ["etcd_leader", "etcd-leader"]:
             etcd_leader = get_etcd_leader(release_name, deploy_tool)
             if etcd_leader is None:
                 raise Exception("no etcd leader")
             target_pod_list.append(etcd_leader)
-        if target_pod in ['etcd_followers', 'etcd-followers']:
+        if target_pod in ["etcd_followers", "etcd-followers"]:
             etcd_followers = get_etcd_followers(release_name, deploy_tool)
             if etcd_followers is None:
                 raise Exception("no etcd followers")
             target_pod_list.extend(etcd_followers)
-            if len(target_pod_list) >=2:
+            if len(target_pod_list) >= 2:
                 # only choose one follower to apply chaos
                 target_pod_list = target_pod_list[:1]
         log.info(f"target_pod_list: {target_pod_list}")
-        chaos_type = chaos_type.replace('_', '-')
-        chaos_config = cc.gen_experiment_config(f"{str(Path(__file__).absolute().parent)}/chaos_objects/template/{chaos_type}-by-pod-list.yaml")
-        chaos_config['metadata']['name'] = f"test-{target_pod.replace('_', '-')}-{chaos_type}-{int(time.time())}"
-        meta_name = chaos_config.get('metadata', None).get('name', None)
-        chaos_config['spec']['selector']['pods']['chaos-testing'] = target_pod_list
+        chaos_type = chaos_type.replace("_", "-")
+        chaos_config = cc.gen_experiment_config(
+            f"{str(Path(__file__).absolute().parent)}/chaos_objects/template/{chaos_type}-by-pod-list.yaml"
+        )
+        chaos_config["metadata"]["name"] = f"test-{target_pod.replace('_', '-')}-{chaos_type}-{int(time.time())}"
+        meta_name = chaos_config.get("metadata", None).get("name", None)
+        chaos_config["spec"]["selector"]["pods"] = {self.milvus_ns: target_pod_list}
+        if chaos_config["spec"].get("action") == "container-kill":
+            pod_container_names = get_pod_container_names(self.milvus_ns, target_pod_list)
+            container_names = []
+            for names in pod_container_names.values():
+                for name in names:
+                    if name not in container_names:
+                        container_names.append(name)
+            if not container_names:
+                raise Exception(f"no containers found in pods {target_pod_list}")
+            chaos_config["spec"]["containerNames"] = container_names
         self.chaos_config = chaos_config  # cache the chaos config for tear down  # cache the chaos config for tear down
         log.info(f"chaos_config: {chaos_config}")
         # apply chaos object
-        chaos_res = CusResource(kind=chaos_config['kind'],
-                                group=constants.CHAOS_GROUP,
-                                version=constants.CHAOS_VERSION,
-                                namespace=constants.CHAOS_NAMESPACE)
+        chaos_res = CusResource(
+            kind=chaos_config["kind"],
+            group=constants.CHAOS_GROUP,
+            version=constants.CHAOS_VERSION,
+            namespace=constants.CHAOS_NAMESPACE,
+        )
         chaos_res.create(chaos_config)
-        create_time = datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f')
+        create_time = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S.%f")
         log.info("chaos injected")
         res = chaos_res.list_all()
-        chaos_list = [r['metadata']['name'] for r in res['items']]
+        chaos_list = [r["metadata"]["name"] for r in res["items"]]
         assert meta_name in chaos_list
         res = chaos_res.get(meta_name)
         log.info(f"chaos inject result: {res['kind']}, {res['metadata']['name']}")
-        chaos_duration = chaos_duration.replace('h', '*3600+').replace('m', '*60+').replace('s', '*1+') + '+0'
+        chaos_duration = chaos_duration.replace("h", "*3600+").replace("m", "*60+").replace("s", "*1+") + "+0"
         chaos_duration = eval(chaos_duration)
         sleep(chaos_duration)
         # delete chaos
         chaos_res.delete(meta_name)
-        delete_time = datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f')
+        delete_time = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S.%f")
         log.info("chaos deleted")
         res = chaos_res.list_all()
-        chaos_list = [r['metadata']['name'] for r in res['items']]
+        chaos_list = [r["metadata"]["name"] for r in res["items"]]
         # verify the chaos is deleted
         sleep(10)
         res = chaos_res.list_all()
-        chaos_list = [r['metadata']['name'] for r in res['items']]
+        chaos_list = [r["metadata"]["name"] for r in res["items"]]
         assert meta_name not in chaos_list
         # wait all pods ready
         t0 = time.time()
-        log.info(f"wait for pods in namespace {constants.CHAOS_NAMESPACE} with label app.kubernetes.io/instance={release_name}")
+        log.info(
+            f"wait for pods in namespace {constants.CHAOS_NAMESPACE} with label app.kubernetes.io/instance={release_name}"
+        )
         wait_pods_ready(constants.CHAOS_NAMESPACE, f"app.kubernetes.io/instance={release_name}")
         log.info(f"wait for pods in namespace {constants.CHAOS_NAMESPACE} with label release={release_name}")
         wait_pods_ready(constants.CHAOS_NAMESPACE, f"release={release_name}")
@@ -128,17 +152,17 @@ class TestChaosApply:
         pods_ready_time = time.time() - t0
         log.info(f"pods ready time: {pods_ready_time}")
 
-        recovery_time = datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f')
+        recovery_time = datetime.fromtimestamp(time.time()).strftime("%Y-%m-%d %H:%M:%S.%f")
         event_records = {
             "chaos_type": chaos_type,
             "target_component": target_pod,
             "meta_name": meta_name,
             "create_time": create_time,
             "delete_time": delete_time,
-            "recovery_time": recovery_time
+            "recovery_time": recovery_time,
         }
         # save event records to json file
-        with open(constants.CHAOS_INFO_SAVE_PATH, 'w') as f:
+        with open(constants.CHAOS_INFO_SAVE_PATH, "w") as f:
             json.dump(event_records, f)
         # reconnect to test the service healthy
         start_time = time.time()

--- a/tests/python_client/utils/util_k8s.py
+++ b/tests/python_client/utils/util_k8s.py
@@ -1,15 +1,15 @@
 import json
 import os.path
 import time
+
 import pyetcd
 import requests
-from pymilvus import connections
+from common.common_type import in_cluster_env
+from common.milvus_sys import MilvusSys
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
-from common.milvus_sys import MilvusSys
+from pymilvus import connections
 from utils.util_log import test_log as log
-from chaos import chaos_commons as cc
-from common.common_type import in_cluster_env
 
 
 def init_k8s_client_config():
@@ -17,9 +17,9 @@ def init_k8s_client_config():
     init kubernetes client config
     """
     try:
-        in_cluster = os.getenv(in_cluster_env, default='False')
+        in_cluster = os.getenv(in_cluster_env, default="False")
         # log.debug(f"env variable IN_CLUSTER: {in_cluster}")
-        if in_cluster.lower() == 'true':
+        if in_cluster.lower() == "true":
             config.load_incluster_config()
         else:
             config.load_kube_config()
@@ -64,7 +64,7 @@ def wait_pods_ready(namespace, label_selector, expected_num=None, timeout=360):
                 all_pos_ready_flag = False
             else:
                 for item in api_response.items:
-                    if item.status.phase != 'Running':
+                    if item.status.phase != "Running":
                         all_pos_ready_flag = False
                         break
                     for c in item.status.container_statuses:
@@ -80,7 +80,7 @@ def wait_pods_ready(namespace, label_selector, expected_num=None, timeout=360):
         else:
             log.info(f"timeout for waiting all pods in namespace {namespace} with label {label_selector} ready")
     except ApiException as e:
-        log.error("Exception when calling CoreV1Api->list_namespaced_pod: %s\n" % e)
+        log.error(f"Exception when calling CoreV1Api->list_namespaced_pod: {e}\n")
         raise Exception(str(e))
 
     return all_pos_ready_flag
@@ -105,7 +105,30 @@ def get_pod_list(namespace, label_selector):
         api_response = api_instance.list_namespaced_pod(namespace=namespace, label_selector=label_selector)
         return api_response.items
     except ApiException as e:
-        log.error("Exception when calling CoreV1Api->list_namespaced_pod: %s\n" % e)
+        log.error(f"Exception when calling CoreV1Api->list_namespaced_pod: {e}\n")
+        raise Exception(str(e))
+
+
+def get_pod_container_names(namespace, pod_names):
+    """
+    get container names for pods
+
+    :param namespace: the namespace where pods are running
+    :type namespace: str
+
+    :param pod_names: pod names to inspect
+    :type pod_names: list[str]
+    """
+    init_k8s_client_config()
+    api_instance = client.CoreV1Api()
+    result = {}
+    try:
+        for pod_name in pod_names:
+            pod = api_instance.read_namespaced_pod(name=pod_name, namespace=namespace)
+            result[pod_name] = [c.name for c in pod.spec.containers]
+        return result
+    except ApiException as e:
+        log.error(f"Exception when calling CoreV1Api->read_namespaced_pod: {e}\n")
         raise Exception(str(e))
 
 
@@ -156,7 +179,7 @@ def get_querynode_id_pod_pairs(namespace, label_selector):
     querynode_id_pod_pair = {}
     ms = MilvusSys()
     for node in ms.query_nodes:
-        ip = node["infos"]['hardware_infos']["ip"].split(":")[0]
+        ip = node["infos"]["hardware_infos"]["ip"].split(":")[0]
         querynode_id_pod_pair[node["identifier"]] = querynode_ip_pod_pair[ip]
     return querynode_id_pod_pair
 
@@ -180,11 +203,11 @@ def get_milvus_instance_name(namespace, host="127.0.0.1", port="19530", milvus_s
     """
     if milvus_sys is None:
         connections.add_connection(_default={"host": host, "port": port})
-        connections.connect(alias='_default')
+        connections.connect(alias="_default")
         ms = MilvusSys()
     else:
         ms = milvus_sys
-    query_node_ip = ms.query_nodes[0]["infos"]['hardware_infos']["ip"].split(":")[0]
+    query_node_ip = ms.query_nodes[0]["infos"]["hardware_infos"]["ip"].split(":")[0]
     ip_name_pairs = get_pod_ip_name_pairs(namespace, "app.kubernetes.io/name=milvus")
     pod_name = ip_name_pairs[query_node_ip]
 
@@ -193,7 +216,7 @@ def get_milvus_instance_name(namespace, host="127.0.0.1", port="19530", milvus_s
     try:
         api_response = api_instance.read_namespaced_pod(namespace=namespace, name=pod_name)
     except ApiException as e:
-        log.error("Exception when calling CoreV1Api->list_namespaced_pod: %s\n" % e)
+        log.error(f"Exception when calling CoreV1Api->list_namespaced_pod: {e}\n")
         raise Exception(str(e))
     milvus_instance_name = api_response.metadata.labels["app.kubernetes.io/instance"]
     return milvus_instance_name
@@ -211,7 +234,7 @@ def get_milvus_deploy_tool(namespace, milvus_sys):
             "helm"
     """
     ms = milvus_sys
-    query_node_ip = ms.query_nodes[0]["infos"]['hardware_infos']["ip"].split(":")[0]
+    query_node_ip = ms.query_nodes[0]["infos"]["hardware_infos"]["ip"].split(":")[0]
     ip_name_pairs = get_pod_ip_name_pairs(namespace, "app.kubernetes.io/name=milvus")
     pod_name = ip_name_pairs[query_node_ip]
     init_k8s_client_config()
@@ -219,10 +242,12 @@ def get_milvus_deploy_tool(namespace, milvus_sys):
     try:
         api_response = api_instance.read_namespaced_pod(namespace=namespace, name=pod_name)
     except ApiException as e:
-        log.error("Exception when calling CoreV1Api->list_namespaced_pod: %s\n" % e)
+        log.error(f"Exception when calling CoreV1Api->list_namespaced_pod: {e}\n")
         raise Exception(str(e))
-    if ("app.kubernetes.io/managed-by" in api_response.metadata.labels and
-            api_response.metadata.labels["app.kubernetes.io/managed-by"] == "milvus-operator"):
+    if (
+        "app.kubernetes.io/managed-by" in api_response.metadata.labels
+        and api_response.metadata.labels["app.kubernetes.io/managed-by"] == "milvus-operator"
+    ):
         deploy_tool = "milvus-operator"
     else:
         deploy_tool = "helm"
@@ -250,7 +275,7 @@ def export_pod_logs(namespace, label_selector, release_name=None):
             raise ValueError("Got an unexpected space release_name")
     else:
         raise TypeError("Got an unexpected non-string release_name")
-    pod_log_path = '/tmp/milvus_logs' if release_name is None else f'/tmp/milvus_logs/{release_name}'
+    pod_log_path = "/tmp/milvus_logs" if release_name is None else f"/tmp/milvus_logs/{release_name}"
 
     if not os.path.isdir(pod_log_path):
         os.makedirs(pod_log_path)
@@ -260,7 +285,7 @@ def export_pod_logs(namespace, label_selector, release_name=None):
     try:
         for item in items:
             pod_name = item.metadata.name
-            os.system(f'kubectl logs {pod_name} > {pod_log_path}/{pod_name}.log 2>&1')
+            os.system(f"kubectl logs {pod_name} > {pod_log_path}/{pod_name}.log 2>&1")
     except Exception as e:
         log.error(f"Exception when export pod {pod_name} logs: %s\n" % e)
         raise Exception(str(e))
@@ -272,7 +297,7 @@ def read_pod_log(namespace, label_selector, release_name):
 
     try:
         # export log to /tmp/release_name path
-        pod_log_path = f'/tmp/milvus_logs/{release_name}'
+        pod_log_path = f"/tmp/milvus_logs/{release_name}"
         if not os.path.isdir(pod_log_path):
             os.makedirs(pod_log_path)
 
@@ -280,9 +305,9 @@ def read_pod_log(namespace, label_selector, release_name):
 
         for item in items:
             pod = item.metadata.name
-            log.debug(f'Start to read {pod} log')
+            log.debug(f"Start to read {pod} log")
             logs = api_instance.read_namespaced_pod_log(name=pod, namespace=namespace, async_req=True)
-            with open(f'{pod_log_path}/{pod}.log', "w") as f:
+            with open(f"{pod_log_path}/{pod}.log", "w") as f:
                 f.write(logs.get())
 
     except ApiException as e:
@@ -291,15 +316,17 @@ def read_pod_log(namespace, label_selector, release_name):
 
 
 def get_metrics_querynode_sq_req_count():
-    """ get metric milvus_querynode_collection_num from prometheus"""
+    """get metric milvus_querynode_collection_num from prometheus"""
 
-    PROMETHEUS = 'http://10.96.7.6:9090'
-    query_str = 'milvus_querynode_sq_req_count{app_kubernetes_io_instance="mic-replica",' \
-                'app_kubernetes_io_name="milvus",namespace="chaos-testing"}'
+    PROMETHEUS = "http://10.96.7.6:9090"
+    query_str = (
+        'milvus_querynode_sq_req_count{app_kubernetes_io_instance="mic-replica",'
+        'app_kubernetes_io_name="milvus",namespace="chaos-testing"}'
+    )
 
-    response = requests.get(PROMETHEUS + '/api/v1/query', params={'query': query_str})
+    response = requests.get(PROMETHEUS + "/api/v1/query", params={"query": query_str})
     if response.status_code == 200:
-        results = response.json()["data"]['result']
+        results = response.json()["data"]["result"]
         # print(results)
         # print(type(results))
         log.debug(json.dumps(results, indent=4))
@@ -317,20 +344,20 @@ def get_metrics_querynode_sq_req_count():
 
 
 def get_svc_ip(namespace, label_selector):
-    """ get svc ip from svc list """
+    """get svc ip from svc list"""
     init_k8s_client_config()
     api_instance = client.CoreV1Api()
     try:
         api_response = api_instance.list_namespaced_service(namespace=namespace, label_selector=label_selector)
     except ApiException as e:
-        log.error("Exception when calling CoreV1Api->list_namespaced_service: %s\n" % e)
+        log.error(f"Exception when calling CoreV1Api->list_namespaced_service: {e}\n")
         raise Exception(str(e))
     svc_ip = api_response.items[0].spec.cluster_ip
     return svc_ip
 
 
 def parse_etcdctl_table_output(output):
-    """ parse etcdctl table output """
+    """parse etcdctl table output"""
     output = output.split("\n")
     title = []
     data = []
@@ -343,7 +370,7 @@ def parse_etcdctl_table_output(output):
 
 
 def get_etcd_leader(release_name, deploy_tool="helm"):
-    """ get etcd leader by etcdctl """
+    """get etcd leader by etcdctl"""
     pod_list = []
     if deploy_tool == "helm":
         label_selector = f"app.kubernetes.io/instance={release_name}-etcd, app.kubernetes.io/name=etcd"
@@ -369,7 +396,7 @@ def get_etcd_leader(release_name, deploy_tool="helm"):
 
 
 def get_etcd_followers(release_name, deploy_tool="helm"):
-    """ get etcd follower by etcdctl """
+    """get etcd follower by etcdctl"""
     pod_list = []
     if deploy_tool == "helm":
         label_selector = f"app.kubernetes.io/instance={release_name}-etcd, app.kubernetes.io/name=etcd"
@@ -402,10 +429,10 @@ def find_activate_standby_coord_pod(namespace, release_name, coord_type):
     etcd_cluster_ip = service.spec.cluster_ip
     etcd_port = service.spec.ports[0].port
     etcd = pyetcd.client(host=etcd_cluster_ip, port=etcd_port)
-    v = etcd.get(f'by-dev/meta/session/{coord_type}')
+    v = etcd.get(f"by-dev/meta/session/{coord_type}")
     log.info(f"coord_type: {coord_type}, etcd session value: {v}")
     activated_pod_ip = json.loads(v[0])["Address"].split(":")[0]
-    label_selector = f'app.kubernetes.io/instance={release_name}, component={coord_type}'
+    label_selector = f"app.kubernetes.io/instance={release_name}, component={coord_type}"
     items = get_pod_list(namespace, label_selector=label_selector)
     all_pod_list = []
     for item in items:
@@ -423,24 +450,31 @@ def find_activate_standby_coord_pod(namespace, release_name, coord_type):
 
 
 def record_time_when_standby_activated(namespace, release_name, coord_type, timeout=360):
-    activate_pod_list_before, standby_pod_list_before = find_activate_standby_coord_pod(namespace, release_name,
-                                                                                        coord_type)
-    log.info(f"check standby switch: activate_pod_list_before {activate_pod_list_before}, "
-             f"standby_pod_list_before {standby_pod_list_before}")
+    activate_pod_list_before, standby_pod_list_before = find_activate_standby_coord_pod(
+        namespace, release_name, coord_type
+    )
+    log.info(
+        f"check standby switch: activate_pod_list_before {activate_pod_list_before}, "
+        f"standby_pod_list_before {standby_pod_list_before}"
+    )
     standby_activated = False
-    activate_pod_list_after, standby_pod_list_after = find_activate_standby_coord_pod(namespace, release_name,
-                                                                                      coord_type)
+    activate_pod_list_after, standby_pod_list_after = find_activate_standby_coord_pod(
+        namespace, release_name, coord_type
+    )
     start_time = time.time()
     end_time = time.time()
     while not standby_activated and end_time - start_time < timeout:
         try:
-            activate_pod_list_after, standby_pod_list_after = find_activate_standby_coord_pod(namespace, release_name,
-                                                                                              coord_type)
+            activate_pod_list_after, standby_pod_list_after = find_activate_standby_coord_pod(
+                namespace, release_name, coord_type
+            )
             if activate_pod_list_after[0] in standby_pod_list_before:
                 standby_activated = True
                 log.info(f"Standby {coord_type} pod {activate_pod_list_after[0]} activated")
-                log.info(f"check standby switch: activate_pod_list_after {activate_pod_list_after}, "
-                         f"standby_pod_list_after {standby_pod_list_after}")
+                log.info(
+                    f"check standby switch: activate_pod_list_after {activate_pod_list_after}, "
+                    f"standby_pod_list_after {standby_pod_list_after}"
+                )
                 break
         except Exception as e:
             log.error(f"Exception when check standby switch: {e}")
@@ -452,11 +486,9 @@ def record_time_when_standby_activated(namespace, release_name, coord_type, time
         log.info(f"Standby {coord_type} pod does not switch standby mode")
 
 
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     label = "app.kubernetes.io/name=milvus, component=querynode"
     instance_name = get_milvus_instance_name("chaos-testing", "10.96.250.111")
     res = get_pod_list("chaos-testing", label_selector=label)
     m = get_pod_ip_name_pairs("chaos-testing", label_selector=label)
-    export_pod_logs(namespace='chaos-testing', label_selector=label)
+    export_pod_logs(namespace="chaos-testing", label_selector=label)


### PR DESCRIPTION
## What changed

- Backport master PR #49800 to 2.6.
- Add missing container-kill Chaos Mesh YAMLs for Milvus components and dependencies.
- Add selected-pod container-kill template for etcd leader/follower chaos cases.
- Resolve container names dynamically before creating container-kill resources.

pr: #49800
Fixes #49798

## Validation

- python3 -m py_compile tests/python_client/chaos/test_chaos_apply.py tests/python_client/chaos/test_chaos_apply_to_determined_pod.py tests/python_client/utils/util_k8s.py
- ruby -ryaml parsed 17 container-kill/template YAML files
- git diff --check origin/2.6..HEAD