### PR TITLE
enhance: [2.6] split GIS geometry filter into coarse/refine and fuse same-column predicates (#50675)

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -491,6 +491,7 @@ queryNode:
       buildParallelRate: 0.5 # the ratio of building interim index parallel matched with cpu num
     multipleChunkedEnable: true # Deprecated. Enable multiple chunked search
     enableGeometryCache: false # Enable geometry cache for geometry data
+    enableGISSplitFusion: false # Enable GIS filter coarse/refine split + same-column fusion optimization
     tieredStorage:
       warmup:
         # options: sync, disable.

--- a/docs/design_docs/gis_filter_coarse_refine_split_fusion.md
+++ b/docs/design_docs/gis_filter_coarse_refine_split_fusion.md
@@ -1,0 +1,154 @@
+# GIS 地理过滤优化：粗筛/精排拆分 + 同列融合
+
+## 1. 背景与问题
+
+带地理过滤的向量检索（filtered search，过滤含 `ST_INTERSECTS` / `ST_WITHIN` 等几何谓词）存在严重的 CPU 浪费。C++ segcore 的 CPU profile 显示：
+
+- 实际几何相交计算（`GEOSPreparedIntersects` 等）占 CPU **< 1%**。
+- GEOS 几何对象的构造/解析/析构（`Geometry::Geometry` / `~Polygon` / `~LinearRing` / `GeometryFactory`）占 CPU **约 20%**，比向量检索还多。
+
+根因：`PhyGISFunctionFilterExpr` 对**每个几何谓词、每一行**都从 WKB 现场构造一个 GEOS 对象、用完销毁。一条查询若有 K 个同列几何谓词，同一行的几何对象就被构造 K 次。`enableGeometryCache` 默认关闭（2.6.5），开启则内存膨胀 5~10 倍（对 bbox 数据尤其不划算），并非通用解。
+
+### 当前实现的两个问题（已在代码确认）
+
+- **问题 1 — 顺序错**：GIS 整体（coarse 粗筛 + refine 精排）落入 `indexed_expr` 桶（`Expr.cpp` `ReorderConjunctExpr`），在 conjunction 重排里排得很靠前，导致昂贵的精排跟着便宜的粗筛一起被排到标量谓词之前。
+- **问题 2 — 不剪枝**：精排不消费 `bitmap_input`（`GISFunctionFilterExpr.cpp::EvalForIndexSegment`）：`collect_hits` 取整个 coarse 位图，对全部 coarse 候选逐行构造几何并做段级缓存，从不与上游标量谓词的结果求交。
+
+两者叠加 = 无论 `work_model` / `experience` 等标量条件怎么筛，精排都对粗筛命中的所有行逐行构造几何对象。这是核心浪费。
+
+## 2. 目标（三者合一）
+
+- **拆分**：每个几何列拆出 `Coarse`(R-Tree) 和 `Refine`(精确) 两个独立 tree 节点。
+- **修 bitmap_input**：`Refine` 消费上游 `bitmap_input`，只精算"全部更便宜谓词都通过"的幸存行。
+- **融合**：同一列的多个几何谓词，`Refine` 阶段对每个幸存行只读一次 WKB / 只构造一次 GEOS 对象，套用全部谓词（K→1）。
+
+## 3. 代数基础（为什么跨 OR 也正确）
+
+设几何块 `B = g1 ⊕ ... ⊕ gk`（⊕ 为该块的 AND 或 OR）。`Ri` 为精确谓词，`Ci` 为其 R-Tree 粗筛，满足 `Ci ⊇ Ri`。令 `B_coarse = ⊕ Ci`，`B_refine = ⊕ Ri`，则 `B_coarse ⊇ B_refine`，故：
+
+```
+scalars ∧ B  =  scalars ∧ B_refine  ≡  scalars ∧ B_coarse ∧ B_refine
+```
+
+于是可把 `B_coarse` 作为额外的 AND 子节点提到最前（便宜、选择性强、剪枝别人），把 `B_refine` 提到最后（昂贵、被所有人剪枝）。AND 块与 OR 块都成立——这是拆分跨 OR 仍正确的依据。
+
+## 4. 架构：两个新算子 + 一份共享状态
+
+```cpp
+// 每个 (segment, 几何块) 一份，Coarse 与 Refine 共享
+struct GISGroupState {
+  FieldId field_id;
+  bool    is_and;                 // 块内组合：AND / OR
+  struct Pred {
+    GISOp            op;
+    Geometry         query_geom;  // 查询常量，构造一次复用
+    PreparedGeometry prepared;    // 预编译一次复用（修掉每 batch 重建）
+    bool             has_index;
+    TargetBitmap     coarse;      // 该谓词 R-Tree 结果，算一次
+  };
+  std::vector<Pred> preds;
+  std::shared_ptr<TargetBitmap> coarse_candidates; // B_coarse，Coarse 节点填，缓存一次
+  std::atomic<bool> coarse_done{false};
+};
+
+class PhyGISCoarseConjunctExpr : public SegmentExpr { std::shared_ptr<GISGroupState> st_; }; // -> indexed 桶（早）
+class PhyGISRefineConjunctExpr : public SegmentExpr { std::shared_ptr<GISGroupState> st_; }; // -> heavy 桶（最后）
+```
+
+## 5. Optimizer 规则（镜像 LIKE 的 `SetLikeIndices` + 运行期建节点）
+
+1. 遍历 conjunction 子节点，识别"同一 field 的几何块"：直接的 GIS 叶子（`PhyGISFunctionFilterExpr`），或仅由该 field 的 GIS 谓词构成的 AND/OR 子树（用 ⊕ 记下组合方式）。
+2. 对每个块构造 `GISGroupState`（收集 `preds`、`is_and`，一次性建好 `query_geom` + `prepared`）。
+3. 生成 `Coarse` 与 `Refine` 两节点（共享同一 state），从原 children 移除原始 GIS 节点。
+4. 分桶：`Coarse` → `indexed_expr`（早）；`Refine` → `heavy_conjunct_expr`（最后）。复用现有 reorder 顺序，无需新机制。
+5. 退化：块内含非几何兄弟或复杂嵌套无法纯几何化 → 该块不拆，保留原 `PhyGISFunctionFilterExpr`（正确性优先）。配合查询改写归一成"标量 AND (同列 ST OR 组)"命中率最高。
+
+## 6. Coarse 节点 Eval（段级一次 + 切片）
+
+```cpp
+void PhyGISCoarseConjunctExpr::Eval(EvalCtx& ctx, VectorPtr& result) {
+  auto bs = GetNextBatchSize(); if (bs == 0) { result = nullptr; return; }
+  if (!st_->coarse_done) {                          // 段级，只一次
+    TargetBitmap cand(active_count_, st_->is_and);  // AND -> 全1 / OR -> 全0
+    for (auto& p : st_->preds) {
+      if (p.has_index) RunRTreeQuery(p);            // 复用现有 idx_ptr->Query(ds)
+      else             p.coarse = TargetBitmap(active_count_, true); // 无索引 -> 全集
+      st_->is_and ? (cand &= p.coarse) : (cand |= p.coarse);
+    }
+    st_->coarse_candidates = std::make_shared<TargetBitmap>(std::move(cand));
+    st_->coarse_done = true;
+  }
+  TargetBitmap out; out.append(*st_->coarse_candidates, current_pos_, bs);
+  current_pos_ += bs;
+  result = std::make_shared<ColumnVector>(std::move(out), TargetBitmap(bs, true));
+}
+```
+
+## 7. Refine 节点 Eval（吃 bitmap_input + 逐行一次构造 + 融合）
+
+```cpp
+void PhyGISRefineConjunctExpr::Eval(EvalCtx& ctx, VectorPtr& result) {
+  auto bs = GetNextBatchSize(); if (bs == 0) { result = nullptr; return; }
+  TargetBitmap res(bs, false);
+
+  const auto& pre = ctx.get_bitmap_input();        // == scalars ∧ B_coarse （修复点）
+  TargetBitmap survivors(bs, true);
+  if (!pre.empty()) survivors &= pre;
+  survivors &= slice(*st_->coarse_candidates, current_pos_, bs); // 双保险
+
+  if (!survivors.none()) {
+    auto hits = collect_hits(survivors);
+    auto* gcache = SimpleGeometryCacheManager::Instance()
+                     .GetCache(segment_->get_segment_id(), st_->field_id);
+    auto wkb = gcache ? nullptr
+                      : segment_->bulk_subscript(st_->field_id, hits); // 一次批量取
+    for (size i : hits) {
+      const Geometry& left = gcache
+          ? *gcache->GetByOffsetUnsafe(i)           // 缓存开：零构造
+          : Geometry(ctx_, wkb[i]...);              // 缓存关：构造【一次】
+      bool bit = st_->is_and;                       // 一个 left 套全部谓词（融合）
+      for (auto& p : st_->preds) {
+        bool r = EvalPrepared(p, left);             // within/contains 语义对调，复用现有
+        bit = st_->is_and ? (bit && r) : (bit || r);
+        if (st_->is_and ^ bit) break;               // 短路
+      }
+      res[local(i)] = bit;
+    }
+  }
+  current_pos_ += bs;
+  result = std::make_shared<ColumnVector>(std::move(res), TargetBitmap(bs, true));
+}
+```
+
+三处收益同时拿到：吃 `bitmap_input` → 只在"标量全过 ∧ coarse"的幸存行上精算；逐行一次构造 → K 谓词共享 `left`（K→1）；`prepared` 复用 → 查询几何只构造一次。
+
+## 8. 在 conjunction 里的最终形态
+
+```
+input_order_: [ numeric... , indexed(含 B_coarse) , string... , 标量heavy... , heavy(含 B_refine 最后) , compare... ]
+```
+
+`bitmap_input` 链：`B_coarse` 早早贡献 → 中间标量继续收窄 → `B_refine` 最后拿到最小集合精算。`CanSkipFollowingExprs` 仍生效（coarse / 标量把结果打成全 0 时，refine 直接跳过）。
+
+## 9. 正确性 / 边界
+
+- 不变式 `Ci ⊇ Ri`（bbox 相交 ⊇ 精确相交；within 同理保守），现有 refine 已依赖，拆分不破坏。
+- OR 块：用第 3 节恒等式提升 `B_coarse` / `B_refine` 为外层 AND 子节点，合法。
+- `Refine` 对非幸存行返回 false，conjunction 再 AND，无误。
+- within/contains 语义对调：复用现有 `evaluate_geometry_prepared`。
+- null 几何：`GetByOffsetUnsafe` 返回 nullptr → 按 op 取 false。
+- 无 R-Tree 索引：coarse = 全集（不剪枝），refine 仍吃 `bitmap_input` + 融合，收益不失。
+- growing / mmap：沿用现有 `std::string` vs `std::string_view` 分支。
+- 缓存正交：本方案对 bbox 数据缓存关着也很快，不依赖 `enableGeometryCache`。
+
+## 10. 落地分期
+
+- **P1**：拆分 + bitmap_input 修复（coarse 早 / refine 晚吃 bitmap_input）。单谓词即可见大收益，风险低。
+- **P2**：Refine 同列融合（K→1）+ prepared 复用。
+- **P3**：更通用的嵌套块识别（超出"标量 AND 同列 OR/AND 组"）。
+
+## 11. 测试与灰度
+
+- Feature flag：`queryNode.segcore.enableGISSplitFusion`，默认关，灰度。
+- 等价测试 `GISCoarseRefineExprTest`：与"逐谓词原始 Eval"做全矩阵等价校验（AND/OR、intersects/within/contains、null、index/no-index、growing/sealed/mmap、空 bitmap_input）。
+- Bench：复现多谓词地理查询，验证 `Geometry::Geometry` 占比 20% → 约 0、refine 候选行数下降、p99 从秒级回落。

--- a/docs/design_docs/gis_filter_coarse_refine_split_fusion.md
+++ b/docs/design_docs/gis_filter_coarse_refine_split_fusion.md
@@ -1,78 +1,78 @@
-# GIS 地理过滤优化：粗筛/精排拆分 + 同列融合
+# GIS Geometry Filter Optimization: Coarse/Refine Split + Same-Column Fusion
 
-## 1. 背景与问题
+## 1. Background and Problem
 
-带地理过滤的向量检索（filtered search，过滤含 `ST_INTERSECTS` / `ST_WITHIN` 等几何谓词）存在严重的 CPU 浪费。C++ segcore 的 CPU profile 显示：
+Vector search with geometry filters (filtered search whose expression contains `ST_INTERSECTS` / `ST_WITHIN` / other geometric predicates) wastes a large amount of CPU. A CPU profile of the C++ segcore shows:
 
-- 实际几何相交计算（`GEOSPreparedIntersects` 等）占 CPU **< 1%**。
-- GEOS 几何对象的构造/解析/析构（`Geometry::Geometry` / `~Polygon` / `~LinearRing` / `GeometryFactory`）占 CPU **约 20%**，比向量检索还多。
+- The actual geometric intersection computation (`GEOSPreparedIntersects` etc.) takes **< 1%** of CPU.
+- Constructing/parsing/destructing GEOS geometry objects (`Geometry::Geometry` / `~Polygon` / `~LinearRing` / `GeometryFactory`) takes **~20%** of CPU — more than the vector search itself.
 
-根因：`PhyGISFunctionFilterExpr` 对**每个几何谓词、每一行**都从 WKB 现场构造一个 GEOS 对象、用完销毁。一条查询若有 K 个同列几何谓词，同一行的几何对象就被构造 K 次。`enableGeometryCache` 默认关闭（2.6.5），开启则内存膨胀 5~10 倍（对 bbox 数据尤其不划算），并非通用解。
+Root cause: `PhyGISFunctionFilterExpr` constructs a GEOS object from WKB on the fly — **per geometry predicate, per row** — and destroys it right after use. If a query has K same-column geometry predicates, the same row's geometry is constructed K times. `enableGeometryCache` is off by default (2.6.5); enabling it inflates memory 5–10x (a particularly bad trade for bbox-style data), so it is not a general solution.
 
-### 当前实现的两个问题（已在代码确认）
+### Two concrete issues in the current implementation (confirmed in code)
 
-- **问题 1 — 顺序错**：GIS 整体（coarse 粗筛 + refine 精排）落入 `indexed_expr` 桶（`Expr.cpp` `ReorderConjunctExpr`），在 conjunction 重排里排得很靠前，导致昂贵的精排跟着便宜的粗筛一起被排到标量谓词之前。
-- **问题 2 — 不剪枝**：精排不消费 `bitmap_input`（`GISFunctionFilterExpr.cpp::EvalForIndexSegment`）：`collect_hits` 取整个 coarse 位图，对全部 coarse 候选逐行构造几何并做段级缓存，从不与上游标量谓词的结果求交。
+- **Issue 1 — wrong scheduling order**: the GIS expression as a whole (cheap R-Tree coarse filter + expensive exact refine) falls into the `indexed_expr` bucket (`Expr.cpp` `ReorderConjunctExpr`), which is ordered very early in the conjunction reorder. The expensive refine is therefore dragged along with the cheap coarse filter and runs *before* the scalar predicates.
+- **Issue 2 — no pruning**: the refine step does not consume `bitmap_input` (`GISFunctionFilterExpr.cpp::EvalForIndexSegment`): `collect_hits` takes the entire coarse bitmap, constructs a geometry for every coarse candidate row (with segment-level caching), and never intersects with the upstream scalar predicates' result.
 
-两者叠加 = 无论 `work_model` / `experience` 等标量条件怎么筛，精排都对粗筛命中的所有行逐行构造几何对象。这是核心浪费。
+Combined effect: no matter how selective the scalar conditions (`work_model` / `experience` / ...) are, the refine constructs geometry objects row by row for everything the coarse filter hit. This is the core waste.
 
-## 2. 目标（三者合一）
+## 2. Goals (three in one)
 
-- **拆分**：每个几何列拆出 `Coarse`(R-Tree) 和 `Refine`(精确) 两个独立 tree 节点。
-- **修 bitmap_input**：`Refine` 消费上游 `bitmap_input`，只精算"全部更便宜谓词都通过"的幸存行。
-- **融合**：同一列的多个几何谓词，`Refine` 阶段对每个幸存行只读一次 WKB / 只构造一次 GEOS 对象，套用全部谓词（K→1）。
+- **Split**: for each geometry column, split out `Coarse` (R-Tree) and `Refine` (exact) as two independent tree nodes.
+- **Fix bitmap_input**: `Refine` consumes the upstream `bitmap_input` and only exact-evaluates the rows that survived *all* cheaper predicates.
+- **Fusion**: for multiple geometry predicates on the same column, the `Refine` stage reads the WKB / constructs the GEOS object only once per surviving row and applies all predicates to it (K→1).
 
-## 3. 代数基础（为什么跨 OR 也正确）
+## 3. Algebraic Foundation (why it is also correct across OR)
 
-设几何块 `B = g1 ⊕ ... ⊕ gk`（⊕ 为该块的 AND 或 OR）。`Ri` 为精确谓词，`Ci` 为其 R-Tree 粗筛，满足 `Ci ⊇ Ri`。令 `B_coarse = ⊕ Ci`，`B_refine = ⊕ Ri`，则 `B_coarse ⊇ B_refine`，故：
+Let a geometry block be `B = g1 ⊕ ... ⊕ gk` (⊕ is the block's AND or OR). Let `Ri` be the exact predicate and `Ci` its R-Tree coarse filter, satisfying `Ci ⊇ Ri`. Define `B_coarse = ⊕ Ci` and `B_refine = ⊕ Ri`; then `B_coarse ⊇ B_refine`, hence:
 
 ```
 scalars ∧ B  =  scalars ∧ B_refine  ≡  scalars ∧ B_coarse ∧ B_refine
 ```
 
-于是可把 `B_coarse` 作为额外的 AND 子节点提到最前（便宜、选择性强、剪枝别人），把 `B_refine` 提到最后（昂贵、被所有人剪枝）。AND 块与 OR 块都成立——这是拆分跨 OR 仍正确的依据。
+So `B_coarse` can be hoisted to the very front as an extra AND child (cheap, selective, prunes everyone else), and `B_refine` pushed to the very end (expensive, pruned by everyone else). This holds for both AND blocks and OR blocks — which is why the split remains correct across OR.
 
-## 4. 架构：两个新算子 + 一份共享状态
+## 4. Architecture: Two New Operators + One Shared State
 
 ```cpp
-// 每个 (segment, 几何块) 一份，Coarse 与 Refine 共享
+// One per (segment, geometry block), shared by Coarse and Refine
 struct GISGroupState {
   FieldId field_id;
-  bool    is_and;                 // 块内组合：AND / OR
+  bool    is_and;                 // combination within the block: AND / OR
   struct Pred {
     GISOp            op;
-    Geometry         query_geom;  // 查询常量，构造一次复用
-    PreparedGeometry prepared;    // 预编译一次复用（修掉每 batch 重建）
+    Geometry         query_geom;  // query constant, constructed once and reused
+    PreparedGeometry prepared;    // prepared once and reused (fixes per-batch rebuild)
     bool             has_index;
-    TargetBitmap     coarse;      // 该谓词 R-Tree 结果，算一次
+    TargetBitmap     coarse;      // this predicate's R-Tree result, computed once
   };
   std::vector<Pred> preds;
-  std::shared_ptr<TargetBitmap> coarse_candidates; // B_coarse，Coarse 节点填，缓存一次
+  std::shared_ptr<TargetBitmap> coarse_candidates; // B_coarse, filled by Coarse, cached once
   std::atomic<bool> coarse_done{false};
 };
 
-class PhyGISCoarseConjunctExpr : public SegmentExpr { std::shared_ptr<GISGroupState> st_; }; // -> indexed 桶（早）
-class PhyGISRefineConjunctExpr : public SegmentExpr { std::shared_ptr<GISGroupState> st_; }; // -> heavy 桶（最后）
+class PhyGISCoarseConjunctExpr : public SegmentExpr { std::shared_ptr<GISGroupState> st_; }; // -> indexed bucket (early)
+class PhyGISRefineConjunctExpr : public SegmentExpr { std::shared_ptr<GISGroupState> st_; }; // -> heavy bucket (last)
 ```
 
-## 5. Optimizer 规则（镜像 LIKE 的 `SetLikeIndices` + 运行期建节点）
+## 5. Optimizer Rule (mirrors LIKE's `SetLikeIndices` + builds nodes at run time)
 
-1. 遍历 conjunction 子节点，识别"同一 field 的几何块"：直接的 GIS 叶子（`PhyGISFunctionFilterExpr`），或仅由该 field 的 GIS 谓词构成的 AND/OR 子树（用 ⊕ 记下组合方式）。
-2. 对每个块构造 `GISGroupState`（收集 `preds`、`is_and`，一次性建好 `query_geom` + `prepared`）。
-3. 生成 `Coarse` 与 `Refine` 两节点（共享同一 state），从原 children 移除原始 GIS 节点。
-4. 分桶：`Coarse` → `indexed_expr`（早）；`Refine` → `heavy_conjunct_expr`（最后）。复用现有 reorder 顺序，无需新机制。
-5. 退化：块内含非几何兄弟或复杂嵌套无法纯几何化 → 该块不拆，保留原 `PhyGISFunctionFilterExpr`（正确性优先）。配合查询改写归一成"标量 AND (同列 ST OR 组)"命中率最高。
+1. Walk the conjunction children and recognize "geometry blocks on the same field": either direct GIS leaves (`PhyGISFunctionFilterExpr`), or an AND/OR subtree consisting solely of GIS predicates on that field (record the combination as ⊕).
+2. For each block, build a `GISGroupState` (collect `preds` and `is_and`; construct `query_geom` + `prepared` once up front).
+3. Emit the `Coarse` and `Refine` nodes (sharing the same state) and remove the original GIS nodes from the children.
+4. Bucketing: `Coarse` → `indexed_expr` (early); `Refine` → `heavy_conjunct_expr` (last). Reuses the existing reorder machinery; no new mechanism needed.
+5. Degradation: if a block contains non-geometry siblings, or is nested in a way that cannot be made purely geometric, the block is not split and the original `PhyGISFunctionFilterExpr` is kept (correctness first). Combined with query rewriting that normalizes filters into "scalars AND (same-column ST OR group)", the hit rate is highest.
 
-## 6. Coarse 节点 Eval（段级一次 + 切片）
+## 6. Coarse Node Eval (once per segment + slicing)
 
 ```cpp
 void PhyGISCoarseConjunctExpr::Eval(EvalCtx& ctx, VectorPtr& result) {
   auto bs = GetNextBatchSize(); if (bs == 0) { result = nullptr; return; }
-  if (!st_->coarse_done) {                          // 段级，只一次
-    TargetBitmap cand(active_count_, st_->is_and);  // AND -> 全1 / OR -> 全0
+  if (!st_->coarse_done) {                          // per segment, only once
+    TargetBitmap cand(active_count_, st_->is_and);  // AND -> all ones / OR -> all zeros
     for (auto& p : st_->preds) {
-      if (p.has_index) RunRTreeQuery(p);            // 复用现有 idx_ptr->Query(ds)
-      else             p.coarse = TargetBitmap(active_count_, true); // 无索引 -> 全集
+      if (p.has_index) RunRTreeQuery(p);            // reuses existing idx_ptr->Query(ds)
+      else             p.coarse = TargetBitmap(active_count_, true); // no index -> full set
       st_->is_and ? (cand &= p.coarse) : (cand |= p.coarse);
     }
     st_->coarse_candidates = std::make_shared<TargetBitmap>(std::move(cand));
@@ -84,33 +84,33 @@ void PhyGISCoarseConjunctExpr::Eval(EvalCtx& ctx, VectorPtr& result) {
 }
 ```
 
-## 7. Refine 节点 Eval（吃 bitmap_input + 逐行一次构造 + 融合）
+## 7. Refine Node Eval (consumes bitmap_input + one construction per row + fusion)
 
 ```cpp
 void PhyGISRefineConjunctExpr::Eval(EvalCtx& ctx, VectorPtr& result) {
   auto bs = GetNextBatchSize(); if (bs == 0) { result = nullptr; return; }
   TargetBitmap res(bs, false);
 
-  const auto& pre = ctx.get_bitmap_input();        // == scalars ∧ B_coarse （修复点）
+  const auto& pre = ctx.get_bitmap_input();        // == scalars ∧ B_coarse (the fix)
   TargetBitmap survivors(bs, true);
   if (!pre.empty()) survivors &= pre;
-  survivors &= slice(*st_->coarse_candidates, current_pos_, bs); // 双保险
+  survivors &= slice(*st_->coarse_candidates, current_pos_, bs); // belt and braces
 
   if (!survivors.none()) {
     auto hits = collect_hits(survivors);
     auto* gcache = SimpleGeometryCacheManager::Instance()
                      .GetCache(segment_->get_segment_id(), st_->field_id);
     auto wkb = gcache ? nullptr
-                      : segment_->bulk_subscript(st_->field_id, hits); // 一次批量取
+                      : segment_->bulk_subscript(st_->field_id, hits); // one bulk fetch
     for (size i : hits) {
       const Geometry& left = gcache
-          ? *gcache->GetByOffsetUnsafe(i)           // 缓存开：零构造
-          : Geometry(ctx_, wkb[i]...);              // 缓存关：构造【一次】
-      bool bit = st_->is_and;                       // 一个 left 套全部谓词（融合）
+          ? *gcache->GetByOffsetUnsafe(i)           // cache on: zero construction
+          : Geometry(ctx_, wkb[i]...);              // cache off: construct ONCE
+      bool bit = st_->is_and;                       // apply all predicates to one left (fusion)
       for (auto& p : st_->preds) {
-        bool r = EvalPrepared(p, left);             // within/contains 语义对调，复用现有
+        bool r = EvalPrepared(p, left);             // within/contains semantics swapped, reuses existing code
         bit = st_->is_and ? (bit && r) : (bit || r);
-        if (st_->is_and ^ bit) break;               // 短路
+        if (st_->is_and ^ bit) break;               // short circuit
       }
       res[local(i)] = bit;
     }
@@ -120,35 +120,69 @@ void PhyGISRefineConjunctExpr::Eval(EvalCtx& ctx, VectorPtr& result) {
 }
 ```
 
-三处收益同时拿到：吃 `bitmap_input` → 只在"标量全过 ∧ coarse"的幸存行上精算；逐行一次构造 → K 谓词共享 `left`（K→1）；`prepared` 复用 → 查询几何只构造一次。
+All three wins land at once: consuming `bitmap_input` → exact evaluation only on rows that passed "all scalars ∧ coarse"; one construction per row → K predicates share one `left` (K→1); `prepared` reuse → the query geometry is constructed only once.
 
-## 8. 在 conjunction 里的最终形态
+## 8. Final Shape Inside the Conjunction
 
 ```
-input_order_: [ numeric... , indexed(含 B_coarse) , string... , 标量heavy... , heavy(含 B_refine 最后) , compare... ]
+input_order_: [ numeric... , indexed(incl. B_coarse) , string... , heavy scalars... , heavy(B_refine last) , compare... ]
 ```
 
-`bitmap_input` 链：`B_coarse` 早早贡献 → 中间标量继续收窄 → `B_refine` 最后拿到最小集合精算。`CanSkipFollowingExprs` 仍生效（coarse / 标量把结果打成全 0 时，refine 直接跳过）。
+The `bitmap_input` chain: `B_coarse` contributes early → intermediate scalars keep narrowing the set → `B_refine` finally receives the smallest set for exact evaluation. `CanSkipFollowingExprs` still applies (when coarse / scalars zero out the result, refine is skipped entirely).
 
-## 9. 正确性 / 边界
+## 9. Correctness / Edge Cases
 
-- 不变式 `Ci ⊇ Ri`（bbox 相交 ⊇ 精确相交；within 同理保守），现有 refine 已依赖，拆分不破坏。
-- OR 块：用第 3 节恒等式提升 `B_coarse` / `B_refine` 为外层 AND 子节点，合法。
-- `Refine` 对非幸存行返回 false，conjunction 再 AND，无误。
-- within/contains 语义对调：复用现有 `evaluate_geometry_prepared`。
-- null 几何：`GetByOffsetUnsafe` 返回 nullptr → 按 op 取 false。
-- 无 R-Tree 索引：coarse = 全集（不剪枝），refine 仍吃 `bitmap_input` + 融合，收益不失。
-- growing / mmap：沿用现有 `std::string` vs `std::string_view` 分支。
-- 缓存正交：本方案对 bbox 数据缓存关着也很快，不依赖 `enableGeometryCache`。
+- Invariant `Ci ⊇ Ri` (bbox intersection ⊇ exact intersection; within is conservative in the same way): the existing refine already relies on it; the split does not break it.
+- OR blocks: hoisting `B_coarse` / `B_refine` as outer AND children is justified by the identity in Section 3.
+- `Refine` returns false for non-surviving rows; the conjunction ANDs the results again, so no error.
+- within/contains semantics swap: reuses the existing `evaluate_geometry_prepared`.
+- Null geometry: `GetByOffsetUnsafe` returns nullptr → false according to the op.
+- No R-Tree index: coarse = full set (no pruning), but refine still consumes `bitmap_input` and fuses, so the win is not lost.
+- growing / mmap: keeps the existing `std::string` vs `std::string_view` branches.
+- Orthogonal to the cache: this design is fast for bbox data even with the cache off; it does not depend on `enableGeometryCache`.
 
-## 10. 落地分期
+## 10. Delivery Phases
 
-- **P1**：拆分 + bitmap_input 修复（coarse 早 / refine 晚吃 bitmap_input）。单谓词即可见大收益，风险低。
-- **P2**：Refine 同列融合（K→1）+ prepared 复用。
-- **P3**：更通用的嵌套块识别（超出"标量 AND 同列 OR/AND 组"）。
+- **P1**: split + bitmap_input fix (coarse early / refine last, consuming bitmap_input). A large win is already visible with a single predicate; low risk.
+- **P2**: same-column fusion in Refine (K→1) + prepared reuse.
+- **P3**: more general nested-block recognition (beyond "scalars AND same-column OR/AND group").
 
-## 11. 测试与灰度
+## 11. Testing and Rollout
 
-- Feature flag：`queryNode.segcore.enableGISSplitFusion`，默认关，灰度。
-- 等价测试 `GISCoarseRefineExprTest`：与"逐谓词原始 Eval"做全矩阵等价校验（AND/OR、intersects/within/contains、null、index/no-index、growing/sealed/mmap、空 bitmap_input）。
-- Bench：复现多谓词地理查询，验证 `Geometry::Geometry` 占比 20% → 约 0、refine 候选行数下降、p99 从秒级回落。
+- Feature flag: `queryNode.segcore.enableGISSplitFusion`, default off, for gradual rollout.
+- Equivalence tests `GISCoarseRefineExprTest`: full-matrix equivalence against the original per-predicate Eval (AND/OR, intersects/within/contains, null, index/no-index, growing/sealed/mmap, empty bitmap_input).
+- Bench: reproduce multi-predicate geo queries; verify that the `Geometry::Geometry` CPU share drops from ~20% to ~0, the refine candidate row count shrinks, and p99 falls back from seconds.
+
+## 12. Measured Results (2026-07-06)
+
+A/B benchmark on the implementation PR (#50675): same binary and same data, only `enableGISSplitFusion` toggled across restarts, with `enableGeometryCache=false` in **both** modes. Dataset: 1M rows; `geo` holds 64-vertex polygons (construction-heavy, the workload this design targets) with an RTREE index; an `INT64` scalar column controls predicate selectivity; query viewports are sized to hit a controlled fraction of rows. Numbers are p50 of 100 sequential `query(count(*))` iterations (pure filter path).
+
+| case | filter shape | OFF p50 (ms) | ON p50 (ms) | speedup |
+|------|--------------|-------------:|------------:|--------:|
+| control | lone `ST_INTERSECTS` (5% viewport) — never split | 54.1 | 53.7 | 1.01x |
+| pruning 1% | `scalar(1%)` ∧ intersects(5%) | 55.6 | 5.2 | 10.7x |
+| pruning 10% | `scalar(10%)` ∧ intersects(5%) | 55.6 | 10.0 | 5.6x |
+| pruning 50% | `scalar(50%)` ∧ intersects(5%) | 55.1 | 28.8 | 1.9x |
+| fusion OR-2 | `scalar(10%)` ∧ (2-way OR, 5% total) | 57.4 | 9.9 | 5.8x |
+| fusion OR-4 | `scalar(10%)` ∧ (4-way OR, 5% total) | 60.3 | 10.9 | 5.5x |
+| pruning × fusion | `scalar(1%)` ∧ (4-way OR) | 60.6 | 6.0 | 10.1x |
+| AND fusion | `scalar(10%)` ∧ intersects(5%) ∧ within(20%) | 259.0 | 12.2 | 21.2x |
+| large coarse set | `scalar(10%)` ∧ intersects(20% viewport) | 209.0 | 27.4 | 7.6x |
+
+What the numbers confirm, per mechanism:
+
+- **No overhead where the rewrite does not apply**: the control case (a lone GIS predicate never enters `SplitFuseGISConjunct`) is 1.01x.
+- **`bitmap_input` pruning**: OFF is flat (~55 ms) regardless of scalar selectivity — the old refine pays for the whole coarse candidate set; ON scales with the surviving rows (5.2 / 10.0 / 28.8 ms at 1% / 10% / 50%).
+- **K→1 fusion**: a 4-way same-column OR costs the same as a single predicate with the same survivor set (10.9 vs 10.0 ms).
+- **Worst case**: an AND of a 5% and a 20% predicate (250k coarse-candidate constructions for a 5k-row answer) drops from 259 ms to 12 ms.
+- Both sides fit `latency ≈ 2.5 ms + 1.03 µs × (#GEOS constructions)` with constructions = Σ|coarseᵢ| when OFF vs |scalars ∧ B_coarse| when ON — matching the algebra in Section 3.
+- `count(*)` is identical ON vs OFF for all cases. Filtered `search` (topk=100) shows the same pattern end-to-end (4.8–18.6x).
+
+Full setup and discussion: https://github.com/milvus-io/milvus/pull/50675#issuecomment-4899397542
+
+## 13. 2.6 Backport Notes (#50751)
+
+The measurements above were taken on the master implementation (#50675); the backported code is functionally identical except for two deliberate adaptations to the 2.6 baseline:
+
+- **No `EnsurePinnedIndex()` call in the coarse R-Tree query**: on 2.6 the scalar index is pinned eagerly in the `SegmentExpr` constructor (`InitSegmentExpr`), so `pinned_index_` / `num_index_chunk_` are already populated when `Eval` runs; the lazy-pinning helper only exists on master.
+- **`STIsValid` equivalence cases omitted from `GISCoarseRefineExprTest`**: the `STIsValid` GISOp does not exist on 2.6 (`plan.proto` `GISOp` stops at `DWithin = 8`), so the master test cases guarding it cannot be expressed. The `as_groupable_gis` whitelist is backported unchanged and still keeps any non-whitelisted op off the fusion path.

--- a/docs/design_docs/gis_filter_coarse_refine_split_fusion.md
+++ b/docs/design_docs/gis_filter_coarse_refine_split_fusion.md
@@ -41,8 +41,7 @@ struct GISGroupState {
   bool    is_and;                 // combination within the block: AND / OR
   struct Pred {
     GISOp            op;
-    Geometry         query_geom;  // query constant, constructed once and reused
-    PreparedGeometry prepared;    // prepared once and reused (fixes per-batch rebuild)
+    std::string      query_wkt;   // query constant WKT; parsed per batch (below)
     bool             has_index;
     TargetBitmap     coarse;      // this predicate's R-Tree result, computed once
   };
@@ -98,17 +97,24 @@ void PhyGISRefineConjunctExpr::Eval(EvalCtx& ctx, VectorPtr& result) {
 
   if (!survivors.none()) {
     auto hits = collect_hits(survivors);
+    // Query geometries + prepared forms are built ONCE PER BATCH on this
+    // thread's GEOS context. GEOS objects are bound to a GEOSContextHandle and
+    // are not shareable across threads, so they cannot be prepared once at
+    // compile time and reused across batches/threads -- per-batch-per-thread is
+    // the finest granularity that is safe. This is still K→1 within the batch.
+    GEOSContextHandle_t qctx = GetThreadLocalGEOSContext();
+    auto [qgeoms, preps] = build_query_geoms(qctx, st_->preds); // once per batch
     auto* gcache = SimpleGeometryCacheManager::Instance()
                      .GetCache(segment_->get_segment_id(), st_->field_id);
     auto wkb = gcache ? nullptr
-                      : segment_->bulk_subscript(st_->field_id, hits); // one bulk fetch
+                      : segment_->bulk_subscript(op_ctx_, st_->field_id, hits); // one bulk fetch
     for (size i : hits) {
       const Geometry& left = gcache
           ? *gcache->GetByOffsetUnsafe(i)           // cache on: zero construction
-          : Geometry(ctx_, wkb[i]...);              // cache off: construct ONCE
+          : Geometry(qctx, wkb[i]...);              // cache off: construct ONCE per row
       bool bit = st_->is_and;                       // apply all predicates to one left (fusion)
-      for (auto& p : st_->preds) {
-        bool r = EvalPrepared(p, left);             // within/contains semantics swapped, reuses existing code
+      for (size j = 0; j < st_->preds.size(); ++j) {
+        bool r = EvalPrepared(st_->preds[j].op, preps[j], qgeoms[j], left); // within/contains swapped, reuses existing code
         bit = st_->is_and ? (bit && r) : (bit || r);
         if (st_->is_and ^ bit) break;               // short circuit
       }
@@ -120,7 +126,7 @@ void PhyGISRefineConjunctExpr::Eval(EvalCtx& ctx, VectorPtr& result) {
 }
 ```
 
-All three wins land at once: consuming `bitmap_input` → exact evaluation only on rows that passed "all scalars ∧ coarse"; one construction per row → K predicates share one `left` (K→1); `prepared` reuse → the query geometry is constructed only once.
+All three wins land at once: consuming `bitmap_input` → exact evaluation only on rows that passed "all scalars ∧ coarse"; one construction per row → K predicates share one `left` (K→1); the query geometries + prepared forms are built once per batch (per thread; see the GEOS constraint above) and reused across all surviving rows in that batch.
 
 ## 8. Final Shape Inside the Conjunction
 

--- a/internal/core/src/exec/expression/ConjunctExpr.h
+++ b/internal/core/src/exec/expression/ConjunctExpr.h
@@ -111,6 +111,13 @@ class PhyConjunctFilterExpr : public Expr {
         return input_order_;
     }
 
+    // Replace the whole inputs list (used by the GIS split-fusion pre-pass that
+    // rewrites same-column geometry predicates into Coarse + Refine nodes).
+    void
+    RebuildInputs(std::vector<std::shared_ptr<Expr>>&& inputs) {
+        inputs_ = std::move(inputs);
+    }
+
     // Set the bitmap input for the next expression in the conjunction.
     // The bitmap indicates which rows still need to be evaluated.
     //

--- a/internal/core/src/exec/expression/Expr.cpp
+++ b/internal/core/src/exec/expression/Expr.cpp
@@ -16,6 +16,9 @@
 
 #include "Expr.h"
 
+#include <map>
+#include <memory>
+
 #include "common/EasyAssert.h"
 #include "common/Tracer.h"
 #include "exec/expression/AlwaysTrueExpr.h"
@@ -26,20 +29,21 @@
 #include "exec/expression/CompareExpr.h"
 #include "exec/expression/ConjunctExpr.h"
 #include "exec/expression/ExistsExpr.h"
+#include "exec/expression/GISConjunctExpr.h"
 #include "exec/expression/GISFunctionFilterExpr.h"
 #include "exec/expression/JsonContainsExpr.h"
 #include "exec/expression/LogicalBinaryExpr.h"
 #include "exec/expression/LogicalUnaryExpr.h"
 #include "exec/expression/NullExpr.h"
 #include "exec/expression/TermExpr.h"
-#include "exec/expression/UnaryExpr.h"
-#include "expr/ITypeExpr.h"
-#include "exec/expression/ValueExpr.h"
 #include "exec/expression/TimestamptzArithCompareExpr.h"
+#include "exec/expression/UnaryExpr.h"
+#include "exec/expression/ValueExpr.h"
 #include "expr/ITypeExpr.h"
 #include "monitor/Monitor.h"
+#include "pb/plan.pb.h"
+#include "segcore/SegcoreConfig.h"
 
-#include <memory>
 namespace milvus {
 namespace exec {
 
@@ -342,7 +346,164 @@ IsLikeExpr(std::shared_ptr<Expr> input) {
     return false;
 }
 
-inline void
+// Split same-column geometry predicates of an AND conjunction into a cheap
+// Coarse(R-Tree) node (bucketed early, prunes others) and an expensive Refine
+// node (bucketed last, consumes bitmap_input + fuses per-row construction).
+// Gated by queryNode.segcore.enableGISSplitFusion. See
+// docs/design_docs/gis_filter_coarse_refine_split_fusion.md.
+static void
+SplitFuseGISConjunct(std::shared_ptr<milvus::exec::PhyConjunctFilterExpr>& expr,
+                     ExecContext* context) {
+    if (!milvus::segcore::SegcoreConfig::default_config()
+             .get_enable_gis_split_fusion()) {
+        return;
+    }
+    // Algebra requires an AND parent to hoist B_coarse / B_refine.
+    if (!expr->IsAnd()) {
+        return;
+    }
+    auto* qc = context->get_query_context();
+    auto* segment = qc->get_segment();
+    if (!segment) {
+        return;
+    }
+    auto active = qc->get_active_count();
+    auto bs = qc->query_config()->get_expr_batch_size();
+    auto cl = qc->get_consistency_level();
+    auto* op_ctx = qc->get_op_context();
+
+    auto as_groupable_gis = [](const std::shared_ptr<Expr>& e)
+        -> std::shared_ptr<PhyGISFunctionFilterExpr> {
+        auto g = std::dynamic_pointer_cast<PhyGISFunctionFilterExpr>(e);
+        if (!g) {
+            return nullptr;
+        }
+        // DWithin carries a distance; not grouped in this pass.
+        if (g->GetGISExpr()->op_ ==
+            proto::plan::GISFunctionFilterExpr_GISOp_DWithin) {
+            return nullptr;
+        }
+        return g;
+    };
+
+    auto emit_split_nodes =
+        [&](int64_t field,
+            bool is_and,
+            const std::vector<std::shared_ptr<PhyGISFunctionFilterExpr>>&
+                leaves,
+            std::vector<std::shared_ptr<Expr>>& out) {
+            auto state = std::make_shared<GISGroupState>();
+            state->field_id = FieldId(field);
+            state->is_and = is_and;
+            for (auto& g : leaves) {
+                auto le = g->GetGISExpr();
+                GISGroupState::Pred p;
+                p.op = le->op_;
+                p.query_wkt = le->geometry_wkt_;
+                p.has_index = segment->HasIndex(FieldId(field));
+                state->preds.push_back(std::move(p));
+            }
+            out.push_back(std::make_shared<PhyGISCoarseConjunctExpr>(
+                state,
+                "PhyGISCoarseConjunctExpr",
+                op_ctx,
+                segment,
+                active,
+                bs,
+                cl));
+            out.push_back(std::make_shared<PhyGISRefineConjunctExpr>(
+                state,
+                "PhyGISRefineConjunctExpr",
+                op_ctx,
+                segment,
+                active,
+                bs,
+                cl));
+        };
+
+    const auto& inputs = expr->GetInputsRef();
+    std::vector<std::shared_ptr<Expr>> kept;
+    std::vector<std::shared_ptr<Expr>> new_nodes;
+    std::map<int64_t, std::vector<std::shared_ptr<PhyGISFunctionFilterExpr>>>
+        direct;
+    bool changed = false;
+
+    for (const auto& child : inputs) {
+        if (auto g = as_groupable_gis(child)) {
+            direct[g->GetGISExpr()->column_.field_id_.get()].push_back(g);
+            changed = true;
+            continue;
+        }
+        // Shape B: a child sub-conjunction made entirely of same-field GIS
+        // predicates (e.g. the "ST OR ST OR ..." group after query rewrite).
+        if (auto sub =
+                std::dynamic_pointer_cast<PhyConjunctFilterExpr>(child)) {
+            const auto& sc = sub->GetInputsRef();
+            bool pure = !sc.empty();
+            int64_t field = -1;
+            std::vector<std::shared_ptr<PhyGISFunctionFilterExpr>> leaves;
+            for (const auto& c2 : sc) {
+                auto g = as_groupable_gis(c2);
+                if (!g) {
+                    pure = false;
+                    break;
+                }
+                int64_t f = g->GetGISExpr()->column_.field_id_.get();
+                if (field == -1) {
+                    field = f;
+                } else if (field != f) {
+                    pure = false;
+                    break;
+                }
+                leaves.push_back(g);
+            }
+            if (pure && field != -1) {
+                emit_split_nodes(field, sub->IsAnd(), leaves, new_nodes);
+                changed = true;
+                continue;
+            }
+        }
+        kept.push_back(child);
+    }
+
+    if (!changed) {
+        return;
+    }
+    // Trivial case: a single same-field GIS predicate with no R-Tree index and
+    // no other prunable sibling (no scalar leaf kept, no Shape-B group). The
+    // split would add a Coarse node that allocates a full-set bitmap for zero
+    // pruning benefit and gains nothing from fusion (only one predicate), so
+    // leave the original leaf untouched.
+    if (kept.empty() && new_nodes.empty() && direct.size() == 1) {
+        auto it = direct.begin();
+        if (it->second.size() == 1 && !segment->HasIndex(FieldId(it->first))) {
+            return;
+        }
+    }
+    // NOTE: when a field appears BOTH as a direct AND-leaf here and inside a
+    // Shape-B subgroup (e.g. `ST_A(geo) AND (ST_B(geo) OR ST_C(geo))`), this
+    // emits two independent coarse/refine pairs for that field, so the row
+    // geometry is constructed twice and the R-Tree runs twice — the result is
+    // still correct but part of the K->1 fusion win is lost. Merging them would
+    // require GISGroupState to carry a top-level-AND of {is_and, preds}
+    // sub-blocks; tracked as a follow-up (kept out of this PR to stay focused).
+    for (auto& kv : direct) {
+        // Direct leaves are children of THIS AND conjunction -> combine = AND.
+        emit_split_nodes(kv.first, /*is_and=*/true, kv.second, new_nodes);
+    }
+
+    std::vector<std::shared_ptr<Expr>> rebuilt;
+    rebuilt.reserve(kept.size() + new_nodes.size());
+    for (auto& e : kept) {
+        rebuilt.push_back(e);
+    }
+    for (auto& e : new_nodes) {
+        rebuilt.push_back(e);
+    }
+    expr->RebuildInputs(std::move(rebuilt));
+}
+
+void
 ReorderConjunctExpr(std::shared_ptr<milvus::exec::PhyConjunctFilterExpr>& expr,
                     ExecContext* context,
                     bool& has_heavy_operation) {
@@ -350,6 +511,9 @@ ReorderConjunctExpr(std::shared_ptr<milvus::exec::PhyConjunctFilterExpr>& expr,
     if (!segment || !expr) {
         return;
     }
+    // Rewrite same-column geometry predicates into Coarse + Refine nodes before
+    // bucketing, so the buckets below schedule coarse early / refine last.
+    SplitFuseGISConjunct(expr, context);
     std::vector<size_t> reorder;
     std::vector<size_t> numeric_expr;
     std::vector<size_t> indexed_expr;
@@ -367,6 +531,19 @@ ReorderConjunctExpr(std::shared_ptr<milvus::exec::PhyConjunctFilterExpr>& expr,
     const auto& inputs = expr->GetInputsRef();
     for (int i = 0; i < inputs.size(); i++) {
         const auto& input = inputs[i];
+
+        // GIS split-fusion nodes: coarse runs early (indexed bucket) so its
+        // R-Tree bitmap prunes others; refine runs last (heavy bucket) so it
+        // consumes the full bitmap_input and only refines surviving rows.
+        if (input->name() == "PhyGISCoarseConjunctExpr") {
+            indexed_expr.push_back(i);
+            continue;
+        }
+        if (input->name() == "PhyGISRefineConjunctExpr") {
+            heavy_conjunct_expr.push_back(i);
+            has_heavy_operation = true;
+            continue;
+        }
 
         if (input->IsSource() && input->GetColumnInfo().has_value()) {
             auto column = input->GetColumnInfo().value();

--- a/internal/core/src/exec/expression/Expr.cpp
+++ b/internal/core/src/exec/expression/Expr.cpp
@@ -378,12 +378,28 @@ SplitFuseGISConjunct(std::shared_ptr<milvus::exec::PhyConjunctFilterExpr>& expr,
         if (!g) {
             return nullptr;
         }
-        // DWithin carries a distance; not grouped in this pass.
-        if (g->GetGISExpr()->op_ ==
-            proto::plan::GISFunctionFilterExpr_GISOp_DWithin) {
-            return nullptr;
+        // Whitelist only the binary topological predicates the coarse/refine
+        // split + fusion path actually supports: they carry a non-empty query
+        // WKT and have a case in EvaluateGISPreparedOp. Everything else is left
+        // on the baseline per-predicate path. In particular:
+        //   - DWithin carries a distance (not handled by the prepared fusion);
+        //   - STIsValid is a UNARY op with an EMPTY query WKT and is routed to
+        //     RawData by DetermineExecPath -- grouping it would construct a
+        //     Geometry from "" (GEOS returns null -> AssertInfo throws) and has
+        //     no EvaluateGISPreparedOp case, crashing valid queries.
+        switch (g->GetGISExpr()->op_) {
+            case proto::plan::GISFunctionFilterExpr_GISOp_Equals:
+            case proto::plan::GISFunctionFilterExpr_GISOp_Touches:
+            case proto::plan::GISFunctionFilterExpr_GISOp_Overlaps:
+            case proto::plan::GISFunctionFilterExpr_GISOp_Crosses:
+            case proto::plan::GISFunctionFilterExpr_GISOp_Contains:
+            case proto::plan::GISFunctionFilterExpr_GISOp_Intersects:
+            case proto::plan::GISFunctionFilterExpr_GISOp_Within:
+                return g;
+            default:
+                // DWithin, STIsValid, Invalid, and any future op: not grouped.
+                return nullptr;
         }
-        return g;
     };
 
     auto emit_split_nodes =

--- a/internal/core/src/exec/expression/Expr.cpp
+++ b/internal/core/src/exec/expression/Expr.cpp
@@ -413,6 +413,18 @@ SplitFuseGISConjunct(std::shared_ptr<milvus::exec::PhyConjunctFilterExpr>& expr,
             state->is_and = is_and;
             for (auto& g : leaves) {
                 auto le = g->GetGISExpr();
+                // Guard at the point of use, independent of the
+                // as_groupable_gis whitelist above: the split path drops
+                // DWithin's distance (Pred carries no distance,
+                // EvalPrepared hardcodes 0.0) and RunRTreeQuery performs no
+                // bbox expansion, so a grouped DWithin would silently
+                // under-match. Fail loudly if a future whitelist edit ever
+                // lets it through.
+                AssertInfo(
+                    le->op_ != proto::plan::GISFunctionFilterExpr_GISOp_DWithin,
+                    "DWithin must not enter the GIS split/fusion group: the "
+                    "grouped path drops its distance and skips the coarse "
+                    "bbox expansion");
                 GISGroupState::Pred p;
                 p.op = le->op_;
                 p.query_wkt = le->geometry_wkt_;

--- a/internal/core/src/exec/expression/Expr.cpp
+++ b/internal/core/src/exec/expression/Expr.cpp
@@ -618,6 +618,12 @@ ReorderConjunctExpr(std::shared_ptr<milvus::exec::PhyConjunctFilterExpr>& expr,
             }
         }
 
+        // NOTE: do NOT extend this recursion through PhyLogicalUnaryExpr (NOT).
+        // The GIS split nodes' all-ones `valid` is only sound because a split
+        // group can never sit under a negation -- see the PRECONDITION in
+        // GISConjunctExpr.cpp. Reordering (and thus splitting) a conjunction
+        // under a NOT would negate that all-ones `valid` into selecting
+        // null-geometry rows.
         if (input->name() == "PhyConjunctFilterExpr") {
             bool sub_expr_heavy = false;
             auto expr = std::static_pointer_cast<PhyConjunctFilterExpr>(input);

--- a/internal/core/src/exec/expression/Expr.cpp
+++ b/internal/core/src/exec/expression/Expr.cpp
@@ -411,6 +411,9 @@ SplitFuseGISConjunct(std::shared_ptr<milvus::exec::PhyConjunctFilterExpr>& expr,
             auto state = std::make_shared<GISGroupState>();
             state->field_id = FieldId(field);
             state->is_and = is_and;
+            // Denominator for the pruning ratios reported when the state dies;
+            // set here so it is valid even if neither node ever executes.
+            state->active_count = active;
             for (auto& g : leaves) {
                 auto le = g->GetGISExpr();
                 // Guard at the point of use, independent of the

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -95,6 +95,10 @@ EquivExprs() {
         R"expr(age >= 0 and st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))") and st_within(geo, "POLYGON((-100 -100, 100 -100, 100 100, -100 100, -100 -100))"))expr",
         // (6) single GIS only (no conjunction -> fusion must be a no-op)
         R"expr(st_intersects(geo, "POINT(0 0)"))expr",
+        // NOTE: the master PR also covers an STIsValid case (st_isvalid must stay
+        // off the split-fusion group path). The ST_IsValid GIS op does not exist
+        // on 2.6 (plan proto GISOp stops at DWithin), so that case is omitted
+        // here; the as_groupable_gis whitelist still defends against it.
     };
     return exprs;
 }
@@ -129,10 +133,10 @@ AssertFusionEquivalence(const std::shared_ptr<Schema>& schema,
 }
 
 std::shared_ptr<Schema>
-MakeGISSchema() {
+MakeGISSchema(bool nullable_geo = false) {
     auto schema = std::make_shared<Schema>();
     auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
-    schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->AddDebugField("geo", DataType::GEOMETRY, nullable_geo);
     schema->AddDebugField("age", DataType::INT64);
     schema->AddDebugField(
         "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
@@ -173,6 +177,46 @@ TEST(GISCoarseRefineExprTest, EquivalenceFusionWithGeometryCache) {
     ASSERT_NE(milvus::exec::SimpleGeometryCacheManager::Instance().GetCache(
                   seg->get_segment_id(), geo_fid),
               nullptr);
+
+    AssertFusionEquivalence(schema, handle, seg.get(), N);
+}
+
+// Equivalence with a NULLABLE geometry field, so ~50% of rows carry null
+// geometry (DataGen's deterministic i%2 valid pattern). Exercises the
+// null-handling branches in the Coarse/Refine nodes (the `valid` bitmaps and
+// the Refine null-skip), which the non-nullable schema never reaches. The
+// split path must still produce exactly the baseline selection on null rows.
+TEST(GISCoarseRefineExprTest, EquivalenceFusionNullableGeometry) {
+    auto schema = MakeGISSchema(/*nullable_geo=*/true);
+    const int64_t N = 1000;
+    auto dataset = DataGen(schema, N);
+    auto seg = CreateSealedWithFieldDataLoaded(schema, dataset);
+    ScopedSchemaHandle handle(*schema);
+
+    // Sanity: the nullable geo column must actually contain null rows, else this
+    // test degenerates into the non-nullable case.
+    auto geo_fid = schema->get_field_id(FieldName("geo"));
+    const auto& valid = dataset.get_col_valid(geo_fid);
+    ASSERT_NE(std::count(valid.begin(), valid.end(), false), 0)
+        << "nullable geo column produced no null rows";
+
+    AssertFusionEquivalence(schema, handle, seg.get(), N);
+}
+
+// Equivalence on a GROWING segment. The baseline GIS path takes different
+// data-type branches for growing vs. sealed segments (std::string vs.
+// std::string_view chunk access), so the sealed-only tests above cannot lock
+// down the growing path. No R-Tree index exists on a growing segment, so this
+// also covers the Coarse node's "no index -> full coarse set" degenerate path.
+TEST(GISCoarseRefineExprTest, EquivalenceFusionGrowingSegment) {
+    auto schema = MakeGISSchema();
+    const int64_t N = 1000;
+    auto dataset = DataGen(schema, N);
+    auto seg = CreateGrowingWithFieldDataLoaded(schema,
+                                                milvus::empty_index_meta,
+                                                SegcoreConfig::default_config(),
+                                                dataset);
+    ScopedSchemaHandle handle(*schema);
 
     AssertFusionEquivalence(schema, handle, seg.get(), N);
 }

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -23,7 +23,11 @@
 
 #include "ExprTestBase.h"
 #include "common/Common.h"
+#include "common/Consts.h"
 #include "common/GeometryCache.h"
+#include "exec/QueryContext.h"
+#include "exec/expression/Expr.h"
+#include "plan/PlanNode.h"
 #include "common/Schema.h"
 #include "common/Types.h"
 #include "knowhere/comp/index_param.h"
@@ -110,10 +114,16 @@ EquivExprs() {
         R"expr(age >= 0 and st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))") and st_within(geo, "POLYGON((-100 -100, 100 -100, 100 100, -100 100, -100 -100))"))expr",
         // (6) single GIS only (no conjunction -> fusion must be a no-op)
         R"expr(st_intersects(geo, "POINT(0 0)"))expr",
-        // NOTE: the master PR also covers an STIsValid case (st_isvalid must stay
+        // NOTE: the master PR also covers STIsValid cases (st_isvalid must stay
         // off the split-fusion group path). The ST_IsValid GIS op does not exist
-        // on 2.6 (plan proto GISOp stops at DWithin), so that case is omitted
+        // on 2.6 (plan proto GISOp stops at DWithin), so those cases are omitted
         // here; the as_groupable_gis whitelist still defends against it.
+        // (7) direct AND-leaf + Shape-B subgroup on the SAME field: `geo`
+        // appears both as a direct conjunction leaf (st_within) and inside an
+        // OR subgroup (Shape B). Per the NOTE in Expr.cpp the rewrite emits two
+        // independent coarse/refine pairs for that field, so this dual-pair
+        // path is the trickiest one -- pin it down with an ON-vs-OFF case.
+        R"expr(st_within(geo, "POLYGON((-100 -100, 100 -100, 100 100, -100 100, -100 -100))") and (st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))") or st_intersects(geo, "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))")))expr",
     };
     return exprs;
 }
@@ -254,4 +264,55 @@ TEST(GISCoarseRefineExprTest, EquivalenceFusionMultiBatch) {
     ScopedSchemaHandle handle(*schema);
 
     AssertFusionEquivalence(schema, handle, seg.get(), N);
+}
+
+// The GIS filter slices only by its own batch cursor and never reads the
+// offset-input list, so it MUST report SupportOffsetInput() == false. If it
+// (or, with fusion ON, the conjunction wrapping it) reported true, the
+// IterativeFilterNode native path would feed a sparse offset list into an Eval
+// that ignores it and return misaligned rows (a silent wrong-results bug). This
+// locks the contract on both the baseline and the split-fusion path so a future
+// change cannot regress it. See PR #50675 review (Medium: SupportOffsetInput).
+TEST(GISCoarseRefineExprTest, GISDoesNotSupportOffsetInput) {
+    auto schema = MakeGISSchema();
+    const int64_t N = 256;
+    auto dataset = DataGen(schema, N);
+    auto seg = CreateSealedWithFieldDataLoaded(schema, dataset);
+    ScopedSchemaHandle handle(*schema);
+
+    // Representative shapes: a bare GIS leaf (compiles to
+    // PhyGISFunctionFilterExpr) and a same-column conjunction that fusion
+    // rewrites into the Coarse/Refine nodes wrapped in a conjunction.
+    const std::vector<std::string> shapes = {
+        R"expr(st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))"))expr",
+        R"expr(st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))") and st_within(geo, "POLYGON((-100 -100, 100 -100, 100 100, -100 100, -100 -100))"))expr",
+    };
+
+    auto top_supports_offset_input = [&](const std::string& expr) -> bool {
+        auto bin = handle.ParseSearch(
+            expr, "vec", 5, knowhere::metric::L2, R"({"nprobe":10})", 3);
+        auto plan = CreateSearchPlanByExpr(schema, bin.data(), bin.size());
+        auto filter_node =
+            std::dynamic_pointer_cast<milvus::plan::FilterBitsNode>(
+                plan->plan_node_->plannodes_->sources()[0]->sources()[0]);
+        std::vector<milvus::expr::TypedExprPtr> filters{filter_node->filter()};
+        auto query_context = std::make_shared<milvus::exec::QueryContext>(
+            DEAFULT_QUERY_ID, seg.get(), N, MAX_TIMESTAMP);
+        milvus::exec::ExecContext exec_context(query_context.get());
+        milvus::exec::ExprSet expr_set(filters, &exec_context);
+        return expr_set.exprs()[0]->SupportOffsetInput();
+    };
+
+    for (const auto& e : shapes) {
+        {
+            GISSplitFusionGuard off(false);
+            EXPECT_FALSE(top_supports_offset_input(e))
+                << "fusion OFF, expr: " << e;
+        }
+        {
+            GISSplitFusionGuard on(true);
+            EXPECT_FALSE(top_supports_offset_input(e))
+                << "fusion ON, expr: " << e;
+        }
+    }
 }

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "ExprTestBase.h"
+#include "common/Common.h"
 #include "common/GeometryCache.h"
 #include "common/Schema.h"
 #include "common/Types.h"
@@ -76,6 +77,20 @@ struct GeometryCacheGuard {
     }
     ~GeometryCacheGuard() {
         SegcoreConfig::default_config().set_enable_geometry_cache(false);
+    }
+};
+
+// RAII guard for the expr batch size, restored on scope exit. Used to force
+// multiple Eval batches over a single segment so the split nodes' per-batch
+// coarse slicing + dual-cursor advance is exercised across batch boundaries.
+struct ExprBatchSizeGuard {
+    int64_t saved;
+    explicit ExprBatchSizeGuard(int64_t batch_size)
+        : saved(EXEC_EVAL_EXPR_BATCH_SIZE.load()) {
+        EXEC_EVAL_EXPR_BATCH_SIZE.store(batch_size);
+    }
+    ~ExprBatchSizeGuard() {
+        EXEC_EVAL_EXPR_BATCH_SIZE.store(saved);
     }
 };
 
@@ -216,6 +231,26 @@ TEST(GISCoarseRefineExprTest, EquivalenceFusionGrowingSegment) {
                                                 milvus::empty_index_meta,
                                                 SegcoreConfig::default_config(),
                                                 dataset);
+    ScopedSchemaHandle handle(*schema);
+
+    AssertFusionEquivalence(schema, handle, seg.get(), N);
+}
+
+// Equivalence with a small expr batch size, so a single N=1000 segment is
+// evaluated over MANY Eval batches. The default batch size (8192) makes the
+// other tests run in a single batch, which never exercises the split nodes'
+// per-batch slicing of the segment-level coarse_candidates bitmap, the
+// MoveCursor advance, or the dual-cursor sync between the Coarse and Refine
+// nodes across batch boundaries. Forcing several batches locks those paths
+// down. (The R-Tree-indexed coarse path is covered separately by
+// RTreeIndexTest.GIS_SplitFusion_Equivalence_Indexed.)
+TEST(GISCoarseRefineExprTest, EquivalenceFusionMultiBatch) {
+    ExprBatchSizeGuard batch_guard(128);  // 1000 rows -> 8 batches
+
+    auto schema = MakeGISSchema();
+    const int64_t N = 1000;
+    auto dataset = DataGen(schema, N);
+    auto seg = CreateSealedWithFieldDataLoaded(schema, dataset);
     ScopedSchemaHandle handle(*schema);
 
     AssertFusionEquivalence(schema, handle, seg.get(), N);

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -1,0 +1,178 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+// Equivalence tests for the GIS coarse/refine split + same-column fusion
+// optimization (queryNode.segcore.enableGISSplitFusion). For every filter that
+// contains same-column geometry predicates, evaluating with the flag ON (split
+// + fusion path) must yield exactly the same bitset as evaluating with the flag
+// OFF (the original per-predicate PhyGISFunctionFilterExpr path).
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ExprTestBase.h"
+#include "common/GeometryCache.h"
+#include "common/Schema.h"
+#include "common/Types.h"
+#include "knowhere/comp/index_param.h"
+#include "query/ExecPlanNodeVisitor.h"
+#include "query/Plan.h"
+#include "query/PlanImpl.h"
+#include "segcore/SegcoreConfig.h"
+#include "segcore/SegmentInterface.h"
+#include "segcore/SegmentSealed.h"
+#include "test_utils/DataGen.h"
+#include "test_utils/storage_test_utils.h"
+
+using namespace milvus;
+using namespace milvus::query;
+using namespace milvus::segcore;
+
+namespace {
+
+BitsetType
+RunFilter(const std::shared_ptr<Schema>& schema,
+          ScopedSchemaHandle& handle,
+          const SegmentInternalInterface* seg,
+          int64_t N,
+          const std::string& expr) {
+    auto bin = handle.ParseSearch(
+        expr, "vec", 5, knowhere::metric::L2, R"({"nprobe":10})", 3);
+    auto plan = CreateSearchPlanByExpr(schema, bin.data(), bin.size());
+    return ExecuteQueryExpr(
+        plan->plan_node_->plannodes_->sources()[0]->sources()[0],
+        seg,
+        N,
+        MAX_TIMESTAMP);
+}
+
+// RAII guard so the global segcore flag is always restored, even on failure.
+struct GISSplitFusionGuard {
+    explicit GISSplitFusionGuard(bool enable) {
+        SegcoreConfig::default_config().set_enable_gis_split_fusion(enable);
+    }
+    ~GISSplitFusionGuard() {
+        SegcoreConfig::default_config().set_enable_gis_split_fusion(false);
+    }
+};
+
+// RAII guard for the geometry-cache flag. Must be set BEFORE the segment is
+// loaded, because the cache is populated at field-load time
+// (ChunkedSegmentSealedImpl::LoadFieldData).
+struct GeometryCacheGuard {
+    explicit GeometryCacheGuard(bool enable) {
+        SegcoreConfig::default_config().set_enable_geometry_cache(enable);
+    }
+    ~GeometryCacheGuard() {
+        SegcoreConfig::default_config().set_enable_geometry_cache(false);
+    }
+};
+
+// Filter shapes exercised by every equivalence test below.
+const std::vector<std::string>&
+EquivExprs() {
+    static const std::vector<std::string> exprs = {
+        // (1) single GIS leaf under AND with a scalar predicate
+        R"expr(age >= 0 and st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))"))expr",
+        // (2) OR-group of same-field GIS under AND (Shape B)
+        R"expr(age >= 0 and (st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))") or st_intersects(geo, "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))")))expr",
+        // (3) same-field AND group (intersects + within)
+        R"expr(st_intersects(geo, "POLYGON((-50 -50, 50 -50, 50 50, -50 50, -50 -50))") and st_within(geo, "POLYGON((-100 -100, 100 -100, 100 100, -100 100, -100 -100))"))expr",
+        // (4) within op combined with a scalar predicate
+        R"expr(age >= 0 and st_within(geo, "POLYGON((-100 -100, 100 -100, 100 100, -100 100, -100 -100))"))expr",
+        // (5) three same-field predicates mixed with a scalar
+        R"expr(age >= 0 and st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))") and st_within(geo, "POLYGON((-100 -100, 100 -100, 100 100, -100 100, -100 -100))"))expr",
+        // (6) single GIS only (no conjunction -> fusion must be a no-op)
+        R"expr(st_intersects(geo, "POINT(0 0)"))expr",
+    };
+    return exprs;
+}
+
+// For each shape, assert the fusion-ON bitset equals the fusion-OFF baseline on
+// the SAME segment (so any geometry-cache state is shared between the two runs).
+void
+AssertFusionEquivalence(const std::shared_ptr<Schema>& schema,
+                        ScopedSchemaHandle& handle,
+                        const SegmentInternalInterface* seg,
+                        int64_t N) {
+    for (const auto& e : EquivExprs()) {
+        BitsetType baseline;
+        BitsetType fused;
+        {
+            GISSplitFusionGuard off(false);
+            baseline = RunFilter(schema, handle, seg, N, e);
+        }
+        {
+            GISSplitFusionGuard on(true);
+            fused = RunFilter(schema, handle, seg, N, e);
+        }
+
+        ASSERT_EQ(baseline.size(), fused.size())
+            << "size mismatch, expr: " << e;
+        ASSERT_EQ(baseline.size(), static_cast<size_t>(N));
+        for (int64_t i = 0; i < static_cast<int64_t>(baseline.size()); ++i) {
+            ASSERT_EQ(baseline[i], fused[i])
+                << "row " << i << " differs, expr: " << e;
+        }
+    }
+}
+
+std::shared_ptr<Schema>
+MakeGISSchema() {
+    auto schema = std::make_shared<Schema>();
+    auto pk_fid = schema->AddDebugField("pk", DataType::INT64);
+    schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->AddDebugField("age", DataType::INT64);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    schema->set_primary_field_id(pk_fid);
+    return schema;
+}
+
+}  // namespace
+
+TEST(GISCoarseRefineExprTest, EquivalenceFusionOnVsOff) {
+    auto schema = MakeGISSchema();
+    const int64_t N = 1000;
+    auto dataset = DataGen(schema, N);
+    auto seg = CreateSealedWithFieldDataLoaded(schema, dataset);
+    ScopedSchemaHandle handle(*schema);
+
+    AssertFusionEquivalence(schema, handle, seg.get(), N);
+}
+
+// Same equivalence, but with enableGeometryCache ON so the segment is loaded
+// with a populated geometry cache. This exercises the Refine node's
+// cache-backed branch (PhyGISRefineConjunctExpr::Eval `if (geometry_cache)`),
+// which the cache-off test cannot reach. The optimization must be orthogonal to
+// the cache (design doc section 9).
+TEST(GISCoarseRefineExprTest, EquivalenceFusionWithGeometryCache) {
+    GeometryCacheGuard cache_on(true);  // set BEFORE loading the segment
+
+    auto schema = MakeGISSchema();
+    const int64_t N = 1000;
+    auto dataset = DataGen(schema, N);
+    auto seg = CreateSealedWithFieldDataLoaded(schema, dataset);
+    ScopedSchemaHandle handle(*schema);
+
+    // Sanity: the cache must actually be populated, otherwise the Refine node
+    // would silently fall back to the WKB path and this test would not cover
+    // the cache branch it is meant to lock down.
+    auto geo_fid = schema->get_field_id(FieldName("geo"));
+    ASSERT_NE(milvus::exec::SimpleGeometryCacheManager::Instance().GetCache(
+                  seg->get_segment_id(), geo_fid),
+              nullptr);
+
+    AssertFusionEquivalence(schema, handle, seg.get(), N);
+}

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -233,8 +233,10 @@ TEST(GISCoarseRefineExprTest, EquivalenceFusionNullableGeometry) {
 // Equivalence on a GROWING segment. The baseline GIS path takes different
 // data-type branches for growing vs. sealed segments (std::string vs.
 // std::string_view chunk access), so the sealed-only tests above cannot lock
-// down the growing path. No R-Tree index exists on a growing segment, so this
-// also covers the Coarse node's "no index -> full coarse set" degenerate path.
+// down the growing path. This variant uses empty_index_meta, so no geometry
+// index is created and it covers the Coarse node's "no index -> full coarse
+// set" degenerate path; growing WITH a geometry R-Tree is covered separately
+// below.
 TEST(GISCoarseRefineExprTest, EquivalenceFusionGrowingSegment) {
     auto schema = MakeGISSchema();
     const int64_t N = 1000;

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -25,7 +25,9 @@
 #include "common/Common.h"
 #include "common/Consts.h"
 #include "common/GeometryCache.h"
+#include "common/IndexMeta.h"
 #include "exec/QueryContext.h"
+#include "index/Meta.h"
 #include "exec/expression/Expr.h"
 #include "plan/PlanNode.h"
 #include "common/Schema.h"
@@ -244,6 +246,57 @@ TEST(GISCoarseRefineExprTest, EquivalenceFusionGrowingSegment) {
     ScopedSchemaHandle handle(*schema);
 
     AssertFusionEquivalence(schema, handle, seg.get(), N);
+}
+
+// Equivalence on a GROWING segment that DOES carry a geometry R-Tree index.
+// FieldIndexing creates the growing geometry index whenever the collection
+// index meta has the field, and HasIndex() flips true once ingested rows are
+// synced into it -- so "growing never has a geometry index" does NOT hold.
+// This is the production shape for freshly ingested geo data and the only
+// shape where the R-Tree Query() bitmap (sized by rows appended to the index)
+// can be larger than active_count_ (MVCC-visible rows): RunRTreeQuery must
+// normalize the index-sized bitmap into active_count_ space instead of
+// feeding it to a size-checked bitwise combine (a bare assert() compiled out
+// under NDEBUG). Runs equivalence at full visibility AND with
+// active_count < index rows to pin the normalization down.
+TEST(GISCoarseRefineExprTest, EquivalenceFusionGrowingSegmentWithRTreeIndex) {
+    auto schema = MakeGISSchema();
+    const int64_t N = 1000;
+    auto dataset = DataGen(schema, N);
+
+    auto geo_fid = schema->get_field_id(FieldName("geo"));
+    std::map<FieldId, FieldIndexMeta> field_metas;
+    field_metas.emplace(geo_fid,
+                        FieldIndexMeta(geo_fid,
+                                       {{knowhere::meta::INDEX_TYPE,
+                                         milvus::index::RTREE_INDEX_TYPE}},
+                                       {}));
+    auto index_meta = std::make_shared<CollectionIndexMeta>(
+        /*max_index_row_cnt=*/N * 2, std::move(field_metas));
+
+    // The growing load path only appends into the indexing record when the
+    // interim segment index is enabled; use a local copy so the global default
+    // config is untouched.
+    SegcoreConfig config = SegcoreConfig::default_config();
+    config.set_enable_interim_segment_index(true);
+    auto seg =
+        CreateGrowingWithFieldDataLoaded(schema, index_meta, config, dataset);
+    ScopedSchemaHandle handle(*schema);
+
+    // Sanity: the growing segment must actually report a synced geometry
+    // index, otherwise this degenerates into the no-index growing test above.
+    auto geo_field_id = schema->get_field_id(FieldName("geo"));
+    ASSERT_TRUE(seg->HasIndex(geo_field_id))
+        << "growing segment did not build/sync the geometry R-Tree index";
+
+    // Full visibility: active_count == rows in the index.
+    AssertFusionEquivalence(schema, handle, seg.get(), N);
+
+    // Partial visibility: active_count < rows in the index -- the concurrent
+    // ingestion shape (the insert path appends to the index before acking
+    // rows; a query ts below the newest inserts lowers active_count too).
+    // RunRTreeQuery must slice its index-sized bitmap down to active_count_.
+    AssertFusionEquivalence(schema, handle, seg.get(), N - 137);
 }
 
 // Equivalence with a small expr batch size, so a single N=1000 segment is

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -126,6 +126,21 @@ EquivExprs() {
         // independent coarse/refine pairs for that field, so this dual-pair
         // path is the trickiest one -- pin it down with an ON-vs-OFF case.
         R"expr(st_within(geo, "POLYGON((-100 -100, 100 -100, 100 100, -100 100, -100 -100))") and (st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))") or st_intersects(geo, "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))")))expr",
+        // (10) DWithin mixed with a groupable GIS leaf on the SAME field.
+        // DWithin must stay on the baseline path: the fusion group drops its
+        // distance (Pred carries none, EvalPrepared hardcodes 0.0) and
+        // RunRTreeQuery skips the coarse bbox expansion
+        // (create_bounding_box_for_dwithin), so a grouped DWithin would
+        // silently under-match -- the quiet failure mode the as_groupable_gis
+        // whitelist exists to prevent, pinned here so a future whitelist edit
+        // fails this equivalence instead of going green. Unlike shape (8),
+        // the baseline leaf here also queries the R-Tree, so this is the one
+        // shape where an R-Tree-pinning baseline node and the split pair
+        // coexist on one field. The 5,000,000 m geodesic radius matches a
+        // meaningful minority of the globally-spread DataGen rows, keeping
+        // the shape discriminating (a ~10 m radius would select nothing and
+        // the ON-vs-OFF comparison would degenerate to 0 == 0).
+        R"expr(st_dwithin(geo, "POINT(0 0)", 5000000) and st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))"))expr",
     };
     return exprs;
 }

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -78,7 +78,9 @@ struct GISSplitFusionGuard {
 // Captures what ~GISGroupState reports -- the same two counters the
 // internal_core_gis_{coarse,refine}_ratio metrics carry -- so a test can assert
 // the pruning contract itself instead of only the result bits, which are
-// identical whether or not Refine prunes. One snapshot per group per segment.
+// identical whether or not Refine prunes. Incomplete/bypassed groups produce no
+// snapshot, matching production metric suppression. One snapshot per completed
+// group per segment.
 struct GISGroupStateCapture {
     struct Snapshot {
         int64_t active_count;
@@ -166,7 +168,37 @@ EquivExprs() {
         // the shape discriminating (a ~10 m radius would select nothing and
         // the ON-vs-OFF comparison would degenerate to 0 == 0).
         R"expr(st_dwithin(geo, "POINT(0 0)", 5000000) and st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))"))expr",
-        // (11) SELECTIVE scalar upstream. Every `age >= 0` above selects all N
+        // (11)-(15) The remaining whitelisted operators. Shapes above cover
+        // only Intersects and Within, but as_groupable_gis whitelists seven
+        // (Equals/Touches/Overlaps/Crosses/Contains/Intersects/Within,
+        // Expr.cpp). Both paths run the SAME EvaluateGISPreparedOp for refine
+        // and the SAME R-Tree Query(ds) for coarse, so per-operator divergence
+        // is impossible by construction TODAY -- these are a regression
+        // tripwire for a future whitelist or shared-helper edit, not a
+        // live-defect check. Each is a single groupable leaf under AND so it
+        // splits, mirroring shape (1).
+        // (11) st_contains: a generated polygon enclosing the origin contains
+        // the query point.
+        R"expr(age >= 0 and st_contains(geo, "POINT(0 0)"))expr",
+        // (12) st_overlaps: partial same-dimension overlap with a large box.
+        R"expr(age >= 0 and st_overlaps(geo, "POLYGON((-50 -50, 50 -50, 50 50, -50 50, -50 -50))"))expr",
+        // (13) st_crosses: a generated LINESTRING crossing the box boundary.
+        R"expr(age >= 0 and st_crosses(geo, "POLYGON((-50 -50, 50 -50, 50 50, -50 50, -50 -50))"))expr",
+        // (14) st_touches: boundary-only contact -- typically empty on random
+        // data, kept as the Touches-case tripwire.
+        R"expr(age >= 0 and st_touches(geo, "POLYGON((-50 -50, 50 -50, 50 50, -50 50, -50 -50))"))expr",
+        // (15) st_equals: exact equality -- effectively empty on random data,
+        // kept as the Equals-case tripwire.
+        R"expr(age >= 0 and st_equals(geo, "POINT(0 0)"))expr",
+        // (16) OR-ROOTED split. SplitFuseGISConjunct bails on a non-AND root,
+        // but ReorderConjunctExpr still recurses into the AND child of an OR and
+        // splits the same-field group there (Expr.cpp). Every other shape here
+        // is AND-rooted; this pins that a split emitted BENEATH an OR stays
+        // ON/OFF-equivalent -- the split nodes' all-ones validity is never
+        // inverted because the recursion provably does not cross a NOT. The
+        // `age >= 950` arm keeps the OR non-degenerate (50 of N=1000 rows).
+        R"expr(age >= 950 or (st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))") and st_within(geo, "POLYGON((-100 -100, 100 -100, 100 100, -100 100, -100 -100))")))expr",
+        // (17) SELECTIVE scalar upstream. Every `age >= 0` above selects all N
         // rows: DataGen fills a non-random INT64 field with `data[i] = i /
         // repeat_count` and repeat_count defaults to 1 (DataGen.h), so the
         // predicate is a tautology and `survivors &= pre` in the Refine node
@@ -341,6 +373,54 @@ TEST(GISCoarseRefineExprTest, EquivalenceFusionOnVsOff) {
     ScopedSchemaHandle handle(*schema);
 
     AssertFusionEquivalence(schema, handle, seg.get(), N);
+}
+
+// FilterBits constructs ExprSet before its result-cache lookup, so a cache hit
+// can destroy a GISGroupState that never executed. Cancellation/error paths can
+// likewise destroy a partially initialized state. Neither case has final
+// segment-level ratios and therefore must not report.
+TEST(GISCoarseRefineExprTest, IncompleteStateDoesNotReportMetrics) {
+    GISGroupStateCapture capture;
+    {
+        auto state = std::make_shared<milvus::exec::GISGroupState>();
+        state->active_count = 100;
+    }
+    {
+        auto state = std::make_shared<milvus::exec::GISGroupState>();
+        state->active_count = 100;
+        state->coarse_done = true;
+        state->coarse_cursor_complete = true;
+        state->coarse_selected = 40;
+        state->refined_rows = 10;
+        // Simulate cancellation after only part of Refine ran.
+        state->refine_cursor_complete = false;
+    }
+    EXPECT_TRUE(capture.snapshots.empty());
+}
+
+// A successful query can also bypass the GIS nodes: numeric predicates run
+// before the indexed Coarse bucket, and an empty active bitmap advances the GIS
+// cursors through SkipFollowingExprs without ever computing B_coarse. Reporting
+// the default 0/active_count counters would look like perfect R-Tree pruning.
+TEST(GISCoarseRefineExprTest, FullyShortCircuitedGroupDoesNotReportMetrics) {
+    ExprBatchSizeGuard batch_guard(128);
+    auto schema = MakeGISSchema();
+    const int64_t N = 1000;
+    auto dataset = DataGen(schema, N);
+    auto seg = CreateSealedWithFieldDataLoaded(schema, dataset);
+    ScopedSchemaHandle handle(*schema);
+
+    GISGroupStateCapture capture;
+    GISSplitFusionGuard on(true);
+    auto res = RunFilter(
+        schema,
+        handle,
+        seg.get(),
+        N,
+        R"expr(age < 0 and st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))"))expr");
+
+    EXPECT_EQ(res.count(), 0u);
+    EXPECT_TRUE(capture.snapshots.empty());
 }
 
 // ON-vs-OFF equivalence is blind to how much work Refine does -- making it
@@ -551,4 +631,55 @@ TEST(GISCoarseRefineExprTest, GISDoesNotSupportOffsetInput) {
                 << "fusion ON, expr: " << e;
         }
     }
+}
+
+// NOTE (2.6): master adds GISSplitStaysBatchedNotAllAtOnce here, pinning that
+// the split conjunction never becomes all-at-once eligible (which would let
+// Refine bulk_subscript the whole WKB column in one Eval and OOM the
+// QueryNode). 2.6 has no all-at-once path at all -- neither
+// CanExecuteAllAtOnce() nor SetExecuteAllAtOnce() exists on Expr -- so every
+// expression is batched unconditionally and there is nothing to pin. The test
+// comes back with that machinery.
+
+// Coarse intersects its emitted slice with bitmap_input so an OUTER conjunction's
+// mask prunes the split group even when it is NESTED (Coarse is the only node
+// that sees the outer mask before the inner accumulator overwrites it; Refine
+// then inherits the narrowed mask). The equivalence tests are blind to this --
+// the recombined result is identical whether or not Coarse consumes the mask --
+// so it is pinned here through refined_rows: an OR whose left arm settles some
+// rows TRUE must keep Refine from evaluating those rows in the nested GIS group.
+TEST(GISCoarseRefineExprTest, NestedOuterMaskPrunesRefine) {
+    auto schema = MakeGISSchema();
+    const int64_t N = 1000;
+    auto dataset = DataGen(schema, N);
+    auto seg = CreateSealedWithFieldDataLoaded(schema, dataset);
+    ScopedSchemaHandle handle(*schema);
+
+    // OR root: age >= 950 settles ~50 rows TRUE, so the nested same-field GIS
+    // AND-group receives them masked OFF via bitmap_input. With no R-Tree here
+    // B_coarse is all-ones (coarse_selected == N), so a Refine that ignored the
+    // outer mask would evaluate all N rows; consuming it drops the settled rows,
+    // making refined_rows strictly less than coarse_selected. The world-covering
+    // query polygons keep B_coarse all-ones regardless of geometry shape, so the
+    // arithmetic depends only on the outer mask.
+    const char* nested =
+        R"expr(age >= 950 or (st_intersects(geo, "POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))") and st_within(geo, "POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))")))expr";
+
+    GISGroupStateCapture capture;
+    GISSplitFusionGuard on(true);
+    auto res = RunFilter(schema, handle, seg.get(), N, nested);
+    ASSERT_EQ(capture.snapshots.size(), 1u)
+        << "expected exactly one GIS split-fusion group for the nested shape";
+    const auto& s = capture.snapshots.front();
+    EXPECT_EQ(s.active_count, N);
+    // No R-Tree on geo -> coarse degenerates to all-ones.
+    EXPECT_EQ(s.coarse_selected, N);
+    EXPECT_GT(s.refined_rows, 0);
+    // Without the Coarse bitmap_input intersect this equals coarse_selected (N):
+    // Refine would build geometries for the age >= 950 rows the OR already
+    // settled.
+    EXPECT_LT(s.refined_rows, s.coarse_selected)
+        << "Coarse dropped the outer bitmap_input; Refine evaluated all of "
+           "B_coarse (refined_rows "
+        << s.refined_rows << " == coarse_selected " << s.coarse_selected << ")";
 }

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -29,6 +29,7 @@
 #include "exec/QueryContext.h"
 #include "index/Meta.h"
 #include "exec/expression/Expr.h"
+#include "exec/expression/GISConjunctExpr.h"
 #include "plan/PlanNode.h"
 #include "common/Schema.h"
 #include "common/Types.h"
@@ -71,6 +72,30 @@ struct GISSplitFusionGuard {
     }
     ~GISSplitFusionGuard() {
         SegcoreConfig::default_config().set_enable_gis_split_fusion(false);
+    }
+};
+
+// Captures what ~GISGroupState reports -- the same two counters the
+// internal_core_gis_{coarse,refine}_ratio metrics carry -- so a test can assert
+// the pruning contract itself instead of only the result bits, which are
+// identical whether or not Refine prunes. One snapshot per group per segment.
+struct GISGroupStateCapture {
+    struct Snapshot {
+        int64_t active_count;
+        int64_t coarse_selected;
+        int64_t refined_rows;
+    };
+    std::vector<Snapshot> snapshots;
+
+    GISGroupStateCapture() {
+        milvus::exec::SetGISGroupStateObserverForTest(
+            [this](const milvus::exec::GISGroupState& st) {
+                snapshots.push_back(
+                    {st.active_count, st.coarse_selected, st.refined_rows});
+            });
+    }
+    ~GISGroupStateCapture() {
+        milvus::exec::SetGISGroupStateObserverForTest(nullptr);
     }
 };
 
@@ -169,6 +194,7 @@ AssertSelectiveShapeIsDiscriminating(const std::shared_ptr<Schema>& schema,
                                      const SegmentInternalInterface* seg,
                                      int64_t N) {
     const auto& e = EquivExprs().back();
+    GISGroupStateCapture capture;
     GISSplitFusionGuard on(true);
     auto res = RunFilter(schema, handle, seg, N, e);
     ASSERT_EQ(res.size(), static_cast<size_t>(N));
@@ -180,11 +206,88 @@ AssertSelectiveShapeIsDiscriminating(const std::shared_ptr<Schema>& schema,
         << "selective shape selected every row, the scalar mask is not "
            "pruning: "
         << e;
-    // The scalar predicate alone bounds the result: rows with age < threshold
-    // can never survive, so anything above this means the mask was dropped.
+    // The scalar predicate alone bounds the RESULT. This says nothing about
+    // whether Refine pruned -- the outer conjunction re-ANDs `age >= 900`
+    // anyway, so it holds even for a Refine that exact-evaluates every active
+    // row. It only pins that the shape stays selective.
     EXPECT_LE(hits, static_cast<size_t>(N - kSelectiveAgeThreshold))
-        << "more rows survived than the scalar predicate admits; "
-           "`survivors &= pre` is not being applied";
+        << "more rows survived than the scalar predicate admits, so the shape "
+           "is no longer selective: "
+        << e;
+
+    // The part the result bits cannot show: how many rows Refine actually
+    // built a geometry for. Dropping `survivors &= pre` or
+    // `survivors &= coarse_slice` (GISConjunctExpr.cpp) leaves every result
+    // bit identical and is visible ONLY here.
+    ASSERT_EQ(capture.snapshots.size(), 1u)
+        << "expected exactly one GIS split-fusion group for shape: " << e;
+    const auto& s = capture.snapshots.front();
+    EXPECT_EQ(s.active_count, N);
+    EXPECT_GT(s.refined_rows, 0)
+        << "Refine evaluated nothing; the split path did not run";
+    EXPECT_LE(s.refined_rows, N - kSelectiveAgeThreshold)
+        << "Refine evaluated more rows than the scalar mask admits ("
+        << s.refined_rows << " > " << (N - kSelectiveAgeThreshold)
+        << "); `survivors &= pre` is not reaching Refine";
+    EXPECT_LE(s.refined_rows, s.coarse_selected)
+        << "Refine evaluated more rows than B_coarse selected ("
+        << s.refined_rows << " > " << s.coarse_selected
+        << "); `survivors &= coarse_slice` is not reaching Refine";
+    // Every selected row must have been refined: the result is a subset of
+    // what Refine looked at.
+    EXPECT_GE(static_cast<size_t>(s.refined_rows), hits)
+        << "result has rows Refine never evaluated";
+}
+
+// The coarse half of the pruning contract, on a segment with a REAL R-Tree
+// (elsewhere in this file coarse_candidates is all-ones, so there is nothing to
+// observe). The scalar predicate is deliberately tautological (`age >= 0`), so
+// B_coarse is the only thing that can prune and the refine bound below cannot
+// be satisfied via the scalar mask instead.
+//
+// What this pins: that the R-Tree coarse pass really ran and really narrowed
+// the candidate set (a degrade to all-ones returns correct results and would
+// otherwise be invisible), and that Refine evaluated no more rows than
+// B_coarse admitted.
+//
+// What it deliberately does NOT pin: the `survivors &= coarse_slice` line in
+// PhyGISRefineConjunctExpr. That AND is redundant while Coarse is bucketed
+// ahead of Refine -- B_coarse reaches Refine through bitmap_input either way --
+// so deleting it leaves both the result bits and refined_rows unchanged.
+// Verified by deleting it: the entire suite, these assertions included, stays
+// green. See the comment at that line.
+constexpr const char* kCoarsePruningExpr =
+    R"expr(age >= 0 and st_intersects(geo, "POLYGON((-50 -50, 50 -50, 50 50, -50 50, -50 -50))"))expr";
+
+void
+AssertCoarseMaskActuallyPrunes(const std::shared_ptr<Schema>& schema,
+                               ScopedSchemaHandle& handle,
+                               const SegmentInternalInterface* seg,
+                               int64_t N) {
+    GISGroupStateCapture capture;
+    GISSplitFusionGuard on(true);
+    auto res = RunFilter(schema, handle, seg, N, kCoarsePruningExpr);
+    ASSERT_EQ(capture.snapshots.size(), 1u)
+        << "expected exactly one GIS split-fusion group";
+    const auto& s = capture.snapshots.front();
+    ASSERT_EQ(s.active_count, N);
+    // The R-Tree must have answered. A coarse bitmap that degenerated to
+    // all-ones (pin failure, index mid-load) still returns correct results, so
+    // nothing else in this file would notice -- and it would make the refine
+    // bound below vacuous.
+    EXPECT_GT(s.coarse_selected, 0)
+        << "B_coarse selected nothing; the shape no longer discriminates";
+    EXPECT_LT(s.coarse_selected, N)
+        << "B_coarse selected every row: the R-Tree coarse pass degraded to "
+           "all-ones, so pruning is gone even though results stay correct";
+    EXPECT_GT(s.refined_rows, 0)
+        << "Refine evaluated nothing; the split path did not run";
+    EXPECT_LE(s.refined_rows, s.coarse_selected)
+        << "Refine evaluated more rows than B_coarse selected ("
+        << s.refined_rows << " > " << s.coarse_selected
+        << "); `survivors &= coarse_slice` is not reaching Refine";
+    EXPECT_GE(static_cast<size_t>(s.refined_rows), res.count())
+        << "result has rows Refine never evaluated";
 }
 
 // For each shape, assert the fusion-ON bitset equals the fusion-OFF baseline on
@@ -367,6 +470,10 @@ TEST(GISCoarseRefineExprTest, EquivalenceFusionGrowingSegmentWithRTreeIndex) {
 
     // Full visibility: active_count == rows in the index.
     AssertFusionEquivalence(schema, handle, seg.get(), N);
+
+    // This is the only segment in this file with a real R-Tree, so it is the
+    // only place the coarse half of the pruning contract is observable.
+    AssertCoarseMaskActuallyPrunes(schema, handle, seg.get(), N);
 
     // Partial visibility: active_count < rows in the index -- the concurrent
     // ingestion shape (the insert path appends to the index before acking

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -141,8 +141,50 @@ EquivExprs() {
         // the shape discriminating (a ~10 m radius would select nothing and
         // the ON-vs-OFF comparison would degenerate to 0 == 0).
         R"expr(st_dwithin(geo, "POINT(0 0)", 5000000) and st_intersects(geo, "POLYGON((-5 -5, 5 -5, 5 5, -5 5, -5 -5))"))expr",
+        // (11) SELECTIVE scalar upstream. Every `age >= 0` above selects all N
+        // rows: DataGen fills a non-random INT64 field with `data[i] = i /
+        // repeat_count` and repeat_count defaults to 1 (DataGen.h), so the
+        // predicate is a tautology and `survivors &= pre` in the Refine node
+        // (GISConjunctExpr.cpp) is a permanent no-op in the scalar direction.
+        // This shape makes the scalar mask actually prune, so the AND of
+        // scalars and B_coarse is exercised for real.
+        // Kept in sync with kSelectiveAgeThreshold below.
+        R"expr(age >= 900 and st_intersects(geo, "POLYGON((-50 -50, 50 -50, 50 50, -50 50, -50 -50))"))expr",
     };
     return exprs;
+}
+
+// Row threshold used by shape (11); with the standard N=1000 segments in this
+// file it leaves 100 of 1000 rows for Refine.
+constexpr int64_t kSelectiveAgeThreshold = 900;
+
+// Shape (11)'s scalar mask only proves anything if it is genuinely selective
+// AND the geometry predicate keeps some of what survives. Pin both ends:
+// a result of 0 or N would make the ON-vs-OFF comparison degenerate to
+// "0 == 0" / "all == all" and stop discriminating, exactly like the
+// tautological `age >= 0` shapes it was added to compensate for.
+void
+AssertSelectiveShapeIsDiscriminating(const std::shared_ptr<Schema>& schema,
+                                     ScopedSchemaHandle& handle,
+                                     const SegmentInternalInterface* seg,
+                                     int64_t N) {
+    const auto& e = EquivExprs().back();
+    GISSplitFusionGuard on(true);
+    auto res = RunFilter(schema, handle, seg, N, e);
+    ASSERT_EQ(res.size(), static_cast<size_t>(N));
+    auto hits = res.count();
+    EXPECT_GT(hits, 0u) << "selective shape selected nothing, it no longer "
+                           "discriminates: "
+                        << e;
+    EXPECT_LT(hits, static_cast<size_t>(N))
+        << "selective shape selected every row, the scalar mask is not "
+           "pruning: "
+        << e;
+    // The scalar predicate alone bounds the result: rows with age < threshold
+    // can never survive, so anything above this means the mask was dropped.
+    EXPECT_LE(hits, static_cast<size_t>(N - kSelectiveAgeThreshold))
+        << "more rows survived than the scalar predicate admits; "
+           "`survivors &= pre` is not being applied";
 }
 
 // For each shape, assert the fusion-ON bitset equals the fusion-OFF baseline on
@@ -196,6 +238,23 @@ TEST(GISCoarseRefineExprTest, EquivalenceFusionOnVsOff) {
     ScopedSchemaHandle handle(*schema);
 
     AssertFusionEquivalence(schema, handle, seg.get(), N);
+}
+
+// ON-vs-OFF equivalence is blind to how much work Refine does -- making it
+// evaluate every active row keeps every result bit identical. It is equally
+// blind to an over-inclusive (even all-ones) coarse bitmap, because Refine
+// re-evaluates the exact predicate and the conjunction ANDs once more at the
+// end. So equivalence alone cannot tell "pruning works" from "pruning silently
+// degraded to a full scan". This pins the one part that IS observable from
+// outside the operator: the scalar mask must actually reach Refine.
+TEST(GISCoarseRefineExprTest, SelectiveScalarMaskActuallyPrunes) {
+    auto schema = MakeGISSchema();
+    const int64_t N = 1000;
+    auto dataset = DataGen(schema, N);
+    auto seg = CreateSealedWithFieldDataLoaded(schema, dataset);
+    ScopedSchemaHandle handle(*schema);
+
+    AssertSelectiveShapeIsDiscriminating(schema, handle, seg.get(), N);
 }
 
 // Same equivalence, but with enableGeometryCache ON so the segment is loaded

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -39,7 +39,24 @@ PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
     // constructor (InitSegmentExpr), so there is no EnsurePinnedIndex() to call
     // here -- pinned_index_/num_index_chunk_ are already populated.
     using Index = index::ScalarIndex<std::string>;
-    AssertInfo(num_index_chunk_ == 1, "num_index_chunk_ should be 1");
+
+    // p.has_index was sampled at compile time from segment_->HasIndex(), but
+    // HasIndex() can report true while the index is still mid-load, so the
+    // eager pin may have yielded nothing (num_index_chunk_ != 1) or a non-string
+    // index (the dynamic_cast below returns nullptr). Unlike the baseline
+    // DetermineExecPath(), this coarse path has no RawData fallback, so guard
+    // both here and degrade to an all-set coarse bitmap in that window -- the
+    // same behavior as the no-index path (p.has_index == false). The Refine
+    // node still evaluates the exact predicate, so results stay correct; we
+    // only lose R-Tree pruning for this segment while the index warms up.
+    const Index* scalar_index =
+        (num_index_chunk_ == 1 && !pinned_index_.empty())
+            ? dynamic_cast<const Index*>(pinned_index_[0].get())
+            : nullptr;
+    if (scalar_index == nullptr) {
+        p.coarse = TargetBitmap(active_count_, true);
+        return;
+    }
 
     // GEOS objects are bound to the per-thread context.
     GEOSContextHandle_t ctx = GetThreadLocalGEOSContext();
@@ -49,7 +66,6 @@ PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
     ds->Set(milvus::index::OPERATOR_TYPE, p.op);
     ds->Set(milvus::index::MATCH_VALUE, query_geom);
 
-    auto scalar_index = dynamic_cast<const Index*>(pinned_index_[0].get());
     auto* idx_ptr = const_cast<Index*>(scalar_index);
     auto tmp = idx_ptr->Query(ds);
     p.coarse = std::move(tmp);
@@ -219,9 +235,11 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
         } else {
             // No geometry cache: fetch WKB once and construct each row geometry
             // ONCE, then evaluate all predicates against it (the K->1 win).
-            milvus::OpContext op_ctx;
+            // Thread the SegmentExpr's op_ctx_ (from qc->get_op_context()) so
+            // tracing and tiered-storage accounting are preserved, matching the
+            // other data-fetch paths in this expr rather than a bare local one.
             auto data_array = segment_->bulk_subscript(
-                &op_ctx, st_->field_id, hit_abs.data(), hit_abs.size());
+                op_ctx_, st_->field_id, hit_abs.data(), hit_abs.size());
             auto geometry_array =
                 static_cast<const milvus::proto::schema::GeometryArray*>(
                     &data_array->scalars().geometry_data());

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -80,6 +80,11 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
             } else {
                 cand |= p.coarse;
             }
+            // p.coarse has been merged into cand and is never read again; the
+            // Refine node consumes the combined coarse_candidates, not the
+            // per-predicate bitmaps. Release it now so we don't hold one extra
+            // active_count_-bit bitmap per predicate for the whole query life.
+            p.coarse = TargetBitmap{};
         }
         st_->coarse_candidates =
             std::make_shared<TargetBitmap>(std::move(cand));
@@ -89,13 +94,19 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
     // Phase 2: emit slice [current_pos_, +real_batch_size).
     TargetBitmap out;
     out.append(*st_->coarse_candidates, current_pos_, real_batch_size);
-    // valid is all-ones intentionally (see also the Refine node): split is only
-    // applied INSIDE a pure conjunction chain (ReorderConjunctExpr recurses only
-    // into PhyConjunctFilterExpr; NOT compiles to PhyLogicalUnaryExpr), and the
-    // three-valued And/Or result bits never consume `valid` (only Not does).
-    // Geometry null rows keep their res bit false on both the baseline and the
-    // split path, so the selection set is identical even though `valid` here
-    // diverges from the baseline's not-null bitmap. See PR #50675 review.
+    // valid is all-ones intentionally (see also the Refine node). PRECONDITION:
+    // these split nodes NEVER sit under a NOT and "null == not-selected" for
+    // them. This holds because split is only applied INSIDE a pure conjunction
+    // chain (ReorderConjunctExpr recurses only into PhyConjunctFilterExpr; NOT
+    // compiles to PhyLogicalUnaryExpr), and because SupportOffsetInput() returns
+    // false so the offset-input path never reorders them either. Under that
+    // precondition the three-valued And/Or result bits never consume `valid`
+    // (only Not does), and geometry null rows keep their res bit false on both
+    // the baseline and the split path -- so the selection set is identical even
+    // though `valid` here diverges from the baseline's not-null bitmap. If a
+    // split group could ever land under a NOT, this all-ones `valid` would
+    // wrongly select null rows and must be replaced by the real not-null bitmap.
+    // See PR #50675 review.
     TargetBitmap valid(real_batch_size, true);
 
     MoveCursor();
@@ -129,10 +140,11 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
     const auto seg_offset = current_pos_;
 
     TargetBitmap res(real_batch_size, false);
-    // valid_res is all-ones intentionally; see the rationale on the Coarse
-    // node's `valid` above (split runs only inside pure conjunctions, where the
-    // result bits never consume `valid`, so this divergence from the baseline's
-    // not-null bitmap is unobservable in the selection set).
+    // valid_res is all-ones intentionally; see the PRECONDITION on the Coarse
+    // node's `valid` above (split runs only inside pure conjunctions and never
+    // under a NOT, so "null == not-selected" is safe and the result bits never
+    // consume `valid` -- this divergence from the baseline's not-null bitmap is
+    // unobservable in the selection set).
     TargetBitmap valid_res(real_batch_size, true);
 
     // Survivors = batch slice of (bitmap_input == scalars ∧ B_coarse) ∧ B_coarse.

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -64,7 +64,7 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
     }
 
     // Phase 1: build B_coarse once for the whole segment.
-    if (!st_->coarse_done.load()) {
+    if (!st_->coarse_done) {
         TargetBitmap cand(active_count_, st_->is_and);  // AND -> 1s / OR -> 0s
         for (auto& p : st_->preds) {
             if (p.has_index) {
@@ -83,12 +83,19 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
         }
         st_->coarse_candidates =
             std::make_shared<TargetBitmap>(std::move(cand));
-        st_->coarse_done.store(true);
+        st_->coarse_done = true;
     }
 
     // Phase 2: emit slice [current_pos_, +real_batch_size).
     TargetBitmap out;
     out.append(*st_->coarse_candidates, current_pos_, real_batch_size);
+    // valid is all-ones intentionally (see also the Refine node): split is only
+    // applied INSIDE a pure conjunction chain (ReorderConjunctExpr recurses only
+    // into PhyConjunctFilterExpr; NOT compiles to PhyLogicalUnaryExpr), and the
+    // three-valued And/Or result bits never consume `valid` (only Not does).
+    // Geometry null rows keep their res bit false on both the baseline and the
+    // split path, so the selection set is identical even though `valid` here
+    // diverges from the baseline's not-null bitmap. See PR #50675 review.
     TargetBitmap valid(real_batch_size, true);
 
     MoveCursor();
@@ -122,6 +129,10 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
     const auto seg_offset = current_pos_;
 
     TargetBitmap res(real_batch_size, false);
+    // valid_res is all-ones intentionally; see the rationale on the Coarse
+    // node's `valid` above (split runs only inside pure conjunctions, where the
+    // result bits never consume `valid`, so this divergence from the baseline's
+    // not-null bitmap is unobservable in the selection set).
     TargetBitmap valid_res(real_batch_size, true);
 
     // Survivors = batch slice of (bitmap_input == scalars ∧ B_coarse) ∧ B_coarse.

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -68,6 +68,27 @@ PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
 
     auto* idx_ptr = const_cast<Index*>(scalar_index);
     auto tmp = idx_ptr->Query(ds);
+    // Query() returns a bitmap sized index->Count() -- every row appended to
+    // the index -- while Eval combines it into a candidate bitmap sized
+    // active_count_, the MVCC-visible row count at the query timestamp. On a
+    // growing segment with a geometry index the two diverge (the ingest path
+    // appends to the index before acking rows, and a query ts below the
+    // newest inserts lowers active_count_ further), and TargetBitmap's
+    // operator&=/|= size check is a bare assert() that is compiled out under
+    // NDEBUG. Normalize into active_count_ space: keep the first
+    // active_count_ bits, and fail loudly if the index ever reports FEWER
+    // rows than are visible (that direction would silently drop candidates).
+    if (static_cast<int64_t>(tmp.size()) != active_count_) {
+        AssertInfo(static_cast<int64_t>(tmp.size()) >= active_count_,
+                   "R-Tree coarse bitmap has fewer rows than active rows: "
+                   "{} < {}",
+                   tmp.size(),
+                   active_count_);
+        TargetBitmap sliced;
+        sliced.append(tmp, 0, active_count_);
+        p.coarse = std::move(sliced);
+        return;
+    }
     p.coarse = std::move(tmp);
 }
 

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -76,18 +76,22 @@ PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
     // newest inserts lowers active_count_ further), and TargetBitmap's
     // operator&=/|= size check is a bare assert() that is compiled out under
     // NDEBUG. Normalize into active_count_ space: keep the first
-    // active_count_ bits, and fail loudly if the index ever reports FEWER
-    // rows than are visible (that direction would silently drop candidates).
-    if (static_cast<int64_t>(tmp.size()) != active_count_) {
-        AssertInfo(static_cast<int64_t>(tmp.size()) >= active_count_,
-                   "R-Tree coarse bitmap has fewer rows than active rows: "
-                   "{} < {}",
-                   tmp.size(),
-                   active_count_);
+    // active_count_ bits. The reverse direction -- the index reporting FEWER
+    // rows than are visible -- is unreachable today (SegmentGrowingImpl
+    // appends to the index before acking rows, so index rows >= active
+    // rows); if that invariant ever breaks, pad the un-indexed tail with 1s
+    // instead of failing the query: coarse ⊇ exact still holds and Refine
+    // evaluates the exact predicate, so results stay correct and we only
+    // lose R-Tree pruning for the tail -- same defensive posture as the
+    // pin-empty degrade above.
+    if (static_cast<int64_t>(tmp.size()) > active_count_) {
         TargetBitmap sliced;
         sliced.append(tmp, 0, active_count_);
         p.coarse = std::move(sliced);
         return;
+    }
+    if (static_cast<int64_t>(tmp.size()) < active_count_) {
+        tmp.resize(active_count_, /*init=*/true);
     }
     p.coarse = std::move(tmp);
 }

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -1,0 +1,226 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include "exec/expression/GISConjunctExpr.h"
+
+#include <vector>
+
+#include "common/EasyAssert.h"
+#include "common/GeometryCache.h"
+#include "common/OpContext.h"
+#include "common/Types.h"
+#include "exec/expression/GISFunctionFilterExpr.h"
+#include "geos_c.h"
+#include "index/Index.h"
+#include "index/Meta.h"
+#include "index/ScalarIndex.h"
+#include "knowhere/dataset.h"
+#include "pb/schema.pb.h"
+
+namespace milvus {
+namespace exec {
+
+// -------------------------------------------------------------------------
+// Coarse node: run each predicate's R-Tree query once (segment-level), combine
+// per is_and, cache, and emit the per-batch slice.
+// -------------------------------------------------------------------------
+void
+PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
+    // Mirrors PhyGISFunctionFilterExpr::EvalForIndexSegment's coarse query.
+    // NOTE: on 2.6 the scalar index is pinned eagerly in SegmentExpr's
+    // constructor (InitSegmentExpr), so there is no EnsurePinnedIndex() to call
+    // here -- pinned_index_/num_index_chunk_ are already populated.
+    using Index = index::ScalarIndex<std::string>;
+    AssertInfo(num_index_chunk_ == 1, "num_index_chunk_ should be 1");
+
+    // GEOS objects are bound to the per-thread context.
+    GEOSContextHandle_t ctx = GetThreadLocalGEOSContext();
+    Geometry query_geom(ctx, p.query_wkt.c_str());
+
+    auto ds = std::make_shared<milvus::Dataset>();
+    ds->Set(milvus::index::OPERATOR_TYPE, p.op);
+    ds->Set(milvus::index::MATCH_VALUE, query_geom);
+
+    auto scalar_index = dynamic_cast<const Index*>(pinned_index_[0].get());
+    auto* idx_ptr = const_cast<Index*>(scalar_index);
+    auto tmp = idx_ptr->Query(ds);
+    p.coarse = std::move(tmp);
+}
+
+void
+PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    auto real_batch_size = NextBatchSize();
+    if (real_batch_size == 0) {
+        result = nullptr;
+        return;
+    }
+
+    // Phase 1: build B_coarse once for the whole segment.
+    if (!st_->coarse_done.load()) {
+        TargetBitmap cand(active_count_, st_->is_and);  // AND -> 1s / OR -> 0s
+        for (auto& p : st_->preds) {
+            if (p.has_index) {
+                RunRTreeQuery(p);
+            } else {
+                // No R-Tree index: coarse degenerates to the full set; the
+                // Refine node still prunes via bitmap_input and fuses
+                // construction.
+                p.coarse = TargetBitmap(active_count_, true);
+            }
+            if (st_->is_and) {
+                cand &= p.coarse;
+            } else {
+                cand |= p.coarse;
+            }
+        }
+        st_->coarse_candidates =
+            std::make_shared<TargetBitmap>(std::move(cand));
+        st_->coarse_done.store(true);
+    }
+
+    // Phase 2: emit slice [current_pos_, +real_batch_size).
+    TargetBitmap out;
+    out.append(*st_->coarse_candidates, current_pos_, real_batch_size);
+    TargetBitmap valid(real_batch_size, true);
+
+    MoveCursor();
+    result = std::make_shared<ColumnVector>(std::move(out), std::move(valid));
+}
+
+// -------------------------------------------------------------------------
+// Refine node: consume bitmap_input, construct each surviving row's geometry
+// ONCE, evaluate ALL predicates against it (fusion).
+// -------------------------------------------------------------------------
+bool
+PhyGISRefineConjunctExpr::EvalPrepared(
+    proto::plan::GISFunctionFilterExpr_GISOp op,
+    const PreparedGeometry& prepared,
+    const Geometry& query_geom,
+    const Geometry& left) const {
+    // Delegate to the shared helper so the prepared-predicate semantics (the
+    // contains/within swap in particular) never drift from the per-predicate
+    // path. DWithin is filtered out before grouping, so distance is unused here.
+    return EvaluateGISPreparedOp(
+        op, prepared, query_geom, left, /*distance=*/0.0);
+}
+
+void
+PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    auto real_batch_size = NextBatchSize();
+    if (real_batch_size == 0) {
+        result = nullptr;
+        return;
+    }
+    const auto seg_offset = current_pos_;
+
+    TargetBitmap res(real_batch_size, false);
+    TargetBitmap valid_res(real_batch_size, true);
+
+    // Survivors = batch slice of (bitmap_input == scalars ∧ B_coarse) ∧ B_coarse.
+    TargetBitmap survivors(real_batch_size, true);
+    const auto& pre = context.get_bitmap_input();
+    if (!pre.empty()) {
+        AssertInfo(static_cast<int64_t>(pre.size()) == real_batch_size,
+                   "bitmap_input size {} != real_batch_size {}",
+                   pre.size(),
+                   real_batch_size);
+        survivors &= pre;
+    }
+    if (st_->coarse_candidates != nullptr) {
+        TargetBitmap coarse_slice;
+        coarse_slice.append(
+            *st_->coarse_candidates, seg_offset, real_batch_size);
+        survivors &= coarse_slice;
+    }
+
+    if (!survivors.none()) {
+        // Build per-thread query geometries + prepared forms ONCE per batch.
+        // qgeoms is reserved so it never reallocates (prepared references it).
+        GEOSContextHandle_t qctx = GetThreadLocalGEOSContext();
+        std::vector<Geometry> qgeoms;
+        std::vector<PreparedGeometry> preps;
+        qgeoms.reserve(st_->preds.size());
+        preps.reserve(st_->preds.size());
+        for (auto& p : st_->preds) {
+            qgeoms.emplace_back(qctx, p.query_wkt.c_str());
+            preps.emplace_back(qctx, qgeoms.back());
+        }
+
+        auto eval_all = [&](const Geometry& left) -> bool {
+            bool bit = st_->is_and;
+            for (size_t j = 0; j < st_->preds.size(); ++j) {
+                bool r =
+                    EvalPrepared(st_->preds[j].op, preps[j], qgeoms[j], left);
+                bit = st_->is_and ? (bit && r) : (bit || r);
+                if (st_->is_and != bit) {
+                    break;  // short-circuit
+                }
+            }
+            return bit;
+        };
+
+        // Collect surviving absolute offsets within this batch.
+        std::vector<int64_t> hit_local;
+        std::vector<int64_t> hit_abs;
+        hit_local.reserve(survivors.count());
+        hit_abs.reserve(survivors.count());
+        for (int64_t i = 0; i < real_batch_size; ++i) {
+            if (survivors[i]) {
+                hit_local.emplace_back(i);
+                hit_abs.emplace_back(seg_offset + i);
+            }
+        }
+
+        auto* geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(
+            segment_->get_segment_id(), st_->field_id);
+
+        if (geometry_cache) {
+            auto cache_lock = geometry_cache->AcquireReadLock();
+            for (size_t k = 0; k < hit_abs.size(); ++k) {
+                auto cached = geometry_cache->GetByOffsetUnsafe(hit_abs[k]);
+                if (cached == nullptr) {
+                    continue;  // null/invalid geometry -> false
+                }
+                if (eval_all(*cached)) {
+                    res.set(hit_local[k]);
+                }
+            }
+        } else {
+            // No geometry cache: fetch WKB once and construct each row geometry
+            // ONCE, then evaluate all predicates against it (the K->1 win).
+            milvus::OpContext op_ctx;
+            auto data_array = segment_->bulk_subscript(
+                &op_ctx, st_->field_id, hit_abs.data(), hit_abs.size());
+            auto geometry_array =
+                static_cast<const milvus::proto::schema::GeometryArray*>(
+                    &data_array->scalars().geometry_data());
+            const auto& vd = data_array->valid_data();
+            GEOSContextHandle_t local_ctx = GetThreadLocalGEOSContext();
+            for (size_t k = 0; k < hit_abs.size(); ++k) {
+                if (!vd.empty() && !vd[k]) {
+                    continue;
+                }
+                const auto& wkb = geometry_array->data(k);
+                Geometry left(local_ctx, wkb.data(), wkb.size());
+                if (eval_all(left)) {
+                    res.set(hit_local[k]);
+                }
+            }
+        }
+    }
+
+    MoveCursor();
+    result =
+        std::make_shared<ColumnVector>(std::move(res), std::move(valid_res));
+}
+
+}  // namespace exec
+}  // namespace milvus

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -11,6 +11,8 @@
 
 #include "exec/expression/GISConjunctExpr.h"
 
+#include <mutex>
+#include <utility>
 #include <vector>
 
 #include "common/EasyAssert.h"
@@ -24,10 +26,67 @@
 #include "index/ScalarIndex.h"
 #include "knowhere/dataset.h"
 #include "log/Log.h"
+#include "monitor/Monitor.h"
 #include "pb/schema.pb.h"
 
 namespace milvus {
 namespace exec {
+
+namespace {
+
+std::mutex&
+GISGroupStateObserverMutex() {
+    static std::mutex mu;
+    return mu;
+}
+
+GISGroupStateObserver&
+GISGroupStateObserverSlot() {
+    static GISGroupStateObserver observer;
+    return observer;
+}
+
+}  // namespace
+
+void
+SetGISGroupStateObserverForTest(GISGroupStateObserver observer) {
+    std::lock_guard<std::mutex> lock(GISGroupStateObserverMutex());
+    GISGroupStateObserverSlot() = std::move(observer);
+}
+
+GISGroupState::~GISGroupState() {
+    // active_count == 0 means the group was built but the segment held no
+    // visible row, so both ratios would be 0/0. Nothing to report.
+    if (active_count > 0) {
+        const double denom = static_cast<double>(active_count);
+        milvus::monitor::internal_core_gis_coarse_ratio.Observe(
+            static_cast<double>(coarse_selected) / denom);
+        milvus::monitor::internal_core_gis_refine_ratio.Observe(
+            static_cast<double>(refined_rows) / denom);
+        // Same numbers, greppable per segment. refined_rows is the one the
+        // equivalence tests cannot see: a Refine that ignores bitmap_input and
+        // evaluates every active row returns identical bits and only shows up
+        // here, as a ratio approaching 1.
+        LOG_DEBUG(
+            "GIS split-fusion pruning: field {} coarse {}/{} refined {}/{} "
+            "({} predicates)",
+            field_id.get(),
+            coarse_selected,
+            active_count,
+            refined_rows,
+            active_count,
+            preds.size());
+    }
+
+    GISGroupStateObserver observer;
+    {
+        std::lock_guard<std::mutex> lock(GISGroupStateObserverMutex());
+        observer = GISGroupStateObserverSlot();
+    }
+    if (observer) {
+        observer(*this);
+    }
+}
 
 // -------------------------------------------------------------------------
 // Coarse node: run each predicate's R-Tree query once (segment-level), combine
@@ -149,18 +208,11 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
             // active_count_-bit bitmap per predicate for the whole query life.
             p.coarse = TargetBitmap{};
         }
+        // Reported once per segment by ~GISGroupState, together with
+        // refined_rows: an all-ones coarse still returns correct results, so
+        // without that a permanently degraded deployment is indistinguishable
+        // from a healthy one.
         st_->coarse_selected = static_cast<int64_t>(cand.count());
-        // Once per segment. The whole point of split-fusion is that this ratio
-        // is well below 1; an all-ones coarse still returns correct results, so
-        // without this line a permanently degraded deployment is
-        // indistinguishable from a healthy one.
-        LOG_DEBUG(
-            "GIS coarse pruning: field {} selected {}/{} rows as candidates "
-            "({} predicates)",
-            st_->field_id.get(),
-            st_->coarse_selected,
-            active_count_,
-            st_->preds.size());
         st_->coarse_candidates =
             std::make_shared<TargetBitmap>(std::move(cand));
         st_->coarse_done = true;
@@ -233,6 +285,16 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
         survivors &= pre;
     }
     if (st_->coarse_candidates != nullptr) {
+        // Redundant by construction TODAY: the Coarse node sits in an earlier
+        // bucket, so the conjunction has already folded B_coarse into
+        // bitmap_input by the time Refine runs, and `pre` above carries it.
+        // Kept as the safety net for the day that stops being true (a bucket
+        // change putting Refine ahead of Coarse would leave this as the only
+        // application of B_coarse). Being redundant, it is also the one part
+        // of the pruning contract no test can pin -- removing it changes
+        // neither the result bits NOR refined_rows, verified by deleting it
+        // and watching the whole suite, including the counter assertions, stay
+        // green. Do not "cover" it with a test that cannot fail.
         TargetBitmap coarse_slice;
         coarse_slice.append(
             *st_->coarse_candidates, seg_offset, real_batch_size);

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -55,9 +55,14 @@ SetGISGroupStateObserverForTest(GISGroupStateObserver observer) {
 }
 
 GISGroupState::~GISGroupState() {
-    // active_count == 0 means the group was built but the segment held no
-    // visible row, so both ratios would be 0/0. Nothing to report.
-    if (active_count > 0) {
+    // Expression construction does not imply execution: FilterBits may return
+    // a cached result, an upstream conjunct may skip this group, or an
+    // exception/cancellation may stop between batches. In those cases the
+    // zero/partial counters are not segment-level pruning ratios and must not
+    // enter the histograms.
+    const bool reportable = active_count > 0 && coarse_done &&
+                            coarse_cursor_complete && refine_cursor_complete;
+    if (reportable) {
         const double denom = static_cast<double>(active_count);
         milvus::monitor::internal_core_gis_coarse_ratio.Observe(
             static_cast<double>(coarse_selected) / denom);
@@ -83,7 +88,7 @@ GISGroupState::~GISGroupState() {
         std::lock_guard<std::mutex> lock(GISGroupStateObserverMutex());
         observer = GISGroupStateObserverSlot();
     }
-    if (observer) {
+    if (observer && reportable) {
         observer(*this);
     }
 }
@@ -92,7 +97,7 @@ GISGroupState::~GISGroupState() {
 // Coarse node: run each predicate's R-Tree query once (segment-level), combine
 // per is_and, cache, and emit the per-batch slice.
 // -------------------------------------------------------------------------
-void
+bool
 PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
     // Mirrors PhyGISFunctionFilterExpr::EvalForIndexSegment's coarse query.
     // NOTE: on 2.6 the scalar index is pinned eagerly in SegmentExpr's
@@ -114,22 +119,12 @@ PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
             ? dynamic_cast<const Index*>(pinned_index_[0].get())
             : nullptr;
     if (scalar_index == nullptr) {
+        // Degrade to an all-set coarse: results stay correct (Refine still
+        // evaluates the exact predicate) but this segment loses R-Tree pruning.
+        // The caller aggregates this across the group's predicates and warns
+        // once per segment (see Eval), instead of once per predicate here.
         p.coarse = TargetBitmap(active_count_, true);
-        p.degraded = GISGroupState::Pred::CoarseDegrade::kIndexUnusable;
-        // Runs once per segment per predicate (guarded by coarse_done), never
-        // on the row-level path. Warn rather than stay silent: results remain
-        // correct but this segment loses all R-Tree pruning, and nothing else
-        // in the pipeline reports it -- a persistently unusable index would
-        // otherwise look exactly like a healthy one that is merely slow.
-        LOG_WARN(
-            "GIS coarse pruning degraded to full scan: field {} reports an "
-            "index but the pin yielded no usable string index "
-            "(num_index_chunk={}, pinned={}); results stay correct via Refine, "
-            "R-Tree pruning is lost for this segment",
-            st_->field_id.get(),
-            num_index_chunk_,
-            pinned_index_.size());
-        return;
+        return true;
     }
 
     // GEOS objects are bound to the per-thread context.
@@ -162,16 +157,21 @@ PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
         TargetBitmap sliced;
         sliced.append(tmp, 0, active_count_);
         p.coarse = std::move(sliced);
-        return;
+        return false;
     }
     if (static_cast<int64_t>(tmp.size()) < active_count_) {
         tmp.resize(active_count_, /*init=*/true);
     }
     p.coarse = std::move(tmp);
+    return false;
 }
 
 void
 PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    // NOTE (2.6): master calls WaitPrefetch() here to close the pinned_index_
+    // race against the prefetch-pool DetermineExecPath()/EnsurePinnedIndex().
+    // 2.6 has neither -- the index is pinned eagerly in InitSegmentExpr on the
+    // constructing thread -- so there is nothing to wait for.
     auto real_batch_size = NextBatchSize();
     if (real_batch_size == 0) {
         result = nullptr;
@@ -181,21 +181,20 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
     // Phase 1: build B_coarse once for the whole segment.
     if (!st_->coarse_done) {
         TargetBitmap cand(active_count_, st_->is_and);  // AND -> 1s / OR -> 0s
+        int unusable_index = 0;  // preds whose R-Tree pin came up empty
+        int no_index = 0;        // preds with no geometry index at all
         for (auto& p : st_->preds) {
             if (p.has_index) {
-                RunRTreeQuery(p);
+                if (RunRTreeQuery(p)) {
+                    ++unusable_index;
+                }
             } else {
                 // No R-Tree index: coarse degenerates to the full set; the
                 // Refine node still prunes via bitmap_input and fuses
-                // construction. Expected, so this is DEBUG -- but it must be
-                // distinguishable from the kIndexUnusable warning above, which
-                // looks identical from the outside.
+                // construction. Expected, so it is aggregated into a single
+                // DEBUG line below rather than logged per predicate.
                 p.coarse = TargetBitmap(active_count_, true);
-                p.degraded = GISGroupState::Pred::CoarseDegrade::kNoIndex;
-                LOG_DEBUG(
-                    "GIS coarse pruning unavailable: field {} has no geometry "
-                    "index, coarse degenerates to the full set",
-                    st_->field_id.get());
+                ++no_index;
             }
             if (st_->is_and) {
                 cand &= p.coarse;
@@ -207,6 +206,34 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
             // per-predicate bitmaps. Release it now so we don't hold one extra
             // active_count_-bit bitmap per predicate for the whole query life.
             p.coarse = TargetBitmap{};
+        }
+        // One log per segment per query (this block is guarded by coarse_done),
+        // NOT one per predicate. The unusable-index case is unexpected and
+        // loses all R-Tree pruning for the segment while the index warms up --
+        // or permanently, if it is broken -- so warn: nothing else in the
+        // pipeline reports it and a degraded deployment would otherwise look
+        // exactly like a healthy one. All preds share the field's index, so
+        // num_index_chunk_/pinned_index_ reflect that shared pin state.
+        if (unusable_index > 0) {
+            LOG_WARN(
+                "GIS coarse pruning degraded to full scan: field {} reports an "
+                "index but the pin yielded no usable string index for {} of {} "
+                "predicate(s) (num_index_chunk={}, pinned={}); results stay "
+                "correct via Refine, R-Tree pruning is lost for this segment",
+                st_->field_id.get(),
+                unusable_index,
+                st_->preds.size(),
+                num_index_chunk_,
+                pinned_index_.size());
+        }
+        if (no_index > 0) {
+            LOG_DEBUG(
+                "GIS coarse pruning unavailable: field {} has no geometry "
+                "index "
+                "for {} of {} predicate(s), coarse degenerates to the full set",
+                st_->field_id.get(),
+                no_index,
+                st_->preds.size());
         }
         // Reported once per segment by ~GISGroupState, together with
         // refined_rows: an all-ones coarse still returns correct results, so
@@ -221,6 +248,28 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
     // Phase 2: emit slice [current_pos_, +real_batch_size).
     TargetBitmap out;
     out.append(*st_->coarse_candidates, current_pos_, real_batch_size);
+    // Intersect with any mask an OUTER conjunction supplied. Within this same AND
+    // it is redundant -- the conjunction re-ANDs Coarse's output and rebuilds
+    // bitmap_input from the accumulated result, so scalar siblings still reach
+    // Refine either way. But when the split group is NESTED (e.g. under an OR
+    // arm: `id < 100 OR (st_intersects(geo,P1) AND st_within(geo,P2))`), the
+    // inner conjunction's accumulator starts fresh and Coarse -- bucketed first
+    // as the indexed expr -- is the only node positioned to consume the outer
+    // mask before it is overwritten. Sound in BOTH directions: a row masked off
+    // is already settled by the parent (TRUE under an OR arm, FALSE under an AND
+    // arm), so dropping it here cannot change the recombined three-valued result,
+    // and it spares Refine from building geometries for rows the outer arm
+    // already decided (also making internal_core_gis_refine_ratio reflect the
+    // real pruned work for nested shapes). coarse_candidates itself is left pure
+    // B_coarse -- only this per-batch slice is narrowed. See PR #50675 review.
+    const auto& outer_mask = context.get_bitmap_input();
+    if (!outer_mask.empty()) {
+        AssertInfo(static_cast<int64_t>(outer_mask.size()) == real_batch_size,
+                   "bitmap_input size {} != real_batch_size {}",
+                   outer_mask.size(),
+                   real_batch_size);
+        out &= outer_mask;
+    }
     // valid is all-ones intentionally (see also the Refine node). PRECONDITION:
     // these split nodes NEVER sit under a NOT and "null == not-selected" for
     // them. This holds because split is only applied INSIDE a pure conjunction
@@ -236,8 +285,8 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
     // See PR #50675 review.
     TargetBitmap valid(real_batch_size, true);
 
-    MoveCursor();
     result = std::make_shared<ColumnVector>(std::move(out), std::move(valid));
+    MoveCursor();
 }
 
 // -------------------------------------------------------------------------
@@ -259,6 +308,9 @@ PhyGISRefineConjunctExpr::EvalPrepared(
 
 void
 PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
+    // NOTE (2.6): master defines PrefetchRawData() above this and calls
+    // WaitPrefetch() here. 2.6's SegmentExpr has no expression-level prefetch,
+    // so both are omitted (see the header).
     auto real_batch_size = NextBatchSize();
     if (real_batch_size == 0) {
         result = nullptr;
@@ -383,9 +435,9 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
         }
     }
 
-    MoveCursor();
     result =
         std::make_shared<ColumnVector>(std::move(res), std::move(valid_res));
+    MoveCursor();
 }
 
 }  // namespace exec

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -23,6 +23,7 @@
 #include "index/Meta.h"
 #include "index/ScalarIndex.h"
 #include "knowhere/dataset.h"
+#include "log/Log.h"
 #include "pb/schema.pb.h"
 
 namespace milvus {
@@ -55,6 +56,20 @@ PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
             : nullptr;
     if (scalar_index == nullptr) {
         p.coarse = TargetBitmap(active_count_, true);
+        p.degraded = GISGroupState::Pred::CoarseDegrade::kIndexUnusable;
+        // Runs once per segment per predicate (guarded by coarse_done), never
+        // on the row-level path. Warn rather than stay silent: results remain
+        // correct but this segment loses all R-Tree pruning, and nothing else
+        // in the pipeline reports it -- a persistently unusable index would
+        // otherwise look exactly like a healthy one that is merely slow.
+        LOG_WARN(
+            "GIS coarse pruning degraded to full scan: field {} reports an "
+            "index but the pin yielded no usable string index "
+            "(num_index_chunk={}, pinned={}); results stay correct via Refine, "
+            "R-Tree pruning is lost for this segment",
+            st_->field_id.get(),
+            num_index_chunk_,
+            pinned_index_.size());
         return;
     }
 
@@ -113,8 +128,15 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
             } else {
                 // No R-Tree index: coarse degenerates to the full set; the
                 // Refine node still prunes via bitmap_input and fuses
-                // construction.
+                // construction. Expected, so this is DEBUG -- but it must be
+                // distinguishable from the kIndexUnusable warning above, which
+                // looks identical from the outside.
                 p.coarse = TargetBitmap(active_count_, true);
+                p.degraded = GISGroupState::Pred::CoarseDegrade::kNoIndex;
+                LOG_DEBUG(
+                    "GIS coarse pruning unavailable: field {} has no geometry "
+                    "index, coarse degenerates to the full set",
+                    st_->field_id.get());
             }
             if (st_->is_and) {
                 cand &= p.coarse;
@@ -127,6 +149,18 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
             // active_count_-bit bitmap per predicate for the whole query life.
             p.coarse = TargetBitmap{};
         }
+        st_->coarse_selected = static_cast<int64_t>(cand.count());
+        // Once per segment. The whole point of split-fusion is that this ratio
+        // is well below 1; an all-ones coarse still returns correct results, so
+        // without this line a permanently degraded deployment is
+        // indistinguishable from a healthy one.
+        LOG_DEBUG(
+            "GIS coarse pruning: field {} selected {}/{} rows as candidates "
+            "({} predicates)",
+            st_->field_id.get(),
+            st_->coarse_selected,
+            active_count_,
+            st_->preds.size());
         st_->coarse_candidates =
             std::make_shared<TargetBitmap>(std::move(cand));
         st_->coarse_done = true;
@@ -236,6 +270,10 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
         std::vector<int64_t> hit_abs;
         hit_local.reserve(survivors.count());
         hit_abs.reserve(survivors.count());
+        // Accumulated across batches: the number of rows this node actually
+        // builds a geometry for and evaluates. This is the pruning contract
+        // made observable -- see GISGroupState::refined_rows.
+        st_->refined_rows += static_cast<int64_t>(survivors.count());
         for (int64_t i = 0; i < real_batch_size; ++i) {
             if (survivors[i]) {
                 hit_local.emplace_back(i);

--- a/internal/core/src/exec/expression/GISConjunctExpr.h
+++ b/internal/core/src/exec/expression/GISConjunctExpr.h
@@ -94,6 +94,17 @@ class PhyGISCoarseConjunctExpr : public SegmentExpr {
         return "PhyGISCoarseConjunctExpr";
     }
 
+    // The split nodes slice their output by the self-managed segment cursor
+    // (current_pos_ / NextBatchSize over active_count_), NOT by an external
+    // offset list. They therefore CANNOT serve the offset-input
+    // (iterative-filter / rescore) path; reporting false makes
+    // IterativeFilterNode fall back to its non-native execution instead of
+    // feeding offsets into Eval (which would mis-size the result bitmap).
+    bool
+    SupportOffsetInput() override {
+        return false;
+    }
+
     // Self-managed segment-level cursor (independent of exec_path_, like
     // PhyLikeConjunctExpr): keeps the conjunction's SkipFollowingExprs in sync.
     void
@@ -147,6 +158,14 @@ class PhyGISRefineConjunctExpr : public SegmentExpr {
     std::string
     ToString() const override {
         return "PhyGISRefineConjunctExpr";
+    }
+
+    // See PhyGISCoarseConjunctExpr::SupportOffsetInput: the Refine node also
+    // slices by its own segment cursor and asserts bitmap_input is sized by
+    // real_batch_size, so it cannot consume an external offset list.
+    bool
+    SupportOffsetInput() override {
+        return false;
     }
 
     // Self-managed segment-level cursor (independent of exec_path_).

--- a/internal/core/src/exec/expression/GISConjunctExpr.h
+++ b/internal/core/src/exec/expression/GISConjunctExpr.h
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -54,7 +53,10 @@ struct GISGroupState {
     // B_coarse = combine(Ci) over all preds. Filled by the Coarse node, read by
     // the Refine node. Cached once per segment for the whole query.
     std::shared_ptr<TargetBitmap> coarse_candidates;
-    std::atomic<bool> coarse_done{false};
+    // A fresh GISGroupState is created per segment (SplitFuseGISConjunct) and
+    // per-segment batch execution is single-threaded, so this guard needs no
+    // atomicity -- it is only read/written inside PhyGISCoarseConjunctExpr::Eval.
+    bool coarse_done{false};
 };
 
 using GISGroupStatePtr = std::shared_ptr<GISGroupState>;

--- a/internal/core/src/exec/expression/GISConjunctExpr.h
+++ b/internal/core/src/exec/expression/GISConjunctExpr.h
@@ -42,6 +42,18 @@ struct GISGroupState {
         bool has_index{false};
         // Per-predicate R-Tree coarse bitmap (segment-level, computed once).
         TargetBitmap coarse;
+        // Why this predicate's coarse bitmap ended up all-ones, if it did.
+        // An all-ones coarse is always CORRECT -- Refine still evaluates the
+        // exact predicate -- but it prunes nothing, so the pruning gain
+        // silently drops to zero. ON/OFF equivalence tests cannot see this
+        // (they are only sensitive to coarse UNDER-inclusion), which is why
+        // the reason is recorded rather than left implicit.
+        enum class CoarseDegrade {
+            kNone = 0,       // R-Tree answered; coarse is a real candidate set
+            kNoIndex,        // no geometry index on this field (expected)
+            kIndexUnusable,  // index reported present but the pin yielded nothing
+        };
+        CoarseDegrade degraded{CoarseDegrade::kNone};
     };
 
     FieldId field_id;
@@ -57,6 +69,20 @@ struct GISGroupState {
     // per-segment batch execution is single-threaded, so this guard needs no
     // atomicity -- it is only read/written inside PhyGISCoarseConjunctExpr::Eval.
     bool coarse_done{false};
+
+    // --- pruning observability -------------------------------------------
+    // The point of split-fusion is that Refine only evaluates survivors. That
+    // contract is invisible to ON/OFF equivalence tests: making Refine
+    // evaluate every active row keeps every result bit identical and only
+    // costs performance. These counters make the contract assertable (and
+    // greppable in production).
+    //
+    // Rows set in B_coarse after combining every predicate.
+    int64_t coarse_selected{0};
+    // Rows Refine actually evaluated the exact predicate for, i.e. survivors
+    // of (scalars AND B_coarse). Must stay well below active_count for a
+    // selective query, otherwise pruning is not happening.
+    int64_t refined_rows{0};
 };
 
 using GISGroupStatePtr = std::shared_ptr<GISGroupState>;

--- a/internal/core/src/exec/expression/GISConjunctExpr.h
+++ b/internal/core/src/exec/expression/GISConjunctExpr.h
@@ -1,0 +1,177 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/Geometry.h"
+#include "common/PreparedGeometry.h"
+#include "common/Types.h"
+#include "exec/expression/EvalCtx.h"
+#include "exec/expression/Expr.h"
+#include "pb/plan.pb.h"
+#include "segcore/SegmentInterface.h"
+
+namespace milvus {
+namespace exec {
+
+// Shared state for one same-column geometry block (a set of GIS predicates on
+// the SAME geometry field combined by a single boolean op). Produced by the
+// optimizer and shared between the Coarse node (fills coarse_candidates once)
+// and the Refine node (exact-refines surviving rows).
+struct GISGroupState {
+    // One geometry predicate of the block.
+    // NOTE: GEOS objects are bound to a per-thread GEOSContextHandle, so the
+    // query Geometry / PreparedGeometry MUST be built per-thread inside Eval
+    // (mirroring PhyGISFunctionFilterExpr). Only the immutable WKT + op + the
+    // segment-level coarse bitmap are shared here.
+    struct Pred {
+        proto::plan::GISFunctionFilterExpr_GISOp op;
+        std::string query_wkt;
+        bool has_index{false};
+        // Per-predicate R-Tree coarse bitmap (segment-level, computed once).
+        TargetBitmap coarse;
+    };
+
+    FieldId field_id;
+    // Block combine op: true => AND (intersect coarse / && refine),
+    //                   false => OR (union coarse / || refine).
+    bool is_and{true};
+    std::vector<Pred> preds;
+
+    // B_coarse = combine(Ci) over all preds. Filled by the Coarse node, read by
+    // the Refine node. Cached once per segment for the whole query.
+    std::shared_ptr<TargetBitmap> coarse_candidates;
+    std::atomic<bool> coarse_done{false};
+};
+
+using GISGroupStatePtr = std::shared_ptr<GISGroupState>;
+
+// Coarse node: runs each predicate's R-Tree query once (segment-level), combines
+// per is_and into coarse_candidates, and emits the per-batch slice. Scheduled
+// EARLY (indexed bucket) so its bitmap prunes other predicates via bitmap_input.
+class PhyGISCoarseConjunctExpr : public SegmentExpr {
+ public:
+    PhyGISCoarseConjunctExpr(GISGroupStatePtr state,
+                             const std::string& name,
+                             milvus::OpContext* op_ctx,
+                             const segcore::SegmentInternalInterface* segment,
+                             int64_t active_count,
+                             int64_t batch_size,
+                             int32_t consistency_level)
+        : SegmentExpr({},
+                      name,
+                      op_ctx,
+                      segment,
+                      state->field_id,
+                      /*nested_path=*/{},
+                      DataType::GEOMETRY,
+                      active_count,
+                      batch_size,
+                      consistency_level),
+          st_(std::move(state)) {
+    }
+
+    void
+    Eval(EvalCtx& context, VectorPtr& result) override;
+
+    std::string
+    ToString() const override {
+        return "PhyGISCoarseConjunctExpr";
+    }
+
+    // Self-managed segment-level cursor (independent of exec_path_, like
+    // PhyLikeConjunctExpr): keeps the conjunction's SkipFollowingExprs in sync.
+    void
+    MoveCursor() override {
+        current_pos_ += NextBatchSize();
+    }
+
+ private:
+    int64_t
+    NextBatchSize() const {
+        auto remain = active_count_ - current_pos_;
+        return remain < batch_size_ ? remain : batch_size_;
+    }
+
+    // Run the R-Tree index query for a single predicate, filling p.coarse.
+    void
+    RunRTreeQuery(GISGroupState::Pred& p);
+
+    GISGroupStatePtr st_;
+    int64_t current_pos_{0};
+};
+
+// Refine node: consumes bitmap_input (== scalars AND B_coarse), and for each
+// surviving row constructs the row geometry ONCE and evaluates ALL predicates of
+// the block against it (fusion, K->1). Scheduled LAST (heavy bucket).
+class PhyGISRefineConjunctExpr : public SegmentExpr {
+ public:
+    PhyGISRefineConjunctExpr(GISGroupStatePtr state,
+                             const std::string& name,
+                             milvus::OpContext* op_ctx,
+                             const segcore::SegmentInternalInterface* segment,
+                             int64_t active_count,
+                             int64_t batch_size,
+                             int32_t consistency_level)
+        : SegmentExpr({},
+                      name,
+                      op_ctx,
+                      segment,
+                      state->field_id,
+                      /*nested_path=*/{},
+                      DataType::GEOMETRY,
+                      active_count,
+                      batch_size,
+                      consistency_level),
+          st_(std::move(state)) {
+    }
+
+    void
+    Eval(EvalCtx& context, VectorPtr& result) override;
+
+    std::string
+    ToString() const override {
+        return "PhyGISRefineConjunctExpr";
+    }
+
+    // Self-managed segment-level cursor (independent of exec_path_).
+    void
+    MoveCursor() override {
+        current_pos_ += NextBatchSize();
+    }
+
+ private:
+    int64_t
+    NextBatchSize() const {
+        auto remain = active_count_ - current_pos_;
+        return remain < batch_size_ ? remain : batch_size_;
+    }
+
+    // Evaluate one predicate against an already-constructed left geometry using
+    // a per-thread prepared query geometry (within/contains semantics swapped,
+    // mirroring PhyGISFunctionFilterExpr::evaluate_geometry_prepared).
+    bool
+    EvalPrepared(proto::plan::GISFunctionFilterExpr_GISOp op,
+                 const PreparedGeometry& prepared,
+                 const Geometry& query_geom,
+                 const Geometry& left) const;
+
+    GISGroupStatePtr st_;
+    int64_t current_pos_{0};
+};
+
+}  // namespace exec
+}  // namespace milvus

--- a/internal/core/src/exec/expression/GISConjunctExpr.h
+++ b/internal/core/src/exec/expression/GISConjunctExpr.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -61,6 +62,10 @@ struct GISGroupState {
     //                   false => OR (union coarse / || refine).
     bool is_and{true};
     std::vector<Pred> preds;
+    // Denominator of both pruning ratios below: the segment's MVCC-visible row
+    // count, captured where the nodes are built (SplitFuseGISConjunct) so it is
+    // available even if neither node ever runs.
+    int64_t active_count{0};
 
     // B_coarse = combine(Ci) over all preds. Filled by the Coarse node, read by
     // the Refine node. Cached once per segment for the whole query.
@@ -74,8 +79,8 @@ struct GISGroupState {
     // The point of split-fusion is that Refine only evaluates survivors. That
     // contract is invisible to ON/OFF equivalence tests: making Refine
     // evaluate every active row keeps every result bit identical and only
-    // costs performance. These counters make the contract assertable (and
-    // greppable in production).
+    // costs performance. These counters carry the contract out of the operator
+    // -- see the destructor, which is the single place that reads them.
     //
     // Rows set in B_coarse after combining every predicate.
     int64_t coarse_selected{0};
@@ -83,9 +88,24 @@ struct GISGroupState {
     // of (scalars AND B_coarse). Must stay well below active_count for a
     // selective query, otherwise pruning is not happening.
     int64_t refined_rows{0};
+
+    // Reports the two counters above as ratios of active_count. This state is
+    // created per segment and shared only by that segment's Coarse/Refine
+    // nodes, so destruction is exactly "this query is done with this segment"
+    // -- the one point where both counters are final and every batch has been
+    // accounted for. Defined out-of-line so the Prometheus headers stay out of
+    // this one.
+    ~GISGroupState();
 };
 
 using GISGroupStatePtr = std::shared_ptr<GISGroupState>;
+
+// Test-only hook, invoked from ~GISGroupState alongside the metric emission so
+// tests observe exactly what production reports. Production never sets it.
+// Pass nullptr to clear. Set it before the query runs, from one thread.
+using GISGroupStateObserver = std::function<void(const GISGroupState&)>;
+void
+SetGISGroupStateObserverForTest(GISGroupStateObserver observer);
 
 // Coarse node: runs each predicate's R-Tree query once (segment-level), combines
 // per is_and into coarse_candidates, and emits the per-batch slice. Scheduled

--- a/internal/core/src/exec/expression/GISConjunctExpr.h
+++ b/internal/core/src/exec/expression/GISConjunctExpr.h
@@ -42,19 +42,14 @@ struct GISGroupState {
         std::string query_wkt;
         bool has_index{false};
         // Per-predicate R-Tree coarse bitmap (segment-level, computed once).
-        TargetBitmap coarse;
-        // Why this predicate's coarse bitmap ended up all-ones, if it did.
         // An all-ones coarse is always CORRECT -- Refine still evaluates the
         // exact predicate -- but it prunes nothing, so the pruning gain
-        // silently drops to zero. ON/OFF equivalence tests cannot see this
-        // (they are only sensitive to coarse UNDER-inclusion), which is why
-        // the reason is recorded rather than left implicit.
-        enum class CoarseDegrade {
-            kNone = 0,       // R-Tree answered; coarse is a real candidate set
-            kNoIndex,        // no geometry index on this field (expected)
-            kIndexUnusable,  // index reported present but the pin yielded nothing
-        };
-        CoarseDegrade degraded{CoarseDegrade::kNone};
+        // silently drops to zero. That is surfaced two ways instead of a
+        // per-predicate flag: the refine ratio metric (a ratio near 1 means
+        // coarse stopped pruning) and, for the unexpected "index present but
+        // unusable" case, a single per-segment LOG_WARN raised by the Coarse
+        // node after combining B_coarse.
+        TargetBitmap coarse;
     };
 
     FieldId field_id;
@@ -75,6 +70,16 @@ struct GISGroupState {
     // atomicity -- it is only read/written inside PhyGISCoarseConjunctExpr::Eval.
     bool coarse_done{false};
 
+    // A state may be destroyed without being evaluated to completion: the
+    // FilterBits result cache can bypass the expression tree entirely,
+    // cancellation/errors can stop between batches, and an upstream conjunct
+    // can skip both GIS nodes. Destructor-based metrics are valid only after
+    // both node cursors account for the whole segment and Coarse actually
+    // computed B_coarse. MoveCursor maintains these flags for both evaluated
+    // and short-circuited batches.
+    bool coarse_cursor_complete{false};
+    bool refine_cursor_complete{false};
+
     // --- pruning observability -------------------------------------------
     // The point of split-fusion is that Refine only evaluates survivors. That
     // contract is invisible to ON/OFF equivalence tests: making Refine
@@ -84,15 +89,17 @@ struct GISGroupState {
     //
     // Rows set in B_coarse after combining every predicate.
     int64_t coarse_selected{0};
-    // Rows Refine actually evaluated the exact predicate for, i.e. survivors
-    // of (scalars AND B_coarse). Must stay well below active_count for a
-    // selective query, otherwise pruning is not happening.
+    // Survivors of (scalars AND B_coarse) that Refine fetched, i.e. the rows it
+    // paid to look at. This is the fetch cost the split exists to shrink and
+    // must stay well below active_count for a selective query. It counts every
+    // fetched survivor, including null/invalid geometries that are skipped
+    // before any exact predicate runs -- Refine still fetched them, so they are
+    // part of the cost being measured; the exact predicate (and the geometry
+    // construction it needs) runs for the non-null subset.
     int64_t refined_rows{0};
 
-    // Reports the two counters above as ratios of active_count. This state is
-    // created per segment and shared only by that segment's Coarse/Refine
-    // nodes, so destruction is exactly "this query is done with this segment"
-    // -- the one point where both counters are final and every batch has been
+    // Reports the two counters above as ratios of active_count, but only when
+    // coarse_done and both cursor-complete flags prove every batch has been
     // accounted for. Defined out-of-line so the Prometheus headers stay out of
     // this one.
     ~GISGroupState();
@@ -156,7 +163,15 @@ class PhyGISCoarseConjunctExpr : public SegmentExpr {
     void
     MoveCursor() override {
         current_pos_ += NextBatchSize();
+        st_->coarse_cursor_complete = current_pos_ == active_count_;
     }
+
+    // NOTE (2.6): the master PR overrides PrefetchRawData() here to a no-op and
+    // documents why CanExecuteAllAtOnce() is deliberately NOT overridden. Neither
+    // applies on 2.6: SegmentExpr has no lazy exec-path / prefetch machinery
+    // (PrefetchRawData, WaitPrefetch, DetermineExecPath) and no all-at-once path
+    // (CanExecuteAllAtOnce / SetExecuteAllAtOnce), so this node is always batched
+    // and never prefetches. Both overrides come back with that machinery.
 
  private:
     int64_t
@@ -166,7 +181,10 @@ class PhyGISCoarseConjunctExpr : public SegmentExpr {
     }
 
     // Run the R-Tree index query for a single predicate, filling p.coarse.
-    void
+    // Returns true if the pin came up empty and coarse degraded to an all-set
+    // bitmap (index reported present but unusable); the caller raises a single
+    // per-segment warning for the whole group instead of one per predicate.
+    bool
     RunRTreeQuery(GISGroupState::Pred& p);
 
     GISGroupStatePtr st_;
@@ -218,7 +236,16 @@ class PhyGISRefineConjunctExpr : public SegmentExpr {
     void
     MoveCursor() override {
         current_pos_ += NextBatchSize();
+        st_->refine_cursor_complete = current_pos_ == active_count_;
     }
+
+    // NOTE (2.6): the master PR overrides DetermineExecPath() (commit to
+    // RawData so no R-Tree cell is pinned) and PrefetchRawData() (warm the
+    // column only when reads will span it) here, plus a comment on why
+    // CanExecuteAllAtOnce() stays inherited. None of that machinery exists on
+    // 2.6 -- the scalar index is pinned eagerly in InitSegmentExpr, there is no
+    // prefetch pool for expressions, and there is no all-at-once path -- so the
+    // overrides are omitted. They come back with that machinery.
 
  private:
     int64_t

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -333,34 +333,8 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
     // - equals, dwithin: no prepared version, fall back to regular Geometry
     auto evaluate_geometry_prepared =
         [this, &prepared_query, &query_geometry](const Geometry& left) -> bool {
-        switch (expr_->op_) {
-            case proto::plan::GISFunctionFilterExpr_GISOp_Intersects:
-                // Symmetric: prepared_query.intersects(left) == left.intersects(query)
-                return prepared_query.intersects(left);
-            case proto::plan::GISFunctionFilterExpr_GISOp_Touches:
-                // Symmetric
-                return prepared_query.touches(left);
-            case proto::plan::GISFunctionFilterExpr_GISOp_Overlaps:
-                // Symmetric
-                return prepared_query.overlaps(left);
-            case proto::plan::GISFunctionFilterExpr_GISOp_Crosses:
-                // Symmetric
-                return prepared_query.crosses(left);
-            case proto::plan::GISFunctionFilterExpr_GISOp_Contains:
-                // left.contains(query) == query.within(left)
-                return prepared_query.within(left);
-            case proto::plan::GISFunctionFilterExpr_GISOp_Within:
-                // left.within(query) == query.contains(left)
-                return prepared_query.contains(left);
-            case proto::plan::GISFunctionFilterExpr_GISOp_Equals:
-                // No prepared version - fall back to regular geometry
-                return left.equals(query_geometry);
-            case proto::plan::GISFunctionFilterExpr_GISOp_DWithin:
-                // Distance-based operation - no prepared version
-                return left.dwithin(query_geometry, expr_->distance_);
-            default:
-                ThrowInfo(NotImplemented, "unknown GIS op : {}", expr_->op_);
-        }
+        return EvaluateGISPreparedOp(
+            expr_->op_, prepared_query, query_geometry, left, expr_->distance_);
     };
 
     TargetBitmap batch_result;

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -428,9 +428,8 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                     }
                 }
             } else {
-                milvus::OpContext op_ctx;
                 auto data_array = segment_->bulk_subscript(
-                    &op_ctx, field_id_, hit_offsets.data(), hit_offsets.size());
+                    op_ctx_, field_id_, hit_offsets.data(), hit_offsets.size());
 
                 auto geometry_array =
                     static_cast<const milvus::proto::schema::GeometryArray*>(

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -16,7 +16,12 @@
 #include <algorithm>
 #include <memory>
 
+#include "common/EasyAssert.h"
 #include "common/FieldDataInterface.h"
+#include "common/Geometry.h"
+#include "common/OpContext.h"
+#include "common/PreparedGeometry.h"
+#include "common/Types.h"
 #include "common/Vector.h"
 #include "exec/expression/Expr.h"
 #include "expr/ITypeExpr.h"
@@ -25,6 +30,47 @@
 
 namespace milvus {
 namespace exec {
+
+// Evaluate a single GIS predicate using a prepared query geometry against an
+// already-constructed `left` row geometry. This centralizes the prepared
+// predicate semantics — notably the contains/within swap
+// (left.contains(query) == query.within(left)) — so the per-predicate path
+// (PhyGISFunctionFilterExpr::EvalForIndexSegment) and the optimizer's fusion
+// path (PhyGISRefineConjunctExpr) stay in lockstep instead of drifting as new
+// GISOps are added.
+inline bool
+EvaluateGISPreparedOp(proto::plan::GISFunctionFilterExpr_GISOp op,
+                      const PreparedGeometry& prepared,
+                      const Geometry& query_geom,
+                      const Geometry& left,
+                      double distance) {
+    switch (op) {
+        case proto::plan::GISFunctionFilterExpr_GISOp_Intersects:
+            // Symmetric: prepared.intersects(left) == left.intersects(query)
+            return prepared.intersects(left);
+        case proto::plan::GISFunctionFilterExpr_GISOp_Touches:
+            return prepared.touches(left);
+        case proto::plan::GISFunctionFilterExpr_GISOp_Overlaps:
+            return prepared.overlaps(left);
+        case proto::plan::GISFunctionFilterExpr_GISOp_Crosses:
+            return prepared.crosses(left);
+        case proto::plan::GISFunctionFilterExpr_GISOp_Contains:
+            // left.contains(query) == query.within(left)
+            return prepared.within(left);
+        case proto::plan::GISFunctionFilterExpr_GISOp_Within:
+            // left.within(query) == query.contains(left)
+            return prepared.contains(left);
+        case proto::plan::GISFunctionFilterExpr_GISOp_Equals:
+            // No prepared version - fall back to regular geometry.
+            return left.equals(query_geom);
+        case proto::plan::GISFunctionFilterExpr_GISOp_DWithin:
+            // Distance-based operation - no prepared version.
+            return left.dwithin(query_geom, distance);
+        default:
+            ThrowInfo(
+                NotImplemented, "unknown GIS op : {}", static_cast<int>(op));
+    }
+}
 
 class PhyGISFunctionFilterExpr : public SegmentExpr {
  public:
@@ -56,6 +102,13 @@ class PhyGISFunctionFilterExpr : public SegmentExpr {
     std::optional<milvus::expr::ColumnInfo>
     GetColumnInfo() const override {
         return expr_->column_;
+    }
+
+    // Expose the logical GIS expr so the optimizer can group same-column GIS
+    // predicates into a PhyGISCoarseConjunctExpr / PhyGISRefineConjunctExpr.
+    const std::shared_ptr<const milvus::expr::GISFunctionFilterExpr>&
+    GetGISExpr() const {
+        return expr_;
     }
 
     std::string

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -885,11 +885,11 @@ struct GisSplitFusionFlagGuard {
 struct ExprBatchSizeGuardLocal {
     int64_t saved;
     explicit ExprBatchSizeGuardLocal(int64_t batch_size)
-        : saved(EXEC_EVAL_EXPR_BATCH_SIZE.load()) {
-        EXEC_EVAL_EXPR_BATCH_SIZE.store(batch_size);
+        : saved(milvus::EXEC_EVAL_EXPR_BATCH_SIZE.load()) {
+        milvus::EXEC_EVAL_EXPR_BATCH_SIZE.store(batch_size);
     }
     ~ExprBatchSizeGuardLocal() {
-        EXEC_EVAL_EXPR_BATCH_SIZE.store(saved);
+        milvus::EXEC_EVAL_EXPR_BATCH_SIZE.store(saved);
     }
 };
 }  // namespace

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -862,3 +862,155 @@ TEST_F(RTreeIndexTest, GIS_Index_Exact_Filtering) {
     // Clean up any remaining index files
     CleanupIndexFiles(stats->GetIndexFiles(), "GIS filtering test");
 }
+
+// Equivalence test for the GIS coarse/refine split + same-column fusion on the
+// INDEXED path: with a geometry R-Tree index loaded, the Coarse node's
+// RunRTreeQuery is exercised. enableGISSplitFusion ON must match OFF.
+TEST_F(RTreeIndexTest, GIS_SplitFusion_Equivalence_Indexed) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("id", DataType::INT64);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto geo_id = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->set_primary_field_id(pk_id);
+
+    const int N = 200;
+    auto full_ds = DataGen(schema, N);
+    auto sealed =
+        CreateSealedWithFieldDataLoaded(schema, full_ds, false, {geo_id.get()});
+
+    // Controlled geometry data (mirrors GIS_Index_Exact_Filtering).
+    std::vector<std::string> wkbs;
+    wkbs.reserve(N);
+    auto ctx = GEOS_init_r();
+    for (int i = 0; i < N; ++i) {
+        const char* wkt =
+            (i % 4 == 0)   ? "POINT(0 0)"
+            : (i % 4 == 1) ? "POLYGON((-1 -1,1 -1,1 1,-1 1,-1 -1))"
+            : (i % 4 == 2) ? "POLYGON((10 10,20 10,20 20,10 20,10 10))"
+                           : "LINESTRING(-1 0,1 0)";
+        wkbs.emplace_back(milvus::Geometry(ctx, wkt).to_wkb_string());
+    }
+    GEOS_finish_r(ctx);
+
+    auto geo_field_data =
+        milvus::storage::CreateFieldData(milvus::storage::DataType::GEOMETRY,
+                                         milvus::storage::DataType::NONE,
+                                         false);
+    geo_field_data->FillFieldData(wkbs.data(), wkbs.size());
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, geo_id.get(), {geo_field_data}, cm);
+    sealed->LoadFieldData(load_info);
+
+    // Build + load the geometry R-Tree index. Use a distinct field/index id so
+    // the index build temp dir (derived from collection_partition_segment_field)
+    // does not collide with GIS_Index_Exact_Filtering, which reuses the fixture's
+    // field_meta_ {1,1,1,100} and leaves that temp dir non-empty.
+    milvus::storage::FieldDataMeta fusion_field_meta{1, 1, 1, 200};
+    fusion_field_meta.field_schema.set_data_type(
+        ::milvus::proto::schema::DataType::Geometry);
+    milvus::storage::IndexMeta fusion_index_meta{1, 200, 1, 1};
+    auto remote_file = (temp_path_.get() / "rtree_fusion.parquet").string();
+    WriteGeometryInsertFile(
+        chunk_manager_, fusion_field_meta, remote_file, wkbs);
+    milvus::storage::FileManagerContext fm_ctx(
+        fusion_field_meta, fusion_index_meta, chunk_manager_, fs_);
+    auto rtree_index =
+        std::make_unique<milvus::index::RTreeIndex<std::string>>(fm_ctx);
+    nlohmann::json build_cfg;
+    build_cfg["insert_files"] = std::vector<std::string>{remote_file};
+    build_cfg["index_type"] = milvus::index::RTREE_INDEX_TYPE;
+    rtree_index->Build(build_cfg);
+    auto stats = rtree_index->UploadUnified({});
+
+    milvus::segcore::LoadIndexInfo info{};
+    info.collection_id = 1;
+    info.partition_id = 1;
+    info.segment_id = 1;
+    info.field_id = geo_id.get();
+    info.field_type = DataType::GEOMETRY;
+    info.index_id = 1;
+    info.index_build_id = 1;
+    info.index_version = 1;
+    info.schema = proto::schema::FieldSchema();
+    info.schema.set_data_type(proto::schema::DataType::Geometry);
+    info.index_params["index_type"] = milvus::index::RTREE_INDEX_TYPE;
+    nlohmann::json cfg_load;
+    cfg_load["index_files"] = stats->GetIndexFiles();
+    rtree_index->LoadUnified(cfg_load);
+    info.cache_index =
+        CreateTestCacheIndex("rtree_fusion_key", std::move(rtree_index));
+    sealed->LoadIndex(info);
+
+    ASSERT_TRUE(sealed->HasIndex(geo_id));
+
+    // Build conjunction filters that combine a scalar predicate with same-column
+    // geometry predicates (so SplitFuseGISConjunct fires and uses the index).
+    auto col_geo = milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY);
+    auto col_id = milvus::expr::ColumnInfo(pk_id, DataType::INT64);
+    proto::plan::GenericValue zero;
+    zero.set_int64_val(0);
+    milvus::expr::TypedExprPtr scalar =
+        std::make_shared<milvus::expr::UnaryRangeFilterExpr>(
+            col_id, proto::plan::OpType::GreaterEqual, zero);
+
+    auto gis = [&](proto::plan::GISFunctionFilterExpr_GISOp op,
+                   const std::string& wkt) -> milvus::expr::TypedExprPtr {
+        return std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+            col_geo, op, wkt);
+    };
+    auto And = [](milvus::expr::TypedExprPtr a,
+                  milvus::expr::TypedExprPtr b) -> milvus::expr::TypedExprPtr {
+        return std::make_shared<milvus::expr::LogicalBinaryExpr>(
+            milvus::expr::LogicalBinaryExpr::OpType::And, a, b);
+    };
+    auto Or = [](milvus::expr::TypedExprPtr a,
+                 milvus::expr::TypedExprPtr b) -> milvus::expr::TypedExprPtr {
+        return std::make_shared<milvus::expr::LogicalBinaryExpr>(
+            milvus::expr::LogicalBinaryExpr::OpType::Or, a, b);
+    };
+    const auto kInter = proto::plan::GISFunctionFilterExpr_GISOp_Intersects;
+    const auto kWithin = proto::plan::GISFunctionFilterExpr_GISOp_Within;
+
+    std::vector<milvus::expr::TypedExprPtr> filters = {
+        // scalar AND single GIS (indexed)
+        And(scalar, gis(kInter, "POLYGON((-2 -2,2 -2,2 2,-2 2,-2 -2))")),
+        // scalar AND (GIS OR GIS) -- Shape B
+        And(scalar,
+            Or(gis(kInter, "POLYGON((-2 -2,2 -2,2 2,-2 2,-2 -2))"),
+               gis(kInter, "POLYGON((10 10,20 10,20 20,10 20,10 10))"))),
+        // same-field AND group (intersects + within)
+        And(gis(kInter, "POLYGON((-2 -2,2 -2,2 2,-2 2,-2 -2))"),
+            gis(kWithin,
+                "POLYGON((-100 -100,100 -100,100 100,-100 100,-100 -100))")),
+    };
+
+    auto run = [&](const milvus::expr::TypedExprPtr& f,
+                   bool enable) -> BitsetType {
+        SegcoreConfig::default_config().set_enable_gis_split_fusion(enable);
+        auto node =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, f);
+        auto bits = ExecuteQueryExpr(node, sealed.get(), N, MAX_TIMESTAMP);
+        SegcoreConfig::default_config().set_enable_gis_split_fusion(false);
+        return bits;
+    };
+
+    for (const auto& f : filters) {
+        BitsetType baseline = run(f, false);
+        BitsetType fused = run(f, true);
+        ASSERT_EQ(baseline.size(), fused.size());
+        ASSERT_EQ(baseline.size(), static_cast<size_t>(N));
+        for (int i = 0; i < N; ++i) {
+            ASSERT_EQ(bool(baseline[i]), bool(fused[i])) << "row " << i;
+        }
+    }
+
+    sealed.reset();
+    CleanupIndexFiles(stats->GetIndexFiles(), "GIS split-fusion equivalence");
+}

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 
 #include "RTreeIndex.h"
+#include "common/Common.h"  // EXEC_EVAL_EXPR_BATCH_SIZE (indexed multi-batch test)
 #include "storage/Util.h"
 #include "storage/FileManager.h"
 #include "common/Types.h"
@@ -863,9 +864,41 @@ TEST_F(RTreeIndexTest, GIS_Index_Exact_Filtering) {
     CleanupIndexFiles(stats->GetIndexFiles(), "GIS filtering test");
 }
 
+namespace {
+// RAII guard so enableGISSplitFusion is always restored to false, even if
+// ExecuteQueryExpr throws mid-run (a bare set/restore would leak the global
+// flag into later tests).
+struct GisSplitFusionFlagGuard {
+    explicit GisSplitFusionFlagGuard(bool enable) {
+        milvus::segcore::SegcoreConfig::default_config()
+            .set_enable_gis_split_fusion(enable);
+    }
+    ~GisSplitFusionFlagGuard() {
+        milvus::segcore::SegcoreConfig::default_config()
+            .set_enable_gis_split_fusion(false);
+    }
+};
+
+// RAII guard for the expr batch size, restored on scope exit, so the indexed
+// equivalence check runs across MULTIPLE Eval batches (exercising the split
+// nodes' per-batch coarse slicing + dual-cursor advance on the indexed path).
+struct ExprBatchSizeGuardLocal {
+    int64_t saved;
+    explicit ExprBatchSizeGuardLocal(int64_t batch_size)
+        : saved(EXEC_EVAL_EXPR_BATCH_SIZE.load()) {
+        EXEC_EVAL_EXPR_BATCH_SIZE.store(batch_size);
+    }
+    ~ExprBatchSizeGuardLocal() {
+        EXEC_EVAL_EXPR_BATCH_SIZE.store(saved);
+    }
+};
+}  // namespace
+
 // Equivalence test for the GIS coarse/refine split + same-column fusion on the
 // INDEXED path: with a geometry R-Tree index loaded, the Coarse node's
-// RunRTreeQuery is exercised. enableGISSplitFusion ON must match OFF.
+// RunRTreeQuery is exercised. enableGISSplitFusion ON must match OFF. The check
+// is run under a small batch size so the indexed coarse-bitmap slicing crosses
+// batch boundaries (indexed x multi-batch coverage).
 TEST_F(RTreeIndexTest, GIS_SplitFusion_Equivalence_Indexed) {
     using namespace milvus;
     using namespace milvus::query;
@@ -989,17 +1022,28 @@ TEST_F(RTreeIndexTest, GIS_SplitFusion_Equivalence_Indexed) {
         And(gis(kInter, "POLYGON((-2 -2,2 -2,2 2,-2 2,-2 -2))"),
             gis(kWithin,
                 "POLYGON((-100 -100,100 -100,100 100,-100 100,-100 -100))")),
+        // direct AND-leaf + Shape-B subgroup on the SAME field: geo is both a
+        // direct conjunction leaf (within) and inside an OR subgroup, so the
+        // rewrite emits two independent coarse/refine pairs for it -- the
+        // dual-pair path, on the indexed side.
+        And(gis(kWithin,
+                "POLYGON((-100 -100,100 -100,100 100,-100 100,-100 -100))"),
+            Or(gis(kInter, "POLYGON((-2 -2,2 -2,2 2,-2 2,-2 -2))"),
+               gis(kInter, "POLYGON((10 10,20 10,20 20,10 20,10 10))"))),
     };
 
     auto run = [&](const milvus::expr::TypedExprPtr& f,
                    bool enable) -> BitsetType {
-        SegcoreConfig::default_config().set_enable_gis_split_fusion(enable);
+        // RAII: flag restored even if ExecuteQueryExpr throws.
+        GisSplitFusionFlagGuard guard(enable);
         auto node =
             std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, f);
-        auto bits = ExecuteQueryExpr(node, sealed.get(), N, MAX_TIMESTAMP);
-        SegcoreConfig::default_config().set_enable_gis_split_fusion(false);
-        return bits;
+        return ExecuteQueryExpr(node, sealed.get(), N, MAX_TIMESTAMP);
     };
+
+    // Force multiple Eval batches (N=200 -> ~4 batches) so the indexed coarse
+    // slicing is exercised across batch boundaries, not just a single batch.
+    ExprBatchSizeGuardLocal batch_guard(64);
 
     for (const auto& f : filters) {
         BitsetType baseline = run(f, false);

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -1010,6 +1010,7 @@ TEST_F(RTreeIndexTest, GIS_SplitFusion_Equivalence_Indexed) {
     };
     const auto kInter = proto::plan::GISFunctionFilterExpr_GISOp_Intersects;
     const auto kWithin = proto::plan::GISFunctionFilterExpr_GISOp_Within;
+    const auto kDWithin = proto::plan::GISFunctionFilterExpr_GISOp_DWithin;
 
     std::vector<milvus::expr::TypedExprPtr> filters = {
         // scalar AND single GIS (indexed)
@@ -1030,6 +1031,21 @@ TEST_F(RTreeIndexTest, GIS_SplitFusion_Equivalence_Indexed) {
                 "POLYGON((-100 -100,100 -100,100 100,-100 100,-100 -100))"),
             Or(gis(kInter, "POLYGON((-2 -2,2 -2,2 2,-2 2,-2 -2))"),
                gis(kInter, "POLYGON((10 10,20 10,20 20,10 20,10 10))"))),
+        // DWithin mixed with a groupable GIS leaf on the SAME field, on the
+        // INDEXED side -- the config where a wrongly-grouped DWithin actually
+        // corrupts the coarse phase (RunRTreeQuery would query the R-Tree
+        // with the raw point instead of the distance-expanded bbox from
+        // create_bounding_box_for_dwithin, and the group's Pred drops the
+        // distance so refine degrades to 0.0). DWithin must stay on the
+        // baseline path per the as_groupable_gis whitelist. Query point (3,3)
+        // with a 1,000,000 m geodesic radius reaches the origin cluster
+        // (point / small polygon / linestring, each a few hundred km away)
+        // but not the (10,10)-(20,20) polygon (~1,100 km): a distance-0
+        // degradation would select zero rows here, so ON-vs-OFF diverges
+        // loudly if DWithin ever enters a fusion group.
+        And(std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+                col_geo, kDWithin, "POINT(3 3)", /*distance=*/1000000.0),
+            gis(kInter, "POLYGON((-2 -2,2 -2,2 2,-2 2,-2 -2))")),
     };
 
     auto run = [&](const milvus::expr::TypedExprPtr& f,

--- a/internal/core/src/monitor/Monitor.cpp
+++ b/internal/core/src/monitor/Monitor.cpp
@@ -188,6 +188,10 @@ std::map<std::string, std::string> optimizeExprLatencyLabels{
     {"type", "optimize_expr_latency"}};
 std::map<std::string, std::string> filterRatioLabels{
     {"type", "expr_filter_ratio"}};
+std::map<std::string, std::string> gisCoarseRatioLabels{
+    {"type", "gis_coarse_ratio"}};
+std::map<std::string, std::string> gisRefineRatioLabels{
+    {"type", "gis_refine_ratio"}};
 
 DEFINE_PROMETHEUS_HISTOGRAM_FAMILY(internal_core_search_latency,
                                    "[cpp]latency(us) of search on segment")
@@ -229,6 +233,14 @@ DEFINE_PROMETHEUS_HISTOGRAM(internal_core_optimize_expr_latency,
 DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(internal_core_expr_filter_ratio,
                                          internal_core_search_latency,
                                          filterRatioLabels,
+                                         ratioBuckets)
+DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(internal_core_gis_coarse_ratio,
+                                         internal_core_search_latency,
+                                         gisCoarseRatioLabels,
+                                         ratioBuckets)
+DEFINE_PROMETHEUS_HISTOGRAM_WITH_BUCKETS(internal_core_gis_refine_ratio,
+                                         internal_core_search_latency,
+                                         gisRefineRatioLabels,
                                          ratioBuckets)
 // mmap metrics
 std::map<std::string, std::string> mmapAllocatedSpaceAnonLabel = {

--- a/internal/core/src/monitor/Monitor.h
+++ b/internal/core/src/monitor/Monitor.h
@@ -80,11 +80,13 @@ DECLARE_PROMETHEUS_HISTOGRAM(internal_core_search_get_target_entry_latency);
 DECLARE_PROMETHEUS_HISTOGRAM(internal_core_search_latency_random_sample);
 DECLARE_PROMETHEUS_HISTOGRAM(internal_core_optimize_expr_latency);
 DECLARE_PROMETHEUS_HISTOGRAM(internal_core_expr_filter_ratio);
-// GIS split-fusion pruning ratios, emitted once per segment per query when
-// queryNode.segcore.enableGISSplitFusion is on (no split nodes exist when it is
-// off, so these stay empty). Both are fractions of the segment's active rows:
-// coarse = rows surviving the R-Tree coarse pass, refine = rows Refine actually
-// builds a geometry for. Refine's ratio IS the optimization's contract -- if it
+// GIS split-fusion pruning ratios, emitted once per completed GIS group per
+// segment query when queryNode.segcore.enableGISSplitFusion is on (no split
+// nodes exist when it is off, so these stay empty). Both are fractions of the
+// segment's active rows:
+// coarse = rows surviving the R-Tree coarse pass, refine = survivors of
+// (scalars AND B_coarse) that Refine fetched (a geometry is then built only for
+// the non-null subset). Refine's ratio IS the optimization's contract -- if it
 // approaches 1 the pruning has silently degraded to a full scan.
 DECLARE_PROMETHEUS_HISTOGRAM(internal_core_gis_coarse_ratio);
 DECLARE_PROMETHEUS_HISTOGRAM(internal_core_gis_refine_ratio);

--- a/internal/core/src/monitor/Monitor.h
+++ b/internal/core/src/monitor/Monitor.h
@@ -80,6 +80,14 @@ DECLARE_PROMETHEUS_HISTOGRAM(internal_core_search_get_target_entry_latency);
 DECLARE_PROMETHEUS_HISTOGRAM(internal_core_search_latency_random_sample);
 DECLARE_PROMETHEUS_HISTOGRAM(internal_core_optimize_expr_latency);
 DECLARE_PROMETHEUS_HISTOGRAM(internal_core_expr_filter_ratio);
+// GIS split-fusion pruning ratios, emitted once per segment per query when
+// queryNode.segcore.enableGISSplitFusion is on (no split nodes exist when it is
+// off, so these stay empty). Both are fractions of the segment's active rows:
+// coarse = rows surviving the R-Tree coarse pass, refine = rows Refine actually
+// builds a geometry for. Refine's ratio IS the optimization's contract -- if it
+// approaches 1 the pruning has silently degraded to a full scan.
+DECLARE_PROMETHEUS_HISTOGRAM(internal_core_gis_coarse_ratio);
+DECLARE_PROMETHEUS_HISTOGRAM(internal_core_gis_refine_ratio);
 
 // async cgo metrics
 DECLARE_PROMETHEUS_HISTOGRAM_FAMILY(internal_cgo_queue_duration_seconds);

--- a/internal/core/src/segcore/SegcoreConfig.h
+++ b/internal/core/src/segcore/SegcoreConfig.h
@@ -167,6 +167,16 @@ class SegcoreConfig {
         return interim_index_mem_expansion_rate_;
     }
 
+    void
+    set_enable_gis_split_fusion(bool value) {
+        enable_gis_split_fusion_ = value;
+    }
+
+    bool
+    get_enable_gis_split_fusion() const {
+        return enable_gis_split_fusion_;
+    }
+
  private:
     inline static const std::unordered_set<std::string>
         valid_dense_vector_index_type = {
@@ -186,6 +196,7 @@ class SegcoreConfig {
         knowhere::RefineType::DATA_VIEW;
     inline static bool refine_with_quant_flag_ = false;
     inline static bool enable_geometry_cache_ = false;
+    inline static bool enable_gis_split_fusion_ = false;
     inline static float interim_index_mem_expansion_rate_ = 1.15f;
 };
 

--- a/internal/core/src/segcore/segcore_init_c.cpp
+++ b/internal/core/src/segcore/segcore_init_c.cpp
@@ -50,6 +50,13 @@ SegcoreSetEnableGeometryCache(const bool value) {
 }
 
 extern "C" void
+SegcoreSetEnableGISSplitFusion(const bool value) {
+    milvus::segcore::SegcoreConfig& config =
+        milvus::segcore::SegcoreConfig::default_config();
+    config.set_enable_gis_split_fusion(value);
+}
+
+extern "C" void
 SegcoreSetNlist(const int64_t value) {
     milvus::segcore::SegcoreConfig& config =
         milvus::segcore::SegcoreConfig::default_config();

--- a/internal/core/src/segcore/segcore_init_c.h
+++ b/internal/core/src/segcore/segcore_init_c.h
@@ -34,6 +34,9 @@ void
 SegcoreSetEnableGeometryCache(const bool);
 
 void
+SegcoreSetEnableGISSplitFusion(const bool);
+
+void
 SegcoreSetNlist(const int64_t);
 
 void

--- a/internal/util/initcore/init_core.go
+++ b/internal/util/initcore/init_core.go
@@ -713,6 +713,12 @@ func InitGeometryCache(params *paramtable.ComponentParam) error {
 	return nil
 }
 
+func InitGISSplitFusion(params *paramtable.ComponentParam) error {
+	enableGISSplitFusion := C.bool(params.QueryNodeCfg.EnableGISSplitFusion.GetAsBool())
+	C.SegcoreSetEnableGISSplitFusion(enableGISSplitFusion)
+	return nil
+}
+
 func CleanRemoteChunkManager() {
 	C.CleanRemoteChunkManagerSingleton()
 }

--- a/internal/util/initcore/query_node.go
+++ b/internal/util/initcore/query_node.go
@@ -193,6 +193,11 @@ func doInitQueryNodeOnce(ctx context.Context) error {
 		return err
 	}
 
+	err = InitGISSplitFusion(paramtable.Get())
+	if err != nil {
+		return err
+	}
+
 	InitTraceConfig(paramtable.Get())
 	C.InitExecExpressionFunctionFactory()
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3474,6 +3474,7 @@ type queryNodeConfig struct {
 	InterimIndexBuildParallelRate ParamItem `refreshable:"false"`
 	MultipleChunkedEnable         ParamItem `refreshable:"false"` // Deprecated
 	EnableGeometryCache           ParamItem `refreshable:"false"`
+	EnableGISSplitFusion          ParamItem `refreshable:"false"`
 
 	TieredWarmupScalarField         ParamItem `refreshable:"true"`
 	TieredWarmupScalarIndex         ParamItem `refreshable:"true"`
@@ -4141,6 +4142,15 @@ This defaults to true, indicating that Milvus creates temporary index for growin
 		Export:       true,
 	}
 	p.EnableGeometryCache.Init(base.mgr)
+
+	p.EnableGISSplitFusion = ParamItem{
+		Key:          "queryNode.segcore.enableGISSplitFusion",
+		Version:      "2.6.6",
+		DefaultValue: "false",
+		Doc:          "Enable GIS filter coarse/refine split + same-column fusion optimization",
+		Export:       true,
+	}
+	p.EnableGISSplitFusion.Init(base.mgr)
 
 	p.InterimIndexNProbe = ParamItem{
 		Key:     "queryNode.segcore.interimIndex.nprobe",


### PR DESCRIPTION
Backport of #50675 to the 2.6 branch.

Splits same-column geometry predicates of an AND conjunction into a cheap
R-Tree coarse node (scheduled early to prune other predicates via bitmap_input)
and an expensive exact-refine node (scheduled last, fusing per-row geometry
construction so a surviving row's geometry is built once and evaluated against
all same-column predicates). Gated by `queryNode.segcore.enableGISSplitFusion`
(default false).

All 16 commits of the master PR are covered (doc / feat / test / review fixes /
observability). Conflicts were limited to same-column geometry filter / segcore
config insertion points and were resolved to keep only the GIS additions
(master-only features such as the namespace filter and visibility/prefer-field-data
flags were dropped, as they do not exist on 2.6). The backported GIS code depends
only on APIs already present on 2.6 (bulk_subscript(OpContext*), EnsurePinnedIndex,
GetThreadLocalGEOSContext, QueryContext getters, EvalCtx::get_bitmap_input,
SimpleGeometryCacheManager).

Also included (master's final three commits, added after this PR was first opened):
- **Pruning observability**: `coarse_selected` / `refined_rows` counters on
  `GISGroupState`, reported once per (segment, query) from its destructor as
  `internal_core_gis_coarse_ratio` / `internal_core_gis_refine_ratio` (ratio
  histograms). The refine ratio *is* the optimization's contract — approaching 1
  means pruning has silently degraded to a full scan, which no equivalence test
  can detect. Nothing is emitted with the flag off.
- **Degrade logging**: one `LOG_WARN` per segment when the field reports an index
  but the pin yields no usable string index (results stay correct, all R-Tree
  pruning is lost), one `LOG_DEBUG` for the expected no-index case.
- **Adversarial-review fixes**: Coarse intersects its emitted slice with
  `bitmap_input` so an outer conjunction's mask prunes a *nested* split group;
  metric reporting is gated on both node cursors having accounted for the whole
  segment.
- **Coverage**: ON/OFF equivalence for the five remaining whitelisted operators,
  an OR-rooted split shape, `NestedOuterMaskPrunesRefine`, and counter-based
  assertions that fail (rather than silently pass) if the pruning is removed.

### Deliberately not backported (2.6 lacks the machinery), each marked with a NOTE in the code

- `PhyGISRefineConjunctExpr::DetermineExecPath()` / `PrefetchRawData()` and the
  Coarse `PrefetchRawData()` no-op: 2.6's `SegmentExpr` has no lazy exec-path or
  expression-level prefetch (`exec_path_`, `PrefetchRawData`, `WaitPrefetch`,
  `DetermineExecPath`). The scalar index is pinned eagerly in `InitSegmentExpr`,
  so `EnsurePinnedIndex()` / `WaitPrefetch()` have nothing to do here either.
- `GISSplitStaysBatchedNotAllAtOnce` test and the two "deliberately not
  overridden" `CanExecuteAllAtOnce()` comments: 2.6 has no all-at-once path
  (`CanExecuteAllAtOnce` / `SetExecuteAllAtOnce` do not exist), so every
  expression is batched unconditionally and there is nothing to pin.
- The two `st_isvalid` equivalence cases: the `ST_IsValid` GIS op does not exist
  on 2.6 (plan proto `GISOp` stops at `DWithin`). The `as_groupable_gis`
  whitelist that defends against it is backported.

### Rebase note

Rebased onto the current 2.6 head. `SupportOffsetInput()` → false, which this PR
originally carried, has since landed independently as #51487, so after the rebase
this PR no longer touches it. The baseline op_ctx threading fix is still carried
here.

pr: #50675
issue: #50674
design doc: docs/design_docs/gis_filter_coarse_refine_split_fusion.md