### PR TITLE
fix: stabilize sparse search test with different nq

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_sparse_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_sparse_search.py
@@ -1,8 +1,8 @@
 import pytest
-from common.common_type import CaseLabel, CheckTasks
-from common import common_type as ct
-from common import common_func as cf
 from base.client_v2_base import TestMilvusClientV2Base
+from common import common_func as cf
+from common import common_type as ct
+from common.common_type import CaseLabel, CheckTasks
 
 default_nb = ct.default_nb
 default_nq = ct.default_nq
@@ -177,7 +177,7 @@ class TestSparseSearchShared(TestMilvusClientV2Base):
         expected: search returns exactly nq groups of results with correct limit and IP ordering
         """
         client = self._client(alias=self.shared_alias)
-        search_vectors = cf.gen_sparse_vectors(nq)
+        search_vectors = cf.gen_sparse_vectors(nq, dim=ct.default_dim)
         self.search(client, self.collection_name,
                     data=search_vectors,
                     anns_field=ct.default_sparse_vec_field_name,


### PR DESCRIPTION
issue: #50293

The sparse different-nq test was flaky because the collection data and query data were generated from different sparse dimension ranges. The collection rows used the test default dimension, while the query helper defaulted to a much larger dimension. With drop_ratio_search=0.2, some queries could lose all useful overlapping terms and return zero hits, even though the test only wanted to verify nq=1 and nq=100 batch search behavior.

ex.

```text
  1. sparse data in collection is generated with dim=128

     The inserted sparse vectors only use dimensions in [0, 127].
     The generator also forces every vector to contain dimensions 0 and 1.

     sparse_vector: {0: 0.80, 1: 0.60, 20: 0.40, 77: 0.90, ...}

  2. query was generated with dim=1000

     The query sparse vector may use dimensions in [0, 999].
     It also contains dimensions 0 and 1, but most random dimensions may be outside [0, 127].

     sparse_vector: {0: 0.01, 1: 0.02, 250: 0.70, 600: 0.50, 900: 0.80, ...}

  3. after drop_ratio_search=0.2, low-weight query terms may be dropped

     sparse_vector after pruning: {250: 0.70, 600: 0.50, 900: 0.80, ...}

  4. the remaining query dimensions do not exist in the collection sparse data

     collection dimensions: [0, 127]
     remaining query dimensions: 250, 600, 900

     There is no sparse term overlap, so the sparse index has no candidates for this query.

  5. search can return 0 hits

     The test expects topK=10 for every query result group, so this random no-overlap query makes the case fail.
```

This fixes the test by generating query sparse vectors with ct.default_dim, the same dimension range used by the inserted sparse data. That keeps the test focused on the intended behavior: sparse search should handle different nq values and return the expected result shape, without depending on accidental cross-dimension overlap surviving sparse term pruning.