### PR TITLE
enhance: [2.6] Add V3 entry streaming reader

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -938,6 +938,8 @@ common:
   defaultIndexName: _default_idx # Name of the index when it is created with name unspecified
   entityExpiration: -1 # Entity expiration in seconds, CAUTION -1 means never expire
   indexSliceSize: 16 # Index slice size in MB
+  entryStream:
+    streamBudgetRatio: 3 # Multiplier for entry stream transient memory budget, relative to CPU core count
   threadCoreCoefficient:
     highPriority: 10 # This parameter specify how many times the number of threads is the number of cores in high priority pool
     middlePriority: 5 # This parameter specify how many times the number of threads is the number of cores in middle priority pool

--- a/internal/core/src/common/Common.cpp
+++ b/internal/core/src/common/Common.cpp
@@ -17,11 +17,13 @@
 #include "common/Common.h"
 #include "gflags/gflags.h"
 #include "log/Log.h"
+#include "storage/EntryStreamUtils.h"
 #include "tantivy-binding.h"
 
 namespace milvus {
 
 std::atomic<int64_t> FILE_SLICE_SIZE(DEFAULT_INDEX_FILE_SLICE_SIZE);
+std::atomic<double> ENTRY_STREAM_BUDGET_RATIO(3.0);
 std::atomic<int64_t> EXEC_EVAL_EXPR_BATCH_SIZE(
     DEFAULT_EXEC_EVAL_EXPR_BATCH_SIZE);
 std::atomic<int64_t> DELETE_DUMP_BATCH_SIZE(DEFAULT_DELETE_DUMP_BATCH_SIZE);
@@ -38,6 +40,19 @@ void
 SetIndexSliceSize(const int64_t size) {
     FILE_SLICE_SIZE.store(size << 20);
     LOG_INFO("set config index slice size (byte): {}", FILE_SLICE_SIZE.load());
+}
+
+void
+SetStreamBudgetRatio(const double ratio) {
+    if (ratio <= 0) {
+        LOG_WARN("ignore invalid entry stream budget ratio: {}", ratio);
+        return;
+    }
+    ENTRY_STREAM_BUDGET_RATIO.store(ratio);
+    storage::TransientMemoryBudget::GetEntryStreamBudget()
+        .NotifyCapacityUpdated();
+    LOG_INFO("set entry stream budget ratio: {}",
+             ENTRY_STREAM_BUDGET_RATIO.load());
 }
 
 void

--- a/internal/core/src/common/Common.h
+++ b/internal/core/src/common/Common.h
@@ -26,6 +26,7 @@
 namespace milvus {
 
 extern std::atomic<int64_t> FILE_SLICE_SIZE;
+extern std::atomic<double> ENTRY_STREAM_BUDGET_RATIO;
 extern std::atomic<int64_t> EXEC_EVAL_EXPR_BATCH_SIZE;
 extern std::atomic<int64_t> DELETE_DUMP_BATCH_SIZE;
 extern std::atomic<bool> ENABLE_LATEST_DELETE_SNAPSHOT_OPTIMIZATION;
@@ -35,6 +36,9 @@ extern std::atomic<bool> CONFIG_PARAM_TYPE_CHECK_ENABLED;
 
 void
 SetIndexSliceSize(const int64_t size);
+
+void
+SetStreamBudgetRatio(const double ratio);
 
 void
 SetDefaultExecEvalExprBatchSize(int64_t val);

--- a/internal/core/src/common/init_c.cpp
+++ b/internal/core/src/common/init_c.cpp
@@ -41,6 +41,11 @@ SetIndexSliceSize(const int64_t size) {
 }
 
 void
+SetStreamBudgetRatio(const double ratio) {
+    milvus::SetStreamBudgetRatio(ratio);
+}
+
+void
 SetHighPriorityThreadCoreCoefficient(const float value) {
     milvus::SetHighPriorityThreadCoreCoefficient(value);
 }

--- a/internal/core/src/common/init_c.h
+++ b/internal/core/src/common/init_c.h
@@ -31,6 +31,9 @@ void
 SetIndexSliceSize(const int64_t);
 
 void
+SetStreamBudgetRatio(const double);
+
+void
 SetHighPriorityThreadCoreCoefficient(const float);
 
 void

--- a/internal/core/src/storage/EntryStreamUtils.h
+++ b/internal/core/src/storage/EntryStreamUtils.h
@@ -1,0 +1,141 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "common/Common.h"
+#include "common/EasyAssert.h"
+
+namespace milvus::storage {
+
+constexpr size_t kMinStreamSliceSize = 64 * 1024;
+
+inline size_t
+DefaultStreamSliceSize() {
+    return DEFAULT_INDEX_FILE_SLICE_SIZE;
+}
+
+inline double
+StreamBudgetRatio() {
+    auto ratio = milvus::ENTRY_STREAM_BUDGET_RATIO.load();
+    return ratio > 0 ? ratio : 1.0;
+}
+
+/// A slice read from a V3 entry. `error` carries an exception captured in
+/// the producer task so the consumer can rethrow instead of hanging.
+struct StreamSliceResult {
+    size_t budget_bytes{0};
+    std::vector<uint8_t> data;
+    std::exception_ptr error = nullptr;
+};
+
+/// Byte budget for transient data that has been submitted for async work but
+/// has not been consumed yet.
+///
+/// Usage:
+///   - Call Acquire(bytes) to block until budget is available.
+///   - Call TryAcquire(bytes) for non-blocking replenish in refill loops.
+///   - Call Release(bytes) after the transient data has been consumed.
+///   - Oversized requests are allowed to run exclusively to guarantee progress.
+class TransientMemoryBudget {
+ public:
+    static TransientMemoryBudget&
+    GetEntryStreamBudget() {
+        static TransientMemoryBudget instance;
+        return instance;
+    }
+
+    /// Block until enough budget is available. Safe to call when the calling
+    /// thread has no inflight tasks (no risk of deadlock with channel pop).
+    void
+    Acquire(size_t bytes) {
+        std::unique_lock<std::mutex> lock(mu_);
+        cv_.wait(lock, [this, bytes] { return CanAcquireLocked(bytes); });
+        inflight_bytes_ += bytes;
+    }
+
+    /// Try to claim budget. Returns true if under budget.
+    /// Used in the refill loop where blocking could cause deadlock.
+    bool
+    TryAcquire(size_t bytes) {
+        std::lock_guard<std::mutex> lock(mu_);
+        if (CanAcquireLocked(bytes)) {
+            inflight_bytes_ += bytes;
+            return true;
+        }
+        return false;
+    }
+
+    void
+    Release(size_t bytes) {
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            AssertInfo(bytes <= inflight_bytes_,
+                       "Transient memory budget over-release: release {}, "
+                       "inflight {}",
+                       bytes,
+                       inflight_bytes_);
+            inflight_bytes_ -= bytes;
+        }
+        cv_.notify_all();
+    }
+
+    size_t
+    CapacityBytes() const {
+        return EntryStreamBudgetBytes();
+    }
+
+    void
+    NotifyCapacityUpdated() {
+        cv_.notify_all();
+    }
+
+ private:
+    TransientMemoryBudget() = default;
+
+    static size_t
+    EntryStreamBudgetBytes() {
+        auto core_num = std::max(1, milvus::CPU_NUM);
+        auto capacity = static_cast<size_t>(core_num * StreamBudgetRatio()) *
+                        DefaultStreamSliceSize();
+        return std::max<size_t>(capacity, DefaultStreamSliceSize());
+    }
+
+    bool
+    CanAcquireLocked(size_t bytes) const {
+        auto capacity_bytes = CapacityBytes();
+        if (bytes > capacity_bytes) {
+            return inflight_bytes_ == 0;
+        }
+        return inflight_bytes_ <= capacity_bytes &&
+               bytes <= capacity_bytes - inflight_bytes_;
+    }
+
+    std::mutex mu_;
+    std::condition_variable cv_;
+    size_t inflight_bytes_{0};
+};
+
+}  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -23,17 +23,198 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <deque>
+#include <functional>
 #include <future>
+#include <limits>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "common/EasyAssert.h"
 #include "nlohmann/json.hpp"
+#include "storage/EntryStreamUtils.h"
 #include "storage/Crc32cUtil.h"
 #include "storage/PluginLoader.h"
 
 namespace milvus::storage {
+namespace {
+
+using SliceLoader = std::function<std::vector<uint8_t>(size_t seq)>;
+using SliceBudgetBytes = std::function<size_t(size_t seq)>;
+
+struct ActiveSliceTask {
+    size_t budget_bytes{0};
+    std::shared_ptr<StreamSliceResult> result;
+    std::future<void> future;
+};
+
+void
+ReadOrderedEntryStream(
+    size_t num_slices,
+    uint32_t expected_crc,
+    const std::string& crc_error_context,
+    ThreadPoolPriority priority,
+    const std::function<void(const uint8_t* data, size_t len)>& slice_consumer,
+    const SliceBudgetBytes& slice_budget_bytes,
+    const SliceLoader& load_slice) {
+    if (num_slices == 0) {
+        auto actual_crc = Crc32cValue(nullptr, 0);
+        AssertInfo(actual_crc == expected_crc,
+                   "{}: expected {}, actual {}",
+                   crc_error_context,
+                   Crc32cToHex(expected_crc),
+                   Crc32cToHex(actual_crc));
+        return;
+    }
+
+    auto& pool = ThreadPools::GetThreadPool(priority);
+    auto& budget = TransientMemoryBudget::GetEntryStreamBudget();
+    size_t max_active_tasks =
+        std::min(num_slices, std::max<size_t>(1, pool.GetMaxThreadNum()));
+
+    size_t next_submit = 0;
+    uint32_t running_crc = 0;
+    bool first = true;
+    std::deque<ActiveSliceTask> active_tasks;
+    std::exception_ptr first_error = nullptr;
+
+    auto rememberError = [&](std::exception_ptr error) {
+        if (!first_error) {
+            first_error = std::move(error);
+        }
+    };
+
+    auto drainActiveTasks = [&]() {
+        while (!active_tasks.empty()) {
+            auto task = std::move(active_tasks.front());
+            active_tasks.pop_front();
+            if (task.future.valid()) {
+                try {
+                    task.future.get();
+                } catch (...) {
+                    rememberError(std::current_exception());
+                }
+            }
+            budget.Release(task.budget_bytes);
+        }
+    };
+
+    auto submitOne = [&](bool block_for_budget) -> bool {
+        size_t seq = next_submit;
+        size_t budget_bytes = 0;
+        std::shared_ptr<StreamSliceResult> result;
+        try {
+            budget_bytes = slice_budget_bytes(seq);
+            result = std::make_shared<StreamSliceResult>();
+            result->budget_bytes = budget_bytes;
+        } catch (...) {
+            rememberError(std::current_exception());
+            return false;
+        }
+
+        if (block_for_budget) {
+            budget.Acquire(budget_bytes);
+        } else if (!budget.TryAcquire(budget_bytes)) {
+            return false;
+        }
+
+        try {
+            active_tasks.push_back(
+                ActiveSliceTask{budget_bytes, result, std::future<void>()});
+            active_tasks.back().future =
+                pool.Submit([result, load_slice, seq]() {
+                    try {
+                        result->data = load_slice(seq);
+                    } catch (...) {
+                        result->error = std::current_exception();
+                    }
+                });
+        } catch (...) {
+            if (!active_tasks.empty() && active_tasks.back().result == result &&
+                !active_tasks.back().future.valid()) {
+                active_tasks.pop_back();
+            }
+            budget.Release(budget_bytes);
+            rememberError(std::current_exception());
+            return false;
+        }
+
+        next_submit++;
+        return true;
+    };
+
+    auto refill = [&]() {
+        while (!first_error && next_submit < num_slices &&
+               active_tasks.size() < max_active_tasks) {
+            bool block_for_budget = active_tasks.empty();
+            if (!submitOne(block_for_budget)) {
+                break;
+            }
+        }
+    };
+
+    auto deliverSlice = [&](const std::shared_ptr<StreamSliceResult>& c) {
+        try {
+            uint32_t slice_crc = Crc32cValue(c->data.data(), c->data.size());
+            running_crc =
+                first ? slice_crc
+                      : Crc32cCombine(running_crc, slice_crc, c->data.size());
+            first = false;
+            slice_consumer(c->data.data(), c->data.size());
+        } catch (...) {
+            rememberError(std::current_exception());
+        }
+    };
+
+    refill();
+
+    while (!active_tasks.empty()) {
+        auto task = std::move(active_tasks.front());
+        active_tasks.pop_front();
+
+        try {
+            task.future.get();
+        } catch (...) {
+            rememberError(std::current_exception());
+        }
+
+        if (!first_error && task.result->error) {
+            rememberError(task.result->error);
+        }
+
+        if (!first_error) {
+            deliverSlice(task.result);
+        }
+
+        budget.Release(task.budget_bytes);
+
+        if (first_error) {
+            drainActiveTasks();
+            break;
+        }
+
+        refill();
+    }
+
+    if (first_error) {
+        std::rethrow_exception(first_error);
+    }
+
+    AssertInfo(running_crc == expected_crc,
+               "{}: expected {}, actual {}",
+               crc_error_context,
+               Crc32cToHex(expected_crc),
+               Crc32cToHex(running_crc));
+}
+
+}  // namespace
+
+size_t
+DefaultEntryStreamSliceSize() {
+    return DefaultStreamSliceSize();
+}
 
 std::unique_ptr<IndexEntryReader>
 IndexEntryReader::Open(std::shared_ptr<milvus::InputStream> input,
@@ -547,6 +728,134 @@ IndexEntryReader::ReadEntriesToFiles(
         close_all_fds();
         throw;
     }
+}
+
+size_t
+IndexEntryReader::GetEntrySize(const std::string& name) const {
+    auto it = entry_index_.find(name);
+    AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
+    if (it->second.encrypted) {
+        return it->second.enc.original_size;
+    }
+    return it->second.plain.size;
+}
+
+void
+IndexEntryReader::ReadEntryStream(
+    const std::string& name,
+    std::function<void(const uint8_t* data, size_t len)> slice_consumer,
+    size_t slice_size) {
+    auto it = entry_index_.find(name);
+    AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
+    const auto& meta = it->second;
+
+    if (meta.encrypted) {
+        ReadEncryptedEntryStream(meta.enc, slice_consumer);
+    } else {
+        ReadPlainEntryStream(meta.plain, slice_consumer, slice_size);
+    }
+}
+
+void
+IndexEntryReader::ReadPlainEntryStream(
+    const PlainEntryMeta& pm,
+    const std::function<void(const uint8_t* data, size_t len)>& slice_consumer,
+    size_t slice_size) {
+    AssertInfo(slice_size >= kMinStreamSliceSize,
+               "ReadEntryStream slice_size must be at least {} bytes, got {}",
+               kMinStreamSliceSize,
+               slice_size);
+    size_t num_slices =
+        pm.size == 0 ? 0 : 1 + (static_cast<size_t>(pm.size) - 1) / slice_size;
+    auto sliceBytes = [pm, slice_size](size_t seq) {
+        size_t off = seq * slice_size;
+        return std::min<size_t>(slice_size, pm.size - off);
+    };
+    auto input = input_;
+    auto load_slice = [input, pm, slice_size, sliceBytes](size_t seq) {
+        size_t off = seq * slice_size;
+        size_t len = sliceBytes(seq);
+        size_t src = pm.offset + off;
+        std::vector<uint8_t> data(len);
+        size_t n = input->ReadAt(data.data(), MILVUS_V3_MAGIC_SIZE + src, len);
+        AssertInfo(n == len, "Failed to read entry slice");
+        return data;
+    };
+
+    ReadOrderedEntryStream(num_slices,
+                           pm.crc32,
+                           "CRC-32C mismatch in stream read",
+                           priority_,
+                           slice_consumer,
+                           sliceBytes,
+                           load_slice);
+}
+
+void
+IndexEntryReader::ReadEncryptedEntryStream(
+    const EncryptedEntryMeta& em,
+    const std::function<void(const uint8_t* data, size_t len)>&
+        slice_consumer) {
+    size_t num_slices = em.slices.size();
+    auto slicePlainBytes = [this, &em](size_t seq) {
+        size_t output_offset = seq * slice_size_;
+        AssertInfo(output_offset < em.original_size,
+                   "Encrypted slice {} exceeds original entry size {}",
+                   seq,
+                   em.original_size);
+        size_t remaining = em.original_size - output_offset;
+        return std::min(remaining, slice_size_);
+    };
+    auto sliceBudgetBytes = [&](size_t seq) {
+        auto plain_len = slicePlainBytes(seq);
+        auto cipher_len = em.slices[seq].size;
+        AssertInfo(plain_len <= (std::numeric_limits<size_t>::max() / 2) &&
+                       cipher_len <=
+                           std::numeric_limits<size_t>::max() - 2 * plain_len,
+                   "Encrypted stream budget size overflow");
+        return cipher_len + 2 * plain_len;
+    };
+    auto input = input_;
+    auto cipher_plugin = cipher_plugin_;
+    int64_t ez_id = ez_id_;
+    int64_t collection_id = collection_id_;
+    auto edek = edek_;
+    auto load_slice = [input,
+                       cipher_plugin,
+                       ez_id,
+                       collection_id,
+                       edek,
+                       &em,
+                       slicePlainBytes](size_t seq) {
+        const auto& slice = em.slices[seq];
+        auto expected_plain_len = slicePlainBytes(seq);
+
+        std::string plain;
+        {
+            std::vector<uint8_t> cipher(slice.size);
+            size_t n = input->ReadAt(
+                cipher.data(), MILVUS_V3_MAGIC_SIZE + slice.offset, slice.size);
+            AssertInfo(n == slice.size, "Failed to read encrypted slice");
+
+            auto dec = cipher_plugin->GetDecryptor(ez_id, collection_id, edek);
+            plain = dec->Decrypt(cipher.data(), cipher.size());
+        }
+        AssertInfo(plain.size() == expected_plain_len,
+                   "Decrypted size mismatch: expected {}, got {}",
+                   expected_plain_len,
+                   plain.size());
+        return std::vector<uint8_t>(
+            reinterpret_cast<const uint8_t*>(plain.data()),
+            reinterpret_cast<const uint8_t*>(plain.data()) + plain.size());
+    };
+
+    ReadOrderedEntryStream(num_slices,
+                           em.crc32,
+                           "CRC-32C mismatch in encrypted stream read",
+                           priority_,
+                           slice_consumer,
+                           sliceBudgetBytes,
+                           load_slice);
 }
 
 }  // namespace milvus::storage

--- a/internal/core/src/storage/IndexEntryReader.h
+++ b/internal/core/src/storage/IndexEntryReader.h
@@ -18,6 +18,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <future>
 #include <memory>
 #include <string>
@@ -32,6 +33,9 @@
 #include "storage/plugin/PluginInterface.h"
 
 namespace milvus::storage {
+
+size_t
+DefaultEntryStreamSliceSize();
 
 struct Entry {
     std::vector<uint8_t> data;
@@ -57,6 +61,33 @@ class IndexEntryReader {
     void
     ReadEntriesToFiles(const std::vector<std::pair<std::string, std::string>>&
                            name_path_pairs);
+
+    /// Stream entry data via transient memory budget.
+    /// Downloads are concurrent (full bandwidth). Slices are delivered in entry
+    /// order to `slice_consumer`; the data pointer is valid only for the
+    /// duration of that call. Global TransientMemoryBudget controls total
+    /// inflight slice bytes across all concurrent entry streams.
+    /// CRC32c is verified incrementally. Consumers may receive partial data
+    /// before a later slice error is reported. Slow consumers keep their slice
+    /// budget until the callback returns, which can block other streams.
+    /// Plain entries are split into `slice_size` byte slices. Encrypted entries
+    /// ignore `slice_size` and use the slice boundaries stored in the V3
+    /// directory.
+    void
+    ReadEntryStream(
+        const std::string& name,
+        std::function<void(const uint8_t* data, size_t len)> slice_consumer,
+        size_t slice_size = DefaultEntryStreamSliceSize());
+
+    /// Return the uncompressed data size of an entry without reading it.
+    size_t
+    GetEntrySize(const std::string& name) const;
+
+    /// Check if an entry exists in the index file.
+    bool
+    HasEntry(const std::string& name) const {
+        return entry_index_.find(name) != entry_index_.end();
+    }
 
     template <typename T>
     T
@@ -113,6 +144,18 @@ class IndexEntryReader {
     ReadPlainEntry(const EntryMeta& meta);
     Entry
     ReadEncryptedEntry(const EntryMeta& meta);
+
+    void
+    ReadPlainEntryStream(const PlainEntryMeta& pm,
+                         const std::function<void(const uint8_t* data,
+                                                  size_t len)>& slice_consumer,
+                         size_t slice_size);
+
+    void
+    ReadEncryptedEntryStream(
+        const EncryptedEntryMeta& em,
+        const std::function<void(const uint8_t* data, size_t len)>&
+            slice_consumer);
 
     void
     VerifyCrc32c(uint32_t expected,

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -13,21 +13,28 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
+#include "common/Common.h"
 #include "common/EasyAssert.h"
+#include "filemanager/InputStream.h"
 #include "test_utils/Constants.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "storage/IndexEntryDirectStreamWriter.h"
 #include "storage/IndexEntryEncryptedLocalWriter.h"
 #include "storage/IndexEntryReader.h"
+#include "storage/EntryStreamUtils.h"
 #include "storage/PluginLoader.h"
 #include "storage/RemoteInputStream.h"
 #include "storage/RemoteOutputStream.h"
@@ -35,6 +42,28 @@
 using namespace milvus::storage;
 
 namespace {
+
+class IndexEntryStreamConfigGuard {
+ public:
+    IndexEntryStreamConfigGuard()
+        : budget_ratio_(milvus::ENTRY_STREAM_BUDGET_RATIO.load()) {
+    }
+
+    ~IndexEntryStreamConfigGuard() {
+        milvus::SetStreamBudgetRatio(budget_ratio_);
+    }
+
+ private:
+    double budget_ratio_;
+};
+
+size_t
+ExpectedEntryStreamBudgetBytes(double ratio) {
+    auto slice_size = DefaultStreamSliceSize();
+    auto core_num = std::max(1, milvus::CPU_NUM);
+    auto capacity = static_cast<size_t>(core_num * ratio) * slice_size;
+    return std::max(capacity, slice_size);
+}
 
 // Simple XOR-based mock cipher for testing (NOT for production use!)
 class MockEncryptor : public plugin::IEncryptor {
@@ -127,6 +156,68 @@ class MockCipherPlugin : public plugin::ICipherPlugin {
     GetDecryptor(int64_t, int64_t, const std::string&) const override {
         return std::make_shared<MockDecryptor>();
     }
+};
+
+class DelayedFailingInputStream : public milvus::InputStream {
+ public:
+    struct Rule {
+        size_t offset;
+        std::chrono::milliseconds delay;
+        bool fail;
+    };
+
+    DelayedFailingInputStream(std::shared_ptr<milvus::InputStream> base,
+                              std::vector<Rule> rules)
+        : base_(std::move(base)), rules_(std::move(rules)) {
+    }
+
+    size_t
+    Size() const override {
+        return base_->Size();
+    }
+
+    bool
+    Seek(int64_t offset) override {
+        return base_->Seek(offset);
+    }
+
+    size_t
+    Tell() const override {
+        return base_->Tell();
+    }
+
+    bool
+    Eof() const override {
+        return base_->Eof();
+    }
+
+    size_t
+    Read(void* ptr, size_t size) override {
+        return base_->Read(ptr, size);
+    }
+
+    size_t
+    ReadAt(void* ptr, size_t offset, size_t size) override {
+        for (const auto& rule : rules_) {
+            if (rule.offset == offset) {
+                std::this_thread::sleep_for(rule.delay);
+                if (rule.fail) {
+                    return 0;
+                }
+                break;
+            }
+        }
+        return base_->ReadAt(ptr, offset, size);
+    }
+
+    size_t
+    Read(int fd, size_t size) override {
+        return base_->Read(fd, size);
+    }
+
+ private:
+    std::shared_ptr<milvus::InputStream> base_;
+    std::vector<Rule> rules_;
 };
 
 }  // namespace
@@ -913,4 +1004,284 @@ TEST_F(IndexEntryEncryptedV3Test, EncryptedFdEntryMultiSlice) {
     EXPECT_GT(info.ValueOrDie().size(), entry_size);
 
     ::unlink(tmp_relative.c_str());
+}
+
+// ---- ReadEntryStream tests ----
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamLarge) {
+    const std::string file_path = kV3FilePath + "_stream_large";
+    const size_t entry_size = 4 * 1024 * 1024;  // 4MB
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("test_data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    std::vector<uint8_t> reassembled;
+    size_t slice_count = 0;
+    reader->ReadEntryStream(
+        "test_data",
+        [&](const uint8_t* d, size_t len) {
+            reassembled.insert(reassembled.end(), d, d + len);
+            slice_count++;
+        },
+        1 * 1024 * 1024);  // 1MB slices
+
+    ASSERT_EQ(reassembled.size(), entry_size);
+    VerifyPattern(reassembled, entry_size);
+    ASSERT_EQ(slice_count, 4);  // 4MB / 1MB = 4 slices
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamSmall) {
+    const std::string file_path = kV3FilePath + "_stream_small";
+    const size_t entry_size = 1024;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("small_data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    std::vector<uint8_t> reassembled;
+    size_t slice_count = 0;
+    reader->ReadEntryStream("small_data", [&](const uint8_t* d, size_t len) {
+        reassembled.insert(reassembled.end(), d, d + len);
+        slice_count++;
+    });
+
+    ASSERT_EQ(reassembled.size(), entry_size);
+    VerifyPattern(reassembled, entry_size);
+    ASSERT_EQ(slice_count, 1);  // single slice (1KB < default slice size)
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamRejectsInvalidSliceSize) {
+    const std::string file_path = kV3FilePath + "_stream_invalid_slice";
+    const size_t entry_size = kMinStreamSliceSize;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    EXPECT_THROW(reader->ReadEntryStream(
+                     "data", [](const uint8_t*, size_t) {}, 0),
+                 milvus::SegcoreError);
+    EXPECT_THROW(
+        reader->ReadEntryStream(
+            "data", [](const uint8_t*, size_t) {}, kMinStreamSliceSize - 1),
+        milvus::SegcoreError);
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamUsesDefaultSliceSize) {
+    IndexEntryStreamConfigGuard guard;
+    milvus::SetStreamBudgetRatio(2.5);
+    const size_t slice_size = DEFAULT_INDEX_FILE_SLICE_SIZE;
+    ASSERT_EQ(DefaultStreamSliceSize(), slice_size);
+    ASSERT_DOUBLE_EQ(StreamBudgetRatio(), 2.5);
+    ASSERT_EQ(TransientMemoryBudget::GetEntryStreamBudget().CapacityBytes(),
+              ExpectedEntryStreamBudgetBytes(2.5));
+
+    milvus::SetStreamBudgetRatio(3.5);
+    ASSERT_DOUBLE_EQ(StreamBudgetRatio(), 3.5);
+    ASSERT_EQ(TransientMemoryBudget::GetEntryStreamBudget().CapacityBytes(),
+              ExpectedEntryStreamBudgetBytes(3.5));
+
+    const std::string file_path = kV3FilePath + "_stream_configured_default";
+    const size_t entry_size = 2 * slice_size + 17;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    std::vector<size_t> slice_sizes;
+    std::vector<uint8_t> reassembled;
+    reader->ReadEntryStream("data", [&](const uint8_t* d, size_t len) {
+        slice_sizes.push_back(len);
+        reassembled.insert(reassembled.end(), d, d + len);
+    });
+
+    ASSERT_EQ(reassembled, data);
+    ASSERT_EQ(slice_sizes, (std::vector<size_t>{slice_size, slice_size, 17}));
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamEmptyEntryVerifiesCrc) {
+    const std::string file_path = kV3FilePath + "_stream_empty";
+    std::vector<uint8_t> data;
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("empty", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    size_t slice_count = 0;
+    reader->ReadEntryStream("empty",
+                            [&](const uint8_t*, size_t) { slice_count++; });
+    ASSERT_EQ(slice_count, 0);
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamMatchesReadEntry) {
+    const std::string file_path = kV3FilePath + "_stream_match";
+    const size_t entry_size = 5 * 1024 * 1024;  // 5MB, non-aligned
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    // Read via ReadEntry
+    auto entry = reader->ReadEntry("data");
+
+    // Read via ReadEntryStream
+    std::vector<uint8_t> streamed;
+    reader->ReadEntryStream(
+        "data",
+        [&](const uint8_t* d, size_t len) {
+            streamed.insert(streamed.end(), d, d + len);
+        },
+        512 * 1024);  // 512KB slices
+
+    ASSERT_EQ(entry.data.size(), streamed.size());
+    EXPECT_EQ(entry.data, streamed);
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamConsumerExceptionDoesNotLeak) {
+    const std::string file_path = kV3FilePath + "_stream_consumer_throw";
+    const size_t slice_size = 64 * 1024;
+    const size_t entry_size = 4 * slice_size;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    size_t slice_count = 0;
+    EXPECT_THROW(reader->ReadEntryStream(
+                     "data",
+                     [&](const uint8_t*, size_t) {
+                         slice_count++;
+                         throw std::runtime_error("stop stream");
+                     },
+                     slice_size),
+                 std::runtime_error);
+    EXPECT_EQ(slice_count, 1);
+
+    std::vector<uint8_t> streamed;
+    reader->ReadEntryStream(
+        "data",
+        [&](const uint8_t* d, size_t len) {
+            streamed.insert(streamed.end(), d, d + len);
+        },
+        slice_size);
+    EXPECT_EQ(streamed, data);
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntryStreamDrainsActiveTasksAfterError) {
+    const std::string file_path = kV3FilePath + "_stream_active_task_error";
+    const size_t slice_size = 64 * 1024;
+    const size_t entry_size = 3 * slice_size;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("data", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto base_input = CreateInputStream(file_path);
+    auto input = std::make_shared<DelayedFailingInputStream>(
+        base_input,
+        std::vector<DelayedFailingInputStream::Rule>{
+            {MILVUS_V3_MAGIC_SIZE, std::chrono::milliseconds(80), false},
+            {MILVUS_V3_MAGIC_SIZE + slice_size,
+             std::chrono::milliseconds(40),
+             true},
+        });
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    size_t slice_count = 0;
+    EXPECT_THROW(
+        reader->ReadEntryStream(
+            "data", [&](const uint8_t*, size_t) { slice_count++; }, slice_size),
+        milvus::SegcoreError);
+    EXPECT_EQ(slice_count, 1);
+
+    auto clean_input = CreateInputStream(file_path);
+    auto clean_reader = IndexEntryReader::Open(clean_input, file_size);
+    std::vector<uint8_t> streamed;
+    clean_reader->ReadEntryStream(
+        "data",
+        [&](const uint8_t* d, size_t len) {
+            streamed.insert(streamed.end(), d, d + len);
+        },
+        slice_size);
+    EXPECT_EQ(streamed, data);
+}
+
+TEST_F(IndexEntryWriterV3Test, GetEntrySize) {
+    const std::string file_path = kV3FilePath + "_entry_size";
+    const size_t entry_size = 3 * 1024 * 1024;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("sized_entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto input = CreateInputStream(file_path);
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    ASSERT_EQ(reader->GetEntrySize("sized_entry"), entry_size);
 }

--- a/internal/datanode/index/init_segcore.go
+++ b/internal/datanode/index/init_segcore.go
@@ -57,6 +57,8 @@ func InitSegcore(nodeID int64) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
+	cStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.StreamBudgetRatio.GetAsFloat())
+	C.SetStreamBudgetRatio(cStreamBudgetRatio)
 
 	// set up thread pool for different priorities
 	cHighPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.HighPriorityThreadCoreCoefficient.GetAsFloat())

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -504,6 +504,15 @@ func SetupCoreConfigChangelCallback() {
 			return nil
 		})
 
+		paramtable.Get().CommonCfg.StreamBudgetRatio.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
+			ratio, err := strconv.ParseFloat(newValue, 64)
+			if err != nil {
+				return err
+			}
+			UpdateStreamBudgetRatio(ratio)
+			return nil
+		})
+
 		paramtable.Get().QueryNodeCfg.KnowhereThreadPoolSize.RegisterCallback(func(ctx context.Context, key, oldValue, newValue string) error {
 			factor, err := strconv.ParseFloat(newValue, 64)
 			if err != nil {

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -93,6 +93,8 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 	// override segcore index slice size
 	cIndexSliceSize := C.int64_t(paramtable.Get().CommonCfg.IndexSliceSize.GetAsInt64())
 	C.SetIndexSliceSize(cIndexSliceSize)
+	cStreamBudgetRatio := C.double(paramtable.Get().CommonCfg.StreamBudgetRatio.GetAsFloat())
+	C.SetStreamBudgetRatio(cStreamBudgetRatio)
 
 	// set up thread pool for different priorities
 	cHighPriorityThreadCoreCoefficient := C.float(paramtable.Get().CommonCfg.HighPriorityThreadCoreCoefficient.GetAsFloat())

--- a/internal/util/initcore/util.go
+++ b/internal/util/initcore/util.go
@@ -51,6 +51,10 @@ func UpdateIndexSliceSize(size int) {
 	C.SetIndexSliceSize(C.int64_t(size))
 }
 
+func UpdateStreamBudgetRatio(ratio float64) {
+	C.SetStreamBudgetRatio(C.double(ratio))
+}
+
 func UpdateHighPriorityThreadCoreCoefficient(coefficient float64) {
 	C.SetHighPriorityThreadCoreCoefficient(C.float(coefficient))
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -41,6 +41,7 @@ import (
 const (
 	// DefaultIndexSliceSize defines the default slice size of index file when serializing.
 	DefaultIndexSliceSize                      = 16
+	DefaultStreamBudgetRatio                   = 3.0
 	DefaultGracefulTime                        = 5000 // ms
 	DefaultGracefulStopTimeout                 = 1800 // s, for node
 	DefaultProxyGracefulStopTimeout            = 30   // s，for proxy
@@ -233,6 +234,7 @@ type commonConfig struct {
 	EntityExpirationTTL  ParamItem `refreshable:"true"`
 
 	IndexSliceSize                      ParamItem `refreshable:"false"`
+	StreamBudgetRatio                   ParamItem `refreshable:"true"`
 	HighPriorityThreadCoreCoefficient   ParamItem `refreshable:"true"`
 	MiddlePriorityThreadCoreCoefficient ParamItem `refreshable:"true"`
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`
@@ -575,6 +577,15 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export:       true,
 	}
 	p.IndexSliceSize.Init(base.mgr)
+
+	p.StreamBudgetRatio = ParamItem{
+		Key:          "common.entryStream.streamBudgetRatio",
+		Version:      "3.0.0",
+		DefaultValue: fmt.Sprintf("%f", DefaultStreamBudgetRatio),
+		Doc:          "Multiplier for entry stream transient memory budget, relative to CPU core count",
+		Export:       true,
+	}
+	p.StreamBudgetRatio.Init(base.mgr)
 
 	p.EnableMaterializedView = ParamItem{
 		Key:          "common.materializedView.enabled",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -59,6 +59,10 @@ func TestComponentParam(t *testing.T) {
 		assert.Equal(t, Params.IndexSliceSize.GetAsInt64(), int64(DefaultIndexSliceSize))
 		t.Logf("knowhere index slice size = %d", Params.IndexSliceSize.GetAsInt64())
 
+		assert.InDelta(t, DefaultStreamBudgetRatio, Params.StreamBudgetRatio.GetAsFloat(), 0.0001)
+		params.Save(Params.StreamBudgetRatio.Key, "2.5")
+		assert.InDelta(t, 2.5, Params.StreamBudgetRatio.GetAsFloat(), 0.0001)
+
 		assert.Equal(t, int64(0), Params.ArrowReaderHoleSizeLimitBytes.GetAsInt64())
 		assert.Equal(t, int64(0), Params.ArrowReaderRangeSizeLimitBytes.GetAsInt64())
 		params.Save(Params.ArrowReaderHoleSizeLimitBytes.Key, "1048576")


### PR DESCRIPTION
pr: #50073
issue: #48957

- Backport V3 entry streaming reader support to 2.6.
- Add entry stream transient memory budget and C/Go config plumbing.
- Add ReadEntryStream/GetEntrySize support and related storage tests.
