### PR TITLE
fix: [2.6] avoid panic for non-point WKT validation (#49719)

### DIFF
--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -823,7 +823,7 @@ func checkValidPoint(wktStr string) error {
 	if err != nil {
 		return err
 	}
-	if g.(*geom.Point) == nil {
+	if _, ok := g.(*geom.Point); !ok {
 		return fmt.Errorf("only supports POINT geometry: %s", wktStr)
 	}
 	return nil

--- a/internal/parser/planparserv2/utils_test.go
+++ b/internal/parser/planparserv2/utils_test.go
@@ -592,6 +592,14 @@ func Test_handleCompare(t *testing.T) {
 	})
 }
 
+func Test_checkValidPoint(t *testing.T) {
+	t.Run("valid non-point WKT", func(t *testing.T) {
+		err := checkValidPoint("POLYGON((0 0, 1 0, 1 1, 0 0))")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only supports POINT geometry")
+	})
+}
+
 func TestParseISO8601Duration(t *testing.T) {
 	testCases := []struct {
 		name      string


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus/pull/49719
relate: https://github.com/milvus-io/milvus/issues/49692

## Summary
Avoid panic when ST_DWITHIN validates a legal non-POINT WKT by returning a point-only validation error instead.
Add a regression test for non-POINT WKT validation.