### PR TITLE
enhance: Reduce copy segment log noise

### DIFF
--- a/internal/datacoord/copy_segment_checker.go
+++ b/internal/datacoord/copy_segment_checker.go
@@ -196,8 +196,7 @@ func (c *copySegmentChecker) Close() {
 
 // LogJobStats reports job statistics grouped by state.
 //
-// This logs the count of jobs in each state and reports metrics for monitoring.
-// Called on every checker tick to provide visibility into job progress.
+// This reports metrics on every checker tick and logs non-empty job stats.
 //
 // Metrics reported:
 //   - CopySegmentJobs gauge with state label
@@ -218,13 +217,14 @@ func (c *copySegmentChecker) LogJobStats(jobs []CopySegmentJob) {
 		stateNum[state] = num
 		metrics.CopySegmentJobs.WithLabelValues(state).Set(float64(num))
 	}
-	log.Info("copy segment job stats", zap.Any("stateNum", stateNum))
+	if len(jobs) > 0 {
+		log.Info("copy segment job stats", zap.Any("stateNum", stateNum))
+	}
 }
 
 // LogTaskStats reports task statistics grouped by state.
 //
-// This logs the count of tasks in each state and reports metrics for monitoring.
-// Called on every checker tick to provide visibility into task execution.
+// This reports metrics on every checker tick and logs non-empty task stats.
 //
 // Metrics reported:
 //   - CopySegmentTasks gauge with state label
@@ -244,15 +244,17 @@ func (c *copySegmentChecker) LogTaskStats() {
 	completed := len(byState[datapb.CopySegmentTaskState_CopySegmentTaskCompleted])
 	failed := len(byState[datapb.CopySegmentTaskState_CopySegmentTaskFailed])
 
-	log.Info("copy segment task stats",
-		zap.Int("pending", pending), zap.Int("inProgress", inProgress),
-		zap.Int("completed", completed), zap.Int("failed", failed))
-
 	// Report metrics
 	metrics.CopySegmentTasks.WithLabelValues(datapb.CopySegmentTaskState_CopySegmentTaskPending.String()).Set(float64(pending))
 	metrics.CopySegmentTasks.WithLabelValues(datapb.CopySegmentTaskState_CopySegmentTaskInProgress.String()).Set(float64(inProgress))
 	metrics.CopySegmentTasks.WithLabelValues(datapb.CopySegmentTaskState_CopySegmentTaskCompleted.String()).Set(float64(completed))
 	metrics.CopySegmentTasks.WithLabelValues(datapb.CopySegmentTaskState_CopySegmentTaskFailed.String()).Set(float64(failed))
+
+	if len(tasks) > 0 {
+		log.Info("copy segment task stats",
+			zap.Int("pending", pending), zap.Int("inProgress", inProgress),
+			zap.Int("completed", completed), zap.Int("failed", failed))
+	}
 }
 
 // ============================================================================

--- a/internal/datacoord/copy_segment_inspector.go
+++ b/internal/datacoord/copy_segment_inspector.go
@@ -263,7 +263,7 @@ func (s *copySegmentInspector) processPending(task CopySegmentTask) {
 //  1. Iterate through all segment ID mappings in the task
 //  2. For each target segment:
 //     a. Retrieve segment metadata
-//     b. Mark segment as Dropped if it exists
+//     b. Mark segment as Dropped if it exists and is not already Dropped
 //     c. Log success/failure of drop operation
 //
 // Why drop target segments:
@@ -279,16 +279,18 @@ func (s *copySegmentInspector) processFailed(task CopySegmentTask) {
 	for _, mapping := range task.GetIdMappings() {
 		targetSegID := mapping.GetTargetSegmentId()
 		segment := s.meta.GetSegment(s.ctx, targetSegID)
-		if segment != nil {
-			op := UpdateStatusOperator(targetSegID, commonpb.SegmentState_Dropped)
-			err := s.meta.UpdateSegmentsInfo(s.ctx, op)
-			if err != nil {
-				log.Warn("failed to drop target segment after copy task failed",
-					WrapCopySegmentTaskLog(task, zap.Int64("segmentID", targetSegID), zap.Error(err))...)
-			} else {
-				log.Info("dropped target segment after copy task failed",
-					WrapCopySegmentTaskLog(task, zap.Int64("segmentID", targetSegID))...)
-			}
+		if segment == nil || segment.GetState() == commonpb.SegmentState_Dropped {
+			continue
+		}
+
+		op := UpdateStatusOperator(targetSegID, commonpb.SegmentState_Dropped)
+		err := s.meta.UpdateSegmentsInfo(s.ctx, op)
+		if err != nil {
+			log.Warn("failed to drop target segment after copy task failed",
+				WrapCopySegmentTaskLog(task, zap.Int64("segmentID", targetSegID), zap.Error(err))...)
+		} else {
+			log.Info("dropped target segment after copy task failed",
+				WrapCopySegmentTaskLog(task, zap.Int64("segmentID", targetSegID))...)
 		}
 	}
 }

--- a/internal/datacoord/copy_segment_inspector_test.go
+++ b/internal/datacoord/copy_segment_inspector_test.go
@@ -245,6 +245,16 @@ func (s *CopySegmentInspectorSuite) TestProcessFailed_DropTargetSegments() {
 	err := s.meta.AddSegment(context.TODO(), seg1)
 	s.NoError(err)
 
+	seg2 := NewSegmentInfo(&datapb.SegmentInfo{
+		ID:            102,
+		CollectionID:  s.collectionID,
+		PartitionID:   10,
+		State:         commonpb.SegmentState_Dropped,
+		NumOfRows:     100,
+		InsertChannel: "ch1",
+	})
+	s.meta.segments.SetSegment(seg2.GetID(), seg2)
+
 	// Create a job
 	job := &copySegmentJob{
 		CopySegmentJob: &datapb.CopySegmentJob{
@@ -260,6 +270,7 @@ func (s *CopySegmentInspectorSuite) TestProcessFailed_DropTargetSegments() {
 	// Create a failed task with target segment
 	idMappings := []*datapb.CopySegmentIDMapping{
 		{SourceSegmentId: 1, TargetSegmentId: 101, PartitionId: 10},
+		{SourceSegmentId: 2, TargetSegmentId: 102, PartitionId: 10},
 	}
 
 	task := &copySegmentTask{
@@ -284,6 +295,9 @@ func (s *CopySegmentInspectorSuite) TestProcessFailed_DropTargetSegments() {
 	// Target segment should be marked as Dropped
 	segment := s.meta.GetSegment(context.TODO(), 101)
 	s.Equal(commonpb.SegmentState_Dropped, segment.GetState())
+
+	droppedSegment := s.meta.GetSegment(context.TODO(), 102)
+	s.Equal(commonpb.SegmentState_Dropped, droppedSegment.GetState())
 }
 
 func (s *CopySegmentInspectorSuite) TestProcessFailed_NoTargetSegment() {

--- a/internal/datacoord/copy_segment_task.go
+++ b/internal/datacoord/copy_segment_task.go
@@ -377,12 +377,13 @@ func (t *copySegmentTask) markTaskAndJobFailed(reason string) {
 // Process flow:
 //  1. Send QueryCopySegmentRequest to assigned DataNode
 //  2. Check response state:
-//     - Not Completed: Mark task/job as failed (fail-fast)
+//     - In progress or other non-terminal states: keep polling later
+//     - Failed: Mark task/job as failed (fail-fast)
 //     - Completed: Sync binlog and index metadata to segment
 //  3. Update task state accordingly
 //
 // Failure handling:
-// - Any error or non-completed state triggers immediate failure
+// - RPC errors and worker failure responses trigger immediate failure
 // - Task failure immediately marks parent job as failed (fail-fast)
 // - Enables quick feedback to user without waiting for timeout
 //
@@ -415,8 +416,6 @@ func (t *copySegmentTask) QueryTaskOnWorker(cluster session.Cluster) {
 	}
 
 	if resp.GetState() != datapb.CopySegmentTaskState_CopySegmentTaskCompleted {
-		log.Info("copy segment task not completed",
-			WrapCopySegmentTaskLog(t, zap.String("state", resp.GetState().String()))...)
 		return
 	}
 
@@ -617,9 +616,16 @@ func AssembleCopySegmentRequest(task CopySegmentTask, job CopySegmentJob) (*data
 			NewBuildIds:  newBuildIDs,
 		}
 		log.Info("prepare copy segment source and target",
-			zap.Any("source", sourceSegDesc),
-			zap.Any("target", target),
-			zap.Any("newBuildIDs", newBuildIDs))
+			WrapCopySegmentTaskLog(task,
+				zap.Int64("sourceCollectionID", source.GetCollectionId()),
+				zap.Int64("sourcePartitionID", source.GetPartitionId()),
+				zap.Int64("sourceSegmentID", source.GetSegmentId()),
+				zap.Int64("targetCollectionID", target.GetCollectionId()),
+				zap.Int64("targetPartitionID", target.GetPartitionId()),
+				zap.Int64("targetSegmentID", target.GetSegmentId()),
+				zap.Int("newBuildIDCount", len(newBuildIDs)),
+				zap.Bool("hasManifestPath", source.GetManifestPath() != ""),
+				zap.Int64("storageVersion", source.GetStorageVersion()))...)
 		targets = append(targets, target)
 	}
 
@@ -735,7 +741,9 @@ func SyncCopySegmentTask(task CopySegmentTask, resp *datapb.QueryCopySegmentResp
 
 			log.Info("update copy segment info done",
 				WrapCopySegmentTaskLog(task, zap.Int64("segmentID", result.GetSegmentId()),
-					zap.Any("segmentResult", result))...)
+					zap.Int64("importedRows", result.GetImportedRows()),
+					zap.Int("binlogFields", len(result.GetBinlogs())),
+					zap.Bool("hasManifestPath", result.GetManifestPath() != ""))...)
 		}
 
 		// Mark task as completed and record copying duration

--- a/internal/datacoord/copy_segment_task_test.go
+++ b/internal/datacoord/copy_segment_task_test.go
@@ -31,7 +31,9 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/datacoord/allocator"
+	"github.com/milvus-io/milvus/internal/datacoord/session"
 	"github.com/milvus-io/milvus/internal/metastore"
+	kvdatacoord "github.com/milvus-io/milvus/internal/metastore/kv/datacoord"
 	catalogmocks "github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/internal/metastore/model"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -466,6 +468,206 @@ func (s *CopySegmentTaskSuite) TestTaskType() {
 	s.Equal(taskcommon.CopySegment, task.GetTaskType())
 }
 
+func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_NotCompletedKeepsTaskInProgress() {
+	cluster := &struct{ session.Cluster }{}
+	mockQuery := mockey.Mock((*struct{ session.Cluster }).QueryCopySegment).Return(
+		&datapb.QueryCopySegmentResponse{
+			TaskID: 1001,
+			State:  datapb.CopySegmentTaskState_CopySegmentTaskInProgress,
+		},
+		nil,
+	).Build()
+	defer mockQuery.UnPatch()
+
+	task := &copySegmentTask{
+		tr:    timerecord.NewTimeRecorder("test"),
+		times: taskcommon.NewTimes(),
+	}
+	task.task.Store(&datapb.CopySegmentTask{
+		TaskId:       1001,
+		JobId:        100,
+		CollectionId: 100,
+		NodeId:       10,
+		State:        datapb.CopySegmentTaskState_CopySegmentTaskInProgress,
+	})
+
+	task.QueryTaskOnWorker(cluster)
+
+	s.Equal(datapb.CopySegmentTaskState_CopySegmentTaskInProgress, task.GetState())
+}
+
+func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_MarksFailedOnRPCError() {
+	cluster := &struct{ session.Cluster }{}
+	mockQuery := mockey.Mock((*struct{ session.Cluster }).QueryCopySegment).Return(
+		nil,
+		errors.New("rpc failed"),
+	).Build()
+	defer mockQuery.UnPatch()
+
+	task := createTestCopyTask(100, 2001).(*copySegmentTask)
+	copyMeta, _ := newCopySegmentTaskTestMeta(s.T(), task)
+
+	task.QueryTaskOnWorker(cluster)
+
+	updatedTask := copyMeta.GetTask(context.Background(), 1001)
+	s.Equal(datapb.CopySegmentTaskState_CopySegmentTaskFailed, updatedTask.GetState())
+	s.Contains(updatedTask.GetReason(), "rpc failed")
+}
+
+func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_MarksFailedOnWorkerFailure() {
+	cluster := &struct{ session.Cluster }{}
+	mockQuery := mockey.Mock((*struct{ session.Cluster }).QueryCopySegment).Return(
+		&datapb.QueryCopySegmentResponse{
+			TaskID: 1001,
+			State:  datapb.CopySegmentTaskState_CopySegmentTaskFailed,
+			Reason: "worker failed",
+		},
+		nil,
+	).Build()
+	defer mockQuery.UnPatch()
+
+	task := createTestCopyTask(100, 2001).(*copySegmentTask)
+	copyMeta, _ := newCopySegmentTaskTestMeta(s.T(), task)
+
+	task.QueryTaskOnWorker(cluster)
+
+	updatedTask := copyMeta.GetTask(context.Background(), 1001)
+	s.Equal(datapb.CopySegmentTaskState_CopySegmentTaskFailed, updatedTask.GetState())
+	s.Equal("worker failed", updatedTask.GetReason())
+}
+
+func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_CompletedSyncsTask() {
+	cluster := &struct{ session.Cluster }{}
+	mockQuery := mockey.Mock((*struct{ session.Cluster }).QueryCopySegment).Return(
+		&datapb.QueryCopySegmentResponse{
+			TaskID: 1001,
+			State:  datapb.CopySegmentTaskState_CopySegmentTaskCompleted,
+			SegmentResults: []*datapb.CopySegmentResult{
+				{
+					SegmentId:    2001,
+					ImportedRows: 100,
+					Binlogs:      makeTestCopySegmentBinlogs(),
+					ManifestPath: "manifest-path",
+				},
+			},
+		},
+		nil,
+	).Build()
+	defer mockQuery.UnPatch()
+
+	task := createTestCopyTask(100, 2001).(*copySegmentTask)
+	copyMeta, m := newCopySegmentTaskTestMeta(s.T(), task)
+	err := m.AddSegment(context.Background(), newTestCopySegment(2001))
+	s.NoError(err)
+
+	task.QueryTaskOnWorker(cluster)
+
+	segment := m.GetSegment(context.Background(), 2001)
+	s.Equal(commonpb.SegmentState_Flushed, segment.GetState())
+	s.Equal("manifest-path", segment.GetManifestPath())
+
+	updatedTask := copyMeta.GetTask(context.Background(), 1001)
+	s.Equal(datapb.CopySegmentTaskState_CopySegmentTaskCompleted, updatedTask.GetState())
+}
+
+func (s *CopySegmentTaskSuite) TestSyncCopySegmentTask_CompletedUpdatesSegment() {
+	ctx := context.Background()
+	task := createTestCopyTask(100, 2001).(*copySegmentTask)
+	copyMeta, m := newCopySegmentTaskTestMeta(s.T(), task)
+
+	err := m.AddSegment(ctx, newTestCopySegment(2001))
+	s.NoError(err)
+
+	insertBinlogs := makeTestCopySegmentBinlogs()
+	resp := &datapb.QueryCopySegmentResponse{
+		TaskID: 1001,
+		State:  datapb.CopySegmentTaskState_CopySegmentTaskCompleted,
+		SegmentResults: []*datapb.CopySegmentResult{
+			{
+				SegmentId:    2001,
+				ImportedRows: 100,
+				Binlogs:      insertBinlogs,
+				ManifestPath: "manifest-path",
+			},
+		},
+	}
+
+	err = SyncCopySegmentTask(task, resp, copyMeta, m)
+	s.NoError(err)
+
+	segment := m.GetSegment(ctx, 2001)
+	s.Equal(commonpb.SegmentState_Flushed, segment.GetState())
+	s.Equal("manifest-path", segment.GetManifestPath())
+	s.Equal(insertBinlogs, segment.GetBinlogs())
+
+	updatedTask := copyMeta.GetTask(ctx, 1001)
+	s.Equal(datapb.CopySegmentTaskState_CopySegmentTaskCompleted, updatedTask.GetState())
+	s.NotZero(updatedTask.(*copySegmentTask).task.Load().GetCompleteTs())
+}
+
+func (s *CopySegmentTaskSuite) TestSyncCopySegmentTask_FailedResponseUpdatesTask() {
+	ctx := context.Background()
+	task := createTestCopyTask(100, 2001).(*copySegmentTask)
+	copyMeta, _ := newCopySegmentTaskTestMeta(s.T(), task)
+
+	err := SyncCopySegmentTask(task, &datapb.QueryCopySegmentResponse{
+		TaskID: 1001,
+		State:  datapb.CopySegmentTaskState_CopySegmentTaskFailed,
+		Reason: "worker failed",
+	}, copyMeta, nil)
+	s.NoError(err)
+
+	updatedTask := copyMeta.GetTask(ctx, 1001)
+	s.Equal(datapb.CopySegmentTaskState_CopySegmentTaskFailed, updatedTask.GetState())
+	s.Equal("worker failed", updatedTask.GetReason())
+}
+
+func (s *CopySegmentTaskSuite) TestSyncCopySegmentTask_DefaultStateNoop() {
+	ctx := context.Background()
+	task := createTestCopyTask(100, 2001).(*copySegmentTask)
+	copyMeta, _ := newCopySegmentTaskTestMeta(s.T(), task)
+
+	err := SyncCopySegmentTask(task, &datapb.QueryCopySegmentResponse{
+		TaskID: 1001,
+		State:  datapb.CopySegmentTaskState_CopySegmentTaskInProgress,
+	}, copyMeta, nil)
+	s.NoError(err)
+
+	updatedTask := copyMeta.GetTask(ctx, 1001)
+	s.Equal(datapb.CopySegmentTaskState_CopySegmentTaskInProgress, updatedTask.GetState())
+}
+
+func (s *CopySegmentTaskSuite) TestSyncCopySegmentTask_UpdateSegmentsInfoErrorMarksFailed() {
+	ctx := context.Background()
+	task := createTestCopyTask(100, 2001).(*copySegmentTask)
+	copyMeta, m := newCopySegmentTaskTestMeta(s.T(), task)
+	err := m.AddSegment(ctx, newTestCopySegment(2001))
+	s.NoError(err)
+
+	err = SyncCopySegmentTask(task, &datapb.QueryCopySegmentResponse{
+		TaskID: 1001,
+		State:  datapb.CopySegmentTaskState_CopySegmentTaskCompleted,
+		SegmentResults: []*datapb.CopySegmentResult{
+			{
+				SegmentId: 2001,
+				Binlogs: []*datapb.FieldBinlog{
+					{
+						FieldID: 100,
+						Binlogs: []*datapb.Binlog{
+							{LogID: 1, LogPath: "invalid-log-path"},
+						},
+					},
+				},
+			},
+		},
+	}, copyMeta, m)
+	s.Error(err)
+
+	updatedTask := copyMeta.GetTask(ctx, 1001)
+	s.Equal(datapb.CopySegmentTaskState_CopySegmentTaskFailed, updatedTask.GetState())
+	s.Contains(updatedTask.GetReason(), "fieldBinlog no need to store logpath")
+}
+
 // createTestIndexMeta creates an indexMeta with pre-registered index definitions for testing.
 // If catalog is nil, a default mock catalog (CreateSegmentIndex returns nil) is used.
 func createTestIndexMeta(t *testing.T, collectionID int64, indexes map[int64]*model.Index, catalog ...metastore.DataCoordCatalog) *indexMeta {
@@ -505,6 +707,41 @@ func createTestCopyTask(collectionID int64, segmentID int64) CopySegmentTask {
 		},
 	})
 	return task
+}
+
+func newCopySegmentTaskTestMeta(t *testing.T, task *copySegmentTask) (CopySegmentMeta, *meta) {
+	ctx := context.Background()
+	catalog := kvdatacoord.NewCatalog(NewMetaMemoryKV(), "", "")
+	m := &meta{
+		catalog:  catalog,
+		segments: NewSegmentsInfo(),
+	}
+	copyMeta, err := NewCopySegmentMeta(ctx, catalog, m, nil, nil)
+	assert.NoError(t, err)
+	assert.NoError(t, copyMeta.AddTask(ctx, task))
+	return copyMeta, m
+}
+
+func newTestCopySegment(segmentID int64) *SegmentInfo {
+	return NewSegmentInfo(&datapb.SegmentInfo{
+		ID:            segmentID,
+		CollectionID:  100,
+		PartitionID:   10,
+		State:         commonpb.SegmentState_Importing,
+		NumOfRows:     100,
+		InsertChannel: "ch1",
+	})
+}
+
+func makeTestCopySegmentBinlogs() []*datapb.FieldBinlog {
+	return []*datapb.FieldBinlog{
+		{
+			FieldID: 100,
+			Binlogs: []*datapb.Binlog{
+				{LogID: 1, EntriesNum: 100},
+			},
+		},
+	}
 }
 
 func (s *CopySegmentTaskSuite) TestSyncVectorScalarIndexes_EmptyResult() {


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/50291

## What changed

This PR reduces noisy copy segment restore logs by:

- suppressing empty copy segment job/task checker stats logs;
- removing the per-poll `copy segment task not completed` log;
- skipping failed-task cleanup for target segments already Dropped;
- replacing full copy segment source/target/result payload logs with compact ids
  and counters.

## Why

Copy segment polling can run frequently while there is no work or while tasks
are still in progress. The previous logs were repetitive and sometimes included
large protobuf payloads, making restore logs harder to scan.

## Validation

- `source ~/.profile && source scripts/setenv.sh && make milvus`
- `reset-milvus; go test -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r ${RPATH}" github.com/milvus-io/milvus/internal/datacoord -run 'TestCopySegment|TestAssembleCopySegmentRequest' -count=1 -timeout 300s`
- `source ~/.profile && source scripts/setenv.sh && make lint-fix`

Full `internal/datacoord` coverage was also attempted locally and hit the known
macOS-only DISKANN mismatch in `TestCompactionTriggerManagerSuite/TestGetExpectedSegmentSize`.
