### PR TITLE
test: add structured error-contract assertions to go_client

### DIFF
--- a/tests/go_client/common/response_checker.go
+++ b/tests/go_client/common/response_checker.go
@@ -93,7 +93,13 @@ func CheckErrCode(t *testing.T, actualErr error, expErr error) {
 // All three are read from the returned error itself via the merr accessors;
 // the wire keys (Status.ExtraInfo["is_input_error"], Status.Retriable) are an
 // implementation detail the client reconstructs in merr.Error.
-func CheckErrTriple(t *testing.T, actualErr error, expErr error, expInput bool, expRetriable bool) {
+//
+// The optional expMsg arguments, when given, are additionally asserted as
+// substrings of the actual error message. Pin them to keep the per-error
+// specificity the code alone cannot give: the code (e.g. 1100) classifies the
+// error, but many distinct errors share one code, so the message is what
+// confirms it is the specific error the test intended to trigger.
+func CheckErrTriple(t *testing.T, actualErr error, expErr error, expInput bool, expRetriable bool, expMsg ...string) {
 	if expErr == nil {
 		require.NoError(t, actualErr, trace())
 		return
@@ -112,6 +118,12 @@ func CheckErrTriple(t *testing.T, actualErr error, expErr error, expInput bool, 
 	require.Equalf(t, expRetriable, gotRetriable,
 		"retriable mismatch: expected %v, got %v; actual error: %v; %s",
 		expRetriable, gotRetriable, actualErr, trace())
+
+	for _, m := range expMsg {
+		require.ErrorContainsf(t, actualErr, m,
+			"error message mismatch: expected to contain %q; actual error: %v; %s",
+			m, actualErr, trace())
+	}
 }
 
 func IsTSafeStalledError(err error) bool {

--- a/tests/go_client/common/response_checker.go
+++ b/tests/go_client/common/response_checker.go
@@ -20,6 +20,7 @@ import (
 	"github.com/milvus-io/milvus/client/v2/index"
 	client "github.com/milvus-io/milvus/client/v2/milvusclient"
 	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func trace() string {
@@ -59,6 +60,58 @@ func CheckErr(t *testing.T, actualErr error, expErrNil bool, expErrorMsg ...stri
 			}
 		}
 	}
+}
+
+// CheckErrCode asserts that actualErr carries the same merr error code as the
+// expected sentinel. Pass nil expErr to assert success.
+//
+// Prefer this over the message-substring form of CheckErr for new assertions:
+// the error code is the stable wire contract, whereas the message text is not
+// and breaks on harmless rewording.
+func CheckErrCode(t *testing.T, actualErr error, expErr error) {
+	if expErr == nil {
+		require.NoError(t, actualErr, trace())
+		return
+	}
+	require.Error(t, actualErr, trace())
+	require.Equalf(t, merr.Code(expErr), merr.Code(actualErr),
+		"error code mismatch: expected %d (%v), got %d; actual error: %v; %s",
+		merr.Code(expErr), expErr, merr.Code(actualErr), actualErr, trace())
+}
+
+// CheckErrTriple asserts the full structured error contract introduced by the
+// merr Sys/Input classification: (code, is_input_error, retriable).
+//
+//   - expErr        the expected merr sentinel, e.g. merr.ErrParameterInvalid;
+//     nil asserts success.
+//   - expInput      whether the client should observe an InputError
+//     (request author's fault, never failed-over, forced non-retriable).
+//   - expRetriable  whether blindly retrying the same request may succeed.
+//     Note: for an InputError the server forces retriable=false, so expInput
+//     true together with expRetriable true is a contradiction.
+//
+// All three are read from the returned error itself via the merr accessors;
+// the wire keys (Status.ExtraInfo["is_input_error"], Status.Retriable) are an
+// implementation detail the client reconstructs in merr.Error.
+func CheckErrTriple(t *testing.T, actualErr error, expErr error, expInput bool, expRetriable bool) {
+	if expErr == nil {
+		require.NoError(t, actualErr, trace())
+		return
+	}
+	require.Error(t, actualErr, trace())
+	require.Equalf(t, merr.Code(expErr), merr.Code(actualErr),
+		"error code mismatch: expected %d (%v), got %d; actual error: %v; %s",
+		merr.Code(expErr), expErr, merr.Code(actualErr), actualErr, trace())
+
+	gotInput := merr.GetErrorType(actualErr) == merr.InputError
+	require.Equalf(t, expInput, gotInput,
+		"is_input_error mismatch: expected %v, got %v; actual error: %v; %s",
+		expInput, gotInput, actualErr, trace())
+
+	gotRetriable := merr.IsRetryableErr(actualErr)
+	require.Equalf(t, expRetriable, gotRetriable,
+		"retriable mismatch: expected %v, got %v; actual error: %v; %s",
+		expRetriable, gotRetriable, actualErr, trace())
 }
 
 func IsTSafeStalledError(err error) bool {

--- a/tests/go_client/common/response_checker_test.go
+++ b/tests/go_client/common/response_checker_test.go
@@ -56,6 +56,12 @@ func TestCheckErrTriple(t *testing.T) {
 		CheckErrCode(t, err, merr.ErrParameterInvalid)
 	})
 
+	t.Run("optional_message_substring", func(t *testing.T) {
+		// The optional expMsg pins the specific error on top of the triple.
+		err := roundTrip(merr.WrapErrParameterInvalidMsg("dim out of range"))
+		CheckErrTriple(t, err, merr.ErrParameterInvalid, true, false, "dim out of range")
+	})
+
 	t.Run("system_error_non_retriable", func(t *testing.T) {
 		// ErrCollectionNotFound is SystemError by default (no proxy stamping here).
 		err := roundTrip(merr.WrapErrCollectionNotFound("c1"))

--- a/tests/go_client/common/response_checker_test.go
+++ b/tests/go_client/common/response_checker_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 func TestRetryOnTSafeStalled(t *testing.T) {
@@ -34,5 +36,50 @@ func TestRetryOnTSafeStalled(t *testing.T) {
 
 		require.ErrorIs(t, err, expectedErr)
 		require.Equal(t, 1, attempts)
+	})
+}
+
+// TestCheckErrTriple validates that the structured error helpers read the
+// (code, is_input_error, retriable) triple correctly off real merr errors,
+// across a Status round-trip — the exact path a client observes: the server
+// builds a commonpb.Status, the SDK reconstructs the error via merr.Error.
+func TestCheckErrTriple(t *testing.T) {
+	// roundTrip mimics the SDK path: error -> wire Status -> error.
+	roundTrip := func(err error) error {
+		return merr.Error(merr.Status(err))
+	}
+
+	t.Run("input_error_non_retriable", func(t *testing.T) {
+		// ErrParameterInvalid: baked InputError, non-retriable.
+		err := roundTrip(merr.WrapErrParameterInvalidMsg("bad param"))
+		CheckErrTriple(t, err, merr.ErrParameterInvalid, true, false)
+		CheckErrCode(t, err, merr.ErrParameterInvalid)
+	})
+
+	t.Run("system_error_non_retriable", func(t *testing.T) {
+		// ErrCollectionNotFound is SystemError by default (no proxy stamping here).
+		err := roundTrip(merr.WrapErrCollectionNotFound("c1"))
+		CheckErrTriple(t, err, merr.ErrCollectionNotFound, false, false)
+	})
+
+	t.Run("system_error_retriable", func(t *testing.T) {
+		// ErrServiceUnavailable: SystemError, retriable=true.
+		err := roundTrip(merr.WrapErrServiceUnavailable("not ready"))
+		CheckErrTriple(t, err, merr.ErrServiceUnavailable, false, true)
+	})
+
+	t.Run("input_error_forces_non_retriable", func(t *testing.T) {
+		// An InputError stamped onto an otherwise-retriable sentinel must come
+		// back non-retriable: the server forces Retriable=false for input errors.
+		base := merr.WrapErrServiceUnavailable("transient")
+		err := roundTrip(merr.WrapErrAsInputError(base))
+		// Code stays ErrServiceUnavailable, but type flips to input and
+		// retriable is forced false.
+		CheckErrTriple(t, err, merr.ErrServiceUnavailable, true, false)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		CheckErrTriple(t, nil, nil, false, false)
+		CheckErrCode(t, nil, nil)
 	})
 }

--- a/tests/go_client/testcases/error_contract_test.go
+++ b/tests/go_client/testcases/error_contract_test.go
@@ -1,0 +1,35 @@
+package testcases
+
+import (
+	"testing"
+	"time"
+
+	client "github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/tests/go_client/common"
+	hp "github.com/milvus-io/milvus/tests/go_client/testcases/helper"
+)
+
+// TestErrorContract demonstrates asserting the structured error contract
+// (code, is_input_error, retriable) end-to-end against a real server, instead
+// of matching on message substrings. These double as living examples of the
+// CheckErrTriple / CheckErrCode helpers.
+func TestErrorContract(t *testing.T) {
+	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
+	mc := hp.CreateDefaultMilvusClient(ctx, t)
+
+	t.Run("empty_collection_name_is_input_error", func(t *testing.T) {
+		schema := genDefaultSchema()
+		err := mc.CreateCollection(ctx, client.NewCreateCollectionOption("", schema))
+		// Malformed request: the caller's fault, never retriable.
+		common.CheckErrTriple(t, err, merr.ErrParameterInvalid, true, false)
+	})
+
+	t.Run("describe_missing_collection_is_input_error", func(t *testing.T) {
+		name := common.GenRandomString("missing", 6)
+		_, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(name))
+		// ErrCollectionNotFound is SystemError by default, but the proxy stamps
+		// it InputError for user-supplied names via WrapErrAsInputErrorWhen.
+		common.CheckErrTriple(t, err, merr.ErrCollectionNotFound, true, false)
+	})
+}

--- a/tests/go_client/testcases/error_contract_test.go
+++ b/tests/go_client/testcases/error_contract_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 // TestErrorContract demonstrates asserting the structured error contract
-// (code, is_input_error, retriable) end-to-end against a real server, instead
-// of matching on message substrings. These double as living examples of the
-// CheckErrTriple / CheckErrCode helpers.
+// (code, is_input_error, retriable) end-to-end against a real server, while
+// still pinning the message substring for per-error specificity. These double
+// as living examples of the CheckErrTriple / CheckErrCode helpers.
 func TestErrorContract(t *testing.T) {
 	ctx := hp.CreateContext(t, time.Second*common.DefaultTimeout)
 	mc := hp.CreateDefaultMilvusClient(ctx, t)
@@ -21,8 +21,10 @@ func TestErrorContract(t *testing.T) {
 	t.Run("empty_collection_name_is_input_error", func(t *testing.T) {
 		schema := genDefaultSchema()
 		err := mc.CreateCollection(ctx, client.NewCreateCollectionOption("", schema))
-		// Malformed request: the caller's fault, never retriable.
-		common.CheckErrTriple(t, err, merr.ErrParameterInvalid, true, false)
+		// Malformed request: the caller's fault, never retriable. The message
+		// substring pins which parameter error this is (code 1100 is shared by
+		// every parameter error).
+		common.CheckErrTriple(t, err, merr.ErrParameterInvalid, true, false, "collection name should not be empty")
 	})
 
 	t.Run("describe_missing_collection_is_input_error", func(t *testing.T) {
@@ -30,6 +32,6 @@ func TestErrorContract(t *testing.T) {
 		_, err := mc.DescribeCollection(ctx, client.NewDescribeCollectionOption(name))
 		// ErrCollectionNotFound is SystemError by default, but the proxy stamps
 		// it InputError for user-supplied names via WrapErrAsInputErrorWhen.
-		common.CheckErrTriple(t, err, merr.ErrCollectionNotFound, true, false)
+		common.CheckErrTriple(t, err, merr.ErrCollectionNotFound, true, false, "can't find collection")
 	})
 }


### PR DESCRIPTION
## What

Add two helpers to `tests/go_client/common` for asserting the structured error contract on the Go SDK:

- `CheckErrCode(t, actualErr, expErr)` — assert the merr error code only.
- `CheckErrTriple(t, actualErr, expErr, expInput, expRetriable)` — assert the full `(code, is_input_error, retriable)` triple.

Both take a merr sentinel (e.g. `merr.ErrParameterInvalid`) as the expected error, so callers never hand-pick numeric codes.

## Why

Today every go_client error assertion goes through `CheckErr`, which matches on **message substrings**. Message text is not a stable contract — it breaks on harmless rewording (and the multi-arg form passes if *any* substring matches, which is even looser).

Since the merr Sys/Input classification landed, the error the SDK returns carries a structured triple. `merr.Error` reconstructs it from the wire `Status` (code, `Retriable`, and `ExtraInfo["is_input_error"]`), and the client surfaces it via `merr.Code` / `merr.IsRetryableErr` / `merr.GetErrorType`. These helpers let go_client tests assert that structured contract directly.

## Scope

- Existing `CheckErr` callsites are **left untouched** — this PR only adds the capability and an executable example. Migrating the ~1.8k existing assertions is a separate ratchet.
- A unit test validates the helpers against real merr errors across a `Status` round-trip (the exact path the SDK observes), including the invariant that an `InputError` is forced non-retriable.

## Test

The unit test runs in the go_client module under the standard `-tags dynamic,test` flags; `TestCheckErrTriple` and the existing `TestRetryOnTSafeStalled` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
