### PR TITLE
fix: align REST access log with gRPC and log multi-collection requests

### DIFF
--- a/internal/proxy/accesslog/info/grpc_info.go
+++ b/internal/proxy/accesslog/info/grpc_info.go
@@ -247,10 +247,26 @@ func (i *GrpcAccessInfo) DbName() string {
 
 func (i *GrpcAccessInfo) CollectionName() string {
 	name, ok := requestutil.GetCollectionNameFromRequest(i.req)
-	if !ok {
-		return Unknown
+	if ok {
+		return name.(string)
 	}
-	return name.(string)
+
+	// requests such as Flush/ShowCollections carry a list of collection names
+	names, ok := requestutil.GetCollectionNamesFromRequest(i.req)
+	if ok {
+		return fmt.Sprint(names.([]string))
+	}
+
+	// requests that reference collections via non-standard fields
+	switch req := i.req.(type) {
+	case *milvuspb.RenameCollectionRequest:
+		// rename references both the source and target collection
+		return fmt.Sprintf("%s->%s", req.GetOldName(), req.GetNewName())
+	case *milvuspb.BatchDescribeCollectionRequest:
+		return fmt.Sprint(req.GetCollectionName())
+	}
+
+	return Unknown
 }
 
 func (i *GrpcAccessInfo) PartitionName() string {

--- a/internal/proxy/accesslog/info/grpc_info_test.go
+++ b/internal/proxy/accesslog/info/grpc_info_test.go
@@ -145,6 +145,43 @@ func (s *GrpcAccessInfoSuite) TestDbName() {
 	s.Equal("test", result[0])
 }
 
+func (s *GrpcAccessInfoSuite) TestCollectionName() {
+	s.info.req = nil
+	result := Get(s.info, "$collection_name")
+	s.Equal(Unknown, result[0])
+
+	// singular collection name
+	s.info.req = &milvuspb.QueryRequest{
+		CollectionName: "test_collection",
+	}
+	result = Get(s.info, "$collection_name")
+	s.Equal("test_collection", result[0])
+
+	// requests carrying a list of collection names (e.g. Flush) should not be Unknown
+	s.info.req = &milvuspb.FlushRequest{
+		CollectionNames: []string{"coll_a", "coll_b"},
+	}
+	result = Get(s.info, "$collection_name")
+	s.Equal(fmt.Sprint([]string{"coll_a", "coll_b"}), result[0])
+	s.NotEqual(Unknown, result[0])
+
+	// rename logs both the source and target collection
+	s.info.req = &milvuspb.RenameCollectionRequest{
+		OldName: "old_coll",
+		NewName: "new_coll",
+	}
+	result = Get(s.info, "$collection_name")
+	s.Equal("old_coll->new_coll", result[0])
+
+	// batch describe carries a list under the singular-named CollectionName field
+	s.info.req = &milvuspb.BatchDescribeCollectionRequest{
+		CollectionName: []string{"coll_a", "coll_b"},
+	}
+	result = Get(s.info, "$collection_name")
+	s.Equal(fmt.Sprint([]string{"coll_a", "coll_b"}), result[0])
+	s.NotEqual(Unknown, result[0])
+}
+
 func (s *GrpcAccessInfoSuite) TestSdkInfo() {
 	ctx := context.Background()
 	clientInfo := &commonpb.ClientInfo{

--- a/internal/proxy/accesslog/info/restful_info.go
+++ b/internal/proxy/accesslog/info/restful_info.go
@@ -19,6 +19,7 @@ package info
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/requestutil"
 )
@@ -194,10 +196,26 @@ func (i *RestfulInfo) DbName() string {
 
 func (i *RestfulInfo) CollectionName() string {
 	name, ok := requestutil.GetCollectionNameFromRequest(i.req)
-	if !ok {
-		return Unknown
+	if ok {
+		return name.(string)
 	}
-	return name.(string)
+
+	// requests such as Flush/ShowCollections carry a list of collection names
+	names, ok := requestutil.GetCollectionNamesFromRequest(i.req)
+	if ok {
+		return fmt.Sprint(names.([]string))
+	}
+
+	// requests that reference collections via non-standard fields
+	switch req := i.req.(type) {
+	case *milvuspb.RenameCollectionRequest:
+		// rename references both the source and target collection
+		return fmt.Sprintf("%s->%s", req.GetOldName(), req.GetNewName())
+	case *milvuspb.BatchDescribeCollectionRequest:
+		return fmt.Sprint(req.GetCollectionName())
+	}
+
+	return Unknown
 }
 
 func (i *RestfulInfo) PartitionName() string {
@@ -291,8 +309,21 @@ func (i *RestfulInfo) QueryParams() string {
 	return Unknown
 }
 
+// ClientRequestTime returns client-side request time string.
+// REST clients pass it via the same key as gRPC metadata, but as an HTTP header.
 func (i *RestfulInfo) ClientRequestTime() string {
-	return Unknown
+	if i.ctx == nil || i.ctx.Request == nil {
+		return Unknown
+	}
+	timestamp := i.ctx.GetHeader(common.ClientRequestMsecKey)
+	if timestamp == "" {
+		return Unknown
+	}
+	unixmsec, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return Unknown
+	}
+	return time.UnixMilli(unixmsec).Format(timeFormat)
 }
 
 func (i *RestfulInfo) SetActualConsistencyLevel(acl commonpb.ConsistencyLevel) {

--- a/internal/proxy/accesslog/info/restful_info_test.go
+++ b/internal/proxy/accesslog/info/restful_info_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
@@ -149,6 +150,46 @@ func (s *RestfulAccessInfoSuite) TestDbName() {
 	s.info.req = req
 	result = Get(s.info, "$database_name")
 	s.Equal("test", result[0])
+}
+
+func (s *RestfulAccessInfoSuite) TestClientRequestTime() {
+	// no request / header -> Unknown, consistent with the gRPC access log
+	result := Get(s.info, "$client_request_time")
+	s.Equal(Unknown, result[0])
+
+	req, err := http.NewRequest(http.MethodPost, "/", nil)
+	s.NoError(err)
+	s.ctx.Request = req
+
+	// missing header -> Unknown
+	result = Get(s.info, "$client_request_time")
+	s.Equal(Unknown, result[0])
+
+	// header present -> formatted client time
+	ts := time.Now().UnixMilli()
+	req.Header.Set(common.ClientRequestMsecKey, fmt.Sprint(ts))
+	result = Get(s.info, "$client_request_time")
+	s.Equal(time.UnixMilli(ts).Format(timeFormat), result[0])
+}
+
+func (s *RestfulAccessInfoSuite) TestCollectionName() {
+	result := Get(s.info, "$collection_name")
+	s.Equal(Unknown, result[0])
+
+	// singular collection name
+	s.info.req = &milvuspb.QueryRequest{CollectionName: "test_collection"}
+	result = Get(s.info, "$collection_name")
+	s.Equal("test_collection", result[0])
+
+	// requests carrying a list of collection names (e.g. Flush)
+	s.info.req = &milvuspb.FlushRequest{CollectionNames: []string{"coll_a", "coll_b"}}
+	result = Get(s.info, "$collection_name")
+	s.Equal(fmt.Sprint([]string{"coll_a", "coll_b"}), result[0])
+
+	// REST v2 rename builds a RenameCollectionRequest; log both source and target
+	s.info.req = &milvuspb.RenameCollectionRequest{OldName: "old_coll", NewName: "new_coll"}
+	result = Get(s.info, "$collection_name")
+	s.Equal("old_coll->new_coll", result[0])
 }
 
 func (s *RestfulAccessInfoSuite) TestSdkInfo() {

--- a/pkg/util/requestutil/getter.go
+++ b/pkg/util/requestutil/getter.go
@@ -44,6 +44,18 @@ func GetCollectionNameFromRequest(req any) (any, bool) {
 	return getter.GetCollectionName(), true
 }
 
+type CollectionNamesGetter interface {
+	GetCollectionNames() []string
+}
+
+func GetCollectionNamesFromRequest(req any) (any, bool) {
+	getter, ok := req.(CollectionNamesGetter)
+	if !ok {
+		return nil, false
+	}
+	return getter.GetCollectionNames(), true
+}
+
 type DBNameGetter interface {
 	GetDbName() string
 }


### PR DESCRIPTION
## Description

The proxy access log recorded the collection field as `Unknown` for any request that does not expose a singular `GetCollectionName() string`. This made it impossible to attribute traffic to a specific collection from access logs — most notably when diagnosing per-collection flush rate-limit rejections (`milvus_proxy_rate_limit_req_count{msg_type="DDLFlush", status="fail"}`, default limit `quotaAndLimits.flushRate.collection.max=0.1`).

Affected proxy-facing requests:

| Request | Collection field | Before | After |
|---------|------------------|--------|-------|
| `Flush` | `collection_names []string` | `Unknown` | `[coll_a coll_b]` |
| `ShowCollections` | `collection_names []string` | `Unknown` | `[coll_a coll_b]` |
| `RenameCollection` | `OldName` / `NewName` | `Unknown` | `old_coll` |
| `BatchDescribeCollection` | `collection_name []string` | `Unknown` | `[coll_a coll_b]` |

## Root cause

`GrpcAccessInfo.CollectionName()` / `RestfulInfo.CollectionName()` only used `requestutil.GetCollectionNameFromRequest`, which relies on the singular `CollectionNameGetter` (`GetCollectionName() string`). `FlushRequest`/`ShowCollectionsRequest` only have the repeated `GetCollectionNames() []string`, so the assertion failed and the field fell back to `Unknown`. `RenameCollectionRequest` and `BatchDescribeCollectionRequest` carry the collection under non-standard fields.

## Fix

- Add `CollectionNamesGetter` + `GetCollectionNamesFromRequest` to `requestutil` (mirrors the existing `PartitionNamesGetter`).
- In `CollectionName()`, fall back to the plural getter, then to the request-specific fields, mirroring the existing `PartitionName()` plural handling.
- Unit test covering nil / singular / `Flush` / `RenameCollection` / `BatchDescribe`.

Internal coordinator RPCs (`DescribeSegment`, `ShowSegments`) only carry `CollectionID` and do not flow through the proxy access log, so they are out of scope.

Fixes #50741

🤖 Generated with [Claude Code](https://claude.com/claude-code)
