### PR TITLE
test: [skip e2e] Increase standalone CPU requests in helm test values

### DIFF
--- a/tests/_helm/values/e2e-amd/standalone
+++ b/tests/_helm/values/e2e-amd/standalone
@@ -30,7 +30,7 @@ standalone:
       cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "2"
+      cpu: "3"
       memory: 8Gi
 log:
   level: debug

--- a/tests/_helm/values/e2e-amd/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-amd/standalone-kafka-mmap
@@ -28,7 +28,7 @@ standalone:
       cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "2"
+      cpu: "3"
       memory: 8Gi
 log:
   level: debug

--- a/tests/_helm/values/e2e-amd/standalone-one-pod
+++ b/tests/_helm/values/e2e-amd/standalone-one-pod
@@ -84,7 +84,7 @@ standalone:
       cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "2"
+      cpu: "3"
       memory: 8Gi
   extraEnv:
   - name: ETCD_CONFIG_PATH

--- a/tests/_helm/values/e2e-arm/standalone
+++ b/tests/_helm/values/e2e-arm/standalone
@@ -17,7 +17,7 @@ standalone:
       cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "2"
+      cpu: "3"
       memory: 8Gi
 log:
   level: debug

--- a/tests/_helm/values/e2e-arm/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e-arm/standalone-kafka-mmap
@@ -15,7 +15,7 @@ standalone:
       cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "2"
+      cpu: "3"
       memory: 8Gi
 log:
   level: debug

--- a/tests/_helm/values/e2e-arm/standalone-one-pod
+++ b/tests/_helm/values/e2e-arm/standalone-one-pod
@@ -67,7 +67,7 @@ standalone:
       cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "2"
+      cpu: "3"
       memory: 8Gi
   extraEnv:
   - name: ETCD_CONFIG_PATH

--- a/tests/_helm/values/e2e/standalone
+++ b/tests/_helm/values/e2e/standalone
@@ -30,7 +30,7 @@ standalone:
       cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "2"
+      cpu: "3"
       memory: 8Gi
 log:
   level: debug

--- a/tests/_helm/values/e2e/standalone-kafka-mmap
+++ b/tests/_helm/values/e2e/standalone-kafka-mmap
@@ -28,7 +28,7 @@ standalone:
       cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "2"
+      cpu: "3"
       memory: 8Gi
 log:
   level: debug

--- a/tests/_helm/values/e2e/standalone-one-pod
+++ b/tests/_helm/values/e2e/standalone-one-pod
@@ -84,7 +84,7 @@ standalone:
       cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "2"
+      cpu: "3"
       memory: 8Gi
   extraEnv:
   - name: ETCD_CONFIG_PATH

--- a/tests/_helm/values/nightly/standalone-authentication-mmap
+++ b/tests/_helm/values/nightly/standalone-authentication-mmap
@@ -30,7 +30,7 @@ standalone:
       cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "2"
+      cpu: "3"
       memory: 8Gi
 log:
   level: debug

--- a/tests/_helm/values/nightly/standalone-one-pod
+++ b/tests/_helm/values/nightly/standalone-one-pod
@@ -109,7 +109,7 @@ standalone:
       cpu: "8"
       memory: 16Gi
     requests:
-      cpu: "2"
+      cpu: "3"
       memory: 8Gi
   extraEnv:
   - name: ETCD_CONFIG_PATH


### PR DESCRIPTION
Related to #50384

This increases standalone Milvus CPU requests from 2 cores to 3 cores in E2E and nightly standalone Helm values.

On the Go SDK ARM CI nodes, allocatable CPU is about 7.91 cores. With a 2-core request, three standalone Milvus pods can be scheduled onto the same 8-core node while each pod can burst up to an 8-core limit. Raising the request to 3 cores prevents three standalone pods from fitting on one node and reduces CPU contention during index build / snapshot restore heavy tests.

Validation:
- `git diff --check origin/master..HEAD`
- Parsed all updated YAML values with Ruby `YAML.load_file`
- Confirmed all updated standalone CPU requests are `"3"`