### PR TITLE
test: remove stale xfail on TextEmbedding drop-function e2e tests

### DIFF
--- a/tests/python_client/testcases/test_text_embedding_function_e2e.py
+++ b/tests/python_client/testcases/test_text_embedding_function_e2e.py
@@ -27,10 +27,6 @@ fake_en = Faker("en_US")
 pd.set_option("expand_frame_repr", False)
 
 prefix = "text_embedding_collection"
-DROP_TEXT_EMBEDDING_FUNCTION_XFAIL_REASON = (
-    "issue: https://github.com/milvus-io/milvus/issues/50424, "
-    "dropping TextEmbedding function incorrectly removes output vector field"
-)
 
 
 # TEI: https://github.com/huggingface/text-embeddings-inference
@@ -1535,7 +1531,6 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
 
     # ==================== drop_collection_function positive tests ====================
 
-    @pytest.mark.xfail(reason=DROP_TEXT_EMBEDDING_FUNCTION_XFAIL_REASON, strict=True)
     def test_drop_collection_function_verify_crud(self, tei_endpoint):
         """
         target: test CRUD behavior changes after dropping function
@@ -1640,7 +1635,6 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         res, _ = collection_w.query(expr="id >= 0", output_fields=["id"])
         assert len(res) == 4  # 6 - 2
 
-    @pytest.mark.xfail(reason=DROP_TEXT_EMBEDDING_FUNCTION_XFAIL_REASON, strict=True)
     def test_drop_collection_function_one_of_multiple(self, tei_endpoint):
         """
         target: test drop one function when multiple text embedding functions exist
@@ -1757,7 +1751,6 @@ class TestTextEmbeddingFunctionCURD(TestcaseBase):
         res, _ = collection_w.query(expr="id >= 0", output_fields=["id"])
         assert len(res) == 3
 
-    @pytest.mark.xfail(reason=DROP_TEXT_EMBEDDING_FUNCTION_XFAIL_REASON, strict=True)
     def test_drop_collection_function_then_add_again(self, tei_endpoint):
         """
         target: test can re-add function after dropping


### PR DESCRIPTION
## Summary

Bug #50424 — *"dropping a TextEmbedding function incorrectly removes the output vector field"* — was fixed and closed by #50471 ("fix: Split function drop semantics by request flag").

The three `drop_collection_function` e2e cases in `test_text_embedding_function_e2e.py` were still marked `@pytest.mark.xfail(strict=True)` referencing #50424. Now that the behavior is correct, the tests **pass**, and with `strict=True` pytest reports them as `XPASS(strict)` → **FAILED**, breaking `ci-v2/e2e-default` on `master` and on every open PR.

```
[XPASS(strict)] issue: .../issues/50424, dropping TextEmbedding function incorrectly removes output vector field
= 3 failed, 5857 passed, 339 skipped, 2 xfailed, 1 xpassed, 9 rerun =
```

This is deterministic (not flaky): the `DataNotMatchException: Insert missed an field 'dense'` log lines are the tests' own expected negative-path assertions (after detaching the function, inserting without the vector must fail).

## Changes

- Remove the three `@pytest.mark.xfail(...)` decorators from:
  - `TestTextEmbeddingFunctionCURD::test_drop_collection_function_verify_crud`
  - `TestTextEmbeddingFunctionCURD::test_drop_collection_function_one_of_multiple`
  - `TestTextEmbeddingFunctionCURD::test_drop_collection_function_then_add_again`
- Remove the now-unused `DROP_TEXT_EMBEDDING_FUNCTION_XFAIL_REASON` constant.

The tests now run as normal positive cases validating the fixed drop-function semantics from #50471.

issue: #50646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
