### PR TITLE
test: Add RBAC description coverage

### DIFF
--- a/tests/go_client/testcases/advcases/rbac_test.go
+++ b/tests/go_client/testcases/advcases/rbac_test.go
@@ -71,8 +71,9 @@ func TestRbacDefault(t *testing.T) {
 	// create user & list user
 	userName := common.GenRandomString("user", 6)
 	pwd := common.GenRandomString("pwd", 6)
+	userDescription := "go client user description"
 	log.Info(t.Name(), zap.String("pwd", pwd))
-	err := mc.CreateUser(ctx, client.NewCreateUserOption(userName, pwd))
+	err := mc.CreateUser(ctx, client.NewCreateUserOption(userName, pwd).WithDescription(userDescription))
 	common.CheckErr(t, err, true)
 	users, err := mc.ListUsers(ctx, client.NewListUserOption())
 	common.CheckErr(t, err, true)
@@ -114,9 +115,11 @@ func TestRbacDefault(t *testing.T) {
 	require.ElementsMatch(t, []entity.GrantItem{expPrivilege}, role.Privileges)
 
 	// describe user
-	user, _ := mc.DescribeUser(ctx, client.NewDescribeUserOption(userName))
+	user, err := mc.DescribeUser(ctx, client.NewDescribeUserOption(userName))
 	common.CheckErr(t, err, true)
-	require.Equal(t, &entity.User{UserName: userName, Roles: []string{roleName}}, user)
+	require.Equal(t, userName, user.UserName)
+	require.ElementsMatch(t, []string{roleName}, user.Roles)
+	require.Equal(t, userDescription, user.Description)
 
 	// check privilege effect
 	require.Eventuallyf(t, func() bool {
@@ -273,12 +276,16 @@ func TestUpdatePassword(t *testing.T) {
 	err := mc.CreateUser(ctx, client.NewCreateUserOption(userName, pwd))
 	common.CheckErr(t, err, true)
 
-	err = mc.UpdatePassword(ctx, client.NewUpdatePasswordOption(userName, pwd, newPwd))
+	updatedDescription := "go client updated user description"
+	err = mc.UpdatePassword(ctx, client.NewUpdatePasswordOption(userName, pwd, newPwd).WithDescription(updatedDescription))
 	common.CheckErr(t, err, true)
 
 	mcUser := hp.CreateMilvusClient(ctx, t, &client.ClientConfig{Address: hp.GetAddr(), Username: userName, Password: newPwd})
 	_, err = mcUser.ListCollections(ctx, client.NewListCollectionOption())
 	common.CheckErr(t, err, true)
+	user, err := mc.DescribeUser(ctx, client.NewDescribeUserOption(userName))
+	common.CheckErr(t, err, true)
+	require.Equal(t, updatedDescription, user.Description)
 
 	// update multi times with multi language
 	oldPwd := newPwd
@@ -293,6 +300,9 @@ func TestUpdatePassword(t *testing.T) {
 	mcNewClient := hp.CreateMilvusClient(ctx, t, &client.ClientConfig{Address: hp.GetAddr(), Username: userName, Password: passwords[len(passwords)-1]})
 	_, err = mcNewClient.ListCollections(ctx, client.NewListCollectionOption())
 	common.CheckErr(t, err, true)
+	user, err = mc.DescribeUser(ctx, client.NewDescribeUserOption(userName))
+	common.CheckErr(t, err, true)
+	require.Equal(t, updatedDescription, user.Description)
 }
 
 func TestUpdatePasswordInvalid(t *testing.T) {

--- a/tests/integration/rbac/rbac_backup_test.go
+++ b/tests/integration/rbac/rbac_backup_test.go
@@ -50,9 +50,9 @@ func GetContext(ctx context.Context, originValue string) context.Context {
 func (s *RBACBasicTestSuite) TestBackup() {
 	ctx := GetContext(context.Background(), defaultAuth)
 
-	createRole := func(name string) {
+	createRole := func(name, description string) {
 		resp, err := s.Cluster.MilvusClient.CreateRole(ctx, &milvuspb.CreateRoleRequest{
-			Entity: &milvuspb.RoleEntity{Name: name},
+			Entity: &milvuspb.RoleEntity{Name: name, Description: description},
 		})
 		s.NoError(err)
 		s.True(merr.Ok(resp))
@@ -86,7 +86,8 @@ func (s *RBACBasicTestSuite) TestBackup() {
 	// generate some rbac content
 	// create role test_role
 	roleName := fmt.Sprintf("test_role_%d", rand.Int31n(1000000))
-	createRole(roleName)
+	roleDescription := "backup restore role description"
+	createRole(roleName, roleDescription)
 
 	// grant collection level search privilege to role test_role
 	operatePrivilege(roleName, "Search", util.AnyWord, util.DefaultDBName, milvuspb.OperatePrivilegeType_Grant)
@@ -141,6 +142,11 @@ func (s *RBACBasicTestSuite) TestBackup() {
 	})
 	s.True(grants["Search"] != nil)
 	s.True(grants[groupName] != nil)
+	roles := lo.SliceToMap(backupRBACResp.GetRBACMeta().GetRoles(), func(role *milvuspb.RoleEntity) (string, *milvuspb.RoleEntity) {
+		return role.GetName(), role
+	})
+	s.Contains(roles, roleName)
+	s.Equal(roleDescription, roles[roleName].GetDescription())
 	s.Equal(groupName, backupRBACResp.GetRBACMeta().PrivilegeGroups[0].GroupName)
 	s.Equal(2, len(backupRBACResp.GetRBACMeta().PrivilegeGroups[0].Privileges))
 
@@ -194,6 +200,11 @@ func (s *RBACBasicTestSuite) TestBackup() {
 	s.NoError(err)
 	s.True(merr.Ok(backupRBACResp2.GetStatus()))
 	s.Equal(backupRBACResp2.GetRBACMeta().String(), backupRBACResp.GetRBACMeta().String())
+	restoredRoles := lo.SliceToMap(backupRBACResp2.GetRBACMeta().GetRoles(), func(role *milvuspb.RoleEntity) (string, *milvuspb.RoleEntity) {
+		return role.GetName(), role
+	})
+	s.Contains(restoredRoles, roleName)
+	s.Equal(roleDescription, restoredRoles[roleName].GetDescription())
 
 	// clean rbac meta
 	operatePrivilege(roleName, "Search", util.AnyWord, util.DefaultDBName, milvuspb.OperatePrivilegeType_Revoke)

--- a/tests/restful_client_v2/testcases/test_role_operation.py
+++ b/tests/restful_client_v2/testcases/test_role_operation.py
@@ -32,22 +32,28 @@ class TestRoleE2E(TestBase):
         rsp = self.role_client.role_list()
         # create role
         role_name = gen_unique_str("role")
+        role_description = "rest role description"
         payload = {
             "roleName": role_name,
+            "description": role_description,
         }
         rsp = self.role_client.role_create(payload)
+        assert rsp["code"] == 0
         # list role after create
         rsp = self.role_client.role_list()
         assert role_name in rsp["data"]
         # describe role
         rsp = self.role_client.role_describe(role_name)
         assert rsp["code"] == 0
+        assert rsp.get("description") == role_description
         # grant privilege to role
         payload = {"roleName": role_name, "objectType": "Global", "objectName": "*", "privilege": "CreateCollection"}
         rsp = self.role_client.role_grant(payload)
         assert rsp["code"] == 0
         # describe role after grant
         rsp = self.role_client.role_describe(role_name)
+        assert rsp["code"] == 0
+        assert rsp.get("description") == role_description
         privileges = []
         for p in rsp["data"]:
             privileges.append(p["privilege"])
@@ -55,8 +61,11 @@ class TestRoleE2E(TestBase):
         # revoke privilege from role
         payload = {"roleName": role_name, "objectType": "Global", "objectName": "*", "privilege": "CreateCollection"}
         rsp = self.role_client.role_revoke(payload)
+        assert rsp["code"] == 0
         # describe role after revoke
         rsp = self.role_client.role_describe(role_name)
+        assert rsp["code"] == 0
+        assert rsp.get("description") == role_description
         privileges = []
         for p in rsp["data"]:
             privileges.append(p["privilege"])

--- a/tests/restful_client_v2/testcases/test_user_operation.py
+++ b/tests/restful_client_v2/testcases/test_user_operation.py
@@ -36,22 +36,37 @@ class TestUserE2E(TestBase):
         # create user
         user_name = gen_unique_str("user")
         password = "1234578"
-        payload = {"userName": user_name, "password": password}
+        user_description = "rest user description"
+        updated_description = "rest updated user description"
+        payload = {"userName": user_name, "password": password, "description": user_description}
         rsp = self.user_client.user_create(payload)
-        # list user after create
-        rsp = self.user_client.user_list()
-        assert user_name in rsp["data"]
-        # describe user
-        rsp = self.user_client.user_describe(user_name)
-
-        # update user password
-        new_password = "87654321"
-        payload = {"userName": user_name, "password": password, "newPassword": new_password}
-        rsp = self.user_client.user_password_update(payload)
         assert rsp["code"] == 0
-        # drop user
-        payload = {"userName": user_name}
-        rsp = self.user_client.user_drop(payload)
+        try:
+            # list user after create
+            rsp = self.user_client.user_list()
+            assert user_name in rsp["data"]
+            # describe user
+            rsp = self.user_client.user_describe(user_name)
+            assert rsp["code"] == 0
+            assert rsp.get("description") == user_description
+
+            # update user password
+            new_password = "87654321"
+            payload = {
+                "userName": user_name,
+                "password": password,
+                "newPassword": new_password,
+                "description": updated_description,
+            }
+            rsp = self.user_client.user_password_update(payload)
+            assert rsp["code"] == 0
+            rsp = self.user_client.user_describe(user_name)
+            assert rsp["code"] == 0
+            assert rsp.get("description") == updated_description
+        finally:
+            # drop user
+            payload = {"userName": user_name}
+            self.user_client.user_drop(payload)
 
         rsp = self.user_client.user_list()
         assert user_name not in rsp["data"]


### PR DESCRIPTION
issue: #50183 #50179

Related to #50183
Related to #50179

### What this PR does

Adds focused RBAC description coverage by reusing existing RBAC tests instead of adding new cases:

- Extends RBAC backup/restore integration coverage to assert role descriptions are preserved.
- Extends Go client RBAC E2E coverage for user description create/read and password update/read-back.
- Extends REST v2 role E2E coverage for create/describe description persistence across grant/revoke.
- Extends REST v2 user E2E coverage for create/describe/update_password description behavior.

### Tests

- `git diff --check`
- `python3 -m py_compile tests/restful_client_v2/testcases/test_role_operation.py tests/restful_client_v2/testcases/test_user_operation.py`
- `cd tests/go_client && go test -count=1 -tags rbac ./testcases/advcases -run '^(TestRbacDefault|TestUpdatePassword|TestRoleDescription)$' -v -args -addr http://10.104.6.197:19530 -user root -password Milvus`
- `/Users/yanliang.qiao/fork/.venv-py312/bin/python3 -m pytest testcases/test_role_operation.py::TestRoleE2E::test_role_e2e --endpoint http://10.104.6.197:19530 --token root:Milvus -v -q -x`
- `/Users/yanliang.qiao/fork/.venv-py312/bin/python3 -m pytest testcases/test_user_operation.py::TestUserE2E::test_user_e2e --endpoint http://10.104.6.197:19530 --token root:Milvus -v -q -x`
- Verified RBAC backup/restore role description preservation against `10.104.6.197:19530` using a temporary Go client admin API check.
