### PR TITLE
fix: [2.6] avoid double-joining full textlog paths in datacoord GC

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -1061,18 +1061,14 @@ func getTextLogs(sinfo *SegmentInfo) map[string]struct{} {
 func getTextLogPaths(sinfo *SegmentInfo, rootPath string) map[string]struct{} {
 	textLogs := make(map[string]struct{})
 	for _, flog := range sinfo.GetTextStatsLogs() {
-		for _, file := range flog.GetFiles() {
-			if rootPath != "" {
-				file = path.Join(rootPath, common.TextIndexPath,
-					fmt.Sprintf("%d", flog.GetBuildID()),
-					fmt.Sprintf("%d", flog.GetVersion()),
-					fmt.Sprintf("%d", sinfo.GetCollectionID()),
-					fmt.Sprintf("%d", sinfo.GetPartitionID()),
-					fmt.Sprintf("%d", sinfo.GetID()),
-					fmt.Sprintf("%d", flog.GetFieldID()),
-					file,
-				)
-			}
+		files := flog.GetFiles()
+		if rootPath != "" {
+			basePath := metautil.BuildTextIndexPrefix(rootPath,
+				flog.GetBuildID(), flog.GetVersion(),
+				sinfo.GetCollectionID(), sinfo.GetPartitionID(), sinfo.GetID(), flog.GetFieldID())
+			files = metautil.BuildStatsFilePaths(basePath, files)
+		}
+		for _, file := range files {
 			textLogs[file] = struct{}{}
 		}
 	}

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -2283,6 +2283,8 @@ func TestGarbageCollector_recycleUnusedBinlogFiles_TextAndJSONStats(t *testing.T
 		}).Build()
 	defer mockRemove.UnPatch()
 
+	segment.GetTextStatsLogs()[101].Files = []string{"gc/text_log/501/1/100/10/1003/101/text_file_keep"}
+
 	mockWalk := mockey.Mock((*storage.LocalChunkManager).WalkWithPrefix).To(
 		func(cm *storage.LocalChunkManager, ctx context.Context, prefix string, recursive bool, fn storage.ChunkObjectWalkFunc) error {
 			switch {

--- a/pkg/util/metautil/binlog.go
+++ b/pkg/util/metautil/binlog.go
@@ -114,6 +114,36 @@ func ExtractTextLogFilenames(textStatsLogs map[int64]*datapb.TextIndexStats) {
 	}
 }
 
+// BuildTextIndexPrefix returns the remote base path for text index files.
+// Format: {rootPath}/text_log/{buildID}/{version}/{collID}/{partID}/{segID}/{fieldID}
+func BuildTextIndexPrefix(rootPath string, buildID, version, collectionID, partitionID, segmentID, fieldID int64) string {
+	return path.Join(rootPath, common.TextIndexPath,
+		strconv.FormatInt(buildID, 10), strconv.FormatInt(version, 10),
+		strconv.FormatInt(collectionID, 10), strconv.FormatInt(partitionID, 10),
+		strconv.FormatInt(segmentID, 10), strconv.FormatInt(fieldID, 10))
+}
+
+// BuildStatsFilePaths normalizes stats files to full object keys.
+// TextMatch stats upload returns relative filenames; this helper also tolerates
+// already-full paths for compatibility with older/intermediate producers.
+func BuildStatsFilePaths(basePath string, files []string) []string {
+	result := make([]string, 0, len(files))
+	if basePath == "" {
+		return append(result, files...)
+	}
+
+	basePath = strings.TrimSuffix(basePath, pathSep)
+	prefix := basePath + pathSep
+	for _, file := range files {
+		if strings.HasPrefix(file, prefix) {
+			result = append(result, file)
+			continue
+		}
+		result = append(result, path.Join(basePath, strings.TrimPrefix(file, pathSep)))
+	}
+	return result
+}
+
 // BuildTextLogPaths reconstructs full paths from filenames for text index logs.
 // This function is compatible with both old version (full paths) and new version (filenames only).
 func BuildTextLogPaths(rootPath string, collectionID, partitionID, segmentID typeutil.UniqueID, textStatsLogs map[int64]*datapb.TextIndexStats) {

--- a/pkg/util/metautil/binlog_test.go
+++ b/pkg/util/metautil/binlog_test.go
@@ -195,3 +195,14 @@ func TestBuildTextLogPaths(t *testing.T) {
 		t.Errorf("BuildTextLogPaths() should keep full path unchanged, got %v", textStatsLogs[100].Files[0])
 	}
 }
+
+func TestBuildStatsFilePaths(t *testing.T) {
+	basePath := BuildTextIndexPrefix("root", 1, 2, 10, 20, 30, 100)
+	fullPath := path.Join(basePath, "file2.txt")
+
+	files := BuildStatsFilePaths(basePath, []string{"file1.txt", fullPath})
+	want := []string{path.Join(basePath, "file1.txt"), fullPath}
+	if !reflect.DeepEqual(files, want) {
+		t.Errorf("BuildStatsFilePaths() Files = %v, want %v", files, want)
+	}
+}


### PR DESCRIPTION
Related to #50591

Normalize text stats files before matching GC object keys so segments that already store full textlog paths are not treated as garbage and removed. Add regression tests for both the path normalization helper and the datacoord recycle path.