### PR TITLE
enhance: revert "add CubeFS as supported cloud storage provider (#50711)"

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -148,7 +148,6 @@ minio:
   # You can use "aliyun" for other cloud provider uses virtual host style bucket
   # You can use "gcpnative" for the Google Cloud Platform provider. Uses service account credentials
   # for authentication.
-  # CubeFS is S3-compatible and works with cloudProvider: aws and useVirtualHost: false (no IAM support).
   # When useIAM enabled, only "aws", "gcp", "aliyun" is supported for now
   cloudProvider: aws
   # The JSON content contains the gcs service account credentials.


### PR DESCRIPTION
This reverts PR #50711 (commit ce6cc762fd), which added a `cubefs` note to `configs/milvus.yaml` documenting CubeFS as a supported cloud storage provider.

Reverting per maintainer request.

Reverts #50711
issue: #26189