### PR TITLE
enhance: track RocksDB and unclassified threads

### DIFF
--- a/internal/util/metrics/thread.go
+++ b/internal/util/metrics/thread.go
@@ -62,6 +62,9 @@ var threadNameGroupRules = []struct {
 	{prefix: "knowhere_build", group: "knowhere_build"},
 	{prefix: "knowhere_search", group: "knowhere_search"},
 	{prefix: "knowhere_fetch", group: "knowhere_fetch"},
+	{prefix: "rocksdb:high", group: "rocksdb_high"},
+	{prefix: "rocksdb:low", group: "rocksdb_low"},
+	{prefix: "rocksdb:bottom", group: "rocksdb_bottom"},
 	{prefix: "MILVUS_FL_WR", group: "file_write"},
 	{prefix: "MILVUS_SEARCH", group: "milvus_search"},
 	{prefix: "MILVUS_LOAD", group: "milvus_load"},
@@ -74,7 +77,10 @@ var threadNameGroupRules = []struct {
 	{prefix: "CGO_WARMUP", group: "cgo_warmup"},
 }
 
-const threadWatcherInterval = 5 * time.Second
+const (
+	threadWatcherInterval  = 5 * time.Second
+	unclassifiedThreadPool = "unclassified"
+)
 
 func NewThreadWatcher() *threadWatcher {
 	return &threadWatcher{
@@ -131,31 +137,37 @@ func (thw *threadWatcher) updateNamedThreadCPUActiveNum() {
 		return
 	}
 
+	activeByGroup, nextSamples := collectActiveThreadGroups(current, thw.samples)
+
+	for _, rule := range threadNameGroupRules {
+		metrics.ThreadCPUActiveNumByPool.WithLabelValues(rule.group).Set(float64(activeByGroup[rule.group]))
+	}
+	metrics.ThreadCPUActiveNumByPool.WithLabelValues(unclassifiedThreadPool).Set(float64(activeByGroup[unclassifiedThreadPool]))
+	thw.samples = nextSamples
+}
+
+func collectActiveThreadGroups(current []threadStat, previous map[int32]threadSample) (map[string]int, map[int32]threadSample) {
 	activeByGroup := make(map[string]int)
 	nextSamples := make(map[int32]threadSample, len(current))
 	for _, stat := range current {
-		group, ok := classifyThreadName(stat.name)
-		if !ok {
-			continue
+		group, classified := classifyThreadName(stat.name)
+		if !classified {
+			group = unclassifiedThreadPool
 		}
 		nextSamples[stat.tid] = threadSample{
 			group: group,
 			cpu:   stat.cpu,
 		}
 
-		previous, existed := thw.samples[stat.tid]
+		previousSample, existed := previous[stat.tid]
 		if !existed {
 			continue
 		}
-		if previous.group == group && (stat.cpu > previous.cpu || stat.state == 'R' || stat.state == 'D') {
+		if previousSample.group == group && (stat.cpu > previousSample.cpu || stat.state == 'R' || stat.state == 'D') {
 			activeByGroup[group]++
 		}
 	}
-
-	for _, rule := range threadNameGroupRules {
-		metrics.ThreadCPUActiveNumByPool.WithLabelValues(rule.group).Set(float64(activeByGroup[rule.group]))
-	}
-	thw.samples = nextSamples
+	return activeByGroup, nextSamples
 }
 
 func collectNamedThreadStats() ([]threadStat, error) {
@@ -224,7 +236,7 @@ func classifyThreadName(name string) (string, bool) {
 			return rule.group, true
 		}
 	}
-	return "", false
+	return unclassifiedThreadPool, false
 }
 
 func (thw *threadWatcher) Stop() {

--- a/internal/util/metrics/thread_test.go
+++ b/internal/util/metrics/thread_test.go
@@ -53,8 +53,21 @@ func TestClassifyThreadName(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "knowhere_fetch", group)
 
-	_, ok = classifyThreadName("grpc_global_tim")
+	group, ok = classifyThreadName("rocksdb:high")
+	require.True(t, ok)
+	require.Equal(t, "rocksdb_high", group)
+
+	group, ok = classifyThreadName("rocksdb:low")
+	require.True(t, ok)
+	require.Equal(t, "rocksdb_low", group)
+
+	group, ok = classifyThreadName("rocksdb:bottom")
+	require.True(t, ok)
+	require.Equal(t, "rocksdb_bottom", group)
+
+	group, ok = classifyThreadName("grpc_global_tim")
 	require.False(t, ok)
+	require.Equal(t, unclassifiedThreadPool, group)
 }
 
 func TestParseThreadStat(t *testing.T) {
@@ -62,4 +75,30 @@ func TestParseThreadStat(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, byte('R'), state)
 	require.Equal(t, uint64(90), cpu)
+}
+
+func TestCollectActiveThreadGroups(t *testing.T) {
+	current := []threadStat{
+		{tid: 1, name: "rocksdb:high", state: 'S', cpu: 11},
+		{tid: 2, name: "arrow-worker", state: 'S', cpu: 6},
+		{tid: 3, name: "rocksdb:low", state: 'R', cpu: 1},
+		{tid: 4, name: "knowhere_search", state: 'S', cpu: 20},
+		{tid: 5, name: "rocksdb:bottom", state: 'D', cpu: 30},
+	}
+	previous := map[int32]threadSample{
+		1: {group: "rocksdb_high", cpu: 10},
+		2: {group: unclassifiedThreadPool, cpu: 5},
+		4: {group: "knowhere_fetch", cpu: 19},
+		5: {group: "rocksdb_bottom", cpu: 30},
+	}
+
+	activeByGroup, nextSamples := collectActiveThreadGroups(current, previous)
+
+	require.Equal(t, 1, activeByGroup["rocksdb_high"])
+	require.Equal(t, 1, activeByGroup[unclassifiedThreadPool])
+	require.Equal(t, 0, activeByGroup["rocksdb_low"])
+	require.Equal(t, 0, activeByGroup["knowhere_search"])
+	require.Equal(t, 1, activeByGroup["rocksdb_bottom"])
+	require.Equal(t, threadSample{group: unclassifiedThreadPool, cpu: 6}, nextSamples[2])
+	require.Len(t, nextSamples, len(current))
 }


### PR DESCRIPTION
This PR extends the named OS thread active metrics added in #50064.

- classify RocksDB background threads into `rocksdb_high`, `rocksdb_low`, and `rocksdb_bottom`
- count active named OS threads that do not match a known classification as `unclassified`
- keep `classifyThreadName` returning whether a known rule matched, while callers explicitly map unmatched threads to `unclassified`
- add focused coverage for RocksDB and unclassified active-thread accounting

issue: #50066