### PR TITLE
test: xfail unstable nullable metric aggregation e2e

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
@@ -628,6 +628,7 @@ class TestSearchAggregation(TestMilvusClientV2Base):
             for hit in bucket.hits:
                 assert hit.fields.get(field_name) == key
 
+    @pytest.mark.xfail(reason="unstable: top_hits may not include NULL nullable metric rows", strict=False)
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_aggregation_nullable_metric_field(self):
         """


### PR DESCRIPTION
issue: #49046

## What this PR does

Marks `test_search_aggregation_nullable_metric_field` as non-strict xfail because the case is unstable when `top_hits` does not include NULL nullable metric rows.