### PR TITLE
enhance: force CRC32C when OpenSSL FIPS is enabled

### DIFF
--- a/cmd/milvus/boring_disabled.go
+++ b/cmd/milvus/boring_disabled.go
@@ -2,8 +2,12 @@
 
 package milvus
 
+import "github.com/milvus-io/milvus/pkg/v3/util/fips"
+
 func boringEnabled() bool {
 	return false
 }
 
-func maybeEnableOpenSSLFIPS() {}
+func maybeEnableOpenSSLFIPS() bool {
+	return fips.MaybeEnableOpenSSLFIPS()
+}

--- a/cmd/milvus/boring_enabled.go
+++ b/cmd/milvus/boring_enabled.go
@@ -2,56 +2,16 @@
 
 package milvus
 
-/*
-#include <openssl/conf.h>
-#include <openssl/evp.h>
-#include <openssl/provider.h>
-#include <openssl/rand.h>
-
-static int enableOpenSSLFIPS() {
-	unsigned char buf[1];
-
-	if (!OSSL_LIB_CTX_load_config(NULL, "/milvus/configs/ssl/openssl-fips.cnf")) {
-		return -1;  // config load failed
-	}
-	if (!EVP_default_properties_is_fips_enabled(NULL)) {
-		return 0;   // config loaded but fips=yes not set
-	}
-	// EVP_default_properties_is_fips_enabled only checks the property string,
-	// not whether the FIPS provider is actually loaded. Verify by checking
-	// that RAND_bytes works (requires a working FIPS DRBG).
-	if (RAND_bytes(buf, 1) != 1) {
-		return -2;  // FIPS property set but provider not functional
-	}
-	return 1;       // FIPS truly enabled and functional
-}
-*/
-import "C"
-
 import (
 	"crypto/boring"
-	"log"
-	"sync"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/fips"
 )
 
 func boringEnabled() bool {
 	return boring.Enabled()
 }
 
-var fipsOnce sync.Once
-
-func maybeEnableOpenSSLFIPS() {
-	fipsOnce.Do(func() {
-		rc := C.enableOpenSSLFIPS()
-		switch rc {
-		case 1:
-			log.Println("OpenSSL FIPS mode enabled")
-		case 0:
-			log.Println("WARNING: OpenSSL FIPS config loaded but fips=yes not set in default properties")
-		case -2:
-			log.Println("FATAL: OpenSSL FIPS property set but FIPS provider not functional (check OPENSSL_MODULES env var and .include path in openssl-fips.cnf)")
-		default:
-			log.Println("Failed to load OpenSSL FIPS config")
-		}
-	})
+func maybeEnableOpenSSLFIPS() bool {
+	return fips.MaybeEnableOpenSSLFIPS()
 }

--- a/pkg/util/fips/openssl_disabled.go
+++ b/pkg/util/fips/openssl_disabled.go
@@ -1,0 +1,23 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !boringcrypto
+
+package fips
+
+func MaybeEnableOpenSSLFIPS() bool {
+	return false
+}

--- a/pkg/util/fips/openssl_enabled.go
+++ b/pkg/util/fips/openssl_enabled.go
@@ -1,0 +1,73 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build boringcrypto
+
+package fips
+
+/*
+#include <openssl/conf.h>
+#include <openssl/evp.h>
+#include <openssl/provider.h>
+#include <openssl/rand.h>
+
+static int enableOpenSSLFIPS() {
+	unsigned char buf[1];
+
+	if (!OSSL_LIB_CTX_load_config(NULL, "/milvus/configs/ssl/openssl-fips.cnf")) {
+		return -1;  // config load failed
+	}
+	if (!EVP_default_properties_is_fips_enabled(NULL)) {
+		return 0;   // config loaded but fips=yes not set
+	}
+	// EVP_default_properties_is_fips_enabled only checks the property string,
+	// not whether the FIPS provider is actually loaded. Verify by checking
+	// that RAND_bytes works (requires a working FIPS DRBG).
+	if (RAND_bytes(buf, 1) != 1) {
+		return -2;  // FIPS property set but provider not functional
+	}
+	return 1;       // FIPS truly enabled and functional
+}
+*/
+import "C"
+
+import (
+	"log"
+	"sync"
+)
+
+var (
+	fipsOnce           sync.Once
+	opensslFIPSEnabled bool
+)
+
+func MaybeEnableOpenSSLFIPS() bool {
+	fipsOnce.Do(func() {
+		rc := C.enableOpenSSLFIPS()
+		switch rc {
+		case 1:
+			log.Println("OpenSSL FIPS mode enabled")
+			opensslFIPSEnabled = true
+		case 0:
+			log.Println("WARNING: OpenSSL FIPS config loaded but fips=yes not set in default properties")
+		case -2:
+			log.Println("FATAL: OpenSSL FIPS property set but FIPS provider not functional (check OPENSSL_MODULES env var and .include path in openssl-fips.cnf)")
+		default:
+			log.Println("Failed to load OpenSSL FIPS config")
+		}
+	})
+	return opensslFIPSEnabled
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/fips"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
@@ -128,6 +129,10 @@ func (p *ComponentParam) init(bt *BaseTable) {
 	p.ServiceParam.init(bt)
 
 	p.CommonCfg.init(bt)
+	if fips.MaybeEnableOpenSSLFIPS() && !p.MinioCfg.UseCRC32C.GetAsBool() {
+		log.Warn("FIPS mode requires CRC32C checksum for S3 PutObject requests; override minio.ssl.useCRC32C to true at runtime")
+		p.MinioCfg.UseCRC32C.SwapTempValue("true")
+	}
 	p.QuotaConfig.init(bt)
 	p.AutoIndexConfig.init(bt)
 	p.TraceCfg.init(bt)


### PR DESCRIPTION
issue: #48359

This change makes Milvus automatically use CRC32C for S3 PutObject requests when OpenSSL FIPS mode is active. In FIPS mode, checksum choices are more constrained, so relying on the configured MinIO checksum behavior can lead to requests using an algorithm that is not acceptable in that runtime.

The implementation moves OpenSSL FIPS enablement into the shared `pkg/util/fips` package and makes it return whether FIPS was actually enabled. That lets startup code keep enabling OpenSSL FIPS as before, while paramtable can also reuse the same state during config initialization.

When FIPS is successfully enabled and `minio.ssl.useCRC32C` is still false, Milvus now logs a warning and temporarily overrides the runtime value to true. This keeps the user-facing config unchanged, but makes the effective runtime behavior compatible with FIPS requirements.