### PR TITLE
fix: validate dump messages start message id

### DIFF
--- a/internal/proxy/dump_messages_test.go
+++ b/internal/proxy/dump_messages_test.go
@@ -171,6 +171,22 @@ func TestDumpMessages_EmptyStartMessageIdBytes(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDumpMessages_InvalidStartMessageIdBytes(t *testing.T) {
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	err := node.DumpMessages(&milvuspb.DumpMessagesRequest{
+		Pchannel: "test-channel",
+		StartMessageId: &commonpb.MessageID{
+			WALName: commonpb.WALName_Pulsar,
+			Id:      "not-a-valid-base64-msgid!!!",
+		},
+	}, stream)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.Empty(t, stream.getSent())
+}
+
 func TestDumpMessages_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -7457,7 +7457,10 @@ func (node *Proxy) DumpMessages(req *milvuspb.DumpMessagesRequest, stream milvus
 		return merr.WrapErrParameterMissing("start_message_id")
 	}
 
-	startMsgID := message.MustUnmarshalMessageID(req.GetStartMessageId())
+	startMsgID, err := message.UnmarshalMessageID(req.GetStartMessageId())
+	if err != nil {
+		return merr.WrapErrParameterInvalidMsg("invalid start_message_id: %s", err.Error())
+	}
 
 	// Use exclusive start position (dump messages AFTER start_message_id)
 	// This is appropriate for salvage scenarios where start_message_id is the last synced message


### PR DESCRIPTION
Fixes #50341

DumpMessages previously used MustUnmarshalMessageID on client-provided start_message_id bytes. A malformed message ID could panic and crash the process.

This change uses the non-panicking UnmarshalMessageID path and returns an invalid parameter error instead.

Added regression coverage for malformed Pulsar start_message_id bytes.