### PR TITLE
fix: [2.6] keep empty highlight results for nullable strings (#50572)

### DIFF
--- a/internal/proxy/highlighter.go
+++ b/internal/proxy/highlighter.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v2/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
 )
 
 const (
@@ -321,14 +323,82 @@ func newLexicalHighlightOperator(t *searchTask, tasks []*highlightTask) (operato
 	}, nil
 }
 
+func hasSearchResultHits(result *schemapb.SearchResultData) bool {
+	return searchResultHitCount(result) > 0
+}
+
+func searchResultHitCount(result *schemapb.SearchResultData) int {
+	if result == nil {
+		return 0
+	}
+
+	rowNum := 0
+	for _, topk := range result.GetTopks() {
+		rowNum += int(topk)
+	}
+	return rowNum
+}
+
+func rowAlignedStringFieldData(fieldData *schemapb.FieldData, rowNum int) ([]string, error) {
+	if fieldData == nil {
+		return nil, merr.WrapErrServiceInternal("get highlight failed, field data is nil")
+	}
+
+	data := fieldData.GetScalars().GetStringData().GetData()
+	validData := fieldData.GetValidData()
+	if len(validData) == 0 {
+		if len(data) != rowNum {
+			return nil, merr.WrapErrServiceInternal(fmt.Sprintf(
+				"get highlight failed, string field %s:%d has %d rows, expected %d",
+				fieldData.GetFieldName(), fieldData.GetFieldId(), len(data), rowNum))
+		}
+		return append([]string(nil), data...), nil
+	}
+
+	if len(validData) != rowNum {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf(
+			"get highlight failed, string field %s:%d has ValidData length %d, expected %d",
+			fieldData.GetFieldName(), fieldData.GetFieldId(), len(validData), rowNum))
+	}
+
+	validCount := lo.CountBy(validData, func(valid bool) bool { return valid })
+	if len(data) != rowNum && len(data) != validCount {
+		return nil, merr.WrapErrServiceInternal(fmt.Sprintf(
+			"get highlight failed, string field %s:%d has %d compact rows, expected %d valid rows",
+			fieldData.GetFieldName(), fieldData.GetFieldId(), len(data), validCount))
+	}
+
+	iterator := typeutil.GetDataIterator(fieldData)
+	texts := make([]string, rowNum)
+	for i := range texts {
+		if value := iterator(i); value != nil {
+			text, ok := value.(string)
+			if !ok {
+				return nil, merr.WrapErrServiceInternal(fmt.Sprintf(
+					"get highlight failed, string field %s:%d has non-string data at row %d",
+					fieldData.GetFieldName(), fieldData.GetFieldId(), i))
+			}
+			texts[i] = text
+		}
+	}
+	return texts, nil
+}
+
 func (op *lexicalHighlightOperator) run(ctx context.Context, span trace.Span, inputs ...any) ([]any, error) {
 	result := inputs[0].(*milvuspb.SearchResults)
-	datas := result.GetResults().GetFieldsData()
-	// skip highlight if result is empty
-	if len(datas) == 0 {
+	resultData := result.GetResults()
+	// skip highlight if result has no hits. FieldsData may contain empty field templates
+	// even when Topks/Ids/Scores show zero matched rows.
+	if !hasSearchResultHits(resultData) {
 		return []any{result}, nil
 	}
 
+	datas := resultData.GetFieldsData()
+	if len(datas) == 0 {
+		return nil, merr.WrapErrServiceInternal("get highlight failed, field data is empty for non-empty search result")
+	}
+
+	rowNum := searchResultHitCount(resultData)
 	req := &querypb.GetHighlightRequest{
 		Topks: result.GetResults().GetTopks(),
 		Tasks: lo.Map(op.tasks, func(task *highlightTask, _ int) *querypb.HighlightTask { return task.HighlightTask }),
@@ -339,16 +409,14 @@ func (op *lexicalHighlightOperator) run(ctx context.Context, span trace.Span, in
 		if !ok {
 			return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, text field not in output field %s: %d", task.GetFieldName(), task.GetFieldId())
 		}
-		texts := textFieldDatas.GetScalars().GetStringData().GetData()
-		task.Texts = append(task.Texts, texts...)
-		task.CorpusTextNum = int64(len(texts))
-
-		field, err := op.schema.schemaHelper.GetFieldFromID(task.GetFieldId())
+		texts, err := rowAlignedStringFieldData(textFieldDatas, rowNum)
 		if err != nil {
 			return nil, err
 		}
+		task.Texts = append(task.Texts, texts...)
+		task.CorpusTextNum = int64(len(texts))
 
-		nameFieldID, err := op.schema.GetMultiAnalyzerNameFieldID(field.GetFieldID())
+		nameFieldID, err := op.schema.GetMultiAnalyzerNameFieldID(task.GetFieldId())
 		if err != nil {
 			return nil, err
 		}
@@ -360,7 +428,16 @@ func (op *lexicalHighlightOperator) run(ctx context.Context, span trace.Span, in
 			if !ok {
 				return nil, merr.WrapErrParameterInvalidMsg("get highlight failed, analyzer name field: %d for multi analyzer not in output field", nameFieldID)
 			}
-			task.AnalyzerNames = append(task.AnalyzerNames, analyzerFieldDatas.GetScalars().GetStringData().GetData()...)
+			analyzerNames, err := rowAlignedStringFieldData(analyzerFieldDatas, rowNum)
+			if err != nil {
+				return nil, err
+			}
+			for i, name := range analyzerNames {
+				if name == "" {
+					analyzerNames[i] = "default"
+				}
+			}
+			task.AnalyzerNames = append(task.AnalyzerNames, analyzerNames...)
 		}
 	}
 
@@ -381,9 +458,11 @@ func (op *lexicalHighlightOperator) run(ctx context.Context, span trace.Span, in
 		return nil, err
 	}
 
-	rowNum := len(result.Results.GetScores())
 	HighlightResults := []*commonpb.HighlightResult{}
 	if rowNum != 0 {
+		if len(task.result.GetResults()) != len(req.GetTasks())*rowNum {
+			return nil, merr.WrapErrServiceInternal(fmt.Sprintf("get highlight failed, result count %d does not match task count %d and row count %d", len(task.result.GetResults()), len(req.GetTasks()), rowNum))
+		}
 		rowDatas := lo.Map(task.result.Results, func(result *querypb.HighlightResult, i int) *commonpb.HighlightData {
 			return buildStringFragments(op.tasks[i/rowNum], i%rowNum, result.GetFragments())
 		})

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
@@ -53,6 +54,14 @@ func TestSearchPipeline(t *testing.T) {
 type SearchPipelineSuite struct {
 	suite.Suite
 	span trace.Span
+}
+
+func testSearchResultIDs(ids ...int64) *schemapb.IDs {
+	return &schemapb.IDs{
+		IdField: &schemapb.IDs_IntId{
+			IntId: &schemapb.LongArray{Data: ids},
+		},
+	}
 }
 
 func (s *SearchPipelineSuite) SetupTest() {
@@ -947,7 +956,7 @@ func (s *SearchPipelineSuite) TestHighlightOp() {
 		qn.EXPECT().GetHighlight(mock.Anything, mock.Anything).Return(
 			&querypb.GetHighlightResponse{
 				Status:  merr.Success(),
-				Results: []*querypb.HighlightResult{},
+				Results: []*querypb.HighlightResult{{}},
 			}, nil)
 		workload.Exec(ctx, 0, qn, "test_chan")
 	}).Return(nil)
@@ -956,6 +965,7 @@ func (s *SearchPipelineSuite) TestHighlightOp() {
 		Results: &schemapb.SearchResultData{
 			TopK:  3,
 			Topks: []int64{1},
+			Ids:   testSearchResultIDs(1),
 			FieldsData: []*schemapb.FieldData{{
 				FieldName: testVarCharField,
 				FieldId:   100,
@@ -972,6 +982,213 @@ func (s *SearchPipelineSuite) TestHighlightOp() {
 		},
 	})
 	s.NoError(err)
+}
+
+func (s *SearchPipelineSuite) TestLexicalHighlightOpNullableStringKeepsEmptyHighlightData() {
+	cases := []struct {
+		name          string
+		rowNum        int
+		stringData    []string
+		validData     []bool
+		expectedTexts []string
+	}{
+		{
+			name:          "compact nullable string",
+			rowNum:        2,
+			stringData:    []string{"match text"},
+			validData:     []bool{true, false},
+			expectedTexts: []string{"target text", "match text", ""},
+		},
+		{
+			name:          "all null string",
+			rowNum:        1,
+			stringData:    []string{},
+			validData:     []bool{false},
+			expectedTexts: []string{"target text", ""},
+		},
+		{
+			name:          "empty string",
+			rowNum:        1,
+			stringData:    []string{""},
+			validData:     []bool{true},
+			expectedTexts: []string{"target text", ""},
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			proxy := &Proxy{}
+			proxy.tsoAllocator = &timestampAllocator{
+				tso: newMockTimestampAllocatorInterface(),
+			}
+			sched, err := newTaskScheduler(ctx, proxy.tsoAllocator)
+			s.Require().NoError(err)
+
+			err = sched.Start()
+			s.Require().NoError(err)
+			defer sched.Close()
+			proxy.sched = sched
+
+			collName := "test_coll_highlight_nullable"
+			fieldName2Types := map[string]schemapb.DataType{
+				testVarCharField: schemapb.DataType_VarChar,
+			}
+			schema := constructCollectionSchemaByDataType(collName, fieldName2Types, testVarCharField, false)
+
+			highlightTasks := map[int64]*highlightTask{
+				100: {
+					HighlightTask: &querypb.HighlightTask{
+						Texts:         []string{"target text"},
+						FieldName:     testVarCharField,
+						FieldId:       100,
+						SearchTextNum: 1,
+					},
+					preTags:  [][]byte{[]byte(DefaultPreTag)},
+					postTags: [][]byte{[]byte(DefaultPostTag)},
+				},
+			}
+
+			mockLb := shardclient.NewMockLBPolicy(s.T())
+			searchTask := &searchTask{
+				node: proxy,
+				highlighter: &LexicalHighlighter{
+					tasks: highlightTasks,
+				},
+				lb:             mockLb,
+				schema:         newSchemaInfo(schema),
+				request:        &milvuspb.SearchRequest{CollectionName: collName, DbName: "default"},
+				collectionName: collName,
+				SearchRequest:  &internalpb.SearchRequest{CollectionID: 0},
+			}
+
+			op, err := opFactory[highlightOp](searchTask, map[string]any{})
+			s.Require().NoError(err)
+
+			queryNodeResults := make([]*querypb.HighlightResult, tc.rowNum)
+			for i := range queryNodeResults {
+				queryNodeResults[i] = &querypb.HighlightResult{}
+			}
+
+			mockLb.EXPECT().ExecuteOneChannel(mock.Anything, mock.Anything).Run(func(ctx context.Context, workload shardclient.CollectionWorkLoad) {
+				qn := mocks.NewMockQueryNodeClient(s.T())
+				qn.EXPECT().GetHighlight(mock.Anything, mock.Anything).Run(func(ctx context.Context, req *querypb.GetHighlightRequest, opts ...grpc.CallOption) {
+					s.Require().Len(req.GetTasks(), 1)
+					task := req.GetTasks()[0]
+					s.Equal(int64(tc.rowNum), task.GetCorpusTextNum())
+					s.Equal(tc.expectedTexts, task.GetTexts())
+				}).Return(
+					&querypb.GetHighlightResponse{
+						Status:  merr.Success(),
+						Results: queryNodeResults,
+					}, nil)
+				workload.Exec(ctx, 0, qn, "test_chan")
+			}).Return(nil)
+
+			ids := make([]int64, tc.rowNum)
+			scores := make([]float32, tc.rowNum)
+			for i := range tc.rowNum {
+				ids[i] = int64(i + 1)
+				scores[i] = 1.0 - float32(i)*0.1
+			}
+
+			results, err := op.run(ctx, s.span, &milvuspb.SearchResults{
+				Results: &schemapb.SearchResultData{
+					NumQueries: 1,
+					TopK:       int64(tc.rowNum),
+					Topks:      []int64{int64(tc.rowNum)},
+					Ids:        testSearchResultIDs(ids...),
+					Scores:     scores,
+					FieldsData: []*schemapb.FieldData{
+						{
+							FieldId:   100,
+							FieldName: testVarCharField,
+							Type:      schemapb.DataType_VarChar,
+							ValidData: tc.validData,
+							Field: &schemapb.FieldData_Scalars{
+								Scalars: &schemapb.ScalarField{
+									Data: &schemapb.ScalarField_StringData{
+										StringData: &schemapb.StringArray{Data: tc.stringData},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+			s.NoError(err)
+			s.Require().Len(results, 1)
+
+			result := results[0].(*milvuspb.SearchResults)
+			highlightResults := result.GetResults().GetHighlightResults()
+			s.Require().Len(highlightResults, 1)
+			s.Equal(testVarCharField, highlightResults[0].GetFieldName())
+			s.Require().Len(highlightResults[0].GetDatas(), tc.rowNum)
+			for _, data := range highlightResults[0].GetDatas() {
+				s.NotNil(data)
+				s.Empty(data.GetFragments())
+			}
+		})
+	}
+}
+
+func (s *SearchPipelineSuite) TestLexicalHighlightOpZeroHitWithNonEmptyFieldsData() {
+	op := &lexicalHighlightOperator{
+		tasks: []*highlightTask{
+			{
+				HighlightTask: &querypb.HighlightTask{
+					Texts:     []string{"target text"},
+					FieldName: testVarCharField,
+					FieldId:   100,
+				},
+				preTags:  [][]byte{[]byte(DefaultPreTag)},
+				postTags: [][]byte{[]byte(DefaultPostTag)},
+			},
+		},
+	}
+
+	results, err := op.run(context.Background(), s.span, &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       5,
+			Topks:      []int64{0},
+			FieldsData: []*schemapb.FieldData{
+				{
+					FieldId:   101,
+					FieldName: "unrelated_field",
+					Type:      schemapb.DataType_Int64,
+					Field: &schemapb.FieldData_Scalars{
+						Scalars: &schemapb.ScalarField{
+							Data: &schemapb.ScalarField_LongData{
+								LongData: &schemapb.LongArray{Data: []int64{}},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+	s.Require().Len(results, 1)
+
+	result := results[0].(*milvuspb.SearchResults)
+	s.Empty(result.GetResults().GetHighlightResults())
+}
+
+func (s *SearchPipelineSuite) TestLexicalHighlightOpNonZeroHitWithEmptyFieldsData() {
+	op := &lexicalHighlightOperator{}
+	_, err := op.run(context.Background(), s.span, &milvuspb.SearchResults{
+		Results: &schemapb.SearchResultData{
+			NumQueries: 1,
+			TopK:       1,
+			Topks:      []int64{1},
+			Ids:        testSearchResultIDs(1),
+		},
+	})
+	s.Error(err)
+	s.Contains(err.Error(), "field data is empty for non-empty search result")
 }
 
 func (s *SearchPipelineSuite) TestSemanticHighlightOp() {


### PR DESCRIPTION
issue: #46308
pr: https://github.com/milvus-io/milvus/pull/50572

## Summary
Keep lexical highlight corpus texts aligned with search result rows when highlighted string fields are nullable or empty. Null and empty rows now still produce highlight data with an empty fragments list.