### PR TITLE
fix: treat an escaped trailing % as a literal in LIKE optimization

### DIFF
--- a/internal/parser/planparserv2/pattern_match.go
+++ b/internal/parser/planparserv2/pattern_match.go
@@ -13,6 +13,20 @@ var wildcards = map[byte]struct{}{
 
 var escapeCharacter byte = '\\'
 
+// trailingWildcard reports whether the pattern ends in an unescaped '%'.
+// A trailing '%' preceded by an odd number of backslashes is escaped (a
+// literal '%'), so it is not a wildcard.
+func trailingWildcard(pattern string) bool {
+	if len(pattern) == 0 || pattern[len(pattern)-1] != '%' {
+		return false
+	}
+	backslashes := 0
+	for i := len(pattern) - 2; i >= 0 && pattern[i] == escapeCharacter; i-- {
+		backslashes++
+	}
+	return backslashes%2 == 0
+}
+
 func optimizeLikePattern(pattern string) (planpb.OpType, string, bool) {
 	if len(pattern) == 0 {
 		return planpb.OpType_Equal, "", true
@@ -42,8 +56,11 @@ func optimizeLikePattern(pattern string) (planpb.OpType, string, bool) {
 		return buf.String(), true
 	}
 
+	// A leading '%' is always a wildcard (nothing can escape it), but a trailing
+	// '%' preceded by an odd number of backslashes is escaped — a literal '%',
+	// not a wildcard — so it must not trigger prefix/inner optimization.
 	leading := pattern[0] == '%'
-	trailing := pattern[len(pattern)-1] == '%'
+	trailing := trailingWildcard(pattern)
 
 	switch {
 	case leading && trailing:

--- a/internal/parser/planparserv2/pattern_match_test.go
+++ b/internal/parser/planparserv2/pattern_match_test.go
@@ -108,6 +108,11 @@ func TestOptimizeLikePattern(t *testing.T) {
 		{"a\\_bc", planpb.OpType_Equal, "a_bc", true},
 		{"abc_", planpb.OpType_Invalid, "", false},
 
+		// escaped trailing % is a literal, not a wildcard (issue #43864)
+		{"a\\%", planpb.OpType_Equal, "a%", true},
+		{"%abc\\%", planpb.OpType_PostfixMatch, "abc%", true},
+		{"a\\\\%", planpb.OpType_PrefixMatch, "a\\\\", true},
+
 		// null pattern
 		{"", planpb.OpType_Equal, "", true},
 	}


### PR DESCRIPTION
## Summary

`optimizeLikePattern` picks prefix / postfix / inner matching from the raw first and last characters of the pattern:

```go
leading := pattern[0] == '%'
trailing := pattern[len(pattern)-1] == '%'
```

The `process` step already unescapes `\%` and `\_`, but this wildcard detection doesn't, so a pattern ending in an escaped `\%` (a literal percent) is mistaken for a trailing wildcard:

- `col LIKE 'a\%'` (meant to match the literal string `a%`) is rewritten to a **prefix match on `a\`** instead of an equal match on `a%`.
- `col LIKE '%abc\%'` becomes an **inner match on `abc\`** instead of a postfix match on `abc%`.

Both silently return the wrong rows.

## Fix

Add `trailingWildcard`, which treats a trailing `%` as a wildcard only when it is preceded by an **even** number of backslashes (an odd count means the `%` is escaped). A leading `%` cannot be escaped — there is nothing before it — so it is unchanged. This stays consistent with the existing `%a\%` → inner-match case (two backslashes = even = the `%` is a real wildcard).

issue: #43864

## Test

Added cases to `TestOptimizeLikePattern` for an escaped trailing `%` in the equal, prefix, and postfix paths:

```
go test ./internal/parser/planparserv2/ -run TestOptimizeLikePattern
```

The two new escaped-percent cases fail before the change and pass after it; `go vet` and `gofmt` are clean.
