### PR TITLE
enhance: cache segment index load resources

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -493,16 +493,21 @@ ChunkedSegmentSealedImpl::LoadVecIndex(LoadIndexInfo& info, bool is_replace) {
         info.field_id,
         id_);
     auto& field_meta = schema_->operator[](field_id);
-    LoadResourceRequest request =
-        milvus::index::IndexFactory::GetInstance().VecIndexLoadResource(
-            field_meta.get_data_type(),
-            info.element_type,
-            info.index_engine_version,
-            info.index_size,
-            info.index_params,
-            info.enable_mmap,
-            info.num_rows,
-            info.dim);
+    LoadResourceRequest request{};
+    if (info.load_resource_request.has_value()) {
+        request = *info.load_resource_request;
+    } else {
+        request =
+            milvus::index::IndexFactory::GetInstance().VecIndexLoadResource(
+                field_meta.get_data_type(),
+                info.element_type,
+                info.index_engine_version,
+                info.index_size,
+                info.index_params,
+                info.enable_mmap,
+                info.num_rows,
+                info.dim);
+    }
 
     // Note: raw data lifecycle (eviction/drop) is handled by LoadDiff + ApplyLoadDiff,
     // not here. This avoids unsafe ManualEvictCache on column groups.
@@ -600,14 +605,19 @@ ChunkedSegmentSealedImpl::LoadScalarIndex(LoadIndexInfo& info,
             {field_id, std::move(info.cache_index)});
     }
 
-    LoadResourceRequest request =
-        milvus::index::IndexFactory::GetInstance().ScalarIndexLoadResource(
-            field_meta.get_data_type(),
-            info.index_engine_version,
-            info.index_size,
-            info.index_params,
-            info.enable_mmap,
-            num_rows_.value_or(0));
+    LoadResourceRequest request{};
+    if (info.load_resource_request.has_value()) {
+        request = *info.load_resource_request;
+    } else {
+        request =
+            milvus::index::IndexFactory::GetInstance().ScalarIndexLoadResource(
+                field_meta.get_data_type(),
+                info.index_engine_version,
+                info.index_size,
+                info.index_params,
+                info.enable_mmap,
+                num_rows_.value_or(0));
+    }
 
     set_bit(index_ready_bitset_, field_id, true);
     index_has_raw_data_[field_id] = request.has_raw_data;

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -143,17 +143,21 @@ SegmentLoadInfo::ConvertFieldIndexInfoToLoadIndexInfo(
 
 bool
 SegmentLoadInfo::CheckIndexHasRawData(const LoadIndexInfo& load_index_info) {
-    auto request = milvus::index::IndexFactory::GetInstance().IndexLoadResource(
-        load_index_info.field_type,
-        load_index_info.element_type,
-        load_index_info.index_engine_version,
-        load_index_info.index_size,
-        load_index_info.index_params,
-        load_index_info.enable_mmap,
-        load_index_info.num_rows,
-        load_index_info.dim);
-
-    return request.has_raw_data;
+    if (load_index_info.load_resource_request.has_value()) {
+        return load_index_info.load_resource_request->has_raw_data;
+    } else {
+        auto request =
+            milvus::index::IndexFactory::GetInstance().IndexLoadResource(
+                load_index_info.field_type,
+                load_index_info.element_type,
+                load_index_info.index_engine_version,
+                load_index_info.index_size,
+                load_index_info.index_params,
+                load_index_info.enable_mmap,
+                load_index_info.num_rows,
+                load_index_info.dim);
+        return request.has_raw_data;
+    }
 }
 
 std::shared_ptr<proto::indexcgo::LoadTextIndexInfo>

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -30,6 +30,8 @@
 #include "common/Schema.h"
 #include "common/Types.h"
 #include "common/protobuf_utils.h"
+#include "index/IndexFactory.h"
+#include "index/Meta.h"
 #include "milvus-storage/column_groups.h"
 #include "pb/common.pb.h"
 #include "pb/index_cgo_msg.pb.h"
@@ -1096,6 +1098,24 @@ class SegmentLoadInfo {
             }
             auto load_index_info = ConvertFieldIndexInfoToLoadIndexInfo(
                 &index_info, info_.segmentid());
+            auto index_type_it =
+                load_index_info.index_params.find(milvus::index::INDEX_TYPE);
+            auto needs_file_context =
+                !IsVectorDataType(load_index_info.field_type) &&
+                index_type_it != load_index_info.index_params.end() &&
+                index_type_it->second == milvus::index::HYBRID_INDEX_TYPE;
+            if (!needs_file_context) {
+                load_index_info.load_resource_request =
+                    milvus::index::IndexFactory::GetInstance()
+                        .IndexLoadResource(load_index_info.field_type,
+                                           load_index_info.element_type,
+                                           load_index_info.index_engine_version,
+                                           load_index_info.index_size,
+                                           load_index_info.index_params,
+                                           load_index_info.enable_mmap,
+                                           load_index_info.num_rows,
+                                           load_index_info.dim);
+            }
             converted_index_infos_.push_back(load_index_info);
             // Check if index has raw data before moving
             if (CheckIndexHasRawData(load_index_info)) {

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -286,6 +286,38 @@ TEST_F(SegmentLoadInfoTest,
                   INDEX_STORE_PATH_VERSION_COLLECTION_ROOTED);
 }
 
+TEST_F(SegmentLoadInfoTest, BuildCacheSkipsHybridScalarResourceEstimate) {
+    proto::segcore::SegmentLoadInfo proto;
+    proto.set_segmentid(100);
+    proto.set_num_of_rows(1000);
+
+    auto* hybrid_index = proto.add_index_infos();
+    hybrid_index->set_fieldid(108);
+    hybrid_index->set_indexid(5001);
+    hybrid_index->add_index_file_paths("/path/to/hybrid_index");
+    auto* hybrid_param = hybrid_index->add_index_params();
+    hybrid_param->set_key(milvus::index::INDEX_TYPE);
+    hybrid_param->set_value(milvus::index::HYBRID_INDEX_TYPE);
+
+    auto* inverted_index = proto.add_index_infos();
+    inverted_index->set_fieldid(109);
+    inverted_index->set_indexid(5002);
+    inverted_index->add_index_file_paths("/path/to/inverted_index");
+    auto* inverted_param = inverted_index->add_index_params();
+    inverted_param->set_key(milvus::index::INDEX_TYPE);
+    inverted_param->set_value(milvus::index::INVERTED_INDEX_TYPE);
+
+    SegmentLoadInfo segment_info(proto, schema_);
+
+    auto hybrid_infos = segment_info.GetFieldIndexInfos(FieldId(108));
+    ASSERT_EQ(hybrid_infos.size(), 1);
+    EXPECT_FALSE(hybrid_infos[0].load_resource_request.has_value());
+
+    auto inverted_infos = segment_info.GetFieldIndexInfos(FieldId(109));
+    ASSERT_EQ(inverted_infos.size(), 1);
+    EXPECT_TRUE(inverted_infos[0].load_resource_request.has_value());
+}
+
 TEST_F(SegmentLoadInfoTest, BinlogInfo) {
     SegmentLoadInfo info(proto_, schema_);
 

--- a/internal/core/src/segcore/Types.h
+++ b/internal/core/src/segcore/Types.h
@@ -18,9 +18,11 @@
 
 #include <iostream>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
+#include "common/resource_c.h"
 #include "common/Types.h"
 #include "common/type_c.h"
 #include "index/Index.h"
@@ -61,6 +63,7 @@ struct LoadIndexInfo {
     int64_t dim;
     std::string
         warmup_policy;  // "disable", "sync", or "async"; empty means use global config
+    std::optional<LoadResourceRequest> load_resource_request;
 
     // Default constructor
     LoadIndexInfo() = default;
@@ -95,7 +98,8 @@ struct LoadIndexInfo {
           index_size(other.index_size),
           num_rows(other.num_rows),
           dim(other.dim),
-          warmup_policy(other.warmup_policy) {
+          warmup_policy(other.warmup_policy),
+          load_resource_request(other.load_resource_request) {
     }
 
     // Copy assignment operator
@@ -125,6 +129,7 @@ struct LoadIndexInfo {
             num_rows = other.num_rows;
             dim = other.dim;
             warmup_policy = other.warmup_policy;
+            load_resource_request = other.load_resource_request;
         }
         return *this;
     }

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.cpp
@@ -47,7 +47,8 @@ SealedIndexTranslator::SealedIndexTranslator(
                         load_index_info->num_rows,
                         load_index_info->dim,
                         load_index_info->index_files,
-                        load_index_info->warmup_policy}),
+                        load_index_info->warmup_policy,
+                        load_index_info->load_resource_request}),
       meta_(
           load_index_info->enable_mmap
               ? milvus::cachinglayer::StorageType::DISK
@@ -93,6 +94,9 @@ SealedIndexTranslator::SealedIndexTranslator(
 
 LoadResourceRequest
 SealedIndexTranslator::EstimateLoadResource() const {
+    if (index_load_info_.load_resource_request.has_value()) {
+        return *index_load_info_.load_resource_request;
+    }
     return milvus::index::IndexFactory::GetInstance().IndexLoadResource(
         index_load_info_.field_type,
         index_load_info_.element_type,

--- a/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/SealedIndexTranslator.h
@@ -10,6 +10,8 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <cstdint>
+#include <optional>
+
 #include "cachinglayer/Translator.h"
 #include "common/resource_c.h"
 #include "index/Index.h"
@@ -77,6 +79,7 @@ class SealedIndexTranslator
         std::vector<std::string> index_files;
         std::string
             warmup_policy;  // "disable", "sync", or "async"; empty means use global config
+        std::optional<LoadResourceRequest> load_resource_request;
     };
 
     milvus::index::CreateIndexInfo index_info_;

--- a/internal/core/unittest/test_loading.cpp
+++ b/internal/core/unittest/test_loading.cpp
@@ -337,6 +337,25 @@ TEST_P(IndexLoadTest, ResourceEstimate) {
     ASSERT_EQ(request.max_disk_cost, expected.max_disk_cost);
 }
 
+TEST(IndexLoadTest, LoadResourceRequestCacheIsOptional) {
+    milvus::segcore::LoadIndexInfo loadIndexInfo;
+    ASSERT_FALSE(loadIndexInfo.load_resource_request.has_value());
+
+    LoadResourceRequest request{1, 2, 3, 4, true};
+    loadIndexInfo.load_resource_request = request;
+
+    ASSERT_TRUE(loadIndexInfo.load_resource_request.has_value());
+    ASSERT_EQ(loadIndexInfo.load_resource_request->max_memory_cost, 1);
+
+    auto copied = loadIndexInfo;
+    ASSERT_TRUE(copied.load_resource_request.has_value());
+    ASSERT_EQ(copied.load_resource_request->final_disk_cost, 4);
+
+    copied.load_resource_request.reset();
+    ASSERT_FALSE(copied.load_resource_request.has_value());
+    ASSERT_TRUE(loadIndexInfo.load_resource_request.has_value());
+}
+
 TEST(IndexLoadTest, ScalarSortMmapEstimateReservesLegacyAux) {
     constexpr uint64_t kIndexSize = 1024UL * 1024 * 1024;
     constexpr int64_t kNumRows = 1025;


### PR DESCRIPTION
## Summary

issue: #50579

Cache estimated index load resources on `LoadIndexInfo` so segment load paths can reuse the same estimate for raw-data checks and resource accounting.

## Changes

- Store the cached load resource estimate as `std::optional<LoadResourceRequest>`.
- Reuse cached load-resource estimates in sealed index loading and V1 translator paths.
- Keep `CheckIndexHasRawData` inline with a direct `IndexFactory` fallback instead of a separate helper.
- Add unit coverage for optional assignment, copy, and reset behavior.

## Test Plan

- [x] `/opt/homebrew/opt/llvm@18/bin/clang-format --dry-run --Werror internal/core/src/segcore/SegmentLoadInfo.cpp internal/core/src/segcore/SegmentLoadInfo.h`
- [x] `git diff --check upstream/master..HEAD`
- [x] `rg "GetIndexLoadResource|has_load_resource_request" internal/core/src/segcore internal/core/unittest/test_loading.cpp`
- [x] `make run-test-cpp filter=IndexLoadTest.LoadResourceRequestCacheIsOptional`
- [x] `make SKIP_3RDPARTY=1 build-cpp-with-unittest` passed before the final inline cleanup; after the cleanup, the same target compiled `SegmentLoadInfo.cpp` successfully and was then stopped before completion.

