### PR TITLE
enhance: route reopened bm25 stats in delegator (#48808)

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -4873,6 +4873,9 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
             index_has_raw_data_[field_id]) {
             continue;
         }
+        if (schema_->is_function_output(field_id)) {
+            continue;
+        }
         const auto& field_meta = schema_->operator[](field_id);
         fill_empty_field(field_meta);
         EnsureArrayOffsetsForStructField(field_meta, num_rows_.value_or(0));

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -211,6 +211,46 @@ TEST(test_chunk_segment, TestSearchOnSealed) {
     }
 }
 
+TEST(test_chunk_segment, ReopenSkipsFunctionOutputFieldWithoutData) {
+    auto old_schema = std::make_shared<Schema>();
+    old_schema->set_schema_version(1);
+    auto pk = old_schema->AddDebugField("pk", DataType::INT64);
+    old_schema->set_primary_field_id(pk);
+
+    auto segment = segcore::CreateSealedSegment(old_schema);
+
+    constexpr int64_t row_count = 5;
+    std::vector<int64_t> pk_values(row_count);
+    std::iota(pk_values.begin(), pk_values.end(), 0);
+
+    auto field_data =
+        std::make_shared<FieldData<int64_t>>(DataType::INT64, false);
+    field_data->FillFieldData(pk_values.data(), row_count);
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        kCollectionID, kPartitionID, kSegmentID, pk.get(), {field_data}, cm);
+    segment->LoadFieldData(load_info);
+
+    auto new_schema = std::make_shared<Schema>();
+    new_schema->set_schema_version(2);
+    new_schema->AddField(
+        FieldName("pk"), pk, DataType::INT64, false, std::nullopt);
+    new_schema->set_primary_field_id(pk);
+    auto sparse = FieldId(pk.get() + 1);
+    new_schema->AddField(FieldName("sparse_out"),
+                         sparse,
+                         DataType::VECTOR_SPARSE_U32_F32,
+                         0,
+                         std::nullopt,
+                         false);
+    new_schema->add_function_output_field_id(sparse);
+
+    segment->Reopen(new_schema);
+    EXPECT_FALSE(segment->FieldAccessible(sparse));
+}
+
 TEST(test_chunk_segment, MissingStructArrayOffsetsReturnsEmptyForOldRows) {
     auto old_schema = std::make_shared<Schema>();
     old_schema->set_schema_version(1);

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -578,6 +578,14 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
         if (field_id_to_offset.count(field_id) > 0) {
             continue;
         }
+        if (schema_->is_function_output(field_id)) {
+            LOG_INFO(
+                "schema newer than insert data found for segment {}, skip "
+                "bulk fill for function output field {}",
+                id_,
+                field_id.get());
+            continue;
+        }
         LOG_INFO(
             "schema newer than insert data found for segment {}, attach empty "
             "field data"
@@ -606,8 +614,12 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
         if (field_id.get() < START_USER_FIELDID) {
             continue;
         }
-        AssertInfo(field_id_to_offset.count(field_id),
-                   fmt::format("can't find field {}", field_id.get()));
+        if (field_id_to_offset.count(field_id) == 0) {
+            AssertInfo(schema_->is_function_output(field_id),
+                       "field {} missing from insert without bulk fill",
+                       field_id.get());
+            continue;
+        }
         auto data_offset = field_id_to_offset[field_id];
         if (field_meta.is_nullable()) {
             insert_record_.get_valid_data(field_id)->set_data_raw(
@@ -2194,6 +2206,9 @@ SegmentGrowingImpl::Reopen(SchemaPtr sch) {
         auto absent_fields = sch->AbsentFields(*schema_);
 
         for (const auto& field_meta : *absent_fields) {
+            if (sch->is_function_output(field_meta.get_id())) {
+                continue;
+            }
             fill_empty_field(field_meta);
         }
 
@@ -2201,6 +2216,9 @@ SegmentGrowingImpl::Reopen(SchemaPtr sch) {
 
         auto row_count = insert_record_.row_count();
         for (const auto& field_meta : *absent_fields) {
+            if (sch->is_function_output(field_meta.get_id())) {
+                continue;
+            }
             EnsureArrayOffsetsForStructField(field_meta, row_count);
         }
     }
@@ -2282,6 +2300,9 @@ SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
 
     for (const auto& [field_id, field_meta] : schema_->get_fields()) {
         if (field_id.get() < START_USER_FIELDID) {
+            continue;
+        }
+        if (schema_->is_function_output(field_id)) {
             continue;
         }
         // append_data is called according to schema before

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -488,6 +488,9 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
     bool
     HasIndex(FieldId field_id) const override {
+        if (!is_field_exist(field_id)) {
+            return false;
+        }
         auto& field_meta = schema_->operator[](field_id);
         if ((IsVectorDataType(field_meta.get_data_type()) ||
              IsGeometryType(field_meta.get_data_type())) &&
@@ -532,7 +535,13 @@ class SegmentGrowingImpl : public SegmentGrowing {
 
     bool
     HasFieldData(FieldId field_id) const override {
-        return true;
+        if (SystemProperty::Instance().IsSystem(field_id)) {
+            return insert_record_.row_count() > 0;
+        }
+        if (!insert_record_.is_data_exist(field_id)) {
+            return false;
+        }
+        return !insert_record_.get_data_base(field_id)->empty();
     }
 
     bool

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -138,6 +138,39 @@ TEST(Growing, RealCount) {
     ASSERT_EQ(0, segment->get_real_count());
 }
 
+TEST(Growing, InsertSkipsMissingFunctionOutputField) {
+    auto schema = std::make_shared<Schema>();
+    schema->set_schema_version(2);
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk);
+    auto sparse = FieldId(pk.get() + 1);
+    schema->AddField(FieldName("sparse_out"),
+                     sparse,
+                     DataType::VECTOR_SPARSE_U32_F32,
+                     0,
+                     std::nullopt,
+                     false);
+    schema->add_function_output_field_id(sparse);
+
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+
+    auto insert_schema = std::make_shared<Schema>();
+    insert_schema->set_schema_version(1);
+    insert_schema->AddField(
+        FieldName("pk"), pk, DataType::INT64, false, std::nullopt);
+    insert_schema->set_primary_field_id(pk);
+
+    constexpr int64_t row_count = 5;
+    auto dataset = DataGen(insert_schema, row_count);
+    segment->PreInsert(row_count);
+    ASSERT_NO_THROW(segment->Insert(0,
+                                    row_count,
+                                    dataset.row_ids_.data(),
+                                    dataset.timestamps_.data(),
+                                    dataset.raw_));
+    EXPECT_FALSE(segment->FieldAccessible(sparse));
+}
+
 TEST(Growing, MissingStructArrayOffsetsReturnsEmptyForOldRows) {
     auto old_schema = std::make_shared<Schema>();
     old_schema->set_schema_version(1);

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -500,6 +500,11 @@ class SegmentInternalInterface : public SegmentInterface {
     virtual bool
     HasIndex(FieldId field_id) const = 0;
 
+    bool
+    FieldAccessible(FieldId field_id) const {
+        return HasFieldData(field_id) || HasIndex(field_id);
+    }
+
     // JSON indexes (JsonFlatIndex + JSON-cast scalar) live in a separate
     // per-segment container from the scalar/vector/binlog index bitsets, so
     // they are checked via this dedicated API rather than widening HasIndex().

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -715,6 +715,10 @@ SegmentLoadInfo::ComputeDiffDefaultFields(LoadDiff& diff,
             continue;
         }
 
+        if (new_info.schema_->is_function_output(field_id)) {
+            continue;
+        }
+
         diff.fields_to_fill_default.push_back(field_id);
     }
 }

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -892,6 +892,41 @@ TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFieldsBasic) {
     EXPECT_EQ(actual_fields, expected_fields);
 }
 
+TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFieldsSkipsFunctionOutput) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField("pk", DataType::INT64);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+    schema->AddDebugField(
+        "sparse_out", DataType::VECTOR_SPARSE_U32_F32, 0, std::nullopt);
+    schema->set_primary_field_id(FieldId(100));
+    const FieldId sparse_field_id = FieldId(102);
+    schema->add_function_output_field_id(sparse_field_id);
+
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+
+    auto* binlog = proto.add_binlog_paths();
+    binlog->set_fieldid(100);
+    auto* log = binlog->add_binlogs();
+    log->set_log_path("/path/to/pk_binlog");
+    log->set_entries_num(1000);
+
+    SegmentLoadInfo empty_info(milvus::proto::segcore::SegmentLoadInfo(),
+                               schema);
+    SegmentLoadInfo new_info(proto, schema);
+    auto diff = empty_info.ComputeDiff(new_info);
+
+    for (const auto& field_id : diff.fields_to_fill_default) {
+        EXPECT_NE(field_id, sparse_field_id);
+    }
+    EXPECT_NE(std::find(diff.fields_to_fill_default.begin(),
+                        diff.fields_to_fill_default.end(),
+                        FieldId(101)),
+              diff.fields_to_fill_default.end());
+}
+
 TEST_F(SegmentLoadInfoTest, ComputeDiffDefaultFieldsSkipAlreadyFilled) {
     // Test that fields already filled with default values are skipped
     // on subsequent ComputeDiff calls

--- a/internal/core/src/segcore/plan_c.cpp
+++ b/internal/core/src/segcore/plan_c.cpp
@@ -52,7 +52,7 @@ CreateSearchPlanByExpr(CCollection c_col,
             auto field_name =
                 (*schema)[milvus::FieldId(field_id)].get_name().get();
             std::string err_msg =
-                "field " + field_name +
+                "field index of the field: " + field_name +
                 " is not loaded, please reload the collection";
             status.error_msg = strdup(err_msg.c_str());
             *res_plan = nullptr;

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -390,19 +390,35 @@ AsyncSearch(CTraceContext c_trace,
 
             auto span = milvus::tracer::StartSpan("SegCoreSearch", &trace_ctx);
             milvus::tracer::SetRootSpan(span);
+            AssertInfo(phg_ptr != nullptr && !phg_ptr->empty(),
+                       "search requires non-empty placeholder group");
+            const int64_t num_queries = milvus::query::GetNumOfQueries(phg_ptr);
+            auto target_vector_field_id =
+                plan->plan_node_->search_info_.field_id_;
 
             milvus::OpContext op_ctx(cancel_token);
             segment->LazyCheckSchema(plan->schema_, &op_ctx);
-
-            auto search_result = segment->Search(plan,
-                                                 phg_ptr,
-                                                 timestamp,
-                                                 cancel_token,
-                                                 consistency_level,
-                                                 collection_ttl,
-                                                 entity_ttl_physical_time_us,
-                                                 filter_only,
-                                                 enable_expr_cache);
+            auto internal_segment =
+                static_cast<milvus::segcore::SegmentInternalInterface*>(
+                    segment);
+            std::unique_ptr<milvus::SearchResult> search_result;
+            if (!filter_only &&
+                !internal_segment->FieldAccessible(target_vector_field_id)) {
+                search_result = std::make_unique<milvus::SearchResult>();
+                search_result->total_nq_ = num_queries;
+                search_result->unity_topK_ = 0;
+                search_result->total_data_cnt_ = 0;
+            } else {
+                search_result = segment->Search(plan,
+                                                phg_ptr,
+                                                timestamp,
+                                                cancel_token,
+                                                consistency_level,
+                                                collection_ttl,
+                                                entity_ttl_physical_time_us,
+                                                filter_only,
+                                                enable_expr_cache);
+            }
             if (!filter_only &&
                 !milvus::PositivelyRelated(
                     plan->plan_node_->search_info_.metric_type_)) {

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -119,6 +119,10 @@ type ShardDelegator interface {
 
 var _ ShardDelegator = (*shardDelegator)(nil)
 
+type idfOracleHolder struct {
+	oracle IDFOracle
+}
+
 // shardDelegator maintains the shard distribution and streaming part of the data.
 type shardDelegator struct {
 	// shard information attributes
@@ -129,12 +133,15 @@ type shardDelegator struct {
 	// collection schema
 	collection *segments.Collection
 
+	collectionManager segments.CollectionManager
+
 	workerManager cluster.Manager
 
 	lifetime lifetime.Lifetime[lifetime.State]
 
 	distribution *distribution
-	idfOracle    IDFOracle
+	// idfOracle is published once after full initialization and is never replaced.
+	idfOracle atomic.Pointer[idfOracleHolder]
 
 	segmentManager segments.SegmentManager
 	// stream delete buffer
@@ -156,14 +163,7 @@ type shardDelegator struct {
 	growingSegmentLock sync.RWMutex
 	partitionStatsMut  sync.RWMutex
 
-	// outputFieldId -> functionRunner map for search function field
-	functionRunners map[UniqueID]function.FunctionRunner
-
-	// outputFieldId -> function type map
-	functionFieldType map[UniqueID]schemapb.FunctionType
-
-	// analyzerFieldID -> analyzerRunner map for run analyzer.
-	analyzerRunners map[UniqueID]function.Analyzer
+	functionState *functionRuntimeState
 
 	// current forward policy
 	l0ForwardPolicy string
@@ -199,6 +199,18 @@ func (sd *shardDelegator) getLogger(ctx context.Context) *log.MLogger {
 	)
 }
 
+func (sd *shardDelegator) getIDFOracle() IDFOracle {
+	holder := sd.idfOracle.Load()
+	if holder == nil {
+		return nil
+	}
+	return holder.oracle
+}
+
+func (sd *shardDelegator) publishIDFOracle(idfOracle IDFOracle) {
+	sd.idfOracle.Store(&idfOracleHolder{oracle: idfOracle})
+}
+
 func (sd *shardDelegator) NotStopped(state lifetime.State) error {
 	if state != lifetime.Stopped {
 		return nil
@@ -220,6 +232,37 @@ func (sd *shardDelegator) Serviceable() bool {
 
 func (sd *shardDelegator) Stopped() bool {
 	return sd.NotStopped(sd.lifetime.GetState()) != nil
+}
+
+func (sd *shardDelegator) prepareSearchFunction(req *internalpb.SearchRequest) (float64, bool, error) {
+	var avgdl float64
+	isBM25 := false
+	err := sd.functionState.withSearchFunction(req.GetFieldId(), func(functionType schemapb.FunctionType, functionRunner function.FunctionRunner, ok bool) error {
+		switch functionType {
+		case schemapb.FunctionType_BM25:
+			isBM25 = true
+			if req.GetMetricType() != metric.BM25 && req.GetMetricType() != metric.EMPTY {
+				return merr.WrapErrParameterInvalid("BM25", req.GetMetricType(), "must use BM25 metric type when searching against BM25 Function output field")
+			}
+			if !ok {
+				return fmt.Errorf("functionRunner not found for field: %d", req.GetFieldId())
+			}
+			var buildErr error
+			avgdl, buildErr = sd.buildBM25IDFWithRunner(req, functionRunner)
+			return buildErr
+		case schemapb.FunctionType_MinHash:
+			if req.GetMetricType() != metric.MHJACCARD && req.GetMetricType() != metric.EMPTY {
+				return merr.WrapErrParameterInvalid("MHJACCARD", req.GetMetricType(), "must use MHJACCARD metric type when searching against MinHash Function output field")
+			}
+			if !ok {
+				return fmt.Errorf("functionRunner not found for field: %d", req.GetFieldId())
+			}
+			return sd.parseMinHashWithRunner(req, functionRunner)
+		default:
+			return nil
+		}
+	})
+	return avgdl, isBM25 && avgdl <= 0, err
 }
 
 // Start sets delegator to working state.
@@ -352,28 +395,13 @@ func (sd *shardDelegator) search(ctx context.Context, req *querypb.SearchRequest
 		)
 	}
 
-	if sd.functionFieldType[req.GetReq().GetFieldId()] == schemapb.FunctionType_BM25 {
-		if req.GetReq().GetMetricType() != metric.BM25 && req.GetReq().GetMetricType() != metric.EMPTY {
-			return nil, merr.WrapErrParameterInvalid("BM25", req.GetReq().GetMetricType(), "must use BM25 metric type when searching against BM25 Function output field")
-		}
-		// build idf for bm25 search
-		avgdl, err := sd.buildBM25IDF(req.GetReq())
-		if err != nil {
-			return nil, err
-		}
-
-		if avgdl <= 0 {
-			log.Warn("search bm25 from empty data, skip search", zap.String("channel", sd.vchannelName), zap.Float64("avgdl", avgdl))
-			return []*internalpb.SearchResults{}, nil
-		}
-	} else if sd.functionFieldType[req.GetReq().GetFieldId()] == schemapb.FunctionType_MinHash {
-		if req.GetReq().GetMetricType() != metric.MHJACCARD && req.GetReq().GetMetricType() != metric.EMPTY {
-			return nil, merr.WrapErrParameterInvalid("MHJACCARD", req.GetReq().GetMetricType(), "must use MHJACCARD metric type when searching against MinHash Function output field")
-		}
-		err := sd.parseMinHash(req.GetReq())
-		if err != nil {
-			return nil, err
-		}
+	avgdl, skipSearch, err := sd.prepareSearchFunction(req.GetReq())
+	if err != nil {
+		return nil, err
+	}
+	if skipSearch {
+		log.Warn("search bm25 from empty data, skip search", zap.String("channel", sd.vchannelName), zap.Float64("avgdl", avgdl))
+		return []*internalpb.SearchResults{}, nil
 	}
 
 	// get final sealedNum after possible segment prune
@@ -406,7 +434,7 @@ func (sd *shardDelegator) search(ctx context.Context, req *querypb.SearchRequest
 	}
 
 	const isSecondStageSearch = false
-	req, err := optimizers.OptimizeSearchParams(ctx, req, sd.queryHook, effectiveSegmentNum, isSecondStageSearch, sd.getVectorFieldDim)
+	req, err = optimizers.OptimizeSearchParams(ctx, req, sd.queryHook, effectiveSegmentNum, isSecondStageSearch, sd.getVectorFieldDim)
 	if err != nil {
 		log.Warn("failed to optimize search params", zap.Error(err))
 		return nil, err
@@ -1194,8 +1222,21 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 
 	log.Info("delegator received update schema event")
 
+	newFunctionState, err := buildFunctionRuntimeState(schema)
+	if err != nil {
+		return err
+	}
+
 	sd.schemaChangeMutex.Lock()
 	defer sd.schemaChangeMutex.Unlock()
+
+	oldSet := newBM25FunctionSet(sd.collection.Schema())
+	newSet := newBM25FunctionSet(schema)
+	idfOracle := sd.getIDFOracle()
+	if idfOracle != nil && !newSet.IsSupersetOf(oldSet) {
+		newFunctionState.Close()
+		return merr.WrapErrServiceInternal("unsupported non-additive BM25 function schema change on loaded collection")
+	}
 
 	// set updated schema version as load barrier
 	// prevent concurrent load segment with old schema
@@ -1227,6 +1268,7 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 			return nodeReq
 		})
 	if err != nil {
+		newFunctionState.Close()
 		return err
 	}
 
@@ -1235,8 +1277,39 @@ func (sd *shardDelegator) UpdateSchema(ctx context.Context, schema *schemapb.Col
 		status, err := worker.UpdateSchema(ctx, req)
 		return (*StatusWrapper)(status), err
 	}, "UpdateSchema", log)
+	if err != nil {
+		newFunctionState.Close()
+		return err
+	}
 
-	return err
+	if err := sd.collectionManager.UpdateSchema(sd.collectionID, schema, schVersion); err != nil {
+		newFunctionState.Close()
+		return err
+	}
+	if idfOracle == nil && len(newSet) > 0 {
+		// StreamingNode schema changes flush and fence old growings before UpdateSchema and new-schema inserts.
+		// Old growings cannot receive stats for newly added BM25 fields; ProcessInsert registers only new growings.
+		idfOracle = NewIDFOracle(sd.vchannelName, schema.GetFunctions())
+		idfOracle.Start()
+		sd.distribution.SetIDFOracle(idfOracle)
+		if current := sd.distribution.current.Load(); current != nil {
+			idfOracle.SetNext(current)
+		}
+		sd.publishIDFOracle(idfOracle)
+	} else if idfOracle != nil && !newSet.Equal(oldSet) {
+		if err := idfOracle.SyncFunctions(schema.GetFunctions()); err != nil {
+			newFunctionState.Close()
+			return err
+		}
+	}
+	sd.functionState.swap(newFunctionState).Close()
+	log.Info("delegator finished update schema event",
+		zap.Uint64("schemaVersion", schVersion),
+		zap.Int("sealedNum", len(sealed)),
+		zap.Int("growingNum", len(growing)),
+		zap.Int("bm25FunctionNum", len(newSet)),
+	)
+	return nil
 }
 
 type StatusWrapper commonpb.Status
@@ -1266,15 +1339,11 @@ func (sd *shardDelegator) Close() {
 	}
 
 	// clean idf oracle
-	if sd.idfOracle != nil {
-		sd.idfOracle.Close()
+	if idfOracle := sd.getIDFOracle(); idfOracle != nil {
+		idfOracle.Close()
 	}
 
-	if sd.functionRunners != nil {
-		for _, function := range sd.functionRunners {
-			function.Close()
-		}
-	}
+	sd.functionState.Close()
 
 	// clean up l0 segment in delete buffer
 	start := time.Now()
@@ -1370,15 +1439,16 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 	})
 
 	sd := &shardDelegator{
-		collectionID:   collectionID,
-		replicaID:      replicaID,
-		vchannelName:   channel,
-		version:        version,
-		collection:     collection,
-		segmentManager: manager.Segment,
-		workerManager:  workerManager,
-		lifetime:       lifetime.NewLifetime(lifetime.Initializing),
-		distribution:   NewDistribution(channel, queryView),
+		collectionID:      collectionID,
+		replicaID:         replicaID,
+		vchannelName:      channel,
+		version:           version,
+		collection:        collection,
+		collectionManager: manager.Collection,
+		segmentManager:    manager.Segment,
+		workerManager:     workerManager,
+		lifetime:          lifetime.NewLifetime(lifetime.Initializing),
+		distribution:      NewDistribution(channel, queryView),
 		deleteBuffer: deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](startTs, sizePerBlock,
 			[]string{paramtable.GetStringNodeID(), channel}),
 		latestTsafe:                atomic.NewUint64(startTs),
@@ -1387,9 +1457,6 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		chunkManager:               chunkManager,
 		partitionStats:             make(map[UniqueID]*storage.PartitionStatsSnapshot),
 		excludedSegments:           excludedSegments,
-		functionRunners:            make(map[int64]function.FunctionRunner),
-		analyzerRunners:            make(map[UniqueID]function.Analyzer),
-		functionFieldType:          make(map[int64]schemapb.FunctionType),
 		l0ForwardPolicy:            policy,
 		postLoadSem:                postLoadSem,
 		postLoadConfigHandler:      postLoadConfigHandler,
@@ -1397,45 +1464,21 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 	}
 
-	hasBM25Field := false
-	for _, tf := range collection.Schema().GetFunctions() {
-		if tf.GetType() == schemapb.FunctionType_BM25 {
-			functionRunner, err := function.NewFunctionRunner(collection.Schema(), tf)
-			if err != nil {
-				return nil, err
-			}
-			sd.functionRunners[tf.OutputFieldIds[0]] = functionRunner
-			// bm25 input field could use same runner between function and analyzer.
-			sd.analyzerRunners[tf.InputFieldIds[0]] = functionRunner.(function.Analyzer)
-			if tf.GetType() == schemapb.FunctionType_BM25 {
-				sd.functionFieldType[tf.OutputFieldIds[0]] = schemapb.FunctionType_BM25
-			}
-			hasBM25Field = true
-		} else if tf.GetType() == schemapb.FunctionType_MinHash {
-			functionRunner, err := function.NewFunctionRunner(collection.Schema(), tf)
-			if err != nil {
-				return nil, err
-			}
-			sd.functionRunners[tf.OutputFieldIds[0]] = functionRunner
-			sd.functionFieldType[tf.OutputFieldIds[0]] = schemapb.FunctionType_MinHash
-		}
+	functionState, err := buildFunctionRuntimeState(collection.Schema())
+	if err != nil {
+		return nil, err
 	}
+	sd.functionState = functionState
 
-	for _, field := range collection.Schema().GetFields() {
-		helper := typeutil.CreateFieldSchemaHelper(field)
-		if helper.EnableAnalyzer() && sd.analyzerRunners[field.GetFieldID()] == nil {
-			analyzerRunner, err := function.NewAnalyzerRunner(field)
-			if err != nil {
-				return nil, err
-			}
-			sd.analyzerRunners[field.GetFieldID()] = analyzerRunner
-		}
-	}
+	hasBM25Field := lo.ContainsBy(collection.Schema().GetFunctions(), func(tf *schemapb.FunctionSchema) bool {
+		return tf.GetType() == schemapb.FunctionType_BM25
+	})
 
 	if hasBM25Field {
-		sd.idfOracle = NewIDFOracle(sd.vchannelName, collection.Schema().GetFunctions())
-		sd.distribution.SetIDFOracle(sd.idfOracle)
-		sd.idfOracle.Start()
+		idfOracle := NewIDFOracle(sd.vchannelName, collection.Schema().GetFunctions())
+		idfOracle.Start()
+		sd.distribution.SetIDFOracle(idfOracle)
+		sd.publishIDFOracle(idfOracle)
 	}
 
 	// initialize GrowingFlushManager for TEXT collections
@@ -1479,23 +1522,21 @@ func (sd *shardDelegator) hasTextFields() bool {
 }
 
 func (sd *shardDelegator) RunAnalyzer(ctx context.Context, req *querypb.RunAnalyzerRequest) ([]*milvuspb.AnalyzerResult, error) {
-	analyzer, ok := sd.analyzerRunners[req.GetFieldId()]
-	if !ok {
-		return nil, fmt.Errorf("analyzer runner for field %d not exist, now only support run analyzer by field if field was bm25/minhash input field", req.GetFieldId())
-	}
-
 	var result [][]*milvuspb.AnalyzerToken
+	var analyzeErr error
 	texts := lo.Map(req.GetPlaceholder(), func(bytes []byte, _ int) string {
 		return string(bytes)
 	})
 
-	var err error
-	if len(analyzer.GetInputFields()) == 1 {
-		result, err = analyzer.BatchAnalyze(req.WithDetail, req.WithHash, texts)
-	} else {
+	ok, err := sd.functionState.withAnalyzerRunner(req.GetFieldId(), func(analyzer function.Analyzer) error {
+		if len(analyzer.GetInputFields()) == 1 {
+			result, analyzeErr = analyzer.BatchAnalyze(req.WithDetail, req.WithHash, texts)
+			return analyzeErr
+		}
+
 		analyzerNames := req.GetAnalyzerNames()
 		if len(analyzerNames) == 0 {
-			return nil, merr.WrapErrAsInputError(fmt.Errorf("analyzer names must be set for multi analyzer"))
+			return merr.WrapErrAsInputError(fmt.Errorf("analyzer names must be set for multi analyzer"))
 		}
 
 		if len(analyzerNames) == 1 && len(texts) > 1 {
@@ -1504,11 +1545,14 @@ func (sd *shardDelegator) RunAnalyzer(ctx context.Context, req *querypb.RunAnaly
 				analyzerNames[i] = req.AnalyzerNames[0]
 			}
 		}
-		result, err = analyzer.BatchAnalyze(req.WithDetail, req.WithHash, texts, analyzerNames)
-	}
-
+		result, analyzeErr = analyzer.BatchAnalyze(req.WithDetail, req.WithHash, texts, analyzerNames)
+		return analyzeErr
+	})
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("analyzer runner for field %d not exist, now only support run analyzer by field if field was bm25/minhash input field", req.GetFieldId())
 	}
 
 	return lo.Map(result, func(tokens []*milvuspb.AnalyzerToken, _ int) *milvuspb.AnalyzerResult {

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -37,6 +37,8 @@ import (
 	"github.com/milvus-io/milvus/internal/querynodev2/pkoracle"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/storagev2/packed"
+	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/internal/util/grpcclient"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
@@ -174,8 +176,8 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 
 			if !sd.distribution.GrowingSegmentExists(segmentID) {
 				// register created growing segment after insert, avoid to add empty growing to delegator
-				if sd.idfOracle != nil {
-					sd.idfOracle.RegisterGrowing(segmentID, insertData.BM25Stats)
+				if idfOracle := sd.getIDFOracle(); idfOracle != nil {
+					idfOracle.RegisterGrowing(segmentID, insertData.BM25Stats)
 				}
 				sd.segmentManager.Put(context.Background(), segments.SegmentTypeGrowing, growing)
 				sd.addGrowing(SegmentEntry{
@@ -189,8 +191,8 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 			}
 
 			sd.growingSegmentLock.Unlock()
-		} else if sd.idfOracle != nil {
-			sd.idfOracle.UpdateGrowing(growing.ID(), insertData.BM25Stats)
+		} else if idfOracle := sd.getIDFOracle(); idfOracle != nil {
+			idfOracle.UpdateGrowing(growing.ID(), insertData.BM25Stats)
 		}
 		log.Info("insert into growing segment",
 			zap.Int64("collectionID", growing.Collection()),
@@ -495,9 +497,9 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 		}
 	}
 
-	for _, segment := range loaded {
-		if sd.idfOracle != nil {
-			sd.idfOracle.RegisterGrowing(segment.ID(), segment.GetBM25Stats())
+	if idfOracle := sd.getIDFOracle(); idfOracle != nil {
+		for _, segment := range loaded {
+			idfOracle.RegisterGrowing(segment.ID(), segment.GetBM25Stats())
 		}
 	}
 	sd.addGrowing(lo.Map(loaded, func(segment segments.Segment, _ int) SegmentEntry {
@@ -516,7 +518,8 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 // load bm25 stats for sealed segments.
 // idf oracle owns the full lifecycle: download, disk write, register, cleanup.
 func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.SegmentLoadInfo, req *querypb.LoadSegmentsRequest) error {
-	if sd.idfOracle == nil {
+	idfOracle := sd.getIDFOracle()
+	if idfOracle == nil {
 		return nil
 	}
 
@@ -527,7 +530,7 @@ func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.Se
 	for _, info := range infos {
 		info := info
 		futures = append(futures, pool.Submit(func() (any, error) {
-			if err := sd.idfOracle.LoadSealed(ctx, info.GetSegmentID(), info, cm); err != nil {
+			if err := idfOracle.LoadSealed(ctx, info.GetSegmentID(), info, cm); err != nil {
 				log.Warn("failed to load bm25 stats for segment",
 					zap.Int64("collectionID", req.GetCollectionID()),
 					zap.Int64("segmentID", info.GetSegmentID()),
@@ -543,6 +546,91 @@ func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.Se
 		log.Warn("failed to load bm25 stats", zap.Error(err))
 		return err
 	}
+	return nil
+}
+
+func (sd *shardDelegator) handleReopenPostLoad(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+	log := sd.getLogger(ctx).With(
+		zap.Int64s("segments", lo.Map(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) int64 { return info.GetSegmentID() })),
+		zap.String("loadScope", req.GetLoadScope().String()),
+	)
+
+	infosWithBM25Stats := make([]*querypb.SegmentLoadInfo, 0, len(req.GetInfos()))
+	for _, info := range req.GetInfos() {
+		bm25Paths, err := packed.NewStatsResolverFromLoadInfo(info).BM25StatsPaths()
+		if err != nil {
+			log.Warn("resolve reopened bm25 stats failed", zap.Int64("segmentID", info.GetSegmentID()), zap.Error(err))
+			return err
+		}
+		if len(bm25Paths) > 0 {
+			infosWithBM25Stats = append(infosWithBM25Stats, info)
+		}
+	}
+
+	if len(infosWithBM25Stats) == 0 {
+		return nil
+	}
+	return sd.loadBM25StatsForReopen(ctx, infosWithBM25Stats, req)
+}
+
+func (sd *shardDelegator) loadBM25StatsForReopen(ctx context.Context, infos []*querypb.SegmentLoadInfo, req *querypb.LoadSegmentsRequest) error {
+	idfOracle := sd.getIDFOracle()
+	if idfOracle == nil {
+		return merr.WrapErrServiceInternal("reopen contains BM25 stats before delegator BM25 oracle is initialized")
+	}
+
+	pool := segments.GetBM25LoadPool()
+	cm := sd.loader.GetChunkManager()
+	futures := make([]*conc.Future[any], 0, len(infos))
+	for _, info := range infos {
+		info := info
+		futures = append(futures, pool.Submit(func() (any, error) {
+			activateIfReadable := sd.distribution.IsReadableSealedSegment(info.GetSegmentID())
+			if err := idfOracle.LoadSealedForReopen(ctx, info.GetSegmentID(), info, cm, activateIfReadable); err != nil {
+				log.Warn("failed to load reopened bm25 stats for segment",
+					zap.Int64("collectionID", req.GetCollectionID()),
+					zap.Int64("segmentID", info.GetSegmentID()),
+					zap.Bool("activateIfReadable", activateIfReadable),
+					zap.Error(err))
+				return nil, err
+			}
+			return nil, nil
+		}))
+	}
+
+	if err := conc.BlockOnAll(futures...); err != nil {
+		log.Warn("failed to load reopened bm25 stats", zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+// syncCollectionIndexMeta refreshes the delegator node's CCollection IndexMeta after a
+// forwarded worker load. Worker LoadSegments already updates IndexMeta on the target
+// worker, but the delegator (which executes growing search locally) must stay in sync.
+func (sd *shardDelegator) syncCollectionIndexMeta(ctx context.Context, req *querypb.LoadSegmentsRequest) error {
+	if len(req.GetIndexInfoList()) == 0 {
+		return nil
+	}
+
+	schema := req.GetSchema()
+	if schema == nil {
+		schema = sd.collection.Schema()
+	}
+
+	loadMeta := req.GetLoadMeta()
+	if loadMeta == nil {
+		loadMeta = &querypb.LoadMetaInfo{
+			CollectionID:  req.GetCollectionID(),
+			SchemaVersion: sd.collection.SchemaVersion(),
+		}
+	}
+
+	meta := segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), schema)
+	if err := sd.collectionManager.PutOrRef(req.GetCollectionID(), schema, meta, loadMeta); err != nil {
+		return err
+	}
+	sd.collectionManager.Unref(req.GetCollectionID(), 1)
 	return nil
 }
 
@@ -623,9 +711,17 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 	}
 	log.Debug("work loads segments done")
 
+	if err := sd.syncCollectionIndexMeta(ctx, req); err != nil {
+		log.Warn("failed to sync collection index meta on delegator", zap.Error(err))
+		return err
+	}
+
 	// load index segment need no stream delete and distribution change
-	if req.GetLoadScope() == querypb.LoadScope_Index || req.GetLoadScope() == querypb.LoadScope_Reopen {
+	if req.GetLoadScope() == querypb.LoadScope_Index {
 		return nil
+	}
+	if req.GetLoadScope() == querypb.LoadScope_Reopen {
+		return sd.handleReopenPostLoad(ctx, req)
 	}
 
 	return sd.withPostLoadLimit(ctx, func() error {
@@ -1236,6 +1332,27 @@ func (sd *shardDelegator) TryCleanExcludedSegments(ts uint64) {
 }
 
 func (sd *shardDelegator) buildBM25IDF(req *internalpb.SearchRequest) (float64, error) {
+	var avgdl float64
+	ok, err := sd.functionState.withFunctionRunner(req.GetFieldId(), func(functionRunner function.FunctionRunner) error {
+		var runErr error
+		avgdl, runErr = sd.buildBM25IDFWithRunner(req, functionRunner)
+		return runErr
+	})
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return 0, fmt.Errorf("functionRunner not found for field: %d", req.GetFieldId())
+	}
+	return avgdl, nil
+}
+
+func (sd *shardDelegator) buildBM25IDFWithRunner(req *internalpb.SearchRequest, functionRunner function.FunctionRunner) (float64, error) {
+	idfOracle := sd.getIDFOracle()
+	if idfOracle == nil {
+		return 0, merr.WrapErrServiceInternal("bm25 oracle is not initialized")
+	}
+
 	pb := &commonpb.PlaceholderGroup{}
 	if err := proto.Unmarshal(req.GetPlaceholderGroup(), pb); err != nil {
 		return 0, merr.WrapErrServiceInternal("failed to unmarshal BM25 IDF placeholder group", err.Error())
@@ -1252,11 +1369,6 @@ func (sd *shardDelegator) buildBM25IDF(req *internalpb.SearchRequest) (float64, 
 
 	texts := funcutil.GetVarCharFromPlaceholder(holder)
 	datas := []any{texts}
-	functionRunner, ok := sd.functionRunners[req.GetFieldId()]
-	if !ok {
-		return 0, fmt.Errorf("functionRunner not found for field: %d", req.GetFieldId())
-	}
-
 	if len(functionRunner.GetInputFields()) == 2 {
 		analyzerName := "default"
 		if name := req.GetAnalyzerName(); name != "" {
@@ -1282,7 +1394,7 @@ func (sd *shardDelegator) buildBM25IDF(req *internalpb.SearchRequest) (float64, 
 		return 0, errors.New("functionRunner return unknown data")
 	}
 
-	idfSparseVector, avgdl, err := sd.idfOracle.BuildIDF(req.GetFieldId(), tfArray)
+	idfSparseVector, avgdl, err := idfOracle.BuildIDF(req.GetFieldId(), tfArray)
 	if err != nil {
 		return 0, err
 	}
@@ -1305,6 +1417,12 @@ func (sd *shardDelegator) buildBM25IDF(req *internalpb.SearchRequest) (float64, 
 }
 
 func (sd *shardDelegator) parseMinHash(req *internalpb.SearchRequest) error {
+	return sd.functionState.withRequiredFunctionRunner(req.GetFieldId(), func(functionRunner function.FunctionRunner) error {
+		return sd.parseMinHashWithRunner(req, functionRunner)
+	})
+}
+
+func (sd *shardDelegator) parseMinHashWithRunner(req *internalpb.SearchRequest, functionRunner function.FunctionRunner) error {
 	pb := &commonpb.PlaceholderGroup{}
 	if err := proto.Unmarshal(req.GetPlaceholderGroup(), pb); err != nil {
 		return merr.WrapErrServiceInternal("failed to unmarshal MinHash placeholder group", err.Error())
@@ -1321,11 +1439,6 @@ func (sd *shardDelegator) parseMinHash(req *internalpb.SearchRequest) error {
 
 	texts := funcutil.GetVarCharFromPlaceholder(holder)
 	datas := []any{texts}
-	functionRunner, ok := sd.functionRunners[req.GetFieldId()]
-	if !ok {
-		return fmt.Errorf("functionRunner not found for field: %d", req.GetFieldId())
-	}
-
 	output, err := functionRunner.BatchRun(datas...)
 	if err != nil {
 		return err
@@ -1372,25 +1485,25 @@ func (sd *shardDelegator) GetHighlight(ctx context.Context, req *querypb.GetHigh
 		if len(task.GetTexts()) != int(task.GetSearchTextNum()+task.GetCorpusTextNum())+len(task.GetQueries()) {
 			return nil, errors.Errorf("package highlight texts error, num of texts not equal the expected num %d:%d", len(task.GetTexts()), int(task.GetSearchTextNum()+task.GetCorpusTextNum())+len(task.GetQueries()))
 		}
-		analyzer, ok := sd.analyzerRunners[task.GetFieldId()]
-		if !ok {
-			return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, the highlight field not found, %s:%d", task.GetFieldName(), task.GetFieldId())
-		}
 		topks := req.GetTopks()
 		var results [][]*milvuspb.AnalyzerToken
-		var err error
-
-		if len(analyzer.GetInputFields()) == 1 {
-			results, err = analyzer.BatchAnalyze(true, false, task.GetTexts())
-			if err != nil {
-				return nil, err
+		var analyzeErr error
+		ok, err := sd.functionState.withAnalyzerRunner(task.GetFieldId(), func(analyzer function.Analyzer) error {
+			if len(analyzer.GetInputFields()) == 1 {
+				results, analyzeErr = analyzer.BatchAnalyze(true, false, task.GetTexts())
+				return analyzeErr
 			}
-		} else if len(analyzer.GetInputFields()) == 2 {
-			// use analyzer names if analyzer need two input field
-			results, err = analyzer.BatchAnalyze(true, false, task.GetTexts(), task.GetAnalyzerNames())
-			if err != nil {
-				return nil, err
+			if len(analyzer.GetInputFields()) == 2 {
+				results, analyzeErr = analyzer.BatchAnalyze(true, false, task.GetTexts(), task.GetAnalyzerNames())
+				return analyzeErr
 			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, the highlight field not found, %s:%d", task.GetFieldName(), task.GetFieldId())
 		}
 
 		// analyze result of search text

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -105,6 +105,12 @@ type DelegatorDataSuite struct {
 	chunkManager storage.ChunkManager
 }
 
+func (s *DelegatorDataSuite) getIDFOracleForTest() *idfOracle {
+	oracle, ok := s.delegator.getIDFOracle().(*idfOracle)
+	s.Require().True(ok)
+	return oracle
+}
+
 func (s *DelegatorDataSuite) SetupSuite() {
 	paramtable.Init()
 	paramtable.SetNodeID(1)
@@ -644,6 +650,175 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithBm25() {
 	})
 }
 
+func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25Stats() {
+	s.genCollectionWithFunction()
+
+	remotePath := "bm25stats/reopen/segment_100/field_101/0"
+	stats := storage.NewBM25Stats()
+	for i := uint32(1); i < 4; i++ {
+		stats.Append(map[uint32]float32{i: 1})
+	}
+	data, err := stats.Serialize()
+	s.Require().NoError(err)
+
+	cm := mocks.NewChunkManager(s.T())
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(&bytesFileReader{bytes.NewReader(data)}, nil)
+	s.loader.EXPECT().GetChunkManager().Return(cm)
+
+	worker1 := &cluster.MockWorker{}
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil)
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err = s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		LoadScope:    querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{
+			{
+				SegmentID:     100,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+				Bm25Logs:      bm25LogsForField(101, remotePath),
+			},
+		},
+	})
+
+	s.NoError(err)
+	loadedStats := s.getIDFOracleForTest()
+	fieldStats, err := loadedStats.current.GetStats(101)
+	s.NoError(err)
+	s.Equal(int64(0), fieldStats.NumRow())
+	segStats, ok := loadedStats.sealed.Get(100)
+	s.True(ok)
+	s.True(segStats.HasField(101))
+
+	sealed, _ := s.delegator.GetSegmentInfo(false)
+	s.Empty(sealed)
+}
+
+func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsMergesReadableSegment() {
+	s.genCollectionWithFunction()
+	s.delegator.distribution.AddDistributions(SegmentEntry{
+		NodeID:      1,
+		SegmentID:   100,
+		PartitionID: 500,
+		Version:     1,
+		Level:       datapb.SegmentLevel_L1,
+	})
+	s.delegator.distribution.SyncTargetVersion(&querypb.SyncAction{
+		TargetVersion:         1,
+		SealedInTarget:        []int64{100},
+		SealedSegmentRowCount: map[int64]int64{100: 3},
+	}, []int64{500})
+	s.True(s.delegator.distribution.IsReadableSealedSegment(100))
+
+	remotePath := "bm25stats/reopen-readable/segment_100/field_101/0"
+	stats := storage.NewBM25Stats()
+	for i := uint32(1); i < 4; i++ {
+		stats.Append(map[uint32]float32{i: 1})
+	}
+	data, err := stats.Serialize()
+	s.Require().NoError(err)
+
+	cm := mocks.NewChunkManager(s.T())
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(&bytesFileReader{bytes.NewReader(data)}, nil)
+	s.loader.EXPECT().GetChunkManager().Return(cm)
+
+	worker1 := &cluster.MockWorker{}
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil)
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err = s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		LoadScope:    querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{
+			{
+				SegmentID:     100,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+				Bm25Logs:      bm25LogsForField(101, remotePath),
+			},
+		},
+	})
+
+	s.NoError(err)
+	loadedStats := s.getIDFOracleForTest()
+	fieldStats, err := loadedStats.current.GetStats(101)
+	s.NoError(err)
+	s.Equal(int64(3), fieldStats.NumRow())
+}
+
+func (s *DelegatorDataSuite) TestLoadSegmentsReopenBM25StatsRequiresOracleForRetry() {
+	worker1 := &cluster.MockWorker{}
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil)
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		LoadScope:    querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{
+			{
+				SegmentID:     100,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+				Bm25Logs:      bm25LogsForField(101, "bm25stats/reopen/segment_100/field_101/0"),
+			},
+		},
+	})
+
+	s.Error(err)
+	s.ErrorIs(err, merr.ErrServiceInternal)
+}
+
+func (s *DelegatorDataSuite) TestLoadSegmentsReopenWithoutBM25StatsNoop() {
+	worker1 := &cluster.MockWorker{}
+	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).Return(nil)
+	s.workerManager.EXPECT().GetWorker(mock.Anything, mock.AnythingOfType("int64")).Return(worker1, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := s.delegator.LoadSegments(ctx, &querypb.LoadSegmentsRequest{
+		Base:         commonpbutil.NewMsgBase(),
+		DstNodeID:    1,
+		CollectionID: s.collectionID,
+		LoadScope:    querypb.LoadScope_Reopen,
+		Infos: []*querypb.SegmentLoadInfo{
+			{
+				SegmentID:     100,
+				PartitionID:   500,
+				StartPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				DeltaPosition: &msgpb.MsgPosition{Timestamp: 20000},
+				Level:         datapb.SegmentLevel_L1,
+				InsertChannel: fmt.Sprintf("by-dev-rootcoord-dml_0_%dv0", s.collectionID),
+			},
+		},
+	})
+
+	s.NoError(err)
+	sealed, _ := s.delegator.GetSegmentInfo(false)
+	s.Empty(sealed)
+}
+
 func (s *DelegatorDataSuite) TestLoadSegments() {
 	s.Run("normal_run", func() {
 		defer func() {
@@ -1055,7 +1230,7 @@ func (s *DelegatorDataSuite) TestPostLoadLimiter() {
 
 func (s *DelegatorDataSuite) waitTargetVersion(targetVersion int64) {
 	for {
-		if s.delegator.idfOracle.TargetVersion() >= targetVersion {
+		if s.getIDFOracleForTest().TargetVersion() >= targetVersion {
 			return
 		}
 		time.Sleep(time.Millisecond * 100)
@@ -1130,11 +1305,11 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 		sealedSegs := []int64{1, 2, 3, 4}
 		for _, segID := range sealedSegs {
 			// every segment stats only has one token, avgdl = 1
-			registerSealedStats(s.delegator.idfOracle.(*idfOracle), segID, uint32(segID), uint32(segID)+1)
+			registerSealedStats(s.getIDFOracleForTest(), segID, uint32(segID), uint32(segID)+1)
 		}
 		snapshot := genSnapShot([]int64{1, 2, 3, 4}, []int64{}, 100)
 
-		s.delegator.idfOracle.SetNext(snapshot)
+		s.getIDFOracleForTest().SetNext(snapshot)
 		s.waitTargetVersion(snapshot.targetVersion)
 		placeholderGroupBytes, err := funcutil.FieldDataToPlaceholderGroupBytes(genStringFieldData("test bm25 data"))
 		s.NoError(err)
@@ -1204,9 +1379,8 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 		placeholderGroupBytes, err := funcutil.FieldDataToPlaceholderGroupBytes(genStringFieldData("test bm25 data"))
 		s.NoError(err)
 
-		oldRunner := s.delegator.functionRunners
 		mockRunner := function.NewMockFunctionRunner(s.T())
-		s.delegator.functionRunners = map[int64]function.FunctionRunner{101: mockRunner}
+		oldRunner := s.delegator.functionState.setFunctionRunnersForTest(map[int64]function.FunctionRunner{101: mockRunner})
 		mockRunner.EXPECT().GetInputFields().Return([]*schemapb.FieldSchema{
 			{
 				FieldID:  101,
@@ -1215,9 +1389,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 			},
 		})
 		mockRunner.EXPECT().BatchRun(mock.Anything).Return(nil, errors.New("mock err"))
-		defer func() {
-			s.delegator.functionRunners = oldRunner
-		}()
+		defer s.delegator.functionState.setFunctionRunnersForTest(oldRunner)
 
 		req := &internalpb.SearchRequest{
 			PlaceholderGroup: placeholderGroupBytes,
@@ -1231,9 +1403,8 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 		placeholderGroupBytes, err := funcutil.FieldDataToPlaceholderGroupBytes(genStringFieldData("test bm25 data"))
 		s.NoError(err)
 
-		oldRunner := s.delegator.functionRunners
 		mockRunner := function.NewMockFunctionRunner(s.T())
-		s.delegator.functionRunners = map[int64]function.FunctionRunner{101: mockRunner}
+		oldRunner := s.delegator.functionState.setFunctionRunnersForTest(map[int64]function.FunctionRunner{101: mockRunner})
 		mockRunner.EXPECT().GetInputFields().Return([]*schemapb.FieldSchema{
 			{
 				FieldID:  101,
@@ -1242,9 +1413,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 			},
 		})
 		mockRunner.EXPECT().BatchRun(mock.Anything).Return([]interface{}{1}, nil)
-		defer func() {
-			s.delegator.functionRunners = oldRunner
-		}()
+		defer s.delegator.functionState.setFunctionRunnersForTest(oldRunner)
 
 		req := &internalpb.SearchRequest{
 			PlaceholderGroup: placeholderGroupBytes,
@@ -1258,9 +1427,8 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 		placeholderGroupBytes, err := funcutil.FieldDataToPlaceholderGroupBytes(genStringFieldData("test bm25 data"))
 		s.NoError(err)
 
-		oldRunner := s.delegator.functionRunners
 		mockRunner := function.NewMockFunctionRunner(s.T())
-		s.delegator.functionRunners = map[int64]function.FunctionRunner{103: mockRunner}
+		oldRunner := s.delegator.functionState.setFunctionRunnersForTest(map[int64]function.FunctionRunner{103: mockRunner})
 		mockRunner.EXPECT().GetInputFields().Return([]*schemapb.FieldSchema{
 			{
 				FieldID:  101,
@@ -1269,9 +1437,7 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 			},
 		})
 		mockRunner.EXPECT().BatchRun(mock.Anything).Return([]interface{}{&schemapb.SparseFloatArray{Contents: [][]byte{typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{1: 1})}}}, nil)
-		defer func() {
-			s.delegator.functionRunners = oldRunner
-		}()
+		defer s.delegator.functionState.setFunctionRunnersForTest(oldRunner)
 
 		req := &internalpb.SearchRequest{
 			PlaceholderGroup: placeholderGroupBytes,
@@ -1287,11 +1453,11 @@ func (s *DelegatorDataSuite) TestBuildBM25IDF() {
 		sealedSegs := []int64{1, 2, 3, 4}
 		for _, segID := range sealedSegs {
 			// every segment stats only has one token, avgdl = 1
-			registerSealedStats(s.delegator.idfOracle.(*idfOracle), segID, uint32(segID), uint32(segID)+1)
+			registerSealedStats(s.getIDFOracleForTest(), segID, uint32(segID), uint32(segID)+1)
 		}
 		snapshot := genSnapShot([]int64{1, 2, 3, 4}, []int64{}, 100)
 
-		s.delegator.idfOracle.SetNext(snapshot)
+		s.getIDFOracleForTest().SetNext(snapshot)
 		s.waitTargetVersion(snapshot.targetVersion)
 		placeholderGroupBytes, err := funcutil.FieldDataToPlaceholderGroupBytes(genStringFieldData("test bm25 data"))
 		s.NoError(err)

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -32,14 +32,17 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/querynodev2/cluster"
+	"github.com/milvus-io/milvus/internal/querynodev2/delegator/deletebuffer"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/internal/util/function"
 	"github.com/milvus-io/milvus/internal/util/streamrpc"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
@@ -2021,6 +2024,399 @@ func TestDelegatorSuite(t *testing.T) {
 	suite.Run(t, new(DelegatorSuite))
 }
 
+func newFunctionRuntimeTestSchema(functions ...*schemapb.FunctionSchema) *schemapb.CollectionSchema {
+	return &schemapb.CollectionSchema{
+		Name: "TestCollection",
+		Fields: []*schemapb.FieldSchema{
+			{
+				Name:         "id",
+				FieldID:      100,
+				IsPrimaryKey: true,
+				DataType:     schemapb.DataType_Int64,
+				AutoID:       true,
+			},
+			{
+				Name:     "text",
+				FieldID:  101,
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "256"},
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: common.AnalyzerParamKey, Value: "{}"},
+				},
+			},
+			{
+				Name:     "sparse",
+				FieldID:  102,
+				DataType: schemapb.DataType_SparseFloatVector,
+			},
+			{
+				Name:     "standalone_text",
+				FieldID:  103,
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "256"},
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: common.AnalyzerParamKey, Value: "{}"},
+				},
+			},
+			{
+				Name:     "minhash",
+				FieldID:  104,
+				DataType: schemapb.DataType_BinaryVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+			{
+				Name:     "sparse_additive",
+				FieldID:  105,
+				DataType: schemapb.DataType_SparseFloatVector,
+			},
+		},
+		Functions: functions,
+	}
+}
+
+func newBM25FunctionSchema() *schemapb.FunctionSchema {
+	return &schemapb.FunctionSchema{
+		Type:             schemapb.FunctionType_BM25,
+		InputFieldNames:  []string{"text"},
+		InputFieldIds:    []int64{101},
+		OutputFieldNames: []string{"sparse"},
+		OutputFieldIds:   []int64{102},
+	}
+}
+
+func newAdditionalBM25FunctionSchema() *schemapb.FunctionSchema {
+	return &schemapb.FunctionSchema{
+		Type:             schemapb.FunctionType_BM25,
+		InputFieldNames:  []string{"text"},
+		InputFieldIds:    []int64{101},
+		OutputFieldNames: []string{"sparse_additive"},
+		OutputFieldIds:   []int64{105},
+	}
+}
+
+func newMinHashFunctionSchema() *schemapb.FunctionSchema {
+	return &schemapb.FunctionSchema{
+		Type:             schemapb.FunctionType_MinHash,
+		InputFieldNames:  []string{"text"},
+		InputFieldIds:    []int64{101},
+		OutputFieldNames: []string{"minhash"},
+		OutputFieldIds:   []int64{104},
+	}
+}
+
+func TestBuildFunctionRuntimeStateAddsBM25AndAnalyzerRunners(t *testing.T) {
+	paramtable.Init()
+	schema := newFunctionRuntimeTestSchema(newBM25FunctionSchema())
+
+	state, err := buildFunctionRuntimeState(schema)
+	require.NoError(t, err)
+	defer state.Close()
+
+	require.Contains(t, state.functionRunners, int64(102))
+	assert.Equal(t, schemapb.FunctionType_BM25, state.functionFieldType[102])
+	require.Contains(t, state.analyzerRunners, int64(101))
+	require.Contains(t, state.analyzerRunners, int64(103))
+	assert.Same(t, state.functionRunners[102], state.analyzerRunners[101])
+}
+
+func TestBuildFunctionRuntimeStateAddsMinHashRunner(t *testing.T) {
+	paramtable.Init()
+	schema := newFunctionRuntimeTestSchema(newMinHashFunctionSchema())
+
+	state, err := buildFunctionRuntimeState(schema)
+	require.NoError(t, err)
+	defer state.Close()
+
+	require.Contains(t, state.functionRunners, int64(104))
+	assert.Equal(t, schemapb.FunctionType_MinHash, state.functionFieldType[104])
+	assert.Contains(t, state.analyzerRunners, int64(101))
+}
+
+func TestBM25FunctionSetAdditiveValidation(t *testing.T) {
+	base := newBM25FunctionSet(newFunctionRuntimeTestSchema(newBM25FunctionSchema()))
+
+	assert.True(t, newBM25FunctionSet(newFunctionRuntimeTestSchema(newBM25FunctionSchema())).IsSupersetOf(base))
+	assert.True(t, newBM25FunctionSet(newFunctionRuntimeTestSchema(newBM25FunctionSchema(), newAdditionalBM25FunctionSchema())).IsSupersetOf(base))
+
+	changed := proto.Clone(newBM25FunctionSchema()).(*schemapb.FunctionSchema)
+	changed.InputFieldIds = []int64{103}
+	assert.False(t, newBM25FunctionSet(newFunctionRuntimeTestSchema(changed)).IsSupersetOf(base))
+	assert.False(t, newBM25FunctionSet(newFunctionRuntimeTestSchema()).IsSupersetOf(base))
+}
+
+func TestBM25FunctionSetIgnoresAnalyzerParams(t *testing.T) {
+	baseSchema := newFunctionRuntimeTestSchema(newBM25FunctionSchema())
+	changedSchema := proto.Clone(baseSchema).(*schemapb.CollectionSchema)
+	changedSchema.Fields[1].TypeParams = []*commonpb.KeyValuePair{
+		{Key: common.MaxLengthKey, Value: "256"},
+		{Key: common.EnableAnalyzerKey, Value: "true"},
+		{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+	}
+
+	base := newBM25FunctionSet(baseSchema)
+	changed := newBM25FunctionSet(changedSchema)
+	assert.True(t, changed.IsSupersetOf(base))
+}
+
+func TestBM25FunctionSetNormalizesFunctionParamOrder(t *testing.T) {
+	baseFunction := newBM25FunctionSchema()
+	baseFunction.Params = []*commonpb.KeyValuePair{
+		{Key: "k1", Value: "v1"},
+		{Key: "k2", Value: "v2"},
+	}
+	changedFunction := proto.Clone(baseFunction).(*schemapb.FunctionSchema)
+	changedFunction.Params = []*commonpb.KeyValuePair{
+		{Key: "k2", Value: "v2"},
+		{Key: "k1", Value: "v1"},
+	}
+
+	base := newBM25FunctionSet(newFunctionRuntimeTestSchema(baseFunction))
+	changed := newBM25FunctionSet(newFunctionRuntimeTestSchema(changedFunction))
+	assert.True(t, changed.IsSupersetOf(base))
+}
+
+func TestUpdateSchemaRejectsNonAdditiveBM25FunctionChange(t *testing.T) {
+	paramtable.Init()
+	paramtable.SetNodeID(1)
+	workerManager := cluster.NewMockManager(t)
+	oldRunner := function.NewMockFunctionRunner(t)
+	oldRunner.EXPECT().Close().Maybe()
+	oldSchema := newFunctionRuntimeTestSchema(newBM25FunctionSchema())
+	oldOracle := NewIDFOracle("test-channel", oldSchema.GetFunctions())
+	sd := &shardDelegator{
+		collectionID:  1000,
+		vchannelName:  "test-channel",
+		collection:    segments.NewCollectionWithoutSegcoreForTest(1000, oldSchema),
+		lifetime:      lifetime.NewLifetime(lifetime.Working),
+		distribution:  NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
+		workerManager: workerManager,
+		functionState: &functionRuntimeState{
+			functionRunners:   map[int64]function.FunctionRunner{102: oldRunner},
+			functionFieldType: map[int64]schemapb.FunctionType{102: schemapb.FunctionType_BM25},
+			analyzerRunners:   map[int64]function.Analyzer{},
+		},
+		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
+		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+	}
+	sd.publishIDFOracle(oldOracle)
+	defer sd.Close()
+
+	changed := proto.Clone(newBM25FunctionSchema()).(*schemapb.FunctionSchema)
+	changed.InputFieldIds = []int64{103}
+	err := sd.UpdateSchema(context.Background(), newFunctionRuntimeTestSchema(changed), 100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported non-additive BM25 function schema change")
+	assert.True(t, sd.functionState.hasFunctionRunner(102))
+	assert.Same(t, oldOracle, sd.getIDFOracle())
+}
+
+func TestUpdateSchemaSyncsAdditiveIDFOracleFunctions(t *testing.T) {
+	paramtable.Init()
+	paramtable.SetNodeID(1)
+	worker := cluster.NewMockWorker(t)
+	worker.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Success(), nil).Once()
+	workerManager := cluster.NewMockManager(t)
+	workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+	oldSchema := newFunctionRuntimeTestSchema(newBM25FunctionSchema())
+	sd := &shardDelegator{
+		collectionID:  1000,
+		vchannelName:  "test-channel",
+		collection:    segments.NewCollectionWithoutSegcoreForTest(1000, oldSchema),
+		lifetime:      lifetime.NewLifetime(lifetime.Working),
+		distribution:  NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
+		workerManager: workerManager,
+		functionState: &functionRuntimeState{
+			functionRunners:   map[int64]function.FunctionRunner{},
+			functionFieldType: map[int64]schemapb.FunctionType{},
+			analyzerRunners:   map[int64]function.Analyzer{},
+		},
+		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
+		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+	}
+	oldOracle := NewIDFOracle("test-channel", oldSchema.GetFunctions())
+	sd.publishIDFOracle(oldOracle)
+	defer sd.Close()
+
+	newSchema := newFunctionRuntimeTestSchema(newBM25FunctionSchema(), newAdditionalBM25FunctionSchema())
+	collectionManager := segments.NewMockCollectionManager(t)
+	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Return(nil).Once()
+	sd.collectionManager = collectionManager
+
+	err := sd.UpdateSchema(context.Background(), newSchema, 100)
+	require.NoError(t, err)
+
+	_, _, err = sd.getIDFOracle().BuildIDF(105, &schemapb.SparseFloatArray{Contents: [][]byte{typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{7: 1})}, Dim: 1})
+	require.NoError(t, err)
+}
+
+func TestUpdateSchemaDoesNotSyncIDFOracleWhenWorkerUpdateFails(t *testing.T) {
+	paramtable.Init()
+	paramtable.SetNodeID(1)
+	worker := cluster.NewMockWorker(t)
+	worker.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Status(merr.WrapErrServiceInternal("mocked")), merr.WrapErrServiceInternal("mocked")).Once()
+	workerManager := cluster.NewMockManager(t)
+	workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+	oldSchema := newFunctionRuntimeTestSchema(newBM25FunctionSchema())
+	sd := &shardDelegator{
+		collectionID:  1000,
+		vchannelName:  "test-channel",
+		collection:    segments.NewCollectionWithoutSegcoreForTest(1000, oldSchema),
+		lifetime:      lifetime.NewLifetime(lifetime.Working),
+		distribution:  NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
+		workerManager: workerManager,
+		functionState: &functionRuntimeState{
+			functionRunners:   map[int64]function.FunctionRunner{},
+			functionFieldType: map[int64]schemapb.FunctionType{},
+			analyzerRunners:   map[int64]function.Analyzer{},
+		},
+		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
+		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+	}
+	oldOracle := NewIDFOracle("test-channel", oldSchema.GetFunctions())
+	sd.publishIDFOracle(oldOracle)
+	defer sd.Close()
+
+	newSchema := newFunctionRuntimeTestSchema(newBM25FunctionSchema(), newAdditionalBM25FunctionSchema())
+	err := sd.UpdateSchema(context.Background(), newSchema, 100)
+	require.Error(t, err)
+
+	_, _, err = sd.getIDFOracle().BuildIDF(105, &schemapb.SparseFloatArray{Contents: [][]byte{typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{7: 1})}, Dim: 1})
+	require.Error(t, err)
+}
+
+func TestUpdateSchemaInitializesIDFOracleWhenBM25Added(t *testing.T) {
+	paramtable.Init()
+	paramtable.SetNodeID(1)
+	worker := cluster.NewMockWorker(t)
+	worker.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Success(), nil).Once()
+	workerManager := cluster.NewMockManager(t)
+	workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+	oldSchema := newFunctionRuntimeTestSchema()
+	sd := &shardDelegator{
+		collectionID:  1000,
+		vchannelName:  "test-channel",
+		collection:    segments.NewCollectionWithoutSegcoreForTest(1000, oldSchema),
+		lifetime:      lifetime.NewLifetime(lifetime.Working),
+		distribution:  NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
+		workerManager: workerManager,
+		functionState: &functionRuntimeState{
+			functionRunners:   map[int64]function.FunctionRunner{},
+			functionFieldType: map[int64]schemapb.FunctionType{},
+			analyzerRunners:   map[int64]function.Analyzer{},
+		},
+		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
+		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+	}
+	defer sd.Close()
+
+	newSchema := newFunctionRuntimeTestSchema(newBM25FunctionSchema())
+	collectionManager := segments.NewMockCollectionManager(t)
+	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Return(nil).Once()
+	sd.collectionManager = collectionManager
+
+	err := sd.UpdateSchema(context.Background(), newSchema, 100)
+	require.NoError(t, err)
+	require.NotNil(t, sd.getIDFOracle())
+
+	_, _, err = sd.getIDFOracle().BuildIDF(102, &schemapb.SparseFloatArray{Contents: [][]byte{typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{7: 1})}, Dim: 1})
+	require.NoError(t, err)
+}
+
+func TestUpdateSchemaRefreshesCollectionBaselineForSequentialBM25Validation(t *testing.T) {
+	paramtable.Init()
+	paramtable.SetNodeID(1)
+	manager := segments.NewManager()
+	oldSchema := newFunctionRuntimeTestSchema()
+	require.NoError(t, manager.Collection.PutOrRef(1000, oldSchema, nil, &querypb.LoadMetaInfo{SchemaVersion: 1}))
+	defer manager.Collection.Unref(1000, 1)
+
+	worker := cluster.NewMockWorker(t)
+	worker.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Success(), nil).Once()
+	workerManager := cluster.NewMockManager(t)
+	workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+
+	functionState, err := buildFunctionRuntimeState(oldSchema)
+	require.NoError(t, err)
+	sd := &shardDelegator{
+		collectionID:               1000,
+		vchannelName:               "test-channel",
+		collection:                 manager.Collection.Get(1000),
+		collectionManager:          manager.Collection,
+		lifetime:                   lifetime.NewLifetime(lifetime.Working),
+		distribution:               NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
+		workerManager:              workerManager,
+		functionState:              functionState,
+		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
+		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+	}
+	defer sd.Close()
+
+	firstSchema := newFunctionRuntimeTestSchema(newBM25FunctionSchema())
+	err = sd.UpdateSchema(context.Background(), firstSchema, 100)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), sd.collection.SchemaVersion())
+
+	changed := proto.Clone(newBM25FunctionSchema()).(*schemapb.FunctionSchema)
+	changed.InputFieldIds = []int64{103}
+	err = sd.UpdateSchema(context.Background(), newFunctionRuntimeTestSchema(changed), 200)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported non-additive BM25 function schema change")
+	require.Equal(t, uint64(100), sd.collection.SchemaVersion())
+}
+
+func TestUpdateSchemaSyncsFunctionRuntimeState(t *testing.T) {
+	paramtable.Init()
+	paramtable.SetNodeID(1)
+	worker := cluster.NewMockWorker(t)
+	worker.EXPECT().UpdateSchema(mock.Anything, mock.AnythingOfType("*querypb.UpdateSchemaRequest")).Return(merr.Success(), nil).Once()
+	workerManager := cluster.NewMockManager(t)
+	workerManager.EXPECT().GetWorker(mock.Anything, int64(1)).Return(worker, nil).Once()
+	oldRunner := function.NewMockFunctionRunner(t)
+	oldRunner.EXPECT().Close().Once()
+	sd := &shardDelegator{
+		collectionID:  1000,
+		vchannelName:  "test-channel",
+		collection:    segments.NewCollectionWithoutSegcoreForTest(1000, newFunctionRuntimeTestSchema()),
+		lifetime:      lifetime.NewLifetime(lifetime.Working),
+		distribution:  NewDistribution("test-channel", NewChannelQueryView(nil, nil, nil, initialTargetVersion)),
+		workerManager: workerManager,
+		functionState: &functionRuntimeState{
+			functionRunners:   map[int64]function.FunctionRunner{999: oldRunner},
+			functionFieldType: map[int64]schemapb.FunctionType{999: schemapb.FunctionType_BM25},
+			analyzerRunners:   map[int64]function.Analyzer{},
+		},
+		deleteBuffer:               deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](0, 0, []string{"1", "test-channel"}),
+		tsCond:                     syncutil.NewContextCond(&sync.Mutex{}),
+		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+	}
+	defer sd.Close()
+
+	newSchema := newFunctionRuntimeTestSchema(newBM25FunctionSchema(), newMinHashFunctionSchema())
+	collectionManager := segments.NewMockCollectionManager(t)
+	collectionManager.EXPECT().UpdateSchema(int64(1000), newSchema, uint64(100)).Return(nil).Once()
+	sd.collectionManager = collectionManager
+
+	err := sd.UpdateSchema(context.Background(), newSchema, 100)
+	require.NoError(t, err)
+
+	require.True(t, sd.functionState.hasFunctionRunner(102))
+	require.True(t, sd.functionState.hasFunctionRunner(104))
+	assert.True(t, sd.functionState.hasFunctionType(102, schemapb.FunctionType_BM25))
+	assert.True(t, sd.functionState.hasFunctionType(104, schemapb.FunctionType_MinHash))
+	require.True(t, sd.functionState.hasAnalyzerRunner(101))
+	require.True(t, sd.functionState.hasAnalyzerRunner(103))
+	assert.True(t, sd.functionState.functionRunnerAliasesAnalyzer(102, 101))
+}
+
 func TestDelegatorSearchBM25InvalidMetricType(t *testing.T) {
 	paramtable.Init()
 	searchReq := &querypb.SearchRequest{
@@ -2033,7 +2429,9 @@ func TestDelegatorSearchBM25InvalidMetricType(t *testing.T) {
 	searchReq.Req.MetricType = metric.IP
 
 	sd := &shardDelegator{
-		functionFieldType:          map[int64]schemapb.FunctionType{101: schemapb.FunctionType_BM25},
+		functionState: &functionRuntimeState{
+			functionFieldType: map[int64]schemapb.FunctionType{101: schemapb.FunctionType_BM25},
+		},
 		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
 	}
 

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -314,6 +314,19 @@ func (d *distribution) PeekSegments(readable bool, partitions ...int64) (sealed 
 	return
 }
 
+// IsReadableSealedSegment reuses PeekSegments(readable=true) semantics for Reopen activation.
+func (d *distribution) IsReadableSealedSegment(segmentID int64) bool {
+	sealed, _ := d.PeekSegments(true)
+	for _, item := range sealed {
+		for _, entry := range item.Segments {
+			if entry.SegmentID == segmentID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Unpin notifies snapshot one reference is released.
 func (d *distribution) Unpin(version int64) {
 	snapshot, ok := d.snapshots.Get(version)

--- a/internal/querynodev2/delegator/function_runtime_state.go
+++ b/internal/querynodev2/delegator/function_runtime_state.go
@@ -1,0 +1,235 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delegator
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+type functionRuntimeState struct {
+	mu                sync.RWMutex
+	functionRunners   map[UniqueID]function.FunctionRunner
+	functionFieldType map[UniqueID]schemapb.FunctionType
+	analyzerRunners   map[UniqueID]function.Analyzer
+}
+
+func buildFunctionRuntimeState(schema *schemapb.CollectionSchema) (*functionRuntimeState, error) {
+	state := &functionRuntimeState{
+		functionRunners:   make(map[UniqueID]function.FunctionRunner),
+		functionFieldType: make(map[UniqueID]schemapb.FunctionType),
+		analyzerRunners:   make(map[UniqueID]function.Analyzer),
+	}
+
+	for _, tf := range schema.GetFunctions() {
+		switch tf.GetType() {
+		case schemapb.FunctionType_BM25:
+			functionRunner, err := function.NewFunctionRunner(schema, tf)
+			if err != nil {
+				state.Close()
+				return nil, err
+			}
+			outputFieldID := tf.GetOutputFieldIds()[0]
+			inputFieldID := tf.GetInputFieldIds()[0]
+			state.functionRunners[outputFieldID] = functionRunner
+			state.analyzerRunners[inputFieldID] = functionRunner.(function.Analyzer)
+			state.functionFieldType[outputFieldID] = schemapb.FunctionType_BM25
+		case schemapb.FunctionType_MinHash:
+			functionRunner, err := function.NewFunctionRunner(schema, tf)
+			if err != nil {
+				state.Close()
+				return nil, err
+			}
+			outputFieldID := tf.GetOutputFieldIds()[0]
+			state.functionRunners[outputFieldID] = functionRunner
+			state.functionFieldType[outputFieldID] = schemapb.FunctionType_MinHash
+		}
+	}
+
+	for _, field := range schema.GetFields() {
+		helper := typeutil.CreateFieldSchemaHelper(field)
+		if helper.EnableAnalyzer() && state.analyzerRunners[field.GetFieldID()] == nil {
+			analyzerRunner, err := function.NewAnalyzerRunner(field)
+			if err != nil {
+				state.Close()
+				return nil, err
+			}
+			state.analyzerRunners[field.GetFieldID()] = analyzerRunner
+		}
+	}
+
+	return state, nil
+}
+
+func (s *functionRuntimeState) Close() {
+	if s == nil {
+		return
+	}
+	closed := typeutil.NewSet[function.FunctionRunner]()
+	for _, runner := range s.functionRunners {
+		if runner == nil || closed.Contain(runner) {
+			continue
+		}
+		runner.Close()
+		closed.Insert(runner)
+	}
+	for _, analyzer := range s.analyzerRunners {
+		runner, ok := analyzer.(function.FunctionRunner)
+		if !ok || runner == nil || closed.Contain(runner) {
+			continue
+		}
+		runner.Close()
+		closed.Insert(runner)
+	}
+}
+
+func (s *functionRuntimeState) counts() (int, int, int) {
+	if s == nil {
+		return 0, 0, 0
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.functionRunners), len(s.functionFieldType), len(s.analyzerRunners)
+}
+
+func (s *functionRuntimeState) hasFunctionRunner(fieldID UniqueID) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.functionRunners[fieldID]
+	return ok
+}
+
+func (s *functionRuntimeState) hasAnalyzerRunner(fieldID UniqueID) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.analyzerRunners[fieldID]
+	return ok
+}
+
+func (s *functionRuntimeState) functionRunnerAliasesAnalyzer(functionFieldID, analyzerFieldID UniqueID) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	runner, ok := s.functionRunners[functionFieldID]
+	if !ok {
+		return false
+	}
+	analyzer, ok := s.analyzerRunners[analyzerFieldID]
+	if !ok {
+		return false
+	}
+	runnerAnalyzer, ok := runner.(function.Analyzer)
+	return ok && runnerAnalyzer == analyzer
+}
+
+func (s *functionRuntimeState) hasFunctionType(fieldID UniqueID, functionType schemapb.FunctionType) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.functionFieldType[fieldID] == functionType
+}
+
+func (s *functionRuntimeState) swap(newState *functionRuntimeState) *functionRuntimeState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	oldState := &functionRuntimeState{
+		functionRunners:   s.functionRunners,
+		functionFieldType: s.functionFieldType,
+		analyzerRunners:   s.analyzerRunners,
+	}
+	s.functionRunners = newState.functionRunners
+	s.functionFieldType = newState.functionFieldType
+	s.analyzerRunners = newState.analyzerRunners
+	return oldState
+}
+
+func (s *functionRuntimeState) withSearchFunction(fieldID UniqueID, run func(schemapb.FunctionType, function.FunctionRunner, bool) error) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	functionType := s.functionFieldType[fieldID]
+	if functionType == schemapb.FunctionType_Unknown {
+		return nil
+	}
+	runner, ok := s.functionRunners[fieldID]
+	return run(functionType, runner, ok)
+}
+
+func (s *functionRuntimeState) setFunctionRunnersForTest(functionRunners map[UniqueID]function.FunctionRunner) map[UniqueID]function.FunctionRunner {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	old := s.functionRunners
+	s.functionRunners = functionRunners
+	return old
+}
+
+func (s *functionRuntimeState) withFunctionRunner(fieldID UniqueID, run func(function.FunctionRunner) error) (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	runner, ok := s.functionRunners[fieldID]
+	if !ok {
+		return false, nil
+	}
+	return true, run(runner)
+}
+
+func (s *functionRuntimeState) withRequiredFunctionRunner(fieldID UniqueID, run func(function.FunctionRunner) error) error {
+	ok, err := s.withFunctionRunner(fieldID, run)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("functionRunner not found for field: %d", fieldID)
+	}
+	return nil
+}
+
+func (s *functionRuntimeState) withAnalyzerRunner(fieldID UniqueID, run func(function.Analyzer) error) (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	analyzer, ok := s.analyzerRunners[fieldID]
+	if !ok {
+		return false, nil
+	}
+	return true, run(analyzer)
+}

--- a/internal/querynodev2/delegator/idf_oracle.go
+++ b/internal/querynodev2/delegator/idf_oracle.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"slices"
 	"sync"
 	"time"
 
@@ -41,6 +42,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/storagev2/packed"
 	"github.com/milvus-io/milvus/internal/util/pathutil"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
@@ -64,6 +66,8 @@ type IDFOracle interface {
 	// Internally handles: streaming download → local disk → optional parse → register.
 	// Idempotent: skips if segment already loaded.
 	LoadSealed(ctx context.Context, segmentID int64, loadInfo *querypb.SegmentLoadInfo, cm storage.ChunkManager) error
+	LoadSealedForReopen(ctx context.Context, segmentID int64, loadInfo *querypb.SegmentLoadInfo, cm storage.ChunkManager, activateIfReadable bool) error
+	SyncFunctions(functions []*schemapb.FunctionSchema) error
 
 	BuildIDF(fieldID int64, tfs *schemapb.SparseFloatArray) ([][]byte, float64, error)
 
@@ -73,7 +77,44 @@ type IDFOracle interface {
 	Close()
 }
 
+type bm25FunctionSet map[typeutil.UniqueID]*schemapb.FunctionSchema
+
 type bm25Stats map[int64]*storage.BM25Stats
+
+func newBM25FunctionSet(schema *schemapb.CollectionSchema) bm25FunctionSet {
+	result := make(bm25FunctionSet)
+	if schema == nil {
+		return result
+	}
+	for _, function := range schema.GetFunctions() {
+		if function.GetType() != schemapb.FunctionType_BM25 || len(function.GetOutputFieldIds()) == 0 {
+			continue
+		}
+		result[function.GetOutputFieldIds()[0]] = function
+	}
+	return result
+}
+
+func (s bm25FunctionSet) IsSupersetOf(old bm25FunctionSet) bool {
+	for outputFieldID, oldFunction := range old {
+		newFunction, ok := s[outputFieldID]
+		if !ok || !sameBM25Function(newFunction, oldFunction) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s bm25FunctionSet) Equal(other bm25FunctionSet) bool {
+	return len(s) == len(other) && s.IsSupersetOf(other)
+}
+
+func sameBM25Function(a, b *schemapb.FunctionSchema) bool {
+	return a.GetType() == b.GetType() &&
+		slices.Equal(a.GetInputFieldIds(), b.GetInputFieldIds()) &&
+		slices.Equal(a.GetOutputFieldIds(), b.GetOutputFieldIds()) &&
+		common.KeyValuePairs(a.GetParams()).Equal(b.GetParams())
+}
 
 func (s bm25Stats) Merge(stats bm25Stats) {
 	for fieldID, newstats := range stats {
@@ -123,6 +164,42 @@ type sealedBm25Stats struct {
 	localDir  string
 	fieldList []int64 // bm25 field list
 	diskSize  int64   // total disk size of local files
+}
+
+func (s *sealedBm25Stats) HasField(fieldID int64) bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.hasFieldLocked(fieldID)
+}
+
+func (s *sealedBm25Stats) hasFieldLocked(fieldID int64) bool {
+	for _, existingFieldID := range s.fieldList {
+		if existingFieldID == fieldID {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *sealedBm25Stats) AddFields(fieldIDs []int64) {
+	s.Lock()
+	defer s.Unlock()
+	s.addFieldsLocked(fieldIDs)
+}
+
+func (s *sealedBm25Stats) addFieldsLocked(fieldIDs []int64) {
+	for _, fieldID := range fieldIDs {
+		if s.hasFieldLocked(fieldID) {
+			continue
+		}
+		s.fieldList = append(s.fieldList, fieldID)
+	}
+}
+
+func (s *sealedBm25Stats) FieldList() []int64 {
+	s.RLock()
+	defer s.RUnlock()
+	return append([]int64(nil), s.fieldList...)
 }
 
 func (s *sealedBm25Stats) Remove() {
@@ -196,6 +273,18 @@ func newBm25Stats(functions []*schemapb.FunctionSchema) bm25Stats {
 	return stats
 }
 
+func (s bm25Stats) AddMissingFunctions(functions []*schemapb.FunctionSchema) {
+	for _, function := range functions {
+		if function.GetType() != schemapb.FunctionType_BM25 || len(function.GetOutputFieldIds()) == 0 {
+			continue
+		}
+		fieldID := function.GetOutputFieldIds()[0]
+		if _, ok := s[fieldID]; !ok {
+			s[fieldID] = storage.NewBM25Stats()
+		}
+	}
+}
+
 type idfTarget struct {
 	sync.RWMutex
 	snapshot *snapshot
@@ -265,6 +354,32 @@ func (o *idfOracle) preloadSealed(segmentID int64, stats *sealedBm25Stats, memor
 	stats.activate.Store(true)
 }
 
+func (o *idfOracle) activateSealedStatsLocked(segStats *sealedBm25Stats, stats bm25Stats) bool {
+	if segStats.activate.Load() {
+		return false
+	}
+	o.current.Merge(stats)
+	segStats.activate.Store(true)
+	return true
+}
+
+func (o *idfOracle) activateExistingSealedStats(segmentID int64, stats bm25Stats) (bool, error) {
+	o.Lock()
+	defer o.Unlock()
+
+	segStats, existed := o.sealed.Get(segmentID)
+	if !existed {
+		return false, nil
+	}
+
+	segStats.Lock()
+	defer segStats.Unlock()
+	if segStats.removed {
+		return false, errors.Newf("sealed bm25 stats for segment %d already removed", segmentID)
+	}
+	return o.activateSealedStatsLocked(segStats, stats), nil
+}
+
 func (o *idfOracle) RegisterGrowing(segmentID int64, stats bm25Stats) {
 	o.Lock()
 	if _, ok := o.growing[segmentID]; ok {
@@ -278,6 +393,14 @@ func (o *idfOracle) RegisterGrowing(segmentID int64, stats bm25Stats) {
 	o.current.Merge(stats)
 	o.Unlock()
 	o.syncResource()
+}
+
+func (o *idfOracle) SyncFunctions(functions []*schemapb.FunctionSchema) error {
+	o.Lock()
+	o.current.AddMissingFunctions(functions)
+	o.Unlock()
+	o.syncResource()
+	return nil
 }
 
 // LoadSealed loads BM25 stats for a sealed segment from remote storage to local disk.
@@ -328,6 +451,138 @@ func (o *idfOracle) LoadSealed(ctx context.Context, segmentID int64, loadInfo *q
 			o.sealed.Insert(segmentID, segStats)
 		}
 		o.sealedDiskSize.Add(result.diskSize)
+
+		o.syncResource()
+		return nil, nil
+	})
+	return err
+}
+
+func (o *idfOracle) LoadSealedForReopen(ctx context.Context, segmentID int64, loadInfo *querypb.SegmentLoadInfo, cm storage.ChunkManager, activateIfReadable bool) error {
+	// QueryCoord deduplicates same sealed-segment load/reopen tasks by replica, segment, and scope.
+	// This shared singleflight key only coalesces duplicate calls; it is not relied on to serialize different tasks.
+	_, err, _ := o.sf.Do(fmt.Sprintf("load_sealed_%d", segmentID), func() (any, error) {
+		logger := log.Ctx(ctx).With(zap.Int64("segmentID", segmentID))
+		logpaths, err := packed.NewStatsResolverFromLoadInfo(loadInfo).BM25StatsPaths()
+		if err != nil {
+			logger.Warn("load remote segment bm25 stats for reopen failed", zap.Error(err))
+			return nil, err
+		}
+		if len(logpaths) == 0 {
+			return nil, nil
+		}
+
+		segStats, existedBeforeLoad := o.sealed.Get(segmentID)
+		missingPaths := make(map[int64][]string, len(logpaths))
+		for fieldID, paths := range logpaths {
+			if existedBeforeLoad && segStats.HasField(fieldID) {
+				continue
+			}
+			missingPaths[fieldID] = paths
+		}
+		if len(missingPaths) == 0 {
+			if existedBeforeLoad && activateIfReadable && !segStats.activate.Load() {
+				existingStats, err := segStats.FetchStats()
+				if err != nil {
+					return nil, err
+				}
+				activated, err := o.activateExistingSealedStats(segmentID, existingStats)
+				if err != nil {
+					return nil, err
+				}
+				if activated {
+					o.syncResource()
+				}
+			}
+			return nil, nil
+		}
+
+		installed := false
+		cleanup := func() {
+			if installed {
+				return
+			}
+			for fieldID := range missingPaths {
+				cleanupPath := path.Join(o.dirPath, fmt.Sprintf("%d", segmentID), fmt.Sprintf("%d", fieldID))
+				if rmErr := os.RemoveAll(cleanupPath); rmErr != nil {
+					logger.Warn("failed to cleanup reopened bm25 stats field dir", zap.Error(rmErr), zap.String("path", cleanupPath))
+				}
+			}
+		}
+		defer cleanup()
+
+		result, err := o.streamLoad(ctx, segmentID, missingPaths, cm, true)
+		if err != nil {
+			return nil, err
+		}
+
+		var existingStats bm25Stats
+		if existedBeforeLoad && activateIfReadable && !segStats.activate.Load() {
+			existingStats, err = segStats.FetchStats()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		o.Lock()
+		segStats, existed := o.sealed.Get(segmentID)
+		if existed {
+			segStats.Lock()
+			if segStats.removed {
+				segStats.Unlock()
+				o.Unlock()
+				return nil, errors.Newf("sealed bm25 stats for segment %d already removed", segmentID)
+			}
+
+			wasActive := segStats.activate.Load()
+			installedFields := make([]int64, 0, len(result.fieldList))
+			installedStats := make(bm25Stats, len(result.fieldList))
+			for _, fieldID := range result.fieldList {
+				if segStats.hasFieldLocked(fieldID) {
+					continue
+				}
+				installedFields = append(installedFields, fieldID)
+				if result.stats != nil {
+					installedStats[fieldID] = result.stats[fieldID]
+				}
+			}
+			if len(installedFields) == 0 {
+				segStats.Unlock()
+				o.Unlock()
+				return nil, nil
+			}
+
+			segStats.addFieldsLocked(installedFields)
+			segStats.diskSize += result.diskSize
+			switch {
+			case wasActive:
+				o.current.Merge(installedStats)
+			case activateIfReadable:
+				// Inactive entries have not contributed any field to current, so activation must merge the full segment.
+				if existingStats == nil {
+					existingStats = make(bm25Stats, len(installedStats))
+				}
+				existingStats.Merge(installedStats)
+				o.activateSealedStatsLocked(segStats, existingStats)
+			}
+			segStats.Unlock()
+		} else {
+			segStats = &sealedBm25Stats{
+				ts:        time.Now(),
+				activate:  atomic.NewBool(false),
+				segmentID: segmentID,
+				localDir:  result.localDir,
+				fieldList: result.fieldList,
+				diskSize:  result.diskSize,
+			}
+			if activateIfReadable {
+				o.activateSealedStatsLocked(segStats, result.stats)
+			}
+			o.sealed.Insert(segmentID, segStats)
+		}
+		o.sealedDiskSize.Add(result.diskSize)
+		installed = true
+		o.Unlock()
 
 		o.syncResource()
 		return nil, nil
@@ -660,7 +915,8 @@ func (o *idfOracle) SyncDistribution() error {
 		}
 	}
 
-	diff := bm25Stats{}
+	activateStats := make(map[int64]bm25Stats)
+	deactivateStats := make(map[int64]bm25Stats)
 
 	var rangeErr error
 	o.sealed.Range(func(segmentID int64, stats *sealedBm25Stats) bool {
@@ -674,7 +930,7 @@ func (o *idfOracle) SyncDistribution() error {
 				rangeErr = fmt.Errorf("fetch stats failed with error: %v", err)
 				return false
 			}
-			diff.Merge(stats)
+			activateStats[segmentID] = stats
 		} else
 		// deactivate segment if segment not in target.
 		if !intarget && activate {
@@ -683,7 +939,7 @@ func (o *idfOracle) SyncDistribution() error {
 				rangeErr = fmt.Errorf("fetch stats failed with error: %v", err)
 				return false
 			}
-			diff.Minus(stats)
+			deactivateStats[segmentID] = stats
 		}
 		return true
 	})
@@ -703,22 +959,27 @@ func (o *idfOracle) SyncDistribution() error {
 			delete(o.growing, segmentID)
 		}
 	}
-	o.current.Merge(diff)
 
 	// remove sealed segment not in target
 	o.sealed.Range(func(segmentID int64, stats *sealedBm25Stats) bool {
 		reserve := reserveMap.Contain(segmentID)
 		intarget := targetMap.Contain(segmentID)
 
+		stats.Lock()
 		activate := stats.activate.Load()
 		// save activate if segment in target.
 		if intarget && !activate {
-			stats.activate.Store(true)
+			if segmentStats, ok := activateStats[segmentID]; ok {
+				o.activateSealedStatsLocked(stats, segmentStats)
+			}
 		}
 
 		// deactivate if segment not in target.
 		if !intarget && activate {
-			stats.activate.Store(false)
+			if segmentStats, ok := deactivateStats[segmentID]; ok {
+				o.current.Minus(segmentStats)
+				stats.activate.Store(false)
+			}
 		}
 
 		// remove
@@ -726,8 +987,11 @@ func (o *idfOracle) SyncDistribution() error {
 		// (means segment target version was old version or segment not in snapshot)
 		// and add before snapshot Ts
 		// (forbid remove some new segment register after current snapshot)
-		if !intarget && !reserve && stats.ts.Before(snapshotTs) {
-			o.sealedDiskSize.Add(-stats.diskSize)
+		remove := !intarget && !reserve && stats.ts.Before(snapshotTs)
+		diskSize := stats.diskSize
+		stats.Unlock()
+		if remove {
+			o.sealedDiskSize.Add(-diskSize)
 			stats.Remove()
 			o.sealed.Remove(segmentID)
 		}

--- a/internal/querynodev2/delegator/idf_oracle_test.go
+++ b/internal/querynodev2/delegator/idf_oracle_test.go
@@ -26,8 +26,11 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks"
@@ -92,11 +95,19 @@ func (s *IDFOracleSuite) waitTargetVersion(targetVersion int64) {
 }
 
 func (suite *IDFOracleSuite) genStats(start uint32, end uint32) map[int64]*storage.BM25Stats {
+	return suite.genStatsForField(102, start, end)
+}
+
+func (suite *IDFOracleSuite) genStatsForField(fieldID int64, start uint32, end uint32) map[int64]*storage.BM25Stats {
+	return genBM25StatsForField(fieldID, start, end)
+}
+
+func genBM25StatsForField(fieldID int64, start uint32, end uint32) map[int64]*storage.BM25Stats {
 	result := make(map[int64]*storage.BM25Stats)
-	result[102] = storage.NewBM25Stats()
+	result[fieldID] = storage.NewBM25Stats()
 	for i := start; i < end; i++ {
 		row := map[uint32]float32{i: 1}
-		result[102].Append(row)
+		result[fieldID].Append(row)
 	}
 	return result
 }
@@ -116,15 +127,23 @@ func (suite *IDFOracleSuite) registerSealed(segID int64, start uint32, end uint3
 		&bytesFileReader{bytes.NewReader(data)}, nil,
 	).Maybe()
 
-	bm25Logs := []*datapb.FieldBinlog{{
-		FieldID: 102,
-		Binlogs: []*datapb.Binlog{{LogPath: remotePath}},
-	}}
+	bm25Logs := bm25LogsForField(102, remotePath)
 
 	diskBefore := suite.idfOracle.sealedDiskSize.Load()
 	err = suite.idfOracle.LoadSealed(context.Background(), segID, &querypb.SegmentLoadInfo{Bm25Logs: bm25Logs}, cm)
 	suite.Require().NoError(err)
 	return suite.idfOracle.sealedDiskSize.Load() - diskBefore
+}
+
+func bm25LogsForField(fieldID int64, paths ...string) []*datapb.FieldBinlog {
+	binlogs := make([]*datapb.Binlog, 0, len(paths))
+	for _, logPath := range paths {
+		binlogs = append(binlogs, &datapb.Binlog{LogPath: logPath})
+	}
+	return []*datapb.FieldBinlog{{
+		FieldID: fieldID,
+		Binlogs: binlogs,
+	}}
 }
 
 // update test snapshot
@@ -436,10 +455,7 @@ func (suite *IDFOracleSuite) TestLoadSealedFailureCleanup() {
 		nil, errors.New("remote read failed"),
 	)
 
-	bm25Logs := []*datapb.FieldBinlog{{
-		FieldID: 102,
-		Binlogs: []*datapb.Binlog{{LogPath: remotePath}},
-	}}
+	bm25Logs := bm25LogsForField(102, remotePath)
 
 	err := suite.idfOracle.LoadSealed(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25Logs}, cm)
 	suite.Error(err)
@@ -456,4 +472,511 @@ func (suite *IDFOracleSuite) TestLoadSealedFailureCleanup() {
 
 func TestIDFOracle(t *testing.T) {
 	suite.Run(t, new(IDFOracleSuite))
+}
+
+func TestLoadSealedForReopenLoadsOnlyMissingFields(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	oldStats := genBM25StatsForField(102, 1, 3)
+	oldData, err := oldStats[102].Serialize()
+	require.NoError(t, err)
+	oldPath := "bm25stats/seg_1/field_102/0"
+	cm := mocks.NewChunkManager(t)
+	cm.EXPECT().Reader(mock.Anything, oldPath).Return(
+		&bytesFileReader{bytes.NewReader(oldData)}, nil,
+	).Once()
+	err = idfOracle.LoadSealed(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(102, oldPath)}, cm)
+	require.NoError(t, err)
+	diskSize := idfOracle.sealedDiskSize.Load()
+
+	newStats := genBM25StatsForField(104, 10, 13)
+	newData, err := newStats[104].Serialize()
+	require.NoError(t, err)
+	newPath := "bm25stats/seg_1/field_104/0"
+	cm.EXPECT().Reader(mock.Anything, newPath).Return(
+		&bytesFileReader{bytes.NewReader(newData)}, nil,
+	).Once()
+
+	reopenInfo := &querypb.SegmentLoadInfo{
+		Bm25Logs: append(
+			bm25LogsForField(102, oldPath),
+			bm25LogsForField(104, newPath)...,
+		),
+	}
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, reopenInfo, cm, false)
+	require.NoError(t, err)
+
+	sealedStats, ok := idfOracle.sealed.Get(1)
+	require.True(t, ok)
+	assert.ElementsMatch(t, []int64{102, 104}, sealedStats.FieldList())
+	assert.Greater(t, idfOracle.sealedDiskSize.Load(), diskSize)
+	fetched, err := sealedStats.FetchStats()
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), fetched[102].NumRow())
+	assert.Equal(t, int64(3), fetched[104].NumRow())
+}
+
+func TestLoadSealedForReopenIdempotentAfterSuccess(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	sealedStats := &sealedBm25Stats{
+		ts:        time.Now(),
+		activate:  atomic.NewBool(false),
+		segmentID: 1,
+		localDir:  path.Join(idfOracle.dirPath, "1"),
+		fieldList: []int64{102},
+		diskSize:  7,
+	}
+	idfOracle.sealed.Insert(1, sealedStats)
+	idfOracle.sealedDiskSize.Store(7)
+
+	newStats := genBM25StatsForField(104, 10, 13)
+	data, err := newStats[104].Serialize()
+	require.NoError(t, err)
+
+	cm := mocks.NewChunkManager(t)
+	remotePath := "bm25stats/seg_1/field_104/0"
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(
+		&bytesFileReader{bytes.NewReader(data)}, nil,
+	).Once()
+
+	reopenInfo := &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(104, remotePath)}
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, reopenInfo, cm, false)
+	require.NoError(t, err)
+	diskSize := idfOracle.sealedDiskSize.Load()
+
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, reopenInfo, cm, false)
+	require.NoError(t, err)
+	assert.Equal(t, diskSize, idfOracle.sealedDiskSize.Load())
+}
+
+func TestLoadSealedForReopenActivatesExistingInactiveSegment(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{103},
+		OutputFieldIds: []int64{104},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	newStats := genBM25StatsForField(104, 10, 13)
+	data, err := newStats[104].Serialize()
+	require.NoError(t, err)
+
+	cm := mocks.NewChunkManager(t)
+	remotePath := "bm25stats/seg_1/field_104/0"
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(
+		&bytesFileReader{bytes.NewReader(data)}, nil,
+	).Once()
+	reopenInfo := &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(104, remotePath)}
+
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, reopenInfo, cm, false)
+	require.NoError(t, err)
+	sealedStats, ok := idfOracle.sealed.Get(1)
+	require.True(t, ok)
+	require.False(t, sealedStats.activate.Load())
+	current, err := idfOracle.current.GetStats(104)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), current.NumRow())
+
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, reopenInfo, cm, true)
+	require.NoError(t, err)
+	assert.True(t, sealedStats.activate.Load())
+	current, err = idfOracle.current.GetStats(104)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), current.NumRow())
+}
+
+func TestLoadSealedForReopenCreatesMissingSegmentEntry(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{104},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	newStats := genBM25StatsForField(104, 10, 13)
+	data, err := newStats[104].Serialize()
+	require.NoError(t, err)
+
+	cm := mocks.NewChunkManager(t)
+	remotePath := "bm25stats/seg_1/field_104/0"
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(
+		&bytesFileReader{bytes.NewReader(data)}, nil,
+	).Once()
+
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(104, remotePath)}, cm, false)
+	require.NoError(t, err)
+
+	sealedStats, ok := idfOracle.sealed.Get(1)
+	require.True(t, ok)
+	assert.ElementsMatch(t, []int64{104}, sealedStats.FieldList())
+	fetched, err := sealedStats.FetchStats()
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), fetched[104].NumRow())
+}
+
+func TestLoadSealedForReopenFailureCleanupPreservesExistingFields(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	oldFieldDir := path.Join(idfOracle.dirPath, "1", "102")
+	require.NoError(t, os.MkdirAll(oldFieldDir, os.ModePerm))
+	require.NoError(t, os.WriteFile(path.Join(oldFieldDir, "0.data"), []byte("keep"), 0o600))
+	sealedStats := &sealedBm25Stats{
+		ts:        time.Now(),
+		activate:  atomic.NewBool(false),
+		segmentID: 1,
+		localDir:  path.Join(idfOracle.dirPath, "1"),
+		fieldList: []int64{102},
+		diskSize:  4,
+	}
+	idfOracle.sealed.Insert(1, sealedStats)
+	idfOracle.sealedDiskSize.Store(4)
+
+	cm := mocks.NewChunkManager(t)
+	remotePath := "bm25stats/seg_1/field_104/0"
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(
+		nil, errors.New("remote read failed"),
+	).Once()
+
+	err := idfOracle.LoadSealedForReopen(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(104, remotePath)}, cm, false)
+	require.Error(t, err)
+
+	sealedStats, ok := idfOracle.sealed.Get(1)
+	require.True(t, ok)
+	assert.ElementsMatch(t, []int64{102}, sealedStats.FieldList())
+	assert.Equal(t, int64(4), idfOracle.sealedDiskSize.Load())
+	_, err = os.Stat(oldFieldDir)
+	assert.NoError(t, err)
+	_, err = os.Stat(path.Join(idfOracle.dirPath, "1", "104"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestActiveReopenBM25MergesNewFieldStats(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+	}, {
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{103},
+		OutputFieldIds: []int64{104},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	sealedStats := &sealedBm25Stats{
+		ts:        time.Now(),
+		activate:  atomic.NewBool(true),
+		segmentID: 1,
+		localDir:  path.Join(idfOracle.dirPath, "1"),
+		fieldList: []int64{102},
+		diskSize:  7,
+	}
+	idfOracle.sealed.Insert(1, sealedStats)
+	idfOracle.sealedDiskSize.Store(7)
+
+	newStats := genBM25StatsForField(104, 10, 13)
+	data, err := newStats[104].Serialize()
+	require.NoError(t, err)
+
+	cm := mocks.NewChunkManager(t)
+	remotePath := "bm25stats/seg_1/field_104/0"
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(
+		&bytesFileReader{bytes.NewReader(data)}, nil,
+	).Once()
+
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(104, remotePath)}, cm, false)
+	require.NoError(t, err)
+
+	current, err := idfOracle.current.GetStats(104)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), current.NumRow())
+	assert.True(t, sealedStats.activate.Load())
+}
+
+func TestReadableReopenBM25MergesNewFieldStats(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{103},
+		OutputFieldIds: []int64{104},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	newStats := genBM25StatsForField(104, 10, 13)
+	data, err := newStats[104].Serialize()
+	require.NoError(t, err)
+
+	cm := mocks.NewChunkManager(t)
+	remotePath := "bm25stats/seg_1/field_104/0"
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(
+		&bytesFileReader{bytes.NewReader(data)}, nil,
+	).Once()
+
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(104, remotePath)}, cm, true)
+	require.NoError(t, err)
+
+	sealedStats, ok := idfOracle.sealed.Get(1)
+	require.True(t, ok)
+	assert.True(t, sealedStats.activate.Load())
+	current, err := idfOracle.current.GetStats(104)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), current.NumRow())
+}
+
+func TestReadableReopenBM25ActivatesExistingInactiveSegment(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+	}, {
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{103},
+		OutputFieldIds: []int64{104},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	// Keep the initial load inactive so this test exercises reopen activation.
+	idfOracle.targetVersion.Store(1)
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	oldStats := genBM25StatsForField(102, 1, 3)
+	oldData, err := oldStats[102].Serialize()
+	require.NoError(t, err)
+	oldPath := "bm25stats/seg_1/field_102/0"
+
+	newStats := genBM25StatsForField(104, 10, 13)
+	newData, err := newStats[104].Serialize()
+	require.NoError(t, err)
+	newPath := "bm25stats/seg_1/field_104/0"
+
+	cm := mocks.NewChunkManager(t)
+	cm.EXPECT().Reader(mock.Anything, oldPath).Return(
+		&bytesFileReader{bytes.NewReader(oldData)}, nil,
+	).Once()
+	cm.EXPECT().Reader(mock.Anything, newPath).Return(
+		&bytesFileReader{bytes.NewReader(newData)}, nil,
+	).Once()
+
+	err = idfOracle.LoadSealed(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(102, oldPath)}, cm)
+	require.NoError(t, err)
+	sealedStats, ok := idfOracle.sealed.Get(1)
+	require.True(t, ok)
+	require.False(t, sealedStats.activate.Load())
+	current, err := idfOracle.current.GetStats(102)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), current.NumRow())
+
+	reopenInfo := &querypb.SegmentLoadInfo{
+		Bm25Logs: append(
+			bm25LogsForField(102, oldPath),
+			bm25LogsForField(104, newPath)...,
+		),
+	}
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, reopenInfo, cm, true)
+	require.NoError(t, err)
+
+	assert.True(t, sealedStats.activate.Load())
+	current, err = idfOracle.current.GetStats(102)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), current.NumRow())
+	current, err = idfOracle.current.GetStats(104)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), current.NumRow())
+}
+
+func TestReadableReopenBM25RetryDoesNotDoubleMerge(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{103},
+		OutputFieldIds: []int64{104},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	newStats := genBM25StatsForField(104, 10, 13)
+	data, err := newStats[104].Serialize()
+	require.NoError(t, err)
+
+	cm := mocks.NewChunkManager(t)
+	remotePath := "bm25stats/seg_1/field_104/0"
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(
+		&bytesFileReader{bytes.NewReader(data)}, nil,
+	).Once()
+	reopenInfo := &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(104, remotePath)}
+
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, reopenInfo, cm, true)
+	require.NoError(t, err)
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, reopenInfo, cm, true)
+	require.NoError(t, err)
+
+	current, err := idfOracle.current.GetStats(104)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), current.NumRow())
+}
+
+func TestSyncDistributionReopenBM25InactiveThenActivate(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{103},
+		OutputFieldIds: []int64{104},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	newStats := genBM25StatsForField(104, 10, 13)
+	data, err := newStats[104].Serialize()
+	require.NoError(t, err)
+
+	cm := mocks.NewChunkManager(t)
+	remotePath := "bm25stats/seg_1/field_104/0"
+	cm.EXPECT().Reader(mock.Anything, remotePath).Return(
+		&bytesFileReader{bytes.NewReader(data)}, nil,
+	).Once()
+
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(104, remotePath)}, cm, false)
+	require.NoError(t, err)
+	current, err := idfOracle.current.GetStats(104)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), current.NumRow())
+
+	idfOracle.SetNext(&snapshot{
+		dist: []SnapshotItem{{
+			NodeID:   1,
+			Segments: []SegmentEntry{{NodeID: 1, SegmentID: 1, TargetVersion: 1}},
+		}},
+		targetVersion: 1,
+	})
+	require.Eventually(t, func() bool {
+		return idfOracle.TargetVersion() >= 1
+	}, time.Second, 10*time.Millisecond)
+
+	current, err = idfOracle.current.GetStats(104)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), current.NumRow())
+}
+
+func TestSealedBM25StatsFieldTracking(t *testing.T) {
+	stats := &sealedBm25Stats{
+		activate:  atomic.NewBool(false),
+		segmentID: 1,
+		fieldList: []int64{102},
+	}
+
+	assert.True(t, stats.HasField(102))
+	assert.False(t, stats.HasField(104))
+	assert.ElementsMatch(t, []int64{102}, stats.FieldList())
+
+	listOnlyStats := &sealedBm25Stats{fieldList: []int64{201}}
+	assert.True(t, listOnlyStats.HasField(201))
+	assert.False(t, listOnlyStats.HasField(202))
+
+	stats.AddFields([]int64{104, 102})
+	assert.True(t, stats.HasField(102))
+	assert.True(t, stats.HasField(104))
+	assert.ElementsMatch(t, []int64{102, 104}, stats.FieldList())
+}
+
+func TestIDFSyncFunctionsAddsNewBM25Field(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	oldStats := storage.NewBM25Stats()
+	oldStats.Append(map[uint32]float32{1: 1})
+	idfOracle.current[102] = oldStats
+
+	err := idfOracle.SyncFunctions([]*schemapb.FunctionSchema{
+		{
+			Type:           schemapb.FunctionType_BM25,
+			InputFieldIds:  []int64{101},
+			OutputFieldIds: []int64{102},
+		},
+		{
+			Type:           schemapb.FunctionType_BM25,
+			InputFieldIds:  []int64{103},
+			OutputFieldIds: []int64{104},
+		},
+	})
+	require.NoError(t, err)
+
+	existing, err := idfOracle.current.GetStats(102)
+	require.NoError(t, err)
+	assert.Same(t, oldStats, existing)
+	added, err := idfOracle.current.GetStats(104)
+	require.NoError(t, err)
+	require.NotNil(t, added)
+	assert.Equal(t, int64(0), added.NumRow())
+
+	sparse := typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{7: 1})
+	_, avgdl, err := idfOracle.BuildIDF(104, &schemapb.SparseFloatArray{Contents: [][]byte{sparse}, Dim: 1})
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), avgdl)
+}
+
+func TestBuildIDFNewFieldAfterSyncFunctions(t *testing.T) {
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	sparse := typeutil.CreateAndSortSparseFloatRow(map[uint32]float32{7: 1})
+	_, _, err := idfOracle.BuildIDF(104, &schemapb.SparseFloatArray{Contents: [][]byte{sparse}, Dim: 1})
+	require.Error(t, err)
+
+	err = idfOracle.SyncFunctions([]*schemapb.FunctionSchema{
+		{
+			Type:           schemapb.FunctionType_BM25,
+			InputFieldIds:  []int64{101},
+			OutputFieldIds: []int64{102},
+		},
+		{
+			Type:           schemapb.FunctionType_BM25,
+			InputFieldIds:  []int64{103},
+			OutputFieldIds: []int64{104},
+		},
+	})
+	require.NoError(t, err)
+
+	_, avgdl, err := idfOracle.BuildIDF(104, &schemapb.SparseFloatArray{Contents: [][]byte{sparse}, Dim: 1})
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), avgdl)
 }

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -78,7 +78,13 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 	}
 
 	if nodeMsg.schema != nil {
-		dNode.delegator.UpdateSchema(context.Background(), nodeMsg.schema, nodeMsg.schemaVersion)
+		if err := dNode.delegator.UpdateSchema(context.Background(), nodeMsg.schema, nodeMsg.schemaVersion); err != nil {
+			log.Warn("failed to update schema in delete node",
+				zap.Int64("collectionID", dNode.collectionID),
+				zap.String("channel", dNode.channel),
+				zap.Uint64("schemaVersion", nodeMsg.schemaVersion),
+				zap.Error(err))
+		}
 	}
 
 	// update tSafe

--- a/internal/querynodev2/segments/index_meta.go
+++ b/internal/querynodev2/segments/index_meta.go
@@ -1,0 +1,60 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segments
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+// ComposeIndexMeta builds segcore CollectionIndexMeta from coordinator index infos.
+func ComposeIndexMeta(ctx context.Context, indexInfos []*indexpb.IndexInfo, schema *schemapb.CollectionSchema) *segcorepb.CollectionIndexMeta {
+	fieldIndexMetas := make([]*segcorepb.FieldIndexMeta, 0, len(indexInfos))
+	for _, info := range indexInfos {
+		fieldIndexMetas = append(fieldIndexMetas, &segcorepb.FieldIndexMeta{
+			CollectionID:    info.GetCollectionID(),
+			FieldID:         info.GetFieldID(),
+			IndexName:       info.GetIndexName(),
+			TypeParams:      info.GetTypeParams(),
+			IndexParams:     info.GetIndexParams(),
+			IsAutoIndex:     info.GetIsAutoIndex(),
+			UserIndexParams: info.GetUserIndexParams(),
+		})
+	}
+	sizePerRecord, err := typeutil.EstimateSizePerRecord(schema)
+	maxIndexRecordPerSegment := int64(0)
+	if err != nil || sizePerRecord == 0 {
+		log.Ctx(ctx).Warn("failed to transfer segment size to collection, because failed to estimate size per record", zap.Error(err))
+	} else {
+		threshold := paramtable.Get().DataCoordCfg.SegmentMaxSize.GetAsFloat() * 1024 * 1024
+		proportion := paramtable.Get().DataCoordCfg.SegmentSealProportion.GetAsFloat()
+		maxIndexRecordPerSegment = int64(threshold * proportion / float64(sizePerRecord))
+	}
+
+	return &segcorepb.CollectionIndexMeta{
+		IndexMetas:       fieldIndexMetas,
+		MaxIndexRowCount: maxIndexRecordPerSegment,
+	}
+}

--- a/internal/querynodev2/segments/index_meta_test.go
+++ b/internal/querynodev2/segments/index_meta_test.go
@@ -1,0 +1,22 @@
+package segments
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
+)
+
+func TestComposeIndexMeta(t *testing.T) {
+	ctx := context.Background()
+	schema := mock_segcore.GenTestCollectionSchema("test", schemapb.DataType_Int64, false)
+	indexInfos := mock_segcore.GenTestIndexInfoList(1, schema)
+
+	meta := ComposeIndexMeta(ctx, indexInfos, schema)
+	require.NotNil(t, meta)
+	require.NotEmpty(t, meta.GetIndexMetas())
+	require.Greater(t, meta.GetMaxIndexRowCount(), int64(0))
+}

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -665,6 +665,40 @@ func (s *LocalSegment) ResetIndexesLazyLoad(lazyState bool) {
 	}
 }
 
+func (s *LocalSegment) syncFieldIndexes(indexInfos []*querypb.FieldIndexInfo) {
+	isLoadedByIndexID := make(map[int64]bool)
+	loadedForNewIndex := !s.IsLazyLoad()
+	for _, index := range s.Indexes() {
+		isLoadedByIndexID[index.IndexInfo.GetIndexID()] = index.IsLoaded
+	}
+
+	indexIDs := typeutil.NewSet[int64]()
+	for _, indexInfo := range indexInfos {
+		indexID := indexInfo.GetIndexID()
+		indexIDs.Insert(indexID)
+		isLoaded, ok := isLoadedByIndexID[indexID]
+		if !ok {
+			isLoaded = loadedForNewIndex
+		}
+		s.fieldIndexes.Insert(indexID, &IndexedFieldInfo{
+			FieldBinlog: &datapb.FieldBinlog{
+				FieldID: indexInfo.GetFieldID(),
+			},
+			IndexInfo: indexInfo,
+			IsLoaded:  isLoaded,
+		})
+	}
+
+	// QueryCoord builds reopen LoadInfo from DataCoord's full finished-index list for this segment.
+	// Treat absent index IDs as stale local metadata.
+	s.fieldIndexes.Range(func(indexID int64, _ *IndexedFieldInfo) bool {
+		if !indexIDs.Contain(indexID) {
+			s.fieldIndexes.Remove(indexID)
+		}
+		return true
+	})
+}
+
 // Search executes a search on the segment.
 // If searchReq.FilterOnly() is true, only executes the filter and returns valid_count (Stage 1 of two-stage search).
 func (s *LocalSegment) Search(ctx context.Context, searchReq *segcore.SearchRequest) (*segcore.SearchResult, error) {
@@ -1402,6 +1436,7 @@ func (s *LocalSegment) Reopen(ctx context.Context, newLoadInfo *querypb.SegmentL
 	if err != nil {
 		return err
 	}
+	s.syncFieldIndexes(newLoadInfo.GetIndexInfos())
 	s.loadInfo.Store(newLoadInfo)
 	s.syncFieldJSONStatsFromLoadInfo(ctx, newLoadInfo)
 	return nil

--- a/internal/querynodev2/services.go
+++ b/internal/querynodev2/services.go
@@ -32,7 +32,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
-	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/querynodev2/tasks"
@@ -47,10 +46,8 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
-	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/conc"
 	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
@@ -168,35 +165,6 @@ func (node *QueryNode) GetStatistics(ctx context.Context, req *querypb.GetStatis
 	return ret, nil
 }
 
-func (node *QueryNode) composeIndexMeta(ctx context.Context, indexInfos []*indexpb.IndexInfo, schema *schemapb.CollectionSchema) *segcorepb.CollectionIndexMeta {
-	fieldIndexMetas := make([]*segcorepb.FieldIndexMeta, 0)
-	for _, info := range indexInfos {
-		fieldIndexMetas = append(fieldIndexMetas, &segcorepb.FieldIndexMeta{
-			CollectionID:    info.GetCollectionID(),
-			FieldID:         info.GetFieldID(),
-			IndexName:       info.GetIndexName(),
-			TypeParams:      info.GetTypeParams(),
-			IndexParams:     info.GetIndexParams(),
-			IsAutoIndex:     info.GetIsAutoIndex(),
-			UserIndexParams: info.GetUserIndexParams(),
-		})
-	}
-	sizePerRecord, err := typeutil.EstimateSizePerRecord(schema)
-	maxIndexRecordPerSegment := int64(0)
-	if err != nil || sizePerRecord == 0 {
-		log.Ctx(ctx).Warn("failed to transfer segment size to collection, because failed to estimate size per record", zap.Error(err))
-	} else {
-		threshold := paramtable.Get().DataCoordCfg.SegmentMaxSize.GetAsFloat() * 1024 * 1024
-		proportion := paramtable.Get().DataCoordCfg.SegmentSealProportion.GetAsFloat()
-		maxIndexRecordPerSegment = int64(threshold * proportion / float64(sizePerRecord))
-	}
-
-	return &segcorepb.CollectionIndexMeta{
-		IndexMetas:       fieldIndexMetas,
-		MaxIndexRowCount: maxIndexRecordPerSegment,
-	}
-}
-
 // WatchDmChannels create consumers on dmChannels to receive Incremental data，which is the important part of real-time query
 func (node *QueryNode) WatchDmChannels(ctx context.Context, req *querypb.WatchDmChannelsRequest) (status *commonpb.Status, e error) {
 	defer node.updateDistributionModifyTS()
@@ -245,7 +213,7 @@ func (node *QueryNode) WatchDmChannels(ctx context.Context, req *querypb.WatchDm
 	}
 
 	err := node.manager.Collection.PutOrRef(req.GetCollectionID(), req.GetSchema(),
-		node.composeIndexMeta(ctx, req.GetIndexInfoList(), req.Schema), req.GetLoadMeta())
+		segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), req.Schema), req.GetLoadMeta())
 	if err != nil {
 		log.Warn("failed to ref collection", zap.Error(err))
 		return merr.Status(err), nil
@@ -505,7 +473,7 @@ func (node *QueryNode) LoadSegments(ctx context.Context, req *querypb.LoadSegmen
 	}
 
 	err := node.manager.Collection.PutOrRef(req.GetCollectionID(), req.GetSchema(),
-		node.composeIndexMeta(ctx, req.GetIndexInfoList(), req.GetSchema()), req.GetLoadMeta())
+		segments.ComposeIndexMeta(ctx, req.GetIndexInfoList(), req.GetSchema()), req.GetLoadMeta())
 	if err != nil {
 		log.Warn("failed to ref collection", zap.Error(err))
 		return merr.Status(err), nil

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -1359,7 +1359,7 @@ func (suite *ServiceSuite) TestSearch_Failed() {
 		CollectionID: suite.collectionID,
 		PartitionIDs: suite.partitionIDs,
 	}
-	indexMeta := suite.node.composeIndexMeta(ctx, mock_segcore.GenTestIndexInfoList(suite.collectionID, schema), schema)
+	indexMeta := segments.ComposeIndexMeta(ctx, mock_segcore.GenTestIndexInfoList(suite.collectionID, schema), schema)
 	suite.node.manager.Collection.PutOrRef(suite.collectionID, schema, indexMeta, LoadMeta)
 
 	// Delegator not found

--- a/tests/python_client/milvus_client/test_add_field_feature.py
+++ b/tests/python_client/milvus_client/test_add_field_feature.py
@@ -188,7 +188,7 @@ class TestMilvusClientAddFieldFeature(TestMilvusClientV2Base):
         # search on the new added null vector field fails for no reloading for it yet
         error = {
             ct.err_code: 999,
-            ct.err_msg: f"field {new_vec_field_name} is not loaded, please reload the collection",
+            ct.err_msg: f"field index of the field: {new_vec_field_name} is not loaded, please reload the collection",
         }
         self.search(
             client,
@@ -1229,7 +1229,10 @@ class TestMilvusClientAddFieldFeature(TestMilvusClientV2Base):
         # 5. verify search on new field fails before indexing (field not loaded)
         search_vecs = cf.gen_vectors(ct.default_nq, search_dim, vector_data_type=vector_type)
         # err_code 999 = gRPC unknown; Milvus uses it for "field not loaded" and "no index" errors
-        error = {ct.err_code: 999, ct.err_msg: f"field {new_vec_field} is not loaded, please reload the collection"}
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: f"field index of the field: {new_vec_field} is not loaded, please reload the collection",
+        }
         self.search(
             client,
             collection_name,


### PR DESCRIPTION
issue: #48808

## Summary
- sync delegator function/analyzer runtime state on schema update
- allow additive BM25 function fields in the IDF oracle without dropping existing stats
- route Reopen BM25 stats through the delegator oracle with field-level idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)