### PR TITLE
enhance: [cp2.6]add DumpMessages to the Go SDK client (#50343)

### DIFF
--- a/client/milvusclient/replicate.go
+++ b/client/milvusclient/replicate.go
@@ -62,3 +62,27 @@ func (c *Client) CreateReplicateStream(ctx context.Context, opts ...grpc.CallOpt
 	})
 	return streamClient, err
 }
+
+// DumpMessages streams messages from a WAL range for data salvage.
+// It is typically used after a force failover: callers obtain the salvage
+// checkpoint from GetReplicateInfo and pass its message id as the request's
+// StartMessageId to recover messages that were not yet synchronized.
+//
+// The returned stream yields DumpMessagesResponse frames; each frame carries
+// either an error status or a non-system message. Iterate with stream.Recv()
+// until io.EOF.
+func (c *Client) DumpMessages(ctx context.Context, req *milvuspb.DumpMessagesRequest, opts ...grpc.CallOption) (milvuspb.MilvusService_DumpMessagesClient, error) {
+	var streamClient milvuspb.MilvusService_DumpMessagesClient
+	err := c.callService(func(milvusService milvuspb.MilvusServiceClient) error {
+		var err error
+		streamClient, err = milvusService.DumpMessages(ctx, req, opts...)
+		if err != nil {
+			return err
+		}
+		if streamClient == nil {
+			return errors.New("stream client is nil")
+		}
+		return nil
+	})
+	return streamClient, err
+}

--- a/client/milvusclient/replicate_example_test.go
+++ b/client/milvusclient/replicate_example_test.go
@@ -19,6 +19,7 @@ package milvusclient_test
 
 import (
 	"context"
+	"io"
 	"log"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -117,4 +118,61 @@ func ExampleClient_CreateReplicateStream() {
 
 	// Here you can continue to use the stream for data transmission
 	// For example: stream.Send(&milvuspb.ReplicateMessage{...})
+}
+
+func ExampleClient_DumpMessages() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cli, err := milvusclient.New(ctx, &milvusclient.ClientConfig{
+		Address: exampleMilvusAddr,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// After a force failover, use GetReplicateInfo to obtain the salvage
+	// checkpoint, then dump the unsynchronized messages from that position.
+	info, err := cli.GetReplicateInfo(ctx, &milvuspb.GetReplicateInfoRequest{
+		SourceClusterId: "source-cluster",
+		TargetPchannel:  "source-channel-dml_0",
+	})
+	if err != nil {
+		log.Printf("Failed to get replicate information: %v", err)
+		return
+	}
+	ckpt := info.GetSalvageCheckpoint()
+	if ckpt == nil {
+		log.Println("No salvage checkpoint available")
+		return
+	}
+
+	stream, err := cli.DumpMessages(ctx, &milvuspb.DumpMessagesRequest{
+		Pchannel:       ckpt.GetPchannel(),
+		StartMessageId: ckpt.GetMessageId(),
+		StartTimetick:  ckpt.GetTimeTick(),
+	})
+	if err != nil {
+		log.Printf("Failed to dump messages: %v", err)
+		return
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Printf("Failed to receive dumped message: %v", err)
+			return
+		}
+		if msg := resp.GetMessage(); msg != nil {
+			log.Printf("Dumped message: %v", msg.GetId())
+		} else if status := resp.GetStatus(); status != nil {
+			log.Printf("Received error status: %v", status)
+			break
+		}
+	}
+
+	log.Println("Dump messages completed")
 }


### PR DESCRIPTION
Cherry-pick from master

pr: #50343
issue: #47598

## Summary

Cherry-picked from master PR #50343 (merged). Adds `Client.DumpMessages` to the Go SDK (`client/milvusclient`), mirroring `CreateReplicateStream`, plus `ExampleClient_DumpMessages`.

Verified the 2.6-pinned `go-api/v2` already exposes the `DumpMessages` stub / `DumpMessagesRequest` / `GetSalvageCheckpoint`, so the code compiles unchanged on 2.6.

## Verification

- [x] File count matches original PR (2 files, 82 insertions)
- [x] Per-file diffs verified identical to master PR #50343
- [x] No conflict markers
- [x] `go build` / `go vet ./milvusclient/` pass on 2.6 (go-api/v2)
- [x] `go test -run TestReplicate` passes
- [ ] make static-check (skipped by cherry-pick workflow)