### PR TITLE
enhance: support timeout_ms for function model providers

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1454,6 +1454,8 @@ credential:
 
 # Any configuration related to functions
 function:
+  model:
+    timeout_ms: 30000 # Global timeout in milliseconds for external model requests. Function param timeout_ms overrides it.
   textEmbedding:
     providers:
       azure_openai:

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1455,7 +1455,7 @@ credential:
 # Any configuration related to functions
 function:
   model:
-    timeout_ms: 30000 # Global timeout in milliseconds for external model requests. Function param timeout_ms overrides it.
+    requestTimeout: 30s # Global timeout for external model requests, e.g. 30s. Function param timeout_ms overrides it.
   textEmbedding:
     providers:
       azure_openai:

--- a/internal/proxy/highlighter_test.go
+++ b/internal/proxy/highlighter_test.go
@@ -93,7 +93,7 @@ func (s *HighlighterSuite) TestLexicalHighlighter_AsSearchPipelineOperator() {
 // ============== SemanticHighlighter Tests ==============
 
 func (s *HighlighterSuite) TestSemanticHighlighter_RequiredFieldIDs_SchemaFieldsOnly() {
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -136,7 +136,7 @@ func (s *HighlighterSuite) TestSemanticHighlighter_RequiredFieldIDs_SchemaFields
 }
 
 func (s *HighlighterSuite) TestSemanticHighlighter_RequiredFieldIDs_WithDynamicFields() {
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -182,7 +182,7 @@ func (s *HighlighterSuite) TestSemanticHighlighter_RequiredFieldIDs_WithDynamicF
 }
 
 func (s *HighlighterSuite) TestSemanticHighlighter_RequiredFieldIDs_DoesNotMutateFieldIDs() {
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -243,7 +243,7 @@ func (s *HighlighterSuite) TestSemanticHighlighter_RequiredFieldIDs_DoesNotMutat
 }
 
 func (s *HighlighterSuite) TestSemanticHighlighter_DynamicFieldNames_Empty() {
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -282,7 +282,7 @@ func (s *HighlighterSuite) TestSemanticHighlighter_DynamicFieldNames_Empty() {
 }
 
 func (s *HighlighterSuite) TestSemanticHighlighter_DynamicFieldNames_WithDynamicFields() {
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -323,7 +323,7 @@ func (s *HighlighterSuite) TestSemanticHighlighter_DynamicFieldNames_WithDynamic
 }
 
 func (s *HighlighterSuite) TestSemanticHighlighter_AsSearchPipelineOperator() {
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -389,7 +389,7 @@ func (s *HighlighterSuite) TestHighlighterInterface_LexicalHighlighter() {
 }
 
 func (s *HighlighterSuite) TestHighlighterInterface_SemanticHighlighter() {
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()

--- a/internal/util/function/embedding/ali_embedding_provider.go
+++ b/internal/util/function/embedding/ali_embedding_provider.go
@@ -38,9 +38,9 @@ type AliEmbeddingProvider struct {
 	embedDimParam int64
 	outputType    string
 
-	maxBatch   int
-	timeoutSec int64
-	extraInfo  *models.ModelExtraInfo
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
 }
 
 func createAliEmbeddingClient(apiKey string, url string) (*ali.AliDashScopeEmbedding, error) {
@@ -90,6 +90,11 @@ func NewAliDashScopeEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functio
 		maxBatch = 6
 	}
 
+	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := AliEmbeddingProvider{
 		client:        c,
 		fieldDim:      fieldDim,
@@ -98,7 +103,7 @@ func NewAliDashScopeEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functio
 		// TextEmbedding only supports dense embedding
 		outputType: "dense",
 		maxBatch:   maxBatch,
-		timeoutSec: 30,
+		timeoutMs:  timeoutMs,
 		extraInfo:  extraInfo,
 	}
 	return &provider, nil
@@ -126,7 +131,7 @@ func (provider *AliEmbeddingProvider) CallEmbedding(ctx context.Context, texts [
 		if end > numRows {
 			end = numRows
 		}
-		resp, err := provider.client.Embedding(provider.modelName, texts[i:end], int(provider.embedDimParam), textType, provider.outputType, provider.timeoutSec)
+		resp, err := provider.client.Embedding(provider.modelName, texts[i:end], int(provider.embedDimParam), textType, provider.outputType, provider.timeoutMs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/function/embedding/ali_embedding_provider.go
+++ b/internal/util/function/embedding/ali_embedding_provider.go
@@ -90,10 +90,7 @@ func NewAliDashScopeEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functio
 		maxBatch = 6
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
 
 	provider := AliEmbeddingProvider{
 		client:        c,

--- a/internal/util/function/embedding/bedrock_embedding_provider.go
+++ b/internal/util/function/embedding/bedrock_embedding_provider.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -49,9 +50,9 @@ type BedrockEmbeddingProvider struct {
 	embedDimParam int64
 	normalize     bool
 
-	maxBatch   int
-	timeoutSec int
-	extraInfo  *models.ModelExtraInfo
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
 }
 
 func createBedRockEmbeddingClient(awsAccessKeyId string, awsSecretAccessKey string, region string) (*bedrockruntime.Client, error) {
@@ -160,6 +161,11 @@ func NewBedrockEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSche
 		client = c
 	}
 
+	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
+	if err != nil {
+		return nil, err
+	}
+
 	return &BedrockEmbeddingProvider{
 		client:        client,
 		fieldDim:      fieldDim,
@@ -167,7 +173,7 @@ func NewBedrockEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSche
 		embedDimParam: dim,
 		normalize:     normalize,
 		maxBatch:      1,
-		timeoutSec:    30,
+		timeoutMs:     timeoutMs,
 		extraInfo:     extraInfo,
 	}, nil
 }
@@ -198,11 +204,13 @@ func (provider *BedrockEmbeddingProvider) CallEmbedding(ctx context.Context, tex
 			return nil, err
 		}
 
-		output, err := provider.client.InvokeModel(context.Background(), &bedrockruntime.InvokeModelInput{
+		callCtx, cancel := context.WithTimeout(ctx, time.Duration(provider.timeoutMs)*time.Millisecond)
+		output, err := provider.client.InvokeModel(callCtx, &bedrockruntime.InvokeModelInput{
 			Body:        payloadBytes,
 			ModelId:     aws.String(provider.modelName),
 			ContentType: aws.String("application/json"),
 		})
+		cancel()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/function/embedding/bedrock_embedding_provider.go
+++ b/internal/util/function/embedding/bedrock_embedding_provider.go
@@ -161,10 +161,7 @@ func NewBedrockEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSche
 		client = c
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
 
 	return &BedrockEmbeddingProvider{
 		client:        client,

--- a/internal/util/function/embedding/cohere_embedding_provider.go
+++ b/internal/util/function/embedding/cohere_embedding_provider.go
@@ -97,10 +97,7 @@ func NewCohereEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 		return "int8"
 	}()
 
-	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
 
 	provider := CohereEmbeddingProvider{
 		client:        c,

--- a/internal/util/function/embedding/cohere_embedding_provider.go
+++ b/internal/util/function/embedding/cohere_embedding_provider.go
@@ -41,9 +41,9 @@ type CohereEmbeddingProvider struct {
 	embdType      models.EmbeddingType
 	outputType    string
 
-	maxBatch   int
-	timeoutSec int64
-	extraInfo  *models.ModelExtraInfo
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
 }
 
 func NewCohereEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*CohereEmbeddingProvider, error) {
@@ -97,6 +97,11 @@ func NewCohereEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 		return "int8"
 	}()
 
+	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := CohereEmbeddingProvider{
 		client:        c,
 		url:           url,
@@ -107,7 +112,7 @@ func NewCohereEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 		embdType:      embdType,
 		outputType:    outputType,
 		maxBatch:      96,
-		timeoutSec:    30,
+		timeoutMs:     timeoutMs,
 		extraInfo:     extraInfo,
 	}
 	return &provider, nil
@@ -143,7 +148,7 @@ func (provider *CohereEmbeddingProvider) CallEmbedding(ctx context.Context, text
 			end = numRows
 		}
 
-		resp, err := provider.client.Embedding(provider.url, provider.modelName, texts[i:end], inputType, provider.outputType, provider.truncate, int(provider.embedDimParam), provider.timeoutSec)
+		resp, err := provider.client.Embedding(provider.url, provider.modelName, texts[i:end], inputType, provider.outputType, provider.truncate, int(provider.embedDimParam), provider.timeoutMs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/function/embedding/gemini_embedding_provider.go
+++ b/internal/util/function/embedding/gemini_embedding_provider.go
@@ -93,10 +93,7 @@ func NewGeminiEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 		url = fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:batchEmbedContents", modelName)
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
 
 	provider := GeminiEmbeddingProvider{
 		client:        c,

--- a/internal/util/function/embedding/gemini_embedding_provider.go
+++ b/internal/util/function/embedding/gemini_embedding_provider.go
@@ -40,9 +40,9 @@ type GeminiEmbeddingProvider struct {
 	embedDimParam int64
 	taskType      string
 
-	maxBatch   int
-	timeoutSec int64
-	extraInfo  *models.ModelExtraInfo
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
 }
 
 func NewGeminiEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*GeminiEmbeddingProvider, error) {
@@ -93,6 +93,11 @@ func NewGeminiEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 		url = fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:batchEmbedContents", modelName)
 	}
 
+	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := GeminiEmbeddingProvider{
 		client:        c,
 		url:           url,
@@ -101,7 +106,7 @@ func NewGeminiEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 		embedDimParam: dim,
 		taskType:      taskType,
 		maxBatch:      32,
-		timeoutSec:    30,
+		timeoutMs:     timeoutMs,
 		extraInfo:     extraInfo,
 	}
 	return &provider, nil
@@ -135,7 +140,7 @@ func (provider *GeminiEmbeddingProvider) CallEmbedding(ctx context.Context, text
 		if end > numRows {
 			end = numRows
 		}
-		resp, err := provider.client.Embedding(provider.url, provider.modelName, texts[i:end], int(provider.embedDimParam), taskType, provider.timeoutSec)
+		resp, err := provider.client.Embedding(provider.url, provider.modelName, texts[i:end], int(provider.embedDimParam), taskType, provider.timeoutMs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/function/embedding/openai_embedding_provider.go
+++ b/internal/util/function/embedding/openai_embedding_provider.go
@@ -123,10 +123,7 @@ func newOpenAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 		}
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
 
 	provider := OpenAIEmbeddingProvider{
 		client:        c,

--- a/internal/util/function/embedding/openai_embedding_provider.go
+++ b/internal/util/function/embedding/openai_embedding_provider.go
@@ -40,9 +40,9 @@ type OpenAIEmbeddingProvider struct {
 	embedDimParam int64
 	user          string
 
-	maxBatch   int
-	timeoutSec int64
-	extraInfo  *models.ModelExtraInfo
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
 }
 
 func createOpenAIEmbeddingClient(apiKey string, url string) (*openai.OpenAIEmbeddingClient, error) {
@@ -123,6 +123,11 @@ func newOpenAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 		}
 	}
 
+	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := OpenAIEmbeddingProvider{
 		client:        c,
 		fieldDim:      fieldDim,
@@ -130,7 +135,7 @@ func newOpenAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 		user:          user,
 		embedDimParam: dim,
 		maxBatch:      128,
-		timeoutSec:    30,
+		timeoutMs:     timeoutMs,
 		extraInfo:     extraInfo,
 	}
 	return &provider, nil
@@ -160,7 +165,7 @@ func (provider *OpenAIEmbeddingProvider) CallEmbedding(ctx context.Context, text
 		if end > numRows {
 			end = numRows
 		}
-		resp, err := provider.client.Embedding(provider.modelName, texts[i:end], int(provider.embedDimParam), provider.user, provider.timeoutSec)
+		resp, err := provider.client.Embedding(provider.modelName, texts[i:end], int(provider.embedDimParam), provider.user, provider.timeoutMs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/function/embedding/siliconflow_embedding_provider.go
+++ b/internal/util/function/embedding/siliconflow_embedding_provider.go
@@ -38,9 +38,9 @@ type SiliconflowEmbeddingProvider struct {
 	modelName     string
 	embedDimParam int64
 
-	maxBatch   int
-	timeoutSec int64
-	extraInfo  *models.ModelExtraInfo
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
 }
 
 func NewSiliconflowEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*SiliconflowEmbeddingProvider, error) {
@@ -77,6 +77,11 @@ func NewSiliconflowEmbeddingProvider(fieldSchema *schemapb.FieldSchema, function
 		url = "https://api.siliconflow.cn/v1/embeddings"
 	}
 
+	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := SiliconflowEmbeddingProvider{
 		client:        c,
 		url:           url,
@@ -84,7 +89,7 @@ func NewSiliconflowEmbeddingProvider(fieldSchema *schemapb.FieldSchema, function
 		modelName:     modelName,
 		embedDimParam: dim,
 		maxBatch:      32,
-		timeoutSec:    30,
+		timeoutMs:     timeoutMs,
 		extraInfo:     extraInfo,
 	}
 	return &provider, nil
@@ -106,7 +111,7 @@ func (provider *SiliconflowEmbeddingProvider) CallEmbedding(ctx context.Context,
 		if end > numRows {
 			end = numRows
 		}
-		resp, err := provider.client.Embedding(provider.url, provider.modelName, texts[i:end], "float", int(provider.embedDimParam), provider.timeoutSec)
+		resp, err := provider.client.Embedding(provider.url, provider.modelName, texts[i:end], "float", int(provider.embedDimParam), provider.timeoutMs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/function/embedding/siliconflow_embedding_provider.go
+++ b/internal/util/function/embedding/siliconflow_embedding_provider.go
@@ -77,10 +77,7 @@ func NewSiliconflowEmbeddingProvider(fieldSchema *schemapb.FieldSchema, function
 		url = "https://api.siliconflow.cn/v1/embeddings"
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
 
 	provider := SiliconflowEmbeddingProvider{
 		client:        c,

--- a/internal/util/function/embedding/tei_embedding_provider.go
+++ b/internal/util/function/embedding/tei_embedding_provider.go
@@ -41,9 +41,9 @@ type TeiEmbeddingProvider struct {
 	truncate            bool
 	truncationDirection string
 
-	maxBatch   int
-	timeoutSec int64
-	extraInfo  *models.ModelExtraInfo
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
 }
 
 func NewTEIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*TeiEmbeddingProvider, error) {
@@ -91,6 +91,11 @@ func NewTEIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *
 		return nil, err
 	}
 
+	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := TeiEmbeddingProvider{
 		client:   c,
 		fieldDim: fieldDim,
@@ -100,7 +105,7 @@ func NewTEIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *
 		truncationDirection: truncationDirection,
 		maxBatch:            maxBatch,
 		truncate:            truncate,
-		timeoutSec:          30,
+		timeoutMs:           timeoutMs,
 		extraInfo:           extraInfo,
 	}
 	return &provider, nil
@@ -129,7 +134,7 @@ func (provider *TeiEmbeddingProvider) CallEmbedding(ctx context.Context, texts [
 		if end > numRows {
 			end = numRows
 		}
-		resp, err := provider.client.Embedding(texts[i:end], provider.truncate, provider.truncationDirection, prompt, provider.timeoutSec)
+		resp, err := provider.client.Embedding(texts[i:end], provider.truncate, provider.truncationDirection, prompt, provider.timeoutMs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/function/embedding/tei_embedding_provider.go
+++ b/internal/util/function/embedding/tei_embedding_provider.go
@@ -91,10 +91,7 @@ func NewTEIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *
 		return nil, err
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
 
 	provider := TeiEmbeddingProvider{
 		client:   c,

--- a/internal/util/function/embedding/vertexai_embedding_provider.go
+++ b/internal/util/function/embedding/vertexai_embedding_provider.go
@@ -204,10 +204,7 @@ func NewVertexAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSch
 		client = c
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
 
 	provider := VertexAIEmbeddingProvider{
 		fieldDim:      fieldDim,

--- a/internal/util/function/embedding/vertexai_embedding_provider.go
+++ b/internal/util/function/embedding/vertexai_embedding_provider.go
@@ -82,9 +82,9 @@ type VertexAIEmbeddingProvider struct {
 	isGemini  bool
 	geminiURL string
 
-	maxBatch   int
-	timeoutSec int64
-	extraInfo  *models.ModelExtraInfo
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
 }
 
 func isGeminiModel(modelName string) bool {
@@ -204,6 +204,11 @@ func NewVertexAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSch
 		client = c
 	}
 
+	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := VertexAIEmbeddingProvider{
 		fieldDim:      fieldDim,
 		client:        client,
@@ -213,7 +218,7 @@ func NewVertexAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSch
 		isGemini:      gemini,
 		geminiURL:     geminiURL,
 		maxBatch:      maxBatch,
-		timeoutSec:    30,
+		timeoutMs:     timeoutMs,
 		extraInfo:     extraInfo,
 	}
 	return &provider, nil
@@ -281,7 +286,7 @@ func (provider *VertexAIEmbeddingProvider) callVertexAIEmbedding(texts []string,
 		if end > numRows {
 			end = numRows
 		}
-		resp, err := provider.client.Embedding(provider.modelName, texts[i:end], provider.embedDimParam, taskType, provider.timeoutSec)
+		resp, err := provider.client.Embedding(provider.modelName, texts[i:end], provider.embedDimParam, taskType, provider.timeoutMs)
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +310,7 @@ func (provider *VertexAIEmbeddingProvider) callGeminiEmbedding(texts []string, m
 	taskType := provider.getTaskType(mode)
 	data := make([][]float32, 0, len(texts))
 	for _, text := range texts {
-		resp, err := provider.client.GeminiEmbedding(provider.geminiURL, text, provider.embedDimParam, taskType, provider.timeoutSec)
+		resp, err := provider.client.GeminiEmbedding(provider.geminiURL, text, provider.embedDimParam, taskType, provider.timeoutMs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/function/embedding/voyageai_embedding_provider.go
+++ b/internal/util/function/embedding/voyageai_embedding_provider.go
@@ -42,9 +42,9 @@ type VoyageAIEmbeddingProvider struct {
 	embdType      models.EmbeddingType
 	outputType    string
 
-	maxBatch   int
-	timeoutSec int64
-	extraInfo  *models.ModelExtraInfo
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
 }
 
 func NewVoyageAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*VoyageAIEmbeddingProvider, error) {
@@ -99,6 +99,11 @@ func NewVoyageAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSch
 		return "int8"
 	}()
 
+	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := VoyageAIEmbeddingProvider{
 		client:        c,
 		url:           url,
@@ -109,7 +114,7 @@ func NewVoyageAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSch
 		embdType:      embdType,
 		outputType:    outputType,
 		maxBatch:      128,
-		timeoutSec:    30,
+		timeoutMs:     timeoutMs,
 		extraInfo:     extraInfo,
 	}
 	return &provider, nil
@@ -138,7 +143,7 @@ func (provider *VoyageAIEmbeddingProvider) CallEmbedding(ctx context.Context, te
 		if end > numRows {
 			end = numRows
 		}
-		r, err := provider.client.Embedding(provider.url, provider.modelName, texts[i:end], int(provider.embedDimParam), textType, provider.outputType, provider.truncate, provider.timeoutSec)
+		r, err := provider.client.Embedding(provider.url, provider.modelName, texts[i:end], int(provider.embedDimParam), textType, provider.outputType, provider.truncate, provider.timeoutMs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/function/embedding/voyageai_embedding_provider.go
+++ b/internal/util/function/embedding/voyageai_embedding_provider.go
@@ -99,10 +99,7 @@ func NewVoyageAIEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSch
 		return "int8"
 	}()
 
-	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
 
 	provider := VoyageAIEmbeddingProvider{
 		client:        c,

--- a/internal/util/function/embedding/yc_embedding_provider.go
+++ b/internal/util/function/embedding/yc_embedding_provider.go
@@ -90,10 +90,7 @@ func NewYCEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *s
 		url = defaultYCTextEmbeddingURL
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
 
 	provider := YCEmbeddingProvider{
 		fieldDim:  fieldDim,

--- a/internal/util/function/embedding/yc_embedding_provider.go
+++ b/internal/util/function/embedding/yc_embedding_provider.go
@@ -52,9 +52,9 @@ type YCEmbeddingProvider struct {
 	apiKey    string
 	modelName string
 
-	maxBatch   int
-	timeoutSec int64
-	extraInfo  *models.ModelExtraInfo
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
 }
 
 func NewYCEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*YCEmbeddingProvider, error) {
@@ -90,14 +90,19 @@ func NewYCEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *s
 		url = defaultYCTextEmbeddingURL
 	}
 
+	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := YCEmbeddingProvider{
-		fieldDim:   fieldDim,
-		url:        url,
-		apiKey:     apiKey,
-		modelName:  modelName,
-		maxBatch:   128,
-		timeoutSec: 30,
-		extraInfo:  extraInfo,
+		fieldDim:  fieldDim,
+		url:       url,
+		apiKey:    apiKey,
+		modelName: modelName,
+		maxBatch:  128,
+		timeoutMs: timeoutMs,
+		extraInfo: extraInfo,
 	}
 	return &provider, nil
 }
@@ -136,7 +141,7 @@ func (provider *YCEmbeddingProvider) CallEmbedding(ctx context.Context, texts []
 			req.Texts = nil
 		}
 
-		resp, err := models.PostRequest[YCEmbeddingResponse](req, provider.url, provider.headers(), provider.timeoutSec)
+		resp, err := models.PostRequest[YCEmbeddingResponse](req, provider.url, provider.headers(), provider.timeoutMs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/util/function/embedding/zilliz_embedding_provider.go
+++ b/internal/util/function/embedding/zilliz_embedding_provider.go
@@ -51,12 +51,19 @@ func NewZillizEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 		switch strings.ToLower(param.Key) {
 		case models.ModelDeploymentIDKey:
 			modelDeploymentID = param.Value
+		case models.TimeoutMsParamKey:
+			// consumed by ResolveTimeoutMs; not a model-service param
 		default:
 			modelParams[param.Key] = param.Value
 		}
 	}
 
-	c, err := zilliz.NewZilliClient(modelDeploymentID, extraInfo.ClusterID, extraInfo.DBName, params)
+	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := zilliz.NewZilliClient(modelDeploymentID, extraInfo.ClusterID, extraInfo.DBName, params, timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/embedding/zilliz_embedding_provider.go
+++ b/internal/util/function/embedding/zilliz_embedding_provider.go
@@ -58,10 +58,7 @@ func NewZillizEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchem
 		}
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(functionSchema.Params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
 
 	c, err := zilliz.NewZilliClient(modelDeploymentID, extraInfo.ClusterID, extraInfo.DBName, params, timeoutMs)
 	if err != nil {

--- a/internal/util/function/embedding/zilliz_embedding_provider_test.go
+++ b/internal/util/function/embedding/zilliz_embedding_provider_test.go
@@ -199,11 +199,11 @@ func (s *ZillizEmbeddingProviderSuite) TestDefaultValues() {
 	// but we can test the default values that should be set
 
 	expectedMaxBatch := 64
-	expectedTimeoutSec := int64(30)
+	expectedTimeoutMs := int64(30000)
 
 	// These are the default values that should be set in the constructor
 	s.Equal(64, expectedMaxBatch)
-	s.Equal(int64(30), expectedTimeoutSec)
+	s.Equal(int64(30000), expectedTimeoutMs)
 }
 
 func (s *ZillizEmbeddingProviderSuite) TestEdgeCases() {

--- a/internal/util/function/highlight/semantic_highlight_test.go
+++ b/internal/util/function/highlight/semantic_highlight_test.go
@@ -62,7 +62,7 @@ func (s *SemanticHighlightSuite) TestNewSemanticHighlight_Success() {
 	queriesJSON, _ := json.Marshal(queries)
 	inputFieldsJSON, _ := json.Marshal(inputFields)
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -241,7 +241,7 @@ func (s *SemanticHighlightSuite) TestProcessOneQuery_Success() {
 		{0.80},
 	}
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -287,7 +287,7 @@ func (s *SemanticHighlightSuite) TestProcessOneQuery_Error() {
 
 	expectedError := errors.New("highlight service error")
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -346,7 +346,7 @@ func (s *SemanticHighlightSuite) TestProcess_Success() {
 	}
 
 	callCount := 0
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -398,7 +398,7 @@ func (s *SemanticHighlightSuite) TestProcess_NqMismatch() {
 	queriesJSON, _ := json.Marshal(queries)
 	inputFieldsJSON, _ := json.Marshal(inputFields)
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -440,7 +440,7 @@ func (s *SemanticHighlightSuite) TestProcess_ProviderError() {
 
 	expectedError := errors.New("provider error")
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -485,7 +485,7 @@ func (s *SemanticHighlightSuite) TestProcess_EmptyData() {
 	queriesJSON, _ := json.Marshal(queries)
 	inputFieldsJSON, _ := json.Marshal(inputFields)
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -567,7 +567,7 @@ func (s *SemanticHighlightSuite) TestNewSemanticHighlight_DynamicField() {
 	queriesJSON, _ := json.Marshal(queries)
 	inputFieldsJSON, _ := json.Marshal(inputFields)
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -620,7 +620,7 @@ func (s *SemanticHighlightSuite) TestNewSemanticHighlight_MixedFields() {
 	queriesJSON, _ := json.Marshal(queries)
 	inputFieldsJSON, _ := json.Marshal(inputFields)
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -700,7 +700,7 @@ func (s *SemanticHighlightSuite) TestGetFieldName() {
 	queriesJSON, _ := json.Marshal(queries)
 	inputFieldsJSON, _ := json.Marshal(inputFields)
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -738,7 +738,7 @@ func (s *SemanticHighlightSuite) TestRequiredFieldIDs_NoDynamicFields() {
 	queriesJSON, _ := json.Marshal(queries)
 	inputFieldsJSON, _ := json.Marshal(inputFields)
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -775,7 +775,7 @@ func (s *SemanticHighlightSuite) TestProcessOneQuery_EmptyDocuments() {
 	queriesJSON, _ := json.Marshal(queries)
 	inputFieldsJSON, _ := json.Marshal(inputFields)
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -814,7 +814,7 @@ func (s *SemanticHighlightSuite) TestProcessOneQuery_SizeMismatch() {
 	queriesJSON, _ := json.Marshal(queries)
 	inputFieldsJSON, _ := json.Marshal(inputFields)
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -872,7 +872,7 @@ func (s *SemanticHighlightSuite) TestNewSemanticHighlight_MultipleDynamicFields(
 	queriesJSON, _ := json.Marshal(queries)
 	inputFieldsJSON, _ := json.Marshal(inputFields)
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -920,7 +920,7 @@ func (s *SemanticHighlightSuite) TestDynamicFieldID_NoDynamicSchema() {
 	queriesJSON, _ := json.Marshal(queries)
 	inputFieldsJSON, _ := json.Marshal(inputFields)
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()

--- a/internal/util/function/highlight/zilliz_highlight_provider.go
+++ b/internal/util/function/highlight/zilliz_highlight_provider.go
@@ -58,10 +58,7 @@ func newZillizHighlightProvider(params []*commonpb.KeyValuePair, conf map[string
 		}
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(params)
 
 	c, err := zilliz.NewZilliClient(modelDeploymentID, extraInfo.ClusterID, extraInfo.DBName, conf, timeoutMs)
 	if err != nil {

--- a/internal/util/function/highlight/zilliz_highlight_provider.go
+++ b/internal/util/function/highlight/zilliz_highlight_provider.go
@@ -51,12 +51,19 @@ func newZillizHighlightProvider(params []*commonpb.KeyValuePair, conf map[string
 				return nil, err
 			}
 
+		case models.TimeoutMsParamKey:
+			// consumed by ResolveTimeoutMs; not a model-service param
 		default:
 			modelParams[param.Key] = param.Value
 		}
 	}
 
-	c, err := zilliz.NewZilliClient(modelDeploymentID, extraInfo.ClusterID, extraInfo.DBName, conf)
+	timeoutMs, err := models.ResolveTimeoutMs(params)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := zilliz.NewZilliClient(modelDeploymentID, extraInfo.ClusterID, extraInfo.DBName, conf, timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/highlight/zilliz_highlight_provider_test.go
+++ b/internal/util/function/highlight/zilliz_highlight_provider_test.go
@@ -183,7 +183,7 @@ func (s *ZillizHighlightProviderSuite) TestZillizHighlightProvider_Highlight_Suc
 		{0.7, 0.6},
 	}
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()
@@ -216,7 +216,7 @@ func (s *ZillizHighlightProviderSuite) TestZillizHighlightProvider_Highlight_Err
 	texts := []string{"doc1", "doc2", "doc3"}
 	expectedError := errors.New("highlight service error")
 
-	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string) (*zilliz.ZillizClient, error) {
+	mock1 := mockey.Mock(zilliz.NewZilliClient).To(func(_ string, _ string, _ string, _ map[string]string, _ int64) (*zilliz.ZillizClient, error) {
 		return &zilliz.ZillizClient{}, nil
 	}).Build()
 	defer mock1.UnPatch()

--- a/internal/util/function/models/ali/ali_dashscope_client.go
+++ b/internal/util/function/models/ali/ali_dashscope_client.go
@@ -100,7 +100,7 @@ func (c *AliDashScopeEmbedding) Check() error {
 	return nil
 }
 
-func (c *AliDashScopeEmbedding) Embedding(modelName string, texts []string, dim int, textType string, outputType string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *AliDashScopeEmbedding) Embedding(modelName string, texts []string, dim int, textType string, outputType string, timeoutMs int64) (*EmbeddingResponse, error) {
 	var r EmbeddingRequest
 	r.Model = modelName
 	r.Input = Input{texts}
@@ -112,7 +112,7 @@ func (c *AliDashScopeEmbedding) Embedding(modelName string, texts []string, dim 
 		"Content-Type":  "application/json",
 		"Authorization": fmt.Sprintf("Bearer %s", c.apiKey),
 	}
-	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutSec)
+	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func NewAliDashScopeRerank(apiKey string) *AliDashScopeRerank {
 	}
 }
 
-func (c *AliDashScopeRerank) Rerank(url string, modelName string, query string, texts []string, params map[string]any, timeoutSec int64) (*RerankResponse, error) {
+func (c *AliDashScopeRerank) Rerank(url string, modelName string, query string, texts []string, params map[string]any, timeoutMs int64) (*RerankResponse, error) {
 	var r RerankRequest
 	r.Model = modelName
 	r.Inputs = Inputs{query, texts}
@@ -168,7 +168,7 @@ func (c *AliDashScopeRerank) Rerank(url string, modelName string, query string, 
 		"Content-Type":  "application/json",
 		"Authorization": fmt.Sprintf("Bearer %s", c.apiKey),
 	}
-	res, err := models.PostRequest[RerankResponse](r, url, headers, timeoutSec)
+	res, err := models.PostRequest[RerankResponse](r, url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/models/cohere/cohere_client.go
+++ b/internal/util/function/models/cohere/cohere_client.go
@@ -45,14 +45,14 @@ func (c *CohereClient) headers() map[string]string {
 	}
 }
 
-func (c *CohereClient) Embedding(url string, modelName string, texts []string, inputType string, outputType string, truncate string, dim int, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *CohereClient) Embedding(url string, modelName string, texts []string, inputType string, outputType string, truncate string, dim int, timeoutMs int64) (*EmbeddingResponse, error) {
 	embClient := newCohereEmbedding(c.apiKey, url)
-	return embClient.embedding(modelName, texts, inputType, outputType, truncate, dim, c.headers(), timeoutSec)
+	return embClient.embedding(modelName, texts, inputType, outputType, truncate, dim, c.headers(), timeoutMs)
 }
 
-func (c *CohereClient) Rerank(url string, modelName string, query string, texts []string, params map[string]any, timeoutSec int64) (*RerankResponse, error) {
+func (c *CohereClient) Rerank(url string, modelName string, query string, texts []string, params map[string]any, timeoutMs int64) (*RerankResponse, error) {
 	rerankClient := newCohereRerankClient(c.apiKey, url)
-	return rerankClient.rerank(modelName, query, texts, c.headers(), params, timeoutSec)
+	return rerankClient.rerank(modelName, query, texts, c.headers(), params, timeoutMs)
 }
 
 type EmbeddingRequest struct {
@@ -98,7 +98,7 @@ func newCohereEmbedding(apiKey string, url string) *cohereEmbedding {
 	}
 }
 
-func (c *cohereEmbedding) embedding(modelName string, texts []string, inputType string, outputType string, truncate string, dim int, headers map[string]string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *cohereEmbedding) embedding(modelName string, texts []string, inputType string, outputType string, truncate string, dim int, headers map[string]string, timeoutMs int64) (*EmbeddingResponse, error) {
 	var r EmbeddingRequest
 	r.Model = modelName
 	r.Texts = texts
@@ -111,7 +111,7 @@ func (c *cohereEmbedding) embedding(modelName string, texts []string, inputType 
 		r.OutputDimension = dim
 	}
 
-	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutSec)
+	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func newCohereRerankClient(apiKey string, url string) *cohereRerank {
 	}
 }
 
-func (c *cohereRerank) rerank(modelName string, query string, texts []string, headers map[string]string, params map[string]any, timeoutSec int64) (*RerankResponse, error) {
+func (c *cohereRerank) rerank(modelName string, query string, texts []string, headers map[string]string, params map[string]any, timeoutMs int64) (*RerankResponse, error) {
 	r := map[string]any{
 		"model":     modelName,
 		"query":     query,
@@ -191,7 +191,7 @@ func (c *cohereRerank) rerank(modelName string, query string, texts []string, he
 		r[k] = v
 	}
 
-	res, err := models.PostRequest[RerankResponse](r, c.url, headers, timeoutSec)
+	res, err := models.PostRequest[RerankResponse](r, c.url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/models/common.go
+++ b/internal/util/function/models/common.go
@@ -31,9 +31,12 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -223,30 +226,35 @@ func ParseAndCheckFieldDim(dimStr string, fieldDim int64, fieldName string) (int
 	return dim, nil
 }
 
-func ParseTimeoutMs(params []*commonpb.KeyValuePair, defaultTimeoutMs int64) (int64, error) {
+// ParseTimeoutMs resolves the request timeout in milliseconds from the function
+// params, falling back to defaultTimeoutMs (and to 30000 when that is also
+// non-positive). An invalid timeout_ms override is logged and ignored rather
+// than failing, so a misconfigured param never breaks provider construction.
+func ParseTimeoutMs(params []*commonpb.KeyValuePair, defaultTimeoutMs int64) int64 {
+	if defaultTimeoutMs <= 0 {
+		defaultTimeoutMs = 30000
+	}
 	for _, param := range params {
 		if strings.ToLower(param.Key) != TimeoutMsParamKey {
 			continue
 		}
 
 		timeoutMs, err := strconv.ParseInt(param.Value, 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("[%s param's value: %s] is not a valid number", TimeoutMsParamKey, param.Value)
+		if err != nil || timeoutMs <= 0 {
+			log.Warn("invalid function timeout_ms param, falling back to default",
+				zap.String("value", param.Value),
+				zap.Int64("defaultMs", defaultTimeoutMs))
+			return defaultTimeoutMs
 		}
-		if timeoutMs <= 0 {
-			return 0, fmt.Errorf("[%s param's value: %s] must be greater than 0", TimeoutMsParamKey, param.Value)
-		}
-		return timeoutMs, nil
+		return timeoutMs
 	}
 
-	if defaultTimeoutMs <= 0 {
-		return 30000, nil
-	}
-	return defaultTimeoutMs, nil
+	return defaultTimeoutMs
 }
 
-func ResolveTimeoutMs(params []*commonpb.KeyValuePair) (int64, error) {
-	return ParseTimeoutMs(params, paramtable.Get().FunctionCfg.ModelRequestTimeoutMs.GetAsInt64())
+func ResolveTimeoutMs(params []*commonpb.KeyValuePair) int64 {
+	defaultTimeout := paramtable.Get().FunctionCfg.ModelRequestTimeout.GetAsDurationByParse()
+	return ParseTimeoutMs(params, defaultTimeout.Milliseconds())
 }
 
 func GetEmbdType(dtype schemapb.DataType) EmbeddingType {

--- a/internal/util/function/models/common.go
+++ b/internal/util/function/models/common.go
@@ -35,6 +35,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 type TextEmbeddingMode int
@@ -63,6 +64,7 @@ const (
 	TruncateParamKey           string = "truncate"
 	MaxClientBatchSizeParamKey string = "max_client_batch_size"
 	IntegrationIDKey           string = "integration_id"
+	TimeoutMsParamKey          string = "timeout_ms"
 )
 
 // ali text embedding
@@ -221,6 +223,32 @@ func ParseAndCheckFieldDim(dimStr string, fieldDim int64, fieldName string) (int
 	return dim, nil
 }
 
+func ParseTimeoutMs(params []*commonpb.KeyValuePair, defaultTimeoutMs int64) (int64, error) {
+	for _, param := range params {
+		if strings.ToLower(param.Key) != TimeoutMsParamKey {
+			continue
+		}
+
+		timeoutMs, err := strconv.ParseInt(param.Value, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("[%s param's value: %s] is not a valid number", TimeoutMsParamKey, param.Value)
+		}
+		if timeoutMs <= 0 {
+			return 0, fmt.Errorf("[%s param's value: %s] must be greater than 0", TimeoutMsParamKey, param.Value)
+		}
+		return timeoutMs, nil
+	}
+
+	if defaultTimeoutMs <= 0 {
+		return 30000, nil
+	}
+	return defaultTimeoutMs, nil
+}
+
+func ResolveTimeoutMs(params []*commonpb.KeyValuePair) (int64, error) {
+	return ParseTimeoutMs(params, paramtable.Get().FunctionCfg.ModelRequestTimeoutMs.GetAsInt64())
+}
+
 func GetEmbdType(dtype schemapb.DataType) EmbeddingType {
 	switch dtype {
 	case schemapb.DataType_FloatVector:
@@ -284,17 +312,17 @@ func IsEnable(conf map[string]string) bool {
 
 type Response any
 
-func PostRequest[T Response](req any, url string, headers map[string]string, timeoutSec int64) (*T, error) {
+func PostRequest[T Response](req any, url string, headers map[string]string, timeoutMs int64) (*T, error) {
 	data, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
 	}
 
-	if timeoutSec <= 0 {
-		timeoutSec = 30
+	if timeoutMs <= 0 {
+		timeoutMs = 30000
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSec)*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutMs)*time.Millisecond)
 	defer cancel()
 
 	body, err := retrySend(ctx, data, http.MethodPost, url, headers, 3)

--- a/internal/util/function/models/common_test.go
+++ b/internal/util/function/models/common_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 type CommonSuite struct {
@@ -65,4 +66,50 @@ func (s *CommonSuite) TestParseAKAndURL() {
 		apiKey, _, _ := ParseAKAndURL(&credentials.Credentials{}, []*commonpb.KeyValuePair{{Key: "integration_id", Value: "test-integration"}}, map[string]string{}, OpenaiAKEnvStr, &ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
 		s.Equal(apiKey, "test-integration|test-cluster|test-db")
 	}
+}
+
+func (s *CommonSuite) TestParseTimeoutMs() {
+	timeoutMs, err := ParseTimeoutMs([]*commonpb.KeyValuePair{}, 45)
+	s.NoError(err)
+	s.Equal(int64(45), timeoutMs)
+
+	timeoutMs, err = ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "90"}}, 45)
+	s.NoError(err)
+	s.Equal(int64(90), timeoutMs)
+
+	_, err = ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "invalid"}}, 45)
+	s.ErrorContains(err, "is not a valid number")
+
+	_, err = ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "0"}}, 45)
+	s.ErrorContains(err, "must be greater than 0")
+
+	timeoutMs, err = ParseTimeoutMs([]*commonpb.KeyValuePair{}, 0)
+	s.NoError(err)
+	s.Equal(int64(30000), timeoutMs)
+
+	// param key match is case-insensitive
+	timeoutMs, err = ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: "Timeout_MS", Value: "120"}}, 45)
+	s.NoError(err)
+	s.Equal(int64(120), timeoutMs)
+
+	// negative override is rejected
+	_, err = ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "-1"}}, 45)
+	s.ErrorContains(err, "must be greater than 0")
+}
+
+func (s *CommonSuite) TestResolveTimeoutMs() {
+	paramtable.Init()
+	params := paramtable.Get()
+
+	// falls back to the global function model timeout when no param is set
+	params.Save(params.FunctionCfg.ModelRequestTimeoutMs.Key, "12345")
+	defer params.Reset(params.FunctionCfg.ModelRequestTimeoutMs.Key)
+	timeoutMs, err := ResolveTimeoutMs([]*commonpb.KeyValuePair{})
+	s.NoError(err)
+	s.Equal(int64(12345), timeoutMs)
+
+	// per-function param overrides the global default
+	timeoutMs, err = ResolveTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "777"}})
+	s.NoError(err)
+	s.Equal(int64(777), timeoutMs)
 }

--- a/internal/util/function/models/common_test.go
+++ b/internal/util/function/models/common_test.go
@@ -69,32 +69,22 @@ func (s *CommonSuite) TestParseAKAndURL() {
 }
 
 func (s *CommonSuite) TestParseTimeoutMs() {
-	timeoutMs, err := ParseTimeoutMs([]*commonpb.KeyValuePair{}, 45)
-	s.NoError(err)
-	s.Equal(int64(45), timeoutMs)
+	s.Equal(int64(45), ParseTimeoutMs([]*commonpb.KeyValuePair{}, 45))
 
-	timeoutMs, err = ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "90"}}, 45)
-	s.NoError(err)
-	s.Equal(int64(90), timeoutMs)
+	s.Equal(int64(90), ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "90"}}, 45))
 
-	_, err = ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "invalid"}}, 45)
-	s.ErrorContains(err, "is not a valid number")
+	// an invalid override falls back to the default instead of failing
+	s.Equal(int64(45), ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "invalid"}}, 45))
 
-	_, err = ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "0"}}, 45)
-	s.ErrorContains(err, "must be greater than 0")
+	// non-positive overrides fall back to the default
+	s.Equal(int64(45), ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "0"}}, 45))
+	s.Equal(int64(45), ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "-1"}}, 45))
 
-	timeoutMs, err = ParseTimeoutMs([]*commonpb.KeyValuePair{}, 0)
-	s.NoError(err)
-	s.Equal(int64(30000), timeoutMs)
+	// a non-positive default falls back to 30000
+	s.Equal(int64(30000), ParseTimeoutMs([]*commonpb.KeyValuePair{}, 0))
 
 	// param key match is case-insensitive
-	timeoutMs, err = ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: "Timeout_MS", Value: "120"}}, 45)
-	s.NoError(err)
-	s.Equal(int64(120), timeoutMs)
-
-	// negative override is rejected
-	_, err = ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "-1"}}, 45)
-	s.ErrorContains(err, "must be greater than 0")
+	s.Equal(int64(120), ParseTimeoutMs([]*commonpb.KeyValuePair{{Key: "Timeout_MS", Value: "120"}}, 45))
 }
 
 func (s *CommonSuite) TestResolveTimeoutMs() {
@@ -102,14 +92,10 @@ func (s *CommonSuite) TestResolveTimeoutMs() {
 	params := paramtable.Get()
 
 	// falls back to the global function model timeout when no param is set
-	params.Save(params.FunctionCfg.ModelRequestTimeoutMs.Key, "12345")
-	defer params.Reset(params.FunctionCfg.ModelRequestTimeoutMs.Key)
-	timeoutMs, err := ResolveTimeoutMs([]*commonpb.KeyValuePair{})
-	s.NoError(err)
-	s.Equal(int64(12345), timeoutMs)
+	params.Save(params.FunctionCfg.ModelRequestTimeout.Key, "12s")
+	defer params.Reset(params.FunctionCfg.ModelRequestTimeout.Key)
+	s.Equal(int64(12000), ResolveTimeoutMs([]*commonpb.KeyValuePair{}))
 
 	// per-function param overrides the global default
-	timeoutMs, err = ResolveTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "777"}})
-	s.NoError(err)
-	s.Equal(int64(777), timeoutMs)
+	s.Equal(int64(777), ResolveTimeoutMs([]*commonpb.KeyValuePair{{Key: TimeoutMsParamKey, Value: "777"}}))
 }

--- a/internal/util/function/models/gemini/gemini_client.go
+++ b/internal/util/function/models/gemini/gemini_client.go
@@ -43,7 +43,7 @@ func (c *GeminiClient) headers() map[string]string {
 	}
 }
 
-func (c *GeminiClient) Embedding(url string, modelName string, texts []string, dim int, taskType string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *GeminiClient) Embedding(url string, modelName string, texts []string, dim int, taskType string, timeoutMs int64) (*EmbeddingResponse, error) {
 	modelName = strings.TrimPrefix(modelName, "models/")
 	requests := make([]BatchEmbedRequest, 0, len(texts))
 	for _, text := range texts {
@@ -66,7 +66,7 @@ func (c *GeminiClient) Embedding(url string, modelName string, texts []string, d
 		Requests: requests,
 	}
 
-	res, err := models.PostRequest[EmbeddingResponse](batchReq, url, c.headers(), timeoutSec)
+	res, err := models.PostRequest[EmbeddingResponse](batchReq, url, c.headers(), timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/models/openai/openai_client.go
+++ b/internal/util/function/models/openai/openai_client.go
@@ -88,7 +88,7 @@ type EmbedddingError struct {
 
 type OpenAIEmbeddingInterface interface {
 	Check() error
-	Embedding(modelName string, texts []string, dim int, user string, timeoutSec int64) (*EmbeddingResponse, error)
+	Embedding(modelName string, texts []string, dim int, user string, timeoutMs int64) (*EmbeddingResponse, error)
 }
 
 type openAIBase struct {
@@ -121,9 +121,9 @@ func (c *openAIBase) genReq(modelName string, texts []string, dim int, user stri
 	return &r
 }
 
-func (c *openAIBase) embedding(url string, headers map[string]string, modelName string, texts []string, dim int, user string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *openAIBase) embedding(url string, headers map[string]string, modelName string, texts []string, dim int, user string, timeoutMs int64) (*EmbeddingResponse, error) {
 	r := c.genReq(modelName, texts, dim, user)
-	res, err := models.PostRequest[EmbeddingResponse](r, url, headers, timeoutSec)
+	res, err := models.PostRequest[EmbeddingResponse](r, url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}
@@ -146,12 +146,12 @@ func NewOpenAIEmbeddingClient(apiKey string, url string) *OpenAIEmbeddingClient 
 	}
 }
 
-func (c *OpenAIEmbeddingClient) Embedding(modelName string, texts []string, dim int, user string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *OpenAIEmbeddingClient) Embedding(modelName string, texts []string, dim int, user string, timeoutMs int64) (*EmbeddingResponse, error) {
 	headers := map[string]string{
 		"Content-Type":  "application/json",
 		"Authorization": fmt.Sprintf("Bearer %s", c.apiKey),
 	}
-	return c.embedding(c.url, headers, modelName, texts, dim, user, timeoutSec)
+	return c.embedding(c.url, headers, modelName, texts, dim, user, timeoutMs)
 }
 
 type AzureOpenAIEmbeddingClient struct {
@@ -169,7 +169,7 @@ func NewAzureOpenAIEmbeddingClient(apiKey string, url string) *AzureOpenAIEmbedd
 	}
 }
 
-func (c *AzureOpenAIEmbeddingClient) Embedding(modelName string, texts []string, dim int, user string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *AzureOpenAIEmbeddingClient) Embedding(modelName string, texts []string, dim int, user string, timeoutMs int64) (*EmbeddingResponse, error) {
 	base, err := url.Parse(c.url)
 	if err != nil {
 		return nil, err
@@ -185,5 +185,5 @@ func (c *AzureOpenAIEmbeddingClient) Embedding(modelName string, texts []string,
 		"Content-Type": "application/json",
 		"api-key":      c.apiKey,
 	}
-	return c.embedding(url, headers, modelName, texts, dim, user, timeoutSec)
+	return c.embedding(url, headers, modelName, texts, dim, user, timeoutMs)
 }

--- a/internal/util/function/models/openai/openai_client_test.go
+++ b/internal/util/function/models/openai/openai_client_test.go
@@ -231,7 +231,7 @@ func TestTimeoutAndRetry(t *testing.T) {
 		c := NewOpenAIEmbeddingClient("mock_key", url)
 		err := c.Check()
 		assert.True(t, err == nil)
-		_, err = c.Embedding("text-embedding-3-small", []string{"sentence"}, 0, "", 1)
+		_, err = c.Embedding("text-embedding-3-small", []string{"sentence"}, 0, "", 1000)
 		assert.True(t, err != nil)
 		assert.Equal(t, atomic.LoadInt32(&st), int32(0))
 		time.Sleep(2 * time.Second)
@@ -243,7 +243,7 @@ func TestTimeoutAndRetry(t *testing.T) {
 		c := NewAzureOpenAIEmbeddingClient("mock_key", url)
 		err := c.Check()
 		assert.True(t, err == nil)
-		_, err = c.Embedding("text-embedding-3-small", []string{"sentence"}, 0, "", 14)
+		_, err = c.Embedding("text-embedding-3-small", []string{"sentence"}, 0, "", 14000)
 		assert.True(t, err != nil)
 		assert.Equal(t, atomic.LoadInt32(&st), int32(3))
 	}

--- a/internal/util/function/models/siliconflow/siliconflow_client.go
+++ b/internal/util/function/models/siliconflow/siliconflow_client.go
@@ -45,14 +45,14 @@ func (c *SiliconflowClient) headers() map[string]string {
 	}
 }
 
-func (c *SiliconflowClient) Embedding(url string, modelName string, texts []string, encodingFormat string, dim int, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *SiliconflowClient) Embedding(url string, modelName string, texts []string, encodingFormat string, dim int, timeoutMs int64) (*EmbeddingResponse, error) {
 	embClient := newSiliconflowEmbedding(c.apiKey, url)
-	return embClient.embedding(modelName, texts, encodingFormat, dim, c.headers(), timeoutSec)
+	return embClient.embedding(modelName, texts, encodingFormat, dim, c.headers(), timeoutMs)
 }
 
-func (c *SiliconflowClient) Rerank(url string, modelName string, query string, texts []string, params map[string]any, timeoutSec int64) (*RerankResponse, error) {
+func (c *SiliconflowClient) Rerank(url string, modelName string, query string, texts []string, params map[string]any, timeoutMs int64) (*RerankResponse, error) {
 	rerankClient := newSiliconflowRerank(c.apiKey, url)
-	return rerankClient.rerank(modelName, query, texts, c.headers(), params, timeoutSec)
+	return rerankClient.rerank(modelName, query, texts, c.headers(), params, timeoutMs)
 }
 
 type EmbeddingRequest struct {
@@ -106,7 +106,7 @@ func newSiliconflowEmbedding(apiKey string, url string) *siliconflowEmbedding {
 	}
 }
 
-func (c *siliconflowEmbedding) embedding(modelName string, texts []string, encodingFormat string, dim int, headers map[string]string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *siliconflowEmbedding) embedding(modelName string, texts []string, encodingFormat string, dim int, headers map[string]string, timeoutMs int64) (*EmbeddingResponse, error) {
 	var r EmbeddingRequest
 	r.Model = modelName
 	r.Input = texts
@@ -115,7 +115,7 @@ func (c *siliconflowEmbedding) embedding(modelName string, texts []string, encod
 		r.Dimensions = dim
 	}
 
-	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutSec)
+	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func newSiliconflowRerank(apiKey string, url string) *siliconflowRerank {
 	}
 }
 
-func (c *siliconflowRerank) rerank(modelName string, query string, texts []string, headers map[string]string, params map[string]any, timeoutSec int64) (*RerankResponse, error) {
+func (c *siliconflowRerank) rerank(modelName string, query string, texts []string, headers map[string]string, params map[string]any, timeoutMs int64) (*RerankResponse, error) {
 	requestBody := map[string]interface{}{
 		"model":     modelName,
 		"query":     query,
@@ -204,7 +204,7 @@ func (c *siliconflowRerank) rerank(modelName string, query string, texts []strin
 	for k, v := range params {
 		requestBody[k] = v
 	}
-	res, err := models.PostRequest[RerankResponse](requestBody, c.url, headers, timeoutSec)
+	res, err := models.PostRequest[RerankResponse](requestBody, c.url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/models/tei/tei.go
+++ b/internal/util/function/models/tei/tei.go
@@ -46,20 +46,20 @@ func (c *TEIClient) headers() map[string]string {
 	return headers
 }
 
-func (c *TEIClient) Embedding(texts []string, truncate bool, truncationDirection string, prompt string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *TEIClient) Embedding(texts []string, truncate bool, truncationDirection string, prompt string, timeoutMs int64) (*EmbeddingResponse, error) {
 	embClient, err := newTEIEmbedding(c.apiKey, c.endpoint)
 	if err != nil {
 		return nil, err
 	}
-	return embClient.embedding(texts, truncate, truncationDirection, prompt, c.headers(), timeoutSec)
+	return embClient.embedding(texts, truncate, truncationDirection, prompt, c.headers(), timeoutMs)
 }
 
-func (c *TEIClient) Rerank(query string, texts []string, params map[string]any, timeoutSec int64) (*RerankResponse, error) {
+func (c *TEIClient) Rerank(query string, texts []string, params map[string]any, timeoutMs int64) (*RerankResponse, error) {
 	rerankClient, err := newTEIRerank(c.apiKey, c.endpoint)
 	if err != nil {
 		return nil, err
 	}
-	return rerankClient.rerank(query, texts, params, c.headers(), timeoutSec)
+	return rerankClient.rerank(query, texts, params, c.headers(), timeoutMs)
 }
 
 type EmbeddingRequest struct {
@@ -89,7 +89,7 @@ func newTEIEmbedding(apiKey string, endpoint string) (*teiEmbedding, error) {
 	}, nil
 }
 
-func (c *teiEmbedding) embedding(texts []string, truncate bool, truncationDirection string, prompt string, headers map[string]string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *teiEmbedding) embedding(texts []string, truncate bool, truncationDirection string, prompt string, headers map[string]string, timeoutMs int64) (*EmbeddingResponse, error) {
 	var r EmbeddingRequest
 	if prompt != "" {
 		var newTexts []string
@@ -106,7 +106,7 @@ func (c *teiEmbedding) embedding(texts []string, truncate bool, truncationDirect
 		r.TruncationDirection = truncationDirection
 	}
 
-	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutSec)
+	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}
@@ -138,14 +138,14 @@ func newTEIRerank(apiKey string, endpoint string) (*teiRerank, error) {
 	}, nil
 }
 
-func (c *teiRerank) rerank(query string, texts []string, params map[string]any, headers map[string]string, timeoutSec int64) (*RerankResponse, error) {
+func (c *teiRerank) rerank(query string, texts []string, params map[string]any, headers map[string]string, timeoutMs int64) (*RerankResponse, error) {
 	r := map[string]any{
 		"query": query,
 		"texts": texts,
 	}
 	maps.Copy(r, params)
 
-	res, err := models.PostRequest[RerankResponse](r, c.url, headers, timeoutSec)
+	res, err := models.PostRequest[RerankResponse](r, c.url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/models/vertexai/vertexai_client.go
+++ b/internal/util/function/models/vertexai/vertexai_client.go
@@ -135,7 +135,7 @@ func (c *VertexAIEmbedding) getAccessToken() (string, error) {
 	return token.AccessToken, nil
 }
 
-func (c *VertexAIEmbedding) GeminiEmbedding(url string, text string, dim int64, taskType string, timeoutSec int64) (*GeminiEmbedContentResponse, error) {
+func (c *VertexAIEmbedding) GeminiEmbedding(url string, text string, dim int64, taskType string, timeoutMs int64) (*GeminiEmbedContentResponse, error) {
 	req := GeminiEmbedContentRequest{
 		Content: GeminiContent{
 			Parts: []GeminiPart{{Text: text}},
@@ -163,14 +163,14 @@ func (c *VertexAIEmbedding) GeminiEmbedding(url string, text string, dim int64, 
 		"Content-Type":  "application/json",
 		"Authorization": fmt.Sprintf("Bearer %s", token),
 	}
-	res, err := models.PostRequest[GeminiEmbedContentResponse](req, url, headers, timeoutSec)
+	res, err := models.PostRequest[GeminiEmbedContentResponse](req, url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}
 	return res, nil
 }
 
-func (c *VertexAIEmbedding) Embedding(modelName string, texts []string, dim int64, taskType string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *VertexAIEmbedding) Embedding(modelName string, texts []string, dim int64, taskType string, timeoutMs int64) (*EmbeddingResponse, error) {
 	var r EmbeddingRequest
 	for _, text := range texts {
 		r.Instances = append(r.Instances, Instance{TaskType: taskType, Content: text})
@@ -194,7 +194,7 @@ func (c *VertexAIEmbedding) Embedding(modelName string, texts []string, dim int6
 		"Content-Type":  "application/json",
 		"Authorization": fmt.Sprintf("Bearer %s", token),
 	}
-	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutSec)
+	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/models/vllm/vllm_client.go
+++ b/internal/util/function/models/vllm/vllm_client.go
@@ -62,20 +62,20 @@ func (c *VLLMClient) headers() map[string]string {
 	return headers
 }
 
-func (c *VLLMClient) Embedding(texts []string, params map[string]any, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *VLLMClient) Embedding(texts []string, params map[string]any, timeoutMs int64) (*EmbeddingResponse, error) {
 	embClient, err := newVLLMEmbeddingClient(c.apiKey, c.endpoint)
 	if err != nil {
 		return nil, err
 	}
-	return embClient.Embedding(texts, params, c.headers(), timeoutSec)
+	return embClient.Embedding(texts, params, c.headers(), timeoutMs)
 }
 
-func (c *VLLMClient) Rerank(query string, texts []string, params map[string]any, timeoutSec int64) (*RerankResponse, error) {
+func (c *VLLMClient) Rerank(query string, texts []string, params map[string]any, timeoutMs int64) (*RerankResponse, error) {
 	rerankClient, err := newVLLMRerankClient(c.apiKey, c.endpoint)
 	if err != nil {
 		return nil, err
 	}
-	return rerankClient.Rerank(query, texts, params, c.headers(), timeoutSec)
+	return rerankClient.Rerank(query, texts, params, c.headers(), timeoutMs)
 }
 
 /*
@@ -157,7 +157,7 @@ func newVLLMEmbeddingClient(apiKey string, endpoint string) (*VLLMEmbedding, err
 	}, nil
 }
 
-func (c *VLLMEmbedding) Embedding(texts []string, params map[string]any, headers map[string]string, timeoutSec int64) (*EmbeddingResponse, error) {
+func (c *VLLMEmbedding) Embedding(texts []string, params map[string]any, headers map[string]string, timeoutMs int64) (*EmbeddingResponse, error) {
 	r := map[string]any{
 		"input":           texts,
 		"encoding_format": "float",
@@ -167,7 +167,7 @@ func (c *VLLMEmbedding) Embedding(texts []string, params map[string]any, headers
 		maps.Copy(r, params)
 	}
 
-	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutSec)
+	res, err := models.PostRequest[EmbeddingResponse](r, c.url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func newVLLMRerankClient(apiKey string, endpoint string) (*VLLMRerank, error) {
 	}, nil
 }
 
-func (c *VLLMRerank) Rerank(query string, texts []string, params map[string]any, headers map[string]string, timeoutSec int64) (*RerankResponse, error) {
+func (c *VLLMRerank) Rerank(query string, texts []string, params map[string]any, headers map[string]string, timeoutMs int64) (*RerankResponse, error) {
 	r := map[string]any{
 		"query":     query,
 		"documents": texts,
@@ -229,7 +229,7 @@ func (c *VLLMRerank) Rerank(query string, texts []string, params map[string]any,
 		maps.Copy(r, params)
 	}
 
-	res, err := models.PostRequest[RerankResponse](r, c.url, headers, timeoutSec)
+	res, err := models.PostRequest[RerankResponse](r, c.url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/models/voyageai/voyageai_client.go
+++ b/internal/util/function/models/voyageai/voyageai_client.go
@@ -45,14 +45,14 @@ func (c *VoyageAIClient) headers() map[string]string {
 	}
 }
 
-func (c *VoyageAIClient) Embedding(url string, modelName string, texts []string, dim int, textType string, outputType string, truncation bool, timeoutSec int64) (any, error) {
+func (c *VoyageAIClient) Embedding(url string, modelName string, texts []string, dim int, textType string, outputType string, truncation bool, timeoutMs int64) (any, error) {
 	embClient := newVoyageAIEmbedding(c.apiKey, url)
-	return embClient.embedding(modelName, texts, dim, textType, outputType, truncation, c.headers(), timeoutSec)
+	return embClient.embedding(modelName, texts, dim, textType, outputType, truncation, c.headers(), timeoutMs)
 }
 
-func (c *VoyageAIClient) Rerank(url string, modelName string, query string, texts []string, params map[string]any, timeoutSec int64) (*RerankResponse, error) {
+func (c *VoyageAIClient) Rerank(url string, modelName string, query string, texts []string, params map[string]any, timeoutMs int64) (*RerankResponse, error) {
 	rerankClient := newVoyageAIRerank(c.apiKey, url)
-	return rerankClient.rerank(modelName, query, texts, c.headers(), params, timeoutSec)
+	return rerankClient.rerank(modelName, query, texts, c.headers(), params, timeoutMs)
 }
 
 type EmbeddingRequest struct {
@@ -122,7 +122,7 @@ func (c *voyageAIEmbedding) Check() error {
 	return nil
 }
 
-func (c *voyageAIEmbedding) embedding(modelName string, texts []string, dim int, textType string, outputType string, truncation bool, headers map[string]string, timeoutSec int64) (any, error) {
+func (c *voyageAIEmbedding) embedding(modelName string, texts []string, dim int, textType string, outputType string, truncation bool, headers map[string]string, timeoutMs int64) (any, error) {
 	if outputType != "float" && outputType != "int8" {
 		return nil, merr.WrapErrParameterInvalidMsg("Voyageai: unsupported output type: [%s], only support float and int8", outputType) //nolint:staticcheck // starts with proper noun
 	}
@@ -138,7 +138,7 @@ func (c *voyageAIEmbedding) embedding(modelName string, texts []string, dim int,
 	}
 
 	if outputType == "float" {
-		res, err := models.PostRequest[EmbeddingResponse[float32]](r, c.url, headers, timeoutSec)
+		res, err := models.PostRequest[EmbeddingResponse[float32]](r, c.url, headers, timeoutMs)
 		if err != nil {
 			return nil, err
 		}
@@ -147,7 +147,7 @@ func (c *voyageAIEmbedding) embedding(modelName string, texts []string, dim int,
 		})
 		return res, nil
 	} else {
-		res, err := models.PostRequest[EmbeddingResponse[int8]](r, c.url, headers, timeoutSec)
+		res, err := models.PostRequest[EmbeddingResponse[int8]](r, c.url, headers, timeoutMs)
 		if err != nil {
 			return nil, err
 		}
@@ -202,7 +202,7 @@ func newVoyageAIRerank(apiKey string, url string) *voyageAIRerank {
 	}
 }
 
-func (c *voyageAIRerank) rerank(modelName string, query string, texts []string, headers map[string]string, params map[string]any, timeoutSec int64) (*RerankResponse, error) {
+func (c *voyageAIRerank) rerank(modelName string, query string, texts []string, headers map[string]string, params map[string]any, timeoutMs int64) (*RerankResponse, error) {
 	r := map[string]any{
 		"model":     modelName,
 		"query":     query,
@@ -211,7 +211,7 @@ func (c *voyageAIRerank) rerank(modelName string, query string, texts []string, 
 	if params != nil {
 		maps.Copy(r, params)
 	}
-	res, err := models.PostRequest[RerankResponse](r, c.url, headers, timeoutSec)
+	res, err := models.PostRequest[RerankResponse](r, c.url, headers, timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/models/zilliz/zilliz_client.go
+++ b/internal/util/function/models/zilliz/zilliz_client.go
@@ -182,9 +182,10 @@ type ZillizClient struct {
 	clusterID         string
 	dbName            string
 	conn              *grpc.ClientConn
+	timeout           time.Duration
 }
 
-func NewZilliClient(modelDeploymentID string, clusterID string, dbName string, info map[string]string) (*ZillizClient, error) {
+func NewZilliClient(modelDeploymentID string, clusterID string, dbName string, info map[string]string, timeoutMs int64) (*ZillizClient, error) {
 	mgr := getClientManager()
 	clientConf, err := loadConfig(info)
 	if err != nil {
@@ -195,12 +196,43 @@ func NewZilliClient(modelDeploymentID string, clusterID string, dbName string, i
 		// failing to connect to the model serving backend is transient
 		return nil, merr.WrapErrServiceUnavailable(err.Error(), "connect model serving failed")
 	}
+	timeout := clientConf.Timeout
+	if timeoutMs > 0 {
+		timeout = time.Duration(timeoutMs) * time.Millisecond
+	}
+	if timeout <= 0 {
+		timeout = 30000 * time.Millisecond
+	}
 	return &ZillizClient{
 		modelDeploymentID: modelDeploymentID,
 		clusterID:         clusterID,
 		dbName:            dbName,
 		conn:              conn,
+		timeout:           timeout,
 	}, nil
+}
+
+func NewZilliClientForTests(modelDeploymentID string, clusterID string, dbName string, conn *grpc.ClientConn, timeoutMs int64) *ZillizClient {
+	timeout := 30000 * time.Millisecond
+	if timeoutMs > 0 {
+		timeout = time.Duration(timeoutMs) * time.Millisecond
+	}
+	return &ZillizClient{
+		modelDeploymentID: modelDeploymentID,
+		clusterID:         clusterID,
+		dbName:            dbName,
+		conn:              conn,
+		timeout:           timeout,
+	}
+}
+
+func (c *ZillizClient) requestContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	timeout := c.timeout
+	if timeout <= 0 {
+		timeout = 30000 * time.Millisecond
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	return c.setMeta(requestCtx), cancel
 }
 
 func (c *ZillizClient) setMeta(ctx context.Context) context.Context {
@@ -219,8 +251,9 @@ func (c *ZillizClient) Embedding(ctx context.Context, texts []string, params map
 		Texts:  texts,
 		Params: params,
 	}
-	ctx = c.setMeta(ctx)
-	res, err := stub.Embedding(ctx, req)
+	callCtx, cancel := c.requestContext(ctx)
+	defer cancel()
+	res, err := stub.Embedding(callCtx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -246,8 +279,9 @@ func (c *ZillizClient) Rerank(ctx context.Context, query string, texts []string,
 		Documents: texts,
 		Params:    params,
 	}
-	ctx = c.setMeta(ctx)
-	res, err := stub.Rerank(ctx, req)
+	callCtx, cancel := c.requestContext(ctx)
+	defer cancel()
+	res, err := stub.Rerank(callCtx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -261,8 +295,9 @@ func (c *ZillizClient) Highlight(ctx context.Context, query string, texts []stri
 		Documents: texts,
 		Params:    params,
 	}
-	ctx = c.setMeta(ctx)
-	res, err := stub.Highlight(ctx, req)
+	callCtx, cancel := c.requestContext(ctx)
+	defer cancel()
+	res, err := stub.Highlight(callCtx, req)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/util/function/models/zilliz/zilliz_client_test.go
+++ b/internal/util/function/models/zilliz/zilliz_client_test.go
@@ -294,11 +294,8 @@ func TestZillizClient_Embedding(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	client := &ZillizClient{
-		modelDeploymentID: "test-deployment",
-		clusterID:         "test-cluster",
-		conn:              conn,
-	}
+	client := NewZilliClientForTests("test-deployment", "test-cluster", "", conn, 15)
+	assert.Equal(t, 15*time.Millisecond, client.timeout)
 
 	// Test successful embedding
 	ctx := context.Background()
@@ -341,11 +338,8 @@ func TestZillizClient_Embedding_Error(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	client := &ZillizClient{
-		modelDeploymentID: "test-deployment",
-		clusterID:         "test-cluster",
-		conn:              conn,
-	}
+	client := NewZilliClientForTests("test-deployment", "test-cluster", "", conn, 15)
+	assert.Equal(t, 15*time.Millisecond, client.timeout)
 
 	// Test embedding with error
 	ctx := context.Background()
@@ -389,11 +383,8 @@ func TestZillizClient_Rerank(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	client := &ZillizClient{
-		modelDeploymentID: "test-deployment",
-		clusterID:         "test-cluster",
-		conn:              conn,
-	}
+	client := NewZilliClientForTests("test-deployment", "test-cluster", "", conn, 15)
+	assert.Equal(t, 15*time.Millisecond, client.timeout)
 
 	// Test successful rerank
 	ctx := context.Background()
@@ -477,7 +468,7 @@ func TestNewZilliClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := NewZilliClient("test-deployment", "test-cluster", "test-db", tt.info)
+			client, err := NewZilliClient("test-deployment", "test-cluster", "test-db", tt.info, 0)
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Nil(t, client)
@@ -510,7 +501,7 @@ func TestNewZilliClient_WithMockServer(t *testing.T) {
 		}
 
 		// This will create the client but won't actually connect until first RPC
-		client, err := NewZilliClient("test-deployment", "test-cluster", "test-db", info)
+		client, err := NewZilliClient("test-deployment", "test-cluster", "test-db", info, 0)
 		// The client creation should succeed even if connection fails
 		// because grpc.NewClient creates lazy connections
 		if err != nil {
@@ -797,4 +788,30 @@ func TestZillizClient_Highlight_MismatchLength(t *testing.T) {
 			assert.Nil(t, scores)
 		})
 	}
+}
+
+func TestZillizClient_RequestContext(t *testing.T) {
+	// configured timeout produces a request deadline close to now+timeout
+	client := NewZilliClientForTests("test-deployment", "test-cluster", "", nil, 50)
+	assert.Equal(t, 50*time.Millisecond, client.timeout)
+
+	ctx, cancel := client.requestContext(context.Background())
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	assert.True(t, ok)
+	assert.Greater(t, time.Until(deadline), time.Duration(0))
+	assert.LessOrEqual(t, time.Until(deadline), 50*time.Millisecond)
+
+	// setMeta is applied on the request context
+	md, ok := metadata.FromOutgoingContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, []string{"test-cluster"}, md.Get("instance-id"))
+
+	// a non-positive timeout falls back to the 30s default
+	fallback := &ZillizClient{clusterID: "test-cluster"}
+	fbCtx, fbCancel := fallback.requestContext(context.Background())
+	defer fbCancel()
+	fbDeadline, ok := fbCtx.Deadline()
+	assert.True(t, ok)
+	assert.Greater(t, time.Until(fbDeadline), 29*time.Second)
 }

--- a/internal/util/function/rerank/ali_rerank_provider.go
+++ b/internal/util/function/rerank/ali_rerank_provider.go
@@ -64,10 +64,7 @@ func newAliProvider(params []*commonpb.KeyValuePair, conf map[string]string, cre
 	if modelName == "" {
 		return nil, merr.WrapErrParameterMissingMsg("ali rerank model name is required")
 	}
-	timeoutMs, err := models.ResolveTimeoutMs(params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(params)
 
 	provider := aliProvider{
 		baseProvider: baseProvider{batchSize: maxBatch},

--- a/internal/util/function/rerank/ali_rerank_provider.go
+++ b/internal/util/function/rerank/ali_rerank_provider.go
@@ -35,6 +35,7 @@ type aliProvider struct {
 	url       string
 	modelName string
 	params    map[string]any
+	timeoutMs int64
 }
 
 func newAliProvider(params []*commonpb.KeyValuePair, conf map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (ModelProvider, error) {
@@ -63,18 +64,24 @@ func newAliProvider(params []*commonpb.KeyValuePair, conf map[string]string, cre
 	if modelName == "" {
 		return nil, merr.WrapErrParameterMissingMsg("ali rerank model name is required")
 	}
+	timeoutMs, err := models.ResolveTimeoutMs(params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := aliProvider{
 		baseProvider: baseProvider{batchSize: maxBatch},
 		client:       client,
 		url:          url,
 		modelName:    modelName,
 		params:       truncateParams,
+		timeoutMs:    timeoutMs,
 	}
 	return &provider, nil
 }
 
 func (provider *aliProvider) Rerank(ctx context.Context, query string, docs []string) ([]float32, error) {
-	rerankResp, err := provider.client.Rerank(provider.url, provider.modelName, query, docs, provider.params, 30)
+	rerankResp, err := provider.client.Rerank(provider.url, provider.modelName, query, docs, provider.params, provider.timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/rerank/cohere_rerank_provider.go
+++ b/internal/util/function/rerank/cohere_rerank_provider.go
@@ -36,6 +36,7 @@ type cohereProvider struct {
 	url          string
 	modelName    string
 	params       map[string]any
+	timeoutMs    int64
 }
 
 func newCohereProvider(params []*commonpb.KeyValuePair, conf map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (ModelProvider, error) {
@@ -75,18 +76,24 @@ func newCohereProvider(params []*commonpb.KeyValuePair, conf map[string]string, 
 	if modelName == "" {
 		return nil, merr.WrapErrParameterMissingMsg("cohere rerank model name is required")
 	}
+	timeoutMs, err := models.ResolveTimeoutMs(params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := cohereProvider{
 		baseProvider: baseProvider{batchSize: maxBatch},
 		cohereClient: cohereClient,
 		url:          url,
 		modelName:    modelName,
 		params:       nil,
+		timeoutMs:    timeoutMs,
 	}
 	return &provider, nil
 }
 
 func (provider *cohereProvider) Rerank(ctx context.Context, query string, docs []string) ([]float32, error) {
-	rerankResp, err := provider.cohereClient.Rerank(provider.url, provider.modelName, query, docs, nil, 30)
+	rerankResp, err := provider.cohereClient.Rerank(provider.url, provider.modelName, query, docs, nil, provider.timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/rerank/cohere_rerank_provider.go
+++ b/internal/util/function/rerank/cohere_rerank_provider.go
@@ -76,10 +76,7 @@ func newCohereProvider(params []*commonpb.KeyValuePair, conf map[string]string, 
 	if modelName == "" {
 		return nil, merr.WrapErrParameterMissingMsg("cohere rerank model name is required")
 	}
-	timeoutMs, err := models.ResolveTimeoutMs(params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(params)
 
 	provider := cohereProvider{
 		baseProvider: baseProvider{batchSize: maxBatch},

--- a/internal/util/function/rerank/model_function_test.go
+++ b/internal/util/function/rerank/model_function_test.go
@@ -264,6 +264,25 @@ func (s *RerankModelSuite) TestNewProvider() {
 		_, err := NewModelProvider(params, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
 		s.NoError(err)
 	}
+	{
+		params := []*commonpb.KeyValuePair{
+			{Key: providerParamName, Value: "ali"},
+			{Key: models.ModelNameParamKey, Value: "ali-test"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.TimeoutMsParamKey, Value: "invalid"},
+		}
+		_, err := NewModelProvider(params, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+		s.ErrorContains(err, "is not a valid number")
+	}
+	{
+		params := []*commonpb.KeyValuePair{
+			{Key: providerParamName, Value: "ali"},
+			{Key: models.ModelNameParamKey, Value: "ali-test"},
+			{Key: models.TimeoutMsParamKey, Value: "0"},
+		}
+		_, err := NewModelProvider(params, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+		s.ErrorContains(err, "must be greater than 0")
+	}
 }
 
 func (s *RerankModelSuite) TestCallVllm() {

--- a/internal/util/function/rerank/model_function_test.go
+++ b/internal/util/function/rerank/model_function_test.go
@@ -271,8 +271,10 @@ func (s *RerankModelSuite) TestNewProvider() {
 			{Key: models.CredentialParamKey, Value: "mock"},
 			{Key: models.TimeoutMsParamKey, Value: "invalid"},
 		}
+		// an invalid timeout_ms is logged and ignored (falls back to the
+		// default), so it must not break provider construction
 		_, err := NewModelProvider(params, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
-		s.ErrorContains(err, "is not a valid number")
+		s.NoError(err)
 	}
 	{
 		params := []*commonpb.KeyValuePair{
@@ -280,8 +282,9 @@ func (s *RerankModelSuite) TestNewProvider() {
 			{Key: models.ModelNameParamKey, Value: "ali-test"},
 			{Key: models.TimeoutMsParamKey, Value: "0"},
 		}
+		// a non-positive timeout_ms also falls back to the default
 		_, err := NewModelProvider(params, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
-		s.ErrorContains(err, "must be greater than 0")
+		s.NoError(err)
 	}
 }
 

--- a/internal/util/function/rerank/siliconflow_rerank_provider.go
+++ b/internal/util/function/rerank/siliconflow_rerank_provider.go
@@ -36,6 +36,7 @@ type siliconflowProvider struct {
 	url               string
 	modelName         string
 	params            map[string]any
+	timeoutMs         int64
 }
 
 func newSiliconflowProvider(params []*commonpb.KeyValuePair, conf map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (ModelProvider, error) {
@@ -83,18 +84,24 @@ func newSiliconflowProvider(params []*commonpb.KeyValuePair, conf map[string]str
 		return nil, merr.WrapErrParameterMissingMsg("siliconflow rerank model name is required")
 	}
 
+	timeoutMs, err := models.ResolveTimeoutMs(params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := siliconflowProvider{
 		baseProvider:      baseProvider{batchSize: maxBatch},
 		siliconflowClient: siliconflowClient,
 		url:               url,
 		modelName:         modelName,
 		params:            rankParams,
+		timeoutMs:         timeoutMs,
 	}
 	return &provider, nil
 }
 
 func (provider *siliconflowProvider) Rerank(ctx context.Context, query string, docs []string) ([]float32, error) {
-	rerankResp, err := provider.siliconflowClient.Rerank(provider.url, provider.modelName, query, docs, nil, 30)
+	rerankResp, err := provider.siliconflowClient.Rerank(provider.url, provider.modelName, query, docs, nil, provider.timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/rerank/siliconflow_rerank_provider.go
+++ b/internal/util/function/rerank/siliconflow_rerank_provider.go
@@ -84,10 +84,7 @@ func newSiliconflowProvider(params []*commonpb.KeyValuePair, conf map[string]str
 		return nil, merr.WrapErrParameterMissingMsg("siliconflow rerank model name is required")
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(params)
 
 	provider := siliconflowProvider{
 		baseProvider:      baseProvider{batchSize: maxBatch},

--- a/internal/util/function/rerank/tei_rerank_provider.go
+++ b/internal/util/function/rerank/tei_rerank_provider.go
@@ -77,10 +77,7 @@ func newTeiProvider(params []*commonpb.KeyValuePair, conf map[string]string, cre
 		return nil, err
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(params)
 
 	provider := teiProvider{
 		baseProvider: baseProvider{batchSize: maxBatch},

--- a/internal/util/function/rerank/tei_rerank_provider.go
+++ b/internal/util/function/rerank/tei_rerank_provider.go
@@ -32,8 +32,9 @@ import (
 
 type teiProvider struct {
 	baseProvider
-	client *tei.TEIClient
-	params map[string]any
+	client    *tei.TEIClient
+	params    map[string]any
+	timeoutMs int64
 }
 
 func newTeiProvider(params []*commonpb.KeyValuePair, conf map[string]string, credentials *credentials.Credentials) (ModelProvider, error) {
@@ -76,16 +77,22 @@ func newTeiProvider(params []*commonpb.KeyValuePair, conf map[string]string, cre
 		return nil, err
 	}
 
+	timeoutMs, err := models.ResolveTimeoutMs(params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := teiProvider{
 		baseProvider: baseProvider{batchSize: maxBatch},
 		client:       client,
 		params:       truncateParams,
+		timeoutMs:    timeoutMs,
 	}
 	return &provider, nil
 }
 
 func (provider *teiProvider) Rerank(ctx context.Context, query string, docs []string) ([]float32, error) {
-	rerankResp, err := provider.client.Rerank(query, docs, provider.params, 30)
+	rerankResp, err := provider.client.Rerank(query, docs, provider.params, provider.timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/rerank/vllm_rerank_provider.go
+++ b/internal/util/function/rerank/vllm_rerank_provider.go
@@ -74,10 +74,7 @@ func newVllmProvider(params []*commonpb.KeyValuePair, conf map[string]string, cr
 		return nil, err
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(params)
 
 	provider := vllmProvider{
 		baseProvider:   baseProvider{batchSize: maxBatch},

--- a/internal/util/function/rerank/vllm_rerank_provider.go
+++ b/internal/util/function/rerank/vllm_rerank_provider.go
@@ -34,6 +34,7 @@ type vllmProvider struct {
 	baseProvider
 	client         *vllm.VLLMClient
 	truncateParams map[string]any
+	timeoutMs      int64
 }
 
 func newVllmProvider(params []*commonpb.KeyValuePair, conf map[string]string, credentials *credentials.Credentials) (ModelProvider, error) {
@@ -73,16 +74,22 @@ func newVllmProvider(params []*commonpb.KeyValuePair, conf map[string]string, cr
 		return nil, err
 	}
 
+	timeoutMs, err := models.ResolveTimeoutMs(params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := vllmProvider{
 		baseProvider:   baseProvider{batchSize: maxBatch},
 		client:         client,
 		truncateParams: truncateParams,
+		timeoutMs:      timeoutMs,
 	}
 	return &provider, nil
 }
 
 func (provider *vllmProvider) Rerank(ctx context.Context, query string, docs []string) ([]float32, error) {
-	rerankResp, err := provider.client.Rerank(query, docs, provider.truncateParams, 30)
+	rerankResp, err := provider.client.Rerank(query, docs, provider.truncateParams, provider.timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/rerank/voyageai_rerank_provider.go
+++ b/internal/util/function/rerank/voyageai_rerank_provider.go
@@ -36,6 +36,7 @@ type voyageaiProvider struct {
 	url            string
 	modelName      string
 	params         map[string]any
+	timeoutMs      int64
 }
 
 func newVoyageaiProvider(params []*commonpb.KeyValuePair, conf map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (ModelProvider, error) {
@@ -73,18 +74,24 @@ func newVoyageaiProvider(params []*commonpb.KeyValuePair, conf map[string]string
 	if modelName == "" {
 		return nil, merr.WrapErrParameterMissingMsg("voyageai rerank model name is required")
 	}
+	timeoutMs, err := models.ResolveTimeoutMs(params)
+	if err != nil {
+		return nil, err
+	}
+
 	provider := voyageaiProvider{
 		baseProvider:   baseProvider{batchSize: maxBatch},
 		voyageaiClient: voyageaiClient,
 		url:            url,
 		modelName:      modelName,
 		params:         modelParams,
+		timeoutMs:      timeoutMs,
 	}
 	return &provider, nil
 }
 
 func (provider *voyageaiProvider) Rerank(ctx context.Context, query string, docs []string) ([]float32, error) {
-	rerankResp, err := provider.voyageaiClient.Rerank(provider.url, provider.modelName, query, docs, nil, 30)
+	rerankResp, err := provider.voyageaiClient.Rerank(provider.url, provider.modelName, query, docs, nil, provider.timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/rerank/voyageai_rerank_provider.go
+++ b/internal/util/function/rerank/voyageai_rerank_provider.go
@@ -74,10 +74,7 @@ func newVoyageaiProvider(params []*commonpb.KeyValuePair, conf map[string]string
 	if modelName == "" {
 		return nil, merr.WrapErrParameterMissingMsg("voyageai rerank model name is required")
 	}
-	timeoutMs, err := models.ResolveTimeoutMs(params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(params)
 
 	provider := voyageaiProvider{
 		baseProvider:   baseProvider{batchSize: maxBatch},

--- a/internal/util/function/rerank/zilliz_rerank_provider.go
+++ b/internal/util/function/rerank/zilliz_rerank_provider.go
@@ -46,12 +46,19 @@ func newZillizProvider(params []*commonpb.KeyValuePair, conf map[string]string, 
 			if maxBatch, err = parseMaxBatch(param.Value); err != nil {
 				return nil, err
 			}
+		case models.TimeoutMsParamKey:
+			// consumed by ResolveTimeoutMs; not a model-service param
 		default:
 			modelParams[param.Key] = param.Value
 		}
 	}
 
-	c, err := zilliz.NewZilliClient(modelDeploymentID, extraInfo.ClusterID, extraInfo.DBName, conf)
+	timeoutMs, err := models.ResolveTimeoutMs(params)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := zilliz.NewZilliClient(modelDeploymentID, extraInfo.ClusterID, extraInfo.DBName, conf, timeoutMs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/rerank/zilliz_rerank_provider.go
+++ b/internal/util/function/rerank/zilliz_rerank_provider.go
@@ -53,10 +53,7 @@ func newZillizProvider(params []*commonpb.KeyValuePair, conf map[string]string, 
 		}
 	}
 
-	timeoutMs, err := models.ResolveTimeoutMs(params)
-	if err != nil {
-		return nil, err
-	}
+	timeoutMs := models.ResolveTimeoutMs(params)
 
 	c, err := zilliz.NewZilliClient(modelDeploymentID, extraInfo.ClusterID, extraInfo.DBName, conf, timeoutMs)
 	if err != nil {

--- a/internal/util/function/rerank/zilliz_rerank_provider_test.go
+++ b/internal/util/function/rerank/zilliz_rerank_provider_test.go
@@ -33,7 +33,7 @@ import (
 
 // RerankClient interface for testing
 type RerankClient interface {
-	Rerank(ctx context.Context, query string, texts []string, params map[string]string, timeoutSec int64) ([]float32, error)
+	Rerank(ctx context.Context, query string, texts []string, params map[string]string, timeoutMs int64) ([]float32, error)
 }
 
 // MockZillizClient is a mock implementation of RerankClient for testing
@@ -41,8 +41,8 @@ type MockZillizClient struct {
 	mock.Mock
 }
 
-func (m *MockZillizClient) Rerank(ctx context.Context, query string, texts []string, params map[string]string, timeoutSec int64) ([]float32, error) {
-	args := m.Called(ctx, query, texts, params, timeoutSec)
+func (m *MockZillizClient) Rerank(ctx context.Context, query string, texts []string, params map[string]string, timeoutMs int64) ([]float32, error) {
+	args := m.Called(ctx, query, texts, params, timeoutMs)
 	return args.Get(0).([]float32), args.Error(1)
 }
 
@@ -63,7 +63,7 @@ type testZillzProvider struct {
 }
 
 func (provider *testZillzProvider) Rerank(ctx context.Context, query string, docs []string) ([]float32, error) {
-	return provider.client.Rerank(ctx, query, docs, provider.params, 30)
+	return provider.client.Rerank(ctx, query, docs, provider.params, 30000)
 }
 
 func TestZillizRerankProvider(t *testing.T) {
@@ -277,7 +277,7 @@ func (s *ZillizRerankProviderSuite) TestZillzProvider_Rerank_Success() {
 	params := map[string]string{"param1": "value1"}
 	expectedScores := []float32{0.9, 0.7, 0.5}
 
-	mockClient.On("Rerank", ctx, query, docs, params, int64(30)).Return(expectedScores, nil)
+	mockClient.On("Rerank", ctx, query, docs, params, int64(30000)).Return(expectedScores, nil)
 
 	// Create test provider with mock client
 	provider := &testZillzProvider{
@@ -305,7 +305,7 @@ func (s *ZillizRerankProviderSuite) TestZillzProvider_Rerank_Error() {
 	params := map[string]string{"param1": "value1"}
 	expectedError := errors.New("rerank service error")
 
-	mockClient.On("Rerank", ctx, query, docs, params, int64(30)).Return([]float32(nil), expectedError)
+	mockClient.On("Rerank", ctx, query, docs, params, int64(30000)).Return([]float32(nil), expectedError)
 
 	// Create test provider with mock client
 	provider := &testZillzProvider{
@@ -368,7 +368,7 @@ func (s *ZillizRerankProviderSuite) TestZillzProvider_Rerank_WithDifferentParams
 	emptyParams := map[string]string{}
 	expectedScores := []float32{0.8, 0.6}
 
-	mockClient.On("Rerank", ctx, query, docs, emptyParams, int64(30)).Return(expectedScores, nil)
+	mockClient.On("Rerank", ctx, query, docs, emptyParams, int64(30000)).Return(expectedScores, nil)
 
 	// Create test provider with empty params
 	provider := &testZillzProvider{
@@ -396,7 +396,7 @@ func (s *ZillizRerankProviderSuite) TestZillzProvider_Rerank_EmptyDocs() {
 	params := map[string]string{}
 	expectedScores := []float32{}
 
-	mockClient.On("Rerank", ctx, query, docs, params, int64(30)).Return(expectedScores, nil)
+	mockClient.On("Rerank", ctx, query, docs, params, int64(30000)).Return(expectedScores, nil)
 
 	// Create test provider
 	provider := &testZillzProvider{
@@ -477,7 +477,7 @@ func BenchmarkZillzProvider_Rerank(b *testing.B) {
 	expectedScores := []float32{0.9, 0.8, 0.7, 0.6, 0.5}
 
 	// Set up the mock to be called many times
-	mockClient.On("Rerank", ctx, query, docs, params, int64(30)).Return(expectedScores, nil)
+	mockClient.On("Rerank", ctx, query, docs, params, int64(30000)).Return(expectedScores, nil)
 
 	// Create test provider with mock client
 	provider := &testZillzProvider{

--- a/pkg/util/paramtable/function_param.go
+++ b/pkg/util/paramtable/function_param.go
@@ -17,11 +17,13 @@
 package paramtable
 
 import (
+	"strconv"
 	"strings"
 )
 
 type functionConfig struct {
 	BatchFactor                   ParamItem  `refreshable:"true"`
+	ModelRequestTimeoutMs         ParamItem  `refreshable:"true"`
 	TextEmbeddingProviders        ParamGroup `refreshable:"true"`
 	RerankModelProviders          ParamGroup `refreshable:"true"`
 	LocalResourcePath             ParamItem  `refreshable:"true"`
@@ -38,6 +40,25 @@ func (p *functionConfig) init(base *BaseTable) {
 		DefaultValue: "5",
 	}
 	p.BatchFactor.Init(base.mgr)
+
+	p.ModelRequestTimeoutMs = ParamItem{
+		Key:          "function.model.timeout_ms",
+		Version:      "2.6.12",
+		DefaultValue: "30000",
+		Formatter: func(v string) string {
+			if v == "" {
+				return "30000"
+			}
+			timeoutMs, err := strconv.ParseInt(v, 10, 64)
+			if err != nil || timeoutMs <= 0 {
+				return "30000"
+			}
+			return v
+		},
+		Export: true,
+		Doc:    "Global timeout in milliseconds for external model requests. Function param timeout_ms overrides it.",
+	}
+	p.ModelRequestTimeoutMs.Init(base.mgr)
 
 	p.TextEmbeddingProviders = ParamGroup{
 		KeyPrefix: "function.textEmbedding.providers.",

--- a/pkg/util/paramtable/function_param.go
+++ b/pkg/util/paramtable/function_param.go
@@ -17,13 +17,12 @@
 package paramtable
 
 import (
-	"strconv"
 	"strings"
 )
 
 type functionConfig struct {
 	BatchFactor                   ParamItem  `refreshable:"true"`
-	ModelRequestTimeoutMs         ParamItem  `refreshable:"true"`
+	ModelRequestTimeout           ParamItem  `refreshable:"true"`
 	TextEmbeddingProviders        ParamGroup `refreshable:"true"`
 	RerankModelProviders          ParamGroup `refreshable:"true"`
 	LocalResourcePath             ParamItem  `refreshable:"true"`
@@ -41,24 +40,14 @@ func (p *functionConfig) init(base *BaseTable) {
 	}
 	p.BatchFactor.Init(base.mgr)
 
-	p.ModelRequestTimeoutMs = ParamItem{
-		Key:          "function.model.timeout_ms",
+	p.ModelRequestTimeout = ParamItem{
+		Key:          "function.model.requestTimeout",
 		Version:      "2.6.12",
-		DefaultValue: "30000",
-		Formatter: func(v string) string {
-			if v == "" {
-				return "30000"
-			}
-			timeoutMs, err := strconv.ParseInt(v, 10, 64)
-			if err != nil || timeoutMs <= 0 {
-				return "30000"
-			}
-			return v
-		},
-		Export: true,
-		Doc:    "Global timeout in milliseconds for external model requests. Function param timeout_ms overrides it.",
+		DefaultValue: "30s",
+		Export:       true,
+		Doc:          "Global timeout for external model requests, e.g. 30s. Function param timeout_ms overrides it.",
 	}
-	p.ModelRequestTimeoutMs.Init(base.mgr)
+	p.ModelRequestTimeout.Init(base.mgr)
 
 	p.TextEmbeddingProviders = ParamGroup{
 		KeyPrefix: "function.textEmbedding.providers.",

--- a/pkg/util/paramtable/function_param_test.go
+++ b/pkg/util/paramtable/function_param_test.go
@@ -18,6 +18,7 @@ package paramtable
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -95,5 +96,5 @@ func TestFunctionConfig(t *testing.T) {
 	defer cfg.AnalyzerRunnerConcurrency.SwapTempValue(old)
 	assert.Equal(t, 1, cfg.GetAnalyzerRunnerConcurrency())
 
-	assert.Equal(t, 30000, cfg.ModelRequestTimeoutMs.GetAsInt())
+	assert.Equal(t, 30*time.Second, cfg.ModelRequestTimeout.GetAsDurationByParse())
 }

--- a/pkg/util/paramtable/function_param_test.go
+++ b/pkg/util/paramtable/function_param_test.go
@@ -94,4 +94,6 @@ func TestFunctionConfig(t *testing.T) {
 	old := cfg.AnalyzerRunnerConcurrency.SwapTempValue("-1")
 	defer cfg.AnalyzerRunnerConcurrency.SwapTempValue(old)
 	assert.Equal(t, 1, cfg.GetAnalyzerRunnerConcurrency())
+
+	assert.Equal(t, 30000, cfg.ModelRequestTimeoutMs.GetAsInt())
 }


### PR DESCRIPTION
issue: #50229

## What this PR does

Adds configurable request timeouts for external function model providers (embedding / rerank / highlight), and standardizes the timeout unit from **seconds → milliseconds** across all providers and clients.

### Changes
- New global config `function.model.timeout_ms` (default `30000`, refreshable, exported to `milvus.yaml`).
- New per-function param `timeout_ms` which **overrides** the global setting (`models.ResolveTimeoutMs`). Invalid / non-positive values fall back to the `30000` default.
- Converted every provider/client timeout argument from `timeoutSec` to `timeoutMs`; `PostRequest` now applies the value as milliseconds.
- Zilliz gRPC client now applies a per-request deadline via `requestContext` (previously had no request timeout).
- Bedrock embedding now derives its call context from the request `ctx` with the configured timeout (was `context.Background()`).

## Tests
- `models`: `TestParseTimeoutMs` (defaults, override, invalid, zero/negative, case-insensitive key), `TestResolveTimeoutMs` (global default + per-function override), and `TestZillizClient_RequestContext` (per-request deadline + metadata).
- `rerank`: provider param validation for invalid / non-positive `timeout_ms`.
- `paramtable`: `TestFunctionConfig` asserts the new default.
- Updated zilliz client / rerank / embedding / highlight tests for the ms unit and the new test constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)