### PR TITLE
enhance: speed up BM25 stats loading during recovery

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -603,6 +603,7 @@ queryNode:
     size: 10 # the size for worker querynode client pool
   idfOracle:
     preload: true # Whether to parse and merge BM25 stats into current during load before first target. When false, stats are only written to disk and loaded on first SyncDistribution.
+    remoteFetchOnly: false # Whether sealed BM25 stats should skip local disk cache and be fetched directly from remote storage. When true, preload parses remote stats directly into current and later target updates fetch from remote storage on demand.
     readBufferSize: 4194304 # Read buffer size in bytes for streaming BM25 stats from remote storage. Reduces per-read overhead through the storage SDK.
     bm25StatsBytesPerEntry: 20 # Estimated memory cost (bytes) per entry in BM25 stats rowsWithToken map for memory accounting. Empirical measurement: 12-19.5 bytes/entry depending on map fill ratio. Increase if cache eviction is too lax; decrease to load more segments concurrently.
   ip:  # TCP/IP address of queryNode. If not specified, use the first unicastable address

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -425,7 +425,7 @@ func (sd *shardDelegator) LoadGrowing(ctx context.Context, infos []*querypb.Segm
 // idf oracle owns the full lifecycle: download, disk write, register, cleanup.
 func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.SegmentLoadInfo, req *querypb.LoadSegmentsRequest) error {
 	idfOracle := sd.getIDFOracle()
-	if idfOracle == nil {
+	if idfOracle == nil || len(infos) == 0 {
 		return nil
 	}
 
@@ -630,21 +630,20 @@ func (sd *shardDelegator) LoadSegments(ctx context.Context, req *querypb.LoadSeg
 		return sd.handleReopenPostLoad(ctx, req)
 	}
 
-	return sd.withPostLoadLimit(ctx, func() error {
-		infos := lo.Filter(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) bool {
-			return !sd.distribution.SealedSegmentExistsOnNode(info.GetSegmentID(), targetNodeID)
-		})
+	infos := lo.Filter(req.GetInfos(), func(info *querypb.SegmentLoadInfo, _ int) bool {
+		return !sd.distribution.SealedSegmentExistsOnNode(info.GetSegmentID(), targetNodeID)
+	})
 
+	// Load BM25 stats before loadStreamDelete so stats are ready before the segment becomes visible.
+	if err := sd.loadBM25Stats(ctx, infos, req); err != nil {
+		log.Warn("failed to load BM25 stats", zap.Error(err))
+		return err
+	}
+
+	return sd.withPostLoadLimit(ctx, func() error {
 		candidates, err := sd.loader.LoadBloomFilterSet(ctx, req.GetCollectionID(), infos...)
 		if err != nil {
 			log.Warn("failed to load bloom filter set for segment", zap.Error(err))
-			return err
-		}
-
-		// Load BM25 stats BEFORE loadStreamDelete so stats are ready before segment becomes visible
-		err = sd.loadBM25Stats(ctx, infos, req)
-		if err != nil {
-			log.Warn("failed to load BM25 stats", zap.Error(err))
 			return err
 		}
 

--- a/internal/querynodev2/delegator/idf_oracle.go
+++ b/internal/querynodev2/delegator/idf_oracle.go
@@ -171,12 +171,15 @@ type sealedBm25Stats struct {
 
 	activate *atomic.Bool
 
-	removed   bool
-	segmentID int64
-	ts        time.Time // Time of segment register
-	localDir  string
-	fieldList []int64 // bm25 field list
-	diskSize  int64   // total disk size of local files
+	removed         bool
+	segmentID       int64
+	ts              time.Time // Time of segment register
+	localDir        string
+	remoteFetchOnly bool
+	remotePaths     map[int64][]string
+	cm              storage.ChunkManager
+	fieldList       []int64 // bm25 field list
+	diskSize        int64   // total disk size of local files
 }
 
 func (s *sealedBm25Stats) HasField(fieldID int64) bool {
@@ -228,7 +231,7 @@ func (s *sealedBm25Stats) Remove() {
 	}
 }
 
-// FetchStats reads stats from local multi-file directory and merges per field.
+// FetchStats reads stats from the configured source and merges per field.
 // Local directory structure: {localDir}/{fieldID}/0.data, 1.data, ...
 func (s *sealedBm25Stats) FetchStats() (map[int64]*storage.BM25Stats, error) {
 	s.RLock()
@@ -238,6 +241,13 @@ func (s *sealedBm25Stats) FetchStats() (map[int64]*storage.BM25Stats, error) {
 		return nil, errors.Newf("sealed bm25 stats for segment %d already removed", s.segmentID)
 	}
 
+	if s.remoteFetchOnly {
+		return s.fetchRemoteStats()
+	}
+	return s.fetchLocalStats()
+}
+
+func (s *sealedBm25Stats) fetchLocalStats() (map[int64]*storage.BM25Stats, error) {
 	stats := make(map[int64]*storage.BM25Stats)
 	for _, fieldID := range s.fieldList {
 		fieldDir := path.Join(s.localDir, fmt.Sprintf("%d", fieldID))
@@ -265,6 +275,24 @@ func (s *sealedBm25Stats) FetchStats() (map[int64]*storage.BM25Stats, error) {
 		stats[fieldID] = fieldStats
 	}
 
+	return stats, nil
+}
+
+func (s *sealedBm25Stats) fetchRemoteStats() (map[int64]*storage.BM25Stats, error) {
+	if s.cm == nil {
+		return nil, errors.Newf("remote chunk manager is nil for segment %d", s.segmentID)
+	}
+
+	stats := make(map[int64]*storage.BM25Stats, len(s.remotePaths))
+	for _, fieldID := range s.fieldList {
+		fieldStats := storage.NewBM25Stats()
+		for _, remotePath := range s.remotePaths[fieldID] {
+			if err := readRemoteBM25Stats(context.Background(), s.cm, remotePath, fieldStats); err != nil {
+				return nil, errors.Wrapf(err, "read remote bm25 stats %s", remotePath)
+			}
+		}
+		stats[fieldID] = fieldStats
+	}
 	return stats, nil
 }
 
@@ -441,7 +469,8 @@ func (o *idfOracle) LoadSealed(ctx context.Context, segmentID int64, loadInfo *q
 
 		needParse := o.targetVersion.Load() == 0 && paramtable.Get().QueryNodeCfg.IDFPreload.GetAsBool()
 
-		result, err := o.streamLoad(ctx, segmentID, logpaths, cm, needParse)
+		remoteFetchOnly := paramtable.Get().QueryNodeCfg.IDFRemoteFetchOnly.GetAsBool()
+		result, err := o.streamLoad(ctx, segmentID, logpaths, cm, needParse, remoteFetchOnly)
 		if err != nil {
 			// cleanup on failure
 			cleanupPath := path.Join(o.dirPath, fmt.Sprintf("%d", segmentID))
@@ -452,12 +481,15 @@ func (o *idfOracle) LoadSealed(ctx context.Context, segmentID int64, loadInfo *q
 		}
 
 		segStats := &sealedBm25Stats{
-			ts:        time.Now(),
-			activate:  atomic.NewBool(false),
-			segmentID: segmentID,
-			localDir:  result.localDir,
-			fieldList: result.fieldList,
-			diskSize:  result.diskSize,
+			ts:              time.Now(),
+			activate:        atomic.NewBool(false),
+			segmentID:       segmentID,
+			localDir:        result.localDir,
+			remoteFetchOnly: result.remoteFetchOnly,
+			remotePaths:     result.remotePaths,
+			cm:              result.cm,
+			fieldList:       result.fieldList,
+			diskSize:        result.diskSize,
 		}
 
 		if needParse && result.stats != nil {
@@ -526,7 +558,14 @@ func (o *idfOracle) LoadSealedForReopen(ctx context.Context, segmentID int64, lo
 		}
 		defer cleanup()
 
-		result, err := o.streamLoad(ctx, segmentID, missingPaths, cm, true)
+		remoteFetchOnly := paramtable.Get().QueryNodeCfg.IDFRemoteFetchOnly.GetAsBool()
+		if existedBeforeLoad {
+			segStats.RLock()
+			remoteFetchOnly = segStats.remoteFetchOnly
+			segStats.RUnlock()
+		}
+
+		result, err := o.streamLoad(ctx, segmentID, missingPaths, cm, true, remoteFetchOnly)
 		if err != nil {
 			return nil, err
 		}
@@ -568,6 +607,15 @@ func (o *idfOracle) LoadSealedForReopen(ctx context.Context, segmentID int64, lo
 			}
 
 			segStats.addFieldsLocked(installedFields)
+			if result.remoteFetchOnly {
+				if segStats.remotePaths == nil {
+					segStats.remotePaths = make(map[int64][]string, len(installedFields))
+				}
+				for _, fieldID := range installedFields {
+					segStats.remotePaths[fieldID] = result.remotePaths[fieldID]
+				}
+				segStats.cm = result.cm
+			}
 			segStats.diskSize += result.diskSize
 			switch {
 			case wasActive:
@@ -583,12 +631,15 @@ func (o *idfOracle) LoadSealedForReopen(ctx context.Context, segmentID int64, lo
 			segStats.Unlock()
 		} else {
 			segStats = &sealedBm25Stats{
-				ts:        time.Now(),
-				activate:  atomic.NewBool(false),
-				segmentID: segmentID,
-				localDir:  result.localDir,
-				fieldList: result.fieldList,
-				diskSize:  result.diskSize,
+				ts:              time.Now(),
+				activate:        atomic.NewBool(false),
+				segmentID:       segmentID,
+				localDir:        result.localDir,
+				remoteFetchOnly: result.remoteFetchOnly,
+				remotePaths:     result.remotePaths,
+				cm:              result.cm,
+				fieldList:       result.fieldList,
+				diskSize:        result.diskSize,
 			}
 			if activateIfReadable {
 				o.activateSealedStatsLocked(segStats, result.stats)
@@ -606,15 +657,18 @@ func (o *idfOracle) LoadSealedForReopen(ctx context.Context, segmentID int64, lo
 }
 
 type streamLoadResult struct {
-	localDir  string
-	fieldList []int64
-	stats     bm25Stats // non-nil only when needParse=true
-	diskSize  int64
+	localDir        string
+	remoteFetchOnly bool
+	remotePaths     map[int64][]string
+	cm              storage.ChunkManager
+	fieldList       []int64
+	stats           bm25Stats // non-nil only when needParse=true
+	diskSize        int64
 }
 
 // streamLoad downloads BM25 stats from remote storage to local disk.
 // When needParse is true, also parses stats using TeeReader.
-func (o *idfOracle) streamLoad(ctx context.Context, segmentID int64, binlogPaths map[int64][]string, cm storage.ChunkManager, needParse bool) (streamLoadResult, error) {
+func (o *idfOracle) streamLoad(ctx context.Context, segmentID int64, binlogPaths map[int64][]string, cm storage.ChunkManager, needParse bool, remoteFetchOnly bool) (streamLoadResult, error) {
 	log := log.Ctx(ctx).With(zap.Int64("segmentID", segmentID))
 	startTs := time.Now()
 
@@ -622,6 +676,36 @@ func (o *idfOracle) streamLoad(ctx context.Context, segmentID int64, binlogPaths
 	var totalDiskSize int64
 	var stats map[int64]*storage.BM25Stats
 	fieldList := make([]int64, 0, len(binlogPaths))
+
+	if remoteFetchOnly {
+		if needParse {
+			stats = make(map[int64]*storage.BM25Stats, len(binlogPaths))
+			for fieldID, paths := range binlogPaths {
+				fieldList = append(fieldList, fieldID)
+				fieldStats := storage.NewBM25Stats()
+				for _, remotePath := range paths {
+					if err := readRemoteBM25Stats(ctx, cm, remotePath, fieldStats); err != nil {
+						return streamLoadResult{}, errors.Wrapf(err, "read remote bm25 stats %s", remotePath)
+					}
+				}
+				stats[fieldID] = fieldStats
+				log.Info("loaded remote bm25 stats", zap.Duration("time", time.Since(startTs)), zap.Int64("numRow", fieldStats.NumRow()), zap.Int64("fieldID", fieldID))
+			}
+		} else {
+			for fieldID := range binlogPaths {
+				fieldList = append(fieldList, fieldID)
+			}
+		}
+
+		log.Info("stream load bm25 stats done", zap.Duration("time", time.Since(startTs)), zap.Int64("diskSize", 0), zap.Bool("parsed", needParse), zap.Bool("remoteFetchOnly", true))
+		return streamLoadResult{
+			remoteFetchOnly: true,
+			remotePaths:     binlogPaths,
+			cm:              cm,
+			fieldList:       fieldList,
+			stats:           stats,
+		}, nil
+	}
 
 	if needParse {
 		stats = make(map[int64]*storage.BM25Stats, len(binlogPaths))
@@ -662,6 +746,17 @@ func (o *idfOracle) streamLoad(ctx context.Context, segmentID int64, binlogPaths
 		stats:     stats,
 		diskSize:  totalDiskSize,
 	}, nil
+}
+
+func readRemoteBM25Stats(ctx context.Context, cm storage.ChunkManager, remotePath string, parseInto *storage.BM25Stats) error {
+	reader, err := cm.Reader(ctx, remotePath)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	br := bufio.NewReaderSize(reader, paramtable.Get().QueryNodeCfg.IDFReadBufferSize.GetAsInt())
+	return parseInto.DeserializeFromReader(br)
 }
 
 // streamOneFile streams a single remote file to a local file.

--- a/internal/querynodev2/delegator/idf_oracle_test.go
+++ b/internal/querynodev2/delegator/idf_oracle_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -110,6 +111,20 @@ func genBM25StatsForField(fieldID int64, start uint32, end uint32) map[int64]*st
 		result[fieldID].Append(row)
 	}
 	return result
+}
+
+func (suite *IDFOracleSuite) setIDFRemoteFetchOnly(enabled bool) {
+	setIDFRemoteFetchOnly(suite.T(), enabled)
+}
+
+func setIDFRemoteFetchOnly(t testing.TB, enabled bool) {
+	t.Helper()
+	item := &paramtable.Get().QueryNodeCfg.IDFRemoteFetchOnly
+	old := item.GetValue()
+	require.NoError(t, paramtable.Get().Save(item.Key, fmt.Sprintf("%t", enabled)))
+	t.Cleanup(func() {
+		_ = paramtable.Get().Save(item.Key, old)
+	})
 }
 
 // registerSealed loads BM25 stats via LoadSealed with a mock ChunkManager.
@@ -340,6 +355,18 @@ func (suite *IDFOracleSuite) TestFetchStatsRemoved() {
 	suite.Contains(err.Error(), "already removed")
 }
 
+func (suite *IDFOracleSuite) TestFetchStatsUsesExplicitRemoteFetchOnlyMode() {
+	stats := &sealedBm25Stats{
+		activate:  atomic.NewBool(false),
+		segmentID: 1,
+		fieldList: []int64{102},
+	}
+
+	_, err := stats.FetchStats()
+	suite.Error(err)
+	suite.Contains(err.Error(), "read local dir")
+}
+
 func (suite *IDFOracleSuite) TestDiskSizeTracking() {
 	disk1 := suite.registerSealed(1, 1, 2)
 	disk2 := suite.registerSealed(2, 2, 3)
@@ -458,6 +485,82 @@ func (suite *IDFOracleSuite) TestLoadSealedNoParse() {
 	fetched, err := sealedStats.FetchStats()
 	suite.NoError(err)
 	suite.Equal(int64(4), fetched[102].NumRow())
+}
+
+func (suite *IDFOracleSuite) TestLoadSealedRemoteFetchOnlyPreload() {
+	suite.setIDFRemoteFetchOnly(true)
+
+	stats := suite.genStats(1, 5)
+	data, err := stats[102].Serialize()
+	suite.Require().NoError(err)
+
+	cm := mocks.NewChunkManager(suite.T())
+	remotePath := "bm25stats/seg_1/field_102/0"
+	cm.EXPECT().Reader(mock.Anything, remotePath).RunAndReturn(
+		func(context.Context, string) (storage.FileReader, error) {
+			return &bytesFileReader{bytes.NewReader(data)}, nil
+		},
+	).Once()
+
+	bm25Logs := []*datapb.FieldBinlog{{
+		FieldID: 102,
+		Binlogs: []*datapb.Binlog{{LogPath: remotePath}},
+	}}
+
+	err = suite.idfOracle.LoadSealed(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25Logs}, cm)
+	suite.NoError(err)
+	suite.Equal(int64(4), suite.idfOracle.current.NumRow())
+	suite.Equal(int64(0), suite.idfOracle.sealedDiskSize.Load())
+
+	sealedStats, ok := suite.idfOracle.sealed.Get(1)
+	suite.True(ok)
+	sealedStats.RLock()
+	suite.Empty(sealedStats.localDir)
+	suite.Equal([]string{remotePath}, sealedStats.remotePaths[102])
+	sealedStats.RUnlock()
+
+	_, statErr := os.Stat(path.Join(suite.idfOracle.dirPath, "1"))
+	suite.True(os.IsNotExist(statErr))
+}
+
+func (suite *IDFOracleSuite) TestLoadSealedRemoteFetchOnlySyncDistribution() {
+	suite.setIDFRemoteFetchOnly(true)
+	suite.targetVersion = 1
+	suite.idfOracle.targetVersion.Store(1)
+
+	stats := suite.genStats(1, 5)
+	data, err := stats[102].Serialize()
+	suite.Require().NoError(err)
+
+	cm := mocks.NewChunkManager(suite.T())
+	remotePath := "bm25stats/seg_1/field_102/0"
+	cm.EXPECT().Reader(mock.Anything, remotePath).RunAndReturn(
+		func(context.Context, string) (storage.FileReader, error) {
+			return &bytesFileReader{bytes.NewReader(data)}, nil
+		},
+	).Twice()
+
+	bm25Logs := []*datapb.FieldBinlog{{
+		FieldID: 102,
+		Binlogs: []*datapb.Binlog{{LogPath: remotePath}},
+	}}
+
+	err = suite.idfOracle.LoadSealed(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25Logs}, cm)
+	suite.NoError(err)
+	suite.True(suite.idfOracle.sealed.Contain(1))
+	suite.Equal(int64(0), suite.idfOracle.current.NumRow())
+	suite.Equal(int64(0), suite.idfOracle.sealedDiskSize.Load())
+
+	suite.updateSnapshot([]int64{1}, []int64{}, []int64{})
+	suite.idfOracle.SetNext(suite.snapshot)
+	suite.waitTargetVersion(suite.targetVersion)
+	suite.Equal(int64(4), suite.idfOracle.current.NumRow())
+
+	suite.updateSnapshot([]int64{}, []int64{}, []int64{1})
+	suite.idfOracle.SetNext(suite.snapshot)
+	suite.waitTargetVersion(suite.targetVersion)
+	suite.Equal(int64(0), suite.idfOracle.current.NumRow())
+	suite.Equal(int64(0), suite.idfOracle.sealedDiskSize.Load())
 }
 
 func (suite *IDFOracleSuite) TestLoadSealedFailureCleanup() {
@@ -891,6 +994,108 @@ func TestSyncDistributionReopenBM25InactiveThenActivate(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return idfOracle.TargetVersion() >= 1
 	}, time.Second, 10*time.Millisecond)
+
+	current, err = idfOracle.current.GetStats(104)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), current.NumRow())
+}
+
+func TestRemoteFetchOnlyReopenMergesRemoteMetadataForMissingFields(t *testing.T) {
+	setIDFRemoteFetchOnly(t, true)
+
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{101},
+		OutputFieldIds: []int64{102},
+	}, {
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{103},
+		OutputFieldIds: []int64{104},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	idfOracle.targetVersion.Store(1)
+	idfOracle.Start()
+	defer idfOracle.Close()
+
+	oldStats := genBM25StatsForField(102, 1, 3)
+	oldData, err := oldStats[102].Serialize()
+	require.NoError(t, err)
+	oldPath := "bm25stats/seg_1/field_102/0"
+
+	newStats := genBM25StatsForField(104, 10, 13)
+	newData, err := newStats[104].Serialize()
+	require.NoError(t, err)
+	newPath := "bm25stats/seg_1/field_104/0"
+
+	cm := mocks.NewChunkManager(t)
+	cm.EXPECT().Reader(mock.Anything, oldPath).RunAndReturn(
+		func(context.Context, string) (storage.FileReader, error) {
+			return &bytesFileReader{bytes.NewReader(oldData)}, nil
+		},
+	).Once()
+	cm.EXPECT().Reader(mock.Anything, newPath).RunAndReturn(
+		func(context.Context, string) (storage.FileReader, error) {
+			return &bytesFileReader{bytes.NewReader(newData)}, nil
+		},
+	).Twice()
+
+	err = idfOracle.LoadSealed(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(102, oldPath)}, cm)
+	require.NoError(t, err)
+
+	reopenInfo := &querypb.SegmentLoadInfo{
+		Bm25Logs: append(
+			bm25LogsForField(102, oldPath),
+			bm25LogsForField(104, newPath)...,
+		),
+	}
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, reopenInfo, cm, false)
+	require.NoError(t, err)
+
+	sealedStats, ok := idfOracle.sealed.Get(1)
+	require.True(t, ok)
+	fetched, err := sealedStats.FetchStats()
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), fetched[102].NumRow())
+	assert.Equal(t, int64(3), fetched[104].NumRow())
+}
+
+func TestRemoteFetchOnlyReopenCreatedSegmentActivatesFromRemote(t *testing.T) {
+	setIDFRemoteFetchOnly(t, true)
+
+	idfOracle := NewIDFOracle("test-channel", []*schemapb.FunctionSchema{{
+		Type:           schemapb.FunctionType_BM25,
+		InputFieldIds:  []int64{103},
+		OutputFieldIds: []int64{104},
+	}}).(*idfOracle)
+	idfOracle.dirPath = t.TempDir()
+	defer idfOracle.Close()
+
+	newStats := genBM25StatsForField(104, 10, 13)
+	data, err := newStats[104].Serialize()
+	require.NoError(t, err)
+
+	cm := mocks.NewChunkManager(t)
+	remotePath := "bm25stats/seg_1/field_104/0"
+	cm.EXPECT().Reader(mock.Anything, remotePath).RunAndReturn(
+		func(context.Context, string) (storage.FileReader, error) {
+			return &bytesFileReader{bytes.NewReader(data)}, nil
+		},
+	).Twice()
+
+	err = idfOracle.LoadSealedForReopen(context.Background(), 1, &querypb.SegmentLoadInfo{Bm25Logs: bm25LogsForField(104, remotePath)}, cm, false)
+	require.NoError(t, err)
+	current, err := idfOracle.current.GetStats(104)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), current.NumRow())
+
+	idfOracle.next.SetSnapshot(&snapshot{
+		dist: []SnapshotItem{{
+			NodeID:   1,
+			Segments: []SegmentEntry{{NodeID: 1, SegmentID: 1, TargetVersion: 1}},
+		}},
+		targetVersion: 1,
+	})
+	require.NoError(t, idfOracle.SyncDistribution())
 
 	current, err = idfOracle.current.GetStats(104)
 	require.NoError(t, err)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3639,6 +3639,7 @@ type queryNodeConfig struct {
 
 	// Idf Oracle
 	IDFPreload             ParamItem `refreshable:"true"`
+	IDFRemoteFetchOnly     ParamItem `refreshable:"true"`
 	IDFReadBufferSize      ParamItem `refreshable:"true"`
 	BM25StatsBytesPerEntry ParamItem `refreshable:"true"`
 	// partial search
@@ -3675,6 +3676,15 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 		Doc:          "Whether to parse and merge BM25 stats into current during load before first target. When false, stats are only written to disk and loaded on first SyncDistribution.",
 	}
 	p.IDFPreload.Init(base.mgr)
+
+	p.IDFRemoteFetchOnly = ParamItem{
+		Key:          "queryNode.idfOracle.remoteFetchOnly",
+		Version:      "2.6.15",
+		Export:       true,
+		DefaultValue: "false",
+		Doc:          "Whether sealed BM25 stats should skip local disk cache and be fetched directly from remote storage. When true, preload parses remote stats directly into current and later target updates fetch from remote storage on demand.",
+	}
+	p.IDFRemoteFetchOnly.Init(base.mgr)
 
 	p.IDFReadBufferSize = ParamItem{
 		Key:          "queryNode.idfOracle.readBufferSize",


### PR DESCRIPTION
## Summary

issue: #50511

Improve recovery-time BM25 stats loading for sealed segments.

### Changes

- Add a remote-only BM25 stats loading mode to read sealed stats directly from remote storage without writing them to local disk.
- Move sealed BM25 stats loading before the post-load limiter so it does not wait behind bloom filter loading and delete forwarding work.

### Test Plan

- `git diff --check upstream/master...HEAD`
- `gofmt -l` on changed Go files
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/querynodev2/delegator -run ...` could not run in this local environment because pkg-config dependencies for `milvus_core`, `rocksdb`, and `milvus-storage` are missing.