### PR TITLE
fix: make import abort retry idempotent

### DIFF
--- a/internal/datacoord/ddl_callbacks_import.go
+++ b/internal/datacoord/ddl_callbacks_import.go
@@ -248,7 +248,8 @@ func (c *DDLCallbacks) commitImportV2AckCallback(ctx context.Context, result mes
 }
 
 // rollbackImportV2AckCallback handles the ack callback for RollbackImport WAL message.
-// It transitions the import job to Failed state.
+// It transitions the import job to Failed state and records that the failure
+// was user-initiated so AbortImport retries can be idempotent.
 // Concurrency safety is guaranteed by the broadcaster framework's resource key lock
 // (exclusive collection-level lock), so no CAS is needed here.
 // Segment cleanup is handled by the import inspector (processFailed), not here.
@@ -271,5 +272,8 @@ func (c *DDLCallbacks) rollbackImportV2AckCallback(ctx context.Context, result m
 		return nil
 	}
 
-	return c.importMeta.UpdateJob(ctx, jobID, UpdateJobState(internalpb.ImportJobState_Failed))
+	return c.importMeta.UpdateJob(ctx, jobID,
+		UpdateJobState(internalpb.ImportJobState_Failed),
+		UpdateJobReason(importJobReasonAbortedByUser),
+	)
 }

--- a/internal/datacoord/ddl_callbacks_import_test.go
+++ b/internal/datacoord/ddl_callbacks_import_test.go
@@ -969,6 +969,7 @@ func TestRollbackImportCallback_TransitionToFailed(t *testing.T) {
 	updatedJob := importMeta.GetJob(ctx, 2)
 	assert.NotNil(t, updatedJob)
 	assert.Equal(t, internalpb.ImportJobState_Failed, updatedJob.GetState())
+	assert.Equal(t, "aborted by user", updatedJob.GetReason())
 	// UpdateJobState(Failed) also releases disk quota and arms GC eligibility.
 	assert.EqualValues(t, 0, updatedJob.GetRequestedDiskSize(),
 		"Failed transition must release RequestedDiskSize")

--- a/internal/datacoord/import_job.go
+++ b/internal/datacoord/import_job.go
@@ -63,6 +63,8 @@ func WithoutJobStates(states ...internalpb.ImportJobState) ImportJobFilter {
 
 type UpdateJobAction func(job ImportJob)
 
+const importJobReasonAbortedByUser = "aborted by user"
+
 func UpdateJobState(state internalpb.ImportJobState) UpdateJobAction {
 	return func(job ImportJob) {
 		job.(*importJob).State = state

--- a/internal/datacoord/services.go
+++ b/internal/datacoord/services.go
@@ -3007,6 +3007,9 @@ func (s *Server) AbortImport(ctx context.Context, req *datapb.AbortImportRequest
 	return s.validateAndExecuteImportAction(ctx, req.GetJobId(),
 		func(job ImportJob) *commonpb.Status {
 			state := job.GetState()
+			if state == internalpb.ImportJobState_Failed && job.GetReason() == importJobReasonAbortedByUser {
+				return merr.Success()
+			}
 			if state == internalpb.ImportJobState_Failed ||
 				state == internalpb.ImportJobState_Committing ||
 				state == internalpb.ImportJobState_Completed {

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -5479,6 +5479,32 @@ func TestAbortImport_HappyPath(t *testing.T) {
 	assert.True(t, merr.Ok(resp))
 }
 
+func TestAbortImport_UserAbortedJobIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+
+	job := &importJob{
+		ImportJob: &datapb.ImportJob{
+			JobID:      2002,
+			State:      internalpb.ImportJobState_Failed,
+			Reason:     "aborted by user",
+			AutoCommit: false,
+		},
+	}
+
+	importMetaMock := NewMockImportMeta(t)
+	importMetaMock.EXPECT().GetJob(mock.Anything, int64(2002)).Return(job).Once()
+
+	server := &Server{
+		importMeta:    importMetaMock,
+		importJobLock: lock.NewKeyLock[int64](),
+	}
+	server.stateCode.Store(commonpb.StateCode_Healthy)
+
+	resp, err := server.AbortImport(ctx, &datapb.AbortImportRequest{JobId: 2002})
+	assert.NoError(t, err)
+	assert.True(t, merr.Ok(resp))
+}
+
 func TestHandleCommitVchannelRPC(t *testing.T) {
 	ctx := context.Background()
 

--- a/tests/restful_client_v2/testcases/test_import_2pc_operation.py
+++ b/tests/restful_client_v2/testcases/test_import_2pc_operation.py
@@ -8535,14 +8535,6 @@ class TestImport2PCRestOperation(TestBase):
             os.remove(file_path)
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.xfail(
-        reason=(
-            "milvus-io/milvus#50483: "
-            "AbortImport should be retry-safe/idempotent after the first abort moves a job to Failed; "
-            "current Milvus returns code=2100 for retry abort on Failed job"
-        ),
-        strict=True,
-    )
     def test_import_2pc_abort_is_idempotent_for_failed_job(self):
         """
         target: abort retry idempotency for terminal failed import job


### PR DESCRIPTION
issue: #50483

## Summary

- Record a stable reason when RollbackImport marks a 2PC import job as Failed.
- Treat repeated AbortImport calls on user-aborted jobs as successful no-ops.
- Keep AbortImport rejection for real failed, committing, or completed import jobs.

## Test Plan

- [x] go test -tags dynamic,test -gcflags=\"all=-N -l\" -count=1 ./internal/datacoord -run 'Test(CommitImport|AbortImport|RollbackImportCallback|CommitImportCallback)'
- [x] make static-check