### PR TITLE
test: [2.6] add CDC force-promote failover tests

### DIFF
--- a/tests/python_client/cdc/conftest.py
+++ b/tests/python_client/cdc/conftest.py
@@ -1,13 +1,32 @@
-import pytest
-import time
 import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, wait
+
+import pytest
 from pymilvus import MilvusClient
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
+
+
+CDC_UPDATE_REPLICATE_TIMEOUT_SECONDS = 600
+
+
+def apply_replicate_configuration(tasks, timeout=CDC_UPDATE_REPLICATE_TIMEOUT_SECONDS):
+    # Fan out in parallel: the server blocks non-primary clusters in
+    # waitUntilPrimaryChangeOrConfigurationSame until the primary's broadcast
+    # propagates via CDC, so a sequential call where the first client happens
+    # to be a replica deadlocks on the client's RPC timeout.
+    with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
+        futures = [
+            executor.submit(client.update_replicate_configuration, timeout=timeout, **config)
+            for client, config in tasks
+        ]
+        wait(futures)
+    for f in futures:
+        f.result()
+
 
 def pytest_addoption(parser):
     """Add command line options for pytest."""
@@ -35,9 +54,7 @@ def pytest_addoption(parser):
         default="root:Milvus",
         help="Downstream Milvus token",
     )
-    parser.addoption(
-        "--sync-timeout", action="store", default="30", help="Sync timeout in seconds"
-    )
+    parser.addoption("--sync-timeout", action="store", default="30", help="Sync timeout in seconds")
     parser.addoption(
         "--source-cluster-id",
         action="store",
@@ -61,6 +78,18 @@ def pytest_addoption(parser):
         action="store",
         default="30m",
         help="Duration for test operations (e.g., 30m, 1h, 60s)",
+    )
+    parser.addoption(
+        "--is-check",
+        action="store",
+        default="true",
+        help="Whether to assert on checker statistics",
+    )
+    parser.addoption(
+        "--milvus-ns",
+        action="store",
+        default="chaos-testing",
+        help="Kubernetes namespace for Milvus deployment",
     )
 
 
@@ -138,6 +167,163 @@ def request_duration(request):
     return request.config.getoption("--request-duration")
 
 
+@pytest.fixture(scope="session")
+def is_check(request):
+    # The root tests/python_client/conftest.py registers --is_check (underscore)
+    # with type=bool, which argparse maps to the same dest (is_check) as our
+    # --is-check (hyphen). The root's bool wins in chaos runs, so accept either.
+    val = request.config.getoption("--is-check")
+    return val if isinstance(val, bool) else str(val).lower() == "true"
+
+
+@pytest.fixture(scope="session")
+def milvus_ns(request):
+    return request.config.getoption("--milvus-ns")
+
+
+@pytest.fixture(scope="session")
+def switchover_helper(request, upstream_client, downstream_client):
+    """Returns a callable that performs CDC topology switchover."""
+    upstream_uri = request.config.getoption("--upstream-uri")
+    upstream_token = request.config.getoption("--upstream-token")
+    downstream_uri = request.config.getoption("--downstream-uri")
+    downstream_token = request.config.getoption("--downstream-token")
+    pchannel_num = int(request.config.getoption("--pchannel-num"))
+    original_source = request.config.getoption("--source-cluster-id")
+    original_target = request.config.getoption("--target-cluster-id")
+
+    # Map cluster IDs to their URIs/tokens
+    cluster_map = {
+        original_source: {"uri": upstream_uri, "token": upstream_token},
+        original_target: {"uri": downstream_uri, "token": downstream_token},
+    }
+
+    def do_switchover(new_source_id, new_target_id):
+        logger.info(f"Performing switchover: {new_source_id} -> {new_target_id}")
+        config = {
+            "clusters": [
+                {
+                    "cluster_id": new_source_id,
+                    "connection_param": cluster_map[new_source_id],
+                    "pchannels": [f"{new_source_id}-rootcoord-dml_{i}" for i in range(pchannel_num)],
+                },
+                {
+                    "cluster_id": new_target_id,
+                    "connection_param": cluster_map[new_target_id],
+                    "pchannels": [f"{new_target_id}-rootcoord-dml_{i}" for i in range(pchannel_num)],
+                },
+            ],
+            "cross_cluster_topology": [{"source_cluster_id": new_source_id, "target_cluster_id": new_target_id}],
+        }
+        # Dedicated short-lived clients so switchover RPCs don't share a
+        # gRPC channel with concurrent DML on the session-scoped clients.
+        # pymilvus's connection manager closes a channel on UNAVAILABLE /
+        # STREAMING_CODE_REPLICATE_VIOLATION to trigger recovery; if a DML
+        # on the session client triggers that close while our sibling
+        # update_replicate_configuration RPC is in flight on the same
+        # channel, the latter surfaces "Cannot invoke RPC on closed
+        # channel!". Separate clients = separate channels = no race.
+        up_tmp = MilvusClient(uri=upstream_uri, token=upstream_token)
+        dn_tmp = MilvusClient(uri=downstream_uri, token=downstream_token)
+        try:
+            apply_replicate_configuration([(up_tmp, config), (dn_tmp, config)])
+        finally:
+            up_tmp.close()
+            dn_tmp.close()
+        logger.info("Switchover completed, waiting 10s for stabilization...")
+        time.sleep(10)
+
+    return do_switchover
+
+
+@pytest.fixture(scope="session")
+def kubectl_helper(milvus_ns):
+    """Helpers for pod-kill failover scenarios."""
+    import subprocess as _sp
+    import time as _time
+
+    def delete_pods(instance_label):
+        cmd = [
+            "kubectl",
+            "delete",
+            "pods",
+            "-l",
+            f"app.kubernetes.io/instance={instance_label}",
+            "-n",
+            milvus_ns,
+            "--grace-period=0",
+            "--force",
+        ]
+        result = _sp.run(cmd, capture_output=True, text=True, check=False)
+        logger.info(
+            f"[KUBECTL] delete pods {instance_label}: rc={result.returncode}, "
+            f"stdout={result.stdout!r}, stderr={result.stderr!r}"
+        )
+        return result
+
+    def wait_for_pods_ready(instance_label, timeout=300):
+        """Wait for pods matching the label to be Ready.
+
+        Two phases because right after `kubectl delete pods`, the operator
+        hasn't recreated pods yet - `kubectl wait` would error with "no
+        matching resources found". So:
+          1. Poll until at least one pod matches.
+          2. Then `kubectl wait` for Ready on the remaining time budget.
+        """
+        deadline = _time.time() + timeout
+        existence = None
+        while _time.time() < deadline:
+            existence = _sp.run(
+                [
+                    "kubectl",
+                    "get",
+                    "pods",
+                    "-l",
+                    f"app.kubernetes.io/instance={instance_label}",
+                    "-n",
+                    milvus_ns,
+                    "--no-headers",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if existence.stdout.strip():
+                break
+            _time.sleep(5)
+        else:
+            raise TimeoutError(f"no pods matched {instance_label} within {timeout}s")
+
+        remaining = max(1, int(deadline - _time.time()))
+        cmd = [
+            "kubectl",
+            "wait",
+            "--for=condition=Ready",
+            "pods",
+            "-l",
+            f"app.kubernetes.io/instance={instance_label}",
+            "-n",
+            milvus_ns,
+            f"--timeout={remaining}s",
+        ]
+        result = _sp.run(cmd, capture_output=True, text=True, check=False)
+        logger.info(f"[KUBECTL] wait pods {instance_label}: rc={result.returncode}")
+        if result.returncode != 0:
+            raise TimeoutError(
+                f"pods matching {instance_label} did not become Ready within {remaining}s: "
+                f"stdout={result.stdout!r}, stderr={result.stderr!r}"
+            )
+        return result
+
+    class KubectlHelper:
+        pass
+
+    KubectlHelper.delete_pods = staticmethod(delete_pods)
+    KubectlHelper.wait_for_pods_ready = staticmethod(wait_for_pods_ready)
+
+    return KubectlHelper()
+
+
 @pytest.fixture(scope="session", autouse=True)
 def cdc_topology_setup(request, upstream_client, downstream_client):
     """Setup CDC topology at the beginning of test session."""
@@ -147,9 +333,7 @@ def cdc_topology_setup(request, upstream_client, downstream_client):
     target_cluster_id = request.config.getoption("--target-cluster-id")
     pchannel_num = int(request.config.getoption("--pchannel-num"))
 
-    logger.info(
-        f"Setting up CDC topology: {source_cluster_id} -> {target_cluster_id} (channels: {pchannel_num})..."
-    )
+    logger.info(f"Setting up CDC topology: {source_cluster_id} -> {target_cluster_id} (channels: {pchannel_num})...")
 
     # Create CDC replication configuration
     config = {
@@ -160,10 +344,7 @@ def cdc_topology_setup(request, upstream_client, downstream_client):
                     "uri": upstream_uri,
                     "token": request.config.getoption("--upstream-token"),
                 },
-                "pchannels": [
-                    f"{source_cluster_id}-rootcoord-dml_{i}"
-                    for i in range(pchannel_num)
-                ],
+                "pchannels": [f"{source_cluster_id}-rootcoord-dml_{i}" for i in range(pchannel_num)],
             },
             {
                 "cluster_id": target_cluster_id,
@@ -171,10 +352,7 @@ def cdc_topology_setup(request, upstream_client, downstream_client):
                     "uri": downstream_uri,
                     "token": request.config.getoption("--downstream-token"),
                 },
-                "pchannels": [
-                    f"{target_cluster_id}-rootcoord-dml_{i}"
-                    for i in range(pchannel_num)
-                ],
+                "pchannels": [f"{target_cluster_id}-rootcoord-dml_{i}" for i in range(pchannel_num)],
             },
         ],
         "cross_cluster_topology": [
@@ -186,9 +364,16 @@ def cdc_topology_setup(request, upstream_client, downstream_client):
     }
 
     try:
-        # Update replication configuration on both clusters
-        upstream_client.update_replicate_configuration(**config)
-        downstream_client.update_replicate_configuration(**config)
+        # Dedicated clients for the control-plane update_replicate_configuration
+        # RPC, mirroring switchover_helper. Keeps the session-scoped clients'
+        # channels clean of any recovery side effects from the initial setup.
+        up_tmp = MilvusClient(uri=upstream_uri, token=request.config.getoption("--upstream-token"))
+        dn_tmp = MilvusClient(uri=downstream_uri, token=request.config.getoption("--downstream-token"))
+        try:
+            apply_replicate_configuration([(up_tmp, config), (dn_tmp, config)])
+        finally:
+            up_tmp.close()
+            dn_tmp.close()
         logger.info("CDC topology setup completed successfully")
 
         # Allow some time for CDC to initialize

--- a/tests/python_client/cdc/testcases/test_force_promote.py
+++ b/tests/python_client/cdc/testcases/test_force_promote.py
@@ -1,0 +1,962 @@
+"""
+CDC force-promote failover scenario tests.
+
+Each test exercises a path through the streamingnode replicate interceptor's
+SwitchReplicateMode + force-promote ack-callback flow:
+- basic           — kill source, promote secondary, verify writable
+- target_restart  — restart secondary mid-promote
+- source_restart  — restart primary mid-promote
+- incomplete_ddl  — release on primary then immediately promote (Ignore=true path)
+- network_partition — partition source↔target, then promote
+- endurance (skipif) — repeated promote/restore loop for ENDURANCE_DURATION_MINUTES
+
+Every test's `finally` restores the A→B topology via switchover_helper so
+subsequent tests start from a known state.
+"""
+
+import os
+import subprocess
+import tempfile
+import threading
+import time
+
+import pytest
+import yaml
+from common.common_type import CaseLabel
+
+from .base import TestCDCSyncBase, logger
+
+FAILOVER_TIMEOUT = int(os.getenv("FAILOVER_TIMEOUT", "180"))
+FORCE_PROMOTE_RPC_TIMEOUT = int(os.getenv("FORCE_PROMOTE_RPC_TIMEOUT", "60"))
+PROMOTE_RETRY_INTERVAL = 5
+DEFAULT_INSERT_COUNT = 200
+
+
+@pytest.mark.tags(CaseLabel.CDC)
+class TestCDCForcePromote(TestCDCSyncBase):
+    """Force-promote failover scenarios."""
+
+    def setup_method(self):
+        self.resources_to_cleanup = []
+        self._upstream_client = None
+        self._downstream_client = None
+
+    def teardown_method(self):
+        """Safety-net cleanup: iterates resources_to_cleanup if a test raised
+        before its own finally could run. Normal cleanup happens in each test's
+        finally block."""
+        for resource_type, resource_name in getattr(self, "resources_to_cleanup", []):
+            if resource_type != "collection":
+                continue
+            for client in (
+                getattr(self, "_upstream_client", None),
+                getattr(self, "_downstream_client", None),
+            ):
+                if client is None:
+                    continue
+                try:
+                    self.cleanup_collection(client, resource_name)
+                except Exception:
+                    pass
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def do_force_promote(
+        self,
+        downstream_client,
+        target_cluster_id,
+        downstream_uri,
+        downstream_token,
+        pchannel_num,
+        timeout=FORCE_PROMOTE_RPC_TIMEOUT,
+    ):
+        """Call force_promote on downstream with a standalone-primary config."""
+        config = {
+            "clusters": [
+                {
+                    "cluster_id": target_cluster_id,
+                    "connection_param": {"uri": downstream_uri, "token": downstream_token},
+                    "pchannels": [f"{target_cluster_id}-rootcoord-dml_{i}" for i in range(pchannel_num)],
+                }
+            ],
+            "cross_cluster_topology": [],
+        }
+        downstream_client.update_replicate_configuration(
+            timeout=timeout,
+            force_promote=True,
+            **config,
+        )
+        logger.info(f"[FORCE_PROMOTE] called on {target_cluster_id} (standalone primary config)")
+
+    def is_already_primary_error(self, err):
+        return "force promote can only be used on secondary clusters" in str(
+            err
+        ) and "current cluster is primary" in str(err)
+
+    def promote_call_until_writable(
+        self,
+        downstream_client,
+        target_cluster_id,
+        downstream_uri,
+        downstream_token,
+        pchannel_num,
+        timeout=FAILOVER_TIMEOUT,
+    ):
+        """Retry force_promote + probe write until success or timeout.
+
+        A probe write creates+drops a throwaway collection. This proves
+        downstream is in standalone-primary mode and accepts DDL.
+        """
+        deadline = time.time() + timeout
+        last_err = None
+        while time.time() < deadline:
+            try:
+                try:
+                    remaining = max(1, int(deadline - time.time()))
+                    self.do_force_promote(
+                        downstream_client,
+                        target_cluster_id,
+                        downstream_uri,
+                        downstream_token,
+                        pchannel_num,
+                        timeout=min(FORCE_PROMOTE_RPC_TIMEOUT, remaining),
+                    )
+                except Exception as e:
+                    if not self.is_already_primary_error(e):
+                        raise
+                    logger.info("[FORCE_PROMOTE] target is already primary; probing writable state")
+                probe = self.gen_unique_name("promote_probe", max_length=40)
+                schema = self.create_default_schema(downstream_client)
+                downstream_client.create_collection(probe, schema=schema)
+                downstream_client.drop_collection(probe)
+                logger.info("[FORCE_PROMOTE] probe write succeeded — cluster writable")
+                return
+            except Exception as e:
+                last_err = e
+                logger.warning(f"[FORCE_PROMOTE_RETRY] failed: {e}")
+                sleep_seconds = min(PROMOTE_RETRY_INTERVAL, max(0, deadline - time.time()))
+                if sleep_seconds:
+                    time.sleep(sleep_seconds)
+        raise TimeoutError(f"force_promote did not become writable within {timeout}s; last error: {last_err}")
+
+    def cleanup_resources(self):
+        """Drop any collections registered in resources_to_cleanup."""
+        for resource_type, resource_name in self.resources_to_cleanup:
+            if resource_type != "collection":
+                continue
+            for client_label, client in (
+                ("upstream", self._upstream_client),
+                ("downstream", self._downstream_client),
+            ):
+                if client is None:
+                    continue
+                try:
+                    self.cleanup_collection(client, resource_name)
+                    logger.info(f"[CLEANUP] dropped {resource_name} on {client_label}")
+                except Exception as e:
+                    logger.warning(f"[CLEANUP] failed to drop {resource_name} on {client_label}: {e}")
+        self.resources_to_cleanup = []
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_force_promote_basic(
+        self,
+        upstream_client,
+        downstream_client,
+        sync_timeout,
+        switchover_helper,
+        kubectl_helper,
+        source_cluster_id,
+        target_cluster_id,
+        upstream_uri,
+        upstream_token,
+        downstream_uri,
+        downstream_token,
+        pchannel_num,
+    ):
+        """Insert N → kill source → force_promote(downstream) → verify writable."""
+        start_time = time.time()
+        c_name = self.gen_unique_name("test_fp_basic", max_length=50)
+        c_after = f"{c_name}_after"
+
+        self.log_test_start("test_force_promote_basic", "FORCE_PROMOTE_BASIC", c_name)
+        self._upstream_client = upstream_client
+        self._downstream_client = downstream_client
+        self.resources_to_cleanup.append(("collection", c_name))
+        self.resources_to_cleanup.append(("collection", c_after))
+
+        try:
+            self.cleanup_collection(upstream_client, c_name)
+            schema = self.create_manual_id_schema(upstream_client)
+            upstream_client.create_collection(collection_name=c_name, schema=schema)
+            index_params = upstream_client.prepare_index_params()
+            index_params.add_index(
+                field_name="vector",
+                index_type="HNSW",
+                metric_type="L2",
+                params={"M": 16, "efConstruction": 200},
+            )
+            upstream_client.create_index(c_name, index_params)
+            upstream_client.load_collection(c_name)
+
+            assert self.wait_for_sync(
+                lambda: downstream_client.has_collection(c_name),
+                sync_timeout,
+                f"create collection {c_name}",
+            )
+
+            data = self.generate_test_data_with_id(DEFAULT_INSERT_COUNT, start_id=0)
+            upstream_client.insert(c_name, data)
+            upstream_client.flush(c_name)
+
+            def check_synced():
+                try:
+                    res = downstream_client.query(collection_name=c_name, filter="", output_fields=["count(*)"])
+                    cnt = res[0]["count(*)"] if res else 0
+                    logger.info(f"[SYNC_PROGRESS] downstream count: {cnt}/{DEFAULT_INSERT_COUNT}")
+                    return cnt >= DEFAULT_INSERT_COUNT
+                except Exception as e:
+                    logger.warning(f"sync check failed: {e}")
+                    return False
+
+            assert self.wait_for_sync(check_synced, sync_timeout, f"initial sync {c_name}")
+
+            # Kill source
+            logger.info(f"[FAILOVER] Killing source pods (instance={source_cluster_id})...")
+            kubectl_helper.delete_pods(source_cluster_id)
+
+            # Promote downstream — retry until writable
+            self.promote_call_until_writable(
+                downstream_client,
+                target_cluster_id,
+                downstream_uri,
+                downstream_token,
+                pchannel_num,
+            )
+
+            # On downstream (now standalone primary), create a new collection + insert
+            schema_after = self.create_manual_id_schema(downstream_client)
+            downstream_client.create_collection(collection_name=c_after, schema=schema_after)
+            idx_after = downstream_client.prepare_index_params()
+            idx_after.add_index(
+                field_name="vector",
+                index_type="HNSW",
+                metric_type="L2",
+                params={"M": 16, "efConstruction": 200},
+            )
+            downstream_client.create_index(c_after, idx_after)
+            downstream_client.load_collection(c_after)
+            data_after = self.generate_test_data_with_id(100, start_id=0)
+            downstream_client.insert(c_after, data_after)
+            downstream_client.flush(c_after)
+
+            res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
+            assert res and res[0]["count(*)"] >= 100, f"downstream not writable after force_promote: count={res}"
+        finally:
+            logger.info("[TEARDOWN] Waiting for source pods before topology restore...")
+            kubectl_helper.wait_for_pods_ready(source_cluster_id, timeout=300)
+            logger.info("[TEARDOWN] Restoring A→B topology...")
+            try:
+                switchover_helper(source_cluster_id, target_cluster_id)
+            except Exception as e:
+                logger.warning(f"switchover restore failed: {e}")
+            self.cleanup_resources()
+            self.log_test_end("test_force_promote_basic", True, time.time() - start_time)
+
+    def test_force_promote_during_target_restart(
+        self,
+        upstream_client,
+        downstream_client,
+        sync_timeout,
+        switchover_helper,
+        kubectl_helper,
+        source_cluster_id,
+        target_cluster_id,
+        upstream_uri,
+        upstream_token,
+        downstream_uri,
+        downstream_token,
+        pchannel_num,
+    ):
+        """Promote downstream while downstream pods are bouncing.
+
+        Mirrors snippets test_restart_b_during_force_promote.py: promote runs
+        async, restart happens in main thread mid-promote.
+        """
+        start_time = time.time()
+        c_name = self.gen_unique_name("test_fp_target_restart", max_length=50)
+        c_after = f"{c_name}_after"
+
+        self.log_test_start(
+            "test_force_promote_during_target_restart",
+            "FORCE_PROMOTE_TARGET_RESTART",
+            c_name,
+        )
+        self._upstream_client = upstream_client
+        self._downstream_client = downstream_client
+        self.resources_to_cleanup.append(("collection", c_name))
+        self.resources_to_cleanup.append(("collection", c_after))
+
+        try:
+            self.cleanup_collection(upstream_client, c_name)
+            schema = self.create_manual_id_schema(upstream_client)
+            upstream_client.create_collection(collection_name=c_name, schema=schema)
+            index_params = upstream_client.prepare_index_params()
+            index_params.add_index(
+                field_name="vector",
+                index_type="HNSW",
+                metric_type="L2",
+                params={"M": 16, "efConstruction": 200},
+            )
+            upstream_client.create_index(c_name, index_params)
+            upstream_client.load_collection(c_name)
+            assert self.wait_for_sync(
+                lambda: downstream_client.has_collection(c_name),
+                sync_timeout,
+                f"create collection {c_name}",
+            )
+
+            data = self.generate_test_data_with_id(DEFAULT_INSERT_COUNT, start_id=0)
+            upstream_client.insert(c_name, data)
+            upstream_client.flush(c_name)
+
+            def check_synced():
+                try:
+                    res = downstream_client.query(collection_name=c_name, filter="", output_fields=["count(*)"])
+                    return (res[0]["count(*)"] if res else 0) >= DEFAULT_INSERT_COUNT
+                except Exception:
+                    return False
+
+            assert self.wait_for_sync(check_synced, sync_timeout, f"sync {c_name}")
+
+            # Promote async — first call almost certainly fails because target dies
+            promote_err = []
+
+            def promote_thread():
+                try:
+                    self.do_force_promote(
+                        downstream_client,
+                        target_cluster_id,
+                        downstream_uri,
+                        downstream_token,
+                        pchannel_num,
+                    )
+                except Exception as e:
+                    promote_err.append(e)
+
+            th = threading.Thread(target=promote_thread, daemon=True)
+            th.start()
+
+            # Mid-promote: kill target pods, wait for them to come back
+            time.sleep(2)
+            logger.info("[FAILOVER] Killing target pods mid-promote...")
+            kubectl_helper.delete_pods(target_cluster_id)
+            time.sleep(2)
+            kubectl_helper.wait_for_pods_ready(target_cluster_id, timeout=300)
+
+            th.join(timeout=FAILOVER_TIMEOUT)
+            assert not th.is_alive(), "Background force_promote thread did not finish in time"
+            if promote_err:
+                logger.info(f"[EXPECTED] async promote raised: {promote_err[0]}")
+
+            # Retry until writable
+            self.promote_call_until_writable(
+                downstream_client,
+                target_cluster_id,
+                downstream_uri,
+                downstream_token,
+                pchannel_num,
+            )
+
+            schema_after = self.create_manual_id_schema(downstream_client)
+            downstream_client.create_collection(collection_name=c_after, schema=schema_after)
+            idx_after = downstream_client.prepare_index_params()
+            idx_after.add_index(
+                field_name="vector",
+                index_type="HNSW",
+                metric_type="L2",
+                params={"M": 16, "efConstruction": 200},
+            )
+            downstream_client.create_index(c_after, idx_after)
+            downstream_client.load_collection(c_after)
+            data_after = self.generate_test_data_with_id(100, start_id=0)
+            downstream_client.insert(c_after, data_after)
+            downstream_client.flush(c_after)
+            res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
+            assert res and res[0]["count(*)"] >= 100, f"downstream not writable after target restart: {res}"
+        finally:
+            logger.info("[TEARDOWN] Waiting for target pods before topology restore...")
+            kubectl_helper.wait_for_pods_ready(target_cluster_id, timeout=300)
+            logger.info("[TEARDOWN] Restoring A→B topology...")
+            try:
+                switchover_helper(source_cluster_id, target_cluster_id)
+            except Exception as e:
+                logger.warning(f"switchover restore failed: {e}")
+            self.cleanup_resources()
+            self.log_test_end(
+                "test_force_promote_during_target_restart",
+                True,
+                time.time() - start_time,
+            )
+
+    def test_force_promote_during_source_restart(
+        self,
+        upstream_client,
+        downstream_client,
+        sync_timeout,
+        switchover_helper,
+        kubectl_helper,
+        source_cluster_id,
+        target_cluster_id,
+        upstream_uri,
+        upstream_token,
+        downstream_uri,
+        downstream_token,
+        pchannel_num,
+    ):
+        """Promote downstream while upstream pods are bouncing.
+
+        Mirrors snippets test_restart_a_during_force_promote.py.
+        """
+        start_time = time.time()
+        c_name = self.gen_unique_name("test_fp_source_restart", max_length=50)
+        c_after = f"{c_name}_after"
+
+        self.log_test_start(
+            "test_force_promote_during_source_restart",
+            "FORCE_PROMOTE_SOURCE_RESTART",
+            c_name,
+        )
+        self._upstream_client = upstream_client
+        self._downstream_client = downstream_client
+        self.resources_to_cleanup.append(("collection", c_name))
+        self.resources_to_cleanup.append(("collection", c_after))
+
+        try:
+            self.cleanup_collection(upstream_client, c_name)
+            schema = self.create_manual_id_schema(upstream_client)
+            upstream_client.create_collection(collection_name=c_name, schema=schema)
+            index_params = upstream_client.prepare_index_params()
+            index_params.add_index(
+                field_name="vector",
+                index_type="HNSW",
+                metric_type="L2",
+                params={"M": 16, "efConstruction": 200},
+            )
+            upstream_client.create_index(c_name, index_params)
+            upstream_client.load_collection(c_name)
+            assert self.wait_for_sync(
+                lambda: downstream_client.has_collection(c_name),
+                sync_timeout,
+                f"create collection {c_name}",
+            )
+
+            data = self.generate_test_data_with_id(DEFAULT_INSERT_COUNT, start_id=0)
+            upstream_client.insert(c_name, data)
+            upstream_client.flush(c_name)
+
+            def check_synced():
+                try:
+                    res = downstream_client.query(collection_name=c_name, filter="", output_fields=["count(*)"])
+                    return (res[0]["count(*)"] if res else 0) >= DEFAULT_INSERT_COUNT
+                except Exception:
+                    return False
+
+            assert self.wait_for_sync(check_synced, sync_timeout, f"sync {c_name}")
+
+            promote_err = []
+
+            def promote_thread():
+                try:
+                    self.do_force_promote(
+                        downstream_client,
+                        target_cluster_id,
+                        downstream_uri,
+                        downstream_token,
+                        pchannel_num,
+                    )
+                except Exception as e:
+                    promote_err.append(e)
+
+            th = threading.Thread(target=promote_thread, daemon=True)
+            th.start()
+
+            time.sleep(2)
+            logger.info("[FAILOVER] Killing source pods mid-promote...")
+            kubectl_helper.delete_pods(source_cluster_id)
+            # Don't wait-ready here — promotion should succeed independently
+            # of whether the old primary is back.
+
+            th.join(timeout=FAILOVER_TIMEOUT)
+            assert not th.is_alive(), "Background force_promote thread did not finish in time"
+            if promote_err:
+                logger.info(f"[INFO] async promote raised (may be expected): {promote_err[0]}")
+
+            self.promote_call_until_writable(
+                downstream_client,
+                target_cluster_id,
+                downstream_uri,
+                downstream_token,
+                pchannel_num,
+            )
+
+            schema_after = self.create_manual_id_schema(downstream_client)
+            downstream_client.create_collection(collection_name=c_after, schema=schema_after)
+            idx_after = downstream_client.prepare_index_params()
+            idx_after.add_index(
+                field_name="vector",
+                index_type="HNSW",
+                metric_type="L2",
+                params={"M": 16, "efConstruction": 200},
+            )
+            downstream_client.create_index(c_after, idx_after)
+            downstream_client.load_collection(c_after)
+            data_after = self.generate_test_data_with_id(100, start_id=0)
+            downstream_client.insert(c_after, data_after)
+            downstream_client.flush(c_after)
+            res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
+            assert res and res[0]["count(*)"] >= 100, f"downstream not writable after source restart: {res}"
+        finally:
+            logger.info("[TEARDOWN] Waiting for source pods before topology restore...")
+            kubectl_helper.wait_for_pods_ready(source_cluster_id, timeout=300)
+            logger.info("[TEARDOWN] Restoring A→B topology...")
+            try:
+                switchover_helper(source_cluster_id, target_cluster_id)
+            except Exception as e:
+                logger.warning(f"switchover restore failed: {e}")
+            self.cleanup_resources()
+            self.log_test_end(
+                "test_force_promote_during_source_restart",
+                True,
+                time.time() - start_time,
+            )
+
+    def test_force_promote_with_incomplete_ddl(
+        self,
+        upstream_client,
+        downstream_client,
+        sync_timeout,
+        switchover_helper,
+        source_cluster_id,
+        target_cluster_id,
+        upstream_uri,
+        upstream_token,
+        downstream_uri,
+        downstream_token,
+        pchannel_num,
+    ):
+        """release_collection on upstream then immediately force_promote.
+
+        Exercises the Ignore=true path in
+        ackCallbackScheduler.fixIncompleteBroadcastsForForcePromote — DDL that
+        was mid-broadcast when the operator promoted gets marked Ignore=true
+        and resubmitted with replicate header cleared.
+
+        Mirrors snippets test_incomplete_broadcast_ddl.py.
+        """
+        start_time = time.time()
+        c_name = self.gen_unique_name("test_fp_inc_ddl", max_length=50)
+        c_after = f"{c_name}_after"
+
+        self.log_test_start(
+            "test_force_promote_with_incomplete_ddl",
+            "FORCE_PROMOTE_INCOMPLETE_DDL",
+            c_name,
+        )
+        self._upstream_client = upstream_client
+        self._downstream_client = downstream_client
+        self.resources_to_cleanup.append(("collection", c_name))
+        self.resources_to_cleanup.append(("collection", c_after))
+
+        try:
+            self.cleanup_collection(upstream_client, c_name)
+            schema = self.create_manual_id_schema(upstream_client)
+            upstream_client.create_collection(collection_name=c_name, schema=schema)
+            index_params = upstream_client.prepare_index_params()
+            index_params.add_index(
+                field_name="vector",
+                index_type="HNSW",
+                metric_type="L2",
+                params={"M": 16, "efConstruction": 200},
+            )
+            upstream_client.create_index(c_name, index_params)
+            upstream_client.load_collection(c_name)
+            assert self.wait_for_sync(
+                lambda: downstream_client.has_collection(c_name),
+                sync_timeout,
+                f"create collection {c_name}",
+            )
+
+            data = self.generate_test_data_with_id(DEFAULT_INSERT_COUNT, start_id=0)
+            upstream_client.insert(c_name, data)
+            upstream_client.flush(c_name)
+
+            def check_synced():
+                try:
+                    res = downstream_client.query(collection_name=c_name, filter="", output_fields=["count(*)"])
+                    return (res[0]["count(*)"] if res else 0) >= DEFAULT_INSERT_COUNT
+                except Exception:
+                    return False
+
+            assert self.wait_for_sync(check_synced, sync_timeout, f"sync {c_name}")
+
+            # In-flight DDL on upstream — may not finish replicating before promote
+            upstream_client.release_collection(c_name)
+            logger.info(f"[INCOMPLETE_DDL] release_collection sent on {c_name}")
+
+            # Immediately promote downstream (no sleep)
+            self.promote_call_until_writable(
+                downstream_client,
+                target_cluster_id,
+                downstream_uri,
+                downstream_token,
+                pchannel_num,
+            )
+
+            # On downstream (now primary), create new collection + insert
+            schema_after = self.create_manual_id_schema(downstream_client)
+            downstream_client.create_collection(collection_name=c_after, schema=schema_after)
+            idx_after = downstream_client.prepare_index_params()
+            idx_after.add_index(
+                field_name="vector",
+                index_type="HNSW",
+                metric_type="L2",
+                params={"M": 16, "efConstruction": 200},
+            )
+            downstream_client.create_index(c_after, idx_after)
+            downstream_client.load_collection(c_after)
+            data_after = self.generate_test_data_with_id(100, start_id=0)
+            downstream_client.insert(c_after, data_after)
+            downstream_client.flush(c_after)
+            res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
+            assert res and res[0]["count(*)"] >= 100, f"downstream not writable after incomplete DDL: {res}"
+        finally:
+            logger.info("[TEARDOWN] Restoring A→B topology...")
+            try:
+                switchover_helper(source_cluster_id, target_cluster_id)
+            except Exception as e:
+                logger.warning(f"switchover restore failed: {e}")
+            self.cleanup_resources()
+            self.log_test_end(
+                "test_force_promote_with_incomplete_ddl",
+                True,
+                time.time() - start_time,
+            )
+
+    def _build_partition_manifest(self, source_cluster_id, target_cluster_id, milvus_ns):
+        """Return a NetworkChaos dict that bidirectionally partitions source ↔ target."""
+        return {
+            "apiVersion": "chaos-mesh.org/v1alpha1",
+            "kind": "NetworkChaos",
+            "metadata": {
+                "name": f"{source_cluster_id}-failover-partition",
+                "namespace": milvus_ns,
+            },
+            "spec": {
+                "action": "partition",
+                "mode": "all",
+                "selector": {
+                    "namespaces": [milvus_ns],
+                    "labelSelectors": {"app.kubernetes.io/instance": source_cluster_id},
+                },
+                "direction": "both",
+                "target": {
+                    "mode": "all",
+                    "selector": {
+                        "namespaces": [milvus_ns],
+                        "labelSelectors": {"app.kubernetes.io/instance": target_cluster_id},
+                    },
+                },
+            },
+        }
+
+    def test_force_promote_with_network_partition(
+        self,
+        upstream_client,
+        downstream_client,
+        sync_timeout,
+        switchover_helper,
+        milvus_ns,
+        source_cluster_id,
+        target_cluster_id,
+        upstream_uri,
+        upstream_token,
+        downstream_uri,
+        downstream_token,
+        pchannel_num,
+    ):
+        """Apply NetworkChaos partition between source/target, then force_promote.
+
+        K8s-native scenario that the snippets tests can't reproduce. Simulates
+        the realistic emergency that motivates force_promote: secondary cannot
+        reach primary, operator force-promotes secondary.
+        """
+        start_time = time.time()
+        c_name = self.gen_unique_name("test_fp_partition", max_length=50)
+        c_after = f"{c_name}_after"
+        chaos_name = f"{source_cluster_id}-failover-partition"
+
+        self.log_test_start(
+            "test_force_promote_with_network_partition",
+            "FORCE_PROMOTE_PARTITION",
+            c_name,
+        )
+        self._upstream_client = upstream_client
+        self._downstream_client = downstream_client
+        self.resources_to_cleanup.append(("collection", c_name))
+        self.resources_to_cleanup.append(("collection", c_after))
+
+        chaos_path = None
+        try:
+            self.cleanup_collection(upstream_client, c_name)
+            schema = self.create_manual_id_schema(upstream_client)
+            upstream_client.create_collection(collection_name=c_name, schema=schema)
+            index_params = upstream_client.prepare_index_params()
+            index_params.add_index(
+                field_name="vector",
+                index_type="HNSW",
+                metric_type="L2",
+                params={"M": 16, "efConstruction": 200},
+            )
+            upstream_client.create_index(c_name, index_params)
+            upstream_client.load_collection(c_name)
+            assert self.wait_for_sync(
+                lambda: downstream_client.has_collection(c_name),
+                sync_timeout,
+                f"create collection {c_name}",
+            )
+
+            data = self.generate_test_data_with_id(DEFAULT_INSERT_COUNT, start_id=0)
+            upstream_client.insert(c_name, data)
+            upstream_client.flush(c_name)
+
+            def check_synced():
+                try:
+                    res = downstream_client.query(collection_name=c_name, filter="", output_fields=["count(*)"])
+                    return (res[0]["count(*)"] if res else 0) >= DEFAULT_INSERT_COUNT
+                except Exception:
+                    return False
+
+            assert self.wait_for_sync(check_synced, sync_timeout, f"sync {c_name}")
+
+            # Apply NetworkChaos
+            manifest = self._build_partition_manifest(source_cluster_id, target_cluster_id, milvus_ns)
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+                yaml.safe_dump(manifest, f)
+                chaos_path = f.name
+            logger.info(f"[CHAOS] applying NetworkChaos partition: {chaos_path}")
+            apply_result = subprocess.run(
+                ["kubectl", "apply", "-f", chaos_path],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert apply_result.returncode == 0, f"kubectl apply failed: {apply_result.stderr}"
+
+            # Let the partition propagate
+            time.sleep(10)
+
+            # Force promote downstream — it can't reach upstream
+            self.promote_call_until_writable(
+                downstream_client,
+                target_cluster_id,
+                downstream_uri,
+                downstream_token,
+                pchannel_num,
+            )
+
+            # Verify writable
+            schema_after = self.create_manual_id_schema(downstream_client)
+            downstream_client.create_collection(collection_name=c_after, schema=schema_after)
+            idx_after = downstream_client.prepare_index_params()
+            idx_after.add_index(
+                field_name="vector",
+                index_type="HNSW",
+                metric_type="L2",
+                params={"M": 16, "efConstruction": 200},
+            )
+            downstream_client.create_index(c_after, idx_after)
+            downstream_client.load_collection(c_after)
+            data_after = self.generate_test_data_with_id(100, start_id=0)
+            downstream_client.insert(c_after, data_after)
+            downstream_client.flush(c_after)
+            res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
+            assert res and res[0]["count(*)"] >= 100, f"downstream not writable after partition+promote: {res}"
+        finally:
+            # Remove the partition first so switchover can fan-out across clusters
+            logger.info(f"[CHAOS] cleaning up NetworkChaos {chaos_name}")
+            subprocess.run(
+                ["kubectl", "delete", "networkchaos", chaos_name, "-n", milvus_ns],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if chaos_path and os.path.exists(chaos_path):
+                os.unlink(chaos_path)
+            # Allow partition to clear before switchover
+            time.sleep(10)
+            logger.info("[TEARDOWN] Restoring A→B topology...")
+            try:
+                switchover_helper(source_cluster_id, target_cluster_id)
+            except Exception as e:
+                logger.warning(f"switchover restore failed: {e}")
+            self.cleanup_resources()
+            self.log_test_end(
+                "test_force_promote_with_network_partition",
+                True,
+                time.time() - start_time,
+            )
+
+    def _do_one_endurance_iteration(
+        self,
+        iteration,
+        upstream_client,
+        downstream_client,
+        sync_timeout,
+        switchover_helper,
+        source_cluster_id,
+        target_cluster_id,
+        upstream_uri,
+        upstream_token,
+        downstream_uri,
+        downstream_token,
+        pchannel_num,
+    ):
+        """One endurance iteration: DDL + insert + force_promote + DDL on new primary."""
+        c_before = f"endurance_before_{iteration}"
+        c_after = f"endurance_after_{iteration}"
+
+        # Reset to A→B topology (in case prior iteration left state behind)
+        try:
+            switchover_helper(source_cluster_id, target_cluster_id)
+        except Exception as e:
+            raise RuntimeError(f"[iter {iteration}] pre-iter switchover failed") from e
+
+        # DDL before failover on upstream
+        self.cleanup_collection(upstream_client, c_before)
+        schema = self.create_manual_id_schema(upstream_client)
+        upstream_client.create_collection(collection_name=c_before, schema=schema)
+        idx = upstream_client.prepare_index_params()
+        idx.add_index(
+            field_name="vector",
+            index_type="HNSW",
+            metric_type="L2",
+            params={"M": 16, "efConstruction": 200},
+        )
+        upstream_client.create_index(c_before, idx)
+        upstream_client.load_collection(c_before)
+        assert self.wait_for_sync(
+            lambda: downstream_client.has_collection(c_before),
+            sync_timeout,
+            f"[iter {iteration}] create {c_before}",
+        )
+        data = self.generate_test_data_with_id(100, start_id=0)
+        upstream_client.insert(c_before, data)
+        upstream_client.flush(c_before)
+
+        def check_synced():
+            try:
+                res = downstream_client.query(collection_name=c_before, filter="", output_fields=["count(*)"])
+                return (res[0]["count(*)"] if res else 0) >= 100
+            except Exception:
+                return False
+
+        assert self.wait_for_sync(check_synced, sync_timeout, f"[iter {iteration}] sync {c_before}")
+
+        # In-flight DDL
+        upstream_client.release_collection(c_before)
+
+        # Force promote
+        self.promote_call_until_writable(
+            downstream_client,
+            target_cluster_id,
+            downstream_uri,
+            downstream_token,
+            pchannel_num,
+        )
+
+        # DDL after failover on downstream
+        schema_after = self.create_manual_id_schema(downstream_client)
+        downstream_client.create_collection(collection_name=c_after, schema=schema_after)
+        idx_after = downstream_client.prepare_index_params()
+        idx_after.add_index(
+            field_name="vector",
+            index_type="HNSW",
+            metric_type="L2",
+            params={"M": 16, "efConstruction": 200},
+        )
+        downstream_client.create_index(c_after, idx_after)
+        downstream_client.load_collection(c_after)
+        data_after = self.generate_test_data_with_id(100, start_id=0)
+        downstream_client.insert(c_after, data_after)
+        downstream_client.flush(c_after)
+        res = downstream_client.query(collection_name=c_after, filter="", output_fields=["count(*)"])
+        assert res and res[0]["count(*)"] >= 100, f"[iter {iteration}] downstream count check failed: {res}"
+
+        # Cleanup both
+        try:
+            downstream_client.drop_collection(c_after)
+        except Exception as e:
+            logger.warning(f"[iter {iteration}] drop {c_after} on downstream: {e}")
+        try:
+            downstream_client.drop_collection(c_before)
+        except Exception as e:
+            logger.warning(f"[iter {iteration}] drop {c_before} on downstream: {e}")
+
+    @pytest.mark.skipif(
+        not os.getenv("RUN_ENDURANCE"),
+        reason="Endurance test only runs when RUN_ENDURANCE is set",
+    )
+    def test_endurance_force_promote(
+        self,
+        upstream_client,
+        downstream_client,
+        sync_timeout,
+        switchover_helper,
+        source_cluster_id,
+        target_cluster_id,
+        upstream_uri,
+        upstream_token,
+        downstream_uri,
+        downstream_token,
+        pchannel_num,
+    ):
+        """Endurance loop: repeated force_promote + DDL for ENDURANCE_DURATION_MINUTES."""
+        duration_minutes = int(os.getenv("ENDURANCE_DURATION_MINUTES", "30"))
+        deadline = time.time() + duration_minutes * 60
+        iteration = 0
+        start_time = time.time()
+        self.log_test_start("test_endurance_force_promote", "ENDURANCE_FORCE_PROMOTE", "")
+        self._upstream_client = upstream_client
+        self._downstream_client = downstream_client
+
+        try:
+            while time.time() < deadline:
+                iteration += 1
+                logger.info(f"=== Endurance iteration {iteration} ===")
+                self._do_one_endurance_iteration(
+                    iteration,
+                    upstream_client,
+                    downstream_client,
+                    sync_timeout,
+                    switchover_helper,
+                    source_cluster_id,
+                    target_cluster_id,
+                    upstream_uri,
+                    upstream_token,
+                    downstream_uri,
+                    downstream_token,
+                    pchannel_num,
+                )
+            logger.info(f"PASSED endurance: {iteration} iterations in {duration_minutes}m")
+        finally:
+            logger.info("[TEARDOWN] Restoring A→B topology after endurance...")
+            try:
+                switchover_helper(source_cluster_id, target_cluster_id)
+            except Exception as e:
+                logger.warning(f"switchover restore failed: {e}")
+            self.log_test_end("test_endurance_force_promote", True, time.time() - start_time)


### PR DESCRIPTION
pr: #49423
## Summary

- Backport CDC force-promote failover scenario tests from #49423 to the 2.6 branch.
- Add the CDC pytest fixtures required by the force-promote tests, including `--milvus-ns`, switchover helpers, and pod readiness helpers.
- Use parallel replicate configuration updates for CDC setup and switchover paths.

## Test
- python -m py_compile tests/python_client/cdc/conftest.py tests/python_client/cdc/testcases/test_force_promote.py
- cd tests/python_client/cdc && pytest testcases/test_force_promote.py --collect-only --milvus-ns chaos-testing --upstream-uri http://127.0.0.1:19530 --downstream-uri http://127.0.0.1:19531 -q