### PR TITLE
fix: validate REST request timeout header

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -656,6 +656,39 @@ func TestTimeoutMiddlewarePassesDeadline(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestTimeoutMiddlewareRejectsInvalidRequestTimeout(t *testing.T) {
+	for _, requestTimeout := range []string{"3.5", "abc"} {
+		t.Run(requestTimeout, func(t *testing.T) {
+			ginHandler := gin.New()
+			path := "/middleware/timeout/invalid"
+			called := make(chan struct{}, 1)
+			ginHandler.POST(path, timeoutMiddleware(func(c *gin.Context) {
+				called <- struct{}{}
+				HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil)})
+			}))
+
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			req.Header.Set(mhttp.HTTPHeaderRequestTimeout, requestTimeout)
+			w := httptest.NewRecorder()
+			ginHandler.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			err := json.Unmarshal(w.Body.Bytes(), returnBody)
+			assert.NoError(t, err)
+			assert.Equal(t, merr.Code(merr.ErrParameterInvalid), returnBody.Code)
+			assert.Contains(t, returnBody.Message, mhttp.HTTPHeaderRequestTimeout)
+			assert.Contains(t, returnBody.Message, requestTimeout)
+
+			select {
+			case <-called:
+				t.Fatal("handler was invoked for invalid Request-Timeout")
+			default:
+			}
+		})
+	}
+}
+
 func TestDocInDocOutCreateCollection(t *testing.T) {
 	paramtable.Init()
 	// disable rate limit

--- a/internal/distributed/proxy/httpserver/timeout_middleware.go
+++ b/internal/distributed/proxy/httpserver/timeout_middleware.go
@@ -241,8 +241,20 @@ func timeoutMiddleware(handler gin.HandlerFunc) gin.HandlerFunc {
 	bufPool := &BufferPool{}
 	return func(gCtx *gin.Context) {
 		timeout := paramtable.Get().HTTPCfg.RequestTimeoutMs.GetAsDuration(time.Millisecond)
-		timeoutSecond, err := strconv.ParseInt(gCtx.Request.Header.Get(mhttp.HTTPHeaderRequestTimeout), 10, 64)
-		if err == nil {
+		requestTimeout := gCtx.Request.Header.Get(mhttp.HTTPHeaderRequestTimeout)
+		if requestTimeout != "" {
+			timeoutSecond, err := strconv.ParseInt(requestTimeout, 10, 64)
+			if err != nil {
+				HTTPAbortReturn(gCtx, http.StatusOK, gin.H{
+					mhttp.HTTPReturnCode: merr.Code(merr.ErrParameterInvalid),
+					mhttp.HTTPReturnMessage: merr.WrapErrParameterInvalidMsg(
+						"%s parse failed, err: %s",
+						mhttp.HTTPHeaderRequestTimeout,
+						err.Error(),
+					).Error(),
+				})
+				return
+			}
 			timeout = time.Duration(timeoutSecond) * time.Second
 		}
 		topCtx, cancel := context.WithTimeout(gCtx.Request.Context(), timeout)


### PR DESCRIPTION
fixes: #49890

This PR validates the REST `Request-Timeout` header instead of silently ignoring invalid values.

Changes:
- Return `ErrParameterInvalid` when `Request-Timeout` is present but cannot be parsed as an integer.
- Preserve the underlying `strconv.ParseInt` error in the response message.
- Add timeout middleware coverage for invalid values such as `3.5` and `abc`.

Test:
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/distributed/proxy/httpserver -run 'TestTimeoutMiddleware'` *(fails locally because generated C/CGo headers are unavailable: `storage/loon_ffi/external_spec_c.h`, `C.CArrowReaderConfig`)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)