### PR TITLE
fix: honor partition names in REST hybrid search

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1877,6 +1877,7 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 	req := &milvuspb.HybridSearchRequest{
 		DbName:         dbName,
 		CollectionName: httpReq.CollectionName,
+		PartitionNames: httpReq.PartitionNames,
 		Requests:       []*milvuspb.SearchRequest{},
 		OutputFields:   httpReq.OutputFields,
 	}

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -945,7 +945,9 @@ func TestHybridSearchWithRerank(t *testing.T) {
 		Status:         &StatusSuccess,
 	}, nil).Once()
 
-	mp.EXPECT().HybridSearch(mock.Anything, mock.Anything).Return(&milvuspb.SearchResults{Status: commonSuccessStatus, Results: &schemapb.SearchResultData{
+	mp.EXPECT().HybridSearch(mock.Anything, mock.MatchedBy(func(req *milvuspb.HybridSearchRequest) bool {
+		return assert.ObjectsAreEqual([]string{"part_a"}, req.GetPartitionNames())
+	})).Return(&milvuspb.SearchResults{Status: commonSuccessStatus, Results: &schemapb.SearchResultData{
 		TopK:         int64(3),
 		OutputFields: []string{FieldWordCount},
 		FieldsData:   generateFieldData(),
@@ -955,7 +957,7 @@ func TestHybridSearchWithRerank(t *testing.T) {
 
 	queryTestCases := requestBodyTestCase{
 		path:        versionalV2(EntityCategory, HybridSearchAction),
-		requestBody: []byte(`{"collectionName": "hello_milvus", "search": [{"data": [[0.1, 0.2]], "annsField": "book_intro", "metricType": "L2", "limit": 3}, {"data": [[0.1, 0.2]], "annsField": "book_intro", "metricType": "L2", "limit": 3}], "functionScore": {"functions": [{"name": "testRank", "type": "Rerank", "inputFieldNames": ["FieldWordCount"], "params": {"name": "decay"}}]}}`),
+		requestBody: []byte(`{"collectionName": "hello_milvus", "partitionNames": ["part_a"], "search": [{"data": [[0.1, 0.2]], "annsField": "book_intro", "metricType": "L2", "limit": 3}, {"data": [[0.1, 0.2]], "annsField": "book_intro", "metricType": "L2", "limit": 3}], "functionScore": {"functions": [{"name": "testRank", "type": "Rerank", "inputFieldNames": ["FieldWordCount"], "params": {"name": "decay"}}]}}`),
 	}
 	sendReqAndVerify(t, testEngine, queryTestCases.path, http.MethodPost, queryTestCases)
 }

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -94,8 +94,6 @@ type ServiceSuite struct {
 	etcdClient          *clientv3.Client
 	rootPath            string
 	chunkManagerFactory *storage.ChunkManagerFactory
-	minioBucketName     string
-	originalBucketName  string
 
 	// Mock
 	factory *dependency.MockFactory
@@ -136,9 +134,6 @@ func (suite *ServiceSuite) SetupTest() {
 	suite.factory = dependency.NewMockFactory(suite.T())
 	// TODO:: cpp chunk manager not support local chunk manager
 	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, suite.T().TempDir())
-	suite.originalBucketName = paramtable.Get().MinioCfg.BucketName.GetValue()
-	suite.minioBucketName = fmt.Sprintf("querynode-service-%s", strconv.FormatInt(time.Now().UnixNano(), 36))
-	paramtable.Get().Save(paramtable.Get().MinioCfg.BucketName.Key, suite.minioBucketName)
 	// suite.chunkManagerFactory = storage.NewChunkManagerFactory("local", storage.RootPath("/tmp/milvus-test"))
 	suite.chunkManagerFactory = storage.NewTestChunkManagerFactory(paramtable.Get(), suite.rootPath)
 	suite.factory.EXPECT().Init(mock.Anything).Return()
@@ -183,11 +178,10 @@ func (suite *ServiceSuite) TearDownTest() {
 	})
 	suite.NoError(err)
 	suite.Equal(commonpb.ErrorCode_Success, resp.ErrorCode)
-	suite.node.chunkManager.RemoveWithPrefix(ctx, suite.node.chunkManager.RootPath())
+	suite.node.chunkManager.RemoveWithPrefix(ctx, paramtable.Get().LocalStorageCfg.Path.GetValue())
 	suite.node.Stop()
 	suite.etcdClient.Close()
 	paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
-	paramtable.Get().Save(paramtable.Get().MinioCfg.BucketName.Key, suite.originalBucketName)
 }
 
 func (suite *ServiceSuite) TestGetComponentStatesNormal() {

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -94,6 +94,8 @@ type ServiceSuite struct {
 	etcdClient          *clientv3.Client
 	rootPath            string
 	chunkManagerFactory *storage.ChunkManagerFactory
+	minioBucketName     string
+	originalBucketName  string
 
 	// Mock
 	factory *dependency.MockFactory
@@ -134,6 +136,9 @@ func (suite *ServiceSuite) SetupTest() {
 	suite.factory = dependency.NewMockFactory(suite.T())
 	// TODO:: cpp chunk manager not support local chunk manager
 	paramtable.Get().Save(paramtable.Get().LocalStorageCfg.Path.Key, suite.T().TempDir())
+	suite.originalBucketName = paramtable.Get().MinioCfg.BucketName.GetValue()
+	suite.minioBucketName = fmt.Sprintf("querynode-service-%s", strconv.FormatInt(time.Now().UnixNano(), 36))
+	paramtable.Get().Save(paramtable.Get().MinioCfg.BucketName.Key, suite.minioBucketName)
 	// suite.chunkManagerFactory = storage.NewChunkManagerFactory("local", storage.RootPath("/tmp/milvus-test"))
 	suite.chunkManagerFactory = storage.NewTestChunkManagerFactory(paramtable.Get(), suite.rootPath)
 	suite.factory.EXPECT().Init(mock.Anything).Return()
@@ -178,10 +183,11 @@ func (suite *ServiceSuite) TearDownTest() {
 	})
 	suite.NoError(err)
 	suite.Equal(commonpb.ErrorCode_Success, resp.ErrorCode)
-	suite.node.chunkManager.RemoveWithPrefix(ctx, paramtable.Get().LocalStorageCfg.Path.GetValue())
+	suite.node.chunkManager.RemoveWithPrefix(ctx, suite.node.chunkManager.RootPath())
 	suite.node.Stop()
 	suite.etcdClient.Close()
 	paramtable.Get().Reset(paramtable.Get().LocalStorageCfg.Path.Key)
+	paramtable.Get().Save(paramtable.Get().MinioCfg.BucketName.Key, suite.originalBucketName)
 }
 
 func (suite *ServiceSuite) TestGetComponentStatesNormal() {


### PR DESCRIPTION
Honor top-level partitionNames for REST v2 hybrid_search so it only searches requested partitions.

issue: #50396