### PR TITLE
fix: [2.6] keep group-by values aligned with PKs when sorting equal scores

### DIFF
--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -241,6 +241,16 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
                     search_result->element_level_
                         ? search_result->element_indices_[start + i]
                         : -1;
+                // group_by_values_ must be permuted in lockstep with the pks,
+                // otherwise the pk<->group-by-value binding is broken for
+                // equal-score (tie) entries, defeating group_size/strict_group_size.
+                const bool has_group_by =
+                    search_result->group_by_values_.has_value();
+                GroupByValueType temp_group_by_value;
+                if (has_group_by) {
+                    temp_group_by_value = std::move(
+                        search_result->group_by_values_.value()[start + i]);
+                }
 
                 size_t curr = i;
                 while (indices[curr] != i) {
@@ -253,6 +263,11 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
                         search_result->element_indices_[start + curr] =
                             search_result->element_indices_[start + next];
                     }
+                    if (has_group_by) {
+                        search_result->group_by_values_.value()[start + curr] =
+                            std::move(search_result->group_by_values_
+                                          .value()[start + next]);
+                    }
                     indices[curr] = curr;  // Mark as processed
                     curr = next;
                 }
@@ -262,6 +277,10 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
                 if (search_result->element_level_) {
                     search_result->element_indices_[start + curr] =
                         temp_element_index;
+                }
+                if (has_group_by) {
+                    search_result->group_by_values_.value()[start + curr] =
+                        std::move(temp_group_by_value);
                 }
                 indices[curr] = curr;
             }

--- a/tests/python_client/milvus_client_v2/test_milvus_client_search_group_by.py
+++ b/tests/python_client/milvus_client_v2/test_milvus_client_search_group_by.py
@@ -351,6 +351,92 @@ class TestGroupSearch(TestMilvusClientV2Base):
                         tmp_distances = group_distances
                         group_distances = [res[i][l + 1].distance]
 
+    @pytest.mark.tags(CaseLabel.L0)
+    def test_hybrid_search_group_by_equal_scores_dedup(self):
+        """
+        target: hybrid_search + group_by(strict_group_size) must still de-dup correctly
+                when all candidate scores are equal (ties), including same-group entities
+                spread across multiple sealed segments and the growing segment.
+        method: every row shares one identical vector on every field (so all candidates
+                tie); one group_id is present in two sealed segments and the growing
+                segment; run hybrid_search with group_by + group_size=1 + strict_group_size.
+        expected: each group value appears exactly once AND the output group value matches
+                  the pk prefix (no pk<->group-by-value misalignment).
+        regression: equal-score tie sorting (SortEqualScoresByPks) must permute
+                    group_by_values together with the primary keys; otherwise the
+                    pk<->group binding breaks and strict_group_size is silently violated.
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str("group_equal_scores")
+        dim = 8
+        vec_fields = ["v0", "v1", "v2"]
+        # one identical vector shared by every row and every field -> all scores tie
+        tied_vec = cf.gen_vectors(1, dim=dim, vector_data_type=DataType.FLOAT_VECTOR)[0]
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field("pk", DataType.VARCHAR, is_primary=True, max_length=128)
+        schema.add_field("group_id", DataType.INT64, nullable=False)
+        for vf in vec_fields:
+            schema.add_field(vf, DataType.FLOAT_VECTOR, dim=dim)
+        self.create_collection(client, collection_name, schema=schema)
+
+        groups = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+
+        def rows(gid, ns):
+            out = []
+            for n in ns:
+                row = {"pk": f"{gid}_{n}", "group_id": gid}
+                for vf in vec_fields:
+                    row[vf] = tied_vec
+                out.append(row)
+            return out
+
+        # group 100 spans sealed-A, sealed-B and the growing segment; others are singletons
+        batch_a = rows(100, [0, 1, 2])
+        for g in groups[1:]:
+            batch_a += rows(g, [0])
+        self.insert(client, collection_name, data=batch_a)
+        self.flush(client, collection_name)
+        self.insert(client, collection_name, data=rows(100, [3, 4, 5]))
+        self.flush(client, collection_name)
+        self.insert(client, collection_name, data=rows(100, [6, 7, 8]))  # growing, not flushed
+
+        index_params = self.prepare_index_params(client)[0]
+        for vf in vec_fields:
+            index_params.add_index(field_name=vf, index_type="IVF_FLAT", metric_type="COSINE", params={"nlist": 4})
+        self.create_index(client, collection_name, index_params=index_params)
+        self.load_collection(client, collection_name)
+
+        limit = len(groups)
+        reqs = [
+            AnnSearchRequest(
+                data=[tied_vec], anns_field=vf, param={"metric_type": "COSINE", "params": {"nprobe": 4}}, limit=limit
+            )
+            for vf in vec_fields
+        ]
+        res = self.hybrid_search(
+            client,
+            collection_name,
+            reqs=reqs,
+            ranker=WeightedRanker(0.34, 0.33, 0.33),
+            limit=limit,
+            group_by_field="group_id",
+            group_size=1,
+            strict_group_size=True,
+            output_fields=["group_id"],
+        )[0]
+        hits = res[0]
+        group_values = [h.get("group_id") for h in hits]
+        # group_size=1 + strict_group_size: every group value must be unique
+        assert len(set(group_values)) == len(group_values), f"duplicate group values returned: {group_values}"
+        # pk<->group-by-value binding must hold: output group_id == pk prefix
+        for h in hits:
+            assert h.get("group_id") == int(str(h.id).rsplit("_", 1)[0]), (
+                f"pk/group mismatch: pk={h.id} group_id={h.get('group_id')}"
+            )
+
+        self.drop_collection(client, collection_name)
+
     @pytest.mark.tags(CaseLabel.L2)
     def test_hybrid_search_group_by(self):
         """


### PR DESCRIPTION
pr: #48984
Related to #50620

`ReduceHelper::SortEqualScoresOneNQ` (`internal/core/src/segcore/reduce/Reduce.cpp`) deterministically re-orders equal-score (tie) runs by primary key. Its in-place cyclic permutation moved `primary_keys_`, `seg_offsets_` and `element_indices_`, but did **not** move `group_by_values_` in lockstep. For a group-by search this breaks the `pk <-> group-by-value` binding whenever scores are tied: the rerank stage then buckets entities by the wrong group value and `strict_group_size` is silently violated (the same group value is returned multiple times).

This fix permutes `group_by_values_` together with the other per-row arrays, guarded by `group_by_values_.has_value()`.

The equal-score sorting path (`SortEqualScoresByPks`, introduced by #44870) does not exist on master, where the search reduce was rewritten in Go with Late Materialization (#48984) — there each result row is materialized cohesively, so this misalignment cannot occur. master is not affected; this fix targets the 2.6 line only, which is why it is not a literal cherry-pick of #48984.

Adds an L0 e2e regression test: `hybrid_search` + `group_by` with tied scores and a group spread across sealed and growing segments, asserting both no duplicate group values and that each row's group value matches its pk.
