### PR TITLE
feat: add predicate delete producer path

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1128,6 +1128,8 @@ common:
     taskPoolReleaseTimeoutSeconds: 60 # The maximum time to wait for the task to finish and release resources in the pool
   enabledOptimizeExpr: true # Indicates whether to enable optimize expr
   enableDriverPrefetch: false # Indicates whether to enable query driver prefetch in segcore.
+  enablePredicateDelete: false # Whether to enable predicate delete WAL events for non-simple delete expressions.
+  predicateDeleteHitCountThreshold: 1024 # Use predicate delete only when the matched row count is greater than this threshold.
   enabledJSONShredding: true # Indicates sealedsegment whether to enable JSON key stats
   enabledGrowingSegmentJSONShredding: false # Indicates growingsegment whether to enable JSON key stats
   enableConfigParamTypeCheck: true # Indicates whether to enable config param type check

--- a/docs/design-docs/design_docs/20260626-predicate-delete.md
+++ b/docs/design-docs/design_docs/20260626-predicate-delete.md
@@ -1,0 +1,172 @@
+# MEP: PredicateDelete — Expression Delete as Durable Predicate Events
+
+- **Created:** 2026-06-26
+- **Author(s):** @MrPresent-Han
+- **Status:** In Progress (Part 1 — Proxy/WAL Producer — implemented)
+- **Component:** Proxy, StreamingNode, QueryNode (Delegator/Segcore), DataCoord/DataNode, milvus-storage
+- **Related Issues:** #50433
+- **Released:** TBD
+
+## Summary
+
+Today a complex `delete by expr` is executed by first querying the matched primary keys (PKs) and then writing ordinary `(pk, ts)` delete rows. This is reliable when the expression matches few rows, but when the expression matches a huge number of rows a single delete is amplified into a massive number of PK delete entries that propagate pressure into the WAL, StreamingNode, L0 compaction, and the QueryNode delegator.
+
+**PredicateDelete** turns a large-scale expression delete from *"a huge set of PK rows"* into *"a small set of durable predicate events"*. The system first guarantees that online queries never miss a delete, then converges physically through L0 forwarding and segment rewrite. PredicateDelete runs as a **parallel lifecycle** alongside the existing PK-delete path; it does not replace it and preserves a full fallback.
+
+This MEP describes the end-to-end design across five parts. **Part 1 (Proxy/WAL producer) is implemented by #50501**; Parts 2–5 are the forward plan and are summarized here for context.
+
+## Motivation
+
+The current expression-delete main path (`query matched PKs → write ordinary `(pk, ts)` deletes`) has these shortcomings when the match count is large:
+
+- **WAL IO pressure**: the expression delete is expanded into a large PK payload; WAL write, replication, and recovery cost grow linearly with the matched row count.
+- **StreamingNode buffer pressure**: SN must buffer, account, and sync ordinary delete rows; large PK/timestamp volumes amplify memory and flush pressure.
+- **L0 compaction pressure**: many PK delete rows produce many L0 carriers and additional L0 compaction scheduling/execution pressure.
+- **Delegator burden**: the QueryNode delegator must always load/replay large L0 segments, slowing recovery load and increasing CPU on the delegator node.
+
+The goal is to make the durable footprint of a complex delete proportional to *the number of delete operations*, not *the number of matched rows*.
+
+```text
+delete expr
+  -> proxy:         PredicateDelete WAL event
+  -> streamingNode: predicate-delta L0 persistence
+  -> queryNode:     replay / evaluate (online correctness)
+  -> datanode:      L0 compaction forwards events
+  -> datanode:      rewrite drops matched rows (physical convergence)
+```
+
+## Goals
+
+- Keep the durable representation of a large expression delete `O(events)` instead of `O(matched rows)`.
+- Preserve online correctness (no missed deletes) at all times, including during segment loading.
+- Run as a parallel path that never breaks existing PK-delete semantics, with a config-gated fallback.
+
+## Non-Goals
+
+- Replacing the PK-delete path. PK deletes remain concrete `(pk, ts)` rows.
+- Supporting arbitrary expressions in the first version. JSON, array, text-match, function, and complex cast nodes are unsupported and must fail fast / fall back.
+- Reusing predicate event counts as deleted-row counts (see Guardrails).
+
+## Overall Principles
+
+- **Parallel paths**: PK delete is concrete `(pk, ts)` rows; PredicateDelete is an expression event and does not reuse PK deltalog semantics.
+- **Independent counting**: a predicate event count is *not* a deleted-row count. It must not feed delete-ratio, `TotalRows`, or deleted-row metrics.
+- **Execution source of truth**: `serialized_expr_plan` is the correctness source; `expr` is for debug/log only. Executors must never re-parse the expression string.
+- **Schema binding**: each event carries `schema_version`; replay/compaction must interpret the expression using the delete-time schema, not the latest schema.
+- **Convergence order**: QueryNode guarantees online correctness, L0 compaction forwards pending events, and the rewrite stage physically drops matched rows.
+
+## Part 1 — Proxy / WAL Producer (implemented, #50501)
+
+**Components:** Proxy delete task (`internal/proxy/task_delete.go`, `task_delete_streaming.go`), WAL append helper, config `common.enablePredicateDelete` / `common.predicateDeleteHitCountThreshold`, `msgpb.DeleteRequest`.
+
+### Routing and fallback
+
+Proxy reuses the existing `getPrimaryKeysFromPlan` split point:
+
+- `pk == x` and `pk IN [...]` continue to use **Simple Delete** (direct `(pk, ts)` rows).
+- Any other expression is a **non-simple delete**. When `common.enablePredicateDelete=false` (default), it keeps the existing query-PK fallback (`complexDelete`). When enabled, the producer additionally guards on match-count to avoid using a predicate event for tiny deletes.
+
+```go
+isSimple, pk, numRow := getPrimaryKeysFromPlan(schema, plan)
+if isSimple {
+    return simpleDelete(ctx, pk, numRow)
+}
+return nonSimpleDelete(ctx, plan) // predicate-delete decision + fallback
+```
+
+```go
+// nonSimpleDelete (simplified)
+if !enablePredicateDelete { return complexDelete(plan) }            // feature off
+if !canUsePredicateDelete(plan, schema) { return complexDelete(plan) } // unsupported expr -> PK fallback
+matched, err := countPredicateDeleteHits(plan)                     // count-only query
+if err != nil { return err }
+if matched <= predicateDeleteHitCountThreshold { return complexDelete(plan) } // small delete -> PK path
+return predicateDelete(plan)                                       // emit predicate event
+```
+
+The threshold (`common.predicateDeleteHitCountThreshold`, default `1024`) ensures PredicateDelete is only used when it actually pays off; below the threshold the cheaper PK path is used.
+
+### Supported expressions (first version)
+
+`canUsePredicateDelete` conservatively allow-lists expressions that are safe to evaluate later by Segcore / storage:
+
+- Comparison ops on a plain scalar field vs. a scalar literal: `==`, `!=`, `<`, `<=`, `>`, `>=`.
+- `field IN [literal, ...]` (plain field membership, not container `IsInField`).
+- `IS NULL`.
+- Boolean composition: `AND`, `OR`, `NOT`.
+
+Unsupported (fall back to PK delete): JSON path / array-element columns, dynamic fields, templated expressions, container-membership term, non-scalar literals, column-vs-column comparisons, `IS NOT NULL`, arithmetic, etc.
+
+### All-vchannel append
+
+A PredicateDelete event has no PK hash, so it cannot be routed to a single vchannel by PK. The proxy appends the **same** predicate event to **every** vchannel of the collection. `partition_ids` is the authoritative scope; PK fields / `NumRows` carry no authoritative meaning for a PredicateDelete.
+
+### WAL contract
+
+The WAL payload extends the existing `DeleteRequest`; no new streaming message type is introduced.
+
+```text
+PredicateDelete (carried on DeleteRequest):
+  expr                  // diagnostic only
+  serialized_expr_plan  // proto.Marshal(planpb.PlanNode) — correctness source
+  delete_timestamp      // MVCC ts
+  schema_version        // delete-time schema
+  partition_ids         // authoritative scope
+```
+
+## Part 2 — StreamingNode / flushcommon: persist predicate delta (planned)
+
+StreamingNode does not evaluate the predicate; it only persists it durably. PredicateDelete uses an independent buffer / writer / metadata and must not enter `storage.DeleteData`. One Arrow row represents one predicate delete event. Multi-partition events are not fanned out into multiple L0 segments; the carrier organizes at channel/WAL level and keeps the full partition scope in the event's `partition_ids`.
+
+`SegmentInfo.PredicateDeltalogs` is a scheduling summary (event count / log size / timestamp range / segment-level `partition_ids` union) that DataCoord can read without opening predicate-delta files. In V3, the real file paths live in a separate manifest `predicate_delta_logs` section.
+
+```text
+metadata: milvus.predicate_delta.format_version = 1
+columns:  source_msg_id, delete_ts, schema_version,
+          partition_ids, expr, serialized_expr_plan
+```
+
+## Part 3 — QueryNode / Segcore: online correctness (planned)
+
+The QueryNode pipeline recognizes PredicateDelete first and must not enter PK-delete alignment / empty-timestamp validation (a PredicateDelete has no PrimaryKeys/Timestamps). The delegator keeps an independent predicate buffer for online forwarding and loading-segment catch-up; raw events never go into `storage.DeleteData` or the PK delete buffer.
+
+Online sealed/growing segments apply an event immediately after partition-scope selection (no bloom-filter prefiltering, since there is no PK). Loading a sealed segment is the no-gap critical window: replay persisted predicate L0, snapshot the predicate buffer, catch up new events, then join distribution. Segcore evaluates the expression to matched row offsets and inserts `DeletedRecord(delete_ts, row_offset)` into the existing MVCC delete model.
+
+## Part 4 — DataCoord / DataNode: L0 compaction forwarding (planned)
+
+L0 compaction does not evaluate the predicate; it forwards pending predicate events from L0 carriers to potentially affected target L1/L2 segments. DataCoord reads only the `PredicateDeltalogs` summary (partition union) for scheduling. Predicate L0 segments are organized separately from ordinary PK-delete L0 segments. Compaction results emit `Deltalogs` and `PredicateDeltalogs` in parallel; predicate events never go into ordinary `Deltalogs`, and event count is never treated as deleted rows.
+
+## Part 5 — milvus-storage: delete-aware reader / physical rewrite (planned)
+
+Physical rewrite computes a row-level alive mask from the manifest delete logs; the Milvus writer appends alive rows to a new segment. The first version returns an aligned `RecordBatch + keep_mask` (bit=1 means alive) rather than filtering inside storage. A `DeleteEvaluator` loads both PK delta (`pk -> max_delete_ts`) and predicate delta (`serialized_expr_plan` → storage IR → Arrow compute). Every delete type requires `row_ts <= delete_ts`; a null predicate result does not delete (only a definite-true match deletes).
+
+```text
+deleted   = (pk_match(row) AND row_ts <= pk_delete_ts)
+          OR (predicate_true(row) AND row_ts <= predicate_delete_ts)
+keep_mask = NOT deleted
+```
+
+## Public Interfaces
+
+### Config (`common`)
+
+| Key | Default | Refreshable | Meaning |
+|-----|---------|-------------|---------|
+| `common.enablePredicateDelete` | `false` | yes | Master switch for the PredicateDelete producer path. |
+| `common.predicateDeleteHitCountThreshold` | `1024` | yes | Use predicate delete only when the matched row count is greater than this threshold; otherwise fall back to PK delete. |
+
+### WAL payload
+
+PredicateDelete reuses `msgpb.DeleteRequest` and carries `serialized_expr_plan`, `delete_timestamp`, `schema_version`, and `partition_ids` (authoritative scope). No new streaming message type is added.
+
+## Risks & Guardrails
+
+- **Rolling upgrade**: old QueryNode/DataNode must not silently ignore a PredicateDelete event; a feature/version gate is required.
+- **No-gap correctness**: a loading segment must not become visible until replay + buffer catch-up completes.
+- **Schema evolution**: executors must use the delete-time schema/version and never reinterpret the expression with the latest schema.
+- **Event identity / idempotency**: the first version may use `source_msg_id` / WAL position; long term needs stable event identity or a checkpoint.
+- **Metrics semantics**: a predicate event count means *number of events only* — never deleted-row count, delete ratio, or task `TotalRows`.
+
+## Conclusion
+
+PredicateDelete reduces a large-scale `delete by expr` from a huge set of PK delete rows to a small set of durable predicate events. It establishes a parallel lifecycle across Proxy, StreamingNode, QueryNode, DataCoord/DataNode, and milvus-storage without breaking existing PK-delete semantics or the fallback path: Proxy produces events, StreamingNode persists them, QueryNode guarantees online visibility, DataNode L0 compaction forwards pending events, and full/mix compaction or the milvus-storage delete-aware reader physically filters rows during rewrite. This lowers long-term pressure on WAL IO, StreamingNode buffers, L0 compaction, and delegator L0 replay.

--- a/internal/proxy/task_delete.go
+++ b/internal/proxy/task_delete.go
@@ -18,6 +18,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy/shardclient"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/exprutil"
+	"github.com/milvus-io/milvus/internal/util/funcutil"
 	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -412,20 +413,10 @@ func (dr *deleteRunner) Run(ctx context.Context) error {
 	isSimple, pk, numRow := getPrimaryKeysFromPlan(dr.schema.CollectionSchema, dr.plan)
 	if isSimple {
 		// if could get delete.primaryKeys from delete expr
-		err := dr.simpleDelete(ctx, pk, numRow)
-		if err != nil {
-			return err
-		}
-	} else {
-		// if get complex delete expr
-		// need query from querynode before delete
-		err := dr.complexDelete(ctx, dr.plan)
-		if err != nil {
-			mlog.Warn(ctx, "complex delete failed,but delete some data", mlog.Int64("count", dr.result.DeleteCnt), mlog.String("expr", dr.req.GetExpr()))
-			return err
-		}
+		return dr.simpleDelete(ctx, pk, numRow)
 	}
-	return nil
+
+	return dr.nonSimpleDelete(ctx, dr.plan)
 }
 
 func (dr *deleteRunner) produce(ctx context.Context, primaryKeys *schemapb.IDs, partitionID UniqueID) (*deleteTask, error) {
@@ -585,16 +576,208 @@ func (dr *deleteRunner) receiveQueryResult(ctx context.Context, client querypb.Q
 	}
 }
 
-func (dr *deleteRunner) complexDelete(ctx context.Context, plan *planpb.PlanNode) error {
-	rc := timerecord.NewTimeRecorder("QueryStreamDelete")
-	var err error
+// canUsePredicateDelete is a local conservative allowlist for predicate-delete producer safety.
+// Existing Milvus expression validators cover the broader query engine, while predicate delete storage apply supports a narrower subset.
+func canUsePredicateDelete(plan *planpb.PlanNode, schema *schemapb.CollectionSchema) bool {
+	if plan == nil || plan.GetQuery() == nil {
+		return false
+	}
+	return canUsePredicateDeleteExpr(plan.GetQuery().GetPredicates(), schema)
+}
 
-	dr.msgID, err = dr.idAllocator.AllocOne()
+// predicateDeleteAllowedCompareOps and predicateDeleteAllowedBinaryOps are the single,
+// greppable source of truth for the expression operators predicate delete accepts today.
+// canUsePredicateDeleteExpr default-denies anything not enumerated here, so newly added
+// planpb operators stay unsupported until they are deliberately allowed.
+var predicateDeleteAllowedCompareOps = map[planpb.OpType]bool{
+	planpb.OpType_Equal:        true,
+	planpb.OpType_NotEqual:     true,
+	planpb.OpType_LessThan:     true,
+	planpb.OpType_LessEqual:    true,
+	planpb.OpType_GreaterThan:  true,
+	planpb.OpType_GreaterEqual: true,
+}
+
+var predicateDeleteAllowedBinaryOps = map[planpb.BinaryExpr_BinaryOp]bool{
+	planpb.BinaryExpr_LogicalAnd: true,
+	planpb.BinaryExpr_LogicalOr:  true,
+}
+
+func canUsePredicateDeleteExpr(expr *planpb.Expr, schema *schemapb.CollectionSchema) bool {
+	if expr == nil || expr.GetIsTemplate() {
+		return false
+	}
+
+	switch e := expr.GetExpr().(type) {
+	case *planpb.Expr_BinaryExpr:
+		binaryExpr := e.BinaryExpr
+		return predicateDeleteAllowedBinaryOps[binaryExpr.GetOp()] &&
+			canUsePredicateDeleteExpr(binaryExpr.GetLeft(), schema) &&
+			canUsePredicateDeleteExpr(binaryExpr.GetRight(), schema)
+	case *planpb.Expr_UnaryExpr:
+		unaryExpr := e.UnaryExpr
+		return unaryExpr.GetOp() == planpb.UnaryExpr_Not &&
+			canUsePredicateDeleteExpr(unaryExpr.GetChild(), schema)
+	case *planpb.Expr_UnaryRangeExpr:
+		unaryRangeExpr := e.UnaryRangeExpr
+		return predicateDeleteAllowedCompareOps[unaryRangeExpr.GetOp()] &&
+			unaryRangeExpr.GetTemplateVariableName() == "" &&
+			len(unaryRangeExpr.GetExtraValues()) == 0 &&
+			isPredicateDeleteColumnSupported(schema, unaryRangeExpr.GetColumnInfo()) &&
+			isPredicateDeleteLiteralSupported(unaryRangeExpr.GetValue())
+	case *planpb.Expr_TermExpr:
+		termExpr := e.TermExpr
+		// Plain field IN literal-list uses ColumnInfo + Values; IsInField is for container membership.
+		if termExpr.GetIsInField() || termExpr.GetTemplateVariableName() != "" || len(termExpr.GetValues()) == 0 {
+			return false
+		}
+		if !isPredicateDeleteColumnSupported(schema, termExpr.GetColumnInfo()) {
+			return false
+		}
+		for _, value := range termExpr.GetValues() {
+			if !isPredicateDeleteLiteralSupported(value) {
+				return false
+			}
+		}
+		return true
+	case *planpb.Expr_NullExpr:
+		nullExpr := e.NullExpr
+		return nullExpr.GetOp() == planpb.NullExpr_IsNull &&
+			isPredicateDeleteColumnSupported(schema, nullExpr.GetColumnInfo())
+	default:
+		// default-deny: new planpb.Expr_* variants must be explicitly enumerated above.
+		return false
+	}
+}
+
+func isPredicateDeleteColumnSupported(schema *schemapb.CollectionSchema, columnInfo *planpb.ColumnInfo) bool {
+	if schema == nil || columnInfo == nil {
+		return false
+	}
+	if len(columnInfo.GetNestedPath()) > 0 || columnInfo.GetIsElementLevel() {
+		return false
+	}
+	if !isPredicateDeleteScalarType(columnInfo.GetDataType()) {
+		return false
+	}
+
+	for _, field := range schema.GetFields() {
+		if field.GetFieldID() != columnInfo.GetFieldId() {
+			continue
+		}
+		if field.GetIsDynamic() || field.GetDataType() != columnInfo.GetDataType() {
+			return false
+		}
+		return isPredicateDeleteScalarType(field.GetDataType())
+	}
+	return false
+}
+
+func isPredicateDeleteScalarType(dataType schemapb.DataType) bool {
+	switch dataType {
+	case schemapb.DataType_Bool,
+		schemapb.DataType_Int8,
+		schemapb.DataType_Int16,
+		schemapb.DataType_Int32,
+		schemapb.DataType_Int64,
+		schemapb.DataType_Float,
+		schemapb.DataType_Double,
+		schemapb.DataType_String,
+		schemapb.DataType_VarChar:
+		return true
+	default:
+		return false
+	}
+}
+
+func isPredicateDeleteLiteralSupported(value *planpb.GenericValue) bool {
+	if value == nil {
+		return false
+	}
+	switch value.GetVal().(type) {
+	case *planpb.GenericValue_BoolVal,
+		*planpb.GenericValue_Int64Val,
+		*planpb.GenericValue_FloatVal,
+		*planpb.GenericValue_StringVal:
+		return true
+	default:
+		return false
+	}
+}
+
+// nonSimpleDelete uses predicate delete only when it is enabled, supported, and the matched row count is above the threshold.
+// Otherwise it keeps the existing PK-delete path for non-simple expressions.
+func (dr *deleteRunner) nonSimpleDelete(ctx context.Context, plan *planpb.PlanNode) error {
+	// Allocate a single MVCC delete timestamp for the whole non-simple delete so the
+	// count probe and the chosen path (complexDelete or predicateDelete) all use the
+	// same ts ("count at T, delete at T").
+	deleteTs, err := dr.tsoAllocatorIns.AllocOne(ctx)
 	if err != nil {
 		return err
 	}
+	// Predicate delete is only applied under the StorageV3 format (common.storage.useLoonFFI)
+	// and behind the feature flag; fall back to the PK-delete path when either is off.
+	if !paramtable.Get().CommonCfg.EnablePredicateDelete.GetAsBool() ||
+		!paramtable.Get().CommonCfg.UseLoonFFI.GetAsBool() {
+		if err = dr.complexDelete(ctx, plan, deleteTs); err != nil {
+			mlog.Warn(ctx, "complex delete failed,but delete some data", mlog.Int64("count", dr.result.DeleteCnt), mlog.String("expr", dr.req.GetExpr()))
+			return err
+		}
+		return nil
+	}
+	if !canUsePredicateDelete(plan, dr.schema.CollectionSchema) {
+		mlog.Info(ctx, "predicate delete falls back to pk delete for unsupported expression", mlog.String("expr", dr.req.GetExpr()))
+		if err = dr.complexDelete(ctx, plan, deleteTs); err != nil {
+			mlog.Warn(ctx, "complex delete failed,but delete some data", mlog.Int64("count", dr.result.DeleteCnt), mlog.String("expr", dr.req.GetExpr()))
+			return err
+		}
+		return nil
+	}
 
-	dr.ts, err = dr.tsoAllocatorIns.AllocOne(ctx)
+	matchedCount, err := dr.countPredicateDeleteHits(ctx, plan, deleteTs)
+	if err != nil {
+		// The count probe is only a path-selection signal; the request is still fully
+		// serviceable via complexDelete. A transient QueryNode or partial-shard error
+		// must not turn a working delete into a user-visible failure, so fall back to
+		// the PK-delete path. Real context cancellation/timeout is still propagated.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		mlog.Warn(ctx, "predicate delete count probe failed, falling back to pk delete",
+			mlog.String("expr", dr.req.GetExpr()), mlog.Err(err))
+		if err = dr.complexDelete(ctx, plan, deleteTs); err != nil {
+			mlog.Warn(ctx, "complex delete failed,but delete some data", mlog.Int64("count", dr.result.DeleteCnt), mlog.String("expr", dr.req.GetExpr()))
+			return err
+		}
+		return nil
+	}
+	threshold := paramtable.Get().CommonCfg.PredicateDeleteHitCountThreshold.GetAsInt64()
+	if matchedCount <= threshold {
+		mlog.Info(ctx, "predicate delete falls back to pk delete",
+			mlog.Int64("matchedCount", matchedCount),
+			mlog.Int64("threshold", threshold),
+			mlog.String("expr", dr.req.GetExpr()))
+		if err = dr.complexDelete(ctx, plan, deleteTs); err != nil {
+			mlog.Warn(ctx, "complex delete failed,but delete some data", mlog.Int64("count", dr.result.DeleteCnt), mlog.String("expr", dr.req.GetExpr()))
+			return err
+		}
+		return nil
+	}
+
+	if err = dr.predicateDelete(ctx, plan, matchedCount, deleteTs); err != nil {
+		mlog.Warn(ctx, "predicate delete failed", mlog.String("expr", dr.req.GetExpr()), mlog.Err(err))
+		return err
+	}
+	return nil
+}
+
+func (dr *deleteRunner) complexDelete(ctx context.Context, plan *planpb.PlanNode, ts uint64) error {
+	rc := timerecord.NewTimeRecorder("QueryStreamDelete")
+	var err error
+
+	dr.ts = ts
+
+	dr.msgID, err = dr.idAllocator.AllocOne()
 	if err != nil {
 		return err
 	}
@@ -632,6 +815,126 @@ func (dr *deleteRunner) complexDelete(ctx context.Context, plan *planpb.PlanNode
 	}
 	mlog.Info(ctx, "complex delete finished", mlog.Int64("deleteCnt", dr.result.GetDeleteCnt()), mlog.Duration("interval", rc.ElapseSpan()))
 	return nil
+}
+
+// predicateDelete appends predicate-delete WAL messages. deleteTs is the shared MVCC delete
+// timestamp allocated by nonSimpleDelete (same ts used by the count probe). matchedCount is the
+// probe-time hit count and is reported as the affected-rows estimate; the physical delete is
+// applied asynchronously by the consumer side.
+func (dr *deleteRunner) predicateDelete(ctx context.Context, plan *planpb.PlanNode, matchedCount int64, deleteTs uint64) error {
+	serializedPlan, err := proto.Marshal(plan)
+	if err != nil {
+		return err
+	}
+
+	dr.ts = deleteTs
+
+	// Allocate a msgID for parity with complexDelete/simpleDelete so any post-run
+	// consumer of dr.msgID (logs, metrics, audit) observes a real value on the
+	// predicate path too, instead of a zero value only for predicate deletes.
+	dr.msgID, err = dr.idAllocator.AllocOne()
+	if err != nil {
+		return err
+	}
+
+	partitionID := common.AllPartitionsID
+	if len(dr.partitionIDs) == 1 {
+		partitionID = dr.partitionIDs[0]
+	}
+
+	sessionTS, err := appendPredicateDeleteMessages(
+		ctx,
+		dr.collectionID,
+		dr.req.GetCollectionName(),
+		partitionID,
+		dr.req.GetPartitionName(),
+		dr.req.GetDbName(),
+		dr.vChannels,
+		dr.idAllocator,
+		dr.ts,
+		serializedPlan,
+	)
+	if err != nil {
+		return err
+	}
+
+	dr.result.DeleteCnt = matchedCount
+	dr.result.Timestamp = sessionTS
+	return nil
+}
+
+func (dr *deleteRunner) countPredicateDeleteHits(ctx context.Context, plan *planpb.PlanNode, queryTs uint64) (int64, error) {
+	countPlan, ok := proto.Clone(plan).(*planpb.PlanNode)
+	if !ok {
+		return 0, merr.WrapErrServiceInternalMsg("failed to clone delete plan for predicate delete count")
+	}
+	queryPlan := countPlan.GetQuery()
+	if queryPlan == nil {
+		return 0, merr.WrapErrServiceInternalMsg("predicate delete count requires a query plan")
+	}
+	queryPlan.IsCount = false
+	queryPlan.Aggregates = []*planpb.Aggregate{{Op: planpb.AggregateOp_count, FieldId: 0}}
+	countPlan.OutputFieldIds = nil
+
+	serializedPlan, err := proto.Marshal(countPlan)
+	if err != nil {
+		return 0, merr.WrapErrServiceInternalErr(err, "failed to serialize predicate delete count plan")
+	}
+
+	msgID, err := dr.idAllocator.AllocOne()
+	if err != nil {
+		return 0, err
+	}
+
+	var matchedCount atomic.Int64
+	err = dr.lb.Execute(ctx, shardclient.CollectionWorkLoad{
+		Db:             dr.req.GetDbName(),
+		CollectionName: dr.req.GetCollectionName(),
+		CollectionID:   dr.collectionID,
+		Nq:             1,
+		Exec: func(ctx context.Context, nodeID int64, qn types.QueryNodeClient, channel string) error {
+			result, err := qn.Query(ctx, &querypb.QueryRequest{
+				Req: &internalpb.RetrieveRequest{
+					Base: commonpbutil.NewMsgBase(
+						commonpbutil.WithMsgType(commonpb.MsgType_Retrieve),
+						commonpbutil.WithMsgID(msgID),
+						commonpbutil.WithSourceID(paramtable.GetNodeID()),
+						commonpbutil.WithTargetID(nodeID),
+					),
+					MvccTimestamp:      queryTs,
+					ReqID:              paramtable.GetNodeID(),
+					DbID:               0, // TODO
+					CollectionID:       dr.collectionID,
+					PartitionIDs:       dr.partitionIDs,
+					SerializedExprPlan: serializedPlan,
+					GuaranteeTimestamp: parseGuaranteeTsFromConsistency(queryTs, queryTs, dr.req.GetConsistencyLevel()),
+					QueryLabel:         metrics.DeleteQueryLabel,
+					Aggregates:         queryPlan.GetAggregates(),
+				},
+				DmlChannels: []string{channel},
+				Scope:       querypb.DataScope_All,
+			})
+			if err != nil {
+				return err
+			}
+			if result == nil {
+				return merr.WrapErrServiceInternalMsg("predicate delete count query returned nil result")
+			}
+			if err := merr.Error(result.GetStatus()); err != nil {
+				return err
+			}
+			count, err := funcutil.CntOfInternalResult(result)
+			if err != nil {
+				return merr.Wrap(err, "failed to parse predicate delete count result")
+			}
+			matchedCount.Add(count)
+			return nil
+		},
+	})
+	if err != nil {
+		return 0, err
+	}
+	return matchedCount.Load(), nil
 }
 
 func (dr *deleteRunner) simpleDelete(ctx context.Context, pk *schemapb.IDs, numRow int64) error {

--- a/internal/proxy/task_delete_streaming.go
+++ b/internal/proxy/task_delete_streaming.go
@@ -6,15 +6,96 @@ import (
 
 	"go.opentelemetry.io/otel"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/timerecord"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+// appendPredicateDeleteMessages appends one predicate-delete WAL message to each target vchannel.
+// It does not reuse the PK-delete repack path because predicate delete has no primary-key hash.
+func appendPredicateDeleteMessages(
+	ctx context.Context,
+	collectionID int64,
+	collectionName string,
+	partitionID int64,
+	partitionName string,
+	dbName string,
+	vChannels []string,
+	idAllocator allocator.Interface,
+	deleteTs uint64,
+	serializedPlan []byte,
+) (uint64, error) {
+	startMsgID, _, err := idAllocator.Alloc(uint32(len(vChannels)))
+	if err != nil {
+		return 0, err
+	}
+
+	var ez *message.CipherConfig
+	if hookutil.IsClusterEncryptionEnabled() {
+		schema, err := globalMetaCache.GetCollectionSchema(ctx, dbName, collectionName)
+		if err != nil {
+			mlog.Warn(ctx, "get collection schema from global meta cache failed", mlog.String("collectionName", collectionName), mlog.Err(err))
+			return 0, merr.WrapErrAsInputErrorWhen(err, merr.ErrCollectionNotFound, merr.ErrDatabaseNotFound)
+		}
+
+		ez = hookutil.GetEzByCollProperties(schema.GetProperties(), collectionID).AsMessageConfig()
+	}
+
+	msgs := make([]message.MutableMessage, 0, len(vChannels))
+	for idx, vchannel := range vChannels {
+		deleteReq := &msgpb.DeleteRequest{
+			Base: commonpbutil.NewMsgBase(
+				commonpbutil.WithMsgType(commonpb.MsgType_Delete),
+				commonpbutil.WithMsgID(startMsgID+int64(idx)),
+				commonpbutil.WithTimeStamp(deleteTs),
+				commonpbutil.WithSourceID(paramtable.GetNodeID()),
+			),
+			ShardName:      vchannel,
+			DbName:         dbName,
+			CollectionName: collectionName,
+			PartitionName:  partitionName,
+			CollectionID:   collectionID,
+			PartitionID:    partitionID,
+			// A predicate delete has no primary keys. It carries the single MVCC delete
+			// timestamp in Timestamps[0] (consumers read it via GetTimestamps and it also
+			// drives the message Begin/EndTimestamp) and the predicate in SerializedExprPlan.
+			// DeleteMsg.CheckAligned() special-cases this shape (expr plan set, 1 ts, 0 pks).
+			Timestamps:         []uint64{deleteTs},
+			SerializedExprPlan: serializedPlan,
+		}
+
+		msg, err := message.NewDeleteMessageBuilderV1().
+			WithHeader(&message.DeleteMessageHeader{
+				CollectionId: collectionID,
+				Rows:         0,
+			}).
+			WithBody(deleteReq).
+			WithVChannel(vchannel).
+			WithCipher(ez).
+			BuildMutable()
+		if err != nil {
+			return 0, err
+		}
+		msgs = append(msgs, msg)
+	}
+
+	resp := streaming.WAL().AppendMessages(ctx, msgs...)
+	if err := resp.UnwrapFirstError(); err != nil {
+		mlog.Warn(ctx, "append predicate delete messages to wal failed", mlog.Err(err))
+		return 0, err
+	}
+	return resp.MaxTimeTick(), nil
+}
 
 // Execute is a function to delete task by streaming service
 // we only overwrite the Execute function

--- a/internal/proxy/task_delete_test.go
+++ b/internal/proxy/task_delete_test.go
@@ -2,14 +2,18 @@ package proxy
 
 import (
 	"context"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/bytedance/mockey"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -17,14 +21,20 @@ import (
 	"github.com/milvus-io/milvus/internal/allocator"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
 	"github.com/milvus-io/milvus/internal/parser/planparserv2"
 	"github.com/milvus-io/milvus/internal/proxy/shardclient"
+	"github.com/milvus-io/milvus/internal/util/funcutil"
+	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/streamrpc"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/rootcoordpb"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -78,6 +88,32 @@ func Test_getPrimaryKeysFromPlan(t *testing.T) {
 		assert.Equal(t, int64(3), rowNum)
 	})
 
+	t.Run("delete with large simple term expr remains simple", func(t *testing.T) {
+		values := make([]string, 0, 1024)
+		for i := 0; i < 1024; i++ {
+			values = append(values, strconv.Itoa(i))
+		}
+		expr := "pk in [" + strings.Join(values, ",") + "]"
+		plan, err := planparserv2.CreateRetrievePlan(schema, expr, nil)
+		assert.NoError(t, err)
+
+		isSimple, pks, rowNum := getPrimaryKeysFromPlan(collSchema, plan)
+		assert.True(t, isSimple)
+		assert.NotNil(t, pks)
+		assert.Equal(t, int64(1024), rowNum)
+	})
+
+	t.Run("delete with pk equality OR expression is optimized to simple", func(t *testing.T) {
+		expr := "pk == 1 or pk == 2 or pk == 3"
+		plan, err := planparserv2.CreateRetrievePlan(schema, expr, nil)
+		assert.NoError(t, err)
+
+		isSimple, pks, rowNum := getPrimaryKeysFromPlan(collSchema, plan)
+		assert.True(t, isSimple)
+		assert.NotNil(t, pks)
+		assert.Equal(t, int64(3), rowNum)
+	})
+
 	t.Run("delete failed with simple term expr", func(t *testing.T) {
 		expr := "pk in [1, 2, 3]"
 		plan, err := planparserv2.CreateRetrievePlan(schema, expr, nil)
@@ -108,6 +144,209 @@ func Test_getPrimaryKeysFromPlan(t *testing.T) {
 		isSimple, _, _ := getPrimaryKeysFromPlan(collSchema, plan)
 		assert.False(t, isSimple)
 	})
+}
+
+func TestCanUsePredicateDelete(t *testing.T) {
+	collSchema := &schemapb.CollectionSchema{
+		Name: "test_delete",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: common.StartOfUserFieldID, Name: "pk", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+			{FieldID: common.StartOfUserFieldID + 1, Name: "non_pk", DataType: schemapb.DataType_Int64},
+			{FieldID: common.StartOfUserFieldID + 2, Name: "other_int", DataType: schemapb.DataType_Int64},
+			{FieldID: common.StartOfUserFieldID + 3, Name: "varchar_field", DataType: schemapb.DataType_VarChar},
+			{FieldID: common.StartOfUserFieldID + 4, Name: "bool_field", DataType: schemapb.DataType_Bool},
+			{FieldID: common.StartOfUserFieldID + 5, Name: "json_field", DataType: schemapb.DataType_JSON},
+			{FieldID: common.StartOfUserFieldID + 6, Name: "array_field", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int64},
+		},
+	}
+	schema, err := typeutil.CreateSchemaHelper(collSchema)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		expr string
+		want bool
+	}{
+		{name: "compare scalar with literal", expr: "non_pk >= 1", want: true},
+		{name: "logical operators", expr: "non_pk > 1 and (varchar_field == \"a\" or not (bool_field == true))", want: true},
+		{name: "in expression", expr: "varchar_field in [\"a\", \"b\"]", want: true},
+		{name: "is null", expr: "varchar_field is null", want: true},
+		{name: "json path", expr: "json_field[\"a\"] == 1", want: false},
+		{name: "array element", expr: "array_field[0] == 1", want: false},
+		{name: "arithmetic", expr: "non_pk + 1 == 2", want: false},
+		{name: "column compare", expr: "non_pk < other_int", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan, err := planparserv2.CreateRetrievePlan(schema, tt.expr, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, canUsePredicateDelete(plan, collSchema))
+		})
+	}
+}
+
+func Test_canUsePredicateDelete_nilPlan(t *testing.T) {
+	collSchema := &schemapb.CollectionSchema{}
+	assert.False(t, canUsePredicateDelete(nil, collSchema))
+	assert.False(t, canUsePredicateDelete(&planpb.PlanNode{}, collSchema))
+	// non-query plan node never reaches predicate delete
+	assert.False(t, canUsePredicateDelete(&planpb.PlanNode{
+		Node: &planpb.PlanNode_Query{Query: &planpb.QueryPlanNode{}},
+	}, collSchema))
+}
+
+func Test_predicateDeleteAllowedCompareOps(t *testing.T) {
+	supported := []planpb.OpType{
+		planpb.OpType_Equal, planpb.OpType_NotEqual,
+		planpb.OpType_LessThan, planpb.OpType_LessEqual,
+		planpb.OpType_GreaterThan, planpb.OpType_GreaterEqual,
+	}
+	for _, op := range supported {
+		assert.True(t, predicateDeleteAllowedCompareOps[op], op.String())
+	}
+	unsupported := []planpb.OpType{
+		planpb.OpType_Invalid, planpb.OpType_Range,
+		planpb.OpType_In, planpb.OpType_PrefixMatch,
+	}
+	for _, op := range unsupported {
+		assert.False(t, predicateDeleteAllowedCompareOps[op], op.String())
+	}
+}
+
+func Test_isPredicateDeleteScalarType(t *testing.T) {
+	supported := []schemapb.DataType{
+		schemapb.DataType_Bool, schemapb.DataType_Int8, schemapb.DataType_Int16,
+		schemapb.DataType_Int32, schemapb.DataType_Int64, schemapb.DataType_Float,
+		schemapb.DataType_Double, schemapb.DataType_String, schemapb.DataType_VarChar,
+	}
+	for _, dt := range supported {
+		assert.True(t, isPredicateDeleteScalarType(dt), dt.String())
+	}
+	unsupported := []schemapb.DataType{
+		schemapb.DataType_None, schemapb.DataType_JSON,
+		schemapb.DataType_Array, schemapb.DataType_FloatVector,
+	}
+	for _, dt := range unsupported {
+		assert.False(t, isPredicateDeleteScalarType(dt), dt.String())
+	}
+}
+
+func Test_isPredicateDeleteLiteralSupported(t *testing.T) {
+	assert.False(t, isPredicateDeleteLiteralSupported(nil))
+	assert.True(t, isPredicateDeleteLiteralSupported(&planpb.GenericValue{Val: &planpb.GenericValue_BoolVal{BoolVal: true}}))
+	assert.True(t, isPredicateDeleteLiteralSupported(&planpb.GenericValue{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}}))
+	assert.True(t, isPredicateDeleteLiteralSupported(&planpb.GenericValue{Val: &planpb.GenericValue_FloatVal{FloatVal: 1.0}}))
+	assert.True(t, isPredicateDeleteLiteralSupported(&planpb.GenericValue{Val: &planpb.GenericValue_StringVal{StringVal: "a"}}))
+	// array literal is not a supported scalar literal
+	assert.False(t, isPredicateDeleteLiteralSupported(&planpb.GenericValue{Val: &planpb.GenericValue_ArrayVal{ArrayVal: &planpb.Array{}}}))
+}
+
+func Test_isPredicateDeleteColumnSupported(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "int64_field", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "dynamic_field", DataType: schemapb.DataType_JSON, IsDynamic: true},
+			{FieldID: 102, Name: "json_field", DataType: schemapb.DataType_JSON},
+		},
+	}
+	tests := []struct {
+		name string
+		sch  *schemapb.CollectionSchema
+		col  *planpb.ColumnInfo
+		want bool
+	}{
+		{name: "nil schema", sch: nil, col: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64}, want: false},
+		{name: "nil column", sch: schema, col: nil, want: false},
+		{name: "nested path", sch: schema, col: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64, NestedPath: []string{"a"}}, want: false},
+		{name: "element level", sch: schema, col: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64, IsElementLevel: true}, want: false},
+		{name: "non scalar column type", sch: schema, col: &planpb.ColumnInfo{FieldId: 102, DataType: schemapb.DataType_JSON}, want: false},
+		{name: "field not found", sch: schema, col: &planpb.ColumnInfo{FieldId: 999, DataType: schemapb.DataType_Int64}, want: false},
+		{name: "dynamic field", sch: schema, col: &planpb.ColumnInfo{FieldId: 101, DataType: schemapb.DataType_Int64}, want: false},
+		{name: "type mismatch", sch: schema, col: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_VarChar}, want: false},
+		{name: "supported scalar", sch: schema, col: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPredicateDeleteColumnSupported(tt.sch, tt.col))
+		})
+	}
+}
+
+func Test_canUsePredicateDeleteExpr_branches(t *testing.T) {
+	schema := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "int64_field", DataType: schemapb.DataType_Int64},
+		},
+	}
+	validRange := &planpb.Expr{Expr: &planpb.Expr_UnaryRangeExpr{UnaryRangeExpr: &planpb.UnaryRangeExpr{
+		ColumnInfo: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64},
+		Op:         planpb.OpType_Equal,
+		Value:      &planpb.GenericValue{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}},
+	}}}
+
+	tests := []struct {
+		name string
+		expr *planpb.Expr
+		want bool
+	}{
+		{name: "nil expr", expr: nil, want: false},
+		{name: "template expr", expr: &planpb.Expr{IsTemplate: true, Expr: validRange.GetExpr()}, want: false},
+		{name: "unsupported expr type", expr: &planpb.Expr{}, want: false},
+		{name: "binary and valid", expr: &planpb.Expr{Expr: &planpb.Expr_BinaryExpr{BinaryExpr: &planpb.BinaryExpr{
+			Op: planpb.BinaryExpr_LogicalAnd, Left: validRange, Right: validRange,
+		}}}, want: true},
+		{name: "binary invalid op", expr: &planpb.Expr{Expr: &planpb.Expr_BinaryExpr{BinaryExpr: &planpb.BinaryExpr{
+			Op: planpb.BinaryExpr_Invalid, Left: validRange, Right: validRange,
+		}}}, want: false},
+		{name: "unary not valid", expr: &planpb.Expr{Expr: &planpb.Expr_UnaryExpr{UnaryExpr: &planpb.UnaryExpr{
+			Op: planpb.UnaryExpr_Not, Child: validRange,
+		}}}, want: true},
+		{name: "unary invalid op", expr: &planpb.Expr{Expr: &planpb.Expr_UnaryExpr{UnaryExpr: &planpb.UnaryExpr{
+			Op: planpb.UnaryExpr_Invalid, Child: validRange,
+		}}}, want: false},
+		{name: "unary range template var", expr: &planpb.Expr{Expr: &planpb.Expr_UnaryRangeExpr{UnaryRangeExpr: &planpb.UnaryRangeExpr{
+			ColumnInfo: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64},
+			Op:         planpb.OpType_Equal, TemplateVariableName: "v",
+		}}}, want: false},
+		{name: "unary range extra values", expr: &planpb.Expr{Expr: &planpb.Expr_UnaryRangeExpr{UnaryRangeExpr: &planpb.UnaryRangeExpr{
+			ColumnInfo:  &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64},
+			Op:          planpb.OpType_Equal,
+			Value:       &planpb.GenericValue{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}},
+			ExtraValues: []*planpb.GenericValue{{Val: &planpb.GenericValue_Int64Val{Int64Val: 2}}},
+		}}}, want: false},
+		{name: "term is-in-field", expr: &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: &planpb.TermExpr{
+			ColumnInfo: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64},
+			IsInField:  true,
+			Values:     []*planpb.GenericValue{{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}}},
+		}}}, want: false},
+		{name: "term empty values", expr: &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: &planpb.TermExpr{
+			ColumnInfo: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64},
+		}}}, want: false},
+		{name: "term unsupported column", expr: &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: &planpb.TermExpr{
+			ColumnInfo: &planpb.ColumnInfo{FieldId: 999, DataType: schemapb.DataType_Int64},
+			Values:     []*planpb.GenericValue{{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}}},
+		}}}, want: false},
+		{name: "term unsupported value", expr: &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: &planpb.TermExpr{
+			ColumnInfo: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64},
+			Values:     []*planpb.GenericValue{{Val: &planpb.GenericValue_ArrayVal{ArrayVal: &planpb.Array{}}}},
+		}}}, want: false},
+		{name: "term valid", expr: &planpb.Expr{Expr: &planpb.Expr_TermExpr{TermExpr: &planpb.TermExpr{
+			ColumnInfo: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64},
+			Values:     []*planpb.GenericValue{{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}}},
+		}}}, want: true},
+		{name: "null is-null", expr: &planpb.Expr{Expr: &planpb.Expr_NullExpr{NullExpr: &planpb.NullExpr{
+			Op: planpb.NullExpr_IsNull, ColumnInfo: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64},
+		}}}, want: true},
+		{name: "null is-not-null", expr: &planpb.Expr{Expr: &planpb.Expr_NullExpr{NullExpr: &planpb.NullExpr{
+			Op: planpb.NullExpr_IsNotNull, ColumnInfo: &planpb.ColumnInfo{FieldId: 100, DataType: schemapb.DataType_Int64},
+		}}}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, canUsePredicateDeleteExpr(tt.expr, schema))
+		})
+	}
 }
 
 func TestDeleteTask_GetChannels(t *testing.T) {
@@ -226,6 +465,319 @@ func TestDeleteTask_Execute(t *testing.T) {
 		}
 		streaming.ExpectErrorOnce(errors.New("mock error"))
 		assert.Error(t, dt.Execute(context.Background()))
+	})
+}
+
+func TestAppendPredicateDeleteMessages(t *testing.T) {
+	collectionName := "test_delete"
+	collectionID := int64(111)
+	partitionName := "default"
+	partitionID := int64(222)
+	dbName := "test_1"
+	vChannel := "test_channel"
+	deleteTs := uint64(1000)
+	serializedPlan := []byte{1, 2, 3}
+
+	t.Run("alloc failed", func(t *testing.T) {
+		idAllocator := allocator.NewMockAllocator(t)
+		idAllocator.EXPECT().Alloc(uint32(1)).Return(int64(0), int64(0), errors.New("mock alloc error"))
+
+		sessionTS, err := appendPredicateDeleteMessages(
+			context.Background(),
+			collectionID,
+			collectionName,
+			partitionID,
+			partitionName,
+			dbName,
+			[]string{vChannel},
+			idAllocator,
+			deleteTs,
+			serializedPlan,
+		)
+
+		require.Error(t, err)
+		assert.Zero(t, sessionTS)
+	})
+
+	t.Run("build message failed", func(t *testing.T) {
+		idAllocator := allocator.NewMockAllocator(t)
+		idAllocator.EXPECT().Alloc(uint32(1)).Return(int64(10), int64(11), nil)
+
+		// Invalid UTF-8 in a proto3 string field makes the message body marshal fail.
+		sessionTS, err := appendPredicateDeleteMessages(
+			context.Background(),
+			collectionID,
+			collectionName,
+			partitionID,
+			partitionName,
+			"\xff\xfe",
+			[]string{vChannel},
+			idAllocator,
+			deleteTs,
+			serializedPlan,
+		)
+
+		require.Error(t, err)
+		assert.Zero(t, sessionTS)
+	})
+
+	t.Run("wal append failed", func(t *testing.T) {
+		idAllocator := allocator.NewMockAllocator(t)
+		idAllocator.EXPECT().Alloc(uint32(1)).Return(int64(10), int64(11), nil)
+
+		mockWAL := mock_streaming.NewMockWALAccesser(t)
+		mockWAL.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, msgs ...message.MutableMessage) streaming.AppendResponses {
+				resp := types.NewAppendResponseN(len(msgs))
+				resp.FillAllError(errors.New("mock wal error"))
+				return resp
+			},
+		)
+		prevWAL := streaming.WAL()
+		streaming.SetWALForTest(mockWAL)
+		defer streaming.SetWALForTest(prevWAL)
+
+		sessionTS, err := appendPredicateDeleteMessages(
+			context.Background(),
+			collectionID,
+			collectionName,
+			partitionID,
+			partitionName,
+			dbName,
+			[]string{vChannel},
+			idAllocator,
+			deleteTs,
+			serializedPlan,
+		)
+
+		require.Error(t, err)
+		assert.Zero(t, sessionTS)
+	})
+
+	t.Run("encryption schema fetch failed", func(t *testing.T) {
+		mockEncryption := mockey.Mock(hookutil.IsClusterEncryptionEnabled).Return(true).Build()
+		defer mockEncryption.UnPatch()
+
+		idAllocator := allocator.NewMockAllocator(t)
+		idAllocator.EXPECT().Alloc(uint32(1)).Return(int64(10), int64(11), nil)
+
+		cache := NewMockCache(t)
+		cache.EXPECT().GetCollectionSchema(mock.Anything, dbName, collectionName).Return(nil, errors.New("mock schema error"))
+		prevMetaCache := globalMetaCache
+		globalMetaCache = cache
+		defer func() { globalMetaCache = prevMetaCache }()
+
+		sessionTS, err := appendPredicateDeleteMessages(
+			context.Background(),
+			collectionID,
+			collectionName,
+			partitionID,
+			partitionName,
+			dbName,
+			[]string{vChannel},
+			idAllocator,
+			deleteTs,
+			serializedPlan,
+		)
+
+		require.Error(t, err)
+		assert.Zero(t, sessionTS)
+	})
+
+	t.Run("encryption enabled success", func(t *testing.T) {
+		mockEncryption := mockey.Mock(hookutil.IsClusterEncryptionEnabled).Return(true).Build()
+		defer mockEncryption.UnPatch()
+
+		idAllocator := allocator.NewMockAllocator(t)
+		idAllocator.EXPECT().Alloc(uint32(1)).Return(int64(10), int64(11), nil)
+
+		cache := NewMockCache(t)
+		cache.EXPECT().GetCollectionSchema(mock.Anything, dbName, collectionName).Return(newSchemaInfo(&schemapb.CollectionSchema{Name: collectionName}), nil)
+		prevMetaCache := globalMetaCache
+		globalMetaCache = cache
+		defer func() { globalMetaCache = prevMetaCache }()
+
+		capturedMsgs := make([]message.MutableMessage, 0, 1)
+		mockWAL := mock_streaming.NewMockWALAccesser(t)
+		mockWAL.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, msgs ...message.MutableMessage) streaming.AppendResponses {
+				capturedMsgs = append(capturedMsgs, msgs...)
+				resp := types.NewAppendResponseN(len(msgs))
+				resp.Responses[0].AppendResult = &types.AppendResult{TimeTick: uint64(200)}
+				return resp
+			},
+		)
+		prevWAL := streaming.WAL()
+		streaming.SetWALForTest(mockWAL)
+		defer streaming.SetWALForTest(prevWAL)
+
+		sessionTS, err := appendPredicateDeleteMessages(
+			context.Background(),
+			collectionID,
+			collectionName,
+			partitionID,
+			partitionName,
+			dbName,
+			[]string{vChannel},
+			idAllocator,
+			deleteTs,
+			serializedPlan,
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint64(200), sessionTS)
+		require.Len(t, capturedMsgs, 1)
+		deleteMsg := message.MustAsMutableDeleteMessageV1(capturedMsgs[0])
+		body := deleteMsg.MustBody()
+		assert.Equal(t, vChannel, body.GetShardName())
+		assert.Equal(t, deleteTs, body.GetBase().GetTimestamp())
+		// A predicate delete carries the single MVCC delete ts in Timestamps[0] and no
+		// primary keys; the predicate itself is in SerializedExprPlan.
+		assert.Equal(t, []uint64{deleteTs}, body.GetTimestamps())
+		assert.Equal(t, serializedPlan, body.GetSerializedExprPlan())
+		assert.Equal(t, partitionID, body.GetPartitionID())
+		// Regression: the message must pass DeleteMsg.CheckAligned() via the predicate
+		// branch (expr plan set, exactly one ts, no pks); otherwise the QueryNode filter
+		// node silently drops it.
+		require.NoError(t, (&msgstream.DeleteMsg{DeleteRequest: body}).CheckAligned())
+	})
+}
+
+// poisonedPlanNode returns a plan whose proto.Marshal fails: proto3 rejects
+// invalid UTF-8 in string fields.
+func poisonedPlanNode() *planpb.PlanNode {
+	return &planpb.PlanNode{
+		Node: &planpb.PlanNode_Query{
+			Query: &planpb.QueryPlanNode{
+				Predicates: &planpb.Expr{
+					Expr: &planpb.Expr_UnaryRangeExpr{
+						UnaryRangeExpr: &planpb.UnaryRangeExpr{
+							Value: &planpb.GenericValue{Val: &planpb.GenericValue_StringVal{StringVal: "\xff\xfe"}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestDeleteRunner_predicateDelete_errors(t *testing.T) {
+	newRunner := func(idAllocator allocator.Interface) *deleteRunner {
+		return &deleteRunner{
+			collectionID: int64(111),
+			partitionIDs: []int64{222},
+			vChannels:    []string{"test_channel"},
+			idAllocator:  idAllocator,
+			result:       &milvuspb.MutationResult{Status: merr.Success(), IDs: &schemapb.IDs{}},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: "test_delete",
+				DbName:         "test_1",
+			},
+		}
+	}
+
+	t.Run("marshal plan failed", func(t *testing.T) {
+		dr := newRunner(nil)
+		require.Error(t, dr.predicateDelete(context.Background(), poisonedPlanNode(), 10, 100))
+	})
+
+	t.Run("alloc msg id failed", func(t *testing.T) {
+		idAllocator := allocator.NewMockAllocator(t)
+		idAllocator.EXPECT().AllocOne().Return(int64(0), errors.New("mock alloc error"))
+		dr := newRunner(idAllocator)
+		plan := &planpb.PlanNode{Node: &planpb.PlanNode_Query{Query: &planpb.QueryPlanNode{}}}
+		require.Error(t, dr.predicateDelete(context.Background(), plan, 10, 100))
+	})
+}
+
+func TestDeleteRunner_countPredicateDeleteHits_errors(t *testing.T) {
+	validPlan := func() *planpb.PlanNode {
+		return &planpb.PlanNode{Node: &planpb.PlanNode_Query{Query: &planpb.QueryPlanNode{}}}
+	}
+	newRunner := func(idAllocator allocator.Interface, lb shardclient.LBPolicy) *deleteRunner {
+		return &deleteRunner{
+			collectionID: int64(111),
+			partitionIDs: []int64{222},
+			vChannels:    []string{"test_channel"},
+			idAllocator:  idAllocator,
+			lb:           lb,
+			result:       &milvuspb.MutationResult{Status: merr.Success(), IDs: &schemapb.IDs{}},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: "test_delete",
+				DbName:         "test_1",
+			},
+		}
+	}
+	// lb that drives the workload against the given QueryNode once.
+	newLB := func(t *testing.T, qn *mocks.MockQueryNodeClient) *shardclient.MockLBPolicy {
+		lb := shardclient.NewMockLBPolicy(t)
+		lb.EXPECT().Execute(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+			return workload.Exec(ctx, 1, qn, "test_channel")
+		})
+		return lb
+	}
+	newAllocator := func(t *testing.T) *allocator.MockAllocator {
+		idAllocator := allocator.NewMockAllocator(t)
+		idAllocator.EXPECT().AllocOne().Return(int64(100), nil)
+		return idAllocator
+	}
+
+	t.Run("clone type mismatch", func(t *testing.T) {
+		cloneMock := mockey.Mock(proto.Clone).Return(&planpb.QueryPlanNode{}).Build()
+		defer cloneMock.UnPatch()
+
+		dr := newRunner(nil, nil)
+		_, err := dr.countPredicateDeleteHits(context.Background(), validPlan(), 100)
+		require.Error(t, err)
+	})
+
+	t.Run("query plan missing", func(t *testing.T) {
+		dr := newRunner(nil, nil)
+		_, err := dr.countPredicateDeleteHits(context.Background(), &planpb.PlanNode{}, 100)
+		require.Error(t, err)
+	})
+
+	t.Run("marshal count plan failed", func(t *testing.T) {
+		dr := newRunner(nil, nil)
+		_, err := dr.countPredicateDeleteHits(context.Background(), poisonedPlanNode(), 100)
+		require.Error(t, err)
+	})
+
+	t.Run("alloc msg id failed", func(t *testing.T) {
+		idAllocator := allocator.NewMockAllocator(t)
+		idAllocator.EXPECT().AllocOne().Return(int64(0), errors.New("mock alloc error"))
+		dr := newRunner(idAllocator, nil)
+		_, err := dr.countPredicateDeleteHits(context.Background(), validPlan(), 100)
+		require.Error(t, err)
+	})
+
+	t.Run("nil query result", func(t *testing.T) {
+		qn := mocks.NewMockQueryNodeClient(t)
+		qn.EXPECT().Query(mock.Anything, mock.Anything).Return(nil, nil)
+		dr := newRunner(newAllocator(t), newLB(t, qn))
+		_, err := dr.countPredicateDeleteHits(context.Background(), validPlan(), 100)
+		require.Error(t, err)
+	})
+
+	t.Run("query result status error", func(t *testing.T) {
+		qn := mocks.NewMockQueryNodeClient(t)
+		qn.EXPECT().Query(mock.Anything, mock.Anything).Return(&internalpb.RetrieveResults{
+			Status: merr.Status(errors.New("mock status error")),
+		}, nil)
+		dr := newRunner(newAllocator(t), newLB(t, qn))
+		_, err := dr.countPredicateDeleteHits(context.Background(), validPlan(), 100)
+		require.Error(t, err)
+	})
+
+	t.Run("count parse failed", func(t *testing.T) {
+		qn := mocks.NewMockQueryNodeClient(t)
+		// A success status without exactly one count column fails CntOfInternalResult.
+		qn.EXPECT().Query(mock.Anything, mock.Anything).Return(&internalpb.RetrieveResults{
+			Status: merr.Success(),
+		}, nil)
+		dr := newRunner(newAllocator(t), newLB(t, qn))
+		_, err := dr.countPredicateDeleteHits(context.Background(), validPlan(), 100)
+		require.Error(t, err)
 	})
 }
 
@@ -772,6 +1324,7 @@ func TestDeleteRunner_Run(t *testing.T) {
 			},
 		},
 	}
+	collSchema.Version = 7
 	schema := newSchemaInfo(collSchema)
 
 	metaCache := NewMockCache(t)
@@ -780,6 +1333,39 @@ func TestDeleteRunner_Run(t *testing.T) {
 	defer func() {
 		globalMetaCache = nil
 	}()
+
+	setPredicateDelete := func(t *testing.T, enabled bool) {
+		old := paramtable.Get().CommonCfg.EnablePredicateDelete.SwapTempValue(strconv.FormatBool(enabled))
+		t.Cleanup(func() {
+			paramtable.Get().CommonCfg.EnablePredicateDelete.SwapTempValue(old)
+		})
+	}
+	setPredicateDeleteThreshold := func(t *testing.T, threshold int64) {
+		old := paramtable.Get().CommonCfg.PredicateDeleteHitCountThreshold.SwapTempValue(strconv.FormatInt(threshold, 10))
+		t.Cleanup(func() {
+			paramtable.Get().CommonCfg.PredicateDeleteHitCountThreshold.SwapTempValue(old)
+		})
+	}
+	// StorageV3 (common.storage.useLoonFFI) must be enabled for predicate delete to be applied.
+	setStorageV3 := func(t *testing.T, enabled bool) {
+		old := paramtable.Get().CommonCfg.UseLoonFFI.SwapTempValue(strconv.FormatBool(enabled))
+		t.Cleanup(func() {
+			paramtable.Get().CommonCfg.UseLoonFFI.SwapTempValue(old)
+		})
+	}
+	assertCountAggRequest := func(t *testing.T, req *querypb.QueryRequest) {
+		require.False(t, req.GetReq().GetIsCount())
+		require.Len(t, req.GetReq().GetAggregates(), 1)
+		require.Equal(t, planpb.AggregateOp_count, req.GetReq().GetAggregates()[0].GetOp())
+		require.Equal(t, int64(0), req.GetReq().GetAggregates()[0].GetFieldId())
+		require.NotNil(t, req.GetReq().GetSerializedExprPlan())
+		countPlan := &planpb.PlanNode{}
+		require.NoError(t, proto.Unmarshal(req.GetReq().GetSerializedExprPlan(), countPlan))
+		require.Len(t, countPlan.GetQuery().GetAggregates(), 1)
+		require.Equal(t, planpb.AggregateOp_count, countPlan.GetQuery().GetAggregates()[0].GetOp())
+		require.Equal(t, int64(0), countPlan.GetQuery().GetAggregates()[0].GetFieldId())
+		require.Empty(t, countPlan.GetOutputFieldIds())
+	}
 
 	t.Run("simple delete task failed", func(t *testing.T) {
 		mockMgr := NewMockChannelsMgr(t)
@@ -819,7 +1405,9 @@ func TestDeleteRunner_Run(t *testing.T) {
 		assert.Equal(t, int64(0), dr.result.DeleteCnt)
 	})
 
-	t.Run("complex delete query rpc failed", func(t *testing.T) {
+	t.Run("config disabled complex delete query rpc failed", func(t *testing.T) {
+		setPredicateDelete(t, false)
+
 		mockMgr := NewMockChannelsMgr(t)
 		qn := mocks.NewMockQueryNodeClient(t)
 		lb := shardclient.NewMockLBPolicy(t)
@@ -859,6 +1447,8 @@ func TestDeleteRunner_Run(t *testing.T) {
 	})
 
 	t.Run("complex delete query failed", func(t *testing.T) {
+		setPredicateDelete(t, false)
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -925,6 +1515,8 @@ func TestDeleteRunner_Run(t *testing.T) {
 	})
 
 	t.Run("complex delete rate limit check failed", func(t *testing.T) {
+		setPredicateDelete(t, false)
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -988,6 +1580,8 @@ func TestDeleteRunner_Run(t *testing.T) {
 	})
 
 	t.Run("complex delete produce failed", func(t *testing.T) {
+		setPredicateDelete(t, false)
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -1051,7 +1645,814 @@ func TestDeleteRunner_Run(t *testing.T) {
 		assert.Equal(t, int64(0), dr.result.DeleteCnt)
 	})
 
+	t.Run("predicate delete success", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, true)
+		setPredicateDeleteThreshold(t, 1024)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		mockMgr := NewMockChannelsMgr(t)
+		qn := mocks.NewMockQueryNodeClient(t)
+		lb := shardclient.NewMockLBPolicy(t)
+		vChannels := []string{"test_channel_0", "test_channel_1"}
+		expr := "non_pk == 1"
+		plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+		require.NoError(t, err)
+		expectedPlan, err := proto.Marshal(plan)
+		require.NoError(t, err)
+
+		capturedMsgs := make([]message.MutableMessage, 0, len(vChannels))
+		mockWAL := mock_streaming.NewMockWALAccesser(t)
+		mockWAL.EXPECT().AppendMessages(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, msgs ...message.MutableMessage) streaming.AppendResponses {
+				capturedMsgs = append(capturedMsgs, msgs...)
+				resp := types.NewAppendResponseN(len(msgs))
+				for i := range resp.Responses {
+					resp.Responses[i].AppendResult = &types.AppendResult{TimeTick: uint64(100 + i)}
+				}
+				return resp
+			},
+		)
+		prevWAL := streaming.WAL()
+		streaming.SetWALForTest(mockWAL)
+		defer streaming.SetWALForTest(prevWAL)
+
+		dr := deleteRunner{
+			queue:           queue.dmQueue,
+			chMgr:           mockMgr,
+			schema:          schema,
+			collectionID:    collectionID,
+			partitionIDs:    []int64{partitionID},
+			vChannels:       vChannels,
+			idAllocator:     idAllocator,
+			tsoAllocatorIns: tsoAllocator,
+			lb:              lb,
+			result: &milvuspb.MutationResult{
+				Status: merr.Success(),
+				IDs: &schemapb.IDs{
+					IdField: nil,
+				},
+			},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: collectionName,
+				PartitionName:  partitionName,
+				DbName:         dbName,
+				Expr:           expr,
+			},
+			plan: plan,
+		}
+		lb.EXPECT().Execute(mock.Anything, mock.Anything).Call.Return(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+			for _, channel := range vChannels {
+				err := workload.Exec(ctx, 1, qn, channel)
+				require.NoError(t, err)
+			}
+			return nil
+		})
+		qn.EXPECT().Query(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, req *querypb.QueryRequest, opts ...grpc.CallOption) (*internalpb.RetrieveResults, error) {
+				assertCountAggRequest(t, req)
+				return funcutil.WrapCntToInternalResult(600), nil
+			}).Twice()
+
+		assert.NoError(t, dr.Run(ctx))
+		// DeleteCnt is the probe-time matched count (600 per vchannel x 2 vchannels = 1200),
+		// not 0 — see predicateDelete reporting matchedCount.
+		assert.Equal(t, int64(1200), dr.result.DeleteCnt)
+		assert.Equal(t, uint64(101), dr.result.Timestamp)
+		assert.Len(t, capturedMsgs, len(vChannels))
+
+		seenVChannels := typeutil.NewSet[string]()
+		var deleteTs uint64
+		for _, msg := range capturedMsgs {
+			deleteMsg := message.MustAsMutableDeleteMessageV1(msg)
+			body := deleteMsg.MustBody()
+			header := deleteMsg.Header()
+
+			seenVChannels.Insert(msg.VChannel())
+			require.Nil(t, body.GetPrimaryKeys())
+			require.Equal(t, []uint64{body.GetBase().GetTimestamp()}, body.GetTimestamps())
+			require.Equal(t, int64(0), body.GetNumRows())
+			require.Equal(t, uint64(0), header.GetRows())
+			require.Equal(t, collectionID, header.GetCollectionId())
+			require.Equal(t, expectedPlan, body.GetSerializedExprPlan())
+			require.Equal(t, partitionID, body.GetPartitionID())
+
+			if deleteTs == 0 {
+				deleteTs = body.GetBase().GetTimestamp()
+			} else {
+				require.Equal(t, deleteTs, body.GetBase().GetTimestamp())
+			}
+		}
+		require.Equal(t, typeutil.NewSet(vChannels...), seenVChannels)
+	})
+
+	t.Run("predicate delete partition scopes", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, true)
+		setPredicateDeleteThreshold(t, 1024)
+
+		cases := []struct {
+			name                string
+			partitionIDs        []int64
+			expectedPartitionID int64
+		}{
+			{
+				name:                "collection wide",
+				partitionIDs:        nil,
+				expectedPartitionID: common.AllPartitionsID,
+			},
+			{
+				name:                "multi partition",
+				partitionIDs:        []int64{partitionID, partitionID + 1},
+				expectedPartitionID: common.AllPartitionsID,
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				vChannels := []string{"test_channel_0"}
+				expr := "non_pk == 1"
+				plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+				require.NoError(t, err)
+
+				var capturedMsg message.MutableMessage
+				mockWAL := mock_streaming.NewMockWALAccesser(t)
+				mockWAL.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+					func(ctx context.Context, msgs ...message.MutableMessage) streaming.AppendResponses {
+						require.Len(t, msgs, 1)
+						capturedMsg = msgs[0]
+						resp := types.NewAppendResponseN(len(msgs))
+						resp.Responses[0].AppendResult = &types.AppendResult{TimeTick: uint64(100)}
+						return resp
+					},
+				)
+				prevWAL := streaming.WAL()
+				streaming.SetWALForTest(mockWAL)
+				defer streaming.SetWALForTest(prevWAL)
+
+				qn := mocks.NewMockQueryNodeClient(t)
+				lb := shardclient.NewMockLBPolicy(t)
+				dr := deleteRunner{
+					queue:           queue.dmQueue,
+					chMgr:           NewMockChannelsMgr(t),
+					schema:          schema,
+					collectionID:    collectionID,
+					partitionIDs:    tc.partitionIDs,
+					vChannels:       vChannels,
+					idAllocator:     idAllocator,
+					tsoAllocatorIns: tsoAllocator,
+					lb:              lb,
+					result: &milvuspb.MutationResult{
+						Status: merr.Success(),
+						IDs:    &schemapb.IDs{},
+					},
+					req: &milvuspb.DeleteRequest{
+						CollectionName: collectionName,
+						DbName:         dbName,
+						Expr:           expr,
+					},
+					plan: plan,
+				}
+				lb.EXPECT().Execute(mock.Anything, mock.Anything).Call.Return(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+					return workload.Exec(ctx, 1, qn, vChannels[0])
+				})
+				qn.EXPECT().Query(mock.Anything, mock.Anything).Return(funcutil.WrapCntToInternalResult(1025), nil)
+
+				require.NoError(t, dr.Run(ctx))
+				deleteMsg := message.MustAsMutableDeleteMessageV1(capturedMsg)
+				body := deleteMsg.MustBody()
+				assert.Equal(t, tc.expectedPartitionID, body.GetPartitionID())
+			})
+		}
+	})
+
+	t.Run("predicate delete falls back to pk delete when count is not above threshold", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, true)
+		setPredicateDeleteThreshold(t, 1024)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		mockMgr := NewMockChannelsMgr(t)
+		qn := mocks.NewMockQueryNodeClient(t)
+		lb := shardclient.NewMockLBPolicy(t)
+		expr := "non_pk == 1"
+		plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+		require.NoError(t, err)
+
+		capturedMsgs := make([]message.MutableMessage, 0, 1)
+		mockWAL := mock_streaming.NewMockWALAccesser(t)
+		mockWAL.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, msgs ...message.MutableMessage) streaming.AppendResponses {
+				capturedMsgs = append(capturedMsgs, msgs...)
+				resp := types.NewAppendResponseN(len(msgs))
+				for i := range resp.Responses {
+					resp.Responses[i].AppendResult = &types.AppendResult{TimeTick: uint64(200 + i)}
+				}
+				return resp
+			},
+		)
+		prevWAL := streaming.WAL()
+		streaming.SetWALForTest(mockWAL)
+		defer streaming.SetWALForTest(prevWAL)
+
+		dr := deleteRunner{
+			queue:           queue.dmQueue,
+			chMgr:           mockMgr,
+			schema:          schema,
+			collectionID:    collectionID,
+			partitionIDs:    []int64{partitionID},
+			vChannels:       channels,
+			idAllocator:     idAllocator,
+			tsoAllocatorIns: tsoAllocator,
+			lb:              lb,
+			result: &milvuspb.MutationResult{
+				Status: merr.Success(),
+				IDs:    &schemapb.IDs{},
+			},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: collectionName,
+				PartitionName:  partitionName,
+				DbName:         dbName,
+				Expr:           expr,
+			},
+			plan: plan,
+		}
+		mockMgr.EXPECT().getChannels(collectionID).Return(channels, nil)
+
+		call := 0
+		lb.EXPECT().Execute(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+			call++
+			return workload.Exec(ctx, 1, qn, channels[0])
+		}).Twice()
+		qn.EXPECT().Query(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, req *querypb.QueryRequest, opts ...grpc.CallOption) (*internalpb.RetrieveResults, error) {
+				require.Equal(t, 1, call)
+				assertCountAggRequest(t, req)
+				return funcutil.WrapCntToInternalResult(1024), nil
+			})
+		qn.EXPECT().QueryStream(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, in *querypb.QueryRequest, opts ...grpc.CallOption) (querypb.QueryNode_QueryStreamClient, error) {
+				require.Equal(t, 2, call)
+				client := streamrpc.NewLocalQueryClient(ctx)
+				server := client.CreateServer()
+				server.Send(&internalpb.RetrieveResults{
+					Status: merr.Success(),
+					Ids:    &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
+				})
+				server.FinishSend(nil)
+				return client, nil
+			})
+
+		require.NoError(t, dr.Run(ctx))
+		assert.Equal(t, int64(3), dr.result.DeleteCnt)
+		assert.Equal(t, uint64(200), dr.result.Timestamp)
+		require.Len(t, capturedMsgs, 1)
+		deleteMsg := message.MustAsMutableDeleteMessageV1(capturedMsgs[0])
+		body := deleteMsg.MustBody()
+		assert.NotNil(t, body.GetPrimaryKeys())
+		assert.Empty(t, body.GetSerializedExprPlan())
+	})
+
+	t.Run("predicate delete falls back to pk delete when storageV3 disabled", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, false)
+		setPredicateDeleteThreshold(t, 1024)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		mockMgr := NewMockChannelsMgr(t)
+		qn := mocks.NewMockQueryNodeClient(t)
+		lb := shardclient.NewMockLBPolicy(t)
+		expr := "non_pk == 1"
+		plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+		require.NoError(t, err)
+
+		capturedMsgs := make([]message.MutableMessage, 0, 1)
+		mockWAL := mock_streaming.NewMockWALAccesser(t)
+		mockWAL.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, msgs ...message.MutableMessage) streaming.AppendResponses {
+				capturedMsgs = append(capturedMsgs, msgs...)
+				resp := types.NewAppendResponseN(len(msgs))
+				for i := range resp.Responses {
+					resp.Responses[i].AppendResult = &types.AppendResult{TimeTick: uint64(200 + i)}
+				}
+				return resp
+			},
+		)
+		prevWAL := streaming.WAL()
+		streaming.SetWALForTest(mockWAL)
+		defer streaming.SetWALForTest(prevWAL)
+
+		dr := deleteRunner{
+			queue:           queue.dmQueue,
+			chMgr:           mockMgr,
+			schema:          schema,
+			collectionID:    collectionID,
+			partitionIDs:    []int64{partitionID},
+			vChannels:       channels,
+			idAllocator:     idAllocator,
+			tsoAllocatorIns: tsoAllocator,
+			lb:              lb,
+			result: &milvuspb.MutationResult{
+				Status: merr.Success(),
+				IDs:    &schemapb.IDs{},
+			},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: collectionName,
+				PartitionName:  partitionName,
+				DbName:         dbName,
+				Expr:           expr,
+			},
+			plan: plan,
+		}
+		mockMgr.EXPECT().getChannels(collectionID).Return(channels, nil)
+
+		// StorageV3 off -> no count probe; go straight to the complexDelete (PK) stream.
+		lb.EXPECT().Execute(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+			return workload.Exec(ctx, 1, qn, channels[0])
+		}).Once()
+		qn.EXPECT().QueryStream(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, in *querypb.QueryRequest, opts ...grpc.CallOption) (querypb.QueryNode_QueryStreamClient, error) {
+				client := streamrpc.NewLocalQueryClient(ctx)
+				server := client.CreateServer()
+				server.Send(&internalpb.RetrieveResults{
+					Status: merr.Success(),
+					Ids:    &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
+				})
+				server.FinishSend(nil)
+				return client, nil
+			})
+
+		require.NoError(t, dr.Run(ctx))
+		assert.Equal(t, int64(3), dr.result.DeleteCnt)
+		require.Len(t, capturedMsgs, 1)
+		deleteMsg := message.MustAsMutableDeleteMessageV1(capturedMsgs[0])
+		body := deleteMsg.MustBody()
+		assert.NotNil(t, body.GetPrimaryKeys())
+		assert.Empty(t, body.GetSerializedExprPlan())
+	})
+
+	t.Run("predicate delete count probe error falls back to pk delete", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, true)
+		setPredicateDeleteThreshold(t, 1024)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		mockMgr := NewMockChannelsMgr(t)
+		qn := mocks.NewMockQueryNodeClient(t)
+		lb := shardclient.NewMockLBPolicy(t)
+		expr := "non_pk == 1"
+		plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+		require.NoError(t, err)
+
+		capturedMsgs := make([]message.MutableMessage, 0, 1)
+		mockWAL := mock_streaming.NewMockWALAccesser(t)
+		mockWAL.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, msgs ...message.MutableMessage) streaming.AppendResponses {
+				capturedMsgs = append(capturedMsgs, msgs...)
+				resp := types.NewAppendResponseN(len(msgs))
+				for i := range resp.Responses {
+					resp.Responses[i].AppendResult = &types.AppendResult{TimeTick: uint64(200 + i)}
+				}
+				return resp
+			},
+		)
+		prevWAL := streaming.WAL()
+		streaming.SetWALForTest(mockWAL)
+		defer streaming.SetWALForTest(prevWAL)
+
+		dr := deleteRunner{
+			queue:           queue.dmQueue,
+			chMgr:           mockMgr,
+			schema:          schema,
+			collectionID:    collectionID,
+			partitionIDs:    []int64{partitionID},
+			vChannels:       channels,
+			idAllocator:     idAllocator,
+			tsoAllocatorIns: tsoAllocator,
+			lb:              lb,
+			result: &milvuspb.MutationResult{
+				Status: merr.Success(),
+				IDs:    &schemapb.IDs{},
+			},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: collectionName,
+				PartitionName:  partitionName,
+				DbName:         dbName,
+				Expr:           expr,
+			},
+			plan: plan,
+		}
+		mockMgr.EXPECT().getChannels(collectionID).Return(channels, nil)
+
+		call := 0
+		lb.EXPECT().Execute(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+			call++
+			return workload.Exec(ctx, 1, qn, channels[0])
+		}).Twice()
+		// First query = count probe -> transient error; the delete must fall back to the
+		// PK-delete stream instead of surfacing the error to the user.
+		qn.EXPECT().Query(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, req *querypb.QueryRequest, opts ...grpc.CallOption) (*internalpb.RetrieveResults, error) {
+				require.Equal(t, 1, call)
+				return nil, errors.New("mock count error")
+			})
+		qn.EXPECT().QueryStream(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, in *querypb.QueryRequest, opts ...grpc.CallOption) (querypb.QueryNode_QueryStreamClient, error) {
+				require.Equal(t, 2, call)
+				client := streamrpc.NewLocalQueryClient(ctx)
+				server := client.CreateServer()
+				server.Send(&internalpb.RetrieveResults{
+					Status: merr.Success(),
+					Ids:    &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
+				})
+				server.FinishSend(nil)
+				return client, nil
+			})
+
+		require.NoError(t, dr.Run(ctx))
+		assert.Equal(t, int64(3), dr.result.DeleteCnt)
+		require.Len(t, capturedMsgs, 1)
+		deleteMsg := message.MustAsMutableDeleteMessageV1(capturedMsgs[0])
+		body := deleteMsg.MustBody()
+		assert.NotNil(t, body.GetPrimaryKeys())
+		assert.Empty(t, body.GetSerializedExprPlan())
+	})
+
+	t.Run("predicate delete falls back to pk delete for unsupported expression", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, true)
+		setPredicateDeleteThreshold(t, 1024)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		mockMgr := NewMockChannelsMgr(t)
+		qn := mocks.NewMockQueryNodeClient(t)
+		lb := shardclient.NewMockLBPolicy(t)
+		// Arithmetic predicates are not in the predicate-delete allowlist.
+		expr := "non_pk % 2 == 0"
+		plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+		require.NoError(t, err)
+		require.False(t, canUsePredicateDelete(plan, schema.CollectionSchema))
+
+		capturedMsgs := make([]message.MutableMessage, 0, 1)
+		mockWAL := mock_streaming.NewMockWALAccesser(t)
+		mockWAL.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, msgs ...message.MutableMessage) streaming.AppendResponses {
+				capturedMsgs = append(capturedMsgs, msgs...)
+				resp := types.NewAppendResponseN(len(msgs))
+				for i := range resp.Responses {
+					resp.Responses[i].AppendResult = &types.AppendResult{TimeTick: uint64(200 + i)}
+				}
+				return resp
+			},
+		)
+		prevWAL := streaming.WAL()
+		streaming.SetWALForTest(mockWAL)
+		defer streaming.SetWALForTest(prevWAL)
+
+		dr := deleteRunner{
+			queue:           queue.dmQueue,
+			chMgr:           mockMgr,
+			schema:          schema,
+			collectionID:    collectionID,
+			partitionIDs:    []int64{partitionID},
+			vChannels:       channels,
+			idAllocator:     idAllocator,
+			tsoAllocatorIns: tsoAllocator,
+			lb:              lb,
+			result: &milvuspb.MutationResult{
+				Status: merr.Success(),
+				IDs:    &schemapb.IDs{},
+			},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: collectionName,
+				PartitionName:  partitionName,
+				DbName:         dbName,
+				Expr:           expr,
+			},
+			plan: plan,
+		}
+		mockMgr.EXPECT().getChannels(collectionID).Return(channels, nil)
+
+		lb.EXPECT().Execute(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+			return workload.Exec(ctx, 1, qn, channels[0])
+		})
+		// No count probe: the unsupported expression goes straight to the PK-delete stream.
+		qn.EXPECT().QueryStream(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, in *querypb.QueryRequest, opts ...grpc.CallOption) (querypb.QueryNode_QueryStreamClient, error) {
+				client := streamrpc.NewLocalQueryClient(ctx)
+				server := client.CreateServer()
+				server.Send(&internalpb.RetrieveResults{
+					Status: merr.Success(),
+					Ids:    &schemapb.IDs{IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1, 2, 3}}}},
+				})
+				server.FinishSend(nil)
+				return client, nil
+			})
+
+		require.NoError(t, dr.Run(ctx))
+		assert.Equal(t, int64(3), dr.result.DeleteCnt)
+		require.Len(t, capturedMsgs, 1)
+		deleteMsg := message.MustAsMutableDeleteMessageV1(capturedMsgs[0])
+		body := deleteMsg.MustBody()
+		assert.NotNil(t, body.GetPrimaryKeys())
+		assert.Empty(t, body.GetSerializedExprPlan())
+	})
+
+	t.Run("predicate delete unsupported expression fallback failed", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, true)
+		setPredicateDeleteThreshold(t, 1024)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		qn := mocks.NewMockQueryNodeClient(t)
+		lb := shardclient.NewMockLBPolicy(t)
+		expr := "non_pk % 2 == 0"
+		plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+		require.NoError(t, err)
+
+		dr := deleteRunner{
+			queue:           queue.dmQueue,
+			chMgr:           NewMockChannelsMgr(t),
+			schema:          schema,
+			collectionID:    collectionID,
+			partitionIDs:    []int64{partitionID},
+			vChannels:       channels,
+			idAllocator:     idAllocator,
+			tsoAllocatorIns: tsoAllocator,
+			lb:              lb,
+			result: &milvuspb.MutationResult{
+				Status: merr.Success(),
+				IDs:    &schemapb.IDs{},
+			},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: collectionName,
+				PartitionName:  partitionName,
+				DbName:         dbName,
+				Expr:           expr,
+			},
+			plan: plan,
+		}
+		lb.EXPECT().Execute(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+			return workload.Exec(ctx, 1, qn, channels[0])
+		})
+		qn.EXPECT().QueryStream(mock.Anything, mock.Anything).Return(nil, errors.New("mock stream error"))
+
+		require.Error(t, dr.Run(ctx))
+	})
+
+	t.Run("predicate delete count probe canceled context", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, true)
+		setPredicateDeleteThreshold(t, 1024)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		qn := mocks.NewMockQueryNodeClient(t)
+		lb := shardclient.NewMockLBPolicy(t)
+		expr := "non_pk == 1"
+		plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+		require.NoError(t, err)
+
+		dr := deleteRunner{
+			queue:           queue.dmQueue,
+			chMgr:           NewMockChannelsMgr(t),
+			schema:          schema,
+			collectionID:    collectionID,
+			partitionIDs:    []int64{partitionID},
+			vChannels:       channels,
+			idAllocator:     idAllocator,
+			tsoAllocatorIns: tsoAllocator,
+			lb:              lb,
+			result: &milvuspb.MutationResult{
+				Status: merr.Success(),
+				IDs:    &schemapb.IDs{},
+			},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: collectionName,
+				PartitionName:  partitionName,
+				DbName:         dbName,
+				Expr:           expr,
+			},
+			plan: plan,
+		}
+		lb.EXPECT().Execute(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+			return workload.Exec(ctx, 1, qn, channels[0])
+		})
+		// The count probe fails because the request context is canceled; the runner must
+		// surface the cancellation instead of falling back to the PK-delete stream.
+		qn.EXPECT().Query(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, req *querypb.QueryRequest, opts ...grpc.CallOption) (*internalpb.RetrieveResults, error) {
+				cancel()
+				return nil, context.Canceled
+			})
+
+		assert.ErrorIs(t, dr.Run(ctx), context.Canceled)
+	})
+
+	t.Run("predicate delete count probe error fallback failed", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, true)
+		setPredicateDeleteThreshold(t, 1024)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		qn := mocks.NewMockQueryNodeClient(t)
+		lb := shardclient.NewMockLBPolicy(t)
+		expr := "non_pk == 1"
+		plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+		require.NoError(t, err)
+
+		dr := deleteRunner{
+			queue:           queue.dmQueue,
+			chMgr:           NewMockChannelsMgr(t),
+			schema:          schema,
+			collectionID:    collectionID,
+			partitionIDs:    []int64{partitionID},
+			vChannels:       channels,
+			idAllocator:     idAllocator,
+			tsoAllocatorIns: tsoAllocator,
+			lb:              lb,
+			result: &milvuspb.MutationResult{
+				Status: merr.Success(),
+				IDs:    &schemapb.IDs{},
+			},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: collectionName,
+				PartitionName:  partitionName,
+				DbName:         dbName,
+				Expr:           expr,
+			},
+			plan: plan,
+		}
+		call := 0
+		lb.EXPECT().Execute(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+			call++
+			return workload.Exec(ctx, 1, qn, channels[0])
+		}).Twice()
+		qn.EXPECT().Query(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, req *querypb.QueryRequest, opts ...grpc.CallOption) (*internalpb.RetrieveResults, error) {
+				require.Equal(t, 1, call)
+				return nil, errors.New("mock count error")
+			})
+		qn.EXPECT().QueryStream(mock.Anything, mock.Anything).Return(nil, errors.New("mock stream error"))
+
+		require.Error(t, dr.Run(ctx))
+	})
+
+	t.Run("predicate delete low hit fallback failed", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, true)
+		setPredicateDeleteThreshold(t, 1024)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		qn := mocks.NewMockQueryNodeClient(t)
+		lb := shardclient.NewMockLBPolicy(t)
+		expr := "non_pk == 1"
+		plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+		require.NoError(t, err)
+
+		dr := deleteRunner{
+			queue:           queue.dmQueue,
+			chMgr:           NewMockChannelsMgr(t),
+			schema:          schema,
+			collectionID:    collectionID,
+			partitionIDs:    []int64{partitionID},
+			vChannels:       channels,
+			idAllocator:     idAllocator,
+			tsoAllocatorIns: tsoAllocator,
+			lb:              lb,
+			result: &milvuspb.MutationResult{
+				Status: merr.Success(),
+				IDs:    &schemapb.IDs{},
+			},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: collectionName,
+				PartitionName:  partitionName,
+				DbName:         dbName,
+				Expr:           expr,
+			},
+			plan: plan,
+		}
+		lb.EXPECT().Execute(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+			return workload.Exec(ctx, 1, qn, channels[0])
+		}).Twice()
+		qn.EXPECT().Query(mock.Anything, mock.Anything).Return(funcutil.WrapCntToInternalResult(1), nil)
+		qn.EXPECT().QueryStream(mock.Anything, mock.Anything).Return(nil, errors.New("mock stream error"))
+
+		require.Error(t, dr.Run(ctx))
+	})
+
+	t.Run("predicate delete wal append failed", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, true)
+		setPredicateDeleteThreshold(t, 1024)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		qn := mocks.NewMockQueryNodeClient(t)
+		lb := shardclient.NewMockLBPolicy(t)
+		expr := "non_pk == 1"
+		plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+		require.NoError(t, err)
+
+		mockWAL := mock_streaming.NewMockWALAccesser(t)
+		mockWAL.EXPECT().AppendMessages(mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, msgs ...message.MutableMessage) streaming.AppendResponses {
+				resp := types.NewAppendResponseN(len(msgs))
+				resp.FillAllError(errors.New("mock wal error"))
+				return resp
+			},
+		)
+		prevWAL := streaming.WAL()
+		streaming.SetWALForTest(mockWAL)
+		defer streaming.SetWALForTest(prevWAL)
+
+		dr := deleteRunner{
+			queue:           queue.dmQueue,
+			chMgr:           NewMockChannelsMgr(t),
+			schema:          schema,
+			collectionID:    collectionID,
+			partitionIDs:    []int64{partitionID},
+			vChannels:       channels,
+			idAllocator:     idAllocator,
+			tsoAllocatorIns: tsoAllocator,
+			lb:              lb,
+			result: &milvuspb.MutationResult{
+				Status: merr.Success(),
+				IDs:    &schemapb.IDs{},
+			},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: collectionName,
+				PartitionName:  partitionName,
+				DbName:         dbName,
+				Expr:           expr,
+			},
+			plan: plan,
+		}
+		lb.EXPECT().Execute(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, workload shardclient.CollectionWorkLoad) error {
+			return workload.Exec(ctx, 1, qn, channels[0])
+		})
+		qn.EXPECT().Query(mock.Anything, mock.Anything).Return(funcutil.WrapCntToInternalResult(2048), nil)
+
+		require.Error(t, dr.Run(ctx))
+	})
+
+	t.Run("predicate delete tso alloc failed", func(t *testing.T) {
+		setPredicateDelete(t, true)
+		setStorageV3(t, true)
+
+		mockTSO := mockey.Mock((*mockTsoAllocator).AllocOne).Return(uint64(0), errors.New("mock tso error")).Build()
+		defer mockTSO.UnPatch()
+
+		expr := "non_pk == 1"
+		plan, err := planparserv2.CreateRetrievePlan(schema.schemaHelper, expr, nil)
+		require.NoError(t, err)
+
+		dr := deleteRunner{
+			schema:          schema,
+			collectionID:    collectionID,
+			partitionIDs:    []int64{partitionID},
+			vChannels:       channels,
+			idAllocator:     idAllocator,
+			tsoAllocatorIns: tsoAllocator,
+			result: &milvuspb.MutationResult{
+				Status: merr.Success(),
+				IDs:    &schemapb.IDs{},
+			},
+			req: &milvuspb.DeleteRequest{
+				CollectionName: collectionName,
+				DbName:         dbName,
+				Expr:           expr,
+			},
+			plan: plan,
+		}
+
+		require.Error(t, dr.Run(context.Background()))
+	})
+
 	t.Run("complex delete success", func(t *testing.T) {
+		setPredicateDelete(t, false)
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -1120,6 +2521,8 @@ func TestDeleteRunner_Run(t *testing.T) {
 	partitionMaps["test_2"] = 3
 
 	t.Run("complex delete with partitionKey mode success", func(t *testing.T) {
+		setPredicateDelete(t, false)
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 

--- a/pkg/mq/msgstream/msg.go
+++ b/pkg/mq/msgstream/msg.go
@@ -427,6 +427,19 @@ func (dt *DeleteMsg) Unmarshal(input MarshalType) (TsMsg, error) {
 }
 
 func (dt *DeleteMsg) CheckAligned() error {
+	// A predicate delete carries a delete expression plan and a single MVCC delete
+	// timestamp but no primary keys; it is not a per-row (pk, ts) delete, so validate
+	// that shape instead of the per-row pk/ts alignment.
+	if len(dt.GetSerializedExprPlan()) != 0 {
+		if len(dt.GetTimestamps()) != 1 {
+			return merr.WrapErrDataIntegrityMsg("predicate delete must carry exactly one delete timestamp, got %d", len(dt.GetTimestamps()))
+		}
+		if numPks := int64(typeutil.GetSizeOfIDs(dt.PrimaryKeys)); numPks != 0 {
+			return merr.WrapErrDataIntegrityMsg("predicate delete must not carry primary keys, got %d", numPks)
+		}
+		return nil
+	}
+
 	numRows := dt.GetNumRows()
 
 	if numRows != int64(len(dt.GetTimestamps())) {

--- a/pkg/mq/msgstream/msg_test.go
+++ b/pkg/mq/msgstream/msg_test.go
@@ -423,6 +423,43 @@ func TestDeleteMsg_Unmarshal_IllegalParameter(t *testing.T) {
 	assert.Nil(t, tsMsg)
 }
 
+func TestDeleteMsg_CheckAligned_PredicateDelete(t *testing.T) {
+	newPredicateDeleteMsg := func() *DeleteMsg {
+		return &DeleteMsg{
+			DeleteRequest: &msgpb.DeleteRequest{
+				CollectionName:     "test_collection",
+				ShardName:          "test-channel",
+				SerializedExprPlan: []byte{1, 2, 3},
+				Timestamps:         []uint64{100},
+			},
+		}
+	}
+
+	t.Run("valid predicate delete", func(t *testing.T) {
+		assert.NoError(t, newPredicateDeleteMsg().CheckAligned())
+	})
+
+	t.Run("more than one timestamp", func(t *testing.T) {
+		msg := newPredicateDeleteMsg()
+		msg.Timestamps = []uint64{100, 101}
+		assert.Error(t, msg.CheckAligned())
+	})
+
+	t.Run("no timestamp", func(t *testing.T) {
+		msg := newPredicateDeleteMsg()
+		msg.Timestamps = nil
+		assert.Error(t, msg.CheckAligned())
+	})
+
+	t.Run("carries primary keys", func(t *testing.T) {
+		msg := newPredicateDeleteMsg()
+		msg.PrimaryKeys = &schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{IntId: &schemapb.LongArray{Data: []int64{1}}},
+		}
+		assert.Error(t, msg.CheckAligned())
+	})
+}
+
 func TestTimeTickMsg(t *testing.T) {
 	timeTickMsg := &TimeTickMsg{
 		BaseMsg: generateBaseMsg(),

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -345,6 +345,8 @@ type commonConfig struct {
 
 	EnabledOptimizeExpr               ParamItem `refreshable:"true"`
 	EnableDriverPrefetch              ParamItem `refreshable:"true"`
+	EnablePredicateDelete             ParamItem `refreshable:"true"`
+	PredicateDeleteHitCountThreshold  ParamItem `refreshable:"true"`
 	EnabledJSONKeyStats               ParamItem `refreshable:"true"`
 	EnabledGrowingSegmentJSONKeyStats ParamItem `refreshable:"true"`
 
@@ -1401,6 +1403,24 @@ If enabled, IPv6 ULA/global addresses will be prioritized ahead of IPv4.`,
 		Export:       true,
 	}
 	p.EnableDriverPrefetch.Init(base.mgr)
+
+	p.EnablePredicateDelete = ParamItem{
+		Key:          "common.enablePredicateDelete",
+		Version:      "3.0.0",
+		DefaultValue: "false",
+		Doc:          "Whether to enable predicate delete WAL events for non-simple delete expressions.",
+		Export:       true,
+	}
+	p.EnablePredicateDelete.Init(base.mgr)
+
+	p.PredicateDeleteHitCountThreshold = ParamItem{
+		Key:          "common.predicateDeleteHitCountThreshold",
+		Version:      "3.0.0",
+		DefaultValue: "1024",
+		Doc:          "Use predicate delete only when the matched row count is greater than this threshold.",
+		Export:       true,
+	}
+	p.PredicateDeleteHitCountThreshold.Init(base.mgr)
 
 	p.UsingJSONStatsForQuery = ParamItem{
 		Key:          "common.usingJSONShreddingForQuery",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -103,6 +103,16 @@ func TestComponentParam(t *testing.T) {
 		params.Save(Params.GracefulStopTimeout.Key, "50")
 		assert.Equal(t, Params.GracefulStopTimeout.GetAsInt64(), int64(50))
 
+		assert.False(t, Params.EnablePredicateDelete.GetAsBool())
+		params.Save(Params.EnablePredicateDelete.Key, "true")
+		assert.True(t, Params.EnablePredicateDelete.GetAsBool())
+		params.Reset(Params.EnablePredicateDelete.Key)
+
+		assert.Equal(t, int64(1024), Params.PredicateDeleteHitCountThreshold.GetAsInt64())
+		params.Save(Params.PredicateDeleteHitCountThreshold.Key, "2048")
+		assert.Equal(t, int64(2048), Params.PredicateDeleteHitCountThreshold.GetAsInt64())
+		params.Reset(Params.PredicateDeleteHitCountThreshold.Key)
+
 		// -- rootcoord --
 		assert.Equal(t, Params.RootCoordTimeTick.GetValue(), "by-dev-rootcoord-timetick")
 		t.Logf("rootcoord timetick channel = %s", Params.RootCoordTimeTick.GetValue())


### PR DESCRIPTION
issue: #50433
design doc: docs/design-docs/design_docs/20260626-predicate-delete.md (added in this PR)

## What
- Add predicate-delete payload support to DeleteRequest producer path for non-simple delete expressions.
- Add common.enablePredicateDelete config gate and route Proxy complex delete to predicate-delete WAL messages when enabled.
- Append one predicate-delete DeleteMessageV1 per vchannel with serialized predicate plan and partition scope.
- Add coverage for paramtable config, predicate-delete routing, append helper paths, and partition scopes.
- Add the PredicateDelete design doc under docs/design-docs (Part 1 producer path is implemented by this PR).

## Design doc
This PR is Part 1 (Proxy/WAL producer) of the PredicateDelete feature.
Design: [docs/design-docs/design_docs/20260626-predicate-delete.md](docs/design-docs/design_docs/20260626-predicate-delete.md)

## Verification
- go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./util/paramtable (from pkg/)
- go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./streaming/util/message (from pkg/)
- go test ./msgpb (from milvus-proto/go-api)
- git diff --check

## Notes
- Draft until the milvus-proto dependency is replaced with an official version instead of the local development replace.
- Focused Proxy delete UT is currently blocked locally by existing mock/type generation and stale C++ core artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
