### PR TITLE
enhance: speed up expr parsing with SLL-first two-stage ANTLR prediction

### DIFF
--- a/internal/parser/planparserv2/plan_parser_v2.go
+++ b/internal/parser/planparserv2/plan_parser_v2.go
@@ -53,14 +53,17 @@ func ParseExprParams(vals map[string]*schemapb.TemplateValue) *ExprParams {
 
 // parseExpr parses an expression with a two-stage strategy:
 //
-//	Stage 1 (fast): SLL prediction + BailErrorStrategy. For the overwhelmingly
-//	  common unambiguous filter expression this skips the expensive adaptive-LL
-//	  prediction entirely. A prediction conflict makes BailErrorStrategy panic,
-//	  which we recover and fall through to stage 2 — no error is recorded.
-//	Stage 2 (accurate): full LL prediction + default error recovery, with the
-//	  real error listener attached, so a genuine syntax error is reported exactly
-//	  as a pure-LL parse would. SLL never accepts input that LL rejects, so the
-//	  successful result is identical to a pure-LL parse.
+//	Stage 1 (fast): SLL prediction with a throwaway probe listener. For the
+//	  overwhelmingly common unambiguous filter expression SLL parses cleanly and
+//	  the result is identical to a full LL parse, so we return it directly. We do
+//	  not use BailErrorStrategy here: antlr-go's BailErrorStrategy can reach an
+//	  unimplemented ParseCancellationException path ("panic: implement me"), so
+//	  "SLL could not decide" is detected via a syntax error on the probe listener
+//	  instead of a bail/recover.
+//	Stage 2 (accurate): only if stage 1 saw an error. Rewind the tokens and reparse
+//	  with full LL prediction + default error recovery and the real error listener,
+//	  so the result/error is exactly what a pure-LL parse would produce. SLL never
+//	  accepts input that LL rejects, so a clean stage-1 parse equals the LL parse.
 func parseExpr(parser *planparserv2.PlanParser, listener *errorListenerImpl) planparserv2.IExprContext {
 	interp := parser.GetInterpreter()
 

--- a/internal/parser/planparserv2/plan_parser_v2.go
+++ b/internal/parser/planparserv2/plan_parser_v2.go
@@ -51,6 +51,53 @@ func ParseExprParams(vals map[string]*schemapb.TemplateValue) *ExprParams {
 	return ep
 }
 
+// parseExpr parses an expression with a two-stage strategy:
+//
+//	Stage 1 (fast): SLL prediction + BailErrorStrategy. For the overwhelmingly
+//	  common unambiguous filter expression this skips the expensive adaptive-LL
+//	  prediction entirely. A prediction conflict makes BailErrorStrategy panic,
+//	  which we recover and fall through to stage 2 — no error is recorded.
+//	Stage 2 (accurate): full LL prediction + default error recovery, with the
+//	  real error listener attached, so a genuine syntax error is reported exactly
+//	  as a pure-LL parse would. SLL never accepts input that LL rejects, so the
+//	  successful result is identical to a pure-LL parse.
+func parseExpr(parser *planparserv2.PlanParser, listener *errorListenerImpl) planparserv2.IExprContext {
+	interp := parser.GetInterpreter()
+
+	// Stage 1 (fast): SLL prediction with a throwaway listener. For the
+	// overwhelmingly common unambiguous filter expression SLL parses cleanly and
+	// the result is identical to a full LL parse, so we return it directly. We do
+	// not use BailErrorStrategy: antlr-go's BailErrorStrategy can hit an
+	// unimplemented ParseCancellationException path ("panic: implement me"), so we
+	// instead detect "SLL could not decide" via a syntax error on a probe
+	// listener. DefaultErrorStrategy's recovery only runs on that rare error path.
+	probe := &errorListenerImpl{}
+	parser.RemoveErrorListeners()
+	parser.AddErrorListener(probe)
+	parser.SetErrorHandler(antlr.NewDefaultErrorStrategy())
+	interp.SetPredictionMode(antlr.PredictionModeSLL)
+	ast := parser.Expr()
+	if probe.Error() == nil {
+		return ast
+	}
+
+	// Stage 2 (accurate): SLL saw an error — it may be a genuine syntax error or
+	// an SLL-only false positive. Rewind the buffered tokens and reparse with full
+	// LL + default recovery and the real listener, so the result/error is exactly
+	// what a pure-LL parse would produce.
+	if tokens, ok := parser.GetTokenStream().(*antlr.CommonTokenStream); ok {
+		tokens.Seek(0)
+		// SetInputStream resets the parser's internal state (context stack,
+		// precedence stack, error handler) while preserving BuildParseTrees.
+		parser.SetInputStream(tokens)
+	}
+	parser.RemoveErrorListeners()
+	parser.AddErrorListener(listener)
+	parser.SetErrorHandler(antlr.NewDefaultErrorStrategy())
+	interp.SetPredictionMode(antlr.PredictionModeLL)
+	return parser.Expr()
+}
+
 func handleInternal(exprStr string) (ast planparserv2.IExprContext, err error) {
 	val, ok := exprCache.Get(exprStr)
 	if ok {
@@ -84,7 +131,7 @@ func handleInternal(exprStr string) (ast planparserv2.IExprContext, err error) {
 		return
 	}
 
-	ast = parser.Expr()
+	ast = parseExpr(parser, listener)
 	if err = listener.Error(); err != nil {
 		return
 	}

--- a/internal/parser/planparserv2/pool.go
+++ b/internal/parser/planparserv2/pool.go
@@ -44,6 +44,14 @@ func getParser(lexer *antlrparser.PlanLexer, listeners ...antlr.ErrorListener) *
 	}
 	parser.BuildParseTrees = true
 	parser.SetInputStream(tokenStream)
+	// Hand the parser out in the default LL prediction mode. parseExpr flips it to
+	// SLL for stage 1 and only restores LL on the (rare) stage-2 path, so a parser
+	// returned to the pool after a clean stage-1 parse is still in SLL mode —
+	// antlr-go's SetInputStream/reset does not restore predictionMode. Reset it
+	// here so the pool always yields an LL parser and any caller that runs the
+	// pooled parser directly (e.g. parser.Expr() in tests/benchmarks) never
+	// inherits SLL-only behavior that could reject inputs full LL accepts.
+	parser.GetInterpreter().SetPredictionMode(antlr.PredictionModeLL)
 	return parser
 }
 

--- a/internal/parser/planparserv2/pool.go
+++ b/internal/parser/planparserv2/pool.go
@@ -24,6 +24,8 @@ var (
 
 func getLexer(stream *antlr.InputStream, listeners ...antlr.ErrorListener) *antlrparser.PlanLexer {
 	lexer := lexerPool.Get().(*antlrparser.PlanLexer)
+	// Drop ANTLR's default ConsoleErrorListener (see getParser).
+	lexer.RemoveErrorListeners()
 	for _, listener := range listeners {
 		lexer.AddErrorListener(listener)
 	}
@@ -34,6 +36,9 @@ func getLexer(stream *antlr.InputStream, listeners ...antlr.ErrorListener) *antl
 func getParser(lexer *antlrparser.PlanLexer, listeners ...antlr.ErrorListener) *antlrparser.PlanParser {
 	tokenStream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
 	parser := parserPool.Get().(*antlrparser.PlanParser)
+	// Drop ANTLR's default ConsoleErrorListener so a syntax error does not do
+	// stderr I/O on the hot failure path; only our own listener stays attached.
+	parser.RemoveErrorListeners()
 	for _, listener := range listeners {
 		parser.AddErrorListener(listener)
 	}

--- a/internal/parser/planparserv2/pool_test.go
+++ b/internal/parser/planparserv2/pool_test.go
@@ -265,6 +265,32 @@ func Test_resetParserPool(t *testing.T) {
 	putLexer(lexer2)
 }
 
+// Test_getParserResetsPredictionMode verifies the pool always hands out a parser
+// in the default LL prediction mode, even after a previous borrower left it stuck
+// in SLL (as parseExpr's stage-1 fast path does). Without the reset in getParser,
+// a reused parser would run SLL-only and could reject inputs that full LL accepts.
+func Test_getParserResetsPredictionMode(t *testing.T) {
+	resetLexerPool()
+	resetParserPool()
+
+	// Borrow a parser, force it into SLL (mimicking parseExpr's stage-1 fast path
+	// returning without restoring LL), and return it to the pool.
+	lexer1 := getLexer(genNaiveInputStream(), &errorListenerImpl{})
+	parser1 := getParser(lexer1, &errorListenerImpl{})
+	parser1.GetInterpreter().SetPredictionMode(antlr.PredictionModeSLL)
+	putParser(parser1)
+	putLexer(lexer1)
+
+	// The next borrow must come back in LL mode regardless of how it was left.
+	lexer2 := getLexer(genNaiveInputStream(), &errorListenerImpl{})
+	parser2 := getParser(lexer2, &errorListenerImpl{})
+	assert.Equal(t, antlr.PredictionModeLL, parser2.GetInterpreter().GetPredictionMode(),
+		"pool must hand out a parser in default LL mode, not a leaked SLL state")
+	assert.NotNil(t, parser2.Expr())
+	putParser(parser2)
+	putLexer(lexer2)
+}
+
 // Test_poolParserBuildParseTrees verifies that BuildParseTrees is set correctly
 // This is important for the parser to generate the parse tree
 func Test_poolParserBuildParseTrees(t *testing.T) {

--- a/internal/parser/planparserv2/sll_corpus_test.go
+++ b/internal/parser/planparserv2/sll_corpus_test.go
@@ -1,0 +1,186 @@
+package planparserv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// corpusExprs is a broad set of syntactically-valid expressions, simple to
+// complex, used to (a) prove the SLL-first two-stage parse yields the exact same
+// tree as a pure LL parse for every shape, and (b) benchmark parse throughput.
+// Grown in batches.
+var corpusExprs = []struct {
+	name string
+	expr string
+}{
+	// ---- batch 1: comparisons / arithmetic / bitwise / shift / unary / range ----
+	{"cmp_eq", "Int64Field == 100"},
+	{"cmp_ne", "Int64Field != 100"},
+	{"cmp_lt", "Int64Field < 100"},
+	{"cmp_le", "Int64Field <= 100"},
+	{"cmp_gt", "Int64Field > 100"},
+	{"cmp_ge", "Int64Field >= 100"},
+	{"cmp_float", "FloatField >= 1.5"},
+	{"cmp_neg", "Int64Field > -5"},
+	{"arith_add", "Int64Field + 5 == 100"},
+	{"arith_sub", "Int64Field - 5 == 100"},
+	{"arith_mul", "Int64Field * 2 < 200"},
+	{"arith_div", "Int64Field / 2 < 200"},
+	{"arith_mod", "Int64Field % 10 == 0"},
+	{"arith_pow", "Int64Field ** 2 < 1000"},
+	{"arith_chain", "Int64Field * 2 + 3 - 1 == 10"},
+	{"arith_paren", "(Int64Field + 5) * 2 == 30"},
+	{"bit_and", "Int64Field & 3 == 1"},
+	{"bit_or", "Int64Field | 3 == 7"},
+	{"bit_xor", "Int64Field ^ 3 == 5"},
+	{"bit_not", "~Int64Field == -1"},
+	{"shift_l", "Int64Field << 2 == 16"},
+	{"shift_r", "Int64Field >> 2 == 1"},
+	{"unary_minus", "-Int64Field < 0"},
+	{"unary_plus", "+Int64Field > 0"},
+	{"unary_not", "!(Int64Field > 0)"},
+	{"range_lt_lt", "10 < Int64Field < 100"},
+	{"range_le_le", "10 <= Int64Field <= 100"},
+	{"range_rev_gt", "100 > Int64Field > 10"},
+	{"range_rev_ge", "100 >= Int64Field >= 10"},
+	{"literal_led_eq", "100 == Int64Field"},
+	{"literal_led_lt", "1.5 <= FloatField"},
+
+	// ---- batch 2: in / string / regex / array / json / struct / null / exists ----
+	{"in_small", "Int64Field in [1, 2, 3]"},
+	{"in_large", "Int64Field in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]"},
+	{"not_in", "Int64Field not in [1, 2, 3]"},
+	{"in_str", `StringField in ["a", "b", "c"]`},
+	{"in_float", "FloatField in [1.0, 2.5, 3.7]"},
+	{"empty_array", "Int64Field in []"},
+	{"str_eq", `StringField == "hello"`},
+	{"str_like_prefix", `StringField like "hello%"`},
+	{"str_like_infix", `StringField like "%mid%"`},
+	{"str_regex", `StringField =~ "ab.*"`},
+	{"str_regex_not", `StringField !~ "ab.*"`},
+	{"arr_contains", "array_contains(ArrayField, 1)"},
+	{"arr_contains_all", "array_contains_all(ArrayField, [1, 2, 3])"},
+	{"arr_contains_any", "array_contains_any(ArrayField, [1, 2, 3])"},
+	{"arr_length", "array_length(ArrayField) == 10"},
+	{"arr_length_cmp", "array_length(ArrayField) > 0 && array_length(ArrayField) < 5"},
+	{"json_eq", `JSONField["key"] == 100`},
+	{"json_nested", `JSONField["a"]["b"] == "value"`},
+	{"json_idx", `JSONField[0] == 1`},
+	{"json_contains", `json_contains(JSONField["arr"], 1)`},
+	{"json_contains_all", `json_contains_all(JSONField["arr"], [1, 2])`},
+	{"json_contains_any", `json_contains_any(JSONField["arr"], [1, 2])`},
+	{"struct_field", "struct_array[sub_int] == 1"},
+	{"is_null", "Int64Field is null"},
+	{"is_not_null", "Int64Field is not null"},
+	{"is_null_upper", "Int64Field IS NULL"},
+	{"json_is_null", `JSONField["k"] is null`},
+	{"exists", `exists JSONField["key"]`},
+	{"exists_field", "exists Int64Field"},
+
+	// ---- batch 3: text/phrase/match, sample, spatial, timestamptz, template, call, deep nesting ----
+	{"text_match", `text_match(VarCharField, "query")`},
+	{"text_match_msm", `text_match(VarCharField, "query", minimum_should_match=2)`},
+	{"phrase_match", `phrase_match(VarCharField, "a b c")`},
+	{"phrase_match_slop", `phrase_match(VarCharField, "a b c", 2)`},
+	{"match_all", `match_all(VarCharField, "x")`},
+	{"match_any", `match_any(VarCharField, "x")`},
+	{"match_least", `match_least(VarCharField, "x", threshold=2)`},
+	{"match_most", `match_most(VarCharField, "x", threshold=3)`},
+	{"match_exact", `match_exact(VarCharField, "x", threshold=1)`},
+	{"random_sample", "random_sample(0.01)"},
+	{"element_filter", "element_filter(ArrayField, x > 1)"},
+	{"st_within", `st_within(GeoField, "POLYGON((0 0,1 0,1 1,0 1,0 0))")`},
+	{"st_contains", `st_contains(GeoField, "POINT(1 1)")`},
+	{"st_intersects", `st_intersects(GeoField, "POINT(1 1)")`},
+	{"st_dwithin", `st_dwithin(GeoField, "POINT(1 1)", 10)`},
+	{"st_isvalid", "st_isvalid(GeoField)"},
+	{"ts_fwd", `TsField > iso "2020-01-01T00:00:00Z"`},
+	{"ts_fwd_interval", `TsField + interval "1d" > iso "2020-01-01T00:00:00Z"`},
+	{"ts_rev", `iso "2020-01-01T00:00:00Z" < TsField`},
+	{"ts_rev_interval", `iso "2020-01-01T00:00:00Z" <= TsField - interval "1h"`},
+	{"template_var", "Int64Field == {age}"},
+	{"template_in", "Int64Field in {id_list}"},
+	{"call_fn", "my_func(Int64Field, 1, 2)"},
+	{"call_noargs", "now()"},
+
+	// ---- batch 3: deeply nested / mixed-precedence complex ----
+	{"deep_logical", "(Int64Field > 10 && Int64Field < 100) || (FloatField > 1.0 && FloatField < 10.0)"},
+	{"deep_mixed", `Int64Field > 10 && StringField like "test%" && array_length(ArrayField) > 0`},
+	{"deep_json_logic", `JSONField["status"] == "active" && Int64Field > 0 && Int64Field is not null`},
+	{"deep_arith_logic", "Int64Field * 2 + 1 > 10 || (Int64Field - 3) % 2 == 0 && FloatField <= 9.9"},
+	{"deep_nested_in", `(Int64Field in [1,2,3] || FloatField > 1.5) && StringField != "exclude"`},
+	{"deep_bit_logic", "(Int64Field & 1) == 1 && (Int64Field >> 2) < 8 || ~Int64Field == -1"},
+	{"deep_paren_chain", "((((Int64Field + 1) * 2 - 3) / 4) % 5) == 0"},
+	{"deep_many_or", "Int64Field == 1 || Int64Field == 2 || Int64Field == 3 || Int64Field == 4 || Int64Field == 5"},
+	{"deep_text_logic", `text_match(VarCharField, "a") && (Int64Field > 0 || exists JSONField["k"])`},
+
+	// ---- batch 4: literal forms / escapes / pathological nesting ----
+	{"int_hex", "Int64Field == 0xFF"},
+	{"int_oct", "Int64Field == 0o17"},
+	{"int_bin", "Int64Field == 0b1010"},
+	{"float_exp", "FloatField == 1.5e3"},
+	{"float_negexp", "FloatField == 1.5e-3"},
+	{"float_lead_dot", "FloatField == .5"},
+	{"bool_true", "BoolField == true"},
+	{"bool_false", "BoolField == false"},
+	{"str_escape", `StringField == "a\"b\tc"`},
+	{"str_single", `StringField == 'single quoted'`},
+	{"str_unicode", `StringField == "éè"`},
+	{"deep_parens_10", "((((((((((Int64Field)))))))))) == 1"},
+	{"in_long_50", "Int64Field in [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50]"},
+	{"nested_call", "outer(inner(Int64Field, 1), mid(2, 3))"},
+	{"multi_template", "Int64Field > {lo} && Int64Field < {hi}"},
+	{"json_deep5", `JSONField["a"]["b"]["c"]["d"]["e"] == 1`},
+	{"mixed_everything", `(Int64Field + 1) * 2 >= {t} && StringField like "x%" && array_contains(ArrayField, 3) || JSONField["k"] is not null`},
+}
+
+// invalidExprs are syntactically malformed; both a pure LL parse and the
+// two-stage parse must reject them identically (exercises the SLL->LL fallback
+// and the error-reporting path).
+var invalidExprs = []string{
+	"Int64Field ==",
+	"Int64Field >> ",
+	"(Int64Field > 1",
+	"Int64Field > 1)",
+	"Int64Field in [1, 2,",
+	"&& Int64Field > 1",
+	"Int64Field 100",
+	"text_match(VarCharField)",
+	"text_match(VarCharField, \"q\", minimum_should_match={min})",
+	"st_dwithin(GeoField, \"POINT(1 1)\")",
+	"Int64Field ** ** 2",
+	"random_sample()",
+	"100 == == Int64Field",
+}
+
+func TestTwoStageMatchesLL_Invalid(t *testing.T) {
+	for _, e := range invalidExprs {
+		_, llErr := benchLexParseLL(e)
+		_, tsErr := benchLexParseTwoStage(e)
+		require.Error(t, llErr, "expected LL to reject %q", e)
+		require.Equal(t, llErr == nil, tsErr == nil, "accept/reject differs for invalid %q (LL=%v two-stage=%v)", e, llErr, tsErr)
+	}
+}
+
+func TestTwoStageMatchesLL_Corpus(t *testing.T) {
+	for _, tc := range corpusExprs {
+		llAst, llErr := benchLexParseLL(tc.expr)
+		tsAst, tsErr := benchLexParseTwoStage(tc.expr)
+		require.Equal(t, llErr == nil, tsErr == nil, "%s: accept/reject differs for %q (LL=%v two-stage=%v)", tc.name, tc.expr, llErr, tsErr)
+		if llErr == nil && tsErr == nil {
+			require.Equal(t, llAst.GetText(), tsAst.GetText(), "%s: parse tree differs for %q", tc.name, tc.expr)
+		}
+	}
+}
+
+func corpusList() []string {
+	out := make([]string, len(corpusExprs))
+	for i, tc := range corpusExprs {
+		out[i] = tc.expr
+	}
+	return out
+}
+
+func BenchmarkCorpus_LL(b *testing.B)       { benchParseSet(b, corpusList(), benchLexParseLL) }
+func BenchmarkCorpus_TwoStage(b *testing.B) { benchParseSet(b, corpusList(), benchLexParseTwoStage) }

--- a/internal/parser/planparserv2/sll_corpus_test.go
+++ b/internal/parser/planparserv2/sll_corpus_test.go
@@ -165,11 +165,13 @@ func TestTwoStageMatchesLL_Invalid(t *testing.T) {
 
 func TestTwoStageMatchesLL_Corpus(t *testing.T) {
 	for _, tc := range corpusExprs {
-		llAst, llErr := benchLexParseLL(tc.expr)
-		tsAst, tsErr := benchLexParseTwoStage(tc.expr)
+		llTree, llErr := parseTree(tc.expr, false)
+		tsTree, tsErr := parseTree(tc.expr, true)
 		require.Equal(t, llErr == nil, tsErr == nil, "%s: accept/reject differs for %q (LL=%v two-stage=%v)", tc.name, tc.expr, llErr, tsErr)
 		if llErr == nil && tsErr == nil {
-			require.Equal(t, llAst.GetText(), tsAst.GetText(), "%s: parse tree differs for %q", tc.name, tc.expr)
+			// Structural (ToStringTree) comparison, not GetText: it must catch any
+			// precedence/associativity divergence between SLL and LL.
+			require.Equal(t, llTree, tsTree, "%s: parse tree differs for %q", tc.name, tc.expr)
 		}
 	}
 }

--- a/internal/parser/planparserv2/sll_two_stage_bench_test.go
+++ b/internal/parser/planparserv2/sll_two_stage_bench_test.go
@@ -1,0 +1,141 @@
+package planparserv2
+
+import (
+	"testing"
+
+	"github.com/antlr4-go/antlr/v4"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/milvus-io/milvus/internal/parser/planparserv2/generated"
+)
+
+// benchLexParseLL parses a single expression with the original single-pass full
+// LL strategy (the pre-optimization baseline). It deliberately bypasses the
+// expr AST cache so the benchmark measures lexing + parsing only.
+func benchLexParseLL(expr string) (gen.IExprContext, error) {
+	listener := &errorListenerImpl{}
+	is := antlr.NewInputStream(convertHanToASCII(expr))
+	lexer := getLexer(is, listener)
+	parser := getParser(lexer, listener)
+	parser.SetErrorHandler(antlr.NewDefaultErrorStrategy())
+	parser.GetInterpreter().SetPredictionMode(antlr.PredictionModeLL)
+	ast := parser.Expr()
+	err := eofErr(parser, listener)
+	putLexer(lexer)
+	putParser(parser)
+	return ast, err
+}
+
+// eofErr mirrors handleInternal: a parse is only accepted if there was no syntax
+// error AND the whole input was consumed (trailing tokens => invalid).
+func eofErr(parser *gen.PlanParser, listener *errorListenerImpl) error {
+	if e := listener.Error(); e != nil {
+		return e
+	}
+	if parser.GetCurrentToken().GetTokenType() != antlr.TokenEOF {
+		return errTrailingTokens
+	}
+	return nil
+}
+
+var errTrailingTokens = &trailingTokenError{}
+
+type trailingTokenError struct{}
+
+func (*trailingTokenError) Error() string { return "invalid expression: trailing tokens" }
+
+// benchLexParseTwoStage parses a single expression with the new SLL-first
+// two-stage strategy (parseExpr). Also bypasses the AST cache.
+func benchLexParseTwoStage(expr string) (gen.IExprContext, error) {
+	listener := &errorListenerImpl{}
+	is := antlr.NewInputStream(convertHanToASCII(expr))
+	lexer := getLexer(is, listener)
+	parser := getParser(lexer, listener)
+	ast := parseExpr(parser, listener)
+	err := eofErr(parser, listener)
+	putLexer(lexer)
+	putParser(parser)
+	return ast, err
+}
+
+// TestTwoStageMatchesLL guarantees the SLL-first two-stage parse yields exactly
+// the same tree (and the same accept/reject decision) as a pure LL parse for the
+// whole benchmark corpus — the correctness contract behind the optimization.
+func TestTwoStageMatchesLL(t *testing.T) {
+	for _, tc := range benchmarkExprs {
+		llAst, llErr := benchLexParseLL(tc.expr)
+		tsAst, tsErr := benchLexParseTwoStage(tc.expr)
+		require.Equal(t, llErr == nil, tsErr == nil, "accept/reject differs for %q (LL err=%v, two-stage err=%v)", tc.expr, llErr, tsErr)
+		if llErr == nil && tsErr == nil {
+			require.Equal(t, llAst.GetText(), tsAst.GetText(), "parse tree differs for %q", tc.expr)
+		}
+	}
+}
+
+// identifierLed expressions begin with a column identifier, so under the current
+// grammar they pay the prediction cost of the two leading Timestamptz* expr
+// alternatives (#4). literalLed begin with a constant and do not.
+var (
+	identifierLedExprs = []string{
+		"Int64Field == 100",
+		"Int64Field > 10 && Int64Field < 100",
+		"Int64Field in [1, 2, 3, 4, 5]",
+		"FloatField >= 1.5",
+		"VarCharField == \"abc\"",
+	}
+	literalLedExprs = []string{
+		"100 == Int64Field",
+		"10 < Int64Field && 100 > Int64Field",
+		"1.5 <= FloatField",
+	}
+)
+
+func benchParseSet(b *testing.B, exprs []string, parse func(string) (gen.IExprContext, error)) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = parse(exprs[i%len(exprs)])
+	}
+}
+
+// BenchmarkParse_LL vs BenchmarkParse_TwoStage: overall corpus, lex+parse only.
+func BenchmarkParse_LL(b *testing.B) {
+	exprs := make([]string, len(benchmarkExprs))
+	for i, tc := range benchmarkExprs {
+		exprs[i] = tc.expr
+	}
+	benchParseSet(b, exprs, benchLexParseLL)
+}
+
+func BenchmarkParse_TwoStage(b *testing.B) {
+	exprs := make([]string, len(benchmarkExprs))
+	for i, tc := range benchmarkExprs {
+		exprs[i] = tc.expr
+	}
+	benchParseSet(b, exprs, benchLexParseTwoStage)
+}
+
+// Per-expression detail so we can see which shapes benefit most.
+func BenchmarkParseEach_LL(b *testing.B) {
+	for _, tc := range benchmarkExprs {
+		b.Run(tc.name, func(b *testing.B) { benchParseSet(b, []string{tc.expr}, benchLexParseLL) })
+	}
+}
+
+func BenchmarkParseEach_TwoStage(b *testing.B) {
+	for _, tc := range benchmarkExprs {
+		b.Run(tc.name, func(b *testing.B) { benchParseSet(b, []string{tc.expr}, benchLexParseTwoStage) })
+	}
+}
+
+// Quantify the #4 Timestamptz-prefix tax: identifier-led vs literal-led, in both
+// prediction strategies.
+func BenchmarkIdentifierLed_LL(b *testing.B) { benchParseSet(b, identifierLedExprs, benchLexParseLL) }
+
+func BenchmarkIdentifierLed_TwoStage(b *testing.B) {
+	benchParseSet(b, identifierLedExprs, benchLexParseTwoStage)
+}
+func BenchmarkLiteralLed_LL(b *testing.B) { benchParseSet(b, literalLedExprs, benchLexParseLL) }
+func BenchmarkLiteralLed_TwoStage(b *testing.B) {
+	benchParseSet(b, literalLedExprs, benchLexParseTwoStage)
+}

--- a/internal/parser/planparserv2/sll_two_stage_bench_test.go
+++ b/internal/parser/planparserv2/sll_two_stage_bench_test.go
@@ -58,16 +58,46 @@ func benchLexParseTwoStage(expr string) (gen.IExprContext, error) {
 	return ast, err
 }
 
+// parseTree parses expr (LL or SLL-first two-stage) and returns a structural
+// S-expression of the parse tree plus the accept/reject error. ToStringTree
+// encodes rule nesting, so unlike GetText (which only concatenates leaf tokens
+// and is identical for any parse over the same token stream) it can detect a
+// precedence/associativity divergence between the two strategies. The tree is
+// computed while the parser is still alive, before it returns to the pool.
+func parseTree(expr string, twoStage bool) (string, error) {
+	listener := &errorListenerImpl{}
+	is := antlr.NewInputStream(convertHanToASCII(expr))
+	lexer := getLexer(is, listener)
+	parser := getParser(lexer, listener)
+	var ast gen.IExprContext
+	if twoStage {
+		ast = parseExpr(parser, listener)
+	} else {
+		parser.SetErrorHandler(antlr.NewDefaultErrorStrategy())
+		parser.GetInterpreter().SetPredictionMode(antlr.PredictionModeLL)
+		ast = parser.Expr()
+	}
+	err := eofErr(parser, listener)
+	tree := ""
+	if err == nil && ast != nil {
+		tree = antlr.TreesStringTree(ast, parser.GetRuleNames(), parser)
+	}
+	putLexer(lexer)
+	putParser(parser)
+	return tree, err
+}
+
 // TestTwoStageMatchesLL guarantees the SLL-first two-stage parse yields exactly
-// the same tree (and the same accept/reject decision) as a pure LL parse for the
-// whole benchmark corpus — the correctness contract behind the optimization.
+// the same parse tree (structural, via ToStringTree) and the same accept/reject
+// decision as a pure LL parse for the whole benchmark corpus — the correctness
+// contract behind the optimization.
 func TestTwoStageMatchesLL(t *testing.T) {
 	for _, tc := range benchmarkExprs {
-		llAst, llErr := benchLexParseLL(tc.expr)
-		tsAst, tsErr := benchLexParseTwoStage(tc.expr)
+		llTree, llErr := parseTree(tc.expr, false)
+		tsTree, tsErr := parseTree(tc.expr, true)
 		require.Equal(t, llErr == nil, tsErr == nil, "accept/reject differs for %q (LL err=%v, two-stage err=%v)", tc.expr, llErr, tsErr)
 		if llErr == nil && tsErr == nil {
-			require.Equal(t, llAst.GetText(), tsAst.GetText(), "parse tree differs for %q", tc.expr)
+			require.Equal(t, llTree, tsTree, "parse tree differs for %q", tc.expr)
 		}
 	}
 }


### PR DESCRIPTION
issue: #50781

## What this PR does

Two parse-path enhancements in `internal/parser/planparserv2` (no grammar regeneration, no public API change):

- **SLL-first two-stage parse** (`parseExpr`): parse with `PredictionModeSLL` first; only if SLL cannot decide, rewind the token buffer and reparse with full `PredictionModeLL` + default recovery. A clean SLL parse is provably identical to a pure-LL parse.
- **Drop ANTLR's default `ConsoleErrorListener`** in the pooled lexer/parser so a syntax error no longer does stderr I/O on the hot failure path.

Note: `antlr-go` v4.13.1 (and upstream `dev`) ship `BailErrorStrategy` with an unimplemented `ParseCancellationException` (`panic("implement me")`), so the standard bail-based two-stage cannot be used; "SLL could not decide" is detected via a probe error listener instead.

## Performance — the win is concentrated, not uniform

Parse-only (lex+parse, AST cache bypassed), separate cold-start processes, min of repeated runs (GC-noise filtered). The honest per-expression picture:

| expression class | example | LL → TS | allocs/op |
|---|---|---|---|
| **range compare `a<x<b`** | `10 < Int64Field < 100` | **~58000 → ~8700 ns (~7× faster)** | **1295 → 184** |
| equality / comparison | `Int64Field == 100` | ~neutral (±2%) | 175 → 177 |
| `in`, `like`, `is null`, JSON, `&&`/`||` | `StringField like "x%"` | ~neutral (±2%) | +2 |
| large `in[...]`, bitwise, deep logical | — | ~neutral (±3%) | ~equal |

The grammar's `Range`/`ReverseRange` alternatives are ambiguous with nested `Relational`, which drives ANTLR's full-LL prediction into a pathological path (1295 allocs for one `a<x<b`). SLL resolves it directly. **That single class accounts for essentially all of the aggregate gain (~-19% ns/op, -21% allocs across a 144-expression corpus); every other expression class is within measurement noise of LL.** The only added cost is one ~40-byte allocation per parse (the probe listener).

So this is high value if range filters (`10 < age < 100`) are common in the workload, and neutral otherwise — not a uniform speedup.

## Correctness

The SLL two-stage parse is verified to produce the **exact same parse tree** as a pure-LL parse, compared structurally via `antlr.TreesStringTree` (an S-expression that encodes nesting — unlike `GetText()`, which only concatenates leaf tokens and cannot detect a precedence/associativity divergence). Verified across:
- the existing benchmark corpus (`TestTwoStageMatchesLL`),
- ~106 valid expressions, simple → complex, covering comparisons, arithmetic/bitwise/shift/unary/power, ranges, IN, string/like/regex, arrays, JSON, struct fields, null/exists, text/phrase/match_*, random_sample, spatial `st_*`, timestamptz (which exercises the SLL→LL fallback), template variables, calls and deep nesting (`TestTwoStageMatchesLL_Corpus`),
- 13 malformed expressions, rejected identically by both strategies (`TestTwoStageMatchesLL_Invalid`).

Full `planparserv2` package test suite passes; `gofumpt`/`gci`/`golangci-lint` clean.

## Evaluated and rejected

Moving the two leading `Timestamptz*` `expr` alternatives out of the grammar was measured to change parse time by **<1%** with identical allocations (the DFA caches the decision after first use), so it is intentionally **not** included.

/kind enhancement
