### PR TITLE
test: use rjieba for jieba tokenizer tests

### DIFF
--- a/tests/python_client/common/common_func.py
+++ b/tests/python_client/common/common_func.py
@@ -15,10 +15,10 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import bm25s
-import jieba
 import numpy as np
 import pandas as pd
 import pytz
+import rjieba
 from base.schema_wrapper import ApiCollectionSchemaWrapper, ApiFieldSchemaWrapper
 from bm25s.tokenization import Tokenizer
 from common import common_type as ct
@@ -238,7 +238,7 @@ def get_bm25_ground_truth(corpus, queries, top_k=100, language="en"):
     # Tokenize the corpus
     def jieba_split(text):
         text_without_punctuation = remove_punctuation(text)
-        return jieba.lcut(text_without_punctuation)
+        return rjieba.cut(text_without_punctuation)
 
     stopwords = "english" if language in ["en", "english"] else [" "]
     stemmer = None
@@ -264,7 +264,7 @@ def custom_tokenizer(language="en"):
     # Tokenize the corpus
     def jieba_split(text):
         text_without_punctuation = remove_punctuation(text)
-        return jieba.cut_for_search(text_without_punctuation)
+        return rjieba.cut_for_search(text_without_punctuation)
 
     def blank_space_split(text):
         text_without_punctuation = remove_punctuation(text)

--- a/tests/python_client/common/phrase_match_generator.py
+++ b/tests/python_client/common/phrase_match_generator.py
@@ -1,10 +1,10 @@
-import re
-import jieba
-from faker import Faker
-from tantivy import SchemaBuilder, Document, Index, Query
-from typing import List, Dict
-import numpy as np
 import random
+import re
+
+import numpy as np
+import rjieba
+from faker import Faker
+from tantivy import Document, Index, Query, SchemaBuilder
 
 
 class PhraseMatchTestGenerator:
@@ -163,18 +163,18 @@ class PhraseMatchTestGenerator:
         self.connectors = self.zh_connectors if language == "zh" else self.en_connectors
         self.modifiers = self.zh_modifiers if language == "zh" else self.en_modifiers
 
-    def tokenize_text(self, text: str) -> List[str]:
+    def tokenize_text(self, text: str) -> list[str]:
         """Tokenize text using jieba tokenizer"""
         text = text.strip()
         text = re.sub(r"[^\w\s]", " ", text)
         text = text.replace("\n", " ")
         if self.language == "zh":
             text = text.replace(" ", "")
-            return list(jieba.cut_for_search(text))
+            return list(rjieba.cut_for_search(text))
         else:
             return list(text.split())
 
-    def generate_embedding(self, dim: int) -> List[float]:
+    def generate_embedding(self, dim: int) -> list[float]:
         """Generate random embedding vector"""
         return list(np.random.random(dim))
 
@@ -184,17 +184,23 @@ class PhraseMatchTestGenerator:
             # Simple pattern with two activities
             lambda: f"{random.choice(self.activities)} {random.choice(self.activities)}",
             # Pattern with connector between activities
-            lambda: f"{random.choice(self.activities)} {random.choice(self.connectors)} {random.choice(self.activities)}",
+            lambda: (
+                f"{random.choice(self.activities)} {random.choice(self.connectors)} {random.choice(self.activities)}"
+            ),
             # Pattern with modifier between activities
-            lambda: f"{random.choice(self.activities)} {random.choice(self.modifiers)} {random.choice(self.activities)}",
+            lambda: (
+                f"{random.choice(self.activities)} {random.choice(self.modifiers)} {random.choice(self.activities)}"
+            ),
             # Complex pattern with verb and activities
             lambda: f"{random.choice(self.verbs)} {random.choice(self.activities)} {random.choice(self.activities)}",
             # Pattern with multiple gaps
-            lambda: f"{random.choice(self.activities)} {random.choice(self.modifiers)} {random.choice(self.connectors)} {random.choice(self.activities)}",
+            lambda: (
+                f"{random.choice(self.activities)} {random.choice(self.modifiers)} {random.choice(self.connectors)} {random.choice(self.activities)}"
+            ),
         ]
         return random.choice(patterns)()
 
-    def generate_test_data(self, num_documents: int, dim: int) -> List[Dict]:
+    def generate_test_data(self, num_documents: int, dim: int) -> list[dict]:
         """
         Generate test documents with text and embeddings
 
@@ -242,7 +248,7 @@ class PhraseMatchTestGenerator:
 
         return self.documents
 
-    def _generate_random_word(self, exclude_words: List[str]) -> str:
+    def _generate_random_word(self, exclude_words: list[str]) -> str:
         """
         Generate a random word that is not in the exclude_words list using Faker
         """
@@ -252,7 +258,7 @@ class PhraseMatchTestGenerator:
             if word not in exclude_words:
                 return word
 
-    def generate_pattern_documents(self, patterns: List[tuple], dim: int, num_docs_per_pattern: int = 1) -> List[Dict]:
+    def generate_pattern_documents(self, patterns: list[tuple], dim: int, num_docs_per_pattern: int = 1) -> list[dict]:
         """
         Generate documents that match specific test patterns with their corresponding slop values
 
@@ -272,8 +278,9 @@ class PhraseMatchTestGenerator:
             # Generate multiple documents for each pattern
             if slop == 0:  # Exact phrase
                 text = " ".join(pattern_words)
-                pattern_documents.append({
-                    "id": random.randint(0, 1000000), "text": text, "emb": self.generate_embedding(dim)})
+                pattern_documents.append(
+                    {"id": random.randint(0, 1000000), "text": text, "emb": self.generate_embedding(dim)}
+                )
 
             else:  # Pattern with gaps
                 # Generate slop number of unique words
@@ -290,10 +297,9 @@ class PhraseMatchTestGenerator:
                     all_words.insert(pos, word)
 
                 text = " ".join(all_words)
-                pattern_documents.append({
-                    "id": random.randint(0, 1000000),
-                    "text": text,
-                    "emb": self.generate_embedding(dim)})
+                pattern_documents.append(
+                    {"id": random.randint(0, 1000000), "text": text, "emb": self.generate_embedding(dim)}
+                )
 
         new_pattern_documents = []
         start = 1000000
@@ -305,7 +311,7 @@ class PhraseMatchTestGenerator:
 
         return new_pattern_documents
 
-    def generate_test_queries(self, num_queries: int) -> List[Dict]:
+    def generate_test_queries(self, num_queries: int) -> list[dict]:
         """
         Generate test queries with varying slop values
 
@@ -326,9 +332,7 @@ class PhraseMatchTestGenerator:
             queries.append(
                 {
                     "id": i,
-                    "query": " ".join(words)
-                    if self.language == "en"
-                    else "".join(words),
+                    "query": " ".join(words) if self.language == "en" else "".join(words),
                     "slop": random.choice(slop_values),
                     "type": f"{num_words}_words",
                 }
@@ -336,7 +340,7 @@ class PhraseMatchTestGenerator:
 
         return queries
 
-    def get_query_results(self, query: str, slop: int) -> List[Dict]:
+    def get_query_results(self, query: str, slop: int) -> list[dict]:
         """
         Get all documents that match the phrase query
 
@@ -368,4 +372,3 @@ class PhraseMatchTestGenerator:
             matched_docs.extend(doc_id)
 
         return matched_docs
-

--- a/tests/python_client/milvus_client/test_milvus_client_analyzer.py
+++ b/tests/python_client/milvus_client/test_milvus_client_analyzer.py
@@ -1,6 +1,6 @@
+from typing import Any, Protocol, cast
+
 import pytest
-from typing import Any, List, Dict, Protocol, cast
-import uuid
 from base.client_v2_base import TestMilvusClientV2Base
 from common.common_type import CaseLabel
 from common.text_generator import generate_text_by_analyzer
@@ -8,59 +8,42 @@ from common.text_generator import generate_text_by_analyzer
 
 class AnalyzerResult(Protocol):
     """Protocol for analyzer result to help with type inference"""
-    tokens: List[Dict[str, Any]]
+
+    tokens: list[dict[str, Any]]
 
 
 class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
-    
     @staticmethod
     def get_expected_jieba_tokens(text, analyzer_params):
         """
-        Generate expected tokens using jieba library based on analyzer parameters
+        Generate expected tokens using rjieba based on analyzer parameters.
         """
-        import jieba
-        import importlib
-        importlib.reload(jieba)
+        import rjieba
+
         tokenizer_config = analyzer_params.get("tokenizer", {})
-        # Set up custom dictionary if provided
-        if "dict" in tokenizer_config:
-            custom_dict = tokenizer_config["dict"]
-            if "_default_" in custom_dict:
-                # jieba.dt.initialize()
-                for word in custom_dict:
-                    if word != "_default_":
-                        jieba.add_word(word)
-                print(f"dict length: {len(jieba.dt.FREQ)}")
-                print(jieba.dt.FREQ)
-            else:
-                file_path = f"/tmp/{uuid.uuid4()}.txt"
-                # add custom words to jieba_dict.txt
-                for word in custom_dict:
-                    with open(file_path, "w") as f:
-                        f.write(f"{word} 1")
-                jieba.set_dictionary(file_path)
-                jieba.dt.tmp_dir = None
-                jieba.dt.cache_file = None
-                jieba.dt.FREQ = {}
-                jieba.dt.initialize()
-            
-        
-        # Configure mode
+        if isinstance(tokenizer_config, str):
+            tokenizer_config = {}
+
+        # rjieba does not expose jieba-rs dynamic dictionary APIs. Fall back
+        # to targeted assertions in custom-dictionary cases.
+        if "dict" in tokenizer_config and tokenizer_config["dict"] != ["_default_"]:
+            return None
+
         mode = tokenizer_config.get("mode", "search")
         hmm = tokenizer_config.get("hmm", True)
-        
+
         if mode == "exact":
-            tokens = list(jieba.cut(text, HMM=hmm))
+            tokens = list(rjieba.cut(text, hmm))
         elif mode == "search":
-            tokens = list(jieba.cut_for_search(text, HMM=hmm))
+            tokens = list(rjieba.cut_for_search(text, hmm))
         else:
-            tokens = list(jieba.cut(text, HMM=hmm))
-        
+            tokens = list(rjieba.cut(text, hmm))
+
         # Filter out empty tokens
         tokens = [token for token in tokens if token.strip()]
-        
+
         return tokens
-    
+
     analyzer_params_list = [
         {
             "tokenizer": "standard",
@@ -80,9 +63,7 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
                 }
             ],
         },
-        {
-            "tokenizer": "icu"
-        }
+        {"tokenizer": "icu"},
         # {
         #     "tokenizer": {"type": "lindera", "dict_kind": "ipadic"},
         #     "filter": [
@@ -95,59 +76,22 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         # {"tokenizer": {"type": "lindera", "dict_kind": "ko-dic"}},
         # {"tokenizer": {"type": "lindera", "dict_kind": "cc-cedict"}},
     ]
-    
+
     jieba_custom_analyzer_params_list = [
         # # Test dict parameter with custom dictionary
-        {
-            "tokenizer": {
-                "type": "jieba",
-                "dict": ["结巴分词器"],
-                "mode": "exact",
-                "hmm": False
-            }
-        },
+        {"tokenizer": {"type": "jieba", "dict": ["结巴分词器"], "mode": "exact", "hmm": False}},
         # Test dict parameter with default dict and custom dict
-        {
-            "tokenizer": {
-                "type": "jieba",
-                "dict": ["_default_", "结巴分词器"],
-                "mode": "search",
-                "hmm": False
-            }
-        },
+        {"tokenizer": {"type": "jieba", "dict": ["_default_", "结巴分词器"], "mode": "search", "hmm": False}},
         # Test exact mode with hmm enabled
-        {
-            "tokenizer": {
-                "type": "jieba",
-                "dict": ["结巴分词器"],
-                "mode": "exact",
-                "hmm": True
-            }
-        },
+        {"tokenizer": {"type": "jieba", "dict": ["结巴分词器"], "mode": "exact", "hmm": True}},
         # Test search mode with hmm enabled
-        {
-            "tokenizer": {
-                "type": "jieba",
-                "dict": ["结巴分词器"],
-                "mode": "search",
-                "hmm": True
-            }
-        },
+        {"tokenizer": {"type": "jieba", "dict": ["结巴分词器"], "mode": "search", "hmm": True}},
         # Test with only mode configuration
-        {
-            "tokenizer": {
-                "type": "jieba",
-                "mode": "exact"
-            }
-        },
+        {"tokenizer": {"type": "jieba", "mode": "exact"}},
         # Test with only hmm configuration
-        {
-            "tokenizer": {
-                "type": "jieba",
-                "hmm": False
-            }
-        }
+        {"tokenizer": {"type": "jieba", "hmm": False}},
     ]
+
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("analyzer_params", analyzer_params_list)
     def test_analyzer(self, analyzer_params):
@@ -160,11 +104,11 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         text = generate_text_by_analyzer(analyzer_params)
         res, _ = self.run_analyzer(client, text, analyzer_params, with_detail=True, with_hash=True)
         res_2, _ = self.run_analyzer(client, text, analyzer_params, with_detail=True, with_hash=True)
-        
+
         # Cast to help type inference for gRPC response
         analyzer_res = cast(AnalyzerResult, res)
         analyzer_res_2 = cast(AnalyzerResult, res_2)
-        
+
         # verify the result are the same when run analyzer twice
         for i in range(len(analyzer_res.tokens)):
             assert analyzer_res.tokens[i]["token"] == analyzer_res_2.tokens[i]["token"]
@@ -180,17 +124,15 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         assert len(token_list) > 0, "No tokens were generated"
 
         # Check tokens are related to input text (all token should be a substring of the text)
-        assert all(
-            token.lower() in text.lower() for token in token_list
-        ), "some of the tokens do not appear in the original text"
+        assert all(token.lower() in text.lower() for token in token_list), (
+            "some of the tokens do not appear in the original text"
+        )
 
         if "filter" in analyzer_params:
             for filter in analyzer_params["filter"]:
                 if filter["type"] == "stop":
                     stop_words = filter["stop_words"]
-                    assert not any(
-                        token in stop_words for token in tokens
-                    ), "some of the tokens are stop words"
+                    assert not any(token in stop_words for token in tokens), "some of the tokens are stop words"
 
         # Check hash value and detail
         for r in tokens:
@@ -211,18 +153,29 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         client = self._client()
         text = "milvus结巴分词器中文测试"
         res, _ = self.run_analyzer(client, text, analyzer_params, with_detail=True)
-        
+
         analyzer_res = cast(AnalyzerResult, res)
         tokens = analyzer_res.tokens
         token_list = [r["token"] for r in tokens]
-        
+
         # Check tokens are not empty
         assert len(token_list) > 0, "No tokens were generated"
-        
-        # Generate expected tokens using jieba library and compare
+
+        # Generate expected tokens using rjieba and compare when the Python
+        # binding exposes the required tokenizer configuration.
         expected_tokens = self.get_expected_jieba_tokens(text, analyzer_params)
-        assert sorted(token_list) == sorted(expected_tokens), f"Expected {expected_tokens}, but got {token_list}"
-        
+        if expected_tokens is None:
+            custom_words = [
+                word
+                for word in analyzer_params["tokenizer"].get("dict", [])
+                if word not in ("", "_default_", "_extend_default_")
+            ]
+            assert all(word in token_list for word in custom_words), (
+                f"Expected custom words {custom_words}, but got {token_list}"
+            )
+        else:
+            assert sorted(token_list) == sorted(expected_tokens), f"Expected {expected_tokens}, but got {token_list}"
+
         # Verify token details
         for r in tokens:
             assert isinstance(r["token"], str)
@@ -230,19 +183,22 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
             assert isinstance(r["end_offset"], int)
             assert isinstance(r["position"], int)
             assert isinstance(r["position_length"], int)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("invalid_analyzer_params", [
-        {"tokenizer": "invalid_tokenizer"},
-        {"tokenizer": 123},
-        {"tokenizer": None},
-        {"tokenizer": []},
-        {"tokenizer": {"type": "invalid_type"}},
-        {"tokenizer": {"type": None}},
-        {"filter": "invalid_filter"},
-        {"filter": [{"type": None}]},
-        {"filter": [{"invalid_key": "value"}]},
-    ])
+    @pytest.mark.parametrize(
+        "invalid_analyzer_params",
+        [
+            {"tokenizer": "invalid_tokenizer"},
+            {"tokenizer": 123},
+            {"tokenizer": None},
+            {"tokenizer": []},
+            {"tokenizer": {"type": "invalid_type"}},
+            {"tokenizer": {"type": None}},
+            {"filter": "invalid_filter"},
+            {"filter": [{"type": None}]},
+            {"filter": [{"invalid_key": "value"}]},
+        ],
+    )
     def test_analyzer_with_invalid_params(self, invalid_analyzer_params):
         """
         target: test analyzer with invalid parameters
@@ -251,32 +207,35 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         """
         client = self._client()
         text = "test text for invalid analyzer"
-        
+
         with pytest.raises(Exception):
             self.run_analyzer(client, text, invalid_analyzer_params)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_analyzer_with_empty_params(self):
         """
         target: test analyzer with empty parameters (uses default)
-        method: use empty analyzer params 
+        method: use empty analyzer params
         expected: analyzer should use default configuration and work normally
         """
         client = self._client()
         text = "test text for empty analyzer"
-        
+
         # Empty params should use default configuration
         res, _ = self.run_analyzer(client, text, {})
         analyzer_res = cast(AnalyzerResult, res)
         assert len(analyzer_res.tokens) > 0
-    
+
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("invalid_text", [
-        None,
-        123,
-        True,
-        False,
-    ])
+    @pytest.mark.parametrize(
+        "invalid_text",
+        [
+            None,
+            123,
+            True,
+            False,
+        ],
+    )
     def test_analyzer_with_invalid_text(self, invalid_text):
         """
         target: test analyzer with invalid text input
@@ -285,10 +244,10 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         """
         client = self._client()
         analyzer_params = {"tokenizer": "standard"}
-        
+
         with pytest.raises(Exception):
             self.run_analyzer(client, invalid_text, analyzer_params)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_analyzer_with_empty_text(self):
         """
@@ -298,18 +257,21 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         """
         client = self._client()
         analyzer_params = {"tokenizer": "standard"}
-        
+
         res, _ = self.run_analyzer(client, "", analyzer_params)
         analyzer_res = cast(AnalyzerResult, res)
         assert len(analyzer_res.tokens) == 0
-    
+
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("text_input", [
-        [],
-        {},
-        ["list", "of", "strings"],
-        {"key": "value"},
-    ])
+    @pytest.mark.parametrize(
+        "text_input",
+        [
+            [],
+            {},
+            ["list", "of", "strings"],
+            {"key": "value"},
+        ],
+    )
     def test_analyzer_with_structured_text(self, text_input):
         """
         target: test analyzer with structured text input (list/dict)
@@ -318,20 +280,23 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         """
         client = self._client()
         analyzer_params = {"tokenizer": "standard"}
-        
+
         res, _ = self.run_analyzer(client, text_input, analyzer_params)
         # For structured input, API returns direct list format
         assert isinstance(res, list)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("invalid_jieba_params", [
-        {"tokenizer": {"type": "jieba", "dict": "not_a_list"}},
-        {"tokenizer": {"type": "jieba", "dict": [123, 456]}},
-        {"tokenizer": {"type": "jieba", "mode": "invalid_mode"}},
-        {"tokenizer": {"type": "jieba", "mode": 123}},
-        {"tokenizer": {"type": "jieba", "hmm": "not_boolean"}},
-        {"tokenizer": {"type": "jieba", "hmm": 123}},
-    ])
+    @pytest.mark.parametrize(
+        "invalid_jieba_params",
+        [
+            {"tokenizer": {"type": "jieba", "dict": "not_a_list"}},
+            {"tokenizer": {"type": "jieba", "dict": [123, 456]}},
+            {"tokenizer": {"type": "jieba", "mode": "invalid_mode"}},
+            {"tokenizer": {"type": "jieba", "mode": 123}},
+            {"tokenizer": {"type": "jieba", "hmm": "not_boolean"}},
+            {"tokenizer": {"type": "jieba", "hmm": 123}},
+        ],
+    )
     def test_jieba_analyzer_with_invalid_config(self, invalid_jieba_params):
         """
         target: test jieba analyzer with invalid configurations
@@ -340,10 +305,10 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         """
         client = self._client()
         text = "测试文本 for jieba analyzer"
-        
+
         with pytest.raises(Exception):
             self.run_analyzer(client, text, invalid_jieba_params)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_jieba_analyzer_with_empty_dict(self):
         """
@@ -354,19 +319,22 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         client = self._client()
         text = "测试文本 for jieba analyzer"
         jieba_params = {"tokenizer": {"type": "jieba", "dict": []}}
-        
+
         res, _ = self.run_analyzer(client, text, jieba_params)
         analyzer_res = cast(AnalyzerResult, res)
         assert len(analyzer_res.tokens) > 0
-    
+
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("invalid_dict_config", [
-        {"tokenizer": {"type": "jieba", "dict": None}},
-        {"tokenizer": {"type": "jieba", "dict": "invalid_string"}},
-        {"tokenizer": {"type": "jieba", "dict": 123}},
-        {"tokenizer": {"type": "jieba", "dict": True}},
-        {"tokenizer": {"type": "jieba", "dict": {"invalid": "dict"}}},
-    ])
+    @pytest.mark.parametrize(
+        "invalid_dict_config",
+        [
+            {"tokenizer": {"type": "jieba", "dict": None}},
+            {"tokenizer": {"type": "jieba", "dict": "invalid_string"}},
+            {"tokenizer": {"type": "jieba", "dict": 123}},
+            {"tokenizer": {"type": "jieba", "dict": True}},
+            {"tokenizer": {"type": "jieba", "dict": {"invalid": "dict"}}},
+        ],
+    )
     def test_jieba_analyzer_with_invalid_dict_values(self, invalid_dict_config):
         """
         target: test jieba analyzer with invalid dict configurations
@@ -375,16 +343,19 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         """
         client = self._client()
         text = "测试文本 for jieba analyzer"
-        
+
         with pytest.raises(Exception):
             self.run_analyzer(client, text, invalid_dict_config)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("edge_case_dict_config", [
-        {"tokenizer": {"type": "jieba", "dict": ["", "valid_word"]}},  # Empty string in list
-        {"tokenizer": {"type": "jieba", "dict": ["valid_word", "valid_word"]}},  # Duplicate words
-        {"tokenizer": {"type": "jieba", "dict": ["_default_"]}},  # Only default dict
-    ])
+    @pytest.mark.parametrize(
+        "edge_case_dict_config",
+        [
+            {"tokenizer": {"type": "jieba", "dict": ["", "valid_word"]}},  # Empty string in list
+            {"tokenizer": {"type": "jieba", "dict": ["valid_word", "valid_word"]}},  # Duplicate words
+            {"tokenizer": {"type": "jieba", "dict": ["_default_"]}},  # Only default dict
+        ],
+    )
     def test_jieba_analyzer_with_edge_case_dict_values(self, edge_case_dict_config):
         """
         target: test jieba analyzer with edge case dict configurations
@@ -393,12 +364,12 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         """
         client = self._client()
         text = "测试文本 for jieba analyzer"
-        
+
         res, _ = self.run_analyzer(client, text, edge_case_dict_config, with_detail=True)
         analyzer_res = cast(AnalyzerResult, res)
         # These should work but might not be recommended usage
         assert len(analyzer_res.tokens) >= 0
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_jieba_analyzer_with_unknown_param(self):
         """
@@ -409,17 +380,20 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         client = self._client()
         text = "测试文本 for jieba analyzer"
         jieba_params = {"tokenizer": {"type": "jieba", "invalid_param": "value"}}
-        
+
         res, _ = self.run_analyzer(client, text, jieba_params)
         analyzer_res = cast(AnalyzerResult, res)
         assert len(analyzer_res.tokens) > 0
-    
+
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("invalid_filter_params", [
-        {"tokenizer": "standard", "filter": [{"type": "stop", "stop_words": "not_a_list"}]},
-        {"tokenizer": "standard", "filter": [{"type": "stop", "stop_words": [123, 456]}]},
-        {"tokenizer": "standard", "filter": [{"type": "invalid_filter_type"}]},
-    ])
+    @pytest.mark.parametrize(
+        "invalid_filter_params",
+        [
+            {"tokenizer": "standard", "filter": [{"type": "stop", "stop_words": "not_a_list"}]},
+            {"tokenizer": "standard", "filter": [{"type": "stop", "stop_words": [123, 456]}]},
+            {"tokenizer": "standard", "filter": [{"type": "invalid_filter_type"}]},
+        ],
+    )
     def test_analyzer_with_invalid_filter(self, invalid_filter_params):
         """
         target: test analyzer with invalid filter configurations
@@ -428,10 +402,10 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         """
         client = self._client()
         text = "This is a test text with stop words"
-        
+
         with pytest.raises(Exception):
             self.run_analyzer(client, text, invalid_filter_params)
-    
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_analyzer_with_empty_stop_words(self):
         """
@@ -442,12 +416,12 @@ class TestMilvusClientAnalyzer(TestMilvusClientV2Base):
         client = self._client()
         text = "This is a test text with stop words"
         filter_params = {"tokenizer": "standard", "filter": [{"type": "stop", "stop_words": []}]}
-        
+
         res, _ = self.run_analyzer(client, text, filter_params, with_detail=True)
         analyzer_res = cast(AnalyzerResult, res)
         tokens = analyzer_res.tokens
         token_list = [r["token"] for r in tokens]
-        
+
         assert len(token_list) > 0
         # With empty stop words, no filtering should occur
         assert "is" in token_list  # Common stop word should still be present

--- a/tests/python_client/pytest.ini
+++ b/tests/python_client/pytest.ini
@@ -13,7 +13,6 @@ markers =
 filterwarnings =
     ignore::DeprecationWarning
     ignore::pymilvus.decorators.PyMilvusDeprecationWarning
-    ignore:pkg_resources is deprecated as an API:UserWarning:jieba._compat
     ignore:invalid escape sequence:SyntaxWarning
 
 asyncio_default_fixture_loop_scope = function

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -66,7 +66,8 @@ Unidecode==1.3.8
 # for full text search
 tantivy==0.22.0
 bm25s==0.2.0
-jieba==0.42.1
+# rjieba 0.1.11 wraps jieba-rs 0.6.x, closest to Milvus' pinned jieba-rs 0.6.8.
+rjieba==0.1.11
 
 # for minhash function test
 xxhash>=3.0.0

--- a/tests/restful_client_v2/requirements.txt
+++ b/tests/restful_client_v2/requirements.txt
@@ -15,7 +15,8 @@ tenacity>=8.2.3
 ml-dtypes==0.5.1
 loguru==0.7.3
 bm25s==0.2.13
-jieba==0.42.1
+# rjieba 0.1.11 wraps jieba-rs 0.6.x, closest to Milvus' pinned jieba-rs 0.6.8.
+rjieba==0.1.11
 pyarrow==21.0.0
 # for external collection formats
 pylance==6.0.0

--- a/tests/restful_client_v2/utils/utils.py
+++ b/tests/restful_client_v2/utils/utils.py
@@ -1,39 +1,27 @@
-import random
-import time
+import base64
+import datetime
 import random
 import string
-from faker import Faker
+import time
+from collections import Counter
+
+import bm25s
 import numpy as np
+import rjieba
+from faker import Faker
+from loguru import logger
 from ml_dtypes import bfloat16
 from sklearn import preprocessing
-import base64
-import requests
-from loguru import logger
-import datetime
 from sklearn.metrics import pairwise_distances
-from collections import Counter
-import bm25s
-import jieba
-
 
 fake = Faker()
 fake.seed_instance(19530)
 rng = np.random.default_rng()
 
 
-en_vocabularies_distribution = {
-    "hello": 0.01,
-    "milvus": 0.01,
-    "vector": 0.01,
-    "database": 0.01
-}
+en_vocabularies_distribution = {"hello": 0.01, "milvus": 0.01, "vector": 0.01, "database": 0.01}
 
-zh_vocabularies_distribution = {
-    "你好": 0.01,
-    "向量": 0.01,
-    "数据": 0.01,
-    "库": 0.01
-}
+zh_vocabularies_distribution = {"你好": 0.01, "向量": 0.01, "数据": 0.01, "库": 0.01}
 
 
 def patch_faker_text(fake_instance, vocabularies_distribution):
@@ -56,7 +44,7 @@ def patch_faker_text(fake_instance, vocabularies_distribution):
     def new_text(*args, **kwargs):
         sentences = []
         # Split original text into sentences
-        original_sentences = original_text(*args,**kwargs).split('.')
+        original_sentences = original_text(*args, **kwargs).split(".")
         original_sentences = [s.strip() for s in original_sentences if s.strip()]
 
         for base_sentence in original_sentences:
@@ -70,13 +58,13 @@ def patch_faker_text(fake_instance, vocabularies_distribution):
                     words.insert(insert_pos, word)
 
             # Reconstruct the sentence
-            base_sentence = ' '.join(words)
+            base_sentence = " ".join(words)
 
             # Ensure proper capitalization
             base_sentence = base_sentence[0].upper() + base_sentence[1:]
             sentences.append(base_sentence)
 
-        return '. '.join(sentences) + '.'
+        return ". ".join(sentences) + "."
 
     # Replace the original text method with our custom one
     fake_instance.text = new_text
@@ -90,7 +78,7 @@ def analyze_documents(texts, language="en"):
         stopword = " "
         new_texts = []
         for doc in texts:
-            seg_list = jieba.cut(doc, cut_all=True)
+            seg_list = rjieba.cut_all(doc)
             new_texts.append(" ".join(seg_list))
         texts = new_texts
         stopwords = [stopword]
@@ -121,12 +109,13 @@ def analyze_documents(texts, language="en"):
 
 def random_string(length=8):
     letters = string.ascii_letters
-    return ''.join(random.choice(letters) for _ in range(length))
+    return "".join(random.choice(letters) for _ in range(length))
 
 
 def gen_collection_name(prefix="test_collection", length=8):
-    name = f'{prefix}_' + datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S_%f") + random_string(length=length)
+    name = f"{prefix}_" + datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S_%f") + random_string(length=length)
     return name
+
 
 def admin_password():
     return "Milvus"
@@ -149,15 +138,12 @@ def wait_cluster_be_ready(cluster_id, client, timeout=120):
     t0 = time.time()
     while True and time.time() - t0 < timeout:
         rsp = client.cluster_describe(cluster_id)
-        if rsp['code'] == 200:
-            if rsp['data']['status'] == "RUNNING":
+        if rsp["code"] == 200:
+            if rsp["data"]["status"] == "RUNNING":
                 return time.time() - t0
         time.sleep(1)
         logger.debug("wait cluster to be ready, cost time: %s" % (time.time() - t0))
     return -1
-
-
-
 
 
 def gen_data_by_type(field):
@@ -205,13 +191,15 @@ def get_random_json_data(uid=None):
     # gen random dict data
     if uid is None:
         uid = 0
-    data = {"uid": uid,  "name": fake.name(), "address": fake.address(), "text": fake.text(), "email": fake.email(),
-            "phone_number": fake.phone_number(),
-            "json": {
-                "name": fake.name(),
-                "address": fake.address()
-                }
-            }
+    data = {
+        "uid": uid,
+        "name": fake.name(),
+        "address": fake.address(),
+        "text": fake.text(),
+        "email": fake.email(),
+        "phone_number": fake.phone_number(),
+        "json": {"name": fake.name(), "address": fake.address()},
+    }
     for i in range(random.randint(1, 10)):
         data["key" + str(random.randint(1, 100_000))] = "value" + str(random.randint(1, 100_000))
     return data
@@ -223,24 +211,28 @@ def get_data_by_payload(payload, nb=3000):
     pk_field = payload.get("primaryField", "id")
     data = []
     if nb == 1:
-        data = [{
-            pk_field: int(time.time()*10000),
-            vector_field: preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist(),
-            **get_random_json_data()
-
-        }]
+        data = [
+            {
+                pk_field: int(time.time() * 10000),
+                vector_field: preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist(),
+                **get_random_json_data(),
+            }
+        ]
     else:
         for i in range(nb):
-            data.append({
-                pk_field: int(time.time()*10000),
-                vector_field: preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist(),
-                **get_random_json_data(uid=i)
-            })
+            data.append(
+                {
+                    pk_field: int(time.time() * 10000),
+                    vector_field: preprocessing.normalize([np.array([random.random() for i in range(dim)])])[
+                        0
+                    ].tolist(),
+                    **get_random_json_data(uid=i),
+                }
+            )
     return data
 
 
 def get_common_fields_by_data(data, exclude_fields=None):
-    fields = set()
     if isinstance(data, dict):
         data = [data]
     if not isinstance(data, list):
@@ -302,19 +294,16 @@ def gen_bf16_vectors(num, dim):
     return raw_vectors, bf16_vectors
 
 
-def gen_vector(datatype="FloatVector", dim=128, binary_data=False, sparse_format='dok'):
+def gen_vector(datatype="FloatVector", dim=128, binary_data=False, sparse_format="dok"):
     value = None
     if datatype == "FloatVector":
         return preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
     if datatype == "SparseFloatVector":
-        if sparse_format == 'dok':
+        if sparse_format == "dok":
             return {d: rng.random() for d in random.sample(range(dim), random.randint(20, 30))}
-        elif sparse_format == 'coo':
+        elif sparse_format == "coo":
             data = {d: rng.random() for d in random.sample(range(dim), random.randint(20, 30))}
-            coo_data = {
-                "indices": list(data.keys()),
-                "values": list(data.values())
-            }
+            coo_data = {"indices": list(data.keys()), "values": list(data.values())}
             return coo_data
         else:
             raise Exception(f"unsupported sparse format: {sparse_format}")
@@ -361,18 +350,15 @@ def l2_distance(u, v):
 
 
 def get_sorted_distance(train_emb, test_emb, metric_type):
-    milvus_sklearn_metric_map = {
-        "L2": l2_distance,
-        "COSINE": cosine_distance,
-        "IP": ip_distance
-    }
+    milvus_sklearn_metric_map = {"L2": l2_distance, "COSINE": cosine_distance, "IP": ip_distance}
     distance = pairwise_distances(train_emb, Y=test_emb, metric=milvus_sklearn_metric_map[metric_type], n_jobs=-1)
-    distance = np.array(distance.T, order='C', dtype=np.float32)
+    distance = np.array(distance.T, order="C", dtype=np.float32)
     distance_sorted = np.sort(distance, axis=1).tolist()
     return distance_sorted
 
 
 # ============= Geometry Utils =============
+
 
 def generate_wkt_by_type(wkt_type: str, bounds: tuple = (0, 100, 0, 100), count: int = 10) -> list:
     """
@@ -389,7 +375,9 @@ def generate_wkt_by_type(wkt_type: str, bounds: tuple = (0, 100, 0, 100), count:
     if wkt_type == "POINT":
         points = []
         for _ in range(count):
-            wkt_string = f"POINT ({random.uniform(bounds[0], bounds[1]):.2f} {random.uniform(bounds[2], bounds[3]):.2f})"
+            wkt_string = (
+                f"POINT ({random.uniform(bounds[0], bounds[1]):.2f} {random.uniform(bounds[2], bounds[3]):.2f})"
+            )
             points.append(wkt_string)
         return points
 
@@ -486,7 +474,9 @@ def generate_wkt_by_type(wkt_type: str, bounds: tuple = (0, 100, 0, 100), count:
                 else:  # POLYGON
                     x, y = random.uniform(bounds[0], bounds[1] - 20), random.uniform(bounds[2], bounds[3] - 20)
                     size = random.uniform(5, 20)
-                    geoms.append(f"POLYGON(({x:.2f} {y:.2f}, {x + size:.2f} {y:.2f}, {x + size:.2f} {y + size:.2f}, {x:.2f} {y + size:.2f}, {x:.2f} {y:.2f}))")
+                    geoms.append(
+                        f"POLYGON(({x:.2f} {y:.2f}, {x + size:.2f} {y:.2f}, {x + size:.2f} {y + size:.2f}, {x:.2f} {y + size:.2f}, {x:.2f} {y:.2f}))"
+                    )
 
             wkt_string = f"GEOMETRYCOLLECTION({', '.join(geoms)})"
             collections.append(wkt_string)
@@ -610,7 +600,7 @@ def generate_spatial_query_data_for_function(spatial_func, base_data, geo_field_
                     all_coords.append(((min_x + max_x) / 2, (min_y + max_y) / 2))
 
         if all_coords and len(all_coords) >= 5:
-            target_coords = all_coords[:min(10, len(all_coords))]
+            target_coords = all_coords[: min(10, len(all_coords))]
             center_x = sum(coord[0] for coord in target_coords) / len(target_coords)
             center_y = sum(coord[1] for coord in target_coords) / len(target_coords)
             size = 40
@@ -628,12 +618,14 @@ def generate_spatial_query_data_for_function(spatial_func, base_data, geo_field_
                     points.append((x, y))
 
         if len(points) >= 3:
-            target_points = points[:min(10, len(points))]
+            target_points = points[: min(10, len(points))]
             min_x = min(p[0] for p in target_points) - 5
             max_x = max(p[0] for p in target_points) + 5
             min_y = min(p[1] for p in target_points) - 5
             max_y = max(p[1] for p in target_points) + 5
-            query_geom = f"POLYGON (({min_x} {min_y}, {max_x} {min_y}, {max_x} {max_y}, {min_x} {max_y}, {min_x} {min_y}))"
+            query_geom = (
+                f"POLYGON (({min_x} {min_y}, {max_x} {min_y}, {max_x} {max_y}, {min_x} {max_y}, {min_x} {min_y}))"
+            )
         else:
             query_geom = "POLYGON ((25 25, 75 25, 75 75, 25 75, 25 25))"
 
@@ -723,8 +715,8 @@ def generate_gt(spatial_func, base_data, query_geom, geo_field_name="geo", pk_fi
         expected_ids: List of primary key values that should match the spatial function
     """
     try:
-        from shapely import wkt
         import shapely
+        from shapely import wkt
     except ImportError:
         logger.warning("shapely not installed, returning empty expected_ids")
         return []


### PR DESCRIPTION
## What

Switch Python test-side Jieba usage from the Python `jieba` package to `rjieba`, the Python binding for `jieba-rs`.

## Changes

- Replace Python test requirements from `jieba==0.42.1` to `rjieba==0.1.11`
- Update Python client and REST test helpers to call `rjieba.cut`, `rjieba.cut_for_search`, and `rjieba.cut_all`
- Update analyzer expected-token helper to use `rjieba` for supported mode/hmm cases
- Keep custom-dictionary validation focused on analyzer output because `rjieba` does not expose dynamic dictionary APIs like Python `jieba.add_word` or `set_dictionary`

## Test

- `git diff --check`
- `python3 -m py_compile tests/python_client/common/common_func.py tests/python_client/common/phrase_match_generator.py tests/restful_client_v2/utils/utils.py tests/python_client/milvus_client/test_milvus_client_analyzer.py`
- `rjieba` API smoke test
- Against `struct-hybrid-master-d44e5bc` at `10.100.36.224:19530`:
  - `TestMilvusClientAnalyzer::test_jieba_custom_analyzer`: 6 passed
  - `TestMilvusClientAnalyzer::test_analyzer`: 3 passed