### PR TITLE
doc: note L1 segments seal on size only in shard-management

### DIFF
--- a/docs/agent_guides/streaming-system/wal/shard-management.md
+++ b/docs/agent_guides/streaming-system/wal/shard-management.md
@@ -8,6 +8,8 @@ See [Collection Messages](../message/message-semantic-collection.md) for per-mes
 
 Growing segments are sealed when any registered policy triggers. See `internal/streamingnode/server/wal/interceptors/shard/policy/seal_policy.go` for the full list of policies.
 
+Note: L1 (normal insert) segments seal on **size only** — the row threshold is disabled (`SegmentRows = math.MaxUint64` in `segment_limitation_policy.go`); only L0 (delete) segments enforce both a row and a size limit (`FlushL0MaxRowNum` / `FlushL0MaxSize`).
+
 ## Key Packages
 
 - `internal/streamingnode/server/wal/interceptors/shard/` — Shard interceptor, `ShardManager`, seal policies, segment stats


### PR DESCRIPTION
## What

Adds a one-line clarification to the streaming-system shard-management guide: L1 (normal insert) segments seal on **size only** — the row threshold is disabled (`SegmentRows = math.MaxUint64` in `segment_limitation_policy.go`). Only L0 (delete) segments enforce both a row and a size limit (`FlushL0MaxRowNum` / `FlushL0MaxSize`).

## Why

The existing doc points readers to `seal_policy.go` for the policy list but doesn't surface that L1 row-based sealing is intentionally disabled, which is easy to misread as an oversight. This documents the deliberate size-only design (consistent with the binlog buffer's row→size switch in #28498) so future readers don't try to 'fix' it by adding an L1 row threshold.

Docs-only change; `seal_policy.go` remains the source of truth for the full policy list.

## Note added to shard-management.md

> Note: L1 (normal insert) segments seal on **size only** — the row threshold is disabled (`SegmentRows = math.MaxUint64` in `segment_limitation_policy.go`); only L0 (delete) segments enforce both a row and a size limit (`FlushL0MaxRowNum` / `FlushL0MaxSize`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
