### PR TITLE
test: fix flaky test_import_job_with_non_exist_files

### DIFF
--- a/tests/restful_client_v2/testcases/test_jobs_operation.py
+++ b/tests/restful_client_v2/testcases/test_jobs_operation.py
@@ -4069,9 +4069,19 @@ class TestCreateImportJobNegative(TestBase):
             "files": [["invalid_file.json"]],
         }
         rsp = self.import_job_client.create_import_jobs(payload)
-        time.sleep(5)
-        rsp = self.import_job_client.get_import_job_progress(rsp["data"]["jobId"])
-        assert rsp["data"]["state"] == "Failed"
+        job_id = rsp["data"]["jobId"]
+        # The job transitions Pending -> Importing -> Failed asynchronously once the
+        # importer tries to read the non-existent file. Poll until a terminal state
+        # instead of asserting after a fixed sleep, which races the scheduler under load.
+        state = None
+        t0 = time.time()
+        while time.time() - t0 < IMPORT_TIMEOUT:
+            rsp = self.import_job_client.get_import_job_progress(job_id)
+            state = rsp["data"]["state"]
+            if state in ("Failed", "Completed"):
+                break
+            time.sleep(1)
+        assert state == "Failed", f"expected import job to fail, got state={state}: {rsp}"
 
     def test_import_job_with_non_exist_binlog_files(self):
         # create collection


### PR DESCRIPTION
## Summary

`TestCreateImportJobNegative::test_import_job_with_non_exist_files` is flaky in `ci-v2/e2e-default`:

```
FAILED testcases/test_jobs_operation.py::TestCreateImportJobNegative::test_import_job_with_non_exist_files
AssertionError: assert 'Importing' == 'Failed'
```

## Root cause

The test created an import job for a non-existent file, slept a **fixed 5 seconds**, then asserted the job `state == "Failed"`:

```python
rsp = self.import_job_client.create_import_jobs(payload)
time.sleep(5)
rsp = self.import_job_client.get_import_job_progress(rsp["data"]["jobId"])
assert rsp["data"]["state"] == "Failed"
```

The import job advances `Pending -> Importing -> Failed` **asynchronously** — it only becomes `Failed` after the datacoord import scheduler actually attempts to read the missing file and propagates the failure. On a fast/idle runner 5s is enough; under CI load the job is still `Importing` at 5s, so the assertion fails. It's a test-side race, not a product bug (the import does eventually fail).

## Fix

Poll the job progress until it reaches a terminal state (`Failed`/`Completed`), bounded by the existing `IMPORT_TIMEOUT`, then assert it failed — matching how every other import test in this file waits. No production behavior change.
