### PR TITLE
fix: reject search iterator v2 in hybrid search

### DIFF
--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -553,6 +553,10 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		if queryInfo.GetSearchIteratorV2Info() != nil {
+			return merr.WrapErrParameterInvalid("", "",
+				"search iterator v2 is not supported for hybrid search")
+		}
 
 		convertedPlaceholder, placeholderType, err := t.convertPlaceholderIfNeeded(subReq.GetPlaceholderGroup(), queryInfo.GetQueryFieldId())
 		if err != nil {

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -6414,6 +6414,35 @@ func TestSearchTask_ArrayOfVectorHybridSearch(t *testing.T) {
 		assert.Contains(t, err.Error(), "search iterator is not supported for vector array (embedding-list) fields in hybrid search")
 	})
 
+	t.Run("hybrid with search iterator v2 should fail", func(t *testing.T) {
+		qt := buildElementHybridTask("regular_vec", "", true, "")
+		qt.request.SubReqs[0].SearchParams = append(qt.request.SubReqs[0].SearchParams,
+			&commonpb.KeyValuePair{Key: SearchIterV2Key, Value: "True"},
+			&commonpb.KeyValuePair{Key: SearchIterBatchSizeKey, Value: "5"})
+
+		err := qt.initAdvancedSearchRequest(ctx)
+
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "search iterator v2 is not supported for hybrid search")
+	})
+
+	t.Run("hybrid with search iterator v2 on second sub-request should fail", func(t *testing.T) {
+		qt := buildElementHybridTask("regular_vec", "", false, "")
+		secondSubReq := proto.Clone(qt.request.SubReqs[0]).(*milvuspb.SubSearchRequest)
+		secondSubReq.SearchParams = append(secondSubReq.SearchParams,
+			&commonpb.KeyValuePair{Key: IteratorField, Value: "True"},
+			&commonpb.KeyValuePair{Key: SearchIterV2Key, Value: "True"},
+			&commonpb.KeyValuePair{Key: SearchIterBatchSizeKey, Value: "5"})
+		qt.request.SubReqs = append(qt.request.SubReqs, secondSubReq)
+
+		err := qt.initAdvancedSearchRequest(ctx)
+
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+		assert.Contains(t, err.Error(), "search iterator v2 is not supported for hybrid search")
+	})
+
 	t.Run("hybrid with ArrayOfVector group by should fail", func(t *testing.T) {
 		qt := buildHybridTask("emb_vec", "", false, "scalar_field")
 		err := qt.initAdvancedSearchRequest(ctx)


### PR DESCRIPTION
## Summary

Reject search iterator v2 for hybrid search because the current response metadata model only supports iterator v2 results for a single query info. This avoids returning hybrid search hits with empty iterator metadata that cannot be used for the next page.

issue: #50407

## Test Plan

- [x] `git diff --check`
- [x] `make milvus`
- [x] `MILVUSCONF=/tmp/milvus_issue-50407/configs PKG_CONFIG_PATH=$(pwd)/internal/core/output/lib/pkgconfig LD_LIBRARY_PATH=$(pwd)/internal/core/output/lib go test -gcflags="all=-N -l" -tags dynamic,test ./internal/proxy -run "^TestSearchTask_ArrayOfVectorHybridSearch$" -count=1 -ldflags="-r $(pwd)/internal/core/output/lib"`