### PR TITLE
enhance: use routing table for proxy hash routing

### DIFF
--- a/internal/proxy/routing_table_hash_test.go
+++ b/internal/proxy/routing_table_hash_test.go
@@ -1,0 +1,153 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/allocator"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	pkgtypeutil "github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+func TestAssignChannelsByPKPreservesModuloRouting(t *testing.T) {
+	channelNames := []string{"channel-0", "channel-1", "channel-2"}
+	pks := []int64{0, 1, 10, 100, 1000, -1}
+	ids := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: pks},
+		},
+	}
+	insertMsg := &msgstream.InsertMsg{}
+
+	got, err := assignChannelsByPK(ids, channelNames, insertMsg)
+
+	expectedHashes := expectedInt64ModuloHashes(t, pks, len(channelNames))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedHashes, insertMsg.HashValues)
+	assert.Equal(t, expectedRowOffsetsByChannel(channelNames, expectedHashes), got)
+}
+
+func TestAssignChannelsByPKReturnsRoutingErrorWithoutChannels(t *testing.T) {
+	ids := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{1}},
+		},
+	}
+	insertMsg := &msgstream.InsertMsg{}
+
+	got, err := assignChannelsByPK(ids, nil, insertMsg)
+
+	assert.ErrorIs(t, err, common.ErrRoutingTableNoValues)
+	assert.Nil(t, got)
+	assert.Empty(t, insertMsg.HashValues)
+}
+
+func TestRepackDeleteMsgByHashPreservesModuloRouting(t *testing.T) {
+	paramtable.Init()
+	vChannels := []string{"vchan-0", "vchan-1", "vchan-2"}
+	pks := []int64{0, 1, 10, 100, 1000, -1}
+	primaryKeys := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: pks},
+		},
+	}
+
+	got, rows, err := repackDeleteMsgByHash(
+		context.Background(),
+		primaryKeys,
+		vChannels,
+		allocator.NewLocalAllocator(100, 200),
+		1000,
+		1,
+		"collection",
+		2,
+		"partition",
+		"default",
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(len(pks)), rows)
+
+	expectedCounts := make(map[uint32]int)
+	for _, hash := range expectedInt64ModuloHashes(t, pks, len(vChannels)) {
+		expectedCounts[hash]++
+	}
+	actualCounts := make(map[uint32]int)
+	for hash, msgs := range got {
+		for _, msg := range msgs {
+			assert.Equal(t, vChannels[hash], msg.ShardName)
+			for _, msgHash := range msg.HashValues {
+				assert.Equal(t, hash, msgHash)
+				actualCounts[msgHash]++
+			}
+		}
+	}
+	assert.Equal(t, expectedCounts, actualCounts)
+}
+
+func TestRepackDeleteMsgByHashReturnsRoutingErrorWithoutChannels(t *testing.T) {
+	paramtable.Init()
+	primaryKeys := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{1}},
+		},
+	}
+
+	got, rows, err := repackDeleteMsgByHash(
+		context.Background(),
+		primaryKeys,
+		nil,
+		allocator.NewLocalAllocator(100, 200),
+		1000,
+		1,
+		"collection",
+		2,
+		"partition",
+		"default",
+	)
+
+	assert.ErrorIs(t, err, common.ErrRoutingTableNoValues)
+	assert.Nil(t, got)
+	assert.Zero(t, rows)
+}
+
+func expectedInt64ModuloHashes(t *testing.T, keys []int64, targetCount int) []uint32 {
+	t.Helper()
+	hashes := make([]uint32, 0, len(keys))
+	for _, key := range keys {
+		hash, err := pkgtypeutil.Hash32Int64(key)
+		assert.NoError(t, err)
+		hashes = append(hashes, hash%uint32(targetCount))
+	}
+	return hashes
+}
+
+func expectedRowOffsetsByChannel(channelNames []string, hashes []uint32) map[string][]int {
+	offsets := make(map[string][]int)
+	for offset, hash := range hashes {
+		channelName := channelNames[hash]
+		offsets[channelName] = append(offsets[channelName], offset)
+	}
+	return offsets
+}

--- a/internal/proxy/task_delete.go
+++ b/internal/proxy/task_delete.go
@@ -154,7 +154,10 @@ func repackDeleteMsgByHash(
 	dbName string,
 ) (map[uint32][]*msgstream.DeleteMsg, int64, error) {
 	maxSize := Params.PulsarCfg.MaxMessageSize.GetAsInt()
-	hashValues := typeutil.HashPK2Channels(primaryKeys, vChannels)
+	hashValues, err := typeutil.HashPK2Channels(primaryKeys, vChannels)
+	if err != nil {
+		return nil, 0, err
+	}
 	// repack delete msg by dmChannel
 	result := make(map[uint32][]*msgstream.DeleteMsg)
 	lastMessageSize := map[uint32]int{}

--- a/internal/proxy/task_insert_streaming.go
+++ b/internal/proxy/task_insert_streaming.go
@@ -98,7 +98,10 @@ func repackInsertDataForStreamingService(
 ) ([]message.MutableMessage, error) {
 	messages := make([]message.MutableMessage, 0)
 
-	channel2RowOffsets := assignChannelsByPK(result.IDs, channelNames, insertMsg)
+	channel2RowOffsets, err := assignChannelsByPK(result.IDs, channelNames, insertMsg)
+	if err != nil {
+		return nil, err
+	}
 	partitionName := insertMsg.PartitionName
 	partitionID, err := globalMetaCache.GetPartitionID(ctx, insertMsg.GetDbName(), insertMsg.CollectionName, partitionName)
 	if err != nil {
@@ -149,7 +152,10 @@ func repackInsertDataWithPartitionKeyForStreamingService(
 ) ([]message.MutableMessage, error) {
 	messages := make([]message.MutableMessage, 0)
 
-	channel2RowOffsets := assignChannelsByPK(result.IDs, channelNames, insertMsg)
+	channel2RowOffsets, err := assignChannelsByPK(result.IDs, channelNames, insertMsg)
+	if err != nil {
+		return nil, err
+	}
 	partitionNames, err := getDefaultPartitionsInPartitionKeyMode(ctx, insertMsg.GetDbName(), insertMsg.CollectionName)
 	if err != nil {
 		log.Ctx(ctx).Warn("get default partition names failed in partition key mode",

--- a/internal/proxy/util.go
+++ b/internal/proxy/util.go
@@ -2803,12 +2803,16 @@ func getDefaultPartitionsInPartitionKeyMode(ctx context.Context, dbName string, 
 	return partitionNames, nil
 }
 
-func assignChannelsByPK(pks *schemapb.IDs, channelNames []string, insertMsg *msgstream.InsertMsg) map[string][]int {
-	insertMsg.HashValues = typeutil.HashPK2Channels(pks, channelNames)
+func assignChannelsByPK(pks *schemapb.IDs, channelNames []string, insertMsg *msgstream.InsertMsg) (map[string][]int, error) {
+	hashValues, err := typeutil.HashPK2Channels(pks, channelNames)
+	if err != nil {
+		return nil, err
+	}
+	insertMsg.HashValues = hashValues
 
 	numChannels := len(channelNames)
 	if numChannels == 0 {
-		return nil
+		return nil, nil
 	}
 
 	numRows := len(insertMsg.HashValues)
@@ -2830,7 +2834,7 @@ func assignChannelsByPK(pks *schemapb.IDs, channelNames []string, insertMsg *msg
 		channel2RowOffsets[channelName] = append(channel2RowOffsets[channelName], offset)
 	}
 
-	return channel2RowOffsets
+	return channel2RowOffsets, nil
 }
 
 func assignPartitionKeys(ctx context.Context, dbName string, collName string, keys []*planpb.GenericValue) ([]string, error) {

--- a/internal/util/typeutil/hash.go
+++ b/internal/util/typeutil/hash.go
@@ -4,46 +4,74 @@ import (
 	"strconv"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
-// HashKey2Partitions hash partition keys to partitions
-func HashKey2Partitions(fieldSchema *schemapb.FieldSchema, keys []*planpb.GenericValue, partitionNames []string) ([]string, error) {
+type int64PartitionKeyHasher struct{}
+
+func (int64PartitionKeyHasher) Hash(key int64) (uint64, error) {
+	value, err := typeutil.Hash32Int64(key)
+	return uint64(value), err
+}
+
+type stringPartitionKeyHasher struct{}
+
+func (stringPartitionKeyHasher) Hash(key string) (uint64, error) {
+	return uint64(typeutil.HashString2Uint32(key)), nil
+}
+
+func locatePartitionNamesByRoutingTable[K comparable](keys []K, partitionNames []string, hasher common.Hasher[K]) ([]string, error) {
+	members := make([]common.RoutingMember, 0, len(partitionNames))
+	for _, partitionName := range partitionNames {
+		members = append(members, common.RoutingMember(partitionName))
+	}
+	table := common.NewHashRoutingTable[K](members, hasher)
+
 	selectedPartitions := make(map[string]struct{})
-	numPartitions := uint32(len(partitionNames))
-	switch fieldSchema.GetDataType() {
-	case schemapb.DataType_Int64:
-		for _, key := range keys {
-			if int64Val, ok := key.GetVal().(*planpb.GenericValue_Int64Val); ok {
-				value, _ := typeutil.Hash32Int64(int64Val.Int64Val)
-				partitionName := partitionNames[value%numPartitions]
-				selectedPartitions[partitionName] = struct{}{}
-			} else {
-				return nil, merr.WrapErrParameterInvalidMsg("the data type of the data and the schema do not match")
-			}
+	for _, key := range keys {
+		partitionName, err := table.LocateKey(key)
+		if err != nil {
+			return nil, err
 		}
-	case schemapb.DataType_VarChar:
-		for _, key := range keys {
-			if stringVal, ok := key.GetVal().(*planpb.GenericValue_StringVal); ok {
-				value := typeutil.HashString2Uint32(stringVal.StringVal)
-				partitionName := partitionNames[value%numPartitions]
-				selectedPartitions[partitionName] = struct{}{}
-			} else {
-				return nil, merr.WrapErrParameterInvalidMsg("the data type of the data and the schema do not match")
-			}
-		}
-	default:
-		return nil, merr.WrapErrParameterInvalidMsg("currently only support DataType Int64 or VarChar as partition keys")
+		selectedPartitions[partitionName.String()] = struct{}{}
 	}
 
-	result := make([]string, 0)
+	result := make([]string, 0, len(selectedPartitions))
 	for partitionName := range selectedPartitions {
 		result = append(result, partitionName)
 	}
-
 	return result, nil
+}
+
+// HashKey2Partitions hash partition keys to partitions
+func HashKey2Partitions(fieldSchema *schemapb.FieldSchema, keys []*planpb.GenericValue, partitionNames []string) ([]string, error) {
+	switch fieldSchema.GetDataType() {
+	case schemapb.DataType_Int64:
+		int64Keys := make([]int64, 0, len(keys))
+		for _, key := range keys {
+			if int64Val, ok := key.GetVal().(*planpb.GenericValue_Int64Val); ok {
+				int64Keys = append(int64Keys, int64Val.Int64Val)
+			} else {
+				return nil, merr.WrapErrParameterInvalidMsg("the data type of the data and the schema do not match")
+			}
+		}
+		return locatePartitionNamesByRoutingTable(int64Keys, partitionNames, int64PartitionKeyHasher{})
+	case schemapb.DataType_VarChar:
+		stringKeys := make([]string, 0, len(keys))
+		for _, key := range keys {
+			if stringVal, ok := key.GetVal().(*planpb.GenericValue_StringVal); ok {
+				stringKeys = append(stringKeys, stringVal.StringVal)
+			} else {
+				return nil, merr.WrapErrParameterInvalidMsg("the data type of the data and the schema do not match")
+			}
+		}
+		return locatePartitionNamesByRoutingTable(stringKeys, partitionNames, stringPartitionKeyHasher{})
+	default:
+		return nil, merr.WrapErrParameterInvalidMsg("currently only support DataType Int64 or VarChar as partition keys")
+	}
 }
 
 // HashMix computes a hash by mixing the upper and lower 64-bit values.

--- a/internal/util/typeutil/hash_test.go
+++ b/internal/util/typeutil/hash_test.go
@@ -1,0 +1,109 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typeutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
+	pkgtypeutil "github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+func TestLocatePartitionNamesByRoutingTableMatchesLegacyModulo(t *testing.T) {
+	t.Run("int64 keys", func(t *testing.T) {
+		partitions := []string{"p_0", "p_1", "p_2", "p_3"}
+		keys := []int64{0, 1, 10, 100, 1000, -1}
+		expected := make(map[string]struct{})
+		for _, key := range keys {
+			hash, err := pkgtypeutil.Hash32Int64(key)
+			assert.NoError(t, err)
+			expected[partitions[hash%uint32(len(partitions))]] = struct{}{}
+		}
+
+		got, err := locatePartitionNamesByRoutingTable(keys, partitions, int64PartitionKeyHasher{})
+
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, mapKeys(expected), got)
+	})
+
+	t.Run("varchar keys", func(t *testing.T) {
+		partitions := []string{"p_0", "p_1", "p_2"}
+		keys := []string{"ab", "bc", "bc", "abd", "milvus"}
+		expected := make(map[string]struct{})
+		for _, key := range keys {
+			hash := pkgtypeutil.HashString2Uint32(key)
+			expected[partitions[hash%uint32(len(partitions))]] = struct{}{}
+		}
+
+		got, err := locatePartitionNamesByRoutingTable(keys, partitions, stringPartitionKeyHasher{})
+
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, mapKeys(expected), got)
+	})
+}
+
+func TestHashKey2PartitionsMatchesLegacyModulo(t *testing.T) {
+	partitions := []string{"p_0", "p_1", "p_2"}
+
+	t.Run("int64 keys", func(t *testing.T) {
+		keys := []*planpb.GenericValue{
+			{Val: &planpb.GenericValue_Int64Val{Int64Val: 1}},
+			{Val: &planpb.GenericValue_Int64Val{Int64Val: 100}},
+			{Val: &planpb.GenericValue_Int64Val{Int64Val: 1000}},
+		}
+		expected := make(map[string]struct{})
+		for _, key := range keys {
+			hash, err := pkgtypeutil.Hash32Int64(key.GetInt64Val())
+			assert.NoError(t, err)
+			expected[partitions[hash%uint32(len(partitions))]] = struct{}{}
+		}
+
+		got, err := HashKey2Partitions(&schemapb.FieldSchema{DataType: schemapb.DataType_Int64}, keys, partitions)
+
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, mapKeys(expected), got)
+	})
+
+	t.Run("varchar keys", func(t *testing.T) {
+		keys := []*planpb.GenericValue{
+			{Val: &planpb.GenericValue_StringVal{StringVal: "ab"}},
+			{Val: &planpb.GenericValue_StringVal{StringVal: "bc"}},
+			{Val: &planpb.GenericValue_StringVal{StringVal: "milvus"}},
+		}
+		expected := make(map[string]struct{})
+		for _, key := range keys {
+			hash := pkgtypeutil.HashString2Uint32(key.GetStringVal())
+			expected[partitions[hash%uint32(len(partitions))]] = struct{}{}
+		}
+
+		got, err := HashKey2Partitions(&schemapb.FieldSchema{DataType: schemapb.DataType_VarChar}, keys, partitions)
+
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, mapKeys(expected), got)
+	})
+}
+
+func mapKeys[K comparable](values map[K]struct{}) []K {
+	keys := make([]K, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/pkg/util/typeutil/hash.go
+++ b/pkg/util/typeutil/hash.go
@@ -32,6 +32,25 @@ import (
 
 const substringLengthForCRC = 100
 
+type routingIndex uint32
+
+func (idx routingIndex) String() string {
+	return strconv.FormatUint(uint64(idx), 10)
+}
+
+type int64RoutingHasher struct{}
+
+func (int64RoutingHasher) Hash(key int64) (uint64, error) {
+	value, err := Hash32Int64(key)
+	return uint64(value), err
+}
+
+type stringRoutingHasher struct{}
+
+func (stringRoutingHasher) Hash(key string) (uint64, error) {
+	return uint64(HashString2Uint32(key)), nil
+}
+
 // Hash32Bytes hashing a byte array to uint32
 func Hash32Bytes(b []byte) (uint32, error) {
 	h := murmur3.New32()
@@ -85,58 +104,63 @@ func HashString2LessUint32(v string) uint32 {
 	return crc32.ChecksumIEEE([]byte(subString)) % math.MaxUint32
 }
 
-// HashPK2Channels hash primary keys to channels
-func HashPK2Channels(primaryKeys *schemapb.IDs, shardNames []string) []uint32 {
-	numShard := uint32(len(shardNames))
+func newRoutingIndexValues(targetCount int) []routingIndex {
+	values := make([]routingIndex, 0, targetCount)
+	for idx := 0; idx < targetCount; idx++ {
+		values = append(values, routingIndex(idx))
+	}
+	return values
+}
+
+func locateRoutingIndexes[K comparable](keys []K, targetCount int, hasher common.Hasher[K]) ([]uint32, error) {
+	table := common.NewHashRoutingTable[K](newRoutingIndexValues(targetCount), hasher)
 	var hashValues []uint32
+	for _, key := range keys {
+		idx, err := table.LocateKey(key)
+		if err != nil {
+			return nil, err
+		}
+		hashValues = append(hashValues, uint32(idx))
+	}
+	return hashValues, nil
+}
+
+// HashPK2Channels hash primary keys to channels
+func HashPK2Channels(primaryKeys *schemapb.IDs, shardNames []string) ([]uint32, error) {
+	var hashValues []uint32
+	var err error
 	switch primaryKeys.IdField.(type) {
 	case *schemapb.IDs_IntId:
 		pks := primaryKeys.GetIntId().Data
-		for _, pk := range pks {
-			value, _ := Hash32Int64(pk)
-			hashValues = append(hashValues, value%numShard)
-		}
+		hashValues, err = locateRoutingIndexes(pks, len(shardNames), int64RoutingHasher{})
 	case *schemapb.IDs_StrId:
 		pks := primaryKeys.GetStrId().Data
-		for _, pk := range pks {
-			hash := HashString2Uint32(pk)
-			hashValues = append(hashValues, hash%numShard)
-		}
+		hashValues, err = locateRoutingIndexes(pks, len(shardNames), stringRoutingHasher{})
 	default:
 		// TODO::
 	}
 
-	return hashValues
+	return hashValues, err
 }
 
 // HashKey2Partitions hash partition keys to partitions
 func HashKey2Partitions(keys *schemapb.FieldData, partitionNames []string) ([]uint32, error) {
-	var hashValues []uint32
-	numPartitions := uint32(len(partitionNames))
 	switch keys.Field.(type) {
 	case *schemapb.FieldData_Scalars:
 		scalarField := keys.GetScalars()
 		switch scalarField.Data.(type) {
 		case *schemapb.ScalarField_LongData:
 			longKeys := scalarField.GetLongData().Data
-			for _, key := range longKeys {
-				value, _ := Hash32Int64(key)
-				hashValues = append(hashValues, value%numPartitions)
-			}
+			return locateRoutingIndexes(longKeys, len(partitionNames), int64RoutingHasher{})
 		case *schemapb.ScalarField_StringData:
 			stringKeys := scalarField.GetStringData().Data
-			for _, key := range stringKeys {
-				value := HashString2Uint32(key)
-				hashValues = append(hashValues, value%numPartitions)
-			}
+			return locateRoutingIndexes(stringKeys, len(partitionNames), stringRoutingHasher{})
 		default:
 			return nil, merr.WrapErrParameterInvalidMsg("currently only support DataType Int64 or VarChar as partition key Field")
 		}
 	default:
 		return nil, merr.WrapErrParameterInvalidMsg("currently not support vector field as partition keys")
 	}
-
-	return hashValues, nil
 }
 
 // this method returns a static sequence for partitions for partiton key mode

--- a/pkg/util/typeutil/hash_test.go
+++ b/pkg/util/typeutil/hash_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 )
 
 func TestUint64(t *testing.T) {
@@ -150,7 +151,8 @@ func TestHashPK2Channels(t *testing.T) {
 			},
 		},
 	}
-	ret := HashPK2Channels(int64IDs, channels)
+	ret, err := HashPK2Channels(int64IDs, channels)
+	assert.NoError(t, err)
 	assert.Equal(t, 5, len(ret))
 	// same pk hash to same channel
 	assert.Equal(t, ret[1], ret[2])
@@ -162,9 +164,147 @@ func TestHashPK2Channels(t *testing.T) {
 			},
 		},
 	}
-	ret = HashPK2Channels(stringIDs, channels)
+	ret, err = HashPK2Channels(stringIDs, channels)
+	assert.NoError(t, err)
 	assert.Equal(t, 5, len(ret))
 	assert.Equal(t, ret[1], ret[2])
+}
+
+func TestHashPK2ChannelsMatchesLegacyModulo(t *testing.T) {
+	channels := []string{"channel-0", "channel-1", "channel-2", "channel-3"}
+
+	t.Run("int64 primary keys", func(t *testing.T) {
+		keys := []int64{0, 1, 10, 100, 1000, -1}
+		ids := &schemapb.IDs{
+			IdField: &schemapb.IDs_IntId{
+				IntId: &schemapb.LongArray{Data: keys},
+			},
+		}
+		expected := make([]uint32, 0, len(keys))
+		for _, key := range keys {
+			hash, err := Hash32Int64(key)
+			assert.NoError(t, err)
+			expected = append(expected, hash%uint32(len(channels)))
+		}
+
+		got, err := HashPK2Channels(ids, channels)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("varchar primary keys", func(t *testing.T) {
+		keys := []string{"ab", "bc", "bc", "abd", "milvus"}
+		ids := &schemapb.IDs{
+			IdField: &schemapb.IDs_StrId{
+				StrId: &schemapb.StringArray{Data: keys},
+			},
+		}
+		expected := make([]uint32, 0, len(keys))
+		for _, key := range keys {
+			expected = append(expected, HashString2Uint32(key)%uint32(len(channels)))
+		}
+
+		got, err := HashPK2Channels(ids, channels)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+}
+
+func TestHashPK2ChannelsReturnsRoutingError(t *testing.T) {
+	ids := &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: []int64{1}},
+		},
+	}
+
+	got, err := HashPK2Channels(ids, nil)
+
+	assert.ErrorIs(t, err, common.ErrRoutingTableNoValues)
+	assert.Nil(t, got)
+}
+
+func TestLocateRoutingIndexesMatchesLegacyModulo(t *testing.T) {
+	t.Run("int64 keys", func(t *testing.T) {
+		keys := []int64{0, 1, 10, 100, 1000, -1}
+		const targetCount = 5
+		expected := make([]uint32, 0, len(keys))
+		for _, key := range keys {
+			hash, err := Hash32Int64(key)
+			assert.NoError(t, err)
+			expected = append(expected, hash%targetCount)
+		}
+
+		got, err := locateRoutingIndexes(keys, targetCount, int64RoutingHasher{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("varchar keys", func(t *testing.T) {
+		keys := []string{"ab", "bc", "bc", "abd", "milvus"}
+		const targetCount = 4
+		expected := make([]uint32, 0, len(keys))
+		for _, key := range keys {
+			expected = append(expected, HashString2Uint32(key)%targetCount)
+		}
+
+		got, err := locateRoutingIndexes(keys, targetCount, stringRoutingHasher{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+}
+
+func TestHashKey2PartitionsMatchesLegacyModulo(t *testing.T) {
+	partitions := []string{"p_0", "p_1", "p_2"}
+
+	t.Run("int64 keys", func(t *testing.T) {
+		keys := []int64{0, 1, 10, 100, 1000, -1}
+		fieldData := &schemapb.FieldData{
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_LongData{
+						LongData: &schemapb.LongArray{Data: keys},
+					},
+				},
+			},
+		}
+		expected := make([]uint32, 0, len(keys))
+		for _, key := range keys {
+			hash, err := Hash32Int64(key)
+			assert.NoError(t, err)
+			expected = append(expected, hash%uint32(len(partitions)))
+		}
+
+		got, err := HashKey2Partitions(fieldData, partitions)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("varchar keys", func(t *testing.T) {
+		keys := []string{"ab", "bc", "bc", "abd", "milvus"}
+		fieldData := &schemapb.FieldData{
+			Field: &schemapb.FieldData_Scalars{
+				Scalars: &schemapb.ScalarField{
+					Data: &schemapb.ScalarField_StringData{
+						StringData: &schemapb.StringArray{Data: keys},
+					},
+				},
+			},
+		}
+		expected := make([]uint32, 0, len(keys))
+		for _, key := range keys {
+			expected = append(expected, HashString2Uint32(key)%uint32(len(partitions)))
+		}
+
+		got, err := HashKey2Partitions(fieldData, partitions)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
 }
 
 func TestRearrangePartitionsForPartitionKey(t *testing.T) {

--- a/tests/integration/util_insert_test.go
+++ b/tests/integration/util_insert_test.go
@@ -536,7 +536,8 @@ func TestHashPK2ChannelsIntegration(t *testing.T) {
 		}
 
 		// Use actual HashPK2Channels to get channel assignments
-		channelIndices := typeutil.HashPK2Channels(ids, shardNames)
+		channelIndices, err := typeutil.HashPK2Channels(ids, shardNames)
+		assert.NoError(t, err)
 
 		// Count distribution
 		channelCounts := make(map[uint32]int)
@@ -573,7 +574,8 @@ func TestHashPK2ChannelsIntegration(t *testing.T) {
 			shardNames[i] = fmt.Sprintf("shard_%d", i)
 		}
 
-		channelIndices := typeutil.HashPK2Channels(ids, shardNames)
+		channelIndices, err := typeutil.HashPK2Channels(ids, shardNames)
+		assert.NoError(t, err)
 
 		channelCounts := make(map[uint32]int)
 		for _, ch := range channelIndices {
@@ -608,7 +610,8 @@ func TestHashPK2ChannelsIntegration(t *testing.T) {
 			shardNames[i] = fmt.Sprintf("shard_%d", i)
 		}
 
-		channelIndices := typeutil.HashPK2Channels(ids, shardNames)
+		channelIndices, err := typeutil.HashPK2Channels(ids, shardNames)
+		assert.NoError(t, err)
 
 		channelCounts := make(map[uint32]int)
 		for _, ch := range channelIndices {
@@ -643,7 +646,8 @@ func TestHashPK2ChannelsIntegration(t *testing.T) {
 			shardNames[i] = fmt.Sprintf("shard_%d", i)
 		}
 
-		channelIndices := typeutil.HashPK2Channels(ids, shardNames)
+		channelIndices, err := typeutil.HashPK2Channels(ids, shardNames)
+		assert.NoError(t, err)
 
 		channelCounts := make(map[uint32]int)
 		for _, ch := range channelIndices {
@@ -677,7 +681,8 @@ func TestHashPK2ChannelsIntegration(t *testing.T) {
 			shardNames[i] = fmt.Sprintf("shard_%d", i)
 		}
 
-		channelIndices := typeutil.HashPK2Channels(ids, shardNames)
+		channelIndices, err := typeutil.HashPK2Channels(ids, shardNames)
+		assert.NoError(t, err)
 
 		channelCounts := make(map[uint32]int)
 		for _, ch := range channelIndices {
@@ -713,7 +718,8 @@ func TestHashPK2ChannelsIntegration(t *testing.T) {
 			shardNames[i] = fmt.Sprintf("shard_%d", i)
 		}
 
-		channelIndices := typeutil.HashPK2Channels(ids, shardNames)
+		channelIndices, err := typeutil.HashPK2Channels(ids, shardNames)
+		assert.NoError(t, err)
 
 		channelCounts := make(map[uint32]int)
 		for _, ch := range channelIndices {


### PR DESCRIPTION
issue: #50749

Depends on #50527.

Route proxy PK/channel and partition-key hash helpers through the routing table while preserving the existing hash modulo behavior.

Query/search are covered through assignPartitionKeys, which delegates to internal/util/typeutil.HashKey2Partitions.
