### PR TITLE
enhance: add CubeFS as supported cloud storage provider

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -148,6 +148,7 @@ minio:
   # You can use "aliyun" for other cloud provider uses virtual host style bucket
   # You can use "gcpnative" for the Google Cloud Platform provider. Uses service account credentials
   # for authentication.
+  # CubeFS is S3-compatible and works with cloudProvider: aws and useVirtualHost: false (no IAM support).
   # When useIAM enabled, only "aws", "gcp", "aliyun" is supported for now
   cloudProvider: aws
   # The JSON content contains the gcs service account credentials.


### PR DESCRIPTION
## What
Add CubeFS as a supported `cloudProvider` option in Milvus object storage configuration.

## Changes
- Add `CloudProviderCubeFS = "cubefs"` constant to `pkg/objectstorage/util.go`
- Add CubeFS case in `NewMinioClient` switch: forces path-style bucket lookup (`BucketLookupPath`) and static V4 credentials (IAM not supported by CubeFS ObjectNode)
- Document `cubefs` as a valid `cloudProvider` value in `configs/milvus.yaml`
- Add integration test `TestNewMinioClientCubeFS` (skipped unless `CLOUD_PROVIDER=cubefs` env is set, consistent with all other provider tests)

## Why path-style?
CubeFS ObjectNode requires `S3ForcePathStyle` — it does not support virtual-host style bucket addressing (`bucket.host/key`).

issue: #26189