### PR TITLE
fix: delay search distance rounding until reduce output

### DIFF
--- a/internal/core/src/query/SearchBruteForce.cpp
+++ b/internal/core/src/query/SearchBruteForce.cpp
@@ -299,7 +299,6 @@ BruteForceSearch(const dataset::SearchDataset& query_ds,
                       KnowhereStatusString(stat));
         }
     }
-    sub_result.round_values();
     return sub_result;
 }
 

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -11,7 +11,6 @@
 
 #include <folly/ExceptionWrapper.h>
 #include <algorithm>
-#include <cmath>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -60,8 +59,6 @@ SearchOnSealedIndex(const Schema& schema,
                     milvus::OpContext* op_context,
                     SearchResult& search_result) {
     auto topK = search_info.topk_;
-    auto round_decimal = search_info.round_decimal_;
-
     auto field_id = search_info.field_id_;
     auto& field = schema[field_id];
     auto is_sparse = field.get_data_type() == DataType::VECTOR_SPARSE_U32_F32;
@@ -140,15 +137,6 @@ SearchOnSealedIndex(const Schema& schema,
     if (!use_iterator) {
         vec_index->Query(
             dataset, search_info, search_bitset, op_context, search_result);
-        float* distances = search_result.distances_.data();
-        auto total_num = num_queries * topK;
-        if (round_decimal != -1) {
-            const float multiplier = pow(10.0, round_decimal);
-            for (int i = 0; i < total_num; i++) {
-                distances[i] =
-                    std::round(distances[i] * multiplier) / multiplier;
-            }
-        }
     }
     FinalizeVectorSearchOffsets(
         search_result,

--- a/internal/core/src/query/SubSearchResultTest.cpp
+++ b/internal/core/src/query/SubSearchResultTest.cpp
@@ -141,3 +141,29 @@ TEST(Reduce, SubSearchResult) {
     TestSubSearchResultMerge<queue_type_ip>(knowhere::metric::IP, 4, 16, 1);
     TestSubSearchResultMerge<queue_type_ip>(knowhere::metric::IP, 4, 16, 10);
 }
+
+TEST(Reduce, SubSearchResultMergesBeforeRounding) {
+    SubSearchResult final_result(1, 2, knowhere::metric::L2, 0);
+
+    SubSearchResult left(1, 2, knowhere::metric::L2, 0);
+    left.mutable_offsets() = {1, INVALID_SEG_OFFSET};
+    left.mutable_distances() = {
+        0.49f, SubSearchResult::init_value(knowhere::metric::L2)};
+
+    SubSearchResult right(1, 2, knowhere::metric::L2, 0);
+    right.mutable_offsets() = {2, INVALID_SEG_OFFSET};
+    right.mutable_distances() = {
+        0.36f, SubSearchResult::init_value(knowhere::metric::L2)};
+
+    final_result.merge(left);
+    final_result.merge(right);
+
+    EXPECT_EQ(final_result.get_offsets()[0], 2);
+    EXPECT_EQ(final_result.get_offsets()[1], 1);
+    EXPECT_FLOAT_EQ(final_result.get_distances()[0], 0.36f);
+    EXPECT_FLOAT_EQ(final_result.get_distances()[1], 0.49f);
+
+    final_result.round_values();
+    EXPECT_FLOAT_EQ(final_result.get_distances()[0], 0.0f);
+    EXPECT_FLOAT_EQ(final_result.get_distances()[1], 0.0f);
+}

--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -11,9 +11,9 @@
 
 #include "Reduce.h"
 
-#include <math.h>
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <future>
 #include <map>
@@ -50,6 +50,19 @@
 #include "storage/ThreadPools.h"
 
 namespace milvus::segcore {
+
+namespace {
+
+float
+RoundScore(float distance, int64_t round_decimal) {
+    if (round_decimal == -1) {
+        return distance;
+    }
+    const float multiplier = std::pow(10.0f, round_decimal);
+    return std::round(distance * multiplier) / multiplier;
+}
+
+}  // namespace
 
 void
 ReduceHelper::Initialize() {
@@ -1029,7 +1042,10 @@ ReduceHelper::GetSearchResultDataSlice(const int slice_index,
                 }
 
                 search_result_data->mutable_scores()->Set(
-                    loc, search_result->distances_[ki]);
+                    loc,
+                    RoundScore(
+                        search_result->distances_[ki],
+                        plan_->plan_node_->search_info_.round_decimal_));
 
                 if (search_result->element_level_) {
                     search_result_data->mutable_element_indices()

--- a/internal/core/src/segcore/reduce_c_test.cpp
+++ b/internal/core/src/segcore/reduce_c_test.cpp
@@ -227,6 +227,44 @@ TEST(CApiTest, ReduceNullResult) {
     DeleteSegment(segment);
 }
 
+TEST(CApiTest, ReduceRanksByRawDistancesBeforeRoundDecimal) {
+    auto schema = std::make_shared<Schema>();
+    query::Plan plan(schema);
+    plan.plan_node_ = std::make_unique<query::VectorPlanNode>();
+    plan.plan_node_->search_info_.round_decimal_ = 0;
+
+    SearchResult seg0;
+    seg0.total_nq_ = 1;
+    seg0.unity_topK_ = 1;
+    seg0.distances_ = {-0.49f};
+    seg0.seg_offsets_ = {10};
+    seg0.primary_keys_ = {int64_t(1)};
+    seg0.topk_per_nq_prefix_sum_ = {0, 1};
+
+    SearchResult seg1;
+    seg1.total_nq_ = 1;
+    seg1.unity_topK_ = 1;
+    seg1.distances_ = {-0.36f};
+    seg1.seg_offsets_ = {20};
+    seg1.primary_keys_ = {int64_t(2)};
+    seg1.topk_per_nq_prefix_sum_ = {0, 1};
+
+    std::vector<SearchResult*> search_results{&seg0, &seg1};
+    int64_t slice_nqs[] = {1};
+    int64_t slice_topks[] = {2};
+
+    TestReduceHelper helper(
+        search_results, &plan, nullptr, slice_nqs, slice_topks, 1, nullptr);
+    helper.ReduceResultData();
+
+    EXPECT_EQ(seg1.result_offsets_, std::vector<int64_t>({0}));
+    EXPECT_EQ(seg0.result_offsets_, std::vector<int64_t>({1}));
+    EXPECT_EQ(helper.FinalSearchRecordsForTest()[1][0],
+              std::vector<int64_t>({0}));
+    EXPECT_EQ(helper.FinalSearchRecordsForTest()[0][0],
+              std::vector<int64_t>({0}));
+}
+
 TEST(CApiTest, ReduceRemoveDuplicates) {
     auto collection = NewCollection(get_default_schema_config().c_str());
     CSegmentInterface segment;


### PR DESCRIPTION
Fixes #50347

`round_decimal` was applied before per-chunk/per-segment result reduction, which could collapse distinct distances into artificial ties and change Top-k ordering.

This change keeps raw distances through search result merging/reduction and applies rounding only when writing final response scores.

Added regression coverage for:
- SubSearchResult merge preserving raw-distance order before rounding
- Cross-segment reduce ranking by raw distances when `round_decimal=0`