### PR TITLE
fix: Normalize raw byte vector lists for external tables

### DIFF
--- a/internal/core/src/storage/DataCodecTest.cpp
+++ b/internal/core/src/storage/DataCodecTest.cpp
@@ -112,6 +112,22 @@ AssertFixedSizeBinaryRows(const std::shared_ptr<arrow::Array>& array,
     EXPECT_EQ(memcmp(fsb_array->Value(1), row1.data(), sizeof(row1)), 0);
 }
 
+// Assert a single FixedSizeBinary row equals the raw bytes of a float vector.
+// Unlike AssertFixedSizeBinaryRows (two fixed rows), this checks one row by
+// index, used to verify individual inner vectors of a normalized VECTOR_ARRAY.
+template <size_t N>
+void
+AssertFixedSizeBinaryRow(const std::shared_ptr<arrow::Array>& array,
+                         int64_t row_index,
+                         const std::array<float, N>& expected) {
+    auto fsb_array =
+        std::static_pointer_cast<arrow::FixedSizeBinaryArray>(array);
+    ASSERT_EQ(fsb_array->byte_width(), sizeof(float) * N);
+    EXPECT_EQ(
+        memcmp(fsb_array->Value(row_index), expected.data(), sizeof(expected)),
+        0);
+}
+
 }  // namespace
 
 TEST(storage, ExternalVarCharStringNormalizesToBinaryAndFillSucceeds) {
@@ -384,6 +400,68 @@ TEST(storage, ExternalFloatVectorFixedSizeByteListNormalizesToFixedSizeBinary) {
     auto normalized = storage::NormalizeExternalArrow(list_array, field_meta);
     ASSERT_EQ(normalized->type_id(), arrow::Type::FIXED_SIZE_BINARY);
     AssertFixedSizeBinaryRows(normalized, row0, row1);
+}
+
+// VECTOR_ARRAY arrives as list<list<uint8>>: the outer list groups multiple
+// vectors per row, each inner vector being a raw uint8 byte list. Normalize
+// must preserve the outer LIST structure and convert only the inner vectors to
+// FixedSizeBinary. Layout under test:
+//   row0 -> [vec0]        (1 inner vector)
+//   row1 -> [vec1, vec2]  (2 inner vectors)
+// so the flattened inner values hold 3 vectors total.
+TEST(storage, ExternalVectorArrayByteListNormalizesInnerVectors) {
+    constexpr int dim = 2;
+    std::array<float, dim> vec0 = {1.0F, 2.0F};
+    std::array<float, dim> vec1 = {3.0F, 4.0F};
+    std::array<float, dim> vec2 = {5.0F, 6.0F};
+
+    // Build the nested list<list<uint8>>: array_builder is the outer list,
+    // inner_vector_builder the per-vector list, inner_byte_builder the raw
+    // uint8 bytes. Append() on a list builder starts a new list slot; the
+    // inner builders are then filled for that slot.
+    auto byte_builder = std::make_shared<arrow::UInt8Builder>();
+    auto vector_builder = std::make_shared<arrow::ListBuilder>(
+        arrow::default_memory_pool(), byte_builder);
+    arrow::ListBuilder array_builder(arrow::default_memory_pool(),
+                                     vector_builder);
+    auto& inner_vector_builder =
+        dynamic_cast<arrow::ListBuilder&>(*array_builder.value_builder());
+    auto& inner_byte_builder = dynamic_cast<arrow::UInt8Builder&>(
+        *inner_vector_builder.value_builder());
+
+    // row0: one inner vector.
+    ASSERT_TRUE(array_builder.Append().ok());
+    ASSERT_TRUE(inner_vector_builder.Append().ok());
+    AppendFloatVectorBytes(inner_byte_builder, vec0);
+
+    // row1: two inner vectors.
+    ASSERT_TRUE(array_builder.Append().ok());
+    ASSERT_TRUE(inner_vector_builder.Append().ok());
+    AppendFloatVectorBytes(inner_byte_builder, vec1);
+    ASSERT_TRUE(inner_vector_builder.Append().ok());
+    AppendFloatVectorBytes(inner_byte_builder, vec2);
+
+    std::shared_ptr<arrow::Array> list_array;
+    ASSERT_TRUE(array_builder.Finish(&list_array).ok());
+
+    auto field_meta = MakeExternalFieldMetaForTest(
+        DataType::VECTOR_ARRAY, DataType::VECTOR_FLOAT, false, dim);
+    auto normalized = storage::NormalizeExternalArrow(list_array, field_meta);
+    // Outer LIST structure is preserved; only inner vectors are rewritten.
+    ASSERT_EQ(normalized->type_id(), arrow::Type::LIST);
+
+    auto normalized_list =
+        std::static_pointer_cast<arrow::ListArray>(normalized);
+    EXPECT_EQ(normalized_list->length(), 2);     // two rows
+    EXPECT_EQ(normalized_list->value_length(0), 1);  // row0 has 1 vector
+    EXPECT_EQ(normalized_list->value_length(1), 2);  // row1 has 2 vectors
+    // Inner vectors normalized from raw uint8 byte lists to FixedSizeBinary.
+    ASSERT_EQ(normalized_list->values()->type_id(),
+              arrow::Type::FIXED_SIZE_BINARY);
+
+    AssertFixedSizeBinaryRow(normalized_list->values(), 0, vec0);
+    AssertFixedSizeBinaryRow(normalized_list->values(), 1, vec1);
+    AssertFixedSizeBinaryRow(normalized_list->values(), 2, vec2);
 }
 
 TEST(storage, ExternalNullableFloatVectorBinaryIsAccepted) {

--- a/internal/core/src/storage/DataCodecTest.cpp
+++ b/internal/core/src/storage/DataCodecTest.cpp
@@ -452,7 +452,7 @@ TEST(storage, ExternalVectorArrayByteListNormalizesInnerVectors) {
 
     auto normalized_list =
         std::static_pointer_cast<arrow::ListArray>(normalized);
-    EXPECT_EQ(normalized_list->length(), 2);     // two rows
+    EXPECT_EQ(normalized_list->length(), 2);         // two rows
     EXPECT_EQ(normalized_list->value_length(0), 1);  // row0 has 1 vector
     EXPECT_EQ(normalized_list->value_length(1), 2);  // row1 has 2 vectors
     // Inner vectors normalized from raw uint8 byte lists to FixedSizeBinary.

--- a/internal/core/src/storage/DataCodecTest.cpp
+++ b/internal/core/src/storage/DataCodecTest.cpp
@@ -90,6 +90,28 @@ MakeExternalFieldMetaForTest(DataType data_type,
     return FieldMeta::ParseFrom(field_schema);
 }
 
+template <size_t N>
+void
+AppendFloatVectorBytes(arrow::UInt8Builder& builder,
+                       const std::array<float, N>& row) {
+    auto bytes = reinterpret_cast<const uint8_t*>(row.data());
+    for (size_t i = 0; i < sizeof(float) * row.size(); ++i) {
+        ASSERT_TRUE(builder.Append(bytes[i]).ok());
+    }
+}
+
+template <size_t N>
+void
+AssertFixedSizeBinaryRows(const std::shared_ptr<arrow::Array>& array,
+                          const std::array<float, N>& row0,
+                          const std::array<float, N>& row1) {
+    auto fsb_array =
+        std::static_pointer_cast<arrow::FixedSizeBinaryArray>(array);
+    ASSERT_EQ(fsb_array->byte_width(), sizeof(float) * N);
+    EXPECT_EQ(memcmp(fsb_array->Value(0), row0.data(), sizeof(row0)), 0);
+    EXPECT_EQ(memcmp(fsb_array->Value(1), row1.data(), sizeof(row1)), 0);
+}
+
 }  // namespace
 
 TEST(storage, ExternalVarCharStringNormalizesToBinaryAndFillSucceeds) {
@@ -311,6 +333,57 @@ TEST(storage, ExternalFloatVectorListNormalizesToFixedSizeBinary) {
         DataType::VECTOR_FLOAT, DataType::NONE, false, 2);
     auto normalized = storage::NormalizeExternalArrow(list_array, field_meta);
     ASSERT_EQ(normalized->type_id(), arrow::Type::FIXED_SIZE_BINARY);
+}
+
+TEST(storage, ExternalFloatVectorByteListNormalizesToFixedSizeBinary) {
+    constexpr int dim = 2;
+    std::array<float, dim> row0 = {1.0F, 2.0F};
+    std::array<float, dim> row1 = {3.0F, 4.0F};
+
+    auto value_builder = std::make_shared<arrow::UInt8Builder>();
+    arrow::ListBuilder builder(arrow::default_memory_pool(), value_builder);
+    auto& byte_builder =
+        dynamic_cast<arrow::UInt8Builder&>(*builder.value_builder());
+
+    ASSERT_TRUE(builder.Append().ok());
+    AppendFloatVectorBytes(byte_builder, row0);
+    ASSERT_TRUE(builder.Append().ok());
+    AppendFloatVectorBytes(byte_builder, row1);
+
+    std::shared_ptr<arrow::Array> list_array;
+    ASSERT_TRUE(builder.Finish(&list_array).ok());
+
+    auto field_meta = MakeExternalFieldMetaForTest(
+        DataType::VECTOR_FLOAT, DataType::NONE, false, dim);
+    auto normalized = storage::NormalizeExternalArrow(list_array, field_meta);
+    ASSERT_EQ(normalized->type_id(), arrow::Type::FIXED_SIZE_BINARY);
+    AssertFixedSizeBinaryRows(normalized, row0, row1);
+}
+
+TEST(storage, ExternalFloatVectorFixedSizeByteListNormalizesToFixedSizeBinary) {
+    constexpr int dim = 2;
+    std::array<float, dim> row0 = {1.0F, 2.0F};
+    std::array<float, dim> row1 = {3.0F, 4.0F};
+
+    auto value_builder = std::make_shared<arrow::UInt8Builder>();
+    arrow::FixedSizeListBuilder builder(
+        arrow::default_memory_pool(), value_builder, sizeof(float) * dim);
+    auto& byte_builder =
+        dynamic_cast<arrow::UInt8Builder&>(*builder.value_builder());
+
+    ASSERT_TRUE(builder.Append().ok());
+    AppendFloatVectorBytes(byte_builder, row0);
+    ASSERT_TRUE(builder.Append().ok());
+    AppendFloatVectorBytes(byte_builder, row1);
+
+    std::shared_ptr<arrow::Array> list_array;
+    ASSERT_TRUE(builder.Finish(&list_array).ok());
+
+    auto field_meta = MakeExternalFieldMetaForTest(
+        DataType::VECTOR_FLOAT, DataType::NONE, false, dim);
+    auto normalized = storage::NormalizeExternalArrow(list_array, field_meta);
+    ASSERT_EQ(normalized->type_id(), arrow::Type::FIXED_SIZE_BINARY);
+    AssertFixedSizeBinaryRows(normalized, row0, row1);
 }
 
 TEST(storage, ExternalNullableFloatVectorBinaryIsAccepted) {

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1982,6 +1982,18 @@ IsByteVectorListInput(DataType data_type) {
            data_type == DataType::VECTOR_BFLOAT16;
 }
 
+// External function output vectors can round-trip through schemaless Arrow
+// paths that erase the semantic element type and surface the column as a raw
+// list<uint8> (the physical Milvus vector bytes). In that case the uint8 bytes
+// already match our on-disk storage layout, so we accept them as raw bytes
+// instead of demanding the semantic element type (e.g. FLOAT for FloatVector).
+//
+// Restrictions:
+//   - Only dense vector columns qualify (IsVectorDataType).
+//   - Sparse float vectors are excluded: they are not fixed-width and do not
+//     use the raw fixed-size-binary layout.
+//   - VECTOR_ARRAY is excluded: its inner vectors are normalized recursively by
+//     the per-element semantic type, not as a flat byte list at this level.
 bool
 CanTreatVectorListAsRawBytes(
     DataType data_type, const std::shared_ptr<arrow::DataType>& actual_type) {
@@ -2037,6 +2049,9 @@ ExpectedVectorListLength(DataType data_type,
                          const std::shared_ptr<arrow::DataType>& actual_type) {
     // Float-like vector lists are element-counted by dim. Byte vector lists are
     // raw-byte encoded, so their list length must match the physical byte width.
+    // The same byte-width rule applies when a semantic vector column arrives as
+    // a raw uint8 byte list (CanTreatVectorListAsRawBytes), hence actual_type is
+    // needed here to disambiguate float-element lists from raw-byte lists.
     if (IsByteVectorListInput(data_type) ||
         CanTreatVectorListAsRawBytes(data_type, actual_type)) {
         return GetDataTypeSize(data_type, dim);
@@ -2051,6 +2066,10 @@ ValidateVectorListElementType(
     const FieldMeta& field_meta) {
     auto expected_type =
         ExpectedVectorListElementArrowType(data_type, field_meta);
+    // Accept either the semantic element type (e.g. FLOAT for FloatVector) or a
+    // raw uint8 byte list carrying the physical vector bytes. The list-length
+    // check downstream still enforces the correct byte width, so mismatched
+    // non-uint8 element types remain rejected below.
     if (actual_type->id() == expected_type ||
         CanTreatVectorListAsRawBytes(data_type, actual_type)) {
         return;
@@ -2099,6 +2118,9 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
             auto values = list_array->values();
             ValidateVectorListElementType(
                 values->type(), data_type, field_meta);
+            // Computed per array: the expected length depends on the actual
+            // element type (dim elements for float lists, byte-width for raw
+            // uint8 byte lists), so it cannot be hoisted out of the loop.
             int expected_list_length =
                 ExpectedVectorListLength(data_type, dim, values->type());
             int elem_bit_width = values->type()->bit_width();
@@ -2135,6 +2157,9 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
             auto values = fsl_array->values();
             ValidateVectorListElementType(
                 values->type(), data_type, field_meta);
+            // Computed per array: the expected length depends on the actual
+            // element type (dim elements for float lists, byte-width for raw
+            // uint8 byte lists), so it cannot be hoisted out of the loop.
             int expected_list_length =
                 ExpectedVectorListLength(data_type, dim, values->type());
             int elem_bit_width = values->type()->bit_width();

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -1982,6 +1982,15 @@ IsByteVectorListInput(DataType data_type) {
            data_type == DataType::VECTOR_BFLOAT16;
 }
 
+bool
+CanTreatVectorListAsRawBytes(
+    DataType data_type, const std::shared_ptr<arrow::DataType>& actual_type) {
+    return actual_type->id() == arrow::Type::UINT8 &&
+           IsVectorDataType(data_type) &&
+           !IsSparseFloatVectorDataType(data_type) &&
+           !IsVectorArrayDataType(data_type);
+}
+
 arrow::Type::type
 ExpectedVectorListElementArrowType(DataType data_type,
                                    const FieldMeta& field_meta) {
@@ -2023,10 +2032,13 @@ ArrowTypeName(arrow::Type::type type) {
 }
 
 int
-ExpectedVectorListLength(DataType data_type, int dim) {
+ExpectedVectorListLength(DataType data_type,
+                         int dim,
+                         const std::shared_ptr<arrow::DataType>& actual_type) {
     // Float-like vector lists are element-counted by dim. Byte vector lists are
     // raw-byte encoded, so their list length must match the physical byte width.
-    if (IsByteVectorListInput(data_type)) {
+    if (IsByteVectorListInput(data_type) ||
+        CanTreatVectorListAsRawBytes(data_type, actual_type)) {
         return GetDataTypeSize(data_type, dim);
     }
     return dim;
@@ -2039,8 +2051,13 @@ ValidateVectorListElementType(
     const FieldMeta& field_meta) {
     auto expected_type =
         ExpectedVectorListElementArrowType(data_type, field_meta);
-    AssertInfo(actual_type->id() == expected_type,
-               "vector element type mismatch{}, expected {}, actual {}",
+    if (actual_type->id() == expected_type ||
+        CanTreatVectorListAsRawBytes(data_type, actual_type)) {
+        return;
+    }
+    AssertInfo(false,
+               "vector element type mismatch{}, expected {} or raw uint8 "
+               "bytes, actual {}",
                FieldErrorSuffix(field_meta),
                ArrowTypeName(expected_type),
                actual_type->ToString());
@@ -2067,7 +2084,6 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
         }
 
         int64_t num_rows = array->length();
-        int expected_list_length = ExpectedVectorListLength(data_type, dim);
         auto buffer_result = arrow::AllocateBuffer(num_rows * byte_width);
         AssertInfo(buffer_result.ok(),
                    "Failed to allocate buffer for vector normalization");
@@ -2083,6 +2099,8 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
             auto values = list_array->values();
             ValidateVectorListElementType(
                 values->type(), data_type, field_meta);
+            int expected_list_length =
+                ExpectedVectorListLength(data_type, dim, values->type());
             int elem_bit_width = values->type()->bit_width();
             AssertInfo(elem_bit_width > 0 && elem_bit_width % 8 == 0,
                        "vector list element{} must be fixed-width "
@@ -2117,6 +2135,8 @@ NormalizeVectorArraysToFixedSizeBinary(const arrow::ArrayVector& arrays,
             auto values = fsl_array->values();
             ValidateVectorListElementType(
                 values->type(), data_type, field_meta);
+            int expected_list_length =
+                ExpectedVectorListLength(data_type, dim, values->type());
             int elem_bit_width = values->type()->bit_width();
             AssertInfo(elem_bit_width > 0 && elem_bit_width % 8 == 0,
                        "vector list element{} must be fixed-width "


### PR DESCRIPTION
issue: #50450

## What changed

Fixes [#50450](https://github.com/milvus-io/milvus/issues/50450).

This updates external Arrow normalization so dense vector
`list<uint8>` and `fixed_size_list<uint8>` inputs are treated as raw Milvus
vector bytes and normalized to `FixedSizeBinary`.

## Why

External table function outputs can be written by Milvus and later read through
schemaless storage paths, where vector bytes may surface as `uint8` lists. The
old validation expected `FloatVector` list inputs to have `float` children, so
valid raw-byte vector data failed with an element type mismatch.

## Validation

- `cmake --build cmake_build --target all_tests -j 8`
- `DYLD_LIBRARY_PATH="$PWD/cmake_build/src:$DYLD_LIBRARY_PATH" cmake_build/unittest/all_tests --gtest_filter='storage.ExternalFloatVectorByteListNormalizesToFixedSizeBinary:storage.ExternalFloatVectorFixedSizeByteListNormalizesToFixedSizeBinary:storage.ExternalFloatVectorListNormalizesToFixedSizeBinary:storage.ExternalBinaryVectorListNormalizesToFixedSizeBinary:storage.ExternalSampleSchemaValidationRejectsMismatchedVectorElementType'`
- `git diff --check`

Note: reset was run before tests; this worktree has no `bin/milvus`, so
standalone was not started. These C++ unit tests do not depend on a running
Milvus process.

