### PR TITLE
enhance: size cgo pool from read concurrency

### DIFF
--- a/internal/util/cgo/pool.go
+++ b/internal/util/cgo/pool.go
@@ -1,19 +1,17 @@
 package cgo
 
 import (
-	"math"
 	"runtime"
 	"time"
 
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
-	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 var caller *cgoCaller
 
 func initCaller(nodeID string) {
-	chSize := int64(math.Ceil(float64(hardware.GetCPUNum()) * paramtable.Get().QueryNodeCfg.CGOPoolSizeRatio.GetAsFloat()))
+	chSize := paramtable.Get().QueryNodeCfg.MaxReadConcurrency.GetAsInt() * int(paramtable.Get().QueryNodeCfg.CGOPoolSizeRatio.GetAsFloat())
 	if chSize <= 0 {
 		chSize = 1
 	}


### PR DESCRIPTION
issue: n/a

What this PR does:
- Sizes the CGO caller pool from QueryNode max read concurrency and cgoPoolSizeRatio instead of raw CPU count.
- Excludes the local logging/profiling, RequestTrace, requestID/traceID, config, script, patch, and artifact changes from the current worktree.

Tests:
- git diff --check
- go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/util/cgo (blocked: pkg-config cannot find milvus_core.pc)