### PR TITLE
fix: mark restore target segments as importing

### DIFF
--- a/internal/datacoord/copy_segment_task.go
+++ b/internal/datacoord/copy_segment_task.go
@@ -689,7 +689,8 @@ func SyncCopySegmentTask(task CopySegmentTask, resp *datapb.QueryCopySegmentResp
 			op1 := UpdateBinlogsOperator(result.GetSegmentId(), result.GetBinlogs(),
 				result.GetStatslogs(), result.GetDeltalogs(), result.GetBm25Logs())
 			op2 := UpdateStatusOperator(result.GetSegmentId(), commonpb.SegmentState_Flushed)
-			operators := []UpdateOperator{op1, op2}
+			op3 := UpdateIsImporting(result.GetSegmentId(), false)
+			operators := []UpdateOperator{op1, op2, op3}
 			if manifestPath := result.GetManifestPath(); manifestPath != "" {
 				operators = append(operators, UpdateManifest(result.GetSegmentId(), manifestPath))
 			}

--- a/internal/datacoord/copy_segment_task_test.go
+++ b/internal/datacoord/copy_segment_task_test.go
@@ -727,6 +727,191 @@ func (s *CopySegmentTaskSuite) TestSyncVectorScalarIndexes_AddSegmentIndexError(
 	s.Contains(syncErr.Error(), "catalog error")
 }
 
+func (s *CopySegmentTaskSuite) TestSyncCopySegmentTask_ClearsImportingFlagOnCompletion() {
+	collectionID := int64(1)
+	segmentID := int64(100)
+
+	catalog := catalogmocks.NewDataCoordCatalog(s.T())
+	catalog.EXPECT().AlterSegments(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, segs []*datapb.SegmentInfo, _ ...metastore.BinlogsIncrement) error {
+		s.Require().Len(segs, 1)
+		seg := segs[0]
+		assert.Equal(s.T(), segmentID, seg.GetID())
+		assert.Equal(s.T(), commonpb.SegmentState_Flushed, seg.GetState())
+		assert.False(s.T(), seg.GetIsImporting())
+		return nil
+	}).Once()
+	mt := &meta{ctx: context.Background(), catalog: catalog, segments: NewSegmentsInfo()}
+	mt.segments.SetSegment(segmentID, NewSegmentInfo(&datapb.SegmentInfo{
+		ID:            segmentID,
+		CollectionID:  collectionID,
+		PartitionID:   10,
+		InsertChannel: "ch1",
+		State:         commonpb.SegmentState_Importing,
+		IsImporting:   true,
+	}))
+
+	copyCatalog := catalogmocks.NewDataCoordCatalog(s.T())
+	copyCatalog.EXPECT().ListCopySegmentJobs(mock.Anything).Return(nil, nil)
+	copyCatalog.EXPECT().ListCopySegmentTasks(mock.Anything).Return(nil, nil)
+	copyCatalog.EXPECT().SaveCopySegmentTask(mock.Anything, mock.Anything).Return(nil).Maybe()
+	copyMeta, err := NewCopySegmentMeta(context.Background(), copyCatalog, nil, nil, nil)
+	s.Require().NoError(err)
+
+	result := &datapb.QueryCopySegmentResponse{
+		State: datapb.CopySegmentTaskState_CopySegmentTaskCompleted,
+		SegmentResults: []*datapb.CopySegmentResult{{
+			SegmentId: segmentID,
+			Binlogs: []*datapb.FieldBinlog{{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{{LogID: 1, LogPath: "files/binlog/1"}},
+			}},
+		}},
+	}
+	task := createTestCopyTask(collectionID, segmentID)
+
+	err = SyncCopySegmentTask(task, result, copyMeta, mt)
+	s.Require().NoError(err)
+	updated := mt.GetSegment(context.Background(), segmentID)
+	s.Require().NotNil(updated)
+	s.Equal(commonpb.SegmentState_Flushed, updated.GetState())
+	s.False(updated.GetIsImporting())
+}
+
+func (s *CopySegmentTaskSuite) TestSyncCopySegmentTask_EmptyManifestStillClearsImportingFlag() {
+	collectionID := int64(1)
+	segmentID := int64(101)
+
+	catalog := catalogmocks.NewDataCoordCatalog(s.T())
+	catalog.EXPECT().AlterSegments(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mt := &meta{ctx: context.Background(), catalog: catalog, segments: NewSegmentsInfo()}
+	mt.segments.SetSegment(segmentID, NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             segmentID,
+		CollectionID:   collectionID,
+		PartitionID:    10,
+		InsertChannel:  "ch1",
+		State:          commonpb.SegmentState_Importing,
+		IsImporting:    true,
+		StorageVersion: 3,
+	}))
+
+	copyCatalog := catalogmocks.NewDataCoordCatalog(s.T())
+	copyCatalog.EXPECT().ListCopySegmentJobs(mock.Anything).Return(nil, nil)
+	copyCatalog.EXPECT().ListCopySegmentTasks(mock.Anything).Return(nil, nil)
+	copyCatalog.EXPECT().SaveCopySegmentTask(mock.Anything, mock.Anything).Return(nil).Maybe()
+	copyMeta, err := NewCopySegmentMeta(context.Background(), copyCatalog, nil, nil, nil)
+	s.Require().NoError(err)
+
+	result := &datapb.QueryCopySegmentResponse{
+		State: datapb.CopySegmentTaskState_CopySegmentTaskCompleted,
+		SegmentResults: []*datapb.CopySegmentResult{{
+			SegmentId:    segmentID,
+			ManifestPath: "",
+			Binlogs: []*datapb.FieldBinlog{{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{{LogID: 2, LogPath: "files/binlog/2"}},
+			}},
+		}},
+	}
+	task := createTestCopyTask(collectionID, segmentID)
+
+	err = SyncCopySegmentTask(task, result, copyMeta, mt)
+	s.Require().NoError(err)
+	updated := mt.GetSegment(context.Background(), segmentID)
+	s.Require().NotNil(updated)
+	s.Equal(commonpb.SegmentState_Flushed, updated.GetState())
+	s.False(updated.GetIsImporting())
+	s.Empty(updated.GetManifestPath())
+}
+
+func (s *CopySegmentTaskSuite) TestSyncCopySegmentTask_ManifestUpdateAndClearImportingFlag() {
+	collectionID := int64(1)
+	segmentID := int64(102)
+	manifestPath := `{"ver":3,"base_path":"files/insert_log/1/10/102"}`
+
+	catalog := catalogmocks.NewDataCoordCatalog(s.T())
+	catalog.EXPECT().AlterSegments(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mt := &meta{ctx: context.Background(), catalog: catalog, segments: NewSegmentsInfo()}
+	mt.segments.SetSegment(segmentID, NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             segmentID,
+		CollectionID:   collectionID,
+		PartitionID:    10,
+		InsertChannel:  "ch1",
+		State:          commonpb.SegmentState_Importing,
+		IsImporting:    true,
+		StorageVersion: 3,
+	}))
+
+	copyCatalog := catalogmocks.NewDataCoordCatalog(s.T())
+	copyCatalog.EXPECT().ListCopySegmentJobs(mock.Anything).Return(nil, nil)
+	copyCatalog.EXPECT().ListCopySegmentTasks(mock.Anything).Return(nil, nil)
+	copyCatalog.EXPECT().SaveCopySegmentTask(mock.Anything, mock.Anything).Return(nil).Maybe()
+	copyMeta, err := NewCopySegmentMeta(context.Background(), copyCatalog, nil, nil, nil)
+	s.Require().NoError(err)
+
+	result := &datapb.QueryCopySegmentResponse{
+		State: datapb.CopySegmentTaskState_CopySegmentTaskCompleted,
+		SegmentResults: []*datapb.CopySegmentResult{{
+			SegmentId:    segmentID,
+			ManifestPath: manifestPath,
+			Binlogs: []*datapb.FieldBinlog{{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{{LogID: 3, LogPath: "files/binlog/3"}},
+			}},
+		}},
+	}
+	task := createTestCopyTask(collectionID, segmentID)
+
+	err = SyncCopySegmentTask(task, result, copyMeta, mt)
+	s.Require().NoError(err)
+	updated := mt.GetSegment(context.Background(), segmentID)
+	s.Require().NotNil(updated)
+	s.Equal(commonpb.SegmentState_Flushed, updated.GetState())
+	s.False(updated.GetIsImporting())
+	s.Equal(manifestPath, updated.GetManifestPath())
+}
+
+func (s *CopySegmentTaskSuite) TestSyncCopySegmentTask_PreservesImportingFlagOnFailure() {
+	collectionID := int64(1)
+	segmentID := int64(103)
+
+	catalog := catalogmocks.NewDataCoordCatalog(s.T())
+	catalog.EXPECT().AlterSegments(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("alter failed")).Once()
+	catalog.EXPECT().ListCopySegmentJobs(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListCopySegmentTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveCopySegmentTask(mock.Anything, mock.Anything).Return(nil).Maybe()
+	catalog.EXPECT().SaveCopySegmentJob(mock.Anything, mock.Anything).Return(nil).Maybe()
+	mt := &meta{ctx: context.Background(), catalog: catalog, segments: NewSegmentsInfo()}
+	mt.segments.SetSegment(segmentID, NewSegmentInfo(&datapb.SegmentInfo{
+		ID:            segmentID,
+		CollectionID:  collectionID,
+		PartitionID:   10,
+		InsertChannel: "ch1",
+		State:         commonpb.SegmentState_Importing,
+		IsImporting:   true,
+	}))
+	copyMeta, err := NewCopySegmentMeta(context.Background(), catalog, nil, nil, nil)
+	s.Require().NoError(err)
+
+	result := &datapb.QueryCopySegmentResponse{
+		State: datapb.CopySegmentTaskState_CopySegmentTaskCompleted,
+		SegmentResults: []*datapb.CopySegmentResult{{
+			SegmentId: segmentID,
+			Binlogs: []*datapb.FieldBinlog{{
+				FieldID: 100,
+				Binlogs: []*datapb.Binlog{{LogID: 4, LogPath: "files/binlog/4"}},
+			}},
+		}},
+	}
+	task := createTestCopyTask(collectionID, segmentID)
+
+	err = SyncCopySegmentTask(task, result, copyMeta, mt)
+	s.Require().Error(err)
+	updated := mt.GetSegment(context.Background(), segmentID)
+	s.Require().NotNil(updated)
+	s.Equal(commonpb.SegmentState_Importing, updated.GetState())
+	s.True(updated.GetIsImporting())
+}
+
 func TestAssembleCopySegmentRequest_SourceSegmentNotFound(t *testing.T) {
 	// Arrange: snapshot data has segment 1, but task maps from segment 999 which doesn't exist
 	snapshotData := &SnapshotData{

--- a/internal/datacoord/snapshot_manager.go
+++ b/internal/datacoord/snapshot_manager.go
@@ -1239,6 +1239,7 @@ func (sm *snapshotManager) createRestoreJob(
 				StorageVersion:      segDesc.GetStorageVersion(),
 				IsSorted:            segDesc.GetIsSorted(),
 				CommitTimestamp:     segDesc.GetCommitTimestamp(),
+				IsImporting:         true,
 			},
 		}
 		targetSegments[targetSegmentID] = newSegment

--- a/internal/datacoord/snapshot_manager_test.go
+++ b/internal/datacoord/snapshot_manager_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/datacoord/broker"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
+	catalogmocks "github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -1813,6 +1814,67 @@ func TestCreateRestoreJob_PropagatesPinID(t *testing.T) {
 	assert.Equal(t, int64(200), captured.GetCollectionId())
 	assert.Equal(t, "snap1", captured.GetSnapshotName())
 	assert.Equal(t, int64(100), captured.GetSourceCollectionId())
+}
+
+func TestCreateRestoreJob_PreRegistersTargetSegmentsAsImporting(t *testing.T) {
+	ctx := context.Background()
+
+	snapshotData := &SnapshotData{
+		SnapshotInfo: &datapb.SnapshotInfo{Name: "snap1", CollectionId: 100},
+		Collection:   &datapb.CollectionDescription{},
+		Segments: []*datapb.SegmentDescription{{
+			SegmentId:      11,
+			PartitionId:    10,
+			SegmentLevel:   datapb.SegmentLevel_L1,
+			ChannelName:    "src-ch",
+			NumOfRows:      123,
+			StorageVersion: 3,
+			IsSorted:       true,
+		}},
+	}
+
+	catalog := catalogmocks.NewDataCoordCatalog(t)
+	catalog.EXPECT().AddSegment(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, seg *datapb.SegmentInfo) error {
+		assert.Equal(t, int64(2001), seg.GetID())
+		assert.Equal(t, int64(200), seg.GetCollectionID())
+		assert.Equal(t, int64(20), seg.GetPartitionID())
+		assert.Equal(t, "dst-ch", seg.GetInsertChannel())
+		assert.Equal(t, commonpb.SegmentState_Importing, seg.GetState())
+		assert.True(t, seg.GetIsImporting())
+		assert.Equal(t, int64(3), seg.GetStorageVersion())
+		return nil
+	}).Once()
+	catalog.EXPECT().SaveChannelCheckpoint(mock.Anything, "dst-ch", mock.Anything).Return(nil).Once()
+
+	mt := &meta{ctx: ctx, catalog: catalog, segments: NewSegmentsInfo(), channelCPs: newChannelCps()}
+	mt.segments.SetSegment(11, NewSegmentInfo(&datapb.SegmentInfo{ID: 11}))
+
+	var err error
+
+	mockAlloc := allocator.NewMockAllocator(t)
+	mockAlloc.EXPECT().AllocN(int64(1)).Return(int64(2001), int64(2002), nil)
+
+	mockHandler := NewNMockHandler(t)
+	mockHandler.EXPECT().GetCollection(mock.Anything, int64(200)).Return(&collectionInfo{StartPositions: []*commonpb.KeyDataPair{{Key: "dst-ch", Data: []byte{1}}}}, nil)
+
+	addJobCalled := false
+	mAddJob := mockey.Mock((*copySegmentMeta).AddJob).To(
+		func(_ *copySegmentMeta, _ context.Context, _ CopySegmentJob) error {
+			addJobCalled = true
+			return nil
+		}).Build()
+	defer mAddJob.UnPatch()
+
+	sm := &snapshotManager{
+		meta:            mt,
+		allocator:       mockAlloc,
+		handler:         mockHandler,
+		copySegmentMeta: &copySegmentMeta{},
+	}
+
+	err = sm.createRestoreJob(ctx, int64(200), map[string]string{"src-ch": "dst-ch"}, map[int64]int64{10: 20}, snapshotData, int64(42), int64(7))
+	require.NoError(t, err)
+	assert.True(t, addJobCalled)
 }
 
 // TestSnapshotManager_HasActivePins_Delegation verifies the manager-layer wrapper


### PR DESCRIPTION
Related to #50271

RestoreSnapshot pre-registered target segments with State=Importing but left IsImporting unset, so the protobuf zero value made them look non-importing to recovery and snapshot filters.

That allowed restore target segments to leak into
GetChannelRecoveryInfo as unflushed segments before copy completed. It also allowed later snapshots to include segments that were still logically in the restore lifecycle.

Add focused regression tests for pre-registration, successful copy, manifest/no-manifest completion, and failure preservation.