### PR TITLE
fix: don't panic on missing keys in MemoryKV MultiLoad/MultiLoadBytes

### DIFF
--- a/internal/kv/mem/mem_kv.go
+++ b/internal/kv/mem/mem_kv.go
@@ -18,6 +18,7 @@ package memkv
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -175,9 +176,18 @@ func (kv *MemoryKV) MultiLoad(ctx context.Context, keys []string) ([]string, err
 	kv.RLock()
 	defer kv.RUnlock()
 	result := make([]string, 0, len(keys))
+	invalid := make([]string, 0, len(keys))
 	for _, key := range keys {
 		item := kv.tree.Get(memoryKVItem{key: key})
+		if item == nil {
+			invalid = append(invalid, key)
+			result = append(result, "")
+			continue
+		}
 		result = append(result, item.(memoryKVItem).value.String())
+	}
+	if len(invalid) != 0 {
+		return result, merr.WrapErrIoKeyNotFound(fmt.Sprintf("%v", invalid))
 	}
 	return result, nil
 }
@@ -187,9 +197,18 @@ func (kv *MemoryKV) MultiLoadBytes(ctx context.Context, keys []string) ([][]byte
 	kv.RLock()
 	defer kv.RUnlock()
 	result := make([][]byte, 0, len(keys))
+	invalid := make([]string, 0, len(keys))
 	for _, key := range keys {
 		item := kv.tree.Get(memoryKVItem{key: key})
+		if item == nil {
+			invalid = append(invalid, key)
+			result = append(result, []byte{})
+			continue
+		}
 		result = append(result, item.(memoryKVItem).value.ByteSlice())
+	}
+	if len(invalid) != 0 {
+		return result, merr.WrapErrIoKeyNotFound(fmt.Sprintf("%v", invalid))
 	}
 	return result, nil
 }

--- a/internal/kv/mem/mem_kv_test.go
+++ b/internal/kv/mem/mem_kv_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/milvus-io/milvus/pkg/v3/kv/predicates"
@@ -176,6 +177,25 @@ func TestMemoryKV_MultiSaveBytesAndRemove(t *testing.T) {
 	_values, err := mem.MultiLoadBytes(context.TODO(), keys[1:])
 	assert.Equal(t, values[1:], _values)
 	assert.NoError(t, err)
+}
+
+func TestMemoryKV_MultiLoadMissingKey(t *testing.T) {
+	mem := NewMemoryKV()
+	assert.NoError(t, mem.MultiSave(context.TODO(), map[string]string{"present": "v"}))
+	assert.NoError(t, mem.MultiSaveBytes(context.TODO(), map[string][]byte{"present": []byte("v")}))
+
+	// A missing key must not panic. Like Load() and the etcd MetaKv
+	// implementation, MultiLoad fills a placeholder for the missing key and
+	// returns a key-not-found error.
+	values, err := mem.MultiLoad(context.TODO(), []string{"present", "missing"})
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrIoKeyNotFound))
+	assert.Equal(t, []string{"v", ""}, values)
+
+	bytesValues, err := mem.MultiLoadBytes(context.TODO(), []string{"present", "missing"})
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrIoKeyNotFound))
+	assert.Equal(t, [][]byte{[]byte("v"), {}}, bytesValues)
 }
 
 func TestMemoryKV_MultiSaveBytesAndRemoveWithPrefix(t *testing.T) {


### PR DESCRIPTION
## Description

`MemoryKV.Load` returns a key-not-found error for a missing key, and the etcd `MetaKv` implementation does the same for `MultiLoad` / `MultiLoadBytes` — it fills a placeholder per missing key and returns `merr.WrapErrIoKeyNotFound`. But `MemoryKV.MultiLoad` and `MultiLoadBytes` type-assert the btree lookup result unconditionally:

```go
item := kv.tree.Get(memoryKVItem{key: key})
result = append(result, item.(memoryKVItem).value.String())
```

so a single missing key panics with `interface conversion: btree.Item is nil, not memkv.memoryKVItem`.

`MemoryKV` is the in-memory `TxnKV` used as a stand-in for etcd in tests, so the mismatch means a test that loads a not-yet-written key crashes instead of getting the key-not-found error it would see against etcd.

## Fix

Make the two multi-load methods consistent with `Load` and the etcd implementation: fill a placeholder (`""` / `[]byte{}`) for each missing key and return `WrapErrIoKeyNotFound` with the missing keys. Present keys are unaffected — no error is returned when nothing is missing.

## Test

Added `TestMemoryKV_MultiLoadMissingKey`, which loads a mix of present and missing keys. It panics on the current code and passes with the fix.

Verified locally with `go test ./internal/kv/mem/`, `go vet ./internal/kv/mem/`, and `gofmt`.
