### PR TITLE
enhance: seed search OpContext trace span

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -28,7 +28,7 @@ class MilvusConan(ConanFile):
         "prometheus-cpp/1.2.4#0918d66c13f97acb7809759f9de49b3f",
         "re2/20230301#f8efaf45f98d0193cd0b2ea08b6b4060",
         "folly/2026.04.20.00@milvus/dev#06852bea5b6449f0c4eb0df002b5779c",
-        "milvus-common/1.0.0-835fcd0@milvus/dev#f908c64d5f16981c6b9f4d4e02358562",
+        "milvus-common/1.0.0-a3299ca@milvus/dev#eea0e22b8d5e36ff6f0a5ffbed14703e",
         "google-cloud-cpp/2.28.0@milvus/dev#468918b43cec43624531a0340398cf43",
         "opentelemetry-cpp/1.23.0@milvus/dev#11bc565ec6e82910ae8f7471da756720",
         "librdkafka/1.9.1#ec1a00d5414f618555799be9566adfb7",

--- a/internal/core/src/exec/operator/Utils.h
+++ b/internal/core/src/exec/operator/Utils.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstddef>
+#include "common/OpContext.h"
 #include "common/QueryInfo.h"
 #include "common/QueryResult.h"
 #include "knowhere/index/index_node.h"
@@ -57,7 +58,8 @@ PrepareVectorIteratorsFromIndex(const SearchInfo& search_info,
                                 const DatasetPtr dataset,
                                 SearchResult& search_result,
                                 const BitsetView& bitset,
-                                const index::VectorIndex& index) {
+                                const index::VectorIndex& index,
+                                milvus::OpContext* op_context = nullptr) {
     // when we use group by, we will use vector iterator to continously get results and group on them
     // when we use iterative filtered search, we will use vector iterator to continously get results and check scalar attr on them
     // until we get valid topk results
@@ -65,8 +67,8 @@ PrepareVectorIteratorsFromIndex(const SearchInfo& search_info,
         try {
             auto search_conf = index.PrepareSearchParams(search_info);
             knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
-                iterators_val =
-                    index.VectorIterators(dataset, search_conf, bitset);
+                iterators_val = index.VectorIterators(
+                    dataset, search_conf, bitset, op_context);
             if (iterators_val.has_value()) {
                 bool larger_is_closer =
                     PositivelyRelated(search_info.metric_type_);

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -782,7 +782,8 @@ template <typename T>
 knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
 VectorDiskAnnIndex<T>::VectorIterators(const DatasetPtr dataset,
                                        const knowhere::Json& conf,
-                                       const BitsetView& bitset) const {
+                                       const BitsetView& bitset,
+                                       milvus::OpContext* op_context) const {
     auto make_empty_iterators = [](int64_t num_queries) {
         std::vector<knowhere::IndexNode::IteratorPtr> iterators;
         iterators.reserve(num_queries);
@@ -812,7 +813,7 @@ VectorDiskAnnIndex<T>::VectorIterators(const DatasetPtr dataset,
         }
         return make_empty_iterators(num_queries);
     }
-    return this->index_.AnnIterator(dataset, conf, bitset, false);
+    return this->index_.AnnIterator(dataset, conf, bitset, false, op_context);
 }
 
 template <typename T>

--- a/internal/core/src/index/VectorDiskIndex.h
+++ b/internal/core/src/index/VectorDiskIndex.h
@@ -116,7 +116,8 @@ class VectorDiskAnnIndex : public VectorIndex {
     knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
     VectorIterators(const DatasetPtr dataset,
                     const knowhere::Json& json,
-                    const BitsetView& bitset) const override;
+                    const BitsetView& bitset,
+                    milvus::OpContext* op_context = nullptr) const override;
 
  private:
     bool

--- a/internal/core/src/index/VectorIndex.h
+++ b/internal/core/src/index/VectorIndex.h
@@ -76,7 +76,8 @@ class VectorIndex : public IndexBase {
     virtual knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
     VectorIterators(const DatasetPtr dataset,
                     const knowhere::Json& json,
-                    const BitsetView& bitset) const {
+                    const BitsetView& bitset,
+                    milvus::OpContext* = nullptr) const {
         ThrowInfo(NotImplemented,
                   "VectorIndex:" + this->GetIndexType() +
                       " didn't implement VectorIterator interface, "

--- a/internal/core/src/index/VectorMemIndex.cpp
+++ b/internal/core/src/index/VectorMemIndex.cpp
@@ -233,7 +233,8 @@ template <typename T>
 knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
 VectorMemIndex<T>::VectorIterators(const milvus::DatasetPtr dataset,
                                    const knowhere::Json& conf,
-                                   const milvus::BitsetView& bitset) const {
+                                   const milvus::BitsetView& bitset,
+                                   milvus::OpContext* op_context) const {
     auto make_empty_iterators = [](int64_t num_queries) {
         std::vector<knowhere::IndexNode::IteratorPtr> iterators;
         iterators.reserve(num_queries);
@@ -283,7 +284,7 @@ VectorMemIndex<T>::VectorIterators(const milvus::DatasetPtr dataset,
         }
         return make_empty_iterators(num_queries);
     }
-    return this->index_.AnnIterator(dataset, conf, bitset, false);
+    return this->index_.AnnIterator(dataset, conf, bitset, false, op_context);
 }
 
 template <typename T>

--- a/internal/core/src/index/VectorMemIndex.h
+++ b/internal/core/src/index/VectorMemIndex.h
@@ -123,7 +123,8 @@ class VectorMemIndex : public VectorIndex {
     knowhere::expected<std::vector<knowhere::IndexNode::IteratorPtr>>
     VectorIterators(const DatasetPtr dataset,
                     const knowhere::Json& json,
-                    const BitsetView& bitset) const override;
+                    const BitsetView& bitset,
+                    milvus::OpContext* op_context = nullptr) const override;
 
     knowhere::expected<knowhere::DataSetPtr>
     CalcDistByIDs(const knowhere::DataSetPtr query_dataset,

--- a/internal/core/src/query/CachedSearchIterator.cpp
+++ b/internal/core/src/query/CachedSearchIterator.cpp
@@ -39,7 +39,8 @@ CachedSearchIterator::CachedSearchIterator(
     const milvus::index::VectorIndex& index,
     const knowhere::DataSetPtr& query_ds,
     const SearchInfo& search_info,
-    const BitsetView& bitset) {
+    const BitsetView& bitset,
+    milvus::OpContext* op_context) {
     if (query_ds == nullptr) {
         ThrowInfo(ErrorCode::UnexpectedError,
                   "Query dataset is nullptr, cannot initialize iterator");
@@ -66,7 +67,7 @@ CachedSearchIterator::CachedSearchIterator(
         search_info, batch_size_, index.GetMetricType(), search_json);
 
     auto expected_iterators =
-        index.VectorIterators(query_ds, search_json, bitset);
+        index.VectorIterators(query_ds, search_json, bitset, op_context);
     if (expected_iterators.has_value()) {
         iterators_ = std::move(expected_iterators.value());
     } else {

--- a/internal/core/src/query/CachedSearchIterator.h
+++ b/internal/core/src/query/CachedSearchIterator.h
@@ -53,7 +53,8 @@ class CachedSearchIterator {
     CachedSearchIterator(const milvus::index::VectorIndex& index,
                          const knowhere::DataSetPtr& dataset,
                          const SearchInfo& search_info,
-                         const BitsetView& bitset);
+                         const BitsetView& bitset,
+                         milvus::OpContext* op_context = nullptr);
 
     // For growing segment with chunked data, BF
     CachedSearchIterator(const dataset::SearchDataset& dataset,

--- a/internal/core/src/query/ExecPlanNodeVisitor.cpp
+++ b/internal/core/src/query/ExecPlanNodeVisitor.cpp
@@ -451,6 +451,7 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
             }
 
             auto op_context = milvus::OpContext(cancel_token_);
+            op_context.trace_span = trace_span_;
             query_context->set_op_context(&op_context);
 
             auto result = ExecuteTask(plan_fragment, query_context);
@@ -510,6 +511,7 @@ ExecPlanNodeVisitor::visit(VectorPlanNode& node) {
 
     // Set op context to query context
     auto op_context = milvus::OpContext(cancel_token_);
+    op_context.trace_span = trace_span_;
     query_context->set_op_context(&op_context);
 
     // Do plan fragment task work

--- a/internal/core/src/query/ExecPlanNodeVisitor.h
+++ b/internal/core/src/query/ExecPlanNodeVisitor.h
@@ -26,6 +26,7 @@
 #include "common/EasyAssert.h"
 #include "common/OpContext.h"
 #include "common/QueryResult.h"
+#include "common/Trace.h"
 #include "common/Types.h"
 #include "common/Vector.h"
 #include "exec/QueryContext.h"
@@ -54,7 +55,8 @@ class ExecPlanNodeVisitor : public PlanNodeVisitor {
                             folly::CancellationToken(),
                         int32_t consistency_level = 0,
                         Timestamp collection_ttl = 0,
-                        int64_t entity_ttl_physical_time_us = 0)
+                        int64_t entity_ttl_physical_time_us = 0,
+                        milvus::tracer::SpanPtr trace_span = nullptr)
         : segment_(segment),
           timestamp_(timestamp),
           entity_ttl_physical_time_us_(
@@ -66,7 +68,8 @@ class ExecPlanNodeVisitor : public PlanNodeVisitor {
           placeholder_group_(placeholder_group),
           cancel_token_(cancel_token),
           consistency_level_(consistency_level),
-          collection_ttl_timestamp_(collection_ttl) {
+          collection_ttl_timestamp_(collection_ttl),
+          trace_span_(std::move(trace_span)) {
     }
 
     // Only used for test
@@ -173,6 +176,7 @@ class ExecPlanNodeVisitor : public PlanNodeVisitor {
     bool expr_use_pk_index_ = false;
     bool filter_only_ = false;
     bool enable_expr_cache_ = false;
+    milvus::tracer::SpanPtr trace_span_ = nullptr;
 };
 
 // for test use only

--- a/internal/core/src/query/ExecPlanNodeVisitor.h
+++ b/internal/core/src/query/ExecPlanNodeVisitor.h
@@ -26,7 +26,7 @@
 #include "common/EasyAssert.h"
 #include "common/OpContext.h"
 #include "common/QueryResult.h"
-#include "common/Trace.h"
+#include "common/Tracer.h"
 #include "common/Types.h"
 #include "common/Vector.h"
 #include "exec/QueryContext.h"

--- a/internal/core/src/query/SearchOnIndex.cpp
+++ b/internal/core/src/query/SearchOnIndex.cpp
@@ -76,13 +76,14 @@ SearchOnIndex(const dataset::SearchDataset& search_dataset,
                                                       dataset,
                                                       search_result,
                                                       search_bitset,
-                                                      indexing)) {
+                                                      indexing,
+                                                      op_context)) {
         return;
     }
 
     if (search_conf.iterator_v2_info_.has_value()) {
-        auto iter =
-            CachedSearchIterator(indexing, dataset, search_conf, search_bitset);
+        auto iter = CachedSearchIterator(
+            indexing, dataset, search_conf, search_bitset, op_context);
         iter.NextBatch(search_conf, search_result);
         if (has_offset_mapping) {
             offset_mapping.TransformOffsets(search_result.seg_offsets_);

--- a/internal/core/src/query/SearchOnSealed.cpp
+++ b/internal/core/src/query/SearchOnSealed.cpp
@@ -124,7 +124,7 @@ SearchOnSealedIndex(const Schema& schema,
 
     if (search_info.iterator_v2_info_.has_value()) {
         CachedSearchIterator cached_iter(
-            *vec_index, dataset, search_info, search_bitset);
+            *vec_index, dataset, search_info, search_bitset, op_context);
         cached_iter.NextBatch(search_info, search_result);
         FinalizeVectorSearchOffsets(
             search_result, offset_mapping, search_info.array_offsets_.get());
@@ -137,7 +137,8 @@ SearchOnSealedIndex(const Schema& schema,
                                                       dataset,
                                                       search_result,
                                                       search_bitset,
-                                                      *vec_index);
+                                                      *vec_index,
+                                                      op_context);
     if (!use_iterator) {
         vec_index->Query(
             dataset, search_info, search_bitset, op_context, search_result);

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -144,7 +144,8 @@ SegmentInternalInterface::Search(
     Timestamp collection_ttl,
     int64_t entity_ttl_physical_time_us,
     bool filter_only,
-    bool enable_expr_cache) const {
+    bool enable_expr_cache,
+    milvus::tracer::SpanPtr trace_span) const {
     std::shared_lock lck(mutex_);
     milvus::tracer::AddEvent("obtained_segment_lock_mutex");
 
@@ -155,7 +156,8 @@ SegmentInternalInterface::Search(
                                        cancel_token,
                                        consistency_level,
                                        collection_ttl,
-                                       entity_ttl_physical_time_us);
+                                       entity_ttl_physical_time_us,
+                                       std::move(trace_span));
     visitor.SetFilterOnly(filter_only);
     visitor.SetEnableExprCache(enable_expr_cache);
     auto results = std::make_unique<SearchResult>();

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -47,7 +47,6 @@
 #include "common/Schema.h"
 #include "common/Span.h"
 #include "common/SystemProperty.h"
-#include "common/Trace.h"
 #include "common/Tracer.h"
 #include "common/Types.h"
 #include "common/VectorArray.h"

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -47,6 +47,7 @@
 #include "common/Schema.h"
 #include "common/Span.h"
 #include "common/SystemProperty.h"
+#include "common/Trace.h"
 #include "common/Tracer.h"
 #include "common/Types.h"
 #include "common/VectorArray.h"
@@ -105,7 +106,8 @@ class SegmentInterface {
            Timestamp collection_ttl,
            int64_t entity_ttl_physical_time_us = 0,
            bool filter_only = false,
-           bool enable_expr_cache = false) const = 0;
+           bool enable_expr_cache = false,
+           milvus::tracer::SpanPtr trace_span = nullptr) const = 0;
 
     // Only used for test
     std::unique_ptr<SearchResult>
@@ -493,7 +495,8 @@ class SegmentInternalInterface : public SegmentInterface {
            Timestamp collection_ttl,
            int64_t entity_ttl_physical_time_us = 0,
            bool filter_only = false,
-           bool enable_expr_cache = false) const override;
+           bool enable_expr_cache = false,
+           milvus::tracer::SpanPtr trace_span = nullptr) const override;
 
     void
     FillPrimaryKeys(const query::Plan* plan,

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -432,7 +432,8 @@ AsyncSearch(CTraceContext c_trace,
                                                 collection_ttl,
                                                 entity_ttl_physical_time_us,
                                                 filter_only,
-                                                enable_expr_cache);
+                                                enable_expr_cache,
+                                                span);
             }
             if (!filter_only &&
                 !milvus::PositivelyRelated(


### PR DESCRIPTION
## Summary

- keep the upstream Knowhere pin from Milvus master: `zilliztech/knowhere.git` at `v3.0.5`
- pin `milvus-common/1.0.0-a3299ca@milvus/dev#eea0e22b8d5e36ff6f0a5ffbed14703e`
- seed the SegCore search span into the `milvus::OpContext` used by `ExecPlanNodeVisitor`
- include trace span types from `common/Tracer.h`, matching the latest milvus-common helper API shape
- keep the trace parent carrier in Milvus local to each search execution path before Knowhere/Cardinal consume it
- propagate the same `milvus::OpContext` into indexed vector iterator paths so group-by, iterative-filter, and iterator-v2 search modes can preserve the trace parent into Knowhere

## Dependencies

Knowhere PR https://github.com/zilliztech/knowhere/pull/1684 prepared Knowhere to consume the OpContext trace span. This Milvus branch no longer pins a temporary Knowhere branch; it keeps the upstream `v3.0.5` pin from Milvus master.

The downstream source changes target the published helper package `milvus-common/1.0.0-a3299ca@milvus/dev#eea0e22b8d5e36ff6f0a5ffbed14703e`, produced from milvus-common commit `a3299cac82bb85868d2e6cd9233e92202fd5ae30` and published through conanfiles PR https://github.com/milvus-io/conanfiles/pull/155.

The branch has been rebased on current Milvus `master`; FileManager stream path work from PR https://github.com/milvus-io/milvus/pull/50455 is inherited from upstream `master` and is no longer carried in this PR branch.

## Verification

- Not run locally. Milvus validation is intentionally left for the downstream image/CI validation path.