### PR TITLE
fix: preserve search aggregation group-by metadata

### DIFF
--- a/internal/util/shallowcopy/shallowcopy.go
+++ b/internal/util/shallowcopy/shallowcopy.go
@@ -45,6 +45,7 @@ func ShallowCopySearchRequest(src *internalpb.SearchRequest, targetID int64) *in
 		EntityTtlPhysicalTime:   src.EntityTtlPhysicalTime,
 		PkFilter:                src.PkFilter,
 		SearchType:              src.SearchType,
+		GroupByFieldIds:         src.GroupByFieldIds,
 	}
 }
 

--- a/internal/util/shallowcopy/shallowcopy_test.go
+++ b/internal/util/shallowcopy/shallowcopy_test.go
@@ -34,6 +34,7 @@ func TestShallowCopySearchRequest(t *testing.T) {
 			IsAdvanced:              true,
 			Offset:                  5,
 			GroupByFieldId:          7,
+			GroupByFieldIds:         []int64{7, 9},
 			GroupSize:               3,
 			FieldId:                 8,
 			IsTopkReduce:            true,
@@ -64,6 +65,7 @@ func TestShallowCopySearchRequest(t *testing.T) {
 		assert.Equal(t, src.PartitionIDs, dst.PartitionIDs)
 		assert.Equal(t, src.PlaceholderGroup, dst.PlaceholderGroup)
 		assert.Equal(t, src.SerializedExprPlan, dst.SerializedExprPlan)
+		assert.Equal(t, src.GroupByFieldIds, dst.GroupByFieldIds)
 	})
 }
 

--- a/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
@@ -1332,10 +1332,6 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
         )
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.xfail(
-        reason="Milvus issue #49840: search_aggregation fails on growing segment",
-        strict=True,
-    )
     def test_search_aggregation_on_growing_segment(self):
         """
         target: verify search_aggregation works on growing segment results.


### PR DESCRIPTION
issue: #49840

## Summary
- Preserve plural group-by field IDs when shallow-copying search requests for query nodes.
- Add regression coverage for SearchRequest shallow-copy metadata propagation.
- Re-enable the growing-segment search aggregation E2E case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)