### PR TITLE
fix: external collection query_iterator fails with fieldID(1) not found

### DIFF
--- a/internal/util/typeutil/result_helper.go
+++ b/internal/util/typeutil/result_helper.go
@@ -2,6 +2,7 @@ package typeutil
 
 import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -25,6 +26,17 @@ func FillRetrieveResultIfEmpty(result RetrieveResults, outputFieldIDs []int64, s
 		return err
 	}
 	for _, outputFieldID := range outputFieldIDs {
+		// System fields (RowID=0, Timestamp=1) are never part of the user/collection
+		// schema, but the proxy appends common.TimeStampField to OutputFieldsId for
+		// the iterator MVCC dedup. The non-empty retrieve path emits them as Int64
+		// columns (synthesized for external collections), so the empty-fill path must
+		// do the same instead of failing the schema lookup with "fieldID(1) not found".
+		// See https://github.com/milvus-io/milvus/issues/50188.
+		if common.IsSystemField(outputFieldID) {
+			appendFieldData(result, genEmptySystemFieldData(outputFieldID))
+			continue
+		}
+
 		field, err := helper.GetFieldFromID(outputFieldID)
 		if err != nil {
 			return err
@@ -39,4 +51,26 @@ func FillRetrieveResultIfEmpty(result RetrieveResults, outputFieldIDs []int64, s
 	}
 
 	return nil
+}
+
+// genEmptySystemFieldData builds an empty Int64 field data for a reserved system
+// field (RowID / Timestamp). System fields are stored as Int64 in segcore and are
+// not present in the user collection schema, so they cannot be resolved via the
+// SchemaHelper.
+func genEmptySystemFieldData(fieldID int64) *schemapb.FieldData {
+	name := ""
+	switch fieldID {
+	case common.RowIDField:
+		name = common.RowIDFieldName
+	case common.TimeStampField:
+		name = common.TimeStampFieldName
+	}
+	field := &schemapb.FieldSchema{
+		FieldID:  fieldID,
+		Name:     name,
+		DataType: schemapb.DataType_Int64,
+	}
+	// GenEmptyFieldData never returns an error for the Int64 data type.
+	emptyFieldData, _ := typeutil.GenEmptyFieldData(field)
+	return emptyFieldData
 }

--- a/internal/util/typeutil/result_helper_test.go
+++ b/internal/util/typeutil/result_helper_test.go
@@ -282,4 +282,77 @@ func TestFillIfEmpty(t *testing.T) {
 			assert.True(t, fieldDataEmpty(fieldData))
 		}
 	})
+
+	// System fields (RowID=0, Timestamp=1) are never part of the user/collection
+	// schema, but the proxy appends common.TimeStampField to OutputFieldsId for
+	// MVCC dedup. For external collections the segcore synthesizes these as Int64
+	// columns, so the empty-fill path must emit them as empty Int64 columns too,
+	// instead of failing the schema lookup with "fieldID(1) not found".
+	// See https://github.com/milvus-io/milvus/issues/50188.
+	t.Run("system field with external collection schema", func(t *testing.T) {
+		result := &segcorepb.RetrieveResults{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{
+					IntId: &schemapb.LongArray{
+						Data: nil,
+					},
+				},
+			},
+		}
+		// External collection schema: virtual PK + user fields, no system fields.
+		schema := &schemapb.CollectionSchema{
+			Name: "external_collection",
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:      100,
+					Name:         common.VirtualPKFieldName,
+					DataType:     schemapb.DataType_Int64,
+					IsPrimaryKey: true,
+					AutoID:       true,
+				},
+				{
+					FieldID:  101,
+					Name:     "vc_tag",
+					DataType: schemapb.DataType_VarChar,
+				},
+			},
+		}
+		// OutputFieldsId carries the system timestamp field appended by the proxy.
+		err := FillRetrieveResultIfEmpty(NewSegcoreResults(result),
+			[]int64{101, common.TimeStampField}, schema)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(result.GetFieldsData()))
+
+		var tsFieldData *schemapb.FieldData
+		for _, fieldData := range result.GetFieldsData() {
+			assert.True(t, fieldDataEmpty(fieldData))
+			if fieldData.GetFieldId() == common.TimeStampField {
+				tsFieldData = fieldData
+			}
+		}
+		assert.NotNil(t, tsFieldData)
+		assert.Equal(t, schemapb.DataType_Int64, tsFieldData.GetType())
+	})
+
+	t.Run("row id system field", func(t *testing.T) {
+		result := &segcorepb.RetrieveResults{
+			Ids: &schemapb.IDs{
+				IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: nil}},
+			},
+		}
+		schema := &schemapb.CollectionSchema{
+			Name: "external_collection",
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: common.VirtualPKFieldName, DataType: schemapb.DataType_Int64, IsPrimaryKey: true, AutoID: true},
+			},
+		}
+		err := FillRetrieveResultIfEmpty(NewSegcoreResults(result),
+			[]int64{common.RowIDField, common.TimeStampField}, schema)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(result.GetFieldsData()))
+		for _, fieldData := range result.GetFieldsData() {
+			assert.True(t, fieldDataEmpty(fieldData))
+			assert.Equal(t, schemapb.DataType_Int64, fieldData.GetType())
+		}
+	})
 }


### PR DESCRIPTION
## Issue

issue: #50188

## Problem

For external collections, `query_iterator` returns hundreds of thousands of rows and then fails with `MilvusException: (code=65535, message=fieldID(1) not found)`. Rebuilding the iterator from the last primary-key cursor reproduces the error immediately and deterministically.

## Root Cause

The proxy unconditionally appends the reserved system Timestamp field (`common.TimeStampField`, fieldID=1) to `OutputFieldsId` for the iterator MVCC dedup (`internal/proxy/task_query.go:610`).

On the QueryNode side, `FillRetrieveResultIfEmpty` is invoked when a query produces a **fully empty** result. It iterates `OutputFieldsId` and resolves each field id through the collection `SchemaHelper` to synthesize empty columns. System fields are never part of the user/collection schema, so for external collections (whose schema contains no system fields, and whose segcore synthesizes the timestamp as a constant Int64 column via `SynthesizeExternalSystemFields` / `init_timestamps_constant`) the lookup `GetFieldFromID(1)` fails with `fieldID(1) not found`.

This surfaces when the iterator paginates past the last matching row so the next batch matches zero rows, and reproduces deterministically when the iterator is rebuilt from the last cursor (the query is again empty, hence the ~20ms fail-fast).

Internal collections do not hit this because segcore returns empty-but-present field columns for zero-match queries, bypassing the empty-fill path; the underlying bug is that the Go empty-fill path does not special-case system fields the way the C++ retrieve path does.

## Fix

Special-case reserved system fields (RowID / Timestamp) in `FillRetrieveResultIfEmpty` and emit them as empty Int64 columns — matching the non-empty retrieve path (segcore emits system fields as Int64) — instead of resolving them through the schema. The proxy already strips system fields via `filterSystemFields`, so the user-facing result is unchanged.

## Test

- Added table-driven cases to `TestFillIfEmpty` covering an external-collection schema (no system fields) with `OutputFieldsId` carrying `TimeStampField`, and a RowID+Timestamp case. Both assert no error and that empty Int64 columns are emitted.
- Changed code covered at 100%.
- `go test -tags dynamic,test -gcflags="all=-N -l" ./internal/util/typeutil/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)