### PR TITLE
test: align nightly test expectations with current server behavior

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_upsert.py
+++ b/tests/python_client/milvus_client/test_milvus_client_upsert.py
@@ -1,13 +1,13 @@
-import pytest
+# fmt: off
 import numpy as np
-
+import pytest
 from base.client_v2_base import TestMilvusClientV2Base
-from utils.util_log import test_log as log
 from common import common_func as cf
 from common import common_type as ct
 from common.common_type import CaseLabel, CheckTasks
-from utils.util_pymilvus import *
 from pymilvus import Function, FunctionType
+from utils.util_log import test_log as log
+from utils.util_pymilvus import *
 
 prefix = "client_insert"
 epsilon = ct.epsilon
@@ -119,7 +119,7 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
         rng = np.random.default_rng(seed=19530)
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
-        error = {ct.err_code: 1100, ct.err_msg: f"the length of a collection name must be less than 255 characters"}
+        error = {ct.err_code: 1100, ct.err_msg: "the length of a collection name must be less than 255 characters"}
         self.upsert(client, collection_name, rows,
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -152,7 +152,7 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
         # 1. create collection
         self.create_collection(client, collection_name, default_dim, consistency_level="Strong")
         # 2. insert
-        error = {ct.err_code: 1, ct.err_msg: f"wrong type of argument 'data',expected 'Dict' or list of 'Dict'"}
+        error = {ct.err_code: 1, ct.err_msg: "wrong type of argument 'data',expected 'Dict' or list of 'Dict'"}
         self.upsert(client, collection_name, data,
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -254,7 +254,7 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
         # 1. create collection
         self.create_collection(client, collection_name, default_dim, consistency_level="Strong")
         # 2. insert
-        error = {ct.err_code: 1, ct.err_msg: f"wrong type of argument 'data',expected 'Dict' or list of 'Dict'"}
+        error = {ct.err_code: 1, ct.err_msg: "wrong type of argument 'data',expected 'Dict' or list of 'Dict'"}
         self.upsert(client, collection_name, data="",
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -294,7 +294,7 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
         rows = [{default_vector_field_name: list(rng.random((1, default_dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(20)]
         error = {ct.err_code: 1,
-                 ct.err_msg: f"Insert missed an field `id` to collection without set nullable==true or set default_value"}
+                 ct.err_msg: "Insert missed an field `id` to collection without set nullable==true or set default_value"}
         self.upsert(client, collection_name, data=rows,
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -315,7 +315,7 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
         rows = [{default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, dim))[0]),
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(10)]
         error = {ct.err_code: 1,
-                 ct.err_msg: f"Attempt to insert an unexpected field `float` to collection without enabling dynamic field"}
+                 ct.err_msg: "Attempt to insert an unexpected field `float` to collection without enabling dynamic field"}
         self.upsert(client, collection_name, data=rows,
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -337,7 +337,7 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
         rows = [
             {default_primary_key_field_name: i, default_vector_field_name: list(rng.random((1, dim))[0]),
              default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
-        error = {ct.err_code: 65535, ct.err_msg: f"dim"}
+        error = {ct.err_code: 65535, ct.err_msg: "dim"}
         self.upsert(client, collection_name, data=rows, check_task=CheckTasks.err_res, check_items=error)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -366,8 +366,10 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
         rows = [{default_primary_key_field_name: i, ct.default_binary_vec_field_name: binary_vectors[i],
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
 
-        # 3. Verify error on upsert
-        error = {ct.err_code: 1100, ct.err_msg: f"the dim ({dim}) of field data(binary_vector) is not equal to schema dim ({default_dim})"}
+        # 3. Verify error on upsert. Binary vector dim is counted in bits, so a
+        # mismatch surfaces as the total-bits-divisibility check rather than a
+        # plain dim-not-equal message.
+        error = {ct.err_code: 1100, ct.err_msg: "of all bits should divide the dim"}
         self.upsert(client, collection_name, data=rows, check_task=CheckTasks.err_res, check_items=error)
 
         self.drop_collection(client, collection_name)
@@ -411,7 +413,7 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
                  default_float_field_name: i * 1.0, default_string_field_name: str(i)} for i in range(default_nb)]
         error = {ct.err_code: 65535, ct.err_msg: f"Invalid partition name: {partition_name}"}
         if partition_name == " ":
-            error = {ct.err_code: 1, ct.err_msg: f"Invalid partition name: . Partition name should not be empty."}
+            error = {ct.err_code: 1, ct.err_msg: "Invalid partition name: . Partition name should not be empty."}
         self.upsert(client, collection_name, data=rows, partition_name=partition_name,
                     check_task=CheckTasks.err_res, check_items=error)
 
@@ -541,7 +543,7 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
         schema.add_field("text_sparse_emb", DataType.SPARSE_FLOAT_VECTOR, nullable=False )
 
         bm25_function = Function(
-            name=f"text",
+            name="text",
             function_type=FunctionType.BM25,
             input_field_names=["text"],
             output_field_names=["text_sparse_emb"],
@@ -562,7 +564,7 @@ class TestMilvusClientUpsertInvalid(TestMilvusClientV2Base):
                  ct.err_msg: "Attempt to insert an unexpected function output field `text_sparse_emb` to collection"}
         self.upsert(client, collection_name, new_rows,
                     check_task=CheckTasks.err_res, check_items=error)
-        
+
     @pytest.mark.tags(CaseLabel.L1)
     def test_milvus_client_upsert_duplicate_pk_int64(self):
         """

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -27,10 +27,6 @@ fake_en = Faker("en_US")
 pd.set_option("expand_frame_repr", False)
 
 prefix = "text_embedding_collection"
-DROP_TEXT_EMBEDDING_FUNCTION_XFAIL_REASON = (
-    "issue: https://github.com/milvus-io/milvus/issues/50424, "
-    "dropping TextEmbedding function incorrectly removes output vector field"
-)
 
 
 # TEI: https://github.com/huggingface/text-embeddings-inference
@@ -1535,7 +1531,6 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
 
     # ==================== drop_collection_function positive tests ====================
 
-    @pytest.mark.xfail(reason=DROP_TEXT_EMBEDDING_FUNCTION_XFAIL_REASON, strict=True)
     def test_drop_collection_function_verify_crud(self, tei_endpoint):
         """
         target: test CRUD behavior changes after dropping function
@@ -1640,7 +1635,6 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         res, _ = collection_w.query(expr="id >= 0", output_fields=["id"])
         assert len(res) == 4  # 6 - 2
 
-    @pytest.mark.xfail(reason=DROP_TEXT_EMBEDDING_FUNCTION_XFAIL_REASON, strict=True)
     def test_drop_collection_function_one_of_multiple(self, tei_endpoint):
         """
         target: test drop one function when multiple text embedding functions exist
@@ -1757,7 +1751,6 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         res, _ = collection_w.query(expr="id >= 0", output_fields=["id"])
         assert len(res) == 3
 
-    @pytest.mark.xfail(reason=DROP_TEXT_EMBEDDING_FUNCTION_XFAIL_REASON, strict=True)
     def test_drop_collection_function_then_add_again(self, tei_endpoint):
         """
         target: test can re-add function after dropping

--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -2115,13 +2115,13 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
         except Exception as e:
             log.info(f"Expected error: {e}")
             assert e.code == 100
-            assert "collection not found" in str(e)
+            assert "can't find collection" in str(e)
 
     def test_drop_collection_function_nonexistent_function(self):
         """
         target: test drop function that doesn't exist
         method: create collection without function, try to drop non-existent function
-        expected: no error (idempotent delete behavior)
+        expected: error function not found (code=1100); drop is non-idempotent since #50471
         """
         self._connect()
         dim = 768
@@ -2134,15 +2134,20 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         self.init_collection_wrap(name=c_name, schema=schema)
 
-        # Drop nonexistent function should not raise error (idempotent)
-        self.client.drop_collection_function(collection_name=c_name, function_name="nonexistent_function")
-        log.info("Drop nonexistent function succeeded (idempotent behavior)")
+        # Dropping a nonexistent function now errors (non-idempotent since #50471)
+        try:
+            self.client.drop_collection_function(collection_name=c_name, function_name="nonexistent_function")
+            assert False, "Expected exception for nonexistent function"
+        except Exception as e:
+            log.info(f"Expected error: {e}")
+            assert e.code == 1100
+            assert "function not found" in str(e)
 
     def test_drop_collection_function_empty_name(self):
         """
         target: test drop function with empty name
         method: call drop_collection_function with function_name=""
-        expected: no error (idempotent delete behavior)
+        expected: error requiring a valid drop identifier; rejected client-side since #50471
         """
         self._connect()
         dim = 768
@@ -2155,6 +2160,10 @@ class TestTextEmbeddingFunctionCURDNegative(TestcaseBase):
         c_name = cf.gen_unique_str(prefix)
         self.init_collection_wrap(name=c_name, schema=schema)
 
-        # Drop with empty name should not raise error (idempotent)
-        self.client.drop_collection_function(collection_name=c_name, function_name="")
-        log.info("Drop with empty function name succeeded (idempotent behavior)")
+        # An empty function name is rejected: a valid drop identifier is required (since #50471)
+        try:
+            self.client.drop_collection_function(collection_name=c_name, function_name="")
+            assert False, "Expected exception for empty function name"
+        except Exception as e:
+            log.info(f"Expected error: {e}")
+            assert "Must specify exactly one valid Drop identifier" in str(e)

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -23,7 +23,13 @@ ignore = [
 [lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]
 "conftest.py" = ["F401", "F811"]
-"**/testcases/**/*.py" = ["E402"]
+# Test modules conventionally use `from common.common_type import *` etc., so
+# star-import rules (F403/F405) are noise. They also build expressions as
+# strings and eval them, so locals that look unused to ruff (F841) are in fact
+# used. E402 covers module-level setup before imports.
+"**/testcases/**/*.py" = ["E402", "F403", "F405", "F841"]
+"**/milvus_client/**/*.py" = ["E402", "F403", "F405", "F841"]
+"**/milvus_client_v2/**/*.py" = ["E402", "F403", "F405", "F841"]
 "**/chaos/**/*.py" = ["E402"]
 
 [format]


### PR DESCRIPTION
## What

Fix the master nightly e2e failures. The server behavior is the intended one; the test expectations were stale.

- **`test_milvus_client_upsert_binary_dim_unmatch`** — a binary vector's dim is counted in bits, so a dim mismatch is rejected by the total-bits-divisibility check (`...of all bits should divide the dim...`, code 1100), not a plain "dim not equal to schema dim" message. Updated the expected message; code 1100 unchanged.
- **`TestTextEmbeddingFunctionCURDNegative` drop cases** — semantics changed by #50471 ("Split function drop semantics by request flag", which made the drop non-idempotent and added `function not found` validation, with a matching Go unit test):
  - drop on a nonexistent collection → reason is `can't find collection` (code 100).
  - drop a nonexistent function → now errors `function not found` (code 1100) instead of being a silent no-op.
  - drop with an empty function name → rejected client-side: a valid drop identifier is required.

## How verified

Each expected value is taken from the actual server/SDK response in the master nightly run (`milvus-e2e-pipeline-4am`), not guessed. The drop-semantics change was confirmed against #50471's diff (it adds `WrapErrParameterInvalidMsg("function not found: %s", ...)` plus a `function not found` Go test).

## Lint plumbing

CI lints whole changed files. These files carry pre-existing ruff debt (700+ F405 from the conventional `from common.common_type import *`), so:
- `tests/ruff.toml`: ignore F403/F405/F841 for `testcases`/`milvus_client`/`milvus_client_v2` (consistent with the existing E402 ignore; these tests build & eval expressions as strings, so "unused" locals are real).
- Added `# fmt: off` to the upsert file (matching the sibling text-embedding file) to avoid reformatting ~900 unrelated lines in a targeted fix.

Not addressed here: a separate flaky `test_milvus_client_struct_array_nullable` query failure (intermittent True/False, not a stale expectation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
