### PR TITLE
enhance: [Proxy] enforce collection description byte limit

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -319,6 +319,10 @@ proxy:
     timeTick:
       bufSize: 512 # The maximum number of messages can be buffered in the timeTick message stream of the proxy when producing messages.
   maxNameLength: 255 # The maximum length of the name or alias that can be created in Milvus, including the collection name, collection alias, partition name, and field name.
+  # Maximum byte length of a collection description accepted by CreateCollection and AlterCollection.
+  # Existing collection metadata can still load with a longer description, but restore or replication
+  # flows that recreate a collection through CreateCollection must satisfy this limit or raise it first.
+  maxCollectionDescriptionLength: 1024
   maxFieldNum: 64 # The maximum number of field can be created when creating in a collection. It is strongly DISCOURAGED to set maxFieldNum >= 64.
   maxVectorFieldNum: 10 # The maximum number of vector fields that can be specified in a collection
   maxShardNum: 16 # The maximum number of shards can be created when creating in a collection.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -319,10 +319,7 @@ proxy:
     timeTick:
       bufSize: 512 # The maximum number of messages can be buffered in the timeTick message stream of the proxy when producing messages.
   maxNameLength: 255 # The maximum length of the name or alias that can be created in Milvus, including the collection name, collection alias, partition name, and field name.
-  # Maximum byte length of a collection description accepted by CreateCollection and AlterCollection.
-  # Existing collection metadata can still load with a longer description, but restore or replication
-  # flows that recreate a collection through CreateCollection must satisfy this limit or raise it first.
-  maxCollectionDescriptionLength: 1024
+  maxCollectionDescriptionLength: 1024 # The maximum byte length of a collection description accepted by CreateCollection and AlterCollection. Existing collection metadata is not revalidated, but restore or replication flows that recreate a collection through CreateCollection must satisfy this limit or raise it first.
   maxFieldNum: 64 # The maximum number of field can be created when creating in a collection. It is strongly DISCOURAGED to set maxFieldNum >= 64.
   maxVectorFieldNum: 10 # The maximum number of vector fields that can be specified in a collection
   maxShardNum: 16 # The maximum number of shards can be created when creating in a collection.

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -479,6 +479,9 @@ func (t *createCollectionTask) PreExecute(ctx context.Context) error {
 	if err := validateCollectionName(t.schema.Name); err != nil {
 		return err
 	}
+	if err := validateCollectionDescription(t.schema.GetDescription()); err != nil {
+		return err
+	}
 
 	// Reject reserved system field names supplied by the user before any
 	// server-side injection runs. __virtual_pk__ is the internal PK name
@@ -1970,6 +1973,15 @@ func (t *alterCollectionTask) PreExecute(ctx context.Context) error {
 				if hasWarmup {
 					return merr.WrapErrCollectionLoaded(t.CollectionName, "can not alter warmup properties if collection loaded")
 				}
+			}
+		}
+
+		for _, property := range t.Properties {
+			if property.GetKey() != common.CollectionDescription {
+				continue
+			}
+			if err := validateCollectionDescription(property.GetValue()); err != nil {
+				return err
 			}
 		}
 

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -1577,6 +1578,14 @@ func TestCreateCollectionTask(t *testing.T) {
 		task.Schema = tooLongNameSchema
 		err = task.PreExecute(ctx)
 		assert.Error(t, err)
+
+		schema = proto.Clone(schemaBackup).(*schemapb.CollectionSchema)
+		schema.Description = strings.Repeat("a", Params.ProxyCfg.MaxCollectionDescriptionLength.GetAsInt()+1)
+		tooLongDescriptionSchema, err := proto.Marshal(schema)
+		assert.NoError(t, err)
+		task.Schema = tooLongDescriptionSchema
+		err = task.PreExecute(ctx)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 
 		schema.Name = "$" // invalid first char
 		invalidFirstCharSchema, err := proto.Marshal(schema)
@@ -5494,6 +5503,58 @@ func TestAlterCollectionTaskValidateTTLAndTTLField(t *testing.T) {
 		}
 		assert.NoError(t, task.PreExecute(ctx))
 	})
+}
+
+func TestAlterCollectionTaskValidateDescription(t *testing.T) {
+	qc := NewMixCoordMock()
+	ctx := context.Background()
+	cache := globalMetaCache
+	defer func() { globalMetaCache = cache }()
+	err := InitMetaCache(ctx, qc)
+	assert.NoError(t, err)
+
+	collectionName := "alter_description_" + funcutil.GenRandomStr()
+	schema := &schemapb.CollectionSchema{
+		Name:        collectionName,
+		Description: "short description",
+		AutoID:      false,
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "8"}}},
+		},
+	}
+	bs, err := proto.Marshal(schema)
+	assert.NoError(t, err)
+	status, err := qc.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         bs,
+		ShardsNum:      1,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, commonpb.ErrorCode_Success, status.GetErrorCode())
+
+	task := &alterCollectionTask{
+		AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+			Base:           &commonpb.MsgBase{},
+			CollectionName: collectionName,
+			Properties: []*commonpb.KeyValuePair{
+				{Key: common.CollectionDescription, Value: strings.Repeat("a", Params.ProxyCfg.MaxCollectionDescriptionLength.GetAsInt()+1)},
+			},
+		},
+		ctx:      ctx,
+		mixCoord: qc,
+	}
+	err = task.PreExecute(ctx)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+
+	task.Properties = []*commonpb.KeyValuePair{
+		{Key: common.CollectionDescription, Value: "short description"},
+		{Key: common.CollectionDescription, Value: strings.Repeat("a", Params.ProxyCfg.MaxCollectionDescriptionLength.GetAsInt()+1)},
+	}
+	err = task.PreExecute(ctx)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 }
 
 func mockVectorIndexForCollection(t *testing.T, ctx context.Context, qc *MixCoordMock, colName string) {

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -327,6 +327,15 @@ func validateCollectionName(collName string) error {
 	return validateCollectionNameOrAlias(collName, "name")
 }
 
+func validateCollectionDescription(description string) error {
+	if len(description) > Params.ProxyCfg.MaxCollectionDescriptionLength.GetAsInt() {
+		return merr.WrapErrParameterInvalidMsg(
+			"the length of a collection description must not exceed %s bytes",
+			Params.ProxyCfg.MaxCollectionDescriptionLength.GetValue())
+	}
+	return nil
+}
+
 func validatePartitionTag(partitionTag string, strictCheck bool) error {
 	partitionTag = strings.TrimSpace(partitionTag)
 

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -116,6 +116,53 @@ func TestValidateCollectionName(t *testing.T) {
 	}
 }
 
+func TestValidateCollectionDescription(t *testing.T) {
+	maxLength := Params.ProxyCfg.MaxCollectionDescriptionLength.GetAsInt()
+	tests := []struct {
+		name        string
+		description string
+		wantErr     bool
+	}{
+		{
+			name:        "empty description",
+			description: "",
+		},
+		{
+			name:        "exactly max bytes",
+			description: strings.Repeat("a", maxLength),
+		},
+		{
+			name:        "over max bytes",
+			description: strings.Repeat("a", maxLength+1),
+			wantErr:     true,
+		},
+		{
+			name:        "cjk rune count under max but byte length over max",
+			description: strings.Repeat("中", maxLength/3+1),
+			wantErr:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateCollectionDescription(test.description)
+			if test.wantErr {
+				assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+
+	t.Run("uses refreshable paramtable limit", func(t *testing.T) {
+		old := Params.ProxyCfg.MaxCollectionDescriptionLength.SwapTempValue("3")
+		defer Params.ProxyCfg.MaxCollectionDescriptionLength.SwapTempValue(old)
+
+		err := validateCollectionDescription("abcd")
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+}
+
 func TestValidateResourceGroupName(t *testing.T) {
 	assert.Nil(t, ValidateResourceGroupName("abc"))
 	assert.Nil(t, ValidateResourceGroupName("_123abc"))

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2036,6 +2036,7 @@ type proxyConfig struct {
 	HealthCheckTimeout                ParamItem `refreshable:"true"`
 	MsgStreamTimeTickBufSize          ParamItem `refreshable:"true"`
 	MaxNameLength                     ParamItem `refreshable:"true"`
+	MaxCollectionDescriptionLength    ParamItem `refreshable:"true"`
 	MaxUsernameLength                 ParamItem `refreshable:"true"`
 	MinPasswordLength                 ParamItem `refreshable:"true"`
 	MaxPasswordLength                 ParamItem `refreshable:"true"`
@@ -2132,6 +2133,16 @@ func (p *proxyConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.MaxNameLength.Init(base.mgr)
+
+	p.MaxCollectionDescriptionLength = ParamItem{
+		Key:          "proxy.maxCollectionDescriptionLength",
+		DefaultValue: "1024",
+		Version:      "2.6.0",
+		PanicIfEmpty: true,
+		Doc:          "The maximum byte length of a collection description accepted by CreateCollection and AlterCollection. Existing collection metadata is not revalidated, but restore or replication flows that recreate a collection through CreateCollection must satisfy this limit or raise it first.",
+		Export:       true,
+	}
+	p.MaxCollectionDescriptionLength.Init(base.mgr)
 
 	p.MinPasswordLength = ParamItem{
 		Key:          "proxy.minPasswordLength",


### PR DESCRIPTION
- Add a refreshable proxy.maxCollectionDescriptionLength setting with a default 1024-byte limit and document it in milvus.yaml.
- Validate collection descriptions during CreateCollection and AlterCollection PreExecute, including duplicate alter properties, while leaving existing metadata loading unchanged.
- Document that restore or replication flows that recreate collections through CreateCollection must satisfy the configured limit or raise it first.
- Cover byte-length boundaries, CJK byte overflow, create rejection, alter rejection, refreshability, duplicate alter-property rejection, and generated YAML consistency in tests.

related: #50173