### PR TITLE
fix: backfill absent nullable vector fields when loading growing segment

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -2423,6 +2423,7 @@ SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     auto manifest_path = load_info_.manifest_path();
     if (manifest_path != "") {
         LoadColumnsGroups(manifest_path);
+        FillAbsentFields();
         return;
     }
 
@@ -2461,6 +2462,17 @@ SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
         LoadFieldData(field_data_info);
     }
 
+    FillAbsentFields();
+
+    // Update resource tracking
+    UpdateResourceTracking();
+}
+
+void
+SegmentGrowingImpl::FillAbsentFields() {
+    if (insert_record_.row_count() == 0) {
+        return;
+    }
     for (const auto& [field_id, field_meta] : schema_->get_fields()) {
         if (field_id.get() < START_USER_FIELDID) {
             continue;
@@ -2468,16 +2480,25 @@ SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
         if (schema_->is_function_output(field_id)) {
             continue;
         }
+        if (IsVectorDataType(field_meta.get_data_type())) {
+            // A vector field may be legally absent from the loaded data only
+            // when it is nullable (added by AddField after the binlogs were
+            // written). Backfill its validity bitmap so that queries observe
+            // all-null values instead of an uninitialized column.
+            if (field_meta.is_nullable() &&
+                insert_record_.is_data_exist(field_id) &&
+                insert_record_.is_valid_data_exist(field_id) &&
+                insert_record_.get_valid_data(field_id)->get_data().empty()) {
+                fill_empty_field(field_meta);
+            }
+            continue;
+        }
         // append_data is called according to schema before
         // so we must check data empty here
-        if (!IsVectorDataType(field_meta.get_data_type()) &&
-            insert_record_.get_data_base(field_id)->empty()) {
+        if (insert_record_.get_data_base(field_id)->empty()) {
             fill_empty_field(field_meta);
         }
     }
-
-    // Update resource tracking
-    UpdateResourceTracking();
 }
 
 void
@@ -2657,8 +2678,10 @@ SegmentGrowingImpl::fill_empty_field(const FieldMeta& field_meta) {
     auto total_row_num = insert_record_.row_count();
 
     auto data = bulk_subscript_not_exist_field(field_meta, total_row_num);
-    insert_record_.get_valid_data(field_id)->set_data_raw(
-        total_row_num, data.get(), field_meta);
+    if (insert_record_.is_valid_data_exist(field_id)) {
+        insert_record_.get_valid_data(field_id)->set_data_raw(
+            total_row_num, data.get(), field_meta);
+    }
     insert_record_.get_data_base(field_id)->set_data_raw(
         0, total_row_num, data.get(), field_meta);
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -167,6 +167,13 @@ class SegmentGrowingImpl : public SegmentGrowing {
     Load(milvus::tracer::TraceContext& trace_ctx,
          milvus::OpContext* op_ctx = nullptr) override;
 
+    // Backfill fields that exist in the schema but had no data to load,
+    // e.g. fields added by AddField after the loaded binlogs were written.
+    // Nullable vector fields get their validity bitmap filled so queries
+    // observe all-null values instead of an uninitialized column.
+    void
+    FillAbsentFields();
+
  private:
     // Build geometry cache for inserted data
     void

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -785,9 +785,11 @@ SegmentInternalInterface::bulk_subscript_not_exist_field(
 
     auto result = CreateEmptyScalarDataArray(count, field_meta);
     if (field_meta.default_value().has_value()) {
-        auto res = result->mutable_valid_data()->mutable_data();
-        for (int64_t i = 0; i < count; ++i) {
-            res[i] = true;
+        if (field_meta.is_nullable()) {
+            auto res = result->mutable_valid_data()->mutable_data();
+            for (int64_t i = 0; i < count; ++i) {
+                res[i] = true;
+            }
         }
         switch (field_meta.get_data_type()) {
             case DataType::BOOL: {
@@ -897,11 +899,12 @@ SegmentInternalInterface::bulk_subscript_not_exist_field(
             }
         }
         return result;
-    };
-    for (int64_t i = 0; i < count; ++i) {
-        auto res = result->mutable_valid_data()->mutable_data();
-        res[i] = false;
     }
+    // Without a default value the column can only read as all-null;
+    // CreateEmptyScalarDataArray already sized valid_data to all-false.
+    AssertInfo(field_meta.is_nullable(),
+               "Non-nullable scalar field without default value should not "
+               "reach here");
     return result;
 }
 

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -68,6 +68,7 @@ set(MILVUS_TEST_FILES
         test_arrow_canonicalize.cpp
         TextLobSpilloverTest.cpp
         test_commit_timestamp.cpp
+        test_schema_reopen.cpp
         )
 
 if ( NOT (INDEX_ENGINE STREQUAL "cardinal") )

--- a/internal/core/unittest/test_schema_reopen.cpp
+++ b/internal/core/unittest/test_schema_reopen.cpp
@@ -11,198 +11,111 @@
 
 #include <gtest/gtest.h>
 #include <memory>
-#include <thread>
+#include <numeric>
 #include <vector>
 
 #include "common/Schema.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/storage_test_utils.h"
 
 using namespace milvus;
 using namespace milvus::segcore;
 
-/**
- * Test for Issue #46656: QueryNode panic with "unordered_map::at" during ProcessInsert
- *
- * Root Cause:
- * - IndexingRecord holds a const reference to Schema (schema_)
- * - When SegmentGrowingImpl::Reopen() updates schema_ to a new Schema object,
- *   the old Schema object may be destroyed
- * - IndexingRecord::schema_ becomes a dangling reference
- * - Accessing schema_.get_fields().at(fieldId) causes undefined behavior:
- *   - std::out_of_range if the hash table is partially corrupted
- *   - SIGFPE if the hash table's bucket_count becomes 0
- *
- * Fix:
- * - AppendingIndex no longer accesses internal schema_ reference
- * - Caller passes in valid field_meta from current schema
- */
 class SchemaReopenTest : public testing::Test {
  protected:
     void
     SetUp() override {
-        // Create initial schema V1 with vector field
+        // Schema V1: the pre-AddField schema that the loaded binlogs were
+        // written with (vector + primary key).
         schema_v1_ = std::make_shared<Schema>();
-        auto vec_fid = schema_v1_->AddDebugField(
+        schema_v1_->AddDebugField(
             "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
         auto pk_fid = schema_v1_->AddDebugField("pk", DataType::INT64);
         schema_v1_->set_primary_field_id(pk_fid);
         schema_v1_->set_schema_version(1);
-
-        // Create schema V2 with additional field
-        schema_v2_ = std::make_shared<Schema>();
-        schema_v2_->AddDebugField(
-            "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
-        auto pk_fid_v2 = schema_v2_->AddDebugField("pk", DataType::INT64);
-        schema_v2_->AddDebugField("new_field",
-                                  DataType::VARCHAR);  // New field in V2
-        schema_v2_->set_primary_field_id(pk_fid_v2);
-        schema_v2_->set_schema_version(2);
     }
 
     SchemaPtr schema_v1_;
-    SchemaPtr schema_v2_;
 };
 
 /**
- * Test: Insert after Reopen should not crash
+ * Test for Issue #50366: StreamingNode crashes in segcore retrieve when a
+ * growing segment is loaded from binlogs that predate an AddField of a
+ * nullable vector field.
  *
- * Before fix: This test would crash with std::out_of_range or SIGFPE
- * because IndexingRecord::AppendingIndex() accessed the dangling schema_ reference.
+ * Scenario:
+ * - A growing segment is recovered via LoadGrowing after a node restart.
+ * - Its binlogs were written before `AddField(new_vec)` so they carry no data
+ *   for the new column, while the segment is constructed with the new schema.
+ * - Before the fix, the post-load backfill skipped all vector fields, so the
+ *   column's validity bitmap stayed empty; FilterVectorValidOffsets then
+ *   returned valid_count == count with an EMPTY valid_offsets vector and
+ *   bulk_subscript dereferenced the empty vector's data() (nullptr) as the
+ *   offsets array -> SIGSEGV.
  *
- * After fix: Insert uses caller-provided field_meta, avoiding dangling reference.
+ * After the fix, FillAbsentFields (called from Load) backfills the validity
+ * bitmap of absent nullable vector fields, so the column reads as all-null.
  */
-TEST_F(SchemaReopenTest, InsertAfterReopenShouldNotCrash) {
-    // Step 1: Create segment with schema V1
-    auto segment = CreateGrowingSegment(schema_v1_, nullptr);
+TEST_F(SchemaReopenTest, LoadWithAbsentNullableVectorFieldShouldReadAllNull) {
+    // Schema V2 shares the first two fields with V1 (same field ids) and has
+    // an extra nullable FLOAT_VECTOR field added by AddField. Added fields must
+    // be nullable (enforced by the proxy on AddCollectionField).
+    auto schema_v2 = std::make_shared<Schema>();
+    schema_v2->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+    auto pk_fid = schema_v2->AddDebugField("pk", DataType::INT64);
+    auto added_fid = schema_v2->AddDebugField("new_vec",
+                                              DataType::VECTOR_FLOAT,
+                                              128,
+                                              knowhere::metric::L2,
+                                              /*nullable=*/true);
+    schema_v2->set_primary_field_id(pk_fid);
+    schema_v2->set_schema_version(2);
+
+    auto segment = CreateGrowingSegment(schema_v2, milvus::empty_index_meta);
     auto seg_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
     ASSERT_NE(seg_impl, nullptr);
 
-    // Step 2: Insert some data with schema V1
+    // The binlogs only contain the V1 columns: no data for new_vec.
     int N = 100;
-    auto data_v1 = DataGen(schema_v1_, N, /*seed=*/42);
+    auto dataset = DataGen(schema_v1_, N, /*seed=*/42);
+    LoadGeneratedDataIntoSegment(dataset, seg_impl);
+    ASSERT_EQ(segment->get_row_count(), N);
+
+    std::vector<int64_t> offsets(N);
+    std::iota(offsets.begin(), offsets.end(), 0);
+    milvus::OpContext op_ctx;
+
+    // Load() runs FillAbsentFields to backfill the validity bitmap of the
+    // absent nullable vector column; reading it must not crash and every
+    // row must read as null.
+    seg_impl->FillAbsentFields();
+    auto col = seg_impl->bulk_subscript(&op_ctx, added_fid, offsets.data(), N);
+    ASSERT_EQ(col->valid_data_size(), N);
+    for (int i = 0; i < N; ++i) {
+        ASSERT_FALSE(col->valid_data(i)) << "row " << i << " should be null";
+    }
+    ASSERT_EQ(col->vectors().float_vector().data_size(), 0);
+
+    // WAL replay after recovery delivers inserts written with the old
+    // schema; Insert patches the missing column with nulls. The bitmap must
+    // stay aligned across the loaded prefix and the replayed tail.
+    auto data_v1 = DataGen(schema_v1_, N, /*seed=*/100);
     segment->PreInsert(N);
-    segment->Insert(0,
+    segment->Insert(N,
                     N,
                     data_v1.row_ids_.data(),
                     data_v1.timestamps_.data(),
                     data_v1.raw_);
+    ASSERT_EQ(segment->get_row_count(), 2 * N);
 
-    // Step 3: Reopen with schema V2 (this may destroy old Schema object)
-    seg_impl->Reopen(schema_v2_);
-
-    // Step 4: Insert more data - this should NOT crash
-    // Before fix: This would crash because IndexingRecord::schema_ is dangling
-    // After fix: This works because AppendingIndex uses caller-provided field_meta
-    auto data_v2 = DataGen(schema_v2_, N, /*seed=*/100);
-    segment->PreInsert(N);
-
-    // This insert should complete without crashing
-    EXPECT_NO_THROW({
-        segment->Insert(N,
-                        N,
-                        data_v2.row_ids_.data(),
-                        data_v2.timestamps_.data(),
-                        data_v2.raw_);
-    });
-
-    // Verify segment state is valid
-    EXPECT_EQ(segment->get_row_count(), 2 * N);
-}
-
-/**
- * Test: Concurrent Insert and Reopen should not crash
- *
- * This simulates the chaos testing scenario where Insert and schema updates
- * happen concurrently after pod recovery.
- */
-TEST_F(SchemaReopenTest, ConcurrentInsertAndReopenShouldNotCrash) {
-    auto segment = CreateGrowingSegment(schema_v1_, nullptr);
-    auto seg_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
-    ASSERT_NE(seg_impl, nullptr);
-
-    std::atomic<bool> stop_flag{false};
-    std::atomic<int> insert_count{0};
-    std::vector<std::exception_ptr> exceptions;
-    std::mutex exceptions_mutex;
-
-    // Thread 1: Continuous inserts
-    auto insert_thread = std::thread([&]() {
-        int offset = 0;
-        while (!stop_flag.load()) {
-            try {
-                int N = 10;
-                auto data = DataGen(schema_v1_, N, offset);
-                segment->PreInsert(N);
-                segment->Insert(offset,
-                                N,
-                                data.row_ids_.data(),
-                                data.timestamps_.data(),
-                                data.raw_);
-                offset += N;
-                insert_count.fetch_add(1);
-            } catch (...) {
-                std::lock_guard<std::mutex> lock(exceptions_mutex);
-                exceptions.push_back(std::current_exception());
-                break;
-            }
-        }
-    });
-
-    // Thread 2: Periodic Reopen
-    auto reopen_thread = std::thread([&]() {
-        for (int i = 0; i < 5 && !stop_flag.load(); ++i) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
-            try {
-                // Alternate between V1 and V2
-                if (i % 2 == 0) {
-                    seg_impl->Reopen(schema_v2_);
-                } else {
-                    seg_impl->Reopen(schema_v1_);
-                }
-            } catch (...) {
-                std::lock_guard<std::mutex> lock(exceptions_mutex);
-                exceptions.push_back(std::current_exception());
-                break;
-            }
-        }
-        stop_flag.store(true);
-    });
-
-    insert_thread.join();
-    reopen_thread.join();
-
-    // Verify no exceptions were thrown
-    EXPECT_TRUE(exceptions.empty())
-        << "Concurrent Insert/Reopen caused exceptions";
-
-    // Verify some inserts completed
-    EXPECT_GT(insert_count.load(), 0) << "Expected some inserts to complete";
-}
-
-/**
- * Test: Field not in IndexingRecord should be handled gracefully
- *
- * When a new field is added via Reopen, it won't exist in IndexingRecord's
- * field_indexings_ map. The code should handle this gracefully.
- */
-TEST_F(SchemaReopenTest, NewFieldAfterReopenShouldBeSkipped) {
-    auto segment = CreateGrowingSegment(schema_v1_, nullptr);
-    auto seg_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
-    ASSERT_NE(seg_impl, nullptr);
-
-    // Reopen with V2 which has a new field
-    seg_impl->Reopen(schema_v2_);
-
-    // Insert data that includes the new field
-    int N = 100;
-    auto data = DataGen(schema_v2_, N, 42);
-    segment->PreInsert(N);
-
-    // This should not crash - new field should be skipped in AppendingIndex
-    // because it doesn't exist in field_indexings_
-    EXPECT_NO_THROW({
-        segment->Insert(
-            0, N, data.row_ids_.data(), data.timestamps_.data(), data.raw_);
-    });
+    std::vector<int64_t> all_offsets(2 * N);
+    std::iota(all_offsets.begin(), all_offsets.end(), 0);
+    col =
+        seg_impl->bulk_subscript(&op_ctx, added_fid, all_offsets.data(), 2 * N);
+    ASSERT_EQ(col->valid_data_size(), 2 * N);
+    for (int i = 0; i < 2 * N; ++i) {
+        ASSERT_FALSE(col->valid_data(i)) << "row " << i << " should be null";
+    }
 }


### PR DESCRIPTION
issue: #50366

### Root cause

Both crashes in #50366 hit the same nullptr dereference in `SegmentGrowingImpl::bulk_subscript_impl<FloatVector>` (SIGSEGV, exit code 139).

When a growing segment is recovered from binlogs (`delegator.LoadGrowing` after a StreamingNode restart or shard transfer), binlogs written before an `AddCollectionField` carry no data for the added column. The schema-change WAL message flushes and fences segments, but the flush is asynchronous: a restart in the seal→flushed window reloads the segment as growing, from old binlogs, under the new schema.

The post-load backfill loop at the end of `SegmentGrowingImpl::Load()` excluded **all** vector fields (`!IsVectorDataType`), so an added nullable vector field ended up with rows > 0 and an **empty validity bitmap**. For that state `FilterVectorValidOffsets` returns `valid_count == count` (its initial value) together with an empty `valid_offsets` vector, and `bulk_subscript` uses the empty vector's `data()` — nullptr — as the offsets array with a non-zero count, crashing in `bulk_subscript_impl` on `seg_offsets[i]`.

The sealed-segment counterpart already handles this correctly: it only excludes non-nullable vector fields from default filling and backfills the rest.

### Changes

- Extract the post-load backfill into `FillAbsentFields()` and backfill the validity bitmap of nullable vector fields that had no data to load, giving the column all-null semantics (mirroring `Reopen`/`fill_empty_field` and the sealed segment behavior). Non-nullable vector fields keep the previous behavior.
- Absence is detected via an **empty validity bitmap** rather than empty physical data: a legally loaded all-null column also has no physical data in mapping storage and must not be filled twice.
- Run the backfill on the storage-v2 manifest load path (`LoadColumnsGroups`) as well, which previously skipped it entirely due to an early return in `Load()`.

### Test

New regression test `SchemaReopenTest.LoadWithAbsentNullableVectorFieldShouldReadAllNull` reproduces the production scenario: load binlogs that predate the AddField into a segment constructed with the new schema, backfill via `FillAbsentFields` (as `Load()` does), read the added nullable vector column, then replay old-schema inserts and read across both the loaded and replayed ranges — all rows must read as null and nothing crashes.

### Non-goals (follow-ups)

- `FilterVectorValidOffsets` can still return an inconsistent (`valid_count`, `valid_offsets`) pair if an upstream invariant is broken (e.g. the interim-index error-recovery path `recreate_index` swaps in a fresh index without resetting `sync_with_index_`/`index_cur_`). Those producer-side bugs and the schema publication atomicity are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)