### PR TITLE
fix: re-watch etcd on auth-token errors instead of panicking

### DIFF
--- a/internal/util/proxyutil/proxy_watcher.go
+++ b/internal/util/proxyutil/proxy_watcher.go
@@ -23,16 +23,17 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
-	v3rpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/milvus-io/milvus/internal/json"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/lifetime"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
@@ -132,11 +133,34 @@ func (p *ProxyWatcher) startWatchEtcd(ctx context.Context, eventCh clientv3.Watc
 				panic("stop watching etcd loop due to closed etcd event channel")
 			}
 			if err := event.Err(); err != nil {
-				if err == v3rpc.ErrCompacted {
-					err2 := p.WatchProxy(ctx)
+				// Recoverable watch errors (compaction, or auth-token
+				// invalidation when etcd auth is enabled) are handled by
+				// re-establishing the watch instead of crashing. Re-watching
+				// issues a unary request that refreshes the etcd auth token, so
+				// the new watch stream recovers. See etcd.IsRetriableWatchErr.
+				if etcd.IsRetriableWatchErr(err) {
+					mlog.Warn(ctx, "proxy watch hit a recoverable error, re-establishing watch", mlog.Err(err))
+					// Re-watch with a bounded retry/backoff. WatchProxy first issues
+					// a unary Get (getSessionsOnEtcd), which goes through clientv3's
+					// unary retry interceptor and refreshes the etcd auth token before
+					// a fresh watch stream is opened. retry.Do is bounded by its
+					// default attempt count and backoff; only transient errors are
+					// retried, a non-transient failure aborts immediately.
+					//
+					// On success WatchProxy spawns a new startWatchEtcd goroutine, so
+					// this goroutine returns and hands the watch over to it (not a
+					// recursive call that would accumulate goroutines).
+					err2 := retry.Do(ctx, func() error {
+						return p.WatchProxy(ctx)
+					}, retry.RetryErr(etcd.IsRetriableWatchErr))
 					if err2 != nil {
-						mlog.Error(ctx, "re watch proxy fails when etcd has a compaction error",
-							mlog.Err(err), mlog.Err(err2))
+						if ctx.Err() != nil {
+							mlog.Warn(ctx, "stop re-watching proxy due to context done", mlog.Err(err2))
+							return
+						}
+						mlog.Error(ctx, "re watch proxy failed after retries, exit",
+							mlog.NamedError("watchErr", err),
+							mlog.NamedError("reWatchErr", err2))
 						panic("failed to handle etcd request, exit..")
 					}
 					return

--- a/internal/util/proxyutil/proxy_watcher_test.go
+++ b/internal/util/proxyutil/proxy_watcher_test.go
@@ -131,15 +131,6 @@ func TestProxyManager_ErrCompacted(t *testing.T) {
 	}
 	pm := NewProxyWatcher(etcdCli, f1)
 
-	eventCh := pm.etcdCli.Watch(
-		ctx,
-		path.Join(paramtable.Get().EtcdCfg.MetaRootPath.GetValue(), sessionutil.DefaultServiceRoot, typeutil.ProxyRole),
-		clientv3.WithPrefix(),
-		clientv3.WithCreatedNotify(),
-		clientv3.WithPrevKV(),
-		clientv3.WithRev(1),
-	)
-
 	for i := 1; i < 10; i++ {
 		k := path.Join(sessKey, typeutil.ProxyRole+strconv.FormatInt(int64(i), 10))
 		v := "invalid session: " + strconv.FormatInt(int64(i), 10)
@@ -150,6 +141,20 @@ func TestProxyManager_ErrCompacted(t *testing.T) {
 	// The reason there the error is no handle is that if you run compact twice, an error will be reported;
 	// error msg is "etcdserver: mvcc: required revision has been compacted"
 	etcdCli.Compact(ctx, 10)
+
+	// Open the watch only AFTER the compaction, from a revision that is already
+	// compacted. This guarantees the watch deterministically returns
+	// ErrCompacted on its first response, instead of racing the live event
+	// stream (a fast etcd can deliver revs 2..10 before the compaction takes
+	// effect, leaving the watch with no error and the test blocking forever).
+	eventCh := pm.etcdCli.Watch(
+		ctx,
+		path.Join(paramtable.Get().EtcdCfg.MetaRootPath.GetValue(), sessionutil.DefaultServiceRoot, typeutil.ProxyRole),
+		clientv3.WithPrefix(),
+		clientv3.WithCreatedNotify(),
+		clientv3.WithPrevKV(),
+		clientv3.WithRev(1),
+	)
 
 	assert.Panics(t, func() {
 		pm.startWatchEtcd(ctx, eventCh)

--- a/internal/util/sessionutil/session_util.go
+++ b/internal/util/sessionutil/session_util.go
@@ -40,6 +40,7 @@ import (
 	kvfactory "github.com/milvus-io/milvus/internal/util/dependency/kv"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/etcd"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/retry"
@@ -872,7 +873,15 @@ func (w *sessionWatcher) handleWatchResponse(wresp clientv3.WatchResponse) {
 	if wresp.Err() != nil {
 		err := w.handleWatchErr(wresp.Err())
 		if err != nil {
-			mlog.Error(context.TODO(), "failed to handle watch session response", mlog.Err(err))
+			// On graceful shutdown s.ctx is canceled, the etcd watch delivers a
+			// final response carrying context.Canceled, and re-watching fails for
+			// the same reason. That is normal teardown, not a fault: exit quietly
+			// instead of crashing the process.
+			if w.s.ctx.Err() != nil {
+				mlog.Warn(w.s.ctx, "stop watching session service due to context done", mlog.Err(err))
+				return
+			}
+			mlog.Error(w.s.ctx, "failed to handle watch session response", mlog.Err(err))
 			panic(err)
 		}
 		return
@@ -919,32 +928,43 @@ func (w *sessionWatcher) handleWatchResponse(wresp clientv3.WatchResponse) {
 }
 
 func (w *sessionWatcher) handleWatchErr(err error) error {
-	// if not ErrCompacted, just close the channel
-	if err != v3rpc.ErrCompacted {
+	// Only recoverable errors are re-watched. ErrCompacted needs a fresh
+	// revision; auth-token errors (etcd auth enabled) need the watch
+	// re-established because clientv3 won't refresh the token on a live watch
+	// stream. Any other error closes the channel. See etcd.IsRetriableWatchErr.
+	if !etcd.IsRetriableWatchErr(err) {
 		// close event channel
 		mlog.Warn(context.TODO(), "Watch service found error", mlog.Err(err))
 		w.closeEventCh()
 		return err
 	}
 
+	// Re-establish the watch with a bounded retry. handleReWatch issues a unary
+	// request first, which refreshes the etcd auth token via clientv3's unary
+	// retry interceptor. Only keep retrying transient errors (e.g. a still-stale
+	// auth token); a non-transient failure aborts immediately.
+	if reErr := retry.Do(w.s.ctx, w.handleReWatch, retry.RetryErr(etcd.IsRetriableWatchErr)); reErr != nil {
+		mlog.Warn(w.s.ctx, "re-watch session service failed", mlog.String("prefix", w.prefix), mlog.Err(reErr))
+		w.closeEventCh()
+		return reErr
+	}
+	return nil
+}
+
+// handleReWatch re-establishes the session watch: it re-reads the current
+// sessions (a unary request that also refreshes the etcd auth token), replays
+// them through the rewatch hook, then opens a fresh watch stream from the new
+// revision.
+func (w *sessionWatcher) handleReWatch() error {
 	sessions, revision, err := w.s.GetSessions(w.s.ctx, w.prefix)
 	if err != nil {
-		mlog.Warn(context.TODO(), "GetSession before rewatch failed", mlog.String("prefix", w.prefix), mlog.Err(err))
-		w.closeEventCh()
 		return err
 	}
-	// rewatch is nil, no logic to handle
 	if w.rewatch == nil {
-		mlog.Warn(context.TODO(), "Watch service with ErrCompacted but no rewatch logic provided")
-	} else {
-		err = w.rewatch(sessions)
-	}
-	if err != nil {
-		mlog.Warn(context.TODO(), "WatchServices rewatch failed", mlog.String("prefix", w.prefix), mlog.Err(err))
-		w.closeEventCh()
+		mlog.Warn(w.s.ctx, "re-watch session service but no rewatch logic provided", mlog.String("prefix", w.prefix))
+	} else if err = w.rewatch(sessions); err != nil {
 		return err
 	}
-
 	w.rch = w.s.etcdCli.Watch(w.s.ctx, path.Join(w.s.metaRoot, DefaultServiceRoot, w.prefix), clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithRev(revision))
 	return nil
 }

--- a/internal/util/sessionutil/session_util_test.go
+++ b/internal/util/sessionutil/session_util_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	v3rpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/milvus-io/milvus/internal/json"
@@ -298,6 +299,22 @@ func TestWatcherHandleWatchResp(t *testing.T) {
 		})
 	})
 
+	t.Run("error during shutdown does not panic", func(t *testing.T) {
+		// When the session ctx is canceled (graceful shutdown), the etcd watch
+		// delivers a final error response; handling it must exit quietly instead
+		// of crashing the process.
+		cctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		downSession := NewSessionWithEtcd(cctx, metaRoot, etcdCli)
+		w := getWatcher(downSession, nil)
+		wresp := clientv3.WatchResponse{
+			Canceled: true,
+		}
+		assert.NotPanics(t, func() {
+			w.handleWatchResponse(wresp)
+		})
+	})
+
 	t.Run("err handled but rewatch failed", func(t *testing.T) {
 		w := getWatcher(s, func(sessions map[string]*Session) error {
 			return errors.New("mocked")
@@ -308,6 +325,27 @@ func TestWatcherHandleWatchResp(t *testing.T) {
 		assert.Panics(t, func() {
 			w.handleWatchResponse(wresp)
 		})
+	})
+
+	t.Run("invalid auth token triggers rewatch instead of close", func(t *testing.T) {
+		rewatched := false
+		w := getWatcher(s, func(sessions map[string]*Session) error {
+			rewatched = true
+			return nil
+		})
+		// An Unauthenticated watch error is recoverable: the watcher must
+		// re-establish the watch (which refreshes the etcd auth token via the
+		// unary path) rather than close the channel and panic.
+		err := w.handleWatchErr(v3rpc.ErrInvalidAuthToken)
+		assert.NoError(t, err)
+		assert.True(t, rewatched)
+		assert.NotNil(t, w.rch)
+	})
+
+	t.Run("non-retriable error closes channel", func(t *testing.T) {
+		w := getWatcher(s, nil)
+		err := w.handleWatchErr(errors.New("some fatal error"))
+		assert.Error(t, err)
 	})
 }
 
@@ -931,6 +969,13 @@ func testForceKill(serverName string) {
 
 	// trigger a force kill
 	etcdCli.Revoke(context.Background(), *session.LeaseID)
+
+	// The force kill is asynchronous: the keepalive loop must observe the lost
+	// lease and call os.Exit(ExitCodeEtcd). Block long enough for that to fire,
+	// otherwise this function returns and the subprocess exits 0, racing (and
+	// usually beating) the force kill. The sleep is only paid in full on a
+	// regression; on success os.Exit terminates the process well before it ends.
+	time.Sleep(30 * time.Second)
 }
 
 func TestGetResourceGroupName(t *testing.T) {

--- a/pkg/util/etcd/etcd_util.go
+++ b/pkg/util/etcd/etcd_util.go
@@ -38,6 +38,43 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
+// IsRetriableWatchErr reports whether an etcd watch error can be recovered by
+// re-establishing the watch.
+//
+// It returns true for:
+//   - ErrCompacted: the watched revision has been compacted; re-watch from a
+//     fresh revision (pre-existing behavior).
+//   - auth-token errors (ErrInvalidAuthToken, ErrUserEmpty, ErrAuthOldRevision):
+//     with etcd auth enabled, the auth token held by a client can be
+//     invalidated server-side (the default "simple" token is GC'd after idle
+//     TTL, is member-local, and is lost on member restart). A long-idle standby
+//     coordinator hits this on promotion. clientv3 treats the resulting
+//     Unauthenticated error on an already-established watch stream as a halt
+//     error (see isHaltErr) and tears the stream down WITHOUT refreshing the
+//     token, so the watch owner must re-watch. Re-watching issues a unary
+//     request first, which goes through clientv3's unary retry interceptor and
+//     refreshes the auth token, so the new watch stream recovers.
+//
+// Genuine authorization failures (permission denied, bad credentials) carry
+// different codes (PermissionDenied, InvalidArgument, FailedPrecondition) and
+// are deliberately NOT retriable. We match the etcd sentinels via errors.Is
+// rather than the raw gRPC Unauthenticated code: clientv3 maps watch errors
+// back to these sentinels (v3rpc.Error), and ErrInvalidAuthToken is the only
+// source of Unauthenticated, so matching the sentinel is both sufficient and
+// narrower than trusting the code.
+//
+// Callers should wrap the re-watch in a bounded retry (retry.Attempts) so a
+// genuinely persistent failure does not loop forever.
+func IsRetriableWatchErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, rpctypes.ErrCompacted) ||
+		errors.Is(err, rpctypes.ErrInvalidAuthToken) ||
+		errors.Is(err, rpctypes.ErrUserEmpty) ||
+		errors.Is(err, rpctypes.ErrAuthOldRevision)
+}
+
 type ClientOption func(*clientv3.Config)
 
 // WithDialKeepAlive configures gRPC keepalive and autosync behaviors for the etcd client.

--- a/pkg/util/etcd/etcd_util_test.go
+++ b/pkg/util/etcd/etcd_util_test.go
@@ -27,7 +27,36 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+func TestIsRetriableWatchErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"compacted", rpctypes.ErrCompacted, true},
+		{"invalid auth token", rpctypes.ErrInvalidAuthToken, true},
+		{"user empty", rpctypes.ErrUserEmpty, true},
+		{"auth old revision", rpctypes.ErrAuthOldRevision, true},
+		// A raw gRPC Unauthenticated that was not mapped back to an etcd
+		// sentinel is deliberately NOT retriable: we match sentinels only.
+		{"unmapped raw grpc unauthenticated", status.Error(codes.Unauthenticated, "some unmapped error"), false},
+		{"wrapped invalid auth token", errors.Wrap(rpctypes.ErrInvalidAuthToken, "watch failed"), true},
+		{"permission denied", rpctypes.ErrPermissionDenied, false},
+		{"lease not found", rpctypes.ErrLeaseNotFound, false},
+		{"generic error", errors.New("some other error"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, IsRetriableWatchErr(c.err))
+		})
+	}
+}
 
 // freePort grabs a random unused TCP port. There's a small TOCTOU window
 // between Close and the subsequent bind, but for unit tests it's acceptable.


### PR DESCRIPTION
## Issue

issue: #50102

## Problem

With etcd auth enabled and `mixCoord.enableActiveStandby: true`, a long-running **standby** MixCoord panics when promoted to active:

```
panic: rpc error: code = Unauthenticated desc = etcdserver: invalid auth token
  ProxyWatcher.startWatchEtcd (proxy_watcher.go:146)
```

This is **not** a credential misconfiguration (the same config works for the active node and all other components, and a restart of the same pod recovers).

Root cause:
- etcd's default `simple` auth token is stateful and server-local: GC'd after idle TTL (`--auth-token-ttl`, default 300s), member-local, and lost on member restart. A long-idle standby's token gets invalidated server-side without the client knowing.
- When an **already-established watch stream** then hits `Unauthenticated`, clientv3 classifies it as a halt error (`isHaltErr` — anything that isn't `Unavailable`/`Internal`) and tears the stream down **without** refreshing the token. clientv3's token refresh only covers unary calls and a stream's first recv, not a live watch stream.
- `ProxyWatcher.startWatchEtcd` and `sessionutil.handleWatchErr` only handled `ErrCompacted` and `panic()`ed on every other watch error.

## Fix

Treat auth-token watch errors as recoverable and re-establish the watch with a bounded retry, instead of panicking. Re-watching issues a unary request first (`getSessionsOnEtcd` / `GetSessions`), which refreshes the auth token via clientv3's unary retry interceptor, so the new watch stream recovers.

- New shared predicate `etcd.IsRetriableWatchErr` classifies recoverable watch errors (`ErrCompacted` + auth-token errors: `ErrInvalidAuthToken` / `ErrUserEmpty` / `ErrAuthOldRevision` / raw `Unauthenticated`).
- `ProxyWatcher.startWatchEtcd` and `sessionutil.handleWatchErr` now re-watch on recoverable errors via `retry.Do(..., retry.RetryErr(etcd.IsRetriableWatchErr))`. The retry is bounded by `retry.Do`'s default attempt count / backoff; non-recoverable errors still fail fast.

The CDC controller and streaming session discoverer already self-heal (return-and-re-list on watch error), so they are unchanged.

> Operational note for affected users: configuring etcd with **JWT** auth tokens (`--auth-token jwt,...`) instead of the default `simple` token avoids the unexpected server-side invalidation entirely (JWT is stateless — valid across members, survives restart, no idle GC).

## Test

- Added `TestIsRetriableWatchErr` (pkg/util/etcd) — predicate classification.
- Added subtests in `TestWatcherHandleWatchResp` (sessionutil) — auth-token error triggers re-watch (not channel close), non-retriable error closes the channel.
- Existing `TestProxyManager_ErrCompacted` still passes (non-retriable bad-session-data fails fast).

> Note: the watcher integration tests link the C++ core; they were not runnable in my local/remote env at PR time and will be validated in CI.
