### PR TITLE
fix: Reject RBAC role names with leading or trailing whitespace

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -5694,9 +5694,10 @@ func (node *Proxy) DropRole(ctx context.Context, req *milvuspb.DropRoleRequest) 
 	if err := merr.CheckHealthy(node.GetStateCode()); err != nil {
 		return merr.Status(err), nil
 	}
-	if err := ValidateRoleName(req.RoleName); err != nil {
-		return merr.Status(err), nil
-	}
+	// No need to check role name
+	// Validation shall be performed in `CreateRole`
+	// also permit dropping role with bad name, e.g. legacy roles persisted
+	// with leading/trailing whitespace before validation rejected them
 	if req.Base == nil {
 		req.Base = &commonpb.MsgBase{}
 	}

--- a/internal/proxy/impl_test.go
+++ b/internal/proxy/impl_test.go
@@ -3120,3 +3120,51 @@ func TestProxy_ListRefreshExternalCollectionJobs_ByCollection(t *testing.T) {
 	assert.NotContains(t, redactedSpec, "AKIAEXAMPLE")
 	assert.NotContains(t, redactedSpec, "SUPERSECRET")
 }
+
+func TestProxy_CreateRole_WhitespaceRoleName(t *testing.T) {
+	paramtable.Init()
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+	ctx := context.Background()
+
+	// Role names with leading/trailing whitespace must be rejected before
+	// the request is forwarded, otherwise the raw name is persisted as the
+	// role identity.
+	for _, name := range []string{" role", "role ", " role ", "\trole", "role\n"} {
+		resp, err := node.CreateRole(ctx, &milvuspb.CreateRoleRequest{
+			Entity: &milvuspb.RoleEntity{Name: name},
+		})
+		assert.NoError(t, err)
+		assert.False(t, merr.Ok(resp), "role name %q should be rejected", name)
+	}
+
+	mixc := mocks.NewMockMixCoordClient(t)
+	mixc.EXPECT().CreateRole(mock.Anything, mock.Anything).Return(merr.Success(), nil).Once()
+	node.mixCoord = mixc
+	resp, err := node.CreateRole(ctx, &milvuspb.CreateRoleRequest{
+		Entity: &milvuspb.RoleEntity{Name: "role"},
+	})
+	assert.NoError(t, err)
+	assert.True(t, merr.Ok(resp))
+}
+
+func TestProxy_DropRole_WhitespaceRoleName(t *testing.T) {
+	paramtable.Init()
+	// DropRole skips role name validation so that legacy roles persisted
+	// with leading/trailing whitespace can still be cleaned up.
+	var forwardedName string
+	mixc := mocks.NewMockMixCoordClient(t)
+	mixc.EXPECT().DropRole(mock.Anything, mock.Anything).RunAndReturn(
+		func(_ context.Context, req *milvuspb.DropRoleRequest, _ ...grpc.CallOption) (*commonpb.Status, error) {
+			forwardedName = req.GetRoleName()
+			return merr.Success(), nil
+		}).Once()
+
+	node := &Proxy{mixCoord: mixc}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	resp, err := node.DropRole(context.Background(), &milvuspb.DropRoleRequest{RoleName: " legacy_role"})
+	assert.NoError(t, err)
+	assert.True(t, merr.Ok(resp))
+	assert.Equal(t, " legacy_role", forwardedName)
+}

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -1534,9 +1534,9 @@ func validateName(entity string, nameType string) error {
 }
 
 func validateNameWithCustomChars(entity string, nameType string, allowedChars string) error {
-	entity = strings.TrimSpace(entity)
-
-	if entity == "" {
+	// Whitespace-only names are reported as empty; names with leading/trailing
+	// whitespace are rejected below by the character checks on the raw value.
+	if strings.TrimSpace(entity) == "" {
 		return merr.WrapErrParameterInvalid("not empty", entity, nameType+" should be not empty")
 	}
 

--- a/internal/proxy/util_test.go
+++ b/internal/proxy/util_test.go
@@ -813,6 +813,11 @@ func TestValidateName(t *testing.T) {
 		"",
 		string(longName),
 		"中文",
+		" abc",
+		"abc ",
+		" abc ",
+		"\tabc",
+		"abc\n",
 	}
 
 	for _, name := range invalidNames {


### PR DESCRIPTION
issue: #50246

## What changed
- Removed the `strings.TrimSpace` from `validateNameWithCustomChars` in `internal/proxy/util.go`. Validation used to run on a trimmed copy of the name while the raw request value was forwarded and persisted, so a role name like `" role"` passed validation but was stored with the whitespace as part of the RBAC identity key (`RolePrefix + "/" + entity.Name`). Raw names are now validated as-is, so leading/trailing whitespace is rejected consistently across `CreateRole`, `OperateUserRole`, `SelectRole`, `OperatePrivilege`, `OperatePrivilegeV2` and `SelectGrant` (and the other identifier types sharing the helper: object name, object type, privilege, snapshot name).
- Removed role-name validation from `Proxy.DropRole` so that roles already persisted with whitespace by older versions can still be dropped (`force_drop` also cascades grant cleanup via `DropGrant`). This mirrors #43064, which removed name validation from the drop-collection path for the same compatibility reason.
- Added unit tests: whitespace cases in `TestValidateName`, `CreateRole` rejecting padded names, and `DropRole` forwarding a legacy padded name unchanged.

## Why
`"role"`, `" role"` and `"role "` could become distinct, hard-to-operate role identities: lookups with the visually identical name fail, and grants/user-role mappings end up under the dirty key. Same root cause and same fix as #43064 applied to collection names.

## Verification
- `git diff --check` — clean
- `gofumpt -l` on changed files — clean
- `golangci-lint run --build-tags dynamic,test ./internal/proxy/...` (same config as `make static-check`) — 0 issues
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy/...` — all packages pass (`TestProxyRpcLimit` and `TestAccessLogger_WithMinio` require local etcd/MinIO services; both pass with those services running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)