### PR TITLE
enhance: add HNSW_SQ index support to Go client

### DIFF
--- a/client/index/common.go
+++ b/client/index/common.go
@@ -47,6 +47,7 @@ const (
 	IvfSQ8     IndexType = "IVF_SQ8"
 	IvfRabitQ  IndexType = "IVF_RABITQ"
 	HNSW       IndexType = "HNSW"
+	HNSWSQ     IndexType = "HNSW_SQ"
 	IvfHNSW    IndexType = "IVF_HNSW"
 	AUTOINDEX  IndexType = "AUTOINDEX"
 	DISKANN    IndexType = "DISKANN"

--- a/client/index/hnsw.go
+++ b/client/index/hnsw.go
@@ -24,6 +24,9 @@ const (
 	hnswMKey           = `M`
 	hsnwEfConstruction = `efConstruction`
 	hnswEfKey          = `ef`
+	hnswSQTypeKey      = `sq_type`
+	hnswRefineKey      = `refine`
+	hnswRefineTypeKey  = `refine_type`
 )
 
 var _ Index = hnswIndex{}
@@ -52,6 +55,51 @@ func NewHNSWIndex(metricType MetricType, m int, efConstruction int) Index {
 		},
 		m:              m,
 		efConstruction: efConstruction,
+	}
+}
+
+var _ Index = (*hnswSQIndex)(nil)
+
+type hnswSQIndex struct {
+	baseIndex
+
+	m              int
+	efConstruction int
+	sqType         string
+	refine         bool
+	refineType     string
+}
+
+func (idx *hnswSQIndex) Params() map[string]string {
+	result := map[string]string{
+		MetricTypeKey:      string(idx.metricType),
+		IndexTypeKey:       string(HNSWSQ),
+		hnswMKey:           strconv.Itoa(idx.m),
+		hsnwEfConstruction: strconv.Itoa(idx.efConstruction),
+		hnswSQTypeKey:      idx.sqType,
+	}
+	if idx.refine {
+		result[hnswRefineKey] = strconv.FormatBool(idx.refine)
+		result[hnswRefineTypeKey] = idx.refineType
+	}
+	return result
+}
+
+func (idx *hnswSQIndex) WithRefineType(refineType string) *hnswSQIndex {
+	idx.refine = true
+	idx.refineType = refineType
+	return idx
+}
+
+func NewHNSWSQIndex(metricType MetricType, m int, efConstruction int, sqType string) *hnswSQIndex {
+	return &hnswSQIndex{
+		baseIndex: baseIndex{
+			metricType: metricType,
+			indexType:  HNSWSQ,
+		},
+		m:              m,
+		efConstruction: efConstruction,
+		sqType:         sqType,
 	}
 }
 

--- a/client/index/hnsw_test.go
+++ b/client/index/hnsw_test.go
@@ -1,0 +1,62 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/client/v2/entity"
+)
+
+func TestHNSW(t *testing.T) {
+	idx := NewHNSWIndex(entity.COSINE, 30, 360)
+
+	assert.NotZero(t, idx)
+
+	result := idx.Params()
+	assert.NotEmpty(t, result)
+
+	assert.EqualValues(t, entity.COSINE, result[MetricTypeKey])
+	assert.EqualValues(t, HNSW, result[IndexTypeKey])
+	assert.Equal(t, "30", result[hnswMKey])
+	assert.Equal(t, "360", result[hsnwEfConstruction])
+}
+
+func TestHNSWSQ(t *testing.T) {
+	idx := NewHNSWSQIndex(entity.COSINE, 30, 360, "SQ6")
+
+	assert.NotZero(t, idx)
+
+	result := idx.Params()
+	assert.NotEmpty(t, result)
+
+	assert.EqualValues(t, entity.COSINE, result[MetricTypeKey])
+	assert.EqualValues(t, HNSWSQ, result[IndexTypeKey])
+	assert.Equal(t, "30", result[hnswMKey])
+	assert.Equal(t, "360", result[hsnwEfConstruction])
+	assert.Equal(t, "SQ6", result[hnswSQTypeKey])
+
+	idx = idx.WithRefineType("SQ8")
+
+	result = idx.Params()
+
+	assert.NotEmpty(t, result)
+	assert.Equal(t, "SQ8", result[hnswRefineTypeKey])
+	assert.Equal(t, "true", result[hnswRefineKey])
+}


### PR DESCRIPTION
**Problem**
The Go client exposes index option builders for types like HNSW, IVF_FLAT, SCANN, etc., but `HNSW_SQ` was missing (while the Python SDK supports it).

**Changes**
- Added `HNSWSQ` IndexType to `common.go`.
- Implemented `hnswSQIndex` and `NewHNSWSQIndex` with `.WithRefineType()` support.
- Added test coverage for both HNSW and HNSW_SQ index parameter generation.

issue: #44635
