### PR TITLE
fix: [2.6] Pass OpContext to PinCells calls (#50231)

### DIFF
--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -410,20 +410,20 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
     };
 
     auto skip_index_func =
-        [val1, val2, lower_inclusive, upper_inclusive](
+        [op_ctx = op_ctx_, val1, val2, lower_inclusive, upper_inclusive](
             const SkipIndex& skip_index, FieldId field_id, int64_t chunk_id) {
             if (lower_inclusive && upper_inclusive) {
                 return skip_index.CanSkipBinaryRange<T>(
-                    field_id, chunk_id, val1, val2, true, true);
+                    op_ctx, field_id, chunk_id, val1, val2, true, true);
             } else if (lower_inclusive && !upper_inclusive) {
                 return skip_index.CanSkipBinaryRange<T>(
-                    field_id, chunk_id, val1, val2, true, false);
+                    op_ctx, field_id, chunk_id, val1, val2, true, false);
             } else if (!lower_inclusive && upper_inclusive) {
                 return skip_index.CanSkipBinaryRange<T>(
-                    field_id, chunk_id, val1, val2, false, true);
+                    op_ctx, field_id, chunk_id, val1, val2, false, true);
             } else {
                 return skip_index.CanSkipBinaryRange<T>(
-                    field_id, chunk_id, val1, val2, false, false);
+                    op_ctx, field_id, chunk_id, val1, val2, false, false);
             }
         };
     int64_t processed_size;

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -152,7 +152,7 @@ PhyTermFilterExpr::CanSkipSegment() {
         bool res = false;
         for (int i = 0; i < num_data_chunk_; ++i) {
             if (!skip_index.CanSkipBinaryRange<T>(
-                    field_id_, i, min, max, true, true)) {
+                    op_ctx_, field_id_, i, min, max, true, true)) {
                 return false;
             } else {
                 res = true;
@@ -200,7 +200,7 @@ PhyTermFilterExpr::InitPkCacheOffset() {
     }
 
     cached_bits_.resize(active_count_, false);
-    segment_->search_ids(cached_bits_, *id_array);
+    segment_->search_ids(op_ctx_, cached_bits_, *id_array);
     cached_bits_inited_ = true;
 }
 

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1712,12 +1712,12 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
         processed_cursor += size;
     };
 
-    auto skip_index_func = [expr_type, val](const SkipIndex& skip_index,
-                                            FieldId field_id,
-                                            int64_t chunk_id) {
-        return skip_index.CanSkipUnaryRange<T>(
-            field_id, chunk_id, expr_type, val);
-    };
+    auto skip_index_func =
+        [op_ctx = op_ctx_, expr_type, val](
+            const SkipIndex& skip_index, FieldId field_id, int64_t chunk_id) {
+            return skip_index.CanSkipUnaryRange<T>(
+                op_ctx, field_id, chunk_id, expr_type, val);
+        };
 
     int64_t processed_size;
     if (has_offset_input_) {

--- a/internal/core/src/index/SkipIndex.cpp
+++ b/internal/core/src/index/SkipIndex.cpp
@@ -19,13 +19,15 @@ namespace milvus {
 static const FieldChunkMetrics defaultFieldChunkMetrics;
 
 const cachinglayer::PinWrapper<const FieldChunkMetrics*>
-SkipIndex::GetFieldChunkMetrics(milvus::FieldId field_id, int chunk_id) const {
+SkipIndex::GetFieldChunkMetrics(milvus::OpContext* op_ctx,
+                                milvus::FieldId field_id,
+                                int chunk_id) const {
     // skip index structure must be setup before using, thus we do not lock here.
     auto field_metrics = fieldChunkMetrics_.find(field_id);
     if (field_metrics != fieldChunkMetrics_.end()) {
         auto& field_chunk_metrics = field_metrics->second;
         auto ca = cachinglayer::SemiInlineGet(
-            field_chunk_metrics->PinCells(nullptr, {chunk_id}));
+            field_chunk_metrics->PinCells(op_ctx, {chunk_id}));
         auto metrics = ca->get_cell_of(chunk_id);
         return cachinglayer::PinWrapper<const FieldChunkMetrics*>(ca, metrics);
     }

--- a/internal/core/src/index/SkipIndex.h
+++ b/internal/core/src/index/SkipIndex.h
@@ -212,11 +212,12 @@ class SkipIndex {
  public:
     template <typename T>
     bool
-    CanSkipUnaryRange(FieldId field_id,
+    CanSkipUnaryRange(milvus::OpContext* op_ctx,
+                      FieldId field_id,
                       int64_t chunk_id,
                       OpType op_type,
                       const T& val) const {
-        auto pw = GetFieldChunkMetrics(field_id, chunk_id);
+        auto pw = GetFieldChunkMetrics(op_ctx, field_id, chunk_id);
         auto field_chunk_metrics = pw.get();
         if (MinMaxUnaryFilter<T>(field_chunk_metrics, op_type, val)) {
             return true;
@@ -227,13 +228,14 @@ class SkipIndex {
 
     template <typename T>
     bool
-    CanSkipBinaryRange(FieldId field_id,
+    CanSkipBinaryRange(milvus::OpContext* op_ctx,
+                       FieldId field_id,
                        int64_t chunk_id,
                        const T& lower_val,
                        const T& upper_val,
                        bool lower_inclusive,
                        bool upper_inclusive) const {
-        auto pw = GetFieldChunkMetrics(field_id, chunk_id);
+        auto pw = GetFieldChunkMetrics(op_ctx, field_id, chunk_id);
         auto field_chunk_metrics = pw.get();
         if (MinMaxBinaryFilter<T>(field_chunk_metrics,
                                   lower_val,
@@ -262,7 +264,9 @@ class SkipIndex {
 
  private:
     const cachinglayer::PinWrapper<const FieldChunkMetrics*>
-    GetFieldChunkMetrics(FieldId field_id, int chunk_id) const;
+    GetFieldChunkMetrics(milvus::OpContext* op_ctx,
+                         FieldId field_id,
+                         int chunk_id) const;
 
     template <typename T>
     struct IsAllowedType {

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -71,7 +71,7 @@ SearchOnSealedIndex(const Schema& schema,
 
     dataset->SetIsSparse(is_sparse);
     auto accessor =
-        SemiInlineGet(field_indexing->indexing_->PinCells(nullptr, {0}));
+        SemiInlineGet(field_indexing->indexing_->PinCells(op_context, {0}));
     auto vec_index =
         dynamic_cast<index::VectorIndex*>(accessor->get_cell_of(0));
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1822,7 +1822,7 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id,
                     return iter;
                 });
             auto accessor =
-                SemiInlineGet(field_index_iter->second->PinCells(nullptr, {0}));
+                SemiInlineGet(field_index_iter->second->PinCells(op_ctx, {0}));
             auto ptr = accessor->get_cell_of(0);
             AssertInfo(ptr->HasRawData(),
                        "text raw data not found, trying to create text index "
@@ -2391,8 +2391,10 @@ ChunkedSegmentSealedImpl::GetFieldDataType(milvus::FieldId field_id) const {
 }
 
 void
-ChunkedSegmentSealedImpl::search_ids(BitsetType& bitset,
+ChunkedSegmentSealedImpl::search_ids(milvus::OpContext* op_ctx,
+                                     BitsetType& bitset,
                                      const IdArray& id_array) const {
+    (void)op_ctx;
     auto field_id = schema_->get_primary_field_id().value_or(FieldId(-1));
     AssertInfo(field_id.get() != -1, "Primary key is -1");
     auto& field_meta = schema_->operator[](field_id);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -952,7 +952,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     }
 
     void
-    search_ids(BitsetType& bitset, const IdArray& id_array) const override;
+    search_ids(milvus::OpContext* op_ctx,
+               BitsetType& bitset,
+               const IdArray& id_array) const override;
 
     void
     LoadVecIndex(const LoadIndexInfo& info);

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1560,8 +1560,10 @@ SegmentGrowingImpl::bulk_subscript(milvus::OpContext* op_ctx,
 }
 
 void
-SegmentGrowingImpl::search_ids(BitsetType& bitset,
+SegmentGrowingImpl::search_ids(milvus::OpContext* op_ctx,
+                               BitsetType& bitset,
                                const IdArray& id_array) const {
+    (void)op_ctx;
     auto field_id = schema_->get_primary_field_id().value_or(FieldId(-1));
     AssertInfo(field_id.get() != -1, "Primary key is -1");
     auto& field_meta = schema_->operator[](field_id);

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -413,7 +413,9 @@ class SegmentGrowingImpl : public SegmentGrowing {
                      Timestamp timestamp) const override;
 
     void
-    search_ids(BitsetType& bitset, const IdArray& id_array) const override;
+    search_ids(milvus::OpContext* op_ctx,
+               BitsetType& bitset,
+               const IdArray& id_array) const override;
 
     bool
     HasIndex(FieldId field_id) const override {

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -508,7 +508,9 @@ class SegmentInternalInterface : public SegmentInterface {
      * so no need timestamp parameter, mvcc node prove the timestamp is already filtered.
      */
     virtual void
-    search_ids(BitsetType& bitset, const IdArray& id_array) const = 0;
+    search_ids(milvus::OpContext* op_ctx,
+               BitsetType& bitset,
+               const IdArray& id_array) const = 0;
 
     /**
      * Apply timestamp filtering on bitset, the query can't see an entity whose

--- a/internal/core/unittest/test_exec.cpp
+++ b/internal/core/unittest/test_exec.cpp
@@ -749,9 +749,9 @@ TEST(TaskTest, SkipIndexWithBitmapInputAlignment) {
     // Check if chunk 0 can be skipped for float > 60
     auto& skip_index = segment->GetSkipIndex();
     bool chunk0_can_skip = skip_index.CanSkipUnaryRange<float>(
-        float_fid, 0, proto::plan::OpType::GreaterThan, 60.0f);
+        nullptr, float_fid, 0, proto::plan::OpType::GreaterThan, 60.0f);
     bool chunk1_can_skip = skip_index.CanSkipUnaryRange<float>(
-        float_fid, 1, proto::plan::OpType::GreaterThan, 60.0f);
+        nullptr, float_fid, 1, proto::plan::OpType::GreaterThan, 60.0f);
 
     // Chunk 0 should be skippable (max=50 < 60), chunk 1 should not (min=65 > 60)
     EXPECT_TRUE(chunk0_can_skip)

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -1517,37 +1517,37 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                     cm);
     segment->LoadFieldData(load_info);
     auto& skip_index = segment->GetSkipIndex();
-    bool equal_5_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::Equal, 5);
-    bool equal_12_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::Equal, 12);
-    bool equal_10_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::Equal, 10);
+    bool equal_5_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, pk_fid, 0, OpType::Equal, 5);
+    bool equal_12_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, pk_fid, 0, OpType::Equal, 12);
+    bool equal_10_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, pk_fid, 0, OpType::Equal, 10);
     ASSERT_FALSE(equal_5_skip);
     ASSERT_TRUE(equal_12_skip);
     ASSERT_FALSE(equal_10_skip);
-    bool less_than_1_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessThan, 1);
-    bool less_than_5_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessThan, 5);
+    bool less_than_1_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, pk_fid, 0, OpType::LessThan, 1);
+    bool less_than_5_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, pk_fid, 0, OpType::LessThan, 5);
     ASSERT_TRUE(less_than_1_skip);
     ASSERT_FALSE(less_than_5_skip);
-    bool less_equal_than_1_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessEqual, 1);
-    bool less_equal_than_15_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(pk_fid, 0, OpType::LessThan, 15);
+    bool less_equal_than_1_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, pk_fid, 0, OpType::LessEqual, 1);
+    bool less_equal_than_15_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, pk_fid, 0, OpType::LessThan, 15);
     ASSERT_FALSE(less_equal_than_1_skip);
     ASSERT_FALSE(less_equal_than_15_skip);
     bool greater_than_10_skip = skip_index.CanSkipUnaryRange<int64_t>(
-        pk_fid, 0, OpType::GreaterThan, 10);
+        nullptr, pk_fid, 0, OpType::GreaterThan, 10);
     bool greater_than_5_skip = skip_index.CanSkipUnaryRange<int64_t>(
-        pk_fid, 0, OpType::GreaterThan, 5);
+        nullptr, pk_fid, 0, OpType::GreaterThan, 5);
     ASSERT_TRUE(greater_than_10_skip);
     ASSERT_FALSE(greater_than_5_skip);
     bool greater_equal_than_10_skip = skip_index.CanSkipUnaryRange<int64_t>(
-        pk_fid, 0, OpType::GreaterEqual, 10);
+        nullptr, pk_fid, 0, OpType::GreaterEqual, 10);
     bool greater_equal_than_5_skip = skip_index.CanSkipUnaryRange<int64_t>(
-        pk_fid, 0, OpType::GreaterEqual, 5);
+        nullptr, pk_fid, 0, OpType::GreaterEqual, 5);
     ASSERT_FALSE(greater_equal_than_10_skip);
     ASSERT_FALSE(greater_equal_than_5_skip);
 
@@ -1563,8 +1563,8 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                {int32_field_data},
                                                cm);
     segment->LoadFieldData(load_info);
-    less_than_1_skip =
-        skip_index.CanSkipUnaryRange<int32_t>(i32_fid, 0, OpType::LessThan, 1);
+    less_than_1_skip = skip_index.CanSkipUnaryRange<int32_t>(
+        nullptr, i32_fid, 0, OpType::LessThan, 1);
     ASSERT_TRUE(less_than_1_skip);
 
     //test for int16
@@ -1579,8 +1579,8 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                {int16_field_data},
                                                cm);
     segment->LoadFieldData(load_info);
-    bool less_than_12_skip =
-        skip_index.CanSkipUnaryRange<int16_t>(i16_fid, 0, OpType::LessThan, 12);
+    bool less_than_12_skip = skip_index.CanSkipUnaryRange<int16_t>(
+        nullptr, i16_fid, 0, OpType::LessThan, 12);
     ASSERT_FALSE(less_than_12_skip);
 
     //test for int8
@@ -1596,7 +1596,7 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                cm);
     segment->LoadFieldData(load_info);
     bool greater_than_12_skip = skip_index.CanSkipUnaryRange<int8_t>(
-        i8_fid, 0, OpType::GreaterThan, 12);
+        nullptr, i8_fid, 0, OpType::GreaterThan, 12);
     ASSERT_TRUE(greater_than_12_skip);
 
     // test for float
@@ -1613,7 +1613,7 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                cm);
     segment->LoadFieldData(load_info);
     greater_than_10_skip = skip_index.CanSkipUnaryRange<float>(
-        float_fid, 0, OpType::GreaterThan, 10.0);
+        nullptr, float_fid, 0, OpType::GreaterThan, 10.0);
     ASSERT_TRUE(greater_than_10_skip);
 
     // test for double
@@ -1630,7 +1630,7 @@ TEST(Sealed, SkipIndexSkipUnaryRange) {
                                                cm);
     segment->LoadFieldData(load_info);
     greater_than_10_skip = skip_index.CanSkipUnaryRange<double>(
-        double_fid, 0, OpType::GreaterThan, 10.0);
+        nullptr, double_fid, 0, OpType::GreaterThan, 10.0);
     ASSERT_TRUE(greater_than_10_skip);
 }
 
@@ -1661,20 +1661,20 @@ TEST(Sealed, SkipIndexSkipBinaryRange) {
                                                     cm);
     segment->LoadFieldData(load_info);
     auto& skip_index = segment->GetSkipIndex();
-    ASSERT_FALSE(
-        skip_index.CanSkipBinaryRange<int64_t>(pk_fid, 0, -3, 1, true, true));
-    ASSERT_TRUE(
-        skip_index.CanSkipBinaryRange<int64_t>(pk_fid, 0, -3, 1, true, false));
+    ASSERT_FALSE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, pk_fid, 0, -3, 1, true, true));
+    ASSERT_TRUE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, pk_fid, 0, -3, 1, true, false));
 
-    ASSERT_FALSE(
-        skip_index.CanSkipBinaryRange<int64_t>(pk_fid, 0, 7, 9, true, true));
-    ASSERT_FALSE(
-        skip_index.CanSkipBinaryRange<int64_t>(pk_fid, 0, 8, 12, true, false));
+    ASSERT_FALSE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, pk_fid, 0, 7, 9, true, true));
+    ASSERT_FALSE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, pk_fid, 0, 8, 12, true, false));
 
-    ASSERT_TRUE(
-        skip_index.CanSkipBinaryRange<int64_t>(pk_fid, 0, 10, 12, false, true));
-    ASSERT_FALSE(
-        skip_index.CanSkipBinaryRange<int64_t>(pk_fid, 0, 10, 12, true, true));
+    ASSERT_TRUE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, pk_fid, 0, 10, 12, false, true));
+    ASSERT_FALSE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, pk_fid, 0, 10, 12, true, true));
 }
 
 TEST(Sealed, SkipIndexSkipUnaryRangeNullable) {
@@ -1705,46 +1705,46 @@ TEST(Sealed, SkipIndexSkipUnaryRangeNullable) {
                                                     cm);
     segment->LoadFieldData(load_info);
     auto& skip_index = segment->GetSkipIndex();
-    bool equal_5_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(i64_fid, 0, OpType::Equal, 5);
-    bool equal_4_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(i64_fid, 0, OpType::Equal, 4);
-    bool equal_2_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(i64_fid, 0, OpType::Equal, 2);
-    bool equal_1_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(i64_fid, 0, OpType::Equal, 1);
+    bool equal_5_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, i64_fid, 0, OpType::Equal, 5);
+    bool equal_4_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, i64_fid, 0, OpType::Equal, 4);
+    bool equal_2_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, i64_fid, 0, OpType::Equal, 2);
+    bool equal_1_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, i64_fid, 0, OpType::Equal, 1);
     ASSERT_TRUE(equal_5_skip);
     ASSERT_TRUE(equal_4_skip);
     ASSERT_FALSE(equal_2_skip);
     ASSERT_FALSE(equal_1_skip);
-    bool less_than_1_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(i64_fid, 0, OpType::LessThan, 1);
-    bool less_than_5_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(i64_fid, 0, OpType::LessThan, 5);
+    bool less_than_1_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, i64_fid, 0, OpType::LessThan, 1);
+    bool less_than_5_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, i64_fid, 0, OpType::LessThan, 5);
     ASSERT_TRUE(less_than_1_skip);
     ASSERT_FALSE(less_than_5_skip);
-    bool less_equal_than_1_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(i64_fid, 0, OpType::LessEqual, 1);
-    bool less_equal_than_15_skip =
-        skip_index.CanSkipUnaryRange<int64_t>(i64_fid, 0, OpType::LessThan, 15);
+    bool less_equal_than_1_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, i64_fid, 0, OpType::LessEqual, 1);
+    bool less_equal_than_15_skip = skip_index.CanSkipUnaryRange<int64_t>(
+        nullptr, i64_fid, 0, OpType::LessThan, 15);
     ASSERT_FALSE(less_equal_than_1_skip);
     ASSERT_FALSE(less_equal_than_15_skip);
     bool greater_than_10_skip = skip_index.CanSkipUnaryRange<int64_t>(
-        i64_fid, 0, OpType::GreaterThan, 10);
+        nullptr, i64_fid, 0, OpType::GreaterThan, 10);
     bool greater_than_5_skip = skip_index.CanSkipUnaryRange<int64_t>(
-        i64_fid, 0, OpType::GreaterThan, 5);
+        nullptr, i64_fid, 0, OpType::GreaterThan, 5);
     bool greater_than_2_skip = skip_index.CanSkipUnaryRange<int64_t>(
-        i64_fid, 0, OpType::GreaterThan, 2);
+        nullptr, i64_fid, 0, OpType::GreaterThan, 2);
     bool greater_than_1_skip = skip_index.CanSkipUnaryRange<int64_t>(
-        i64_fid, 0, OpType::GreaterThan, 1);
+        nullptr, i64_fid, 0, OpType::GreaterThan, 1);
     ASSERT_TRUE(greater_than_10_skip);
     ASSERT_TRUE(greater_than_5_skip);
     ASSERT_TRUE(greater_than_2_skip);
     ASSERT_FALSE(greater_than_1_skip);
     bool greater_equal_than_3_skip = skip_index.CanSkipUnaryRange<int64_t>(
-        i64_fid, 0, OpType::GreaterEqual, 3);
+        nullptr, i64_fid, 0, OpType::GreaterEqual, 3);
     bool greater_equal_than_2_skip = skip_index.CanSkipUnaryRange<int64_t>(
-        i64_fid, 0, OpType::GreaterEqual, 2);
+        nullptr, i64_fid, 0, OpType::GreaterEqual, 2);
     ASSERT_TRUE(greater_equal_than_3_skip);
     ASSERT_FALSE(greater_equal_than_2_skip);
 }
@@ -1776,20 +1776,20 @@ TEST(Sealed, SkipIndexSkipBinaryRangeNullable) {
                                                     cm);
     segment->LoadFieldData(load_info);
     auto& skip_index = segment->GetSkipIndex();
-    ASSERT_FALSE(
-        skip_index.CanSkipBinaryRange<int64_t>(i64_fid, 0, -3, 1, true, true));
-    ASSERT_TRUE(
-        skip_index.CanSkipBinaryRange<int64_t>(i64_fid, 0, -3, 1, true, false));
+    ASSERT_FALSE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, i64_fid, 0, -3, 1, true, true));
+    ASSERT_TRUE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, i64_fid, 0, -3, 1, true, false));
 
-    ASSERT_FALSE(
-        skip_index.CanSkipBinaryRange<int64_t>(i64_fid, 0, 1, 3, true, true));
-    ASSERT_FALSE(
-        skip_index.CanSkipBinaryRange<int64_t>(i64_fid, 0, 1, 2, true, false));
+    ASSERT_FALSE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, i64_fid, 0, 1, 3, true, true));
+    ASSERT_FALSE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, i64_fid, 0, 1, 2, true, false));
 
-    ASSERT_TRUE(
-        skip_index.CanSkipBinaryRange<int64_t>(i64_fid, 0, 2, 3, false, true));
-    ASSERT_FALSE(
-        skip_index.CanSkipBinaryRange<int64_t>(i64_fid, 0, 2, 3, true, true));
+    ASSERT_TRUE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, i64_fid, 0, 2, 3, false, true));
+    ASSERT_FALSE(skip_index.CanSkipBinaryRange<int64_t>(
+        nullptr, i64_fid, 0, 2, 3, true, true));
 }
 
 TEST(Sealed, SkipIndexSkipStringRange) {
@@ -1820,38 +1820,38 @@ TEST(Sealed, SkipIndexSkipStringRange) {
     segment->LoadFieldData(load_info);
     auto& skip_index = segment->GetSkipIndex();
     ASSERT_TRUE(skip_index.CanSkipUnaryRange<std::string>(
-        string_fid, 0, OpType::Equal, "w"));
+        nullptr, string_fid, 0, OpType::Equal, "w"));
     ASSERT_FALSE(skip_index.CanSkipUnaryRange<std::string>(
-        string_fid, 0, OpType::Equal, "e"));
+        nullptr, string_fid, 0, OpType::Equal, "e"));
     ASSERT_FALSE(skip_index.CanSkipUnaryRange<std::string>(
-        string_fid, 0, OpType::Equal, "j"));
+        nullptr, string_fid, 0, OpType::Equal, "j"));
 
     ASSERT_TRUE(skip_index.CanSkipUnaryRange<std::string>(
-        string_fid, 0, OpType::LessThan, "e"));
+        nullptr, string_fid, 0, OpType::LessThan, "e"));
     ASSERT_FALSE(skip_index.CanSkipUnaryRange<std::string>(
-        string_fid, 0, OpType::LessEqual, "e"));
+        nullptr, string_fid, 0, OpType::LessEqual, "e"));
 
     ASSERT_TRUE(skip_index.CanSkipUnaryRange<std::string>(
-        string_fid, 0, OpType::GreaterThan, "j"));
+        nullptr, string_fid, 0, OpType::GreaterThan, "j"));
     ASSERT_FALSE(skip_index.CanSkipUnaryRange<std::string>(
-        string_fid, 0, OpType::GreaterEqual, "j"));
+        nullptr, string_fid, 0, OpType::GreaterEqual, "j"));
     ASSERT_FALSE(skip_index.CanSkipUnaryRange<int64_t>(
-        string_fid, 0, OpType::GreaterEqual, 1));
+        nullptr, string_fid, 0, OpType::GreaterEqual, 1));
 
     ASSERT_TRUE(skip_index.CanSkipBinaryRange<std::string>(
-        string_fid, 0, "a", "c", true, true));
+        nullptr, string_fid, 0, "a", "c", true, true));
     ASSERT_TRUE(skip_index.CanSkipBinaryRange<std::string>(
-        string_fid, 0, "c", "e", true, false));
+        nullptr, string_fid, 0, "c", "e", true, false));
     ASSERT_FALSE(skip_index.CanSkipBinaryRange<std::string>(
-        string_fid, 0, "c", "e", true, true));
+        nullptr, string_fid, 0, "c", "e", true, true));
     ASSERT_FALSE(skip_index.CanSkipBinaryRange<std::string>(
-        string_fid, 0, "e", "k", false, true));
+        nullptr, string_fid, 0, "e", "k", false, true));
     ASSERT_FALSE(skip_index.CanSkipBinaryRange<std::string>(
-        string_fid, 0, "j", "k", true, true));
+        nullptr, string_fid, 0, "j", "k", true, true));
     ASSERT_TRUE(skip_index.CanSkipBinaryRange<std::string>(
-        string_fid, 0, "j", "k", false, true));
+        nullptr, string_fid, 0, "j", "k", false, true));
     ASSERT_FALSE(skip_index.CanSkipBinaryRange<int64_t>(
-        string_fid, 0, 1, 2, false, true));
+        nullptr, string_fid, 0, 1, 2, false, true));
 }
 
 TEST(Sealed, QueryAllFields) {


### PR DESCRIPTION
Cherry-pick from master
pr: #50231
Related to #50230

Pass op ctx to `PinCells` calls during search & query cgo calls so that AsyncCGO cancellation could be detected by cachying layer avoiding waste waiting time for resource requesting.