### PR TITLE
fix: [2.6] avoid access log trace id panic (#50223)

### DIFF
--- a/internal/proxy/accesslog/formater_test.go
+++ b/internal/proxy/accesslog/formater_test.go
@@ -156,6 +156,15 @@ func (s *LogFormatterSuite) TestFormatMethodInfo() {
 		s.True(strings.Contains(fs, s.traceID))
 	}
 
+	missingIDContext := metadata.AppendToOutgoingContext(s.ctx, "other", "value")
+	for _, req := range s.reqs {
+		i := info.NewGrpcAccessInfo(missingIDContext, s.serverinfo, req)
+		s.NotPanics(func() {
+			fs := formatter.Format(i)
+			s.True(strings.Contains(fs, info.Unknown))
+		})
+	}
+
 	tracer.Init()
 	traceContext, traceSpan := otel.Tracer(typeutil.ProxyRole).Start(s.ctx, "test")
 	trueTraceID := traceSpan.SpanContext().TraceID().String()

--- a/internal/proxy/accesslog/info/grpc_info.go
+++ b/internal/proxy/accesslog/info/grpc_info.go
@@ -132,7 +132,10 @@ func (i *GrpcAccessInfo) Address() string {
 func (i *GrpcAccessInfo) TraceID() string {
 	meta, ok := metadata.FromOutgoingContext(i.ctx)
 	if ok {
-		return meta.Get(ClientRequestIDKey)[0]
+		values := meta.Get(ClientRequestIDKey)
+		if len(values) > 0 {
+			return values[0]
+		}
 	}
 
 	traceID := trace.SpanFromContext(i.ctx).SpanContext().TraceID()


### PR DESCRIPTION
issue: #50222
pr: https://github.com/milvus-io/milvus/pull/50223

## Summary
Avoid panics when access log trace id metadata exists without client_request_id. Fall back to the OpenTelemetry trace id or Unknown instead.