### PR TITLE
test: Add hybrid search partition isolation coverage

### DIFF
--- a/tests/go_client/testcases/hybrid_search_test.go
+++ b/tests/go_client/testcases/hybrid_search_test.go
@@ -1,6 +1,7 @@
 package testcases
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -93,6 +94,114 @@ func TestHybridSearchTemplateParam(t *testing.T) {
 		for _, id := range hits.IDs.(*column.ColumnInt64).Data() {
 			require.Greater(t, id, int64(int64Value))
 		}
+	}
+}
+
+func TestHybridSearchPartitionKeyIsolationUnsupportedFilter(t *testing.T) {
+	t.Parallel()
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	const dim = 5
+	collName := common.GenRandomString("pk_iso_hybrid", 6)
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName("vector_a").WithDataType(entity.FieldTypeFloatVector).WithDim(dim)).
+		WithField(entity.NewField().WithName("vector_b").WithDataType(entity.FieldTypeFloatVector).WithDim(dim)).
+		WithField(entity.NewField().WithName("tenant").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64).WithIsPartitionKey(true)).
+		WithField(entity.NewField().WithName("color").WithDataType(entity.FieldTypeVarChar).WithMaxLength(64))
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema).
+		WithNumPartitions(16).
+		WithProperty("partitionkey.isolation", true).
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	vectorA := [][]float32{
+		{0.10, 0.20, 0.30, 0.40, 0.50},
+		{0.11, 0.21, 0.31, 0.41, 0.51},
+		{0.90, 0.80, 0.70, 0.60, 0.50},
+		{0.91, 0.81, 0.71, 0.61, 0.51},
+		{0.10, 0.20, 0.30, 0.40, 0.50},
+	}
+	vectorB := [][]float32{
+		{0.50, 0.40, 0.30, 0.20, 0.10},
+		{0.51, 0.41, 0.31, 0.21, 0.11},
+		{0.50, 0.60, 0.70, 0.80, 0.90},
+		{0.51, 0.61, 0.71, 0.81, 0.91},
+		{0.50, 0.40, 0.30, 0.20, 0.10},
+	}
+	_, err = mc.Insert(ctx, client.NewColumnBasedInsertOption(collName).
+		WithColumns(
+			column.NewColumnInt64("id", []int64{1, 2, 3, 4, 5}),
+			column.NewColumnFloatVector("vector_a", dim, vectorA),
+			column.NewColumnFloatVector("vector_b", dim, vectorB),
+			column.NewColumnVarChar("tenant", []string{"tenant_a", "tenant_a", "tenant_b", "tenant_b", "tenant_c"}),
+			column.NewColumnVarChar("color", []string{"tenant_a_1", "tenant_a_2", "tenant_b_1", "tenant_b_2", "tenant_c_control"}),
+		))
+	common.CheckErr(t, err, true)
+
+	flushTask, err := mc.Flush(ctx, client.NewFlushOption(collName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, flushTask.Await(ctx), true)
+
+	for _, fieldName := range []string{"vector_a", "vector_b"} {
+		idxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, fieldName, index.NewAutoIndex(entity.COSINE)))
+		common.CheckErr(t, err, true)
+		common.CheckErr(t, idxTask.Await(ctx), true)
+	}
+
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, loadTask.Await(ctx), true)
+
+	queryA := []entity.Vector{entity.FloatVector([]float32{0.10, 0.20, 0.30, 0.40, 0.50})}
+	queryB := []entity.Vector{entity.FloatVector([]float32{0.50, 0.40, 0.30, 0.20, 0.10})}
+
+	searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 5, queryA).
+		WithANNSField("vector_a").
+		WithSearchParam("metric_type", "COSINE").
+		WithFilter(`tenant == "tenant_a"`).
+		WithOutputFields("id", "tenant", "color").
+		WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	require.Len(t, searchRes, 1)
+	tenants := searchRes[0].GetColumn("tenant").(*column.ColumnVarChar).Data()
+	require.NotEmpty(t, tenants)
+	require.Subset(t, []string{"tenant_a"}, tenants)
+
+	invalidFilters := map[string]string{
+		`tenant in ["tenant_a", "tenant_b"]`: "partition key isolation does not support IN",
+		"":                                   "partition key not found in expr",
+	}
+	for expr, errMsg := range invalidFilters {
+		_, err := mc.Search(ctx, client.NewSearchOption(collName, 5, queryA).
+			WithANNSField("vector_a").
+			WithSearchParam("metric_type", "COSINE").
+			WithFilter(expr).
+			WithOutputFields("id", "tenant", "color").
+			WithConsistencyLevel(entity.ClStrong))
+		require.ErrorContains(t, err, errMsg)
+	}
+
+	for expr, errMsg := range invalidFilters {
+		annReq1 := client.NewAnnRequest("vector_a", 5, queryA...).
+			WithSearchParam("metric_type", "COSINE").
+			WithFilter(expr)
+		annReq2 := client.NewAnnRequest("vector_b", 5, queryB...).
+			WithSearchParam("metric_type", "COSINE").
+			WithFilter(expr)
+		_, err := mc.HybridSearch(ctx, client.NewHybridSearchOption(collName, 5, annReq1, annReq2).
+			WithReranker(client.NewRRFReranker()).
+			WithOutputFields("id", "tenant", "color").
+			WithConsistencyLevel(entity.ClStrong))
+		if err == nil {
+			t.Skipf("xfail: https://github.com/milvus-io/milvus/issues/50398, hybrid_search accepted unsupported filter %q", expr)
+		}
+		require.ErrorContains(t, err, errMsg)
 	}
 }
 

--- a/tests/python_client/milvus_client/test_milvus_client_partition_key_isolation.py
+++ b/tests/python_client/milvus_client/test_milvus_client_partition_key_isolation.py
@@ -1,18 +1,20 @@
+import random
+import time
+
+import pandas as pd
+import pytest
 from base.client_v2_base import TestMilvusClientV2Base
 from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
+from pymilvus import AnnSearchRequest, DataType, RRFRanker
 from utils.util_log import test_log as log
-import time
-import pytest
-import random
-from pymilvus import DataType
-import pandas as pd
 
 
 @pytest.mark.tags(CaseLabel.L1)
 class TestPartitionKeyIsolation(TestMilvusClientV2Base):
-    """ Test case of partition key isolation"""
+    """Test case of partition key isolation"""
+
     def test_par_key_isolation_with_valid_expr(self):
         # create
         client = self._client()
@@ -23,16 +25,25 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
         schema = self.create_schema(client, enable_dynamic_field=True)[0]
         self.add_field(schema, "id", DataType.INT64, is_primary=True)
-        self.add_field(schema, "scalar_3", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_3"))
-        self.add_field(schema, "scalar_6", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_6"))
-        self.add_field(schema, "scalar_9", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_9"))
-        self.add_field(schema, "scalar_12", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_12"))
-        self.add_field(schema, "scalar_5_linear", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_5_linear"))
+        self.add_field(
+            schema, "scalar_3", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_3")
+        )
+        self.add_field(
+            schema, "scalar_6", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_6")
+        )
+        self.add_field(
+            schema, "scalar_9", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_9")
+        )
+        self.add_field(
+            schema, "scalar_12", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_12")
+        )
+        self.add_field(
+            schema,
+            "scalar_5_linear",
+            DataType.VARCHAR,
+            max_length=1000,
+            is_partition_key=bool(partition_key == "scalar_5_linear"),
+        )
         self.add_field(schema, "emb", DataType.FLOAT_VECTOR, dim=dim)
         self.create_collection(client, collection_name, schema=schema, num_partitions=1)
 
@@ -53,15 +64,17 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
             t0 = time.time()
             data = []
             for j in range(start_idx, end_idx):
-                data.append({
-                    "id": j,
-                    "scalar_3": str(j % 3),
-                    "scalar_6": str(j % 6),
-                    "scalar_9": str(j % 9),
-                    "scalar_12": str(j % 12),
-                    "scalar_5_linear": str(j % 5),
-                    "emb": [random.random() for _ in range(dim)]
-                })
+                data.append(
+                    {
+                        "id": j,
+                        "scalar_3": str(j % 3),
+                        "scalar_6": str(j % 6),
+                        "scalar_9": str(j % 9),
+                        "scalar_12": str(j % 12),
+                        "scalar_5_linear": str(j % 5),
+                        "emb": [random.random() for _ in range(dim)],
+                    }
+                )
             # collect data as DataFrame for pandas verification later
             df_data = {
                 "id": [j for j in range(start_idx, end_idx)],
@@ -81,8 +94,9 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
         self.wait_for_compaction_ready(client, compact_id)
         t0 = time.time()
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name="emb", metric_type="L2", index_type="HNSW",
-                               params={"M": 16, "efConstruction": 64})
+        index_params.add_index(
+            field_name="emb", metric_type="L2", index_type="HNSW", params={"M": 16, "efConstruction": 64}
+        )
         self.create_index(client, collection_name, index_params, timeout=360)
         index_list = self.list_indexes(client, collection_name)[0]
         for index_name in index_list:
@@ -101,17 +115,20 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
             "scalar_6 == '3' and (scalar_12 == '1' or scalar_3 != '1')",
             "scalar_6 == '2' and ('4' < scalar_12 < '6' or scalar_3 == '1')",
             "scalar_6 == '5' and scalar_12 in ['1', '3', '5']",
-            "scalar_6 == '1'"
+            "scalar_6 == '1'",
         ]
         for expr in valid_expressions:
-            res = self.search(client, collection_name,
-                              data=[[random.random() for _ in range(dim)]],
-                              anns_field="emb",
-                              filter=expr,
-                              search_params={"metric_type": "L2", "params": {}},
-                              limit=1000,
-                              output_fields=["scalar_3", "scalar_6", "scalar_12"],
-                              consistency_level="Strong")[0]
+            res = self.search(
+                client,
+                collection_name,
+                data=[[random.random() for _ in range(dim)]],
+                anns_field="emb",
+                filter=expr,
+                search_params={"metric_type": "L2", "params": {}},
+                limit=1000,
+                output_fields=["scalar_3", "scalar_6", "scalar_12"],
+                consistency_level="Strong",
+            )[0]
             true_res = all_df.query(expr)
             assert len(res[0]) == len(true_res)
 
@@ -124,16 +141,25 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
         schema = self.create_schema(client, enable_dynamic_field=True)[0]
         self.add_field(schema, "id", DataType.INT64, is_primary=True)
-        self.add_field(schema, "scalar_3", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_3"))
-        self.add_field(schema, "scalar_6", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_6"))
-        self.add_field(schema, "scalar_9", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_9"))
-        self.add_field(schema, "scalar_12", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_12"))
-        self.add_field(schema, "scalar_5_linear", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_5_linear"))
+        self.add_field(
+            schema, "scalar_3", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_3")
+        )
+        self.add_field(
+            schema, "scalar_6", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_6")
+        )
+        self.add_field(
+            schema, "scalar_9", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_9")
+        )
+        self.add_field(
+            schema, "scalar_12", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_12")
+        )
+        self.add_field(
+            schema,
+            "scalar_5_linear",
+            DataType.VARCHAR,
+            max_length=1000,
+            is_partition_key=bool(partition_key == "scalar_5_linear"),
+        )
         self.add_field(schema, "emb", DataType.FLOAT_VECTOR, dim=128)
         self.create_collection(client, collection_name, schema=schema, num_partitions=1)
 
@@ -153,23 +179,26 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
             t0 = time.time()
             data = []
             for j in range(start_idx, end_idx):
-                data.append({
-                    "id": j,
-                    "scalar_3": str(j % 3),
-                    "scalar_6": str(j % 6),
-                    "scalar_9": str(j % 9),
-                    "scalar_12": str(j % 12),
-                    "scalar_5_linear": str(j % 5),
-                    "emb": [random.random() for _ in range(128)]
-                })
+                data.append(
+                    {
+                        "id": j,
+                        "scalar_3": str(j % 3),
+                        "scalar_6": str(j % 6),
+                        "scalar_9": str(j % 9),
+                        "scalar_12": str(j % 12),
+                        "scalar_5_linear": str(j % 5),
+                        "emb": [random.random() for _ in range(128)],
+                    }
+                )
             log.info(f"generate test data {len(data)} cost time {time.time() - t0}")
             self.insert(client, collection_name, data)
         compact_id = self.compact(client, collection_name)[0]
         self.wait_for_compaction_ready(client, compact_id)
         t0 = time.time()
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name="emb", metric_type="L2", index_type="HNSW",
-                               params={"M": 16, "efConstruction": 64})
+        index_params.add_index(
+            field_name="emb", metric_type="L2", index_type="HNSW", params={"M": 16, "efConstruction": 64}
+        )
         self.create_index(client, collection_name, index_params, timeout=360)
         index_list = self.list_indexes(client, collection_name)[0]
         for index_name in index_list:
@@ -191,21 +220,24 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
             "scalar_6 != '1'",
             "scalar_6 > '1'",
             "'1' < scalar_6 < '3'",
-            "scalar_3 == '1'"  # scalar_3 is not partition key
+            "scalar_3 == '1'",  # scalar_3 is not partition key
         ]
         false_result = []
         for expr in invalid_expressions:
             # v2 api_request catches exceptions and returns (Error, False) instead of raising
             # use check_task=check_nothing to skip default assert_succ in ResponseChecker
-            res, check = self.search(client, collection_name,
-                                     data=[[random.random() for _ in range(128)]],
-                                     anns_field="emb",
-                                     filter=expr,
-                                     search_params={"metric_type": "L2", "params": {"nprobe": 16}},
-                                     limit=10,
-                                     output_fields=["scalar_6"],
-                                     consistency_level="Strong",
-                                     check_task=CheckTasks.check_nothing)
+            res, check = self.search(
+                client,
+                collection_name,
+                data=[[random.random() for _ in range(128)]],
+                anns_field="emb",
+                filter=expr,
+                search_params={"metric_type": "L2", "params": {"nprobe": 16}},
+                limit=10,
+                output_fields=["scalar_6"],
+                consistency_level="Strong",
+                check_task=CheckTasks.check_nothing,
+            )
             if check is not False:
                 log.info(f"search with {expr} get res {res}")
                 false_result.append(expr)
@@ -214,6 +246,141 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
         if len(false_result) > 0:
             log.info(f"search with unsupported expr {false_result}, but not raise error\n")
             assert False
+
+    def test_hybrid_search_par_key_isolation_with_unsupported_expr(self):
+        """
+        target: verify hybrid search enforces partition key isolation like search
+        method: create partition key isolation collection, compare search and hybrid_search invalid filters
+        expected: hybrid_search rejects multi-tenant and no-tenant filters
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        self.drop_collection(client, collection_name)
+
+        dim = 5
+        query_a = [[0.10, 0.20, 0.30, 0.40, 0.50]]
+        query_b = [[0.50, 0.40, 0.30, 0.20, 0.10]]
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        self.add_field(schema, "id", DataType.INT64, is_primary=True)
+        self.add_field(schema, "vector_a", DataType.FLOAT_VECTOR, dim=dim)
+        self.add_field(schema, "vector_b", DataType.FLOAT_VECTOR, dim=dim)
+        self.add_field(schema, "tenant", DataType.VARCHAR, max_length=64, is_partition_key=True)
+        self.add_field(schema, "color", DataType.VARCHAR, max_length=64)
+
+        index_params = self.prepare_index_params(client)[0]
+        for field in ["vector_a", "vector_b"]:
+            index_params.add_index(field_name=field, index_name=field, index_type="AUTOINDEX", metric_type="COSINE")
+        self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+            num_partitions=16,
+            properties={"partitionkey.isolation": "true"},
+        )
+
+        rows = [
+            {
+                "id": 1,
+                "vector_a": [0.10, 0.20, 0.30, 0.40, 0.50],
+                "vector_b": [0.50, 0.40, 0.30, 0.20, 0.10],
+                "tenant": "tenant_a",
+                "color": "tenant_a_1",
+            },
+            {
+                "id": 2,
+                "vector_a": [0.11, 0.21, 0.31, 0.41, 0.51],
+                "vector_b": [0.51, 0.41, 0.31, 0.21, 0.11],
+                "tenant": "tenant_a",
+                "color": "tenant_a_2",
+            },
+            {
+                "id": 3,
+                "vector_a": [0.90, 0.80, 0.70, 0.60, 0.50],
+                "vector_b": [0.50, 0.60, 0.70, 0.80, 0.90],
+                "tenant": "tenant_b",
+                "color": "tenant_b_1",
+            },
+            {
+                "id": 4,
+                "vector_a": [0.91, 0.81, 0.71, 0.61, 0.51],
+                "vector_b": [0.51, 0.61, 0.71, 0.81, 0.91],
+                "tenant": "tenant_b",
+                "color": "tenant_b_2",
+            },
+            {
+                "id": 5,
+                "vector_a": [0.10, 0.20, 0.30, 0.40, 0.50],
+                "vector_b": [0.50, 0.40, 0.30, 0.20, 0.10],
+                "tenant": "tenant_c",
+                "color": "tenant_c_control",
+            },
+        ]
+        self.insert(client, collection_name, rows)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+
+        res = self.search(
+            client,
+            collection_name,
+            data=query_a,
+            anns_field="vector_a",
+            filter='tenant == "tenant_a"',
+            limit=5,
+            output_fields=["id", "tenant", "color"],
+            search_params={"metric_type": "COSINE", "params": {}},
+        )[0]
+        assert {hit["tenant"] for hit in res[0]} == {"tenant_a"}
+
+        invalid_filters = [
+            ('tenant in ["tenant_a", "tenant_b"]', "partition key isolation does not support IN"),
+            ("", "partition key not found in expr"),
+        ]
+        for expr, err_msg in invalid_filters:
+            res, check = self.search(
+                client,
+                collection_name,
+                data=query_a,
+                anns_field="vector_a",
+                filter=expr,
+                limit=5,
+                output_fields=["id", "tenant", "color"],
+                search_params={"metric_type": "COSINE", "params": {}},
+                check_task=CheckTasks.check_nothing,
+            )
+            assert check is False
+            assert err_msg in str(res)
+
+        for expr, err_msg in invalid_filters:
+            reqs = [
+                AnnSearchRequest(
+                    data=query_a,
+                    anns_field="vector_a",
+                    param={"metric_type": "COSINE", "params": {}},
+                    limit=5,
+                    filter=expr,
+                ),
+                AnnSearchRequest(
+                    data=query_b,
+                    anns_field="vector_b",
+                    param={"metric_type": "COSINE", "params": {}},
+                    limit=5,
+                    filter=expr,
+                ),
+            ]
+            res, check = self.hybrid_search(
+                client,
+                collection_name,
+                reqs=reqs,
+                ranker=RRFRanker(60),
+                limit=5,
+                output_fields=["id", "tenant", "color"],
+                check_task=CheckTasks.check_nothing,
+            )
+            if check is not False:
+                log.info(f"hybrid_search with unsupported expr {expr} got res {res}")
+                pytest.xfail(f"issue: https://github.com/milvus-io/milvus/issues/50398, expr: {expr}")
+            assert err_msg in str(res)
 
     def test_par_key_isolation_without_partition_key(self):
         # create
@@ -224,23 +391,35 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
         schema = self.create_schema(client, enable_dynamic_field=True)[0]
         self.add_field(schema, "id", DataType.INT64, is_primary=True)
-        self.add_field(schema, "scalar_3", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_3"))
-        self.add_field(schema, "scalar_6", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_6"))
-        self.add_field(schema, "scalar_9", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_9"))
-        self.add_field(schema, "scalar_12", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_12"))
-        self.add_field(schema, "scalar_5_linear", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_5_linear"))
+        self.add_field(
+            schema, "scalar_3", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_3")
+        )
+        self.add_field(
+            schema, "scalar_6", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_6")
+        )
+        self.add_field(
+            schema, "scalar_9", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_9")
+        )
+        self.add_field(
+            schema, "scalar_12", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_12")
+        )
+        self.add_field(
+            schema,
+            "scalar_5_linear",
+            DataType.VARCHAR,
+            max_length=1000,
+            is_partition_key=bool(partition_key == "scalar_5_linear"),
+        )
         self.add_field(schema, "emb", DataType.FLOAT_VECTOR, dim=128)
         self.create_collection(client, collection_name, schema=schema)
         err_msg = "partition key isolation mode is enabled but no partition key field is set"
-        self.alter_collection_properties(client, collection_name,
-                                         {"partitionkey.isolation": enable_isolation},
-                                         check_task=CheckTasks.err_res,
-                                         check_items={"err_code": 1100, "err_msg": err_msg})
+        self.alter_collection_properties(
+            client,
+            collection_name,
+            {"partitionkey.isolation": enable_isolation},
+            check_task=CheckTasks.err_res,
+            check_items={"err_code": 1100, "err_msg": err_msg},
+        )
 
     def test_set_par_key_isolation_after_vector_indexed(self):
         # create
@@ -251,16 +430,25 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
         self.drop_collection(client, collection_name)
         schema = self.create_schema(client, enable_dynamic_field=True)[0]
         self.add_field(schema, "id", DataType.INT64, is_primary=True)
-        self.add_field(schema, "scalar_3", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_3"))
-        self.add_field(schema, "scalar_6", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_6"))
-        self.add_field(schema, "scalar_9", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_9"))
-        self.add_field(schema, "scalar_12", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_12"))
-        self.add_field(schema, "scalar_5_linear", DataType.VARCHAR, max_length=1000,
-                       is_partition_key=bool(partition_key == "scalar_5_linear"))
+        self.add_field(
+            schema, "scalar_3", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_3")
+        )
+        self.add_field(
+            schema, "scalar_6", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_6")
+        )
+        self.add_field(
+            schema, "scalar_9", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_9")
+        )
+        self.add_field(
+            schema, "scalar_12", DataType.VARCHAR, max_length=1000, is_partition_key=bool(partition_key == "scalar_12")
+        )
+        self.add_field(
+            schema,
+            "scalar_5_linear",
+            DataType.VARCHAR,
+            max_length=1000,
+            is_partition_key=bool(partition_key == "scalar_5_linear"),
+        )
         self.add_field(schema, "emb", DataType.FLOAT_VECTOR, dim=128)
         self.create_collection(client, collection_name, schema=schema, num_partitions=1)
 
@@ -280,23 +468,26 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
             t0 = time.time()
             data = []
             for j in range(start_idx, end_idx):
-                data.append({
-                    "id": j,
-                    "scalar_3": str(j % 3),
-                    "scalar_6": str(j % 6),
-                    "scalar_9": str(j % 9),
-                    "scalar_12": str(j % 12),
-                    "scalar_5_linear": str(j % 5),
-                    "emb": [random.random() for _ in range(128)]
-                })
+                data.append(
+                    {
+                        "id": j,
+                        "scalar_3": str(j % 3),
+                        "scalar_6": str(j % 6),
+                        "scalar_9": str(j % 9),
+                        "scalar_12": str(j % 12),
+                        "scalar_5_linear": str(j % 5),
+                        "emb": [random.random() for _ in range(128)],
+                    }
+                )
             log.info(f"generate test data {len(data)} cost time {time.time() - t0}")
             self.insert(client, collection_name, data)
         compact_id = self.compact(client, collection_name)[0]
         self.wait_for_compaction_ready(client, compact_id)
         t0 = time.time()
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name="emb", metric_type="L2", index_type="HNSW",
-                               params={"M": 16, "efConstruction": 64})
+        index_params.add_index(
+            field_name="emb", metric_type="L2", index_type="HNSW", params={"M": 16, "efConstruction": 64}
+        )
         self.create_index(client, collection_name, index_params, timeout=360)
         index_list = self.list_indexes(client, collection_name)[0]
         for index_name in index_list:
@@ -304,28 +495,38 @@ class TestPartitionKeyIsolation(TestMilvusClientV2Base):
         tt = time.time() - t0
         log.info(f"create index cost time {tt}")
         # try set isolation=true after index exists → expect failure
-        error = {ct.err_code: 702,
-                 ct.err_msg: "can not alter partition key isolation mode if the collection already has a vector index"}
-        self.alter_collection_properties(client, collection_name,
-                                         {"partitionkey.isolation": "true"},
-                                         check_task=CheckTasks.err_res, check_items=error)
+        error = {
+            ct.err_code: 702,
+            ct.err_msg: "can not alter partition key isolation mode if the collection already has a vector index",
+        }
+        self.alter_collection_properties(
+            client,
+            collection_name,
+            {"partitionkey.isolation": "true"},
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
         # drop index, then set isolation=true → expect success
         for index_name in index_list:
             self.drop_index(client, collection_name, index_name)
         self.alter_collection_properties(client, collection_name, {"partitionkey.isolation": "true"})
         # recreate index, load, search
         index_params = self.prepare_index_params(client)[0]
-        index_params.add_index(field_name="emb", metric_type="L2", index_type="HNSW",
-                               params={"M": 16, "efConstruction": 64})
+        index_params.add_index(
+            field_name="emb", metric_type="L2", index_type="HNSW", params={"M": 16, "efConstruction": 64}
+        )
         self.create_index(client, collection_name, index_params, timeout=360)
         self.load_collection(client, collection_name)
-        res = self.search(client, collection_name,
-                          data=[[random.random() for _ in range(128)]],
-                          anns_field="emb",
-                          filter="scalar_6 == '1' and scalar_3 == '1'",
-                          search_params={"metric_type": "L2", "params": {"nprobe": 16}},
-                          limit=10,
-                          output_fields=["scalar_6", "scalar_3"],
-                          consistency_level="Strong")[0]
+        res = self.search(
+            client,
+            collection_name,
+            data=[[random.random() for _ in range(128)]],
+            anns_field="emb",
+            filter="scalar_6 == '1' and scalar_3 == '1'",
+            search_params={"metric_type": "L2", "params": {"nprobe": 16}},
+            limit=10,
+            output_fields=["scalar_6", "scalar_3"],
+            consistency_level="Strong",
+        )[0]
         log.info(f"search res {res}")
         assert len(res[0]) > 0

--- a/tests/restful_client_v2/testcases/test_vector_operations.py
+++ b/tests/restful_client_v2/testcases/test_vector_operations.py
@@ -1,23 +1,30 @@
+import json
 import random
-from sklearn import preprocessing
+import re
+import sys
+import time
+
 import numpy as np
 import pandas as pd
-import sys
-import json
-import time
-from utils.constant import default_nb, MAX_SUM_OFFSET_AND_LIMIT
-from utils.utils import gen_collection_name, get_sorted_distance, patch_faker_text, en_vocabularies_distribution, \
-    zh_vocabularies_distribution
-from utils.util_log import test_log as logger
 import pytest
 from base.testbase import TestBase
-from utils.utils import (gen_unique_str, get_data_by_payload, get_common_fields_by_data, gen_vector, analyze_documents)
-from pymilvus import (
-    FieldSchema, CollectionSchema, DataType,
-    Collection, utility
-)
 from faker import Faker
-import re
+from pymilvus import Collection, CollectionSchema, DataType, FieldSchema, utility
+from sklearn import preprocessing
+from utils.constant import MAX_SUM_OFFSET_AND_LIMIT, default_nb
+from utils.util_log import test_log as logger
+from utils.utils import (
+    analyze_documents,
+    en_vocabularies_distribution,
+    gen_collection_name,
+    gen_unique_str,
+    gen_vector,
+    get_common_fields_by_data,
+    get_data_by_payload,
+    get_sorted_distance,
+    patch_faker_text,
+    zh_vocabularies_distribution,
+)
 
 Faker.seed(19530)
 fake_en = Faker("en_US")
@@ -29,7 +36,6 @@ patch_faker_text(fake_zh, zh_vocabularies_distribution)
 
 @pytest.mark.L0
 class TestInsertVector(TestBase):
-
     @pytest.mark.parametrize("insert_round", [3])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
@@ -39,16 +45,12 @@ class TestInsertVector(TestBase):
         """
         # create a collection
         name = gen_collection_name()
-        collection_payload = {
-            "collectionName": name,
-            "dimension": dim,
-            "metricType": "L2"
-        }
+        collection_payload = {"collectionName": name, "dimension": dim, "metricType": "L2"}
         rsp = self.collection_client.collection_create(collection_payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = get_data_by_payload(collection_payload, nb)
@@ -59,8 +61,8 @@ class TestInsertVector(TestBase):
             body_size = sys.getsizeof(json.dumps(payload))
             logger.info(f"body size: {body_size / 1024 / 1024} MB")
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True, False])
@@ -68,8 +70,9 @@ class TestInsertVector(TestBase):
     @pytest.mark.parametrize("enable_dynamic_schema", [True, False])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
-    def test_insert_entities_with_all_scalar_datatype(self, nb, dim, insert_round, auto_id,
-                                                      is_partition_key, enable_dynamic_schema):
+    def test_insert_entities_with_all_scalar_datatype(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -82,32 +85,48 @@ class TestInsertVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "bool", "dataType": "Bool", "elementTypeParams": {}},
                     {"fieldName": "json", "dataType": "JSON", "elementTypeParams": {}},
-                    {"fieldName": "int_array", "dataType": "Array", "elementDataType": "Int64",
-                     "elementTypeParams": {"max_capacity": "1024"}},
-                    {"fieldName": "varchar_array", "dataType": "Array", "elementDataType": "VarChar",
-                     "elementTypeParams": {"max_capacity": "1024", "max_length": "256"}},
-                    {"fieldName": "bool_array", "dataType": "Array", "elementDataType": "Bool",
-                     "elementTypeParams": {"max_capacity": "1024"}},
+                    {
+                        "fieldName": "int_array",
+                        "dataType": "Array",
+                        "elementDataType": "Int64",
+                        "elementTypeParams": {"max_capacity": "1024"},
+                    },
+                    {
+                        "fieldName": "varchar_array",
+                        "dataType": "Array",
+                        "elementDataType": "VarChar",
+                        "elementTypeParams": {"max_capacity": "1024", "max_length": "256"},
+                    },
+                    {
+                        "fieldName": "bool_array",
+                        "dataType": "Array",
+                        "elementDataType": "Bool",
+                        "elementTypeParams": {"max_capacity": "1024"},
+                    },
                     {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                     {"fieldName": "image_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "text_emb", "indexName": "text_emb", "metricType": "L2"},
-                {"fieldName": "image_emb", "indexName": "image_emb", "metricType": "L2"}
-            ]
+                {"fieldName": "image_emb", "indexName": "image_emb", "metricType": "L2"},
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -123,9 +142,11 @@ class TestInsertVector(TestBase):
                         "varchar_array": [f"varchar_{i}"],
                         "bool_array": [random.choice([True, False])],
                         "text_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                         "image_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                     }
                 else:
                     tmp = {
@@ -139,9 +160,11 @@ class TestInsertVector(TestBase):
                         "varchar_array": [f"varchar_{i}"],
                         "bool_array": [random.choice([True, False])],
                         "text_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                         "image_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                     }
                 if enable_dynamic_schema:
                     tmp.update({f"dynamic_field_{i}": i})
@@ -151,12 +174,12 @@ class TestInsertVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # query data to make sure the data is inserted
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": "user_id > 0", "limit": 50})
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 50
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 50
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
@@ -165,9 +188,9 @@ class TestInsertVector(TestBase):
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
     @pytest.mark.parametrize("pass_fp32_to_fp16_or_bf16", [True, False])
-    def test_insert_entities_with_all_vector_datatype(self, nb, dim, insert_round, auto_id,
-                                                      is_partition_key, enable_dynamic_schema,
-                                                      pass_fp32_to_fp16_or_bf16):
+    def test_insert_entities_with_all_vector_datatype(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema, pass_fp32_to_fp16_or_bf16
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -180,31 +203,45 @@ class TestInsertVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "float_vector", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                    {"fieldName": "float16_vector", "dataType": "Float16Vector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
-                    {"fieldName": "bfloat16_vector", "dataType": "BFloat16Vector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
+                    {
+                        "fieldName": "float16_vector",
+                        "dataType": "Float16Vector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
+                    {
+                        "fieldName": "bfloat16_vector",
+                        "dataType": "BFloat16Vector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
                     {"fieldName": "binary_vector", "dataType": "BinaryVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "float_vector", "indexName": "float_vector", "metricType": "L2"},
                 {"fieldName": "float16_vector", "indexName": "float16_vector", "metricType": "L2"},
                 {"fieldName": "bfloat16_vector", "indexName": "bfloat16_vector", "metricType": "L2"},
-                {"fieldName": "binary_vector", "indexName": "binary_vector", "metricType": "HAMMING",
-                 "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"}}
-            ]
+                {
+                    "fieldName": "binary_vector",
+                    "indexName": "binary_vector",
+                    "metricType": "HAMMING",
+                    "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"},
+                },
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -244,7 +281,7 @@ class TestInsertVector(TestBase):
                             if pass_fp32_to_fp16_or_bf16
                             else gen_vector(datatype="BFloat16Vector", dim=dim)
                         ),
-                        "binary_vector": gen_vector(datatype="BinaryVector", dim=dim)
+                        "binary_vector": gen_vector(datatype="BinaryVector", dim=dim),
                     }
                 if enable_dynamic_schema:
                     tmp.update({f"dynamic_field_{i}": i})
@@ -254,8 +291,8 @@ class TestInsertVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         c = Collection(name)
         res = c.query(
             expr="user_id > 0",
@@ -265,8 +302,8 @@ class TestInsertVector(TestBase):
         logger.info(f"res: {res}")
         # query data to make sure the data is inserted
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": "user_id > 0", "limit": 50})
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 50
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 50
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
@@ -275,9 +312,9 @@ class TestInsertVector(TestBase):
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
     @pytest.mark.parametrize("pass_fp32_to_fp16_or_bf16", [True, False])
-    def test_insert_entities_with_all_vector_datatype_0(self, nb, dim, insert_round, auto_id,
-                                                        is_partition_key, enable_dynamic_schema,
-                                                        pass_fp32_to_fp16_or_bf16):
+    def test_insert_entities_with_all_vector_datatype_0(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema, pass_fp32_to_fp16_or_bf16
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -290,35 +327,61 @@ class TestInsertVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "book_vector", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                     {"fieldName": "float_vector", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                    {"fieldName": "float16_vector", "dataType": "Float16Vector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
-                    {"fieldName": "bfloat16_vector", "dataType": "BFloat16Vector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                    {
+                        "fieldName": "float16_vector",
+                        "dataType": "Float16Vector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
+                    {
+                        "fieldName": "bfloat16_vector",
+                        "dataType": "BFloat16Vector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
+                ],
             },
             "indexParams": [
-                {"fieldName": "book_vector", "indexName": "book_vector", "metricType": "L2",
-                 "params": {"index_type": "FLAT"}},
-                {"fieldName": "float_vector", "indexName": "float_vector", "metricType": "L2",
-                 "params": {"index_type": "IVF_FLAT", "nlist": 128}},
-                {"fieldName": "float16_vector", "indexName": "float16_vector", "metricType": "L2",
-                 "params": {"index_type": "IVF_SQ8", "nlist": "128"}},
-                {"fieldName": "bfloat16_vector", "indexName": "bfloat16_vector", "metricType": "L2",
-                 "params": {"index_type": "IVF_PQ", "nlist": 128, "m": 16, "nbits": 8}},
-            ]
+                {
+                    "fieldName": "book_vector",
+                    "indexName": "book_vector",
+                    "metricType": "L2",
+                    "params": {"index_type": "FLAT"},
+                },
+                {
+                    "fieldName": "float_vector",
+                    "indexName": "float_vector",
+                    "metricType": "L2",
+                    "params": {"index_type": "IVF_FLAT", "nlist": 128},
+                },
+                {
+                    "fieldName": "float16_vector",
+                    "indexName": "float16_vector",
+                    "metricType": "L2",
+                    "params": {"index_type": "IVF_SQ8", "nlist": "128"},
+                },
+                {
+                    "fieldName": "bfloat16_vector",
+                    "indexName": "bfloat16_vector",
+                    "metricType": "L2",
+                    "params": {"index_type": "IVF_PQ", "nlist": 128, "m": 16, "nbits": 8},
+                },
+            ],
         }
 
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -368,8 +431,8 @@ class TestInsertVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         c = Collection(name)
         res = c.query(
             expr="user_id > 0",
@@ -379,8 +442,8 @@ class TestInsertVector(TestBase):
         logger.info(f"res: {res}")
         # query data to make sure the data is inserted
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": "user_id > 0", "limit": 50})
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 50
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 50
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
@@ -389,9 +452,9 @@ class TestInsertVector(TestBase):
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
     @pytest.mark.parametrize("pass_fp32_to_fp16_or_bf16", [True, False])
-    def test_insert_entities_with_all_vector_datatype_1(self, nb, dim, insert_round, auto_id,
-                                                        is_partition_key, enable_dynamic_schema,
-                                                        pass_fp32_to_fp16_or_bf16):
+    def test_insert_entities_with_all_vector_datatype_1(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema, pass_fp32_to_fp16_or_bf16
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -404,32 +467,54 @@ class TestInsertVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "float_vector", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                    {"fieldName": "float16_vector", "dataType": "Float16Vector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
-                    {"fieldName": "bfloat16_vector", "dataType": "BFloat16Vector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                    {
+                        "fieldName": "float16_vector",
+                        "dataType": "Float16Vector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
+                    {
+                        "fieldName": "bfloat16_vector",
+                        "dataType": "BFloat16Vector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
+                ],
             },
             "indexParams": [
-                {"fieldName": "float_vector", "indexName": "float_vector", "metricType": "L2",
-                 "params": {"index_type": "HNSW", "M": 32, "efConstruction": 360}},
-                {"fieldName": "float16_vector", "indexName": "float16_vector", "metricType": "L2",
-                 "params": {"index_type": "SCANN", "nlist": "128"}},
-                {"fieldName": "bfloat16_vector", "indexName": "bfloat16_vector", "metricType": "L2",
-                 "params": {"index_type": "DISKANN"}},
-            ]
+                {
+                    "fieldName": "float_vector",
+                    "indexName": "float_vector",
+                    "metricType": "L2",
+                    "params": {"index_type": "HNSW", "M": 32, "efConstruction": 360},
+                },
+                {
+                    "fieldName": "float16_vector",
+                    "indexName": "float16_vector",
+                    "metricType": "L2",
+                    "params": {"index_type": "SCANN", "nlist": "128"},
+                },
+                {
+                    "fieldName": "bfloat16_vector",
+                    "indexName": "bfloat16_vector",
+                    "metricType": "L2",
+                    "params": {"index_type": "DISKANN"},
+                },
+            ],
         }
 
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -477,8 +562,8 @@ class TestInsertVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         c = Collection(name)
         res = c.query(
             expr="user_id > 0",
@@ -488,8 +573,8 @@ class TestInsertVector(TestBase):
         logger.info(f"res: {res}")
         # query data to make sure the data is inserted
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": "user_id > 0", "limit": 50})
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 50
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 50
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
@@ -497,8 +582,9 @@ class TestInsertVector(TestBase):
     @pytest.mark.parametrize("enable_dynamic_schema", [True])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
-    def test_insert_entities_with_all_vector_datatype_2(self, nb, dim, insert_round, auto_id,
-                                                        is_partition_key, enable_dynamic_schema):
+    def test_insert_entities_with_all_vector_datatype_2(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -511,35 +597,61 @@ class TestInsertVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
-                    {"fieldName": "binary_vector_0", "dataType": "BinaryVector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
-                    {"fieldName": "binary_vector_1", "dataType": "BinaryVector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
+                    {
+                        "fieldName": "binary_vector_0",
+                        "dataType": "BinaryVector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
+                    {
+                        "fieldName": "binary_vector_1",
+                        "dataType": "BinaryVector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
                     {"fieldName": "sparse_float_vector_0", "dataType": "SparseFloatVector"},
                     {"fieldName": "sparse_float_vector_1", "dataType": "SparseFloatVector"},
-                ]
+                ],
             },
             "indexParams": [
-                {"fieldName": "binary_vector_0", "indexName": "binary_vector_0_index", "metricType": "HAMMING",
-                 "params": {"index_type": "BIN_FLAT"}},
-                {"fieldName": "binary_vector_1", "indexName": "binary_vector_1_index", "metricType": "HAMMING",
-                 "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"}},
-                {"fieldName": "sparse_float_vector_0", "indexName": "sparse_float_vector_0_index", "metricType": "IP",
-                 "params": {"index_type": "SPARSE_INVERTED_INDEX", "drop_ratio_build": "0.2"}},
-                {"fieldName": "sparse_float_vector_1", "indexName": "sparse_float_vector_1_index", "metricType": "IP",
-                 "params": {"index_type": "SPARSE_WAND", "drop_ratio_build": "0.2"}}
-            ]
+                {
+                    "fieldName": "binary_vector_0",
+                    "indexName": "binary_vector_0_index",
+                    "metricType": "HAMMING",
+                    "params": {"index_type": "BIN_FLAT"},
+                },
+                {
+                    "fieldName": "binary_vector_1",
+                    "indexName": "binary_vector_1_index",
+                    "metricType": "HAMMING",
+                    "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"},
+                },
+                {
+                    "fieldName": "sparse_float_vector_0",
+                    "indexName": "sparse_float_vector_0_index",
+                    "metricType": "IP",
+                    "params": {"index_type": "SPARSE_INVERTED_INDEX", "drop_ratio_build": "0.2"},
+                },
+                {
+                    "fieldName": "sparse_float_vector_1",
+                    "indexName": "sparse_float_vector_1_index",
+                    "metricType": "IP",
+                    "params": {"index_type": "SPARSE_WAND", "drop_ratio_build": "0.2"},
+                },
+            ],
         }
 
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -573,8 +685,8 @@ class TestInsertVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         c = Collection(name)
         res = c.query(
             expr="user_id > 0",
@@ -584,8 +696,8 @@ class TestInsertVector(TestBase):
         logger.info(f"res: {res}")
         # query data to make sure the data is inserted
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": "user_id > 0", "limit": 50})
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 50
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 50
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True, False])
@@ -593,8 +705,9 @@ class TestInsertVector(TestBase):
     @pytest.mark.parametrize("enable_dynamic_schema", [True, False])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
-    def test_insert_entities_with_all_json_datatype(self, nb, dim, insert_round, auto_id,
-                                                    is_partition_key, enable_dynamic_schema):
+    def test_insert_entities_with_all_json_datatype(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -607,32 +720,48 @@ class TestInsertVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "bool", "dataType": "Bool", "elementTypeParams": {}},
                     {"fieldName": "json", "dataType": "JSON", "elementTypeParams": {}},
-                    {"fieldName": "int_array", "dataType": "Array", "elementDataType": "Int64",
-                     "elementTypeParams": {"max_capacity": "1024"}},
-                    {"fieldName": "varchar_array", "dataType": "Array", "elementDataType": "VarChar",
-                     "elementTypeParams": {"max_capacity": "1024", "max_length": "256"}},
-                    {"fieldName": "bool_array", "dataType": "Array", "elementDataType": "Bool",
-                     "elementTypeParams": {"max_capacity": "1024"}},
+                    {
+                        "fieldName": "int_array",
+                        "dataType": "Array",
+                        "elementDataType": "Int64",
+                        "elementTypeParams": {"max_capacity": "1024"},
+                    },
+                    {
+                        "fieldName": "varchar_array",
+                        "dataType": "Array",
+                        "elementDataType": "VarChar",
+                        "elementTypeParams": {"max_capacity": "1024", "max_length": "256"},
+                    },
+                    {
+                        "fieldName": "bool_array",
+                        "dataType": "Array",
+                        "elementDataType": "Bool",
+                        "elementTypeParams": {"max_capacity": "1024"},
+                    },
                     {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                     {"fieldName": "image_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "text_emb", "indexName": "text_emb", "metricType": "L2"},
-                {"fieldName": "image_emb", "indexName": "image_emb", "metricType": "L2"}
-            ]
+                {"fieldName": "image_emb", "indexName": "image_emb", "metricType": "L2"},
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         json_value = [
             1,
             1.0,
@@ -657,9 +786,11 @@ class TestInsertVector(TestBase):
                         "varchar_array": [f"varchar_{i}"],
                         "bool_array": [random.choice([True, False])],
                         "text_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                         "image_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                     }
                 else:
                     tmp = {
@@ -673,9 +804,11 @@ class TestInsertVector(TestBase):
                         "varchar_array": [f"varchar_{i}"],
                         "bool_array": [random.choice([True, False])],
                         "text_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                         "image_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                     }
                 if enable_dynamic_schema:
                     tmp.update({f"dynamic_field_{i}": i})
@@ -685,12 +818,12 @@ class TestInsertVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # query data to make sure the data is inserted
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": "user_id > 0", "limit": 50})
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 50
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 50
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True, False])
@@ -698,8 +831,9 @@ class TestInsertVector(TestBase):
     @pytest.mark.parametrize("enable_dynamic_schema", [True, False])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
-    def test_insert_entities_with_default_none(self, nb, dim, insert_round, auto_id, is_partition_key,
-                                               enable_dynamic_schema):
+    def test_insert_entities_with_default_none(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema
+    ):
         """
         Insert a vector with defaultValue and none
         """
@@ -712,26 +846,41 @@ class TestInsertVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}, "defaultValue": 10},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                        "defaultValue": 10,
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}, "nullable": True},
-                    {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"},
-                     "defaultValue": "default", "nullable": True},
+                    {
+                        "fieldName": "book_describe",
+                        "dataType": "VarChar",
+                        "elementTypeParams": {"max_length": "256"},
+                        "defaultValue": "default",
+                        "nullable": True,
+                    },
                     {"fieldName": "json", "dataType": "JSON", "elementTypeParams": {}, "nullable": True},
-                    {"fieldName": "varchar_array", "dataType": "Array", "elementDataType": "VarChar",
-                     "elementTypeParams": {"max_capacity": "1024", "max_length": "256"}, "nullable": True},
+                    {
+                        "fieldName": "varchar_array",
+                        "dataType": "Array",
+                        "elementDataType": "VarChar",
+                        "elementTypeParams": {"max_capacity": "1024", "max_length": "256"},
+                        "nullable": True,
+                    },
                     {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "text_emb", "indexName": "text_emb", "metricType": "L2"},
-            ]
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for k in range(insert_round):
             data = []
@@ -744,7 +893,8 @@ class TestInsertVector(TestBase):
                         "json": None,
                         "varchar_array": None,
                         "text_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                     }
                 else:
                     tmp = {
@@ -755,7 +905,8 @@ class TestInsertVector(TestBase):
                         "json": None,
                         "varchar_array": None,
                         "text_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                     }
                 if enable_dynamic_schema:
                     tmp.update({f"dynamic_field_{i}": i})
@@ -765,20 +916,19 @@ class TestInsertVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # query data to make sure the data is inserted
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": "user_id > 0", "limit": 5})
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 5
-        assert rsp['data'][0]['book_describe'] == 'default'
-        assert rsp['data'][0]['word_count'] is None
-        assert rsp['data'][0]['json'] is None
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 5
+        assert rsp["data"][0]["book_describe"] == "default"
+        assert rsp["data"][0]["word_count"] is None
+        assert rsp["data"][0]["json"] is None
 
 
 @pytest.mark.L0
 class TestInsertVectorNegative(TestBase):
-
     def test_insert_vector_with_invalid_collection_name(self):
         """
         Insert a vector with an invalid collection name
@@ -792,9 +942,9 @@ class TestInsertVectorNegative(TestBase):
             "dimension": dim,
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         nb = default_nb
         data = get_data_by_payload(payload, nb)
@@ -805,8 +955,8 @@ class TestInsertVectorNegative(TestBase):
         body_size = sys.getsizeof(json.dumps(payload))
         logger.info(f"body size: {body_size / 1024 / 1024} MB")
         rsp = self.vector_client.vector_insert(payload)
-        assert rsp['code'] == 100
-        assert "can't find collection" in rsp['message']
+        assert rsp["code"] == 100
+        assert "can't find collection" in rsp["message"]
 
     def test_insert_vector_with_invalid_database_name(self):
         """
@@ -820,9 +970,9 @@ class TestInsertVectorNegative(TestBase):
             "dimension": dim,
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         nb = 10
         data = get_data_by_payload(payload, nb)
@@ -832,9 +982,8 @@ class TestInsertVectorNegative(TestBase):
         }
         body_size = sys.getsizeof(json.dumps(payload))
         logger.info(f"body size: {body_size / 1024 / 1024} MB")
-        success = False
         rsp = self.vector_client.vector_insert(payload, db_name="invalid_database")
-        assert rsp['code'] == 800
+        assert rsp["code"] == 800
 
     def test_insert_vector_with_mismatch_dim(self):
         """
@@ -848,15 +997,17 @@ class TestInsertVectorNegative(TestBase):
             "dimension": dim,
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         nb = 1
         data = [
-            {"id": i,
-             "vector": [np.float64(random.random()) for _ in range(dim + 1)],
-             } for i in range(nb)
+            {
+                "id": i,
+                "vector": [np.float64(random.random()) for _ in range(dim + 1)],
+            }
+            for i in range(nb)
         ]
         payload = {
             "collectionName": name,
@@ -865,8 +1016,8 @@ class TestInsertVectorNegative(TestBase):
         body_size = sys.getsizeof(json.dumps(payload))
         logger.info(f"body size: {body_size / 1024 / 1024} MB")
         rsp = self.vector_client.vector_insert(payload)
-        assert rsp['code'] == 1804
-        assert "fail to deal the insert data" in rsp['message']
+        assert rsp["code"] == 1804
+        assert "fail to deal the insert data" in rsp["message"]
 
     def test_insert_entities_with_none_no_nullable_field(self):
         """
@@ -882,14 +1033,14 @@ class TestInsertVectorNegative(TestBase):
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{128}"}},
-                ]
-            }
+                ],
+            },
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         data = []
         for i in range(10):
@@ -903,8 +1054,8 @@ class TestInsertVectorNegative(TestBase):
             "data": data,
         }
         rsp = self.vector_client.vector_insert(payload)
-        assert rsp['code'] == 1804
-        assert "fail to deal the insert data" in rsp['message']
+        assert rsp["code"] == 1804
+        assert "fail to deal the insert data" in rsp["message"]
 
     def test_insert_with_bm25_function_output_field_data(self):
         """
@@ -919,8 +1070,11 @@ class TestInsertVectorNegative(TestBase):
                 "enableDynamicField": False,
                 "fields": [
                     {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
-                    {"fieldName": "text", "dataType": "VarChar",
-                     "elementTypeParams": {"max_length": "512", "enable_analyzer": True}},
+                    {
+                        "fieldName": "text",
+                        "dataType": "VarChar",
+                        "elementTypeParams": {"max_length": "512", "enable_analyzer": True},
+                    },
                     {"fieldName": "sparse_vector", "dataType": "SparseFloatVector"},
                 ],
                 "functions": [
@@ -929,29 +1083,29 @@ class TestInsertVectorNegative(TestBase):
                         "type": "BM25",
                         "inputFieldNames": ["text"],
                         "outputFieldNames": ["sparse_vector"],
-                        "params": {}
+                        "params": {},
                     }
-                ]
+                ],
             },
             "indexParams": [
-                {"fieldName": "sparse_vector", "indexName": "sparse_idx", "metricType": "BM25",
-                 "params": {"index_type": "SPARSE_INVERTED_INDEX"}}
-            ]
+                {
+                    "fieldName": "sparse_vector",
+                    "indexName": "sparse_idx",
+                    "metricType": "BM25",
+                    "params": {"index_type": "SPARSE_INVERTED_INDEX"},
+                }
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         self.wait_collection_load_completed(name)
 
         # insert data with BM25 function output field should fail
-        data = [
-            {"id": i, "text": f"sample text {i}",
-             "sparse_vector": {1: 0.5, 2: 0.3}}
-            for i in range(10)
-        ]
+        data = [{"id": i, "text": f"sample text {i}", "sparse_vector": {1: 0.5, 2: 0.3}} for i in range(10)]
         insert_payload = {"collectionName": name, "data": data}
         rsp = self.vector_client.vector_insert(insert_payload)
-        assert rsp['code'] != 0
-        assert "function output" in rsp['message'].lower() or "bm25" in rsp['message'].lower()
+        assert rsp["code"] != 0
+        assert "function output" in rsp["message"].lower() or "bm25" in rsp["message"].lower()
 
     def test_insert_without_bm25_function_output_field_data(self):
         """
@@ -966,8 +1120,11 @@ class TestInsertVectorNegative(TestBase):
                 "enableDynamicField": False,
                 "fields": [
                     {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
-                    {"fieldName": "text", "dataType": "VarChar",
-                     "elementTypeParams": {"max_length": "512", "enable_analyzer": True}},
+                    {
+                        "fieldName": "text",
+                        "dataType": "VarChar",
+                        "elementTypeParams": {"max_length": "512", "enable_analyzer": True},
+                    },
                     {"fieldName": "sparse_vector", "dataType": "SparseFloatVector"},
                 ],
                 "functions": [
@@ -976,33 +1133,33 @@ class TestInsertVectorNegative(TestBase):
                         "type": "BM25",
                         "inputFieldNames": ["text"],
                         "outputFieldNames": ["sparse_vector"],
-                        "params": {}
+                        "params": {},
                     }
-                ]
+                ],
             },
             "indexParams": [
-                {"fieldName": "sparse_vector", "indexName": "sparse_idx", "metricType": "BM25",
-                 "params": {"index_type": "SPARSE_INVERTED_INDEX"}}
-            ]
+                {
+                    "fieldName": "sparse_vector",
+                    "indexName": "sparse_idx",
+                    "metricType": "BM25",
+                    "params": {"index_type": "SPARSE_INVERTED_INDEX"},
+                }
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         self.wait_collection_load_completed(name)
 
         # insert data without function output field should succeed
-        data = [
-            {"id": i, "text": f"sample text {i}"}
-            for i in range(10)
-        ]
+        data = [{"id": i, "text": f"sample text {i}"} for i in range(10)]
         insert_payload = {"collectionName": name, "data": data}
         rsp = self.vector_client.vector_insert(insert_payload)
-        assert rsp['code'] == 0
-        assert rsp['data']['insertCount'] == 10
+        assert rsp["code"] == 0
+        assert rsp["data"]["insertCount"] == 10
 
 
 @pytest.mark.L0
 class TestUpsertVector(TestBase):
-
     @pytest.mark.parametrize("insert_round", [2])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
@@ -1014,21 +1171,25 @@ class TestUpsertVector(TestBase):
             "collectionName": name,
             "schema": {
                 "fields": [
-                    {"fieldName": "book_id", "dataType": f"{id_type}", "isPrimary": True,
-                     "elementTypeParams": {"max_length": "256"}},
+                    {
+                        "fieldName": "book_id",
+                        "dataType": f"{id_type}",
+                        "isPrimary": True,
+                        "elementTypeParams": {"max_length": "256"},
+                    },
                     {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": True, "elementTypeParams": {}},
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
-                    {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}}
+                    {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                 ]
             },
-            "indexParams": [{"fieldName": "text_emb", "indexName": "text_emb_index", "metricType": "L2"}]
+            "indexParams": [{"fieldName": "text_emb", "indexName": "text_emb_index", "metricType": "L2"}],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -1038,7 +1199,7 @@ class TestUpsertVector(TestBase):
                     "user_id": i * nb + j,
                     "word_count": i * nb + j,
                     "book_describe": f"book_{i * nb + j}",
-                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
+                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist(),
                 }
                 data.append(tmp)
             payload = {
@@ -1048,8 +1209,8 @@ class TestUpsertVector(TestBase):
             body_size = sys.getsizeof(json.dumps(payload))
             logger.info(f"body size: {body_size / 1024 / 1024} MB")
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
             c = Collection(name)
             c.flush()
 
@@ -1062,7 +1223,7 @@ class TestUpsertVector(TestBase):
                     "user_id": i * nb + j + 1,
                     "word_count": i * nb + j + 2,
                     "book_describe": f"book_{i * nb + j + 3}",
-                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
+                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist(),
                 }
                 data.append(tmp)
             payload = {
@@ -1077,10 +1238,10 @@ class TestUpsertVector(TestBase):
             rsp = self.vector_client.vector_query({"collectionName": name, "filter": "book_id > 0"})
         if id_type == "VarChar":
             rsp = self.vector_client.vector_query({"collectionName": name, "filter": "book_id > '0'"})
-        for data in rsp['data']:
-            assert data['user_id'] == int(data['book_id']) + 1
-            assert data['word_count'] == int(data['book_id']) + 2
-            assert data['book_describe'] == f"book_{int(data['book_id']) + 3}"
+        for data in rsp["data"]:
+            assert data["user_id"] == int(data["book_id"]) + 1
+            assert data["word_count"] == int(data["book_id"]) + 2
+            assert data["book_describe"] == f"book_{int(data['book_id']) + 3}"
         res = utility.get_query_segment_info(name)
         logger.info(f"res: {res}")
 
@@ -1097,21 +1258,25 @@ class TestUpsertVector(TestBase):
             "schema": {
                 "autoId": True,
                 "fields": [
-                    {"fieldName": "book_id", "dataType": f"{id_type}", "isPrimary": True,
-                     "elementTypeParams": {"max_length": "256"}},
+                    {
+                        "fieldName": "book_id",
+                        "dataType": f"{id_type}",
+                        "isPrimary": True,
+                        "elementTypeParams": {"max_length": "256"},
+                    },
                     {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": True, "elementTypeParams": {}},
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
-                    {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}}
-                ]
+                    {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
+                ],
             },
-            "indexParams": [{"fieldName": "text_emb", "indexName": "text_emb_index", "metricType": "L2"}]
+            "indexParams": [{"fieldName": "text_emb", "indexName": "text_emb_index", "metricType": "L2"}],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         ids = []
         # insert data
         for i in range(insert_round):
@@ -1122,7 +1287,7 @@ class TestUpsertVector(TestBase):
                     "user_id": i * nb + j,
                     "word_count": i * nb + j,
                     "book_describe": f"book_{i * nb + j}",
-                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
+                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist(),
                 }
                 data.append(tmp)
             payload = {
@@ -1132,9 +1297,9 @@ class TestUpsertVector(TestBase):
             body_size = sys.getsizeof(json.dumps(payload))
             logger.info(f"body size: {body_size / 1024 / 1024} MB")
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
-            ids.extend(rsp['data']['insertIds'])
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
+            ids.extend(rsp["data"]["insertIds"])
             c = Collection(name)
             c.flush()
 
@@ -1147,7 +1312,7 @@ class TestUpsertVector(TestBase):
                     "user_id": i * nb + j + 1,
                     "word_count": i * nb + j + 2,
                     "book_describe": f"book_{i * nb + j + 3}",
-                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
+                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist(),
                 }
                 data.append(tmp)
             payload = {
@@ -1162,10 +1327,10 @@ class TestUpsertVector(TestBase):
             rsp = self.vector_client.vector_query({"collectionName": name, "filter": "book_id > 0"})
         if id_type == "VarChar":
             rsp = self.vector_client.vector_query({"collectionName": name, "filter": "book_id > '0'"})
-        for data in rsp['data']:
-            assert data['user_id'] == int(data['book_id']) + 1
-            assert data['word_count'] == int(data['book_id']) + 2
-            assert data['book_describe'] == f"book_{int(data['book_id']) + 3}"
+        for data in rsp["data"]:
+            assert data["user_id"] == int(data["book_id"]) + 1
+            assert data["word_count"] == int(data["book_id"]) + 2
+            assert data["book_describe"] == f"book_{int(data['book_id']) + 3}"
         res = utility.get_query_segment_info(name)
         logger.info(f"res: {res}")
 
@@ -1180,22 +1345,30 @@ class TestUpsertVector(TestBase):
             "collectionName": name,
             "schema": {
                 "fields": [
-                    {"fieldName": "book_id", "dataType": f"{id_type}", "isPrimary": True,
-                     "elementTypeParams": {"max_length": "256"}},
+                    {
+                        "fieldName": "book_id",
+                        "dataType": f"{id_type}",
+                        "isPrimary": True,
+                        "elementTypeParams": {"max_length": "256"},
+                    },
                     {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": True, "elementTypeParams": {}},
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}, "defaultValue": 123},
-                    {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"},
-                     "nullable": True},
-                    {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}}
+                    {
+                        "fieldName": "book_describe",
+                        "dataType": "VarChar",
+                        "elementTypeParams": {"max_length": "256"},
+                        "nullable": True,
+                    },
+                    {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                 ]
             },
-            "indexParams": [{"fieldName": "text_emb", "indexName": "text_emb_index", "metricType": "L2"}]
+            "indexParams": [{"fieldName": "text_emb", "indexName": "text_emb_index", "metricType": "L2"}],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -1205,7 +1378,7 @@ class TestUpsertVector(TestBase):
                     "user_id": i * nb + j,
                     "word_count": i * nb + j,
                     "book_describe": f"book_{i * nb + j}",
-                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
+                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist(),
                 }
                 data.append(tmp)
             payload = {
@@ -1215,8 +1388,8 @@ class TestUpsertVector(TestBase):
             body_size = sys.getsizeof(json.dumps(payload))
             logger.info(f"body size: {body_size / 1024 / 1024} MB")
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
             c = Collection(name)
             c.flush()
 
@@ -1229,7 +1402,7 @@ class TestUpsertVector(TestBase):
                     "user_id": i * nb + j + 1,
                     "word_count": None,
                     "book_describe": None,
-                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
+                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist(),
                 }
                 data.append(tmp)
             payload = {
@@ -1244,15 +1417,14 @@ class TestUpsertVector(TestBase):
             rsp = self.vector_client.vector_query({"collectionName": name, "filter": "book_id > 0"})
         if id_type == "VarChar":
             rsp = self.vector_client.vector_query({"collectionName": name, "filter": "book_id > '0'"})
-        for data in rsp['data']:
-            assert data['user_id'] == int(data['book_id']) + 1
-            assert data['word_count'] == 123
-            assert data['book_describe'] is None
+        for data in rsp["data"]:
+            assert data["user_id"] == int(data["book_id"]) + 1
+            assert data["word_count"] == 123
+            assert data["book_describe"] is None
 
 
 @pytest.mark.L0
 class TestUpsertVectorNegative(TestBase):
-
     def test_upsert_vector_with_invalid_collection_name(self):
         """
         upsert a vector with an invalid collection name
@@ -1266,9 +1438,9 @@ class TestUpsertVectorNegative(TestBase):
             "dimension": dim,
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         nb = default_nb
         data = get_data_by_payload(payload, nb)
@@ -1279,8 +1451,8 @@ class TestUpsertVectorNegative(TestBase):
         body_size = sys.getsizeof(json.dumps(payload))
         logger.info(f"body size: {body_size / 1024 / 1024} MB")
         rsp = self.vector_client.vector_upsert(payload)
-        assert rsp['code'] == 100
-        assert "can't find collection" in rsp['message']
+        assert rsp["code"] == 100
+        assert "can't find collection" in rsp["message"]
 
     def test_upsert_entities_with_none_no_nullable_field(self):
         """
@@ -1296,14 +1468,14 @@ class TestUpsertVectorNegative(TestBase):
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{128}"}},
-                ]
-            }
+                ],
+            },
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         data = []
         for i in range(10):
@@ -1317,13 +1489,12 @@ class TestUpsertVectorNegative(TestBase):
             "data": data,
         }
         rsp = self.vector_client.vector_upsert(payload)
-        assert rsp['code'] == 1804
-        assert "fail to deal the insert data" in rsp['message']
+        assert rsp["code"] == 1804
+        assert "fail to deal the insert data" in rsp["message"]
 
 
 @pytest.mark.L0
 class TestSearchVector(TestBase):
-
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
     @pytest.mark.parametrize("is_partition_key", [True])
@@ -1331,9 +1502,9 @@ class TestSearchVector(TestBase):
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [16])
     @pytest.mark.parametrize("pass_fp32_to_fp16_or_bf16", [True, False])
-    def test_search_vector_with_all_vector_datatype(self, nb, dim, insert_round, auto_id,
-                                                    is_partition_key, enable_dynamic_schema,
-                                                    pass_fp32_to_fp16_or_bf16):
+    def test_search_vector_with_all_vector_datatype(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema, pass_fp32_to_fp16_or_bf16
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -1346,31 +1517,45 @@ class TestSearchVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "float_vector", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                    {"fieldName": "float16_vector", "dataType": "Float16Vector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
-                    {"fieldName": "bfloat16_vector", "dataType": "BFloat16Vector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
+                    {
+                        "fieldName": "float16_vector",
+                        "dataType": "Float16Vector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
+                    {
+                        "fieldName": "bfloat16_vector",
+                        "dataType": "BFloat16Vector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
                     {"fieldName": "binary_vector", "dataType": "BinaryVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "float_vector", "indexName": "float_vector", "metricType": "COSINE"},
                 {"fieldName": "float16_vector", "indexName": "float16_vector", "metricType": "COSINE"},
                 {"fieldName": "bfloat16_vector", "indexName": "bfloat16_vector", "metricType": "COSINE"},
-                {"fieldName": "binary_vector", "indexName": "binary_vector", "metricType": "HAMMING",
-                 "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"}}
-            ]
+                {
+                    "fieldName": "binary_vector",
+                    "indexName": "binary_vector",
+                    "metricType": "HAMMING",
+                    "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"},
+                },
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -1391,7 +1576,7 @@ class TestSearchVector(TestBase):
                             if pass_fp32_to_fp16_or_bf16
                             else gen_vector(datatype="BFloat16Vector", dim=dim)
                         ),
-                        "binary_vector": gen_vector(datatype="BinaryVector", dim=dim)
+                        "binary_vector": gen_vector(datatype="BinaryVector", dim=dim),
                     }
                 else:
                     tmp = {
@@ -1410,7 +1595,7 @@ class TestSearchVector(TestBase):
                             if pass_fp32_to_fp16_or_bf16
                             else gen_vector(datatype="BFloat16Vector", dim=dim)
                         ),
-                        "binary_vector": gen_vector(datatype="BinaryVector", dim=dim)
+                        "binary_vector": gen_vector(datatype="BinaryVector", dim=dim),
                     }
                 if enable_dynamic_schema:
                     tmp.update({f"dynamic_field_{i}": i})
@@ -1420,8 +1605,8 @@ class TestSearchVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # search data
         payload = {
             "collectionName": name,
@@ -1430,12 +1615,12 @@ class TestSearchVector(TestBase):
             "filter": "word_count > 100",
             "groupingField": "user_id",
             "outputFields": ["*"],
-            "limit": 100
+            "limit": 100,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # assert no dup user_id
-        user_ids = [r["user_id"] for r in rsp['data']]
+        user_ids = [r["user_id"] for r in rsp["data"]]
         assert len(user_ids) == len(set(user_ids))
 
     @pytest.mark.parametrize("insert_round", [1])
@@ -1445,9 +1630,10 @@ class TestSearchVector(TestBase):
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
     @pytest.mark.parametrize("nq", [1, 2])
-    @pytest.mark.parametrize("metric_type", ['COSINE', "L2", "IP"])
-    def test_search_vector_with_float_vector_datatype(self, nb, dim, insert_round, auto_id,
-                                                      is_partition_key, enable_dynamic_schema, nq, metric_type):
+    @pytest.mark.parametrize("metric_type", ["COSINE", "L2", "IP"])
+    def test_search_vector_with_float_vector_datatype(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema, nq, metric_type
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -1460,22 +1646,26 @@ class TestSearchVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "float_vector", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "float_vector", "indexName": "float_vector", "metricType": metric_type},
-            ]
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -1503,8 +1693,8 @@ class TestSearchVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # search data
         payload = {
             "collectionName": name,
@@ -1515,8 +1705,8 @@ class TestSearchVector(TestBase):
             "limit": 100,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 100 * nq
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 100 * nq
 
     @pytest.mark.parametrize("insert_round", [1, 10])
     @pytest.mark.parametrize("auto_id", [True, False])
@@ -1524,11 +1714,11 @@ class TestSearchVector(TestBase):
     @pytest.mark.parametrize("enable_dynamic_schema", [True])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
-    @pytest.mark.parametrize("groupingField", ['user_id', None])
-    @pytest.mark.parametrize("sparse_format", ['dok', 'coo'])
-    def test_search_vector_with_sparse_float_vector_datatype(self, nb, dim, insert_round, auto_id,
-                                                             is_partition_key, enable_dynamic_schema, groupingField,
-                                                             sparse_format):
+    @pytest.mark.parametrize("groupingField", ["user_id", None])
+    @pytest.mark.parametrize("sparse_format", ["dok", "coo"])
+    def test_search_vector_with_sparse_float_vector_datatype(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema, groupingField, sparse_format
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -1541,23 +1731,31 @@ class TestSearchVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "sparse_float_vector", "dataType": "SparseFloatVector"},
-                ]
+                ],
             },
             "indexParams": [
-                {"fieldName": "sparse_float_vector", "indexName": "sparse_float_vector", "metricType": "IP",
-                 "params": {"index_type": "SPARSE_INVERTED_INDEX", "drop_ratio_build": "0.2"}}
-            ]
+                {
+                    "fieldName": "sparse_float_vector",
+                    "indexName": "sparse_float_vector",
+                    "metricType": "IP",
+                    "params": {"index_type": "SPARSE_INVERTED_INDEX", "drop_ratio_build": "0.2"},
+                }
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -1568,8 +1766,9 @@ class TestSearchVector(TestBase):
                         "user_id": idx % 100,
                         "word_count": j,
                         "book_describe": f"book_{idx}",
-                        "sparse_float_vector": gen_vector(datatype="SparseFloatVector", dim=dim,
-                                                          sparse_format=sparse_format),
+                        "sparse_float_vector": gen_vector(
+                            datatype="SparseFloatVector", dim=dim, sparse_format=sparse_format
+                        ),
                     }
                 else:
                     tmp = {
@@ -1577,8 +1776,9 @@ class TestSearchVector(TestBase):
                         "user_id": idx % 100,
                         "word_count": j,
                         "book_describe": f"book_{idx}",
-                        "sparse_float_vector": gen_vector(datatype="SparseFloatVector", dim=dim,
-                                                          sparse_format=sparse_format),
+                        "sparse_float_vector": gen_vector(
+                            datatype="SparseFloatVector", dim=dim, sparse_format=sparse_format
+                        ),
                     }
                 if enable_dynamic_schema:
                     tmp.update({f"dynamic_field_{i}": i})
@@ -1588,8 +1788,8 @@ class TestSearchVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # search data
         payload = {
             "collectionName": name,
@@ -1600,14 +1800,14 @@ class TestSearchVector(TestBase):
                 "metricType": "IP",
                 "params": {
                     "drop_ratio_search": "0.2",
-                }
+                },
             },
             "limit": 500,
         }
         if groupingField:
             payload["groupingField"] = groupingField
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True, False])
@@ -1615,10 +1815,11 @@ class TestSearchVector(TestBase):
     @pytest.mark.parametrize("enable_dynamic_schema", [True])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
-    @pytest.mark.parametrize("groupingField", ['user_id', None])
-    @pytest.mark.parametrize("tokenizer", ['standard'])
-    def test_search_vector_for_en_full_text_search(self, nb, dim, insert_round, auto_id,
-                                                   is_partition_key, enable_dynamic_schema, groupingField, tokenizer):
+    @pytest.mark.parametrize("groupingField", ["user_id", None])
+    @pytest.mark.parametrize("tokenizer", ["standard"])
+    def test_search_vector_for_en_full_text_search(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema, groupingField, tokenizer
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -1631,16 +1832,26 @@ class TestSearchVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
-                    {"fieldName": "document_content", "dataType": "VarChar",
-                     "elementTypeParams": {"max_length": "1000", "enable_analyzer": True,
-                                           "analyzer_params": {
-                                               "tokenizer": tokenizer,
-                                           },
-                                           "enable_match": True}},
+                    {
+                        "fieldName": "document_content",
+                        "dataType": "VarChar",
+                        "elementTypeParams": {
+                            "max_length": "1000",
+                            "enable_analyzer": True,
+                            "analyzer_params": {
+                                "tokenizer": tokenizer,
+                            },
+                            "enable_match": True,
+                        },
+                    },
                     {"fieldName": "sparse_vector", "dataType": "SparseFloatVector"},
                 ],
                 "functions": [
@@ -1649,24 +1860,27 @@ class TestSearchVector(TestBase):
                         "type": "BM25",
                         "inputFieldNames": ["document_content"],
                         "outputFieldNames": ["sparse_vector"],
-                        "params": {}
+                        "params": {},
                     }
-                ]
+                ],
             },
-
             "indexParams": [
-                {"fieldName": "sparse_vector", "indexName": "sparse_vector", "metricType": "BM25",
-                 "params": {"index_type": "SPARSE_INVERTED_INDEX"}}
-            ]
+                {
+                    "fieldName": "sparse_vector",
+                    "indexName": "sparse_vector",
+                    "metricType": "BM25",
+                    "params": {"index_type": "SPARSE_INVERTED_INDEX"},
+                }
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
-        if tokenizer == 'standard':
+        assert rsp["code"] == 0
+        if tokenizer == "standard":
             fake = fake_en
-        elif tokenizer == 'jieba':
+        elif tokenizer == "jieba":
             fake = fake_zh
         else:
             raise Exception("Invalid tokenizer")
@@ -1699,9 +1913,9 @@ class TestSearchVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
-        assert rsp['code'] == 0
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
+        assert rsp["code"] == 0
 
         # search data
         payload = {
@@ -1719,8 +1933,8 @@ class TestSearchVector(TestBase):
         if groupingField:
             payload["groupingField"] = groupingField
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        assert len(rsp['data']) > 0
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) > 0
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True, False])
@@ -1728,11 +1942,12 @@ class TestSearchVector(TestBase):
     @pytest.mark.parametrize("enable_dynamic_schema", [True])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
-    @pytest.mark.parametrize("groupingField", ['user_id', None])
-    @pytest.mark.parametrize("tokenizer", ['jieba'])
+    @pytest.mark.parametrize("groupingField", ["user_id", None])
+    @pytest.mark.parametrize("tokenizer", ["jieba"])
     @pytest.mark.xfail(reason="issue: https://github.com/milvus-io/milvus/issues/36751")
-    def test_search_vector_for_zh_full_text_search(self, nb, dim, insert_round, auto_id,
-                                                   is_partition_key, enable_dynamic_schema, groupingField, tokenizer):
+    def test_search_vector_for_zh_full_text_search(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema, groupingField, tokenizer
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -1745,16 +1960,26 @@ class TestSearchVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
-                    {"fieldName": "document_content", "dataType": "VarChar",
-                     "elementTypeParams": {"max_length": "1000", "enable_analyzer": True,
-                                           "analyzer_params": {
-                                               "tokenizer": tokenizer,
-                                           },
-                                           "enable_match": True}},
+                    {
+                        "fieldName": "document_content",
+                        "dataType": "VarChar",
+                        "elementTypeParams": {
+                            "max_length": "1000",
+                            "enable_analyzer": True,
+                            "analyzer_params": {
+                                "tokenizer": tokenizer,
+                            },
+                            "enable_match": True,
+                        },
+                    },
                     {"fieldName": "sparse_vector", "dataType": "SparseFloatVector"},
                 ],
                 "functions": [
@@ -1763,24 +1988,27 @@ class TestSearchVector(TestBase):
                         "type": "BM25",
                         "inputFieldNames": ["document_content"],
                         "outputFieldNames": ["sparse_vector"],
-                        "params": {}
+                        "params": {},
                     }
-                ]
+                ],
             },
-
             "indexParams": [
-                {"fieldName": "sparse_vector", "indexName": "sparse_vector", "metricType": "BM25",
-                 "params": {"index_type": "SPARSE_INVERTED_INDEX"}}
-            ]
+                {
+                    "fieldName": "sparse_vector",
+                    "indexName": "sparse_vector",
+                    "metricType": "BM25",
+                    "params": {"index_type": "SPARSE_INVERTED_INDEX"},
+                }
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
-        if tokenizer == 'standard':
+        assert rsp["code"] == 0
+        if tokenizer == "standard":
             fake = fake_en
-        elif tokenizer == 'jieba':
+        elif tokenizer == "jieba":
             fake = fake_zh
         else:
             raise Exception("Invalid tokenizer")
@@ -1813,9 +2041,9 @@ class TestSearchVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
-        assert rsp['code'] == 0
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
+        assert rsp["code"] == 0
 
         # search data
         payload = {
@@ -1833,8 +2061,8 @@ class TestSearchVector(TestBase):
         if groupingField:
             payload["groupingField"] = groupingField
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        assert len(rsp['data']) > 0
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) > 0
 
     @pytest.mark.parametrize("insert_round", [2])
     @pytest.mark.parametrize("auto_id", [True])
@@ -1842,9 +2070,10 @@ class TestSearchVector(TestBase):
     @pytest.mark.parametrize("enable_dynamic_schema", [True])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
-    @pytest.mark.parametrize("metric_type", ['HAMMING'])
-    def test_search_vector_with_binary_vector_datatype(self, metric_type, nb, dim, insert_round, auto_id,
-                                                       is_partition_key, enable_dynamic_schema):
+    @pytest.mark.parametrize("metric_type", ["HAMMING"])
+    def test_search_vector_with_binary_vector_datatype(
+        self, metric_type, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -1857,23 +2086,31 @@ class TestSearchVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
-                    {"fieldName": "binary_vector", "dataType": "BinaryVector", "elementTypeParams": {"dim": f"{dim}"}}
-                ]
+                    {"fieldName": "binary_vector", "dataType": "BinaryVector", "elementTypeParams": {"dim": f"{dim}"}},
+                ],
             },
             "indexParams": [
-                {"fieldName": "binary_vector", "indexName": "binary_vector", "metricType": metric_type,
-                 "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"}}
-            ]
+                {
+                    "fieldName": "binary_vector",
+                    "indexName": "binary_vector",
+                    "metricType": metric_type,
+                    "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"},
+                }
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -1901,8 +2138,8 @@ class TestSearchVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # flush data
         c = Collection(name)
         c.flush()
@@ -1919,8 +2156,8 @@ class TestSearchVector(TestBase):
             "limit": 100,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 100
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 100
 
     @pytest.mark.parametrize("metric_type", ["IP", "L2", "COSINE"])
     def test_search_vector_with_simple_payload(self, metric_type):
@@ -1939,14 +2176,14 @@ class TestSearchVector(TestBase):
             "data": [vector_to_search],
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         limit = int(payload.get("limit", 100))
         assert len(res) == limit
-        ids = [item['id'] for item in res]
+        ids = [item["id"] for item in res]
         assert len(ids) == len(set(ids))
-        distance = [item['distance'] for item in res]
+        distance = [item["distance"] for item in res]
         if metric_type == "L2":
             assert distance == sorted(distance)
         if metric_type == "IP" or metric_type == "COSINE":
@@ -1977,16 +2214,16 @@ class TestSearchVector(TestBase):
         }
         rsp = self.vector_client.vector_search(payload)
         if sum_limit_offset > max_search_sum_limit_offset:
-            assert rsp['code'] == 65535
+            assert rsp["code"] == 65535
             return
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         limit = int(payload.get("limit", 100))
         assert len(res) == limit
-        ids = [item['id'] for item in res]
+        ids = [item["id"] for item in res]
         assert len(ids) == len(set(ids))
-        distance = [item['distance'] for item in res]
+        distance = [item["distance"] for item in res]
         if metric_type == "L2":
             assert distance == sorted(distance)
         if metric_type == "IP":
@@ -2018,10 +2255,10 @@ class TestSearchVector(TestBase):
         }
         rsp = self.vector_client.vector_search(payload)
         if offset + limit > MAX_SUM_OFFSET_AND_LIMIT:
-            assert rsp['code'] == 90126
+            assert rsp["code"] == 90126
             return
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         assert len(res) == limit
         for item in res:
@@ -2053,15 +2290,15 @@ class TestSearchVector(TestBase):
             "offset": 0,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         assert len(res) <= limit
         for item in res:
             uid = item.get("uid")
-            eval(filter_expr)
+            assert eval(filter_expr, {}, {"uid": uid}) is True
 
-    @pytest.mark.parametrize("filter_expr", ["name > \"placeholder\"", "name like \"placeholder%\""])
+    @pytest.mark.parametrize("filter_expr", ['name > "placeholder"', 'name like "placeholder%"'])
     def test_search_vector_with_complex_varchar_filter(self, filter_expr):
         """
         Search a vector with a simple payload
@@ -2094,8 +2331,8 @@ class TestSearchVector(TestBase):
             "offset": 0,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         assert len(res) <= limit
         for item in res:
@@ -2106,9 +2343,9 @@ class TestSearchVector(TestBase):
             if "like" in filter_expr:
                 assert name.startswith(prefix)
 
-    @pytest.mark.parametrize("filter_expr", ["uid < 100 and name > \"placeholder\"",
-                                             "uid < 100 and name like \"placeholder%\""
-                                             ])
+    @pytest.mark.parametrize(
+        "filter_expr", ['uid < 100 and name > "placeholder"', 'uid < 100 and name like "placeholder%"']
+    )
     def test_search_vector_with_complex_int64_varchar_and_filter(self, filter_expr):
         """
         Search a vector with a simple payload
@@ -2141,8 +2378,8 @@ class TestSearchVector(TestBase):
             "offset": 0,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         assert len(res) <= limit
         for item in res:
@@ -2150,7 +2387,7 @@ class TestSearchVector(TestBase):
             name = item.get("name")
             logger.info(f"name: {name}")
             uid_expr = filter_expr.split("and")[0]
-            assert eval(uid_expr) is True
+            assert eval(uid_expr, {}, {"uid": uid}) is True
             varchar_expr = filter_expr.split("and")[1]
             if ">" in varchar_expr:
                 assert name > prefix
@@ -2168,13 +2405,6 @@ class TestSearchVector(TestBase):
         dim = 128
         limit = 100
         schema_payload, data = self.init_collection(name, dim=dim, nb=nb)
-        names = []
-        for item in data:
-            names.append(item.get("name"))
-        names.sort()
-        logger.info(f"names: {names}")
-        mid = len(names) // 2
-        prefix = names[mid][0:2]
         vector_field = schema_payload.get("vectorField")
         # search data
         vector_to_search = preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
@@ -2185,11 +2415,11 @@ class TestSearchVector(TestBase):
             "outputFields": output_fields,
             "limit": limit,
             "offset": 0,
-            "consistencyLevel": consistency_level
+            "consistencyLevel": consistency_level,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         assert len(res) == limit
 
@@ -2209,8 +2439,10 @@ class TestSearchVector(TestBase):
         vector_to_search = preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
         training_data = [item[vector_field] for item in data]
         distance_sorted = get_sorted_distance(training_data, [vector_to_search], metric_type)
-        r1, r2 = distance_sorted[0][nb // 2], distance_sorted[0][nb // 2 + limit + int(
-            (0.5 * limit))]  # recall is not 100% so add 50% to make sure the range is more than limit
+        r1, r2 = (
+            distance_sorted[0][nb // 2],
+            distance_sorted[0][nb // 2 + limit + int(0.5 * limit)],
+        )  # recall is not 100% so add 50% to make sure the range is more than limit
         if metric_type == "L2":
             r1, r2 = r2, r1
         output_fields = get_common_fields_by_data(data, exclude_fields=[vector_field])
@@ -2226,20 +2458,20 @@ class TestSearchVector(TestBase):
                     "radius": r1,
                     "range_filter": r2,
                 }
-            }
+            },
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         assert len(res) >= limit * 0.8
         # add buffer to the distance of comparison
         if metric_type == "L2":
-            r1 = r1 + 10 ** -6
-            r2 = r2 - 10 ** -6
+            r1 = r1 + 10**-6
+            r2 = r2 - 10**-6
         else:
-            r1 = r1 - 10 ** -6
-            r2 = r2 + 10 ** -6
+            r1 = r1 - 10**-6
+            r2 = r2 + 10**-6
         for item in res:
             distance = item.get("distance")
             if metric_type == "L2":
@@ -2264,8 +2496,10 @@ class TestSearchVector(TestBase):
         vector_to_search = preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
         training_data = [item[vector_field] for item in data]
         distance_sorted = get_sorted_distance(training_data, [vector_to_search], metric_type)
-        r1, r2 = distance_sorted[0][nb // 2], distance_sorted[0][
-            nb // 2 + limit + int((0.2 * limit))]  # recall is not 100% so add 20% to make sure the range is correct
+        r1, r2 = (
+            distance_sorted[0][nb // 2],
+            distance_sorted[0][nb // 2 + limit + int(0.2 * limit)],
+        )  # recall is not 100% so add 20% to make sure the range is correct
         if metric_type == "L2":
             r1, r2 = r2, r1
         output_fields = get_common_fields_by_data(data, exclude_fields=[vector_field])
@@ -2276,14 +2510,11 @@ class TestSearchVector(TestBase):
             "outputFields": output_fields,
             "limit": limit,
             "offset": 0,
-            "searchParams": {
-                "ignoreGrowing": ignore_growing
-
-            }
+            "searchParams": {"ignoreGrowing": ignore_growing},
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         if ignore_growing is True:
             assert len(res) == 0
@@ -2344,11 +2575,10 @@ class TestSearchVector(TestBase):
             FieldSchema(name="emb", dtype=DataType.FLOAT_VECTOR, dim=dim),
         ]
         schema = CollectionSchema(fields=fields, description="test collection")
-        collection = Collection(name=name, schema=schema
-                                )
+        collection = Collection(name=name, schema=schema)
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         data_size = 3000
         batch_size = 1000
         # insert data
@@ -2359,7 +2589,7 @@ class TestSearchVector(TestBase):
                 "sentence": fake.sentence().lower(),
                 "paragraph": fake.sentence().lower(),
                 "text": fake.text().lower(),
-                "emb": [random.random() for _ in range(dim)]
+                "emb": [random.random() for _ in range(dim)],
             }
             for i in range(data_size)
         ]
@@ -2369,14 +2599,14 @@ class TestSearchVector(TestBase):
         for field in text_fields:
             wf_map[field] = analyze_documents(df[field].tolist(), language=language)
         for i in range(0, data_size, batch_size):
-            tmp = data[i:i + batch_size]
+            tmp = data[i : i + batch_size]
             payload = {
                 "collectionName": name,
                 "data": tmp,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == len(tmp)
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == len(tmp)
         collection.create_index(
             "emb",
             {"index_type": "IVF_SQ8", "metric_type": "L2", "params": {"nlist": 64}},
@@ -2389,9 +2619,10 @@ class TestSearchVector(TestBase):
             expr = f"text_match({field}, '{token}')"
             logger.info(f"expr: {expr}")
             rsp = self.vector_client.vector_search(
-                {"collectionName": name, "data": vector_to_search, "filter": f"{expr}", "outputFields": ["*"]})
-            assert rsp['code'] == 0, rsp
-            for d in rsp['data']:
+                {"collectionName": name, "data": vector_to_search, "filter": f"{expr}", "outputFields": ["*"]}
+            )
+            assert rsp["code"] == 0, rsp
+            for d in rsp["data"]:
                 assert token in d[field]
 
     @pytest.mark.parametrize("tokenizer", ["standard"])
@@ -2448,11 +2679,10 @@ class TestSearchVector(TestBase):
             FieldSchema(name="emb", dtype=DataType.FLOAT_VECTOR, dim=dim),
         ]
         schema = CollectionSchema(fields=fields, description="test collection")
-        collection = Collection(name=name, schema=schema
-                                )
+        collection = Collection(name=name, schema=schema)
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         data_size = 3000
         batch_size = 1000
         # insert data
@@ -2463,7 +2693,7 @@ class TestSearchVector(TestBase):
                 "sentence": fake.sentence().lower(),
                 "paragraph": fake.sentence().lower(),
                 "text": fake.text().lower(),
-                "emb": [random.random() for _ in range(dim)]
+                "emb": [random.random() for _ in range(dim)],
             }
             for i in range(data_size)
         ]
@@ -2473,14 +2703,14 @@ class TestSearchVector(TestBase):
         for field in text_fields:
             wf_map[field] = analyze_documents(df[field].tolist(), language=language)
         for i in range(0, data_size, batch_size):
-            tmp = data[i:i + batch_size]
+            tmp = data[i : i + batch_size]
             payload = {
                 "collectionName": name,
                 "data": tmp,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == len(tmp)
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == len(tmp)
         # add additional data to make sure query result is not empty
         target_data_len = 10
         phrase_map = {}
@@ -2494,7 +2724,7 @@ class TestSearchVector(TestBase):
                 "sentence": phrase_map["sentence"],
                 "paragraph": phrase_map["paragraph"],
                 "text": phrase_map["text"],
-                "emb": [random.random() for _ in range(dim)]
+                "emb": [random.random() for _ in range(dim)],
             }
             for i in range(data_size, data_size + target_data_len)
         ]
@@ -2503,8 +2733,8 @@ class TestSearchVector(TestBase):
             "data": tmp,
         }
         rsp = self.vector_client.vector_insert(payload)
-        assert rsp['code'] == 0
-        assert rsp['data']['insertCount'] == len(tmp)
+        assert rsp["code"] == 0
+        assert rsp["data"]["insertCount"] == len(tmp)
 
         collection.create_index(
             "emb",
@@ -2519,12 +2749,13 @@ class TestSearchVector(TestBase):
             expr = f"phrase_match({field}, '{phrase}')"
             logger.info(f"expr: {expr}")
             rsp = self.vector_client.vector_search(
-                {"collectionName": name, "data": vector_to_search, "filter": f"{expr}", "outputFields": ["*"]})
-            assert rsp['code'] == 0, rsp
-            for d in rsp['data']:
-                d[field] = re.sub(r'[^\w\s]','', d[field])
+                {"collectionName": name, "data": vector_to_search, "filter": f"{expr}", "outputFields": ["*"]}
+            )
+            assert rsp["code"] == 0, rsp
+            for d in rsp["data"]:
+                d[field] = re.sub(r"[^\w\s]", "", d[field])
                 assert phrase in d[field]
-            assert len(rsp['data']) >= target_data_len * len(vector_to_search)
+            assert len(rsp["data"]) >= target_data_len * len(vector_to_search)
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
@@ -2533,9 +2764,10 @@ class TestSearchVector(TestBase):
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
     @pytest.mark.parametrize("nq", [1, 2])
-    @pytest.mark.parametrize("metric_type", ['COSINE', "L2", "IP"])
-    def test_search_vector_with_default_none(self, nb, dim, insert_round, auto_id, is_partition_key,
-                                             enable_dynamic_schema, nq, metric_type):
+    @pytest.mark.parametrize("metric_type", ["COSINE", "L2", "IP"])
+    def test_search_vector_with_default_none(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema, nq, metric_type
+    ):
         """
         Insert a vector with default and none
         """
@@ -2548,23 +2780,33 @@ class TestSearchVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}, "defaultValue": 8888},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                        "defaultValue": 8888,
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}, "nullable": True},
-                    {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"},
-                     "nullable": True, "defaultValue": "8888"},
+                    {
+                        "fieldName": "book_describe",
+                        "dataType": "VarChar",
+                        "elementTypeParams": {"max_length": "256"},
+                        "nullable": True,
+                        "defaultValue": "8888",
+                    },
                     {"fieldName": "float_vector", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "float_vector", "indexName": "float_vector", "metricType": metric_type},
-            ]
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -2592,8 +2834,8 @@ class TestSearchVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # search data
         payload = {
             "collectionName": name,
@@ -2604,15 +2846,14 @@ class TestSearchVector(TestBase):
             "limit": 100,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        assert rsp['data'][0]['book_describe'] == "8888"
-        assert rsp['data'][0]['word_count'] is None
-        assert len(rsp['data']) == 100 * nq
+        assert rsp["code"] == 0
+        assert rsp["data"][0]["book_describe"] == "8888"
+        assert rsp["data"][0]["word_count"] is None
+        assert len(rsp["data"]) == 100 * nq
 
 
 @pytest.mark.L0
 class TestSearchVectorNegative(TestBase):
-
     @pytest.mark.parametrize("metric_type", ["L2"])
     def test_search_vector_without_required_data_param(self, metric_type):
         """
@@ -2623,12 +2864,11 @@ class TestSearchVectorNegative(TestBase):
         self.init_collection(name, metric_type=metric_type)
 
         # search data
-        dim = 128
         payload = {
             "collectionName": name,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 1802
+        assert rsp["code"] == 1802
 
     @pytest.mark.parametrize("invalid_metric_type", ["L2", "IP", "UNSUPPORTED"])
     @pytest.mark.xfail(reason="issue: https://github.com/milvus-io/milvus/issues/37138")
@@ -2645,12 +2885,10 @@ class TestSearchVectorNegative(TestBase):
         payload = {
             "collectionName": name,
             "data": [preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()],
-            "searchParams": {
-                "metricType": invalid_metric_type
-            }
+            "searchParams": {"metricType": invalid_metric_type},
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] != 0
+        assert rsp["code"] != 0
 
     @pytest.mark.parametrize("limit", [0, 16385])
     def test_search_vector_with_invalid_limit(self, limit):
@@ -2674,7 +2912,7 @@ class TestSearchVectorNegative(TestBase):
             "offset": 0,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 65535
+        assert rsp["code"] == 65535
 
     @pytest.mark.parametrize("offset", [-1, 100_001])
     def test_search_vector_with_invalid_offset(self, offset):
@@ -2699,7 +2937,7 @@ class TestSearchVectorNegative(TestBase):
             "offset": offset,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 65535
+        assert rsp["code"] == 65535
 
     def test_search_vector_with_invalid_collection_name(self):
         """
@@ -2722,21 +2960,21 @@ class TestSearchVectorNegative(TestBase):
             "offset": 0,
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 100
-        assert "can't find collection" in rsp['message']
+        assert rsp["code"] == 100
+        assert "can't find collection" in rsp["message"]
 
 
 @pytest.mark.L0
 class TestAdvancedSearchVector(TestBase):
-
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
     @pytest.mark.parametrize("is_partition_key", [True])
     @pytest.mark.parametrize("enable_dynamic_schema", [True])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [2])
-    def test_advanced_search_vector_with_multi_float32_vector_datatype(self, nb, dim, insert_round, auto_id,
-                                                                       is_partition_key, enable_dynamic_schema):
+    def test_advanced_search_vector_with_multi_float32_vector_datatype(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -2749,25 +2987,28 @@ class TestAdvancedSearchVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "float_vector_1", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                     {"fieldName": "float_vector_2", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "float_vector_1", "indexName": "float_vector_1", "metricType": "COSINE"},
                 {"fieldName": "float_vector_2", "indexName": "float_vector_2", "metricType": "COSINE"},
-
-            ]
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -2788,7 +3029,6 @@ class TestAdvancedSearchVector(TestBase):
                         "book_describe": f"book_{i}",
                         "float_vector_1": gen_vector(datatype="FloatVector", dim=dim),
                         "float_vector_2": gen_vector(datatype="FloatVector", dim=dim),
-
                     }
                 if enable_dynamic_schema:
                     tmp.update({f"dynamic_field_{i}": i})
@@ -2798,55 +3038,54 @@ class TestAdvancedSearchVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # advanced search data
 
         payload = {
             "collectionName": name,
-            "search": [{
-                "data": [gen_vector(datatype="FloatVector", dim=dim)],
-                "annsField": "float_vector_1",
-                "limit": 10,
-                "outputFields": ["*"]
-            },
+            "search": [
+                {
+                    "data": [gen_vector(datatype="FloatVector", dim=dim)],
+                    "annsField": "float_vector_1",
+                    "limit": 10,
+                    "outputFields": ["*"],
+                },
                 {
                     "data": [gen_vector(datatype="FloatVector", dim=dim)],
                     "annsField": "float_vector_2",
                     "limit": 10,
-                    "outputFields": ["*"]
-                }
-
+                    "outputFields": ["*"],
+                },
             ],
             "rerank": {
                 "strategy": "rrf",
                 "params": {
                     "k": 10,
-                }
+                },
             },
             "limit": 10,
-            "outputFields": ["user_id", "word_count", "book_describe"]
+            "outputFields": ["user_id", "word_count", "book_describe"],
         }
 
         rsp = self.vector_client.vector_advanced_search(payload)
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 10
-        assert len(rsp['topks']) == 1
-        assert rsp['topks'][0] == 10
-        
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 10
+        assert len(rsp["topks"]) == 1
+        assert rsp["topks"][0] == 10
 
 
 @pytest.mark.L0
 class TestHybridSearchVector(TestBase):
-
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
     @pytest.mark.parametrize("is_partition_key", [True])
     @pytest.mark.parametrize("enable_dynamic_schema", [True])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [2])
-    def test_hybrid_search_vector_with_multi_float32_vector_datatype(self, nb, dim, insert_round, auto_id,
-                                                                     is_partition_key, enable_dynamic_schema):
+    def test_hybrid_search_vector_with_multi_float32_vector_datatype(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -2859,25 +3098,28 @@ class TestHybridSearchVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "float_vector_1", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                     {"fieldName": "float_vector_2", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "float_vector_1", "indexName": "float_vector_1", "metricType": "COSINE"},
                 {"fieldName": "float_vector_2", "indexName": "float_vector_2", "metricType": "COSINE"},
-
-            ]
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -2898,7 +3140,6 @@ class TestHybridSearchVector(TestBase):
                         "book_describe": f"book_{i}",
                         "float_vector_1": gen_vector(datatype="FloatVector", dim=dim),
                         "float_vector_2": gen_vector(datatype="FloatVector", dim=dim),
-
                     }
                 if enable_dynamic_schema:
                     tmp.update({f"dynamic_field_{i}": i})
@@ -2908,39 +3149,343 @@ class TestHybridSearchVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # advanced search data
 
         payload = {
             "collectionName": name,
-            "search": [{
-                "data": [gen_vector(datatype="FloatVector", dim=dim)],
-                "annsField": "float_vector_1",
-                "limit": 10,
-                "outputFields": ["*"]
-            },
+            "search": [
+                {
+                    "data": [gen_vector(datatype="FloatVector", dim=dim)],
+                    "annsField": "float_vector_1",
+                    "limit": 10,
+                    "outputFields": ["*"],
+                },
                 {
                     "data": [gen_vector(datatype="FloatVector", dim=dim)],
                     "annsField": "float_vector_2",
                     "limit": 10,
-                    "outputFields": ["*"]
-                }
-
+                    "outputFields": ["*"],
+                },
             ],
             "rerank": {
                 "strategy": "rrf",
                 "params": {
                     "k": 10,
-                }
+                },
             },
             "limit": 10,
-            "outputFields": ["user_id", "word_count", "book_describe"]
+            "outputFields": ["user_id", "word_count", "book_describe"],
         }
 
         rsp = self.vector_client.vector_hybrid_search(payload)
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 10
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 10
+
+    @pytest.mark.xfail(reason="issue: https://github.com/milvus-io/milvus/issues/50396")
+    def test_minhash_hybrid_search_with_partition(self):
+        """
+        target: test REST hybrid search within a specific partition with MinHash and dense vector
+        method: insert data into two partitions, hybrid search with partitionNames=["part_a"]
+        expected: results only come from the specified partition
+        """
+        name = gen_collection_name()
+        self.name = name
+        dense_dim = 128
+        minhash_field = "minhash_signature"
+        dense_field = "dense_vector"
+        text_field = "text"
+        num_hashes = 16
+        minhash_dim = num_hashes * 32
+
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": False,
+                "fields": [
+                    {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                    {"fieldName": text_field, "dataType": "VarChar", "elementTypeParams": {"max_length": "65535"}},
+                    {
+                        "fieldName": minhash_field,
+                        "dataType": "BinaryVector",
+                        "elementTypeParams": {"dim": f"{minhash_dim}"},
+                    },
+                    {"fieldName": dense_field, "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dense_dim}"}},
+                ],
+                "functions": [
+                    {
+                        "name": "text_to_minhash",
+                        "type": "MinHash",
+                        "inputFieldNames": [text_field],
+                        "outputFieldNames": [minhash_field],
+                        "params": {"num_hashes": num_hashes, "shingle_size": 3},
+                    }
+                ],
+            },
+            "indexParams": [
+                {
+                    "fieldName": minhash_field,
+                    "indexName": minhash_field,
+                    "indexType": "MINHASH_LSH",
+                    "metricType": "MHJACCARD",
+                    "params": {"mh_lsh_band": 8},
+                },
+                {
+                    "fieldName": dense_field,
+                    "indexName": dense_field,
+                    "indexType": "HNSW",
+                    "metricType": "COSINE",
+                    "params": {"M": 16, "efConstruction": 200},
+                },
+            ],
+        }
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 0
+
+        for partition_name in ["part_a", "part_b"]:
+            rsp = self.partition_client.partition_create(collection_name=name, partition_name=partition_name)
+            assert rsp["code"] == 0
+
+        rng = np.random.default_rng(seed=42)
+        texts_a = [f"partition alpha minhash hybrid search document {i} milvus restful test" for i in range(50)]
+        texts_b = [f"partition beta minhash hybrid search document {i} milvus restful test" for i in range(50)]
+        rows_a = [
+            {
+                "id": i,
+                text_field: texts_a[i],
+                dense_field: rng.random(dense_dim).astype(np.float32).tolist(),
+            }
+            for i in range(50)
+        ]
+        rows_b = [
+            {
+                "id": 50 + i,
+                text_field: texts_b[i],
+                dense_field: rng.random(dense_dim).astype(np.float32).tolist(),
+            }
+            for i in range(50)
+        ]
+
+        rsp = self.vector_client.vector_insert(
+            {
+                "collectionName": name,
+                "partitionName": "part_a",
+                "data": rows_a,
+            }
+        )
+        assert rsp["code"] == 0
+        assert rsp["data"]["insertCount"] == len(rows_a)
+        rsp = self.vector_client.vector_insert(
+            {
+                "collectionName": name,
+                "partitionName": "part_b",
+                "data": rows_b,
+            }
+        )
+        assert rsp["code"] == 0
+        assert rsp["data"]["insertCount"] == len(rows_b)
+
+        collection = Collection(name)
+        collection.flush()
+        collection.load()
+        self.wait_load_completed(name, timeout=30)
+
+        query_dense = rng.random(dense_dim).astype(np.float32).tolist()
+        payload = {
+            "collectionName": name,
+            "partitionNames": ["part_a"],
+            "search": [
+                {
+                    "data": [texts_a[0]],
+                    "annsField": minhash_field,
+                    "metricType": "MHJACCARD",
+                    "params": {"metric_type": "MHJACCARD"},
+                    "limit": 10,
+                },
+                {
+                    "data": [query_dense],
+                    "annsField": dense_field,
+                    "metricType": "COSINE",
+                    "params": {"metric_type": "COSINE", "ef": 64},
+                    "limit": 10,
+                },
+            ],
+            "rerank": {
+                "strategy": "rrf",
+                "params": {"k": 60},
+            },
+            "limit": 10,
+            "outputFields": ["id"],
+        }
+
+        rsp = self.vector_client.vector_hybrid_search(payload)
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) > 0
+        for hit in rsp["data"]:
+            assert hit["id"] < 50
+
+    def test_hybrid_search_partition_key_isolation_with_unsupported_filter(self):
+        """
+        target: verify REST hybrid search enforces partition key isolation like search
+        method: create partition key isolation collection and compare search/hybrid_search invalid filters
+        expected: hybrid_search rejects multi-tenant and no-tenant filters
+        """
+        name = gen_collection_name()
+        self.name = name
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": False,
+                "fields": [
+                    {"fieldName": "id", "dataType": "Int64", "isPrimary": True},
+                    {"fieldName": "vector_a", "dataType": "FloatVector", "elementTypeParams": {"dim": "5"}},
+                    {"fieldName": "vector_b", "dataType": "FloatVector", "elementTypeParams": {"dim": "5"}},
+                    {
+                        "fieldName": "tenant",
+                        "dataType": "VarChar",
+                        "isPartitionKey": True,
+                        "elementTypeParams": {"max_length": "64"},
+                    },
+                    {"fieldName": "color", "dataType": "VarChar", "elementTypeParams": {"max_length": "64"}},
+                ],
+            },
+            "indexParams": [
+                {
+                    "fieldName": "vector_a",
+                    "indexName": "vector_a",
+                    "metricType": "COSINE",
+                    "params": {"index_type": "AUTOINDEX"},
+                },
+                {
+                    "fieldName": "vector_b",
+                    "indexName": "vector_b",
+                    "metricType": "COSINE",
+                    "params": {"index_type": "AUTOINDEX"},
+                },
+            ],
+            "params": {
+                "partitionsNum": 16,
+                "partitionKeyIsolation": True,
+            },
+        }
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 0
+
+        data = [
+            {
+                "id": 1,
+                "vector_a": [0.10, 0.20, 0.30, 0.40, 0.50],
+                "vector_b": [0.50, 0.40, 0.30, 0.20, 0.10],
+                "tenant": "tenant_a",
+                "color": "tenant_a_1",
+            },
+            {
+                "id": 2,
+                "vector_a": [0.11, 0.21, 0.31, 0.41, 0.51],
+                "vector_b": [0.51, 0.41, 0.31, 0.21, 0.11],
+                "tenant": "tenant_a",
+                "color": "tenant_a_2",
+            },
+            {
+                "id": 3,
+                "vector_a": [0.90, 0.80, 0.70, 0.60, 0.50],
+                "vector_b": [0.50, 0.60, 0.70, 0.80, 0.90],
+                "tenant": "tenant_b",
+                "color": "tenant_b_1",
+            },
+            {
+                "id": 4,
+                "vector_a": [0.91, 0.81, 0.71, 0.61, 0.51],
+                "vector_b": [0.51, 0.61, 0.71, 0.81, 0.91],
+                "tenant": "tenant_b",
+                "color": "tenant_b_2",
+            },
+            {
+                "id": 5,
+                "vector_a": [0.10, 0.20, 0.30, 0.40, 0.50],
+                "vector_b": [0.50, 0.40, 0.30, 0.20, 0.10],
+                "tenant": "tenant_c",
+                "color": "tenant_c_control",
+            },
+        ]
+        rsp = self.vector_client.vector_insert({"collectionName": name, "data": data})
+        assert rsp["code"] == 0
+        assert rsp["data"]["insertCount"] == len(data)
+
+        collection = Collection(name)
+        collection.flush()
+        collection.load()
+        self.wait_load_completed(name, timeout=30)
+
+        query_a = [0.10, 0.20, 0.30, 0.40, 0.50]
+        query_b = [0.50, 0.40, 0.30, 0.20, 0.10]
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": name,
+                "data": [query_a],
+                "annsField": "vector_a",
+                "filter": 'tenant == "tenant_a"',
+                "limit": 5,
+                "outputFields": ["id", "tenant", "color"],
+            }
+        )
+        assert rsp["code"] == 0
+        assert {item["tenant"] for item in rsp["data"]} == {"tenant_a"}
+
+        invalid_filters = [
+            ('tenant in ["tenant_a", "tenant_b"]', "partition key isolation does not support IN"),
+            (None, "partition key not found in expr"),
+        ]
+        for expr, err_msg in invalid_filters:
+            search_payload = {
+                "collectionName": name,
+                "data": [query_a],
+                "annsField": "vector_a",
+                "limit": 5,
+                "outputFields": ["id", "tenant", "color"],
+            }
+            if expr is not None:
+                search_payload["filter"] = expr
+            rsp = self.vector_client.vector_search(search_payload)
+            assert rsp["code"] != 0
+            assert err_msg in str(rsp)
+
+        for expr, err_msg in invalid_filters:
+            search_reqs = [
+                {
+                    "data": [query_a],
+                    "annsField": "vector_a",
+                    "metricType": "COSINE",
+                    "params": {"metric_type": "COSINE"},
+                    "limit": 5,
+                },
+                {
+                    "data": [query_b],
+                    "annsField": "vector_b",
+                    "metricType": "COSINE",
+                    "params": {"metric_type": "COSINE"},
+                    "limit": 5,
+                },
+            ]
+            if expr is not None:
+                for req in search_reqs:
+                    req["filter"] = expr
+            rsp = self.vector_client.vector_hybrid_search(
+                {
+                    "collectionName": name,
+                    "search": search_reqs,
+                    "rerank": {"strategy": "rrf", "params": {"k": 60}},
+                    "limit": 5,
+                    "outputFields": ["id", "tenant", "color"],
+                }
+            )
+            if rsp["code"] == 0:
+                logger.info(f"hybrid_search with unsupported expr {expr} got rsp {rsp}")
+                pytest.xfail(f"issue: https://github.com/milvus-io/milvus/issues/50398, expr: {expr}")
+            assert err_msg in str(rsp)
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
@@ -2949,9 +3494,10 @@ class TestHybridSearchVector(TestBase):
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
     @pytest.mark.parametrize("limit", [100])
-    @pytest.mark.parametrize("offset", [100,200])
-    def test_hybrid_search_vector_with_offset(self, nb, dim, insert_round, auto_id,
-                                              is_partition_key, enable_dynamic_schema, limit, offset):
+    @pytest.mark.parametrize("offset", [100, 200])
+    def test_hybrid_search_vector_with_offset(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema, limit, offset
+    ):
         """
         Test hybrid search with offset parameter
         """
@@ -2964,22 +3510,26 @@ class TestHybridSearchVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "float_vector_1", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                     {"fieldName": "float_vector_2", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "float_vector_1", "indexName": "float_vector_1", "metricType": "COSINE"},
                 {"fieldName": "float_vector_2", "indexName": "float_vector_2", "metricType": "COSINE"},
-            ]
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
-        
+        assert rsp["code"] == 0
+
         # insert data
         for i in range(insert_round):
             data = []
@@ -3009,88 +3559,90 @@ class TestHybridSearchVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
-            
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
+
         float_vector_1 = gen_vector(datatype="FloatVector", dim=dim)
-        float_vector_2 = gen_vector(datatype="FloatVector", dim=dim)    
+        float_vector_2 = gen_vector(datatype="FloatVector", dim=dim)
         # hybrid search with offset
         payload = {
             "collectionName": name,
-            "search": [{
-                "data": [float_vector_1],
-                "annsField": "float_vector_1",
-                "limit": offset + limit,
-                "outputFields": ["*"]
-            },
+            "search": [
+                {
+                    "data": [float_vector_1],
+                    "annsField": "float_vector_1",
+                    "limit": offset + limit,
+                    "outputFields": ["*"],
+                },
                 {
                     "data": [float_vector_2],
                     "annsField": "float_vector_2",
                     "limit": offset + limit,
-                    "outputFields": ["*"]
-                }
+                    "outputFields": ["*"],
+                },
             ],
             "rerank": {
                 "strategy": "rrf",
                 "params": {
                     "k": 10,
-                }
+                },
             },
             "limit": limit,
             "offset": offset,
-            "outputFields": ["book_id", "user_id", "word_count", "book_describe"]
+            "outputFields": ["book_id", "user_id", "word_count", "book_describe"],
         }
-        
+
         rsp = self.vector_client.vector_hybrid_search(payload)
-        
+
         # Check if offset + limit exceeds max allowed
         if offset + limit > MAX_SUM_OFFSET_AND_LIMIT:
-            assert rsp['code'] == 1
-            assert "exceeds" in rsp['message'] or "invalid" in rsp['message'].lower()
+            assert rsp["code"] == 1
+            assert "exceeds" in rsp["message"] or "invalid" in rsp["message"].lower()
         else:
-            assert rsp['code'] == 0
-            assert len(rsp['data']) <= limit
-            
+            assert rsp["code"] == 0
+            assert len(rsp["data"]) <= limit
+
             # Verify offset works by comparing with search without offset
             payload_no_offset = {
                 "collectionName": name,
-                "search": [{
-                    "data": [float_vector_1],
-                    "annsField": "float_vector_1",
-                    "limit": offset + limit,
-                    "outputFields": ["*"]
-                },
+                "search": [
+                    {
+                        "data": [float_vector_1],
+                        "annsField": "float_vector_1",
+                        "limit": offset + limit,
+                        "outputFields": ["*"],
+                    },
                     {
                         "data": [float_vector_2],
                         "annsField": "float_vector_2",
                         "limit": offset + limit,
-                        "outputFields": ["*"]
-                    }
+                        "outputFields": ["*"],
+                    },
                 ],
                 "rerank": {
                     "strategy": "rrf",
                     "params": {
                         "k": 10,
-                    }
+                    },
                 },
                 "limit": offset + limit,
-                "outputFields": ["book_id", "user_id", "word_count", "book_describe"]
+                "outputFields": ["book_id", "user_id", "word_count", "book_describe"],
             }
             rsp_no_offset = self.vector_client.vector_hybrid_search(payload_no_offset)
-            if rsp_no_offset['code'] == 0 and len(rsp_no_offset['data']) > offset:
+            if rsp_no_offset["code"] == 0 and len(rsp_no_offset["data"]) > offset:
                 # Extract PKs from results with offset
                 pks_with_offset = set()
-                for item in rsp['data']:
-                    if 'book_id' in item:
-                        pks_with_offset.add(item['book_id'])
-                
+                for item in rsp["data"]:
+                    if "book_id" in item:
+                        pks_with_offset.add(item["book_id"])
+
                 # Extract PKs from the corresponding portion of results without offset
                 pks_no_offset_expected = set()
-                expected_results = rsp_no_offset['data'][offset:offset + limit]
+                expected_results = rsp_no_offset["data"][offset : offset + limit]
                 for item in expected_results:
-                    if 'book_id' in item:
-                        pks_no_offset_expected.add(item['book_id'])
-                
+                    if "book_id" in item:
+                        pks_no_offset_expected.add(item["book_id"])
+
                 # Calculate intersection rate
                 if len(pks_no_offset_expected) > 0:
                     intersection = pks_with_offset.intersection(pks_no_offset_expected)
@@ -3108,8 +3660,9 @@ class TestHybridSearchVector(TestBase):
     @pytest.mark.parametrize("nb", [1000])
     @pytest.mark.parametrize("dim", [2])
     @pytest.mark.parametrize("invalid_offset", [-1, -10, -100, "abc", [], {}])
-    def test_hybrid_search_vector_with_invalid_offset(self, nb, dim, auto_id,
-                                                      is_partition_key, enable_dynamic_schema, invalid_offset):
+    def test_hybrid_search_vector_with_invalid_offset(
+        self, nb, dim, auto_id, is_partition_key, enable_dynamic_schema, invalid_offset
+    ):
         """
         Test hybrid search with invalid offset values
         """
@@ -3122,22 +3675,26 @@ class TestHybridSearchVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "float_vector_1", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                     {"fieldName": "float_vector_2", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "float_vector_1", "indexName": "float_vector_1", "metricType": "L2"},
                 {"fieldName": "float_vector_2", "indexName": "float_vector_2", "metricType": "L2"},
-            ]
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
-        
+        assert rsp["code"] == 0
+
         # insert data
         data = []
         for i in range(nb):
@@ -3166,38 +3723,39 @@ class TestHybridSearchVector(TestBase):
             "data": data,
         }
         rsp = self.vector_client.vector_insert(payload)
-        assert rsp['code'] == 0
-        
+        assert rsp["code"] == 0
+
         # hybrid search with invalid offset
         payload = {
             "collectionName": name,
-            "search": [{
-                "data": [gen_vector(datatype="FloatVector", dim=dim)],
-                "annsField": "float_vector_1",
-                "limit": 10,
-                "outputFields": ["*"]
-            },
+            "search": [
+                {
+                    "data": [gen_vector(datatype="FloatVector", dim=dim)],
+                    "annsField": "float_vector_1",
+                    "limit": 10,
+                    "outputFields": ["*"],
+                },
                 {
                     "data": [gen_vector(datatype="FloatVector", dim=dim)],
                     "annsField": "float_vector_2",
                     "limit": 10,
-                    "outputFields": ["*"]
-                }
+                    "outputFields": ["*"],
+                },
             ],
             "rerank": {
                 "strategy": "rrf",
                 "params": {
                     "k": 10,
-                }
+                },
             },
             "limit": 10,
             "offset": invalid_offset,
-            "outputFields": ["user_id", "word_count", "book_describe"]
+            "outputFields": ["user_id", "word_count", "book_describe"],
         }
-        
+
         rsp = self.vector_client.vector_hybrid_search(payload)
-        assert rsp['code'] != 0
-        assert "offset" in rsp['message'].lower() or "invalid" in rsp['message'].lower()
+        assert rsp["code"] != 0
+        assert "offset" in rsp["message"].lower() or "invalid" in rsp["message"].lower()
 
     @pytest.mark.parametrize("nb", [5000])
     @pytest.mark.parametrize("dim", [128])
@@ -3221,16 +3779,16 @@ class TestHybridSearchVector(TestBase):
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "float_vector_1", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                     {"fieldName": "float_vector_2", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "float_vector_1", "indexName": "float_vector_1", "metricType": "IP"},
                 {"fieldName": "float_vector_2", "indexName": "float_vector_2", "metricType": "IP"},
-            ]
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
-        
+        assert rsp["code"] == 0
+
         # insert data
         data = []
         for i in range(nb):
@@ -3247,64 +3805,65 @@ class TestHybridSearchVector(TestBase):
             "data": data,
         }
         rsp = self.vector_client.vector_insert(payload)
-        assert rsp['code'] == 0
-        
+        assert rsp["code"] == 0
+
         # hybrid search with large offset
         payload = {
             "collectionName": name,
-            "search": [{
-                "data": [gen_vector(datatype="FloatVector", dim=dim)],
-                "annsField": "float_vector_1",
-                "limit": limit + large_offset,
-                "outputFields": ["*"]
-            },
+            "search": [
+                {
+                    "data": [gen_vector(datatype="FloatVector", dim=dim)],
+                    "annsField": "float_vector_1",
+                    "limit": limit + large_offset,
+                    "outputFields": ["*"],
+                },
                 {
                     "data": [gen_vector(datatype="FloatVector", dim=dim)],
                     "annsField": "float_vector_2",
                     "limit": limit + large_offset,
-                    "outputFields": ["*"]
-                }
+                    "outputFields": ["*"],
+                },
             ],
             "rerank": {
                 "strategy": "rrf",
                 "params": {
                     "k": 10,
-                }
+                },
             },
             "limit": limit,
             "offset": large_offset,
-            "outputFields": ["user_id", "word_count", "book_describe"]
+            "outputFields": ["user_id", "word_count", "book_describe"],
         }
-        
+
         rsp = self.vector_client.vector_hybrid_search(payload)
         # When offset + limit exceeds max allowed
         if large_offset + limit > MAX_SUM_OFFSET_AND_LIMIT:
-            assert rsp['code'] == 65535
-            assert "exceeds" in rsp['message'] or "invalid" in rsp['message'].lower()
+            assert rsp["code"] == 65535
+            assert "exceeds" in rsp["message"] or "invalid" in rsp["message"].lower()
         # When offset is larger than the available results
         elif large_offset >= nb:
             # Should return empty results or handle gracefully
-            assert rsp['code'] == 0
-            assert len(rsp['data']) == 0
+            assert rsp["code"] == 0
+            assert len(rsp["data"]) == 0
 
         else:
-            assert rsp['code'] == 0
+            assert rsp["code"] == 0
             # Should return remaining results after offset
             expected_count = min(limit, nb - large_offset)
-            assert len(rsp['data']) == expected_count
+            assert len(rsp["data"]) == expected_count
 
 
 @pytest.mark.L0
 class TestQueryVector(TestBase):
-
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
     @pytest.mark.parametrize("is_partition_key", [True])
     @pytest.mark.parametrize("enable_dynamic_schema", [True])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
-    def test_query_entities_with_all_scalar_datatype(self, nb, dim, insert_round, auto_id,
-                                                     is_partition_key, enable_dynamic_schema):
+    def test_query_entities_with_all_scalar_datatype(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -3317,32 +3876,48 @@ class TestQueryVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "25536"}},
                     {"fieldName": "bool", "dataType": "Bool", "elementTypeParams": {}},
                     {"fieldName": "json", "dataType": "JSON", "elementTypeParams": {}},
-                    {"fieldName": "int_array", "dataType": "Array", "elementDataType": "Int64",
-                     "elementTypeParams": {"max_capacity": "1024"}},
-                    {"fieldName": "varchar_array", "dataType": "Array", "elementDataType": "VarChar",
-                     "elementTypeParams": {"max_capacity": "1024", "max_length": "256"}},
-                    {"fieldName": "bool_array", "dataType": "Array", "elementDataType": "Bool",
-                     "elementTypeParams": {"max_capacity": "1024"}},
+                    {
+                        "fieldName": "int_array",
+                        "dataType": "Array",
+                        "elementDataType": "Int64",
+                        "elementTypeParams": {"max_capacity": "1024"},
+                    },
+                    {
+                        "fieldName": "varchar_array",
+                        "dataType": "Array",
+                        "elementDataType": "VarChar",
+                        "elementTypeParams": {"max_capacity": "1024", "max_length": "256"},
+                    },
+                    {
+                        "fieldName": "bool_array",
+                        "dataType": "Array",
+                        "elementDataType": "Bool",
+                        "elementTypeParams": {"max_capacity": "1024"},
+                    },
                     {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                     {"fieldName": "image_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "text_emb", "indexName": "text_emb", "metricType": "L2"},
-                {"fieldName": "image_emb", "indexName": "image_emb", "metricType": "L2"}
-            ]
+                {"fieldName": "image_emb", "indexName": "image_emb", "metricType": "L2"},
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -3358,9 +3933,11 @@ class TestQueryVector(TestBase):
                         "varchar_array": [f"varchar_{i}"],
                         "bool_array": [random.choice([True, False])],
                         "text_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                         "image_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                     }
                 else:
                     tmp = {
@@ -3374,9 +3951,11 @@ class TestQueryVector(TestBase):
                         "varchar_array": [f"varchar_{i}"],
                         "bool_array": [random.choice([True, False])],
                         "text_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                         "image_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                     }
                 if enable_dynamic_schema:
                     tmp.update({f"dynamic_field_{i}": i})
@@ -3386,50 +3965,35 @@ class TestQueryVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # query data to make sure the data is inserted
         # 1. query for int64
-        payload = {
-            "collectionName": name,
-            "filter": "user_id > 0",
-            "limit": 50,
-            "outputFields": ["*"]
-        }
+        payload = {"collectionName": name, "filter": "user_id > 0", "limit": 50, "outputFields": ["*"]}
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 50
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 50
 
         # 2. query for varchar
-        payload = {
-            "collectionName": name,
-            "filter": "book_describe like \"book%\"",
-            "limit": 50,
-            "outputFields": ["*"]
-        }
+        payload = {"collectionName": name, "filter": 'book_describe like "book%"', "limit": 50, "outputFields": ["*"]}
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 50
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 50
 
         # 3. query for json
         payload = {
             "collectionName": name,
             "filter": "json_contains(json['key'] , 1)",
             "limit": 50,
-            "outputFields": ["*"]
+            "outputFields": ["*"],
         }
         rsp = self.vector_client.vector_query(payload)
-        assert len(rsp['data']) == 1
+        assert len(rsp["data"]) == 1
 
         # 4. query for array
-        payload = {
-            "collectionName": name,
-            "filter": "array_contains(int_array, 1)",
-            "limit": 50,
-            "outputFields": ["*"]
-        }
+        payload = {"collectionName": name, "filter": "array_contains(int_array, 1)", "limit": 50, "outputFields": ["*"]}
         rsp = self.vector_client.vector_query(payload)
-        assert len(rsp['data']) == 1
+        assert len(rsp["data"]) == 1
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
@@ -3438,9 +4002,9 @@ class TestQueryVector(TestBase):
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
     @pytest.mark.parametrize("pass_fp32_to_fp16_or_bf16", [True, False])
-    def test_query_entities_with_all_vector_datatype(self, nb, dim, insert_round, auto_id,
-                                                     is_partition_key, enable_dynamic_schema,
-                                                     pass_fp32_to_fp16_or_bf16):
+    def test_query_entities_with_all_vector_datatype(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema, pass_fp32_to_fp16_or_bf16
+    ):
         """
         Insert a vector with a simple payload
         """
@@ -3453,31 +4017,45 @@ class TestQueryVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
                     {"fieldName": "float_vector", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                    {"fieldName": "float16_vector", "dataType": "Float16Vector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
-                    {"fieldName": "bfloat16_vector", "dataType": "BFloat16Vector",
-                     "elementTypeParams": {"dim": f"{dim}"}},
+                    {
+                        "fieldName": "float16_vector",
+                        "dataType": "Float16Vector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
+                    {
+                        "fieldName": "bfloat16_vector",
+                        "dataType": "BFloat16Vector",
+                        "elementTypeParams": {"dim": f"{dim}"},
+                    },
                     {"fieldName": "binary_vector", "dataType": "BinaryVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "float_vector", "indexName": "float_vector", "metricType": "L2"},
                 {"fieldName": "float16_vector", "indexName": "float16_vector", "metricType": "L2"},
                 {"fieldName": "bfloat16_vector", "indexName": "bfloat16_vector", "metricType": "L2"},
-                {"fieldName": "binary_vector", "indexName": "binary_vector", "metricType": "HAMMING",
-                 "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"}}
-            ]
+                {
+                    "fieldName": "binary_vector",
+                    "indexName": "binary_vector",
+                    "metricType": "HAMMING",
+                    "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"},
+                },
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -3498,7 +4076,7 @@ class TestQueryVector(TestBase):
                             if pass_fp32_to_fp16_or_bf16
                             else gen_vector(datatype="BFloat16Vector", dim=dim)
                         ),
-                        "binary_vector": gen_vector(datatype="BinaryVector", dim=dim)
+                        "binary_vector": gen_vector(datatype="BinaryVector", dim=dim),
                     }
                 else:
                     tmp = {
@@ -3517,7 +4095,7 @@ class TestQueryVector(TestBase):
                             if pass_fp32_to_fp16_or_bf16
                             else gen_vector(datatype="BFloat16Vector", dim=dim)
                         ),
-                        "binary_vector": gen_vector(datatype="BinaryVector", dim=dim)
+                        "binary_vector": gen_vector(datatype="BinaryVector", dim=dim),
                     }
                 if enable_dynamic_schema:
                     tmp.update({f"dynamic_field_{i}": i})
@@ -3527,8 +4105,8 @@ class TestQueryVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         c = Collection(name)
         res = c.query(
             expr="user_id > 0",
@@ -3538,12 +4116,13 @@ class TestQueryVector(TestBase):
         logger.info(f"res: {res}")
         # query data to make sure the data is inserted
         rsp = self.vector_client.vector_query({"collectionName": name, "filter": "user_id > 0", "limit": 50})
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 50
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 50
 
-    @pytest.mark.parametrize("expr", ["10+20 <= uid < 20+30", "uid in [1,2,3,4]",
-                                      "uid > 0", "uid >= 0", "uid > 0",
-                                      "uid > -100 and uid < 100"])
+    @pytest.mark.parametrize(
+        "expr",
+        ["10+20 <= uid < 20+30", "uid in [1,2,3,4]", "uid > 0", "uid >= 0", "uid > 0", "uid > -100 and uid < 100"],
+    )
     @pytest.mark.parametrize("include_output_fields", [True, False])
     @pytest.mark.parametrize("partial_fields", [True, False])
     def test_query_vector_with_int64_filter(self, expr, include_output_fields, partial_fields):
@@ -3555,32 +4134,26 @@ class TestQueryVector(TestBase):
         schema_payload, data = self.init_collection(name)
         output_fields = get_common_fields_by_data(data)
         if partial_fields:
-            output_fields = output_fields[:len(output_fields) // 2]
+            output_fields = output_fields[: len(output_fields) // 2]
             if "uid" not in output_fields:
                 output_fields.append("uid")
         else:
             output_fields = output_fields
 
         # query data
-        payload = {
-            "collectionName": name,
-            "filter": expr,
-            "limit": 100,
-            "offset": 0,
-            "outputFields": output_fields
-        }
+        payload = {"collectionName": name, "filter": expr, "limit": 100, "offset": 0, "outputFields": output_fields}
         if not include_output_fields:
             payload.pop("outputFields")
-            if 'vector' in output_fields:
+            if "vector" in output_fields:
                 output_fields.remove("vector")
         time.sleep(5)
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         for r in res:
-            uid = r['uid']
-            assert eval(expr) is True
+            uid = r["uid"]
+            assert eval(expr, {}, {"uid": uid}) is True
             for field in output_fields:
                 assert field in r
 
@@ -3592,15 +4165,10 @@ class TestQueryVector(TestBase):
         self.name = name
         self.init_collection(name, nb=default_nb)
         # query for "count(*)"
-        payload = {
-            "collectionName": name,
-            "filter": " ",
-            "limit": 0,
-            "outputFields": ["count(*)"]
-        }
+        payload = {"collectionName": name, "filter": " ", "limit": 0, "outputFields": ["count(*)"]}
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        assert rsp['data'][0]['count(*)'] == 3000
+        assert rsp["code"] == 0
+        assert rsp["data"][0]["count(*)"] == 3000
 
     @pytest.mark.xfail(reason="query by id is not supported")
     def test_query_vector_by_id(self):
@@ -3615,9 +4183,9 @@ class TestQueryVector(TestBase):
             "id": insert_ids,
         }
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
 
-    @pytest.mark.parametrize("filter_expr", ["name > \"placeholder\"", "name like \"placeholder%\""])
+    @pytest.mark.parametrize("filter_expr", ['name > "placeholder"', 'name like "placeholder%"'])
     @pytest.mark.parametrize("include_output_fields", [True, False])
     def test_query_vector_with_varchar_filter(self, filter_expr, include_output_fields):
         """
@@ -3650,8 +4218,8 @@ class TestQueryVector(TestBase):
         if not include_output_fields:
             payload.pop("outputFields")
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         assert len(res) <= limit
         for item in res:
@@ -3669,7 +4237,7 @@ class TestQueryVector(TestBase):
         """
         max_sum_of_limit_offset = 16384
         name = gen_collection_name()
-        filter_expr = "name > \"placeholder\""
+        filter_expr = 'name > "placeholder"'
         self.name = name
         nb = default_nb
         dim = 128
@@ -3696,10 +4264,10 @@ class TestQueryVector(TestBase):
         }
         rsp = self.vector_client.vector_query(payload)
         if sum_of_limit_offset > max_sum_of_limit_offset:
-            assert rsp['code'] == 1
+            assert rsp["code"] == 1
             return
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         assert len(res) <= limit
         for item in res:
@@ -3764,11 +4332,10 @@ class TestQueryVector(TestBase):
             FieldSchema(name="emb", dtype=DataType.FLOAT_VECTOR, dim=dim),
         ]
         schema = CollectionSchema(fields=fields, description="test collection")
-        collection = Collection(name=name, schema=schema
-                                )
+        collection = Collection(name=name, schema=schema)
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         data_size = 3000
         batch_size = 1000
         # insert data
@@ -3779,7 +4346,7 @@ class TestQueryVector(TestBase):
                 "sentence": fake.sentence().lower(),
                 "paragraph": fake.sentence().lower(),
                 "text": fake.text().lower(),
-                "emb": [random.random() for _ in range(dim)]
+                "emb": [random.random() for _ in range(dim)],
             }
             for i in range(data_size)
         ]
@@ -3789,14 +4356,14 @@ class TestQueryVector(TestBase):
         for field in text_fields:
             wf_map[field] = analyze_documents(df[field].tolist(), language=language)
         for i in range(0, data_size, batch_size):
-            tmp = data[i:i + batch_size]
+            tmp = data[i : i + batch_size]
             payload = {
                 "collectionName": name,
                 "data": tmp,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == len(tmp)
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == len(tmp)
         collection.create_index(
             "emb",
             {"index_type": "IVF_SQ8", "metric_type": "L2", "params": {"nlist": 64}},
@@ -3808,8 +4375,8 @@ class TestQueryVector(TestBase):
             expr = f"text_match({field}, '{token}')"
             logger.info(f"expr: {expr}")
             rsp = self.vector_client.vector_query({"collectionName": name, "filter": f"{expr}", "outputFields": ["*"]})
-            assert rsp['code'] == 0, rsp
-            for d in rsp['data']:
+            assert rsp["code"] == 0, rsp
+            for d in rsp["data"]:
                 assert token in d[field]
 
     @pytest.mark.parametrize("tokenizer", ["standard"])
@@ -3866,11 +4433,10 @@ class TestQueryVector(TestBase):
             FieldSchema(name="emb", dtype=DataType.FLOAT_VECTOR, dim=dim),
         ]
         schema = CollectionSchema(fields=fields, description="test collection")
-        collection = Collection(name=name, schema=schema
-                                )
+        collection = Collection(name=name, schema=schema)
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         data_size = 3000
         batch_size = 1000
         # insert data
@@ -3881,7 +4447,7 @@ class TestQueryVector(TestBase):
                 "sentence": fake.sentence().lower(),
                 "paragraph": fake.sentence().lower(),
                 "text": fake.text().lower(),
-                "emb": [random.random() for _ in range(dim)]
+                "emb": [random.random() for _ in range(dim)],
             }
             for i in range(data_size)
         ]
@@ -3892,14 +4458,14 @@ class TestQueryVector(TestBase):
             wf_map[field] = analyze_documents(df[field].tolist(), language=language)
 
         for i in range(0, data_size, batch_size):
-            tmp = data[i:i + batch_size]
+            tmp = data[i : i + batch_size]
             payload = {
                 "collectionName": name,
                 "data": tmp,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == len(tmp)
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == len(tmp)
         # add additional data to make sure query result is not empty
         target_data_len = 10
         phrase_map = {}
@@ -3913,7 +4479,7 @@ class TestQueryVector(TestBase):
                 "sentence": phrase_map["sentence"],
                 "paragraph": phrase_map["paragraph"],
                 "text": phrase_map["text"],
-                "emb": [random.random() for _ in range(dim)]
+                "emb": [random.random() for _ in range(dim)],
             }
             for i in range(data_size, data_size + target_data_len)
         ]
@@ -3922,8 +4488,8 @@ class TestQueryVector(TestBase):
             "data": tmp,
         }
         rsp = self.vector_client.vector_insert(payload)
-        assert rsp['code'] == 0
-        assert rsp['data']['insertCount'] == len(tmp)
+        assert rsp["code"] == 0
+        assert rsp["data"]["insertCount"] == len(tmp)
 
         collection.create_index(
             "emb",
@@ -3936,11 +4502,11 @@ class TestQueryVector(TestBase):
             expr = f"phrase_match({field}, '{phrase}')"
             logger.info(f"expr: {expr}")
             rsp = self.vector_client.vector_query({"collectionName": name, "filter": f"{expr}", "outputFields": ["*"]})
-            assert rsp['code'] == 0, rsp
-            for d in rsp['data']:
-                d[field] = re.sub(r'[^\w\s]','', d[field])
+            assert rsp["code"] == 0, rsp
+            for d in rsp["data"]:
+                d[field] = re.sub(r"[^\w\s]", "", d[field])
                 assert phrase in d[field]
-            assert len(rsp['data']) >= target_data_len
+            assert len(rsp["data"]) >= target_data_len
 
     @pytest.mark.parametrize("insert_round", [1])
     @pytest.mark.parametrize("auto_id", [True])
@@ -3948,8 +4514,9 @@ class TestQueryVector(TestBase):
     @pytest.mark.parametrize("enable_dynamic_schema", [True])
     @pytest.mark.parametrize("nb", [3000])
     @pytest.mark.parametrize("dim", [128])
-    def test_query_entities_with_default_none(self, nb, dim, insert_round, auto_id, is_partition_key,
-                                              enable_dynamic_schema):
+    def test_query_entities_with_default_none(
+        self, nb, dim, insert_round, auto_id, is_partition_key, enable_dynamic_schema
+    ):
         """
         Insert a vector with default and none
         """
@@ -3962,31 +4529,54 @@ class TestQueryVector(TestBase):
                 "enableDynamicField": enable_dynamic_schema,
                 "fields": [
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
-                    {"fieldName": "user_id", "dataType": "Int64", "isPartitionKey": is_partition_key,
-                     "elementTypeParams": {}},
+                    {
+                        "fieldName": "user_id",
+                        "dataType": "Int64",
+                        "isPartitionKey": is_partition_key,
+                        "elementTypeParams": {},
+                    },
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}, "defaultValue": 8888},
-                    {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "25536"},
-                     "nullable": True},
+                    {
+                        "fieldName": "book_describe",
+                        "dataType": "VarChar",
+                        "elementTypeParams": {"max_length": "25536"},
+                        "nullable": True,
+                    },
                     {"fieldName": "bool", "dataType": "Bool", "elementTypeParams": {}, "nullable": True},
                     {"fieldName": "json", "dataType": "JSON", "elementTypeParams": {}, "nullable": True},
-                    {"fieldName": "int_array", "dataType": "Array", "elementDataType": "Int64",
-                     "elementTypeParams": {"max_capacity": "1024"}, "nullable": True},
-                    {"fieldName": "varchar_array", "dataType": "Array", "elementDataType": "VarChar",
-                     "elementTypeParams": {"max_capacity": "1024", "max_length": "256"}, "nullable": True},
-                    {"fieldName": "bool_array", "dataType": "Array", "elementDataType": "Bool",
-                     "elementTypeParams": {"max_capacity": "1024"}, "nullable": True},
+                    {
+                        "fieldName": "int_array",
+                        "dataType": "Array",
+                        "elementDataType": "Int64",
+                        "elementTypeParams": {"max_capacity": "1024"},
+                        "nullable": True,
+                    },
+                    {
+                        "fieldName": "varchar_array",
+                        "dataType": "Array",
+                        "elementDataType": "VarChar",
+                        "elementTypeParams": {"max_capacity": "1024", "max_length": "256"},
+                        "nullable": True,
+                    },
+                    {
+                        "fieldName": "bool_array",
+                        "dataType": "Array",
+                        "elementDataType": "Bool",
+                        "elementTypeParams": {"max_capacity": "1024"},
+                        "nullable": True,
+                    },
                     {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "text_emb", "indexName": "text_emb", "metricType": "L2"},
-            ]
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -4002,7 +4592,8 @@ class TestQueryVector(TestBase):
                         "varchar_array": None,
                         "bool_array": None,
                         "text_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                     }
                 else:
                     tmp = {
@@ -4016,7 +4607,8 @@ class TestQueryVector(TestBase):
                         "varchar_array": None,
                         "bool_array": None,
                         "text_emb": preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[
-                            0].tolist(),
+                            0
+                        ].tolist(),
                     }
                 if enable_dynamic_schema:
                     tmp.update({f"dynamic_field_{i}": i})
@@ -4026,27 +4618,21 @@ class TestQueryVector(TestBase):
                 "data": data,
             }
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # query data to make sure the data is inserted
-        payload = {
-            "collectionName": name,
-            "filter": "user_id > 0",
-            "limit": 50,
-            "outputFields": ["*"]
-        }
+        payload = {"collectionName": name, "filter": "user_id > 0", "limit": 50, "outputFields": ["*"]}
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        assert rsp['data'][0]['book_describe'] is None
-        assert rsp['data'][0]['word_count'] == 8888
-        assert rsp['data'][0]['json'] is None
-        assert rsp['data'][0]['varchar_array'] is None
-        assert len(rsp['data']) == 50
+        assert rsp["code"] == 0
+        assert rsp["data"][0]["book_describe"] is None
+        assert rsp["data"][0]["word_count"] == 8888
+        assert rsp["data"][0]["json"] is None
+        assert rsp["data"][0]["varchar_array"] is None
+        assert len(rsp["data"]) == 50
 
 
 @pytest.mark.L0
 class TestQueryVectorNegative(TestBase):
-
     def test_query_with_wrong_filter_expr(self):
         name = gen_collection_name()
         self.name = name
@@ -4063,13 +4649,12 @@ class TestQueryVectorNegative(TestBase):
             "filter": f"{insert_ids}",
         }
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 1100
-        assert "failed to create query plan" in rsp['message']
+        assert rsp["code"] == 1100
+        assert "failed to create query plan" in rsp["message"]
 
 
 @pytest.mark.L0
 class TestGetVector(TestBase):
-
     def test_get_vector_with_simple_payload(self):
         """
         Search a vector with a simple payload
@@ -4086,12 +4671,12 @@ class TestGetVector(TestBase):
             "data": [vector_to_search],
         }
         rsp = self.vector_client.vector_search(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         limit = int(payload.get("limit", 100))
         assert len(res) == limit
-        ids = [item['id'] for item in res]
+        ids = [item["id"] for item in res]
         assert len(ids) == len(set(ids))
         payload = {
             "collectionName": name,
@@ -4099,12 +4684,12 @@ class TestGetVector(TestBase):
             "id": ids[0],
         }
         rsp = self.vector_client.vector_get(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {res}")
         logger.info(f"res: {len(res)}")
         for item in res:
-            assert item['id'] == ids[0]
+            assert item["id"] == ids[0]
 
     @pytest.mark.L0
     @pytest.mark.parametrize("id_field_type", ["list", "one"])
@@ -4126,12 +4711,12 @@ class TestGetVector(TestBase):
             "filter": f"uid in {uids}",
         }
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         ids = []
         for r in res:
-            ids.append(r['id'])
+            ids.append(r["id"])
         logger.info(f"ids: {len(ids)}")
         id_to_get = None
         if id_field_type == "list":
@@ -4144,14 +4729,10 @@ class TestGetVector(TestBase):
             else:
                 id_to_get = 0
         # get by id list
-        payload = {
-            "collectionName": name,
-            "outputFields": output_fields,
-            "id": id_to_get
-        }
+        payload = {"collectionName": name, "outputFields": output_fields, "id": id_to_get}
         rsp = self.vector_client.vector_get(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         if isinstance(id_to_get, list):
             if include_invalid_id:
                 assert len(res) == len(id_to_get) - 1
@@ -4162,11 +4743,11 @@ class TestGetVector(TestBase):
                 assert len(res) == 0
             else:
                 assert len(res) == 1
-        for r in rsp['data']:
+        for r in rsp["data"]:
             if isinstance(id_to_get, list):
-                assert r['id'] in id_to_get
+                assert r["id"] in id_to_get
             else:
-                assert r['id'] == id_to_get
+                assert r["id"] == id_to_get
             if include_output_fields:
                 for field in output_fields:
                     assert field in r
@@ -4174,7 +4755,6 @@ class TestGetVector(TestBase):
 
 @pytest.mark.L0
 class TestDeleteVector(TestBase):
-
     @pytest.mark.xfail(reason="delete by id is not supported")
     def test_delete_vector_by_id(self):
         """
@@ -4188,7 +4768,7 @@ class TestDeleteVector(TestBase):
             "id": insert_ids,
         }
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
 
     @pytest.mark.parametrize("id_field_type", ["list", "one"])
     def test_delete_vector_by_pk_field_ids(self, id_field_type):
@@ -4204,24 +4784,15 @@ class TestDeleteVector(TestBase):
         if id_field_type == "one":
             id_to_delete = insert_ids[0]
         if isinstance(id_to_delete, list):
-            payload = {
-                "collectionName": name,
-                "filter": f"id in {id_to_delete}"
-            }
+            payload = {"collectionName": name, "filter": f"id in {id_to_delete}"}
         else:
-            payload = {
-                "collectionName": name,
-                "filter": f"id == {id_to_delete}"
-            }
+            payload = {"collectionName": name, "filter": f"id == {id_to_delete}"}
         rsp = self.vector_client.vector_delete(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # verify data deleted by get
-        payload = {
-            "collectionName": name,
-            "id": id_to_delete
-        }
+        payload = {"collectionName": name, "id": id_to_delete}
         rsp = self.vector_client.vector_get(payload)
-        assert len(rsp['data']) == 0
+        assert len(rsp["data"]) == 0
 
     @pytest.mark.parametrize("id_field_type", ["list", "one"])
     def test_delete_vector_by_filter_pk_field(self, id_field_type):
@@ -4241,12 +4812,12 @@ class TestDeleteVector(TestBase):
             "filter": f"uid in {uids}",
         }
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         ids = []
         for r in res:
-            ids.append(r['id'])
+            ids.append(r["id"])
         logger.info(f"ids: {len(ids)}")
         id_to_get = None
         if id_field_type == "list":
@@ -4269,7 +4840,7 @@ class TestDeleteVector(TestBase):
             }
 
         rsp = self.vector_client.vector_delete(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         logger.info(f"delete res: {rsp}")
 
         # verify data deleted
@@ -4281,8 +4852,8 @@ class TestDeleteVector(TestBase):
         }
         time.sleep(5)
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == 0
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == 0
 
     def test_delete_vector_by_custom_pk_field(self):
         dim = 128
@@ -4297,16 +4868,16 @@ class TestDeleteVector(TestBase):
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
-                    {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}}
+                    {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                 ]
             },
-            "indexParams": [{"fieldName": "text_emb", "indexName": "text_emb_index", "metricType": "L2"}]
+            "indexParams": [{"fieldName": "text_emb", "indexName": "text_emb_index", "metricType": "L2"}],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         pk_values = []
         # insert data
         for i in range(insert_round):
@@ -4316,7 +4887,7 @@ class TestDeleteVector(TestBase):
                     "book_id": i * nb + j,
                     "word_count": i * nb + j,
                     "book_describe": f"book_{i * nb + j}",
-                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
+                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist(),
                 }
                 data.append(tmp)
             payload = {
@@ -4328,8 +4899,8 @@ class TestDeleteVector(TestBase):
             body_size = sys.getsizeof(json.dumps(payload))
             logger.info(f"body size: {body_size / 1024 / 1024} MB")
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # query data before delete
         c = Collection(name)
         res = c.query(expr="", output_fields=["count(*)"])
@@ -4360,16 +4931,16 @@ class TestDeleteVector(TestBase):
                     {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
-                    {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}}
+                    {"fieldName": "text_emb", "dataType": "FloatVector", "elementTypeParams": {"dim": f"{dim}"}},
                 ]
             },
-            "indexParams": [{"fieldName": "text_emb", "indexName": "text_emb_index", "metricType": "L2"}]
+            "indexParams": [{"fieldName": "text_emb", "indexName": "text_emb_index", "metricType": "L2"}],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
         logger.info(f"rsp: {rsp}")
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         for i in range(insert_round):
             data = []
@@ -4378,7 +4949,7 @@ class TestDeleteVector(TestBase):
                     "book_id": i * nb + j,
                     "word_count": i * nb + j,
                     "book_describe": f"book_{i * nb + j}",
-                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist()
+                    "text_emb": preprocessing.normalize([np.array([random.random() for i in range(dim)])])[0].tolist(),
                 }
                 data.append(tmp)
             payload = {
@@ -4388,8 +4959,8 @@ class TestDeleteVector(TestBase):
             body_size = sys.getsizeof(json.dumps(payload))
             logger.info(f"body size: {body_size / 1024 / 1024} MB")
             rsp = self.vector_client.vector_insert(payload)
-            assert rsp['code'] == 0
-            assert rsp['data']['insertCount'] == nb
+            assert rsp["code"] == 0
+            assert rsp["data"]["insertCount"] == nb
         # query data before delete
         c = Collection(name)
         res = c.query(expr="", output_fields=["count(*)"])
@@ -4415,18 +4986,12 @@ class TestDeleteVector(TestBase):
         self.name = name
         self.init_collection(name, dim=128, nb=default_nb)
         expr = "uid > 0"
-        payload = {
-            "collectionName": name,
-            "filter": expr,
-            "limit": 3000,
-            "offset": 0,
-            "outputFields": ["id", "uid"]
-        }
+        payload = {"collectionName": name, "filter": expr, "limit": 3000, "offset": 0, "outputFields": ["id", "uid"]}
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
-        id_list = [r['uid'] for r in res]
+        id_list = [r["uid"] for r in res]
         delete_expr = f"uid in {[i for i in id_list[:10]]}"
         # query data before delete
         payload = {
@@ -4434,13 +4999,14 @@ class TestDeleteVector(TestBase):
             "filter": delete_expr,
             "limit": 3000,
             "offset": 0,
-            "outputFields": ["id", "uid"]
+            "outputFields": ["id", "uid"],
         }
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         num_before_delete = len(res)
         logger.info(f"res: {len(res)}")
+        assert num_before_delete > 0
         # delete data
         payload = {
             "collectionName": name,
@@ -4453,7 +5019,7 @@ class TestDeleteVector(TestBase):
             "filter": delete_expr,
             "limit": 3000,
             "offset": 0,
-            "outputFields": ["id", "uid"]
+            "outputFields": ["id", "uid"],
         }
         time.sleep(1)
         rsp = self.vector_client.vector_query(payload)
@@ -4462,7 +5028,6 @@ class TestDeleteVector(TestBase):
 
 @pytest.mark.L0
 class TestDeleteVectorNegative(TestBase):
-
     def test_delete_vector_with_invalid_collection_name(self):
         """
         Delete a vector with an invalid collection name
@@ -4474,18 +5039,12 @@ class TestDeleteVectorNegative(TestBase):
         # query data
         # expr = f"id in {[i for i in range(10)]}".replace("[", "(").replace("]", ")")
         expr = "id > 0"
-        payload = {
-            "collectionName": name,
-            "filter": expr,
-            "limit": 3000,
-            "offset": 0,
-            "outputFields": ["id", "uid"]
-        }
+        payload = {"collectionName": name, "filter": expr, "limit": 3000, "offset": 0, "outputFields": ["id", "uid"]}
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
-        id_list = [r['id'] for r in res]
+        id_list = [r["id"] for r in res]
         delete_expr = f"id in {[i for i in id_list[:10]]}"
         # query data before delete
         payload = {
@@ -4493,11 +5052,11 @@ class TestDeleteVectorNegative(TestBase):
             "filter": delete_expr,
             "limit": 3000,
             "offset": 0,
-            "outputFields": ["id", "uid"]
+            "outputFields": ["id", "uid"],
         }
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         # delete data
         payload = {
@@ -4505,8 +5064,8 @@ class TestDeleteVectorNegative(TestBase):
             "filter": delete_expr,
         }
         rsp = self.vector_client.vector_delete(payload)
-        assert rsp['code'] == 100
-        assert "can't find collection" in rsp['message']
+        assert rsp["code"] == 100
+        assert "can't find collection" in rsp["message"]
 
 
 @pytest.mark.L1
@@ -4523,15 +5082,16 @@ class TestVectorWithAuth(TestBase):
             "dimension": dim,
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         nb = 10
         data = [
             {
                 "vector": [np.float64(random.random()) for _ in range(dim)],
-            } for _ in range(nb)
+            }
+            for _ in range(nb)
         ]
         payload = {
             "collectionName": name,
@@ -4542,7 +5102,7 @@ class TestVectorWithAuth(TestBase):
         client = self.vector_client
         client.api_key = "invalid_api_key"
         rsp = client.vector_insert(payload)
-        assert rsp['code'] == 1800
+        assert rsp["code"] == 1800
 
     def test_insert_vector_with_invalid_api_key(self):
         """
@@ -4556,15 +5116,16 @@ class TestVectorWithAuth(TestBase):
             "dimension": dim,
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         rsp = self.collection_client.collection_describe(name)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # insert data
         nb = 10
         data = [
             {
                 "vector": [np.float64(random.random()) for _ in range(dim)],
-            } for _ in range(nb)
+            }
+            for _ in range(nb)
         ]
         payload = {
             "collectionName": name,
@@ -4575,7 +5136,7 @@ class TestVectorWithAuth(TestBase):
         client = self.vector_client
         client.api_key = "invalid_api_key"
         rsp = client.vector_insert(payload)
-        assert rsp['code'] == 1800
+        assert rsp["code"] == 1800
 
     def test_delete_vector_with_invalid_api_key(self):
         """
@@ -4596,23 +5157,19 @@ class TestVectorWithAuth(TestBase):
             "filter": f"uid in {uids}",
         }
         rsp = self.vector_client.vector_query(payload)
-        assert rsp['code'] == 0
-        res = rsp['data']
+        assert rsp["code"] == 0
+        res = rsp["data"]
         logger.info(f"res: {len(res)}")
         ids = []
         for r in res:
-            ids.append(r['id'])
+            ids.append(r["id"])
         logger.info(f"ids: {len(ids)}")
-        id_to_get = ids
         # delete by id list
-        payload = {
-            "collectionName": name,
-            "filter": f"uid in {uids}"
-        }
+        payload = {"collectionName": name, "filter": f"uid in {uids}"}
         client = self.vector_client
         client.api_key = "invalid_api_key"
         rsp = client.vector_delete(payload)
-        assert rsp['code'] == 1800
+        assert rsp["code"] == 1800
 
 
 @pytest.mark.L0
@@ -4625,7 +5182,9 @@ class TestSearchByPK(TestBase):
     The first result for each query should be itself with distance ~0 (for L2/COSINE metrics).
     """
 
-    @pytest.mark.xfail(reason="https://github.com/milvus-io/milvus/issues/47495 - JSON float64 precision loss for large int64 IDs")
+    @pytest.mark.xfail(
+        reason="https://github.com/milvus-io/milvus/issues/47495 - JSON float64 precision loss for large int64 IDs"
+    )
     def test_search_by_pk_with_int64_ids_as_numbers(self):
         """
         Search by primary key with int64 ids provided as numbers.
@@ -4649,19 +5208,14 @@ class TestSearchByPK(TestBase):
         # autoId generates IDs > 2^53 which lose precision when parsed as JSON float64
         test_ids = [int(i) for i in insert_ids[:3]]
 
-        payload = {
-            "collectionName": name,
-            "ids": test_ids,
-            "outputFields": ["*"],
-            "limit": limit
-        }
+        payload = {"collectionName": name, "ids": test_ids, "outputFields": ["*"], "limit": limit}
         rsp = self.vector_client.vector_search(payload)
 
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # Each query ID returns up to `limit` results
-        assert len(rsp['data']) == len(test_ids) * limit
+        assert len(rsp["data"]) == len(test_ids) * limit
         # The queried IDs should appear in results (as they match themselves with distance ~0)
-        returned_ids = [item['id'] for item in rsp['data']]
+        returned_ids = [item["id"] for item in rsp["data"]]
         for rid in test_ids:
             assert rid in returned_ids
 
@@ -4680,17 +5234,12 @@ class TestSearchByPK(TestBase):
         # Convert insert_ids to strings
         test_ids = [str(i) for i in insert_ids[:3]]
 
-        payload = {
-            "collectionName": name,
-            "ids": test_ids,
-            "outputFields": ["*"],
-            "limit": limit
-        }
+        payload = {"collectionName": name, "ids": test_ids, "outputFields": ["*"], "limit": limit}
         rsp = self.vector_client.vector_search(payload)
 
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == len(test_ids) * limit
-        returned_ids = [item['id'] for item in rsp['data']]
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == len(test_ids) * limit
+        returned_ids = [item["id"] for item in rsp["data"]]
         for rid in test_ids:
             assert int(rid) in returned_ids
 
@@ -4710,19 +5259,20 @@ class TestSearchByPK(TestBase):
                 "autoId": False,
                 "enableDynamicField": True,
                 "fields": [
-                    {"fieldName": "pk", "dataType": "VarChar", "isPrimary": True,
-                     "elementTypeParams": {"max_length": "128"}},
+                    {
+                        "fieldName": "pk",
+                        "dataType": "VarChar",
+                        "isPrimary": True,
+                        "elementTypeParams": {"max_length": "128"},
+                    },
                     {"fieldName": "uid", "dataType": "Int64", "elementTypeParams": {}},
-                    {"fieldName": "vector", "dataType": "FloatVector",
-                     "elementTypeParams": {"dim": str(dim)}},
-                ]
+                    {"fieldName": "vector", "dataType": "FloatVector", "elementTypeParams": {"dim": str(dim)}},
+                ],
             },
-            "indexParams": [
-                {"fieldName": "vector", "indexName": "vector", "metricType": "L2"}
-            ]
+            "indexParams": [{"fieldName": "vector", "indexName": "vector", "metricType": "L2"}],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         self.wait_collection_load_completed(name)
 
         # Insert data
@@ -4732,29 +5282,26 @@ class TestSearchByPK(TestBase):
         for i in range(nb):
             pk = f"pk_{i:06d}"
             insert_pks.append(pk)
-            data.append({
-                "pk": pk,
-                "uid": i,
-                "vector": gen_vector(datatype="FloatVector", dim=dim),
-            })
+            data.append(
+                {
+                    "pk": pk,
+                    "uid": i,
+                    "vector": gen_vector(datatype="FloatVector", dim=dim),
+                }
+            )
 
         insert_payload = {"collectionName": name, "data": data}
         rsp = self.vector_client.vector_insert(insert_payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
 
         # Search by pk
         test_pks = insert_pks[:3]
-        search_payload = {
-            "collectionName": name,
-            "ids": test_pks,
-            "outputFields": ["*"],
-            "limit": limit
-        }
+        search_payload = {"collectionName": name, "ids": test_pks, "outputFields": ["*"], "limit": limit}
         rsp = self.vector_client.vector_search(search_payload)
 
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == len(test_pks) * limit
-        returned_pks = [item['pk'] for item in rsp['data']]
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == len(test_pks) * limit
+        returned_pks = [item["pk"] for item in rsp["data"]]
         for pk in test_pks:
             assert pk in returned_pks
 
@@ -4773,19 +5320,13 @@ class TestSearchByPK(TestBase):
         test_ids = [str(i) for i in insert_ids[:5]]
 
         # Apply filter that matches only some results
-        payload = {
-            "collectionName": name,
-            "ids": test_ids,
-            "filter": "uid >= 5",
-            "outputFields": ["*"],
-            "limit": 100
-        }
+        payload = {"collectionName": name, "ids": test_ids, "filter": "uid >= 5", "outputFields": ["*"], "limit": 100}
         rsp = self.vector_client.vector_search(payload)
 
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # All returned items should have uid >= 5
-        for item in rsp['data']:
-            assert item['uid'] >= 5
+        for item in rsp["data"]:
+            assert item["uid"] >= 5
 
     def test_search_by_pk_with_output_fields(self):
         """
@@ -4801,19 +5342,14 @@ class TestSearchByPK(TestBase):
         # Use string IDs to avoid float64 precision loss
         test_ids = [str(i) for i in insert_ids[:3]]
 
-        payload = {
-            "collectionName": name,
-            "ids": test_ids,
-            "outputFields": ["uid", "id"],
-            "limit": limit
-        }
+        payload = {"collectionName": name, "ids": test_ids, "outputFields": ["uid", "id"], "limit": limit}
         rsp = self.vector_client.vector_search(payload)
 
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == len(test_ids) * limit
-        for item in rsp['data']:
-            assert 'uid' in item
-            assert 'id' in item
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == len(test_ids) * limit
+        for item in rsp["data"]:
+            assert "uid" in item
+            assert "id" in item
 
     def test_search_by_pk_with_limit(self):
         """
@@ -4830,17 +5366,12 @@ class TestSearchByPK(TestBase):
         test_ids = [str(i) for i in insert_ids[:5]]
         limit = 10
 
-        payload = {
-            "collectionName": name,
-            "ids": test_ids,
-            "outputFields": ["*"],
-            "limit": limit
-        }
+        payload = {"collectionName": name, "ids": test_ids, "outputFields": ["*"], "limit": limit}
         rsp = self.vector_client.vector_search(payload)
 
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         # Result count should be len(test_ids) * limit
-        assert len(rsp['data']) == len(test_ids) * limit
+        assert len(rsp["data"]) == len(test_ids) * limit
 
     def test_search_by_pk_with_nonexistent_ids(self):
         """
@@ -4857,16 +5388,11 @@ class TestSearchByPK(TestBase):
         # Use only non-existent IDs
         nonexistent_ids = [999999999, 888888888]
 
-        payload = {
-            "collectionName": name,
-            "ids": nonexistent_ids,
-            "outputFields": ["*"],
-            "limit": limit
-        }
+        payload = {"collectionName": name, "ids": nonexistent_ids, "outputFields": ["*"], "limit": limit}
         rsp = self.vector_client.vector_search(payload)
 
         # Non-existent IDs should return error
-        assert rsp['code'] == 1100
+        assert rsp["code"] == 1100
 
     def test_search_by_pk_result_verification(self):
         """
@@ -4882,23 +5408,18 @@ class TestSearchByPK(TestBase):
         # Use string IDs to avoid float64 precision loss
         test_ids = [str(i) for i in insert_ids[:3]]
 
-        payload = {
-            "collectionName": name,
-            "ids": test_ids,
-            "outputFields": ["*"],
-            "limit": limit
-        }
+        payload = {"collectionName": name, "ids": test_ids, "outputFields": ["*"], "limit": limit}
         rsp = self.vector_client.vector_search(payload)
 
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == len(test_ids) * limit
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == len(test_ids) * limit
 
         # Group results by query (each limit results belong to one query)
         # The first result in each group should have distance ~0 (matching itself)
         for i in range(len(test_ids)):
-            first_result = rsp['data'][i * limit]
+            first_result = rsp["data"][i * limit]
             # First result should be the query entity itself with very small distance
-            assert first_result['distance'] < 0.001 or first_result['id'] == int(test_ids[i])
+            assert first_result["distance"] < 0.001 or first_result["id"] == int(test_ids[i])
 
     def test_search_by_pk_with_bm25_function_schema(self):
         """
@@ -4922,10 +5443,16 @@ class TestSearchByPK(TestBase):
                     {"fieldName": "user_id", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "word_count", "dataType": "Int64", "elementTypeParams": {}},
                     {"fieldName": "book_describe", "dataType": "VarChar", "elementTypeParams": {"max_length": "256"}},
-                    {"fieldName": "document_content", "dataType": "VarChar",
-                     "elementTypeParams": {"max_length": "1000", "enable_analyzer": True,
-                                           "analyzer_params": {"tokenizer": "standard"},
-                                           "enable_match": True}},
+                    {
+                        "fieldName": "document_content",
+                        "dataType": "VarChar",
+                        "elementTypeParams": {
+                            "max_length": "1000",
+                            "enable_analyzer": True,
+                            "analyzer_params": {"tokenizer": "standard"},
+                            "enable_match": True,
+                        },
+                    },
                     {"fieldName": "sparse_vector", "dataType": "SparseFloatVector"},
                 ],
                 "functions": [
@@ -4934,35 +5461,41 @@ class TestSearchByPK(TestBase):
                         "type": "BM25",
                         "inputFieldNames": ["document_content"],
                         "outputFieldNames": ["sparse_vector"],
-                        "params": {}
+                        "params": {},
                     }
-                ]
+                ],
             },
             "indexParams": [
-                {"fieldName": "sparse_vector", "indexName": "sparse_vector", "metricType": "BM25",
-                 "params": {"index_type": "SPARSE_INVERTED_INDEX"}}
-            ]
+                {
+                    "fieldName": "sparse_vector",
+                    "indexName": "sparse_vector",
+                    "metricType": "BM25",
+                    "params": {"index_type": "SPARSE_INVERTED_INDEX"},
+                }
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         self.wait_collection_load_completed(name)
 
         # Insert data
         nb = default_nb
         data = []
         for i in range(nb):
-            data.append({
-                "user_id": i % 10,
-                "word_count": i,
-                "book_describe": f"book_{i}",
-                "document_content": fake_en.text().lower(),
-            })
+            data.append(
+                {
+                    "user_id": i % 10,
+                    "word_count": i,
+                    "book_describe": f"book_{i}",
+                    "document_content": fake_en.text().lower(),
+                }
+            )
         insert_payload = {"collectionName": name, "data": data}
         rsp = self.vector_client.vector_insert(insert_payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
 
         # Use string IDs to avoid float64 precision loss for large autoId values
-        test_ids = [str(i) for i in rsp['data']['insertIds'][:3]]
+        test_ids = [str(i) for i in rsp["data"]["insertIds"][:3]]
 
         # Search by pk - must specify annsField for BM25 sparse vector
         search_payload = {
@@ -4970,13 +5503,13 @@ class TestSearchByPK(TestBase):
             "ids": test_ids,
             "annsField": "sparse_vector",
             "outputFields": ["book_id", "user_id"],
-            "limit": limit
+            "limit": limit,
         }
         rsp = self.vector_client.vector_search(search_payload)
 
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == len(test_ids) * limit
-        returned_ids = [item['book_id'] for item in rsp['data']]
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == len(test_ids) * limit
+        returned_ids = [item["book_id"] for item in rsp["data"]]
         for rid in test_ids:
             assert int(rid) in returned_ids
 
@@ -4999,19 +5532,22 @@ class TestSearchByPK(TestBase):
                 "fields": [
                     {"fieldName": "pk", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
                     {"fieldName": "uid", "dataType": "Int64", "elementTypeParams": {}},
-                    {"fieldName": "dense_vector", "dataType": "FloatVector",
-                     "elementTypeParams": {"dim": str(dim)}},
+                    {"fieldName": "dense_vector", "dataType": "FloatVector", "elementTypeParams": {"dim": str(dim)}},
                     {"fieldName": "sparse_vector", "dataType": "SparseFloatVector"},
-                ]
+                ],
             },
             "indexParams": [
                 {"fieldName": "dense_vector", "indexName": "dense_vector", "metricType": "L2"},
-                {"fieldName": "sparse_vector", "indexName": "sparse_vector", "metricType": "IP",
-                 "params": {"index_type": "SPARSE_INVERTED_INDEX"}}
-            ]
+                {
+                    "fieldName": "sparse_vector",
+                    "indexName": "sparse_vector",
+                    "metricType": "IP",
+                    "params": {"index_type": "SPARSE_INVERTED_INDEX"},
+                },
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         self.wait_collection_load_completed(name)
 
         # Insert data
@@ -5020,15 +5556,17 @@ class TestSearchByPK(TestBase):
         insert_pks = []
         for i in range(nb):
             insert_pks.append(i)
-            data.append({
-                "pk": i,
-                "uid": i % 10,
-                "dense_vector": gen_vector(datatype="FloatVector", dim=dim),
-                "sparse_vector": gen_vector(datatype="SparseFloatVector", dim=1000),
-            })
+            data.append(
+                {
+                    "pk": i,
+                    "uid": i % 10,
+                    "dense_vector": gen_vector(datatype="FloatVector", dim=dim),
+                    "sparse_vector": gen_vector(datatype="SparseFloatVector", dim=1000),
+                }
+            )
         insert_payload = {"collectionName": name, "data": data}
         rsp = self.vector_client.vector_insert(insert_payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
 
         # Search by pk - specify annsField for dense_vector
         test_pks = insert_pks[:3]
@@ -5037,13 +5575,13 @@ class TestSearchByPK(TestBase):
             "ids": test_pks,
             "annsField": "dense_vector",
             "outputFields": ["pk", "uid"],
-            "limit": limit
+            "limit": limit,
         }
         rsp = self.vector_client.vector_search(search_payload)
 
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == len(test_pks) * limit
-        returned_pks = [item['pk'] for item in rsp['data']]
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == len(test_pks) * limit
+        returned_pks = [item["pk"] for item in rsp["data"]]
         for pk in test_pks:
             assert pk in returned_pks
 
@@ -5066,23 +5604,28 @@ class TestSearchByPK(TestBase):
                 "fields": [
                     {"fieldName": "pk", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
                     {"fieldName": "uid", "dataType": "Int64", "elementTypeParams": {}},
-                    {"fieldName": "float_vector", "dataType": "FloatVector",
-                     "elementTypeParams": {"dim": str(dim)}},
-                    {"fieldName": "float16_vector", "dataType": "Float16Vector",
-                     "elementTypeParams": {"dim": str(dim)}},
-                    {"fieldName": "binary_vector", "dataType": "BinaryVector",
-                     "elementTypeParams": {"dim": str(dim)}},
-                ]
+                    {"fieldName": "float_vector", "dataType": "FloatVector", "elementTypeParams": {"dim": str(dim)}},
+                    {
+                        "fieldName": "float16_vector",
+                        "dataType": "Float16Vector",
+                        "elementTypeParams": {"dim": str(dim)},
+                    },
+                    {"fieldName": "binary_vector", "dataType": "BinaryVector", "elementTypeParams": {"dim": str(dim)}},
+                ],
             },
             "indexParams": [
                 {"fieldName": "float_vector", "indexName": "float_vector", "metricType": "L2"},
                 {"fieldName": "float16_vector", "indexName": "float16_vector", "metricType": "L2"},
-                {"fieldName": "binary_vector", "indexName": "binary_vector", "metricType": "HAMMING",
-                 "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"}}
-            ]
+                {
+                    "fieldName": "binary_vector",
+                    "indexName": "binary_vector",
+                    "metricType": "HAMMING",
+                    "params": {"index_type": "BIN_IVF_FLAT", "nlist": "512"},
+                },
+            ],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         self.wait_collection_load_completed(name)
 
         # Insert data
@@ -5091,16 +5634,18 @@ class TestSearchByPK(TestBase):
         insert_pks = []
         for i in range(nb):
             insert_pks.append(i)
-            data.append({
-                "pk": i,
-                "uid": i % 10,
-                "float_vector": gen_vector(datatype="FloatVector", dim=dim),
-                "float16_vector": gen_vector(datatype="FloatVector", dim=dim),
-                "binary_vector": gen_vector(datatype="BinaryVector", dim=dim),
-            })
+            data.append(
+                {
+                    "pk": i,
+                    "uid": i % 10,
+                    "float_vector": gen_vector(datatype="FloatVector", dim=dim),
+                    "float16_vector": gen_vector(datatype="FloatVector", dim=dim),
+                    "binary_vector": gen_vector(datatype="BinaryVector", dim=dim),
+                }
+            )
         insert_payload = {"collectionName": name, "data": data}
         rsp = self.vector_client.vector_insert(insert_payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
 
         # Search by pk - specify annsField for float_vector
         test_pks = insert_pks[:3]
@@ -5109,13 +5654,13 @@ class TestSearchByPK(TestBase):
             "ids": test_pks,
             "annsField": "float_vector",
             "outputFields": ["pk", "uid"],
-            "limit": limit
+            "limit": limit,
         }
         rsp = self.vector_client.vector_search(search_payload)
 
-        assert rsp['code'] == 0
-        assert len(rsp['data']) == len(test_pks) * limit
-        returned_pks = [item['pk'] for item in rsp['data']]
+        assert rsp["code"] == 0
+        assert len(rsp["data"]) == len(test_pks) * limit
+        returned_pks = [item["pk"] for item in rsp["data"]]
         for pk in test_pks:
             assert pk in returned_pks
 
@@ -5138,17 +5683,11 @@ class TestSearchByPKNegative(TestBase):
         test_ids = [str(i) for i in insert_ids[:3]]
         vector = preprocessing.normalize([np.array([random.random() for _ in range(dim)])])[0].tolist()
 
-        payload = {
-            "collectionName": name,
-            "ids": test_ids,
-            "data": [vector],
-            "outputFields": ["*"],
-            "limit": 10
-        }
+        payload = {"collectionName": name, "ids": test_ids, "data": [vector], "outputFields": ["*"], "limit": 10}
         rsp = self.vector_client.vector_search(payload)
 
-        assert rsp['code'] == 1100
-        assert "mutually exclusive" in rsp['message'].lower() or "exclusive" in rsp['message'].lower()
+        assert rsp["code"] == 1100
+        assert "mutually exclusive" in rsp["message"].lower() or "exclusive" in rsp["message"].lower()
 
     def test_search_by_pk_with_empty_ids_array(self):
         """
@@ -5160,15 +5699,10 @@ class TestSearchByPKNegative(TestBase):
         nb = default_nb
         self.init_collection(name, dim=dim, nb=nb)
 
-        payload = {
-            "collectionName": name,
-            "ids": [],
-            "outputFields": ["*"],
-            "limit": 10
-        }
+        payload = {"collectionName": name, "ids": [], "outputFields": ["*"], "limit": 10}
         rsp = self.vector_client.vector_search(payload)
 
-        assert rsp['code'] == 1802
+        assert rsp["code"] == 1802
 
     def test_search_by_pk_with_fractional_float_ids(self):
         """
@@ -5180,15 +5714,10 @@ class TestSearchByPKNegative(TestBase):
         nb = default_nb
         self.init_collection(name, dim=dim, nb=nb)
 
-        payload = {
-            "collectionName": name,
-            "ids": [1.5, 2.7, 3.9],
-            "outputFields": ["*"],
-            "limit": 10
-        }
+        payload = {"collectionName": name, "ids": [1.5, 2.7, 3.9], "outputFields": ["*"], "limit": 10}
         rsp = self.vector_client.vector_search(payload)
 
-        assert rsp['code'] == 1100
+        assert rsp["code"] == 1100
 
     def test_search_by_pk_with_invalid_id_type(self):
         """
@@ -5200,15 +5729,10 @@ class TestSearchByPKNegative(TestBase):
         nb = default_nb
         self.init_collection(name, dim=dim, nb=nb)
 
-        payload = {
-            "collectionName": name,
-            "ids": [True, False],
-            "outputFields": ["*"],
-            "limit": 10
-        }
+        payload = {"collectionName": name, "ids": [True, False], "outputFields": ["*"], "limit": 10}
         rsp = self.vector_client.vector_search(payload)
 
-        assert rsp['code'] == 1100
+        assert rsp["code"] == 1100
 
     def test_search_by_pk_with_unparseable_string_ids(self):
         """
@@ -5220,15 +5744,10 @@ class TestSearchByPKNegative(TestBase):
         nb = default_nb
         self.init_collection(name, dim=dim, nb=nb)
 
-        payload = {
-            "collectionName": name,
-            "ids": ["abc", "def", "ghi"],
-            "outputFields": ["*"],
-            "limit": 10
-        }
+        payload = {"collectionName": name, "ids": ["abc", "def", "ghi"], "outputFields": ["*"], "limit": 10}
         rsp = self.vector_client.vector_search(payload)
 
-        assert rsp['code'] == 1100
+        assert rsp["code"] == 1100
 
     def test_search_by_pk_varchar_with_empty_string(self):
         """
@@ -5245,38 +5764,36 @@ class TestSearchByPKNegative(TestBase):
                 "autoId": False,
                 "enableDynamicField": True,
                 "fields": [
-                    {"fieldName": "pk", "dataType": "VarChar", "isPrimary": True,
-                     "elementTypeParams": {"max_length": "128"}},
+                    {
+                        "fieldName": "pk",
+                        "dataType": "VarChar",
+                        "isPrimary": True,
+                        "elementTypeParams": {"max_length": "128"},
+                    },
                     {"fieldName": "uid", "dataType": "Int64", "elementTypeParams": {}},
-                    {"fieldName": "vector", "dataType": "FloatVector",
-                     "elementTypeParams": {"dim": str(dim)}},
-                ]
+                    {"fieldName": "vector", "dataType": "FloatVector", "elementTypeParams": {"dim": str(dim)}},
+                ],
             },
-            "indexParams": [
-                {"fieldName": "vector", "indexName": "vector", "metricType": "L2"}
-            ]
+            "indexParams": [{"fieldName": "vector", "indexName": "vector", "metricType": "L2"}],
         }
         rsp = self.collection_client.collection_create(payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
         self.wait_collection_load_completed(name)
 
         # Insert some data
-        data = [{
-            "pk": "valid_pk",
-            "uid": 1,
-            "vector": gen_vector(datatype="FloatVector", dim=dim),
-        }]
+        data = [
+            {
+                "pk": "valid_pk",
+                "uid": 1,
+                "vector": gen_vector(datatype="FloatVector", dim=dim),
+            }
+        ]
         insert_payload = {"collectionName": name, "data": data}
         rsp = self.vector_client.vector_insert(insert_payload)
-        assert rsp['code'] == 0
+        assert rsp["code"] == 0
 
         # Search with empty string
-        search_payload = {
-            "collectionName": name,
-            "ids": [""],
-            "outputFields": ["*"],
-            "limit": 10
-        }
+        search_payload = {"collectionName": name, "ids": [""], "outputFields": ["*"], "limit": 10}
         rsp = self.vector_client.vector_search(search_payload)
 
-        assert rsp['code'] == 1100
+        assert rsp["code"] == 1100


### PR DESCRIPTION
## What changed

- Add Python client, RESTful v2, and Go SDK regression coverage for hybrid search on collections with `partitionkey.isolation=true`.
- Verify normal search still rejects unsupported partition-key isolation filters:
  - `tenant in ["tenant_a", "tenant_b"]`
  - missing tenant filter
- Keep the current hybrid search server bug as conditional xfail/skip, so baseline search regressions are not hidden.
- Add RESTful v2 coverage for MinHash + dense hybrid search with explicit `partitionNames`.

## Issues

Related to #50398
Related to #50396

## Verification

- `ruff check ../tests/python_client/milvus_client/test_milvus_client_partition_key_isolation.py ../tests/restful_client_v2/testcases/test_vector_operations.py`
- `python -m py_compile tests/python_client/milvus_client/test_milvus_client_partition_key_isolation.py tests/restful_client_v2/testcases/test_vector_operations.py`
- `git diff --check`
- Python client 50398 case against `10.104.18.101`: `1 xfailed`
- RESTful v2 50398 case against `10.104.18.101`: `1 xfailed`
- Go SDK 50398 case against `10.104.18.101`: reproduces current bug and conditionally skips