### PR TITLE
enhance: prefetch data before execution

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -483,7 +483,6 @@ queryNode:
   stats:
     publishInterval: 1000 # The interval that query node publishes the node statistics information, including segment status, cpu usage, memory usage, health status, etc. Unit: ms.
   segcore:
-    cgoPoolSizeRatio: 2 # The ratio of cgo pool size to max read concurrency.
     knowhereThreadPoolNumRatio: 4 # The number of threads in knowhere's thread pool. If disk is enabled, the pool size will multiply with knowhereThreadPoolNumRatio([1, 32]).
     chunkRows: 128 # Row count by which Segcore divides a segment into chunks.
     interimIndex:

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -483,6 +483,7 @@ queryNode:
   stats:
     publishInterval: 1000 # The interval that query node publishes the node statistics information, including segment status, cpu usage, memory usage, health status, etc. Unit: ms.
   segcore:
+    cgoPoolSizeRatio: 2 # The ratio of cgo pool size to max read concurrency.
     knowhereThreadPoolNumRatio: 4 # The number of threads in knowhere's thread pool. If disk is enabled, the pool size will multiply with knowhereThreadPoolNumRatio([1, 32]).
     chunkRows: 128 # Row count by which Segcore divides a segment into chunks.
     interimIndex:

--- a/internal/core/src/exec/Driver.cpp
+++ b/internal/core/src/exec/Driver.cpp
@@ -51,6 +51,7 @@
 #include "glog/logging.h"
 #include "log/Log.h"
 #include "plan/PlanNode.h"
+#include "storage/PrefetchThreadPool.h"
 
 namespace milvus {
 namespace exec {
@@ -68,7 +69,7 @@ DriverFactory::CreateDriver(
     const std::function<int(int pipelineid)>& num_drivers) {
     auto driver = std::shared_ptr<Driver>(new Driver());
     ctx->driver_ = driver.get();
-    std::vector<std::unique_ptr<Operator>> operators;
+    std::vector<std::shared_ptr<Operator>> operators;
     operators.reserve(plannodes_.size());
 
     for (size_t i = 0; i < plannodes_.size(); ++i) {
@@ -78,70 +79,70 @@ DriverFactory::CreateDriver(
                 std::dynamic_pointer_cast<const plan::FilterBitsNode>(
                     plannode)) {
             tracer::AddEvent("create_operator: FilterBitsNode");
-            operators.push_back(std::make_unique<PhyFilterBitsNode>(
+            operators.push_back(std::make_shared<PhyFilterBitsNode>(
                 id, ctx.get(), filterbitsnode));
         } else if (auto filternode = std::dynamic_pointer_cast<
                        const plan::IterativeFilterNode>(plannode)) {
             tracer::AddEvent("create_operator: IterativeFilterNode");
-            operators.push_back(std::make_unique<PhyIterativeFilterNode>(
+            operators.push_back(std::make_shared<PhyIterativeFilterNode>(
                 id, ctx.get(), filternode));
         } else if (auto mvccnode =
                        std::dynamic_pointer_cast<const plan::MvccNode>(
                            plannode)) {
             tracer::AddEvent("create_operator: MvccNode");
             operators.push_back(
-                std::make_unique<PhyMvccNode>(id, ctx.get(), mvccnode));
+                std::make_shared<PhyMvccNode>(id, ctx.get(), mvccnode));
         } else if (auto vectorsearchnode =
                        std::dynamic_pointer_cast<const plan::VectorSearchNode>(
                            plannode)) {
             tracer::AddEvent("create_operator: VectorSearchNode");
-            operators.push_back(std::make_unique<PhyVectorSearchNode>(
+            operators.push_back(std::make_shared<PhyVectorSearchNode>(
                 id, ctx.get(), vectorsearchnode));
         } else if (auto searchGroupByNode =
                        std::dynamic_pointer_cast<const plan::SearchGroupByNode>(
                            plannode)) {
             tracer::AddEvent("create_operator: SearchGroupByNode");
-            operators.push_back(std::make_unique<PhySearchGroupByNode>(
+            operators.push_back(std::make_shared<PhySearchGroupByNode>(
                 id, ctx.get(), searchGroupByNode));
         } else if (auto queryGroupByNode =
                        std::dynamic_pointer_cast<const plan::AggregationNode>(
                            plannode)) {
             tracer::AddEvent("create_operator: AggregationNode");
-            operators.push_back(std::make_unique<PhyAggregationNode>(
+            operators.push_back(std::make_shared<PhyAggregationNode>(
                 id, ctx.get(), queryGroupByNode));
         } else if (auto projectNode =
                        std::dynamic_pointer_cast<const plan::ProjectNode>(
                            plannode)) {
             tracer::AddEvent("create_operator: ProjectNode");
             operators.push_back(
-                std::make_unique<PhyProjectNode>(id, ctx.get(), projectNode));
+                std::make_shared<PhyProjectNode>(id, ctx.get(), projectNode));
         } else if (auto orderByNode =
                        std::dynamic_pointer_cast<const plan::OrderByNode>(
                            plannode)) {
             tracer::AddEvent("create_operator: QueryOrderByNode");
-            operators.push_back(std::make_unique<PhyQueryOrderByNode>(
+            operators.push_back(std::make_shared<PhyQueryOrderByNode>(
                 id, ctx.get(), orderByNode));
         } else if (auto samplenode =
                        std::dynamic_pointer_cast<const plan::RandomSampleNode>(
                            plannode)) {
             tracer::AddEvent("create_operator: RandomSampleNode");
-            operators.push_back(std::make_unique<PhyRandomSampleNode>(
+            operators.push_back(std::make_shared<PhyRandomSampleNode>(
                 id, ctx.get(), samplenode));
         } else if (auto rescoresnode =
                        std::dynamic_pointer_cast<const plan::RescoresNode>(
                            plannode)) {
             tracer::AddEvent("create_operator: RescoresNode");
             operators.push_back(
-                std::make_unique<PhyRescoresNode>(id, ctx.get(), rescoresnode));
+                std::make_shared<PhyRescoresNode>(id, ctx.get(), rescoresnode));
         } else if (auto node = std::dynamic_pointer_cast<
                        const plan::IterativeElementFilterNode>(plannode)) {
             tracer::AddEvent("create_operator: IterativeElementFilterNode");
-            operators.push_back(std::make_unique<PhyIterativeElementFilterNode>(
+            operators.push_back(std::make_shared<PhyIterativeElementFilterNode>(
                 id, ctx.get(), node));
         } else if (auto node = std::dynamic_pointer_cast<
                        const plan::ElementFilterBitsNode>(plannode)) {
             tracer::AddEvent("create_operator: ElementFilterBitsNode");
-            operators.push_back(std::make_unique<PhyElementFilterBitsNode>(
+            operators.push_back(std::make_shared<PhyElementFilterBitsNode>(
                 id, ctx.get(), node));
         } else {
             ThrowInfo(ErrorCode::UnexpectedError, "Unknown plan node type");
@@ -224,7 +225,7 @@ Driver::initializeOperators() {
 
 void
 Driver::Init(std::unique_ptr<DriverContext> ctx,
-             std::vector<std::unique_ptr<Operator>> operators) {
+             std::vector<std::shared_ptr<Operator>> operators) {
     assert(ctx != nullptr);
     ctx_ = std::move(ctx);
     AssertInfo(operators.size() != 0, "operators in driver must not empty");
@@ -239,6 +240,7 @@ Driver::Close() {
     }
 
     for (auto& op : operators_) {
+        op->WaitPrefetch();
         op->Close();
     }
 
@@ -282,6 +284,7 @@ Driver::RunInternal(std::shared_ptr<Driver>& self,
                     RowVectorPtr& result) {
     try {
         initializeOperators();
+        std::call_once(self->once_, [self]() { self->PrefetchAsync(); });
         int num_operators = operators_.size();
         ContinueFuture future;
 
@@ -381,6 +384,14 @@ Driver::RunInternal(std::shared_ptr<Driver>& self,
     } catch (std::exception& e) {
         get_task()->SetError(std::current_exception());
         return StopReason::kAlreadyTerminated;
+    }
+}
+
+void
+Driver::PrefetchAsync() {
+    auto prefetch_pool = GetPrefetchThreadPool();
+    for (auto& op : operators_) {
+        op->PrefetchAsync(prefetch_pool);
     }
 }
 

--- a/internal/core/src/exec/Driver.h
+++ b/internal/core/src/exec/Driver.h
@@ -210,7 +210,7 @@ class Driver : public std::enable_shared_from_this<Driver> {
 
     void
     Init(std::unique_ptr<DriverContext> driver_ctx,
-         std::vector<std::unique_ptr<Operator>> operators);
+         std::vector<std::shared_ptr<Operator>> operators);
 
     void
     CloseByTask() {
@@ -238,13 +238,16 @@ class Driver : public std::enable_shared_from_this<Driver> {
                 RowVectorPtr& result);
 
     void
+    PrefetchAsync();
+
+    void
     Close();
 
     std::unique_ptr<DriverContext> ctx_;
 
     std::atomic_bool closed_{false};
 
-    std::vector<std::unique_ptr<Operator>> operators_;
+    std::vector<std::shared_ptr<Operator>> operators_;
 
     size_t current_operator_index_{0};
 
@@ -253,6 +256,7 @@ class Driver : public std::enable_shared_from_this<Driver> {
     BlockingReason blocking_reason_{BlockingReason::kNotBlocked};
 
     friend struct DriverFactory;
+    std::once_flag once_;
 };
 
 using Consumer = std::function<BlockingReason(RowVectorPtr, ContinueFuture*)>;

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -20,11 +20,14 @@
 #include <cstdint>
 #include <string_view>
 #include <variant>
+#include <vector>
 
 #include "common/Array.h"
 #include "common/Json.h"
 #include "common/Tracer.h"
 #include "common/VectorArray.h"
+#include "exec/expression/Expr.h"
+#include "exec/expression/Utils.h"
 #include "fmt/core.h"
 #include "opentelemetry/trace/span.h"
 
@@ -35,6 +38,7 @@ namespace exec {
 
 void
 PhyBinaryArithOpEvalRangeExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    WaitPrefetch();
     tracer::AutoSpan span(
         "PhyBinaryArithOpEvalRangeExpr::Eval", tracer::GetRootSpan(), true);
     span.GetSpan()->SetAttribute("data_type",
@@ -2035,6 +2039,75 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForData(
                processed_size,
                real_batch_size);
     return res_vec;
+}
+
+void
+PhyBinaryArithOpEvalRangeExpr::PrefetchRawData() {
+    auto datatype = expr_->column_.data_type_;
+    if (expr_->column_.element_level_) {
+        datatype = expr_->column_.element_type_;
+    }
+
+    switch (datatype) {
+        case DataType::BOOL: {
+            PrefetchRawData<bool>();
+            break;
+        }
+        case DataType::INT8: {
+            PrefetchRawData<int8_t>();
+            break;
+        }
+        case DataType::INT16: {
+            PrefetchRawData<int16_t>();
+            break;
+        }
+        case DataType::INT32: {
+            PrefetchRawData<int32_t>();
+            break;
+        }
+        case DataType::INT64: {
+            PrefetchRawData<int64_t>();
+            break;
+        }
+        case DataType::FLOAT: {
+            PrefetchRawData<float>();
+            break;
+        }
+        case DataType::DOUBLE: {
+            PrefetchRawData<double>();
+            break;
+        }
+        default: {
+            SegmentExpr::PrefetchRawData(expr_->column_.field_id_);
+            break;
+        }
+    }
+}
+
+template <typename T>
+void
+PhyBinaryArithOpEvalRangeExpr::PrefetchRawData() {
+    using H =
+        std::conditional_t<std::is_integral_v<T> && !std::is_same_v<bool, T>,
+                           int64_t,
+                           T>;
+    auto& skip_index = segment_->GetSkipIndex();
+    auto value = GetValueWithCastNumber<H>(expr_->value_);
+    auto right_value = GetValueWithCastNumber<H>(expr_->right_operand_);
+
+    std::vector<int64_t> chunks_may_hit;
+    for (size_t i = 0; i < num_data_chunk_; ++i) {
+        auto skip = skip_index.CanSkipBinaryArithRange<T>(field_id_,
+                                                          i,
+                                                          expr_->op_type_,
+                                                          expr_->arith_op_type_,
+                                                          value,
+                                                          right_value);
+        if (!skip) {
+            chunks_may_hit.push_back(i);
+        }
+    }
+    segment_->prefetch_chunks(op_ctx_, field_id_, chunks_may_hit);
 }
 
 template VectorPtr

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.h
@@ -500,7 +500,7 @@ class PhyBinaryArithOpEvalRangeExpr : public SegmentExpr {
                       batch_size,
                       consistency_level),
           expr_(expr) {
-        DetermineExecPath();
+        // DetermineExecPath();
     }
 
     void
@@ -571,6 +571,13 @@ class PhyBinaryArithOpEvalRangeExpr : public SegmentExpr {
     GetColumnInfo() const override {
         return expr_->column_;
     }
+
+    void
+    PrefetchRawData() override;
+
+    template <typename T>
+    void
+    PrefetchRawData();
 
  private:
     template <typename T>

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -18,6 +18,9 @@
 
 #include <cstdint>
 #include <limits>
+#include <string>
+#include <string_view>
+#include <type_traits>
 #include <utility>
 #include <variant>
 
@@ -48,6 +51,7 @@ namespace exec {
 
 void
 PhyBinaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    WaitPrefetch();
     tracer::AutoSpan span(
         "PhyBinaryRangeFilterExpr::Eval", tracer::GetRootSpan(), true);
     span.GetSpan()->SetAttribute("data_type",
@@ -1034,5 +1038,81 @@ PhyBinaryRangeFilterExpr::DetermineExecPath() {
     }
 }
 
+void
+PhyBinaryRangeFilterExpr::PrefetchRawData() {
+    auto datatype = expr_->column_.data_type_;
+    if (expr_->column_.element_level_) {
+        datatype = expr_->column_.element_type_;
+    }
+
+    switch (datatype) {
+        case DataType::BOOL:
+            PrefetchRawData<bool>();
+            break;
+        case DataType::INT8:
+            PrefetchRawData<int8_t>();
+            break;
+        case DataType::INT16:
+            PrefetchRawData<int16_t>();
+            break;
+        case DataType::INT32:
+            PrefetchRawData<int32_t>();
+            break;
+        case DataType::INT64:
+            PrefetchRawData<int64_t>();
+            break;
+        case DataType::TIMESTAMPTZ:
+            PrefetchRawData<int64_t>();
+            break;
+        case DataType::FLOAT:
+            PrefetchRawData<float>();
+            break;
+        case DataType::DOUBLE:
+            PrefetchRawData<double>();
+            break;
+        case DataType::VARCHAR:
+            if (segment_->type() == SegmentType::Growing &&
+                !storage::MmapManager::GetInstance()
+                     .GetMmapConfig()
+                     .growing_enable_mmap) {
+                PrefetchRawData<std::string>();
+            } else {
+                PrefetchRawData<std::string_view>();
+            }
+            break;
+        default:
+            SegmentExpr::PrefetchRawData(expr_->column_.field_id_);
+            break;
+    }
+}
+
+template <typename T>
+void
+PhyBinaryRangeFilterExpr::PrefetchRawData() {
+    using U =
+        std::conditional_t<std::is_same_v<T, std::string_view>, std::string, T>;
+    using H =
+        std::conditional_t<std::is_integral_v<U> && !std::is_same_v<bool, T>,
+                           int64_t,
+                           U>;
+    H lower_val = GetValueWithCastNumber<H>(expr_->lower_val_);
+    H upper_val = GetValueWithCastNumber<H>(expr_->upper_val_);
+    auto& skip_index = segment_->GetSkipIndex();
+
+    std::vector<int64_t> chunks_may_hit;
+    for (size_t i = 0; i < num_data_chunk_; ++i) {
+        auto skip = skip_index.CanSkipBinaryRange(field_id_,
+                                                  i,
+                                                  lower_val,
+                                                  upper_val,
+                                                  expr_->lower_inclusive_,
+                                                  expr_->upper_inclusive_);
+        if (!skip) {
+            chunks_may_hit.push_back(i);
+        }
+    }
+
+    segment_->prefetch_chunks(op_ctx_, field_id_, chunks_may_hit);
+}
 }  // namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -300,7 +300,7 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
                       false,
                       plan_options),
           expr_(expr) {
-        DetermineExecPath();
+        // DetermineExecPath();
     }
 
     void
@@ -368,6 +368,13 @@ class PhyBinaryRangeFilterExpr : public SegmentExpr {
     template <typename T>
     VectorPtr
     ExecRangeVisitorImplForPk(EvalCtx& context);
+
+    void
+    PrefetchRawData() override;
+
+    template <typename T>
+    void
+    PrefetchRawData();
 
  private:
     std::shared_ptr<const milvus::expr::BinaryRangeFilterExpr> expr_;

--- a/internal/core/src/exec/expression/ExistsExpr.cpp
+++ b/internal/core/src/exec/expression/ExistsExpr.cpp
@@ -55,6 +55,7 @@ PhyExistsFilterExpr::DetermineExecPath() {
 
 void
 PhyExistsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    WaitPrefetch();
     tracer::AutoSpan span(
         "PhyExistsFilterExpr::Eval", tracer::GetRootSpan(), true);
     span.GetSpan()->SetAttribute("data_type",

--- a/internal/core/src/exec/expression/ExistsExpr.h
+++ b/internal/core/src/exec/expression/ExistsExpr.h
@@ -72,7 +72,7 @@ class PhyExistsFilterExpr : public SegmentExpr {
                       false,
                       plan_options),
           expr_(expr) {
-        DetermineExecPath();
+        // DetermineExecPath();
     }
 
     void

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <type_traits>
 
@@ -2421,16 +2422,16 @@ class SegmentExpr : public Expr {
     PrefetchAsync(const std::shared_ptr<folly::CPUThreadPoolExecutor>
                       prefetch_pool) override {
         auto self = std::static_pointer_cast<SegmentExpr>(shared_from_this());
-        prefetch_future_ = folly::via(prefetch_pool.get(), [self]() {
+        prefetch_future_.emplace(folly::via(prefetch_pool.get(), [self]() {
             if (self->op_ctx_ != nullptr &&
                 self->op_ctx_->cancellation_token.isCancellationRequested()) {
                 return;
             }
             self->EnsureExecPathDetermined();
             if (self->exec_path_ == ExprExecPath::RawData) {
-                self->PrefetchRawData(self->field_id_);
+                self->PrefetchRawData();
             }
-        });
+        }));
     }
 
     virtual void
@@ -2445,8 +2446,9 @@ class SegmentExpr : public Expr {
 
     void
     WaitPrefetch() override {
-        if (prefetch_future_.valid()) {
-            std::move(prefetch_future_).wait();
+        if (prefetch_future_.has_value()) {
+            std::move(*prefetch_future_).wait();
+            prefetch_future_.reset();
             return;
         }
         EnsureExecPathDetermined();
@@ -2523,7 +2525,7 @@ class SegmentExpr : public Expr {
     double json_filter_stats_latency_us_{0.0};
     double json_stats_shredding_latency_us_{0.0};
     double json_stats_shared_latency_us_{0.0};
-    folly::Future<folly::Unit> prefetch_future_;
+    std::optional<folly::Future<folly::Unit>> prefetch_future_;
 };
 
 bool

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -2447,8 +2447,9 @@ class SegmentExpr : public Expr {
     void
     WaitPrefetch() override {
         if (prefetch_future_.has_value()) {
-            std::move(*prefetch_future_).wait();
+            auto future = std::move(*prefetch_future_);
             prefetch_future_.reset();
+            std::move(future).get();
             return;
         }
         EnsureExecPathDetermined();

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -2430,6 +2430,7 @@ class SegmentExpr : public Expr {
             self->EnsureExecPathDetermined();
             if (self->exec_path_ == ExprExecPath::RawData) {
                 self->PrefetchRawData();
+                self->prefetched_ = true;
             }
         }));
     }

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -20,6 +20,7 @@
 #include <bit>
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <type_traits>
 
@@ -117,7 +118,7 @@ ApplyValidMask(const bool* valid_data,
     }
 }
 
-class Expr {
+class Expr : public std::enable_shared_from_this<Expr> {
  public:
     Expr(DataType type,
          const std::vector<std::shared_ptr<Expr>>&& inputs,
@@ -201,6 +202,21 @@ class Expr {
     std::vector<std::shared_ptr<Expr>>&
     GetInputsRef() {
         return inputs_;
+    }
+
+    virtual void
+    PrefetchAsync(
+        const std::shared_ptr<folly::CPUThreadPoolExecutor> prefetch_pool) {
+        for (const auto& input : inputs_) {
+            input->PrefetchAsync(prefetch_pool);
+        }
+    }
+
+    virtual void
+    WaitPrefetch() {
+        for (const auto& input : inputs_) {
+            input->WaitPrefetch();
+        }
     }
 
  protected:
@@ -2125,7 +2141,7 @@ class SegmentExpr : public Expr {
 
  protected:
     // Check if a compatible scalar index exists for this expression.
-    // Only called internally by DetermineExecPath() and CanUseNestedIndex().
+    // Only called internally by DetermineExecPath().
     bool
     HasCompatibleScalarIndex() const {
         // Queries segment metadata directly -- no pin required, so short-
@@ -2209,7 +2225,8 @@ class SegmentExpr : public Expr {
  public:
     bool
     CanUseNestedIndex() const override {
-        if (!HasCompatibleScalarIndex() || pinned_index_.empty()) {
+        EnsureExecPathDetermined();
+        if (exec_path_ != ExprExecPath::ScalarIndex || pinned_index_.empty()) {
             return false;
         }
         auto* index_ptr = pinned_index_[0].get();
@@ -2270,8 +2287,8 @@ class SegmentExpr : public Expr {
         return false;
     }
 
-    // Determine at init time whether this expression can use JsonStats.
-    // All conditions are available at construction time.
+    // Check whether this expression can use JsonStats without pinning.
+    // All conditions are available before execution path determination.
     bool
     CanUseJsonStatsAtInit() const {
         return plan_options_.expr_use_json_stats && HasJsonStats(field_id_) &&
@@ -2286,6 +2303,7 @@ class SegmentExpr : public Expr {
     // check if this expression can be executed all at once without batch iteration.
     bool
     CanExecuteAllAtOnce() const override {
+        EnsureExecPathDetermined();
         return exec_path_ != ExprExecPath::RawData;
     }
 
@@ -2300,11 +2318,20 @@ class SegmentExpr : public Expr {
     // and JsonStats cache full results and slice via data cursor.
     bool
     UseIndexCursor() const {
+        EnsureExecPathDetermined();
         return exec_path_ == ExprExecPath::ScalarIndex;
     }
 
+    void
+    EnsureExecPathDetermined() const {
+        std::call_once(determine_exec_path_once_, [this]() {
+            const_cast<SegmentExpr*>(this)->DetermineExecPath();
+        });
+    }
+
     // Determine the execution path for this expression.
-    // Called during initialization by subclass constructors.
+    // Called from PrefetchAsync() on the prefetch pool, or lazily by direct
+    // call paths that do not prefetch before evaluating expressions.
     // Subclasses should override to implement operator-specific logic.
     // The scalar index is pinned only when we commit to the ScalarIndex
     // path. JSON path compatibility is checked via segment-level metadata
@@ -2390,6 +2417,41 @@ class SegmentExpr : public Expr {
                                               TargetBitmap(size, true));
     }
 
+    void
+    PrefetchAsync(const std::shared_ptr<folly::CPUThreadPoolExecutor>
+                      prefetch_pool) override {
+        auto self = std::static_pointer_cast<SegmentExpr>(shared_from_this());
+        prefetch_future_ = folly::via(prefetch_pool.get(), [self]() {
+            if (self->op_ctx_ != nullptr &&
+                self->op_ctx_->cancellation_token.isCancellationRequested()) {
+                return;
+            }
+            self->EnsureExecPathDetermined();
+            if (self->exec_path_ == ExprExecPath::RawData) {
+                self->PrefetchRawData(self->field_id_);
+            }
+        });
+    }
+
+    virtual void
+    PrefetchRawData() {
+        PrefetchRawData(field_id_);
+    }
+
+    void
+    PrefetchRawData(FieldId field_id) {
+        segment_->prefetch_chunks(op_ctx_, field_id);
+    }
+
+    void
+    WaitPrefetch() override {
+        if (prefetch_future_.valid()) {
+            std::move(prefetch_future_).wait();
+            return;
+        }
+        EnsureExecPathDetermined();
+    }
+
  protected:
     const segcore::SegmentInternalInterface* segment_;
     const FieldId field_id_;
@@ -2404,8 +2466,10 @@ class SegmentExpr : public Expr {
     bool is_json_contains_{false};
     bool is_data_mode_{false};
     query::PlanOptions plan_options_;
-    // Execution path determined by DetermineExecPath() during initialization.
+    // Execution path determined once, preferably by PrefetchAsync() on the
+    // prefetch pool. Direct callers that do not prefetch determine it lazily.
     ExprExecPath exec_path_{ExprExecPath::RawData};
+    mutable std::once_flag determine_exec_path_once_;
     // Flag set by SetExecuteAllAtOnce() to enable move-based fast paths,
     // avoiding bitmap copies in ProcessIndexChunks/SliceCachedResult.
     bool execute_all_at_once_{false};
@@ -2459,6 +2523,7 @@ class SegmentExpr : public Expr {
     double json_filter_stats_latency_us_{0.0};
     double json_stats_shredding_latency_us_{0.0};
     double json_stats_shared_latency_us_{0.0};
+    folly::Future<folly::Unit> prefetch_future_;
 };
 
 bool
@@ -2550,6 +2615,21 @@ class ExprSet {
     SetExecuteAllAtOnce() {
         for (auto& expr : exprs_) {
             expr->SetExecuteAllAtOnce();
+        }
+    }
+
+    void
+    PrefetchAsync(
+        const std::shared_ptr<folly::CPUThreadPoolExecutor> prefetch_pool) {
+        for (const auto& expr : exprs_) {
+            expr->PrefetchAsync(prefetch_pool);
+        }
+    }
+
+    void
+    WaitPrefetch() {
+        for (const auto& expr : exprs_) {
+            expr->WaitPrefetch();
         }
     }
 

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -205,6 +205,7 @@ PhyGISFunctionFilterExpr::DetermineExecPath() {
 
 void
 PhyGISFunctionFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    WaitPrefetch();
     AssertInfo(expr_->column_.data_type_ == DataType::GEOMETRY,
                "unsupported data type: {}",
                expr_->column_.data_type_);

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -55,7 +55,7 @@ class PhyGISFunctionFilterExpr : public SegmentExpr {
                       batch_size,
                       consistency_level),
           expr_(expr) {
-        DetermineExecPath();
+        // DetermineExecPath();
     }
 
     void

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -126,6 +126,7 @@ class ContainsAllMatcher {
 
 void
 PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    WaitPrefetch();
     tracer::AutoSpan span(
         "PhyJsonContainsFilterExpr::Eval", tracer::GetRootSpan(), true);
     span.GetSpan()->SetAttribute("data_type",

--- a/internal/core/src/exec/expression/JsonContainsExpr.h
+++ b/internal/core/src/exec/expression/JsonContainsExpr.h
@@ -476,7 +476,7 @@ class PhyJsonContainsFilterExpr : public SegmentExpr {
                       true,
                       plan_options),
           expr_(expr) {
-        DetermineExecPath();
+        // DetermineExecPath();
     }
 
     void

--- a/internal/core/src/exec/expression/NullExpr.cpp
+++ b/internal/core/src/exec/expression/NullExpr.cpp
@@ -38,6 +38,7 @@ namespace exec {
 
 void
 PhyNullExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    WaitPrefetch();
     tracer::AutoSpan span("PhyNullExpr::Eval", tracer::GetRootSpan(), true);
     span.GetSpan()->SetAttribute("data_type",
                                  static_cast<int>(expr_->column_.data_type_));

--- a/internal/core/src/exec/expression/NullExpr.h
+++ b/internal/core/src/exec/expression/NullExpr.h
@@ -49,7 +49,7 @@ class PhyNullExpr : public SegmentExpr {
                       batch_size,
                       consistency_level),
           expr_(expr) {
-        DetermineExecPath();
+        // DetermineExecPath();
     }
 
     void

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -32,6 +32,7 @@
 #include "common/bson_view.h"
 #include "common/type_c.h"
 #include "common/ScopedTimer.h"
+#include "exec/expression/Element.h"
 #include "exec/expression/EvalCtx.h"
 #include "exec/expression/Utils.h"
 #include "folly/FBVector.h"
@@ -56,6 +57,7 @@ namespace exec {
 
 void
 PhyTermFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    WaitPrefetch();
     tracer::AutoSpan span(
         "PhyTermFilterExpr::Eval", tracer::GetRootSpan(), true);
     span.GetSpan()->SetAttribute("data_type",
@@ -1232,6 +1234,77 @@ PhyTermFilterExpr::DetermineExecPath() {
     if (data_type == DataType::ARRAY) {
         exec_path_ = ExprExecPath::RawData;
     }
+}
+
+void
+PhyTermFilterExpr::PrefetchRawData() {
+    auto datatype = expr_->column_.data_type_;
+    if (expr_->column_.element_level_) {
+        datatype = expr_->column_.element_type_;
+    }
+
+    switch (datatype) {
+        case DataType::BOOL:
+            PrefetchRawData<bool>();
+            break;
+        case DataType::INT8:
+            PrefetchRawData<int8_t>();
+            break;
+        case DataType::INT16:
+            PrefetchRawData<int16_t>();
+            break;
+        case DataType::INT32:
+            PrefetchRawData<int32_t>();
+            break;
+        case DataType::INT64:
+            PrefetchRawData<int64_t>();
+            break;
+        case DataType::TIMESTAMPTZ:
+            PrefetchRawData<int64_t>();
+            break;
+        case DataType::FLOAT:
+            PrefetchRawData<float>();
+            break;
+        case DataType::DOUBLE:
+            PrefetchRawData<double>();
+            break;
+        case DataType::VARCHAR:
+            if (segment_->type() == SegmentType::Growing &&
+                !storage::MmapManager::GetInstance()
+                     .GetMmapConfig()
+                     .growing_enable_mmap) {
+                PrefetchRawData<std::string>();
+            } else {
+                PrefetchRawData<std::string_view>();
+            }
+            break;
+        default:
+            SegmentExpr::PrefetchRawData(expr_->column_.field_id_);
+            break;
+    }
+}
+
+template <typename T>
+void
+PhyTermFilterExpr::PrefetchRawData() {
+    auto& skip_index = segment_->GetSkipIndex();
+
+    std::vector<T> elements;
+    elements.reserve(expr_->vals_.size());
+    for (const auto& val : expr_->vals_) {
+        auto e = GetValueWithCastNumber<T>(val);
+        elements.push_back(e);
+    }
+
+    std::vector<int64_t> chunks_may_hit;
+    for (size_t i = 0; i < num_data_chunk_; ++i) {
+        auto skip = skip_index.CanSkipInQuery(field_id_, i, elements);
+        if (!skip) {
+            chunks_may_hit.push_back(i);
+        }
+    }
+
+    segment_->prefetch_chunks(op_ctx_, field_id_, chunks_may_hit);
 }
 
 }  //namespace exec

--- a/internal/core/src/exec/expression/TermExpr.h
+++ b/internal/core/src/exec/expression/TermExpr.h
@@ -81,7 +81,7 @@ class PhyTermFilterExpr : public SegmentExpr {
                       false,
                       plan_options),
           expr_(expr) {
-        DetermineExecPath();
+        // DetermineExecPath();
     }
 
     void
@@ -104,6 +104,13 @@ class PhyTermFilterExpr : public SegmentExpr {
     GetColumnInfo() const override {
         return expr_->column_;
     }
+
+    void
+    PrefetchRawData() override;
+
+    template <typename T>
+    void
+    PrefetchRawData();
 
  private:
     void

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
@@ -96,7 +96,8 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
     TargetBitmapView res(res_vec->GetRawData(), real_batch_size);
     TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
     auto exec_sub_batch =
-        [arith_op, compare_op]<FilterType filter_type = FilterType::sequential>(
+        [ arith_op,
+          compare_op ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
             const bool* valid_data,
             const int32_t* offsets,
@@ -105,103 +106,103 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
             TargetBitmapView valid_res,
             T compare_value,
             proto::plan::Interval interval) {
-            const int64_t compare_us = compare_value;
-            for (int i = 0; i < size; ++i) {
-                const int64_t current_ts_us = data[i];
-                const int op_sign =
-                    (arith_op == proto::plan::ArithOpType::Add) ? 1 : -1;
-                // Floor division to correctly handle pre-epoch (negative) timestamps:
-                // C++ truncates toward zero, but we need floor for time decomposition.
-                // e.g., -1500000 us should be epoch_sec=-2, sub_sec_us=500000
-                //        not epoch_sec=-1, sub_sec_us=-500000
-                // Uses div-then-adjust pattern to avoid signed overflow near INT64_MIN.
-                std::time_t epoch_sec = current_ts_us / 1000000 -
-                                        (current_ts_us % 1000000 < 0 ? 1 : 0);
-                int64_t sub_sec_us = current_ts_us - epoch_sec * 1000000;
-                struct std::tm tm_buf;
-                if (::gmtime_r(&epoch_sec, &tm_buf) == nullptr) {
-                    ThrowInfo(OpTypeInvalid,
-                              "gmtime_r failed for timestamp {} us",
-                              current_ts_us);
-                }
-                // Apply interval fields using int64_t intermediate arithmetic
-                // to avoid int overflow UB, then validate range before assigning
-                // back to struct tm (which uses int fields).
-                auto safe_add = [](int base, int64_t delta) -> int {
-                    int64_t result = static_cast<int64_t>(base) + delta;
-                    AssertInfo(result >= INT_MIN && result <= INT_MAX,
-                               "timestamp interval arithmetic overflow: "
-                               "{} + {} = {}",
-                               base,
-                               delta,
-                               result);
-                    return static_cast<int>(result);
-                };
-                // Cast to int64_t before multiplying to avoid int * int overflow
-                // (e.g. interval.years() == INT32_MIN, op_sign == -1).
-                tm_buf.tm_year =
-                    safe_add(tm_buf.tm_year,
-                             static_cast<int64_t>(interval.years()) * op_sign);
-                tm_buf.tm_mon =
-                    safe_add(tm_buf.tm_mon,
-                             static_cast<int64_t>(interval.months()) * op_sign);
-                tm_buf.tm_mday =
-                    safe_add(tm_buf.tm_mday,
-                             static_cast<int64_t>(interval.days()) * op_sign);
-                tm_buf.tm_hour =
-                    safe_add(tm_buf.tm_hour,
-                             static_cast<int64_t>(interval.hours()) * op_sign);
-                tm_buf.tm_min = safe_add(
-                    tm_buf.tm_min,
-                    static_cast<int64_t>(interval.minutes()) * op_sign);
-                tm_buf.tm_sec = safe_add(
-                    tm_buf.tm_sec,
-                    static_cast<int64_t>(interval.seconds()) * op_sign);
-                // timegm normalizes the tm fields and converts back to epoch.
-                // It succeeds for all normalized inputs from gmtime_r + safe_add.
-                // No -1 check: -1 is a valid epoch second (1969-12-31T23:59:59Z)
-                // and is reachable via legal interval arithmetic (e.g., epoch 0 - 1s).
-                std::time_t new_epoch_sec = ::timegm(&tm_buf);
-                // Guard against overflow in epoch_sec * 1000000.
-                // INT64_MAX / 1000000 ≈ ±9.2e12 sec ≈ ±292,271 years from epoch.
-                constexpr int64_t kMaxSec = (INT64_MAX - 999999) / 1000000;
-                constexpr int64_t kMinSec = (INT64_MIN + 999999) / 1000000;
-                AssertInfo(
-                    new_epoch_sec >= kMinSec && new_epoch_sec <= kMaxSec,
-                    "timestamp after interval arithmetic out of representable "
-                    "range: {} seconds from epoch",
-                    static_cast<int64_t>(new_epoch_sec));
-                // Restore sub-second microseconds from the original timestamp
-                int64_t final_us =
-                    static_cast<int64_t>(new_epoch_sec) * 1000000 + sub_sec_us;
-                bool match = false;
-                switch (compare_op) {
-                    case proto::plan::OpType::Equal:
-                        match = (final_us == compare_us);
-                        break;
-                    case proto::plan::OpType::NotEqual:
-                        match = (final_us != compare_us);
-                        break;
-                    case proto::plan::OpType::GreaterThan:
-                        match = (final_us > compare_us);
-                        break;
-                    case proto::plan::OpType::GreaterEqual:
-                        match = (final_us >= compare_us);
-                        break;
-                    case proto::plan::OpType::LessThan:
-                        match = (final_us < compare_us);
-                        break;
-                    case proto::plan::OpType::LessEqual:
-                        match = (final_us <= compare_us);
-                        break;
-                    default:  // Should not happen
-                        ThrowInfo(OpTypeInvalid,
-                                  "Unsupported compare op for "
-                                  "timestamptz_arith_compare_expr");
-                }
-                res[i] = match;
+        const int64_t compare_us = compare_value;
+        for (int i = 0; i < size; ++i) {
+            const int64_t current_ts_us = data[i];
+            const int op_sign =
+                (arith_op == proto::plan::ArithOpType::Add) ? 1 : -1;
+            // Floor division to correctly handle pre-epoch (negative) timestamps:
+            // C++ truncates toward zero, but we need floor for time decomposition.
+            // e.g., -1500000 us should be epoch_sec=-2, sub_sec_us=500000
+            //        not epoch_sec=-1, sub_sec_us=-500000
+            // Uses div-then-adjust pattern to avoid signed overflow near INT64_MIN.
+            std::time_t epoch_sec =
+                current_ts_us / 1000000 - (current_ts_us % 1000000 < 0 ? 1 : 0);
+            int64_t sub_sec_us = current_ts_us - epoch_sec * 1000000;
+            struct std::tm tm_buf;
+            if (::gmtime_r(&epoch_sec, &tm_buf) == nullptr) {
+                ThrowInfo(OpTypeInvalid,
+                          "gmtime_r failed for timestamp {} us",
+                          current_ts_us);
             }
-        };
+            // Apply interval fields using int64_t intermediate arithmetic
+            // to avoid int overflow UB, then validate range before assigning
+            // back to struct tm (which uses int fields).
+            auto safe_add = [](int base, int64_t delta) -> int {
+                int64_t result = static_cast<int64_t>(base) + delta;
+                AssertInfo(result >= INT_MIN && result <= INT_MAX,
+                           "timestamp interval arithmetic overflow: "
+                           "{} + {} = {}",
+                           base,
+                           delta,
+                           result);
+                return static_cast<int>(result);
+            };
+            // Cast to int64_t before multiplying to avoid int * int overflow
+            // (e.g. interval.years() == INT32_MIN, op_sign == -1).
+            tm_buf.tm_year =
+                safe_add(tm_buf.tm_year,
+                         static_cast<int64_t>(interval.years()) * op_sign);
+            tm_buf.tm_mon =
+                safe_add(tm_buf.tm_mon,
+                         static_cast<int64_t>(interval.months()) * op_sign);
+            tm_buf.tm_mday =
+                safe_add(tm_buf.tm_mday,
+                         static_cast<int64_t>(interval.days()) * op_sign);
+            tm_buf.tm_hour =
+                safe_add(tm_buf.tm_hour,
+                         static_cast<int64_t>(interval.hours()) * op_sign);
+            tm_buf.tm_min =
+                safe_add(tm_buf.tm_min,
+                         static_cast<int64_t>(interval.minutes()) * op_sign);
+            tm_buf.tm_sec =
+                safe_add(tm_buf.tm_sec,
+                         static_cast<int64_t>(interval.seconds()) * op_sign);
+            // timegm normalizes the tm fields and converts back to epoch.
+            // It succeeds for all normalized inputs from gmtime_r + safe_add.
+            // No -1 check: -1 is a valid epoch second (1969-12-31T23:59:59Z)
+            // and is reachable via legal interval arithmetic (e.g., epoch 0 - 1s).
+            std::time_t new_epoch_sec = ::timegm(&tm_buf);
+            // Guard against overflow in epoch_sec * 1000000.
+            // INT64_MAX / 1000000 ≈ ±9.2e12 sec ≈ ±292,271 years from epoch.
+            constexpr int64_t kMaxSec = (INT64_MAX - 999999) / 1000000;
+            constexpr int64_t kMinSec = (INT64_MIN + 999999) / 1000000;
+            AssertInfo(
+                new_epoch_sec >= kMinSec && new_epoch_sec <= kMaxSec,
+                "timestamp after interval arithmetic out of representable "
+                "range: {} seconds from epoch",
+                static_cast<int64_t>(new_epoch_sec));
+            // Restore sub-second microseconds from the original timestamp
+            int64_t final_us =
+                static_cast<int64_t>(new_epoch_sec) * 1000000 + sub_sec_us;
+            bool match = false;
+            switch (compare_op) {
+                case proto::plan::OpType::Equal:
+                    match = (final_us == compare_us);
+                    break;
+                case proto::plan::OpType::NotEqual:
+                    match = (final_us != compare_us);
+                    break;
+                case proto::plan::OpType::GreaterThan:
+                    match = (final_us > compare_us);
+                    break;
+                case proto::plan::OpType::GreaterEqual:
+                    match = (final_us >= compare_us);
+                    break;
+                case proto::plan::OpType::LessThan:
+                    match = (final_us < compare_us);
+                    break;
+                case proto::plan::OpType::LessEqual:
+                    match = (final_us <= compare_us);
+                    break;
+                default:  // Should not happen
+                    ThrowInfo(OpTypeInvalid,
+                              "Unsupported compare op for "
+                              "timestamptz_arith_compare_expr");
+            }
+            res[i] = match;
+        }
+    };
     int64_t processed_size;
     if (has_offset_input_) {
         processed_size = ProcessDataByOffsets<T>(exec_sub_batch,

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
@@ -27,6 +27,7 @@ PhyTimestamptzArithCompareExpr::ToString() const {
 
 void
 PhyTimestamptzArithCompareExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    WaitPrefetch();
     auto input = context.get_offset_input();
     SetHasOffsetInput((input != nullptr));
     result = ExecCompareVisitorImpl<int64_t>(input);

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.cpp
@@ -16,6 +16,7 @@
 #include "exec/expression/Expr.h"
 #include "expr/ITypeExpr.h"
 #include "pb/plan.pb.h"
+#include "storage/PrefetchThreadPool.h"
 
 namespace milvus {
 namespace exec {
@@ -78,6 +79,7 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
                 active_count_,
                 batch_size_,
                 consistency_level_);
+            helperPhyExpr_->EnsureExecPathDetermined();
         }
         return helperPhyExpr_->ExecRangeVisitorImpl<T>(input);
     }
@@ -94,8 +96,7 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
     TargetBitmapView res(res_vec->GetRawData(), real_batch_size);
     TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
     auto exec_sub_batch =
-        [ arith_op,
-          compare_op ]<FilterType filter_type = FilterType::sequential>(
+        [arith_op, compare_op]<FilterType filter_type = FilterType::sequential>(
             const T* data,
             const bool* valid_data,
             const int32_t* offsets,
@@ -104,103 +105,103 @@ PhyTimestamptzArithCompareExpr::ExecCompareVisitorImplForAll(
             TargetBitmapView valid_res,
             T compare_value,
             proto::plan::Interval interval) {
-        const int64_t compare_us = compare_value;
-        for (int i = 0; i < size; ++i) {
-            const int64_t current_ts_us = data[i];
-            const int op_sign =
-                (arith_op == proto::plan::ArithOpType::Add) ? 1 : -1;
-            // Floor division to correctly handle pre-epoch (negative) timestamps:
-            // C++ truncates toward zero, but we need floor for time decomposition.
-            // e.g., -1500000 us should be epoch_sec=-2, sub_sec_us=500000
-            //        not epoch_sec=-1, sub_sec_us=-500000
-            // Uses div-then-adjust pattern to avoid signed overflow near INT64_MIN.
-            std::time_t epoch_sec =
-                current_ts_us / 1000000 - (current_ts_us % 1000000 < 0 ? 1 : 0);
-            int64_t sub_sec_us = current_ts_us - epoch_sec * 1000000;
-            struct std::tm tm_buf;
-            if (::gmtime_r(&epoch_sec, &tm_buf) == nullptr) {
-                ThrowInfo(OpTypeInvalid,
-                          "gmtime_r failed for timestamp {} us",
-                          current_ts_us);
-            }
-            // Apply interval fields using int64_t intermediate arithmetic
-            // to avoid int overflow UB, then validate range before assigning
-            // back to struct tm (which uses int fields).
-            auto safe_add = [](int base, int64_t delta) -> int {
-                int64_t result = static_cast<int64_t>(base) + delta;
-                AssertInfo(result >= INT_MIN && result <= INT_MAX,
-                           "timestamp interval arithmetic overflow: "
-                           "{} + {} = {}",
-                           base,
-                           delta,
-                           result);
-                return static_cast<int>(result);
-            };
-            // Cast to int64_t before multiplying to avoid int * int overflow
-            // (e.g. interval.years() == INT32_MIN, op_sign == -1).
-            tm_buf.tm_year =
-                safe_add(tm_buf.tm_year,
-                         static_cast<int64_t>(interval.years()) * op_sign);
-            tm_buf.tm_mon =
-                safe_add(tm_buf.tm_mon,
-                         static_cast<int64_t>(interval.months()) * op_sign);
-            tm_buf.tm_mday =
-                safe_add(tm_buf.tm_mday,
-                         static_cast<int64_t>(interval.days()) * op_sign);
-            tm_buf.tm_hour =
-                safe_add(tm_buf.tm_hour,
-                         static_cast<int64_t>(interval.hours()) * op_sign);
-            tm_buf.tm_min =
-                safe_add(tm_buf.tm_min,
-                         static_cast<int64_t>(interval.minutes()) * op_sign);
-            tm_buf.tm_sec =
-                safe_add(tm_buf.tm_sec,
-                         static_cast<int64_t>(interval.seconds()) * op_sign);
-            // timegm normalizes the tm fields and converts back to epoch.
-            // It succeeds for all normalized inputs from gmtime_r + safe_add.
-            // No -1 check: -1 is a valid epoch second (1969-12-31T23:59:59Z)
-            // and is reachable via legal interval arithmetic (e.g., epoch 0 - 1s).
-            std::time_t new_epoch_sec = ::timegm(&tm_buf);
-            // Guard against overflow in epoch_sec * 1000000.
-            // INT64_MAX / 1000000 ≈ ±9.2e12 sec ≈ ±292,271 years from epoch.
-            constexpr int64_t kMaxSec = (INT64_MAX - 999999) / 1000000;
-            constexpr int64_t kMinSec = (INT64_MIN + 999999) / 1000000;
-            AssertInfo(
-                new_epoch_sec >= kMinSec && new_epoch_sec <= kMaxSec,
-                "timestamp after interval arithmetic out of representable "
-                "range: {} seconds from epoch",
-                static_cast<int64_t>(new_epoch_sec));
-            // Restore sub-second microseconds from the original timestamp
-            int64_t final_us =
-                static_cast<int64_t>(new_epoch_sec) * 1000000 + sub_sec_us;
-            bool match = false;
-            switch (compare_op) {
-                case proto::plan::OpType::Equal:
-                    match = (final_us == compare_us);
-                    break;
-                case proto::plan::OpType::NotEqual:
-                    match = (final_us != compare_us);
-                    break;
-                case proto::plan::OpType::GreaterThan:
-                    match = (final_us > compare_us);
-                    break;
-                case proto::plan::OpType::GreaterEqual:
-                    match = (final_us >= compare_us);
-                    break;
-                case proto::plan::OpType::LessThan:
-                    match = (final_us < compare_us);
-                    break;
-                case proto::plan::OpType::LessEqual:
-                    match = (final_us <= compare_us);
-                    break;
-                default:  // Should not happen
+            const int64_t compare_us = compare_value;
+            for (int i = 0; i < size; ++i) {
+                const int64_t current_ts_us = data[i];
+                const int op_sign =
+                    (arith_op == proto::plan::ArithOpType::Add) ? 1 : -1;
+                // Floor division to correctly handle pre-epoch (negative) timestamps:
+                // C++ truncates toward zero, but we need floor for time decomposition.
+                // e.g., -1500000 us should be epoch_sec=-2, sub_sec_us=500000
+                //        not epoch_sec=-1, sub_sec_us=-500000
+                // Uses div-then-adjust pattern to avoid signed overflow near INT64_MIN.
+                std::time_t epoch_sec = current_ts_us / 1000000 -
+                                        (current_ts_us % 1000000 < 0 ? 1 : 0);
+                int64_t sub_sec_us = current_ts_us - epoch_sec * 1000000;
+                struct std::tm tm_buf;
+                if (::gmtime_r(&epoch_sec, &tm_buf) == nullptr) {
                     ThrowInfo(OpTypeInvalid,
-                              "Unsupported compare op for "
-                              "timestamptz_arith_compare_expr");
+                              "gmtime_r failed for timestamp {} us",
+                              current_ts_us);
+                }
+                // Apply interval fields using int64_t intermediate arithmetic
+                // to avoid int overflow UB, then validate range before assigning
+                // back to struct tm (which uses int fields).
+                auto safe_add = [](int base, int64_t delta) -> int {
+                    int64_t result = static_cast<int64_t>(base) + delta;
+                    AssertInfo(result >= INT_MIN && result <= INT_MAX,
+                               "timestamp interval arithmetic overflow: "
+                               "{} + {} = {}",
+                               base,
+                               delta,
+                               result);
+                    return static_cast<int>(result);
+                };
+                // Cast to int64_t before multiplying to avoid int * int overflow
+                // (e.g. interval.years() == INT32_MIN, op_sign == -1).
+                tm_buf.tm_year =
+                    safe_add(tm_buf.tm_year,
+                             static_cast<int64_t>(interval.years()) * op_sign);
+                tm_buf.tm_mon =
+                    safe_add(tm_buf.tm_mon,
+                             static_cast<int64_t>(interval.months()) * op_sign);
+                tm_buf.tm_mday =
+                    safe_add(tm_buf.tm_mday,
+                             static_cast<int64_t>(interval.days()) * op_sign);
+                tm_buf.tm_hour =
+                    safe_add(tm_buf.tm_hour,
+                             static_cast<int64_t>(interval.hours()) * op_sign);
+                tm_buf.tm_min = safe_add(
+                    tm_buf.tm_min,
+                    static_cast<int64_t>(interval.minutes()) * op_sign);
+                tm_buf.tm_sec = safe_add(
+                    tm_buf.tm_sec,
+                    static_cast<int64_t>(interval.seconds()) * op_sign);
+                // timegm normalizes the tm fields and converts back to epoch.
+                // It succeeds for all normalized inputs from gmtime_r + safe_add.
+                // No -1 check: -1 is a valid epoch second (1969-12-31T23:59:59Z)
+                // and is reachable via legal interval arithmetic (e.g., epoch 0 - 1s).
+                std::time_t new_epoch_sec = ::timegm(&tm_buf);
+                // Guard against overflow in epoch_sec * 1000000.
+                // INT64_MAX / 1000000 ≈ ±9.2e12 sec ≈ ±292,271 years from epoch.
+                constexpr int64_t kMaxSec = (INT64_MAX - 999999) / 1000000;
+                constexpr int64_t kMinSec = (INT64_MIN + 999999) / 1000000;
+                AssertInfo(
+                    new_epoch_sec >= kMinSec && new_epoch_sec <= kMaxSec,
+                    "timestamp after interval arithmetic out of representable "
+                    "range: {} seconds from epoch",
+                    static_cast<int64_t>(new_epoch_sec));
+                // Restore sub-second microseconds from the original timestamp
+                int64_t final_us =
+                    static_cast<int64_t>(new_epoch_sec) * 1000000 + sub_sec_us;
+                bool match = false;
+                switch (compare_op) {
+                    case proto::plan::OpType::Equal:
+                        match = (final_us == compare_us);
+                        break;
+                    case proto::plan::OpType::NotEqual:
+                        match = (final_us != compare_us);
+                        break;
+                    case proto::plan::OpType::GreaterThan:
+                        match = (final_us > compare_us);
+                        break;
+                    case proto::plan::OpType::GreaterEqual:
+                        match = (final_us >= compare_us);
+                        break;
+                    case proto::plan::OpType::LessThan:
+                        match = (final_us < compare_us);
+                        break;
+                    case proto::plan::OpType::LessEqual:
+                        match = (final_us <= compare_us);
+                        break;
+                    default:  // Should not happen
+                        ThrowInfo(OpTypeInvalid,
+                                  "Unsupported compare op for "
+                                  "timestamptz_arith_compare_expr");
+                }
+                res[i] = match;
             }
-            res[i] = match;
-        }
-    };
+        };
     int64_t processed_size;
     if (has_offset_input_) {
         processed_size = ProcessDataByOffsets<T>(exec_sub_batch,

--- a/internal/core/src/exec/expression/TimestamptzArithCompareExpr.h
+++ b/internal/core/src/exec/expression/TimestamptzArithCompareExpr.h
@@ -44,7 +44,7 @@ class PhyTimestamptzArithCompareExpr : public SegmentExpr {
                       batch_size,
                       consistency_level),
           expr_(expr) {
-        DetermineExecPath();
+        // DetermineExecPath();
     }
 
     void

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -16,6 +16,9 @@
 
 #include "UnaryExpr.h"
 
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/futures/Future-inl.h>
+#include <folly/futures/Future.h>
 #include <simdjson.h>
 #include <algorithm>
 #include <chrono>
@@ -26,6 +29,7 @@
 #include <optional>
 #include <cctype>
 #include <set>
+#include <string_view>
 #include <unordered_set>
 #include <variant>
 
@@ -176,6 +180,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplArrayForIndex<proto::plan::Array>(
 
 void
 PhyUnaryRangeFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    WaitPrefetch();
     tracer::AutoSpan span(
         "PhyUnaryRangeFilterExpr::Eval", tracer::GetRootSpan(), true);
     span.GetSpan()->SetAttribute("data_type",
@@ -2174,6 +2179,74 @@ PhyUnaryRangeFilterExpr::ExecNgramMatch(EvalCtx& context) {
     MoveCursor();
     return std::make_shared<ColumnVector>(std::move(batch_candidates),
                                           std::move(valid_result));
+}
+
+void
+PhyUnaryRangeFilterExpr::PrefetchRawData() {
+    auto datatype = expr_->column_.data_type_;
+    if (expr_->column_.element_level_) {
+        datatype = expr_->column_.element_type_;
+    }
+
+    switch (datatype) {
+        case DataType::BOOL:
+            PrefetchRawData<bool>();
+            break;
+        case DataType::INT8:
+            PrefetchRawData<int8_t>();
+            break;
+        case DataType::INT16:
+            PrefetchRawData<int16_t>();
+            break;
+        case DataType::INT32:
+            PrefetchRawData<int32_t>();
+            break;
+        case DataType::INT64:
+            PrefetchRawData<int64_t>();
+            break;
+        case DataType::TIMESTAMPTZ:
+            PrefetchRawData<int64_t>();
+            break;
+        case DataType::FLOAT:
+            PrefetchRawData<float>();
+            break;
+        case DataType::DOUBLE:
+            PrefetchRawData<double>();
+            break;
+        case DataType::VARCHAR:
+            if (segment_->type() == SegmentType::Growing &&
+                !storage::MmapManager::GetInstance()
+                     .GetMmapConfig()
+                     .growing_enable_mmap) {
+                PrefetchRawData<std::string>();
+            } else {
+                PrefetchRawData<std::string_view>();
+            }
+            break;
+        default:
+            SegmentExpr::PrefetchRawData(expr_->column_.field_id_);
+            break;
+    }
+}
+
+template <typename T>
+void
+PhyUnaryRangeFilterExpr::PrefetchRawData() {
+    using U =
+        std::conditional_t<std::is_same_v<T, std::string_view>, std::string, T>;
+    auto op_type = expr_->op_type_;
+    auto& skip_index = segment_->GetSkipIndex();
+    U val = GetValueFromProto<U>(expr_->val_);
+
+    std::vector<int64_t> chunks_may_hit;
+    for (size_t i = 0; i < num_data_chunk_; i++) {
+        if (skip_index.CanSkipUnaryRange<U>(field_id_, i, op_type, val)) {
+            continue;
+        }
+        chunks_may_hit.push_back(i);
+    }
+
+    segment_->prefetch_chunks(op_ctx_, field_id_, chunks_may_hit);
 }
 
 }  // namespace exec

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <folly/Unit.h>
 
 #include <optional>
 #include <utility>
@@ -1010,7 +1011,7 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
                 pinned_ngram_index_ = segment->GetNgramIndex(op_ctx_, field_id);
             }
         }
-        DetermineExecPath();
+        // DetermineExecPath();
     }
 
     void
@@ -1149,6 +1150,13 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
 
     static std::pair<std::string, std::string>
     SplitAtFirstSlashDigit(std::string input);
+
+    void
+    PrefetchRawData() override;
+
+    template <typename T>
+    void
+    PrefetchRawData();
 
  private:
     std::shared_ptr<const milvus::expr::UnaryRangeFilterExpr> expr_;

--- a/internal/core/src/exec/operator/ElementFilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/ElementFilterBitsNode.cpp
@@ -177,6 +177,7 @@ PhyElementFilterBitsNode::EvaluateElementExpression(
     if (doc_hit_ratio < DOC_HIT_RATIO_THRESHOLD_LOW) {
         offset_mode = true;
     } else if (doc_hit_ratio < DOC_HIT_RATIO_THRESHOLD_HIGH) {
+        element_exprs_->WaitPrefetch();
         offset_mode = !std::all_of(
             element_exprs_->exprs().begin(),
             element_exprs_->exprs().end(),

--- a/internal/core/src/exec/operator/ElementFilterBitsNode.h
+++ b/internal/core/src/exec/operator/ElementFilterBitsNode.h
@@ -71,6 +71,17 @@ class PhyElementFilterBitsNode : public Operator {
         return BlockingReason::kNotBlocked;
     }
 
+    void
+    PrefetchAsync(const std::shared_ptr<folly::CPUThreadPoolExecutor>
+                      prefetch_pool) override {
+        element_exprs_->PrefetchAsync(prefetch_pool);
+    }
+
+    void
+    WaitPrefetch() override {
+        element_exprs_->WaitPrefetch();
+    }
+
     std::string
     ToString() const override {
         return "PhyElementFilterBitsNode";

--- a/internal/core/src/exec/operator/FilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/FilterBitsNode.cpp
@@ -136,6 +136,8 @@ PhyFilterBitsNode::GetOutput() {
         "PhyFilterBitsNode::Execute", tracer::GetRootSpan(), true);
     tracer::AddEvent(fmt::format("input_rows: {}", need_process_rows_));
 
+    exprs_->WaitPrefetch();
+
     std::chrono::high_resolution_clock::time_point scalar_start =
         std::chrono::high_resolution_clock::now();
 

--- a/internal/core/src/exec/operator/FilterBitsNode.h
+++ b/internal/core/src/exec/operator/FilterBitsNode.h
@@ -71,6 +71,17 @@ class PhyFilterBitsNode : public Operator {
         return "PhyFilterBitsNode";
     }
 
+    void
+    PrefetchAsync(const std::shared_ptr<folly::CPUThreadPoolExecutor>
+                      prefetch_pool) override {
+        exprs_->PrefetchAsync(prefetch_pool);
+    }
+
+    void
+    WaitPrefetch() override {
+        exprs_->WaitPrefetch();
+    }
+
  private:
     std::unique_ptr<ExprSet> exprs_;
     QueryContext* query_context_;

--- a/internal/core/src/exec/operator/MvccNode.cpp
+++ b/internal/core/src/exec/operator/MvccNode.cpp
@@ -74,6 +74,7 @@ PhyMvccNode::GetOutput() {
     }
 
     tracer::AddEvent(fmt::format("input_rows: {}", active_count_));
+    WaitPrefetch();
 
     // Visibility filtering disabled globally: skip all filtering.
     if (!segcore::SegcoreConfig::default_config()

--- a/internal/core/src/exec/operator/MvccNode.h
+++ b/internal/core/src/exec/operator/MvccNode.h
@@ -16,8 +16,10 @@
 
 #pragma once
 
+#include <folly/futures/Future.h>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "exec/Driver.h"
 #include "exec/expression/Expr.h"
@@ -66,6 +68,26 @@ class PhyMvccNode : public Operator {
         return "PhyMvccNode";
     }
 
+    void
+    PrefetchAsync(const std::shared_ptr<folly::CPUThreadPoolExecutor>
+                      prefetch_pool) override {
+        auto self = std::static_pointer_cast<PhyMvccNode>(shared_from_this());
+        prefetch_future_ = folly::via(prefetch_pool.get(), [self]() {
+            self->segment_->prefetch_chunks(
+                self->operator_context_->get_exec_context()
+                    ->get_query_context()
+                    ->get_op_context(),
+                TimestampFieldID);
+        });
+    }
+
+    void
+    WaitPrefetch() override {
+        if (prefetch_future_.valid()) {
+            std::move(prefetch_future_).wait();
+        }
+    }
+
  private:
     const segcore::SegmentInternalInterface* segment_;
     milvus::Timestamp query_timestamp_;
@@ -73,6 +95,7 @@ class PhyMvccNode : public Operator {
     bool is_finished_{false};
     bool is_source_node_{false};
     milvus::Timestamp collection_ttl_timestamp_;
+    folly::Future<folly::Unit> prefetch_future_;
 };
 
 }  // namespace exec

--- a/internal/core/src/exec/operator/MvccNode.h
+++ b/internal/core/src/exec/operator/MvccNode.h
@@ -18,6 +18,7 @@
 
 #include <folly/futures/Future.h>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -72,19 +73,20 @@ class PhyMvccNode : public Operator {
     PrefetchAsync(const std::shared_ptr<folly::CPUThreadPoolExecutor>
                       prefetch_pool) override {
         auto self = std::static_pointer_cast<PhyMvccNode>(shared_from_this());
-        prefetch_future_ = folly::via(prefetch_pool.get(), [self]() {
+        prefetch_future_.emplace(folly::via(prefetch_pool.get(), [self]() {
             self->segment_->prefetch_chunks(
                 self->operator_context_->get_exec_context()
                     ->get_query_context()
                     ->get_op_context(),
                 TimestampFieldID);
-        });
+        }));
     }
 
     void
     WaitPrefetch() override {
-        if (prefetch_future_.valid()) {
-            std::move(prefetch_future_).wait();
+        if (prefetch_future_.has_value()) {
+            std::move(*prefetch_future_).wait();
+            prefetch_future_.reset();
         }
     }
 
@@ -95,7 +97,7 @@ class PhyMvccNode : public Operator {
     bool is_finished_{false};
     bool is_source_node_{false};
     milvus::Timestamp collection_ttl_timestamp_;
-    folly::Future<folly::Unit> prefetch_future_;
+    std::optional<folly::Future<folly::Unit>> prefetch_future_;
 };
 
 }  // namespace exec

--- a/internal/core/src/exec/operator/MvccNode.h
+++ b/internal/core/src/exec/operator/MvccNode.h
@@ -85,8 +85,9 @@ class PhyMvccNode : public Operator {
     void
     WaitPrefetch() override {
         if (prefetch_future_.has_value()) {
-            std::move(*prefetch_future_).wait();
+            auto future = std::move(*prefetch_future_);
             prefetch_future_.reset();
+            std::move(future).get();
         }
     }
 

--- a/internal/core/src/exec/operator/Operator.h
+++ b/internal/core/src/exec/operator/Operator.h
@@ -91,7 +91,7 @@ class OperatorContext {
     mutable std::unique_ptr<ExecContext> exec_context_;
 };
 
-class Operator {
+class Operator : public std::enable_shared_from_this<Operator> {
  public:
     Operator(DriverContext* ctx,
              RowTypePtr output_type,
@@ -171,6 +171,15 @@ class Operator {
     virtual const RowTypePtr&
     OutputType() const {
         return output_type_;
+    }
+
+    virtual void
+    PrefetchAsync(
+        const std::shared_ptr<folly::CPUThreadPoolExecutor> prefetch_pool) {
+    }
+
+    virtual void
+    WaitPrefetch() {
     }
 
  protected:

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -78,8 +78,6 @@ PhyVectorSearchNode::AddInput(RowVectorPtr& input) {
 
 RowVectorPtr
 PhyVectorSearchNode::GetOutput() {
-    WaitPrefetch();
-
     milvus::exec::checkCancellation(query_context_);
 
     if (is_finished_ || !no_more_input_) {
@@ -94,6 +92,7 @@ PhyVectorSearchNode::GetOutput() {
         return nullptr;
     }
 
+    WaitPrefetch();
     span.GetSpan()->SetAttribute("search_type", search_info_.metric_type_);
     span.GetSpan()->SetAttribute("topk", search_info_.topk_);
 

--- a/internal/core/src/exec/operator/VectorSearchNode.cpp
+++ b/internal/core/src/exec/operator/VectorSearchNode.cpp
@@ -78,6 +78,8 @@ PhyVectorSearchNode::AddInput(RowVectorPtr& input) {
 
 RowVectorPtr
 PhyVectorSearchNode::GetOutput() {
+    WaitPrefetch();
+
     milvus::exec::checkCancellation(query_context_);
 
     if (is_finished_ || !no_more_input_) {

--- a/internal/core/src/exec/operator/VectorSearchNode.h
+++ b/internal/core/src/exec/operator/VectorSearchNode.h
@@ -97,8 +97,9 @@ class PhyVectorSearchNode : public Operator {
     void
     WaitPrefetch() override {
         if (prefetch_future_.has_value()) {
-            std::move(*prefetch_future_).wait();
+            auto future = std::move(*prefetch_future_);
             prefetch_future_.reset();
+            std::move(future).get();
         }
     }
 

--- a/internal/core/src/exec/operator/VectorSearchNode.h
+++ b/internal/core/src/exec/operator/VectorSearchNode.h
@@ -19,6 +19,7 @@
 #include <folly/futures/Future.h>
 #include <stdint.h>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "common/Promise.h"
@@ -82,7 +83,7 @@ class PhyVectorSearchNode : public Operator {
                       prefetch_pool) override {
         auto self =
             std::static_pointer_cast<PhyVectorSearchNode>(shared_from_this());
-        prefetch_future_ = folly::via(prefetch_pool.get(), [self]() {
+        prefetch_future_.emplace(folly::via(prefetch_pool.get(), [self]() {
             auto* op_ctx = self->query_context_->get_op_context();
             if (op_ctx != nullptr &&
                 op_ctx->cancellation_token.isCancellationRequested()) {
@@ -90,13 +91,14 @@ class PhyVectorSearchNode : public Operator {
             }
             self->segment_->prefetch_vector(op_ctx,
                                             self->search_info_.field_id_);
-        });
+        }));
     }
 
     void
     WaitPrefetch() override {
-        if (prefetch_future_.valid()) {
-            std::move(prefetch_future_).wait();
+        if (prefetch_future_.has_value()) {
+            std::move(*prefetch_future_).wait();
+            prefetch_future_.reset();
         }
     }
 
@@ -110,7 +112,7 @@ class PhyVectorSearchNode : public Operator {
     const milvus::query::PlaceholderGroup* placeholder_group_;
     milvus::SearchInfo search_info_;
 
-    folly::Future<folly::Unit> prefetch_future_;
+    std::optional<folly::Future<folly::Unit>> prefetch_future_;
 };
 }  // namespace exec
 }  // namespace milvus

--- a/internal/core/src/exec/operator/VectorSearchNode.h
+++ b/internal/core/src/exec/operator/VectorSearchNode.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/futures/Future.h>
 #include <stdint.h>
 #include <memory>
 #include <string>
@@ -76,6 +77,29 @@ class PhyVectorSearchNode : public Operator {
         return "PhyVectorSearchNode";
     }
 
+    void
+    PrefetchAsync(const std::shared_ptr<folly::CPUThreadPoolExecutor>
+                      prefetch_pool) override {
+        auto self =
+            std::static_pointer_cast<PhyVectorSearchNode>(shared_from_this());
+        prefetch_future_ = folly::via(prefetch_pool.get(), [self]() {
+            auto* op_ctx = self->query_context_->get_op_context();
+            if (op_ctx != nullptr &&
+                op_ctx->cancellation_token.isCancellationRequested()) {
+                return;
+            }
+            self->segment_->prefetch_vector(op_ctx,
+                                            self->search_info_.field_id_);
+        });
+    }
+
+    void
+    WaitPrefetch() override {
+        if (prefetch_future_.valid()) {
+            std::move(prefetch_future_).wait();
+        }
+    }
+
  private:
     const milvus::segcore::SegmentInternalInterface* segment_;
     QueryContext* query_context_;
@@ -85,6 +109,8 @@ class PhyVectorSearchNode : public Operator {
 
     const milvus::query::PlaceholderGroup* placeholder_group_;
     milvus::SearchInfo search_info_;
+
+    folly::Future<folly::Unit> prefetch_future_;
 };
 }  // namespace exec
 }  // namespace milvus

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1363,10 +1363,22 @@ ChunkedSegmentSealedImpl::prefetch_chunks(
     FieldId field_id,
     const std::vector<int64_t>& chunk_ids) const {
     std::shared_lock lck(mutex_);
-    AssertInfo(get_bit(field_data_ready_bitset_, field_id),
-               "Can't get bitset element at " + std::to_string(field_id.get()));
+    // AssertInfo(get_bit(field_data_ready_bitset_, field_id),
+    //            "Can't get bitset element at " + std::to_string(field_id.get()));
     if (auto column = get_column(field_id)) {
         column->PrefetchChunks(op_ctx, chunk_ids);
+    }
+}
+
+void
+ChunkedSegmentSealedImpl::prefetch_chunks(milvus::OpContext* op_ctx,
+                                          FieldId field_id) const {
+    std::shared_lock lck(mutex_);
+    if (auto column = get_column(field_id)) {
+        auto num_chunks = column->num_chunks();
+        std::vector<int64_t> ids(num_chunks);
+        std::iota(ids.begin(), ids.end(), 0);
+        prefetch_chunks(op_ctx, field_id, ids);
     }
 }
 
@@ -6675,4 +6687,17 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
     return true;
 }
 
+void
+ChunkedSegmentSealedImpl::prefetch_vector(milvus::OpContext* op_ctx,
+                                          FieldId field_id) const {
+    auto is_ready = this->vector_indexings_.is_ready(field_id);
+    if (is_ready) {
+        auto field_indexing =
+            this->vector_indexings_.get_field_indexing(field_id);
+        auto cache_index = field_indexing->indexing_;
+        SemiInlineGet(cache_index->PinCells(op_ctx, {0}));
+    } else {
+        SegmentInternalInterface::prefetch_chunks(op_ctx, field_id);
+    }
+}
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1378,7 +1378,7 @@ ChunkedSegmentSealedImpl::prefetch_chunks(milvus::OpContext* op_ctx,
         auto num_chunks = column->num_chunks();
         std::vector<int64_t> ids(num_chunks);
         std::iota(ids.begin(), ids.end(), 0);
-        prefetch_chunks(op_ctx, field_id, ids);
+        column->PrefetchChunks(op_ctx, ids);
     }
 }
 
@@ -6697,7 +6697,7 @@ ChunkedSegmentSealedImpl::prefetch_vector(milvus::OpContext* op_ctx,
         auto cache_index = field_indexing->indexing_;
         SemiInlineGet(cache_index->PinCells(op_ctx, {0}));
     } else {
-        SegmentInternalInterface::prefetch_chunks(op_ctx, field_id);
+        this->prefetch_chunks(op_ctx, field_id);
     }
 }
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -499,6 +499,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                     const std::vector<int64_t>& chunk_ids) const override;
 
     void
+    prefetch_chunks(milvus::OpContext* op_ctx, FieldId field_id) const override;
+
+    void
+    prefetch_vector(milvus::OpContext* op_ctx, FieldId field_id) const override;
+
+    void
     ApplyFieldValidData(milvus::OpContext* op_ctx,
                         FieldId field_id,
                         int64_t chunk_id,

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -351,6 +352,16 @@ class SegmentInternalInterface : public SegmentInterface {
                     FieldId field_id,
                     const std::vector<int64_t>& chunk_ids) const {
         // do nothing
+    }
+
+    // Convenience: prefetch all chunks of a field. Default impl enumerates
+    // [0, num_chunk(field_id)) and forwards to the typed overload.
+    virtual void
+    prefetch_chunks(milvus::OpContext* op_ctx, FieldId field_id) const {
+    }
+
+    virtual void
+    prefetch_vector(milvus::OpContext* op_ctx, FieldId field_id) const {
     }
 
     // Apply field nullability to an already-initialized valid_result bitmap.

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -25,6 +25,7 @@
 #include "pthread.h"
 #include "segcore/SegcoreConfig.h"
 #include "segcore/segcore_init_c.h"
+#include "storage/PrefetchThreadPool.h"
 
 namespace milvus::segcore {
 
@@ -184,6 +185,11 @@ SegcoreSetKnowhereSearchThreadPoolNum(const uint32_t num_threads) {
 extern "C" void
 SegcoreSetKnowhereFetchThreadPoolNum(const uint32_t num_threads) {
     milvus::config::KnowhereInitFetchThreadPool(num_threads);
+}
+
+extern "C" void
+SegcoreSetPrefetchThreadPoolNum(const uint32_t num_threads) {
+    milvus::SetPrefetchThreadPoolSize(num_threads);
 }
 
 extern "C" void

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -88,6 +88,9 @@ void
 SegcoreSetKnowhereFetchThreadPoolNum(const uint32_t num_threads);
 
 void
+SegcoreSetPrefetchThreadPoolNum(const uint32_t num_threads);
+
+void
 SegcoreSetKnowhereGpuMemoryPoolSize(const uint32_t init_size,
                                     const uint32_t max_size);
 

--- a/internal/core/src/storage/PrefetchThreadPool.h
+++ b/internal/core/src/storage/PrefetchThreadPool.h
@@ -1,0 +1,26 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <memory>
+namespace milvus {
+
+inline std::shared_ptr<folly::CPUThreadPoolExecutor>
+GetPrefetchThreadPool() {
+    static std::shared_ptr<folly::CPUThreadPoolExecutor> pool =
+        std::make_shared<folly::CPUThreadPoolExecutor>(
+            24,
+            folly::CPUThreadPoolExecutor::makeDefaultPriorityQueue(1),
+            std::make_shared<folly::NamedThreadFactory>("MILVUS_PREFETCH_"));
+    return pool;
+}
+}  // namespace milvus

--- a/internal/core/src/storage/PrefetchThreadPool.h
+++ b/internal/core/src/storage/PrefetchThreadPool.h
@@ -10,17 +10,36 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #pragma once
-#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <algorithm>
+#include <cstdint>
 #include <memory>
-namespace milvus {
 
-inline std::shared_ptr<folly::CPUThreadPoolExecutor>
-GetPrefetchThreadPool() {
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
+
+namespace milvus {
+namespace detail {
+
+inline std::shared_ptr<folly::CPUThreadPoolExecutor>&
+PrefetchThreadPool() {
     static std::shared_ptr<folly::CPUThreadPoolExecutor> pool =
         std::make_shared<folly::CPUThreadPoolExecutor>(
-            24,
+            1,
             folly::CPUThreadPoolExecutor::makeDefaultPriorityQueue(1),
             std::make_shared<folly::NamedThreadFactory>("MILVUS_PREFETCH_"));
     return pool;
+}
+
+}  // namespace detail
+
+inline std::shared_ptr<folly::CPUThreadPoolExecutor>
+GetPrefetchThreadPool() {
+    return detail::PrefetchThreadPool();
+}
+
+inline void
+SetPrefetchThreadPoolSize(uint32_t num_threads) {
+    detail::PrefetchThreadPool()->setNumThreads(
+        std::max<uint32_t>(1, num_threads));
 }
 }  // namespace milvus

--- a/internal/util/cgo/executor.go
+++ b/internal/util/cgo/executor.go
@@ -4,6 +4,7 @@ package cgo
 #cgo pkg-config: milvus_core
 
 #include "futures/future_c.h"
+#include "segcore/segcore_init_c.h"
 */
 import "C"
 
@@ -23,14 +24,14 @@ func initExecutor() {
 
 	// Initialize search executor pool.
 	searchPoolSize := int(math.Ceil(pt.QueryNodeCfg.MaxReadConcurrency.GetAsFloat() * pt.QueryNodeCfg.CGOPoolSizeRatio.GetAsFloat()))
-	C.executor_set_search_thread_num(C.int(searchPoolSize))
+	setSearchThreadNum(searchPoolSize)
 
 	resetSearchThreadNum := func(evt *config.Event) {
 		if evt.HasUpdated {
 			pt := paramtable.Get()
 			newSize := int(math.Ceil(pt.QueryNodeCfg.MaxReadConcurrency.GetAsFloat() * pt.QueryNodeCfg.CGOPoolSizeRatio.GetAsFloat()))
 			mlog.Info(context.TODO(), "reset cgo search thread num", mlog.Int("thread_num", newSize))
-			C.executor_set_search_thread_num(C.int(newSize))
+			setSearchThreadNum(newSize)
 		}
 	}
 	pt.Watch(pt.QueryNodeCfg.MaxReadConcurrency.Key, config.NewHandler("cgo.search."+pt.QueryNodeCfg.MaxReadConcurrency.Key, resetSearchThreadNum))
@@ -49,4 +50,12 @@ func initExecutor() {
 		}
 	}
 	pt.Watch(pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.Key, config.NewHandler("cgo.load."+pt.CommonCfg.MiddlePriorityThreadCoreCoefficient.Key, resetLoadThreadNum))
+}
+
+func setSearchThreadNum(size int) {
+	if size <= 0 {
+		size = 1
+	}
+	C.executor_set_search_thread_num(C.int(size))
+	C.SegcoreSetPrefetchThreadPoolNum(C.uint32_t(size))
 }

--- a/internal/util/cgo/pool.go
+++ b/internal/util/cgo/pool.go
@@ -6,14 +6,14 @@ import (
 	"time"
 
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
-	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 var caller *cgoCaller
 
 func initCaller(nodeID string) {
-	chSize := int64(math.Ceil(float64(hardware.GetCPUNum()) * paramtable.Get().QueryNodeCfg.CGOPoolSizeRatio.GetAsFloat()))
+	pt := paramtable.Get()
+	chSize := int(math.Ceil(pt.QueryNodeCfg.MaxReadConcurrency.GetAsFloat() * pt.QueryNodeCfg.CGOPoolSizeRatio.GetAsFloat()))
 	if chSize <= 0 {
 		chSize = 1
 	}


### PR DESCRIPTION
issue: #50583

## Summary
- prefetch scalar expression chunks, vector data, and MVCC timestamp chunks before driver execution
- wait for prefetch completion before consuming prefetched MVCC/vector/scalar data
- size the cgo caller pool from queryNode MaxReadConcurrency and expose queryNode.segcore.cgoPoolSizeRatio in milvus.yaml
