### PR TITLE
enhance: cache scalar-index IsNotNull() across batches on the ByOffsets paths

### DIFF
--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -373,6 +373,20 @@ class SegmentExpr : public Expr {
         }
     }
 
+    // The IsNotNull() virtual rebuilds a segment-sized bitmap on every
+    // call (allocation + fill + AND); per-batch callers must reuse one
+    // copy. The all-valid flag short-circuits per-row bitmap reads.
+    template <typename Index>
+    const TargetBitmap&
+    GetCachedIndexValidBitmap(Index* index_ptr) {
+        if (!cached_index_valid_res_) {
+            cached_index_valid_res_ =
+                std::make_shared<TargetBitmap>(index_ptr->IsNotNull());
+            cached_index_all_valid_ = cached_index_valid_res_->all();
+        }
+        return *cached_index_valid_res_;
+    }
+
     int64_t
     GetNextBatchSize() {
         auto current_chunk =
@@ -556,9 +570,13 @@ class SegmentExpr : public Expr {
         auto scalar_index = dynamic_cast<const Index*>(pinned_index_[0].get());
         auto* index_ptr = const_cast<Index*>(scalar_index);
 
-        auto valid_result = index_ptr->IsNotNull();
-        for (auto i = 0; i < input->size(); ++i) {
-            valid_res[i] = valid_result[(*input)[i]];
+        const auto& valid_result = GetCachedIndexValidBitmap(index_ptr);
+        if (cached_index_all_valid_) {
+            valid_res.set();
+        } else {
+            for (auto i = 0; i < input->size(); ++i) {
+                valid_res[i] = valid_result[(*input)[i]];
+            }
         }
         auto result = std::move(func.template operator()<FilterType::random>(
             index_ptr, values..., input->data()));
@@ -584,7 +602,8 @@ class SegmentExpr : public Expr {
         using Index = index::ScalarIndex<IndexInnerType>;
         auto scalar_index = dynamic_cast<const Index*>(pinned_index_[0].get());
         auto* index_ptr = const_cast<Index*>(scalar_index);
-        auto valid_result = index_ptr->IsNotNull();
+        const auto& valid_result = GetCachedIndexValidBitmap(index_ptr);
+        const bool all_valid = cached_index_all_valid_;
         auto batch_size = input->size();
 
         if (!skip_func || !skip_func(skip_index, field_id_, 0)) {
@@ -596,7 +615,7 @@ class SegmentExpr : public Expr {
                     continue;
                 }
                 T raw_data = raw.value();
-                bool valid_data = valid_result[offset];
+                bool valid_data = all_valid || valid_result[offset];
                 func.template operator()<FilterType::random>(&raw_data,
                                                              &valid_data,
                                                              nullptr,
@@ -605,10 +624,17 @@ class SegmentExpr : public Expr {
                                                              valid_res + i,
                                                              values...);
             }
+        } else if (all_valid) {
+            res.set(0, batch_size);
+            valid_res.set(0, batch_size);
         } else {
             for (auto i = 0; i < batch_size; ++i) {
                 auto offset = (*input)[i];
-                res[i] = valid_res[i] = valid_result[offset];
+                // materialize the bool once: chaining proxies would read
+                // back the word just stored into valid_res
+                const bool valid = valid_result[offset];
+                valid_res[i] = valid;
+                res[i] = valid;
             }
         }
 
@@ -1794,10 +1820,12 @@ class SegmentExpr : public Expr {
                 auto scalar_index =
                     dynamic_cast<const Index*>(pinned_index_[0].get());
                 auto* index_ptr = const_cast<Index*>(scalar_index);
-                const auto& res = index_ptr->IsNotNull();
-                for (auto i = 0; i < batch_size; ++i) {
-                    valid_result[i] = res[input[i]];
-                }
+                const auto& res = GetCachedIndexValidBitmap(index_ptr);
+                if (!cached_index_all_valid_) {
+                    for (auto i = 0; i < batch_size; ++i) {
+                        valid_result[i] = res[input[i]];
+                    }
+                }  // else: valid_result is already all-set
             } else {
                 apply_field_valid_data();
             }
@@ -2243,6 +2271,11 @@ class SegmentExpr : public Expr {
     // Populated once per segment, then sliced per batch via SliceCachedResult().
     std::shared_ptr<TargetBitmap> cached_result_{nullptr};
     std::shared_ptr<TargetBitmap> cached_valid_result_{nullptr};
+
+    // Cached scalar-index IsNotNull() bitmap for the ByOffsets paths
+    // (single-index-chunk only); see GetCachedIndexValidBitmap().
+    std::shared_ptr<TargetBitmap> cached_index_valid_res_{nullptr};
+    bool cached_index_all_valid_{false};
 
     // Legacy cache fields — TODO: remove after all subclasses migrated to cached_result_.
     int64_t cached_index_chunk_id_{-1};


### PR DESCRIPTION
issue: #50444

## What this PR does

Expression evaluation is batch-driven (`PhyExpr::Eval()` once per 8192-row
batch, ~122× per 1M-row segment). The scalar-index **ByOffsets** validity paths
recomputed per-row work every batch that does not change within a query. This
removes three sources of it (all in `Expr.h`):

### 1. Cache `IsNotNull()` across batches (98.6x) — the core
`ScalarIndex::IsNotNull()` rebuilds a segment-sized bitmap on every call
(allocation + fill + AND, ~500KB traffic for 1M rows). The three ByOffsets paths
(`ProcessIndexChunksByOffsets`, `ProcessIndexLookupByOffsets`,
`ProcessChunksForValidByOffsets`) called it once per batch, while the ChunksAll
paths already cache it. Add `GetCachedIndexValidBitmap()` (expression-instance
cache + precomputed all-valid flag). Measured **3.32ms → 0.03ms** per expression
per 1M-row segment. All three callers assert `num_index_chunk_ == 1`, so the
cached answer cannot change within a query.

### 2. All-valid fast paths
When the column has no nulls (the common case), replace the per-row random
bitmap reads with one bulk `set()`, or skip the fill loop entirely (the output
bitmap is pre-set).

### 3. Avoid chained proxy assignment
In `ProcessIndexLookupByOffsets`, `res[i] = valid_res[i] = v` forces a
store-to-load read-back of the word just written; materialize the bool once.

## Scope note

This PR was split. The `ApplyValidData` vectorization (64-row pack + `countr_zero`)
and its rollout to the per-kernel validity-masking loops across the expression
kernels are handled in a follow-up PR; the `OffsetMapping` `all()/none()`
vectorization landed separately in #50468.

## Tests

- `Expr.*:ExprTest.*:*Null*:OffsetMapping.*` re-run: passing (2047 tests).
- Microbenchmarks (Xeon Gold 6338) as quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
