### PR TITLE
fix: [cp 2.6] parse kafka and rmq message ids as signed

### DIFF
--- a/pkg/streaming/walimpls/impls/kafka/kafka_test.go
+++ b/pkg/streaming/walimpls/impls/kafka/kafka_test.go
@@ -26,6 +26,10 @@ func TestRegistry(t *testing.T) {
 	id, err := message.UnmarshalMessageID(&commonpb.MessageID{WALName: commonpb.WALName(message.WALNameKafka), Id: kafkaID(123).Marshal()})
 	assert.NoError(t, err)
 	assert.True(t, id.EQ(kafkaID(123)))
+
+	id, err = message.UnmarshalMessageID(kafkaID(-2).IntoProto())
+	assert.NoError(t, err)
+	assert.True(t, id.EQ(kafkaID(-2)))
 }
 
 func TestKafka(t *testing.T) {

--- a/pkg/streaming/walimpls/impls/kafka/message_id.go
+++ b/pkg/streaming/walimpls/impls/kafka/message_id.go
@@ -19,7 +19,7 @@ func UnmarshalMessageID(data string) (message.MessageID, error) {
 }
 
 func unmarshalMessageID(data string) (kafkaID, error) {
-	v, err := message.DecodeUint64(data)
+	v, err := message.DecodeInt64(data)
 	if err != nil {
 		return 0, errors.Wrapf(message.ErrInvalidMessageID, "decode kafkaID fail with err: %s, id: %s", err.Error(), data)
 	}

--- a/pkg/streaming/walimpls/impls/kafka/message_id_test.go
+++ b/pkg/streaming/walimpls/impls/kafka/message_id_test.go
@@ -27,6 +27,10 @@ func TestMessageID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, kafkaID(1), msgID)
 
+	msgID, err = UnmarshalMessageID(kafkaID(kafka.OffsetBeginning).Marshal())
+	assert.NoError(t, err)
+	assert.Equal(t, kafkaID(kafka.OffsetBeginning), msgID)
+
 	_, err = UnmarshalMessageID(string([]byte{0x01, 0x02, 0x03, 0x04}))
 	assert.Error(t, err)
 }

--- a/pkg/streaming/walimpls/impls/rmq/message_id_test.go
+++ b/pkg/streaming/walimpls/impls/rmq/message_id_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	rawRocksmq "github.com/milvus-io/milvus/pkg/v2/mq/mqimpl/rocksmq/client"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 )
 
@@ -24,6 +25,10 @@ func TestMessageID(t *testing.T) {
 	msgID, err := UnmarshalMessageID(rmqID(1).Marshal())
 	assert.NoError(t, err)
 	assert.Equal(t, rmqID(1), msgID)
+
+	msgID, err = UnmarshalMessageID(rmqID(rawRocksmq.EarliestMessageID()).Marshal())
+	assert.NoError(t, err)
+	assert.Equal(t, rmqID(rawRocksmq.EarliestMessageID()), msgID)
 
 	_, err = UnmarshalMessageID(string([]byte{0x01, 0x02, 0x03, 0x04}))
 	assert.Error(t, err)

--- a/pkg/streaming/walimpls/impls/rmq/rmq_test.go
+++ b/pkg/streaming/walimpls/impls/rmq/rmq_test.go
@@ -37,6 +37,10 @@ func TestRegistry(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.True(t, id.EQ(rmqID(1)))
+
+	id, err = message.UnmarshalMessageID(rmqID(-1).IntoProto())
+	assert.NoError(t, err)
+	assert.True(t, id.EQ(rmqID(-1)))
 }
 
 func TestWAL(t *testing.T) {


### PR DESCRIPTION
issue: #50240
pr: #50241

- kafka wal: parse message IDs as signed offsets so special positions such as OffsetBeginning can recover from checkpoints
- rmq wal: keep negative earliest-position regression coverage for signed message ID handling
- wal tests: cover negative sentinel IDs through backend and registry unmarshal paths