### PR TITLE
enhance: [2.6] batch the per-row chunk lock in growing-segment string bulk_subscript (#50717)

### DIFF
--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -1425,6 +1425,32 @@ SegmentGrowingImpl::bulk_subscript_ptr_impl(
     google::protobuf::RepeatedPtrField<std::string>* dst) const {
     auto vec = dynamic_cast<const ConcurrentVector<S>*>(vec_raw);
     auto& src = *vec;
+    // Fast path for in-memory (non-mmap) string columns: operator[] / view_element
+    // takes a shared_lock on the chunk vector for EVERY row (get_chunk_data), so a
+    // top-K * VarChar bulk fetch on a growing segment acquires the lock N times.
+    // Group the offsets by chunk and take the lock once per chunk via
+    // get_chunk_data, then copy outside the lock. Safe because: the mutex only
+    // guards vec_ resize (chunk objects are moved, their heap buffers stay put);
+    // chunks are fixed-size (no intra-chunk realloc); inserts only append to new
+    // offsets, never mutate an already-committed row a search result references.
+    if constexpr (std::is_same_v<S, std::string>) {
+        if (!src.is_mmap()) {
+            const int64_t size_per_chunk = src.get_size_per_chunk();
+            std::unordered_map<int64_t, std::vector<int64_t>> rows_by_chunk;
+            for (int64_t i = 0; i < count; ++i) {
+                rows_by_chunk[seg_offsets[i] / size_per_chunk].push_back(i);
+            }
+            for (auto& [chunk_id, rows] : rows_by_chunk) {
+                auto* base = static_cast<const std::string*>(
+                    src.get_chunk_data(chunk_id));
+                for (int64_t i : rows) {
+                    const auto& s = base[seg_offsets[i] % size_per_chunk];
+                    dst->at(i).assign(s.data(), s.size());
+                }
+            }
+            return;
+        }
+    }
     for (int64_t i = 0; i < count; ++i) {
         auto offset = seg_offsets[i];
         if (IsVariableTypeSupportInChunk<S> && src.is_mmap()) {

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -12,6 +12,8 @@
 #include <gtest/gtest.h>
 
 #include <thread>
+#include <atomic>
+#include <random>
 #include <vector>
 
 #include "common/Types.h"
@@ -1316,4 +1318,73 @@ TEST(Growing, MultipleFieldsResourceEstimation) {
                            N * sizeof(float) + N * sizeof(double) +
                            N * sizeof(Timestamp);
     EXPECT_GE(resource.memory_bytes, min_expected);
+}
+
+// Regression for the chunk-batched string bulk_subscript fast path
+// (SegmentGrowingImpl::bulk_subscript_ptr_impl<std::string>): bulk_subscript on a
+// VarChar field of a growing segment must return correct values, and must stay
+// race-free while another thread keeps inserting into the same segment (the
+// production pattern is a single insert stream with concurrent reads).
+TEST(Growing, StringBulkSubscriptUnderConcurrentInsert) {
+    auto schema = std::make_shared<Schema>();
+    auto str_fid = schema->AddDebugField("str", DataType::VARCHAR);
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk);
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+
+    const int64_t N = 20000;  // spans many growing chunks
+    auto dataset = DataGen(schema, N);
+    auto expect = dataset.get_col<std::string>(str_fid);
+    segment->PreInsert(N);
+    segment->Insert(0,
+                    N,
+                    dataset.row_ids_.data(),
+                    dataset.timestamps_.data(),
+                    dataset.raw_);
+
+    // Scattered offsets, as a top-K result (sorted by score) would be.
+    std::mt19937_64 rng(123);
+    std::uniform_int_distribution<int64_t> dist(0, N - 1);
+    std::vector<int64_t> offsets(400);
+    for (auto& o : offsets) {
+        o = dist(rng);
+    }
+
+    auto verify = [&]() {
+        auto result = segment->bulk_subscript(
+            nullptr, str_fid, offsets.data(), offsets.size());
+        const auto& got = result->scalars().string_data().data();
+        ASSERT_EQ(got.size(), static_cast<int>(offsets.size()));
+        for (size_t i = 0; i < offsets.size(); ++i) {
+            ASSERT_EQ(got[i], expect[offsets[i]]);
+        }
+    };
+
+    verify();  // single-threaded correctness through the real function
+
+    // One writer keeps appending new rows while we repeatedly bulk_subscript the
+    // committed rows (which the writer never mutates).
+    const int64_t batch = 1024;
+    auto more = DataGen(schema, batch);
+    std::atomic<bool> stop{false};
+    std::thread writer([&]() {
+        std::vector<int64_t> rids(batch);
+        std::vector<Timestamp> tss(batch);
+        int64_t seq = N;
+        while (!stop.load(std::memory_order_relaxed)) {
+            auto off = segment->PreInsert(batch);
+            for (int64_t i = 0; i < batch; ++i) {
+                rids[i] = seq + i;
+                tss[i] = seq + i;
+            }
+            segment->Insert(off, batch, rids.data(), tss.data(), more.raw_);
+            seq += batch;
+        }
+    });
+
+    for (int round = 0; round < 300; ++round) {
+        verify();
+    }
+    stop.store(true);
+    writer.join();
 }


### PR DESCRIPTION
issue: #50716
pr: https://github.com/milvus-io/milvus/pull/50717

## Summary

[2.6] version of #50717.

`SegmentGrowingImpl::bulk_subscript_ptr_impl<std::string>` reads each row via
`operator[]` (on 2.6), which takes a `std::shared_lock` on the chunk vector for
**every** row through `ChunkVector::get_chunk_data`. A top-K * VarChar bulk fetch
on a growing segment therefore acquires/releases the lock N times, contending
with the insert path's `unique_lock` when the segment is written and queried at
the same time.

This adds a fast path for in-memory (non-mmap) string columns: group the
requested offsets by chunk, take the lock **once per chunk** via `get_chunk_data`,
and copy the strings **outside** the lock. Lock acquisitions drop from N to
`#distinct chunks`. mmap columns and JSON keep the existing per-row path.

**Safety**: the chunk-vector mutex only guards `vec_` resize (chunk objects are
moved, their heap buffers stay put); chunks are fixed-size (no intra-chunk
realloc); inserts only append to new offsets and never mutate an already-committed
row that a search result references — so reading committed offsets out of the lock
is race-free.

## Test

`Growing.StringBulkSubscriptUnderConcurrentInsert` (in `SegmentGrowingTest.cpp`)
builds a real growing segment with a VarChar field, inserts known values, and
calls the production `segment->bulk_subscript(...)` on scattered offsets, asserting
the returned strings match the inserted values — while a separate thread keeps
inserting new rows into the same segment (the production single-writer /
concurrent-reader pattern). Existing `GrowingSegmentRegexQueryTest` (string / JSON
on a growing segment) also passes.

## Benchmark

Local microbenchmark (Release `-O3`, growing string column, 200K rows / ~195
chunks, top-K=1000 scattered offsets, under a continuous concurrent writer):

| | per-row baseline | grouped (this change) | speedup |
|---|---|---|---|
| 2.6 (`operator[]` per row) | ~14.0–15.6 s | ~3.7 s | **3.75–4.18x** |

(2.6 shows a larger gain than master because its baseline also constructs a
temporary `std::string` per row.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
