### PR TITLE
fix: prevent sealed segment schema publish before fields ready

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3562,9 +3562,11 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
     // we have to clone the shared pointer,
     // to make sure it won't get released if segment released
     auto column = get_column(field_id);
-    AssertInfo(column != nullptr,
-               "field {} must exist when getting raw data",
-               field_id.get());
+    if (column == nullptr) {
+        ThrowInfo(FieldNotLoaded,
+                  "field {} is not loaded when getting raw data",
+                  field_id.get());
+    }
 
     int64_t valid_count = count;
     const bool* valid_data = nullptr;
@@ -4762,13 +4764,16 @@ ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
     LOG_INFO(
         "Schema-only reopen segment {} with diff {}", id_, diff.ToString());
 
+    ApplySchemaForReopen(sch);
+    ApplyLoadDiff(op_ctx, new_local, diff);
+    for (auto field_id : diff.fields_to_fill_default) {
+        new_local.SetFieldFilledWithDefault(field_id);
+    }
+
     auto published = std::make_shared<const SegmentLoadInfo>(new_local);
     std::atomic_store(&segment_load_info_, published);
     use_take_for_output_.store(published->GetUseTakeForOutput(),
                                std::memory_order_relaxed);
-
-    ApplySchemaForReopen(sch);
-    ApplyLoadDiff(op_ctx, new_local, diff);
 
     LOG_INFO("Schema-only reopen segment {} done", id_);
 }
@@ -4821,13 +4826,16 @@ ChunkedSegmentSealedImpl::Reopen(
         current_mutable.GetDefaultFilledFieldsForNewInfo(new_local));
     LOG_INFO("Reopen segment {} with diff {}", id_, diff.ToString());
 
+    ApplySchemaForReopen(target_schema);
+    ApplyLoadDiff(op_ctx, new_local, diff);
+    for (auto field_id : diff.fields_to_fill_default) {
+        new_local.SetFieldFilledWithDefault(field_id);
+    }
+
     auto published = std::make_shared<const SegmentLoadInfo>(new_local);
     std::atomic_store(&segment_load_info_, published);
     use_take_for_output_.store(published->GetUseTakeForOutput(),
                                std::memory_order_relaxed);
-
-    ApplySchemaForReopen(target_schema);
-    ApplyLoadDiff(op_ctx, new_local, diff);
 
     LOG_INFO("Reopen segment {} done", id_);
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3355,6 +3355,19 @@ ChunkedSegmentSealedImpl::RecordDefaultFieldsFilled(
 }
 
 void
+ChunkedSegmentSealedImpl::PublishAppliedLoadInfo(SegmentLoadInfo& load_info,
+                                                 const LoadDiff& diff) {
+    for (auto field_id : diff.fields_to_fill_default) {
+        load_info.SetFieldFilledWithDefault(field_id);
+    }
+
+    auto published = std::make_shared<const SegmentLoadInfo>(load_info);
+    std::atomic_store(&segment_load_info_, published);
+    use_take_for_output_.store(published->GetUseTakeForOutput(),
+                               std::memory_order_relaxed);
+}
+
+void
 ChunkedSegmentSealedImpl::RecordTextIndexCreated(FieldId field_id) {
     auto current = std::atomic_load(&segment_load_info_);
     std::shared_ptr<const SegmentLoadInfo> next;
@@ -4766,14 +4779,7 @@ ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
 
     ApplySchemaForReopen(sch);
     ApplyLoadDiff(op_ctx, new_local, diff);
-    for (auto field_id : diff.fields_to_fill_default) {
-        new_local.SetFieldFilledWithDefault(field_id);
-    }
-
-    auto published = std::make_shared<const SegmentLoadInfo>(new_local);
-    std::atomic_store(&segment_load_info_, published);
-    use_take_for_output_.store(published->GetUseTakeForOutput(),
-                               std::memory_order_relaxed);
+    PublishAppliedLoadInfo(new_local, diff);
 
     LOG_INFO("Schema-only reopen segment {} done", id_);
 }
@@ -4828,14 +4834,7 @@ ChunkedSegmentSealedImpl::Reopen(
 
     ApplySchemaForReopen(target_schema);
     ApplyLoadDiff(op_ctx, new_local, diff);
-    for (auto field_id : diff.fields_to_fill_default) {
-        new_local.SetFieldFilledWithDefault(field_id);
-    }
-
-    auto published = std::make_shared<const SegmentLoadInfo>(new_local);
-    std::atomic_store(&segment_load_info_, published);
-    use_take_for_output_.store(published->GetUseTakeForOutput(),
-                               std::memory_order_relaxed);
+    PublishAppliedLoadInfo(new_local, diff);
 
     LOG_INFO("Reopen segment {} done", id_);
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1536,8 +1536,8 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     std::shared_ptr<const SegmentLoadInfo> segment_load_info_;
 
     // Serializes top-level writers of segment_load_info_
-    // (Reopen(pb), SetLoadInfo, Load) so their diff → publish → ApplyLoadDiff
-    // sequences never interleave. Does NOT block readers — reader paths access
+    // (Reopen(pb), SetLoadInfo, Load) so their diff/apply/publish sequences
+    // never interleave. Does NOT block readers — reader paths access
     // segment_load_info_ via atomic_load.
     // Lock order: reopen_mutex_ → mutex_ (outer → inner) only. Never inverse,
     // and reader paths that take mutex_ must not take reopen_mutex_.

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1376,6 +1376,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     RecordDefaultFieldsFilled(const std::vector<FieldId>& field_ids);
 
+    void
+    PublishAppliedLoadInfo(SegmentLoadInfo& segment_load_info,
+                           const LoadDiff& diff);
+
     // Atomically records that a text index has been created for `field_id` in
     // the published segment_load_info_. Uses a CAS loop so it is safe whether
     // or not the caller holds reopen_mutex_ (tests call CreateTextIndex

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -3620,6 +3620,44 @@ TEST(SealedSegmentReopen, SchemaOnlyReopenPublishesDefaultFilledState) {
     EXPECT_TRUE(snapshot->IsFieldFilledWithDefault(FieldId(101)));
 }
 
+TEST(SealedSegmentReopen,
+     CancelledReopenDoesNotPublishNewSchemaBeforeDefaultFieldReady) {
+    auto old_schema = std::make_shared<Schema>();
+    old_schema->AddDebugField("pk", DataType::INT64);
+    old_schema->set_primary_field_id(FieldId(100));
+    old_schema->set_schema_version(100);
+
+    auto new_schema = std::make_shared<Schema>();
+    new_schema->AddDebugField("pk", DataType::INT64);
+    auto new_field = new_schema->AddDebugField("new_field", DataType::INT64);
+    new_schema->set_primary_field_id(FieldId(100));
+    new_schema->set_schema_version(200);
+
+    auto dataset = DataGen(old_schema, 1);
+    auto segment = CreateSealedWithFieldDataLoaded(old_schema, dataset);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    folly::CancellationSource source;
+    source.requestCancellation();
+    milvus::OpContext op_ctx(source.getToken());
+    EXPECT_THROW(
+        {
+            try {
+                sealed->Reopen(&op_ctx,
+                               sealed->TestGetSegmentLoadInfo()->GetProto(),
+                               new_schema);
+            } catch (const SegcoreError& e) {
+                EXPECT_EQ(e.get_error_code(), ErrorCode::FollyCancel);
+                throw;
+            }
+        },
+        SegcoreError);
+
+    EXPECT_FALSE(sealed->TestGetSegmentLoadInfo()->HasFieldInSchema(new_field));
+    EXPECT_FALSE(sealed->HasFieldData(new_field));
+}
+
 TEST(SealedSegmentReopen, SchemaAwareReopenDiscardsOlderSchema) {
     auto old_schema = std::make_shared<Schema>();
     auto pk_id = old_schema->AddDebugField("pk", DataType::INT64);


### PR DESCRIPTION
issue: #50281

- segcore sealed segment: publish reopen load-info snapshots only after load diff/default-field preparation succeeds
- segcore read path: return FieldNotLoaded when raw field data is absent instead of asserting
- segcore tests: cover cancelled add-field reopen so unfinished schema state is not published