### PR TITLE
fix: align nullable struct array data with row offsets

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -959,6 +959,13 @@ class SegmentExpr : public Expr {
             auto data_pos =
                 i == current_data_chunk_ ? current_data_chunk_pos_ : 0;
             int64_t size = segment_->chunk_size(field_id_, i) - data_pos;
+            if (segment_->type() == SegmentType::Growing &&
+                i == num_data_chunk_ - 1) {
+                auto tail_size = active_count_ % size_per_chunk_;
+                auto active_chunk_size =
+                    tail_size == 0 ? size_per_chunk_ : tail_size;
+                size = active_chunk_size - data_pos;
+            }
             size = std::min(size, batch_size_ - processed_rows);
             if (size == 0)
                 continue;

--- a/internal/core/src/segcore/ConcurrentVector.cpp
+++ b/internal/core/src/segcore/ConcurrentVector.cpp
@@ -168,9 +168,46 @@ VectorBase::set_data_raw(ssize_t element_offset,
         case DataType::ARRAY: {
             auto& array_data = FIELD_DATA(data, array);
             std::vector<Array> data_raw{};
-            data_raw.reserve(array_data.size());
-            for (auto& array_bytes : array_data) {
-                data_raw.emplace_back(Array(array_bytes));
+            if (field_meta.is_nullable() &&
+                data->valid_data_size() == element_count) {
+                ssize_t valid_count = 0;
+                for (ssize_t i = 0; i < element_count; ++i) {
+                    if (data->valid_data(i)) {
+                        ++valid_count;
+                    }
+                }
+
+                auto dense_aligned = array_data.size() == element_count;
+                auto compact_nullable = array_data.size() == valid_count;
+                AssertInfo(
+                    dense_aligned || compact_nullable,
+                    "nullable ARRAY data size {} must match element count {} "
+                    "or valid count {}",
+                    array_data.size(),
+                    element_count,
+                    valid_count);
+
+                data_raw.reserve(element_count);
+                ssize_t physical_row = 0;
+                for (ssize_t i = 0; i < element_count; ++i) {
+                    if (!data->valid_data(i)) {
+                        data_raw.emplace_back(Array());
+                        continue;
+                    }
+
+                    auto source_index = dense_aligned ? i : physical_row++;
+                    data_raw.emplace_back(Array(array_data[source_index]));
+                }
+            } else {
+                AssertInfo(array_data.size() == element_count,
+                           "ARRAY data size {} must match element count {} "
+                           "when not using compact nullable format",
+                           array_data.size(),
+                           element_count);
+                data_raw.reserve(array_data.size());
+                for (auto& array_bytes : array_data) {
+                    data_raw.emplace_back(Array(array_bytes));
+                }
             }
 
             return set_data_raw(element_offset, data_raw.data(), element_count);

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -49,21 +49,13 @@ class ThreadSafeValidData {
     void
     set_data_raw(const std::vector<FieldDataPtr>& datas) {
         std::unique_lock<std::shared_mutex> lck(mutex_);
-        auto total = 0;
-        for (auto& field_data : datas) {
-            total += field_data->get_num_rows();
-        }
-        if (length_ + total > data_.size()) {
-            data_.resize(length_ + total);
-        }
+        set_data_raw_locked(length_, datas);
+    }
 
-        for (auto& field_data : datas) {
-            auto num_row = field_data->get_num_rows();
-            for (size_t i = 0; i < num_row; i++) {
-                data_[length_ + i] = field_data->is_valid(i);
-            }
-            length_ += num_row;
-        }
+    void
+    set_data_raw(size_t offset, const std::vector<FieldDataPtr>& datas) {
+        std::unique_lock<std::shared_mutex> lck(mutex_);
+        set_data_raw_locked(offset, datas);
     }
 
     void
@@ -71,16 +63,75 @@ class ThreadSafeValidData {
                  const DataArray* data,
                  const FieldMeta& field_meta) {
         std::unique_lock<std::shared_mutex> lck(mutex_);
-        if (field_meta.is_nullable()) {
-            if (length_ + num_rows > data_.size()) {
-                data_.resize(length_ + num_rows);
-            }
-            auto src = data->valid_data().data();
-            std::copy_n(src, num_rows, data_.data() + length_);
-            length_ += num_rows;
-        }
+        set_data_raw_locked(length_, num_rows, data, field_meta);
     }
 
+    void
+    set_data_raw(size_t offset,
+                 size_t num_rows,
+                 const DataArray* data,
+                 const FieldMeta& field_meta) {
+        std::unique_lock<std::shared_mutex> lck(mutex_);
+        set_data_raw_locked(offset, num_rows, data, field_meta);
+    }
+
+    size_t
+    length() const {
+        std::shared_lock<std::shared_mutex> lck(mutex_);
+        return length_;
+    }
+
+ private:
+    void
+    set_data_raw_locked(size_t offset,
+                        const std::vector<FieldDataPtr>& datas) {
+        size_t total = 0;
+        for (auto& field_data : datas) {
+            total += field_data->get_num_rows();
+        }
+        auto end = offset + total;
+        if (end > data_.size()) {
+            data_.resize(end);
+        }
+
+        auto write_offset = offset;
+        for (auto& field_data : datas) {
+            auto num_row = field_data->get_num_rows();
+            for (size_t i = 0; i < num_row; i++) {
+                data_[write_offset + i] = field_data->is_valid(i);
+            }
+            write_offset += num_row;
+        }
+        length_ = std::max(length_, end);
+    }
+
+    void
+    set_data_raw_locked(size_t offset,
+                        size_t num_rows,
+                        const DataArray* data,
+                        const FieldMeta& field_meta) {
+        if (!field_meta.is_nullable()) {
+            return;
+        }
+
+        AssertInfo(data != nullptr, "nullable field data should not be null");
+        AssertInfo(static_cast<size_t>(data->valid_data_size()) >= num_rows,
+                   "nullable field valid data size {} is less than row count {}",
+                   data->valid_data_size(),
+                   num_rows);
+
+        auto end = offset + num_rows;
+        if (end > data_.size()) {
+            data_.resize(end);
+        }
+        if (num_rows > 0) {
+            auto src = data->valid_data().data();
+            std::copy_n(src, num_rows, data_.data() + offset);
+        }
+        length_ = std::max(length_, end);
+    }
+
+ public:
     bool
     is_valid(size_t offset) const {
         std::shared_lock<std::shared_mutex> lck(mutex_);

--- a/internal/core/src/segcore/ConcurrentVectorTest.cpp
+++ b/internal/core/src/segcore/ConcurrentVectorTest.cpp
@@ -138,6 +138,48 @@ TEST(ThreadSafeValidData, SetDataRawWithOffsetAlignsByLogicalRowOffset) {
     EXPECT_TRUE(bitmap[8]);
 }
 
+TEST(ConcurrentVector, NullableArrayCompactDataAlignsByLogicalRowOffset) {
+    auto valid_data = std::make_shared<ThreadSafeValidData>();
+    milvus::FieldMeta field_meta(milvus::FieldName("profile[p_int]"),
+                                 milvus::FieldId(100),
+                                 milvus::DataType::ARRAY,
+                                 milvus::DataType::INT64,
+                                 true,
+                                 std::nullopt);
+
+    milvus::DataArray data;
+    data.add_valid_data(false);
+    data.add_valid_data(true);
+    data.add_valid_data(true);
+    data.add_valid_data(true);
+    auto* array_data = data.mutable_scalars()->mutable_array_data();
+    array_data->set_element_type(milvus::proto::schema::DataType::Int64);
+    array_data->mutable_data()->Add();
+    array_data->mutable_data()->Add()->mutable_long_data()->add_data(60);
+    array_data->mutable_data()->Add()->mutable_long_data()->add_data(61);
+
+    valid_data->set_data_raw(5, 4, &data, field_meta);
+
+    ConcurrentVector<milvus::Array> vec(16, nullptr, valid_data);
+    vec.set_data_raw(5, 4, &data, field_meta);
+
+    auto span = milvus::Span<milvus::Array>(vec.get_span_base(0));
+    ASSERT_GE(span.row_count(), 9);
+    EXPECT_EQ(span.data()[5].length(), 0);
+    EXPECT_EQ(span.data()[6].length(), 0);
+    ASSERT_EQ(span.data()[7].length(), 1);
+    EXPECT_EQ(span.data()[7].get_data<int64_t>(0), 60);
+    ASSERT_EQ(span.data()[8].length(), 1);
+    EXPECT_EQ(span.data()[8].get_data<int64_t>(0), 61);
+
+    auto bitmap = valid_data->get_data();
+    ASSERT_EQ(bitmap.size(), 9);
+    EXPECT_FALSE(bitmap[5]);
+    EXPECT_TRUE(bitmap[6]);
+    EXPECT_TRUE(bitmap[7]);
+    EXPECT_TRUE(bitmap[8]);
+}
+
 TEST(ConcurrentVector, TestAckSingle) {
     std::vector<std::tuple<int64_t, int64_t, int64_t>> raw_data;
     std::default_random_engine e(42);

--- a/internal/core/src/segcore/ConcurrentVectorTest.cpp
+++ b/internal/core/src/segcore/ConcurrentVectorTest.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <optional>
 #include <random>
 #include <thread>
 #include <tuple>
@@ -97,6 +98,44 @@ TEST(ConcurrentVector, TestMultithreads) {
             ASSERT_EQ(raw_data, std_data) << data;
         }
     }
+}
+
+TEST(ThreadSafeValidData, SetDataRawWithOffsetAlignsByLogicalRowOffset) {
+    ThreadSafeValidData valid_data;
+    milvus::FieldMeta field_meta(milvus::FieldName("nullable"),
+                                 milvus::FieldId(100),
+                                 milvus::DataType::INT64,
+                                 true,
+                                 std::nullopt);
+
+    milvus::DataArray out_of_order_data;
+    out_of_order_data.add_valid_data(true);
+    out_of_order_data.add_valid_data(false);
+    out_of_order_data.add_valid_data(true);
+
+    valid_data.set_data_raw(4, 3, &out_of_order_data, field_meta);
+
+    ASSERT_EQ(valid_data.length(), 7);
+    auto bitmap = valid_data.get_data();
+    ASSERT_EQ(bitmap.size(), 7);
+    for (size_t i = 0; i < 4; ++i) {
+        EXPECT_FALSE(bitmap[i]);
+    }
+    EXPECT_TRUE(bitmap[4]);
+    EXPECT_FALSE(bitmap[5]);
+    EXPECT_TRUE(bitmap[6]);
+
+    milvus::DataArray append_data;
+    append_data.add_valid_data(false);
+    append_data.add_valid_data(true);
+
+    valid_data.set_data_raw(2, &append_data, field_meta);
+
+    ASSERT_EQ(valid_data.length(), 9);
+    bitmap = valid_data.get_data();
+    ASSERT_EQ(bitmap.size(), 9);
+    EXPECT_FALSE(bitmap[7]);
+    EXPECT_TRUE(bitmap[8]);
 }
 
 TEST(ConcurrentVector, TestAckSingle) {

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -611,6 +611,7 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
         auto data_offset = field_id_to_offset[field_id];
         if (field_meta.is_nullable()) {
             insert_record_.get_valid_data(field_id)->set_data_raw(
+                reserved_offset,
                 num_rows,
                 &insert_record_proto->fields_data(data_offset),
                 field_meta);
@@ -872,7 +873,8 @@ SegmentGrowingImpl::load_field_data_common(
 
     if (!indexing_record_.HasRawData(field_id)) {
         if (insert_record_.is_valid_data_exist(field_id)) {
-            insert_record_.get_valid_data(field_id)->set_data_raw(field_data);
+            insert_record_.get_valid_data(field_id)->set_data_raw(
+                reserved_offset, field_data);
         }
         insert_record_.get_data_base(field_id)->set_data_raw(reserved_offset,
                                                              field_data);
@@ -2473,7 +2475,7 @@ SegmentGrowingImpl::fill_empty_field(const FieldMeta& field_meta) {
 
     auto data = bulk_subscript_not_exist_field(field_meta, total_row_num);
     insert_record_.get_valid_data(field_id)->set_data_raw(
-        total_row_num, data.get(), field_meta);
+        0, total_row_num, data.get(), field_meta);
     insert_record_.get_data_base(field_id)->set_data_raw(
         0, total_row_num, data.get(), field_meta);
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -212,31 +212,76 @@ ExtractArrayLengths(const proto::schema::FieldData& field_data,
         // ARRAY: extract from scalars().array_data().data(i)
         const auto& array_data = field_data.scalars().array_data();
         auto element_type = field_meta.get_element_type();
+        bool dense_aligned = true;
+        bool compact_nullable = false;
+        int64_t valid_count = num_rows;
+        auto has_valid_data = field_data.valid_data_size() == num_rows;
+        if (field_meta.is_nullable() && has_valid_data) {
+            valid_count = 0;
+            for (int64_t i = 0; i < num_rows; ++i) {
+                if (field_data.valid_data(i)) {
+                    ++valid_count;
+                }
+            }
+            dense_aligned = array_data.data_size() == num_rows;
+            compact_nullable = array_data.data_size() == valid_count;
+            AssertInfo(
+                dense_aligned || compact_nullable,
+                "nullable ARRAY supports only dense-aligned data "
+                "(data_size == num_rows) or compact data "
+                "(valid_data_size == num_rows and data_size == valid_count), "
+                "got data_size {}, valid_data_size {}, num_rows {}, "
+                "valid_count {}",
+                array_data.data_size(),
+                field_data.valid_data_size(),
+                num_rows,
+                valid_count);
+            compact_nullable = compact_nullable && !dense_aligned;
+        } else {
+            AssertInfo(array_data.data_size() == num_rows,
+                       "non-nullable ARRAY data_size {} must match num_rows {}",
+                       array_data.data_size(),
+                       num_rows);
+        }
 
+        int64_t physical_row = 0;
         for (int i = 0; i < num_rows; ++i) {
+            if (field_meta.is_nullable() && has_valid_data &&
+                !field_data.valid_data(i)) {
+                array_lengths[i] = 0;
+                continue;
+            }
+
+            auto source_index = compact_nullable ? physical_row++ : i;
             int32_t array_len = 0;
 
             switch (element_type) {
                 case DataType::BOOL:
-                    array_len = array_data.data(i).bool_data().data_size();
+                    array_len =
+                        array_data.data(source_index).bool_data().data_size();
                     break;
                 case DataType::INT8:
                 case DataType::INT16:
                 case DataType::INT32:
-                    array_len = array_data.data(i).int_data().data_size();
+                    array_len =
+                        array_data.data(source_index).int_data().data_size();
                     break;
                 case DataType::INT64:
-                    array_len = array_data.data(i).long_data().data_size();
+                    array_len =
+                        array_data.data(source_index).long_data().data_size();
                     break;
                 case DataType::FLOAT:
-                    array_len = array_data.data(i).float_data().data_size();
+                    array_len =
+                        array_data.data(source_index).float_data().data_size();
                     break;
                 case DataType::DOUBLE:
-                    array_len = array_data.data(i).double_data().data_size();
+                    array_len =
+                        array_data.data(source_index).double_data().data_size();
                     break;
                 case DataType::STRING:
                 case DataType::VARCHAR:
-                    array_len = array_data.data(i).string_data().data_size();
+                    array_len =
+                        array_data.data(source_index).string_data().data_size();
                     break;
                 default:
                     ThrowInfo(ErrorCode::UnexpectedError,


### PR DESCRIPTION
issue: #50333

### What Problem Does This PR Solve?

Dynamically added nullable StructArray fields can expose row-offset mismatches when `element_filter` evaluates growing segments. In the reported case, ASAN detected a heap-buffer-overflow while querying a nullable StructArray field added after existing rows.

### What Changes Were Proposed?

- Write nullable valid-data bits at the reserved logical row offset for growing segment inserts and schema backfill.
- Expand compact nullable ARRAY payloads to logical row positions before storing array data and extracting StructArray element lengths.
- Bound element-level full scans on growing segments to the active row count in the final chunk, instead of scanning the full configured chunk capacity.
- Add a focused nullable ARRAY compact-data alignment unit test.

### Testing

- `git diff --check`
- `milvus-dev-cli build local -b master --asan -f`
  - build: `build-local-zhuwenxing-fix-struct-array-105168f-asan`
  - image: `harbor.milvus.io/manta/milvus:local-zhuwenxing-fix-struct-array-valid-data-offset-105168f-asan`
- `milvus-dev-cli deploy create build-local-zhuwenxing-fix-struct-array-105168f-asan --name sa-valid-offset-clean-asan`
- Python 3.12.12 + PyMilvus 3.1.0rc30 from TestPyPI repro for #50333 passed against the ASAN deployment.
  - Query returned only `id=203`.
  - Milvus pod restart count stayed `0`.
  - No `AddressSanitizer`, `heap-buffer-overflow`, or `ABORTING` logs after validation.
- Not run: `scripts/check_cpp_fmt.sh` because local `clang-format-15` is not in PATH.
- Not run: `make run-test-cpp filter=ConcurrentVector.NullableArrayCompactDataAlignsByLogicalRowOffset` because the local C++ unittest folder/binary does not exist.