### PR TITLE
fix: retry early import commit handling

### DIFF
--- a/internal/datacoord/ddl_callbacks_import.go
+++ b/internal/datacoord/ddl_callbacks_import.go
@@ -227,10 +227,24 @@ func (c *DDLCallbacks) commitImportV2AckCallback(ctx context.Context, result mes
 		mlog.Warn(ctx, "CommitImport: job not found, skipping", mlog.FieldJobID(jobID))
 		return nil
 	}
-	if job.GetState() != internalpb.ImportJobState_Uncommitted {
-		mlog.Info(ctx, "CommitImport: job not in Uncommitted state, no-op",
+	switch job.GetState() {
+	case internalpb.ImportJobState_Uncommitted:
+		// proceed
+	case internalpb.ImportJobState_Committing, internalpb.ImportJobState_Completed:
+		mlog.Info(ctx, "CommitImport: job already committing or completed, no-op",
 			mlog.FieldJobID(jobID), mlog.String("state", job.GetState().String()))
 		return nil
+	case internalpb.ImportJobState_Failed:
+		mlog.Info(ctx, "CommitImport: job already failed, no-op",
+			mlog.FieldJobID(jobID))
+		return nil
+	default:
+		// CommitImport may be replicated before the local import task reaches
+		// Uncommitted. Returning an error keeps the broadcast task alive so the
+		// callback can retry after the import task finishes writing local meta.
+		mlog.Info(ctx, "CommitImport: job is not ready, retry later",
+			mlog.FieldJobID(jobID), mlog.String("state", job.GetState().String()))
+		return merr.WrapErrImportSysFailedMsg("job %d is in state %s, waiting for Uncommitted", jobID, job.GetState())
 	}
 
 	if err := c.importMeta.UpdateJob(ctx, jobID,

--- a/internal/datacoord/ddl_callbacks_import_test.go
+++ b/internal/datacoord/ddl_callbacks_import_test.go
@@ -944,6 +944,61 @@ func TestCommitImportCallback_UncommittedToCommitting(t *testing.T) {
 	assert.Equal(t, internalpb.ImportJobState_Committing, updatedJob.GetState())
 }
 
+func TestCommitImportCallback_BeforeUncommitted_Retry(t *testing.T) {
+	ctx := context.Background()
+	importMeta, _ := newTestImportMeta(t)
+
+	job := &importJob{
+		ImportJob: &datapb.ImportJob{
+			JobID:      11,
+			State:      internalpb.ImportJobState_Importing,
+			AutoCommit: false,
+		},
+		tr: timerecord.NewTimeRecorder("test"),
+	}
+	err := importMeta.AddJob(ctx, job)
+	assert.NoError(t, err)
+
+	callbacks := &DDLCallbacks{Server: &Server{importMeta: importMeta}}
+	err = callbacks.commitImportV2AckCallback(ctx, buildCommitImportBroadcastResult(11))
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrImportSysFailed))
+
+	updatedJob := importMeta.GetJob(ctx, 11)
+	assert.NotNil(t, updatedJob)
+	assert.Equal(t, internalpb.ImportJobState_Importing, updatedJob.GetState())
+}
+
+func TestCommitImportCallback_RetryAfterUncommitted(t *testing.T) {
+	ctx := context.Background()
+	importMeta, _ := newTestImportMeta(t)
+
+	job := &importJob{
+		ImportJob: &datapb.ImportJob{
+			JobID:      12,
+			State:      internalpb.ImportJobState_Importing,
+			AutoCommit: false,
+		},
+		tr: timerecord.NewTimeRecorder("test"),
+	}
+	err := importMeta.AddJob(ctx, job)
+	assert.NoError(t, err)
+
+	callbacks := &DDLCallbacks{Server: &Server{importMeta: importMeta}}
+	err = callbacks.commitImportV2AckCallback(ctx, buildCommitImportBroadcastResult(12))
+	assert.Error(t, err)
+
+	err = importMeta.UpdateJob(ctx, 12, UpdateJobState(internalpb.ImportJobState_Uncommitted))
+	assert.NoError(t, err)
+
+	err = callbacks.commitImportV2AckCallback(ctx, buildCommitImportBroadcastResult(12))
+	assert.NoError(t, err)
+
+	updatedJob := importMeta.GetJob(ctx, 12)
+	assert.NotNil(t, updatedJob)
+	assert.Equal(t, internalpb.ImportJobState_Committing, updatedJob.GetState())
+}
+
 func TestRollbackImportCallback_TransitionToFailed(t *testing.T) {
 	ctx := context.Background()
 	importMeta, _ := newTestImportMeta(t)

--- a/internal/datacoord/import_meta.go
+++ b/internal/datacoord/import_meta.go
@@ -346,6 +346,18 @@ func (m *importMeta) HandleCommitVchannel(ctx context.Context, jobID int64, vcha
 	if job == nil {
 		return merr.WrapErrImportSysFailedMsg("job %d not found", jobID)
 	}
+	switch job.GetState() {
+	case internalpb.ImportJobState_Uncommitted, internalpb.ImportJobState_Committing:
+		// continue
+	case internalpb.ImportJobState_Completed, internalpb.ImportJobState_Failed:
+		return nil
+	default:
+		// Do not record committed_vchannels while the import task is still
+		// importing. The caller must retry after the job becomes Uncommitted;
+		// otherwise a later retry would treat this vchannel as committed even
+		// though the visibility callback has not run.
+		return merr.WrapErrImportSysFailedMsg("job %d is in state %s, waiting for Uncommitted", jobID, job.GetState())
+	}
 	// Idempotency: if vchannel already committed, skip.
 	for _, c := range job.GetCommittedVchannels() {
 		if c == vchannel {

--- a/internal/datacoord/import_meta_test.go
+++ b/internal/datacoord/import_meta_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/milvus-io/milvus/internal/metastore/mocks"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/metricsinfo"
 )
 
@@ -376,6 +377,82 @@ func TestHandleCommitVchannel(t *testing.T) {
 	err = im.HandleCommitVchannel(context.TODO(), int64(9999), "ch1", cb)
 	assert.Error(t, err)
 	assert.Equal(t, 1, callCount) // callback not called for missing job
+}
+
+func TestHandleCommitVchannel_BeforeUncommitted_RetryWithoutMutation(t *testing.T) {
+	catalog := mocks.NewDataCoordCatalog(t)
+	catalog.EXPECT().ListImportJobs(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListPreImportTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListImportTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	im, err := NewImportMeta(context.TODO(), catalog, nil, nil)
+	assert.NoError(t, err)
+
+	const jobID int64 = 102
+	err = im.AddJob(context.TODO(), &importJob{
+		ImportJob: &datapb.ImportJob{
+			JobID:     jobID,
+			State:     internalpb.ImportJobState_Importing,
+			Vchannels: []string{"ch1"},
+		},
+	})
+	assert.NoError(t, err)
+
+	callCount := 0
+	err = im.HandleCommitVchannel(context.TODO(), jobID, "ch1", func() error {
+		callCount++
+		return nil
+	})
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrImportSysFailed))
+	assert.Equal(t, 0, callCount)
+	updated := im.GetJob(context.TODO(), jobID)
+	assert.Equal(t, internalpb.ImportJobState_Importing, updated.GetState())
+	assert.NotContains(t, updated.GetCommittedVchannels(), "ch1")
+}
+
+func TestHandleCommitVchannel_RetryAfterUncommitted(t *testing.T) {
+	catalog := mocks.NewDataCoordCatalog(t)
+	catalog.EXPECT().ListImportJobs(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListPreImportTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListImportTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().SaveImportJob(mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	im, err := NewImportMeta(context.TODO(), catalog, nil, nil)
+	assert.NoError(t, err)
+
+	const jobID int64 = 103
+	err = im.AddJob(context.TODO(), &importJob{
+		ImportJob: &datapb.ImportJob{
+			JobID:     jobID,
+			State:     internalpb.ImportJobState_Importing,
+			Vchannels: []string{"ch1"},
+		},
+	})
+	assert.NoError(t, err)
+
+	callCount := 0
+	err = im.HandleCommitVchannel(context.TODO(), jobID, "ch1", func() error {
+		callCount++
+		return nil
+	})
+	assert.Error(t, err)
+	assert.Equal(t, 0, callCount)
+
+	err = im.UpdateJob(context.TODO(), jobID, UpdateJobState(internalpb.ImportJobState_Uncommitted))
+	assert.NoError(t, err)
+
+	err = im.HandleCommitVchannel(context.TODO(), jobID, "ch1", func() error {
+		callCount++
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, callCount)
+	updated := im.GetJob(context.TODO(), jobID)
+	assert.Equal(t, internalpb.ImportJobState_Committing, updated.GetState())
+	assert.Contains(t, updated.GetCommittedVchannels(), "ch1")
 }
 
 func TestHandleCommitVchannelTransitionsUncommittedToCommittingBeforeCallback(t *testing.T) {

--- a/internal/datacoord/services_test.go
+++ b/internal/datacoord/services_test.go
@@ -5568,6 +5568,29 @@ func TestHandleCommitVchannelRPC_StoresCommitTimestamp(t *testing.T) {
 	}
 }
 
+func TestHandleCommitVchannelRPC_MissingJobReturnsError(t *testing.T) {
+	ctx := context.Background()
+
+	catalog := mocks.NewDataCoordCatalog(t)
+	catalog.EXPECT().ListImportJobs(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListPreImportTasks(mock.Anything).Return(nil, nil)
+	catalog.EXPECT().ListImportTasks(mock.Anything).Return(nil, nil)
+
+	importMeta, err := NewImportMeta(ctx, catalog, nil, nil)
+	require.NoError(t, err)
+
+	server := &Server{
+		importMeta: importMeta,
+	}
+	server.stateCode.Store(commonpb.StateCode_Healthy)
+
+	resp, err := server.HandleCommitVchannel(ctx, &datapb.HandleCommitVchannelRequest{
+		JobId:    3001,
+		Vchannel: "vchan-0",
+	})
+	require.ErrorIs(t, merr.CheckRPCCall(resp, err), merr.ErrImportSysFailed)
+}
+
 // Named helper types for mockey interface-method patching. Using named types
 // instead of anonymous struct{ Iface } avoids a go1.26 `go vet` printf-pass
 // panic in x/tools refactor/satisfy on method expressions of *struct{...}.

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -127,8 +127,14 @@ func (impl *WALFlusherImpl) Execute(recoverSnapshot *recovery.RecoverySnapshot) 
 			}
 			impl.metrics.ObserveMetrics(msg.TimeTick())
 			if err := impl.dispatch(msg); err != nil {
-				// The error is always context canceled.
-				return nil
+				if errors.IsAny(err, context.Canceled, context.DeadlineExceeded) {
+					return nil
+				}
+				impl.logger.Error(impl.notifier.Context(), "wal flusher dispatch failed with unexpected error",
+					mlog.FieldVChannel(msg.VChannel()),
+					mlog.String("messageType", msg.MessageType().String()),
+					mlog.Err(err))
+				return err
 			}
 		}
 	}
@@ -331,7 +337,7 @@ func (impl *WALFlusherImpl) dispatchCommitImport(msg message.ImmutableMessage) e
 	// fence for this dispatch and must not be repeated on every retry.
 	// This retry blocks the whole pchannel flusher until DataCoord accepts the
 	// commit fence, preserving WAL replay order for later messages on the pchannel.
-	impl.logger.Warn(context.TODO(), "HandleCommitVchannel may block the pchannel flusher until DataCoord accepts the commit fence",
+	impl.logger.Info(impl.notifier.Context(), "HandleCommitVchannel waits until DataCoord accepts the commit fence",
 		mlog.FieldJobID(jobID),
 		mlog.FieldVChannel(vchannel),
 		mlog.Uint64("commitTs", msg.TimeTick()))

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/tsoutil"
 )
@@ -243,6 +244,12 @@ func (impl *WALFlusherImpl) dispatch(msg message.ImmutableMessage) (err error) {
 		impl.lastDispatchTimeTick = timetick
 	}()
 
+	if msg.MessageType() == message.MessageTypeCommitImport {
+		// CommitImport must not be observed until DataCoord accepts the commit
+		// fence; otherwise replay can skip the only retry signal for this vchannel.
+		return impl.dispatchCommitImport(msg)
+	}
+
 	// TODO: should be removed at 3.0, after merge the flusher logic into recovery storage.
 	// Only truncate collection needs to observe before the flusher handles the message.
 	// Other messages should keep the deferred order so lifecycle cleanup such as
@@ -282,45 +289,6 @@ func (impl *WALFlusherImpl) dispatch(msg message.ImmutableMessage) (err error) {
 		defer func() {
 			impl.flusherComponents.WhenDropCollection(msg.VChannel())
 		}()
-	case message.MessageTypeCommitImport:
-		commitMsg, err := message.AsImmutableCommitImportMessageV2(msg)
-		if err != nil {
-			impl.logger.DPanic(context.TODO(), "failed to parse CommitImportMessage", mlog.Err(err))
-			return nil
-		}
-		vchannel := msg.VChannel()
-		jobID := commitMsg.Header().GetJobId()
-
-		// Flush DML data before this commit fence. Panic on failure so WAL replays the message.
-		if err := resource.Resource().WriteBufferManager().
-			FlushChannel(context.Background(), vchannel, msg.TimeTick()); err != nil {
-			if errors.Is(err, merr.ErrChannelNotFound) {
-				impl.logger.Info(context.TODO(), "CommitImport targets stale vchannel, skip local flush and continue commit ack",
-					mlog.FieldVChannel(vchannel), mlog.FieldJobID(jobID), mlog.Err(err))
-			} else {
-				impl.logger.Panic(context.TODO(), "FlushChannel on CommitImport failed, panicking to retry from WAL",
-					mlog.FieldVChannel(vchannel), mlog.FieldJobID(jobID), mlog.Err(err))
-			}
-		}
-
-		// Notify DataCoord that this vchannel has committed.
-		mixCoord, err := resource.Resource().MixCoordClient().GetWithContext(impl.notifier.Context())
-		if err != nil {
-			return errors.Wrap(err, "failed to get MixCoordClient for HandleCommitVchannel")
-		}
-		resp, err := mixCoord.HandleCommitVchannel(impl.notifier.Context(), &datapb.HandleCommitVchannelRequest{
-			Base:            commonpbutil.NewMsgBase(commonpbutil.WithSourceID(paramtable.GetNodeID())),
-			JobId:           jobID,
-			Vchannel:        vchannel,
-			CommitTimestamp: msg.TimeTick(),
-		})
-		if err := merr.CheckRPCCall(resp, err); err != nil {
-			impl.logger.Panic(context.TODO(), "HandleCommitVchannel RPC failed, panicking to retry from WAL",
-				mlog.FieldJobID(jobID), mlog.FieldVChannel(vchannel), mlog.Err(err))
-		}
-		impl.logger.Info(context.TODO(), "CommitImportMessage handled: vchannel committed",
-			mlog.FieldVChannel(vchannel), mlog.FieldJobID(jobID))
-		return nil // don't forward to flusherComponents
 	case message.MessageTypeRollbackImport:
 		// No-op: DataCoord DDL ack callback handles all state changes.
 		impl.logger.Info(context.TODO(), "RollbackImportMessage consumed (no-op in flusher)",
@@ -328,4 +296,72 @@ func (impl *WALFlusherImpl) dispatch(msg message.ImmutableMessage) (err error) {
 		return nil // don't forward to flusherComponents
 	}
 	return impl.flusherComponents.HandleMessage(impl.notifier.Context(), msg)
+}
+
+func (impl *WALFlusherImpl) dispatchCommitImport(msg message.ImmutableMessage) error {
+	if funcutil.IsControlChannel(msg.VChannel()) && !msg.IsPChannelLevel() {
+		return impl.ObserveMessage(impl.notifier.Context(), msg)
+	}
+
+	commitMsg, err := message.AsImmutableCommitImportMessageV2(msg)
+	if err != nil {
+		impl.logger.DPanic(context.TODO(), "failed to parse CommitImportMessage", mlog.Err(err))
+		return nil
+	}
+	vchannel := msg.VChannel()
+	jobID := commitMsg.Header().GetJobId()
+
+	// Flush DML data before this commit fence. Panic on failure so WAL replays the message.
+	if err := resource.Resource().WriteBufferManager().
+		FlushChannel(context.Background(), vchannel, msg.TimeTick()); err != nil {
+		if errors.Is(err, merr.ErrChannelNotFound) {
+			impl.logger.Info(context.TODO(), "CommitImport targets stale vchannel, skip local flush and continue commit ack",
+				mlog.FieldVChannel(vchannel), mlog.FieldJobID(jobID), mlog.Err(err))
+		} else {
+			impl.logger.Panic(context.TODO(), "FlushChannel on CommitImport failed, panicking to retry from WAL",
+				mlog.FieldVChannel(vchannel), mlog.FieldJobID(jobID), mlog.Err(err))
+		}
+	}
+
+	mixCoord, err := resource.Resource().MixCoordClient().GetWithContext(impl.notifier.Context())
+	if err != nil {
+		return errors.Wrap(err, "failed to get MixCoordClient for HandleCommitVchannel")
+	}
+	// Retry only the DataCoord ack. The local FlushChannel above is a best-effort
+	// fence for this dispatch and must not be repeated on every retry.
+	// This retry blocks the whole pchannel flusher until DataCoord accepts the
+	// commit fence, preserving WAL replay order for later messages on the pchannel.
+	impl.logger.Warn(context.TODO(), "HandleCommitVchannel may block the pchannel flusher until DataCoord accepts the commit fence",
+		mlog.FieldJobID(jobID),
+		mlog.FieldVChannel(vchannel),
+		mlog.Uint64("commitTs", msg.TimeTick()))
+	if err := retry.Do(impl.notifier.Context(), func() error {
+		resp, err := mixCoord.HandleCommitVchannel(impl.notifier.Context(), &datapb.HandleCommitVchannelRequest{
+			Base:            commonpbutil.NewMsgBase(commonpbutil.WithSourceID(paramtable.GetNodeID())),
+			JobId:           jobID,
+			Vchannel:        vchannel,
+			CommitTimestamp: msg.TimeTick(),
+		})
+		if err := merr.CheckRPCCall(resp, err); err != nil {
+			impl.logger.Debug(context.TODO(), "HandleCommitVchannel failed, retry later",
+				mlog.FieldJobID(jobID),
+				mlog.FieldVChannel(vchannel),
+				mlog.Uint64("commitTs", msg.TimeTick()),
+				mlog.Err(err))
+			return err
+		}
+		return nil
+	}, retry.AttemptAlways()); err != nil {
+		return err
+	}
+
+	if err := impl.ObserveMessage(impl.notifier.Context(), msg); err != nil {
+		impl.logger.Warn(context.TODO(), "failed to observe CommitImport message",
+			mlog.FieldVChannel(vchannel), mlog.FieldJobID(jobID), mlog.Err(err))
+		return err
+	}
+
+	impl.logger.Info(context.TODO(), "CommitImportMessage handled: vchannel committed",
+		mlog.FieldVChannel(vchannel), mlog.FieldJobID(jobID))
+	return nil
 }

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/streamingutil"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/util"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -439,6 +440,84 @@ func TestDispatch_CommitImportMessage_ChannelNotFoundStillCommitsVchannelNoPanic
 		err := impl.dispatch(immutableMsg)
 		require.NoError(t, err)
 	})
+}
+
+func TestWALFlusher_ExecuteReturnsObserveMessageError(t *testing.T) {
+	streamingutil.SetStreamingServiceEnabled()
+	defer streamingutil.UnsetStreamingServiceEnabled()
+
+	const (
+		vchannel = "test-vchannel"
+		jobID    = int64(42)
+		timeTick = uint64(200)
+	)
+
+	mutableMsg := message.NewCommitImportMessageBuilderV2().
+		WithHeader(&message.CommitImportMessageHeader{
+			CollectionId: 100,
+			JobId:        jobID,
+		}).
+		WithBody(&message.CommitImportMessageBody{}).
+		WithVChannel(vchannel).
+		MustBuildMutable()
+	mutableMsg.WithTimeTick(timeTick)
+	mutableMsg.WithLastConfirmed(rmq.NewRmqID(199))
+	immutableMsg := mutableMsg.IntoImmutableMessage(rmq.NewRmqID(200))
+
+	mixcoord := mocks.NewMockMixCoordClient(t)
+	mixcoord.EXPECT().HandleCommitVchannel(mock.Anything, mock.MatchedBy(func(req *datapb.HandleCommitVchannelRequest) bool {
+		return req.GetJobId() == jobID && req.GetVchannel() == vchannel && req.GetCommitTimestamp() == timeTick
+	})).Return(merr.Status(nil), nil).Once()
+	fMixcoord := syncutil.NewFuture[internaltypes.MixCoordClient]()
+	fMixcoord.Set(mixcoord)
+
+	mockWBMgr := writebuffer.NewMockBufferManager(t)
+	mockWBMgr.EXPECT().FlushChannel(mock.Anything, vchannel, timeTick).Return(nil).Once()
+
+	rs := mock_recovery.NewMockRecoveryStorage(t)
+	rs.EXPECT().ObserveMessage(mock.Anything, immutableMsg).Return(errors.New("observe failed")).Once()
+
+	l := mock_wal.NewMockWAL(t)
+	pchannel := types.PChannelInfo{Name: "pchannel"}
+	l.EXPECT().WALName().Return(message.WALNameRocksmq).Maybe()
+	l.EXPECT().Channel().Return(pchannel).Maybe()
+	l.EXPECT().Read(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, option wal.ReadOption) (wal.Scanner, error) {
+			ch := make(chan message.ImmutableMessage, 1)
+			ch <- immutableMsg
+			scanner := mock_wal.NewMockScanner(t)
+			scanner.EXPECT().Chan().Return(ch)
+			scanner.EXPECT().Close().Return(nil)
+			return scanner, nil
+		}).Once()
+
+	resource.InitForTest(
+		t,
+		resource.OptMixCoordClient(fMixcoord),
+		resource.OptWriteBufferManager(mockWBMgr),
+		resource.OptChunkManager(mock_storage.NewMockChunkManager(t)),
+	)
+
+	rateLimitComponent := rate.NewWALRateLimitComponent(pchannel)
+	defer rateLimitComponent.Close()
+	flusher := &WALFlusherImpl{
+		notifier:             syncutil.NewAsyncTaskNotifier[struct{}](),
+		wal:                  syncutil.NewFuture[wal.WAL](),
+		logger:               mlog.With(mlog.FieldComponent("test-flusher")),
+		metrics:              newFlusherMetrics(pchannel),
+		RecoveryStorage:      rs,
+		rateLimitComponent:   rateLimitComponent,
+		emptyTimeTickCounter: metrics.WALFlusherEmptyTimeTickFilteredTotal.WithLabelValues(paramtable.GetStringNodeID(), pchannel.Name),
+	}
+	flusher.wal.Set(l)
+
+	err := flusher.Execute(&recovery.RecoverySnapshot{
+		VChannels: map[string]*streamingpb.VChannelMeta{},
+		Checkpoint: &recovery.WALCheckpoint{
+			TimeTick: 0,
+		},
+	})
+	require.ErrorContains(t, err, "observe failed")
 }
 
 func TestDispatch_CommitImportMessage_FlushUnexpectedErrorPanics(t *testing.T) {

--- a/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
+++ b/internal/streamingnode/server/flusher/flusherimpl/wal_flusher_test.go
@@ -329,6 +329,62 @@ func TestDispatch_CommitImportMessage(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestDispatch_CommitImportMessage_RetriesHandleCommitVchannelBeforeObserve(t *testing.T) {
+	streamingutil.SetStreamingServiceEnabled()
+	defer streamingutil.UnsetStreamingServiceEnabled()
+
+	const (
+		vchannel = "test-vchannel"
+		jobID    = int64(42)
+		timeTick = uint64(200)
+	)
+
+	mutableMsg := message.NewCommitImportMessageBuilderV2().
+		WithHeader(&message.CommitImportMessageHeader{
+			CollectionId: 100,
+			JobId:        jobID,
+		}).
+		WithBody(&message.CommitImportMessageBody{}).
+		WithVChannel(vchannel).
+		MustBuildMutable()
+	mutableMsg.WithTimeTick(timeTick)
+	mutableMsg.WithLastConfirmed(rmq.NewRmqID(199))
+	immutableMsg := mutableMsg.IntoImmutableMessage(rmq.NewRmqID(200))
+
+	mixcoord := mocks.NewMockMixCoordClient(t)
+	mixcoord.EXPECT().HandleCommitVchannel(mock.Anything, mock.MatchedBy(func(req *datapb.HandleCommitVchannelRequest) bool {
+		return req.GetJobId() == jobID && req.GetVchannel() == vchannel && req.GetCommitTimestamp() == timeTick
+	})).Return(merr.Status(merr.WrapErrImportSysFailedMsg("job not ready")), nil).Once()
+	mixcoord.EXPECT().HandleCommitVchannel(mock.Anything, mock.MatchedBy(func(req *datapb.HandleCommitVchannelRequest) bool {
+		return req.GetJobId() == jobID && req.GetVchannel() == vchannel && req.GetCommitTimestamp() == timeTick
+	})).Return(merr.Status(nil), nil).Once()
+	fMixcoord := syncutil.NewFuture[internaltypes.MixCoordClient]()
+	fMixcoord.Set(mixcoord)
+
+	mockWBMgr := writebuffer.NewMockBufferManager(t)
+	mockWBMgr.EXPECT().FlushChannel(mock.Anything, vchannel, timeTick).Return(nil).Once()
+
+	rs := mock_recovery.NewMockRecoveryStorage(t)
+	rs.EXPECT().ObserveMessage(mock.Anything, immutableMsg).Return(nil).Once()
+
+	resource.InitForTest(
+		t,
+		resource.OptMixCoordClient(fMixcoord),
+		resource.OptWriteBufferManager(mockWBMgr),
+	)
+
+	impl := &WALFlusherImpl{
+		notifier:        syncutil.NewAsyncTaskNotifier[struct{}](),
+		logger:          mlog.With(mlog.FieldComponent("test-flusher")),
+		RecoveryStorage: rs,
+	}
+
+	require.NotPanics(t, func() {
+		err := impl.dispatch(immutableMsg)
+		require.NoError(t, err)
+	})
+}
+
 func TestDispatch_CommitImportMessage_ChannelNotFoundStillCommitsVchannelNoPanic(t *testing.T) {
 	streamingutil.SetStreamingServiceEnabled()
 	defer streamingutil.UnsetStreamingServiceEnabled()
@@ -414,7 +470,6 @@ func TestDispatch_CommitImportMessage_FlushUnexpectedErrorPanics(t *testing.T) {
 		Once()
 
 	rs := mock_recovery.NewMockRecoveryStorage(t)
-	rs.EXPECT().ObserveMessage(mock.Anything, mock.Anything).Return(nil)
 
 	resource.InitForTest(t, resource.OptWriteBufferManager(mockWBMgr))
 


### PR DESCRIPTION
issue: #50499

## Summary

- Return a retryable import system error when CommitImport arrives before an import job reaches Uncommitted.
- Make HandleCommitVchannel wait for Uncommitted before mutating committed vchannels or invoking the visibility callback.
- Retry HandleCommitVchannel in the WAL flusher with the default retry backoff, and observe the CommitImport WAL message only after the commit ack succeeds.

## Test Plan

- [x] `PKG_CONFIG_PATH=/Users/yihao.dai/workspace/milvus/internal/core/output/lib/pkgconfig CGO_LDFLAGS='-Wl,-rpath,/Users/yihao.dai/workspace/milvus/internal/core/output/lib' GOTOOLCHAIN=auto go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord -run 'TestCommitImportCallback|TestHandleCommitVchannel'`
- [x] `PKG_CONFIG_PATH=/Users/yihao.dai/workspace/milvus/internal/core/output/lib/pkgconfig CGO_LDFLAGS='-Wl,-rpath,/Users/yihao.dai/workspace/milvus/internal/core/output/lib' GOTOOLCHAIN=auto go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/streamingnode/server/flusher/flusherimpl`
- [x] `PKG_CONFIG_PATH=/Users/yihao.dai/workspace/milvus/.worktrees/fix-import-early-commit-retry/internal/core/output/lib/pkgconfig CGO_LDFLAGS='-Wl,-rpath,/Users/yihao.dai/workspace/milvus/.worktrees/fix-import-early-commit-retry/internal/core/output/lib' GOTOOLCHAIN=auto make static-check`
