### PR TITLE
test: Add sparse inverted invalid parameter checks

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_sparse_inverted_index.py
+++ b/tests/python_client/milvus_client/test_milvus_client_sparse_inverted_index.py
@@ -1114,7 +1114,6 @@ class TestSparseInvertedIndexV3Negative(_SparseInvertedIndexV3Base):
             "sindi_window_size",
         )
 
-    @pytest.mark.xfail(reason="Known issue #50108: server accepts unsupported sparse inverted index codec values")
     def test_sparse_index_rejects_invalid_codec(self):
         """
         target: verify ordinary sparse indexes reject unsupported posting-list codecs
@@ -1125,15 +1124,25 @@ class TestSparseInvertedIndexV3Negative(_SparseInvertedIndexV3Base):
             "bad_codec",
             "IP",
             {"inverted_index_algo": "DAAT_MAXSCORE", "inverted_index_codec": "invalid_codec"},
-            "inverted_index_codec",
+            "inverted_index_codec invalid_codec not found or not supported, supported: [block_streamvbyte block_maskedvbyte]: invalid parameter",
         )
 
-    @pytest.mark.xfail(reason="Known issue #50108: server accepts non-positive block_max_block_size values")
     @pytest.mark.parametrize(
-        "field_name, block_size",
-        [("bad_block_size_zero", 0), ("bad_block_size_negative", -1)],
+        "field_name, block_size, error_message",
+        [
+            (
+                "bad_block_size_zero",
+                0,
+                "Out of range in json: param 'block_max_block_size' (0) should be in range [1, 2147483647]: invalid parameter",
+            ),
+            (
+                "bad_block_size_negative",
+                -1,
+                "Out of range in json: param 'block_max_block_size' (-1) should be in range [1, 2147483647]: invalid parameter",
+            ),
+        ],
     )
-    def test_block_max_rejects_invalid_block_size(self, field_name, block_size):
+    def test_block_max_rejects_invalid_block_size(self, field_name, block_size, error_message):
         """
         target: verify Block-Max sparse indexes reject non-positive block size params
         method: create BLOCK_MAX_WAND indexes with zero and negative block_max_block_size
@@ -1143,5 +1152,5 @@ class TestSparseInvertedIndexV3Negative(_SparseInvertedIndexV3Base):
             field_name,
             "IP",
             {"inverted_index_algo": "BLOCK_MAX_WAND", "block_max_block_size": block_size},
-            "block_max_block_size",
+            error_message,
         )


### PR DESCRIPTION
issue: #50108

This PR updates sparse inverted index negative coverage to verify the server rejects invalid build parameters during create_index.

Changes:
- Remove stale xfail markers for invalid sparse inverted index codec and non-positive block size cases.
- Assert the concrete validation messages for unsupported inverted_index_codec and block_max_block_size values 0/-1.

Verification:
- python3 -m py_compile tests/python_client/milvus_client/test_milvus_client_sparse_inverted_index.py
- python3 -m pytest -o "addopts=-p no:locust -v" tests/python_client/milvus_client/test_milvus_client_sparse_inverted_index.py::TestSparseInvertedIndexV3Negative -q --host 10.104.18.28 --port 19530
