### PR TITLE
test: add struct array feature coverage

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -1,3 +1,4 @@
+import csv
 import json
 import os
 import random
@@ -128,6 +129,25 @@ EMB_LIST_DIM = 32
 BINARY_METRIC = "MAX_SIM_HAMMING"
 FLOAT_METRIC = "MAX_SIM_COSINE"
 INT8_METRIC = "MAX_SIM_COSINE"
+STRUCT_ARRAY_IMPORT_VECTOR_TYPES = [
+    pytest.param(DataType.FLOAT_VECTOR, id="float_vector"),
+    pytest.param(DataType.FLOAT16_VECTOR, id="float16_vector"),
+    pytest.param(DataType.BFLOAT16_VECTOR, id="bfloat16_vector"),
+    pytest.param(DataType.INT8_VECTOR, id="int8_vector"),
+    pytest.param(DataType.BINARY_VECTOR, id="binary_vector"),
+]
+STRUCT_ARRAY_IMPORT_FILE_TYPES = [
+    pytest.param("JSON", id="json"),
+    pytest.param("JSONL", id="jsonl"),
+    pytest.param("CSV", id="csv"),
+    pytest.param("PARQUET", id="parquet"),
+]
+STRUCT_ARRAY_BULK_WRITER_FILE_TYPES = [
+    pytest.param(BulkFileType.JSON, id="bulk_writer_json"),
+    pytest.param(BulkFileType.JSONL, id="bulk_writer_jsonl"),
+    pytest.param(BulkFileType.CSV, id="bulk_writer_csv"),
+    pytest.param(BulkFileType.PARQUET, id="bulk_writer_parquet"),
+]
 
 EMB_LIST_STRATEGY_CONFIGS = {
     "tokenann": {
@@ -170,11 +190,28 @@ EMB_LIST_STRATEGY_INDEX_CONFIGS = {
         "search_params": {"search_list": 30, "retrieval_ann_ratio": 3.0, "emb_list_rerank": True},
     },
 }
-EMB_LIST_STRATEGY_INDEX_CASES = [
-    ("tokenann", "HNSW"),
-    ("muvera", "HNSW"),
-    ("lemur", "HNSW"),
-    ("tokenann", "DISKANN"),
+for _index_type in ["HNSW_SQ", "HNSW_PQ", "HNSW_PRQ", "IVF_FLAT", "IVF_FLAT_CC"]:
+    EMB_LIST_STRATEGY_INDEX_CONFIGS[_index_type] = {
+        "build_params": EMB_LIST_INDEX_CONFIGS[_index_type]["build_params"],
+        "search_params": {
+            **EMB_LIST_INDEX_CONFIGS[_index_type]["search_params"],
+            "retrieval_ann_ratio": 3.0,
+            "emb_list_rerank": True,
+        },
+    }
+EMB_LIST_MUVERA_LEMUR_INDEX_TYPES = ["HNSW", "HNSW_SQ", "HNSW_PQ", "HNSW_PRQ", "IVF_FLAT", "IVF_FLAT_CC"]
+EMB_LIST_STRATEGY_INDEX_CASES = (
+    [pytest.param("tokenann", "HNSW", id="tokenann-hnsw")]
+    + [
+        pytest.param(strategy, index_type, id=f"{strategy}-{index_type.lower()}")
+        for strategy in ["muvera", "lemur"]
+        for index_type in EMB_LIST_MUVERA_LEMUR_INDEX_TYPES
+    ]
+    + [pytest.param("tokenann", "DISKANN", id="tokenann-diskann")]
+)
+EMB_LIST_UNSUPPORTED_STRATEGY_INDEX_CASES = [
+    pytest.param("muvera", "DISKANN", id="muvera-diskann"),
+    pytest.param("lemur", "DISKANN", id="lemur-diskann"),
 ]
 
 
@@ -2805,8 +2842,8 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
     def test_search_emb_list_with_explicit_strategy(self, emb_list_strategy, index_type):
         """
         target: test emb list search with explicitly specified strategies
-        method: create HNSW and DISKANN indexes with supported emb_list_strategy values, load, and search
-        expected: index creation and search work correctly
+        method: create indexes with supported emb_list_strategy/index combinations, load, and search
+        expected: index creation and search work correctly for each supported combination
         """
         collection_name = cf.gen_unique_str(f"{prefix}_search_{emb_list_strategy}_{index_type.lower()}")
         client = self._client()
@@ -2898,6 +2935,61 @@ class TestMilvusClientStructArraySearch(TestMilvusClientV2Base):
         assert len(results[0]) > 0
         for hit in results[0]:
             assert 0 <= hit["id"] < nb
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize("emb_list_strategy,index_type", EMB_LIST_UNSUPPORTED_STRATEGY_INDEX_CASES)
+    def test_create_emb_list_with_unsupported_strategy_index(self, emb_list_strategy, index_type):
+        """
+        target: test unsupported emb list strategy/index combinations
+        method: create DISKANN index with muvera or lemur emb_list_strategy
+        expected: index creation fails because DISKANN only supports tokenann strategy
+        """
+        collection_name = cf.gen_unique_str(f"{prefix}_search_{emb_list_strategy}_{index_type.lower()}_invalid")
+        client = self._client()
+        strategy_config = EMB_LIST_STRATEGY_CONFIGS[emb_list_strategy]
+        index_config = EMB_LIST_STRATEGY_INDEX_CONFIGS[index_type]
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM)
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("clip_embedding1", DataType.FLOAT_VECTOR, dim=EMB_LIST_DIM)
+        struct_schema.add_field("scalar_field", DataType.INT64)
+        schema.add_field(
+            "clips",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=10,
+        )
+
+        res, check = self.create_collection(client, collection_name, schema=schema)
+        assert check
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="clips[clip_embedding1]",
+            index_name=f"struct_vector_index_{emb_list_strategy}_{index_type.lower()}",
+            index_type=index_type,
+            metric_type="MAX_SIM_COSINE",
+            params={
+                **index_config["build_params"],
+                **strategy_config["strategy_params"],
+            },
+        )
+
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: "DiskANN only supports TokenANN strategy",
+        }
+        self.create_index(
+            client,
+            collection_name,
+            index_params,
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     @pytest.mark.parametrize(
@@ -4887,7 +4979,7 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
         self.minio_endpoint = f"{minio_host}:9000"
 
     def gen_file_with_local_bulk_writer(
-        self, schema, data: list[dict[str, Any]], file_type: str = "PARQUET"
+        self, schema, data: list[dict[str, Any]], file_type: str | BulkFileType = "PARQUET"
     ) -> tuple[str, dict]:
         """
         Generate import file using LocalBulkWriter from insert-format data
@@ -4900,8 +4992,12 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
         Returns:
             Tuple of (directory path containing generated files, original data dict for verification)
         """
-        # Convert file_type string to BulkFileType enum
-        bulk_file_type = BulkFileType.PARQUET if file_type == "PARQUET" else BulkFileType.JSON
+        if isinstance(file_type, BulkFileType):
+            bulk_file_type = file_type
+            file_type_name = file_type.name
+        else:
+            bulk_file_type = BulkFileType[file_type]
+            file_type_name = file_type
 
         # Create LocalBulkWriter
         writer = LocalBulkWriter(
@@ -4911,7 +5007,7 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
             file_type=bulk_file_type,
         )
 
-        log.info(f"Creating {file_type} file using LocalBulkWriter with {len(data)} rows")
+        log.info(f"Creating {file_type_name} file using LocalBulkWriter with {len(data)} rows")
 
         # Append each row using the same format as insert
         for row in data:
@@ -4962,7 +5058,8 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
 
             # Upload file
             filename = os.path.basename(local_file_path)
-            minio_file_path = os.path.join(self.REMOTE_DATA_PATH, filename)
+            local_parent = os.path.basename(os.path.dirname(local_file_path))
+            minio_file_path = os.path.join(self.REMOTE_DATA_PATH, local_parent, filename)
             minio_client.fput_object(self.bucket_name, minio_file_path, local_file_path)
 
             log.info(f"Uploaded file to MinIO: {minio_file_path}")
@@ -5308,6 +5405,357 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
 
     @pytest.mark.tags(CaseLabel.L1)
     @pytest.mark.parametrize("dim", [128])
+    @pytest.mark.parametrize("entities", [200])
+    @pytest.mark.parametrize("array_capacity", [100])
+    def test_import_struct_array_with_csv(self, dim, entities, array_capacity):
+        """
+        Test bulk import of struct array data from CSV.
+
+        Struct array is encoded as a JSON string in the CSV column, matching
+        importutilv2/csv row parser expectations.
+        """
+        client = self._client()
+        c_name = cf.gen_unique_str("import_struct_array_csv")
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="float_vector", datatype=DataType.FLOAT_VECTOR, dim=dim)
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("struct_varchar", DataType.VARCHAR, max_length=65535)
+        struct_schema.add_field("struct_int8", DataType.INT8)
+        struct_schema.add_field("struct_int16", DataType.INT16)
+        struct_schema.add_field("struct_int32", DataType.INT32)
+        struct_schema.add_field("struct_int64", DataType.INT64)
+        struct_schema.add_field("struct_float", DataType.FLOAT)
+        struct_schema.add_field("struct_double", DataType.DOUBLE)
+        struct_schema.add_field("struct_bool", DataType.BOOL)
+        struct_schema.add_field("struct_float_vec", DataType.FLOAT_VECTOR, dim=dim)
+        schema.add_field(
+            "struct_array",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=array_capacity,
+        )
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="float_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params={"M": 16, "efConstruction": 200},
+        )
+        index_params.add_index(
+            field_name="struct_array[struct_float_vec]",
+            index_type="HNSW",
+            metric_type="MAX_SIM_COSINE",
+            params={"M": 16, "efConstruction": 200},
+        )
+        client.create_collection(collection_name=c_name, schema=schema, index_params=index_params)
+
+        local_file_path = os.path.join(self.LOCAL_FILES_PATH, f"test_{cf.gen_unique_str()}.csv")
+        original_data = self.gen_csv_file(entities, dim, local_file_path)
+        remote_files = self.upload_to_minio(local_file_path)
+        self.call_bulkinsert(c_name, remote_files)
+
+        client.refresh_load(collection_name=c_name)
+        stats = client.get_collection_stats(collection_name=c_name)
+        assert stats["row_count"] == entities
+        self.verify_data(client, c_name, original_data)
+
+    def create_vector_import_collection(
+        self, client, c_name: str, vector_type: DataType, dim: int, array_capacity: int
+    ):
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="float_vector", datatype=DataType.FLOAT_VECTOR, dim=dim)
+
+        struct_schema = client.create_struct_field_schema()
+        struct_schema.add_field("struct_int", DataType.INT64)
+        struct_schema.add_field("struct_vec", vector_type, dim=dim)
+        schema.add_field(
+            "struct_array",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=array_capacity,
+        )
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="float_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params={"M": 16, "efConstruction": 200},
+        )
+        index_params.add_index(
+            field_name="struct_array[struct_vec]",
+            index_type="HNSW",
+            metric_type=self.struct_vector_metric(vector_type),
+            params={"M": 16, "efConstruction": 200},
+        )
+        client.create_collection(collection_name=c_name, schema=schema, index_params=index_params)
+        return schema
+
+    @staticmethod
+    def struct_vector_metric(vector_type: DataType) -> str:
+        return "MAX_SIM_HAMMING" if vector_type == DataType.BINARY_VECTOR else "MAX_SIM_COSINE"
+
+    @staticmethod
+    def struct_vector_arrow_type(vector_type: DataType):
+        if vector_type == DataType.FLOAT_VECTOR:
+            return pa.list_(pa.float32())
+        if vector_type in [DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR, DataType.BINARY_VECTOR]:
+            return pa.list_(pa.uint8())
+        if vector_type == DataType.INT8_VECTOR:
+            return pa.list_(pa.int8())
+        raise ValueError(f"unsupported struct vector type: {vector_type}")
+
+    @staticmethod
+    def vector_type_name(vector_type: DataType) -> str:
+        return vector_type.name.lower()
+
+    @staticmethod
+    def float_values(seed: int, dim: int) -> list[float]:
+        return [float(((seed + i) % 97) + 1) / 97 for i in range(dim)]
+
+    @classmethod
+    def binary_bytes(cls, seed: int, dim: int) -> list[int]:
+        return [((seed + i) % 256) for i in range(dim // 8)]
+
+    @classmethod
+    def binary_bits(cls, seed: int, dim: int) -> list[int]:
+        return [((seed + i) % 2) for i in range(dim)]
+
+    @classmethod
+    def int8_values(cls, seed: int, dim: int) -> list[int]:
+        return [((seed + i) % 255) - 128 for i in range(dim)]
+
+    @classmethod
+    def struct_vector_value_for_import(cls, vector_type: DataType, seed: int, dim: int, file_type: str):
+        if vector_type == DataType.FLOAT_VECTOR:
+            return cls.float_values(seed, dim)
+        if vector_type == DataType.FLOAT16_VECTOR:
+            values = cls.float_values(seed, dim)
+            if file_type == "PARQUET":
+                return list(np.array(values, dtype=np.float16).tobytes())
+            return values
+        if vector_type == DataType.BFLOAT16_VECTOR:
+            values = cls.float_values(seed, dim)
+            if file_type == "PARQUET":
+                return list(np.array(values, dtype=cf.bfloat16).tobytes())
+            return values
+        if vector_type == DataType.INT8_VECTOR:
+            return cls.int8_values(seed, dim)
+        if vector_type == DataType.BINARY_VECTOR:
+            return cls.binary_bytes(seed, dim)
+        raise ValueError(f"unsupported struct vector type: {vector_type}")
+
+    @classmethod
+    def struct_vector_value_for_bulk_writer(cls, vector_type: DataType, seed: int, dim: int):
+        if vector_type == DataType.FLOAT_VECTOR:
+            return cls.float_values(seed, dim)
+        if vector_type == DataType.FLOAT16_VECTOR:
+            return np.array(cls.float_values(seed, dim), dtype=np.float16)
+        if vector_type == DataType.BFLOAT16_VECTOR:
+            return np.array(cls.float_values(seed, dim), dtype=cf.bfloat16)
+        if vector_type == DataType.INT8_VECTOR:
+            return np.array(cls.int8_values(seed, dim), dtype=np.int8)
+        if vector_type == DataType.BINARY_VECTOR:
+            return cls.binary_bits(seed, dim)
+        raise ValueError(f"unsupported struct vector type: {vector_type}")
+
+    @classmethod
+    def struct_search_vector(cls, vector_type: DataType, seed: int, dim: int):
+        if vector_type == DataType.FLOAT_VECTOR:
+            return EmbeddingList([np.array(cls.float_values(seed, dim), dtype=np.float32)])
+        if vector_type == DataType.FLOAT16_VECTOR:
+            return EmbeddingList([np.array(cls.float_values(seed, dim), dtype=np.float16)])
+        if vector_type == DataType.BFLOAT16_VECTOR:
+            return EmbeddingList([np.array(cls.float_values(seed, dim), dtype=cf.bfloat16)])
+        if vector_type == DataType.INT8_VECTOR:
+            return EmbeddingList([np.array(cls.int8_values(seed, dim), dtype=np.int8)])
+        if vector_type == DataType.BINARY_VECTOR:
+            return EmbeddingList([np.frombuffer(bytes(cls.binary_bytes(seed, dim)), dtype=np.uint8)])
+        raise ValueError(f"unsupported struct vector type: {vector_type}")
+
+    def gen_struct_vector_rows(self, entities: int, dim: int, vector_type: DataType, file_type: str) -> dict[str, Any]:
+        id_arr = []
+        float_vector_arr = []
+        struct_arr = []
+        for i in range(entities):
+            rng = random.Random(i)
+            struct_list = []
+            for j in range(rng.randint(1, 4)):
+                struct_list.append(
+                    {
+                        "struct_int": i * 10 + j,
+                        "struct_vec": self.struct_vector_value_for_import(vector_type, i * 10 + j, dim, file_type),
+                    }
+                )
+            id_arr.append(i)
+            float_vector = [rng.random() for _ in range(dim)]
+            float_vector_arr.append(float_vector)
+            struct_arr.append(struct_list)
+        return {
+            "id": id_arr,
+            "float_vector": float_vector_arr,
+            "struct_array": struct_arr,
+        }
+
+    def gen_struct_vector_bulk_writer_rows(
+        self, entities: int, dim: int, vector_type: DataType
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        original_data = self.gen_struct_vector_rows(entities, dim, vector_type, "JSON")
+        rows = []
+        for i in range(entities):
+            struct_array = []
+            for item in original_data["struct_array"][i]:
+                struct_array.append(
+                    {
+                        "struct_int": item["struct_int"],
+                        "struct_vec": self.struct_vector_value_for_bulk_writer(vector_type, item["struct_int"], dim),
+                    }
+                )
+            rows.append(
+                {
+                    "id": original_data["id"][i],
+                    "float_vector": original_data["float_vector"][i],
+                    "struct_array": struct_array,
+                }
+            )
+        return rows, original_data
+
+    def write_struct_vector_import_file(
+        self, data: dict[str, Any], vector_type: DataType, file_type: str, dim: int, file_path: str
+    ):
+        rows = [
+            {
+                "id": data["id"][i],
+                "float_vector": data["float_vector"][i],
+                "struct_array": data["struct_array"][i],
+            }
+            for i in range(len(data["id"]))
+        ]
+        if file_type == "JSON":
+            with open(file_path, "w") as f:
+                json.dump(rows, f, indent=2)
+            return
+        if file_type == "JSONL":
+            with open(file_path, "w") as f:
+                for row in rows:
+                    f.write(json.dumps(row))
+                    f.write("\n")
+            return
+        if file_type == "CSV":
+            with open(file_path, "w", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=["id", "float_vector", "struct_array"])
+                writer.writeheader()
+                for row in rows:
+                    writer.writerow(
+                        {
+                            "id": row["id"],
+                            "float_vector": json.dumps(row["float_vector"]),
+                            "struct_array": json.dumps(row["struct_array"]),
+                        }
+                    )
+            return
+
+        struct_type = pa.struct(
+            [
+                pa.field("struct_int", pa.int64()),
+                pa.field("struct_vec", self.struct_vector_arrow_type(vector_type)),
+            ]
+        )
+        table = pa.table(
+            {
+                "id": pa.array(data["id"], type=pa.int64()),
+                "float_vector": pa.array(data["float_vector"], type=pa.list_(pa.float32())),
+                "struct_array": pa.array(data["struct_array"], type=pa.list_(struct_type)),
+            }
+        )
+        pq.write_table(table, file_path, row_group_size=10000)
+
+    def verify_struct_vector_import(self, client: MilvusClient, collection_name: str, entities: int):
+        client.refresh_load(collection_name=collection_name)
+        stats = client.get_collection_stats(collection_name=collection_name)
+        assert stats["row_count"] == entities
+        results = client.query(collection_name=collection_name, filter="id >= 0", output_fields=["id"], limit=entities)
+        assert len(results) == entities
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("dim", [32])
+    @pytest.mark.parametrize("entities", [20])
+    @pytest.mark.parametrize("array_capacity", [32])
+    @pytest.mark.parametrize("vector_type", STRUCT_ARRAY_IMPORT_VECTOR_TYPES)
+    @pytest.mark.parametrize("file_type", STRUCT_ARRAY_IMPORT_FILE_TYPES)
+    def test_import_struct_array_vector_subfield_all_file_types(
+        self, dim, entities, array_capacity, vector_type, file_type
+    ):
+        """
+        Test import support for every struct-array vector sub-field type and row import file format.
+
+        The vector sub-field types are aligned with struct array insert support.
+        JSON, CSV, and parquet are all bulk import row formats and should accept the same vector sub-field set.
+        """
+        client = self._client()
+        c_name = cf.gen_unique_str(f"import_struct_{self.vector_type_name(vector_type)}_{file_type.lower()}")
+        self.create_vector_import_collection(client, c_name, vector_type, dim, array_capacity)
+
+        local_file_path = os.path.join(self.LOCAL_FILES_PATH, f"test_{cf.gen_unique_str()}.{file_type.lower()}")
+        original_data = self.gen_struct_vector_rows(entities, dim, vector_type, file_type)
+        self.write_struct_vector_import_file(original_data, vector_type, file_type, dim, local_file_path)
+        import_files = self.upload_to_minio(local_file_path)
+
+        self.call_bulkinsert(c_name, import_files)
+        self.verify_struct_vector_import(client, c_name, entities)
+
+        results = client.search(
+            collection_name=c_name,
+            data=[self.struct_search_vector(vector_type, 0, dim)],
+            anns_field="struct_array[struct_vec]",
+            search_params={"metric_type": self.struct_vector_metric(vector_type), "params": {"ef": 64}},
+            limit=1,
+            output_fields=["id"],
+        )
+        assert len(results[0]) == 1
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("dim", [32])
+    @pytest.mark.parametrize("entities", [20])
+    @pytest.mark.parametrize("array_capacity", [32])
+    @pytest.mark.parametrize("vector_type", STRUCT_ARRAY_IMPORT_VECTOR_TYPES)
+    @pytest.mark.parametrize("file_type", STRUCT_ARRAY_BULK_WRITER_FILE_TYPES)
+    def test_import_struct_array_vector_subfield_with_local_bulk_writer(
+        self, dim, entities, array_capacity, vector_type, file_type
+    ):
+        """
+        Test pymilvus LocalBulkWriter support for every struct-array vector sub-field type and row file format.
+
+        BulkWriter should accept the same struct array vector sub-field types and native insert-format inputs as
+        ordinary vector fields, then generate importable JSON, JSONL, CSV, and parquet files for them.
+        """
+        client = self._client()
+        c_name = cf.gen_unique_str(f"import_struct_bw_{self.vector_type_name(vector_type)}_{file_type.name.lower()}")
+        schema = self.create_vector_import_collection(client, c_name, vector_type, dim, array_capacity)
+        insert_data, _ = self.gen_struct_vector_bulk_writer_rows(entities, dim, vector_type)
+
+        batch_files, _ = self.gen_file_with_local_bulk_writer(
+            schema=schema,
+            data=insert_data,
+            file_type=file_type,
+        )
+        import_files = []
+        for file_list in batch_files:
+            for file_path in file_list:
+                import_files.extend(self.upload_to_minio(file_path))
+
+        self.call_bulkinsert(c_name, import_files)
+        self.verify_struct_vector_import(client, c_name, entities)
+
+    @pytest.mark.tags(CaseLabel.L1)
+    @pytest.mark.parametrize("dim", [128])
     @pytest.mark.parametrize("entities", [1000])
     @pytest.mark.parametrize("array_capacity", [100])
     @pytest.mark.parametrize("file_type", ["PARQUET", "JSON"])
@@ -5592,6 +6040,52 @@ class TestMilvusClientStructArrayImport(TestMilvusClientV2Base):
 
         log.info(f"Generated comprehensive JSON file with {num_rows} rows: {file_path}")
 
+        return {
+            "id": id_arr,
+            "float_vector": float_vector_arr,
+            "struct_array": struct_arr,
+        }
+
+    def gen_csv_file(self, num_rows: int, dim: int, file_path: str) -> dict:
+        """Generate CSV file with struct array encoded as JSON string."""
+        id_arr = []
+        float_vector_arr = []
+        struct_arr = []
+
+        with open(file_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=["id", "float_vector", "struct_array"])
+            writer.writeheader()
+            for i in range(num_rows):
+                rng = random.Random(i)
+                id_arr.append(i)
+                float_vector = [rng.random() for _ in range(dim)]
+                float_vector_arr.append(float_vector)
+
+                struct_list = []
+                for j in range(rng.randint(1, 5)):
+                    struct_list.append(
+                        {
+                            "struct_varchar": f"varchar_{i}_{j}",
+                            "struct_int8": rng.randint(-128, 127),
+                            "struct_int16": rng.randint(-32768, 32767),
+                            "struct_int32": rng.randint(-2147483648, 2147483647),
+                            "struct_int64": rng.randint(-9223372036854775808, 9223372036854775807),
+                            "struct_float": rng.random() * 100,
+                            "struct_double": rng.random() * 1000,
+                            "struct_bool": rng.choice([True, False]),
+                            "struct_float_vec": [rng.random() for _ in range(dim)],
+                        }
+                    )
+                struct_arr.append(struct_list)
+                writer.writerow(
+                    {
+                        "id": i,
+                        "float_vector": json.dumps(float_vector),
+                        "struct_array": json.dumps(struct_list),
+                    }
+                )
+
+        log.info(f"Generated comprehensive CSV file with {num_rows} rows: {file_path}")
         return {
             "id": id_arr,
             "float_vector": float_vector_arr,

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_query.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_query.py
@@ -1356,6 +1356,60 @@ class TestMilvusClientStructArrayElementIndexRegression(TestMilvusClientV2Base):
         for hit in results[0]:
             assert any(e["int_val"] > 100 for e in hit["structA"])
 
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_bitmap_index_on_varchar_subfield(self):
+        """
+        target: BITMAP index on struct VARCHAR sub-field type correctness
+        method: create BITMAP index on structA[color], insert data, verify searchable
+        expected: index created and element_filter search works correctly
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_idx_bitmap_vc")
+
+        schema = self._create_schema(client)
+        index_params = client.prepare_index_params()
+        index_params.add_index(
+            field_name="normal_vector",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="structA[embedding]",
+            index_type="HNSW",
+            metric_type="COSINE",
+            params=INDEX_PARAMS,
+        )
+        index_params.add_index(
+            field_name="structA[color]",
+            index_type="BITMAP",
+        )
+        res, check = self.create_collection(
+            client,
+            collection_name,
+            schema=schema,
+            index_params=index_params,
+        )
+        assert check
+
+        data = self._insert_sealed_and_growing(client, collection_name)
+        query_vector = data[0]["structA"][0]["embedding"]
+
+        results, check = self.search(
+            client,
+            collection_name,
+            data=[query_vector],
+            anns_field="structA[embedding]",
+            search_params={"metric_type": "COSINE"},
+            filter='element_filter(structA, $[color] == "Blue")',
+            limit=10,
+            output_fields=["id", "structA"],
+        )
+        assert check
+        assert len(results[0]) > 0
+        for hit in results[0]:
+            assert any(e["color"] == "Blue" for e in hit["structA"])
+
     # ---- 5.2 STL_SORT index type correctness ----
 
     @pytest.mark.tags(CaseLabel.L1)

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array_element_search.py
@@ -3756,6 +3756,80 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
         self.load_collection(client, collection_name)
         return data
 
+    def _setup_multi_struct_collection(self, client, collection_name, metric_type="COSINE"):
+        """Create a compact deterministic collection for hybrid scope/group-by checks."""
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name="id", datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name="doc_int", datatype=DataType.INT64)
+        schema.add_field(field_name="normal_vector", datatype=DataType.FLOAT_VECTOR, dim=default_dim)
+
+        struct_a = client.create_struct_field_schema()
+        struct_a.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_a.add_field("embedding_alt", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_a.add_field("tag", DataType.VARCHAR, max_length=32)
+        schema.add_field(
+            "structA",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_a,
+            max_capacity=10,
+        )
+
+        struct_b = client.create_struct_field_schema()
+        struct_b.add_field("embedding", DataType.FLOAT_VECTOR, dim=default_dim)
+        struct_b.add_field("tag", DataType.VARCHAR, max_length=32)
+        schema.add_field(
+            "structB",
+            datatype=DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_b,
+            max_capacity=10,
+        )
+
+        index_params = client.prepare_index_params()
+        for field_name in ["normal_vector", "structA[embedding]", "structA[embedding_alt]", "structB[embedding]"]:
+            index_params.add_index(field_name=field_name, index_type="FLAT", metric_type=metric_type)
+        self.create_collection(client, collection_name, schema=schema, index_params=index_params)
+
+        def _struct_a(scores):
+            return [
+                {
+                    "embedding": self._cosine_vector(score),
+                    "embedding_alt": self._cosine_vector(score),
+                    "tag": f"a_{idx}",
+                }
+                for idx, score in enumerate(scores)
+            ]
+
+        def _struct_b(scores):
+            return [
+                {
+                    "embedding": self._cosine_vector(score),
+                    "tag": f"b_{idx}",
+                }
+                for idx, score in enumerate(scores)
+            ]
+
+        score_rows = [
+            (1, [0.99, 0.10, 0.10]),
+            (2, [0.90, 0.89, 0.88]),
+            (3, [0.70, 0.69, 0.68]),
+        ]
+        data = [
+            {
+                "id": row_id,
+                "doc_int": row_id * 10,
+                "normal_vector": self._cosine_vector(0.20 + row_id * 0.01),
+                "structA": _struct_a(scores),
+                "structB": _struct_b(scores),
+            }
+            for row_id, scores in score_rows
+        ]
+        self.insert(client, collection_name, data)
+        self.flush(client, collection_name)
+        self.load_collection(client, collection_name)
+        return data
+
     # ---- L1 tests ----
 
     @pytest.mark.tags(CaseLabel.L1)
@@ -3919,6 +3993,322 @@ class TestMilvusClientStructArrayElementHybridSearch(TestMilvusClientV2Base):
             assert abs(hit["distance"] - expected_scores[hit["id"]]) < 1e-5, (
                 f"unexpected RRF score for id={hit['id']}: got {hit['distance']}, expected {expected_scores[hit['id']]}"
             )
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_hybrid_element_scope_topk_sum_changes_collapse_order(self):
+        """
+        target: element_scope collapse controls row-level hybrid collapse
+        method: compare default max collapse with topk_sum across two different struct arrays
+        expected: default max ranks row 1 first; topk_sum ranks row 2 first
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_scope_topk_sum")
+        self._setup_multi_struct_collection(client, collection_name)
+        query_vector = self._cosine_vector(1.0)
+
+        def _req(field_name, params=None):
+            search_params = {"metric_type": "COSINE"}
+            if params is not None:
+                search_params["params"] = params
+            return AnnSearchRequest(
+                **{
+                    "data": [query_vector],
+                    "anns_field": field_name,
+                    "param": search_params,
+                    "limit": 9,
+                }
+            )
+
+        default_results, check = self.hybrid_search(
+            client,
+            collection_name,
+            [_req("structA[embedding]"), _req("structB[embedding]")],
+            ranker=RRFRanker(),
+            limit=3,
+            output_fields=["id"],
+        )
+        assert check
+        default_ids = [hit["id"] for hit in default_results[0]]
+        assert default_ids[0] == 1, f"default max collapse should rank row 1 first, got {default_ids}"
+
+        element_scope = {"element_scope": {"collapse": {"strategy": "topk_sum", "topk": 3}}}
+        scoped_results, check = self.hybrid_search(
+            client,
+            collection_name,
+            [_req("structA[embedding]", element_scope), _req("structB[embedding]", element_scope)],
+            ranker=RRFRanker(),
+            limit=3,
+            output_fields=["id"],
+        )
+        assert check
+        scoped_ids = [hit["id"] for hit in scoped_results[0]]
+        assert scoped_ids[0] == 2, f"topk_sum collapse should rank row 2 first, got {scoped_ids}"
+        assert scoped_ids != default_ids
+        assert len(scoped_ids) == len(set(scoped_ids)), f"row-level hybrid should not duplicate ids: {scoped_ids}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_hybrid_element_level_range_same_struct_supported(self):
+        """
+        target: same-struct element-level hybrid supports range search
+        method: apply COSINE radius to both same-struct sub-searches
+        expected: hybrid succeeds and only rows with in-range elements are returned
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_range_same_struct")
+        self._setup_multi_struct_collection(client, collection_name)
+        query_vector = self._cosine_vector(1.0)
+        range_params = {"radius": 0.85}
+
+        req1 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding]",
+                "param": {"metric_type": "COSINE", "params": range_params},
+                "limit": 9,
+            }
+        )
+        req2 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding_alt]",
+                "param": {"metric_type": "COSINE", "params": range_params},
+                "limit": 9,
+            }
+        )
+
+        results, check = self.hybrid_search(
+            client,
+            collection_name,
+            [req1, req2],
+            ranker=RRFRanker(),
+            limit=4,
+            output_fields=["id"],
+        )
+        assert check
+        ids = [hit["id"] for hit in results[0]]
+        assert ids, "hybrid range search should return in-range element hits"
+        assert set(ids).issubset({1, 2}), f"range should filter out row 3, got ids={ids}"
+
+    @pytest.mark.tags(CaseLabel.L1)
+    def test_hybrid_same_struct_element_group_by_pk_supported(self):
+        """
+        target: same-struct element-level hybrid supports group_by on primary key
+        method: hybrid search structA[embedding] + structA[embedding_alt] with group_by_field="id"
+        expected: request succeeds and each primary key appears at most once
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_gb_pk")
+        self._setup_multi_struct_collection(client, collection_name)
+        query_vector = self._cosine_vector(1.0)
+        req1 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding]",
+                "param": {"metric_type": "COSINE"},
+                "limit": 9,
+            }
+        )
+        req2 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding_alt]",
+                "param": {"metric_type": "COSINE"},
+                "limit": 9,
+            }
+        )
+
+        results, check = self.hybrid_search(
+            client,
+            collection_name,
+            [req1, req2],
+            ranker=RRFRanker(),
+            limit=3,
+            output_fields=["id"],
+            group_by_field="id",
+        )
+        assert check
+        ids = [hit["id"] for hit in results[0]]
+        assert ids[0] == 1
+        assert len(ids) == len(set(ids)), f"group_by primary key should deduplicate ids: {ids}"
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_hybrid_same_struct_element_scope_not_supported(self):
+        """
+        target: element_scope is rejected for same-struct element-level hybrid
+        method: pass element_scope to one same-struct sub-search
+        expected: parameter error
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_scope_same_struct")
+        self._setup_multi_struct_collection(client, collection_name)
+        query_vector = self._cosine_vector(1.0)
+        req1 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding]",
+                "param": {
+                    "metric_type": "COSINE",
+                    "params": {"element_scope": {"collapse": {"strategy": "max"}}},
+                },
+                "limit": 9,
+            }
+        )
+        req2 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding_alt]",
+                "param": {"metric_type": "COSINE"},
+                "limit": 9,
+            }
+        )
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: "element_scope is not allowed for same-struct element-level hybrid search",
+        }
+        self.hybrid_search(
+            client,
+            collection_name,
+            [req1, req2],
+            ranker=RRFRanker(),
+            limit=3,
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_hybrid_element_scope_sum_l2_not_supported(self):
+        """
+        target: sum-family element_scope is limited to positively related metrics
+        method: use topk_sum collapse with L2 element-level hybrid
+        expected: parameter error
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_scope_l2")
+        self._setup_multi_struct_collection(client, collection_name, metric_type="L2")
+        query_vector = self._cosine_vector(1.0)
+        req1 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding]",
+                "param": {
+                    "metric_type": "L2",
+                    "params": {"element_scope": {"collapse": {"strategy": "topk_sum", "topk": 2}}},
+                },
+                "limit": 9,
+            }
+        )
+        req2 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structB[embedding]",
+                "param": {"metric_type": "L2"},
+                "limit": 9,
+            }
+        )
+        error = {ct.err_code: 1100, ct.err_msg: "element_scope.collapse.strategy topk_sum is only supported"}
+        self.hybrid_search(
+            client,
+            collection_name,
+            [req1, req2],
+            ranker=RRFRanker(),
+            limit=3,
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_hybrid_group_by_non_pk_not_supported_for_same_struct_element(self):
+        """
+        target: same-struct element-level hybrid only allows group_by on primary key
+        method: group_by_field uses doc_int
+        expected: parameter error
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_gb_nonpk")
+        self._setup_multi_struct_collection(client, collection_name)
+        query_vector = self._cosine_vector(1.0)
+        req1 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding]",
+                "param": {"metric_type": "COSINE"},
+                "limit": 9,
+            }
+        )
+        req2 = AnnSearchRequest(
+            **{
+                "data": [query_vector],
+                "anns_field": "structA[embedding_alt]",
+                "param": {"metric_type": "COSINE"},
+                "limit": 9,
+            }
+        )
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: "only group by primary key is supported for same-struct element-level vector array fields",
+        }
+        self.hybrid_search(
+            client,
+            collection_name,
+            [req1, req2],
+            ranker=RRFRanker(),
+            limit=3,
+            output_fields=["id"],
+            group_by_field="doc_int",
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
+
+    @pytest.mark.tags(CaseLabel.L2)
+    @pytest.mark.parametrize(
+        "req_fields",
+        [
+            ("structA[embedding]", "normal_vector"),
+            ("structA[embedding]", "structB[embedding]"),
+        ],
+        ids=["mixed-normal-vector", "different-structs"],
+    )
+    def test_hybrid_group_by_non_same_struct_element_not_supported(self, req_fields):
+        """
+        target: element-level hybrid group_by requires all sub-searches from the same struct array
+        method: mix element-level search with normal vector or a different struct array
+        expected: parameter error
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_gb_scope")
+        data = self._setup_multi_struct_collection(client, collection_name)
+        query_vector = self._cosine_vector(1.0)
+        reqs = []
+        for field_name in req_fields:
+            vector = data[0]["normal_vector"] if field_name == "normal_vector" else query_vector
+            reqs.append(
+                AnnSearchRequest(
+                    **{
+                        "data": [vector],
+                        "anns_field": field_name,
+                        "param": {"metric_type": "COSINE"},
+                        "limit": 9,
+                    }
+                )
+            )
+
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: "group by search is only supported for same-struct element-level vector array fields",
+        }
+        self.hybrid_search(
+            client,
+            collection_name,
+            reqs,
+            ranker=RRFRanker(),
+            limit=3,
+            output_fields=["id"],
+            group_by_field="id",
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_hybrid_element_filter_with_weighted_ranker(self):
@@ -4650,6 +5040,97 @@ class TestMilvusClientStructArrayElementSearchInvalid(TestMilvusClientV2Base):
             all_data.extend(growing)
         self.load_collection(client, collection_name)
         return all_data
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_hybrid_embedding_list_range_not_supported(self):
+        """
+        target: hybrid range search is rejected for embedding-list-level struct vector sub-search
+        method: use EmbeddingList data with radius in one hybrid sub-search
+        expected: parameter error from hybrid validation
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_emblist_radius")
+        data = self._create_embedding_list_collection(client, collection_name)
+
+        tensor = EmbeddingList()
+        tensor.add(_seed_vector(7))
+        tensor.add(_seed_vector(8))
+        req1 = AnnSearchRequest(
+            **{
+                "data": [tensor],
+                "anns_field": "structA[embedding]",
+                "param": {"metric_type": "MAX_SIM_COSINE", "params": {"radius": 0.1}},
+                "limit": 10,
+            }
+        )
+        req2 = AnnSearchRequest(
+            **{
+                "data": [data[0]["normal_vector"]],
+                "anns_field": "normal_vector",
+                "param": {"metric_type": "COSINE"},
+                "limit": 10,
+            }
+        )
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: "range search is not supported for vector array (embedding-list) fields in hybrid search",
+        }
+        self.hybrid_search(
+            client,
+            collection_name,
+            [req1, req2],
+            ranker=RRFRanker(),
+            limit=10,
+            output_fields=["id"],
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_hybrid_embedding_list_group_by_not_supported(self):
+        """
+        target: hybrid group_by is rejected for embedding-list-level struct vector sub-search
+        method: use EmbeddingList data and group_by_field="id" in hybrid search
+        expected: parameter error from hybrid validation
+        """
+        client = self._client()
+        collection_name = cf.gen_unique_str(f"{prefix}_hyb_emblist_gb")
+        data = self._create_embedding_list_collection(client, collection_name)
+
+        tensor = EmbeddingList()
+        tensor.add(_seed_vector(3))
+        tensor.add(_seed_vector(4))
+        req1 = AnnSearchRequest(
+            **{
+                "data": [tensor],
+                "anns_field": "structA[embedding]",
+                "param": {"metric_type": "MAX_SIM_COSINE"},
+                "limit": 10,
+            }
+        )
+        req2 = AnnSearchRequest(
+            **{
+                "data": [data[0]["normal_vector"]],
+                "anns_field": "normal_vector",
+                "param": {"metric_type": "COSINE"},
+                "limit": 10,
+            }
+        )
+        error = {
+            ct.err_code: 1100,
+            ct.err_msg: "group by search is not supported for vector array (embedding-list) fields in hybrid search",
+        }
+        self.hybrid_search(
+            client,
+            collection_name,
+            [req1, req2],
+            ranker=RRFRanker(),
+            limit=10,
+            output_fields=["id"],
+            group_by_field="id",
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_element_search_invalid_embedding_list_with_radius(self):

--- a/tests/python_client/requirements.txt
+++ b/tests/python_client/requirements.txt
@@ -23,8 +23,8 @@ pytest-sugar==0.9.5
 pytest-random-order
 
 # pymilvus
-pymilvus==3.1.0rc39
-pymilvus[bulk_writer]==3.1.0rc39
+pymilvus==3.1.0rc50
+pymilvus[bulk_writer]==3.1.0rc50
 # for protobuf
 protobuf>=5.29.5
 


### PR DESCRIPTION
## What type of PR is this?

/test

## What this PR does / why we need it

Adds Python client coverage for struct array feature scenarios on master:

- Covers struct-array vector subfields across JSON, JSONL, CSV, and Parquet import files.
- Covers LocalBulkWriter generated JSON, JSONL, CSV, and Parquet files for FLOAT_VECTOR, FLOAT16_VECTOR, BFLOAT16_VECTOR, INT8_VECTOR, and BINARY_VECTOR struct subfields.
- Aligns BulkWriter test inputs with ordinary vector field input forms, including FP16/BF16 ndarray inputs and INT8 ndarray inputs.
- Adds hybrid search, range, group-by, element_scope regression coverage, and bitmap index coverage for struct array element fields.
- Updates Python client test dependency pin to pymilvus 3.1.0rc50 so the merged BulkWriter JSONL and struct vector fixes are exercised.

## Which issue(s) this PR fixes

None.

## Special notes for your reviewer

The BulkWriter coverage intentionally uses native insert-format inputs for non-float32 vectors to match ordinary vector field behavior.

## Tests

```bash
python -W ignore -m pytest -v -n 6 --tb=short \
  milvus_client/test_milvus_client_struct_array.py::TestMilvusClientStructArrayImport::test_import_struct_array_vector_subfield_with_local_bulk_writer \
  --host 10.100.36.207 --port 19530 --token root:Milvus \
  --minio_host 10.100.36.206 --minio_bucket struct-array-master-ff3dbeb
```

Result: `20 passed in 120.02s`
