### PR TITLE
enhance: add dynamic StructArray field APIs

### DIFF
--- a/client/entity/schema.go
+++ b/client/entity/schema.go
@@ -223,6 +223,7 @@ func (s *Schema) ReadProto(p *schemapb.CollectionSchema) *Schema {
 // original (scalar or vector) type.
 func structArrayFieldFromProto(p *schemapb.StructArrayFieldSchema) *Field {
 	structSchema := NewStructSchema()
+	typeParams := KvPairsMap(p.GetTypeParams())
 	for _, sf := range p.GetFields() {
 		field := NewField().ReadProto(sf)
 		// unwrap Array/ArrayOfVector wrapper added by ProtoMessage()
@@ -230,6 +231,11 @@ func structArrayFieldFromProto(p *schemapb.StructArrayFieldSchema) *Field {
 		case schemapb.DataType_Array, schemapb.DataType_ArrayOfVector:
 			field.DataType = FieldType(sf.GetElementType())
 			field.ElementType = 0
+		}
+		if _, ok := typeParams[TypeParamMaxCapacity]; !ok {
+			if maxCapacity, has := field.TypeParams[TypeParamMaxCapacity]; has {
+				typeParams[TypeParamMaxCapacity] = maxCapacity
+			}
 		}
 		structSchema.WithField(field)
 	}
@@ -239,7 +245,7 @@ func structArrayFieldFromProto(p *schemapb.StructArrayFieldSchema) *Field {
 		Description:  p.GetDescription(),
 		DataType:     FieldTypeArray,
 		ElementType:  FieldTypeStruct,
-		TypeParams:   KvPairsMap(p.GetTypeParams()),
+		TypeParams:   typeParams,
 		Nullable:     p.GetNullable(),
 		StructSchema: structSchema,
 	}

--- a/client/entity/schema.go
+++ b/client/entity/schema.go
@@ -154,6 +154,7 @@ func (s *Schema) ProtoMessage() *schemapb.CollectionSchema {
 			Name:        field.Name,
 			Description: field.Description,
 			TypeParams:  MapKvPairs(field.TypeParams),
+			Nullable:    field.Nullable,
 		}
 		// max_capacity declared on the parent struct field must be carried onto each sub-field's
 		// type params — the server validates it per sub-field on insert.
@@ -239,6 +240,7 @@ func structArrayFieldFromProto(p *schemapb.StructArrayFieldSchema) *Field {
 		DataType:     FieldTypeArray,
 		ElementType:  FieldTypeStruct,
 		TypeParams:   KvPairsMap(p.GetTypeParams()),
+		Nullable:     p.GetNullable(),
 		StructSchema: structSchema,
 	}
 }

--- a/client/entity/schema_test.go
+++ b/client/entity/schema_test.go
@@ -221,6 +221,10 @@ func (s *SchemaSuite) TestStructArrayFieldRoundTrip() {
 	s.Equal(2, len(p.GetFields()))
 	s.Equal(1, len(p.GetStructArrayFields()))
 	s.True(p.GetStructArrayFields()[0].GetNullable())
+	s.Equal("16", KvPairsMap(p.GetStructArrayFields()[0].GetTypeParams())[TypeParamMaxCapacity])
+
+	// DescribeCollection may return max_capacity only on struct sub-fields.
+	p.GetStructArrayFields()[0].TypeParams = nil
 
 	got := (&Schema{}).ReadProto(p)
 	// 3 logical fields including the struct array
@@ -237,6 +241,7 @@ func (s *SchemaSuite) TestStructArrayFieldRoundTrip() {
 	s.Equal(FieldTypeArray, clips.DataType)
 	s.Equal(FieldTypeStruct, clips.ElementType)
 	s.True(clips.Nullable)
+	s.Equal("16", clips.TypeParams[TypeParamMaxCapacity])
 	s.Require().NotNil(clips.StructSchema)
 	s.Equal(2, len(clips.StructSchema.Fields))
 

--- a/client/entity/schema_test.go
+++ b/client/entity/schema_test.go
@@ -214,11 +214,13 @@ func (s *SchemaSuite) TestStructArrayFieldRoundTrip() {
 			WithDataType(FieldTypeArray).
 			WithElementType(FieldTypeStruct).
 			WithMaxCapacity(16).
+			WithNullable(true).
 			WithStructSchema(structSchema))
 
 	p := schema.ProtoMessage()
 	s.Equal(2, len(p.GetFields()))
 	s.Equal(1, len(p.GetStructArrayFields()))
+	s.True(p.GetStructArrayFields()[0].GetNullable())
 
 	got := (&Schema{}).ReadProto(p)
 	// 3 logical fields including the struct array
@@ -234,6 +236,7 @@ func (s *SchemaSuite) TestStructArrayFieldRoundTrip() {
 	s.Require().NotNil(clips)
 	s.Equal(FieldTypeArray, clips.DataType)
 	s.Equal(FieldTypeStruct, clips.ElementType)
+	s.True(clips.Nullable)
 	s.Require().NotNil(clips.StructSchema)
 	s.Equal(2, len(clips.StructSchema.Fields))
 

--- a/client/milvusclient/collection.go
+++ b/client/milvusclient/collection.go
@@ -211,3 +211,18 @@ func (c *Client) AddCollectionField(ctx context.Context, opt AddCollectionFieldO
 	})
 	return err
 }
+
+// AddCollectionStructField adds a struct array field to a collection.
+func (c *Client) AddCollectionStructField(ctx context.Context, opt AddCollectionStructFieldOption, callOpts ...grpc.CallOption) error {
+	if err := opt.Validate(); err != nil {
+		return err
+	}
+
+	req := opt.Request()
+
+	err := c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
+		resp, err := milvusService.AddCollectionStructField(ctx, req, callOpts...)
+		return merr.CheckRPCCall(resp, err)
+	})
+	return err
+}

--- a/client/milvusclient/collection_options.go
+++ b/client/milvusclient/collection_options.go
@@ -465,3 +465,46 @@ func NewAddCollectionFieldOption(collectionName string, field *entity.Field) *ad
 		fieldSch:       field,
 	}
 }
+
+type AddCollectionStructFieldOption interface {
+	Request() *milvuspb.AddCollectionStructFieldRequest
+	// Validate validates the option before sending request
+	Validate() error
+}
+
+type addCollectionStructFieldOption struct {
+	collectionName string
+	fieldSch       *entity.Field
+}
+
+func (c *addCollectionStructFieldOption) Request() *milvuspb.AddCollectionStructFieldRequest {
+	collSchema := entity.NewSchema().WithField(c.fieldSch).ProtoMessage()
+	return &milvuspb.AddCollectionStructFieldRequest{
+		CollectionName:         c.collectionName,
+		StructArrayFieldSchema: collSchema.GetStructArrayFields()[0],
+	}
+}
+
+// Validate validates the option before sending request
+func (c *addCollectionStructFieldOption) Validate() error {
+	if c == nil {
+		return fmt.Errorf("add collection struct field option is nil")
+	}
+	if c.fieldSch == nil {
+		return fmt.Errorf("struct array field schema is required")
+	}
+	if c.fieldSch.DataType != entity.FieldTypeArray || c.fieldSch.ElementType != entity.FieldTypeStruct {
+		return fmt.Errorf("adding struct array field requires data type Array and element type Struct, field name = %s", c.fieldSch.Name)
+	}
+	if c.fieldSch.StructSchema == nil {
+		return fmt.Errorf("struct schema is required for struct array field %s", c.fieldSch.Name)
+	}
+	return c.fieldSch.StructSchema.Validate(c.fieldSch.Name)
+}
+
+func NewAddCollectionStructFieldOption(collectionName string, field *entity.Field) *addCollectionStructFieldOption {
+	return &addCollectionStructFieldOption{
+		collectionName: collectionName,
+		fieldSch:       field,
+	}
+}

--- a/client/milvusclient/collection_test.go
+++ b/client/milvusclient/collection_test.go
@@ -568,6 +568,32 @@ func (s *CollectionSuite) TestAddCollectionStructField() {
 		s.Contains(err.Error(), "requires data type Array and element type Struct")
 	})
 
+	s.Run("nil_option", func() {
+		var opt *addCollectionStructFieldOption
+		err := opt.Validate()
+		s.Error(err)
+		s.Contains(err.Error(), "option is nil")
+	})
+
+	s.Run("nil_field_schema", func() {
+		collName := fmt.Sprintf("coll_%s", s.randString(6))
+		err := NewAddCollectionStructFieldOption(collName, nil).Validate()
+		s.Error(err)
+		s.Contains(err.Error(), "struct array field schema is required")
+	})
+
+	s.Run("nil_struct_schema", func() {
+		collName := fmt.Sprintf("coll_%s", s.randString(6))
+		field := entity.NewField().
+			WithName("clips").
+			WithDataType(entity.FieldTypeArray).
+			WithElementType(entity.FieldTypeStruct)
+
+		err := s.client.AddCollectionStructField(ctx, NewAddCollectionStructFieldOption(collName, field))
+		s.Error(err)
+		s.Contains(err.Error(), "struct schema is required")
+	})
+
 	s.Run("invalid_sub_field", func() {
 		collName := fmt.Sprintf("coll_%s", s.randString(6))
 		field := entity.NewField().

--- a/client/milvusclient/collection_test.go
+++ b/client/milvusclient/collection_test.go
@@ -494,6 +494,94 @@ func (s *CollectionSuite) TestAddCollectionField() {
 	})
 }
 
+func (s *CollectionSuite) TestAddCollectionStructField() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Run("success", func() {
+		collName := fmt.Sprintf("coll_%s", s.randString(6))
+		fieldName := fmt.Sprintf("field_%s", s.randString(6))
+		s.mock.EXPECT().AddCollectionStructField(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, acsfr *milvuspb.AddCollectionStructFieldRequest) (*commonpb.Status, error) {
+			s.Equal(collName, acsfr.GetCollectionName())
+			structProto := acsfr.GetStructArrayFieldSchema()
+			s.Require().NotNil(structProto)
+			s.Equal(fieldName, structProto.GetName())
+			s.True(structProto.GetNullable())
+			s.Equal("16", entity.KvPairsMap(structProto.GetTypeParams())[common.MaxCapacityKey])
+			s.Require().Len(structProto.GetFields(), 2)
+
+			tagField := structProto.GetFields()[0]
+			s.Equal("tag", tagField.GetName())
+			s.Equal(schemapb.DataType_Array, tagField.GetDataType())
+			s.Equal(schemapb.DataType_VarChar, tagField.GetElementType())
+			tagParams := entity.KvPairsMap(tagField.GetTypeParams())
+			s.Equal("64", tagParams[common.MaxLengthKey])
+			s.Equal("16", tagParams[common.MaxCapacityKey])
+
+			embField := structProto.GetFields()[1]
+			s.Equal("emb", embField.GetName())
+			s.Equal(schemapb.DataType_ArrayOfVector, embField.GetDataType())
+			s.Equal(schemapb.DataType_FloatVector, embField.GetElementType())
+			embParams := entity.KvPairsMap(embField.GetTypeParams())
+			s.Equal("8", embParams[common.DimKey])
+			s.Equal("16", embParams[common.MaxCapacityKey])
+			return merr.Success(), nil
+		}).Once()
+
+		structSchema := entity.NewStructSchema().
+			WithField(entity.NewField().WithName("tag").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64)).
+			WithField(entity.NewField().WithName("emb").WithDataType(entity.FieldTypeFloatVector).WithDim(8))
+		field := entity.NewField().
+			WithName(fieldName).
+			WithDataType(entity.FieldTypeArray).
+			WithElementType(entity.FieldTypeStruct).
+			WithMaxCapacity(16).
+			WithNullable(true).
+			WithStructSchema(structSchema)
+
+		err := s.client.AddCollectionStructField(ctx, NewAddCollectionStructFieldOption(collName, field))
+		s.NoError(err)
+	})
+
+	s.Run("failure", func() {
+		collName := fmt.Sprintf("coll_%s", s.randString(6))
+		fieldName := fmt.Sprintf("field_%s", s.randString(6))
+		s.mock.EXPECT().AddCollectionStructField(mock.Anything, mock.Anything).Return(merr.Status(errors.New("mocked")), nil).Once()
+
+		field := entity.NewField().
+			WithName(fieldName).
+			WithDataType(entity.FieldTypeArray).
+			WithElementType(entity.FieldTypeStruct).
+			WithMaxCapacity(16).
+			WithStructSchema(entity.NewStructSchema().WithField(entity.NewField().WithName("tag").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64)))
+
+		err := s.client.AddCollectionStructField(ctx, NewAddCollectionStructFieldOption(collName, field))
+		s.Error(err)
+	})
+
+	s.Run("non_struct_array_field", func() {
+		collName := fmt.Sprintf("coll_%s", s.randString(6))
+		field := entity.NewField().WithName("field").WithDataType(entity.FieldTypeInt64).WithNullable(true)
+
+		err := s.client.AddCollectionStructField(ctx, NewAddCollectionStructFieldOption(collName, field))
+		s.Error(err)
+		s.Contains(err.Error(), "requires data type Array and element type Struct")
+	})
+
+	s.Run("invalid_sub_field", func() {
+		collName := fmt.Sprintf("coll_%s", s.randString(6))
+		field := entity.NewField().
+			WithName("clips").
+			WithDataType(entity.FieldTypeArray).
+			WithElementType(entity.FieldTypeStruct).
+			WithStructSchema(entity.NewStructSchema().WithField(entity.NewField().WithName("tag").WithDataType(entity.FieldTypeVarChar).WithNullable(true)))
+
+		err := s.client.AddCollectionStructField(ctx, NewAddCollectionStructFieldOption(collName, field))
+		s.Error(err)
+		s.Contains(err.Error(), "must not be nullable")
+	})
+}
+
 func TestCollection(t *testing.T) {
 	suite.Run(t, new(CollectionSuite))
 }

--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -37,6 +37,7 @@ const (
 	ExternalCollectionJobCategory = "/jobs/external_collection/"
 	PrivilegeGroupCategory        = "/privilege_groups/"
 	CollectionFieldCategory       = "/collections/fields/"
+	CollectionStructFieldCategory = "/collections/struct_fields/"
 	ResourceGroupCategory         = "/resource_groups/"
 	SegmentCategory               = "/segments/"
 	QuotaCenterCategory           = "/quotacenter/"

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1077,6 +1077,10 @@ func (h *HandlersV2) alterCollectionFieldProperties(ctx context.Context, c *gin.
 func (h *HandlersV2) addCollectionField(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*CollectionFieldReqWithSchema)
 
+	if httpReq.Schema.IsStructArrayField() {
+		return h.addCollectionStructField(ctx, c, httpReq, dbName)
+	}
+
 	schemaProto, err := httpReq.Schema.GetProto(ctx)
 	if err != nil {
 		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
@@ -1097,6 +1101,30 @@ func (h *HandlersV2) addCollectionField(ctx context.Context, c *gin.Context, any
 	c.Set(ContextRequest, req)
 	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AddCollectionField", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
 		return h.proxy.AddCollectionField(reqCtx, req.(*milvuspb.AddCollectionFieldRequest))
+	})
+
+	if err == nil {
+		HTTPReturn(c, http.StatusOK, wrapperReturnDefault())
+	}
+	return resp, err
+}
+
+func (h *HandlersV2) addCollectionStructField(ctx context.Context, c *gin.Context, httpReq *CollectionFieldReqWithSchema, dbName string) (interface{}, error) {
+	schemaProto, err := httpReq.Schema.GetStructArrayProto(ctx)
+	if err != nil {
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
+
+	req := &milvuspb.AddCollectionStructFieldRequest{
+		DbName:                 dbName,
+		CollectionName:         httpReq.CollectionName,
+		StructArrayFieldSchema: schemaProto,
+	}
+
+	c.Set(ContextRequest, req)
+	resp, err := wrapperProxyWithLimit(ctx, c, req, h.checkAuth, false, "/milvus.proto.milvus.MilvusService/AddCollectionStructField", true, h.proxy, func(reqCtx context.Context, req any) (interface{}, error) {
+		return h.proxy.AddCollectionStructField(reqCtx, req.(*milvuspb.AddCollectionStructFieldRequest))
 	})
 
 	if err == nil {

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -95,6 +95,7 @@ var routeToMethod = map[string]string{ //nolint:gosec // not credentials, just a
 
 	"/v2/vectordb/collections/fields/alter_properties": "AlterCollectionField",
 	"/v2/vectordb/collections/fields/add":              "AddCollectionField",
+	"/v2/vectordb/collections/struct_fields/add":       "AddCollectionStructField",
 
 	"/v2/vectordb/databases/create":           "CreateDatabase",
 	"/v2/vectordb/databases/drop":             "DropDatabase",
@@ -207,6 +208,7 @@ func (h *HandlersV2) RegisterRoutesToV2(router gin.IRouter) {
 
 	// /collections/fields/add
 	router.POST(CollectionFieldCategory+AddAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionFieldReqWithSchema{} }, wrapperTraceLog(h.addCollectionField))))
+	router.POST(CollectionStructFieldCategory+AddAction, timeoutMiddleware(wrapperPost(func() any { return &CollectionFieldReqWithSchema{} }, wrapperTraceLog(h.addCollectionStructField))))
 
 	router.POST(DataBaseCategory+CreateAction, timeoutMiddleware(wrapperPost(func() any { return &DatabaseReqWithProperties{} }, wrapperTraceLog(h.createDatabase))))
 	router.POST(DataBaseCategory+DropAction, timeoutMiddleware(wrapperPost(func() any { return &DatabaseReqRequiredName{} }, wrapperTraceLog(h.dropDatabase))))
@@ -1078,7 +1080,9 @@ func (h *HandlersV2) addCollectionField(ctx context.Context, c *gin.Context, any
 	httpReq := anyReq.(*CollectionFieldReqWithSchema)
 
 	if httpReq.Schema.IsStructArrayField() {
-		return h.addCollectionStructField(ctx, c, httpReq, dbName)
+		err := merr.WrapErrParameterInvalidMsg("StructArray field must be added through /v2/vectordb/collections/struct_fields/add")
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
 	}
 
 	schemaProto, err := httpReq.Schema.GetProto(ctx)
@@ -1109,7 +1113,9 @@ func (h *HandlersV2) addCollectionField(ctx context.Context, c *gin.Context, any
 	return resp, err
 }
 
-func (h *HandlersV2) addCollectionStructField(ctx context.Context, c *gin.Context, httpReq *CollectionFieldReqWithSchema, dbName string) (interface{}, error) {
+func (h *HandlersV2) addCollectionStructField(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
+	httpReq := anyReq.(*CollectionFieldReqWithSchema)
+
 	schemaProto, err := httpReq.Schema.GetStructArrayProto(ctx)
 	if err != nil {
 		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3588,6 +3588,82 @@ func (s *AddCollectionFieldSuite) TestAddCollectionFieldNormal() {
 	validateRequestBodyTestCases(s.T(), s.testEngine, addFieldTestCases, false)
 }
 
+func (s *AddCollectionFieldSuite) TestAddCollectionStructFieldNormal() {
+	testCases := []struct {
+		name        string
+		requestBody []byte
+	}{
+		{
+			name: "array_with_struct_element",
+			requestBody: []byte(`{"collectionName": "book", "schema": {
+				"fieldName": "clips",
+				"description": "clip metadata",
+				"dataType": "Array",
+				"elementDataType": "Struct",
+				"nullable": true,
+				"elementTypeParams": {"max_capacity": 16},
+				"fields": [
+					{"fieldName": "tag", "dataType": "Array", "elementDataType": "VarChar", "elementTypeParams": {"max_length": 64}},
+					{"fieldName": "emb", "dataType": "ArrayOfVector", "elementDataType": "FloatVector", "elementTypeParams": {"dim": 8}}
+				]
+			}}`),
+		},
+		{
+			name: "array_of_struct",
+			requestBody: []byte(`{"collectionName": "book", "schema": {
+				"fieldName": "clips",
+				"dataType": "ArrayOfStruct",
+				"nullable": true,
+				"typeParams": {"max_capacity": 16},
+				"fields": [
+					{"fieldName": "tag", "dataType": "Array", "elementDataType": "VarChar", "elementTypeParams": {"max_length": 64}},
+					{"fieldName": "emb", "dataType": "ArrayOfVector", "elementDataType": "FloatVector", "elementTypeParams": {"dim": 8}}
+				]
+			}}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.mp.EXPECT().AddCollectionStructField(mock.Anything, mock.MatchedBy(func(req *milvuspb.AddCollectionStructFieldRequest) bool {
+				if req.GetCollectionName() != "book" {
+					return false
+				}
+				structSchema := req.GetStructArrayFieldSchema()
+				if structSchema.GetName() != "clips" || !structSchema.GetNullable() || len(structSchema.GetFields()) != 2 {
+					return false
+				}
+				if kvPairsToMap(structSchema.GetTypeParams())[common.MaxCapacityKey] != "16" {
+					return false
+				}
+				tag := structSchema.GetFields()[0]
+				tagParams := kvPairsToMap(tag.GetTypeParams())
+				if tag.GetName() != "tag" || tag.GetDataType() != schemapb.DataType_Array || tag.GetElementType() != schemapb.DataType_VarChar {
+					return false
+				}
+				if tagParams[common.MaxLengthKey] != "64" || tagParams[common.MaxCapacityKey] != "16" {
+					return false
+				}
+				emb := structSchema.GetFields()[1]
+				embParams := kvPairsToMap(emb.GetTypeParams())
+				if emb.GetName() != "emb" || emb.GetDataType() != schemapb.DataType_ArrayOfVector || emb.GetElementType() != schemapb.DataType_FloatVector {
+					return false
+				}
+				return embParams[common.DimKey] == "8" && embParams[common.MaxCapacityKey] == "16"
+			})).Return(merr.Success(), nil).Once()
+
+			req := httptest.NewRequest(http.MethodPost, versionalV2(CollectionFieldCategory, AddAction), bytes.NewReader(tc.requestBody))
+			w := httptest.NewRecorder()
+			s.testEngine.ServeHTTP(w, req)
+			s.Equal(http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			err := json.Unmarshal(w.Body.Bytes(), returnBody)
+			s.NoError(err)
+			s.Equal(int32(0), returnBody.Code)
+		})
+	}
+}
+
 func (s *AddCollectionFieldSuite) TestAddCollectionFieldFail() {
 	s.Run("bad_request", func() {
 		addFieldTestCases := []requestBodyTestCase{
@@ -3648,6 +3724,14 @@ func (s *AddCollectionFieldSuite) TestAddCollectionFieldFail() {
 
 func TestAddCollectionFieldSuite(t *testing.T) {
 	suite.Run(t, new(AddCollectionFieldSuite))
+}
+
+func kvPairsToMap(kvs []*commonpb.KeyValuePair) map[string]string {
+	ret := make(map[string]string, len(kvs))
+	for _, kv := range kvs {
+		ret[kv.GetKey()] = kv.GetValue()
+	}
+	return ret
 }
 
 func TestCollectionFunctionSuite(t *testing.T) {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3664,6 +3664,51 @@ func (s *AddCollectionFieldSuite) TestAddCollectionStructFieldNormal() {
 	}
 }
 
+func (s *AddCollectionFieldSuite) TestAddCollectionStructFieldFail() {
+	s.Run("invalid_struct_schema", func() {
+		requestBody := []byte(`{"collectionName": "book", "schema": {
+			"fieldName": "clips",
+			"dataType": "ArrayOfStruct",
+			"nullable": true,
+			"typeParams": {"max_capacity": 16}
+		}}`)
+
+		req := httptest.NewRequest(http.MethodPost, versionalV2(CollectionStructFieldCategory, AddAction), bytes.NewReader(requestBody))
+		w := httptest.NewRecorder()
+		s.testEngine.ServeHTTP(w, req)
+		s.Equal(http.StatusOK, w.Code)
+		returnBody := &ReturnErrMsg{}
+		err := json.Unmarshal(w.Body.Bytes(), returnBody)
+		s.NoError(err)
+		s.Equal(merr.Code(merr.ErrParameterInvalid), returnBody.Code)
+		s.Contains(returnBody.Message, "must contain at least one sub-field")
+	})
+
+	s.Run("server_error", func() {
+		requestBody := []byte(`{"collectionName": "book", "schema": {
+			"fieldName": "clips",
+			"dataType": "ArrayOfStruct",
+			"nullable": true,
+			"typeParams": {"max_capacity": 16},
+			"fields": [
+				{"fieldName": "tag", "dataType": "Array", "elementDataType": "VarChar", "elementTypeParams": {"max_length": 64}}
+			]
+		}}`)
+
+		s.mp.EXPECT().AddCollectionStructField(mock.Anything, mock.Anything).Return(merr.Status(merr.WrapErrServiceInternal("mock error")), nil).Once()
+
+		req := httptest.NewRequest(http.MethodPost, versionalV2(CollectionStructFieldCategory, AddAction), bytes.NewReader(requestBody))
+		w := httptest.NewRecorder()
+		s.testEngine.ServeHTTP(w, req)
+		s.Equal(http.StatusOK, w.Code)
+		returnBody := &ReturnErrMsg{}
+		err := json.Unmarshal(w.Body.Bytes(), returnBody)
+		s.NoError(err)
+		s.Equal(merr.Code(merr.ErrServiceInternal), returnBody.Code)
+		s.Contains(returnBody.Message, "mock error")
+	})
+}
+
 func (s *AddCollectionFieldSuite) TestAddCollectionFieldRejectsStructArray() {
 	requestBody := []byte(`{"collectionName": "book", "schema": {
 		"fieldName": "clips",

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3652,7 +3652,7 @@ func (s *AddCollectionFieldSuite) TestAddCollectionStructFieldNormal() {
 				return embParams[common.DimKey] == "8" && embParams[common.MaxCapacityKey] == "16"
 			})).Return(merr.Success(), nil).Once()
 
-			req := httptest.NewRequest(http.MethodPost, versionalV2(CollectionFieldCategory, AddAction), bytes.NewReader(tc.requestBody))
+			req := httptest.NewRequest(http.MethodPost, versionalV2(CollectionStructFieldCategory, AddAction), bytes.NewReader(tc.requestBody))
 			w := httptest.NewRecorder()
 			s.testEngine.ServeHTTP(w, req)
 			s.Equal(http.StatusOK, w.Code)
@@ -3662,6 +3662,28 @@ func (s *AddCollectionFieldSuite) TestAddCollectionStructFieldNormal() {
 			s.Equal(int32(0), returnBody.Code)
 		})
 	}
+}
+
+func (s *AddCollectionFieldSuite) TestAddCollectionFieldRejectsStructArray() {
+	requestBody := []byte(`{"collectionName": "book", "schema": {
+		"fieldName": "clips",
+		"dataType": "ArrayOfStruct",
+		"nullable": true,
+		"typeParams": {"max_capacity": 16},
+		"fields": [
+			{"fieldName": "tag", "dataType": "Array", "elementDataType": "VarChar", "elementTypeParams": {"max_length": 64}}
+		]
+	}}`)
+
+	req := httptest.NewRequest(http.MethodPost, versionalV2(CollectionFieldCategory, AddAction), bytes.NewReader(requestBody))
+	w := httptest.NewRecorder()
+	s.testEngine.ServeHTTP(w, req)
+	s.Equal(http.StatusOK, w.Code)
+	returnBody := &ReturnErrMsg{}
+	err := json.Unmarshal(w.Body.Bytes(), returnBody)
+	s.NoError(err)
+	s.Equal(merr.Code(merr.ErrParameterInvalid), returnBody.Code)
+	s.Contains(returnBody.Message, "/v2/vectordb/collections/struct_fields/add")
 }
 
 func (s *AddCollectionFieldSuite) TestAddCollectionFieldFail() {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3665,6 +3665,26 @@ func (s *AddCollectionFieldSuite) TestAddCollectionStructFieldNormal() {
 }
 
 func (s *AddCollectionFieldSuite) TestAddCollectionStructFieldFail() {
+	s.Run("reject_non_struct_array_schema", func() {
+		requestBody := []byte(`{"collectionName": "book", "schema": {
+			"fieldName": "bad_scalar",
+			"dataType": "Int64",
+			"fields": [
+				{"fieldName": "tag", "dataType": "Array", "elementDataType": "VarChar", "elementTypeParams": {"max_length": 64}}
+			]
+		}}`)
+
+		req := httptest.NewRequest(http.MethodPost, versionalV2(CollectionStructFieldCategory, AddAction), bytes.NewReader(requestBody))
+		w := httptest.NewRecorder()
+		s.testEngine.ServeHTTP(w, req)
+		s.Equal(http.StatusOK, w.Code)
+		returnBody := &ReturnErrMsg{}
+		err := json.Unmarshal(w.Body.Bytes(), returnBody)
+		s.NoError(err)
+		s.Equal(merr.Code(merr.ErrParameterInvalid), returnBody.Code)
+		s.Contains(returnBody.Message, "must use ArrayOfStruct or Array with Struct element")
+	})
+
 	s.Run("invalid_struct_schema", func() {
 		requestBody := []byte(`{"collectionName": "book", "schema": {
 			"fieldName": "clips",

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -675,6 +675,14 @@ func (field *FieldSchema) IsStructArrayField() bool {
 }
 
 func (field *FieldSchema) GetStructArrayProto(ctx context.Context) (*schemapb.StructArrayFieldSchema, error) {
+	if field == nil {
+		return nil, merr.WrapErrParameterInvalidMsg("StructArray field schema is required")
+	}
+	if !field.IsStructArrayField() {
+		return nil, merr.WrapErrParameterInvalidMsg(
+			"StructArray field must use ArrayOfStruct or Array with Struct element, got dataType %s and elementDataType %s",
+			field.DataType, field.ElementDataType)
+	}
 	typeParams := make(map[string]interface{}, len(field.TypeParams)+len(field.ElementTypeParams))
 	for key, param := range field.ElementTypeParams {
 		typeParams[key] = param

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
@@ -609,6 +610,7 @@ func (req *DropIndexPropertiesReq) GetIndexName() string {
 
 type FieldSchema struct {
 	FieldName         string                 `json:"fieldName" binding:"required"`
+	Description       string                 `json:"description"`
 	DataType          string                 `json:"dataType" binding:"required"`
 	ElementDataType   string                 `json:"elementDataType"`
 	ExternalField     string                 `json:"externalField"`
@@ -616,6 +618,8 @@ type FieldSchema struct {
 	IsPartitionKey    bool                   `json:"isPartitionKey"`
 	IsClusteringKey   bool                   `json:"isClusteringKey"`
 	ElementTypeParams map[string]interface{} `json:"elementTypeParams"`
+	TypeParams        map[string]interface{} `json:"typeParams"`
+	Fields            []FieldSchema          `json:"fields"`
 	Nullable          bool                   `json:"nullable"`
 	DefaultValue      interface{}            `json:"defaultValue"`
 }
@@ -629,6 +633,7 @@ func (field *FieldSchema) GetProto(ctx context.Context) (*schemapb.FieldSchema, 
 	dataType := schemapb.DataType(fieldDataType)
 	fieldSchema := &schemapb.FieldSchema{
 		Name:            field.FieldName,
+		Description:     field.Description,
 		IsPrimaryKey:    field.IsPrimary,
 		IsPartitionKey:  field.IsPartitionKey,
 		IsClusteringKey: field.IsClusteringKey,
@@ -661,6 +666,31 @@ func (field *FieldSchema) GetProto(ctx context.Context) (*schemapb.FieldSchema, 
 	return fieldSchema, nil
 }
 
+func (field *FieldSchema) IsStructArrayField() bool {
+	if field == nil {
+		return false
+	}
+	return field.DataType == schemapb.DataType_ArrayOfStruct.String() ||
+		field.DataType == schemapb.DataType_Array.String() && field.ElementDataType == schemapb.DataType_Struct.String()
+}
+
+func (field *FieldSchema) GetStructArrayProto(ctx context.Context) (*schemapb.StructArrayFieldSchema, error) {
+	typeParams := make(map[string]interface{}, len(field.TypeParams)+len(field.ElementTypeParams))
+	for key, param := range field.ElementTypeParams {
+		typeParams[key] = param
+	}
+	for key, param := range field.TypeParams {
+		typeParams[key] = param
+	}
+	return (&StructArrayFieldSchema{
+		FieldName:   field.FieldName,
+		Description: field.Description,
+		Fields:      field.Fields,
+		TypeParams:  typeParams,
+		Nullable:    field.Nullable,
+	}).GetProto(ctx)
+}
+
 // StructArrayFieldSchema describes a struct array field in RESTful v2 API.
 // Each struct array field contains multiple sub-fields; every sub-field must
 // be declared as either Array (scalar element) or ArrayOfVector (vector element).
@@ -669,6 +699,7 @@ type StructArrayFieldSchema struct {
 	Description string                 `json:"description"`
 	Fields      []FieldSchema          `json:"fields" binding:"required"`
 	TypeParams  map[string]interface{} `json:"typeParams"`
+	Nullable    bool                   `json:"nullable"`
 }
 
 // GetProto converts the RESTful StructArrayFieldSchema to its proto counterpart.
@@ -681,6 +712,16 @@ func (sf *StructArrayFieldSchema) GetProto(ctx context.Context) (*schemapb.Struc
 		Name:        sf.FieldName,
 		Description: sf.Description,
 		TypeParams:  []*commonpb.KeyValuePair{},
+		Nullable:    sf.Nullable,
+	}
+	parentTypeParams := make(map[string]string, len(sf.TypeParams))
+	for key, param := range sf.TypeParams {
+		value, err := getElementTypeParams(param)
+		if err != nil {
+			return nil, err
+		}
+		parentTypeParams[key] = value
+		proto.TypeParams = append(proto.TypeParams, &commonpb.KeyValuePair{Key: key, Value: value})
 	}
 	subNames := map[string]struct{}{}
 	for i := range sf.Fields {
@@ -714,16 +755,21 @@ func (sf *StructArrayFieldSchema) GetProto(ctx context.Context) (*schemapb.Struc
 				"duplicated sub-field name %s in struct %s", subProto.Name, sf.FieldName)
 		}
 		subNames[subProto.Name] = struct{}{}
+		if maxCapacity, ok := parentTypeParams[common.MaxCapacityKey]; ok && !hasTypeParam(subProto.TypeParams, common.MaxCapacityKey) {
+			subProto.TypeParams = append(subProto.TypeParams, &commonpb.KeyValuePair{Key: common.MaxCapacityKey, Value: maxCapacity})
+		}
 		proto.Fields = append(proto.Fields, subProto)
 	}
-	for key, param := range sf.TypeParams {
-		value, err := getElementTypeParams(param)
-		if err != nil {
-			return nil, err
-		}
-		proto.TypeParams = append(proto.TypeParams, &commonpb.KeyValuePair{Key: key, Value: value})
-	}
 	return proto, nil
+}
+
+func hasTypeParam(typeParams []*commonpb.KeyValuePair, key string) bool {
+	for _, typeParam := range typeParams {
+		if typeParam.GetKey() == key {
+			return true
+		}
+	}
+	return false
 }
 
 type FunctionScore struct {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -408,11 +408,12 @@ func printStructArrayFieldsV2(structFields []*schemapb.StructArrayFieldSchema) [
 			subs = append(subs, detail)
 		}
 		entry := gin.H{
-			HTTPReturnFieldName:   sf.GetName(),
-			HTTPReturnFieldID:     sf.GetFieldID(),
-			HTTPReturnDescription: sf.GetDescription(),
-			HTTPReturnFieldType:   schemapb.DataType_ArrayOfStruct.String(),
-			"fields":              subs,
+			HTTPReturnFieldName:     sf.GetName(),
+			HTTPReturnFieldID:       sf.GetFieldID(),
+			HTTPReturnDescription:   sf.GetDescription(),
+			HTTPReturnFieldNullable: sf.GetNullable(),
+			HTTPReturnFieldType:     schemapb.DataType_ArrayOfStruct.String(),
+			"fields":                subs,
 		}
 		if len(sf.GetTypeParams()) > 0 {
 			entry[Params] = sf.GetTypeParams()

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -4406,6 +4406,59 @@ func TestStructArrayFieldSchemaGetProtoTypeParams(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestFieldSchemaStructArrayHelpers(t *testing.T) {
+	var nilField *FieldSchema
+	assert.False(t, nilField.IsStructArrayField())
+	assert.False(t, (&FieldSchema{DataType: "Int64"}).IsStructArrayField())
+	assert.True(t, (&FieldSchema{DataType: "Array", ElementDataType: "Struct"}).IsStructArrayField())
+	assert.True(t, (&FieldSchema{DataType: "ArrayOfStruct"}).IsStructArrayField())
+
+	proto, err := (&FieldSchema{
+		FieldName:       "clips",
+		Description:     "clip metadata",
+		DataType:        "Array",
+		ElementDataType: "Struct",
+		Nullable:        true,
+		ElementTypeParams: map[string]interface{}{
+			common.MaxCapacityKey: 16,
+		},
+		TypeParams: map[string]interface{}{
+			common.MaxCapacityKey: 32,
+		},
+		Fields: []FieldSchema{
+			{
+				FieldName:       "tag",
+				DataType:        "Array",
+				ElementDataType: "VarChar",
+				ElementTypeParams: map[string]interface{}{
+					common.MaxLengthKey: 64,
+				},
+			},
+			{
+				FieldName:       "scores",
+				DataType:        "Array",
+				ElementDataType: "Int64",
+				ElementTypeParams: map[string]interface{}{
+					common.MaxCapacityKey: 7,
+				},
+			},
+		},
+	}).GetStructArrayProto(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "clips", proto.GetName())
+	assert.Equal(t, "clip metadata", proto.GetDescription())
+	assert.True(t, proto.GetNullable())
+	assert.Equal(t, "32", kvPairsToMap(proto.GetTypeParams())[common.MaxCapacityKey])
+
+	require.Len(t, proto.GetFields(), 2)
+	tagParams := kvPairsToMap(proto.GetFields()[0].GetTypeParams())
+	assert.Equal(t, "64", tagParams[common.MaxLengthKey])
+	assert.Equal(t, "32", tagParams[common.MaxCapacityKey])
+
+	scoreParams := kvPairsToMap(proto.GetFields()[1].GetTypeParams())
+	assert.Equal(t, "7", scoreParams[common.MaxCapacityKey])
+}
+
 func TestPrintStructArrayFieldsV2QualifiedSubFields(t *testing.T) {
 	printed := printStructArrayFieldsV2([]*schemapb.StructArrayFieldSchema{
 		{

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -4374,6 +4374,7 @@ func TestStructArrayFieldSchemaGetProtoTypeParams(t *testing.T) {
 	proto, err := (&StructArrayFieldSchema{
 		FieldName:   "my_struct",
 		Description: "with params",
+		Nullable:    true,
 		TypeParams: map[string]interface{}{
 			common.MaxCapacityKey: 8,
 		},
@@ -4384,9 +4385,14 @@ func TestStructArrayFieldSchemaGetProtoTypeParams(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "my_struct", proto.GetName())
 	assert.Equal(t, "with params", proto.GetDescription())
+	assert.True(t, proto.GetNullable())
 	require.Len(t, proto.GetTypeParams(), 1)
 	assert.Equal(t, common.MaxCapacityKey, proto.GetTypeParams()[0].GetKey())
 	assert.Equal(t, "8", proto.GetTypeParams()[0].GetValue())
+	subParams := proto.GetFields()[0].GetTypeParams()
+	require.Len(t, subParams, 1)
+	assert.Equal(t, common.MaxCapacityKey, subParams[0].GetKey())
+	assert.Equal(t, "8", subParams[0].GetValue())
 
 	_, err = (&StructArrayFieldSchema{
 		FieldName: "bad_params",

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -3872,11 +3872,13 @@ func TestIsEmbeddingListData(t *testing.T) {
 
 func TestPrintStructArrayFieldsV2(t *testing.T) {
 	schema := buildStructArrayTestSchema()
+	schema.GetStructArrayFields()[0].Nullable = true
 	printed := printStructArrayFieldsV2(schema.GetStructArrayFields())
 	require.Len(t, printed, 1)
 	entry := printed[0]
 	assert.Equal(t, "my_struct", entry[HTTPReturnFieldName])
 	assert.Equal(t, schemapb.DataType_ArrayOfStruct.String(), entry[HTTPReturnFieldType])
+	assert.Equal(t, true, entry[HTTPReturnFieldNullable])
 	subs, ok := entry["fields"].([]gin.H)
 	require.True(t, ok)
 	require.Len(t, subs, 2)

--- a/tests/go_client/testcases/add_field_test.go
+++ b/tests/go_client/testcases/add_field_test.go
@@ -76,6 +76,60 @@ func TestAddCollectionField(t *testing.T) {
 	}
 }
 
+func TestAddCollectionStructField(t *testing.T) {
+	t.Parallel()
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateMilvusClient(ctx, t, &client.ClientConfig{
+		Address:  hp.GetAddr(),
+		Username: hp.GetUser(),
+		Password: hp.GetPassword(),
+	})
+
+	collName := common.GenRandomString("addstructfield", 6)
+	err := mc.CreateCollection(ctx, client.SimpleCreateCollectionOptions(collName, common.DefaultDim))
+	common.CheckErr(t, err, true)
+
+	structSchema := entity.NewStructSchema().
+		WithField(entity.NewField().WithName("tag").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64)).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).WithDim(common.DefaultDim))
+	structField := entity.NewField().
+		WithName("clips").
+		WithDataType(entity.FieldTypeArray).
+		WithElementType(entity.FieldTypeStruct).
+		WithMaxCapacity(16).
+		WithNullable(true).
+		WithStructSchema(structSchema)
+
+	err = mc.AddCollectionStructField(ctx, client.NewAddCollectionStructFieldOption(collName, structField))
+	common.CheckErr(t, err, true)
+
+	coll, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(collName))
+	common.CheckErr(t, err, true)
+
+	var added *entity.Field
+	for _, field := range coll.Schema.Fields {
+		if field.Name == "clips" {
+			added = field
+			break
+		}
+	}
+	require.NotNil(t, added)
+	require.Equal(t, entity.FieldTypeArray, added.DataType)
+	require.Equal(t, entity.FieldTypeStruct, added.ElementType)
+	require.True(t, added.Nullable)
+	require.Equal(t, "16", added.TypeParams[entity.TypeParamMaxCapacity])
+	require.NotNil(t, added.StructSchema)
+	require.Len(t, added.StructSchema.Fields, 2)
+	require.Equal(t, "tag", added.StructSchema.Fields[0].Name)
+	require.Equal(t, entity.FieldTypeVarChar, added.StructSchema.Fields[0].DataType)
+	require.Equal(t, "embedding", added.StructSchema.Fields[1].Name)
+	require.Equal(t, entity.FieldTypeFloatVector, added.StructSchema.Fields[1].DataType)
+	dim, err := added.StructSchema.Fields[1].GetDim()
+	common.CheckErr(t, err, true)
+	require.EqualValues(t, common.DefaultDim, dim)
+}
+
 // parameterized test for add field invalid cases
 func TestAddCollectionFieldInvalid(t *testing.T) {
 	t.Parallel()

--- a/tests/restful_client_v2/api/milvus.py
+++ b/tests/restful_client_v2/api/milvus.py
@@ -560,6 +560,20 @@ class CollectionClient(Requests):
         response = self.post(url, headers=self.update_headers(), data=payload)
         return response.json()    
 
+    def add_struct_field(self, collection_name, field_params, db_name="default"):
+        """Add struct field"""
+        url = f"{self.endpoint}/v2/vectordb/collections/struct_fields/add"
+        payload = {
+            "collectionName": collection_name,
+            "schema": field_params
+        }
+        if self.db_name is not None:
+            payload["dbName"] = self.db_name
+        if db_name != "default":
+            payload["dbName"] = db_name
+        response = self.post(url, headers=self.update_headers(), data=payload)
+        return response.json()
+
     def flush(self, collection_name, db_name="default"):
         """Flush collection"""
         url = f"{self.endpoint}/v2/vectordb/collections/flush"

--- a/tests/restful_client_v2/api/milvus.py
+++ b/tests/restful_client_v2/api/milvus.py
@@ -1,14 +1,15 @@
 import json
-import requests
 import time
-import uuid
-from utils.util_log import test_log as logger
-from minio import Minio
-from minio.error import S3Error
-from minio.commonconfig import CopySource
-from tenacity import retry, retry_if_exception_type, stop_after_attempt
-from requests.exceptions import ConnectionError
 import urllib.parse
+import uuid
+
+import requests
+from minio import Minio
+from minio.commonconfig import CopySource
+from minio.error import S3Error
+from requests.exceptions import ConnectionError
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
+from utils.util_log import test_log as logger
 
 REQUEST_TIMEOUT = "120"
 
@@ -17,7 +18,7 @@ ENABLE_LOG_SAVE = False
 
 def simplify_list(lst):
     if len(lst) > 20:
-        return [lst[0], '...', lst[-1]]
+        return [lst[0], "...", lst[-1]]
     return lst
 
 
@@ -26,12 +27,20 @@ def simplify_dict(d):
         d = {}
     if len(d) > 20:
         keys = list(d.keys())
-        d = {keys[0]: d[keys[0]], '...': '...', keys[-1]: d[keys[-1]]}
+        d = {keys[0]: d[keys[0]], "...": "...", keys[-1]: d[keys[-1]]}
     simplified = {}
     for k, v in d.items():
         if isinstance(v, list):
-            simplified[k] = simplify_list([simplify_dict(item) if isinstance(item, dict) else simplify_list(
-                item) if isinstance(item, list) else item for item in v])
+            simplified[k] = simplify_list(
+                [
+                    simplify_dict(item)
+                    if isinstance(item, dict)
+                    else simplify_list(item)
+                    if isinstance(item, list)
+                    else item
+                    for item in v
+                ]
+            )
         elif isinstance(v, dict):
             simplified[k] = simplify_dict(v)
         else:
@@ -62,35 +71,45 @@ def logger_request_response(response, url, tt, headers, data, str_data, str_resp
     data_dict = json.loads(data) if data else {}
     data_dict_simple = simplify_dict(data_dict)
     if ENABLE_LOG_SAVE:
-        with open('request_response.jsonl', 'a') as f:
-            f.write(json.dumps({
-                "method": method,
-                "url": url,
-                "headers": headers,
-                "params": params,
-                "data": data_dict_simple,
-                "response": response.json()
-            }) + "\n")
+        with open("request_response.jsonl", "a") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "method": method,
+                        "url": url,
+                        "headers": headers,
+                        "params": params,
+                        "data": data_dict_simple,
+                        "response": response.json(),
+                    }
+                )
+                + "\n"
+            )
     data = json.dumps(data_dict_simple, indent=4)
     try:
         if response.status_code == 200:
-            if ('code' in response.json() and response.json()["code"] == 0) or (
-                    'Code' in response.json() and response.json()["Code"] == 0):
+            if ("code" in response.json() and response.json()["code"] == 0) or (
+                "Code" in response.json() and response.json()["Code"] == 0
+            ):
                 logger.debug(
-                    f"\nmethod: {method}, \nurl: {url}, \ncost time: {tt}, \nheader: {headers}, \npayload: {data}, \nresponse: {str_response}")
+                    f"\nmethod: {method}, \nurl: {url}, \ncost time: {tt}, \nheader: {headers}, \npayload: {data}, \nresponse: {str_response}"
+                )
 
             else:
                 logger.debug(
-                    f"\nmethod: {method}, \nurl: {url}, \ncost time: {tt}, \nheader: {headers}, \npayload: {data}, \nresponse: {response.text}")
+                    f"\nmethod: {method}, \nurl: {url}, \ncost time: {tt}, \nheader: {headers}, \npayload: {data}, \nresponse: {response.text}"
+                )
         else:
             logger.debug(
-                f"method: \nmethod: {method}, \nurl: {url}, \ncost time: {tt}, \nheader: {headers}, \npayload: {data}, \nresponse: {response.text}")
+                f"method: \nmethod: {method}, \nurl: {url}, \ncost time: {tt}, \nheader: {headers}, \npayload: {data}, \nresponse: {response.text}"
+            )
     except Exception as e:
         logger.debug(
-            f"method: \nmethod: {method}, \nurl: {url}, \ncost time: {tt}, \nheader: {headers}, \npayload: {data}, \nresponse: {response.text}, \nerror: {e}")
+            f"method: \nmethod: {method}, \nurl: {url}, \ncost time: {tt}, \nheader: {headers}, \npayload: {data}, \nresponse: {response.text}, \nerror: {e}"
+        )
 
 
-class Requests():
+class Requests:
     uuid = str(uuid.uuid1())
 
     def __init__(self, url=None, api_key=None):
@@ -99,10 +118,10 @@ class Requests():
         if self.__class__.uuid is None:
             self.__class__.uuid = str(uuid.uuid1())
         self.headers = {
-            'Content-Type': 'application/json',
-            'Authorization': f'Bearer {self.api_key}',
-            'RequestId': self.__class__.uuid,
-            "Request-Timeout": REQUEST_TIMEOUT
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+            "RequestId": self.__class__.uuid,
+            "Request-Timeout": REQUEST_TIMEOUT,
         }
 
     @classmethod
@@ -111,10 +130,10 @@ class Requests():
 
     def update_headers(self):
         headers = {
-            'Content-Type': 'application/json',
-            'Authorization': f'Bearer {self.api_key}',
-            'RequestId': self.__class__.uuid,
-            "Request-Timeout": REQUEST_TIMEOUT
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+            "RequestId": self.__class__.uuid,
+            "Request-Timeout": REQUEST_TIMEOUT,
         }
         return headers
 
@@ -124,11 +143,11 @@ class Requests():
     def post(self, url, headers=None, data=None, params=None):
         headers = headers if headers is not None else self.update_headers()
         data = json.dumps(data)
-        str_data = data[:200] + '...' + data[-200:] if len(data) > 400 else data
+        str_data = data[:200] + "..." + data[-200:] if len(data) > 400 else data
         t0 = time.time()
         response = requests.post(url, headers=headers, data=data, params=params)
         tt = time.time() - t0
-        str_response = response.text[:200] + '...' + response.text[-200:] if len(response.text) > 400 else response.text
+        str_response = response.text[:200] + "..." + response.text[-200:] if len(response.text) > 400 else response.text
         logger_request_response(response, url, tt, headers, data, str_data, str_response, "post", params=params)
         return response
 
@@ -136,14 +155,14 @@ class Requests():
     def get(self, url, headers=None, params=None, data=None):
         headers = headers if headers is not None else self.update_headers()
         data = json.dumps(data)
-        str_data = data[:200] + '...' + data[-200:] if len(data) > 400 else data
+        str_data = data[:200] + "..." + data[-200:] if len(data) > 400 else data
         t0 = time.time()
         if data is None or data == "null":
             response = requests.get(url, headers=headers, params=params)
         else:
             response = requests.get(url, headers=headers, params=params, data=data)
         tt = time.time() - t0
-        str_response = response.text[:200] + '...' + response.text[-200:] if len(response.text) > 400 else response.text
+        str_response = response.text[:200] + "..." + response.text[-200:] if len(response.text) > 400 else response.text
         logger_request_response(response, url, tt, headers, data, str_data, str_response, "get", params=params)
         return response
 
@@ -151,11 +170,11 @@ class Requests():
     def put(self, url, headers=None, data=None):
         headers = headers if headers is not None else self.update_headers()
         data = json.dumps(data)
-        str_data = data[:200] + '...' + data[-200:] if len(data) > 400 else data
+        str_data = data[:200] + "..." + data[-200:] if len(data) > 400 else data
         t0 = time.time()
         response = requests.put(url, headers=headers, data=data)
         tt = time.time() - t0
-        str_response = response.text[:200] + '...' + response.text[-200:] if len(response.text) > 400 else response.text
+        str_response = response.text[:200] + "..." + response.text[-200:] if len(response.text) > 400 else response.text
         logger_request_response(response, url, tt, headers, data, str_data, str_response, "put")
         return response
 
@@ -163,11 +182,11 @@ class Requests():
     def delete(self, url, headers=None, data=None):
         headers = headers if headers is not None else self.update_headers()
         data = json.dumps(data)
-        str_data = data[:200] + '...' + data[-200:] if len(data) > 400 else data
+        str_data = data[:200] + "..." + data[-200:] if len(data) > 400 else data
         t0 = time.time()
         response = requests.delete(url, headers=headers, data=data)
         tt = time.time() - t0
-        str_response = response.text[:200] + '...' + response.text[-200:] if len(response.text) > 400 else response.text
+        str_response = response.text[:200] + "..." + response.text[-200:] if len(response.text) > 400 else response.text
         logger_request_response(response, url, tt, headers, data, str_data, str_response, "delete")
         return response
 
@@ -183,17 +202,17 @@ class VectorClient(Requests):
 
     def update_headers(self):
         headers = {
-            'Content-Type': 'application/json',
-            'Authorization': f'Bearer {self.api_key}',
-            'Accept-Type-Allow-Int64': "true",
-            'RequestId': self.__class__.uuid,
-            "Request-Timeout": REQUEST_TIMEOUT
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+            "Accept-Type-Allow-Int64": "true",
+            "RequestId": self.__class__.uuid,
+            "Request-Timeout": REQUEST_TIMEOUT,
         }
         return headers
 
     def vector_search(self, payload, db_name="default", timeout=10):
         time.sleep(1)
-        url = f'{self.endpoint}/v2/vectordb/entities/search'
+        url = f"{self.endpoint}/v2/vectordb/entities/search"
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -218,7 +237,7 @@ class VectorClient(Requests):
 
     def vector_advanced_search(self, payload, db_name="default", timeout=10):
         time.sleep(1)
-        url = f'{self.endpoint}/v2/vectordb/entities/advanced_search'
+        url = f"{self.endpoint}/v2/vectordb/entities/advanced_search"
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -243,7 +262,7 @@ class VectorClient(Requests):
 
     def vector_hybrid_search(self, payload, db_name="default", timeout=10):
         time.sleep(1)
-        url = f'{self.endpoint}/v2/vectordb/entities/hybrid_search'
+        url = f"{self.endpoint}/v2/vectordb/entities/hybrid_search"
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -268,7 +287,7 @@ class VectorClient(Requests):
 
     def vector_query(self, payload, db_name="default", timeout=5):
         time.sleep(1)
-        url = f'{self.endpoint}/v2/vectordb/entities/query'
+        url = f"{self.endpoint}/v2/vectordb/entities/query"
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -293,7 +312,7 @@ class VectorClient(Requests):
 
     def vector_get(self, payload, db_name="default"):
         time.sleep(1)
-        url = f'{self.endpoint}/v2/vectordb/entities/get'
+        url = f"{self.endpoint}/v2/vectordb/entities/get"
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -302,7 +321,7 @@ class VectorClient(Requests):
         return response.json()
 
     def vector_delete(self, payload, db_name="default"):
-        url = f'{self.endpoint}/v2/vectordb/entities/delete'
+        url = f"{self.endpoint}/v2/vectordb/entities/delete"
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -311,7 +330,7 @@ class VectorClient(Requests):
         return response.json()
 
     def vector_insert(self, payload, db_name="default"):
-        url = f'{self.endpoint}/v2/vectordb/entities/insert'
+        url = f"{self.endpoint}/v2/vectordb/entities/insert"
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -320,7 +339,7 @@ class VectorClient(Requests):
         return response.json()
 
     def vector_upsert(self, payload, db_name="default"):
-        url = f'{self.endpoint}/v2/vectordb/entities/upsert'
+        url = f"{self.endpoint}/v2/vectordb/entities/upsert"
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -330,7 +349,6 @@ class VectorClient(Requests):
 
 
 class CollectionClient(Requests):
-
     def __init__(self, endpoint, token):
         super().__init__(url=endpoint, api_key=token)
         self.endpoint = endpoint
@@ -353,27 +371,24 @@ class CollectionClient(Requests):
         if headers is not None:
             return headers
         headers = {
-            'Content-Type': 'application/json',
-            'Authorization': f'Bearer {self.api_key}',
-            'RequestId': self.__class__.uuid,
-            "Request-Timeout": REQUEST_TIMEOUT
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+            "RequestId": self.__class__.uuid,
+            "Request-Timeout": REQUEST_TIMEOUT,
         }
         return headers
 
     def collection_has(self, db_name="default", collection_name=None):
-        url = f'{self.endpoint}/v2/vectordb/collections/has'
+        url = f"{self.endpoint}/v2/vectordb/collections/has"
         if self.db_name is not None:
             db_name = self.db_name
-        data = {
-            "dbName": db_name,
-            "collectionName": collection_name
-        }
+        data = {"dbName": db_name, "collectionName": collection_name}
         response = self.post(url, headers=self.update_headers(), data=data)
         res = response.json()
         return res
 
     def collection_rename(self, payload, db_name="default"):
-        url = f'{self.endpoint}/v2/vectordb/collections/rename'
+        url = f"{self.endpoint}/v2/vectordb/collections/rename"
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -382,43 +397,34 @@ class CollectionClient(Requests):
         return response.json()
 
     def collection_stats(self, db_name="default", collection_name=None):
-        url = f'{self.endpoint}/v2/vectordb/collections/get_stats'
+        url = f"{self.endpoint}/v2/vectordb/collections/get_stats"
         if self.db_name is not None:
             db_name = self.db_name
-        data = {
-            "dbName": db_name,
-            "collectionName": collection_name
-        }
+        data = {"dbName": db_name, "collectionName": collection_name}
         response = self.post(url, headers=self.update_headers(), data=data)
         res = response.json()
         return res
 
     def collection_load(self, db_name="default", collection_name=None):
-        url = f'{self.endpoint}/v2/vectordb/collections/load'
+        url = f"{self.endpoint}/v2/vectordb/collections/load"
         if self.db_name is not None:
             db_name = self.db_name
-        payload = {
-            "dbName": db_name,
-            "collectionName": collection_name
-        }
+        payload = {"dbName": db_name, "collectionName": collection_name}
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def collection_release(self, db_name="default", collection_name=None):
-        url = f'{self.endpoint}/v2/vectordb/collections/release'
+        url = f"{self.endpoint}/v2/vectordb/collections/release"
         if self.db_name is not None:
             db_name = self.db_name
-        payload = {
-            "dbName": db_name,
-            "collectionName": collection_name
-        }
+        payload = {"dbName": db_name, "collectionName": collection_name}
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def collection_load_state(self, db_name="default", collection_name=None, partition_names=None):
-        url = f'{self.endpoint}/v2/vectordb/collections/get_load_state'
+        url = f"{self.endpoint}/v2/vectordb/collections/get_load_state"
         if self.db_name is not None:
             db_name = self.db_name
         data = {
@@ -432,16 +438,12 @@ class CollectionClient(Requests):
         return res
 
     def collection_list(self, db_name="default"):
-        url = f'{self.endpoint}/v2/vectordb/collections/list'
+        url = f"{self.endpoint}/v2/vectordb/collections/list"
         params = {}
         if self.db_name is not None:
-            params = {
-                "dbName": self.db_name
-            }
+            params = {"dbName": self.db_name}
         if db_name != "default":
-            params = {
-                "dbName": db_name
-            }
+            params = {"dbName": db_name}
         response = self.post(url, headers=self.update_headers(), params=params)
         res = response.json()
         return res
@@ -452,7 +454,7 @@ class CollectionClient(Requests):
         db_name = payload.get("dbName", db_name)
         self.name_list.append((db_name, c_name))
 
-        url = f'{self.endpoint}/v2/vectordb/collections/create'
+        url = f"{self.endpoint}/v2/vectordb/collections/create"
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -465,24 +467,18 @@ class CollectionClient(Requests):
         return response.json()
 
     def collection_describe(self, collection_name, db_name="default"):
-        url = f'{self.endpoint}/v2/vectordb/collections/describe'
+        url = f"{self.endpoint}/v2/vectordb/collections/describe"
         data = {"collectionName": collection_name}
         if self.db_name is not None:
-            data = {
-                "collectionName": collection_name,
-                "dbName": self.db_name
-            }
+            data = {"collectionName": collection_name, "dbName": self.db_name}
         if db_name != "default":
-            data = {
-                "collectionName": collection_name,
-                "dbName": db_name
-            }
+            data = {"collectionName": collection_name, "dbName": db_name}
         response = self.post(url, headers=self.update_headers(), data=data)
         return response.json()
 
     def collection_drop(self, payload, db_name="default"):
         time.sleep(1)  # wait for collection drop and in case of rate limit
-        url = f'{self.endpoint}/v2/vectordb/collections/drop'
+        url = f"{self.endpoint}/v2/vectordb/collections/drop"
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -493,9 +489,7 @@ class CollectionClient(Requests):
     def refresh_load(self, collection_name, db_name="default"):
         """Refresh load collection"""
         url = f"{self.endpoint}/v2/vectordb/collections/refresh_load"
-        payload = {
-            "collectionName": collection_name
-        }
+        payload = {"collectionName": collection_name}
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -506,10 +500,7 @@ class CollectionClient(Requests):
     def alter_collection_properties(self, collection_name, properties, db_name="default"):
         """Alter collection properties"""
         url = f"{self.endpoint}/v2/vectordb/collections/alter_properties"
-        payload = {
-            "collectionName": collection_name,
-            "properties": properties
-        }
+        payload = {"collectionName": collection_name, "properties": properties}
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -520,10 +511,7 @@ class CollectionClient(Requests):
     def drop_collection_properties(self, collection_name, delete_keys, db_name="default"):
         """Drop collection properties"""
         url = f"{self.endpoint}/v2/vectordb/collections/drop_properties"
-        payload = {
-            "collectionName": collection_name,
-            "propertyKeys": delete_keys
-        }
+        payload = {"collectionName": collection_name, "propertyKeys": delete_keys}
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -534,11 +522,7 @@ class CollectionClient(Requests):
     def alter_field_properties(self, collection_name, field_name, field_params, db_name="default"):
         """Alter field properties"""
         url = f"{self.endpoint}/v2/vectordb/collections/fields/alter_properties"
-        payload = {
-            "collectionName": collection_name,
-            "fieldName": field_name,
-            "fieldParams": field_params
-        }
+        payload = {"collectionName": collection_name, "fieldName": field_name, "fieldParams": field_params}
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -549,24 +533,18 @@ class CollectionClient(Requests):
     def add_field(self, collection_name, field_params, db_name="default"):
         """Add field"""
         url = f"{self.endpoint}/v2/vectordb/collections/fields/add"
-        payload = {
-            "collectionName": collection_name,
-            "schema": field_params
-        }
+        payload = {"collectionName": collection_name, "schema": field_params}
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
             payload["dbName"] = db_name
         response = self.post(url, headers=self.update_headers(), data=payload)
-        return response.json()    
+        return response.json()
 
     def add_struct_field(self, collection_name, field_params, db_name="default"):
         """Add struct field"""
         url = f"{self.endpoint}/v2/vectordb/collections/struct_fields/add"
-        payload = {
-            "collectionName": collection_name,
-            "schema": field_params
-        }
+        payload = {"collectionName": collection_name, "schema": field_params}
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -577,9 +555,7 @@ class CollectionClient(Requests):
     def flush(self, collection_name, db_name="default"):
         """Flush collection"""
         url = f"{self.endpoint}/v2/vectordb/collections/flush"
-        payload = {
-            "collectionName": collection_name
-        }
+        payload = {"collectionName": collection_name}
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -590,9 +566,7 @@ class CollectionClient(Requests):
     def compact(self, collection_name, db_name="default"):
         """Compact collection"""
         url = f"{self.endpoint}/v2/vectordb/collections/compact"
-        payload = {
-            "collectionName": collection_name
-        }
+        payload = {"collectionName": collection_name}
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -603,9 +577,7 @@ class CollectionClient(Requests):
     def get_compaction_state(self, collection_name, db_name="default"):
         """Get compaction state"""
         url = f"{self.endpoint}/v2/vectordb/collections/get_compaction_state"
-        payload = {
-            "collectionName": collection_name
-        }
+        payload = {"collectionName": collection_name}
         if self.db_name is not None:
             payload["dbName"] = self.db_name
         if db_name != "default":
@@ -615,7 +587,6 @@ class CollectionClient(Requests):
 
 
 class PartitionClient(Requests):
-
     def __init__(self, endpoint, token):
         super().__init__(url=endpoint, api_key=token)
         self.endpoint = endpoint
@@ -624,105 +595,72 @@ class PartitionClient(Requests):
         self.headers = self.update_headers()
 
     def partition_list(self, db_name="default", collection_name=None):
-        url = f'{self.endpoint}/v2/vectordb/partitions/list'
-        data = {
-            "collectionName": collection_name
-        }
+        url = f"{self.endpoint}/v2/vectordb/partitions/list"
+        data = {"collectionName": collection_name}
         if self.db_name is not None:
-            data = {
-                "dbName": self.db_name,
-                "collectionName": collection_name
-            }
+            data = {"dbName": self.db_name, "collectionName": collection_name}
         if db_name != "default":
-            data = {
-                "dbName": db_name,
-                "collectionName": collection_name
-            }
+            data = {"dbName": db_name, "collectionName": collection_name}
         response = self.post(url, headers=self.update_headers(), data=data)
         res = response.json()
         return res
 
     def partition_create(self, db_name="default", collection_name=None, partition_name=None):
-        url = f'{self.endpoint}/v2/vectordb/partitions/create'
+        url = f"{self.endpoint}/v2/vectordb/partitions/create"
         if self.db_name is not None:
             db_name = self.db_name
-        payload = {
-            "dbName": db_name,
-            "collectionName": collection_name,
-            "partitionName": partition_name
-        }
+        payload = {"dbName": db_name, "collectionName": collection_name, "partitionName": partition_name}
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def partition_drop(self, db_name="default", collection_name=None, partition_name=None):
-        url = f'{self.endpoint}/v2/vectordb/partitions/drop'
+        url = f"{self.endpoint}/v2/vectordb/partitions/drop"
         if self.db_name is not None:
             db_name = self.db_name
-        payload = {
-            "dbName": db_name,
-            "collectionName": collection_name,
-            "partitionName": partition_name
-        }
+        payload = {"dbName": db_name, "collectionName": collection_name, "partitionName": partition_name}
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def partition_load(self, db_name="default", collection_name=None, partition_names=None):
-        url = f'{self.endpoint}/v2/vectordb/partitions/load'
+        url = f"{self.endpoint}/v2/vectordb/partitions/load"
         if self.db_name is not None:
             db_name = self.db_name
-        payload = {
-            "dbName": db_name,
-            "collectionName": collection_name,
-            "partitionNames": partition_names
-        }
+        payload = {"dbName": db_name, "collectionName": collection_name, "partitionNames": partition_names}
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def partition_release(self, db_name="default", collection_name=None, partition_names=None):
-        url = f'{self.endpoint}/v2/vectordb/partitions/release'
+        url = f"{self.endpoint}/v2/vectordb/partitions/release"
         if self.db_name is not None:
             db_name = self.db_name
-        payload = {
-            "dbName": db_name,
-            "collectionName": collection_name,
-            "partitionNames": partition_names
-        }
+        payload = {"dbName": db_name, "collectionName": collection_name, "partitionNames": partition_names}
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def partition_has(self, db_name="default", collection_name=None, partition_name=None):
-        url = f'{self.endpoint}/v2/vectordb/partitions/has'
+        url = f"{self.endpoint}/v2/vectordb/partitions/has"
         if self.db_name is not None:
             db_name = self.db_name
-        data = {
-            "dbName": db_name,
-            "collectionName": collection_name,
-            "partitionName": partition_name
-        }
+        data = {"dbName": db_name, "collectionName": collection_name, "partitionName": partition_name}
         response = self.post(url, headers=self.update_headers(), data=data)
         res = response.json()
         return res
 
     def partition_stats(self, db_name="default", collection_name=None, partition_name=None):
-        url = f'{self.endpoint}/v2/vectordb/partitions/get_stats'
+        url = f"{self.endpoint}/v2/vectordb/partitions/get_stats"
         if self.db_name is not None:
             db_name = self.db_name
-        data = {
-            "dbName": db_name,
-            "collectionName": collection_name,
-            "partitionName": partition_name
-        }
+        data = {"dbName": db_name, "collectionName": collection_name, "partitionName": partition_name}
         response = self.post(url, headers=self.update_headers(), data=data)
         res = response.json()
         return res
 
 
 class UserClient(Requests):
-
     def __init__(self, endpoint, token):
         super().__init__(url=endpoint, api_key=token)
         self.endpoint = endpoint
@@ -731,53 +669,50 @@ class UserClient(Requests):
         self.headers = self.update_headers()
 
     def user_list(self):
-        url = f'{self.endpoint}/v2/vectordb/users/list'
+        url = f"{self.endpoint}/v2/vectordb/users/list"
         response = self.post(url, headers=self.update_headers())
         res = response.json()
         return res
 
     def user_create(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/users/create'
+        url = f"{self.endpoint}/v2/vectordb/users/create"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def user_password_update(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/users/update_password'
+        url = f"{self.endpoint}/v2/vectordb/users/update_password"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def user_describe(self, user_name):
-        url = f'{self.endpoint}/v2/vectordb/users/describe'
-        data = {
-            "userName": user_name
-        }
+        url = f"{self.endpoint}/v2/vectordb/users/describe"
+        data = {"userName": user_name}
         response = self.post(url, headers=self.update_headers(), data=data)
         res = response.json()
         return res
 
     def user_drop(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/users/drop'
+        url = f"{self.endpoint}/v2/vectordb/users/drop"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def user_grant(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/users/grant_role'
+        url = f"{self.endpoint}/v2/vectordb/users/grant_role"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def user_revoke(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/users/revoke_role'
+        url = f"{self.endpoint}/v2/vectordb/users/revoke_role"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
 
 class RoleClient(Requests):
-
     def __init__(self, endpoint, token):
         super().__init__(url=endpoint, api_key=token)
         self.endpoint = endpoint
@@ -787,13 +722,13 @@ class RoleClient(Requests):
         self.role_names = []
 
     def role_list(self):
-        url = f'{self.endpoint}/v2/vectordb/roles/list'
+        url = f"{self.endpoint}/v2/vectordb/roles/list"
         response = self.post(url, headers=self.update_headers())
         res = response.json()
         return res
 
     def role_create(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/roles/create'
+        url = f"{self.endpoint}/v2/vectordb/roles/create"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         if res["code"] == 0:
@@ -801,35 +736,32 @@ class RoleClient(Requests):
         return res
 
     def role_describe(self, role_name):
-        url = f'{self.endpoint}/v2/vectordb/roles/describe'
-        data = {
-            "roleName": role_name
-        }
+        url = f"{self.endpoint}/v2/vectordb/roles/describe"
+        data = {"roleName": role_name}
         response = self.post(url, headers=self.update_headers(), data=data)
         res = response.json()
         return res
 
     def role_drop(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/roles/drop'
+        url = f"{self.endpoint}/v2/vectordb/roles/drop"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def role_grant(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/roles/grant_privilege'
+        url = f"{self.endpoint}/v2/vectordb/roles/grant_privilege"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def role_revoke(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/roles/revoke_privilege'
+        url = f"{self.endpoint}/v2/vectordb/roles/revoke_privilege"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
 
 class IndexClient(Requests):
-
     def __init__(self, endpoint, token):
         super().__init__(url=endpoint, api_key=token)
         self.endpoint = endpoint
@@ -838,7 +770,7 @@ class IndexClient(Requests):
         self.headers = self.update_headers()
 
     def index_create(self, payload, db_name="default"):
-        url = f'{self.endpoint}/v2/vectordb/indexes/create'
+        url = f"{self.endpoint}/v2/vectordb/indexes/create"
         if self.db_name is not None:
             db_name = self.db_name
         payload["dbName"] = db_name
@@ -846,33 +778,31 @@ class IndexClient(Requests):
         res = response.json()
         return res
 
-    def index_describe(self, collection_name=None, index_name=None, db_name="default", ):
-        url = f'{self.endpoint}/v2/vectordb/indexes/describe'
+    def index_describe(
+        self,
+        collection_name=None,
+        index_name=None,
+        db_name="default",
+    ):
+        url = f"{self.endpoint}/v2/vectordb/indexes/describe"
         if self.db_name is not None:
             db_name = self.db_name
-        data = {
-            "dbName": db_name,
-            "collectionName": collection_name,
-            "indexName": index_name
-        }
+        data = {"dbName": db_name, "collectionName": collection_name, "indexName": index_name}
         response = self.post(url, headers=self.update_headers(), data=data)
         res = response.json()
         return res
 
     def index_list(self, collection_name=None, db_name="default"):
-        url = f'{self.endpoint}/v2/vectordb/indexes/list'
+        url = f"{self.endpoint}/v2/vectordb/indexes/list"
         if self.db_name is not None:
             db_name = self.db_name
-        data = {
-            "dbName": db_name,
-            "collectionName": collection_name
-        }
+        data = {"dbName": db_name, "collectionName": collection_name}
         response = self.post(url, headers=self.update_headers(), data=data)
         res = response.json()
         return res
 
     def index_drop(self, payload, db_name="default"):
-        url = f'{self.endpoint}/v2/vectordb/indexes/drop'
+        url = f"{self.endpoint}/v2/vectordb/indexes/drop"
         if self.db_name is not None:
             db_name = self.db_name
         payload["dbName"] = db_name
@@ -883,11 +813,7 @@ class IndexClient(Requests):
     def alter_index_properties(self, collection_name, index_name, properties, db_name="default"):
         """Alter index properties"""
         url = f"{self.endpoint}/v2/vectordb/indexes/alter_properties"
-        payload = {
-            "collectionName": collection_name,
-            "indexName": index_name,
-            "properties": properties
-        }
+        payload = {"collectionName": collection_name, "indexName": index_name, "properties": properties}
         if self.db_name is not None:
             db_name = self.db_name
         if db_name != "default":
@@ -898,11 +824,7 @@ class IndexClient(Requests):
     def drop_index_properties(self, collection_name, index_name, delete_keys, db_name="default"):
         """Drop index properties"""
         url = f"{self.endpoint}/v2/vectordb/indexes/drop_properties"
-        payload = {
-            "collectionName": collection_name,
-            "indexName": index_name,
-            "propertyKeys": delete_keys
-        }
+        payload = {"collectionName": collection_name, "indexName": index_name, "propertyKeys": delete_keys}
         if self.db_name is not None:
             db_name = self.db_name
         if db_name != "default":
@@ -912,7 +834,6 @@ class IndexClient(Requests):
 
 
 class AliasClient(Requests):
-
     def __init__(self, endpoint, token):
         super().__init__(url=endpoint, api_key=token)
         self.endpoint = endpoint
@@ -921,41 +842,38 @@ class AliasClient(Requests):
         self.headers = self.update_headers()
 
     def list_alias(self):
-        url = f'{self.endpoint}/v2/vectordb/aliases/list'
+        url = f"{self.endpoint}/v2/vectordb/aliases/list"
         response = self.post(url, headers=self.update_headers())
         res = response.json()
         return res
 
     def describe_alias(self, alias_name):
-        url = f'{self.endpoint}/v2/vectordb/aliases/describe'
-        data = {
-            "aliasName": alias_name
-        }
+        url = f"{self.endpoint}/v2/vectordb/aliases/describe"
+        data = {"aliasName": alias_name}
         response = self.post(url, headers=self.update_headers(), data=data)
         res = response.json()
         return res
 
     def alter_alias(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/aliases/alter'
+        url = f"{self.endpoint}/v2/vectordb/aliases/alter"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def drop_alias(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/aliases/drop'
+        url = f"{self.endpoint}/v2/vectordb/aliases/drop"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
     def create_alias(self, payload):
-        url = f'{self.endpoint}/v2/vectordb/aliases/create'
+        url = f"{self.endpoint}/v2/vectordb/aliases/create"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
 
 
 class ImportJobClient(Requests):
-
     def __init__(self, endpoint, token):
         super().__init__(url=endpoint, api_key=token)
         self.endpoint = endpoint
@@ -969,7 +887,7 @@ class ImportJobClient(Requests):
         payload["dbName"] = db_name
         if db_name is None:
             payload.pop("dbName")
-        url = f'{self.endpoint}/v2/vectordb/jobs/import/list'
+        url = f"{self.endpoint}/v2/vectordb/jobs/import/list"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
@@ -977,7 +895,7 @@ class ImportJobClient(Requests):
     def create_import_jobs(self, payload, db_name="default"):
         if self.db_name is not None:
             db_name = self.db_name
-        url = f'{self.endpoint}/v2/vectordb/jobs/import/create'
+        url = f"{self.endpoint}/v2/vectordb/jobs/import/create"
         payload["dbName"] = db_name
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
@@ -986,15 +904,12 @@ class ImportJobClient(Requests):
     def get_import_job_progress(self, job_id, db_name="default"):
         if self.db_name is not None:
             db_name = self.db_name
-        payload = {
-            "dbName": db_name,
-            "jobID": job_id
-        }
+        payload = {"dbName": db_name, "jobID": job_id}
         if db_name is None:
             payload.pop("dbName")
         if job_id is None:
             payload.pop("jobID")
-        url = f'{self.endpoint}/v2/vectordb/jobs/import/get_progress'
+        url = f"{self.endpoint}/v2/vectordb/jobs/import/get_progress"
         response = self.post(url, headers=self.update_headers(), data=payload)
         res = response.json()
         return res
@@ -1005,7 +920,7 @@ class ImportJobClient(Requests):
         rsp = self.get_import_job_progress(job_id)
         while not finished:
             rsp = self.get_import_job_progress(job_id)
-            if rsp['data']['state'] == "Completed":
+            if rsp["data"]["state"] == "Completed":
                 finished = True
             time.sleep(5)
             if time.time() - t0 > 120:
@@ -1026,9 +941,9 @@ class DatabaseClient(Requests):
         """Create a database"""
         url = f"{self.endpoint}/v2/vectordb/databases/create"
         rsp = self.post(url, data=payload).json()
-        if rsp['code'] == 0:
-            self.db_name = payload['dbName']
-            self.db_names.append(payload['dbName'])
+        if rsp["code"] == 0:
+            self.db_name = payload["dbName"]
+            self.db_names.append(payload["dbName"])
         return rsp
 
     def database_list(self, payload):
@@ -1055,26 +970,19 @@ class DatabaseClient(Requests):
     def alter_database_properties(self, db_name, properties):
         """Alter database properties"""
         url = f"{self.endpoint}/v2/vectordb/databases/alter"
-        payload = {
-            "dbName": db_name,
-            "properties": properties
-        }
+        payload = {"dbName": db_name, "properties": properties}
         response = self.post(url, headers=self.update_headers(), data=payload)
         return response.json()
 
     def drop_database_properties(self, db_name, property_keys):
         """Drop database properties"""
         url = f"{self.endpoint}/v2/vectordb/databases/drop_properties"
-        payload = {
-            "dbName": db_name,
-            "propertyKeys": property_keys
-        }
+        payload = {"dbName": db_name, "propertyKeys": property_keys}
         response = self.post(url, headers=self.update_headers(), data=payload)
         return response.json()
 
 
-class StorageClient():
-
+class StorageClient:
     def __init__(self, endpoint, access_key, secret_key, bucket_name, root_path="file"):
         self.endpoint = endpoint
         self.access_key = access_key
@@ -1104,10 +1012,7 @@ class StorageClient():
             logger.error("fail to copy files to minio", exc)
 
     def get_collection_binlog(self, collection_id):
-        dir_list = [
-            "delta_log",
-            "insert_log"
-        ]
+        dir_list = ["delta_log", "insert_log"]
         binlog_list = []
         # list objects dir/collection_id in bucket
         for dir in dir_list:
@@ -1121,9 +1026,6 @@ class StorageClient():
 
 if __name__ == "__main__":
     sc = StorageClient(
-        endpoint="10.104.19.57:9000",
-        access_key="minioadmin",
-        secret_key="minioadmin",
-        bucket_name="milvus-bucket"
+        endpoint="10.104.19.57:9000", access_key="minioadmin", secret_key="minioadmin", bucket_name="milvus-bucket"
     )
     sc.get_collection_binlog("448305293023730313")

--- a/tests/restful_client_v2/testcases/test_collection_operations.py
+++ b/tests/restful_client_v2/testcases/test_collection_operations.py
@@ -1792,6 +1792,131 @@ class TestCollectionAddField(TestBase):
         assert rsp["code"] == 0
         assert len(rsp["data"]) > 0
 
+    @pytest.mark.parametrize(
+        "schema_variant,field_params",
+        [
+            (
+                "array_with_struct_element",
+                {
+                    "fieldName": "dynamic_struct",
+                    "dataType": "Array",
+                    "elementDataType": "Struct",
+                    "nullable": True,
+                    "elementTypeParams": {"max_capacity": 16},
+                    "fields": [
+                        {"fieldName": "sub_int", "dataType": "Array", "elementDataType": "Int32"},
+                        {
+                            "fieldName": "sub_vec",
+                            "dataType": "ArrayOfVector",
+                            "elementDataType": "FloatVector",
+                            "elementTypeParams": {"dim": 8},
+                        },
+                    ],
+                },
+            ),
+            (
+                "array_of_struct",
+                {
+                    "fieldName": "dynamic_struct",
+                    "dataType": "ArrayOfStruct",
+                    "nullable": True,
+                    "typeParams": {"max_capacity": 16},
+                    "fields": [
+                        {"fieldName": "sub_int", "dataType": "Array", "elementDataType": "Int32"},
+                        {
+                            "fieldName": "sub_vec",
+                            "dataType": "ArrayOfVector",
+                            "elementDataType": "FloatVector",
+                            "elementTypeParams": {"dim": 8},
+                        },
+                    ],
+                },
+            ),
+        ],
+    )
+    def test_add_struct_array_field(self, schema_variant, field_params):
+        """
+        target: test REST v2 add StructArray field
+        method: create collection, add StructArray field, insert and query rows with the new field
+        expected: StructArray field is added and usable through REST v2
+        """
+        name = gen_collection_name()
+        dim = DEFAULT_STRUCT_ARRAY_DIM
+        field_name = field_params["fieldName"]
+        client = self.collection_client
+        vector_client = self.vector_client
+
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "fields": [
+                    {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True},
+                    {"fieldName": "book_intro", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
+                ]
+            },
+            "indexParams": [{"fieldName": "book_intro", "indexName": "book_intro_index", "metricType": "L2"}],
+        }
+        rsp = client.collection_create(payload)
+        assert rsp["code"] == 0, rsp
+        client.wait_load_completed(collection_name=name, timeout=60)
+
+        rsp = vector_client.vector_insert(
+            {
+                "collectionName": name,
+                "data": [{"book_id": 0, "book_intro": gen_vector(dim=dim)}],
+            }
+        )
+        assert rsp["code"] == 0, rsp
+
+        rsp = client.add_field(name, field_params)
+        logger.info(f"add struct array field response ({schema_variant}): {rsp}")
+        assert rsp["code"] == 0, rsp
+
+        rsp = client.collection_describe(name)
+        assert rsp["code"] == 0, rsp
+        struct_fields = {field["name"]: field for field in rsp["data"].get("structFields", [])}
+        assert field_name in struct_fields, rsp
+        struct_field = struct_fields[field_name]
+        assert struct_field["type"] == "ArrayOfStruct"
+
+        sub_fields = {field["name"]: field for field in struct_field.get("fields", [])}
+        assert sorted(sub_fields) == ["sub_int", "sub_vec"]
+        assert sub_fields["sub_int"]["type"] == "Array"
+        assert sub_fields["sub_int"]["elementType"] == "Int32"
+        assert sub_fields["sub_vec"]["type"] == "ArrayOfVector"
+        assert sub_fields["sub_vec"]["elementType"] == "FloatVector"
+        for sub_field in sub_fields.values():
+            sub_params = {param["key"]: param["value"] for param in sub_field.get("params", [])}
+            assert str(sub_params["max_capacity"]) == str(DEFAULT_STRUCT_ARRAY_SUB_CAPACITY)
+
+        new_row = {
+            "book_id": 1,
+            "book_intro": gen_vector(dim=dim),
+            field_name: [
+                {"sub_int": 11, "sub_vec": _rand_struct_array_vector(dim)},
+                {"sub_int": 12, "sub_vec": _rand_struct_array_vector(dim)},
+            ],
+        }
+        rsp = vector_client.vector_insert({"collectionName": name, "data": [new_row]})
+        assert rsp["code"] == 0, rsp
+
+        rsp = vector_client.vector_query(
+            {
+                "collectionName": name,
+                "filter": "book_id == 1",
+                "outputFields": ["book_id", field_name],
+                "limit": 1,
+            }
+        )
+        assert rsp["code"] == 0, rsp
+        assert len(rsp["data"]) == 1
+        got = rsp["data"][0]
+        assert got["book_id"] == 1
+        assert len(got[field_name]) == len(new_row[field_name])
+        for actual, expected in zip(got[field_name], new_row[field_name]):
+            assert int(actual["sub_int"]) == expected["sub_int"]
+            np.testing.assert_allclose(actual["sub_vec"], expected["sub_vec"], rtol=1e-5, atol=1e-5)
+
 
 @pytest.mark.L1
 class TestCollectionAddFieldNegative(TestBase):

--- a/tests/restful_client_v2/testcases/test_collection_operations.py
+++ b/tests/restful_client_v2/testcases/test_collection_operations.py
@@ -1868,7 +1868,7 @@ class TestCollectionAddField(TestBase):
         )
         assert rsp["code"] == 0, rsp
 
-        rsp = client.add_field(name, field_params)
+        rsp = client.add_struct_field(name, field_params)
         logger.info(f"add struct array field response ({schema_variant}): {rsp}")
         assert rsp["code"] == 0, rsp
 


### PR DESCRIPTION
issue: #50235

### What problem does this PR solve?

This PR adds API support for dynamically adding StructArray fields to an existing collection, aligned with the existing Python SDK API shape.

### What is changed?

- Add Go SDK `Client.AddCollectionStructField(...)` and `NewAddCollectionStructFieldOption(...)`.
- Convert Go SDK StructArray field schema into `AddCollectionStructFieldRequest`.
- Preserve StructArray parent `nullable` and `max_capacity` when converting schemas and describing collections.
- Add REST v2 endpoint:
  - `POST /v2/vectordb/collections/struct_fields/add`
- Reject StructArray payloads from the ordinary REST v2 field endpoint:
  - `POST /v2/vectordb/collections/fields/add`
- Support REST v2 StructArray add payloads using both:
  - `dataType: "Array", elementDataType: "Struct"`
  - `dataType: "ArrayOfStruct"`
- Add Go SDK and REST v2 regression coverage.

### Verification

- `milvus-dev-cli go-ut local . -b master -t internal/distributed/proxy/httpserver -k 'TestAddCollectionFieldSuite' -f`
  - `ut-go-local-zhuwenxi-issue-50235-cbec6c2-26ef323b`
- `milvus-dev-cli build local . -b master -f`
  - `build-local-zhuwenxing-issue-50235-clea-cbec6c2`
- `milvus-dev-cli deploy create build-local-zhuwenxing-issue-50235-clea-cbec6c2 --name issue-50235-struct-add`
- `pytest -q testcases/test_collection_operations.py::TestCollectionAddField::test_add_struct_array_field --endpoint http://10.100.36.203:19530 --token root:Milvus --minio_host 10.100.36.198`
  - `2 passed`
