### PR TITLE
fix: defer sealed segment load-info publish until reopen succeeds

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -641,8 +641,10 @@ ChunkedSegmentSealedImpl::LoadFieldData(const LoadFieldDataInfo& load_info,
 }
 
 void
-ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
-                                           milvus::OpContext* op_ctx) {
+ChunkedSegmentSealedImpl::LoadColumnGroups(
+    const SegmentLoadInfo& target_load_info,
+    const std::string& manifest_path,
+    milvus::OpContext* op_ctx) {
     auto load_cg_start = std::chrono::high_resolution_clock::now();
     LOG_INFO(
         "[LoadColumnGroups] segment {} start, manifest {}", id_, manifest_path);
@@ -651,8 +653,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
     auto properties = std::make_shared<milvus_storage::api::Properties>(
         *milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
              .GetProperties());
-    auto load_info = std::atomic_load(&segment_load_info_);
-    auto column_groups = load_info->GetColumnGroups();
+    auto column_groups = target_load_info.GetColumnGroups();
 
     // External collections: inject extfs.{collectionID}.* derived from
     // external_source and external_spec only. InjectExternalSpecProperties zero-
@@ -665,7 +666,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
     // matches.
     if (schema_->is_external_collection()) {
         InjectExternalSpecProperties(*properties,
-                                     load_info->GetCollectionID(),
+                                     target_load_info.GetCollectionID(),
                                      schema_->get_external_source(),
                                      schema_->get_external_spec());
     }
@@ -785,6 +786,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
     std::vector<std::future<void>> load_group_futures;
     for (auto& task : tasks) {
         auto future = pool.Submit([this,
+                                   &target_load_info,
                                    column_groups,
                                    properties,
                                    cg_index = task.cg_index,
@@ -795,7 +797,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
                               id_,
                               cg_index,
                               "ChunkedSegmentSealedImpl::LoadColumnGroup()");
-            LoadColumnGroup(column_groups,
+            LoadColumnGroup(target_load_info,
+                            column_groups,
                             properties,
                             cg_index,
                             field_ids,
@@ -809,13 +812,14 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
     storage::WaitAllFutures(load_group_futures);
 
     if (schema_->is_external_collection()) {
-        SynthesizeExternalSystemFields();
+        SynthesizeExternalSystemFields(target_load_info);
     }
 }
 
 void
-ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields() {
-    int64_t num_rows = std::atomic_load(&segment_load_info_)->GetNumOfRows();
+ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields(
+    const SegmentLoadInfo& target_load_info) {
+    int64_t num_rows = target_load_info.GetNumOfRows();
     if (num_rows == 0) {
         std::unique_lock lck(mutex_);
         update_row_count(0);
@@ -1097,6 +1101,7 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                                    info.enable_mmap,
                                    true,
                                    statistics_opt,
+                                   load_info.storage_version,
                                    op_ctx,
                                    is_replace);
             if (field_id == TimestampFieldID) {
@@ -1207,6 +1212,7 @@ ChunkedSegmentSealedImpl::load_field_data_internal(
                                    info.enable_mmap,
                                    false,
                                    std::nullopt,
+                                   load_info.storage_version,
                                    op_ctx,
                                    is_replace);
         }
@@ -3060,8 +3066,8 @@ ChunkedSegmentSealedImpl::fill_with_empty(FieldId field_id,
 }
 
 void
-ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id,
-                                          milvus::OpContext* op_ctx) {
+ChunkedSegmentSealedImpl::CreateTextIndexNoPublish(FieldId field_id,
+                                                   milvus::OpContext* op_ctx) {
     // Check for cancellation before starting
     CheckCancellation(op_ctx,
                       id_,
@@ -3163,10 +3169,12 @@ ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id,
 
     text_indexes_[field_id] = std::make_shared<index::TextMatchIndexHolder>(
         std::move(index), cfg.GetScalarIndexEnableMmap());
-    // Publish the CreatedTextIndexes update to the atomic segment_load_info_
-    // snapshot. Uses CAS loop so it is safe even when CreateTextIndex is
-    // invoked directly by tests without an outer Reopen/Load holding
-    // reopen_mutex_.
+}
+
+void
+ChunkedSegmentSealedImpl::CreateTextIndex(FieldId field_id,
+                                          milvus::OpContext* op_ctx) {
+    CreateTextIndexNoPublish(field_id, op_ctx);
     RecordTextIndexCreated(field_id);
 }
 
@@ -3181,12 +3189,18 @@ ChunkedSegmentSealedImpl::RecordDefaultFieldsFilled(
     std::shared_ptr<const SegmentLoadInfo> next;
     do {
         auto copy = std::make_shared<SegmentLoadInfo>(*current);
-        for (auto field_id : field_ids) {
-            copy->SetFieldFilledWithDefault(field_id);
-        }
+        RecordDefaultFieldsFilled(*copy, field_ids);
         next = std::const_pointer_cast<const SegmentLoadInfo>(copy);
     } while (!std::atomic_compare_exchange_weak(
         &segment_load_info_, &current, next));
+}
+
+void
+ChunkedSegmentSealedImpl::RecordDefaultFieldsFilled(
+    SegmentLoadInfo& staged_load_info, const std::vector<FieldId>& field_ids) {
+    for (auto field_id : field_ids) {
+        staged_load_info.SetFieldFilledWithDefault(field_id);
+    }
 }
 
 void
@@ -3195,10 +3209,16 @@ ChunkedSegmentSealedImpl::RecordTextIndexCreated(FieldId field_id) {
     std::shared_ptr<const SegmentLoadInfo> next;
     do {
         auto copy = std::make_shared<SegmentLoadInfo>(*current);
-        copy->SetTextIndexCreated(field_id);
+        RecordTextIndexCreated(*copy, field_id);
         next = std::const_pointer_cast<const SegmentLoadInfo>(copy);
     } while (!std::atomic_compare_exchange_weak(
         &segment_load_info_, &current, next));
+}
+
+void
+ChunkedSegmentSealedImpl::RecordTextIndexCreated(
+    SegmentLoadInfo& staged_load_info, FieldId field_id) {
+    staged_load_info.SetTextIndexCreated(field_id);
 }
 
 void
@@ -4392,6 +4412,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     bool enable_mmap,
     bool is_proxy_column,
     std::optional<ParquetStatistics> statistics,
+    int64_t storage_version,
     milvus::OpContext* op_ctx,
     bool is_replace) {
     {
@@ -4459,8 +4480,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
 
     // set pks to offset
     if (schema_->get_primary_field_id().value_or(FieldId(-1)) == field_id) {
-        if (std::atomic_load(&segment_load_info_)->GetStorageVersion() >=
-            STORAGE_V2) {
+        if (storage_version >= STORAGE_V2) {
             init_storage_v2_pk_index(field_id, column, data_type);
         } else {
             init_storage_v1_pk_index(field_id, column, data_type, is_replace);
@@ -4597,13 +4617,13 @@ ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
     LOG_INFO(
         "Schema-only reopen segment {} with diff {}", id_, diff.ToString());
 
+    ApplySchemaForReopen(sch);
+    ApplyLoadDiff(op_ctx, new_local, &new_local, diff);
+
     auto published = std::make_shared<const SegmentLoadInfo>(new_local);
     std::atomic_store(&segment_load_info_, published);
     use_take_for_output_.store(published->GetUseTakeForOutput(),
                                std::memory_order_relaxed);
-
-    ApplySchemaForReopen(sch);
-    ApplyLoadDiff(op_ctx, new_local, diff);
 
     LOG_INFO("Schema-only reopen segment {} done", id_);
 }
@@ -4656,21 +4676,24 @@ ChunkedSegmentSealedImpl::Reopen(
         current_mutable.GetDefaultFilledFieldsForNewInfo(new_local));
     LOG_INFO("Reopen segment {} with diff {}", id_, diff.ToString());
 
+    ApplySchemaForReopen(target_schema);
+    ApplyLoadDiff(op_ctx, new_local, &new_local, diff);
+
     auto published = std::make_shared<const SegmentLoadInfo>(new_local);
     std::atomic_store(&segment_load_info_, published);
     use_take_for_output_.store(published->GetUseTakeForOutput(),
                                std::memory_order_relaxed);
-
-    ApplySchemaForReopen(target_schema);
-    ApplyLoadDiff(op_ctx, new_local, diff);
 
     LOG_INFO("Reopen segment {} done", id_);
 }
 
 void
 ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
-                                        SegmentLoadInfo& segment_load_info,
+                                        const SegmentLoadInfo& target_load_info,
+                                        SegmentLoadInfo* staged_load_info,
                                         LoadDiff& diff) {
+    AssertInfo(staged_load_info != nullptr,
+               "staged load info must not be null during apply load diff");
     // TODO: pass trace_ctx separately when needed
     milvus::tracer::TraceContext trace_ctx;
 
@@ -4702,7 +4725,8 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
     // load column groups
     if (diff.load_external_manifest) {
         // External collections: load via manifest path
-        LoadColumnGroups(segment_load_info.GetManifestPath(), op_ctx);
+        LoadColumnGroups(
+            target_load_info, target_load_info.GetManifestPath(), op_ctx);
     } else {
         bool has_cg_changes = !diff.column_groups_to_load.empty() ||
                               !diff.column_groups_to_replace.empty() ||
@@ -4712,7 +4736,7 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
             auto properties =
                 milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
                     .GetProperties();
-            auto column_groups = segment_load_info.GetColumnGroups();
+            auto column_groups = target_load_info.GetColumnGroups();
             auto arrow_schema = schema_->ConvertToLoonArrowSchema();
             auto needed_columns = std::make_shared<std::vector<std::string>>();
             for (const auto& field_id : schema_->get_field_ids()) {
@@ -4730,14 +4754,16 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
             }
             // New column group fields
             if (!diff.column_groups_to_load.empty()) {
-                LoadColumnGroups(column_groups,
+                LoadColumnGroups(target_load_info,
+                                 column_groups,
                                  properties,
                                  diff.column_groups_to_load,
                                  true,
                                  op_ctx);
             }
             if (!diff.column_groups_to_lazyload.empty()) {
-                LoadColumnGroups(column_groups,
+                LoadColumnGroups(target_load_info,
+                                 column_groups,
                                  properties,
                                  diff.column_groups_to_lazyload,
                                  false,
@@ -4745,7 +4771,8 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
             }
             // Replace column group fields
             if (!diff.column_groups_to_replace.empty()) {
-                LoadColumnGroups(column_groups,
+                LoadColumnGroups(target_load_info,
+                                 column_groups,
                                  properties,
                                  diff.column_groups_to_replace,
                                  true,
@@ -4753,7 +4780,8 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
                                  true);
             }
             if (!diff.column_groups_to_lazyreplace.empty()) {
-                LoadColumnGroups(column_groups,
+                LoadColumnGroups(target_load_info,
+                                 column_groups,
                                  properties,
                                  diff.column_groups_to_lazyreplace,
                                  false,
@@ -4766,21 +4794,23 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
 
     // Initialize LOB paths for TEXT fields after any column group loading
-    if (segment_load_info.HasManifestPath()) {
-        InitTextLobPaths(segment_load_info.GetManifestPath());
+    if (target_load_info.HasManifestPath()) {
+        InitTextLobPaths(target_load_info.GetManifestPath());
     }
 
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
 
     // Load new field binlogs
     if (!diff.binlogs_to_load.empty()) {
-        LoadBatchFieldData(trace_ctx, diff.binlogs_to_load, op_ctx);
+        LoadBatchFieldData(
+            trace_ctx, target_load_info, diff.binlogs_to_load, op_ctx);
     }
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
 
     // Replace field binlogs
     if (!diff.binlogs_to_replace.empty()) {
-        LoadBatchFieldData(trace_ctx, diff.binlogs_to_replace, op_ctx, true);
+        LoadBatchFieldData(
+            trace_ctx, target_load_info, diff.binlogs_to_replace, op_ctx, true);
     }
 
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
@@ -4836,7 +4866,8 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
     // fill default values for fields without data sources (schema evolution)
     if (!diff.fields_to_fill_default.empty()) {
         FillDefaultValueFields(diff.fields_to_fill_default);
-        RecordDefaultFieldsFilled(diff.fields_to_fill_default);
+        RecordDefaultFieldsFilled(*staged_load_info,
+                                  diff.fields_to_fill_default);
     }
 
     CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::ApplyLoadDiff()");
@@ -4844,7 +4875,8 @@ ChunkedSegmentSealedImpl::ApplyLoadDiff(milvus::OpContext* op_ctx,
     // create text indexes from raw data
     if (!diff.text_indexes_to_create.empty()) {
         for (const auto& field_id : diff.text_indexes_to_create) {
-            CreateTextIndex(field_id, op_ctx);
+            CreateTextIndexNoPublish(field_id, op_ctx);
+            RecordTextIndexCreated(*staged_load_info, field_id);
         }
     }
 
@@ -5063,7 +5095,8 @@ ChunkedSegmentSealedImpl::LoadManifest(const std::string& manifest_path) {
         cg_field_ids.emplace_back(i, std::move(milvus_field_ids));
     }
 
-    LoadColumnGroups(column_groups, properties, cg_field_ids, true);
+    auto snapshot = std::atomic_load(&segment_load_info_);
+    LoadColumnGroups(*snapshot, column_groups, properties, cg_field_ids, true);
 
     // initialize LOB paths for TEXT fields
     InitTextLobPaths(manifest_path);
@@ -5110,6 +5143,7 @@ ChunkedSegmentSealedImpl::InitTextLobPaths(const std::string& manifest_path) {
 
 void
 ChunkedSegmentSealedImpl::LoadColumnGroups(
+    const SegmentLoadInfo& target_load_info,
     const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
     const std::shared_ptr<milvus_storage::api::Properties>& properties,
     std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
@@ -5122,6 +5156,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
         auto cg_index = pair.first;
         const auto& field_ids = pair.second;
         auto future = pool.Submit([this,
+                                   &target_load_info,
                                    column_groups,
                                    properties,
                                    cg_index,
@@ -5134,7 +5169,8 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
                               id_,
                               cg_index,
                               "ChunkedSegmentSealedImpl::LoadColumnGroup()");
-            LoadColumnGroup(column_groups,
+            LoadColumnGroup(target_load_info,
+                            column_groups,
                             properties,
                             cg_index,
                             field_ids,
@@ -5150,6 +5186,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(
 
 void
 ChunkedSegmentSealedImpl::LoadColumnGroup(
+    const SegmentLoadInfo& target_load_info,
     const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
     const std::shared_ptr<milvus_storage::api::Properties>& properties,
     int64_t index,
@@ -5157,12 +5194,13 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     bool eager_load,
     milvus::OpContext* op_ctx,
     bool is_replace) {
+    (void)properties;
     AssertInfo(index < column_groups->size(),
                "load column group index out of range");
     AssertInfo(!milvus_field_ids.empty(),
                "load column group with empty field list");
     auto column_group = column_groups->at(index);
-    auto load_info = std::atomic_load(&segment_load_info_);
+    const auto& load_info = target_load_info;
 
     for (const auto& field_id : milvus_field_ids) {
         AssertInfo(field_exists_in_schema(schema_, field_id),
@@ -5268,11 +5306,11 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
             mmap_config.GetMmapPopulate(),
             mmap_dir_path,
             milvus_field_ids.size(),
-            load_info->GetPriority(),
+            load_info.GetPriority(),
             eager_load,
             warmup_policy,
             cache_key_suffix,
-            load_info->GetEstimatedBytesPerRow());
+            load_info.GetEstimatedBytesPerRow());
     auto chunked_column_group =
         std::make_shared<ChunkedColumnGroup>(std::move(translator));
 
@@ -5285,16 +5323,17 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
         load_field_data_common(
             field_id,
             column,
-            load_info->GetNumOfRows(),
+            load_info.GetNumOfRows(),
             data_type,
             use_mmap,
             true,
             std::
                 nullopt,  // manifest cannot provide parquet skip index directly
+            load_info.GetStorageVersion(),
             op_ctx,
             is_replace);
         if (field_id == TimestampFieldID) {
-            int64_t num_rows = load_info->GetNumOfRows();
+            int64_t num_rows = load_info.GetNumOfRows();
             if (commit_ts_ != 0) {
                 std::vector<Timestamp> ts(num_rows, commit_ts_);
                 init_storage_v1_timestamp_index(std::move(ts), num_rows);
@@ -5402,6 +5441,7 @@ ChunkedSegmentSealedImpl::LoadBatchIndexes(
 void
 ChunkedSegmentSealedImpl::LoadBatchFieldData(
     milvus::tracer::TraceContext& trace_ctx,
+    const SegmentLoadInfo& target_load_info,
     std::vector<std::pair<std::vector<FieldId>, proto::segcore::FieldBinlog>>&
         field_binlog_to_load,
     milvus::OpContext* op_ctx,
@@ -5416,12 +5456,12 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         SegcoreConfig::default_config()
             .get_prefer_field_data_when_index_has_raw_data();
 
-    auto load_info_snapshot = std::atomic_load(&segment_load_info_);
+    const auto& load_info_snapshot = target_load_info;
     std::map<FieldId, LoadFieldDataInfo> field_data_to_load;
     for (auto& [field_ids, field_binlog] : field_binlog_to_load) {
         LoadFieldDataInfo load_field_data_info;
         load_field_data_info.storage_version =
-            load_info_snapshot->GetStorageVersion();
+            load_info_snapshot.GetStorageVersion();
         auto fields_to_load = field_ids;
         AssertInfo(!fields_to_load.empty(),
                    "load field data with empty field list");
@@ -5553,8 +5593,8 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
 void
 ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
                                milvus::OpContext* op_ctx) {
-    // Serialize with Reopen(pb)/SetLoadInfo. Runtime-only updates produced by
-    // ApplyLoadDiff are committed through COW helpers after the data is loaded.
+    // Serialize with Reopen(pb)/SetLoadInfo. Load stages runtime-only updates
+    // in mutable_copy and only publishes them after ApplyLoadDiff succeeds.
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
 
     auto snapshot = std::atomic_load(&segment_load_info_);
@@ -5571,7 +5611,12 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     auto diff = mutable_copy.GetLoadDiff();
     LOG_WARN("Load segment {} with diff {}", id_, diff.ToString());
 
-    ApplyLoadDiff(op_ctx, mutable_copy, diff);
+    ApplyLoadDiff(op_ctx, *snapshot, &mutable_copy, diff);
+
+    auto published = std::make_shared<const SegmentLoadInfo>(mutable_copy);
+    std::atomic_store(&segment_load_info_, published);
+    use_take_for_output_.store(published->GetUseTakeForOutput(),
+                               std::memory_order_relaxed);
 
     LOG_INFO("Successfully loaded segment {} with {} rows", id_, num_rows);
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1253,6 +1253,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     void
     LoadBatchFieldData(milvus::tracer::TraceContext& trace_ctx,
+                       const SegmentLoadInfo& target_load_info,
                        std::vector<std::pair<std::vector<FieldId>,
                                              proto::segcore::FieldBinlog>>&
                            field_binlog_to_load,
@@ -1272,6 +1273,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     void
     LoadColumnGroups(
+        const SegmentLoadInfo& target_load_info,
         const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
         std::vector<std::pair<int, std::vector<FieldId>>>& cg_field_ids,
@@ -1281,7 +1283,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     // Load column groups from a manifest file path (for external collections)
     void
-    LoadColumnGroups(const std::string& manifest_path,
+    LoadColumnGroups(const SegmentLoadInfo& target_load_info,
+                     const std::string& manifest_path,
                      milvus::OpContext* op_ctx = nullptr);
 
     /**
@@ -1299,6 +1302,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
      */
     void
     LoadColumnGroup(
+        const SegmentLoadInfo& target_load_info,
         const std::shared_ptr<milvus_storage::api::ColumnGroups>& column_groups,
         const std::shared_ptr<milvus_storage::api::Properties>& properties,
         int64_t index,
@@ -1311,7 +1315,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // for external collections. External collections don't have real PK or
     // timestamp fields in their parquet data, so these must be generated.
     void
-    SynthesizeExternalSystemFields();
+    SynthesizeExternalSystemFields(const SegmentLoadInfo& target_load_info);
 
     /**
      * @brief Reloads columns from the specified field IDs
@@ -1337,19 +1341,21 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
             text_indexes_to_load);
 
     /**
-     * @brief Apply load differences to update segment load information
+     * @brief Apply load differences for a target load snapshot
      *
-     * This method processes the differences between current and new load states,
-     * updating the segment's loaded fields and indexes accordingly. It handles
-     * incremental updates during segment reopen operations.
+     * This method processes the differences between current and target load
+     * states, updates runtime resources, and records runtime-only markers into
+     * the staged snapshot for a later publish.
      *
      * @param op_ctx The operation context
-     * @param segment_load_info The segment load information to be updated
+     * @param target_load_info The target load information that drives resource loading
+     * @param staged_load_info Mutable staged load information updated during apply
      * @param load_diff The differences to apply, containing fields and indexes to add/remove
      */
     void
     ApplyLoadDiff(milvus::OpContext* op_ctx,
-                  SegmentLoadInfo& segment_load_info,
+                  const SegmentLoadInfo& target_load_info,
+                  SegmentLoadInfo* staged_load_info,
                   LoadDiff& load_diff);
 
     void
@@ -1361,12 +1367,23 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     RecordDefaultFieldsFilled(const std::vector<FieldId>& field_ids);
 
+    void
+    RecordDefaultFieldsFilled(SegmentLoadInfo& staged_load_info,
+                              const std::vector<FieldId>& field_ids);
+
+    void
+    CreateTextIndexNoPublish(FieldId field_id,
+                             milvus::OpContext* op_ctx = nullptr);
+
     // Atomically records that a text index has been created for `field_id` in
     // the published segment_load_info_. Uses a CAS loop so it is safe whether
     // or not the caller holds reopen_mutex_ (tests call CreateTextIndex
     // directly, outside a Reopen/Load chain).
     void
     RecordTextIndexCreated(FieldId field_id);
+
+    void
+    RecordTextIndexCreated(SegmentLoadInfo& staged_load_info, FieldId field_id);
 
     void
     load_field_data_common(
@@ -1377,6 +1394,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         bool enable_mmap,
         bool is_proxy_column,
         std::optional<ParquetStatistics> statistics = {},
+        int64_t storage_version = STORAGE_V1,
         milvus::OpContext* op_ctx = nullptr,
         bool is_replace = false);
 

--- a/internal/core/src/segcore/LoadCancellationTest.cpp
+++ b/internal/core/src/segcore/LoadCancellationTest.cpp
@@ -156,6 +156,168 @@ TEST(LoadCancellationSegment, LoadExternalManifestPreCancelled) {
         SegcoreError);
 }
 
+TEST(LoadCancellationSegment, ReopenPreCancelledDoesNotPublishNewSnapshot) {
+    auto schema = std::make_shared<Schema>();
+    schema->set_schema_version(1);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto text_fid = schema->AddDebugField("text", DataType::VARCHAR);
+    schema->set_primary_field_id(pk_fid);
+    auto segment = CreateSealedSegment(
+        schema, nullptr, -1, SegcoreConfig::default_config(), true);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    milvus::proto::segcore::SegmentLoadInfo old_load_info;
+    old_load_info.set_collectionid(1);
+    old_load_info.set_partitionid(1);
+    old_load_info.set_segmentid(1);
+    old_load_info.set_num_of_rows(10);
+    old_load_info.set_use_take_for_output(false);
+    sealed->SetLoadInfo(old_load_info);
+    sealed->TestRecordTextIndexCreated(text_fid);
+    auto before = sealed->TestGetSegmentLoadInfo();
+    ASSERT_TRUE(before->HasTextIndexCreated(text_fid));
+    ASSERT_FALSE(before->GetUseTakeForOutput());
+
+    auto new_load_info = old_load_info;
+    new_load_info.set_use_take_for_output(true);
+
+    folly::CancellationSource source;
+    source.requestCancellation();
+    OpContext op_ctx(source.getToken());
+
+    EXPECT_THROW(
+        {
+            try {
+                sealed->Reopen(&op_ctx, new_load_info, schema);
+            } catch (const SegcoreError& e) {
+                EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+                throw;
+            }
+        },
+        SegcoreError);
+
+    auto after = sealed->TestGetSegmentLoadInfo();
+    EXPECT_FALSE(after->GetUseTakeForOutput());
+    EXPECT_TRUE(after->HasTextIndexCreated(text_fid));
+    EXPECT_EQ(after->GetProto().ShortDebugString(),
+              before->GetProto().ShortDebugString());
+}
+
+TEST(LoadCancellationSegment,
+     LoadPreCancelledDoesNotPublishRuntimeOnlyMarkers) {
+    auto schema = std::make_shared<Schema>();
+    schema->set_schema_version(1);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    auto text_fid = schema->AddDebugField("text", DataType::VARCHAR);
+    schema->set_primary_field_id(pk_fid);
+    auto segment = CreateSealedSegment(
+        schema, nullptr, -1, SegcoreConfig::default_config(), true);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    milvus::proto::segcore::SegmentLoadInfo load_info;
+    load_info.set_collectionid(1);
+    load_info.set_partitionid(1);
+    load_info.set_segmentid(1);
+    load_info.set_num_of_rows(10);
+    load_info.set_use_take_for_output(false);
+    auto* index_info = load_info.add_index_infos();
+    index_info->set_fieldid(text_fid.get());
+    sealed->SetLoadInfo(load_info);
+    auto before = sealed->TestGetSegmentLoadInfo();
+    EXPECT_FALSE(before->HasTextIndexCreated(text_fid));
+
+    folly::CancellationSource source;
+    source.requestCancellation();
+    OpContext op_ctx(source.getToken());
+    milvus::tracer::TraceContext trace_ctx;
+
+    EXPECT_THROW(
+        {
+            try {
+                sealed->Load(trace_ctx, &op_ctx);
+            } catch (const SegcoreError& e) {
+                EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+                throw;
+            }
+        },
+        SegcoreError);
+
+    auto after = sealed->TestGetSegmentLoadInfo();
+    EXPECT_FALSE(after->HasTextIndexCreated(text_fid));
+    EXPECT_EQ(after->GetProto().ShortDebugString(),
+              before->GetProto().ShortDebugString());
+}
+
+TEST(LoadCancellationSegment,
+     SchemaOnlyReopenPreCancelledDoesNotPublishNewSnapshot) {
+    auto old_schema = std::make_shared<Schema>();
+    old_schema->set_schema_version(1);
+    auto text_fid = old_schema->AddDebugField("text", DataType::VARCHAR);
+    auto pk_fid = old_schema->AddDebugField("pk", DataType::INT64);
+    old_schema->set_primary_field_id(pk_fid);
+    auto segment = CreateSealedSegment(
+        old_schema, nullptr, -1, SegcoreConfig::default_config(), true);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    milvus::proto::segcore::SegmentLoadInfo old_load_info;
+    old_load_info.set_collectionid(1);
+    old_load_info.set_partitionid(1);
+    old_load_info.set_segmentid(1);
+    old_load_info.set_num_of_rows(10);
+    old_load_info.set_use_take_for_output(false);
+    sealed->SetLoadInfo(old_load_info);
+    sealed->TestRecordTextIndexCreated(text_fid);
+    auto before = sealed->TestGetSegmentLoadInfo();
+
+    auto new_schema = std::make_shared<Schema>();
+    new_schema->set_schema_version(2);
+    new_schema->AddField(
+        FieldName("text"), text_fid, DataType::VARCHAR, false, std::nullopt);
+    new_schema->AddField(
+        FieldName("pk"), pk_fid, DataType::INT64, false, std::nullopt);
+    new_schema->set_primary_field_id(pk_fid);
+
+    auto new_load_info = old_load_info;
+
+    folly::CancellationSource source;
+    source.requestCancellation();
+    OpContext op_ctx(source.getToken());
+
+    EXPECT_THROW(
+        {
+            try {
+                sealed->Reopen(&op_ctx, new_load_info, new_schema);
+            } catch (const SegcoreError& e) {
+                EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+                throw;
+            }
+        },
+        SegcoreError);
+
+    auto after = sealed->TestGetSegmentLoadInfo();
+    EXPECT_TRUE(after->HasTextIndexCreated(text_fid));
+    EXPECT_EQ(after->GetProto().ShortDebugString(),
+              before->GetProto().ShortDebugString());
+}
+
+TEST(LoadCancellationSegment, CreateTextIndexMarkerHelperPublishesSnapshot) {
+    auto schema = std::make_shared<Schema>();
+    auto text_fid = schema->AddDebugField("text", DataType::VARCHAR);
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk_fid);
+    auto segment = CreateSealedSegment(
+        schema, nullptr, -1, SegcoreConfig::default_config(), true);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    sealed->TestRecordTextIndexCreated(text_fid);
+    EXPECT_TRUE(
+        sealed->TestGetSegmentLoadInfo()->HasTextIndexCreated(text_fid));
+}
+
 // Test cancellation during loop operation
 TEST(LoadCancellationUtility, CancellationDuringLoop) {
     folly::CancellationSource source;


### PR DESCRIPTION
Related to #50368

Keep SegmentLoadInfo and use_take_for_output_ aligned with the actual runtime state when ApplyLoadDiff is cancelled or fails.

Stage reopen-time load-info updates in a mutable snapshot, pass the target load info explicitly through ApplyLoadDiff, and publish the new snapshot only after all resource mutations succeed. Add cancellation regression tests covering pre-cancel reopen/load paths to ensure failed operations do not advance the published snapshot.