### PR TITLE
fix: guard RootCoord AllocN batch size

### DIFF
--- a/internal/datacoord/allocator/allocator.go
+++ b/internal/datacoord/allocator/allocator.go
@@ -18,6 +18,7 @@ package allocator
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
@@ -84,13 +85,21 @@ func (alloc *rootCoordAllocator) AllocID(ctx context.Context) (typeutil.UniqueID
 	return resp.ID, nil
 }
 
-// AllocID allocates an `UniqueID` from RootCoord, invoking AllocID grpc
+// AllocN allocates `n` UniqueIDs from RootCoord, invoking AllocID grpc
 func (alloc *rootCoordAllocator) AllocN(n int64) (typeutil.UniqueID, typeutil.UniqueID, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	if n <= 0 {
 		n = 1
 	}
+	if n > math.MaxUint32 {
+		return 0, 0, merr.WrapErrParameterInvalidMsg(
+			"too large to allocate IDs in a single batch: requested %d, max %d",
+			n,
+			uint64(math.MaxUint32),
+		)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	resp, err := alloc.mixCoord.AllocID(ctx, &rootcoordpb.AllocIDRequest{
 		Base: commonpbutil.NewMsgBase(
 			commonpbutil.WithMsgType(commonpb.MsgType_RequestID),

--- a/internal/datacoord/allocator/allocator_test.go
+++ b/internal/datacoord/allocator/allocator_test.go
@@ -18,6 +18,7 @@ package allocator
 
 import (
 	"context"
+	"math"
 	"math/rand"
 	"testing"
 
@@ -90,6 +91,20 @@ func (s *RootCoordAllocatorSuite) TestAllocID() {
 }
 
 func (s *RootCoordAllocatorSuite) TestAllocN() {
+	s.Run("too_large", func() {
+		ms := mocks.NewMixCoord(s.T())
+		allocator := NewRootCoordAllocator(ms)
+		ms.EXPECT().AllocID(mock.Anything, mock.Anything).Return(&rootcoordpb.AllocIDResponse{
+			Status: merr.Success(),
+		}, nil).Maybe()
+
+		_, _, err := allocator.AllocN(math.MaxUint32 + 1)
+		s.Require().Error(err)
+		s.ErrorIs(err, merr.ErrParameterInvalid)
+		s.Contains(err.Error(), "too large to allocate IDs in a single batch: requested 4294967296, max 4294967295")
+		ms.AssertNotCalled(s.T(), "AllocID", mock.Anything, mock.Anything)
+	})
+
 	s.Run("normal", func() {
 		n := rand.Int63n(100) + 1
 		id := rand.Int63n(1000000)


### PR DESCRIPTION
RootCoord AllocN accepts int64, but RootCoord receives the batch count as uint32. Reject oversized batches before building the RPC request so the count cannot wrap and allocate fewer IDs than requested.

See also: #49919

Signed-off-by: yangxuan <xuan.yang@zilliz.com>