### PR TITLE
fix: reject unrefreshed external fields

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1352,6 +1352,7 @@ ChunkedSegmentSealedImpl::prefetch_chunks(
     milvus::OpContext* op_ctx,
     FieldId field_id,
     const std::vector<int64_t>& chunk_ids) const {
+    CheckExternalFieldAvailableInSnapshot(schema_->operator[](field_id));
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
@@ -1371,6 +1372,7 @@ ChunkedSegmentSealedImpl::ApplyFieldValidData(
     if (size == 0) {
         return;
     }
+    CheckExternalFieldAvailableInSnapshot(schema_->operator[](field_id));
 
     std::shared_ptr<ChunkedColumnInterface> column;
     {
@@ -1400,6 +1402,7 @@ ChunkedSegmentSealedImpl::ApplyFieldValidDataByOffsets(
     if (count == 0) {
         return;
     }
+    CheckExternalFieldAvailableInSnapshot(schema_->operator[](field_id));
 
     std::shared_ptr<ChunkedColumnInterface> column;
     {
@@ -1431,6 +1434,7 @@ PinWrapper<SpanBase>
 ChunkedSegmentSealedImpl::chunk_data_impl(milvus::OpContext* op_ctx,
                                           FieldId field_id,
                                           int64_t chunk_id) const {
+    CheckExternalFieldAvailableInSnapshot(schema_->operator[](field_id));
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
@@ -1447,6 +1451,7 @@ ChunkedSegmentSealedImpl::chunk_array_view_impl(
     FieldId field_id,
     int64_t chunk_id,
     std::optional<std::pair<int64_t, int64_t>> offset_len) const {
+    CheckExternalFieldAvailableInSnapshot(schema_->operator[](field_id));
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
@@ -1463,6 +1468,7 @@ ChunkedSegmentSealedImpl::chunk_vector_array_view_impl(
     FieldId field_id,
     int64_t chunk_id,
     std::optional<std::pair<int64_t, int64_t>> offset_len) const {
+    CheckExternalFieldAvailableInSnapshot(schema_->operator[](field_id));
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
@@ -1479,6 +1485,7 @@ ChunkedSegmentSealedImpl::chunk_string_view_impl(
     FieldId field_id,
     int64_t chunk_id,
     std::optional<std::pair<int64_t, int64_t>> offset_len) const {
+    CheckExternalFieldAvailableInSnapshot(schema_->operator[](field_id));
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
@@ -1495,6 +1502,7 @@ ChunkedSegmentSealedImpl::chunk_string_views_by_offsets(
     FieldId field_id,
     int64_t chunk_id,
     const FixedVector<int32_t>& offsets) const {
+    CheckExternalFieldAvailableInSnapshot(schema_->operator[](field_id));
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
@@ -1511,6 +1519,7 @@ ChunkedSegmentSealedImpl::chunk_array_views_by_offsets(
     FieldId field_id,
     int64_t chunk_id,
     const FixedVector<int32_t>& offsets) const {
+    CheckExternalFieldAvailableInSnapshot(schema_->operator[](field_id));
     std::shared_lock lck(mutex_);
     AssertInfo(get_bit(field_data_ready_bitset_, field_id),
                "Can't get bitset element at " + std::to_string(field_id.get()));
@@ -1612,6 +1621,7 @@ ChunkedSegmentSealedImpl::vector_search(SearchInfo& search_info,
     AssertInfo(is_system_field_ready(), "System field is not ready");
     auto field_id = search_info.field_id_;
     auto& field_meta = schema_->operator[](field_id);
+    CheckExternalFieldAvailableInSnapshot(field_meta);
 
     AssertInfo(field_meta.is_vector(),
                "The meta type of vector field is not vector type");
@@ -1744,6 +1754,7 @@ ChunkedSegmentSealedImpl::get_vector(milvus::OpContext* op_ctx,
                                      const int64_t* ids,
                                      int64_t count) const {
     auto& field_meta = schema_->operator[](field_id);
+    CheckExternalFieldAvailableInSnapshot(field_meta);
     AssertInfo(field_meta.is_vector(), "vector field is not vector type");
 
     if (!get_bit(index_ready_bitset_, field_id) &&
@@ -1809,6 +1820,7 @@ ChunkedSegmentSealedImpl::get_emb_list(milvus::OpContext* op_ctx,
                                        const FieldMeta& field_meta,
                                        const int64_t* seg_offsets,
                                        int64_t count) const {
+    CheckExternalFieldAvailableInSnapshot(field_meta);
     AssertInfo(field_meta.get_data_type() == DataType::VECTOR_ARRAY,
                "get_emb_list only supports VECTOR_ARRAY");
 
@@ -2755,6 +2767,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                          TargetBitmap& valid_map,
                                          bool small_int_raw_type) const {
     auto& field_meta = schema_->operator[](field_id);
+    CheckExternalFieldAvailableInSnapshot(field_meta);
     // DO NOT directly access the column by map like: `fields_.at(field_id)->Data()`,
     // we have to clone the shared pointer, to make sure it won't get released
     // if segment released
@@ -3842,6 +3855,7 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
                                          const int64_t* seg_offsets,
                                          int64_t count) const {
     auto& field_meta = schema_->operator[](field_id);
+    CheckExternalFieldAvailableInSnapshot(field_meta);
     // if count == 0, return empty data array
     if (count == 0) {
         return fill_with_empty(field_id, count);
@@ -3933,6 +3947,8 @@ ChunkedSegmentSealedImpl::bulk_subscript(
     int64_t count,
     const std::vector<std::string>& dynamic_field_names) const {
     Assert(!dynamic_field_names.empty());
+    auto& field_meta = schema_->operator[](field_id);
+    CheckExternalFieldAvailableInSnapshot(field_meta);
     if (count == 0) {
         return fill_with_empty(field_id, 0);
     }
@@ -3959,6 +3975,43 @@ ChunkedSegmentSealedImpl::bulk_subscript(
         seg_offsets,
         count);
     return ret;
+}
+
+bool
+ChunkedSegmentSealedImpl::ExternalFieldAvailableInSnapshot(
+    FieldId field_id) const {
+    // Do not call FieldAccessible() here. After an external schema reopen, the
+    // field can exist in schema while the currently loaded snapshot bitsets were
+    // built before refresh and may not contain this field position yet.
+    auto field_loaded = has_bit_position(field_data_ready_bitset_, field_id) &&
+                        get_bit(field_data_ready_bitset_, field_id);
+    auto index_loaded = has_bit_position(index_ready_bitset_, field_id) &&
+                        get_bit(index_ready_bitset_, field_id);
+    auto binlog_index_loaded =
+        has_bit_position(binlog_index_bitset_, field_id) &&
+        get_bit(binlog_index_bitset_, field_id);
+    return field_exists_in_schema(schema_, field_id) &&
+           (field_loaded || index_loaded || binlog_index_loaded);
+}
+
+void
+ChunkedSegmentSealedImpl::CheckExternalFieldAvailableInSnapshot(
+    const FieldMeta& field_meta) const {
+    if (!schema_->is_external_collection() || !field_meta.is_external_field()) {
+        return;
+    }
+
+    if (ExternalFieldAvailableInSnapshot(field_meta.get_id())) {
+        return;
+    }
+
+    ThrowInfo(FieldNotLoaded,
+              "external field '{}' (external column '{}') is not available in "
+              "the current loaded external collection snapshot; run "
+              "RefreshExternalCollection and reload the collection before "
+              "accessing this field",
+              field_meta.get_name().get(),
+              field_meta.get_external_field());
 }
 
 bool
@@ -6269,6 +6322,7 @@ ChunkedSegmentSealedImpl::TryTakeForRetrieve(
             continue;
         }
         auto& field_meta = schema_->operator[](field_id);
+        CheckExternalFieldAvailableInSnapshot(field_meta);
         if (!field_meta.is_external_field() &&
             !schema_->is_function_output(field_id) && is_external_collection) {
             continue;
@@ -6531,6 +6585,7 @@ ChunkedSegmentSealedImpl::TryTakeForSearch(const query::Plan* plan,
     std::vector<std::string> take_column_names;
     for (auto field_id : plan->target_entries_) {
         auto& field_meta = schema_->operator[](field_id);
+        CheckExternalFieldAvailableInSnapshot(field_meta);
         if (!field_meta.is_external_field() &&
             !schema_->is_function_output(field_id) && is_external_collection) {
             continue;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -638,6 +638,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                       const std::shared_ptr<ChunkedColumnInterface>& column);
 
  private:
+    bool
+    ExternalFieldAvailableInSnapshot(FieldId field_id) const;
+
+    void
+    CheckExternalFieldAvailableInSnapshot(const FieldMeta& field_meta) const;
+
     void
     load_system_field_internal(
         FieldId field_id,
@@ -1436,8 +1442,25 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
  public:
     // Test-only: inject a mock Reader for unit testing take() paths.
     void
-    SetReaderForTesting(std::unique_ptr<milvus_storage::api::Reader> r) {
+    SetReaderForTesting(std::unique_ptr<milvus_storage::api::Reader> r,
+                        bool mark_external_fields_ready = true) {
         reader_ = std::move(r);
+        if (!mark_external_fields_ready || !schema_->is_external_collection()) {
+            return;
+        }
+        std::unique_lock lck(mutex_);
+        for (const auto& [field_id, field_meta] : schema_->get_fields()) {
+            if (!field_meta.is_external_field()) {
+                continue;
+            }
+            auto pos = field_id.get() - START_USER_FIELDID;
+            AssertInfo(pos >= 0, "invalid field id");
+            AssertInfo(
+                static_cast<size_t>(pos) < field_data_ready_bitset_.size(),
+                "field {} is outside ready bitset",
+                field_id.get());
+            field_data_ready_bitset_[pos] = true;
+        }
     }
 
     // Wrappers for protected methods to enable direct unit testing.

--- a/internal/core/unittest/test_external_take.cpp
+++ b/internal/core/unittest/test_external_take.cpp
@@ -947,6 +947,34 @@ CreateExternalSegment(SegmentSealedUPtr& holder,
     return dynamic_cast<ChunkedSegmentSealedImpl*>(holder.get());
 }
 
+TEST(ExternalFieldAvailabilityTest,
+     RejectsSearchTakeMissingFromLoadedSnapshot) {
+    auto info = BuildExternalSchema();
+    auto table = BuildTestArrowTable();
+    SegmentSealedUPtr holder;
+    auto* segment = CreateExternalSegment(holder, info.schema);
+    ASSERT_NE(segment, nullptr);
+    segment->SetReaderForTesting(std::make_unique<MockTakeReader>(table),
+                                 false);
+    segment->SetUseTakeForOutputForTesting(true);
+
+    auto plan = std::make_unique<query::Plan>(info.schema);
+    plan->target_entries_ = {info.double_id};
+
+    SearchResult results;
+    std::vector<int64_t> offsets = {0, 1};
+
+    try {
+        segment->TestTryTakeForSearch(
+            plan.get(), offsets.data(), offsets.size(), results);
+        FAIL() << "expected missing external field to be rejected";
+    } catch (const std::exception& e) {
+        std::string message = e.what();
+        EXPECT_NE(message.find("double_col"), std::string::npos);
+        EXPECT_NE(message.find("RefreshExternalCollection"), std::string::npos);
+    }
+}
+
 // Mock Reader that always returns an error from take().
 class ErrorMockTakeReader : public milvus_storage::api::Reader {
  public:

--- a/tests/python_client/milvus_client/test_milvus_client_external_table.py
+++ b/tests/python_client/milvus_client/test_milvus_client_external_table.py
@@ -2146,11 +2146,6 @@ class TestMilvusClientExternalTableAddField(ExternalTableTestBase):
         assert {row["id"] for row in filtered} == {100}
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.xfail(
-        reason="https://github.com/milvus-io/milvus/issues/50416: "
-        "querying newly added external field before refresh returns internal QueryNode assert",
-        strict=True,
-    )
     def test_milvus_client_external_table_add_field_without_refresh_not_silent(self, minio_env, external_prefix):
         """
         target: test external table add field without refresh does not silently return wrong data
@@ -2205,7 +2200,7 @@ class TestMilvusClientExternalTableAddField(ExternalTableTestBase):
         )[0][0]
         assert [hit["id"] for hit in old_hits] == [hit["id"] for hit in baseline_hits]
 
-        err_check = {ct.err_code: 65535, ct.err_msg: "refresh"}
+        err_check = {ct.err_code: 65535, ct.err_msg: "RefreshExternalCollection"}
         self.query(
             client,
             coll,
@@ -2221,6 +2216,17 @@ class TestMilvusClientExternalTableAddField(ExternalTableTestBase):
             filter="score > 0",
             output_fields=["id", "score"],
             limit=10,
+            check_task=CheckTasks.err_res,
+            check_items=err_check,
+        )
+        self.search(
+            client,
+            coll,
+            data=_float_vectors([0], ct.default_dim).tolist(),
+            limit=1,
+            anns_field="embedding",
+            output_fields=["id", "score"],
+            search_params={"metric_type": "L2"},
             check_task=CheckTasks.err_res,
             check_items=err_check,
         )


### PR DESCRIPTION
Fixes [https://github.com/milvus-io/milvus/issues/50416](https://github.com/milvus-io/milvus/issues/50416)

### What changed

This PR rejects access to external fields that exist in collection schema but are not available in the currently loaded external collection snapshot.

The guard is kept local to `ChunkedSegmentSealedImpl`: sealed segments check their field/index/binlog ready bitsets before accessing an external field. Field-read guards remain at data access, vector search, and take paths so query, search output, and retrieve output fail consistently. Internal collection schema-evolution default/null fill behavior is kept unchanged, and no new `SegmentInterface` API is added.

The existing external add-field e2e for [https://github.com/milvus-io/milvus/issues/50416](https://github.com/milvus-io/milvus/issues/50416) is opened and extended to cover search output fields before refresh.

### Why

External collection schema-only reopen can expose newly added fields before `RefreshExternalCollection` has refreshed the corresponding external columns in the loaded snapshot. Returning placeholder/default values for those fields can hide the stale snapshot state and produce misleading results.

### Impact

When an external collection query/search/retrieve accesses an unrefreshed external field, Milvus now returns `FieldNotLoaded` with guidance to run `RefreshExternalCollection` and reload the collection.

Internal collections continue using the existing add-field default fill semantics.

### Validation

- `git diff --check`
- `/opt/homebrew/opt/llvm@15/bin/clang-format --dry-run -Werror internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp internal/core/src/segcore/ChunkedSegmentSealedImpl.h internal/core/src/segcore/SegmentInterface.cpp internal/core/src/segcore/SegmentInterface.h internal/core/unittest/test_external_take.cpp`
- `python3 -m py_compile tests/python_client/milvus_client/test_milvus_client_external_table.py`
- `cmake --build cmake_build --target all_tests -j 8`
- `DYLD_LIBRARY_PATH=/Users/wei.liu/Code/issue-50416-impl/milvus/cmake_build/thirdparty/boost_ext:/Users/wei.liu/Code/issue-50416-impl/milvus/internal/core/output/lib:/Users/wei.liu/Code/issue-50416-impl/milvus/internal/core/output/unittest cmake_build/unittest/all_tests --gtest_filter=ExternalFieldAvailabilityTest.*:ExternalTakeTest.*`

Not run locally: targeted Python e2e execution. The current local Python environment is missing `bm25s`, and local Milvus `localhost:19530` is not running. The opened e2e is expected to run in CI.
