### PR TITLE
enhance: preserve field binlog metadata in snapshots

### DIFF
--- a/internal/datacoord/snapshot.go
+++ b/internal/datacoord/snapshot.go
@@ -64,7 +64,8 @@ const (
 	// Version 1: Initial version with format-version field in metadata
 	// Version 2: Adds index_store_path_version to vector/scalar index files
 	// Version 3: Adds commit_timestamp to ManifestEntry (import/CDC segments)
-	SnapshotFormatVersion = 3
+	// Version 4: Adds child_fields and format to AvroFieldBinlog
+	SnapshotFormatVersion = 4
 )
 
 var (
@@ -79,12 +80,16 @@ var (
 	manifestSchemaV3Once sync.Once
 	manifestSchemaV3     avro.Schema
 	manifestSchemaV3Err  error
+
+	manifestSchemaV4Once sync.Once
+	manifestSchemaV4     avro.Schema
+	manifestSchemaV4Err  error
 )
 
 // getManifestSchema returns the cached Avro schema for writing new manifest files.
-// New writes always use the current schema version (V3).
+// New writes always use the current schema version (V4).
 func getManifestSchema() (avro.Schema, error) {
-	return getManifestSchemaV3()
+	return getManifestSchemaV4()
 }
 
 func getManifestSchemaV1() (avro.Schema, error) {
@@ -108,6 +113,13 @@ func getManifestSchemaV3() (avro.Schema, error) {
 	return manifestSchemaV3, manifestSchemaV3Err
 }
 
+func getManifestSchemaV4() (avro.Schema, error) {
+	manifestSchemaV4Once.Do(func() {
+		manifestSchemaV4, manifestSchemaV4Err = avro.Parse(getAvroSchemaV4())
+	})
+	return manifestSchemaV4, manifestSchemaV4Err
+}
+
 // getManifestSchemaByVersion returns the Avro schema for the specified format
 // version. Avro binary is positional, so each on-disk version must be decoded
 // with the exact schema it was written with — a single "current" schema with
@@ -117,7 +129,8 @@ func getManifestSchemaV3() (avro.Schema, error) {
 //   - Version 0, 1: Legacy schema (no index_store_path_version, no commit_timestamp)
 //   - Version 2: Adds index_store_path_version
 //   - Version 3: Adds commit_timestamp (import/CDC segments)
-//   - Version 4+: Future schemas (to be added when needed)
+//   - Version 4: Adds child_fields and format to AvroFieldBinlog
+//   - Version 5+: Future schemas (to be added when needed)
 //
 // When adding a new schema version:
 //  1. Create a new schema function (e.g., getAvroSchemaV4) that derives from
@@ -136,6 +149,8 @@ func getManifestSchemaByVersion(version int) (avro.Schema, error) {
 		return getManifestSchemaV2()
 	case 3:
 		return getManifestSchemaV3()
+	case 4:
+		return getManifestSchemaV4()
 	default:
 		return nil, merr.WrapErrServiceInternalMsg("unsupported manifest schema version: %d", version)
 	}
@@ -239,6 +254,10 @@ type ManifestEntry struct {
 type AvroFieldBinlog struct {
 	// FieldID is the unique identifier of the field these binlogs belong to.
 	FieldID int64 `avro:"field_id"`
+	// ChildFields lists the logical field IDs covered by this binlog group.
+	ChildFields []int64 `avro:"child_fields"`
+	// Format records the file format for this field binlog group.
+	Format string `avro:"format"`
 	// Binlogs contains the list of binlog files for this field.
 	Binlogs []AvroBinlog `avro:"binlogs"`
 }
@@ -1094,8 +1113,10 @@ func convertSegmentToManifestEntry(segment *datapb.SegmentDescription) ManifestE
 // Handles timestamp conversion from uint64 (proto) to int64 (Avro).
 func convertFieldBinlogToAvro(fb *datapb.FieldBinlog) AvroFieldBinlog {
 	avroFieldBinlog := AvroFieldBinlog{
-		FieldID: fb.GetFieldID(),
-		Binlogs: make([]AvroBinlog, len(fb.GetBinlogs())),
+		FieldID:     fb.GetFieldID(),
+		ChildFields: append([]int64(nil), fb.GetChildFields()...),
+		Format:      fb.GetFormat(),
+		Binlogs:     make([]AvroBinlog, len(fb.GetBinlogs())),
 	}
 
 	for i, binlog := range fb.GetBinlogs() {
@@ -1150,8 +1171,10 @@ func convertIndexFilePathInfoToAvro(info *indexpb.IndexFilePathInfo) AvroIndexFi
 // Handles timestamp conversion from int64 (Avro) to uint64 (proto).
 func convertAvroToFieldBinlog(avroFB AvroFieldBinlog) *datapb.FieldBinlog {
 	fieldBinlog := &datapb.FieldBinlog{
-		FieldID: avroFB.FieldID,
-		Binlogs: make([]*datapb.Binlog, len(avroFB.Binlogs)),
+		FieldID:     avroFB.FieldID,
+		ChildFields: append([]int64(nil), avroFB.ChildFields...),
+		Format:      avroFB.Format,
+		Binlogs:     make([]*datapb.Binlog, len(avroFB.Binlogs)),
 	}
 
 	for i, avroBinlog := range avroFB.Binlogs {
@@ -1568,5 +1591,25 @@ func getAvroSchemaV3() string {
 		`{"name": "is_sorted", "type": "boolean"},`,
 		`{"name": "is_sorted", "type": "boolean"},
 				{"name": "commit_timestamp", "type": "long", "default": 0},`,
+		1)
+}
+
+// getAvroSchemaV4 returns the V4 schema, derived from V3 by extending
+// AvroFieldBinlog with child_fields and format. New writes use V4; legacy V1/V2/V3
+// manifests are decoded with their exact historical schemas.
+func getAvroSchemaV4() string {
+	return strings.Replace(getAvroSchemaV3(),
+		`"name": "AvroFieldBinlog",
+							"fields": [
+								{"name": "field_id", "type": "long"},
+								{
+									"name": "binlogs",`,
+		`"name": "AvroFieldBinlog",
+							"fields": [
+								{"name": "field_id", "type": "long"},
+								{"name": "child_fields", "type": {"type": "array", "items": "long"}, "default": []},
+								{"name": "format", "type": "string", "default": ""},
+								{
+									"name": "binlogs",`,
 		1)
 }

--- a/internal/datacoord/snapshot_test.go
+++ b/internal/datacoord/snapshot_test.go
@@ -524,7 +524,9 @@ func TestSnapshotReader_ListSnapshots_Success(t *testing.T) {
 
 func TestFieldBinlog_RoundtripConversion(t *testing.T) {
 	originalFieldBinlog := &datapb.FieldBinlog{
-		FieldID: 123,
+		FieldID:     123,
+		ChildFields: []int64{123, 124, 125},
+		Format:      "parquet",
 		Binlogs: []*datapb.Binlog{
 			{
 				EntriesNum:    1000,
@@ -551,6 +553,8 @@ func TestFieldBinlog_RoundtripConversion(t *testing.T) {
 	resultFieldBinlog := convertAvroToFieldBinlog(avroFieldBinlog)
 
 	assert.Equal(t, originalFieldBinlog.FieldID, resultFieldBinlog.FieldID)
+	assert.Equal(t, originalFieldBinlog.ChildFields, resultFieldBinlog.ChildFields)
+	assert.Equal(t, originalFieldBinlog.Format, resultFieldBinlog.Format)
 	assert.Len(t, resultFieldBinlog.Binlogs, len(originalFieldBinlog.Binlogs))
 
 	for i, originalBinlog := range originalFieldBinlog.Binlogs {
@@ -720,6 +724,122 @@ func TestSnapshotManifest_LegacyV2NoCommitTimestamp(t *testing.T) {
 		"V2 manifest must decode with CommitTimestamp=0 (field absent in schema)")
 }
 
+func TestSnapshotManifest_FieldBinlogChildFieldsAndFormatRoundtripV4(t *testing.T) {
+	tempDir := t.TempDir()
+	cm := storage.NewLocalChunkManager(objectstorage.RootPath(tempDir))
+	reader := NewSnapshotReader(cm)
+
+	segment := &datapb.SegmentDescription{
+		SegmentId:   1001,
+		PartitionId: 2001,
+		Binlogs: []*datapb.FieldBinlog{
+			{
+				FieldID:     900,
+				ChildFields: []int64{100, 101},
+				Format:      "parquet",
+				Binlogs: []*datapb.Binlog{{
+					EntriesNum: 10,
+					LogPath:    "files/insert_log/1/2/3/900/1",
+				}},
+			},
+		},
+	}
+	entry := convertSegmentToManifestEntry(segment)
+
+	assert.Contains(t, getAvroSchemaV4(), "child_fields")
+	assert.Contains(t, getAvroSchemaV4(), `"format"`)
+	v4Schema, err := getManifestSchemaByVersion(4)
+	require.NoError(t, err)
+	binaryData, err := avro.Marshal(v4Schema, entry)
+	require.NoError(t, err)
+
+	manifestPath := path.Join(tempDir, "v4_manifest.avro")
+	require.NoError(t, cm.Write(context.Background(), manifestPath, binaryData))
+
+	segments, err := reader.readManifestFile(context.Background(), manifestPath, 4)
+	require.NoError(t, err)
+	require.Len(t, segments, 1)
+	require.Len(t, segments[0].GetBinlogs(), 1)
+	assert.Equal(t, []int64{100, 101}, segments[0].GetBinlogs()[0].GetChildFields())
+	assert.Equal(t, "parquet", segments[0].GetBinlogs()[0].GetFormat())
+}
+
+func TestSnapshotManifest_LegacyV3NoChildFieldsOrFormat(t *testing.T) {
+	tempDir := t.TempDir()
+	cm := storage.NewLocalChunkManager(objectstorage.RootPath(tempDir))
+	reader := NewSnapshotReader(cm)
+
+	segment := &datapb.SegmentDescription{
+		SegmentId:   1001,
+		PartitionId: 2001,
+		Binlogs: []*datapb.FieldBinlog{{
+			FieldID:     900,
+			ChildFields: []int64{100, 101},
+			Format:      "parquet",
+			Binlogs: []*datapb.Binlog{{
+				EntriesNum: 10,
+				LogPath:    "files/insert_log/1/2/3/900/1",
+			}},
+		}},
+	}
+	entry := convertSegmentToManifestEntry(segment)
+
+	assert.NotContains(t, getAvroSchemaV3(), "child_fields")
+	assert.NotContains(t, getAvroSchemaV3(), `"format"`)
+	v3Schema, err := getManifestSchemaByVersion(3)
+	require.NoError(t, err)
+	binaryData, err := avro.Marshal(v3Schema, entry)
+	require.NoError(t, err)
+
+	manifestPath := path.Join(tempDir, "v3_manifest.avro")
+	require.NoError(t, cm.Write(context.Background(), manifestPath, binaryData))
+
+	segments, err := reader.readManifestFile(context.Background(), manifestPath, 3)
+	require.NoError(t, err)
+	require.Len(t, segments, 1)
+	require.Len(t, segments[0].GetBinlogs(), 1)
+	assert.Empty(t, segments[0].GetBinlogs()[0].GetChildFields())
+	assert.Equal(t, "", segments[0].GetBinlogs()[0].GetFormat())
+}
+
+func TestSnapshotManifest_LegacyV2NoChildFieldsOrFormat(t *testing.T) {
+	tempDir := t.TempDir()
+	cm := storage.NewLocalChunkManager(objectstorage.RootPath(tempDir))
+	reader := NewSnapshotReader(cm)
+
+	segment := &datapb.SegmentDescription{
+		SegmentId:   1001,
+		PartitionId: 2001,
+		Binlogs: []*datapb.FieldBinlog{{
+			FieldID:     900,
+			ChildFields: []int64{100, 101},
+			Format:      "parquet",
+			Binlogs: []*datapb.Binlog{{
+				EntriesNum: 10,
+				LogPath:    "files/insert_log/1/2/3/900/1",
+			}},
+		}},
+	}
+	entry := convertSegmentToManifestEntry(segment)
+
+	assert.NotContains(t, getAvroSchemaV2(), "child_fields")
+	assert.NotContains(t, getAvroSchemaV2(), `"format"`)
+	v2Schema, err := getManifestSchemaByVersion(2)
+	require.NoError(t, err)
+	binaryData, err := avro.Marshal(v2Schema, entry)
+	require.NoError(t, err)
+
+	manifestPath := path.Join(tempDir, "v2_no_child_fields.avro")
+	require.NoError(t, cm.Write(context.Background(), manifestPath, binaryData))
+
+	segments, err := reader.readManifestFile(context.Background(), manifestPath, 2)
+	require.NoError(t, err)
+	require.Len(t, segments, 1)
+	require.Len(t, segments[0].GetBinlogs(), 1)
+	assert.Empty(t, segments[0].GetBinlogs()[0].GetChildFields())
+	assert.Equal(t, "", segments[0].GetBinlogs()[0].GetFormat())
+}
+
 // =========================== Integration Tests ===========================
 
 func TestSnapshotWriter_ManifestList_Roundtrip(t *testing.T) {
@@ -765,6 +885,11 @@ func TestSnapshot_CompleteWorkflow(t *testing.T) {
 	if len(readSnapshot.Segments) > 0 {
 		assert.Equal(t, snapshotData.Segments[0].SegmentId, readSnapshot.Segments[0].SegmentId)
 		assert.Equal(t, snapshotData.Segments[0].PartitionId, readSnapshot.Segments[0].PartitionId)
+		if len(snapshotData.Segments[0].GetBinlogs()) > 0 {
+			require.Len(t, readSnapshot.Segments[0].GetBinlogs(), len(snapshotData.Segments[0].GetBinlogs()))
+			assert.Equal(t, snapshotData.Segments[0].GetBinlogs()[0].GetChildFields(), readSnapshot.Segments[0].GetBinlogs()[0].GetChildFields())
+			assert.Equal(t, snapshotData.Segments[0].GetBinlogs()[0].GetFormat(), readSnapshot.Segments[0].GetBinlogs()[0].GetFormat())
+		}
 	}
 
 	// 7. Verify indexes information
@@ -859,12 +984,27 @@ func TestSnapshot_NewFields_Serialization(t *testing.T) {
 	assert.Equal(t, len(original.Bm25Statslogs), len(restored.Bm25Statslogs), "Bm25Statslogs count should match")
 	if len(original.Bm25Statslogs) > 0 {
 		assert.Equal(t, original.Bm25Statslogs[0].FieldID, restored.Bm25Statslogs[0].FieldID)
+		assert.Equal(t, original.Bm25Statslogs[0].ChildFields, restored.Bm25Statslogs[0].ChildFields)
+		assert.Equal(t, original.Bm25Statslogs[0].Format, restored.Bm25Statslogs[0].Format)
 		assert.Equal(t, len(original.Bm25Statslogs[0].Binlogs), len(restored.Bm25Statslogs[0].Binlogs))
 		if len(original.Bm25Statslogs[0].Binlogs) > 0 {
 			assert.Equal(t, original.Bm25Statslogs[0].Binlogs[0].LogPath, restored.Bm25Statslogs[0].Binlogs[0].LogPath)
 			assert.Equal(t, original.Bm25Statslogs[0].Binlogs[0].LogSize, restored.Bm25Statslogs[0].Binlogs[0].LogSize)
 		}
 	}
+
+	// 3.5 Verify insert binlog metadata fields
+	require.NotEmpty(t, restored.Binlogs)
+	assert.Equal(t, original.Binlogs[0].ChildFields, restored.Binlogs[0].ChildFields)
+	assert.Equal(t, original.Binlogs[0].Format, restored.Binlogs[0].Format)
+
+	// 3.6 Verify stats/delta binlog metadata fields
+	require.NotEmpty(t, restored.Statslogs)
+	require.NotEmpty(t, restored.Deltalogs)
+	assert.Equal(t, original.Statslogs[0].ChildFields, restored.Statslogs[0].ChildFields)
+	assert.Equal(t, original.Statslogs[0].Format, restored.Statslogs[0].Format)
+	assert.Equal(t, original.Deltalogs[0].ChildFields, restored.Deltalogs[0].ChildFields)
+	assert.Equal(t, original.Deltalogs[0].Format, restored.Deltalogs[0].Format)
 
 	// 4. Verify TextIndexFiles field (map type)
 	assert.Equal(t, len(original.TextIndexFiles), len(restored.TextIndexFiles), "TextIndexFiles count should match")
@@ -1150,10 +1290,9 @@ func TestValidateFormatVersion(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "version_4_future",
-			version:     4,
-			wantErr:     true,
-			errContains: "too new",
+			name:    "version_4_current",
+			version: 4,
+			wantErr: false,
 		},
 		{
 			name:        "version_100_future",
@@ -1204,10 +1343,9 @@ func TestGetManifestSchemaByVersion(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "version_4_unsupported",
-			version:     4,
-			wantErr:     true,
-			errContains: "unsupported manifest schema version",
+			name:    "version_4_current",
+			version: 4,
+			wantErr: false,
 		},
 		{
 			name:        "version_99_unsupported",


### PR DESCRIPTION
issue: #44358

Introduce snapshot format V4 so manifest serialization keeps FieldBinlog child_fields and format instead of dropping them during snapshot write/read round trips.

Keep V1/V2/V3 readers compatible, route new writes to V4, and extend snapshot tests to cover roundtrip correctness and legacy compatibility.