### PR TITLE
test: fix stale error-message assertion in struct array reject test

### DIFF
--- a/tests/restful_client_v2/testcases/test_struct_array_nullable.py
+++ b/tests/restful_client_v2/testcases/test_struct_array_nullable.py
@@ -209,7 +209,9 @@ class TestRestfulStructArrayNullable(TestBase):
             },
         )
         assert rsp["code"] != 0
-        assert "Invalid field type, type:ArrayOfStruct" in rsp["message"]
+        # The server rejects ArrayOfStruct via the regular field-add endpoint and
+        # directs the caller to the dedicated struct_fields/add endpoint.
+        assert "struct_fields/add" in rsp["message"]
 
         rsp = self.collection_client.collection_describe(name)
         assert rsp["code"] == 0


### PR DESCRIPTION
## Summary

`TestRestfulStructArrayNullable::test_rest_v2_add_struct_array_field_rejected` fails deterministically in `ci-v2/e2e-default`:

```
AssertionError: assert 'Invalid field type, type:ArrayOfStruct' in
  'StructArray field must be added through /v2/vectordb/collections/struct_fields/add: invalid parameter'
```

The test verifies that adding an `ArrayOfStruct` field via the regular `/collections/fields/add` endpoint is rejected. The rejection works correctly (non-zero code, field not added, `structFields == []`), but the test asserted a **stale error-message substring** (`Invalid field type, type:ArrayOfStruct`). The server actually returns a clearer message directing the caller to the dedicated endpoint: `StructArray field must be added through /v2/vectordb/collections/struct_fields/add`.

This assertion was masked until now: the file failed collection on a bad `L1` marker (fixed in #50651), so none of its tests ran. Once the file is collectable, the stale assertion fails.

## Fix

Assert the stable `struct_fields/add` substring, which still verifies the rejection guides the caller to the correct endpoint. Introduced by #50109.
