### PR TITLE
fix: [3.0] update GPU Docker images to CUDA 12.9

### DIFF
--- a/build/docker/builder/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/builder/gpu/ubuntu22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 as builder
+FROM nvidia/cuda:12.9.1-devel-ubuntu22.04 as builder
 
 ARG TARGETARCH
 

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
+FROM nvidia/cuda:12.9.1-runtime-ubuntu22.04
 
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
- Update Ubuntu 22.04 GPU builder/runtime Dockerfiles from CUDA 11.8.0 to CUDA 12.9.1 on the 3.0 branch.
- Keep the existing 3.0 build env tag because `milvusdb/milvus-env:gpu-ubuntu22.04-20260525-c5b2f49` already uses CUDA 12.9.1.
- Fix GPU image runtime compatibility with Knowhere v3.0.1 / cuVS CUDA 12 dependencies.

pr: #49514
issue: #49515
issue: #48093

## Test plan
- [x] `git diff --check HEAD`
- [x] `git diff --check upstream/3.0..HEAD`
- [x] `docker manifest inspect nvidia/cuda:12.9.1-devel-ubuntu22.04`
- [x] `docker manifest inspect nvidia/cuda:12.9.1-runtime-ubuntu22.04`
- [x] `docker compose config --quiet`
- [x] `make build-cpp`
- [x] `make static-check`
- [x] `docker run --rm nvidia/cuda:12.9.1-runtime-ubuntu22.04 sh -lc "test -e /usr/local/cuda/lib64/libcudart.so.12 && echo runtime-libcudart-ok"`
- [x] `docker run --rm nvidia/cuda:12.9.1-devel-ubuntu22.04 sh -lc "nvcc --version | tail -n 1"`
- [x] Manual GPU E2E diagnostic: v3.0-beta payload on CUDA 12.9 runtime, `GPU_BRUTE_FORCE` + `FLOAT16_VECTOR` + filter expression, `nq=2048`, `limit=100`, result `SEARCH_OK`.