### PR TITLE
fix: reject non-finite parquet FloatVector import

### DIFF
--- a/internal/util/importutilv2/parquet/field_reader.go
+++ b/internal/util/importutilv2/parquet/field_reader.go
@@ -219,7 +219,7 @@ func (c *FieldReader) Next(count int64) (any, any, error) {
 			return nil, nil, nil
 		}
 		vectors := lo.Flatten(arrayData.([][]float32))
-		return vectors, nil, nil
+		return vectors, nil, typeutil.VerifyFloats32(vectors)
 	case schemapb.DataType_SparseFloatVector:
 		if c.field.GetNullable() {
 			return ReadNullableSparseFloatVectorData(c, count)

--- a/internal/util/importutilv2/parquet/fixed_size_list_reader_test.go
+++ b/internal/util/importutilv2/parquet/fixed_size_list_reader_test.go
@@ -19,6 +19,7 @@ package parquet
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"testing"
@@ -98,6 +99,30 @@ func TestImportFixedSizeList_FloatVector(t *testing.T) {
 	require.Equal(t, 2, insertData.Data[fixedSizeListDataFieldID].RowNum())
 	require.EqualValues(t, []float32{1, 2, 3, 4}, insertData.Data[fixedSizeListDataFieldID].GetRow(0))
 	require.EqualValues(t, []float32{5, 6, 7, 8}, insertData.Data[fixedSizeListDataFieldID].GetRow(1))
+}
+
+func TestImportFixedSizeList_FloatVectorRejectsNonFiniteValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value float32
+	}{
+		{name: "nan", value: float32(math.NaN())},
+		{name: "positive infinity", value: float32(math.Inf(1))},
+		{name: "negative infinity", value: float32(math.Inf(-1))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := fixedSizeListFloatVectorSchema(4, false)
+			rows := []fixedSizeFloat32Row{
+				{valid: true, values: float32Ptrs(1, 2, tt.value, 4)},
+			}
+
+			_, err := tryReadFixedSizeListParquet(t, schema, fixedSizeFloat32ListArray(t, 4, rows))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "not a number or infinity")
+		})
+	}
 }
 
 func TestImportFixedSizeList_NullableFloatVector(t *testing.T) {

--- a/tests/restful_client_v2/testcases/test_import_2pc_operation.py
+++ b/tests/restful_client_v2/testcases/test_import_2pc_operation.py
@@ -7903,10 +7903,6 @@ class TestImport2PCRestOperation(TestBase):
                 os.remove(file_path)
 
     @pytest.mark.tags(CaseLabel.L0)
-    @pytest.mark.xfail(
-        reason="milvus-io/milvus#50459: import currently accepts NaN/Inf FloatVector values",
-        strict=True,
-    )
     def test_import_2pc_vector_nan_inf_fails_with_reason_and_no_visible_rows(self):
         """
         target: FloatVector finite-value validation for manual import


### PR DESCRIPTION
## Summary

- Reject NaN and Infinity values in non-nullable Parquet FloatVector import.
- Add reader-level regression coverage for NaN, +Inf, and -Inf.
- Enable existing REST 2PC regression coverage for invalid FloatVector imports.

Fixes #50459

## Test Plan

- [x] go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/util/importutilv2/parquet
- [x] conda run -n milvus2 python -m py_compile tests/restful_client_v2/testcases/test_import_2pc_operation.py
- [x] git diff --check
- [x] make static-check
