### PR TITLE
enhance: Add Go SDK search aggregation support

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cockroachdb/errors v1.9.1
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
-	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260514121806-9b60a053353f
+	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260526093827-489331a5a41f
 	github.com/milvus-io/milvus/pkg/v3 v3.0.0-beta
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/samber/lo v1.52.0

--- a/client/go.sum
+++ b/client/go.sum
@@ -222,8 +222,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
-github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260514121806-9b60a053353f h1:Z2paGeFL0i1a3Dqw82DwRwZ2ix3FtyKU7+u6rR7jbUs=
-github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260514121806-9b60a053353f/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260526093827-489331a5a41f h1:W+paUzc+AA381Rydx2DJffoQuM4l+efVqO+2i9GdfMw=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260526093827-489331a5a41f/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/client/milvusclient/iterator_option.go
+++ b/client/milvusclient/iterator_option.go
@@ -54,6 +54,9 @@ func (opt *searchIteratorOption) ValidateParams() error {
 	if opt.batchSize <= 0 {
 		return fmt.Errorf("batch size must be greater than 0")
 	}
+	if opt.searchAggregation != nil {
+		return fmt.Errorf("search_aggregation is not supported with search iterator")
+	}
 	return nil
 }
 

--- a/client/milvusclient/read.go
+++ b/client/milvusclient/read.go
@@ -68,6 +68,11 @@ func (c *Client) Search(ctx context.Context, option SearchOption, callOptions ..
 func (c *Client) handleSearchResult(schema *entity.Schema, outputFields []string, nq int, resp *milvuspb.SearchResults) ([]ResultSet, error) {
 	sr := make([]ResultSet, 0, nq)
 	results := resp.GetResults()
+	aggBuckets, err := parseAggregationBuckets(results)
+	if err != nil {
+		return nil, err
+	}
+	isAggregationResult := len(results.GetAggTopks()) > 0 || len(results.GetAggBuckets()) > 0
 	offset := 0
 	fieldDataList := results.GetFieldsData()
 	gb := results.GetGroupByFieldValue()
@@ -86,8 +91,14 @@ func (c *Client) handleSearchResult(schema *entity.Schema, outputFields []string
 				entry.Err = errors.Newf("topk not returned for nq %d", i)
 				return
 			}
+			if i < len(aggBuckets) {
+				entry.AggregationBuckets = aggBuckets[i]
+			}
 			rc = int(results.GetTopks()[i]) // result entry count for current query
 			entry.ResultCount = rc
+			if rc == 0 && isAggregationResult {
+				return
+			}
 			entry.Scores = results.GetScores()[offset : offset+rc]
 
 			// set recall if returned

--- a/client/milvusclient/read_example_test.go
+++ b/client/milvusclient/read_example_test.go
@@ -168,6 +168,59 @@ func ExampleClient_Search_outputFields() {
 	}
 }
 
+func ExampleClient_Search_searchAggregation() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	milvusAddr := "127.0.0.1:19530"
+	token := "root:Milvus"
+
+	cli, err := milvusclient.New(ctx, &milvusclient.ClientConfig{
+		Address: milvusAddr,
+		APIKey:  token,
+	})
+	if err != nil {
+		log.Fatal("failed to connect to milvus server: ", err.Error())
+	}
+
+	defer cli.Close(ctx)
+
+	queryVector := []float32{0.3580376395471989, -0.6023495712049978, 0.18414012509913835, -0.26286205330961354, 0.9029438446296592}
+	aggregation := milvusclient.NewSearchAggregation([]string{"category"}, 10).
+		WithSearchSize(30).
+		WithMetric("total_price", "sum", "price").
+		WithMetric("doc_count", "count", "*").
+		WithOrder("total_price", "desc").
+		WithTopHits(milvusclient.NewTopHits(2).WithSort("_score", "asc")).
+		WithSubAggregation(
+			milvusclient.NewSearchAggregation([]string{"brand"}, 5).
+				WithMetric("avg_rating", "avg", "rating").
+				WithOrder("avg_rating", "desc").
+				WithTopHits(milvusclient.NewTopHits(1).WithSort("rating", "desc")),
+		)
+
+	resultSets, err := cli.Search(ctx, milvusclient.NewSearchOption(
+		"products", // collectionName
+		100,        // limit is still required by Search; aggregation size controls returned buckets.
+		[]entity.Vector{entity.FloatVector(queryVector)},
+	).WithANNSField("embedding").WithSearchAggregation(aggregation))
+	if err != nil {
+		log.Fatal("failed to perform search aggregation: ", err.Error())
+	}
+
+	for _, bucket := range resultSets[0].AggregationBuckets {
+		log.Println("Bucket key: ", bucket.Key)
+		log.Println("Document count: ", bucket.Count)
+		log.Println("Metrics: ", bucket.Metrics)
+		for _, hit := range bucket.Hits {
+			log.Println("Top hit: ", hit.PK, hit.Score, hit.Fields)
+		}
+		for _, subBucket := range bucket.SubGroups {
+			log.Println("Sub bucket: ", subBucket.Key, subBucket.Metrics)
+		}
+	}
+}
+
 func ExampleClient_Search_offsetLimit() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/client/milvusclient/read_option_test.go
+++ b/client/milvusclient/read_option_test.go
@@ -186,6 +186,79 @@ func (s *SearchOptionSuite) TestPlaceHolder() {
 	}
 }
 
+func (s *SearchOptionSuite) TestSearchAggregationOption() {
+	opt := NewSearchOption("coll", 100, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+		WithSearchAggregation(
+			NewSearchAggregation([]string{"brand"}, 3).
+				WithMetric("count_all", "count", "*").
+				WithTopHits(NewTopHits(2).WithSort("_score", "asc")),
+		)
+
+	req, err := opt.Request()
+	s.Require().NoError(err)
+	s.NotNil(req.GetSearchAggregation())
+	s.Equal([]string{"brand"}, req.GetSearchAggregation().GetFields())
+	s.EqualValues(3, req.GetSearchAggregation().GetSize())
+	s.Equal("count", req.GetSearchAggregation().GetMetrics()["count_all"].GetOp())
+}
+
+func (s *SearchOptionSuite) TestSearchAggregationRejectsConflictingOptions() {
+	base := func() *searchOption {
+		return NewSearchOption("coll", 10, []entity.Vector{entity.FloatVector([]float32{0.1, 0.2})}).
+			WithSearchAggregation(NewSearchAggregation([]string{"brand"}, 3))
+	}
+
+	cases := []struct {
+		name string
+		opt  *searchOption
+		msg  string
+	}{
+		{
+			name: "legacy group by field",
+			opt:  base().WithGroupByField("brand"),
+			msg:  "search_aggregation and group_by_field/group_size are mutually exclusive",
+		},
+		{
+			name: "legacy group size",
+			opt:  base().WithGroupSize(2),
+			msg:  "search_aggregation and group_by_field/group_size are mutually exclusive",
+		},
+		{
+			name: "legacy strict group size",
+			opt:  base().WithStrictGroupSize(true),
+			msg:  "search_aggregation and group_by_field/group_size are mutually exclusive",
+		},
+		{
+			name: "offset",
+			opt:  base().WithOffset(1),
+			msg:  "offset is not supported with search_aggregation",
+		},
+		{
+			name: "raw offset param",
+			opt:  base().WithSearchParam("offset", "1"),
+			msg:  "offset is not supported with search_aggregation",
+		},
+		{
+			name: "raw group_by_field param",
+			opt:  base().WithSearchParam("group_by_field", "brand"),
+			msg:  "group_by_field and search_aggregation cannot be used simultaneously",
+		},
+		{
+			name: "raw group_by_fields param",
+			opt:  base().WithSearchParam("group_by_fields", "brand,color"),
+			msg:  "group_by_fields and search_aggregation cannot be used simultaneously",
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			_, err := tc.opt.Request()
+			s.Require().Error(err)
+			s.Contains(err.Error(), tc.msg)
+		})
+	}
+}
+
 func TestSearchOption(t *testing.T) {
 	suite.Run(t, new(SearchOptionSuite))
 }

--- a/client/milvusclient/read_options.go
+++ b/client/milvusclient/read_options.go
@@ -60,6 +60,7 @@ type searchOption struct {
 	collectionName             string
 	partitionNames             []string
 	outputFields               []string
+	searchAggregation          *SearchAggregation
 	consistencyLevel           entity.ConsistencyLevel
 	useDefaultConsistencyLevel bool
 }
@@ -335,6 +336,28 @@ func (opt *searchOption) Request() (*milvuspb.SearchRequest, error) {
 	request.ConsistencyLevel = commonpb.ConsistencyLevel(opt.consistencyLevel)
 	request.UseDefaultConsistency = opt.useDefaultConsistencyLevel
 	request.OutputFields = opt.outputFields
+	if opt.searchAggregation != nil {
+		if opt.annRequest.groupByField != "" || opt.annRequest.groupSize != 0 || opt.annRequest.strictGroupSize {
+			return nil, errors.New("search_aggregation and group_by_field/group_size are mutually exclusive")
+		}
+		if opt.annRequest.offset > 0 {
+			return nil, errors.New("offset is not supported with search_aggregation")
+		}
+		if rawOffset := strings.TrimSpace(opt.annRequest.searchParam[spOffset]); rawOffset != "" && rawOffset != "0" {
+			return nil, errors.New("offset is not supported with search_aggregation")
+		}
+		if strings.TrimSpace(opt.annRequest.searchParam[spGroupBy]) != "" {
+			return nil, errors.New("group_by_field and search_aggregation cannot be used simultaneously")
+		}
+		if strings.TrimSpace(opt.annRequest.searchParam["group_by_fields"]) != "" {
+			return nil, errors.New("group_by_fields and search_aggregation cannot be used simultaneously")
+		}
+		searchAggregation, err := opt.searchAggregation.protoMessage()
+		if err != nil {
+			return nil, err
+		}
+		request.SearchAggregation = searchAggregation
+	}
 
 	return request, nil
 }
@@ -402,6 +425,11 @@ func (opt *searchOption) WithAnnParam(ap index.AnnParam) *searchOption {
 
 func (opt *searchOption) WithSearchParam(key, value string) *searchOption {
 	opt.annRequest.WithSearchParam(key, value)
+	return opt
+}
+
+func (opt *searchOption) WithSearchAggregation(agg *SearchAggregation) *searchOption {
+	opt.searchAggregation = agg
 	return opt
 }
 

--- a/client/milvusclient/results.go
+++ b/client/milvusclient/results.go
@@ -37,9 +37,11 @@ type ResultSet struct {
 	GroupByValue column.Column
 	IDs          column.Column // auto generated id, can be mapped to the columns from `Insert` API
 	Fields       DataSet       // output field data
-	Scores       []float32     // distance to the target vector
-	Recall       float32       // recall of the query vector's search result (estimated by zilliz cloud)
-	Err          error         // search error if any
+	// AggregationBuckets contains search aggregation results for this query.
+	AggregationBuckets []AggregationBucket
+	Scores             []float32 // distance to the target vector
+	Recall             float32   // recall of the query vector's search result (estimated by zilliz cloud)
+	Err                error     // search error if any
 }
 
 // GetColumn returns column with provided field name.
@@ -62,6 +64,7 @@ func (rs ResultSet) Slice(start, end int) ResultSet {
 		Fields: lo.Map(rs.Fields, func(column column.Column, _ int) column.Column {
 			return column.Slice(start, end)
 		}),
+		AggregationBuckets: rs.AggregationBuckets,
 		// Recall will not be sliced
 		Err: rs.Err,
 	}

--- a/client/milvusclient/search_aggregation.go
+++ b/client/milvusclient/search_aggregation.go
@@ -1,0 +1,277 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package milvusclient
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+)
+
+var (
+	validAggregationMetricOps = map[string]struct{}{
+		"avg":   {},
+		"sum":   {},
+		"count": {},
+		"min":   {},
+		"max":   {},
+	}
+	validAggregationDirections = map[string]struct{}{
+		"asc":  {},
+		"desc": {},
+	}
+	specialAggregationOrderKeys = map[string]struct{}{
+		"_count": {},
+		"_key":   {},
+	}
+)
+
+// SearchAggregation describes one level of bucket aggregation for Search.
+type SearchAggregation struct {
+	fields         []string
+	size           int64
+	searchSize     int64
+	metrics        map[string]aggregationMetric
+	order          []aggregationOrder
+	topHits        *TopHits
+	subAggregation *SearchAggregation
+}
+
+type aggregationMetric struct {
+	op        string
+	fieldName string
+}
+
+type aggregationOrder struct {
+	key       string
+	direction string
+}
+
+type aggregationSort struct {
+	fieldName string
+	direction string
+}
+
+// TopHits describes representative hits returned inside each aggregation bucket.
+type TopHits struct {
+	size int64
+	sort []aggregationSort
+}
+
+// NewSearchAggregation creates one search aggregation level.
+func NewSearchAggregation(fields []string, size int) *SearchAggregation {
+	return &SearchAggregation{
+		fields:  append([]string(nil), fields...),
+		size:    int64(size),
+		metrics: make(map[string]aggregationMetric),
+	}
+}
+
+// WithSearchSize sets the candidate bucket budget for this aggregation level.
+func (a *SearchAggregation) WithSearchSize(searchSize int) *SearchAggregation {
+	a.searchSize = int64(searchSize)
+	return a
+}
+
+// WithMetric adds an aggregation metric.
+func (a *SearchAggregation) WithMetric(alias, op, fieldName string) *SearchAggregation {
+	if a.metrics == nil {
+		a.metrics = make(map[string]aggregationMetric)
+	}
+	a.metrics[alias] = aggregationMetric{op: op, fieldName: fieldName}
+	return a
+}
+
+// WithOrder appends a bucket ordering criterion.
+func (a *SearchAggregation) WithOrder(key, direction string) *SearchAggregation {
+	a.order = append(a.order, aggregationOrder{key: key, direction: direction})
+	return a
+}
+
+// WithTopHits sets the top hits spec for this aggregation level.
+func (a *SearchAggregation) WithTopHits(topHits *TopHits) *SearchAggregation {
+	a.topHits = topHits
+	return a
+}
+
+// WithSubAggregation sets the nested child aggregation level.
+func (a *SearchAggregation) WithSubAggregation(sub *SearchAggregation) *SearchAggregation {
+	a.subAggregation = sub
+	return a
+}
+
+// NewTopHits creates a top hits spec.
+func NewTopHits(size int) *TopHits {
+	return &TopHits{size: int64(size)}
+}
+
+// WithSort appends a top hits sorting criterion.
+func (h *TopHits) WithSort(fieldName, direction string) *TopHits {
+	h.sort = append(h.sort, aggregationSort{fieldName: fieldName, direction: direction})
+	return h
+}
+
+func (a *SearchAggregation) Validate() error {
+	_, err := a.protoMessage()
+	return err
+}
+
+func (h *TopHits) Validate() error {
+	_, err := h.protoMessage()
+	return err
+}
+
+func (a *SearchAggregation) protoMessage() (*commonpb.SearchAggregationSpec, error) {
+	if a == nil {
+		return nil, errors.New("search_aggregation cannot be nil")
+	}
+	if len(a.fields) == 0 {
+		return nil, errors.New("SearchAggregation.fields must be non-empty")
+	}
+	fields := make([]string, 0, len(a.fields))
+	for _, field := range a.fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return nil, errors.New("SearchAggregation.fields must contain non-empty field names")
+		}
+		if isAggregationJSONPath(field) {
+			return nil, fmt.Errorf("SearchAggregation.fields does not yet support bracketed JSON path expressions: %q", field)
+		}
+		fields = append(fields, field)
+	}
+	if a.size <= 0 {
+		return nil, errors.New("SearchAggregation.size must be positive")
+	}
+	if a.searchSize < 0 {
+		return nil, errors.New("SearchAggregation.search_size must be non-negative")
+	}
+	if a.searchSize > 0 && a.searchSize < a.size {
+		return nil, errors.New("SearchAggregation.search_size must be greater than or equal to size")
+	}
+
+	spec := &commonpb.SearchAggregationSpec{
+		Fields:     fields,
+		Size:       a.size,
+		SearchSize: a.searchSize,
+	}
+
+	metricAliases := make(map[string]struct{}, len(a.metrics))
+	if len(a.metrics) > 0 {
+		spec.Metrics = make(map[string]*commonpb.MetricAggSpec, len(a.metrics))
+	}
+	for alias, metric := range a.metrics {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			return nil, errors.New("metric alias must be non-empty")
+		}
+		op := strings.ToLower(strings.TrimSpace(metric.op))
+		if _, ok := validAggregationMetricOps[op]; !ok {
+			return nil, fmt.Errorf("unsupported metric op %q", metric.op)
+		}
+		fieldName := strings.TrimSpace(metric.fieldName)
+		if fieldName == "" {
+			return nil, fmt.Errorf("metric %q field name must be non-empty", alias)
+		}
+		if isAggregationJSONPath(fieldName) {
+			return nil, fmt.Errorf("metric %q field does not yet support bracketed JSON path expressions: %q", alias, fieldName)
+		}
+		if op != "count" && fieldName == "*" {
+			return nil, fmt.Errorf("metric %q field_name '*' is only valid for count op", alias)
+		}
+		spec.Metrics[alias] = &commonpb.MetricAggSpec{Op: op, FieldName: fieldName}
+		metricAliases[alias] = struct{}{}
+	}
+
+	for _, order := range a.order {
+		key := strings.TrimSpace(order.key)
+		if key == "" {
+			return nil, errors.New("SearchAggregation.order key must be non-empty")
+		}
+		if _, ok := metricAliases[key]; !ok {
+			if _, ok := specialAggregationOrderKeys[key]; !ok {
+				return nil, fmt.Errorf("SearchAggregation.order key %q must be a metric alias or one of [_count _key]", key)
+			}
+		}
+		direction, err := normalizeAggregationDirection(order.direction)
+		if err != nil {
+			return nil, fmt.Errorf("invalid SearchAggregation.order direction for %q: %w", key, err)
+		}
+		spec.Order = append(spec.Order, &commonpb.OrderSpec{Key: key, Direction: direction})
+	}
+
+	if a.topHits != nil {
+		topHits, err := a.topHits.protoMessage()
+		if err != nil {
+			return nil, err
+		}
+		spec.TopHits = topHits
+	}
+
+	if a.subAggregation != nil {
+		sub, err := a.subAggregation.protoMessage()
+		if err != nil {
+			return nil, err
+		}
+		spec.SubAggregation = sub
+	}
+
+	return spec, nil
+}
+
+func (h *TopHits) protoMessage() (*commonpb.TopHitsSpec, error) {
+	if h == nil {
+		return nil, errors.New("top_hits cannot be nil")
+	}
+	if h.size <= 0 {
+		return nil, errors.New("TopHits.size must be positive")
+	}
+
+	spec := &commonpb.TopHitsSpec{Size: h.size}
+	for _, sort := range h.sort {
+		fieldName := strings.TrimSpace(sort.fieldName)
+		if fieldName == "" {
+			return nil, errors.New("TopHits.sort field name must be non-empty")
+		}
+		if isAggregationJSONPath(fieldName) {
+			return nil, fmt.Errorf("TopHits.sort does not yet support bracketed JSON path expressions: %q", fieldName)
+		}
+		direction, err := normalizeAggregationDirection(sort.direction)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TopHits.sort direction for %q: %w", fieldName, err)
+		}
+		spec.Sort = append(spec.Sort, &commonpb.SortSpec{FieldName: fieldName, Direction: direction})
+	}
+	return spec, nil
+}
+
+func normalizeAggregationDirection(direction string) (string, error) {
+	direction = strings.ToLower(strings.TrimSpace(direction))
+	if direction == "" {
+		return "", errors.New("direction must be non-empty")
+	}
+	if _, ok := validAggregationDirections[direction]; !ok {
+		return "", fmt.Errorf("direction must be asc or desc, got %q", direction)
+	}
+	return direction, nil
+}
+
+func isAggregationJSONPath(fieldName string) bool {
+	return strings.Contains(fieldName, "[") || strings.Contains(fieldName, "]")
+}

--- a/client/milvusclient/search_aggregation_result.go
+++ b/client/milvusclient/search_aggregation_result.go
@@ -1,0 +1,229 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package milvusclient
+
+import (
+	"strconv"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+)
+
+// AggregationBucket is one bucket in a search aggregation result tree.
+type AggregationBucket struct {
+	Key       []BucketKeyEntry
+	Count     int64
+	Metrics   map[string]any
+	Hits      []AggregationHit
+	SubGroups []AggregationBucket
+}
+
+// BucketKeyEntry is one field value in a bucket key.
+type BucketKeyEntry struct {
+	FieldName string
+	FieldID   int64
+	Value     any
+}
+
+// AggregationHit is one top hit inside an aggregation bucket.
+type AggregationHit struct {
+	PK       any
+	Score    float32
+	Fields   map[string]any
+	FieldIDs map[string]int64
+}
+
+func parseAggregationBuckets(results *schemapb.SearchResultData) ([][]AggregationBucket, error) {
+	if results == nil {
+		return nil, nil
+	}
+	pbBuckets := results.GetAggBuckets()
+	aggTopks := results.GetAggTopks()
+	if len(pbBuckets) == 0 && len(aggTopks) == 0 {
+		return nil, nil
+	}
+	if len(aggTopks) == 0 {
+		return nil, errors.New("search_aggregation response missing agg_topks")
+	}
+	if len(aggTopks) != int(results.GetNumQueries()) {
+		return nil, errors.Newf("search_aggregation agg_topks length %d does not match nq %d", len(aggTopks), results.GetNumQueries())
+	}
+
+	total := int64(0)
+	for _, topk := range aggTopks {
+		if topk < 0 {
+			return nil, errors.New("search_aggregation agg_topks cannot contain negative values")
+		}
+		total += topk
+	}
+	if total != int64(len(pbBuckets)) {
+		return nil, errors.Newf("search_aggregation agg_topks sum %d does not match bucket count %d", total, len(pbBuckets))
+	}
+
+	parsed := make([][]AggregationBucket, len(aggTopks))
+	offset := 0
+	for i, topk := range aggTopks {
+		buckets := make([]AggregationBucket, 0, int(topk))
+		for j := int64(0); j < topk; j++ {
+			bucket, err := parseAggregationBucket(pbBuckets[offset])
+			if err != nil {
+				return nil, err
+			}
+			buckets = append(buckets, bucket)
+			offset++
+		}
+		parsed[i] = buckets
+	}
+	return parsed, nil
+}
+
+func parseAggregationBucket(pb *schemapb.AggBucket) (AggregationBucket, error) {
+	if pb == nil {
+		return AggregationBucket{}, errors.New("search_aggregation bucket is nil")
+	}
+	bucket := AggregationBucket{
+		Key:       make([]BucketKeyEntry, 0, len(pb.GetKey())),
+		Metrics:   make(map[string]any, len(pb.GetMetrics())),
+		Hits:      make([]AggregationHit, 0, len(pb.GetHits())),
+		SubGroups: make([]AggregationBucket, 0, len(pb.GetSubGroups())),
+		Count:     pb.GetCount(),
+	}
+	for _, entry := range pb.GetKey() {
+		bucket.Key = append(bucket.Key, parseBucketKeyEntry(entry))
+	}
+	for alias, metric := range pb.GetMetrics() {
+		bucket.Metrics[alias] = metricValueToAny(metric)
+	}
+	for _, hit := range pb.GetHits() {
+		bucket.Hits = append(bucket.Hits, parseAggregationHit(hit))
+	}
+	for _, sub := range pb.GetSubGroups() {
+		subBucket, err := parseAggregationBucket(sub)
+		if err != nil {
+			return AggregationBucket{}, err
+		}
+		bucket.SubGroups = append(bucket.SubGroups, subBucket)
+	}
+	return bucket, nil
+}
+
+func parseBucketKeyEntry(pb *schemapb.BucketKeyEntry) BucketKeyEntry {
+	if pb == nil {
+		return BucketKeyEntry{}
+	}
+	fieldName := pb.GetFieldName()
+	if fieldName == "" {
+		fieldName = strconv.FormatInt(pb.GetFieldId(), 10)
+	}
+	return BucketKeyEntry{
+		FieldName: fieldName,
+		FieldID:   pb.GetFieldId(),
+		Value:     bucketKeyEntryValueToAny(pb),
+	}
+}
+
+func parseAggregationHit(pb *schemapb.AggHit) AggregationHit {
+	if pb == nil {
+		return AggregationHit{}
+	}
+	hit := AggregationHit{
+		PK:       aggHitPKToAny(pb),
+		Score:    pb.GetScore(),
+		Fields:   make(map[string]any, len(pb.GetFields())),
+		FieldIDs: make(map[string]int64, len(pb.GetFields())),
+	}
+	for _, field := range pb.GetFields() {
+		fieldName := field.GetFieldName()
+		if fieldName == "" {
+			fieldName = strconv.FormatInt(field.GetFieldId(), 10)
+		}
+		hit.Fields[fieldName] = aggHitFieldValueToAny(field)
+		hit.FieldIDs[fieldName] = field.GetFieldId()
+	}
+	return hit
+}
+
+func metricValueToAny(pb *schemapb.MetricValue) any {
+	if pb == nil {
+		return nil
+	}
+	switch v := pb.GetValue().(type) {
+	case *schemapb.MetricValue_IntVal:
+		return v.IntVal
+	case *schemapb.MetricValue_DoubleVal:
+		return v.DoubleVal
+	case *schemapb.MetricValue_StringVal:
+		return v.StringVal
+	case *schemapb.MetricValue_BoolVal:
+		return v.BoolVal
+	default:
+		return nil
+	}
+}
+
+func aggHitFieldValueToAny(pb *schemapb.AggHitField) any {
+	if pb == nil {
+		return nil
+	}
+	switch v := pb.GetValue().(type) {
+	case *schemapb.AggHitField_IntVal:
+		return v.IntVal
+	case *schemapb.AggHitField_BoolVal:
+		return v.BoolVal
+	case *schemapb.AggHitField_FloatVal:
+		return v.FloatVal
+	case *schemapb.AggHitField_DoubleVal:
+		return v.DoubleVal
+	case *schemapb.AggHitField_StringVal:
+		return v.StringVal
+	case *schemapb.AggHitField_BytesVal:
+		return v.BytesVal
+	default:
+		return nil
+	}
+}
+
+func bucketKeyEntryValueToAny(pb *schemapb.BucketKeyEntry) any {
+	if pb == nil {
+		return nil
+	}
+	switch v := pb.GetValue().(type) {
+	case *schemapb.BucketKeyEntry_IntVal:
+		return v.IntVal
+	case *schemapb.BucketKeyEntry_StringVal:
+		return v.StringVal
+	case *schemapb.BucketKeyEntry_BoolVal:
+		return v.BoolVal
+	default:
+		return nil
+	}
+}
+
+func aggHitPKToAny(pb *schemapb.AggHit) any {
+	if pb == nil {
+		return nil
+	}
+	switch v := pb.GetPk().(type) {
+	case *schemapb.AggHit_IntPk:
+		return v.IntPk
+	case *schemapb.AggHit_StrPk:
+		return v.StrPk
+	default:
+		return nil
+	}
+}

--- a/client/milvusclient/search_aggregation_result_test.go
+++ b/client/milvusclient/search_aggregation_result_test.go
@@ -1,0 +1,189 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package milvusclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/client/v2/entity"
+)
+
+func makeAggBucketProto() *schemapb.AggBucket {
+	return &schemapb.AggBucket{
+		Key: []*schemapb.BucketKeyEntry{
+			{FieldId: 100, FieldName: "brand", Value: &schemapb.BucketKeyEntry_StringVal{StringVal: "acme"}},
+			{FieldId: 101, FieldName: "active", Value: &schemapb.BucketKeyEntry_BoolVal{BoolVal: true}},
+			{FieldId: 102, Value: &schemapb.BucketKeyEntry_IntVal{IntVal: 7}},
+		},
+		Count: 3,
+		Metrics: map[string]*schemapb.MetricValue{
+			"count": {Value: &schemapb.MetricValue_IntVal{IntVal: 3}},
+			"avg":   {Value: &schemapb.MetricValue_DoubleVal{DoubleVal: 12.5}},
+			"label": {Value: &schemapb.MetricValue_StringVal{StringVal: "hot"}},
+			"flag":  {Value: &schemapb.MetricValue_BoolVal{BoolVal: true}},
+		},
+		Hits: []*schemapb.AggHit{
+			{
+				Pk:    &schemapb.AggHit_IntPk{IntPk: 10},
+				Score: 0.5,
+				Fields: []*schemapb.AggHitField{
+					{FieldId: 200, FieldName: "price", Value: &schemapb.AggHitField_IntVal{IntVal: 99}},
+					{FieldId: 201, FieldName: "in_stock", Value: &schemapb.AggHitField_BoolVal{BoolVal: true}},
+					{FieldId: 202, FieldName: "score_f", Value: &schemapb.AggHitField_FloatVal{FloatVal: 1.5}},
+					{FieldId: 203, FieldName: "rating", Value: &schemapb.AggHitField_DoubleVal{DoubleVal: 4.8}},
+					{FieldId: 204, FieldName: "name", Value: &schemapb.AggHitField_StringVal{StringVal: "item"}},
+					{FieldId: 205, FieldName: "raw", Value: &schemapb.AggHitField_BytesVal{BytesVal: []byte{1, 2}}},
+					{FieldId: 206, Value: &schemapb.AggHitField_StringVal{StringVal: "fallback"}},
+				},
+			},
+			{
+				Pk:    &schemapb.AggHit_StrPk{StrPk: "pk2"},
+				Score: 0.8,
+			},
+		},
+		SubGroups: []*schemapb.AggBucket{
+			{
+				Key:   []*schemapb.BucketKeyEntry{{FieldId: 110, FieldName: "color", Value: &schemapb.BucketKeyEntry_StringVal{StringVal: "red"}}},
+				Count: 1,
+			},
+		},
+	}
+}
+
+func TestParseAggregationBuckets(t *testing.T) {
+	results := &schemapb.SearchResultData{
+		NumQueries: 2,
+		AggTopks:   []int64{1, 0},
+		AggBuckets: []*schemapb.AggBucket{makeAggBucketProto()},
+	}
+
+	buckets, err := parseAggregationBuckets(results)
+	require.NoError(t, err)
+	require.Len(t, buckets, 2)
+	require.Len(t, buckets[0], 1)
+	require.Empty(t, buckets[1])
+
+	bucket := buckets[0][0]
+	require.EqualValues(t, 3, bucket.Count)
+	require.Equal(t, []BucketKeyEntry{
+		{FieldName: "brand", FieldID: 100, Value: "acme"},
+		{FieldName: "active", FieldID: 101, Value: true},
+		{FieldName: "102", FieldID: 102, Value: int64(7)},
+	}, bucket.Key)
+	require.Equal(t, map[string]any{
+		"count": int64(3),
+		"avg":   float64(12.5),
+		"label": "hot",
+		"flag":  true,
+	}, bucket.Metrics)
+	require.Len(t, bucket.Hits, 2)
+	require.EqualValues(t, 10, bucket.Hits[0].PK)
+	require.EqualValues(t, 0.5, bucket.Hits[0].Score)
+	require.Equal(t, map[string]any{
+		"price":    int64(99),
+		"in_stock": true,
+		"score_f":  float32(1.5),
+		"rating":   float64(4.8),
+		"name":     "item",
+		"raw":      []byte{1, 2},
+		"206":      "fallback",
+	}, bucket.Hits[0].Fields)
+	require.Equal(t, map[string]int64{
+		"price":    200,
+		"in_stock": 201,
+		"score_f":  202,
+		"rating":   203,
+		"name":     204,
+		"raw":      205,
+		"206":      206,
+	}, bucket.Hits[0].FieldIDs)
+	require.Equal(t, "pk2", bucket.Hits[1].PK)
+	require.Len(t, bucket.SubGroups, 1)
+	require.Equal(t, "red", bucket.SubGroups[0].Key[0].Value)
+}
+
+func TestParseAggregationBucketsRejectsMalformedAggTopks(t *testing.T) {
+	cases := []*schemapb.SearchResultData{
+		{NumQueries: 2, AggTopks: []int64{1}, AggBuckets: []*schemapb.AggBucket{makeAggBucketProto()}},
+		{NumQueries: 1, AggBuckets: []*schemapb.AggBucket{makeAggBucketProto()}},
+		{NumQueries: 1, AggTopks: []int64{2}, AggBuckets: []*schemapb.AggBucket{makeAggBucketProto()}},
+		{NumQueries: 1, AggTopks: []int64{-1}},
+	}
+	for _, tc := range cases {
+		_, err := parseAggregationBuckets(tc)
+		require.Error(t, err)
+	}
+}
+
+func (s *ReadSuite) TestHandleSearchResultAggregationWithOutputFieldsDoesNotParseNormalFields() {
+	resp := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			Topks:      []int64{0},
+			AggTopks:   []int64{1},
+			AggBuckets: []*schemapb.AggBucket{makeAggBucketProto()},
+		},
+	}
+
+	resultSets, err := s.client.handleSearchResult(s.schema, []string{"brand", "price"}, 1, resp)
+	s.Require().NoError(err)
+	s.Require().Len(resultSets, 1)
+	s.Equal(0, resultSets[0].ResultCount)
+	s.Nil(resultSets[0].IDs)
+	s.Empty(resultSets[0].Fields)
+	s.Empty(resultSets[0].Scores)
+	s.Require().Len(resultSets[0].AggregationBuckets, 1)
+	s.Equal("acme", resultSets[0].AggregationBuckets[0].Key[0].Value)
+}
+
+func (s *ReadSuite) TestHandleSearchResultRejectsMalformedAggTopks() {
+	resp := &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 2,
+			Topks:      []int64{0, 0},
+			AggTopks:   []int64{1},
+			AggBuckets: []*schemapb.AggBucket{makeAggBucketProto()},
+		},
+	}
+
+	_, err := s.client.handleSearchResult(s.schema, nil, 2, resp)
+	s.Require().Error(err)
+}
+
+func (s *ResultSetSuite) TestResultSetSliceKeepsAggregationBuckets() {
+	rs := ResultSet{
+		AggregationBuckets: []AggregationBucket{{Count: 1}},
+	}
+
+	sliced := rs.Slice(0, 0)
+	s.Require().Len(sliced.AggregationBuckets, 1)
+	s.EqualValues(1, sliced.AggregationBuckets[0].Count)
+}
+
+func (s *SearchIteratorSuite) TestSearchIteratorRejectsSearchAggregation() {
+	opt := NewSearchIteratorOption("coll", entity.FloatVector([]float32{0.1, 0.2}))
+	opt.WithSearchAggregation(NewSearchAggregation([]string{"brand"}, 3))
+
+	_, err := s.client.SearchIterator(context.Background(), opt)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "search_aggregation is not supported with search iterator")
+}

--- a/client/milvusclient/search_aggregation_test.go
+++ b/client/milvusclient/search_aggregation_test.go
@@ -1,0 +1,115 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package milvusclient
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchAggregationProtoBasic(t *testing.T) {
+	agg := NewSearchAggregation([]string{"brand", "color"}, 5).
+		WithSearchSize(20).
+		WithMetric("avg_price", "AVG", "price").
+		WithMetric("max_score", "max", "_score").
+		WithMetric("doc_count", "count", "*").
+		WithOrder("avg_price", "DESC").
+		WithTopHits(NewTopHits(2).WithSort("_score", "ASC"))
+
+	pb, err := agg.protoMessage()
+	require.NoError(t, err)
+	require.Equal(t, []string{"brand", "color"}, pb.GetFields())
+	require.EqualValues(t, 5, pb.GetSize())
+	require.EqualValues(t, 20, pb.GetSearchSize())
+	require.Equal(t, "avg", pb.GetMetrics()["avg_price"].GetOp())
+	require.Equal(t, "price", pb.GetMetrics()["avg_price"].GetFieldName())
+	require.Equal(t, "max", pb.GetMetrics()["max_score"].GetOp())
+	require.Equal(t, "_score", pb.GetMetrics()["max_score"].GetFieldName())
+	require.Equal(t, "count", pb.GetMetrics()["doc_count"].GetOp())
+	require.Equal(t, "*", pb.GetMetrics()["doc_count"].GetFieldName())
+	require.Equal(t, "avg_price", pb.GetOrder()[0].GetKey())
+	require.Equal(t, "desc", pb.GetOrder()[0].GetDirection())
+	require.EqualValues(t, 2, pb.GetTopHits().GetSize())
+	require.Equal(t, "_score", pb.GetTopHits().GetSort()[0].GetFieldName())
+	require.Equal(t, "asc", pb.GetTopHits().GetSort()[0].GetDirection())
+}
+
+func TestSearchAggregationProtoNested(t *testing.T) {
+	agg := NewSearchAggregation([]string{"category"}, 3).
+		WithSubAggregation(
+			NewSearchAggregation([]string{"brand", "color"}, 2).
+				WithMetric("avg_rating", "avg", "rating").
+				WithTopHits(NewTopHits(1).WithSort("price", "asc")),
+		)
+
+	pb, err := agg.protoMessage()
+	require.NoError(t, err)
+	require.Equal(t, []string{"brand", "color"}, pb.GetSubAggregation().GetFields())
+	require.EqualValues(t, 2, pb.GetSubAggregation().GetSize())
+	require.EqualValues(t, 1, pb.GetSubAggregation().GetTopHits().GetSize())
+}
+
+func TestSearchAggregationProtoBuildsDeepNesting(t *testing.T) {
+	agg := NewSearchAggregation([]string{"level_0"}, 1)
+	for i := 1; i < 6; i++ {
+		agg = NewSearchAggregation([]string{fmt.Sprintf("level_%d", i)}, 1).
+			WithSubAggregation(agg)
+	}
+	pb, err := agg.protoMessage()
+	require.NoError(t, err)
+
+	depth := 1
+	for cur := pb; cur.GetSubAggregation() != nil; cur = cur.GetSubAggregation() {
+		depth++
+	}
+	require.Equal(t, 6, depth)
+}
+
+func TestSearchAggregationValidate(t *testing.T) {
+	cases := []struct {
+		name string
+		agg  *SearchAggregation
+	}{
+		{name: "empty fields", agg: NewSearchAggregation(nil, 3)},
+		{name: "empty field", agg: NewSearchAggregation([]string{""}, 3)},
+		{name: "json path field", agg: NewSearchAggregation([]string{`meta["region"]`}, 3)},
+		{name: "zero size", agg: NewSearchAggregation([]string{"brand"}, 0)},
+		{name: "negative size", agg: NewSearchAggregation([]string{"brand"}, -1)},
+		{name: "search size less than size", agg: NewSearchAggregation([]string{"brand"}, 4).WithSearchSize(3)},
+		{name: "negative search size", agg: NewSearchAggregation([]string{"brand"}, 4).WithSearchSize(-1)},
+		{name: "empty metric alias", agg: NewSearchAggregation([]string{"brand"}, 3).WithMetric("", "avg", "price")},
+		{name: "unsupported metric op", agg: NewSearchAggregation([]string{"brand"}, 3).WithMetric("m", "median", "price")},
+		{name: "empty metric field", agg: NewSearchAggregation([]string{"brand"}, 3).WithMetric("m", "avg", "")},
+		{name: "json metric field", agg: NewSearchAggregation([]string{"brand"}, 3).WithMetric("m", "avg", `meta["price"]`)},
+		{name: "star for non count", agg: NewSearchAggregation([]string{"brand"}, 3).WithMetric("m", "avg", "*")},
+		{name: "unknown order key", agg: NewSearchAggregation([]string{"brand"}, 3).WithOrder("missing", "desc")},
+		{name: "empty order direction", agg: NewSearchAggregation([]string{"brand"}, 3).WithOrder("_count", "")},
+		{name: "bad order direction", agg: NewSearchAggregation([]string{"brand"}, 3).WithOrder("_count", "down")},
+		{name: "bad top hits size", agg: NewSearchAggregation([]string{"brand"}, 3).WithTopHits(NewTopHits(0))},
+		{name: "empty top hits sort field", agg: NewSearchAggregation([]string{"brand"}, 3).WithTopHits(NewTopHits(1).WithSort("", "asc"))},
+		{name: "json top hits sort field", agg: NewSearchAggregation([]string{"brand"}, 3).WithTopHits(NewTopHits(1).WithSort(`meta["price"]`, "asc"))},
+		{name: "bad top hits sort direction", agg: NewSearchAggregation([]string{"brand"}, 3).WithTopHits(NewTopHits(1).WithSort("price", "up"))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Error(t, tc.agg.Validate())
+		})
+	}
+}

--- a/tests/go_client/go.mod
+++ b/tests/go_client/go.mod
@@ -5,7 +5,7 @@ go 1.25.10
 require (
 	github.com/apache/arrow/go/v17 v17.0.0
 	github.com/cockroachdb/errors v1.9.1
-	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260514121806-9b60a053353f
+	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260526093827-489331a5a41f
 	github.com/milvus-io/milvus/client/v2 v2.0.0-20241125024034-0b9edb62a92d
 	github.com/milvus-io/milvus/pkg/v3 v3.0.0-beta
 	github.com/minio/minio-go/v7 v7.0.73

--- a/tests/go_client/go.sum
+++ b/tests/go_client/go.sum
@@ -245,8 +245,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
-github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260514121806-9b60a053353f h1:Z2paGeFL0i1a3Dqw82DwRwZ2ix3FtyKU7+u6rR7jbUs=
-github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260514121806-9b60a053353f/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260526093827-489331a5a41f h1:W+paUzc+AA381Rydx2DJffoQuM4l+efVqO+2i9GdfMw=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260526093827-489331a5a41f/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/tests/go_client/testcases/search_aggregation_test.go
+++ b/tests/go_client/testcases/search_aggregation_test.go
@@ -1,0 +1,306 @@
+package testcases
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/client/v2/column"
+	"github.com/milvus-io/milvus/client/v2/entity"
+	"github.com/milvus-io/milvus/client/v2/index"
+	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+const (
+	searchAggPKField       = "id"
+	searchAggVectorField   = "vector"
+	searchAggBrandField    = "brand"
+	searchAggColorField    = "color"
+	searchAggCategoryField = "category"
+	searchAggPriceField    = "price"
+	searchAggRatingField   = "rating"
+	searchAggStockField    = "in_stock"
+	searchAggDim           = 4
+)
+
+type searchAggregationFixture struct {
+	collectionName string
+	vectors        []entity.FloatVector
+}
+
+func prepareSearchAggregationFixture(t *testing.T) searchAggregationFixture {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	collName := common.GenRandomString("search_agg", 6)
+	schema := entity.NewSchema().WithName(collName).
+		WithField(entity.NewField().WithName(searchAggPKField).WithDataType(entity.FieldTypeInt64).WithIsPrimaryKey(true)).
+		WithField(entity.NewField().WithName(searchAggVectorField).WithDataType(entity.FieldTypeFloatVector).WithDim(searchAggDim)).
+		WithField(entity.NewField().WithName(searchAggBrandField).WithDataType(entity.FieldTypeVarChar).WithMaxLength(32)).
+		WithField(entity.NewField().WithName(searchAggColorField).WithDataType(entity.FieldTypeVarChar).WithMaxLength(32)).
+		WithField(entity.NewField().WithName(searchAggCategoryField).WithDataType(entity.FieldTypeVarChar).WithMaxLength(32)).
+		WithField(entity.NewField().WithName(searchAggPriceField).WithDataType(entity.FieldTypeInt64)).
+		WithField(entity.NewField().WithName(searchAggRatingField).WithDataType(entity.FieldTypeDouble)).
+		WithField(entity.NewField().WithName(searchAggStockField).WithDataType(entity.FieldTypeBool))
+	err := mc.CreateCollection(ctx, client.NewCreateCollectionOption(collName, schema).WithConsistencyLevel(entity.ClStrong))
+	common.CheckErr(t, err, true)
+	t.Cleanup(func() {
+		cleanupCtx := hp.CreateContext(t, time.Second*30)
+		_ = mc.DropCollection(cleanupCtx, client.NewDropCollectionOption(collName))
+		_ = mc.Close(cleanupCtx)
+	})
+
+	pks := make([]int64, 0, 12)
+	vectors := make([][]float32, 0, 12)
+	brands := make([]string, 0, 12)
+	colors := make([]string, 0, 12)
+	categories := make([]string, 0, 12)
+	prices := make([]int64, 0, 12)
+	ratings := make([]float64, 0, 12)
+	stocks := make([]bool, 0, 12)
+
+	brandValues := []string{"brand_a", "brand_b", "brand_c"}
+	colorValues := []string{"red", "blue"}
+	categoryValues := []string{"phone", "tablet"}
+	for i := 0; i < 12; i++ {
+		pks = append(pks, int64(i))
+		vectors = append(vectors, []float32{float32(i), 0, 0, 0})
+		brands = append(brands, brandValues[i%len(brandValues)])
+		colors = append(colors, colorValues[(i/3)%len(colorValues)])
+		categories = append(categories, categoryValues[(i/6)%len(categoryValues)])
+		prices = append(prices, int64(100+i*10))
+		ratings = append(ratings, 3.0+float64(i%5)*0.25)
+		stocks = append(stocks, i%2 == 0)
+	}
+
+	_, err = mc.Insert(ctx, client.NewColumnBasedInsertOption(collName).WithColumns(
+		column.NewColumnInt64(searchAggPKField, pks),
+		column.NewColumnFloatVector(searchAggVectorField, searchAggDim, vectors),
+		column.NewColumnVarChar(searchAggBrandField, brands),
+		column.NewColumnVarChar(searchAggColorField, colors),
+		column.NewColumnVarChar(searchAggCategoryField, categories),
+		column.NewColumnInt64(searchAggPriceField, prices),
+		column.NewColumnDouble(searchAggRatingField, ratings),
+		column.NewColumnBool(searchAggStockField, stocks),
+	))
+	common.CheckErr(t, err, true)
+
+	flushTask, err := mc.Flush(ctx, client.NewFlushOption(collName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, flushTask.Await(ctx), true)
+
+	indexTask, err := mc.CreateIndex(ctx, client.NewCreateIndexOption(collName, searchAggVectorField, index.NewFlatIndex(entity.L2)))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, indexTask.Await(ctx), true)
+
+	loadTask, err := mc.LoadCollection(ctx, client.NewLoadCollectionOption(collName))
+	common.CheckErr(t, err, true)
+	common.CheckErr(t, loadTask.Await(ctx), true)
+
+	queryVectors := make([]entity.FloatVector, 0, len(vectors))
+	for _, vector := range vectors {
+		queryVectors = append(queryVectors, entity.FloatVector(vector))
+	}
+	return searchAggregationFixture{collectionName: collName, vectors: queryVectors}
+}
+
+func TestSearchAggregationSingleFieldTopHits(t *testing.T) {
+	t.Parallel()
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	fixture := prepareSearchAggregationFixture(t)
+
+	res, err := mc.Search(ctx, client.NewSearchOption(fixture.collectionName, 10, []entity.Vector{fixture.vectors[0], fixture.vectors[6]}).
+		WithANNSField(searchAggVectorField).
+		WithOutputFields(searchAggBrandField, searchAggPriceField).
+		WithSearchAggregation(
+			client.NewSearchAggregation([]string{searchAggBrandField}, 3).
+				WithMetric("doc_count", "count", "*").
+				WithMetric("total_price", "sum", searchAggPriceField).
+				WithOrder("_key", "asc").
+				WithTopHits(client.NewTopHits(2).WithSort("_score", "asc")),
+		))
+	common.CheckErr(t, err, true)
+	require.Len(t, res, 2)
+
+	for _, result := range res {
+		require.Len(t, result.AggregationBuckets, 3)
+		for _, bucket := range result.AggregationBuckets {
+			brand := requireSearchAggregationKey[string](t, bucket, searchAggBrandField)
+			require.EqualValues(t, bucket.Count, bucket.Metrics["doc_count"])
+			require.Len(t, bucket.Hits, 2)
+			requireSearchAggregationScoresAsc(t, bucket.Hits)
+
+			var priceSum int64
+			for _, hit := range bucket.Hits {
+				require.Equal(t, brand, hit.Fields[searchAggBrandField])
+				priceSum += hit.Fields[searchAggPriceField].(int64)
+			}
+			require.EqualValues(t, priceSum, bucket.Metrics["total_price"])
+		}
+	}
+}
+
+func TestSearchAggregationCompositeKeyMetricsOrder(t *testing.T) {
+	t.Parallel()
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	fixture := prepareSearchAggregationFixture(t)
+
+	res, err := mc.Search(ctx, client.NewSearchOption(fixture.collectionName, 10, []entity.Vector{fixture.vectors[0], fixture.vectors[6]}).
+		WithANNSField(searchAggVectorField).
+		WithFilter(fmt.Sprintf("%s == true", searchAggStockField)).
+		WithOutputFields(searchAggBrandField, searchAggColorField, searchAggPriceField, searchAggStockField).
+		WithSearchAggregation(
+			client.NewSearchAggregation([]string{searchAggBrandField, searchAggColorField}, 3).
+				WithMetric("avg_price", "avg", searchAggPriceField).
+				WithMetric("doc_count", "count", "*").
+				WithOrder("avg_price", "desc").
+				WithTopHits(client.NewTopHits(2).WithSort(searchAggPriceField, "asc")),
+		))
+	common.CheckErr(t, err, true)
+	require.Len(t, res, 2)
+
+	for _, result := range res {
+		require.Len(t, result.AggregationBuckets, 3)
+		var lastAvg float64
+		for i, bucket := range result.AggregationBuckets {
+			avgPrice := bucket.Metrics["avg_price"].(float64)
+			if i > 0 {
+				require.LessOrEqual(t, avgPrice, lastAvg)
+			}
+			lastAvg = avgPrice
+
+			brand := requireSearchAggregationKey[string](t, bucket, searchAggBrandField)
+			color := requireSearchAggregationKey[string](t, bucket, searchAggColorField)
+			require.EqualValues(t, bucket.Count, bucket.Metrics["doc_count"])
+			require.NotEmpty(t, bucket.Hits)
+			requireSearchAggregationHitPricesAsc(t, bucket.Hits)
+
+			var priceSum int64
+			for _, hit := range bucket.Hits {
+				require.Equal(t, brand, hit.Fields[searchAggBrandField])
+				require.Equal(t, color, hit.Fields[searchAggColorField])
+				require.True(t, hit.Fields[searchAggStockField].(bool))
+				priceSum += hit.Fields[searchAggPriceField].(int64)
+			}
+			require.InEpsilon(t, float64(priceSum)/float64(len(bucket.Hits)), avgPrice, 0.000001)
+		}
+	}
+}
+
+func TestSearchAggregationNestedWithFilter(t *testing.T) {
+	t.Parallel()
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	fixture := prepareSearchAggregationFixture(t)
+
+	res, err := mc.Search(ctx, client.NewSearchOption(fixture.collectionName, 10, []entity.Vector{fixture.vectors[0]}).
+		WithANNSField(searchAggVectorField).
+		WithFilter(fmt.Sprintf("%s == true", searchAggStockField)).
+		WithOutputFields(searchAggCategoryField, searchAggBrandField, searchAggRatingField, searchAggStockField).
+		WithSearchAggregation(
+			client.NewSearchAggregation([]string{searchAggCategoryField}, 2).
+				WithMetric("item_count", "count", "*").
+				WithOrder("_key", "asc").
+				WithTopHits(client.NewTopHits(1).WithSort("_score", "asc")).
+				WithSubAggregation(
+					client.NewSearchAggregation([]string{searchAggBrandField}, 2).
+						WithMetric("avg_rating", "avg", searchAggRatingField).
+						WithOrder("avg_rating", "desc").
+						WithTopHits(client.NewTopHits(1).WithSort(searchAggRatingField, "desc")),
+				),
+		))
+	common.CheckErr(t, err, true)
+	require.Len(t, res, 1)
+	require.Len(t, res[0].AggregationBuckets, 2)
+
+	for _, bucket := range res[0].AggregationBuckets {
+		category := requireSearchAggregationKey[string](t, bucket, searchAggCategoryField)
+		require.EqualValues(t, bucket.Count, bucket.Metrics["item_count"])
+		require.NotEmpty(t, bucket.Hits)
+		for _, hit := range bucket.Hits {
+			require.Equal(t, category, hit.Fields[searchAggCategoryField])
+			require.True(t, hit.Fields[searchAggStockField].(bool))
+		}
+
+		require.NotEmpty(t, bucket.SubGroups)
+		require.LessOrEqual(t, len(bucket.SubGroups), 2)
+		for _, subBucket := range bucket.SubGroups {
+			brand := requireSearchAggregationKey[string](t, subBucket, searchAggBrandField)
+			require.NotEmpty(t, subBucket.Hits)
+			for _, hit := range subBucket.Hits {
+				require.Equal(t, category, hit.Fields[searchAggCategoryField])
+				require.Equal(t, brand, hit.Fields[searchAggBrandField])
+				require.True(t, hit.Fields[searchAggStockField].(bool))
+				require.InEpsilon(t, hit.Fields[searchAggRatingField].(float64), subBucket.Metrics["avg_rating"].(float64), 0.000001)
+			}
+		}
+	}
+}
+
+func TestSearchAggregationRejectMutuallyExclusiveParams(t *testing.T) {
+	t.Parallel()
+
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+	fixture := prepareSearchAggregationFixture(t)
+	aggregation := client.NewSearchAggregation([]string{searchAggBrandField}, 2)
+
+	_, err := mc.Search(ctx, client.NewSearchOption(fixture.collectionName, 10, []entity.Vector{fixture.vectors[0]}).
+		WithANNSField(searchAggVectorField).
+		WithGroupByField(searchAggBrandField).
+		WithSearchAggregation(aggregation))
+	common.CheckErr(t, err, false, "search_aggregation and group_by_field/group_size are mutually exclusive")
+
+	_, err = mc.Search(ctx, client.NewSearchOption(fixture.collectionName, 10, []entity.Vector{fixture.vectors[0]}).
+		WithANNSField(searchAggVectorField).
+		WithSearchParam("offset", "1").
+		WithSearchAggregation(aggregation))
+	common.CheckErr(t, err, false, "offset is not supported with search_aggregation")
+
+	iteratorOpt := client.NewSearchIteratorOption(fixture.collectionName, fixture.vectors[0]).
+		WithANNSField(searchAggVectorField)
+	iteratorOpt.WithSearchAggregation(aggregation)
+	_, err = mc.SearchIterator(ctx, iteratorOpt)
+	common.CheckErr(t, err, false, "search_aggregation is not supported with search iterator")
+}
+
+func requireSearchAggregationKey[T comparable](t *testing.T, bucket client.AggregationBucket, fieldName string) T {
+	t.Helper()
+	for _, entry := range bucket.Key {
+		if entry.FieldName == fieldName {
+			value, ok := entry.Value.(T)
+			require.Truef(t, ok, "bucket key %s has unexpected type %T", fieldName, entry.Value)
+			return value
+		}
+	}
+	require.FailNowf(t, "bucket key not found", "field %s not found in %+v", fieldName, bucket.Key)
+	var zero T
+	return zero
+}
+
+func requireSearchAggregationScoresAsc(t *testing.T, hits []client.AggregationHit) {
+	t.Helper()
+	for i := 1; i < len(hits); i++ {
+		require.LessOrEqual(t, hits[i-1].Score, hits[i].Score)
+	}
+}
+
+func requireSearchAggregationHitPricesAsc(t *testing.T, hits []client.AggregationHit) {
+	t.Helper()
+	lastPrice := int64(math.MinInt64)
+	for _, hit := range hits {
+		price := hit.Fields[searchAggPriceField].(int64)
+		require.GreaterOrEqual(t, price, lastPrice)
+		lastPrice = price
+	}
+}


### PR DESCRIPTION
issue: #49046

## What
- Add Go SDK builders for search aggregation and top hits, including validation and proto request wiring.
- Parse search aggregation responses from `AggBuckets`/`AggTopks` into `ResultSet.AggregationBuckets`.
- Reject incompatible search options such as legacy group-by, offset, and search iterator usage.
- Add unit tests, a Go SDK example, and Go E2E coverage for search aggregation.

## Tests
- `cd client && go test ./... -count=1`
- `cd tests/go_client && GO_CLIENT_SKIP_EXTERNAL_TABLE_DEPS_INSTALL=true go test ./testcases -run TestSearchAggregation -count=1 -args -addr http://10.104.18.101:19530`

## Notes
- `make static-check` was attempted locally but blocked by missing LLVM: `ERROR: Valid LLVM (14-18) not installed. Run: brew install llvm@17`.
