### PR TITLE
fix: upgrade openssl across all runtime images for CVE-2026-45447

### DIFF
--- a/build/docker/milvus/amazonlinux2023/Dockerfile
+++ b/build/docker/milvus/amazonlinux2023/Dockerfile
@@ -15,6 +15,7 @@ ARG TARGETARCH
 ARG MILVUS_ASAN_LIB
 
 RUN yum install -y wget libgomp libaio libatomic tzdata && \
+    yum upgrade -y openssl openssl-libs && \
     rm -rf /var/cache/yum/*
 
 # Add Tini

--- a/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu20.04/Dockerfile
@@ -12,6 +12,11 @@ ARG MILVUS_BASE_IMAGE_REPO="milvusdb/milvus-base"
 ARG MILVUS_BASE_IMAGE_TAG="gpu-20230822-34f9067"
 FROM ${MILVUS_BASE_IMAGE_REPO}:${MILVUS_BASE_IMAGE_TAG}
 
+# Upgrade openssl to fix CVE-2026-45447 (base image is a pinned/legacy ubuntu20.04 build)
+RUN apt-get update && \
+    apt-get upgrade -y openssl libssl1.1 && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /milvus/bin
 COPY --chown=root:root --chmod=774 ./bin/milvus /milvus/bin/milvus
 

--- a/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/gpu/ubuntu22.04/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
     sed -i 's/http:/https:/g' /etc/apt/sources.list && \
     apt-get update && \
+    apt-get upgrade -y openssl libssl3 && \
     apt-get install -y --no-install-recommends curl libaio-dev libgomp1 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
         ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \

--- a/build/docker/milvus/rockylinux9/Dockerfile
+++ b/build/docker/milvus/rockylinux9/Dockerfile
@@ -17,6 +17,7 @@ ARG MILVUS_ASAN_LIB
 RUN dnf install -y dnf-plugins-core && \
     dnf config-manager --set-enabled crb && \
     dnf install -y wget libgomp libaio libatomic tzdata && \
+    dnf upgrade -y openssl openssl-libs && \
     rm -rf /var/cache/dnf/*
 
 # Add Tini

--- a/build/docker/milvus/ubuntu20.04/Dockerfile
+++ b/build/docker/milvus/ubuntu20.04/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
     sed -i 's/http:/https:/g' /etc/apt/sources.list && \
     apt-get update && \
+    apt-get upgrade -y openssl libssl1.1 && \
     apt-get install -y --no-install-recommends gpgv curl libaio-dev libgomp1 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
         ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \

--- a/build/docker/milvus/ubuntu22.04/Dockerfile
+++ b/build/docker/milvus/ubuntu22.04/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
     sed -i 's/http:/https:/g' /etc/apt/sources.list && \
     apt-get update && \
+    apt-get upgrade -y openssl libssl3 && \
     apt-get install -y --no-install-recommends gpgv curl libaio-dev libgomp1 && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
         ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \


### PR DESCRIPTION
## What

Upgrade openssl / libssl in **every** Milvus runtime image to fix **CVE-2026-45447**.

The original change patched only `ubuntu22.04`. External scanners scan every published image, so the other variants must be kept consistent. This PR now covers all of them:

| Image | Package manager | Fix |
|-------|-----------------|-----|
| `ubuntu22.04` | apt | `apt-get upgrade -y openssl libssl3` |
| `ubuntu20.04` | apt | `apt-get upgrade -y openssl libssl1.1` |
| `gpu/ubuntu22.04` | apt | `apt-get upgrade -y openssl libssl3` |
| `gpu/ubuntu20.04` | apt | `apt-get upgrade -y openssl libssl1.1` (added layer — base image is a pinned legacy build) |
| `amazonlinux2023` | yum | `yum upgrade -y openssl openssl-libs` |
| `rockylinux9` | dnf | `dnf upgrade -y openssl openssl-libs` |

Package names differ by base: `libssl3` on jammy, `libssl1.1` on focal, `openssl-libs` on the RPM distros.

## Why

CVE-2026-45447 affects openssl, which ships in all of the runtime images above — not just `ubuntu22.04`. Patching one left the GPU and other-OS images vulnerable to the same scan finding.

Auto-generated as part of the CVE-fix workflow.
