### PR TITLE
fix: remove stale collection schema metadata on alter

### DIFF
--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -758,10 +758,13 @@ func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Col
 		return err
 	}
 	saves := map[string]string{newKey: string(value)}
+	removals := []string{}
 	// no default aliases will be created.
 	// save fields info to new path.
 	if fieldModify {
+		newFieldIDs := make(map[int64]struct{}, len(newColl.Fields))
 		for _, field := range newColl.Fields {
+			newFieldIDs[field.FieldID] = struct{}{}
 			k := BuildFieldKey(newColl.CollectionID, field.FieldID)
 			fieldInfo := model.MarshalFieldModel(field)
 			v, err := proto.Marshal(fieldInfo)
@@ -770,8 +773,15 @@ func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Col
 			}
 			saves[k] = string(v)
 		}
+		for _, field := range oldColl.Fields {
+			if _, ok := newFieldIDs[field.FieldID]; !ok {
+				removals = append(removals, BuildFieldKey(oldColl.CollectionID, field.FieldID))
+			}
+		}
 
+		newStructArrayFieldIDs := make(map[int64]struct{}, len(newColl.StructArrayFields))
 		for _, structArrayField := range newColl.StructArrayFields {
+			newStructArrayFieldIDs[structArrayField.FieldID] = struct{}{}
 			k := BuildStructArrayFieldKey(newColl.CollectionID, structArrayField.FieldID)
 			structArrayFieldInfo := model.MarshalStructArrayFieldModel(structArrayField)
 			v, err := proto.Marshal(structArrayFieldInfo)
@@ -780,7 +790,15 @@ func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Col
 			}
 			saves[k] = string(v)
 		}
+		for _, structArrayField := range oldColl.StructArrayFields {
+			if _, ok := newStructArrayFieldIDs[structArrayField.FieldID]; !ok {
+				removals = append(removals, BuildStructArrayFieldKey(oldColl.CollectionID, structArrayField.FieldID))
+			}
+		}
+
+		newFunctionIDs := make(map[int64]struct{}, len(newColl.Functions))
 		for _, function := range newColl.Functions {
+			newFunctionIDs[function.ID] = struct{}{}
 			k := BuildFunctionKey(newColl.CollectionID, function.ID)
 			functionInfo := model.MarshalFunctionModel(function)
 			v, err := proto.Marshal(functionInfo)
@@ -789,9 +807,20 @@ func (kc *Catalog) alterModifyCollection(ctx context.Context, oldColl *model.Col
 			}
 			saves[k] = string(v)
 		}
+		for _, function := range oldColl.Functions {
+			if _, ok := newFunctionIDs[function.ID]; !ok {
+				removals = append(removals, BuildFunctionKey(oldColl.CollectionID, function.ID))
+			}
+		}
 	}
 
 	maxTxnNum := paramtable.Get().MetaStoreCfg.MaxEtcdTxnNum.GetAsInt()
+	if len(removals) > 0 {
+		if len(saves)+len(removals) <= maxTxnNum {
+			return kc.Txn.MultiSaveAndRemove(ctx, saves, removals)
+		}
+		return batchMultiSaveAndRemove(ctx, kc.Txn, maxTxnNum, saves, removals)
+	}
 	return etcd.SaveByBatchWithLimit(saves, maxTxnNum, func(partialKvs map[string]string) error {
 		return kc.Txn.MultiSave(ctx, partialKvs)
 	})

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -1192,6 +1192,63 @@ func TestCatalog_AlterCollection(t *testing.T) {
 		err := kc.AlterCollection(ctx, oldC, newC, metastore.MODIFY, 0, true)
 		assert.NoError(t, err)
 	})
+
+	t.Run("modify removes stale schema keys", func(t *testing.T) {
+		var collectionID int64 = 1
+		snapshot := mocks.NewTxnKV(t)
+		snapshot.EXPECT().MultiSaveAndRemove(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, saves map[string]string, removals []string, preds ...predicates.Predicate) error {
+				assert.Contains(t, saves, BuildCollectionKey(0, collectionID))
+				assert.Contains(t, saves, BuildFieldKey(collectionID, 100))
+				assert.Contains(t, saves, BuildStructArrayFieldKey(collectionID, 200))
+				assert.Contains(t, saves, BuildFunctionKey(collectionID, 300))
+				assert.NotContains(t, saves, BuildFieldKey(collectionID, 101))
+				assert.NotContains(t, saves, BuildStructArrayFieldKey(collectionID, 201))
+				assert.NotContains(t, saves, BuildFunctionKey(collectionID, 301))
+				assert.ElementsMatch(t, []string{
+					BuildFieldKey(collectionID, 101),
+					BuildStructArrayFieldKey(collectionID, 201),
+					BuildFunctionKey(collectionID, 301),
+				}, removals)
+				return nil
+			})
+
+		kc := NewCatalog(snapshot).(*Catalog)
+		ctx := context.Background()
+		oldC := &model.Collection{
+			DBID:         0,
+			CollectionID: collectionID,
+			State:        pb.CollectionState_CollectionCreated,
+			Fields: []*model.Field{
+				{FieldID: 100, Name: "keep_field"},
+				{FieldID: 101, Name: "drop_field"},
+			},
+			StructArrayFields: []*model.StructArrayField{
+				{FieldID: 200, Name: "keep_struct"},
+				{FieldID: 201, Name: "drop_struct"},
+			},
+			Functions: []*model.Function{
+				{ID: 300, Name: "keep_function"},
+				{ID: 301, Name: "drop_function"},
+			},
+		}
+		newC := &model.Collection{
+			DBID:         0,
+			CollectionID: collectionID,
+			State:        pb.CollectionState_CollectionCreated,
+			Fields: []*model.Field{
+				{FieldID: 100, Name: "keep_field"},
+			},
+			StructArrayFields: []*model.StructArrayField{
+				{FieldID: 200, Name: "keep_struct"},
+			},
+			Functions: []*model.Function{
+				{ID: 300, Name: "keep_function"},
+			},
+		}
+		err := kc.AlterCollection(ctx, oldC, newC, metastore.MODIFY, 0, true)
+		assert.NoError(t, err)
+	})
 }
 
 func TestCatalog_AlterCollectionDB(t *testing.T) {


### PR DESCRIPTION
issue: #50388

This PR removes stale per-schema metadata keys when AlterCollection updates collection fields, struct array fields, or functions. It keeps collection schema metadata and per-field/function metadata consistent after DropField-style schema updates, so RootCoord reload and BirdWatcher do not observe dropped fields from stale `root-coord/fields` keys.

Validation:
- `gofumpt -l internal/metastore/kv/rootcoord/kv_catalog.go internal/metastore/kv/rootcoord/kv_catalog_test.go`
- `git diff --check`
- `source scripts/check_build.sh`
- `make SKIP_3RDPARTY=1`
- `make build-go`
- `go test -v -count=1 -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r ${MILVUS_WORK_DIR}/cmake_build/lib -r ${MILVUS_WORK_DIR}/internal/core/output/lib" ./internal/metastore/kv/rootcoord -timeout 300s`
- `make static-check`
- Local standalone DropField regression with pymilvus: verified API output/filter errors for dropped field, raw etcd dropped field key removal, BirdWatcher output, and restart persistence.