### PR TITLE
fix: avoid datacoord go vet panic

### DIFF
--- a/internal/datacoord/copy_segment_task_test.go
+++ b/internal/datacoord/copy_segment_task_test.go
@@ -469,15 +469,14 @@ func (s *CopySegmentTaskSuite) TestTaskType() {
 }
 
 func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_NotCompletedKeepsTaskInProgress() {
-	cluster := &struct{ session.Cluster }{}
-	mockQuery := mockey.Mock((*struct{ session.Cluster }).QueryCopySegment).Return(
+	cluster := session.NewMockCluster(s.T())
+	cluster.EXPECT().QueryCopySegment(mock.Anything, mock.Anything).Return(
 		&datapb.QueryCopySegmentResponse{
 			TaskID: 1001,
 			State:  datapb.CopySegmentTaskState_CopySegmentTaskInProgress,
 		},
 		nil,
-	).Build()
-	defer mockQuery.UnPatch()
+	)
 
 	task := &copySegmentTask{
 		tr:    timerecord.NewTimeRecorder("test"),
@@ -497,12 +496,11 @@ func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_NotCompletedKeepsTaskInProg
 }
 
 func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_MarksFailedOnRPCError() {
-	cluster := &struct{ session.Cluster }{}
-	mockQuery := mockey.Mock((*struct{ session.Cluster }).QueryCopySegment).Return(
+	cluster := session.NewMockCluster(s.T())
+	cluster.EXPECT().QueryCopySegment(mock.Anything, mock.Anything).Return(
 		nil,
 		errors.New("rpc failed"),
-	).Build()
-	defer mockQuery.UnPatch()
+	)
 
 	task := createTestCopyTask(100, 2001).(*copySegmentTask)
 	copyMeta, _ := newCopySegmentTaskTestMeta(s.T(), task)
@@ -515,16 +513,15 @@ func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_MarksFailedOnRPCError() {
 }
 
 func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_MarksFailedOnWorkerFailure() {
-	cluster := &struct{ session.Cluster }{}
-	mockQuery := mockey.Mock((*struct{ session.Cluster }).QueryCopySegment).Return(
+	cluster := session.NewMockCluster(s.T())
+	cluster.EXPECT().QueryCopySegment(mock.Anything, mock.Anything).Return(
 		&datapb.QueryCopySegmentResponse{
 			TaskID: 1001,
 			State:  datapb.CopySegmentTaskState_CopySegmentTaskFailed,
 			Reason: "worker failed",
 		},
 		nil,
-	).Build()
-	defer mockQuery.UnPatch()
+	)
 
 	task := createTestCopyTask(100, 2001).(*copySegmentTask)
 	copyMeta, _ := newCopySegmentTaskTestMeta(s.T(), task)
@@ -537,8 +534,8 @@ func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_MarksFailedOnWorkerFailure(
 }
 
 func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_CompletedSyncsTask() {
-	cluster := &struct{ session.Cluster }{}
-	mockQuery := mockey.Mock((*struct{ session.Cluster }).QueryCopySegment).Return(
+	cluster := session.NewMockCluster(s.T())
+	cluster.EXPECT().QueryCopySegment(mock.Anything, mock.Anything).Return(
 		&datapb.QueryCopySegmentResponse{
 			TaskID: 1001,
 			State:  datapb.CopySegmentTaskState_CopySegmentTaskCompleted,
@@ -552,8 +549,7 @@ func (s *CopySegmentTaskSuite) TestQueryTaskOnWorker_CompletedSyncsTask() {
 			},
 		},
 		nil,
-	).Build()
-	defer mockQuery.UnPatch()
+	)
 
 	task := createTestCopyTask(100, 2001).(*copySegmentTask)
 	copyMeta, m := newCopySegmentTaskTestMeta(s.T(), task)


### PR DESCRIPTION
Fixes #50490

## What this PR does

This PR replaces the anonymous embedded `struct{ session.Cluster }` mockey patch in copy segment tests with the generated `session.MockCluster`. The tests still mock `QueryCopySegment`, but they no longer use an anonymous struct method expression that triggers the Go 1.26.4 `printf` analyzer panic during vet.

## Verification

```bash
gofumpt -l internal/datacoord/copy_segment_task_test.go
git diff --check
rg -n "mockey\.Mock\(\(\*struct\{|\(\*struct\{[^\n]*\}\)\." --glob "*.go"
source scripts/setenv.sh && go test -vet=printf -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r ${MILVUS_WORK_DIR}/cmake_build/lib -r ${MILVUS_WORK_DIR}/internal/core/output/lib" -run "^$" -exec /usr/bin/true -count=1 ./internal/datacoord
rm -rf /tmp/milvus2-test-libs && mkdir -p /tmp/milvus2-test-libs && for f in internal/core/output/lib/*.dylib cmake_build/thirdparty/boost_ext/*.dylib; do ln -sf "$PWD/$f" /tmp/milvus2-test-libs/; done && source scripts/setenv.sh && go test -v -vet=off -tags dynamic,test -gcflags="all=-N -l" -ldflags="-r /tmp/milvus2-test-libs" -run "TestCopySegmentTask/TestQueryTaskOnWorker" -count=1 ./internal/datacoord
```
