### PR TITLE
enhance: support storage format compaction and metrics

### DIFF
--- a/internal/datacoord/compaction_policy_storage_version.go
+++ b/internal/datacoord/compaction_policy_storage_version.go
@@ -76,6 +76,10 @@ func segmentColumnGroupFormatsAllEqual(segment *SegmentInfo, targetFormat string
 
 	binlogs := segment.GetBinlogs()
 	if len(binlogs) == 0 {
+		log.Warn("unexpected empty binlogs for V3 segment during storage format compaction",
+			zap.Int64("segmentID", segment.GetID()),
+			zap.Int64("collectionID", segment.GetCollectionID()),
+			zap.String("targetFormat", targetFormat))
 		return false
 	}
 

--- a/internal/datacoord/compaction_policy_storage_version.go
+++ b/internal/datacoord/compaction_policy_storage_version.go
@@ -57,7 +57,8 @@ func (policy *storageVersionUpgradePolicy) Name() string {
 }
 
 func (policy *storageVersionUpgradePolicy) Enable() bool {
-	return paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.GetAsBool()
+	return paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.GetAsBool() ||
+		paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.GetAsBool()
 }
 
 func (policy *storageVersionUpgradePolicy) targetVersion() int64 {
@@ -66,6 +67,24 @@ func (policy *storageVersionUpgradePolicy) targetVersion() int64 {
 		targetVersion = storage.StorageV3
 	}
 	return targetVersion
+}
+
+func segmentColumnGroupFormatsAllEqual(segment *SegmentInfo, targetFormat string) bool {
+	if targetFormat == "" || segment.GetStorageVersion() != storage.StorageV3 {
+		return true
+	}
+
+	binlogs := segment.GetBinlogs()
+	if len(binlogs) == 0 {
+		return false
+	}
+
+	for _, fieldBinlog := range binlogs {
+		if fieldBinlog.GetFormat() != targetFormat {
+			return false
+		}
+	}
+	return true
 }
 
 func (policy *storageVersionUpgradePolicy) Trigger(ctx context.Context) (map[CompactionTriggerType][]CompactionView, error) {
@@ -124,6 +143,10 @@ func (policy *storageVersionUpgradePolicy) triggerOneCollection(ctx context.Cont
 		log.Warn("fail to apply storageVersionUpgradePolicy, collection not exist")
 		return nil, nil
 	}
+	if collection.IsExternal() {
+		log.Info("skip storage version compaction for external collection")
+		return nil, nil
+	}
 
 	collectionTTL, err := common.GetCollectionTTLFromMap(collection.Properties)
 	if err != nil {
@@ -152,6 +175,9 @@ func (policy *storageVersionUpgradePolicy) triggerOneCollection(ctx context.Cont
 			}
 		}
 	}
+	versionEnabled := paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.GetAsBool()
+	formatEnabled := paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.GetAsBool()
+	targetFormat := paramtable.Get().DataNodeCfg.StorageFormat.GetValue()
 
 	segments := policy.meta.SelectSegments(ctx, WithCollection(collectionID), SegmentFilterFunc(func(segment *SegmentInfo) bool {
 		return isSegmentHealthy(segment) &&
@@ -159,8 +185,12 @@ func (policy *storageVersionUpgradePolicy) triggerOneCollection(ctx context.Cont
 			!segment.isCompacting &&
 			!segment.GetIsImporting() &&
 			segment.GetLevel() != datapb.SegmentLevel_L0 &&
-			segment.GetStorageVersion() != targetVersion &&
-			!policy.meta.isSegmentCompactionProtected(segment.GetID())
+			!policy.meta.isSegmentCompactionProtected(segment.GetID()) &&
+			((versionEnabled && segment.GetStorageVersion() != targetVersion) ||
+				(formatEnabled &&
+					targetVersion == storage.StorageV3 &&
+					segment.GetStorageVersion() == storage.StorageV3 &&
+					!segmentColumnGroupFormatsAllEqual(segment, targetFormat)))
 	}))
 
 	views := make([]CompactionView, 0, len(segments))

--- a/internal/datacoord/compaction_policy_storage_version_test.go
+++ b/internal/datacoord/compaction_policy_storage_version_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -66,14 +67,65 @@ func (s *StorageVersionUpgradePolicySuite) SetupTest() {
 	s.policy = newStorageVersionUpgradePolicy(meta, s.mockAlloc, s.handler, s.versionMgr)
 }
 
+func (s *StorageVersionUpgradePolicySuite) setPolicyMeta(collID int64, coll *collectionInfo, segments map[UniqueID]*SegmentInfo) {
+	segmentsInfo := &SegmentsInfo{
+		segments: segments,
+		secondaryIndexes: segmentInfoIndexes{
+			coll2Segments: map[UniqueID]map[UniqueID]*SegmentInfo{
+				collID: segments,
+			},
+		},
+	}
+
+	collections := typeutil.NewConcurrentMap[UniqueID, *collectionInfo]()
+	collections.Insert(collID, coll)
+
+	s.policy.meta = &meta{
+		segments:    segmentsInfo,
+		collections: collections,
+	}
+}
+
+func newStorageVersionPolicyTestSegment(collID, segmentID int64, storageVersion int64, format string) *SegmentInfo {
+	return &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:             segmentID,
+			CollectionID:   collID,
+			PartitionID:    10,
+			InsertChannel:  "ch-1",
+			Level:          datapb.SegmentLevel_L1,
+			State:          commonpb.SegmentState_Flushed,
+			NumOfRows:      10000,
+			StorageVersion: storageVersion,
+			Binlogs: []*datapb.FieldBinlog{
+				{
+					FieldID:     0,
+					ChildFields: []int64{100},
+					Format:      format,
+				},
+			},
+		},
+	}
+}
+
 func (s *StorageVersionUpgradePolicySuite) TestEnable() {
 	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
+	defer paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key)
 
 	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "false")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key, "false")
 	s.False(s.policy.Enable())
 
-	// Test with enabled
 	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key, "false")
+	s.True(s.policy.Enable())
+
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "false")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key, "true")
+	s.True(s.policy.Enable())
+
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key, "true")
 	s.True(s.policy.Enable())
 }
 
@@ -107,11 +159,13 @@ func (s *StorageVersionUpgradePolicySuite) TestTriggerWithSegments() {
 
 	// Setup params
 	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key, "false")
 	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitInterval.Key, "1")
 	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitTokens.Key, "10")
 	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true") // target is StorageV3
 	defer func() {
 		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key)
 		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitInterval.Key)
 		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionRateLimitTokens.Key)
 		paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
@@ -187,6 +241,227 @@ func (s *StorageVersionUpgradePolicySuite) TestTriggerWithSegments() {
 	s.NoError(err)
 	// Only segment 101 should be triggered (old version, not L0)
 	s.Equal(1, len(views))
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerVersionAndFormatRefresh() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataNodeCfg.StorageFormat.Key, "vortex")
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+		paramtable.Get().Reset(paramtable.Get().DataNodeCfg.StorageFormat.Key)
+	}()
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1000), nil)
+
+	segments := map[UniqueID]*SegmentInfo{
+		101: newStorageVersionPolicyTestSegment(collID, 101, storage.StorageV2, "parquet"),
+		102: newStorageVersionPolicyTestSegment(collID, 102, storage.StorageV3, "parquet"),
+		103: newStorageVersionPolicyTestSegment(collID, 103, storage.StorageV3, "vortex"),
+	}
+	s.setPolicyMeta(collID, coll, segments)
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.NoError(err)
+	s.Len(views, 2)
+
+	segmentIDs := typeutil.NewSet[int64]()
+	for _, view := range views {
+		mixView, ok := view.(*MixSegmentView)
+		s.Require().True(ok)
+		s.Require().Len(mixView.GetSegmentsView(), 1)
+		segmentIDs.Insert(mixView.GetSegmentsView()[0].ID)
+	}
+	s.True(segmentIDs.Contain(int64(101)))
+	s.True(segmentIDs.Contain(int64(102)))
+	s.False(segmentIDs.Contain(int64(103)))
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerFormatRefreshOnly() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "false")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataNodeCfg.StorageFormat.Key, "vortex")
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+		paramtable.Get().Reset(paramtable.Get().DataNodeCfg.StorageFormat.Key)
+	}()
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1000), nil)
+
+	segments := map[UniqueID]*SegmentInfo{
+		101: newStorageVersionPolicyTestSegment(collID, 101, storage.StorageV3, "parquet"),
+		102: newStorageVersionPolicyTestSegment(collID, 102, storage.StorageV3, "vortex"),
+		103: newStorageVersionPolicyTestSegment(collID, 103, storage.StorageV2, "parquet"),
+	}
+	s.setPolicyMeta(collID, coll, segments)
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.NoError(err)
+	s.Len(views, 1)
+
+	mixView, ok := views[0].(*MixSegmentView)
+	s.True(ok)
+	s.Len(mixView.GetSegmentsView(), 1)
+	s.Equal(int64(101), mixView.GetSegmentsView()[0].ID)
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestTriggerFormatRefreshSkipsExternalCollection() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "false")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataNodeCfg.StorageFormat.Key, "vortex")
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+		paramtable.Get().Reset(paramtable.Get().DataNodeCfg.StorageFormat.Key)
+	}()
+
+	coll := &collectionInfo{
+		ID: collID,
+		Schema: &schemapb.CollectionSchema{
+			Fields: []*schemapb.FieldSchema{
+				{
+					FieldID:       1,
+					Name:          "external_pk",
+					DataType:      schemapb.DataType_Int64,
+					ExternalField: "pk_col",
+				},
+			},
+		},
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+
+	segments := map[UniqueID]*SegmentInfo{
+		101: newStorageVersionPolicyTestSegment(collID, 101, storage.StorageV3, "lance-table"),
+	}
+	s.setPolicyMeta(collID, coll, segments)
+	s.policy.currentCount = 7
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.NoError(err)
+	s.Empty(views)
+	s.Equal(7, s.policy.currentCount)
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestFormatRefreshRespectsSegmentFilters() {
+	ctx := context.Background()
+	collID := int64(100)
+
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key, "false")
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key, "true")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.UseLoonFFI.Key, "true")
+	paramtable.Get().Save(paramtable.Get().DataNodeCfg.StorageFormat.Key, "vortex")
+	defer func() {
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageVersionCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().DataCoordCfg.StorageFormatCompactionEnabled.Key)
+		paramtable.Get().Reset(paramtable.Get().CommonCfg.UseLoonFFI.Key)
+		paramtable.Get().Reset(paramtable.Get().DataNodeCfg.StorageFormat.Key)
+	}()
+
+	coll := &collectionInfo{
+		ID:     collID,
+		Schema: newTestSchema(),
+	}
+	s.handler.EXPECT().GetCollection(mock.Anything, mock.Anything).Return(coll, nil)
+	s.mockAlloc.EXPECT().AllocID(mock.Anything).Return(int64(1000), nil)
+
+	segments := map[UniqueID]*SegmentInfo{
+		101: newStorageVersionPolicyTestSegment(collID, 101, storage.StorageV3, "parquet"),
+		102: newStorageVersionPolicyTestSegment(collID, 102, storage.StorageV3, "parquet"),
+		103: newStorageVersionPolicyTestSegment(collID, 103, storage.StorageV3, "parquet"),
+		104: newStorageVersionPolicyTestSegment(collID, 104, storage.StorageV3, "parquet"),
+		105: newStorageVersionPolicyTestSegment(collID, 105, storage.StorageV3, "parquet"),
+	}
+	segments[101].isCompacting = true
+	segments[102].IsImporting = true
+	segments[103].Level = datapb.SegmentLevel_L0
+	segments[104].State = commonpb.SegmentState_Dropped
+
+	s.setPolicyMeta(collID, coll, segments)
+	s.policy.meta.snapshotMeta = &snapshotMeta{
+		compactionBlockedCollections: typeutil.NewUniqueSet(),
+		snapshotPendingCollections:   typeutil.NewUniqueSet(),
+		segmentProtectionUntil:       map[int64]uint64{105: uint64(time.Now().Add(time.Hour).Unix())},
+	}
+
+	views, err := s.policy.triggerOneCollection(ctx, collID, 10)
+	s.NoError(err)
+	s.Empty(views)
+}
+
+func (s *StorageVersionUpgradePolicySuite) TestSegmentColumnGroupFormatsAllEqual() {
+	collID := int64(100)
+
+	s.True(segmentColumnGroupFormatsAllEqual(
+		newStorageVersionPolicyTestSegment(collID, 101, storage.StorageV3, "vortex"),
+		"vortex",
+	))
+	s.False(segmentColumnGroupFormatsAllEqual(
+		newStorageVersionPolicyTestSegment(collID, 102, storage.StorageV3, "vortex"),
+		"parquet",
+	))
+	s.True(segmentColumnGroupFormatsAllEqual(
+		newStorageVersionPolicyTestSegment(collID, 103, storage.StorageV3, "vortex"),
+		"",
+	))
+	s.True(segmentColumnGroupFormatsAllEqual(
+		newStorageVersionPolicyTestSegment(collID, 104, storage.StorageV2, "parquet"),
+		"vortex",
+	))
+	s.False(segmentColumnGroupFormatsAllEqual(
+		&SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:             105,
+				CollectionID:   collID,
+				StorageVersion: storage.StorageV3,
+			},
+		},
+		"vortex",
+	))
+	s.False(segmentColumnGroupFormatsAllEqual(
+		newStorageVersionPolicyTestSegment(collID, 106, storage.StorageV3, ""),
+		"vortex",
+	))
+	s.False(segmentColumnGroupFormatsAllEqual(
+		&SegmentInfo{
+			SegmentInfo: &datapb.SegmentInfo{
+				ID:             107,
+				CollectionID:   collID,
+				StorageVersion: storage.StorageV3,
+				Binlogs: []*datapb.FieldBinlog{
+					{Format: "vortex"},
+					{Format: "parquet"},
+				},
+			},
+		},
+		"vortex",
+	))
 }
 
 func (s *StorageVersionUpgradePolicySuite) TestTriggerWithCompactingSegment() {

--- a/internal/datacoord/compaction_policy_storage_version_test.go
+++ b/internal/datacoord/compaction_policy_storage_version_test.go
@@ -24,11 +24,15 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
 	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -417,6 +421,16 @@ func (s *StorageVersionUpgradePolicySuite) TestFormatRefreshRespectsSegmentFilte
 
 func (s *StorageVersionUpgradePolicySuite) TestSegmentColumnGroupFormatsAllEqual() {
 	collID := int64(100)
+	core, logs := observer.New(zapcore.WarnLevel)
+	oldLogger := log.L()
+	oldLevel := log.GetLevel()
+	log.ReplaceGlobals(zap.New(core), &log.ZapProperties{
+		Core:  core,
+		Level: zap.NewAtomicLevelAt(zapcore.WarnLevel),
+	})
+	defer log.ReplaceGlobals(oldLogger, &log.ZapProperties{
+		Level: zap.NewAtomicLevelAt(oldLevel),
+	})
 
 	s.True(segmentColumnGroupFormatsAllEqual(
 		newStorageVersionPolicyTestSegment(collID, 101, storage.StorageV3, "vortex"),
@@ -444,6 +458,10 @@ func (s *StorageVersionUpgradePolicySuite) TestSegmentColumnGroupFormatsAllEqual
 		},
 		"vortex",
 	))
+	entries := logs.FilterMessage("unexpected empty binlogs for V3 segment during storage format compaction").All()
+	s.Len(entries, 1)
+	s.Equal(int64(105), entries[0].ContextMap()["segmentID"])
+	s.Equal("vortex", entries[0].ContextMap()["targetFormat"])
 	s.False(segmentColumnGroupFormatsAllEqual(
 		newStorageVersionPolicyTestSegment(collID, 106, storage.StorageV3, ""),
 		"vortex",

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -24,6 +24,7 @@ import (
 	"math"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -151,11 +152,14 @@ func newChannelCps() *channelCPs {
 	return cp
 }
 
+type segmentMetricStateChange map[string]map[string]map[string]map[string]map[string]int
+
 // A local cache of segment metric update. Must call commit() to take effect.
 type segMetricMutation struct {
-	stateChange       map[string]map[string]map[string]map[string]int // segment state, seg level -> state -> isSorted -> storageVersion change count (to increase or decrease).
-	rowCountChange    int64                                           // Change in # of rows.
-	rowCountAccChange int64                                           // Total # of historical added rows, accumulated.
+	stateChange             segmentMetricStateChange // segment level -> state -> isSorted -> storageVersion -> format change count.
+	deferSegmentLabelChange bool                     // UpdateSegmentsInfo computes label changes from original and final segment state.
+	rowCountChange          int64                    // Change in # of rows.
+	rowCountAccChange       int64                    // Total # of historical added rows, accumulated.
 }
 
 type collectionInfo struct {
@@ -168,6 +172,50 @@ type collectionInfo struct {
 	DatabaseName   string
 	DatabaseID     int64
 	VChannelNames  []string
+}
+
+const (
+	segmentMetricFormatLegacy  = "legacy"
+	segmentMetricFormatUnknown = "unknown"
+	segmentMetricFormatMixed   = "mixed"
+)
+
+func segmentMetricFormatLabel(segment *SegmentInfo) string {
+	if segment == nil {
+		return segmentMetricFormatUnknown
+	}
+
+	formats := make(map[string]struct{})
+	for _, fieldBinlog := range segment.GetBinlogs() {
+		format := strings.TrimSpace(fieldBinlog.GetFormat())
+		if format == "" {
+			continue
+		}
+		formats[format] = struct{}{}
+	}
+	if len(formats) == 0 {
+		if segment.GetStorageVersion() < storage.StorageV2 {
+			return segmentMetricFormatLegacy
+		}
+		return segmentMetricFormatUnknown
+	}
+	if len(formats) > 1 {
+		return segmentMetricFormatMixed
+	}
+	for format := range formats {
+		return format
+	}
+	return segmentMetricFormatUnknown
+}
+
+func segmentMetricLabelValues(segment *SegmentInfo) []string {
+	return []string{
+		segment.GetState().String(),
+		segment.GetLevel().String(),
+		getSortStatus(segment.GetIsSorted()),
+		fmt.Sprint(segment.GetStorageVersion()),
+		segmentMetricFormatLabel(segment),
+	}
 }
 
 // IsExternal returns true when the collection schema references an external source or spec.
@@ -344,7 +392,7 @@ func (m *meta) reloadFromKV(ctx context.Context, collectionIDs []int64) error {
 		for _, segment := range segments {
 			// segments from catalog.ListSegments will not have logPath
 			m.segments.SetSegment(segment.ID, NewSegmentInfo(segment))
-			metrics.DataCoordNumSegments.WithLabelValues(segment.GetState().String(), segment.GetLevel().String(), getSortStatus(segment.GetIsSorted()), fmt.Sprint(segment.GetStorageVersion())).Inc()
+			metrics.DataCoordNumSegments.WithLabelValues(segmentMetricLabelValues(NewSegmentInfo(segment))...).Inc()
 			if segment.State == commonpb.SegmentState_Flushed {
 				numStoredRows += segment.NumOfRows
 
@@ -660,7 +708,7 @@ func (m *meta) AddSegment(ctx context.Context, segment *SegmentInfo) error {
 	}
 	m.segments.SetSegment(segment.GetID(), segment)
 
-	metrics.DataCoordNumSegments.WithLabelValues(segment.GetState().String(), segment.GetLevel().String(), getSortStatus(segment.GetIsSorted()), fmt.Sprint(segment.GetStorageVersion())).Inc()
+	metrics.DataCoordNumSegments.WithLabelValues(segmentMetricLabelValues(segment)...).Inc()
 	log.Info("meta update: adding segment - complete", zap.Int64("segmentID", segment.GetID()))
 	return nil
 }
@@ -683,7 +731,7 @@ func (m *meta) DropSegment(ctx context.Context, segmentID UniqueID) error {
 			zap.Error(err))
 		return err
 	}
-	metrics.DataCoordNumSegments.WithLabelValues(segment.GetState().String(), segment.GetLevel().String(), getSortStatus(segment.GetIsSorted()), fmt.Sprint(segment.GetStorageVersion())).Dec()
+	metrics.DataCoordNumSegments.WithLabelValues(segmentMetricLabelValues(segment)...).Dec()
 
 	m.segments.DropSegment(segmentID)
 	log.Info("meta update: dropping segment - complete",
@@ -797,7 +845,7 @@ func (m *meta) SetState(ctx context.Context, segmentID UniqueID, targetState com
 	// Persist segment updates first.
 	clonedSegment := curSegInfo.Clone()
 	metricMutation := &segMetricMutation{
-		stateChange: make(map[string]map[string]map[string]map[string]int),
+		stateChange: make(segmentMetricStateChange),
 	}
 	if clonedSegment != nil && isSegmentHealthy(clonedSegment) {
 		// Update segment state and prepare segment metric update.
@@ -945,7 +993,7 @@ func CreateL0Operator(collectionID, partitionID, segmentID int64, channel string
 				State:         commonpb.SegmentState_Flushed,
 				Level:         datapb.SegmentLevel_L0,
 			})
-			modPack.metricMutation.addNewSeg(commonpb.SegmentState_Flushed, datapb.SegmentLevel_L0, false, 0, 0)
+			modPack.metricMutation.addNewSeg(commonpb.SegmentState_Flushed, datapb.SegmentLevel_L0, false, 0, segmentMetricFormatLegacy, 0)
 		}
 		return true
 	}
@@ -1749,7 +1797,8 @@ func (m *meta) UpdateSegmentsInfo(ctx context.Context, operators ...UpdateOperat
 		segments:   make(map[int64]*SegmentInfo),
 		increments: make(map[int64]metastore.BinlogsIncrement),
 		metricMutation: &segMetricMutation{
-			stateChange: make(map[string]map[string]map[string]map[string]int),
+			stateChange:             make(segmentMetricStateChange),
+			deferSegmentLabelChange: true,
 		},
 	}
 
@@ -1777,6 +1826,7 @@ func (m *meta) UpdateSegmentsInfo(ctx context.Context, operators ...UpdateOperat
 	if err := updatePack.Validate(); err != nil {
 		return err
 	}
+	updatePack.prepareSegmentMetricUpdates()
 
 	segments := lo.MapToSlice(updatePack.segments, func(_ int64, segment *SegmentInfo) *datapb.SegmentInfo { return segment.SegmentInfo })
 	increments := lo.Values(updatePack.increments)
@@ -1807,7 +1857,7 @@ func (m *meta) UpdateDropChannelSegmentInfo(ctx context.Context, channel string,
 
 	// Prepare segment metric mutation.
 	metricMutation := &segMetricMutation{
-		stateChange: make(map[string]map[string]map[string]map[string]int),
+		stateChange: make(segmentMetricStateChange),
 	}
 	modSegments := make(map[UniqueID]*SegmentInfo)
 	// save new segments flushed from buffer data
@@ -1848,7 +1898,7 @@ func (m *meta) UpdateDropChannelSegmentInfo(ctx context.Context, channel string,
 // mergeDropSegment merges drop segment information with meta segments
 func (m *meta) mergeDropSegment(seg2Drop *SegmentInfo) (*SegmentInfo, *segMetricMutation) {
 	metricMutation := &segMetricMutation{
-		stateChange: make(map[string]map[string]map[string]map[string]int),
+		stateChange: make(segmentMetricStateChange),
 	}
 
 	segment := m.segments.GetSegment(seg2Drop.ID)
@@ -2233,7 +2283,7 @@ func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, resul
 		zap.Int64("partitionID", t.PartitionID),
 		zap.String("channel", t.GetChannel()))
 
-	metricMutation := &segMetricMutation{stateChange: make(map[string]map[string]map[string]map[string]int)}
+	metricMutation := &segMetricMutation{stateChange: make(segmentMetricStateChange)}
 	compactFromSegIDs := make([]int64, 0)
 	compactToSegIDs := make([]int64, 0)
 	compactFromSegInfos := make([]*SegmentInfo, 0)
@@ -2308,7 +2358,7 @@ func (m *meta) completeClusterCompactionMutation(t *datapb.CompactionTask, resul
 		segment := NewSegmentInfo(segmentInfo)
 		compactToSegInfos = append(compactToSegInfos, segment)
 		compactToSegIDs = append(compactToSegIDs, segment.GetID())
-		metricMutation.addNewSeg(segment.GetState(), segment.GetLevel(), segment.GetIsSorted(), segment.GetStorageVersion(), segment.GetNumOfRows())
+		metricMutation.addNewSeg(segment.GetState(), segment.GetLevel(), segment.GetIsSorted(), segment.GetStorageVersion(), segmentMetricFormatLabel(segment), segment.GetNumOfRows())
 	}
 
 	log = log.With(zap.Int64s("compact from", compactFromSegIDs), zap.Int64s("compact to", compactToSegIDs))
@@ -2346,7 +2396,7 @@ func (m *meta) completeMixCompactionMutation(
 		zap.Int64("planID", t.GetPlanID()),
 	)
 
-	metricMutation := &segMetricMutation{stateChange: make(map[string]map[string]map[string]map[string]int)}
+	metricMutation := &segMetricMutation{stateChange: make(segmentMetricStateChange)}
 	var compactFromSegIDs []int64
 	var compactFromSegInfos []*SegmentInfo
 	for _, segmentID := range t.GetInputSegments() {
@@ -2445,7 +2495,7 @@ func (m *meta) completeMixCompactionMutation(
 		}
 
 		// metrics mutation for compactTo segments
-		metricMutation.addNewSeg(compactToSegmentInfo.GetState(), compactToSegmentInfo.GetLevel(), compactToSegmentInfo.GetIsSorted(), compactToSegmentInfo.GetStorageVersion(), compactToSegmentInfo.GetNumOfRows())
+		metricMutation.addNewSeg(compactToSegmentInfo.GetState(), compactToSegmentInfo.GetLevel(), compactToSegmentInfo.GetIsSorted(), compactToSegmentInfo.GetStorageVersion(), segmentMetricFormatLabel(compactToSegmentInfo), compactToSegmentInfo.GetNumOfRows())
 
 		log.Info("Add a new compactTo segment",
 			zap.Int64("compactTo", compactToSegmentInfo.GetID()),
@@ -2885,26 +2935,29 @@ func (m *meta) GetEarliestStartPositionOfGrowingSegments(label *CompactionGroupL
 	return earliest
 }
 
-// initStateChangeEntry initializes the nested map structure for the given keys and returns the innermost map.
-func (s *segMetricMutation) initStateChangeEntry(level, state, sortedStatus string) map[string]int {
+// initStateChangeEntry initializes the nested map structure for the given keys and returns the format change map.
+func (s *segMetricMutation) initStateChangeEntry(level, state, sortedStatus, storageVersion string) map[string]int {
 	if _, ok := s.stateChange[level]; !ok {
-		s.stateChange[level] = make(map[string]map[string]map[string]int)
+		s.stateChange[level] = make(map[string]map[string]map[string]map[string]int)
 	}
 	if _, ok := s.stateChange[level][state]; !ok {
-		s.stateChange[level][state] = make(map[string]map[string]int)
+		s.stateChange[level][state] = make(map[string]map[string]map[string]int)
 	}
 	if _, ok := s.stateChange[level][state][sortedStatus]; !ok {
-		s.stateChange[level][state][sortedStatus] = make(map[string]int)
+		s.stateChange[level][state][sortedStatus] = make(map[string]map[string]int)
 	}
-	return s.stateChange[level][state][sortedStatus]
+	if _, ok := s.stateChange[level][state][sortedStatus][storageVersion]; !ok {
+		s.stateChange[level][state][sortedStatus][storageVersion] = make(map[string]int)
+	}
+	return s.stateChange[level][state][sortedStatus][storageVersion]
 }
 
 // addNewSeg update metrics update for a new segment.
-func (s *segMetricMutation) addNewSeg(state commonpb.SegmentState, level datapb.SegmentLevel, isSorted bool, storageVersion int64, rowCount int64) {
+func (s *segMetricMutation) addNewSeg(state commonpb.SegmentState, level datapb.SegmentLevel, isSorted bool, storageVersion int64, format string, rowCount int64) {
 	storageVersionStr := fmt.Sprint(storageVersion)
 	sortedStatus := getSortStatus(isSorted)
-	entry := s.initStateChangeEntry(level.String(), state.String(), sortedStatus)
-	entry[storageVersionStr] += 1
+	entry := s.initStateChangeEntry(level.String(), state.String(), sortedStatus, storageVersionStr)
+	entry[format] += 1
 
 	s.rowCountChange += rowCount
 	s.rowCountAccChange += rowCount
@@ -2916,24 +2969,26 @@ func (s *segMetricMutation) commit() {
 	for level, submap := range s.stateChange {
 		for state, sortedMap := range submap {
 			for sortedLabel, versionMap := range sortedMap {
-				for storageVersion, change := range versionMap {
-					metrics.DataCoordNumSegments.WithLabelValues(state, level, sortedLabel, storageVersion).Add(float64(change))
+				for storageVersion, formatMap := range versionMap {
+					for format, change := range formatMap {
+						metrics.DataCoordNumSegments.WithLabelValues(state, level, sortedLabel, storageVersion, format).Add(float64(change))
+					}
 				}
 			}
 		}
 	}
 }
 
-// append updates current segMetricMutation when segment state change happens.
-func (s *segMetricMutation) append(oldState, newState commonpb.SegmentState, level datapb.SegmentLevel, isSorted bool, storageVersion int64, rowCountUpdate int64) {
-	if oldState != newState {
+// append updates current segMetricMutation when segment state changes.
+func (s *segMetricMutation) append(oldState, newState commonpb.SegmentState, level datapb.SegmentLevel, isSorted bool, storageVersion int64, format string, rowCountUpdate int64) {
+	if oldState != newState && !s.deferSegmentLabelChange {
 		storageVersionStr := fmt.Sprint(storageVersion)
 		sortedStatus := getSortStatus(isSorted)
 		levelStr := level.String()
-		oldEntry := s.initStateChangeEntry(levelStr, oldState.String(), sortedStatus)
-		newEntry := s.initStateChangeEntry(levelStr, newState.String(), sortedStatus)
-		oldEntry[storageVersionStr] -= 1
-		newEntry[storageVersionStr] += 1
+		oldEntry := s.initStateChangeEntry(levelStr, oldState.String(), sortedStatus, storageVersionStr)
+		newEntry := s.initStateChangeEntry(levelStr, newState.String(), sortedStatus, storageVersionStr)
+		oldEntry[format] -= 1
+		newEntry[format] += 1
 	}
 	// Update # of rows on new flush operations and drop operations.
 	if isFlushState(newState) && !isFlushState(oldState) {
@@ -2943,6 +2998,45 @@ func (s *segMetricMutation) append(oldState, newState commonpb.SegmentState, lev
 	} else if newState == commonpb.SegmentState_Dropped && oldState != newState {
 		// If new drop.
 		s.rowCountChange -= rowCountUpdate
+	}
+}
+
+func sameSegmentMetricLabels(oldSegment, newSegment *SegmentInfo) bool {
+	return oldSegment.GetState() == newSegment.GetState() &&
+		oldSegment.GetLevel() == newSegment.GetLevel() &&
+		oldSegment.GetIsSorted() == newSegment.GetIsSorted() &&
+		oldSegment.GetStorageVersion() == newSegment.GetStorageVersion() &&
+		segmentMetricFormatLabel(oldSegment) == segmentMetricFormatLabel(newSegment)
+}
+
+func (s *segMetricMutation) appendSegmentLabelChange(oldSegment, newSegment *SegmentInfo) {
+	oldEntry := s.initStateChangeEntry(
+		oldSegment.GetLevel().String(),
+		oldSegment.GetState().String(),
+		getSortStatus(oldSegment.GetIsSorted()),
+		fmt.Sprint(oldSegment.GetStorageVersion()),
+	)
+	oldEntry[segmentMetricFormatLabel(oldSegment)] -= 1
+
+	newEntry := s.initStateChangeEntry(
+		newSegment.GetLevel().String(),
+		newSegment.GetState().String(),
+		getSortStatus(newSegment.GetIsSorted()),
+		fmt.Sprint(newSegment.GetStorageVersion()),
+	)
+	newEntry[segmentMetricFormatLabel(newSegment)] += 1
+}
+
+func (p *updateSegmentPack) prepareSegmentMetricUpdates() {
+	for id, updated := range p.segments {
+		original := p.meta.segments.GetSegment(id)
+		if original == nil {
+			continue
+		}
+		if sameSegmentMetricLabels(original, updated) {
+			continue
+		}
+		p.metricMutation.appendSegmentLabelChange(original, updated)
 	}
 }
 
@@ -2957,7 +3051,7 @@ func updateSegStateAndPrepareMetrics(segToUpdate *SegmentInfo, targetState commo
 		zap.String("old state", segToUpdate.GetState().String()),
 		zap.String("new state", targetState.String()),
 		zap.Int64("# of rows", segToUpdate.GetNumOfRows()))
-	metricMutation.append(segToUpdate.GetState(), targetState, segToUpdate.GetLevel(), segToUpdate.GetIsSorted(), segToUpdate.GetStorageVersion(), segToUpdate.GetNumOfRows())
+	metricMutation.append(segToUpdate.GetState(), targetState, segToUpdate.GetLevel(), segToUpdate.GetIsSorted(), segToUpdate.GetStorageVersion(), segmentMetricFormatLabel(segToUpdate), segToUpdate.GetNumOfRows())
 	segToUpdate.State = targetState
 	if targetState == commonpb.SegmentState_Dropped {
 		segToUpdate.DroppedAt = uint64(time.Now().UnixNano())
@@ -3049,7 +3143,7 @@ func (m *meta) completeSortCompactionMutation(
 		zap.Int64("partitionID", t.PartitionID),
 		zap.String("channel", t.GetChannel()))
 
-	metricMutation := &segMetricMutation{stateChange: make(map[string]map[string]map[string]map[string]int)}
+	metricMutation := &segMetricMutation{stateChange: make(segmentMetricStateChange)}
 	compactFromSegID := t.GetInputSegments()[0]
 	oldSegment := m.segments.GetSegment(compactFromSegID)
 	if oldSegment == nil {
@@ -3122,7 +3216,7 @@ func (m *meta) completeSortCompactionMutation(
 
 	segment := NewSegmentInfo(segmentInfo)
 	if segment.GetNumOfRows() > 0 {
-		metricMutation.addNewSeg(segment.GetState(), segment.GetLevel(), segment.GetIsSorted(), segment.GetStorageVersion(), segment.GetNumOfRows())
+		metricMutation.addNewSeg(segment.GetState(), segment.GetLevel(), segment.GetIsSorted(), segment.GetStorageVersion(), segmentMetricFormatLabel(segment), segment.GetNumOfRows())
 	} else {
 		segment.State = commonpb.SegmentState_Dropped
 		segment.DroppedAt = uint64(time.Now().UnixNano())
@@ -3162,7 +3256,7 @@ func (m *meta) completeBumpSchemaVersionCompactionMutation(
 		zap.Int64("partitionID", t.PartitionID),
 		zap.String("channel", t.GetChannel()))
 
-	metricMutation := &segMetricMutation{stateChange: make(map[string]map[string]map[string]map[string]int)}
+	metricMutation := &segMetricMutation{stateChange: make(segmentMetricStateChange)}
 
 	// Schema bump compaction has one input and one result.
 	if len(t.GetInputSegments()) != 1 {
@@ -3322,7 +3416,7 @@ func (m *meta) completeBumpSchemaVersionReplacementMutation(
 		SchemaVersion:             schemaVersion,
 	})
 	if newSegment.GetNumOfRows() > 0 {
-		metricMutation.addNewSeg(newSegment.GetState(), newSegment.GetLevel(), newSegment.GetIsSorted(), newSegment.GetStorageVersion(), newSegment.GetNumOfRows())
+		metricMutation.addNewSeg(newSegment.GetState(), newSegment.GetLevel(), newSegment.GetIsSorted(), newSegment.GetStorageVersion(), segmentMetricFormatLabel(newSegment), newSegment.GetNumOfRows())
 	} else {
 		newSegment.State = commonpb.SegmentState_Dropped
 		newSegment.DroppedAt = uint64(time.Now().UnixNano())
@@ -3382,7 +3476,7 @@ func (m *meta) DropSegmentsOfPartition(ctx context.Context, partitionIDs []int64
 
 	// Filter out the segments of the partition to be dropped.
 	metricMutation := &segMetricMutation{
-		stateChange: make(map[string]map[string]map[string]map[string]int),
+		stateChange: make(segmentMetricStateChange),
 	}
 	modSegments := make([]*SegmentInfo, 0)
 	segments := make([]*datapb.SegmentInfo, 0)
@@ -3459,7 +3553,7 @@ func (m *meta) TruncateChannelByTime(ctx context.Context, vChannel string, flush
 	segments := m.segments.GetSegmentsBySelector(SegmentFilterFunc(isSegmentHealthy), WithChannel(vChannel))
 	segmentsToDrop := make([]*SegmentInfo, 0)
 	metricMutation := &segMetricMutation{
-		stateChange: make(map[string]map[string]map[string]map[string]int),
+		stateChange: make(segmentMetricStateChange),
 	}
 
 	for _, segment := range segments {

--- a/internal/datacoord/meta_test.go
+++ b/internal/datacoord/meta_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
+	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -173,7 +174,7 @@ func (suite *MetaReloadSuite) TestReloadFromKV() {
 		_, err := newMeta(ctx, suite.catalog, nil, brk)
 		suite.NoError(err)
 
-		suite.MetricsEqual(metrics.DataCoordNumSegments.WithLabelValues(metrics.FlushedSegmentLabel, datapb.SegmentLevel_Legacy.String(), "unsorted", "0"), 1)
+		suite.MetricsEqual(metrics.DataCoordNumSegments.WithLabelValues(metrics.FlushedSegmentLabel, datapb.SegmentLevel_Legacy.String(), "unsorted", "0", "legacy"), 1)
 	})
 
 	suite.Run("ListIndexes_fail", func() {
@@ -464,9 +465,9 @@ func (suite *MetaBasicSuite) TestCompleteCompactionMutation() {
 
 		// check mutation metrics - only input segments changed to Dropped
 		suite.EqualValues(-4, mutation.rowCountChange)
-		flushedUnsorted := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Flushed.String()][getSortStatus(false)]["0"]
+		flushedUnsorted := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Flushed.String()][getSortStatus(false)]["0"][segmentMetricFormatLegacy]
 		suite.EqualValues(-2, flushedUnsorted)
-		droppedUnsorted := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Dropped.String()][getSortStatus(false)]["0"]
+		droppedUnsorted := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Dropped.String()][getSortStatus(false)]["0"][segmentMetricFormatLegacy]
 		suite.EqualValues(2, droppedUnsorted)
 	})
 
@@ -525,10 +526,10 @@ func (suite *MetaBasicSuite) TestCompleteCompactionMutation() {
 		suite.EqualValues(2, len(mutation.stateChange[datapb.SegmentLevel_L1.String()]))
 		suite.EqualValues(-4, mutation.rowCountChange)
 		suite.EqualValues(0, mutation.rowCountAccChange)
-		flushedUnsorted := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Flushed.String()][getSortStatus(false)]["0"]
+		flushedUnsorted := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Flushed.String()][getSortStatus(false)]["0"][segmentMetricFormatLegacy]
 		suite.EqualValues(-2, flushedUnsorted)
 
-		droppedUnsorted := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Dropped.String()][getSortStatus(false)]["0"]
+		droppedUnsorted := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Dropped.String()][getSortStatus(false)]["0"][segmentMetricFormatLegacy]
 		suite.EqualValues(3, droppedUnsorted)
 	})
 
@@ -600,10 +601,10 @@ func (suite *MetaBasicSuite) TestCompleteCompactionMutation() {
 		suite.EqualValues(2, len(mutation.stateChange[datapb.SegmentLevel_L1.String()]))
 		suite.EqualValues(-2, mutation.rowCountChange)
 		suite.EqualValues(2, mutation.rowCountAccChange)
-		flushedCount := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Flushed.String()][getSortStatus(false)]["0"]
+		flushedCount := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Flushed.String()][getSortStatus(false)]["0"][segmentMetricFormatLegacy]
 		suite.EqualValues(-1, flushedCount)
 
-		droppedCount := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Dropped.String()][getSortStatus(false)]["0"]
+		droppedCount := mutation.stateChange[datapb.SegmentLevel_L1.String()][commonpb.SegmentState_Dropped.String()][getSortStatus(false)]["0"][segmentMetricFormatLegacy]
 		suite.EqualValues(2, droppedCount)
 	})
 
@@ -3717,6 +3718,252 @@ func TestUpdateSegmentsInfo(t *testing.T) {
 		seg = meta.GetSegment(context.TODO(), 1)
 		assert.Equal(t, uint64(0), seg.GetCommitTimestamp())
 	})
+}
+
+func TestSegmentMetricFormatLabel(t *testing.T) {
+	tests := []struct {
+		name    string
+		segment *SegmentInfo
+		want    string
+	}{
+		{
+			name: "legacy storage without format",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV1,
+			}),
+			want: "legacy",
+		},
+		{
+			name: "storage v2 without format",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV2,
+			}),
+			want: "unknown",
+		},
+		{
+			name: "storage v3 parquet",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+				Binlogs: []*datapb.FieldBinlog{
+					{Format: "parquet"},
+					{Format: "parquet"},
+				},
+			}),
+			want: "parquet",
+		},
+		{
+			name: "storage v3 external iceberg table",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+				Binlogs: []*datapb.FieldBinlog{
+					{Format: "iceberg-table"},
+				},
+			}),
+			want: "iceberg-table",
+		},
+		{
+			name: "storage v3 external lance table",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+				Binlogs: []*datapb.FieldBinlog{
+					{Format: "lance-table"},
+				},
+			}),
+			want: "lance-table",
+		},
+		{
+			name: "mixed column group formats",
+			segment: NewSegmentInfo(&datapb.SegmentInfo{
+				StorageVersion: storage.StorageV3,
+				Binlogs: []*datapb.FieldBinlog{
+					{Format: "parquet"},
+					{Format: "vortex"},
+				},
+			}),
+			want: "mixed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, segmentMetricFormatLabel(test.segment))
+		})
+	}
+}
+
+func TestUpdateSegmentsInfoUpdatesSegmentFormatMetric(t *testing.T) {
+	metrics.DataCoordNumSegments.Reset()
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	defer metrics.DataCoordNumSegments.Reset()
+
+	segment := NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             1,
+		State:          commonpb.SegmentState_Flushed,
+		Level:          datapb.SegmentLevel_L1,
+		StorageVersion: storage.StorageV3,
+	})
+	require.NoError(t, meta.AddSegment(context.TODO(), segment))
+
+	unknownLabels := []string{metrics.FlushedSegmentLabel, datapb.SegmentLevel_L1.String(), "unsorted", fmt.Sprint(storage.StorageV3), "unknown"}
+	icebergLabels := []string{metrics.FlushedSegmentLabel, datapb.SegmentLevel_L1.String(), "unsorted", fmt.Sprint(storage.StorageV3), "iceberg-table"}
+	assert.Equal(t, float64(1), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(unknownLabels...)))
+
+	err = meta.UpdateSegmentsInfo(context.TODO(), AddBinlogsOperator(1,
+		[]*datapb.FieldBinlog{
+			{
+				FieldID:     100,
+				ChildFields: []int64{100},
+				Format:      "iceberg-table",
+				Binlogs: []*datapb.Binlog{
+					{LogID: 10, EntriesNum: 100, LogSize: 1000, MemorySize: 1000},
+				},
+			},
+		},
+		nil,
+		nil,
+		nil,
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(0), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(unknownLabels...)))
+	assert.Equal(t, float64(1), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(icebergLabels...)))
+}
+
+func TestUpdateSegmentsInfoUpdatesSegmentFormatMetricToMixed(t *testing.T) {
+	metrics.DataCoordNumSegments.Reset()
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	defer metrics.DataCoordNumSegments.Reset()
+
+	segment := NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             1,
+		State:          commonpb.SegmentState_Flushed,
+		Level:          datapb.SegmentLevel_L1,
+		StorageVersion: storage.StorageV3,
+	})
+	require.NoError(t, meta.AddSegment(context.TODO(), segment))
+
+	unknownLabels := []string{metrics.FlushedSegmentLabel, datapb.SegmentLevel_L1.String(), "unsorted", fmt.Sprint(storage.StorageV3), "unknown"}
+	mixedLabels := []string{metrics.FlushedSegmentLabel, datapb.SegmentLevel_L1.String(), "unsorted", fmt.Sprint(storage.StorageV3), segmentMetricFormatMixed}
+	assert.Equal(t, float64(1), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(unknownLabels...)))
+
+	err = meta.UpdateSegmentsInfo(context.TODO(), AddBinlogsOperator(1,
+		[]*datapb.FieldBinlog{
+			{
+				FieldID:     100,
+				ChildFields: []int64{100},
+				Format:      "parquet",
+				Binlogs: []*datapb.Binlog{
+					{LogID: 10, EntriesNum: 100, LogSize: 1000, MemorySize: 1000},
+				},
+			},
+			{
+				FieldID:     101,
+				ChildFields: []int64{101},
+				Format:      "vortex",
+				Binlogs: []*datapb.Binlog{
+					{LogID: 11, EntriesNum: 100, LogSize: 1000, MemorySize: 1000},
+				},
+			},
+		},
+		nil,
+		nil,
+		nil,
+	))
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(0), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(unknownLabels...)))
+	assert.Equal(t, float64(1), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(mixedLabels...)))
+}
+
+func TestUpdateSegmentsInfoUpdatesSegmentFormatMetricWithStateChange(t *testing.T) {
+	metrics.DataCoordNumSegments.Reset()
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	defer metrics.DataCoordNumSegments.Reset()
+
+	segment := NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             1,
+		State:          commonpb.SegmentState_Growing,
+		Level:          datapb.SegmentLevel_L1,
+		StorageVersion: storage.StorageV3,
+	})
+	require.NoError(t, meta.AddSegment(context.TODO(), segment))
+
+	growingUnknownLabels := []string{commonpb.SegmentState_Growing.String(), datapb.SegmentLevel_L1.String(), "unsorted", fmt.Sprint(storage.StorageV3), segmentMetricFormatUnknown}
+	flushedUnknownLabels := []string{metrics.FlushedSegmentLabel, datapb.SegmentLevel_L1.String(), "unsorted", fmt.Sprint(storage.StorageV3), segmentMetricFormatUnknown}
+	flushedLanceLabels := []string{metrics.FlushedSegmentLabel, datapb.SegmentLevel_L1.String(), "unsorted", fmt.Sprint(storage.StorageV3), "lance-table"}
+	assert.Equal(t, float64(1), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(growingUnknownLabels...)))
+
+	err = meta.UpdateSegmentsInfo(context.TODO(),
+		UpdateStatusOperator(1, commonpb.SegmentState_Flushed),
+		AddBinlogsOperator(1,
+			[]*datapb.FieldBinlog{
+				{
+					FieldID:     100,
+					ChildFields: []int64{100},
+					Format:      "lance-table",
+					Binlogs: []*datapb.Binlog{
+						{LogID: 10, EntriesNum: 100, LogSize: 1000, MemorySize: 1000},
+					},
+				},
+			},
+			nil,
+			nil,
+			nil,
+		),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(0), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(growingUnknownLabels...)))
+	assert.Equal(t, float64(0), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(flushedUnknownLabels...)))
+	assert.Equal(t, float64(1), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(flushedLanceLabels...)))
+}
+
+func TestUpdateSegmentsInfoUpdatesSegmentFormatMetricWithBinlogsBeforeStateChange(t *testing.T) {
+	metrics.DataCoordNumSegments.Reset()
+	meta, err := newMemoryMeta(t)
+	require.NoError(t, err)
+	defer metrics.DataCoordNumSegments.Reset()
+
+	segment := NewSegmentInfo(&datapb.SegmentInfo{
+		ID:             1,
+		State:          commonpb.SegmentState_Importing,
+		Level:          datapb.SegmentLevel_L1,
+		StorageVersion: storage.StorageV3,
+		NumOfRows:      100,
+	})
+	require.NoError(t, meta.AddSegment(context.TODO(), segment))
+
+	importingUnknownLabels := []string{commonpb.SegmentState_Importing.String(), datapb.SegmentLevel_L1.String(), "unsorted", fmt.Sprint(storage.StorageV3), segmentMetricFormatUnknown}
+	importingParquetLabels := []string{commonpb.SegmentState_Importing.String(), datapb.SegmentLevel_L1.String(), "unsorted", fmt.Sprint(storage.StorageV3), "parquet"}
+	flushedParquetLabels := []string{metrics.FlushedSegmentLabel, datapb.SegmentLevel_L1.String(), "unsorted", fmt.Sprint(storage.StorageV3), "parquet"}
+	assert.Equal(t, float64(1), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(importingUnknownLabels...)))
+
+	err = meta.UpdateSegmentsInfo(context.TODO(),
+		UpdateBinlogsOperator(1,
+			[]*datapb.FieldBinlog{
+				{
+					FieldID:     100,
+					ChildFields: []int64{100},
+					Format:      "parquet",
+					Binlogs: []*datapb.Binlog{
+						{LogID: 10, EntriesNum: 100, LogSize: 1000, MemorySize: 1000},
+					},
+				},
+			},
+			nil,
+			nil,
+			nil,
+		),
+		UpdateStatusOperator(1, commonpb.SegmentState_Flushed),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(0), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(importingUnknownLabels...)))
+	assert.Equal(t, float64(0), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(importingParquetLabels...)))
+	assert.Equal(t, float64(1), prometheustestutil.ToFloat64(metrics.DataCoordNumSegments.WithLabelValues(flushedParquetLabels...)))
 }
 
 func TestUpdateManifestVersion(t *testing.T) {

--- a/internal/datacoord/task_refresh_external_collection.go
+++ b/internal/datacoord/task_refresh_external_collection.go
@@ -447,6 +447,7 @@ func applyExternalCollectionSegmentUpdate(
 				incoming.GetLevel(),
 				incoming.GetIsSorted(),
 				incoming.GetStorageVersion(),
+				segmentMetricFormatLabel(segInfo),
 				incoming.GetNumOfRows(),
 			)
 

--- a/pkg/metrics/datacoord_metrics.go
+++ b/pkg/metrics/datacoord_metrics.go
@@ -53,6 +53,7 @@ var (
 			segmentLevelLabelName,
 			segmentIsSortedLabelName,
 			segmentStorageVersionLabelName,
+			segmentFormatLabelName,
 		})
 
 	// DataCoordCollectionNum records the num of collections managed by DataCoord.

--- a/pkg/metrics/datacoord_metrics_test.go
+++ b/pkg/metrics/datacoord_metrics_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDataCoordNumSegmentsWithStorageVersion(t *testing.T) {
+func TestDataCoordNumSegmentsWithStorageVersionAndFormat(t *testing.T) {
 	// Create a new registry to avoid conflicts with global metrics
 	registry := prometheus.NewRegistry()
 
@@ -40,33 +40,35 @@ func TestDataCoordNumSegmentsWithStorageVersion(t *testing.T) {
 			segmentLevelLabelName,
 			segmentIsSortedLabelName,
 			segmentStorageVersionLabelName,
+			segmentFormatLabelName,
 		})
 
 	registry.MustRegister(testGauge)
 
-	// Test with different storage versions
+	// Test with different storage versions and segment formats
 	testCases := []struct {
 		state          string
 		level          string
 		isSorted       string
 		storageVersion string
+		format         string
 		value          float64
 	}{
-		{"Flushed", "L1", "sorted", "0", 10},  // StorageV1
-		{"Flushed", "L1", "sorted", "2", 20},  // StorageV2
-		{"Flushed", "L2", "unsorted", "0", 5}, // StorageV1
-		{"Growing", "L0", "unsorted", "2", 3}, // StorageV2
+		{"Flushed", "L1", "sorted", "0", "legacy", 10},         // StorageV1
+		{"Flushed", "L1", "sorted", "2", "parquet", 20},        // StorageV2
+		{"Flushed", "L2", "unsorted", "0", "legacy", 5},        // StorageV1
+		{"Growing", "L0", "unsorted", "2", "iceberg-table", 3}, // StorageV2 external
 	}
 
 	for _, tc := range testCases {
-		testGauge.WithLabelValues(tc.state, tc.level, tc.isSorted, tc.storageVersion).Set(tc.value)
+		testGauge.WithLabelValues(tc.state, tc.level, tc.isSorted, tc.storageVersion, tc.format).Set(tc.value)
 	}
 
 	// Verify each metric value
 	for _, tc := range testCases {
-		value := testutil.ToFloat64(testGauge.WithLabelValues(tc.state, tc.level, tc.isSorted, tc.storageVersion))
-		assert.Equal(t, tc.value, value, "metric value should match for state=%s, level=%s, sorted=%s, version=%s",
-			tc.state, tc.level, tc.isSorted, tc.storageVersion)
+		value := testutil.ToFloat64(testGauge.WithLabelValues(tc.state, tc.level, tc.isSorted, tc.storageVersion, tc.format))
+		assert.Equal(t, tc.value, value, "metric value should match for state=%s, level=%s, sorted=%s, version=%s, format=%s",
+			tc.state, tc.level, tc.isSorted, tc.storageVersion, tc.format)
 	}
 
 	// Test DeletePartialMatch by storage version
@@ -74,24 +76,24 @@ func TestDataCoordNumSegmentsWithStorageVersion(t *testing.T) {
 	assert.Equal(t, 2, deleted, "should delete 2 metrics with StorageV1")
 
 	// Verify remaining metrics
-	value := testutil.ToFloat64(testGauge.WithLabelValues("Flushed", "L1", "sorted", "2"))
+	value := testutil.ToFloat64(testGauge.WithLabelValues("Flushed", "L1", "sorted", "2", "parquet"))
 	assert.Equal(t, float64(20), value, "StorageV2 metric should still exist")
 }
 
 func TestDataCoordNumSegmentsRegistration(t *testing.T) {
-	// Test that DataCoordNumSegments can be used with 4 labels including storage version
+	// Test that DataCoordNumSegments can be used with 5 labels including storage version and segment format
 	registry := prometheus.NewRegistry()
 	RegisterDataCoord(registry)
 
-	// This should not panic - using all 4 labels
-	DataCoordNumSegments.WithLabelValues("Flushed", "L1", "sorted", "0").Set(1)
-	DataCoordNumSegments.WithLabelValues("Growing", "L0", "unsorted", "2").Set(2)
+	// This should not panic - using all 5 labels
+	DataCoordNumSegments.WithLabelValues("Flushed", "L1", "sorted", "0", "legacy").Set(1)
+	DataCoordNumSegments.WithLabelValues("Growing", "L0", "unsorted", "2", "lance-table").Set(2)
 
 	// Verify values
-	value := testutil.ToFloat64(DataCoordNumSegments.WithLabelValues("Flushed", "L1", "sorted", "0"))
+	value := testutil.ToFloat64(DataCoordNumSegments.WithLabelValues("Flushed", "L1", "sorted", "0", "legacy"))
 	assert.Equal(t, float64(1), value)
 
-	value = testutil.ToFloat64(DataCoordNumSegments.WithLabelValues("Growing", "L0", "unsorted", "2"))
+	value = testutil.ToFloat64(DataCoordNumSegments.WithLabelValues("Growing", "L0", "unsorted", "2", "lance-table"))
 	assert.Equal(t, float64(2), value)
 
 	// Clean up
@@ -100,12 +102,12 @@ func TestDataCoordNumSegmentsRegistration(t *testing.T) {
 
 func TestDataCoordNumSegmentsLabelNames(t *testing.T) {
 	// Verify the metric has the expected number of labels
-	desc := DataCoordNumSegments.WithLabelValues("state", "level", "sorted", "version").Desc()
+	desc := DataCoordNumSegments.WithLabelValues("state", "level", "sorted", "version", "format").Desc()
 	assert.NotNil(t, desc)
 
-	// The metric should work with exactly 4 label values
+	// The metric should work with exactly 5 label values
 	assert.NotPanics(t, func() {
-		DataCoordNumSegments.WithLabelValues("Flushed", "L1", "sorted", "0").Inc()
+		DataCoordNumSegments.WithLabelValues("Flushed", "L1", "sorted", "0", "legacy").Inc()
 	})
 
 	// Clean up

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -121,6 +121,7 @@ const (
 	segmentLevelLabelName          = "segment_level"
 	segmentIsSortedLabelName       = "segment_is_sorted"
 	segmentStorageVersionLabelName = "segment_storage_version"
+	segmentFormatLabelName         = "segment_format"
 	usernameLabelName              = "username"
 	roleNameLabelName              = "role_name"
 	cacheNameLabelName             = "cache_name"

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5028,6 +5028,7 @@ type dataCoordConfig struct {
 	SingleCompactionDeltalogMaxNum    ParamItem `refreshable:"true"`
 
 	StorageVersionCompactionEnabled                   ParamItem `refreshable:"true"`
+	StorageFormatCompactionEnabled                    ParamItem `refreshable:"true"`
 	StorageVersionCompactionRateLimitTokens           ParamItem `refreshable:"true"`
 	StorageVersionCompactionRateLimitInterval         ParamItem `refreshable:"true"`
 	StorageVersionCompactionSessionVersionRequirement ParamItem `refreshable:"true"`
@@ -5592,6 +5593,15 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       false,
 	}
 	p.StorageVersionCompactionEnabled.Init(base.mgr)
+
+	p.StorageFormatCompactionEnabled = ParamItem{
+		Key:          "dataCoord.compaction.storageFormat.enabled",
+		Version:      "3.0.0",
+		DefaultValue: "true",
+		Doc:          "Enable storage format compaction",
+		Export:       false,
+	}
+	p.StorageFormatCompactionEnabled.Init(base.mgr)
 
 	p.StorageVersionCompactionRateLimitTokens = ParamItem{
 		Key:          "dataCoord.compaction.storageVersion.rateLimitTokens",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5597,7 +5597,7 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 	p.StorageFormatCompactionEnabled = ParamItem{
 		Key:          "dataCoord.compaction.storageFormat.enabled",
 		Version:      "3.0.0",
-		DefaultValue: "true",
+		DefaultValue: "false",
 		Doc:          "Enable storage format compaction",
 		Export:       false,
 	}

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -633,6 +633,7 @@ func TestComponentParam(t *testing.T) {
 		params.Save("dataCoord.compaction.dropTolerance", "100")
 		assert.Equal(t, float64(100), Params.CompactionDropToleranceInSeconds.GetAsDuration(time.Second).Seconds())
 		assert.Equal(t, int64(10000), Params.CompactionPreAllocateIDExpansionFactor.GetAsInt64())
+		assert.False(t, Params.StorageFormatCompactionEnabled.GetAsBool())
 
 		params.Save("dataCoord.compaction.clustering.enable", "true")
 		assert.Equal(t, true, Params.ClusteringCompactionEnable.GetAsBool())


### PR DESCRIPTION
#issue: #50182

Storage version compaction used to only care whether a segment had reached the target storage version. That is not enough once StorageV3 segments can still have different column-group formats, because a segment may already be V3 but still not match the format DataNode is configured to write. This change lets DataCoord use the same compaction path to refresh those segments by format as well.

The implementation adds a separate storage format compaction switch and enables the policy when either version or format compaction is turned on. For V3 segments, DataCoord now checks every field binlog format against the configured target format, schedules only the segments that actually need a rewrite, and keeps the existing health, L0, importing, compacting, and snapshot-protection filters in place. External collections are skipped so table-backed segments are not accidentally pulled into this internal rewrite flow.

Segment metrics now include a segment format label in addition to state, level, sorted status, and storage version. The metric update path also tracks format transitions when binlogs are added or rewritten, including legacy, unknown, and mixed-format cases, so DataCoord can report how storage formats are distributed while segments move through refresh and compaction.