### PR TITLE
fix: use initialized CPU_NUM for futures executors

### DIFF
--- a/internal/core/src/futures/Executor.cpp
+++ b/internal/core/src/futures/Executor.cpp
@@ -9,12 +9,13 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <algorithm>
 #include <memory>
-#include <thread>
 
 #include "Executor.h"
 #include "folly/executors/CPUThreadPoolExecutor.h"
 #include "folly/executors/thread_factory/NamedThreadFactory.h"
+#include "storage/ThreadPool.h"
 
 namespace milvus::futures {
 
@@ -22,7 +23,7 @@ const int kNumPriority = 3;
 
 folly::CPUThreadPoolExecutor*
 getSearchCPUExecutor() {
-    auto thread_num = std::thread::hardware_concurrency();
+    auto thread_num = std::max(1, milvus::CPU_NUM);
     static folly::CPUThreadPoolExecutor executor(
         thread_num,
         folly::CPUThreadPoolExecutor::makeDefaultPriorityQueue(kNumPriority),
@@ -32,7 +33,7 @@ getSearchCPUExecutor() {
 
 folly::CPUThreadPoolExecutor*
 getLoadCPUExecutor() {
-    auto thread_num = std::thread::hardware_concurrency();
+    auto thread_num = std::max(1, milvus::CPU_NUM);
     static folly::CPUThreadPoolExecutor executor(
         thread_num,
         folly::CPUThreadPoolExecutor::makeDefaultPriorityQueue(kNumPriority),


### PR DESCRIPTION
Reuse milvus::CPU_NUM in futures Executor instead of std::thread::hardware_concurrency(), so search/load CPU executor sizing follows the container-aware CPU count initialized from Go side.

issue: #50244