### PR TITLE
doc: add verification gate and C++ error-chain audit to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,18 @@ go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy/... -r
 
 Per-module shortcuts: `make test-querycoord`, `make test-proxy`, etc.
 
+## Verification gate (MANDATORY before claiming "done" or pushing for review)
+
+The reading procedure above tells you how to *enter* the code. This tells you how to *prove a change works*. A change is NOT verified by "it compiles + unit tests pass + success-path e2e is green." When the goal of a change is a **behavior** (retry / classification / routing / error-code propagation / fallback / cache invalidation / concurrency), execute these IN ORDER. Skipping them is the most expensive failure mode — it ships changes that are self-consistent but miss their purpose.
+
+**G1 — Verify the data, not just your transform.** If your change adds a function/layer that maps or preserves a value X (an error code, a Status, a category, a flag), you only verified *your function*. Now verify its INPUT. Audit **every** place that constructs, throws, or rewrites X across the **whole repo** — not only the lines you edited. grep the escape hatches: `throw`, `.ToString()`/stringify, blanket fallbacks (catch-all → `Invalid` / `IOError` / `UnexpectedError`). A value destroyed or mis-set upstream makes your boundary logic dead code. Audit at the SOURCE of X, never only at the boundary that consumes it.
+
+**G2 — Trace each real failure mode end-to-end.** Success-path e2e — even thousands of cases — does NOT exercise the failure modes a behavioral change exists for (S3 throttle, corrupt file, OOM, cancel, timeout, not-ready). For EACH one: either trace it by hand from origin → consumer, or fault-inject it, and confirm it lands in the intended bucket. "All green" on the happy path is not evidence the change works; it is only evidence you did not break the happy path.
+
+**G3 — Do not over-claim.** Commit messages and PR body may assert ONLY benefits verified end-to-end via G1+G2. A benefit that depends on un-audited upstream or an un-triggered failure mode must be written as "follow-up" or "preserves codes for observability; retry wiring unverified" — never as achieved. A reviewer will verify your claim against the running system; over-claiming wastes their round.
+
+**G4 — Adversarial self-review before human review.** Before pushing, do one pass asking: which failure mode have I NOT traced to its bucket? which upstream construction site of X have I NOT read? what would an adversarial reviewer grep for? Fix the gaps, or list them explicitly in the PR.
+
 ## Run Milvus Locally
 
 ```bash
@@ -72,6 +84,7 @@ Input-vs-System) and [error_handling_casebook.md](docs/dev/error_handling_casebo
 3. Before marking anything InputError: grep `retry.Do` consumers. Before converting an `errors.New` sentinel to merr: grep `errors.Is` guards.
 4. Pick codes from the existing family ranges in `pkg/util/merr/errors.go` (scan first; see the partition table in [error_sentinel_convention.md](docs/dev/error_sentinel_convention.md)); never hand-pick 20xx segcore codes.
 5. Touched a wire projection, oldCode mapping, or metric label? Run the merr guard tests AND a full `make test-go` — contract changes break packages you didn't touch.
+6. **C++ side (segcore / milvus-storage / cgo boundary) — the rules above are Go/merr; the same discipline applies in C++, and the verification gate (G1) is non-negotiable here.** The final class is decided at the `ThrowInfo` / `AssertInfo` / `SegcoreError` / arrow-`Status` / `LOON_*` **construction sites**, NOT at the cgo boundary translator. A boundary helper (`KnowhereStatusToErrorCode` / `ArrowStatusToErrorCode` / `LoonResultToErrorCode`) is correct ONLY if its inputs carry the right category — so audit upstream, not the helper. When a code must survive to the cgo boundary, grep every construction/throw/rewrite site and confirm none collapse it: `FailureCStatus` needs a real `SegcoreError` (an `ExecOperatorException` or `throw std::runtime_error(status.ToString())` destroys the code), and an upstream `IOError`-rewritten-as-`Invalid` (or catch-all → `IOError`) silently inverts transient vs permanent. Apply the blame test (rule 1) at EVERY such site, not only the ones you edit.
 
 ## PR and Commit Conventions
 


### PR DESCRIPTION
Follow-up to #50515 — documentation only, no code change.

## Why

CLAUDE.md already ritualizes how an agent *enters* the code (the subsystem reading procedure) and the Go/merr error-handling rules, but has no symmetric ritual for *proving a change achieves its purpose*. In practice this lets a behavioral change (error-code propagation, retry classification, routing) reach a "compiles + unit tests pass + success-path e2e is green" state while missing its goal — e.g. a boundary classifier that is correct in isolation but fed a value the upstream already destroyed (`throw std::runtime_error(status.ToString())`) or mis-set (an IOError rewritten as Invalid, inverting transient vs permanent). Success-path e2e never exercises the failure modes such a change exists for, so "all green" reads as done when it is not.

The error-handling rules are also Go/merr-centric, so the same discipline was not stated for the C++ side (segcore / milvus-storage / cgo boundary), which is where the final `ErrorCode` is actually decided.

## What

- New **Verification gate** section (symmetric in weight to the reading procedure):
  - **G1** verify the data, not just your transform — audit every upstream construction/throw/rewrite site of the value, not only edited lines, and grep the escape hatches.
  - **G2** trace each real failure mode end-to-end (trace or fault-inject; success-path e2e is not evidence).
  - **G3** do not over-claim in commit / PR body.
  - **G4** adversarial self-review before human review.
- **Error handling** section: a C++ rule (segcore / milvus-storage / cgo) — the class is decided at the `ThrowInfo` / `AssertInfo` / `SegcoreError` / arrow-`Status` / `LOON_*` construction sites, not the cgo translator; a boundary helper is correct only if its inputs carry the right category; apply the blame test at every such site.
