### PR TITLE
fix: validate REST import auto_commit option

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -4385,12 +4385,20 @@ func TestCreateImportJobAutoCommitOptionValidation(t *testing.T) {
 		mp.EXPECT().ImportV2(mock.Anything, mock.MatchedBy(func(req *internalpb.ImportRequest) bool {
 			return kvPairsToMap(req.GetOptions())["auto_commit"] == "false"
 		})).Return(&internalpb.ImportResponse{Status: commonSuccessStatus, JobID: "2"}, nil).Once()
+		mp.EXPECT().ImportV2(mock.Anything, mock.MatchedBy(func(req *internalpb.ImportRequest) bool {
+			return kvPairsToMap(req.GetOptions())["auto_commit"] == "False"
+		})).Return(&internalpb.ImportResponse{Status: commonSuccessStatus, JobID: "3"}, nil).Once()
+		mp.EXPECT().ImportV2(mock.Anything, mock.MatchedBy(func(req *internalpb.ImportRequest) bool {
+			return kvPairsToMap(req.GetOptions())["priority"] == ""
+		})).Return(&internalpb.ImportResponse{Status: commonSuccessStatus, JobID: "4"}, nil).Once()
 		testEngine := initHTTPServerV2(mp, false)
 
 		for _, body := range []string{
 			`{"collectionName": "book", "files": [["a.parquet"]]}`,
 			`{"collectionName": "book", "files": [["a.parquet"]], "options": {"auto_commit": "true"}}`,
 			`{"collectionName": "book", "files": [["a.parquet"]], "options": {"auto_commit": "false"}}`,
+			`{"collectionName": "book", "files": [["a.parquet"]], "options": {"auto_commit": "False"}}`,
+			`{"collectionName": "book", "files": [["a.parquet"]], "options": {"priority": null}}`,
 		} {
 			req := httptest.NewRequest(http.MethodPost, versionalV2(ImportJobCategory, CreateAction), bytes.NewReader([]byte(body)))
 			w := httptest.NewRecorder()

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -4371,6 +4371,67 @@ func TestCommitImportJob(t *testing.T) {
 	}
 }
 
+func TestCreateImportJobAutoCommitOptionValidation(t *testing.T) {
+	paramtable.Init()
+
+	t.Run("accepts omitted true and false strings", func(t *testing.T) {
+		mp := mocks.NewMockProxy(t)
+		mp.EXPECT().ImportV2(mock.Anything, mock.MatchedBy(func(req *internalpb.ImportRequest) bool {
+			return len(req.GetOptions()) == 0
+		})).Return(&internalpb.ImportResponse{Status: commonSuccessStatus, JobID: "0"}, nil).Once()
+		mp.EXPECT().ImportV2(mock.Anything, mock.MatchedBy(func(req *internalpb.ImportRequest) bool {
+			return kvPairsToMap(req.GetOptions())["auto_commit"] == "true"
+		})).Return(&internalpb.ImportResponse{Status: commonSuccessStatus, JobID: "1"}, nil).Once()
+		mp.EXPECT().ImportV2(mock.Anything, mock.MatchedBy(func(req *internalpb.ImportRequest) bool {
+			return kvPairsToMap(req.GetOptions())["auto_commit"] == "false"
+		})).Return(&internalpb.ImportResponse{Status: commonSuccessStatus, JobID: "2"}, nil).Once()
+		testEngine := initHTTPServerV2(mp, false)
+
+		for _, body := range []string{
+			`{"collectionName": "book", "files": [["a.parquet"]]}`,
+			`{"collectionName": "book", "files": [["a.parquet"]], "options": {"auto_commit": "true"}}`,
+			`{"collectionName": "book", "files": [["a.parquet"]], "options": {"auto_commit": "false"}}`,
+		} {
+			req := httptest.NewRequest(http.MethodPost, versionalV2(ImportJobCategory, CreateAction), bytes.NewReader([]byte(body)))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			returnBody := &ReturnErrMsg{}
+			err := json.Unmarshal(w.Body.Bytes(), returnBody)
+			assert.Nil(t, err)
+			assert.Equal(t, merr.Code(nil), returnBody.Code)
+		}
+	})
+
+	for _, testcase := range []requestBodyTestCase{
+		{
+			path:        versionalV2(ImportJobCategory, CreateAction),
+			requestBody: []byte(`{"collectionName": "book", "files": [["a.parquet"]], "options": {"auto_commit": null}}`),
+			errCode:     merr.Code(merr.ErrIncorrectParameterFormat),
+			errMsg:      "options.auto_commit must be one of \"true\" or \"false\"",
+		},
+		{
+			path:        versionalV2(ImportJobCategory, CreateAction),
+			requestBody: []byte(`{"collectionName": "book", "files": [["a.parquet"]], "options": {"auto_commit": ""}}`),
+			errCode:     merr.Code(merr.ErrIncorrectParameterFormat),
+			errMsg:      "options.auto_commit must be one of \"true\" or \"false\"",
+		},
+		{
+			path:        versionalV2(ImportJobCategory, CreateAction),
+			requestBody: []byte(`{"collectionName": "book", "files": [["a.parquet"]], "options": {"auto_commit": "yes"}}`),
+			errCode:     merr.Code(merr.ErrIncorrectParameterFormat),
+			errMsg:      "options.auto_commit must be one of \"true\" or \"false\"",
+		},
+	} {
+		t.Run(string(testcase.requestBody), func(t *testing.T) {
+			mp := mocks.NewMockProxy(t)
+			testEngine := initHTTPServerV2(mp, false)
+			sendReqAndVerify(t, testEngine, testcase.path, http.MethodPost, testcase)
+		})
+	}
+}
+
 func TestAbortImportJob(t *testing.T) {
 	paramtable.Init()
 	mp := mocks.NewMockProxy(t)

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -286,9 +286,10 @@ func (req *ImportReq) UnmarshalJSON(data []byte) error {
 			if key == importutilv2.AutoCommitKey {
 				return merr.WrapErrParameterInvalidMsg("options.%s must be one of %q or %q", importutilv2.AutoCommitKey, autoCommitTrue, autoCommitFalse)
 			}
-			return merr.WrapErrParameterInvalidMsg("options.%s must be a string", key)
+			options[key] = ""
+			continue
 		}
-		if key == importutilv2.AutoCommitKey && *value != autoCommitTrue && *value != autoCommitFalse {
+		if key == importutilv2.AutoCommitKey && strings.ToLower(*value) != autoCommitTrue && strings.ToLower(*value) != autoCommitFalse {
 			return merr.WrapErrParameterInvalidMsg("options.%s must be one of %q or %q", importutilv2.AutoCommitKey, autoCommitTrue, autoCommitFalse)
 		}
 		options[key] = *value

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/json"
+	"github.com/milvus-io/milvus/internal/util/importutilv2"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -258,6 +260,46 @@ type ImportReq struct {
 	PartitionName  string            `json:"partitionName"`
 	Files          [][]string        `json:"files" binding:"required"`
 	Options        map[string]string `json:"options"`
+}
+
+const (
+	autoCommitTrue  = "true"
+	autoCommitFalse = "false"
+)
+
+func (req *ImportReq) UnmarshalJSON(data []byte) error {
+	type importReqAlias struct {
+		DbName         string             `json:"dbName"`
+		CollectionName string             `json:"collectionName" binding:"required"`
+		PartitionName  string             `json:"partitionName"`
+		Files          [][]string         `json:"files" binding:"required"`
+		Options        map[string]*string `json:"options"`
+	}
+	var decoded importReqAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	options := make(map[string]string, len(decoded.Options))
+	for key, value := range decoded.Options {
+		if value == nil {
+			if key == importutilv2.AutoCommitKey {
+				return merr.WrapErrParameterInvalidMsg("options.%s must be one of %q or %q", importutilv2.AutoCommitKey, autoCommitTrue, autoCommitFalse)
+			}
+			return merr.WrapErrParameterInvalidMsg("options.%s must be a string", key)
+		}
+		if key == importutilv2.AutoCommitKey && *value != autoCommitTrue && *value != autoCommitFalse {
+			return merr.WrapErrParameterInvalidMsg("options.%s must be one of %q or %q", importutilv2.AutoCommitKey, autoCommitTrue, autoCommitFalse)
+		}
+		options[key] = *value
+	}
+
+	req.DbName = decoded.DbName
+	req.CollectionName = decoded.CollectionName
+	req.PartitionName = decoded.PartitionName
+	req.Files = decoded.Files
+	req.Options = options
+	return nil
 }
 
 func (req *ImportReq) GetDbName() string {

--- a/tests/restful_client_v2/testcases/test_import_2pc_operation.py
+++ b/tests/restful_client_v2/testcases/test_import_2pc_operation.py
@@ -4047,31 +4047,23 @@ class TestImport2PCRestOperation(TestBase):
             os.remove(file_path)
 
     @pytest.mark.tags(CaseLabel.L0)
-    def test_import_2pc_auto_commit_non_false_value_defaults_to_true_and_completes(self):
+    def test_import_2pc_create_rejects_invalid_auto_commit_option(self):
         """
         target: auto_commit option contract
-        method: create import job with auto_commit set to a value other than false
-        expected: option is treated as true, job reaches Completed automatically, and rows become visible
+        method: create import job with auto_commit set to a value other than true or false
+        expected: request is rejected synchronously with a readable auto_commit validation error and no jobId
         """
         collection_name = gen_collection_name(prefix="import_2pc_auto_invalid")
         self._create_base_collection(collection_name)
 
-        rows = self._make_rows(3006, 4, phase=3006)
-        file_name = f"import_2pc_auto_invalid_{uuid4()}.parquet"
-        file_path = self._write_parquet_and_upload(rows, file_name)
-
-        job_id = self._create_import_job(collection_name, file_name, options={"auto_commit": "not-a-bool"})
-        rsp, ok = self.import_job_client.wait_import_job_state(job_id, "Completed", timeout=IMPORT_2PC_TIMEOUT)
-        assert ok, rsp
-        assert rsp["data"]["importedRows"] == len(rows), rsp
-        assert rsp["data"]["totalRows"] == len(rows), rsp
-
-        expected_ids = {row["id"] for row in rows}
-        seen_ids, visible = self._wait_imported_ids_visible(collection_name, expected_ids, timeout=120)
-        assert visible, {"expected": expected_ids, "seen": seen_ids}
-
-        if os.path.exists(file_path):
-            os.remove(file_path)
+        self._assert_import_create_rejected(
+            {
+                "collectionName": collection_name,
+                "files": [["import_2pc_auto_invalid.parquet"]],
+                "options": {"auto_commit": "not-a-bool"},
+            },
+            ("auto_commit", "true", "false"),
+        )
 
     @pytest.mark.tags(CaseLabel.L0)
     def test_import_2pc_auto_commit_uppercase_false_stops_at_uncommitted(self):

--- a/tests/restful_client_v2/testcases/test_import_2pc_operation.py
+++ b/tests/restful_client_v2/testcases/test_import_2pc_operation.py
@@ -2948,10 +2948,6 @@ class TestImport2PCRestOperation(TestBase):
         )
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.xfail(
-        reason="milvus-io/milvus#50460: Milvus accepts options.auto_commit=null and creates an import job; REST option values should be strings",
-        strict=True,
-    )
     def test_import_2pc_create_rejects_null_auto_commit_option(self):
         """
         target: import create auto_commit option null validation


### PR DESCRIPTION
## Summary

Reject REST import create requests when `options.auto_commit` is present but not `"true"` or `"false"`. The omitted option remains accepted and keeps the default auto-commit behavior.

Fixes #50460

## Changes

- Add strict REST JSON validation for `options.auto_commit`.
- Add handler coverage for omitted, valid, null, empty, and invalid values.

## Test Plan

- `GOTOOLCHAIN=auto make static-check`
- `GOTOOLCHAIN=auto go test ./util/merr` from `pkg/`
- `GOTOOLCHAIN=auto go test ./internal/json`

Note: local `static-check` used `milvus-cpp-share` to reuse the main checkout C++ artifacts and a temporary ignored `cmd/tools/migration/legacy/legacypb/legacy.pb.go` copied from the main checkout, because this generated file is ignored but required by the migration package during local lint loading.