### PR TITLE
test: fix mock registration race in TestIndexInspector_inspect

### DIFF
--- a/internal/datacoord/index_inspector_test.go
+++ b/internal/datacoord/index_inspector_test.go
@@ -90,11 +90,10 @@ func TestIndexInspector_inspect(t *testing.T) {
 
 		inspector := newIndexInspector(ctx, notifyChan, meta, scheduler, alloc, handler, storage, versionManager)
 
-		inspector.Start()
-		defer inspector.Stop()
-
-		notifyChan <- segment.GetCollectionID()
-
+		// Register all expectations before Start(): the inspector goroutine
+		// (reloadFromMeta, the ticker, and the notify channel) may invoke the
+		// mocks immediately, and a call racing with EXPECT registration hits
+		// a no-expectation mock and silently aborts the indexing flow.
 		alloc.EXPECT().AllocID(mock.Anything).Return(rand.Int63(), nil)
 		catalog.EXPECT().CreateSegmentIndex(mock.Anything, mock.Anything).Return(nil)
 		catalog.EXPECT().AlterSegmentIndexes(mock.Anything, mock.Anything).Return(nil)
@@ -110,6 +109,11 @@ func TestIndexInspector_inspect(t *testing.T) {
 			})
 			assert.NoError(t, err)
 		})
+
+		inspector.Start()
+		defer inspector.Stop()
+
+		notifyChan <- segment.GetCollectionID()
 
 		assert.Eventually(t, func() bool {
 			return !meta.indexMeta.IsUnIndexedSegment(segment.GetCollectionID(), segment.GetID())


### PR DESCRIPTION
## What this PR does

Fixes a flaky failure of `TestIndexInspector_inspect/normal_test` (observed in the `ci-v2/ut-go` run of #50438: `Enqueue: 0 out of 1 expectation(s) met`, `AlterSegmentIndexes: 1 out of 2`).

The test called `inspector.Start()` and pushed the notify **before** registering the mock expectations. `Start()` synchronously runs `reloadFromMeta()` and spawns the inspect loop (ticker + notify channel), so the inspector goroutine can invoke `AllocID` / `CreateSegmentIndex` / `Enqueue` while `EXPECT()` registration is still in progress on the test goroutine. A call that lands on a mock with no matching expectation aborts the indexing flow, the expected calls never happen, and the test fails at teardown with unmet expectations.

Fix: register all expectations before `Start()`, so no inspector-side call can race with registration.

## Tests

`go test -race -count=20 -run 'TestIndexInspector_inspect$' ./internal/datacoord/` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)