### PR TITLE
fix: stabilize flaky TestCreateIndexVanillaFaissGeneric by scanning all IVF lists

### DIFF
--- a/tests/go_client/testcases/index_test.go
+++ b/tests/go_client/testcases/index_test.go
@@ -1007,7 +1007,8 @@ func TestCreateIndexVanillaFaissGeneric(t *testing.T) {
 	queryVec := hp.GenSearchVectors(common.DefaultNq, common.DefaultDim, entity.FieldTypeFloatVector)
 	searchRes, err := mc.Search(ctx, client.NewSearchOption(schema.CollectionName, common.DefaultLimit, queryVec).
 		WithANNSField(common.DefaultFloatVecFieldName).
-		WithSearchParam("nprobe", "8").
+		// nprobe=nlist (IVF64) scans all lists so topK results are returned deterministically (#50392)
+		WithSearchParam("nprobe", "64").
 		WithConsistencyLevel(entity.ClStrong))
 	common.CheckErr(t, err, true)
 	common.CheckSearchResult(t, searchRes, common.DefaultNq, common.DefaultLimit)


### PR DESCRIPTION
issue: #50392

## What changed
- `tests/go_client/testcases/index_test.go`: in `TestCreateIndexVanillaFaissGeneric`, raise the search `nprobe` from `8` to `64` (= the index's `nlist`), with a comment explaining the coverage guarantee.

## Why
The test builds an `IVF64,Flat` FAISS index (`nlist=64`) over `DefaultNb=3000` rows, then searches with `topK=10` and `nprobe=8` — scanning only 8 of the 64 inverted lists (~12.5%). IVF clustering is non-uniform, so for some query vectors the 8 probed lists collectively hold fewer than `topK=10` vectors. The segment then returns a short result set and `CheckSearchResult` fails intermittently (observed `ResultCount=7` instead of `10` in Jenkins build 5691, while nearby builds passed). There is no client RPC error — it is a silent recall artifact of a low `nprobe`, not a server regression.

Setting `nprobe = nlist = 64` makes the search scan every inverted list, so all 3000 rows are examined and `topK=10` results are returned deterministically on every run, removing the flake. The test still exercises the full `FAISS` / `IVF64,Flat` index create + load + search path.

## Verification
- `git diff --check` — clean (no whitespace errors)
- `gofmt -l tests/go_client/testcases/index_test.go` — clean
- `go vet ./testcases/` (from `tests/go_client`) — exit 0
- The test is a Go SDK E2E case requiring a running Milvus standalone server, so functional confirmation runs in CI (`milvus-go-sdk-pipeline`), consistent with how the flake was originally reported.
