### PR TITLE
fix: enforce partition key isolation in hybrid search

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -77,6 +77,7 @@ type searchTask struct {
 	schema                 *schemaInfo
 	needRequery            bool
 	partitionKeyMode       bool
+	partitionKeyIsolation  bool
 	largeTopKEnabled       bool
 	enableMaterializedView bool
 	mustUsePartitionKey    bool
@@ -189,6 +190,7 @@ func (t *searchTask) PreExecute(ctx context.Context) error {
 		return err2
 	}
 	t.largeTopKEnabled = collectionInfo.queryMode == common.QueryModeLargeTopK
+	t.partitionKeyIsolation = collectionInfo.partitionKeyIsolation
 
 	t.partitionKeyMode, err = isPartitionKeyMode(ctx, t.request.GetDbName(), collectionName)
 	if err != nil {
@@ -449,7 +451,19 @@ func (t *searchTask) initSearchAggregation() error {
 	return nil
 }
 
-func setQueryInfoIfMvEnable(queryInfo *planpb.QueryInfo, t *searchTask, plan *planpb.PlanNode) error {
+func (t *searchTask) validatePartitionKeyIsolation(plan *planpb.PlanNode) error {
+	if !t.partitionKeyIsolation {
+		return nil
+	}
+	expr, err := exprutil.ParseExprFromPlan(plan)
+	if err != nil {
+		log.Ctx(t.ctx).Warn("failed to parse expr from plan when validating partition key isolation", zap.Error(err))
+		return err
+	}
+	return exprutil.ValidatePartitionKeyIsolation(expr)
+}
+
+func setQueryInfoIfMvEnable(queryInfo *planpb.QueryInfo, t *searchTask) error {
 	if t.enableMaterializedView {
 		partitionKeyFieldSchema, err := typeutil.GetPartitionKeyFieldSchema(t.schema.CollectionSchema)
 		if err != nil {
@@ -457,23 +471,7 @@ func setQueryInfoIfMvEnable(queryInfo *planpb.QueryInfo, t *searchTask, plan *pl
 			return err
 		}
 		if typeutil.IsFieldDataTypeSupportMaterializedView(partitionKeyFieldSchema) {
-			collInfo, colErr := globalMetaCache.GetCollectionInfo(t.ctx, t.request.GetDbName(), t.collectionName, t.CollectionID)
-			if colErr != nil {
-				log.Ctx(t.ctx).Warn("failed to get collection info", zap.Error(colErr))
-				return err
-			}
-
-			if collInfo.partitionKeyIsolation {
-				expr, err := exprutil.ParseExprFromPlan(plan)
-				if err != nil {
-					log.Ctx(t.ctx).Warn("failed to parse expr from plan during MV", zap.Error(err))
-					return err
-				}
-				err = exprutil.ValidatePartitionKeyIsolation(expr)
-				if err != nil {
-					return err
-				}
-				// force set hints to disable
+			if t.partitionKeyIsolation {
 				queryInfo.Hints = "disable"
 			}
 			queryInfo.MaterializedViewInvolved = true
@@ -642,7 +640,10 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 		// set PartitionIDs for sub search
 		if t.partitionKeyMode {
 			// isolation has tighter constraint, check first
-			mvErr := setQueryInfoIfMvEnable(queryInfo, t, plan)
+			if err := t.validatePartitionKeyIsolation(plan); err != nil {
+				return err
+			}
+			mvErr := setQueryInfoIfMvEnable(queryInfo, t)
 			if mvErr != nil {
 				return mvErr
 			}
@@ -865,7 +866,10 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 
 	if t.partitionKeyMode {
 		// isolation has tighter constraint, check first
-		mvErr := setQueryInfoIfMvEnable(queryInfo, t, plan)
+		if err := t.validatePartitionKeyIsolation(plan); err != nil {
+			return err
+		}
+		mvErr := setQueryInfoIfMvEnable(queryInfo, t)
 		if mvErr != nil {
 			return mvErr
 		}

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -4949,6 +4949,39 @@ func (s *MaterializedViewTestSuite) getSearchTask() *searchTask {
 	return task
 }
 
+func (s *MaterializedViewTestSuite) getHybridSearchTask(dsl string) *searchTask {
+	placeholderGroup, err := proto.Marshal(constructPlaceholderGroup(1, testVecDim))
+	s.NoError(err)
+
+	subReqs := make([]*milvuspb.SubSearchRequest, 0, 2)
+	for i := 0; i < 2; i++ {
+		subReqs = append(subReqs, &milvuspb.SubSearchRequest{
+			Dsl:              dsl,
+			DslType:          commonpb.DslType_BoolExprV1,
+			PlaceholderGroup: placeholderGroup,
+			Nq:               1,
+			SearchParams:     getValidSearchParams(),
+		})
+	}
+
+	task := &searchTask{
+		ctx:            s.ctx,
+		collectionName: s.colName,
+		SearchRequest:  &internalpb.SearchRequest{},
+		request: &milvuspb.SearchRequest{
+			DbName:         s.dbName,
+			CollectionName: s.colName,
+			Nq:             1,
+			SearchParams: []*commonpb.KeyValuePair{
+				{Key: LimitKey, Value: "5"},
+			},
+			SubReqs: subReqs,
+		},
+	}
+	s.NoError(task.OnEnqueue())
+	return task
+}
+
 func (s *MaterializedViewTestSuite) TestMvNotEnabledWithNoPartitionKey() {
 	task := s.getSearchTask()
 	task.enableMaterializedView = false
@@ -5060,6 +5093,40 @@ func (s *MaterializedViewTestSuite) TestMvEnabledPartitionKeyOnVarCharWithIsolat
 		schemaInfo := newSchemaInfo(schema)
 		s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil)
 		s.ErrorContains(task.PreExecute(s.ctx), "partition key isolation does not support IN")
+	}
+}
+
+func (s *MaterializedViewTestSuite) TestHybridSearchPartitionKeyIsolationWithoutMaterializedView() {
+	schema := ConstructCollectionSchemaWithPartitionKey(s.colName, s.fieldName2Types, testInt64Field, testVarCharField, false)
+	schemaInfo := newSchemaInfo(schema)
+	s.mockMetaCache.EXPECT().GetCollectionSchema(mock.Anything, mock.Anything, mock.Anything).Return(schemaInfo, nil).Maybe()
+	s.mockMetaCache.EXPECT().GetPartitionsIndex(mock.Anything, mock.Anything, mock.Anything).Return([]string{"partition_1", "partition_2"}, nil).Maybe()
+	s.mockMetaCache.EXPECT().GetPartitions(mock.Anything, mock.Anything, mock.Anything).Return(map[string]int64{"partition_1": 1, "partition_2": 2}, nil).Maybe()
+
+	testCases := []struct {
+		name     string
+		dsl      string
+		errorMsg string
+	}{
+		{
+			name:     "missing partition key filter",
+			dsl:      "",
+			errorMsg: "partition key not found in expr or the expr is invalid when validating partition key isolation",
+		},
+		{
+			name:     "multiple partition key values",
+			dsl:      testVarCharField + " in [\"a\", \"b\"]",
+			errorMsg: "partition key isolation does not support IN",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			task := s.getHybridSearchTask(tc.dsl)
+			task.enableMaterializedView = false
+
+			s.ErrorContains(task.PreExecute(s.ctx), tc.errorMsg)
+		})
 	}
 }
 


### PR DESCRIPTION
Enforce partition key isolation validation for every ANN sub-request in hybrid_search.

issue: #50398