### PR TITLE
fix: prevent panic when outgoing metadata lacks client_request_id

### DIFF
--- a/internal/proxy/accesslog/info/grpc_info.go
+++ b/internal/proxy/accesslog/info/grpc_info.go
@@ -132,7 +132,9 @@ func (i *GrpcAccessInfo) Address() string {
 func (i *GrpcAccessInfo) TraceID() string {
 	meta, ok := metadata.FromOutgoingContext(i.ctx)
 	if ok {
-		return meta.Get(ClientRequestIDKey)[0]
+		if vals := meta.Get(ClientRequestIDKey); len(vals) > 0 {
+			return vals[0]
+		}
 	}
 
 	traceID := trace.SpanFromContext(i.ctx).SpanContext().TraceID()

--- a/internal/proxy/accesslog/info/grpc_info_test.go
+++ b/internal/proxy/accesslog/info/grpc_info_test.go
@@ -26,12 +26,12 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/suite"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"

--- a/internal/proxy/accesslog/info/grpc_info_test.go
+++ b/internal/proxy/accesslog/info/grpc_info_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -305,6 +306,50 @@ func (s *GrpcAccessInfoSuite) TestClientRequestTime() {
 	})
 	s.info.ctx = ctx
 	s.NotEqual(Unknown, Get(s.info, "$client_request_time")[0])
+}
+
+func (s *GrpcAccessInfoSuite) TestTraceID() {
+	s.Equal(Unknown, s.info.TraceID())
+
+	// 1. Test with incoming metadata (should be ignored, returns Unknown)
+	md := metadata.MD{ClientRequestIDKey: []string{"test-trace-incoming"}}
+	s.info.ctx = metadata.NewIncomingContext(context.Background(), md)
+	s.Equal(Unknown, s.info.TraceID())
+
+	// 2. Test with outgoing metadata but no client_request_id
+	md = metadata.MD{"some-other-key": []string{"value"}}
+	s.info.ctx = metadata.NewOutgoingContext(context.Background(), md)
+	s.NotPanics(func() {
+		s.Equal(Unknown, s.info.TraceID())
+	})
+
+	// 3. Test with outgoing metadata having an empty client_request_id slice
+	md = metadata.MD{ClientRequestIDKey: []string{}}
+	s.info.ctx = metadata.NewOutgoingContext(context.Background(), md)
+	s.NotPanics(func() {
+		s.Equal(Unknown, s.info.TraceID())
+	})
+
+	// 4. Test with outgoing metadata and client_request_id
+	md = metadata.MD{ClientRequestIDKey: []string{"test-trace-outgoing"}}
+	s.info.ctx = metadata.NewOutgoingContext(context.Background(), md)
+	s.Equal("test-trace-outgoing", s.info.TraceID())
+
+	// 5. Test with valid OpenTelemetry trace ID (no outgoing metadata)
+	validTraceID := trace.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    validTraceID,
+		SpanID:     trace.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctxWithTrace := trace.ContextWithSpanContext(context.Background(), spanCtx)
+	s.info.ctx = ctxWithTrace
+	s.Equal(validTraceID.String(), s.info.TraceID())
+
+	// 6. Test with valid OpenTelemetry trace ID + outgoing metadata lacking client_request_id
+	md = metadata.MD{"some-other-key": []string{"value"}}
+	s.info.ctx = metadata.NewOutgoingContext(ctxWithTrace, md)
+	s.Equal(validTraceID.String(), s.info.TraceID())
 }
 
 func (s *GrpcAccessInfoSuite) TestTemplateValueLength() {


### PR DESCRIPTION
PR Title: fix: prevent proxy access log panic when outgoing metadata lacks **client_request_id**

**Description**
I've fixed a bug (Issue #50222) where the proxy access log formatter could trigger a runtime panic. When the request context has outgoing gRPC metadata but doesn't contain the client_request_id, the old implementation attempted to index the slice unconditionally (meta.Get(ClientRequestIDKey)[0]), causing an index out of range panic.

I fixed this by safely checking the length of the slice before accessing it. If it's missing, it now **falls back to the** **OpenTelemetry trace ID or Unknown.**

**Changes I Made:**
Modified GrpcAccessInfo.TraceID() in internal/proxy/accesslog/info/grpc_info.go to safely check len(vals) > 0 before accessing index 0.
Added a comprehensive unit test suite in internal/proxy/accesslog/info/grpc_info_test.go (TestTraceID).
Edge Cases I Covered & Tested:
Empty Context: I ensured it correctly falls back to Unknown.
Incoming Metadata Only: It properly ignores client_request_id if present in incoming context rather than outgoing (or span context).
Outgoing Metadata without client_request_id: I successfully mitigated the panic! When outgoing metadata like log-level is present without a request ID, it now returns Unknown without panicking.
Outgoing Metadata with Empty Slice: Safely handles a []string{} assignment.
Outgoing Metadata with Valid client_request_id: Successfully extracts and uses the ID.
Valid OpenTelemetry Trace ID (No Metadata): Extracts the proper OTel trace ID.
Valid OpenTelemetry Trace ID (Metadata present but lacking client_request_id): It falls back correctly to the OTel trace ID when outgoing metadata is present but lacks the client request ID, which fulfills the exact requirement raised in the issue.
Related Issue
issue: #50222

Verification
I made sure the code builds and all tests pass successfully with go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy/accesslog/...
DCO sign-off provided in my commit.