### PR TITLE
fix: Check external fields against loaded manifest

### DIFF
--- a/internal/core/src/query/PlanImpl.h
+++ b/internal/core/src/query/PlanImpl.h
@@ -57,7 +57,12 @@ struct Plan {
     SchemaPtr schema_;
     std::unique_ptr<VectorPlanNode> plan_node_;
     std::map<std::string, FieldId> tag2field_;  // PlaceholderName -> FieldId
+    // Requested output fields, kept in request order for result materialization.
+    // access_entries_ also includes them for external manifest checks.
     std::vector<FieldId> target_entries_;
+    // Fields referenced by search execution or output. For external
+    // collections this drives manifest-column checks, not data readiness.
+    std::vector<FieldId> access_entries_;
     std::vector<std::string> target_dynamic_fields_;
     void
     check_identical(Plan& other);
@@ -122,7 +127,12 @@ struct RetrievePlan {
  public:
     SchemaPtr schema_;
     std::unique_ptr<RetrievePlanNode> plan_node_;
+    // Requested output fields, kept in request order for retrieve results.
+    // access_entries_ also includes them for external manifest checks.
     std::vector<FieldId> field_ids_;
+    // Fields referenced by retrieve execution or output. For external
+    // collections this drives manifest-column checks, not data readiness.
+    std::vector<FieldId> access_entries_;
     std::vector<std::string> target_dynamic_fields_;
 };
 

--- a/internal/core/src/query/PlanProto.cpp
+++ b/internal/core/src/query/PlanProto.cpp
@@ -11,6 +11,8 @@
 
 #include "PlanProto.h"
 
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/message.h>
 #include <google/protobuf/text_format.h>
 #include <algorithm>
 #include <cstddef>
@@ -241,6 +243,101 @@ getAggregateOpName(planpb::AggregateOp op) {
 }
 
 namespace {
+
+// Adds a non-zero field id once while preserving first-seen order.
+void
+AddAccessFieldID(std::vector<FieldId>& field_ids, int64_t field_id) {
+    if (field_id == 0) {
+        return;
+    }
+    auto it = std::find_if(
+        field_ids.begin(), field_ids.end(), [field_id](FieldId id) {
+            return id.get() == field_id;
+        });
+    if (it == field_ids.end()) {
+        field_ids.emplace_back(FieldId(field_id));
+    }
+}
+
+// Walks a plan proto tree and records every ColumnInfo field reference.
+void
+CollectColumnInfoFieldIDs(const google::protobuf::Message& message,
+                          std::vector<FieldId>& field_ids) {
+    if (message.GetDescriptor() == proto::plan::ColumnInfo::descriptor()) {
+        const auto& column_info =
+            static_cast<const proto::plan::ColumnInfo&>(message);
+        AddAccessFieldID(field_ids, column_info.field_id());
+        return;
+    }
+
+    const auto* descriptor = message.GetDescriptor();
+    const auto* reflection = message.GetReflection();
+    for (int i = 0; i < descriptor->field_count(); ++i) {
+        const auto* field = descriptor->field(i);
+        if (field->cpp_type() !=
+            google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+            continue;
+        }
+        if (field->is_repeated()) {
+            auto size = reflection->FieldSize(message, field);
+            for (int j = 0; j < size; ++j) {
+                CollectColumnInfoFieldIDs(
+                    reflection->GetRepeatedMessage(message, field, j),
+                    field_ids);
+            }
+            continue;
+        }
+        if (reflection->HasField(message, field)) {
+            CollectColumnInfoFieldIDs(reflection->GetMessage(message, field),
+                                      field_ids);
+        }
+    }
+}
+
+// Builds the unified field-reference list used by external manifest checks.
+std::vector<FieldId>
+CollectAccessFieldIDs(const proto::plan::PlanNode& plan_node_proto) {
+    std::vector<FieldId> field_ids;
+    auto add_field_id = [&](int64_t field_id) {
+        AddAccessFieldID(field_ids, field_id);
+    };
+    // This list is consumed by the external-collection manifest guard. It is
+    // deliberately a field-reference list, not a data/index-readiness list:
+    // external output can be served by take(), while predicates/group-by/etc.
+    // may use loaded columns or indexes. Both only need the current loaded
+    // manifest to contain the referenced external column.
+    if (plan_node_proto.has_vector_anns()) {
+        const auto& vector_anns = plan_node_proto.vector_anns();
+        add_field_id(vector_anns.field_id());
+        if (vector_anns.has_query_info()) {
+            const auto& query_info = vector_anns.query_info();
+            add_field_id(query_info.query_field_id());
+            add_field_id(query_info.group_by_field_id());
+            for (auto field_id : query_info.group_by_field_ids()) {
+                add_field_id(field_id);
+            }
+        }
+    }
+
+    if (plan_node_proto.has_query()) {
+        const auto& query = plan_node_proto.query();
+        for (auto field_id : query.group_by_field_ids()) {
+            add_field_id(field_id);
+        }
+        for (const auto& aggregate : query.aggregates()) {
+            add_field_id(aggregate.field_id());
+        }
+        for (const auto& order_by : query.order_by_fields()) {
+            add_field_id(order_by.field_id());
+        }
+    }
+
+    CollectColumnInfoFieldIDs(plan_node_proto, field_ids);
+    for (auto field_id : plan_node_proto.output_field_ids()) {
+        add_field_id(field_id);
+    }
+    return field_ids;
+}
 
 // Helper function to process group_by fields
 void
@@ -865,6 +962,7 @@ ProtoParser::CreatePlan(const proto::plan::PlanNode& plan_node_proto) {
     auto plan_node = PlanNodeFromProto(plan_node_proto);
     plan->plan_node_ = std::move(plan_node);
     plan->tag2field_["$0"] = plan->plan_node_->search_info_.field_id_;
+    plan->access_entries_ = CollectAccessFieldIDs(plan_node_proto);
     ExtractedPlanInfo extra_info(schema->get_field_id_bitset_size());
     extra_info.add_involved_field(plan->plan_node_->search_info_.field_id_);
     plan->extra_info_opt_ = std::move(extra_info);
@@ -889,6 +987,7 @@ ProtoParser::CreateRetrievePlan(const proto::plan::PlanNode& plan_node_proto) {
     auto plan_node = RetrievePlanNodeFromProto(plan_node_proto);
 
     retrieve_plan->plan_node_ = std::move(plan_node);
+    retrieve_plan->access_entries_ = CollectAccessFieldIDs(plan_node_proto);
     for (auto field_id_raw : plan_node_proto.output_field_ids()) {
         auto field_id = FieldId(field_id_raw);
         retrieve_plan->field_ids_.push_back(field_id);

--- a/internal/core/src/query/PlanProtoTest.cpp
+++ b/internal/core/src/query/PlanProtoTest.cpp
@@ -30,16 +30,19 @@ BuildSchema() {
         "fakevec", milvus::DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
     auto i64_fid = schema->AddDebugField("age", milvus::DataType::INT64);
     schema->set_primary_field_id(i64_fid);
+    schema->AddDebugField("score", milvus::DataType::INT64);
     return schema;
 }
 
 milvus::proto::plan::PlanNode
-BuildSearchPlanNode(float search_topk_ratio, float refine_topk_ratio) {
+BuildSearchPlanNode(float search_topk_ratio,
+                    float refine_topk_ratio,
+                    milvus::FieldId vector_field_id) {
     milvus::proto::plan::PlanNode plan_node;
     auto* vector_anns = plan_node.mutable_vector_anns();
     vector_anns->set_vector_type(milvus::proto::plan::VectorType::FloatVector);
     vector_anns->set_placeholder_tag("$0");
-    vector_anns->set_field_id(100);
+    vector_anns->set_field_id(vector_field_id.get());
 
     auto* query_info = vector_anns->mutable_query_info();
     query_info->set_topk(10);
@@ -67,10 +70,14 @@ TEST(PlanProto, NotSetUnsupported) {
 TEST(PlanProto, RejectsGlobalRefineRatiosBelowOne) {
     using namespace milvus::query;
 
-    ProtoParser parser(BuildSchema());
+    auto schema = BuildSchema();
+    auto vector_field_id = schema->get_field_id(milvus::FieldName("fakevec"));
+    ProtoParser parser(schema);
 
-    EXPECT_ANY_THROW(parser.PlanNodeFromProto(BuildSearchPlanNode(0.5f, 1.5f)));
-    EXPECT_ANY_THROW(parser.PlanNodeFromProto(BuildSearchPlanNode(1.5f, 0.5f)));
+    EXPECT_ANY_THROW(parser.PlanNodeFromProto(
+        BuildSearchPlanNode(0.5f, 1.5f, vector_field_id)));
+    EXPECT_ANY_THROW(parser.PlanNodeFromProto(
+        BuildSearchPlanNode(1.5f, 0.5f, vector_field_id)));
 }
 
 TEST(PlanProto, VectorArrayFieldIdGapInStructArray) {
@@ -132,4 +139,68 @@ TEST(PlanProto, VectorArrayFieldIdGapInStructArray) {
     const auto& involved_fields = plan->extra_info_opt_->involved_fields_;
     ASSERT_EQ(involved_fields.size(), 49);
     EXPECT_TRUE(involved_fields[48]);
+}
+
+TEST(PlanProto, SearchPlanCollectsFieldAccessInfo) {
+    namespace planpb = milvus::proto::plan;
+
+    auto schema = BuildSchema();
+    auto vector_field_id = schema->get_field_id(milvus::FieldName("fakevec"));
+    auto predicate_field_id = schema->get_field_id(milvus::FieldName("age"));
+    auto output_field_id = schema->get_field_id(milvus::FieldName("score"));
+    auto plan_node = BuildSearchPlanNode(0.0f, 0.0f, vector_field_id);
+    plan_node.add_output_field_ids(output_field_id.get());
+
+    auto* query_info = plan_node.mutable_vector_anns()->mutable_query_info();
+    query_info->set_query_field_id(predicate_field_id.get());
+    query_info->add_group_by_field_ids(predicate_field_id.get());
+
+    auto* predicates = plan_node.mutable_vector_anns()->mutable_predicates();
+    auto* term_expr = predicates->mutable_term_expr();
+    auto* column_info = term_expr->mutable_column_info();
+    column_info->set_field_id(predicate_field_id.get());
+    column_info->set_data_type(milvus::proto::schema::DataType::Int64);
+
+    auto plan = milvus::query::CreateSearchPlanFromPlanNode(schema, plan_node);
+
+    EXPECT_EQ(plan->target_entries_,
+              std::vector<milvus::FieldId>({output_field_id}));
+    EXPECT_EQ(plan->access_entries_,
+              std::vector<milvus::FieldId>(
+                  {vector_field_id, predicate_field_id, output_field_id}));
+}
+
+TEST(PlanProto, RetrievePlanCollectsFieldAccessInfo) {
+    namespace planpb = milvus::proto::plan;
+
+    auto schema = BuildSchema();
+    auto predicate_field_id = schema->get_field_id(milvus::FieldName("age"));
+    auto output_field_id = schema->get_field_id(milvus::FieldName("score"));
+
+    planpb::PlanNode plan_node;
+    plan_node.add_output_field_ids(output_field_id.get());
+
+    auto* query = plan_node.mutable_query();
+    query->set_limit(10);
+    query->add_group_by_field_ids(predicate_field_id.get());
+    auto* aggregate = query->add_aggregates();
+    aggregate->set_op(planpb::sum);
+    aggregate->set_field_id(predicate_field_id.get());
+    auto* order_by = query->add_order_by_fields();
+    order_by->set_field_id(predicate_field_id.get());
+
+    auto* predicates = query->mutable_predicates();
+    auto* term_expr = predicates->mutable_term_expr();
+    auto* column_info = term_expr->mutable_column_info();
+    column_info->set_field_id(predicate_field_id.get());
+    column_info->set_data_type(milvus::proto::schema::DataType::Int64);
+
+    auto plan = milvus::query::CreateRetrievePlanByExpr(
+        schema, plan_node.SerializeAsString().data(), plan_node.ByteSizeLong());
+
+    EXPECT_EQ(plan->field_ids_,
+              std::vector<milvus::FieldId>({output_field_id}));
+    EXPECT_EQ(
+        plan->access_entries_,
+        std::vector<milvus::FieldId>({predicate_field_id, output_field_id}));
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -5925,6 +5925,17 @@ ChunkedSegmentSealedImpl::HasFieldData(FieldId field_id) const {
            snapshot->load_info->IsFieldFilledWithDefault(field_id);
 }
 
+// Checks the cached loaded manifest instead of field-data/index bitsets.
+bool
+ChunkedSegmentSealedImpl::HasColumnInLoadedManifest(
+    const std::string& column_name) const {
+    auto load_info = CaptureLoadInfoSnapshot();
+    if (load_info == nullptr || !load_info->HasManifestPath()) {
+        return true;
+    }
+    return load_info->HasManifestColumn(column_name);
+}
+
 std::pair<std::shared_ptr<ChunkedColumnInterface>, bool>
 ChunkedSegmentSealedImpl::GetFieldDataIfExist(FieldId field_id) const {
     auto snapshot = CapturePublishedState();
@@ -6908,6 +6919,7 @@ ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
 
     SegmentLoadInfo current_mutable(*current->load_info);
     SegmentLoadInfo new_local(current->load_info->GetProto(), sch);
+    new_local.InheritCachedColumnGroupsFrom(*current->load_info);
     for (auto fid : current->load_info->GetCreatedTextIndexes()) {
         new_local.SetTextIndexCreated(fid);
     }
@@ -6915,6 +6927,12 @@ ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
     auto diff = current_mutable.ComputeDiff(new_local);
     new_local.SetFieldsFilledWithDefault(
         current_mutable.GetDefaultFilledFieldsForNewInfo(new_local));
+    // Populate manifest cache before publishing; readers do not take
+    // reopen_mutex_.
+    if (new_local.HasManifestPath() && sch->is_external_collection()) {
+        CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::Reopen()");
+        (void)new_local.GetColumnGroups();
+    }
     LOG_INFO(
         "Schema-only reopen segment {} with diff {}", id_, diff.ToString());
 
@@ -6974,6 +6992,7 @@ ChunkedSegmentSealedImpl::Reopen(
 
     SegmentLoadInfo current_mutable(*current->load_info);
     SegmentLoadInfo new_local(new_load_info, target_schema);
+    new_local.InheritCachedColumnGroupsFrom(*current->load_info);
     for (auto fid : current->load_info->GetCreatedTextIndexes()) {
         new_local.SetTextIndexCreated(fid);
     }
@@ -6981,6 +7000,13 @@ ChunkedSegmentSealedImpl::Reopen(
     auto diff = current_mutable.ComputeDiff(new_local);
     new_local.SetFieldsFilledWithDefault(
         current_mutable.GetDefaultFilledFieldsForNewInfo(new_local));
+    // Populate manifest cache before publishing; readers do not take
+    // reopen_mutex_.
+    if (new_local.HasManifestPath() &&
+        target_schema->is_external_collection()) {
+        CheckCancellation(op_ctx, id_, "ChunkedSegmentSealedImpl::Reopen()");
+        (void)new_local.GetColumnGroups();
+    }
     LOG_INFO("Reopen segment {} with diff {}", id_, diff.ToString());
 
     auto next_runtime = CloneMutableRuntimeResourceState();
@@ -7369,6 +7395,8 @@ ChunkedSegmentSealedImpl::SetLoadInfo(
         std::unique_lock lck(mutex_);
         commit_ts_ = commit_ts;
     }
+    // Do not parse manifest here: Load() must be able to observe a
+    // pre-cancelled OpContext before any storage/manifest IO happens.
     auto published = std::make_shared<const SegmentLoadInfo>(
         std::move(load_info), schema_snapshot);
     PublishState(BuildNextPublishedState(
@@ -7384,51 +7412,6 @@ ChunkedSegmentSealedImpl::SetLoadInfo(
         published->GetStorageVersion(),
         published->GetUseTakeForOutput(),
         commit_ts);
-}
-
-void
-ChunkedSegmentSealedImpl::LoadManifest(const std::string& manifest_path) {
-    LOG_INFO(
-        "Loading segment {} field data with manifest {}", id_, manifest_path);
-    auto properties = milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
-                          .GetProperties();
-
-    auto snapshot = CapturePublishedState();
-    auto column_groups = snapshot->load_info->GetColumnGroups();
-    auto schema_snapshot = snapshot->schema;
-    auto segment_load_info = snapshot->load_info;
-    auto arrow_schema = schema_snapshot->ConvertToLoonArrowSchema(
-        /*text_lob_as_binary=*/true);
-    auto runtime = CloneMutableRuntimeResourceState();
-    runtime->reader = std::shared_ptr<milvus_storage::api::Reader>(
-        milvus_storage::api::Reader::create(
-            column_groups, arrow_schema, nullptr, *properties)
-            .release());
-
-    std::vector<std::pair<int, std::vector<FieldId>>> cg_field_ids;
-    for (int i = 0; i < column_groups->size(); ++i) {
-        auto column_group = column_groups->at(i);
-        std::vector<FieldId> milvus_field_ids;
-        for (auto& column : column_group->columns) {
-            auto field_id = std::stoll(column);
-            milvus_field_ids.emplace_back(field_id);
-        }
-        cg_field_ids.emplace_back(i, std::move(milvus_field_ids));
-    }
-
-    LoadColumnGroups(column_groups,
-                     properties,
-                     cg_field_ids,
-                     *segment_load_info,
-                     schema_snapshot,
-                     true,
-                     nullptr,
-                     false,
-                     runtime.get());
-
-    // initialize LOB paths for TEXT fields inside staged runtime
-    InitTextLobPaths(manifest_path, schema_snapshot, runtime.get());
-    PublishRuntimeStateLocked(ToConstRuntimeState(std::move(runtime)));
 }
 
 void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -139,6 +139,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     HasJsonIndex(FieldId field_id) const override;
     bool
     HasFieldData(FieldId field_id) const override;
+    // Checks the loaded external manifest for a storage column.
+    bool
+    HasColumnInLoadedManifest(const std::string& column_name) const override;
 
     std::pair<std::shared_ptr<ChunkedColumnInterface>, bool>
     GetFieldDataIfExist(FieldId field_id) const;
@@ -427,9 +430,6 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     Load(milvus::tracer::TraceContext& trace_ctx,
          milvus::OpContext* op_ctx) override;
-
-    void
-    LoadManifest(const std::string& manifest_path);
 
  public:
     size_t
@@ -1938,6 +1938,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                      milvus::OpContext* op_ctx = nullptr,
                      RuntimeResourceState* runtime = nullptr);
 
+    // Load column groups from a manifest file path (for external collections)
     void
     LoadColumnGroups(const std::string& manifest_path,
                      const SegmentLoadInfo& segment_load_info,

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -536,6 +536,13 @@ class SegmentInternalInterface : public SegmentInterface {
         return HasFieldData(field_id) || HasIndex(field_id);
     }
 
+    // Returns whether the segment's loaded manifest contains the storage
+    // column. Non-manifest segment types default to true.
+    virtual bool
+    HasColumnInLoadedManifest(const std::string&) const {
+        return true;
+    }
+
     // JSON indexes (JsonFlatIndex + JSON-cast scalar) live in a separate
     // per-segment container from the scalar/vector/binlog index bitsets, so
     // they are checked via this dedicated API rather than widening HasIndex().

--- a/internal/core/src/segcore/SegmentLoadInfo.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfo.cpp
@@ -55,6 +55,26 @@ SegmentLoadInfo::GetColumnGroups() const {
     return column_groups_;
 }
 
+// Looks up a storage column in the cached manifest column groups only.
+bool
+SegmentLoadInfo::HasManifestColumn(const std::string& column_name) const {
+    auto column_groups = column_groups_;
+    if (column_groups == nullptr) {
+        return false;
+    }
+    for (const auto& group : *column_groups) {
+        if (group == nullptr) {
+            continue;
+        }
+        for (const auto& column : group->columns) {
+            if (column == column_name) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 LoadIndexInfo
 SegmentLoadInfo::ConvertFieldIndexInfoToLoadIndexInfo(
     const proto::segcore::FieldIndexInfo* field_index_info,

--- a/internal/core/src/segcore/SegmentLoadInfo.h
+++ b/internal/core/src/segcore/SegmentLoadInfo.h
@@ -784,12 +784,28 @@ class SegmentLoadInfo {
      * @return Shared pointer to ColumnGroups, nullptr if manifest is empty
      *
      * The cache is populated on first access. Callers are responsible for
-     * serializing concurrent first-time calls on the same instance; in
-     * ChunkedSegmentSealedImpl this is guaranteed by `reopen_mutex_` since
-     * GetColumnGroups is only invoked from Load/Reopen/SetLoadInfo chains.
+     * serializing concurrent first-time calls on the same instance.
+     * ChunkedSegmentSealedImpl publishes loaded manifest snapshots only after
+     * this cache is initialized, so query paths only read the cached value via
+     * HasManifestColumn.
      */
     [[nodiscard]] std::shared_ptr<milvus_storage::api::ColumnGroups>
     GetColumnGroups() const;
+
+    // Checks the already cached manifest column groups. It intentionally does
+    // not parse the manifest on demand because query paths call this method.
+    [[nodiscard]] bool
+    HasManifestColumn(const std::string& column_name) const;
+
+    // Reuses manifest column groups when another load info points at the same
+    // manifest path.
+    void
+    InheritCachedColumnGroupsFrom(const SegmentLoadInfo& source) {
+        if (source.HasManifestPath() &&
+            source.GetManifestPath() == GetManifestPath()) {
+            column_groups_ = source.column_groups_;
+        }
+    }
 
     /**
      * @brief Pre-populate the column group cache without parsing a manifest

--- a/internal/core/src/segcore/SegmentLoadInfoTest.cpp
+++ b/internal/core/src/segcore/SegmentLoadInfoTest.cpp
@@ -3175,6 +3175,37 @@ TEST_F(SegmentLoadInfoTest,
     EXPECT_TRUE(diff.column_groups_to_lazyreplace.empty());
 }
 
+TEST_F(SegmentLoadInfoTest, HasManifestColumnUsesManifestColumnNames) {
+    schema_->set_external_source("s3://external-bucket/table");
+
+    SegmentLoadInfo info(MakeManifestProto("/manifest/v1"), schema_);
+    info.SetColumnGroupsForTesting(MakeExternalColumnGroups(
+        {{{"id"}, {"/external/id.parquet"}},
+         {{"vector", "tenant"}, {"/external/data.parquet"}}}));
+
+    EXPECT_TRUE(info.HasManifestColumn("id"));
+    EXPECT_TRUE(info.HasManifestColumn("vector"));
+    EXPECT_TRUE(info.HasManifestColumn("tenant"));
+    EXPECT_FALSE(info.HasManifestColumn("missing"));
+    EXPECT_FALSE(info.HasManifestColumn("101"));
+}
+
+TEST_F(SegmentLoadInfoTest, CachedManifestColumnsCanBeInherited) {
+    schema_->set_external_source("s3://external-bucket/table");
+
+    SegmentLoadInfo current(MakeManifestProto("/manifest/v1"), schema_);
+    current.SetColumnGroupsForTesting(MakeExternalColumnGroups(
+        {{{"id"}, {"/external/id.parquet"}},
+         {{"vector", "tenant"}, {"/external/data.parquet"}}}));
+
+    SegmentLoadInfo next(current.GetProto(), schema_);
+    next.InheritCachedColumnGroupsFrom(current);
+
+    EXPECT_TRUE(next.HasManifestColumn("id"));
+    EXPECT_TRUE(next.HasManifestColumn("vector"));
+    EXPECT_TRUE(next.HasManifestColumn("tenant"));
+}
+
 TEST_F(SegmentLoadInfoTest,
        ComputeDiffExternalManifestUpdateReloadsExternalManifest) {
     schema_->set_external_source("s3://external-bucket/table");

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -612,6 +612,11 @@ AsyncRetrieveByOffsets(CTraceContext c_trace,
 
             milvus::OpContext op_ctx(cancel_token);
             segment->LazyCheckSchema(plan->schema_, &op_ctx);
+            auto internal_segment =
+                static_cast<milvus::segcore::SegmentInternalInterface*>(
+                    segment);
+            CheckExternalFieldsInLoadedManifest(
+                plan->schema_, internal_segment, plan->access_entries_);
 
             auto retrieve_result =
                 segment->Retrieve(&trace_ctx, plan, offsets, len, cancel_token);

--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -21,7 +21,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
-#include <functional>
 #include <limits>
 #include <memory>
 #include <string>
@@ -371,6 +370,50 @@ GetSearchResultValidCount(CSearchResult search_result) {
     return res->valid_count_;
 }
 
+// Verifies the plan's external field references against the loaded manifest,
+// after LazyCheckSchema refreshed the segment schema and manifest view.
+// Optionally ignores fields that the current execution path will not access.
+void
+CheckExternalFieldsInLoadedManifest(
+    const milvus::SchemaPtr& schema,
+    milvus::segcore::SegmentInternalInterface* segment,
+    const std::vector<milvus::FieldId>& fields,
+    const std::vector<milvus::FieldId>& skipped_fields = {}) {
+    if (!schema || !schema->is_external_collection()) {
+        return;
+    }
+
+    for (auto field_id : fields) {
+        if (std::find(skipped_fields.begin(), skipped_fields.end(), field_id) !=
+            skipped_fields.end()) {
+            continue;
+        }
+        if (!schema->has_field(field_id)) {
+            continue;
+        }
+
+        if (!schema->IsExternalManifestStoredField(field_id)) {
+            continue;
+        }
+        const auto& field_meta = schema->operator[](field_id);
+        auto column_name = schema->GetPhysicalColumnName(field_id);
+        // External output may be served through take(), so "ready" here means
+        // the loaded manifest contains the storage column. It intentionally
+        // does not require field data or index accessibility.
+        if (!segment->HasColumnInLoadedManifest(column_name)) {
+            throw milvus::SegcoreError(
+                milvus::FieldNotLoaded,
+                fmt::format(
+                    "external field \"{}\" (storage column \"{}\") is not "
+                    "available in the current loaded external collection "
+                    "manifest; run RefreshExternalCollection and reload the "
+                    "collection before accessing this field",
+                    field_meta.get_name().get(),
+                    column_name));
+        }
+    }
+}
+
 //////////////////////////////    public C API wrappers    //////////////////////////////
 
 CFuture*  // Future<milvus::SearchResult*>
@@ -420,6 +463,17 @@ AsyncSearch(CTraceContext c_trace,
             auto internal_segment =
                 static_cast<milvus::segcore::SegmentInternalInterface*>(
                     segment);
+            std::vector<milvus::FieldId> skipped_manifest_fields;
+            if (filter_only) {
+                skipped_manifest_fields.push_back(target_vector_field_id);
+                for (auto field_id : plan->target_entries_) {
+                    skipped_manifest_fields.push_back(field_id);
+                }
+            }
+            CheckExternalFieldsInLoadedManifest(plan->schema_,
+                                                internal_segment,
+                                                plan->access_entries_,
+                                                skipped_manifest_fields);
             std::unique_ptr<milvus::SearchResult> search_result;
             if (!filter_only &&
                 !internal_segment->FieldAccessible(target_vector_field_id)) {
@@ -513,6 +567,11 @@ AsyncRetrieve(CTraceContext c_trace,
 
             milvus::OpContext op_ctx(cancel_token);
             segment->LazyCheckSchema(plan->schema_, &op_ctx);
+            auto internal_segment =
+                static_cast<milvus::segcore::SegmentInternalInterface*>(
+                    segment);
+            CheckExternalFieldsInLoadedManifest(
+                plan->schema_, internal_segment, plan->access_entries_);
 
             auto retrieve_result =
                 segment->Retrieve(&trace_ctx,

--- a/internal/core/src/segcore/segment_c_test.cpp
+++ b/internal/core/src/segcore/segment_c_test.cpp
@@ -1024,6 +1024,57 @@ TEST(CApiTest, RetrieveTestWithExpr) {
     DeleteSegment(segment);
 }
 
+TEST(CApiTest, RetrieveByOffsetsChecksExternalLoadedManifest) {
+    auto schema = std::make_shared<Schema>();
+    auto pk_field = FieldId(100);
+    auto missing_field = FieldId(101);
+    schema->AddField(FieldMeta(FieldName("pk"),
+                               pk_field,
+                               DataType::INT64,
+                               false,
+                               std::nullopt,
+                               "pk_col"));
+    schema->AddField(FieldMeta(FieldName("new_field"),
+                               missing_field,
+                               DataType::INT64,
+                               false,
+                               std::nullopt,
+                               "new_col"));
+    schema->set_primary_field_id(pk_field);
+    schema->set_external_source("s3://bucket/table");
+
+    auto segment = CreateSealedSegment(schema);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    proto::segcore::SegmentLoadInfo load_info;
+    load_info.set_segmentid(1);
+    load_info.set_num_of_rows(1);
+    load_info.set_manifest_path("/manifest/v1");
+    sealed->SetLoadInfo(load_info);
+
+    auto plan = std::make_unique<query::RetrievePlan>(schema);
+    plan->field_ids_ = {missing_field};
+    plan->access_entries_ = {missing_field};
+
+    int64_t offsets[] = {0};
+    CRetrieveResult* retrieve_result = nullptr;
+    auto status =
+        CRetrieveByOffsets(static_cast<CSegmentInterface>(segment.get()),
+                           plan.get(),
+                           offsets,
+                           1,
+                           &retrieve_result);
+
+    ASSERT_EQ(status.error_code, FieldNotLoaded);
+    ASSERT_NE(status.error_msg, nullptr);
+    EXPECT_NE(std::string(status.error_msg).find("RefreshExternalCollection"),
+              std::string::npos)
+        << status.error_msg;
+    EXPECT_EQ(retrieve_result, nullptr);
+    free(const_cast<char*>(status.error_msg));
+}
+
 TEST(CApiTest, GetMemoryUsageInBytesTest) {
     auto collection = NewCollection(get_default_schema_config().c_str());
     CSegmentInterface segment;

--- a/tests/python_client/milvus_client/test_milvus_client_external_table.py
+++ b/tests/python_client/milvus_client/test_milvus_client_external_table.py
@@ -2160,11 +2160,6 @@ class TestMilvusClientExternalTableAddField(ExternalTableTestBase):
         assert filtered[0]["text_body"] == "external text body 100"
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.xfail(
-        reason="https://github.com/milvus-io/milvus/issues/50416: "
-        "querying newly added external field before refresh returns internal QueryNode assert",
-        strict=True,
-    )
     def test_milvus_client_external_table_add_field_without_refresh_not_silent(self, minio_env, external_prefix):
         """
         target: test external table add field without refresh does not silently return wrong data
@@ -2219,7 +2214,7 @@ class TestMilvusClientExternalTableAddField(ExternalTableTestBase):
         )[0][0]
         assert [hit["id"] for hit in old_hits] == [hit["id"] for hit in baseline_hits]
 
-        err_check = {ct.err_code: 65535, ct.err_msg: "refresh"}
+        err_check = {ct.err_code: 65535, ct.err_msg: "RefreshExternalCollection"}
         self.query(
             client,
             coll,


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/50416

## What

This PR moves external field checks into the C++ Search/Retrieve path after `LazyCheckSchema` has refreshed the segment schema and load info.

Instead of probing `HasFieldData` or `FieldAccessible`, the guard checks whether every referenced external field exists in the currently loaded external manifest:

- `CheckExternalFieldsInLoadedSnapshot` is renamed to `CheckExternalFieldsInLoadedManifest` to match the real readiness boundary.
- Plan `access_entries_` now includes expression/execution fields and requested output fields, so Search and Retrieve use one field-reference list for external manifest checks.
- Search filter-only skips the vector field and output target fields because that path does not access them.
- Non-manifest segments keep the existing behavior.

The loaded manifest column-group cache is also preserved across schema-only reopen when the manifest path is unchanged, so the query path can check manifest membership without parsing remote manifests or falsely reporting missing columns after schema refresh.

## Why

For external collections, a newly added field can appear in the Go collection schema before the loaded C++ segment has refreshed to a manifest that contains the corresponding external column.

If Search/Retrieve touches that field against the stale loaded manifest, segcore can surface an internal field-state failure instead of a clear external-field-not-ready error. The real readiness condition here is whether the loaded manifest contains the external column, not whether the field is loaded into memory.

## Validation

- `ninja -C cmake_build milvus_core all_tests`
- `DYLD_LIBRARY_PATH=cmake_build/src cmake_build/unittest/all_tests --gtest_filter='PlanProto.SearchPlanCollectsFieldAccessInfo:PlanProto.RetrievePlanCollectsFieldAccessInfo:SegmentLoadInfoTest.HasManifestColumnUsesManifestColumnNames:SegmentLoadInfoTest.CachedManifestColumnsCanBeInherited'`
- `/opt/homebrew/opt/llvm@15/bin/clang-format --dry-run -Werror internal/core/src/query/PlanImpl.h internal/core/src/query/PlanProto.cpp internal/core/src/query/PlanProtoTest.cpp internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp internal/core/src/segcore/ChunkedSegmentSealedImpl.h internal/core/src/segcore/SegmentInterface.h internal/core/src/segcore/SegmentLoadInfo.cpp internal/core/src/segcore/SegmentLoadInfo.h internal/core/src/segcore/SegmentLoadInfoTest.cpp internal/core/src/segcore/segment_c.cpp`
- `CLANG_FORMAT=/opt/homebrew/opt/llvm@15/bin/clang-format make cppcheck`
- `git diff --check milvus/master...HEAD`
