### PR TITLE
enhance: optimize segment dist lookup by segment id

### DIFF
--- a/internal/querycoordv2/meta/segment_dist_manager.go
+++ b/internal/querycoordv2/meta/segment_dist_manager.go
@@ -35,6 +35,8 @@ type segDistCriterion struct {
 	nodes          []int64
 	collectionID   int64
 	channel        string
+	segmentID      int64
+	hasSegmentID   bool
 	hasOtherFilter bool
 }
 
@@ -86,10 +88,19 @@ func WithNodeID(nodeID int64) SegmentDistFilter {
 	return NodeSegDistFilter(nodeID)
 }
 
+type SegmentIDSegDistFilter int64
+
+func (f SegmentIDSegDistFilter) Match(s *Segment) bool {
+	return s.GetID() == int64(f)
+}
+
+func (f SegmentIDSegDistFilter) AddFilter(filter *segDistCriterion) {
+	filter.segmentID = int64(f)
+	filter.hasSegmentID = true
+}
+
 func WithSegmentID(segmentID int64) SegmentDistFilter {
-	return SegmentDistFilterFunc(func(s *Segment) bool {
-		return s.GetID() == segmentID
-	})
+	return SegmentIDSegDistFilter(segmentID)
 }
 
 type CollectionSegDistFilter int64
@@ -194,11 +205,16 @@ type nodeSegments struct {
 	segments        []*Segment
 	collSegments    map[int64][]*Segment
 	channelSegments map[string][]*Segment
+	segmentSegments map[int64][]*Segment
 }
 
 func (s nodeSegments) Filter(criterion *segDistCriterion, filter func(*Segment) bool) []*Segment {
 	var segments []*Segment
+	needFilter := criterion.hasOtherFilter
 	switch {
+	case criterion.hasSegmentID:
+		segments = s.segmentSegments[criterion.segmentID]
+		needFilter = needFilter || criterion.collectionID != 0 || criterion.channel != ""
 	case criterion.channel != "":
 		segments = s.channelSegments[criterion.channel]
 	case criterion.collectionID != 0:
@@ -206,7 +222,7 @@ func (s nodeSegments) Filter(criterion *segDistCriterion, filter func(*Segment) 
 	default:
 		segments = s.segments
 	}
-	if criterion.hasOtherFilter {
+	if needFilter {
 		segments = lo.Filter(segments, func(segment *Segment, _ int) bool {
 			return filter(segment)
 		})
@@ -219,6 +235,7 @@ func composeNodeSegments(segments []*Segment) nodeSegments {
 		segments:        segments,
 		collSegments:    lo.GroupBy(segments, func(segment *Segment) int64 { return segment.GetCollectionID() }),
 		channelSegments: lo.GroupBy(segments, func(segment *Segment) string { return segment.GetInsertChannel() }),
+		segmentSegments: lo.GroupBy(segments, func(segment *Segment) int64 { return segment.GetID() }),
 	}
 }
 

--- a/internal/querycoordv2/meta/segment_dist_manager_test.go
+++ b/internal/querycoordv2/meta/segment_dist_manager_test.go
@@ -37,6 +37,19 @@ type SegmentDistManagerSuite struct {
 	segments   map[int64]*Segment
 }
 
+type countingSegmentDistFilter struct {
+	count *int
+}
+
+func (f countingSegmentDistFilter) Match(*Segment) bool {
+	*f.count++
+	return true
+}
+
+func (f countingSegmentDistFilter) AddFilter(criterion *segDistCriterion) {
+	criterion.hasOtherFilter = true
+}
+
 func (suite *SegmentDistManagerSuite) SetupSuite() {
 	const (
 		shardNum = 2
@@ -172,6 +185,27 @@ func (suite *SegmentDistManagerSuite) TestGetBy() {
 	})
 	segments = dist.GetByFilter(WithReplica(replica))
 	suite.Len(segments, 2)
+
+	// Test GetBySegment
+	segments = dist.GetByFilter(WithSegmentID(1))
+	suite.Len(segments, 2)
+	suite.AssertIDs(segments, 1)
+
+	segments = dist.GetByFilter(WithCollectionID(-1), WithSegmentID(1))
+	suite.Len(segments, 0)
+
+	segments = dist.GetByFilter(WithNodeID(suite.nodes[2]), WithSegmentID(1))
+	suite.Len(segments, 0)
+}
+
+func (suite *SegmentDistManagerSuite) TestGetBySegmentIDUsesIndex() {
+	visited := 0
+
+	segments := suite.dist.GetByFilter(countingSegmentDistFilter{count: &visited}, WithSegmentID(4))
+
+	suite.Len(segments, 2)
+	suite.AssertIDs(segments, 4)
+	suite.Equal(2, visited)
 }
 
 func (suite *SegmentDistManagerSuite) AssertIDs(segments []*Segment, ids ...int64) bool {


### PR DESCRIPTION
## Summary
- add a segmentID index to QueryCoord's SegmentDistManager node snapshot
- make WithSegmentID use the indexed lookup path before applying remaining filters
- add coverage that segmentID lookups only visit matching segment replicas

