### PR TITLE
enhance: reuse segment load info cache during load

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5727,12 +5727,7 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     LOG_INFO("Loading segment {} with {} rows", id_, num_rows);
 
     // reopen_mutex_ synchronizes this read with all schema_ writers.
-    SegmentLoadInfo mutable_copy(snapshot->GetProto(), schema_);
-    mutable_copy.SetFieldsFilledWithDefault(
-        snapshot->GetFieldsFilledWithDefault());
-    for (auto fid : snapshot->GetCreatedTextIndexes()) {
-        mutable_copy.SetTextIndexCreated(fid);
-    }
+    SegmentLoadInfo mutable_copy(*snapshot);
     auto diff = mutable_copy.GetLoadDiff();
     LOG_WARN("Load segment {} with diff {}", id_, diff.ToString());
 

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -414,15 +414,19 @@ class SegmentLoadInfo {
 
     /**
      * @brief Copy constructor
-     * @note Rebuilds cache instead of copying (LoadIndexInfo is not copyable)
+     * @note Reuses converted index metadata; binlog pointers are rebuilt for
+     *       this instance's protobuf storage.
      */
     SegmentLoadInfo(const SegmentLoadInfo& other)
         : info_(other.info_),
           schema_(other.schema_),
-          column_groups_(other.column_groups_),
+          converted_index_infos_(other.converted_index_infos_),
+          converted_field_index_cache_(other.converted_field_index_cache_),
+          field_index_has_raw_data_(other.field_index_has_raw_data_),
           fields_filled_with_default_(other.fields_filled_with_default_),
+          column_groups_(other.column_groups_),
           created_text_indexes_(other.created_text_indexes_) {
-        BuildCache();
+        BuildFieldBinlogCache();
     }
 
     /**
@@ -444,17 +448,21 @@ class SegmentLoadInfo {
 
     /**
      * @brief Copy assignment operator
-     * @note Rebuilds cache instead of copying (LoadIndexInfo is not copyable)
+     * @note Reuses converted index metadata; binlog pointers are rebuilt for
+     *       this instance's protobuf storage.
      */
     SegmentLoadInfo&
     operator=(const SegmentLoadInfo& other) {
         if (this != &other) {
             info_ = other.info_;
             schema_ = other.schema_;
+            converted_index_infos_ = other.converted_index_infos_;
+            converted_field_index_cache_ = other.converted_field_index_cache_;
+            field_index_has_raw_data_ = other.field_index_has_raw_data_;
             column_groups_ = other.column_groups_;
             fields_filled_with_default_ = other.fields_filled_with_default_;
             created_text_indexes_ = other.created_text_indexes_;
-            BuildCache();
+            BuildFieldBinlogCache();
         }
         return *this;
     }
@@ -1072,7 +1080,7 @@ class SegmentLoadInfo {
 
  private:
     void
-    BuildCache() {
+    BuildFieldBinlogCache() {
         field_binlog_cache_.clear();
         // Build binlog cache
         for (int i = 0; i < info_.binlog_paths_size(); i++) {
@@ -1080,6 +1088,11 @@ class SegmentLoadInfo {
             auto field_id = FieldId(binlog.fieldid());
             field_binlog_cache_[field_id] = &binlog;
         }
+    }
+
+    void
+    BuildCache() {
+        BuildFieldBinlogCache();
 
         // Convert index infos to LoadIndexInfo and build per-field cache
         converted_index_infos_.clear();


### PR DESCRIPTION
## Summary

Optimize sealed segment load by reusing the cached metadata already held by `SegmentLoadInfo` when computing the initial load diff.

This avoids rebuilding converted index metadata from the protobuf snapshot during `ChunkedSegmentSealedImpl::Load()`, while still rebuilding the binlog pointer cache for the copied protobuf storage.

issue: #50521

## Test Plan

- `git diff --check upstream/master..HEAD`
- `/opt/homebrew/opt/llvm@18/bin/clang-format --dry-run --Werror --style=file internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp internal/core/src/segcore/SegmentLoadInfo.h`
