### PR TITLE
fix: normalize highlight analyzer names

### DIFF
--- a/internal/proxy/highlighter.go
+++ b/internal/proxy/highlighter.go
@@ -112,7 +112,7 @@ func (h *LexicalHighlighter) addTaskWithSearchText(collInfo *schemaInfo, fieldID
 	return nil
 }
 
-func (h *LexicalHighlighter) addTaskWithQuery(fieldID int64, query *highlightQuery) {
+func (h *LexicalHighlighter) addTaskWithQuery(collInfo *schemaInfo, fieldID int64, query *highlightQuery, analyzerName string) error {
 	task, ok := h.tasks[fieldID]
 	if !ok {
 		task = &highlightTask{
@@ -132,16 +132,33 @@ func (h *LexicalHighlighter) addTaskWithQuery(fieldID int64, query *highlightQue
 	task.Queries = append(task.Queries, &querypb.HighlightQuery{
 		Type: query.highlightType,
 	})
+
+	nameFieldID, err := collInfo.GetMultiAnalyzerNameFieldID(fieldID)
+	if err != nil {
+		return err
+	}
+	if nameFieldID > 0 {
+		if analyzerName == "" {
+			analyzerName = "default"
+		}
+		task.AnalyzerNames = append(task.AnalyzerNames, analyzerName)
+		if !lo.Contains(h.extraFields, nameFieldID) {
+			h.extraFields = append(h.extraFields, nameFieldID)
+		}
+	}
+	return nil
 }
 
-func (h *LexicalHighlighter) initHighlightQueries(t *searchTask) error {
+func (h *LexicalHighlighter) initHighlightQueries(t *searchTask, analyzerName string) error {
 	// add query to highlight tasks
 	for _, query := range h.queries {
 		fieldID, ok := t.schema.MapFieldID(query.fieldName)
 		if !ok {
 			return merr.WrapErrParameterInvalidMsg("highlight field not found in schema: %s", query.fieldName)
 		}
-		h.addTaskWithQuery(fieldID, query)
+		if err := h.addTaskWithQuery(t.schema, fieldID, query, analyzerName); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -789,7 +789,7 @@ func (t *searchTask) createLexicalHighlighter(highlighter *commonpb.Highlighter,
 			return err
 		}
 	}
-	return h.initHighlightQueries(t)
+	return h.initHighlightQueries(t, analyzerName)
 }
 
 func (t *searchTask) addHighlightTask(highlighter *commonpb.Highlighter, metricType string, annsField int64, placeholder []byte, analyzerName string) error {

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -5425,6 +5425,93 @@ func TestSearchTask_AddHighlightTask(t *testing.T) {
 		assert.Equal(t, "text_field", h.tasks[100].FieldName)
 	})
 
+	t.Run("lexical highlight query adds default analyzer name for multi analyzer", func(t *testing.T) {
+		multiAnalyzerSchema := proto.Clone(schema).(*schemapb.CollectionSchema)
+		multiAnalyzerSchema.Fields[0].TypeParams = []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "256"},
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: "multi_analyzer_params", Value: `{
+				"by_field": "analyzer",
+				"analyzers": {
+					"standard": {},
+					"default": {}
+				}
+			}`},
+		}
+		multiAnalyzerSchema.Fields = append(multiAnalyzerSchema.Fields, &schemapb.FieldSchema{
+			FieldID:    102,
+			Name:       "analyzer",
+			DataType:   schemapb.DataType_VarChar,
+			TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "256"}},
+		})
+
+		task := &searchTask{
+			schema: newSchemaInfo(multiAnalyzerSchema),
+		}
+
+		highlighter := &commonpb.Highlighter{
+			Type: commonpb.HighlightType_Lexical,
+			Params: []*commonpb.KeyValuePair{
+				{Key: HighlightSearchTextKey, Value: "true"},
+				{Key: HighlightQueryKey, Value: `[{"text":"extra query","type":"TextMatch","field":"text_field"}]`},
+			},
+		}
+
+		err := task.addHighlightTask(highlighter, metric.BM25, 101, placeholderBytes, "standard")
+		assert.NoError(t, err)
+
+		h, ok := task.highlighter.(*LexicalHighlighter)
+		require.True(t, ok)
+		require.Equal(t, 1, len(h.tasks))
+		require.NotNil(t, h.tasks[100])
+		assert.Equal(t, []string{"test_str", "extra query"}, h.tasks[100].Texts)
+		assert.Equal(t, []string{"standard", "standard"}, h.tasks[100].AnalyzerNames)
+		assert.Equal(t, int64(1), h.tasks[100].SearchTextNum)
+		require.Len(t, h.tasks[100].Queries, 1)
+	})
+
+	t.Run("lexical highlight query requires analyzer name field for multi analyzer", func(t *testing.T) {
+		multiAnalyzerSchema := proto.Clone(schema).(*schemapb.CollectionSchema)
+		multiAnalyzerSchema.Fields[0].TypeParams = []*commonpb.KeyValuePair{
+			{Key: common.MaxLengthKey, Value: "256"},
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: "multi_analyzer_params", Value: `{
+				"by_field": "analyzer",
+				"analyzers": {
+					"standard": {},
+					"default": {}
+				}
+			}`},
+		}
+		multiAnalyzerSchema.Fields = append(multiAnalyzerSchema.Fields, &schemapb.FieldSchema{
+			FieldID:    102,
+			Name:       "analyzer",
+			DataType:   schemapb.DataType_VarChar,
+			TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "256"}},
+		})
+
+		task := &searchTask{
+			schema: newSchemaInfo(multiAnalyzerSchema),
+		}
+
+		highlighter := &commonpb.Highlighter{
+			Type: commonpb.HighlightType_Lexical,
+			Params: []*commonpb.KeyValuePair{
+				{Key: HighlightQueryKey, Value: `[{"text":"extra query","type":"TextMatch","field":"text_field"}]`},
+			},
+		}
+
+		err := task.addHighlightTask(highlighter, metric.BM25, 101, placeholderBytes, "")
+		assert.NoError(t, err)
+
+		h, ok := task.highlighter.(*LexicalHighlighter)
+		require.True(t, ok)
+		require.NotNil(t, h.tasks[100])
+		assert.Equal(t, []string{"extra query"}, h.tasks[100].Texts)
+		assert.Equal(t, []string{"default"}, h.tasks[100].AnalyzerNames)
+		assert.ElementsMatch(t, []int64{100, 102}, h.RequiredFieldIDs())
+	})
+
 	t.Run("Lexical highlight with custom tags", func(t *testing.T) {
 		task := &searchTask{
 			schema: info,

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -1545,16 +1545,9 @@ func (sd *shardDelegator) RunAnalyzer(ctx context.Context, req *querypb.RunAnaly
 			return analyzeErr
 		}
 
-		analyzerNames := req.GetAnalyzerNames()
-		if len(analyzerNames) == 0 {
-			return merr.WrapErrParameterMissingMsg("analyzer names must be set for multi analyzer")
-		}
-
-		if len(analyzerNames) == 1 && len(texts) > 1 {
-			analyzerNames = make([]string, len(texts))
-			for i := range analyzerNames {
-				analyzerNames[i] = req.AnalyzerNames[0]
-			}
+		analyzerNames, err := normalizeAnalyzerNames(req.GetAnalyzerNames(), len(texts))
+		if err != nil {
+			return err
 		}
 		result, analyzeErr = analyzer.BatchAnalyze(req.WithDetail, req.WithHash, texts, analyzerNames)
 		return analyzeErr

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -60,6 +60,57 @@ import (
 
 // delegator data related part
 
+const defaultAnalyzerName = "default"
+
+func normalizeAnalyzerNames(analyzerNames []string, textNum int) ([]string, error) {
+	if textNum == 0 {
+		return []string{}, nil
+	}
+
+	switch len(analyzerNames) {
+	case 0:
+		names := make([]string, textNum)
+		for i := range names {
+			names[i] = defaultAnalyzerName
+		}
+		return names, nil
+	case 1:
+		name := analyzerNames[0]
+		if name == "" {
+			name = defaultAnalyzerName
+		}
+		names := make([]string, textNum)
+		for i := range names {
+			names[i] = name
+		}
+		return names, nil
+	case textNum:
+		names := append([]string(nil), analyzerNames...)
+		for i, name := range names {
+			if name == "" {
+				names[i] = defaultAnalyzerName
+			}
+		}
+		return names, nil
+	default:
+		return nil, merr.WrapErrParameterInvalidMsg("analyzer names size must be 0, 1, or equal to text size, got analyzer names size [%d], text size [%d]", len(analyzerNames), textNum)
+	}
+}
+
+func normalizeHighlightAnalyzerNames(analyzerNames []string, textNum int) ([]string, error) {
+	if len(analyzerNames) != textNum {
+		return nil, merr.WrapErrServiceInternalMsg("highlight analyzer names size must equal text size, got analyzer names size [%d], text size [%d]", len(analyzerNames), textNum)
+	}
+
+	names := append([]string(nil), analyzerNames...)
+	for i, name := range names {
+		if name == "" {
+			names[i] = defaultAnalyzerName
+		}
+	}
+	return names, nil
+}
+
 // segmentEffectiveTs returns the timestamp for delete-buffer pin/ListAfter.
 // For import segments with commit_timestamp, only deletes from T_commit onwards
 // are applied via the buffer (pre-commit deletes are in the delta log or L0 path).
@@ -1370,7 +1421,11 @@ func (sd *shardDelegator) GetHighlight(ctx context.Context, req *querypb.GetHigh
 				return analyzeErr
 			}
 			if len(analyzer.GetInputFields()) == 2 {
-				results, analyzeErr = analyzer.BatchAnalyze(true, false, task.GetTexts(), task.GetAnalyzerNames())
+				analyzerNames, err := normalizeHighlightAnalyzerNames(task.GetAnalyzerNames(), len(task.GetTexts()))
+				if err != nil {
+					return err
+				}
+				results, analyzeErr = analyzer.BatchAnalyze(true, false, task.GetTexts(), analyzerNames)
 				return analyzeErr
 			}
 			return nil

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -1641,7 +1641,7 @@ func (s *DelegatorSuite) TestRunAnalyzer() {
 		s.Equal(2, len(result[1].GetTokens()))
 	})
 
-	s.Run("error multi analyzer but no analyzer name", func() {
+	s.Run("multi analyzer defaults analyzer name", func() {
 		err := s.manager.Collection.PutOrRef(s.collectionID, &schemapb.CollectionSchema{
 			Fields: []*schemapb.FieldSchema{
 				{
@@ -1691,6 +1691,13 @@ func (s *DelegatorSuite) TestRunAnalyzer() {
 		_, err = s.delegator.RunAnalyzer(ctx, &querypb.RunAnalyzerRequest{
 			FieldId:     100,
 			Placeholder: [][]byte{[]byte("test doc")},
+		})
+		s.Require().NoError(err)
+
+		_, err = s.delegator.RunAnalyzer(ctx, &querypb.RunAnalyzerRequest{
+			FieldId:       100,
+			Placeholder:   [][]byte{[]byte("test doc")},
+			AnalyzerNames: []string{"default", "standard"},
 		})
 		s.Require().Error(err)
 	})
@@ -1852,6 +1859,66 @@ func (s *DelegatorSuite) TestGetHighlight() {
 		})
 		s.Require().NoError(err)
 		s.Require().Equal(2, len(result))
+
+		result, err = s.delegator.GetHighlight(ctx, &querypb.GetHighlightRequest{
+			Topks: []int64{1},
+			Tasks: []*querypb.HighlightTask{
+				{
+					FieldId:       100,
+					Texts:         []string{"test1", "test2", "this is a test1 document"},
+					AnalyzerNames: []string{"default", "default", "default"},
+					SearchTextNum: 1,
+					CorpusTextNum: 1,
+					Queries:       []*querypb.HighlightQuery{{Type: querypb.HighlightQueryType_TextMatch}},
+				},
+			},
+		})
+		s.Require().NoError(err)
+		s.Require().Equal(1, len(result))
+
+		_, err = s.delegator.GetHighlight(ctx, &querypb.GetHighlightRequest{
+			Topks: []int64{1},
+			Tasks: []*querypb.HighlightTask{
+				{
+					FieldId:       100,
+					Texts:         []string{"test1", "test2", "this is a test1 document"},
+					SearchTextNum: 1,
+					CorpusTextNum: 1,
+					Queries:       []*querypb.HighlightQuery{{Type: querypb.HighlightQueryType_TextMatch}},
+				},
+			},
+		})
+		s.Require().Error(err)
+
+		_, err = s.delegator.GetHighlight(ctx, &querypb.GetHighlightRequest{
+			Topks: []int64{1},
+			Tasks: []*querypb.HighlightTask{
+				{
+					FieldId:       100,
+					Texts:         []string{"test1", "test2", "this is a test1 document"},
+					AnalyzerNames: []string{"standard"},
+					SearchTextNum: 1,
+					CorpusTextNum: 1,
+					Queries:       []*querypb.HighlightQuery{{Type: querypb.HighlightQueryType_TextMatch}},
+				},
+			},
+		})
+		s.Require().Error(err)
+
+		_, err = s.delegator.GetHighlight(ctx, &querypb.GetHighlightRequest{
+			Topks: []int64{1},
+			Tasks: []*querypb.HighlightTask{
+				{
+					FieldId:       100,
+					Texts:         []string{"test1", "test2", "this is a test1 document"},
+					AnalyzerNames: []string{"default", "standard"},
+					SearchTextNum: 1,
+					CorpusTextNum: 1,
+					Queries:       []*querypb.HighlightQuery{{Type: querypb.HighlightQueryType_TextMatch}},
+				},
+			},
+		})
+		s.Require().Error(err)
 	})
 
 	s.Run("empty target texts", func() {


### PR DESCRIPTION
issue: #46308

## Summary
Normalize analyzer names before running multi-analyzer highlight and analyzer requests: omitted names use default, one name is broadcast, and per-text names must match the text count. Also add default analyzer names for lexical highlight query texts and request the analyzer-name field for multi-analyzer query-only highlight.