### PR TITLE
enhance: Add REST search aggregation support

### DIFF
--- a/internal/distributed/proxy/httpserver/constant.go
+++ b/internal/distributed/proxy/httpserver/constant.go
@@ -144,6 +144,7 @@ const (
 	HTTPReturnLoadState      = "loadState"
 	HTTPReturnLoadProgress   = "loadProgress"
 	HTTPReturnTopks          = "topks"
+	HTTPReturnAggTopks       = "aggTopks"
 
 	HTTPReturnHas = "has"
 

--- a/internal/distributed/proxy/httpserver/handler.go
+++ b/internal/distributed/proxy/httpserver/handler.go
@@ -360,6 +360,9 @@ func (h *Handlers) handleSearch(c *gin.Context) (interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: parse body failed: %v", errBadRequest, err)
 	}
+	if wrappedReq.HasSearchAggregation() {
+		return nil, fmt.Errorf("%w: searchAggregation is not supported for low-level REST search", errBadRequest)
+	}
 	req := milvuspb.SearchRequest{
 		Base:               wrappedReq.Base,
 		DbName:             wrappedReq.DbName,

--- a/internal/distributed/proxy/httpserver/handler_test.go
+++ b/internal/distributed/proxy/httpserver/handler_test.go
@@ -602,3 +602,21 @@ func TestHandlers(t *testing.T) {
 		})
 	}
 }
+
+func TestLowLevelSearchRejectSearchAggregation(t *testing.T) {
+	h := NewHandlers(&mockProxyComponent{})
+	testEngine := gin.New()
+	h.RegisterRoutesTo(testEngine)
+
+	for _, body := range [][]byte{
+		[]byte(`{"collection_name":"book","searchAggregation":{"fields":["brand"],"size":1}}`),
+		[]byte(`{"collection_name":"book","search_aggregation":{"fields":["brand"],"size":1}}`),
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/search", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		testEngine.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "searchAggregation is not supported for low-level REST search")
+	}
+}

--- a/internal/distributed/proxy/httpserver/handler_v1.go
+++ b/internal/distributed/proxy/httpserver/handler_v1.go
@@ -945,6 +945,14 @@ func (h *HandlersV1) search(c *gin.Context) {
 		})
 		return
 	}
+	if httpReq.SearchAggregation != nil {
+		err := merr.WrapErrParameterInvalidMsg("searchAggregation is not supported for REST v1 search")
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(err),
+			HTTPReturnMessage: err.Error(),
+		})
+		return
+	}
 	if httpReq.CollectionName == "" || httpReq.Vector == nil {
 		log.Warn("high level restful api, search require parameter: [collectionName, vector], but miss")
 		HTTPAbortReturn(c, http.StatusOK, gin.H{

--- a/internal/distributed/proxy/httpserver/handler_v1_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v1_test.go
@@ -1571,6 +1571,34 @@ func TestSearch(t *testing.T) {
 	})
 }
 
+func TestSearchV1RejectSearchAggregation(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(proxy.Params.HTTPCfg.AcceptTypeAllowInt64.Key, "true")
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	testEngine := initHTTPServer(mocks.NewMockProxy(t), true)
+	data, _ := json.Marshal(map[string]interface{}{
+		HTTPCollectionName: DefaultCollectionName,
+		"vector":           []float32{0.0, 0.0},
+		"searchAggregation": map[string]interface{}{
+			"fields": []string{"brand"},
+			"size":   1,
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, versional(VectorSearchPath), bytes.NewReader(data))
+	req.SetBasicAuth(util.UserRoot, getDefaultRootPassword())
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	resp := &ReturnErrMsg{}
+	err := json.Unmarshal(w.Body.Bytes(), resp)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(1100), resp.Code)
+	assert.Contains(t, resp.Message, "searchAggregation is not supported for REST v1 search")
+}
+
 type ReturnType int
 
 func wrapWithDescribeColl(t *testing.T, mp *mocks.MockProxy, returnType ReturnType, times int, testCases []testCase) (*mocks.MockProxy, []testCase) {

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1603,6 +1603,40 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		return nil, merr.ErrMissingRequiredParameters
 	}
 
+	if httpReq.SearchAggregation != nil {
+		if hasIDs {
+			err := merr.WrapErrParameterInvalidMsg("ids and searchAggregation cannot be used simultaneously")
+			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			return nil, err
+		}
+		if httpReq.Offset != 0 {
+			err := merr.WrapErrParameterInvalidMsg("offset is not supported with searchAggregation")
+			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			return nil, err
+		}
+		if searchParamsContainAny(httpReq.SearchParams, proxy.OffsetKey) {
+			err := merr.WrapErrParameterInvalidMsg("searchParams.offset is not supported with searchAggregation")
+			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			return nil, err
+		}
+		if httpReq.GroupByField != "" || httpReq.GroupSize != 0 || httpReq.StrictGroupSize {
+			err := merr.WrapErrParameterInvalidMsg("groupingField/groupSize/strictGroupSize and searchAggregation cannot be used simultaneously")
+			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			return nil, err
+		}
+		if searchParamsContainAny(httpReq.SearchParams, proxy.GroupByFieldKey, proxy.GroupByFieldsKey) {
+			err := merr.WrapErrParameterInvalidMsg("searchParams.group_by_field(s) and searchAggregation cannot be used simultaneously")
+			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			return nil, err
+		}
+		req.SearchAggregation, err = convertSearchAggregationReq(httpReq.SearchAggregation)
+		if err != nil {
+			log.Ctx(ctx).Warn("high level restful api, convert SearchAggregation failed", zap.Error(err))
+			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			return nil, err
+		}
+	}
+
 	searchParams, err := generateSearchParams(httpReq.SearchParams)
 	if err != nil {
 		log.Ctx(ctx).Warn("high level restful api, generate SearchParams failed", zap.Error(err))
@@ -1685,7 +1719,33 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 		searchResp := resp.(*milvuspb.SearchResults)
 		cost := proxy.GetCostValue(searchResp.GetStatus())
 		scannedRemoteBytes, scannedTotalBytes, cacheHitRatio, isValid := proxy.GetStorageCost(searchResp.GetStatus())
-		if searchResp.Results.TopK == int64(0) {
+		if hasSearchAggregationResult(searchResp.Results) {
+			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
+			outputData, err := buildSearchAggregationResp(searchResp.Results, allowJS, collSchema)
+			if err != nil {
+				log.Ctx(ctx).Warn("high level restful api, fail to deal with search aggregation result", zap.Any("result", searchResp.Results), zap.Error(err))
+				HTTPReturn(c, http.StatusOK, gin.H{
+					HTTPReturnCode:    merr.Code(merr.ErrInvalidSearchResult),
+					HTTPReturnMessage: merr.ErrInvalidSearchResult.Error() + ", error: " + err.Error(),
+				})
+			} else {
+				respBody := gin.H{
+					HTTPReturnCode:     merr.Code(nil),
+					HTTPReturnData:     outputData,
+					HTTPReturnCost:     cost,
+					HTTPReturnAggTopks: searchResp.Results.GetAggTopks(),
+				}
+				if len(searchResp.Results.Recalls) > 0 {
+					respBody[HTTPReturnRecalls] = searchResp.Results.Recalls
+				}
+				if proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool() && isValid {
+					respBody[HTTPReturnScannedRemoteBytes] = scannedRemoteBytes
+					respBody[HTTPReturnScannedTotalBytes] = scannedTotalBytes
+					respBody[HTTPReturnCacheHitRatio] = cacheHitRatio
+				}
+				HTTPReturnStream(c, http.StatusOK, respBody)
+			}
+		} else if searchResp.Results.TopK == int64(0) {
 			HTTPReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(nil), HTTPReturnData: []interface{}{}, HTTPReturnCost: cost})
 		} else {
 			allowJS, _ := strconv.ParseBool(c.Request.Header.Get(HTTPHeaderAllowInt64))
@@ -1763,6 +1823,19 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 		return nil, err
 	}
 	c.Set(ContextRequest, req)
+
+	if httpReq.SearchAggregation != nil {
+		err := merr.WrapErrParameterInvalidMsg("searchAggregation is not supported for hybrid search")
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
+	for _, subReq := range httpReq.Search {
+		if subReq.SearchAggregation != nil {
+			err := merr.WrapErrParameterInvalidMsg("searchAggregation is not supported for hybrid search")
+			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+			return nil, err
+		}
+	}
 
 	collSchema, err := h.GetCollectionSchema(ctx, c, dbName, httpReq.CollectionName)
 	if err != nil {

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -3544,6 +3544,172 @@ func TestGetQuotaMetrics(t *testing.T) {
 	fmt.Println(w.Body.String())
 }
 
+func TestSearchAggregationV2(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+	paramtable.Get().Save(proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.Key, "true")
+	defer paramtable.Get().Reset(proxy.Params.QueryNodeCfg.StorageUsageTrackingEnabled.Key)
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Once()
+	mp.EXPECT().Search(mock.Anything, mock.MatchedBy(func(req *milvuspb.SearchRequest) bool {
+		agg := req.GetSearchAggregation()
+		return agg != nil &&
+			len(agg.GetFields()) == 1 &&
+			agg.GetFields()[0] == "brand" &&
+			agg.GetSize() == 2 &&
+			agg.GetSearchSize() == 4 &&
+			agg.GetMetrics()["avg_price"].GetOp() == "avg" &&
+			agg.GetMetrics()["avg_price"].GetFieldName() == "price" &&
+			agg.GetOrder()[0].GetKey() == "avg_price" &&
+			agg.GetOrder()[0].GetDirection() == "desc" &&
+			agg.GetTopHits().GetSize() == 1 &&
+			agg.GetTopHits().GetSort()[0].GetFieldName() == "_score" &&
+			agg.GetTopHits().GetSort()[0].GetDirection() == "asc" &&
+			agg.GetSubAggregation().GetFields()[0] == "color" &&
+			req.GetIds() == nil
+	})).Return(&milvuspb.SearchResults{
+		Status: &commonpb.Status{
+			ErrorCode: commonpb.ErrorCode_Success,
+			Code:      merr.Code(nil),
+			ExtraInfo: map[string]string{
+				"scanned_remote_bytes": "11",
+				"scanned_total_bytes":  "22",
+				"cache_hit_ratio":      "0.5",
+			},
+		},
+		Results: &schemapb.SearchResultData{
+			TopK:       0,
+			NumQueries: 1,
+			AggTopks:   []int64{1},
+			Recalls:    []float32{0.75},
+			AggBuckets: []*schemapb.AggBucket{
+				{
+					Key:     []*schemapb.BucketKeyEntry{{FieldId: 101, FieldName: "brand", Value: &schemapb.BucketKeyEntry_StringVal{StringVal: "acme"}}},
+					Count:   3,
+					Metrics: map[string]*schemapb.MetricValue{"avg_price": {Value: &schemapb.MetricValue_DoubleVal{DoubleVal: 12.5}}},
+					Hits: []*schemapb.AggHit{
+						{
+							Pk:    &schemapb.AggHit_IntPk{IntPk: 10},
+							Score: 0.9,
+							Fields: []*schemapb.AggHitField{
+								{FieldId: 201, FieldName: "price", Value: &schemapb.AggHitField_IntVal{IntVal: 99}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil).Once()
+
+	testEngine := initHTTPServerV2(mp, false)
+	req := httptest.NewRequest(http.MethodPost, versionalV2(EntityCategory, SearchAction), bytes.NewReader([]byte(`{
+		"collectionName": "book",
+		"data": [[0.1, 0.2]],
+		"annsField": "book_intro",
+		"limit": 10,
+		"searchAggregation": {
+			"fields": [" brand "],
+			"size": 2,
+			"searchSize": 4,
+			"metrics": {" avg_price ": {"op": " avg ", "fieldName": " price "}},
+			"order": [{"key": " avg_price ", "direction": " desc "}],
+			"topHits": {"size": 1, "sort": [{"fieldName": " _score ", "direction": " asc "}]},
+			"subAggregation": {"fields": ["color"], "size": 1}
+		}
+	}`)))
+	req.Header.Set(HTTPHeaderAllowInt64, "true")
+	w := httptest.NewRecorder()
+	testEngine.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	resp := map[string]interface{}{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(0), resp[HTTPReturnCode])
+	assert.Equal(t, []interface{}{float64(1)}, resp[HTTPReturnAggTopks])
+	assert.Equal(t, []interface{}{float64(0.75)}, resp[HTTPReturnRecalls])
+	assert.Equal(t, float64(11), resp[HTTPReturnScannedRemoteBytes])
+	assert.Equal(t, float64(22), resp[HTTPReturnScannedTotalBytes])
+	assert.Equal(t, float64(0.5), resp[HTTPReturnCacheHitRatio])
+	data := resp[HTTPReturnData].([]interface{})
+	buckets := data[0].(map[string]interface{})["buckets"].([]interface{})
+	bucket := buckets[0].(map[string]interface{})
+	assert.Equal(t, float64(3), bucket["count"])
+	assert.Equal(t, map[string]interface{}{"avg_price": float64(12.5)}, bucket["metrics"])
+	hits := bucket["hits"].([]interface{})
+	assert.Equal(t, float64(10), hits[0].(map[string]interface{})[FieldBookID])
+	assert.Equal(t, float64(99), hits[0].(map[string]interface{})["price"])
+}
+
+func TestSearchAggregationV2UnsupportedCombinations(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	mp := mocks.NewMockProxy(t)
+	mp.EXPECT().DescribeCollection(mock.Anything, mock.Anything).Return(&milvuspb.DescribeCollectionResponse{
+		CollectionName: DefaultCollectionName,
+		Schema:         generateCollectionSchema(schemapb.DataType_Int64, false, true),
+		ShardsNum:      ShardNumDefault,
+		Status:         &StatusSuccess,
+	}, nil).Times(5)
+	testEngine := initHTTPServerV2(mp, false)
+
+	searchAggregation := `"searchAggregation": {"fields": ["brand"], "size": 1}`
+	testCases := []requestBodyTestCase{
+		{
+			path:        SearchAction,
+			requestBody: []byte(`{"collectionName":"book","ids":[1],` + searchAggregation + `}`),
+			errCode:     1100,
+			errMsg:      "ids and searchAggregation cannot be used simultaneously",
+		},
+		{
+			path:        SearchAction,
+			requestBody: []byte(`{"collectionName":"book","data":[[0.1,0.2]],"annsField":"book_intro","limit":10,"offset":1,` + searchAggregation + `}`),
+			errCode:     1100,
+			errMsg:      "offset is not supported with searchAggregation",
+		},
+		{
+			path:        SearchAction,
+			requestBody: []byte(`{"collectionName":"book","data":[[0.1,0.2]],"annsField":"book_intro","limit":10,"groupingField":"brand",` + searchAggregation + `}`),
+			errCode:     1100,
+			errMsg:      "groupingField/groupSize/strictGroupSize and searchAggregation cannot be used simultaneously",
+		},
+		{
+			path:        SearchAction,
+			requestBody: []byte(`{"collectionName":"book","data":[[0.1,0.2]],"annsField":"book_intro","limit":10,"searchParams":{"offset":1},` + searchAggregation + `}`),
+			errCode:     1100,
+			errMsg:      "searchParams.offset is not supported with searchAggregation",
+		},
+		{
+			path:        SearchAction,
+			requestBody: []byte(`{"collectionName":"book","data":[[0.1,0.2]],"annsField":"book_intro","limit":10,"searchParams":{"params":{"group_by_fields":"[\"brand\"]"}},` + searchAggregation + `}`),
+			errCode:     1100,
+			errMsg:      "searchParams.group_by_field(s) and searchAggregation cannot be used simultaneously",
+		},
+		{
+			path:        HybridSearchAction,
+			requestBody: []byte(`{"collectionName":"book","search":[{"data":[[0.1,0.2]],"annsField":"book_intro","limit":10}],"rerank":{"strategy":"rrf","params":{}},` + searchAggregation + `}`),
+			errCode:     1100,
+			errMsg:      "searchAggregation is not supported for hybrid search",
+		},
+		{
+			path:        AdvancedSearchAction,
+			requestBody: []byte(`{"collectionName":"book","search":[{"data":[[0.1,0.2]],"annsField":"book_intro","limit":10,` + searchAggregation + `}],"rerank":{"strategy":"rrf","params":{}}}`),
+			errCode:     1100,
+			errMsg:      "searchAggregation is not supported for hybrid search",
+		},
+	}
+	validateTestCases(t, testEngine, testCases, false)
+}
+
 type AddCollectionFieldSuite struct {
 	suite.Suite
 	testEngine *gin.Engine

--- a/internal/distributed/proxy/httpserver/request.go
+++ b/internal/distributed/proxy/httpserver/request.go
@@ -84,12 +84,13 @@ type SingleUpsertReq struct {
 }
 
 type SearchReq struct {
-	DbName         string             `json:"dbName"`
-	CollectionName string             `json:"collectionName" validate:"required"`
-	Filter         string             `json:"filter"`
-	Limit          int32              `json:"limit"`
-	Offset         int32              `json:"offset"`
-	OutputFields   []string           `json:"outputFields"`
-	Vector         []float32          `json:"vector"`
-	Params         map[string]float64 `json:"params"`
+	DbName            string                `json:"dbName"`
+	CollectionName    string                `json:"collectionName" validate:"required"`
+	Filter            string                `json:"filter"`
+	Limit             int32                 `json:"limit"`
+	Offset            int32                 `json:"offset"`
+	OutputFields      []string              `json:"outputFields"`
+	Vector            []float32             `json:"vector"`
+	Params            map[string]float64    `json:"params"`
+	SearchAggregation *SearchAggregationReq `json:"searchAggregation"`
 }

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -376,23 +376,24 @@ func parseFieldPartialUpdateOp(op string) (schemapb.FieldPartialUpdateOp_OpType,
 }
 
 type SearchReqV2 struct {
-	DbName           string                 `json:"dbName"`
-	CollectionName   string                 `json:"collectionName" binding:"required"`
-	Data             []interface{}          `json:"data"`
-	Ids              []interface{}          `json:"ids"`
-	AnnsField        string                 `json:"annsField"`
-	PartitionNames   []string               `json:"partitionNames"`
-	Filter           string                 `json:"filter"`
-	GroupByField     string                 `json:"groupingField"`
-	GroupSize        int32                  `json:"groupSize"`
-	StrictGroupSize  bool                   `json:"strictGroupSize"`
-	Limit            int32                  `json:"limit"`
-	Offset           int32                  `json:"offset"`
-	OutputFields     []string               `json:"outputFields"`
-	SearchParams     map[string]interface{} `json:"searchParams"`
-	ConsistencyLevel string                 `json:"consistencyLevel"`
-	ExprParams       map[string]interface{} `json:"exprParams"`
-	FunctionScore    FunctionScore          `json:"functionScore"`
+	DbName            string                 `json:"dbName"`
+	CollectionName    string                 `json:"collectionName" binding:"required"`
+	Data              []interface{}          `json:"data"`
+	Ids               []interface{}          `json:"ids"`
+	AnnsField         string                 `json:"annsField"`
+	PartitionNames    []string               `json:"partitionNames"`
+	Filter            string                 `json:"filter"`
+	GroupByField      string                 `json:"groupingField"`
+	GroupSize         int32                  `json:"groupSize"`
+	StrictGroupSize   bool                   `json:"strictGroupSize"`
+	Limit             int32                  `json:"limit"`
+	Offset            int32                  `json:"offset"`
+	OutputFields      []string               `json:"outputFields"`
+	SearchParams      map[string]interface{} `json:"searchParams"`
+	ConsistencyLevel  string                 `json:"consistencyLevel"`
+	ExprParams        map[string]interface{} `json:"exprParams"`
+	FunctionScore     FunctionScore          `json:"functionScore"`
+	SearchAggregation *SearchAggregationReq  `json:"searchAggregation"`
 	// not use Params any more, just for compatibility
 	Params map[string]float64 `json:"params"`
 }
@@ -400,37 +401,69 @@ type SearchReqV2 struct {
 func (req *SearchReqV2) GetDbName() string         { return req.DbName }
 func (req *SearchReqV2) GetCollectionName() string { return req.CollectionName }
 
+type SearchAggregationReq struct {
+	Fields         []string                        `json:"fields"`
+	Size           int64                           `json:"size"`
+	SearchSize     int64                           `json:"searchSize"`
+	Metrics        map[string]MetricAggregationReq `json:"metrics"`
+	Order          []AggregationOrderReq           `json:"order"`
+	TopHits        *TopHitsReq                     `json:"topHits"`
+	SubAggregation *SearchAggregationReq           `json:"subAggregation"`
+}
+
+type MetricAggregationReq struct {
+	Op        string `json:"op"`
+	FieldName string `json:"fieldName"`
+}
+
+type AggregationOrderReq struct {
+	Key       string `json:"key"`
+	Direction string `json:"direction"`
+}
+
+type TopHitsReq struct {
+	Size int64                `json:"size"`
+	Sort []AggregationSortReq `json:"sort"`
+}
+
+type AggregationSortReq struct {
+	FieldName string `json:"fieldName"`
+	Direction string `json:"direction"`
+}
+
 type Rand struct {
 	Strategy string                 `json:"strategy"`
 	Params   map[string]interface{} `json:"params"`
 }
 
 type SubSearchReq struct {
-	Data         []interface{}          `json:"data" binding:"required"`
-	AnnsField    string                 `json:"annsField"`
-	Filter       string                 `json:"filter"`
-	GroupByField string                 `json:"groupingField"`
-	MetricType   string                 `json:"metricType"`
-	Limit        int32                  `json:"limit"`
-	Offset       int32                  `json:"offset"`
-	SearchParams map[string]interface{} `json:"params"`
-	ExprParams   map[string]interface{} `json:"exprParams"`
+	Data              []interface{}          `json:"data" binding:"required"`
+	AnnsField         string                 `json:"annsField"`
+	Filter            string                 `json:"filter"`
+	GroupByField      string                 `json:"groupingField"`
+	MetricType        string                 `json:"metricType"`
+	Limit             int32                  `json:"limit"`
+	Offset            int32                  `json:"offset"`
+	SearchParams      map[string]interface{} `json:"params"`
+	ExprParams        map[string]interface{} `json:"exprParams"`
+	SearchAggregation *SearchAggregationReq  `json:"searchAggregation"`
 }
 
 type HybridSearchReq struct {
-	DbName           string         `json:"dbName"`
-	CollectionName   string         `json:"collectionName" binding:"required"`
-	PartitionNames   []string       `json:"partitionNames"`
-	Search           []SubSearchReq `json:"search"`
-	Rerank           Rand           `json:"rerank"`
-	Limit            int32          `json:"limit"`
-	Offset           int32          `json:"offset"`
-	GroupByField     string         `json:"groupingField"`
-	GroupSize        int32          `json:"groupSize"`
-	StrictGroupSize  bool           `json:"strictGroupSize"`
-	OutputFields     []string       `json:"outputFields"`
-	ConsistencyLevel string         `json:"consistencyLevel"`
-	FunctionScore    FunctionScore  `json:"functionScore"`
+	DbName            string                `json:"dbName"`
+	CollectionName    string                `json:"collectionName" binding:"required"`
+	PartitionNames    []string              `json:"partitionNames"`
+	Search            []SubSearchReq        `json:"search"`
+	Rerank            Rand                  `json:"rerank"`
+	Limit             int32                 `json:"limit"`
+	Offset            int32                 `json:"offset"`
+	GroupByField      string                `json:"groupingField"`
+	GroupSize         int32                 `json:"groupSize"`
+	StrictGroupSize   bool                  `json:"strictGroupSize"`
+	OutputFields      []string              `json:"outputFields"`
+	ConsistencyLevel  string                `json:"consistencyLevel"`
+	FunctionScore     FunctionScore         `json:"functionScore"`
+	SearchAggregation *SearchAggregationReq `json:"searchAggregation"`
 }
 
 func (req *HybridSearchReq) GetDbName() string         { return req.DbName }

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -2727,6 +2727,221 @@ func buildQueryResp(rowsNum int64, needFields []string, fieldDataList []*schemap
 	return queryResp, nil
 }
 
+func hasSearchAggregationResult(results *schemapb.SearchResultData) bool {
+	return results != nil && (len(results.GetAggTopks()) > 0 || len(results.GetAggBuckets()) > 0)
+}
+
+func buildSearchAggregationResp(results *schemapb.SearchResultData, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) ([]gin.H, error) {
+	if results == nil {
+		return nil, errors.New("search_aggregation result is nil")
+	}
+	aggTopks := results.GetAggTopks()
+	pbBuckets := results.GetAggBuckets()
+	if len(aggTopks) == 0 {
+		return nil, errors.New("search_aggregation response missing agg_topks")
+	}
+	if results.GetNumQueries() <= 0 {
+		return nil, errors.New("search_aggregation response missing nq")
+	}
+	if len(aggTopks) != int(results.GetNumQueries()) {
+		return nil, fmt.Errorf("search_aggregation agg_topks length %d does not match nq %d", len(aggTopks), results.GetNumQueries())
+	}
+
+	total := int64(0)
+	for _, topk := range aggTopks {
+		if topk < 0 {
+			return nil, errors.New("search_aggregation agg_topks cannot contain negative values")
+		}
+		total += topk
+	}
+	if total != int64(len(pbBuckets)) {
+		return nil, fmt.Errorf("search_aggregation agg_topks sum %d does not match bucket count %d", total, len(pbBuckets))
+	}
+
+	output := make([]gin.H, 0, len(aggTopks))
+	offset := 0
+	for _, topk := range aggTopks {
+		buckets := make([]gin.H, 0, int(topk))
+		for i := int64(0); i < topk; i++ {
+			bucket, err := buildAggBucketResp(pbBuckets[offset], enableInt64, collectionSchema)
+			if err != nil {
+				return nil, err
+			}
+			buckets = append(buckets, bucket)
+			offset++
+		}
+		output = append(output, gin.H{"buckets": buckets})
+	}
+	return output, nil
+}
+
+func buildAggBucketResp(pb *schemapb.AggBucket, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) (gin.H, error) {
+	if pb == nil {
+		return nil, errors.New("search_aggregation bucket is nil")
+	}
+	bucket := gin.H{
+		"key":       buildAggBucketKeyResp(pb.GetKey(), enableInt64),
+		"count":     formatRESTInt64(pb.GetCount(), enableInt64),
+		"metrics":   buildAggMetricsResp(pb.GetMetrics(), enableInt64),
+		"hits":      buildAggHitsResp(pb.GetHits(), enableInt64, collectionSchema),
+		"subGroups": []gin.H{},
+	}
+	subGroups := make([]gin.H, 0, len(pb.GetSubGroups()))
+	for _, sub := range pb.GetSubGroups() {
+		subGroup, err := buildAggBucketResp(sub, enableInt64, collectionSchema)
+		if err != nil {
+			return nil, err
+		}
+		subGroups = append(subGroups, subGroup)
+	}
+	bucket["subGroups"] = subGroups
+	return bucket, nil
+}
+
+func buildAggBucketKeyResp(keys []*schemapb.BucketKeyEntry, enableInt64 bool) []gin.H {
+	resp := make([]gin.H, 0, len(keys))
+	for _, key := range keys {
+		if key == nil {
+			resp = append(resp, gin.H{})
+			continue
+		}
+		fieldName := key.GetFieldName()
+		if fieldName == "" {
+			fieldName = strconv.FormatInt(key.GetFieldId(), 10)
+		}
+		resp = append(resp, gin.H{
+			"fieldName": fieldName,
+			"fieldId":   formatRESTInt64(key.GetFieldId(), enableInt64),
+			"value":     bucketKeyEntryValueToRESTAny(key, enableInt64),
+		})
+	}
+	return resp
+}
+
+func buildAggMetricsResp(metrics map[string]*schemapb.MetricValue, enableInt64 bool) gin.H {
+	resp := make(gin.H, len(metrics))
+	for alias, metric := range metrics {
+		resp[alias] = metricValueToRESTAny(metric, enableInt64)
+	}
+	return resp
+}
+
+func buildAggHitsResp(hits []*schemapb.AggHit, enableInt64 bool, collectionSchema *schemapb.CollectionSchema) []gin.H {
+	resp := make([]gin.H, 0, len(hits))
+	pkFieldName := getRESTPrimaryFieldName(collectionSchema)
+	for _, hit := range hits {
+		if hit == nil {
+			resp = append(resp, gin.H{})
+			continue
+		}
+		row := gin.H{
+			pkFieldName:        aggHitPKToRESTAny(hit, enableInt64),
+			HTTPReturnDistance: hit.GetScore(),
+		}
+		for _, field := range hit.GetFields() {
+			if field == nil {
+				continue
+			}
+			fieldName := field.GetFieldName()
+			if fieldName == "" {
+				fieldName = strconv.FormatInt(field.GetFieldId(), 10)
+			}
+			row[fieldName] = aggHitFieldValueToRESTAny(field, enableInt64)
+		}
+		resp = append(resp, row)
+	}
+	return resp
+}
+
+func getRESTPrimaryFieldName(collectionSchema *schemapb.CollectionSchema) string {
+	if collectionSchema == nil {
+		return DefaultPrimaryFieldName
+	}
+	for _, field := range collectionSchema.GetFields() {
+		if field.GetIsPrimaryKey() {
+			return field.GetName()
+		}
+	}
+	return DefaultPrimaryFieldName
+}
+
+func formatRESTInt64(v int64, enableInt64 bool) interface{} {
+	if enableInt64 {
+		return v
+	}
+	return strconv.FormatInt(v, 10)
+}
+
+func metricValueToRESTAny(pb *schemapb.MetricValue, enableInt64 bool) interface{} {
+	if pb == nil {
+		return nil
+	}
+	switch v := pb.GetValue().(type) {
+	case *schemapb.MetricValue_IntVal:
+		return formatRESTInt64(v.IntVal, enableInt64)
+	case *schemapb.MetricValue_DoubleVal:
+		return v.DoubleVal
+	case *schemapb.MetricValue_StringVal:
+		return v.StringVal
+	case *schemapb.MetricValue_BoolVal:
+		return v.BoolVal
+	default:
+		return nil
+	}
+}
+
+func bucketKeyEntryValueToRESTAny(pb *schemapb.BucketKeyEntry, enableInt64 bool) interface{} {
+	if pb == nil {
+		return nil
+	}
+	switch v := pb.GetValue().(type) {
+	case *schemapb.BucketKeyEntry_IntVal:
+		return formatRESTInt64(v.IntVal, enableInt64)
+	case *schemapb.BucketKeyEntry_StringVal:
+		return v.StringVal
+	case *schemapb.BucketKeyEntry_BoolVal:
+		return v.BoolVal
+	default:
+		return nil
+	}
+}
+
+func aggHitPKToRESTAny(pb *schemapb.AggHit, enableInt64 bool) interface{} {
+	if pb == nil {
+		return nil
+	}
+	switch v := pb.GetPk().(type) {
+	case *schemapb.AggHit_IntPk:
+		return formatRESTInt64(v.IntPk, enableInt64)
+	case *schemapb.AggHit_StrPk:
+		return v.StrPk
+	default:
+		return nil
+	}
+}
+
+func aggHitFieldValueToRESTAny(pb *schemapb.AggHitField, enableInt64 bool) interface{} {
+	if pb == nil {
+		return nil
+	}
+	switch v := pb.GetValue().(type) {
+	case *schemapb.AggHitField_IntVal:
+		return formatRESTInt64(v.IntVal, enableInt64)
+	case *schemapb.AggHitField_BoolVal:
+		return v.BoolVal
+	case *schemapb.AggHitField_FloatVal:
+		return v.FloatVal
+	case *schemapb.AggHitField_DoubleVal:
+		return v.DoubleVal
+	case *schemapb.AggHitField_StringVal:
+		return v.StringVal
+	case *schemapb.AggHitField_BytesVal:
+		return v.BytesVal
+	default:
+		return nil
+	}
+}
+
 func formatInt64(intArray []int64) []string {
 	stringArray := make([]string, 0, len(intArray))
 	for _, i := range intArray {
@@ -3215,6 +3430,29 @@ func WrapErrorToResponse(err error) *milvuspb.BoolResponse {
 	}
 }
 
+func searchParamsContainAny(reqSearchParams map[string]interface{}, keys ...string) bool {
+	for _, key := range keys {
+		if _, ok := reqSearchParams[key]; ok {
+			return true
+		}
+	}
+
+	params, ok := reqSearchParams[Params]
+	if !ok {
+		return false
+	}
+	paramsMap, ok := params.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	for _, key := range keys {
+		if _, ok := paramsMap[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // after 2.5.2, all parameters of search_params can be written into one layer
 // no more parameters will be written searchParams.params
 // to ensure compatibility and milvus can still get a json format parameter
@@ -3274,6 +3512,106 @@ func generateSearchParams(reqSearchParams map[string]interface{}) ([]*commonpb.K
 	// need to exposure ParamRoundDecimal in req?
 	searchParams = append(searchParams, &commonpb.KeyValuePair{Key: ParamRoundDecimal, Value: "-1"})
 	return searchParams, nil
+}
+
+func convertSearchAggregationReq(req *SearchAggregationReq) (*commonpb.SearchAggregationSpec, error) {
+	if req == nil {
+		return nil, nil
+	}
+	if len(req.Fields) == 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.fields must be non-empty")
+	}
+	fields := make([]string, 0, len(req.Fields))
+	for _, field := range req.Fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.fields must contain non-empty field names")
+		}
+		fields = append(fields, field)
+	}
+	if req.Size <= 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.size must be positive")
+	}
+	if req.SearchSize < 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.searchSize must be non-negative")
+	}
+	if req.SearchSize > 0 && req.SearchSize < req.Size {
+		return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.searchSize must be greater than or equal to size")
+	}
+
+	spec := &commonpb.SearchAggregationSpec{
+		Fields:     fields,
+		Size:       req.Size,
+		SearchSize: req.SearchSize,
+	}
+
+	if len(req.Metrics) > 0 {
+		spec.Metrics = make(map[string]*commonpb.MetricAggSpec, len(req.Metrics))
+	}
+	for alias, metric := range req.Metrics {
+		alias = strings.TrimSpace(alias)
+		op := strings.TrimSpace(metric.Op)
+		fieldName := strings.TrimSpace(metric.FieldName)
+		if alias == "" {
+			return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.metrics alias must be non-empty")
+		}
+		if op == "" {
+			return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.metrics.%s.op must be non-empty", alias)
+		}
+		if fieldName == "" {
+			return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.metrics.%s.fieldName must be non-empty", alias)
+		}
+		spec.Metrics[alias] = &commonpb.MetricAggSpec{Op: op, FieldName: fieldName}
+	}
+
+	for _, order := range req.Order {
+		key := strings.TrimSpace(order.Key)
+		direction := strings.TrimSpace(order.Direction)
+		if key == "" {
+			return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.order key must be non-empty")
+		}
+		if direction == "" {
+			return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.order direction must be non-empty")
+		}
+		spec.Order = append(spec.Order, &commonpb.OrderSpec{Key: key, Direction: direction})
+	}
+
+	if req.TopHits != nil {
+		topHits, err := convertTopHitsReq(req.TopHits)
+		if err != nil {
+			return nil, err
+		}
+		spec.TopHits = topHits
+	}
+
+	if req.SubAggregation != nil {
+		sub, err := convertSearchAggregationReq(req.SubAggregation)
+		if err != nil {
+			return nil, err
+		}
+		spec.SubAggregation = sub
+	}
+
+	return spec, nil
+}
+
+func convertTopHitsReq(req *TopHitsReq) (*commonpb.TopHitsSpec, error) {
+	if req.Size <= 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.topHits.size must be positive")
+	}
+	spec := &commonpb.TopHitsSpec{Size: req.Size}
+	for _, sort := range req.Sort {
+		fieldName := strings.TrimSpace(sort.FieldName)
+		direction := strings.TrimSpace(sort.Direction)
+		if fieldName == "" {
+			return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.topHits.sort fieldName must be non-empty")
+		}
+		if direction == "" {
+			return nil, merr.WrapErrParameterInvalidMsg("searchAggregation.topHits.sort direction must be non-empty")
+		}
+		spec.Sort = append(spec.Sort, &commonpb.SortSpec{FieldName: fieldName, Direction: direction})
+	}
+	return spec, nil
 }
 
 func genFunctionSchema(ctx context.Context, function *FunctionSchema) (*schemapb.FunctionSchema, error) {

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -3288,6 +3288,140 @@ func TestGenerateSearchParams(t *testing.T) {
 	})
 }
 
+func TestConvertSearchAggregationReq(t *testing.T) {
+	req := &SearchAggregationReq{
+		Fields:     []string{" brand "},
+		Size:       3,
+		SearchSize: 5,
+		Metrics: map[string]MetricAggregationReq{
+			" avg_price ": {Op: " avg ", FieldName: " price "},
+		},
+		Order: []AggregationOrderReq{{Key: " avg_price ", Direction: " desc "}},
+		TopHits: &TopHitsReq{
+			Size: 2,
+			Sort: []AggregationSortReq{{FieldName: " _score ", Direction: " asc "}},
+		},
+		SubAggregation: &SearchAggregationReq{
+			Fields: []string{"color"},
+			Size:   2,
+		},
+	}
+
+	spec, err := convertSearchAggregationReq(req)
+	require.NoError(t, err)
+	require.Equal(t, []string{"brand"}, spec.GetFields())
+	require.EqualValues(t, 3, spec.GetSize())
+	require.EqualValues(t, 5, spec.GetSearchSize())
+	require.Equal(t, "avg", spec.GetMetrics()["avg_price"].GetOp())
+	require.Equal(t, "price", spec.GetMetrics()["avg_price"].GetFieldName())
+	require.Equal(t, "avg_price", spec.GetOrder()[0].GetKey())
+	require.Equal(t, "desc", spec.GetOrder()[0].GetDirection())
+	require.EqualValues(t, 2, spec.GetTopHits().GetSize())
+	require.Equal(t, "_score", spec.GetTopHits().GetSort()[0].GetFieldName())
+	require.Equal(t, "color", spec.GetSubAggregation().GetFields()[0])
+
+	testCases := []struct {
+		name string
+		req  *SearchAggregationReq
+		msg  string
+	}{
+		{name: "empty fields", req: &SearchAggregationReq{Size: 1}, msg: "fields must be non-empty"},
+		{name: "blank field", req: &SearchAggregationReq{Fields: []string{" "}, Size: 1}, msg: "non-empty field names"},
+		{name: "bad size", req: &SearchAggregationReq{Fields: []string{"brand"}, Size: 0}, msg: "size must be positive"},
+		{name: "bad search size", req: &SearchAggregationReq{Fields: []string{"brand"}, Size: 2, SearchSize: 1}, msg: "greater than or equal to size"},
+		{name: "blank metric op", req: &SearchAggregationReq{Fields: []string{"brand"}, Size: 1, Metrics: map[string]MetricAggregationReq{"m": {FieldName: "price"}}}, msg: "op must be non-empty"},
+		{name: "blank order direction", req: &SearchAggregationReq{Fields: []string{"brand"}, Size: 1, Order: []AggregationOrderReq{{Key: "_count"}}}, msg: "direction must be non-empty"},
+		{name: "bad top hits size", req: &SearchAggregationReq{Fields: []string{"brand"}, Size: 1, TopHits: &TopHitsReq{}}, msg: "topHits.size must be positive"},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.name, func(t *testing.T) {
+			_, err := convertSearchAggregationReq(testcase.req)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), testcase.msg)
+		})
+	}
+}
+
+func TestBuildSearchAggregationResp(t *testing.T) {
+	results := &schemapb.SearchResultData{
+		NumQueries: 1,
+		AggTopks:   []int64{1},
+		AggBuckets: []*schemapb.AggBucket{
+			{
+				Key: []*schemapb.BucketKeyEntry{
+					{FieldId: 101, FieldName: "brand", Value: &schemapb.BucketKeyEntry_StringVal{StringVal: "acme"}},
+					{FieldId: 102, FieldName: "model_id", Value: &schemapb.BucketKeyEntry_IntVal{IntVal: 9}},
+				},
+				Count: 3,
+				Metrics: map[string]*schemapb.MetricValue{
+					"avg_price": {Value: &schemapb.MetricValue_DoubleVal{DoubleVal: 12.5}},
+					"stock":     {Value: &schemapb.MetricValue_IntVal{IntVal: 7}},
+				},
+				Hits: []*schemapb.AggHit{
+					{
+						Pk:    &schemapb.AggHit_IntPk{IntPk: 1001},
+						Score: 0.8,
+						Fields: []*schemapb.AggHitField{
+							{FieldId: 201, FieldName: "price", Value: &schemapb.AggHitField_IntVal{IntVal: 99}},
+							{FieldId: 202, FieldName: "title", Value: &schemapb.AggHitField_StringVal{StringVal: "item"}},
+						},
+					},
+				},
+				SubGroups: []*schemapb.AggBucket{
+					{
+						Key:   []*schemapb.BucketKeyEntry{{FieldId: 103, FieldName: "color", Value: &schemapb.BucketKeyEntry_StringVal{StringVal: "red"}}},
+						Count: 1,
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := buildSearchAggregationResp(results, false, generateCollectionSchema(schemapb.DataType_Int64, false, true))
+	require.NoError(t, err)
+	require.Len(t, resp, 1)
+	buckets := resp[0]["buckets"].([]gin.H)
+	require.Len(t, buckets, 1)
+	bucket := buckets[0]
+	require.Equal(t, "3", bucket["count"])
+
+	keys := bucket["key"].([]gin.H)
+	require.Equal(t, "brand", keys[0]["fieldName"])
+	require.Equal(t, "101", keys[0]["fieldId"])
+	require.Equal(t, "acme", keys[0]["value"])
+	require.Equal(t, "9", keys[1]["value"])
+
+	metrics := bucket["metrics"].(gin.H)
+	require.Equal(t, 12.5, metrics["avg_price"])
+	require.Equal(t, "7", metrics["stock"])
+
+	hits := bucket["hits"].([]gin.H)
+	require.Equal(t, "1001", hits[0][FieldBookID])
+	require.Equal(t, float32(0.8), hits[0][HTTPReturnDistance])
+	require.Equal(t, "99", hits[0]["price"])
+	require.Equal(t, "item", hits[0]["title"])
+
+	subGroups := bucket["subGroups"].([]gin.H)
+	require.Equal(t, "1", subGroups[0]["count"])
+
+	_, err = buildSearchAggregationResp(&schemapb.SearchResultData{NumQueries: 1, AggBuckets: results.GetAggBuckets()}, true, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing agg_topks")
+
+	_, err = buildSearchAggregationResp(&schemapb.SearchResultData{AggTopks: []int64{1}, AggBuckets: results.GetAggBuckets()}, true, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing nq")
+
+	_, err = buildSearchAggregationResp(&schemapb.SearchResultData{NumQueries: 2, AggTopks: []int64{1}, AggBuckets: results.GetAggBuckets()}, true, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match nq")
+
+	_, err = buildSearchAggregationResp(&schemapb.SearchResultData{NumQueries: 1, AggTopks: []int64{2}, AggBuckets: results.GetAggBuckets()}, true, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not match bucket count")
+}
+
 func TestGenFunctionSchem(t *testing.T) {
 	{
 		funcSchema := &FunctionSchema{

--- a/internal/distributed/proxy/httpserver/wrap_request.go
+++ b/internal/distributed/proxy/httpserver/wrap_request.go
@@ -381,19 +381,25 @@ func convertFieldDataArray(input []*FieldData) ([]*schemapb.FieldData, error) {
 
 // SearchRequest is the RESTful request body for search
 type SearchRequest struct {
-	Base               *commonpb.MsgBase        `protobuf:"bytes,1,opt,name=base,proto3" json:"base,omitempty"`
-	DbName             string                   `protobuf:"bytes,2,opt,name=db_name,json=dbName,proto3" json:"db_name,omitempty"`
-	CollectionName     string                   `protobuf:"bytes,3,opt,name=collection_name,json=collectionName,proto3" json:"collection_name,omitempty"`
-	PartitionNames     []string                 `protobuf:"bytes,4,rep,name=partition_names,json=partitionNames,proto3" json:"partition_names,omitempty"`
-	Dsl                string                   `protobuf:"bytes,5,opt,name=dsl,proto3" json:"dsl,omitempty"`
-	DslType            commonpb.DslType         `protobuf:"varint,7,opt,name=dsl_type,json=dslType,proto3,enum=milvus.proto.common.DslType" json:"dsl_type,omitempty"`
-	BinaryVectors      [][]byte                 `json:"binary_vectors,omitempty"`
-	Vectors            [][]float32              `json:"vectors,omitempty"`
-	OutputFields       []string                 `protobuf:"bytes,8,rep,name=output_fields,json=outputFields,proto3" json:"output_fields,omitempty"`
-	SearchParams       []*commonpb.KeyValuePair `protobuf:"bytes,9,rep,name=search_params,json=searchParams,proto3" json:"search_params,omitempty"`
-	TravelTimestamp    uint64                   `protobuf:"varint,10,opt,name=travel_timestamp,json=travelTimestamp,proto3" json:"travel_timestamp,omitempty"`
-	GuaranteeTimestamp uint64                   `protobuf:"varint,11,opt,name=guarantee_timestamp,json=guaranteeTimestamp,proto3" json:"guarantee_timestamp,omitempty"`
-	Nq                 int64                    `protobuf:"varint,12,opt,name=nq,proto3" json:"nq,omitempty"`
+	Base                   *commonpb.MsgBase        `protobuf:"bytes,1,opt,name=base,proto3" json:"base,omitempty"`
+	DbName                 string                   `protobuf:"bytes,2,opt,name=db_name,json=dbName,proto3" json:"db_name,omitempty"`
+	CollectionName         string                   `protobuf:"bytes,3,opt,name=collection_name,json=collectionName,proto3" json:"collection_name,omitempty"`
+	PartitionNames         []string                 `protobuf:"bytes,4,rep,name=partition_names,json=partitionNames,proto3" json:"partition_names,omitempty"`
+	Dsl                    string                   `protobuf:"bytes,5,opt,name=dsl,proto3" json:"dsl,omitempty"`
+	DslType                commonpb.DslType         `protobuf:"varint,7,opt,name=dsl_type,json=dslType,proto3,enum=milvus.proto.common.DslType" json:"dsl_type,omitempty"`
+	BinaryVectors          [][]byte                 `json:"binary_vectors,omitempty"`
+	Vectors                [][]float32              `json:"vectors,omitempty"`
+	OutputFields           []string                 `protobuf:"bytes,8,rep,name=output_fields,json=outputFields,proto3" json:"output_fields,omitempty"`
+	SearchParams           []*commonpb.KeyValuePair `protobuf:"bytes,9,rep,name=search_params,json=searchParams,proto3" json:"search_params,omitempty"`
+	TravelTimestamp        uint64                   `protobuf:"varint,10,opt,name=travel_timestamp,json=travelTimestamp,proto3" json:"travel_timestamp,omitempty"`
+	GuaranteeTimestamp     uint64                   `protobuf:"varint,11,opt,name=guarantee_timestamp,json=guaranteeTimestamp,proto3" json:"guarantee_timestamp,omitempty"`
+	Nq                     int64                    `protobuf:"varint,12,opt,name=nq,proto3" json:"nq,omitempty"`
+	SearchAggregation      *SearchAggregationReq    `json:"searchAggregation,omitempty"`
+	SearchAggregationSnake *SearchAggregationReq    `json:"search_aggregation,omitempty"`
+}
+
+func (r *SearchRequest) HasSearchAggregation() bool {
+	return r.SearchAggregation != nil || r.SearchAggregationSnake != nil
 }
 
 func binaryVector2Bytes(vectors [][]byte) []byte {

--- a/tests/restful_client_v2/testcases/test_vector_operations.py
+++ b/tests/restful_client_v2/testcases/test_vector_operations.py
@@ -1493,6 +1493,439 @@ class TestUpsertVectorNegative(TestBase):
         assert "fail to deal the insert data" in rsp["message"]
 
 
+class TestSearchAggregationVector(TestBase):
+    def _create_search_aggregation_collection(self):
+        name = gen_collection_name()
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": True,
+                "fields": [
+                    {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
+                    {"fieldName": "category", "dataType": "VarChar", "elementTypeParams": {"max_length": "64"}},
+                    {"fieldName": "brand", "dataType": "VarChar", "elementTypeParams": {"max_length": "64"}},
+                    {"fieldName": "color", "dataType": "VarChar", "elementTypeParams": {"max_length": "64"}},
+                    {"fieldName": "price", "dataType": "Int64", "elementTypeParams": {}},
+                    {"fieldName": "rating", "dataType": "Double", "elementTypeParams": {}},
+                    {"fieldName": "in_stock", "dataType": "Bool", "elementTypeParams": {}},
+                    {"fieldName": "vector", "dataType": "FloatVector", "elementTypeParams": {"dim": "2"}},
+                ],
+            },
+            "indexParams": [{"fieldName": "vector", "indexName": "vector", "indexType": "FLAT", "metricType": "L2"}],
+        }
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 0
+
+        brands = ["acme", "best", "core"]
+        colors = ["red", "blue"]
+        categories = ["fiction", "science"]
+        data = []
+        for i in range(12):
+            data.append(
+                {
+                    "book_id": i,
+                    "category": categories[i // 6],
+                    "brand": brands[i % len(brands)],
+                    "color": colors[i % len(colors)],
+                    "price": i + 1,
+                    "rating": float((i % 5) + 1),
+                    "in_stock": i % 4 != 0,
+                    "vector": [float(i) / 100, float(i) / 100],
+                }
+            )
+        rsp = self.vector_client.vector_insert({"collectionName": name, "data": data})
+        assert rsp["code"] == 0
+        assert rsp["data"]["insertCount"] == len(data)
+        Collection(name).flush()
+        return name, data
+
+    @staticmethod
+    def _key_value(bucket, field_name):
+        for key in bucket["key"]:
+            if key["fieldName"] == field_name:
+                return key["value"]
+        raise AssertionError(f"field {field_name} not found in bucket key {bucket['key']}")
+
+    @staticmethod
+    def _assert_aggregation_response(rsp):
+        assert rsp["code"] == 0
+        assert "aggTopks" in rsp, rsp
+        assert "data" in rsp, rsp
+
+    @pytest.mark.L0
+    def test_search_aggregation_minimal_parameters(self):
+        name, _ = self._create_search_aggregation_collection()
+
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": name,
+                "data": [[0.0, 0.0], [0.11, 0.11]],
+                "annsField": "vector",
+                "limit": 12,
+                "outputFields": ["brand"],
+                "searchAggregation": {"fields": ["brand"], "size": 1},
+            }
+        )
+        self._assert_aggregation_response(rsp)
+        assert rsp["aggTopks"] == [1, 1]
+        assert len(rsp["data"]) == 2
+        for query_result in rsp["data"]:
+            buckets = query_result["buckets"]
+            assert len(buckets) == 1
+            assert buckets[0]["key"][0]["fieldName"] == "brand"
+            assert int(buckets[0]["count"]) > 0
+            assert buckets[0]["metrics"] == {}
+            assert buckets[0]["hits"] == []
+
+    @pytest.mark.L0
+    def test_search_aggregation(self):
+        name = gen_collection_name()
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": True,
+                "fields": [
+                    {"fieldName": "book_id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
+                    {"fieldName": "brand", "dataType": "VarChar", "elementTypeParams": {"max_length": "64"}},
+                    {"fieldName": "price", "dataType": "Int64", "elementTypeParams": {}},
+                    {"fieldName": "vector", "dataType": "FloatVector", "elementTypeParams": {"dim": "2"}},
+                ],
+            },
+            "indexParams": [{"fieldName": "vector", "indexName": "vector", "indexType": "FLAT", "metricType": "L2"}],
+        }
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 0
+
+        brands = ["acme", "best", "core"]
+        data = []
+        for i in range(12):
+            data.append(
+                {
+                    "book_id": i,
+                    "brand": brands[i % len(brands)],
+                    "price": i + 1,
+                    "vector": [float(i) / 100, float(i) / 100],
+                }
+            )
+        rsp = self.vector_client.vector_insert({"collectionName": name, "data": data})
+        assert rsp["code"] == 0
+        assert rsp["data"]["insertCount"] == 12
+        Collection(name).flush()
+
+        search_payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 10,
+            "outputFields": ["brand", "price"],
+            "searchAggregation": {
+                "fields": ["brand"],
+                "size": 3,
+                "metrics": {
+                    "doc_count": {"op": "count", "fieldName": "*"},
+                    "total_price": {"op": "sum", "fieldName": "price"},
+                },
+                "order": [{"key": "_key", "direction": "asc"}],
+                "topHits": {"size": 2, "sort": [{"fieldName": "_score", "direction": "asc"}]},
+            },
+        }
+        rsp = self.vector_client.vector_search(search_payload)
+        assert rsp["code"] == 0
+        assert rsp["aggTopks"] == [3]
+        assert len(rsp["data"]) == 1
+        buckets = rsp["data"][0]["buckets"]
+        assert len(buckets) == 3
+
+        for bucket in buckets:
+            key = bucket["key"][0]
+            brand = key["value"]
+            assert key["fieldName"] == "brand"
+            assert brand in brands
+            assert int(bucket["count"]) > 0
+            assert int(bucket["metrics"]["doc_count"]) == int(bucket["count"])
+            assert int(bucket["metrics"]["total_price"]) > 0
+            assert len(bucket["hits"]) <= 2
+            hit_prices = []
+            for hit in bucket["hits"]:
+                assert hit["brand"] == brand
+                assert "book_id" in hit
+                assert "distance" in hit
+                price = int(hit["price"])
+                assert price in [row["price"] for row in data if row["brand"] == brand]
+                hit_prices.append(price)
+            assert int(bucket["metrics"]["total_price"]) >= sum(hit_prices)
+
+        conflict_payloads = [
+            (
+                {
+                    "collectionName": name,
+                    "data": [[0.0, 0.0]],
+                    "annsField": "vector",
+                    "limit": 10,
+                    "offset": 1,
+                    "searchAggregation": {"fields": ["brand"], "size": 2},
+                },
+                "offset is not supported with searchAggregation",
+            ),
+            (
+                {
+                    "collectionName": name,
+                    "data": [[0.0, 0.0]],
+                    "annsField": "vector",
+                    "limit": 10,
+                    "groupingField": "brand",
+                    "searchAggregation": {"fields": ["brand"], "size": 2},
+                },
+                "groupingField/groupSize/strictGroupSize and searchAggregation cannot be used simultaneously",
+            ),
+            (
+                {
+                    "collectionName": name,
+                    "ids": [0],
+                    "searchAggregation": {"fields": ["brand"], "size": 2},
+                },
+                "ids and searchAggregation cannot be used simultaneously",
+            ),
+            (
+                {
+                    "collectionName": name,
+                    "data": [[0.0, 0.0]],
+                    "annsField": "vector",
+                    "limit": 10,
+                    "searchParams": {"offset": 1},
+                    "searchAggregation": {"fields": ["brand"], "size": 2},
+                },
+                "searchParams.offset is not supported with searchAggregation",
+            ),
+            (
+                {
+                    "collectionName": name,
+                    "data": [[0.0, 0.0]],
+                    "annsField": "vector",
+                    "limit": 10,
+                    "searchParams": {"params": {"group_by_fields": '["brand"]'}},
+                    "searchAggregation": {"fields": ["brand"], "size": 2},
+                },
+                "searchParams.group_by_field(s) and searchAggregation cannot be used simultaneously",
+            ),
+        ]
+        for conflict_payload, message in conflict_payloads:
+            rsp = self.vector_client.vector_search(conflict_payload)
+            assert rsp["code"] != 0
+            assert message in rsp["message"]
+
+        hybrid_payload = {
+            "collectionName": name,
+            "search": [{"data": [[0.0, 0.0]], "annsField": "vector", "limit": 10}],
+            "rerank": {"strategy": "rrf", "params": {}},
+            "searchAggregation": {"fields": ["brand"], "size": 2},
+        }
+        rsp = self.vector_client.vector_hybrid_search(hybrid_payload)
+        assert rsp["code"] != 0
+        assert "searchAggregation is not supported for hybrid search" in rsp["message"]
+
+        advanced_payload = {
+            "collectionName": name,
+            "search": [
+                {
+                    "data": [[0.0, 0.0]],
+                    "annsField": "vector",
+                    "limit": 10,
+                    "searchAggregation": {"fields": ["brand"], "size": 2},
+                }
+            ],
+            "rerank": {"strategy": "rrf", "params": {}},
+            "limit": 10,
+        }
+        rsp = self.vector_client.vector_advanced_search(advanced_payload)
+        assert rsp["code"] != 0
+        assert "searchAggregation is not supported for hybrid search" in rsp["message"]
+
+    @pytest.mark.L1
+    def test_search_aggregation_composite_key_metrics_order(self):
+        name, data = self._create_search_aggregation_collection()
+
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": name,
+                "data": [[0.0, 0.0]],
+                "annsField": "vector",
+                "limit": len(data),
+                "outputFields": ["brand", "color", "price"],
+                "searchAggregation": {
+                    "fields": ["brand", "color"],
+                    "size": 6,
+                    "metrics": {
+                        "doc_count": {"op": "count", "fieldName": "*"},
+                        "avg_price": {"op": "avg", "fieldName": "price"},
+                    },
+                    "order": [{"key": "avg_price", "direction": "desc"}],
+                    "topHits": {"size": 2, "sort": [{"fieldName": "price", "direction": "asc"}]},
+                },
+            }
+        )
+        self._assert_aggregation_response(rsp)
+        assert rsp["aggTopks"] == [6]
+
+        buckets = rsp["data"][0]["buckets"]
+        assert len(buckets) == 6
+        avg_prices = [bucket["metrics"]["avg_price"] for bucket in buckets]
+        assert avg_prices == sorted(avg_prices, reverse=True)
+        for bucket in buckets:
+            brand = self._key_value(bucket, "brand")
+            color = self._key_value(bucket, "color")
+            expected_rows = [row for row in data if row["brand"] == brand and row["color"] == color]
+            expected_avg = sum(row["price"] for row in expected_rows) / len(expected_rows)
+
+            assert [key["fieldName"] for key in bucket["key"]] == ["brand", "color"]
+            assert int(bucket["count"]) == len(expected_rows)
+            assert int(bucket["metrics"]["doc_count"]) == len(expected_rows)
+            assert abs(bucket["metrics"]["avg_price"] - expected_avg) < 0.000001
+            assert len(bucket["hits"]) == 2
+            hit_prices = [int(hit["price"]) for hit in bucket["hits"]]
+            assert hit_prices == sorted(hit_prices)
+            for hit in bucket["hits"]:
+                assert hit["brand"] == brand
+                assert hit["color"] == color
+
+    @pytest.mark.L1
+    def test_search_aggregation_two_level_nested_with_filter(self):
+        name, data = self._create_search_aggregation_collection()
+        filtered = [row for row in data if row["in_stock"]]
+
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": name,
+                "data": [[0.0, 0.0]],
+                "annsField": "vector",
+                "filter": "in_stock == true",
+                "limit": len(filtered),
+                "outputFields": ["category", "brand", "price", "rating", "in_stock"],
+                "searchAggregation": {
+                    "fields": ["category"],
+                    "size": 2,
+                    "metrics": {
+                        "item_count": {"op": "count", "fieldName": "*"},
+                        "total_price": {"op": "sum", "fieldName": "price"},
+                    },
+                    "order": [{"key": "_key", "direction": "asc"}],
+                    "topHits": {"size": 1, "sort": [{"fieldName": "_score", "direction": "asc"}]},
+                    "subAggregation": {
+                        "fields": ["brand"],
+                        "size": 3,
+                        "metrics": {"avg_rating": {"op": "avg", "fieldName": "rating"}},
+                        "order": [{"key": "avg_rating", "direction": "desc"}],
+                        "topHits": {"size": 2, "sort": [{"fieldName": "price", "direction": "asc"}]},
+                    },
+                },
+            }
+        )
+        self._assert_aggregation_response(rsp)
+        assert rsp["aggTopks"] == [2]
+
+        buckets = rsp["data"][0]["buckets"]
+        assert len(buckets) == 2
+        category_keys = [self._key_value(bucket, "category") for bucket in buckets]
+        assert category_keys == sorted(category_keys)
+        for bucket in buckets:
+            category = self._key_value(bucket, "category")
+            category_rows = [row for row in filtered if row["category"] == category]
+            assert int(bucket["count"]) == len(category_rows)
+            assert int(bucket["metrics"]["item_count"]) == len(category_rows)
+            assert int(bucket["metrics"]["total_price"]) == sum(row["price"] for row in category_rows)
+            for hit in bucket["hits"]:
+                assert hit["category"] == category
+                assert hit["in_stock"] is True
+
+            sub_groups = bucket["subGroups"]
+            assert len(sub_groups) == len({row["brand"] for row in category_rows})
+            avg_ratings = [sub_group["metrics"]["avg_rating"] for sub_group in sub_groups]
+            assert avg_ratings == sorted(avg_ratings, reverse=True)
+            for sub_group in sub_groups:
+                brand = self._key_value(sub_group, "brand")
+                brand_rows = [row for row in category_rows if row["brand"] == brand]
+                expected_avg = sum(row["rating"] for row in brand_rows) / len(brand_rows)
+                assert int(sub_group["count"]) == len(brand_rows)
+                assert abs(sub_group["metrics"]["avg_rating"] - expected_avg) < 0.000001
+                assert len(sub_group["hits"]) <= 2
+                hit_prices = [int(hit["price"]) for hit in sub_group["hits"]]
+                assert hit_prices == sorted(hit_prices)
+                for hit in sub_group["hits"]:
+                    assert hit["category"] == category
+                    assert hit["brand"] == brand
+                    assert hit["in_stock"] is True
+
+    @pytest.mark.parametrize(
+        "search_aggregation,message",
+        [
+            ({"size": 1}, "searchAggregation.fields must be non-empty"),
+            ({"fields": ["brand"], "size": 0}, "searchAggregation.size must be positive"),
+            (
+                {"fields": ["brand"], "size": 3, "searchSize": 2},
+                "searchAggregation.searchSize must be greater than or equal to size",
+            ),
+            (
+                {"fields": ["brand"], "size": 1, "metrics": {"bad": {"op": "", "fieldName": "price"}}},
+                "searchAggregation.metrics.bad.op must be non-empty",
+            ),
+            (
+                {"fields": ["brand"], "size": 1, "topHits": {"size": 0}},
+                "searchAggregation.topHits.size must be positive",
+            ),
+        ],
+    )
+    @pytest.mark.L1
+    def test_search_aggregation_reject_invalid_parameters(self, search_aggregation, message):
+        name, _ = self._create_search_aggregation_collection()
+
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": name,
+                "data": [[0.0, 0.0]],
+                "annsField": "vector",
+                "limit": 10,
+                "searchAggregation": search_aggregation,
+            }
+        )
+        assert rsp["code"] != 0
+        assert message in rsp["message"]
+
+    @pytest.mark.L1
+    @pytest.mark.parametrize(
+        "search_aggregation,message",
+        [
+            (
+                {"fields": ["unknown_group_field"], "size": 1},
+                "unknown_group_field",
+            ),
+            (
+                {"fields": ["brand"], "size": 1, "metrics": {"bad_metric": {"op": "median", "fieldName": "price"}}},
+                "median",
+            ),
+            (
+                {"fields": ["brand"], "size": 1, "order": [{"key": "_count", "direction": "up"}]},
+                "up",
+            ),
+        ],
+    )
+    def test_search_aggregation_reject_server_validation(self, search_aggregation, message):
+        name, _ = self._create_search_aggregation_collection()
+
+        rsp = self.vector_client.vector_search(
+            {
+                "collectionName": name,
+                "data": [[0.0, 0.0]],
+                "annsField": "vector",
+                "limit": 10,
+                "searchAggregation": search_aggregation,
+            }
+        )
+        assert rsp["code"] != 0
+        assert message in rsp["message"]
+
+
 @pytest.mark.L0
 class TestSearchVector(TestBase):
     @pytest.mark.parametrize("insert_round", [1])


### PR DESCRIPTION
Related: #49046

## What changed
- Add REST v2 searchAggregation request parsing, validation, and proxy conversion for search requests.
- Return aggregation buckets with top hits, metrics, optional recall information, cost, and storage metadata.
- Reject searchAggregation on unsupported REST v1 / low-level search paths and hybrid sub-search inputs.
- Add Go unit coverage and RESTful v2 e2e coverage for happy paths, nested aggregations, metrics/order, filters, and validation failures.

## Verification
- /Users/yanliang.qiao/fork/.venv-py312/bin/python -m ruff check tests/restful_client_v2/testcases/test_vector_operations.py
- /Users/yanliang.qiao/fork/.venv-py312/bin/python -m ruff format --check tests/restful_client_v2/testcases/test_vector_operations.py
- /Users/yanliang.qiao/fork/.venv-py312/bin/python -m py_compile tests/restful_client_v2/testcases/test_vector_operations.py
- /Users/yanliang.qiao/fork/.venv-py312/bin/python -m pytest --collect-only testcases/test_vector_operations.py::TestSearchAggregationVector -q
- git diff --check

Note: local Go unit test build is blocked by missing native Milvus dependencies on this machine: rocksdb.pc and milvus_core.pc.