### PR TITLE
fix(client): clamp out-of-range begin/end in parseScalarData

### DIFF
--- a/client/column/columns.go
+++ b/client/column/columns.go
@@ -94,8 +94,17 @@ func parseScalarData[T any, COL Column, NCOL Column](
 	creator func(string, []T) COL,
 	nullableCreator func(string, []T, []bool, ...ColumnOption[T]) (NCOL, error),
 ) (Column, error) {
-	if end < 0 {
+	// Clamp start/end into range, mirroring parseVectorArrayData, so an
+	// out-of-range slice (e.g. paging past the end of a scalar field) returns a
+	// clamped column instead of panicking.
+	if end < 0 || end > len(data) {
 		end = len(data)
+	}
+	if start < 0 {
+		start = 0
+	}
+	if start > end {
+		start = end
 	}
 	data = data[start:end]
 	if len(validData) > 0 {

--- a/client/column/columns_test.go
+++ b/client/column/columns_test.go
@@ -173,3 +173,29 @@ func TestGetIntData(t *testing.T) {
 		})
 	}
 }
+
+func TestParseScalarDataBeginEndClamping(t *testing.T) {
+	// FieldDataColumn must clamp out-of-range begin/end for scalar fields the
+	// same way parseVectorArrayData does, rather than panicking on the slice.
+	fd := &schemapb.FieldData{
+		Type:      schemapb.DataType_Int64,
+		FieldName: "id",
+		Field: &schemapb.FieldData_Scalars{
+			Scalars: &schemapb.ScalarField{
+				Data: &schemapb.ScalarField_LongData{
+					LongData: &schemapb.LongArray{Data: []int64{1, 2, 3}},
+				},
+			},
+		},
+	}
+
+	// negative begin clamps to 0; end past the data length clamps to len.
+	col, err := FieldDataColumn(fd, -5, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, col.Len())
+
+	// begin > end collapses to an empty column.
+	col2, err := FieldDataColumn(fd, 10, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, col2.Len())
+}


### PR DESCRIPTION
## Issue

`FieldDataColumn(fd, begin, end)` panics with `slice bounds out of range` for scalar fields when `begin`/`end` fall outside the field data.

`parseScalarData` only handled `end < 0` and then sliced `data[start:end]` directly, so a request such as `FieldDataColumn(fd, -5, 10)` (or paging past the end of a field with fewer rows) panics. The vector-array path, `parseVectorArrayData`, already clamps `begin`/`end` into range and is covered by `TestParseVectorArrayDataBeginEndClamping` — the scalar path should behave the same.

## Fix

Clamp `end` to `len(data)`, `start` to `>= 0`, and `start` to `<= end` before slicing, mirroring `parseVectorArrayData`. Paging past the end of a scalar field now returns a clamped (possibly empty) column instead of panicking.

## Test

Added `TestParseScalarDataBeginEndClamping`, mirroring the existing vector-array clamp test: it feeds an Int64 field with 3 rows and asserts `FieldDataColumn(fd, -5, 10)` returns a length-3 column and `FieldDataColumn(fd, 10, 1)` returns an empty one.

Verified locally:

```
$ go test ./column/ -run TestParseScalarDataBeginEndClamping -count=1
ok  	github.com/milvus-io/milvus/client/v2/column
```

Before the fix the new test panics with `slice bounds out of range [:10] with capacity 3`. `go vet ./column/`, `gofmt`, and the full `go test ./column/` all pass.
