### PR TITLE
test: align python client expectations with current API responses

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_collection.py
+++ b/tests/python_client/milvus_client/test_milvus_client_collection.py
@@ -4260,7 +4260,7 @@ class TestMilvusClientDescribeCollectionValid(TestMilvusClientV2Base):
             "aliases": [],
             "consistency_level": 0,
             "consistency_level_name": "Strong",
-            "properties": {"timezone": "UTC"},
+            "properties": {"timezone": "UTC", "max_field_id": "102"},
             "num_partitions": 1,
             "enable_dynamic_field": True,
             "enable_namespace": False,

--- a/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
@@ -1154,7 +1154,7 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
         """
         target: clarify search_aggregation metric/order compatibility with dynamic fields.
         method: aggregate by a static scalar field, compute sum(dynamic_price), and order by that metric alias.
-        expected: request is rejected because dynamic metric sources have no resolved scalar type.
+        expected: request is rejected because JSON / dynamic metric fields are not yet supported with search_aggregation.
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -1162,7 +1162,7 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
             client, collection_name
         )
 
-        error = {ct.err_code: 999, ct.err_msg: "aggregation operator sum does not support data type None"}
+        error = {ct.err_code: 999, ct.err_msg: "JSON / dynamic fields are not yet supported with search_aggregation"}
         self.search(
             client,
             collection_name,
@@ -1299,7 +1299,8 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
             client, collection_name
         )
 
-        metric_error = {ct.err_code: 999, ct.err_msg: "aggregation operator sum does not support data type JSON"}
+        metric_error = {ct.err_code: 999,
+                        ct.err_msg: "JSON / dynamic fields are not yet supported with search_aggregation"}
         self.search(
             client,
             collection_name,

--- a/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
@@ -1299,8 +1299,10 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
             client, collection_name
         )
 
-        metric_error = {ct.err_code: 999,
-                        ct.err_msg: "JSON / dynamic fields are not yet supported with search_aggregation"}
+        metric_error = {
+            ct.err_code: 999,
+            ct.err_msg: "JSON / dynamic fields are not yet supported with search_aggregation",
+        }
         self.search(
             client,
             collection_name,


### PR DESCRIPTION
## Summary
- update `test_milvus_client_collection_describe` to expect `properties.max_field_id` in `describe_collection`
- align `search_aggregation` JSON/dynamic field rejection cases with the current server error messages
- keep the affected Python client regressions covered without asserting outdated responses

## Test plan
- [x] `python3 -m py_compile tests/python_client/milvus_client/test_milvus_client_collection.py tests/python_client/milvus_client/test_milvus_client_search_aggregation.py`
- [ ] full pytest execution was not run locally in this submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)