### PR TITLE
fix: handle nullable vector array offsets by logical rows

### DIFF
--- a/internal/core/src/common/Chunk.h
+++ b/internal/core/src/common/Chunk.h
@@ -520,27 +520,14 @@ class VectorArrayChunk : public Chunk {
         : Chunk(row_nums, data, size, nullable, chunk_mmap_guard),
           dim_(dim),
           element_type_(element_type) {
-        if (nullable_) {
-            logical_to_physical_.reserve(row_nums_);
-            for (int64_t i = 0; i < row_nums_; i++) {
-                if (valid_[i]) {
-                    logical_to_physical_.push_back(physical_row_nums_++);
-                } else {
-                    logical_to_physical_.push_back(-1);
-                }
-            }
-        } else {
-            physical_row_nums_ = row_nums_;
-        }
-
         auto null_bitmap_bytes_num = nullable_ ? (row_nums_ + 7) / 8 : 0;
         offsets_lens_ =
             reinterpret_cast<uint32_t*>(data + null_bitmap_bytes_num);
 
         auto offset = 0;
-        offsets_.reserve(physical_row_nums_ + 1);
+        offsets_.reserve(row_nums_ + 1);
         offsets_.push_back(offset);
-        for (int64_t i = 0; i < physical_row_nums_; i++) {
+        for (int64_t i = 0; i < row_nums_; i++) {
             offset += offsets_lens_[i * 2 + 1];
             offsets_.push_back(offset);
         }
@@ -548,11 +535,14 @@ class VectorArrayChunk : public Chunk {
 
     VectorArrayView
     View(int64_t idx) const {
-        AssertInfo(idx >= 0 && idx < physical_row_nums_,
+        AssertInfo(idx >= 0 && idx < row_nums_,
                    "VectorArrayChunk::View offset {} out of range, "
-                   "physical rows {}",
+                   "rows {}",
                    idx,
-                   physical_row_nums_);
+                   row_nums_);
+        AssertInfo(!nullable_ || valid_[idx],
+                   "VectorArrayChunk::View offset {} is null",
+                   idx);
         int idx_off = 2 * idx;
         auto offset = offsets_lens_[idx_off];
         auto len = offsets_lens_[idx_off + 1];
@@ -596,7 +586,7 @@ class VectorArrayChunk : public Chunk {
         for (int64_t i = start_offset; i < end_offset; i++) {
             if (nullable_) {
                 if (valid_[i]) {
-                    views.emplace_back(View(logical_to_physical_[i]));
+                    views.emplace_back(View(i));
                 } else {
                     views.emplace_back();
                 }
@@ -632,9 +622,7 @@ class VectorArrayChunk : public Chunk {
     int64_t dim_;
     uint32_t* offsets_lens_;
     milvus::DataType element_type_;
-    int64_t physical_row_nums_ = 0;
     std::vector<size_t> offsets_;
-    std::vector<int64_t> logical_to_physical_;
 };
 
 class SparseFloatVectorChunk : public Chunk {

--- a/internal/core/src/common/ChunkWriter.cpp
+++ b/internal/core/src/common/ChunkWriter.cpp
@@ -336,7 +336,6 @@ ArrayChunkWriter::write_to_target(const arrow::ArrayVector& array_vec,
 std::pair<size_t, size_t>
 VectorArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
     size_t total_rows = 0;
-    size_t valid_rows = 0;
     size_t total_size = 0;
 
     for (const auto& array_data : array_vec) {
@@ -362,7 +361,6 @@ VectorArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
                     if (nullable_ && list_array->IsNull(i)) {
                         continue;
                     }
-                    valid_rows++;
                     actual_values_count +=
                         list_offsets[i + 1] - list_offsets[i];
                 }
@@ -377,14 +375,12 @@ VectorArrayChunkWriter::calculate_size(const arrow::ArrayVector& array_vec) {
     }
 
     row_nums_ = total_rows;
-    valid_row_nums_ = nullable_ ? valid_rows : total_rows;
 
     if (nullable_) {
         total_size += (total_rows + 7) / 8;
     }
-    // Add space for offset and length arrays.
-    total_size +=
-        sizeof(uint32_t) * (valid_row_nums_ * 2 + 1) + MMAP_ARRAY_PADDING;
+    // Add space for logical-row offset and length arrays.
+    total_size += sizeof(uint32_t) * (row_nums_ * 2 + 1) + MMAP_ARRAY_PADDING;
     return {total_size, total_rows};
 }
 
@@ -393,7 +389,7 @@ VectorArrayChunkWriter::write_to_target(
     const arrow::ArrayVector& array_vec,
     const std::shared_ptr<ChunkTarget>& target) {
     std::vector<uint32_t> offsets_lens;
-    offsets_lens.reserve(valid_row_nums_ * 2 + 1);
+    offsets_lens.reserve(row_nums_ * 2 + 1);
     std::vector<const uint8_t*> vector_data_ptrs;
     std::vector<size_t> data_sizes;
 
@@ -409,7 +405,7 @@ VectorArrayChunkWriter::write_to_target(
 
     uint32_t current_offset =
         (nullable_ ? static_cast<uint32_t>((row_nums_ + 7) / 8) : 0) +
-        sizeof(uint32_t) * (valid_row_nums_ * 2 + 1);
+        sizeof(uint32_t) * (row_nums_ * 2 + 1);
 
     for (const auto& array_data : array_vec) {
         auto list_array =
@@ -424,6 +420,8 @@ VectorArrayChunkWriter::write_to_target(
         // Each list contains multiple vectors, each stored as a fixed-size binary chunk
         for (int64_t i = 0; i < list_array->length(); i++) {
             if (nullable_ && list_array->IsNull(i)) {
+                offsets_lens.push_back(current_offset);
+                offsets_lens.push_back(0);
                 continue;
             }
             auto start_idx = list_offsets[i];

--- a/internal/core/src/common/ChunkWriter.h
+++ b/internal/core/src/common/ChunkWriter.h
@@ -311,7 +311,6 @@ class VectorArrayChunkWriter : public ChunkWriterBase {
 
  private:
     const milvus::DataType element_type_;
-    size_t valid_row_nums_ = 0;
 };
 
 class SparseFloatVectorChunkWriter : public ChunkWriterBase {

--- a/internal/core/src/common/ChunkWriterTest.cpp
+++ b/internal/core/src/common/ChunkWriterTest.cpp
@@ -405,21 +405,20 @@ TEST_P(VectorArrayChunkWriterParameterizedTest, SizeConsistencyWithSlice) {
 TEST(VectorArrayChunkWriterTest, NullableRowsRoundTripThroughChunkViews) {
     constexpr int dim = 2;
     auto list_array =
-        BuildNullableFloatVectorArrayListArray({1, std::nullopt, 2}, dim);
-    ASSERT_EQ(list_array->length(), 3);
+        BuildNullableFloatVectorArrayListArray({1, std::nullopt, 0, 2}, dim);
+    ASSERT_EQ(list_array->length(), 4);
     ASSERT_EQ(list_array->null_count(), 1);
 
     arrow::ArrayVector vec{list_array};
     VectorArrayChunkWriter writer(dim, DataType::VECTOR_FLOAT, true);
     auto [calculated_size, row_count] = writer.calculate_size(vec);
 
-    const int expected_valid_rows = 2;
     const int expected_vectors = 3;
     const int expected_size =
-        (row_count + 7) / 8 + sizeof(uint32_t) * (expected_valid_rows * 2 + 1) +
+        (row_count + 7) / 8 + sizeof(uint32_t) * (row_count * 2 + 1) +
         expected_vectors * dim * sizeof(float) + MMAP_ARRAY_PADDING;
     EXPECT_EQ(calculated_size, expected_size);
-    EXPECT_EQ(row_count, 3);
+    EXPECT_EQ(row_count, 4);
 
     auto target = std::make_shared<MemChunkTarget>(calculated_size);
     writer.write_to_target(vec, target);
@@ -433,14 +432,26 @@ TEST(VectorArrayChunkWriterTest, NullableRowsRoundTripThroughChunkViews) {
                            nullptr,
                            true);
     auto [views, valid] = chunk.Views();
-    ASSERT_EQ(views.size(), 3);
-    ASSERT_EQ(valid.size(), 3);
+    ASSERT_EQ(views.size(), 4);
+    ASSERT_EQ(valid.size(), 4);
     EXPECT_TRUE(valid[0]);
     EXPECT_FALSE(valid[1]);
     EXPECT_TRUE(valid[2]);
+    EXPECT_TRUE(valid[3]);
     EXPECT_EQ(views[0].length(), 1);
     EXPECT_EQ(views[1].length(), 0);
-    EXPECT_EQ(views[2].length(), 2);
+    EXPECT_EQ(views[2].length(), 0);
+    EXPECT_EQ(views[3].length(), 2);
+
+    const auto* offsets = chunk.Offsets();
+    EXPECT_EQ(offsets[0], 0);
+    EXPECT_EQ(offsets[1], 1);
+    EXPECT_EQ(offsets[2], 1);
+    EXPECT_EQ(offsets[3], 1);
+    EXPECT_EQ(offsets[4], 3);
+
+    EXPECT_ANY_THROW(chunk.View(1));
+    EXPECT_EQ(chunk.View(2).length(), 0);
 }
 
 // Instantiate parameterized tests for all vector types

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -711,9 +711,6 @@ class ChunkedVectorArrayColumn : public ChunkedColumnBase {
             auto chunk =
                 static_cast<VectorArrayChunk*>(ca->get_cell_of(cids[i]));
             auto offset = offsets_in_chunk[i];
-            if (nullable_) {
-                offset = chunk->PhysicalOffsetOf(offset);
-            }
             auto array = chunk->View(offset).output_data();
             fn(std::move(array), i);
         }

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -706,9 +706,6 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
             auto* group_chunk = ca->get_cell_of(cids[i]);
             auto chunk = group_chunk->GetChunk(field_id_);
             auto offset = offsets_in_chunk[i];
-            if (field_meta_.is_nullable()) {
-                offset = chunk->PhysicalOffsetOf(offset);
-            }
             auto array = static_cast<VectorArrayChunk*>(chunk.get())
                              ->View(offset)
                              .output_data();

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstring>
 #include <iterator>
 #include <memory>
@@ -35,6 +36,9 @@ namespace {
 
 constexpr int32_t kElementSize = 4;
 constexpr int64_t kTestFieldId = 1;
+constexpr int64_t kVectorArrayFieldId = 2;
+constexpr int64_t kVectorArrayRows = 4;
+constexpr int64_t kVectorArrayDim = 2;
 
 struct ColumnFixture {
     std::shared_ptr<ChunkedColumnInterface> column;
@@ -47,6 +51,11 @@ struct ColumnSpec {
     std::vector<int64_t> rows_per_chunk;
     std::vector<std::vector<bool>> valid_patterns;  // empty => all valid
     bool nullable{true};
+};
+
+struct VectorArrayColumnFixture {
+    std::shared_ptr<ChunkedColumnInterface> column;
+    std::shared_ptr<void> buffer_holder;
 };
 
 std::vector<char>
@@ -81,11 +90,58 @@ BuildChunkBuffer(int64_t row_num,
     return buf;
 }
 
+std::vector<char>
+BuildNullableVectorArrayChunkBuffer() {
+    const auto bitmap_bytes = (kVectorArrayRows + 7) / 8;
+    const auto header_bytes = sizeof(uint32_t) * (kVectorArrayRows * 2 + 1);
+    const std::array<float, 6> payload{1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F};
+    const auto payload_bytes = payload.size() * sizeof(float);
+
+    std::vector<char> buf(
+        bitmap_bytes + header_bytes + payload_bytes + MMAP_ARRAY_PADDING, 0);
+    buf[0] = 0b00001101;  // rows 0, 2, and 3 are valid; row 1 is null.
+
+    const auto payload_offset =
+        static_cast<uint32_t>(bitmap_bytes + header_bytes);
+    const auto row0_end =
+        payload_offset + static_cast<uint32_t>(kVectorArrayDim * sizeof(float));
+    const auto row3_end =
+        row0_end + static_cast<uint32_t>(2 * kVectorArrayDim * sizeof(float));
+    const std::array<uint32_t, kVectorArrayRows * 2 + 1> header{
+        payload_offset,
+        1,
+        row0_end,
+        0,
+        row0_end,
+        0,
+        row0_end,
+        2,
+        row3_end,
+    };
+    std::memcpy(buf.data() + bitmap_bytes,
+                header.data(),
+                header.size() * sizeof(uint32_t));
+    std::memcpy(buf.data() + payload_offset, payload.data(), payload_bytes);
+    return buf;
+}
+
 std::unique_ptr<FixedWidthChunk>
 MakeFixedChunk(int64_t row_num, bool nullable, char* data, size_t size) {
     auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
     return std::make_unique<FixedWidthChunk>(
         row_num, 1, data, size, kElementSize, nullable, guard);
+}
+
+std::unique_ptr<VectorArrayChunk>
+MakeVectorArrayChunk(char* data, size_t size) {
+    auto guard = std::make_shared<ChunkMmapGuard>(nullptr, 0, "");
+    return std::make_unique<VectorArrayChunk>(kVectorArrayDim,
+                                              kVectorArrayRows,
+                                              data,
+                                              size,
+                                              DataType::VECTOR_FLOAT,
+                                              guard,
+                                              /*nullable=*/true);
 }
 
 class CountingChunkTranslator : public TestChunkTranslator {
@@ -226,6 +282,66 @@ struct ProxyChunkColumnFactory {
     }
 };
 
+struct ChunkedVectorArrayColumnFactory {
+    static VectorArrayColumnFixture
+    Create() {
+        auto buffers = std::make_shared<std::vector<std::vector<char>>>(1);
+        (*buffers)[0] = BuildNullableVectorArrayChunkBuffer();
+        std::vector<std::unique_ptr<Chunk>> chunks;
+        chunks.push_back(
+            MakeVectorArrayChunk((*buffers)[0].data(), (*buffers)[0].size()));
+
+        auto translator = std::make_unique<TestChunkTranslator>(
+            std::vector<int64_t>{kVectorArrayRows},
+            "cc_vector_array_iface",
+            std::move(chunks));
+        FieldMeta fm(FieldName("va"),
+                     FieldId(kVectorArrayFieldId),
+                     DataType::VECTOR_ARRAY,
+                     kVectorArrayDim,
+                     knowhere::metric::L2,
+                     /*nullable=*/true,
+                     std::nullopt);
+        auto slot = cachinglayer::Manager::GetInstance().CreateCacheSlot<Chunk>(
+            std::move(translator), nullptr);
+        auto column =
+            MakeChunkedColumnBase(DataType::VECTOR_ARRAY, std::move(slot), fm);
+        return {column, std::static_pointer_cast<void>(buffers)};
+    }
+};
+
+struct ProxyVectorArrayColumnFactory {
+    static VectorArrayColumnFixture
+    Create() {
+        auto buffers = std::make_shared<std::vector<std::vector<char>>>(1);
+        (*buffers)[0] = BuildNullableVectorArrayChunkBuffer();
+        std::unordered_map<FieldId, std::shared_ptr<Chunk>> fields;
+        fields[FieldId(kVectorArrayFieldId)] =
+            MakeVectorArrayChunk((*buffers)[0].data(), (*buffers)[0].size());
+
+        std::vector<std::unique_ptr<GroupChunk>> group_chunks;
+        group_chunks.push_back(std::make_unique<GroupChunk>(fields));
+        auto translator = std::make_unique<TestGroupChunkTranslator>(
+            /*num_fields=*/1,
+            std::vector<int64_t>{kVectorArrayRows},
+            "pcc_vector_array_iface",
+            std::move(group_chunks));
+        auto group =
+            std::make_shared<ChunkedColumnGroup>(std::move(translator));
+        FieldMeta fm(FieldName("va"),
+                     FieldId(kVectorArrayFieldId),
+                     DataType::VECTOR_ARRAY,
+                     kVectorArrayDim,
+                     knowhere::metric::L2,
+                     /*nullable=*/true,
+                     std::nullopt);
+        auto column = std::make_shared<ProxyChunkColumn>(
+            group, FieldId(kVectorArrayFieldId), fm);
+        return {std::static_pointer_cast<ChunkedColumnInterface>(column),
+                std::static_pointer_cast<void>(buffers)};
+    }
+};
+
 }  // namespace
 
 template <typename Factory>
@@ -340,6 +456,52 @@ TYPED_TEST(ChunkedColumnInterfaceTest,
                      nullptr, &value, null_offset, kElementSize, 1),
                  std::exception);
     EXPECT_FALSE(fx.column->GetOffsetMapping().IsEnabled());
+}
+
+template <typename Factory>
+class VectorArrayColumnInterfaceTest : public ::testing::Test {};
+
+using VectorArrayFactories = ::testing::Types<ChunkedVectorArrayColumnFactory,
+                                              ProxyVectorArrayColumnFactory>;
+TYPED_TEST_SUITE(VectorArrayColumnInterfaceTest, VectorArrayFactories);
+
+TYPED_TEST(VectorArrayColumnInterfaceTest,
+           BulkVectorArrayAtUsesLogicalOffsetsForNullableRows) {
+    auto fx = TypeParam::Create();
+
+    const int64_t offsets[] = {0, 2, 3};
+    std::vector<VectorFieldProto> values(std::size(offsets));
+    fx.column->BulkVectorArrayAt(
+        nullptr,
+        [&](VectorFieldProto&& value, size_t i) {
+            values[i] = std::move(value);
+        },
+        offsets,
+        std::size(offsets));
+
+    ASSERT_EQ(values[0].float_vector().data().size(), 2);
+    EXPECT_FLOAT_EQ(values[0].float_vector().data(0), 1.0F);
+    EXPECT_FLOAT_EQ(values[0].float_vector().data(1), 2.0F);
+    EXPECT_EQ(values[1].float_vector().data().size(), 0);
+    ASSERT_EQ(values[2].float_vector().data().size(), 4);
+    EXPECT_FLOAT_EQ(values[2].float_vector().data(0), 3.0F);
+    EXPECT_FLOAT_EQ(values[2].float_vector().data(1), 4.0F);
+    EXPECT_FLOAT_EQ(values[2].float_vector().data(2), 5.0F);
+    EXPECT_FLOAT_EQ(values[2].float_vector().data(3), 6.0F);
+
+    bool valid = true;
+    fx.column->BulkIsValid(
+        nullptr,
+        [&](bool is_valid, size_t) { valid = is_valid; },
+        offsets + 1,
+        1);
+    EXPECT_TRUE(valid);
+
+    const int64_t null_offset[] = {1};
+    EXPECT_THROW(
+        fx.column->BulkVectorArrayAt(
+            nullptr, [](VectorFieldProto&&, size_t) {}, null_offset, 1),
+        std::exception);
 }
 
 }  // namespace milvus

--- a/internal/core/unittest/test_element_filter.cpp
+++ b/internal/core/unittest/test_element_filter.cpp
@@ -3486,6 +3486,85 @@ MakeNullableElementSearchFixture() {
     return f;
 }
 
+inline bool
+IsBitmapRowValid(const std::vector<uint8_t>& valid_bitmap, int64_t row) {
+    return (valid_bitmap[row >> 3] >> (row & 0x07)) & 1;
+}
+
+inline std::vector<uint8_t>
+BuildFieldValidBitmap(const GeneratedData& data, FieldId field_id) {
+    const auto row_count = data.raw_->num_rows();
+    std::vector<uint8_t> valid_bitmap((row_count + 7) / 8, 0);
+    for (int i = 0; i < data.raw_->fields_data_size(); ++i) {
+        const auto& fd = data.raw_->fields_data(i);
+        if (fd.field_id() != field_id.get()) {
+            continue;
+        }
+        for (int row = 0; row < row_count; ++row) {
+            const bool valid =
+                fd.valid_data_size() == 0 ? true : fd.valid_data(row);
+            if (valid) {
+                valid_bitmap[row >> 3] |= (1 << (row & 0x07));
+            }
+        }
+        return valid_bitmap;
+    }
+    return valid_bitmap;
+}
+
+inline NullableElementSearchFixture
+MakeNullableElementSearchWithNullAndEmptyRowsFixture() {
+    constexpr int kRows = 3;
+    constexpr int kTargetRow = 2;
+    constexpr int kTargetElem = 0;
+
+    NullableElementSearchFixture f;
+    f.schema = std::make_shared<Schema>();
+    f.vec_fid = f.schema->AddDebugVectorArrayField("structA[array_vec]",
+                                                   DataType::VECTOR_FLOAT,
+                                                   kNullableElemDim,
+                                                   knowhere::metric::L2,
+                                                   /*nullable=*/true);
+    f.int64_fid = f.schema->AddDebugField("id", DataType::INT64);
+    f.schema->set_primary_field_id(f.int64_fid);
+
+    f.raw_data = DataGen(f.schema, kRows, 42, 0, 1, kNullableElemArrayLen);
+
+    for (int i = 0; i < f.raw_data.raw_->fields_data_size(); ++i) {
+        auto* fd = f.raw_data.raw_->mutable_fields_data(i);
+        if (fd->field_id() != f.vec_fid.get()) {
+            continue;
+        }
+
+        auto* vec_array = fd->mutable_vectors()->mutable_vector_array();
+        for (int row = 0; row < kRows; ++row) {
+            vec_array->mutable_data(row)
+                ->mutable_float_vector()
+                ->mutable_data()
+                ->Clear();
+        }
+
+        auto* target_row = vec_array->mutable_data(kTargetRow)
+                               ->mutable_float_vector()
+                               ->mutable_data();
+        const std::array<float, kNullableElemArrayLen * kNullableElemDim>
+            target_values{7.0F, 7.0F, 7.0F, 7.0F, 1.0F, 0.0F, 0.0F, 0.0F};
+        target_row->Add(target_values.begin(), target_values.end());
+
+        auto* valid_data = fd->mutable_valid_data();
+        valid_data->Clear();
+        valid_data->Add(false);  // row 0: null
+        valid_data->Add(true);   // row 1: empty
+        valid_data->Add(true);   // row 2: two vectors
+        break;
+    }
+
+    f.flat_data = {7.0F, 7.0F, 7.0F, 7.0F, 1.0F, 0.0F, 0.0F, 0.0F};
+    f.query_data.assign(f.flat_data.begin(),
+                        f.flat_data.begin() + kNullableElemDim);
+    return f;
+}
+
 inline proto::common::PlaceholderGroup
 MakeElementLevelPlaceholder(const std::vector<float>& query_data) {
     auto raw = CreatePlaceholderGroupFromBlob<milvus::FloatVector>(
@@ -3520,23 +3599,23 @@ CreateNullableSealedSegment(const NullableElementSearchFixture& f) {
         f.raw_data, segment.get(), false, GetExcludedFieldIds(f.schema, {}));
 
     auto vec_array_values = f.raw_data.get_col<VectorFieldProto>(f.vec_fid);
+    auto valid_bitmap = BuildFieldValidBitmap(f.raw_data, f.vec_fid);
     std::vector<milvus::VectorArray> vector_arrays;
     vector_arrays.reserve(vec_array_values.size());
-    for (const auto& value : vec_array_values) {
-        vector_arrays.emplace_back(value);
-    }
-
-    std::vector<uint8_t> valid_bitmap((kNullableElemN + 7) / 8, 0);
-    for (int row = 0; row < kNullableElemN; ++row) {
-        valid_bitmap[row >> 3] |= (1 << (row & 0x07));
+    for (int64_t row = 0; row < f.raw_data.raw_->num_rows(); ++row) {
+        if (IsBitmapRowValid(valid_bitmap, row)) {
+            vector_arrays.emplace_back(vec_array_values[row]);
+        }
     }
 
     auto field_data = storage::CreateFieldData(DataType::VECTOR_ARRAY,
                                                DataType::VECTOR_FLOAT,
                                                /*nullable=*/true,
                                                kNullableElemDim);
-    field_data->FillFieldData(
-        vector_arrays.data(), valid_bitmap.data(), kNullableElemN, 0);
+    field_data->FillFieldData(vector_arrays.data(),
+                              valid_bitmap.data(),
+                              f.raw_data.raw_->num_rows(),
+                              0);
 
     auto storage_config = gen_local_storage_config(TestLocalPath);
     auto cm = CreateChunkManager(storage_config);
@@ -3564,6 +3643,33 @@ LoadNullableElementFlatIndex(SegmentSealed* segment,
         valid_rows[row] = true;
     }
     indexing->BuildValidData(valid_rows.get(), kNullableElemN);
+
+    LoadIndexInfo load_index_info;
+    load_index_info.field_id = vec_fid.get();
+    load_index_info.index_params = GenIndexParams(indexing.get());
+    load_index_info.cache_index =
+        CreateTestCacheIndex("test", std::move(indexing));
+    load_index_info.index_params["metric_type"] = knowhere::metric::L2;
+    load_index_info.field_type = DataType::VECTOR_ARRAY;
+    load_index_info.element_type = DataType::VECTOR_FLOAT;
+    segment->LoadIndex(load_index_info);
+}
+
+inline void
+LoadNullableElementFlatIndexWithValidRows(SegmentSealed* segment,
+                                          FieldId vec_fid,
+                                          const std::vector<float>& flat_data,
+                                          const std::vector<bool>& valid_rows) {
+    auto indexing = GenVecIndexing(flat_data.size() / kNullableElemDim,
+                                   kNullableElemDim,
+                                   flat_data.data(),
+                                   knowhere::IndexEnum::INDEX_FAISS_IDMAP);
+
+    std::unique_ptr<bool[]> valid_data(new bool[valid_rows.size()]);
+    for (size_t row = 0; row < valid_rows.size(); ++row) {
+        valid_data[row] = valid_rows[row];
+    }
+    indexing->BuildValidData(valid_data.get(), valid_rows.size());
 
     LoadIndexInfo load_index_info;
     load_index_info.field_id = vec_fid.get();
@@ -3671,6 +3777,17 @@ ExpectNullableTargetTopOne(const milvus::SearchResult& sr) {
     ASSERT_NEAR(sr.distances_[0], 0.0f, 1e-5f);
 }
 
+inline void
+ExpectTopOne(const milvus::SearchResult& sr,
+             int64_t expected_doc,
+             int32_t expected_elem) {
+    ASSERT_TRUE(sr.element_level_);
+    ASSERT_FALSE(sr.seg_offsets_.empty());
+    ASSERT_EQ(sr.seg_offsets_[0], expected_doc);
+    ASSERT_EQ(sr.element_indices_[0], expected_elem);
+    ASSERT_NEAR(sr.distances_[0], 0.0f, 1e-5f);
+}
+
 }  // namespace
 
 TEST(ElementVectorSearch, NullableSealedBruteForce_ElementBitset) {
@@ -3690,6 +3807,26 @@ TEST(ElementVectorSearch, NullableSealedIndex_ElementBitset) {
     auto sr = RunNullableElementSearch(segment.get(), f);
     ASSERT_NE(sr, nullptr);
     ExpectNullableTargetTopOne(*sr);
+}
+
+TEST(ElementVectorSearch, NullableSealedBruteForce_NullAndEmptyRows) {
+    auto f = MakeNullableElementSearchWithNullAndEmptyRowsFixture();
+    auto segment = CreateNullableSealedSegment(f);
+
+    auto sr = RunNullableElementSearch(segment.get(), f);
+    ASSERT_NE(sr, nullptr);
+    ExpectTopOne(*sr, /*expected_doc=*/2, /*expected_elem=*/0);
+}
+
+TEST(ElementVectorSearch, NullableSealedIndex_NullAndEmptyRows) {
+    auto f = MakeNullableElementSearchWithNullAndEmptyRowsFixture();
+    auto segment = CreateNullableSealedSegment(f);
+    LoadNullableElementFlatIndexWithValidRows(
+        segment.get(), f.vec_fid, f.flat_data, {false, true, true});
+
+    auto sr = RunNullableElementSearch(segment.get(), f);
+    ASSERT_NE(sr, nullptr);
+    ExpectTopOne(*sr, /*expected_doc=*/2, /*expected_elem=*/0);
 }
 
 TEST(ElementVectorSearch, NullableGrowingBruteForce_ElementBitset) {


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/50461
ref: https://github.com/milvus-io/milvus/issues/42148

Issue: nullable VectorArray chunks store non-null rows in a compact physical layout, so logical row indexes can diverge from physical row indexes when missing/null rows exist. Some access paths use logical-to-physical translation when reading the vector-array data, but the offsets returned by VectorArrayOffsets() were still indexed by the compact physical layout. Sealed segment vector search used logical row indexes to read those offsets directly, without applying the same logical-to-physical translation. This could make it read the wrong row span or read past the valid offsets range, resulting in empty search results or std::bad_alloc.

Fix: build VectorArrayChunk offsets by logical row count instead of physical row count. The offsets array now has row_nums + 1 entries and can be indexed directly by logical row id. Null rows and empty rows both have a zero-length span, while the existing Chunk valid bitmap preserves the distinction between null and non-null empty rows.