### PR TITLE
fix: pin rapidjson to cci.20230929 so core builds under clang 19

### DIFF
--- a/internal/core/conanfile.py
+++ b/internal/core/conanfile.py
@@ -135,6 +135,10 @@ class MilvusConan(ConanFile):
         # (arrow/*:with_snappy and arrow/*:with_lz4 are enabled for Parquet decoding)
         self.requires("snappy/1.2.1#b940695c64ccbff63c1aabd4b1eee3f3", force=True)
         self.requires("lz4/1.10.0#982d9b673900f665a1da109e09c17cab", force=True)
+        # Pin rapidjson to the newest cci snapshot. Arrow 17 pulls an older
+        # rapidjson transitively, which fails to compile under clang 19 (libc++ 19).
+        # force=True overrides Arrow's transitive version.
+        self.requires("rapidjson/cci.20230929#0a3982e5f4fa453a9b9cd0dd5b1dcb3a", force=True)
         if self.settings.os == "Linux":
             self.requires("openblas/0.3.30")
         if self.settings.os != "Macos":


### PR DESCRIPTION
## What this PR does

Pins `rapidjson` to the newest `cci.20230929` snapshot in `internal/core/conanfile.py` so the C++ core builds under **clang 19 / libc++ 19** (Homebrew LLVM on macOS Apple Silicon).

## Why

Arrow 17 pulls **`rapidjson/1.1.0`** (a 2016 release) as a transitive dependency. Its headers fail to compile under clang 19 / libc++ 19. Milvus core includes Arrow's JSON headers, which transitively pull in rapidjson, so the **core build** breaks under clang 19 even though the Arrow binary itself is consumed prebuilt.

This is the macOS/clang-19 path that was not exercised by #50616's Linux CI (which resolves a prebuilt Arrow binary and never source-includes the old rapidjson under clang 19).

## How

```python
self.requires("rapidjson/cci.20230929#0a3982e5f4fa453a9b9cd0dd5b1dcb3a", force=True)
```

- `force=True` overrides Arrow's transitive `rapidjson/1.1.0`.
- rapidjson is **header-only**, so this does **not** invalidate the prebuilt Arrow `package_id` — `conan graph info` confirms Arrow stays `Cache`-resolved.
- Recipe revision is pinned from the milvus production remote (`default-conan-local2`), consistent with how arrow/azure/snappy/lz4 are pinned.

## Verification

- `conan graph info` resolves cleanly: `rapidjson/1.1.0 -> rapidjson/cci.20230929#0a3982e5...`, no conflict, Arrow unchanged.
- Full core build passes under macOS arm64 / Homebrew clang 19.

issue: #50615

🤖 Generated with [Claude Code](https://claude.com/claude-code)