### PR TITLE
fix: keep streaming segment delta until distribution catches up

### DIFF
--- a/internal/querycoordv2/task/action.go
+++ b/internal/querycoordv2/task/action.go
@@ -148,27 +148,28 @@ func (action *SegmentAction) IsFinished(distMgr *meta.DistributionManager) bool 
 }
 
 func (action *SegmentAction) isDistMatched(distMgr *meta.DistributionManager) bool {
+	inDist := segmentInDist(distMgr, action.Node(), action.GetShard(), action.GetSegmentID(), action.GetScope())
 	switch action.Type() {
 	case ActionTypeGrow:
-		return action.segmentInDist(distMgr)
+		return inDist
 	case ActionTypeReduce:
-		return !action.segmentInDist(distMgr)
+		return !inDist
 	default:
 		return true
 	}
 }
 
-func (action *SegmentAction) segmentInDist(distMgr *meta.DistributionManager) bool {
-	if action.GetScope() == querypb.DataScope_Streaming {
+func segmentInDist(distMgr *meta.DistributionManager, nodeID int64, channelName string, segmentID int64, scope querypb.DataScope) bool {
+	if scope == querypb.DataScope_Streaming {
 		channels := distMgr.ChannelDistManager.GetByFilter(
-			meta.WithNodeID2Channel(action.Node()),
-			meta.WithChannelName2Channel(action.GetShard()),
+			meta.WithNodeID2Channel(nodeID),
+			meta.WithChannelName2Channel(channelName),
 		)
 		for _, channel := range channels {
 			if channel.View == nil {
 				continue
 			}
-			if _, ok := channel.View.GrowingSegments[action.GetSegmentID()]; ok {
+			if _, ok := channel.View.GrowingSegments[segmentID]; ok {
 				return true
 			}
 		}
@@ -176,8 +177,8 @@ func (action *SegmentAction) segmentInDist(distMgr *meta.DistributionManager) bo
 	}
 
 	segments := distMgr.SegmentDistManager.GetByFilter(
-		meta.WithNodeID(action.Node()),
-		meta.WithSegmentID(action.GetSegmentID()),
+		meta.WithNodeID(nodeID),
+		meta.WithSegmentID(segmentID),
 	)
 	return len(segments) > 0
 }

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -267,6 +267,8 @@ type segmentDeltaRecord struct {
 	collectionID int64
 	nodeID       int64
 	segmentID    int64
+	channelName  string
+	scope        querypb.DataScope
 	actionType   ActionType
 	delta        int
 }
@@ -350,6 +352,8 @@ func (delta *SegmentTaskDelta) Add(task *SegmentTask) {
 			collectionID: task.CollectionID(),
 			nodeID:       segmentAction.Node(),
 			segmentID:    segmentAction.GetSegmentID(),
+			channelName:  segmentAction.GetShard(),
+			scope:        segmentAction.GetScope(),
 			actionType:   segmentAction.Type(),
 			delta:        segmentAction.WorkLoadEffect(),
 		})
@@ -407,17 +411,12 @@ func (record segmentDeltaRecord) isSegmentDistMatched(distMgr *meta.Distribution
 		return false
 	}
 
-	segments := distMgr.SegmentDistManager.GetByFilter(
-		meta.WithNodeID(record.nodeID),
-		meta.WithSegmentID(record.segmentID),
-	)
-	segmentInDist := len(segments) > 0
-
+	inDist := segmentInDist(distMgr, record.nodeID, record.channelName, record.segmentID, record.scope)
 	switch record.actionType {
 	case ActionTypeGrow:
-		return segmentInDist
+		return inDist
 	case ActionTypeReduce:
-		return !segmentInDist
+		return !inDist
 	default:
 		// Only grow/reduce actions affect segment presence; other segment
 		// actions have zero workload effect and are treated as reflected.

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -2119,6 +2119,59 @@ func (suite *TaskSuite) TestSegmentTaskDeltaWithDistFilter() {
 	suite.Equal(1, scheduler.GetChannelTaskDelta(targetNode, coll))
 }
 
+func (suite *TaskSuite) TestSegmentTaskDeltaSnapshotKeepsStreamingReduceUntilGrowingDistGone() {
+	ctx := context.Background()
+	scheduler := suite.newScheduler()
+
+	coll := int64(1001)
+	partition := int64(100)
+	channel := "channel-1"
+	sourceNode := int64(1)
+	segmentID := int64(102)
+	rowCount := 100
+
+	suite.dist.ChannelDistManager.Update(sourceNode, &meta.DmChannel{
+		VchannelInfo: &datapb.VchannelInfo{
+			CollectionID: coll,
+			ChannelName:  channel,
+		},
+		Node:    sourceNode,
+		Version: 1,
+		View: &meta.LeaderView{
+			ID:           sourceNode,
+			CollectionID: coll,
+			Channel:      channel,
+			GrowingSegments: map[int64]*meta.Segment{
+				segmentID: utils.CreateTestSegment(coll, partition, segmentID, sourceNode, 1, channel),
+			},
+		},
+	})
+
+	reduceTask, err := NewSegmentTask(
+		ctx,
+		10*time.Second,
+		WrapIDSource(0),
+		coll,
+		suite.replica,
+		commonpb.LoadPriority_LOW,
+		NewSegmentActionWithScope(sourceNode, ActionTypeReduce, channel, segmentID, querypb.DataScope_Streaming, rowCount),
+	)
+	suite.NoError(err)
+	reduceTask.SetID(1)
+	scheduler.incExecutingTaskDelta(reduceTask)
+
+	snapshot := scheduler.GetSegmentTaskDeltaSnapshot([]int64{sourceNode}, coll)
+	suite.Equal(-rowCount, snapshot.GetByNode(sourceNode))
+	suite.Equal(-rowCount, snapshot.GetByNodeInCollection(sourceNode))
+
+	suite.dist.ChannelDistManager.Update(sourceNode)
+	snapshot = scheduler.GetSegmentTaskDeltaSnapshot([]int64{sourceNode}, coll)
+	suite.Equal(0, snapshot.GetByNode(sourceNode))
+	suite.Equal(0, snapshot.GetByNodeInCollection(sourceNode))
+
+	scheduler.decExecutingTaskDelta(reduceTask)
+}
+
 func (suite *TaskSuite) TestChannelTaskDeltaCache() {
 	delta := NewChannelTaskDelta()
 


### PR DESCRIPTION
## Summary

Fixes #50793

QueryCoord segment task delta filtering checked only sealed segment distribution. Streaming/growing segments are tracked from the channel leader view, so a streaming reduce task could be treated as reflected immediately after the RPC returned even if the growing segment was still present in distribution.

This PR makes segment distribution matching scope-aware:

- `DataScope_Streaming` checks channel leader view `GrowingSegments`
- sealed segment scopes keep using `SegmentDistManager`
- segment delta records persist channel name and data scope
- adds regression coverage for streaming reduce deltas staying active until the growing distribution disappears

## Test Plan

- `gofumpt -l internal/querycoordv2/task/action.go internal/querycoordv2/task/scheduler.go internal/querycoordv2/task/task_test.go`
- `git diff --check HEAD~1..HEAD`