### PR TITLE
fix: guard growing segment field maps against concurrent rehash

### DIFF
--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -1696,12 +1696,7 @@ class InsertRecordGrowing {
         // Guard the field map against concurrent structural modification
         // (e.g. append_field_meta during schema evolution rehashing data_).
         std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
-        AssertInfo(data_.find(field_id) != data_.end(),
-                   "Cannot find field_data with field_id: " +
-                       std::to_string(field_id.get()));
-        AssertInfo(data_.at(field_id) != nullptr,
-                   "data_ at i is null" + std::to_string(field_id.get()));
-        return data_.at(field_id).get();
+        return get_data_base_unlocked(field_id);
     }
 
     // get field data in given type, const version
@@ -1729,12 +1724,7 @@ class InsertRecordGrowing {
         // Guard the field map against concurrent structural modification
         // (e.g. append_field_meta during schema evolution rehashing valid_data_).
         std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
-        AssertInfo(valid_data_.find(field_id) != valid_data_.end(),
-                   "Cannot find valid_data with field_id: " +
-                       std::to_string(field_id.get()));
-        AssertInfo(valid_data_.at(field_id) != nullptr,
-                   "valid_data_ at i is null" + std::to_string(field_id.get()));
-        return valid_data_.at(field_id);
+        return get_valid_data_unlocked(field_id);
     }
 
     bool
@@ -1746,20 +1736,26 @@ class InsertRecordGrowing {
     bool
     is_valid_data_exist(FieldId field_id) const {
         std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
-        return valid_data_.find(field_id) != valid_data_.end();
+        return is_valid_data_exist_unlocked(field_id);
     }
 
     SpanBase
     get_span_base(FieldId field_id, int64_t chunk_id) const {
-        auto data = get_data_base(field_id);
-        if (is_valid_data_exist(field_id)) {
+        // Take the shared lock once for the whole span resolution instead of
+        // re-locking inside each of get_data_base / is_valid_data_exist /
+        // get_valid_data. This both removes the redundant lock churn on this
+        // hot path and gives a consistent snapshot of the field map across the
+        // three lookups.
+        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
+        auto data = get_data_base_unlocked(field_id);
+        if (is_valid_data_exist_unlocked(field_id)) {
             auto size = data->get_chunk_size(chunk_id);
             auto element_offset = data->get_element_offset(chunk_id);
-            return SpanBase(
-                data->get_chunk_data(chunk_id),
-                get_valid_data(field_id)->get_chunk_data(element_offset),
-                size,
-                data->get_element_size());
+            return SpanBase(data->get_chunk_data(chunk_id),
+                            get_valid_data_unlocked(field_id)->get_chunk_data(
+                                element_offset),
+                            size,
+                            data->get_element_size());
         }
         return data->get_span_base(chunk_id);
     }
@@ -1848,6 +1844,34 @@ class InsertRecordGrowing {
     AckResponder ack_responder_;
 
  private:
+    // Unlocked field-map lookups. Callers MUST already hold field_map_mutex_
+    // (at least shared). These let multi-lookup hot paths such as
+    // get_span_base resolve under a single lock acquisition.
+    VectorBase*
+    get_data_base_unlocked(FieldId field_id) const {
+        AssertInfo(data_.find(field_id) != data_.end(),
+                   "Cannot find field_data with field_id: " +
+                       std::to_string(field_id.get()));
+        AssertInfo(data_.at(field_id) != nullptr,
+                   "data_ at i is null" + std::to_string(field_id.get()));
+        return data_.at(field_id).get();
+    }
+
+    ThreadSafeValidDataPtr
+    get_valid_data_unlocked(FieldId field_id) const {
+        AssertInfo(valid_data_.find(field_id) != valid_data_.end(),
+                   "Cannot find valid_data with field_id: " +
+                       std::to_string(field_id.get()));
+        AssertInfo(valid_data_.at(field_id) != nullptr,
+                   "valid_data_ at i is null" + std::to_string(field_id.get()));
+        return valid_data_.at(field_id);
+    }
+
+    bool
+    is_valid_data_exist_unlocked(FieldId field_id) const {
+        return valid_data_.find(field_id) != valid_data_.end();
+    }
+
     std::unordered_map<FieldId, std::unique_ptr<VectorBase>> data_{};
     std::unordered_map<FieldId, ThreadSafeValidDataPtr> valid_data_{};
     mutable std::shared_mutex shared_mutex_{};

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -1520,7 +1520,10 @@ class InsertRecordGrowing {
             pk2offset_->clear();
         }
         reserved = 0;
-        data_.clear();
+        {
+            std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
+            data_.clear();
+        }
         ack_responder_.clear();
     }
 
@@ -1689,6 +1692,9 @@ class InsertRecordGrowing {
     // get data without knowing the type
     VectorBase*
     get_data_base(FieldId field_id) const {
+        // Guard the field map against concurrent structural modification
+        // (e.g. append_field_meta during schema evolution rehashing data_).
+        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
         AssertInfo(data_.find(field_id) != data_.end(),
                    "Cannot find field_data with field_id: " +
                        std::to_string(field_id.get()));
@@ -1719,6 +1725,9 @@ class InsertRecordGrowing {
 
     ThreadSafeValidDataPtr
     get_valid_data(FieldId field_id) const {
+        // Guard the field map against concurrent structural modification
+        // (e.g. append_field_meta during schema evolution rehashing valid_data_).
+        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
         AssertInfo(valid_data_.find(field_id) != valid_data_.end(),
                    "Cannot find valid_data with field_id: " +
                        std::to_string(field_id.get()));
@@ -1729,11 +1738,13 @@ class InsertRecordGrowing {
 
     bool
     is_data_exist(FieldId field_id) const {
+        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
         return data_.find(field_id) != data_.end();
     }
 
     bool
     is_valid_data_exist(FieldId field_id) const {
+        std::shared_lock<std::shared_mutex> lck(field_map_mutex_);
         return valid_data_.find(field_id) != valid_data_.end();
     }
 
@@ -1755,7 +1766,9 @@ class InsertRecordGrowing {
     // append a column of scalar type
     void
     append_valid_data(FieldId field_id) {
-        valid_data_.emplace(field_id, std::make_shared<ThreadSafeValidData>());
+        auto valid_data = std::make_shared<ThreadSafeValidData>();
+        std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
+        valid_data_.emplace(field_id, std::move(valid_data));
     }
 
     // append a column of vector type
@@ -1767,14 +1780,16 @@ class InsertRecordGrowing {
                 const storage::MmapChunkDescriptorPtr mmap_descriptor) {
         static_assert(std::is_base_of_v<VectorTrait, VectorType>);
         bool use_mapping_storage = is_valid_data_exist(field_id);
-        data_.emplace(
-            field_id,
-            std::make_unique<ConcurrentVector<VectorType>>(
-                dim,
-                size_per_chunk,
-                mmap_descriptor,
-                use_mapping_storage ? get_valid_data(field_id) : nullptr,
-                use_mapping_storage));
+        // Resolve valid_data and build the column before taking the write lock
+        // so the shared-lock readers above are not nested inside the unique lock.
+        auto column = std::make_unique<ConcurrentVector<VectorType>>(
+            dim,
+            size_per_chunk,
+            mmap_descriptor,
+            use_mapping_storage ? get_valid_data(field_id) : nullptr,
+            use_mapping_storage);
+        std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
+        data_.emplace(field_id, std::move(column));
     }
 
     // append a column of scalar or sparse float vector type
@@ -1785,26 +1800,28 @@ class InsertRecordGrowing {
                 const storage::MmapChunkDescriptorPtr mmap_descriptor) {
         static_assert(IsScalar<Type> || IsSparse<Type>);
         bool use_mapping_storage = is_valid_data_exist(field_id);
+        // Resolve valid_data and build the column before taking the write lock
+        // so the shared-lock readers above are not nested inside the unique lock.
+        std::unique_ptr<ConcurrentVector<Type>> column;
         if constexpr (IsSparse<Type>) {
-            data_.emplace(
-                field_id,
-                std::make_unique<ConcurrentVector<Type>>(
-                    size_per_chunk,
-                    mmap_descriptor,
-                    use_mapping_storage ? get_valid_data(field_id) : nullptr,
-                    use_mapping_storage));
+            column = std::make_unique<ConcurrentVector<Type>>(
+                size_per_chunk,
+                mmap_descriptor,
+                use_mapping_storage ? get_valid_data(field_id) : nullptr,
+                use_mapping_storage);
         } else {
-            data_.emplace(
-                field_id,
-                std::make_unique<ConcurrentVector<Type>>(
-                    size_per_chunk,
-                    mmap_descriptor,
-                    use_mapping_storage ? get_valid_data(field_id) : nullptr));
+            column = std::make_unique<ConcurrentVector<Type>>(
+                size_per_chunk,
+                mmap_descriptor,
+                use_mapping_storage ? get_valid_data(field_id) : nullptr);
         }
+        std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
+        data_.emplace(field_id, std::move(column));
     }
 
     void
     drop_field_data(FieldId field_id) {
+        std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
         data_.erase(field_id);
         valid_data_.erase(field_id);
     }
@@ -1833,6 +1850,12 @@ class InsertRecordGrowing {
     std::unordered_map<FieldId, std::unique_ptr<VectorBase>> data_{};
     std::unordered_map<FieldId, ThreadSafeValidDataPtr> valid_data_{};
     mutable std::shared_mutex shared_mutex_{};
+    // Protects the structure of data_ / valid_data_ against concurrent
+    // rehash: structural writes (append_*/drop/clear during schema evolution)
+    // take it unique, lookups (get_data_base/get_valid_data/...) take it shared.
+    // Kept separate from shared_mutex_ so frequent reads do not contend with
+    // pk inserts.
+    mutable std::shared_mutex field_map_mutex_{};
 };
 
 // Keep the original template API via alias

--- a/internal/core/src/segcore/InsertRecord.h
+++ b/internal/core/src/segcore/InsertRecord.h
@@ -1523,6 +1523,7 @@ class InsertRecordGrowing {
         {
             std::unique_lock<std::shared_mutex> lck(field_map_mutex_);
             data_.clear();
+            valid_data_.clear();
         }
         ack_responder_.clear();
     }
@@ -1855,6 +1856,15 @@ class InsertRecordGrowing {
     // take it unique, lookups (get_data_base/get_valid_data/...) take it shared.
     // Kept separate from shared_mutex_ so frequent reads do not contend with
     // pk inserts.
+    //
+    // PRECONDITION: this lock only protects the map structure, NOT element
+    // lifetime. The raw VectorBase* returned by get_data_base() escapes the
+    // shared lock, so callers rely on no concurrent erase()/clear() of the
+    // entry they hold (append-only mutation is safe). Today that holds because
+    // drop_field_data() has no callers and clear() is never called
+    // concurrently with reads; whoever adds drop-field support (e.g. schema
+    // evolution dropping fields) must also fence element lifetime, this lock
+    // alone will not save the escaped pointers.
     mutable std::shared_mutex field_map_mutex_{};
 };
 

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -70,6 +70,7 @@ set(MILVUS_TEST_FILES
         TextLobSpilloverTest.cpp
         test_commit_timestamp.cpp
         test_schema_reopen.cpp
+        test_growing_concurrent_reopen.cpp
         )
 
 if ( NOT (INDEX_ENGINE STREQUAL "cardinal") )

--- a/internal/core/unittest/test_growing_concurrent_reopen.cpp
+++ b/internal/core/unittest/test_growing_concurrent_reopen.cpp
@@ -47,8 +47,10 @@ using namespace milvus::segcore;
  *   shared.
  *
  * Before fix: this test reliably crashes (SIGSEGV / ASan heap-use-after-free)
- * under the concurrent rehash. After fix: queries either succeed or throw
- * cleanly; no crash.
+ * under the concurrent rehash. After fix: every query must succeed — the
+ * readers target nullable_i64, which exists in the base schema and is not
+ * touched by the evolution, so the test asserts no exception at all (not
+ * merely "no crash").
  *
  * Reliability notes: a rehash only corrupts a concurrent reader during the
  * brief window the bucket array is reallocated, so the reproduction maximizes

--- a/internal/core/unittest/test_growing_concurrent_reopen.cpp
+++ b/internal/core/unittest/test_growing_concurrent_reopen.cpp
@@ -1,0 +1,165 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "common/OpContext.h"
+#include "common/Schema.h"
+#include "segcore/SegmentGrowingImpl.h"
+#include "test_utils/DataGen.h"
+
+using namespace milvus;
+using namespace milvus::segcore;
+
+/**
+ * Regression test for Issue #50377: Standalone SIGSEGV in query
+ * (bulk_subscript) on a nullable field of a growing segment, concurrent with
+ * schema evolution.
+ *
+ * Root Cause:
+ * - InsertRecordGrowing holds data_ / valid_data_ as plain std::unordered_map.
+ * - The query path (SegmentGrowingImpl::bulk_subscript -> get_data_base /
+ *   get_valid_data) read these maps WITHOUT any lock.
+ * - Reopen() (schema evolution adding a field) calls append_field_meta ->
+ *   append_data / append_valid_data, which emplace into the maps and can
+ *   trigger a rehash.
+ * - A rehash concurrent with a lock-free find()/at() on a reader thread walks
+ *   freed bucket memory -> SIGSEGV (exit 139), exactly matching the production
+ *   crash: GISFunctionFilterExpr -> bulk_subscript -> get_valid_data ->
+ *   std::unordered_map.
+ *
+ * Fix:
+ * - Guard the structure of data_ / valid_data_ with a dedicated shared_mutex
+ *   (field_map_mutex_): structural writes take it unique, lookups take it
+ *   shared.
+ *
+ * Before fix: this test reliably crashes (SIGSEGV / ASan heap-use-after-free)
+ * under the concurrent rehash. After fix: queries either succeed or throw
+ * cleanly; no crash.
+ *
+ * Reliability notes: a rehash only corrupts a concurrent reader during the
+ * brief window the bucket array is reallocated, so the reproduction maximizes
+ * overlap by (1) running many fresh-segment rounds, (2) issuing single-offset
+ * bulk_subscript so readers spend almost all their time inside the map
+ * find()/at() rather than copying payload, (3) using many reader threads, and
+ * (4) yielding in the writer between field additions to widen the window.
+ */
+TEST(GrowingConcurrentReopenTest,
+     ConcurrentBulkSubscriptAndReopenShouldNotCrash) {
+    // The race fires within the first round without the fix (manifests as a
+    // SIGSEGV in a Release build, or a failed map lookup under debug/ASan), so
+    // a modest round count keeps the test fast while remaining reliable.
+    const int kRounds = 30;
+    const int kExtraFields = 48;
+    const unsigned kReaders = std::max(4u, std::thread::hardware_concurrency());
+
+    // Pre-build the schema chain once; each schema adds one more nullable field
+    // so Reopening through them forces repeated emplace() into data_ /
+    // valid_data_ (the structural mutation that races with readers).
+    auto make_schema = [](int extra) {
+        auto sch = std::make_shared<Schema>();
+        sch->AddDebugField(
+            "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+        auto pk = sch->AddDebugField("pk", DataType::INT64);
+        sch->AddDebugField("nullable_i64", DataType::INT64, /*nullable=*/true);
+        for (int j = 1; j <= extra; ++j) {
+            sch->AddDebugField("evo_field_" + std::to_string(j),
+                               DataType::INT64,
+                               /*nullable=*/true);
+        }
+        sch->set_primary_field_id(pk);
+        sch->set_schema_version(1 + extra);
+        return sch;
+    };
+
+    auto base = make_schema(0);
+    auto nullable_fid = base->get_field_id(FieldName("nullable_i64"));
+    std::vector<SchemaPtr> evolutions;
+    for (int k = 1; k <= kExtraFields; ++k) {
+        evolutions.push_back(make_schema(k));
+    }
+
+    std::vector<std::exception_ptr> exceptions;
+    std::mutex exceptions_mutex;
+    std::atomic<int64_t> query_count{0};
+
+    for (int round = 0; round < kRounds; ++round) {
+        auto segment = CreateGrowingSegment(base, nullptr);
+        auto seg_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+        ASSERT_NE(seg_impl, nullptr);
+
+        // Seed a few rows so bulk_subscript has data to read.
+        const int N = 16;
+        auto data = DataGen(base, N, /*seed=*/round + 1);
+        segment->PreInsert(N);
+        segment->Insert(
+            0, N, data.row_ids_.data(), data.timestamps_.data(), data.raw_);
+
+        std::atomic<bool> stop_flag{false};
+
+        // Reader threads: single-offset bulk_subscript in a tight loop. With
+        // count == 1 a reader is almost always inside get_data_base /
+        // get_valid_data (the unordered_map lookups), maximizing overlap with a
+        // concurrent rehash.
+        auto reader = [&](int tid) {
+            milvus::OpContext op_ctx;
+            int64_t offset = tid % N;
+            while (!stop_flag.load(std::memory_order_relaxed)) {
+                try {
+                    auto res = seg_impl->bulk_subscript(
+                        &op_ctx, nullable_fid, &offset, 1);
+                    (void)res;
+                    query_count.fetch_add(1, std::memory_order_relaxed);
+                } catch (...) {
+                    std::lock_guard<std::mutex> lock(exceptions_mutex);
+                    exceptions.push_back(std::current_exception());
+                    break;
+                }
+            }
+        };
+
+        std::vector<std::thread> readers;
+        for (unsigned i = 0; i < kReaders; ++i) {
+            readers.emplace_back(reader, static_cast<int>(i));
+        }
+
+        // Writer: drive schema evolution, adding one field at a time so the
+        // map repeatedly rehashes underneath the readers.
+        for (auto& sch : evolutions) {
+            try {
+                seg_impl->Reopen(sch);
+            } catch (...) {
+                std::lock_guard<std::mutex> lock(exceptions_mutex);
+                exceptions.push_back(std::current_exception());
+                break;
+            }
+            std::this_thread::yield();
+        }
+
+        stop_flag.store(true);
+        for (auto& t : readers) {
+            t.join();
+        }
+
+        if (!exceptions.empty()) {
+            break;
+        }
+    }
+
+    EXPECT_TRUE(exceptions.empty())
+        << "Concurrent bulk_subscript / Reopen raised exceptions";
+    EXPECT_GT(query_count.load(), 0) << "Expected some queries to complete";
+}


### PR DESCRIPTION
issue: #50377

## Problem

Standalone crashes with SIGSEGV (exit 139) when an `ST_WITHIN` query runs on a nullable GEOMETRY field of a **growing** segment concurrently with schema-evolution (add field).

The reported stack:
```
GISFunctionFilterExpr.cpp -> segment_->bulk_subscript(...)
SegmentGrowingImpl.cpp    -> insert_record_.get_valid_data(field_id)
/usr/include/c++/12/bits/unordered_map.h:880   (SIGSEGV)
```

## Root cause

`InsertRecordGrowing` keeps the per-field columns in two plain `std::unordered_map`s (`data_` / `valid_data_`).

- The query path (`SegmentGrowingImpl::bulk_subscript` → `get_data_base` / `get_valid_data`, and every other growing-segment reader that funnels through them) reads these maps **without any lock**.
- Schema evolution (`Reopen` → `fill_empty_field` → `append_field_meta` → `append_data` / `append_valid_data`) `emplace`s into the maps, which can **rehash** the bucket array.
- A rehash concurrent with a lock-free `find()` / `at()` on a query thread walks freed bucket memory → SIGSEGV. The GIS `ST_WITHIN` path just happens to be a frequent reader (`bulk_subscript`).

Only `Insert` (shared) and `Reopen` (unique) took `sch_mutex_`; the query path took nothing, so nothing serialized a reader against the rehash.

## Fix

Add a dedicated `field_map_mutex_` to `InsertRecordGrowing`:
- structural writers (`append_*`, `drop_field_data`, `clear`) take it **unique**;
- lookups (`get_data_base`, `get_valid_data`, `is_data_exist`, `is_valid_data_exist`) take it **shared**.

The `append_data` paths resolve their reader-dependent values before taking the unique lock to avoid recursive locking on the non-recursive `shared_mutex`. The mutex is kept separate from the existing `shared_mutex_` (which serializes pk inserts) so the hot read path does not contend with inserts. Because all growing-segment readers funnel through these accessors, this covers `bulk_subscript`, vector search and expression chunk reads uniformly.

## Test

`internal/core/unittest/test_growing_concurrent_reopen.cpp` races single-offset `bulk_subscript` readers against `Reopen`-driven field additions. It reliably fails before the fix (failed map lookup under debug/ASan; SIGSEGV in Release) and passes after.