### PR TITLE
enhance: vectorize ApplyValidData and share it as ApplyValidMask

### DIFF
--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -1849,12 +1849,13 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForData(
         // there is a batch operation in ArithOpElementFunc,
         // so not divide data again for the reason that it may reduce performance if the null distribution is scattered
         // but to mask res with valid_data after the batch operation.
-        if (valid_data != nullptr) {
+        if constexpr (filter_type == FilterType::sequential) {
+            // contiguous rows: reuse the vectorized shared helper
+            ApplyValidMask(valid_data, res, valid_res, size);
+        } else if (valid_data != nullptr) {
+            // scattered by offsets: gather, keep the per-row loop
             for (int i = 0; i < size; i++) {
-                auto offset = i;
-                if constexpr (filter_type == FilterType::random) {
-                    offset = (offsets) ? offsets[i] : i;
-                }
+                auto offset = (offsets) ? offsets[i] : i;
                 if (!valid_data[offset]) {
                     res[i] = valid_res[i] = false;
                 }

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -420,12 +420,13 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForData(EvalCtx& context) {
         // there is a batch operation in BinaryRangeElementFunc,
         // so not divide data again for the reason that it may reduce performance if the null distribution is scattered
         // but to mask res with valid_data after the batch operation.
-        if (valid_data != nullptr) {
+        if constexpr (filter_type == FilterType::sequential) {
+            // contiguous rows: reuse the vectorized shared helper
+            ApplyValidMask(valid_data, res, valid_res, size);
+        } else if (valid_data != nullptr) {
+            // scattered by offsets: gather, keep the per-row loop
             for (int i = 0; i < size; i++) {
-                auto offset = i;
-                if constexpr (filter_type == FilterType::random) {
-                    offset = (offsets) ? offsets[i] : i;
-                }
+                auto offset = (offsets) ? offsets[i] : i;
                 if (!valid_data[offset]) {
                     res[i] = valid_res[i] = false;
                 }

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <algorithm>
+#include <bit>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -71,6 +72,46 @@ PinIndex(milvus::OpContext* op_ctx,
                                      is_array);
     } else {
         return segment->PinIndex(op_ctx, field_meta.get_id());
+    }
+}
+
+// Mask null rows out of a filter result: wherever valid_data marks a row null
+// (false), clear both the result bit and the validity bit. No-op when
+// valid_data is null (a non-nullable column carries no validity array). This
+// is the shared validity-masking primitive used by SegmentExpr::ApplyValidData
+// and by the per-kernel sequential masking sites.
+//
+// Packs 64 rows into a word (the fixed-trip inner loop vectorizes) and then
+// walks only the null bits via std::countr_zero. An all-valid block has no null
+// bits set, so the common no-null case costs nothing. Bit-identical to the
+// straightforward `if (!valid_data[i]) res[i] = valid_res[i] = false;` loop.
+//
+// SEQUENTIAL only: row i maps to position i. The scattered / by-offsets case
+// (valid_data[offsets[i]]) is a gather and must keep its own per-row loop.
+inline void
+ApplyValidMask(const bool* valid_data,
+               TargetBitmapView res,
+               TargetBitmapView valid_res,
+               const int size) {
+    if (valid_data == nullptr) {
+        return;
+    }
+    int i = 0;
+    for (; i + 64 <= size; i += 64) {
+        uint64_t m = 0;
+        for (int k = 0; k < 64; ++k) {
+            m |= uint64_t(valid_data[i + k] != 0) << k;
+        }
+        for (uint64_t nulls = ~m; nulls != 0; nulls &= nulls - 1) {
+            const int k = std::countr_zero(nulls);
+            res[i + k] = false;
+            valid_res[i + k] = false;
+        }
+    }
+    for (; i < size; i++) {
+        if (!valid_data[i]) {
+            res[i] = valid_res[i] = false;
+        }
     }
 }
 
@@ -364,13 +405,7 @@ class SegmentExpr : public Expr {
                    TargetBitmapView res,
                    TargetBitmapView valid_res,
                    const int size) {
-        if (valid_data != nullptr) {
-            for (int i = 0; i < size; i++) {
-                if (!valid_data[i]) {
-                    res[i] = valid_res[i] = false;
-                }
-            }
-        }
+        ApplyValidMask(valid_data, res, valid_res, size);
     }
 
     int64_t


### PR DESCRIPTION
issue: #50486

## What this PR does

`ApplyValidData` masks null rows out of a filter result (clears `res` and
`valid_res` wherever the column is null). It ran one branchy per-row loop; for
the common no-null case it scanned every row for nothing, and the same loop body
was duplicated across `SegmentExpr::ApplyValidData` and a couple of kernels.

- Extract the masking into a shared free function **`ApplyValidMask`** (in
  `exec/expression/Expr.h`, `namespace milvus::exec`). It packs 64 rows into a
  word (the fixed-trip loop vectorizes) and walks only the null bits via
  `std::countr_zero`, so an all-valid block costs nothing. Bit-identical to the
  per-row clear (`if (!valid_data[i]) res[i] = valid_res[i] = false;`).
- `SegmentExpr::ApplyValidData` now delegates to it, so its existing callers —
  the skip-index branch and the by-offsets gather paths — benefit automatically.
- Converge the two separable "mask after batch" sites (`BinaryRangeExpr`,
  `BinaryArithOpEvalRangeExpr`) onto the shared helper for the **sequential**
  `FilterType`; the scattered by-offsets branch is a gather and keeps its
  per-row loop.

## Why only those two kernels

`BinaryRange`/`BinaryArithOp` evaluate their predicate as a **vectorized batch
op** (`inplace_within_range_val`) that processes all rows including nulls, so
validity is necessarily masked in a separate pass afterward — a separable
post-batch mask. The other kernels (JsonContains, GIS, Compare, Unary/Term JSON)
have **per-row scalar predicates** and check nullity inline with `continue` to
skip the expensive per-row work; they are not separable post-batch masks and are
intentionally left as-is.

## Benchmark

`ApplyValidData`: 1.9x with no nulls, 2.14x at 50% nulls, break-even (~1.01x)
around 1% null density; no scenario regresses. (Xeon Gold 6338.)

## Tests

- Full C++ build: clean (exit 0).
- `Expr.*:ExprTest.*:*Null*:*Range*:*ArithOp*`: passing, 0 failures.
- The new/old `ApplyValidData` implementations are bit-identical at 0/0.1/1/50%
  null densities.

## Relation to other PRs

Split out of #50447 (which is now the `IsNotNull()` caching only). The
`OffsetMapping` `all()/none()` vectorization landed separately in #50468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
