### PR TITLE
fix: [poc_2.6.17] keep group-by values aligned with PKs when sorting equal scores

### DIFF
--- a/internal/core/src/segcore/reduce/Reduce.cpp
+++ b/internal/core/src/segcore/reduce/Reduce.cpp
@@ -209,6 +209,16 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
                 PkType temp_pk =
                     std::move(search_result->primary_keys_[start + i]);
                 int64_t temp_offset = search_result->seg_offsets_[start + i];
+                // group_by_values_ must be permuted in lockstep with the pks,
+                // otherwise the pk<->group-by-value binding is broken for
+                // equal-score (tie) entries, defeating group_size/strict_group_size.
+                const bool has_group_by =
+                    search_result->group_by_values_.has_value();
+                GroupByValueType temp_group_by_value;
+                if (has_group_by) {
+                    temp_group_by_value = std::move(
+                        search_result->group_by_values_.value()[start + i]);
+                }
 
                 size_t curr = i;
                 while (indices[curr] != i) {
@@ -217,12 +227,21 @@ ReduceHelper::SortEqualScoresOneNQ(size_t nq_begin,
                         std::move(search_result->primary_keys_[start + next]);
                     search_result->seg_offsets_[start + curr] =
                         search_result->seg_offsets_[start + next];
+                    if (has_group_by) {
+                        search_result->group_by_values_.value()[start + curr] =
+                            std::move(search_result->group_by_values_
+                                          .value()[start + next]);
+                    }
                     indices[curr] = curr;  // Mark as processed
                     curr = next;
                 }
 
                 search_result->primary_keys_[start + curr] = std::move(temp_pk);
                 search_result->seg_offsets_[start + curr] = temp_offset;
+                if (has_group_by) {
+                    search_result->group_by_values_.value()[start + curr] =
+                        std::move(temp_group_by_value);
+                }
                 indices[curr] = curr;
             }
         }


### PR DESCRIPTION
pr: #48984
Related to #50620

Cherry-pick of #50621 onto the poc_2.6.17 branch (C++ fix only; adapted: this branch's `SortEqualScoresOneNQ` has no `element_indices_` permutation yet, so only the `group_by_values_` lockstep permutation is added). The L0 e2e regression test lives on the upstream PRs #50621 (2.6) / #50622 (hotfix-2.6.18); this branch carries the minimal fix and was verified locally (built + reproduced 3/3).

`ReduceHelper::SortEqualScoresOneNQ` re-orders equal-score (tie) runs by primary key but did not permute `group_by_values_` together with `primary_keys_`/`seg_offsets_`. For a group-by search this breaks the `pk <-> group-by-value` binding when scores are tied, so the rerank stage buckets entities by the wrong group value and `strict_group_size` is silently violated (the same group value is returned multiple times).

This fix permutes `group_by_values_` in lockstep, guarded by `group_by_values_.has_value()`. The buggy path (`SortEqualScoresByPks`, #44870) does not exist on master, where the reduce was rewritten in Go (#48984); master is not affected.
