### PR TITLE
fix: [cp2.6]Restrict Kafka chaos selectors to broker pods

### DIFF
--- a/tests/python_client/chaos/chaos_objects/container_kill/chaos_kafka_container_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/container_kill/chaos_kafka_container_kill.yaml
@@ -16,6 +16,7 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: kafka
+        app.kubernetes.io/component: kafka
     mode: fixed
     value: "1"
     action: container-kill

--- a/tests/python_client/chaos/chaos_objects/pod_failure/chaos_kafka_pod_failure.yaml
+++ b/tests/python_client/chaos/chaos_objects/pod_failure/chaos_kafka_pod_failure.yaml
@@ -9,7 +9,7 @@ spec:
       - chaos-testing
     labelSelectors:
       app.kubernetes.io/instance: milvus-chaos
-      component: kafka
+      app.kubernetes.io/component: kafka
   mode: fixed
   value: "1"
   action: pod-failure

--- a/tests/python_client/chaos/chaos_objects/pod_kill/chaos_kafka_pod_kill.yaml
+++ b/tests/python_client/chaos/chaos_objects/pod_kill/chaos_kafka_pod_kill.yaml
@@ -16,6 +16,7 @@ spec:
       labelSelectors:
         app.kubernetes.io/instance: milvus-chaos
         app.kubernetes.io/name: kafka
+        app.kubernetes.io/component: kafka
     mode: fixed
     value: "1"
     action: pod-kill


### PR DESCRIPTION
pr: #50380

This cherry-picks #50380 to 2.6.

Changes:
- Restrict Kafka chaos selectors to broker pods with app.kubernetes.io/component: kafka.
- Keep Kafka pod kill/failure/container kill chaos targets consistent with master.