### PR TITLE
fix: avoid holding writebuffer lock during sync submit

### DIFF
--- a/internal/flushcommon/writebuffer/l0_write_buffer.go
+++ b/internal/flushcommon/writebuffer/l0_write_buffer.go
@@ -60,7 +60,6 @@ func (wb *l0WriteBuffer) dispatchDeleteMsgsWithoutFilter(deleteMsgs []*msgstream
 
 func (wb *l0WriteBuffer) BufferData(insertData []*InsertData, deleteMsgs []*msgstream.DeleteMsg, startPos, endPos *msgpb.MsgPosition, schemaVersion int32) error {
 	wb.mut.Lock()
-	defer wb.mut.Unlock()
 
 	for _, inData := range insertData {
 		if wb.useGrowingSourceFlush {
@@ -74,6 +73,7 @@ func (wb *l0WriteBuffer) BufferData(insertData []*InsertData, deleteMsgs []*msgs
 
 		err := wb.bufferInsert(inData, startPos, endPos, schemaVersion)
 		if err != nil {
+			wb.mut.Unlock()
 			return err
 		}
 	}
@@ -93,6 +93,12 @@ func (wb *l0WriteBuffer) BufferData(insertData []*InsertData, deleteMsgs []*msgs
 			delete(wb.l0partition, segment)
 			delete(wb.l0Segments, partition)
 		}
+	}
+	syncTasks := wb.getSyncTasksLocked(context.Background(), segmentsSync)
+	wb.mut.Unlock()
+
+	if len(syncTasks) > 0 {
+		wb.submitSyncTasks(context.Background(), syncTasks)
 	}
 
 	return nil

--- a/internal/flushcommon/writebuffer/write_buffer.go
+++ b/internal/flushcommon/writebuffer/write_buffer.go
@@ -521,17 +521,19 @@ func (wb *writeBufferBase) EvictBuffer(policies ...SyncPolicy) {
 
 	ts := wb.checkpoint.GetTimestamp()
 	segmentIDs := wb.getSegmentsToSync(ts, policies...)
-
-	var futures []*conc.Future[struct{}]
+	var syncTasks []syncmgr.Task
 	if len(segmentIDs) > 0 {
 		logger.Info(context.TODO(), "evict buffer find segments to sync", mlog.Int64s("segmentIDs", segmentIDs))
-		futures = wb.syncSegments(context.Background(), segmentIDs)
+		syncTasks = wb.getSyncTasksLocked(context.Background(), segmentIDs)
 	}
 
 	wb.mut.Unlock()
 
-	if len(futures) > 0 {
-		conc.AwaitAll(futures...)
+	if len(syncTasks) > 0 {
+		futures := wb.submitSyncTasks(context.Background(), syncTasks)
+		if len(futures) > 0 {
+			conc.AwaitAll(futures...)
+		}
 	}
 }
 
@@ -729,15 +731,18 @@ func (wb *writeBufferBase) retryGrowingSourceProgress() {
 		wb.scheduleGrowingSourceRetryLocked()
 	}
 
-	var futures []*conc.Future[struct{}]
+	var syncTasks []syncmgr.Task
 	if len(segmentIDs) > 0 {
 		wb.logger.Info(context.TODO(), "retry growing-source source sync", mlog.Int64s("segmentIDs", segmentIDs))
-		futures = wb.syncSegments(context.Background(), segmentIDs)
+		syncTasks = wb.getSyncTasksLocked(context.Background(), segmentIDs)
 	}
 	wb.mut.Unlock()
 
-	if len(futures) > 0 {
-		conc.AwaitAll(futures...)
+	if len(syncTasks) > 0 {
+		futures := wb.submitSyncTasks(context.Background(), syncTasks)
+		if len(futures) > 0 {
+			conc.AwaitAll(futures...)
+		}
 	}
 }
 
@@ -813,8 +818,6 @@ func (wb *writeBufferBase) triggerSync() (segmentIDs []int64) {
 	segmentsToSync := wb.getSegmentsToSync(wb.checkpoint.GetTimestamp(), wb.syncPolicies...)
 	if len(segmentsToSync) > 0 {
 		mlog.Info(context.TODO(), "write buffer get segments to sync", mlog.Int64s("segmentIDs", segmentsToSync))
-		// ignore future here, use callback to handle error
-		wb.syncSegments(context.Background(), segmentsToSync)
 	}
 
 	return segmentsToSync
@@ -869,7 +872,16 @@ func (wb *writeBufferBase) dropPartitions(partitionIDs []int64) {
 }
 
 func (wb *writeBufferBase) syncSegments(ctx context.Context, segmentIDs []int64) []*conc.Future[struct{}] {
-	result := make([]*conc.Future[struct{}], 0, len(segmentIDs))
+	wb.mut.Lock()
+	syncTasks := wb.getSyncTasksLocked(ctx, segmentIDs)
+	wb.mut.Unlock()
+	return wb.submitSyncTasks(ctx, syncTasks)
+}
+
+// getSyncTasksLocked builds sync tasks and moves payload out of the write buffer.
+// The caller must hold wb.mut and submit the returned tasks after releasing it.
+func (wb *writeBufferBase) getSyncTasksLocked(ctx context.Context, segmentIDs []int64) []syncmgr.Task {
+	result := make([]syncmgr.Task, 0, len(segmentIDs))
 	for _, segmentID := range segmentIDs {
 		syncTask, err := wb.getSyncTask(ctx, segmentID)
 		if err != nil {
@@ -887,7 +899,14 @@ func (wb *writeBufferBase) syncSegments(ctx context.Context, segmentIDs []int64)
 				mlog.Fatal(ctx, "failed to get sync task", mlog.FieldSegmentID(segmentID), mlog.Err(err))
 			}
 		}
+		result = append(result, syncTask)
+	}
+	return result
+}
 
+func (wb *writeBufferBase) submitSyncTasks(ctx context.Context, syncTasks []syncmgr.Task) []*conc.Future[struct{}] {
+	result := make([]*conc.Future[struct{}], 0, len(syncTasks))
+	for _, syncTask := range syncTasks {
 		future, err := wb.syncMgr.SyncData(ctx, syncTask, func(err error) error {
 			if wb.taskObserverCallback != nil {
 				wb.taskObserverCallback(syncTask, err)
@@ -935,10 +954,10 @@ func (wb *writeBufferBase) syncSegments(ctx context.Context, segmentIDs []int64)
 						}
 					}
 				}
-				if resyncGrowingSourceSegmentID != 0 {
-					wb.syncSegments(context.Background(), []int64{resyncGrowingSourceSegmentID})
-				}
 				wb.mut.Unlock()
+			}
+			if resyncGrowingSourceSegmentID != 0 {
+				wb.syncSegments(context.Background(), []int64{resyncGrowingSourceSegmentID})
 			}
 
 			if err != nil {
@@ -959,7 +978,7 @@ func (wb *writeBufferBase) syncSegments(ctx context.Context, segmentIDs []int64)
 			if growingSourceTask, ok := syncTask.(*syncmgr.GrowingSourceSyncTask); ok {
 				growingSourceTask.ReleaseSource()
 			}
-			mlog.Fatal(ctx, "failed to sync data", mlog.Int64("segmentID", segmentID), mlog.Err(err))
+			mlog.Fatal(ctx, "failed to sync data", mlog.Int64("segmentID", syncTask.SegmentID()), mlog.Err(err))
 		}
 		result = append(result, future)
 	}
@@ -1478,7 +1497,7 @@ func (wb *writeBufferBase) Close(ctx context.Context, drop bool) {
 		return
 	}
 
-	var futures []*conc.Future[struct{}]
+	var syncTasks []syncmgr.Task
 	segmentIDs := typeutil.NewSet[int64]()
 	for id := range wb.buffers {
 		segmentIDs.Insert(id)
@@ -1507,7 +1526,28 @@ func (wb *writeBufferBase) Close(ctx context.Context, drop bool) {
 		case *syncmgr.GrowingSourceSyncTask:
 			t.WithDrop()
 		}
+		syncTasks = append(syncTasks, syncTask)
+	}
+	wb.mut.Unlock()
 
+	futures := wb.submitDropSyncTasks(ctx, syncTasks)
+	err := conc.AwaitAll(futures...)
+	if err != nil {
+		mlog.Error(ctx, "failed to sink write buffer data", mlog.Err(err))
+		// TODO change to remove channel in the future
+		panic(err)
+	}
+	err = wb.metaWriter.DropChannel(ctx, wb.channelName)
+	if err != nil {
+		mlog.Error(ctx, "failed to drop channel", mlog.Err(err))
+		// TODO change to remove channel in the future
+		panic(err)
+	}
+}
+
+func (wb *writeBufferBase) submitDropSyncTasks(ctx context.Context, syncTasks []syncmgr.Task) []*conc.Future[struct{}] {
+	futures := make([]*conc.Future[struct{}], 0, len(syncTasks))
+	for _, syncTask := range syncTasks {
 		f, err := wb.syncMgr.SyncData(ctx, syncTask, func(err error) error {
 			if wb.taskObserverCallback != nil {
 				wb.taskObserverCallback(syncTask, err)
@@ -1527,24 +1567,11 @@ func (wb *writeBufferBase) Close(ctx context.Context, drop bool) {
 			if growingSourceTask, ok := syncTask.(*syncmgr.GrowingSourceSyncTask); ok {
 				growingSourceTask.ReleaseSource()
 			}
-			mlog.Fatal(ctx, "failed to sync segment", mlog.Int64("segmentID", id), mlog.Err(err))
+			mlog.Fatal(ctx, "failed to sync segment", mlog.Int64("segmentID", syncTask.SegmentID()), mlog.Err(err))
 		}
 		futures = append(futures, f)
 	}
-	wb.mut.Unlock()
-
-	err := conc.AwaitAll(futures...)
-	if err != nil {
-		mlog.Error(ctx, "failed to sink write buffer data", mlog.Err(err))
-		// TODO change to remove channel in the future
-		panic(err)
-	}
-	err = wb.metaWriter.DropChannel(ctx, wb.channelName)
-	if err != nil {
-		mlog.Error(ctx, "failed to drop channel", mlog.Err(err))
-		// TODO change to remove channel in the future
-		panic(err)
-	}
+	return futures
 }
 
 // prepareInsert transfers InsertMsg into organized InsertData grouped by segmentID

--- a/internal/flushcommon/writebuffer/write_buffer_test.go
+++ b/internal/flushcommon/writebuffer/write_buffer_test.go
@@ -419,6 +419,147 @@ func (s *WriteBufferSuite) TestEvictBuffer() {
 		wb.EvictBuffer(GetOldestBufferPolicy(1))
 	})
 
+	s.Run("sync_submit_outside_lock", func() {
+		buf, err := newSegmentBuffer(4, s.collSchema)
+		s.Require().NoError(err)
+		buf.insertBuffer.startPos = &msgpb.MsgPosition{Timestamp: 440}
+		buf.deltaBuffer.startPos = &msgpb.MsgPosition{Timestamp: 400}
+
+		wb.mut.Lock()
+		wb.buffers[4] = buf
+		wb.checkpoint = &msgpb.MsgPosition{Timestamp: 1000}
+		wb.mut.Unlock()
+
+		segment := metacache.NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 4,
+		}, nil, nil)
+		s.metacache.EXPECT().GetSegmentByID(int64(4)).Return(segment, true)
+		s.metacache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return()
+
+		submitEntered := make(chan struct{})
+		releaseSubmit := make(chan struct{})
+		s.syncMgr.EXPECT().SyncData(mock.Anything, mock.MatchedBy(func(task syncmgr.Task) bool {
+			return task != nil && task.SegmentID() == 4
+		}), mock.Anything).RunAndReturn(
+			func(context.Context, syncmgr.Task, ...func(error) error) (*conc.Future[struct{}], error) {
+				close(submitEntered)
+				<-releaseSubmit
+				return conc.Go[struct{}](func() (struct{}, error) {
+					return struct{}{}, nil
+				}), nil
+			},
+		).Once()
+
+		evictDone := make(chan struct{})
+		go func() {
+			defer close(evictDone)
+			wb.EvictBuffer(GetOldestBufferPolicy(1))
+		}()
+
+		select {
+		case <-submitEntered:
+		case <-time.After(3 * time.Second):
+			s.FailNow("SyncData should be called before checking the write buffer lock")
+		}
+
+		readDone := make(chan struct{})
+		go func() {
+			defer close(readDone)
+			_ = wb.MemorySize()
+		}()
+
+		select {
+		case <-readDone:
+		case <-time.After(3 * time.Second):
+			s.FailNow("write buffer read lock should not be blocked by SyncData submit")
+		}
+
+		close(releaseSubmit)
+		select {
+		case <-evictDone:
+		case <-time.After(3 * time.Second):
+			s.FailNow("EvictBuffer should finish after SyncData submit is released")
+		}
+	})
+
+	s.Run("drop_close_sync_submit_outside_lock", func() {
+		syncMgr := syncmgr.NewMockSyncManager(s.T())
+		metaCache := metacache.NewMockMetaCache(s.T())
+		metaWriter := syncmgr.NewMockMetaWriter(s.T())
+		metaCache.EXPECT().GetSchema(mock.Anything).Return(s.collSchema).Maybe()
+		metaCache.EXPECT().Collection().Return(s.collID).Maybe()
+
+		closeWB, err := newWriteBufferBase(s.channelName, metaCache, syncMgr, &writeBufferOption{
+			metaWriter: metaWriter,
+			pkStatsFactory: func(vchannel *datapb.SegmentInfo) pkoracle.PkStat {
+				return pkoracle.NewBloomFilterSet()
+			},
+		})
+		s.Require().NoError(err)
+
+		buf, err := newSegmentBuffer(5, s.collSchema)
+		s.Require().NoError(err)
+		buf.insertBuffer.startPos = &msgpb.MsgPosition{Timestamp: 540}
+		buf.deltaBuffer.startPos = &msgpb.MsgPosition{Timestamp: 500}
+
+		closeWB.mut.Lock()
+		closeWB.buffers[5] = buf
+		closeWB.checkpoint = &msgpb.MsgPosition{Timestamp: 1000}
+		closeWB.mut.Unlock()
+
+		segment := metacache.NewSegmentInfo(&datapb.SegmentInfo{
+			ID: 5,
+		}, nil, nil)
+		metaCache.EXPECT().GetSegmentByID(int64(5)).Return(segment, true)
+		metaCache.EXPECT().UpdateSegments(mock.Anything, mock.Anything).Return()
+
+		submitEntered := make(chan struct{})
+		releaseSubmit := make(chan struct{})
+		syncMgr.EXPECT().SyncData(mock.Anything, mock.MatchedBy(func(task syncmgr.Task) bool {
+			return task != nil && task.SegmentID() == 5 && task.IsDrop()
+		}), mock.Anything).RunAndReturn(
+			func(context.Context, syncmgr.Task, ...func(error) error) (*conc.Future[struct{}], error) {
+				close(submitEntered)
+				<-releaseSubmit
+				return conc.Go[struct{}](func() (struct{}, error) {
+					return struct{}{}, nil
+				}), nil
+			},
+		).Once()
+		metaWriter.EXPECT().DropChannel(mock.Anything, s.channelName).Return(nil).Once()
+
+		closeDone := make(chan struct{})
+		go func() {
+			defer close(closeDone)
+			closeWB.Close(context.Background(), true)
+		}()
+
+		select {
+		case <-submitEntered:
+		case <-time.After(3 * time.Second):
+			s.FailNow("SyncData should be called before checking the write buffer lock")
+		}
+
+		readDone := make(chan struct{})
+		go func() {
+			defer close(readDone)
+			_ = closeWB.MemorySize()
+		}()
+
+		select {
+		case <-readDone:
+		case <-time.After(3 * time.Second):
+			s.FailNow("write buffer read lock should not be blocked by Close SyncData submit")
+		}
+
+		close(releaseSubmit)
+		select {
+		case <-closeDone:
+		case <-time.After(3 * time.Second):
+			s.FailNow("Close should finish after SyncData submit is released")
+		}
+	})
+
 	s.Run("await_outside_lock", func() {
 		mockAllocator := allocator.NewMockAllocator(s.T())
 		var nextSegmentID atomic.Int64


### PR DESCRIPTION
issue: #50750

Move sync task submission out of the writebuffer mutex. The writebuffer still selects segments, yields buffered payload, records sync checkpoints, and marks segment syncing while holding the lock, but submits the already built tasks to syncmgr after releasing it.

This prevents ReleaseCollection from hanging in manual-flush preparation when syncmgr dispatcher backpressure blocks SyncData submission, because CheckReleaseManualFlushNeed can still acquire the writebuffer read lock.

Also move growing-source follow-up resync out of the callback critical section and add a regression test that blocks SyncData submission while verifying writebuffer readers are not blocked.