### PR TITLE
test: fix bare L1 marker breaking restful_client_v2 e2e collection

### DIFF
--- a/tests/restful_client_v2/testcases/test_struct_array_nullable.py
+++ b/tests/restful_client_v2/testcases/test_struct_array_nullable.py
@@ -1,5 +1,6 @@
 import pytest
 from base.testbase import TestBase
+from utils.constant import CaseLabel
 from utils.utils import gen_collection_name
 
 REST_VECTOR_DIM = 8
@@ -20,7 +21,7 @@ def assert_profile_equal(actual, expected):
     assert actual == expected
 
 
-@pytest.mark.L1
+@pytest.mark.tags(CaseLabel.L1)
 class TestRestfulStructArrayNullable(TestBase):
     dim = REST_VECTOR_DIM
 


### PR DESCRIPTION
## Summary

`tests/restful_client_v2/testcases/test_struct_array_nullable.py` decorated its test class with a **bare `@pytest.mark.L1`** instead of the suite convention `@pytest.mark.tags(CaseLabel.L1)`.

restful_client_v2's `pytest.ini` runs with `addopts = --strict`, which turns any unregistered marker into a hard error. `L1` is not a registered marker (only `tags` is), so pytest fails at **collection time**:

```
ERROR collecting testcases/test_struct_array_nullable.py
Failed: 'L1' not found in `markers` configuration option
```

With `-x` (stop on first failure) this aborts the entire `ci-v2/e2e-default` run — deterministically, on master and on every PR whose e2e matrix includes the restful_client_v2 suite. Separately, the bare marker also would not be matched by the framework's `pytest_tagging` `--tags L1` level selection, so the level tag had no effect anyway.

## Changes

- Import `CaseLabel` from `utils.constant`.
- Replace `@pytest.mark.L1` with `@pytest.mark.tags(CaseLabel.L1)`, matching every other file in the suite.

Introduced by #50109.
