### PR TITLE
fix: Restrict Kafka chaos selectors to broker pods

### DIFF
--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_kafka_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_kafka_container_kill.yaml
@@ -16,6 +16,7 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: kafka
+        app.kubernetes.io/component: kafka
     mode: fixed
     value: "1"
     action: container-kill

--- a/tests/python_client/chaos/chaos_objects/pod_failure/chaos_kafka_pod_failure.yaml
+++ b/tests/python_client/chaos/chaos_objects/pod_failure/chaos_kafka_pod_failure.yaml
@@ -9,7 +9,7 @@ spec:
       - chaos-testing
     labelSelectors:
       app.kubernetes.io/instance: milvus-chaos
-      component: kafka
+      app.kubernetes.io/component: kafka
   mode: fixed
   value: "1"
   action: pod-failure

--- a/tests/python_client/chaos/chaos_objects/pod_kill/chaos_kafka_pod_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/pod_kill/chaos_kafka_pod_kill.yaml
@@ -16,6 +16,7 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: kafka
+        app.kubernetes.io/component: kafka
     mode: fixed
     value: "1"
     action: pod-kill


### PR DESCRIPTION
issue: #50379

Fixes #50379

This PR narrows Kafka chaos selectors to broker pods by adding `app.kubernetes.io/component: kafka`. The previous selector matched both broker pods and the Kafka exporter pod because both use `app.kubernetes.io/name: kafka`.

Changes:
- Add `app.kubernetes.io/component: kafka` to Kafka container-kill chaos.
- Add the same broker selector to Kafka pod-kill chaos.
- Update Kafka pod-failure chaos from the legacy `component: kafka` selector to `app.kubernetes.io/component: kafka`.

Verification:
- `git diff --check`
- Parsed the three Kafka chaos YAML files and verified each selector contains `app.kubernetes.io/component=kafka` with no stale `component` selector.
