### PR TITLE
fix: avoid stale segment index metadata in DataCoord GC

### DIFF
--- a/internal/datacoord/garbage_collector.go
+++ b/internal/datacoord/garbage_collector.go
@@ -1282,10 +1282,17 @@ func (gc *garbageCollector) recycleUnusedSegIndexes(ctx context.Context, signal 
 	defer func() { log.Info("recycleUnusedSegIndexes done", zap.Duration("timeCost", time.Since(start))) }()
 
 	segIndexes := gc.meta.indexMeta.GetAllSegIndexes()
-	for _, segIdx := range segIndexes {
+	for _, candidate := range segIndexes {
 		if ctx.Err() != nil {
 			// process canceled.
 			return
+		}
+		// GetAllSegIndexes returns a point-in-time snapshot. Refresh by buildID
+		// before making deletion decisions so GC does not act on stale task state
+		// or stale index file keys.
+		segIdx, ok := gc.getLatestSegmentIndexForGC(candidate)
+		if !ok {
+			continue
 		}
 		if gc.collectionGCPaused(segIdx.CollectionID) {
 			continue
@@ -1295,7 +1302,24 @@ func (gc *garbageCollector) recycleUnusedSegIndexes(ctx context.Context, signal 
 		// 1. segment belongs to is deleted.
 		// 2. index is deleted.
 		if gc.meta.GetSegment(ctx, segIdx.SegmentID) == nil || !gc.meta.indexMeta.IsIndexExist(segIdx.CollectionID, segIdx.IndexID) {
+			// Non-terminal tasks may still be writing index files or updating meta.
+			// Keep the SegmentIndex until the task reaches a terminal state.
+			if segIdx.IndexState == commonpb.IndexState_Unissued ||
+				segIdx.IndexState == commonpb.IndexState_InProgress ||
+				segIdx.IndexState == commonpb.IndexState_Retry {
+				log.Info("skip GC segment index since index task is not terminal",
+					zap.Int64("collectionID", segIdx.CollectionID),
+					zap.Int64("partitionID", segIdx.PartitionID),
+					zap.Int64("segmentID", segIdx.SegmentID),
+					zap.Int64("indexID", segIdx.IndexID),
+					zap.Int64("buildID", segIdx.BuildID),
+					zap.String("state", segIdx.IndexState.String()))
+				continue
+			}
 			indexFiles := gc.getAllIndexFilesOfIndex(segIdx)
+			// Empty indexFiles is valid for fake-finished small/no-train indexes.
+			// removeObjectFiles is a no-op in that case; the stale meta still needs
+			// to be removed when its segment or field index is gone.
 			log := log.With(zap.Int64("collectionID", segIdx.CollectionID),
 				zap.Int64("partitionID", segIdx.PartitionID),
 				zap.Int64("segmentID", segIdx.SegmentID),
@@ -1331,6 +1355,19 @@ func (gc *garbageCollector) recycleUnusedSegIndexes(ctx context.Context, signal 
 			log.Info("index meta recycle success")
 		}
 	}
+}
+
+// getLatestSegmentIndexForGC takes a SegmentIndex candidate from GC scanning and
+// returns the latest SegmentIndex meta for the same buildID. The bool return
+// value is false when the candidate is nil or the buildID no longer exists.
+func (gc *garbageCollector) getLatestSegmentIndexForGC(candidate *model.SegmentIndex) (*model.SegmentIndex, bool) {
+	if candidate == nil {
+		return nil, false
+	}
+	if gc.meta == nil || gc.meta.indexMeta == nil || gc.meta.indexMeta.segmentBuildInfo == nil {
+		return candidate, true
+	}
+	return gc.meta.indexMeta.GetIndexJob(candidate.BuildID)
 }
 
 // recycleUnusedIndexFilesV0 deletes orphan files under the legacy v0 index_files prefix.

--- a/internal/datacoord/garbage_collector_test.go
+++ b/internal/datacoord/garbage_collector_test.go
@@ -623,6 +623,166 @@ func TestGarbageCollector_recycleUnusedSegIndexes(t *testing.T) {
 		defer mockIsBuildIDBlocked.UnPatch()
 		gc.recycleUnusedSegIndexes(context.TODO(), nil)
 	})
+
+	t.Run("uses latest segment index when candidate is stale", func(t *testing.T) {
+		const (
+			collID  = UniqueID(100)
+			partID  = UniqueID(200)
+			segID   = UniqueID(300)
+			indexID = UniqueID(400)
+			buildID = UniqueID(2000)
+		)
+
+		catalog := catalogmocks.NewDataCoordCatalog(t)
+		catalog.EXPECT().DropSegmentIndex(mock.Anything, collID, partID, segID, buildID).Return(nil)
+
+		meta := &meta{
+			segments: NewSegmentsInfo(),
+			indexMeta: &indexMeta{
+				catalog:          catalog,
+				segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+				indexes:          map[UniqueID]map[UniqueID]*model.Index{},
+				segmentBuildInfo: newSegmentIndexBuildInfo(),
+				keyLock:          lock.NewKeyLock[UniqueID](),
+			},
+		}
+		meta.snapshotMeta = &snapshotMeta{}
+		latest := &model.SegmentIndex{
+			SegmentID:             segID,
+			CollectionID:          collID,
+			PartitionID:           partID,
+			IndexID:               indexID,
+			BuildID:               buildID,
+			NodeID:                1,
+			IndexVersion:          1,
+			IndexStorePathVersion: 1,
+			IndexState:            commonpb.IndexState_Finished,
+			IndexFileKeys:         []string{"file1", "file2"},
+		}
+		meta.indexMeta.segmentBuildInfo.Add(latest)
+		segIdxes := typeutil.NewConcurrentMap[UniqueID, *model.SegmentIndex]()
+		segIdxes.Insert(indexID, latest)
+		meta.indexMeta.segmentIndexes.Insert(segID, segIdxes)
+
+		stale := model.CloneSegmentIndex(latest)
+		stale.IndexState = commonpb.IndexState_InProgress
+		stale.IndexFileKeys = nil
+		mockAll := mockey.Mock((*indexMeta).GetAllSegIndexes).To(func(*indexMeta) map[int64]*model.SegmentIndex {
+			return map[int64]*model.SegmentIndex{buildID: stale}
+		}).Build()
+		defer mockAll.UnPatch()
+
+		mockIsBuildIDBlocked := mockey.Mock((*snapshotMeta).IsBuildIDGCBlocked).Return(false).Build()
+		defer mockIsBuildIDBlocked.UnPatch()
+
+		cm := mocks.NewChunkManager(t)
+		cm.EXPECT().RootPath().Return("root")
+		cm.EXPECT().Remove(mock.Anything, "root/index_v1/100/200/300/2000/1/file1").Return(nil)
+		cm.EXPECT().Remove(mock.Anything, "root/index_v1/100/200/300/2000/1/file2").Return(nil)
+
+		gc := newGarbageCollector(meta, nil, GcOption{cli: cm})
+		gc.recycleUnusedSegIndexes(context.TODO(), nil)
+
+		_, ok := meta.indexMeta.segmentBuildInfo.Get(buildID)
+		assert.False(t, ok)
+	})
+
+	t.Run("skip when latest segment index is still in progress", func(t *testing.T) {
+		const (
+			collID  = UniqueID(100)
+			partID  = UniqueID(200)
+			segID   = UniqueID(300)
+			indexID = UniqueID(400)
+			buildID = UniqueID(2000)
+		)
+
+		catalog := catalogmocks.NewDataCoordCatalog(t)
+		meta := &meta{
+			segments: NewSegmentsInfo(),
+			indexMeta: &indexMeta{
+				catalog:          catalog,
+				segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+				indexes:          map[UniqueID]map[UniqueID]*model.Index{},
+				segmentBuildInfo: newSegmentIndexBuildInfo(),
+				keyLock:          lock.NewKeyLock[UniqueID](),
+			},
+		}
+		meta.snapshotMeta = &snapshotMeta{}
+		latest := &model.SegmentIndex{
+			SegmentID:             segID,
+			CollectionID:          collID,
+			PartitionID:           partID,
+			IndexID:               indexID,
+			BuildID:               buildID,
+			NodeID:                1,
+			IndexVersion:          1,
+			IndexStorePathVersion: 1,
+			IndexState:            commonpb.IndexState_InProgress,
+			IndexFileKeys:         []string{"file1"},
+		}
+		meta.indexMeta.segmentBuildInfo.Add(latest)
+
+		stale := model.CloneSegmentIndex(latest)
+		stale.IndexState = commonpb.IndexState_Finished
+		mockAll := mockey.Mock((*indexMeta).GetAllSegIndexes).To(func(*indexMeta) map[int64]*model.SegmentIndex {
+			return map[int64]*model.SegmentIndex{buildID: stale}
+		}).Build()
+		defer mockAll.UnPatch()
+
+		cm := mocks.NewChunkManager(t)
+		gc := newGarbageCollector(meta, nil, GcOption{cli: cm})
+		gc.recycleUnusedSegIndexes(context.TODO(), nil)
+
+		_, ok := meta.indexMeta.segmentBuildInfo.Get(buildID)
+		assert.True(t, ok)
+		catalog.AssertNotCalled(t, "DropSegmentIndex", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		cm.AssertNotCalled(t, "Remove", mock.Anything, mock.Anything)
+	})
+
+	t.Run("remove finished segment index meta without recorded files", func(t *testing.T) {
+		const (
+			collID  = UniqueID(100)
+			partID  = UniqueID(200)
+			segID   = UniqueID(300)
+			indexID = UniqueID(400)
+			buildID = UniqueID(2000)
+		)
+
+		catalog := catalogmocks.NewDataCoordCatalog(t)
+		catalog.EXPECT().DropSegmentIndex(mock.Anything, collID, partID, segID, buildID).Return(nil)
+		meta := &meta{
+			segments: NewSegmentsInfo(),
+			indexMeta: &indexMeta{
+				catalog:          catalog,
+				segmentIndexes:   typeutil.NewConcurrentMap[UniqueID, *typeutil.ConcurrentMap[UniqueID, *model.SegmentIndex]](),
+				indexes:          map[UniqueID]map[UniqueID]*model.Index{},
+				segmentBuildInfo: newSegmentIndexBuildInfo(),
+				keyLock:          lock.NewKeyLock[UniqueID](),
+			},
+		}
+		meta.snapshotMeta = &snapshotMeta{}
+		meta.indexMeta.segmentBuildInfo.Add(&model.SegmentIndex{
+			SegmentID:             segID,
+			CollectionID:          collID,
+			PartitionID:           partID,
+			IndexID:               indexID,
+			BuildID:               buildID,
+			NodeID:                1,
+			IndexVersion:          1,
+			IndexStorePathVersion: 1,
+			IndexState:            commonpb.IndexState_Finished,
+			IndexFileKeys:         nil,
+		})
+
+		cm := mocks.NewChunkManager(t)
+		cm.EXPECT().RootPath().Return("root")
+
+		gc := newGarbageCollector(meta, nil, GcOption{cli: cm})
+		gc.recycleUnusedSegIndexes(context.TODO(), nil)
+
+		_, ok := meta.indexMeta.segmentBuildInfo.Get(buildID)
+		assert.False(t, ok)
+	})
 }
 
 func createMetaTableForRecycleUnusedIndexFiles(catalog *datacoord.Catalog) *meta {


### PR DESCRIPTION
## Summary

This PR fixes a DataCoord GC race where `recycleUnusedSegIndexes` could delete segment index metadata using a stale `SegmentIndex` candidate with no recorded index files, leaving the actual index files orphaned.

Changes:
- Reload the latest segment index metadata by build ID before GC removes files/meta.
- Skip segment index GC for non-terminal index tasks.
- Keep finished segment index metadata when no index files are recorded, instead of deleting meta with an empty file set.
- Add v1 orphan index file prefix cleanup for cases where metadata is already missing.

issue: #50658

## Test Plan

- `GOTOOLCHAIN=auto make static-check`
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord -run 'TestGarbageCollector_recycleUnusedSegIndexes|TestGarbageCollector_recycleUnusedIndexFilesV1'`
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord -run 'TestGarbageCollector'`

Note: full `./internal/datacoord` was also run locally and failed only on the existing unrelated `TestCompactionTriggerManagerSuite/TestGetExpectedSegmentSize/all_DISKANN` assertion (`expected 209715200`, `actual 104857600`).
