### PR TITLE
enhance: Make max array capacity configurable

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -324,7 +324,6 @@ proxy:
   maxVectorFieldNum: 10 # The maximum number of vector fields that can be specified in a collection
   maxShardNum: 16 # The maximum number of shards can be created when creating in a collection.
   maxDimension: 32768 # The maximum number of dimensions of a vector can have when creating in a collection.
-  maxArrayCapacity: 4096 # The maximum number of elements in an array field for a single row.
   # Whether to produce gin logs.\n
   # please adjust in embedded Milvus: false
   ginLogging: true
@@ -338,6 +337,7 @@ proxy:
   dclConcurrency: 16 # The concurrent execution number of DCL at proxy.
   mustUsePartitionKey: false # switch for whether proxy must use partition key for the collection
   resolveAliasForPrivilege: true # switch for whether proxy shall resolve alias to actual collection name during RBAC privilege checks
+  maxArrayCapacity: 4096 # maximum number of elements in an array field for a single row
   maxIndexParamsSize: 102400 # maximum total size of index params in bytes for create index requests
   # maximum number of result entries, typically Nq * TopK * GroupSize. 
   # It costs additional memory and time to process a large number of result entries. 

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -324,6 +324,7 @@ proxy:
   maxVectorFieldNum: 10 # The maximum number of vector fields that can be specified in a collection
   maxShardNum: 16 # The maximum number of shards can be created when creating in a collection.
   maxDimension: 32768 # The maximum number of dimensions of a vector can have when creating in a collection.
+  maxArrayCapacity: 4096 # The maximum number of elements in an array field for a single row.
   # Whether to produce gin logs.\n
   # please adjust in embedded Milvus: false
   ginLogging: true

--- a/internal/proxy/msg_pack.go
+++ b/internal/proxy/msg_pack.go
@@ -81,7 +81,7 @@ func genInsertMsgsByPartition(ctx context.Context,
 		// If the insert message size exceeds the threshold, flush the current
 		// message first. A single row can be larger than the threshold, so do
 		// not emit an empty message before adding that row.
-		if requestSize > 0 && requestSize+curRowMessageSize >= threshold {
+		if msg.NumRows > 0 && requestSize+curRowMessageSize >= threshold {
 			repackedMsgs = append(repackedMsgs, msg)
 			msg = createInsertMsg(segmentID, channelName)
 			requestSize = 0

--- a/internal/proxy/msg_pack.go
+++ b/internal/proxy/msg_pack.go
@@ -78,8 +78,10 @@ func genInsertMsgsByPartition(ctx context.Context,
 			return nil, err
 		}
 
-		// if insertMsg's size is greater than the threshold, split into multiple insertMsgs
-		if requestSize+curRowMessageSize >= threshold && msg.NumRows > 0 {
+		// If the insert message size exceeds the threshold, flush the current
+		// message first. A single row can be larger than the threshold, so do
+		// not emit an empty message before adding that row.
+		if requestSize > 0 && requestSize+curRowMessageSize >= threshold {
 			repackedMsgs = append(repackedMsgs, msg)
 			msg = createInsertMsg(segmentID, channelName)
 			requestSize = 0

--- a/internal/proxy/msg_pack_test.go
+++ b/internal/proxy/msg_pack_test.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,51 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/testutils"
 )
+
+func TestGenInsertMsgsByPartitionSingleOversizedRow(t *testing.T) {
+	assert.NoError(t, Params.Save(Params.PulsarCfg.MaxMessageSize.Key, "64"))
+	defer Params.Reset(Params.PulsarCfg.MaxMessageSize.Key)
+
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_VarChar,
+		FieldId:   101,
+		FieldName: "large_text",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_StringData{
+					StringData: &schemapb.StringArray{
+						Data: []string{strings.Repeat("x", 1024)},
+					},
+				},
+			},
+		},
+	}
+	insertMsg := &msgstream.InsertMsg{
+		BaseMsg: msgstream.BaseMsg{
+			Ctx:        context.Background(),
+			HashValues: []uint32{1},
+		},
+		InsertRequest: &msgpb.InsertRequest{
+			Base: &commonpb.MsgBase{
+				MsgType:  commonpb.MsgType_Insert,
+				SourceID: paramtable.GetNodeID(),
+			},
+			DbName:         "default",
+			CollectionName: "test_collection",
+			PartitionName:  "test_partition",
+			NumRows:        1,
+			FieldsData:     []*schemapb.FieldData{fieldData},
+			Timestamps:     []uint64{1},
+			RowIDs:         []int64{1},
+			Version:        msgpb.InsertDataVersion_ColumnBased,
+		},
+	}
+
+	msgs, err := genInsertMsgsByPartition(context.Background(), 0, 1, "test_partition", []int{0}, "test_channel", insertMsg)
+	assert.NoError(t, err)
+	assert.Len(t, msgs, 1)
+	assert.Equal(t, uint64(1), msgs[0].(*msgstream.InsertMsg).GetNumRows())
+}
 
 func TestRepackInsertData(t *testing.T) {
 	nb := 10

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -2555,8 +2555,9 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 			if err != nil {
 				return merr.WrapErrParameterInvalidMsg("the value for %s of field %s must be an integer", common.MaxCapacityKey, fieldName)
 			}
-			if maxCapacityPerRow > defaultMaxArrayCapacity || maxCapacityPerRow <= 0 {
-				return merr.WrapErrParameterInvalidMsg("the maximum capacity specified for a Array should be in (0, %d]", defaultMaxArrayCapacity)
+			maxArrayCapacity := Params.ProxyCfg.MaxArrayCapacity.GetAsInt64()
+			if maxCapacityPerRow > maxArrayCapacity || maxCapacityPerRow <= 0 {
+				return merr.WrapErrParameterInvalidMsg("the maximum capacity specified for a Array should be in (0, %d]", maxArrayCapacity)
 			}
 		}
 	}

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -6091,6 +6091,8 @@ func TestAlterCollectionFieldCheckLoaded(t *testing.T) {
 }
 
 func TestAlterCollectionField(t *testing.T) {
+	paramtable.Init()
+
 	qc := NewMixCoordMock()
 	InitMetaCache(context.Background(), qc)
 	collectionName := "test_alter_collection_field"
@@ -6301,6 +6303,27 @@ func TestAlterCollectionField(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("update array field max_capacity with custom limit", func(t *testing.T) {
+		err := paramtable.Get().Save(paramtable.Get().ProxyCfg.MaxArrayCapacity.Key, "5000")
+		assert.NoError(t, err)
+		defer paramtable.Get().Reset(paramtable.Get().ProxyCfg.MaxArrayCapacity.Key)
+
+		task := &alterCollectionFieldTask{
+			AlterCollectionFieldRequest: &milvuspb.AlterCollectionFieldRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: collectionName,
+				FieldName:      "array_field",
+				Properties: []*commonpb.KeyValuePair{
+					{Key: common.MaxCapacityKey, Value: "5000"},
+				},
+			},
+			mixCoord: qc,
+		}
+
+		err = task.PreExecute(context.Background())
+		assert.NoError(t, err)
+	})
 }
 
 // constructCollectionSchemaWithStructArrayField constructs a collection schema specifically for testing StructArrayField

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -74,8 +74,6 @@ const (
 	// enableMultipleVectorFields indicates whether to enable multiple vector fields.
 	enableMultipleVectorFields = true
 
-	defaultMaxArrayCapacity = 4096
-
 	defaultMaxSearchRequest = 1024
 
 	// DefaultArithmeticIndexType name of default index type for scalar field
@@ -484,6 +482,7 @@ func validateMaxLengthPerRow(collectionName string, field *schemapb.FieldSchema)
 }
 
 func getMaxCapacityPerRow(collectionName string, field *schemapb.FieldSchema) (int64, error) {
+	maxArrayCapacity := Params.ProxyCfg.MaxArrayCapacity.GetAsInt64()
 	exist := false
 	var maxCapacityPerRow int64
 	for _, param := range field.TypeParams {
@@ -496,8 +495,8 @@ func getMaxCapacityPerRow(collectionName string, field *schemapb.FieldSchema) (i
 		if err != nil {
 			return 0, merr.WrapErrParameterInvalidMsg("the value for %s of field %s must be an integer", common.MaxCapacityKey, field.GetName())
 		}
-		if maxCapacityPerRow > defaultMaxArrayCapacity || maxCapacityPerRow <= 0 {
-			return 0, merr.WrapErrParameterInvalidMsg("the maximum capacity specified for a Array should be in (0, 4096]")
+		if maxCapacityPerRow > maxArrayCapacity || maxCapacityPerRow <= 0 {
+			return 0, merr.WrapErrParameterInvalidMsg("the maximum capacity specified for a Array should be in (0, %d]", maxArrayCapacity)
 		}
 		exist = true
 	}

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -2449,6 +2449,8 @@ func Test_CheckDynamicFieldData(t *testing.T) {
 }
 
 func Test_validateMaxCapacityPerRow(t *testing.T) {
+	paramtable.Init()
+
 	t.Run("normal case", func(t *testing.T) {
 		arrayField := &schemapb.FieldSchema{
 			DataType:    schemapb.DataType_Array,
@@ -2509,6 +2511,27 @@ func Test_validateMaxCapacityPerRow(t *testing.T) {
 
 		err := validateMaxCapacityPerRow("collection", arrayField)
 		assert.Error(t, err)
+	})
+
+	t.Run("custom max capacity", func(t *testing.T) {
+		paramtable.Init()
+		err := paramtable.Get().Save(paramtable.Get().ProxyCfg.MaxArrayCapacity.Key, "5000")
+		assert.NoError(t, err)
+		defer paramtable.Get().Reset(paramtable.Get().ProxyCfg.MaxArrayCapacity.Key)
+
+		arrayField := &schemapb.FieldSchema{
+			DataType:    schemapb.DataType_Array,
+			ElementType: schemapb.DataType_Int64,
+			TypeParams: []*commonpb.KeyValuePair{
+				{
+					Key:   common.MaxCapacityKey,
+					Value: "5000",
+				},
+			},
+		}
+
+		err = validateMaxCapacityPerRow("collection", arrayField)
+		assert.NoError(t, err)
 	})
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2572,11 +2572,14 @@ please adjust in embedded Milvus: false`,
 		PanicIfEmpty: true,
 		Doc:          "maximum number of elements in an array field for a single row",
 		Export:       true,
+		Formatter: func(v string) string {
+			if getAsInt64(v) <= 0 {
+				return "4096"
+			}
+			return v
+		},
 	}
 	p.MaxArrayCapacity.Init(base.mgr)
-	if p.MaxArrayCapacity.GetAsInt64() <= 0 {
-		panic(fmt.Sprintf("proxy.maxArrayCapacity should be greater than 0, not %d", p.MaxArrayCapacity.GetAsInt64()))
-	}
 
 	p.MaxIndexParamsSize = ParamItem{
 		Key:          "proxy.maxIndexParamsSize",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2085,6 +2085,7 @@ type proxyConfig struct {
 	ResolveAliasForPrivilege          ParamItem `refreshable:"true"`
 	MaxVarCharLength                  ParamItem `refreshable:"false"`
 	MaxTextLength                     ParamItem `refreshable:"false"`
+	MaxArrayCapacity                  ParamItem `refreshable:"true"`
 	MaxIndexParamsSize                ParamItem `refreshable:"true"`
 	MaxResultEntries                  ParamItem `refreshable:"true"`
 	EnableCachedServiceProvider       ParamItem `refreshable:"true"`
@@ -2563,6 +2564,19 @@ please adjust in embedded Milvus: false`,
 		Doc:          "maximum number of characters for a row of the text field",
 	}
 	p.MaxTextLength.Init(base.mgr)
+
+	p.MaxArrayCapacity = ParamItem{
+		Key:          "proxy.maxArrayCapacity",
+		Version:      "2.6.19",
+		DefaultValue: "4096",
+		PanicIfEmpty: true,
+		Doc:          "maximum number of elements in an array field for a single row",
+		Export:       true,
+	}
+	p.MaxArrayCapacity.Init(base.mgr)
+	if p.MaxArrayCapacity.GetAsInt64() <= 0 {
+		panic(fmt.Sprintf("proxy.maxArrayCapacity should be greater than 0, not %d", p.MaxArrayCapacity.GetAsInt64()))
+	}
 
 	p.MaxIndexParamsSize = ParamItem{
 		Key:          "proxy.maxIndexParamsSize",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -313,6 +313,10 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, int64(4096), Params.MaxArrayCapacity.GetAsInt64())
 		params.Save("proxy.maxArrayCapacity", "5000")
 		assert.Equal(t, int64(5000), Params.MaxArrayCapacity.GetAsInt64())
+		params.Save("proxy.maxArrayCapacity", "0")
+		assert.Equal(t, int64(4096), Params.MaxArrayCapacity.GetAsInt64())
+		params.Save("proxy.maxArrayCapacity", "-1")
+		assert.Equal(t, int64(4096), Params.MaxArrayCapacity.GetAsInt64())
 	})
 
 	// t.Run("test proxyConfig panic", func(t *testing.T) {

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -309,6 +309,10 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, 72, Params.MaxPasswordLength.GetAsInt())
 		params.Save("proxy.maxPasswordLength", "-10")
 		assert.Equal(t, 72, Params.MaxPasswordLength.GetAsInt())
+
+		assert.Equal(t, int64(4096), Params.MaxArrayCapacity.GetAsInt64())
+		params.Save("proxy.maxArrayCapacity", "5000")
+		assert.Equal(t, int64(5000), Params.MaxArrayCapacity.GetAsInt64())
 	})
 
 	// t.Run("test proxyConfig panic", func(t *testing.T) {


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/50263

This PR makes max array capacity configurable, preparing for row level multi-user sharing