### PR TITLE
fix: resolve xxhash multiple-definition when linking C++ unit tests

### DIFF
--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -124,6 +124,16 @@ add_compile_definitions(
         MILVUS_CPPUT_OUTPUT_DIR="${CMAKE_INSTALL_PREFIX}/cpput_output"
         MILVUS_UNIT_TEST)
 
+if (LINUX)
+    # milvus-storage's Rust bridge (librust_bridge.a) statically embeds xxhash
+    # and re-exports its XXH* symbols globally. These collide with the conan
+    # xxhash that milvus_core links for BloomFilter/MinHash, so linking the
+    # unit-test binaries fails with "multiple definition of `XXH...'". Tell the
+    # GNU linker to keep the first definition instead of erroring on the
+    # duplicate. Applies to every test target declared below (and subdirs).
+    add_link_options("LINKER:--allow-multiple-definition")
+endif()
+
 add_executable(all_tests
         ${MILVUS_TEST_FILES}
         )


### PR DESCRIPTION
## Summary

Linking the C++ unit-test binaries fails on Linux with `multiple definition of 'XXH...'`, breaking `ci-v2/build-ut-cov` (UT-CPP-Cov stage) and `ci-v2/ut-cpp`:

```
FAILED: unittest/test_json_uint64
... multiple definition of `XXH32';
  thirdparty/milvus-storage/.../rust/librust_bridge.a(...xxhash.o): first defined here
collect2: error: ld returned 1 exit status
```

`test_json_uint64` is just the first test binary linked — any target linking both `milvus_conan_deps` and `milvus-storage` trips it.

## Root cause

Two copies of xxhash on the same static link line:

1. `milvus-storage`'s Rust bridge (`librust_bridge.a`) statically embeds xxhash and **re-exports** its `XXH*` symbols globally.
2. The conan `xxhash/0.8.3` that `milvus_core` legitimately links for `common/BloomFilter.h` and `minhash/MinHashComputer.cpp`.

The GNU linker errors on the duplicate global symbols. This surfaced after the `milvus-common`/Knowhere bump in #50612 rebuilt the in-tree milvus-storage Rust bridge with the embedded xxhash; it is cache-state dependent, so unrelated PRs (#50616, #50645, #50636) hit the identical error intermittently.

## Changes

- Add `-Wl,--allow-multiple-definition` (via `add_link_options(LINKER:...)`, guarded by `if(LINUX)`) in `internal/core/unittest/CMakeLists.txt`, so the linker keeps the first xxhash definition for all unit-test targets.

## Follow-up

Proper root fix tracked in #50648: localize/hide the duplicate third-party `XXH*` symbols in `librust_bridge.a` (symbol version script / `objcopy --localize-symbols`) in milvus-storage so it doesn't export a second copy of xxhash.

issue: #50648

🤖 Generated with [Claude Code](https://claude.com/claude-code)
