### PR TITLE
enhance: add boost score support

### DIFF
--- a/internal/core/src/exec/operator/RescoresNode.cpp
+++ b/internal/core/src/exec/operator/RescoresNode.cpp
@@ -42,6 +42,7 @@
 #include "pb/plan.pb.h"
 #include "plan/PlanNode.h"
 #include "prometheus/histogram.h"
+#include "rescores/BoostScoreRunner.h"
 #include "rescores/Scorer.h"
 
 namespace milvus::exec {
@@ -120,81 +121,13 @@ PhyRescoresNode::GetOutput() {
 
     std::vector<std::optional<float>> boost_scores(offsets.size());
     auto function_mode = option_->function_mode();
-
-    for (auto& scorer : scorers_) {
-        auto filter = scorer->filter();
-        // boost for all result if no filter
-        if (!filter) {
-            scorer->batch_score(
-                op_context, segment, function_mode, offsets, boost_scores);
-            continue;
-        }
-
-        std::vector<expr::TypedExprPtr> filters;
-        filters.emplace_back(filter);
-        auto expr_set = std::make_unique<ExprSet>(filters, exec_context);
-        std::vector<VectorPtr> results;
-        EvalCtx eval_ctx(exec_context);
-
-        const auto& exprs = expr_set->exprs();
-        bool is_native_supported = true;
-        for (const auto& expr : exprs) {
-            is_native_supported =
-                (is_native_supported && (expr->SupportOffsetInput()));
-        }
-
-        if (is_native_supported) {
-            // could set input offset if expr was native supported
-            eval_ctx.set_offset_input(&offsets);
-            expr_set->Eval(0, 1, true, eval_ctx, results);
-
-            // filter result for offsets[i] was resut bitset[i]
-            AssertInfo(!results.empty() && results[0] != nullptr,
-                       "PhyRescoresNode: filter expr returned null result, "
-                       "offsets size: {}, filter: {}",
-                       offsets.size(),
-                       filter->ToString());
-            auto col_vec = std::dynamic_pointer_cast<ColumnVector>(results[0]);
-            AssertInfo(
-                col_vec != nullptr,
-                "PhyRescoresNode: failed to cast result to ColumnVector, "
-                "filter: {}",
-                filter->ToString());
-            auto col_vec_size = col_vec->size();
-            TargetBitmapView bitsetview(col_vec->GetRawData(), col_vec_size);
-            scorer->batch_score(op_context,
-                                segment,
-                                function_mode,
-                                offsets,
-                                bitsetview,
-                                boost_scores);
-        } else {
-            // query all segment if expr not native
-            expr_set->Eval(0, 1, true, eval_ctx, results);
-
-            // filter result for offsets[i] was bitset[offset[i]]
-            AssertInfo(!results.empty() && results[0] != nullptr,
-                       "PhyRescoresNode: filter expr returned null result, "
-                       "filter: {}",
-                       filter->ToString());
-            auto col_vec = std::dynamic_pointer_cast<ColumnVector>(results[0]);
-            AssertInfo(
-                col_vec != nullptr,
-                "PhyRescoresNode: failed to cast result to ColumnVector, "
-                "filter: {}",
-                filter->ToString());
-            TargetBitmap bitset;
-            auto col_vec_size = col_vec->size();
-            TargetBitmapView view(col_vec->GetRawData(), col_vec_size);
-            bitset.append(view);
-            scorer->batch_score(op_context,
-                                segment,
-                                function_mode,
-                                offsets,
-                                bitset,
-                                boost_scores);
-        }
-    }
+    rescores::ComputeFunctionScores(exec_context,
+                                    op_context,
+                                    segment,
+                                    scorers_,
+                                    function_mode,
+                                    offsets,
+                                    boost_scores);
 
     // calculate final score
     auto boost_mode = option_->boost_mode();

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -662,21 +662,6 @@ ProtoParser::PlanNodeFromProto(const planpb::PlanNode& plan_node_proto) {
         sources = std::vector<milvus::plan::PlanNodePtr>{plannode};
     }
 
-    // if has score function, run filter and scorer at last
-    if (plan_node_proto.scorers_size() > 0) {
-        std::vector<std::shared_ptr<rescores::Scorer>> scorers;
-        for (const auto& function : plan_node_proto.scorers()) {
-            scorers.push_back(ParseScorer(function));
-        }
-
-        plannode = std::make_shared<milvus::plan::RescoresNode>(
-            milvus::plan::GetNextPlanNodeId(),
-            std::move(scorers),
-            plan_node_proto.score_option(),
-            sources);
-        sources = std::vector<milvus::plan::PlanNodePtr>{plannode};
-    }
-
     plan_node->plannodes_ = plannode;
 
     PlanOptionsFromProto(plan_node_proto.plan_options(),

--- a/internal/core/src/rescores/BoostScoreRunner.cpp
+++ b/internal/core/src/rescores/BoostScoreRunner.cpp
@@ -1,0 +1,187 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rescores/BoostScoreRunner.h"
+
+#include <memory>
+
+#include "common/EasyAssert.h"
+#include "common/Vector.h"
+#include "exec/expression/EvalCtx.h"
+#include "exec/expression/Expr.h"
+#include "expr/ITypeExpr.h"
+#include "rescores/Utils.h"
+
+namespace milvus::rescores {
+
+namespace {
+
+void
+CopyScoresToBuffers(const std::vector<std::optional<float>>& scores,
+                    float* output_scores,
+                    bool* output_has_score) {
+    for (auto i = 0; i < scores.size(); i++) {
+        output_has_score[i] = scores[i].has_value();
+        output_scores[i] = scores[i].value_or(0.0F);
+    }
+}
+
+}  // namespace
+
+void
+ComputeScorerScores(exec::ExecContext* exec_context,
+                    OpContext* op_context,
+                    const segcore::SegmentInternalInterface* segment,
+                    const std::shared_ptr<Scorer>& scorer,
+                    FixedVector<int32_t>& offsets,
+                    std::vector<std::optional<float>>& output_scores) {
+    AssertInfo(output_scores.size() == offsets.size(),
+               "scorer score output size {} must match offsets size {}",
+               output_scores.size(),
+               offsets.size());
+
+    auto function_mode = proto::plan::FunctionModeSum;
+    auto filter = scorer->filter();
+    if (!filter) {
+        scorer->batch_score(
+            op_context, segment, function_mode, offsets, output_scores);
+        return;
+    }
+
+    std::vector<expr::TypedExprPtr> filters;
+    filters.emplace_back(filter);
+    auto expr_set = std::make_unique<exec::ExprSet>(filters, exec_context);
+    std::vector<VectorPtr> results;
+    exec::EvalCtx eval_ctx(exec_context);
+
+    const auto& exprs = expr_set->exprs();
+    bool is_native_supported = true;
+    for (const auto& expr : exprs) {
+        is_native_supported =
+            (is_native_supported && (expr->SupportOffsetInput()));
+    }
+
+    if (is_native_supported) {
+        eval_ctx.set_offset_input(&offsets);
+        expr_set->Eval(0, 1, true, eval_ctx, results);
+
+        AssertInfo(!results.empty() && results[0] != nullptr,
+                   "ComputeScorerScores: filter expr returned null result, "
+                   "offsets size: {}, filter: {}",
+                   offsets.size(),
+                   filter->ToString());
+        auto col_vec = std::dynamic_pointer_cast<ColumnVector>(results[0]);
+        AssertInfo(col_vec != nullptr,
+                   "ComputeScorerScores: failed to cast result to "
+                   "ColumnVector, filter: {}",
+                   filter->ToString());
+        auto col_vec_size = col_vec->size();
+        TargetBitmapView bitsetview(col_vec->GetRawData(), col_vec_size);
+        scorer->batch_score(op_context,
+                            segment,
+                            function_mode,
+                            offsets,
+                            bitsetview,
+                            output_scores);
+    } else {
+        expr_set->Eval(0, 1, true, eval_ctx, results);
+
+        AssertInfo(!results.empty() && results[0] != nullptr,
+                   "ComputeScorerScores: filter expr returned null result, "
+                   "filter: {}",
+                   filter->ToString());
+        auto col_vec = std::dynamic_pointer_cast<ColumnVector>(results[0]);
+        AssertInfo(col_vec != nullptr,
+                   "ComputeScorerScores: failed to cast result to "
+                   "ColumnVector, filter: {}",
+                   filter->ToString());
+        TargetBitmap bitset;
+        auto col_vec_size = col_vec->size();
+        TargetBitmapView view(col_vec->GetRawData(), col_vec_size);
+        bitset.append(view);
+        scorer->batch_score(
+            op_context, segment, function_mode, offsets, bitset, output_scores);
+    }
+}
+
+void
+ComputeScorerScores(exec::ExecContext* exec_context,
+                    OpContext* op_context,
+                    const segcore::SegmentInternalInterface* segment,
+                    const std::shared_ptr<Scorer>& scorer,
+                    FixedVector<int32_t>& offsets,
+                    float* output_scores,
+                    bool* output_has_score) {
+    std::vector<std::optional<float>> scores(offsets.size());
+    ComputeScorerScores(
+        exec_context, op_context, segment, scorer, offsets, scores);
+    CopyScoresToBuffers(scores, output_scores, output_has_score);
+}
+
+void
+ComputeFunctionScores(exec::ExecContext* exec_context,
+                      OpContext* op_context,
+                      const segcore::SegmentInternalInterface* segment,
+                      const std::vector<std::shared_ptr<Scorer>>& scorers,
+                      proto::plan::FunctionMode function_mode,
+                      FixedVector<int32_t>& offsets,
+                      std::vector<std::optional<float>>& output_scores) {
+    AssertInfo(output_scores.size() == offsets.size(),
+               "function score output size {} must match offsets size {}",
+               output_scores.size(),
+               offsets.size());
+
+    for (const auto& scorer : scorers) {
+        std::vector<std::optional<float>> scorer_scores(offsets.size());
+        ComputeScorerScores(
+            exec_context, op_context, segment, scorer, offsets, scorer_scores);
+        for (auto i = 0; i < offsets.size(); i++) {
+            if (!scorer_scores[i].has_value()) {
+                continue;
+            }
+            if (!output_scores[i].has_value()) {
+                output_scores[i] = scorer_scores[i].value();
+            } else {
+                output_scores[i] =
+                    function_score_merge(output_scores[i].value(),
+                                         scorer_scores[i].value(),
+                                         function_mode);
+            }
+        }
+    }
+}
+
+void
+ComputeFunctionScores(exec::ExecContext* exec_context,
+                      OpContext* op_context,
+                      const segcore::SegmentInternalInterface* segment,
+                      const std::vector<std::shared_ptr<Scorer>>& scorers,
+                      proto::plan::FunctionMode function_mode,
+                      FixedVector<int32_t>& offsets,
+                      float* output_scores,
+                      bool* output_has_score) {
+    std::vector<std::optional<float>> scores(offsets.size());
+    ComputeFunctionScores(exec_context,
+                          op_context,
+                          segment,
+                          scorers,
+                          function_mode,
+                          offsets,
+                          scores);
+    CopyScoresToBuffers(scores, output_scores, output_has_score);
+}
+
+}  // namespace milvus::rescores

--- a/internal/core/src/rescores/BoostScoreRunner.h
+++ b/internal/core/src/rescores/BoostScoreRunner.h
@@ -1,0 +1,71 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "common/OpContext.h"
+#include "common/Types.h"
+#include "pb/plan.pb.h"
+#include "rescores/Scorer.h"
+#include "segcore/SegmentInterface.h"
+
+namespace milvus::exec {
+class ExecContext;
+}
+
+namespace milvus::rescores {
+
+void
+ComputeScorerScores(exec::ExecContext* exec_context,
+                    OpContext* op_context,
+                    const segcore::SegmentInternalInterface* segment,
+                    const std::shared_ptr<Scorer>& scorer,
+                    FixedVector<int32_t>& offsets,
+                    std::vector<std::optional<float>>& output_scores);
+
+void
+ComputeScorerScores(exec::ExecContext* exec_context,
+                    OpContext* op_context,
+                    const segcore::SegmentInternalInterface* segment,
+                    const std::shared_ptr<Scorer>& scorer,
+                    FixedVector<int32_t>& offsets,
+                    float* output_scores,
+                    bool* output_has_score);
+
+void
+ComputeFunctionScores(exec::ExecContext* exec_context,
+                      OpContext* op_context,
+                      const segcore::SegmentInternalInterface* segment,
+                      const std::vector<std::shared_ptr<Scorer>>& scorers,
+                      proto::plan::FunctionMode function_mode,
+                      FixedVector<int32_t>& offsets,
+                      std::vector<std::optional<float>>& output_scores);
+
+void
+ComputeFunctionScores(exec::ExecContext* exec_context,
+                      OpContext* op_context,
+                      const segcore::SegmentInternalInterface* segment,
+                      const std::vector<std::shared_ptr<Scorer>>& scorers,
+                      proto::plan::FunctionMode function_mode,
+                      FixedVector<int32_t>& offsets,
+                      float* output_scores,
+                      bool* output_has_score);
+
+}  // namespace milvus::rescores

--- a/internal/core/src/rescores/Utils.h
+++ b/internal/core/src/rescores/Utils.h
@@ -47,7 +47,7 @@ function_score_merge(const float& a,
 
 #define MAGIC_BITS (0x3FFL << 52)
 
-double
+inline double
 hash_to_double(const uint64_t& h) {
     auto double_bytes = (MAGIC_BITS | (h & 0xFFFFFFFFFFFFF));
     double result;

--- a/internal/core/src/segcore/boost_score.cpp
+++ b/internal/core/src/segcore/boost_score.cpp
@@ -1,0 +1,316 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "segcore/boost_score_c.h"
+
+#include <arrow/array/array_primitive.h>
+#include <arrow/c/bridge.h>
+
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "common/Common.h"
+#include "common/Consts.h"
+#include "common/EasyAssert.h"
+#include "common/OpContext.h"
+#include "common/Types.h"
+#include "exec/QueryContext.h"
+#include "futures/Executor.h"
+#include "futures/Future.h"
+#include "pb/plan.pb.h"
+#include "query/PlanImpl.h"
+#include "query/PlanProto.h"
+#include "rescores/BoostScoreRunner.h"
+#include "segcore/SegmentInterface.h"
+
+namespace {
+
+using OffsetChunks = std::vector<milvus::FixedVector<int32_t>>;
+
+milvus::FixedVector<int32_t>
+BuildScorerOffsets(const std::shared_ptr<arrow::Array>& offsets) {
+    AssertInfo(offsets != nullptr, "offset array is null");
+    AssertInfo(offsets->type_id() == arrow::Type::INT64,
+               "offset array must be Int64, got {}",
+               offsets->type()->ToString());
+    AssertInfo(offsets->null_count() == 0, "offset array contains null");
+
+    auto int64_offsets = std::static_pointer_cast<arrow::Int64Array>(offsets);
+    auto count = int64_offsets->length();
+    milvus::FixedVector<int32_t> scorer_offsets;
+    scorer_offsets.reserve(count);
+    for (auto i = 0; i < count; ++i) {
+        auto offset = int64_offsets->Value(i);
+        AssertInfo(
+            offset >= 0, "offset must be non-negative, offset: {}", offset);
+        AssertInfo(offset <= std::numeric_limits<int32_t>::max(),
+                   "offset exceeds int32 range, offset: {}",
+                   offset);
+        scorer_offsets.push_back(static_cast<int32_t>(offset));
+    }
+    return scorer_offsets;
+}
+
+void
+ValidateScorerScoreInputs(CSegmentInterface c_segment,
+                          CSearchPlan c_plan,
+                          const void* serialized_score_function,
+                          int64_t serialized_score_function_size,
+                          ArrowArray* offset_chunks,
+                          ArrowSchema* offset_schemas,
+                          int64_t num_chunks,
+                          float* const* output_score_chunks,
+                          bool* const* output_has_score_chunks) {
+    AssertInfo(c_segment != nullptr, "segment is null");
+    AssertInfo(c_plan != nullptr, "search plan is null");
+    AssertInfo(serialized_score_function != nullptr,
+               "serialized score function is null");
+    AssertInfo(serialized_score_function_size > 0,
+               "serialized score function is empty");
+    AssertInfo(num_chunks >= 0, "chunk count must be non-negative");
+    if (num_chunks > 0) {
+        AssertInfo(offset_chunks != nullptr, "offset chunks is null");
+        AssertInfo(offset_schemas != nullptr, "offset schemas is null");
+        AssertInfo(output_score_chunks != nullptr,
+                   "output score chunks is null");
+        AssertInfo(output_has_score_chunks != nullptr,
+                   "output has score chunks is null");
+    }
+}
+
+std::shared_ptr<milvus::rescores::Scorer>
+ParseScorer(milvus::query::Plan* plan,
+            const void* serialized_score_function,
+            int64_t serialized_score_function_size) {
+    milvus::proto::plan::ScoreFunction score_function;
+    auto ok = score_function.ParseFromArray(serialized_score_function,
+                                            serialized_score_function_size);
+    AssertInfo(ok, "failed to parse score function");
+
+    milvus::query::ProtoParser parser(plan->schema_);
+    return parser.ParseScorer(score_function);
+}
+
+OffsetChunks
+BuildScorerOffsetChunks(ArrowArray* offset_chunks,
+                        ArrowSchema* offset_schemas,
+                        int64_t num_chunks) {
+    OffsetChunks scorer_offset_chunks(num_chunks);
+    for (auto chunk_idx = 0; chunk_idx < num_chunks; ++chunk_idx) {
+        auto offset_array_result = arrow::ImportArray(
+            &offset_chunks[chunk_idx], &offset_schemas[chunk_idx]);
+        AssertInfo(offset_array_result.ok(),
+                   "failed to import offset chunk {}: {}",
+                   chunk_idx,
+                   offset_array_result.status().ToString());
+        auto offset_array = offset_array_result.ValueOrDie();
+        if (offset_array->length() == 0) {
+            continue;
+        }
+        scorer_offset_chunks[chunk_idx] = BuildScorerOffsets(offset_array);
+    }
+    return scorer_offset_chunks;
+}
+
+void
+ComputeScorerScoresOnPreparedChunks(
+    milvus::segcore::SegmentInternalInterface* segment,
+    milvus::query::Plan* plan,
+    const std::shared_ptr<milvus::rescores::Scorer>& scorer,
+    OffsetChunks& scorer_offset_chunks,
+    uint64_t timestamp,
+    uint64_t collection_ttl,
+    int32_t consistency_level,
+    uint64_t entity_ttl_physical_time_us,
+    float* const* output_score_chunks,
+    bool* const* output_has_score_chunks,
+    const folly::CancellationToken& cancel_token = folly::CancellationToken()) {
+    auto active_count = segment->get_active_count(timestamp);
+    auto query_context = std::make_shared<milvus::exec::QueryContext>(
+        DEAFULT_QUERY_ID,
+        segment,
+        active_count,
+        timestamp,
+        collection_ttl,
+        consistency_level,
+        plan->plan_node_->plan_options_,
+        std::make_shared<milvus::exec::QueryConfig>(),
+        nullptr,
+        std::unordered_map<std::string,
+                           std::shared_ptr<milvus::exec::BaseConfig>>(),
+        entity_ttl_physical_time_us);
+    query_context->set_search_info(plan->plan_node_->search_info_);
+
+    auto op_context = milvus::OpContext(cancel_token);
+    query_context->set_op_context(&op_context);
+    auto exec_context = milvus::exec::ExecContext(query_context.get());
+
+    for (auto chunk_idx = 0; chunk_idx < scorer_offset_chunks.size();
+         ++chunk_idx) {
+        milvus::futures::throwIfCancelled(cancel_token);
+        auto& scorer_offsets = scorer_offset_chunks[chunk_idx];
+        if (scorer_offsets.empty()) {
+            continue;
+        }
+        AssertInfo(output_score_chunks[chunk_idx] != nullptr,
+                   "output score chunk {} is null",
+                   chunk_idx);
+        AssertInfo(output_has_score_chunks[chunk_idx] != nullptr,
+                   "output has score chunk {} is null",
+                   chunk_idx);
+
+        milvus::rescores::ComputeScorerScores(
+            &exec_context,
+            &op_context,
+            segment,
+            scorer,
+            scorer_offsets,
+            output_score_chunks[chunk_idx],
+            output_has_score_chunks[chunk_idx]);
+    }
+}
+
+}  // namespace
+
+CStatus
+ComputeScorerScoresOnOffsetChunks(CSegmentInterface c_segment,
+                                  CSearchPlan c_plan,
+                                  const void* serialized_score_function,
+                                  int64_t serialized_score_function_size,
+                                  ArrowArray* offset_chunks,
+                                  ArrowSchema* offset_schemas,
+                                  int64_t num_chunks,
+                                  uint64_t timestamp,
+                                  uint64_t collection_ttl,
+                                  int32_t consistency_level,
+                                  uint64_t entity_ttl_physical_time_us,
+                                  float* const* output_score_chunks,
+                                  bool* const* output_has_score_chunks) {
+    try {
+        ValidateScorerScoreInputs(c_segment,
+                                  c_plan,
+                                  serialized_score_function,
+                                  serialized_score_function_size,
+                                  offset_chunks,
+                                  offset_schemas,
+                                  num_chunks,
+                                  output_score_chunks,
+                                  output_has_score_chunks);
+
+        auto segment =
+            static_cast<milvus::segcore::SegmentInternalInterface*>(c_segment);
+        auto plan = static_cast<milvus::query::Plan*>(c_plan);
+        auto scorer = ParseScorer(
+            plan, serialized_score_function, serialized_score_function_size);
+        auto scorer_offset_chunks =
+            BuildScorerOffsetChunks(offset_chunks, offset_schemas, num_chunks);
+        ComputeScorerScoresOnPreparedChunks(segment,
+                                            plan,
+                                            scorer,
+                                            scorer_offset_chunks,
+                                            timestamp,
+                                            collection_ttl,
+                                            consistency_level,
+                                            entity_ttl_physical_time_us,
+                                            output_score_chunks,
+                                            output_has_score_chunks);
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CFuture*
+AsyncComputeScorerScoresOnOffsetChunks(CSegmentInterface c_segment,
+                                       CSearchPlan c_plan,
+                                       const void* serialized_score_function,
+                                       int64_t serialized_score_function_size,
+                                       ArrowArray* offset_chunks,
+                                       ArrowSchema* offset_schemas,
+                                       int64_t num_chunks,
+                                       uint64_t timestamp,
+                                       uint64_t collection_ttl,
+                                       int32_t consistency_level,
+                                       uint64_t entity_ttl_physical_time_us,
+                                       float* const* output_score_chunks,
+                                       bool* const* output_has_score_chunks) {
+    try {
+        ValidateScorerScoreInputs(c_segment,
+                                  c_plan,
+                                  serialized_score_function,
+                                  serialized_score_function_size,
+                                  offset_chunks,
+                                  offset_schemas,
+                                  num_chunks,
+                                  output_score_chunks,
+                                  output_has_score_chunks);
+
+        auto segment =
+            static_cast<milvus::segcore::SegmentInternalInterface*>(c_segment);
+        auto plan = static_cast<milvus::query::Plan*>(c_plan);
+        auto scorer = ParseScorer(
+            plan, serialized_score_function, serialized_score_function_size);
+        auto scorer_offset_chunks = std::make_shared<OffsetChunks>(
+            BuildScorerOffsetChunks(offset_chunks, offset_schemas, num_chunks));
+        auto future = milvus::futures::Future<bool>::async(
+            milvus::futures::getSearchCPUExecutor(),
+            milvus::futures::ExecutePriority::HIGH,
+            [segment,
+             plan,
+             scorer = std::move(scorer),
+             scorer_offset_chunks = std::move(scorer_offset_chunks),
+             timestamp,
+             collection_ttl,
+             consistency_level,
+             entity_ttl_physical_time_us,
+             output_score_chunks,
+             output_has_score_chunks](
+                folly::CancellationToken cancel_token) -> bool* {
+                ComputeScorerScoresOnPreparedChunks(segment,
+                                                    plan,
+                                                    scorer,
+                                                    *scorer_offset_chunks,
+                                                    timestamp,
+                                                    collection_ttl,
+                                                    consistency_level,
+                                                    entity_ttl_physical_time_us,
+                                                    output_score_chunks,
+                                                    output_has_score_chunks,
+                                                    cancel_token);
+                return nullptr;
+            });
+
+        return static_cast<CFuture*>(static_cast<void*>(
+            static_cast<milvus::futures::IFuture*>(future.release())));
+    } catch (std::exception& e) {
+        std::string error_msg = e.what();
+        auto future = milvus::futures::Future<bool>::async(
+            milvus::futures::getSearchCPUExecutor(),
+            milvus::futures::ExecutePriority::HIGH,
+            [error_msg = std::move(error_msg)](
+                folly::CancellationToken cancel_token) -> bool* {
+                (void)cancel_token;
+                ThrowInfo(milvus::UnexpectedError,
+                          "AsyncComputeScorerScoresOnOffsetChunks preflight "
+                          "failed: {}",
+                          error_msg);
+                return nullptr;
+            });
+        return static_cast<CFuture*>(static_cast<void*>(
+            static_cast<milvus::futures::IFuture*>(future.release())));
+    }
+}

--- a/internal/core/src/segcore/boost_score_c.h
+++ b/internal/core/src/segcore/boost_score_c.h
@@ -1,0 +1,66 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "common/common_type_c.h"
+#include "common/type_c.h"
+#include "futures/future_c_types.h"
+#include "segcore/plan_c.h"
+
+struct ArrowArray;
+struct ArrowSchema;
+
+CStatus
+ComputeScorerScoresOnOffsetChunks(CSegmentInterface segment,
+                                  CSearchPlan plan,
+                                  const void* serialized_score_function,
+                                  int64_t serialized_score_function_size,
+                                  struct ArrowArray* offset_chunks,
+                                  struct ArrowSchema* offset_schemas,
+                                  int64_t num_chunks,
+                                  uint64_t timestamp,
+                                  uint64_t collection_ttl,
+                                  int32_t consistency_level,
+                                  uint64_t entity_ttl_physical_time_us,
+                                  float* const* output_score_chunks,
+                                  bool* const* output_has_score_chunks);
+
+CFuture*
+AsyncComputeScorerScoresOnOffsetChunks(CSegmentInterface segment,
+                                       CSearchPlan plan,
+                                       const void* serialized_score_function,
+                                       int64_t serialized_score_function_size,
+                                       struct ArrowArray* offset_chunks,
+                                       struct ArrowSchema* offset_schemas,
+                                       int64_t num_chunks,
+                                       uint64_t timestamp,
+                                       uint64_t collection_ttl,
+                                       int32_t consistency_level,
+                                       uint64_t entity_ttl_physical_time_us,
+                                       float* const* output_score_chunks,
+                                       bool* const* output_has_score_chunks);
+
+#ifdef __cplusplus
+}
+#endif

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -58,6 +58,7 @@ set(MILVUS_TEST_FILES
         test_query_group_by.cpp
         test_minhash.cpp
         test_async_warmup.cpp
+        test_boost_score_c.cpp
         test_sort_buffer.cpp
         test_row_container.cpp
         test_query_order_by.cpp

--- a/internal/core/unittest/test_boost_score_c.cpp
+++ b/internal/core/unittest/test_boost_score_c.cpp
@@ -1,0 +1,448 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <arrow/api.h>
+#include <arrow/c/bridge.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "common/Common.h"
+#include "common/Consts.h"
+#include "common/Schema.h"
+#include "futures/future_c.h"
+#include "knowhere/comp/index_param.h"
+#include "pb/plan.pb.h"
+#include "query/Plan.h"
+#include "query/PlanImpl.h"
+#include "segcore/SegmentSealed.h"
+#include "segcore/boost_score_c.h"
+#include "test_utils/DataGen.h"
+#include "test_utils/storage_test_utils.h"
+
+namespace {
+
+class BoostScoreCTest : public testing::Test {
+ protected:
+    void
+    SetUp() override {
+        schema_ = std::make_shared<milvus::Schema>();
+        vec_fid_ = schema_->AddDebugField("fakevec",
+                                          milvus::DataType::VECTOR_FLOAT,
+                                          16,
+                                          knowhere::metric::L2);
+        auto pk_fid = schema_->AddDebugField("pk", milvus::DataType::INT64);
+        schema_->set_primary_field_id(pk_fid);
+
+        auto raw_data = milvus::segcore::DataGen(schema_, 100);
+        segment_ = CreateSealedWithFieldDataLoaded(schema_, raw_data);
+
+        milvus::proto::plan::PlanNode plan_node;
+        auto anns = plan_node.mutable_vector_anns();
+        anns->set_vector_type(milvus::proto::plan::VectorType::FloatVector);
+        anns->set_field_id(vec_fid_.get());
+        anns->set_placeholder_tag("$0");
+        auto query_info = anns->mutable_query_info();
+        query_info->set_topk(10);
+        query_info->set_metric_type(knowhere::metric::L2);
+        query_info->set_search_params(R"({"nprobe": 10})");
+        plan_ = milvus::query::CreateSearchPlanFromPlanNode(schema_, plan_node);
+    }
+
+    milvus::proto::plan::ScoreFunction
+    MakeWeightScorer(float weight) {
+        milvus::proto::plan::ScoreFunction scorer;
+        scorer.set_weight(weight);
+        scorer.set_type(milvus::proto::plan::FunctionType::FunctionTypeWeight);
+        return scorer;
+    }
+
+    std::shared_ptr<arrow::Array>
+    MakeOffsets(const std::vector<int64_t>& offsets) {
+        arrow::Int64Builder builder;
+        for (auto offset : offsets) {
+            auto status = builder.Append(offset);
+            EXPECT_TRUE(status.ok()) << status.ToString();
+        }
+        std::shared_ptr<arrow::Array> result;
+        auto status = builder.Finish(&result);
+        EXPECT_TRUE(status.ok()) << status.ToString();
+        return result;
+    }
+
+    void
+    ExportOffsets(const std::shared_ptr<arrow::Array>& offsets,
+                  ArrowArray* offset_array,
+                  ArrowSchema* offset_schema) {
+        auto status = arrow::ExportArray(*offsets, offset_array, offset_schema);
+        ASSERT_TRUE(status.ok()) << status.ToString();
+    }
+
+    void
+    ReleaseArrow(ArrowArray* offset_array, ArrowSchema* offset_schema) {
+        if (offset_array->release != nullptr) {
+            offset_array->release(offset_array);
+        }
+        if (offset_schema->release != nullptr) {
+            offset_schema->release(offset_schema);
+        }
+    }
+
+    void
+    FreeStatus(CStatus* status) {
+        if (status->error_msg != nullptr && status->error_msg[0] != '\0') {
+            free(const_cast<char*>(status->error_msg));
+            status->error_msg = nullptr;
+        }
+    }
+
+    milvus::SchemaPtr schema_;
+    milvus::FieldId vec_fid_;
+    std::unique_ptr<milvus::segcore::SegmentSealed> segment_;
+    std::unique_ptr<milvus::query::Plan> plan_;
+};
+
+TEST_F(BoostScoreCTest, ComputeScorerScoresSync) {
+    auto scorer = MakeWeightScorer(2.0F);
+    std::string scorer_blob;
+    ASSERT_TRUE(scorer.SerializeToString(&scorer_blob));
+
+    auto offsets = MakeOffsets({0, 1, 2});
+    ArrowArray offset_array{};
+    ArrowSchema offset_schema{};
+    ExportOffsets(offsets, &offset_array, &offset_schema);
+
+    std::vector<float> scores(3);
+    auto has_scores = std::make_unique<bool[]>(3);
+    float* score_chunks[] = {scores.data()};
+    bool* has_score_chunks[] = {has_scores.get()};
+
+    auto status = ComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment_.get()),
+        static_cast<CSearchPlan>(plan_.get()),
+        scorer_blob.data(),
+        scorer_blob.size(),
+        &offset_array,
+        &offset_schema,
+        1,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        score_chunks,
+        has_score_chunks);
+    ASSERT_EQ(status.error_code, milvus::Success) << status.error_msg;
+
+    for (auto i = 0; i < 3; ++i) {
+        EXPECT_TRUE(has_scores[i]);
+        EXPECT_FLOAT_EQ(scores[i], 2.0F);
+    }
+
+    ReleaseArrow(&offset_array, &offset_schema);
+}
+
+TEST_F(BoostScoreCTest, ComputeScorerScoresAsync) {
+    auto scorer = MakeWeightScorer(3.0F);
+    std::string scorer_blob;
+    ASSERT_TRUE(scorer.SerializeToString(&scorer_blob));
+
+    auto offsets = MakeOffsets({0, 1, 2});
+    ArrowArray offset_array{};
+    ArrowSchema offset_schema{};
+    ExportOffsets(offsets, &offset_array, &offset_schema);
+
+    std::vector<float> scores(3);
+    auto has_scores = std::make_unique<bool[]>(3);
+    float* score_chunks[] = {scores.data()};
+    bool* has_score_chunks[] = {has_scores.get()};
+
+    auto future = AsyncComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment_.get()),
+        static_cast<CSearchPlan>(plan_.get()),
+        scorer_blob.data(),
+        scorer_blob.size(),
+        &offset_array,
+        &offset_schema,
+        1,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        score_chunks,
+        has_score_chunks);
+    ASSERT_NE(future, nullptr);
+
+    void* result = nullptr;
+    while (!future_is_ready(future)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    auto status = future_leak_and_get(future, &result);
+    EXPECT_EQ(result, nullptr);
+    ASSERT_EQ(status.error_code, milvus::Success) << status.error_msg;
+    future_destroy(future);
+
+    for (auto i = 0; i < 3; ++i) {
+        EXPECT_TRUE(has_scores[i]);
+        EXPECT_FLOAT_EQ(scores[i], 3.0F);
+    }
+
+    ReleaseArrow(&offset_array, &offset_schema);
+}
+
+TEST_F(BoostScoreCTest, AsyncPreflightFailureReturnsDestroyableFuture) {
+    auto offsets = MakeOffsets({0});
+    ArrowArray offset_array{};
+    ArrowSchema offset_schema{};
+    ExportOffsets(offsets, &offset_array, &offset_schema);
+
+    std::vector<float> scores(1);
+    auto has_scores = std::make_unique<bool[]>(1);
+    float* score_chunks[] = {scores.data()};
+    bool* has_score_chunks[] = {has_scores.get()};
+    const char invalid_scorer_blob[] = {static_cast<char>(0xff), 0x01};
+
+    auto future = AsyncComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment_.get()),
+        static_cast<CSearchPlan>(plan_.get()),
+        invalid_scorer_blob,
+        sizeof(invalid_scorer_blob),
+        &offset_array,
+        &offset_schema,
+        1,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        score_chunks,
+        has_score_chunks);
+    ASSERT_NE(future, nullptr);
+
+    void* result = nullptr;
+    while (!future_is_ready(future)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    auto status = future_leak_and_get(future, &result);
+    EXPECT_EQ(result, nullptr);
+    EXPECT_NE(status.error_code, milvus::Success);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(
+        std::string(status.error_msg)
+            .find("AsyncComputeScorerScoresOnOffsetChunks preflight failed"),
+        std::string::npos);
+    FreeStatus(&status);
+    future_destroy(future);
+
+    ReleaseArrow(&offset_array, &offset_schema);
+}
+
+TEST_F(BoostScoreCTest, ValidateRequiredInputs) {
+    auto scorer = MakeWeightScorer(2.0F);
+    std::string scorer_blob;
+    ASSERT_TRUE(scorer.SerializeToString(&scorer_blob));
+
+    auto offsets = MakeOffsets({0});
+    ArrowArray offset_array{};
+    ArrowSchema offset_schema{};
+    ExportOffsets(offsets, &offset_array, &offset_schema);
+
+    std::vector<float> scores(1);
+    auto has_scores = std::make_unique<bool[]>(1);
+    float* score_chunks[] = {scores.data()};
+    bool* has_score_chunks[] = {has_scores.get()};
+
+    auto status =
+        ComputeScorerScoresOnOffsetChunks(nullptr,
+                                          static_cast<CSearchPlan>(plan_.get()),
+                                          scorer_blob.data(),
+                                          scorer_blob.size(),
+                                          &offset_array,
+                                          &offset_schema,
+                                          1,
+                                          milvus::MAX_TIMESTAMP,
+                                          0,
+                                          0,
+                                          0,
+                                          score_chunks,
+                                          has_score_chunks);
+    EXPECT_NE(status.error_code, milvus::Success);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(std::string(status.error_msg).find("segment is null"),
+              std::string::npos);
+    FreeStatus(&status);
+
+    status = ComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment_.get()),
+        nullptr,
+        scorer_blob.data(),
+        scorer_blob.size(),
+        &offset_array,
+        &offset_schema,
+        1,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        score_chunks,
+        has_score_chunks);
+    EXPECT_NE(status.error_code, milvus::Success);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(std::string(status.error_msg).find("search plan is null"),
+              std::string::npos);
+    FreeStatus(&status);
+
+    status = ComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment_.get()),
+        static_cast<CSearchPlan>(plan_.get()),
+        nullptr,
+        scorer_blob.size(),
+        &offset_array,
+        &offset_schema,
+        1,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        score_chunks,
+        has_score_chunks);
+    EXPECT_NE(status.error_code, milvus::Success);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(std::string(status.error_msg).find("score function is null"),
+              std::string::npos);
+    FreeStatus(&status);
+
+    status = ComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment_.get()),
+        static_cast<CSearchPlan>(plan_.get()),
+        scorer_blob.data(),
+        0,
+        &offset_array,
+        &offset_schema,
+        1,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        score_chunks,
+        has_score_chunks);
+    EXPECT_NE(status.error_code, milvus::Success);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(std::string(status.error_msg).find("score function is empty"),
+              std::string::npos);
+    FreeStatus(&status);
+
+    ReleaseArrow(&offset_array, &offset_schema);
+}
+
+TEST_F(BoostScoreCTest, ZeroChunksSucceedsWithoutOutputBuffers) {
+    auto scorer = MakeWeightScorer(2.0F);
+    std::string scorer_blob;
+    ASSERT_TRUE(scorer.SerializeToString(&scorer_blob));
+
+    auto status = ComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment_.get()),
+        static_cast<CSearchPlan>(plan_.get()),
+        scorer_blob.data(),
+        scorer_blob.size(),
+        nullptr,
+        nullptr,
+        0,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        nullptr,
+        nullptr);
+    ASSERT_EQ(status.error_code, milvus::Success) << status.error_msg;
+}
+
+TEST_F(BoostScoreCTest, RejectInvalidOffsetChunks) {
+    auto scorer = MakeWeightScorer(2.0F);
+    std::string scorer_blob;
+    ASSERT_TRUE(scorer.SerializeToString(&scorer_blob));
+
+    arrow::Int32Builder int32_builder;
+    ASSERT_TRUE(int32_builder.Append(1).ok());
+    std::shared_ptr<arrow::Array> int32_offsets;
+    ASSERT_TRUE(int32_builder.Finish(&int32_offsets).ok());
+    ArrowArray int32_offset_array{};
+    ArrowSchema int32_offset_schema{};
+    ExportOffsets(int32_offsets, &int32_offset_array, &int32_offset_schema);
+
+    std::vector<float> scores(1);
+    auto has_scores = std::make_unique<bool[]>(1);
+    float* score_chunks[] = {scores.data()};
+    bool* has_score_chunks[] = {has_scores.get()};
+
+    auto status = ComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment_.get()),
+        static_cast<CSearchPlan>(plan_.get()),
+        scorer_blob.data(),
+        scorer_blob.size(),
+        &int32_offset_array,
+        &int32_offset_schema,
+        1,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        score_chunks,
+        has_score_chunks);
+    EXPECT_NE(status.error_code, milvus::Success);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(std::string(status.error_msg).find("offset array must be Int64"),
+              std::string::npos);
+    FreeStatus(&status);
+
+    ReleaseArrow(&int32_offset_array, &int32_offset_schema);
+
+    arrow::Int64Builder null_builder;
+    ASSERT_TRUE(null_builder.Append(1).ok());
+    ASSERT_TRUE(null_builder.AppendNull().ok());
+    std::shared_ptr<arrow::Array> null_offsets;
+    ASSERT_TRUE(null_builder.Finish(&null_offsets).ok());
+    ArrowArray null_offset_array{};
+    ArrowSchema null_offset_schema{};
+    ExportOffsets(null_offsets, &null_offset_array, &null_offset_schema);
+
+    std::vector<float> null_scores(2);
+    auto null_has_scores = std::make_unique<bool[]>(2);
+    float* null_score_chunks[] = {null_scores.data()};
+    bool* null_has_score_chunks[] = {null_has_scores.get()};
+
+    status = ComputeScorerScoresOnOffsetChunks(
+        static_cast<CSegmentInterface>(segment_.get()),
+        static_cast<CSearchPlan>(plan_.get()),
+        scorer_blob.data(),
+        scorer_blob.size(),
+        &null_offset_array,
+        &null_offset_schema,
+        1,
+        milvus::MAX_TIMESTAMP,
+        0,
+        0,
+        0,
+        null_score_chunks,
+        null_has_score_chunks);
+    EXPECT_NE(status.error_code, milvus::Success);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(std::string(status.error_msg).find("offset array contains null"),
+              std::string::npos);
+    FreeStatus(&status);
+
+    ReleaseArrow(&null_offset_array, &null_offset_schema);
+}
+
+}  // namespace

--- a/internal/core/unittest/test_exec.cpp
+++ b/internal/core/unittest/test_exec.cpp
@@ -17,7 +17,9 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <queue>
 #include <string>
+#include <utility>
 #include <unordered_map>
 #include <vector>
 
@@ -33,6 +35,7 @@
 #include "common/protobuf_utils.h"
 #include "exec/QueryContext.h"
 #include "exec/Task.h"
+#include "exec/operator/RescoresNode.h"
 #include "exec/expression/ConjunctExpr.h"
 #include "exec/expression/Expr.h"
 #include "exec/expression/function/FunctionFactory.h"
@@ -43,6 +46,7 @@
 #include "knowhere/comp/index_param.h"
 #include "pb/plan.pb.h"
 #include "plan/PlanNode.h"
+#include "rescores/Scorer.h"
 #include "query/PlanNode.h"
 #include "query/Utils.h"
 #include "segcore/SegcoreConfig.h"
@@ -129,6 +133,158 @@ INSTANTIATE_TEST_SUITE_P(TaskTestSuite,
                          TaskTest,
                          ::testing::Values(DataType::VECTOR_FLOAT,
                                            DataType::VECTOR_SPARSE_U32_F32));
+
+namespace {
+
+bool
+PlanTreeContainsRescoresNode(
+    const std::shared_ptr<milvus::plan::PlanNode>& root) {
+    std::queue<std::shared_ptr<milvus::plan::PlanNode>> queue;
+    if (root != nullptr) {
+        queue.push(root);
+    }
+
+    while (!queue.empty()) {
+        auto node = queue.front();
+        queue.pop();
+        if (std::dynamic_pointer_cast<milvus::plan::RescoresNode>(node) !=
+            nullptr) {
+            return true;
+        }
+        for (const auto& source : node->sources()) {
+            queue.push(source);
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+TEST(PlanProtoTest, ScorersDoNotInsertRescoresNode) {
+    using namespace milvus;
+    using namespace milvus::query;
+
+    auto schema = std::make_shared<Schema>();
+    auto vec_fid = schema->AddDebugField(
+        "fakevec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+
+    proto::plan::PlanNode plan_node;
+    auto anns = plan_node.mutable_vector_anns();
+    anns->set_vector_type(proto::plan::VectorType::FloatVector);
+    anns->set_field_id(vec_fid.get());
+    anns->set_placeholder_tag("$0");
+    auto query_info = anns->mutable_query_info();
+    query_info->set_topk(10);
+    query_info->set_metric_type(knowhere::metric::L2);
+    query_info->set_search_params(R"({"nprobe": 10})");
+
+    auto scorer = plan_node.add_scorers();
+    scorer->set_weight(2.0F);
+    scorer->set_type(proto::plan::FunctionType::FunctionTypeWeight);
+    plan_node.mutable_score_option()->set_boost_mode(
+        proto::plan::BoostMode::BoostModeMultiply);
+    plan_node.mutable_score_option()->set_function_mode(
+        proto::plan::FunctionMode::FunctionModeSum);
+
+    auto plan = CreateSearchPlanFromPlanNode(schema, plan_node);
+    ASSERT_NE(plan, nullptr);
+    ASSERT_NE(plan->plan_node_, nullptr);
+    ASSERT_NE(plan->plan_node_->plannodes_, nullptr);
+    EXPECT_FALSE(PlanTreeContainsRescoresNode(plan->plan_node_->plannodes_));
+}
+
+TEST(RescoresNodeTest, ReturnsNullBeforeNoMoreInputAndPassesThroughNullInput) {
+    proto::plan::ScoreOption option;
+    option.set_boost_mode(proto::plan::BoostModeMultiply);
+    option.set_function_mode(proto::plan::FunctionModeSum);
+    std::vector<std::shared_ptr<rescores::Scorer>> scorers;
+    auto logical_node = std::make_shared<plan::RescoresNode>(
+        "rescore", scorers, option, std::vector<plan::PlanNodePtr>{});
+    auto query_context =
+        std::make_shared<QueryContext>("rescore-test",
+                                       nullptr,
+                                       0,
+                                       MAX_TIMESTAMP,
+                                       0,
+                                       0,
+                                       query::PlanOptions{false},
+                                       std::make_shared<QueryConfig>());
+    auto task = Task::Create("rescore-test-task",
+                             plan::PlanFragment(logical_node),
+                             0,
+                             query_context);
+    DriverContext driver_context(task, 0, 0, 0, 0);
+    PhyRescoresNode node(0, &driver_context, logical_node);
+
+    EXPECT_TRUE(node.NeedInput());
+    EXPECT_EQ(node.GetOutput(), nullptr);
+
+    node.NoMoreInput();
+    EXPECT_EQ(node.GetOutput(), nullptr);
+    EXPECT_TRUE(node.IsFinished());
+    EXPECT_FALSE(node.NeedInput());
+}
+
+TEST(RescoresNodeTest, AppliesBoostAndSortsSearchResult) {
+    proto::plan::ScoreOption option;
+    option.set_boost_mode(proto::plan::BoostModeMultiply);
+    option.set_function_mode(proto::plan::FunctionModeSum);
+    std::vector<std::shared_ptr<rescores::Scorer>> scorers{
+        std::make_shared<rescores::WeightScorer>(nullptr, 10.0F),
+    };
+    auto logical_node = std::make_shared<plan::RescoresNode>(
+        "rescore", scorers, option, std::vector<plan::PlanNodePtr>{});
+
+    SearchResult search_result;
+    search_result.total_nq_ = 1;
+    search_result.unity_topK_ = 4;
+    search_result.total_data_cnt_ = 4;
+    search_result.distances_ = {0.4F, 0.1F, 0.3F, 0.2F};
+    search_result.seg_offsets_ = {4, -1, 3, 2};
+
+    SearchInfo search_info;
+    search_info.topk_ = 4;
+    search_info.metric_type_ = knowhere::metric::IP;
+
+    auto query_context =
+        std::make_shared<QueryContext>("rescore-test",
+                                       nullptr,
+                                       4,
+                                       MAX_TIMESTAMP,
+                                       0,
+                                       0,
+                                       query::PlanOptions{false},
+                                       std::make_shared<QueryConfig>());
+    OpContext op_context;
+    query_context->set_op_context(&op_context);
+    query_context->set_search_info(search_info);
+    query_context->set_search_result(std::move(search_result));
+
+    auto task = Task::Create("rescore-test-task",
+                             plan::PlanFragment(logical_node),
+                             0,
+                             query_context);
+    DriverContext driver_context(task, 0, 0, 0, 0);
+    PhyRescoresNode node(0, &driver_context, logical_node);
+    auto input = std::make_shared<RowVector>(std::vector<VectorPtr>{});
+    auto expected_input = input;
+    node.AddInput(input);
+    node.NoMoreInput();
+
+    auto output = node.GetOutput();
+    EXPECT_EQ(output, expected_input);
+    EXPECT_TRUE(node.IsFinished());
+
+    auto rescored = query_context->get_search_result();
+    EXPECT_EQ(rescored.seg_offsets_, (std::vector<int64_t>{4, 3, 2, -1}));
+    ASSERT_EQ(rescored.distances_.size(), 4);
+    EXPECT_FLOAT_EQ(rescored.distances_[0], 4.0F);
+    EXPECT_FLOAT_EQ(rescored.distances_[1], 3.0F);
+    EXPECT_FLOAT_EQ(rescored.distances_[2], 2.0F);
+    EXPECT_FLOAT_EQ(rescored.distances_[3], 0.1F);
+}
 
 TEST_P(TaskTest, RegisterFunction) {
     milvus::exec::expression::FunctionFactory& factory =

--- a/internal/core/unittest/test_scorer.cpp
+++ b/internal/core/unittest/test_scorer.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "common/Types.h"
@@ -22,10 +23,78 @@
 #include "filemanager/InputStream.h"
 #include "gtest/gtest.h"
 #include "pb/plan.pb.h"
+#include "rescores/BoostScoreRunner.h"
 #include "rescores/Scorer.h"
 
 using namespace milvus;
 using namespace milvus::rescores;
+
+namespace {
+
+class StaticScorer : public Scorer {
+ public:
+    explicit StaticScorer(std::vector<std::optional<float>> scores)
+        : scores_(std::move(scores)) {
+    }
+
+    expr::TypedExprPtr
+    filter() override {
+        return nullptr;
+    }
+
+    void
+    batch_score(milvus::OpContext* op_ctx,
+                const segcore::SegmentInternalInterface* segment,
+                const proto::plan::FunctionMode& mode,
+                const FixedVector<int32_t>& offsets,
+                const TargetBitmapView& bitmap,
+                std::vector<std::optional<float>>& boost_scores) override {
+        for (auto i = 0; i < offsets.size(); ++i) {
+            if (bitmap[i] && scores_[i].has_value()) {
+                boost_scores[i] = scores_[i];
+            }
+        }
+    }
+
+    void
+    batch_score(milvus::OpContext* op_ctx,
+                const segcore::SegmentInternalInterface* segment,
+                const proto::plan::FunctionMode& mode,
+                const FixedVector<int32_t>& offsets,
+                const TargetBitmap& bitmap,
+                std::vector<std::optional<float>>& boost_scores) override {
+        for (auto i = 0; i < offsets.size(); ++i) {
+            auto offset = offsets[i];
+            if (offset >= 0 && static_cast<size_t>(offset) < bitmap.size() &&
+                bitmap[offset] && scores_[i].has_value()) {
+                boost_scores[i] = scores_[i];
+            }
+        }
+    }
+
+    void
+    batch_score(milvus::OpContext* op_ctx,
+                const segcore::SegmentInternalInterface* segment,
+                const proto::plan::FunctionMode& mode,
+                const FixedVector<int32_t>& offsets,
+                std::vector<std::optional<float>>& boost_scores) override {
+        for (auto i = 0; i < offsets.size(); ++i) {
+            if (scores_[i].has_value()) {
+                boost_scores[i] = scores_[i];
+            }
+        }
+    }
+
+    float
+    weight() override {
+        return 0.0F;
+    }
+
+ private:
+    std::vector<std::optional<float>> scores_;
+};
+
+}  // namespace
 
 class WeightScorerTest : public ::testing::Test {
  protected:
@@ -88,4 +157,86 @@ TEST_F(WeightScorerTest, BatchScoreTargetBitmapOutOfBoundsOffsets) {
     EXPECT_FALSE(boost_scores[2].has_value());
     EXPECT_FALSE(boost_scores[3].has_value());
     EXPECT_FALSE(boost_scores[4].has_value());
+}
+
+TEST(BoostScoreRunnerTest, ComputeScorerScoresNoFilterCopiesToBuffers) {
+    auto scorer = std::make_shared<WeightScorer>(nullptr, 2.5F);
+    FixedVector<int32_t> offsets = {3, 1, 4};
+    std::vector<float> scores(offsets.size(), -1.0F);
+    auto has_scores = std::make_unique<bool[]>(offsets.size());
+
+    ComputeScorerScores(nullptr,
+                        nullptr,
+                        nullptr,
+                        scorer,
+                        offsets,
+                        scores.data(),
+                        has_scores.get());
+
+    for (auto i = 0; i < offsets.size(); ++i) {
+        EXPECT_TRUE(has_scores[i]);
+        EXPECT_FLOAT_EQ(scores[i], 2.5F);
+    }
+}
+
+TEST(BoostScoreRunnerTest, ComputeFunctionScoresMergesAndSkipsNulls) {
+    std::vector<std::shared_ptr<Scorer>> scorers{
+        std::make_shared<StaticScorer>(
+            std::vector<std::optional<float>>{2.0F, std::nullopt, 4.0F}),
+        std::make_shared<StaticScorer>(
+            std::vector<std::optional<float>>{3.0F, 5.0F, std::nullopt}),
+    };
+    FixedVector<int32_t> offsets = {0, 1, 2};
+    std::vector<float> scores(offsets.size(), -1.0F);
+    auto has_scores = std::make_unique<bool[]>(offsets.size());
+
+    ComputeFunctionScores(nullptr,
+                          nullptr,
+                          nullptr,
+                          scorers,
+                          proto::plan::FunctionModeSum,
+                          offsets,
+                          scores.data(),
+                          has_scores.get());
+
+    EXPECT_TRUE(has_scores[0]);
+    EXPECT_FLOAT_EQ(scores[0], 5.0F);
+    EXPECT_TRUE(has_scores[1]);
+    EXPECT_FLOAT_EQ(scores[1], 5.0F);
+    EXPECT_TRUE(has_scores[2]);
+    EXPECT_FLOAT_EQ(scores[2], 4.0F);
+
+    std::vector<std::optional<float>> optional_scores(offsets.size(),
+                                                      std::nullopt);
+    ComputeFunctionScores(nullptr,
+                          nullptr,
+                          nullptr,
+                          scorers,
+                          proto::plan::FunctionModeMultiply,
+                          offsets,
+                          optional_scores);
+
+    ASSERT_TRUE(optional_scores[0].has_value());
+    EXPECT_FLOAT_EQ(optional_scores[0].value(), 6.0F);
+    ASSERT_TRUE(optional_scores[1].has_value());
+    EXPECT_FLOAT_EQ(optional_scores[1].value(), 5.0F);
+    ASSERT_TRUE(optional_scores[2].has_value());
+    EXPECT_FLOAT_EQ(optional_scores[2].value(), 4.0F);
+}
+
+TEST(BoostScoreRunnerTest, ComputeFunctionScoresRejectsMismatchedOutputSize) {
+    std::vector<std::shared_ptr<Scorer>> scorers{
+        std::make_shared<WeightScorer>(nullptr, 2.0F),
+    };
+    FixedVector<int32_t> offsets = {0, 1};
+    std::vector<std::optional<float>> scores(1, std::nullopt);
+
+    EXPECT_THROW(ComputeFunctionScores(nullptr,
+                                       nullptr,
+                                       nullptr,
+                                       scorers,
+                                       proto::plan::FunctionModeSum,
+                                       offsets,
+                                       scores),
+                 milvus::SegcoreError);
 }

--- a/internal/querynodev2/segments/segment_boost_score.go
+++ b/internal/querynodev2/segments/segment_boost_score.go
@@ -1,0 +1,79 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segments
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/arrow/go/v17/arrow"
+
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/state"
+	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func ComputeScorerScoresOnChunkedOffsets(
+	ctx context.Context,
+	segment Segment,
+	searchReq *segcore.SearchRequest,
+	scorer *planpb.ScoreFunction,
+	offsets *arrow.Chunked,
+) (*arrow.Chunked, error) {
+	return computeScorerScoresOnChunkedOffsets(ctx, segment, searchReq, scorer, offsets, false)
+}
+
+func AsyncComputeScorerScoresOnChunkedOffsets(
+	ctx context.Context,
+	segment Segment,
+	searchReq *segcore.SearchRequest,
+	scorer *planpb.ScoreFunction,
+	offsets *arrow.Chunked,
+) (*arrow.Chunked, error) {
+	return computeScorerScoresOnChunkedOffsets(ctx, segment, searchReq, scorer, offsets, true)
+}
+
+func computeScorerScoresOnChunkedOffsets(
+	ctx context.Context,
+	segment Segment,
+	searchReq *segcore.SearchRequest,
+	scorer *planpb.ScoreFunction,
+	offsets *arrow.Chunked,
+	async bool,
+) (*arrow.Chunked, error) {
+	if segment == nil {
+		return nil, merr.WrapErrServiceInternal("segment is nil")
+	}
+
+	local, ok := segment.(*LocalSegment)
+	if !ok {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("segment %d does not support boost score", segment.ID()))
+	}
+	if local.csegment == nil {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("segment %d has nil CSegment", segment.ID()))
+	}
+	if !local.ptrLock.PinIf(state.IsNotReleased) {
+		return nil, merr.WrapErrSegmentNotLoaded(segment.ID(), "segment released")
+	}
+	defer local.ptrLock.Unpin()
+
+	if async {
+		return segcore.AsyncComputeScorerScoresOnChunkedOffsets(ctx, local.csegment, searchReq, scorer, offsets)
+	}
+	return segcore.ComputeScorerScoresOnChunkedOffsets(local.csegment, searchReq, scorer, offsets)
+}

--- a/internal/querynodev2/segments/segment_boost_score_test.go
+++ b/internal/querynodev2/segments/segment_boost_score_test.go
@@ -1,0 +1,81 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segments
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
+	"github.com/milvus-io/milvus/internal/querynodev2/segments/state"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+)
+
+func TestComputeScorerScoresOnChunkedOffsetsNilSegment(t *testing.T) {
+	scores, err := ComputeScorerScoresOnChunkedOffsets(context.Background(), nil, nil, nil, nil)
+	require.Error(t, err)
+	require.Nil(t, scores)
+	require.Contains(t, err.Error(), "segment is nil")
+
+	scores, err = AsyncComputeScorerScoresOnChunkedOffsets(context.Background(), nil, nil, nil, nil)
+	require.Error(t, err)
+	require.Nil(t, scores)
+	require.Contains(t, err.Error(), "segment is nil")
+}
+
+func TestComputeScorerScoresOnChunkedOffsetsNonLocalSegment(t *testing.T) {
+	segment := NewMockSegment(t)
+	segment.EXPECT().ID().Return(int64(1001))
+
+	scores, err := ComputeScorerScoresOnChunkedOffsets(context.Background(), segment, nil, nil, nil)
+	require.Error(t, err)
+	require.Nil(t, scores)
+	require.Contains(t, err.Error(), "does not support boost score")
+}
+
+func TestComputeScorerScoresOnChunkedOffsetsNilCSegment(t *testing.T) {
+	segment := &LocalSegment{
+		baseSegment: baseSegment{
+			loadInfo: atomic.NewPointer(&querypb.SegmentLoadInfo{SegmentID: 1002}),
+		},
+	}
+
+	scores, err := ComputeScorerScoresOnChunkedOffsets(context.Background(), segment, nil, nil, nil)
+	require.Error(t, err)
+	require.Nil(t, scores)
+	require.Contains(t, err.Error(), "has nil CSegment")
+}
+
+func TestComputeScorerScoresOnChunkedOffsetsReleasedSegment(t *testing.T) {
+	segment := &LocalSegment{
+		baseSegment: baseSegment{
+			loadInfo: atomic.NewPointer(&querypb.SegmentLoadInfo{SegmentID: 1003}),
+		},
+		ptrLock:  state.NewLoadStateLock(state.LoadStateOnlyMeta),
+		csegment: mock_segcore.NewMockCSegment(t),
+	}
+	guard := segment.ptrLock.StartReleaseAll()
+	require.NotNil(t, guard)
+
+	scores, err := AsyncComputeScorerScoresOnChunkedOffsets(context.Background(), segment, nil, nil, nil)
+	require.Error(t, err)
+	require.Nil(t, scores)
+	require.Contains(t, err.Error(), "segment released")
+}

--- a/internal/querynodev2/tasks/boost_score.go
+++ b/internal/querynodev2/tasks/boost_score.go
@@ -1,0 +1,262 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus/internal/querynodev2/segments"
+	"github.com/milvus-io/milvus/internal/util/function/chain"
+	"github.com/milvus-io/milvus/internal/util/function/chain/expr"
+	"github.com/milvus-io/milvus/internal/util/function/chain/types"
+	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+const (
+	boostScoreColumnPrefix = "$boost_score_"
+	functionScoreColumn    = "$function_score"
+)
+
+func boostScoreColumn(index int) string {
+	return fmt.Sprintf("%s%d", boostScoreColumnPrefix, index)
+}
+
+func boostReduceColumns(cols []string) []string {
+	selected := make([]string, 0, 4)
+	for _, col := range cols {
+		switch {
+		case col == types.IDFieldName,
+			col == types.ScoreFieldName,
+			col == types.SegOffsetFieldName,
+			col == elementIndicesCol,
+			isGroupByColumnName(col):
+			selected = append(selected, col)
+		}
+	}
+	return selected
+}
+
+func extractPlanScorers(serializedPlan []byte) ([]*planpb.ScoreFunction, error) {
+	plan, err := extractPlanWithScorers(serializedPlan)
+	if err != nil || plan == nil {
+		return nil, err
+	}
+	return plan.GetScorers(), nil
+}
+
+func extractPlanWithScorers(serializedPlan []byte) (*planpb.PlanNode, error) {
+	if len(serializedPlan) == 0 {
+		return nil, nil
+	}
+
+	plan := &planpb.PlanNode{}
+	if err := proto.Unmarshal(serializedPlan, plan); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func functionModeToScoreCombineMode(mode planpb.FunctionMode) (string, error) {
+	switch mode {
+	case planpb.FunctionMode_FunctionModeMultiply:
+		return expr.ModeMultiply, nil
+	case planpb.FunctionMode_FunctionModeSum:
+		return expr.ModeSum, nil
+	default:
+		return "", merr.WrapErrServiceInternal(fmt.Sprintf("boost_score: unknown function mode %s", mode.String()))
+	}
+}
+
+func boostModeToScoreCombineMode(mode planpb.BoostMode) (string, error) {
+	switch mode {
+	case planpb.BoostMode_BoostModeMultiply:
+		return expr.ModeMultiply, nil
+	case planpb.BoostMode_BoostModeSum:
+		return expr.ModeSum, nil
+	default:
+		return "", merr.WrapErrServiceInternal(fmt.Sprintf("boost_score: unknown boost mode %s", mode.String()))
+	}
+}
+
+var boostScoreRunnerFactory = newSegmentBoostScoreRunner
+
+type boostScoreFunc func(context.Context, segments.Segment, *segcore.SearchRequest, *planpb.ScoreFunction, *arrow.Chunked) (*arrow.Chunked, error)
+
+func newSegmentBoostScoreRunner(scoreFunc boostScoreFunc, segment segments.Segment, searchReq *segcore.SearchRequest, scorer *planpb.ScoreFunction) expr.BoostScoreRunner {
+	return func(ctx context.Context, offsets *arrow.Chunked) (*arrow.Chunked, error) {
+		return scoreFunc(ctx, segment, searchReq, scorer, offsets)
+	}
+}
+
+func buildBoostScoreChain(
+	df *chain.DataFrame,
+	segment segments.Segment,
+	searchReq *segcore.SearchRequest,
+	scorers []*planpb.ScoreFunction,
+	scoreFunc boostScoreFunc,
+	functionMode string,
+	boostMode string,
+) (*chain.FuncChain, error) {
+	boostChain := chain.NewFuncChainWithAllocator(defaultAllocator).
+		SetName("l0-rerank").
+		SetStage(types.StageL0Rerank)
+
+	boostScoreColumns, err := appendBoostScoreColumns(boostChain, segment, searchReq, scorers, scoreFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	functionScoreCol, err := appendFunctionScoreColumn(boostChain, boostScoreColumns, functionMode)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := appendFinalBoostScore(boostChain, functionScoreCol, boostMode); err != nil {
+		return nil, err
+	}
+
+	boostChain.Select(boostReduceColumns(df.ColumnNames())...)
+	boostChain.Sort(types.ScoreFieldName, true)
+	return boostChain, nil
+}
+
+func appendBoostScoreColumns(
+	boostChain *chain.FuncChain,
+	segment segments.Segment,
+	searchReq *segcore.SearchRequest,
+	scorers []*planpb.ScoreFunction,
+	scoreFunc boostScoreFunc,
+) ([]string, error) {
+	boostScoreColumns := make([]string, 0, len(scorers))
+	for scorerIdx, scorer := range scorers {
+		outputCol := boostScoreColumn(scorerIdx)
+		boostExpr, err := expr.NewBoostScoreExpr(boostScoreRunnerFactory(scoreFunc, segment, searchReq, scorer))
+		if err != nil {
+			return nil, err
+		}
+		boostChain.Map(boostExpr, []string{types.SegOffsetFieldName}, []string{outputCol})
+		boostScoreColumns = append(boostScoreColumns, outputCol)
+	}
+	return boostScoreColumns, nil
+}
+
+func appendFunctionScoreColumn(boostChain *chain.FuncChain, boostScoreColumns []string, functionMode string) (string, error) {
+	if len(boostScoreColumns) == 1 {
+		return boostScoreColumns[0], nil
+	}
+
+	functionCombineExpr, err := expr.NewScoreCombineExpr(functionMode, nil, expr.WithNullPolicy(expr.ScoreCombineNullSkip))
+	if err != nil {
+		return "", err
+	}
+	boostChain.Map(functionCombineExpr, boostScoreColumns, []string{functionScoreColumn})
+	return functionScoreColumn, nil
+}
+
+func appendFinalBoostScore(boostChain *chain.FuncChain, functionScoreCol string, boostMode string) error {
+	finalCombineExpr, err := expr.NewScoreCombineExpr(boostMode, nil, expr.WithNullPolicy(expr.ScoreCombineNullSkip))
+	if err != nil {
+		return err
+	}
+	boostChain.Map(finalCombineExpr,
+		[]string{types.ScoreFieldName, functionScoreCol},
+		[]string{types.ScoreFieldName})
+	return nil
+}
+
+func (t *SearchTask) applyBoostScores(segDFs []*chain.DataFrame, searchedSegments []segments.Segment, searchReq *segcore.SearchRequest) error {
+	if len(segDFs) != len(searchedSegments) {
+		return merr.WrapErrServiceInternal(fmt.Sprintf("boost_score: DataFrame count %d does not match segment count %d", len(segDFs), len(searchedSegments)))
+	}
+
+	plan, err := extractPlanWithScorers(t.req.GetReq().GetSerializedExprPlan())
+	if err != nil {
+		return merr.WrapErrServiceInternal(fmt.Sprintf("boost_score: failed to parse search plan scorers: %v", err))
+	}
+	if plan == nil || len(plan.GetScorers()) == 0 {
+		return nil
+	}
+
+	scorers := plan.GetScorers()
+	functionMode, err := functionModeToScoreCombineMode(plan.GetScoreOption().GetFunctionMode())
+	if err != nil {
+		return err
+	}
+	boostMode, err := boostModeToScoreCombineMode(plan.GetScoreOption().GetBoostMode())
+	if err != nil {
+		return err
+	}
+
+	boostedDFs := make([]*chain.DataFrame, len(segDFs))
+	scoreFunc := segments.AsyncComputeScorerScoresOnChunkedOffsets
+	boostOneSegment := func(ctx context.Context, i int) error {
+		df := segDFs[i]
+		segment := searchedSegments[i]
+		if df == nil {
+			return merr.WrapErrServiceInternal(fmt.Sprintf("boost_score: DataFrame %d is nil", i))
+		}
+
+		boostChain, err := buildBoostScoreChain(df, segment, searchReq, scorers, scoreFunc, functionMode, boostMode)
+		if err != nil {
+			return err
+		}
+
+		boosted, err := boostChain.ExecuteWithContext(ctx, df)
+		if err != nil {
+			return err
+		}
+
+		boostedDFs[i] = boosted
+		return nil
+	}
+
+	if len(segDFs) == 1 {
+		if err := boostOneSegment(t.ctx, 0); err != nil {
+			return err
+		}
+	} else {
+		errGroup, groupCtx := errgroup.WithContext(t.ctx)
+		for i := range segDFs {
+			idx := i
+			errGroup.Go(func() error {
+				return boostOneSegment(groupCtx, idx)
+			})
+		}
+		if err := errGroup.Wait(); err != nil {
+			for _, boosted := range boostedDFs {
+				if boosted != nil {
+					boosted.Release()
+				}
+			}
+			return err
+		}
+	}
+
+	for i, boosted := range boostedDFs {
+		segDFs[i].Release()
+		segDFs[i] = boosted
+	}
+
+	return nil
+}

--- a/internal/querynodev2/tasks/boost_score_test.go
+++ b/internal/querynodev2/tasks/boost_score_test.go
@@ -1,0 +1,760 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus/internal/querynodev2/segments"
+	"github.com/milvus-io/milvus/internal/util/function/chain"
+	"github.com/milvus-io/milvus/internal/util/function/chain/expr"
+	"github.com/milvus-io/milvus/internal/util/function/chain/types"
+	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/metric"
+)
+
+func TestBoostScoreColumn(t *testing.T) {
+	require.Equal(t, "$boost_score_0", boostScoreColumn(0))
+	require.Equal(t, "$boost_score_3", boostScoreColumn(3))
+}
+
+func TestBoostReduceColumnsKeepsReduceColumnsOnly(t *testing.T) {
+	groupCol := groupByColumnName(100)
+	cols := []string{
+		types.IDFieldName,
+		boostScoreColumn(0),
+		types.ScoreFieldName,
+		functionScoreColumn,
+		types.SegOffsetFieldName,
+		elementIndicesCol,
+		groupCol,
+		"user_field",
+	}
+
+	require.Equal(t,
+		[]string{types.IDFieldName, types.ScoreFieldName, types.SegOffsetFieldName, elementIndicesCol, groupCol},
+		boostReduceColumns(cols))
+}
+
+func withBoostScoreCheckedAllocator(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	oldAllocator := defaultAllocator
+	defaultAllocator = pool
+	t.Cleanup(func() {
+		defaultAllocator = oldAllocator
+		pool.AssertSize(t, 0)
+	})
+}
+
+func makeBoostScoreTestDF(t *testing.T, ids []int64, scores []float32, offsets []int64, chunkSizes []int64) *chain.DataFrame {
+	builder := chain.NewDataFrameBuilder()
+	builder.SetChunkSizes(chunkSizes)
+
+	idChunks := make([]arrow.Array, len(chunkSizes))
+	scoreChunks := make([]arrow.Array, len(chunkSizes))
+	offsetChunks := make([]arrow.Array, len(chunkSizes))
+
+	pos := 0
+	for chunkIdx, size := range chunkSizes {
+		idBuilder := array.NewInt64Builder(defaultAllocator)
+		scoreBuilder := array.NewFloat32Builder(defaultAllocator)
+		offsetBuilder := array.NewInt64Builder(defaultAllocator)
+		for rowIdx := int64(0); rowIdx < size; rowIdx++ {
+			idBuilder.Append(ids[pos])
+			scoreBuilder.Append(scores[pos])
+			offsetBuilder.Append(offsets[pos])
+			pos++
+		}
+		idChunks[chunkIdx] = idBuilder.NewArray()
+		scoreChunks[chunkIdx] = scoreBuilder.NewArray()
+		offsetChunks[chunkIdx] = offsetBuilder.NewArray()
+		idBuilder.Release()
+		scoreBuilder.Release()
+		offsetBuilder.Release()
+	}
+
+	require.NoError(t, builder.AddColumnFromChunks(types.IDFieldName, idChunks))
+	require.NoError(t, builder.AddColumnFromChunks(types.ScoreFieldName, scoreChunks))
+	require.NoError(t, builder.AddColumnFromChunks(types.SegOffsetFieldName, offsetChunks))
+	return builder.Build()
+}
+
+func makeBoostScoreTestTask(t *testing.T, plan *planpb.PlanNode) *SearchTask {
+	if plan.GetVectorAnns().GetQueryInfo().GetMetricType() == "" {
+		plan.Node = &planpb.PlanNode_VectorAnns{
+			VectorAnns: &planpb.VectorANNS{
+				QueryInfo: &planpb.QueryInfo{MetricType: metric.COSINE},
+			},
+		}
+	}
+
+	blob, err := proto.Marshal(plan)
+	require.NoError(t, err)
+	return &SearchTask{
+		ctx: context.Background(),
+		req: &querypb.SearchRequest{
+			Req: &internalpb.SearchRequest{
+				SerializedExprPlan: blob,
+			},
+		},
+	}
+}
+
+type boostScoreOutput struct {
+	scores   []float32
+	hasScore []bool
+}
+
+func mockBoostScoreRunnerFactory(outputs ...boostScoreOutput) func(boostScoreFunc, segments.Segment, *segcore.SearchRequest, *planpb.ScoreFunction) expr.BoostScoreRunner {
+	call := 0
+	return func(boostScoreFunc, segments.Segment, *segcore.SearchRequest, *planpb.ScoreFunction) expr.BoostScoreRunner {
+		idx := call
+		call++
+		return func(ctx context.Context, offsets *arrow.Chunked) (*arrow.Chunked, error) {
+			chunks := make([]arrow.Array, 0, len(offsets.Chunks()))
+			pos := 0
+			for _, offsetChunk := range offsets.Chunks() {
+				builder := array.NewFloat32Builder(defaultAllocator)
+				for rowIdx := 0; rowIdx < offsetChunk.Len(); rowIdx++ {
+					if outputs[idx].hasScore[pos] {
+						builder.Append(outputs[idx].scores[pos])
+					} else {
+						builder.AppendNull()
+					}
+					pos++
+				}
+				chunk := builder.NewArray()
+				builder.Release()
+				chunks = append(chunks, chunk)
+			}
+			return newBoostScoreTestChunked(chunks), nil
+		}
+	}
+}
+
+func newBoostScoreTestChunked(chunks []arrow.Array) *arrow.Chunked {
+	result := arrow.NewChunked(arrow.PrimitiveTypes.Float32, chunks)
+	for _, chunk := range chunks {
+		chunk.Release()
+	}
+	return result
+}
+
+func newConstantBoostScoreTestChunked(offsets *arrow.Chunked, score float32) *arrow.Chunked {
+	chunks := make([]arrow.Array, 0, len(offsets.Chunks()))
+	for _, offsetChunk := range offsets.Chunks() {
+		builder := array.NewFloat32Builder(defaultAllocator)
+		for rowIdx := 0; rowIdx < offsetChunk.Len(); rowIdx++ {
+			builder.Append(score)
+		}
+		chunk := builder.NewArray()
+		builder.Release()
+		chunks = append(chunks, chunk)
+	}
+	return newBoostScoreTestChunked(chunks)
+}
+
+func TestBuildBoostScoreChainSkipsFunctionCombineForSingleScorer(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	oldFactory := boostScoreRunnerFactory
+	boostScoreRunnerFactory = mockBoostScoreRunnerFactory(boostScoreOutput{
+		scores:   []float32{2.0},
+		hasScore: []bool{true},
+	})
+	defer func() { boostScoreRunnerFactory = oldFactory }()
+
+	df := makeBoostScoreTestDF(t, []int64{1}, []float32{0.5}, []int64{10}, []int64{1})
+	defer df.Release()
+
+	boostChain, err := buildBoostScoreChain(
+		df,
+		nil,
+		nil,
+		[]*planpb.ScoreFunction{{Weight: 1}},
+		segments.ComputeScorerScoresOnChunkedOffsets,
+		expr.ModeSum,
+		expr.ModeMultiply,
+	)
+	require.NoError(t, err)
+
+	result, err := boostChain.Execute(df)
+	require.NoError(t, err)
+	defer result.Release()
+
+	require.Nil(t, result.Column(boostScoreColumn(0)))
+	require.Nil(t, result.Column(functionScoreColumn))
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	require.InDelta(t, 1.0, scores.Value(0), 1e-6)
+}
+
+func TestBuildBoostScoreChainCombinesMultipleScorers(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	oldFactory := boostScoreRunnerFactory
+	boostScoreRunnerFactory = mockBoostScoreRunnerFactory(
+		boostScoreOutput{scores: []float32{2.0}, hasScore: []bool{true}},
+		boostScoreOutput{scores: []float32{3.0}, hasScore: []bool{true}},
+	)
+	defer func() { boostScoreRunnerFactory = oldFactory }()
+
+	df := makeBoostScoreTestDF(t, []int64{1}, []float32{0.5}, []int64{10}, []int64{1})
+	defer df.Release()
+
+	boostChain, err := buildBoostScoreChain(
+		df,
+		nil,
+		nil,
+		[]*planpb.ScoreFunction{{Weight: 1}, {Weight: 1}},
+		segments.ComputeScorerScoresOnChunkedOffsets,
+		expr.ModeSum,
+		expr.ModeMultiply,
+	)
+	require.NoError(t, err)
+
+	result, err := boostChain.Execute(df)
+	require.NoError(t, err)
+	defer result.Release()
+
+	require.Nil(t, result.Column(boostScoreColumn(0)))
+	require.Nil(t, result.Column(boostScoreColumn(1)))
+	require.Nil(t, result.Column(functionScoreColumn))
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	require.InDelta(t, 2.5, scores.Value(0), 1e-6)
+}
+
+func TestApplyBoostScoresSingleScorerCombinesAndSorts(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	oldFactory := boostScoreRunnerFactory
+	boostScoreRunnerFactory = mockBoostScoreRunnerFactory(boostScoreOutput{
+		scores:   []float32{1.0, 10.0, 2.0},
+		hasScore: []bool{true, true, false},
+	})
+	defer func() { boostScoreRunnerFactory = oldFactory }()
+
+	df := makeBoostScoreTestDF(t,
+		[]int64{1, 2, 3},
+		[]float32{0.5, 0.2, 0.9},
+		[]int64{10, 20, 30},
+		[]int64{3},
+	)
+	segDFs := []*chain.DataFrame{df}
+
+	task := makeBoostScoreTestTask(t, &planpb.PlanNode{
+		Scorers: []*planpb.ScoreFunction{{Weight: 1}},
+		ScoreOption: &planpb.ScoreOption{
+			BoostMode: planpb.BoostMode_BoostModeMultiply,
+		},
+	})
+
+	require.NoError(t, task.applyBoostScores(segDFs, []segments.Segment{nil}, nil))
+	defer segDFs[0].Release()
+
+	result := segDFs[0]
+	ids := result.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	require.Equal(t, int64(2), ids.Value(0))
+	require.InDelta(t, 2.0, scores.Value(0), 1e-6)
+	require.Equal(t, int64(3), ids.Value(1))
+	require.InDelta(t, 0.9, scores.Value(1), 1e-6)
+	require.Equal(t, int64(1), ids.Value(2))
+	require.InDelta(t, 0.5, scores.Value(2), 1e-6)
+}
+
+func TestApplyBoostScoresMultipleScorersCombinesScoresAndSorts(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	oldFactory := boostScoreRunnerFactory
+	boostScoreRunnerFactory = mockBoostScoreRunnerFactory(
+		boostScoreOutput{scores: []float32{2.0, 0.0, 3.0}, hasScore: []bool{true, false, true}},
+		boostScoreOutput{scores: []float32{4.0, 5.0, 0.0}, hasScore: []bool{true, true, false}},
+	)
+	defer func() { boostScoreRunnerFactory = oldFactory }()
+
+	df := makeBoostScoreTestDF(t,
+		[]int64{1, 2, 3},
+		[]float32{0.5, 0.2, 0.9},
+		[]int64{10, 20, 30},
+		[]int64{3},
+	)
+	segDFs := []*chain.DataFrame{df}
+
+	task := makeBoostScoreTestTask(t, &planpb.PlanNode{
+		Scorers: []*planpb.ScoreFunction{{Weight: 1}, {Weight: 2}},
+		ScoreOption: &planpb.ScoreOption{
+			FunctionMode: planpb.FunctionMode_FunctionModeSum,
+			BoostMode:    planpb.BoostMode_BoostModeSum,
+		},
+	})
+
+	require.NoError(t, task.applyBoostScores(segDFs, []segments.Segment{nil}, nil))
+	defer segDFs[0].Release()
+
+	result := segDFs[0]
+	ids := result.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	require.Nil(t, result.Column(functionScoreColumn))
+	require.Equal(t, int64(1), ids.Value(0))
+	require.InDelta(t, 6.5, scores.Value(0), 1e-6)
+	require.Equal(t, int64(2), ids.Value(1))
+	require.InDelta(t, 5.2, scores.Value(1), 1e-6)
+	require.Equal(t, int64(3), ids.Value(2))
+	require.InDelta(t, 3.9, scores.Value(2), 1e-6)
+}
+
+func TestApplyBoostScoresNoScorersNoop(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	df := makeBoostScoreTestDF(t,
+		[]int64{1},
+		[]float32{0.5},
+		[]int64{10},
+		[]int64{1},
+	)
+	defer df.Release()
+	segDFs := []*chain.DataFrame{df}
+	task := makeBoostScoreTestTask(t, &planpb.PlanNode{})
+
+	require.NoError(t, task.applyBoostScores(segDFs, []segments.Segment{nil}, nil))
+	require.Same(t, df, segDFs[0])
+}
+
+func TestApplyBoostScoresDistanceMetricKeepsInternalScoreDescending(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	oldFactory := boostScoreRunnerFactory
+	boostScoreRunnerFactory = mockBoostScoreRunnerFactory(boostScoreOutput{
+		scores:   []float32{1.0, 1.0, 0.25},
+		hasScore: []bool{true, true, true},
+	})
+	defer func() { boostScoreRunnerFactory = oldFactory }()
+
+	df := makeBoostScoreTestDF(t,
+		[]int64{1, 2, 3},
+		[]float32{0.0, -0.4, -0.8},
+		[]int64{10, 20, 30},
+		[]int64{3},
+	)
+	segDFs := []*chain.DataFrame{df}
+
+	task := makeBoostScoreTestTask(t, &planpb.PlanNode{
+		Node: &planpb.PlanNode_VectorAnns{
+			VectorAnns: &planpb.VectorANNS{
+				QueryInfo: &planpb.QueryInfo{MetricType: metric.L2},
+			},
+		},
+		Scorers: []*planpb.ScoreFunction{{Weight: 1}},
+		ScoreOption: &planpb.ScoreOption{
+			BoostMode: planpb.BoostMode_BoostModeMultiply,
+		},
+	})
+
+	require.NoError(t, task.applyBoostScores(segDFs, []segments.Segment{nil}, nil))
+	defer segDFs[0].Release()
+
+	result := segDFs[0]
+	ids := result.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	require.Equal(t, int64(1), ids.Value(0))
+	require.InDelta(t, 0.0, scores.Value(0), 1e-6)
+	require.Equal(t, int64(3), ids.Value(1))
+	require.InDelta(t, -0.2, scores.Value(1), 1e-6)
+	require.Equal(t, int64(2), ids.Value(2))
+	require.InDelta(t, -0.4, scores.Value(2), 1e-6)
+}
+
+func TestApplyBoostScoresDistanceMetricSumKeepsInternalScoreDescending(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	oldFactory := boostScoreRunnerFactory
+	boostScoreRunnerFactory = mockBoostScoreRunnerFactory(boostScoreOutput{
+		scores:   []float32{0.0, 0.0, 0.7},
+		hasScore: []bool{false, false, true},
+	})
+	defer func() { boostScoreRunnerFactory = oldFactory }()
+
+	df := makeBoostScoreTestDF(t,
+		[]int64{1, 2, 3},
+		[]float32{0.0, -0.4, -0.8},
+		[]int64{10, 20, 30},
+		[]int64{3},
+	)
+	segDFs := []*chain.DataFrame{df}
+
+	task := makeBoostScoreTestTask(t, &planpb.PlanNode{
+		Node: &planpb.PlanNode_VectorAnns{
+			VectorAnns: &planpb.VectorANNS{
+				QueryInfo: &planpb.QueryInfo{MetricType: metric.L2},
+			},
+		},
+		Scorers: []*planpb.ScoreFunction{{Weight: 1}},
+		ScoreOption: &planpb.ScoreOption{
+			BoostMode: planpb.BoostMode_BoostModeSum,
+		},
+	})
+
+	require.NoError(t, task.applyBoostScores(segDFs, []segments.Segment{nil}, nil))
+	defer segDFs[0].Release()
+
+	result := segDFs[0]
+	ids := result.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	require.Equal(t, int64(1), ids.Value(0))
+	require.InDelta(t, 0.0, scores.Value(0), 1e-6)
+	require.Equal(t, int64(3), ids.Value(1))
+	require.InDelta(t, -0.1, scores.Value(1), 1e-6)
+	require.Equal(t, int64(2), ids.Value(2))
+	require.InDelta(t, -0.4, scores.Value(2), 1e-6)
+}
+
+func TestApplyBoostScoresMultipleScorersAllMissKeepOriginalScores(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	oldFactory := boostScoreRunnerFactory
+	boostScoreRunnerFactory = mockBoostScoreRunnerFactory(
+		boostScoreOutput{scores: []float32{0.0, 0.0}, hasScore: []bool{false, false}},
+		boostScoreOutput{scores: []float32{0.0, 0.0}, hasScore: []bool{false, false}},
+	)
+	defer func() { boostScoreRunnerFactory = oldFactory }()
+
+	df := makeBoostScoreTestDF(t,
+		[]int64{1, 2},
+		[]float32{0.3, 0.7},
+		[]int64{10, 20},
+		[]int64{2},
+	)
+	segDFs := []*chain.DataFrame{df}
+
+	task := makeBoostScoreTestTask(t, &planpb.PlanNode{
+		Scorers: []*planpb.ScoreFunction{{Weight: 1}, {Weight: 2}},
+		ScoreOption: &planpb.ScoreOption{
+			FunctionMode: planpb.FunctionMode_FunctionModeSum,
+			BoostMode:    planpb.BoostMode_BoostModeSum,
+		},
+	})
+
+	require.NoError(t, task.applyBoostScores(segDFs, []segments.Segment{nil}, nil))
+	defer segDFs[0].Release()
+
+	result := segDFs[0]
+	ids := result.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	require.Nil(t, result.Column(functionScoreColumn))
+	require.Equal(t, int64(2), ids.Value(0))
+	require.InDelta(t, 0.7, scores.Value(0), 1e-6)
+	require.Equal(t, int64(1), ids.Value(1))
+	require.InDelta(t, 0.3, scores.Value(1), 1e-6)
+}
+
+func TestExtractPlanScorers(t *testing.T) {
+	t.Run("empty plan", func(t *testing.T) {
+		scorers, err := extractPlanScorers(nil)
+		require.NoError(t, err)
+		require.Empty(t, scorers)
+	})
+
+	t.Run("no scorers", func(t *testing.T) {
+		blob, err := proto.Marshal(&planpb.PlanNode{})
+		require.NoError(t, err)
+
+		scorers, err := extractPlanScorers(blob)
+		require.NoError(t, err)
+		require.Empty(t, scorers)
+	})
+
+	t.Run("one scorer", func(t *testing.T) {
+		plan := &planpb.PlanNode{
+			Scorers: []*planpb.ScoreFunction{{Weight: 2.5}},
+		}
+		blob, err := proto.Marshal(plan)
+		require.NoError(t, err)
+
+		scorers, err := extractPlanScorers(blob)
+		require.NoError(t, err)
+		require.Len(t, scorers, 1)
+		require.Equal(t, float32(2.5), scorers[0].GetWeight())
+	})
+
+	t.Run("multiple scorers", func(t *testing.T) {
+		plan := &planpb.PlanNode{
+			Scorers: []*planpb.ScoreFunction{{Weight: 1}, {Weight: 3}},
+		}
+		blob, err := proto.Marshal(plan)
+		require.NoError(t, err)
+
+		scorers, err := extractPlanScorers(blob)
+		require.NoError(t, err)
+		require.Len(t, scorers, 2)
+		require.Equal(t, float32(1), scorers[0].GetWeight())
+		require.Equal(t, float32(3), scorers[1].GetWeight())
+	})
+
+	t.Run("invalid plan", func(t *testing.T) {
+		_, err := extractPlanScorers([]byte{0xff, 0x01})
+		require.Error(t, err)
+	})
+}
+
+func TestApplyBoostScoresUsesAsyncBoostScoreFunc(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	oldFactory := boostScoreRunnerFactory
+	defer func() { boostScoreRunnerFactory = oldFactory }()
+
+	boostScoreRunnerFactory = func(scoreFunc boostScoreFunc, segment segments.Segment, searchReq *segcore.SearchRequest, scorer *planpb.ScoreFunction) expr.BoostScoreRunner {
+		require.Equal(t,
+			reflect.ValueOf(segments.AsyncComputeScorerScoresOnChunkedOffsets).Pointer(),
+			reflect.ValueOf(scoreFunc).Pointer(),
+		)
+		return func(ctx context.Context, offsets *arrow.Chunked) (*arrow.Chunked, error) {
+			return newConstantBoostScoreTestChunked(offsets, 1.0), nil
+		}
+	}
+
+	df := makeBoostScoreTestDF(t, []int64{1}, []float32{0.5}, []int64{10}, []int64{1})
+	segDFs := []*chain.DataFrame{df}
+
+	task := makeBoostScoreTestTask(t, &planpb.PlanNode{
+		Scorers: []*planpb.ScoreFunction{{Weight: 1}},
+		ScoreOption: &planpb.ScoreOption{
+			BoostMode: planpb.BoostMode_BoostModeMultiply,
+		},
+	})
+
+	require.NoError(t, task.applyBoostScores(segDFs, []segments.Segment{nil}, nil))
+	defer segDFs[0].Release()
+}
+
+func TestApplyBoostScoresRunsSegmentsConcurrently(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	oldFactory := boostScoreRunnerFactory
+	defer func() { boostScoreRunnerFactory = oldFactory }()
+
+	var started atomic.Int32
+	var releaseBoth sync.Once
+	bothStarted := make(chan struct{})
+	boostScoreRunnerFactory = func(boostScoreFunc, segments.Segment, *segcore.SearchRequest, *planpb.ScoreFunction) expr.BoostScoreRunner {
+		return func(ctx context.Context, offsets *arrow.Chunked) (*arrow.Chunked, error) {
+			if started.Add(1) == 2 {
+				releaseBoth.Do(func() { close(bothStarted) })
+			}
+
+			select {
+			case <-bothStarted:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+
+			return newConstantBoostScoreTestChunked(offsets, 1.0), nil
+		}
+	}
+
+	df1 := makeBoostScoreTestDF(t, []int64{1}, []float32{0.5}, []int64{10}, []int64{1})
+	df2 := makeBoostScoreTestDF(t, []int64{2}, []float32{0.7}, []int64{20}, []int64{1})
+	segDFs := []*chain.DataFrame{df1, df2}
+
+	task := makeBoostScoreTestTask(t, &planpb.PlanNode{
+		Scorers: []*planpb.ScoreFunction{{Weight: 1}},
+		ScoreOption: &planpb.ScoreOption{
+			BoostMode: planpb.BoostMode_BoostModeMultiply,
+		},
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	task.ctx = ctx
+
+	require.NoError(t, task.applyBoostScores(segDFs, []segments.Segment{nil, nil}, nil))
+	defer segDFs[0].Release()
+	defer segDFs[1].Release()
+	require.Equal(t, int32(2), started.Load())
+}
+
+func TestApplyBoostScoresReleasesBoostedFramesOnError(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	oldFactory := boostScoreRunnerFactory
+	defer func() { boostScoreRunnerFactory = oldFactory }()
+
+	var calls atomic.Int32
+	boostScoreRunnerFactory = func(boostScoreFunc, segments.Segment, *segcore.SearchRequest, *planpb.ScoreFunction) expr.BoostScoreRunner {
+		return func(ctx context.Context, offsets *arrow.Chunked) (*arrow.Chunked, error) {
+			if calls.Add(1) == 1 {
+				return newConstantBoostScoreTestChunked(offsets, 1.0), nil
+			}
+			return nil, errors.New("mock boost failure")
+		}
+	}
+
+	df1 := makeBoostScoreTestDF(t, []int64{1}, []float32{0.5}, []int64{10}, []int64{1})
+	df2 := makeBoostScoreTestDF(t, []int64{2}, []float32{0.7}, []int64{20}, []int64{1})
+	segDFs := []*chain.DataFrame{df1, df2}
+	defer df1.Release()
+	defer df2.Release()
+
+	task := makeBoostScoreTestTask(t, &planpb.PlanNode{
+		Scorers: []*planpb.ScoreFunction{{Weight: 1}},
+		ScoreOption: &planpb.ScoreOption{
+			BoostMode: planpb.BoostMode_BoostModeMultiply,
+		},
+	})
+
+	require.Error(t, task.applyBoostScores(segDFs, []segments.Segment{nil, nil}, nil))
+}
+
+func TestBoostScoreModeConversions(t *testing.T) {
+	functionMode, err := functionModeToScoreCombineMode(planpb.FunctionMode_FunctionModeMultiply)
+	require.NoError(t, err)
+	require.Equal(t, expr.ModeMultiply, functionMode)
+
+	functionMode, err = functionModeToScoreCombineMode(planpb.FunctionMode_FunctionModeSum)
+	require.NoError(t, err)
+	require.Equal(t, expr.ModeSum, functionMode)
+
+	_, err = functionModeToScoreCombineMode(planpb.FunctionMode(999))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown function mode")
+
+	boostMode, err := boostModeToScoreCombineMode(planpb.BoostMode_BoostModeMultiply)
+	require.NoError(t, err)
+	require.Equal(t, expr.ModeMultiply, boostMode)
+
+	boostMode, err = boostModeToScoreCombineMode(planpb.BoostMode_BoostModeSum)
+	require.NoError(t, err)
+	require.Equal(t, expr.ModeSum, boostMode)
+
+	_, err = boostModeToScoreCombineMode(planpb.BoostMode(999))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown boost mode")
+}
+
+func TestApplyBoostScoresValidationErrors(t *testing.T) {
+	t.Run("segment count mismatch", func(t *testing.T) {
+		task := &SearchTask{}
+		err := task.applyBoostScores(nil, []segments.Segment{nil}, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not match segment count")
+	})
+
+	t.Run("invalid serialized plan", func(t *testing.T) {
+		task := &SearchTask{
+			req: &querypb.SearchRequest{
+				Req: &internalpb.SearchRequest{SerializedExprPlan: []byte{0xff, 0x01}},
+			},
+		}
+		err := task.applyBoostScores(nil, nil, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse search plan scorers")
+	})
+
+	t.Run("invalid function mode", func(t *testing.T) {
+		withBoostScoreCheckedAllocator(t)
+		df := makeBoostScoreTestDF(t, []int64{1}, []float32{0.5}, []int64{10}, []int64{1})
+		defer df.Release()
+
+		task := makeBoostScoreTestTask(t, &planpb.PlanNode{
+			Scorers: []*planpb.ScoreFunction{{Weight: 1}},
+			ScoreOption: &planpb.ScoreOption{
+				FunctionMode: planpb.FunctionMode(999),
+				BoostMode:    planpb.BoostMode_BoostModeMultiply,
+			},
+		})
+		err := task.applyBoostScores([]*chain.DataFrame{df}, []segments.Segment{nil}, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown function mode")
+	})
+
+	t.Run("invalid boost mode", func(t *testing.T) {
+		withBoostScoreCheckedAllocator(t)
+		df := makeBoostScoreTestDF(t, []int64{1}, []float32{0.5}, []int64{10}, []int64{1})
+		defer df.Release()
+
+		task := makeBoostScoreTestTask(t, &planpb.PlanNode{
+			Scorers: []*planpb.ScoreFunction{{Weight: 1}},
+			ScoreOption: &planpb.ScoreOption{
+				FunctionMode: planpb.FunctionMode_FunctionModeSum,
+				BoostMode:    planpb.BoostMode(999),
+			},
+		})
+		err := task.applyBoostScores([]*chain.DataFrame{df}, []segments.Segment{nil}, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown boost mode")
+	})
+
+	t.Run("nil dataframe", func(t *testing.T) {
+		task := makeBoostScoreTestTask(t, &planpb.PlanNode{
+			Scorers: []*planpb.ScoreFunction{{Weight: 1}},
+			ScoreOption: &planpb.ScoreOption{
+				BoostMode: planpb.BoostMode_BoostModeMultiply,
+			},
+		})
+		err := task.applyBoostScores([]*chain.DataFrame{nil}, []segments.Segment{nil}, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "DataFrame 0 is nil")
+	})
+}
+
+func TestBuildBoostScoreChainPropagatesBuilderErrors(t *testing.T) {
+	withBoostScoreCheckedAllocator(t)
+
+	df := makeBoostScoreTestDF(t, []int64{1}, []float32{0.5}, []int64{10}, []int64{1})
+	defer df.Release()
+
+	oldFactory := boostScoreRunnerFactory
+	boostScoreRunnerFactory = func(boostScoreFunc, segments.Segment, *segcore.SearchRequest, *planpb.ScoreFunction) expr.BoostScoreRunner {
+		return nil
+	}
+	defer func() { boostScoreRunnerFactory = oldFactory }()
+
+	_, err := buildBoostScoreChain(
+		df,
+		nil,
+		nil,
+		[]*planpb.ScoreFunction{{Weight: 1}},
+		segments.ComputeScorerScoresOnChunkedOffsets,
+		expr.ModeSum,
+		expr.ModeMultiply,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "runner is nil")
+
+	chainWithBadFunctionMode := chain.NewFuncChainWithAllocator(defaultAllocator)
+	_, err = appendFunctionScoreColumn(chainWithBadFunctionMode, []string{boostScoreColumn(0), boostScoreColumn(1)}, "bad-mode")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid mode")
+
+	chainWithBadBoostMode := chain.NewFuncChainWithAllocator(defaultAllocator)
+	err = appendFinalBoostScore(chainWithBadBoostMode, boostScoreColumn(0), "bad-mode")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid mode")
+}

--- a/internal/querynodev2/tasks/search_task.go
+++ b/internal/querynodev2/tasks/search_task.go
@@ -291,7 +291,9 @@ func (t *SearchTask) Execute() error {
 		}
 	}()
 
-	// TODO: if L0 rerank is configured, run rerank chain on segDFs here
+	if err := t.applyBoostScores(segDFs, searchedSegments, searchReq); err != nil {
+		return err
+	}
 
 	if err := t.executeGoReduce(segDFs, results, searchReq, metricType, tr, relatedDataSize, allSearchCount); err != nil {
 		return err

--- a/internal/util/function/chain/expr/boost_score_expr.go
+++ b/internal/util/function/chain/expr/boost_score_expr.go
@@ -1,0 +1,100 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * # or implied. See the License for the specific language governing
+ * # permissions and limitations under the License.
+ */
+
+package expr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/arrow/go/v17/arrow"
+
+	"github.com/milvus-io/milvus/internal/util/function/chain/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+const BoostScoreFuncName = "boost_score"
+
+type BoostScoreRunner func(ctx context.Context, offsets *arrow.Chunked) (*arrow.Chunked, error)
+
+type BoostScoreExpr struct {
+	BaseExpr
+	runner BoostScoreRunner
+}
+
+func NewBoostScoreExpr(runner BoostScoreRunner) (*BoostScoreExpr, error) {
+	if runner == nil {
+		return nil, merr.WrapErrParameterInvalidMsg("boost_score: runner is nil")
+	}
+	return &BoostScoreExpr{
+		BaseExpr: *NewBaseExpr(BoostScoreFuncName, []string{types.StageL0Rerank}),
+		runner:   runner,
+	}, nil
+}
+
+func (e *BoostScoreExpr) OutputDataTypes() []arrow.DataType {
+	return []arrow.DataType{arrow.PrimitiveTypes.Float32}
+}
+
+func (e *BoostScoreExpr) Execute(ctx *types.FuncContext, inputs []*arrow.Chunked) ([]*arrow.Chunked, error) {
+	if len(inputs) != 1 {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("boost_score: expected 1 input column, got %d", len(inputs)))
+	}
+	if e.runner == nil {
+		return nil, merr.WrapErrServiceInternal("boost_score: runner is nil")
+	}
+
+	offsets := inputs[0]
+	if offsets == nil {
+		return nil, merr.WrapErrServiceInternal("boost_score: offset column is nil")
+	}
+	if offsets.DataType().ID() != arrow.INT64 {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("boost_score: offset column must be Int64, got %s", offsets.DataType()))
+	}
+
+	scores, err := e.runner(ctx.Context(), offsets)
+	if err != nil {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf("boost_score: %v", err))
+	}
+	if err := validateBoostScoreOutput(offsets, scores); err != nil {
+		if scores != nil {
+			scores.Release()
+		}
+		return nil, err
+	}
+
+	return []*arrow.Chunked{scores}, nil
+}
+
+func validateBoostScoreOutput(offsets, scores *arrow.Chunked) error {
+	if scores == nil {
+		return merr.WrapErrServiceInternal("boost_score: runner returned nil scores")
+	}
+	if scores.DataType().ID() != arrow.FLOAT32 {
+		return merr.WrapErrServiceInternal(fmt.Sprintf("boost_score: score column must be Float32, got %s", scores.DataType()))
+	}
+	if len(scores.Chunks()) != len(offsets.Chunks()) {
+		return merr.WrapErrServiceInternal(fmt.Sprintf("boost_score: score chunks %d does not match offset chunks %d", len(scores.Chunks()), len(offsets.Chunks())))
+	}
+	for i := range offsets.Chunks() {
+		if scores.Chunk(i).Len() != offsets.Chunk(i).Len() {
+			return merr.WrapErrServiceInternal(fmt.Sprintf("boost_score: score chunk %d length %d does not match offset chunk length %d", i, scores.Chunk(i).Len(), offsets.Chunk(i).Len()))
+		}
+	}
+	return nil
+}

--- a/internal/util/function/chain/expr/boost_score_expr_test.go
+++ b/internal/util/function/chain/expr/boost_score_expr_test.go
@@ -1,0 +1,246 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * # or implied. See the License for the specific language governing
+ * # permissions and limitations under the License.
+ */
+
+package expr
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus/internal/util/function/chain/types"
+)
+
+type BoostScoreExprTestSuite struct {
+	suite.Suite
+	pool *memory.CheckedAllocator
+}
+
+func (s *BoostScoreExprTestSuite) SetupTest() {
+	s.pool = memory.NewCheckedAllocator(memory.NewGoAllocator())
+}
+
+func (s *BoostScoreExprTestSuite) TearDownTest() {
+	s.pool.AssertSize(s.T(), 0)
+}
+
+func TestBoostScoreExprTestSuite(t *testing.T) {
+	suite.Run(t, new(BoostScoreExprTestSuite))
+}
+
+func (s *BoostScoreExprTestSuite) createOffsetColumn(chunks ...[]int64) *arrow.Chunked {
+	arrays := make([]arrow.Array, 0, len(chunks))
+	for _, values := range chunks {
+		builder := array.NewInt64Builder(s.pool)
+		builder.AppendValues(values, nil)
+		arr := builder.NewArray()
+		builder.Release()
+		arrays = append(arrays, arr)
+	}
+	chunked := arrow.NewChunked(arrow.PrimitiveTypes.Int64, arrays)
+	for _, arr := range arrays {
+		arr.Release()
+	}
+	return chunked
+}
+
+func (s *BoostScoreExprTestSuite) createScoreColumn(values [][]float32, valid [][]bool) *arrow.Chunked {
+	arrays := make([]arrow.Array, 0, len(values))
+	for chunkIdx, chunkValues := range values {
+		builder := array.NewFloat32Builder(s.pool)
+		for rowIdx, value := range chunkValues {
+			if valid != nil && !valid[chunkIdx][rowIdx] {
+				builder.AppendNull()
+			} else {
+				builder.Append(value)
+			}
+		}
+		arr := builder.NewArray()
+		builder.Release()
+		arrays = append(arrays, arr)
+	}
+	chunked := arrow.NewChunked(arrow.PrimitiveTypes.Float32, arrays)
+	for _, arr := range arrays {
+		arr.Release()
+	}
+	return chunked
+}
+
+func (s *BoostScoreExprTestSuite) TestNewBoostScoreExpr() {
+	runner := func(context.Context, *arrow.Chunked) (*arrow.Chunked, error) {
+		return nil, nil
+	}
+	expr, err := NewBoostScoreExpr(runner)
+	s.Require().NoError(err)
+	s.Equal(BoostScoreFuncName, expr.Name())
+	s.Equal([]arrow.DataType{arrow.PrimitiveTypes.Float32}, expr.OutputDataTypes())
+	s.True(expr.IsRunnable(types.StageL0Rerank))
+	s.False(expr.IsRunnable(types.StageL2Rerank))
+
+	_, err = NewBoostScoreExpr(nil)
+	s.Error(err)
+	s.Contains(err.Error(), "runner is nil")
+}
+
+func (s *BoostScoreExprTestSuite) TestExecutePassesChunkedOffsets() {
+	offsets := s.createOffsetColumn([]int64{10, 20}, []int64{30, 40, 50})
+	defer offsets.Release()
+
+	called := false
+	expr, err := NewBoostScoreExpr(func(ctx context.Context, got *arrow.Chunked) (*arrow.Chunked, error) {
+		called = true
+		s.Equal(context.TODO(), ctx)
+		s.Same(offsets, got)
+		return s.createScoreColumn(
+			[][]float32{{1.5, 0}, {2.5, 3.5, 0}},
+			[][]bool{{true, false}, {true, true, false}},
+		), nil
+	})
+	s.Require().NoError(err)
+
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, types.StageL0Rerank)
+	outputs, err := expr.Execute(ctx, []*arrow.Chunked{offsets})
+	s.Require().NoError(err)
+	defer outputs[0].Release()
+
+	s.True(called)
+	s.Len(outputs, 1)
+	s.Equal(2, len(outputs[0].Chunks()))
+	s.Equal(2, outputs[0].Chunk(0).Len())
+	s.Equal(3, outputs[0].Chunk(1).Len())
+
+	chunk0 := outputs[0].Chunk(0).(*array.Float32)
+	chunk1 := outputs[0].Chunk(1).(*array.Float32)
+	s.InDelta(1.5, float64(chunk0.Value(0)), 1e-6)
+	s.True(chunk0.IsNull(1))
+	s.InDelta(2.5, float64(chunk1.Value(0)), 1e-6)
+	s.InDelta(3.5, float64(chunk1.Value(1)), 1e-6)
+	s.True(chunk1.IsNull(2))
+}
+
+func (s *BoostScoreExprTestSuite) TestExecuteRejectsInvalidInputs() {
+	expr, err := NewBoostScoreExpr(func(context.Context, *arrow.Chunked) (*arrow.Chunked, error) {
+		return nil, nil
+	})
+	s.Require().NoError(err)
+	ctx := types.NewFuncContextFull(context.Background(), s.pool, types.StageL0Rerank)
+
+	_, err = expr.Execute(ctx, nil)
+	s.Error(err)
+	s.Contains(err.Error(), "expected 1 input")
+
+	builder := array.NewInt32Builder(s.pool)
+	builder.Append(1)
+	arr := builder.NewArray()
+	builder.Release()
+	wrongType := arrow.NewChunked(arrow.PrimitiveTypes.Int32, []arrow.Array{arr})
+	arr.Release()
+	defer wrongType.Release()
+
+	_, err = expr.Execute(ctx, []*arrow.Chunked{wrongType})
+	s.Error(err)
+	s.Contains(err.Error(), "must be Int64")
+
+	_, err = expr.Execute(ctx, []*arrow.Chunked{nil})
+	s.Error(err)
+	s.Contains(err.Error(), "offset column is nil")
+
+	expr.runner = nil
+	_, err = expr.Execute(ctx, []*arrow.Chunked{wrongType})
+	s.Error(err)
+	s.Contains(err.Error(), "runner is nil")
+}
+
+func (s *BoostScoreExprTestSuite) TestExecuteRunnerError() {
+	offsets := s.createOffsetColumn([]int64{10})
+	defer offsets.Release()
+
+	expr, err := NewBoostScoreExpr(func(context.Context, *arrow.Chunked) (*arrow.Chunked, error) {
+		return nil, fmt.Errorf("runner failed")
+	})
+	s.Require().NoError(err)
+
+	ctx := types.NewFuncContextFull(context.Background(), s.pool, types.StageL0Rerank)
+	_, err = expr.Execute(ctx, []*arrow.Chunked{offsets})
+	s.Error(err)
+	s.Contains(err.Error(), "runner failed")
+}
+
+func (s *BoostScoreExprTestSuite) TestExecuteRejectsInvalidRunnerOutput() {
+	offsets := s.createOffsetColumn([]int64{10, 20}, []int64{30})
+	defer offsets.Release()
+	ctx := types.NewFuncContextFull(context.Background(), s.pool, types.StageL0Rerank)
+
+	cases := []struct {
+		name    string
+		scores  func() *arrow.Chunked
+		message string
+	}{
+		{
+			name: "nil scores",
+			scores: func() *arrow.Chunked {
+				return nil
+			},
+			message: "nil scores",
+		},
+		{
+			name: "wrong type",
+			scores: func() *arrow.Chunked {
+				builder := array.NewFloat64Builder(s.pool)
+				builder.Append(1)
+				arr := builder.NewArray()
+				builder.Release()
+				chunked := arrow.NewChunked(arrow.PrimitiveTypes.Float64, []arrow.Array{arr})
+				arr.Release()
+				return chunked
+			},
+			message: "must be Float32",
+		},
+		{
+			name: "chunk count mismatch",
+			scores: func() *arrow.Chunked {
+				return s.createScoreColumn([][]float32{{1, 2, 3}}, nil)
+			},
+			message: "score chunks",
+		},
+		{
+			name: "chunk length mismatch",
+			scores: func() *arrow.Chunked {
+				return s.createScoreColumn([][]float32{{1}, {2}}, nil)
+			},
+			message: "length",
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			expr, err := NewBoostScoreExpr(func(context.Context, *arrow.Chunked) (*arrow.Chunked, error) {
+				return tc.scores(), nil
+			})
+			s.Require().NoError(err)
+			_, err = expr.Execute(ctx, []*arrow.Chunked{offsets})
+			s.Error(err)
+			s.Contains(err.Error(), tc.message)
+		})
+	}
+}

--- a/internal/util/function/chain/expr/decay_expr_integration_test.go
+++ b/internal/util/function/chain/expr/decay_expr_integration_test.go
@@ -21,6 +21,7 @@ package expr_test
 import (
 	"testing"
 
+	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/suite"
 
@@ -169,6 +170,60 @@ func (s *DecayExprIntegrationTestSuite) TestIntegration_ChainWithDecay() {
 
 	// Should have 3 results per chunk
 	s.Equal([]int64{3, 3}, result.ChunkSizes())
+}
+
+func (s *DecayExprIntegrationTestSuite) TestIntegration_NullDecayFactorTreatedAsZero() {
+	fieldData := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "distance",
+		FieldId:   100,
+		ValidData: []bool{true, false},
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{
+						Data: []int64{100, 0},
+					},
+				},
+			},
+		},
+	}
+	resultData := &schemapb.SearchResultData{
+		NumQueries: 1,
+		TopK:       2,
+		Topks:      []int64{2},
+		Scores:     []float32{1.0, 0.8},
+		Ids: &schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{
+				IntId: &schemapb.LongArray{
+					Data: []int64{1, 2},
+				},
+			},
+		},
+		FieldsData: []*schemapb.FieldData{fieldData},
+	}
+	df, err := chain.FromSearchResultData(resultData, s.pool, []string{"distance"})
+	s.Require().NoError(err)
+	defer df.Release()
+
+	decayExpr, err := expr.NewDecayExpr(expr.GaussFunction, 100, 50, 0, 0.5)
+	s.Require().NoError(err)
+	combineExpr, err := expr.NewScoreCombineExpr(expr.ModeMultiply, nil, expr.WithNullPolicy(expr.ScoreCombineNullAsZero))
+	s.Require().NoError(err)
+
+	result, err := chain.NewFuncChainWithAllocator(s.pool).
+		SetStage(types.StageL2Rerank).
+		Map(decayExpr, []string{"distance"}, []string{"_decay_score"}).
+		Map(combineExpr, []string{types.ScoreFieldName, "_decay_score"}, []string{types.ScoreFieldName}).
+		Execute(df)
+	s.Require().NoError(err)
+	defer result.Release()
+
+	scores := result.Column(types.ScoreFieldName).Chunk(0).(*array.Float32)
+	s.False(scores.IsNull(0))
+	s.InDelta(1.0, scores.Value(0), 0.001)
+	s.False(scores.IsNull(1))
+	s.InDelta(0.0, scores.Value(1), 0.001)
 }
 
 func (s *DecayExprIntegrationTestSuite) TestIntegration_ParseFromJSON() {

--- a/internal/util/function/chain/expr/score_combine_expr.go
+++ b/internal/util/function/chain/expr/score_combine_expr.go
@@ -59,10 +59,30 @@ const (
 //
 // Outputs:
 //   - outputs[0]: combined score column
+type ScoreCombineNullPolicy int
+
+const (
+	// ScoreCombineNullPropagate returns null if any input is null.
+	ScoreCombineNullPropagate ScoreCombineNullPolicy = iota
+	// ScoreCombineNullAsZero treats null inputs as zero.
+	ScoreCombineNullAsZero
+	// ScoreCombineNullSkip skips null inputs and returns null if all inputs are null.
+	ScoreCombineNullSkip
+)
+
 type ScoreCombineExpr struct {
 	BaseExpr
-	mode    string    // combine mode: multiply, sum, max, min, avg, weighted
-	weights []float64 // weights for weighted mode
+	mode       string                 // combine mode: multiply, sum, max, min, avg, weighted
+	weights    []float64              // weights for weighted mode
+	nullPolicy ScoreCombineNullPolicy // null handling policy
+}
+
+type ScoreCombineOption func(*ScoreCombineExpr)
+
+func WithNullPolicy(policy ScoreCombineNullPolicy) ScoreCombineOption {
+	return func(s *ScoreCombineExpr) {
+		s.nullPolicy = policy
+	}
 }
 
 // =============================================================================
@@ -72,7 +92,7 @@ type ScoreCombineExpr struct {
 // NewScoreCombineExpr creates a new ScoreCombineExpr with the given parameters.
 // Note: Column mapping (which columns to use as input/output) is handled by MapOp,
 // not by the function itself.
-func NewScoreCombineExpr(mode string, weights []float64) (*ScoreCombineExpr, error) {
+func NewScoreCombineExpr(mode string, weights []float64, opts ...ScoreCombineOption) (*ScoreCombineExpr, error) {
 	// Default mode
 	if mode == "" {
 		mode = ModeMultiply
@@ -98,11 +118,16 @@ func NewScoreCombineExpr(mode string, weights []float64) (*ScoreCombineExpr, err
 	}
 
 	// nil supportStages means the function supports all stages
-	return &ScoreCombineExpr{
-		BaseExpr: *NewBaseExpr("score_combine", nil),
-		mode:     mode,
-		weights:  weights,
-	}, nil
+	expr := &ScoreCombineExpr{
+		BaseExpr:   *NewBaseExpr("score_combine", nil),
+		mode:       mode,
+		weights:    weights,
+		nullPolicy: ScoreCombineNullPropagate,
+	}
+	for _, opt := range opts {
+		opt(expr)
+	}
+	return expr, nil
 }
 
 // NewScoreCombineExprFromParams creates a ScoreCombineExpr from a parameter map.
@@ -190,42 +215,113 @@ func (s *ScoreCombineExpr) processChunk(ctx *types.FuncContext, inputs []*arrow.
 	defer builder.Release()
 
 	chunkLen := inputs[0].Chunk(chunkIdx).Len()
-
-	for rowIdx := 0; rowIdx < chunkLen; rowIdx++ {
-		// Check if any input is null
-		hasNull := false
-		for _, input := range inputs {
-			if input.Chunk(chunkIdx).IsNull(rowIdx) {
-				hasNull = true
-				break
-			}
+	readers := make([]numericReader, len(inputs))
+	for colIdx, input := range inputs {
+		chunk := input.Chunk(chunkIdx)
+		if chunk.Len() != chunkLen {
+			return nil, merr.WrapErrServiceInternalMsg("score_combine: input 0 chunk %d has %d rows but input %d has %d rows", chunkIdx, chunkLen, colIdx, chunk.Len())
 		}
-
-		if hasNull {
-			builder.AppendNull()
-			continue
+		reader, ok := newNumericReader(chunk)
+		if !ok {
+			return nil, merr.WrapErrServiceInternalMsg("score_combine: column %d: unsupported input column type %T, expected numeric type", colIdx, chunk)
 		}
-
-		// Collect values from all input columns using base_expr utility
-		values := make([]float64, len(inputs))
-		for colIdx, input := range inputs {
-			val, err := GetNumericValue(input.Chunk(chunkIdx), rowIdx)
-			if err != nil {
-				return nil, merr.WrapErrServiceInternalMsg("score_combine: column %d: %v", colIdx, err)
-			}
-			values[colIdx] = val
-		}
-
-		// Combine values based on mode
-		result := s.combine(values)
-		builder.Append(float32(result))
+		readers[colIdx] = reader
 	}
+
+	s.processRows(builder, readers, chunkLen)
 
 	return builder.NewArray(), nil
 }
 
+func (s *ScoreCombineExpr) processRows(builder *array.Float32Builder, readers []numericReader, chunkLen int) {
+	values := make([]float64, 0, len(readers))
+	weights := make([]float64, 0, len(readers))
+	for rowIdx := 0; rowIdx < chunkLen; rowIdx++ {
+		rowValues, rowWeights, ok := s.collectRowValues(readers, rowIdx, values, weights)
+		if !ok {
+			builder.AppendNull()
+			continue
+		}
+		builder.Append(float32(s.combine(rowValues, rowWeights)))
+	}
+}
+
+func (s *ScoreCombineExpr) collectRowValues(readers []numericReader, rowIdx int, values []float64, weights []float64) ([]float64, []float64, bool) {
+	values = values[:0]
+	weights = weights[:0]
+	for idx, reader := range readers {
+		if reader.IsNull(rowIdx) {
+			switch s.nullPolicy {
+			case ScoreCombineNullPropagate:
+				return values, weights, false
+			case ScoreCombineNullAsZero:
+				values = append(values, 0)
+				if s.mode == ModeWeighted {
+					weights = append(weights, s.weights[idx])
+				}
+			case ScoreCombineNullSkip:
+				continue
+			default:
+				return values, weights, false
+			}
+			continue
+		}
+
+		values = append(values, reader.Float64(rowIdx))
+		if s.mode == ModeWeighted {
+			weights = append(weights, s.weights[idx])
+		}
+	}
+	return values, weights, len(values) > 0
+}
+
+type numericReader interface {
+	IsNull(int) bool
+	Float64(int) float64
+}
+
+type numericValue interface {
+	~int8 | ~int16 | ~int32 | ~int64 | ~float32 | ~float64
+}
+
+type arrowNumericArray[T numericValue] interface {
+	IsNull(int) bool
+	Value(int) T
+}
+
+type typedNumericReader[T numericValue, A arrowNumericArray[T]] struct {
+	arr A
+}
+
+func (r typedNumericReader[T, A]) IsNull(idx int) bool {
+	return r.arr.IsNull(idx)
+}
+
+func (r typedNumericReader[T, A]) Float64(idx int) float64 {
+	return float64(r.arr.Value(idx))
+}
+
+func newNumericReader(arr arrow.Array) (numericReader, bool) {
+	switch a := arr.(type) {
+	case *array.Int8:
+		return typedNumericReader[int8, *array.Int8]{arr: a}, true
+	case *array.Int16:
+		return typedNumericReader[int16, *array.Int16]{arr: a}, true
+	case *array.Int32:
+		return typedNumericReader[int32, *array.Int32]{arr: a}, true
+	case *array.Int64:
+		return typedNumericReader[int64, *array.Int64]{arr: a}, true
+	case *array.Float32:
+		return typedNumericReader[float32, *array.Float32]{arr: a}, true
+	case *array.Float64:
+		return typedNumericReader[float64, *array.Float64]{arr: a}, true
+	default:
+		return nil, false
+	}
+}
+
 // combine combines multiple values based on the mode.
-func (s *ScoreCombineExpr) combine(values []float64) float64 {
+func (s *ScoreCombineExpr) combine(values []float64, weights []float64) float64 {
 	switch s.mode {
 	case ModeMultiply:
 		result := 1.0
@@ -265,7 +361,7 @@ func (s *ScoreCombineExpr) combine(values []float64) float64 {
 	case ModeWeighted:
 		sum := 0.0
 		for i, v := range values {
-			sum += v * s.weights[i]
+			sum += v * weights[i]
 		}
 		return sum
 

--- a/internal/util/function/chain/expr/score_combine_expr_test.go
+++ b/internal/util/function/chain/expr/score_combine_expr_test.go
@@ -69,6 +69,25 @@ func (s *ScoreCombineExprTestSuite) createFloat32ChunkedArray(values []float32) 
 	return chunked
 }
 
+func (s *ScoreCombineExprTestSuite) createNullableFloat32ChunkedArray(values []float32, valid []bool) *arrow.Chunked {
+	builder := array.NewFloat32Builder(s.pool)
+	defer builder.Release()
+
+	for i, v := range values {
+		if valid[i] {
+			builder.Append(v)
+		} else {
+			builder.AppendNull()
+		}
+	}
+
+	arr := builder.NewArray()
+	chunked := arrow.NewChunked(arrow.PrimitiveTypes.Float32, []arrow.Array{arr})
+	arr.Release()
+
+	return chunked
+}
+
 func (s *ScoreCombineExprTestSuite) createMultiChunkFloat32Array(chunk1, chunk2 []float32) *arrow.Chunked {
 	builder1 := array.NewFloat32Builder(s.pool)
 	defer builder1.Release()
@@ -314,6 +333,133 @@ func (s *ScoreCombineExprTestSuite) TestExecute_Weighted() {
 	s.InDelta(24.6, result.Value(2), 0.001)
 }
 
+func (s *ScoreCombineExprTestSuite) TestExecute_PropagatesNullInputsByDefault() {
+	col1 := s.createNullableFloat32ChunkedArray([]float32{2.0, 0.0, 0.0}, []bool{true, false, false})
+	defer col1.Release()
+	col2 := s.createNullableFloat32ChunkedArray([]float32{3.0, 4.0, 0.0}, []bool{true, true, false})
+	defer col2.Release()
+
+	expr, err := NewScoreCombineExpr(ModeSum, nil)
+	s.Require().NoError(err)
+
+	ctx := types.NewFuncContext(s.pool)
+	outputs, err := expr.Execute(ctx, []*arrow.Chunked{col1, col2})
+	s.Require().NoError(err)
+	defer outputs[0].Release()
+
+	result := outputs[0].Chunk(0).(*array.Float32)
+	s.False(result.IsNull(0))
+	s.InDelta(5.0, result.Value(0), 0.001)
+	s.True(result.IsNull(1))
+	s.True(result.IsNull(2))
+}
+
+func (s *ScoreCombineExprTestSuite) TestExecute_TreatsNullInputsAsZero() {
+	col1 := s.createNullableFloat32ChunkedArray([]float32{2.0, 0.0, 0.0}, []bool{true, false, false})
+	defer col1.Release()
+	col2 := s.createNullableFloat32ChunkedArray([]float32{3.0, 4.0, 0.0}, []bool{true, true, false})
+	defer col2.Release()
+	col3 := s.createNullableFloat32ChunkedArray([]float32{0.0, 5.0, 0.0}, []bool{false, true, false})
+	defer col3.Release()
+
+	expr, err := NewScoreCombineExpr(ModeSum, nil, WithNullPolicy(ScoreCombineNullAsZero))
+	s.Require().NoError(err)
+
+	ctx := types.NewFuncContext(s.pool)
+	outputs, err := expr.Execute(ctx, []*arrow.Chunked{col1, col2, col3})
+	s.Require().NoError(err)
+	defer outputs[0].Release()
+
+	result := outputs[0].Chunk(0).(*array.Float32)
+	s.False(result.IsNull(0))
+	s.InDelta(5.0, result.Value(0), 0.001)
+	s.False(result.IsNull(1))
+	s.InDelta(9.0, result.Value(1), 0.001)
+	s.False(result.IsNull(2))
+	s.InDelta(0.0, result.Value(2), 0.001)
+}
+
+func (s *ScoreCombineExprTestSuite) TestExecute_TreatsNullInputsAsZeroWeighted() {
+	col1 := s.createNullableFloat32ChunkedArray([]float32{10.0, 0.0}, []bool{true, false})
+	defer col1.Release()
+	col2 := s.createNullableFloat32ChunkedArray([]float32{0.0, 20.0}, []bool{false, true})
+	defer col2.Release()
+
+	expr, err := NewScoreCombineExpr(ModeWeighted, []float64{0.8, 0.2}, WithNullPolicy(ScoreCombineNullAsZero))
+	s.Require().NoError(err)
+
+	ctx := types.NewFuncContext(s.pool)
+	outputs, err := expr.Execute(ctx, []*arrow.Chunked{col1, col2})
+	s.Require().NoError(err)
+	defer outputs[0].Release()
+
+	result := outputs[0].Chunk(0).(*array.Float32)
+	s.InDelta(8.0, result.Value(0), 0.001)
+	s.InDelta(4.0, result.Value(1), 0.001)
+}
+
+func (s *ScoreCombineExprTestSuite) TestExecute_SkipsNullInputs() {
+	col1 := s.createNullableFloat32ChunkedArray([]float32{2.0, 0.0, 0.0}, []bool{true, false, false})
+	defer col1.Release()
+	col2 := s.createNullableFloat32ChunkedArray([]float32{3.0, 4.0, 0.0}, []bool{true, true, false})
+	defer col2.Release()
+	col3 := s.createNullableFloat32ChunkedArray([]float32{0.0, 5.0, 0.0}, []bool{false, true, false})
+	defer col3.Release()
+
+	expr, err := NewScoreCombineExpr(ModeSum, nil, WithNullPolicy(ScoreCombineNullSkip))
+	s.Require().NoError(err)
+
+	ctx := types.NewFuncContext(s.pool)
+	outputs, err := expr.Execute(ctx, []*arrow.Chunked{col1, col2, col3})
+	s.Require().NoError(err)
+	defer outputs[0].Release()
+
+	result := outputs[0].Chunk(0).(*array.Float32)
+	s.False(result.IsNull(0))
+	s.InDelta(5.0, result.Value(0), 0.001)
+	s.False(result.IsNull(1))
+	s.InDelta(9.0, result.Value(1), 0.001)
+	s.True(result.IsNull(2))
+}
+
+func (s *ScoreCombineExprTestSuite) TestExecute_SkipsNullInputsMultiply() {
+	col1 := s.createNullableFloat32ChunkedArray([]float32{2.0, 0.0}, []bool{true, false})
+	defer col1.Release()
+	col2 := s.createNullableFloat32ChunkedArray([]float32{3.0, 3.0}, []bool{true, true})
+	defer col2.Release()
+
+	expr, err := NewScoreCombineExpr(ModeMultiply, nil, WithNullPolicy(ScoreCombineNullSkip))
+	s.Require().NoError(err)
+
+	ctx := types.NewFuncContext(s.pool)
+	outputs, err := expr.Execute(ctx, []*arrow.Chunked{col1, col2})
+	s.Require().NoError(err)
+	defer outputs[0].Release()
+
+	result := outputs[0].Chunk(0).(*array.Float32)
+	s.InDelta(6.0, result.Value(0), 0.001)
+	s.InDelta(3.0, result.Value(1), 0.001)
+}
+
+func (s *ScoreCombineExprTestSuite) TestExecute_TreatsNullInputsAsZeroMultiply() {
+	col1 := s.createNullableFloat32ChunkedArray([]float32{2.0, 0.0}, []bool{true, false})
+	defer col1.Release()
+	col2 := s.createNullableFloat32ChunkedArray([]float32{3.0, 3.0}, []bool{true, true})
+	defer col2.Release()
+
+	expr, err := NewScoreCombineExpr(ModeMultiply, nil, WithNullPolicy(ScoreCombineNullAsZero))
+	s.Require().NoError(err)
+
+	ctx := types.NewFuncContext(s.pool)
+	outputs, err := expr.Execute(ctx, []*arrow.Chunked{col1, col2})
+	s.Require().NoError(err)
+	defer outputs[0].Release()
+
+	result := outputs[0].Chunk(0).(*array.Float32)
+	s.InDelta(6.0, result.Value(0), 0.001)
+	s.InDelta(0.0, result.Value(1), 0.001)
+}
+
 func (s *ScoreCombineExprTestSuite) TestExecute_MultipleChunks() {
 	col1 := s.createMultiChunkFloat32Array([]float32{1.0, 2.0}, []float32{3.0, 4.0})
 	defer col1.Release()
@@ -450,40 +596,37 @@ func (s *ScoreCombineExprTestSuite) TestMemoryLeak_ScoreCombineExecution() {
 
 func (s *ScoreCombineExprTestSuite) TestCombine_Multiply() {
 	expr := &ScoreCombineExpr{mode: ModeMultiply}
-	result := expr.combine([]float64{2.0, 3.0, 4.0})
+	result := expr.combine([]float64{2.0, 3.0, 4.0}, nil)
 	s.InDelta(24.0, result, 0.001) // 2*3*4 = 24
 }
 
 func (s *ScoreCombineExprTestSuite) TestCombine_Sum() {
 	expr := &ScoreCombineExpr{mode: ModeSum}
-	result := expr.combine([]float64{1.0, 2.0, 3.0})
+	result := expr.combine([]float64{1.0, 2.0, 3.0}, nil)
 	s.InDelta(6.0, result, 0.001) // 1+2+3 = 6
 }
 
 func (s *ScoreCombineExprTestSuite) TestCombine_Max() {
 	expr := &ScoreCombineExpr{mode: ModeMax}
-	result := expr.combine([]float64{1.0, 5.0, 3.0})
+	result := expr.combine([]float64{1.0, 5.0, 3.0}, nil)
 	s.InDelta(5.0, result, 0.001)
 }
 
 func (s *ScoreCombineExprTestSuite) TestCombine_Min() {
 	expr := &ScoreCombineExpr{mode: ModeMin}
-	result := expr.combine([]float64{1.0, 5.0, 3.0})
+	result := expr.combine([]float64{1.0, 5.0, 3.0}, nil)
 	s.InDelta(1.0, result, 0.001)
 }
 
 func (s *ScoreCombineExprTestSuite) TestCombine_Avg() {
 	expr := &ScoreCombineExpr{mode: ModeAvg}
-	result := expr.combine([]float64{2.0, 4.0, 6.0})
+	result := expr.combine([]float64{2.0, 4.0, 6.0}, nil)
 	s.InDelta(4.0, result, 0.001) // (2+4+6)/3 = 4
 }
 
 func (s *ScoreCombineExprTestSuite) TestCombine_Weighted() {
-	expr := &ScoreCombineExpr{
-		mode:    ModeWeighted,
-		weights: []float64{0.5, 0.3, 0.2},
-	}
-	result := expr.combine([]float64{10.0, 20.0, 30.0})
+	expr := &ScoreCombineExpr{mode: ModeWeighted}
+	result := expr.combine([]float64{10.0, 20.0, 30.0}, []float64{0.5, 0.3, 0.2})
 	// 10*0.5 + 20*0.3 + 30*0.2 = 5 + 6 + 6 = 17
 	s.InDelta(17.0, result, 0.001)
 }
@@ -575,4 +718,140 @@ func (s *ScoreCombineExprTestSuite) TestGetNumericValue() {
 	val, err = GetNumericValue(arrInt, 0)
 	s.Require().NoError(err)
 	s.InDelta(100.0, val, 0.001)
+}
+
+func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExprFromParams_Invalid() {
+	_, err := NewScoreCombineExprFromParams(map[string]interface{}{
+		"mode": "bad-mode",
+	})
+	s.Error(err)
+	s.Contains(err.Error(), "invalid mode")
+
+	_, err = NewScoreCombineExprFromParams(map[string]interface{}{
+		"mode":    "weighted",
+		"weights": []interface{}{"bad"},
+	})
+	s.Error(err)
+	s.Contains(err.Error(), "weights")
+}
+
+func (s *ScoreCombineExprTestSuite) TestExecute_SkipsNullInputsWeighted() {
+	col1 := s.createNullableFloat32ChunkedArray([]float32{10.0, 0.0, 0.0}, []bool{true, false, false})
+	defer col1.Release()
+	col2 := s.createNullableFloat32ChunkedArray([]float32{20.0, 20.0, 0.0}, []bool{true, true, false})
+	defer col2.Release()
+
+	expr, err := NewScoreCombineExpr(ModeWeighted, []float64{0.8, 0.2}, WithNullPolicy(ScoreCombineNullSkip))
+	s.Require().NoError(err)
+
+	ctx := types.NewFuncContext(s.pool)
+	outputs, err := expr.Execute(ctx, []*arrow.Chunked{col1, col2})
+	s.Require().NoError(err)
+	defer outputs[0].Release()
+
+	result := outputs[0].Chunk(0).(*array.Float32)
+	s.InDelta(12.0, result.Value(0), 0.001)
+	s.InDelta(4.0, result.Value(1), 0.001)
+	s.True(result.IsNull(2))
+}
+
+func (s *ScoreCombineExprTestSuite) TestExecute_RejectsMismatchedChunksAndUnsupportedTypes() {
+	col1 := s.createFloat32ChunkedArray([]float32{1.0, 2.0})
+	defer col1.Release()
+	col2 := s.createMultiChunkFloat32Array([]float32{1.0}, []float32{2.0})
+	defer col2.Release()
+
+	expr, err := NewScoreCombineExpr(ModeSum, nil)
+	s.Require().NoError(err)
+	ctx := types.NewFuncContext(s.pool)
+
+	_, err = expr.Execute(ctx, []*arrow.Chunked{col1, col2})
+	s.Error(err)
+	s.Contains(err.Error(), "input 0 has 1 chunks")
+
+	shortCol := s.createFloat32ChunkedArray([]float32{1.0})
+	defer shortCol.Release()
+	_, err = expr.Execute(ctx, []*arrow.Chunked{col1, shortCol})
+	s.Error(err)
+	s.Contains(err.Error(), "has 2 rows")
+
+	stringBuilder := array.NewStringBuilder(s.pool)
+	stringBuilder.AppendValues([]string{"a", "b"}, nil)
+	stringArray := stringBuilder.NewArray()
+	stringBuilder.Release()
+	stringCol := arrow.NewChunked(arrow.BinaryTypes.String, []arrow.Array{stringArray})
+	stringArray.Release()
+	defer stringCol.Release()
+
+	_, err = expr.Execute(ctx, []*arrow.Chunked{col1, stringCol})
+	s.Error(err)
+	s.Contains(err.Error(), "unsupported input column type")
+}
+
+func (s *ScoreCombineExprTestSuite) TestNewNumericReaderAllSupportedTypes() {
+	cases := []struct {
+		name string
+		arr  arrow.Array
+		want float64
+	}{
+		{name: "int8", arr: func() arrow.Array {
+			b := array.NewInt8Builder(s.pool)
+			b.Append(1)
+			arr := b.NewArray()
+			b.Release()
+			return arr
+		}(), want: 1},
+		{name: "int16", arr: func() arrow.Array {
+			b := array.NewInt16Builder(s.pool)
+			b.Append(2)
+			arr := b.NewArray()
+			b.Release()
+			return arr
+		}(), want: 2},
+		{name: "int32", arr: func() arrow.Array {
+			b := array.NewInt32Builder(s.pool)
+			b.Append(3)
+			arr := b.NewArray()
+			b.Release()
+			return arr
+		}(), want: 3},
+		{name: "int64", arr: func() arrow.Array {
+			b := array.NewInt64Builder(s.pool)
+			b.Append(4)
+			arr := b.NewArray()
+			b.Release()
+			return arr
+		}(), want: 4},
+		{name: "float32", arr: func() arrow.Array {
+			b := array.NewFloat32Builder(s.pool)
+			b.Append(5.5)
+			arr := b.NewArray()
+			b.Release()
+			return arr
+		}(), want: 5.5},
+		{name: "float64", arr: func() arrow.Array {
+			b := array.NewFloat64Builder(s.pool)
+			b.Append(6.5)
+			arr := b.NewArray()
+			b.Release()
+			return arr
+		}(), want: 6.5},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			defer tc.arr.Release()
+			reader, ok := newNumericReader(tc.arr)
+			s.True(ok)
+			s.False(reader.IsNull(0))
+			s.InDelta(tc.want, reader.Float64(0), 0.001)
+		})
+	}
+
+	stringBuilder := array.NewStringBuilder(s.pool)
+	stringBuilder.Append("not numeric")
+	stringArray := stringBuilder.NewArray()
+	stringBuilder.Release()
+	defer stringArray.Release()
+	_, ok := newNumericReader(stringArray)
+	s.False(ok)
 }

--- a/internal/util/function/chain/operator_map.go
+++ b/internal/util/function/chain/operator_map.go
@@ -21,6 +21,8 @@ package chain
 import (
 	"fmt"
 
+	"github.com/apache/arrow/go/v17/arrow"
+
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
@@ -94,6 +96,10 @@ func (o *MapOp) Execute(ctx *types.FuncContext, input *DataFrame) (*DataFrame, e
 			len(outputs), len(o.outputs))
 	}
 
+	return o.buildOutputDataFrame(input, outputs)
+}
+
+func (o *MapOp) buildOutputDataFrame(input *DataFrame, outputs []*arrow.Chunked) (*DataFrame, error) {
 	// 4. Create builder
 	builder := NewDataFrameBuilder()
 	defer builder.Release()

--- a/internal/util/function/chain/operator_map_test.go
+++ b/internal/util/function/chain/operator_map_test.go
@@ -335,3 +335,46 @@ func (s *MapOpTestSuite) TestNewMapOpFromReprNoOutputs() {
 	s.Error(err)
 	s.Contains(err.Error(), "requires outputs")
 }
+
+func (s *MapOpTestSuite) TestBuildOutputDataFrameReleasesOutputsOnCopyError() {
+	builder := NewDataFrameBuilder()
+	builder.SetChunkSizes([]int64{1})
+	idBuilder := array.NewInt64Builder(s.pool)
+	idBuilder.Append(1)
+	idChunk := idBuilder.NewArray()
+	idBuilder.Release()
+	s.Require().NoError(builder.AddColumnFromChunks(types.IDFieldName, []arrow.Array{idChunk}))
+	df := builder.Build()
+	defer df.Release()
+
+	// Corrupt schema-only metadata to exercise the defensive AddColumnFrom error path.
+	df.schema = arrow.NewSchema([]arrow.Field{
+		{Name: types.IDFieldName, Type: arrow.PrimitiveTypes.Int64},
+		{Name: "missing", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	outBuilder := array.NewFloat32Builder(s.pool)
+	outBuilder.Append(2.0)
+	outArray := outBuilder.NewArray()
+	outBuilder.Release()
+	out := arrow.NewChunked(arrow.PrimitiveTypes.Float32, []arrow.Array{outArray})
+	outArray.Release()
+
+	op, err := NewMapOp(&doubleScoreExpr{}, []string{types.ScoreFieldName}, []string{types.ScoreFieldName})
+	s.Require().NoError(err)
+	_, err = op.buildOutputDataFrame(df, []*arrow.Chunked{out})
+	s.Error(err)
+	s.Contains(err.Error(), "missing")
+}
+
+func (s *MapOpTestSuite) TestBuildOutputDataFrameWrapsAddColumnsError() {
+	df := s.createTestDF([]int64{1}, []float32{1.0}, []int64{1})
+	defer df.Release()
+
+	op, err := NewMapOp(&doubleScoreExpr{}, []string{types.ScoreFieldName}, []string{types.ScoreFieldName})
+	s.Require().NoError(err)
+	_, err = op.buildOutputDataFrame(df, []*arrow.Chunked{nil})
+	s.Error(err)
+	s.Contains(err.Error(), "map_op")
+	s.Contains(err.Error(), "is nil")
+}

--- a/internal/util/function/chain/operator_sort.go
+++ b/internal/util/function/chain/operator_sort.go
@@ -122,40 +122,46 @@ func (o *SortOp) Execute(ctx *types.FuncContext, input *DataFrame) (*DataFrame, 
 
 		// Sort indices based on values, with tie-breaking by ID ascending.
 		// Nulls always sort to the end regardless of sort direction.
-		sort.SliceStable(indices, func(i, j int) bool {
-			vi := indices[i]
-			vj := indices[j]
+		less, useTypedLess := makeArrayRowLess(sortChunk, tbChunk, o.desc)
+		if useTypedLess {
+			sort.SliceStable(indices, func(i, j int) bool {
+				return less(indices[i], indices[j])
+			})
+		} else {
+			sort.SliceStable(indices, func(i, j int) bool {
+				vi := indices[i]
+				vj := indices[j]
 
-			iNull := sortChunk.IsNull(vi)
-			jNull := sortChunk.IsNull(vj)
-			if iNull && jNull {
-				// Both null — use tie-break if available
+				iNull := sortChunk.IsNull(vi)
+				jNull := sortChunk.IsNull(vj)
+				if iNull && jNull {
+					// Both null — use tie-break if available
+					if tbChunk != nil {
+						return compareArrayValues(tbChunk, vi, vj) < 0
+					}
+					return false
+				}
+				if iNull {
+					return false // null always goes after non-null
+				}
+				if jNull {
+					return true // non-null always goes before null
+				}
+
+				cmp := compareArrayValues(sortChunk, vi, vj)
+				if cmp != 0 {
+					if o.desc {
+						return cmp > 0
+					}
+					return cmp < 0
+				}
+				// Tie-break: sort by tie-break column ascending
 				if tbChunk != nil {
 					return compareArrayValues(tbChunk, vi, vj) < 0
 				}
 				return false
-			}
-			if iNull {
-				return false // null always goes after non-null
-			}
-			if jNull {
-				return true // non-null always goes before null
-			}
-
-			cmp := compareArrayValues(sortChunk, vi, vj)
-			if cmp != 0 {
-				if o.desc {
-					return cmp > 0
-				}
-				return cmp < 0
-			}
-			// Tie-break: sort by tie-break column ascending
-			if tbChunk != nil {
-				return compareArrayValues(tbChunk, vi, vj) < 0
-			}
-			return false
-		})
-
+			})
+		}
 		newChunkSizes[chunkIdx] = int64(chunkLen)
 
 		// Reorder each column
@@ -184,6 +190,27 @@ func (o *SortOp) Execute(ctx *types.FuncContext, input *DataFrame) (*DataFrame, 
 	}
 
 	return builder.Build(), nil
+}
+
+type rowLessFunc func(i, j int) bool
+
+func makeArrayRowLess(sortArr arrow.Array, tieArr arrow.Array, desc bool) (rowLessFunc, bool) {
+	if !desc {
+		return nil, false
+	}
+	if scoreArr, ok := sortArr.(*array.Float32); ok && scoreArr.NullN() == 0 {
+		if idArr, ok := tieArr.(*array.Int64); ok && idArr.NullN() == 0 {
+			return func(i, j int) bool {
+				si := scoreArr.Value(i)
+				sj := scoreArr.Value(j)
+				if si != sj {
+					return si > sj
+				}
+				return idArr.Value(i) < idArr.Value(j)
+			}, true
+		}
+	}
+	return nil, false
 }
 
 // isComparableType checks if an Arrow data type is comparable for sorting.

--- a/internal/util/function/chain/operator_sort_test.go
+++ b/internal/util/function/chain/operator_sort_test.go
@@ -368,3 +368,76 @@ func (s *SortOpTestSuite) TestSortTieBreakPartialTies() {
 	s.Equal(int64(40), ids.Value(3)) // score 0.5
 	s.Equal(int64(50), ids.Value(4)) // score 0.1
 }
+
+func (s *SortOpTestSuite) TestSortFastPathFloat32DescWithInt64TieBreak() {
+	builder := NewDataFrameBuilder()
+	builder.SetChunkSizes([]int64{4})
+
+	idBuilder := array.NewInt64Builder(s.pool)
+	idBuilder.AppendValues([]int64{3, 2, 1, 4}, nil)
+	idChunk := idBuilder.NewArray()
+	idBuilder.Release()
+
+	scoreBuilder := array.NewFloat32Builder(s.pool)
+	scoreBuilder.AppendValues([]float32{0.5, 0.9, 0.5, 0.7}, nil)
+	scoreChunk := scoreBuilder.NewArray()
+	scoreBuilder.Release()
+
+	s.Require().NoError(builder.AddColumnFromChunks(types.IDFieldName, []arrow.Array{idChunk}))
+	s.Require().NoError(builder.AddColumnFromChunks(types.ScoreFieldName, []arrow.Array{scoreChunk}))
+	df := builder.Build()
+	defer df.Release()
+
+	op := NewSortOpWithTieBreak(types.ScoreFieldName, true, types.IDFieldName)
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+	result, err := op.Execute(ctx, df)
+	s.Require().NoError(err)
+	defer result.Release()
+
+	ids := result.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	s.Equal(int64(2), ids.Value(0))
+	s.Equal(int64(4), ids.Value(1))
+	s.Equal(int64(1), ids.Value(2))
+	s.Equal(int64(3), ids.Value(3))
+}
+
+func (s *SortOpTestSuite) TestSortIgnoresNonComparableTieBreakAndStringHelpers() {
+	builder := NewDataFrameBuilder()
+	builder.SetChunkSizes([]int64{3})
+
+	idBuilder := array.NewInt64Builder(s.pool)
+	idBuilder.AppendValues([]int64{3, 2, 1}, nil)
+	idChunk := idBuilder.NewArray()
+	idBuilder.Release()
+
+	scoreBuilder := array.NewFloat64Builder(s.pool)
+	scoreBuilder.AppendValues([]float64{0.5, 0.5, 0.5}, nil)
+	scoreChunk := scoreBuilder.NewArray()
+	scoreBuilder.Release()
+
+	boolBuilder := array.NewBooleanBuilder(s.pool)
+	boolBuilder.AppendValues([]bool{true, false, true}, nil)
+	boolChunk := boolBuilder.NewArray()
+	boolBuilder.Release()
+
+	s.Require().NoError(builder.AddColumnFromChunks(types.IDFieldName, []arrow.Array{idChunk}))
+	s.Require().NoError(builder.AddColumnFromChunks(types.ScoreFieldName, []arrow.Array{scoreChunk}))
+	s.Require().NoError(builder.AddColumnFromChunks("bool_tie", []arrow.Array{boolChunk}))
+	df := builder.Build()
+	defer df.Release()
+
+	op := NewSortOpWithTieBreak(types.ScoreFieldName, true, "bool_tie")
+	s.Equal("Sort($score DESC, bool_tie ASC)", op.String())
+	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
+	result, err := op.Execute(ctx, df)
+	s.Require().NoError(err)
+	defer result.Release()
+
+	ids := result.Column(types.IDFieldName).Chunk(0).(*array.Int64)
+	s.Equal(int64(3), ids.Value(0))
+	s.Equal(int64(2), ids.Value(1))
+	s.Equal(int64(1), ids.Value(2))
+
+	emptyOp := &SortOp{}
+	s.Empty(emptyOp.Column())
+}

--- a/internal/util/function/chain/rerank_builder.go
+++ b/internal/util/function/chain/rerank_builder.go
@@ -509,7 +509,7 @@ func buildDecayChain(fc *FuncChain, collSchema *schemapb.CollectionSchema, funcS
 		[]string{inputField},
 		[]string{decayScoreCol})
 
-	combineExpr, err := expr.NewScoreCombineExpr(expr.ModeMultiply, nil)
+	combineExpr, err := expr.NewScoreCombineExpr(expr.ModeMultiply, nil, expr.WithNullPolicy(expr.ScoreCombineNullAsZero))
 	if err != nil {
 		return merr.WrapErrParameterInvalidMsg("rerank_builder: %v", err)
 	}

--- a/internal/util/segcore/boost_score.go
+++ b/internal/util/segcore/boost_score.go
@@ -1,0 +1,295 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segcore
+
+/*
+#cgo pkg-config: milvus_core
+
+#include <stdlib.h>
+#include <string.h>
+#include "futures/future_c.h"
+#include "segcore/boost_score_c.h"
+
+// Arrow C Data Interface structs (standard ABI, layout matches Go cdata package)
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
+struct ArrowSchema {
+    const char* format;
+    const char* name;
+    const char* metadata;
+    int64_t flags;
+    int64_t n_children;
+    struct ArrowSchema** children;
+    struct ArrowSchema* dictionary;
+    void (*release)(struct ArrowSchema*);
+    void* private_data;
+};
+
+struct ArrowArray {
+    int64_t length;
+    int64_t null_count;
+    int64_t offset;
+    int64_t n_buffers;
+    int64_t n_children;
+    const void** buffers;
+    struct ArrowArray** children;
+    struct ArrowArray* dictionary;
+    void (*release)(struct ArrowArray*);
+    void* private_data;
+};
+
+#endif  // ARROW_C_DATA_INTERFACE
+
+static inline void
+MilvusGoBoostScoreArrowSchemaRelease(struct ArrowSchema* schema) {
+    if (schema != NULL && schema->release != NULL) {
+        schema->release(schema);
+    }
+}
+
+static inline int
+MilvusGoBoostScoreArrowArrayIsReleased(const struct ArrowArray* array) {
+    return array == NULL || array->release == NULL;
+}
+
+static inline void
+MilvusGoBoostScoreArrowArrayRelease(struct ArrowArray* array) {
+    if (!MilvusGoBoostScoreArrowArrayIsReleased(array)) {
+        array->release(array);
+    }
+}
+
+static inline void**
+MilvusGoBoostScoreAllocPointerArray(int64_t count) {
+    return (void**)calloc((size_t)count, sizeof(void*));
+}
+
+static inline void
+MilvusGoBoostScoreSetPointerArray(void** array, int64_t index, void* value) {
+    array[index] = value;
+}
+*/
+import "C"
+
+import (
+	"context"
+	"runtime"
+	"unsafe"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/cdata"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/milvus-io/milvus/internal/util/cgo"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+func ComputeScorerScoresOnChunkedOffsets(segment CSegment, searchReq *SearchRequest, scoreFunction *planpb.ScoreFunction, offsets *arrow.Chunked) (*arrow.Chunked, error) {
+	return computeScorerScoresOnChunkedOffsets(context.Background(), segment, searchReq, scoreFunction, offsets, false)
+}
+
+func AsyncComputeScorerScoresOnChunkedOffsets(ctx context.Context, segment CSegment, searchReq *SearchRequest, scoreFunction *planpb.ScoreFunction, offsets *arrow.Chunked) (*arrow.Chunked, error) {
+	return computeScorerScoresOnChunkedOffsets(ctx, segment, searchReq, scoreFunction, offsets, true)
+}
+
+func computeScorerScoresOnChunkedOffsets(ctx context.Context, segment CSegment, searchReq *SearchRequest, scoreFunction *planpb.ScoreFunction, offsets *arrow.Chunked, async bool) (*arrow.Chunked, error) {
+	if segment == nil {
+		return nil, merr.WrapErrParameterInvalidMsg("segment is nil")
+	}
+	if searchReq == nil || searchReq.plan == nil {
+		return nil, merr.WrapErrParameterInvalidMsg("search request or plan is nil")
+	}
+	if scoreFunction == nil {
+		return nil, merr.WrapErrParameterInvalidMsg("score function is nil")
+	}
+	if offsets == nil {
+		return nil, merr.WrapErrParameterInvalidMsg("offsets is nil")
+	}
+	if offsets.DataType().ID() != arrow.INT64 {
+		return nil, merr.WrapErrParameterInvalidMsg("offset column must be Int64, got %s", offsets.DataType())
+	}
+
+	scoreFunctionBlob, err := proto.Marshal(scoreFunction)
+	if err != nil {
+		return nil, merr.Wrap(err, "failed to marshal score function")
+	}
+	if len(scoreFunctionBlob) == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("empty score function")
+	}
+
+	numChunks := len(offsets.Chunks())
+	scoreArrays := make([]arrow.Array, numChunks)
+	if numChunks == 0 {
+		return arrow.NewChunked(arrow.PrimitiveTypes.Float32, scoreArrays), nil
+	}
+
+	offsetArrays := make([]C.struct_ArrowArray, numChunks)
+	offsetSchemas := make([]C.struct_ArrowSchema, numChunks)
+	scoreChunks := make([][]float32, numChunks)
+	hasScoreChunks := make([][]C.bool, numChunks)
+	pins := make([]runtime.Pinner, 0, numChunks*2)
+	defer func() {
+		for i := range pins {
+			pins[i].Unpin()
+		}
+	}()
+	defer func() {
+		for i := range offsetArrays {
+			C.MilvusGoBoostScoreArrowArrayRelease(&offsetArrays[i])
+			C.MilvusGoBoostScoreArrowSchemaRelease(&offsetSchemas[i])
+		}
+	}()
+
+	scorePtrArray := C.MilvusGoBoostScoreAllocPointerArray(C.int64_t(numChunks))
+	hasScorePtrArray := C.MilvusGoBoostScoreAllocPointerArray(C.int64_t(numChunks))
+	if scorePtrArray == nil || hasScorePtrArray == nil {
+		if scorePtrArray != nil {
+			C.free(unsafe.Pointer(scorePtrArray))
+		}
+		if hasScorePtrArray != nil {
+			C.free(unsafe.Pointer(hasScorePtrArray))
+		}
+		return nil, merr.WrapErrServiceInternalMsg("failed to allocate boost score pointer arrays")
+	}
+	defer C.free(unsafe.Pointer(scorePtrArray))
+	defer C.free(unsafe.Pointer(hasScorePtrArray))
+
+	for chunkIdx, chunk := range offsets.Chunks() {
+		offsetChunk, ok := chunk.(*array.Int64)
+		if !ok {
+			return nil, merr.WrapErrParameterInvalidMsg("offset chunk %d must be Int64, got %T", chunkIdx, chunk)
+		}
+		if offsetChunk.NullN() > 0 {
+			return nil, merr.WrapErrParameterInvalidMsg("offset chunk %d contains null", chunkIdx)
+		}
+
+		cdata.ExportArrowArray(
+			offsetChunk,
+			(*cdata.CArrowArray)(unsafe.Pointer(&offsetArrays[chunkIdx])),
+			(*cdata.CArrowSchema)(unsafe.Pointer(&offsetSchemas[chunkIdx])),
+		)
+
+		length := offsetChunk.Len()
+		if length == 0 {
+			continue
+		}
+
+		scoreChunks[chunkIdx] = make([]float32, length)
+		hasScoreChunks[chunkIdx] = make([]C.bool, length)
+		var scorePin runtime.Pinner
+		scorePin.Pin(&scoreChunks[chunkIdx][0])
+		pins = append(pins, scorePin)
+		var hasScorePin runtime.Pinner
+		hasScorePin.Pin(&hasScoreChunks[chunkIdx][0])
+		pins = append(pins, hasScorePin)
+		C.MilvusGoBoostScoreSetPointerArray(scorePtrArray, C.int64_t(chunkIdx), unsafe.Pointer(&scoreChunks[chunkIdx][0]))
+		C.MilvusGoBoostScoreSetPointerArray(hasScorePtrArray, C.int64_t(chunkIdx), unsafe.Pointer(&hasScoreChunks[chunkIdx][0]))
+	}
+
+	cSegment := C.CSegmentInterface(segment.RawPointer())
+	cPlan := searchReq.plan.cSearchPlan
+	scoreFunctionPtr := unsafe.Pointer(&scoreFunctionBlob[0])
+	scoreFunctionSize := C.int64_t(len(scoreFunctionBlob))
+	offsetArrayPtr := &offsetArrays[0]
+	offsetSchemaPtr := &offsetSchemas[0]
+	numChunk := C.int64_t(numChunks)
+	mvccTimestamp := C.uint64_t(searchReq.mvccTimestamp)
+	collectionTTL := C.uint64_t(searchReq.collectionTTL)
+	consistencyLevel := C.int32_t(searchReq.consistencyLevel)
+	entityTTLPhysicalTime := C.uint64_t(searchReq.entityTTLPhysicalTime)
+	scorePtr := (**C.float)(unsafe.Pointer(scorePtrArray))
+	hasScorePtr := (**C.bool)(unsafe.Pointer(hasScorePtrArray))
+
+	if async {
+		future := cgo.Async(ctx,
+			func() cgo.CFuturePtr {
+				return (cgo.CFuturePtr)(C.AsyncComputeScorerScoresOnOffsetChunks(
+					cSegment,
+					cPlan,
+					scoreFunctionPtr,
+					scoreFunctionSize,
+					offsetArrayPtr,
+					offsetSchemaPtr,
+					numChunk,
+					mvccTimestamp,
+					collectionTTL,
+					consistencyLevel,
+					entityTTLPhysicalTime,
+					scorePtr,
+					hasScorePtr,
+				))
+			},
+			cgo.WithName("boost_score"),
+		)
+		defer future.Release()
+		if _, err := future.BlockAndLeakyGet(); err != nil {
+			return nil, err
+		}
+	} else {
+		status := C.ComputeScorerScoresOnOffsetChunks(
+			cSegment,
+			cPlan,
+			scoreFunctionPtr,
+			scoreFunctionSize,
+			offsetArrayPtr,
+			offsetSchemaPtr,
+			numChunk,
+			mvccTimestamp,
+			collectionTTL,
+			consistencyLevel,
+			entityTTLPhysicalTime,
+			scorePtr,
+			hasScorePtr,
+		)
+		if err := ConsumeCStatusIntoError(&status); err != nil {
+			return nil, err
+		}
+	}
+
+	for chunkIdx := range scoreChunks {
+		builder := array.NewFloat32Builder(memory.DefaultAllocator)
+		for rowIdx, score := range scoreChunks[chunkIdx] {
+			if bool(hasScoreChunks[chunkIdx][rowIdx]) {
+				builder.Append(score)
+			} else {
+				builder.AppendNull()
+			}
+		}
+		scoreArrays[chunkIdx] = builder.NewArray()
+		builder.Release()
+	}
+	result := arrow.NewChunked(arrow.PrimitiveTypes.Float32, scoreArrays)
+	for _, scoreArray := range scoreArrays {
+		if scoreArray != nil {
+			scoreArray.Release()
+		}
+	}
+
+	runtime.KeepAlive(segment)
+	runtime.KeepAlive(searchReq)
+	runtime.KeepAlive(scoreFunction)
+	runtime.KeepAlive(scoreFunctionBlob)
+	runtime.KeepAlive(offsets)
+	runtime.KeepAlive(scoreChunks)
+	runtime.KeepAlive(hasScoreChunks)
+
+	return result, nil
+}

--- a/internal/util/segcore/boost_score_test.go
+++ b/internal/util/segcore/boost_score_test.go
@@ -1,0 +1,279 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segcore_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
+	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+func TestComputeScorerScoresOnChunkedOffsetsValidation(t *testing.T) {
+	offsets := newInt64Chunked(t, []int64{0})
+	defer offsets.Release()
+
+	scoreFunction := &planpb.ScoreFunction{Weight: 1}
+	segment := newBoostScoreTestSegment(t)
+	searchReq := newBoostScoreTestSearchRequest(t)
+
+	t.Run("nil segment", func(t *testing.T) {
+		scores, err := segcore.ComputeScorerScoresOnChunkedOffsets(nil, searchReq, scoreFunction, offsets)
+		require.Error(t, err)
+		require.Nil(t, scores)
+		require.Contains(t, err.Error(), "segment is nil")
+	})
+
+	t.Run("nil search request", func(t *testing.T) {
+		scores, err := segcore.ComputeScorerScoresOnChunkedOffsets(segment, nil, scoreFunction, offsets)
+		require.Error(t, err)
+		require.Nil(t, scores)
+		require.Contains(t, err.Error(), "search request or plan is nil")
+	})
+
+	t.Run("nil score function", func(t *testing.T) {
+		scores, err := segcore.ComputeScorerScoresOnChunkedOffsets(segment, searchReq, nil, offsets)
+		require.Error(t, err)
+		require.Nil(t, scores)
+		require.Contains(t, err.Error(), "score function is nil")
+	})
+
+	t.Run("nil offsets", func(t *testing.T) {
+		scores, err := segcore.ComputeScorerScoresOnChunkedOffsets(segment, searchReq, scoreFunction, nil)
+		require.Error(t, err)
+		require.Nil(t, scores)
+		require.Contains(t, err.Error(), "offsets is nil")
+	})
+
+	t.Run("non int64 offsets", func(t *testing.T) {
+		badOffsets := newFloat32Chunked(t, []float32{0})
+		defer badOffsets.Release()
+
+		scores, err := segcore.ComputeScorerScoresOnChunkedOffsets(segment, searchReq, scoreFunction, badOffsets)
+		require.Error(t, err)
+		require.Nil(t, scores)
+		require.Contains(t, err.Error(), "offset column must be Int64")
+	})
+
+	t.Run("null offset", func(t *testing.T) {
+		badOffsets := newNullableInt64Chunked(t)
+		defer badOffsets.Release()
+
+		scores, err := segcore.ComputeScorerScoresOnChunkedOffsets(segment, searchReq, scoreFunction, badOffsets)
+		require.Error(t, err)
+		require.Nil(t, scores)
+		require.Contains(t, err.Error(), "offset chunk 0 contains null")
+	})
+
+	t.Run("empty offsets", func(t *testing.T) {
+		emptyOffsets := arrow.NewChunked(arrow.PrimitiveTypes.Int64, nil)
+		defer emptyOffsets.Release()
+
+		scores, err := segcore.ComputeScorerScoresOnChunkedOffsets(segment, searchReq, scoreFunction, emptyOffsets)
+		require.NoError(t, err)
+		require.NotNil(t, scores)
+		defer scores.Release()
+		require.Equal(t, arrow.PrimitiveTypes.Float32, scores.DataType())
+		require.Empty(t, scores.Chunks())
+	})
+}
+
+func TestComputeScorerScoresOnChunkedOffsets(t *testing.T) {
+	collection, segment, searchReq := newBoostScoreTestContext(t)
+	defer collection.Release()
+	defer segment.Release()
+	defer searchReq.Delete()
+
+	offsets := newInt64Chunked(t, []int64{0, 1}, []int64{2, 3})
+	defer offsets.Release()
+
+	scores, err := segcore.ComputeScorerScoresOnChunkedOffsets(
+		segment,
+		searchReq,
+		&planpb.ScoreFunction{
+			Weight: 2.5,
+			Type:   planpb.FunctionType_FunctionTypeWeight,
+		},
+		offsets,
+	)
+	require.NoError(t, err)
+	requireBoostScores(t, scores, [][]float32{{2.5, 2.5}, {2.5, 2.5}})
+}
+
+func TestAsyncComputeScorerScoresOnChunkedOffsets(t *testing.T) {
+	collection, segment, searchReq := newBoostScoreTestContext(t)
+	defer collection.Release()
+	defer segment.Release()
+	defer searchReq.Delete()
+
+	offsets := newInt64Chunked(t, []int64{0, 1, 2})
+	defer offsets.Release()
+
+	scores, err := segcore.AsyncComputeScorerScoresOnChunkedOffsets(
+		context.Background(),
+		segment,
+		searchReq,
+		&planpb.ScoreFunction{
+			Weight: 3.5,
+			Type:   planpb.FunctionType_FunctionTypeWeight,
+		},
+		offsets,
+	)
+	require.NoError(t, err)
+	requireBoostScores(t, scores, [][]float32{{3.5, 3.5, 3.5}})
+}
+
+func newBoostScoreTestContext(t *testing.T) (*segcore.CCollection, segcore.CSegment, *segcore.SearchRequest) {
+	t.Helper()
+	initBoostScoreTestEnv(t)
+
+	const (
+		collectionID = int64(100)
+		partitionID  = int64(10)
+		segmentID    = int64(1)
+	)
+
+	schema := mock_segcore.GenTestCollectionSchema("boost-score-suite", schemapb.DataType_Int64, false)
+	collection, err := segcore.CreateCCollection(&segcore.CreateCCollectionRequest{
+		CollectionID: collectionID,
+		Schema:       schema,
+		IndexMeta:    mock_segcore.GenTestIndexMeta(collectionID, schema),
+	})
+	require.NoError(t, err)
+
+	segment, err := segcore.CreateCSegment(&segcore.CreateCSegmentRequest{
+		Collection:  collection,
+		SegmentID:   segmentID,
+		SegmentType: segcore.SegmentTypeGrowing,
+		IsSorted:    false,
+	})
+	require.NoError(t, err)
+
+	insertMsg, err := mock_segcore.GenInsertMsg(collection, partitionID, segmentID, 10)
+	require.NoError(t, err)
+	_, err = segment.Insert(context.Background(), &segcore.InsertRequest{
+		RowIDs:     insertMsg.RowIDs,
+		Timestamps: insertMsg.Timestamps,
+		Record: &segcorepb.InsertRecord{
+			FieldsData: insertMsg.FieldsData,
+			NumRows:    int64(len(insertMsg.RowIDs)),
+		},
+	})
+	require.NoError(t, err)
+
+	searchReq, err := mock_segcore.GenSearchPlanAndRequestsWithTopK(collection, []int64{segmentID}, 1, 10)
+	require.NoError(t, err)
+
+	return collection, segment, searchReq
+}
+
+func initBoostScoreTestEnv(t *testing.T) {
+	t.Helper()
+	paramtable.Init()
+	initcore.InitExecExpressionFunctionFactory()
+	localDataRootPath := filepath.Join(paramtable.Get().LocalStorageCfg.Path.GetValue(), typeutil.QueryNodeRole)
+	require.NoError(t, initcore.InitLocalChunkManager(localDataRootPath))
+	require.NoError(t, initcore.InitMmapManager(paramtable.Get(), 1))
+	initcore.InitTieredStorage(paramtable.Get())
+}
+
+func newBoostScoreTestSegment(t *testing.T) segcore.CSegment {
+	t.Helper()
+	collection, segment, searchReq := newBoostScoreTestContext(t)
+	t.Cleanup(collection.Release)
+	t.Cleanup(segment.Release)
+	t.Cleanup(searchReq.Delete)
+	return segment
+}
+
+func newBoostScoreTestSearchRequest(t *testing.T) *segcore.SearchRequest {
+	t.Helper()
+	collection, segment, searchReq := newBoostScoreTestContext(t)
+	t.Cleanup(collection.Release)
+	t.Cleanup(segment.Release)
+	t.Cleanup(searchReq.Delete)
+	return searchReq
+}
+
+func newInt64Chunked(t *testing.T, chunks ...[]int64) *arrow.Chunked {
+	t.Helper()
+	arrays := make([]arrow.Array, 0, len(chunks))
+	for _, values := range chunks {
+		builder := array.NewInt64Builder(memory.DefaultAllocator)
+		builder.AppendValues(values, nil)
+		chunk := builder.NewArray()
+		builder.Release()
+		arrays = append(arrays, chunk)
+	}
+	chunked := arrow.NewChunked(arrow.PrimitiveTypes.Int64, arrays)
+	for _, chunk := range arrays {
+		chunk.Release()
+	}
+	return chunked
+}
+
+func newNullableInt64Chunked(t *testing.T) *arrow.Chunked {
+	t.Helper()
+	builder := array.NewInt64Builder(memory.DefaultAllocator)
+	builder.Append(1)
+	builder.AppendNull()
+	chunk := builder.NewArray()
+	builder.Release()
+	chunked := arrow.NewChunked(arrow.PrimitiveTypes.Int64, []arrow.Array{chunk})
+	chunk.Release()
+	return chunked
+}
+
+func newFloat32Chunked(t *testing.T, values []float32) *arrow.Chunked {
+	t.Helper()
+	builder := array.NewFloat32Builder(memory.DefaultAllocator)
+	builder.AppendValues(values, nil)
+	chunk := builder.NewArray()
+	builder.Release()
+	chunked := arrow.NewChunked(arrow.PrimitiveTypes.Float32, []arrow.Array{chunk})
+	chunk.Release()
+	return chunked
+}
+
+func requireBoostScores(t *testing.T, scores *arrow.Chunked, expected [][]float32) {
+	t.Helper()
+	require.NotNil(t, scores)
+	defer scores.Release()
+	require.Equal(t, arrow.PrimitiveTypes.Float32, scores.DataType())
+	require.Len(t, scores.Chunks(), len(expected))
+	for chunkIdx, expectedChunk := range expected {
+		chunk := scores.Chunk(chunkIdx).(*array.Float32)
+		require.Equal(t, len(expectedChunk), chunk.Len())
+		require.Zero(t, chunk.NullN())
+		for rowIdx, expectedScore := range expectedChunk {
+			require.InDelta(t, expectedScore, chunk.Value(rowIdx), 1e-6)
+		}
+	}
+}

--- a/tests/python_client/milvus_client/test_milvus_client_search_boost_ranker.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_boost_ranker.py
@@ -1,15 +1,11 @@
-import pytest
-from pymilvus import (
-    DataType,
-    Function, FunctionType, FunctionScore
-)
+import math
 
-from utils.util_pymilvus import *
-from common.common_type import CaseLabel, CheckTasks
-from common import common_type as ct
-from common import common_func as cf
-from utils.util_log import test_log as log
+import pytest
 from base.client_v2_base import TestMilvusClientV2Base
+from common import common_func as cf
+from common import common_type as ct
+from common.common_type import CaseLabel, CheckTasks
+from pymilvus import DataType, Function, FunctionScore, FunctionType
 
 default_nb = ct.default_nb
 default_nq = ct.default_nq
@@ -56,9 +52,7 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
 
         # Create index
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name=self.vector_field_name,
-                               metric_type="COSINE",
-                               index_type="AUTOINDEX")
+        index_params.add_index(field_name=self.vector_field_name, metric_type="COSINE", index_type="AUTOINDEX")
         self.create_index(client, self.collection_name, index_params=index_params)
 
         # Load collection
@@ -88,6 +82,79 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
             functions = [functions]
         return FunctionScore(functions=functions, params=params)
 
+    def _prepare_deterministic_collection(self, client, metric_type="COSINE"):
+        collection_name = "TestSearchBoostRankerCorrectness" + cf.gen_unique_str("_")
+        dim = 2
+        rows = [
+            {
+                self.pk_field_name: 1,
+                self.vector_field_name: [1.0, 0.0],
+                self.int64_field_name: 1,
+                self.float_field_name: 0.1,
+                self.varchar_field_name: "odd",
+            },
+            {
+                self.pk_field_name: 2,
+                self.vector_field_name: [0.8, 0.6],
+                self.int64_field_name: 2,
+                self.float_field_name: 0.2,
+                self.varchar_field_name: "even",
+            },
+            {
+                self.pk_field_name: 3,
+                self.vector_field_name: [0.6, 0.8],
+                self.int64_field_name: 3,
+                self.float_field_name: 0.3,
+                self.varchar_field_name: "odd",
+            },
+            {
+                self.pk_field_name: 4,
+                self.vector_field_name: [0.0, 1.0],
+                self.int64_field_name: 4,
+                self.float_field_name: 0.4,
+                self.varchar_field_name: "even",
+            },
+        ]
+
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(self.pk_field_name, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(self.vector_field_name, DataType.FLOAT_VECTOR, dim=dim)
+        schema.add_field(self.int64_field_name, DataType.INT64)
+        schema.add_field(self.float_field_name, DataType.FLOAT)
+        schema.add_field(self.varchar_field_name, DataType.VARCHAR, max_length=256)
+
+        self.create_collection(client, collection_name, schema=schema)
+        self.insert(client, collection_name, data=rows)
+        self.flush(client, collection_name)
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=self.vector_field_name, metric_type=metric_type, index_type="FLAT", params={})
+        self.create_index(client, collection_name, index_params=index_params)
+        self.load_collection(client, collection_name)
+        return collection_name, dim
+
+    def _search_boost_correctness(self, client, collection_name, ranker):
+        res, _ = self.search(
+            client,
+            collection_name,
+            [[1.0, 0.0]],
+            anns_field=self.vector_field_name,
+            search_params={},
+            limit=4,
+            ranker=ranker,
+            output_fields=[self.pk_field_name],
+        )
+        hits = res[0]
+        return [hit[self.pk_field_name] for hit in hits], [hit["distance"] for hit in hits]
+
+    def _assert_boost_scores(self, actual_ids, actual_scores, expected_scores):
+        expected_ids = [pk for pk, _ in sorted(expected_scores.items(), key=lambda item: (-item[1], item[0]))]
+        assert actual_ids == expected_ids
+        for pk, score in zip(actual_ids, actual_scores):
+            assert math.isclose(score, expected_scores[pk], rel_tol=1e-5, abs_tol=1e-5), (
+                f"expected score for pk {pk} to be {expected_scores[pk]}, got {score}"
+            )
+
     # ==================== Positive Tests ====================
 
     @pytest.mark.tags(CaseLabel.L0)
@@ -103,15 +170,19 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         fs = self._make_function_score(boost_fn)
 
         res, _ = self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.check_search_results,
-            check_items={"enable_milvus_client_api": True,
-                         "nq": default_nq,
-                         "limit": default_limit,
-                         "pk_name": self.pk_field_name}
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": default_nq,
+                "limit": default_limit,
+                "pk_name": self.pk_field_name,
+            },
         )
         assert len(res) == default_nq
 
@@ -128,15 +199,19 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         fs = self._make_function_score(boost_fn)
 
         res, _ = self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.check_search_results,
-            check_items={"enable_milvus_client_api": True,
-                         "nq": default_nq,
-                         "limit": default_limit,
-                         "pk_name": self.pk_field_name}
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": default_nq,
+                "limit": default_limit,
+                "pk_name": self.pk_field_name,
+            },
         )
         assert len(res) == default_nq
 
@@ -149,22 +224,24 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         """
         client = self._client()
         vectors = cf.gen_vectors(default_nq, self.dim)
-        boost_fn1 = self._make_boost_function(
-            name="boost1", weight="2.0", filter_expr=f"{self.int64_field_name} > 0")
-        boost_fn2 = self._make_boost_function(
-            name="boost2", weight="0.5", filter_expr=f"{self.int64_field_name} <= 0")
+        boost_fn1 = self._make_boost_function(name="boost1", weight="2.0", filter_expr=f"{self.int64_field_name} > 0")
+        boost_fn2 = self._make_boost_function(name="boost2", weight="0.5", filter_expr=f"{self.int64_field_name} <= 0")
         fs = self._make_function_score([boost_fn1, boost_fn2])
 
         res, _ = self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.check_search_results,
-            check_items={"enable_milvus_client_api": True,
-                         "nq": default_nq,
-                         "limit": default_limit,
-                         "pk_name": self.pk_field_name}
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": default_nq,
+                "limit": default_limit,
+                "pk_name": self.pk_field_name,
+            },
         )
         assert len(res) == default_nq
 
@@ -181,15 +258,19 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         fs = self._make_function_score(boost_fn, params={"boost_mode": "sum"})
 
         res, _ = self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.check_search_results,
-            check_items={"enable_milvus_client_api": True,
-                         "nq": default_nq,
-                         "limit": default_limit,
-                         "pk_name": self.pk_field_name}
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": default_nq,
+                "limit": default_limit,
+                "pk_name": self.pk_field_name,
+            },
         )
         assert len(res) == default_nq
 
@@ -206,15 +287,19 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         fs = self._make_function_score(boost_fn, params={"boost_mode": "multiply"})
 
         res, _ = self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.check_search_results,
-            check_items={"enable_milvus_client_api": True,
-                         "nq": default_nq,
-                         "limit": default_limit,
-                         "pk_name": self.pk_field_name}
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": default_nq,
+                "limit": default_limit,
+                "pk_name": self.pk_field_name,
+            },
         )
         assert len(res) == default_nq
 
@@ -227,22 +312,24 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         """
         client = self._client()
         vectors = cf.gen_vectors(default_nq, self.dim)
-        boost_fn1 = self._make_boost_function(
-            name="boost1", weight="1.5", filter_expr=f"{self.int64_field_name} > 0")
-        boost_fn2 = self._make_boost_function(
-            name="boost2", weight="0.8", filter_expr=f"{self.float_field_name} > 0")
+        boost_fn1 = self._make_boost_function(name="boost1", weight="1.5", filter_expr=f"{self.int64_field_name} > 0")
+        boost_fn2 = self._make_boost_function(name="boost2", weight="0.8", filter_expr=f"{self.float_field_name} > 0")
         fs = self._make_function_score([boost_fn1, boost_fn2], params={"function_mode": "sum"})
 
         res, _ = self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.check_search_results,
-            check_items={"enable_milvus_client_api": True,
-                         "nq": default_nq,
-                         "limit": default_limit,
-                         "pk_name": self.pk_field_name}
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": default_nq,
+                "limit": default_limit,
+                "pk_name": self.pk_field_name,
+            },
         )
         assert len(res) == default_nq
 
@@ -260,16 +347,20 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
 
         search_filter = f"{self.int64_field_name} >= 0"
         res, _ = self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             filter=search_filter,
             ranker=fs,
             check_task=CheckTasks.check_search_results,
-            check_items={"enable_milvus_client_api": True,
-                         "nq": default_nq,
-                         "limit": default_limit,
-                         "pk_name": self.pk_field_name}
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": default_nq,
+                "limit": default_limit,
+                "pk_name": self.pk_field_name,
+            },
         )
         assert len(res) == default_nq
 
@@ -287,16 +378,20 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
 
         output_fields = [self.int64_field_name, self.float_field_name, self.varchar_field_name]
         res, _ = self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             output_fields=output_fields,
             ranker=fs,
             check_task=CheckTasks.check_search_results,
-            check_items={"enable_milvus_client_api": True,
-                         "nq": default_nq,
-                         "limit": default_limit,
-                         "pk_name": self.pk_field_name}
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": default_nq,
+                "limit": default_limit,
+                "pk_name": self.pk_field_name,
+            },
         )
         assert len(res) == default_nq
         # Verify output fields are present in the entity sub-dict
@@ -320,15 +415,19 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         fs = self._make_function_score(boost_fn)
 
         res, _ = self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=limit,
             ranker=fs,
             check_task=CheckTasks.check_search_results,
-            check_items={"enable_milvus_client_api": True,
-                         "nq": default_nq,
-                         "limit": limit,
-                         "pk_name": self.pk_field_name}
+            check_items={
+                "enable_milvus_client_api": True,
+                "nq": default_nq,
+                "limit": limit,
+                "pk_name": self.pk_field_name,
+            },
         )
         assert len(res) == default_nq
 
@@ -344,7 +443,9 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
 
         # Search without ranker
         res_no_ranker, _ = self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
         )
@@ -353,7 +454,9 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         boost_fn = self._make_boost_function(weight="10.0")
         fs = self._make_function_score(boost_fn, params={"boost_mode": "multiply"})
         res_with_ranker, _ = self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             ranker=fs,
@@ -362,8 +465,251 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         # Verify scores are different (boost should affect scores)
         scores_no_ranker = [hit["distance"] for hit in res_no_ranker[0]]
         scores_with_ranker = [hit["distance"] for hit in res_with_ranker[0]]
-        assert scores_no_ranker != scores_with_ranker, \
+        assert scores_no_ranker != scores_with_ranker, (
             "Boost ranker should change scores compared to search without ranker"
+        )
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_boost_ranker_multiply_correctness(self):
+        """
+        target: verify boost_mode=multiply applies only matching filter rows and sorts by boosted score
+        method: use deterministic vectors and scalar filter with known COSINE base scores
+        expected: returned IDs and distances match base_score * boost_weight for matched rows
+        """
+        client = self._client()
+        collection_name, _ = self._prepare_deterministic_collection(client)
+        try:
+            boost_fn = self._make_boost_function(weight="2.0", filter_expr=f"{self.int64_field_name} in [2, 4]")
+            fs = self._make_function_score(boost_fn, params={"boost_mode": "multiply"})
+
+            actual_ids, actual_scores = self._search_boost_correctness(client, collection_name, fs)
+            self._assert_boost_scores(
+                actual_ids,
+                actual_scores,
+                {
+                    1: 1.0,
+                    2: 1.6,
+                    3: 0.6,
+                    4: 0.0,
+                },
+            )
+        finally:
+            self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_boost_ranker_sum_correctness(self):
+        """
+        target: verify boost_mode=sum adds boost scores only to rows matching the scorer filter
+        method: use deterministic vectors and scalar filter with known COSINE base scores
+        expected: returned IDs and distances match base_score + boost_weight for matched rows
+        """
+        client = self._client()
+        collection_name, _ = self._prepare_deterministic_collection(client)
+        try:
+            boost_fn = self._make_boost_function(weight="0.5", filter_expr=f"{self.int64_field_name} in [2, 4]")
+            fs = self._make_function_score(boost_fn, params={"boost_mode": "sum"})
+
+            actual_ids, actual_scores = self._search_boost_correctness(client, collection_name, fs)
+            self._assert_boost_scores(
+                actual_ids,
+                actual_scores,
+                {
+                    1: 1.0,
+                    2: 1.3,
+                    3: 0.6,
+                    4: 0.5,
+                },
+            )
+        finally:
+            self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_boost_ranker_all_boost_functions_miss_keep_base_scores(self):
+        """
+        target: verify null boost scores are skipped when all boost function filters miss
+        method: use two boost functions whose filters match no row in a deterministic collection
+        expected: every row keeps its original base score and ordering
+        """
+        client = self._client()
+        collection_name, _ = self._prepare_deterministic_collection(client)
+        try:
+            boost_fn1 = self._make_boost_function(
+                name="boost_none_int", weight="2.0", filter_expr=f"{self.int64_field_name} > 100"
+            )
+            boost_fn2 = self._make_boost_function(
+                name="boost_none_string", weight="3.0", filter_expr=f"{self.varchar_field_name} == 'missing'"
+            )
+            fs = self._make_function_score([boost_fn1, boost_fn2], params={"function_mode": "sum", "boost_mode": "sum"})
+
+            actual_ids, actual_scores = self._search_boost_correctness(client, collection_name, fs)
+            self._assert_boost_scores(
+                actual_ids,
+                actual_scores,
+                {
+                    1: 1.0,
+                    2: 0.8,
+                    3: 0.6,
+                    4: 0.0,
+                },
+            )
+        finally:
+            self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_boost_ranker_function_mode_sum_correctness(self):
+        """
+        target: verify multiple boost functions combine with function_mode=sum before final boost
+        method: use overlapping deterministic filters and boost_mode=sum
+        expected: rows receive the sum of matching function scores and are sorted by final score
+        """
+        client = self._client()
+        collection_name, _ = self._prepare_deterministic_collection(client)
+        try:
+            boost_fn1 = self._make_boost_function(
+                name="boost_even", weight="0.5", filter_expr=f"{self.int64_field_name} in [2, 4]"
+            )
+            boost_fn2 = self._make_boost_function(
+                name="boost_high", weight="0.25", filter_expr=f"{self.int64_field_name} >= 3"
+            )
+            fs = self._make_function_score([boost_fn1, boost_fn2], params={"function_mode": "sum", "boost_mode": "sum"})
+
+            actual_ids, actual_scores = self._search_boost_correctness(client, collection_name, fs)
+            self._assert_boost_scores(
+                actual_ids,
+                actual_scores,
+                {
+                    1: 1.0,
+                    2: 1.3,
+                    3: 0.85,
+                    4: 0.75,
+                },
+            )
+        finally:
+            self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_boost_ranker_function_mode_multiply_correctness(self):
+        """
+        target: verify multiple boost functions combine with function_mode=multiply before final boost
+        method: use overlapping deterministic filters and boost_mode=multiply
+        expected: rows matching one or more functions use the multiplied function score; unmatched rows keep base score
+        """
+        client = self._client()
+        collection_name, _ = self._prepare_deterministic_collection(client)
+        try:
+            boost_fn1 = self._make_boost_function(
+                name="boost_even", weight="2.0", filter_expr=f"{self.int64_field_name} in [2, 4]"
+            )
+            boost_fn2 = self._make_boost_function(
+                name="boost_high", weight="3.0", filter_expr=f"{self.int64_field_name} >= 3"
+            )
+            fs = self._make_function_score(
+                [boost_fn1, boost_fn2], params={"function_mode": "multiply", "boost_mode": "multiply"}
+            )
+
+            actual_ids, actual_scores = self._search_boost_correctness(client, collection_name, fs)
+            self._assert_boost_scores(
+                actual_ids,
+                actual_scores,
+                {
+                    1: 1.0,
+                    2: 1.6,
+                    3: 1.8,
+                    4: 0.0,
+                },
+            )
+        finally:
+            self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_boost_ranker_function_multiply_boost_sum_correctness(self):
+        """
+        target: verify function_mode=multiply and boost_mode=sum produce exact boosted scores
+        method: use overlapping deterministic filters so one row matches both functions and one row matches none
+        expected: matching function scores are multiplied, then added to the base score; unmatched rows keep base score
+        """
+        client = self._client()
+        collection_name, _ = self._prepare_deterministic_collection(client)
+        try:
+            boost_fn1 = self._make_boost_function(
+                name="boost_even", weight="2.0", filter_expr=f"{self.int64_field_name} in [2, 4]"
+            )
+            boost_fn2 = self._make_boost_function(
+                name="boost_high", weight="3.0", filter_expr=f"{self.int64_field_name} >= 3"
+            )
+            fs = self._make_function_score(
+                [boost_fn1, boost_fn2], params={"function_mode": "multiply", "boost_mode": "sum"}
+            )
+
+            actual_ids, actual_scores = self._search_boost_correctness(client, collection_name, fs)
+            self._assert_boost_scores(
+                actual_ids,
+                actual_scores,
+                {
+                    1: 1.0,
+                    2: 2.8,
+                    3: 3.6,
+                    4: 6.0,
+                },
+            )
+        finally:
+            self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_boost_ranker_l2_multiply_correctness(self):
+        """
+        target: verify boost_mode=multiply can improve a deterministic L2 result
+        method: multiply row 3's L2 distance by 0.25 to move it ahead of row 2
+        expected: returned distances match boosted L2 distances and are sorted ascending
+        """
+        client = self._client()
+        collection_name, _ = self._prepare_deterministic_collection(client, metric_type="L2")
+        try:
+            boost_fn = self._make_boost_function(weight="0.25", filter_expr=f"{self.int64_field_name} == 3")
+            fs = self._make_function_score(boost_fn, params={"boost_mode": "multiply"})
+
+            actual_ids, actual_scores = self._search_boost_correctness(client, collection_name, fs)
+            assert actual_ids == [1, 3, 2, 4]
+            expected_scores = {
+                1: 0.0,
+                2: 0.4,
+                3: 0.2,
+                4: 2.0,
+            }
+            for pk, score in zip(actual_ids, actual_scores):
+                assert math.isclose(score, expected_scores[pk], rel_tol=1e-5, abs_tol=1e-5), (
+                    f"expected score for pk {pk} to be {expected_scores[pk]}, got {score}"
+                )
+        finally:
+            self.drop_collection(client, collection_name)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_search_boost_ranker_l2_sum_correctness(self):
+        """
+        target: verify boost_mode=sum applies to deterministic L2 internal scores
+        method: add 0.7 to row 3's internal score to move it ahead of row 2
+        expected: returned distances match proxy-restored scores and are sorted ascending
+        """
+        client = self._client()
+        collection_name, _ = self._prepare_deterministic_collection(client, metric_type="L2")
+        try:
+            boost_fn = self._make_boost_function(weight="0.7", filter_expr=f"{self.int64_field_name} == 3")
+            fs = self._make_function_score(boost_fn, params={"boost_mode": "sum"})
+
+            actual_ids, actual_scores = self._search_boost_correctness(client, collection_name, fs)
+            assert actual_ids == [1, 3, 2, 4]
+            expected_scores = {
+                1: 0.0,
+                2: 0.4,
+                3: 0.1,
+                4: 2.0,
+            }
+            for pk, score in zip(actual_ids, actual_scores):
+                assert math.isclose(score, expected_scores[pk], rel_tol=1e-5, abs_tol=1e-5), (
+                    f"expected score for pk {pk} to be {expected_scores[pk]}, got {score}"
+                )
+        finally:
+            self.drop_collection(client, collection_name)
 
     # ==================== Negative Tests ====================
 
@@ -380,13 +726,14 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         fs = self._make_function_score(boost_fn)
 
         self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.err_res,
-            check_items={"err_code": 1100,
-                         "err_msg": "invalid parameter"}
+            check_items={"err_code": 1100, "err_msg": "invalid parameter"},
         )
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -408,13 +755,14 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         fs = self._make_function_score(boost_fn)
 
         self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.err_res,
-            check_items={"err_code": 1100,
-                         "err_msg": "must set weight params"}
+            check_items={"err_code": 1100, "err_msg": "must set weight params"},
         )
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -430,14 +778,15 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         fs = self._make_function_score(boost_fn)
 
         self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             ranker=fs,
             group_by_field=self.int64_field_name,
             check_task=CheckTasks.err_res,
-            check_items={"err_code": 1100,
-                         "err_msg": "segment scorer with group_by"}
+            check_items={"err_code": 1100, "err_msg": "segment scorer with group_by"},
         )
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -453,11 +802,12 @@ class TestSearchBoostRanker(TestMilvusClientV2Base):
         fs = self._make_function_score(boost_fn)
 
         self.search(
-            client, self.collection_name, vectors,
+            client,
+            self.collection_name,
+            vectors,
             anns_field=self.vector_field_name,
             limit=default_limit,
             ranker=fs,
             check_task=CheckTasks.err_res,
-            check_items={"err_code": 1100,
-                         "err_msg": "parse expr failed"}
+            check_items={"err_code": 1100, "err_msg": "parse expr failed"},
         )

--- a/tests/python_client/milvus_client/test_milvus_client_search_group_by.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_group_by.py
@@ -425,6 +425,91 @@ class TestGroupSearch(TestMilvusClientV2Base):
                 check_items={"nq": ct.default_nq, "limit": ct.default_limit},
             )
 
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_hybrid_search_group_by_same_group_across_sub_requests(self):
+        """
+        target: reproduce hybrid search group-by with the same group value returned by different sub requests
+        method: create two vector fields; make each sub request prefer a different row with the same problem_id
+        expected: group_size=1 returns at most one hit per problem_id after weighted rerank
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        dim = 4
+        group_by_field = "problem_id"
+        vector_field_1 = "arcs_vector"
+        vector_field_2 = "description_vector"
+
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(self.primary_field, DataType.INT64, is_primary=True, auto_id=False)
+        schema.add_field(group_by_field, DataType.VARCHAR, max_length=64)
+        schema.add_field(vector_field_1, DataType.FLOAT_VECTOR, dim=dim)
+        schema.add_field(vector_field_2, DataType.FLOAT_VECTOR, dim=dim)
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=vector_field_1, index_type="FLAT", metric_type="COSINE", params={})
+        index_params.add_index(field_name=vector_field_2, index_type="FLAT", metric_type="COSINE", params={})
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
+
+        rows = [
+            {
+                self.primary_field: 1,
+                group_by_field: "p1",
+                vector_field_1: [1.0, 0.0, 0.0, 0.0],
+                vector_field_2: [0.0, 1.0, 0.0, 0.0],
+            },
+            {
+                self.primary_field: 2,
+                group_by_field: "p1",
+                vector_field_1: [0.0, 1.0, 0.0, 0.0],
+                vector_field_2: [1.0, 0.0, 0.0, 0.0],
+            },
+            {
+                self.primary_field: 3,
+                group_by_field: "p2",
+                vector_field_1: [0.0, 0.0, 1.0, 0.0],
+                vector_field_2: [0.0, 0.0, 1.0, 0.0],
+            },
+            {
+                self.primary_field: 4,
+                group_by_field: "p3",
+                vector_field_1: [0.0, 0.0, 0.0, 1.0],
+                vector_field_2: [0.0, 0.0, 0.0, 1.0],
+            },
+        ]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        query_vector = [[1.0, 0.0, 0.0, 0.0]]
+        req_1 = AnnSearchRequest(
+            data=query_vector,
+            anns_field=vector_field_1,
+            param={"metric_type": "COSINE"},
+            limit=4,
+        )
+        req_2 = AnnSearchRequest(
+            data=query_vector,
+            anns_field=vector_field_2,
+            param={"metric_type": "COSINE"},
+            limit=4,
+        )
+        res = self.hybrid_search(
+            client,
+            collection_name,
+            reqs=[req_1, req_2],
+            ranker=WeightedRanker(0.5, 0.5),
+            limit=4,
+            group_by_field=group_by_field,
+            group_size=1,
+            strict_group_size=True,
+            output_fields=[group_by_field],
+            consistency_level="Strong",
+        )[0]
+
+        group_values = [hit.get(group_by_field) for hit in res[0]]
+        log.info(f"hybrid group-by results: ids={[hit.get(self.primary_field) for hit in res[0]]}, groups={group_values}")
+        assert len(group_values) == len(set(group_values)), f"duplicated group values in hybrid search: {group_values}"
+
     @pytest.mark.tags(CaseLabel.L2)
     def test_hybrid_search_group_by_empty_results(self):
         """


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/46565

  Implement boost score evaluation for the Go search reduce pipeline, including
  QueryNode task integration, segcore C API bindings, and score expression
  combination support.

  Add boost score runner logic in core, expose segment-level boost scoring to Go,
  and cover the new behavior with C++, Go, and Python client tests.