### PR TITLE
enhance: stream field data loading

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -981,7 +981,7 @@ common:
   defaultIndexName: _default_idx # Name of the index when it is created with name unspecified
   indexSliceSize: 16 # Index slice size in MB
   entryStream:
-    streamBudgetRatio: 3 # Multiplier for entry stream transient memory budget, relative to CPU core count
+    streamBudgetBytes: 0 # Process-wide transient memory budget in bytes for entry stream loading. Set to 0 to disable the limit.
   threadCoreCoefficient:
     highPriority: 10 # This parameter specify how many times the number of threads is the number of cores in high priority pool
     middlePriority: 5 # This parameter specify how many times the number of threads is the number of cores in middle priority pool

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -541,7 +541,7 @@ queryNode:
     knowhereScoreConsistency: false # Enable knowhere strong consistency score computation logic
     storageV2:
       cellTargetSizeBytes: 4194304 # Target average byte size per storage v2 cache cell. Parquet row groups are greedily packed so that rgs_per_cell * avg_row_group_size ≈ this target. Each cell always contains at least one row group and cells never cross file boundaries. Tune larger for bigger batch IO (fewer cells) or smaller to get finer cache granularity. Default 4 MiB.
-      fieldDataLoadBudgetBytes: 134217728 # Process-wide transient memory budget in bytes for storage v2 field-data loading. Lower values reduce peak transient memory at the cost of load throughput. Oversized cells are allowed to proceed exclusively. Default 128 MiB.
+      fieldDataLoadBudgetBytes: 134217728 # Process-wide transient memory budget in bytes for storage v2 field-data loading. It gates in-flight Arrow data across concurrent load tasks. Lower values reduce peak transient memory at the cost of load throughput. Oversized cells are still allowed to proceed exclusively to guarantee progress. Default 128 MiB.
     deleteDumpBatchSize: 10000 # Batch size for delete snapshot dump in segcore.
   loadMemoryUsageFactor: 1 # The multiply factor of calculating the memory usage while loading segments
   enableDisk: false # enable querynode load disk index, and search on disk index

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -541,7 +541,6 @@ queryNode:
     knowhereScoreConsistency: false # Enable knowhere strong consistency score computation logic
     storageV2:
       cellTargetSizeBytes: 4194304 # Target average byte size per storage v2 cache cell. Parquet row groups are greedily packed so that rgs_per_cell * avg_row_group_size ≈ this target. Each cell always contains at least one row group and cells never cross file boundaries. Tune larger for bigger batch IO (fewer cells) or smaller to get finer cache granularity. Default 4 MiB.
-      fieldDataLoadBudgetBytes: 134217728 # Process-wide transient memory budget in bytes for storage v2 field-data loading. It gates in-flight Arrow data across concurrent load tasks. Lower values reduce peak transient memory at the cost of load throughput. Oversized cells are still allowed to proceed exclusively to guarantee progress. Default 128 MiB.
     deleteDumpBatchSize: 10000 # Batch size for delete snapshot dump in segcore.
   loadMemoryUsageFactor: 1 # The multiply factor of calculating the memory usage while loading segments
   enableDisk: false # enable querynode load disk index, and search on disk index
@@ -980,8 +979,7 @@ common:
   defaultPartitionName: _default # Name of the default partition when a collection is created
   defaultIndexName: _default_idx # Name of the index when it is created with name unspecified
   indexSliceSize: 16 # Index slice size in MB
-  entryStream:
-    streamBudgetBytes: 0 # Process-wide transient memory budget in bytes for entry stream loading. It gates in-flight entry stream slices across concurrent load tasks. Lower values reduce peak transient memory at the cost of load throughput. Oversized slices are still allowed to proceed exclusively to guarantee progress. Set to 0 to disable the limit.
+  loadTransientBudgetBytes: 0 # Process-wide transient memory budget in bytes shared by scalar index entry reading and storage v2 field-data loading. It gates in-flight transient data across concurrent load tasks. Lower values reduce peak transient memory at the cost of load throughput. Oversized requests are still allowed to proceed exclusively to guarantee progress. Set to 0 to disable the limit.
   threadCoreCoefficient:
     highPriority: 10 # This parameter specify how many times the number of threads is the number of cores in high priority pool
     middlePriority: 5 # This parameter specify how many times the number of threads is the number of cores in middle priority pool

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -981,7 +981,7 @@ common:
   defaultIndexName: _default_idx # Name of the index when it is created with name unspecified
   indexSliceSize: 16 # Index slice size in MB
   entryStream:
-    streamBudgetBytes: 0 # Process-wide transient memory budget in bytes for entry stream loading. Set to 0 to disable the limit.
+    streamBudgetBytes: 0 # Process-wide transient memory budget in bytes for entry stream loading. It gates in-flight entry stream slices across concurrent load tasks. Lower values reduce peak transient memory at the cost of load throughput. Oversized slices are still allowed to proceed exclusively to guarantee progress. Set to 0 to disable the limit.
   threadCoreCoefficient:
     highPriority: 10 # This parameter specify how many times the number of threads is the number of cores in high priority pool
     middlePriority: 5 # This parameter specify how many times the number of threads is the number of cores in middle priority pool

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -979,7 +979,7 @@ common:
   defaultPartitionName: _default # Name of the default partition when a collection is created
   defaultIndexName: _default_idx # Name of the index when it is created with name unspecified
   indexSliceSize: 16 # Index slice size in MB
-  loadTransientBudgetBytes: 0 # Process-wide transient memory budget in bytes shared by scalar index entry reading and storage v2 field-data loading. It gates in-flight transient data across concurrent load tasks. Lower values reduce peak transient memory at the cost of load throughput. Oversized requests are still allowed to proceed exclusively to guarantee progress. Set to 0 to disable the limit.
+  loadTransientBudgetBytes: 0 # Process-wide transient memory budget in bytes shared by scalar index V3 entry streaming and storage v2/v3 field-data loading. It gates in-flight transient data across concurrent load tasks. Lower values reduce peak transient memory at the cost of load throughput. Oversized requests are still allowed to proceed exclusively to guarantee progress. Set to 0 to disable the limit.
   threadCoreCoefficient:
     highPriority: 10 # This parameter specify how many times the number of threads is the number of cores in high priority pool
     middlePriority: 5 # This parameter specify how many times the number of threads is the number of cores in middle priority pool

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -541,6 +541,7 @@ queryNode:
     knowhereScoreConsistency: false # Enable knowhere strong consistency score computation logic
     storageV2:
       cellTargetSizeBytes: 4194304 # Target average byte size per storage v2 cache cell. Parquet row groups are greedily packed so that rgs_per_cell * avg_row_group_size ≈ this target. Each cell always contains at least one row group and cells never cross file boundaries. Tune larger for bigger batch IO (fewer cells) or smaller to get finer cache granularity. Default 4 MiB.
+      fieldDataLoadBudgetBytes: 134217728 # Process-wide transient memory budget in bytes for storage v2 field-data loading. Lower values reduce peak transient memory at the cost of load throughput. Oversized cells are allowed to proceed exclusively. Default 128 MiB.
     deleteDumpBatchSize: 10000 # Batch size for delete snapshot dump in segcore.
   loadMemoryUsageFactor: 1 # The multiply factor of calculating the memory usage while loading segments
   enableDisk: false # enable querynode load disk index, and search on disk index

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -987,11 +987,6 @@ common:
     lowPriority: 1 # This parameter specify how many times the number of threads is the number of cores in low priority pool
     bm25Load: 1 # This parameter specify how many times the number of threads is the number of cores in BM25 load pool
     maxThreadsSize: 16 # The maximum number of threads in the thread pool, only effective when greater than 0
-  fieldDataLoad:
-    memoryLimitMB: 128 # Global transient memory budget for concurrent field data loading
-    batchSizeMB: 32 # Target size for grouping field data cells into one load batch
-    readBufferSizeMB: 16 # Per-reader buffer/window size for field data loading
-    maxReadParallelism: 8 # Maximum read parallelism within one field data load batch
   buildIndexThreadPoolRatio: 0.75
   DiskIndex:
     MaxDegree: 56

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -987,6 +987,11 @@ common:
     lowPriority: 1 # This parameter specify how many times the number of threads is the number of cores in low priority pool
     bm25Load: 1 # This parameter specify how many times the number of threads is the number of cores in BM25 load pool
     maxThreadsSize: 16 # The maximum number of threads in the thread pool, only effective when greater than 0
+  fieldDataLoad:
+    memoryLimitMB: 128 # Global transient memory budget for concurrent field data loading
+    batchSizeMB: 32 # Target size for grouping field data cells into one load batch
+    readBufferSizeMB: 16 # Per-reader buffer/window size for field data loading
+    maxReadParallelism: 8 # Maximum read parallelism within one field data load batch
   buildIndexThreadPoolRatio: 0.75
   DiskIndex:
     MaxDegree: 56

--- a/internal/core/src/common/Common.cpp
+++ b/internal/core/src/common/Common.cpp
@@ -28,7 +28,6 @@
 namespace milvus {
 
 std::atomic<int64_t> FILE_SLICE_SIZE(DEFAULT_INDEX_FILE_SLICE_SIZE);
-std::atomic<double> ENTRY_STREAM_BUDGET_RATIO(3.0);
 std::atomic<int64_t> EXEC_EVAL_EXPR_BATCH_SIZE(
     DEFAULT_EXEC_EVAL_EXPR_BATCH_SIZE);
 std::atomic<int64_t> DELETE_DUMP_BATCH_SIZE(DEFAULT_DELETE_DUMP_BATCH_SIZE);
@@ -52,16 +51,14 @@ SetIndexSliceSize(const int64_t size) {
 }
 
 void
-SetStreamBudgetRatio(const double ratio) {
-    if (ratio <= 0) {
-        LOG_WARN("ignore invalid entry stream budget ratio: {}", ratio);
+SetEntryStreamBudgetBytes(int64_t bytes) {
+    if (bytes < 0) {
+        LOG_WARN("ignore invalid entry stream budget bytes: {}", bytes);
         return;
     }
-    ENTRY_STREAM_BUDGET_RATIO.store(ratio);
-    storage::TransientMemoryBudget::GetEntryStreamBudget()
-        .NotifyCapacityUpdated();
-    LOG_INFO("set entry stream budget ratio: {}",
-             ENTRY_STREAM_BUDGET_RATIO.load());
+    storage::TransientMemoryBudget::SetEntryStreamBudgetBytes(
+        static_cast<size_t>(bytes));
+    LOG_INFO("set entry stream budget bytes: {}", bytes);
 }
 
 void

--- a/internal/core/src/common/Common.cpp
+++ b/internal/core/src/common/Common.cpp
@@ -51,14 +51,14 @@ SetIndexSliceSize(const int64_t size) {
 }
 
 void
-SetEntryStreamBudgetBytes(int64_t bytes) {
+SetLoadTransientBudgetBytes(int64_t bytes) {
     if (bytes < 0) {
-        LOG_WARN("ignore invalid entry stream budget bytes: {}", bytes);
+        LOG_WARN("ignore invalid load transient budget bytes: {}", bytes);
         return;
     }
-    storage::TransientMemoryBudget::SetEntryStreamBudgetBytes(
+    storage::TransientMemoryBudget::SetLoadTransientBudgetBytes(
         static_cast<size_t>(bytes));
-    LOG_INFO("set entry stream budget bytes: {}", bytes);
+    LOG_INFO("set load transient budget bytes: {}", bytes);
 }
 
 void

--- a/internal/core/src/common/Common.h
+++ b/internal/core/src/common/Common.h
@@ -39,7 +39,7 @@ void
 SetIndexSliceSize(const int64_t size);
 
 void
-SetEntryStreamBudgetBytes(int64_t bytes);
+SetLoadTransientBudgetBytes(int64_t bytes);
 
 void
 SetDefaultExecEvalExprBatchSize(int64_t val);

--- a/internal/core/src/common/Common.h
+++ b/internal/core/src/common/Common.h
@@ -26,7 +26,6 @@
 namespace milvus {
 
 extern std::atomic<int64_t> FILE_SLICE_SIZE;
-extern std::atomic<double> ENTRY_STREAM_BUDGET_RATIO;
 extern std::atomic<int64_t> EXEC_EVAL_EXPR_BATCH_SIZE;
 extern std::atomic<int64_t> DELETE_DUMP_BATCH_SIZE;
 extern std::atomic<bool> ENABLE_LATEST_DELETE_SNAPSHOT_OPTIMIZATION;
@@ -40,7 +39,7 @@ void
 SetIndexSliceSize(const int64_t size);
 
 void
-SetStreamBudgetRatio(const double ratio);
+SetEntryStreamBudgetBytes(int64_t bytes);
 
 void
 SetDefaultExecEvalExprBatchSize(int64_t val);

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -77,29 +77,6 @@ SetThreadPoolMaxThreadsSize(const int value) {
 }
 
 void
-SetFieldDataLoadMemoryLimitMB(const int64_t value) {
-    milvus::storage::TransientMemoryBudget::SetFieldDataLoadBudgetBytes(
-        static_cast<size_t>(std::max<int64_t>(value, 1)) << 20);
-}
-
-void
-SetFieldDataLoadBatchSizeMB(const int64_t value) {
-    milvus::segcore::SetFieldDataLoadBatchTargetBytes(
-        std::max<int64_t>(value, 1) << 20);
-}
-
-void
-SetFieldDataLoadReadBufferSizeMB(const int64_t value) {
-    milvus::segcore::SetFieldDataReadWindowBytes(std::max<int64_t>(value, 1)
-                                                 << 20);
-}
-
-void
-SetFieldDataLoadMaxReadParallelism(const int64_t value) {
-    milvus::segcore::SetFieldDataMaxReadParallelism(value);
-}
-
-void
 SetDefaultExprEvalBatchSize(int64_t val) {
     milvus::SetDefaultExecEvalExprBatchSize(val);
 }

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -218,6 +218,18 @@ SetStorageV2CellTargetSizeBytes(int64_t bytes) {
 }
 
 void
+SetStorageV2FieldDataLoadBudgetBytes(int64_t bytes) {
+    if (bytes <= 0) {
+        LOG_WARN("ignore invalid storage v2 field data load budget bytes: {}",
+                 bytes);
+        return;
+    }
+    milvus::storage::TransientMemoryBudget::SetFieldDataLoadBudgetBytes(
+        static_cast<size_t>(bytes));
+    LOG_INFO("set storage v2 field data load budget bytes: {}", bytes);
+}
+
+void
 LogOpenSSLFIPSStatus() {
     std::call_once(fipsFlag, []() {
         LOG_INFO("Milvus FIPS in OpenSSL: {}",

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -52,8 +52,8 @@ SetIndexSliceSize(const int64_t size) {
 }
 
 void
-SetStreamBudgetRatio(const double ratio) {
-    milvus::SetStreamBudgetRatio(ratio);
+SetEntryStreamBudgetBytes(int64_t bytes) {
+    milvus::SetEntryStreamBudgetBytes(bytes);
 }
 
 void

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 #include <cstddef>
+#include <algorithm>
 #include <mutex>
 #include <string>
 
@@ -31,7 +32,9 @@
 #include "storage/ThreadPool.h"
 #include "exec/expression/ExprCache.h"
 #include "log/Log.h"
+#include "segcore/memory_planner.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
+#include "storage/EntryStreamUtils.h"
 #include "storage/ThreadPool.h"
 
 std::once_flag traceFlag;
@@ -71,6 +74,29 @@ SetLowPriorityThreadCoreCoefficient(const float value) {
 void
 SetThreadPoolMaxThreadsSize(const int value) {
     milvus::SetThreadPoolMaxThreadsSize(value);
+}
+
+void
+SetFieldDataLoadMemoryLimitMB(const int64_t value) {
+    milvus::storage::TransientMemoryBudget::SetFieldDataLoadBudgetBytes(
+        static_cast<size_t>(std::max<int64_t>(value, 1)) << 20);
+}
+
+void
+SetFieldDataLoadBatchSizeMB(const int64_t value) {
+    milvus::segcore::SetFieldDataLoadBatchTargetBytes(
+        std::max<int64_t>(value, 1) << 20);
+}
+
+void
+SetFieldDataLoadReadBufferSizeMB(const int64_t value) {
+    milvus::segcore::SetFieldDataReadWindowBytes(std::max<int64_t>(value, 1)
+                                                 << 20);
+}
+
+void
+SetFieldDataLoadMaxReadParallelism(const int64_t value) {
+    milvus::segcore::SetFieldDataMaxReadParallelism(value);
 }
 
 void

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -52,8 +52,8 @@ SetIndexSliceSize(const int64_t size) {
 }
 
 void
-SetEntryStreamBudgetBytes(int64_t bytes) {
-    milvus::SetEntryStreamBudgetBytes(bytes);
+SetLoadTransientBudgetBytes(int64_t bytes) {
+    milvus::SetLoadTransientBudgetBytes(bytes);
 }
 
 void
@@ -215,18 +215,6 @@ UpdateArrowIOThreadPoolMetrics() {
 void
 SetStorageV2CellTargetSizeBytes(int64_t bytes) {
     milvus::segcore::storagev2translator::SetCellTargetSizeBytes(bytes);
-}
-
-void
-SetStorageV2FieldDataLoadBudgetBytes(int64_t bytes) {
-    if (bytes <= 0) {
-        LOG_WARN("ignore invalid storage v2 field data load budget bytes: {}",
-                 bytes);
-        return;
-    }
-    milvus::storage::TransientMemoryBudget::SetFieldDataLoadBudgetBytes(
-        static_cast<size_t>(bytes));
-    LOG_INFO("set storage v2 field data load budget bytes: {}", bytes);
 }
 
 void

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -47,6 +47,18 @@ void
 SetThreadPoolMaxThreadsSize(const int);
 
 void
+SetFieldDataLoadMemoryLimitMB(const int64_t);
+
+void
+SetFieldDataLoadBatchSizeMB(const int64_t);
+
+void
+SetFieldDataLoadReadBufferSizeMB(const int64_t);
+
+void
+SetFieldDataLoadMaxReadParallelism(const int64_t);
+
+void
 SetDefaultExprEvalBatchSize(int64_t val);
 
 void

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -120,6 +120,10 @@ UpdateArrowIOThreadPoolMetrics();
 void
 SetStorageV2CellTargetSizeBytes(int64_t bytes);
 
+// Process-wide transient memory budget for storage v2 field-data load.
+void
+SetStorageV2FieldDataLoadBudgetBytes(int64_t bytes);
+
 #ifdef __cplusplus
 };
 #endif

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -47,18 +47,6 @@ void
 SetThreadPoolMaxThreadsSize(const int);
 
 void
-SetFieldDataLoadMemoryLimitMB(const int64_t);
-
-void
-SetFieldDataLoadBatchSizeMB(const int64_t);
-
-void
-SetFieldDataLoadReadBufferSizeMB(const int64_t);
-
-void
-SetFieldDataLoadMaxReadParallelism(const int64_t);
-
-void
 SetDefaultExprEvalBatchSize(int64_t val);
 
 void

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -32,7 +32,7 @@ void
 SetIndexSliceSize(const int64_t);
 
 void
-SetEntryStreamBudgetBytes(int64_t bytes);
+SetLoadTransientBudgetBytes(int64_t bytes);
 
 void
 SetHighPriorityThreadCoreCoefficient(const float);
@@ -119,10 +119,6 @@ UpdateArrowIOThreadPoolMetrics();
 // packed into cells so that rgs_per_cell * avg_row_group_size ≈ this value.
 void
 SetStorageV2CellTargetSizeBytes(int64_t bytes);
-
-// Process-wide transient memory budget for storage v2 field-data load.
-void
-SetStorageV2FieldDataLoadBudgetBytes(int64_t bytes);
 
 #ifdef __cplusplus
 };

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -32,7 +32,7 @@ void
 SetIndexSliceSize(const int64_t);
 
 void
-SetStreamBudgetRatio(const double);
+SetEntryStreamBudgetBytes(int64_t bytes);
 
 void
 SetHighPriorityThreadCoreCoefficient(const float);

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -17,8 +17,10 @@
 #include <nlohmann/json.hpp>
 #include <stdint.h>
 #include <stdlib.h>
+#include <algorithm>
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -708,11 +710,17 @@ TYPED_TEST_SUITE_P(HybridIndexTestInverted);
 
 TYPED_TEST_P(HybridIndexTestInverted,
              ResourceEstimateUsesInternalInvertedIndexType) {
-    auto stream_budget =
-        storage::TransientMemoryBudget::GetEntryStreamBudget().CapacityBytes();
-    auto stream_overhead =
-        static_cast<uint64_t>(stream_budget + storage::kTailMergeGrace);
-    auto index_size = stream_overhead + 1024;
+    auto stream_budget = storage::EntryStreamMaxTransientBytes();
+    auto index_size = static_cast<uint64_t>(stream_budget);
+    if (stream_budget == std::numeric_limits<size_t>::max() ||
+        index_size > std::numeric_limits<uint64_t>::max() -
+                         storage::kTailMergeGrace - 1024) {
+        index_size = storage::kTailMergeGrace + 1024;
+    } else {
+        index_size += 1024;
+    }
+    auto stream_overhead = static_cast<uint64_t>(
+        std::min<size_t>(index_size, storage::EntryStreamMaxTransientBytes()));
     std::map<std::string, std::string> index_params{
         {"index_type", milvus::index::HYBRID_INDEX_TYPE},
         {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -45,6 +45,8 @@
 #include "milvus-storage/filesystem/fs.h"
 #include "pb/common.pb.h"
 #include "pb/schema.pb.h"
+#include "segcore/memory_planner.h"
+#include "segcore/storagev1translator/SealedIndexTranslator.h"
 #include "storage/ChunkManager.h"
 #include "storage/FileManager.h"
 #include "storage/InsertData.h"
@@ -746,6 +748,52 @@ TYPED_TEST_P(HybridIndexTestInverted,
     EXPECT_FALSE(request.has_raw_data);
 }
 
+TYPED_TEST_P(HybridIndexTestInverted,
+             ScalarIndexLoadingOverheadDoesNotCapFileDimension) {
+    std::map<std::string, std::string> index_params{
+        {"index_type", milvus::index::HYBRID_INDEX_TYPE},
+        {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
+    milvus::segcore::LoadIndexInfo load_info{};
+    load_info.collection_id = 1;
+    load_info.partition_id = 2;
+    load_info.segment_id = 3;
+    load_info.field_id = 101;
+    load_info.field_type = this->type_;
+    load_info.element_type = DataType::NONE;
+    load_info.enable_mmap = false;
+    load_info.index_id = this->index_build_id_;
+    load_info.index_build_id = this->index_build_id_;
+    load_info.index_version = this->index_version_;
+    load_info.index_params = index_params;
+    load_info.index_files = this->index_files_;
+    load_info.index_engine_version = this->index_version_;
+    load_info.index_size = 1024;
+    load_info.num_rows = this->nb_;
+    load_info.dim = 0;
+
+    index::CreateIndexInfo index_info{};
+    index_info.index_type = milvus::index::HYBRID_INDEX_TYPE;
+    index_info.field_type = this->type_;
+    index_info.index_engine_version = this->index_version_;
+
+    storage::FileManagerContext ctx(
+        this->field_meta_, this->index_meta_, this->chunk_manager_, this->fs_);
+    ctx.set_for_loading_index(true);
+
+    Config config = index_params;
+    milvus::segcore::storagev1translator::SealedIndexTranslator translator(
+        index_info,
+        &load_info,
+        milvus::tracer::TraceContext{},
+        ctx,
+        std::move(config));
+
+    ASSERT_TRUE(translator.meta()->loading_overhead.has_value());
+    EXPECT_EQ(translator.meta()->loading_overhead->group,
+              milvus::segcore::kLoadTransientOverheadGroup);
+    EXPECT_EQ(translator.meta()->loading_overhead->upper_bound.file_bytes, 0);
+}
+
 template <typename T>
 class HybridIndexTestNullable : public HybridIndexTestV1<T> {
  public:
@@ -941,7 +989,8 @@ REGISTER_TYPED_TEST_SUITE_P(HybridIndexTestV4,
                             TestRangeCompareFuncTest);
 
 REGISTER_TYPED_TEST_SUITE_P(HybridIndexTestInverted,
-                            ResourceEstimateUsesInternalInvertedIndexType);
+                            ResourceEstimateUsesInternalInvertedIndexType,
+                            ScalarIndexLoadingOverheadDoesNotCapFileDimension);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(HybridIndexE2ECheck_HighCardinality,
                                HybridIndexTestV2,

--- a/internal/core/src/index/HybridScalarIndexTest.cpp
+++ b/internal/core/src/index/HybridScalarIndexTest.cpp
@@ -13,6 +13,7 @@
 #include <boost/filesystem/operations.hpp>
 #include <fmt/core.h>
 #include <folly/FBVector.h>
+#include <folly/ScopeGuard.h>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 #include <stdint.h>
@@ -33,6 +34,7 @@
 #include "common/TracerBase.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
+#include "cachinglayer/LoadingOverheadTracker.h"
 #include "gtest/gtest.h"
 #include "index/HybridScalarIndex.h"
 #include "index/Index.h"
@@ -750,6 +752,12 @@ TYPED_TEST_P(HybridIndexTestInverted,
 
 TYPED_TEST_P(HybridIndexTestInverted,
              ScalarIndexLoadingOverheadDoesNotCapFileDimension) {
+    auto& budget = storage::TransientMemoryBudget::GetLoadTransientBudget();
+    auto old_capacity = budget.CapacityBytes();
+    auto cleanup = folly::makeGuard(
+        [&budget, old_capacity]() { budget.SetCapacityBytes(old_capacity); });
+    budget.SetCapacityBytes(0);
+
     std::map<std::string, std::string> index_params{
         {"index_type", milvus::index::HYBRID_INDEX_TYPE},
         {milvus::index::SCALAR_INDEX_ENGINE_VERSION, "3"}};
@@ -791,6 +799,9 @@ TYPED_TEST_P(HybridIndexTestInverted,
     ASSERT_TRUE(translator.meta()->loading_overhead.has_value());
     EXPECT_EQ(translator.meta()->loading_overhead->group,
               milvus::segcore::kLoadTransientOverheadGroup);
+    EXPECT_EQ(
+        translator.meta()->loading_overhead->upper_bound.memory_bytes,
+        milvus::cachinglayer::LoadingOverheadTracker::kUnlimited.memory_bytes);
     EXPECT_EQ(translator.meta()->loading_overhead->upper_bound.file_bytes, 0);
 }
 

--- a/internal/core/src/index/Index.h
+++ b/internal/core/src/index/Index.h
@@ -23,6 +23,7 @@
 #include "common/EasyAssert.h"
 #include "common/File.h"
 #include "common/JsonCastType.h"
+#include "common/OpContext.h"
 #include "knowhere/comp/index_param.h"
 #include "knowhere/dataset.h"
 #include "knowhere/index/index_factory.h"
@@ -30,10 +31,6 @@
 #include "common/Types.h"
 #include "index/Meta.h"
 #include "index/IndexStats.h"
-
-namespace milvus {
-struct OpContext;
-}
 
 namespace milvus::index {
 

--- a/internal/core/src/index/Index.h
+++ b/internal/core/src/index/Index.h
@@ -31,6 +31,10 @@
 #include "index/Meta.h"
 #include "index/IndexStats.h"
 
+namespace milvus {
+struct OpContext;
+}
+
 namespace milvus::index {
 
 class IndexBase {
@@ -65,7 +69,8 @@ class IndexBase {
     Upload(const Config& config = {}) = 0;
 
     virtual void
-    LoadUnified(const Config& config) {
+    LoadUnified(const Config& config, milvus::OpContext* op_ctx = nullptr) {
+        (void)op_ctx;
         ThrowInfo(Unsupported,
                   "LoadUnified is not supported for this index type");
     }

--- a/internal/core/src/index/ScalarIndex.cpp
+++ b/internal/core/src/index/ScalarIndex.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "common/Types.h"
+#include "common/OpContext.h"
 #include "fmt/core.h"
 #include "index/IndexStats.h"
 #include "index/Meta.h"
@@ -211,7 +212,7 @@ ScalarIndex<T>::UploadUnified(const Config& config) {
 
 template <typename T>
 void
-ScalarIndex<T>::LoadUnified(const Config& config) {
+ScalarIndex<T>::LoadUnified(const Config& config, milvus::OpContext* op_ctx) {
     AssertInfo(
         file_manager_ != nullptr,
         "file_manager_ is null, LoadUnified requires a valid file manager");
@@ -241,8 +242,10 @@ ScalarIndex<T>::LoadUnified(const Config& config) {
     auto collection_id =
         GetValueFromConfig<int64_t>(config, COLLECTION_ID).value_or(0);
 
-    auto reader =
-        storage::IndexEntryReader::Open(input, file_size, collection_id);
+    auto cancellation_token =
+        op_ctx ? op_ctx->cancellation_token : folly::CancellationToken();
+    auto reader = storage::IndexEntryReader::Open(
+        input, file_size, collection_id, milvus::HIGH, cancellation_token);
     AssertInfo(reader != nullptr, "failed to create IndexEntryReader");
 
     LoadEntries(*reader, config);

--- a/internal/core/src/index/ScalarIndex.cpp
+++ b/internal/core/src/index/ScalarIndex.cpp
@@ -242,10 +242,18 @@ ScalarIndex<T>::LoadUnified(const Config& config, milvus::OpContext* op_ctx) {
     auto collection_id =
         GetValueFromConfig<int64_t>(config, COLLECTION_ID).value_or(0);
 
+    auto load_priority =
+        GetValueFromConfig<milvus::proto::common::LoadPriority>(
+            config, milvus::LOAD_PRIORITY)
+            .value_or(milvus::proto::common::LoadPriority::HIGH);
     auto cancellation_token =
         op_ctx ? op_ctx->cancellation_token : folly::CancellationToken();
-    auto reader = storage::IndexEntryReader::Open(
-        input, file_size, collection_id, milvus::HIGH, cancellation_token);
+    auto reader =
+        storage::IndexEntryReader::Open(input,
+                                        file_size,
+                                        collection_id,
+                                        milvus::PriorityForLoad(load_priority),
+                                        cancellation_token);
     AssertInfo(reader != nullptr, "failed to create IndexEntryReader");
 
     LoadEntries(*reader, config);

--- a/internal/core/src/index/ScalarIndex.h
+++ b/internal/core/src/index/ScalarIndex.h
@@ -235,7 +235,8 @@ class ScalarIndex : public IndexBase {
     // LoadEntries() for subclass-specific loading. Currently handles the V3
     // file format (see UploadUnified above for naming rationale).
     void
-    LoadUnified(const Config& config) override;
+    LoadUnified(const Config& config,
+                milvus::OpContext* op_ctx = nullptr) override;
 
     virtual void
     WriteEntries(storage::IndexEntryWriter* writer) {

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -15,6 +15,7 @@
 // limitations under the License.
 #include <gtest/gtest.h>
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <future>
@@ -24,10 +25,12 @@
 
 #include "arrow/api.h"
 #include <folly/CancellationToken.h>
+#include "folly/ScopeGuard.h"
 #include "common/EasyAssert.h"
 #include "gtest/gtest.h"
 #include "milvus-storage/common/metadata.h"
 #include "segcore/memory_planner.h"
+#include "storage/EntryStreamUtils.h"
 
 using namespace milvus::segcore;
 
@@ -441,4 +444,63 @@ TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
         EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::FollyCancel);
     }
     EXPECT_LT(received, specs.size());
+}
+
+TEST(LoadCellBatchAsync, CancellationWhileWaitingForBudgetSkipsRead) {
+    auto& budget =
+        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget();
+    auto old_capacity = budget.CapacityBytes();
+    budget.SetCapacityBytes(1);
+    budget.Acquire(1);
+    auto cleanup = folly::makeGuard([&budget, old_capacity]() {
+        budget.Release(1);
+        budget.SetCapacityBytes(old_capacity);
+    });
+
+    std::atomic<int> read_calls{0};
+    BatchReaderFactory factory = [&read_calls](size_t /*batch_key*/,
+                                               int64_t /*rg_offset*/,
+                                               int64_t total_rg_count,
+                                               int64_t /*reader_memory_limit*/,
+                                               uint64_t /*read_parallelism*/)
+        -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
+        read_calls.fetch_add(1);
+        auto schema = arrow::schema({arrow::field("x", arrow::int64())});
+        std::vector<std::shared_ptr<arrow::Table>> tables;
+        for (int64_t i = 0; i < total_rg_count; ++i) {
+            tables.push_back(arrow::Table::MakeEmpty(schema).ValueOrDie());
+        }
+        return tables;
+    };
+
+    folly::CancellationSource source;
+    milvus::OpContext op_ctx(source.getToken());
+    auto channel = std::make_shared<CellReaderChannel>(1);
+    std::vector<CellSpec> specs = {{/*cid=*/0,
+                                    /*file_idx=*/0,
+                                    /*local_rg_offset=*/0,
+                                    /*rg_count=*/1,
+                                    /*memory_size=*/1}};
+    auto futures = LoadCellBatchAsync(
+        &op_ctx, std::move(specs), std::move(factory), channel, 1);
+
+    ASSERT_EQ(futures.size(), 1);
+    EXPECT_EQ(futures[0].wait_for(std::chrono::milliseconds(50)),
+              std::future_status::timeout);
+    EXPECT_EQ(read_calls.load(), 0);
+
+    source.requestCancellation();
+
+    ASSERT_EQ(futures[0].wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    try {
+        futures[0].get();
+        FAIL() << "expected cancellation";
+    } catch (const milvus::SegcoreError& e) {
+        EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::FollyCancel);
+    }
+
+    std::shared_ptr<CellLoadResult> cell_data;
+    EXPECT_FALSE(channel->pop(cell_data));
+    EXPECT_EQ(read_calls.load(), 0);
 }

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -321,7 +321,48 @@ TEST(LoadCellBatchAsync, ReadParallelismScalesWithBatchBudget) {
     }
 
     EXPECT_EQ(observed_parallelism.load(), 8);
-    EXPECT_EQ(observed_reader_memory_limit.load(), 16 * MB);
+    EXPECT_EQ(observed_reader_memory_limit.load(), 32 * MB);
+}
+
+TEST(LoadCellBatchAsync, FinalizeCellBeforePush) {
+    constexpr int64_t MB = 1 << 20;
+    std::vector<CellSpec> specs = {
+        {0, 0, 0, 1, 8 * MB},
+        {1, 0, 1, 1, 8 * MB},
+    };
+
+    std::atomic<int> finalized{0};
+    auto channel = std::make_shared<CellReaderChannel>();
+    auto futures = LoadCellBatchAsync(
+        nullptr,
+        std::move(specs),
+        MakeMockReaderFactory(),
+        channel,
+        32 * MB,
+        milvus::proto::common::LoadPriority::HIGH,
+        [&finalized](const std::vector<std::shared_ptr<arrow::Table>>& tables,
+                     int64_t /*cid*/) {
+            EXPECT_EQ(tables.size(), 1);
+            finalized.fetch_add(1);
+            return std::make_unique<milvus::GroupChunk>();
+        });
+
+    int received = 0;
+    std::shared_ptr<CellLoadResult> cell_data;
+    while (channel->pop(cell_data)) {
+        ASSERT_NE(cell_data, nullptr);
+        EXPECT_NE(cell_data->chunk, nullptr);
+        EXPECT_TRUE(cell_data->tables.empty());
+        EXPECT_EQ(cell_data->budget_bytes, 0);
+        ReleaseCellLoadResultBudget(cell_data);
+        ++received;
+    }
+    for (auto& future : futures) {
+        future.get();
+    }
+
+    EXPECT_EQ(received, 2);
+    EXPECT_EQ(finalized.load(), 2);
 }
 
 TEST(LoadCellBatchAsync, FileBoundarySplit) {

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -205,12 +205,16 @@ MakeMockReaderFactory() {
 // Helper to run LoadCellBatchAsync and return future count (= batch count).
 size_t
 RunAndCountBatches(std::vector<CellSpec> cell_specs, int64_t memory_limit) {
-    auto channel = std::make_shared<CellReaderChannel>(64);
+    auto channel = std::make_shared<CellReaderChannel>();
     auto futures = LoadCellBatchAsync(nullptr,
                                       std::move(cell_specs),
                                       MakeMockReaderFactory(),
                                       channel,
                                       memory_limit);
+    std::shared_ptr<CellLoadResult> cell_data;
+    while (channel->pop(cell_data)) {
+        ReleaseCellLoadResultBudget(cell_data);
+    }
     for (auto& f : futures) {
         f.get();
     }
@@ -332,12 +336,14 @@ TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
     ASSERT_TRUE(channel->pop(cell_data));
     ASSERT_NE(cell_data, nullptr);
     EXPECT_EQ(cell_data->cid, 0);
+    ReleaseCellLoadResultBudget(cell_data);
 
     source.requestCancellation();
 
     size_t received = 1;
     while (channel->pop(cell_data)) {
         ASSERT_NE(cell_data, nullptr);
+        ReleaseCellLoadResultBudget(cell_data);
         ++received;
     }
 

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -183,6 +183,32 @@ TEST(ParallelDegreeSplitStrategy, ContinuousExceedingAvgSize) {
     EXPECT_EQ(blocks[1], (RowGroupBlock{5, 4}));
 }
 
+TEST(FieldDataLoadBatchSplitTargetBytes, UsesBatchTargetByDefault) {
+    auto& budget =
+        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget();
+    auto old_capacity = budget.CapacityBytes();
+    auto cleanup = folly::makeGuard(
+        [&budget, old_capacity]() { budget.SetCapacityBytes(old_capacity); });
+
+    budget.SetCapacityBytes(kDefaultFieldDataLoadBatchTargetBytes * 4);
+
+    EXPECT_EQ(FieldDataLoadBatchSplitTargetBytes(),
+              kDefaultFieldDataLoadBatchTargetBytes);
+}
+
+TEST(FieldDataLoadBatchSplitTargetBytes, CapsTargetByConfiguredBudget) {
+    constexpr int64_t MB = 1 << 20;
+    auto& budget =
+        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget();
+    auto old_capacity = budget.CapacityBytes();
+    auto cleanup = folly::makeGuard(
+        [&budget, old_capacity]() { budget.SetCapacityBytes(old_capacity); });
+
+    budget.SetCapacityBytes(8 * MB);
+
+    EXPECT_EQ(FieldDataLoadBatchSplitTargetBytes(), 8 * MB);
+}
+
 // ---- LoadCellBatchAsync tests ----
 
 namespace {

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -185,7 +185,7 @@ TEST(ParallelDegreeSplitStrategy, ContinuousExceedingAvgSize) {
 
 TEST(FieldDataLoadBatchSplitTargetBytes, UsesBatchTargetByDefault) {
     auto& budget =
-        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget();
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
     auto cleanup = folly::makeGuard(
         [&budget, old_capacity]() { budget.SetCapacityBytes(old_capacity); });
@@ -199,7 +199,7 @@ TEST(FieldDataLoadBatchSplitTargetBytes, UsesBatchTargetByDefault) {
 TEST(FieldDataLoadBatchSplitTargetBytes, CapsTargetByConfiguredBudget) {
     constexpr int64_t MB = 1 << 20;
     auto& budget =
-        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget();
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
     auto cleanup = folly::makeGuard(
         [&budget, old_capacity]() { budget.SetCapacityBytes(old_capacity); });
@@ -474,7 +474,7 @@ TEST(LoadCellBatchAsync, CancellationStopsMidBatchPush) {
 
 TEST(LoadCellBatchAsync, CancellationWhileWaitingForBudgetSkipsRead) {
     auto& budget =
-        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget();
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
     budget.SetCapacityBytes(1);
     budget.Acquire(1);

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -20,10 +20,12 @@
 #include <cstdint>
 #include <future>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "arrow/api.h"
+#include "cachinglayer/LoadingOverheadTracker.h"
 #include <folly/CancellationToken.h>
 #include "folly/ScopeGuard.h"
 #include "common/EasyAssert.h"
@@ -207,6 +209,52 @@ TEST(FieldDataLoadBatchSplitTargetBytes, CapsTargetByConfiguredBudget) {
     budget.SetCapacityBytes(8 * MB);
 
     EXPECT_EQ(FieldDataLoadBatchSplitTargetBytes(), 8 * MB);
+}
+
+TEST(FieldDataLoadingOverheadUpperBound, UsesUnlimitedWhenBudgetDisabled) {
+    auto& budget =
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
+    auto old_capacity = budget.CapacityBytes();
+    auto cleanup = folly::makeGuard(
+        [&budget, old_capacity]() { budget.SetCapacityBytes(old_capacity); });
+
+    budget.SetCapacityBytes(0);
+
+    auto upper_bound =
+        FieldDataLoadingOverheadUpperBound(/*max_memory_overhead=*/128);
+
+    EXPECT_EQ(
+        upper_bound.memory_bytes,
+        milvus::cachinglayer::LoadingOverheadTracker::kUnlimited.memory_bytes);
+    EXPECT_EQ(
+        upper_bound.file_bytes,
+        milvus::cachinglayer::LoadingOverheadTracker::kUnlimited.file_bytes);
+}
+
+TEST(FieldDataLoadingOverheadUpperBound, UsesBudgetWithMaxOverheadFloor) {
+    constexpr int64_t MB = 1 << 20;
+    auto& budget =
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget();
+    auto old_capacity = budget.CapacityBytes();
+    auto cleanup = folly::makeGuard(
+        [&budget, old_capacity]() { budget.SetCapacityBytes(old_capacity); });
+
+    budget.SetCapacityBytes(8 * MB);
+
+    auto memory_only =
+        FieldDataLoadingOverheadUpperBound(/*max_memory_overhead=*/16 * MB);
+    EXPECT_EQ(memory_only.memory_bytes, 16 * MB);
+    EXPECT_EQ(memory_only.file_bytes, 0);
+
+    auto mmap_smaller_overhead = FieldDataLoadingOverheadUpperBound(
+        /*max_memory_overhead=*/4 * MB, std::optional<int64_t>{2 * MB});
+    EXPECT_EQ(mmap_smaller_overhead.memory_bytes, 8 * MB);
+    EXPECT_EQ(mmap_smaller_overhead.file_bytes, 8 * MB);
+
+    auto mmap_larger_file_overhead = FieldDataLoadingOverheadUpperBound(
+        /*max_memory_overhead=*/4 * MB, std::optional<int64_t>{32 * MB});
+    EXPECT_EQ(mmap_larger_file_overhead.memory_bytes, 8 * MB);
+    EXPECT_EQ(mmap_larger_file_overhead.file_bytes, 32 * MB);
 }
 
 // ---- LoadCellBatchAsync tests ----

--- a/internal/core/src/segcore/MemoryPlannerTest.cpp
+++ b/internal/core/src/segcore/MemoryPlannerTest.cpp
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <gtest/gtest.h>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <future>
@@ -190,7 +191,8 @@ MakeMockReaderFactory() {
     return [](size_t /*batch_key*/,
               int64_t /*rg_offset*/,
               int64_t total_rg_count,
-              int64_t /*reader_memory_limit*/)
+              int64_t /*reader_memory_limit*/,
+              uint64_t /*read_parallelism*/)
                -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
         // Return one empty table per row group
         auto schema = arrow::schema({arrow::field("x", arrow::int64())});
@@ -276,6 +278,50 @@ TEST(LoadCellBatchAsync, SingleCellExceedsLimit) {
                                     /*memory_size=*/256 * MB}};
     auto batches = RunAndCountBatches(specs, 128 * MB);
     EXPECT_EQ(batches, 1);
+}
+
+TEST(LoadCellBatchAsync, ReadParallelismScalesWithBatchBudget) {
+    constexpr int64_t MB = 1 << 20;
+
+    std::atomic<uint64_t> observed_parallelism{0};
+    std::atomic<int64_t> observed_reader_memory_limit{0};
+    BatchReaderFactory factory = [&observed_parallelism,
+                                  &observed_reader_memory_limit](
+                                     size_t /*batch_key*/,
+                                     int64_t /*rg_offset*/,
+                                     int64_t total_rg_count,
+                                     int64_t reader_memory_limit,
+                                     uint64_t read_parallelism)
+        -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
+        observed_parallelism.store(read_parallelism);
+        observed_reader_memory_limit.store(reader_memory_limit);
+        auto schema = arrow::schema({arrow::field("x", arrow::int64())});
+        std::vector<std::shared_ptr<arrow::Table>> tables;
+        for (int64_t i = 0; i < total_rg_count; ++i) {
+            tables.push_back(arrow::Table::MakeEmpty(schema).ValueOrDie());
+        }
+        return tables;
+    };
+
+    std::vector<CellSpec> specs = {{/*cid=*/0,
+                                    /*file_idx=*/0,
+                                    /*local_rg_offset=*/0,
+                                    /*rg_count=*/8,
+                                    /*memory_size=*/128 * MB}};
+
+    auto channel = std::make_shared<CellReaderChannel>();
+    auto futures = LoadCellBatchAsync(
+        nullptr, std::move(specs), std::move(factory), channel, 32 * MB);
+    std::shared_ptr<CellLoadResult> cell_data;
+    while (channel->pop(cell_data)) {
+        ReleaseCellLoadResultBudget(cell_data);
+    }
+    for (auto& future : futures) {
+        future.get();
+    }
+
+    EXPECT_EQ(observed_parallelism.load(), 8);
+    EXPECT_EQ(observed_reader_memory_limit.load(), 16 * MB);
 }
 
 TEST(LoadCellBatchAsync, FileBoundarySplit) {

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -169,7 +169,8 @@ ReadFileRowGroupBlock(const milvus_storage::ArrowFileSystemPtr& fs,
                               file,
                               nullptr,
                               reader_memory_limit,
-                              milvus::storage::GetReaderProperties()));
+                              milvus::storage::GetReaderProperties(),
+                              milvus::storage::GetArrowReaderProperties()));
     auto close_guard = folly::makeGuard([&reader]() { (void)reader->Close(); });
     ARROW_RETURN_NOT_OK(reader->SetRowGroupOffsetAndCount(rg_offset, rg_count));
     std::vector<std::shared_ptr<arrow::Table>> tables;
@@ -524,7 +525,14 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
 
             auto& budget = milvus::storage::TransientMemoryBudget::
                 GetFieldDataLoadBudget();
-            budget.Acquire(batch_budget_bytes);
+            auto acquired = budget.AcquireUntil(batch_budget_bytes, [op_ctx]() {
+                return op_ctx &&
+                       op_ctx->cancellation_token.isCancellationRequested();
+            });
+            if (!acquired) {
+                CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
+                return;
+            }
             size_t transferred_budget_bytes = 0;
             auto release_guard = folly::makeGuard(
                 [&budget, batch_budget_bytes, &transferred_budget_bytes]() {
@@ -533,6 +541,7 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                                        transferred_budget_bytes);
                     }
                 });
+            CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
 
             auto tables_result = (*shared_factory)(batch.file_idx,
                                                    batch.rg_offset,
@@ -620,13 +629,13 @@ MakeChunkReaderFactory(
                           int64_t rg_offset,
                           int64_t total_rg_count,
                           int64_t /*reader_memory_limit*/,
-                          uint64_t read_parallelism)
+                          uint64_t /*read_parallelism*/)
                -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
         std::vector<int64_t> rg_indices(total_rg_count);
         std::iota(rg_indices.begin(), rg_indices.end(), rg_offset);
         ARROW_ASSIGN_OR_RAISE(
             auto batches,
-            chunk_reader->get_chunks(rg_indices, read_parallelism));
+            chunk_reader->get_chunks(rg_indices, /*parallelism=*/1));
         std::vector<std::shared_ptr<arrow::Table>> tables;
         tables.reserve(batches.size());
         for (auto& batch : batches) {

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "arrow/api.h"
+#include "cachinglayer/LoadingOverheadTracker.h"
 #include "common/Channel.h"
 #include "common/Common.h"
 #include "common/EasyAssert.h"
@@ -113,6 +114,24 @@ SetFieldDataMaxReadParallelism(int64_t parallelism) {
     FIELD_DATA_MAX_READ_PARALLELISM.store(std::max<int64_t>(parallelism, 1));
     LOG_INFO("set field data max read parallelism: {}",
              FIELD_DATA_MAX_READ_PARALLELISM.load());
+}
+
+milvus::cachinglayer::ResourceUsage
+FieldDataLoadingOverheadUpperBound(int64_t max_memory_overhead,
+                                   std::optional<int64_t> max_file_overhead) {
+    auto budget_capacity = static_cast<int64_t>(
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
+            .CapacityBytes());
+    if (budget_capacity == 0) {
+        return milvus::cachinglayer::LoadingOverheadTracker::kUnlimited;
+    }
+
+    auto memory_ub = std::max<int64_t>(budget_capacity, max_memory_overhead);
+    auto file_ub =
+        max_file_overhead.has_value()
+            ? std::max<int64_t>(budget_capacity, max_file_overhead.value())
+            : int64_t{0};
+    return {memory_ub, file_ub};
 }
 
 namespace {

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <exception>
 #include <future>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <string>
@@ -39,10 +40,48 @@
 #include "segcore/Utils.h"
 #include "segcore/memory_planner.h"
 #include "storage/KeyRetriever.h"
+#include "storage/ChunkStreamUtils.h"
 #include "storage/ThreadPool.h"
 #include "storage/ThreadPools.h"
 
 namespace milvus::segcore {
+
+namespace {
+
+size_t
+CellLoadingBudgetBytes(const CellSpec& cell) {
+    auto overhead_size = cell.loading_overhead_size > 0
+                             ? cell.loading_overhead_size
+                             : cell.memory_size;
+    AssertInfo(overhead_size > 0,
+               "[StorageV2] Cell loading overhead size must be positive, "
+               "cid={}, got {}, memory_size={}",
+               cell.cid,
+               overhead_size,
+               cell.memory_size);
+    return static_cast<size_t>(overhead_size);
+}
+
+size_t
+BatchLoadingBudgetBytes(const std::vector<CellSpec>& cells) {
+    size_t total = 0;
+    for (const auto& cell : cells) {
+        auto bytes = CellLoadingBudgetBytes(cell);
+        if (bytes > std::numeric_limits<size_t>::max() - total) {
+            return std::numeric_limits<size_t>::max();
+        }
+        total += bytes;
+    }
+    return total;
+}
+
+int64_t
+BatchReaderMemoryLimit(int64_t batch_memory, int64_t memory_limit) {
+    auto capped = std::min(batch_memory, memory_limit);
+    return std::max<int64_t>(capped, FILE_SLICE_SIZE.load());
+}
+
+}  // namespace
 
 MemoryBasedSplitStrategy::MemoryBasedSplitStrategy(
     const milvus_storage::RowGroupMetadataVector& row_group_metadatas)
@@ -337,9 +376,6 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
 
     auto& pool = ThreadPools::GetThreadPool(milvus::PriorityForLoad(priority));
     auto remaining = std::make_shared<std::atomic<size_t>>(batches.size());
-    auto reader_memory_limit =
-        std::max<int64_t>(memory_limit / static_cast<int64_t>(batches.size()),
-                          FILE_SLICE_SIZE.load());
     auto shared_factory =
         std::make_shared<BatchReaderFactory>(std::move(reader_factory));
 
@@ -347,8 +383,12 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     futures.reserve(batches.size());
 
     for (auto& batch : batches) {
+        auto batch_budget_bytes = BatchLoadingBudgetBytes(batch.cells);
+        auto reader_memory_limit =
+            BatchReaderMemoryLimit(batch.batch_memory, memory_limit);
         futures.emplace_back(pool.Submit([batch = std::move(batch),
                                           shared_factory,
+                                          batch_budget_bytes,
                                           reader_memory_limit,
                                           channel,
                                           remaining,
@@ -359,6 +399,18 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                 }
             });
             CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
+
+            auto& budget = milvus::storage::TransientMemoryBudget::
+                GetFieldDataLoadBudget();
+            budget.Acquire(batch_budget_bytes);
+            size_t transferred_budget_bytes = 0;
+            auto release_guard = folly::makeGuard(
+                [&budget, batch_budget_bytes, &transferred_budget_bytes]() {
+                    if (transferred_budget_bytes < batch_budget_bytes) {
+                        budget.Release(batch_budget_bytes -
+                                       transferred_budget_bytes);
+                    }
+                });
 
             auto tables_result = (*shared_factory)(batch.file_idx,
                                                    batch.rg_offset,
@@ -380,6 +432,7 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                 CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
                 auto cell_result = std::make_shared<CellLoadResult>();
                 cell_result->cid = cell.cid;
+                cell_result->budget_bytes = CellLoadingBudgetBytes(cell);
                 cell_result->tables.reserve(cell.rg_count);
                 for (int64_t i = 0; i < cell.rg_count; ++i) {
                     cell_result->tables.push_back(
@@ -387,11 +440,27 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                 }
                 table_offset += cell.rg_count;
                 channel->push(std::move(cell_result));
+                transferred_budget_bytes += CellLoadingBudgetBytes(cell);
             }
         }));
     }
 
     return futures;
+}
+
+void
+ReleaseCellLoadResultBudget(
+    const std::shared_ptr<CellLoadResult>& cell_load_result) {
+    if (cell_load_result == nullptr) {
+        return;
+    }
+    cell_load_result->tables.clear();
+    if (cell_load_result->budget_bytes == 0) {
+        return;
+    }
+    milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget().Release(
+        cell_load_result->budget_bytes);
+    cell_load_result->budget_bytes = 0;
 }
 
 BatchReaderFactory

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -40,11 +40,67 @@
 #include "segcore/Utils.h"
 #include "segcore/memory_planner.h"
 #include "storage/KeyRetriever.h"
-#include "storage/ChunkStreamUtils.h"
+#include "storage/EntryStreamUtils.h"
 #include "storage/ThreadPool.h"
 #include "storage/ThreadPools.h"
 
 namespace milvus::segcore {
+
+namespace {
+
+std::atomic<int64_t> FIELD_DATA_LOAD_BATCH_TARGET_BYTES(
+    kDefaultFieldDataLoadBatchTargetBytes);
+std::atomic<int64_t> FIELD_DATA_READ_WINDOW_BYTES(
+    kDefaultFieldDataReadWindowBytes);
+std::atomic<int64_t> FIELD_DATA_MAX_READ_PARALLELISM(
+    kDefaultFieldDataMaxReadParallelism);
+
+int64_t
+PositiveBytes(int64_t bytes, int64_t fallback) {
+    return bytes > 0 ? bytes : fallback;
+}
+
+}  // namespace
+
+int64_t
+FieldDataLoadBatchTargetBytes() {
+    return PositiveBytes(FIELD_DATA_LOAD_BATCH_TARGET_BYTES.load(),
+                         kDefaultFieldDataLoadBatchTargetBytes);
+}
+
+int64_t
+FieldDataReadWindowBytes() {
+    return PositiveBytes(FIELD_DATA_READ_WINDOW_BYTES.load(),
+                         kDefaultFieldDataReadWindowBytes);
+}
+
+int64_t
+FieldDataMaxReadParallelism() {
+    return std::max<int64_t>(FIELD_DATA_MAX_READ_PARALLELISM.load(), 1);
+}
+
+void
+SetFieldDataLoadBatchTargetBytes(int64_t bytes) {
+    FIELD_DATA_LOAD_BATCH_TARGET_BYTES.store(
+        PositiveBytes(bytes, kDefaultFieldDataLoadBatchTargetBytes));
+    LOG_INFO("set field data load batch target bytes: {}",
+             FIELD_DATA_LOAD_BATCH_TARGET_BYTES.load());
+}
+
+void
+SetFieldDataReadWindowBytes(int64_t bytes) {
+    FIELD_DATA_READ_WINDOW_BYTES.store(
+        PositiveBytes(bytes, kDefaultFieldDataReadWindowBytes));
+    LOG_INFO("set field data read window bytes: {}",
+             FIELD_DATA_READ_WINDOW_BYTES.load());
+}
+
+void
+SetFieldDataMaxReadParallelism(int64_t parallelism) {
+    FIELD_DATA_MAX_READ_PARALLELISM.store(std::max<int64_t>(parallelism, 1));
+    LOG_INFO("set field data max read parallelism: {}",
+             FIELD_DATA_MAX_READ_PARALLELISM.load());
+}
 
 namespace {
 
@@ -78,7 +134,77 @@ BatchLoadingBudgetBytes(const std::vector<CellSpec>& cells) {
 int64_t
 BatchReaderMemoryLimit(int64_t batch_memory, int64_t memory_limit) {
     auto capped = std::min(batch_memory, memory_limit);
-    return std::max<int64_t>(capped, FILE_SLICE_SIZE.load());
+    return std::max<int64_t>(capped, FieldDataReadWindowBytes());
+}
+
+uint64_t
+BatchReadParallelism(size_t batch_budget_bytes, int64_t total_rg_count) {
+    if (total_rg_count <= 1) {
+        return 1;
+    }
+
+    auto read_window = std::max<int64_t>(FieldDataReadWindowBytes(), 1);
+    auto budget_capacity =
+        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget()
+            .CapacityBytes();
+    auto bounded_budget = std::min(batch_budget_bytes, budget_capacity);
+    auto parallelism_by_budget =
+        std::max<size_t>(1, bounded_budget / static_cast<size_t>(read_window));
+    auto max_parallelism = FieldDataMaxReadParallelism();
+    auto parallelism = std::min<size_t>(parallelism_by_budget,
+                                        static_cast<size_t>(max_parallelism));
+    return std::min<uint64_t>(static_cast<uint64_t>(parallelism),
+                              static_cast<uint64_t>(total_rg_count));
+}
+
+std::vector<RowGroupBlock>
+SplitContiguousRange(int64_t rg_offset,
+                     int64_t total_rg_count,
+                     uint64_t read_parallelism) {
+    std::vector<RowGroupBlock> blocks;
+    if (total_rg_count <= 0) {
+        return blocks;
+    }
+
+    auto block_count = std::min<int64_t>(
+        total_rg_count,
+        static_cast<int64_t>(std::max<uint64_t>(read_parallelism, 1)));
+    blocks.reserve(block_count);
+    auto avg_block_size = (total_rg_count + block_count - 1) / block_count;
+    int64_t remaining = total_rg_count;
+    int64_t next_offset = rg_offset;
+    while (remaining > 0) {
+        auto count = std::min<int64_t>(avg_block_size, remaining);
+        blocks.push_back({next_offset, count});
+        next_offset += count;
+        remaining -= count;
+    }
+    return blocks;
+}
+
+arrow::Result<std::vector<std::shared_ptr<arrow::Table>>>
+ReadFileRowGroupBlock(const milvus_storage::ArrowFileSystemPtr& fs,
+                      const std::string& file,
+                      int64_t rg_offset,
+                      int64_t rg_count,
+                      int64_t reader_memory_limit) {
+    ARROW_ASSIGN_OR_RAISE(auto reader,
+                          milvus_storage::FileRowGroupReader::Make(
+                              fs,
+                              file,
+                              nullptr,
+                              reader_memory_limit,
+                              milvus::storage::GetReaderProperties()));
+    auto close_guard = folly::makeGuard([&reader]() { (void)reader->Close(); });
+    ARROW_RETURN_NOT_OK(reader->SetRowGroupOffsetAndCount(rg_offset, rg_count));
+    std::vector<std::shared_ptr<arrow::Table>> tables;
+    tables.reserve(rg_count);
+    for (int64_t i = 0; i < rg_count; ++i) {
+        std::shared_ptr<arrow::Table> table;
+        ARROW_RETURN_NOT_OK(reader->ReadNextRowGroup(&table));
+        tables.push_back(std::move(table));
+    }
+    return tables;
 }
 
 }  // namespace
@@ -362,17 +488,31 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
         batches.push_back(std::move(current));
     }
 
-    LOG_INFO(
-        "[StorageV2] LoadCellBatchAsync: {} cells -> {} batches "
-        "(memory_limit={}MB)",
-        cell_specs.size(),
-        batches.size(),
-        memory_limit >> 20);
-
     if (batches.empty()) {
         channel->close();
         return {};
     }
+
+    uint64_t max_read_parallelism = 1;
+    for (const auto& batch : batches) {
+        max_read_parallelism =
+            std::max(max_read_parallelism,
+                     BatchReadParallelism(BatchLoadingBudgetBytes(batch.cells),
+                                          batch.rg_count));
+    }
+
+    LOG_INFO(
+        "[StorageV2] LoadCellBatchAsync: {} cells -> {} batches "
+        "(memory_limit={}MB, budget_capacity={}MB, read_window={}MB, "
+        "max_read_parallelism={})",
+        cell_specs.size(),
+        batches.size(),
+        memory_limit >> 20,
+        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget()
+                .CapacityBytes() >>
+            20,
+        FieldDataReadWindowBytes() >> 20,
+        max_read_parallelism);
 
     auto& pool = ThreadPools::GetThreadPool(milvus::PriorityForLoad(priority));
     auto remaining = std::make_shared<std::atomic<size_t>>(batches.size());
@@ -384,12 +524,17 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
 
     for (auto& batch : batches) {
         auto batch_budget_bytes = BatchLoadingBudgetBytes(batch.cells);
-        auto reader_memory_limit =
-            BatchReaderMemoryLimit(batch.batch_memory, memory_limit);
+        auto read_parallelism =
+            BatchReadParallelism(batch_budget_bytes, batch.rg_count);
+        auto reader_memory_limit = std::max<int64_t>(
+            BatchReaderMemoryLimit(batch.batch_memory, memory_limit) /
+                static_cast<int64_t>(read_parallelism),
+            FieldDataReadWindowBytes());
         futures.emplace_back(pool.Submit([batch = std::move(batch),
                                           shared_factory,
                                           batch_budget_bytes,
                                           reader_memory_limit,
+                                          read_parallelism,
                                           channel,
                                           remaining,
                                           op_ctx]() {
@@ -415,7 +560,8 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
             auto tables_result = (*shared_factory)(batch.file_idx,
                                                    batch.rg_offset,
                                                    batch.rg_count,
-                                                   reader_memory_limit);
+                                                   reader_memory_limit,
+                                                   read_parallelism);
             AssertInfo(tables_result.ok(),
                        "[StorageV2] Failed to read batch: " +
                            tables_result.status().ToString());
@@ -471,28 +617,13 @@ MakeFileReaderFactory(std::vector<std::string> remote_files,
     return [files, fs](size_t batch_key,
                        int64_t rg_offset,
                        int64_t total_rg_count,
-                       int64_t reader_memory_limit)
+                       int64_t reader_memory_limit,
+                       uint64_t read_parallelism)
                -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
-        ARROW_ASSIGN_OR_RAISE(auto reader,
-                              milvus_storage::FileRowGroupReader::Make(
-                                  fs,
-                                  (*files)[batch_key],
-                                  nullptr,
-                                  reader_memory_limit,
-                                  milvus::storage::GetReaderProperties(),
-                                  milvus::storage::GetArrowReaderProperties()));
-        auto close_guard =
-            folly::makeGuard([&reader]() { (void)reader->Close(); });
-        ARROW_RETURN_NOT_OK(
-            reader->SetRowGroupOffsetAndCount(rg_offset, total_rg_count));
-        std::vector<std::shared_ptr<arrow::Table>> tables;
-        tables.reserve(total_rg_count);
-        for (int64_t i = 0; i < total_rg_count; ++i) {
-            std::shared_ptr<arrow::Table> table;
-            ARROW_RETURN_NOT_OK(reader->ReadNextRowGroup(&table));
-            tables.push_back(std::move(table));
-        }
-        return tables;
+        const auto& file = (*files)[batch_key];
+        (void)read_parallelism;
+        return ReadFileRowGroupBlock(
+            fs, file, rg_offset, total_rg_count, reader_memory_limit);
     };
 }
 
@@ -502,13 +633,14 @@ MakeChunkReaderFactory(
     return [chunk_reader](size_t /*batch_key*/,
                           int64_t rg_offset,
                           int64_t total_rg_count,
-                          int64_t /*reader_memory_limit*/)
+                          int64_t /*reader_memory_limit*/,
+                          uint64_t read_parallelism)
                -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
         std::vector<int64_t> rg_indices(total_rg_count);
         std::iota(rg_indices.begin(), rg_indices.end(), rg_offset);
         ARROW_ASSIGN_OR_RAISE(
             auto batches,
-            chunk_reader->get_chunks(rg_indices, /*parallelism=*/1));
+            chunk_reader->get_chunks(rg_indices, read_parallelism));
         std::vector<std::shared_ptr<arrow::Table>> tables;
         tables.reserve(batches.size());
         for (auto& batch : batches) {

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -72,7 +72,7 @@ int64_t
 FieldDataLoadBatchSplitTargetBytes() {
     auto target = FieldDataLoadBatchTargetBytes();
     auto budget_capacity =
-        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget()
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
             .CapacityBytes();
     if (budget_capacity == 0) {
         return target;
@@ -158,9 +158,11 @@ BatchReadParallelism(size_t batch_budget_bytes, int64_t total_rg_count) {
 
     auto read_window = std::max<int64_t>(FieldDataReadWindowBytes(), 1);
     auto budget_capacity =
-        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget()
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
             .CapacityBytes();
-    auto bounded_budget = std::min(batch_budget_bytes, budget_capacity);
+    auto bounded_budget = budget_capacity == 0
+                              ? batch_budget_bytes
+                              : std::min(batch_budget_bytes, budget_capacity);
     auto parallelism_by_budget =
         std::max<size_t>(1, bounded_budget / static_cast<size_t>(read_window));
     auto max_parallelism = FieldDataMaxReadParallelism();
@@ -498,7 +500,7 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
         cell_specs.size(),
         batches.size(),
         memory_limit >> 20,
-        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget()
+        milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
                 .CapacityBytes() >>
             20,
         FieldDataReadWindowBytes() >> 20,
@@ -537,7 +539,7 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
             CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
 
             auto& budget = milvus::storage::TransientMemoryBudget::
-                GetFieldDataLoadBudget();
+                GetLoadTransientBudget();
             auto acquired = budget.AcquireUntil(batch_budget_bytes, [op_ctx]() {
                 return op_ctx &&
                        op_ctx->cancellation_token.isCancellationRequested();
@@ -613,7 +615,7 @@ ReleaseCellLoadResultBudget(
     if (cell_load_result->budget_bytes == 0) {
         return;
     }
-    milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget().Release(
+    milvus::storage::TransientMemoryBudget::GetLoadTransientBudget().Release(
         cell_load_result->budget_bytes);
     cell_load_result->budget_bytes = 0;
 }

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -157,31 +157,6 @@ BatchReadParallelism(size_t batch_budget_bytes, int64_t total_rg_count) {
                               static_cast<uint64_t>(total_rg_count));
 }
 
-std::vector<RowGroupBlock>
-SplitContiguousRange(int64_t rg_offset,
-                     int64_t total_rg_count,
-                     uint64_t read_parallelism) {
-    std::vector<RowGroupBlock> blocks;
-    if (total_rg_count <= 0) {
-        return blocks;
-    }
-
-    auto block_count = std::min<int64_t>(
-        total_rg_count,
-        static_cast<int64_t>(std::max<uint64_t>(read_parallelism, 1)));
-    blocks.reserve(block_count);
-    auto avg_block_size = (total_rg_count + block_count - 1) / block_count;
-    int64_t remaining = total_rg_count;
-    int64_t next_offset = rg_offset;
-    while (remaining > 0) {
-        auto count = std::min<int64_t>(avg_block_size, remaining);
-        blocks.push_back({next_offset, count});
-        next_offset += count;
-        remaining -= count;
-    }
-    return blocks;
-}
-
 arrow::Result<std::vector<std::shared_ptr<arrow::Table>>>
 ReadFileRowGroupBlock(const milvus_storage::ArrowFileSystemPtr& fs,
                       const std::string& file,
@@ -526,10 +501,8 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
         auto batch_budget_bytes = BatchLoadingBudgetBytes(batch.cells);
         auto read_parallelism =
             BatchReadParallelism(batch_budget_bytes, batch.rg_count);
-        auto reader_memory_limit = std::max<int64_t>(
-            BatchReaderMemoryLimit(batch.batch_memory, memory_limit) /
-                static_cast<int64_t>(read_parallelism),
-            FieldDataReadWindowBytes());
+        auto reader_memory_limit =
+            BatchReaderMemoryLimit(batch.batch_memory, memory_limit);
         futures.emplace_back(pool.Submit([batch = std::move(batch),
                                           shared_factory,
                                           batch_budget_bytes,
@@ -618,10 +591,9 @@ MakeFileReaderFactory(std::vector<std::string> remote_files,
                        int64_t rg_offset,
                        int64_t total_rg_count,
                        int64_t reader_memory_limit,
-                       uint64_t read_parallelism)
+                       uint64_t /*read_parallelism*/)
                -> arrow::Result<std::vector<std::shared_ptr<arrow::Table>>> {
         const auto& file = (*files)[batch_key];
-        (void)read_parallelism;
         return ReadFileRowGroupBlock(
             fs, file, rg_offset, total_rg_count, reader_memory_limit);
     };

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -398,7 +398,8 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    BatchReaderFactory reader_factory,
                    std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
-                   milvus::proto::common::LoadPriority priority) {
+                   milvus::proto::common::LoadPriority priority,
+                   CellFinalizeFunc finalize_cell) {
     if (cell_specs.empty()) {
         channel->close();
         return {};
@@ -493,6 +494,8 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
     auto remaining = std::make_shared<std::atomic<size_t>>(batches.size());
     auto shared_factory =
         std::make_shared<BatchReaderFactory>(std::move(reader_factory));
+    auto shared_finalizer =
+        std::make_shared<CellFinalizeFunc>(std::move(finalize_cell));
 
     std::vector<std::future<void>> futures;
     futures.reserve(batches.size());
@@ -510,6 +513,7 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                                           read_parallelism,
                                           channel,
                                           remaining,
+                                          shared_finalizer,
                                           op_ctx]() {
             auto task_guard = folly::makeGuard([&channel, &remaining]() {
                 if (remaining->fetch_sub(1) == 1) {
@@ -551,15 +555,25 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                 CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
                 auto cell_result = std::make_shared<CellLoadResult>();
                 cell_result->cid = cell.cid;
-                cell_result->budget_bytes = CellLoadingBudgetBytes(cell);
+                auto cell_budget_bytes = CellLoadingBudgetBytes(cell);
+                cell_result->budget_bytes = cell_budget_bytes;
                 cell_result->tables.reserve(cell.rg_count);
                 for (int64_t i = 0; i < cell.rg_count; ++i) {
                     cell_result->tables.push_back(
                         std::move(all_tables[table_offset + i]));
                 }
                 table_offset += cell.rg_count;
+                if (*shared_finalizer) {
+                    cell_result->chunk =
+                        (*shared_finalizer)(cell_result->tables, cell.cid);
+                    ReleaseCellLoadResultBudget(cell_result);
+                    transferred_budget_bytes += cell_budget_bytes;
+                    CheckCancellation(op_ctx, -1, "LoadCellBatchAsync");
+                    channel->push(std::move(cell_result));
+                    continue;
+                }
                 channel->push(std::move(cell_result));
-                transferred_budget_bytes += CellLoadingBudgetBytes(cell);
+                transferred_budget_bytes += cell_budget_bytes;
             }
         }));
     }

--- a/internal/core/src/segcore/memory_planner.cpp
+++ b/internal/core/src/segcore/memory_planner.cpp
@@ -69,6 +69,19 @@ FieldDataLoadBatchTargetBytes() {
 }
 
 int64_t
+FieldDataLoadBatchSplitTargetBytes() {
+    auto target = FieldDataLoadBatchTargetBytes();
+    auto budget_capacity =
+        milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget()
+            .CapacityBytes();
+    if (budget_capacity == 0) {
+        return target;
+    }
+    return std::max<int64_t>(
+        1, std::min<int64_t>(target, static_cast<int64_t>(budget_capacity)));
+}
+
+int64_t
 FieldDataReadWindowBytes() {
     return PositiveBytes(FIELD_DATA_READ_WINDOW_BYTES.load(),
                          kDefaultFieldDataReadWindowBytes);

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -105,9 +105,13 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
 // providing backpressure to producer threads while keeping them busy.
 constexpr double kChannelCapacityMultiplier = 1.5;
 
-// Safety margin for loading overhead upper bound estimation.
-// Covers Arrow Table alignment overhead, metadata, and other estimation errors.
-constexpr double kLoadingOverheadInflationRatio = 1.2;
+// StorageV2 field-data loading uses one process-wide transient memory budget,
+// so all field-data translators must share one MCL overhead group.
+constexpr const char* kFieldDataLoadOverheadGroup =
+    "StorageV2FieldDataLoadOverhead";
+
+constexpr int64_t kFieldDataLoadBatchTargetBytes =
+    DEFAULT_FIELD_MAX_MEMORY_LIMIT / 4;
 
 // A cell specification: identifies a cell's location within a specific file.
 struct CellSpec {
@@ -116,11 +120,14 @@ struct CellSpec {
     int64_t local_rg_offset;  // file-local row group start offset
     int64_t rg_count;         // number of row groups in this cell
     int64_t memory_size = 0;  // estimated Arrow memory in bytes; 0 = unknown
+    int64_t loading_overhead_size =
+        0;  // transient overhead budget; 0 = memory_size
 };
 
 // Result of loading a single cell: cid + the arrow tables read.
 struct CellLoadResult {
     int64_t cid;
+    size_t budget_bytes{0};
     std::vector<std::shared_ptr<arrow::Table>> tables;
 };
 
@@ -149,7 +156,8 @@ using BatchReaderFactory =
  * @param cell_specs cell specifications (sorted internally)
  * @param reader_factory factory that reads all row groups for a batch
  * @param channel channel to receive loaded cell data; closed when all done
- * @param memory_limit total memory limit for readers
+ * @param memory_limit batch split target and per-reader upper bound. A global
+ * transient memory budget gates concurrent batch loading across calls.
  * @param priority load priority
  * @return vector of futures for the batch loading tasks
  */
@@ -161,6 +169,10 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    int64_t memory_limit,
                    milvus::proto::common::LoadPriority priority =
                        milvus::proto::common::LoadPriority::HIGH);
+
+void
+ReleaseCellLoadResultBudget(
+    const std::shared_ptr<CellLoadResult>& cell_load_result);
 
 /**
  * Creates a BatchReaderFactory that reads from Parquet files via FileRowGroupReader.

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -106,10 +106,9 @@ LoadWithStrategy(const std::vector<std::string>& remote_files,
 // providing backpressure to producer threads while keeping them busy.
 constexpr double kChannelCapacityMultiplier = 1.5;
 
-// StorageV2 field-data loading uses one process-wide transient memory budget,
-// so all field-data translators must share one MCL overhead group.
-constexpr const char* kFieldDataLoadOverheadGroup =
-    "StorageV2FieldDataLoadOverhead";
+// Load-time readers use one process-wide transient memory budget, so all
+// translators backed by that budget must share one MCL overhead group.
+constexpr const char* kLoadTransientOverheadGroup = "LoadTransientOverhead";
 
 constexpr int64_t kDefaultFieldDataLoadBatchTargetBytes =
     DEFAULT_FIELD_MAX_MEMORY_LIMIT / 4;

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -22,9 +22,11 @@
 #include <functional>
 #include <future>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
+#include "cachinglayer/Utils.h"
 #include "common/Channel.h"
 #include "common/FieldData.h"
 #include "common/GroupChunk.h"
@@ -139,6 +141,11 @@ SetFieldDataReadWindowBytes(int64_t bytes);
 
 void
 SetFieldDataMaxReadParallelism(int64_t parallelism);
+
+milvus::cachinglayer::ResourceUsage
+FieldDataLoadingOverheadUpperBound(
+    int64_t max_memory_overhead,
+    std::optional<int64_t> max_file_overhead = std::nullopt);
 
 // A cell specification: identifies a cell's location within a specific file.
 struct CellSpec {

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -110,8 +110,32 @@ constexpr double kChannelCapacityMultiplier = 1.5;
 constexpr const char* kFieldDataLoadOverheadGroup =
     "StorageV2FieldDataLoadOverhead";
 
-constexpr int64_t kFieldDataLoadBatchTargetBytes =
+constexpr int64_t kDefaultFieldDataLoadBatchTargetBytes =
     DEFAULT_FIELD_MAX_MEMORY_LIMIT / 4;
+
+constexpr int64_t kDefaultFieldDataReadWindowBytes =
+    DEFAULT_INDEX_FILE_SLICE_SIZE;
+
+constexpr int64_t kDefaultFieldDataMaxReadParallelism =
+    DEFAULT_FIELD_MAX_MEMORY_LIMIT / DEFAULT_INDEX_FILE_SLICE_SIZE;
+
+int64_t
+FieldDataLoadBatchTargetBytes();
+
+int64_t
+FieldDataReadWindowBytes();
+
+int64_t
+FieldDataMaxReadParallelism();
+
+void
+SetFieldDataLoadBatchTargetBytes(int64_t bytes);
+
+void
+SetFieldDataReadWindowBytes(int64_t bytes);
+
+void
+SetFieldDataMaxReadParallelism(int64_t parallelism);
 
 // A cell specification: identifies a cell's location within a specific file.
 struct CellSpec {
@@ -138,13 +162,15 @@ using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
 // batch_key: grouping key (file_idx for files, 0 for single reader)
 // rg_offset: start row group index for this batch
 // total_rg_count: total row groups across all cells in this batch
-// reader_memory_limit: memory budget for this batch's reader
+// reader_memory_limit: per-reader window size for this batch
+// read_parallelism: max number of readers/chunks to run within this batch
 using BatchReaderFactory =
     std::function<arrow::Result<std::vector<std::shared_ptr<arrow::Table>>>(
         size_t batch_key,
         int64_t rg_offset,
         int64_t total_rg_count,
-        int64_t reader_memory_limit)>;
+        int64_t reader_memory_limit,
+        uint64_t read_parallelism)>;
 
 /**
  * Load cells in batches using a pluggable reader factory. Cells are sorted by

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -124,6 +124,9 @@ int64_t
 FieldDataLoadBatchTargetBytes();
 
 int64_t
+FieldDataLoadBatchSplitTargetBytes();
+
+int64_t
 FieldDataReadWindowBytes();
 
 int64_t

--- a/internal/core/src/segcore/memory_planner.h
+++ b/internal/core/src/segcore/memory_planner.h
@@ -27,6 +27,7 @@
 
 #include "common/Channel.h"
 #include "common/FieldData.h"
+#include "common/GroupChunk.h"
 #include "common/OpContext.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
@@ -148,11 +149,13 @@ struct CellSpec {
         0;  // transient overhead budget; 0 = memory_size
 };
 
-// Result of loading a single cell: cid + the arrow tables read.
+// Result of loading a single cell: cid + either the loaded Arrow tables or the
+// finalized group chunk when a cell finalizer is provided.
 struct CellLoadResult {
     int64_t cid;
     size_t budget_bytes{0};
     std::vector<std::shared_ptr<arrow::Table>> tables;
+    std::unique_ptr<milvus::GroupChunk> chunk;
 };
 
 using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
@@ -163,7 +166,8 @@ using CellReaderChannel = milvus::Channel<std::shared_ptr<CellLoadResult>>;
 // rg_offset: start row group index for this batch
 // total_rg_count: total row groups across all cells in this batch
 // reader_memory_limit: per-reader window size for this batch
-// read_parallelism: max number of readers/chunks to run within this batch
+// read_parallelism: max number of readers/chunks to run within this batch for
+// factories that support intra-batch parallel reads.
 using BatchReaderFactory =
     std::function<arrow::Result<std::vector<std::shared_ptr<arrow::Table>>>(
         size_t batch_key,
@@ -172,11 +176,15 @@ using BatchReaderFactory =
         int64_t reader_memory_limit,
         uint64_t read_parallelism)>;
 
+using CellFinalizeFunc = std::function<std::unique_ptr<milvus::GroupChunk>(
+    const std::vector<std::shared_ptr<arrow::Table>>& tables, int64_t cid)>;
+
 /**
  * Load cells in batches using a pluggable reader factory. Cells are sorted by
  * (file_idx, local_rg_offset) and grouped into IO-merged batches.
- * Each completed cell is pushed to the channel immediately, enabling
- * streaming consumption without accumulating all ArrowTables.
+ * Each completed cell is pushed to the channel immediately. When finalize_cell
+ * is provided, the batch task converts Arrow tables into the final GroupChunk
+ * before pushing and releases the transient Arrow budget immediately.
  *
  * @param op_ctx operation context for cancellation
  * @param cell_specs cell specifications (sorted internally)
@@ -194,14 +202,17 @@ LoadCellBatchAsync(milvus::OpContext* op_ctx,
                    std::shared_ptr<CellReaderChannel>& channel,
                    int64_t memory_limit,
                    milvus::proto::common::LoadPriority priority =
-                       milvus::proto::common::LoadPriority::HIGH);
+                       milvus::proto::common::LoadPriority::HIGH,
+                   CellFinalizeFunc finalize_cell = nullptr);
 
 void
 ReleaseCellLoadResultBudget(
     const std::shared_ptr<CellLoadResult>& cell_load_result);
 
 /**
- * Creates a BatchReaderFactory that reads from Parquet files via FileRowGroupReader.
+ * Creates a BatchReaderFactory that reads from Parquet files via
+ * FileRowGroupReader. This factory uses one reader for the requested contiguous
+ * row group range and leaves row group internals to the storage/Arrow reader.
  * The returned factory owns a copy of remote_files, so the caller's vector
  * need not outlive the factory.
  */

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -1,7 +1,6 @@
 #include "segcore/storagev1translator/SealedIndexTranslator.h"
 
 #include <filesystem>
-#include <limits>
 #include <utility>
 
 #include "common/EasyAssert.h"
@@ -87,7 +86,7 @@ SealedIndexTranslator::SealedIndexTranslator(
             static_cast<int64_t>(
                 milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
                     .CapacityBytes()),
-            std::numeric_limits<int64_t>::max()};
+            int64_t{0}};
         meta_.loading_overhead = milvus::cachinglayer::LoadingOverheadConfig{
             upper_bound, milvus::segcore::kLoadTransientOverheadGroup};
     }

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -181,7 +181,7 @@ SealedIndexTranslator::get_cells(milvus::OpContext* ctx,
         config_[milvus::index::COLLECTION_ID] =
             file_manager_context_.fieldDataMeta.collection_id;
         LOG_INFO("load V3 scalar index with configs: {}", config_.dump());
-        index->LoadUnified(config_);
+        index->LoadUnified(config_, ctx);
     } else {
         LOG_INFO("load index with configs: {}", config_.dump());
         index->Load(ctx_, config_);

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <utility>
 
+#include "cachinglayer/LoadingOverheadTracker.h"
 #include "common/EasyAssert.h"
 #include "common/common_type_c.h"
 #include "common/resource_c.h"
@@ -82,11 +83,16 @@ SealedIndexTranslator::SealedIndexTranslator(
             config_, milvus::index::SCALAR_INDEX_ENGINE_VERSION)
             .value_or(1);
     if (scalar_version >= 3 && !IsVectorDataType(index_load_info_.field_type)) {
-        auto upper_bound = milvus::cachinglayer::ResourceUsage{
-            static_cast<int64_t>(
-                milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
-                    .CapacityBytes()),
-            int64_t{0}};
+        auto budget_capacity = static_cast<int64_t>(
+            milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
+                .CapacityBytes());
+        auto memory_upper_bound =
+            budget_capacity == 0
+                ? milvus::cachinglayer::LoadingOverheadTracker::kUnlimited
+                      .memory_bytes
+                : budget_capacity;
+        auto upper_bound =
+            milvus::cachinglayer::ResourceUsage{memory_upper_bound, int64_t{0}};
         meta_.loading_overhead = milvus::cachinglayer::LoadingOverheadConfig{
             upper_bound, milvus::segcore::kLoadTransientOverheadGroup};
     }

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -17,6 +17,7 @@
 #include "nlohmann/json.hpp"
 #include "segcore/Types.h"
 #include "segcore/Utils.h"
+#include "segcore/memory_planner.h"
 #include "storage/EntryStreamUtils.h"
 
 namespace milvus::segcore::storagev1translator {
@@ -84,11 +85,11 @@ SealedIndexTranslator::SealedIndexTranslator(
     if (scalar_version >= 3 && !IsVectorDataType(index_load_info_.field_type)) {
         auto upper_bound = milvus::cachinglayer::ResourceUsage{
             static_cast<int64_t>(
-                milvus::storage::TransientMemoryBudget::GetEntryStreamBudget()
+                milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
                     .CapacityBytes()),
             std::numeric_limits<int64_t>::max()};
         meta_.loading_overhead = milvus::cachinglayer::LoadingOverheadConfig{
-            upper_bound, "ScalarIndexV3TransientMemoryBudget"};
+            upper_bound, milvus::segcore::kLoadTransientOverheadGroup};
     }
 }
 

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -219,7 +219,7 @@ GroupChunkTranslator::GroupChunkTranslator(
         int64_t max_cell_sz = *std::max_element(
             meta_.chunk_memory_size_.begin(), meta_.chunk_memory_size_.end());
         auto budget_capacity = static_cast<int64_t>(
-            milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget()
+            milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
                 .CapacityBytes());
         auto max_overhead_size = loading_overhead_bytes(max_cell_sz);
         auto memory_ub = std::max<int64_t>(budget_capacity, max_overhead_size);
@@ -228,9 +228,9 @@ GroupChunkTranslator::GroupChunkTranslator(
                            : int64_t{0};
         auto upper_bound =
             milvus::cachinglayer::ResourceUsage{memory_ub, file_ub};
-        // Keep MCL reservation aligned with the process-wide field data
-        // transient budget rather than multiplying it by translator type.
-        auto group = milvus::segcore::kFieldDataLoadOverheadGroup;
+        // Keep MCL reservation aligned with the process-wide transient load
+        // budget rather than multiplying it by translator type.
+        auto group = milvus::segcore::kLoadTransientOverheadGroup;
         meta_.loading_overhead =
             milvus::cachinglayer::LoadingOverheadConfig{upper_bound, group};
     }

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -50,7 +50,7 @@
 #include "segcore/memory_planner.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "storage/KeyRetriever.h"
-#include "storage/ChunkStreamUtils.h"
+#include "storage/EntryStreamUtils.h"
 #include "storage/ThreadPools.h"
 #include "storage/Util.h"
 
@@ -365,7 +365,7 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
                                             std::move(cell_specs),
                                             std::move(factory),
                                             channel,
-                                            kFieldDataLoadBatchTargetBytes,
+                                            FieldDataLoadBatchTargetBytes(),
                                             load_priority_);
 
     LOG_INFO(

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -23,6 +23,7 @@
 #include <filesystem>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -218,16 +219,10 @@ GroupChunkTranslator::GroupChunkTranslator(
     if (!meta_.chunk_memory_size_.empty()) {
         int64_t max_cell_sz = *std::max_element(
             meta_.chunk_memory_size_.begin(), meta_.chunk_memory_size_.end());
-        auto budget_capacity = static_cast<int64_t>(
-            milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
-                .CapacityBytes());
         auto max_overhead_size = loading_overhead_bytes(max_cell_sz);
-        auto memory_ub = std::max<int64_t>(budget_capacity, max_overhead_size);
-        auto file_ub = use_mmap_
-                           ? std::max<int64_t>(budget_capacity, max_cell_sz)
-                           : int64_t{0};
-        auto upper_bound =
-            milvus::cachinglayer::ResourceUsage{memory_ub, file_ub};
+        auto upper_bound = milvus::segcore::FieldDataLoadingOverheadUpperBound(
+            max_overhead_size,
+            use_mmap_ ? std::optional<int64_t>{max_cell_sz} : std::nullopt);
         // Keep MCL reservation aligned with the process-wide transient load
         // budget rather than multiplying it by translator type.
         auto group = milvus::segcore::kLoadTransientOverheadGroup;

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -360,13 +360,20 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     auto fs = milvus::segcore::GetDefaultArrowFileSystem();
 
     auto factory = milvus::segcore::MakeFileReaderFactory(insert_files_, fs);
+    auto finalize_cell =
+        [this](const std::vector<std::shared_ptr<arrow::Table>>& tables,
+               int64_t cid) {
+            return load_group_chunk(
+                tables, static_cast<milvus::cachinglayer::cid_t>(cid));
+        };
     auto load_futures =
         milvus::segcore::LoadCellBatchAsync(ctx,
                                             std::move(cell_specs),
                                             std::move(factory),
                                             channel,
                                             FieldDataLoadBatchTargetBytes(),
-                                            load_priority_);
+                                            load_priority_,
+                                            std::move(finalize_cell));
 
     LOG_INFO(
         "[StorageV2] translator {} submits {} batch tasks for column group {}",
@@ -374,7 +381,7 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
         load_futures.size(),
         column_group_info_.field_id);
 
-    // Pop loop — convert each cell immediately, no ArrowTable accumulation
+    // Pop loop — batch tasks finalize cells before pushing.
     std::unordered_map<cachinglayer::cid_t, std::unique_ptr<milvus::GroupChunk>>
         completed_cells;
     completed_cells.reserve(cids.size());
@@ -385,8 +392,12 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
             try {
                 CheckCancellation(
                     ctx, segment_id_, "GroupChunkTranslator::get_cells()");
-                completed_cells[cell_data->cid] =
-                    load_group_chunk(cell_data->tables, cell_data->cid);
+                AssertInfo(cell_data->chunk != nullptr,
+                           "[StorageV2] translator {} cell {} is not "
+                           "finalized by batch task",
+                           key_,
+                           cell_data->cid);
+                completed_cells[cell_data->cid] = std::move(cell_data->chunk);
                 milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
             } catch (...) {
                 milvus::segcore::ReleaseCellLoadResultBudget(cell_data);

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <cstdint>
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -49,6 +50,7 @@
 #include "segcore/memory_planner.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "storage/KeyRetriever.h"
+#include "storage/ChunkStreamUtils.h"
 #include "storage/ThreadPools.h"
 #include "storage/Util.h"
 
@@ -95,9 +97,6 @@ GroupChunkTranslator::GroupChunkTranslator(
       column_group_info_(column_group_info),
       insert_files_(std::move(insert_files)),
       row_group_meta_list_(std::move(row_group_meta_list)),
-      use_mmap_(use_mmap),
-      mmap_populate_(mmap_populate),
-      load_priority_(load_priority),
       meta_(num_fields,
             use_mmap ? milvus::cachinglayer::StorageType::DISK
                      : milvus::cachinglayer::StorageType::MEMORY,
@@ -126,7 +125,16 @@ GroupChunkTranslator::GroupChunkTranslator(
                     return false;
                 }(),
                 /* is_index */ false),
-            /* support_eviction */ true) {
+            /* support_eviction */ true),
+      use_mmap_(use_mmap),
+      mmap_populate_(mmap_populate),
+      has_array_field_(std::any_of(field_metas_.begin(),
+                                   field_metas_.end(),
+                                   [](const auto& field) {
+                                       return field.second.get_data_type() ==
+                                              DataType::ARRAY;
+                                   })),
+      load_priority_(load_priority) {
     // Build prefix sum for O(1) lookup in get_cid_from_file_and_row_group_index
     file_row_group_prefix_sum_.reserve(row_group_meta_list_.size() + 1);
     file_row_group_prefix_sum_.push_back(
@@ -206,33 +214,23 @@ GroupChunkTranslator::GroupChunkTranslator(
         num_cells,
         cell_target_size_bytes);
 
-    // Set loading overhead config to cap total overhead reservation.
-    // During get_cells, decoded Arrow Tables exist simultaneously in:
-    //   - pool threads (pool_size): reading batches, pending push
-    //   - bounded channel (pool_size * kChannelCapacityMultiplier): pushed, awaiting pop
-    //   - main thread (1): being converted to GroupChunk
+    // Set loading overhead config to cap total transient memory reservation.
     if (!meta_.chunk_memory_size_.empty()) {
-        // Use THREAD_POOL_MAX_THREADS_SIZE as the upper bound for pool size.
-        // This is the global cap applied to all priority pools.
-        int pool_size = milvus::THREAD_POOL_MAX_THREADS_SIZE.load();
-        if (pool_size <= 0) {
-            pool_size = static_cast<int>(std::round(
-                milvus::CPU_NUM *
-                milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
-        }
-        auto max_inflight = static_cast<int64_t>(
-            pool_size * (1.0 + kChannelCapacityMultiplier) + 1);
         int64_t max_cell_sz = *std::max_element(
             meta_.chunk_memory_size_.begin(), meta_.chunk_memory_size_.end());
-        auto ub = static_cast<int64_t>(max_inflight * max_cell_sz *
-                                       kLoadingOverheadInflationRatio);
-        auto upper_bound = use_mmap_
-                               ? milvus::cachinglayer::ResourceUsage{ub, ub}
-                               : milvus::cachinglayer::ResourceUsage{ub, 0};
-        // Group by CellDataType name so all CacheSlots of the same type
-        // share one overhead upper bound via LoadingOverheadTracker.
-        auto group = fmt::format("GroupChunkTranslator_{}",
-                                 static_cast<int>(meta_.cell_data_type));
+        auto budget_capacity = static_cast<int64_t>(
+            milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget()
+                .CapacityBytes());
+        auto max_overhead_size = loading_overhead_bytes(max_cell_sz);
+        auto memory_ub = std::max<int64_t>(budget_capacity, max_overhead_size);
+        auto file_ub = use_mmap_
+                           ? std::max<int64_t>(budget_capacity, max_cell_sz)
+                           : int64_t{0};
+        auto upper_bound =
+            milvus::cachinglayer::ResourceUsage{memory_ub, file_ub};
+        // Keep MCL reservation aligned with the process-wide field data
+        // transient budget rather than multiplying it by translator type.
+        auto group = milvus::segcore::kFieldDataLoadOverheadGroup;
         meta_.loading_overhead =
             milvus::cachinglayer::LoadingOverheadConfig{upper_bound, group};
     }
@@ -257,14 +255,12 @@ GroupChunkTranslator::estimated_byte_size_of_cell(
     milvus::cachinglayer::cid_t cid) const {
     assert(cid < meta_.chunk_memory_size_.size());
     auto cell_sz = meta_.chunk_memory_size_[cid];
+    auto overhead_sz = loading_overhead_bytes(cell_sz);
 
     if (use_mmap_) {
-        // why double the disk size for loading?
-        // during file writing, the temporary size could be larger than the final size
-        // so we need to reserve more space for the disk size.
-        return {{0, cell_sz}, {2 * cell_sz, 2 * cell_sz}};
+        return {{0, cell_sz}, {overhead_sz, cell_sz}};
     } else {
-        return {{cell_sz, 0}, {2 * cell_sz, 0}};
+        return {{cell_sz, 0}, {overhead_sz, 0}};
     }
 }
 
@@ -346,11 +342,13 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     for (auto cid : cids) {
         auto [rg_start, rg_end] = meta_.get_row_group_range(cid);
         auto [file_idx, local_off] = get_file_and_row_group_offset(rg_start);
-        cell_specs.push_back({cid,
-                              file_idx,
-                              static_cast<int64_t>(local_off),
-                              static_cast<int64_t>(rg_end - rg_start),
-                              meta_.chunk_memory_size_[cid]});
+        cell_specs.push_back(
+            {cid,
+             file_idx,
+             static_cast<int64_t>(local_off),
+             static_cast<int64_t>(rg_end - rg_start),
+             meta_.chunk_memory_size_[cid],
+             loading_overhead_bytes(meta_.chunk_memory_size_[cid])});
     }
 
     // Submit cell-batch loading tasks
@@ -367,7 +365,7 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
                                             std::move(cell_specs),
                                             std::move(factory),
                                             channel,
-                                            DEFAULT_FIELD_MAX_MEMORY_LIMIT,
+                                            kFieldDataLoadBatchTargetBytes,
                                             load_priority_);
 
     LOG_INFO(
@@ -384,10 +382,16 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     try {
         std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
         while (channel->pop(cell_data)) {
-            CheckCancellation(
-                ctx, segment_id_, "GroupChunkTranslator::get_cells()");
-            completed_cells[cell_data->cid] =
-                load_group_chunk(cell_data->tables, cell_data->cid);
+            try {
+                CheckCancellation(
+                    ctx, segment_id_, "GroupChunkTranslator::get_cells()");
+                completed_cells[cell_data->cid] =
+                    load_group_chunk(cell_data->tables, cell_data->cid);
+                milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
+            } catch (...) {
+                milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
+                throw;
+            }
         }
     } catch (...) {
         // Drain the channel to unblock producers that may be stuck on push()
@@ -396,6 +400,7 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
         std::shared_ptr<milvus::segcore::CellLoadResult> discard;
         try {
             while (channel->pop(discard)) {
+                milvus::segcore::ReleaseCellLoadResultBudget(discard);
             }
         } catch (...) {
             LOG_WARN("drain channel exception swallowed");
@@ -535,6 +540,17 @@ GroupChunkTranslator::load_group_chunk(
                                     load_priority_);
     }
     return std::make_unique<milvus::GroupChunk>(chunks);
+}
+
+int64_t
+GroupChunkTranslator::loading_overhead_bytes(int64_t cell_size) const {
+    if (!has_array_field_) {
+        return cell_size;
+    }
+    if (cell_size > std::numeric_limits<int64_t>::max() / 2) {
+        return std::numeric_limits<int64_t>::max();
+    }
+    return cell_size * 2;
 }
 
 }  // namespace milvus::segcore::storagev2translator

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -366,14 +366,14 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
             return load_group_chunk(
                 tables, static_cast<milvus::cachinglayer::cid_t>(cid));
         };
-    auto load_futures =
-        milvus::segcore::LoadCellBatchAsync(ctx,
-                                            std::move(cell_specs),
-                                            std::move(factory),
-                                            channel,
-                                            FieldDataLoadBatchTargetBytes(),
-                                            load_priority_,
-                                            std::move(finalize_cell));
+    auto load_futures = milvus::segcore::LoadCellBatchAsync(
+        ctx,
+        std::move(cell_specs),
+        std::move(factory),
+        channel,
+        FieldDataLoadBatchSplitTargetBytes(),
+        load_priority_,
+        std::move(finalize_cell));
 
     LOG_INFO(
         "[StorageV2] translator {} submits {} batch tasks for column group {}",

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
@@ -97,6 +97,9 @@ class GroupChunkTranslator
     load_group_chunk(const std::vector<std::shared_ptr<arrow::Table>>& tables,
                      const milvus::cachinglayer::cid_t cid);
 
+    int64_t
+    loading_overhead_bytes(int64_t cell_size) const;
+
     int64_t segment_id_;
     GroupChunkType group_chunk_type_{GroupChunkType::DEFAULT};
     std::string key_;
@@ -110,6 +113,7 @@ class GroupChunkTranslator
     GroupCTMeta meta_;
     bool use_mmap_;
     bool mmap_populate_;
+    bool has_array_field_{false};
     milvus::proto::common::LoadPriority load_priority_{
         milvus::proto::common::LoadPriority::HIGH};
 };

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -218,7 +218,7 @@ ManifestGroupTranslator::ManifestGroupTranslator(
         int64_t max_cell_sz = *std::max_element(
             meta_.chunk_memory_size_.begin(), meta_.chunk_memory_size_.end());
         auto budget_capacity = static_cast<int64_t>(
-            milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget()
+            milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
                 .CapacityBytes());
         auto max_overhead_size = loading_overhead_bytes(max_cell_sz);
         auto memory_ub = std::max<int64_t>(budget_capacity, max_overhead_size);
@@ -227,9 +227,9 @@ ManifestGroupTranslator::ManifestGroupTranslator(
                            : int64_t{0};
         auto upper_bound =
             milvus::cachinglayer::ResourceUsage{memory_ub, file_ub};
-        // Keep MCL reservation aligned with the process-wide field data
-        // transient budget rather than multiplying it by translator type.
-        auto group = milvus::segcore::kFieldDataLoadOverheadGroup;
+        // Keep MCL reservation aligned with the process-wide transient load
+        // budget rather than multiplying it by translator type.
+        auto group = milvus::segcore::kLoadTransientOverheadGroup;
         meta_.loading_overhead =
             milvus::cachinglayer::LoadingOverheadConfig{upper_bound, group};
     }

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <exception>
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -50,6 +51,7 @@
 #include "segcore/memory_planner.h"
 #include "storage/ThreadPools.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
+#include "storage/ChunkStreamUtils.h"
 #include "storage/Util.h"
 
 #include <atomic>
@@ -118,6 +120,12 @@ ManifestGroupTranslator::ManifestGroupTranslator(
             /* support_eviction */ true),
       use_mmap_(use_mmap),
       mmap_populate_(mmap_populate),
+      has_array_field_(std::any_of(field_metas_.begin(),
+                                   field_metas_.end(),
+                                   [](const auto& field) {
+                                       return field.second.get_data_type() ==
+                                              DataType::ARRAY;
+                                   })),
       load_priority_(load_priority) {
     auto chunk_size_result = chunk_reader_->get_chunk_size();
     if (!chunk_size_result.ok()) {
@@ -205,29 +213,23 @@ ManifestGroupTranslator::ManifestGroupTranslator(
         num_cells,
         cell_target_size_bytes);
 
-    // Set loading overhead config to cap total overhead reservation.
+    // Set loading overhead config to cap total transient memory reservation.
     if (!meta_.chunk_memory_size_.empty()) {
-        // Use THREAD_POOL_MAX_THREADS_SIZE as the upper bound for pool size.
-        // This is the global cap applied to all priority pools.
-        int pool_size = milvus::THREAD_POOL_MAX_THREADS_SIZE.load();
-        if (pool_size <= 0) {
-            pool_size = static_cast<int>(std::round(
-                milvus::CPU_NUM *
-                milvus::HIGH_PRIORITY_THREAD_CORE_COEFFICIENT.load()));
-        }
-        auto max_inflight = static_cast<int64_t>(
-            pool_size * (1.0 + kChannelCapacityMultiplier) + 1);
         int64_t max_cell_sz = *std::max_element(
             meta_.chunk_memory_size_.begin(), meta_.chunk_memory_size_.end());
-        auto ub = static_cast<int64_t>(max_inflight * max_cell_sz *
-                                       kLoadingOverheadInflationRatio);
-        auto upper_bound = use_mmap_
-                               ? milvus::cachinglayer::ResourceUsage{ub, ub}
-                               : milvus::cachinglayer::ResourceUsage{ub, 0};
-        // Group by CellDataType name so all CacheSlots of the same type
-        // share one overhead upper bound via LoadingOverheadTracker.
-        auto group = fmt::format("ManifestGroupTranslator_{}",
-                                 static_cast<int>(meta_.cell_data_type));
+        auto budget_capacity = static_cast<int64_t>(
+            milvus::storage::TransientMemoryBudget::GetFieldDataLoadBudget()
+                .CapacityBytes());
+        auto max_overhead_size = loading_overhead_bytes(max_cell_sz);
+        auto memory_ub = std::max<int64_t>(budget_capacity, max_overhead_size);
+        auto file_ub = use_mmap_
+                           ? std::max<int64_t>(budget_capacity, max_cell_sz)
+                           : int64_t{0};
+        auto upper_bound =
+            milvus::cachinglayer::ResourceUsage{memory_ub, file_ub};
+        // Keep MCL reservation aligned with the process-wide field data
+        // transient budget rather than multiplying it by translator type.
+        auto group = milvus::segcore::kFieldDataLoadOverheadGroup;
         meta_.loading_overhead =
             milvus::cachinglayer::LoadingOverheadConfig{upper_bound, group};
     }
@@ -249,14 +251,12 @@ ManifestGroupTranslator::estimated_byte_size_of_cell(
     milvus::cachinglayer::cid_t cid) const {
     assert(cid < meta_.chunk_memory_size_.size());
     auto cell_sz = meta_.chunk_memory_size_[cid];
+    auto overhead_sz = loading_overhead_bytes(cell_sz);
 
     if (use_mmap_) {
-        // why double the disk size for loading?
-        // during file writing, the temporary size could be larger than the final size
-        // so we need to reserve more space for the disk size.
-        return {{0, cell_sz}, {2 * cell_sz, 2 * cell_sz}};
+        return {{0, cell_sz}, {overhead_sz, cell_sz}};
     } else {
-        return {{cell_sz, 0}, {2 * cell_sz, 0}};
+        return {{cell_sz, 0}, {overhead_sz, 0}};
     }
 }
 
@@ -293,11 +293,13 @@ ManifestGroupTranslator::get_cells(
     cell_specs.reserve(cids.size());
     for (auto cid : cids) {
         auto [start, end] = meta_.get_row_group_range(cid);
-        cell_specs.push_back({cid,
-                              /*file_idx=*/0,
-                              static_cast<int64_t>(start),
-                              static_cast<int64_t>(end - start),
-                              meta_.chunk_memory_size_[cid]});
+        cell_specs.push_back(
+            {cid,
+             /*file_idx=*/0,
+             static_cast<int64_t>(start),
+             static_cast<int64_t>(end - start),
+             meta_.chunk_memory_size_[cid],
+             loading_overhead_bytes(meta_.chunk_memory_size_[cid])});
     }
 
     // Create factory using ChunkReader — reads a batch of row groups at once
@@ -315,7 +317,7 @@ ManifestGroupTranslator::get_cells(
                                             std::move(cell_specs),
                                             std::move(factory),
                                             channel,
-                                            DEFAULT_FIELD_MAX_MEMORY_LIMIT,
+                                            kFieldDataLoadBatchTargetBytes,
                                             load_priority_);
 
     LOG_INFO(
@@ -334,10 +336,16 @@ ManifestGroupTranslator::get_cells(
     try {
         std::shared_ptr<milvus::segcore::CellLoadResult> cell_data;
         while (channel->pop(cell_data)) {
-            CheckCancellation(
-                ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
-            completed_cells[cell_data->cid] =
-                load_group_chunk(cell_data->tables, cell_data->cid);
+            try {
+                CheckCancellation(
+                    ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
+                completed_cells[cell_data->cid] =
+                    load_group_chunk(cell_data->tables, cell_data->cid);
+                milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
+            } catch (...) {
+                milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
+                throw;
+            }
         }
     } catch (...) {
         // Drain the channel to unblock producers that may be stuck on push()
@@ -346,6 +354,7 @@ ManifestGroupTranslator::get_cells(
         std::shared_ptr<milvus::segcore::CellLoadResult> discard;
         try {
             while (channel->pop(discard)) {
+                milvus::segcore::ReleaseCellLoadResultBudget(discard);
             }
         } catch (...) {
             LOG_WARN("drain channel exception swallowed");
@@ -511,6 +520,17 @@ ManifestGroupTranslator::load_group_chunk(
     }
 
     return std::make_unique<milvus::GroupChunk>(chunks);
+}
+
+int64_t
+ManifestGroupTranslator::loading_overhead_bytes(int64_t cell_size) const {
+    if (!has_array_field_) {
+        return cell_size;
+    }
+    if (cell_size > std::numeric_limits<int64_t>::max() / 2) {
+        return std::numeric_limits<int64_t>::max();
+    }
+    return cell_size * 2;
 }
 
 }  // namespace milvus::segcore::storagev2translator

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -312,13 +312,18 @@ ManifestGroupTranslator::get_cells(
         static_cast<size_t>(pool.GetMaxThreadNum() *
                             milvus::segcore::kChannelCapacityMultiplier));
 
-    auto load_futures =
-        milvus::segcore::LoadCellBatchAsync(ctx,
-                                            std::move(cell_specs),
-                                            std::move(factory),
-                                            channel,
-                                            FieldDataLoadBatchTargetBytes(),
-                                            load_priority_);
+    auto load_futures = milvus::segcore::LoadCellBatchAsync(
+        ctx,
+        std::move(cell_specs),
+        std::move(factory),
+        channel,
+        FieldDataLoadBatchTargetBytes(),
+        load_priority_,
+        [this](const std::vector<std::shared_ptr<arrow::Table>>& tables,
+               int64_t cid) {
+            return load_group_chunk(
+                tables, static_cast<milvus::cachinglayer::cid_t>(cid));
+        });
 
     LOG_INFO(
         "[StorageV2] translator {} submits {} batch tasks for manifest "
@@ -327,7 +332,7 @@ ManifestGroupTranslator::get_cells(
         load_futures.size(),
         column_group_index_);
 
-    // Pop loop — convert each cell immediately, no ArrowTable accumulation
+    // Pop loop — batch tasks finalize cells before pushing.
     std::unordered_map<milvus::cachinglayer::cid_t,
                        std::unique_ptr<milvus::GroupChunk>>
         completed_cells;
@@ -339,8 +344,12 @@ ManifestGroupTranslator::get_cells(
             try {
                 CheckCancellation(
                     ctx, segment_id_, "ManifestGroupTranslator::get_cells()");
-                completed_cells[cell_data->cid] =
-                    load_group_chunk(cell_data->tables, cell_data->cid);
+                AssertInfo(cell_data->chunk != nullptr,
+                           "[StorageV2] translator {} cell {} is not "
+                           "finalized by batch task",
+                           key_,
+                           cell_data->cid);
+                completed_cells[cell_data->cid] = std::move(cell_data->chunk);
                 milvus::segcore::ReleaseCellLoadResultBudget(cell_data);
             } catch (...) {
                 milvus::segcore::ReleaseCellLoadResultBudget(cell_data);

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -317,7 +317,7 @@ ManifestGroupTranslator::get_cells(
         std::move(cell_specs),
         std::move(factory),
         channel,
-        FieldDataLoadBatchTargetBytes(),
+        FieldDataLoadBatchSplitTargetBytes(),
         load_priority_,
         [this](const std::vector<std::shared_ptr<arrow::Table>>& tables,
                int64_t cid) {

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -51,7 +51,7 @@
 #include "segcore/memory_planner.h"
 #include "storage/ThreadPools.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
-#include "storage/ChunkStreamUtils.h"
+#include "storage/EntryStreamUtils.h"
 #include "storage/Util.h"
 
 #include <atomic>
@@ -317,7 +317,7 @@ ManifestGroupTranslator::get_cells(
                                             std::move(cell_specs),
                                             std::move(factory),
                                             channel,
-                                            kFieldDataLoadBatchTargetBytes,
+                                            FieldDataLoadBatchTargetBytes(),
                                             load_priority_);
 
     LOG_INFO(

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.cpp
@@ -217,16 +217,10 @@ ManifestGroupTranslator::ManifestGroupTranslator(
     if (!meta_.chunk_memory_size_.empty()) {
         int64_t max_cell_sz = *std::max_element(
             meta_.chunk_memory_size_.begin(), meta_.chunk_memory_size_.end());
-        auto budget_capacity = static_cast<int64_t>(
-            milvus::storage::TransientMemoryBudget::GetLoadTransientBudget()
-                .CapacityBytes());
         auto max_overhead_size = loading_overhead_bytes(max_cell_sz);
-        auto memory_ub = std::max<int64_t>(budget_capacity, max_overhead_size);
-        auto file_ub = use_mmap_
-                           ? std::max<int64_t>(budget_capacity, max_cell_sz)
-                           : int64_t{0};
-        auto upper_bound =
-            milvus::cachinglayer::ResourceUsage{memory_ub, file_ub};
+        auto upper_bound = milvus::segcore::FieldDataLoadingOverheadUpperBound(
+            max_overhead_size,
+            use_mmap_ ? std::optional<int64_t>{max_cell_sz} : std::nullopt);
         // Keep MCL reservation aligned with the process-wide transient load
         // budget rather than multiplying it by translator type.
         auto group = milvus::segcore::kLoadTransientOverheadGroup;

--- a/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/ManifestGroupTranslator.h
@@ -184,6 +184,9 @@ class ManifestGroupTranslator
     load_group_chunk(const std::vector<std::shared_ptr<arrow::Table>>& tables,
                      milvus::cachinglayer::cid_t cid);
 
+    int64_t
+    loading_overhead_bytes(int64_t cell_size) const;
+
     int64_t segment_id_;
     GroupChunkType group_chunk_type_;
     int64_t column_group_index_;
@@ -194,6 +197,7 @@ class ManifestGroupTranslator
     GroupCTMeta meta_;
     bool use_mmap_;
     bool mmap_populate_;
+    bool has_array_field_{false};
     std::string mmap_dir_path_;
     milvus::proto::common::LoadPriority load_priority_{
         milvus::proto::common::LoadPriority::HIGH};

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -136,6 +136,11 @@ class TransientMemoryBudget {
         cv_.notify_all();
     }
 
+    void
+    NotifyCapacityUpdated() {
+        cv_.notify_all();
+    }
+
  private:
     TransientMemoryBudget() = default;
 

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -67,25 +67,14 @@ struct StreamSliceResult {
 class TransientMemoryBudget {
  public:
     static TransientMemoryBudget&
-    GetEntryStreamBudget() {
+    GetLoadTransientBudget() {
         static TransientMemoryBudget instance;
         return instance;
     }
 
-    static TransientMemoryBudget&
-    GetFieldDataLoadBudget() {
-        static TransientMemoryBudget instance(DEFAULT_FIELD_MAX_MEMORY_LIMIT);
-        return instance;
-    }
-
     static void
-    SetEntryStreamBudgetBytes(size_t bytes) {
-        GetEntryStreamBudget().SetCapacityBytes(bytes);
-    }
-
-    static void
-    SetFieldDataLoadBudgetBytes(size_t bytes) {
-        GetFieldDataLoadBudget().SetCapacityBytes(bytes);
+    SetLoadTransientBudgetBytes(size_t bytes) {
+        GetLoadTransientBudget().SetCapacityBytes(bytes);
     }
 
     /// Block until enough budget is available. Safe to call when the calling
@@ -196,7 +185,7 @@ class TransientMemoryBudget {
 inline size_t
 EntryStreamMaxTransientBytes() {
     auto capacity =
-        TransientMemoryBudget::GetEntryStreamBudget().CapacityBytes();
+        TransientMemoryBudget::GetLoadTransientBudget().CapacityBytes();
     if (capacity == 0) {
         return std::numeric_limits<size_t>::max();
     }

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -64,6 +65,8 @@ struct StreamSliceResult {
 ///
 /// Usage:
 ///   - Call Acquire(bytes) to block until budget is available.
+///   - Call AcquireUntil(bytes, stop_waiting) to block until budget is
+///     available or the caller's lifecycle ends.
 ///   - Call TryAcquire(bytes) for non-blocking replenish in refill loops.
 ///   - Call Release(bytes) after the transient data has been consumed.
 ///   - Oversized requests are allowed to run exclusively to guarantee progress.
@@ -93,6 +96,25 @@ class TransientMemoryBudget {
         std::unique_lock<std::mutex> lock(mu_);
         cv_.wait(lock, [this, bytes] { return CanAcquireLocked(bytes); });
         inflight_bytes_ += bytes;
+    }
+
+    /// Block until enough budget is available, or stop_waiting returns true.
+    /// The callback must be cheap and non-blocking. Returning false means no
+    /// budget was acquired and the caller should stop its work.
+    template <typename StopWaiting>
+    bool
+    AcquireUntil(size_t bytes, StopWaiting stop_waiting) {
+        std::unique_lock<std::mutex> lock(mu_);
+        while (true) {
+            if (stop_waiting()) {
+                return false;
+            }
+            if (CanAcquireLocked(bytes)) {
+                inflight_bytes_ += bytes;
+                return true;
+            }
+            cv_.wait_for(lock, std::chrono::milliseconds(10));
+        }
     }
 
     /// Try to claim budget. Returns true if under budget.

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -25,10 +25,12 @@
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <vector>
 
 #include "common/Common.h"
 #include "common/EasyAssert.h"
+#include "folly/CancellationToken.h"
 
 namespace milvus::storage {
 
@@ -44,6 +46,14 @@ IsStreamSliceSizeAligned(size_t slice_size) {
 inline size_t
 DefaultStreamSliceSize() {
     return DEFAULT_INDEX_FILE_SLICE_SIZE;
+}
+
+inline void
+ThrowIfCancelled(const folly::CancellationToken& cancellation_token,
+                 const std::string& operation) {
+    if (cancellation_token.isCancellationRequested()) {
+        ThrowInfo(ErrorCode::FollyCancel, "{} cancelled", operation);
+    }
 }
 
 /// A slice read from a V3 entry. `error` carries an exception captured in

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -75,6 +75,12 @@ class TransientMemoryBudget {
         return instance;
     }
 
+    static TransientMemoryBudget&
+    GetFieldDataLoadBudget() {
+        static TransientMemoryBudget instance(DEFAULT_FIELD_MAX_MEMORY_LIMIT);
+        return instance;
+    }
+
     /// Block until enough budget is available. Safe to call when the calling
     /// thread has no inflight tasks (no risk of deadlock with channel pop).
     void
@@ -112,6 +118,9 @@ class TransientMemoryBudget {
 
     size_t
     CapacityBytes() const {
+        if (fixed_capacity_bytes_ > 0) {
+            return fixed_capacity_bytes_;
+        }
         return EntryStreamBudgetBytes();
     }
 
@@ -122,6 +131,10 @@ class TransientMemoryBudget {
 
  private:
     TransientMemoryBudget() = default;
+
+    explicit TransientMemoryBudget(size_t fixed_capacity_bytes)
+        : fixed_capacity_bytes_(std::max<size_t>(fixed_capacity_bytes, 1)) {
+    }
 
     static size_t
     EntryStreamBudgetBytes() {
@@ -144,6 +157,7 @@ class TransientMemoryBudget {
     std::mutex mu_;
     std::condition_variable cv_;
     size_t inflight_bytes_{0};
+    size_t fixed_capacity_bytes_{0};
 };
 
 inline size_t

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -46,12 +46,6 @@ DefaultStreamSliceSize() {
     return DEFAULT_INDEX_FILE_SLICE_SIZE;
 }
 
-inline double
-StreamBudgetRatio() {
-    auto ratio = milvus::ENTRY_STREAM_BUDGET_RATIO.load();
-    return ratio > 0 ? ratio : 1.0;
-}
-
 /// A slice read from a V3 entry. `error` carries an exception captured in
 /// the producer task so the consumer can rethrow instead of hanging.
 struct StreamSliceResult {
@@ -61,7 +55,7 @@ struct StreamSliceResult {
 };
 
 /// Byte budget for transient data that has been submitted for async work but
-/// has not been consumed yet.
+/// has not been consumed yet. Capacity 0 means unlimited.
 ///
 /// Usage:
 ///   - Call Acquire(bytes) to block until budget is available.
@@ -82,6 +76,11 @@ class TransientMemoryBudget {
     GetFieldDataLoadBudget() {
         static TransientMemoryBudget instance(DEFAULT_FIELD_MAX_MEMORY_LIMIT);
         return instance;
+    }
+
+    static void
+    SetEntryStreamBudgetBytes(size_t bytes) {
+        GetEntryStreamBudget().SetCapacityBytes(bytes);
     }
 
     static void
@@ -153,7 +152,7 @@ class TransientMemoryBudget {
     SetCapacityBytes(size_t bytes) {
         {
             std::lock_guard<std::mutex> lock(mu_);
-            capacity_bytes_ = std::max<size_t>(bytes, 1);
+            capacity_bytes_ = bytes;
         }
         cv_.notify_all();
     }
@@ -167,28 +166,20 @@ class TransientMemoryBudget {
     TransientMemoryBudget() = default;
 
     explicit TransientMemoryBudget(size_t capacity_bytes)
-        : capacity_bytes_(std::max<size_t>(capacity_bytes, 1)) {
-    }
-
-    static size_t
-    EntryStreamBudgetBytes() {
-        auto core_num = std::max(1, milvus::CPU_NUM);
-        auto capacity = static_cast<size_t>(core_num * StreamBudgetRatio()) *
-                        DefaultStreamSliceSize();
-        return std::max<size_t>(capacity, DefaultStreamSliceSize());
+        : capacity_bytes_(capacity_bytes) {
     }
 
     size_t
     CapacityBytesLocked() const {
-        if (capacity_bytes_ > 0) {
-            return capacity_bytes_;
-        }
-        return EntryStreamBudgetBytes();
+        return capacity_bytes_;
     }
 
     bool
     CanAcquireLocked(size_t bytes) const {
         auto capacity_bytes = CapacityBytesLocked();
+        if (capacity_bytes == 0) {
+            return true;
+        }
         if (bytes > capacity_bytes) {
             return inflight_bytes_ == 0;
         }
@@ -206,6 +197,9 @@ inline size_t
 EntryStreamMaxTransientBytes() {
     auto capacity =
         TransientMemoryBudget::GetEntryStreamBudget().CapacityBytes();
+    if (capacity == 0) {
+        return std::numeric_limits<size_t>::max();
+    }
     if (capacity > std::numeric_limits<size_t>::max() - kTailMergeGrace) {
         return std::numeric_limits<size_t>::max();
     }

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -81,6 +81,11 @@ class TransientMemoryBudget {
         return instance;
     }
 
+    static void
+    SetFieldDataLoadBudgetBytes(size_t bytes) {
+        GetFieldDataLoadBudget().SetCapacityBytes(bytes);
+    }
+
     /// Block until enough budget is available. Safe to call when the calling
     /// thread has no inflight tasks (no risk of deadlock with channel pop).
     void
@@ -118,22 +123,24 @@ class TransientMemoryBudget {
 
     size_t
     CapacityBytes() const {
-        if (fixed_capacity_bytes_ > 0) {
-            return fixed_capacity_bytes_;
-        }
-        return EntryStreamBudgetBytes();
+        std::lock_guard<std::mutex> lock(mu_);
+        return CapacityBytesLocked();
     }
 
     void
-    NotifyCapacityUpdated() {
+    SetCapacityBytes(size_t bytes) {
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            capacity_bytes_ = std::max<size_t>(bytes, 1);
+        }
         cv_.notify_all();
     }
 
  private:
     TransientMemoryBudget() = default;
 
-    explicit TransientMemoryBudget(size_t fixed_capacity_bytes)
-        : fixed_capacity_bytes_(std::max<size_t>(fixed_capacity_bytes, 1)) {
+    explicit TransientMemoryBudget(size_t capacity_bytes)
+        : capacity_bytes_(std::max<size_t>(capacity_bytes, 1)) {
     }
 
     static size_t
@@ -144,9 +151,17 @@ class TransientMemoryBudget {
         return std::max<size_t>(capacity, DefaultStreamSliceSize());
     }
 
+    size_t
+    CapacityBytesLocked() const {
+        if (capacity_bytes_ > 0) {
+            return capacity_bytes_;
+        }
+        return EntryStreamBudgetBytes();
+    }
+
     bool
     CanAcquireLocked(size_t bytes) const {
-        auto capacity_bytes = CapacityBytes();
+        auto capacity_bytes = CapacityBytesLocked();
         if (bytes > capacity_bytes) {
             return inflight_bytes_ == 0;
         }
@@ -154,10 +169,10 @@ class TransientMemoryBudget {
                bytes <= capacity_bytes - inflight_bytes_;
     }
 
-    std::mutex mu_;
+    mutable std::mutex mu_;
     std::condition_variable cv_;
     size_t inflight_bytes_{0};
-    size_t fixed_capacity_bytes_{0};
+    size_t capacity_bytes_{0};
 };
 
 inline size_t

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -45,6 +45,14 @@ namespace {
 using SliceLoader = std::function<std::vector<uint8_t>(size_t seq)>;
 using SliceBudgetBytes = std::function<size_t(size_t seq)>;
 
+void
+ThrowIfCancelled(const folly::CancellationToken& cancellation_token,
+                 const std::string& operation) {
+    if (cancellation_token.isCancellationRequested()) {
+        ThrowInfo(ErrorCode::FollyCancel, "{} cancelled", operation);
+    }
+}
+
 struct ActiveSliceTask {
     size_t budget_bytes{0};
     std::shared_ptr<StreamSliceResult> result;
@@ -53,8 +61,20 @@ struct ActiveSliceTask {
 
 class TransientBudgetGuard {
  public:
-    explicit TransientBudgetGuard(size_t bytes) : bytes_(bytes) {
-        TransientMemoryBudget::GetEntryStreamBudget().Acquire(bytes_);
+    TransientBudgetGuard(size_t bytes,
+                         const folly::CancellationToken& cancellation_token,
+                         const std::string& operation)
+        : bytes_(bytes) {
+        ThrowIfCancelled(cancellation_token, operation);
+        auto acquired =
+            TransientMemoryBudget::GetEntryStreamBudget().AcquireUntil(
+                bytes_, [&cancellation_token]() {
+                    return cancellation_token.isCancellationRequested();
+                });
+        if (!acquired) {
+            ThrowIfCancelled(cancellation_token, operation);
+            ThrowInfo(ErrorCode::FollyCancel, "{} cancelled", operation);
+        }
     }
 
     ~TransientBudgetGuard() {
@@ -132,9 +152,11 @@ ReadOrderedEntryStream(
     uint32_t expected_crc,
     const std::string& crc_error_context,
     ThreadPoolPriority priority,
+    const folly::CancellationToken& cancellation_token,
     const std::function<void(const uint8_t* data, size_t len)>& slice_consumer,
     const SliceBudgetBytes& slice_budget_bytes,
     const SliceLoader& load_slice) {
+    ThrowIfCancelled(cancellation_token, "ReadEntryStream");
     if (num_slices == 0) {
         auto actual_crc = Crc32cValue(nullptr, 0);
         AssertInfo(actual_crc == expected_crc,
@@ -159,6 +181,16 @@ ReadOrderedEntryStream(
     auto rememberError = [&](std::exception_ptr error) {
         if (!first_error) {
             first_error = std::move(error);
+        }
+    };
+
+    auto rememberCancellation = [&]() {
+        try {
+            ThrowIfCancelled(cancellation_token, "ReadEntryStream");
+            return false;
+        } catch (...) {
+            rememberError(std::current_exception());
+            return true;
         }
     };
 
@@ -191,8 +223,20 @@ ReadOrderedEntryStream(
         }
 
         if (block_for_budget) {
-            budget.Acquire(budget_bytes);
+            auto acquired =
+                budget.AcquireUntil(budget_bytes, [&cancellation_token]() {
+                    return cancellation_token.isCancellationRequested();
+                });
+            if (!acquired) {
+                rememberCancellation();
+                return false;
+            }
         } else if (!budget.TryAcquire(budget_bytes)) {
+            return false;
+        }
+
+        if (rememberCancellation()) {
+            budget.Release(budget_bytes);
             return false;
         }
 
@@ -200,9 +244,11 @@ ReadOrderedEntryStream(
             active_tasks.push_back(
                 ActiveSliceTask{budget_bytes, result, std::future<void>()});
             active_tasks.back().future =
-                pool.Submit([result, load_slice, seq]() {
+                pool.Submit([result, load_slice, seq, cancellation_token]() {
                     try {
+                        ThrowIfCancelled(cancellation_token, "ReadEntryStream");
                         result->data = load_slice(seq);
+                        ThrowIfCancelled(cancellation_token, "ReadEntryStream");
                     } catch (...) {
                         result->error = std::current_exception();
                     }
@@ -233,6 +279,7 @@ ReadOrderedEntryStream(
 
     auto deliverSlice = [&](const std::shared_ptr<StreamSliceResult>& c) {
         try {
+            ThrowIfCancelled(cancellation_token, "ReadEntryStream");
             uint32_t slice_crc = Crc32cValue(c->data.data(), c->data.size());
             running_crc =
                 first ? slice_crc
@@ -296,14 +343,18 @@ std::unique_ptr<IndexEntryReader>
 IndexEntryReader::Open(std::shared_ptr<milvus::InputStream> input,
                        int64_t file_size,
                        int64_t collection_id,
-                       ThreadPoolPriority priority) {
+                       ThreadPoolPriority priority,
+                       folly::CancellationToken cancellation_token) {
     auto reader = std::unique_ptr<IndexEntryReader>(new IndexEntryReader());
     reader->input_ = std::move(input);
     reader->file_size_ = file_size;
     reader->collection_id_ = collection_id;
     reader->priority_ = priority;
+    reader->cancellation_token_ = cancellation_token;
+    reader->CheckCancelled("IndexEntryReader::Open");
     reader->ValidateMagic();
     reader->ReadFooterAndDirectory();
+    reader->CheckCancelled("IndexEntryReader::Open");
 
     // Parse __meta__ entry
     auto meta_entry = reader->ReadEntry(MILVUS_V3_META_ENTRY_NAME);
@@ -321,9 +372,16 @@ IndexEntryReader::Open(std::shared_ptr<milvus::InputStream> input,
 }
 
 void
+IndexEntryReader::CheckCancelled(const std::string& operation) const {
+    ThrowIfCancelled(cancellation_token_, operation);
+}
+
+void
 IndexEntryReader::ValidateMagic() {
+    CheckCancelled("IndexEntryReader::ValidateMagic");
     char magic_buf[MILVUS_V3_MAGIC_SIZE];
     size_t bytes_read = input_->ReadAt(magic_buf, 0, MILVUS_V3_MAGIC_SIZE);
+    CheckCancelled("IndexEntryReader::ValidateMagic");
     AssertInfo(bytes_read == MILVUS_V3_MAGIC_SIZE,
                "Failed to read V3 magic number");
     AssertInfo(
@@ -333,6 +391,7 @@ IndexEntryReader::ValidateMagic() {
 
 void
 IndexEntryReader::ReadFooterAndDirectory() {
+    CheckCancelled("IndexEntryReader::ReadFooterAndDirectory");
     constexpr size_t kTailBufferSize = 64 * 1024UL;
     size_t tail_size =
         std::min(static_cast<size_t>(file_size_), kTailBufferSize);
@@ -341,6 +400,7 @@ IndexEntryReader::ReadFooterAndDirectory() {
     std::vector<uint8_t> tail_data(tail_size);
     size_t bytes_read =
         input_->ReadAt(tail_data.data(), tail_offset, tail_size);
+    CheckCancelled("IndexEntryReader::ReadFooterAndDirectory");
     AssertInfo(bytes_read == tail_size, "Failed to read file tail");
 
     // Parse 32-byte Footer from the last 32 bytes
@@ -382,6 +442,7 @@ IndexEntryReader::ReadFooterAndDirectory() {
 
         size_t additional_read =
             input_->ReadAt(full_tail_data.data(), new_tail_offset, need_more);
+        CheckCancelled("IndexEntryReader::ReadFooterAndDirectory");
         AssertInfo(additional_read == need_more,
                    "Failed to read additional directory data");
 
@@ -471,6 +532,7 @@ IndexEntryReader::VerifyCrc32c(uint32_t expected,
 
 Entry
 IndexEntryReader::ReadEntry(const std::string& name) {
+    CheckCancelled("IndexEntryReader::ReadEntry");
     auto cache_it = small_entry_cache_.find(name);
     if (cache_it != small_entry_cache_.end()) {
         return cache_it->second;
@@ -496,6 +558,7 @@ IndexEntryReader::ReadEntry(const std::string& name) {
 
 Entry
 IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
+    CheckCancelled("IndexEntryReader::ReadPlainEntry");
     const auto& pm = meta.plain;
     Entry result;
     result.data.resize(pm.size);
@@ -505,12 +568,14 @@ IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
     if (pm.size <= kRangeSize) {
         size_t n = input_->ReadAt(
             result.data.data(), MILVUS_V3_MAGIC_SIZE + pm.offset, pm.size);
+        CheckCancelled("IndexEntryReader::ReadPlainEntry");
         AssertInfo(n == pm.size, "Failed to read entry data");
         VerifyCrc32c(pm.crc32, result.data.data(), pm.size, "");
         return result;
     }
 
     auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto cancellation_token = cancellation_token_;
     uint8_t* dest = result.data.data();
 
     std::vector<std::future<void>> futures;
@@ -521,21 +586,29 @@ IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
         size_t len = std::min(remaining, kRangeSize);
         size_t this_offset = offset;
 
-        futures.push_back(pool.Submit([this, dest, this_offset, len, &pm]() {
-            size_t n =
-                input_->ReadAt(dest + this_offset,
-                               MILVUS_V3_MAGIC_SIZE + pm.offset + this_offset,
-                               len);
-            AssertInfo(n == len, "Failed to read entry data range");
-        }));
+        futures.push_back(pool.Submit(
+            [this, dest, this_offset, len, &pm, cancellation_token]() {
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadPlainEntry");
+                size_t n = input_->ReadAt(
+                    dest + this_offset,
+                    MILVUS_V3_MAGIC_SIZE + pm.offset + this_offset,
+                    len);
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadPlainEntry");
+                AssertInfo(n == len, "Failed to read entry data range");
+            }));
 
         remaining -= len;
         offset += len;
     }
 
-    for (auto& f : futures) {
-        f.get();
+    std::exception_ptr first_error = nullptr;
+    DrainFutures(futures, first_error);
+    if (first_error) {
+        std::rethrow_exception(first_error);
     }
+    CheckCancelled("IndexEntryReader::ReadPlainEntry");
 
     // CRC verification: sequential pass over the assembled buffer
     VerifyCrc32c(pm.crc32, result.data.data(), pm.size, "");
@@ -545,11 +618,13 @@ IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
 
 Entry
 IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
+    CheckCancelled("IndexEntryReader::ReadEncryptedEntry");
     const auto& em = meta.enc;
     Entry result;
     result.data.resize(em.original_size);
 
     auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto cancellation_token = cancellation_token_;
     uint8_t* dest = result.data.data();
 
     std::vector<std::future<void>> futures;
@@ -561,30 +636,40 @@ IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
         size_t plain_len = std::min(remaining, slice_size_);
         cur_output_offset += plain_len;
 
-        futures.push_back(
-            pool.Submit([this, slice, dest, this_output_offset, plain_len]() {
-                std::vector<uint8_t> cipher(slice.size);
-                size_t n = input_->ReadAt(cipher.data(),
-                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
-                                          slice.size);
-                AssertInfo(n == slice.size, "Failed to read encrypted slice");
+        futures.push_back(pool.Submit([this,
+                                       slice,
+                                       dest,
+                                       this_output_offset,
+                                       plain_len,
+                                       cancellation_token]() {
+            ThrowIfCancelled(cancellation_token,
+                             "IndexEntryReader::ReadEncryptedEntry");
+            std::vector<uint8_t> cipher(slice.size);
+            size_t n = input_->ReadAt(
+                cipher.data(), MILVUS_V3_MAGIC_SIZE + slice.offset, slice.size);
+            ThrowIfCancelled(cancellation_token,
+                             "IndexEntryReader::ReadEncryptedEntry");
+            AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
-                auto dec =
-                    cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
-                auto plain = dec->Decrypt(cipher.data(), cipher.size());
+            auto dec =
+                cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
+            auto plain = dec->Decrypt(cipher.data(), cipher.size());
 
-                AssertInfo(plain.size() == plain_len,
-                           "Decrypted size mismatch: expected {}, got {}",
-                           plain_len,
-                           plain.size());
-                milvus::fastmem::FastMemcpy(
-                    dest + this_output_offset, plain.data(), plain.size());
-            }));
+            AssertInfo(plain.size() == plain_len,
+                       "Decrypted size mismatch: expected {}, got {}",
+                       plain_len,
+                       plain.size());
+            milvus::fastmem::FastMemcpy(
+                dest + this_output_offset, plain.data(), plain.size());
+        }));
     }
 
-    for (auto& f : futures) {
-        f.get();
+    std::exception_ptr first_error = nullptr;
+    DrainFutures(futures, first_error);
+    if (first_error) {
+        std::rethrow_exception(first_error);
     }
+    CheckCancelled("IndexEntryReader::ReadEncryptedEntry");
 
     // CRC verification over full plaintext buffer
     VerifyCrc32c(em.crc32, result.data.data(), em.original_size, "");
@@ -596,6 +681,7 @@ IndexEntryReader::EntryDownloadState
 IndexEntryReader::PrepareEntryDownload(const std::string& name,
                                        const std::string& local_path,
                                        const EntryMeta& meta) {
+    CheckCancelled("IndexEntryReader::PrepareEntryDownload");
     constexpr size_t kRangeSize = 16 * 1024 * 1024;
 
     int fd = ::open(local_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
@@ -634,6 +720,7 @@ IndexEntryReader::SubmitEntryDownloadTasks(
     std::vector<std::future<void>>& futures) {
     constexpr size_t kRangeSize = 16 * 1024 * 1024;
     auto& pool = ThreadPools::GetThreadPool(priority_);
+    auto cancellation_token = cancellation_token_;
 
     if (meta.encrypted) {
         const auto& em = meta.enc;
@@ -652,11 +739,16 @@ IndexEntryReader::SubmitEntryDownloadTasks(
                                            this_output_offset,
                                            plain_len,
                                            i,
-                                           &state]() {
+                                           &state,
+                                           cancellation_token]() {
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadEntriesToFiles");
                 std::vector<uint8_t> cipher(slice.size);
                 size_t n = input_->ReadAt(cipher.data(),
                                           MILVUS_V3_MAGIC_SIZE + slice.offset,
                                           slice.size);
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadEntriesToFiles");
                 AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
                 auto dec =
@@ -667,6 +759,8 @@ IndexEntryReader::SubmitEntryDownloadTasks(
                            "Decrypted size mismatch: expected {}, got {}",
                            plain_len,
                            plain.size());
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadEntriesToFiles");
                 auto written = ::pwrite(
                     fd, plain.data(), plain.size(), this_output_offset);
                 AssertInfo(written == static_cast<ssize_t>(plain.size()),
@@ -696,10 +790,15 @@ IndexEntryReader::SubmitEntryDownloadTasks(
                                            fd = state.fd,
                                            this_file_offset,
                                            this_range_idx,
-                                           &state]() {
+                                           &state,
+                                           cancellation_token]() {
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadEntriesToFiles");
                 std::vector<uint8_t> buf(len);
                 size_t n = input_->ReadAt(
                     buf.data(), MILVUS_V3_MAGIC_SIZE + this_src_offset, len);
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadEntriesToFiles");
                 AssertInfo(n == len, "Failed to read data for file");
                 auto written = ::pwrite(fd, buf.data(), len, this_file_offset);
                 AssertInfo(written == static_cast<ssize_t>(len),
@@ -718,6 +817,7 @@ IndexEntryReader::SubmitEntryDownloadTasks(
 
 void
 IndexEntryReader::FinalizeEntryDownload(EntryDownloadState& state) {
+    CheckCancelled("IndexEntryReader::FinalizeEntryDownload");
     uint32_t combined_crc = 0;
     if (!state.range_crcs.empty()) {
         combined_crc = state.range_crcs[0].crc;
@@ -741,6 +841,7 @@ IndexEntryReader::PrepareEntryStreamDownload(const std::string& name,
                                              const std::string& local_path,
                                              const EntryMeta& meta,
                                              io::Priority write_priority) {
+    CheckCancelled("IndexEntryReader::PrepareEntryStreamDownload");
     auto slice_size = DefaultEntryStreamSliceSize();
     AssertInfo(slice_size >= kMinStreamSliceSize,
                "ReadEntriesStreamToFiles slice_size must be at least {} bytes, "
@@ -778,6 +879,7 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
     auto& pool = ThreadPools::GetThreadPool(priority_);
     auto input = input_;
     auto* writer = state.writer.get();
+    auto cancellation_token = cancellation_token_;
 
     if (meta.encrypted) {
         const auto& em = meta.enc;
@@ -806,14 +908,21 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
                                            output_offset,
                                            plain_len,
                                            i,
-                                           &state]() {
+                                           &state,
+                                           cancellation_token]() {
                 TransientBudgetGuard budget_guard(
-                    EncryptedStreamBudgetBytes(slice.size, plain_len));
+                    EncryptedStreamBudgetBytes(slice.size, plain_len),
+                    cancellation_token,
+                    "IndexEntryReader::ReadEntriesStreamToFiles");
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadEntriesStreamToFiles");
 
                 std::vector<uint8_t> cipher(slice.size);
                 size_t n = input->ReadAt(cipher.data(),
                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
                                          slice.size);
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadEntriesStreamToFiles");
                 AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
                 auto dec =
@@ -824,6 +933,8 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
                            "Decrypted size mismatch: expected {}, got {}",
                            plain_len,
                            plain.size());
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadEntriesStreamToFiles");
                 writer->WriteAt(output_offset, plain.data(), plain.size());
                 state.range_crcs[i] = {
                     Crc32cValue(reinterpret_cast<const uint8_t*>(plain.data()),
@@ -842,24 +953,38 @@ IndexEntryReader::SubmitEntryStreamDownloadTasks(
                 PlainStreamSliceBytes(pm.size, slice_size, num_slices, seq);
             size_t src_offset = pm.offset + output_offset;
 
-            futures.push_back(pool.Submit(
-                [input, writer, output_offset, src_offset, len, seq, &state]() {
-                    TransientBudgetGuard budget_guard(len);
+            futures.push_back(pool.Submit([input,
+                                           writer,
+                                           output_offset,
+                                           src_offset,
+                                           len,
+                                           seq,
+                                           &state,
+                                           cancellation_token]() {
+                TransientBudgetGuard budget_guard(
+                    len,
+                    cancellation_token,
+                    "IndexEntryReader::ReadEntriesStreamToFiles");
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadEntriesStreamToFiles");
 
-                    std::vector<uint8_t> buf(len);
-                    size_t n = input->ReadAt(
-                        buf.data(), MILVUS_V3_MAGIC_SIZE + src_offset, len);
-                    AssertInfo(n == len, "Failed to read entry slice");
+                std::vector<uint8_t> buf(len);
+                size_t n = input->ReadAt(
+                    buf.data(), MILVUS_V3_MAGIC_SIZE + src_offset, len);
+                ThrowIfCancelled(cancellation_token,
+                                 "IndexEntryReader::ReadEntriesStreamToFiles");
+                AssertInfo(n == len, "Failed to read entry slice");
 
-                    writer->WriteAt(output_offset, buf.data(), len);
-                    state.range_crcs[seq] = {Crc32cValue(buf.data(), len), len};
-                }));
+                writer->WriteAt(output_offset, buf.data(), len);
+                state.range_crcs[seq] = {Crc32cValue(buf.data(), len), len};
+            }));
         }
     }
 }
 
 void
 IndexEntryReader::FinalizeEntryStreamDownload(EntryStreamDownloadState& state) {
+    CheckCancelled("IndexEntryReader::FinalizeEntryStreamDownload");
     uint32_t combined_crc = 0;
     if (!state.range_crcs.empty()) {
         combined_crc = state.range_crcs[0].crc;
@@ -881,6 +1006,7 @@ IndexEntryReader::FinalizeEntryStreamDownload(EntryStreamDownloadState& state) {
 void
 IndexEntryReader::ReadEntryToFile(const std::string& name,
                                   const std::string& local_path) {
+    CheckCancelled("IndexEntryReader::ReadEntryToFile");
     auto it = entry_index_.find(name);
     AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
     const auto& meta = it->second;
@@ -890,8 +1016,10 @@ IndexEntryReader::ReadEntryToFile(const std::string& name,
         std::vector<std::future<void>> futures;
         SubmitEntryDownloadTasks(meta, state, futures);
 
-        for (auto& f : futures) {
-            f.get();
+        std::exception_ptr first_error = nullptr;
+        DrainFutures(futures, first_error);
+        if (first_error) {
+            std::rethrow_exception(first_error);
         }
 
         FinalizeEntryDownload(state);
@@ -906,6 +1034,7 @@ IndexEntryReader::ReadEntryToFile(const std::string& name,
 void
 IndexEntryReader::ReadEntriesToFiles(
     const std::vector<std::pair<std::string, std::string>>& name_path_pairs) {
+    CheckCancelled("IndexEntryReader::ReadEntriesToFiles");
     if (name_path_pairs.empty()) {
         return;
     }
@@ -939,8 +1068,10 @@ IndexEntryReader::ReadEntriesToFiles(
         }
 
         // Wait for ALL tasks to complete
-        for (auto& f : all_futures) {
-            f.get();
+        std::exception_ptr first_error = nullptr;
+        DrainFutures(all_futures, first_error);
+        if (first_error) {
+            std::rethrow_exception(first_error);
         }
 
         // Verify CRCs and close all file descriptors
@@ -957,6 +1088,7 @@ void
 IndexEntryReader::ReadEntryStreamToFile(const std::string& name,
                                         const std::string& local_path,
                                         io::Priority write_priority) {
+    CheckCancelled("IndexEntryReader::ReadEntryStreamToFile");
     AssertInfo(HasEntry(name), "Entry not found: {}", name);
     auto writer = FileWriter(local_path, write_priority);
     ReadEntryStream(name, [&writer](const uint8_t* data, size_t len) {
@@ -969,6 +1101,7 @@ void
 IndexEntryReader::ReadEntriesStreamToFiles(
     const std::vector<std::pair<std::string, std::string>>& name_path_pairs,
     io::Priority write_priority) {
+    CheckCancelled("IndexEntryReader::ReadEntriesStreamToFiles");
     if (name_path_pairs.empty()) {
         return;
     }
@@ -1011,6 +1144,7 @@ IndexEntryReader::ReadEntriesStreamToFiles(
 
 size_t
 IndexEntryReader::GetEntrySize(const std::string& name) const {
+    CheckCancelled("IndexEntryReader::GetEntrySize");
     auto it = entry_index_.find(name);
     AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
     if (it->second.encrypted) {
@@ -1024,6 +1158,7 @@ IndexEntryReader::ReadEntryStream(
     const std::string& name,
     std::function<void(const uint8_t* data, size_t len)> slice_consumer,
     size_t slice_size) {
+    CheckCancelled("IndexEntryReader::ReadEntryStream");
     auto it = entry_index_.find(name);
     AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
     const auto& meta = it->second;
@@ -1054,12 +1189,18 @@ IndexEntryReader::ReadPlainEntryStream(
         return PlainStreamSliceBytes(entry_size, slice_size, num_slices, seq);
     };
     auto input = input_;
-    auto load_slice = [input, pm, slice_size, sliceBytes](size_t seq) {
+    auto cancellation_token = cancellation_token_;
+    auto load_slice = [input, pm, slice_size, sliceBytes, cancellation_token](
+                          size_t seq) {
         size_t off = seq * slice_size;
         size_t len = sliceBytes(seq);
         size_t src = pm.offset + off;
         std::vector<uint8_t> data(len);
+        ThrowIfCancelled(cancellation_token,
+                         "IndexEntryReader::ReadEntryStream");
         size_t n = input->ReadAt(data.data(), MILVUS_V3_MAGIC_SIZE + src, len);
+        ThrowIfCancelled(cancellation_token,
+                         "IndexEntryReader::ReadEntryStream");
         AssertInfo(n == len, "Failed to read entry slice");
         return data;
     };
@@ -1068,6 +1209,7 @@ IndexEntryReader::ReadPlainEntryStream(
                            pm.crc32,
                            "CRC-32C mismatch in stream read",
                            priority_,
+                           cancellation_token_,
                            slice_consumer,
                            sliceBytes,
                            load_slice);
@@ -1102,21 +1244,27 @@ IndexEntryReader::ReadEncryptedEntryStream(
     int64_t ez_id = ez_id_;
     int64_t collection_id = collection_id_;
     auto edek = edek_;
+    auto cancellation_token = cancellation_token_;
     auto load_slice = [input,
                        cipher_plugin,
                        ez_id,
                        collection_id,
                        edek,
                        &em,
-                       slicePlainBytes](size_t seq) {
+                       slicePlainBytes,
+                       cancellation_token](size_t seq) {
         const auto& slice = em.slices[seq];
         auto expected_plain_len = slicePlainBytes(seq);
 
         std::string plain;
         {
             std::vector<uint8_t> cipher(slice.size);
+            ThrowIfCancelled(cancellation_token,
+                             "IndexEntryReader::ReadEntryStream");
             size_t n = input->ReadAt(
                 cipher.data(), MILVUS_V3_MAGIC_SIZE + slice.offset, slice.size);
+            ThrowIfCancelled(cancellation_token,
+                             "IndexEntryReader::ReadEntryStream");
             AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
             auto dec = cipher_plugin->GetDecryptor(ez_id, collection_id, edek);
@@ -1135,6 +1283,7 @@ IndexEntryReader::ReadEncryptedEntryStream(
                            em.crc32,
                            "CRC-32C mismatch in encrypted stream read",
                            priority_,
+                           cancellation_token_,
                            slice_consumer,
                            sliceBudgetBytes,
                            load_slice);

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -67,7 +67,7 @@ class TransientBudgetGuard {
         : bytes_(bytes) {
         ThrowIfCancelled(cancellation_token, operation);
         auto acquired =
-            TransientMemoryBudget::GetEntryStreamBudget().AcquireUntil(
+            TransientMemoryBudget::GetLoadTransientBudget().AcquireUntil(
                 bytes_, [&cancellation_token]() {
                     return cancellation_token.isCancellationRequested();
                 });
@@ -78,7 +78,7 @@ class TransientBudgetGuard {
     }
 
     ~TransientBudgetGuard() {
-        TransientMemoryBudget::GetEntryStreamBudget().Release(bytes_);
+        TransientMemoryBudget::GetLoadTransientBudget().Release(bytes_);
     }
 
     TransientBudgetGuard(const TransientBudgetGuard&) = delete;
@@ -168,7 +168,7 @@ ReadOrderedEntryStream(
     }
 
     auto& pool = ThreadPools::GetThreadPool(priority);
-    auto& budget = TransientMemoryBudget::GetEntryStreamBudget();
+    auto& budget = TransientMemoryBudget::GetLoadTransientBudget();
     size_t max_active_tasks =
         std::min(num_slices, std::max<size_t>(1, pool.GetMaxThreadNum()));
 

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -45,14 +45,6 @@ namespace {
 using SliceLoader = std::function<std::vector<uint8_t>(size_t seq)>;
 using SliceBudgetBytes = std::function<size_t(size_t seq)>;
 
-void
-ThrowIfCancelled(const folly::CancellationToken& cancellation_token,
-                 const std::string& operation) {
-    if (cancellation_token.isCancellationRequested()) {
-        ThrowInfo(ErrorCode::FollyCancel, "{} cancelled", operation);
-    }
-}
-
 struct ActiveSliceTask {
     size_t budget_bytes{0};
     std::shared_ptr<StreamSliceResult> result;

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "folly/CancellationToken.h"
 #include "common/EasyAssert.h"
 #include "filemanager/InputStream.h"
 #include "nlohmann/json.hpp"
@@ -48,7 +49,9 @@ class IndexEntryReader {
     Open(std::shared_ptr<milvus::InputStream> input,
          int64_t file_size,
          int64_t collection_id = 0,
-         ThreadPoolPriority priority = ThreadPoolPriority::HIGH);
+         ThreadPoolPriority priority = ThreadPoolPriority::HIGH,
+         folly::CancellationToken cancellation_token =
+             folly::CancellationToken());
 
     std::vector<std::string>
     GetEntryNames() const;
@@ -150,6 +153,8 @@ class IndexEntryReader {
     ReadFooterAndDirectory();
     void
     ValidateMagic();
+    void
+    CheckCancelled(const std::string& operation) const;
 
     Entry
     ReadPlainEntry(const EntryMeta& meta);
@@ -228,6 +233,7 @@ class IndexEntryReader {
     int64_t file_size_ = 0;
     int64_t collection_id_ = 0;
     ThreadPoolPriority priority_ = ThreadPoolPriority::HIGH;
+    folly::CancellationToken cancellation_token_;
 
     bool is_encrypted_ = false;
     std::string edek_;

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -52,7 +52,7 @@ namespace {
 class IndexEntryStreamConfigGuard {
  public:
     IndexEntryStreamConfigGuard()
-        : budget_(TransientMemoryBudget::GetEntryStreamBudget()),
+        : budget_(TransientMemoryBudget::GetLoadTransientBudget()),
           capacity_bytes_(budget_.CapacityBytes()) {
     }
 
@@ -1197,16 +1197,17 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamRejectsInvalidSliceSize) {
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultSliceSize) {
     IndexEntryStreamConfigGuard guard;
     const size_t slice_size = DEFAULT_INDEX_FILE_SLICE_SIZE;
-    auto& budget = TransientMemoryBudget::GetEntryStreamBudget();
+    auto& budget = TransientMemoryBudget::GetLoadTransientBudget();
 
     ASSERT_EQ(DefaultStreamSliceSize(), slice_size);
-    milvus::SetEntryStreamBudgetBytes(0);
+    milvus::SetLoadTransientBudgetBytes(0);
     ASSERT_EQ(budget.CapacityBytes(), 0);
     ASSERT_EQ(EntryStreamMaxTransientBytes(),
               std::numeric_limits<size_t>::max());
 
     const size_t configured_budget = 3 * slice_size;
-    milvus::SetEntryStreamBudgetBytes(static_cast<int64_t>(configured_budget));
+    milvus::SetLoadTransientBudgetBytes(
+        static_cast<int64_t>(configured_budget));
     ASSERT_EQ(budget.CapacityBytes(), configured_budget);
     ASSERT_EQ(EntryStreamMaxTransientBytes(),
               configured_budget + kTailMergeGrace);
@@ -1505,7 +1506,7 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamCancellationWhileWaitingBudget) {
         writer.Finish();
     }
 
-    auto& budget = TransientMemoryBudget::GetEntryStreamBudget();
+    auto& budget = TransientMemoryBudget::GetLoadTransientBudget();
     auto old_capacity = budget.CapacityBytes();
     budget.SetCapacityBytes(slice_size);
     budget.Acquire(slice_size);

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <cstring>
 #include <fstream>
+#include <future>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -27,6 +28,8 @@
 #include <utility>
 #include <vector>
 
+#include "folly/CancellationToken.h"
+#include "folly/ScopeGuard.h"
 #include "common/Common.h"
 #include "common/EasyAssert.h"
 #include "filemanager/InputStream.h"
@@ -1490,6 +1493,60 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamDrainsActiveTasksAfterError) {
         },
         slice_size);
     EXPECT_EQ(streamed, data);
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamCancellationWhileWaitingBudget) {
+    const std::string file_path = kV3FilePath + "_stream_cancel_budget_wait";
+    const size_t slice_size = kMinStreamSliceSize;
+    auto data = GeneratePattern(slice_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto& budget = TransientMemoryBudget::GetEntryStreamBudget();
+    auto old_capacity = budget.CapacityBytes();
+    budget.SetCapacityBytes(slice_size);
+    budget.Acquire(slice_size);
+    auto cleanup = folly::makeGuard([&budget, old_capacity, slice_size]() {
+        budget.Release(slice_size);
+        budget.SetCapacityBytes(old_capacity);
+    });
+
+    folly::CancellationSource source;
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(
+        input, file_size, 0, milvus::HIGH, source.getToken());
+
+    std::atomic<size_t> slice_count{0};
+    auto future = std::async(std::launch::async, [&]() {
+        reader->ReadEntryStream(
+            "data",
+            [&slice_count](const uint8_t*, size_t) {
+                slice_count.fetch_add(1);
+            },
+            slice_size);
+    });
+
+    EXPECT_EQ(future.wait_for(std::chrono::milliseconds(50)),
+              std::future_status::timeout);
+    EXPECT_EQ(slice_count.load(), 0);
+
+    source.requestCancellation();
+
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    try {
+        future.get();
+        FAIL() << "expected cancellation";
+    } catch (const milvus::SegcoreError& e) {
+        EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::FollyCancel);
+    }
+    EXPECT_EQ(slice_count.load(), 0);
 }
 
 TEST_F(IndexEntryWriterV3Test, GetEntrySize) {

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <fstream>
 #include <future>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -51,24 +52,18 @@ namespace {
 class IndexEntryStreamConfigGuard {
  public:
     IndexEntryStreamConfigGuard()
-        : budget_ratio_(milvus::ENTRY_STREAM_BUDGET_RATIO.load()) {
+        : budget_(TransientMemoryBudget::GetEntryStreamBudget()),
+          capacity_bytes_(budget_.CapacityBytes()) {
     }
 
     ~IndexEntryStreamConfigGuard() {
-        milvus::SetStreamBudgetRatio(budget_ratio_);
+        budget_.SetCapacityBytes(capacity_bytes_);
     }
 
  private:
-    double budget_ratio_;
+    TransientMemoryBudget& budget_;
+    size_t capacity_bytes_;
 };
-
-size_t
-ExpectedEntryStreamBudgetBytes(double ratio) {
-    auto slice_size = DefaultStreamSliceSize();
-    auto core_num = std::max(1, milvus::CPU_NUM);
-    auto capacity = static_cast<size_t>(core_num * ratio) * slice_size;
-    return std::max(capacity, slice_size);
-}
 
 // Simple XOR-based mock cipher for testing (NOT for production use!)
 class MockEncryptor : public plugin::IEncryptor {
@@ -1201,17 +1196,20 @@ TEST_F(IndexEntryWriterV3Test, ReadEntryStreamRejectsInvalidSliceSize) {
 
 TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultSliceSize) {
     IndexEntryStreamConfigGuard guard;
-    milvus::SetStreamBudgetRatio(2.5);
     const size_t slice_size = DEFAULT_INDEX_FILE_SLICE_SIZE;
-    ASSERT_EQ(DefaultStreamSliceSize(), slice_size);
-    ASSERT_DOUBLE_EQ(StreamBudgetRatio(), 2.5);
-    ASSERT_EQ(TransientMemoryBudget::GetEntryStreamBudget().CapacityBytes(),
-              ExpectedEntryStreamBudgetBytes(2.5));
+    auto& budget = TransientMemoryBudget::GetEntryStreamBudget();
 
-    milvus::SetStreamBudgetRatio(3.5);
-    ASSERT_DOUBLE_EQ(StreamBudgetRatio(), 3.5);
-    ASSERT_EQ(TransientMemoryBudget::GetEntryStreamBudget().CapacityBytes(),
-              ExpectedEntryStreamBudgetBytes(3.5));
+    ASSERT_EQ(DefaultStreamSliceSize(), slice_size);
+    milvus::SetEntryStreamBudgetBytes(0);
+    ASSERT_EQ(budget.CapacityBytes(), 0);
+    ASSERT_EQ(EntryStreamMaxTransientBytes(),
+              std::numeric_limits<size_t>::max());
+
+    const size_t configured_budget = 3 * slice_size;
+    milvus::SetEntryStreamBudgetBytes(static_cast<int64_t>(configured_budget));
+    ASSERT_EQ(budget.CapacityBytes(), configured_budget);
+    ASSERT_EQ(EntryStreamMaxTransientBytes(),
+              configured_budget + kTailMergeGrace);
 
     const std::string file_path = kV3FilePath + "_stream_configured_default";
     const size_t tail_size = kTailMergeGrace + 17;

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -57,8 +57,8 @@ func InitSegcore(nodeID int64) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
-	cStreamBudgetBytes := C.int64_t(paramtable.Get().CommonCfg.StreamBudgetBytes.GetAsInt64())
-	C.SetEntryStreamBudgetBytes(cStreamBudgetBytes)
+	cLoadTransientBudgetBytes := C.int64_t(paramtable.Get().CommonCfg.LoadTransientBudgetBytes.GetAsInt64())
+	C.SetLoadTransientBudgetBytes(cLoadTransientBudgetBytes)
 
 	// set up thread pool for different priorities
 	cHighPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.HighPriorityThreadCoreCoefficient.GetAsFloat())

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -57,8 +57,8 @@ func InitSegcore(nodeID int64) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
-	cStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.StreamBudgetRatio.GetAsFloat())
-	C.SetStreamBudgetRatio(cStreamBudgetRatio)
+	cStreamBudgetBytes := C.int64_t(paramtable.Get().CommonCfg.StreamBudgetBytes.GetAsInt64())
+	C.SetEntryStreamBudgetBytes(cStreamBudgetBytes)
 
 	// set up thread pool for different priorities
 	cHighPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.HighPriorityThreadCoreCoefficient.GetAsFloat())

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -286,6 +286,16 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 			mlog.Info(node.ctx, "queryNode.segcore.storageV2.cellTargetSizeBytes updated",
 				mlog.Int64("bytes", newBytes))
 		}))
+	pt.Watch(pt.QueryNodeCfg.StorageV2FieldDataLoadBudgetBytes.Key,
+		config.NewHandler("queryNode.segcore.storageV2.fieldDataLoadBudgetBytes", func(evt *config.Event) {
+			if !evt.HasUpdated {
+				return
+			}
+			newBytes := paramtable.Get().QueryNodeCfg.StorageV2FieldDataLoadBudgetBytes.GetAsInt64()
+			initcore.UpdateStorageV2FieldDataLoadBudgetBytes(newBytes)
+			log.Info("queryNode.segcore.storageV2.fieldDataLoadBudgetBytes updated",
+				zap.Int64("bytes", newBytes))
+		}))
 	initcore.RegisterArrowReaderConfigWatchers(pt, "querynode")
 }
 

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -257,6 +257,36 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 		config.NewHandler("common.threadCoreCoefficient.lowPriority", ResizeLowPriorityPool))
 	pt.Watch(pt.CommonCfg.ThreadPoolMaxThreadsSize.Key,
 		config.NewHandler("common.threadCoreCoefficient.maxThreadsSize", ResizeAllPools))
+	fieldDataLoadHandler := func(key string) func(evt *config.Event) {
+		return func(evt *config.Event) {
+			if !evt.HasUpdated {
+				return
+			}
+			cfg := paramtable.Get().CommonCfg
+			initcore.UpdateFieldDataLoadMemoryLimitMB(cfg.FieldDataLoadMemoryLimitMB.GetAsInt())
+			initcore.UpdateFieldDataLoadBatchSizeMB(cfg.FieldDataLoadBatchSizeMB.GetAsInt())
+			initcore.UpdateFieldDataLoadReadBufferSizeMB(cfg.FieldDataLoadReadBufferSizeMB.GetAsInt())
+			initcore.UpdateFieldDataLoadMaxReadParallelism(cfg.FieldDataLoadMaxReadParallelism.GetAsInt())
+			log.Info("field data load config updated",
+				zap.String("trigger", key),
+				zap.Int("memoryLimitMB", cfg.FieldDataLoadMemoryLimitMB.GetAsInt()),
+				zap.Int("batchSizeMB", cfg.FieldDataLoadBatchSizeMB.GetAsInt()),
+				zap.Int("readBufferSizeMB", cfg.FieldDataLoadReadBufferSizeMB.GetAsInt()),
+				zap.Int("maxReadParallelism", cfg.FieldDataLoadMaxReadParallelism.GetAsInt()))
+		}
+	}
+	pt.Watch(pt.CommonCfg.FieldDataLoadMemoryLimitMB.Key,
+		config.NewHandler(pt.CommonCfg.FieldDataLoadMemoryLimitMB.Key,
+			fieldDataLoadHandler(pt.CommonCfg.FieldDataLoadMemoryLimitMB.Key)))
+	pt.Watch(pt.CommonCfg.FieldDataLoadBatchSizeMB.Key,
+		config.NewHandler(pt.CommonCfg.FieldDataLoadBatchSizeMB.Key,
+			fieldDataLoadHandler(pt.CommonCfg.FieldDataLoadBatchSizeMB.Key)))
+	pt.Watch(pt.CommonCfg.FieldDataLoadReadBufferSizeMB.Key,
+		config.NewHandler(pt.CommonCfg.FieldDataLoadReadBufferSizeMB.Key,
+			fieldDataLoadHandler(pt.CommonCfg.FieldDataLoadReadBufferSizeMB.Key)))
+	pt.Watch(pt.CommonCfg.FieldDataLoadMaxReadParallelism.Key,
+		config.NewHandler(pt.CommonCfg.FieldDataLoadMaxReadParallelism.Key,
+			fieldDataLoadHandler(pt.CommonCfg.FieldDataLoadMaxReadParallelism.Key)))
 	pt.Watch(pt.CommonCfg.DiskWriteMode.Key,
 		config.NewHandler("common.diskWriteMode", node.ReconfigDiskFileWriterParams))
 	pt.Watch(pt.CommonCfg.DiskWriteBufferSizeKb.Key,

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -286,16 +286,6 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 			mlog.Info(node.ctx, "queryNode.segcore.storageV2.cellTargetSizeBytes updated",
 				mlog.Int64("bytes", newBytes))
 		}))
-	pt.Watch(pt.QueryNodeCfg.StorageV2FieldDataLoadBudgetBytes.Key,
-		config.NewHandler("queryNode.segcore.storageV2.fieldDataLoadBudgetBytes", func(evt *config.Event) {
-			if !evt.HasUpdated {
-				return
-			}
-			newBytes := paramtable.Get().QueryNodeCfg.StorageV2FieldDataLoadBudgetBytes.GetAsInt64()
-			initcore.UpdateStorageV2FieldDataLoadBudgetBytes(newBytes)
-			log.Info("queryNode.segcore.storageV2.fieldDataLoadBudgetBytes updated",
-				zap.Int64("bytes", newBytes))
-		}))
 	initcore.RegisterArrowReaderConfigWatchers(pt, "querynode")
 }
 

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -257,36 +257,6 @@ func (node *QueryNode) RegisterSegcoreConfigWatcher() {
 		config.NewHandler("common.threadCoreCoefficient.lowPriority", ResizeLowPriorityPool))
 	pt.Watch(pt.CommonCfg.ThreadPoolMaxThreadsSize.Key,
 		config.NewHandler("common.threadCoreCoefficient.maxThreadsSize", ResizeAllPools))
-	fieldDataLoadHandler := func(key string) func(evt *config.Event) {
-		return func(evt *config.Event) {
-			if !evt.HasUpdated {
-				return
-			}
-			cfg := paramtable.Get().CommonCfg
-			initcore.UpdateFieldDataLoadMemoryLimitMB(cfg.FieldDataLoadMemoryLimitMB.GetAsInt())
-			initcore.UpdateFieldDataLoadBatchSizeMB(cfg.FieldDataLoadBatchSizeMB.GetAsInt())
-			initcore.UpdateFieldDataLoadReadBufferSizeMB(cfg.FieldDataLoadReadBufferSizeMB.GetAsInt())
-			initcore.UpdateFieldDataLoadMaxReadParallelism(cfg.FieldDataLoadMaxReadParallelism.GetAsInt())
-			log.Info("field data load config updated",
-				zap.String("trigger", key),
-				zap.Int("memoryLimitMB", cfg.FieldDataLoadMemoryLimitMB.GetAsInt()),
-				zap.Int("batchSizeMB", cfg.FieldDataLoadBatchSizeMB.GetAsInt()),
-				zap.Int("readBufferSizeMB", cfg.FieldDataLoadReadBufferSizeMB.GetAsInt()),
-				zap.Int("maxReadParallelism", cfg.FieldDataLoadMaxReadParallelism.GetAsInt()))
-		}
-	}
-	pt.Watch(pt.CommonCfg.FieldDataLoadMemoryLimitMB.Key,
-		config.NewHandler(pt.CommonCfg.FieldDataLoadMemoryLimitMB.Key,
-			fieldDataLoadHandler(pt.CommonCfg.FieldDataLoadMemoryLimitMB.Key)))
-	pt.Watch(pt.CommonCfg.FieldDataLoadBatchSizeMB.Key,
-		config.NewHandler(pt.CommonCfg.FieldDataLoadBatchSizeMB.Key,
-			fieldDataLoadHandler(pt.CommonCfg.FieldDataLoadBatchSizeMB.Key)))
-	pt.Watch(pt.CommonCfg.FieldDataLoadReadBufferSizeMB.Key,
-		config.NewHandler(pt.CommonCfg.FieldDataLoadReadBufferSizeMB.Key,
-			fieldDataLoadHandler(pt.CommonCfg.FieldDataLoadReadBufferSizeMB.Key)))
-	pt.Watch(pt.CommonCfg.FieldDataLoadMaxReadParallelism.Key,
-		config.NewHandler(pt.CommonCfg.FieldDataLoadMaxReadParallelism.Key,
-			fieldDataLoadHandler(pt.CommonCfg.FieldDataLoadMaxReadParallelism.Key)))
 	pt.Watch(pt.CommonCfg.DiskWriteMode.Key,
 		config.NewHandler("common.diskWriteMode", node.ReconfigDiskFileWriterParams))
 	pt.Watch(pt.CommonCfg.DiskWriteBufferSizeKb.Key,

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -298,9 +298,9 @@ func TestRegisterSegcoreConfigWatcher(t *testing.T) {
 		pt.Save(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, "1048576")
 	})
 	assert.NotPanics(t, func() {
-		pt.Save(pt.QueryNodeCfg.StorageV2FieldDataLoadBudgetBytes.Key, "67108864")
+		pt.Save(pt.CommonCfg.LoadTransientBudgetBytes.Key, "67108864")
 	})
-	pt.Reset(pt.QueryNodeCfg.StorageV2FieldDataLoadBudgetBytes.Key)
+	pt.Reset(pt.CommonCfg.LoadTransientBudgetBytes.Key)
 }
 
 func TestQueryNode(t *testing.T) {

--- a/internal/querynodev2/server_test.go
+++ b/internal/querynodev2/server_test.go
@@ -297,6 +297,10 @@ func TestRegisterSegcoreConfigWatcher(t *testing.T) {
 	assert.NotPanics(t, func() {
 		pt.Save(pt.CommonCfg.ArrowReaderRangeSizeLimitBytes.Key, "1048576")
 	})
+	assert.NotPanics(t, func() {
+		pt.Save(pt.QueryNodeCfg.StorageV2FieldDataLoadBudgetBytes.Key, "67108864")
+	})
+	pt.Reset(pt.QueryNodeCfg.StorageV2FieldDataLoadBudgetBytes.Key)
 }
 
 func TestQueryNode(t *testing.T) {

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -597,6 +597,42 @@ func SetupCoreConfigChangelCallback() {
 			return nil
 		})
 
+		paramtable.Get().CommonCfg.FieldDataLoadMemoryLimitMB.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+			size, err := strconv.Atoi(newValue)
+			if err != nil {
+				return err
+			}
+			UpdateFieldDataLoadMemoryLimitMB(size)
+			return nil
+		})
+
+		paramtable.Get().CommonCfg.FieldDataLoadBatchSizeMB.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+			size, err := strconv.Atoi(newValue)
+			if err != nil {
+				return err
+			}
+			UpdateFieldDataLoadBatchSizeMB(size)
+			return nil
+		})
+
+		paramtable.Get().CommonCfg.FieldDataLoadReadBufferSizeMB.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+			size, err := strconv.Atoi(newValue)
+			if err != nil {
+				return err
+			}
+			UpdateFieldDataLoadReadBufferSizeMB(size)
+			return nil
+		})
+
+		paramtable.Get().CommonCfg.FieldDataLoadMaxReadParallelism.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+			parallelism, err := strconv.Atoi(newValue)
+			if err != nil {
+				return err
+			}
+			UpdateFieldDataLoadMaxReadParallelism(parallelism)
+			return nil
+		})
+
 		paramtable.Get().CommonCfg.EnabledOptimizeExpr.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
 			enable, err := strconv.ParseBool(newValue)
 			if err != nil {

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -597,42 +597,6 @@ func SetupCoreConfigChangelCallback() {
 			return nil
 		})
 
-		paramtable.Get().CommonCfg.FieldDataLoadMemoryLimitMB.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
-			size, err := strconv.Atoi(newValue)
-			if err != nil {
-				return err
-			}
-			UpdateFieldDataLoadMemoryLimitMB(size)
-			return nil
-		})
-
-		paramtable.Get().CommonCfg.FieldDataLoadBatchSizeMB.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
-			size, err := strconv.Atoi(newValue)
-			if err != nil {
-				return err
-			}
-			UpdateFieldDataLoadBatchSizeMB(size)
-			return nil
-		})
-
-		paramtable.Get().CommonCfg.FieldDataLoadReadBufferSizeMB.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
-			size, err := strconv.Atoi(newValue)
-			if err != nil {
-				return err
-			}
-			UpdateFieldDataLoadReadBufferSizeMB(size)
-			return nil
-		})
-
-		paramtable.Get().CommonCfg.FieldDataLoadMaxReadParallelism.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
-			parallelism, err := strconv.Atoi(newValue)
-			if err != nil {
-				return err
-			}
-			UpdateFieldDataLoadMaxReadParallelism(parallelism)
-			return nil
-		})
-
 		paramtable.Get().CommonCfg.EnabledOptimizeExpr.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
 			enable, err := strconv.ParseBool(newValue)
 			if err != nil {

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -520,12 +520,8 @@ func SetupCoreConfigChangelCallback() {
 			return nil
 		})
 
-		paramtable.Get().CommonCfg.StreamBudgetBytes.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
-			bytes, err := strconv.ParseInt(newValue, 10, 64)
-			if err != nil {
-				return err
-			}
-			UpdateEntryStreamBudgetBytes(bytes)
+		paramtable.Get().CommonCfg.LoadTransientBudgetBytes.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+			UpdateLoadTransientBudgetBytes(paramtable.Get().CommonCfg.LoadTransientBudgetBytes.GetAsInt64())
 			return nil
 		})
 

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -520,12 +520,12 @@ func SetupCoreConfigChangelCallback() {
 			return nil
 		})
 
-		paramtable.Get().CommonCfg.StreamBudgetRatio.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
-			ratio, err := strconv.ParseFloat(newValue, 64)
+		paramtable.Get().CommonCfg.StreamBudgetBytes.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+			bytes, err := strconv.ParseInt(newValue, 10, 64)
 			if err != nil {
 				return err
 			}
-			UpdateStreamBudgetRatio(ratio)
+			UpdateEntryStreamBudgetBytes(bytes)
 			return nil
 		})
 

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -149,10 +149,10 @@ func TestInitArrowReaderConfig(t *testing.T) {
 	assert.NoError(t, InitArrowReaderConfig(pt))
 }
 
-func TestUpdateStorageV2FieldDataLoadBudgetBytes(t *testing.T) {
+func TestUpdateLoadTransientBudgetBytes(t *testing.T) {
 	assert.NotPanics(t, func() {
-		UpdateStorageV2FieldDataLoadBudgetBytes(64 * 1024 * 1024)
-		UpdateStorageV2FieldDataLoadBudgetBytes(128 * 1024 * 1024)
+		UpdateLoadTransientBudgetBytes(0)
+		UpdateLoadTransientBudgetBytes(128 * 1024 * 1024)
 	})
 }
 

--- a/internal/util/initcore/init_core_test.go
+++ b/internal/util/initcore/init_core_test.go
@@ -149,6 +149,13 @@ func TestInitArrowReaderConfig(t *testing.T) {
 	assert.NoError(t, InitArrowReaderConfig(pt))
 }
 
+func TestUpdateStorageV2FieldDataLoadBudgetBytes(t *testing.T) {
+	assert.NotPanics(t, func() {
+		UpdateStorageV2FieldDataLoadBudgetBytes(64 * 1024 * 1024)
+		UpdateStorageV2FieldDataLoadBudgetBytes(128 * 1024 * 1024)
+	})
+}
+
 func TestInitStorageV2FileSystem(t *testing.T) {
 	// init local storage
 	paramtable.Init()

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -117,15 +117,6 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	cThreadPoolMaxThreadsSize := C.int(paramtable.Get().CommonCfg.ThreadPoolMaxThreadsSize.GetAsInt())
 	C.SetThreadPoolMaxThreadsSize(cThreadPoolMaxThreadsSize)
 
-	cFieldDataLoadMemoryLimitMB := C.int64_t(paramtable.Get().CommonCfg.FieldDataLoadMemoryLimitMB.GetAsInt())
-	C.SetFieldDataLoadMemoryLimitMB(cFieldDataLoadMemoryLimitMB)
-	cFieldDataLoadBatchSizeMB := C.int64_t(paramtable.Get().CommonCfg.FieldDataLoadBatchSizeMB.GetAsInt())
-	C.SetFieldDataLoadBatchSizeMB(cFieldDataLoadBatchSizeMB)
-	cFieldDataLoadReadBufferSizeMB := C.int64_t(paramtable.Get().CommonCfg.FieldDataLoadReadBufferSizeMB.GetAsInt())
-	C.SetFieldDataLoadReadBufferSizeMB(cFieldDataLoadReadBufferSizeMB)
-	cFieldDataLoadMaxReadParallelism := C.int64_t(paramtable.Get().CommonCfg.FieldDataLoadMaxReadParallelism.GetAsInt())
-	C.SetFieldDataLoadMaxReadParallelism(cFieldDataLoadMaxReadParallelism)
-
 	cCPUNum := C.int(hardware.GetCPUNum())
 	C.InitCpuNum(cCPUNum)
 

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -166,6 +166,8 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 
 	cStorageV2CellTargetSizeBytes := C.int64_t(paramtable.Get().QueryNodeCfg.StorageV2CellTargetSizeBytes.GetAsInt64())
 	C.SetStorageV2CellTargetSizeBytes(cStorageV2CellTargetSizeBytes)
+	cStorageV2FieldDataLoadBudgetBytes := C.int64_t(paramtable.Get().QueryNodeCfg.StorageV2FieldDataLoadBudgetBytes.GetAsInt64())
+	C.SetStorageV2FieldDataLoadBudgetBytes(cStorageV2FieldDataLoadBudgetBytes)
 
 	enableParquetStatsSkipIndex := paramtable.Get().CommonCfg.ParquetStatsSkipIndex.GetAsBool()
 	C.SetDefaultEnableParquetStatsSkipIndex(C.bool(enableParquetStatsSkipIndex))

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -104,8 +104,8 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
-	cStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.StreamBudgetRatio.GetAsFloat())
-	C.SetStreamBudgetRatio(cStreamBudgetRatio)
+	cStreamBudgetBytes := C.int64_t(paramtable.Get().CommonCfg.StreamBudgetBytes.GetAsInt64())
+	C.SetEntryStreamBudgetBytes(cStreamBudgetBytes)
 
 	// set up thread pool for different priorities
 	cHighPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.HighPriorityThreadCoreCoefficient.GetAsFloat())

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -104,8 +104,8 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
-	cStreamBudgetBytes := C.int64_t(paramtable.Get().CommonCfg.StreamBudgetBytes.GetAsInt64())
-	C.SetEntryStreamBudgetBytes(cStreamBudgetBytes)
+	cLoadTransientBudgetBytes := C.int64_t(paramtable.Get().CommonCfg.LoadTransientBudgetBytes.GetAsInt64())
+	C.SetLoadTransientBudgetBytes(cLoadTransientBudgetBytes)
 
 	// set up thread pool for different priorities
 	cHighPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.HighPriorityThreadCoreCoefficient.GetAsFloat())
@@ -166,9 +166,6 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 
 	cStorageV2CellTargetSizeBytes := C.int64_t(paramtable.Get().QueryNodeCfg.StorageV2CellTargetSizeBytes.GetAsInt64())
 	C.SetStorageV2CellTargetSizeBytes(cStorageV2CellTargetSizeBytes)
-	cStorageV2FieldDataLoadBudgetBytes := C.int64_t(paramtable.Get().QueryNodeCfg.StorageV2FieldDataLoadBudgetBytes.GetAsInt64())
-	C.SetStorageV2FieldDataLoadBudgetBytes(cStorageV2FieldDataLoadBudgetBytes)
-
 	enableParquetStatsSkipIndex := paramtable.Get().CommonCfg.ParquetStatsSkipIndex.GetAsBool()
 	C.SetDefaultEnableParquetStatsSkipIndex(C.bool(enableParquetStatsSkipIndex))
 

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -117,6 +117,15 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	cThreadPoolMaxThreadsSize := C.int(paramtable.Get().CommonCfg.ThreadPoolMaxThreadsSize.GetAsInt())
 	C.SetThreadPoolMaxThreadsSize(cThreadPoolMaxThreadsSize)
 
+	cFieldDataLoadMemoryLimitMB := C.int64_t(paramtable.Get().CommonCfg.FieldDataLoadMemoryLimitMB.GetAsInt())
+	C.SetFieldDataLoadMemoryLimitMB(cFieldDataLoadMemoryLimitMB)
+	cFieldDataLoadBatchSizeMB := C.int64_t(paramtable.Get().CommonCfg.FieldDataLoadBatchSizeMB.GetAsInt())
+	C.SetFieldDataLoadBatchSizeMB(cFieldDataLoadBatchSizeMB)
+	cFieldDataLoadReadBufferSizeMB := C.int64_t(paramtable.Get().CommonCfg.FieldDataLoadReadBufferSizeMB.GetAsInt())
+	C.SetFieldDataLoadReadBufferSizeMB(cFieldDataLoadReadBufferSizeMB)
+	cFieldDataLoadMaxReadParallelism := C.int64_t(paramtable.Get().CommonCfg.FieldDataLoadMaxReadParallelism.GetAsInt())
+	C.SetFieldDataLoadMaxReadParallelism(cFieldDataLoadMaxReadParallelism)
+
 	cCPUNum := C.int(hardware.GetCPUNum())
 	C.InitCpuNum(cCPUNum)
 

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -51,8 +51,8 @@ func UpdateIndexSliceSize(size int) {
 	C.SetIndexSliceSize(C.int64_t(size))
 }
 
-func UpdateStreamBudgetRatio(ratio float64) {
-	C.SetStreamBudgetRatio(C.double(ratio))
+func UpdateEntryStreamBudgetBytes(bytes int64) {
+	C.SetEntryStreamBudgetBytes(C.int64_t(bytes))
 }
 
 func UpdateHighPriorityThreadCoreCoefficient(coefficient float64) {

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -51,8 +51,8 @@ func UpdateIndexSliceSize(size int) {
 	C.SetIndexSliceSize(C.int64_t(size))
 }
 
-func UpdateEntryStreamBudgetBytes(bytes int64) {
-	C.SetEntryStreamBudgetBytes(C.int64_t(bytes))
+func UpdateLoadTransientBudgetBytes(bytes int64) {
+	C.SetLoadTransientBudgetBytes(C.int64_t(bytes))
 }
 
 func UpdateHighPriorityThreadCoreCoefficient(coefficient float64) {
@@ -187,10 +187,6 @@ func RegisterArrowReaderConfigWatchers(pt *paramtable.ComponentParam, source str
 
 func UpdateStorageV2CellTargetSizeBytes(bytes int64) {
 	C.SetStorageV2CellTargetSizeBytes(C.int64_t(bytes))
-}
-
-func UpdateStorageV2FieldDataLoadBudgetBytes(bytes int64) {
-	C.SetStorageV2FieldDataLoadBudgetBytes(C.int64_t(bytes))
 }
 
 func UpdateDefaultGrowingJSONKeyStatsEnable(enable bool) {

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -189,6 +189,10 @@ func UpdateStorageV2CellTargetSizeBytes(bytes int64) {
 	C.SetStorageV2CellTargetSizeBytes(C.int64_t(bytes))
 }
 
+func UpdateStorageV2FieldDataLoadBudgetBytes(bytes int64) {
+	C.SetStorageV2FieldDataLoadBudgetBytes(C.int64_t(bytes))
+}
+
 func UpdateDefaultGrowingJSONKeyStatsEnable(enable bool) {
 	C.SetDefaultGrowingJSONKeyStatsEnable(C.bool(enable))
 }

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -71,22 +71,6 @@ func UpdateThreadPoolMaxThreadsSize(size int) {
 	C.SetThreadPoolMaxThreadsSize(C.int(size))
 }
 
-func UpdateFieldDataLoadMemoryLimitMB(size int) {
-	C.SetFieldDataLoadMemoryLimitMB(C.int64_t(size))
-}
-
-func UpdateFieldDataLoadBatchSizeMB(size int) {
-	C.SetFieldDataLoadBatchSizeMB(C.int64_t(size))
-}
-
-func UpdateFieldDataLoadReadBufferSizeMB(size int) {
-	C.SetFieldDataLoadReadBufferSizeMB(C.int64_t(size))
-}
-
-func UpdateFieldDataLoadMaxReadParallelism(parallelism int) {
-	C.SetFieldDataLoadMaxReadParallelism(C.int64_t(parallelism))
-}
-
 func UpdateDefaultExprEvalBatchSize(size int) {
 	C.SetDefaultExprEvalBatchSize(C.int64_t(size))
 }

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -71,6 +71,22 @@ func UpdateThreadPoolMaxThreadsSize(size int) {
 	C.SetThreadPoolMaxThreadsSize(C.int(size))
 }
 
+func UpdateFieldDataLoadMemoryLimitMB(size int) {
+	C.SetFieldDataLoadMemoryLimitMB(C.int64_t(size))
+}
+
+func UpdateFieldDataLoadBatchSizeMB(size int) {
+	C.SetFieldDataLoadBatchSizeMB(C.int64_t(size))
+}
+
+func UpdateFieldDataLoadReadBufferSizeMB(size int) {
+	C.SetFieldDataLoadReadBufferSizeMB(C.int64_t(size))
+}
+
+func UpdateFieldDataLoadMaxReadParallelism(parallelism int) {
+	C.SetFieldDataLoadMaxReadParallelism(C.int64_t(parallelism))
+}
+
 func UpdateDefaultExprEvalBatchSize(size int) {
 	C.SetDefaultExprEvalBatchSize(C.int64_t(size))
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -51,6 +51,7 @@ const (
 	DefaultLowPriorityThreadCoreCoefficient    = 1
 	DefaultBM25LoadThreadCoreCoefficient       = 1
 	DefaultThreadPoolMaxThreadsSize            = 16
+	DefaultStorageV2FieldDataLoadBudgetBytes   = 128 << 20
 
 	DefaultSessionTTL        = 15 // s
 	DefaultSessionRetryTimes = 30
@@ -3656,7 +3657,8 @@ type queryNodeConfig struct {
 
 	// Target average byte size per storage v2 cache cell. Parquet row groups
 	// are packed into cells so rgs_per_cell * avg_rg_size ≈ this value.
-	StorageV2CellTargetSizeBytes ParamItem `refreshable:"true"`
+	StorageV2CellTargetSizeBytes      ParamItem `refreshable:"true"`
+	StorageV2FieldDataLoadBudgetBytes ParamItem `refreshable:"true"`
 
 	EnableWorkerSQCostMetrics ParamItem `refreshable:"true"`
 
@@ -4837,6 +4839,27 @@ user-task-polling:
 		},
 	}
 	p.StorageV2CellTargetSizeBytes.Init(base.mgr)
+
+	p.StorageV2FieldDataLoadBudgetBytes = ParamItem{
+		Key:          "queryNode.segcore.storageV2.fieldDataLoadBudgetBytes",
+		Version:      "3.0.0",
+		DefaultValue: strconv.Itoa(DefaultStorageV2FieldDataLoadBudgetBytes),
+		Doc: `Process-wide transient memory budget in bytes for storage v2 ` +
+			`field-data loading. It gates in-flight Arrow data across concurrent ` +
+			`load tasks. Lower values reduce peak transient memory at the cost of ` +
+			`load throughput. Oversized cells are still allowed to proceed ` +
+			`exclusively to guarantee progress. Default 128 MiB.`,
+		Export: true,
+		Formatter: func(v string) string {
+			if getAsInt64(v) <= 0 {
+				log.Warn("queryNode.segcore.storageV2.fieldDataLoadBudgetBytes must be positive, using default 128 MiB",
+					zap.String("configured", v))
+				return strconv.Itoa(DefaultStorageV2FieldDataLoadBudgetBytes)
+			}
+			return v
+		},
+	}
+	p.StorageV2FieldDataLoadBudgetBytes.Init(base.mgr)
 
 	p.EnableWorkerSQCostMetrics = ParamItem{
 		Key:          "queryNode.enableWorkerSQCostMetrics",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -563,7 +563,7 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Version:      "3.0.0",
 		DefaultValue: strconv.Itoa(DefaultLoadTransientBudgetBytes),
 		Doc: `Process-wide transient memory budget in bytes shared by scalar ` +
-			`index entry reading and storage v2 field-data loading. It gates ` +
+			`index V3 entry streaming and storage v2/v3 field-data loading. It gates ` +
 			`in-flight transient data across concurrent load tasks. Lower ` +
 			`values reduce peak transient memory at the cost of load throughput. ` +
 			`Oversized requests are still allowed to proceed exclusively to ` +

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -41,7 +41,7 @@ import (
 const (
 	// DefaultIndexSliceSize defines the default slice size of index file when serializing.
 	DefaultIndexSliceSize                      = 16
-	DefaultStreamBudgetRatio                   = 3.0
+	DefaultEntryStreamBudgetBytes              = 0
 	DefaultGracefulTime                        = 5000 // ms
 	DefaultGracefulStopTimeout                 = 1800 // s, for node
 	DefaultProxyGracefulStopTimeout            = 30   // s，for proxy
@@ -233,7 +233,7 @@ type commonConfig struct {
 	DefaultIndexName     ParamItem `refreshable:"true"`
 
 	IndexSliceSize                      ParamItem `refreshable:"false"`
-	StreamBudgetRatio                   ParamItem `refreshable:"true"`
+	StreamBudgetBytes                   ParamItem `refreshable:"true"`
 	HighPriorityThreadCoreCoefficient   ParamItem `refreshable:"true"`
 	MiddlePriorityThreadCoreCoefficient ParamItem `refreshable:"true"`
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`
@@ -559,14 +559,26 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 	}
 	p.IndexSliceSize.Init(base.mgr)
 
-	p.StreamBudgetRatio = ParamItem{
-		Key:          "common.entryStream.streamBudgetRatio",
+	p.StreamBudgetBytes = ParamItem{
+		Key:          "common.entryStream.streamBudgetBytes",
 		Version:      "3.0.0",
-		DefaultValue: fmt.Sprintf("%f", DefaultStreamBudgetRatio),
-		Doc:          "Multiplier for entry stream transient memory budget, relative to CPU core count",
-		Export:       true,
+		DefaultValue: strconv.Itoa(DefaultEntryStreamBudgetBytes),
+		Doc: `Process-wide transient memory budget in bytes for entry stream ` +
+			`loading. It gates in-flight entry stream slices across concurrent ` +
+			`load tasks. Lower values reduce peak transient memory at the cost of ` +
+			`load throughput. Oversized slices are still allowed to proceed ` +
+			`exclusively to guarantee progress. Set to 0 to disable the limit.`,
+		Export: true,
+		Formatter: func(v string) string {
+			if getAsInt64(v) < 0 {
+				log.Warn("common.entryStream.streamBudgetBytes must be non-negative, using unlimited",
+					zap.String("configured", v))
+				return strconv.Itoa(DefaultEntryStreamBudgetBytes)
+			}
+			return v
+		},
 	}
-	p.StreamBudgetRatio.Init(base.mgr)
+	p.StreamBudgetBytes.Init(base.mgr)
 
 	p.EnableMaterializedView = ParamItem{
 		Key:          "common.materializedView.enabled",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -51,10 +51,6 @@ const (
 	DefaultLowPriorityThreadCoreCoefficient    = 1
 	DefaultBM25LoadThreadCoreCoefficient       = 1
 	DefaultThreadPoolMaxThreadsSize            = 16
-	DefaultFieldDataLoadMemoryLimitMB          = 128
-	DefaultFieldDataLoadBatchSizeMB            = 32
-	DefaultFieldDataLoadReadBufferSizeMB       = 16
-	DefaultFieldDataLoadMaxReadParallelism     = 8
 
 	DefaultSessionTTL        = 15 // s
 	DefaultSessionRetryTimes = 30
@@ -242,10 +238,6 @@ type commonConfig struct {
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`
 	BM25LoadThreadCoreCoefficient       ParamItem `refreshable:"true"`
 	ThreadPoolMaxThreadsSize            ParamItem `refreshable:"true"`
-	FieldDataLoadMemoryLimitMB          ParamItem `refreshable:"true"`
-	FieldDataLoadBatchSizeMB            ParamItem `refreshable:"true"`
-	FieldDataLoadReadBufferSizeMB       ParamItem `refreshable:"true"`
-	FieldDataLoadMaxReadParallelism     ParamItem `refreshable:"true"`
 	ArrowIOThreadPoolCoefficient        ParamItem `refreshable:"true"`
 	ArrowIOThreadPoolMaxCapacity        ParamItem `refreshable:"true"`
 	ArrowReaderHoleSizeLimitBytes       ParamItem `refreshable:"true"`
@@ -732,42 +724,6 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export:       true,
 	}
 	p.ThreadPoolMaxThreadsSize.Init(base.mgr)
-
-	p.FieldDataLoadMemoryLimitMB = ParamItem{
-		Key:          "common.fieldDataLoad.memoryLimitMB",
-		Version:      "3.0.0",
-		DefaultValue: strconv.Itoa(DefaultFieldDataLoadMemoryLimitMB),
-		Doc:          "Global transient memory budget for concurrent field data loading in MB",
-		Export:       true,
-	}
-	p.FieldDataLoadMemoryLimitMB.Init(base.mgr)
-
-	p.FieldDataLoadBatchSizeMB = ParamItem{
-		Key:          "common.fieldDataLoad.batchSizeMB",
-		Version:      "3.0.0",
-		DefaultValue: strconv.Itoa(DefaultFieldDataLoadBatchSizeMB),
-		Doc:          "Target size for grouping field data cells into one load batch in MB",
-		Export:       true,
-	}
-	p.FieldDataLoadBatchSizeMB.Init(base.mgr)
-
-	p.FieldDataLoadReadBufferSizeMB = ParamItem{
-		Key:          "common.fieldDataLoad.readBufferSizeMB",
-		Version:      "3.0.0",
-		DefaultValue: strconv.Itoa(DefaultFieldDataLoadReadBufferSizeMB),
-		Doc:          "Per-reader buffer/window size for field data loading in MB",
-		Export:       true,
-	}
-	p.FieldDataLoadReadBufferSizeMB.Init(base.mgr)
-
-	p.FieldDataLoadMaxReadParallelism = ParamItem{
-		Key:          "common.fieldDataLoad.maxReadParallelism",
-		Version:      "3.0.0",
-		DefaultValue: strconv.Itoa(DefaultFieldDataLoadMaxReadParallelism),
-		Doc:          "Maximum read parallelism within one field data load batch",
-		Export:       true,
-	}
-	p.FieldDataLoadMaxReadParallelism.Init(base.mgr)
 
 	p.ArrowIOThreadPoolCoefficient = ParamItem{
 		Key:          "common.arrow.ioThreadPoolCoefficient",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -41,7 +41,7 @@ import (
 const (
 	// DefaultIndexSliceSize defines the default slice size of index file when serializing.
 	DefaultIndexSliceSize                      = 16
-	DefaultEntryStreamBudgetBytes              = 0
+	DefaultLoadTransientBudgetBytes            = 0
 	DefaultGracefulTime                        = 5000 // ms
 	DefaultGracefulStopTimeout                 = 1800 // s, for node
 	DefaultProxyGracefulStopTimeout            = 30   // s，for proxy
@@ -51,7 +51,6 @@ const (
 	DefaultLowPriorityThreadCoreCoefficient    = 1
 	DefaultBM25LoadThreadCoreCoefficient       = 1
 	DefaultThreadPoolMaxThreadsSize            = 16
-	DefaultStorageV2FieldDataLoadBudgetBytes   = 128 << 20
 
 	DefaultSessionTTL        = 15 // s
 	DefaultSessionRetryTimes = 30
@@ -233,7 +232,7 @@ type commonConfig struct {
 	DefaultIndexName     ParamItem `refreshable:"true"`
 
 	IndexSliceSize                      ParamItem `refreshable:"false"`
-	StreamBudgetBytes                   ParamItem `refreshable:"true"`
+	LoadTransientBudgetBytes            ParamItem `refreshable:"true"`
 	HighPriorityThreadCoreCoefficient   ParamItem `refreshable:"true"`
 	MiddlePriorityThreadCoreCoefficient ParamItem `refreshable:"true"`
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`
@@ -559,26 +558,27 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 	}
 	p.IndexSliceSize.Init(base.mgr)
 
-	p.StreamBudgetBytes = ParamItem{
-		Key:          "common.entryStream.streamBudgetBytes",
+	p.LoadTransientBudgetBytes = ParamItem{
+		Key:          "common.loadTransientBudgetBytes",
 		Version:      "3.0.0",
-		DefaultValue: strconv.Itoa(DefaultEntryStreamBudgetBytes),
-		Doc: `Process-wide transient memory budget in bytes for entry stream ` +
-			`loading. It gates in-flight entry stream slices across concurrent ` +
-			`load tasks. Lower values reduce peak transient memory at the cost of ` +
-			`load throughput. Oversized slices are still allowed to proceed ` +
-			`exclusively to guarantee progress. Set to 0 to disable the limit.`,
+		DefaultValue: strconv.Itoa(DefaultLoadTransientBudgetBytes),
+		Doc: `Process-wide transient memory budget in bytes shared by scalar ` +
+			`index entry reading and storage v2 field-data loading. It gates ` +
+			`in-flight transient data across concurrent load tasks. Lower ` +
+			`values reduce peak transient memory at the cost of load throughput. ` +
+			`Oversized requests are still allowed to proceed exclusively to ` +
+			`guarantee progress. Set to 0 to disable the limit.`,
 		Export: true,
 		Formatter: func(v string) string {
 			if getAsInt64(v) < 0 {
-				log.Warn("common.entryStream.streamBudgetBytes must be non-negative, using unlimited",
+				log.Warn("common.loadTransientBudgetBytes must be non-negative, using unlimited",
 					zap.String("configured", v))
-				return strconv.Itoa(DefaultEntryStreamBudgetBytes)
+				return strconv.Itoa(DefaultLoadTransientBudgetBytes)
 			}
 			return v
 		},
 	}
-	p.StreamBudgetBytes.Init(base.mgr)
+	p.LoadTransientBudgetBytes.Init(base.mgr)
 
 	p.EnableMaterializedView = ParamItem{
 		Key:          "common.materializedView.enabled",
@@ -3669,8 +3669,7 @@ type queryNodeConfig struct {
 
 	// Target average byte size per storage v2 cache cell. Parquet row groups
 	// are packed into cells so rgs_per_cell * avg_rg_size ≈ this value.
-	StorageV2CellTargetSizeBytes      ParamItem `refreshable:"true"`
-	StorageV2FieldDataLoadBudgetBytes ParamItem `refreshable:"true"`
+	StorageV2CellTargetSizeBytes ParamItem `refreshable:"true"`
 
 	EnableWorkerSQCostMetrics ParamItem `refreshable:"true"`
 
@@ -4851,27 +4850,6 @@ user-task-polling:
 		},
 	}
 	p.StorageV2CellTargetSizeBytes.Init(base.mgr)
-
-	p.StorageV2FieldDataLoadBudgetBytes = ParamItem{
-		Key:          "queryNode.segcore.storageV2.fieldDataLoadBudgetBytes",
-		Version:      "3.0.0",
-		DefaultValue: strconv.Itoa(DefaultStorageV2FieldDataLoadBudgetBytes),
-		Doc: `Process-wide transient memory budget in bytes for storage v2 ` +
-			`field-data loading. It gates in-flight Arrow data across concurrent ` +
-			`load tasks. Lower values reduce peak transient memory at the cost of ` +
-			`load throughput. Oversized cells are still allowed to proceed ` +
-			`exclusively to guarantee progress. Default 128 MiB.`,
-		Export: true,
-		Formatter: func(v string) string {
-			if getAsInt64(v) <= 0 {
-				log.Warn("queryNode.segcore.storageV2.fieldDataLoadBudgetBytes must be positive, using default 128 MiB",
-					zap.String("configured", v))
-				return strconv.Itoa(DefaultStorageV2FieldDataLoadBudgetBytes)
-			}
-			return v
-		},
-	}
-	p.StorageV2FieldDataLoadBudgetBytes.Init(base.mgr)
 
 	p.EnableWorkerSQCostMetrics = ParamItem{
 		Key:          "queryNode.enableWorkerSQCostMetrics",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -571,8 +571,8 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export: true,
 		Formatter: func(v string) string {
 			if getAsInt64(v) < 0 {
-				log.Warn("common.loadTransientBudgetBytes must be non-negative, using unlimited",
-					zap.String("configured", v))
+				mlog.Warn(context.TODO(), "common.loadTransientBudgetBytes must be non-negative, using unlimited",
+					mlog.String("configured", v))
 				return strconv.Itoa(DefaultLoadTransientBudgetBytes)
 			}
 			return v

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -51,6 +51,10 @@ const (
 	DefaultLowPriorityThreadCoreCoefficient    = 1
 	DefaultBM25LoadThreadCoreCoefficient       = 1
 	DefaultThreadPoolMaxThreadsSize            = 16
+	DefaultFieldDataLoadMemoryLimitMB          = 128
+	DefaultFieldDataLoadBatchSizeMB            = 32
+	DefaultFieldDataLoadReadBufferSizeMB       = 16
+	DefaultFieldDataLoadMaxReadParallelism     = 8
 
 	DefaultSessionTTL        = 15 // s
 	DefaultSessionRetryTimes = 30
@@ -238,6 +242,10 @@ type commonConfig struct {
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`
 	BM25LoadThreadCoreCoefficient       ParamItem `refreshable:"true"`
 	ThreadPoolMaxThreadsSize            ParamItem `refreshable:"true"`
+	FieldDataLoadMemoryLimitMB          ParamItem `refreshable:"true"`
+	FieldDataLoadBatchSizeMB            ParamItem `refreshable:"true"`
+	FieldDataLoadReadBufferSizeMB       ParamItem `refreshable:"true"`
+	FieldDataLoadMaxReadParallelism     ParamItem `refreshable:"true"`
 	ArrowIOThreadPoolCoefficient        ParamItem `refreshable:"true"`
 	ArrowIOThreadPoolMaxCapacity        ParamItem `refreshable:"true"`
 	ArrowReaderHoleSizeLimitBytes       ParamItem `refreshable:"true"`
@@ -724,6 +732,42 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export:       true,
 	}
 	p.ThreadPoolMaxThreadsSize.Init(base.mgr)
+
+	p.FieldDataLoadMemoryLimitMB = ParamItem{
+		Key:          "common.fieldDataLoad.memoryLimitMB",
+		Version:      "3.0.0",
+		DefaultValue: strconv.Itoa(DefaultFieldDataLoadMemoryLimitMB),
+		Doc:          "Global transient memory budget for concurrent field data loading in MB",
+		Export:       true,
+	}
+	p.FieldDataLoadMemoryLimitMB.Init(base.mgr)
+
+	p.FieldDataLoadBatchSizeMB = ParamItem{
+		Key:          "common.fieldDataLoad.batchSizeMB",
+		Version:      "3.0.0",
+		DefaultValue: strconv.Itoa(DefaultFieldDataLoadBatchSizeMB),
+		Doc:          "Target size for grouping field data cells into one load batch in MB",
+		Export:       true,
+	}
+	p.FieldDataLoadBatchSizeMB.Init(base.mgr)
+
+	p.FieldDataLoadReadBufferSizeMB = ParamItem{
+		Key:          "common.fieldDataLoad.readBufferSizeMB",
+		Version:      "3.0.0",
+		DefaultValue: strconv.Itoa(DefaultFieldDataLoadReadBufferSizeMB),
+		Doc:          "Per-reader buffer/window size for field data loading in MB",
+		Export:       true,
+	}
+	p.FieldDataLoadReadBufferSizeMB.Init(base.mgr)
+
+	p.FieldDataLoadMaxReadParallelism = ParamItem{
+		Key:          "common.fieldDataLoad.maxReadParallelism",
+		Version:      "3.0.0",
+		DefaultValue: strconv.Itoa(DefaultFieldDataLoadMaxReadParallelism),
+		Doc:          "Maximum read parallelism within one field data load batch",
+		Export:       true,
+	}
+	p.FieldDataLoadMaxReadParallelism.Init(base.mgr)
 
 	p.ArrowIOThreadPoolCoefficient = ParamItem{
 		Key:          "common.arrow.ioThreadPoolCoefficient",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -79,9 +79,12 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, Params.IndexSliceSize.GetAsInt64(), int64(DefaultIndexSliceSize))
 		t.Logf("knowhere index slice size = %d", Params.IndexSliceSize.GetAsInt64())
 
-		assert.InDelta(t, DefaultStreamBudgetRatio, Params.StreamBudgetRatio.GetAsFloat(), 0.0001)
-		params.Save(Params.StreamBudgetRatio.Key, "2.5")
-		assert.InDelta(t, 2.5, Params.StreamBudgetRatio.GetAsFloat(), 0.0001)
+		defer params.Reset(Params.StreamBudgetBytes.Key)
+		assert.Equal(t, int64(DefaultEntryStreamBudgetBytes), Params.StreamBudgetBytes.GetAsInt64())
+		params.Save(Params.StreamBudgetBytes.Key, "-1")
+		assert.Equal(t, int64(DefaultEntryStreamBudgetBytes), Params.StreamBudgetBytes.GetAsInt64())
+		params.Save(Params.StreamBudgetBytes.Key, "67108864")
+		assert.Equal(t, int64(67108864), Params.StreamBudgetBytes.GetAsInt64())
 
 		assert.Equal(t, int64(0), Params.ArrowReaderHoleSizeLimitBytes.GetAsInt64())
 		assert.Equal(t, int64(0), Params.ArrowReaderRangeSizeLimitBytes.GetAsInt64())

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -79,12 +79,12 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, Params.IndexSliceSize.GetAsInt64(), int64(DefaultIndexSliceSize))
 		t.Logf("knowhere index slice size = %d", Params.IndexSliceSize.GetAsInt64())
 
-		defer params.Reset(Params.StreamBudgetBytes.Key)
-		assert.Equal(t, int64(DefaultEntryStreamBudgetBytes), Params.StreamBudgetBytes.GetAsInt64())
-		params.Save(Params.StreamBudgetBytes.Key, "-1")
-		assert.Equal(t, int64(DefaultEntryStreamBudgetBytes), Params.StreamBudgetBytes.GetAsInt64())
-		params.Save(Params.StreamBudgetBytes.Key, "67108864")
-		assert.Equal(t, int64(67108864), Params.StreamBudgetBytes.GetAsInt64())
+		defer params.Reset(Params.LoadTransientBudgetBytes.Key)
+		assert.Equal(t, int64(DefaultLoadTransientBudgetBytes), Params.LoadTransientBudgetBytes.GetAsInt64())
+		params.Save(Params.LoadTransientBudgetBytes.Key, "-1")
+		assert.Equal(t, int64(DefaultLoadTransientBudgetBytes), Params.LoadTransientBudgetBytes.GetAsInt64())
+		params.Save(Params.LoadTransientBudgetBytes.Key, "67108864")
+		assert.Equal(t, int64(67108864), Params.LoadTransientBudgetBytes.GetAsInt64())
 
 		assert.Equal(t, int64(0), Params.ArrowReaderHoleSizeLimitBytes.GetAsInt64())
 		assert.Equal(t, int64(0), Params.ArrowReaderRangeSizeLimitBytes.GetAsInt64())
@@ -494,13 +494,6 @@ func TestComponentParam(t *testing.T) {
 		// test query side config
 		chunkRows := Params.ChunkRows.GetAsInt64()
 		assert.Equal(t, int64(128), chunkRows)
-		defer params.Reset(Params.StorageV2FieldDataLoadBudgetBytes.Key)
-		assert.Equal(t, int64(DefaultStorageV2FieldDataLoadBudgetBytes), Params.StorageV2FieldDataLoadBudgetBytes.GetAsInt64())
-		params.Save(Params.StorageV2FieldDataLoadBudgetBytes.Key, "0")
-		assert.Equal(t, int64(DefaultStorageV2FieldDataLoadBudgetBytes), Params.StorageV2FieldDataLoadBudgetBytes.GetAsInt64())
-		params.Save(Params.StorageV2FieldDataLoadBudgetBytes.Key, "67108864")
-		assert.Equal(t, int64(67108864), Params.StorageV2FieldDataLoadBudgetBytes.GetAsInt64())
-
 		nlist := Params.InterimIndexNlist.GetAsInt64()
 		assert.Equal(t, int64(128), nlist)
 

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -491,6 +491,12 @@ func TestComponentParam(t *testing.T) {
 		// test query side config
 		chunkRows := Params.ChunkRows.GetAsInt64()
 		assert.Equal(t, int64(128), chunkRows)
+		defer params.Reset(Params.StorageV2FieldDataLoadBudgetBytes.Key)
+		assert.Equal(t, int64(DefaultStorageV2FieldDataLoadBudgetBytes), Params.StorageV2FieldDataLoadBudgetBytes.GetAsInt64())
+		params.Save(Params.StorageV2FieldDataLoadBudgetBytes.Key, "0")
+		assert.Equal(t, int64(DefaultStorageV2FieldDataLoadBudgetBytes), Params.StorageV2FieldDataLoadBudgetBytes.GetAsInt64())
+		params.Save(Params.StorageV2FieldDataLoadBudgetBytes.Key, "67108864")
+		assert.Equal(t, int64(67108864), Params.StorageV2FieldDataLoadBudgetBytes.GetAsInt64())
 
 		nlist := Params.InterimIndexNlist.GetAsInt64()
 		assert.Equal(t, int64(128), nlist)


### PR DESCRIPTION
- Replace `common.entryStream.streamBudgetRatio` with refreshable `common.loadTransientBudgetBytes`, a process-wide transient load budget shared by scalar index V3 entry streaming and storage v2/v3 field-data loading. `0` keeps the limit disabled.
- Gate field-data batch reads on the shared budget, split batches by loading overhead, scale read parallelism from the effective batch budget, and finalize `GroupChunk` cells before pushing them so Arrow tables are released promptly.
- Align MCL loading-overhead reservations for storage v1 scalar indexes and storage v2/v3 field data under one load-transient overhead group, with array-field overhead and mmap file usage accounted separately.
- Propagate load cancellation into budget waits, field-data batch tasks, and V3 scalar `IndexEntryReader` stream/file reads so canceled loads do not stay blocked behind transient memory pressure.
- Update segcore init/config watchers and add C++/Go coverage for budget sizing, cancellation, field-data batching/finalization, V3 entry streaming, and the new config.

issue: #49499
