### PR TITLE
enhance: make external vectors nullable by default

### DIFF
--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -2539,11 +2539,11 @@ func GetPrimaryFieldSchema(schema *schemapb.CollectionSchema) (*schemapb.FieldSc
 }
 
 // NormalizeAndValidateExternalCollectionSchema ensures unsupported features are
-// disabled for external collections AND mutates each non-vector user field to
-// set nullable=true. The mutation is intentional: external Parquet sources may
-// contain nulls in scalar columns, and a non-nullable scalar field would silently
-// produce incorrect results when reading those nulls. The function is named
-// "NormalizeAndValidate" so callers know it has a write-back side effect.
+// disabled for external collections AND mutates each user field to set
+// nullable=true. The mutation is intentional: external Parquet sources may
+// contain nulls, and non-nullable fields would silently produce incorrect
+// results when reading those nulls. The function is named "NormalizeAndValidate"
+// so callers know it has a write-back side effect.
 //
 // Validation runs in two passes: pass 1 checks every field; pass 2 mutates
 // only after all checks succeed. Without this split, a failing check on a
@@ -2630,19 +2630,14 @@ func NormalizeAndValidateExternalCollectionSchema(schema *schemapb.CollectionSch
 	}
 
 	// Pass 2: normalize. All fields passed validation; safe to mutate.
-	// Force nullable for external scalar fields: Parquet columns can contain
-	// nulls, and non-nullable scalars would silently produce incorrect results.
+	// Force nullable for external user fields: Parquet columns can contain
+	// nulls, and non-nullable fields would silently produce incorrect results.
 	for _, field := range schema.GetFields() {
 		if IsExternalSystemOrVirtualField(field.GetName()) {
 			continue
 		}
 		// Function output fields are computed internally.
 		if isExternalGeneratedField(field, generatedColumns) {
-			continue
-		}
-		if IsVectorType(field.GetDataType()) {
-			// External nullable vectors currently build incorrect offset mapping.
-			// Restore forced nullable after the offset mapping path is fixed.
 			continue
 		}
 		if !field.GetNullable() {

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -5571,10 +5571,12 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 			}
 			err := NormalizeAndValidateExternalCollectionSchema(schema)
 			assert.NoError(t, err, "expected no error for type %s", tc.dt.String())
+			assert.True(t, schema.GetFields()[0].GetNullable(), "base vector field should be nullable")
+			assert.True(t, schema.GetFields()[1].GetNullable(), "field type %s should be nullable", tc.dt.String())
 		}
 	})
 
-	t.Run("user scalar fields forced nullable but vector fields unchanged", func(t *testing.T) {
+	t.Run("user fields forced nullable", func(t *testing.T) {
 		schema := buildSchema()
 		for _, f := range schema.GetFields() {
 			assert.False(t, f.GetNullable())
@@ -5582,7 +5584,7 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 		err := NormalizeAndValidateExternalCollectionSchema(schema)
 		assert.NoError(t, err)
 		assert.True(t, schema.GetFields()[0].GetNullable(), "scalar field should be nullable")
-		assert.False(t, schema.GetFields()[1].GetNullable(), "vector field should remain non-nullable")
+		assert.True(t, schema.GetFields()[1].GetNullable(), "vector field should be nullable")
 	})
 
 	t.Run("virtual pk stays non-nullable", func(t *testing.T) {
@@ -5601,7 +5603,7 @@ func TestNormalizeAndValidateExternalCollectionSchema(t *testing.T) {
 			case common.VirtualPKFieldName:
 				assert.False(t, f.GetNullable(), "virtual PK should remain non-nullable")
 			case "vec":
-				assert.False(t, f.GetNullable(), "vector field should remain non-nullable")
+				assert.True(t, f.GetNullable(), "vector field should be nullable")
 			default:
 				assert.True(t, f.GetNullable())
 			}

--- a/tests/python_client/milvus_client/test_milvus_client_external_table.py
+++ b/tests/python_client/milvus_client/test_milvus_client_external_table.py
@@ -582,7 +582,7 @@ class TestMilvusClientExternalTableSchema(ExternalTableTestBase):
         self.create_collection(client, collection_name=coll, schema=schema)
         info = self.describe_collection(client, coll)[0]
         by_name = {f["name"]: f for f in info["fields"]}
-        for field in ("id", "v"):
+        for field in ("id", "v", "vec"):
             assert by_name[field].get("nullable") is True, (
                 f"user field '{field}' should be force-nullable, got {by_name[field]}"
             )

--- a/tests/restful_client_v2/testcases/test_external_collection_operations.py
+++ b/tests/restful_client_v2/testcases/test_external_collection_operations.py
@@ -711,7 +711,7 @@ def _assert_describe_external_collection_response(
     collection_name,
     expected_source=None,
     expected_spec=None,
-    expected_vector_nullable=False,
+    expected_vector_nullable=True,
 ):
     assert {"code", "data"}.issubset(desc), desc
     assert set(desc).issubset({"code", "data", "message"}), desc
@@ -990,7 +990,7 @@ class TestRestExternalCollection(TestBase):
         rsp = self.index_client.index_create(payload, db_name=db_name)
         _assert_success_default_response(rsp)
 
-    def _load_and_wait(self, collection_name, db_name="default", expected_vector_nullable=False):
+    def _load_and_wait(self, collection_name, db_name="default", expected_vector_nullable=True):
         payload = {"collectionName": collection_name}
         if db_name != "default":
             payload["dbName"] = db_name


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/45881

## Summary

- Make external user vector fields nullable by default during schema
  normalization.
- Keep external system/virtual fields and generated function output fields
  excluded from forced nullable normalization.
- Update schema, REST, and MilvusClient external table coverage so omitted
  vector nullable settings are expected to describe as nullable.

## Why

External collection schemas already make user scalar fields nullable by
default because external files can contain null values that Milvus cannot
reject at collection creation time. Vector fields were temporarily excluded
while the nullable vector offset mapping path still depended on eager
load-time mapping.

After lazy offset mapping for nullable vectors, that special-case exclusion is
no longer needed. External vector fields can now follow the same default
nullable normalization rule as scalar fields.

Related lazy offset mapping PR:
https://github.com/milvus-io/milvus/pull/49168

## Validation

- `git diff --check`
- `python3 -m py_compile tests/restful_client_v2/testcases/test_external_collection_operations.py tests/python_client/milvus_client/test_milvus_client_external_table.py`
- `GOTOOLCHAIN=auto go test -tags dynamic,test github.com/milvus-io/milvus/pkg/v3/util/typeutil -run TestNormalizeAndValidateExternalCollectionSchema -count=1 -v`
- `GOTOOLCHAIN=auto go test -tags dynamic,test github.com/milvus-io/milvus/pkg/v3/util/typeutil -count=1`

## Local environment note

- `/reset-milvus` reset etcd/minio before Go test runs, but this worktree does
  not have `bin/milvus`, so standalone Milvus could not be restarted locally.
  The validated tests above are pure schema/typeutil tests.
