### PR TITLE
fix: [2.6] upgrade GPU Docker images to CUDA 12.9

### DIFF
--- a/.env
+++ b/.env
@@ -5,11 +5,11 @@ IMAGE_ARCH=amd64
 OS_NAME=ubuntu22.04
 
 # for services.builder.image in docker-compose.yml
-DATE_VERSION=20260318-39568a2
-LATEST_DATE_VERSION=20260318-39568a2
+DATE_VERSION=20260603-5baf83b
+LATEST_DATE_VERSION=20260603-5baf83b
 # for services.gpubuilder.image in docker-compose.yml
-GPU_DATE_VERSION=20260318-39568a2
-LATEST_GPU_DATE_VERSION=20260318-39568a2
+GPU_DATE_VERSION=20260603-5baf83b
+LATEST_GPU_DATE_VERSION=20260603-5baf83b
 
 # for other services in docker-compose.yml
 MINIO_ADDRESS=minio:9000
@@ -17,4 +17,3 @@ PULSAR_ADDRESS=pulsar://pulsar:6650
 ETCD_ENDPOINTS=etcd:2379
 AZURITE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
 ENABLE_GCP_NATIVE=ON
-

--- a/build/docker/builder/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/builder/gpu/ubuntu22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 as builder
+FROM nvidia/cuda:12.9.1-devel-ubuntu22.04 as builder
 
 ARG TARGETARCH
 

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+FROM nvidia/cuda:12.9.1-runtime-ubuntu22.04
 
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
- Update Ubuntu 22.04 GPU builder/runtime Dockerfiles from CUDA 11.8.0 to CUDA 12.9.1.
- Refresh 2.6 build environment image tags to `20260603-5baf83b`, generated by `ci-v2/build-env`, so CPU/GPU CI uses the branch-compatible 2.6 toolchain.

pr: #49514
issue: #50025

## Test plan
- [x] `git diff --check upstream/2.6..HEAD`
- [x] `docker compose config`
- [x] `docker manifest inspect nvidia/cuda:12.9.1-devel-ubuntu22.04`
- [x] `docker manifest inspect nvidia/cuda:12.9.1-runtime-ubuntu22.04`
- [x] `docker compose build builder`
- [x] `docker compose run --no-deps --rm builder /bin/bash -lc 'conan --version && go version && cmake --version | head -1'` confirmed `Conan version 1.64.1`
- [x] `docker compose build gpubuilder`
- [x] `docker compose run --no-deps --rm gpubuilder /bin/bash -lc 'make build-cpp-gpu'`
- [x] `docker compose run --no-deps --rm gpubuilder /bin/bash -lc 'make static-check'`
- [x] `docker compose run --no-deps --rm gpubuilder /bin/bash -lc 'ldd internal/core/output/lib/libcuvs.so'` confirmed `libcudart.so.12` is resolved from `/usr/local/cuda/lib64` in the CUDA 12.9.1 image.