### PR TITLE
fix: [Proxy] validate AlterCollection description only when changed

### DIFF
--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -2213,6 +2213,13 @@ func (t *alterCollectionTask) PreExecute(ctx context.Context) error {
 			if property.GetKey() != common.CollectionDescription {
 				continue
 			}
+			// Only validate the description when it is actually changed. A
+			// pre-existing collection may resend its (possibly oversized)
+			// description unchanged while altering other properties (e.g. TTL);
+			// re-validating an unchanged value would reject legitimate alters.
+			if property.GetValue() == collSchema.GetDescription() {
+				continue
+			}
 			if err := validateCollectionDescription(property.GetValue()); err != nil {
 				return err
 			}

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -5584,48 +5584,95 @@ func TestAlterCollectionTaskValidateDescription(t *testing.T) {
 	err := InitMetaCache(ctx, qc)
 	assert.NoError(t, err)
 
-	collectionName := "alter_description_" + funcutil.GenRandomStr()
-	schema := &schemapb.CollectionSchema{
-		Name:        collectionName,
-		Description: "short description",
-		AutoID:      false,
-		Fields: []*schemapb.FieldSchema{
-			{FieldID: 100, Name: "pk", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
-			{FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "8"}}},
-		},
-	}
-	bs, err := proto.Marshal(schema)
-	assert.NoError(t, err)
-	status, err := qc.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
-		Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
-		DbName:         dbName,
-		CollectionName: collectionName,
-		Schema:         bs,
-		ShardsNum:      1,
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, commonpb.ErrorCode_Success, status.GetErrorCode())
+	maxLen := Params.ProxyCfg.MaxCollectionDescriptionLength.GetAsInt()
+	oversized := strings.Repeat("a", maxLen+1)
+	differentOversized := strings.Repeat("b", maxLen+1)
 
-	task := &alterCollectionTask{
-		AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
-			Base:           &commonpb.MsgBase{},
-			CollectionName: collectionName,
-			Properties: []*commonpb.KeyValuePair{
-				{Key: common.CollectionDescription, Value: strings.Repeat("a", Params.ProxyCfg.MaxCollectionDescriptionLength.GetAsInt()+1)},
+	// Create a collection through the mock coordinator directly so we can seed a
+	// pre-existing oversized description, which the proxy CreateCollection guard
+	// would normally reject. This simulates a collection created before the
+	// description length limit existed.
+	createCollection := func(description string) string {
+		collectionName := "alter_description_" + funcutil.GenRandomStr()
+		schema := &schemapb.CollectionSchema{
+			Name:        collectionName,
+			Description: description,
+			AutoID:      false,
+			Fields: []*schemapb.FieldSchema{
+				{FieldID: 100, Name: "pk", IsPrimaryKey: true, DataType: schemapb.DataType_Int64},
+				{FieldID: 101, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "8"}}},
 			},
-		},
-		ctx:      ctx,
-		mixCoord: qc,
+		}
+		bs, err := proto.Marshal(schema)
+		assert.NoError(t, err)
+		status, err := qc.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+			Base:           &commonpb.MsgBase{MsgType: commonpb.MsgType_CreateCollection},
+			DbName:         dbName,
+			CollectionName: collectionName,
+			Schema:         bs,
+			ShardsNum:      1,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, commonpb.ErrorCode_Success, status.GetErrorCode())
+		return collectionName
 	}
-	err = task.PreExecute(ctx)
-	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
 
-	task.Properties = []*commonpb.KeyValuePair{
-		{Key: common.CollectionDescription, Value: "short description"},
-		{Key: common.CollectionDescription, Value: strings.Repeat("a", Params.ProxyCfg.MaxCollectionDescriptionLength.GetAsInt()+1)},
+	runAlter := func(collectionName string, properties []*commonpb.KeyValuePair) error {
+		task := &alterCollectionTask{
+			AlterCollectionRequest: &milvuspb.AlterCollectionRequest{
+				Base:           &commonpb.MsgBase{},
+				CollectionName: collectionName,
+				Properties:     properties,
+			},
+			ctx:      ctx,
+			mixCoord: qc,
+		}
+		return task.PreExecute(ctx)
 	}
-	err = task.PreExecute(ctx)
-	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+
+	// A collection whose stored description is within the limit.
+	validCollection := createCollection("short description")
+	// A collection whose stored description already exceeds the current limit.
+	legacyCollection := createCollection(oversized)
+
+	t.Run("changing a valid description to an oversized one is rejected", func(t *testing.T) {
+		err := runAlter(validCollection, []*commonpb.KeyValuePair{
+			{Key: common.CollectionDescription, Value: oversized},
+		})
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("resending an unchanged oversized description while altering TTL is accepted", func(t *testing.T) {
+		err := runAlter(legacyCollection, []*commonpb.KeyValuePair{
+			{Key: common.CollectionDescription, Value: oversized},
+			{Key: common.CollectionTTLConfigKey, Value: "10"},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("changing an oversized description to a different oversized value is rejected", func(t *testing.T) {
+		err := runAlter(legacyCollection, []*commonpb.KeyValuePair{
+			{Key: common.CollectionDescription, Value: differentOversized},
+		})
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("shrinking an oversized description to a valid value is accepted", func(t *testing.T) {
+		err := runAlter(legacyCollection, []*commonpb.KeyValuePair{
+			{Key: common.CollectionDescription, Value: "now within the limit"},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("with duplicate description keys, a changed oversized value is still rejected", func(t *testing.T) {
+		// The unchanged value is skipped, but the other (changed) oversized value
+		// is still validated per-property, so the alter is rejected.
+		err := runAlter(legacyCollection, []*commonpb.KeyValuePair{
+			{Key: common.CollectionDescription, Value: oversized},
+			{Key: common.CollectionDescription, Value: differentOversized},
+		})
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	})
 }
 
 func mockVectorIndexForCollection(t *testing.T, ctx context.Context, qc *MixCoordMock, colName string) {


### PR DESCRIPTION
PR #50178 added an unconditional collection-description length check in proxy `alterCollectionTask.PreExecute`. The check runs on every incoming `collection.description` value, including values that are not actually changing.

### Bug

A collection created before the limit existed (e.g. a 2 KB description) gets rejected when a client resends that unchanged description alongside a genuine change (e.g. a TTL update). Proxy fails it with `ErrParameterInvalid`, even though the description is not being modified. This breaks the PR's own invariant: existing collection metadata is not re-validated.

### Change

Validate the description only when its value actually differs from the stored one. A pre-existing collection can resend its (possibly oversized) description unchanged while altering other properties; that unchanged value is now skipped. A new or genuinely changed oversized description still returns `ErrParameterInvalid`.

This keeps the check in `alterCollectionTask.PreExecute`, the same layer as every other AlterCollection property validator (TTL, mmap, consistency level), so the fix stays minimal and consistent with the surrounding code.

## Tests

`internal/proxy/task_test.go` — `TestAlterCollectionTaskValidateDescription` rewritten as table cases:
- resending an unchanged oversized description while altering TTL is accepted (the bug);
- changing a valid description to an oversized one is rejected;
- changing an oversized description to a different oversized value is rejected;
- shrinking an oversized description to a valid value is accepted;
- with duplicate description keys, a changed oversized value is still rejected per-property.

related: #50173
