### PR TITLE
fix: [cp2.6]return error instead of panic on malformed DumpMessages start_message_id

### DIFF
--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -7172,7 +7172,13 @@ func (node *Proxy) DumpMessages(req *milvuspb.DumpMessagesRequest, stream milvus
 		return merr.WrapErrParameterMissing("start_message_id")
 	}
 
-	startMsgID := message.MustUnmarshalMessageID(req.GetStartMessageId())
+	// Unmarshal the message id without panicking: the id bytes are
+	// client-controlled, so a malformed value must be rejected as an invalid
+	// parameter rather than crashing the process.
+	startMsgID, err := message.UnmarshalMessageID(req.GetStartMessageId())
+	if err != nil {
+		return merr.WrapErrParameterInvalidMsg("invalid start_message_id: %s", err.Error())
+	}
 
 	// Use exclusive start position (dump messages AFTER start_message_id)
 	// This is appropriate for salvage scenarios where start_message_id is the last synced message

--- a/pkg/streaming/util/message/message_id.go
+++ b/pkg/streaming/util/message/message_id.go
@@ -49,6 +49,9 @@ func MustUnmarshalMessageID(msgID *commonpb.MessageID) MessageID {
 
 // UnmsarshalMessageID unmarshal the message id.
 func UnmarshalMessageID(msgID *commonpb.MessageID) (MessageID, error) {
+	if msgID == nil {
+		return nil, errors.Wrap(ErrInvalidMessageID, "nil message id")
+	}
 	// wal_name is a client-controlled proto enum; proto3 allows any int32 on the
 	// wire. Return errors instead of panicking so a malformed value cannot crash
 	// the process. MustUnmarshalMessageID keeps the panic contract for trusted
@@ -64,7 +67,7 @@ func UnmarshalMessageID(msgID *commonpb.MessageID) (MessageID, error) {
 	}
 	unmarshaler, ok := messageIDUnmarshaler.Get(name)
 	if !ok {
-		return nil, errors.Wrapf(ErrInvalidMessageID, "message id unmarshaler not registered for wal: %s", name.String())
+		return nil, errors.Wrapf(ErrInvalidMessageID, "message id unmarshaler not registered for wal: %s", msgID.WALName.String())
 	}
 	return unmarshaler(msgID.Id)
 }

--- a/pkg/streaming/util/message/message_id.go
+++ b/pkg/streaming/util/message/message_id.go
@@ -49,13 +49,22 @@ func MustUnmarshalMessageID(msgID *commonpb.MessageID) MessageID {
 
 // UnmsarshalMessageID unmarshal the message id.
 func UnmarshalMessageID(msgID *commonpb.MessageID) (MessageID, error) {
+	// wal_name is a client-controlled proto enum; proto3 allows any int32 on the
+	// wire. Return errors instead of panicking so a malformed value cannot crash
+	// the process. MustUnmarshalMessageID keeps the panic contract for trusted
+	// internal callers.
 	name := WALName(msgID.WALName)
 	if name == WALNameUnknown {
-		name = MustGetDefaultWALName()
+		// Use the non-panicking lookup: an unregistered default WAL must not
+		// nil-deref on client input.
+		name = GetDefaultWALName()
+		if name == WALNameUnknown {
+			return nil, errors.Wrapf(ErrInvalidMessageID, "default wal name is not registered, wal: %s", msgID.WALName.String())
+		}
 	}
 	unmarshaler, ok := messageIDUnmarshaler.Get(name)
 	if !ok {
-		panic("MessageID Unmarshaler not registered: " + name.String())
+		return nil, errors.Wrapf(ErrInvalidMessageID, "message id unmarshaler not registered for wal: %s", name.String())
 	}
 	return unmarshaler(msgID.Id)
 }

--- a/pkg/streaming/util/message/message_id_test.go
+++ b/pkg/streaming/util/message/message_id_test.go
@@ -22,8 +22,17 @@ func TestRegisterMessageIDUnmarshaler(t *testing.T) {
 	assert.Nil(t, id)
 	assert.Error(t, err)
 
+	// An unregistered wal_name (a client can put any int32 on the wire for a
+	// proto enum) must return an error instead of panicking, so it cannot crash
+	// the process. 101 is not a registered WAL. MustUnmarshalMessageID keeps the
+	// panic contract.
+	id, err = message.UnmarshalMessageID(&commonpb.MessageID{WALName: commonpb.WALName(101), Id: "123"})
+	assert.Nil(t, id)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, message.ErrInvalidMessageID)
+
 	assert.Panics(t, func() {
-		message.UnmarshalMessageID(&commonpb.MessageID{WALName: commonpb.WALName(101), Id: "123"})
+		message.MustUnmarshalMessageID(&commonpb.MessageID{WALName: commonpb.WALName(101), Id: "123"})
 	})
 
 	assert.Panics(t, func() {

--- a/pkg/streaming/util/message/message_id_test.go
+++ b/pkg/streaming/util/message/message_id_test.go
@@ -30,6 +30,12 @@ func TestRegisterMessageIDUnmarshaler(t *testing.T) {
 	assert.Nil(t, id)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, message.ErrInvalidMessageID)
+	assert.Contains(t, err.Error(), "101")
+
+	id, err = message.UnmarshalMessageID(nil)
+	assert.Nil(t, id)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, message.ErrInvalidMessageID)
 
 	assert.Panics(t, func() {
 		message.MustUnmarshalMessageID(&commonpb.MessageID{WALName: commonpb.WALName(101), Id: "123"})

--- a/tests/integration/replication/data_salvage_test.go
+++ b/tests/integration/replication/data_salvage_test.go
@@ -265,3 +265,31 @@ func (s *DataSalvageSuite) TestDumpMessagesWithMissingStartMessageId() {
 
 	s.Error(err)
 }
+
+// TestDumpMessagesWithMalformedStartMessageId verifies that DumpMessages
+// returns an error (instead of panicking and crashing the process) when
+// start_message_id is non-empty but cannot be unmarshaled. See issue #50341.
+func (s *DataSalvageSuite) TestDumpMessagesWithMalformedStartMessageId() {
+	ctx := context.Background()
+
+	stream, err := s.Cluster.MilvusClient.DumpMessages(ctx, &milvuspb.DumpMessagesRequest{
+		Pchannel: "test-pchannel",
+		StartMessageId: &commonpb.MessageID{
+			Id:      "not-a-valid-base64-msgid!!!", // non-empty but undecodable
+			WALName: commonpb.WALName_Pulsar,
+		},
+	})
+
+	// The error might come during stream creation or first Recv()
+	if err == nil {
+		_, err = stream.Recv()
+	}
+
+	s.Error(err)
+
+	// The server must stay up: a follow-up RPC should still succeed.
+	_, err = s.Cluster.MilvusClient.GetReplicateInfo(ctx, &milvuspb.GetReplicateInfoRequest{
+		TargetPchannel: "test-pchannel",
+	})
+	s.NoError(err)
+}


### PR DESCRIPTION
Cherry-pick from master (PR still open)

pr: #50342
issue: #50341

## Summary

Cherry-picked from master PR #50342 (open - preemptive backport)

**Note**: Original PR is still open. This CP PR should be updated if the original PR changes.

## Verification

- [x] File count matches original PR
- [x] Code changes verified
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)
