### PR TITLE
fix: implement OCC/CAS via partial update interceptor to prevent lost…

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1411,6 +1411,8 @@ streaming:
   replication:
     pendingMessagesQueueLength: 128 # The capacity of pending message queue for each replication stream client.
     pendingMessagesQueueMaxSize: 134217728 # The maximum size (in bytes) of pending message queue for each replication stream client. Default is 128MB.
+  partialUpdate:
+    pkVersionCacheTimeout: 60s # LRU idle timeout for the per-streamingnode hot PK version cache used by the partial_update interceptor. PK entries not touched by a CAS Check within this duration are evicted.
 
 # Any configuration related to the knowhere vector search engine
 knowhere:

--- a/internal/distributed/streaming/internal/errs/error.go
+++ b/internal/distributed/streaming/internal/errs/error.go
@@ -11,4 +11,5 @@ var (
 	ErrUnrecoverable            = errors.New("unrecoverable")
 	ErrFenced                   = errors.New("fenced")
 	ErrIgnoredOperation         = errors.New("ignored operation")
+	ErrPKStateConflict          = errors.New("pk-state CAS conflict")
 )

--- a/internal/distributed/streaming/internal/producer/producer.go
+++ b/internal/distributed/streaming/internal/producer/producer.go
@@ -143,6 +143,13 @@ func (p *ResumableProducer) produceInternal(ctx context.Context, msg message.Mut
 			if sErr.IsIgnoredOperation() {
 				return nil, errors.Mark(err, errs.ErrIgnoredOperation)
 			}
+			// A pk-state CAS conflict must not be retried inside the streaming
+			// client: retrying with the same stale expected version would just
+			// conflict again forever. Bubble it up so the proxy OCC retry loop
+			// can re-read the latest row versions and rebuild the request.
+			if sErr.IsPKStateConflict() {
+				return nil, errors.Mark(err, errs.ErrPKStateConflict)
+			}
 			if sErr.IsRateLimitRejected() {
 				// current message is rate limit rejected, wait until the rate limit is available.
 				if err := p.rateLimiter.WaitUntilAvailable(ctx); err != nil {

--- a/internal/distributed/streaming/internal/producer/producer_test.go
+++ b/internal/distributed/streaming/internal/producer/producer_test.go
@@ -195,6 +195,7 @@ func TestResumableProducer_ProduceInternalErrors(t *testing.T) {
 	p.EXPECT().Append(mock.Anything, mock.Anything).Return(nil, status.NewUnrecoverableError("unrecoverable")).Once()
 	p.EXPECT().Append(mock.Anything, mock.Anything).Return(nil, status.NewIgnoreOperation("ignored")).Once()
 	p.EXPECT().Append(mock.Anything, mock.Anything).Return(nil, status.NewRateLimitRejected("rejected")).Once()
+	p.EXPECT().Append(mock.Anything, mock.Anything).Return(nil, status.NewInner(status.PKStateConflictCausePrefix+"version mismatch")).Once()
 	p.EXPECT().Append(mock.Anything, mock.Anything).Return(&types.AppendResult{}, nil).Once()
 
 	rp := NewResumableProducer(func(ctx context.Context, opts *handler.ProducerOptions) (producer.Producer, error) {
@@ -214,6 +215,15 @@ func TestResumableProducer_ProduceInternalErrors(t *testing.T) {
 		_, err := rp.produceInternal(context.Background(), msg)
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, errs.ErrIgnoredOperation))
+	})
+
+	t.Run("PKStateConflict_NoRetry_Bubbles", func(t *testing.T) {
+		// CAS conflict must NOT be retried inside the streaming client; it
+		// has to surface to proxy's OCC retry loop unchanged. Mocked Append
+		// is `.Once()`, so any inner retry would panic the mock.
+		_, err := rp.produceInternal(context.Background(), msg)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, errs.ErrPKStateConflict))
 	})
 
 	t.Run("RateLimitRejected_Retry", func(t *testing.T) {

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -49,6 +49,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy/connection"
 	"github.com/milvus-io/milvus/internal/proxy/privilege"
 	"github.com/milvus-io/milvus/internal/proxy/replicate"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/partial_update"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/segcore"
@@ -82,6 +83,94 @@ import (
 )
 
 const moduleName = "Proxy"
+
+const (
+	occInitialBackoff = 5 * time.Millisecond
+	occMaxBackoff     = 100 * time.Millisecond
+)
+
+// computeOCCRetryParams returns (maxAttempts, initialBackoff) for the
+// pk-state OCC retry loop. Non-partial-update upserts always run exactly
+// once with no backoff. For partial updates the values come from
+// paramtable; negative retries are clamped to zero.
+func computeOCCRetryParams(partialUpdate bool) (int, time.Duration) {
+	if !partialUpdate {
+		return 1, occInitialBackoff
+	}
+	retries := paramtable.Get().ProxyCfg.PartialUpdateRetryOnConflict.GetAsInt()
+	if retries < 0 {
+		retries = 0
+	}
+	backoff := occInitialBackoff
+	if ms := paramtable.Get().ProxyCfg.PartialUpdateRetryBackoffMs.GetAsInt(); ms > 0 {
+		backoff = time.Duration(ms) * time.Millisecond
+	}
+	return retries + 1, backoff
+}
+
+// nextOCCBackoff doubles the backoff up to occMaxBackoff.
+func nextOCCBackoff(cur time.Duration) time.Duration {
+	if cur >= occMaxBackoff {
+		return occMaxBackoff
+	}
+	next := cur * 2
+	if next > occMaxBackoff {
+		return occMaxBackoff
+	}
+	return next
+}
+
+// newUpsertTaskForRetry rebuilds a fresh upsertTask for an OCC retry attempt
+// so that BeginTs is re-allocated and queryPreExecute re-reads the latest
+// row versions. Kept separate from the inline first-attempt construction so
+// the retry loop body is small and the helper can be unit-tested.
+func newUpsertTaskForRetry(ctx context.Context, request *milvuspb.UpsertRequest, node *Proxy) *upsertTask {
+	return &upsertTask{
+		baseMsg: msgstream.BaseMsg{
+			HashValues: request.HashKeys,
+		},
+		ctx:       ctx,
+		Condition: NewTaskCondition(ctx),
+		req:       request,
+		result: &milvuspb.MutationResult{
+			Status: merr.Success(),
+			IDs: &schemapb.IDs{
+				IdField: nil,
+			},
+		},
+		idAllocator:     node.rowIDAllocator,
+		chMgr:           node.chMgr,
+		schemaTimestamp: request.SchemaTimestamp,
+		node:            node,
+	}
+}
+
+// classifyOCCRetry decides what the OCC retry loop should do given the
+// current attempt result. Pure function, no side effects, designed to keep
+// the retry loop in Upsert thin and easy to unit-test.
+//
+//	waitErr:        the error returned by the most recent enqueue/wait pair
+//	                (nil means success).
+//	partialUpdate:  whether the request is a partial-update upsert. Only
+//	                partial updates are retried.
+//	attempt:        current zero-based attempt index.
+//	maxAttempts:    upper bound (>= 1).
+//
+// Returns retry=true only when the loop should sleep and try again. When
+// retry=false the caller breaks out of the loop. exhausted=true signals
+// that retries are exhausted and the caller should log a warning.
+func classifyOCCRetry(waitErr error, partialUpdate bool, attempt, maxAttempts int) (retry, exhausted bool) {
+	if waitErr == nil {
+		return false, false
+	}
+	if !partialUpdate || !partial_update.IsPKStateConflict(waitErr) {
+		return false, false
+	}
+	if attempt >= maxAttempts-1 {
+		return false, true
+	}
+	return true, false
+}
 
 // checkExternalCollectionBlockedForWrite checks if the collection is external and returns error if so.
 // External collections do not support write operations (insert, delete, upsert, flush, etc).
@@ -3052,25 +3141,58 @@ func (node *Proxy) Upsert(ctx context.Context, request *milvuspb.UpsertRequest) 
 		zap.Int("len(FieldsData)", len(request.FieldsData)),
 		zap.Int("len(HashKeys)", len(request.HashKeys)))
 
-	if err := node.sched.dmQueue.Enqueue(it); err != nil {
-		log.Info("Failed to enqueue upsert task",
-			zap.Error(err))
-		return &milvuspb.MutationResult{
-			Status: merr.Status(err),
-		}, nil
+	// pk-state OCC retry loop. For non-pk-state CAS upserts the loop
+	// runs exactly once. On a CAS conflict reported by the streaming-node
+	// pk_state interceptor, the task is rebuilt from scratch so that
+	// BeginTs is re-allocated and queryPreExecute re-reads the latest row
+	// versions before the next attempt.
+	maxAttempts, backoff := computeOCCRetryParams(request.GetPartialUpdate())
+	var waitErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			it = newUpsertTaskForRetry(ctx, request, node)
+		}
+
+		if err := node.sched.dmQueue.Enqueue(it); err != nil {
+			log.Info("Failed to enqueue upsert task",
+				zap.Error(err))
+			return &milvuspb.MutationResult{
+				Status: merr.Status(err),
+			}, nil
+		}
+
+		waitErr = it.WaitToFinish()
+		retry, exhausted := classifyOCCRetry(waitErr, request.GetPartialUpdate(), attempt, maxAttempts)
+		if exhausted {
+			log.Warn("pk-state CAS conflict exhausted retries",
+				zap.Int("attempts", maxAttempts),
+				zap.Error(waitErr))
+		}
+		if !retry {
+			break
+		}
+		log.Info("pk-state CAS conflict, retrying",
+			zap.Int("attempt", attempt),
+			zap.Duration("backoff", backoff),
+			zap.Error(waitErr))
+		select {
+		case <-ctx.Done():
+			waitErr = ctx.Err()
+		case <-time.After(backoff):
+		}
+		if waitErr != nil && errors.Is(waitErr, context.Canceled) {
+			break
+		}
+		backoff = nextOCCBackoff(backoff)
 	}
 
-	log.Debug("Detail of upsert request in Proxy",
-		zap.Uint64("BeginTS", it.BeginTs()),
-		zap.Uint64("EndTS", it.EndTs()))
-
-	if err := it.WaitToFinish(); err != nil {
-		log.Warn("Failed to execute insert task in task scheduler",
-			zap.Error(err))
+	if waitErr != nil {
+		log.Info("Failed to execute insert task in task scheduler",
+			zap.Error(waitErr))
 		// Not every error case changes the status internally
 		// change status there to handle it
 		if it.result.GetStatus().GetErrorCode() == commonpb.ErrorCode_Success {
-			it.result.Status = merr.Status(err)
+			it.result.Status = merr.Status(waitErr)
 		}
 
 		numRows := request.NumRows
@@ -3080,7 +3202,7 @@ func (node *Proxy) Upsert(ctx context.Context, request *milvuspb.UpsertRequest) 
 		}
 
 		return &milvuspb.MutationResult{
-			Status:   merr.Status(err),
+			Status:   merr.Status(waitErr),
 			ErrIndex: errIndex,
 		}, nil
 	}

--- a/internal/proxy/impl_occ_retry_test.go
+++ b/internal/proxy/impl_occ_retry_test.go
@@ -1,0 +1,327 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func TestComputeOCCRetryParams_NonPartialUpdate(t *testing.T) {
+	paramtable.Init()
+	attempts, backoff := computeOCCRetryParams(false)
+	assert.Equal(t, 1, attempts, "non partial update must run exactly once")
+	assert.Equal(t, occInitialBackoff, backoff)
+}
+
+func TestComputeOCCRetryParams_PartialUpdateUsesParamtable(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.ProxyCfg.PartialUpdateRetryOnConflict.Key, "5")
+	pt.Save(pt.ProxyCfg.PartialUpdateRetryBackoffMs.Key, "20")
+	defer pt.Reset(pt.ProxyCfg.PartialUpdateRetryOnConflict.Key)
+	defer pt.Reset(pt.ProxyCfg.PartialUpdateRetryBackoffMs.Key)
+
+	attempts, backoff := computeOCCRetryParams(true)
+	assert.Equal(t, 6, attempts, "maxAttempts == retries+1")
+	assert.Equal(t, 20*time.Millisecond, backoff)
+}
+
+func TestComputeOCCRetryParams_NegativeRetriesClamped(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.ProxyCfg.PartialUpdateRetryOnConflict.Key, "-3")
+	defer pt.Reset(pt.ProxyCfg.PartialUpdateRetryOnConflict.Key)
+
+	attempts, _ := computeOCCRetryParams(true)
+	assert.Equal(t, 1, attempts, "negative retries clamp to zero -> single attempt")
+}
+
+func TestComputeOCCRetryParams_ZeroBackoffKeepsDefault(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	pt.Save(pt.ProxyCfg.PartialUpdateRetryBackoffMs.Key, "0")
+	defer pt.Reset(pt.ProxyCfg.PartialUpdateRetryBackoffMs.Key)
+
+	_, backoff := computeOCCRetryParams(true)
+	assert.Equal(t, occInitialBackoff, backoff,
+		"non-positive backoff should fall back to default")
+}
+
+func TestNextOCCBackoff_Doubles(t *testing.T) {
+	assert.Equal(t, 10*time.Millisecond, nextOCCBackoff(5*time.Millisecond))
+	assert.Equal(t, 40*time.Millisecond, nextOCCBackoff(20*time.Millisecond))
+}
+
+func TestNextOCCBackoff_CapsAtMax(t *testing.T) {
+	assert.Equal(t, occMaxBackoff, nextOCCBackoff(80*time.Millisecond),
+		"80ms*2 == 160ms must clamp to 100ms")
+	assert.Equal(t, occMaxBackoff, nextOCCBackoff(occMaxBackoff))
+	assert.Equal(t, occMaxBackoff, nextOCCBackoff(200*time.Millisecond),
+		"already-over-max input must stay at max")
+}
+
+func TestBuildUpsertOCCInput_NonPartialUpdate(t *testing.T) {
+	pks := &schemapb.IDs{}
+	got := buildUpsertOCCInput(false, pks, []uint64{1, 2}, []bool{true, false})
+	assert.Nil(t, got, "non partial-update must produce no OCC metadata")
+}
+
+func TestBuildUpsertOCCInput_EmptyExpectedTs(t *testing.T) {
+	pks := &schemapb.IDs{}
+	got := buildUpsertOCCInput(true, pks, nil, nil)
+	assert.Nil(t, got, "no expected-row info must produce no OCC metadata")
+}
+
+func TestBuildUpsertOCCInput_PopulatesAllFields(t *testing.T) {
+	pks := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{10, 11}}},
+	}
+	expectedTs := []uint64{100, 200}
+	expectedExists := []bool{true, false}
+
+	got := buildUpsertOCCInput(true, pks, expectedTs, expectedExists)
+
+	assert.NotNil(t, got)
+	assert.Same(t, pks, got.PKs)
+	assert.Equal(t, expectedTs, got.ExpectedTs)
+	assert.Equal(t, expectedExists, got.ExpectedExists)
+}
+
+func TestAttachOCCToInsertHeader_StampsAllFields(t *testing.T) {
+	header := &message.InsertMessageHeader{}
+	pks := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{42}}},
+	}
+	occ := &OCCRowMeta{
+		PKs:            pks,
+		ExpectedTs:     []uint64{1234},
+		ExpectedExists: []bool{true},
+	}
+
+	attachOCCToInsertHeader(header, occ)
+
+	assert.Equal(t, messagespb.OCCMode_OCC_MODE_CAS, header.OccMode)
+	assert.Same(t, pks, header.ExpectedPks)
+	assert.Equal(t, []uint64{1234}, header.ExpectedRowTimestamps)
+	assert.Equal(t, []bool{true}, header.ExpectedRowExists)
+}
+
+// --- helpers extracted from queryPreExecute ---
+
+func tsFieldData(values []int64) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		FieldId: common.TimeStampField,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: values},
+				},
+			},
+		},
+	}
+}
+
+func intPKField(id int64, values []int64) *schemapb.FieldData {
+	return &schemapb.FieldData{
+		FieldId: id,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: values},
+				},
+			},
+		},
+	}
+}
+
+func TestExtractHiddenTimestampColumn_Found(t *testing.T) {
+	pk := intPKField(100, []int64{1, 2, 3})
+	ts := tsFieldData([]int64{10, 20, 30})
+	in := []*schemapb.FieldData{pk, ts}
+
+	out, rowTs, ok := extractHiddenTimestampColumn(in)
+
+	assert.True(t, ok)
+	assert.Equal(t, []uint64{10, 20, 30}, rowTs)
+	assert.Len(t, out, 1)
+	assert.Equal(t, int64(100), out[0].GetFieldId())
+}
+
+func TestExtractHiddenTimestampColumn_TimestampFirst(t *testing.T) {
+	ts := tsFieldData([]int64{7})
+	pk := intPKField(100, []int64{42})
+	in := []*schemapb.FieldData{ts, pk}
+
+	out, rowTs, ok := extractHiddenTimestampColumn(in)
+
+	assert.True(t, ok)
+	assert.Equal(t, []uint64{7}, rowTs)
+	assert.Len(t, out, 1)
+	assert.Equal(t, int64(100), out[0].GetFieldId())
+}
+
+func TestExtractHiddenTimestampColumn_Missing(t *testing.T) {
+	pk := intPKField(100, []int64{1, 2})
+	in := []*schemapb.FieldData{pk}
+
+	out, rowTs, ok := extractHiddenTimestampColumn(in)
+
+	assert.False(t, ok, "missing ts column must be reported as not-found")
+	assert.Nil(t, rowTs)
+	assert.Len(t, out, 1, "input slice returned unchanged")
+}
+
+func TestExtractHiddenTimestampColumn_Empty(t *testing.T) {
+	out, rowTs, ok := extractHiddenTimestampColumn(nil)
+	assert.False(t, ok)
+	assert.Nil(t, rowTs)
+	assert.Empty(t, out)
+}
+
+func TestAssignOCCRowVersions_NoRows(t *testing.T) {
+	ids := &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: nil}}}
+	occTs, occExists, err := assignOCCRowVersions(ids, nil, nil, map[interface{}]int{}, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, occTs)
+	assert.Nil(t, occExists)
+}
+
+func TestAssignOCCRowVersions_UpdatesAndInserts(t *testing.T) {
+	// upsert payload PKs: [1, 2, 3]
+	upsertIDs := &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}}}
+	// update indices reference PKs at upsertIDs[0], upsertIDs[2] (i.e. 1 and 3)
+	updateIdx := []int{0, 2}
+	insertIdx := []int{1}
+	// existing rows: PK 1 -> ts 100 (existIndex 0), PK 3 -> ts 300 (existIndex 1)
+	existPKToIndex := map[interface{}]int{int64(1): 0, int64(3): 1}
+	existRowTs := []uint64{100, 300}
+
+	occTs, occExists, err := assignOCCRowVersions(upsertIDs, updateIdx, insertIdx, existPKToIndex, existRowTs)
+
+	assert.NoError(t, err)
+	// layout: updates first (in updateIdx order), then first-writes
+	assert.Equal(t, []uint64{100, 300, 0}, occTs)
+	assert.Equal(t, []bool{true, true, false}, occExists)
+}
+
+func TestAssignOCCRowVersions_MissingPKMappingReturnsError(t *testing.T) {
+	upsertIDs := &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{42}}}}
+	updateIdx := []int{0}
+	// mapping intentionally empty: simulates internal invariant violation.
+	existPKToIndex := map[interface{}]int{}
+
+	occTs, occExists, err := assignOCCRowVersions(upsertIDs, updateIdx, nil, existPKToIndex, []uint64{})
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrParameterInvalid),
+		"expected ParameterInvalid for missing pk mapping, got: %v", err)
+	assert.Nil(t, occTs)
+	assert.Nil(t, occExists)
+}
+
+func TestAssignOCCRowVersions_NilExistRowTsDegrades(t *testing.T) {
+	upsertIDs := &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1}}}}
+	updateIdx := []int{0}
+	existPKToIndex := map[interface{}]int{int64(1): 0}
+
+	// existRowTs == nil simulates the missing-ts-column degraded path.
+	occTs, occExists, err := assignOCCRowVersions(upsertIDs, updateIdx, nil, existPKToIndex, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []uint64{0}, occTs, "missing existRowTs => 0 (first-write semantics)")
+	assert.Equal(t, []bool{true}, occExists, "still tagged as expected-exists for the update branch")
+}
+
+func TestAssignOCCRowVersions_ExistIndexOutOfRangeKeepsZero(t *testing.T) {
+	// Defensive bound check: even if mapping points to an existIndex >= len(existRowTs)
+	// (shouldn't happen but the helper guards it), assignment must not panic
+	// and must default the row timestamp to 0.
+	upsertIDs := &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1}}}}
+	updateIdx := []int{0}
+	existPKToIndex := map[interface{}]int{int64(1): 5}
+	existRowTs := []uint64{100, 200}
+
+	occTs, occExists, err := assignOCCRowVersions(upsertIDs, updateIdx, nil, existPKToIndex, existRowTs)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []uint64{0}, occTs)
+	assert.Equal(t, []bool{true}, occExists)
+}
+
+// --- classifyOCCRetry: pure decision function for the retry loop ---
+
+func newPKStateConflictErr() error {
+	return status.NewInner("%sversion mismatch", status.PKStateConflictCausePrefix)
+}
+
+func TestClassifyOCCRetry_NilErrIsTerminal(t *testing.T) {
+	retry, exhausted := classifyOCCRetry(nil, true, 0, 3)
+	assert.False(t, retry)
+	assert.False(t, exhausted)
+}
+
+func TestClassifyOCCRetry_NonPartialUpdateNeverRetries(t *testing.T) {
+	retry, exhausted := classifyOCCRetry(newPKStateConflictErr(), false, 0, 3)
+	assert.False(t, retry, "non-partial-update upsert must never trigger OCC retry")
+	assert.False(t, exhausted)
+}
+
+func TestClassifyOCCRetry_NonCASErrorNeverRetries(t *testing.T) {
+	retry, exhausted := classifyOCCRetry(errors.New("some other error"), true, 0, 3)
+	assert.False(t, retry)
+	assert.False(t, exhausted)
+}
+
+func TestClassifyOCCRetry_CASConflictRetriesUntilLast(t *testing.T) {
+	retry, exhausted := classifyOCCRetry(newPKStateConflictErr(), true, 0, 3)
+	assert.True(t, retry)
+	assert.False(t, exhausted)
+}
+
+func TestClassifyOCCRetry_CASConflictExhaustedOnLastAttempt(t *testing.T) {
+	retry, exhausted := classifyOCCRetry(newPKStateConflictErr(), true, 2, 3)
+	assert.False(t, retry, "must not retry after the final attempt")
+	assert.True(t, exhausted)
+}
+
+func TestClassifyOCCRetry_SingleAttemptExhaustsImmediately(t *testing.T) {
+	// maxAttempts=1 means the first failure already exhausts retries.
+	retry, exhausted := classifyOCCRetry(newPKStateConflictErr(), true, 0, 1)
+	assert.False(t, retry)
+	assert.True(t, exhausted)
+}
+
+// --- newUpsertTaskForRetry ---
+
+func TestNewUpsertTaskForRetry_InitializesAllFields(t *testing.T) {
+	ctx := context.Background()
+	req := &milvuspb.UpsertRequest{
+		HashKeys:        []uint32{1, 2, 3},
+		SchemaTimestamp: 9999,
+	}
+	node := &Proxy{}
+
+	it := newUpsertTaskForRetry(ctx, req, node)
+
+	assert.NotNil(t, it)
+	assert.Equal(t, ctx, it.ctx)
+	assert.Same(t, req, it.req)
+	assert.Same(t, node, it.node)
+	assert.Equal(t, []uint32{1, 2, 3}, it.baseMsg.HashValues)
+	assert.Equal(t, uint64(9999), it.schemaTimestamp)
+	assert.NotNil(t, it.result, "fresh task must have an initialized result")
+	assert.NotNil(t, it.result.IDs)
+	assert.NotNil(t, it.Condition, "Condition must be reset so a retry can wait for completion")
+}

--- a/internal/proxy/msg_pack.go
+++ b/internal/proxy/msg_pack.go
@@ -23,6 +23,8 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -35,6 +37,55 @@ func genInsertMsgsByPartition(ctx context.Context,
 	channelName string,
 	insertMsg *msgstream.InsertMsg,
 ) ([]msgstream.TsMsg, error) {
+	msgs, _, err := genInsertMsgsByPartitionWithOCC(ctx, segmentID, partitionID, partitionName, rowOffsets, channelName, insertMsg, nil)
+	return msgs, err
+}
+
+// OCCRowMeta carries per-row partial-update OCC metadata used by streaming
+// upsert. The three slices/IDs are aligned with the rows of the merged
+// InsertMsg produced by upsertTask.queryPreExecute.
+type OCCRowMeta struct {
+	PKs            *schemapb.IDs
+	ExpectedTs     []uint64
+	ExpectedExists []bool
+}
+
+// buildUpsertOCCInput returns OCC metadata for streaming upsert. It returns
+// nil when the request is not a partial update or carries no expected-row
+// information, so the streaming path falls back to a plain insert.
+func buildUpsertOCCInput(partialUpdate bool, pks *schemapb.IDs, expectedTs []uint64, expectedExists []bool) *OCCRowMeta {
+	if !partialUpdate || len(expectedTs) == 0 {
+		return nil
+	}
+	return &OCCRowMeta{
+		PKs:            pks,
+		ExpectedTs:     expectedTs,
+		ExpectedExists: expectedExists,
+	}
+}
+
+// attachOCCToInsertHeader stamps the CAS mode and per-row expected version
+// arrays from occ onto header in place. occ is assumed non-nil.
+func attachOCCToInsertHeader(header *message.InsertMessageHeader, occ *OCCRowMeta) {
+	header.OccMode = messagespb.OCCMode_OCC_MODE_CAS
+	header.ExpectedPks = occ.PKs
+	header.ExpectedRowTimestamps = occ.ExpectedTs
+	header.ExpectedRowExists = occ.ExpectedExists
+}
+
+// genInsertMsgsByPartitionWithOCC repacks insert rows into one or more
+// InsertMsgs respecting the WAL message size threshold. When occInput is
+// non-nil it ALSO returns one OCCRowMeta per output InsertMsg, aligned 1:1
+// with the returned msgs, so the caller can attach the matching CAS header.
+func genInsertMsgsByPartitionWithOCC(ctx context.Context,
+	segmentID UniqueID,
+	partitionID UniqueID,
+	partitionName string,
+	rowOffsets []int,
+	channelName string,
+	insertMsg *msgstream.InsertMsg,
+	occInput *OCCRowMeta,
+) ([]msgstream.TsMsg, []*OCCRowMeta, error) {
 	threshold := Params.PulsarCfg.MaxMessageSize.GetAsInt()
 
 	// create empty insert message
@@ -69,18 +120,27 @@ func genInsertMsgsByPartition(ctx context.Context,
 	idxComputer := typeutil.NewFieldDataIdxComputer(fieldsData)
 
 	repackedMsgs := make([]msgstream.TsMsg, 0)
+	occOuts := make([]*OCCRowMeta, 0)
 	requestSize := 0
 	msg := createInsertMsg(segmentID, channelName)
+	var curOCC *OCCRowMeta
+	if occInput != nil {
+		curOCC = &OCCRowMeta{PKs: &schemapb.IDs{}}
+	}
 	for _, offset := range rowOffsets {
 		fieldIdxs := idxComputer.Compute(int64(offset))
 		curRowMessageSize, err := typeutil.EstimateEntitySize(fieldsData, offset, fieldIdxs...)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		// if insertMsg's size is greater than the threshold, split into multiple insertMsgs
 		if requestSize+curRowMessageSize >= threshold && msg.NumRows > 0 {
 			repackedMsgs = append(repackedMsgs, msg)
+			if curOCC != nil {
+				occOuts = append(occOuts, curOCC)
+				curOCC = &OCCRowMeta{PKs: &schemapb.IDs{}}
+			}
 			msg = createInsertMsg(segmentID, channelName)
 			requestSize = 0
 		}
@@ -91,10 +151,21 @@ func genInsertMsgsByPartition(ctx context.Context,
 		msg.RowIDs = append(msg.RowIDs, insertMsg.RowIDs[offset])
 		msg.NumRows++
 		requestSize += curRowMessageSize
+		if curOCC != nil {
+			typeutil.AppendIDs(curOCC.PKs, occInput.PKs, offset)
+			curOCC.ExpectedTs = append(curOCC.ExpectedTs, occInput.ExpectedTs[offset])
+			curOCC.ExpectedExists = append(curOCC.ExpectedExists, occInput.ExpectedExists[offset])
+		}
 	}
 	if msg.NumRows > 0 {
 		repackedMsgs = append(repackedMsgs, msg)
+		if curOCC != nil {
+			occOuts = append(occOuts, curOCC)
+		}
 	}
 
-	return repackedMsgs, nil
+	if occInput == nil {
+		return repackedMsgs, nil, nil
+	}
+	return repackedMsgs, occOuts, nil
 }

--- a/internal/proxy/msg_pack_test.go
+++ b/internal/proxy/msg_pack_test.go
@@ -183,3 +183,121 @@ func TestRepackInsertDataWithPartitionKey(t *testing.T) {
 		insertMsg.RowIDs[index] = int64(index)
 	}
 }
+
+// =========================================================================
+// Partial-update OCC repack tests (genInsertMsgsByPartitionWithOCC)
+// =========================================================================
+
+// buildOCCInsertMsg builds a minimal column-based InsertMsg with `nb` rows
+// (single Int64 PK column) suitable for genInsertMsgsByPartitionWithOCC.
+func buildOCCInsertMsg(nb int) *msgstream.InsertMsg {
+	pks := make([]int64, nb)
+	for i := 0; i < nb; i++ {
+		pks[i] = int64(i + 1)
+	}
+	pkField := &schemapb.FieldData{
+		FieldId:   100,
+		FieldName: "pk",
+		Type:      schemapb.DataType_Int64,
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{LongData: &schemapb.LongArray{Data: pks}},
+			},
+		},
+	}
+	im := &msgstream.InsertMsg{
+		BaseMsg: msgstream.BaseMsg{HashValues: make([]uint32, nb)},
+		InsertRequest: &msgpb.InsertRequest{
+			Base: &commonpb.MsgBase{
+				MsgType:  commonpb.MsgType_Insert,
+				SourceID: paramtable.GetNodeID(),
+			},
+			NumRows:    uint64(nb),
+			FieldsData: []*schemapb.FieldData{pkField},
+			Version:    msgpb.InsertDataVersion_ColumnBased,
+		},
+	}
+	im.Timestamps = make([]uint64, nb)
+	im.RowIDs = make([]UniqueID, nb)
+	for i := 0; i < nb; i++ {
+		im.Timestamps[i] = uint64(i)
+		im.RowIDs[i] = int64(i)
+	}
+	return im
+}
+
+func TestGenInsertMsgsByPartitionWithOCC_NilOccInputBackwardCompat(t *testing.T) {
+	paramtable.Init()
+	nb := 4
+	insertMsg := buildOCCInsertMsg(nb)
+	rowOffsets := []int{0, 1, 2, 3}
+
+	msgs, occOuts, err := genInsertMsgsByPartitionWithOCC(
+		context.Background(), 0, 1, "p1", rowOffsets, "ch", insertMsg, nil,
+	)
+	assert.NoError(t, err)
+	assert.Nil(t, occOuts, "occOuts should be nil when occInput is nil")
+	assert.Len(t, msgs, 1)
+	im := msgs[0].(*msgstream.InsertMsg)
+	assert.EqualValues(t, nb, im.NumRows)
+}
+
+func TestGenInsertMsgsByPartitionWithOCC_AlignsOccMeta(t *testing.T) {
+	paramtable.Init()
+	nb := 3
+	insertMsg := buildOCCInsertMsg(nb)
+	occInput := &OCCRowMeta{
+		PKs: &schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{10, 20, 30}}},
+		},
+		ExpectedTs:     []uint64{100, 200, 300},
+		ExpectedExists: []bool{true, false, true},
+	}
+
+	rowOffsets := []int{0, 1, 2}
+	msgs, occOuts, err := genInsertMsgsByPartitionWithOCC(
+		context.Background(), 0, 1, "p1", rowOffsets, "ch", insertMsg, occInput,
+	)
+	assert.NoError(t, err)
+	assert.Len(t, msgs, 1, "small payload should fit into a single InsertMsg")
+	assert.Len(t, occOuts, 1, "occOuts must be aligned 1:1 with msgs")
+	out := occOuts[0]
+	assert.Equal(t, []int64{10, 20, 30}, out.PKs.GetIntId().GetData())
+	assert.Equal(t, []uint64{100, 200, 300}, out.ExpectedTs)
+	assert.Equal(t, []bool{true, false, true}, out.ExpectedExists)
+}
+
+func TestGenInsertMsgsByPartitionWithOCC_SplitsAcrossThreshold(t *testing.T) {
+	paramtable.Init()
+	// Force the WAL message-size threshold to 1 byte so every row triggers a
+	// new InsertMsg, exercising the split path that also needs to slice
+	// OCCRowMeta.
+	origVal := Params.PulsarCfg.MaxMessageSize.GetValue()
+	paramtable.Get().Save(Params.PulsarCfg.MaxMessageSize.Key, "1")
+	defer paramtable.Get().Save(Params.PulsarCfg.MaxMessageSize.Key, origVal)
+
+	nb := 3
+	insertMsg := buildOCCInsertMsg(nb)
+	occInput := &OCCRowMeta{
+		PKs: &schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}},
+		},
+		ExpectedTs:     []uint64{11, 22, 33},
+		ExpectedExists: []bool{true, true, false},
+	}
+
+	rowOffsets := []int{0, 1, 2}
+	msgs, occOuts, err := genInsertMsgsByPartitionWithOCC(
+		context.Background(), 0, 1, "p1", rowOffsets, "ch", insertMsg, occInput,
+	)
+	assert.NoError(t, err)
+	// One row per output message because threshold=1 forces a flush after
+	// each row beyond the first.
+	assert.Len(t, msgs, nb)
+	assert.Len(t, occOuts, nb)
+	for i := 0; i < nb; i++ {
+		assert.Equal(t, []int64{int64(i + 1)}, occOuts[i].PKs.GetIntId().GetData())
+		assert.Equal(t, []uint64{occInput.ExpectedTs[i]}, occOuts[i].ExpectedTs)
+		assert.Equal(t, []bool{occInput.ExpectedExists[i]}, occOuts[i].ExpectedExists)
+	}
+}

--- a/internal/proxy/query_pipeline.go
+++ b/internal/proxy/query_pipeline.go
@@ -86,6 +86,7 @@ func NewQueryPipeline(
 	aggregates []*planpb.Aggregate,
 	outputMap *agg.AggregationFieldMap,
 	outputFieldIDs []int64,
+	keepTimestamp bool,
 ) (*QueryPipeline, error) {
 	hasAggregation := len(groupByFieldIDs) > 0 || len(aggregates) > 0
 	hasOrderBy := len(orderByFields) > 0
@@ -99,7 +100,7 @@ func NewQueryPipeline(
 	} else if hasOrderBy {
 		p = buildOrderByPipeline(schema, limit, offset, orderByFields, outputFieldIDs)
 	} else {
-		p = buildPlainQueryPipeline(schema, limit, offset, reduceType)
+		p = buildPlainQueryPipeline(schema, limit, offset, reduceType, keepTimestamp)
 	}
 	if err != nil {
 		return nil, err
@@ -117,11 +118,12 @@ func buildPlainQueryPipeline(
 	schema *schemapb.CollectionSchema,
 	limit, offset int64,
 	reduceType reduce.IReduceType,
+	keepTimestamp bool,
 ) *queryutil.Pipeline {
 	b := queryutil.NewPipelineBuilder("proxy-query-plain")
 	b.Add(queryutil.OpReduceByPK, in(), ch(chanReduced), queryutil.NewSortAndCheckPKOperator(reduceType, schema))
 	b.Add(queryutil.OpSlice, ch(chanReduced), ch(chanSliced), queryutil.NewSliceOperator(limit, offset))
-	b.Add("complement_fields", ch(chanSliced), out(), newComplementFieldOperator(schema))
+	b.Add("complement_fields", ch(chanSliced), out(), newComplementFieldOperator(schema, keepTimestamp))
 	return b.Build()
 }
 
@@ -141,7 +143,7 @@ func buildOrderByPipeline(
 	// Uses FieldID matching instead of name matching to correctly handle dynamic
 	// field subkeys (e.g., user requests "x" which maps to $meta's FieldID).
 	b.Add(queryutil.OpRemap, ch(chanSliced), ch("remapped"), queryutil.NewFieldIDRemapOperator(outputFieldIDs))
-	b.Add("complement_fields", ch("remapped"), out(), newComplementFieldOperator(schema))
+	b.Add("complement_fields", ch("remapped"), out(), newComplementFieldOperator(schema, false))
 	return b.Build()
 }
 
@@ -226,7 +228,10 @@ func (p *QueryPipeline) Execute(ctx context.Context, results []*internalpb.Retri
 
 // newComplementFieldOperator sets FieldName/Type/IsDynamic from schema and
 // drops the internal timestamp column. Used for non-aggregation queries.
-func newComplementFieldOperator(schema *schemapb.CollectionSchema) queryutil.Operator {
+// When keepTimestamp is true (partial-update OCC), the hidden Timestamp
+// system column is preserved (with FieldName/FieldId/Type filled in) so the
+// proxy can observe the per-row version.
+func newComplementFieldOperator(schema *schemapb.CollectionSchema, keepTimestamp bool) queryutil.Operator {
 	return queryutil.NewLambdaOperator("complement_fields", func(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
 		result := inputs[0].(*internalpb.RetrieveResults)
 		if result == nil {
@@ -245,9 +250,15 @@ func newComplementFieldOperator(schema *schemapb.CollectionSchema) queryutil.Ope
 			}
 		}
 
-		// Drop internal timestamp column (FieldID=1).
+		// Drop internal timestamp column (FieldID=1) unless OCC asks to keep it.
 		for i := 0; i < len(result.FieldsData); i++ {
 			if result.FieldsData[i] != nil && result.FieldsData[i].FieldId == common.TimeStampField {
+				if keepTimestamp {
+					result.FieldsData[i].FieldName = common.TimeStampFieldName
+					result.FieldsData[i].FieldId = common.TimeStampField
+					result.FieldsData[i].Type = schemapb.DataType_Int64
+					continue
+				}
 				result.FieldsData = append(result.FieldsData[:i], result.FieldsData[i+1:]...)
 				i--
 			}

--- a/internal/proxy/query_pipeline_test.go
+++ b/internal/proxy/query_pipeline_test.go
@@ -69,6 +69,7 @@ func TestNewQueryPipeline_Plain(t *testing.T) {
 		schema, 3, 0, reduce.IReduceNoOrder,
 		nil, nil, nil, nil,
 		[]int64{100, 101},
+		false,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, pipeline)
@@ -104,6 +105,7 @@ func TestNewQueryPipeline_Plain_ComplementFields(t *testing.T) {
 		schema, 2, 0, reduce.IReduceNoOrder,
 		nil, nil, nil, nil,
 		[]int64{100, 101},
+		false,
 	)
 	require.NoError(t, err)
 
@@ -139,6 +141,7 @@ func TestNewQueryPipeline_OrderBy(t *testing.T) {
 		schema, 3, 0, reduce.IReduceNoOrder,
 		orderByFields, nil, nil, nil,
 		[]int64{100, 101},
+		false,
 	)
 	require.NoError(t, err)
 
@@ -178,6 +181,7 @@ func TestNewQueryPipeline_OrderBy_WithOffset(t *testing.T) {
 		schema, 2, 1, reduce.IReduceNoOrder, // limit=2, offset=1
 		orderByFields, nil, nil, nil,
 		[]int64{100, 101},
+		false,
 	)
 	require.NoError(t, err)
 
@@ -205,6 +209,7 @@ func TestNewQueryPipeline_EmptyResult(t *testing.T) {
 		schema, 10, 0, reduce.IReduceNoOrder,
 		nil, nil, nil, nil,
 		[]int64{100, 101},
+		false,
 	)
 	require.NoError(t, err)
 
@@ -243,6 +248,7 @@ func TestNewQueryPipeline_GroupBy(t *testing.T) {
 		[]*planpb.Aggregate{{Op: planpb.AggregateOp_count, FieldId: 500}},
 		outputMap,
 		nil, // outputFieldIDs not used for GROUP BY
+		false,
 	)
 	require.NoError(t, err)
 
@@ -293,6 +299,7 @@ func TestNewQueryPipeline_GroupByOrderBy(t *testing.T) {
 		[]*planpb.Aggregate{{Op: planpb.AggregateOp_count, FieldId: 500}},
 		outputMap,
 		nil,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -327,6 +334,7 @@ func TestNewQueryPipeline_Plain_ElementIndices(t *testing.T) {
 		schema, 3, 0, reduce.IReduceNoOrder,
 		nil, nil, nil, nil,
 		[]int64{100, 101},
+		false,
 	)
 	require.NoError(t, err)
 
@@ -367,6 +375,7 @@ func TestNewQueryPipeline_Plain_NoElementLevel(t *testing.T) {
 		schema, 3, 0, reduce.IReduceNoOrder,
 		nil, nil, nil, nil,
 		[]int64{100, 101},
+		false,
 	)
 	require.NoError(t, err)
 
@@ -403,7 +412,49 @@ func TestNewQueryPipeline_GroupByOrderBy_InvalidField(t *testing.T) {
 		nil,          // no aggregates
 		nil,          // outputMap (nil ok since we expect error before use)
 		nil,
+		false,
 	)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
+}
+
+// =========================================================================
+// Partial-update OCC: keepTimestamp behavior in complementFieldOperator
+// =========================================================================
+
+func TestNewQueryPipeline_Plain_KeepTimestamp(t *testing.T) {
+	schema := testSchema()
+	// keepTimestamp=true is the partial-update OCC path: the hidden Timestamp
+	// system column must survive complementFieldOperator with FieldName/FieldId
+	// /Type populated so the proxy can read per-row versions.
+	pipeline, err := NewQueryPipeline(
+		schema, 3, 0, reduce.IReduceNoOrder,
+		nil, nil, nil, nil,
+		[]int64{100, 101},
+		true,
+	)
+	require.NoError(t, err)
+
+	r := &internalpb.RetrieveResults{
+		Ids: makeTestIntIDs([]int64{1, 2}),
+		FieldsData: []*schemapb.FieldData{
+			makeTestInt64Field(100, "", []int64{1, 2}),
+			makeTestInt64Field(101, "", []int64{10, 20}),
+			makeTestInt64Field(common.TimeStampField, "", []int64{42, 43}),
+		},
+	}
+
+	result, err := pipeline.Execute(context.Background(), []*internalpb.RetrieveResults{r})
+	require.NoError(t, err)
+
+	var tsCol *schemapb.FieldData
+	for _, fd := range result.GetFieldsData() {
+		if fd.GetFieldId() == common.TimeStampField {
+			tsCol = fd
+		}
+	}
+	require.NotNil(t, tsCol, "timestamp column must be preserved when keepTimestamp=true")
+	assert.Equal(t, common.TimeStampFieldName, tsCol.GetFieldName())
+	assert.Equal(t, schemapb.DataType_Int64, tsCol.GetType())
+	assert.Equal(t, []int64{42, 43}, tsCol.GetScalars().GetLongData().GetData())
 }

--- a/internal/proxy/task_insert_streaming.go
+++ b/internal/proxy/task_insert_streaming.go
@@ -147,6 +147,80 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 	ez *message.CipherConfig,
 	schemaVersion int32,
 ) ([]message.MutableMessage, error) {
+	msgs, err := repackInsertDataWithPartitionKeyForStreamingServiceOCC(ctx, channelNames, insertMsg, result, partitionKeys, ez, schemaVersion, nil)
+	return msgs, err
+}
+
+// repackInsertDataForStreamingServiceOCC repacks insert data into WAL
+// messages and, when occInput is non-nil, attaches an InsertMessageHeader
+// with OCCMode=CAS plus the per-row expected versions.
+func repackInsertDataForStreamingServiceOCC(
+	ctx context.Context,
+	channelNames []string,
+	insertMsg *msgstream.InsertMsg,
+	result *milvuspb.MutationResult,
+	ez *message.CipherConfig,
+	schemaVersion int32,
+	occInput *OCCRowMeta,
+) ([]message.MutableMessage, error) {
+	messages := make([]message.MutableMessage, 0)
+
+	channel2RowOffsets := assignChannelsByPK(result.IDs, channelNames, insertMsg)
+	for channel, rowOffsets := range channel2RowOffsets {
+		partitionName := insertMsg.PartitionName
+		partitionID, err := globalMetaCache.GetPartitionID(ctx, insertMsg.GetDbName(), insertMsg.CollectionName, partitionName)
+		if err != nil {
+			return nil, err
+		}
+		// segment id is assigned at streaming node.
+		msgs, occOuts, err := genInsertMsgsByPartitionWithOCC(ctx, 0, partitionID, partitionName, rowOffsets, channel, insertMsg, occInput)
+		if err != nil {
+			return nil, err
+		}
+		for i, msg := range msgs {
+			insertRequest := msg.(*msgstream.InsertMsg).InsertRequest
+			header := &message.InsertMessageHeader{
+				CollectionId: insertMsg.CollectionID,
+				Partitions: []*message.PartitionSegmentAssignment{
+					{
+						PartitionId: partitionID,
+						Rows:        insertRequest.GetNumRows(),
+						BinarySize:  0, // TODO: current not used, message estimate size is used.
+					},
+				},
+				SchemaVersion: &schemaVersion,
+			}
+			if occInput != nil {
+				attachOCCToInsertHeader(header, occOuts[i])
+			}
+			newMsg, err := message.NewInsertMessageBuilderV1().
+				WithVChannel(channel).
+				WithHeader(header).
+				WithBody(insertRequest).
+				WithCipher(ez).
+				BuildMutable()
+			if err != nil {
+				return nil, err
+			}
+			messages = append(messages, newMsg)
+		}
+	}
+	return messages, nil
+}
+
+// repackInsertDataWithPartitionKeyForStreamingServiceOCC is the OCC-aware
+// variant of repackInsertDataWithPartitionKeyForStreamingService. occInput
+// rows are aligned with insertMsg row order.
+func repackInsertDataWithPartitionKeyForStreamingServiceOCC(
+	ctx context.Context,
+	channelNames []string,
+	insertMsg *msgstream.InsertMsg,
+	result *milvuspb.MutationResult,
+	partitionKeys *schemapb.FieldData,
+	ez *message.CipherConfig,
+	schemaVersion int32,
+	occInput *OCCRowMeta,
+) ([]message.MutableMessage, error) {
 	messages := make([]message.MutableMessage, 0)
 
 	channel2RowOffsets := assignChannelsByPK(result.IDs, channelNames, insertMsg)
@@ -190,25 +264,29 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 		}
 
 		for partitionName, rowOffsets := range partition2RowOffsets {
-			msgs, err := genInsertMsgsByPartition(ctx, 0, partitionIDs[partitionName], partitionName, rowOffsets, channel, insertMsg)
+			msgs, occOuts, err := genInsertMsgsByPartitionWithOCC(ctx, 0, partitionIDs[partitionName], partitionName, rowOffsets, channel, insertMsg, occInput)
 			if err != nil {
 				return nil, err
 			}
-			for _, msg := range msgs {
+			for i, msg := range msgs {
 				insertRequest := msg.(*msgstream.InsertMsg).InsertRequest
+				header := &message.InsertMessageHeader{
+					CollectionId: insertMsg.CollectionID,
+					Partitions: []*message.PartitionSegmentAssignment{
+						{
+							PartitionId: partitionIDs[partitionName],
+							Rows:        insertRequest.GetNumRows(),
+							BinarySize:  0, // TODO: current not used, message estimate size is used.
+						},
+					},
+					SchemaVersion: &schemaVersion,
+				}
+				if occInput != nil {
+					attachOCCToInsertHeader(header, occOuts[i])
+				}
 				newMsg, err := message.NewInsertMessageBuilderV1().
 					WithVChannel(channel).
-					WithHeader(&message.InsertMessageHeader{
-						CollectionId: insertMsg.CollectionID,
-						Partitions: []*message.PartitionSegmentAssignment{
-							{
-								PartitionId: partitionIDs[partitionName],
-								Rows:        insertRequest.GetNumRows(),
-								BinarySize:  0, // TODO: current not used, message estimate size is used.
-							},
-						},
-						SchemaVersion: &schemaVersion,
-					}).
+					WithHeader(header).
 					WithBody(insertRequest).
 					WithCipher(ez).
 					BuildMutable()

--- a/internal/proxy/task_query.go
+++ b/internal/proxy/task_query.go
@@ -88,6 +88,11 @@ type queryTask struct {
 	resolvedTimezoneStr  string
 	storageCost          segcore.StorageCost
 	aggregationFieldMap  *agg.AggregationFieldMap
+
+	// keepTimestamp prevents the result pipeline from stripping the
+	// hidden Timestamp system column. Used by partial-update OCC to
+	// observe per-row version on the proxy side.
+	keepTimestamp bool
 }
 
 func (t *queryTask) getQueryLabel() string {
@@ -989,6 +994,7 @@ func (t *queryTask) PostExecute(ctx context.Context) error {
 		t.GetAggregates(),
 		t.aggregationFieldMap,
 		filterSystemFields(t.GetOutputFieldsId()),
+		t.keepTimestamp,
 	)
 	if err != nil {
 		log.Warn("fail to create query pipeline", zap.Error(err))

--- a/internal/proxy/task_upsert.go
+++ b/internal/proxy/task_upsert.go
@@ -79,6 +79,14 @@ type upsertTask struct {
 	deletePKs       *schemapb.IDs
 	insertFieldData []*schemapb.FieldData
 
+	// partial-update OCC state, populated by queryPreExecute and consumed by
+	// packInsertMessage to construct the InsertMessageHeader CAS extension.
+	// Indices in these slices are aligned with the rows of upsertMsg.InsertMsg.
+	// occExpectedRowTs[i]    : expected hidden Timestamp version of pk[i].
+	// occExpectedRowExists[i]: false means a first-write (CAS expects no row).
+	occExpectedRowTs     []uint64
+	occExpectedRowExists []bool
+
 	storageCost segcore.StorageCost
 }
 
@@ -224,6 +232,10 @@ func retrieveByPKs(ctx context.Context, t *upsertTask, ids *schemapb.IDs, output
 		mixCoord:       t.node.(*Proxy).mixCoord,
 		lb:             t.node.(*Proxy).lbPolicy,
 		shardclientMgr: t.node.(*Proxy).shardMgr,
+		// partial-update OCC needs the hidden Timestamp column to be preserved
+		// in the reduced result so that queryPreExecute can build the per-row
+		// expected version map.
+		keepTimestamp: t.req.GetPartialUpdate(),
 	}
 
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-Upsert-retrieveByPKs")
@@ -279,6 +291,19 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 	}
 
 	existFieldData := resp.GetFieldsData()
+	// For partial-update OCC, peel the hidden Timestamp column from the
+	// query result before downstream merge logic so it does not bleed into
+	// insertFieldData. existRowTs[i] is the version of the i-th row in
+	// existIDs (matched by existPKToIndex below).
+	var existRowTs []uint64
+	if it.req.GetPartialUpdate() {
+		var ok bool
+		existFieldData, existRowTs, ok = extractHiddenTimestampColumn(existFieldData)
+		if !ok {
+			log.Warn("queryPreExecute: timestamp column not found in retrieve result; partial-update will degrade to first-write semantics")
+		}
+		resp.FieldsData = existFieldData
+	}
 	pkFieldData, err := typeutil.GetPrimaryFieldData(existFieldData, primaryFieldSchema)
 	if err != nil {
 		log.Error("get primary field data failed", zap.Error(err))
@@ -374,6 +399,15 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 	it.deletePKs = &schemapb.IDs{}
 	it.insertFieldData = typeutil.PrepareResultFieldData(existFieldData, int64(upsertIDSize))
 
+	// Build a stable existPK -> index mapping once: it is also needed by OCC
+	// version assembly (so we read existRowTs[existIndex] for each update).
+	existIDsLen := typeutil.GetSizeOfIDs(existIDs)
+	existPKToIndex := make(map[interface{}]int, existIDsLen)
+	for j := 0; j < existIDsLen; j++ {
+		pk := typeutil.GetPK(existIDs, int64(j))
+		existPKToIndex[pk] = j
+	}
+
 	if len(updateIdxInUpsert) > 0 {
 		upsertFieldMap := lo.SliceToMap(it.upsertMsg.InsertMsg.GetFieldsData(), func(field *schemapb.FieldData) (int64, *schemapb.FieldData) {
 			return field.FieldId, field
@@ -383,15 +417,8 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 		// fall back to REPLACE.
 		fieldOpMap := buildFieldOpMap(it.req)
 
-		// Build mapping from existing primary keys to their positions in query result
-		// This ensures we can correctly locate data even if query results are not in the same order as request
-		existIDsLen := typeutil.GetSizeOfIDs(existIDs)
-		existPKToIndex := make(map[interface{}]int, existIDsLen)
-		for i := 0; i < existIDsLen; i++ {
-			pk := typeutil.GetPK(existIDs, int64(i))
-			existPKToIndex[pk] = i
-		}
-
+		// existPKToIndex (and existIDsLen) are built once at function scope
+		// above; reuse it so OCC version assembly and the merge path agree.
 		existIndices := make([]int64, len(updateIdxInUpsert))
 		for i, upsertIdx := range updateIdxInUpsert {
 			typeutil.AppendIDs(it.deletePKs, upsertIDs, upsertIdx)
@@ -571,6 +598,17 @@ func (it *upsertTask) queryPreExecute(ctx context.Context) error {
 			}
 		}
 	}
+
+	// Build the per-row OCC expected-version arrays aligned with the row
+	// layout used to populate insertFieldData: [updates in order, then
+	// inserts in order]. This MUST match the order in which insertExecute
+	// later sends rows down to the WAL.
+	occRowTs, occRowExists, err := assignOCCRowVersions(upsertIDs, updateIdxInUpsert, insertIdxInUpsert, existPKToIndex, existRowTs)
+	if err != nil {
+		return err
+	}
+	it.occExpectedRowTs = occRowTs
+	it.occExpectedRowExists = occRowExists
 	return nil
 }
 
@@ -1431,4 +1469,70 @@ func (it *upsertTask) PreExecute(ctx context.Context) error {
 
 func (it *upsertTask) PostExecute(ctx context.Context) error {
 	return nil
+}
+
+// extractHiddenTimestampColumn locates the hidden Timestamp column in a
+// retrieved field-data slice and splits it out as a separate uint64 row
+// version array. It returns the input slice with the timestamp column
+// removed, the per-row timestamps, and ok=true when the column was found.
+// When ok=false the input slice and a nil version slice are returned
+// unchanged so the caller can degrade to first-write semantics.
+func extractHiddenTimestampColumn(fields []*schemapb.FieldData) ([]*schemapb.FieldData, []uint64, bool) {
+	keptIdx := -1
+	for idx, fd := range fields {
+		if fd.GetFieldId() == common.TimeStampField {
+			keptIdx = idx
+			break
+		}
+	}
+	if keptIdx < 0 {
+		return fields, nil, false
+	}
+	tsLong := fields[keptIdx].GetScalars().GetLongData().GetData()
+	existRowTs := make([]uint64, len(tsLong))
+	for i, v := range tsLong {
+		existRowTs[i] = uint64(v)
+	}
+	fields = append(fields[:keptIdx], fields[keptIdx+1:]...)
+	return fields, existRowTs, true
+}
+
+// assignOCCRowVersions builds the per-row OCC (expectedTs, expectedExists)
+// arrays aligned with insertFieldData layout: [updates in order, then
+// first-writes in order]. existPKToIndex maps each existing PK (as returned
+// by typeutil.GetPK) to its position in existRowTs. existRowTs may be nil
+// when the hidden timestamp column was missing; in that case all updates
+// are tagged as expectedExists=true with expectedTs=0 so the streaming-node
+// interceptor degrades gracefully. Returns ErrParameterInvalid when an
+// update PK is missing from the mapping (an internal invariant violation).
+// Returns (nil, nil, nil) when there are no rows to assign.
+func assignOCCRowVersions(
+	upsertIDs *schemapb.IDs,
+	updateIdxInUpsert []int,
+	insertIdxInUpsert []int,
+	existPKToIndex map[interface{}]int,
+	existRowTs []uint64,
+) ([]uint64, []bool, error) {
+	totalRows := len(updateIdxInUpsert) + len(insertIdxInUpsert)
+	if totalRows == 0 {
+		return nil, nil, nil
+	}
+	occExpectedRowTs := make([]uint64, totalRows)
+	occExpectedRowExists := make([]bool, totalRows)
+	for i, idx := range updateIdxInUpsert {
+		oldPK := typeutil.GetPK(upsertIDs, int64(idx))
+		existIndex, ok := existPKToIndex[oldPK]
+		if !ok {
+			return nil, nil, merr.WrapErrParameterInvalidMsg("primary key not found in exist data mapping (occ)")
+		}
+		occExpectedRowExists[i] = true
+		if existRowTs != nil && existIndex < len(existRowTs) {
+			occExpectedRowTs[i] = existRowTs[existIndex]
+		}
+	}
+	for j := range insertIdxInUpsert {
+		occExpectedRowExists[len(updateIdxInUpsert)+j] = false
+		occExpectedRowTs[len(updateIdxInUpsert)+j] = 0
+	}
+	return occExpectedRowTs, occExpectedRowExists, nil
 }

--- a/internal/proxy/task_upsert_streaming.go
+++ b/internal/proxy/task_upsert_streaming.go
@@ -86,10 +86,12 @@ func (ut *upsertTask) packInsertMessage(ctx context.Context, ez *message.CipherC
 
 	// start to repack insert data
 	var msgs []message.MutableMessage
+	occInput := buildUpsertOCCInput(ut.req.GetPartialUpdate(), ut.result.IDs,
+		ut.occExpectedRowTs, ut.occExpectedRowExists)
 	if ut.partitionKeys == nil {
-		msgs, err = repackInsertDataForStreamingService(ut.TraceCtx(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ez, ut.schemaVersion)
+		msgs, err = repackInsertDataForStreamingServiceOCC(ut.TraceCtx(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ez, ut.schemaVersion, occInput)
 	} else {
-		msgs, err = repackInsertDataWithPartitionKeyForStreamingService(ut.TraceCtx(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ut.partitionKeys, ez, ut.schemaVersion)
+		msgs, err = repackInsertDataWithPartitionKeyForStreamingServiceOCC(ut.TraceCtx(), channelNames, ut.upsertMsg.InsertMsg, ut.result, ut.partitionKeys, ez, ut.schemaVersion, occInput)
 	}
 	if err != nil {
 		log.Warn("assign segmentID and repack insert data failed", zap.Error(err))

--- a/internal/streamingnode/server/wal/adaptor/wal_test.go
+++ b/internal/streamingnode/server/wal/adaptor/wal_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/lock"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/partial_update"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/redo"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/replicate"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard"
@@ -61,6 +62,7 @@ func TestWAL(t *testing.T) {
 		lock.NewInterceptorBuilder(),
 		replicate.NewInterceptorBuilder(),
 		timetick.NewInterceptorBuilder(),
+		partial_update.NewInterceptorBuilder(),
 		shard.NewInterceptorBuilder(),
 	)
 	message.RegisterDefaultWALName(message.WALNameTest)

--- a/internal/streamingnode/server/wal/interceptors/partial_update/builder.go
+++ b/internal/streamingnode/server/wal/interceptors/partial_update/builder.go
@@ -1,0 +1,35 @@
+package partial_update
+
+import (
+	"time"
+
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+// NewInterceptorBuilder creates a new pk_state_interceptor builder.
+func NewInterceptorBuilder() interceptors.InterceptorBuilder {
+	return &interceptorBuilder{}
+}
+
+type interceptorBuilder struct{}
+
+func (b *interceptorBuilder) Build(param *interceptors.InterceptorBuildParam) interceptors.Interceptor {
+	timeout := paramtable.Get().StreamingCfg.PartialUpdatePKVersionCacheTimeout.GetAsDurationByParse()
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	ready := make(chan struct{})
+	// TODO(partial_update recovery): currently the interceptor is ready
+	// immediately, so right after a leader switch the PK version cache is cold
+	// and stale CAS appends may be wrongly accepted (assumed-historical match).
+	// Phase 2 recovery should rebuild the cache from WAL/storage history and
+	// only close(ready) once the cache has caught up to the current checkpoint,
+	// gating CAS appends until then. See PartialUpdatePKVersionCacheTimeout for
+	// the eviction side; recovery is the cold-start side of the same cache.
+	close(ready)
+	return &pkStateInterceptor{
+		cache: NewPKVersionCache(timeout),
+		ready: ready,
+	}
+}

--- a/internal/streamingnode/server/wal/interceptors/partial_update/partial_update_concurrent_test.go
+++ b/internal/streamingnode/server/wal/interceptors/partial_update/partial_update_concurrent_test.go
@@ -1,0 +1,157 @@
+package partial_update
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+)
+
+// TestConcurrentLostUpdateEliminated simulates two clients racing to update
+// the same primary key. Each client repeatedly:
+//
+//  1. reads the current cached version (representing queryPreExecute)
+//  2. attempts an OCC append at that version
+//  3. on conflict, retries with the freshly observed version
+//
+// The invariant is that the final cached version equals the timestamp of the
+// last successful append AND the total successful appends equals the sum of
+// per-client successes (no append silently lost).
+func TestConcurrentLostUpdateEliminated(t *testing.T) {
+	itc := newTestInterceptor()
+
+	const pk = int64(1000)
+	key := pkKey{collectionID: 1, pk: pk}
+	// Bootstrap the cache so subsequent ops are version-bound updates.
+	{
+		unlock := itc.cache.Lock([]pkKey{key})
+		itc.cache.Update(key, 1)
+		unlock()
+	}
+
+	const clientA = "A"
+	const clientB = "B"
+	const opsPerClient = 200
+
+	var (
+		successA, successB         int64
+		conflictA                  int64
+		conflictB                  int64
+		lastSuccessA, lastSuccessB uint64
+	)
+
+	// nextTS is the per-client tick used as the new version after a successful
+	// append. We multiplex the two clients into disjoint ts ranges so the
+	// final cache value reveals which client landed last.
+	tsA := uint64(1_000_000)
+	tsB := uint64(2_000_000)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	runClient := func(name string, baseTS *uint64, success, conflict *int64, lastSuccess *uint64) {
+		defer wg.Done()
+		for i := 0; i < opsPerClient; i++ {
+			// Step 1: snapshot the current version (analogous to queryPreExecute).
+			itc.cache.shards[shardOf(key)].mu.Lock()
+			var expectedTS uint64
+			if e := itc.cache.shards[shardOf(key)].cache[key]; e != nil {
+				expectedTS = e.ts
+			}
+			itc.cache.shards[shardOf(key)].mu.Unlock()
+
+			// Step 2: Build OCC message at the snapshot version.
+			myTS := atomic.AddUint64(baseTS, 1)
+			msg := buildOCCMessageWithTimeTick(t, []int64{pk}, []uint64{expectedTS}, []bool{true}, myTS)
+
+			_, err := itc.DoAppend(context.Background(), msg, func(ctx context.Context, m message.MutableMessage) (message.MessageID, error) {
+				return nil, nil
+			})
+			if err == nil {
+				atomic.AddInt64(success, 1)
+				atomic.StoreUint64(lastSuccess, myTS)
+				_ = name
+			} else if IsPKStateConflict(err) {
+				atomic.AddInt64(conflict, 1)
+				// Retry next iteration; outer loop just continues.
+				i-- // reattempt this op
+			} else {
+				t.Errorf("unexpected err: %v", err)
+				return
+			}
+		}
+	}
+	go runClient(clientA, &tsA, &successA, &conflictA, &lastSuccessA)
+	go runClient(clientB, &tsB, &successB, &conflictB, &lastSuccessB)
+	wg.Wait()
+
+	// Both clients must succeed at exactly opsPerClient.
+	assert.EqualValues(t, opsPerClient, successA, "client A successes")
+	assert.EqualValues(t, opsPerClient, successB, "client B successes")
+
+	// At least one conflict should have happened in a real race. If neither
+	// observed a conflict the test scheduler simply serialized the goroutines
+	// (still correct, but make the assertion non-strict).
+	t.Logf("conflicts: A=%d B=%d", conflictA, conflictB)
+
+	// Final cache value must equal the last successful tick from one of the
+	// two clients. We can't know which, but it must equal one of the two
+	// clients' last successful ts (whichever landed last).
+	itc.cache.shards[shardOf(key)].mu.Lock()
+	var final uint64
+	if e := itc.cache.shards[shardOf(key)].cache[key]; e != nil {
+		final = e.ts
+	}
+	itc.cache.shards[shardOf(key)].mu.Unlock()
+
+	if final != lastSuccessA && final != lastSuccessB {
+		t.Fatalf("final cache version %d did not match either client's last successful ts (A=%d, B=%d) — silent lost update", final, lastSuccessA, lastSuccessB)
+	}
+}
+
+// buildOCCMessageWithTimeTick is a thin variant of buildInsertMessageWithOCC
+// that assigns a caller-provided time tick. The interceptor uses TimeTick()
+// to advance the version cache, so this lets us simulate distinct successful
+// append timestamps.
+func buildOCCMessageWithTimeTick(t *testing.T, pks []int64, ts []uint64, exists []bool, timetick uint64) message.MutableMessage {
+	t.Helper()
+	header := &message.InsertMessageHeader{
+		CollectionId: 1,
+		Partitions: []*message.PartitionSegmentAssignment{
+			{PartitionId: 2, Rows: uint64(len(pks)), BinarySize: 1},
+		},
+		OccMode:               messagespb.OCCMode_OCC_MODE_CAS,
+		ExpectedPks:           &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: pks}}},
+		ExpectedRowTimestamps: ts,
+		ExpectedRowExists:     exists,
+	}
+	body := &msgpb.InsertRequest{
+		Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_Insert, SourceID: 1},
+		ShardName:      "v1",
+		DbName:         "db",
+		CollectionName: "c",
+		PartitionName:  "p",
+		CollectionID:   1,
+		PartitionID:    2,
+		Version:        msgpb.InsertDataVersion_ColumnBased,
+		RowIDs:         make([]int64, len(pks)),
+		Timestamps:     make([]uint64, len(pks)),
+		NumRows:        uint64(len(pks)),
+	}
+	msg, err := message.NewInsertMessageBuilderV1().
+		WithHeader(header).
+		WithBody(body).
+		WithVChannel("v1").
+		BuildMutable()
+	assert.NoError(t, err)
+	msg.WithTimeTick(timetick)
+	return msg
+}

--- a/internal/streamingnode/server/wal/interceptors/partial_update/partial_update_interceptor.go
+++ b/internal/streamingnode/server/wal/interceptors/partial_update/partial_update_interceptor.go
@@ -1,0 +1,116 @@
+package partial_update
+
+import (
+	"context"
+
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+const (
+	interceptorName = "pk_state"
+)
+
+// IsPKStateConflict reports whether err originated from a CAS conflict
+// raised by this interceptor. Safe to call after the error has crossed the
+// WAL append RPC boundary (StreamingClient re-hydrates StreamingError).
+func IsPKStateConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	se := status.AsStreamingError(err)
+	if se == nil {
+		return false
+	}
+	return se.IsPKStateConflict()
+}
+
+// newConflictError wraps the underlying CAS-mismatch reason into a
+// StreamingError that survives the WAL append RPC round trip.
+func newConflictError(reason string) error {
+	return status.NewInner("%s%s", status.PKStateConflictCausePrefix, reason)
+}
+
+var (
+	_ interceptors.Interceptor            = (*pkStateInterceptor)(nil)
+	_ interceptors.InterceptorWithMetrics = (*pkStateInterceptor)(nil)
+	_ interceptors.InterceptorWithReady   = (*pkStateInterceptor)(nil)
+)
+
+// pkStateInterceptor enforces optimistic concurrency control for
+// pk-state CAS upserts at the WAL append boundary.
+type pkStateInterceptor struct {
+	cache *PKVersionCache
+	ready chan struct{}
+}
+
+func (p *pkStateInterceptor) Name() string { return interceptorName }
+
+func (p *pkStateInterceptor) Ready() <-chan struct{} { return p.ready }
+
+func (p *pkStateInterceptor) Close() { p.cache.Close() }
+
+// DoAppend performs the CAS check for pk-state inserts. For all other
+// messages it is a transparent pass-through.
+func (p *pkStateInterceptor) DoAppend(ctx context.Context, msg message.MutableMessage, appendOp interceptors.Append) (message.MessageID, error) {
+	if msg.MessageType() != message.MessageTypeInsert {
+		return appendOp(ctx, msg)
+	}
+	im := message.MustAsMutableInsertMessageV1(msg)
+	h := im.Header()
+	if h.GetOccMode() != messagespb.OCCMode_OCC_MODE_CAS {
+		return appendOp(ctx, msg)
+	}
+
+	// Wait until interceptor is ready (CAS state is recovered).
+	select {
+	case <-p.ready:
+	default:
+		select {
+		case <-p.ready:
+		case <-ctx.Done():
+			return nil, status.NewOnShutdownError("pk-state interceptor not ready, leader switching")
+		}
+	}
+
+	expectedPks := h.GetExpectedPks()
+	expectedTs := h.GetExpectedRowTimestamps()
+	expectedExists := h.GetExpectedRowExists()
+	pkSize := typeutil.GetSizeOfIDs(expectedPks)
+	if pkSize != len(expectedTs) || pkSize != len(expectedExists) {
+		return nil, status.NewUnrecoverableError("pk-state OCC header malformed")
+	}
+
+	collectionID := h.GetCollectionId()
+	keys := make([]pkKey, 0, pkSize)
+	for i := 0; i < pkSize; i++ {
+		pk := typeutil.GetPK(expectedPks, int64(i))
+		keys = append(keys, pkKey{collectionID: collectionID, pk: pk})
+	}
+
+	unlock := p.cache.Lock(keys)
+	// Check phase.
+	for i, key := range keys {
+		if err := p.cache.Check(key, expectedTs[i], expectedExists[i]); err != nil {
+			unlock()
+			return nil, newConflictError(err.Error())
+		}
+	}
+	// Append.
+	msgID, err := appendOp(ctx, msg)
+	if err != nil {
+		unlock()
+		return nil, err
+	}
+	// Update cache with the assigned TimeTick. Timetick interceptor runs
+	// before pk_state in the chain, so msg.TimeTick() is set.
+	ts := msg.TimeTick()
+	for _, key := range keys {
+		p.cache.Update(key, ts)
+	}
+	unlock()
+	return msgID, nil
+}

--- a/internal/streamingnode/server/wal/interceptors/partial_update/partial_update_interceptor_test.go
+++ b/internal/streamingnode/server/wal/interceptors/partial_update/partial_update_interceptor_test.go
@@ -1,0 +1,173 @@
+package partial_update
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+)
+
+// buildInsertMessageWithOCC builds a mutable insert message carrying an OCC
+// header. expected[i] is consumed as (pk, ts, exists) triples.
+func buildInsertMessageWithOCC(t *testing.T, pks []int64, ts []uint64, exists []bool) message.MutableMessage {
+	t.Helper()
+	header := &message.InsertMessageHeader{
+		CollectionId: 1,
+		Partitions: []*message.PartitionSegmentAssignment{
+			{PartitionId: 2, Rows: uint64(len(pks)), BinarySize: 1},
+		},
+		OccMode:               messagespb.OCCMode_OCC_MODE_CAS,
+		ExpectedPks:           &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: pks}}},
+		ExpectedRowTimestamps: ts,
+		ExpectedRowExists:     exists,
+	}
+	body := &msgpb.InsertRequest{
+		Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_Insert, SourceID: 1},
+		ShardName:      "v1",
+		DbName:         "db",
+		CollectionName: "c",
+		PartitionName:  "p",
+		DbID:           1,
+		CollectionID:   1,
+		PartitionID:    2,
+		SegmentID:      0,
+		Version:        msgpb.InsertDataVersion_ColumnBased,
+		FieldsData:     nil,
+		RowIDs:         make([]int64, len(pks)),
+		Timestamps:     make([]uint64, len(pks)),
+		NumRows:        uint64(len(pks)),
+	}
+	msg, err := message.NewInsertMessageBuilderV1().
+		WithHeader(header).
+		WithBody(body).
+		WithVChannel("v1").
+		BuildMutable()
+	assert.NoError(t, err)
+	// Set a deterministic time tick so the interceptor can populate the
+	// version cache after a successful append.
+	msg.WithTimeTick(1234)
+	return msg
+}
+
+func newTestInterceptor() *pkStateInterceptor {
+	ready := make(chan struct{})
+	close(ready)
+	return &pkStateInterceptor{
+		cache: NewPKVersionCache(0),
+		ready: ready,
+	}
+}
+
+func TestIsPKStateConflict(t *testing.T) {
+	assert.False(t, IsPKStateConflict(nil))
+	assert.False(t, IsPKStateConflict(errors.New("plain error")))
+	assert.False(t, IsPKStateConflict(status.NewUnrecoverableError("not me")))
+	conflict := newConflictError("pk=1 mismatch")
+	assert.True(t, IsPKStateConflict(conflict))
+	// Wrapping in fmt.Errorf still preserves detection.
+	wrapped := fmt.Errorf("oops: %w", conflict)
+	assert.True(t, IsPKStateConflict(wrapped))
+}
+
+func TestPKStateInterceptor_FirstWritePath(t *testing.T) {
+	itc := newTestInterceptor()
+	msg := buildInsertMessageWithOCC(t, []int64{10}, []uint64{0}, []bool{false})
+
+	called := false
+	id, err := itc.DoAppend(context.Background(), msg, func(ctx context.Context, m message.MutableMessage) (message.MessageID, error) {
+		called = true
+		return nil, nil
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, id)
+	assert.True(t, called, "appendOp should be invoked when CAS succeeds")
+}
+
+func TestPKStateInterceptor_ReinsertAfterDeleteAccepted(t *testing.T) {
+	itc := newTestInterceptor()
+	// Pre-populate the cache to simulate a stale post-delete remnant: the row
+	// was written (ts=100) and later deleted, but the cache entry lingers.
+	{
+		unlock := itc.cache.Lock([]pkKey{{collectionID: 1, pk: int64(11)}})
+		itc.cache.Update(pkKey{collectionID: 1, pk: int64(11)}, 100)
+		unlock()
+	}
+	// A re-insert (expectedExists=false) of the same PK must be accepted, not
+	// rejected as a conflict: the caller observed the row as non-existent, so
+	// the lingering entry can only be a stale post-delete remnant.
+	msg := buildInsertMessageWithOCC(t, []int64{11}, []uint64{0}, []bool{false})
+
+	called := false
+	_, err := itc.DoAppend(context.Background(), msg, func(ctx context.Context, m message.MutableMessage) (message.MessageID, error) {
+		called = true
+		return nil, nil
+	})
+	assert.NoError(t, err)
+	assert.True(t, called, "appendOp should be invoked for a re-insert after delete")
+}
+
+func TestPKStateInterceptor_VersionMismatch(t *testing.T) {
+	itc := newTestInterceptor()
+	{
+		unlock := itc.cache.Lock([]pkKey{{collectionID: 1, pk: int64(12)}})
+		itc.cache.Update(pkKey{collectionID: 1, pk: int64(12)}, 200)
+		unlock()
+	}
+	// Caller thinks the row is at ts=199, actual cache has 200 -> conflict.
+	msg := buildInsertMessageWithOCC(t, []int64{12}, []uint64{199}, []bool{true})
+
+	_, err := itc.DoAppend(context.Background(), msg, func(ctx context.Context, m message.MutableMessage) (message.MessageID, error) {
+		t.Fatal("appendOp must NOT be called on conflict")
+		return nil, nil
+	})
+	assert.Error(t, err)
+	assert.True(t, IsPKStateConflict(err))
+}
+
+func TestPKStateInterceptor_PassThroughNonOCC(t *testing.T) {
+	itc := newTestInterceptor()
+	header := &message.InsertMessageHeader{
+		CollectionId: 1,
+		Partitions: []*message.PartitionSegmentAssignment{
+			{PartitionId: 2, Rows: 1, BinarySize: 1},
+		},
+		// No OccMode, no expected* fields.
+	}
+	body := &msgpb.InsertRequest{
+		Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_Insert, SourceID: 1},
+		ShardName:      "v1",
+		DbName:         "db",
+		CollectionName: "c",
+		PartitionName:  "p",
+		CollectionID:   1,
+		PartitionID:    2,
+		Version:        msgpb.InsertDataVersion_ColumnBased,
+		RowIDs:         []int64{0},
+		Timestamps:     []uint64{0},
+		NumRows:        1,
+	}
+	msg, err := message.NewInsertMessageBuilderV1().
+		WithHeader(header).
+		WithBody(body).
+		WithVChannel("v1").
+		BuildMutable()
+	assert.NoError(t, err)
+	msg.WithTimeTick(1)
+
+	called := false
+	_, err = itc.DoAppend(context.Background(), msg, func(ctx context.Context, m message.MutableMessage) (message.MessageID, error) {
+		called = true
+		return nil, nil
+	})
+	assert.NoError(t, err)
+	assert.True(t, called, "non-OCC inserts must pass through")
+}

--- a/internal/streamingnode/server/wal/interceptors/partial_update/pk_version_checker.go
+++ b/internal/streamingnode/server/wal/interceptors/partial_update/pk_version_checker.go
@@ -1,0 +1,231 @@
+// Package partial_update implements optimistic concurrency control (OCC/CAS)
+// for pk-state CAS upsert at the streaming-node WAL append layer.
+package partial_update
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+// numShards is the number of shards for the PK lock map.
+const numShards = 256
+
+// pkKey scopes a primary key to its collection. Identical PK values in
+// different collections must NOT share a version-cache entry, otherwise a
+// CAS Check for one collection would observe (and conflict with) another
+// collection's version. The cache is keyed by this composite, never by the
+// bare PK.
+type pkKey struct {
+	collectionID int64
+	pk           interface{}
+}
+
+// ErrCASConflict indicates the expected version of a PK does not match the
+// observed last-appended version, so the pk-state must be retried.
+var ErrCASConflict = errors.New("pk-state CAS conflict")
+
+// ErrUnavailable indicates the version cache is not yet ready to serve
+// (e.g. still recovering from history after a leader switch).
+var ErrUnavailable = errors.New("pk-state PK version cache unavailable")
+
+// pkEntry is a single cached PK version together with the last time it was
+// touched by a CAS Check. lastCheck drives the timeout-based LRU eviction.
+type pkEntry struct {
+	ts        uint64
+	lastCheck time.Time
+}
+
+// PKVersionCache keeps a hot in-memory cache of the last successfully
+// appended Timestamp for each primary key, sharded by hash(pk) mod numShards
+// to reduce lock contention. Entries that have not been touched by a CAS
+// Check within timeout are evicted by a background sweeper (LRU by last
+// Check time).
+type PKVersionCache struct {
+	shards  [numShards]pkShard
+	timeout time.Duration
+	stop    chan struct{}
+	stopped sync.Once
+}
+
+type pkShard struct {
+	mu    sync.Mutex
+	cache map[pkKey]*pkEntry
+}
+
+// NewPKVersionCache creates a new PKVersionCache. timeout is the LRU idle
+// window: PK entries not touched by a CAS Check within timeout are evicted by
+// a background sweeper. A non-positive timeout disables eviction (and the
+// sweeper goroutine), which is intended for tests.
+func NewPKVersionCache(timeout time.Duration) *PKVersionCache {
+	c := &PKVersionCache{timeout: timeout, stop: make(chan struct{})}
+	for i := 0; i < numShards; i++ {
+		c.shards[i].cache = make(map[pkKey]*pkEntry)
+	}
+	if timeout > 0 {
+		go c.sweepLoop()
+	}
+	return c
+}
+
+// Close stops the background sweeper. Safe to call multiple times.
+func (c *PKVersionCache) Close() {
+	c.stopped.Do(func() { close(c.stop) })
+}
+
+// sweepLoop periodically evicts entries idle for longer than timeout.
+func (c *PKVersionCache) sweepLoop() {
+	interval := c.timeout / 2
+	if interval < time.Second {
+		interval = time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			c.sweep(time.Now())
+		}
+	}
+}
+
+// sweep evicts entries whose lastCheck is older than now-timeout.
+func (c *PKVersionCache) sweep(now time.Time) {
+	deadline := now.Add(-c.timeout)
+	for i := 0; i < numShards; i++ {
+		s := &c.shards[i]
+		s.mu.Lock()
+		for pk, e := range s.cache {
+			if e.lastCheck.Before(deadline) {
+				delete(s.cache, pk)
+			}
+		}
+		s.mu.Unlock()
+	}
+}
+
+// shardOf returns the shard index for a composite (collectionID, pk) key.
+func shardOf(key pkKey) int {
+	var cb [8]byte
+	binary.LittleEndian.PutUint64(cb[:], uint64(key.collectionID))
+	switch v := key.pk.(type) {
+	case int64:
+		// Mix bits of pk, then fold in the collection id.
+		u := uint64(v)
+		u ^= u >> 33
+		u *= 0xff51afd7ed558ccd
+		u ^= u >> 33
+		u ^= uint64(key.collectionID) * 0x9e3779b97f4a7c15
+		return int(u % numShards)
+	case string:
+		h := fnv.New64a()
+		_, _ = h.Write(cb[:])
+		_, _ = h.Write([]byte(v))
+		return int(h.Sum64() % numShards)
+	default:
+		return int(uint64(key.collectionID) % numShards)
+	}
+}
+
+// Lock acquires per-PK locks for the given composite keys. Keys are
+// deduplicated and sorted (by shard index) before acquiring locks to avoid
+// deadlocks across concurrent callers. The returned function releases the
+// locks.
+func (c *PKVersionCache) Lock(keys []pkKey) func() {
+	if len(keys) == 0 {
+		return func() {}
+	}
+	// Compute shard set (dedup).
+	seen := make(map[int]struct{}, len(keys))
+	shardIdx := make([]int, 0, len(keys))
+	for _, key := range keys {
+		s := shardOf(key)
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		shardIdx = append(shardIdx, s)
+	}
+	sort.Ints(shardIdx)
+	for _, s := range shardIdx {
+		c.shards[s].mu.Lock()
+	}
+	return func() {
+		// Reverse-order unlock for symmetry.
+		for i := len(shardIdx) - 1; i >= 0; i-- {
+			c.shards[shardIdx[i]].mu.Unlock()
+		}
+	}
+}
+
+// Check verifies the expected version for a key is still the latest one
+// observed by the cache. OCC semantics here are monotonic: the caller asserts
+// "no one has written this key after the version I read"; the cache only
+// rejects when it has already seen a strictly newer version. Caller MUST hold
+// the shard lock for key (acquired via Lock).
+//
+//   - expectedExists=false: always accepted. A non-existent-row assertion
+//     that still finds a cache entry can only mean the row was deleted after
+//     the version was cached (a stale entry), since cache entries are created
+//     solely by successful OCC writes and the caller's read ran at Strong
+//     consistency. Treat it as a legitimate re-insert and let the subsequent
+//     Update advance the version, restoring full protection for the new row.
+//     This gives up concurrent duplicate-insert detection (not a lost update),
+//     but keeps the concurrent-update (expectedExists=true) protection intact.
+//   - expectedExists=true:
+//   - cache miss: accepted (cold-start / post-recovery historical match).
+//   - cached > expected: ErrCASConflict (a later write has happened).
+//   - cached <= expected: accepted; cache is lazily advanced to expectedTs
+//     so subsequent checks see the latest known version even when a
+//     non-OCC path (regular insert / regular upsert) advanced the segment
+//     hidden timestamp without going through this interceptor.
+func (c *PKVersionCache) Check(key pkKey, expectedTs uint64, expectedExists bool) error {
+	s := &c.shards[shardOf(key)]
+	cur, ok := s.cache[key]
+	if ok {
+		// Refresh the idle timer: a touched PK is kept hot (LRU by last Check).
+		cur.lastCheck = time.Now()
+	}
+	if !expectedExists {
+		// First-write / re-insert after delete: always accept. The caller
+		// observed the row as non-existent; any lingering cache entry is a
+		// stale post-delete remnant and must not block the re-insert.
+		return nil
+	}
+	if !ok {
+		// Cold cache, accept and rely on storage-side recovery.
+		// TODO(partial_update recovery): this assumed-historical match is unsafe
+		// right after a leader switch when the cache is cold but the PK actually
+		// has a newer version in WAL/storage history. Phase 2 recovery must warm
+		// the cache before serving CAS, so a genuine miss here means "truly first
+		// write" rather than "not yet recovered". See builder.go ready-gating.
+		return nil
+	}
+	if cur.ts > expectedTs {
+		return errors.Wrapf(ErrCASConflict, "pk version mismatch: cached=%d > expected=%d", cur.ts, expectedTs)
+	}
+	if cur.ts < expectedTs {
+		cur.ts = expectedTs
+	}
+	return nil
+}
+
+// Update advances the cached version for key to max(cache[key], ts).
+// Caller MUST hold the shard lock for key.
+func (c *PKVersionCache) Update(key pkKey, ts uint64) {
+	s := &c.shards[shardOf(key)]
+	if cur, ok := s.cache[key]; ok {
+		if cur.ts < ts {
+			cur.ts = ts
+		}
+		cur.lastCheck = time.Now()
+		return
+	}
+	s.cache[key] = &pkEntry{ts: ts, lastCheck: time.Now()}
+}

--- a/internal/streamingnode/server/wal/interceptors/partial_update/pk_version_checker_test.go
+++ b/internal/streamingnode/server/wal/interceptors/partial_update/pk_version_checker_test.go
@@ -1,0 +1,141 @@
+package partial_update
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPKVersionCache_FirstWrite(t *testing.T) {
+	c := NewPKVersionCache(0)
+	k := pkKey{collectionID: 1, pk: int64(1)}
+	unlock := c.Lock([]pkKey{k})
+	defer unlock()
+
+	// expectedExists=false on a cold cache must succeed (first-write CAS).
+	assert.NoError(t, c.Check(k, 0, false))
+	c.Update(k, 100)
+
+	// A second first-write attempt (re-insert after delete) must also be
+	// accepted: a non-existent-row assertion that still finds a cache entry
+	// can only be a stale post-delete remnant, never a real conflict.
+	assert.NoError(t, c.Check(k, 0, false))
+}
+
+func TestPKVersionCache_UpdateMatch(t *testing.T) {
+	c := NewPKVersionCache(0)
+	k := pkKey{collectionID: 1, pk: int64(2)}
+	unlock := c.Lock([]pkKey{k})
+	defer unlock()
+
+	c.Update(k, 200)
+	// Matching version on update path passes.
+	assert.NoError(t, c.Check(k, 200, true))
+
+	// Mismatching version must fail with ErrCASConflict.
+	err := c.Check(k, 199, true)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCASConflict))
+}
+
+func TestPKVersionCache_ColdCacheUpdateAccepted(t *testing.T) {
+	c := NewPKVersionCache(0)
+	k := pkKey{collectionID: 1, pk: int64(3)}
+	unlock := c.Lock([]pkKey{k})
+	defer unlock()
+
+	// expectedExists=true with empty cache: accepted (recovery hot-path).
+	assert.NoError(t, c.Check(k, 999, true))
+}
+
+// TestPKVersionCache_CachedBehindExpectedAccepted verifies the monotonic OCC
+// semantics: when the cache is lagging the version observed by the caller
+// (e.g. a non-OCC path such as regular insert/upsert advanced the segment
+// hidden timestamp without going through this interceptor), Check must accept
+// and lazily advance the cache. Only cached > expected is a real conflict.
+func TestPKVersionCache_CachedBehindExpectedAccepted(t *testing.T) {
+	c := NewPKVersionCache(0)
+	k := pkKey{collectionID: 1, pk: int64(5)}
+	unlock := c.Lock([]pkKey{k})
+	defer unlock()
+
+	c.Update(k, 100)
+	// Caller observed a newer version (200) than the cache (100): the cache
+	// is behind because a non-OCC path advanced the segment hidden ts. The
+	// CAS must accept and advance the cache to expected.
+	assert.NoError(t, c.Check(k, 200, true))
+	// A subsequent matching check at the new version must also pass.
+	assert.NoError(t, c.Check(k, 200, true))
+	// And going back to the stale version must now be a conflict.
+	err := c.Check(k, 100, true)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCASConflict))
+}
+
+func TestPKVersionCache_UpdateMonotonic(t *testing.T) {
+	c := NewPKVersionCache(0)
+	k := pkKey{collectionID: 1, pk: int64(4)}
+	unlock := c.Lock([]pkKey{k})
+	defer unlock()
+
+	c.Update(k, 100)
+	c.Update(k, 50) // older ts must not regress the cache.
+	assert.NoError(t, c.Check(k, 100, true))
+}
+
+func TestPKVersionCache_StringPK(t *testing.T) {
+	c := NewPKVersionCache(0)
+	k := pkKey{collectionID: 1, pk: "abc"}
+	unlock := c.Lock([]pkKey{k})
+	defer unlock()
+
+	assert.NoError(t, c.Check(k, 0, false))
+	c.Update(k, 42)
+	assert.NoError(t, c.Check(k, 42, true))
+	assert.Error(t, c.Check(k, 41, true))
+}
+
+// TestPKVersionCache_CollectionIsolation verifies that identical PK values in
+// different collections keep independent versions: a CAS Check for one
+// collection must not observe (and conflict with) another collection's
+// version.
+func TestPKVersionCache_CollectionIsolation(t *testing.T) {
+	c := NewPKVersionCache(0)
+	kA := pkKey{collectionID: 100, pk: int64(7)}
+	kB := pkKey{collectionID: 200, pk: int64(7)}
+	unlock := c.Lock([]pkKey{kA, kB})
+	defer unlock()
+
+	c.Update(kA, 500)
+	// Collection B has never seen pk 7: a first-write CAS must succeed even
+	// though collection A already holds pk 7.
+	assert.NoError(t, c.Check(kB, 0, false))
+	// Collection A still observes its own version.
+	assert.NoError(t, c.Check(kA, 500, true))
+}
+
+func TestPKVersionCache_ConcurrentSafe(t *testing.T) {
+	// Verify that the sharded lock scheme actually serializes per-PK CAS
+	// even under contention.
+	c := NewPKVersionCache(0)
+	const goroutines = 32
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				k7 := pkKey{collectionID: 1, pk: int64(7)}
+				k8 := pkKey{collectionID: 1, pk: int64(8)}
+				unlock := c.Lock([]pkKey{k7, k8})
+				c.Update(k7, uint64(i))
+				c.Update(k8, uint64(i))
+				unlock()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/streamingnode/server/walmanager/manager_impl.go
+++ b/internal/streamingnode/server/walmanager/manager_impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/adaptor"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/lock"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/partial_update"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/redo"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/replicate"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/interceptors/shard"
@@ -33,6 +34,7 @@ func OpenManager() (Manager, error) {
 			lock.NewInterceptorBuilder(),
 			replicate.NewInterceptorBuilder(),
 			timetick.NewInterceptorBuilder(),
+			partial_update.NewInterceptorBuilder(),
 			shard.NewInterceptorBuilder(),
 		},
 	)

--- a/internal/util/streamingutil/status/streaming_error.go
+++ b/internal/util/streamingutil/status/streaming_error.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -9,6 +10,16 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 )
+
+// PKStateConflictCausePrefix is the prefix prepended to the Cause field of the
+// StreamingError raised on a pk-state CAS conflict. The streamingpb
+// StreamingCode enum is a stable wire contract that cannot be extended without
+// a coordinated proto rollout, so the conflict is signaled by string-matching
+// on this prefix (the code itself is STREAMING_CODE_INNER).
+//
+// Note: redact.Sprintf used by New strips inner whitespace from format
+// strings, so the prefix must NOT contain spaces.
+const PKStateConflictCausePrefix = "pk_state_conflict:"
 
 var _ error = (*StreamingError)(nil)
 
@@ -99,6 +110,15 @@ func (e *StreamingError) IsOnShutdown() bool {
 // IsRateLimitRejected returns true if the error is caused by rate limit rejected.
 func (e *StreamingError) IsRateLimitRejected() bool {
 	return e.Code == streamingpb.StreamingCode_STREAMING_CODE_RATE_LIMIT_REJECTED
+}
+
+// IsPKStateConflict returns true if the error is a pk-state CAS conflict
+// raised by the partial-update interceptor. Such conflicts must NOT be
+// retried inside the streaming client: they have to bubble up to the proxy
+// so its bounded OCC retry loop can re-read the latest row versions.
+func (e *StreamingError) IsPKStateConflict() bool {
+	return e.Code == streamingpb.StreamingCode_STREAMING_CODE_INNER &&
+		strings.HasPrefix(e.Cause, PKStateConflictCausePrefix)
 }
 
 // NewOnShutdownError creates a new StreamingError with code STREAMING_CODE_ON_SHUTDOWN.

--- a/pkg/proto/messages.proto
+++ b/pkg/proto/messages.proto
@@ -162,6 +162,31 @@ message InsertMessageHeader {
     repeated PartitionSegmentAssignment partitions = 2;
     // optional so consumers can distinguish omitted (legacy producer) from explicit value.
     optional int32 schema_version                  = 3;
+    // pk_state OCC (optimistic concurrency control) extension.
+    // When occ_mode = OCC_MODE_CAS, streaming node will perform a CAS check
+    // against PKVersionCache before appending the body. The check uses
+    // expected_pks / expected_row_timestamps / expected_row_exists aligned
+    // with the rows carried in the InsertRequest body (same order, same length).
+    OCCMode occ_mode                               = 4;
+    // expected_pks carries the primary key value for each row, used by the
+    // pk_state_interceptor to acquire the per-PK CAS lock without
+    // depending on schema knowledge inside streamingnode.
+    schema.IDs expected_pks                        = 5;
+    // expected_row_timestamps is the row-level expected version (the hidden
+    // Timestamp system field of the previously read row). Length must match
+    // the number of rows in the body when occ_mode != OCC_MODE_NONE.
+    // When expected_row_exists[i] == false, expected_row_timestamps[i] is
+    // ignored and the CAS expects "no existing row for this PK".
+    repeated uint64 expected_row_timestamps        = 6;
+    // expected_row_exists indicates whether the i-th row was a read-modify-write
+    // (true) or a brand-new first-write insert (false).
+    repeated bool expected_row_exists              = 7;
+}
+
+// OCCMode is the optimistic concurrency control mode of an insert message.
+enum OCCMode {
+    OCC_MODE_NONE = 0;
+    OCC_MODE_CAS  = 1;
 }
 
 // PartitionSegmentAssignment is the segment assignment of a partition.

--- a/pkg/proto/messagespb/messages.pb.go
+++ b/pkg/proto/messagespb/messages.pb.go
@@ -253,6 +253,53 @@ func (MessageType) EnumDescriptor() ([]byte, []int) {
 	return file_messages_proto_rawDescGZIP(), []int{0}
 }
 
+// OCCMode is the optimistic concurrency control mode of an insert message.
+type OCCMode int32
+
+const (
+	OCCMode_OCC_MODE_NONE OCCMode = 0
+	OCCMode_OCC_MODE_CAS  OCCMode = 1
+)
+
+// Enum value maps for OCCMode.
+var (
+	OCCMode_name = map[int32]string{
+		0: "OCC_MODE_NONE",
+		1: "OCC_MODE_CAS",
+	}
+	OCCMode_value = map[string]int32{
+		"OCC_MODE_NONE": 0,
+		"OCC_MODE_CAS":  1,
+	}
+)
+
+func (x OCCMode) Enum() *OCCMode {
+	p := new(OCCMode)
+	*p = x
+	return p
+}
+
+func (x OCCMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (OCCMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_messages_proto_enumTypes[1].Descriptor()
+}
+
+func (OCCMode) Type() protoreflect.EnumType {
+	return &file_messages_proto_enumTypes[1]
+}
+
+func (x OCCMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use OCCMode.Descriptor instead.
+func (OCCMode) EnumDescriptor() ([]byte, []int) {
+	return file_messages_proto_rawDescGZIP(), []int{1}
+}
+
 type TxnState int32
 
 const (
@@ -301,11 +348,11 @@ func (x TxnState) String() string {
 }
 
 func (TxnState) Descriptor() protoreflect.EnumDescriptor {
-	return file_messages_proto_enumTypes[1].Descriptor()
+	return file_messages_proto_enumTypes[2].Descriptor()
 }
 
 func (TxnState) Type() protoreflect.EnumType {
-	return &file_messages_proto_enumTypes[1]
+	return &file_messages_proto_enumTypes[2]
 }
 
 func (x TxnState) Number() protoreflect.EnumNumber {
@@ -314,7 +361,7 @@ func (x TxnState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use TxnState.Descriptor instead.
 func (TxnState) EnumDescriptor() ([]byte, []int) {
-	return file_messages_proto_rawDescGZIP(), []int{1}
+	return file_messages_proto_rawDescGZIP(), []int{2}
 }
 
 // ResourceDomain is the domain of resource hold.
@@ -364,11 +411,11 @@ func (x ResourceDomain) String() string {
 }
 
 func (ResourceDomain) Descriptor() protoreflect.EnumDescriptor {
-	return file_messages_proto_enumTypes[2].Descriptor()
+	return file_messages_proto_enumTypes[3].Descriptor()
 }
 
 func (ResourceDomain) Type() protoreflect.EnumType {
-	return &file_messages_proto_enumTypes[2]
+	return &file_messages_proto_enumTypes[3]
 }
 
 func (x ResourceDomain) Number() protoreflect.EnumNumber {
@@ -377,7 +424,7 @@ func (x ResourceDomain) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ResourceDomain.Descriptor instead.
 func (ResourceDomain) EnumDescriptor() ([]byte, []int) {
-	return file_messages_proto_rawDescGZIP(), []int{2}
+	return file_messages_proto_rawDescGZIP(), []int{3}
 }
 
 // Message is the basic unit of communication between publisher and consumer.
@@ -774,6 +821,25 @@ type InsertMessageHeader struct {
 	Partitions   []*PartitionSegmentAssignment `protobuf:"bytes,2,rep,name=partitions,proto3" json:"partitions,omitempty"`
 	// optional so consumers can distinguish omitted (legacy producer) from explicit value.
 	SchemaVersion *int32 `protobuf:"varint,3,opt,name=schema_version,json=schemaVersion,proto3,oneof" json:"schema_version,omitempty"`
+	// pk_state OCC (optimistic concurrency control) extension.
+	// When occ_mode = OCC_MODE_CAS, streaming node will perform a CAS check
+	// against PKVersionCache before appending the body. The check uses
+	// expected_pks / expected_row_timestamps / expected_row_exists aligned
+	// with the rows carried in the InsertRequest body (same order, same length).
+	OccMode OCCMode `protobuf:"varint,4,opt,name=occ_mode,json=occMode,proto3,enum=milvus.proto.messages.OCCMode" json:"occ_mode,omitempty"`
+	// expected_pks carries the primary key value for each row, used by the
+	// pk_state_interceptor to acquire the per-PK CAS lock without
+	// depending on schema knowledge inside streamingnode.
+	ExpectedPks *schemapb.IDs `protobuf:"bytes,5,opt,name=expected_pks,json=expectedPks,proto3" json:"expected_pks,omitempty"`
+	// expected_row_timestamps is the row-level expected version (the hidden
+	// Timestamp system field of the previously read row). Length must match
+	// the number of rows in the body when occ_mode != OCC_MODE_NONE.
+	// When expected_row_exists[i] == false, expected_row_timestamps[i] is
+	// ignored and the CAS expects "no existing row for this PK".
+	ExpectedRowTimestamps []uint64 `protobuf:"varint,6,rep,packed,name=expected_row_timestamps,json=expectedRowTimestamps,proto3" json:"expected_row_timestamps,omitempty"`
+	// expected_row_exists indicates whether the i-th row was a read-modify-write
+	// (true) or a brand-new first-write insert (false).
+	ExpectedRowExists []bool `protobuf:"varint,7,rep,packed,name=expected_row_exists,json=expectedRowExists,proto3" json:"expected_row_exists,omitempty"`
 }
 
 func (x *InsertMessageHeader) Reset() {
@@ -827,6 +893,34 @@ func (x *InsertMessageHeader) GetSchemaVersion() int32 {
 		return *x.SchemaVersion
 	}
 	return 0
+}
+
+func (x *InsertMessageHeader) GetOccMode() OCCMode {
+	if x != nil {
+		return x.OccMode
+	}
+	return OCCMode_OCC_MODE_NONE
+}
+
+func (x *InsertMessageHeader) GetExpectedPks() *schemapb.IDs {
+	if x != nil {
+		return x.ExpectedPks
+	}
+	return nil
+}
+
+func (x *InsertMessageHeader) GetExpectedRowTimestamps() []uint64 {
+	if x != nil {
+		return x.ExpectedRowTimestamps
+	}
+	return nil
+}
+
+func (x *InsertMessageHeader) GetExpectedRowExists() []bool {
+	if x != nil {
+		return x.ExpectedRowExists
+	}
+	return nil
 }
 
 // PartitionSegmentAssignment is the segment assignment of a partition.
@@ -6680,7 +6774,7 @@ var file_messages_proto_rawDesc = []byte{
 	0x73, 0x73, 0x61, 0x67, 0x65, 0x73, 0x2e, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x52, 0x08,
 	0x6d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x73, 0x22, 0x17, 0x0a, 0x15, 0x54, 0x69, 0x6d, 0x65,
 	0x54, 0x69, 0x63, 0x6b, 0x4d, 0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x48, 0x65, 0x61, 0x64, 0x65,
-	0x72, 0x22, 0xcc, 0x01, 0x0a, 0x13, 0x49, 0x6e, 0x73, 0x65, 0x72, 0x74, 0x4d, 0x65, 0x73, 0x73,
+	0x72, 0x22, 0xac, 0x03, 0x0a, 0x13, 0x49, 0x6e, 0x73, 0x65, 0x72, 0x74, 0x4d, 0x65, 0x73, 0x73,
 	0x61, 0x67, 0x65, 0x48, 0x65, 0x61, 0x64, 0x65, 0x72, 0x12, 0x23, 0x0a, 0x0d, 0x63, 0x6f, 0x6c,
 	0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x03,
 	0x52, 0x0c, 0x63, 0x6f, 0x6c, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x49, 0x64, 0x12, 0x51,
@@ -6691,7 +6785,21 @@ var file_messages_proto_rawDesc = []byte{
 	0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x52, 0x0a, 0x70, 0x61, 0x72, 0x74, 0x69, 0x74, 0x69, 0x6f, 0x6e,
 	0x73, 0x12, 0x2a, 0x0a, 0x0e, 0x73, 0x63, 0x68, 0x65, 0x6d, 0x61, 0x5f, 0x76, 0x65, 0x72, 0x73,
 	0x69, 0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x05, 0x48, 0x00, 0x52, 0x0d, 0x73, 0x63, 0x68,
-	0x65, 0x6d, 0x61, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x88, 0x01, 0x01, 0x42, 0x11, 0x0a,
+	0x65, 0x6d, 0x61, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x88, 0x01, 0x01, 0x12, 0x39, 0x0a,
+	0x08, 0x6f, 0x63, 0x63, 0x5f, 0x6d, 0x6f, 0x64, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0e, 0x32,
+	0x1e, 0x2e, 0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x6d,
+	0x65, 0x73, 0x73, 0x61, 0x67, 0x65, 0x73, 0x2e, 0x4f, 0x43, 0x43, 0x4d, 0x6f, 0x64, 0x65, 0x52,
+	0x07, 0x6f, 0x63, 0x63, 0x4d, 0x6f, 0x64, 0x65, 0x12, 0x3b, 0x0a, 0x0c, 0x65, 0x78, 0x70, 0x65,
+	0x63, 0x74, 0x65, 0x64, 0x5f, 0x70, 0x6b, 0x73, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x18,
+	0x2e, 0x6d, 0x69, 0x6c, 0x76, 0x75, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x73, 0x63,
+	0x68, 0x65, 0x6d, 0x61, 0x2e, 0x49, 0x44, 0x73, 0x52, 0x0b, 0x65, 0x78, 0x70, 0x65, 0x63, 0x74,
+	0x65, 0x64, 0x50, 0x6b, 0x73, 0x12, 0x36, 0x0a, 0x17, 0x65, 0x78, 0x70, 0x65, 0x63, 0x74, 0x65,
+	0x64, 0x5f, 0x72, 0x6f, 0x77, 0x5f, 0x74, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x73,
+	0x18, 0x06, 0x20, 0x03, 0x28, 0x04, 0x52, 0x15, 0x65, 0x78, 0x70, 0x65, 0x63, 0x74, 0x65, 0x64,
+	0x52, 0x6f, 0x77, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x73, 0x12, 0x2e, 0x0a,
+	0x13, 0x65, 0x78, 0x70, 0x65, 0x63, 0x74, 0x65, 0x64, 0x5f, 0x72, 0x6f, 0x77, 0x5f, 0x65, 0x78,
+	0x69, 0x73, 0x74, 0x73, 0x18, 0x07, 0x20, 0x03, 0x28, 0x08, 0x52, 0x11, 0x65, 0x78, 0x70, 0x65,
+	0x63, 0x74, 0x65, 0x64, 0x52, 0x6f, 0x77, 0x45, 0x78, 0x69, 0x73, 0x74, 0x73, 0x42, 0x11, 0x0a,
 	0x0f, 0x5f, 0x73, 0x63, 0x68, 0x65, 0x6d, 0x61, 0x5f, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e,
 	0x22, 0xcd, 0x01, 0x0a, 0x1a, 0x50, 0x61, 0x72, 0x74, 0x69, 0x74, 0x69, 0x6f, 0x6e, 0x53, 0x65,
 	0x67, 0x6d, 0x65, 0x6e, 0x74, 0x41, 0x73, 0x73, 0x69, 0x67, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x12,
@@ -7470,7 +7578,10 @@ var file_messages_proto_rawDesc = []byte{
 	0xa0, 0x06, 0x12, 0x0d, 0x0a, 0x08, 0x42, 0x65, 0x67, 0x69, 0x6e, 0x54, 0x78, 0x6e, 0x10, 0x84,
 	0x07, 0x12, 0x0e, 0x0a, 0x09, 0x43, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x54, 0x78, 0x6e, 0x10, 0x85,
 	0x07, 0x12, 0x10, 0x0a, 0x0b, 0x52, 0x6f, 0x6c, 0x6c, 0x62, 0x61, 0x63, 0x6b, 0x54, 0x78, 0x6e,
-	0x10, 0x86, 0x07, 0x12, 0x08, 0x0a, 0x03, 0x54, 0x78, 0x6e, 0x10, 0xe7, 0x07, 0x2a, 0x74, 0x0a,
+	0x10, 0x86, 0x07, 0x12, 0x08, 0x0a, 0x03, 0x54, 0x78, 0x6e, 0x10, 0xe7, 0x07, 0x2a, 0x2e, 0x0a,
+	0x07, 0x4f, 0x43, 0x43, 0x4d, 0x6f, 0x64, 0x65, 0x12, 0x11, 0x0a, 0x0d, 0x4f, 0x43, 0x43, 0x5f,
+	0x4d, 0x4f, 0x44, 0x45, 0x5f, 0x4e, 0x4f, 0x4e, 0x45, 0x10, 0x00, 0x12, 0x10, 0x0a, 0x0c, 0x4f,
+	0x43, 0x43, 0x5f, 0x4d, 0x4f, 0x44, 0x45, 0x5f, 0x43, 0x41, 0x53, 0x10, 0x01, 0x2a, 0x74, 0x0a,
 	0x08, 0x54, 0x78, 0x6e, 0x53, 0x74, 0x61, 0x74, 0x65, 0x12, 0x0e, 0x0a, 0x0a, 0x54, 0x78, 0x6e,
 	0x55, 0x6e, 0x6b, 0x6e, 0x6f, 0x77, 0x6e, 0x10, 0x00, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x78, 0x6e,
 	0x49, 0x6e, 0x46, 0x6c, 0x69, 0x67, 0x68, 0x74, 0x10, 0x01, 0x12, 0x0f, 0x0a, 0x0b, 0x54, 0x78,
@@ -7511,214 +7622,218 @@ func file_messages_proto_rawDescGZIP() []byte {
 	return file_messages_proto_rawDescData
 }
 
-var file_messages_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_messages_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_messages_proto_msgTypes = make([]protoimpl.MessageInfo, 124)
 var file_messages_proto_goTypes = []interface{}{
 	(MessageType)(0),                               // 0: milvus.proto.messages.MessageType
-	(TxnState)(0),                                  // 1: milvus.proto.messages.TxnState
-	(ResourceDomain)(0),                            // 2: milvus.proto.messages.ResourceDomain
-	(*Message)(nil),                                // 3: milvus.proto.messages.Message
-	(*FlushMessageBody)(nil),                       // 4: milvus.proto.messages.FlushMessageBody
-	(*ManualFlushMessageBody)(nil),                 // 5: milvus.proto.messages.ManualFlushMessageBody
-	(*CreateSegmentMessageBody)(nil),               // 6: milvus.proto.messages.CreateSegmentMessageBody
-	(*BeginTxnMessageBody)(nil),                    // 7: milvus.proto.messages.BeginTxnMessageBody
-	(*CommitTxnMessageBody)(nil),                   // 8: milvus.proto.messages.CommitTxnMessageBody
-	(*RollbackTxnMessageBody)(nil),                 // 9: milvus.proto.messages.RollbackTxnMessageBody
-	(*TxnMessageBody)(nil),                         // 10: milvus.proto.messages.TxnMessageBody
-	(*TimeTickMessageHeader)(nil),                  // 11: milvus.proto.messages.TimeTickMessageHeader
-	(*InsertMessageHeader)(nil),                    // 12: milvus.proto.messages.InsertMessageHeader
-	(*PartitionSegmentAssignment)(nil),             // 13: milvus.proto.messages.PartitionSegmentAssignment
-	(*SegmentAssignment)(nil),                      // 14: milvus.proto.messages.SegmentAssignment
-	(*DeleteMessageHeader)(nil),                    // 15: milvus.proto.messages.DeleteMessageHeader
-	(*FlushMessageHeader)(nil),                     // 16: milvus.proto.messages.FlushMessageHeader
-	(*CreateSegmentMessageHeader)(nil),             // 17: milvus.proto.messages.CreateSegmentMessageHeader
-	(*ManualFlushMessageHeader)(nil),               // 18: milvus.proto.messages.ManualFlushMessageHeader
-	(*CreateCollectionMessageHeader)(nil),          // 19: milvus.proto.messages.CreateCollectionMessageHeader
-	(*DropCollectionMessageHeader)(nil),            // 20: milvus.proto.messages.DropCollectionMessageHeader
-	(*CreatePartitionMessageHeader)(nil),           // 21: milvus.proto.messages.CreatePartitionMessageHeader
-	(*DropPartitionMessageHeader)(nil),             // 22: milvus.proto.messages.DropPartitionMessageHeader
-	(*AlterReplicateConfigMessageHeader)(nil),      // 23: milvus.proto.messages.AlterReplicateConfigMessageHeader
-	(*AlterReplicateConfigMessageBody)(nil),        // 24: milvus.proto.messages.AlterReplicateConfigMessageBody
-	(*BeginTxnMessageHeader)(nil),                  // 25: milvus.proto.messages.BeginTxnMessageHeader
-	(*CommitTxnMessageHeader)(nil),                 // 26: milvus.proto.messages.CommitTxnMessageHeader
-	(*RollbackTxnMessageHeader)(nil),               // 27: milvus.proto.messages.RollbackTxnMessageHeader
-	(*TxnMessageHeader)(nil),                       // 28: milvus.proto.messages.TxnMessageHeader
-	(*ImportMessageHeader)(nil),                    // 29: milvus.proto.messages.ImportMessageHeader
-	(*SchemaChangeMessageHeader)(nil),              // 30: milvus.proto.messages.SchemaChangeMessageHeader
-	(*SchemaChangeMessageBody)(nil),                // 31: milvus.proto.messages.SchemaChangeMessageBody
-	(*AlterCollectionMessageHeader)(nil),           // 32: milvus.proto.messages.AlterCollectionMessageHeader
-	(*AlterCollectionMessageBody)(nil),             // 33: milvus.proto.messages.AlterCollectionMessageBody
-	(*AlterCollectionMessageUpdates)(nil),          // 34: milvus.proto.messages.AlterCollectionMessageUpdates
-	(*AlterLoadConfigOfAlterCollection)(nil),       // 35: milvus.proto.messages.AlterLoadConfigOfAlterCollection
-	(*AlterLoadConfigMessageHeader)(nil),           // 36: milvus.proto.messages.AlterLoadConfigMessageHeader
-	(*AlterLoadConfigMessageBody)(nil),             // 37: milvus.proto.messages.AlterLoadConfigMessageBody
-	(*LoadFieldConfig)(nil),                        // 38: milvus.proto.messages.LoadFieldConfig
-	(*LoadReplicaConfig)(nil),                      // 39: milvus.proto.messages.LoadReplicaConfig
-	(*DropLoadConfigMessageHeader)(nil),            // 40: milvus.proto.messages.DropLoadConfigMessageHeader
-	(*DropLoadConfigMessageBody)(nil),              // 41: milvus.proto.messages.DropLoadConfigMessageBody
-	(*CreateDatabaseMessageHeader)(nil),            // 42: milvus.proto.messages.CreateDatabaseMessageHeader
-	(*CreateDatabaseMessageBody)(nil),              // 43: milvus.proto.messages.CreateDatabaseMessageBody
-	(*AlterDatabaseMessageHeader)(nil),             // 44: milvus.proto.messages.AlterDatabaseMessageHeader
-	(*AlterDatabaseMessageBody)(nil),               // 45: milvus.proto.messages.AlterDatabaseMessageBody
-	(*AlterLoadConfigOfAlterDatabase)(nil),         // 46: milvus.proto.messages.AlterLoadConfigOfAlterDatabase
-	(*DropDatabaseMessageHeader)(nil),              // 47: milvus.proto.messages.DropDatabaseMessageHeader
-	(*DropDatabaseMessageBody)(nil),                // 48: milvus.proto.messages.DropDatabaseMessageBody
-	(*AlterAliasMessageHeader)(nil),                // 49: milvus.proto.messages.AlterAliasMessageHeader
-	(*AlterAliasMessageBody)(nil),                  // 50: milvus.proto.messages.AlterAliasMessageBody
-	(*DropAliasMessageHeader)(nil),                 // 51: milvus.proto.messages.DropAliasMessageHeader
-	(*DropAliasMessageBody)(nil),                   // 52: milvus.proto.messages.DropAliasMessageBody
-	(*CreateUserMessageHeader)(nil),                // 53: milvus.proto.messages.CreateUserMessageHeader
-	(*CreateUserMessageBody)(nil),                  // 54: milvus.proto.messages.CreateUserMessageBody
-	(*AlterUserMessageHeader)(nil),                 // 55: milvus.proto.messages.AlterUserMessageHeader
-	(*AlterUserMessageBody)(nil),                   // 56: milvus.proto.messages.AlterUserMessageBody
-	(*DropUserMessageHeader)(nil),                  // 57: milvus.proto.messages.DropUserMessageHeader
-	(*DropUserMessageBody)(nil),                    // 58: milvus.proto.messages.DropUserMessageBody
-	(*AlterRoleMessageHeader)(nil),                 // 59: milvus.proto.messages.AlterRoleMessageHeader
-	(*AlterRoleMessageBody)(nil),                   // 60: milvus.proto.messages.AlterRoleMessageBody
-	(*DropRoleMessageHeader)(nil),                  // 61: milvus.proto.messages.DropRoleMessageHeader
-	(*DropRoleMessageBody)(nil),                    // 62: milvus.proto.messages.DropRoleMessageBody
-	(*RoleBinding)(nil),                            // 63: milvus.proto.messages.RoleBinding
-	(*AlterUserRoleMessageHeader)(nil),             // 64: milvus.proto.messages.AlterUserRoleMessageHeader
-	(*AlterUserRoleMessageBody)(nil),               // 65: milvus.proto.messages.AlterUserRoleMessageBody
-	(*DropUserRoleMessageHeader)(nil),              // 66: milvus.proto.messages.DropUserRoleMessageHeader
-	(*DropUserRoleMessageBody)(nil),                // 67: milvus.proto.messages.DropUserRoleMessageBody
-	(*RestoreRBACMessageHeader)(nil),               // 68: milvus.proto.messages.RestoreRBACMessageHeader
-	(*RestoreRBACMessageBody)(nil),                 // 69: milvus.proto.messages.RestoreRBACMessageBody
-	(*AlterPrivilegeMessageHeader)(nil),            // 70: milvus.proto.messages.AlterPrivilegeMessageHeader
-	(*AlterPrivilegeMessageBody)(nil),              // 71: milvus.proto.messages.AlterPrivilegeMessageBody
-	(*DropPrivilegeMessageHeader)(nil),             // 72: milvus.proto.messages.DropPrivilegeMessageHeader
-	(*DropPrivilegeMessageBody)(nil),               // 73: milvus.proto.messages.DropPrivilegeMessageBody
-	(*AlterPrivilegeGroupMessageHeader)(nil),       // 74: milvus.proto.messages.AlterPrivilegeGroupMessageHeader
-	(*AlterPrivilegeGroupMessageBody)(nil),         // 75: milvus.proto.messages.AlterPrivilegeGroupMessageBody
-	(*DropPrivilegeGroupMessageHeader)(nil),        // 76: milvus.proto.messages.DropPrivilegeGroupMessageHeader
-	(*DropPrivilegeGroupMessageBody)(nil),          // 77: milvus.proto.messages.DropPrivilegeGroupMessageBody
-	(*AlterResourceGroupMessageHeader)(nil),        // 78: milvus.proto.messages.AlterResourceGroupMessageHeader
-	(*AlterResourceGroupMessageBody)(nil),          // 79: milvus.proto.messages.AlterResourceGroupMessageBody
-	(*DropResourceGroupMessageHeader)(nil),         // 80: milvus.proto.messages.DropResourceGroupMessageHeader
-	(*DropResourceGroupMessageBody)(nil),           // 81: milvus.proto.messages.DropResourceGroupMessageBody
-	(*CreateIndexMessageHeader)(nil),               // 82: milvus.proto.messages.CreateIndexMessageHeader
-	(*CreateIndexMessageBody)(nil),                 // 83: milvus.proto.messages.CreateIndexMessageBody
-	(*AlterIndexMessageHeader)(nil),                // 84: milvus.proto.messages.AlterIndexMessageHeader
-	(*AlterIndexMessageBody)(nil),                  // 85: milvus.proto.messages.AlterIndexMessageBody
-	(*DropIndexMessageHeader)(nil),                 // 86: milvus.proto.messages.DropIndexMessageHeader
-	(*DropIndexMessageBody)(nil),                   // 87: milvus.proto.messages.DropIndexMessageBody
-	(*CreateSnapshotMessageHeader)(nil),            // 88: milvus.proto.messages.CreateSnapshotMessageHeader
-	(*CreateSnapshotMessageBody)(nil),              // 89: milvus.proto.messages.CreateSnapshotMessageBody
-	(*DropSnapshotMessageHeader)(nil),              // 90: milvus.proto.messages.DropSnapshotMessageHeader
-	(*DropSnapshotMessageBody)(nil),                // 91: milvus.proto.messages.DropSnapshotMessageBody
-	(*DropSnapshotsByCollectionMessageHeader)(nil), // 92: milvus.proto.messages.DropSnapshotsByCollectionMessageHeader
-	(*DropSnapshotsByCollectionMessageBody)(nil),   // 93: milvus.proto.messages.DropSnapshotsByCollectionMessageBody
-	(*RestoreSnapshotMessageHeader)(nil),           // 94: milvus.proto.messages.RestoreSnapshotMessageHeader
-	(*RestoreSnapshotMessageBody)(nil),             // 95: milvus.proto.messages.RestoreSnapshotMessageBody
-	(*AlterWALMessageHeader)(nil),                  // 96: milvus.proto.messages.AlterWALMessageHeader
-	(*AlterWALMessageBody)(nil),                    // 97: milvus.proto.messages.AlterWALMessageBody
-	(*RefreshExternalCollectionMessageHeader)(nil), // 98: milvus.proto.messages.RefreshExternalCollectionMessageHeader
-	(*RefreshExternalCollectionMessageBody)(nil),   // 99: milvus.proto.messages.RefreshExternalCollectionMessageBody
-	(*CommitImportMessageHeader)(nil),              // 100: milvus.proto.messages.CommitImportMessageHeader
-	(*CommitImportMessageBody)(nil),                // 101: milvus.proto.messages.CommitImportMessageBody
-	(*RollbackImportMessageHeader)(nil),            // 102: milvus.proto.messages.RollbackImportMessageHeader
-	(*RollbackImportMessageBody)(nil),              // 103: milvus.proto.messages.RollbackImportMessageBody
-	(*CacheExpirations)(nil),                       // 104: milvus.proto.messages.CacheExpirations
-	(*CacheExpiration)(nil),                        // 105: milvus.proto.messages.CacheExpiration
-	(*LegacyProxyCollectionMetaCache)(nil),         // 106: milvus.proto.messages.LegacyProxyCollectionMetaCache
-	(*ManualFlushExtraResponse)(nil),               // 107: milvus.proto.messages.ManualFlushExtraResponse
-	(*FlushAllMessageHeader)(nil),                  // 108: milvus.proto.messages.FlushAllMessageHeader
-	(*FlushAllMessageBody)(nil),                    // 109: milvus.proto.messages.FlushAllMessageBody
-	(*TxnContext)(nil),                             // 110: milvus.proto.messages.TxnContext
-	(*RMQMessageLayout)(nil),                       // 111: milvus.proto.messages.RMQMessageLayout
-	(*BroadcastHeader)(nil),                        // 112: milvus.proto.messages.BroadcastHeader
-	(*ReplicateHeader)(nil),                        // 113: milvus.proto.messages.ReplicateHeader
-	(*ResourceKey)(nil),                            // 114: milvus.proto.messages.ResourceKey
-	(*CipherHeader)(nil),                           // 115: milvus.proto.messages.CipherHeader
-	(*TruncateCollectionMessageHeader)(nil),        // 116: milvus.proto.messages.TruncateCollectionMessageHeader
-	(*TruncateCollectionMessageBody)(nil),          // 117: milvus.proto.messages.TruncateCollectionMessageBody
-	(*BatchUpdateManifestMessageHeader)(nil),       // 118: milvus.proto.messages.BatchUpdateManifestMessageHeader
-	(*BatchUpdateManifestMessageBody)(nil),         // 119: milvus.proto.messages.BatchUpdateManifestMessageBody
-	(*BatchUpdateManifestItem)(nil),                // 120: milvus.proto.messages.BatchUpdateManifestItem
-	(*BatchUpdateManifestV2ColumnGroups)(nil),      // 121: milvus.proto.messages.BatchUpdateManifestV2ColumnGroups
-	nil,                                     // 122: milvus.proto.messages.Message.PropertiesEntry
-	nil,                                     // 123: milvus.proto.messages.AlterResourceGroupMessageHeader.ResourceGroupConfigsEntry
-	nil,                                     // 124: milvus.proto.messages.AlterWALMessageHeader.ConfigEntry
-	nil,                                     // 125: milvus.proto.messages.RMQMessageLayout.PropertiesEntry
-	nil,                                     // 126: milvus.proto.messages.BatchUpdateManifestV2ColumnGroups.ColumnGroupsEntry
-	(datapb.SegmentLevel)(0),                // 127: milvus.proto.data.SegmentLevel
-	(*commonpb.ReplicateConfiguration)(nil), // 128: milvus.proto.common.ReplicateConfiguration
-	(*schemapb.CollectionSchema)(nil),       // 129: milvus.proto.schema.CollectionSchema
-	(*fieldmaskpb.FieldMask)(nil),           // 130: google.protobuf.FieldMask
-	(commonpb.ConsistencyLevel)(0),          // 131: milvus.proto.common.ConsistencyLevel
-	(*commonpb.KeyValuePair)(nil),           // 132: milvus.proto.common.KeyValuePair
-	(commonpb.LoadPriority)(0),              // 133: milvus.proto.common.LoadPriority
-	(*milvuspb.UserEntity)(nil),             // 134: milvus.proto.milvus.UserEntity
-	(*internalpb.CredentialInfo)(nil),       // 135: milvus.proto.internal.CredentialInfo
-	(*milvuspb.RoleEntity)(nil),             // 136: milvus.proto.milvus.RoleEntity
-	(*milvuspb.RBACMeta)(nil),               // 137: milvus.proto.milvus.RBACMeta
-	(*milvuspb.GrantEntity)(nil),            // 138: milvus.proto.milvus.GrantEntity
-	(*milvuspb.PrivilegeGroupInfo)(nil),     // 139: milvus.proto.milvus.PrivilegeGroupInfo
-	(*indexpb.FieldIndex)(nil),              // 140: milvus.proto.index.FieldIndex
-	(commonpb.WALName)(0),                   // 141: milvus.proto.common.WALName
-	(commonpb.MsgType)(0),                   // 142: milvus.proto.common.MsgType
-	(*commonpb.MessageID)(nil),              // 143: milvus.proto.common.MessageID
-	(*rgpb.ResourceGroupConfig)(nil),        // 144: milvus.proto.rg.ResourceGroupConfig
-	(*datapb.FieldBinlog)(nil),              // 145: milvus.proto.data.FieldBinlog
+	(OCCMode)(0),                                   // 1: milvus.proto.messages.OCCMode
+	(TxnState)(0),                                  // 2: milvus.proto.messages.TxnState
+	(ResourceDomain)(0),                            // 3: milvus.proto.messages.ResourceDomain
+	(*Message)(nil),                                // 4: milvus.proto.messages.Message
+	(*FlushMessageBody)(nil),                       // 5: milvus.proto.messages.FlushMessageBody
+	(*ManualFlushMessageBody)(nil),                 // 6: milvus.proto.messages.ManualFlushMessageBody
+	(*CreateSegmentMessageBody)(nil),               // 7: milvus.proto.messages.CreateSegmentMessageBody
+	(*BeginTxnMessageBody)(nil),                    // 8: milvus.proto.messages.BeginTxnMessageBody
+	(*CommitTxnMessageBody)(nil),                   // 9: milvus.proto.messages.CommitTxnMessageBody
+	(*RollbackTxnMessageBody)(nil),                 // 10: milvus.proto.messages.RollbackTxnMessageBody
+	(*TxnMessageBody)(nil),                         // 11: milvus.proto.messages.TxnMessageBody
+	(*TimeTickMessageHeader)(nil),                  // 12: milvus.proto.messages.TimeTickMessageHeader
+	(*InsertMessageHeader)(nil),                    // 13: milvus.proto.messages.InsertMessageHeader
+	(*PartitionSegmentAssignment)(nil),             // 14: milvus.proto.messages.PartitionSegmentAssignment
+	(*SegmentAssignment)(nil),                      // 15: milvus.proto.messages.SegmentAssignment
+	(*DeleteMessageHeader)(nil),                    // 16: milvus.proto.messages.DeleteMessageHeader
+	(*FlushMessageHeader)(nil),                     // 17: milvus.proto.messages.FlushMessageHeader
+	(*CreateSegmentMessageHeader)(nil),             // 18: milvus.proto.messages.CreateSegmentMessageHeader
+	(*ManualFlushMessageHeader)(nil),               // 19: milvus.proto.messages.ManualFlushMessageHeader
+	(*CreateCollectionMessageHeader)(nil),          // 20: milvus.proto.messages.CreateCollectionMessageHeader
+	(*DropCollectionMessageHeader)(nil),            // 21: milvus.proto.messages.DropCollectionMessageHeader
+	(*CreatePartitionMessageHeader)(nil),           // 22: milvus.proto.messages.CreatePartitionMessageHeader
+	(*DropPartitionMessageHeader)(nil),             // 23: milvus.proto.messages.DropPartitionMessageHeader
+	(*AlterReplicateConfigMessageHeader)(nil),      // 24: milvus.proto.messages.AlterReplicateConfigMessageHeader
+	(*AlterReplicateConfigMessageBody)(nil),        // 25: milvus.proto.messages.AlterReplicateConfigMessageBody
+	(*BeginTxnMessageHeader)(nil),                  // 26: milvus.proto.messages.BeginTxnMessageHeader
+	(*CommitTxnMessageHeader)(nil),                 // 27: milvus.proto.messages.CommitTxnMessageHeader
+	(*RollbackTxnMessageHeader)(nil),               // 28: milvus.proto.messages.RollbackTxnMessageHeader
+	(*TxnMessageHeader)(nil),                       // 29: milvus.proto.messages.TxnMessageHeader
+	(*ImportMessageHeader)(nil),                    // 30: milvus.proto.messages.ImportMessageHeader
+	(*SchemaChangeMessageHeader)(nil),              // 31: milvus.proto.messages.SchemaChangeMessageHeader
+	(*SchemaChangeMessageBody)(nil),                // 32: milvus.proto.messages.SchemaChangeMessageBody
+	(*AlterCollectionMessageHeader)(nil),           // 33: milvus.proto.messages.AlterCollectionMessageHeader
+	(*AlterCollectionMessageBody)(nil),             // 34: milvus.proto.messages.AlterCollectionMessageBody
+	(*AlterCollectionMessageUpdates)(nil),          // 35: milvus.proto.messages.AlterCollectionMessageUpdates
+	(*AlterLoadConfigOfAlterCollection)(nil),       // 36: milvus.proto.messages.AlterLoadConfigOfAlterCollection
+	(*AlterLoadConfigMessageHeader)(nil),           // 37: milvus.proto.messages.AlterLoadConfigMessageHeader
+	(*AlterLoadConfigMessageBody)(nil),             // 38: milvus.proto.messages.AlterLoadConfigMessageBody
+	(*LoadFieldConfig)(nil),                        // 39: milvus.proto.messages.LoadFieldConfig
+	(*LoadReplicaConfig)(nil),                      // 40: milvus.proto.messages.LoadReplicaConfig
+	(*DropLoadConfigMessageHeader)(nil),            // 41: milvus.proto.messages.DropLoadConfigMessageHeader
+	(*DropLoadConfigMessageBody)(nil),              // 42: milvus.proto.messages.DropLoadConfigMessageBody
+	(*CreateDatabaseMessageHeader)(nil),            // 43: milvus.proto.messages.CreateDatabaseMessageHeader
+	(*CreateDatabaseMessageBody)(nil),              // 44: milvus.proto.messages.CreateDatabaseMessageBody
+	(*AlterDatabaseMessageHeader)(nil),             // 45: milvus.proto.messages.AlterDatabaseMessageHeader
+	(*AlterDatabaseMessageBody)(nil),               // 46: milvus.proto.messages.AlterDatabaseMessageBody
+	(*AlterLoadConfigOfAlterDatabase)(nil),         // 47: milvus.proto.messages.AlterLoadConfigOfAlterDatabase
+	(*DropDatabaseMessageHeader)(nil),              // 48: milvus.proto.messages.DropDatabaseMessageHeader
+	(*DropDatabaseMessageBody)(nil),                // 49: milvus.proto.messages.DropDatabaseMessageBody
+	(*AlterAliasMessageHeader)(nil),                // 50: milvus.proto.messages.AlterAliasMessageHeader
+	(*AlterAliasMessageBody)(nil),                  // 51: milvus.proto.messages.AlterAliasMessageBody
+	(*DropAliasMessageHeader)(nil),                 // 52: milvus.proto.messages.DropAliasMessageHeader
+	(*DropAliasMessageBody)(nil),                   // 53: milvus.proto.messages.DropAliasMessageBody
+	(*CreateUserMessageHeader)(nil),                // 54: milvus.proto.messages.CreateUserMessageHeader
+	(*CreateUserMessageBody)(nil),                  // 55: milvus.proto.messages.CreateUserMessageBody
+	(*AlterUserMessageHeader)(nil),                 // 56: milvus.proto.messages.AlterUserMessageHeader
+	(*AlterUserMessageBody)(nil),                   // 57: milvus.proto.messages.AlterUserMessageBody
+	(*DropUserMessageHeader)(nil),                  // 58: milvus.proto.messages.DropUserMessageHeader
+	(*DropUserMessageBody)(nil),                    // 59: milvus.proto.messages.DropUserMessageBody
+	(*AlterRoleMessageHeader)(nil),                 // 60: milvus.proto.messages.AlterRoleMessageHeader
+	(*AlterRoleMessageBody)(nil),                   // 61: milvus.proto.messages.AlterRoleMessageBody
+	(*DropRoleMessageHeader)(nil),                  // 62: milvus.proto.messages.DropRoleMessageHeader
+	(*DropRoleMessageBody)(nil),                    // 63: milvus.proto.messages.DropRoleMessageBody
+	(*RoleBinding)(nil),                            // 64: milvus.proto.messages.RoleBinding
+	(*AlterUserRoleMessageHeader)(nil),             // 65: milvus.proto.messages.AlterUserRoleMessageHeader
+	(*AlterUserRoleMessageBody)(nil),               // 66: milvus.proto.messages.AlterUserRoleMessageBody
+	(*DropUserRoleMessageHeader)(nil),              // 67: milvus.proto.messages.DropUserRoleMessageHeader
+	(*DropUserRoleMessageBody)(nil),                // 68: milvus.proto.messages.DropUserRoleMessageBody
+	(*RestoreRBACMessageHeader)(nil),               // 69: milvus.proto.messages.RestoreRBACMessageHeader
+	(*RestoreRBACMessageBody)(nil),                 // 70: milvus.proto.messages.RestoreRBACMessageBody
+	(*AlterPrivilegeMessageHeader)(nil),            // 71: milvus.proto.messages.AlterPrivilegeMessageHeader
+	(*AlterPrivilegeMessageBody)(nil),              // 72: milvus.proto.messages.AlterPrivilegeMessageBody
+	(*DropPrivilegeMessageHeader)(nil),             // 73: milvus.proto.messages.DropPrivilegeMessageHeader
+	(*DropPrivilegeMessageBody)(nil),               // 74: milvus.proto.messages.DropPrivilegeMessageBody
+	(*AlterPrivilegeGroupMessageHeader)(nil),       // 75: milvus.proto.messages.AlterPrivilegeGroupMessageHeader
+	(*AlterPrivilegeGroupMessageBody)(nil),         // 76: milvus.proto.messages.AlterPrivilegeGroupMessageBody
+	(*DropPrivilegeGroupMessageHeader)(nil),        // 77: milvus.proto.messages.DropPrivilegeGroupMessageHeader
+	(*DropPrivilegeGroupMessageBody)(nil),          // 78: milvus.proto.messages.DropPrivilegeGroupMessageBody
+	(*AlterResourceGroupMessageHeader)(nil),        // 79: milvus.proto.messages.AlterResourceGroupMessageHeader
+	(*AlterResourceGroupMessageBody)(nil),          // 80: milvus.proto.messages.AlterResourceGroupMessageBody
+	(*DropResourceGroupMessageHeader)(nil),         // 81: milvus.proto.messages.DropResourceGroupMessageHeader
+	(*DropResourceGroupMessageBody)(nil),           // 82: milvus.proto.messages.DropResourceGroupMessageBody
+	(*CreateIndexMessageHeader)(nil),               // 83: milvus.proto.messages.CreateIndexMessageHeader
+	(*CreateIndexMessageBody)(nil),                 // 84: milvus.proto.messages.CreateIndexMessageBody
+	(*AlterIndexMessageHeader)(nil),                // 85: milvus.proto.messages.AlterIndexMessageHeader
+	(*AlterIndexMessageBody)(nil),                  // 86: milvus.proto.messages.AlterIndexMessageBody
+	(*DropIndexMessageHeader)(nil),                 // 87: milvus.proto.messages.DropIndexMessageHeader
+	(*DropIndexMessageBody)(nil),                   // 88: milvus.proto.messages.DropIndexMessageBody
+	(*CreateSnapshotMessageHeader)(nil),            // 89: milvus.proto.messages.CreateSnapshotMessageHeader
+	(*CreateSnapshotMessageBody)(nil),              // 90: milvus.proto.messages.CreateSnapshotMessageBody
+	(*DropSnapshotMessageHeader)(nil),              // 91: milvus.proto.messages.DropSnapshotMessageHeader
+	(*DropSnapshotMessageBody)(nil),                // 92: milvus.proto.messages.DropSnapshotMessageBody
+	(*DropSnapshotsByCollectionMessageHeader)(nil), // 93: milvus.proto.messages.DropSnapshotsByCollectionMessageHeader
+	(*DropSnapshotsByCollectionMessageBody)(nil),   // 94: milvus.proto.messages.DropSnapshotsByCollectionMessageBody
+	(*RestoreSnapshotMessageHeader)(nil),           // 95: milvus.proto.messages.RestoreSnapshotMessageHeader
+	(*RestoreSnapshotMessageBody)(nil),             // 96: milvus.proto.messages.RestoreSnapshotMessageBody
+	(*AlterWALMessageHeader)(nil),                  // 97: milvus.proto.messages.AlterWALMessageHeader
+	(*AlterWALMessageBody)(nil),                    // 98: milvus.proto.messages.AlterWALMessageBody
+	(*RefreshExternalCollectionMessageHeader)(nil), // 99: milvus.proto.messages.RefreshExternalCollectionMessageHeader
+	(*RefreshExternalCollectionMessageBody)(nil),   // 100: milvus.proto.messages.RefreshExternalCollectionMessageBody
+	(*CommitImportMessageHeader)(nil),              // 101: milvus.proto.messages.CommitImportMessageHeader
+	(*CommitImportMessageBody)(nil),                // 102: milvus.proto.messages.CommitImportMessageBody
+	(*RollbackImportMessageHeader)(nil),            // 103: milvus.proto.messages.RollbackImportMessageHeader
+	(*RollbackImportMessageBody)(nil),              // 104: milvus.proto.messages.RollbackImportMessageBody
+	(*CacheExpirations)(nil),                       // 105: milvus.proto.messages.CacheExpirations
+	(*CacheExpiration)(nil),                        // 106: milvus.proto.messages.CacheExpiration
+	(*LegacyProxyCollectionMetaCache)(nil),         // 107: milvus.proto.messages.LegacyProxyCollectionMetaCache
+	(*ManualFlushExtraResponse)(nil),               // 108: milvus.proto.messages.ManualFlushExtraResponse
+	(*FlushAllMessageHeader)(nil),                  // 109: milvus.proto.messages.FlushAllMessageHeader
+	(*FlushAllMessageBody)(nil),                    // 110: milvus.proto.messages.FlushAllMessageBody
+	(*TxnContext)(nil),                             // 111: milvus.proto.messages.TxnContext
+	(*RMQMessageLayout)(nil),                       // 112: milvus.proto.messages.RMQMessageLayout
+	(*BroadcastHeader)(nil),                        // 113: milvus.proto.messages.BroadcastHeader
+	(*ReplicateHeader)(nil),                        // 114: milvus.proto.messages.ReplicateHeader
+	(*ResourceKey)(nil),                            // 115: milvus.proto.messages.ResourceKey
+	(*CipherHeader)(nil),                           // 116: milvus.proto.messages.CipherHeader
+	(*TruncateCollectionMessageHeader)(nil),        // 117: milvus.proto.messages.TruncateCollectionMessageHeader
+	(*TruncateCollectionMessageBody)(nil),          // 118: milvus.proto.messages.TruncateCollectionMessageBody
+	(*BatchUpdateManifestMessageHeader)(nil),       // 119: milvus.proto.messages.BatchUpdateManifestMessageHeader
+	(*BatchUpdateManifestMessageBody)(nil),         // 120: milvus.proto.messages.BatchUpdateManifestMessageBody
+	(*BatchUpdateManifestItem)(nil),                // 121: milvus.proto.messages.BatchUpdateManifestItem
+	(*BatchUpdateManifestV2ColumnGroups)(nil),      // 122: milvus.proto.messages.BatchUpdateManifestV2ColumnGroups
+	nil,                                     // 123: milvus.proto.messages.Message.PropertiesEntry
+	nil,                                     // 124: milvus.proto.messages.AlterResourceGroupMessageHeader.ResourceGroupConfigsEntry
+	nil,                                     // 125: milvus.proto.messages.AlterWALMessageHeader.ConfigEntry
+	nil,                                     // 126: milvus.proto.messages.RMQMessageLayout.PropertiesEntry
+	nil,                                     // 127: milvus.proto.messages.BatchUpdateManifestV2ColumnGroups.ColumnGroupsEntry
+	(*schemapb.IDs)(nil),                    // 128: milvus.proto.schema.IDs
+	(datapb.SegmentLevel)(0),                // 129: milvus.proto.data.SegmentLevel
+	(*commonpb.ReplicateConfiguration)(nil), // 130: milvus.proto.common.ReplicateConfiguration
+	(*schemapb.CollectionSchema)(nil),       // 131: milvus.proto.schema.CollectionSchema
+	(*fieldmaskpb.FieldMask)(nil),           // 132: google.protobuf.FieldMask
+	(commonpb.ConsistencyLevel)(0),          // 133: milvus.proto.common.ConsistencyLevel
+	(*commonpb.KeyValuePair)(nil),           // 134: milvus.proto.common.KeyValuePair
+	(commonpb.LoadPriority)(0),              // 135: milvus.proto.common.LoadPriority
+	(*milvuspb.UserEntity)(nil),             // 136: milvus.proto.milvus.UserEntity
+	(*internalpb.CredentialInfo)(nil),       // 137: milvus.proto.internal.CredentialInfo
+	(*milvuspb.RoleEntity)(nil),             // 138: milvus.proto.milvus.RoleEntity
+	(*milvuspb.RBACMeta)(nil),               // 139: milvus.proto.milvus.RBACMeta
+	(*milvuspb.GrantEntity)(nil),            // 140: milvus.proto.milvus.GrantEntity
+	(*milvuspb.PrivilegeGroupInfo)(nil),     // 141: milvus.proto.milvus.PrivilegeGroupInfo
+	(*indexpb.FieldIndex)(nil),              // 142: milvus.proto.index.FieldIndex
+	(commonpb.WALName)(0),                   // 143: milvus.proto.common.WALName
+	(commonpb.MsgType)(0),                   // 144: milvus.proto.common.MsgType
+	(*commonpb.MessageID)(nil),              // 145: milvus.proto.common.MessageID
+	(*rgpb.ResourceGroupConfig)(nil),        // 146: milvus.proto.rg.ResourceGroupConfig
+	(*datapb.FieldBinlog)(nil),              // 147: milvus.proto.data.FieldBinlog
 }
 var file_messages_proto_depIdxs = []int32{
-	122, // 0: milvus.proto.messages.Message.properties:type_name -> milvus.proto.messages.Message.PropertiesEntry
-	3,   // 1: milvus.proto.messages.TxnMessageBody.messages:type_name -> milvus.proto.messages.Message
-	13,  // 2: milvus.proto.messages.InsertMessageHeader.partitions:type_name -> milvus.proto.messages.PartitionSegmentAssignment
-	14,  // 3: milvus.proto.messages.PartitionSegmentAssignment.segment_assignment:type_name -> milvus.proto.messages.SegmentAssignment
-	127, // 4: milvus.proto.messages.CreateSegmentMessageHeader.level:type_name -> milvus.proto.data.SegmentLevel
-	128, // 5: milvus.proto.messages.AlterReplicateConfigMessageHeader.replicate_configuration:type_name -> milvus.proto.common.ReplicateConfiguration
-	129, // 6: milvus.proto.messages.SchemaChangeMessageBody.schema:type_name -> milvus.proto.schema.CollectionSchema
-	130, // 7: milvus.proto.messages.AlterCollectionMessageHeader.update_mask:type_name -> google.protobuf.FieldMask
-	104, // 8: milvus.proto.messages.AlterCollectionMessageHeader.cache_expirations:type_name -> milvus.proto.messages.CacheExpirations
-	34,  // 9: milvus.proto.messages.AlterCollectionMessageBody.updates:type_name -> milvus.proto.messages.AlterCollectionMessageUpdates
-	129, // 10: milvus.proto.messages.AlterCollectionMessageUpdates.schema:type_name -> milvus.proto.schema.CollectionSchema
-	131, // 11: milvus.proto.messages.AlterCollectionMessageUpdates.consistency_level:type_name -> milvus.proto.common.ConsistencyLevel
-	132, // 12: milvus.proto.messages.AlterCollectionMessageUpdates.properties:type_name -> milvus.proto.common.KeyValuePair
-	35,  // 13: milvus.proto.messages.AlterCollectionMessageUpdates.alter_load_config:type_name -> milvus.proto.messages.AlterLoadConfigOfAlterCollection
-	38,  // 14: milvus.proto.messages.AlterLoadConfigMessageHeader.load_fields:type_name -> milvus.proto.messages.LoadFieldConfig
-	39,  // 15: milvus.proto.messages.AlterLoadConfigMessageHeader.replicas:type_name -> milvus.proto.messages.LoadReplicaConfig
-	133, // 16: milvus.proto.messages.LoadReplicaConfig.priority:type_name -> milvus.proto.common.LoadPriority
-	132, // 17: milvus.proto.messages.CreateDatabaseMessageBody.properties:type_name -> milvus.proto.common.KeyValuePair
-	132, // 18: milvus.proto.messages.AlterDatabaseMessageBody.properties:type_name -> milvus.proto.common.KeyValuePair
-	46,  // 19: milvus.proto.messages.AlterDatabaseMessageBody.alter_load_config:type_name -> milvus.proto.messages.AlterLoadConfigOfAlterDatabase
-	134, // 20: milvus.proto.messages.CreateUserMessageHeader.user_entity:type_name -> milvus.proto.milvus.UserEntity
-	135, // 21: milvus.proto.messages.CreateUserMessageBody.credential_info:type_name -> milvus.proto.internal.CredentialInfo
-	134, // 22: milvus.proto.messages.AlterUserMessageHeader.user_entity:type_name -> milvus.proto.milvus.UserEntity
-	135, // 23: milvus.proto.messages.AlterUserMessageBody.credential_info:type_name -> milvus.proto.internal.CredentialInfo
-	136, // 24: milvus.proto.messages.AlterRoleMessageHeader.role_entity:type_name -> milvus.proto.milvus.RoleEntity
-	134, // 25: milvus.proto.messages.RoleBinding.user_entity:type_name -> milvus.proto.milvus.UserEntity
-	136, // 26: milvus.proto.messages.RoleBinding.role_entity:type_name -> milvus.proto.milvus.RoleEntity
-	63,  // 27: milvus.proto.messages.AlterUserRoleMessageHeader.role_binding:type_name -> milvus.proto.messages.RoleBinding
-	63,  // 28: milvus.proto.messages.DropUserRoleMessageHeader.role_binding:type_name -> milvus.proto.messages.RoleBinding
-	137, // 29: milvus.proto.messages.RestoreRBACMessageBody.rbac_meta:type_name -> milvus.proto.milvus.RBACMeta
-	138, // 30: milvus.proto.messages.AlterPrivilegeMessageHeader.entity:type_name -> milvus.proto.milvus.GrantEntity
-	138, // 31: milvus.proto.messages.DropPrivilegeMessageHeader.entity:type_name -> milvus.proto.milvus.GrantEntity
-	139, // 32: milvus.proto.messages.AlterPrivilegeGroupMessageHeader.privilege_group_info:type_name -> milvus.proto.milvus.PrivilegeGroupInfo
-	139, // 33: milvus.proto.messages.DropPrivilegeGroupMessageHeader.privilege_group_info:type_name -> milvus.proto.milvus.PrivilegeGroupInfo
-	123, // 34: milvus.proto.messages.AlterResourceGroupMessageHeader.resource_group_configs:type_name -> milvus.proto.messages.AlterResourceGroupMessageHeader.ResourceGroupConfigsEntry
-	140, // 35: milvus.proto.messages.CreateIndexMessageBody.field_index:type_name -> milvus.proto.index.FieldIndex
-	140, // 36: milvus.proto.messages.AlterIndexMessageBody.field_indexes:type_name -> milvus.proto.index.FieldIndex
-	141, // 37: milvus.proto.messages.AlterWALMessageHeader.target_wal_name:type_name -> milvus.proto.common.WALName
-	124, // 38: milvus.proto.messages.AlterWALMessageHeader.config:type_name -> milvus.proto.messages.AlterWALMessageHeader.ConfigEntry
-	105, // 39: milvus.proto.messages.CacheExpirations.cache_expirations:type_name -> milvus.proto.messages.CacheExpiration
-	106, // 40: milvus.proto.messages.CacheExpiration.legacy_proxy_collection_meta_cache:type_name -> milvus.proto.messages.LegacyProxyCollectionMetaCache
-	142, // 41: milvus.proto.messages.LegacyProxyCollectionMetaCache.msg_type:type_name -> milvus.proto.common.MsgType
-	125, // 42: milvus.proto.messages.RMQMessageLayout.properties:type_name -> milvus.proto.messages.RMQMessageLayout.PropertiesEntry
-	114, // 43: milvus.proto.messages.BroadcastHeader.Resource_keys:type_name -> milvus.proto.messages.ResourceKey
-	143, // 44: milvus.proto.messages.ReplicateHeader.message_id:type_name -> milvus.proto.common.MessageID
-	143, // 45: milvus.proto.messages.ReplicateHeader.last_confirmed_message_id:type_name -> milvus.proto.common.MessageID
-	2,   // 46: milvus.proto.messages.ResourceKey.domain:type_name -> milvus.proto.messages.ResourceDomain
-	120, // 47: milvus.proto.messages.BatchUpdateManifestMessageBody.items:type_name -> milvus.proto.messages.BatchUpdateManifestItem
-	121, // 48: milvus.proto.messages.BatchUpdateManifestItem.v2_column_groups:type_name -> milvus.proto.messages.BatchUpdateManifestV2ColumnGroups
-	126, // 49: milvus.proto.messages.BatchUpdateManifestV2ColumnGroups.column_groups:type_name -> milvus.proto.messages.BatchUpdateManifestV2ColumnGroups.ColumnGroupsEntry
-	144, // 50: milvus.proto.messages.AlterResourceGroupMessageHeader.ResourceGroupConfigsEntry.value:type_name -> milvus.proto.rg.ResourceGroupConfig
-	145, // 51: milvus.proto.messages.BatchUpdateManifestV2ColumnGroups.ColumnGroupsEntry.value:type_name -> milvus.proto.data.FieldBinlog
-	52,  // [52:52] is the sub-list for method output_type
-	52,  // [52:52] is the sub-list for method input_type
-	52,  // [52:52] is the sub-list for extension type_name
-	52,  // [52:52] is the sub-list for extension extendee
-	0,   // [0:52] is the sub-list for field type_name
+	123, // 0: milvus.proto.messages.Message.properties:type_name -> milvus.proto.messages.Message.PropertiesEntry
+	4,   // 1: milvus.proto.messages.TxnMessageBody.messages:type_name -> milvus.proto.messages.Message
+	14,  // 2: milvus.proto.messages.InsertMessageHeader.partitions:type_name -> milvus.proto.messages.PartitionSegmentAssignment
+	1,   // 3: milvus.proto.messages.InsertMessageHeader.occ_mode:type_name -> milvus.proto.messages.OCCMode
+	128, // 4: milvus.proto.messages.InsertMessageHeader.expected_pks:type_name -> milvus.proto.schema.IDs
+	15,  // 5: milvus.proto.messages.PartitionSegmentAssignment.segment_assignment:type_name -> milvus.proto.messages.SegmentAssignment
+	129, // 6: milvus.proto.messages.CreateSegmentMessageHeader.level:type_name -> milvus.proto.data.SegmentLevel
+	130, // 7: milvus.proto.messages.AlterReplicateConfigMessageHeader.replicate_configuration:type_name -> milvus.proto.common.ReplicateConfiguration
+	131, // 8: milvus.proto.messages.SchemaChangeMessageBody.schema:type_name -> milvus.proto.schema.CollectionSchema
+	132, // 9: milvus.proto.messages.AlterCollectionMessageHeader.update_mask:type_name -> google.protobuf.FieldMask
+	105, // 10: milvus.proto.messages.AlterCollectionMessageHeader.cache_expirations:type_name -> milvus.proto.messages.CacheExpirations
+	35,  // 11: milvus.proto.messages.AlterCollectionMessageBody.updates:type_name -> milvus.proto.messages.AlterCollectionMessageUpdates
+	131, // 12: milvus.proto.messages.AlterCollectionMessageUpdates.schema:type_name -> milvus.proto.schema.CollectionSchema
+	133, // 13: milvus.proto.messages.AlterCollectionMessageUpdates.consistency_level:type_name -> milvus.proto.common.ConsistencyLevel
+	134, // 14: milvus.proto.messages.AlterCollectionMessageUpdates.properties:type_name -> milvus.proto.common.KeyValuePair
+	36,  // 15: milvus.proto.messages.AlterCollectionMessageUpdates.alter_load_config:type_name -> milvus.proto.messages.AlterLoadConfigOfAlterCollection
+	39,  // 16: milvus.proto.messages.AlterLoadConfigMessageHeader.load_fields:type_name -> milvus.proto.messages.LoadFieldConfig
+	40,  // 17: milvus.proto.messages.AlterLoadConfigMessageHeader.replicas:type_name -> milvus.proto.messages.LoadReplicaConfig
+	135, // 18: milvus.proto.messages.LoadReplicaConfig.priority:type_name -> milvus.proto.common.LoadPriority
+	134, // 19: milvus.proto.messages.CreateDatabaseMessageBody.properties:type_name -> milvus.proto.common.KeyValuePair
+	134, // 20: milvus.proto.messages.AlterDatabaseMessageBody.properties:type_name -> milvus.proto.common.KeyValuePair
+	47,  // 21: milvus.proto.messages.AlterDatabaseMessageBody.alter_load_config:type_name -> milvus.proto.messages.AlterLoadConfigOfAlterDatabase
+	136, // 22: milvus.proto.messages.CreateUserMessageHeader.user_entity:type_name -> milvus.proto.milvus.UserEntity
+	137, // 23: milvus.proto.messages.CreateUserMessageBody.credential_info:type_name -> milvus.proto.internal.CredentialInfo
+	136, // 24: milvus.proto.messages.AlterUserMessageHeader.user_entity:type_name -> milvus.proto.milvus.UserEntity
+	137, // 25: milvus.proto.messages.AlterUserMessageBody.credential_info:type_name -> milvus.proto.internal.CredentialInfo
+	138, // 26: milvus.proto.messages.AlterRoleMessageHeader.role_entity:type_name -> milvus.proto.milvus.RoleEntity
+	136, // 27: milvus.proto.messages.RoleBinding.user_entity:type_name -> milvus.proto.milvus.UserEntity
+	138, // 28: milvus.proto.messages.RoleBinding.role_entity:type_name -> milvus.proto.milvus.RoleEntity
+	64,  // 29: milvus.proto.messages.AlterUserRoleMessageHeader.role_binding:type_name -> milvus.proto.messages.RoleBinding
+	64,  // 30: milvus.proto.messages.DropUserRoleMessageHeader.role_binding:type_name -> milvus.proto.messages.RoleBinding
+	139, // 31: milvus.proto.messages.RestoreRBACMessageBody.rbac_meta:type_name -> milvus.proto.milvus.RBACMeta
+	140, // 32: milvus.proto.messages.AlterPrivilegeMessageHeader.entity:type_name -> milvus.proto.milvus.GrantEntity
+	140, // 33: milvus.proto.messages.DropPrivilegeMessageHeader.entity:type_name -> milvus.proto.milvus.GrantEntity
+	141, // 34: milvus.proto.messages.AlterPrivilegeGroupMessageHeader.privilege_group_info:type_name -> milvus.proto.milvus.PrivilegeGroupInfo
+	141, // 35: milvus.proto.messages.DropPrivilegeGroupMessageHeader.privilege_group_info:type_name -> milvus.proto.milvus.PrivilegeGroupInfo
+	124, // 36: milvus.proto.messages.AlterResourceGroupMessageHeader.resource_group_configs:type_name -> milvus.proto.messages.AlterResourceGroupMessageHeader.ResourceGroupConfigsEntry
+	142, // 37: milvus.proto.messages.CreateIndexMessageBody.field_index:type_name -> milvus.proto.index.FieldIndex
+	142, // 38: milvus.proto.messages.AlterIndexMessageBody.field_indexes:type_name -> milvus.proto.index.FieldIndex
+	143, // 39: milvus.proto.messages.AlterWALMessageHeader.target_wal_name:type_name -> milvus.proto.common.WALName
+	125, // 40: milvus.proto.messages.AlterWALMessageHeader.config:type_name -> milvus.proto.messages.AlterWALMessageHeader.ConfigEntry
+	106, // 41: milvus.proto.messages.CacheExpirations.cache_expirations:type_name -> milvus.proto.messages.CacheExpiration
+	107, // 42: milvus.proto.messages.CacheExpiration.legacy_proxy_collection_meta_cache:type_name -> milvus.proto.messages.LegacyProxyCollectionMetaCache
+	144, // 43: milvus.proto.messages.LegacyProxyCollectionMetaCache.msg_type:type_name -> milvus.proto.common.MsgType
+	126, // 44: milvus.proto.messages.RMQMessageLayout.properties:type_name -> milvus.proto.messages.RMQMessageLayout.PropertiesEntry
+	115, // 45: milvus.proto.messages.BroadcastHeader.Resource_keys:type_name -> milvus.proto.messages.ResourceKey
+	145, // 46: milvus.proto.messages.ReplicateHeader.message_id:type_name -> milvus.proto.common.MessageID
+	145, // 47: milvus.proto.messages.ReplicateHeader.last_confirmed_message_id:type_name -> milvus.proto.common.MessageID
+	3,   // 48: milvus.proto.messages.ResourceKey.domain:type_name -> milvus.proto.messages.ResourceDomain
+	121, // 49: milvus.proto.messages.BatchUpdateManifestMessageBody.items:type_name -> milvus.proto.messages.BatchUpdateManifestItem
+	122, // 50: milvus.proto.messages.BatchUpdateManifestItem.v2_column_groups:type_name -> milvus.proto.messages.BatchUpdateManifestV2ColumnGroups
+	127, // 51: milvus.proto.messages.BatchUpdateManifestV2ColumnGroups.column_groups:type_name -> milvus.proto.messages.BatchUpdateManifestV2ColumnGroups.ColumnGroupsEntry
+	146, // 52: milvus.proto.messages.AlterResourceGroupMessageHeader.ResourceGroupConfigsEntry.value:type_name -> milvus.proto.rg.ResourceGroupConfig
+	147, // 53: milvus.proto.messages.BatchUpdateManifestV2ColumnGroups.ColumnGroupsEntry.value:type_name -> milvus.proto.data.FieldBinlog
+	54,  // [54:54] is the sub-list for method output_type
+	54,  // [54:54] is the sub-list for method input_type
+	54,  // [54:54] is the sub-list for extension type_name
+	54,  // [54:54] is the sub-list for extension extendee
+	0,   // [0:54] is the sub-list for field type_name
 }
 
 func init() { file_messages_proto_init() }
@@ -9165,7 +9280,7 @@ func file_messages_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_messages_proto_rawDesc,
-			NumEnums:      3,
+			NumEnums:      4,
 			NumMessages:   124,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2094,6 +2094,10 @@ type proxyConfig struct {
 	HybridSearchRequeryPolicy ParamItem `refreshable:"true"`
 
 	MetaCacheGCTimeInterval ParamItem `refreshable:"true"`
+
+	// partial_update upsert OCC retry settings
+	PartialUpdateRetryOnConflict ParamItem `refreshable:"true"`
+	PartialUpdateRetryBackoffMs  ParamItem `refreshable:"true"`
 }
 
 func (p *proxyConfig) init(base *BaseTable) {
@@ -2645,6 +2649,24 @@ Disabled if the value is less or equal to 0.`,
 		Export:       true,
 	}
 	p.MetaCacheGCTimeInterval.Init(base.mgr)
+
+	p.PartialUpdateRetryOnConflict = ParamItem{
+		Key:          "proxy.partialUpdate.retryOnConflict",
+		Version:      "2.6.0",
+		DefaultValue: "3",
+		Doc:          "Maximum number of retries when a partial-update upsert hits a CAS conflict at the streaming node.",
+		Export:       false,
+	}
+	p.PartialUpdateRetryOnConflict.Init(base.mgr)
+
+	p.PartialUpdateRetryBackoffMs = ParamItem{
+		Key:          "proxy.partialUpdate.retryBackoffMs",
+		Version:      "2.6.0",
+		DefaultValue: "5",
+		Doc:          "Initial backoff (in milliseconds) between partial-update retries; doubles each attempt up to 100ms.",
+		Export:       false,
+	}
+	p.PartialUpdateRetryBackoffMs.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////
@@ -7364,6 +7386,9 @@ type streamingConfig struct {
 	// Replication pending message queue configuration
 	ReplicationPendingMessagesQueueLength  ParamItem `refreshable:"true"`
 	ReplicationPendingMessagesQueueMaxSize ParamItem `refreshable:"true"`
+
+	// partial_update OCC settings
+	PartialUpdatePKVersionCacheTimeout ParamItem `refreshable:"false"`
 }
 
 func (p *streamingConfig) init(base *BaseTable) {
@@ -7953,6 +7978,15 @@ so we set 1 second here as a threshold.`,
 		RecoveryIncreaseInterval:     "1s",
 		Export:                       false,
 	})
+
+	p.PartialUpdatePKVersionCacheTimeout = ParamItem{
+		Key:          "streaming.partialUpdate.pkVersionCacheTimeout",
+		Version:      "2.6.0",
+		DefaultValue: "60s",
+		Doc:          "LRU idle timeout for the per-streamingnode hot PK version cache used by the partial_update interceptor. PK entries not touched by a CAS Check within this duration are evicted.",
+		Export:       true,
+	}
+	p.PartialUpdatePKVersionCacheTimeout.Init(base.mgr)
 }
 
 type AdaptiveRateLimitConfigDefaultValue struct {


### PR DESCRIPTION
issue：https://github.com/milvus-io/milvus/issues/49980

fixed result：
<img width="842" height="622" alt="image" src="https://github.com/user-attachments/assets/d636395a-fa6a-43f9-9164-c2a780500831" />

**Add optimistic concurrency control for partial update on the streaming WAL path**

This change uses the hidden row Timestamp as the version observed by Proxy during
query/merge, then carries the expected row state in WAL messages so the final
partial-update insert can be validated before append. This prevents stale
partial updates from silently overwriting newer writes.

Key changes:
- add OCC metadata to WAL message headers, including occ_mode, expected_pks,
  expected_row_timestamps and expected_row_exists
- add cache_action to insert/delete headers to explicitly control post-append
  PK state maintenance instead of inferring behavior from message type
- introduce pk_state_interceptor on the StreamingNode WAL append boundary
- maintain an in-memory PKVersionCache keyed by PK -> last visible timestamp
- validate partial-update CAS writes with Check -> append -> Update semantics
- update normal insert / normal upsert final insert with SET_EXISTS after append
- update explicit delete with SET_DELETE after append
- mark internal delete messages generated by upsert / partial-update as
  cache_action=NONE so cache correctness no longer depends on delete/insert order
- add Proxy-side conflict retry with task rebuild, re-query, merge and bounded
  backoff retries

Behavioral details:
- partial-update carries the expected row timestamp and existence flag for each
  row, and fails fast on PK state conflict
- first-write partial-update is supported via expected_row_exists=false
- mixed batches with both first-write and update rows are checked atomically
- normal upsert still writes delete + insert semantically, but only the final
  insert updates cache state
- explicit user delete removes PK state from cache, while internal delete does
  not mutate cache

Compatibility and invariants:
- new proto fields are optional, so the message format remains backward compatible
- existing consumers that do not read OCC fields will ignore them
- compaction invariants remain unchanged because successful partial updates are
  still materialized as regular delete + insert with monotonic timestamps
- cache timestamps are aligned with the final WAL timetick assigned on append

Known limitations:
- after StreamingNode leader switch, PKVersionCache starts cold and some
  partial-update/delete races may temporarily degrade to cache-miss pass-through
- delete vs partial-update concurrency is still not fully protected in the cold
  cache window
- cache eviction is not introduced in this stage and will need follow-up work