### PR TITLE
fix: Pass OpContext to PinCells calls

### DIFF
--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -1863,10 +1863,15 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForData(
     };
 
     auto skip_index_func =
-        [op_type, arith_type, value, right_operand](
+        [op_ctx = op_ctx_, op_type, arith_type, value, right_operand](
             const SkipIndex& skip_index, FieldId field_id, int64_t chunk_id) {
-            return skip_index.CanSkipBinaryArithRange<T>(
-                field_id, chunk_id, op_type, arith_type, value, right_operand);
+            return skip_index.CanSkipBinaryArithRange<T>(op_ctx,
+                                                         field_id,
+                                                         chunk_id,
+                                                         op_type,
+                                                         arith_type,
+                                                         value,
+                                                         right_operand);
         };
 
     int64_t processed_size;

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -435,20 +435,20 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
     };
 
     auto skip_index_func =
-        [val1, val2, lower_inclusive, upper_inclusive](
+        [op_ctx = op_ctx_, val1, val2, lower_inclusive, upper_inclusive](
             const SkipIndex& skip_index, FieldId field_id, int64_t chunk_id) {
             if (lower_inclusive && upper_inclusive) {
                 return skip_index.CanSkipBinaryRange<T>(
-                    field_id, chunk_id, val1, val2, true, true);
+                    op_ctx, field_id, chunk_id, val1, val2, true, true);
             } else if (lower_inclusive && !upper_inclusive) {
                 return skip_index.CanSkipBinaryRange<T>(
-                    field_id, chunk_id, val1, val2, true, false);
+                    op_ctx, field_id, chunk_id, val1, val2, true, false);
             } else if (!lower_inclusive && upper_inclusive) {
                 return skip_index.CanSkipBinaryRange<T>(
-                    field_id, chunk_id, val1, val2, false, true);
+                    op_ctx, field_id, chunk_id, val1, val2, false, true);
             } else {
                 return skip_index.CanSkipBinaryRange<T>(
-                    field_id, chunk_id, val1, val2, false, false);
+                    op_ctx, field_id, chunk_id, val1, val2, false, false);
             }
         };
     int64_t processed_size;

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -182,7 +182,7 @@ PhyTermFilterExpr::CanSkipSegment() {
         bool res = false;
         for (int i = 0; i < num_data_chunk_; ++i) {
             if (!skip_index.CanSkipBinaryRange<T>(
-                    field_id_, i, min, max, true, true)) {
+                    op_ctx_, field_id_, i, min, max, true, true)) {
                 return false;
             } else {
                 res = true;
@@ -1153,13 +1153,14 @@ PhyTermFilterExpr::ExecVisitorImplForData(EvalCtx& context) {
     };
 
     auto skip_index_func =
-        [&cached_elements = cached_skip_elements_](
+        [op_ctx = op_ctx_, &cached_elements = cached_skip_elements_](
             const SkipIndex& skip_index, FieldId field_id, int64_t chunk_id) {
             auto* elements = std::any_cast<std::vector<T>>(&cached_elements);
             if (elements == nullptr) {
                 return false;
             }
-            return skip_index.CanSkipInQuery<T>(field_id, chunk_id, *elements);
+            return skip_index.CanSkipInQuery<T>(
+                op_ctx, field_id, chunk_id, *elements);
         };
 
     int64_t processed_size;

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1817,12 +1817,12 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
         processed_cursor += size;
     };
 
-    auto skip_index_func = [expr_type, val](const SkipIndex& skip_index,
-                                            FieldId field_id,
-                                            int64_t chunk_id) {
-        return skip_index.CanSkipUnaryRange<T>(
-            field_id, chunk_id, expr_type, val);
-    };
+    auto skip_index_func =
+        [op_ctx = op_ctx_, expr_type, val](
+            const SkipIndex& skip_index, FieldId field_id, int64_t chunk_id) {
+            return skip_index.CanSkipUnaryRange<T>(
+                op_ctx, field_id, chunk_id, expr_type, val);
+        };
 
     int64_t processed_size;
     if (has_offset_input_) {

--- a/internal/core/src/index/SkipIndex.cpp
+++ b/internal/core/src/index/SkipIndex.cpp
@@ -21,13 +21,15 @@ namespace milvus {
 static const index::NoneFieldChunkMetrics defaultFieldChunkMetrics{};
 
 const cachinglayer::PinWrapper<const index::FieldChunkMetrics*>
-SkipIndex::GetFieldChunkMetrics(milvus::FieldId field_id, int chunk_id) const {
+SkipIndex::GetFieldChunkMetrics(milvus::OpContext* op_ctx,
+                                milvus::FieldId field_id,
+                                int chunk_id) const {
     // skip index structure must be setup before using, thus we do not lock here.
     auto field_metrics = fieldChunkMetrics_.find(field_id);
     if (field_metrics != fieldChunkMetrics_.end()) {
         auto& field_chunk_metrics = field_metrics->second;
         auto ca = cachinglayer::SemiInlineGet(
-            field_chunk_metrics->PinCells(nullptr, {chunk_id}));
+            field_chunk_metrics->PinCells(op_ctx, {chunk_id}));
         auto metrics = ca->get_cell_of(chunk_id);
         return cachinglayer::PinWrapper<const index::FieldChunkMetrics*>(
             std::move(ca), metrics);
@@ -46,7 +48,7 @@ FieldChunkMetricsTranslator::get_cells(
         cells;
     cells.reserve(cids.size());
     for (auto chunk_id : cids) {
-        auto pw = column_->GetChunk(nullptr, chunk_id);
+        auto pw = column_->GetChunk(ctx, chunk_id);
         auto chunk_metrics = builder_.Build(data_type_, pw.get());
         cells.emplace_back(chunk_id, std::move(chunk_metrics));
     }

--- a/internal/core/src/index/SkipIndex.h
+++ b/internal/core/src/index/SkipIndex.h
@@ -187,14 +187,34 @@ class SkipIndex {
  public:
     template <typename T>
     std::enable_if_t<SkipIndex::IsAllowedType<T>::value, bool>
+    CanSkipUnaryRange(milvus::OpContext* op_ctx,
+                      FieldId field_id,
+                      int64_t chunk_id,
+                      OpType op_type,
+                      const T& val) const {
+        auto pw = GetFieldChunkMetrics(op_ctx, field_id, chunk_id);
+        auto field_chunk_metrics = pw.get();
+        return field_chunk_metrics->CanSkipUnaryRange(op_type,
+                                                      index::Metrics{val});
+    }
+
+    template <typename T>
+    std::enable_if_t<SkipIndex::IsAllowedType<T>::value, bool>
     CanSkipUnaryRange(FieldId field_id,
                       int64_t chunk_id,
                       OpType op_type,
                       const T& val) const {
-        auto pw = GetFieldChunkMetrics(field_id, chunk_id);
-        auto field_chunk_metrics = pw.get();
-        return field_chunk_metrics->CanSkipUnaryRange(op_type,
-                                                      index::Metrics{val});
+        return CanSkipUnaryRange<T>(nullptr, field_id, chunk_id, op_type, val);
+    }
+
+    template <typename T>
+    std::enable_if_t<!SkipIndex::IsAllowedType<T>::value, bool>
+    CanSkipUnaryRange(milvus::OpContext* op_ctx,
+                      FieldId field_id,
+                      int64_t chunk_id,
+                      OpType op_type,
+                      const T& val) const {
+        return false;
     }
 
     template <typename T>
@@ -203,7 +223,25 @@ class SkipIndex {
                       int64_t chunk_id,
                       OpType op_type,
                       const T& val) const {
-        return false;
+        return CanSkipUnaryRange<T>(nullptr, field_id, chunk_id, op_type, val);
+    }
+
+    template <typename T>
+    std::enable_if_t<SkipIndex::IsAllowedType<T>::value, bool>
+    CanSkipBinaryRange(milvus::OpContext* op_ctx,
+                       FieldId field_id,
+                       int64_t chunk_id,
+                       const T& lower_val,
+                       const T& upper_val,
+                       bool lower_inclusive,
+                       bool upper_inclusive) const {
+        auto pw = GetFieldChunkMetrics(op_ctx, field_id, chunk_id);
+        auto field_chunk_metrics = pw.get();
+        return field_chunk_metrics->CanSkipBinaryRange(
+            index::Metrics{lower_val},
+            index::Metrics{upper_val},
+            lower_inclusive,
+            upper_inclusive);
     }
 
     template <typename T>
@@ -214,13 +252,25 @@ class SkipIndex {
                        const T& upper_val,
                        bool lower_inclusive,
                        bool upper_inclusive) const {
-        auto pw = GetFieldChunkMetrics(field_id, chunk_id);
-        auto field_chunk_metrics = pw.get();
-        return field_chunk_metrics->CanSkipBinaryRange(
-            index::Metrics{lower_val},
-            index::Metrics{upper_val},
-            lower_inclusive,
-            upper_inclusive);
+        return CanSkipBinaryRange<T>(nullptr,
+                                     field_id,
+                                     chunk_id,
+                                     lower_val,
+                                     upper_val,
+                                     lower_inclusive,
+                                     upper_inclusive);
+    }
+
+    template <typename T>
+    std::enable_if_t<!SkipIndex::IsAllowedType<T>::value, bool>
+    CanSkipBinaryRange(milvus::OpContext* op_ctx,
+                       FieldId field_id,
+                       int64_t chunk_id,
+                       const T& lower_val,
+                       const T& upper_val,
+                       bool lower_inclusive,
+                       bool upper_inclusive) const {
+        return false;
     }
 
     template <typename T>
@@ -231,12 +281,19 @@ class SkipIndex {
                        const T& upper_val,
                        bool lower_inclusive,
                        bool upper_inclusive) const {
-        return false;
+        return CanSkipBinaryRange<T>(nullptr,
+                                     field_id,
+                                     chunk_id,
+                                     lower_val,
+                                     upper_val,
+                                     lower_inclusive,
+                                     upper_inclusive);
     }
 
     template <typename T>
     std::enable_if_t<SkipIndex::IsAllowedType<T>::arith_value, bool>
-    CanSkipBinaryArithRange(FieldId field_id,
+    CanSkipBinaryArithRange(milvus::OpContext* op_ctx,
+                            FieldId field_id,
                             int64_t chunk_id,
                             OpType op_type,
                             ArithOpType arith_type,
@@ -252,8 +309,11 @@ class SkipIndex {
                     return false;
                 }
             }
-            return CanSkipUnaryRange<T>(
-                field_id, chunk_id, new_op_type, static_cast<T>(new_value_hp));
+            return CanSkipUnaryRange<T>(op_ctx,
+                                        field_id,
+                                        chunk_id,
+                                        new_op_type,
+                                        static_cast<T>(new_value_hp));
         };
         switch (arith_type) {
             case ArithOpType::Add: {
@@ -296,8 +356,26 @@ class SkipIndex {
     }
 
     template <typename T>
-    std::enable_if_t<!SkipIndex::IsAllowedType<T>::arith_value, bool>
+    std::enable_if_t<SkipIndex::IsAllowedType<T>::arith_value, bool>
     CanSkipBinaryArithRange(FieldId field_id,
+                            int64_t chunk_id,
+                            OpType op_type,
+                            ArithOpType arith_type,
+                            const HighPrecisionType<T> value,
+                            const HighPrecisionType<T> right_operand) const {
+        return CanSkipBinaryArithRange<T>(nullptr,
+                                          field_id,
+                                          chunk_id,
+                                          op_type,
+                                          arith_type,
+                                          value,
+                                          right_operand);
+    }
+
+    template <typename T>
+    std::enable_if_t<!SkipIndex::IsAllowedType<T>::arith_value, bool>
+    CanSkipBinaryArithRange(milvus::OpContext* op_ctx,
+                            FieldId field_id,
                             int64_t chunk_id,
                             OpType op_type,
                             ArithOpType arith_type,
@@ -307,11 +385,29 @@ class SkipIndex {
     }
 
     template <typename T>
+    std::enable_if_t<!SkipIndex::IsAllowedType<T>::arith_value, bool>
+    CanSkipBinaryArithRange(FieldId field_id,
+                            int64_t chunk_id,
+                            OpType op_type,
+                            ArithOpType arith_type,
+                            const HighPrecisionType<T> value,
+                            const HighPrecisionType<T> right_operand) const {
+        return CanSkipBinaryArithRange<T>(nullptr,
+                                          field_id,
+                                          chunk_id,
+                                          op_type,
+                                          arith_type,
+                                          value,
+                                          right_operand);
+    }
+
+    template <typename T>
     std::enable_if_t<SkipIndex::IsAllowedType<T>::in_value, bool>
-    CanSkipInQuery(FieldId field_id,
+    CanSkipInQuery(milvus::OpContext* op_ctx,
+                   FieldId field_id,
                    int64_t chunk_id,
                    const std::vector<T>& values) const {
-        auto pw = GetFieldChunkMetrics(field_id, chunk_id);
+        auto pw = GetFieldChunkMetrics(op_ctx, field_id, chunk_id);
         auto field_chunk_metrics = pw.get();
         auto vals = std::vector<index::Metrics>{};
         vals.reserve(values.size());
@@ -322,11 +418,28 @@ class SkipIndex {
     }
 
     template <typename T>
+    std::enable_if_t<SkipIndex::IsAllowedType<T>::in_value, bool>
+    CanSkipInQuery(FieldId field_id,
+                   int64_t chunk_id,
+                   const std::vector<T>& values) const {
+        return CanSkipInQuery<T>(nullptr, field_id, chunk_id, values);
+    }
+
+    template <typename T>
+    std::enable_if_t<!SkipIndex::IsAllowedType<T>::in_value, bool>
+    CanSkipInQuery(milvus::OpContext* op_ctx,
+                   FieldId field_id,
+                   int64_t chunk_id,
+                   const std::vector<T>& values) const {
+        return false;
+    }
+
+    template <typename T>
     std::enable_if_t<!SkipIndex::IsAllowedType<T>::in_value, bool>
     CanSkipInQuery(FieldId field_id,
                    int64_t chunk_id,
                    const std::vector<T>& values) const {
-        return false;
+        return CanSkipInQuery<T>(nullptr, field_id, chunk_id, values);
     }
 
     void
@@ -380,7 +493,14 @@ class SkipIndex {
     }
 
     const cachinglayer::PinWrapper<const index::FieldChunkMetrics*>
-    GetFieldChunkMetrics(FieldId field_id, int chunk_id) const;
+    GetFieldChunkMetrics(milvus::OpContext* op_ctx,
+                         FieldId field_id,
+                         int chunk_id) const;
+
+    const cachinglayer::PinWrapper<const index::FieldChunkMetrics*>
+    GetFieldChunkMetrics(FieldId field_id, int chunk_id) const {
+        return GetFieldChunkMetrics(nullptr, field_id, chunk_id);
+    }
 
     std::unordered_map<
         FieldId,

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -449,6 +449,9 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
                 query_context->set_enable_sub_expr_cache_write(false);
             }
 
+            auto op_context = milvus::OpContext(cancel_token_);
+            query_context->set_op_context(&op_context);
+
             auto result = ExecuteTask(plan_fragment, query_context);
 
             if (result != nullptr && !result->childrens().empty()) {

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -92,7 +92,7 @@ SearchOnSealedIndex(const Schema& schema,
 
     dataset->SetIsSparse(is_sparse);
     auto accessor =
-        SemiInlineGet(field_indexing->indexing_->PinCells(nullptr, {0}));
+        SemiInlineGet(field_indexing->indexing_->PinCells(op_context, {0}));
     auto vec_index =
         dynamic_cast<index::VectorIndex*>(accessor->get_cell_of(0));
 

--- a/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
+++ b/internal/core/src/query/SearchOnSealedIndexBitsetLifetimeTest.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <folly/CancellationToken.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
@@ -257,6 +259,57 @@ TEST(SearchOnSealedIndexBitsetLifetime,
                         search_result);
 
     AssertVectorIteratorUsableAfterSearchReturns(search_result, valid_count);
+}
+
+TEST(SearchOnSealedIndexCancellation, PinVectorIndexUsesCallerOpContext) {
+    constexpr int64_t total_count = 1000;
+    constexpr int64_t topk = 10;
+
+    int64_t valid_count = 0;
+    auto valid_data = MakeValidData(total_count, valid_count);
+    auto vectors = MakeCompactVectors(valid_count, kDim);
+
+    auto schema = std::make_shared<Schema>();
+    auto vector_field = schema->AddDebugField(
+        "vector", DataType::VECTOR_FLOAT, kDim, knowhere::metric::COSINE, true);
+    auto pk_field = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_field);
+
+    auto index_base =
+        BuildNullableVectorIndex(total_count, kDim, valid_data.get(), vectors);
+
+    milvus::OpContext* observed_ctx = nullptr;
+    segcore::SealedIndexingRecord indexing_record;
+    indexing_record.append_field_indexing(
+        vector_field,
+        knowhere::metric::COSINE,
+        CreateTestCacheIndex("cancellable-search-on-sealed-index",
+                             std::move(index_base),
+                             &observed_ctx));
+
+    SearchInfo search_info;
+    search_info.field_id_ = vector_field;
+    search_info.topk_ = topk;
+    search_info.round_decimal_ = -1;
+    search_info.metric_type_ = knowhere::metric::COSINE;
+    search_info.search_params_ = knowhere::Json{
+        {knowhere::indexparam::NPROBE, "32"},
+    };
+
+    folly::CancellationSource source;
+    milvus::OpContext op_context(source.getToken());
+    SearchResult search_result;
+    SearchOnSealedIndex(*schema,
+                        indexing_record,
+                        search_info,
+                        vectors.data(),
+                        nullptr,
+                        1,
+                        BitsetView{},
+                        &op_context,
+                        search_result);
+
+    EXPECT_EQ(observed_ctx, &op_context);
 }
 
 TEST(SearchOnSealedIndexNullableNoFilter,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1552,7 +1552,7 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
             "finish_searching_vector_temperate_binlog_index");
     } else if (get_bit(index_ready_bitset_, field_id)) {
         if (search_info.global_refine_enable_ &&
-            IsIndexRefineEnabled(field_id)) {
+            IsIndexRefineEnabled(op_context, field_id)) {
             search_info.topk_ = GetEffectiveSearchTopk(search_info);
         }
         AssertInfo(vector_indexings_.is_ready(field_id),
@@ -3012,7 +3012,7 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id,
                     return iter;
                 });
             auto accessor =
-                SemiInlineGet(field_index_iter->second->PinCells(nullptr, {0}));
+                SemiInlineGet(field_index_iter->second->PinCells(op_ctx, {0}));
             auto ptr = accessor->get_cell_of(0);
             AssertInfo(ptr->HasRawData(),
                        "text raw data not found, trying to create text index "
@@ -3816,6 +3816,7 @@ ChunkedSegmentSealedImpl::IndexHasRawData(FieldId field_id) const {
 
 bool
 ChunkedSegmentSealedImpl::CalcDistByIDs(
+    milvus::OpContext* op_ctx,
     FieldId field_id,
     const knowhere::DataSetPtr& query_dataset,
     const int64_t* seg_offsets,
@@ -3827,7 +3828,7 @@ ChunkedSegmentSealedImpl::CalcDistByIDs(
     }
     auto field_indexing = vector_indexings_.get_field_indexing(field_id);
     auto accessor =
-        SemiInlineGet(field_indexing->indexing_->PinCells(nullptr, {0}));
+        SemiInlineGet(field_indexing->indexing_->PinCells(op_ctx, {0}));
     auto vec_index =
         dynamic_cast<index::VectorIndex*>(accessor->get_cell_of(0));
     if (vec_index == nullptr) {
@@ -3851,7 +3852,7 @@ ChunkedSegmentSealedImpl::CalcDistByIDs(
         labels = physical_offsets.data();
     }
     auto res = vec_index->CalcDistByIDs(
-        query_dataset, BitsetView(), labels, count, is_cosine, nullptr);
+        query_dataset, BitsetView(), labels, count, is_cosine, op_ctx);
     if (!res.has_value()) {
         return false;
     }
@@ -3864,13 +3865,14 @@ ChunkedSegmentSealedImpl::CalcDistByIDs(
 }
 
 bool
-ChunkedSegmentSealedImpl::IsIndexRefineEnabled(FieldId field_id) const {
+ChunkedSegmentSealedImpl::IsIndexRefineEnabled(milvus::OpContext* op_ctx,
+                                               FieldId field_id) const {
     if (!vector_indexings_.is_ready(field_id)) {
         return false;
     }
     auto field_indexing = vector_indexings_.get_field_indexing(field_id);
     auto accessor =
-        SemiInlineGet(field_indexing->indexing_->PinCells(nullptr, {0}));
+        SemiInlineGet(field_indexing->indexing_->PinCells(op_ctx, {0}));
     auto vec_index =
         dynamic_cast<index::VectorIndex*>(accessor->get_cell_of(0));
     return vec_index != nullptr && vec_index->IsIndexRefineEnabled();

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -187,10 +187,32 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                   const int64_t* seg_offsets,
                   size_t count,
                   bool is_cosine,
-                  float* distances) const override;
+                  float* distances) const override {
+        return CalcDistByIDs(nullptr,
+                             field_id,
+                             query_dataset,
+                             seg_offsets,
+                             count,
+                             is_cosine,
+                             distances);
+    }
 
     bool
-    IsIndexRefineEnabled(FieldId field_id) const override;
+    CalcDistByIDs(milvus::OpContext* op_ctx,
+                  FieldId field_id,
+                  const knowhere::DataSetPtr& query_dataset,
+                  const int64_t* seg_offsets,
+                  size_t count,
+                  bool is_cosine,
+                  float* distances) const;
+
+    bool
+    IsIndexRefineEnabled(FieldId field_id) const override {
+        return IsIndexRefineEnabled(nullptr, field_id);
+    }
+
+    bool
+    IsIndexRefineEnabled(milvus::OpContext* op_ctx, FieldId field_id) const;
 
     DataType
     GetFieldDataType(FieldId fieldId) const override;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -204,7 +204,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                   const int64_t* seg_offsets,
                   size_t count,
                   bool is_cosine,
-                  float* distances) const;
+                  float* distances) const override;
 
     bool
     IsIndexRefineEnabled(FieldId field_id) const override {
@@ -212,7 +212,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     }
 
     bool
-    IsIndexRefineEnabled(milvus::OpContext* op_ctx, FieldId field_id) const;
+    IsIndexRefineEnabled(milvus::OpContext* op_ctx,
+                         FieldId field_id) const override;
 
     DataType
     GetFieldDataType(FieldId fieldId) const override;

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -268,7 +268,8 @@ class SegmentInterface {
     // Compute exact distances from the index for given query vectors and candidate IDs.
     // Used for refine step in reduce phase. Returns false if not supported (e.g., no index).
     virtual bool
-    CalcDistByIDs(FieldId field_id,
+    CalcDistByIDs(milvus::OpContext* op_ctx,
+                  FieldId field_id,
                   const knowhere::DataSetPtr& query_dataset,
                   const int64_t* seg_offsets,
                   size_t count,
@@ -278,8 +279,29 @@ class SegmentInterface {
     }
 
     virtual bool
-    IsIndexRefineEnabled(FieldId field_id) const {
+    CalcDistByIDs(FieldId field_id,
+                  const knowhere::DataSetPtr& query_dataset,
+                  const int64_t* seg_offsets,
+                  size_t count,
+                  bool is_cosine,
+                  float* distances) const {
+        return CalcDistByIDs(nullptr,
+                             field_id,
+                             query_dataset,
+                             seg_offsets,
+                             count,
+                             is_cosine,
+                             distances);
+    }
+
+    virtual bool
+    IsIndexRefineEnabled(milvus::OpContext* op_ctx, FieldId field_id) const {
         return false;
+    }
+
+    virtual bool
+    IsIndexRefineEnabled(FieldId field_id) const {
+        return IsIndexRefineEnabled(nullptr, field_id);
     }
 
     virtual void

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -43,7 +43,6 @@
 #include "pb/schema.pb.h"
 #include "prometheus/histogram.h"
 #include "query/PlanImpl.h"
-#include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/SegmentInterface.h"
 #include "segcore/Utils.h"
 #include "segcore/pkVisitor.h"
@@ -129,13 +128,8 @@ ReduceHelper::IsSearchResultRefineEnabled(SearchResult* search_result) const {
         return false;
     }
     auto segment = static_cast<SegmentInterface*>(search_result->segment_);
-    if (auto* chunked_segment =
-            dynamic_cast<ChunkedSegmentSealedImpl*>(segment)) {
-        return chunked_segment->IsIndexRefineEnabled(
-            op_ctx_, plan_->plan_node_->search_info_.field_id_);
-    }
     return segment->IsIndexRefineEnabled(
-        plan_->plan_node_->search_info_.field_id_);
+        op_ctx_, plan_->plan_node_->search_info_.field_id_);
 }
 
 void
@@ -422,24 +416,13 @@ ReduceHelper::RefineOneSegment(SearchResult* search_result,
         auto result_count = static_cast<size_t>(count);
         auto* offsets = &search_result->seg_offsets_[nq_begin];
         new_distances.resize(result_count);
-        bool ok = false;
-        if (auto* chunked_segment =
-                dynamic_cast<ChunkedSegmentSealedImpl*>(segment)) {
-            ok = chunked_segment->CalcDistByIDs(op_ctx_,
-                                                field_id,
-                                                query_dataset,
-                                                offsets,
-                                                count,
-                                                is_cosine,
-                                                new_distances.data());
-        } else {
-            ok = segment->CalcDistByIDs(field_id,
-                                        query_dataset,
-                                        offsets,
-                                        count,
-                                        is_cosine,
-                                        new_distances.data());
-        }
+        bool ok = segment->CalcDistByIDs(op_ctx_,
+                                         field_id,
+                                         query_dataset,
+                                         offsets,
+                                         count,
+                                         is_cosine,
+                                         new_distances.data());
         if (!ok) {
             LOG_WARN(
                 "failed to refine distances by ids, keep approximate "

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -43,6 +43,7 @@
 #include "pb/schema.pb.h"
 #include "prometheus/histogram.h"
 #include "query/PlanImpl.h"
+#include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/SegmentInterface.h"
 #include "segcore/Utils.h"
 #include "segcore/pkVisitor.h"
@@ -128,6 +129,11 @@ ReduceHelper::IsSearchResultRefineEnabled(SearchResult* search_result) const {
         return false;
     }
     auto segment = static_cast<SegmentInterface*>(search_result->segment_);
+    if (auto* chunked_segment =
+            dynamic_cast<ChunkedSegmentSealedImpl*>(segment)) {
+        return chunked_segment->IsIndexRefineEnabled(
+            op_ctx_, plan_->plan_node_->search_info_.field_id_);
+    }
     return segment->IsIndexRefineEnabled(
         plan_->plan_node_->search_info_.field_id_);
 }
@@ -416,12 +422,24 @@ ReduceHelper::RefineOneSegment(SearchResult* search_result,
         auto result_count = static_cast<size_t>(count);
         auto* offsets = &search_result->seg_offsets_[nq_begin];
         new_distances.resize(result_count);
-        bool ok = segment->CalcDistByIDs(field_id,
-                                         query_dataset,
-                                         offsets,
-                                         count,
-                                         is_cosine,
-                                         new_distances.data());
+        bool ok = false;
+        if (auto* chunked_segment =
+                dynamic_cast<ChunkedSegmentSealedImpl*>(segment)) {
+            ok = chunked_segment->CalcDistByIDs(op_ctx_,
+                                                field_id,
+                                                query_dataset,
+                                                offsets,
+                                                count,
+                                                is_cosine,
+                                                new_distances.data());
+        } else {
+            ok = segment->CalcDistByIDs(field_id,
+                                        query_dataset,
+                                        offsets,
+                                        count,
+                                        is_cosine,
+                                        new_distances.data());
+        }
         if (!ok) {
             LOG_WARN(
                 "failed to refine distances by ids, keep approximate "

--- a/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/InterimSealedIndexTranslator.cpp
@@ -196,7 +196,7 @@ InterimSealedIndexTranslator::get_cells(
 
     bool first_build = true;
     for (int i = 0; i < num_chunk; ++i) {
-        auto pw = vec_data_->GetChunk(nullptr, i);
+        auto pw = vec_data_->GetChunk(ctx, i);
         auto chunk = pw.get();
 
         int64_t actual_row_count =

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -490,6 +490,117 @@ TEST(Sealed, with_predicate_filter_all) {
     EXPECT_EQ(sr2->get_total_result_count(), 0);
 }
 
+TEST(Sealed, SegmentInterfaceIsIndexRefineEnabledPropagatesOpContext) {
+    auto dim = 4;
+    auto N = ROW_COUNT;
+    auto metric_type = knowhere::metric::L2;
+    auto schema = std::make_shared<Schema>();
+    auto fake_id = schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, dim, metric_type);
+    auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
+    schema->set_primary_field_id(i64_fid);
+
+    auto dataset = DataGen(schema, N);
+    auto vec_col = dataset.get_col<float>(fake_id);
+
+    auto create_index_info = milvus::index::CreateIndexInfo{};
+    create_index_info.field_type = DataType::VECTOR_FLOAT;
+    create_index_info.metric_type = knowhere::metric::L2;
+    create_index_info.index_type = knowhere::IndexEnum::INDEX_HNSW;
+    create_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+    auto indexing = milvus::index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, milvus::storage::FileManagerContext());
+    auto build_conf =
+        knowhere::Json{{knowhere::meta::DIM, std::to_string(dim)},
+                       {knowhere::indexparam::HNSW_M, "16"},
+                       {knowhere::indexparam::EFCONSTRUCTION, "200"},
+                       {knowhere::indexparam::EF, "200"},
+                       {knowhere::meta::METRIC_TYPE, knowhere::metric::L2}};
+    auto database = knowhere::GenDataSet(N, dim, vec_col.data());
+    indexing->BuildWithDataset(database, build_conf);
+
+    milvus::OpContext* observed_ctx = nullptr;
+    LoadIndexInfo load_info;
+    load_info.field_id = fake_id.get();
+    load_info.index_params = GenIndexParams(indexing.get());
+    load_info.cache_index =
+        CreateTestCacheIndex("test", std::move(indexing), &observed_ctx);
+    load_info.index_params["metric_type"] = "L2";
+
+    auto sealed_segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+    sealed_segment->DropFieldData(fake_id);
+    sealed_segment->LoadIndex(load_info);
+
+    auto* segment_interface =
+        static_cast<SegmentInterface*>(sealed_segment.get());
+    folly::CancellationSource source;
+    milvus::OpContext op_context(source.getToken());
+
+    EXPECT_TRUE(segment_interface->IsIndexRefineEnabled(&op_context, fake_id));
+    EXPECT_EQ(observed_ctx, &op_context);
+}
+
+TEST(Sealed, SegmentInterfaceCalcDistByIDsPropagatesOpContext) {
+    auto dim = 4;
+    auto N = ROW_COUNT;
+    auto metric_type = knowhere::metric::L2;
+    auto schema = std::make_shared<Schema>();
+    auto fake_id = schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, dim, metric_type);
+    auto i64_fid = schema->AddDebugField("counter", DataType::INT64);
+    schema->set_primary_field_id(i64_fid);
+
+    auto dataset = DataGen(schema, N);
+    auto vec_col = dataset.get_col<float>(fake_id);
+
+    auto create_index_info = milvus::index::CreateIndexInfo{};
+    create_index_info.field_type = DataType::VECTOR_FLOAT;
+    create_index_info.metric_type = knowhere::metric::L2;
+    create_index_info.index_type = knowhere::IndexEnum::INDEX_HNSW;
+    create_index_info.index_engine_version =
+        knowhere::Version::GetCurrentVersion().VersionNumber();
+    auto indexing = milvus::index::IndexFactory::GetInstance().CreateIndex(
+        create_index_info, milvus::storage::FileManagerContext());
+    auto build_conf =
+        knowhere::Json{{knowhere::meta::DIM, std::to_string(dim)},
+                       {knowhere::indexparam::HNSW_M, "16"},
+                       {knowhere::indexparam::EFCONSTRUCTION, "200"},
+                       {knowhere::indexparam::EF, "200"},
+                       {knowhere::meta::METRIC_TYPE, knowhere::metric::L2}};
+    auto database = knowhere::GenDataSet(N, dim, vec_col.data());
+    indexing->BuildWithDataset(database, build_conf);
+
+    milvus::OpContext* observed_ctx = nullptr;
+    LoadIndexInfo load_info;
+    load_info.field_id = fake_id.get();
+    load_info.index_params = GenIndexParams(indexing.get());
+    load_info.cache_index =
+        CreateTestCacheIndex("test", std::move(indexing), &observed_ctx);
+    load_info.index_params["metric_type"] = "L2";
+
+    auto sealed_segment = CreateSealedWithFieldDataLoaded(schema, dataset);
+    sealed_segment->DropFieldData(fake_id);
+    sealed_segment->LoadIndex(load_info);
+
+    auto* segment_interface =
+        static_cast<SegmentInterface*>(sealed_segment.get());
+    auto query_dataset = knowhere::GenDataSet(1, dim, vec_col.data());
+    auto seg_offsets = std::array<int64_t, 1>{0};
+    auto distances = std::array<float, 1>{0.0F};
+    folly::CancellationSource source;
+    milvus::OpContext op_context(source.getToken());
+
+    EXPECT_TRUE(segment_interface->CalcDistByIDs(&op_context,
+                                                 fake_id,
+                                                 query_dataset,
+                                                 seg_offsets.data(),
+                                                 seg_offsets.size(),
+                                                 false,
+                                                 distances.data()));
+    EXPECT_EQ(observed_ctx, &op_context);
+}
+
 TEST(Sealed, LoadFieldData) {
     auto dim = 4;
     auto N = ROW_COUNT;

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -519,6 +519,9 @@ TEST(Sealed, SegmentInterfaceIsIndexRefineEnabledPropagatesOpContext) {
                        {knowhere::meta::METRIC_TYPE, knowhere::metric::L2}};
     auto database = knowhere::GenDataSet(N, dim, vec_col.data());
     indexing->BuildWithDataset(database, build_conf);
+    auto expected_refine_enabled =
+        dynamic_cast<index::VectorIndex*>(indexing.get())
+            ->IsIndexRefineEnabled();
 
     milvus::OpContext* observed_ctx = nullptr;
     LoadIndexInfo load_info;
@@ -537,7 +540,8 @@ TEST(Sealed, SegmentInterfaceIsIndexRefineEnabledPropagatesOpContext) {
     folly::CancellationSource source;
     milvus::OpContext op_context(source.getToken());
 
-    EXPECT_TRUE(segment_interface->IsIndexRefineEnabled(&op_context, fake_id));
+    EXPECT_EQ(segment_interface->IsIndexRefineEnabled(&op_context, fake_id),
+              expected_refine_enabled);
     EXPECT_EQ(observed_ctx, &op_context);
 }
 

--- a/internal/core/unittest/test_utils/cachinglayer_test_utils.h
+++ b/internal/core/unittest/test_utils/cachinglayer_test_utils.h
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "cachinglayer/Manager.h"
@@ -192,9 +193,16 @@ class TestIndexTranslator : public Translator<milvus::index::IndexBase> {
  public:
     TestIndexTranslator(std::string key,
                         std::unique_ptr<milvus::index::IndexBase>&& index)
+        : TestIndexTranslator(std::move(key), std::move(index), nullptr) {
+    }
+
+    TestIndexTranslator(std::string key,
+                        std::unique_ptr<milvus::index::IndexBase>&& index,
+                        milvus::OpContext** observed_ctx)
         : Translator<milvus::index::IndexBase>(),
           key_(key),
           index_(std::move(index)),
+          observed_ctx_(observed_ctx),
           meta_(milvus::cachinglayer::Meta(
               StorageType::MEMORY,
               CellIdMappingMode::IDENTICAL,
@@ -236,6 +244,9 @@ class TestIndexTranslator : public Translator<milvus::index::IndexBase> {
 
     std::vector<std::pair<cid_t, std::unique_ptr<milvus::index::IndexBase>>>
     get_cells(milvus::OpContext* ctx, const std::vector<cid_t>& cids) override {
+        if (observed_ctx_ != nullptr) {
+            *observed_ctx_ = ctx;
+        }
         std::vector<std::pair<cid_t, std::unique_ptr<milvus::index::IndexBase>>>
             res;
         res.reserve(cids.size());
@@ -249,6 +260,7 @@ class TestIndexTranslator : public Translator<milvus::index::IndexBase> {
  private:
     std::string key_;
     std::unique_ptr<milvus::index::IndexBase> index_;
+    milvus::OpContext** observed_ctx_{nullptr};
     milvus::cachinglayer::Meta meta_;
 };
 
@@ -258,6 +270,17 @@ CreateTestCacheIndex(std::string key,
     std::unique_ptr<milvus::cachinglayer::Translator<milvus::index::IndexBase>>
         translator = std::make_unique<TestIndexTranslator>(std::move(key),
                                                            std::move(index));
+    return milvus::cachinglayer::Manager::GetInstance().CreateCacheSlot(
+        std::move(translator));
+}
+
+inline index::CacheIndexBasePtr
+CreateTestCacheIndex(std::string key,
+                     std::unique_ptr<milvus::index::IndexBase>&& index,
+                     milvus::OpContext** observed_ctx) {
+    std::unique_ptr<milvus::cachinglayer::Translator<milvus::index::IndexBase>>
+        translator = std::make_unique<TestIndexTranslator>(
+            std::move(key), std::move(index), observed_ctx);
     return milvus::cachinglayer::Manager::GetInstance().CreateCacheSlot(
         std::move(translator));
 }


### PR DESCRIPTION
Related to #50230

Pass op ctx to `PinCells` calls during search & query cgo calls so that AsyncCGO cancellation could be detected by cachying layer avoiding waste waiting time for resource requesting.