### PR TITLE
test: remove stale xfail on nullable struct array schema propagation

### DIFF
--- a/tests/restful_client_v2/testcases/test_struct_array_nullable.py
+++ b/tests/restful_client_v2/testcases/test_struct_array_nullable.py
@@ -267,10 +267,6 @@ class TestRestfulStructArrayNullable(TestBase):
         assert rsp["code"] != 0
         assert "Struct" in rsp["message"]
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="REST v2 schema.structFields nullable=true is silently ignored instead of preserved in describe output",
-    )
     def test_rest_v2_nullable_struct_array_schema_propagation(self):
         """
         target: test REST v2 nullable propagation for Struct Array


### PR DESCRIPTION
## Summary

`TestRestfulStructArrayNullable::test_rest_v2_nullable_struct_array_schema_propagation` was marked `xfail(strict=True)` for *'REST v2 schema.structFields nullable=true is silently ignored instead of preserved in describe output'*.

The behavior now correctly preserves `nullable=true` on struct array fields in the describe output, so the test passes. With `strict=True` an unexpected pass becomes `XPASS(strict)` which pytest reports as **FAILED**, breaking `ci-v2/e2e-default`:

```
[XPASS(strict)] REST v2 schema.structFields nullable=true is silently ignored instead of preserved in describe output
```

This was masked until the file's bad `L1` marker was fixed (#50651); once the file is collectable the stale xfail surfaces. Remove the decorator so the test runs as a normal positive case validating the (now correct) nullable propagation. Introduced by #50109.