### PR TITLE
fix: [cp2.6] support CPU adaptation for GPU CAGRA loading (#50096)

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -88,6 +88,7 @@ class MilvusConan(ConanFile):
         "onetbb:tbbproxy": False,
         "gdal:shared": True,
         "gdal:fPIC": True,
+        "openblas:use_openmp": True,
     }
 
     def configure(self):

--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -29,8 +29,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/segcore"
-	"github.com/milvus-io/milvus/internal/util/vecindexmgr"
-	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
@@ -309,9 +307,7 @@ func NewCollection(collectionID int64, schema *schemapb.CollectionSchema, indexM
 	if indexMeta != nil && len(indexMeta.GetIndexMetas()) > 0 && indexMeta.GetMaxIndexRowCount() > 0 {
 		req.IndexMeta = indexMeta
 		for _, indexMeta := range indexMeta.GetIndexMetas() {
-			isGpuIndex = lo.ContainsBy(indexMeta.GetIndexParams(), func(param *commonpb.KeyValuePair) bool {
-				return param.Key == common.IndexTypeKey && vecindexmgr.GetVecIndexMgrInstance().IsGPUVecIndex(param.Value)
-			})
+			isGpuIndex = gpuIndexRequiresGpu(indexMeta.GetIndexParams())
 			if isGpuIndex {
 				break
 			}

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/segcorepb"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -85,6 +86,117 @@ func (s *CollectionManagerSuite) TestUpdateSchema() {
 			err := s.cm.UpdateSchema(1, nil, 100)
 			s.Error(err)
 		})
+	})
+}
+
+func (s *CollectionManagerSuite) TestGpuIndexFlagWithCagraAdaptForCPU() {
+	schema := mock_segcore.GenTestCollectionSchema("collection_cagra", schemapb.DataType_Int64, false)
+	vectorFieldID := int64(0)
+	for _, field := range schema.GetFields() {
+		if field.GetDataType() == schemapb.DataType_FloatVector {
+			vectorFieldID = field.GetFieldID()
+			break
+		}
+	}
+	s.Require().NotZero(vectorFieldID)
+
+	tests := []struct {
+		name       string
+		indexType  string
+		adaptValue string
+		expected   bool
+	}{
+		{
+			name:       "GPU_CAGRA adapt for CPU",
+			indexType:  "GPU_CAGRA",
+			adaptValue: "true",
+			expected:   false,
+		},
+		{
+			name:       "GPU_CUVS_CAGRA adapt for CPU",
+			indexType:  "GPU_CUVS_CAGRA",
+			adaptValue: "1",
+			expected:   false,
+		},
+		{
+			name:      "GPU_CAGRA without adapt for CPU",
+			indexType: "GPU_CAGRA",
+			expected:  true,
+		},
+		{
+			name:       "other GPU index",
+			indexType:  "GPU_IVF_FLAT",
+			adaptValue: "true",
+			expected:   true,
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			indexParams := []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: test.indexType},
+				{Key: common.MetricTypeKey, Value: "L2"},
+			}
+			if test.adaptValue != "" {
+				indexParams = append(indexParams, &commonpb.KeyValuePair{Key: "adapt_for_cpu", Value: test.adaptValue})
+			}
+			indexMeta := &segcorepb.CollectionIndexMeta{
+				MaxIndexRowCount: 1,
+				IndexMetas: []*segcorepb.FieldIndexMeta{
+					{
+						FieldID:     vectorFieldID,
+						IndexName:   test.indexType,
+						IndexParams: indexParams,
+					},
+				},
+			}
+
+			collection, err := NewCollection(10, schema, indexMeta, &querypb.LoadMetaInfo{
+				LoadType: querypb.LoadType_LoadCollection,
+			})
+			s.Require().NoError(err)
+			defer DeleteCollection(collection)
+			s.Equal(test.expected, collection.IsGpuIndex())
+		})
+	}
+
+	s.Run("GPU_CAGRA adapt for CPU from load config", func() {
+		params := paramtable.Get()
+		oldEnable := params.KnowhereConfig.Enable.GetValue()
+		adaptKey := params.KnowhereConfig.IndexParam.KeyPrefix + "GPU_CAGRA.load.adapt_for_cpu"
+		oldAdaptValue := params.GetWithDefault(adaptKey, "")
+		defer params.Save(params.KnowhereConfig.Enable.Key, oldEnable)
+		defer func() {
+			if oldAdaptValue == "" {
+				params.Remove(adaptKey)
+				return
+			}
+			params.Save(adaptKey, oldAdaptValue)
+		}()
+
+		params.Save(params.KnowhereConfig.Enable.Key, "true")
+		params.Save(adaptKey, "true")
+
+		indexMeta := &segcorepb.CollectionIndexMeta{
+			MaxIndexRowCount: 1,
+			IndexMetas: []*segcorepb.FieldIndexMeta{
+				{
+					FieldID:   vectorFieldID,
+					IndexName: "GPU_CAGRA",
+					IndexParams: []*commonpb.KeyValuePair{
+						{Key: common.IndexTypeKey, Value: "GPU_CAGRA"},
+						{Key: common.MetricTypeKey, Value: "L2"},
+					},
+				},
+			},
+		}
+
+		collection, err := NewCollection(10, schema, indexMeta, &querypb.LoadMetaInfo{
+			LoadType: querypb.LoadType_LoadCollection,
+		})
+		s.Require().NoError(err)
+		defer DeleteCollection(collection)
+		s.False(collection.IsGpuIndex())
 	})
 }
 

--- a/internal/querynodev2/segments/segment_loader.go
+++ b/internal/querynodev2/segments/segment_loader.go
@@ -1981,7 +1981,7 @@ func estimateLoadingResourceUsageOfSegment(schema *schemapb.CollectionSchema, lo
 				segDiskLoadingSize += estimateResult.MaxDiskCost
 			}
 
-			if vecindexmgr.GetVecIndexMgrInstance().IsGPUVecIndex(common.GetIndexType(fieldIndexInfo.IndexParams)) {
+			if gpuIndexRequiresGpu(fieldIndexInfo.IndexParams) {
 				fieldGpuMemorySize = append(fieldGpuMemorySize, estimateResult.MaxMemoryCost)
 			}
 
@@ -2362,6 +2362,37 @@ func getBinlogDataMemorySize(fieldBinlog *datapb.FieldBinlog) int64 {
 	}
 
 	return fieldSize
+}
+
+func gpuIndexRequiresGpu(indexParams []*commonpb.KeyValuePair) bool {
+	indexParamMap := funcutil.KeyValuePair2Map(indexParams)
+	indexType := indexParamMap[common.IndexTypeKey]
+
+	switch indexType {
+	case "GPU_CAGRA", "GPU_CUVS_CAGRA":
+	case "GPU_BRUTE_FORCE", "GPU_CUVS_BRUTE_FORCE",
+		"GPU_IVF_FLAT", "GPU_CUVS_IVF_FLAT",
+		"GPU_IVF_PQ", "GPU_CUVS_IVF_PQ":
+		return true
+	default:
+		return false
+	}
+
+	err := indexparams.AppendPrepareLoadParams(paramtable.Get(), indexParamMap)
+	if err != nil {
+		log.Warn("failed to append prepare load params for gpu index resource check",
+			zap.String("indexType", indexType),
+			zap.Error(err))
+	}
+
+	adaptForCPU, ok := indexParamMap["adapt_for_cpu"]
+	if ok {
+		enabled, err := strconv.ParseBool(adaptForCPU)
+		if err == nil && enabled {
+			return false
+		}
+	}
+	return true
 }
 
 func checkSegmentGpuMemSize(fieldGpuMemSizeList []uint64, OverloadedMemoryThresholdPercentage float32) error {

--- a/internal/querynodev2/segments/segment_loader_test.go
+++ b/internal/querynodev2/segments/segment_loader_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
@@ -1295,6 +1296,89 @@ func (suite *SegmentLoaderTextIndexEstimateSuite) TestLogicalEstimate_ExpansionF
 	suite.NoError(err)
 	expected := uint64(float64(textIndexSize) * expansionFactor)
 	suite.EqualValues(expected, usage.MemorySize)
+}
+
+func TestGpuIndexRequiresGpu(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   []*commonpb.KeyValuePair
+		expected bool
+	}{
+		{
+			name: "GPU_CAGRA adapt for CPU",
+			params: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: "GPU_CAGRA"},
+				{Key: "adapt_for_cpu", Value: "true"},
+			},
+			expected: false,
+		},
+		{
+			name: "GPU_CUVS_CAGRA adapt for CPU",
+			params: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: "GPU_CUVS_CAGRA"},
+				{Key: "adapt_for_cpu", Value: "1"},
+			},
+			expected: false,
+		},
+		{
+			name: "GPU_CAGRA without adapt for CPU",
+			params: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: "GPU_CAGRA"},
+			},
+			expected: true,
+		},
+		{
+			name: "GPU_CAGRA invalid adapt for CPU",
+			params: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: "GPU_CAGRA"},
+				{Key: "adapt_for_cpu", Value: "invalid"},
+			},
+			expected: true,
+		},
+		{
+			name: "other GPU index ignores adapt for CPU",
+			params: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: "GPU_IVF_FLAT"},
+				{Key: "adapt_for_cpu", Value: "true"},
+			},
+			expected: true,
+		},
+		{
+			name: "CPU index",
+			params: []*commonpb.KeyValuePair{
+				{Key: common.IndexTypeKey, Value: "HNSW"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, gpuIndexRequiresGpu(test.params))
+		})
+	}
+
+	t.Run("GPU_CAGRA adapt for CPU from load config", func(t *testing.T) {
+		params := paramtable.Get()
+		oldEnable := params.KnowhereConfig.Enable.GetValue()
+		adaptKey := params.KnowhereConfig.IndexParam.KeyPrefix + "GPU_CAGRA.load.adapt_for_cpu"
+		oldAdaptValue := params.GetWithDefault(adaptKey, "")
+		defer params.Save(params.KnowhereConfig.Enable.Key, oldEnable)
+		defer func() {
+			if oldAdaptValue == "" {
+				params.Remove(adaptKey)
+				return
+			}
+			params.Save(adaptKey, oldAdaptValue)
+		}()
+
+		params.Save(params.KnowhereConfig.Enable.Key, "true")
+		params.Save(adaptKey, "true")
+
+		assert.False(t, gpuIndexRequiresGpu([]*commonpb.KeyValuePair{
+			{Key: common.IndexTypeKey, Value: "GPU_CAGRA"},
+		}))
+	})
 }
 
 func TestSegmentLoader(t *testing.T) {


### PR DESCRIPTION
Cherry-pick from master

pr: #50096
issue: #49836

## Summary
- Treat GPU CAGRA indexes with `adapt_for_cpu` enabled as CPU-adapted in QueryNode resource checks.
- Apply the same GPU requirement check when estimating segment load resources and collection GPU index flags.
- Keep the Milvus-side OpenBLAS Conan option needed by the current Knowhere dependency set on 2.6.

## Test plan
- [x] `git diff --check upstream/2.6..HEAD`
- [x] `GO_DIFF_FILES="internal/datanode/index_services_test.go internal/querynodev2/segments/collection.go internal/querynodev2/segments/collection_test.go internal/querynodev2/segments/segment_loader.go internal/querynodev2/segments/segment_loader_test.go" make fmt`
- [ ] `go test -count=1 -tags test ./internal/querynodev2/segments -run 'TestGpuIndexRequiresGpu|TestCollectionManagerSuite/TestGpuIndexFlagWithCagraAdaptForCPU'` blocked locally because this clean 2.6 workspace has not built `internal/core/output/lib/libmilvus_core.so`.