### PR TITLE
fix: isolate local index cache cleanup paths

### DIFF
--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -410,6 +410,8 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
     Config config_with_emb_list = config;
     config_with_emb_list[EMB_LIST] = is_embedding_list;
     auto local_raw_data_prefix = file_manager_->GetLocalRawDataObjectPrefix();
+    auto raw_data_lease =
+        file_manager_->AcquireLocalDirWriteLease(local_raw_data_prefix);
 
     std::string offsets_path;
     // Set offsets path in config for VECTOR_ARRAY
@@ -420,6 +422,8 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
 
     // Set valid data path to track nullable vector fields
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
+    auto index_lease =
+        file_manager_->AcquireLocalDirWriteLease(local_index_path_prefix);
     auto valid_data_path = local_index_path_prefix + "/" + VALID_DATA_KEY;
     config_with_emb_list[VALID_DATA_PATH_KEY] = valid_data_path;
 
@@ -438,7 +442,7 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
                 SetDim(dim.value());
             }
             file_manager_->AddFile(valid_data_path);
-            local_chunk_manager->RemoveDir(local_raw_data_prefix);
+            file_manager_->RemoveRawDataFiles();
             LOG_INFO("build all-null nullable disk index done, build_id: {}",
                      config.value("build_id", "unknown"));
             return;
@@ -470,7 +474,7 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
             if (local_chunk_manager->Exist(valid_data_path)) {
                 file_manager_->AddFile(valid_data_path);
             }
-            local_chunk_manager->RemoveDir(local_raw_data_prefix);
+            file_manager_->RemoveRawDataFiles();
             empty_emb_list_offsets_ = std::move(offsets.value());
             LOG_INFO("build all-empty emb_list disk index done, build_id: {}",
                      config.value("build_id", "unknown"));
@@ -516,7 +520,7 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
         file_manager_->AddFile(valid_data_path);
     }
 
-    local_chunk_manager->RemoveDir(local_raw_data_prefix);
+    file_manager_->RemoveRawDataFiles();
 
     LOG_INFO("build disk index done, build_id: {}",
              config.value("build_id", "unknown"));
@@ -536,10 +540,14 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
 
     // set data path
     auto local_raw_data_prefix = file_manager_->GetLocalRawDataObjectPrefix();
+    auto raw_data_lease =
+        file_manager_->AcquireLocalDirWriteLease(local_raw_data_prefix);
     auto local_data_path = local_raw_data_prefix + "raw_data";
     build_config[DISK_ANN_RAW_DATA_PATH] = local_data_path;
 
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
+    auto index_lease =
+        file_manager_->AcquireLocalDirWriteLease(local_index_path_prefix);
     build_config[DISK_ANN_PREFIX_PATH] = local_index_path_prefix;
 
     const auto& offset_mapping = GetOffsetMapping();
@@ -553,6 +561,7 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
         if (dim.has_value()) {
             SetDim(dim.value());
         }
+        file_manager_->RemoveRawDataFiles();
         return;
     }
 
@@ -575,7 +584,7 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
         file_manager_->AddFile(empty_offsets_path);
         SetDim(dataset->GetDim());
         empty_emb_list_offsets_ = std::move(empty_offsets);
-        local_chunk_manager->RemoveDir(local_raw_data_prefix);
+        file_manager_->RemoveRawDataFiles();
         return;
     }
 
@@ -652,7 +661,7 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
         file_manager_->AddFile(valid_data_path);
     }
 
-    local_chunk_manager->RemoveDir(local_raw_data_prefix);
+    file_manager_->RemoveRawDataFiles();
 
     // TODO ::
     // SetDim(index_->Dim());
@@ -884,11 +893,8 @@ VectorDiskAnnIndex<T>::GetEmbListByIds(const DatasetPtr dataset,
 template <typename T>
 void
 VectorDiskAnnIndex<T>::CleanLocalData() {
-    auto local_chunk_manager =
-        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    local_chunk_manager->RemoveDir(file_manager_->GetLocalIndexObjectPrefix());
-    local_chunk_manager->RemoveDir(
-        file_manager_->GetLocalRawDataObjectPrefix());
+    file_manager_->RemoveIndexFiles();
+    file_manager_->RemoveRawDataFiles();
 }
 
 template <typename T>

--- a/internal/core/src/index/VectorDiskIndex.cpp
+++ b/internal/core/src/index/VectorDiskIndex.cpp
@@ -406,19 +406,15 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
     knowhere::Json build_config;
     build_config.update(config);
 
-    auto segment_id = file_manager_->GetFieldDataMeta().segment_id;
-    auto field_id = file_manager_->GetFieldDataMeta().field_id;
-
     auto is_embedding_list = (elem_type_ != DataType::NONE);
     Config config_with_emb_list = config;
     config_with_emb_list[EMB_LIST] = is_embedding_list;
+    auto local_raw_data_prefix = file_manager_->GetLocalRawDataObjectPrefix();
 
     std::string offsets_path;
     // Set offsets path in config for VECTOR_ARRAY
     if (is_embedding_list) {
-        offsets_path = storage::GenFieldRawDataPathPrefix(
-                           local_chunk_manager, segment_id, field_id) +
-                       "offset";
+        offsets_path = local_raw_data_prefix + "offset";
         config_with_emb_list[EMB_LIST_OFFSETS_PATH] = offsets_path;
     }
 
@@ -442,8 +438,7 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
                 SetDim(dim.value());
             }
             file_manager_->AddFile(valid_data_path);
-            local_chunk_manager->RemoveDir(storage::GenFieldRawDataPathPrefix(
-                local_chunk_manager, segment_id, field_id));
+            local_chunk_manager->RemoveDir(local_raw_data_prefix);
             LOG_INFO("build all-null nullable disk index done, build_id: {}",
                      config.value("build_id", "unknown"));
             return;
@@ -475,8 +470,7 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
             if (local_chunk_manager->Exist(valid_data_path)) {
                 file_manager_->AddFile(valid_data_path);
             }
-            local_chunk_manager->RemoveDir(storage::GenFieldRawDataPathPrefix(
-                local_chunk_manager, segment_id, field_id));
+            local_chunk_manager->RemoveDir(local_raw_data_prefix);
             empty_emb_list_offsets_ = std::move(offsets.value());
             LOG_INFO("build all-empty emb_list disk index done, build_id: {}",
                      config.value("build_id", "unknown"));
@@ -522,8 +516,7 @@ VectorDiskAnnIndex<T>::Build(const Config& config) {
         file_manager_->AddFile(valid_data_path);
     }
 
-    local_chunk_manager->RemoveDir(storage::GenFieldRawDataPathPrefix(
-        local_chunk_manager, segment_id, field_id));
+    local_chunk_manager->RemoveDir(local_raw_data_prefix);
 
     LOG_INFO("build disk index done, build_id: {}",
              config.value("build_id", "unknown"));
@@ -542,11 +535,8 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
     build_config[EMB_LIST] = is_embedding_list;
 
     // set data path
-    auto segment_id = file_manager_->GetFieldDataMeta().segment_id;
-    auto field_id = file_manager_->GetFieldDataMeta().field_id;
-    auto local_data_path = storage::GenFieldRawDataPathPrefix(
-                               local_chunk_manager, segment_id, field_id) +
-                           "raw_data";
+    auto local_raw_data_prefix = file_manager_->GetLocalRawDataObjectPrefix();
+    auto local_data_path = local_raw_data_prefix + "raw_data";
     build_config[DISK_ANN_RAW_DATA_PATH] = local_data_path;
 
     auto local_index_path_prefix = file_manager_->GetLocalIndexObjectPrefix();
@@ -585,8 +575,7 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
         file_manager_->AddFile(empty_offsets_path);
         SetDim(dataset->GetDim());
         empty_emb_list_offsets_ = std::move(empty_offsets);
-        local_chunk_manager->RemoveDir(storage::GenFieldRawDataPathPrefix(
-            local_chunk_manager, segment_id, field_id));
+        local_chunk_manager->RemoveDir(local_raw_data_prefix);
         return;
     }
 
@@ -626,10 +615,7 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
         }
 
         // Write offsets to disk file (use same path convention as Build method)
-        std::string offsets_path =
-            storage::GenFieldRawDataPathPrefix(
-                local_chunk_manager, segment_id, field_id) +
-            "offset";
+        std::string offsets_path = local_raw_data_prefix + "offset";
         local_chunk_manager->CreateFile(offsets_path);
 
         size_t total_vectors =
@@ -666,8 +652,7 @@ VectorDiskAnnIndex<T>::BuildWithDataset(const DatasetPtr& dataset,
         file_manager_->AddFile(valid_data_path);
     }
 
-    local_chunk_manager->RemoveDir(storage::GenFieldRawDataPathPrefix(
-        local_chunk_manager, segment_id, field_id));
+    local_chunk_manager->RemoveDir(local_raw_data_prefix);
 
     // TODO ::
     // SetDim(index_->Dim());

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -78,7 +78,8 @@ JsonKeyStats::JsonKeyStats(const storage::FileManagerContext& ctx,
                            double json_stats_shredding_ratio_threshold,
                            int64_t json_stats_write_batch_size,
                            uint32_t tantivy_index_version)
-    : ScalarIndex<std::string>(JSON_KEY_STATS_INDEX_TYPE) {
+    : ScalarIndex<std::string>(JSON_KEY_STATS_INDEX_TYPE),
+      file_manager_context_(ctx) {
     schema_ = ctx.fieldDataMeta.field_schema;
     field_id_ = ctx.fieldDataMeta.field_id;
     segment_id_ = ctx.fieldDataMeta.segment_id;
@@ -1125,7 +1126,7 @@ JsonKeyStats::LoadSharedKeyIndex(
     std::unique_ptr<cachinglayer::Translator<index::BsonInvertedIndex>>
         translator = std::make_unique<
             segcore::storagev1translator::BsonInvertedIndexTranslator>(
-            load_info, disk_file_manager_);
+            load_info, file_manager_context_);
 
     bson_index_cache_slot_ =
         cachinglayer::Manager::GetInstance().CreateCacheSlot(

--- a/internal/core/src/index/json_stats/JsonKeyStats.h
+++ b/internal/core/src/index/json_stats/JsonKeyStats.h
@@ -673,6 +673,7 @@ class JsonKeyStats : public ScalarIndex<std::string> {
     int64_t num_rows_{0};
     bool is_built_ = false;
     std::string path_;
+    milvus::storage::FileManagerContext file_manager_context_;
     milvus::storage::ChunkManagerPtr rcm_;
     std::shared_ptr<milvus::storage::MemFileManagerImpl> mem_file_manager_;
     std::shared_ptr<milvus::storage::DiskFileManagerImpl> disk_file_manager_;

--- a/internal/core/src/segcore/load_index_c.cpp
+++ b/internal/core/src/segcore/load_index_c.cpp
@@ -292,17 +292,8 @@ CleanLoadedIndex(CLoadIndexInfo c_load_index_info) {
     try {
         auto load_index_info =
             (milvus::segcore::LoadIndexInfo*)c_load_index_info;
-        auto local_chunk_manager =
-            milvus::storage::LocalChunkManagerSingleton::GetInstance()
-                .GetChunkManager();
-        auto index_file_path_prefix =
-            milvus::storage::GenIndexPathPrefix(local_chunk_manager,
-                                                load_index_info->index_build_id,
-                                                load_index_info->index_version,
-                                                load_index_info->segment_id,
-                                                load_index_info->field_id,
-                                                false);
-        local_chunk_manager->RemoveDir(index_file_path_prefix);
+        load_index_info->cache_index.reset();
+        load_index_info->index.reset();
         auto status = CStatus();
         status.error_code = milvus::Success;
         status.error_msg = "";

--- a/internal/core/src/segcore/load_index_c_test.cpp
+++ b/internal/core/src/segcore/load_index_c_test.cpp
@@ -58,6 +58,9 @@
 #include "segcore/load_index_c.h"
 #include "segcore/plan_c.h"
 #include "segcore/segment_c.h"
+#include "storage/DiskFileManagerImpl.h"
+#include "storage/LocalChunkManagerSingleton.h"
+#include "storage/Util.h"
 #include "test_utils/DataGen.h"
 #include "test_utils/GenExprProto.h"
 #include "test_utils/PbHelper.h"
@@ -74,6 +77,123 @@ using namespace knowhere;
 
 const int64_t ROW_COUNT = 10 * 1000;
 const int64_t BIAS = 4200;
+
+namespace {
+
+class LocalDirOwningIndex : public milvus::index::IndexBase {
+ public:
+    explicit LocalDirOwningIndex(
+        const milvus::storage::FileManagerContext& file_manager_context)
+        : IndexBase("LOCAL_DIR_OWNING"),
+          disk_file_manager_(
+              std::make_shared<milvus::storage::DiskFileManagerImpl>(
+                  file_manager_context)),
+          local_index_prefix_(disk_file_manager_->GetLocalIndexObjectPrefix()) {
+    }
+
+    const std::string&
+    LocalIndexPrefix() const {
+        return local_index_prefix_;
+    }
+
+    milvus::BinarySet
+    Serialize(const milvus::Config& /*config*/) override {
+        return {};
+    }
+
+    void
+    Load(const milvus::BinarySet& /*binary_set*/,
+         const milvus::Config& /*config*/ = {}) override {
+    }
+
+    void
+    Load(milvus::tracer::TraceContext /*ctx*/,
+         const milvus::Config& /*config*/ = {}) override {
+    }
+
+    void
+    BuildWithRawDataForUT(size_t /*n*/,
+                          const void* /*values*/,
+                          const milvus::Config& /*config*/ = {}) override {
+    }
+
+    void
+    BuildWithDataset(const milvus::DatasetPtr& /*dataset*/,
+                     const milvus::Config& /*config*/ = {}) override {
+    }
+
+    void
+    Build(const milvus::Config& /*config*/ = {}) override {
+    }
+
+    int64_t
+    Count() override {
+        return 0;
+    }
+
+    milvus::index::IndexStatsPtr
+    Upload(const milvus::Config& /*config*/ = {}) override {
+        return nullptr;
+    }
+
+    const bool
+    HasRawData() const override {
+        return false;
+    }
+
+    bool
+    IsMmapSupported() const override {
+        return false;
+    }
+
+ private:
+    std::shared_ptr<milvus::storage::DiskFileManagerImpl> disk_file_manager_;
+    std::string local_index_prefix_;
+};
+
+milvus::storage::FileManagerContext
+MakeFileManagerContext(const milvus::segcore::LoadIndexInfo& load_index_info) {
+    auto local_chunk_manager =
+        milvus::storage::LocalChunkManagerSingleton::GetInstance()
+            .GetChunkManager();
+
+    milvus::proto::schema::FieldSchema field_schema;
+    field_schema.set_fieldid(load_index_info.field_id);
+    field_schema.set_data_type(milvus::proto::schema::DataType::FloatVector);
+
+    milvus::storage::FieldDataMeta field_meta{load_index_info.collection_id,
+                                              load_index_info.partition_id,
+                                              load_index_info.segment_id,
+                                              load_index_info.field_id,
+                                              field_schema};
+    milvus::storage::IndexMeta index_meta{load_index_info.segment_id,
+                                          load_index_info.field_id,
+                                          load_index_info.index_build_id,
+                                          load_index_info.index_version,
+                                          "clean_loaded_index",
+                                          "vector",
+                                          milvus::DataType::VECTOR_FLOAT,
+                                          DIM,
+                                          false};
+    return milvus::storage::FileManagerContext(
+        field_meta, index_meta, local_chunk_manager, nullptr);
+}
+
+std::pair<std::unique_ptr<LocalDirOwningIndex>, std::string>
+CreateLocalDirOwningIndexFile(
+    const milvus::storage::FileManagerContext& file_manager_context,
+    const std::string& file_name) {
+    auto local_chunk_manager =
+        milvus::storage::LocalChunkManagerSingleton::GetInstance()
+            .GetChunkManager();
+    auto index = std::make_unique<LocalDirOwningIndex>(file_manager_context);
+    auto local_file = index->LocalIndexPrefix() + file_name;
+    local_chunk_manager->CreateFile(local_file);
+    EXPECT_TRUE(local_chunk_manager->Exist(local_file));
+    return {std::move(index), local_file};
+}
+
+}  // namespace
 
 auto
 generate_data(int N) {
@@ -185,6 +305,45 @@ TEST(LoadIndexCTest, FinishLoadIndexInfoPreservesIndexStorePathVersion) {
     EXPECT_EQ(load_index_info.index_store_path_version,
               milvus::proto::index::IndexStorePathVersion::
                   INDEX_STORE_PATH_VERSION_COLLECTION_ROOTED);
+}
+
+TEST(LoadIndexCTest, CleanLoadedIndexDoesNotRemoveSiblingGeneration) {
+    auto local_chunk_manager =
+        milvus::storage::LocalChunkManagerSingleton::GetInstance()
+            .GetChunkManager();
+
+    milvus::segcore::LoadIndexInfo load_index_info;
+    load_index_info.collection_id = 100;
+    load_index_info.partition_id = 20;
+    load_index_info.segment_id = 30;
+    load_index_info.field_id = 40;
+    load_index_info.index_build_id = 50;
+    load_index_info.index_version = 1;
+    load_index_info.field_type = milvus::DataType::VECTOR_FLOAT;
+    load_index_info.dim = DIM;
+
+    auto file_manager_context = MakeFileManagerContext(load_index_info);
+    auto [index, index_file] =
+        CreateLocalDirOwningIndexFile(file_manager_context, "index_data");
+    auto [cache_index, cache_index_file] =
+        CreateLocalDirOwningIndexFile(file_manager_context, "cache_index_data");
+    auto [sibling_index, sibling_file] = CreateLocalDirOwningIndexFile(
+        file_manager_context, "sibling_index_data");
+    load_index_info.index = std::move(index);
+    load_index_info.cache_index = CreateTestCacheIndex(
+        "clean_loaded_index_cache", std::move(cache_index));
+    ASSERT_TRUE(local_chunk_manager->Exist(index_file));
+    ASSERT_TRUE(local_chunk_manager->Exist(cache_index_file));
+    ASSERT_NE(sibling_index, nullptr);
+    ASSERT_TRUE(local_chunk_manager->Exist(sibling_file));
+
+    auto status =
+        CleanLoadedIndex(static_cast<CLoadIndexInfo>(&load_index_info));
+
+    ASSERT_EQ(status.error_code, milvus::Success);
+    EXPECT_TRUE(local_chunk_manager->Exist(sibling_file));
+    EXPECT_FALSE(local_chunk_manager->Exist(index_file));
+    EXPECT_FALSE(local_chunk_manager->Exist(cache_index_file));
 }
 
 template <class TraitType>

--- a/internal/core/src/segcore/storagev1translator/BsonInvertedIndexTranslator.cpp
+++ b/internal/core/src/segcore/storagev1translator/BsonInvertedIndexTranslator.cpp
@@ -28,14 +28,15 @@
 #include "log/Log.h"
 #include "pb/common.pb.h"
 #include "segcore/Utils.h"
+#include "storage/DiskFileManagerImpl.h"
 
 namespace milvus::segcore::storagev1translator {
 
 BsonInvertedIndexTranslator::BsonInvertedIndexTranslator(
     BsonInvertedIndexLoadInfo load_info,
-    std::shared_ptr<milvus::storage::DiskFileManagerImpl> disk_file_manager)
+    milvus::storage::FileManagerContext file_manager_context)
     : load_info_(std::move(load_info)),
-      disk_file_manager_(disk_file_manager),
+      file_manager_context_(std::move(file_manager_context)),
       key_(fmt::format("seg_{}_json_stats_shared_field_{}",
                        load_info_.segment_id,
                        load_info_.field_id)),
@@ -96,8 +97,11 @@ BsonInvertedIndexTranslator::get_cells(
     CheckCancellation(
         ctx, load_info_.segment_id, "BsonInvertedIndexTranslator::get_cells()");
 
+    auto disk_file_manager =
+        std::make_shared<milvus::storage::DiskFileManagerImpl>(
+            file_manager_context_);
     auto index =
-        std::make_unique<milvus::index::BsonInvertedIndex>(disk_file_manager_);
+        std::make_unique<milvus::index::BsonInvertedIndex>(disk_file_manager);
 
     {
         milvus::ScopedTimer timer(

--- a/internal/core/src/segcore/storagev1translator/BsonInvertedIndexTranslator.h
+++ b/internal/core/src/segcore/storagev1translator/BsonInvertedIndexTranslator.h
@@ -42,8 +42,7 @@ class BsonInvertedIndexTranslator : public milvus::cachinglayer::Translator<
  public:
     BsonInvertedIndexTranslator(
         BsonInvertedIndexLoadInfo load_info,
-        std::shared_ptr<milvus::storage::DiskFileManagerImpl>
-            disk_file_manager);
+        milvus::storage::FileManagerContext file_manager_context);
 
     ~BsonInvertedIndexTranslator() override = default;
 
@@ -74,7 +73,7 @@ class BsonInvertedIndexTranslator : public milvus::cachinglayer::Translator<
 
  private:
     BsonInvertedIndexLoadInfo load_info_;
-    std::shared_ptr<milvus::storage::DiskFileManagerImpl> disk_file_manager_;
+    milvus::storage::FileManagerContext file_manager_context_;
     std::string key_;
     milvus::cachinglayer::Meta meta_;
 };

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -70,10 +70,17 @@
 #include "storage/Util.h"
 
 namespace milvus::storage {
+
+namespace {
+std::atomic<uint64_t> g_file_path_generation{0};
+}
+
 DiskFileManagerImpl::DiskFileManagerImpl(
     const FileManagerContext& fileManagerContext)
     : FileManagerImpl(fileManagerContext.fieldDataMeta,
-                      fileManagerContext.indexMeta) {
+                      fileManagerContext.indexMeta),
+      file_path_generation_(
+          g_file_path_generation.fetch_add(1, std::memory_order_relaxed)) {
     rcm_ = fileManagerContext.chunkManagerPtr;
     fs_ = fileManagerContext.fs;
     plugin_context_ = fileManagerContext.plugin_context;
@@ -82,10 +89,11 @@ DiskFileManagerImpl::DiskFileManagerImpl(
 }
 
 DiskFileManagerImpl::~DiskFileManagerImpl() {
-    RemoveIndexFiles();
-    RemoveTextLogFiles();
-    RemoveJsonStatsFiles();
-    RemoveNgramIndexFiles();
+    RemoveLocalDirBestEffort(GetLocalIndexObjectPrefix());
+    RemoveLocalDirBestEffort(GetLocalTextIndexPrefix());
+    RemoveLocalDirBestEffort(GetLocalJsonStatsPrefix());
+    RemoveLocalDirBestEffort(GetLocalNgramIndexPrefix());
+    RemoveLocalDirBestEffort(GetLocalRawDataObjectPrefix());
 }
 
 bool
@@ -142,6 +150,46 @@ DiskFileManagerImpl::GetRemoteJsonStatsMetaPath(const std::string& file_name) {
 std::string
 DiskFileManagerImpl::GetLocalJsonStatsMetaPrefix() {
     return GetLocalJsonStatsPrefix();
+}
+
+std::string
+DiskFileManagerImpl::AppendLocalPathGeneration(
+    const std::string& prefix) const {
+    namespace fs = std::filesystem;
+    auto base = prefix;
+    auto is_path_separator = [](char c) { return c == '/' || c == '\\'; };
+    while (!base.empty() && is_path_separator(base.back())) {
+        base.pop_back();
+    }
+
+    auto path = fs::path(base);
+    auto leaf = path.filename().string();
+    auto result =
+        leaf.empty()
+            ? (fs::path(prefix) / std::to_string(file_path_generation_))
+                  .string()
+            : (path.parent_path() /
+               fmt::format("{}_{}", leaf, file_path_generation_))
+                  .string();
+    if (!result.empty() && result.back() != fs::path::preferred_separator) {
+        result += fs::path::preferred_separator;
+    }
+    return result;
+}
+
+void
+DiskFileManagerImpl::RemoveLocalDirBestEffort(const std::string& dir) noexcept {
+    try {
+        auto local_chunk_manager =
+            LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+        if (local_chunk_manager != nullptr) {
+            local_chunk_manager->RemoveDir(dir);
+        }
+    } catch (const std::exception& e) {
+        LOG_WARN("failed to remove local dir {}, error: {}", dir, e.what());
+    } catch (...) {
+        LOG_WARN("failed to remove local dir {}, unknown error", dir);
+    }
 }
 
 bool
@@ -636,11 +684,7 @@ DiskFileManagerImpl::cache_raw_data_to_disk_common(
     auto data_type = field_data->get_data_type();
     if (!file_created) {
         auto init_file_info = [&](milvus::DataType dt) {
-            local_data_path = storage::GenFieldRawDataPathPrefix(
-                                  local_chunk_manager,
-                                  GetFieldDataMeta().segment_id,
-                                  GetFieldDataMeta().field_id) +
-                              "raw_data";
+            local_data_path = GetLocalRawDataObjectPrefix() + "raw_data";
             if (dt == milvus::DataType::VECTOR_SPARSE_U32_F32) {
                 local_data_path += ".sparse_u32_f32";
             }
@@ -1092,13 +1136,10 @@ DiskFileManagerImpl::CacheOptFieldToDisk(const Config& config) {
             "vector index build with multiple fields is not supported yet");
     }
 
-    auto segment_id = GetFieldDataMeta().segment_id;
-    auto vec_field_id = GetFieldDataMeta().field_id;
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    auto local_data_path = storage::GenFieldRawDataPathPrefix(
-                               local_chunk_manager, segment_id, vec_field_id) +
-                           std::string(VEC_OPT_FIELDS);
+    auto local_data_path =
+        GetLocalRawDataObjectPrefix() + std::string(VEC_OPT_FIELDS);
     local_chunk_manager->CreateFile(local_data_path);
     uint64_t write_offset = 0;
     WriteOptFieldsIvfMeta(
@@ -1171,13 +1212,10 @@ DiskFileManagerImpl::cache_opt_field_to_disk_v2(const Config& config) {
             "vector index build with multiple fields is not supported yet");
     }
 
-    auto segment_id = GetFieldDataMeta().segment_id;
-    auto vec_field_id = GetFieldDataMeta().field_id;
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    auto local_data_path = storage::GenFieldRawDataPathPrefix(
-                               local_chunk_manager, segment_id, vec_field_id) +
-                           std::string(VEC_OPT_FIELDS);
+    auto local_data_path =
+        GetLocalRawDataObjectPrefix() + std::string(VEC_OPT_FIELDS);
     local_chunk_manager->CreateFile(local_data_path);
     uint64_t write_offset = 0;
     WriteOptFieldsIvfMeta(
@@ -1245,13 +1283,10 @@ DiskFileManagerImpl::cache_opt_field_to_disk_v3(const Config& config) {
                "[StorageV3] loon ffi properties is null when build index "
                "with manifest");
 
-    auto segment_id = GetFieldDataMeta().segment_id;
-    auto vec_field_id = GetFieldDataMeta().field_id;
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    auto local_data_path = storage::GenFieldRawDataPathPrefix(
-                               local_chunk_manager, segment_id, vec_field_id) +
-                           std::string(VEC_OPT_FIELDS);
+    auto local_data_path =
+        GetLocalRawDataObjectPrefix() + std::string(VEC_OPT_FIELDS);
     local_chunk_manager->CreateFile(local_data_path);
     uint64_t write_offset = 0;
     WriteOptFieldsIvfMeta(
@@ -1321,12 +1356,13 @@ std::string
 DiskFileManagerImpl::GetLocalIndexObjectPrefix() {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return GenIndexPathPrefix(local_chunk_manager,
-                              index_meta_.build_id,
-                              index_meta_.index_version,
-                              index_meta_.segment_id,
-                              index_meta_.field_id,
-                              false);
+    return AppendLocalPathGeneration(
+        GenIndexPathPrefix(local_chunk_manager,
+                           index_meta_.build_id,
+                           index_meta_.index_version,
+                           index_meta_.segment_id,
+                           index_meta_.field_id,
+                           false));
 }
 
 // temporary path used during index building
@@ -1334,12 +1370,13 @@ std::string
 DiskFileManagerImpl::GetLocalTempIndexObjectPrefix() {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return GenIndexPathPrefix(local_chunk_manager,
-                              index_meta_.build_id,
-                              index_meta_.index_version,
-                              index_meta_.segment_id,
-                              index_meta_.field_id,
-                              true);
+    return AppendLocalPathGeneration(
+        GenIndexPathPrefix(local_chunk_manager,
+                           index_meta_.build_id,
+                           index_meta_.index_version,
+                           index_meta_.segment_id,
+                           index_meta_.field_id,
+                           true));
 }
 
 // path to store pre-built index contents downloaded from remote storage
@@ -1347,12 +1384,13 @@ std::string
 DiskFileManagerImpl::GetLocalTextIndexPrefix() {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return GenTextIndexPathPrefix(local_chunk_manager,
-                                  index_meta_.build_id,
-                                  index_meta_.index_version,
-                                  field_meta_.segment_id,
-                                  field_meta_.field_id,
-                                  false);
+    return AppendLocalPathGeneration(
+        GenTextIndexPathPrefix(local_chunk_manager,
+                               index_meta_.build_id,
+                               index_meta_.index_version,
+                               field_meta_.segment_id,
+                               field_meta_.field_id,
+                               false));
 }
 
 // temporary path used during index building
@@ -1360,36 +1398,39 @@ std::string
 DiskFileManagerImpl::GetLocalTempTextIndexPrefix() {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return GenIndexPathPrefix(local_chunk_manager,
-                              index_meta_.build_id,
-                              index_meta_.index_version,
-                              field_meta_.segment_id,
-                              field_meta_.field_id,
-                              true);
+    return AppendLocalPathGeneration(
+        GenIndexPathPrefix(local_chunk_manager,
+                           index_meta_.build_id,
+                           index_meta_.index_version,
+                           field_meta_.segment_id,
+                           field_meta_.field_id,
+                           true));
 }
 
 std::string
 DiskFileManagerImpl::GetLocalJsonStatsPrefix() {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return GenJsonStatsPathPrefix(local_chunk_manager,
-                                  index_meta_.build_id,
-                                  index_meta_.index_version,
-                                  field_meta_.segment_id,
-                                  field_meta_.field_id,
-                                  false);
+    return AppendLocalPathGeneration(
+        GenJsonStatsPathPrefix(local_chunk_manager,
+                               index_meta_.build_id,
+                               index_meta_.index_version,
+                               field_meta_.segment_id,
+                               field_meta_.field_id,
+                               false));
 }
 
 std::string
 DiskFileManagerImpl::GetLocalTempJsonStatsPrefix() {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return GenJsonStatsPathPrefix(local_chunk_manager,
-                                  index_meta_.build_id,
-                                  index_meta_.index_version,
-                                  field_meta_.segment_id,
-                                  field_meta_.field_id,
-                                  true);
+    return AppendLocalPathGeneration(
+        GenJsonStatsPathPrefix(local_chunk_manager,
+                               index_meta_.build_id,
+                               index_meta_.index_version,
+                               field_meta_.segment_id,
+                               field_meta_.field_id,
+                               true));
 }
 
 std::string
@@ -1426,24 +1467,26 @@ std::string
 DiskFileManagerImpl::GetLocalNgramIndexPrefix() {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return GenNgramIndexPrefix(local_chunk_manager,
-                               index_meta_.build_id,
-                               index_meta_.index_version,
-                               field_meta_.segment_id,
-                               field_meta_.field_id,
-                               false);
+    return AppendLocalPathGeneration(
+        GenNgramIndexPrefix(local_chunk_manager,
+                            index_meta_.build_id,
+                            index_meta_.index_version,
+                            field_meta_.segment_id,
+                            field_meta_.field_id,
+                            false));
 }
 
 std::string
 DiskFileManagerImpl::GetLocalTempNgramIndexPrefix() {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return GenNgramIndexPrefix(local_chunk_manager,
-                               index_meta_.build_id,
-                               index_meta_.index_version,
-                               field_meta_.segment_id,
-                               field_meta_.field_id,
-                               true);
+    return AppendLocalPathGeneration(
+        GenNgramIndexPrefix(local_chunk_manager,
+                            index_meta_.build_id,
+                            index_meta_.index_version,
+                            field_meta_.segment_id,
+                            field_meta_.field_id,
+                            true));
 }
 
 std::string
@@ -1464,8 +1507,8 @@ std::string
 DiskFileManagerImpl::GetLocalRawDataObjectPrefix() {
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    return GenFieldRawDataPathPrefix(
-        local_chunk_manager, field_meta_.segment_id, field_meta_.field_id);
+    return AppendLocalPathGeneration(GenFieldRawDataPathPrefix(
+        local_chunk_manager, field_meta_.segment_id, field_meta_.field_id));
 }
 
 bool

--- a/internal/core/src/storage/DiskFileManagerImpl.cpp
+++ b/internal/core/src/storage/DiskFileManagerImpl.cpp
@@ -75,6 +75,66 @@ namespace {
 std::atomic<uint64_t> g_file_path_generation{0};
 }
 
+struct DiskFileManagerImpl::LocalDirState {
+    explicit LocalDirState(std::string dir) : dir(std::move(dir)) {
+    }
+
+    std::string dir;
+    std::mutex mutex;
+    bool closed = false;
+    bool delete_on_zero = false;
+    uint64_t active_writers = 0;
+};
+
+DiskFileManagerImpl::LocalDirWriteLease::LocalDirWriteLease(
+    std::shared_ptr<LocalDirState> state)
+    : state_(std::move(state)) {
+}
+
+DiskFileManagerImpl::LocalDirWriteLease&
+DiskFileManagerImpl::LocalDirWriteLease::operator=(
+    LocalDirWriteLease&& other) noexcept {
+    if (this != &other) {
+        Release();
+        state_ = std::move(other.state_);
+    }
+    return *this;
+}
+
+DiskFileManagerImpl::LocalDirWriteLease::~LocalDirWriteLease() {
+    Release();
+}
+
+void
+DiskFileManagerImpl::LocalDirWriteLease::Release() noexcept {
+    auto state = std::exchange(state_, nullptr);
+    if (state == nullptr) {
+        return;
+    }
+
+    bool remove_dir = false;
+    std::string dir;
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        if (state->active_writers == 0) {
+            LOG_WARN(
+                "local dir write lease released with no active writers, "
+                "dir: {}",
+                state->dir);
+            return;
+        }
+        --state->active_writers;
+        if (state->active_writers == 0 && state->delete_on_zero) {
+            remove_dir = true;
+            dir = state->dir;
+        }
+    }
+
+    if (remove_dir) {
+        DiskFileManagerImpl::RemoveLocalDirBestEffort(dir);
+    }
+}
+
 DiskFileManagerImpl::DiskFileManagerImpl(
     const FileManagerContext& fileManagerContext)
     : FileManagerImpl(fileManagerContext.fieldDataMeta,
@@ -89,11 +149,11 @@ DiskFileManagerImpl::DiskFileManagerImpl(
 }
 
 DiskFileManagerImpl::~DiskFileManagerImpl() {
-    RemoveLocalDirBestEffort(GetLocalIndexObjectPrefix());
-    RemoveLocalDirBestEffort(GetLocalTextIndexPrefix());
-    RemoveLocalDirBestEffort(GetLocalJsonStatsPrefix());
-    RemoveLocalDirBestEffort(GetLocalNgramIndexPrefix());
-    RemoveLocalDirBestEffort(GetLocalRawDataObjectPrefix());
+    RemoveIndexFiles();
+    RemoveTextLogFiles();
+    RemoveJsonStatsFiles();
+    RemoveNgramIndexFiles();
+    RemoveRawDataFiles();
 }
 
 bool
@@ -189,6 +249,56 @@ DiskFileManagerImpl::RemoveLocalDirBestEffort(const std::string& dir) noexcept {
         LOG_WARN("failed to remove local dir {}, error: {}", dir, e.what());
     } catch (...) {
         LOG_WARN("failed to remove local dir {}, unknown error", dir);
+    }
+}
+
+std::shared_ptr<DiskFileManagerImpl::LocalDirState>
+DiskFileManagerImpl::GetOrCreateLocalDirState(const std::string& dir) {
+    std::lock_guard<std::mutex> lock(local_dir_states_mutex_);
+    auto it = local_dir_states_.find(dir);
+    if (it != local_dir_states_.end()) {
+        return it->second;
+    }
+
+    auto state = std::make_shared<LocalDirState>(dir);
+    local_dir_states_.emplace(dir, state);
+    return state;
+}
+
+DiskFileManagerImpl::LocalDirWriteLease
+DiskFileManagerImpl::AcquireLocalDirWriteLease(const std::string& dir) {
+    auto state = GetOrCreateLocalDirState(dir);
+    std::lock_guard<std::mutex> lock(state->mutex);
+    if (state->closed) {
+        ThrowInfo(FileWriteFailed,
+                  fmt::format("local dir {} is closed for cleanup", dir));
+    }
+    ++state->active_writers;
+    return LocalDirWriteLease(std::move(state));
+}
+
+void
+DiskFileManagerImpl::CloseAndRemoveLocalDir(const std::string& dir) noexcept {
+    try {
+        auto state = GetOrCreateLocalDirState(dir);
+        bool remove_dir = false;
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            state->closed = true;
+            if (state->active_writers == 0) {
+                remove_dir = true;
+            } else {
+                state->delete_on_zero = true;
+            }
+        }
+
+        if (remove_dir) {
+            RemoveLocalDirBestEffort(dir);
+        }
+    } catch (const std::exception& e) {
+        LOG_WARN("failed to close local dir {}, error: {}", dir, e.what());
+    } catch (...) {
+        LOG_WARN("failed to close local dir {}, unknown error", dir);
     }
 }
 
@@ -452,32 +562,36 @@ void
 DiskFileManagerImpl::CacheIndexToDisk(
     const std::vector<std::string>& remote_files,
     milvus::proto::common::LoadPriority priority) {
-    return CacheIndexToDiskInternal(
-        remote_files, GetLocalIndexObjectPrefix(), priority);
+    auto local_prefix = GetLocalIndexObjectPrefix();
+    auto lease = AcquireLocalDirWriteLease(local_prefix);
+    CacheIndexToDiskInternal(remote_files, local_prefix, priority);
 }
 
 void
 DiskFileManagerImpl::CacheTextLogToDisk(
     const std::vector<std::string>& remote_files,
     milvus::proto::common::LoadPriority priority) {
-    return CacheIndexToDiskInternal(
-        remote_files, GetLocalTextIndexPrefix(), priority);
+    auto local_prefix = GetLocalTextIndexPrefix();
+    auto lease = AcquireLocalDirWriteLease(local_prefix);
+    CacheIndexToDiskInternal(remote_files, local_prefix, priority);
 }
 
 void
 DiskFileManagerImpl::CacheNgramIndexToDisk(
     const std::vector<std::string>& remote_files,
     milvus::proto::common::LoadPriority priority) {
-    return CacheIndexToDiskInternal(
-        remote_files, GetLocalNgramIndexPrefix(), priority);
+    auto local_prefix = GetLocalNgramIndexPrefix();
+    auto lease = AcquireLocalDirWriteLease(local_prefix);
+    CacheIndexToDiskInternal(remote_files, local_prefix, priority);
 }
 
 void
 DiskFileManagerImpl::CacheJsonStatsSharedIndexToDisk(
     const std::vector<std::string>& remote_files,
     milvus::proto::common::LoadPriority priority) {
-    return CacheIndexToDiskInternal(
-        remote_files, GetLocalJsonStatsSharedIndexPrefix(), priority);
+    auto local_prefix = GetLocalJsonStatsSharedIndexPrefix();
+    auto lease = AcquireLocalDirWriteLease(GetLocalJsonStatsPrefix());
+    CacheIndexToDiskInternal(remote_files, local_prefix, priority);
 }
 
 std::string
@@ -487,6 +601,7 @@ DiskFileManagerImpl::CacheJsonStatsMetaToDisk(
     auto local_chunk_manager =
         LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     auto local_prefix = GetLocalJsonStatsMetaPrefix();
+    auto lease = AcquireLocalDirWriteLease(GetLocalJsonStatsPrefix());
 
     auto file_name = remote_file.substr(remote_file.find_last_of('/') + 1);
     auto local_file =
@@ -514,6 +629,16 @@ DiskFileManagerImpl::CacheJsonStatsMetaToDisk(
 template <typename DataType>
 std::string
 DiskFileManagerImpl::CacheRawDataToDisk(const Config& config) {
+    auto raw_data_lease =
+        AcquireLocalDirWriteLease(GetLocalRawDataObjectPrefix());
+    std::optional<LocalDirWriteLease> valid_data_lease;
+    if (index::GetValueFromConfig<std::string>(config,
+                                               index::VALID_DATA_PATH_KEY)
+            .has_value()) {
+        valid_data_lease.emplace(
+            AcquireLocalDirWriteLease(GetLocalIndexObjectPrefix()));
+    }
+
     auto storage_version =
         index::GetValueFromConfig<int64_t>(config, STORAGE_VERSION_KEY)
             .value_or(0);
@@ -958,37 +1083,32 @@ DiskFileManagerImpl::cache_raw_data_to_disk_storage_v2(const Config& config) {
 
 void
 DiskFileManagerImpl::RemoveIndexFiles() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    local_chunk_manager->RemoveDir(GetLocalIndexObjectPrefix());
+    CloseAndRemoveLocalDir(GetLocalIndexObjectPrefix());
 }
 
 void
 DiskFileManagerImpl::RemoveTextLogFiles() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    local_chunk_manager->RemoveDir(GetLocalTextIndexPrefix());
+    CloseAndRemoveLocalDir(GetLocalTextIndexPrefix());
 }
 
 void
 DiskFileManagerImpl::RemoveJsonStatsSharedIndexFiles() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    local_chunk_manager->RemoveDir(GetLocalJsonStatsSharedIndexPrefix());
+    CloseAndRemoveLocalDir(GetLocalJsonStatsPrefix());
 }
 
 void
 DiskFileManagerImpl::RemoveJsonStatsFiles() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    local_chunk_manager->RemoveDir(GetLocalJsonStatsPrefix());
+    CloseAndRemoveLocalDir(GetLocalJsonStatsPrefix());
 }
 
 void
 DiskFileManagerImpl::RemoveNgramIndexFiles() {
-    auto local_chunk_manager =
-        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
-    local_chunk_manager->RemoveDir(GetLocalNgramIndexPrefix());
+    CloseAndRemoveLocalDir(GetLocalNgramIndexPrefix());
+}
+
+void
+DiskFileManagerImpl::RemoveRawDataFiles() {
+    CloseAndRemoveLocalDir(GetLocalRawDataObjectPrefix());
 }
 
 template <DataType T>
@@ -1110,6 +1230,13 @@ WriteOptFieldsIvfMeta(
 
 std::string
 DiskFileManagerImpl::CacheOptFieldToDisk(const Config& config) {
+    auto opt_fields =
+        index::GetValueFromConfig<OptFieldT>(config, VEC_OPT_FIELDS);
+    if (!opt_fields.has_value() || opt_fields->empty()) {
+        return "";
+    }
+    auto lease = AcquireLocalDirWriteLease(GetLocalRawDataObjectPrefix());
+
     auto storage_version =
         index::GetValueFromConfig<int64_t>(config, STORAGE_VERSION_KEY)
             .value_or(0);
@@ -1121,16 +1248,9 @@ DiskFileManagerImpl::CacheOptFieldToDisk(const Config& config) {
     }
 
     // legacy path
-    auto opt_fields =
-        index::GetValueFromConfig<OptFieldT>(config, VEC_OPT_FIELDS);
-    if (!opt_fields.has_value()) {
-        return "";
-    }
     auto fields_map = opt_fields.value();
     const uint32_t num_of_fields = fields_map.size();
-    if (0 == num_of_fields) {
-        return "";
-    } else if (num_of_fields > 1) {
+    if (num_of_fields > 1) {
         ThrowInfo(
             ErrorCode::NotImplemented,
             "vector index build with multiple fields is not supported yet");

--- a/internal/core/src/storage/DiskFileManagerImpl.h
+++ b/internal/core/src/storage/DiskFileManagerImpl.h
@@ -19,8 +19,10 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "storage/IndexData.h"
@@ -33,7 +35,36 @@
 namespace milvus::storage {
 
 class DiskFileManagerImpl : public FileManagerImpl {
+ private:
+    struct LocalDirState;
+
  public:
+    class LocalDirWriteLease {
+     public:
+        LocalDirWriteLease() = default;
+        LocalDirWriteLease(LocalDirWriteLease&& other) noexcept = default;
+        LocalDirWriteLease&
+        operator=(LocalDirWriteLease&& other) noexcept;
+        LocalDirWriteLease(const LocalDirWriteLease&) = delete;
+        LocalDirWriteLease&
+        operator=(const LocalDirWriteLease&) = delete;
+        ~LocalDirWriteLease();
+
+        explicit operator bool() const {
+            return state_ != nullptr;
+        }
+
+     private:
+        friend class DiskFileManagerImpl;
+
+        explicit LocalDirWriteLease(std::shared_ptr<LocalDirState> state);
+
+        void
+        Release() noexcept;
+
+        std::shared_ptr<LocalDirState> state_;
+    };
+
     explicit DiskFileManagerImpl(const FileManagerContext& fileManagerContext);
 
     ~DiskFileManagerImpl() override;
@@ -177,6 +208,12 @@ class DiskFileManagerImpl : public FileManagerImpl {
     RemoveNgramIndexFiles();
 
     void
+    RemoveRawDataFiles();
+
+    LocalDirWriteLease
+    AcquireLocalDirWriteLease(const std::string& dir);
+
+    void
     AddBatchIndexFiles(const std::string& local_file_name,
                        const std::vector<int64_t>& local_file_offsets,
                        const std::vector<std::string>& remote_files,
@@ -225,8 +262,14 @@ class DiskFileManagerImpl : public FileManagerImpl {
     std::string
     AppendLocalPathGeneration(const std::string& prefix) const;
 
-    void
+    static void
     RemoveLocalDirBestEffort(const std::string& dir) noexcept;
+
+    void
+    CloseAndRemoveLocalDir(const std::string& dir) noexcept;
+
+    std::shared_ptr<LocalDirState>
+    GetOrCreateLocalDirState(const std::string& dir);
 
     bool
     AddFileInternal(const std::string& file_name,
@@ -282,6 +325,10 @@ class DiskFileManagerImpl : public FileManagerImpl {
 
     // remote file path
     std::map<std::string, int64_t> remote_paths_to_size_;
+
+    mutable std::mutex local_dir_states_mutex_;
+    std::unordered_map<std::string, std::shared_ptr<LocalDirState>>
+        local_dir_states_;
 
     size_t added_total_file_size_ = 0;
 

--- a/internal/core/src/storage/DiskFileManagerImpl.h
+++ b/internal/core/src/storage/DiskFileManagerImpl.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <shared_mutex>
@@ -221,6 +222,12 @@ class DiskFileManagerImpl : public FileManagerImpl {
     std::string
     GetRemoteTextLogPath(const std::string& file_name, int64_t slice_num) const;
 
+    std::string
+    AppendLocalPathGeneration(const std::string& prefix) const;
+
+    void
+    RemoveLocalDirBestEffort(const std::string& dir) noexcept;
+
     bool
     AddFileInternal(const std::string& file_name,
                     const std::function<std::string(const std::string&, int)>&
@@ -277,6 +284,8 @@ class DiskFileManagerImpl : public FileManagerImpl {
     std::map<std::string, int64_t> remote_paths_to_size_;
 
     size_t added_total_file_size_ = 0;
+
+    uint64_t file_path_generation_;
 };
 
 using DiskANNFileManagerImplPtr = std::shared_ptr<DiskFileManagerImpl>;

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -304,7 +304,7 @@ TEST_F(DiskAnnFileManagerTest, OpenInputStreamUsesBasenameForIndexPath) {
         storage::FileManagerContext(field_meta, index_meta, cm_, fs));
 
     const std::string local_path =
-        TestLocalPath + "cache/local_chunk/index_files/1000_1_30_5/index_data";
+        fm->GetLocalIndexObjectPrefix() + "index_data";
     auto output = fm->OpenOutputStream(local_path);
     const uint64_t expected = 0x1020304050607080ULL;
     output->Write(expected);
@@ -345,7 +345,7 @@ TEST_F(DiskAnnFileManagerTest, OpenInputStreamDoesNotUseRemoteParentPath) {
         storage::FileManagerContext(field_meta, index_meta, cm_, fs));
 
     const std::string local_path =
-        TestLocalPath + "cache/local_chunk/index_files/1000_1_30_5/index_data";
+        fm->GetLocalIndexObjectPrefix() + "index_data";
     auto output = fm->OpenOutputStream(local_path);
     const uint64_t expected = 42;
     output->Write(expected);
@@ -540,6 +540,20 @@ const int64_t kOptFieldDataRange = 1000;
 const size_t kEntityCnt = 1000 * 10;
 const FieldDataMeta kOptVecFieldDataMeta = {1, 2, 3, 100};
 using OffsetT = uint32_t;
+
+auto
+StripTrailingPathSeparators(std::string path) -> std::string {
+    auto is_path_separator = [](char c) { return c == '/' || c == '\\'; };
+    while (!path.empty() && is_path_separator(path.back())) {
+        path.pop_back();
+    }
+    return path;
+}
+
+auto
+StartsWith(const std::string& value, const std::string& prefix) -> bool {
+    return value.rfind(prefix, 0) == 0;
+}
 
 auto
 CreateFileManager(const ChunkManagerPtr& cm,
@@ -1210,6 +1224,90 @@ TEST_F(DiskAnnFileManagerTest, CacheRawDataToDiskNullableVector) {
             cm_->Remove(insert_file_path);
         }
     }
+}
+
+TEST_F(DiskAnnFileManagerTest, LocalPathGenerationIsPerFileManager) {
+    auto fm1 = CreateFileManager(cm_, fs_);
+    auto fm2 = CreateFileManager(cm_, fs_);
+
+    EXPECT_NE(fm1->GetLocalIndexObjectPrefix(),
+              fm2->GetLocalIndexObjectPrefix());
+    EXPECT_NE(fm1->GetLocalTempIndexObjectPrefix(),
+              fm2->GetLocalTempIndexObjectPrefix());
+    EXPECT_NE(fm1->GetLocalTextIndexPrefix(), fm2->GetLocalTextIndexPrefix());
+    EXPECT_NE(fm1->GetLocalTempTextIndexPrefix(),
+              fm2->GetLocalTempTextIndexPrefix());
+    EXPECT_NE(fm1->GetLocalJsonStatsPrefix(), fm2->GetLocalJsonStatsPrefix());
+    EXPECT_NE(fm1->GetLocalTempJsonStatsPrefix(),
+              fm2->GetLocalTempJsonStatsPrefix());
+    EXPECT_NE(fm1->GetLocalNgramIndexPrefix(), fm2->GetLocalNgramIndexPrefix());
+    EXPECT_NE(fm1->GetLocalTempNgramIndexPrefix(),
+              fm2->GetLocalTempNgramIndexPrefix());
+    EXPECT_NE(fm1->GetLocalRawDataObjectPrefix(),
+              fm2->GetLocalRawDataObjectPrefix());
+
+    EXPECT_EQ(fm1->GetRemoteIndexObjectPrefix(),
+              fm2->GetRemoteIndexObjectPrefix());
+    EXPECT_EQ(fm1->GetRemoteTextLogPrefix(), fm2->GetRemoteTextLogPrefix());
+}
+
+TEST_F(DiskAnnFileManagerTest, LocalPathGenerationUsesLeafFolderName) {
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    auto file_manager = CreateFileManager(cm_, fs_);
+    auto generated_prefix = file_manager->GetLocalIndexObjectPrefix();
+    auto legacy_prefix = GenIndexPathPrefix(local_chunk_manager,
+                                            1000,
+                                            1,
+                                            kOptVecFieldDataMeta.segment_id,
+                                            kOptVecFieldDataMeta.field_id,
+                                            false);
+
+    auto generated_path =
+        boost::filesystem::path(StripTrailingPathSeparators(generated_prefix));
+    auto legacy_path =
+        boost::filesystem::path(StripTrailingPathSeparators(legacy_prefix));
+
+    EXPECT_EQ(generated_path.parent_path(), legacy_path.parent_path());
+    EXPECT_TRUE(StartsWith(generated_path.filename().string(),
+                           legacy_path.filename().string() + "_"));
+    EXPECT_FALSE(StartsWith(generated_prefix, legacy_prefix));
+
+    auto legacy_file = legacy_prefix + "old_generation/index_data";
+    auto generated_file = generated_prefix + "index_data";
+    local_chunk_manager->CreateFile(legacy_file);
+    local_chunk_manager->CreateFile(generated_file);
+    ASSERT_TRUE(local_chunk_manager->Exist(legacy_file));
+    ASSERT_TRUE(local_chunk_manager->Exist(generated_file));
+
+    local_chunk_manager->RemoveDir(legacy_prefix);
+    EXPECT_FALSE(local_chunk_manager->Exist(legacy_file));
+    EXPECT_TRUE(local_chunk_manager->Exist(generated_file));
+}
+
+TEST_F(DiskAnnFileManagerTest, FileCleanupKeepsOtherGeneration) {
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+
+    std::string fm1_file;
+    std::string fm2_file;
+    {
+        auto fm1 = CreateFileManager(cm_, fs_);
+        auto fm2 = CreateFileManager(cm_, fs_);
+        fm1_file = fm1->GetLocalIndexObjectPrefix() + "index_data";
+        fm2_file = fm2->GetLocalIndexObjectPrefix() + "index_data";
+
+        local_chunk_manager->CreateFile(fm1_file);
+        local_chunk_manager->CreateFile(fm2_file);
+        EXPECT_TRUE(local_chunk_manager->Exist(fm1_file));
+        EXPECT_TRUE(local_chunk_manager->Exist(fm2_file));
+
+        fm1.reset();
+        EXPECT_FALSE(local_chunk_manager->Exist(fm1_file));
+        EXPECT_TRUE(local_chunk_manager->Exist(fm2_file));
+    }
+
+    EXPECT_FALSE(local_chunk_manager->Exist(fm2_file));
 }
 
 TEST_F(DiskAnnFileManagerTest, FileCleanup) {

--- a/internal/core/src/storage/DiskFileManagerTest.cpp
+++ b/internal/core/src/storage/DiskFileManagerTest.cpp
@@ -1310,6 +1310,61 @@ TEST_F(DiskAnnFileManagerTest, FileCleanupKeepsOtherGeneration) {
     EXPECT_FALSE(local_chunk_manager->Exist(fm2_file));
 }
 
+TEST_F(DiskAnnFileManagerTest, DirectoryLeaseDefersCleanupUntilRelease) {
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    auto file_manager = CreateFileManager(cm_, fs_);
+    auto local_index_prefix = file_manager->GetLocalIndexObjectPrefix();
+    auto local_index_file = local_index_prefix + "index_data";
+
+    {
+        auto lease =
+            file_manager->AcquireLocalDirWriteLease(local_index_prefix);
+        ASSERT_TRUE(lease);
+        local_chunk_manager->CreateFile(local_index_file);
+        ASSERT_TRUE(local_chunk_manager->Exist(local_index_file));
+
+        file_manager->RemoveIndexFiles();
+        EXPECT_TRUE(local_chunk_manager->Exist(local_index_file));
+    }
+
+    EXPECT_FALSE(local_chunk_manager->Exist(local_index_file));
+}
+
+TEST_F(DiskAnnFileManagerTest, DirectoryLeaseRejectsNewWritersAfterCleanup) {
+    auto local_chunk_manager =
+        LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    auto file_manager = CreateFileManager(cm_, fs_);
+    auto local_index_prefix = file_manager->GetLocalIndexObjectPrefix();
+    auto local_index_file = local_index_prefix + "index_data";
+
+    {
+        auto lease =
+            file_manager->AcquireLocalDirWriteLease(local_index_prefix);
+        ASSERT_TRUE(lease);
+        local_chunk_manager->CreateFile(local_index_file);
+        ASSERT_TRUE(local_chunk_manager->Exist(local_index_file));
+
+        file_manager->RemoveIndexFiles();
+        EXPECT_THROW(
+            {
+                auto blocked =
+                    file_manager->AcquireLocalDirWriteLease(local_index_prefix);
+                (void)blocked;
+            },
+            SegcoreError);
+    }
+
+    EXPECT_THROW(
+        {
+            auto blocked =
+                file_manager->AcquireLocalDirWriteLease(local_index_prefix);
+            (void)blocked;
+        },
+        SegcoreError);
+    EXPECT_FALSE(local_chunk_manager->Exist(local_index_file));
+}
+
 TEST_F(DiskAnnFileManagerTest, FileCleanup) {
     std::string local_index_file_path;
     std::string local_text_index_file_path;

--- a/internal/core/unittest/test_storage_v2_index_raw_data.cpp
+++ b/internal/core/unittest/test_storage_v2_index_raw_data.cpp
@@ -173,7 +173,8 @@ TEST_F(StorageV2IndexRawDataTest, TestGetRawData) {
                 storage::FileManagerContext(
                     field_data_meta, index_meta, cm_, fs_));
         auto res = file_manager->CacheRawDataToDisk<float>(config);
-        ASSERT_EQ(res, TestLocalPath + "raw_datas/3/105/raw_data");
+        ASSERT_EQ(res,
+                  file_manager->GetLocalRawDataObjectPrefix() + "raw_data");
     }
 
     {


### PR DESCRIPTION
issue: #48792

Local index cache directories were derived from index metadata. When QueryNode releases a segment and then loads the same segment/index again, the old and new `DiskFileManagerImpl` instances can point to the same local directory.

That makes two races possible:
- a late writer from the old load can write into the directory used by the new load;
- cleanup can remove a local directory while async writers for that directory are still active.

Both races can leave the local disk index state inconsistent during load/release concurrency.

This PR fixes the problem in two layers:
- Add a process-local generation to each `DiskFileManagerImpl` and append it to all local index/text/json/ngram/raw-data cache prefixes. Old and new file managers no longer share the same local directory, while remote paths stay unchanged.
- Add per-directory RAII write leases. Cleanup closes the directory, rejects new writers, and defers `RemoveDir` until active writers release their leases.

The disk index raw-data scratch paths and cleanup are routed through `DiskFileManagerImpl` so they use the same generation and lease rules.