### PR TITLE
feat: support function chain API for search rerank

### DIFF
--- a/docs/design-docs/design_docs/20260624-function-chain-api.md
+++ b/docs/design-docs/design_docs/20260624-function-chain-api.md
@@ -1,0 +1,642 @@
+# MEP: Function Chain API for Search Rerank
+
+- **Created:** 2026-06-24
+- **Author(s):** @junjie.jiang
+- **Status:** Draft
+- **Component:** SDK / Proxy / Function Chain
+- **Related Issues:** TBD
+- **Released:** N/A
+
+## Summary
+
+Function Chain introduces a typed, ordered, stage-aware pipeline for scoring and reranking search results. A chain is sent as structured protobuf, not as an opaque JSON string, so Milvus can validate dependencies, fetch required fields internally, execute built-in scoring functions, and project final search results back through the existing result schema.
+
+The first release focuses on ordinary `SearchRequest` L2 rerank:
+
+- Users build an L2 chain in SDKs and pass it through `function_chains`.
+- Proxy validates the request, plans required rerank input fields, and reuses the existing rerank pipeline.
+- The function-chain runtime executes `map`, `sort`, and `limit` operators on a DataFrame converted from reduced search results.
+- Final `$score` is serialized through the existing search score/distance field.
+- Intermediate variables and internally fetched fields are not returned unless requested by normal search output projection.
+
+## Motivation
+
+Milvus already has legacy rerank entry points such as `function_score` and ranker parameters. They are useful for predefined scoring formulas, but they do not provide a general ordered plan for composing multiple rerank steps.
+
+Users need to express pipelines such as:
+
+1. Compute a freshness score from a timestamp field.
+2. Combine the original ANN score, freshness, and popularity.
+3. Optionally call an external rerank model for text relevance.
+4. Rewrite the final score.
+5. Sort and optionally trim candidates.
+
+Representing this as typed operations gives Milvus:
+
+- deterministic execution order;
+- typed nested parameters without JSON-in-string encoding;
+- explicit field dependency analysis;
+- consistent `$score` semantics;
+- future room for additional stages and operators.
+
+## Goals
+
+- Add public protobuf messages for a function-chain logical plan.
+- Add SDK builder APIs that compile to the protobuf plan.
+- Support ordinary Search L2 rerank through `SearchRequest.function_chains`.
+- Reuse the existing Proxy rerank pipeline rather than adding a separate search pipeline operator.
+- Fetch function-chain-required schema fields internally even when users do not request them in `output_fields`.
+- Keep final search response projection Search-owned.
+- Support first-version built-in expressions:
+  - `decay`
+  - `num_combine`
+  - `round_decimal`
+  - `rerank_model`
+- Preserve compatibility with existing search and legacy rerank behavior.
+
+## Non-Goals
+
+The first release does not include:
+
+- `function_chains` support for hybrid search execution;
+- insert/upsert/ingestion function chains;
+- L0/L1 pushdown to QueryNode or Segcore;
+- arbitrary user-defined expression language;
+- returning intermediate chain variables as user-facing result fields;
+- replacing `function_score` or legacy rank parameters;
+- client-side execution of external model calls.
+
+The public stage enum reserves room for future stages, but ordinary Search initially accepts only `L2_RERANK`.
+
+## Public Interfaces
+
+### PyMilvus DSL
+
+A user builds a chain with `FunctionChain`, `FunctionChainStage`, `col`, and helper functions under `fn`:
+
+```python
+from pymilvus import FunctionChain, FunctionChainStage
+from pymilvus.function_chain import col, fn
+
+chain = (
+    FunctionChain(FunctionChainStage.L2_RERANK, name="fresh_popular_rerank")
+    .map(
+        "freshness",
+        fn.decay(
+            col("published_at"),
+            function="exp",
+            origin=current_time,
+            scale=86400,
+            offset=0,
+            decay=0.5,
+        ),
+    )
+    .map(
+        "$score",
+        fn.num_combine(
+            col("$score"),
+            col("freshness"),
+            col("popularity"),
+            mode="weighted",
+            weights=[0.7, 0.2, 0.1],
+        ),
+    )
+    .map("$score", fn.round_decimal(col("$score"), decimal=4))
+    .sort(col("$score"), desc=True, tie_break_col=col("$id"))
+    .limit(10)
+)
+
+client.search(
+    collection_name="articles",
+    data=[query_vector],
+    anns_field="embedding",
+    search_params={"metric_type": "IP"},
+    limit=100,
+    output_fields=["title"],
+    function_chains=chain,
+)
+```
+
+For model rerank:
+
+```python
+chain = (
+    FunctionChain(FunctionChainStage.L2_RERANK, name="model_rerank")
+    .map(
+        "$score",
+        fn.rerank_model(
+            col("doc"),
+            queries=["renewable energy developments"],
+            provider="voyageai",
+            model_name="rerank-2.5",
+            truncation=True,
+            max_client_batch_size=128,
+        ),
+    )
+    .sort(col("$score"), desc=True, tie_break_col=col("$id"))
+)
+```
+
+External model credentials are resolved by Milvus server-side provider configuration. SDK requests should not carry API keys.
+
+### Search API
+
+Ordinary Search accepts `function_chains`:
+
+```python
+client.search(..., function_chains=chain)
+client.search(..., function_chains=[chain])
+```
+
+SDK and server validation reject ambiguous combinations:
+
+- `function_chains` with SDK `ranker` / proto `function_score`;
+- non-L2 chains for ordinary Search;
+- `function_chains` for hybrid search in the first release.
+
+### Protobuf
+
+The public protobuf models a chain as an ordered logical plan:
+
+```proto
+enum FunctionChainStage {
+  FunctionChainStageUnspecified = 0;
+  FunctionChainStageIngestion = 1;
+  FunctionChainStagePreProcess = 2;
+  FunctionChainStageL0Rerank = 3;
+  FunctionChainStageL1Rerank = 4;
+  FunctionChainStageL2Rerank = 5;
+  FunctionChainStagePostProcess = 6;
+}
+
+message FunctionChain {
+  string name = 1;
+  FunctionChainStage stage = 2;
+  repeated FunctionChainOp ops = 3;
+}
+
+message FunctionChainOp {
+  string op = 1;
+  FunctionChainExpr expr = 2;
+  repeated string inputs = 3;
+  repeated string outputs = 4;
+  map<string, FunctionParamValue> params = 5;
+}
+
+message FunctionChainExpr {
+  string name = 1;
+  repeated FunctionChainExprArg args = 2;
+  map<string, FunctionParamValue> params = 3;
+}
+
+message FunctionChainExprArg {
+  oneof arg {
+    FunctionChainColumnArg column = 1;
+    FunctionParamValue literal = 2;
+  }
+}
+
+message FunctionChainColumnArg {
+  string name = 1;
+}
+
+message FunctionParamValue {
+  oneof value {
+    bool bool_value = 1;
+    int64 int64_value = 2;
+    double double_value = 3;
+    string string_value = 4;
+    FunctionParamArray array_value = 5;
+    FunctionParamObject object_value = 6;
+    bytes bytes_value = 7;
+  }
+}
+
+message FunctionParamArray {
+  repeated FunctionParamValue values = 1;
+}
+
+message FunctionParamObject {
+  map<string, FunctionParamValue> fields = 1;
+}
+```
+
+`SearchRequest` carries chains through:
+
+```proto
+repeated schema.FunctionChain function_chains = 24;
+```
+
+Hybrid request proto may reserve a field for future support, but first-version execution rejects it.
+
+## Semantics
+
+### `$score`
+
+`$score` is a system virtual column, not a collection field.
+
+Runtime behavior:
+
+1. At rerank input construction, `$score` is initialized from the current search result score/distance.
+2. Functions can read `$score` through `col("$score")`.
+3. `map("$score", expr)` overwrites the current score register.
+4. `sort(col("$score"), desc=True)` sorts candidates by the current rewritten score.
+5. The final `$score` is serialized through existing result score/distance fields.
+6. SDK users observe it as the normal hit distance/score value.
+
+Representation:
+
+| Layer | Representation |
+|-------|----------------|
+| Python DSL | `"$score"` |
+| Proto | `FunctionChainColumnArg.name = "$score"` |
+| Runtime | score register / DataFrame column |
+| Search result | existing distance/score field |
+
+`$id` is also available as a read-only system value for tie-breaking. Other `$xxx` system names are rejected in first-version L2 rerank.
+
+### Operators
+
+#### `map`
+
+`map(output, expr)` evaluates an expression and writes the result to `output`.
+
+- `output` may be a temporary variable such as `freshness`.
+- `output` may be writable system value `$score`.
+- First-version L2 rerank does not allow writing `$id` or unknown `$xxx` values.
+
+#### `sort`
+
+`sort(by, desc=True, tie_break_col=None)` sorts the current candidate chunk.
+
+- `by` is encoded as an op input and parameter.
+- `tie_break_col` is optional and is also encoded as an input.
+- Sorting is explicit. Milvus does not infer ordering direction from vector metric type after a chain sort is present.
+
+#### `limit`
+
+`limit(limit, offset=0)` trims each query chunk after previous operators.
+
+This is part of the user-provided plan. Search does not append implicit `limit` or `offset` operators to public function chains.
+
+### Built-in expressions
+
+#### `decay`
+
+Computes a numeric decay score from one numeric input column.
+
+Parameters:
+
+- `function`: `gauss`, `exp`, or `linear`
+- `origin`
+- `scale`
+- `offset`
+- `decay`
+
+#### `num_combine`
+
+Combines two or more numeric inputs.
+
+Modes:
+
+- `multiply`
+- `sum`
+- `max`
+- `min`
+- `avg`
+- `weighted`
+
+`weighted` mode requires one numeric weight per input.
+
+#### `round_decimal`
+
+Rounds one Float32 score column to a fixed number of decimal places in `[0, 6]`.
+
+#### `rerank_model`
+
+Calls an external rerank model provider for a text column. It is only runnable at L2 rerank stage in the first release.
+
+Required parameters:
+
+- `queries`: one query per search query chunk.
+- provider parameters such as `provider`, `model_name`, `max_client_batch_size`, and provider-specific options.
+
+Provider credentials and endpoint defaults are resolved on the Milvus server using existing function provider configuration.
+
+## Input, Write, and Projection Semantics
+
+Function Chain separates chain execution names from final result projection.
+
+```text
+expr-based op read names = column references in FunctionChainExpr.args
+non-expr op read names   = FunctionChainOp.inputs
+op write names           = FunctionChainOp.outputs
+final result projection  = Search-owned output projection
+```
+
+Example:
+
+```python
+FunctionChain(FunctionChainStage.L2_RERANK) \
+    .map("freshness", fn.decay(col("published_at"), ...)) \
+    .map("$score", fn.num_combine(col("$score"), col("freshness"), mode="sum")) \
+    .sort(col("$score"), desc=True)
+```
+
+Dependency analysis sees:
+
+- required input before previous writes: `published_at`, `$score`;
+- written names: `freshness`, `$score`;
+- `freshness` is not fetched from collection schema because a previous op writes it;
+- `published_at` is fetched internally for rerank even if it is not in user `output_fields`;
+- final response returns only `$id`, final `$score`, and user-requested output fields.
+
+Intermediate variables such as `freshness` are not returned to the user.
+
+## Design Details
+
+### High-level Search flow
+
+```text
+SearchRequest.function_chains
+  -> SDK serialization
+  -> Proxy request validation
+  -> chain.ProtoChainToRepr
+  -> Proxy L2 input planning
+  -> normal search/reduce/requery pipeline
+  -> rerankOperator builds DataFrame
+  -> chain.FuncChainFromRepr
+  -> FuncChain.Execute
+  -> Search-owned final projection
+```
+
+Function Chain L2 rerank is treated as a rerank source. It reuses the existing `rerankOperator` rather than adding a separate `functionChainOperator`.
+
+### Internal representation
+
+The chain package converts public proto to a caller-independent representation:
+
+```go
+type ChainRepr struct {
+    Name      string
+    Stage     string
+    Operators []OperatorRepr
+    Info      ChainReprInfo
+}
+
+type ChainReprInfo struct {
+    RequiredInputs []string
+    WrittenNames   []string
+    Ops            []OperatorReprInfo
+}
+
+type OperatorReprInfo struct {
+    Type       string
+    ReadNames  []string
+    WriteNames []string
+}
+```
+
+`ChainRepr.Info.RequiredInputs` only means "the chain reads these names before any previous op writes them." It does not decide whether a name is a schema field, runtime system value, or invalid. That classification is caller-owned.
+
+### Proxy L2 input planning
+
+For ordinary Search L2 rerank, Proxy classifies each required input:
+
+1. `$score` and `$id` are runtime system inputs.
+2. Other names must resolve to supported collection schema fields.
+3. Unknown non-system names are rejected.
+4. Unsupported `$xxx` system inputs are rejected.
+5. Temporary variables written by previous ops are not fetched from schema.
+
+First-version supported schema input field types:
+
+- Bool
+- Int8 / Int16 / Int32 / Int64 / Timestamptz
+- Float / Double
+- String / VarChar / Text
+
+Unsupported input field types include vector fields, JSON, Array, Geometry, and dynamic field subkeys.
+
+### Request-level rules
+
+#### `function_score` conflict
+
+`function_score` and `function_chains` are mutually exclusive:
+
+```text
+function_score and function_chains cannot be used together
+```
+
+Both APIs define rerank score behavior. Combining them would make ordering ambiguous.
+
+SDK `ranker` maps to legacy rerank/function-score behavior, so SDK rejects `ranker` plus `function_chains` before RPC.
+
+#### Stage uniqueness
+
+The same `FunctionChainStage` may appear at most once in one request.
+
+The first release supports only one ordinary Search stage:
+
+```text
+FunctionChainStageL2Rerank
+```
+
+Users who need multiple rerank steps should put multiple ops in one L2 chain instead of sending multiple L2 chains.
+
+#### Hybrid search
+
+First-version hybrid search rejects `function_chains`:
+
+```text
+function_chains is not supported for hybrid search yet
+```
+
+Hybrid support needs a separate design for whether public chains apply to sub-searches, merged candidates, or both.
+
+### Requery and field availability
+
+No new fetch mechanism is required. Function-chain input fields flow through existing rerank metadata:
+
+```text
+rerankMeta.GetInputFieldNames()
+rerankMeta.GetInputFieldIDs()
+```
+
+When requery is needed, the requery operator includes rerank-required field names so the DataFrame can be built before rerank execution. Final projection still uses user output fields and does not expose internally fetched rerank inputs.
+
+### Rerank operator integration
+
+`rerankOperator` follows the existing function-score flow:
+
+```text
+SearchResultData
+  -> chain.FromSearchResultData(..., neededFields)
+  -> build FuncChain from rerank metadata
+  -> ExecuteWithContext
+  -> chain.ToSearchResultDataWithOptions(...)
+```
+
+The chain builder dispatches by rerank metadata type:
+
+- legacy function score -> existing function-score chain builder;
+- legacy rank params -> existing legacy rank builder;
+- public function chain -> `FuncChainFromRepr` / `FuncChainFromReprWithContext`.
+
+### Tail behavior
+
+A public `FunctionChain` is executed as sent.
+
+Milvus does not implicitly append tail operators such as:
+
+- sort;
+- limit;
+- group-by;
+- round-decimal.
+
+Users or SDK helpers must add explicit ops when they want those effects.
+
+## Validation Rules
+
+First-version validation includes:
+
+1. Function chain proto must not be nil.
+2. Stage must be supported by the request type.
+3. Duplicate stages are rejected.
+4. Operator names must be non-empty.
+5. Expression names must be non-empty when an expression is present.
+6. Column references and input/output names must be non-empty.
+7. Expr args must be either column refs or supported literals.
+8. Parameter values must be typed and convertible to runtime values.
+9. L2 input system names are restricted to `$id` and `$score`.
+10. L2 system outputs are restricted to `$score`.
+11. Non-system required inputs must be supported collection fields.
+12. Unknown operators and functions are rejected.
+13. A function must be runnable at the chain stage.
+14. Function-specific parameters must pass validation.
+15. External rerank model query count must match query chunk count.
+
+Additional ordering constraints such as "at most one sort" or "sort must be last" can be considered as future stricter validation. The first release executes the ordered plan as sent unless a runtime operator rejects it.
+
+## Compatibility, Deprecation, and Migration Plan
+
+### Compatibility
+
+- Existing search requests without `function_chains` are unchanged.
+- Existing `function_score` and legacy rank behavior remain supported.
+- Public function chains are opt-in.
+- Existing result schema is preserved; final score is exposed through current score/distance fields.
+
+### Deprecation
+
+No deprecation is introduced in this MEP.
+
+### Migration
+
+Users can migrate from `function_score` or ranker APIs to `function_chains` when they need explicit ordered composition. There is no automatic conversion in the first release.
+
+## Security Considerations
+
+External model rerank can call third-party services from Milvus server processes.
+
+Security requirements:
+
+1. API credentials are resolved server-side through existing provider configuration or credential stores.
+2. SDK `function_chains` requests should not include raw API keys.
+3. Provider credentials must be redacted in logs by existing credential handling paths.
+4. Provider endpoints should use HTTPS unless explicitly configured for trusted local testing.
+5. Requests to external providers may include user text fields. Deployments must treat this as data egress and configure providers accordingly.
+6. Timeouts and batching limits must prevent unbounded external calls.
+
+## Observability
+
+Initial observability reuses existing search/function error paths and provider HTTP errors.
+
+Useful follow-up metrics:
+
+- function-chain execution latency by operator/function type;
+- number of internally fetched fields for function-chain rerank;
+- external rerank provider latency and error count by provider;
+- rejected function-chain requests by validation category.
+
+## Test Plan
+
+### SDK tests
+
+1. Builder serialization for `map`, `sort`, `limit`.
+2. Typed parameter serialization for scalar, bytes, arrays, and nested objects.
+3. `col(...)` validation.
+4. Helper validation for `decay`, `num_combine`, `round_decimal`, and `rerank_model`.
+5. Search request encoding with single chain and list of chains.
+6. Reject `function_chains` plus `ranker`.
+7. Reject non-L2 chains for ordinary Search.
+8. Reject `function_chains` for hybrid search.
+
+### Proxy and chain planning tests
+
+1. `function_score` plus `function_chains` is rejected.
+2. Duplicate L2 chains are rejected.
+3. Non-L2 chain stages are rejected in ordinary Search.
+4. Hybrid Search with `function_chains` is rejected.
+5. `$score`-only chain succeeds with no schema input fields.
+6. `field + $score` chain fetches only required schema fields.
+7. A previous op output used by a later op is not fetched as a schema field.
+8. Unknown non-system input is rejected.
+9. Unsupported `$xxx` system input is rejected.
+10. Unsupported system output is rejected.
+11. Unsupported schema input field type is rejected.
+
+### Rerank path tests
+
+1. `buildChainFromMeta` builds a `FuncChain` from `functionChainRerankMeta`.
+2. Existing `rerankOperator` executes a proto-derived chain through DataFrame.
+3. A chain that maps and sorts `$score` changes result order and scores.
+4. A chain with `limit` updates per-query TopKs.
+5. Chain-required fields are available after requery but are not exposed in final response fields.
+6. Existing `function_score` and legacy rank behavior remain unchanged.
+7. Optional external provider test for `rerank_model`, such as VoyageAI, gated on server-side credentials.
+
+### Regression checks
+
+Run targeted Go tests with Milvus test flags:
+
+```bash
+go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/util/function/chain/...
+go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/proxy/... -run 'FunctionChain|Rerank'
+```
+
+Run SDK tests from the PyMilvus repository or local checkout as appropriate.
+
+## Rejected Alternatives
+
+### 1. Encode params as JSON strings in `KeyValuePair`
+
+Rejected because function-chain parameters may contain nested objects, arrays, booleans, integers, floating-point values, and bytes. JSON-in-string encoding would cause:
+
+- late parsing failures;
+- weak type information;
+- inconsistent SDK behavior;
+- weaker validation errors;
+- ambiguity around numeric types.
+
+`FunctionParamValue` keeps the public plan typed.
+
+### 2. Reuse `function_score` for all chain behavior
+
+Rejected because `function_score` is not an ordered operator pipeline and cannot naturally express multiple map/sort/limit/model steps with explicit dependencies.
+
+### 3. Add a separate `functionChainOperator` to the search pipeline
+
+Rejected for the first release because function chains are another rerank implementation. Reusing the existing `rerankOperator` keeps fetch/requery/final-projection behavior consistent with legacy rerank.
+
+### 4. Classify required inputs in the generic chain package
+
+Rejected because only the caller knows whether a name is a schema field, request payload field, runtime system value, or invalid. The chain package only reports structural dependencies.
+
+## Open Questions
+
+1. What is the best public API for hybrid search support: top-level post-merge chain, per-sub-search chains, or both?
+2. Which functions should be allowed in future L0/L1 stages, and where should they execute?
+3. Should strict operator ordering rules be enforced, such as one `sort` and only as the last ordering op?
+4. Should users be able to return intermediate variables explicitly in future APIs?
+5. Should provider-specific metrics be standardized across embedding and rerank model providers?

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/hamba/avro/v2 v2.29.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/magiconair/properties v1.8.7
-	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260612100615-43795e8f8f6e
+	github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260625075625-7262f8042a55
 	github.com/milvus-io/milvus/client/v2 v2.6.2
 	github.com/milvus-io/milvus/pkg/v3 v3.0.0-beta
 	github.com/shirou/gopsutil/v4 v4.25.10

--- a/go.sum
+++ b/go.sum
@@ -800,8 +800,8 @@ github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6 h1:YHMFI6L
 github.com/milvus-io/cgosymbolizer v0.0.0-20250318084424-114f4050c3a6/go.mod h1:DvXTE/K/RtHehxU8/GtDs4vFtfw64jJ3PaCnFri8CRg=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZzUfIfYe5qYDBzt4ZYRqzUjTR6CvUzjat8=
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
-github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260612100615-43795e8f8f6e h1:axPnOhjsWqqxk0dOQRSIU2mdg52Kyl/8E6iDFZy/IpE=
-github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260612100615-43795e8f8f6e/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260625075625-7262f8042a55 h1:U07yIwkWsk7wpGCkWZlY8lSVEFNWKpmm7M+aF5D+wg8=
+github.com/milvus-io/milvus-proto/go-api/v3 v3.0.0-20260625075625-7262f8042a55/go.mod h1:rbKpv5JToISTKTTLl0duL5r6wbYnjJ9SsD0QgXMzKy0=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -1729,6 +1729,12 @@ func (h *HandlersV2) search(ctx context.Context, c *gin.Context, anyReq any, dbN
 			return nil, err
 		}
 	}
+	if len(httpReq.FunctionChains) != 0 {
+		if req.FunctionChains, err = genFunctionChains(httpReq.FunctionChains); err != nil {
+			HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(merr.ErrParameterInvalid), HTTPReturnMessage: err.Error()})
+			return nil, err
+		}
+	}
 
 	if hasIDs {
 		// Search by primary keys
@@ -1895,6 +1901,11 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 
 	if httpReq.SearchAggregation != nil {
 		err := merr.WrapErrParameterInvalidMsg("searchAggregation is not supported for hybrid search")
+		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
+		return nil, err
+	}
+	if len(httpReq.FunctionChains) != 0 {
+		err := merr.WrapErrParameterInvalidMsg("functionChains is not supported for hybrid search yet")
 		HTTPAbortReturn(c, http.StatusOK, gin.H{HTTPReturnCode: merr.Code(err), HTTPReturnMessage: err.Error()})
 		return nil, err
 	}

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -394,6 +394,7 @@ type SearchReqV2 struct {
 	ConsistencyLevel  string                 `json:"consistencyLevel"`
 	ExprParams        map[string]interface{} `json:"exprParams"`
 	FunctionScore     FunctionScore          `json:"functionScore"`
+	FunctionChains    []FunctionChainReq     `json:"functionChains"`
 	SearchAggregation *SearchAggregationReq  `json:"searchAggregation"`
 	// not use Params any more, just for compatibility
 	Params map[string]float64 `json:"params"`
@@ -464,6 +465,7 @@ type HybridSearchReq struct {
 	OutputFields      []string              `json:"outputFields"`
 	ConsistencyLevel  string                `json:"consistencyLevel"`
 	FunctionScore     FunctionScore         `json:"functionScore"`
+	FunctionChains    []FunctionChainReq    `json:"functionChains"`
 	SearchAggregation *SearchAggregationReq `json:"searchAggregation"`
 }
 
@@ -823,6 +825,31 @@ func hasTypeParam(typeParams []*commonpb.KeyValuePair, key string) bool {
 type FunctionScore struct {
 	Functions []FunctionSchema       `json:"functions"`
 	Params    map[string]interface{} `json:"params"`
+}
+
+type FunctionChainReq struct {
+	Name  string               `json:"name"`
+	Stage string               `json:"stage"`
+	Ops   []FunctionChainOpReq `json:"ops"`
+}
+
+type FunctionChainOpReq struct {
+	Op      string                 `json:"op"`
+	Expr    *FunctionChainExprReq  `json:"expr"`
+	Inputs  []string               `json:"inputs"`
+	Outputs []string               `json:"outputs"`
+	Params  map[string]interface{} `json:"params"`
+}
+
+type FunctionChainExprReq struct {
+	Name   string                    `json:"name"`
+	Args   []FunctionChainExprArgReq `json:"args"`
+	Params map[string]interface{}    `json:"params"`
+}
+
+type FunctionChainExprArgReq struct {
+	Column  *string     `json:"column"`
+	Literal interface{} `json:"literal"`
 }
 
 type FunctionSchema struct {

--- a/internal/distributed/proxy/httpserver/utils.go
+++ b/internal/distributed/proxy/httpserver/utils.go
@@ -44,6 +44,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy"
 	"github.com/milvus-io/milvus/internal/proxy/accesslog"
 	"github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/internal/util/function/chain"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/log"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
@@ -3662,4 +3663,199 @@ func genFunctionScore(ctx context.Context, functionScore *FunctionScore) (*schem
 		fScore.Params = append(fScore.Params, &commonpb.KeyValuePair{Key: key, Value: fmt.Sprintf("%v", value)})
 	}
 	return &fScore, nil
+}
+
+func genFunctionChains(chains []FunctionChainReq) ([]*schemapb.FunctionChain, error) {
+	result := make([]*schemapb.FunctionChain, 0, len(chains))
+	for i, chainReq := range chains {
+		chainPB, err := genFunctionChain(chainReq)
+		if err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg("functionChains[%d]: %v", i, err)
+		}
+		result = append(result, chainPB)
+	}
+	return result, nil
+}
+
+func genFunctionChain(req FunctionChainReq) (*schemapb.FunctionChain, error) {
+	stage, err := genFunctionChainStage(req.Stage)
+	if err != nil {
+		return nil, err
+	}
+
+	ops := make([]*schemapb.FunctionChainOp, 0, len(req.Ops))
+	for i, opReq := range req.Ops {
+		opPB, err := genFunctionChainOp(opReq)
+		if err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg("ops[%d]: %v", i, err)
+		}
+		ops = append(ops, opPB)
+	}
+
+	return &schemapb.FunctionChain{
+		Name:  strings.TrimSpace(req.Name),
+		Stage: stage,
+		Ops:   ops,
+	}, nil
+}
+
+func genFunctionChainStage(stageName string) (schemapb.FunctionChainStage, error) {
+	stageName = strings.TrimSpace(stageName)
+	stageValue, ok := schemapb.FunctionChainStage_value[stageName]
+	if !ok {
+		return schemapb.FunctionChainStage_FunctionChainStageUnspecified, merr.WrapErrParameterInvalidMsg("unsupported function chain stage: %s", stageName)
+	}
+	stage := schemapb.FunctionChainStage(stageValue)
+	if _, err := chain.ProtoStageToReprStage(stage); err != nil {
+		return schemapb.FunctionChainStage_FunctionChainStageUnspecified, err
+	}
+	return stage, nil
+}
+
+func genFunctionChainOp(req FunctionChainOpReq) (*schemapb.FunctionChainOp, error) {
+	opName := strings.TrimSpace(req.Op)
+	if opName == "" {
+		return nil, merr.WrapErrParameterInvalidMsg("op name is empty")
+	}
+
+	paramMap, err := genFunctionParamMap(req.Params)
+	if err != nil {
+		return nil, merr.WrapErrParameterInvalidMsg("params: %v", err)
+	}
+
+	var exprPB *schemapb.FunctionChainExpr
+	if req.Expr != nil {
+		exprPB, err = genFunctionChainExpr(*req.Expr)
+		if err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg("expr: %v", err)
+		}
+	}
+
+	return &schemapb.FunctionChainOp{
+		Op:      opName,
+		Expr:    exprPB,
+		Inputs:  trimStringList(req.Inputs),
+		Outputs: trimStringList(req.Outputs),
+		Params:  paramMap,
+	}, nil
+}
+
+func genFunctionChainExpr(req FunctionChainExprReq) (*schemapb.FunctionChainExpr, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, merr.WrapErrParameterInvalidMsg("expr name is empty")
+	}
+
+	args := make([]*schemapb.FunctionChainExprArg, 0, len(req.Args))
+	for i, argReq := range req.Args {
+		argPB, err := genFunctionChainExprArg(argReq)
+		if err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg("args[%d]: %v", i, err)
+		}
+		args = append(args, argPB)
+	}
+
+	params, err := genFunctionParamMap(req.Params)
+	if err != nil {
+		return nil, merr.WrapErrParameterInvalidMsg("params: %v", err)
+	}
+
+	return &schemapb.FunctionChainExpr{
+		Name:   name,
+		Args:   args,
+		Params: params,
+	}, nil
+}
+
+func genFunctionChainExprArg(req FunctionChainExprArgReq) (*schemapb.FunctionChainExprArg, error) {
+	hasColumn := req.Column != nil
+	hasLiteral := req.Literal != nil
+	if hasColumn == hasLiteral {
+		return nil, merr.WrapErrParameterInvalidMsg("exactly one of column or literal is required")
+	}
+	if hasColumn {
+		name := strings.TrimSpace(*req.Column)
+		if name == "" {
+			return nil, merr.WrapErrParameterInvalidMsg("column name is empty")
+		}
+		return &schemapb.FunctionChainExprArg{
+			Arg: &schemapb.FunctionChainExprArg_Column{
+				Column: &schemapb.FunctionChainColumnArg{Name: name},
+			},
+		}, nil
+	}
+
+	literal, err := genFunctionParamValue(req.Literal)
+	if err != nil {
+		return nil, merr.WrapErrParameterInvalidMsg("literal: %v", err)
+	}
+	return &schemapb.FunctionChainExprArg{
+		Arg: &schemapb.FunctionChainExprArg_Literal{Literal: literal},
+	}, nil
+}
+
+func genFunctionParamMap(params map[string]interface{}) (map[string]*schemapb.FunctionParamValue, error) {
+	result := make(map[string]*schemapb.FunctionParamValue, len(params))
+	for key, value := range params {
+		paramName := strings.TrimSpace(key)
+		if paramName == "" {
+			return nil, merr.WrapErrParameterInvalidMsg("param name is empty")
+		}
+		paramValue, err := genFunctionParamValue(value)
+		if err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg("param %q: %v", key, err)
+		}
+		result[paramName] = paramValue
+	}
+	return result, nil
+}
+
+func genFunctionParamValue(value interface{}) (*schemapb.FunctionParamValue, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, merr.WrapErrParameterInvalidMsg("function param value is nil")
+	case bool:
+		return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_BoolValue{BoolValue: v}}, nil
+	case float64:
+		if math.Trunc(v) == v && v >= math.MinInt64 && v <= math.MaxInt64 {
+			return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_Int64Value{Int64Value: int64(v)}}, nil
+		}
+		return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_DoubleValue{DoubleValue: v}}, nil
+	case string:
+		return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_StringValue{StringValue: v}}, nil
+	case []interface{}:
+		values := make([]*schemapb.FunctionParamValue, 0, len(v))
+		for i, item := range v {
+			converted, err := genFunctionParamValue(item)
+			if err != nil {
+				return nil, merr.WrapErrParameterInvalidMsg("array[%d]: %v", i, err)
+			}
+			values = append(values, converted)
+		}
+		return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_ArrayValue{ArrayValue: &schemapb.FunctionParamArray{Values: values}}}, nil
+	case map[string]interface{}:
+		fields := make(map[string]*schemapb.FunctionParamValue, len(v))
+		for key, item := range v {
+			fieldName := strings.TrimSpace(key)
+			if fieldName == "" {
+				return nil, merr.WrapErrParameterInvalidMsg("object field name is empty")
+			}
+			converted, err := genFunctionParamValue(item)
+			if err != nil {
+				return nil, merr.WrapErrParameterInvalidMsg("object field %q: %v", key, err)
+			}
+			fields[fieldName] = converted
+		}
+		return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_ObjectValue{ObjectValue: &schemapb.FunctionParamObject{Fields: fields}}}, nil
+	default:
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported function param value type %T", value)
+	}
+}
+
+func trimStringList(values []string) []string {
+	trimmed := make([]string, len(values))
+	for i, value := range values {
+		trimmed[i] = strings.TrimSpace(value)
+	}
+	return trimmed
 }

--- a/internal/distributed/proxy/httpserver/utils_test.go
+++ b/internal/distributed/proxy/httpserver/utils_test.go
@@ -3495,6 +3495,95 @@ func TestGenFunctionScore(t *testing.T) {
 	}
 }
 
+func TestGenFunctionChains(t *testing.T) {
+	column := "$score"
+	chains, err := genFunctionChains([]FunctionChainReq{
+		{
+			Name:  "l2",
+			Stage: "FunctionChainStageL2Rerank",
+			Ops: []FunctionChainOpReq{
+				{
+					Op:      "map",
+					Outputs: []string{"new_score"},
+					Expr: &FunctionChainExprReq{
+						Name: "num_combine",
+						Args: []FunctionChainExprArgReq{
+							{Column: &column},
+							{Literal: 2.5},
+						},
+						Params: map[string]interface{}{
+							"mode":    "weighted",
+							"weights": []interface{}{1.0, 2.0},
+							"nested":  map[string]interface{}{"flag": true, "count": 3.0},
+						},
+					},
+				},
+				{
+					Op:     "sort",
+					Inputs: []string{"new_score"},
+					Params: map[string]interface{}{"column": "new_score", "desc": true},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, chains, 1)
+	chainPB := chains[0]
+	assert.Equal(t, "l2", chainPB.GetName())
+	assert.Equal(t, schemapb.FunctionChainStage_FunctionChainStageL2Rerank, chainPB.GetStage())
+	require.Len(t, chainPB.GetOps(), 2)
+
+	mapOp := chainPB.GetOps()[0]
+	assert.Equal(t, "map", mapOp.GetOp())
+	assert.Equal(t, []string{"new_score"}, mapOp.GetOutputs())
+	require.NotNil(t, mapOp.GetExpr())
+	assert.Equal(t, "num_combine", mapOp.GetExpr().GetName())
+	assert.Equal(t, "$score", mapOp.GetExpr().GetArgs()[0].GetColumn().GetName())
+	assert.Equal(t, 2.5, mapOp.GetExpr().GetArgs()[1].GetLiteral().GetDoubleValue())
+	assert.Equal(t, "weighted", mapOp.GetExpr().GetParams()["mode"].GetStringValue())
+	assert.Equal(t, int64(1), mapOp.GetExpr().GetParams()["weights"].GetArrayValue().GetValues()[0].GetInt64Value())
+	assert.Equal(t, int64(3), mapOp.GetExpr().GetParams()["nested"].GetObjectValue().GetFields()["count"].GetInt64Value())
+
+	sortOp := chainPB.GetOps()[1]
+	assert.Equal(t, "sort", sortOp.GetOp())
+	assert.True(t, sortOp.GetParams()["desc"].GetBoolValue())
+	assert.Equal(t, "new_score", sortOp.GetParams()["column"].GetStringValue())
+}
+
+func TestGenFunctionChainsInvalid(t *testing.T) {
+	column := "field"
+	emptyColumn := " "
+	_, err := genFunctionChains([]FunctionChainReq{{Stage: "BadStage"}})
+	assert.ErrorContains(t, err, "unsupported function chain stage")
+
+	_, err = genFunctionChains([]FunctionChainReq{{Stage: "FunctionChainStageUnspecified"}})
+	assert.ErrorContains(t, err, "unsupported function chain stage")
+
+	_, err = genFunctionChains([]FunctionChainReq{{Stage: "FunctionChainStageL2Rerank", Ops: []FunctionChainOpReq{{Op: " "}}}})
+	assert.ErrorContains(t, err, "op name is empty")
+
+	_, err = genFunctionChains([]FunctionChainReq{{Stage: "FunctionChainStageL2Rerank", Ops: []FunctionChainOpReq{{Op: "map", Expr: &FunctionChainExprReq{Name: " "}}}}})
+	assert.ErrorContains(t, err, "expr name is empty")
+
+	_, err = genFunctionChains([]FunctionChainReq{{Stage: "FunctionChainStageL2Rerank", Ops: []FunctionChainOpReq{{Op: "map", Expr: &FunctionChainExprReq{Name: "expr", Args: []FunctionChainExprArgReq{{Column: &column, Literal: 1}}}}}}})
+	assert.ErrorContains(t, err, "exactly one of column or literal is required")
+
+	_, err = genFunctionChains([]FunctionChainReq{{Stage: "FunctionChainStageL2Rerank", Ops: []FunctionChainOpReq{{Op: "map", Expr: &FunctionChainExprReq{Name: "expr", Args: []FunctionChainExprArgReq{{}}}}}}})
+	assert.ErrorContains(t, err, "exactly one of column or literal is required")
+
+	_, err = genFunctionChains([]FunctionChainReq{{Stage: "FunctionChainStageL2Rerank", Ops: []FunctionChainOpReq{{Op: "map", Expr: &FunctionChainExprReq{Name: "expr", Args: []FunctionChainExprArgReq{{Column: &emptyColumn}}}}}}})
+	assert.ErrorContains(t, err, "column name is empty")
+
+	_, err = genFunctionChains([]FunctionChainReq{{Stage: "FunctionChainStageL2Rerank", Ops: []FunctionChainOpReq{{Op: "map", Params: map[string]interface{}{"bad": nil}}}}})
+	assert.ErrorContains(t, err, "function param value is nil")
+
+	_, err = genFunctionChains([]FunctionChainReq{{Stage: "FunctionChainStageL2Rerank", Ops: []FunctionChainOpReq{{Op: "map", Params: map[string]interface{}{" ": 1.0}}}}})
+	assert.ErrorContains(t, err, "param name is empty")
+
+	_, err = genFunctionChains([]FunctionChainReq{{Stage: "FunctionChainStageL2Rerank", Ops: []FunctionChainOpReq{{Op: "map", Params: map[string]interface{}{"object": map[string]interface{}{" ": 1.0}}}}}})
+	assert.ErrorContains(t, err, "object field name is empty")
+}
+
 func TestParseUsernamePassword(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/proxy/function_chain_validator.go
+++ b/internal/proxy/function_chain_validator.go
@@ -1,0 +1,191 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package proxy
+
+import (
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function/chain"
+	chaintypes "github.com/milvus-io/milvus/internal/util/function/chain/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+type functionChainRerankMeta struct {
+	inputFieldNames []string
+	inputFieldIDs   []int64
+	chainPB         *schemapb.FunctionChain
+	repr            *chain.ChainRepr
+}
+
+func (m *functionChainRerankMeta) GetInputFieldNames() []string { return m.inputFieldNames }
+func (m *functionChainRerankMeta) GetInputFieldIDs() []int64    { return m.inputFieldIDs }
+
+func hasFunctionRerank(request *milvuspb.SearchRequest) bool {
+	return request.GetFunctionScore() != nil || len(request.GetFunctionChains()) > 0
+}
+
+func validateFunctionChainSearchRequest(request *milvuspb.SearchRequest, isAdvanced bool) error {
+	if request.GetFunctionScore() != nil && len(request.GetFunctionChains()) > 0 {
+		return merr.WrapErrParameterInvalidMsg("function_score and function_chains cannot be used together")
+	}
+	if isAdvanced && len(request.GetFunctionChains()) > 0 {
+		return merr.WrapErrParameterInvalidMsg("function_chains is not supported for hybrid search yet")
+	}
+	return nil
+}
+
+func newFunctionChainRerankMeta(chains []*schemapb.FunctionChain, schema *schemaInfo) (*functionChainRerankMeta, error) {
+	if len(chains) == 0 {
+		return nil, nil
+	}
+
+	seenStages := make(map[schemapb.FunctionChainStage]struct{}, len(chains))
+	var chainPB *schemapb.FunctionChain
+	var repr *chain.ChainRepr
+
+	for i, pb := range chains {
+		stage := pb.GetStage()
+		if _, ok := seenStages[stage]; ok {
+			return nil, merr.WrapErrParameterInvalidMsg("function chain stage %s appears more than once", stage.String())
+		}
+		seenStages[stage] = struct{}{}
+
+		if stage != schemapb.FunctionChainStage_FunctionChainStageL2Rerank {
+			return nil, merr.WrapErrParameterInvalidMsg("function chain[%d] stage %s is not supported in search request", i, stage.String())
+		}
+		if len(pb.GetOps()) == 0 {
+			return nil, merr.WrapErrParameterInvalidMsg("function chain[%d] must contain at least one op", i)
+		}
+
+		r, err := chain.ProtoChainToRepr(pb)
+		if err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg("function chain[%d]: %v", i, err)
+		}
+		if err := validateL2RerankSystemNames(r); err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg("function chain[%d]: %v", i, err)
+		}
+		chainPB = pb
+		repr = r
+	}
+
+	inputFieldNames, inputFieldIDs, err := planL2FunctionChainInputs(repr, schema)
+	if err != nil {
+		return nil, err
+	}
+
+	return &functionChainRerankMeta{
+		inputFieldNames: inputFieldNames,
+		inputFieldIDs:   inputFieldIDs,
+		chainPB:         chainPB,
+		repr:            repr,
+	}, nil
+}
+
+func planL2FunctionChainInputs(repr *chain.ChainRepr, schema *schemaInfo) ([]string, []int64, error) {
+	if repr == nil {
+		return nil, nil, merr.WrapErrParameterInvalidMsg("function chain repr is nil")
+	}
+
+	inputFieldNames := make([]string, 0)
+	inputFieldIDs := make([]int64, 0)
+	seenInputFields := make(map[string]struct{})
+
+	for _, input := range repr.Info.RequiredInputs {
+		if chain.IsFunctionChainSystemName(input) {
+			if err := validateL2RerankSystemInput(input); err != nil {
+				return nil, nil, err
+			}
+			continue
+		}
+
+		_, fieldID, err := getFunctionChainInputField(schema, input)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if _, ok := seenInputFields[input]; ok {
+			continue
+		}
+		seenInputFields[input] = struct{}{}
+		inputFieldNames = append(inputFieldNames, input)
+		inputFieldIDs = append(inputFieldIDs, fieldID)
+	}
+
+	return inputFieldNames, inputFieldIDs, nil
+}
+
+func validateL2RerankSystemNames(repr *chain.ChainRepr) error {
+	if repr == nil {
+		return merr.WrapErrParameterInvalidMsg("function chain repr is nil")
+	}
+	for opIdx, op := range repr.Info.Ops {
+		for _, input := range op.ReadNames {
+			if !chain.IsFunctionChainSystemName(input) {
+				continue
+			}
+			if err := validateL2RerankSystemInput(input); err != nil {
+				return merr.WrapErrParameterInvalidMsg("op[%d] input %q: %v", opIdx, input, err)
+			}
+		}
+		for _, output := range op.WriteNames {
+			if !chain.IsFunctionChainSystemName(output) {
+				continue
+			}
+			if err := validateL2RerankSystemOutput(output); err != nil {
+				return merr.WrapErrParameterInvalidMsg("op[%d] output %q: %v", opIdx, output, err)
+			}
+		}
+	}
+	return nil
+}
+
+func validateL2RerankSystemInput(name string) error {
+	switch name {
+	case chaintypes.IDFieldName, chaintypes.ScoreFieldName:
+		return nil
+	default:
+		return merr.WrapErrParameterInvalidMsg("system input %q is not supported by L2 rerank function chain", name)
+	}
+}
+
+func validateL2RerankSystemOutput(name string) error {
+	switch name {
+	case chaintypes.ScoreFieldName:
+		return nil
+	default:
+		return merr.WrapErrParameterInvalidMsg("system output %q is not writable by L2 rerank function chain", name)
+	}
+}
+
+func getFunctionChainInputField(schema *schemaInfo, name string) (*schemapb.FieldSchema, int64, error) {
+	if schema == nil || schema.schemaHelper == nil {
+		return nil, 0, merr.WrapErrParameterInvalidMsg("function chain input %q is neither a previous output nor a collection field", name)
+	}
+
+	field, err := schema.schemaHelper.GetFieldFromName(name)
+	if err != nil {
+		return nil, 0, merr.WrapErrParameterInvalidMsg("function chain input %q is neither a previous output nor a collection field", name)
+	}
+
+	return validateFunctionChainInputField(name, field, field.GetFieldID())
+}
+
+func validateFunctionChainInputField(name string, field *schemapb.FieldSchema, fieldID int64) (*schemapb.FieldSchema, int64, error) {
+	if _, err := chain.ToArrowType(field.GetDataType()); err != nil {
+		return nil, 0, merr.WrapErrParameterInvalidMsg("function chain input %q has unsupported field type %s", name, field.GetDataType().String())
+	}
+	return field, fieldID, nil
+}

--- a/internal/proxy/function_chain_validator_test.go
+++ b/internal/proxy/function_chain_validator_test.go
@@ -1,0 +1,261 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function/chain/types"
+)
+
+func TestValidateFunctionChainSearchRequest(t *testing.T) {
+	t.Run("ordinary function chains", func(t *testing.T) {
+		err := validateFunctionChainSearchRequest(&milvuspb.SearchRequest{
+			FunctionChains: []*schemapb.FunctionChain{l2FunctionChain(mapOp(types.ScoreFieldName, "expr", columnArg(types.ScoreFieldName)))},
+		}, false)
+		require.NoError(t, err)
+	})
+
+	t.Run("ordinary request without function chains", func(t *testing.T) {
+		err := validateFunctionChainSearchRequest(&milvuspb.SearchRequest{}, false)
+		require.NoError(t, err)
+	})
+
+	t.Run("function score and function chains", func(t *testing.T) {
+		err := validateFunctionChainSearchRequest(&milvuspb.SearchRequest{
+			FunctionScore:  &schemapb.FunctionScore{},
+			FunctionChains: []*schemapb.FunctionChain{l2FunctionChain(mapOp(types.ScoreFieldName, "expr", columnArg(types.ScoreFieldName)))},
+		}, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "function_score and function_chains cannot be used together")
+	})
+
+	t.Run("hybrid function chains", func(t *testing.T) {
+		err := validateFunctionChainSearchRequest(&milvuspb.SearchRequest{
+			FunctionChains: []*schemapb.FunctionChain{l2FunctionChain(mapOp(types.ScoreFieldName, "expr", columnArg(types.ScoreFieldName)))},
+		}, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "function_chains is not supported for hybrid search yet")
+	})
+}
+
+func TestNewFunctionChainRerankMeta(t *testing.T) {
+	schema := newFunctionChainTestSchema()
+
+	t.Run("empty chains", func(t *testing.T) {
+		meta, err := newFunctionChainRerankMeta(nil, schema)
+		require.NoError(t, err)
+		assert.Nil(t, meta)
+	})
+
+	t.Run("score only chain", func(t *testing.T) {
+		chainPB := l2FunctionChain(mapOp(types.ScoreFieldName, "expr", columnArg(types.ScoreFieldName)))
+
+		meta, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{chainPB}, schema)
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+		assert.Empty(t, meta.GetInputFieldNames())
+		assert.Empty(t, meta.GetInputFieldIDs())
+		assert.Equal(t, chainPB, meta.chainPB)
+		assert.NotNil(t, meta.repr)
+	})
+
+	t.Run("schema field and score", func(t *testing.T) {
+		chainPB := l2FunctionChain(
+			mapOp("score1", "decay", columnArg("ts")),
+			mapOp(types.ScoreFieldName, "sum", columnArg("score1"), columnArg(types.ScoreFieldName)),
+		)
+
+		meta, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{chainPB}, schema)
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+		assert.Equal(t, []string{"ts"}, meta.GetInputFieldNames())
+		assert.Equal(t, []int64{101}, meta.GetInputFieldIDs())
+	})
+
+	t.Run("duplicate schema input is planned once", func(t *testing.T) {
+		chainPB := l2FunctionChain(
+			mapOp("score1", "expr", columnArg("ts"), columnArg(types.ScoreFieldName)),
+			mapOp(types.ScoreFieldName, "expr", columnArg("ts"), columnArg("score1")),
+		)
+
+		meta, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{chainPB}, schema)
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+		assert.Equal(t, []string{"ts"}, meta.GetInputFieldNames())
+		assert.Equal(t, []int64{101}, meta.GetInputFieldIDs())
+	})
+
+	t.Run("struct array sub field input is unsupported", func(t *testing.T) {
+		structSchema := newFunctionChainStructTestSchema()
+		chainPB := l2FunctionChain(mapOp("score1", "expr", columnArg("struct_scalar_array")))
+
+		_, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{chainPB}, structSchema)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported field type")
+		assert.Contains(t, err.Error(), "Array")
+	})
+
+	t.Run("nil schema", func(t *testing.T) {
+		_, _, err := getFunctionChainInputField(nil, "ts")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "neither a previous output nor a collection field")
+	})
+
+	t.Run("duplicate stage", func(t *testing.T) {
+		_, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{
+			l2FunctionChain(mapOp(types.ScoreFieldName, "expr", columnArg(types.ScoreFieldName))),
+			l2FunctionChain(mapOp(types.ScoreFieldName, "expr", columnArg(types.ScoreFieldName))),
+		}, schema)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "appears more than once")
+	})
+
+	t.Run("non l2 stage", func(t *testing.T) {
+		_, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{
+			{
+				Stage: schemapb.FunctionChainStage_FunctionChainStageL1Rerank,
+				Ops:   []*schemapb.FunctionChainOp{mapOp(types.ScoreFieldName, "expr", columnArg(types.ScoreFieldName))},
+			},
+		}, schema)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is not supported in search request")
+	})
+
+	t.Run("empty l2 chain", func(t *testing.T) {
+		_, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{
+			l2FunctionChain(),
+		}, schema)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "function chain[0] must contain at least one op")
+	})
+
+	t.Run("unknown field", func(t *testing.T) {
+		_, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{
+			l2FunctionChain(mapOp("score1", "decay", columnArg("unknown"))),
+		}, schema)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown")
+		assert.Contains(t, err.Error(), "neither a previous output nor a collection field")
+	})
+
+	t.Run("unsupported system input", func(t *testing.T) {
+		_, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{
+			l2FunctionChain(mapOp("score1", "expr", columnArg("$timestamp"))),
+		}, schema)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "system input \"$timestamp\" is not supported")
+	})
+
+	t.Run("unsupported system output", func(t *testing.T) {
+		_, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{
+			l2FunctionChain(mapOp(types.IDFieldName, "expr", columnArg(types.ScoreFieldName), columnArg("ts"))),
+		}, schema)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "system output \"$id\" is not writable")
+	})
+
+	t.Run("reserved temporary system output", func(t *testing.T) {
+		_, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{
+			l2FunctionChain(mapOp("$tmp_score", "expr", columnArg(types.ScoreFieldName), columnArg("ts"))),
+		}, schema)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "system output \"$tmp_score\" is not writable")
+	})
+
+	t.Run("score system output is writable", func(t *testing.T) {
+		_, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{
+			l2FunctionChain(mapOp(types.ScoreFieldName, "expr", columnArg(types.ScoreFieldName), columnArg("ts"))),
+		}, schema)
+		require.NoError(t, err)
+	})
+
+	t.Run("unsupported field type", func(t *testing.T) {
+		_, err := newFunctionChainRerankMeta([]*schemapb.FunctionChain{
+			l2FunctionChain(mapOp("score1", "expr", columnArg("vec"))),
+		}, schema)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported field type")
+		assert.Contains(t, err.Error(), "FloatVector")
+	})
+}
+
+func newFunctionChainTestSchema() *schemaInfo {
+	return newSchemaInfo(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "ts", DataType: schemapb.DataType_Int64},
+			{FieldID: 102, Name: "tag", DataType: schemapb.DataType_VarChar},
+			{FieldID: 103, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}},
+			{FieldID: 104, Name: "flag", DataType: schemapb.DataType_Bool},
+			{FieldID: 105, Name: "price", DataType: schemapb.DataType_Double},
+		},
+	})
+}
+
+func newFunctionChainStructTestSchema() *schemaInfo {
+	return newSchemaInfo(&schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+		},
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{
+			{
+				Name: "structArray",
+				Fields: []*schemapb.FieldSchema{
+					{FieldID: 201, Name: "struct_scalar_array", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int32},
+				},
+			},
+		},
+	})
+}
+
+func l2FunctionChain(ops ...*schemapb.FunctionChainOp) *schemapb.FunctionChain {
+	return &schemapb.FunctionChain{
+		Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+		Ops:   ops,
+	}
+}
+
+func l2LimitFunctionChain(limit int64) *schemapb.FunctionChain {
+	return l2FunctionChain(&schemapb.FunctionChainOp{
+		Op: types.OpTypeLimit,
+		Params: map[string]*schemapb.FunctionParamValue{
+			"limit": {Value: &schemapb.FunctionParamValue_Int64Value{Int64Value: limit}},
+		},
+	})
+}
+
+func mapOp(output string, exprName string, args ...*schemapb.FunctionChainExprArg) *schemapb.FunctionChainOp {
+	return &schemapb.FunctionChainOp{
+		Op:      types.OpTypeMap,
+		Outputs: []string{output},
+		Expr: &schemapb.FunctionChainExpr{
+			Name:   exprName,
+			Args:   args,
+			Params: map[string]*schemapb.FunctionParamValue{},
+		},
+	}
+}
+
+func columnArg(name string) *schemapb.FunctionChainExprArg {
+	return &schemapb.FunctionChainExprArg{Arg: &schemapb.FunctionChainExprArg_Column{Column: &schemapb.FunctionChainColumnArg{Name: name}}}
+}

--- a/internal/proxy/search_pipeline.go
+++ b/internal/proxy/search_pipeline.go
@@ -37,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy/search_agg"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/function/chain"
+	chaintypes "github.com/milvus-io/milvus/internal/util/function/chain/types"
 	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v3/log"
@@ -1179,6 +1180,12 @@ func buildChainFromMeta(
 	switch m := meta.(type) {
 	case *funcScoreRerankMeta:
 		return chain.BuildRerankChain(collSchema, m.funcScore, metrics, searchParams, alloc)
+	case *functionChainRerankMeta:
+		buildCtx := chaintypes.FunctionBuildContext{}
+		if searchParams != nil {
+			buildCtx.ModelExtraInfo = searchParams.ModelExtraInfo
+		}
+		return chain.FuncChainFromReprWithContext(m.repr, alloc, buildCtx)
 	case *legacyRerankMeta:
 		return chain.BuildRerankChainWithLegacy(collSchema, m.legacyParams, metrics, searchParams, alloc)
 	default:
@@ -1283,8 +1290,17 @@ func (op *rerankOperator) run(ctx context.Context, span trace.Span, inputs ...an
 		return nil, err
 	}
 
-	// Execute chain
-	resultDF, err := fc.ExecuteWithContext(ctx, dataframes...)
+	// Execute chain. Column pruning is an execution optimization only;
+	// final response projection is still handled by the end operator.
+	resultDF, err := fc.ExecuteWithOptions(ctx, chain.ExecuteOptions{
+		EnableColumnPruning: true,
+		Downstream: chain.DownstreamSpec{
+			RequiredColumns: neededFields,
+		},
+		SystemColumnPolicy: chain.SystemColumnPolicy{
+			KeepAllSystemColumns: true,
+		},
+	}, dataframes...)
 	// Release input dataframes
 	for _, df := range dataframes {
 		df.Release()

--- a/internal/proxy/search_pipeline_test.go
+++ b/internal/proxy/search_pipeline_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -36,6 +37,7 @@ import (
 	"github.com/milvus-io/milvus/internal/mocks"
 	"github.com/milvus-io/milvus/internal/proxy/search_agg"
 	"github.com/milvus-io/milvus/internal/proxy/shardclient"
+	"github.com/milvus-io/milvus/internal/util/function/chain"
 	"github.com/milvus-io/milvus/internal/util/function/highlight"
 	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
@@ -76,6 +78,15 @@ func (s *SearchPipelineSuite) SetupTest() {
 
 func (s *SearchPipelineSuite) TearDownTest() {
 	s.span.End()
+}
+
+func (s *SearchPipelineSuite) TestBuildChainFromFunctionChainRerankMeta() {
+	repr, err := chain.ProtoChainToRepr(l2LimitFunctionChain(10))
+	s.Require().NoError(err)
+
+	fc, err := buildChainFromMeta(&functionChainRerankMeta{repr: repr}, nil, nil, nil, memory.NewGoAllocator())
+	s.Require().NoError(err)
+	s.NotNil(fc)
 }
 
 func (s *SearchPipelineSuite) TestSerializeBucketKeyPreservesRequestedOrder() {
@@ -258,6 +269,57 @@ func (s *SearchPipelineSuite) TestRerankOp() {
 
 	_, err = op.run(context.Background(), s.span, reduced[0], []string{"IP"})
 	s.NoError(err)
+}
+
+func (s *SearchPipelineSuite) TestRerankOpWithFunctionChainMeta() {
+	schema := &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "ts", DataType: schemapb.DataType_Int64},
+		},
+	}
+	nq := int64(2)
+	topk := int64(10)
+	limit := int64(3)
+
+	reduceOp := searchReduceOperator{
+		context.Background(),
+		schema.Fields[0],
+		nq,
+		topk,
+		0,
+		1,
+		[]int64{1},
+		[]*planpb.QueryInfo{{}},
+		nil,
+		false,
+	}
+
+	data := genTestSearchResultData(nq, topk, schemapb.DataType_Int64, "ts", 101, false)
+	reduced, err := reduceOp.run(context.Background(), s.span, []*internalpb.SearchResults{data})
+	s.Require().NoError(err)
+
+	repr, err := chain.ProtoChainToRepr(l2LimitFunctionChain(limit))
+	s.Require().NoError(err)
+
+	op := rerankOperator{
+		nq:           nq,
+		topK:         topk,
+		roundDecimal: -1,
+		collSchema:   schema,
+		rerankMeta:   &functionChainRerankMeta{repr: repr},
+	}
+
+	outputs, err := op.run(context.Background(), s.span, reduced[0], []string{"IP"})
+	s.Require().NoError(err)
+	s.Require().Len(outputs, 1)
+
+	result := outputs[0].(*milvuspb.SearchResults).GetResults()
+	s.Equal([]int64{limit, limit}, result.GetTopks())
+	s.Equal(limit, result.GetTopK())
+	s.Len(result.GetScores(), int(nq*limit))
+	s.Len(result.GetIds().GetIntId().GetData(), int(nq*limit))
 }
 
 func (s *SearchPipelineSuite) TestElementBestCollapseOp_CollapsesElementLevelResultsByRowID() {

--- a/internal/proxy/task_search.go
+++ b/internal/proxy/task_search.go
@@ -495,6 +495,9 @@ func (t *searchTask) initAdvancedSearchRequest(ctx context.Context) error {
 	t.legacyGroupByWire = errGroupByField == nil && errGroupByFields != nil && t.request.GetSearchAggregation() == nil
 
 	var err error
+	if err := validateFunctionChainSearchRequest(t.request, true); err != nil {
+		return err
+	}
 	if t.request.FunctionScore != nil {
 		t.rerankMeta = newRerankMeta(t.schema.CollectionSchema, t.request.FunctionScore)
 	} else {
@@ -832,13 +835,22 @@ func (t *searchTask) initSearchRequest(ctx context.Context) error {
 
 	t.SearchType = searchType
 
-	if t.request.FunctionScore != nil {
+	if err := validateFunctionChainSearchRequest(t.request, false); err != nil {
+		return err
+	}
+	if len(t.request.GetFunctionChains()) > 0 {
+		meta, err := newFunctionChainRerankMeta(t.request.GetFunctionChains(), t.schema)
+		if err != nil {
+			return err
+		}
+		t.rerankMeta = meta
+	} else if t.request.FunctionScore != nil {
 		t.rerankMeta = newRerankMeta(t.schema.CollectionSchema, t.request.FunctionScore)
 	}
 
-	// order_by and function_score cannot be used together
+	// order_by and function rerank cannot be used together
 	if len(t.orderByFields) > 0 && t.rerankMeta != nil {
-		return merr.WrapErrParameterInvalidMsg("order_by and function_score cannot be used together: they specify conflicting sort criteria")
+		return merr.WrapErrParameterInvalidMsg("order_by and function rerank cannot be used together: they specify conflicting sort criteria")
 	}
 
 	analyzer, err := funcutil.GetAttrByKeyFromRepeatedKV(AnalyzerKey, t.request.GetSearchParams())
@@ -1092,8 +1104,8 @@ func (t *searchTask) tryGeneratePlan(params []*commonpb.KeyValuePair, dsl string
 
 	hasFilter := dsl != "" || len(exprTemplateValues) > 0
 	searchType := internalpb.SearchType_DEFAULT
-	// if function score is not nil, set searchType to DEFAULT, optimizations will be disabled in queryhook
-	if t.request.GetFunctionScore() == nil {
+	// if function rerank is set, keep searchType DEFAULT; optimizations will be disabled in queryhook
+	if !hasFunctionRerank(t.request) {
 		searchType = searchInfo.DetermineSearchType(hasFilter)
 	}
 

--- a/internal/proxy/task_search_test.go
+++ b/internal/proxy/task_search_test.go
@@ -354,6 +354,26 @@ func TestSearchTask_PostExecute(t *testing.T) {
 		assert.Equal(t, []int64{9, 8, 7, 6, 5, 4, 3, 2, 1, 0}, qt.result.Results.Ids.GetIntId().Data)
 	})
 
+	t.Run("Test search function chain limit rerank", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		collName := "test_collection_function_chain_rerank" + funcutil.GenRandomStr()
+		_, fieldNameId := createCollWithFields(t, collName, qc)
+		qt := getSearchTask(t, collName)
+		qt.request.FunctionChains = []*schemapb.FunctionChain{l2LimitFunctionChain(3)}
+		err = qt.PreExecute(ctx)
+		assert.NoError(t, err)
+
+		assert.NotNil(t, qt.resultBuf)
+		qt.resultBuf.Insert(genTestSearchResultData(1, 10, schemapb.DataType_Float, testFloatField, fieldNameId[testFloatField], false))
+		err := qt.PostExecute(context.TODO())
+		assert.NoError(t, err)
+		assert.Equal(t, []int64{3}, qt.result.Results.Topks)
+		assert.Equal(t, int64(3), qt.result.Results.TopK)
+		assert.Len(t, qt.result.Results.Scores, 3)
+		assert.Len(t, qt.result.Results.Ids.GetIntId().Data, 3)
+	})
+
 	getHybridSearchTaskWithRerank := func(t *testing.T, collName string, funcInput string, data [][]string) *searchTask {
 		subReqs := []*milvuspb.SubSearchRequest{}
 		for _, item := range data {
@@ -5430,6 +5450,141 @@ func TestSearchTask_InitSearchRequestWithStructArrayFields(t *testing.T) {
 	}
 }
 
+func TestSearchTask_FunctionChainRerankMeta(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	schema := &schemapb.CollectionSchema{
+		Name: "test_function_chain_rerank_collection",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "pk", DataType: schemapb.DataType_Int64, IsPrimaryKey: true},
+			{FieldID: 101, Name: "ts", DataType: schemapb.DataType_Int64},
+			{FieldID: 102, Name: "vec", DataType: schemapb.DataType_FloatVector, TypeParams: []*commonpb.KeyValuePair{{Key: common.DimKey, Value: "128"}}},
+		},
+	}
+	schemaInfo := newSchemaInfo(schema)
+
+	newRequest := func() *milvuspb.SearchRequest {
+		return &milvuspb.SearchRequest{
+			CollectionName: "test_function_chain_rerank_collection",
+			SearchParams: []*commonpb.KeyValuePair{
+				{Key: AnnsFieldKey, Value: "vec"},
+				{Key: TopKKey, Value: "10"},
+				{Key: common.MetricTypeKey, Value: metric.L2},
+				{Key: ParamsKey, Value: `{"nprobe": 10}`},
+			},
+			SearchInput: &milvuspb.SearchRequest_PlaceholderGroup{PlaceholderGroup: nil},
+		}
+	}
+	newFunctionChainRequest := func() *milvuspb.SearchRequest {
+		request := newRequest()
+		request.FunctionChains = []*schemapb.FunctionChain{
+			l2FunctionChain(mapOp("score1", "expr", columnArg("ts")), mapOp("$score", "expr", columnArg("score1"), columnArg("$score"))),
+		}
+		return request
+	}
+	newTask := func(request *milvuspb.SearchRequest) *searchTask {
+		translatedOutputFields, _, _, _, _, err := translateOutputFields(request.GetOutputFields(), schemaInfo, true)
+		require.NoError(t, err)
+		outputFieldIDs, err := getOutputFieldIDs(schemaInfo, translatedOutputFields)
+		require.NoError(t, err)
+
+		return &searchTask{
+			ctx:            ctx,
+			collectionName: request.GetCollectionName(),
+			SearchRequest: &internalpb.SearchRequest{
+				CollectionID:     1,
+				PartitionIDs:     []int64{1},
+				Dsl:              "",
+				PlaceholderGroup: nil,
+				DslType:          commonpb.DslType_BoolExprV1,
+				OutputFieldsId:   outputFieldIDs,
+			},
+			request:                request,
+			schema:                 schemaInfo,
+			translatedOutputFields: translatedOutputFields,
+			tr:                     timerecord.NewTimeRecorder("test"),
+			queryInfos:             []*planpb.QueryInfo{{}},
+		}
+	}
+
+	t.Run("ordinary search initializes function chain rerank meta", func(t *testing.T) {
+		task := newTask(newFunctionChainRequest())
+
+		require.NoError(t, task.initSearchRequest(ctx))
+		meta, ok := task.rerankMeta.(*functionChainRerankMeta)
+		require.True(t, ok)
+		assert.Equal(t, []string{"ts"}, meta.GetInputFieldNames())
+		assert.Equal(t, []int64{101}, meta.GetInputFieldIDs())
+	})
+
+	t.Run("ordinary search with function chains keeps default search type", func(t *testing.T) {
+		task := newTask(newFunctionChainRequest())
+
+		require.NoError(t, task.initSearchRequest(ctx))
+		assert.Equal(t, internalpb.SearchType_DEFAULT, task.SearchType)
+	})
+
+	t.Run("ordinary search rejects order by with function chains", func(t *testing.T) {
+		request := newFunctionChainRequest()
+		request.SearchParams = append(request.SearchParams, &commonpb.KeyValuePair{Key: OrderByFieldsKey, Value: "ts:asc"})
+		task := newTask(request)
+
+		err := task.initSearchRequest(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "order_by and function rerank cannot be used together")
+	})
+
+	t.Run("ordinary search no requery fetches function chain inputs in search plan", func(t *testing.T) {
+		task := newTask(newFunctionChainRequest())
+
+		require.NoError(t, task.initSearchRequest(ctx))
+		assert.False(t, task.needRequery)
+
+		plan := &planpb.PlanNode{}
+		require.NoError(t, proto.Unmarshal(task.SerializedExprPlan, plan))
+		assert.ElementsMatch(t, []int64{100, 101}, plan.OutputFieldIds)
+	})
+
+	t.Run("ordinary search requery path still fetches function chain inputs in search plan", func(t *testing.T) {
+		request := newFunctionChainRequest()
+		request.OutputFields = []string{"vec"}
+		task := newTask(request)
+
+		require.NoError(t, task.initSearchRequest(ctx))
+		assert.True(t, task.needRequery)
+
+		plan := &planpb.PlanNode{}
+		require.NoError(t, proto.Unmarshal(task.SerializedExprPlan, plan))
+		assert.Equal(t, []int64{101}, plan.OutputFieldIds)
+	})
+
+	t.Run("ordinary search keeps function score rerank meta", func(t *testing.T) {
+		request := newRequest()
+		request.FunctionScore = &schemapb.FunctionScore{
+			Functions: []*schemapb.FunctionSchema{
+				{
+					Name:             "decay",
+					Type:             schemapb.FunctionType_Rerank,
+					InputFieldNames:  []string{"ts"},
+					OutputFieldNames: []string{},
+					Params: []*commonpb.KeyValuePair{
+						{Key: "reranker", Value: "decay"},
+						{Key: "origin", Value: "100"},
+						{Key: "scale", Value: "10"},
+					},
+				},
+			},
+		}
+		task := newTask(request)
+
+		require.NoError(t, task.initSearchRequest(ctx))
+		meta, ok := task.rerankMeta.(*funcScoreRerankMeta)
+		require.True(t, ok)
+		assert.Equal(t, []string{"ts"}, meta.GetInputFieldNames())
+		assert.Equal(t, []int64{101}, meta.GetInputFieldIDs())
+	})
+}
+
 func TestSearchTask_AddHighlightTask(t *testing.T) {
 	paramtable.Init()
 
@@ -5738,7 +5893,7 @@ func TestSearchTask_OrderByValidation(t *testing.T) {
 
 		err := qt.initSearchRequest(ctx)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "order_by and function_score cannot be used together")
+		assert.Contains(t, err.Error(), "order_by and function rerank cannot be used together")
 	})
 
 	t.Run("regular search with invalid order_by direction should fail", func(t *testing.T) {

--- a/internal/querynodev2/tasks/boost_score.go
+++ b/internal/querynodev2/tasks/boost_score.go
@@ -137,7 +137,7 @@ func buildBoostScoreChain(
 	}
 
 	boostChain.Select(boostReduceColumns(df.ColumnNames())...)
-	boostChain.Sort(types.ScoreFieldName, true)
+	boostChain.Sort(types.ScoreFieldName, true, types.IDFieldName)
 	return boostChain, nil
 }
 
@@ -166,7 +166,7 @@ func appendFunctionScoreColumn(boostChain *chain.FuncChain, boostScoreColumns []
 		return boostScoreColumns[0], nil
 	}
 
-	functionCombineExpr, err := expr.NewScoreCombineExpr(functionMode, nil, expr.WithNullPolicy(expr.ScoreCombineNullSkip))
+	functionCombineExpr, err := expr.NewNumCombineExpr(functionMode, nil, expr.WithNullPolicy(expr.NumCombineNullSkip))
 	if err != nil {
 		return "", err
 	}
@@ -175,7 +175,7 @@ func appendFunctionScoreColumn(boostChain *chain.FuncChain, boostScoreColumns []
 }
 
 func appendFinalBoostScore(boostChain *chain.FuncChain, functionScoreCol string, boostMode string) error {
-	finalCombineExpr, err := expr.NewScoreCombineExpr(boostMode, nil, expr.WithNullPolicy(expr.ScoreCombineNullSkip))
+	finalCombineExpr, err := expr.NewNumCombineExpr(boostMode, nil, expr.WithNullPolicy(expr.NumCombineNullSkip))
 	if err != nil {
 		return err
 	}

--- a/internal/util/function/chain/chain.go
+++ b/internal/util/function/chain/chain.go
@@ -175,12 +175,23 @@ func (fc *FuncChain) Execute(input *DataFrame) (*DataFrame, error) {
 // ExecuteWithContext executes the chain with context for cancellation support.
 // Supports multiple inputs when the first operator is MergeOp.
 func (fc *FuncChain) ExecuteWithContext(ctx context.Context, inputs ...*DataFrame) (*DataFrame, error) {
+	return fc.ExecuteWithOptions(ctx, ExecuteOptions{}, inputs...)
+}
+
+// ExecuteWithOptions executes the chain with optional optimization metadata.
+// FuncChain remains the only executor; OptimizationPlan only guides execution.
+func (fc *FuncChain) ExecuteWithOptions(ctx context.Context, opts ExecuteOptions, inputs ...*DataFrame) (*DataFrame, error) {
 	if len(inputs) == 0 {
 		return nil, merr.WrapErrParameterMissingMsg("at least one input is required")
 	}
 
 	// Validate chain before execution
 	if err := fc.Validate(); err != nil {
+		return nil, err
+	}
+
+	plan, err := fc.buildOptimizationPlan(opts)
+	if err != nil {
 		return nil, err
 	}
 
@@ -198,6 +209,13 @@ func (fc *FuncChain) ExecuteWithContext(ctx context.Context, inputs ...*DataFram
 				return nil, merr.Wrapf(err, "%s failed", mergeOp.Name())
 			}
 			startIdx = 1
+			if plan != nil {
+				result, err = fc.pruneIfNeeded(result, plan.PruneAfter[0], plan.SystemColumnPolicy, inputs)
+				if err != nil {
+					fc.releaseIfOwned(result, inputs)
+					return nil, err
+				}
+			}
 		} else {
 			if len(inputs) > 1 {
 				return nil, merr.WrapErrParameterInvalidMsg("chain expects 1 input but got %d (first operator is not MergeOp)", len(inputs))
@@ -223,6 +241,15 @@ func (fc *FuncChain) ExecuteWithContext(ctx context.Context, inputs ...*DataFram
 		default:
 		}
 
+		if plan != nil {
+			var err error
+			result, err = fc.pruneIfNeeded(result, plan.PruneBefore[i], plan.SystemColumnPolicy, inputs)
+			if err != nil {
+				fc.releaseIfOwned(result, inputs)
+				return nil, err
+			}
+		}
+
 		newResult, err := op.Execute(funcCtx, result)
 		if err != nil {
 			fc.releaseIfOwned(result, inputs)
@@ -234,9 +261,29 @@ func (fc *FuncChain) ExecuteWithContext(ctx context.Context, inputs ...*DataFram
 			fc.releaseIfOwned(result, inputs)
 		}
 		result = newResult
+
+		if plan != nil {
+			result, err = fc.pruneIfNeeded(result, plan.PruneAfter[i], plan.SystemColumnPolicy, inputs)
+			if err != nil {
+				fc.releaseIfOwned(result, inputs)
+				return nil, err
+			}
+		}
 	}
 
 	return result, nil
+}
+
+func (fc *FuncChain) pruneIfNeeded(df *DataFrame, keep ColumnSet, policy SystemColumnPolicy, inputs []*DataFrame) (*DataFrame, error) {
+	pruned, err := PruneDataFrame(df, keep, policy)
+	if err != nil {
+		fc.releaseIfOwned(df, inputs)
+		return nil, err
+	}
+	if pruned != df {
+		fc.releaseIfOwned(df, inputs)
+	}
+	return pruned, nil
 }
 
 // releaseIfOwned releases df if it's not one of the original inputs.
@@ -283,9 +330,9 @@ func (fc *FuncChain) Select(columns ...string) *FuncChain {
 	return fc.Add(NewSelectOp(columns))
 }
 
-// Sort sorts the DataFrame by a column, breaking ties by $id ascending.
-func (fc *FuncChain) Sort(column string, desc bool) *FuncChain {
-	return fc.Add(NewSortOpWithTieBreak(column, desc, types.IDFieldName))
+// Sort sorts the DataFrame by a column, breaking ties by tieBreakCol ascending.
+func (fc *FuncChain) Sort(column string, desc bool, tieBreakCol string) *FuncChain {
+	return fc.Add(newSortOp(column, desc, tieBreakCol))
 }
 
 // Limit limits the number of rows in the DataFrame.

--- a/internal/util/function/chain/chain_bench_test.go
+++ b/internal/util/function/chain/chain_bench_test.go
@@ -475,7 +475,7 @@ func BenchmarkSortOp(b *testing.B) {
 			}
 			defer df.Release()
 
-			chain := NewFuncChainWithAllocator(nil).Sort("int64_field", bc.desc)
+			chain := NewFuncChainWithAllocator(nil).Sort("int64_field", bc.desc, types.IDFieldName)
 
 			b.ResetTimer()
 			b.ReportAllocs()
@@ -603,7 +603,7 @@ func BenchmarkChain_FilterSortLimit(b *testing.B) {
 			chain := NewFuncChainWithAllocator(nil).
 				SetStage(types.StageL2Rerank).
 				Filter(&BenchFilterFunction{threshold: bc.threshold}, []string{types.ScoreFieldName}).
-				Sort(types.ScoreFieldName, true).
+				Sort(types.ScoreFieldName, true, types.IDFieldName).
 				Limit(bc.limit)
 
 			b.ResetTimer()
@@ -687,7 +687,7 @@ func BenchmarkChain_FullPipeline(b *testing.B) {
 				SetStage(types.StageL2Rerank).
 				Map(&BenchScoreTransformFunction{multiplier: 2.0}, []string{types.ScoreFieldName}, []string{"transformed_score"}).
 				Filter(&BenchFilterFunction{threshold: 0.3}, []string{types.ScoreFieldName}).
-				Sort("transformed_score", true).
+				Sort("transformed_score", true, types.IDFieldName).
 				Limit(50).
 				Select(types.IDFieldName, "transformed_score", "int64_field", "float64_field")
 
@@ -724,7 +724,7 @@ func BenchmarkScale_VaryingNQ(b *testing.B) {
 			defer df.Release()
 
 			chain := NewFuncChainWithAllocator(nil).
-				Sort(types.ScoreFieldName, true).
+				Sort(types.ScoreFieldName, true, types.IDFieldName).
 				Limit(10)
 
 			b.ResetTimer()
@@ -756,7 +756,7 @@ func BenchmarkScale_VaryingTopK(b *testing.B) {
 			defer df.Release()
 
 			chain := NewFuncChainWithAllocator(nil).
-				Sort(types.ScoreFieldName, true).
+				Sort(types.ScoreFieldName, true, types.IDFieldName).
 				Limit(10)
 
 			b.ResetTimer()
@@ -791,7 +791,7 @@ func BenchmarkScale_VaryingColumns(b *testing.B) {
 			chain := NewFuncChainWithAllocator(nil).
 				SetStage(types.StageL2Rerank).
 				Filter(&BenchFilterFunction{threshold: 0.5}, []string{types.ScoreFieldName}).
-				Sort(types.ScoreFieldName, true).
+				Sort(types.ScoreFieldName, true, types.IDFieldName).
 				Limit(100)
 
 			b.ResetTimer()
@@ -836,7 +836,7 @@ func BenchmarkWithCheckedAllocator(b *testing.B) {
 			chain := NewFuncChainWithAllocator(pool).
 				SetStage(types.StageL2Rerank).
 				Filter(&BenchFilterFunction{threshold: 0.5}, []string{types.ScoreFieldName}).
-				Sort(types.ScoreFieldName, true).
+				Sort(types.ScoreFieldName, true, types.IDFieldName).
 				Limit(10)
 
 			b.ResetTimer()
@@ -881,7 +881,7 @@ func BenchmarkEndToEnd_Pipeline(b *testing.B) {
 			chain := NewFuncChainWithAllocator(nil).
 				SetStage(types.StageL2Rerank).
 				Filter(&BenchFilterFunction{threshold: 0.5}, []string{types.ScoreFieldName}).
-				Sort(types.ScoreFieldName, true).
+				Sort(types.ScoreFieldName, true, types.IDFieldName).
 				Limit(50).
 				Select(types.IDFieldName, types.ScoreFieldName, "int64_field")
 

--- a/internal/util/function/chain/chain_test.go
+++ b/internal/util/function/chain/chain_test.go
@@ -259,7 +259,7 @@ func (s *ChainTestSuite) TestSortOp_Ascending() {
 
 	result, err := NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
-		Sort("age", false). // ascending
+		Sort("age", false, types.IDFieldName). // ascending
 		Execute(df)
 	s.Require().NoError(err)
 	defer result.Release()
@@ -288,7 +288,7 @@ func (s *ChainTestSuite) TestSortOp_Descending() {
 
 	result, err := NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
-		Sort("age", true). // descending
+		Sort("age", true, types.IDFieldName). // descending
 		Execute(df)
 	s.Require().NoError(err)
 	defer result.Release()
@@ -309,7 +309,7 @@ func (s *ChainTestSuite) TestSortOp_NonExistentColumn() {
 
 	_, err := NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
-		Sort("nonexistent", false).
+		Sort("nonexistent", false, types.IDFieldName).
 		Execute(df)
 	s.Error(err)
 }
@@ -478,7 +478,7 @@ func (s *ChainTestSuite) TestChainedOperations() {
 		SetStage(types.StageL2Rerank).
 		Filter(&MockFilterFunction{threshold: 0.3}, []string{types.ScoreFieldName}).
 		Select(types.IDFieldName, types.ScoreFieldName, "age").
-		Sort(types.ScoreFieldName, true). // descending
+		Sort(types.ScoreFieldName, true, types.IDFieldName). // descending
 		Limit(3).
 		Execute(df)
 	s.Require().NoError(err)
@@ -535,7 +535,7 @@ func (s *ChainTestSuite) TestMemoryLeak_SortOperation() {
 
 		result, err := NewFuncChainWithAllocator(s.pool).
 			SetStage(types.StageL2Rerank).
-			Sort("age", true).
+			Sort("age", true, types.IDFieldName).
 			Execute(df)
 		s.Require().NoError(err)
 
@@ -706,7 +706,7 @@ func (s *ChainTestSuite) TestMemoryLeak_SortOpError_NonExistentColumn() {
 
 		_, err := NewFuncChainWithAllocator(s.pool).
 			SetStage(types.StageL2Rerank).
-			Sort("non_existent_column", true).
+			Sort("non_existent_column", true, types.IDFieldName).
 			Execute(df)
 		s.Require().Error(err)
 
@@ -843,11 +843,11 @@ func (s *ChainTestSuite) TestOperatorStrings() {
 	s.Contains(selectOp.String(), "Select")
 
 	// SortOp
-	sortOpAsc := NewSortOp("col", false)
-	s.Equal("Sort(col ASC)", sortOpAsc.String())
+	sortOpAsc := newSortOp("col", false, types.IDFieldName)
+	s.Equal("Sort(col ASC, $id ASC)", sortOpAsc.String())
 
-	sortOpDesc := NewSortOp("col", true)
-	s.Equal("Sort(col DESC)", sortOpDesc.String())
+	sortOpDesc := newSortOp("col", true, types.IDFieldName)
+	s.Equal("Sort(col DESC, $id ASC)", sortOpDesc.String())
 
 	// LimitOp
 	limitOp := NewLimitOp(10, 0)
@@ -927,7 +927,7 @@ func (s *ChainTestSuite) TestValidate_ValidChain() {
 	fc := NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
 		Select(types.IDFieldName, "age").
-		Sort("age", false).
+		Sort("age", false, types.IDFieldName).
 		Limit(10)
 
 	err := fc.Validate()
@@ -1194,7 +1194,7 @@ func (s *ChainTestSuite) TestExecuteWithContext_Cancellation() {
 	_, err := NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
 		Select(types.IDFieldName, "age").
-		Sort("age", false).
+		Sort("age", false, types.IDFieldName).
 		Limit(10).
 		ExecuteWithContext(goCtx, df)
 
@@ -1211,7 +1211,7 @@ func (s *ChainTestSuite) TestExecuteWithContext_Success() {
 	result, err := NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
 		Select(types.IDFieldName, "age").
-		Sort("age", false).
+		Sort("age", false, types.IDFieldName).
 		Limit(2).
 		ExecuteWithContext(goCtx, df)
 
@@ -1230,7 +1230,7 @@ func (s *ChainTestSuite) TestFunctionRegistry() {
 	s.NotNil(registry)
 
 	// Test Register and Has
-	factory := func(params map[string]interface{}) (types.FunctionExpr, error) {
+	factory := func(_ types.FunctionBuildContext, _ types.FunctionConfig) (types.FunctionExpr, error) {
 		return &MockAddColumnFunction{value: 1}, nil
 	}
 	err := registry.Register("test_func", factory)
@@ -1262,11 +1262,11 @@ func (s *ChainTestSuite) TestFunctionRegistry() {
 	s.False(ok)
 
 	// Test Create
-	expr, err := registry.Create("test_func", nil)
+	expr, err := registry.Create(types.FunctionBuildContext{}, types.FunctionConfig{Name: "test_func"})
 	s.NoError(err)
 	s.NotNil(expr)
 
-	_, err = registry.Create("nonexistent", nil)
+	_, err = registry.Create(types.FunctionBuildContext{}, types.FunctionConfig{Name: "nonexistent"})
 	s.Error(err)
 
 	// Test Names
@@ -1284,7 +1284,7 @@ func (s *ChainTestSuite) TestGlobalFunctionRegistry() {
 	funcName := "test_global_func_" + s.T().Name()
 
 	// Register a test function first
-	err := types.RegisterFunction(funcName, func(params map[string]interface{}) (types.FunctionExpr, error) {
+	err := types.RegisterFunction(funcName, func(_ types.FunctionBuildContext, _ types.FunctionConfig) (types.FunctionExpr, error) {
 		return &MockAddColumnFunction{value: 42}, nil
 	})
 	s.NoError(err)
@@ -1306,15 +1306,15 @@ func (s *ChainTestSuite) TestGlobalFunctionRegistry() {
 	s.False(ok)
 
 	// Test CreateFunction
-	expr, err := types.CreateFunction(funcName, nil)
+	expr, err := types.CreateFunction(types.FunctionBuildContext{}, types.FunctionConfig{Name: funcName})
 	s.NoError(err)
 	s.NotNil(expr)
 
-	_, err = types.CreateFunction("nonexistent", nil)
+	_, err = types.CreateFunction(types.FunctionBuildContext{}, types.FunctionConfig{Name: "nonexistent"})
 	s.Error(err)
 
 	// Test duplicate registration returns error
-	err = types.RegisterFunction(funcName, func(params map[string]interface{}) (types.FunctionExpr, error) {
+	err = types.RegisterFunction(funcName, func(_ types.FunctionBuildContext, _ types.FunctionConfig) (types.FunctionExpr, error) {
 		return nil, nil
 	})
 	s.Error(err)
@@ -1322,7 +1322,7 @@ func (s *ChainTestSuite) TestGlobalFunctionRegistry() {
 
 	// Test MustRegisterFunction panics on duplicate
 	s.Panics(func() {
-		types.MustRegisterFunction(funcName, func(params map[string]interface{}) (types.FunctionExpr, error) {
+		types.MustRegisterFunction(funcName, func(_ types.FunctionBuildContext, _ types.FunctionConfig) (types.FunctionExpr, error) {
 			return nil, nil
 		})
 	})
@@ -1354,9 +1354,13 @@ func (s *ChainTestSuite) TestOperatorInputsOutputs() {
 	s.Equal([]string{"a", "b", "c"}, selectOp.Outputs())
 
 	// SortOp
-	sortOp := NewSortOp("sort_col", true)
-	s.Equal([]string{"sort_col"}, sortOp.Inputs())
+	sortOp := newSortOp("sort_col", true, types.IDFieldName)
+	s.Equal([]string{"sort_col", types.IDFieldName}, sortOp.Inputs())
 	s.Empty(sortOp.Outputs())
+
+	sortOpWithTieBreak := newSortOp("sort_col", true, "tie_col")
+	s.Equal([]string{"sort_col", "tie_col"}, sortOpWithTieBreak.Inputs())
+	s.Empty(sortOpWithTieBreak.Outputs())
 
 	// LimitOp
 	limitOp := NewLimitOp(10, 5)
@@ -1546,7 +1550,7 @@ func (s *ChainTestSuite) TestSortOp_FloatColumn() {
 	// Sort by score descending
 	result, err := NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
-		Sort(types.ScoreFieldName, true).
+		Sort(types.ScoreFieldName, true, types.IDFieldName).
 		Execute(df)
 	s.Require().NoError(err)
 	defer result.Release()
@@ -1592,7 +1596,7 @@ func (s *ChainTestSuite) TestSortOp_StringColumn() {
 	// Sort by name ascending
 	result, err := NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
-		Sort("name", false).
+		Sort("name", false, types.IDFieldName).
 		Execute(df)
 	s.Require().NoError(err)
 	defer result.Release()
@@ -1653,7 +1657,7 @@ func (s *ChainTestSuite) TestSortOp_AllColumnsReordered() {
 	// Sort by age ascending
 	result, err := NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
-		Sort("age", false).
+		Sort("age", false, types.IDFieldName).
 		Execute(df)
 	s.Require().NoError(err)
 	defer result.Release()
@@ -1740,7 +1744,7 @@ func (s *ChainTestSuite) TestSortOp_MultipleChunksAllColumnsReordered() {
 	// Sort by value ascending
 	result, err := NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
-		Sort("value", false).
+		Sort("value", false, types.IDFieldName).
 		Execute(df)
 	s.Require().NoError(err)
 	defer result.Release()
@@ -1790,7 +1794,7 @@ func (s *ChainTestSuite) TestFuncChain_StringWithOperators() {
 		SetName("test-chain").
 		Select("a", "b").
 		Filter(&MockFilterFunction{threshold: 0.5}, []string{"score"}).
-		Sort("s", true).
+		Sort("s", true, types.IDFieldName).
 		Limit(10)
 
 	str := fc.String()

--- a/internal/util/function/chain/expr/base_expr.go
+++ b/internal/util/function/chain/expr/base_expr.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
@@ -58,115 +59,16 @@ func (b *BaseExpr) IsRunnable(stage string) bool {
 	return b.supportStages.Contain(stage)
 }
 
-// =============================================================================
-// Parameter Parsing Functions
-// =============================================================================
-
-// GetStringParam extracts a string parameter from the params map.
-// funcName is used for error message prefixing.
-func GetStringParam(params map[string]interface{}, funcName, key string, required bool) (string, error) {
-	val, ok := params[key]
-	if !ok {
-		if required {
-			return "", merr.WrapErrParameterInvalidMsg("%s: missing required parameter %q", funcName, key)
+func (b *BaseExpr) ValidateArgs(args []*schemapb.FunctionChainExprArg) error {
+	for i, arg := range args {
+		if arg == nil {
+			return merr.WrapErrParameterInvalidMsg("%s: expr arg[%d] is nil", b.name, i)
 		}
-		return "", nil
-	}
-
-	strVal, ok := val.(string)
-	if !ok {
-		return "", merr.WrapErrParameterInvalidMsg("%s: parameter %q must be a string, got %T", funcName, key, val)
-	}
-	return strVal, nil
-}
-
-// GetFloat64Param extracts a float64 parameter from the params map.
-// funcName is used for error message prefixing.
-func GetFloat64Param(params map[string]interface{}, funcName, key string, required bool, defaultVal float64) (float64, error) {
-	val, ok := params[key]
-	if !ok {
-		if required {
-			return 0, merr.WrapErrParameterInvalidMsg("%s: missing required parameter %q", funcName, key)
+		if _, ok := arg.GetArg().(*schemapb.FunctionChainExprArg_Literal); ok {
+			return merr.WrapErrParameterInvalidMsg("%s: literal expr arg[%d] is not supported", b.name, i)
 		}
-		return defaultVal, nil
 	}
-
-	switch v := val.(type) {
-	case float64:
-		return v, nil
-	case float32:
-		return float64(v), nil
-	case int:
-		return float64(v), nil
-	case int64:
-		return float64(v), nil
-	case int32:
-		return float64(v), nil
-	default:
-		return 0, merr.WrapErrParameterInvalidMsg("%s: parameter %q must be a number, got %T", funcName, key, val)
-	}
-}
-
-// ParseStringSliceParam extracts a string slice parameter from the params map.
-// funcName is used for error message prefixing.
-func ParseStringSliceParam(params map[string]interface{}, funcName, key string) ([]string, error) {
-	val, ok := params[key]
-	if !ok {
-		return nil, merr.WrapErrParameterInvalidMsg("%s: missing required parameter %q", funcName, key)
-	}
-
-	switch v := val.(type) {
-	case []string:
-		return v, nil
-	case []interface{}:
-		result := make([]string, len(v))
-		for i, item := range v {
-			str, ok := item.(string)
-			if !ok {
-				return nil, merr.WrapErrParameterInvalidMsg("%s: parameter %q[%d] must be a string, got %T", funcName, key, i, item)
-			}
-			result[i] = str
-		}
-		return result, nil
-	default:
-		return nil, merr.WrapErrParameterInvalidMsg("%s: parameter %q must be a string array, got %T", funcName, key, val)
-	}
-}
-
-// ParseFloat64SliceParam extracts a float64 slice parameter from the params map.
-// funcName is used for error message prefixing.
-// Returns nil if the parameter is not present (optional parameter).
-func ParseFloat64SliceParam(params map[string]interface{}, funcName, key string) ([]float64, error) {
-	val, ok := params[key]
-	if !ok {
-		return nil, nil // optional, return nil if not present
-	}
-
-	switch v := val.(type) {
-	case []float64:
-		return v, nil
-	case []interface{}:
-		result := make([]float64, len(v))
-		for i, item := range v {
-			switch num := item.(type) {
-			case float64:
-				result[i] = num
-			case float32:
-				result[i] = float64(num)
-			case int:
-				result[i] = float64(num)
-			case int64:
-				result[i] = float64(num)
-			case int32:
-				result[i] = float64(num)
-			default:
-				return nil, merr.WrapErrParameterInvalidMsg("%s: parameter %q[%d] must be a number, got %T", funcName, key, i, item)
-			}
-		}
-		return result, nil
-	default:
-		return nil, merr.WrapErrParameterInvalidMsg("%s: parameter %q must be a number array, got %T", funcName, key, val)
-	}
+	return nil
 }
 
 // =============================================================================
@@ -190,6 +92,6 @@ func GetNumericValue(arr arrow.Array, idx int) (float64, error) {
 	case *array.Float64:
 		return a.Value(idx), nil
 	default:
-		return 0, merr.WrapErrServiceInternalMsg("unsupported input column type %T, expected numeric type", arr)
+		return 0, merr.WrapErrParameterInvalidMsg("unsupported input column type %T, expected numeric type", arr)
 	}
 }

--- a/internal/util/function/chain/expr/base_expr_test.go
+++ b/internal/util/function/chain/expr/base_expr_test.go
@@ -24,6 +24,9 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/array"
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function/chain/types"
 )
 
 type BaseExprTestSuite struct {
@@ -72,178 +75,131 @@ func (s *BaseExprTestSuite) TestBaseExprIsRunnableEmptyStages() {
 }
 
 // =============================================================================
-// GetStringParam Tests
+// ParamReader Tests
 // =============================================================================
 
-func (s *BaseExprTestSuite) TestGetStringParamSuccess() {
-	params := map[string]interface{}{"key": "value"}
-	val, err := GetStringParam(params, "func", "key", true)
+func (s *BaseExprTestSuite) TestParamReaderString() {
+	r := types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": stringParam("value")})
+	val, err := r.String("key", true)
 	s.Require().NoError(err)
 	s.Equal("value", val)
-}
 
-func (s *BaseExprTestSuite) TestGetStringParamMissingRequired() {
-	params := map[string]interface{}{}
-	_, err := GetStringParam(params, "func", "key", true)
-	s.Error(err)
-	s.Contains(err.Error(), "missing required parameter")
-}
+	_, err = r.String("missing", true)
+	s.ErrorContains(err, "missing required parameter")
 
-func (s *BaseExprTestSuite) TestGetStringParamMissingOptional() {
-	params := map[string]interface{}{}
-	val, err := GetStringParam(params, "func", "key", false)
+	val, err = r.String("missing", false)
 	s.Require().NoError(err)
 	s.Equal("", val)
+
+	_, err = types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": intParam(1)}).String("key", true)
+	s.ErrorContains(err, "must be a string")
 }
 
-func (s *BaseExprTestSuite) TestGetStringParamWrongType() {
-	params := map[string]interface{}{"key": 123}
-	_, err := GetStringParam(params, "func", "key", true)
-	s.Error(err)
-	s.Contains(err.Error(), "must be a string")
-}
-
-// =============================================================================
-// GetFloat64Param Tests
-// =============================================================================
-
-func (s *BaseExprTestSuite) TestGetFloat64ParamFloat64() {
-	params := map[string]interface{}{"key": float64(3.14)}
-	val, err := GetFloat64Param(params, "func", "key", true, 0)
+func (s *BaseExprTestSuite) TestParamReaderFloat64() {
+	r := types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{
+		"double": doubleParam(3.14),
+		"int":    intParam(42),
+	})
+	val, err := r.Float64("double", true, 0)
 	s.Require().NoError(err)
 	s.InDelta(3.14, val, 1e-9)
-}
 
-func (s *BaseExprTestSuite) TestGetFloat64ParamFloat32() {
-	params := map[string]interface{}{"key": float32(2.5)}
-	val, err := GetFloat64Param(params, "func", "key", true, 0)
-	s.Require().NoError(err)
-	s.InDelta(2.5, val, 1e-5)
-}
-
-func (s *BaseExprTestSuite) TestGetFloat64ParamInt() {
-	params := map[string]interface{}{"key": 42}
-	val, err := GetFloat64Param(params, "func", "key", true, 0)
+	val, err = r.Float64("int", true, 0)
 	s.Require().NoError(err)
 	s.InDelta(42.0, val, 1e-9)
-}
 
-func (s *BaseExprTestSuite) TestGetFloat64ParamInt64() {
-	params := map[string]interface{}{"key": int64(100)}
-	val, err := GetFloat64Param(params, "func", "key", true, 0)
-	s.Require().NoError(err)
-	s.InDelta(100.0, val, 1e-9)
-}
-
-func (s *BaseExprTestSuite) TestGetFloat64ParamInt32() {
-	params := map[string]interface{}{"key": int32(50)}
-	val, err := GetFloat64Param(params, "func", "key", true, 0)
-	s.Require().NoError(err)
-	s.InDelta(50.0, val, 1e-9)
-}
-
-func (s *BaseExprTestSuite) TestGetFloat64ParamMissingRequired() {
-	params := map[string]interface{}{}
-	_, err := GetFloat64Param(params, "func", "key", true, 0)
-	s.Error(err)
-	s.Contains(err.Error(), "missing required parameter")
-}
-
-func (s *BaseExprTestSuite) TestGetFloat64ParamMissingOptionalDefault() {
-	params := map[string]interface{}{}
-	val, err := GetFloat64Param(params, "func", "key", false, 99.9)
+	val, err = r.Float64("missing", false, 99.9)
 	s.Require().NoError(err)
 	s.InDelta(99.9, val, 1e-9)
+
+	_, err = types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": stringParam("bad")}).Float64("key", true, 0)
+	s.ErrorContains(err, "must be a number")
 }
 
-func (s *BaseExprTestSuite) TestGetFloat64ParamWrongType() {
-	params := map[string]interface{}{"key": "not_a_number"}
-	_, err := GetFloat64Param(params, "func", "key", true, 0)
-	s.Error(err)
-	s.Contains(err.Error(), "must be a number")
-}
-
-// =============================================================================
-// ParseStringSliceParam Tests
-// =============================================================================
-
-func (s *BaseExprTestSuite) TestParseStringSliceParamStringSlice() {
-	params := map[string]interface{}{"key": []string{"a", "b", "c"}}
-	val, err := ParseStringSliceParam(params, "func", "key")
+func (s *BaseExprTestSuite) TestParamReaderInt64() {
+	r := types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{
+		"int":    intParam(42),
+		"double": doubleParam(42.0),
+	})
+	val, err := r.Int64("int", true, 0)
 	s.Require().NoError(err)
-	s.Equal([]string{"a", "b", "c"}, val)
-}
+	s.Equal(int64(42), val)
 
-func (s *BaseExprTestSuite) TestParseStringSliceParamInterfaceSlice() {
-	params := map[string]interface{}{"key": []interface{}{"x", "y"}}
-	val, err := ParseStringSliceParam(params, "func", "key")
+	val, err = r.Int64("double", true, 0)
 	s.Require().NoError(err)
-	s.Equal([]string{"x", "y"}, val)
+	s.Equal(int64(42), val)
+
+	_, err = types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": doubleParam(1.5)}).Int64("key", true, 0)
+	s.ErrorContains(err, "must be an integer")
 }
 
-func (s *BaseExprTestSuite) TestParseStringSliceParamMissing() {
-	params := map[string]interface{}{}
-	_, err := ParseStringSliceParam(params, "func", "key")
-	s.Error(err)
-	s.Contains(err.Error(), "missing required parameter")
-}
-
-func (s *BaseExprTestSuite) TestParseStringSliceParamWrongType() {
-	params := map[string]interface{}{"key": "not_an_array"}
-	_, err := ParseStringSliceParam(params, "func", "key")
-	s.Error(err)
-	s.Contains(err.Error(), "must be a string array")
-}
-
-func (s *BaseExprTestSuite) TestParseStringSliceParamNonStringElement() {
-	params := map[string]interface{}{"key": []interface{}{"ok", 123}}
-	_, err := ParseStringSliceParam(params, "func", "key")
-	s.Error(err)
-	s.Contains(err.Error(), "must be a string")
-}
-
-// =============================================================================
-// ParseFloat64SliceParam Tests
-// =============================================================================
-
-func (s *BaseExprTestSuite) TestParseFloat64SliceParamFloat64Slice() {
-	params := map[string]interface{}{"key": []float64{1.1, 2.2, 3.3}}
-	val, err := ParseFloat64SliceParam(params, "func", "key")
+func (s *BaseExprTestSuite) TestParamReaderBool() {
+	r := types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": boolParam(true)})
+	val, err := r.Bool("key", true, false)
 	s.Require().NoError(err)
-	s.Equal([]float64{1.1, 2.2, 3.3}, val)
-}
+	s.True(val)
 
-func (s *BaseExprTestSuite) TestParseFloat64SliceParamInterfaceSlice() {
-	params := map[string]interface{}{"key": []interface{}{float64(1.0), float32(2.0), 3, int64(4), int32(5)}}
-	val, err := ParseFloat64SliceParam(params, "func", "key")
+	val, err = r.Bool("missing", false, true)
 	s.Require().NoError(err)
-	s.Equal(5, len(val))
-	s.InDelta(1.0, val[0], 1e-9)
-	s.InDelta(2.0, val[1], 1e-5)
-	s.InDelta(3.0, val[2], 1e-9)
-	s.InDelta(4.0, val[3], 1e-9)
-	s.InDelta(5.0, val[4], 1e-9)
+	s.True(val)
+
+	_, err = types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": stringParam("bad")}).Bool("key", true, false)
+	s.ErrorContains(err, "must be a bool")
 }
 
-func (s *BaseExprTestSuite) TestParseFloat64SliceParamMissingOptional() {
-	params := map[string]interface{}{}
-	val, err := ParseFloat64SliceParam(params, "func", "key")
+func (s *BaseExprTestSuite) TestParamReaderStringSlice() {
+	r := types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": arrayParam(stringParam("a"), stringParam("b"))})
+	val, err := r.StringSlice("key", true)
+	s.Require().NoError(err)
+	s.Equal([]string{"a", "b"}, val)
+
+	_, err = r.StringSlice("missing", true)
+	s.ErrorContains(err, "missing required parameter")
+
+	_, err = types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": stringParam("bad")}).StringSlice("key", true)
+	s.ErrorContains(err, "must be a string array")
+
+	_, err = types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": arrayParam(stringParam("ok"), intParam(1))}).StringSlice("key", true)
+	s.ErrorContains(err, "must be a string")
+}
+
+func (s *BaseExprTestSuite) TestParamReaderFloat64Slice() {
+	r := types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": arrayParam(doubleParam(1.1), intParam(2))})
+	val, err := r.Float64Slice("key", true)
+	s.Require().NoError(err)
+	s.Equal([]float64{1.1, 2.0}, val)
+
+	val, err = r.Float64Slice("missing", false)
 	s.Require().NoError(err)
 	s.Nil(val)
+
+	_, err = types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": stringParam("bad")}).Float64Slice("key", true)
+	s.ErrorContains(err, "must be a number array")
+
+	_, err = types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"key": arrayParam(doubleParam(1.0), stringParam("bad"))}).Float64Slice("key", true)
+	s.ErrorContains(err, "must be a number")
 }
 
-func (s *BaseExprTestSuite) TestParseFloat64SliceParamWrongType() {
-	params := map[string]interface{}{"key": "not_an_array"}
-	_, err := ParseFloat64SliceParam(params, "func", "key")
-	s.Error(err)
-	s.Contains(err.Error(), "must be a number array")
-}
+func (s *BaseExprTestSuite) TestParamReaderKeyValuePairs() {
+	r := types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{
+		"s": stringParam("value"),
+		"i": intParam(8),
+		"f": doubleParam(0.5),
+		"b": boolParam(true),
+	})
+	kvs, err := r.KeyValuePairs()
+	s.Require().NoError(err)
+	values := map[string]string{}
+	for _, kv := range kvs {
+		values[kv.Key] = kv.Value
+	}
+	s.Equal("value", values["s"])
+	s.Equal("8", values["i"])
+	s.Equal("0.5", values["f"])
+	s.Equal("true", values["b"])
 
-func (s *BaseExprTestSuite) TestParseFloat64SliceParamNonNumericElement() {
-	params := map[string]interface{}{"key": []interface{}{1.0, "bad"}}
-	_, err := ParseFloat64SliceParam(params, "func", "key")
-	s.Error(err)
-	s.Contains(err.Error(), "must be a number")
+	_, err = types.NewParamReader("func", map[string]*schemapb.FunctionParamValue{"bad": arrayParam(stringParam("x"))}).KeyValuePairs()
+	s.ErrorContains(err, "must be scalar")
 }
 
 // =============================================================================

--- a/internal/util/function/chain/expr/decay_expr.go
+++ b/internal/util/function/chain/expr/decay_expr.go
@@ -55,7 +55,7 @@ type decayReScorer func(origin, scale, decay, offset, distance float64) float64
 
 // DecayExpr implements FunctionExpr for decay scoring.
 // It takes a numeric input column and outputs the pure decay factor (0~1).
-// The combination with $score is handled by a subsequent ScoreCombineExpr node in the chain.
+// The combination with $score is handled by a subsequent NumCombineExpr node in the chain.
 // Column mapping is handled by MapOp.
 //
 // Expected inputs (passed from MapOp):
@@ -161,35 +161,31 @@ func NewDecayExpr(function string, origin, scale, offset, decay float64) (*Decay
 // NewDecayExprFromParams creates a DecayExpr from a parameter map.
 // This is the factory function for the function registry.
 // All parameter parsing is handled here, keeping it close to the expr definition.
-func NewDecayExprFromParams(params map[string]interface{}) (types.FunctionExpr, error) {
+func NewDecayExprFromParams(_ types.FunctionBuildContext, cfg types.FunctionConfig) (types.FunctionExpr, error) {
 	const funcName = "decay"
+	reader := types.NewParamReader(funcName, cfg.Params)
 
-	// Extract function (required)
-	function, err := GetStringParam(params, funcName, FunctionKey, true)
+	function, err := reader.String(FunctionKey, true)
 	if err != nil {
 		return nil, err
 	}
 
-	// Extract origin (required)
-	origin, err := GetFloat64Param(params, funcName, OriginKey, true, 0)
+	origin, err := reader.Float64(OriginKey, true, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	// Extract scale (required)
-	scale, err := GetFloat64Param(params, funcName, ScaleKey, true, 0)
+	scale, err := reader.Float64(ScaleKey, true, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	// Extract offset (optional, default 0)
-	offset, err := GetFloat64Param(params, funcName, OffsetKey, false, 0)
+	offset, err := reader.Float64(OffsetKey, false, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	// Extract decay (optional, default 0.5)
-	decayVal, err := GetFloat64Param(params, funcName, DecayKey, false, 0.5)
+	decayVal, err := reader.Float64(DecayKey, false, 0.5)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/function/chain/expr/decay_expr_integration_test.go
+++ b/internal/util/function/chain/expr/decay_expr_integration_test.go
@@ -153,16 +153,16 @@ func (s *DecayExprIntegrationTestSuite) TestIntegration_ChainWithDecay() {
 	decayExpr, err := expr.NewDecayExpr(expr.GaussFunction, 100, 50, 0, 0.5)
 	s.Require().NoError(err)
 
-	combineExpr, err := expr.NewScoreCombineExpr(expr.ModeMultiply, nil)
+	combineExpr, err := expr.NewNumCombineExpr(expr.ModeMultiply, nil)
 	s.Require().NoError(err)
 
 	// DecayExpr outputs pure decay factor into "_decay_score",
-	// then ScoreCombineExpr multiplies $score with _decay_score.
+	// then NumCombineExpr multiplies $score with _decay_score.
 	result, err := chain.NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
 		Map(decayExpr, []string{"distance"}, []string{"_decay_score"}).
 		Map(combineExpr, []string{types.ScoreFieldName, "_decay_score"}, []string{types.ScoreFieldName}).
-		Sort(types.ScoreFieldName, true). // descending
+		Sort(types.ScoreFieldName, true, types.IDFieldName). // descending
 		Limit(3).
 		Execute(df)
 	s.Require().NoError(err)
@@ -208,7 +208,7 @@ func (s *DecayExprIntegrationTestSuite) TestIntegration_NullDecayFactorTreatedAs
 
 	decayExpr, err := expr.NewDecayExpr(expr.GaussFunction, 100, 50, 0, 0.5)
 	s.Require().NoError(err)
-	combineExpr, err := expr.NewScoreCombineExpr(expr.ModeMultiply, nil, expr.WithNullPolicy(expr.ScoreCombineNullAsZero))
+	combineExpr, err := expr.NewNumCombineExpr(expr.ModeMultiply, nil, expr.WithNullPolicy(expr.NumCombineNullAsZero))
 	s.Require().NoError(err)
 
 	result, err := chain.NewFuncChainWithAllocator(s.pool).
@@ -226,39 +226,45 @@ func (s *DecayExprIntegrationTestSuite) TestIntegration_NullDecayFactorTreatedAs
 	s.InDelta(0.0, scores.Value(1), 0.001)
 }
 
-func (s *DecayExprIntegrationTestSuite) TestIntegration_ParseFromJSON() {
+func (s *DecayExprIntegrationTestSuite) TestIntegration_ParseFromProto() {
 	// DecayExpr only takes distance input, outputs decay factor into _decay_score.
-	// ScoreCombineExpr then multiplies $score with _decay_score.
-	jsonRepr := `{
-		"name": "decay-test",
-		"stage": "L2_rerank",
-		"operators": [{
-			"type": "map",
-			"inputs": ["distance"],
-			"outputs": ["_decay_score"],
-			"function": {
-				"name": "decay",
-				"params": {
-					"function": "gauss",
-					"origin": 100,
-					"scale": 50,
-					"decay": 0.5
-				}
-			}
-		}, {
-			"type": "map",
-			"inputs": ["$score", "_decay_score"],
-			"outputs": ["$score"],
-			"function": {
-				"name": "score_combine",
-				"params": {
-					"mode": "multiply"
-				}
-			}
-		}]
-	}`
-
-	fc, err := chain.ParseFuncChainRepr(jsonRepr, s.pool)
+	// NumCombineExpr then multiplies $score with _decay_score.
+	fc, err := chain.ParseFuncChainProto(&schemapb.FunctionChain{
+		Name:  "decay-test",
+		Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+		Ops: []*schemapb.FunctionChainOp{
+			{
+				Op:      types.OpTypeMap,
+				Outputs: []string{"_decay_score"},
+				Expr: &schemapb.FunctionChainExpr{
+					Name: "decay",
+					Args: []*schemapb.FunctionChainExprArg{
+						columnArg("distance"),
+					},
+					Params: map[string]*schemapb.FunctionParamValue{
+						types.DecayParamFunction: stringParam(types.DecayFuncGauss),
+						types.DecayParamOrigin:   intParam(100),
+						types.DecayParamScale:    intParam(50),
+						types.DecayParamDecay:    doubleParam(0.5),
+					},
+				},
+			},
+			{
+				Op:      types.OpTypeMap,
+				Outputs: []string{types.ScoreFieldName},
+				Expr: &schemapb.FunctionChainExpr{
+					Name: "num_combine",
+					Args: []*schemapb.FunctionChainExprArg{
+						columnArg(types.ScoreFieldName),
+						columnArg("_decay_score"),
+					},
+					Params: map[string]*schemapb.FunctionParamValue{
+						types.NumCombineParamMode: stringParam(types.NumCombineModeMultiply),
+					},
+				},
+			},
+		},
+	}, s.pool)
 	s.Require().NoError(err)
 
 	df := s.createTestDataFrame(schemapb.DataType_Int64)
@@ -271,24 +277,43 @@ func (s *DecayExprIntegrationTestSuite) TestIntegration_ParseFromJSON() {
 	s.True(result.HasColumn(types.ScoreFieldName))
 }
 
-func (s *DecayExprIntegrationTestSuite) TestIntegration_ScoreCombine_ParseFromJSON() {
-	jsonRepr := `{
-		"name": "score-combine-test",
-		"stage": "L2_rerank",
-		"operators": [{
-			"type": "map",
-			"inputs": ["$score", "_func_score"],
-			"outputs": ["$score"],
-			"function": {
-				"name": "score_combine",
-				"params": {
-					"mode": "multiply"
-				}
-			}
-		}]
-	}`
-
-	fc, err := chain.ParseFuncChainRepr(jsonRepr, s.pool)
+func (s *DecayExprIntegrationTestSuite) TestIntegration_NumCombine_ParseFromProto() {
+	fc, err := chain.ParseFuncChainProto(&schemapb.FunctionChain{
+		Name:  "num-combine-test",
+		Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+		Ops: []*schemapb.FunctionChainOp{
+			{
+				Op:      types.OpTypeMap,
+				Outputs: []string{types.ScoreFieldName},
+				Expr: &schemapb.FunctionChainExpr{
+					Name: "num_combine",
+					Args: []*schemapb.FunctionChainExprArg{
+						columnArg(types.ScoreFieldName),
+						columnArg("_func_score"),
+					},
+					Params: map[string]*schemapb.FunctionParamValue{
+						types.NumCombineParamMode: stringParam(types.NumCombineModeMultiply),
+					},
+				},
+			},
+		},
+	}, s.pool)
 	s.Require().NoError(err)
 	s.NotNil(fc)
+}
+
+func columnArg(name string) *schemapb.FunctionChainExprArg {
+	return &schemapb.FunctionChainExprArg{Arg: &schemapb.FunctionChainExprArg_Column{Column: &schemapb.FunctionChainColumnArg{Name: name}}}
+}
+
+func intParam(value int64) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_Int64Value{Int64Value: value}}
+}
+
+func doubleParam(value float64) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_DoubleValue{DoubleValue: value}}
+}
+
+func stringParam(value string) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_StringValue{StringValue: value}}
 }

--- a/internal/util/function/chain/expr/decay_expr_test.go
+++ b/internal/util/function/chain/expr/decay_expr_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
 )
 
@@ -223,29 +224,28 @@ func (s *DecayExprTestSuite) TestNewDecayExpr_NumericalStability() {
 // =============================================================================
 
 func (s *DecayExprTestSuite) TestNewDecayExprFromParams_Valid() {
-	// Note: input_column is no longer part of function params, it's handled by MapOp
-	params := map[string]interface{}{
-		"function": "gauss",
-		"origin":   100.0,
-		"scale":    50.0,
-		"offset":   10.0,
-		"decay":    0.3,
+	params := map[string]*schemapb.FunctionParamValue{
+		"function": stringParam("gauss"),
+		"origin":   doubleParam(100.0),
+		"scale":    doubleParam(50.0),
+		"offset":   doubleParam(10.0),
+		"decay":    doubleParam(0.3),
 	}
 
-	expr, err := NewDecayExprFromParams(params)
+	expr, err := NewDecayExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: params})
 	s.Require().NoError(err)
 	s.NotNil(expr)
 	s.Equal("decay", expr.Name())
 }
 
 func (s *DecayExprTestSuite) TestNewDecayExprFromParams_DefaultValues() {
-	params := map[string]interface{}{
-		"function": "gauss",
-		"origin":   100.0,
-		"scale":    50.0,
+	params := map[string]*schemapb.FunctionParamValue{
+		"function": stringParam("gauss"),
+		"origin":   doubleParam(100.0),
+		"scale":    doubleParam(50.0),
 	}
 
-	expr, err := NewDecayExprFromParams(params)
+	expr, err := NewDecayExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: params})
 	s.Require().NoError(err)
 
 	decayExpr := expr.(*DecayExpr)
@@ -254,62 +254,56 @@ func (s *DecayExprTestSuite) TestNewDecayExprFromParams_DefaultValues() {
 }
 
 func (s *DecayExprTestSuite) TestNewDecayExprFromParams_MissingRequired() {
-	// Missing function
-	_, err := NewDecayExprFromParams(map[string]interface{}{
-		"origin": 100.0,
-		"scale":  50.0,
-	})
+	_, err := NewDecayExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{
+		"origin": doubleParam(100.0),
+		"scale":  doubleParam(50.0),
+	}})
 	s.Error(err)
 	s.Contains(err.Error(), "function")
 
-	// Missing origin
-	_, err = NewDecayExprFromParams(map[string]interface{}{
-		"function": "gauss",
-		"scale":    50.0,
-	})
+	_, err = NewDecayExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{
+		"function": stringParam("gauss"),
+		"scale":    doubleParam(50.0),
+	}})
 	s.Error(err)
 	s.Contains(err.Error(), "origin")
 
-	// Missing scale
-	_, err = NewDecayExprFromParams(map[string]interface{}{
-		"function": "gauss",
-		"origin":   100.0,
-	})
+	_, err = NewDecayExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{
+		"function": stringParam("gauss"),
+		"origin":   doubleParam(100.0),
+	}})
 	s.Error(err)
 	s.Contains(err.Error(), "scale")
 }
 
 func (s *DecayExprTestSuite) TestNewDecayExprFromParams_WrongTypes() {
-	// function is not string
-	_, err := NewDecayExprFromParams(map[string]interface{}{
-		"function": 123,
-		"origin":   100.0,
-		"scale":    50.0,
-	})
+	_, err := NewDecayExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{
+		"function": intParam(123),
+		"origin":   doubleParam(100.0),
+		"scale":    doubleParam(50.0),
+	}})
 	s.Error(err)
 	s.Contains(err.Error(), "must be a string")
 
-	// scale is not number
-	_, err = NewDecayExprFromParams(map[string]interface{}{
-		"function": "gauss",
-		"origin":   100.0,
-		"scale":    "fifty",
-	})
+	_, err = NewDecayExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{
+		"function": stringParam("gauss"),
+		"origin":   doubleParam(100.0),
+		"scale":    stringParam("fifty"),
+	}})
 	s.Error(err)
 	s.Contains(err.Error(), "must be a number")
 }
 
 func (s *DecayExprTestSuite) TestNewDecayExprFromParams_NumericConversions() {
-	// Test int values are converted to float64
-	params := map[string]interface{}{
-		"function": "gauss",
-		"origin":   100, // int
-		"scale":    int64(50),
-		"offset":   int32(10),
-		"decay":    float32(0.3),
+	params := map[string]*schemapb.FunctionParamValue{
+		"function": stringParam("gauss"),
+		"origin":   intParam(100),
+		"scale":    intParam(50),
+		"offset":   intParam(10),
+		"decay":    doubleParam(0.3),
 	}
 
-	expr, err := NewDecayExprFromParams(params)
+	expr, err := NewDecayExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: params})
 	s.Require().NoError(err)
 	s.NotNil(expr)
 }

--- a/internal/util/function/chain/expr/function_param_test_helpers_test.go
+++ b/internal/util/function/chain/expr/function_param_test_helpers_test.go
@@ -1,0 +1,23 @@
+package expr
+
+import "github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+
+func boolParam(value bool) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_BoolValue{BoolValue: value}}
+}
+
+func intParam(value int64) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_Int64Value{Int64Value: value}}
+}
+
+func doubleParam(value float64) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_DoubleValue{DoubleValue: value}}
+}
+
+func stringParam(value string) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_StringValue{StringValue: value}}
+}
+
+func arrayParam(values ...*schemapb.FunctionParamValue) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_ArrayValue{ArrayValue: &schemapb.FunctionParamArray{Values: values}}}
+}

--- a/internal/util/function/chain/expr/num_combine_expr.go
+++ b/internal/util/function/chain/expr/num_combine_expr.go
@@ -33,24 +33,26 @@ import (
 // =============================================================================
 
 const (
-	// Parameter keys for ScoreCombineExpr
-	ModeKey    = types.ScoreCombineParamMode
-	WeightsKey = types.ScoreCombineParamWeights
+	// Parameter keys for NumCombineExpr
+	ModeKey    = types.NumCombineParamMode
+	WeightsKey = types.NumCombineParamWeights
 
 	// Mode values
-	ModeMultiply = types.ScoreCombineModeMultiply
-	ModeSum      = types.ScoreCombineModeSum
-	ModeMax      = types.ScoreCombineModeMax
-	ModeMin      = types.ScoreCombineModeMin
-	ModeAvg      = types.ScoreCombineModeAvg
-	ModeWeighted = types.ScoreCombineModeWeighted
+	ModeMultiply = types.NumCombineModeMultiply
+	ModeSum      = types.NumCombineModeSum
+	ModeMax      = types.NumCombineModeMax
+	ModeMin      = types.NumCombineModeMin
+	ModeAvg      = types.NumCombineModeAvg
+	ModeWeighted = types.NumCombineModeWeighted
 )
 
 // =============================================================================
 // Types
 // =============================================================================
 
-// ScoreCombineExpr implements FunctionExpr for combining multiple score columns into one.
+const NumCombineFuncName = "num_combine"
+
+// NumCombineExpr implements FunctionExpr for combining multiple numeric columns into one.
 // It supports dynamic input columns to prepare for multi-rerank scenarios.
 // Column mapping is handled by MapOp.
 //
@@ -58,29 +60,29 @@ const (
 //   - inputs[0..N-1]: N numeric columns to combine (at least 2)
 //
 // Outputs:
-//   - outputs[0]: combined score column
-type ScoreCombineNullPolicy int
+//   - outputs[0]: combined numeric column
+type NumCombineNullPolicy int
 
 const (
-	// ScoreCombineNullPropagate returns null if any input is null.
-	ScoreCombineNullPropagate ScoreCombineNullPolicy = iota
-	// ScoreCombineNullAsZero treats null inputs as zero.
-	ScoreCombineNullAsZero
-	// ScoreCombineNullSkip skips null inputs and returns null if all inputs are null.
-	ScoreCombineNullSkip
+	// NumCombineNullPropagate returns null if any input is null.
+	NumCombineNullPropagate NumCombineNullPolicy = iota
+	// NumCombineNullAsZero treats null inputs as zero.
+	NumCombineNullAsZero
+	// NumCombineNullSkip skips null inputs and returns null if all inputs are null.
+	NumCombineNullSkip
 )
 
-type ScoreCombineExpr struct {
+type NumCombineExpr struct {
 	BaseExpr
-	mode       string                 // combine mode: multiply, sum, max, min, avg, weighted
-	weights    []float64              // weights for weighted mode
-	nullPolicy ScoreCombineNullPolicy // null handling policy
+	mode       string               // combine mode: multiply, sum, max, min, avg, weighted
+	weights    []float64            // weights for weighted mode
+	nullPolicy NumCombineNullPolicy // null handling policy
 }
 
-type ScoreCombineOption func(*ScoreCombineExpr)
+type NumCombineOption func(*NumCombineExpr)
 
-func WithNullPolicy(policy ScoreCombineNullPolicy) ScoreCombineOption {
-	return func(s *ScoreCombineExpr) {
+func WithNullPolicy(policy NumCombineNullPolicy) NumCombineOption {
+	return func(s *NumCombineExpr) {
 		s.nullPolicy = policy
 	}
 }
@@ -89,10 +91,10 @@ func WithNullPolicy(policy ScoreCombineNullPolicy) ScoreCombineOption {
 // Constructor Functions
 // =============================================================================
 
-// NewScoreCombineExpr creates a new ScoreCombineExpr with the given parameters.
+// NewNumCombineExpr creates a new NumCombineExpr with the given parameters.
 // Note: Column mapping (which columns to use as input/output) is handled by MapOp,
 // not by the function itself.
-func NewScoreCombineExpr(mode string, weights []float64, opts ...ScoreCombineOption) (*ScoreCombineExpr, error) {
+func NewNumCombineExpr(mode string, weights []float64, opts ...NumCombineOption) (*NumCombineExpr, error) {
 	// Default mode
 	if mode == "" {
 		mode = ModeMultiply
@@ -108,21 +110,21 @@ func NewScoreCombineExpr(mode string, weights []float64, opts ...ScoreCombineOpt
 		ModeWeighted: true,
 	}
 	if !validModes[mode] {
-		return nil, merr.WrapErrParameterInvalidMsg("score_combine: invalid mode %q, must be one of [%s, %s, %s, %s, %s, %s]",
+		return nil, merr.WrapErrParameterInvalidMsg("num_combine: invalid mode %q, must be one of [%s, %s, %s, %s, %s, %s]",
 			mode, ModeMultiply, ModeSum, ModeMax, ModeMin, ModeAvg, ModeWeighted)
 	}
 
 	// Weighted mode requires weights
 	if mode == ModeWeighted && len(weights) == 0 {
-		return nil, merr.WrapErrParameterInvalidMsg("score_combine: weighted mode requires weights")
+		return nil, merr.WrapErrParameterInvalidMsg("num_combine: weighted mode requires weights")
 	}
 
 	// nil supportStages means the function supports all stages
-	expr := &ScoreCombineExpr{
-		BaseExpr:   *NewBaseExpr("score_combine", nil),
+	expr := &NumCombineExpr{
+		BaseExpr:   *NewBaseExpr(NumCombineFuncName, nil),
 		mode:       mode,
 		weights:    weights,
-		nullPolicy: ScoreCombineNullPropagate,
+		nullPolicy: NumCombineNullPropagate,
 	}
 	for _, opt := range opts {
 		opt(expr)
@@ -130,25 +132,23 @@ func NewScoreCombineExpr(mode string, weights []float64, opts ...ScoreCombineOpt
 	return expr, nil
 }
 
-// NewScoreCombineExprFromParams creates a ScoreCombineExpr from a parameter map.
+// NewNumCombineExprFromParams creates a NumCombineExpr from a parameter map.
 // This is the factory function for the function registry.
 // All parameter parsing is handled here, keeping it close to the expr definition.
-func NewScoreCombineExprFromParams(params map[string]interface{}) (types.FunctionExpr, error) {
-	const funcName = "score_combine"
+func NewNumCombineExprFromParams(_ types.FunctionBuildContext, cfg types.FunctionConfig) (types.FunctionExpr, error) {
+	reader := types.NewParamReader(NumCombineFuncName, cfg.Params)
 
-	// Parse mode (optional, default multiply)
-	mode, err := GetStringParam(params, funcName, ModeKey, false)
+	mode, err := reader.String(ModeKey, false)
 	if err != nil {
 		return nil, err
 	}
 
-	// Parse weights (optional)
-	weights, err := ParseFloat64SliceParam(params, funcName, WeightsKey)
+	weights, err := reader.Float64Slice(WeightsKey, false)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewScoreCombineExpr(mode, weights)
+	return NewNumCombineExpr(mode, weights)
 }
 
 // =============================================================================
@@ -159,25 +159,25 @@ func NewScoreCombineExprFromParams(params map[string]interface{}) (types.Functio
 // (nil supportStages in BaseExpr means the function supports all stages)
 
 // OutputDataTypes returns the data types of output columns.
-// ScoreCombineExpr outputs a single Float32 column (the combined score).
-func (s *ScoreCombineExpr) OutputDataTypes() []arrow.DataType {
+// NumCombineExpr outputs a single Float32 column (the combined numeric value).
+func (s *NumCombineExpr) OutputDataTypes() []arrow.DataType {
 	return []arrow.DataType{arrow.PrimitiveTypes.Float32}
 }
 
-// Execute executes the score combine function on input columns and returns output columns.
-func (s *ScoreCombineExpr) Execute(ctx *types.FuncContext, inputs []*arrow.Chunked) ([]*arrow.Chunked, error) {
+// Execute executes the numeric combine function on input columns and returns output columns.
+func (s *NumCombineExpr) Execute(ctx *types.FuncContext, inputs []*arrow.Chunked) ([]*arrow.Chunked, error) {
 	if len(inputs) < 2 {
-		return nil, merr.WrapErrServiceInternalMsg("score_combine: expected at least 2 input columns, got %d", len(inputs))
+		return nil, merr.WrapErrParameterInvalidMsg("num_combine: expected at least 2 input columns, got %d", len(inputs))
 	}
 
 	if s.mode == ModeWeighted && len(s.weights) != len(inputs) {
-		return nil, merr.WrapErrServiceInternalMsg("score_combine: weighted mode requires %d weights, got %d", len(inputs), len(s.weights))
+		return nil, merr.WrapErrParameterInvalidMsg("num_combine: weighted mode requires %d weights, got %d", len(inputs), len(s.weights))
 	}
 
 	numChunks := len(inputs[0].Chunks())
 	for idx := 1; idx < len(inputs); idx++ {
 		if len(inputs[idx].Chunks()) != numChunks {
-			return nil, merr.WrapErrServiceInternalMsg("score_combine: input 0 has %d chunks but input %d has %d chunks", numChunks, idx, len(inputs[idx].Chunks()))
+			return nil, merr.WrapErrServiceInternalMsg("num_combine: input 0 has %d chunks but input %d has %d chunks", numChunks, idx, len(inputs[idx].Chunks()))
 		}
 	}
 	resultChunks := make([]arrow.Array, numChunks)
@@ -210,7 +210,7 @@ func (s *ScoreCombineExpr) Execute(ctx *types.FuncContext, inputs []*arrow.Chunk
 // =============================================================================
 
 // processChunk processes a single chunk, combining scores.
-func (s *ScoreCombineExpr) processChunk(ctx *types.FuncContext, inputs []*arrow.Chunked, chunkIdx int) (arrow.Array, error) {
+func (s *NumCombineExpr) processChunk(ctx *types.FuncContext, inputs []*arrow.Chunked, chunkIdx int) (arrow.Array, error) {
 	builder := array.NewFloat32Builder(ctx.Pool())
 	defer builder.Release()
 
@@ -219,11 +219,11 @@ func (s *ScoreCombineExpr) processChunk(ctx *types.FuncContext, inputs []*arrow.
 	for colIdx, input := range inputs {
 		chunk := input.Chunk(chunkIdx)
 		if chunk.Len() != chunkLen {
-			return nil, merr.WrapErrServiceInternalMsg("score_combine: input 0 chunk %d has %d rows but input %d has %d rows", chunkIdx, chunkLen, colIdx, chunk.Len())
+			return nil, merr.WrapErrServiceInternalMsg("num_combine: input 0 chunk %d has %d rows but input %d has %d rows", chunkIdx, chunkLen, colIdx, chunk.Len())
 		}
 		reader, ok := newNumericReader(chunk)
 		if !ok {
-			return nil, merr.WrapErrServiceInternalMsg("score_combine: column %d: unsupported input column type %T, expected numeric type", colIdx, chunk)
+			return nil, merr.WrapErrParameterInvalidMsg("num_combine: column %d: unsupported input column type %T, expected numeric type", colIdx, chunk)
 		}
 		readers[colIdx] = reader
 	}
@@ -233,7 +233,7 @@ func (s *ScoreCombineExpr) processChunk(ctx *types.FuncContext, inputs []*arrow.
 	return builder.NewArray(), nil
 }
 
-func (s *ScoreCombineExpr) processRows(builder *array.Float32Builder, readers []numericReader, chunkLen int) {
+func (s *NumCombineExpr) processRows(builder *array.Float32Builder, readers []numericReader, chunkLen int) {
 	values := make([]float64, 0, len(readers))
 	weights := make([]float64, 0, len(readers))
 	for rowIdx := 0; rowIdx < chunkLen; rowIdx++ {
@@ -246,20 +246,20 @@ func (s *ScoreCombineExpr) processRows(builder *array.Float32Builder, readers []
 	}
 }
 
-func (s *ScoreCombineExpr) collectRowValues(readers []numericReader, rowIdx int, values []float64, weights []float64) ([]float64, []float64, bool) {
+func (s *NumCombineExpr) collectRowValues(readers []numericReader, rowIdx int, values []float64, weights []float64) ([]float64, []float64, bool) {
 	values = values[:0]
 	weights = weights[:0]
 	for idx, reader := range readers {
 		if reader.IsNull(rowIdx) {
 			switch s.nullPolicy {
-			case ScoreCombineNullPropagate:
+			case NumCombineNullPropagate:
 				return values, weights, false
-			case ScoreCombineNullAsZero:
+			case NumCombineNullAsZero:
 				values = append(values, 0)
 				if s.mode == ModeWeighted {
 					weights = append(weights, s.weights[idx])
 				}
-			case ScoreCombineNullSkip:
+			case NumCombineNullSkip:
 				continue
 			default:
 				return values, weights, false
@@ -321,7 +321,7 @@ func newNumericReader(arr arrow.Array) (numericReader, bool) {
 }
 
 // combine combines multiple values based on the mode.
-func (s *ScoreCombineExpr) combine(values []float64, weights []float64) float64 {
+func (s *NumCombineExpr) combine(values []float64, weights []float64) float64 {
 	switch s.mode {
 	case ModeMultiply:
 		result := 1.0
@@ -377,5 +377,5 @@ func (s *ScoreCombineExpr) combine(values []float64, weights []float64) float64 
 // =============================================================================
 
 func init() {
-	types.MustRegisterFunction("score_combine", NewScoreCombineExprFromParams)
+	types.MustRegisterFunction(NumCombineFuncName, NewNumCombineExprFromParams)
 }

--- a/internal/util/function/chain/expr/num_combine_expr_test.go
+++ b/internal/util/function/chain/expr/num_combine_expr_test.go
@@ -26,35 +26,37 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
 // =============================================================================
 // Test Suite
 // =============================================================================
 
-type ScoreCombineExprTestSuite struct {
+type NumCombineExprTestSuite struct {
 	suite.Suite
 	pool *memory.CheckedAllocator
 }
 
-func (s *ScoreCombineExprTestSuite) SetupTest() {
+func (s *NumCombineExprTestSuite) SetupTest() {
 	s.pool = memory.NewCheckedAllocator(memory.NewGoAllocator())
 }
 
-func (s *ScoreCombineExprTestSuite) TearDownTest() {
+func (s *NumCombineExprTestSuite) TearDownTest() {
 	s.pool.AssertSize(s.T(), 0)
 }
 
-func TestScoreCombineExprTestSuite(t *testing.T) {
-	suite.Run(t, new(ScoreCombineExprTestSuite))
+func TestNumCombineExprTestSuite(t *testing.T) {
+	suite.Run(t, new(NumCombineExprTestSuite))
 }
 
 // =============================================================================
 // Helper Functions
 // =============================================================================
 
-func (s *ScoreCombineExprTestSuite) createFloat32ChunkedArray(values []float32) *arrow.Chunked {
+func (s *NumCombineExprTestSuite) createFloat32ChunkedArray(values []float32) *arrow.Chunked {
 	builder := array.NewFloat32Builder(s.pool)
 	defer builder.Release()
 
@@ -69,7 +71,7 @@ func (s *ScoreCombineExprTestSuite) createFloat32ChunkedArray(values []float32) 
 	return chunked
 }
 
-func (s *ScoreCombineExprTestSuite) createNullableFloat32ChunkedArray(values []float32, valid []bool) *arrow.Chunked {
+func (s *NumCombineExprTestSuite) createNullableFloat32ChunkedArray(values []float32, valid []bool) *arrow.Chunked {
 	builder := array.NewFloat32Builder(s.pool)
 	defer builder.Release()
 
@@ -88,7 +90,7 @@ func (s *ScoreCombineExprTestSuite) createNullableFloat32ChunkedArray(values []f
 	return chunked
 }
 
-func (s *ScoreCombineExprTestSuite) createMultiChunkFloat32Array(chunk1, chunk2 []float32) *arrow.Chunked {
+func (s *NumCombineExprTestSuite) createMultiChunkFloat32Array(chunk1, chunk2 []float32) *arrow.Chunked {
 	builder1 := array.NewFloat32Builder(s.pool)
 	defer builder1.Release()
 	for _, v := range chunk1 {
@@ -114,41 +116,41 @@ func (s *ScoreCombineExprTestSuite) createMultiChunkFloat32Array(chunk1, chunk2 
 // Constructor Tests
 // =============================================================================
 
-func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExpr_Valid() {
-	expr, err := NewScoreCombineExpr(ModeMultiply, nil)
+func (s *NumCombineExprTestSuite) TestNewNumCombineExpr_Valid() {
+	expr, err := NewNumCombineExpr(ModeMultiply, nil)
 	s.Require().NoError(err)
 	s.NotNil(expr)
-	s.Equal("score_combine", expr.Name())
+	s.Equal(NumCombineFuncName, expr.Name())
 	s.Equal(ModeMultiply, expr.mode)
 }
 
-func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExpr_AllModes() {
+func (s *NumCombineExprTestSuite) TestNewNumCombineExpr_AllModes() {
 	modes := []string{ModeMultiply, ModeSum, ModeMax, ModeMin, ModeAvg}
 
 	for _, mode := range modes {
-		expr, err := NewScoreCombineExpr(mode, nil)
+		expr, err := NewNumCombineExpr(mode, nil)
 		s.Require().NoError(err, "mode: %s", mode)
 		s.NotNil(expr)
 		s.Equal(mode, expr.mode)
 	}
 }
 
-func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExpr_WeightedMode() {
+func (s *NumCombineExprTestSuite) TestNewNumCombineExpr_WeightedMode() {
 	weights := []float64{0.5, 0.3, 0.2}
-	expr, err := NewScoreCombineExpr(ModeWeighted, weights)
+	expr, err := NewNumCombineExpr(ModeWeighted, weights)
 	s.Require().NoError(err)
 	s.NotNil(expr)
 	s.Equal(weights, expr.weights)
 }
 
-func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExpr_InvalidMode() {
-	_, err := NewScoreCombineExpr("invalid_mode", nil)
+func (s *NumCombineExprTestSuite) TestNewNumCombineExpr_InvalidMode() {
+	_, err := NewNumCombineExpr("invalid_mode", nil)
 	s.Error(err)
 	s.Contains(err.Error(), "invalid mode")
 }
 
-func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExpr_WeightedModeNoWeights() {
-	_, err := NewScoreCombineExpr(ModeWeighted, nil)
+func (s *NumCombineExprTestSuite) TestNewNumCombineExpr_WeightedModeNoWeights() {
+	_, err := NewNumCombineExpr(ModeWeighted, nil)
 	s.Error(err)
 	s.Contains(err.Error(), "weighted mode requires weights")
 }
@@ -157,47 +159,44 @@ func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExpr_WeightedModeNoWeight
 // Factory Tests
 // =============================================================================
 
-func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExprFromParams_Valid() {
-	params := map[string]interface{}{
-		"mode": "multiply",
+func (s *NumCombineExprTestSuite) TestNewNumCombineExprFromParams_Valid() {
+	params := map[string]*schemapb.FunctionParamValue{
+		"mode": stringParam("multiply"),
 	}
 
-	expr, err := NewScoreCombineExprFromParams(params)
+	expr, err := NewNumCombineExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: params})
 	s.Require().NoError(err)
 	s.NotNil(expr)
-	s.Equal("score_combine", expr.Name())
+	s.Equal(NumCombineFuncName, expr.Name())
 }
 
-func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExprFromParams_WithWeights() {
-	params := map[string]interface{}{
-		"mode":    "weighted",
-		"weights": []float64{0.6, 0.4},
+func (s *NumCombineExprTestSuite) TestNewNumCombineExprFromParams_WithWeights() {
+	params := map[string]*schemapb.FunctionParamValue{
+		"mode":    stringParam("weighted"),
+		"weights": arrayParam(doubleParam(0.6), doubleParam(0.4)),
 	}
 
-	expr, err := NewScoreCombineExprFromParams(params)
+	expr, err := NewNumCombineExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: params})
 	s.Require().NoError(err)
-	combineExpr := expr.(*ScoreCombineExpr)
+	combineExpr := expr.(*NumCombineExpr)
 	s.Equal([]float64{0.6, 0.4}, combineExpr.weights)
 }
 
-func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExprFromParams_WeightsAsInterface() {
-	// Test with []interface{} for weights
-	params := map[string]interface{}{
-		"mode":    "weighted",
-		"weights": []interface{}{0.6, 0.4},
+func (s *NumCombineExprTestSuite) TestNewNumCombineExprFromParams_WeightsAsInts() {
+	params := map[string]*schemapb.FunctionParamValue{
+		"mode":    stringParam("weighted"),
+		"weights": arrayParam(intParam(1), intParam(2)),
 	}
 
-	expr, err := NewScoreCombineExprFromParams(params)
+	expr, err := NewNumCombineExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: params})
 	s.Require().NoError(err)
 	s.NotNil(expr)
 }
 
-func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExprFromParams_DefaultMode() {
-	params := map[string]interface{}{}
-
-	expr, err := NewScoreCombineExprFromParams(params)
+func (s *NumCombineExprTestSuite) TestNewNumCombineExprFromParams_DefaultMode() {
+	expr, err := NewNumCombineExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{}})
 	s.Require().NoError(err)
-	combineExpr := expr.(*ScoreCombineExpr)
+	combineExpr := expr.(*NumCombineExpr)
 	s.Equal(ModeMultiply, combineExpr.mode)
 }
 
@@ -205,13 +204,13 @@ func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExprFromParams_DefaultMod
 // Execute Tests
 // =============================================================================
 
-func (s *ScoreCombineExprTestSuite) TestExecute_Multiply() {
+func (s *NumCombineExprTestSuite) TestExecute_Multiply() {
 	col1 := s.createFloat32ChunkedArray([]float32{2.0, 3.0, 4.0})
 	defer col1.Release()
 	col2 := s.createFloat32ChunkedArray([]float32{0.5, 0.5, 0.5})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeMultiply, nil)
+	expr, err := NewNumCombineExpr(ModeMultiply, nil)
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -227,13 +226,13 @@ func (s *ScoreCombineExprTestSuite) TestExecute_Multiply() {
 	s.InDelta(2.0, result.Value(2), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_Sum() {
+func (s *NumCombineExprTestSuite) TestExecute_Sum() {
 	col1 := s.createFloat32ChunkedArray([]float32{1.0, 2.0, 3.0})
 	defer col1.Release()
 	col2 := s.createFloat32ChunkedArray([]float32{0.5, 0.5, 0.5})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeSum, nil)
+	expr, err := NewNumCombineExpr(ModeSum, nil)
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -248,13 +247,13 @@ func (s *ScoreCombineExprTestSuite) TestExecute_Sum() {
 	s.InDelta(3.5, result.Value(2), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_Max() {
+func (s *NumCombineExprTestSuite) TestExecute_Max() {
 	col1 := s.createFloat32ChunkedArray([]float32{1.0, 5.0, 3.0})
 	defer col1.Release()
 	col2 := s.createFloat32ChunkedArray([]float32{2.0, 2.0, 4.0})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeMax, nil)
+	expr, err := NewNumCombineExpr(ModeMax, nil)
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -269,13 +268,13 @@ func (s *ScoreCombineExprTestSuite) TestExecute_Max() {
 	s.InDelta(4.0, result.Value(2), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_Min() {
+func (s *NumCombineExprTestSuite) TestExecute_Min() {
 	col1 := s.createFloat32ChunkedArray([]float32{1.0, 5.0, 3.0})
 	defer col1.Release()
 	col2 := s.createFloat32ChunkedArray([]float32{2.0, 2.0, 4.0})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeMin, nil)
+	expr, err := NewNumCombineExpr(ModeMin, nil)
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -290,13 +289,13 @@ func (s *ScoreCombineExprTestSuite) TestExecute_Min() {
 	s.InDelta(3.0, result.Value(2), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_Avg() {
+func (s *NumCombineExprTestSuite) TestExecute_Avg() {
 	col1 := s.createFloat32ChunkedArray([]float32{2.0, 4.0, 6.0})
 	defer col1.Release()
 	col2 := s.createFloat32ChunkedArray([]float32{4.0, 6.0, 8.0})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeAvg, nil)
+	expr, err := NewNumCombineExpr(ModeAvg, nil)
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -311,14 +310,14 @@ func (s *ScoreCombineExprTestSuite) TestExecute_Avg() {
 	s.InDelta(7.0, result.Value(2), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_Weighted() {
+func (s *NumCombineExprTestSuite) TestExecute_Weighted() {
 	col1 := s.createFloat32ChunkedArray([]float32{10.0, 20.0, 30.0})
 	defer col1.Release()
 	col2 := s.createFloat32ChunkedArray([]float32{1.0, 2.0, 3.0})
 	defer col2.Release()
 
 	// weights: 0.8 for col1, 0.2 for col2
-	expr, err := NewScoreCombineExpr(ModeWeighted, []float64{0.8, 0.2})
+	expr, err := NewNumCombineExpr(ModeWeighted, []float64{0.8, 0.2})
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -333,13 +332,13 @@ func (s *ScoreCombineExprTestSuite) TestExecute_Weighted() {
 	s.InDelta(24.6, result.Value(2), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_PropagatesNullInputsByDefault() {
+func (s *NumCombineExprTestSuite) TestExecute_PropagatesNullInputsByDefault() {
 	col1 := s.createNullableFloat32ChunkedArray([]float32{2.0, 0.0, 0.0}, []bool{true, false, false})
 	defer col1.Release()
 	col2 := s.createNullableFloat32ChunkedArray([]float32{3.0, 4.0, 0.0}, []bool{true, true, false})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeSum, nil)
+	expr, err := NewNumCombineExpr(ModeSum, nil)
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -354,7 +353,7 @@ func (s *ScoreCombineExprTestSuite) TestExecute_PropagatesNullInputsByDefault() 
 	s.True(result.IsNull(2))
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_TreatsNullInputsAsZero() {
+func (s *NumCombineExprTestSuite) TestExecute_TreatsNullInputsAsZero() {
 	col1 := s.createNullableFloat32ChunkedArray([]float32{2.0, 0.0, 0.0}, []bool{true, false, false})
 	defer col1.Release()
 	col2 := s.createNullableFloat32ChunkedArray([]float32{3.0, 4.0, 0.0}, []bool{true, true, false})
@@ -362,7 +361,7 @@ func (s *ScoreCombineExprTestSuite) TestExecute_TreatsNullInputsAsZero() {
 	col3 := s.createNullableFloat32ChunkedArray([]float32{0.0, 5.0, 0.0}, []bool{false, true, false})
 	defer col3.Release()
 
-	expr, err := NewScoreCombineExpr(ModeSum, nil, WithNullPolicy(ScoreCombineNullAsZero))
+	expr, err := NewNumCombineExpr(ModeSum, nil, WithNullPolicy(NumCombineNullAsZero))
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -379,13 +378,13 @@ func (s *ScoreCombineExprTestSuite) TestExecute_TreatsNullInputsAsZero() {
 	s.InDelta(0.0, result.Value(2), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_TreatsNullInputsAsZeroWeighted() {
+func (s *NumCombineExprTestSuite) TestExecute_TreatsNullInputsAsZeroWeighted() {
 	col1 := s.createNullableFloat32ChunkedArray([]float32{10.0, 0.0}, []bool{true, false})
 	defer col1.Release()
 	col2 := s.createNullableFloat32ChunkedArray([]float32{0.0, 20.0}, []bool{false, true})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeWeighted, []float64{0.8, 0.2}, WithNullPolicy(ScoreCombineNullAsZero))
+	expr, err := NewNumCombineExpr(ModeWeighted, []float64{0.8, 0.2}, WithNullPolicy(NumCombineNullAsZero))
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -398,7 +397,7 @@ func (s *ScoreCombineExprTestSuite) TestExecute_TreatsNullInputsAsZeroWeighted()
 	s.InDelta(4.0, result.Value(1), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_SkipsNullInputs() {
+func (s *NumCombineExprTestSuite) TestExecute_SkipsNullInputs() {
 	col1 := s.createNullableFloat32ChunkedArray([]float32{2.0, 0.0, 0.0}, []bool{true, false, false})
 	defer col1.Release()
 	col2 := s.createNullableFloat32ChunkedArray([]float32{3.0, 4.0, 0.0}, []bool{true, true, false})
@@ -406,7 +405,7 @@ func (s *ScoreCombineExprTestSuite) TestExecute_SkipsNullInputs() {
 	col3 := s.createNullableFloat32ChunkedArray([]float32{0.0, 5.0, 0.0}, []bool{false, true, false})
 	defer col3.Release()
 
-	expr, err := NewScoreCombineExpr(ModeSum, nil, WithNullPolicy(ScoreCombineNullSkip))
+	expr, err := NewNumCombineExpr(ModeSum, nil, WithNullPolicy(NumCombineNullSkip))
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -422,13 +421,13 @@ func (s *ScoreCombineExprTestSuite) TestExecute_SkipsNullInputs() {
 	s.True(result.IsNull(2))
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_SkipsNullInputsMultiply() {
+func (s *NumCombineExprTestSuite) TestExecute_SkipsNullInputsMultiply() {
 	col1 := s.createNullableFloat32ChunkedArray([]float32{2.0, 0.0}, []bool{true, false})
 	defer col1.Release()
 	col2 := s.createNullableFloat32ChunkedArray([]float32{3.0, 3.0}, []bool{true, true})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeMultiply, nil, WithNullPolicy(ScoreCombineNullSkip))
+	expr, err := NewNumCombineExpr(ModeMultiply, nil, WithNullPolicy(NumCombineNullSkip))
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -441,13 +440,13 @@ func (s *ScoreCombineExprTestSuite) TestExecute_SkipsNullInputsMultiply() {
 	s.InDelta(3.0, result.Value(1), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_TreatsNullInputsAsZeroMultiply() {
+func (s *NumCombineExprTestSuite) TestExecute_TreatsNullInputsAsZeroMultiply() {
 	col1 := s.createNullableFloat32ChunkedArray([]float32{2.0, 0.0}, []bool{true, false})
 	defer col1.Release()
 	col2 := s.createNullableFloat32ChunkedArray([]float32{3.0, 3.0}, []bool{true, true})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeMultiply, nil, WithNullPolicy(ScoreCombineNullAsZero))
+	expr, err := NewNumCombineExpr(ModeMultiply, nil, WithNullPolicy(NumCombineNullAsZero))
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -460,13 +459,13 @@ func (s *ScoreCombineExprTestSuite) TestExecute_TreatsNullInputsAsZeroMultiply()
 	s.InDelta(0.0, result.Value(1), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_MultipleChunks() {
+func (s *NumCombineExprTestSuite) TestExecute_MultipleChunks() {
 	col1 := s.createMultiChunkFloat32Array([]float32{1.0, 2.0}, []float32{3.0, 4.0})
 	defer col1.Release()
 	col2 := s.createMultiChunkFloat32Array([]float32{2.0, 2.0}, []float32{2.0, 2.0})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeMultiply, nil)
+	expr, err := NewNumCombineExpr(ModeMultiply, nil)
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -488,7 +487,7 @@ func (s *ScoreCombineExprTestSuite) TestExecute_MultipleChunks() {
 	s.InDelta(8.0, chunk1.Value(1), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_ThreeInputColumns() {
+func (s *NumCombineExprTestSuite) TestExecute_ThreeInputColumns() {
 	col1 := s.createFloat32ChunkedArray([]float32{2.0, 3.0})
 	defer col1.Release()
 	col2 := s.createFloat32ChunkedArray([]float32{3.0, 4.0})
@@ -496,7 +495,7 @@ func (s *ScoreCombineExprTestSuite) TestExecute_ThreeInputColumns() {
 	col3 := s.createFloat32ChunkedArray([]float32{1.0, 1.0})
 	defer col3.Release()
 
-	expr, err := NewScoreCombineExpr(ModeSum, nil)
+	expr, err := NewNumCombineExpr(ModeSum, nil)
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -510,21 +509,22 @@ func (s *ScoreCombineExprTestSuite) TestExecute_ThreeInputColumns() {
 	s.InDelta(8.0, result.Value(1), 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_TooFewInputs() {
+func (s *NumCombineExprTestSuite) TestExecute_TooFewInputs() {
 	col1 := s.createFloat32ChunkedArray([]float32{1.0, 2.0})
 	defer col1.Release()
 
-	expr, err := NewScoreCombineExpr(ModeMultiply, nil)
+	expr, err := NewNumCombineExpr(ModeMultiply, nil)
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
 	// Execute with only 1 input
 	_, err = expr.Execute(ctx, []*arrow.Chunked{col1})
 	s.Error(err)
+	s.ErrorIs(err, merr.ErrParameterInvalid)
 	s.Contains(err.Error(), "at least 2 input columns")
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_WeightedModeWrongWeightsCount() {
+func (s *NumCombineExprTestSuite) TestExecute_WeightedModeWrongWeightsCount() {
 	col1 := s.createFloat32ChunkedArray([]float32{1.0, 2.0})
 	defer col1.Release()
 	col2 := s.createFloat32ChunkedArray([]float32{3.0, 4.0})
@@ -533,12 +533,13 @@ func (s *ScoreCombineExprTestSuite) TestExecute_WeightedModeWrongWeightsCount() 
 	defer col3.Release()
 
 	// Create with 2 weights, but execute with 3 inputs
-	expr, err := NewScoreCombineExpr(ModeWeighted, []float64{0.5, 0.5})
+	expr, err := NewNumCombineExpr(ModeWeighted, []float64{0.5, 0.5})
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
 	_, err = expr.Execute(ctx, []*arrow.Chunked{col1, col2, col3})
 	s.Error(err)
+	s.ErrorIs(err, merr.ErrParameterInvalid)
 	s.Contains(err.Error(), "weighted mode requires 3 weights, got 2")
 }
 
@@ -546,8 +547,8 @@ func (s *ScoreCombineExprTestSuite) TestExecute_WeightedModeWrongWeightsCount() 
 // Interface Method Tests
 // =============================================================================
 
-func (s *ScoreCombineExprTestSuite) TestOutputDataTypes() {
-	expr, err := NewScoreCombineExpr(ModeMultiply, nil)
+func (s *NumCombineExprTestSuite) TestOutputDataTypes() {
+	expr, err := NewNumCombineExpr(ModeMultiply, nil)
 	s.Require().NoError(err)
 
 	outputTypes := expr.OutputDataTypes()
@@ -555,11 +556,11 @@ func (s *ScoreCombineExprTestSuite) TestOutputDataTypes() {
 	s.Equal(arrow.PrimitiveTypes.Float32, outputTypes[0])
 }
 
-func (s *ScoreCombineExprTestSuite) TestIsRunnable() {
-	expr, err := NewScoreCombineExpr(ModeMultiply, nil)
+func (s *NumCombineExprTestSuite) TestIsRunnable() {
+	expr, err := NewNumCombineExpr(ModeMultiply, nil)
 	s.Require().NoError(err)
 
-	// score_combine can run in all stages
+	// num_combine can run in all stages
 	s.True(expr.IsRunnable("L0_rerank"))
 	s.True(expr.IsRunnable("L1_rerank"))
 	s.True(expr.IsRunnable("L2_rerank"))
@@ -571,12 +572,12 @@ func (s *ScoreCombineExprTestSuite) TestIsRunnable() {
 // Memory Leak Tests
 // =============================================================================
 
-func (s *ScoreCombineExprTestSuite) TestMemoryLeak_ScoreCombineExecution() {
+func (s *NumCombineExprTestSuite) TestMemoryLeak_NumCombineExecution() {
 	for range 10 {
 		col1 := s.createFloat32ChunkedArray([]float32{1.0, 2.0, 3.0})
 		col2 := s.createFloat32ChunkedArray([]float32{0.5, 0.5, 0.5})
 
-		expr, err := NewScoreCombineExpr(ModeMultiply, nil)
+		expr, err := NewNumCombineExpr(ModeMultiply, nil)
 		s.Require().NoError(err)
 
 		ctx := types.NewFuncContext(s.pool)
@@ -594,98 +595,47 @@ func (s *ScoreCombineExprTestSuite) TestMemoryLeak_ScoreCombineExecution() {
 // Combine Function Unit Tests
 // =============================================================================
 
-func (s *ScoreCombineExprTestSuite) TestCombine_Multiply() {
-	expr := &ScoreCombineExpr{mode: ModeMultiply}
+func (s *NumCombineExprTestSuite) TestCombine_Multiply() {
+	expr := &NumCombineExpr{mode: ModeMultiply}
 	result := expr.combine([]float64{2.0, 3.0, 4.0}, nil)
 	s.InDelta(24.0, result, 0.001) // 2*3*4 = 24
 }
 
-func (s *ScoreCombineExprTestSuite) TestCombine_Sum() {
-	expr := &ScoreCombineExpr{mode: ModeSum}
+func (s *NumCombineExprTestSuite) TestCombine_Sum() {
+	expr := &NumCombineExpr{mode: ModeSum}
 	result := expr.combine([]float64{1.0, 2.0, 3.0}, nil)
 	s.InDelta(6.0, result, 0.001) // 1+2+3 = 6
 }
 
-func (s *ScoreCombineExprTestSuite) TestCombine_Max() {
-	expr := &ScoreCombineExpr{mode: ModeMax}
+func (s *NumCombineExprTestSuite) TestCombine_Max() {
+	expr := &NumCombineExpr{mode: ModeMax}
 	result := expr.combine([]float64{1.0, 5.0, 3.0}, nil)
 	s.InDelta(5.0, result, 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestCombine_Min() {
-	expr := &ScoreCombineExpr{mode: ModeMin}
+func (s *NumCombineExprTestSuite) TestCombine_Min() {
+	expr := &NumCombineExpr{mode: ModeMin}
 	result := expr.combine([]float64{1.0, 5.0, 3.0}, nil)
 	s.InDelta(1.0, result, 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestCombine_Avg() {
-	expr := &ScoreCombineExpr{mode: ModeAvg}
+func (s *NumCombineExprTestSuite) TestCombine_Avg() {
+	expr := &NumCombineExpr{mode: ModeAvg}
 	result := expr.combine([]float64{2.0, 4.0, 6.0}, nil)
 	s.InDelta(4.0, result, 0.001) // (2+4+6)/3 = 4
 }
 
-func (s *ScoreCombineExprTestSuite) TestCombine_Weighted() {
-	expr := &ScoreCombineExpr{mode: ModeWeighted}
+func (s *NumCombineExprTestSuite) TestCombine_Weighted() {
+	expr := &NumCombineExpr{
+		mode:    ModeWeighted,
+		weights: []float64{0.5, 0.3, 0.2},
+	}
 	result := expr.combine([]float64{10.0, 20.0, 30.0}, []float64{0.5, 0.3, 0.2})
 	// 10*0.5 + 20*0.3 + 30*0.2 = 5 + 6 + 6 = 17
 	s.InDelta(17.0, result, 0.001)
 }
 
-// =============================================================================
-// Helper Function Tests (base_expr utilities)
-// =============================================================================
-
-func (s *ScoreCombineExprTestSuite) TestParseStringSliceParam() {
-	const funcName = "test"
-
-	// Test with []string
-	params := map[string]interface{}{
-		"cols": []string{"a", "b", "c"},
-	}
-	result, err := ParseStringSliceParam(params, funcName, "cols")
-	s.Require().NoError(err)
-	s.Equal([]string{"a", "b", "c"}, result)
-
-	// Test with []interface{}
-	params = map[string]interface{}{
-		"cols": []interface{}{"a", "b", "c"},
-	}
-	result, err = ParseStringSliceParam(params, funcName, "cols")
-	s.Require().NoError(err)
-	s.Equal([]string{"a", "b", "c"}, result)
-
-	// Test missing key
-	_, err = ParseStringSliceParam(map[string]interface{}{}, funcName, "cols")
-	s.Error(err)
-	s.Contains(err.Error(), "missing required parameter")
-}
-
-func (s *ScoreCombineExprTestSuite) TestParseFloat64SliceParam() {
-	const funcName = "test"
-
-	// Test with []float64
-	params := map[string]interface{}{
-		"weights": []float64{0.5, 0.3, 0.2},
-	}
-	result, err := ParseFloat64SliceParam(params, funcName, "weights")
-	s.Require().NoError(err)
-	s.Equal([]float64{0.5, 0.3, 0.2}, result)
-
-	// Test with []interface{}
-	params = map[string]interface{}{
-		"weights": []interface{}{0.5, 0.3, 0.2},
-	}
-	result, err = ParseFloat64SliceParam(params, funcName, "weights")
-	s.Require().NoError(err)
-	s.Equal([]float64{0.5, 0.3, 0.2}, result)
-
-	// Test missing key (should return nil, not error)
-	result, err = ParseFloat64SliceParam(map[string]interface{}{}, funcName, "weights")
-	s.NoError(err)
-	s.Nil(result)
-}
-
-func (s *ScoreCombineExprTestSuite) TestGetNumericValue() {
+func (s *NumCombineExprTestSuite) TestGetNumericValue() {
 	// Test Float32
 	builder32 := array.NewFloat32Builder(s.pool)
 	builder32.Append(1.5)
@@ -720,28 +670,28 @@ func (s *ScoreCombineExprTestSuite) TestGetNumericValue() {
 	s.InDelta(100.0, val, 0.001)
 }
 
-func (s *ScoreCombineExprTestSuite) TestNewScoreCombineExprFromParams_Invalid() {
-	_, err := NewScoreCombineExprFromParams(map[string]interface{}{
-		"mode": "bad-mode",
-	})
+func (s *NumCombineExprTestSuite) TestNewNumCombineExprFromParams_Invalid() {
+	_, err := NewNumCombineExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{
+		"mode": stringParam("bad-mode"),
+	}})
 	s.Error(err)
 	s.Contains(err.Error(), "invalid mode")
 
-	_, err = NewScoreCombineExprFromParams(map[string]interface{}{
-		"mode":    "weighted",
-		"weights": []interface{}{"bad"},
-	})
+	_, err = NewNumCombineExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{
+		"mode":    stringParam("weighted"),
+		"weights": arrayParam(stringParam("bad")),
+	}})
 	s.Error(err)
 	s.Contains(err.Error(), "weights")
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_SkipsNullInputsWeighted() {
+func (s *NumCombineExprTestSuite) TestExecute_SkipsNullInputsWeighted() {
 	col1 := s.createNullableFloat32ChunkedArray([]float32{10.0, 0.0, 0.0}, []bool{true, false, false})
 	defer col1.Release()
 	col2 := s.createNullableFloat32ChunkedArray([]float32{20.0, 20.0, 0.0}, []bool{true, true, false})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeWeighted, []float64{0.8, 0.2}, WithNullPolicy(ScoreCombineNullSkip))
+	expr, err := NewNumCombineExpr(ModeWeighted, []float64{0.8, 0.2}, WithNullPolicy(NumCombineNullSkip))
 	s.Require().NoError(err)
 
 	ctx := types.NewFuncContext(s.pool)
@@ -755,13 +705,13 @@ func (s *ScoreCombineExprTestSuite) TestExecute_SkipsNullInputsWeighted() {
 	s.True(result.IsNull(2))
 }
 
-func (s *ScoreCombineExprTestSuite) TestExecute_RejectsMismatchedChunksAndUnsupportedTypes() {
+func (s *NumCombineExprTestSuite) TestExecute_RejectsMismatchedChunksAndUnsupportedTypes() {
 	col1 := s.createFloat32ChunkedArray([]float32{1.0, 2.0})
 	defer col1.Release()
 	col2 := s.createMultiChunkFloat32Array([]float32{1.0}, []float32{2.0})
 	defer col2.Release()
 
-	expr, err := NewScoreCombineExpr(ModeSum, nil)
+	expr, err := NewNumCombineExpr(ModeSum, nil)
 	s.Require().NoError(err)
 	ctx := types.NewFuncContext(s.pool)
 
@@ -788,7 +738,7 @@ func (s *ScoreCombineExprTestSuite) TestExecute_RejectsMismatchedChunksAndUnsupp
 	s.Contains(err.Error(), "unsupported input column type")
 }
 
-func (s *ScoreCombineExprTestSuite) TestNewNumericReaderAllSupportedTypes() {
+func (s *NumCombineExprTestSuite) TestNewNumericReaderAllSupportedTypes() {
 	cases := []struct {
 		name string
 		arr  arrow.Array

--- a/internal/util/function/chain/expr/rerank_model_expr.go
+++ b/internal/util/function/chain/expr/rerank_model_expr.go
@@ -24,10 +24,15 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
+	"github.com/milvus-io/milvus/internal/util/function/models"
 	"github.com/milvus-io/milvus/internal/util/function/rerank"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
+
+const RerankModelFuncName = "rerank_model"
 
 // RerankModelExpr implements FunctionExpr for model-based reranking.
 // It takes a text column as input, calls an external rerank service per-chunk (per-NQ),
@@ -47,16 +52,59 @@ type RerankModelExpr struct {
 // NewRerankModelExpr creates a new RerankModelExpr with the given provider and queries.
 func NewRerankModelExpr(provider rerank.ModelProvider, queries []string) (*RerankModelExpr, error) {
 	if provider == nil {
-		return nil, merr.WrapErrServiceInternal("model: provider is nil")
+		return nil, merr.WrapErrServiceInternal("rerank_model: provider is nil")
 	}
 	if len(queries) == 0 {
-		return nil, merr.WrapErrParameterMissingMsg("model: queries must not be empty")
+		return nil, merr.WrapErrParameterMissingMsg("rerank_model: queries must not be empty")
 	}
 	return &RerankModelExpr{
-		BaseExpr: *NewBaseExpr("model", []string{types.StageL2Rerank}),
+		BaseExpr: *NewBaseExpr(RerankModelFuncName, []string{types.StageL2Rerank}),
 		provider: provider,
 		queries:  queries,
 	}, nil
+}
+
+func NewRerankModelExprFromParams(ctx types.FunctionBuildContext, cfg types.FunctionConfig) (types.FunctionExpr, error) {
+	reader := types.NewParamReader(RerankModelFuncName, cfg.Params)
+
+	queries, err := reader.StringSlice("queries", true)
+	if err != nil {
+		return nil, err
+	}
+
+	extraInfo := ctx.ModelExtraInfo
+	if extraInfo == nil {
+		extraInfo = &models.ModelExtraInfo{}
+	}
+
+	providerParams, err := modelProviderParams(cfg.Params)
+	if err != nil {
+		return nil, err
+	}
+	provider, err := rerank.NewModelProvider(providerParams, extraInfo)
+	if err != nil {
+		return nil, err
+	}
+	return NewRerankModelExpr(provider, queries)
+}
+
+func modelProviderParams(params map[string]*schemapb.FunctionParamValue) ([]*commonpb.KeyValuePair, error) {
+	reader := types.NewParamReader(RerankModelFuncName, params)
+	result := make([]*commonpb.KeyValuePair, 0, len(params))
+	for key, value := range params {
+		// queries is consumed by RerankModelExpr. Legacy model providers ignore
+		// unknown params, but queries is a typed array and cannot be represented
+		// as a scalar KeyValuePair.
+		if key == "queries" {
+			continue
+		}
+		strValue, err := reader.ParamValueToString(key, value)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, &commonpb.KeyValuePair{Key: key, Value: strValue})
+	}
+	return result, nil
 }
 
 // OutputDataTypes returns the data types of output columns.
@@ -68,14 +116,14 @@ func (m *RerankModelExpr) OutputDataTypes() []arrow.DataType {
 // Execute calls the external rerank service for each chunk (NQ) and returns model scores.
 func (m *RerankModelExpr) Execute(ctx *types.FuncContext, inputs []*arrow.Chunked) ([]*arrow.Chunked, error) {
 	if len(inputs) != 1 {
-		return nil, merr.WrapErrServiceInternalMsg("model: expected 1 input column (text), got %d", len(inputs))
+		return nil, merr.WrapErrServiceInternalMsg("rerank_model: expected 1 input column (text), got %d", len(inputs))
 	}
 
 	textCol := inputs[0]
 	numChunks := len(textCol.Chunks())
 
 	if len(m.queries) != numChunks {
-		return nil, merr.WrapErrServiceInternalMsg("model: queries count (%d) != nq count (%d)", len(m.queries), numChunks)
+		return nil, merr.WrapErrParameterInvalidMsg("rerank_model: queries count (%d) != nq count (%d)", len(m.queries), numChunks)
 	}
 
 	scoreChunks := make([]arrow.Array, numChunks)
@@ -106,7 +154,7 @@ func (m *RerankModelExpr) Execute(ctx *types.FuncContext, inputs []*arrow.Chunke
 func (m *RerankModelExpr) processChunk(ctx *types.FuncContext, chunk arrow.Array, query string) (arrow.Array, error) {
 	stringArr, ok := chunk.(*array.String)
 	if !ok {
-		return nil, merr.WrapErrServiceInternalMsg("model: input column must be String/VarChar, got %T", chunk)
+		return nil, merr.WrapErrServiceInternalMsg("rerank_model: input column must be String/VarChar, got %T", chunk)
 	}
 
 	n := stringArr.Len()
@@ -158,10 +206,14 @@ func (m *RerankModelExpr) rerankBatch(ctx context.Context, query string, texts [
 			return nil, err
 		}
 		if len(batchScores) != end-i {
-			return nil, merr.WrapErrServiceInternalMsg("model: rerank service returned %d scores for %d docs", len(batchScores), end-i)
+			return nil, merr.WrapErrServiceInternalMsg("rerank_model: rerank service returned %d scores for %d docs", len(batchScores), end-i)
 		}
 		scores = append(scores, batchScores...)
 	}
 
 	return scores, nil
+}
+
+func init() {
+	types.MustRegisterFunction(RerankModelFuncName, NewRerankModelExprFromParams)
 }

--- a/internal/util/function/chain/expr/rerank_model_expr_test.go
+++ b/internal/util/function/chain/expr/rerank_model_expr_test.go
@@ -21,6 +21,8 @@ package expr
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -28,7 +30,10 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 // =============================================================================
@@ -136,7 +141,7 @@ func (s *RerankModelExprTestSuite) TestNewRerankModelExpr_Valid() {
 	expr, err := NewRerankModelExpr(provider, []string{"query1", "query2"})
 	s.Require().NoError(err)
 	s.NotNil(expr)
-	s.Equal("model", expr.Name())
+	s.Equal(RerankModelFuncName, expr.Name())
 }
 
 func (s *RerankModelExprTestSuite) TestNewRerankModelExpr_NilProvider() {
@@ -157,6 +162,62 @@ func (s *RerankModelExprTestSuite) TestNewRerankModelExpr_NilQueries() {
 	_, err := NewRerankModelExpr(provider, nil)
 	s.Error(err)
 	s.Contains(err.Error(), "queries must not be empty")
+}
+
+func (s *RerankModelExprTestSuite) TestNewRerankModelExprFromParams() {
+	paramtable.Init()
+	paramtable.Get().FunctionCfg.RerankModelProviders.GetFunc = func() map[string]string {
+		return map[string]string{}
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results": [{"index": 0, "relevance_score": 0.1}]}`))
+	}))
+	defer ts.Close()
+
+	fn, err := NewRerankModelExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{
+		"provider": stringParam("vllm"),
+		"endpoint": stringParam(ts.URL),
+		"queries":  arrayParam(stringParam("query")),
+	}})
+	s.Require().NoError(err)
+	s.Equal(RerankModelFuncName, fn.Name())
+
+	_, err = NewRerankModelExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{
+		"provider": stringParam("vllm"),
+		"endpoint": stringParam(ts.URL),
+	}})
+	s.ErrorContains(err, "missing required parameter")
+
+	_, err = NewRerankModelExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{
+		"provider": stringParam("vllm"),
+		"endpoint": stringParam(ts.URL),
+		"queries":  arrayParam(stringParam("query")),
+		"invalid":  arrayParam(stringParam("value")),
+	}})
+	s.ErrorContains(err, "must be scalar")
+}
+
+func (s *RerankModelExprTestSuite) TestModelProviderParamsSkipsQueries() {
+	params, err := modelProviderParams(map[string]*schemapb.FunctionParamValue{
+		"provider": stringParam("vllm"),
+		"enabled":  boolParam(true),
+		"batch":    intParam(8),
+		"ratio":    doubleParam(0.5),
+		"queries":  arrayParam(stringParam("query")),
+	})
+	s.Require().NoError(err)
+
+	values := make(map[string]string, len(params))
+	for _, param := range params {
+		values[param.Key] = param.Value
+	}
+	s.Equal("vllm", values["provider"])
+	s.Equal("true", values["enabled"])
+	s.Equal("8", values["batch"])
+	s.Equal("0.5", values["ratio"])
+	s.NotContains(values, "queries")
 }
 
 // =============================================================================
@@ -380,6 +441,7 @@ func (s *RerankModelExprTestSuite) TestExecute_QueryCountMismatch() {
 	ctx := types.NewFuncContext(s.pool)
 	_, err = expr.Execute(ctx, []*arrow.Chunked{textCol})
 	s.Error(err)
+	s.ErrorIs(err, merr.ErrParameterInvalid)
 	s.Contains(err.Error(), "queries count")
 }
 

--- a/internal/util/function/chain/expr/round_decimal_expr.go
+++ b/internal/util/function/chain/expr/round_decimal_expr.go
@@ -35,10 +35,6 @@ const RoundDecimalFuncName = "round_decimal"
 //
 // Input:  1 column ($score, Float32)
 // Output: 1 column ($score, Float32, rounded)
-//
-// Note: Not registered in the function registry because it requires a specific
-// decimal parameter that is set programmatically from SearchParams.RoundDecimal
-// in rerank_builder.go, not from user-facing function configuration.
 type RoundDecimalExpr struct {
 	BaseExpr
 	decimal    int64
@@ -56,6 +52,15 @@ func NewRoundDecimalExpr(decimal int64) (*RoundDecimalExpr, error) {
 		decimal:    decimal,
 		multiplier: math.Pow(10.0, float64(decimal)),
 	}, nil
+}
+
+func NewRoundDecimalExprFromParams(_ types.FunctionBuildContext, cfg types.FunctionConfig) (types.FunctionExpr, error) {
+	reader := types.NewParamReader(RoundDecimalFuncName, cfg.Params)
+	decimal, err := reader.Int64("decimal", true, 0)
+	if err != nil {
+		return nil, err
+	}
+	return NewRoundDecimalExpr(decimal)
 }
 
 func (e *RoundDecimalExpr) OutputDataTypes() []arrow.DataType {
@@ -77,7 +82,7 @@ func (e *RoundDecimalExpr) Execute(ctx *types.FuncContext, inputs []*arrow.Chunk
 			for i := 0; i < chunkIdx; i++ {
 				newChunks[i].Release()
 			}
-			return nil, merr.WrapErrServiceInternalMsg("round_decimal: input chunk %d must be Float32, got %T", chunkIdx, scoreCol.Chunk(chunkIdx))
+			return nil, merr.WrapErrParameterInvalidMsg("round_decimal: input chunk %d must be Float32, got %T", chunkIdx, scoreCol.Chunk(chunkIdx))
 		}
 
 		builder := array.NewFloat32Builder(ctx.Pool())
@@ -100,4 +105,8 @@ func (e *RoundDecimalExpr) Execute(ctx *types.FuncContext, inputs []*arrow.Chunk
 	}
 
 	return []*arrow.Chunked{result}, nil
+}
+
+func init() {
+	types.MustRegisterFunction(RoundDecimalFuncName, NewRoundDecimalExprFromParams)
 }

--- a/internal/util/function/chain/expr/round_decimal_expr_test.go
+++ b/internal/util/function/chain/expr/round_decimal_expr_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
 )
 
@@ -72,6 +73,21 @@ func (s *RoundDecimalExprTestSuite) TestNewRoundDecimalExpr_InvalidDecimals() {
 
 	_, err = NewRoundDecimalExpr(7)
 	s.Error(err)
+}
+
+func (s *RoundDecimalExprTestSuite) TestNewRoundDecimalExprFromParams() {
+	expr, err := NewRoundDecimalExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{"decimal": intParam(2)}})
+	s.Require().NoError(err)
+	s.Equal(RoundDecimalFuncName, expr.Name())
+
+	_, err = NewRoundDecimalExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{}})
+	s.ErrorContains(err, "missing required parameter")
+
+	_, err = NewRoundDecimalExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{"decimal": doubleParam(1.5)}})
+	s.ErrorContains(err, "must be an integer")
+
+	_, err = NewRoundDecimalExprFromParams(types.FunctionBuildContext{}, types.FunctionConfig{Params: map[string]*schemapb.FunctionParamValue{"decimal": intParam(7)}})
+	s.ErrorContains(err, "decimal must be in range")
 }
 
 func (s *RoundDecimalExprTestSuite) TestExecute_RoundTo2Decimals() {

--- a/internal/util/function/chain/operator_filter.go
+++ b/internal/util/function/chain/operator_filter.go
@@ -174,10 +174,14 @@ func filterArray(pool memory.Allocator, data arrow.Array, mask *array.Boolean) (
 
 // NewFilterOpFromRepr creates a FilterOp from an OperatorRepr.
 func NewFilterOpFromRepr(repr *OperatorRepr) (Operator, error) {
+	return NewFilterOpFromReprWithContext(repr, types.FunctionBuildContext{})
+}
+
+func NewFilterOpFromReprWithContext(repr *OperatorRepr, buildCtx types.FunctionBuildContext) (Operator, error) {
 	if repr.Function == nil {
 		return nil, merr.WrapErrParameterMissingMsg("filter_op: function is required")
 	}
-	fn, err := FunctionFromRepr(repr.Function)
+	fn, err := FunctionFromReprWithContext(repr.Function, buildCtx)
 	if err != nil {
 		return nil, merr.WrapErrParameterInvalidMsg("filter function: %v", err)
 	}

--- a/internal/util/function/chain/operator_group_by.go
+++ b/internal/util/function/chain/operator_group_by.go
@@ -455,40 +455,45 @@ func (o *GroupByOp) computeGroupScore(g *group) {
 
 // NewGroupByOpFromRepr creates a GroupByOp from an OperatorRepr.
 func NewGroupByOpFromRepr(repr *OperatorRepr) (Operator, error) {
-	field, ok := repr.Params["field"].(string)
-	if !ok || field == "" {
+	reader := types.NewParamReader("group_by_op", repr.Params)
+	field, err := reader.String("field", true)
+	if err != nil {
+		return nil, err
+	}
+	if field == "" {
 		return nil, merr.WrapErrParameterMissingMsg("group_by_op: field is required")
 	}
 
-	groupSize, err := getInt64Param(repr.Params, "group_size")
+	groupSize, err := reader.Int64("group_size", true, 0)
 	if err != nil {
-		return nil, merr.Wrap(err, "group_by_op")
+		return nil, err
 	}
 	if groupSize <= 0 {
 		return nil, merr.WrapErrParameterInvalidMsg("group_by_op: group_size must be positive")
 	}
 
-	limit, err := getInt64Param(repr.Params, "limit")
+	limit, err := reader.Int64("limit", true, 0)
 	if err != nil {
-		return nil, merr.Wrap(err, "group_by_op")
+		return nil, err
 	}
 	if limit <= 0 {
 		return nil, merr.WrapErrParameterInvalidMsg("group_by_op: limit must be positive")
 	}
 
-	offset := int64(0)
-	if _, ok := repr.Params["offset"]; ok {
-		offset, err = getInt64Param(repr.Params, "offset")
-		if err != nil {
-			return nil, merr.Wrap(err, "group_by_op")
-		}
-		if offset < 0 {
-			return nil, merr.WrapErrParameterInvalidMsg("group_by_op: offset must be non-negative")
-		}
+	offset, err := reader.Int64("offset", false, 0)
+	if err != nil {
+		return nil, err
+	}
+	if offset < 0 {
+		return nil, merr.WrapErrParameterInvalidMsg("group_by_op: offset must be non-negative")
 	}
 
 	scorer := GroupScorerMax
-	if scorerStr, ok := repr.Params["scorer"].(string); ok {
+	scorerStr, err := reader.String("scorer", false)
+	if err != nil {
+		return nil, err
+	}
+	if scorerStr != "" {
 		scorer = GroupScorer(scorerStr)
 		if err := ValidateGroupScorer(scorer); err != nil {
 			return nil, merr.Wrap(err, "group_by_op")
@@ -496,24 +501,6 @@ func NewGroupByOpFromRepr(repr *OperatorRepr) (Operator, error) {
 	}
 
 	return NewGroupByOpWithScorer(field, groupSize, limit, offset, scorer), nil
-}
-
-// getInt64Param extracts an int64 parameter from a map.
-func getInt64Param(params map[string]interface{}, key string) (int64, error) {
-	val, ok := params[key]
-	if !ok {
-		return 0, merr.WrapErrParameterMissingMsg("%s is required", key)
-	}
-	switch v := val.(type) {
-	case int64:
-		return v, nil
-	case int:
-		return int64(v), nil
-	case float64:
-		return int64(v), nil
-	default:
-		return 0, merr.WrapErrParameterInvalidMsg("%s must be a number", key)
-	}
 }
 
 // compareValues compares two values for tiebreaking.

--- a/internal/util/function/chain/operator_group_by_test.go
+++ b/internal/util/function/chain/operator_group_by_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
 )
 
@@ -569,11 +570,11 @@ func (s *GroupByOpTestSuite) TestFuncChain_GroupBy_InvalidParams() {
 func (s *GroupByOpTestSuite) TestNewGroupByOpFromRepr() {
 	repr := &OperatorRepr{
 		Type: types.OpTypeGroupBy,
-		Params: map[string]interface{}{
-			"field":      "category",
-			"group_size": int64(3),
-			"limit":      int64(10),
-			"offset":     int64(5),
+		Params: map[string]*schemapb.FunctionParamValue{
+			"field":      stringParam("category"),
+			"group_size": intParam(3),
+			"limit":      intParam(10),
+			"offset":     intParam(5),
 		},
 	}
 
@@ -591,10 +592,10 @@ func (s *GroupByOpTestSuite) TestNewGroupByOpFromRepr() {
 func (s *GroupByOpTestSuite) TestNewGroupByOpFromRepr_DefaultOffset() {
 	repr := &OperatorRepr{
 		Type: types.OpTypeGroupBy,
-		Params: map[string]interface{}{
-			"field":      "category",
-			"group_size": int64(3),
-			"limit":      int64(10),
+		Params: map[string]*schemapb.FunctionParamValue{
+			"field":      stringParam("category"),
+			"group_size": intParam(3),
+			"limit":      intParam(10),
 		},
 	}
 
@@ -649,7 +650,7 @@ func (s *GroupByOpTestSuite) TestGroupByOp_WithSort() {
 	result, err := NewFuncChainWithAllocator(s.pool).
 		SetStage(types.StageL2Rerank).
 		GroupBy("category", 2, 3, 0).
-		Sort(GroupScoreFieldName, true).
+		Sort(GroupScoreFieldName, true, types.IDFieldName).
 		Execute(df)
 
 	s.Require().NoError(err)
@@ -846,11 +847,11 @@ func (s *GroupByOpTestSuite) TestNewGroupByOpFromRepr_WithScorer() {
 	// Test max scorer
 	repr := &OperatorRepr{
 		Type: types.OpTypeGroupBy,
-		Params: map[string]interface{}{
-			"field":      "category",
-			"group_size": int64(3),
-			"limit":      int64(10),
-			"scorer":     "max",
+		Params: map[string]*schemapb.FunctionParamValue{
+			"field":      stringParam("category"),
+			"group_size": intParam(3),
+			"limit":      intParam(10),
+			"scorer":     stringParam("max"),
 		},
 	}
 	op, err := NewGroupByOpFromRepr(repr)
@@ -858,19 +859,19 @@ func (s *GroupByOpTestSuite) TestNewGroupByOpFromRepr_WithScorer() {
 	s.Equal(GroupScorerMax, op.(*GroupByOp).groupScorer)
 
 	// Test sum scorer
-	repr.Params["scorer"] = "sum"
+	repr.Params["scorer"] = stringParam("sum")
 	op, err = NewGroupByOpFromRepr(repr)
 	s.Require().NoError(err)
 	s.Equal(GroupScorerSum, op.(*GroupByOp).groupScorer)
 
 	// Test avg scorer
-	repr.Params["scorer"] = "avg"
+	repr.Params["scorer"] = stringParam("avg")
 	op, err = NewGroupByOpFromRepr(repr)
 	s.Require().NoError(err)
 	s.Equal(GroupScorerAvg, op.(*GroupByOp).groupScorer)
 
 	// Test invalid scorer
-	repr.Params["scorer"] = "invalid"
+	repr.Params["scorer"] = stringParam("invalid")
 	_, err = NewGroupByOpFromRepr(repr)
 	s.Error(err)
 	s.Contains(err.Error(), "invalid group scorer")

--- a/internal/util/function/chain/operator_limit.go
+++ b/internal/util/function/chain/operator_limit.go
@@ -107,34 +107,17 @@ func (o *LimitOp) String() string {
 
 // NewLimitOpFromRepr creates a LimitOp from an OperatorRepr.
 func NewLimitOpFromRepr(repr *OperatorRepr) (Operator, error) {
-	limitVal, ok := repr.Params["limit"]
-	if !ok {
-		return nil, merr.WrapErrParameterMissingMsg("limit_op: limit is required")
-	}
-	var limit int64
-	switch v := limitVal.(type) {
-	case int64:
-		limit = v
-	case int:
-		limit = int64(v)
-	case float64:
-		limit = int64(v)
-	default:
-		return nil, merr.WrapErrParameterInvalidMsg("limit_op: limit must be a number")
+	reader := types.NewParamReader("limit_op", repr.Params)
+	limit, err := reader.Int64("limit", true, 0)
+	if err != nil {
+		return nil, err
 	}
 	if limit <= 0 {
 		return nil, merr.WrapErrParameterInvalidMsg("limit_op: limit must be positive")
 	}
-	offset := int64(0)
-	if offsetVal, ok := repr.Params["offset"]; ok {
-		switch v := offsetVal.(type) {
-		case int64:
-			offset = v
-		case int:
-			offset = int64(v)
-		case float64:
-			offset = int64(v)
-		}
+	offset, err := reader.Int64("offset", false, 0)
+	if err != nil {
+		return nil, err
 	}
 	if offset < 0 {
 		return nil, merr.WrapErrParameterInvalidMsg("limit_op: offset must be non-negative")

--- a/internal/util/function/chain/operator_limit_test.go
+++ b/internal/util/function/chain/operator_limit_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
 )
 
@@ -175,7 +176,7 @@ func (s *LimitOpTestSuite) TestLimitEmptyChunk() {
 func (s *LimitOpTestSuite) TestLimitNegativeOffset() {
 	repr := &OperatorRepr{
 		Type:   "limit",
-		Params: map[string]interface{}{"limit": int64(10), "offset": int64(-1)},
+		Params: map[string]*schemapb.FunctionParamValue{"limit": intParam(10), "offset": intParam(-1)},
 	}
 	_, err := NewLimitOpFromRepr(repr)
 	s.Require().Error(err)

--- a/internal/util/function/chain/operator_map.go
+++ b/internal/util/function/chain/operator_map.go
@@ -145,10 +145,14 @@ func (o *MapOp) String() string {
 
 // NewMapOpFromRepr creates a MapOp from an OperatorRepr.
 func NewMapOpFromRepr(repr *OperatorRepr) (Operator, error) {
+	return NewMapOpFromReprWithContext(repr, types.FunctionBuildContext{})
+}
+
+func NewMapOpFromReprWithContext(repr *OperatorRepr, buildCtx types.FunctionBuildContext) (Operator, error) {
 	if repr.Function == nil {
 		return nil, merr.WrapErrParameterInvalidMsg("map operator requires function")
 	}
-	fn, err := FunctionFromRepr(repr.Function)
+	fn, err := FunctionFromReprWithContext(repr.Function, buildCtx)
 	if err != nil {
 		return nil, merr.WrapErrParameterInvalidMsg("map function: %v", err)
 	}

--- a/internal/util/function/chain/operator_map_test.go
+++ b/internal/util/function/chain/operator_map_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
 )
 
@@ -317,7 +318,7 @@ func (s *MapOpTestSuite) TestNewMapOpFromReprNilFunction() {
 func (s *MapOpTestSuite) TestNewMapOpFromReprNoInputs() {
 	repr := &OperatorRepr{
 		Type:     types.OpTypeMap,
-		Function: &FunctionRepr{Name: "score_combine", Params: map[string]interface{}{}},
+		Function: &FunctionRepr{Name: "num_combine", Params: map[string]*schemapb.FunctionParamValue{}},
 		Outputs:  []string{"out"},
 	}
 	_, err := NewMapOpFromRepr(repr)
@@ -328,7 +329,7 @@ func (s *MapOpTestSuite) TestNewMapOpFromReprNoInputs() {
 func (s *MapOpTestSuite) TestNewMapOpFromReprNoOutputs() {
 	repr := &OperatorRepr{
 		Type:     types.OpTypeMap,
-		Function: &FunctionRepr{Name: "score_combine", Params: map[string]interface{}{}},
+		Function: &FunctionRepr{Name: "num_combine", Params: map[string]*schemapb.FunctionParamValue{}},
 		Inputs:   []string{"in"},
 	}
 	_, err := NewMapOpFromRepr(repr)

--- a/internal/util/function/chain/operator_merge.go
+++ b/internal/util/function/chain/operator_merge.go
@@ -215,11 +215,11 @@ func (op *MergeOp) ExecuteMulti(ctx *types.FuncContext, inputs []*DataFrame) (*D
 	case MergeStrategyWeighted:
 		return op.mergeWeighted(ctx, inputs)
 	case MergeStrategyMax:
-		return op.mergeScoreCombine(ctx, inputs, maxMergeFunc)
+		return op.mergeNumCombine(ctx, inputs, maxMergeFunc)
 	case MergeStrategySum:
-		return op.mergeScoreCombine(ctx, inputs, sumMergeFunc)
+		return op.mergeNumCombine(ctx, inputs, sumMergeFunc)
 	case MergeStrategyAvg:
-		return op.mergeScoreCombine(ctx, inputs, avgMergeFunc)
+		return op.mergeNumCombine(ctx, inputs, avgMergeFunc)
 	default:
 		return nil, merr.WrapErrServiceInternalMsg("merge_op: unsupported strategy %s", op.strategy)
 	}
@@ -418,8 +418,8 @@ func avgMergeFunc(existing, new float32, count int) (float32, int) {
 	return existing + new, count + 1
 }
 
-// mergeScoreCombine implements max/sum/avg score merge.
-func (op *MergeOp) mergeScoreCombine(ctx *types.FuncContext, inputs []*DataFrame, mergeFunc scoreMergeFunc) (*DataFrame, error) {
+// mergeNumCombine implements max/sum/avg score merge.
+func (op *MergeOp) mergeNumCombine(ctx *types.FuncContext, inputs []*DataFrame, mergeFunc scoreMergeFunc) (*DataFrame, error) {
 	return op.mergeWithScoreCollector(ctx, inputs, func(inputs []*DataFrame, chunkIdx int) (map[any]float32, map[any]idLocation, error) {
 		idScores, idCounts, idLocs, err := op.collectCombinedScores(inputs, chunkIdx, mergeFunc)
 		if err != nil {

--- a/internal/util/function/chain/operator_merge_test.go
+++ b/internal/util/function/chain/operator_merge_test.go
@@ -1131,7 +1131,7 @@ func (s *MergeHelperTestSuite) TestSingleInputWeightedScoreNotFloat32() {
 }
 
 // =============================================================================
-// mergeScoreCombine Tests (max/sum/avg with actual DataFrames)
+// mergeNumCombine Tests (max/sum/avg with actual DataFrames)
 // =============================================================================
 
 func (s *MergeHelperTestSuite) TestMergeMaxStrategy() {
@@ -1214,7 +1214,7 @@ func (s *MergeHelperTestSuite) TestMergeAvgStrategy() {
 	s.InDelta(0.9, float64(idScoreMap[3]), 1e-6)
 }
 
-func (s *MergeHelperTestSuite) TestMergeScoreCombineMissingIDColumn() {
+func (s *MergeHelperTestSuite) TestMergeNumCombineMissingIDColumn() {
 	// Create DF without ID column
 	builder := NewDataFrameBuilder()
 	builder.SetChunkSizes([]int64{1})
@@ -1238,7 +1238,7 @@ func (s *MergeHelperTestSuite) TestMergeScoreCombineMissingIDColumn() {
 	s.Contains(err.Error(), "missing ID or score column")
 }
 
-func (s *MergeHelperTestSuite) TestMergeScoreCombineMissingScoreColumn() {
+func (s *MergeHelperTestSuite) TestMergeNumCombineMissingScoreColumn() {
 	// Create DF without score column
 	builder := NewDataFrameBuilder()
 	builder.SetChunkSizes([]int64{1})
@@ -1262,7 +1262,7 @@ func (s *MergeHelperTestSuite) TestMergeScoreCombineMissingScoreColumn() {
 	s.Contains(err.Error(), "missing ID or score column")
 }
 
-func (s *MergeHelperTestSuite) TestMergeScoreCombineScoreNotFloat32() {
+func (s *MergeHelperTestSuite) TestMergeNumCombineScoreNotFloat32() {
 	// Create DF with int64 score column
 	builder := NewDataFrameBuilder()
 	builder.SetChunkSizes([]int64{1})
@@ -1292,7 +1292,7 @@ func (s *MergeHelperTestSuite) TestMergeScoreCombineScoreNotFloat32() {
 	s.Contains(err.Error(), "not Float32")
 }
 
-func (s *MergeHelperTestSuite) TestMergeScoreCombineWithNormalization() {
+func (s *MergeHelperTestSuite) TestMergeNumCombineWithNormalization() {
 	df1 := s.createDF([]int64{1, 2}, []float32{0.5, 0.8}, []int64{2})
 	df2 := s.createDF([]int64{1, 3}, []float32{0.3, 0.9}, []int64{2})
 	defer df1.Release()
@@ -1308,7 +1308,7 @@ func (s *MergeHelperTestSuite) TestMergeScoreCombineWithNormalization() {
 	s.Equal(int64(3), result.NumRows())
 }
 
-func (s *MergeHelperTestSuite) TestMergeScoreCombineWithMixedMetricsNoNormalize() {
+func (s *MergeHelperTestSuite) TestMergeNumCombineWithMixedMetricsNoNormalize() {
 	df1 := s.createDF([]int64{1, 2}, []float32{0.5, 0.8}, []int64{2})
 	df2 := s.createDF([]int64{1, 3}, []float32{0.3, 0.9}, []int64{2})
 	defer df1.Release()

--- a/internal/util/function/chain/operator_select.go
+++ b/internal/util/function/chain/operator_select.go
@@ -87,28 +87,13 @@ func (o *SelectOp) String() string {
 
 // NewSelectOpFromRepr creates a SelectOp from an OperatorRepr.
 func NewSelectOpFromRepr(repr *OperatorRepr) (Operator, error) {
-	columnsInterface, ok := repr.Params["columns"]
-	if !ok {
-		return nil, merr.WrapErrParameterMissingMsg("select_op: columns is required")
-	}
-	columns, ok := columnsInterface.([]interface{})
-	if !ok {
-		// Try []string
-		if colsStr, ok := columnsInterface.([]string); ok {
-			return NewSelectOp(colsStr), nil
-		}
-		return nil, merr.WrapErrParameterInvalidMsg("select_op: columns must be a list")
+	reader := types.NewParamReader("select_op", repr.Params)
+	columns, err := reader.StringSlice("columns", false)
+	if err != nil {
+		return nil, err
 	}
 	if len(columns) == 0 {
 		return nil, merr.WrapErrParameterMissingMsg("select_op: columns is required")
 	}
-	colsStr := make([]string, len(columns))
-	for i, col := range columns {
-		if colStr, ok := col.(string); ok {
-			colsStr[i] = colStr
-		} else {
-			return nil, merr.WrapErrParameterInvalidMsg("select_op: column[%d] must be a string", i)
-		}
-	}
-	return NewSelectOp(colsStr), nil
+	return NewSelectOp(columns), nil
 }

--- a/internal/util/function/chain/operator_sort.go
+++ b/internal/util/function/chain/operator_sort.go
@@ -45,23 +45,19 @@ type SortOp struct {
 	tieBreakCol string // optional: column name for tie-breaking (ascending)
 }
 
-// NewSortOp creates a new SortOp with the given column and sort direction.
-func NewSortOp(column string, desc bool) *SortOp {
+func newSortOp(column string, desc bool, tieBreakCol string) *SortOp {
+	inputs := []string{column}
+	if tieBreakCol != "" && tieBreakCol != column {
+		inputs = append(inputs, tieBreakCol)
+	}
 	return &SortOp{
 		BaseOp: BaseOp{
-			inputs:  []string{column},
+			inputs:  inputs,
 			outputs: []string{}, // Sort doesn't produce new columns
 		},
-		desc: desc,
+		desc:        desc,
+		tieBreakCol: tieBreakCol,
 	}
-}
-
-// NewSortOpWithTieBreak creates a new SortOp that breaks ties using
-// the given column in ascending order.
-func NewSortOpWithTieBreak(column string, desc bool, tieBreakCol string) *SortOp {
-	op := NewSortOp(column, desc)
-	op.tieBreakCol = tieBreakCol
-	return op
 }
 
 // Column returns the sort column name.
@@ -288,22 +284,23 @@ func reorderArray(pool memory.Allocator, data arrow.Array, indices []int) (arrow
 
 // NewSortOpFromRepr creates a SortOp from an OperatorRepr.
 func NewSortOpFromRepr(repr *OperatorRepr) (Operator, error) {
-	column, ok := repr.Params["column"].(string)
-	if !ok || column == "" {
+	if len(repr.Inputs) == 0 {
 		return nil, merr.WrapErrParameterMissingMsg("sort_op: column is required")
 	}
-	desc := false
-	if descVal, ok := repr.Params["desc"]; ok {
-		if descBool, ok := descVal.(bool); ok {
-			desc = descBool
-		}
+	if len(repr.Inputs) > 2 {
+		return nil, merr.WrapErrParameterInvalidMsg("sort_op: expects at most 2 input columns, got %d", len(repr.Inputs))
 	}
-	tieBreakCol := ""
-	if tbVal, ok := repr.Params["tie_break_col"].(string); ok {
-		tieBreakCol = tbVal
+
+	reader := types.NewParamReader("sort_op", repr.Params)
+	desc, err := reader.Bool("desc", false, false)
+	if err != nil {
+		return nil, err
 	}
-	if tieBreakCol != "" {
-		return NewSortOpWithTieBreak(column, desc, tieBreakCol), nil
+
+	column := repr.Inputs[0]
+	tieBreakCol := types.IDFieldName
+	if len(repr.Inputs) > 1 {
+		tieBreakCol = repr.Inputs[1]
 	}
-	return NewSortOp(column, desc), nil
+	return newSortOp(column, desc, tieBreakCol), nil
 }

--- a/internal/util/function/chain/operator_sort_test.go
+++ b/internal/util/function/chain/operator_sort_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
 )
 
@@ -86,7 +87,7 @@ func (s *SortOpTestSuite) TestSortDescending() {
 	)
 	defer df.Release()
 
-	op := NewSortOp(types.ScoreFieldName, true)
+	op := newSortOp(types.ScoreFieldName, true, types.IDFieldName)
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	result, err := op.Execute(ctx, df)
 	s.Require().NoError(err)
@@ -110,7 +111,7 @@ func (s *SortOpTestSuite) TestSortAscending() {
 	)
 	defer df.Release()
 
-	op := NewSortOp(types.ScoreFieldName, false)
+	op := newSortOp(types.ScoreFieldName, false, types.IDFieldName)
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	result, err := op.Execute(ctx, df)
 	s.Require().NoError(err)
@@ -149,7 +150,7 @@ func (s *SortOpTestSuite) TestSortWithAllNullScores() {
 	df := builder.Build()
 	defer df.Release()
 
-	op := NewSortOp(types.ScoreFieldName, true)
+	op := newSortOp(types.ScoreFieldName, true, types.IDFieldName)
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	result, err := op.Execute(ctx, df)
 	s.Require().NoError(err)
@@ -193,7 +194,7 @@ func (s *SortOpTestSuite) TestSortNullsLastDescending() {
 	df := builder.Build()
 	defer df.Release()
 
-	op := NewSortOp(types.ScoreFieldName, true)
+	op := newSortOp(types.ScoreFieldName, true, types.IDFieldName)
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	result, err := op.Execute(ctx, df)
 	s.Require().NoError(err)
@@ -236,7 +237,7 @@ func (s *SortOpTestSuite) TestSortNullsLastAscending() {
 	df := builder.Build()
 	defer df.Release()
 
-	op := NewSortOp(types.ScoreFieldName, false)
+	op := newSortOp(types.ScoreFieldName, false, types.IDFieldName)
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	result, err := op.Execute(ctx, df)
 	s.Require().NoError(err)
@@ -259,7 +260,7 @@ func (s *SortOpTestSuite) TestSortMultiChunkIndependent() {
 	)
 	defer df.Release()
 
-	op := NewSortOp(types.ScoreFieldName, true)
+	op := newSortOp(types.ScoreFieldName, true, types.IDFieldName)
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	result, err := op.Execute(ctx, df)
 	s.Require().NoError(err)
@@ -282,7 +283,7 @@ func (s *SortOpTestSuite) TestSortColumnNotFound() {
 	df := s.createSortTestDF([]int64{1}, []float64{0.5}, []int64{1})
 	defer df.Release()
 
-	op := NewSortOp("nonexistent", true)
+	op := newSortOp("nonexistent", true, types.IDFieldName)
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	_, err := op.Execute(ctx, df)
 	s.Error(err)
@@ -309,13 +310,48 @@ func (s *SortOpTestSuite) TestSortEmptyChunk() {
 	df := builder.Build()
 	defer df.Release()
 
-	op := NewSortOp(types.ScoreFieldName, true)
+	op := newSortOp(types.ScoreFieldName, true, types.IDFieldName)
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	result, err := op.Execute(ctx, df)
 	s.Require().NoError(err)
 	defer result.Release()
 
 	s.Equal(int64(0), result.NumRows())
+}
+
+func (s *SortOpTestSuite) TestSortInputsIncludeTieBreak() {
+	op := newSortOp(types.ScoreFieldName, true, types.IDFieldName)
+	s.Equal([]string{types.ScoreFieldName, types.IDFieldName}, op.Inputs())
+	s.Empty(op.Outputs())
+}
+
+func (s *SortOpTestSuite) TestSortFromReprUsesInputsAndDefaultsTieBreak() {
+	op, err := NewSortOpFromRepr(&OperatorRepr{
+		Inputs: []string{types.ScoreFieldName},
+		Params: map[string]*schemapb.FunctionParamValue{
+			"desc": {Value: &schemapb.FunctionParamValue_BoolValue{BoolValue: true}},
+		},
+	})
+	s.Require().NoError(err)
+	s.Equal([]string{types.ScoreFieldName, types.IDFieldName}, op.Inputs())
+	s.Equal("Sort($score DESC, $id ASC)", op.String())
+
+	op, err = NewSortOpFromRepr(&OperatorRepr{
+		Inputs: []string{types.ScoreFieldName, "tie"},
+	})
+	s.Require().NoError(err)
+	s.Equal([]string{types.ScoreFieldName, "tie"}, op.Inputs())
+	s.Equal("Sort($score ASC, tie ASC)", op.String())
+}
+
+func (s *SortOpTestSuite) TestSortFromReprRejectsInvalidInputs() {
+	_, err := NewSortOpFromRepr(&OperatorRepr{})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "column is required")
+
+	_, err = NewSortOpFromRepr(&OperatorRepr{Inputs: []string{"score", "tie", "extra"}})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "expects at most 2 input columns")
 }
 
 func (s *SortOpTestSuite) TestSortTieBreakByID() {
@@ -329,7 +365,7 @@ func (s *SortOpTestSuite) TestSortTieBreakByID() {
 	)
 	defer df.Release()
 
-	op := NewSortOpWithTieBreak(types.ScoreFieldName, true, types.IDFieldName)
+	op := newSortOp(types.ScoreFieldName, true, types.IDFieldName)
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	result, err := op.Execute(ctx, df)
 	s.Require().NoError(err)
@@ -354,7 +390,7 @@ func (s *SortOpTestSuite) TestSortTieBreakPartialTies() {
 	)
 	defer df.Release()
 
-	op := NewSortOpWithTieBreak(types.ScoreFieldName, true, types.IDFieldName)
+	op := newSortOp(types.ScoreFieldName, true, types.IDFieldName)
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	result, err := op.Execute(ctx, df)
 	s.Require().NoError(err)
@@ -388,7 +424,7 @@ func (s *SortOpTestSuite) TestSortFastPathFloat32DescWithInt64TieBreak() {
 	df := builder.Build()
 	defer df.Release()
 
-	op := NewSortOpWithTieBreak(types.ScoreFieldName, true, types.IDFieldName)
+	op := newSortOp(types.ScoreFieldName, true, types.IDFieldName)
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	result, err := op.Execute(ctx, df)
 	s.Require().NoError(err)
@@ -426,7 +462,7 @@ func (s *SortOpTestSuite) TestSortIgnoresNonComparableTieBreakAndStringHelpers()
 	df := builder.Build()
 	defer df.Release()
 
-	op := NewSortOpWithTieBreak(types.ScoreFieldName, true, "bool_tie")
+	op := newSortOp(types.ScoreFieldName, true, "bool_tie")
 	s.Equal("Sort($score DESC, bool_tie ASC)", op.String())
 	ctx := types.NewFuncContextFull(context.TODO(), s.pool, "rerank")
 	result, err := op.Execute(ctx, df)

--- a/internal/util/function/chain/optimization_plan.go
+++ b/internal/util/function/chain/optimization_plan.go
@@ -1,0 +1,213 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package chain
+
+import "github.com/milvus-io/milvus/pkg/v3/util/merr"
+
+// ColumnSet is a small set helper for column names.
+type ColumnSet map[string]struct{}
+
+// NewColumnSet creates a ColumnSet from column names.
+func NewColumnSet(cols ...string) ColumnSet {
+	set := make(ColumnSet, len(cols))
+	for _, col := range cols {
+		set.Add(col)
+	}
+	return set
+}
+
+// Add adds a column name to the set.
+func (s ColumnSet) Add(col string) {
+	if col == "" {
+		return
+	}
+	s[col] = struct{}{}
+}
+
+// Remove removes a column name from the set.
+func (s ColumnSet) Remove(col string) {
+	delete(s, col)
+}
+
+// Contains reports whether the set contains a column name.
+func (s ColumnSet) Contains(col string) bool {
+	_, ok := s[col]
+	return ok
+}
+
+// Clone returns a copy of the set.
+func (s ColumnSet) Clone() ColumnSet {
+	clone := make(ColumnSet, len(s))
+	for col := range s {
+		clone[col] = struct{}{}
+	}
+	return clone
+}
+
+// RemoveSystemColumns removes function-chain system columns from the set.
+func (s ColumnSet) RemoveSystemColumns() {
+	for col := range s {
+		if IsFunctionChainSystemName(col) {
+			delete(s, col)
+		}
+	}
+}
+
+// DownstreamSpec describes non-system columns consumed after FuncChain execution.
+// It is the liveness root for optimization, not the final API response projection.
+type DownstreamSpec struct {
+	RequiredColumns []string
+}
+
+// SystemColumnPolicy controls how pruning treats function-chain system columns.
+type SystemColumnPolicy struct {
+	KeepAllSystemColumns bool
+}
+
+func normalizeSystemColumnPolicy(policy SystemColumnPolicy) SystemColumnPolicy {
+	// The current conservative default is to retain all existing system columns.
+	if !policy.KeepAllSystemColumns {
+		policy.KeepAllSystemColumns = true
+	}
+	return policy
+}
+
+// ExecuteOptions controls optional FuncChain execution optimizations.
+type ExecuteOptions struct {
+	EnableColumnPruning bool
+	EnableParallel      bool // reserved for future schedule support
+
+	Downstream         DownstreamSpec
+	SystemColumnPolicy SystemColumnPolicy
+}
+
+// LivenessInfo contains non-system column liveness for each operator.
+type LivenessInfo struct {
+	LiveBefore []ColumnSet
+	LiveAfter  []ColumnSet
+}
+
+// OptimizationPlan is non-executable metadata used by FuncChain.ExecuteWithOptions.
+type OptimizationPlan struct {
+	Liveness    *LivenessInfo
+	PruneBefore []ColumnSet
+	PruneAfter  []ColumnSet
+
+	SystemColumnPolicy SystemColumnPolicy
+}
+
+type functionChainPlanner struct {
+	operators []Operator
+	opts      ExecuteOptions
+}
+
+func (fc *FuncChain) buildOptimizationPlan(opts ExecuteOptions) (*OptimizationPlan, error) {
+	planner := functionChainPlanner{
+		operators: fc.operators,
+		opts:      opts,
+	}
+	return planner.Plan()
+}
+
+func (p functionChainPlanner) Plan() (*OptimizationPlan, error) {
+	if !p.opts.EnableColumnPruning && !p.opts.EnableParallel {
+		return nil, nil
+	}
+	if p.opts.EnableParallel {
+		return nil, merr.WrapErrServiceInternal("function chain parallel execution is not implemented")
+	}
+	if err := p.validateOperatorMetadata(); err != nil {
+		return nil, err
+	}
+
+	liveness := p.analyzeLiveness()
+	return &OptimizationPlan{
+		Liveness:           liveness,
+		PruneBefore:        liveness.LiveBefore,
+		PruneAfter:         liveness.LiveAfter,
+		SystemColumnPolicy: normalizeSystemColumnPolicy(p.opts.SystemColumnPolicy),
+	}, nil
+}
+
+func (p functionChainPlanner) validateOperatorMetadata() error {
+	for i, op := range p.operators {
+		if op == nil {
+			return merr.WrapErrServiceInternalMsg("operator[%d] is nil", i)
+		}
+		for _, input := range op.Inputs() {
+			if input == "" {
+				return merr.WrapErrServiceInternalMsg("operator[%d] %s has empty input column", i, op.Name())
+			}
+		}
+		seenOutputs := make(map[string]struct{}, len(op.Outputs()))
+		for _, output := range op.Outputs() {
+			if output == "" {
+				return merr.WrapErrServiceInternalMsg("operator[%d] %s has empty output column", i, op.Name())
+			}
+			if _, ok := seenOutputs[output]; ok {
+				return merr.WrapErrServiceInternalMsg("operator[%d] %s has duplicate output column %q", i, op.Name(), output)
+			}
+			seenOutputs[output] = struct{}{}
+		}
+	}
+	for _, col := range p.opts.Downstream.RequiredColumns {
+		if col == "" {
+			return merr.WrapErrServiceInternal("downstream required column is empty")
+		}
+	}
+	return nil
+}
+
+func (p functionChainPlanner) analyzeLiveness() *LivenessInfo {
+	n := len(p.operators)
+	liveBefore := make([]ColumnSet, n)
+	liveAfter := make([]ColumnSet, n)
+
+	live := NewColumnSet(p.opts.Downstream.RequiredColumns...)
+	live.RemoveSystemColumns()
+
+	for i := n - 1; i >= 0; i-- {
+		op := p.operators[i]
+
+		liveAfter[i] = live.Clone()
+		next := live.Clone()
+
+		for _, output := range op.Outputs() {
+			if IsFunctionChainSystemName(output) {
+				continue
+			}
+			next.Remove(output)
+		}
+
+		for _, input := range op.Inputs() {
+			if IsFunctionChainSystemName(input) {
+				continue
+			}
+			next.Add(input)
+		}
+
+		liveBefore[i] = next.Clone()
+		live = next
+	}
+
+	return &LivenessInfo{
+		LiveBefore: liveBefore,
+		LiveAfter:  liveAfter,
+	}
+}

--- a/internal/util/function/chain/optimization_plan_test.go
+++ b/internal/util/function/chain/optimization_plan_test.go
@@ -1,0 +1,524 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package chain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function/chain/types"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+type testOperator struct {
+	BaseOp
+	name string
+}
+
+func newTestOperator(name string, inputs, outputs []string) *testOperator {
+	return &testOperator{
+		BaseOp: BaseOp{
+			inputs:  inputs,
+			outputs: outputs,
+		},
+		name: name,
+	}
+}
+
+func (op *testOperator) Name() string { return op.name }
+
+func (op *testOperator) Execute(ctx *types.FuncContext, input *DataFrame) (*DataFrame, error) {
+	return input, nil
+}
+
+func (op *testOperator) String() string { return op.name }
+
+type addFloatFunction struct{}
+
+func (f *addFloatFunction) Name() string { return "add_float" }
+
+func (f *addFloatFunction) OutputDataTypes() []arrow.DataType {
+	return []arrow.DataType{arrow.PrimitiveTypes.Float32}
+}
+
+func (f *addFloatFunction) Execute(ctx *types.FuncContext, inputs []*arrow.Chunked) ([]*arrow.Chunked, error) {
+	left := inputs[0]
+	right := inputs[1]
+	chunks := make([]arrow.Array, len(left.Chunks()))
+	for i := 0; i < len(left.Chunks()); i++ {
+		leftChunk := left.Chunk(i).(*array.Float32)
+		rightChunk := right.Chunk(i).(*array.Float32)
+		builder := array.NewFloat32Builder(ctx.Pool())
+		for row := 0; row < leftChunk.Len(); row++ {
+			builder.Append(leftChunk.Value(row) + rightChunk.Value(row))
+		}
+		chunks[i] = builder.NewArray()
+		builder.Release()
+	}
+	result := arrow.NewChunked(arrow.PrimitiveTypes.Float32, chunks)
+	for _, chunk := range chunks {
+		chunk.Release()
+	}
+	return []*arrow.Chunked{result}, nil
+}
+
+func (f *addFloatFunction) IsRunnable(stage string) bool { return true }
+
+func requireColumnSet(t *testing.T, actual ColumnSet, expected ...string) {
+	t.Helper()
+	require.Len(t, actual, len(expected))
+	for _, col := range expected {
+		require.Truef(t, actual.Contains(col), "expected column %q in set %#v", col, actual)
+	}
+}
+
+func TestOptimizationPlanLivenessLinear(t *testing.T) {
+	fc := NewFuncChainWithAllocator(memory.DefaultAllocator).SetStage(types.StageL2Rerank)
+	fc.Add(newTestOperator("op0", []string{"a"}, []string{"tmp_a"}))
+	fc.Add(newTestOperator("op1", []string{"tmp_a", "b"}, []string{"tmp_b"}))
+	fc.Add(newTestOperator("op2", []string{"tmp_b"}, []string{types.ScoreFieldName}))
+
+	plan, err := fc.buildOptimizationPlan(ExecuteOptions{
+		EnableColumnPruning: true,
+		Downstream: DownstreamSpec{
+			RequiredColumns: []string{"keep"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	requireColumnSet(t, plan.Liveness.LiveAfter[2], "keep")
+	requireColumnSet(t, plan.Liveness.LiveBefore[2], "tmp_b", "keep")
+	requireColumnSet(t, plan.Liveness.LiveAfter[1], "tmp_b", "keep")
+	requireColumnSet(t, plan.Liveness.LiveBefore[1], "tmp_a", "b", "keep")
+	requireColumnSet(t, plan.Liveness.LiveAfter[0], "tmp_a", "b", "keep")
+	requireColumnSet(t, plan.Liveness.LiveBefore[0], "a", "b", "keep")
+}
+
+func TestOptimizationPlanIgnoresSystemColumns(t *testing.T) {
+	fc := NewFuncChainWithAllocator(memory.DefaultAllocator).SetStage(types.StageL2Rerank)
+	fc.Add(newTestOperator("op0", []string{types.IDFieldName, "$seg_offset", "field"}, []string{"tmp"}))
+	fc.Add(newTestOperator("op1", []string{"tmp", types.ScoreFieldName}, []string{types.ScoreFieldName}))
+
+	plan, err := fc.buildOptimizationPlan(ExecuteOptions{
+		EnableColumnPruning: true,
+		Downstream: DownstreamSpec{
+			RequiredColumns: []string{types.IDFieldName, types.ScoreFieldName, "field_out"},
+		},
+	})
+	require.NoError(t, err)
+
+	requireColumnSet(t, plan.Liveness.LiveBefore[1], "tmp", "field_out")
+	requireColumnSet(t, plan.Liveness.LiveBefore[0], "field", "field_out")
+}
+
+func TestPruneDataFrameDropsDeadNonSystemColumns(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	df := buildPruningTestDataFrame(t, pool)
+	pruned, err := PruneDataFrame(df, NewColumnSet("keep"), SystemColumnPolicy{KeepAllSystemColumns: true})
+	require.NoError(t, err)
+	require.NotSame(t, df, pruned)
+
+	require.True(t, pruned.HasColumn(types.IDFieldName))
+	require.True(t, pruned.HasColumn(types.ScoreFieldName))
+	require.True(t, pruned.HasColumn("$seg_offset"))
+	require.True(t, pruned.HasColumn("keep"))
+	require.False(t, pruned.HasColumn("drop"))
+	require.Equal(t, df.ChunkSizes(), pruned.ChunkSizes())
+
+	pruned.Release()
+	df.Release()
+}
+
+func TestPruneDataFrameNoDropReturnsSameDataFrame(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	df := buildPruningTestDataFrame(t, pool)
+	pruned, err := PruneDataFrame(df, NewColumnSet("keep", "drop"), SystemColumnPolicy{KeepAllSystemColumns: true})
+	require.NoError(t, err)
+	require.Same(t, df, pruned)
+	df.Release()
+}
+
+func TestExecuteWithOptionsPrunesMapTemporaryColumn(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	df := buildPruningTestDataFrame(t, pool)
+	defer df.Release()
+
+	mapTmp, err := NewMapOp(&addFloatFunction{}, []string{types.ScoreFieldName, "keep"}, []string{"tmp_score"})
+	require.NoError(t, err)
+	mapScore, err := NewMapOp(&addFloatFunction{}, []string{"tmp_score", types.ScoreFieldName}, []string{types.ScoreFieldName})
+	require.NoError(t, err)
+
+	fc := NewFuncChainWithAllocator(pool).SetStage(types.StageL2Rerank)
+	fc.Add(mapTmp)
+	fc.Add(mapScore)
+
+	result, err := fc.ExecuteWithOptions(context.Background(), ExecuteOptions{
+		EnableColumnPruning: true,
+		Downstream: DownstreamSpec{
+			RequiredColumns: []string{"keep"},
+		},
+		SystemColumnPolicy: SystemColumnPolicy{KeepAllSystemColumns: true},
+	}, df)
+	require.NoError(t, err)
+	defer result.Release()
+
+	require.True(t, result.HasColumn(types.IDFieldName))
+	require.True(t, result.HasColumn(types.ScoreFieldName))
+	require.True(t, result.HasColumn("$seg_offset"))
+	require.True(t, result.HasColumn("keep"))
+	require.False(t, result.HasColumn("tmp_score"))
+	require.False(t, result.HasColumn("drop"))
+}
+
+func TestExecuteWithContextDefaultBehaviorUnchanged(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	df := buildPruningTestDataFrame(t, pool)
+	defer df.Release()
+
+	mapTmp, err := NewMapOp(&addFloatFunction{}, []string{types.ScoreFieldName, "keep"}, []string{"tmp_score"})
+	require.NoError(t, err)
+
+	fc := NewFuncChainWithAllocator(pool).SetStage(types.StageL2Rerank)
+	fc.Add(mapTmp)
+
+	result, err := fc.ExecuteWithContext(context.Background(), df)
+	require.NoError(t, err)
+	defer result.Release()
+
+	require.True(t, result.HasColumn("tmp_score"))
+	require.True(t, result.HasColumn("drop"))
+}
+
+func TestOptimizationPlanDisabledReturnsNil(t *testing.T) {
+	fc := NewFuncChainWithAllocator(memory.DefaultAllocator).SetStage(types.StageL2Rerank)
+	fc.Add(newTestOperator("op", []string{"a"}, []string{"b"}))
+
+	plan, err := fc.buildOptimizationPlan(ExecuteOptions{})
+	require.NoError(t, err)
+	require.Nil(t, plan)
+}
+
+func TestOptimizationPlanParallelNotImplemented(t *testing.T) {
+	fc := NewFuncChainWithAllocator(memory.DefaultAllocator).SetStage(types.StageL2Rerank)
+	fc.Add(newTestOperator("op", []string{"a"}, []string{"b"}))
+
+	plan, err := fc.buildOptimizationPlan(ExecuteOptions{EnableParallel: true})
+	require.Error(t, err)
+	require.Nil(t, plan)
+	require.Contains(t, err.Error(), "parallel execution is not implemented")
+}
+
+func TestOptimizationPlanValidateOperatorMetadata(t *testing.T) {
+	tests := []struct {
+		name       string
+		operators  []Operator
+		downstream []string
+	}{
+		{
+			name:      "nil operator",
+			operators: []Operator{nil},
+		},
+		{
+			name:      "empty input",
+			operators: []Operator{newTestOperator("op", []string{""}, []string{"out"})},
+		},
+		{
+			name:      "empty output",
+			operators: []Operator{newTestOperator("op", []string{"in"}, []string{""})},
+		},
+		{
+			name:      "duplicate output",
+			operators: []Operator{newTestOperator("op", []string{"in"}, []string{"out", "out"})},
+		},
+		{
+			name:       "empty downstream",
+			operators:  []Operator{newTestOperator("op", []string{"in"}, []string{"out"})},
+			downstream: []string{""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := NewFuncChainWithAllocator(memory.DefaultAllocator).SetStage(types.StageL2Rerank)
+			for _, op := range tt.operators {
+				fc.Add(op)
+			}
+
+			plan, err := fc.buildOptimizationPlan(ExecuteOptions{
+				EnableColumnPruning: true,
+				Downstream: DownstreamSpec{
+					RequiredColumns: tt.downstream,
+				},
+			})
+			require.Error(t, err)
+			require.Nil(t, plan)
+		})
+	}
+}
+
+func TestOptimizationPlanLivenessInputOutputSameColumn(t *testing.T) {
+	fc := NewFuncChainWithAllocator(memory.DefaultAllocator).SetStage(types.StageL2Rerank)
+	fc.Add(newTestOperator("op", []string{"tmp"}, []string{"tmp"}))
+
+	plan, err := fc.buildOptimizationPlan(ExecuteOptions{
+		EnableColumnPruning: true,
+		Downstream: DownstreamSpec{
+			RequiredColumns: []string{"tmp"},
+		},
+	})
+	require.NoError(t, err)
+	requireColumnSet(t, plan.Liveness.LiveAfter[0], "tmp")
+	requireColumnSet(t, plan.Liveness.LiveBefore[0], "tmp")
+}
+
+func TestOptimizationPlanLivenessEmptyDownstream(t *testing.T) {
+	fc := NewFuncChainWithAllocator(memory.DefaultAllocator).SetStage(types.StageL2Rerank)
+	fc.Add(newTestOperator("op", []string{"a"}, []string{"tmp"}))
+
+	plan, err := fc.buildOptimizationPlan(ExecuteOptions{EnableColumnPruning: true})
+	require.NoError(t, err)
+	requireColumnSet(t, plan.Liveness.LiveAfter[0])
+	requireColumnSet(t, plan.Liveness.LiveBefore[0], "a")
+}
+
+func TestPruneDataFrameNil(t *testing.T) {
+	pruned, err := PruneDataFrame(nil, NewColumnSet("keep"), SystemColumnPolicy{KeepAllSystemColumns: true})
+	require.Error(t, err)
+	require.Nil(t, pruned)
+}
+
+func TestPruneDataFrameDefaultKeepsSystemColumns(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	df := buildPruningTestDataFrame(t, pool)
+	pruned, err := PruneDataFrame(df, NewColumnSet("keep"), SystemColumnPolicy{})
+	require.NoError(t, err)
+	defer pruned.Release()
+
+	require.True(t, pruned.HasColumn(types.IDFieldName))
+	require.True(t, pruned.HasColumn(types.ScoreFieldName))
+	require.True(t, pruned.HasColumn("$seg_offset"))
+	require.True(t, pruned.HasColumn("keep"))
+	require.False(t, pruned.HasColumn("drop"))
+
+	df.Release()
+}
+
+func TestPruneDataFramePreservesMetadata(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	df := buildPruningTestDataFrame(t, pool)
+	pruned, err := PruneDataFrame(df, NewColumnSet("keep"), SystemColumnPolicy{KeepAllSystemColumns: true})
+	require.NoError(t, err)
+	defer pruned.Release()
+
+	fieldType, ok := pruned.FieldType("keep")
+	require.True(t, ok)
+	require.Equal(t, schemapb.DataType_Float, fieldType)
+	fieldID, ok := pruned.FieldID("keep")
+	require.True(t, ok)
+	require.EqualValues(t, 100, fieldID)
+	require.False(t, pruned.fieldNullables["keep"])
+	metricType, ok := pruned.MetricType()
+	require.True(t, ok)
+	require.Equal(t, "IP", metricType)
+
+	df.Release()
+}
+
+type assertColumnsOperator struct {
+	BaseOp
+	expected []string
+}
+
+func newAssertColumnsOperator(inputs, outputs, expected []string) *assertColumnsOperator {
+	return &assertColumnsOperator{
+		BaseOp: BaseOp{
+			inputs:  inputs,
+			outputs: outputs,
+		},
+		expected: expected,
+	}
+}
+
+func (op *assertColumnsOperator) Name() string { return "assert_columns" }
+
+func (op *assertColumnsOperator) Execute(ctx *types.FuncContext, input *DataFrame) (*DataFrame, error) {
+	if !equalStringSet(op.expected, input.ColumnNames()) {
+		return nil, merr.WrapErrServiceInternalMsg("expected columns %v, got %v", op.expected, input.ColumnNames())
+	}
+	return input, nil
+}
+
+func equalStringSet(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	seen := make(map[string]int, len(left))
+	for _, value := range left {
+		seen[value]++
+	}
+	for _, value := range right {
+		seen[value]--
+		if seen[value] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (op *assertColumnsOperator) String() string { return op.Name() }
+
+func TestExecuteWithOptionsPrunesBeforeEachOperator(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	df := buildPruningTestDataFrame(t, pool)
+	defer df.Release()
+
+	mapTmp, err := NewMapOp(&addFloatFunction{}, []string{types.ScoreFieldName, "keep"}, []string{"tmp_score"})
+	require.NoError(t, err)
+
+	fc := NewFuncChainWithAllocator(pool).SetStage(types.StageL2Rerank)
+	fc.Add(mapTmp)
+	fc.Add(newAssertColumnsOperator(
+		[]string{"tmp_score"},
+		nil,
+		[]string{types.IDFieldName, types.ScoreFieldName, "$seg_offset", "keep", "tmp_score"},
+	))
+
+	result, err := fc.ExecuteWithOptions(context.Background(), ExecuteOptions{
+		EnableColumnPruning: true,
+		Downstream: DownstreamSpec{
+			RequiredColumns: []string{"keep"},
+		},
+	}, df)
+	require.NoError(t, err)
+	defer result.Release()
+
+	require.True(t, result.HasColumn("keep"))
+	require.False(t, result.HasColumn("tmp_score"))
+	require.False(t, result.HasColumn("drop"))
+}
+
+func TestExecuteWithOptionsPrunesAfterMergeOp(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	df1 := buildPruningTestDataFrame(t, pool)
+	defer df1.Release()
+	df2 := buildPruningTestDataFrame(t, pool)
+	defer df2.Release()
+
+	fc := NewFuncChainWithAllocator(pool).SetStage(types.StageL2Rerank)
+	fc.Add(NewMergeOp(MergeStrategyMax))
+	fc.Add(newAssertColumnsOperator(
+		[]string{"keep"},
+		nil,
+		[]string{types.IDFieldName, types.ScoreFieldName, "$seg_offset", "keep"},
+	))
+
+	result, err := fc.ExecuteWithOptions(context.Background(), ExecuteOptions{
+		EnableColumnPruning: true,
+		Downstream: DownstreamSpec{
+			RequiredColumns: []string{"keep"},
+		},
+	}, df1, df2)
+	require.NoError(t, err)
+	defer result.Release()
+
+	require.True(t, result.HasColumn(types.IDFieldName))
+	require.True(t, result.HasColumn(types.ScoreFieldName))
+	require.True(t, result.HasColumn("$seg_offset"))
+	require.True(t, result.HasColumn("keep"))
+	require.False(t, result.HasColumn("drop"))
+}
+
+func TestExecuteWithOptionsEmptyChainDoesNotPrune(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	df := buildPruningTestDataFrame(t, pool)
+	defer df.Release()
+
+	fc := NewFuncChainWithAllocator(pool).SetStage(types.StageL2Rerank)
+	result, err := fc.ExecuteWithOptions(context.Background(), ExecuteOptions{
+		EnableColumnPruning: true,
+		Downstream: DownstreamSpec{
+			RequiredColumns: []string{"keep"},
+		},
+	}, df)
+	require.NoError(t, err)
+	require.Same(t, df, result)
+	require.True(t, result.HasColumn("drop"))
+}
+
+func buildPruningTestDataFrame(t *testing.T, pool memory.Allocator) *DataFrame {
+	t.Helper()
+	builder := NewDataFrameBuilder()
+	defer builder.Release()
+	builder.SetChunkSizes([]int64{3})
+	builder.SetMetricType("IP")
+	addInt64Column(t, builder, pool, types.IDFieldName, []int64{1, 2, 3}, schemapb.DataType_Int64)
+	addFloat32Column(t, builder, pool, types.ScoreFieldName, []float32{0.1, 0.2, 0.3}, schemapb.DataType_Float)
+	addInt64Column(t, builder, pool, "$seg_offset", []int64{10, 11, 12}, schemapb.DataType_Int64)
+	addFloat32Column(t, builder, pool, "keep", []float32{1, 2, 3}, schemapb.DataType_Float)
+	builder.SetFieldID("keep", 100)
+	addFloat32Column(t, builder, pool, "drop", []float32{4, 5, 6}, schemapb.DataType_Float)
+	return builder.Build()
+}
+
+func addInt64Column(t *testing.T, builder *DataFrameBuilder, pool memory.Allocator, name string, values []int64, dataType schemapb.DataType) {
+	t.Helper()
+	b := array.NewInt64Builder(pool)
+	b.AppendValues(values, nil)
+	arr := b.NewArray()
+	b.Release()
+	builder.SetFieldType(name, dataType)
+	builder.SetFieldNullable(name, false)
+	require.NoError(t, builder.AddColumnFromChunks(name, []arrow.Array{arr}))
+}
+
+func addFloat32Column(t *testing.T, builder *DataFrameBuilder, pool memory.Allocator, name string, values []float32, dataType schemapb.DataType) {
+	t.Helper()
+	b := array.NewFloat32Builder(pool)
+	b.AppendValues(values, nil)
+	arr := b.NewArray()
+	b.Release()
+	builder.SetFieldType(name, dataType)
+	builder.SetFieldNullable(name, false)
+	require.NoError(t, builder.AddColumnFromChunks(name, []arrow.Array{arr}))
+}

--- a/internal/util/function/chain/pruning.go
+++ b/internal/util/function/chain/pruning.go
@@ -1,0 +1,61 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package chain
+
+import "github.com/milvus-io/milvus/pkg/v3/util/merr"
+
+// PruneDataFrame returns a DataFrame containing keepNonSystem plus retained system columns.
+// If no column is dropped, the original DataFrame is returned unchanged.
+func PruneDataFrame(df *DataFrame, keepNonSystem ColumnSet, policy SystemColumnPolicy) (*DataFrame, error) {
+	if df == nil {
+		return nil, merr.WrapErrServiceInternal("dataframe is nil")
+	}
+
+	policy = normalizeSystemColumnPolicy(policy)
+	colNames := df.ColumnNames()
+	keepNames := make([]string, 0, len(colNames))
+	dropped := false
+	for _, name := range colNames {
+		keep := keepNonSystem.Contains(name)
+		if policy.KeepAllSystemColumns && IsFunctionChainSystemName(name) {
+			keep = true
+		}
+		if keep {
+			keepNames = append(keepNames, name)
+		} else {
+			dropped = true
+		}
+	}
+
+	if !dropped {
+		return df, nil
+	}
+
+	builder := NewDataFrameBuilder()
+	defer builder.Release()
+	builder.SetChunkSizes(df.chunkSizes)
+	builder.CopyAllMetadata(df)
+
+	for _, name := range keepNames {
+		if err := builder.AddColumnFrom(df, name); err != nil {
+			return nil, err
+		}
+	}
+	return builder.Build(), nil
+}

--- a/internal/util/function/chain/repr.go
+++ b/internal/util/function/chain/repr.go
@@ -19,153 +19,307 @@
 package chain
 
 import (
-	"encoding/json"
+	"strings"
 
 	"github.com/apache/arrow/go/v17/arrow/memory"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
-// =============================================================================
-// JSON Representation Types (for deserialization)
-// =============================================================================
-
-// ChainJSON is the JSON representation of a FuncChain for serialization/deserialization.
-type ChainJSON struct {
-	Name      string         `json:"name,omitempty"`
-	Stage     string         `json:"stage"`
-	Operators []OperatorJSON `json:"operators"`
-}
-
-// OperatorJSON is the JSON representation of an Operator for serialization/deserialization.
-type OperatorJSON struct {
-	Type     string                 `json:"type"`
-	Params   map[string]interface{} `json:"params,omitempty"`
-	Function *FunctionJSON          `json:"function,omitempty"` // for map operator
-	Inputs   []string               `json:"inputs,omitempty"`   // input column names
-	Outputs  []string               `json:"outputs,omitempty"`  // output column names
-}
-
-// FunctionJSON is the JSON representation of a FunctionExpr for serialization/deserialization.
-type FunctionJSON struct {
-	Name   string                 `json:"name"`
-	Params map[string]interface{} `json:"params"`
-}
-
-// =============================================================================
-// Internal Representation Types (no JSON tags)
-// =============================================================================
-
-// ChainRepr is the internal representation of a FuncChain (no JSON tags).
+// ChainRepr is the internal representation of a FuncChain.
 type ChainRepr struct {
 	Name      string
 	Stage     string
 	Operators []OperatorRepr
+	Info      ChainReprInfo
 }
 
-// OperatorRepr is the internal representation of an Operator (no JSON tags).
-// It uses a unified Params map instead of specific fields.
+// OperatorRepr is the internal representation of an Operator.
 type OperatorRepr struct {
 	Type     string
-	Params   map[string]interface{}
-	Function *FunctionRepr // for map operator
+	Params   map[string]*schemapb.FunctionParamValue
+	Function *FunctionRepr // for map/filter operators that evaluate an expression
 	Inputs   []string      // input column names
 	Outputs  []string      // output column names
 }
 
-// FunctionRepr is the internal representation of a FunctionExpr (no JSON tags).
+// FunctionRepr is the internal representation of a FunctionExpr.
 type FunctionRepr struct {
 	Name   string
-	Params map[string]interface{}
+	Params map[string]*schemapb.FunctionParamValue
+	Args   []*schemapb.FunctionChainExprArg
 }
 
-// =============================================================================
-// Conversion Functions
-// =============================================================================
-
-// functionJSONToRepr converts FunctionJSON to FunctionRepr.
-func functionJSONToRepr(json *FunctionJSON) *FunctionRepr {
-	if json == nil {
-		return nil
-	}
-	return &FunctionRepr{
-		Name:   json.Name,
-		Params: json.Params,
-	}
+// ChainReprInfo contains context-independent structural information derived from a ChainRepr.
+// RequiredInputs are names read before any previous op produces them. Callers decide
+// whether those names are schema fields, request payload fields, or runtime/system values.
+type ChainReprInfo struct {
+	RequiredInputs []string
+	WrittenNames   []string
+	Ops            []OperatorReprInfo
 }
 
-// operatorJSONToRepr converts OperatorJSON to OperatorRepr.
-// It infers Inputs/Outputs based on operator type and parameters.
-func operatorJSONToRepr(json *OperatorJSON) (*OperatorRepr, error) {
-	if json == nil {
-		return nil, merr.WrapErrServiceInternal("OperatorJSON is nil")
-	}
-
-	repr := &OperatorRepr{
-		Type:     json.Type,
-		Params:   make(map[string]interface{}),
-		Function: functionJSONToRepr(json.Function),
-		Inputs:   json.Inputs,
-		Outputs:  json.Outputs,
-	}
-
-	// Copy params
-	if json.Params != nil {
-		for k, v := range json.Params {
-			repr.Params[k] = v
-		}
-	}
-	return repr, nil
+// OperatorReprInfo contains normalized input/output information for one operator.
+type OperatorReprInfo struct {
+	Type       string
+	ReadNames  []string
+	WriteNames []string
 }
 
-// chainJSONToRepr converts ChainJSON to ChainRepr.
-func chainJSONToRepr(json *ChainJSON) (*ChainRepr, error) {
-	if json == nil {
-		return nil, merr.WrapErrServiceInternal("ChainJSON is nil")
+// ParseFuncChainProto creates a FuncChain from the public FunctionChain proto.
+// It uses an empty FunctionBuildContext. Use FuncChainFromReprWithContext when
+// constructing functions that require runtime-only context, such as model rerank.
+func ParseFuncChainProto(pb *schemapb.FunctionChain, alloc memory.Allocator) (*FuncChain, error) {
+	repr, err := ProtoChainToRepr(pb)
+	if err != nil {
+		return nil, err
+	}
+	return funcChainFromRepr(repr, alloc, types.FunctionBuildContext{})
+}
+
+// ProtoChainToRepr converts the public FunctionChain proto to the internal representation.
+func ProtoChainToRepr(pb *schemapb.FunctionChain) (*ChainRepr, error) {
+	if pb == nil {
+		return nil, merr.WrapErrParameterInvalidMsg("function chain proto is nil")
+	}
+
+	stage, err := ProtoStageToReprStage(pb.GetStage())
+	if err != nil {
+		return nil, err
 	}
 
 	repr := &ChainRepr{
-		Name:      json.Name,
-		Stage:     json.Stage,
-		Operators: make([]OperatorRepr, 0, len(json.Operators)),
+		Name:      pb.GetName(),
+		Stage:     stage,
+		Operators: make([]OperatorRepr, 0, len(pb.GetOps())),
 	}
 
-	for i, opJSON := range json.Operators {
-		opRepr, err := operatorJSONToRepr(&opJSON)
+	for i, opPB := range pb.GetOps() {
+		opRepr, err := ProtoOpToRepr(opPB)
 		if err != nil {
-			return nil, merr.WrapErrServiceInternalMsg("operator[%d]: %v", i, err)
+			return nil, merr.WrapErrParameterInvalidMsg("op[%d]: %v", i, err)
 		}
 		repr.Operators = append(repr.Operators, *opRepr)
 	}
 
+	if err := repr.RefreshInfo(); err != nil {
+		return nil, err
+	}
+
 	return repr, nil
 }
 
-// =============================================================================
-// Parsing Functions
-// =============================================================================
-
-// ParseFuncChainRepr parses a JSON string and creates a FuncChain.
-// alloc must not be nil.
-func ParseFuncChainRepr(jsonStr string, alloc memory.Allocator) (*FuncChain, error) {
-	var chainJSON ChainJSON
-	if err := json.Unmarshal([]byte(jsonStr), &chainJSON); err != nil {
-		return nil, merr.WrapErrParameterInvalidMsg("failed to parse JSON: %v", err)
+// ProtoOpToRepr converts a public FunctionChainOp proto to the internal operator representation.
+func ProtoOpToRepr(pb *schemapb.FunctionChainOp) (*OperatorRepr, error) {
+	if pb == nil {
+		return nil, merr.WrapErrParameterInvalidMsg("op proto is nil")
 	}
 
-	repr, err := chainJSONToRepr(&chainJSON)
+	opType := strings.TrimSpace(pb.GetOp())
+	if opType == "" {
+		return nil, merr.WrapErrParameterInvalidMsg("op name is empty")
+	}
+
+	inputs, err := normalizeReprNames(pb.GetInputs(), "input")
 	if err != nil {
-		return nil, merr.WrapErrParameterInvalidMsg("failed to convert JSON to Repr: %v", err)
+		return nil, err
+	}
+	outputs, err := normalizeReprNames(pb.GetOutputs(), "output")
+	if err != nil {
+		return nil, err
 	}
 
-	return funcChainFromRepr(repr, alloc)
+	repr := &OperatorRepr{
+		Type:    opType,
+		Params:  pb.GetParams(),
+		Inputs:  inputs,
+		Outputs: outputs,
+	}
+
+	if pb.GetExpr() != nil {
+		expr, exprInputs, err := ProtoExprToRepr(pb.GetExpr())
+		if err != nil {
+			return nil, err
+		}
+		repr.Function = expr
+		repr.Inputs = exprInputs
+	}
+
+	return repr, nil
+}
+
+// ProtoExprToRepr converts a public FunctionChainExpr proto to the internal function representation.
+// It also returns the column references in expr args, preserving first-seen order.
+func ProtoExprToRepr(pb *schemapb.FunctionChainExpr) (*FunctionRepr, []string, error) {
+	if pb == nil {
+		return nil, nil, nil
+	}
+
+	name := strings.TrimSpace(pb.GetName())
+	if name == "" {
+		return nil, nil, merr.WrapErrParameterInvalidMsg("expr name is empty")
+	}
+
+	inputs, err := ProtoExprArgsToInputs(pb.GetArgs())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &FunctionRepr{
+		Name:   name,
+		Params: pb.GetParams(),
+		Args:   pb.GetArgs(),
+	}, inputs, nil
+}
+
+// ProtoExprArgsToInputs extracts column references from public FunctionChainExpr args.
+func ProtoExprArgsToInputs(args []*schemapb.FunctionChainExprArg) ([]string, error) {
+	inputs := make([]string, 0, len(args))
+	seenInputs := make(map[string]struct{})
+
+	for i, arg := range args {
+		input, err := FunctionChainExprArgInput(arg)
+		if err != nil {
+			return nil, merr.WrapErrParameterInvalidMsg("expr arg[%d]: %v", i, err)
+		}
+		if input == "" {
+			continue
+		}
+		if _, ok := seenInputs[input]; ok {
+			continue
+		}
+		seenInputs[input] = struct{}{}
+		inputs = append(inputs, input)
+	}
+
+	return inputs, nil
+}
+
+// FunctionChainExprArgInput extracts the input column name from an arg, if it is a column reference.
+func FunctionChainExprArgInput(arg *schemapb.FunctionChainExprArg) (string, error) {
+	if arg == nil {
+		return "", merr.WrapErrParameterInvalidMsg("function chain expr arg is nil")
+	}
+
+	switch v := arg.GetArg().(type) {
+	case *schemapb.FunctionChainExprArg_Column:
+		name := strings.TrimSpace(v.Column.GetName())
+		if name == "" {
+			return "", merr.WrapErrParameterInvalidMsg("column name is empty")
+		}
+		return name, nil
+	case *schemapb.FunctionChainExprArg_Literal:
+		if v.Literal == nil {
+			return "", merr.WrapErrParameterInvalidMsg("literal: function param value is nil")
+		}
+		return "", nil
+	default:
+		return "", merr.WrapErrParameterInvalidMsg("function chain expr arg is unset")
+	}
+}
+
+// ProtoStageToReprStage converts public FunctionChainStage enum to chain runtime stage string.
+func ProtoStageToReprStage(stage schemapb.FunctionChainStage) (string, error) {
+	switch stage {
+	case schemapb.FunctionChainStage_FunctionChainStageIngestion:
+		return types.StageIngestion, nil
+	case schemapb.FunctionChainStage_FunctionChainStagePreProcess:
+		return types.StagePreProcess, nil
+	case schemapb.FunctionChainStage_FunctionChainStageL0Rerank:
+		return types.StageL0Rerank, nil
+	case schemapb.FunctionChainStage_FunctionChainStageL1Rerank:
+		return types.StageL1Rerank, nil
+	case schemapb.FunctionChainStage_FunctionChainStageL2Rerank:
+		return types.StageL2Rerank, nil
+	case schemapb.FunctionChainStage_FunctionChainStagePostProcess:
+		return types.StagePostProcess, nil
+	default:
+		return "", merr.WrapErrParameterInvalidMsg("unsupported function chain stage: %s", stage.String())
+	}
+}
+
+// RefreshInfo rebuilds context-independent dependency information from a ChainRepr.
+// It does not classify names as schema fields, payload fields, or system variables.
+func (repr *ChainRepr) RefreshInfo() error {
+	if repr == nil {
+		return nil
+	}
+
+	info := ChainReprInfo{
+		RequiredInputs: make([]string, 0),
+		WrittenNames:   make([]string, 0),
+		Ops:            make([]OperatorReprInfo, 0, len(repr.Operators)),
+	}
+	produced := make(map[string]struct{})
+	seenRequiredInputs := make(map[string]struct{})
+	seenWrittenNames := make(map[string]struct{})
+
+	for i, op := range repr.Operators {
+		opType := strings.TrimSpace(op.Type)
+		if opType == "" {
+			return merr.WrapErrParameterInvalidMsg("op[%d] name is empty", i)
+		}
+
+		inputs, err := normalizeReprNames(op.Inputs, "input")
+		if err != nil {
+			return merr.WrapErrParameterInvalidMsg("op[%d]: %v", i, err)
+		}
+		outputs, err := normalizeReprNames(op.Outputs, "output")
+		if err != nil {
+			return merr.WrapErrParameterInvalidMsg("op[%d]: %v", i, err)
+		}
+
+		repr.Operators[i].Type = opType
+		repr.Operators[i].Inputs = inputs
+		repr.Operators[i].Outputs = outputs
+
+		info.Ops = append(info.Ops, OperatorReprInfo{
+			Type:       opType,
+			ReadNames:  append([]string(nil), inputs...),
+			WriteNames: append([]string(nil), outputs...),
+		})
+
+		for _, input := range inputs {
+			if _, ok := produced[input]; ok {
+				continue
+			}
+			if _, ok := seenRequiredInputs[input]; !ok {
+				seenRequiredInputs[input] = struct{}{}
+				info.RequiredInputs = append(info.RequiredInputs, input)
+			}
+		}
+
+		for _, output := range outputs {
+			produced[output] = struct{}{}
+			if _, ok := seenWrittenNames[output]; !ok {
+				seenWrittenNames[output] = struct{}{}
+				info.WrittenNames = append(info.WrittenNames, output)
+			}
+		}
+	}
+
+	repr.Info = info
+	return nil
+}
+
+// FuncChainFromRepr creates a FuncChain from a ChainRepr.
+// Stage is required and validates that all functions support the stage.
+// alloc must not be nil.
+// It uses an empty FunctionBuildContext. Use FuncChainFromReprWithContext when
+// constructing functions that require runtime-only context, such as model rerank.
+func FuncChainFromRepr(repr *ChainRepr, alloc memory.Allocator) (*FuncChain, error) {
+	return funcChainFromRepr(repr, alloc, types.FunctionBuildContext{})
+}
+
+// FuncChainFromReprWithContext creates a FuncChain from a ChainRepr with runtime-only context.
+func FuncChainFromReprWithContext(repr *ChainRepr, alloc memory.Allocator, buildCtx types.FunctionBuildContext) (*FuncChain, error) {
+	return funcChainFromRepr(repr, alloc, buildCtx)
 }
 
 // funcChainFromRepr creates a FuncChain from a ChainRepr.
-// Stage is required and validates that all functions support the stage.
-// alloc must not be nil.
-func funcChainFromRepr(repr *ChainRepr, alloc memory.Allocator) (*FuncChain, error) {
+func funcChainFromRepr(repr *ChainRepr, alloc memory.Allocator, buildCtx types.FunctionBuildContext) (*FuncChain, error) {
 	if alloc == nil {
 		return nil, merr.WrapErrServiceInternal("alloc is nil")
 	}
@@ -181,7 +335,7 @@ func funcChainFromRepr(repr *ChainRepr, alloc memory.Allocator) (*FuncChain, err
 	chain.SetStage(repr.Stage)
 
 	for i, opRepr := range repr.Operators {
-		op, err := operatorFromRepr(&opRepr)
+		op, err := operatorFromReprWithContext(&opRepr, buildCtx)
 		if err != nil {
 			return nil, merr.WrapErrServiceInternalMsg("operator[%d]: %v", i, err)
 		}
@@ -198,6 +352,17 @@ func funcChainFromRepr(repr *ChainRepr, alloc memory.Allocator) (*FuncChain, err
 
 // operatorFromRepr creates an Operator from an OperatorRepr.
 func operatorFromRepr(repr *OperatorRepr) (Operator, error) {
+	return operatorFromReprWithContext(repr, types.FunctionBuildContext{})
+}
+
+func operatorFromReprWithContext(repr *OperatorRepr, buildCtx types.FunctionBuildContext) (Operator, error) {
+	switch repr.Type {
+	case types.OpTypeMap:
+		return NewMapOpFromReprWithContext(repr, buildCtx)
+	case types.OpTypeFilter:
+		return NewFilterOpFromReprWithContext(repr, buildCtx)
+	}
+
 	factory, ok := GetOperatorFactory(repr.Type)
 	if !ok {
 		return nil, merr.WrapErrParameterInvalidMsg("unknown operator type: %s", repr.Type)
@@ -206,10 +371,51 @@ func operatorFromRepr(repr *OperatorRepr) (Operator, error) {
 }
 
 // FunctionFromRepr creates a FunctionExpr from a FunctionRepr.
+// It uses an empty FunctionBuildContext. Use FunctionFromReprWithContext when
+// constructing functions that require runtime-only context, such as model rerank.
 func FunctionFromRepr(repr *FunctionRepr) (types.FunctionExpr, error) {
+	return FunctionFromReprWithContext(repr, types.FunctionBuildContext{})
+}
+
+// FunctionFromReprWithContext creates a FunctionExpr from a FunctionRepr and build context.
+func FunctionFromReprWithContext(repr *FunctionRepr, buildCtx types.FunctionBuildContext) (types.FunctionExpr, error) {
+	if repr == nil {
+		return nil, merr.WrapErrParameterInvalidMsg("function repr is nil")
+	}
 	if repr.Name == "" {
 		return nil, merr.WrapErrParameterMissingMsg("function name is required")
 	}
 
-	return types.CreateFunction(repr.Name, repr.Params)
+	fn, err := types.CreateFunction(buildCtx, types.FunctionConfig{
+		Name:   repr.Name,
+		Params: repr.Params,
+		Args:   repr.Args,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if validator, ok := fn.(types.FunctionArgValidator); ok {
+		if err := validator.ValidateArgs(repr.Args); err != nil {
+			return nil, err
+		}
+	}
+	return fn, nil
+}
+
+func normalizeReprNames(names []string, label string) ([]string, error) {
+	result := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return nil, merr.WrapErrParameterInvalidMsg("%s name is empty", label)
+		}
+		result = append(result, name)
+	}
+	return result, nil
+}
+
+// IsFunctionChainSystemName reports whether name uses the function-chain system-name prefix.
+// It does not validate whether the current caller or stage may provide that name.
+func IsFunctionChainSystemName(name string) bool {
+	return strings.HasPrefix(name, "$")
 }

--- a/internal/util/function/chain/repr_test.go
+++ b/internal/util/function/chain/repr_test.go
@@ -24,8 +24,12 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/memory"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	chainexpr "github.com/milvus-io/milvus/internal/util/function/chain/expr"
 	"github.com/milvus-io/milvus/internal/util/function/chain/types"
+	"github.com/milvus-io/milvus/internal/util/function/models"
 )
 
 // MockFunctionExpr is a mock implementation of FunctionExpr for testing.
@@ -72,180 +76,420 @@ func (m *MockBooleanFunctionExpr) Execute(ctx *types.FuncContext, inputs []*arro
 
 func init() {
 	// Register mock_filter function for testing
-	types.RegisterFunction("mock_filter", func(params map[string]interface{}) (types.FunctionExpr, error) {
+	types.RegisterFunction("mock_filter", func(_ types.FunctionBuildContext, _ types.FunctionConfig) (types.FunctionExpr, error) {
 		return &MockBooleanFunctionExpr{name: "mock_filter"}, nil
 	})
 }
 
-func TestParseFuncChainRepr_BasicOperators(t *testing.T) {
-	jsonStr := `{
-		"name": "test-chain",
-		"stage": "L2_rerank",
-		"operators": [
+func TestParseFuncChainProto_BasicOperators(t *testing.T) {
+	pb := &schemapb.FunctionChain{
+		Name:  "test-chain",
+		Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+		Ops: []*schemapb.FunctionChainOp{
 			{
-				"type": "filter",
-				"function": {
-					"name": "mock_filter",
-					"params": {}
+				Op: "filter",
+				Expr: &schemapb.FunctionChainExpr{
+					Name:   "mock_filter",
+					Args:   []*schemapb.FunctionChainExprArg{columnArg("score")},
+					Params: map[string]*schemapb.FunctionParamValue{},
 				},
-				"inputs": ["score"]
 			},
 			{
-				"type": "select",
-				"params": {
-					"columns": ["id", "score", "name"]
-				}
+				Op: "select",
+				Params: map[string]*schemapb.FunctionParamValue{
+					"columns": arrayParam(stringParam("id"), stringParam("score"), stringParam("name")),
+				},
 			},
 			{
-				"type": "sort",
-				"params": {
-					"column": "score",
-					"desc": true
-				}
+				Op:     "sort",
+				Inputs: []string{"score"},
+				Params: map[string]*schemapb.FunctionParamValue{
+					"desc": boolParam(true),
+				},
 			},
 			{
-				"type": "limit",
-				"params": {
-					"limit": 10,
-					"offset": 5
-				}
-			}
-		]
-	}`
+				Op: "limit",
+				Params: map[string]*schemapb.FunctionParamValue{
+					"limit":  intParam(10),
+					"offset": intParam(5),
+				},
+			},
+		},
+	}
 
-	chain, err := ParseFuncChainRepr(jsonStr, memory.NewGoAllocator())
+	chain, err := ParseFuncChainProto(pb, memory.NewGoAllocator())
 	assert.NoError(t, err)
 	assert.NotNil(t, chain)
 	assert.Equal(t, "test-chain", chain.name)
 	assert.Equal(t, types.StageL2Rerank, chain.Stage())
 	assert.Len(t, chain.operators, 4)
 
-	// Verify operator types
 	assert.IsType(t, &FilterOp{}, chain.operators[0])
 	assert.IsType(t, &SelectOp{}, chain.operators[1])
 	assert.IsType(t, &SortOp{}, chain.operators[2])
 	assert.IsType(t, &LimitOp{}, chain.operators[3])
 }
 
-func TestParseFuncChainRepr_InvalidRepr(t *testing.T) {
-	jsonStr := `{ invalid json }`
-	_, err := ParseFuncChainRepr(jsonStr, memory.NewGoAllocator())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to parse JSON")
-}
-
-func TestParseFuncChainRepr_UnknownOperator(t *testing.T) {
-	jsonStr := `{
-		"stage": "L2_rerank",
-		"operators": [
-			{
-				"type": "unknown_op"
-			}
-		]
-	}`
-
-	_, err := ParseFuncChainRepr(jsonStr, memory.NewGoAllocator())
+func TestParseFuncChainProto_UnknownOperator(t *testing.T) {
+	_, err := ParseFuncChainProto(&schemapb.FunctionChain{
+		Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+		Ops: []*schemapb.FunctionChainOp{
+			{Op: "unknown_op"},
+		},
+	}, memory.NewGoAllocator())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown operator type")
 }
 
-func TestParseFuncChainRepr_MissingStage(t *testing.T) {
-	jsonStr := `{
-		"operators": [
+func TestParseFuncChainProto_MissingStage(t *testing.T) {
+	_, err := ParseFuncChainProto(&schemapb.FunctionChain{
+		Ops: []*schemapb.FunctionChainOp{
 			{
-				"type": "select",
-				"params": {"columns": ["test"]}
-			}
-		]
-	}`
-
-	_, err := ParseFuncChainRepr(jsonStr, memory.NewGoAllocator())
+				Op: "select",
+				Params: map[string]*schemapb.FunctionParamValue{
+					"columns": arrayParam(stringParam("test")),
+				},
+			},
+		},
+	}, memory.NewGoAllocator())
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "stage is required")
+	assert.Contains(t, err.Error(), "unsupported function chain stage")
 }
 
-func TestParseFuncChainRepr_MissingParams(t *testing.T) {
+func TestParseFuncChainProto_MissingParams(t *testing.T) {
 	testCases := []struct {
-		name    string
-		jsonStr string
-		errMsg  string
+		name   string
+		chain  *schemapb.FunctionChain
+		errMsg string
 	}{
 		{
 			name: "filter missing function",
-			jsonStr: `{
-				"stage": "L2_rerank",
-				"operators": [{"type": "filter", "params": {}}]
-			}`,
+			chain: &schemapb.FunctionChain{
+				Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+				Ops:   []*schemapb.FunctionChainOp{{Op: "filter"}},
+			},
 			errMsg: "filter_op: function is required",
 		},
 		{
 			name: "filter missing inputs",
-			jsonStr: `{
-				"stage": "L2_rerank",
-				"operators": [{"type": "filter", "function": {"name": "mock_filter", "params": {}}}]
-			}`,
+			chain: &schemapb.FunctionChain{
+				Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+				Ops: []*schemapb.FunctionChainOp{{
+					Op:   "filter",
+					Expr: &schemapb.FunctionChainExpr{Name: "mock_filter"},
+				}},
+			},
 			errMsg: "filter_op: inputs is required",
 		},
 		{
 			name: "sort missing column",
-			jsonStr: `{
-				"stage": "L2_rerank",
-				"operators": [{"type": "sort", "params": {}}]
-			}`,
+			chain: &schemapb.FunctionChain{
+				Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+				Ops:   []*schemapb.FunctionChainOp{{Op: "sort"}},
+			},
 			errMsg: "sort_op: column is required",
 		},
 		{
 			name: "select missing columns",
-			jsonStr: `{
-				"stage": "L2_rerank",
-				"operators": [{"type": "select", "params": {}}]
-			}`,
+			chain: &schemapb.FunctionChain{
+				Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+				Ops:   []*schemapb.FunctionChainOp{{Op: "select"}},
+			},
 			errMsg: "select_op: columns is required",
 		},
 		{
 			name: "limit invalid limit",
-			jsonStr: `{
-				"stage": "L2_rerank",
-				"operators": [{"type": "limit", "params": {"limit": 0}}]
-			}`,
+			chain: &schemapb.FunctionChain{
+				Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+				Ops: []*schemapb.FunctionChainOp{{
+					Op: "limit",
+					Params: map[string]*schemapb.FunctionParamValue{
+						"limit": intParam(0),
+					},
+				}},
+			},
 			errMsg: "limit_op: limit must be positive",
 		},
 		{
 			name: "map missing function",
-			jsonStr: `{
-				"stage": "L2_rerank",
-				"operators": [{"type": "map"}]
-			}`,
+			chain: &schemapb.FunctionChain{
+				Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+				Ops:   []*schemapb.FunctionChainOp{{Op: "map"}},
+			},
 			errMsg: "map operator requires function",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := ParseFuncChainRepr(tc.jsonStr, memory.NewGoAllocator())
+			_, err := ParseFuncChainProto(tc.chain, memory.NewGoAllocator())
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errMsg)
 		})
 	}
 }
 
-func TestParseFuncChainRepr_UnknownFunction(t *testing.T) {
-	jsonStr := `{
-		"stage": "L2_rerank",
-		"operators": [
+func TestParseFuncChainProto_UnknownFunction(t *testing.T) {
+	_, err := ParseFuncChainProto(&schemapb.FunctionChain{
+		Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+		Ops: []*schemapb.FunctionChainOp{
 			{
-				"type": "map",
-				"function": {
-					"name": "UNKNOWN_FUNC",
-					"params": {}
-				}
-			}
-		]
-	}`
-
-	_, err := ParseFuncChainRepr(jsonStr, memory.NewGoAllocator())
+				Op: "map",
+				Expr: &schemapb.FunctionChainExpr{
+					Name:   "UNKNOWN_FUNC",
+					Params: map[string]*schemapb.FunctionParamValue{},
+				},
+			},
+		},
+	}, memory.NewGoAllocator())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown function")
+}
+
+func TestParseFuncChainProto_RoundDecimalFunction(t *testing.T) {
+	chain, err := ParseFuncChainProto(&schemapb.FunctionChain{
+		Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+		Ops: []*schemapb.FunctionChainOp{
+			{
+				Op:      types.OpTypeMap,
+				Outputs: []string{types.ScoreFieldName},
+				Expr: &schemapb.FunctionChainExpr{
+					Name: "round_decimal",
+					Args: []*schemapb.FunctionChainExprArg{columnArg(types.ScoreFieldName)},
+					Params: map[string]*schemapb.FunctionParamValue{
+						"decimal": intParam(2),
+					},
+				},
+			},
+		},
+	}, memory.NewGoAllocator())
+	require.NoError(t, err)
+	require.NotNil(t, chain)
+	assert.Len(t, chain.operators, 1)
+	assert.IsType(t, &MapOp{}, chain.operators[0])
+}
+
+func TestProtoOpToReprDerivesInputsFromExprArgs(t *testing.T) {
+	repr, err := ProtoOpToRepr(&schemapb.FunctionChainOp{
+		Op: types.OpTypeMap,
+		Expr: &schemapb.FunctionChainExpr{
+			Name: "expr",
+			Args: []*schemapb.FunctionChainExprArg{
+				columnArg("$score"),
+				literalArg(intParam(100)),
+				columnArg("tag"),
+				columnArg("$score"),
+			},
+			Params: map[string]*schemapb.FunctionParamValue{
+				"expr": stringParam("($0 > $1) && ($2 != \"dog\")"),
+			},
+		},
+		Outputs: []string{"new_score"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, repr)
+	assert.Equal(t, []string{"$score", "tag"}, repr.Inputs)
+	assert.Equal(t, []string{"new_score"}, repr.Outputs)
+	require.NotNil(t, repr.Function)
+	assert.Equal(t, "expr", repr.Function.Name)
+	require.Len(t, repr.Function.Args, 4)
+	assert.Equal(t, "($0 > $1) && ($2 != \"dog\")", repr.Function.Params["expr"].GetStringValue())
+}
+
+func TestProtoChainToReprBuildsInfo(t *testing.T) {
+	repr, err := ProtoChainToRepr(&schemapb.FunctionChain{
+		Stage: schemapb.FunctionChainStage_FunctionChainStageL2Rerank,
+		Ops: []*schemapb.FunctionChainOp{
+			{
+				Op: types.OpTypeMap,
+				Expr: &schemapb.FunctionChainExpr{
+					Name: "decay",
+					Args: []*schemapb.FunctionChainExprArg{columnArg("ts")},
+				},
+				Outputs: []string{"score1"},
+			},
+			{
+				Op: types.OpTypeMap,
+				Expr: &schemapb.FunctionChainExpr{
+					Name: "sum",
+					Args: []*schemapb.FunctionChainExprArg{
+						columnArg("score1"),
+						columnArg("$score"),
+					},
+				},
+				Outputs: []string{"$score"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, repr)
+	assert.Equal(t, []string{"ts", "$score"}, repr.Info.RequiredInputs)
+	assert.Equal(t, []string{"score1", "$score"}, repr.Info.WrittenNames)
+	require.Len(t, repr.Info.Ops, 2)
+	assert.Equal(t, []string{"ts"}, repr.Info.Ops[0].ReadNames)
+	assert.Equal(t, []string{"score1"}, repr.Info.Ops[0].WriteNames)
+	assert.Equal(t, []string{"score1", "$score"}, repr.Info.Ops[1].ReadNames)
+	assert.Equal(t, []string{"$score"}, repr.Info.Ops[1].WriteNames)
+}
+
+func TestProtoStageToReprStage(t *testing.T) {
+	tests := []struct {
+		stage    schemapb.FunctionChainStage
+		expected string
+	}{
+		{schemapb.FunctionChainStage_FunctionChainStageIngestion, types.StageIngestion},
+		{schemapb.FunctionChainStage_FunctionChainStagePreProcess, types.StagePreProcess},
+		{schemapb.FunctionChainStage_FunctionChainStageL0Rerank, types.StageL0Rerank},
+		{schemapb.FunctionChainStage_FunctionChainStageL1Rerank, types.StageL1Rerank},
+		{schemapb.FunctionChainStage_FunctionChainStageL2Rerank, types.StageL2Rerank},
+		{schemapb.FunctionChainStage_FunctionChainStagePostProcess, types.StagePostProcess},
+	}
+	for _, tc := range tests {
+		t.Run(tc.stage.String(), func(t *testing.T) {
+			stage, err := ProtoStageToReprStage(tc.stage)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, stage)
+		})
+	}
+
+	_, err := ProtoStageToReprStage(schemapb.FunctionChainStage_FunctionChainStageUnspecified)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported function chain stage")
+}
+
+func TestIsFunctionChainSystemName(t *testing.T) {
+	assert.True(t, IsFunctionChainSystemName("$score"))
+	assert.True(t, IsFunctionChainSystemName("$id"))
+	assert.False(t, IsFunctionChainSystemName("score"))
+	assert.False(t, IsFunctionChainSystemName(""))
+}
+
+func TestFunctionChainExprArgInput(t *testing.T) {
+	input, err := FunctionChainExprArgInput(columnArg(" ts "))
+	require.NoError(t, err)
+	assert.Equal(t, "ts", input)
+
+	input, err = FunctionChainExprArgInput(literalArg(stringParam("value")))
+	require.NoError(t, err)
+	assert.Empty(t, input)
+
+	_, err = FunctionChainExprArgInput(nil)
+	assert.ErrorContains(t, err, "function chain expr arg is nil")
+
+	_, err = FunctionChainExprArgInput(columnArg(" "))
+	assert.ErrorContains(t, err, "column name is empty")
+
+	_, err = FunctionChainExprArgInput(&schemapb.FunctionChainExprArg{})
+	assert.ErrorContains(t, err, "function chain expr arg is unset")
+}
+
+func TestProtoConversionErrors(t *testing.T) {
+	_, err := ProtoChainToRepr(nil)
+	assert.ErrorContains(t, err, "function chain proto is nil")
+
+	_, err = ProtoOpToRepr(nil)
+	assert.ErrorContains(t, err, "op proto is nil")
+
+	_, err = ProtoOpToRepr(&schemapb.FunctionChainOp{Op: " "})
+	assert.ErrorContains(t, err, "op name is empty")
+
+	_, err = ProtoOpToRepr(&schemapb.FunctionChainOp{Op: "map", Inputs: []string{" "}})
+	assert.ErrorContains(t, err, "input name is empty")
+
+	_, _, err = ProtoExprToRepr(&schemapb.FunctionChainExpr{Name: " "})
+	assert.ErrorContains(t, err, "expr name is empty")
+}
+
+func TestFunctionFromReprWithContextPassesTypedConfigAndContext(t *testing.T) {
+	funcName := "mock_context_function"
+	extraInfo := &models.ModelExtraInfo{ClusterID: "cluster-1", DBName: "db-1", BatchFactor: 7}
+	params := map[string]*schemapb.FunctionParamValue{"name": stringParam("custom")}
+	args := []*schemapb.FunctionChainExprArg{columnArg("text"), literalArg(intParam(10))}
+
+	called := false
+	err := types.RegisterFunction(funcName, func(ctx types.FunctionBuildContext, cfg types.FunctionConfig) (types.FunctionExpr, error) {
+		called = true
+		assert.Same(t, extraInfo, ctx.ModelExtraInfo)
+		assert.Equal(t, funcName, cfg.Name)
+		assert.Same(t, params["name"], cfg.Params["name"])
+		require.Len(t, cfg.Args, 2)
+		assert.Same(t, args[0], cfg.Args[0])
+		assert.Same(t, args[1], cfg.Args[1])
+		return &MockFunctionExpr{name: cfg.Name}, nil
+	})
+	require.NoError(t, err)
+
+	fn, err := FunctionFromReprWithContext(&FunctionRepr{
+		Name:   funcName,
+		Params: params,
+		Args:   args,
+	}, types.FunctionBuildContext{ModelExtraInfo: extraInfo})
+	require.NoError(t, err)
+	require.NotNil(t, fn)
+	assert.True(t, called)
+	assert.Equal(t, funcName, fn.Name())
+}
+
+func TestFunctionFromReprWithContextRejectsLiteralArgsByDefault(t *testing.T) {
+	_, err := FunctionFromReprWithContext(&FunctionRepr{
+		Name: chainexpr.NumCombineFuncName,
+		Args: []*schemapb.FunctionChainExprArg{
+			columnArg("score"),
+			literalArg(intParam(10)),
+		},
+	}, types.FunctionBuildContext{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "num_combine: literal expr arg[1] is not supported")
+}
+
+func TestFunctionFromReprWithContextErrors(t *testing.T) {
+	_, err := FunctionFromReprWithContext(nil, types.FunctionBuildContext{})
+	assert.ErrorContains(t, err, "function repr is nil")
+
+	_, err = FunctionFromReprWithContext(&FunctionRepr{}, types.FunctionBuildContext{})
+	assert.ErrorContains(t, err, "function name is required")
+}
+
+func TestFuncChainFromReprWithContextPassesBuildContext(t *testing.T) {
+	funcName := "mock_chain_context_function"
+	extraInfo := &models.ModelExtraInfo{ClusterID: "cluster-2", DBName: "db-2", BatchFactor: 11}
+	params := map[string]*schemapb.FunctionParamValue{"flag": boolParam(true)}
+	args := []*schemapb.FunctionChainExprArg{columnArg("score")}
+
+	called := false
+	err := types.RegisterFunction(funcName, func(ctx types.FunctionBuildContext, cfg types.FunctionConfig) (types.FunctionExpr, error) {
+		called = true
+		assert.Same(t, extraInfo, ctx.ModelExtraInfo)
+		assert.Equal(t, funcName, cfg.Name)
+		assert.Same(t, params["flag"], cfg.Params["flag"])
+		require.Len(t, cfg.Args, 1)
+		assert.Same(t, args[0], cfg.Args[0])
+		return &MockFunctionExpr{name: cfg.Name}, nil
+	})
+	require.NoError(t, err)
+
+	repr := &ChainRepr{
+		Name:  "context-chain",
+		Stage: types.StageL2Rerank,
+		Operators: []OperatorRepr{
+			{
+				Type: types.OpTypeMap,
+				Function: &FunctionRepr{
+					Name:   funcName,
+					Params: params,
+					Args:   args,
+				},
+				Inputs:  []string{"score"},
+				Outputs: []string{"new_score"},
+			},
+		},
+	}
+
+	chain, err := FuncChainFromReprWithContext(repr, memory.NewGoAllocator(), types.FunctionBuildContext{ModelExtraInfo: extraInfo})
+	require.NoError(t, err)
+	require.NotNil(t, chain)
+	assert.True(t, called)
+	assert.Len(t, chain.operators, 1)
 }
 
 func TestFuncChainFromRepr(t *testing.T) {
@@ -257,36 +501,72 @@ func TestFuncChainFromRepr(t *testing.T) {
 				Type: types.OpTypeFilter,
 				Function: &FunctionRepr{
 					Name:   "mock_filter",
-					Params: map[string]interface{}{},
+					Params: map[string]*schemapb.FunctionParamValue{},
 				},
 				Inputs: []string{"score"},
 			},
 			{
 				Type: types.OpTypeSelect,
-				Params: map[string]interface{}{
-					"columns": []string{"a", "b"},
+				Params: map[string]*schemapb.FunctionParamValue{
+					"columns": arrayParam(stringParam("a"), stringParam("b")),
 				},
 			},
 			{
-				Type: types.OpTypeSort,
-				Params: map[string]interface{}{
-					"column": "a",
-					"desc":   true,
+				Type:   types.OpTypeSort,
+				Inputs: []string{"a"},
+				Params: map[string]*schemapb.FunctionParamValue{
+					"desc": boolParam(true),
 				},
 			},
 			{
 				Type: types.OpTypeLimit,
-				Params: map[string]interface{}{
-					"limit":  int64(100),
-					"offset": int64(10),
+				Params: map[string]*schemapb.FunctionParamValue{
+					"limit":  intParam(100),
+					"offset": intParam(10),
 				},
 			},
 		},
 	}
 
-	chain, err := funcChainFromRepr(repr, memory.NewGoAllocator())
+	chain, err := FuncChainFromRepr(repr, memory.NewGoAllocator())
 	assert.NoError(t, err)
 	assert.NotNil(t, chain)
 	assert.Equal(t, "repr-chain", chain.name)
 	assert.Len(t, chain.operators, 4)
+}
+
+func columnArg(name string) *schemapb.FunctionChainExprArg {
+	return &schemapb.FunctionChainExprArg{Arg: &schemapb.FunctionChainExprArg_Column{Column: &schemapb.FunctionChainColumnArg{Name: name}}}
+}
+
+func literalArg(value *schemapb.FunctionParamValue) *schemapb.FunctionChainExprArg {
+	return &schemapb.FunctionChainExprArg{Arg: &schemapb.FunctionChainExprArg_Literal{Literal: value}}
+}
+
+func boolParam(value bool) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_BoolValue{BoolValue: value}}
+}
+
+func intParam(value int64) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_Int64Value{Int64Value: value}}
+}
+
+func doubleParam(value float64) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_DoubleValue{DoubleValue: value}}
+}
+
+func stringParam(value string) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_StringValue{StringValue: value}}
+}
+
+func bytesParam(value []byte) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_BytesValue{BytesValue: value}}
+}
+
+func arrayParam(values ...*schemapb.FunctionParamValue) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_ArrayValue{ArrayValue: &schemapb.FunctionParamArray{Values: values}}}
+}
+
+func objectParam(fields map[string]*schemapb.FunctionParamValue) *schemapb.FunctionParamValue {
+	return &schemapb.FunctionParamValue{Value: &schemapb.FunctionParamValue_ObjectValue{ObjectValue: &schemapb.FunctionParamObject{Fields: fields}}}
 }

--- a/internal/util/function/chain/rerank_builder.go
+++ b/internal/util/function/chain/rerank_builder.go
@@ -251,7 +251,7 @@ func convertLegacyParams(rankParams []*commonpb.KeyValuePair) (*schemapb.Functio
 //     Merge(Weighted) → Sort/GroupBy → [RoundDecimal] → Select
 //
 //  3. Decay:
-//     Merge(Max|Sum|Avg) → Map(DecayExpr→_decay_score) → Map(ScoreCombine: $score*_decay_score→$score) → Sort/GroupBy → [RoundDecimal] → Select
+//     Merge(Max|Sum|Avg) → Map(DecayExpr→_decay_score) → Map(NumCombine: $score*_decay_score→$score) → Sort/GroupBy → [RoundDecimal] → Select
 //
 //  4. Model:
 //     Merge(Max) → Map(RerankModelExpr) → Sort/GroupBy → [RoundDecimal] → Select
@@ -331,7 +331,7 @@ func buildRerankChainInternal(
 		fc.Add(groupByOp)
 	} else {
 		// Non-grouping: sort by score and apply limit
-		fc.Sort(types.ScoreFieldName, sortDescending)
+		fc.Sort(types.ScoreFieldName, sortDescending, types.IDFieldName)
 		if searchParams.Limit > 0 {
 			fc.LimitWithOffset(searchParams.Limit, searchParams.Offset)
 		}
@@ -491,7 +491,7 @@ func buildDecayChain(fc *FuncChain, collSchema *schemapb.CollectionSchema, funcS
 		WithForceDescending(true))
 
 	// DecayExpr only computes the decay factor (0~1) into an intermediate column,
-	// then ScoreCombineExpr multiplies it with $score.
+	// then NumCombineExpr multiplies it with $score.
 	decayScoreCol := "_decay_score"
 
 	decayExpr, err := expr.NewDecayExpr(
@@ -509,7 +509,7 @@ func buildDecayChain(fc *FuncChain, collSchema *schemapb.CollectionSchema, funcS
 		[]string{inputField},
 		[]string{decayScoreCol})
 
-	combineExpr, err := expr.NewScoreCombineExpr(expr.ModeMultiply, nil, expr.WithNullPolicy(expr.ScoreCombineNullAsZero))
+	combineExpr, err := expr.NewNumCombineExpr(expr.ModeMultiply, nil, expr.WithNullPolicy(expr.NumCombineNullAsZero))
 	if err != nil {
 		return merr.WrapErrParameterInvalidMsg("rerank_builder: %v", err)
 	}

--- a/internal/util/function/chain/rerank_builder_test.go
+++ b/internal/util/function/chain/rerank_builder_test.go
@@ -380,7 +380,7 @@ func (s *RerankBuilderTestSuite) TestBuildDecayChain() {
 	s.Require().NoError(err)
 	s.NotNil(fc)
 
-	// Verify chain structure: MergeOp -> MapOp(Decay) -> MapOp(ScoreCombine) -> SortOp -> LimitOp -> SelectOp
+	// Verify chain structure: MergeOp -> MapOp(Decay) -> MapOp(NumCombine) -> SortOp -> LimitOp -> SelectOp
 	s.Equal(6, len(fc.operators))
 	s.Equal("Merge", fc.operators[0].Name())
 	s.Equal("Map", fc.operators[1].Name())
@@ -1213,7 +1213,7 @@ func (s *RerankBuilderTestSuite) TestBuildDecayChainWithGrouping() {
 	s.Require().NoError(err)
 	s.NotNil(fc)
 
-	// Verify chain structure: MergeOp -> MapOp(Decay) -> MapOp(ScoreCombine) -> GroupByOp -> SelectOp
+	// Verify chain structure: MergeOp -> MapOp(Decay) -> MapOp(NumCombine) -> GroupByOp -> SelectOp
 	s.Equal(5, len(fc.operators))
 	s.Equal("Merge", fc.operators[0].Name())
 	s.Equal("Map", fc.operators[1].Name())

--- a/internal/util/function/chain/types/constants.go
+++ b/internal/util/function/chain/types/constants.go
@@ -54,17 +54,17 @@ const (
 // =============================================================================
 
 const (
-	// Score combine parameter keys
-	ScoreCombineParamMode    = "mode"
-	ScoreCombineParamWeights = "weights"
+	// Numeric combine parameter keys
+	NumCombineParamMode    = "mode"
+	NumCombineParamWeights = "weights"
 
-	// Score combine mode values
-	ScoreCombineModeMultiply = "multiply"
-	ScoreCombineModeSum      = "sum"
-	ScoreCombineModeMax      = "max"
-	ScoreCombineModeMin      = "min"
-	ScoreCombineModeAvg      = "avg"
-	ScoreCombineModeWeighted = "weighted"
+	// Numeric combine mode values
+	NumCombineModeMultiply = "multiply"
+	NumCombineModeSum      = "sum"
+	NumCombineModeMax      = "max"
+	NumCombineModeMin      = "min"
+	NumCombineModeAvg      = "avg"
+	NumCombineModeWeighted = "weighted"
 )
 
 // =============================================================================

--- a/internal/util/function/chain/types/param_reader.go
+++ b/internal/util/function/chain/types/param_reader.go
@@ -1,0 +1,198 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package types
+
+import (
+	"strconv"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// ParamReader reads typed FunctionChain params from schemapb.FunctionParamValue.
+// It is shared by FunctionExpr factories and typed Operator factories.
+type ParamReader struct {
+	scope  string
+	params map[string]*schemapb.FunctionParamValue
+}
+
+// NewParamReader creates a reader for typed FunctionChain params. The scope is
+// used in error messages, typically the function or operator name.
+func NewParamReader(scope string, params map[string]*schemapb.FunctionParamValue) ParamReader {
+	return ParamReader{scope: scope, params: params}
+}
+
+func (r ParamReader) get(key string, required bool) (*schemapb.FunctionParamValue, bool, error) {
+	value, ok := r.params[key]
+	if !ok {
+		if required {
+			return nil, false, merr.WrapErrParameterInvalidMsg("%s: missing required parameter %q", r.scope, key)
+		}
+		return nil, false, nil
+	}
+	if value == nil || value.GetValue() == nil {
+		return nil, false, merr.WrapErrParameterInvalidMsg("%s: parameter %q is unset", r.scope, key)
+	}
+	return value, true, nil
+}
+
+func (r ParamReader) String(key string, required bool) (string, error) {
+	value, ok, err := r.get(key, required)
+	if err != nil || !ok {
+		return "", err
+	}
+	v, ok := value.GetValue().(*schemapb.FunctionParamValue_StringValue)
+	if !ok {
+		return "", merr.WrapErrParameterInvalidMsg("%s: parameter %q must be a string", r.scope, key)
+	}
+	return v.StringValue, nil
+}
+
+func (r ParamReader) Int64(key string, required bool, defaultVal int64) (int64, error) {
+	value, ok, err := r.get(key, required)
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return defaultVal, nil
+	}
+	switch v := value.GetValue().(type) {
+	case *schemapb.FunctionParamValue_Int64Value:
+		return v.Int64Value, nil
+	case *schemapb.FunctionParamValue_DoubleValue:
+		if float64(int64(v.DoubleValue)) != v.DoubleValue {
+			return 0, merr.WrapErrParameterInvalidMsg("%s: parameter %q must be an integer, got %f", r.scope, key, v.DoubleValue)
+		}
+		return int64(v.DoubleValue), nil
+	default:
+		return 0, merr.WrapErrParameterInvalidMsg("%s: parameter %q must be an integer", r.scope, key)
+	}
+}
+
+func (r ParamReader) Float64(key string, required bool, defaultVal float64) (float64, error) {
+	value, ok, err := r.get(key, required)
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return defaultVal, nil
+	}
+	switch v := value.GetValue().(type) {
+	case *schemapb.FunctionParamValue_DoubleValue:
+		return v.DoubleValue, nil
+	case *schemapb.FunctionParamValue_Int64Value:
+		return float64(v.Int64Value), nil
+	default:
+		return 0, merr.WrapErrParameterInvalidMsg("%s: parameter %q must be a number", r.scope, key)
+	}
+}
+
+func (r ParamReader) Bool(key string, required bool, defaultVal bool) (bool, error) {
+	value, ok, err := r.get(key, required)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return defaultVal, nil
+	}
+	v, ok := value.GetValue().(*schemapb.FunctionParamValue_BoolValue)
+	if !ok {
+		return false, merr.WrapErrParameterInvalidMsg("%s: parameter %q must be a bool", r.scope, key)
+	}
+	return v.BoolValue, nil
+}
+
+func (r ParamReader) StringSlice(key string, required bool) ([]string, error) {
+	value, ok, err := r.get(key, required)
+	if err != nil || !ok {
+		return nil, err
+	}
+	arrayValue, ok := value.GetValue().(*schemapb.FunctionParamValue_ArrayValue)
+	if !ok {
+		return nil, merr.WrapErrParameterInvalidMsg("%s: parameter %q must be a string array", r.scope, key)
+	}
+	values := arrayValue.ArrayValue.GetValues()
+	result := make([]string, len(values))
+	for i, item := range values {
+		v, ok := item.GetValue().(*schemapb.FunctionParamValue_StringValue)
+		if !ok {
+			return nil, merr.WrapErrParameterInvalidMsg("%s: parameter %q[%d] must be a string", r.scope, key, i)
+		}
+		result[i] = v.StringValue
+	}
+	return result, nil
+}
+
+func (r ParamReader) Float64Slice(key string, required bool) ([]float64, error) {
+	value, ok, err := r.get(key, required)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	arrayValue, ok := value.GetValue().(*schemapb.FunctionParamValue_ArrayValue)
+	if !ok {
+		return nil, merr.WrapErrParameterInvalidMsg("%s: parameter %q must be a number array", r.scope, key)
+	}
+	values := arrayValue.ArrayValue.GetValues()
+	result := make([]float64, len(values))
+	for i, item := range values {
+		switch v := item.GetValue().(type) {
+		case *schemapb.FunctionParamValue_DoubleValue:
+			result[i] = v.DoubleValue
+		case *schemapb.FunctionParamValue_Int64Value:
+			result[i] = float64(v.Int64Value)
+		default:
+			return nil, merr.WrapErrParameterInvalidMsg("%s: parameter %q[%d] must be a number", r.scope, key, i)
+		}
+	}
+	return result, nil
+}
+
+func (r ParamReader) KeyValuePairs() ([]*commonpb.KeyValuePair, error) {
+	result := make([]*commonpb.KeyValuePair, 0, len(r.params))
+	for key, value := range r.params {
+		strValue, err := r.ParamValueToString(key, value)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, &commonpb.KeyValuePair{Key: key, Value: strValue})
+	}
+	return result, nil
+}
+
+func (r ParamReader) ParamValueToString(key string, value *schemapb.FunctionParamValue) (string, error) {
+	if value == nil || value.GetValue() == nil {
+		return "", merr.WrapErrParameterInvalidMsg("%s: parameter %q is unset", r.scope, key)
+	}
+	switch v := value.GetValue().(type) {
+	case *schemapb.FunctionParamValue_StringValue:
+		return v.StringValue, nil
+	case *schemapb.FunctionParamValue_Int64Value:
+		return strconv.FormatInt(v.Int64Value, 10), nil
+	case *schemapb.FunctionParamValue_DoubleValue:
+		return strconv.FormatFloat(v.DoubleValue, 'f', -1, 64), nil
+	case *schemapb.FunctionParamValue_BoolValue:
+		return strconv.FormatBool(v.BoolValue), nil
+	default:
+		return "", merr.WrapErrParameterInvalidMsg("%s: parameter %q must be scalar string/number/bool", r.scope, key)
+	}
+}

--- a/internal/util/function/chain/types/registry.go
+++ b/internal/util/function/chain/types/registry.go
@@ -79,12 +79,12 @@ func (r *FunctionRegistry) Get(name string) (FunctionFactory, bool) {
 }
 
 // Create creates a FunctionExpr using the factory registered with the given name.
-func (r *FunctionRegistry) Create(name string, params map[string]interface{}) (FunctionExpr, error) {
-	factory, ok := r.Get(name)
+func (r *FunctionRegistry) Create(ctx FunctionBuildContext, cfg FunctionConfig) (FunctionExpr, error) {
+	factory, ok := r.Get(cfg.Name)
 	if !ok {
-		return nil, merr.WrapErrParameterInvalidMsg("unknown function: %s", name)
+		return nil, merr.WrapErrParameterInvalidMsg("unknown function: %s", cfg.Name)
 	}
-	return factory(params)
+	return factory(ctx, cfg)
 }
 
 // Has returns true if a function with the given name is registered.
@@ -131,8 +131,8 @@ func GetFunctionFactory(name string) (FunctionFactory, bool) {
 }
 
 // CreateFunction creates a FunctionExpr using the global registry.
-func CreateFunction(name string, params map[string]interface{}) (FunctionExpr, error) {
-	return globalRegistry.Create(name, params)
+func CreateFunction(ctx FunctionBuildContext, cfg FunctionConfig) (FunctionExpr, error) {
+	return globalRegistry.Create(ctx, cfg)
 }
 
 // HasFunction returns true if a function with the given name is registered in the global registry.

--- a/internal/util/function/chain/types/registry_test.go
+++ b/internal/util/function/chain/types/registry_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 )
 
 // dummyFunc is a minimal FunctionExpr implementation for testing.
@@ -43,7 +45,7 @@ func (d *dummyFunc) IsRunnable(_ string) bool { return true }
 
 // dummyFactory returns a FunctionFactory that produces a dummyFunc with the given name.
 func dummyFactory(name string) FunctionFactory {
-	return func(params map[string]interface{}) (FunctionExpr, error) {
+	return func(_ FunctionBuildContext, _ FunctionConfig) (FunctionExpr, error) {
 		return &dummyFunc{name: name}, nil
 	}
 }
@@ -132,7 +134,7 @@ func TestFunctionRegistry_Get(t *testing.T) {
 	assert.NotNil(t, factory)
 
 	// Verify the factory produces the expected function
-	fn, err := factory(nil)
+	fn, err := factory(FunctionBuildContext{}, FunctionConfig{})
 	require.NoError(t, err)
 	assert.Equal(t, "get_func", fn.Name())
 }
@@ -149,21 +151,26 @@ func TestFunctionRegistry_Create(t *testing.T) {
 	r := NewFunctionRegistry()
 	r.MustRegister("create_func", dummyFactory("create_func"))
 
-	fn, err := r.Create("create_func", nil)
+	fn, err := r.Create(FunctionBuildContext{}, FunctionConfig{Name: "create_func"})
 	require.NoError(t, err)
 	assert.Equal(t, "create_func", fn.Name())
 }
 
-func TestFunctionRegistry_Create_WithParams(t *testing.T) {
+func TestFunctionRegistry_Create_WithConfig(t *testing.T) {
 	r := NewFunctionRegistry()
 
-	// Register a factory that reads params
-	r.MustRegister("param_func", func(params map[string]interface{}) (FunctionExpr, error) {
-		name, _ := params["name"].(string)
+	r.MustRegister("param_func", func(_ FunctionBuildContext, cfg FunctionConfig) (FunctionExpr, error) {
+		name := cfg.Name
+		if v := cfg.Params["name"]; v != nil && v.GetStringValue() != "" {
+			name = v.GetStringValue()
+		}
 		return &dummyFunc{name: name}, nil
 	})
 
-	fn, err := r.Create("param_func", map[string]interface{}{"name": "custom"})
+	fn, err := r.Create(FunctionBuildContext{}, FunctionConfig{
+		Name:   "param_func",
+		Params: map[string]*schemapb.FunctionParamValue{"name": {Value: &schemapb.FunctionParamValue_StringValue{StringValue: "custom"}}},
+	})
 	require.NoError(t, err)
 	assert.Equal(t, "custom", fn.Name())
 }
@@ -171,7 +178,7 @@ func TestFunctionRegistry_Create_WithParams(t *testing.T) {
 func TestFunctionRegistry_Create_NotFound(t *testing.T) {
 	r := NewFunctionRegistry()
 
-	fn, err := r.Create("missing", nil)
+	fn, err := r.Create(FunctionBuildContext{}, FunctionConfig{Name: "missing"})
 	assert.Error(t, err)
 	assert.Nil(t, fn)
 	assert.Contains(t, err.Error(), "unknown function")
@@ -253,7 +260,7 @@ func TestGlobalRegistry_GetFunctionFactory(t *testing.T) {
 	assert.True(t, ok)
 	assert.NotNil(t, factory)
 
-	fn, err := factory(nil)
+	fn, err := factory(FunctionBuildContext{}, FunctionConfig{})
 	require.NoError(t, err)
 	assert.Equal(t, name, fn.Name())
 }
@@ -269,13 +276,13 @@ func TestGlobalRegistry_CreateFunction(t *testing.T) {
 
 	MustRegisterFunction(name, dummyFactory(name))
 
-	fn, err := CreateFunction(name, nil)
+	fn, err := CreateFunction(FunctionBuildContext{}, FunctionConfig{Name: name})
 	require.NoError(t, err)
 	assert.Equal(t, name, fn.Name())
 }
 
 func TestGlobalRegistry_CreateFunction_NotFound(t *testing.T) {
-	fn, err := CreateFunction("test_global_create_missing_xyz", nil)
+	fn, err := CreateFunction(FunctionBuildContext{}, FunctionConfig{Name: "test_global_create_missing_xyz"})
 	assert.Error(t, err)
 	assert.Nil(t, fn)
 	assert.Contains(t, err.Error(), "unknown function")

--- a/internal/util/function/chain/types/types.go
+++ b/internal/util/function/chain/types/types.go
@@ -26,6 +26,9 @@ import (
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/memory"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/function/models"
 )
 
 // =============================================================================
@@ -110,7 +113,7 @@ func (ctx *FuncContext) Stage() string {
 // Functions are stateless and only focus on computation logic.
 // Column mapping is handled by the Operator layer (MapOp).
 type FunctionExpr interface {
-	// Name returns the function name (e.g., "decay", "score_combine").
+	// Name returns the function name (e.g., "decay", "num_combine").
 	Name() string
 
 	// OutputDataTypes returns the data types of output columns.
@@ -130,5 +133,24 @@ type FunctionExpr interface {
 	IsRunnable(stage string) bool
 }
 
-// FunctionFactory is a factory function that creates a FunctionExpr from parameters.
-type FunctionFactory func(params map[string]interface{}) (FunctionExpr, error)
+// FunctionArgValidator validates public expression args for functions that have
+// per-expression arg policy.
+type FunctionArgValidator interface {
+	ValidateArgs(args []*schemapb.FunctionChainExprArg) error
+}
+
+// FunctionBuildContext contains runtime-only context used while constructing a FunctionExpr.
+// It is not serialized in public FunctionChain proto params.
+type FunctionBuildContext struct {
+	ModelExtraInfo *models.ModelExtraInfo
+}
+
+// FunctionConfig contains the public function expression configuration from FunctionChain proto.
+type FunctionConfig struct {
+	Name   string
+	Params map[string]*schemapb.FunctionParamValue
+	Args   []*schemapb.FunctionChainExprArg
+}
+
+// FunctionFactory is a factory function that creates a FunctionExpr from typed config.
+type FunctionFactory func(ctx FunctionBuildContext, cfg FunctionConfig) (FunctionExpr, error)

--- a/tests/restful_client_v2/testcases/test_function_chain_api.py
+++ b/tests/restful_client_v2/testcases/test_function_chain_api.py
@@ -1,0 +1,496 @@
+import pytest
+from base.testbase import TestBase
+from pymilvus import Collection
+from utils.constant import CaseLabel
+from utils.utils import gen_collection_name
+
+prefix = "function_chain_api"
+
+
+@pytest.mark.tags(CaseLabel.L0)
+class TestFunctionChainAPI(TestBase):
+    """
+    ******************************************************************
+      The following cases test Function Chain RESTful API integration.
+    ******************************************************************
+    """
+
+    def _create_function_chain_collection(self):
+        name = gen_collection_name(prefix)
+        self.name = name
+        payload = {
+            "collectionName": name,
+            "schema": {
+                "autoId": False,
+                "enableDynamicField": False,
+                "fields": [
+                    {"fieldName": "id", "dataType": "Int64", "isPrimary": True, "elementTypeParams": {}},
+                    {"fieldName": "ts", "dataType": "Int64", "elementTypeParams": {}},
+                    {"fieldName": "vector", "dataType": "FloatVector", "elementTypeParams": {"dim": "2"}},
+                ],
+            },
+            "indexParams": [
+                {"fieldName": "vector", "indexName": "vector", "indexType": "FLAT", "metricType": "L2"},
+            ],
+        }
+        rsp = self.collection_client.collection_create(payload)
+        assert rsp["code"] == 0, f"create collection failed: {rsp}"
+
+        data = [
+            {"id": 1, "ts": 10, "vector": [0.0, 0.0]},
+            {"id": 2, "ts": 20, "vector": [0.01, 0.0]},
+            {"id": 3, "ts": 30, "vector": [0.02, 0.0]},
+        ]
+        rsp = self.vector_client.vector_insert({"collectionName": name, "data": data})
+        assert rsp["code"] == 0, f"insert failed: {rsp}"
+        assert rsp["data"]["insertCount"] == len(data)
+        Collection(name).flush()
+        self.collection_client.collection_load(collection_name=name)
+        self.wait_load_completed(name, timeout=30)
+        return name
+
+    def _score_plus_ts_function_chain(self):
+        return [
+            {
+                "name": "l2_score_plus_ts",
+                "stage": "FunctionChainStageL2Rerank",
+                "ops": [
+                    {
+                        "op": "map",
+                        "outputs": ["$score"],
+                        "expr": {
+                            "name": "num_combine",
+                            "args": [
+                                {"column": "$score"},
+                                {"column": "ts"},
+                            ],
+                            "params": {"mode": "sum"},
+                        },
+                    },
+                    {
+                        "op": "sort",
+                        "inputs": ["$score"],
+                        "params": {"column": "$score", "desc": True},
+                    },
+                ],
+            }
+        ]
+
+    def test_search_with_function_chains_reranks_by_scalar_field(self):
+        """
+        target: test REST v2 search with functionChains
+        method: map $score = num_combine($score, ts), then sort $score desc
+        expected: search succeeds and result order follows rewritten score
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 3,
+            "outputFields": ["ts"],
+            "functionChains": self._score_plus_ts_function_chain(),
+        }
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] == 0, f"search with functionChains failed: {rsp}"
+        assert len(rsp["data"]) == 3
+
+        ids = [item["id"] for item in rsp["data"]]
+        timestamps = [item["ts"] for item in rsp["data"]]
+        distances = [item["distance"] for item in rsp["data"]]
+
+        assert ids == [3, 2, 1]
+        assert timestamps == [30, 20, 10]
+        assert distances == sorted(distances, reverse=True)
+        assert distances[0] > 29
+        assert distances[-1] > 9
+
+    def test_search_function_chains_can_use_hidden_input_field(self):
+        """
+        target: test REST v2 search fetches functionChain input fields even when not returned
+        method: rerank by ts but only request id in outputFields
+        expected: search succeeds, result order follows ts, and hidden ts is not returned
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 3,
+            "outputFields": ["id"],
+            "functionChains": self._score_plus_ts_function_chain(),
+        }
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] == 0, f"search with hidden functionChain input failed: {rsp}"
+        assert [item["id"] for item in rsp["data"]] == [3, 2, 1]
+        assert all("ts" not in item for item in rsp["data"])
+
+    def test_search_function_chains_limit_op(self):
+        """
+        target: test REST v2 search supports functionChain limit operator
+        method: request limit=3 and apply functionChains limit op with limit=2
+        expected: search returns only function-chain-limited results
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 3,
+            "functionChains": [
+                {
+                    "name": "l2_limit",
+                    "stage": "FunctionChainStageL2Rerank",
+                    "ops": [
+                        {
+                            "op": "limit",
+                            "params": {"limit": 2},
+                        }
+                    ],
+                }
+            ],
+        }
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] == 0, f"search with functionChains limit failed: {rsp}"
+        assert len(rsp["data"]) == 2
+
+    def test_search_function_chains_temp_column_not_returned_and_rerank_correct(self):
+        """
+        target: test REST v2 search supports normal temporary functionChain columns
+        method: write rerank score to tmp_score, then write tmp_score back to $score and sort
+        expected: search succeeds, rerank order is correct, and tmp_score is not returned
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 3,
+            "outputFields": ["ts"],
+            "functionChains": [
+                {
+                    "name": "l2_temp_score",
+                    "stage": "FunctionChainStageL2Rerank",
+                    "ops": [
+                        {
+                            "op": "map",
+                            "outputs": ["tmp_score"],
+                            "expr": {
+                                "name": "num_combine",
+                                "args": [
+                                    {"column": "$score"},
+                                    {"column": "ts"},
+                                ],
+                                "params": {"mode": "sum"},
+                            },
+                        },
+                        {
+                            "op": "map",
+                            "outputs": ["$score"],
+                            "expr": {
+                                "name": "num_combine",
+                                "args": [
+                                    {"column": "tmp_score"},
+                                    {"column": "$score"},
+                                ],
+                                "params": {"mode": "sum"},
+                            },
+                        },
+                        {
+                            "op": "sort",
+                            "inputs": ["$score"],
+                            "params": {"column": "$score", "desc": True},
+                        },
+                    ],
+                }
+            ],
+        }
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] == 0, f"search with temporary functionChain column failed: {rsp}"
+        assert [item["id"] for item in rsp["data"]] == [3, 2, 1]
+        assert [item["ts"] for item in rsp["data"]] == [30, 20, 10]
+        assert all("tmp_score" not in item for item in rsp["data"])
+
+    def test_search_rejects_function_chains_reserved_temp_output(self):
+        """
+        target: test REST v2 functionChains reject user temporary columns in system namespace
+        method: write a map output named $tmp_score
+        expected: request fails because $ prefix is reserved for system columns
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 3,
+            "functionChains": [
+                {
+                    "name": "bad_reserved_output",
+                    "stage": "FunctionChainStageL2Rerank",
+                    "ops": [
+                        {
+                            "op": "map",
+                            "outputs": ["$tmp_score"],
+                            "expr": {
+                                "name": "num_combine",
+                                "args": [
+                                    {"column": "$score"},
+                                    {"column": "ts"},
+                                ],
+                                "params": {"mode": "sum"},
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] != 0
+        assert "$tmp_score" in rsp["message"]
+
+    def test_search_rejects_function_chains_write_readonly_system_column(self):
+        """
+        target: test REST v2 functionChains reject writes to read-only system columns
+        method: write map output to $id
+        expected: request fails because only $score is writable in L2 rerank chains
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 3,
+            "functionChains": [
+                {
+                    "name": "bad_write_id",
+                    "stage": "FunctionChainStageL2Rerank",
+                    "ops": [
+                        {
+                            "op": "map",
+                            "outputs": ["$id"],
+                            "expr": {
+                                "name": "num_combine",
+                                "args": [
+                                    {"column": "$score"},
+                                    {"column": "ts"},
+                                ],
+                                "params": {"mode": "sum"},
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] != 0
+        assert "$id" in rsp["message"]
+
+    def test_search_rejects_function_chains_unknown_system_input(self):
+        """
+        target: test REST v2 functionChains reject unknown system input columns
+        method: read $tmp_score from a map expression
+        expected: request fails because users cannot invent new $-prefixed system columns
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 3,
+            "functionChains": [
+                {
+                    "name": "bad_system_input",
+                    "stage": "FunctionChainStageL2Rerank",
+                    "ops": [
+                        {
+                            "op": "map",
+                            "outputs": ["$score"],
+                            "expr": {
+                                "name": "num_combine",
+                                "args": [
+                                    {"column": "$tmp_score"},
+                                    {"literal": 1},
+                                ],
+                                "params": {"mode": "sum"},
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] != 0
+        assert "$tmp_score" in rsp["message"]
+
+    def test_search_rejects_function_chains_unreadable_system_input(self):
+        """
+        target: test REST v2 functionChains reject internal system input columns
+        method: read $seg_offset from a map expression
+        expected: request fails because L2 rerank chains only expose selected system inputs
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 3,
+            "functionChains": [
+                {
+                    "name": "bad_seg_offset_input",
+                    "stage": "FunctionChainStageL2Rerank",
+                    "ops": [
+                        {
+                            "op": "map",
+                            "outputs": ["$score"],
+                            "expr": {
+                                "name": "num_combine",
+                                "args": [
+                                    {"column": "$seg_offset"},
+                                    {"literal": 1},
+                                ],
+                                "params": {"mode": "sum"},
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] != 0
+        assert "$seg_offset" in rsp["message"]
+
+    def test_search_rejects_function_score_with_function_chains(self):
+        """
+        target: test REST v2 search rejects ambiguous rerank APIs
+        method: send functionScore and functionChains together
+        expected: request fails with mutual-exclusive error
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 3,
+            "functionScore": {
+                "functions": [
+                    {
+                        "name": "decay_ts",
+                        "type": "Rerank",
+                        "inputFieldNames": ["ts"],
+                        "params": {
+                            "reranker": "decay",
+                            "function": "linear",
+                            "origin": 30,
+                            "scale": 10,
+                            "offset": 0,
+                            "decay": 0.5,
+                        },
+                    }
+                ]
+            },
+            "functionChains": self._score_plus_ts_function_chain(),
+        }
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] != 0
+        assert "function_score and function_chains cannot be used together" in rsp["message"]
+
+    def test_search_rejects_function_chains_bad_stage(self):
+        """
+        target: test REST v2 functionChains stage validation
+        method: send an ingestion-stage chain in a search request
+        expected: request fails because search only supports L2 rerank chains
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 3,
+            "functionChains": [
+                {
+                    "name": "bad_stage",
+                    "stage": "FunctionChainStageIngestion",
+                    "ops": [
+                        {
+                            "op": "limit",
+                            "params": {"limit": 2},
+                        }
+                    ],
+                }
+            ],
+        }
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] != 0
+        assert "stage FunctionChainStageIngestion is not supported in search request" in rsp["message"]
+
+    def test_search_rejects_function_chains_bad_expr_arg(self):
+        """
+        target: test REST v2 functionChains expression argument validation
+        method: send an expression arg with both column and literal
+        expected: request fails with exactly-one-of validation error
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "data": [[0.0, 0.0]],
+            "annsField": "vector",
+            "limit": 3,
+            "functionChains": [
+                {
+                    "name": "bad_arg",
+                    "stage": "FunctionChainStageL2Rerank",
+                    "ops": [
+                        {
+                            "op": "map",
+                            "outputs": ["$score"],
+                            "expr": {
+                                "name": "num_combine",
+                                "args": [
+                                    {"column": "$score"},
+                                    {"column": "ts", "literal": 1},
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+        rsp = self.vector_client.vector_search(payload)
+        assert rsp["code"] != 0
+        assert "exactly one of column or literal is required" in rsp["message"]
+
+    def test_hybrid_search_rejects_function_chains(self):
+        """
+        target: test REST v2 hybrid search rejects functionChains in first version
+        method: send top-level functionChains to hybrid_search
+        expected: request fails with unsupported error
+        """
+        name = self._create_function_chain_collection()
+
+        payload = {
+            "collectionName": name,
+            "search": [
+                {
+                    "data": [[0.0, 0.0]],
+                    "annsField": "vector",
+                    "limit": 3,
+                }
+            ],
+            "rerank": {"strategy": "rrf", "params": {}},
+            "limit": 3,
+            "functionChains": self._score_plus_ts_function_chain(),
+        }
+        rsp = self.vector_client.vector_hybrid_search(payload)
+        assert rsp["code"] != 0
+        assert "functionChains is not supported for hybrid search yet" in rsp["message"]


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/50571
design doc: docs/design-docs/design_docs/20260624-function-chain-api.md

Add the FunctionChain proto-to-runtime path for ordinary Search L2 rerank. The change converts public FunctionChain protos into ChainRepr, derives caller-independent read/write metadata, validates Search-specific inputs in Proxy, and executes public chains through the existing rerank pipeline.

Add request validation for duplicate stages, unsupported stages, unsupported system inputs/outputs, unknown schema fields, unsupported input field types, and hybrid-search usage. Extend REST v2 request conversion to accept function_chains.

Replace score_combine with num_combine and add typed parameter readers, repr-based FuncChain construction, chain optimization/pruning helpers, and model-rerank parameter handling. Add coverage for chain repr conversion, function/operator behavior, Proxy planning, search pipeline integration, REST conversion, and REST API cases.

Add the Function Chain API design document and update milvus-proto to the latest upstream pseudo-version.