### PR TITLE
fix: prevent BM25 IDF nil map panic

### DIFF
--- a/internal/querynodev2/delegator/idf_oracle.go
+++ b/internal/querynodev2/delegator/idf_oracle.go
@@ -83,7 +83,7 @@ type bm25Stats map[int64]*storage.BM25Stats
 
 func (s bm25Stats) Clone() bm25Stats {
 	if len(s) == 0 {
-		return nil
+		return bm25Stats{}
 	}
 	cloned := make(bm25Stats, len(s))
 	for fieldID, stats := range s {

--- a/internal/querynodev2/delegator/idf_oracle_test.go
+++ b/internal/querynodev2/delegator/idf_oracle_test.go
@@ -274,6 +274,18 @@ func (suite *IDFOracleSuite) TestRegisterGrowingClonesStats() {
 	suite.Equal(int64(1), suite.idfOracle.current.NumRow())
 }
 
+func (suite *IDFOracleSuite) TestUpdateGrowingAfterEmptyRegistration() {
+	suite.idfOracle.RegisterGrowing(1, bm25Stats{})
+
+	registered, ok := suite.idfOracle.growing[1]
+	suite.True(ok)
+	suite.NotNil(registered.bm25Stats)
+
+	suite.idfOracle.UpdateGrowing(1, suite.genStats(1, 2))
+	suite.Equal(int64(1), registered.bm25Stats[102].NumRow())
+	suite.Equal(int64(1), suite.idfOracle.current.NumRow())
+}
+
 func (suite *IDFOracleSuite) TestStats() {
 	stats := newBm25Stats([]*schemapb.FunctionSchema{{
 		Type:           schemapb.FunctionType_BM25,


### PR DESCRIPTION
issue: #50542

## Summary
Keep cloned empty BM25 stats writable so recovered growing segments cannot register nil stats in the IDF oracle. Add a regression test for updating a growing segment after empty BM25 stats registration.