### PR TITLE
fix: Use remote prefix for stream-loaded disk index

### DIFF
--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -92,6 +92,8 @@ ResolveDiskAnnLoadIndexPrefix(const Config& config,
 
     auto index_prefix = GetDiskAnnFilePrefix(index_files->front());
 
+    // DiskANN stores the files for one built index in a flat directory and
+    // reconstructs file names from a single prefix during stream load.
     for (const auto& index_file : index_files.value()) {
         auto file_prefix = GetDiskAnnFilePrefix(index_file);
         AssertInfo(file_prefix == index_prefix,

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -19,6 +19,7 @@
 #include <math.h>
 #include <string.h>
 #include <algorithm>
+#include <boost/filesystem/path.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
@@ -59,6 +60,49 @@
 #include "storage/Util.h"
 
 namespace milvus::index {
+
+namespace {
+
+std::string
+GetDiskAnnFilePrefix(const std::string& index_file) {
+    auto file_name = boost::filesystem::path(index_file).filename().string();
+    AssertInfo(!file_name.empty() && file_name.size() < index_file.size(),
+               "index file path has no parent path: {}",
+               index_file);
+    // Keep the original trailing separator. Knowhere appends fixed file names
+    // such as "_mem.index.bin" directly to this prefix when stream loading.
+    return index_file.substr(0, index_file.size() - file_name.size());
+}
+
+}  // namespace
+
+std::string
+ResolveDiskAnnLoadIndexPrefix(const Config& config,
+                              const std::string& local_index_path_prefix,
+                              bool load_index_with_stream) {
+    if (!load_index_with_stream) {
+        return local_index_path_prefix;
+    }
+
+    auto index_files =
+        GetValueFromConfig<std::vector<std::string>>(config, INDEX_FILES);
+    AssertInfo(index_files.has_value() && !index_files->empty(),
+               "index file paths is empty when load disk ann index with "
+               "stream");
+
+    auto index_prefix = GetDiskAnnFilePrefix(index_files->front());
+
+    for (const auto& index_file : index_files.value()) {
+        auto file_prefix = GetDiskAnnFilePrefix(index_file);
+        AssertInfo(file_prefix == index_prefix,
+                   "stream-loaded disk index files must share the same parent "
+                   "path, expected {}, got {} from {}",
+                   index_prefix,
+                   file_prefix,
+                   index_file);
+    }
+    return index_prefix;
+}
 
 #define kSearchListMaxValue1 200    // used if tok <= 20
 #define kSearchListMaxValue2 65535  // used for topk > 20
@@ -911,9 +955,11 @@ VectorDiskAnnIndex<T>::update_load_json(const Config& config) {
     knowhere::Json load_config;
     load_config.update(config);
 
-    // set data path
+    // Non-stream load reads the local cache populated by CacheIndexToDisk.
+    // Stream load skips that cache, so the prefix must stay remote/logical.
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
-    load_config[DISK_ANN_PREFIX_PATH] = local_index_path_prefix;
+    load_config[DISK_ANN_PREFIX_PATH] = ResolveDiskAnnLoadIndexPrefix(
+        config, local_index_path_prefix, index_.LoadIndexWithStream());
 
     if (GetIndexType() == knowhere::IndexEnum::INDEX_DISKANN) {
         // set base info

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -65,13 +65,17 @@ namespace {
 
 std::string
 GetDiskAnnFilePrefix(const std::string& index_file) {
-    auto file_name = boost::filesystem::path(index_file).filename().string();
-    AssertInfo(!file_name.empty() && file_name.size() < index_file.size(),
+    auto path = boost::filesystem::path(index_file);
+    AssertInfo(path.has_parent_path() && !path.filename().empty(),
                "index file path has no parent path: {}",
                index_file);
     // Keep the original trailing separator. Knowhere appends fixed file names
     // such as "_mem.index.bin" directly to this prefix when stream loading.
-    return index_file.substr(0, index_file.size() - file_name.size());
+    auto prefix = path.parent_path().generic_string();
+    if (prefix.back() != '/') {
+        prefix += "/";
+    }
+    return prefix;
 }
 
 }  // namespace

--- a/internal/core/src/index/VectorDiskIndex.h
+++ b/internal/core/src/index/VectorDiskIndex.h
@@ -17,12 +17,18 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "index/VectorIndex.h"
 #include "storage/DiskFileManagerImpl.h"
 
 namespace milvus::index {
+
+std::string
+ResolveDiskAnnLoadIndexPrefix(const Config& config,
+                              const std::string& local_index_path_prefix,
+                              bool load_index_with_stream);
 
 template <typename T>
 class VectorDiskAnnIndex : public VectorIndex {

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -329,6 +329,45 @@ TEST_F(DiskAnnFileManagerTest, GetRemoteIndexObjectPrefix_V1CollectionRooted) {
                 std::string::npos);
 }
 
+TEST_F(DiskAnnFileManagerTest, ResolveStreamLoadPrefixFromIndexFiles) {
+    const std::string local_prefix =
+        "/milvus/data/cache/12/local_chunk/index_files/1000_1_30_5/";
+    milvus::Config config;
+    config[milvus::index::INDEX_FILES] =
+        std::vector<std::string>{"index_v1/100/20/30/1000/1/_mem.index.bin"};
+
+    auto prefix = milvus::index::ResolveDiskAnnLoadIndexPrefix(
+        config, local_prefix, true);
+
+    EXPECT_EQ(prefix, "index_v1/100/20/30/1000/1/");
+    EXPECT_EQ(prefix + "_mem.index.bin",
+              "index_v1/100/20/30/1000/1/_mem.index.bin");
+}
+
+TEST_F(DiskAnnFileManagerTest, ResolveNonStreamLoadPrefixFromLocalCache) {
+    const std::string local_prefix =
+        "/milvus/data/cache/12/local_chunk/index_files/1000_1_30_5/";
+    milvus::Config config;
+    config[milvus::index::INDEX_FILES] =
+        std::vector<std::string>{"index_v1/100/20/30/1000/1/_mem.index.bin"};
+
+    auto prefix = milvus::index::ResolveDiskAnnLoadIndexPrefix(
+        config, local_prefix, false);
+
+    EXPECT_EQ(prefix, local_prefix);
+}
+
+TEST_F(DiskAnnFileManagerTest, LocalIndexCachePathIsDetected) {
+    EXPECT_TRUE(FileManagerImpl::IsLocalIndexCachePath(
+        "/milvus/data/cache/12/local_chunk/index_files/"
+        "1000_1_3_100/_mem.index.bin"));
+    EXPECT_FALSE(FileManagerImpl::IsLocalIndexCachePath(
+        "local_chunk/index_files/1000_1_3_100/_mem.index.bin"));
+    EXPECT_FALSE(FileManagerImpl::IsLocalIndexCachePath(
+        "/milvus/data/cache/12/local_chunk/text_log/"
+        "1000_1_3_100/log.bin"));
+}
+
 TEST_F(DiskAnnFileManagerTest, V3PackedIndexPathMismatch) {
     FieldDataMeta filed_data_meta = {1, 2, 3, 100};
     IndexMeta index_meta = {3, 100, 1000, 1, "index"};

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -342,6 +342,13 @@ TEST_F(DiskAnnFileManagerTest, ResolveStreamLoadPrefixFromIndexFiles) {
     EXPECT_EQ(prefix, "index_v1/100/20/30/1000/1/");
     EXPECT_EQ(prefix + "_mem.index.bin",
               "index_v1/100/20/30/1000/1/_mem.index.bin");
+
+    config[milvus::index::INDEX_FILES] =
+        std::vector<std::string>{"/_mem.index.bin"};
+    prefix =
+        milvus::index::ResolveDiskAnnLoadIndexPrefix(config, local_prefix, true);
+
+    EXPECT_EQ(prefix, "/");
 }
 
 TEST_F(DiskAnnFileManagerTest, ResolveNonStreamLoadPrefixFromLocalCache) {

--- a/internal/core/src/storage/FileManager.h
+++ b/internal/core/src/storage/FileManager.h
@@ -340,15 +340,13 @@ class FileManagerImpl : public milvus::FileManager {
             return false;
         }
 
-        if (!boost::filesystem::path(filename).is_absolute()) {
-            return false;
-        }
-
         return IsLocalIndexCachePath(filename);
     }
 
-    // A local cache path is only valid after downloading index files to disk.
-    // Remote streams must not treat it as an object-store key.
+    // Best-effort guard: a local cache path is only valid after downloading
+    // index files to disk. Remote streams must not treat it as an object-store
+    // key. The local chunk root is configurable and may be missed when changed,
+    // so this check is fail-open; reuse the stable index-files constant.
     static bool
     IsLocalIndexCachePath(const std::string& filename) {
         if (!boost::filesystem::path(filename).is_absolute()) {
@@ -356,8 +354,9 @@ class FileManagerImpl : public milvus::FileManager {
         }
 
         auto normalized = NormalizePath(filename);
-        return normalized.find("/local_chunk/index_files/") !=
-               std::string::npos;
+        const auto index_cache_path =
+            "/local_chunk/" + std::string(INDEX_ROOT_PATH) + "/";
+        return normalized.find(index_cache_path) != std::string::npos;
     }
 
     bool

--- a/internal/core/src/storage/FileManager.h
+++ b/internal/core/src/storage/FileManager.h
@@ -192,6 +192,10 @@ class FileManagerImpl : public milvus::FileManager {
     std::shared_ptr<InputStream>
     OpenInputStream(const std::string& filename, bool is_index_file) {
         AssertInfo(fs_, "fs_ is nullptr, cannot open input stream");
+        AssertInfo(
+            !IsLocalCachePathForRemoteIndexStream(filename, is_index_file),
+            "remote index stream received local cache path: {}",
+            filename);
         std::string remote_file_path;
         if (ShouldOpenIndexFileDirectly(filename, is_index_file)) {
             remote_file_path = NormalizePath(filename);
@@ -327,6 +331,33 @@ class FileManagerImpl : public milvus::FileManager {
     static std::string
     GetFileName(const std::string& filepath) {
         return boost::filesystem::path(filepath).filename().string();
+    }
+
+    bool
+    IsLocalCachePathForRemoteIndexStream(const std::string& filename,
+                                         bool is_index_file) const {
+        if (!is_index_file || milvus_storage::IsLocalFileSystem(fs_)) {
+            return false;
+        }
+
+        if (!boost::filesystem::path(filename).is_absolute()) {
+            return false;
+        }
+
+        return IsLocalIndexCachePath(filename);
+    }
+
+    // A local cache path is only valid after downloading index files to disk.
+    // Remote streams must not treat it as an object-store key.
+    static bool
+    IsLocalIndexCachePath(const std::string& filename) {
+        if (!boost::filesystem::path(filename).is_absolute()) {
+            return false;
+        }
+
+        auto normalized = NormalizePath(filename);
+        return normalized.find("/local_chunk/index_files/") !=
+               std::string::npos;
     }
 
     bool


### PR DESCRIPTION
## Summary

- derive the stream-loaded disk index prefix from the parent path of `index_files` instead of the local cache prefix
- keep non-stream disk index load using the local cache prefix after `CacheIndexToDisk`
- fail fast when a remote index stream receives a local cache path

Fixes #50247

## Test Plan

- [x] `git diff --check HEAD~1..HEAD`
- [x] formatted touched C++ files with `/opt/homebrew/bin/clang-format -i`
- [ ] `make verifiers` attempted locally, but blocked in third-party setup while cloning `mongo-c-driver-src`; the process was terminated after the clone produced no output for over two minutes