### PR TITLE
enhance: support minhash schema bump backfill

### DIFF
--- a/internal/datanode/compactor/bump_schema_version_compactor.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor.go
@@ -242,6 +242,14 @@ func validateSupportedMissingFunctionMaterialization(functionSchema *schemapb.Fu
 			return errors.New("bm25 function should have output fields")
 		}
 		return nil
+	case schemapb.FunctionType_MinHash:
+		if len(functionSchema.GetInputFieldIds()) == 0 {
+			return errors.New("minhash function should have input fields")
+		}
+		if len(functionSchema.GetOutputFieldIds()) == 0 {
+			return errors.New("minhash function should have output fields")
+		}
+		return nil
 	default:
 		return errors.New("unsupported function type")
 	}
@@ -253,6 +261,10 @@ func validateMaterializationInputField(functionSchema *schemapb.FunctionSchema, 
 		if field.GetDataType() != schemapb.DataType_VarChar && field.GetDataType() != schemapb.DataType_Text {
 			return errors.New("input field data type must be varchar or text for bm25 materialization")
 		}
+	case schemapb.FunctionType_MinHash:
+		if field.GetDataType() != schemapb.DataType_VarChar && field.GetDataType() != schemapb.DataType_Text {
+			return errors.New("input field data type must be varchar or text for minhash materialization")
+		}
 	}
 	return nil
 }
@@ -262,6 +274,10 @@ func validateMaterializationOutputField(functionSchema *schemapb.FunctionSchema,
 	case schemapb.FunctionType_BM25:
 		if field.GetDataType() != schemapb.DataType_SparseFloatVector {
 			return errors.New("output field data type must be sparse float vector for bm25 materialization")
+		}
+	case schemapb.FunctionType_MinHash:
+		if field.GetDataType() != schemapb.DataType_BinaryVector {
+			return errors.New("output field data type must be binary vector for minhash materialization")
 		}
 	}
 	return nil
@@ -600,6 +616,27 @@ func appendBM25StatsFromArrowArray(stats *storage.BM25Stats, arr arrow.Array) (i
 	return memorySize, nil
 }
 
+func isBM25MaterializedOutputField(schema *schemapb.CollectionSchema, fieldID int64) bool {
+	for _, functionSchema := range schema.GetFunctions() {
+		if functionSchema.GetType() != schemapb.FunctionType_BM25 {
+			continue
+		}
+		for _, outputFieldID := range functionSchema.GetOutputFieldIds() {
+			if outputFieldID == fieldID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func arrowArrayMemorySize(arr arrow.Array) int {
+	if arr == nil || arr.Data() == nil {
+		return 0
+	}
+	return int(storage.ActualSizeInBytes(arr.Data()))
+}
+
 type bumpSchemaVersionBatchWriter interface {
 	Write(storage.Record) error
 	GetWrittenUncompressed() uint64
@@ -842,10 +879,12 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		zap.Int64s("outputFieldIDs", outputFieldIDs),
 	)
 	_, span := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "BumpSchemaVersionCompact.batchProcess")
-	statsByField := make(map[int64]*storage.BM25Stats, len(outputFieldIDs))
-	sparseMemorySizeByField := make(map[int64]int, len(outputFieldIDs))
+	statsByField := make(map[int64]*storage.BM25Stats)
+	fieldMemorySizeByField := make(map[int64]int, len(outputFieldIDs))
 	for _, outputFieldID := range outputFieldIDs {
-		statsByField[outputFieldID] = storage.NewBM25Stats()
+		if isBM25MaterializedOutputField(t.plan.GetSchema(), outputFieldID) {
+			statsByField[outputFieldID] = storage.NewBM25Stats()
+		}
 	}
 	existingFields = partialMaterializerExistingFields(t.plan.GetSchema(), missingFunctions, existingFields)
 	materializer, err := NewRecordMaterializer(t.plan.GetSchema(), missingFunctions, existingFields)
@@ -886,13 +925,17 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 				span.End()
 				return nil, merr.WrapErrServiceInternal(fmt.Sprintf("output field %d not found in materialized record", outputFieldID))
 			}
-			batchMemSize, err := appendBM25StatsFromArrowArray(statsByField[outputFieldID], outputCol)
-			if err != nil {
-				releaseWrappedRecord(wrapped, record)
-				span.End()
-				return nil, err
+			batchMemSize := arrowArrayMemorySize(outputCol)
+			if stats, ok := statsByField[outputFieldID]; ok {
+				bm25MemSize, err := appendBM25StatsFromArrowArray(stats, outputCol)
+				if err != nil {
+					releaseWrappedRecord(wrapped, record)
+					span.End()
+					return nil, err
+				}
+				batchMemSize = bm25MemSize
 			}
-			sparseMemorySizeByField[outputFieldID] += batchMemSize
+			fieldMemorySizeByField[outputFieldID] += batchMemSize
 		}
 
 		writeStart := time.Now()
@@ -914,9 +957,9 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 	span.End()
 
 	_, span2 := otel.Tracer(typeutil.DataNodeRole).Start(ctx, "BumpSchemaVersionCompact.updateStats")
-	for _, outputFieldID := range outputFieldIDs {
+	for outputFieldID, stats := range statsByField {
 		startTime := time.Now()
-		err := t.updateStats(statsByField[outputFieldID], outputFieldID, writerResult)
+		err := t.updateStats(stats, outputFieldID, writerResult)
 		updateStatsDuration += time.Since(startTime)
 		if err != nil {
 			span2.End()
@@ -931,7 +974,7 @@ func (t *bumpSchemaVersionCompactionTask) runMissingFunctionMaterialization(ctx 
 		zap.Int("v3StatsCount", len(writerResult.v3Stats)),
 	)
 
-	mergedInsertLogs, err := t.buildMergedLogsV3(segment, writerResult, sparseMemorySizeByField, totalRows)
+	mergedInsertLogs, err := t.buildMergedLogsV3(segment, writerResult, fieldMemorySizeByField, totalRows)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/datanode/compactor/bump_schema_version_compactor_test.go
+++ b/internal/datanode/compactor/bump_schema_version_compactor_test.go
@@ -167,6 +167,116 @@ func (s *BumpSchemaVersionCompactionTaskSuite) setupTest() {
 	s.task = NewBumpSchemaVersionCompactionTask(context.Background(), cm, plan, compactionParams)
 }
 
+func genTestCollectionMetaWithMinHash() *etcdpb.CollectionMeta {
+	return &etcdpb.CollectionMeta{
+		ID: 1,
+		Schema: &schemapb.CollectionSchema{
+			Name: "schema_bump_minhash_test",
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: common.RowIDField, Name: "row_id", DataType: schemapb.DataType_Int64},
+				{FieldID: common.TimeStampField, Name: "Timestamp", DataType: schemapb.DataType_Int64},
+				{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+				{
+					FieldID:  101,
+					Name:     "text",
+					DataType: schemapb.DataType_VarChar,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.MaxLengthKey, Value: "128"},
+					},
+				},
+				{
+					FieldID:  102,
+					Name:     "minhash",
+					DataType: schemapb.DataType_BinaryVector,
+					TypeParams: []*commonpb.KeyValuePair{
+						{Key: common.DimKey, Value: "32"},
+					},
+					IsFunctionOutput: true,
+				},
+			},
+			Functions: []*schemapb.FunctionSchema{
+				{
+					Name:             "minhash_func",
+					Id:               1000,
+					Type:             schemapb.FunctionType_MinHash,
+					InputFieldNames:  []string{"text"},
+					InputFieldIds:    []int64{101},
+					OutputFieldNames: []string{"minhash"},
+					OutputFieldIds:   []int64{102},
+				},
+			},
+		},
+	}
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) setupMinHashTest() {
+	s.mockBinlogIO = mock_util.NewMockBinlogIO(s.T())
+	s.meta = genTestCollectionMetaWithMinHash()
+
+	params, err := compaction.GenerateJSONParams(s.meta.GetSchema())
+	s.Require().NoError(err)
+
+	plan := &datapb.CompactionPlan{
+		PlanID: 999,
+		SegmentBinlogs: []*datapb.CompactionSegmentBinlogs{{
+			CollectionID:   1,
+			PartitionID:    1,
+			SegmentID:      100,
+			InsertChannel:  "test_channel",
+			StorageVersion: storage.StorageV3,
+			Manifest:       "manifest",
+		}},
+		Type:                   datapb.CompactionType_BumpSchemaVersionCompaction,
+		Schema:                 s.meta.GetSchema(),
+		PreAllocatedSegmentIDs: &datapb.IDRange{Begin: 19531, End: math.MaxInt64},
+		PreAllocatedLogIDs:     &datapb.IDRange{Begin: 9530, End: 19530},
+		MaxSize:                64 * 1024 * 1024,
+		JsonParams:             params,
+		TotalRows:              3,
+	}
+
+	cm, err := storage.NewChunkManagerFactoryWithParam(paramtable.Get()).NewPersistentStorageChunkManager(context.Background())
+	s.Require().NoError(err)
+	compactionParams := compaction.GenParams()
+	compactionParams.StorageVersion = storage.StorageV3
+	s.task = NewBumpSchemaVersionCompactionTask(context.Background(), cm, plan, compactionParams)
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) prepareMinHashBumpSchemaVersionCompaction() {
+	segID := int64(100)
+	s.mockBinlogIO.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil).Maybe()
+	s.initSegBufferForSchemaBump(segID)
+	s.finishBumpSchemaVersionSegment()
+}
+
+func (s *BumpSchemaVersionCompactionTaskSuite) TestBumpSchemaVersionCompactionMaterializesMinHashOutput() {
+	s.setupMinHashTest()
+	s.prepareMinHashBumpSchemaVersionCompaction()
+
+	result, err := s.task.Compact()
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal(datapb.CompactionTaskState_completed, result.GetState())
+	s.Require().Len(result.GetSegments(), 1)
+
+	segment := result.GetSegments()[0]
+	s.EqualValues(3, segment.GetNumOfRows())
+	s.NotEmpty(segment.GetManifest())
+	s.Empty(segment.GetBm25Logs())
+
+	const minHashOutputFieldID = int64(102)
+	found := false
+	for _, fl := range segment.GetInsertLogs() {
+		if fl.GetFieldID() == minHashOutputFieldID {
+			found = true
+			s.Require().Len(fl.GetBinlogs(), 1)
+			s.EqualValues(3, fl.GetBinlogs()[0].GetEntriesNum())
+			s.Greater(fl.GetBinlogs()[0].GetMemorySize(), int64(0))
+		}
+	}
+	s.True(found, "MinHash output field should be materialized into insert logs")
+}
+
 func (s *BumpSchemaVersionCompactionTaskSuite) SetupTest() {
 	// Align with sort_compaction_test fixture: use a per-test temp dir as the local
 	// storage root and disable Loon FFI. Without UseLoonFFI=false, the loon local

--- a/internal/datanode/compactor/record_materializer.go
+++ b/internal/datanode/compactor/record_materializer.go
@@ -325,16 +325,77 @@ type bm25FunctionMaterializer struct {
 	ownRunner            bool
 }
 
-var _ FunctionMaterializer = (*bm25FunctionMaterializer)(nil)
+type minHashFunctionMaterializer struct {
+	runner               function.FunctionRunner
+	inputFieldIDs        []int64
+	outputFieldIDs       []int64
+	missingOutputIndexes []int
+	outputFields         map[int64]*schemapb.FieldSchema
+	ownRunner            bool
+}
+
+var (
+	_ FunctionMaterializer = (*bm25FunctionMaterializer)(nil)
+	_ FunctionMaterializer = (*minHashFunctionMaterializer)(nil)
+)
 
 func newFunctionMaterializer(schema *schemapb.CollectionSchema, runner function.FunctionRunner, missingOutputIndexes []int, ownRunner bool) (FunctionMaterializer, error) {
 	functionSchema := runner.GetSchema()
 	switch functionSchema.GetType() {
 	case schemapb.FunctionType_BM25:
 		return newBM25FunctionMaterializer(schema, runner, missingOutputIndexes, ownRunner)
+	case schemapb.FunctionType_MinHash:
+		return newMinHashFunctionMaterializer(schema, runner, missingOutputIndexes, ownRunner)
 	default:
 		return nil, errors.Newf("unsupported function type %s", functionSchema.GetType().String())
 	}
+}
+
+func newMinHashFunctionMaterializer(schema *schemapb.CollectionSchema, runner function.FunctionRunner, missingOutputIndexes []int, ownRunner bool) (*minHashFunctionMaterializer, error) {
+	functionSchema := runner.GetSchema()
+	inputFields := runner.GetInputFields()
+	if len(inputFields) == 0 {
+		return nil, errors.New("minhash function should have input fields")
+	}
+	inputFieldIDs := make([]int64, 0, len(inputFields))
+	for _, inputField := range inputFields {
+		if inputField == nil || typeutil.GetField(schema, inputField.GetFieldID()) == nil {
+			return nil, errors.New("input field not found in schema")
+		}
+		if inputField.GetDataType() != schemapb.DataType_VarChar && inputField.GetDataType() != schemapb.DataType_Text {
+			return nil, errors.New("input field data type must be varchar or text for minhash function materialization")
+		}
+		inputFieldIDs = append(inputFieldIDs, inputField.GetFieldID())
+	}
+
+	outputFieldIDs := functionSchema.GetOutputFieldIds()
+	if len(outputFieldIDs) == 0 {
+		return nil, errors.New("minhash function should have output fields")
+	}
+
+	outputFields := make(map[int64]*schemapb.FieldSchema, len(outputFieldIDs))
+	for _, outputFieldID := range outputFieldIDs {
+		outputField := typeutil.GetField(schema, outputFieldID)
+		if outputField == nil {
+			return nil, errors.New("output field not found in schema")
+		}
+		if outputField.GetDataType() != schemapb.DataType_BinaryVector {
+			return nil, errors.New("output field data type must be binary vector for minhash function materialization")
+		}
+		if outputField.GetNullable() {
+			return nil, errors.Newf("function output field cannot be nullable: function %s, field %s", functionSchema.GetName(), outputField.GetName())
+		}
+		outputFields[outputFieldID] = outputField
+	}
+
+	return &minHashFunctionMaterializer{
+		runner:               runner,
+		inputFieldIDs:        inputFieldIDs,
+		outputFieldIDs:       outputFieldIDs,
+		missingOutputIndexes: missingOutputIndexes,
+		outputFields:         outputFields,
+		ownRunner:            ownRunner,
+	}, nil
 }
 
 func newBM25FunctionMaterializer(schema *schemapb.CollectionSchema, runner function.FunctionRunner, missingOutputIndexes []int, ownRunner bool) (*bm25FunctionMaterializer, error) {
@@ -425,6 +486,60 @@ func (m *bm25FunctionMaterializer) Close() {
 	}
 }
 
+func (m *minHashFunctionMaterializer) Materialize(rec storage.Record) (map[int64]arrow.Array, error) {
+	inputs := make([]any, 0, len(m.inputFieldIDs))
+	for _, inputFieldID := range m.inputFieldIDs {
+		input, err := stringInputsFromRecord(rec, inputFieldID)
+		if err != nil {
+			return nil, err
+		}
+		inputs = append(inputs, input)
+	}
+	outputs, err := m.runner.BatchRun(inputs...)
+	if err != nil {
+		return nil, err
+	}
+	if len(outputs) != len(m.outputFieldIDs) {
+		return nil, errors.Newf("minhash function materialization expects %d outputs, got %d", len(m.outputFieldIDs), len(outputs))
+	}
+
+	result := make(map[int64]arrow.Array, len(m.missingOutputIndexes))
+	for _, outputIndex := range m.missingOutputIndexes {
+		outputFieldID := m.outputFieldIDs[outputIndex]
+		outputFieldData, ok := outputs[outputIndex].(*schemapb.FieldData)
+		if !ok {
+			releaseArrowArrays(result)
+			return nil, errors.Newf("unexpected output type from MinHash function runner, expected FieldData, got %T", outputs[outputIndex])
+		}
+		vectorField := outputFieldData.GetVectors()
+		if vectorField == nil || vectorField.GetBinaryVector() == nil {
+			releaseArrowArrays(result)
+			return nil, errors.New("unexpected output from MinHash function runner, expected binary vector field data")
+		}
+		fieldData := &storage.BinaryVectorFieldData{
+			Data: vectorField.GetBinaryVector(),
+			Dim:  int(vectorField.GetDim()),
+		}
+		if fieldData.RowNum() != rec.Len() {
+			releaseArrowArrays(result)
+			return nil, errors.Newf("minhash function output row count mismatch, expected %d, got %d", rec.Len(), fieldData.RowNum())
+		}
+		arr, err := buildArrowArrayFromFieldData(m.outputFields[outputFieldID], fieldData, rec.Len())
+		if err != nil {
+			releaseArrowArrays(result)
+			return nil, err
+		}
+		result[outputFieldID] = arr
+	}
+	return result, nil
+}
+
+func (m *minHashFunctionMaterializer) Close() {
+	if m.ownRunner && m.runner != nil {
+		m.runner.Close()
+	}
+}
+
 func functionOutputIndexesToMaterialize(functionSchema *schemapb.FunctionSchema, existingFields map[int64]struct{}) []int {
 	outputFieldIDs := functionSchema.GetOutputFieldIds()
 	indexes := make([]int, 0, len(outputFieldIDs))
@@ -485,6 +600,21 @@ func buildSparseFloatVectorArrowArray(field *schemapb.FieldSchema, outputSparseA
 		return nil, errors.Newf("bm25 function output row count mismatch, expected %d, got %d", rowCount, len(outputSparseArray.GetContents()))
 	}
 
+	fieldData := &storage.SparseFloatVectorFieldData{
+		SparseFloatArray: schemapb.SparseFloatArray{
+			Contents: outputSparseArray.GetContents(),
+			Dim:      outputSparseArray.GetDim(),
+		},
+	}
+
+	return buildArrowArrayFromFieldData(field, fieldData, rowCount)
+}
+
+func buildArrowArrayFromFieldData(field *schemapb.FieldSchema, fieldData storage.FieldData, rowCount int) (arrow.Array, error) {
+	if fieldData.RowNum() != rowCount {
+		return nil, errors.Newf("function output row count mismatch for field %d, expected %d, got %d", field.GetFieldID(), rowCount, fieldData.RowNum())
+	}
+
 	outputSchema := &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{field}}
 	arrowSchema, err := storage.ConvertToArrowSchema(outputSchema, true)
 	if err != nil {
@@ -493,12 +623,6 @@ func buildSparseFloatVectorArrowArray(field *schemapb.FieldSchema, outputSparseA
 	builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
 	defer builder.Release()
 
-	fieldData := &storage.SparseFloatVectorFieldData{
-		SparseFloatArray: schemapb.SparseFloatArray{
-			Contents: outputSparseArray.GetContents(),
-			Dim:      outputSparseArray.GetDim(),
-		},
-	}
 	insertData := &storage.InsertData{Data: map[int64]storage.FieldData{
 		field.GetFieldID(): fieldData,
 	}}

--- a/internal/datanode/compactor/record_materializer_test.go
+++ b/internal/datanode/compactor/record_materializer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/util/function"
@@ -417,6 +418,195 @@ func materializerBM25Schema() (*schemapb.CollectionSchema, *schemapb.FunctionSch
 		OutputFieldIds: []int64{101},
 	}
 	return &schemapb.CollectionSchema{Fields: []*schemapb.FieldSchema{inputField, outputField}, Functions: []*schemapb.FunctionSchema{functionSchema}}, functionSchema, inputField, outputField
+}
+
+func materializerMinHashSchema() (*schemapb.CollectionSchema, *schemapb.FunctionSchema, *schemapb.FieldSchema, *schemapb.FieldSchema) {
+	inputField := &schemapb.FieldSchema{
+		FieldID:  100,
+		Name:     "text",
+		DataType: schemapb.DataType_VarChar,
+	}
+	outputField := &schemapb.FieldSchema{
+		FieldID:  101,
+		Name:     "minhash",
+		DataType: schemapb.DataType_BinaryVector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.DimKey, Value: "32"},
+		},
+	}
+	functionSchema := &schemapb.FunctionSchema{
+		Name:           "minhash_func",
+		Type:           schemapb.FunctionType_MinHash,
+		InputFieldIds:  []int64{inputField.GetFieldID()},
+		OutputFieldIds: []int64{outputField.GetFieldID()},
+	}
+	schema := &schemapb.CollectionSchema{
+		Fields:    []*schemapb.FieldSchema{inputField, outputField},
+		Functions: []*schemapb.FunctionSchema{functionSchema},
+	}
+	return schema, functionSchema, inputField, outputField
+}
+
+func TestMinHashFunctionMaterializerMaterializesBinaryOutput(t *testing.T) {
+	schema, functionSchema, inputField, outputField := materializerMinHashSchema()
+	runner := &materializerTestFunctionRunner{
+		schema:       functionSchema,
+		inputFields:  []*schemapb.FieldSchema{inputField},
+		outputFields: []*schemapb.FieldSchema{outputField},
+		outputs: []any{&schemapb.FieldData{
+			Type:    schemapb.DataType_BinaryVector,
+			FieldId: outputField.GetFieldID(),
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 32,
+					Data: &schemapb.VectorField_BinaryVector{
+						BinaryVector: []byte{
+							0x01, 0x02, 0x03, 0x04,
+							0x05, 0x06, 0x07, 0x08,
+						},
+					},
+				},
+			},
+		}},
+	}
+	materializer, err := newFunctionMaterializer(schema, runner, []int{0}, false)
+	require.NoError(t, err)
+	defer materializer.Close()
+
+	input := newStringArray(t, []string{"hello", "world"})
+	defer input.Release()
+	record := &materializerTestRecord{len: 2, columns: map[storage.FieldID]arrow.Array{100: input}}
+
+	arrays, err := materializer.Materialize(record)
+	require.NoError(t, err)
+	require.Len(t, arrays, 1)
+	defer releaseArrowArrays(arrays)
+
+	output := arrays[101]
+	require.NotNil(t, output)
+	require.Equal(t, 2, output.Len())
+	binary, ok := output.(*array.FixedSizeBinary)
+	require.True(t, ok)
+	require.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, binary.Value(0))
+	require.Equal(t, []byte{0x05, 0x06, 0x07, 0x08}, binary.Value(1))
+	require.Len(t, runner.inputs, 1)
+	require.Equal(t, []string{"hello", "world"}, runner.inputs[0])
+}
+
+func TestMinHashFunctionMaterializerRejectsNonBinaryOutputField(t *testing.T) {
+	schema, functionSchema, inputField, outputField := materializerMinHashSchema()
+	outputField.DataType = schemapb.DataType_FloatVector
+	runner := &materializerTestFunctionRunner{
+		schema:       functionSchema,
+		inputFields:  []*schemapb.FieldSchema{inputField},
+		outputFields: []*schemapb.FieldSchema{outputField},
+	}
+
+	_, err := newFunctionMaterializer(schema, runner, []int{0}, false)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "output field data type must be binary vector for minhash function materialization")
+}
+
+func TestMinHashFunctionMaterializerRejectsRowCountMismatch(t *testing.T) {
+	schema, functionSchema, inputField, outputField := materializerMinHashSchema()
+	runner := &materializerTestFunctionRunner{
+		schema:       functionSchema,
+		inputFields:  []*schemapb.FieldSchema{inputField},
+		outputFields: []*schemapb.FieldSchema{outputField},
+		outputs: []any{&schemapb.FieldData{
+			Type:    schemapb.DataType_BinaryVector,
+			FieldId: outputField.GetFieldID(),
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim: 32,
+					Data: &schemapb.VectorField_BinaryVector{
+						BinaryVector: []byte{0x01, 0x02, 0x03, 0x04},
+					},
+				},
+			},
+		}},
+	}
+	materializer, err := newFunctionMaterializer(schema, runner, []int{0}, false)
+	require.NoError(t, err)
+	defer materializer.Close()
+
+	input := newStringArray(t, []string{"hello", "world"})
+	defer input.Release()
+	record := &materializerTestRecord{len: 2, columns: map[storage.FieldID]arrow.Array{100: input}}
+
+	arrays, err := materializer.Materialize(record)
+	require.Nil(t, arrays)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "minhash function output row count mismatch")
+}
+
+func TestRecordMaterializerMaterializesBM25AndMinHashOutputs(t *testing.T) {
+	bm25Schema, bm25Function, inputField, bm25Output := materializerBM25Schema()
+	minHashOutput := &schemapb.FieldSchema{
+		FieldID:  102,
+		Name:     "minhash",
+		DataType: schemapb.DataType_BinaryVector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.DimKey, Value: "32"},
+		},
+	}
+	minHashFunction := &schemapb.FunctionSchema{
+		Name:           "minhash_func",
+		Type:           schemapb.FunctionType_MinHash,
+		InputFieldIds:  []int64{inputField.GetFieldID()},
+		OutputFieldIds: []int64{minHashOutput.GetFieldID()},
+	}
+	bm25Schema.Fields = append(bm25Schema.Fields, minHashOutput)
+	bm25Schema.Functions = []*schemapb.FunctionSchema{bm25Function, minHashFunction}
+
+	input := newStringArray(t, []string{"hello", "world"})
+	defer input.Release()
+	record := &materializerTestRecord{len: 2, columns: map[storage.FieldID]arrow.Array{100: input}}
+
+	bm25Runner := &materializerTestFunctionRunner{
+		schema:       bm25Function,
+		inputFields:  []*schemapb.FieldSchema{inputField},
+		outputFields: []*schemapb.FieldSchema{bm25Output},
+		outputs: []any{&schemapb.SparseFloatArray{
+			Dim: 16,
+			Contents: [][]byte{
+				typeutil.CreateSparseFloatRow([]uint32{1}, []float32{0.5}),
+				typeutil.CreateSparseFloatRow([]uint32{2}, []float32{0.8}),
+			},
+		}},
+	}
+	minHashRunner := &materializerTestFunctionRunner{
+		schema:       minHashFunction,
+		inputFields:  []*schemapb.FieldSchema{inputField},
+		outputFields: []*schemapb.FieldSchema{minHashOutput},
+		outputs: []any{&schemapb.FieldData{
+			Type:    schemapb.DataType_BinaryVector,
+			FieldId: minHashOutput.GetFieldID(),
+			Field: &schemapb.FieldData_Vectors{
+				Vectors: &schemapb.VectorField{
+					Dim:  32,
+					Data: &schemapb.VectorField_BinaryVector{BinaryVector: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+				},
+			},
+		}},
+	}
+	bm25Materializer, err := newFunctionMaterializer(bm25Schema, bm25Runner, []int{0}, false)
+	require.NoError(t, err)
+	minHashMaterializer, err := newFunctionMaterializer(bm25Schema, minHashRunner, []int{0}, false)
+	require.NoError(t, err)
+	materializer := &RecordMaterializer{
+		schema:        bm25Schema,
+		materializers: []FunctionMaterializer{bm25Materializer, minHashMaterializer},
+	}
+	defer materializer.Close()
+
+	wrapped, err := materializer.Wrap(record)
+	require.NoError(t, err)
+	defer wrapped.Release()
+
+	require.NotNil(t, wrapped.Column(bm25Output.GetFieldID()))
+	require.NotNil(t, wrapped.Column(minHashOutput.GetFieldID()))
+	require.Equal(t, 2, wrapped.Len())
 }
 
 func newStringArray(t *testing.T, values []string) *array.String {

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -1080,8 +1080,9 @@ func (t *alterCollectionSchemaTask) preExecuteAdd(ctx context.Context) error {
 	if len(funcSchemas) != 1 || funcSchemas[0] == nil {
 		return merr.WrapErrParameterInvalidMsg("For now, exactly one function schema is required in alter schema task")
 	}
-	if funcSchemas[0].GetType() != schemapb.FunctionType_BM25 {
-		return merr.WrapErrParameterInvalidMsg("For now, only BM25 function is supported in alter schema task")
+	functionType := funcSchemas[0].GetType()
+	if functionType != schemapb.FunctionType_BM25 && functionType != schemapb.FunctionType_MinHash {
+		return merr.WrapErrParameterInvalidMsg("For now, only BM25 and MinHash functions are supported in alter schema task")
 	}
 	if len(fieldInfos) == 0 {
 		return merr.WrapErrParameterInvalidMsg("fieldInfos is empty, function output fields are required")

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -7256,6 +7256,13 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 		Name:     "sparse_bm25",
 		DataType: schemapb.DataType_SparseFloatVector,
 	}
+	minHashOutputField := &schemapb.FieldSchema{
+		Name:     "minhash_binary",
+		DataType: schemapb.DataType_BinaryVector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: common.DimKey, Value: "32"},
+		},
+	}
 
 	// BM25 function schema: input "text", output "sparse_bm25".
 	functionSchema := &schemapb.FunctionSchema{
@@ -7265,7 +7272,9 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 		OutputFieldNames: []string{"sparse_bm25"},
 	}
 
-	buildValidRequest := func() *milvuspb.AlterCollectionSchemaRequest {
+	buildAddFunctionRequest := func(field *schemapb.FieldSchema, function *schemapb.FunctionSchema) *milvuspb.AlterCollectionSchemaRequest {
+		field = proto.Clone(field).(*schemapb.FieldSchema)
+		function = proto.Clone(function).(*schemapb.FunctionSchema)
 		return &milvuspb.AlterCollectionSchemaRequest{
 			DbName:         dbName,
 			CollectionName: collectionName,
@@ -7273,13 +7282,17 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 				Op: &milvuspb.AlterCollectionSchemaRequest_Action_AddRequest{
 					AddRequest: &milvuspb.AlterCollectionSchemaRequest_AddRequest{
 						FieldInfos: []*milvuspb.AlterCollectionSchemaRequest_FieldInfo{
-							{FieldSchema: sparseOutputField},
+							{FieldSchema: field},
 						},
-						FuncSchema: []*schemapb.FunctionSchema{functionSchema},
+						FuncSchema: []*schemapb.FunctionSchema{function},
 					},
 				},
 			},
 		}
+	}
+
+	buildValidRequest := func() *milvuspb.AlterCollectionSchemaRequest {
+		return buildAddFunctionRequest(sparseOutputField, functionSchema)
 	}
 
 	buildTask := func(req *milvuspb.AlterCollectionSchemaRequest, schema *schemapb.CollectionSchema) *alterCollectionSchemaTask {
@@ -7500,18 +7513,30 @@ func TestAlterCollectionSchemaTask(t *testing.T) {
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 	})
 
-	t.Run("PreExecute rejects non-BM25 function", func(t *testing.T) {
+	t.Run("PreExecute happy path for MinHash", func(t *testing.T) {
+		functionSchema := &schemapb.FunctionSchema{
+			Name:             "minhash_func",
+			Type:             schemapb.FunctionType_MinHash,
+			InputFieldNames:  []string{"text"},
+			OutputFieldNames: []string{"minhash_binary"},
+		}
+		task := buildTask(buildAddFunctionRequest(minHashOutputField, functionSchema), oldSchema)
+		err := task.PreExecute(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("PreExecute rejects unsupported function", func(t *testing.T) {
 		req := buildValidRequest()
 		addRequest := req.GetAction().GetAddRequest()
 		functionSchema := proto.Clone(addRequest.GetFuncSchema()[0]).(*schemapb.FunctionSchema)
-		functionSchema.Type = schemapb.FunctionType_MinHash
+		functionSchema.Type = schemapb.FunctionType_TextEmbedding
 		addRequest.FuncSchema = []*schemapb.FunctionSchema{functionSchema}
 
 		task := buildTask(req, oldSchema)
 		err := task.PreExecute(ctx)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
-		assert.ErrorContains(t, err, "only BM25 function is supported")
+		assert.ErrorContains(t, err, "only BM25 and MinHash functions are supported")
 	})
 
 	t.Run("PreExecute ignores legacy DoPhysicalBackfill", func(t *testing.T) {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema.go
@@ -220,10 +220,10 @@ func (c *Core) broadcastAlterCollectionSchemaAdd(ctx context.Context, broadcaste
 
 func checkAlterSchemaFunctionAllowed(functionSchema *schemapb.FunctionSchema) error {
 	switch functionSchema.GetType() {
-	case schemapb.FunctionType_BM25:
+	case schemapb.FunctionType_BM25, schemapb.FunctionType_MinHash:
 		return nil
 	default:
-		return merr.WrapErrParameterInvalidMsg("For now, only BM25 function is supported in alter schema task")
+		return merr.WrapErrParameterInvalidMsg("For now, only BM25 and MinHash functions are supported in alter schema task")
 	}
 }
 
@@ -233,6 +233,11 @@ func validateAlterSchemaFunctionInputOutput(functionSchema *schemapb.FunctionSch
 		inputCount := len(functionSchema.GetInputFieldNames())
 		if (inputCount != 1 && inputCount != 2) || len(functionSchema.GetOutputFieldNames()) != 1 {
 			return merr.WrapErrParameterInvalidMsg("BM25 function should have one or two input fields and exactly one output field")
+		}
+		return nil
+	case schemapb.FunctionType_MinHash:
+		if len(functionSchema.GetInputFieldNames()) != 1 || len(functionSchema.GetOutputFieldNames()) != 1 {
+			return merr.WrapErrParameterInvalidMsg("MinHash function should have exactly one input field and exactly one output field")
 		}
 		return nil
 	default:

--- a/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_schema_test.go
@@ -228,13 +228,28 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 	})
 	require.NoError(t, merr.CheckRPCCall(addFieldResp, err))
 
-	// Non-BM25 function is not supported by schema evolution backfill.
-	nonBM25Req := buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_output_non_bm25", "minhash_fn")
-	nonBM25Req.GetAction().GetAddRequest().GetFuncSchema()[0].Type = schemapb.FunctionType_MinHash
-	resp, err = core.AlterCollectionSchema(ctx, nonBM25Req)
+	// MinHash happy path: add binary vector output field + MinHash function.
+	minHashReq := buildAlterSchemaReq(dbName, collectionName, "text_input", "minhash_output", "minhash_fn")
+	minHashReq.GetAction().GetAddRequest().GetFuncSchema()[0].Type = schemapb.FunctionType_MinHash
+	minHashReq.GetAction().GetAddRequest().GetFieldInfos()[0].GetFieldSchema().DataType = schemapb.DataType_BinaryVector
+	minHashReq.GetAction().GetAddRequest().GetFieldInfos()[0].GetFieldSchema().TypeParams = []*commonpb.KeyValuePair{
+		{Key: common.DimKey, Value: "32"},
+	}
+	resp, err = core.AlterCollectionSchema(ctx, minHashReq)
+	require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 2)
+
+	minHashBadArityReq := buildAlterSchemaReq(dbName, collectionName, "text_input", "minhash_bad_arity", "minhash_bad_arity_fn")
+	minHashBadArityReq.GetAction().GetAddRequest().GetFuncSchema()[0].Type = schemapb.FunctionType_MinHash
+	minHashBadArityReq.GetAction().GetAddRequest().GetFuncSchema()[0].InputFieldNames = []string{"text_input", "field1"}
+	minHashBadArityReq.GetAction().GetAddRequest().GetFieldInfos()[0].GetFieldSchema().DataType = schemapb.DataType_BinaryVector
+	minHashBadArityReq.GetAction().GetAddRequest().GetFieldInfos()[0].GetFieldSchema().TypeParams = []*commonpb.KeyValuePair{
+		{Key: common.DimKey, Value: "32"},
+	}
+	resp, err = core.AlterCollectionSchema(ctx, minHashBadArityReq)
 	alterErr := merr.CheckRPCCall(resp.GetAlterStatus(), err)
 	require.ErrorIs(t, alterErr, merr.ErrParameterInvalid)
-	require.ErrorContains(t, alterErr, "only BM25 function is supported")
+	require.ErrorContains(t, alterErr, "MinHash function should have exactly one input field and exactly one output field")
 
 	nullableOutputReq := buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_output_nullable", "bm25_nullable_output")
 	nullableOutputReq.GetAction().GetAddRequest().GetFieldInfos()[0].GetFieldSchema().Nullable = true
@@ -243,22 +258,22 @@ func TestDDLCallbacksBroadcastAlterCollectionSchema(t *testing.T) {
 	require.ErrorIs(t, alterErr, merr.ErrParameterInvalid)
 	require.ErrorContains(t, alterErr, "function output field cannot be nullable")
 
-	// happy path: add sparse vector output field + BM25 function → schema version bumps (AddCollectionField already bumped to 1, so now 2)
+	// happy path: add sparse vector output field + BM25 function → schema version bumps.
 	firstAlterReq := buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_output", "bm25_fn")
 	resp, err = core.AlterCollectionSchema(ctx, firstAlterReq)
 	require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 2)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 3)
 
-	// second happy path: schema version bumps to 3
+	// second happy path: schema version bumps again.
 	secondAlterReq := buildAlterSchemaReq(dbName, collectionName, "text_input", "sparse_output2", "bm25_fn2")
 	resp, err = core.AlterCollectionSchema(ctx, secondAlterReq)
 	require.NoError(t, merr.CheckRPCCall(resp.GetAlterStatus(), err))
-	assertSchemaVersion(t, ctx, core, dbName, collectionName, 3)
+	assertSchemaVersion(t, ctx, core, dbName, collectionName, 4)
 	updated, err := core.meta.GetCollectionByName(ctx, dbName, collectionName, typeutil.MaxTimestamp, false)
 	require.NoError(t, err)
 	schema := updated.ToCollectionSchemaPB()
 	require.False(t, schema.GetDoPhysicalBackfill())
-	require.EqualValues(t, 3, schema.GetVersion())
+	require.EqualValues(t, 4, schema.GetVersion())
 
 	// case 9: function already exists (same name "bm25_fn")
 	resp, err = core.AlterCollectionSchema(ctx, &milvuspb.AlterCollectionSchemaRequest{


### PR DESCRIPTION
## What this PR does

This PR supports end-to-end add-MinHash-function schema evolution by:
- allowing RootCoord alter-schema to accept MinHash functions with strict arity validation;
- adding a concrete MinHash record materializer in DataNode compactor;
- extending bump schema version compaction to materialize missing MinHash BinaryVector outputs while keeping BM25 stats BM25-only.

## Tests

- source ./scripts/setenv.sh && go test -v -count=1 -gcflags="all=-N -l" -tags dynamic,test ./internal/datanode/compactor -run 'TestBumpSchemaVersionCompactionTaskSuite/TestBumpSchemaVersionCompactionMaterializesMinHashOutput'
- source ./scripts/setenv.sh && go test -v -count=1 -gcflags="all=-N -l" -tags dynamic,test ./internal/datanode/compactor -run 'Test(BumpSchemaVersionCompactionTaskSuite|RecordMaterializer|BM25FunctionMaterializer|MinHashFunctionMaterializer)'
- source ./scripts/setenv.sh && go test -v -count=1 -gcflags="all=-N -l" -tags dynamic,test ./internal/rootcoord -run TestDDLCallbacksBroadcastAlterCollectionSchema

issue: #48808

🤖 Generated with [Claude Code](https://claude.com/claude-code)