### PR TITLE
fix: [3.0] Support byte vector output through external take

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -19,6 +19,7 @@
 #include <simdjson.h>
 #include <algorithm>
 #include <chrono>
+#include <cstring>
 #include <cstdint>
 #include <ctime>
 #include <exception>
@@ -5343,6 +5344,72 @@ ChunkedSegmentSealedImpl::ArrowToDataArray(
                           floats + dim,
                           float_data->mutable_data()->mutable_data() +
                               data_pos * dim);
+                data_pos++;
+            }
+            break;
+        }
+        case DataType::VECTOR_BINARY:
+        case DataType::VECTOR_FLOAT16:
+        case DataType::VECTOR_BFLOAT16:
+        case DataType::VECTOR_INT8: {
+            int dim = field_meta.get_dim();
+            auto byte_width = field_meta.get_sizeof();
+            auto vectors = data_array->mutable_vectors();
+            vectors->set_dim(dim);
+            std::string* vector_data = nullptr;
+            switch (field_meta.get_data_type()) {
+                case DataType::VECTOR_BINARY:
+                    vector_data = vectors->mutable_binary_vector();
+                    break;
+                case DataType::VECTOR_FLOAT16:
+                    vector_data = vectors->mutable_float16_vector();
+                    break;
+                case DataType::VECTOR_BFLOAT16:
+                    vector_data = vectors->mutable_bfloat16_vector();
+                    break;
+                case DataType::VECTOR_INT8:
+                    vector_data = vectors->mutable_int8_vector();
+                    break;
+                default:
+                    break;
+            }
+
+            int64_t valid_count = size;
+            if (field_meta.is_nullable()) {
+                valid_count = 0;
+                for (int64_t i = 0; i < size; i++) {
+                    if (arr->IsValid(result_mapping[i])) {
+                        valid_count++;
+                    }
+                }
+            }
+            vector_data->resize(valid_count * byte_width);
+            int64_t data_pos = 0;
+            for (int64_t i = 0; i < size; i++) {
+                auto idx = result_mapping[i];
+                if (arr->IsNull(idx)) {
+                    continue;
+                }
+                const uint8_t* val = nullptr;
+                if (arr->type_id() == arrow::Type::FIXED_SIZE_BINARY) {
+                    val = std::static_pointer_cast<arrow::FixedSizeBinaryArray>(
+                              arr)
+                              ->Value(idx);
+                } else {
+                    auto bin_val =
+                        std::static_pointer_cast<arrow::BinaryArray>(arr)
+                            ->Value(idx);
+                    AssertInfo(
+                        static_cast<int64_t>(bin_val.size()) == byte_width,
+                        "vector byte width mismatch, expected {}, "
+                        "actual {}",
+                        byte_width,
+                        bin_val.size());
+                    val = reinterpret_cast<const uint8_t*>(bin_val.data());
+                }
+                std::memcpy(vector_data->data() + data_pos * byte_width,
+                            val,
+                            byte_width);
                 data_pos++;
             }
             break;

--- a/internal/core/src/segcore/Utils.cpp
+++ b/internal/core/src/segcore/Utils.cpp
@@ -851,13 +851,13 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
             } else if (field_meta.get_data_type() == DataType::VECTOR_FLOAT16) {
                 auto data = VEC_FIELD_DATA(src_field_data, float16);
                 auto obj = vector_array->mutable_float16_vector();
-                obj->assign(data + physical_offset * dim * sizeof(float16),
+                obj->append(data + physical_offset * dim * sizeof(float16),
                             dim * sizeof(float16));
             } else if (field_meta.get_data_type() ==
                        DataType::VECTOR_BFLOAT16) {
                 auto data = VEC_FIELD_DATA(src_field_data, bfloat16);
                 auto obj = vector_array->mutable_bfloat16_vector();
-                obj->assign(data + physical_offset * dim * sizeof(bfloat16),
+                obj->append(data + physical_offset * dim * sizeof(bfloat16),
                             dim * sizeof(bfloat16));
             } else if (field_meta.get_data_type() == DataType::VECTOR_BINARY) {
                 AssertInfo(
@@ -866,7 +866,7 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
                 auto num_bytes = dim / 8;
                 auto data = VEC_FIELD_DATA(src_field_data, binary);
                 auto obj = vector_array->mutable_binary_vector();
-                obj->assign(data + physical_offset * num_bytes, num_bytes);
+                obj->append(data + physical_offset * num_bytes, num_bytes);
             } else if (field_meta.get_data_type() ==
                        DataType::VECTOR_SPARSE_U32_F32) {
                 auto* mutable_src_vec = src_field_data->mutable_vectors()
@@ -882,7 +882,7 @@ MergeDataArray(std::vector<MergeBase>& merge_bases,
             } else if (field_meta.get_data_type() == DataType::VECTOR_INT8) {
                 auto data = VEC_FIELD_DATA(src_field_data, int8);
                 auto obj = vector_array->mutable_int8_vector();
-                obj->assign(data + physical_offset * dim * sizeof(int8),
+                obj->append(data + physical_offset * dim * sizeof(int8),
                             dim * sizeof(int8));
             } else if (field_meta.get_data_type() == DataType::VECTOR_ARRAY) {
                 auto& data = src_field_data->vectors().vector_array();

--- a/internal/core/src/segcore/UtilsTest.cpp
+++ b/internal/core/src/segcore/UtilsTest.cpp
@@ -11,6 +11,7 @@
 
 #include <folly/CancellationToken.h>
 #include <folly/FBVector.h>
+#include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -198,6 +199,94 @@ TEST(Util_Segcore, MergeDataArrayWithNullableVectors) {
     ASSERT_TRUE(merged_result->valid_data(2));
     ASSERT_TRUE(merged_result->valid_data(3));
     ASSERT_TRUE(merged_result->valid_data(4));
+}
+
+TEST(Util_Segcore, MergeDataArrayWithNullableByteVectorsAppendsRows) {
+    using namespace milvus;
+    using namespace milvus::segcore;
+
+    struct TestCase {
+        DataType data_type;
+        int64_t dim;
+        std::string metric_type;
+        int64_t bytes_per_row;
+    };
+
+    std::vector<TestCase> test_cases = {
+        {DataType::VECTOR_BINARY, 16, knowhere::metric::HAMMING, 2},
+        {DataType::VECTOR_FLOAT16, 2, knowhere::metric::L2, 4},
+        {DataType::VECTOR_BFLOAT16, 2, knowhere::metric::L2, 4},
+        {DataType::VECTOR_INT8, 3, knowhere::metric::L2, 3},
+    };
+
+    for (const auto& test_case : test_cases) {
+        SCOPED_TRACE(fmt::format("data_type={}", test_case.data_type));
+
+        auto schema = std::make_shared<Schema>();
+        auto vec = schema->AddDebugField("embeddings",
+                                         test_case.data_type,
+                                         test_case.dim,
+                                         test_case.metric_type,
+                                         true);
+        auto& field_meta = (*schema)[vec];
+
+        constexpr int64_t total_count = 4;
+        constexpr int64_t valid_count = 3;
+        std::array<bool, total_count> valid_flags = {true, false, true, true};
+
+        std::string compact_data(valid_count * test_case.bytes_per_row, '\0');
+        for (size_t i = 0; i < compact_data.size(); ++i) {
+            compact_data[i] = static_cast<char>(i + 1);
+        }
+
+        auto data_array = CreateVectorDataArrayFrom(compact_data.data(),
+                                                    valid_flags.data(),
+                                                    total_count,
+                                                    valid_count,
+                                                    field_meta);
+
+        std::map<FieldId, std::unique_ptr<milvus::DataArray>>
+            output_fields_data;
+        output_fields_data[vec] = std::move(data_array);
+
+        std::vector<MergeBase> merge_bases;
+        std::array<size_t, total_count> physical_offsets = {0, 0, 1, 2};
+        for (size_t i = 0; i < total_count; ++i) {
+            merge_bases.emplace_back(&output_fields_data, i);
+            if (valid_flags[i]) {
+                merge_bases.back().setValidDataOffset(vec, physical_offsets[i]);
+            }
+        }
+
+        auto merged_result = MergeDataArray(merge_bases, field_meta);
+
+        ASSERT_EQ(merged_result->valid_data().size(), total_count);
+        EXPECT_TRUE(merged_result->valid_data(0));
+        EXPECT_FALSE(merged_result->valid_data(1));
+        EXPECT_TRUE(merged_result->valid_data(2));
+        EXPECT_TRUE(merged_result->valid_data(3));
+
+        std::string actual;
+        switch (test_case.data_type) {
+            case DataType::VECTOR_BINARY:
+                actual = merged_result->vectors().binary_vector();
+                break;
+            case DataType::VECTOR_FLOAT16:
+                actual = merged_result->vectors().float16_vector();
+                break;
+            case DataType::VECTOR_BFLOAT16:
+                actual = merged_result->vectors().bfloat16_vector();
+                break;
+            case DataType::VECTOR_INT8:
+                actual = merged_result->vectors().int8_vector();
+                break;
+            default:
+                ThrowInfo(DataTypeInvalid, "unexpected test vector type");
+        }
+
+        ASSERT_EQ(actual.size(), compact_data.size());
+        EXPECT_EQ(actual, compact_data);
+    }
 }
 
 // Tests for CheckCancellation utility function

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -48,6 +48,11 @@ namespace {
 constexpr int64_t kTestRows = 5;
 constexpr int64_t kVecDim = 4;
 
+ChunkedSegmentSealedImpl*
+CreateExternalSegment(SegmentSealedUPtr& holder,
+                      const SchemaPtr& schema,
+                      int64_t segment_id);
+
 // Mock Reader that returns a pre-built Arrow Table from take().
 class MockTakeReader : public milvus_storage::api::Reader {
  public:
@@ -230,6 +235,187 @@ BuildNullableVectorArrowTable() {
         arrow::field("vec_col", fsb_type),
     });
     return arrow::Table::Make(schema, {vec_arr});
+}
+
+struct ExternalNullableVectorSchema {
+    SchemaPtr schema;
+    FieldId pk_id;
+    FieldId vec_id;
+    DataType data_type;
+    int64_t dim;
+};
+
+ExternalNullableVectorSchema
+BuildExternalNullableVectorSchema(DataType data_type, int64_t dim) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddField(
+        FieldName("RowID"), RowFieldID, DataType::INT64, false, std::nullopt);
+    schema->AddField(FieldName("Timestamp"),
+                     TimestampFieldID,
+                     DataType::INT64,
+                     false,
+                     std::nullopt);
+
+    ExternalNullableVectorSchema info;
+    info.pk_id = FieldId(100);
+    info.vec_id = FieldId(101);
+    info.data_type = data_type;
+    info.dim = dim;
+
+    schema->AddField(FieldMeta(FieldName("pk"),
+                               info.pk_id,
+                               DataType::INT64,
+                               false,
+                               std::nullopt,
+                               "pk"));
+
+    auto metric_type = data_type == DataType::VECTOR_BINARY
+                           ? knowhere::metric::JACCARD
+                           : knowhere::metric::L2;
+    schema->AddField(FieldMeta(FieldName("vec_col"),
+                               info.vec_id,
+                               data_type,
+                               dim,
+                               metric_type,
+                               true,
+                               std::nullopt,
+                               "vec_col"));
+
+    schema->set_primary_field_id(info.pk_id);
+    schema->set_external_source("s3://test-bucket/data");
+    schema->set_external_spec(R"({"format":"parquet"})");
+    info.schema = schema;
+    return info;
+}
+
+int64_t
+DenseVectorByteWidth(DataType data_type, int64_t dim) {
+    switch (data_type) {
+        case DataType::VECTOR_BINARY:
+            return (dim + 7) / 8;
+        case DataType::VECTOR_FLOAT16:
+        case DataType::VECTOR_BFLOAT16:
+            return dim * 2;
+        case DataType::VECTOR_INT8:
+            return dim;
+        default:
+            return dim * sizeof(float);
+    }
+}
+
+std::string
+MakeBytes(int64_t byte_width, uint8_t start) {
+    std::string bytes;
+    bytes.resize(byte_width);
+    for (int64_t i = 0; i < byte_width; ++i) {
+        bytes[i] = static_cast<char>(start + i);
+    }
+    return bytes;
+}
+
+std::shared_ptr<arrow::Table>
+BuildNullableDenseVectorArrowTable(DataType data_type, int64_t dim) {
+    auto byte_width = DenseVectorByteWidth(data_type, dim);
+    auto fsb_type = arrow::fixed_size_binary(byte_width);
+    arrow::FixedSizeBinaryBuilder builder(fsb_type);
+    auto row0 = MakeBytes(byte_width, 1);
+    auto row2 = MakeBytes(byte_width, 101);
+    EXPECT_TRUE(
+        builder.Append(reinterpret_cast<const uint8_t*>(row0.data())).ok());
+    EXPECT_TRUE(builder.AppendNull().ok());
+    EXPECT_TRUE(
+        builder.Append(reinterpret_cast<const uint8_t*>(row2.data())).ok());
+    auto vec_arr = builder.Finish().ValueOrDie();
+
+    auto schema = arrow::schema({
+        arrow::field("vec_col", fsb_type),
+    });
+    return arrow::Table::Make(schema, {vec_arr});
+}
+
+void
+AssertNullableDenseVectorTake(DataType data_type, int64_t dim) {
+    auto info = BuildExternalNullableVectorSchema(data_type, dim);
+    auto table = BuildNullableDenseVectorArrowTable(data_type, dim);
+    auto byte_width = DenseVectorByteWidth(data_type, dim);
+    auto row0 = MakeBytes(byte_width, 1);
+    auto row2 = MakeBytes(byte_width, 101);
+    auto expected = row0 + row2;
+
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema, 1);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::RetrievePlan>(info.schema);
+    plan->field_ids_ = {info.vec_id};
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 1, 2};
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), offsets.size(), false, false);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(results->fields_data_size(), 1);
+
+    const auto& retrieved = results->fields_data(0);
+    ASSERT_EQ(retrieved.valid_data_size(), 3);
+    EXPECT_TRUE(retrieved.valid_data(0));
+    EXPECT_FALSE(retrieved.valid_data(1));
+    EXPECT_TRUE(retrieved.valid_data(2));
+    ASSERT_EQ(retrieved.vectors().dim(), dim);
+
+    std::string actual;
+    switch (data_type) {
+        case DataType::VECTOR_BINARY:
+            actual = retrieved.vectors().binary_vector();
+            break;
+        case DataType::VECTOR_FLOAT16:
+            actual = retrieved.vectors().float16_vector();
+            break;
+        case DataType::VECTOR_BFLOAT16:
+            actual = retrieved.vectors().bfloat16_vector();
+            break;
+        case DataType::VECTOR_INT8:
+            actual = retrieved.vectors().int8_vector();
+            break;
+        default:
+            FAIL() << "unsupported dense vector type";
+    }
+    ASSERT_EQ(actual.size(), expected.size());
+    EXPECT_EQ(actual, expected);
+
+    SearchResult search_results;
+    search_results.seg_offsets_ = offsets;
+    search_results.distances_.resize(offsets.size());
+    auto search_plan = std::make_unique<query::Plan>(info.schema);
+    search_plan->target_entries_ = {info.vec_id};
+    ok = segment->TestTryTakeForSearch(
+        search_plan.get(), offsets.data(), offsets.size(), search_results);
+    ASSERT_TRUE(ok);
+    auto searched = search_results.output_fields_data_.at(info.vec_id).get();
+    ASSERT_EQ(searched->valid_data_size(), 3);
+    EXPECT_TRUE(searched->valid_data(0));
+    EXPECT_FALSE(searched->valid_data(1));
+    EXPECT_TRUE(searched->valid_data(2));
+    ASSERT_EQ(searched->vectors().dim(), dim);
+
+    switch (data_type) {
+        case DataType::VECTOR_BINARY:
+            actual = searched->vectors().binary_vector();
+            break;
+        case DataType::VECTOR_FLOAT16:
+            actual = searched->vectors().float16_vector();
+            break;
+        case DataType::VECTOR_BFLOAT16:
+            actual = searched->vectors().bfloat16_vector();
+            break;
+        case DataType::VECTOR_INT8:
+            actual = searched->vectors().int8_vector();
+            break;
+        default:
+            FAIL() << "unsupported dense vector type";
+    }
+    ASSERT_EQ(actual.size(), expected.size());
+    EXPECT_EQ(actual, expected);
 }
 
 // Build an external schema with all supported types.
@@ -809,6 +995,22 @@ TEST(ExternalTakeTest, TryTakeForSearch_NullableVectorUsesCompactData) {
     EXPECT_FLOAT_EQ(fv.data(5), 9.0f);
     EXPECT_FLOAT_EQ(fv.data(6), 10.0f);
     EXPECT_FLOAT_EQ(fv.data(7), 11.0f);
+}
+
+TEST(ExternalTakeTest, NullableBinaryVectorTakeUsesCompactData) {
+    AssertNullableDenseVectorTake(DataType::VECTOR_BINARY, 16);
+}
+
+TEST(ExternalTakeTest, NullableFloat16VectorTakeUsesCompactData) {
+    AssertNullableDenseVectorTake(DataType::VECTOR_FLOAT16, 4);
+}
+
+TEST(ExternalTakeTest, NullableBFloat16VectorTakeUsesCompactData) {
+    AssertNullableDenseVectorTake(DataType::VECTOR_BFLOAT16, 4);
+}
+
+TEST(ExternalTakeTest, NullableInt8VectorTakeUsesCompactData) {
+    AssertNullableDenseVectorTake(DataType::VECTOR_INT8, 4);
 }
 
 // Test fallback: returns false for non-external collection

--- a/tests/go_client/testcases/external_table_refresh_test.go
+++ b/tests/go_client/testcases/external_table_refresh_test.go
@@ -23,6 +23,7 @@ import (
 	miniocreds "github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/stretchr/testify/require"
 
+	"github.com/milvus-io/milvus/client/v2/column"
 	"github.com/milvus-io/milvus/client/v2/entity"
 	"github.com/milvus-io/milvus/client/v2/index"
 	client "github.com/milvus-io/milvus/client/v2/milvusclient"
@@ -207,6 +208,61 @@ func generateNullableFloatVectorParquetBytes() ([]byte, error) {
 	embeddingBuilder.AppendNull()
 	idBuilder.Append(2)
 	appendVector([]float32{8, 9, 10, 11})
+
+	record := builder.NewRecord()
+	defer record.Release()
+
+	if err := writer.Write(record); err != nil {
+		return nil, fmt.Errorf("write record: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("close writer: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func generateFloat16TakeParquetBytes(numRows int64, startID int64) ([]byte, error) {
+	arrowSchema := arrow.NewSchema(
+		[]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "embedding", Type: &arrow.FixedSizeBinaryType{ByteWidth: testVecDim * 4}},
+			{Name: "fp16_vec", Type: &arrow.FixedSizeBinaryType{ByteWidth: testVecDim * 2}},
+		},
+		nil,
+	)
+
+	var buf bytes.Buffer
+	writer, err := pqarrow.NewFileWriter(arrowSchema, &buf, nil, pqarrow.DefaultWriterProps())
+	if err != nil {
+		return nil, fmt.Errorf("create parquet writer: %w", err)
+	}
+
+	pool := memory.NewGoAllocator()
+	builder := array.NewRecordBuilder(pool, arrowSchema)
+	defer builder.Release()
+
+	idBuilder := builder.Field(0).(*array.Int64Builder)
+	embeddingBuilder := builder.Field(1).(*array.FixedSizeBinaryBuilder)
+	fp16VecBuilder := builder.Field(2).(*array.FixedSizeBinaryBuilder)
+
+	for i := int64(0); i < numRows; i++ {
+		idx := startID + i
+		idBuilder.Append(idx)
+
+		embeddingBytes := make([]byte, testVecDim*4)
+		for d := 0; d < testVecDim; d++ {
+			value := float32(idx)*0.1 + float32(d)
+			binary.LittleEndian.PutUint32(embeddingBytes[d*4:(d+1)*4], math.Float32bits(value))
+		}
+		embeddingBuilder.Append(embeddingBytes)
+
+		fp16Bytes := make([]byte, testVecDim*2)
+		for b := range fp16Bytes {
+			fp16Bytes[b] = byte((idx + int64(b)) % 256)
+		}
+		fp16VecBuilder.Append(fp16Bytes)
+	}
 
 	record := builder.NewRecord()
 	defer record.Release()
@@ -1168,6 +1224,117 @@ func TestExternalCollectionNullableFloatVectorTakeOutput(t *testing.T) {
 	assertVector(0, []float32{0, 1, 2, 3})
 	require.True(t, rows[1].isNull, "embedding should be null for id=1")
 	assertVector(2, []float32{8, 9, 10, 11})
+}
+
+func TestExternalCollectionFloat16VectorTakeOutput(t *testing.T) {
+	t.Parallel()
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	minioCfg := getMinIOConfig()
+	minioClient, err := newMinIOClient(minioCfg)
+	require.NoError(t, err)
+
+	exists, err := minioClient.BucketExists(ctx, minioCfg.bucket)
+	if err != nil || !exists {
+		t.Skipf("MinIO bucket %q not accessible (exists=%v, err=%v), skipping",
+			minioCfg.bucket, exists, err)
+	}
+
+	collName := common.GenRandomString("ext_fp16_take", 6)
+	extPath := fmt.Sprintf("external-e2e-test/%s", collName)
+
+	data, err := generateFloat16TakeParquetBytes(64, 0)
+	require.NoError(t, err, "generate fp16 take parquet")
+
+	objectKey := fmt.Sprintf("%s/data.parquet", extPath)
+	uploadParquetToMinIO(ctx, t, minioClient, minioCfg.bucket, objectKey, data)
+
+	t.Cleanup(func() {
+		cleanupMinIOPrefix(context.Background(), minioClient, minioCfg.bucket,
+			fmt.Sprintf("%s/", extPath))
+		_ = mc.DropCollection(context.Background(), client.NewDropCollectionOption(collName))
+	})
+
+	schema := entity.NewSchema().
+		WithName(collName).
+		WithExternalSource(extTestURI(minioCfg, extPath)).
+		WithExternalSpec(extTestSpec(minioCfg, "parquet")).
+		WithField(entity.NewField().WithName("id").WithDataType(entity.FieldTypeInt64).WithExternalField("id")).
+		WithField(entity.NewField().WithName("embedding").WithDataType(entity.FieldTypeFloatVector).
+			WithDim(testVecDim).WithExternalField("embedding")).
+		WithField(entity.NewField().WithName("fp16_vec").WithDataType(entity.FieldTypeFloat16Vector).
+			WithDim(testVecDim).WithExternalField("fp16_vec"))
+
+	err = mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema))
+	common.CheckErr(t, err, true)
+
+	refreshAndWait(ctx, t, mc, collName)
+
+	createVectorIndex := func(fieldName string) {
+		t.Helper()
+		idx := index.NewAutoIndex(entity.L2)
+		idxTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, fieldName, idx))
+		common.CheckErr(t, err, true)
+		err = idxTask.Await(ctx)
+		common.CheckErr(t, err, true)
+		t.Log("Vector index created on " + fieldName)
+	}
+	createVectorIndex("embedding")
+	createVectorIndex("fp16_vec")
+
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	err = loadTask.Await(ctx)
+	common.CheckErr(t, err, true)
+	t.Log("Collection loaded")
+
+	expectedFP16 := func(id int64) []byte {
+		out := make([]byte, testVecDim*2)
+		for i := range out {
+			out[i] = byte((id + int64(i)) % 256)
+		}
+		return out
+	}
+	assertFP16Column := func(colName string, col column.Column, row int, id int64) {
+		t.Helper()
+		require.NotNil(t, col, "%s column should be present", colName)
+		raw, err := col.Get(row)
+		require.NoError(t, err)
+		vec, ok := raw.(entity.Float16Vector)
+		require.Truef(t, ok, "%s row %d has unexpected type %T", colName, row, raw)
+		require.Equal(t, expectedFP16(id), []byte(vec))
+	}
+
+	queryRes, err := mc.Query(ctx, client.NewQueryOption(collName).
+		WithConsistencyLevel(entity.ClStrong).
+		WithFilter("id == 42").
+		WithOutputFields("id", "fp16_vec"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, queryRes.ResultCount)
+	queryID, err := queryRes.GetColumn("id").GetAsInt64(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(42), queryID)
+	assertFP16Column("fp16_vec", queryRes.GetColumn("fp16_vec"), 0, 42)
+
+	queryVec := make([]float32, testVecDim)
+	for i := range queryVec {
+		queryVec[i] = float32(42)*0.1 + float32(i)
+	}
+	searchRes, err := mc.Search(ctx, client.NewSearchOption(collName, 1,
+		[]entity.Vector{entity.FloatVector(queryVec)}).
+		WithConsistencyLevel(entity.ClStrong).
+		WithANNSField("embedding").
+		WithFilter("id == 42").
+		WithOutputFields("id", "fp16_vec"))
+	common.CheckErr(t, err, true)
+	require.Equal(t, 1, len(searchRes))
+	require.Equal(t, 1, searchRes[0].ResultCount)
+	searchID, err := searchRes[0].GetColumn("id").GetAsInt64(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(42), searchID)
+	assertFP16Column("fp16_vec", searchRes[0].GetColumn("fp16_vec"), 0, 42)
 }
 
 // TestExternalCollectionIncrementalRefresh tests that refreshing an external collection


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/45881
pr: https://github.com/milvus-io/milvus/pull/49924

## What changed

Backport only the `ArrowToDataArray` dense byte-vector conversion subset
from the master take fix [#49924](https://github.com/milvus-io/milvus/pull/49924).
This is not a full backport of that PR; it copies the minimal part needed
on 3.0 to fix external-table take output when the take path reads binary
vector payloads.

`ArrowToDataArray` now converts `BinaryVector`, `Float16Vector`,
`BFloat16Vector`, and `Int8Vector` Arrow binary payloads back into
`DataArray`.

A focused Go client e2e test now covers FP16 vector output from an
external collection through both query and search result paths.

## Root cause

The external take path normalizes dense byte-vector fields into Arrow
binary arrays. On 3.0, `ArrowToDataArray` only handled float vector
output, so binary-vector style payloads could enter the optimized take
output path without being converted back into the expected Milvus vector
`DataArray`.

For nullable fields, the fix copies only valid physical rows into the
protobuf vector payload while preserving the logical `valid_data` bitmap.

This PR intentionally excludes the unrelated parts of the master PR,
including sparse vector support and other master-only changes.

## Validation

- `source ~/.profile && make build-cpp-with-unittest`
- `DYLD_LIBRARY_PATH=... ./internal/core/output/unittest/all_tests --gtest_filter='ExternalTakeTest.Nullable*VectorTakeUsesCompactData:ExternalTakeTest.TryTakeForRetrieve_NullableVectorUsesCompactData:ExternalTakeTest.TryTakeForSearch_NullableVectorUsesCompactData'`
- `git diff --check`
- Reset local Milvus, started standalone with `./bin/milvus run standalone --run-with-subprocess`, then ran:

```bash
cd tests/go_client
source ~/.profile
source ../../scripts/setenv.sh
MINIO_ADDRESS=localhost:9000 \
MINIO_ACCESS_KEY=minioadmin \
MINIO_SECRET_KEY=minioadmin \
MINIO_BUCKET=a-bucket \
MINIO_ROOT_PATH=files \
go test -tags dynamic,test ./testcases \
  -run '^TestExternalCollectionFloat16VectorTakeOutput$' \
  -addr=http://localhost:19530 \
  -timeout 10m \
  -count=1 -v
```

Result:

```text
Job 466897675154097263: state=RefreshCompleted progress=100%
Vector index created on embedding
Vector index created on fp16_vec
Collection loaded
Response method=Query includes fp16_vec Float16Vector "KissLS4vMDE="
Response method=Search includes fp16_vec Float16Vector "KissLS4vMDE="
--- PASS: TestExternalCollectionFloat16VectorTakeOutput (5.15s)
PASS
ok github.com/milvus-io/milvus/tests/go_client/testcases 6.332s
```
