### PR TITLE
fix: keep empty highlight results for nullable strings

### DIFF
--- a/internal/proxy/highlighter.go
+++ b/internal/proxy/highlighter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 const (
@@ -322,12 +323,64 @@ func newLexicalHighlightOperator(t *searchTask, tasks []*highlightTask) (operato
 }
 
 func hasSearchResultHits(result *schemapb.SearchResultData) bool {
+	return searchResultHitCount(result) > 0
+}
+
+func searchResultHitCount(result *schemapb.SearchResultData) int {
 	if result == nil {
-		return false
+		return 0
 	}
 
-	ids := result.GetIds()
-	return len(ids.GetIntId().GetData()) > 0 || len(ids.GetStrId().GetData()) > 0
+	rowNum := 0
+	for _, topk := range result.GetTopks() {
+		rowNum += int(topk)
+	}
+	return rowNum
+}
+
+func rowAlignedStringFieldData(fieldData *schemapb.FieldData, rowNum int) ([]string, error) {
+	if fieldData == nil {
+		return nil, merr.WrapErrServiceInternalMsg("get highlight failed, field data is nil")
+	}
+
+	data := fieldData.GetScalars().GetStringData().GetData()
+	validData := fieldData.GetValidData()
+	if len(validData) == 0 {
+		if len(data) != rowNum {
+			return nil, merr.WrapErrServiceInternalMsg(
+				"get highlight failed, string field %s:%d has %d rows, expected %d",
+				fieldData.GetFieldName(), fieldData.GetFieldId(), len(data), rowNum)
+		}
+		return append([]string(nil), data...), nil
+	}
+
+	if len(validData) != rowNum {
+		return nil, merr.WrapErrServiceInternalMsg(
+			"get highlight failed, string field %s:%d has ValidData length %d, expected %d",
+			fieldData.GetFieldName(), fieldData.GetFieldId(), len(validData), rowNum)
+	}
+
+	validCount := lo.CountBy(validData, func(valid bool) bool { return valid })
+	if len(data) != rowNum && len(data) != validCount {
+		return nil, merr.WrapErrServiceInternalMsg(
+			"get highlight failed, string field %s:%d has %d compact rows, expected %d valid rows",
+			fieldData.GetFieldName(), fieldData.GetFieldId(), len(data), validCount)
+	}
+
+	iterator := typeutil.GetDataIterator(fieldData)
+	texts := make([]string, rowNum)
+	for i := range texts {
+		if value := iterator(i); value != nil {
+			text, ok := value.(string)
+			if !ok {
+				return nil, merr.WrapErrServiceInternalMsg(
+					"get highlight failed, string field %s:%d has non-string data at row %d",
+					fieldData.GetFieldName(), fieldData.GetFieldId(), i)
+			}
+			texts[i] = text
+		}
+	}
+	return texts, nil
 }
 
 func (op *lexicalHighlightOperator) run(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
@@ -344,6 +397,7 @@ func (op *lexicalHighlightOperator) run(ctx context.Context, span trace.Span, in
 		return nil, merr.WrapErrServiceInternalMsg("get highlight failed, field data is empty for non-empty search result")
 	}
 
+	rowNum := searchResultHitCount(resultData)
 	req := &querypb.GetHighlightRequest{
 		Topks: result.GetResults().GetTopks(),
 		Tasks: lo.Map(op.tasks, func(task *highlightTask, _ int) *querypb.HighlightTask { return task.HighlightTask }),
@@ -354,16 +408,14 @@ func (op *lexicalHighlightOperator) run(ctx context.Context, span trace.Span, in
 		if !ok {
 			return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, text field not in output field %s: %d", task.GetFieldName(), task.GetFieldId())
 		}
-		texts := textFieldDatas.GetScalars().GetStringData().GetData()
-		task.Texts = append(task.Texts, texts...)
-		task.CorpusTextNum = int64(len(texts))
-
-		field, err := op.schema.schemaHelper.GetFieldFromID(task.GetFieldId())
+		texts, err := rowAlignedStringFieldData(textFieldDatas, rowNum)
 		if err != nil {
 			return nil, err
 		}
+		task.Texts = append(task.Texts, texts...)
+		task.CorpusTextNum = int64(len(texts))
 
-		nameFieldID, err := op.schema.GetMultiAnalyzerNameFieldID(field.GetFieldID())
+		nameFieldID, err := op.schema.GetMultiAnalyzerNameFieldID(task.GetFieldId())
 		if err != nil {
 			return nil, err
 		}
@@ -375,7 +427,16 @@ func (op *lexicalHighlightOperator) run(ctx context.Context, span trace.Span, in
 			if !ok {
 				return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, analyzer name field: %d for multi analyzer not in output field", nameFieldID)
 			}
-			task.AnalyzerNames = append(task.AnalyzerNames, analyzerFieldDatas.GetScalars().GetStringData().GetData()...)
+			analyzerNames, err := rowAlignedStringFieldData(analyzerFieldDatas, rowNum)
+			if err != nil {
+				return nil, err
+			}
+			for i, name := range analyzerNames {
+				if name == "" {
+					analyzerNames[i] = "default"
+				}
+			}
+			task.AnalyzerNames = append(task.AnalyzerNames, analyzerNames...)
 		}
 	}
 
@@ -396,9 +457,11 @@ func (op *lexicalHighlightOperator) run(ctx context.Context, span trace.Span, in
 		return nil, err
 	}
 
-	rowNum := len(result.Results.GetScores())
 	HighlightResults := []*commonpb.HighlightResult{}
 	if rowNum != 0 {
+		if len(task.result.GetResults()) != len(req.GetTasks())*rowNum {
+			return nil, merr.WrapErrServiceInternalMsg("get highlight failed, result count %d does not match task count %d and row count %d", len(task.result.GetResults()), len(req.GetTasks()), rowNum)
+		}
 		rowDatas := lo.Map(task.result.Results, func(result *querypb.HighlightResult, i int) *commonpb.HighlightData {
 			return buildStringFragments(op.tasks[i/rowNum], i%rowNum, result.GetFragments())
 		})

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -1213,7 +1214,7 @@ func (s *SearchPipelineSuite) TestHighlightOp() {
 		qn.EXPECT().GetHighlight(mock.Anything, mock.Anything).Return(
 			&querypb.GetHighlightResponse{
 				Status:  merr.Success(),
-				Results: []*querypb.HighlightResult{},
+				Results: []*querypb.HighlightResult{{}},
 			}, nil)
 		workload.Exec(ctx, 0, qn, "test_chan")
 	}).Return(nil)
@@ -1239,6 +1240,156 @@ func (s *SearchPipelineSuite) TestHighlightOp() {
 		},
 	})
 	s.NoError(err)
+}
+
+func (s *SearchPipelineSuite) TestLexicalHighlightOpNullableStringKeepsEmptyHighlightData() {
+	cases := []struct {
+		name          string
+		rowNum        int
+		stringData    []string
+		validData     []bool
+		expectedTexts []string
+	}{
+		{
+			name:          "compact nullable string",
+			rowNum:        2,
+			stringData:    []string{"match text"},
+			validData:     []bool{true, false},
+			expectedTexts: []string{"target text", "match text", ""},
+		},
+		{
+			name:          "all null string",
+			rowNum:        1,
+			stringData:    []string{},
+			validData:     []bool{false},
+			expectedTexts: []string{"target text", ""},
+		},
+		{
+			name:          "empty string",
+			rowNum:        1,
+			stringData:    []string{""},
+			validData:     []bool{true},
+			expectedTexts: []string{"target text", ""},
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			proxy := &Proxy{}
+			proxy.tsoAllocator = &timestampAllocator{
+				tso: newMockTimestampAllocatorInterface(),
+			}
+			sched, err := newTaskScheduler(ctx, proxy.tsoAllocator)
+			s.Require().NoError(err)
+
+			err = sched.Start()
+			s.Require().NoError(err)
+			defer sched.Close()
+			proxy.sched = sched
+
+			collName := "test_coll_highlight_nullable"
+			fieldName2Types := map[string]schemapb.DataType{
+				testVarCharField: schemapb.DataType_VarChar,
+			}
+			schema := constructCollectionSchemaByDataType(collName, fieldName2Types, testVarCharField, false)
+
+			highlightTasks := map[int64]*highlightTask{
+				100: {
+					HighlightTask: &querypb.HighlightTask{
+						Texts:         []string{"target text"},
+						FieldName:     testVarCharField,
+						FieldId:       100,
+						SearchTextNum: 1,
+					},
+					preTags:  [][]byte{[]byte(DefaultPreTag)},
+					postTags: [][]byte{[]byte(DefaultPostTag)},
+				},
+			}
+
+			mockLb := shardclient.NewMockLBPolicy(s.T())
+			searchTask := &searchTask{
+				node: proxy,
+				highlighter: &LexicalHighlighter{
+					tasks: highlightTasks,
+				},
+				lb:             mockLb,
+				schema:         newSchemaInfo(schema),
+				request:        &milvuspb.SearchRequest{CollectionName: collName, DbName: "default"},
+				collectionName: collName,
+				SearchRequest:  &internalpb.SearchRequest{CollectionID: 0},
+			}
+
+			op, err := opFactory[highlightOp](searchTask, map[string]any{})
+			s.Require().NoError(err)
+
+			queryNodeResults := make([]*querypb.HighlightResult, tc.rowNum)
+			for i := range queryNodeResults {
+				queryNodeResults[i] = &querypb.HighlightResult{}
+			}
+
+			mockLb.EXPECT().ExecuteOneChannel(mock.Anything, mock.Anything).Run(func(ctx context.Context, workload shardclient.CollectionWorkLoad) {
+				qn := mocks.NewMockQueryNodeClient(s.T())
+				qn.EXPECT().GetHighlight(mock.Anything, mock.Anything).Run(func(ctx context.Context, req *querypb.GetHighlightRequest, opts ...grpc.CallOption) {
+					s.Require().Len(req.GetTasks(), 1)
+					task := req.GetTasks()[0]
+					s.Equal(int64(tc.rowNum), task.GetCorpusTextNum())
+					s.Equal(tc.expectedTexts, task.GetTexts())
+				}).Return(
+					&querypb.GetHighlightResponse{
+						Status:  merr.Success(),
+						Results: queryNodeResults,
+					}, nil)
+				workload.Exec(ctx, 0, qn, "test_chan")
+			}).Return(nil)
+
+			ids := make([]int64, tc.rowNum)
+			scores := make([]float32, tc.rowNum)
+			for i := range tc.rowNum {
+				ids[i] = int64(i + 1)
+				scores[i] = 1.0 - float32(i)*0.1
+			}
+
+			results, err := op.run(ctx, s.span, &milvuspb.SearchResults{
+				Results: &schemapb.SearchResultData{
+					NumQueries: 1,
+					TopK:       int64(tc.rowNum),
+					Topks:      []int64{int64(tc.rowNum)},
+					Ids:        testSearchResultIDs(ids...),
+					Scores:     scores,
+					FieldsData: []*schemapb.FieldData{
+						{
+							FieldId:   100,
+							FieldName: testVarCharField,
+							Type:      schemapb.DataType_VarChar,
+							ValidData: tc.validData,
+							Field: &schemapb.FieldData_Scalars{
+								Scalars: &schemapb.ScalarField{
+									Data: &schemapb.ScalarField_StringData{
+										StringData: &schemapb.StringArray{Data: tc.stringData},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+			s.NoError(err)
+			s.Require().Len(results, 1)
+
+			result := results[0].(*milvuspb.SearchResults)
+			highlightResults := result.GetResults().GetHighlightResults()
+			s.Require().Len(highlightResults, 1)
+			s.Equal(testVarCharField, highlightResults[0].GetFieldName())
+			s.Require().Len(highlightResults[0].GetDatas(), tc.rowNum)
+			for _, data := range highlightResults[0].GetDatas() {
+				s.NotNil(data)
+				s.Empty(data.GetFragments())
+			}
+		})
+	}
 }
 
 func (s *SearchPipelineSuite) TestLexicalHighlightOpZeroHitWithNonEmptyFieldsData() {


### PR DESCRIPTION
issue: #46308

## Summary
Keep lexical highlight corpus texts aligned with search result rows when highlighted string fields are nullable or empty. Null and empty rows now still produce highlight data with an empty fragments list.