### PR TITLE
test: Restore CSV nullable vector bulk writer coverage

### DIFF
--- a/tests/python_client/testcases/test_bulk_insert.py
+++ b/tests/python_client/testcases/test_bulk_insert.py
@@ -404,10 +404,7 @@ class TestBulkInsertNullableVector(TestcaseBaseBulkInsert):
         "file_type",
         [
             BulkFileType.JSON,
-            pytest.param(
-                BulkFileType.CSV,
-                marks=pytest.mark.skip(reason="CSV nullable FloatVector import currently parses empty value as string"),
-            ),
+            BulkFileType.CSV,
             BulkFileType.PARQUET,
         ],
     )
@@ -425,7 +422,6 @@ class TestBulkInsertNullableVector(TestcaseBaseBulkInsert):
 
         null_ids = []
         non_null_ids = []
-        writer_config = {"nullkey": "null"} if file_type == BulkFileType.CSV else None
         with RemoteBulkWriter(
             schema=schema,
             remote_path="bulk_data",
@@ -436,7 +432,6 @@ class TestBulkInsertNullableVector(TestcaseBaseBulkInsert):
                 secret_key="minioadmin",
             ),
             file_type=file_type,
-            config=writer_config,
             chunk_size=2048 if file_type == BulkFileType.PARQUET else 1024 * 1024 * 1024,
         ) as remote_writer:
             for i in range(entities):
@@ -458,8 +453,7 @@ class TestBulkInsertNullableVector(TestcaseBaseBulkInsert):
         if file_type == BulkFileType.PARQUET:
             assert len(files) > 1
         for files_in_batch in files:
-            import_kwargs = {"nullkey": "null"} if file_type == BulkFileType.CSV else {}
-            success, _ = self._import_files(c_name, files_in_batch, **import_kwargs)
+            success, _ = self._import_files(c_name, files_in_batch)
             assert success
         self._assert_nullable_float_vector_data(c_name, entities, null_ids, non_null_ids, dim)
 


### PR DESCRIPTION
## Summary

Restore the CSV branch in the nullable vector RemoteBulkWriter regression test.

This removes the previous skip and the explicit `nullkey="null"` workaround so the test now covers the default CSV import path for nullable `FLOAT_VECTOR` values.

Fixes #49678

## Test Plan

- [x] `/Users/yanliang.qiao/fork/.venv-py312/bin/python -m pytest testcases/test_bulk_insert.py::TestBulkInsertNullableVector::test_bulk_writer_nullable_float_vector --collect-only -q`
- [x] `/Users/yanliang.qiao/fork/.venv-py312/bin/python -m pytest -q -s 'testcases/test_bulk_insert.py::TestBulkInsertNullableVector::test_bulk_writer_nullable_float_vector[60-32-4]' --host 10.104.30.186 --port 19530 --minio_host 10.104.18.198 --minio_bucket yanliang-mas2`

Note: I also ran the full JSON/CSV/Parquet parametrized test against the same temporary cluster. JSON and CSV passed; the Parquet parameter later hit a `get_bulk_insert_state` RPC `DEADLINE_EXCEEDED` while polling import state, unrelated to this CSV regression change.
