### PR TITLE
fix: load nullable diskann valid data for stream index

### DIFF
--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -163,13 +163,16 @@ VectorDiskAnnIndex<T>::Load(milvus::tracer::TraceContext ctx,
             GetValueFromConfig<std::vector<std::string>>(config, "index_files");
         AssertInfo(index_files.has_value(),
                    "index file paths is empty when load disk ann index data");
-        // If index is loaded with stream, we don't need to cache index to disk
-        if (!index_.LoadIndexWithStream()) {
-            auto load_priority =
-                GetValueFromConfig<milvus::proto::common::LoadPriority>(
-                    config, milvus::LOAD_PRIORITY)
-                    .value_or(milvus::proto::common::LoadPriority::HIGH);
-            file_manager_->CacheIndexToDisk(index_files.value(), load_priority);
+        auto load_priority =
+            GetValueFromConfig<milvus::proto::common::LoadPriority>(
+                config, milvus::LOAD_PRIORITY)
+                .value_or(milvus::proto::common::LoadPriority::HIGH);
+        auto cache_files =
+            index_.LoadIndexWithStream()
+                ? FilterValidDataDiskFileSlices(index_files.value())
+                : index_files.value();
+        if (!cache_files.empty()) {
+            file_manager_->CacheIndexToDisk(cache_files, load_priority);
         }
         read_file_span->End();
     }

--- a/internal/core/src/index/VectorIndexValidDataUtils.h
+++ b/internal/core/src/index/VectorIndexValidDataUtils.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -33,6 +34,39 @@ namespace milvus::index {
 inline bool
 IsValidDataBinary(const std::string& name) {
     return name == VALID_DATA_COUNT_KEY || name == VALID_DATA_KEY;
+}
+
+inline std::string
+GetIndexFileName(const std::string& file) {
+    auto pos = file.find_last_of("/\\");
+    if (pos == std::string::npos) {
+        return file;
+    }
+    return file.substr(pos + 1);
+}
+
+inline bool
+IsValidDataDiskFileSlice(const std::string& file) {
+    const auto file_name = GetIndexFileName(file);
+    const std::string prefix = std::string(VALID_DATA_KEY) + "_";
+    if (file_name.size() <= prefix.size() ||
+        file_name.compare(0, prefix.size(), prefix) != 0) {
+        return false;
+    }
+    return std::all_of(file_name.begin() + prefix.size(),
+                       file_name.end(),
+                       [](char c) { return c >= '0' && c <= '9'; });
+}
+
+inline std::vector<std::string>
+FilterValidDataDiskFileSlices(const std::vector<std::string>& files) {
+    std::vector<std::string> valid_data_files;
+    for (const auto& file : files) {
+        if (IsValidDataDiskFileSlice(file)) {
+            valid_data_files.emplace_back(file);
+        }
+    }
+    return valid_data_files;
 }
 
 inline bool

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -52,6 +52,7 @@
 #include "gtest/gtest.h"
 #include "index/Meta.h"
 #include "knowhere/binaryset.h"
+#include "knowhere/index/index_factory.h"
 #include "knowhere/object.h"
 #include "knowhere/operands.h"
 #include "milvus-storage/filesystem/fs.h"
@@ -74,6 +75,7 @@
 #include "index/StringIndexMarisa.h"
 #include "index/StringIndexSort.h"
 #include "index/VectorDiskIndex.h"
+#include "index/VectorIndexValidDataUtils.h"
 
 class DiskAnnFileManagerTest_CacheOptFieldToDiskCorrectDOUBLE_Test;
 class DiskAnnFileManagerTest_CacheOptFieldToDiskCorrectFLOAT_Test;
@@ -379,13 +381,135 @@ TEST_F(DiskAnnFileManagerTest, TestThreadPoolException) {
 }
 
 namespace {
+class FileSliceSizeGuard {
+ public:
+    explicit FileSliceSizeGuard(int64_t slice_size)
+        : old_slice_size_(milvus::FILE_SLICE_SIZE.load()) {
+        milvus::FILE_SLICE_SIZE.store(slice_size);
+    }
+
+    ~FileSliceSizeGuard() {
+        milvus::FILE_SLICE_SIZE.store(old_slice_size_);
+    }
+
+ private:
+    int64_t old_slice_size_;
+};
+
 const int64_t kOptFieldId = 123456;
 const std::string kOptFieldName = "opt_field_name";
 const int64_t kOptFieldDataRange = 1000;
+const char* kStreamLoadTestIndexType = "STREAM_LOAD_TEST_DISKANN";
 // kOptFieldPath computed inline to avoid static initialization order issue
 const size_t kEntityCnt = 1000 * 10;
 const FieldDataMeta kOptVecFieldDataMeta = {1, 2, 3, 100};
 using OffsetT = uint32_t;
+
+class StreamLoadTestIndexNode : public knowhere::IndexNode {
+ public:
+    explicit StreamLoadTestIndexNode(const int32_t& version,
+                                     const knowhere::Object& object)
+        : knowhere::IndexNode(version) {
+    }
+
+    knowhere::Status
+    Train(const knowhere::DataSetPtr dataset,
+          std::shared_ptr<knowhere::Config> cfg,
+          bool use_knowhere_build_pool = true) override {
+        return knowhere::Status::success;
+    }
+
+    knowhere::Status
+    Add(const knowhere::DataSetPtr dataset,
+        std::shared_ptr<knowhere::Config> cfg,
+        bool use_knowhere_build_pool = true) override {
+        return knowhere::Status::success;
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    Search(const knowhere::DataSetPtr dataset,
+           std::unique_ptr<knowhere::Config> cfg,
+           const knowhere::BitsetView& bitset,
+           milvus::OpContext* op_context = nullptr) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(
+            knowhere::Status::not_implemented, "not implemented");
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    GetVectorByIds(const knowhere::DataSetPtr dataset,
+                   milvus::OpContext* op_context = nullptr) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(
+            knowhere::Status::not_implemented, "not implemented");
+    }
+
+    bool
+    HasRawData(const std::string& metric_type) const override {
+        return false;
+    }
+
+    knowhere::expected<knowhere::DataSetPtr>
+    GetIndexMeta(std::unique_ptr<knowhere::Config> cfg) const override {
+        return knowhere::expected<knowhere::DataSetPtr>::Err(
+            knowhere::Status::not_implemented, "not implemented");
+    }
+
+    knowhere::Status
+    Serialize(knowhere::BinarySet& binset) const override {
+        return knowhere::Status::success;
+    }
+
+    knowhere::Status
+    Deserialize(const knowhere::BinarySet& binset,
+                std::shared_ptr<knowhere::Config> config) override {
+        return knowhere::Status::success;
+    }
+
+    knowhere::Status
+    DeserializeFromFile(const std::string& filename,
+                        std::shared_ptr<knowhere::Config> config) override {
+        return knowhere::Status::success;
+    }
+
+    std::unique_ptr<knowhere::BaseConfig>
+    CreateConfig() const override {
+        return std::make_unique<knowhere::BaseConfig>();
+    }
+
+    int64_t
+    Dim() const override {
+        return 128;
+    }
+
+    int64_t
+    Size() const override {
+        return 0;
+    }
+
+    int64_t
+    Count() const override {
+        return 0;
+    }
+
+    std::string
+    Type() const override {
+        return kStreamLoadTestIndexType;
+    }
+
+    bool
+    LoadIndexWithStream() override {
+        return true;
+    }
+};
+
+[[maybe_unused]] const knowhere::IndexFactory& kStreamLoadTestIndexFactory =
+    knowhere::IndexFactory::Instance().Register<knowhere::fp32>(
+        kStreamLoadTestIndexType,
+        [](const int32_t& version, const knowhere::Object& object) {
+            auto index = knowhere::Index<StreamLoadTestIndexNode>::Create(
+                version, object);
+            return knowhere::Index<knowhere::IndexNode>(std::move(index));
+        },
+        knowhere::feature::FLOAT32 | knowhere::feature::DISK);
 
 auto
 CreateFileManager(const ChunkManagerPtr& cm,
@@ -521,6 +645,203 @@ CheckOptFieldCorrectness(
     }
 }
 }  // namespace
+
+TEST_F(DiskAnnFileManagerTest, FilterValidDataDiskFileSlices) {
+    std::vector<std::string> files = {"/remote/index/valid_data_0",
+                                      "valid_data_12",
+                                      "/remote/index/valid_data",
+                                      "/remote/index/valid_data_x",
+                                      "/remote/index/not_valid_data_0",
+                                      "/remote/index/_mem.index.bin",
+                                      "/remote/index/valid_data_0_extra",
+                                      "/remote/index/valid_data_"};
+
+    auto filtered = milvus::index::FilterValidDataDiskFileSlices(files);
+
+    ASSERT_EQ(filtered.size(), 2);
+    EXPECT_EQ(filtered[0], "/remote/index/valid_data_0");
+    EXPECT_EQ(filtered[1], "valid_data_12");
+}
+
+TEST_F(DiskAnnFileManagerTest, CacheValidDataDiskFileSlices) {
+    auto file_manager = CreateFileManager(cm_, fs_);
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    auto local_index_prefix = file_manager->GetLocalIndexObjectPrefix();
+    if (local_chunk_manager->Exist(local_index_prefix)) {
+        local_chunk_manager->RemoveDir(local_index_prefix);
+    }
+    local_chunk_manager->CreateDir(local_index_prefix);
+
+    auto valid_data_path =
+        local_index_prefix + "/" + milvus::index::VALID_DATA_KEY;
+    std::vector<uint8_t> payload = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    local_chunk_manager->CreateFile(valid_data_path);
+    local_chunk_manager->Write(valid_data_path, payload.data(), payload.size());
+
+    ASSERT_TRUE(file_manager->AddFile(valid_data_path));
+    auto remote_paths_to_size = file_manager->GetRemotePathsToFileSize();
+    std::vector<std::string> remote_files;
+    remote_files.reserve(remote_paths_to_size.size());
+    for (const auto& entry : remote_paths_to_size) {
+        remote_files.emplace_back(entry.first);
+    }
+
+    auto valid_data_files =
+        milvus::index::FilterValidDataDiskFileSlices(remote_files);
+    ASSERT_EQ(valid_data_files.size(), remote_files.size());
+
+    local_chunk_manager->Remove(valid_data_path);
+    ASSERT_FALSE(local_chunk_manager->Exist(valid_data_path));
+
+    file_manager->CacheIndexToDisk(valid_data_files,
+                                   milvus::proto::common::LoadPriority::HIGH);
+
+    ASSERT_TRUE(local_chunk_manager->Exist(valid_data_path));
+    ASSERT_EQ(local_chunk_manager->Size(valid_data_path), payload.size());
+    std::vector<uint8_t> read_payload(payload.size());
+    local_chunk_manager->Read(
+        valid_data_path, read_payload.data(), read_payload.size());
+    EXPECT_EQ(read_payload, payload);
+
+    local_chunk_manager->Remove(valid_data_path);
+    for (const auto& remote_file : remote_files) {
+        cm_->Remove(remote_file);
+    }
+}
+
+TEST_F(DiskAnnFileManagerTest, CacheValidDataMultipleDiskFileSlices) {
+    FileSliceSizeGuard slice_size_guard(4);
+
+    auto file_manager = CreateFileManager(cm_, fs_);
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    auto local_index_prefix = file_manager->GetLocalIndexObjectPrefix();
+    if (local_chunk_manager->Exist(local_index_prefix)) {
+        local_chunk_manager->RemoveDir(local_index_prefix);
+    }
+    local_chunk_manager->CreateDir(local_index_prefix);
+
+    auto valid_data_path =
+        local_index_prefix + "/" + milvus::index::VALID_DATA_KEY;
+    std::vector<uint8_t> payload(45);
+    for (size_t i = 0; i < payload.size(); ++i) {
+        payload[i] = static_cast<uint8_t>(i);
+    }
+    local_chunk_manager->CreateFile(valid_data_path);
+    local_chunk_manager->Write(valid_data_path, payload.data(), payload.size());
+
+    ASSERT_TRUE(file_manager->AddFile(valid_data_path));
+    auto remote_paths_to_size = file_manager->GetRemotePathsToFileSize();
+    ASSERT_EQ(remote_paths_to_size.size(), 12);
+
+    std::vector<std::string> remote_files;
+    remote_files.reserve(remote_paths_to_size.size());
+    for (const auto& entry : remote_paths_to_size) {
+        remote_files.emplace_back(entry.first);
+    }
+
+    auto valid_data_files =
+        milvus::index::FilterValidDataDiskFileSlices(remote_files);
+    ASSERT_EQ(valid_data_files.size(), remote_files.size());
+    std::reverse(valid_data_files.begin(), valid_data_files.end());
+
+    local_chunk_manager->Remove(valid_data_path);
+    ASSERT_FALSE(local_chunk_manager->Exist(valid_data_path));
+
+    file_manager->CacheIndexToDisk(valid_data_files,
+                                   milvus::proto::common::LoadPriority::HIGH);
+
+    ASSERT_TRUE(local_chunk_manager->Exist(valid_data_path));
+    ASSERT_EQ(local_chunk_manager->Size(valid_data_path), payload.size());
+    std::vector<uint8_t> read_payload(payload.size());
+    local_chunk_manager->Read(
+        valid_data_path, read_payload.data(), read_payload.size());
+    EXPECT_EQ(read_payload, payload);
+
+    local_chunk_manager->Remove(valid_data_path);
+    for (const auto& remote_file : remote_files) {
+        cm_->Remove(remote_file);
+    }
+}
+
+TEST_F(DiskAnnFileManagerTest, LoadStreamIndexCachesOnlyValidDataSidecar) {
+    FileSliceSizeGuard slice_size_guard(64);
+
+    constexpr int64_t total_count = 3000;
+    constexpr int64_t valid_count = 2400;
+
+    FieldDataMeta field_data_meta = {1, 2, 3003, 100};
+    field_data_meta.field_schema.set_nullable(true);
+    IndexMeta index_meta = {
+        3003, 100, 1000, 1, "test", "vec_field", DataType::VECTOR_FLOAT, 128};
+    storage::FileManagerContext file_manager_context(
+        field_data_meta, index_meta, cm_, fs_);
+    auto file_manager =
+        std::make_shared<DiskFileManagerImpl>(file_manager_context);
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    auto local_index_prefix = file_manager->GetLocalIndexObjectPrefix();
+
+    if (local_chunk_manager->Exist(local_index_prefix)) {
+        local_chunk_manager->RemoveDir(local_index_prefix);
+    }
+    local_chunk_manager->CreateDir(local_index_prefix);
+
+    auto valid_data_path =
+        local_index_prefix + "/" + milvus::index::VALID_DATA_KEY;
+    auto wire_count = milvus::index::ToValidDataCount(total_count);
+    auto bitmap_size = milvus::index::GetValidDataBitmapSize(total_count);
+    std::vector<uint8_t> valid_data(sizeof(uint64_t) + bitmap_size, 0);
+    std::memcpy(valid_data.data(), &wire_count, sizeof(uint64_t));
+    for (int64_t i = 0; i < total_count; ++i) {
+        if (i % 5 != 0) {
+            valid_data[sizeof(uint64_t) + i / 8] |= (1 << (i % 8));
+        }
+    }
+    local_chunk_manager->CreateFile(valid_data_path);
+    local_chunk_manager->Write(
+        valid_data_path, valid_data.data(), valid_data.size());
+
+    ASSERT_TRUE(file_manager->AddFile(valid_data_path));
+    auto remote_paths_to_size = file_manager->GetRemotePathsToFileSize();
+    ASSERT_EQ(remote_paths_to_size.size(), (valid_data.size() + 63) / 64);
+    ASSERT_GT(remote_paths_to_size.size(), 1);
+    std::vector<std::string> index_files = {"remote/index/_mem.index.bin"};
+    for (const auto& remote_path_to_size : remote_paths_to_size) {
+        index_files.emplace_back(remote_path_to_size.first);
+    }
+    ASSERT_EQ(milvus::index::FilterValidDataDiskFileSlices(index_files).size(),
+              remote_paths_to_size.size());
+
+    local_chunk_manager->Remove(valid_data_path);
+    ASSERT_FALSE(local_chunk_manager->Exist(valid_data_path));
+
+    milvus::index::VectorDiskAnnIndex<float> loaded_index(
+        DataType::NONE,
+        kStreamLoadTestIndexType,
+        knowhere::metric::L2,
+        knowhere::Version::GetCurrentVersion().VersionNumber(),
+        file_manager_context);
+
+    milvus::Config load_config;
+    load_config[DIM_KEY] = 128;
+    load_config["index_files"] = index_files;
+    loaded_index.Load(milvus::tracer::TraceContext{}, load_config);
+
+    EXPECT_FALSE(
+        local_chunk_manager->Exist(local_index_prefix + "/_mem.index.bin"));
+    ASSERT_TRUE(local_chunk_manager->Exist(valid_data_path));
+    ASSERT_TRUE(loaded_index.GetOffsetMapping().IsEnabled());
+    EXPECT_EQ(loaded_index.GetOffsetMapping().GetTotalCount(), total_count);
+    EXPECT_EQ(loaded_index.GetOffsetMapping().GetValidCount(), valid_count);
+    EXPECT_EQ(loaded_index.GetDim(), 128);
+
+    local_chunk_manager->Remove(valid_data_path);
+    for (const auto& remote_path_to_size : remote_paths_to_size) {
+        cm_->Remove(remote_path_to_size.first);
+    }
+}
 
 TEST_F(DiskAnnFileManagerTest, CacheOptFieldToDiskOptFieldMoreThanOne) {
     auto file_manager = CreateFileManager(cm_, fs_);


### PR DESCRIPTION
## Summary
- Cache nullable vector `valid_data_*` sidecar files when DiskANN index loading uses the stream path.
- Keep non-stream DiskANN loading unchanged and avoid caching stream-loaded main index files such as `_mem.index.bin`.
- Add focused coverage for stream-mode `VectorDiskAnnIndex::Load()` and valid-data sidecar filtering/reconstruction.

issue: #50282

## Test plan
- [x] `jobs=4 env bash scripts/core_build.sh -u`
- [x] `make run-test-cpp filter=DiskAnnFileManagerTest.LoadStreamIndexCachesOnlyValidDataSidecar:DiskAnnFileManagerTest.FilterValidDataDiskFileSlices:DiskAnnFileManagerTest.CacheValidDataDiskFileSlices`
- [x] `make cppcheck`
- [x] `git diff --check`
- [x] Local e2e on v2.6.18/Cardinal stream load: without this fix reproduced `bitset size: 3000, data count: 2400`; with this fix the same nullable-vector range search returned `search_ok nq=1, hits=10`.
