### PR TITLE
fix: [2.6] add missing fmt import in datacoord task_index.go

### DIFF
--- a/internal/datacoord/task_index.go
+++ b/internal/datacoord/task_index.go
@@ -18,6 +18,7 @@ package datacoord
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"strings"
 	"time"


### PR DESCRIPTION
issue: #50764

The `2.6` branch CI is currently failing to compile (`build-go`) at `cce25693c6`:

```
internal/datacoord/task_index.go:332:41: undefined: fmt
internal/datacoord/task_index.go:355:41: undefined: fmt
make: *** [Makefile:113: build-go] Error 1
```

### Root cause — merge-order conflict

- #50545 (merr error-handling standardization) replaced every `fmt.*` use in `task_index.go` with `merr.*` and dropped the then-unused `fmt` import.
- #50727 (ArrayOfVector EmbList indexes) then added two new `fmt.Sprintf` calls but did not re-add the `fmt` import.

Each PR compiled in isolation, but the merged tree did not. This is the same class of failure as #50756.

### Fix

Re-add the `fmt` import to `internal/datacoord/task_index.go`, unblocking the 2.6 branch build. `gofmt` clean; the import has two real usages so it is not unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
