### PR TITLE
fix: make SalvageCheckpoint reachable via GetReplicateInfo after force-promote

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -52,6 +52,7 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -7368,9 +7369,19 @@ func (node *Proxy) GetReplicateInfo(ctx context.Context, req *milvuspb.GetReplic
 		}
 	}()
 
+	var checkpointProto *commonpb.ReplicateCheckpoint
 	checkpoint, err := streaming.WAL().Replicate().GetReplicateCheckpoint(ctx, req.GetTargetPchannel())
 	if err != nil {
-		return nil, err
+		// On a standalone-primary cluster (e.g. after force_promote) the WAL is no
+		// longer a secondary, so the live replicate checkpoint is unavailable. That
+		// must not hide the salvage checkpoint, which is exactly what callers need
+		// after a force_promote. Other errors are still fatal.
+		if !status.AsStreamingError(err).IsReplicateViolation() {
+			return nil, err
+		}
+		logger.Info("not a secondary cluster, live replicate checkpoint unavailable; continue to salvage checkpoint")
+	} else {
+		checkpointProto = checkpoint.IntoProto()
 	}
 
 	// Get the salvage checkpoint for the specified source cluster.
@@ -7396,7 +7407,7 @@ func (node *Proxy) GetReplicateInfo(ctx context.Context, req *milvuspb.GetReplic
 	}
 
 	return &milvuspb.GetReplicateInfoResponse{
-		Checkpoint:        checkpoint.IntoProto(),
+		Checkpoint:        checkpointProto,
 		SalvageCheckpoint: salvageCheckpointProto,
 	}, nil
 }

--- a/internal/proxy/replicate_info_test.go
+++ b/internal/proxy/replicate_info_test.go
@@ -24,14 +24,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
-	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
+	streamingstatus "github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
@@ -97,7 +97,7 @@ func TestProxy_GetReplicateInfo_GetSalvageCheckpointUnimplemented(t *testing.T) 
 	replicateService.EXPECT().GetReplicateCheckpoint(mock.Anything, "test-pchannel").
 		Return(&utility.ReplicateCheckpoint{ClusterID: "cluster-a", PChannel: "test-pchannel", TimeTick: 100}, nil)
 	replicateService.EXPECT().GetSalvageCheckpoint(mock.Anything, "test-pchannel").
-		Return(nil, status.Error(codes.Unimplemented, "method GetSalvageCheckpoint not implemented"))
+		Return(nil, grpcstatus.Error(codes.Unimplemented, "method GetSalvageCheckpoint not implemented"))
 
 	mockWAL := mock_streaming.NewMockWALAccesser(t)
 	mockWAL.EXPECT().Replicate().Return(replicateService)
@@ -247,7 +247,7 @@ func TestProxy_GetReplicateInfo_ReplicateViolation_ReturnsSalvageCheckpoint(t *t
 	}
 	replicateService := mock_streaming.NewMockReplicateService(t)
 	replicateService.EXPECT().GetReplicateCheckpoint(mock.Anything, "test-pchannel").
-		Return(nil, status.NewReplicateViolation("wal is not a secondary cluster in replicating topology"))
+		Return(nil, streamingstatus.NewReplicateViolation("wal is not a secondary cluster in replicating topology"))
 	replicateService.EXPECT().GetSalvageCheckpoint(mock.Anything, "test-pchannel").
 		Return(salvageCPs, nil)
 

--- a/internal/proxy/replicate_info_test.go
+++ b/internal/proxy/replicate_info_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
@@ -234,4 +235,40 @@ func TestProxy_GetReplicateInfo_Success_NoSourceClusterIDFilter(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.Equal(t, "cluster-a", resp.GetCheckpoint().GetClusterId())
 	assert.Nil(t, resp.GetSalvageCheckpoint()) // no source cluster filter → no match
+}
+
+func TestProxy_GetReplicateInfo_ReplicateViolation_ReturnsSalvageCheckpoint(t *testing.T) {
+	// On a standalone-primary cluster (e.g. after force_promote) the live
+	// replicate checkpoint is unavailable (REPLICATE_VIOLATION). GetReplicateInfo
+	// must treat that as non-fatal: leave the live checkpoint nil and still return
+	// the salvage checkpoint, which is exactly what callers need post-promote.
+	salvageCPs := []*utility.ReplicateCheckpoint{
+		{ClusterID: "source-cluster", PChannel: "source-pchannel", TimeTick: 200},
+	}
+	replicateService := mock_streaming.NewMockReplicateService(t)
+	replicateService.EXPECT().GetReplicateCheckpoint(mock.Anything, "test-pchannel").
+		Return(nil, status.NewReplicateViolation("wal is not a secondary cluster in replicating topology"))
+	replicateService.EXPECT().GetSalvageCheckpoint(mock.Anything, "test-pchannel").
+		Return(salvageCPs, nil)
+
+	mockWAL := mock_streaming.NewMockWALAccesser(t)
+	mockWAL.EXPECT().Replicate().Return(replicateService)
+	prevWAL := streaming.WAL()
+	streaming.SetWALForTest(mockWAL)
+	defer streaming.SetWALForTest(prevWAL)
+
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	resp, err := node.GetReplicateInfo(context.Background(), &milvuspb.GetReplicateInfoRequest{
+		TargetPchannel:  "test-pchannel",
+		SourceClusterId: "source-cluster",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Nil(t, resp.GetCheckpoint()) // live checkpoint unavailable on a primary
+	assert.NotNil(t, resp.GetSalvageCheckpoint())
+	assert.Equal(t, "source-cluster", resp.GetSalvageCheckpoint().GetClusterId())
+	assert.Equal(t, "source-pchannel", resp.GetSalvageCheckpoint().GetPchannel())
+	assert.Equal(t, uint64(200), resp.GetSalvageCheckpoint().GetTimeTick())
 }

--- a/internal/streamingnode/client/handler/handler_client_impl.go
+++ b/internal/streamingnode/client/handler/handler_client_impl.go
@@ -342,6 +342,15 @@ func (hc *handlerClientImpl) createHandlerAfterStreamingNodeReady(ctx context.Co
 			}
 			logger.Warn("create handler failed", zap.Any("assignment", assign), zap.Error(err))
 
+			// Unrecoverable errors (e.g. replicate violation when the WAL is no longer
+			// a secondary cluster) won't change by retrying the same WAL role. Surface
+			// them immediately so callers get a typed error within RTT instead of
+			// retrying until their context deadline.
+			if status.AsStreamingError(err).IsUnrecoverable() {
+				logger.Warn("create handler failed with unrecoverable error, stop retrying", zap.Error(err))
+				return nil, err
+			}
+
 			// Check if the error is permanent failure until new assignment.
 			if isPermanentFailureUntilNewAssignment(err) {
 				reportErr := hc.rebalanceTrigger.ReportAssignmentError(ctx, assign.Channel, err)

--- a/internal/streamingnode/client/handler/handler_client_test.go
+++ b/internal/streamingnode/client/handler/handler_client_test.go
@@ -228,6 +228,41 @@ func TestHandlerClient_PrepareReleaseManualFlush(t *testing.T) {
 	assert.False(t, prepared)
 }
 
+func TestHandlerClient_GetReplicateCheckpointReplicateViolation(t *testing.T) {
+	assignment := &types.PChannelInfoAssigned{
+		Channel: types.PChannelInfo{Name: "pchannel", Term: 1},
+		Node:    types.StreamingNodeInfo{ServerID: 1, Address: "localhost"},
+	}
+
+	service := mock_lazygrpc.NewMockService[streamingpb.StreamingNodeHandlerServiceClient](t)
+	handlerServiceClient := mock_streamingpb.NewMockStreamingNodeHandlerServiceClient(t)
+	// Remote WAL reports a replicate violation: the target is no longer a secondary
+	// cluster (e.g. after force_promote). This is unrecoverable for the current WAL
+	// role, so it must be returned immediately rather than retried to the deadline.
+	handlerServiceClient.EXPECT().GetReplicateCheckpoint(mock.Anything, mock.Anything).Return(
+		nil, status.NewReplicateViolation("wal is not a secondary cluster in replicating topology"))
+	service.EXPECT().GetService(mock.Anything).Return(handlerServiceClient, nil)
+
+	w := mock_assignment.NewMockWatcher(t)
+	// Always return the assignment so the create func is invoked.
+	w.EXPECT().Get(mock.Anything, mock.Anything).Return(assignment)
+	// Watch is intentionally NOT expected: an immediate return must not enter the
+	// backoff retry loop. If it did, the mock would fail on an unexpected Watch call.
+	rebalanceTrigger := mock_types.NewMockAssignmentRebalanceTrigger(t)
+
+	handler := &handlerClientImpl{
+		lifetime:         typeutil.NewLifetime(),
+		service:          service,
+		watcher:          w,
+		rebalanceTrigger: rebalanceTrigger,
+	}
+
+	cp, err := handler.GetReplicateCheckpoint(context.Background(), "pchannel")
+	assert.Error(t, err)
+	assert.Nil(t, cp)
+	assert.True(t, status.AsStreamingError(err).IsReplicateViolation())
+}
+
 func TestDial(t *testing.T) {
 	paramtable.Init()
 


### PR DESCRIPTION
issue: #50344

## Summary

After a `force_promote`, the persisted `SalvageCheckpoint` was unreachable from any client. Two compounding defects:

### Defect 1 — `GetReplicateInfo` returns early, never reaching `GetSalvageCheckpoint`
`internal/proxy/impl.go`: the handler called `GetReplicateCheckpoint` first and returned on any error. On a standalone-primary (post `force_promote`) the WAL is no longer a secondary, so `GetReplicateCheckpoint` fails with `STREAMING_CODE_REPLICATE_VIOLATION` ("wal is not a secondary cluster in replicating topology") and the follow-up `GetSalvageCheckpoint` — the whole point — was never reached.

**Fix:** treat **only** `REPLICATE_VIOLATION` as non-fatal — leave the live checkpoint `nil` and continue to the salvage checkpoint. All other errors stay fatal (no blanket swallow).

### Defect 2 — client retries `REPLICATE_VIOLATION` to the deadline
`internal/streamingnode/client/handler/handler_client_impl.go`: `createHandlerAfterStreamingNodeReady` retried the (permanent) violation in a backoff loop until the caller's context cancelled, so it surfaced as `DEADLINE_EXCEEDED` rather than a typed error.

**Fix:** return immediately on `status.AsStreamingError(err).IsUnrecoverable()` — a category that **already** includes replicate violation (and is documented as "Stop resuming retry and report to user"). The retry loop simply wasn't honoring it.

Fixing Defect 2 is also what lets Defect 1 detect the violation: otherwise the error would have been swallowed into a deadline before the proxy could classify it.

## Changes

- `internal/proxy/impl.go`: `GetReplicateInfo` continues to `GetSalvageCheckpoint` on `REPLICATE_VIOLATION`, returns `checkpoint=nil` in that case.
- `internal/streamingnode/client/handler/handler_client_impl.go`: stop retrying unrecoverable errors; return them within RTT.
- `internal/streamingnode/client/handler/handler_client_test.go`: add `TestHandlerClient_GetReplicateCheckpointReplicateViolation` asserting an immediate, typed return (no retry loop / `Watch` call).

## Test Plan

- [x] gofmt clean; `internal/util/streamingutil/status` builds
- [x] New unit test mirrors the existing handler-client mock harness
- [ ] CI: `TestHandlerClient_GetReplicateCheckpointReplicateViolation` passes
- [ ] CI: `replication/data_salvage` integration suite — `TestGetReplicateInfoOnPrimaryCluster` now returns cleanly on a primary instead of erroring

> Note: the proxy / streamingnode packages can't be fully built locally in this environment due to a pre-existing stale C++ artifact mismatch in the unrelated `internal/storagev2/packed` cgo package (reproducible on a clean master checkout). The changed packages are pure-Go and use already-existing `StreamingError` APIs; CI compiles and runs them.