### PR TITLE
enhance: cache LikePatternMatcher across batches

### DIFF
--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -1637,10 +1637,12 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
     TargetBitmapView valid_res(res_vec->GetValidRawData(), real_batch_size);
     auto expr_type = expr_->op_type_;
 
-    // Pre-build regex objects once for the entire segment
+    // Pre-build regex / LIKE pattern objects once for the entire segment
     EnsureRegexCache();
+    EnsureLikeMatcherCache();
     const PartialRegexMatcher* regex_matcher_ptr = cached_regex_matcher_.get();
     const VolnitskySearcher* volnitsky_ptr = cached_volnitsky_searcher_.get();
+    const LikePatternMatcher* like_matcher_ptr = cached_like_matcher_.get();
 
     size_t processed_cursor = 0;
     auto execute_sub_batch =
@@ -1649,7 +1651,8 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
             &processed_cursor,
             &bitmap_input,
             regex_matcher_ptr,
-            volnitsky_ptr
+            volnitsky_ptr,
+            like_matcher_ptr
         ]<FilterType filter_type = FilterType::sequential>(
             const T* data,
             const bool* valid_data,
@@ -1767,7 +1770,8 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
                 break;
             }
             case proto::plan::Match: {
-                UnaryElementFunc<T, proto::plan::Match, filter_type> func;
+                UnaryElementFuncForMatch<T, filter_type> func;
+                func.matcher = like_matcher_ptr;
                 func(data,
                      size,
                      val,

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -116,6 +116,11 @@ struct UnaryElementFuncForMatch {
     using IndexInnerType =
         std::conditional_t<std::is_same_v<T, std::string_view>, std::string, T>;
 
+    // Pre-built matcher — owned by PhyUnaryRangeFilterExpr and reused
+    // across batches; nullptr means build a local one (mirrors
+    // UnaryElementFuncForRegexMatch).
+    const LikePatternMatcher* matcher = nullptr;
+
     void
     operator()(const T* src,
                size_t size,
@@ -128,9 +133,14 @@ struct UnaryElementFuncForMatch {
 
         if constexpr (std::is_same_v<T, std::string> ||
                       std::is_same_v<T, std::string_view>) {
-            LikePatternMatcher matcher(val);
+            std::unique_ptr<LikePatternMatcher> local_matcher;
+            const LikePatternMatcher* m = matcher;
+            if (m == nullptr) {
+                local_matcher = std::make_unique<LikePatternMatcher>(val);
+                m = local_matcher.get();
+            }
             for (int i = 0; i < size; ++i) {
-                res[i] = matcher(src[i]);
+                res[i] = (*m)(src[i]);
             }
         } else {
             ThrowInfo(OpTypeInvalid,
@@ -148,16 +158,21 @@ struct UnaryElementFuncForMatch {
                const int32_t* offsets = nullptr) {
         if constexpr (std::is_same_v<T, std::string> ||
                       std::is_same_v<T, std::string_view>) {
-            LikePatternMatcher matcher(val);
+            std::unique_ptr<LikePatternMatcher> local_matcher;
+            const LikePatternMatcher* m = matcher;
+            if (m == nullptr) {
+                local_matcher = std::make_unique<LikePatternMatcher>(val);
+                m = local_matcher.get();
+            }
             bool has_bitmap_input = !bitmap_input.empty();
             for (int i = 0; i < size; ++i) {
                 if (has_bitmap_input && !bitmap_input[i + start_cursor]) {
                     continue;
                 }
                 if constexpr (filter_type == FilterType::random) {
-                    res[i] = matcher(src[offsets ? offsets[i] : i]);
+                    res[i] = (*m)(src[offsets ? offsets[i] : i]);
                 } else {
-                    res[i] = matcher(src[i]);
+                    res[i] = (*m)(src[i]);
                 }
             }
         } else {
@@ -1168,6 +1183,22 @@ class PhyUnaryRangeFilterExpr : public SegmentExpr {
             cached_volnitsky_searcher_ =
                 std::make_unique<VolnitskySearcher>(cached_volnitsky_literal_);
         }
+    }
+
+    // Cached LIKE pattern matcher — constructed once per segment, reused
+    // across batches (the pattern is an expression constant).
+    bool like_cache_inited_{false};
+    std::unique_ptr<LikePatternMatcher> cached_like_matcher_;
+
+    void
+    EnsureLikeMatcherCache() {
+        if (like_cache_inited_)
+            return;
+        like_cache_inited_ = true;
+        if (expr_->op_type_ != proto::plan::OpType::Match)
+            return;
+        auto pattern = GetValueFromProto<std::string>(expr_->val_);
+        cached_like_matcher_ = std::make_unique<LikePatternMatcher>(pattern);
     }
 };
 }  // namespace exec


### PR DESCRIPTION
issue: #50445

## What this PR does

`UnaryElementFuncForMatch` constructed a `LikePatternMatcher` from the expression's constant LIKE pattern inside the per-batch kernel. `PhyExpr::Eval()` runs once per 8192-row batch, so a `LIKE` filter over a 1M-row segment re-parsed the same pattern and reallocated the matcher's token structures ~122 times.

Mirror the existing RegexMatch caching convention (`cached_regex_matcher_` / `EnsureRegexCache()`):

- `UnaryElementFuncForMatch` gains a `const LikePatternMatcher* matcher` member; `nullptr` falls back to local construction, so call sites that are not wired keep their current behavior (same design as `UnaryElementFuncForRegexMatch`).
- `PhyUnaryRangeFilterExpr` gains `cached_like_matcher_` + `EnsureLikeMatcherCache()`, built once per segment.
- The data-path `Match` dispatch injects the cached matcher.

## Tests

- Incremental core build passes.
- `--gtest_filter="*Match*:*Like*:*StringExpr*"`: 221/221 passed (1 pre-existing skip: `RegexMatcherTest.NewLine`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)