### PR TITLE
enhance: set external refresh segment level to L1

### DIFF
--- a/internal/datanode/external/task_update.go
+++ b/internal/datanode/external/task_update.go
@@ -906,6 +906,7 @@ func (t *RefreshExternalCollectionTask) balanceFragmentsToSegments(ctx context.C
 			NumOfRows:      work.rowCount,
 			ManifestPath:   manifestPaths[i],
 			StorageVersion: storage.StorageV3,
+			Level:          datapb.SegmentLevel_L1,
 			// Fake binlog so downstream treats external segments like normal
 			// StorageV3 segments. MemorySize is pre-computed from Take sampling
 			// so QueryNode skips the external-specific sampling path.

--- a/internal/datanode/external/task_update_test.go
+++ b/internal/datanode/external/task_update_test.go
@@ -3458,6 +3458,7 @@ func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_Empt
 	s.NoError(err)
 	s.Len(result, 1)
 	s.Equal(int64(100), result[0].GetNumOfRows())
+	s.Equal(datapb.SegmentLevel_L1, result[0].GetLevel())
 }
 
 func (s *RefreshExternalCollectionTaskSuite) TestBalanceFragmentsToSegments_ContextCanceledInLoops() {


### PR DESCRIPTION
External collection refresh created new segments without an explicit level, so the protobuf default marked them as Legacy. Set the level to L1 to align the stored metadata with the normal non-L0 segment semantics and keep metrics/observability consistent.