### PR TITLE
fix: [2.6] backfill absent nullable vector fields when loading growing segment (#50508)

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1776,6 +1776,7 @@ SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     auto manifest_path = load_info_.manifest_path();
     if (manifest_path != "") {
         LoadColumnsGroups(manifest_path);
+        FillAbsentFields();
         return;
     }
 
@@ -1812,20 +1813,40 @@ SegmentGrowingImpl::Load(milvus::tracer::TraceContext& trace_ctx,
 
 void
 SegmentGrowingImpl::FinishLoad() {
+    FillAbsentFields();
+
+    // Update resource tracking
+    UpdateResourceTracking();
+}
+
+void
+SegmentGrowingImpl::FillAbsentFields() {
+    if (insert_record_.row_count() == 0) {
+        return;
+    }
     for (const auto& [field_id, field_meta] : schema_->get_fields()) {
         if (field_id.get() < START_USER_FIELDID) {
             continue;
         }
+        if (IsVectorDataType(field_meta.get_data_type())) {
+            // A vector field may be legally absent from the loaded data only
+            // when it is nullable (added by AddField after the binlogs were
+            // written). Backfill its validity bitmap so that queries observe
+            // all-null values instead of an uninitialized column.
+            if (field_meta.is_nullable() &&
+                insert_record_.is_data_exist(field_id) &&
+                insert_record_.is_valid_data_exist(field_id) &&
+                insert_record_.get_valid_data(field_id)->get_data().empty()) {
+                fill_empty_field(field_meta);
+            }
+            continue;
+        }
         // append_data is called according to schema before
         // so we must check data empty here
-        if (!IsVectorDataType(field_meta.get_data_type()) &&
-            insert_record_.get_data_base(field_id)->empty()) {
+        if (insert_record_.get_data_base(field_id)->empty()) {
             fill_empty_field(field_meta);
         }
     }
-
-    // Update resource tracking
-    UpdateResourceTracking();
 }
 
 void
@@ -1996,8 +2017,10 @@ SegmentGrowingImpl::fill_empty_field(const FieldMeta& field_meta) {
     auto total_row_num = insert_record_.row_count();
 
     auto data = bulk_subscript_not_exist_field(field_meta, total_row_num);
-    insert_record_.get_valid_data(field_id)->set_data_raw(
-        total_row_num, data.get(), field_meta);
+    if (insert_record_.is_valid_data_exist(field_id)) {
+        insert_record_.get_valid_data(field_id)->set_data_raw(
+            total_row_num, data.get(), field_meta);
+    }
     insert_record_.get_data_base(field_id)->set_data_raw(
         0, total_row_num, data.get(), field_meta);
 

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -122,6 +122,13 @@ class SegmentGrowingImpl : public SegmentGrowing {
     Load(milvus::tracer::TraceContext& trace_ctx,
          milvus::OpContext* op_ctx = nullptr) override;
 
+    // Backfill fields that exist in the schema but had no data to load,
+    // e.g. fields added by AddField after the loaded binlogs were written.
+    // Nullable vector fields get their validity bitmap filled so queries
+    // observe all-null values instead of an uninitialized column.
+    void
+    FillAbsentFields();
+
  private:
     // Build geometry cache for inserted data
     void

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -514,9 +514,11 @@ SegmentInternalInterface::bulk_subscript_not_exist_field(
 
     auto result = CreateEmptyScalarDataArray(count, field_meta);
     if (field_meta.default_value().has_value()) {
-        auto res = result->mutable_valid_data()->mutable_data();
-        for (int64_t i = 0; i < count; ++i) {
-            res[i] = true;
+        if (field_meta.is_nullable()) {
+            auto res = result->mutable_valid_data()->mutable_data();
+            for (int64_t i = 0; i < count; ++i) {
+                res[i] = true;
+            }
         }
         switch (field_meta.get_data_type()) {
             case DataType::BOOL: {
@@ -626,11 +628,12 @@ SegmentInternalInterface::bulk_subscript_not_exist_field(
             }
         }
         return result;
-    };
-    for (int64_t i = 0; i < count; ++i) {
-        auto res = result->mutable_valid_data()->mutable_data();
-        res[i] = false;
     }
+    // Without a default value the column can only read as all-null;
+    // CreateEmptyScalarDataArray already sized valid_data to all-false.
+    AssertInfo(field_meta.is_nullable(),
+               "Non-nullable scalar field without default value should not "
+               "reach here");
     return result;
 }
 

--- a/internal/core/unittest/CMakeLists.txt
+++ b/internal/core/unittest/CMakeLists.txt
@@ -56,6 +56,7 @@ set(MILVUS_TEST_FILES
         test_storage_v2_index_raw_data.cpp
         test_group_by_json.cpp
         test_growing_concurrent_reopen.cpp
+        test_schema_reopen.cpp
         )
 
 if ( NOT (INDEX_ENGINE STREQUAL "cardinal") )

--- a/internal/core/unittest/test_schema_reopen.cpp
+++ b/internal/core/unittest/test_schema_reopen.cpp
@@ -11,12 +11,14 @@
 
 #include <gtest/gtest.h>
 #include <memory>
+#include <numeric>
 #include <thread>
 #include <vector>
 
 #include "common/Schema.h"
 #include "segcore/SegmentGrowingImpl.h"
 #include "test_utils/DataGen.h"
+#include "test_utils/storage_test_utils.h"
 
 using namespace milvus;
 using namespace milvus::segcore;
@@ -54,8 +56,12 @@ class SchemaReopenTest : public testing::Test {
         schema_v2_->AddDebugField(
             "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
         auto pk_fid_v2 = schema_v2_->AddDebugField("pk", DataType::INT64);
+        // Added fields must be nullable (enforced by the proxy on
+        // AddCollectionField); an absent non-nullable scalar without a
+        // default value is rejected by bulk_subscript_not_exist_field.
         schema_v2_->AddDebugField("new_field",
-                                  DataType::VARCHAR);  // New field in V2
+                                  DataType::VARCHAR,
+                                  /*nullable=*/true);  // New field in V2
         schema_v2_->set_primary_field_id(pk_fid_v2);
         schema_v2_->set_schema_version(2);
     }
@@ -205,4 +211,85 @@ TEST_F(SchemaReopenTest, NewFieldAfterReopenShouldBeSkipped) {
         segment->Insert(
             0, N, data.row_ids_.data(), data.timestamps_.data(), data.raw_);
     });
+}
+
+/**
+ * Test for Issue #50366: StreamingNode crashes in segcore retrieve when a
+ * growing segment is loaded from binlogs that predate an AddField of a
+ * nullable vector field.
+ *
+ * Scenario:
+ * - A growing segment is recovered via LoadGrowing after a node restart.
+ * - Its binlogs were written before `AddField(new_vec)` so they carry no data
+ *   for the new column, while the segment is constructed with the new schema.
+ * - Before the fix, the post-load backfill skipped all vector fields, so the
+ *   column's validity bitmap stayed empty; FilterVectorValidOffsets then
+ *   returned valid_count == count with an EMPTY valid_offsets vector and
+ *   bulk_subscript dereferenced the empty vector's data() (nullptr) as the
+ *   offsets array -> SIGSEGV.
+ *
+ * After the fix, FillAbsentFields (called from Load) backfills the validity
+ * bitmap of absent nullable vector fields, so the column reads as all-null.
+ */
+TEST_F(SchemaReopenTest, LoadWithAbsentNullableVectorFieldShouldReadAllNull) {
+    // Schema V2 shares the first two fields with V1 (same field ids) and has
+    // an extra nullable FLOAT_VECTOR field added by AddField. Added fields must
+    // be nullable (enforced by the proxy on AddCollectionField).
+    auto schema_v2 = std::make_shared<Schema>();
+    schema_v2->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 128, knowhere::metric::L2);
+    auto pk_fid = schema_v2->AddDebugField("pk", DataType::INT64);
+    auto added_fid = schema_v2->AddDebugField("new_vec",
+                                              DataType::VECTOR_FLOAT,
+                                              128,
+                                              knowhere::metric::L2,
+                                              /*nullable=*/true);
+    schema_v2->set_primary_field_id(pk_fid);
+    schema_v2->set_schema_version(2);
+
+    auto segment = CreateGrowingSegment(schema_v2, milvus::empty_index_meta);
+    auto seg_impl = dynamic_cast<SegmentGrowingImpl*>(segment.get());
+    ASSERT_NE(seg_impl, nullptr);
+
+    // The binlogs only contain the V1 columns: no data for new_vec.
+    int N = 100;
+    auto dataset = DataGen(schema_v1_, N, /*seed=*/42);
+    LoadGeneratedDataIntoSegment(dataset, seg_impl);
+    ASSERT_EQ(segment->get_row_count(), N);
+
+    std::vector<int64_t> offsets(N);
+    std::iota(offsets.begin(), offsets.end(), 0);
+    milvus::OpContext op_ctx;
+
+    // Load() runs FillAbsentFields to backfill the validity bitmap of the
+    // absent nullable vector column; reading it must not crash and every
+    // row must read as null.
+    seg_impl->FillAbsentFields();
+    auto col = seg_impl->bulk_subscript(&op_ctx, added_fid, offsets.data(), N);
+    ASSERT_EQ(col->valid_data_size(), N);
+    for (int i = 0; i < N; ++i) {
+        ASSERT_FALSE(col->valid_data(i)) << "row " << i << " should be null";
+    }
+    ASSERT_EQ(col->vectors().float_vector().data_size(), 0);
+
+    // WAL replay after recovery delivers inserts written with the old
+    // schema; Insert patches the missing column with nulls. The bitmap must
+    // stay aligned across the loaded prefix and the replayed tail.
+    auto data_v1 = DataGen(schema_v1_, N, /*seed=*/100);
+    segment->PreInsert(N);
+    segment->Insert(N,
+                    N,
+                    data_v1.row_ids_.data(),
+                    data_v1.timestamps_.data(),
+                    data_v1.raw_);
+    ASSERT_EQ(segment->get_row_count(), 2 * N);
+
+    std::vector<int64_t> all_offsets(2 * N);
+    std::iota(all_offsets.begin(), all_offsets.end(), 0);
+    col =
+        seg_impl->bulk_subscript(&op_ctx, added_fid, all_offsets.data(), 2 * N);
+    ASSERT_EQ(col->valid_data_size(), 2 * N);
+    for (int i = 0; i < 2 * N; ++i) {
+        ASSERT_FALSE(col->valid_data(i)) << "row " << i << " should be null";
+    }
 }


### PR DESCRIPTION
Backport of #50508 to the 2.6 branch.

### Root cause

Both crashes in #50366 hit the same nullptr dereference in `SegmentGrowingImpl::bulk_subscript_impl<FloatVector>` (SIGSEGV, exit code 139).

When a growing segment is recovered from binlogs (`delegator.LoadGrowing` after a StreamingNode restart or shard transfer), binlogs written before an `AddCollectionField` carry no data for the added column. The schema-change WAL message flushes and fences segments, but the flush is asynchronous: a restart in the seal→flushed window reloads the segment as growing, from old binlogs, under the new schema.

The post-load backfill loop excluded **all** vector fields, so an added nullable vector field ended up with rows > 0 and an **empty validity bitmap**. For that state `FilterVectorValidOffsets` returns `valid_count == count` with an empty `valid_offsets` vector, and `bulk_subscript` uses the empty vector's `data()` — nullptr — as the offsets array with a non-zero count, crashing in `bulk_subscript_impl` on `seg_offsets[i]`.

### Changes

- Extract the post-load backfill into `FillAbsentFields()` and backfill the validity bitmap of nullable vector fields that had no data to load, giving the column all-null semantics (mirroring `Reopen`/`fill_empty_field` and the sealed-segment behavior). Non-nullable vector fields keep the previous behavior.
- Absence is detected via an **empty validity bitmap** rather than empty physical data: a legally loaded all-null column also has no physical data in mapping storage and must not be filled twice.
- Run the backfill on the storage-v2 manifest load path (`LoadColumnsGroups`) as well.
- New regression test `SchemaReopenTest.LoadWithAbsentNullableVectorFieldShouldReadAllNull`.

### Backport-specific adaptations (differ from the master PR)

- On 2.6 the growing backfill stays in `FinishLoad()` (the override invoked from `segment_c.cpp`); it now delegates to `FillAbsentFields()` and still calls `UpdateResourceTracking()`. Master inlined this into `Load()`.
- Dropped the `schema_->is_function_output()` skip from the master version: that `Schema` accessor does not exist on 2.6, and BM25 function-output fields are non-nullable vectors that the vector branch already leaves untouched, so behavior is unchanged.
- Kept 2.6's three existing `SchemaReopenTest` cases (issue #46656 coverage) and **added** the new test, rather than replacing the file as the master PR did.

issue: #50366
pr: #50508

🤖 Generated with [Claude Code](https://claude.com/claude-code)