### PR TITLE
fix: avoid panic in tombstoneScheduler.AddPending during shutdown

### DIFF
--- a/internal/streamingcoord/server/broadcaster/tombstone_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/tombstone_scheduler.go
@@ -57,7 +57,14 @@ func (s *tombstoneScheduler) Initialize(bm *broadcastTaskManager, tombstoneBroad
 func (s *tombstoneScheduler) AddPending(broadcastID uint64) {
 	select {
 	case <-s.notifier.Context().Done():
-		panic("unreachable: tombstone scheduler is closing when adding pending tombstone")
+		// The scheduler is closing while an in-flight ack callback still tries to
+		// enqueue a tombstone. This is reachable under concurrent shutdown, so it
+		// must not panic. Dropping the in-memory enqueue is safe: the task state is
+		// already persisted as TOMBSTONE (MarkAckCallbackDone) before reaching here,
+		// and will be recovered into the GC list on the next startup.
+		s.Logger().Info("tombstone scheduler is closing, skip adding pending tombstone",
+			zap.Uint64("broadcastID", broadcastID))
+		return
 	case s.pending <- broadcastID:
 	}
 }


### PR DESCRIPTION
## Issue

issue: #50549

## What this PR does

`tombstoneScheduler.AddPending` panicked with
`unreachable: tombstone scheduler is closing when adding pending tombstone`
when `s.notifier.Context()` was already `Done()`.

That path **is** reachable under concurrent shutdown: an in-flight
`ackCallbackScheduler.doAckCallback` goroutine (spawned by `triggerAckCallback`)
can call `AddPending` after `Close()` cancels the tombstone scheduler's context.
The panic in a background goroutine crashes the whole process — surfacing as a
flaky `ci-v2/ut-go` failure (`TestForcePromoteFailover/no_incomplete_tasks`,
`panic: unreachable: tombstone scheduler is closing ...`).

## Why dropping the enqueue on shutdown is safe

`AddPending` only adds the broadcastID to the **in-memory** GC tracking list.
The durable state is already written before we get here:

1. `doAckCallback` calls `bt.MarkAckCallbackDone(...)` which sets the task state to
   `BROADCAST_TASK_STATE_TOMBSTONE` and persists it (`saveTaskIfDirty`) — *then*
   calls `AddPending`.
2. On the next startup, `broadcast_manager` recovers all `TOMBSTONE` tasks into
   `tombstoneIDs` and re-seeds the GC list via `Initialize`.

So skipping the enqueue during shutdown only defers GC of that one tombstone to
the next restart, which is already how GC behaves (lifetime + count thresholds).
No data/cleanup is lost.

## Change

Replace the `panic` with a log + `return` when the context is already cancelled.
