### PR TITLE
fix: declare -lcrypto in the FIPS OpenSSL cgo package

### DIFF
--- a/pkg/util/fips/openssl_enabled.go
+++ b/pkg/util/fips/openssl_enabled.go
@@ -19,6 +19,7 @@
 package fips
 
 /*
+#cgo LDFLAGS: -lcrypto
 #include <openssl/conf.h>
 #include <openssl/evp.h>
 #include <openssl/provider.h>


### PR DESCRIPTION
The boringcrypto-only cgo package pkg/util/fips/openssl_enabled.go calls
libcrypto symbols (OSSL_LIB_CTX_load_config, EVP_default_properties_is_fips_enabled,
RAND_bytes) but declared no link dependency, so FIPS builds failed at the Go
external-link step with "libcrypto.so.3: DSO missing from command line". The link
only used to succeed when a transitive library re-exported those symbols.

Declare the dependency in the package that needs it via `#cgo LDFLAGS: -lcrypto`
rather than adding -lcrypto to CGO_LDFLAGS in the Makefile/environment. A
package-scoped directive leaves the recorded CGO_LDFLAGS build setting empty, so it
does not change the package hash of other cgo packages and does not require every
Go plugin to be rebuilt with a matching flag to keep plugin.Open working.

Verified on a real FIPS build: bin/milvus links libcrypto.so.3 directly, while the
hook/autoindex/cipher plugins keep empty CGO_LDFLAGS, carry no libcrypto dependency,
and pass the plugin.Open package-hash check.

issue: #50374