### PR TITLE
test: Enable vortex storage in Helm test values

### DIFF
--- a/tests/_helm/values/e2e-amd/distributed-pulsar
+++ b/tests/_helm/values/e2e-amd/distributed-pulsar
@@ -81,6 +81,9 @@ extraConfigFiles:
         enablev2: true
         # enable storage v3
         useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
     dataCoord:
       targetVecIndexVersion: 10
       gc:

--- a/tests/_helm/values/e2e-amd/standalone
+++ b/tests/_helm/values/e2e-amd/standalone
@@ -40,6 +40,9 @@ extraConfigFiles:
       storage:
         # enable storage v3
         useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
     dataCoord:
       targetVecIndexVersion: 10
       gc:

--- a/tests/_helm/values/e2e-arm/distributed-pulsar
+++ b/tests/_helm/values/e2e-arm/distributed-pulsar
@@ -68,6 +68,9 @@ extraConfigFiles:
         enablev2: true
         # enable storage v3
         useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
     dataCoord:
       targetVecIndexVersion: 10
       gc:

--- a/tests/_helm/values/e2e-arm/standalone
+++ b/tests/_helm/values/e2e-arm/standalone
@@ -27,6 +27,9 @@ extraConfigFiles:
       storage:
         # enable storage v3
         useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
     dataCoord:
       targetVecIndexVersion: 10
       gc:

--- a/tests/_helm/values/e2e/distributed-pulsar
+++ b/tests/_helm/values/e2e/distributed-pulsar
@@ -81,6 +81,9 @@ extraConfigFiles:
         enablev2: true
         # enable storage v3
         useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
     dataCoord:
       targetVecIndexVersion: 10
       gc:

--- a/tests/_helm/values/e2e/standalone
+++ b/tests/_helm/values/e2e/standalone
@@ -40,6 +40,9 @@ extraConfigFiles:
       storage:
         # enable storage v3
         useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
     dataCoord:
       targetVecIndexVersion: 10
       gc:

--- a/tests/_helm/values/nightly/distributed-woodpecker
+++ b/tests/_helm/values/nightly/distributed-woodpecker
@@ -88,6 +88,9 @@ extraConfigFiles:
         enablev2: true
         # enable storage v3
         useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
     dataCoord:
       targetVecIndexVersion: 10
       gc:

--- a/tests/_helm/values/nightly/distributed-woodpecker-service
+++ b/tests/_helm/values/nightly/distributed-woodpecker-service
@@ -97,6 +97,9 @@ extraConfigFiles:
         enablev2: true
         # enable storage v3
         useLoonFFI: true
+    dataNode:
+      storage:
+        format: vortex
     dataCoord:
       targetVecIndexVersion: 10
       gc:


### PR DESCRIPTION
## Summary

Enable the DataNode vortex storage format in the Helm values that already enable Loon FFI storage:

- tests/_helm/values/e2e/standalone
- tests/_helm/values/e2e/distributed-pulsar
- tests/_helm/values/e2e-amd/standalone
- tests/_helm/values/e2e-amd/distributed-pulsar
- tests/_helm/values/e2e-arm/standalone
- tests/_helm/values/e2e-arm/distributed-pulsar
- tests/_helm/values/nightly/distributed-woodpecker
- tests/_helm/values/nightly/distributed-woodpecker-service

Fixes #50441

## Test Plan

- [x] ruby YAML parse check for the eight target values files, verifying common.storage.useLoonFFI is true and dataNode.storage.format is vortex
- [x] git diff scope check confirmed only the two nightly woodpecker files were added in the follow-up amend