### PR TITLE
enhance: reject remote vector output when configured

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -28,7 +28,7 @@ class MilvusConan(ConanFile):
         "prometheus-cpp/1.2.4#0918d66c13f97acb7809759f9de49b3f",
         "re2/20230301#f8efaf45f98d0193cd0b2ea08b6b4060",
         "folly/2026.04.20.00@milvus/dev#06852bea5b6449f0c4eb0df002b5779c",
-        "milvus-common/1.0.0-ac18852@milvus/dev#d9aa7497425662eb17749b4871700200",
+        "milvus-common/1.0.0-4f41e32@milvus/dev#1ce0b1d539952e383c64a51881384d31",
         "google-cloud-cpp/2.28.0@milvus/dev#468918b43cec43624531a0340398cf43",
         "opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720",
         "librdkafka/1.9.1#ec1a00d5414f618555799be9566adfb7",

--- a/internal/core/src/mmap/ChunkedColumn.h
+++ b/internal/core/src/mmap/ChunkedColumn.h
@@ -234,6 +234,17 @@ class ChunkedColumnBase : public ChunkedColumnInterface {
         SemiInlineGet(slot_->PinCells(op_ctx, chunk_ids));
     }
 
+    bool
+    CellsLoaded(const int64_t* offsets, int64_t count) const override {
+        if (count == 0) {
+            return true;
+        }
+        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
+        return std::all_of(cids.begin(), cids.end(), [this](cid_t cid) {
+            return slot_->IsCached(cid);
+        });
+    }
+
     PinWrapper<SpanBase>
     Span(milvus::OpContext* op_ctx, int64_t chunk_id) const override {
         ThrowInfo(ErrorCode::Unsupported,

--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -97,6 +97,13 @@ class ChunkedColumnGroup {
         return SemiInlineGet(slot_->PinCells(op_ctx, chunk_ids));
     }
 
+    bool
+    CellsLoaded(const std::vector<cachinglayer::cid_t>& cids) const {
+        return std::all_of(cids.begin(), cids.end(), [this](cid_t cid) {
+            return slot_->IsCached(cid);
+        });
+    }
+
     std::vector<PinWrapper<GroupChunk*>>
     GetAllGroupChunks(milvus::OpContext* op_ctx) {
         auto ca = SemiInlineGet(slot_->PinAllCells(op_ctx));
@@ -301,6 +308,15 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
     PrefetchChunks(milvus::OpContext* op_ctx,
                    const std::vector<int64_t>& chunk_ids) const override {
         group_->GetGroupChunks(op_ctx, chunk_ids);
+    }
+
+    bool
+    CellsLoaded(const int64_t* offsets, int64_t count) const override {
+        if (count == 0) {
+            return true;
+        }
+        auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
+        return group_->CellsLoaded(cids);
     }
 
     PinWrapper<SpanBase>

--- a/internal/core/src/mmap/ChunkedColumnInterface.h
+++ b/internal/core/src/mmap/ChunkedColumnInterface.h
@@ -93,6 +93,9 @@ class ChunkedColumnInterface {
     PrefetchChunks(milvus::OpContext* op_ctx,
                    const std::vector<int64_t>& chunk_ids) const = 0;
 
+    virtual bool
+    CellsLoaded(const int64_t* offsets, int64_t count) const = 0;
+
     virtual PinWrapper<
         std::pair<std::vector<std::string_view>, FixedVector<bool>>>
     StringViews(milvus::OpContext* op_ctx,

--- a/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
+++ b/internal/core/src/mmap/ChunkedColumnInterfaceTest.cpp
@@ -386,6 +386,41 @@ TYPED_TEST(ChunkedColumnInterfaceTest, BuildValidRowIdsBuildsFullMapping) {
     EXPECT_EQ(m.GetPhysicalOffset(11), 6);
 }
 
+TYPED_TEST(ChunkedColumnInterfaceTest, CellsLoadedDoesNotFetchCells) {
+    ColumnSpec spec{{5, 3, 4}, {}, /*nullable=*/false};
+    auto fx = TypeParam::Create(spec);
+
+    const int64_t offsets[] = {0, 6};
+
+    EXPECT_FALSE(fx.column->CellsLoaded(offsets, std::size(offsets)));
+    EXPECT_TRUE(fx.fetched->empty());
+}
+
+TYPED_TEST(ChunkedColumnInterfaceTest, CellsLoadedTracksFetchedCells) {
+    ColumnSpec spec{{5, 3, 4}, {}, /*nullable=*/false};
+    auto fx = TypeParam::Create(spec);
+
+    const int64_t chunk0_offsets[] = {0, 4};
+    const int64_t chunk1_offsets[] = {6};
+    const int64_t mixed_offsets[] = {0, 6};
+
+    std::vector<int32_t> values(std::size(chunk1_offsets));
+    fx.column->BulkVectorValueAt(nullptr,
+                                 values.data(),
+                                 chunk1_offsets,
+                                 kElementSize,
+                                 std::size(chunk1_offsets));
+
+    EXPECT_TRUE(
+        fx.column->CellsLoaded(chunk1_offsets, std::size(chunk1_offsets)));
+    EXPECT_FALSE(
+        fx.column->CellsLoaded(chunk0_offsets, std::size(chunk0_offsets)));
+    EXPECT_FALSE(
+        fx.column->CellsLoaded(mixed_offsets, std::size(mixed_offsets)));
+    EXPECT_EQ(fx.fetched->size(), 1u);
+    EXPECT_EQ(fx.fetched->count(1), 1u);
+}
+
 TYPED_TEST(ChunkedColumnInterfaceTest, BuildValidRowIdsNonNullableIsNoop) {
     ColumnSpec spec{{5, 5}, {}, /*nullable=*/false};
     auto fx = TypeParam::Create(spec);

--- a/internal/core/src/mmap/VirtualPKChunkedColumn.h
+++ b/internal/core/src/mmap/VirtualPKChunkedColumn.h
@@ -109,6 +109,21 @@ class VirtualPKChunkedColumn : public ChunkedColumnInterface {
         // No-op - no data to prefetch
     }
 
+    bool
+    CellsLoaded(const int64_t* offsets, int64_t count) const override {
+        if (count == 0) {
+            return true;
+        }
+        AssertInfo(offsets != nullptr, "Offsets cannot be nullptr");
+        for (int64_t i = 0; i < count; i++) {
+            AssertInfo(offsets[i] >= 0 && offsets[i] < num_rows_,
+                       "offset {} is out of range, num_rows: {}",
+                       offsets[i],
+                       num_rows_);
+        }
+        return true;
+    }
+
     PinWrapper<std::pair<std::vector<std::string_view>, FixedVector<bool>>>
     StringViews(milvus::OpContext* op_ctx,
                 int64_t chunk_id,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -150,6 +150,14 @@
 namespace milvus::segcore {
 using namespace milvus::cachinglayer;
 
+static void
+CheckVectorOutputCellsLoaded(int64_t segment_id,
+                             FieldId field_id,
+                             const FieldMeta& field_meta,
+                             const ChunkedColumnInterface* column,
+                             const int64_t* offsets,
+                             int64_t count);
+
 static inline void
 set_bit(BitsetType& bitset, FieldId field_id, bool flag = true) {
     auto pos = field_id.get() - START_USER_FIELDID;
@@ -1808,6 +1816,8 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
             if (!vec_index->HasValidData()) {
                 auto column = get_column(field_id);
                 if (column != nullptr) {
+                    CheckVectorOutputCellsLoaded(
+                        id_, field_id, field_meta, column.get(), ids, count);
                     return get_raw_data(
                         op_ctx, field_id, field_meta, ids, count);
                 }
@@ -1875,6 +1885,12 @@ ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
         if (!vec_index->HasValidData()) {
             auto column = get_column(field_id);
             if (column != nullptr) {
+                CheckVectorOutputCellsLoaded(id_,
+                                             field_id,
+                                             field_meta,
+                                             column.get(),
+                                             seg_offsets,
+                                             count);
                 return get_raw_data(
                     op_ctx, field_id, field_meta, seg_offsets, count);
             }
@@ -3566,7 +3582,6 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
     AssertInfo(column != nullptr,
                "field {} must exist when getting raw data",
                field_id.get());
-
     int64_t valid_count = count;
     const bool* valid_data = nullptr;
     const int64_t* valid_offsets = seg_offsets;
@@ -3942,6 +3957,17 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
             vector = get_vector(op_ctx, field_id, seg_offsets, count);
         }
     } else {
+        // retrieve data from column data instead of index
+        // we could reject remote vector output if the vector is not loaded in local cache
+        // for performance needs
+        if (SegcoreConfig::default_config().get_reject_remote_vector_output()) {
+            auto column = get_column(field_id);
+            AssertInfo(column != nullptr,
+                       "field {} must exist when getting raw data",
+                       field_id.get());
+            CheckVectorOutputCellsLoaded(
+                id_, field_id, field_meta, column.get(), seg_offsets, count);
+        }
         vector = get_raw_data(op_ctx, field_id, field_meta, seg_offsets, count);
     }
 
@@ -5834,6 +5860,32 @@ ShouldProjectInternalTakeDynamicField(
     }
     auto dynamic_field_id = schema.get_dynamic_field_id();
     return dynamic_field_id.has_value() && dynamic_field_id.value() == field_id;
+}
+
+static void
+CheckVectorOutputCellsLoaded(int64_t segment_id,
+                             FieldId field_id,
+                             const FieldMeta& field_meta,
+                             const ChunkedColumnInterface* column,
+                             const int64_t* offsets,
+                             int64_t count) {
+    if (!SegcoreConfig::default_config().get_reject_remote_vector_output() ||
+        !IsVectorDataType(field_meta.get_data_type()) || count == 0) {
+        return;
+    }
+    if (column == nullptr || !column->CellsLoaded(offsets, count)) {
+        ThrowInfo(
+            FieldNotLoaded,
+            "vector field '{}' not loaded in local cache for "
+            "output, segment id={}, please notice that vector field is by "
+            "default resident in remote storage starting from milvus 3.0 to "
+            "reduce local storage overhead, but performance will be degraded, "
+            "you could manually set vector field warmup policy to 'sync' to "
+            "load the vector data, please refer to "
+            "https://milvus.io/docs/warm-up.md for more details",
+            field_meta.get_name().get(),
+            segment_id);
+    }
 }
 
 ChunkedSegmentSealedImpl::TakeContext

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5875,8 +5875,8 @@ CheckVectorOutputCellsLoaded(int64_t segment_id,
     }
     if (column == nullptr || !column->CellsLoaded(offsets, count)) {
         ThrowInfo(
-            FieldNotLoaded,
-            "vector field '{}' not loaded in local cache for "
+            RetrieveError,
+            "vector field '{}' is not loaded in local cache for "
             "output, segment id={}, please notice that vector field is by "
             "default resident in remote storage starting from milvus 3.0 to "
             "reduce local storage overhead, but performance will be degraded, "
@@ -6344,6 +6344,7 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
     auto needed_columns = std::make_shared<std::vector<std::string>>();
     std::vector<FieldId> take_field_ids;
     std::vector<std::string> take_column_names;
+    bool has_vector_output = false;
     for (auto field_id : plan->field_ids_) {
         if (SystemProperty::Instance().IsSystem(field_id)) {
             continue;
@@ -6356,6 +6357,8 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
             !schema_->IsExternalManifestStoredField(field_id)) {
             continue;
         }
+        has_vector_output =
+            has_vector_output || IsVectorDataType(field_meta.get_data_type());
         auto column_name = schema_->GetPhysicalColumnName(field_id);
         needed_columns->push_back(column_name);
         take_field_ids.push_back(field_id);
@@ -6366,6 +6369,16 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
     }
 
     auto ctx = BuildTakeContext(offsets, size);
+    if (SegcoreConfig::default_config().get_reject_remote_vector_output() &&
+        has_vector_output) {
+        LogTakeFallback("retrieve",
+                        id_,
+                        size,
+                        ctx.unique_offsets.size(),
+                        take_field_ids.size(),
+                        "reject remote vector output enabled");
+        return false;
+    }
 
     double take_elapsed_ms = 0;
     auto table = ExecuteTake(ctx.unique_offsets,
@@ -6613,12 +6626,15 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
     std::vector<FieldId> take_field_ids;
     std::vector<const FieldMeta*> take_field_metas;
     std::vector<std::string> take_column_names;
+    bool has_vector_output = false;
     for (auto field_id : plan->target_entries_) {
         auto& field_meta = schema_->operator[](field_id);
         if (is_external_collection &&
             !schema_->IsExternalManifestStoredField(field_id)) {
             continue;
         }
+        has_vector_output =
+            has_vector_output || IsVectorDataType(field_meta.get_data_type());
         auto column_name = schema_->GetPhysicalColumnName(field_id);
         needed_columns->push_back(column_name);
         take_field_ids.push_back(field_id);
@@ -6630,6 +6646,16 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
     }
 
     auto ctx = BuildTakeContext(seg_offsets, size);
+    if (SegcoreConfig::default_config().get_reject_remote_vector_output() &&
+        has_vector_output) {
+        LogTakeFallback("search",
+                        id_,
+                        size,
+                        ctx.unique_offsets.size(),
+                        take_field_ids.size(),
+                        "reject remote vector output enabled");
+        return false;
+    }
 
     double take_elapsed_ms = 0;
     auto table = ExecuteTake(

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -64,6 +64,7 @@
 #include "pb/schema.pb.h"
 #include "plan/PlanNode.h"
 #include "query/ExecPlanNodeVisitor.h"
+#include "query/PlanImpl.h"
 #include "query/SearchOnSealed.h"
 #include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/SegcoreConfig.h"
@@ -94,6 +95,53 @@ struct DeferRelease {
 };
 
 using namespace milvus;
+
+namespace {
+
+class ScopedRejectRemoteVectorOutput {
+ public:
+    explicit ScopedRejectRemoteVectorOutput(bool enabled)
+        : old_value_(segcore::SegcoreConfig::default_config()
+                         .get_reject_remote_vector_output()) {
+        segcore::SegcoreConfig::default_config()
+            .set_reject_remote_vector_output(enabled);
+    }
+
+    ~ScopedRejectRemoteVectorOutput() {
+        segcore::SegcoreConfig::default_config()
+            .set_reject_remote_vector_output(old_value_);
+    }
+
+ private:
+    bool old_value_;
+};
+
+SearchResult
+MakeSearchResult(std::vector<int64_t> offsets) {
+    SearchResult result;
+    result.seg_offsets_ = std::move(offsets);
+    result.distances_.resize(result.seg_offsets_.size(), 0.0F);
+    return result;
+}
+
+segcore::SegmentSealedUPtr
+CreateColdVectorOutputSegment(const SchemaPtr& schema,
+                              const FieldId& vector_field_id,
+                              int64_t row_count) {
+    auto dataset = segcore::DataGen(schema, row_count);
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareInsertBinlog(
+        kCollectionID, kPartitionID, kSegmentID, dataset, cm);
+    load_info.field_infos.at(vector_field_id.get()).warmup_policy = "disable";
+
+    auto segment = segcore::CreateSealedSegment(schema);
+    segment->LoadFieldData(load_info);
+    return segment;
+}
+
+}  // namespace
+
 TEST(test_chunk_segment, TestSearchOnSealed) {
     int dim = 16;
     int chunk_num = 3;
@@ -208,6 +256,119 @@ TEST(test_chunk_segment, TestSearchOnSealed) {
     ASSERT_EQ(total_row_count, offsets.size());
     for (int i = 0; i < total_row_count; i++) {
         ASSERT_TRUE(offsets.find(i) != offsets.end());
+    }
+}
+
+TEST(test_chunk_segment, RejectRemoteVectorOutputFailsWhenVectorCellsAreCold) {
+    constexpr int64_t row_count = 16;
+    constexpr int64_t dim = 4;
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    auto vector_id = schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_id);
+
+    auto segment = CreateColdVectorOutputSegment(schema, vector_id, row_count);
+    auto* chunked =
+        dynamic_cast<segcore::ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(chunked, nullptr);
+
+    query::Plan plan(schema);
+    plan.target_entries_ = {vector_id};
+    auto result = MakeSearchResult({0, 3, 7});
+
+    ScopedRejectRemoteVectorOutput scoped_config(true);
+
+    try {
+        chunked->TestFillTargetEntry(&plan, result);
+        FAIL() << "expected cold vector output to be rejected";
+    } catch (const SegcoreError& err) {
+        EXPECT_EQ(err.get_error_code(), FieldNotLoaded);
+        EXPECT_NE(std::string(err.what()).find("vector field"),
+                  std::string::npos);
+    }
+}
+
+TEST(test_chunk_segment,
+     RejectRemoteVectorOutputFailsForRetrieveWhenVectorCellsAreCold) {
+    constexpr int64_t row_count = 16;
+    constexpr int64_t dim = 4;
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    auto vector_id = schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_id);
+
+    auto segment = CreateColdVectorOutputSegment(schema, vector_id, row_count);
+    auto* chunked =
+        dynamic_cast<segcore::ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(chunked, nullptr);
+
+    query::RetrievePlan plan(schema);
+    plan.field_ids_ = {vector_id};
+    const int64_t offsets[] = {0, 3, 7};
+
+    ScopedRejectRemoteVectorOutput scoped_config(true);
+
+    try {
+        auto results = chunked->Retrieve(
+            nullptr,
+            &plan,
+            offsets,
+            static_cast<int64_t>(sizeof(offsets) / sizeof(offsets[0])),
+            folly::CancellationToken());
+        (void)results;
+        FAIL() << "expected cold vector output to be rejected";
+    } catch (const SegcoreError& err) {
+        EXPECT_EQ(err.get_error_code(), FieldNotLoaded);
+        EXPECT_NE(std::string(err.what()).find("vector field"),
+                  std::string::npos);
+    }
+}
+
+TEST(test_chunk_segment,
+     RejectRemoteVectorOutputAllowsScalarAndDisabledConfig) {
+    constexpr int64_t row_count = 16;
+    constexpr int64_t dim = 4;
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("pk", DataType::INT64);
+    auto scalar_id = schema->AddDebugField("scalar", DataType::INT64);
+    auto vector_id = schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, dim, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_id);
+
+    {
+        auto segment =
+            CreateColdVectorOutputSegment(schema, vector_id, row_count);
+        auto* chunked =
+            dynamic_cast<segcore::ChunkedSegmentSealedImpl*>(segment.get());
+        ASSERT_NE(chunked, nullptr);
+
+        query::Plan scalar_plan(schema);
+        scalar_plan.target_entries_ = {scalar_id};
+        auto scalar_result = MakeSearchResult({1, 2, 5});
+
+        ScopedRejectRemoteVectorOutput scoped_config(true);
+        ASSERT_NO_THROW(
+            chunked->TestFillTargetEntry(&scalar_plan, scalar_result));
+        ASSERT_EQ(scalar_result.output_fields_data_.count(scalar_id), 1);
+    }
+
+    {
+        auto segment =
+            CreateColdVectorOutputSegment(schema, vector_id, row_count);
+        auto* chunked =
+            dynamic_cast<segcore::ChunkedSegmentSealedImpl*>(segment.get());
+        ASSERT_NE(chunked, nullptr);
+
+        query::Plan vector_plan(schema);
+        vector_plan.target_entries_ = {vector_id};
+        auto vector_result = MakeSearchResult({1, 2, 5});
+
+        ScopedRejectRemoteVectorOutput scoped_config(false);
+        ASSERT_NO_THROW(
+            chunked->TestFillTargetEntry(&vector_plan, vector_result));
+        ASSERT_EQ(vector_result.output_fields_data_.count(vector_id), 1);
     }
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -283,7 +283,7 @@ TEST(test_chunk_segment, RejectRemoteVectorOutputFailsWhenVectorCellsAreCold) {
         chunked->TestFillTargetEntry(&plan, result);
         FAIL() << "expected cold vector output to be rejected";
     } catch (const SegcoreError& err) {
-        EXPECT_EQ(err.get_error_code(), FieldNotLoaded);
+        EXPECT_EQ(err.get_error_code(), RetrieveError);
         EXPECT_NE(std::string(err.what()).find("vector field"),
                   std::string::npos);
     }
@@ -320,7 +320,7 @@ TEST(test_chunk_segment,
         (void)results;
         FAIL() << "expected cold vector output to be rejected";
     } catch (const SegcoreError& err) {
-        EXPECT_EQ(err.get_error_code(), FieldNotLoaded);
+        EXPECT_EQ(err.get_error_code(), RetrieveError);
         EXPECT_NE(std::string(err.what()).find("vector field"),
                   std::string::npos);
     }

--- a/internal/core/src/segcore/SegcoreConfig.h
+++ b/internal/core/src/segcore/SegcoreConfig.h
@@ -196,6 +196,16 @@ class SegcoreConfig {
         return prefer_field_data_when_index_has_raw_data_;
     }
 
+    void
+    set_reject_remote_vector_output(bool value) {
+        reject_remote_vector_output_ = value;
+    }
+
+    bool
+    get_reject_remote_vector_output() const {
+        return reject_remote_vector_output_;
+    }
+
     static constexpr int64_t kDefaultMaxGroupByGroups = 100000;
 
     int64_t
@@ -241,6 +251,7 @@ class SegcoreConfig {
     inline static bool enable_geometry_cache_ = false;
     inline static bool visibility_filter_enabled_ = true;
     inline static bool prefer_field_data_when_index_has_raw_data_ = false;
+    inline static bool reject_remote_vector_output_ = false;
     inline static float interim_index_mem_expansion_rate_ = 1.15f;
     inline static int64_t max_group_by_groups_ = kDefaultMaxGroupByGroups;
 };

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -265,6 +265,7 @@ ConfigureTieredStorage(const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
                        const char* disk_path,
                        const int64_t loading_timeout_ms,
                        const int64_t warmup_loading_timeout_ms,
+                       const bool reject_remote_vector_output,
                        const uint32_t prefetch_pool_threads) {
     std::string disk_path_str(disk_path);
     milvus::cachinglayer::Manager::ConfigureTieredStorage(
@@ -291,6 +292,8 @@ ConfigureTieredStorage(const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
         std::chrono::milliseconds(loading_timeout_ms),
         std::chrono::milliseconds(warmup_loading_timeout_ms),
         prefetch_pool_threads);
+    milvus::segcore::SegcoreConfig::default_config()
+        .set_reject_remote_vector_output(reject_remote_vector_output);
 }
 
 extern "C" void
@@ -298,6 +301,7 @@ UpdateTieredStorageConfig(
     const int64_t loading_timeout_ms,
     const int64_t warmup_loading_timeout_ms,
     const bool storage_usage_tracking_enabled,
+    const bool reject_remote_vector_output,
     const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
     const CacheWarmupPolicy vectorFieldCacheWarmupPolicy,
     const CacheWarmupPolicy scalarIndexCacheWarmupPolicy,
@@ -310,6 +314,8 @@ UpdateTieredStorageConfig(
          vectorFieldCacheWarmupPolicy,
          scalarIndexCacheWarmupPolicy,
          vectorIndexCacheWarmupPolicy});
+    milvus::segcore::SegcoreConfig::default_config()
+        .set_reject_remote_vector_output(reject_remote_vector_output);
 }
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -141,6 +141,7 @@ ConfigureTieredStorage(
     const char* disk_path,
     const int64_t loading_timeout_ms,
     const int64_t warmup_loading_timeout_ms,
+    const bool reject_remote_vector_output,
     // async warmup prefetch pool threads
     const uint32_t prefetch_pool_threads);
 
@@ -148,6 +149,7 @@ void
 UpdateTieredStorageConfig(const int64_t loading_timeout_ms,
                           const int64_t warmup_loading_timeout_ms,
                           const bool storage_usage_tracking_enabled,
+                          const bool reject_remote_vector_output,
                           const CacheWarmupPolicy scalarFieldCacheWarmupPolicy,
                           const CacheWarmupPolicy vectorFieldCacheWarmupPolicy,
                           const CacheWarmupPolicy scalarIndexCacheWarmupPolicy,

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -52,6 +52,24 @@ constexpr int64_t kTestRows = 5;
 constexpr int64_t kVecDim = 4;
 constexpr int64_t kBinaryVecDim = 16;
 
+class ScopedRejectRemoteVectorOutput {
+ public:
+    explicit ScopedRejectRemoteVectorOutput(bool enabled)
+        : old_value_(SegcoreConfig::default_config()
+                         .get_reject_remote_vector_output()) {
+        SegcoreConfig::default_config().set_reject_remote_vector_output(
+            enabled);
+    }
+
+    ~ScopedRejectRemoteVectorOutput() {
+        SegcoreConfig::default_config().set_reject_remote_vector_output(
+            old_value_);
+    }
+
+ private:
+    bool old_value_;
+};
+
 std::string
 BuildDenseVectorBytes(int row, int byte_width, int seed) {
     std::string bytes(byte_width, '\0');
@@ -2416,6 +2434,36 @@ TEST(ExternalTakeAccessMode, RetrieveEnabledUsesTake) {
     EXPECT_EQ(results->fields_data(0).scalars().long_data().data_size(), size);
 }
 
+TEST(ExternalTakeAccessMode, RetrieveRejectRemoteVectorOutputReturnsFalse) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    auto table = BuildTestArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {vec_id};
+
+    ScopedRejectRemoteVectorOutput scoped_config(true);
+
+    auto results = std::make_unique<proto::segcore::RetrieveResults>();
+    std::vector<int64_t> offsets = {0, 1, 2};
+    bool ok = segment->TryTakeForRetrieve(
+        plan.get(), results, offsets.data(), offsets.size(), false, false);
+    EXPECT_FALSE(ok);
+    EXPECT_EQ(results->fields_data_size(), 0);
+}
+
 // use_take_for_output=false: TryTakeForSearch returns false
 TEST(ExternalTakeAccessMode, SearchDisabledReturnsFalse) {
     auto [schema,
@@ -2476,6 +2524,36 @@ TEST(ExternalTakeAccessMode, SearchEnabledUsesTake) {
     EXPECT_EQ(int64_arr->scalars().long_data().data(0), 0);
     EXPECT_EQ(int64_arr->scalars().long_data().data(1), 20000);
     EXPECT_EQ(int64_arr->scalars().long_data().data(2), 40000);
+}
+
+TEST(ExternalTakeAccessMode, SearchRejectRemoteVectorOutputReturnsFalse) {
+    auto [schema,
+          bool_id,
+          int8_id,
+          int16_id,
+          int32_id,
+          int64_id,
+          float_id,
+          double_id,
+          varchar_id,
+          vec_id] = BuildExternalSchema();
+    auto table = BuildTestArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, schema);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table));
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::Plan>(schema);
+    plan->target_entries_ = {vec_id};
+
+    ScopedRejectRemoteVectorOutput scoped_config(true);
+
+    SearchResult results;
+    std::vector<int64_t> offsets = {0, 2, 4};
+    bool ok = segment->TestTryTakeForSearch(
+        plan.get(), offsets.data(), offsets.size(), results);
+    EXPECT_FALSE(ok);
+    EXPECT_TRUE(results.output_fields_data_.empty());
 }
 
 // NormalizeVectorArraysToFixedSizeBinary tests are skipped in this file

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -392,6 +392,7 @@ func InitTieredStorage(params *paramtable.ComponentParam) error {
 	loadingResourceFactor := C.float(params.QueryNodeCfg.TieredLoadingResourceFactor.GetAsFloat())
 	loadingTimeoutMs := C.int64_t(params.QueryNodeCfg.TieredLoadingTimeoutMs.GetAsInt64())
 	warmupLoadingTimeoutMs := C.int64_t(params.QueryNodeCfg.TieredWarmupLoadingTimeoutMs.GetAsInt64())
+	rejectRemoteVectorOutput := C.bool(params.QueryNodeCfg.TieredRejectRemoteVectorOutput.GetAsBool())
 	overloadedMemoryThresholdPercentage := C.float(memoryMaxRatio)
 	maxDiskUsagePercentage := C.float(diskMaxRatio)
 	diskPath := C.CString(params.LocalStorageCfg.Path.GetValue())
@@ -409,7 +410,7 @@ func InitTieredStorage(params *paramtable.ComponentParam) error {
 		evictionEnabled, cacheTouchWindowMs,
 		backgroundEvictionEnabled, evictionIntervalMs, cacheCellUnaccessedSurvivalTime,
 		overloadedMemoryThresholdPercentage, loadingResourceFactor, maxDiskUsagePercentage, diskPath,
-		loadingTimeoutMs, warmupLoadingTimeoutMs, prefetchPoolThreads)
+		loadingTimeoutMs, warmupLoadingTimeoutMs, rejectRemoteVectorOutput, prefetchPoolThreads)
 
 	tieredEvictableMemoryCacheRatio := params.QueryNodeCfg.TieredEvictableMemoryCacheRatio.GetAsFloat()
 	tieredEvictableDiskCacheRatio := params.QueryNodeCfg.TieredEvictableDiskCacheRatio.GetAsFloat()
@@ -453,11 +454,13 @@ func UpdateTieredStorageConfig(params *paramtable.ComponentParam) error {
 	loadingTimeoutMs := C.int64_t(params.QueryNodeCfg.TieredLoadingTimeoutMs.GetAsInt64())
 	warmupLoadingTimeoutMs := C.int64_t(params.QueryNodeCfg.TieredWarmupLoadingTimeoutMs.GetAsInt64())
 	storageUsageTrackingEnabled := C.bool(params.QueryNodeCfg.StorageUsageTrackingEnabled.GetAsBool())
+	rejectRemoteVectorOutput := C.bool(params.QueryNodeCfg.TieredRejectRemoteVectorOutput.GetAsBool())
 
 	C.UpdateTieredStorageConfig(
 		loadingTimeoutMs,
 		warmupLoadingTimeoutMs,
 		storageUsageTrackingEnabled,
+		rejectRemoteVectorOutput,
 		scalarFieldCacheWarmupPolicy,
 		vectorFieldCacheWarmupPolicy,
 		scalarIndexCacheWarmupPolicy,
@@ -692,6 +695,7 @@ func SetupCoreConfigChangelCallback() {
 		paramtable.Get().QueryNodeCfg.TieredLoadingTimeoutMs.RegisterCallback(updateTieredStorageConfigCallback)
 		paramtable.Get().QueryNodeCfg.TieredWarmupLoadingTimeoutMs.RegisterCallback(updateTieredStorageConfigCallback)
 		paramtable.Get().QueryNodeCfg.StorageUsageTrackingEnabled.RegisterCallback(updateTieredStorageConfigCallback)
+		paramtable.Get().QueryNodeCfg.TieredRejectRemoteVectorOutput.RegisterCallback(updateTieredStorageConfigCallback)
 		paramtable.Get().QueryNodeCfg.TieredWarmupScalarField.RegisterCallback(updateTieredStorageConfigCallback)
 		paramtable.Get().QueryNodeCfg.TieredWarmupVectorField.RegisterCallback(updateTieredStorageConfigCallback)
 		paramtable.Get().QueryNodeCfg.TieredWarmupScalarIndex.RegisterCallback(updateTieredStorageConfigCallback)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4048,7 +4048,7 @@ If set to 0, time based eviction is disabled.`,
 
 	p.TieredRejectRemoteVectorOutput = ParamItem{
 		Key:          "queryNode.segcore.tieredStorage.rejectRemoteVectorOutput",
-		Version:      "2.6.14",
+		Version:      "3.0.0",
 		DefaultValue: "false",
 		Doc:          "When true, search/query fails instead of loading remote vector field data for output fields that are not already cached in local memory or disk.",
 		Export:       false,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3587,6 +3587,7 @@ type queryNodeConfig struct {
 	TieredLoadingTimeoutMs          ParamItem `refreshable:"true"`
 	TieredWarmupLoadingTimeoutMs    ParamItem `refreshable:"true"`
 	StorageUsageTrackingEnabled     ParamItem `refreshable:"true"`
+	TieredRejectRemoteVectorOutput  ParamItem `refreshable:"true"`
 
 	KnowhereScoreConsistency ParamItem `refreshable:"false"`
 
@@ -4044,6 +4045,15 @@ If set to 0, time based eviction is disabled.`,
 		Export:       true,
 	}
 	p.StorageUsageTrackingEnabled.Init(base.mgr)
+
+	p.TieredRejectRemoteVectorOutput = ParamItem{
+		Key:          "queryNode.segcore.tieredStorage.rejectRemoteVectorOutput",
+		Version:      "2.6.14",
+		DefaultValue: "false",
+		Doc:          "When true, search/query fails instead of loading remote vector field data for output fields that are not already cached in local memory or disk.",
+		Export:       false,
+	}
+	p.TieredRejectRemoteVectorOutput.Init(base.mgr)
 
 	p.TieredLoadingResourceFactor = ParamItem{
 		Key:          "queryNode.segcore.tieredStorage.loadingResourceFactor",


### PR DESCRIPTION
## Summary
- add a hidden query node config to reject vector output fields that are not already cached locally
- add cache-cell locality checks for chunked sealed vector output materialization
- cover search/retrieve rejection and non-fetching CellsLoaded behavior

issue: #50820


