### PR TITLE
fix: correct parameter name in GetMaxCapacity error message

### DIFF
--- a/pkg/util/parameterutil/get_max_len.go
+++ b/pkg/util/parameterutil/get_max_len.go
@@ -45,7 +45,7 @@ func GetMaxCapacity(field *schemapb.FieldSchema) (int64, error) {
 	maxCapacity, err := strconv.Atoi(maxCapacityStr)
 	if err != nil {
 		msg := fmt.Sprintf("invalid max capacity: %s", maxCapacityStr)
-		return 0, merr.WrapErrParameterInvalid("value of max length should be of int", maxCapacityStr, msg)
+		return 0, merr.WrapErrParameterInvalid("value of max capacity should be of int", maxCapacityStr, msg)
 	}
 	return int64(maxCapacity), nil
 }

--- a/pkg/util/parameterutil/get_max_len_test.go
+++ b/pkg/util/parameterutil/get_max_len_test.go
@@ -88,6 +88,8 @@ func TestGetMaxCapacity(t *testing.T) {
 		}
 		_, err := GetMaxCapacity(f)
 		assert.Error(t, err)
+		// the message must name the parameter that was actually invalid
+		assert.Contains(t, err.Error(), "value of max capacity should be of int")
 	})
 
 	t.Run("normal case", func(t *testing.T) {


### PR DESCRIPTION
issue: #50719

`GetMaxCapacity` reused `GetMaxLength`'s error string, so an array field with a non-integer `max_capacity` reported `value of max length should be of int` — the wrong parameter. This corrects it to `max capacity` and extends the existing `max capacity not int` unit test to assert the message.

Verified locally: the added assertion fails before the change and passes after; `go test ./util/parameterutil/`, `gofmt`, and `go vet` are clean.

/kind bug
