### PR TITLE
enhance: add routing table abstraction

### DIFF
--- a/pkg/common/hash_routing_table.go
+++ b/pkg/common/hash_routing_table.go
@@ -1,0 +1,151 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+)
+
+var (
+	// ErrRoutingTableNoHasher indicates that a hash routing table has no hasher configured.
+	ErrRoutingTableNoHasher = errors.New("routing table has no hasher")
+	// ErrRoutingTableNoValues indicates that a routing table has no values to route to.
+	ErrRoutingTableNoValues = errors.New("routing table has no values")
+	// ErrRoutingTableOpCommitted indicates that a value operation has already been committed.
+	ErrRoutingTableOpCommitted = errors.New("routing table operation has already been committed")
+)
+
+// Hasher hashes a key for routing table lookup.
+type Hasher[K comparable] interface {
+	Hash(key K) (uint64, error)
+}
+
+// RoutingMember is a string-backed routing table value.
+type RoutingMember string
+
+func (m RoutingMember) String() string {
+	return string(m)
+}
+
+// HashRoutingTable routes keys to values by taking hash(key) modulo the current value count.
+type HashRoutingTable[K comparable, V fmt.Stringer] struct {
+	mu     sync.RWMutex
+	hasher Hasher[K]
+	values map[string]V
+	keys   []string
+}
+
+// NewHashRoutingTable creates a hash routing table with a copy of values.
+func NewHashRoutingTable[K comparable, V fmt.Stringer](values []V, hasher Hasher[K]) *HashRoutingTable[K, V] {
+	valueMap := make(map[string]V, len(values))
+	keys := make([]string, 0, len(values))
+	for _, value := range values {
+		key := value.String()
+		if _, ok := valueMap[key]; ok {
+			continue
+		}
+		valueMap[key] = value
+		keys = append(keys, key)
+	}
+	return &HashRoutingTable[K, V]{
+		hasher: hasher,
+		values: valueMap,
+		keys:   keys,
+	}
+}
+
+func (t *HashRoutingTable[K, V]) LocateKey(key K) (V, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	var v V
+	if len(t.keys) == 0 {
+		return v, ErrRoutingTableNoValues
+	}
+	if t.hasher == nil {
+		return v, ErrRoutingTableNoHasher
+	}
+
+	h, err := t.hasher.Hash(key)
+	if err != nil {
+		return v, err
+	}
+	return t.values[t.keys[h%uint64(len(t.keys))]], nil
+}
+
+func (t *HashRoutingTable[K, V]) NewValueOp() ValueOp[K, V] {
+	return &hashValueOp[K, V]{
+		table:   t,
+		adds:    make([]V, 0),
+		removes: make([]V, 0),
+	}
+}
+
+type hashValueOp[K comparable, V fmt.Stringer] struct {
+	table     *HashRoutingTable[K, V]
+	adds      []V
+	removes   []V
+	committed bool
+}
+
+func (o *hashValueOp[K, V]) Add(v V) ValueOp[K, V] {
+	o.adds = append(o.adds, v)
+	return o
+}
+
+func (o *hashValueOp[K, V]) Remove(v V) ValueOp[K, V] {
+	o.removes = append(o.removes, v)
+	return o
+}
+
+func (o *hashValueOp[K, V]) Commit() error {
+	o.table.mu.Lock()
+	defer o.table.mu.Unlock()
+
+	if o.committed {
+		return ErrRoutingTableOpCommitted
+	}
+	o.committed = true
+
+	for _, add := range o.adds {
+		key := add.String()
+		if _, ok := o.table.values[key]; ok {
+			continue
+		}
+		o.table.values[key] = add
+		o.table.keys = append(o.table.keys, key)
+	}
+	for _, remove := range o.removes {
+		key := remove.String()
+		if _, ok := o.table.values[key]; !ok {
+			continue
+		}
+		delete(o.table.values, key)
+		for i, valueKey := range o.table.keys {
+			if valueKey == key {
+				o.table.keys = append(o.table.keys[:i], o.table.keys[i+1:]...)
+				break
+			}
+		}
+	}
+	o.adds = nil
+	o.removes = nil
+	return nil
+}

--- a/pkg/common/hash_routing_table_test.go
+++ b/pkg/common/hash_routing_table_test.go
@@ -1,0 +1,230 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ RoutingTable[string, RoutingMember] = (*HashRoutingTable[string, RoutingMember])(nil)
+
+type testHasher[K comparable] struct {
+	values map[K]uint64
+	err    error
+}
+
+func (h testHasher[K]) Hash(key K) (uint64, error) {
+	if h.err != nil {
+		return 0, h.err
+	}
+	return h.values[key], nil
+}
+
+func TestHashRoutingTableLocateKey(t *testing.T) {
+	table := NewHashRoutingTable[string](
+		[]RoutingMember{"node-1", "node-2", "node-3"},
+		testHasher[string]{
+			values: map[string]uint64{
+				"k0": 0,
+				"k1": 1,
+				"k4": 4,
+			},
+		},
+	)
+
+	got, err := table.LocateKey("k0")
+	require.NoError(t, err)
+	assert.Equal(t, RoutingMember("node-1"), got)
+
+	got, err = table.LocateKey("k1")
+	require.NoError(t, err)
+	assert.Equal(t, RoutingMember("node-2"), got)
+
+	got, err = table.LocateKey("k4")
+	require.NoError(t, err)
+	assert.Equal(t, RoutingMember("node-2"), got)
+}
+
+func TestHashRoutingTableLocateKeyPropagatesHasherError(t *testing.T) {
+	expectedErr := errors.New("hash failed")
+	table := NewHashRoutingTable[string]([]RoutingMember{"node-1"}, testHasher[string]{err: expectedErr})
+
+	got, err := table.LocateKey("key")
+
+	assert.Empty(t, got)
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestHashRoutingTableLocateKeyRejectsInvalidTable(t *testing.T) {
+	t.Run("empty values", func(t *testing.T) {
+		table := NewHashRoutingTable[string, RoutingMember](nil, testHasher[string]{values: map[string]uint64{"key": 1}})
+
+		assert.NotPanics(t, func() {
+			_, err := table.LocateKey("key")
+			assert.ErrorIs(t, err, ErrRoutingTableNoValues)
+		})
+	})
+
+	t.Run("nil hasher", func(t *testing.T) {
+		table := NewHashRoutingTable[string, RoutingMember]([]RoutingMember{"node-1"}, nil)
+
+		assert.NotPanics(t, func() {
+			_, err := table.LocateKey("key")
+			assert.ErrorIs(t, err, ErrRoutingTableNoHasher)
+		})
+	})
+}
+
+func TestNewHashRoutingTableClonesValues(t *testing.T) {
+	values := []RoutingMember{"node-1"}
+	table := NewHashRoutingTable[string](values, testHasher[string]{values: map[string]uint64{"key": 0}})
+	values[0] = "node-2"
+
+	got, err := table.LocateKey("key")
+
+	require.NoError(t, err)
+	assert.Equal(t, RoutingMember("node-1"), got)
+}
+
+func TestNewHashRoutingTableKeepsValuesUnique(t *testing.T) {
+	table := NewHashRoutingTable[string](
+		[]RoutingMember{"node-1", "node-2", "node-2"},
+		testHasher[string]{values: map[string]uint64{"key": 2}},
+	)
+
+	got, err := table.LocateKey("key")
+
+	require.NoError(t, err)
+	assert.Equal(t, RoutingMember("node-1"), got)
+}
+
+func TestHashValueOpCommit(t *testing.T) {
+	table := NewHashRoutingTable[string](
+		[]RoutingMember{"node-1", "node-2"},
+		testHasher[string]{values: map[string]uint64{"key": 1}},
+	)
+
+	got, err := table.LocateKey("key")
+	require.NoError(t, err)
+	assert.Equal(t, RoutingMember("node-2"), got)
+
+	err = table.NewValueOp().Add(RoutingMember("node-3")).Remove(RoutingMember("node-2")).Commit()
+	require.NoError(t, err)
+
+	got, err = table.LocateKey("key")
+	require.NoError(t, err)
+	assert.Equal(t, RoutingMember("node-3"), got)
+}
+
+func TestHashValueOpCommitIsSingleUse(t *testing.T) {
+	table := NewHashRoutingTable[string](
+		[]RoutingMember{"node-1", "node-2"},
+		testHasher[string]{values: map[string]uint64{"key": 3}},
+	)
+	op := table.NewValueOp().Add(RoutingMember("node-3"))
+
+	require.NoError(t, op.Commit())
+	assert.ErrorIs(t, op.Commit(), ErrRoutingTableOpCommitted)
+
+	got, err := table.LocateKey("key")
+	require.NoError(t, err)
+	assert.Equal(t, RoutingMember("node-1"), got)
+}
+
+func TestHashValueOpCommitKeepsValuesUnique(t *testing.T) {
+	table := NewHashRoutingTable[string](
+		[]RoutingMember{"node-1", "node-2"},
+		testHasher[string]{values: map[string]uint64{"key": 2}},
+	)
+
+	err := table.NewValueOp().Add(RoutingMember("node-2")).Commit()
+	require.NoError(t, err)
+
+	got, err := table.LocateKey("key")
+	require.NoError(t, err)
+	assert.Equal(t, RoutingMember("node-1"), got)
+}
+
+func TestHashValueOpRemoveMissingValue(t *testing.T) {
+	table := NewHashRoutingTable[string](
+		[]RoutingMember{"node-1", "node-2"},
+		testHasher[string]{values: map[string]uint64{"key": 1}},
+	)
+
+	err := table.NewValueOp().Remove(RoutingMember("missing")).Commit()
+	require.NoError(t, err)
+
+	got, err := table.LocateKey("key")
+	require.NoError(t, err)
+	assert.Equal(t, RoutingMember("node-2"), got)
+}
+
+func TestHashValueOpRemoveLastValueMakesTableEmpty(t *testing.T) {
+	table := NewHashRoutingTable[string](
+		[]RoutingMember{"node-1"},
+		testHasher[string]{values: map[string]uint64{"key": 0}},
+	)
+
+	err := table.NewValueOp().Remove(RoutingMember("node-1")).Commit()
+	require.NoError(t, err)
+
+	_, err = table.LocateKey("key")
+	assert.ErrorIs(t, err, ErrRoutingTableNoValues)
+}
+
+func TestHashRoutingTableConcurrentLocateAndCommit(t *testing.T) {
+	table := NewHashRoutingTable[string](
+		[]RoutingMember{"node-1", "node-2"},
+		testHasher[string]{values: map[string]uint64{"key": 1}},
+	)
+
+	const iterations = 100
+	var wg sync.WaitGroup
+	errCh := make(chan error, iterations*2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if _, err := table.LocateKey("key"); err != nil {
+				errCh <- err
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if err := table.NewValueOp().
+				Add(RoutingMember("node-temp")).
+				Remove(RoutingMember("node-temp")).
+				Commit(); err != nil {
+				errCh <- err
+			}
+		}
+	}()
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		assert.NoError(t, err)
+	}
+}

--- a/pkg/common/routing_table.go
+++ b/pkg/common/routing_table.go
@@ -1,0 +1,39 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "fmt"
+
+// RoutingTable is a table that maps keys to values.
+// Values are identified by their String value.
+type RoutingTable[K comparable, V fmt.Stringer] interface {
+	// LocateKey locates the value for the given key.
+	LocateKey(key K) (V, error)
+	// NewValueOp creates an operation for updating the table values.
+	NewValueOp() ValueOp[K, V]
+}
+
+// ValueOp is a set of operations on a value.
+type ValueOp[K comparable, V fmt.Stringer] interface {
+	// Add adds a value to the operation.
+	Add(v V) ValueOp[K, V]
+	// Remove removes a value from the operation.
+	Remove(v V) ValueOp[K, V]
+	// Commit atomically applies the operation.
+	// A ValueOp is single-use and returns an error when committed more than once.
+	Commit() error
+}


### PR DESCRIPTION
issue: #50463

Add generic routing table interfaces and a map-backed hash implementation under `pkg/common`.

Also add focused unit coverage for lookup, invalid table state, hasher errors, value uniqueness, single-use commits, value removal, and concurrent locate/update access.