### PR TITLE
fix: [cp2.6]make SalvageCheckpoint reachable via GetReplicateInfo after force-promote

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -51,6 +51,7 @@ import (
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
 	"github.com/milvus-io/milvus/internal/util/segcore"
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v2/common"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
@@ -7082,9 +7083,19 @@ func (node *Proxy) GetReplicateInfo(ctx context.Context, req *milvuspb.GetReplic
 		}
 	}()
 
+	var checkpointProto *commonpb.ReplicateCheckpoint
 	checkpoint, err := streaming.WAL().Replicate().GetReplicateCheckpoint(ctx, req.GetTargetPchannel())
 	if err != nil {
-		return nil, err
+		// On a standalone-primary cluster (e.g. after force_promote) the WAL is no
+		// longer a secondary, so the live replicate checkpoint is unavailable. That
+		// must not hide the salvage checkpoint, which is exactly what callers need
+		// after a force_promote. Other errors are still fatal.
+		if !status.AsStreamingError(err).IsReplicateViolation() {
+			return nil, err
+		}
+		logger.Info("not a secondary cluster, live replicate checkpoint unavailable; continue to salvage checkpoint")
+	} else {
+		checkpointProto = checkpoint.IntoProto()
 	}
 
 	// Get the salvage checkpoint for the specified source cluster.
@@ -7102,7 +7113,7 @@ func (node *Proxy) GetReplicateInfo(ctx context.Context, req *milvuspb.GetReplic
 	}
 
 	return &milvuspb.GetReplicateInfoResponse{
-		Checkpoint:        checkpoint.IntoProto(),
+		Checkpoint:        checkpointProto,
 		SalvageCheckpoint: salvageCheckpointProto,
 	}, nil
 }

--- a/internal/proxy/replicate_info_test.go
+++ b/internal/proxy/replicate_info_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
+	streamingstatus "github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
 
@@ -206,4 +207,40 @@ func TestProxy_GetReplicateInfo_Success_NoSourceClusterIDFilter(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.Equal(t, "cluster-a", resp.GetCheckpoint().GetClusterId())
 	assert.Nil(t, resp.GetSalvageCheckpoint()) // no source cluster filter → no match
+}
+
+func TestProxy_GetReplicateInfo_ReplicateViolation_ReturnsSalvageCheckpoint(t *testing.T) {
+	// On a standalone-primary cluster (e.g. after force_promote) the live
+	// replicate checkpoint is unavailable (REPLICATE_VIOLATION). GetReplicateInfo
+	// must treat that as non-fatal: leave the live checkpoint nil and still return
+	// the salvage checkpoint, which is exactly what callers need post-promote.
+	salvageCPs := []*utility.ReplicateCheckpoint{
+		{ClusterID: "source-cluster", PChannel: "source-pchannel", TimeTick: 200},
+	}
+	replicateService := mock_streaming.NewMockReplicateService(t)
+	replicateService.EXPECT().GetReplicateCheckpoint(mock.Anything, "test-pchannel").
+		Return(nil, streamingstatus.NewReplicateViolation("wal is not a secondary cluster in replicating topology"))
+	replicateService.EXPECT().GetSalvageCheckpoint(mock.Anything, "test-pchannel").
+		Return(salvageCPs, nil)
+
+	mockWAL := mock_streaming.NewMockWALAccesser(t)
+	mockWAL.EXPECT().Replicate().Return(replicateService)
+	prevWAL := streaming.WAL()
+	streaming.SetWALForTest(mockWAL)
+	defer streaming.SetWALForTest(prevWAL)
+
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	resp, err := node.GetReplicateInfo(context.Background(), &milvuspb.GetReplicateInfoRequest{
+		TargetPchannel:  "test-pchannel",
+		SourceClusterId: "source-cluster",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Nil(t, resp.GetCheckpoint()) // live checkpoint unavailable on a primary
+	assert.NotNil(t, resp.GetSalvageCheckpoint())
+	assert.Equal(t, "source-cluster", resp.GetSalvageCheckpoint().GetClusterId())
+	assert.Equal(t, "source-pchannel", resp.GetSalvageCheckpoint().GetPchannel())
+	assert.Equal(t, uint64(200), resp.GetSalvageCheckpoint().GetTimeTick())
 }

--- a/internal/streamingnode/client/handler/handler_client_impl.go
+++ b/internal/streamingnode/client/handler/handler_client_impl.go
@@ -292,6 +292,15 @@ func (hc *handlerClientImpl) createHandlerAfterStreamingNodeReady(ctx context.Co
 			}
 			logger.Warn("create handler failed", zap.Any("assignment", assign), zap.Error(err))
 
+			// Unrecoverable errors (e.g. replicate violation when the WAL is no longer
+			// a secondary cluster) won't change by retrying the same WAL role. Surface
+			// them immediately so callers get a typed error within RTT instead of
+			// retrying until their context deadline.
+			if status.AsStreamingError(err).IsUnrecoverable() {
+				logger.Warn("create handler failed with unrecoverable error, stop retrying", zap.Error(err))
+				return nil, err
+			}
+
 			// Check if the error is permanent failure until new assignment.
 			if isPermanentFailureUntilNewAssignment(err) {
 				reportErr := hc.rebalanceTrigger.ReportAssignmentError(ctx, assign.Channel, err)

--- a/internal/streamingnode/client/handler/handler_client_test.go
+++ b/internal/streamingnode/client/handler/handler_client_test.go
@@ -193,6 +193,41 @@ func TestHandlerClient_GetSalvageCheckpoint(t *testing.T) {
 	assert.Nil(t, cps)
 }
 
+func TestHandlerClient_GetReplicateCheckpointReplicateViolation(t *testing.T) {
+	assignment := &types.PChannelInfoAssigned{
+		Channel: types.PChannelInfo{Name: "pchannel", Term: 1},
+		Node:    types.StreamingNodeInfo{ServerID: 1, Address: "localhost"},
+	}
+
+	service := mock_lazygrpc.NewMockService[streamingpb.StreamingNodeHandlerServiceClient](t)
+	handlerServiceClient := mock_streamingpb.NewMockStreamingNodeHandlerServiceClient(t)
+	// Remote WAL reports a replicate violation: the target is no longer a secondary
+	// cluster (e.g. after force_promote). This is unrecoverable for the current WAL
+	// role, so it must be returned immediately rather than retried to the deadline.
+	handlerServiceClient.EXPECT().GetReplicateCheckpoint(mock.Anything, mock.Anything).Return(
+		nil, status.NewReplicateViolation("wal is not a secondary cluster in replicating topology"))
+	service.EXPECT().GetService(mock.Anything).Return(handlerServiceClient, nil)
+
+	w := mock_assignment.NewMockWatcher(t)
+	// Always return the assignment so the create func is invoked.
+	w.EXPECT().Get(mock.Anything, mock.Anything).Return(assignment)
+	// Watch is intentionally NOT expected: an immediate return must not enter the
+	// backoff retry loop. If it did, the mock would fail on an unexpected Watch call.
+	rebalanceTrigger := mock_types.NewMockAssignmentRebalanceTrigger(t)
+
+	handler := &handlerClientImpl{
+		lifetime:         typeutil.NewLifetime(),
+		service:          service,
+		watcher:          w,
+		rebalanceTrigger: rebalanceTrigger,
+	}
+
+	cp, err := handler.GetReplicateCheckpoint(context.Background(), "pchannel")
+	assert.Error(t, err)
+	assert.Nil(t, cp)
+	assert.True(t, status.AsStreamingError(err).IsReplicateViolation())
+}
+
 func TestDial(t *testing.T) {
 	paramtable.Init()
 


### PR DESCRIPTION
Cherry-pick from master

pr: #50350
issue: #50344

## Summary

Cherry-picked from master PR #50350 (merged)

## Verification

- [x] File count matches original PR
- [x] Code changes verified
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)
