### PR TITLE
test: Adjust standalone helm test resources

### DIFF
--- a/tests/_helm/values/e2e-amd/standalone
+++ b/tests/_helm/values/e2e-amd/standalone
@@ -27,11 +27,11 @@ standalone:
     enabled: true
   resources:
     limits:
-      cpu: "6"
-      memory: 12Gi
+      cpu: "8"
+      memory: 16Gi
     requests:
-      cpu: "3"
-      memory: 6Gi
+      cpu: "2"
+      memory: 8Gi
 log:
   level: debug
 extraConfigFiles:

--- a/tests/_helm/values/e2e-amd/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-amd/standalone-kafka-mmap
@@ -25,11 +25,11 @@ standalone:
     enabled: true
   resources:
     limits:
-      cpu: "6"
-      memory: 12Gi
+      cpu: "8"
+      memory: 16Gi
     requests:
       cpu: "2"
-      memory: 4Gi
+      memory: 8Gi
 log:
   level: debug
 extraConfigFiles:

--- a/tests/_helm/values/e2e-amd/standalone-one-pod
+++ b/tests/_helm/values/e2e-amd/standalone-one-pod
@@ -79,6 +79,13 @@ service:
 standalone:
   disk:
     enabled: true
+  resources:
+    limits:
+      cpu: "8"
+      memory: 16Gi
+    requests:
+      cpu: "2"
+      memory: 8Gi
   extraEnv:
   - name: ETCD_CONFIG_PATH
     value: /milvus/configs/advanced/etcd.yaml

--- a/tests/_helm/values/e2e-arm/standalone
+++ b/tests/_helm/values/e2e-arm/standalone
@@ -14,11 +14,11 @@ standalone:
     enabled: true
   resources:
     limits:
-      cpu: "4"
+      cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "1"
-      memory: 3.5Gi
+      cpu: "2"
+      memory: 8Gi
 log:
   level: debug
 extraConfigFiles:

--- a/tests/_helm/values/e2e-arm/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-arm/standalone-kafka-mmap
@@ -12,11 +12,11 @@ standalone:
     enabled: true
   resources:
     limits:
-      cpu: "4"
+      cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "1"
-      memory: 3.5Gi
+      cpu: "2"
+      memory: 8Gi
 log:
   level: debug
 extraConfigFiles:

--- a/tests/_helm/values/e2e-arm/standalone-one-pod
+++ b/tests/_helm/values/e2e-arm/standalone-one-pod
@@ -62,6 +62,13 @@ service:
 standalone:
   disk:
     enabled: true
+  resources:
+    limits:
+      cpu: "8"
+      memory: 16Gi
+    requests:
+      cpu: "2"
+      memory: 8Gi
   extraEnv:
   - name: ETCD_CONFIG_PATH
     value: /milvus/configs/advanced/etcd.yaml

--- a/tests/_helm/values/e2e/standalone
+++ b/tests/_helm/values/e2e/standalone
@@ -27,11 +27,11 @@ standalone:
     enabled: true
   resources:
     limits:
-      cpu: "4"
+      cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "1"
-      memory: 3.5Gi
+      cpu: "2"
+      memory: 8Gi
 log:
   level: debug
 extraConfigFiles:

--- a/tests/_helm/values/e2e/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e/standalone-kafka-mmap
@@ -25,11 +25,11 @@ standalone:
     enabled: true
   resources:
     limits:
-      cpu: "4"
+      cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "1"
-      memory: 3.5Gi
+      cpu: "2"
+      memory: 8Gi
 log:
   level: debug
 extraConfigFiles:

--- a/tests/_helm/values/e2e/standalone-one-pod
+++ b/tests/_helm/values/e2e/standalone-one-pod
@@ -79,6 +79,13 @@ service:
 standalone:
   disk:
     enabled: true
+  resources:
+    limits:
+      cpu: "8"
+      memory: 16Gi
+    requests:
+      cpu: "2"
+      memory: 8Gi
   extraEnv:
   - name: ETCD_CONFIG_PATH
     value: /milvus/configs/advanced/etcd.yaml

--- a/tests/_helm/values/nightly/standalone-authentication-mmap
+++ b/tests/_helm/values/nightly/standalone-authentication-mmap
@@ -27,11 +27,11 @@ standalone:
     enabled: true
   resources:
     limits:
-      cpu: "4"
+      cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "1"
-      memory: 3.5Gi
+      cpu: "2"
+      memory: 8Gi
 log:
   level: debug
 extraConfigFiles:

--- a/tests/_helm/values/nightly/standalone-one-pod
+++ b/tests/_helm/values/nightly/standalone-one-pod
@@ -104,6 +104,13 @@ service:
 standalone:
   disk:
     enabled: true
+  resources:
+    limits:
+      cpu: "8"
+      memory: 16Gi
+    requests:
+      cpu: "2"
+      memory: 8Gi
   extraEnv:
   - name: ETCD_CONFIG_PATH
     value: /milvus/configs/advanced/etcd.yaml


### PR DESCRIPTION
## What
- Set standalone Helm test resource requests to 2 CPU / 8Gi memory.
- Set standalone Helm test resource limits to 8 CPU / 16Gi memory.
- Add the same standalone resources to one-pod values that previously omitted them.

## Related
Related #50384

## Verification
- ruby -ryaml validation for all 11 standalone values files
- git diff --check HEAD~1..HEAD