### PR TITLE
feat: add TwelveLabs text embedding provider

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1506,6 +1506,10 @@ function:
       tei:
         credential:  # The name in the crendential configuration item
         enable: true # Whether to enable TEI model service
+      twelvelabs:
+        credential:  # The name in the credential configuration item
+        enable: true # Whether to enable TwelveLabs model service
+        url:  # Your TwelveLabs embedding url, Default is the official embedding url
       vertexai:
         credential:  # The name in the crendential configuration item
         enable: true # Whether to enable vertexai model service

--- a/docs/design-docs/design_docs/20260625-twelvelabs-text-embedding-provider.md
+++ b/docs/design-docs/design_docs/20260625-twelvelabs-text-embedding-provider.md
@@ -1,0 +1,238 @@
+# MEP: Add TwelveLabs Text Embedding Provider (`twelvelabs`)
+
+- **Created:** 2026-06-25
+- **Author(s):** @mohit-twelvelabs
+- **Status:** Draft
+- **Component:** Proxy | QueryNode | DataNode | Function
+- **Related Issues:** TBD
+- **Released:** [TBD]
+
+## Summary
+
+This proposal introduces a new text embedding provider `twelvelabs` for the Milvus `TextEmbedding` function.
+The provider integrates with the [TwelveLabs](https://twelvelabs.io) Embed API (Marengo multimodal embedding model) and lets users generate text embeddings during insert/search pipelines in the same way as the existing providers (`openai`, `cohere`, `tei`, etc.).
+
+The feature includes:
+
+1. New provider implementation in `internal/util/function/embedding`.
+2. Provider selection integration in `TextEmbeddingFunction`.
+3. Provider config and credentials support in `paramtable`/`milvus.yaml`.
+4. Unit tests following existing function test patterns.
+
+## Motivation
+
+TwelveLabs Marengo is a multimodal embedding model that embeds text, image, audio, and video into a single shared 512-dimensional vector space. A common workflow is **video search**: video embeddings are generated out-of-band (TwelveLabs SDK / API) and stored in Milvus, then a user issues a natural-language query that must be embedded with the *same* model so that text and video vectors are comparable.
+
+Today, Milvus users on TwelveLabs must run an external embedding job to embed the query text before searching, which creates:
+
+- additional latency and operational complexity,
+- duplicated auth/retry/error handling logic,
+- weaker parity with first-class Milvus function providers.
+
+Adding `twelvelabs` lets the query side be embedded in-pipeline (via the `TextEmbedding` function on the search path), keeping cross-modal text→video search consistent with how every other provider is used.
+
+## Public Interfaces
+
+### Function schema parameters
+
+No new function type is introduced. The existing `FunctionType_TextEmbedding` is reused with:
+
+- `provider=twelvelabs`
+- `model_name=<TwelveLabs embedding model, e.g. marengo3.0>`
+- `dim=<optional, must match output field dim — Marengo is 512>`
+- `credential=<optional, preferred>`
+
+### Config interfaces
+
+New config group keys under:
+
+- `function.textEmbedding.providers.twelvelabs.enable`
+- `function.textEmbedding.providers.twelvelabs.credential`
+- `function.textEmbedding.providers.twelvelabs.url`
+
+New environment variable:
+
+- `MILVUS_TWELVELABS_API_KEY`
+
+## Design Details
+
+### Architecture placement
+
+The provider implements the existing `textEmbeddingProvider` interface:
+
+- `MaxBatch() int`
+- `FieldDim() int64`
+- `CallEmbedding(ctx, texts, mode) (any, error)`
+
+The `twelvelabs` provider is selected in `NewTextEmbeddingFunction(...)` by `provider=twelvelabs`.
+
+### Request/Response mapping
+
+The TwelveLabs Embed endpoint (`POST /v1.3/embed`) accepts `multipart/form-data` and the `x-api-key` header. Milvus provider parameters map to API fields:
+
+- `model_name` -> form field `model_name`
+- a single input text -> form field `text`
+- API key -> `x-api-key` header
+
+The response shape for a text input is:
+
+```json
+{"model_name":"marengo3.0","text_embedding":{"segments":[{"float":[ ... 512 floats ... ]}]}}
+```
+
+The provider reads `text_embedding.segments[0].float`.
+
+Provider output type:
+
+- `[][]float32` only (Marengo returns float embeddings).
+
+Validation rules:
+
+1. Returned embedding dimension must equal the output field dimension.
+2. If `dim` param is provided, it must match the output field dimension (existing Milvus rule).
+3. Output field must be a `FloatVector`.
+
+### Batching and timeout
+
+The TwelveLabs text-embed endpoint embeds **one text per request**, so the provider issues one HTTP request per input row. The external cap by `extraInfo.BatchFactor` still applies via `MaxBatch()`.
+
+Default values:
+
+- `maxBatch = 64`
+- request timeout follows the global `function.model.requestTimeout` (default `30s`), overridable per-function via `timeout_ms`.
+
+### Credential resolution order
+
+Credential parsing uses the existing utility `models.ParseAKAndURL(...)` with standard precedence:
+
+1. Function param (`credential`)
+2. `milvus.yaml` provider config
+3. Environment variable (`MILVUS_TWELVELABS_API_KEY`)
+
+This keeps behavior consistent with other providers.
+
+### Error handling
+
+The provider classifies HTTP failures the same way as `models.send(...)`: `429` and `5xx` are mapped to retryable service-unavailable errors, other `4xx` to permanent function-failed errors. Provider-level errors are normalized to existing embedding-provider style: missing credential, empty response, embedding dim mismatch.
+
+## Compatibility, Deprecation, and Migration Plan
+
+### Compatibility
+
+- Fully backward compatible for existing users.
+- No behavior change for existing providers.
+- No schema migration required.
+- Opt-in: the provider is only used when `provider=twelvelabs` is set on a function.
+
+### Deprecation / migration
+
+- No deprecations in this MEP.
+- Existing function definitions continue to work unchanged.
+
+## Security Considerations
+
+1. API keys must be configured via credential config/env; avoid hard-coding in function params.
+2. Credentials are redacted in logs via the existing Milvus credential handling path.
+3. Requests must use HTTPS endpoints.
+
+## Observability
+
+Initial version relies on existing error surfaces from the function execution path. Follow-up (optional): provider-specific request latency metrics and response-code counters.
+
+## Test Plan
+
+### Unit tests (`twelvelabs_embedding_provider_test.go`)
+
+1. Happy path with 1 text.
+2. Multiple texts, order preserved (one request per text).
+3. Embedding dim mismatch should return error.
+4. Empty response (no segments) should return error.
+5. HTTP error should return error.
+6. Missing credential / missing model name should return error.
+7. Unsupported (non-FloatVector) output type should return error.
+8. Custom URL and default URL behavior; basic getters.
+
+### Regression checks
+
+Run the existing embedding package test suites with the required Milvus flags:
+
+```bash
+go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/util/function/embedding/...
+go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./pkg/util/paramtable/...
+```
+
+## Rejected Alternatives
+
+### 1) Implement the provider outside the TextEmbedding framework
+
+Rejected because it duplicates runtime logic and creates inconsistent UX.
+
+### 2) Add a TwelveLabs-specific function type
+
+Rejected because provider extension is sufficient and aligns with existing architecture.
+
+### 3) Add a new HTTP client dependency
+
+Rejected because the standard library `net/http` + `mime/multipart` covers the single multipart call; no new dependency is needed.
+
+## Open Questions
+
+1. Should image/audio query embedding (also supported by Marengo) be surfaced through a future multimodal function type? Out of scope for this MEP.
+
+## User Documentation Draft (milvus.io style)
+
+### Title and scope
+
+- Page title: `TwelveLabs`
+- Feature scope: `TextEmbedding` provider `twelvelabs`
+- Audience: users building cross-modal (text → video) search in Milvus.
+
+### Prerequisites
+
+1. Milvus instance with the function feature enabled.
+2. A TwelveLabs account and API key (free tier available at https://twelvelabs.io).
+3. A `FloatVector` output field whose dim matches the model (Marengo: 512).
+
+### Configuration example
+
+```yaml
+function:
+  textEmbedding:
+    providers:
+      twelvelabs:
+        credential: twelvelabs_cred
+        enable: true
+        url: https://api.twelvelabs.io/v1.3/embed
+```
+
+```yaml
+credential:
+  twelvelabs_cred:
+    apikey: <YOUR_TWELVELABS_API_KEY>
+```
+
+### Function parameter table
+
+- `provider` (required): must be `twelvelabs`
+- `model_name` (required): TwelveLabs embedding model, e.g. `marengo3.0`
+- `dim` (optional): must match output field dimension if specified (512 for Marengo)
+- `credential` (recommended): credential name from Milvus credential config
+
+### End-to-end usage
+
+1. Generate video embeddings with the TwelveLabs API/SDK and insert them into a 512-dim `FloatVector` field.
+2. On a separate collection (or the same field) add a `TextEmbedding` function with `provider=twelvelabs` over a `VARCHAR` query field.
+3. Run a text search — Milvus embeds the query text with Marengo and searches it against the stored video vectors.
+
+### Troubleshooting section
+
+- 401/403: invalid or missing API key.
+- 429: request rate exceeded; retry with backoff.
+- Dim mismatch: output field dim is not equal to the model output dim (512).
+- Provider disabled: `function.textEmbedding.providers.twelvelabs.enable` is false.
+
+## References
+
+- Milvus embedding provider architecture: `internal/util/function/embedding`
+- Milvus provider config path: `pkg/util/paramtable/function_param.go`
+- TwelveLabs Embed API docs: https://docs.twelvelabs.io/v1.3/api-reference/embeddings/create-text-image-audio-embeddings

--- a/internal/util/function/embedding/mock_embedding_service.go
+++ b/internal/util/function/embedding/mock_embedding_service.go
@@ -253,6 +253,27 @@ func CreateCohereEmbeddingServer[T int8 | float32]() *httptest.Server {
 	return ts
 }
 
+// CreateTwelveLabsEmbeddingServer mimics the TwelveLabs /v1.3/embed endpoint,
+// which takes a single text per multipart/form-data request and returns one
+// embedding segment.
+func CreateTwelveLabsEmbeddingServer(dim int) *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseMultipartForm(1 << 20)
+		text := r.FormValue("text")
+		emb := mockEmbedding[float32]([]string{text}, dim)[0]
+
+		res := twelveLabsEmbeddingResponse{ModelName: r.FormValue("model_name")}
+		res.TextEmbedding.Segments = []struct {
+			Float []float32 `json:"float"`
+		}{{Float: emb}}
+
+		w.WriteHeader(http.StatusOK)
+		data, _ := json.Marshal(res)
+		w.Write(data)
+	}))
+	return ts
+}
+
 func CreateTEIEmbeddingServer(dim int) *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req tei.EmbeddingRequest

--- a/internal/util/function/embedding/text_embedding_function.go
+++ b/internal/util/function/embedding/text_embedding_function.go
@@ -49,6 +49,7 @@ const (
 	ycProvider           string = "yc"
 	zillizProvider       string = "zilliz"
 	geminiProvider       string = "gemini"
+	twelveLabsProvider   string = "twelvelabs"
 )
 
 func hasEmptyString(texts []string) bool {
@@ -143,8 +144,10 @@ func NewTextEmbeddingFunction(coll *schemapb.CollectionSchema, functionSchema *s
 		embP, newProviderErr = NewZillizEmbeddingProvider(base.outputFields[0], functionSchema, conf, extraInfo)
 	case geminiProvider:
 		embP, newProviderErr = NewGeminiEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
+	case twelveLabsProvider:
+		embP, newProviderErr = NewTwelveLabsEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
 	default:
-		return nil, merr.WrapErrParameterInvalidMsg("unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider)
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider, twelveLabsProvider)
 	}
 
 	if newProviderErr != nil {

--- a/internal/util/function/embedding/twelvelabs_embedding_provider.go
+++ b/internal/util/function/embedding/twelvelabs_embedding_provider.go
@@ -1,0 +1,198 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+const (
+	defaultTwelveLabsEmbeddingURL = "https://api.twelvelabs.io/v1.3/embed"
+)
+
+// twelveLabsEmbeddingResponse mirrors the JSON returned by the TwelveLabs
+// /v1.3/embed endpoint for a text input. Marengo returns a single segment for
+// a text query, whose "float" field holds the embedding vector.
+//
+//	{"model_name":"marengo3.0","text_embedding":{"segments":[{"float":[...]}]}}
+type twelveLabsEmbeddingResponse struct {
+	ModelName     string `json:"model_name"`
+	TextEmbedding struct {
+		Segments []struct {
+			Float []float32 `json:"float"`
+		} `json:"segments"`
+	} `json:"text_embedding"`
+}
+
+// TwelveLabsEmbeddingProvider calls the TwelveLabs Marengo multimodal embedding
+// model. Marengo embeds text, image, audio and video into the same vector
+// space, so text embeddings produced here can be searched against video
+// embeddings generated out-of-band. The text endpoint accepts a single piece
+// of text per request, so a batch is sent as one request per row.
+type TwelveLabsEmbeddingProvider struct {
+	fieldDim int64
+
+	url       string
+	apiKey    string
+	modelName string
+
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
+}
+
+func NewTwelveLabsEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*TwelveLabsEmbeddingProvider, error) {
+	fieldDim, err := typeutil.GetDim(fieldSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	if fieldSchema.DataType != schemapb.DataType_FloatVector {
+		return nil, merr.WrapErrParameterInvalidMsg("TwelveLabs embedding only supports FloatVector output field, but got %s", fieldSchema.DataType.String()) //nolint:staticcheck // starts with proper noun
+	}
+
+	var modelName string
+	for _, param := range functionSchema.Params {
+		switch strings.ToLower(param.Key) {
+		case models.ModelNameParamKey:
+			modelName = param.Value
+		case models.DimParamKey:
+			if _, err = models.ParseAndCheckFieldDim(param.Value, fieldDim, fieldSchema.Name); err != nil {
+				return nil, err
+			}
+		default:
+		}
+	}
+	if modelName == "" {
+		return nil, merr.WrapErrParameterMissingMsg("twelvelabs embedding model name is required")
+	}
+
+	apiKey, url, err := models.ParseAKAndURL(credentials, functionSchema.Params, params, models.TwelveLabsAKEnvStr, extraInfo)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey == "" {
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the %s environment variable in the Milvus service", models.TwelveLabsAKEnvStr)
+	}
+	if url == "" {
+		url = defaultTwelveLabsEmbeddingURL
+	}
+
+	timeoutMs := models.ResolveTimeoutMs(functionSchema.Params)
+
+	provider := TwelveLabsEmbeddingProvider{
+		fieldDim:  fieldDim,
+		url:       url,
+		apiKey:    apiKey,
+		modelName: modelName,
+		maxBatch:  64,
+		timeoutMs: timeoutMs,
+		extraInfo: extraInfo,
+	}
+	return &provider, nil
+}
+
+func (provider *TwelveLabsEmbeddingProvider) MaxBatch() int {
+	return provider.extraInfo.BatchFactor * provider.maxBatch
+}
+
+func (provider *TwelveLabsEmbeddingProvider) FieldDim() int64 {
+	return provider.fieldDim
+}
+
+// embed sends a single text to the TwelveLabs embed endpoint and returns its
+// embedding vector. The endpoint expects multipart/form-data with model_name
+// and text fields and the x-api-key header.
+func (provider *TwelveLabsEmbeddingProvider) embed(ctx context.Context, text string) ([]float32, error) {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	if err := writer.WriteField("model_name", provider.modelName); err != nil {
+		return nil, err
+	}
+	if err := writer.WriteField("text", text); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.url, &buf)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("x-api-key", provider.apiKey)
+
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL is constructed from configured model endpoints, not user input
+	if err != nil {
+		return nil, merr.WrapErrServiceUnavailable(err.Error(), "call twelvelabs service failed")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, merr.WrapErrServiceUnavailable(err.Error(), "call twelvelabs service failed, read response failed")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		msg := fmt.Sprintf("call twelvelabs service failed, errs:[%s, %s]", resp.Status, body)
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
+			return nil, merr.WrapErrServiceUnavailable(msg)
+		}
+		return nil, merr.WrapErrFunctionFailedMsg("%s", msg)
+	}
+
+	var res twelveLabsEmbeddingResponse
+	if err := json.Unmarshal(body, &res); err != nil {
+		return nil, merr.Wrap(err, "call twelvelabs service failed, unmarshal response failed")
+	}
+	if len(res.TextEmbedding.Segments) == 0 {
+		return nil, merr.WrapErrFunctionFailedMsg("twelvelabs returned no text embedding segments")
+	}
+	return res.TextEmbedding.Segments[0].Float, nil
+}
+
+func (provider *TwelveLabsEmbeddingProvider) CallEmbedding(ctx context.Context, texts []string, _ models.TextEmbeddingMode) (any, error) {
+	data := make([][]float32, 0, len(texts))
+	for _, text := range texts {
+		emb, err := provider.embed(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		if len(emb) != int(provider.fieldDim) {
+			return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]",
+				provider.fieldDim, len(emb))
+		}
+		data = append(data, emb)
+	}
+	return data, nil
+}

--- a/internal/util/function/embedding/twelvelabs_embedding_provider.go
+++ b/internal/util/function/embedding/twelvelabs_embedding_provider.go
@@ -27,6 +27,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/util/credentials"
@@ -143,6 +144,12 @@ func (provider *TwelveLabsEmbeddingProvider) embed(ctx context.Context, text str
 	}
 	if err := writer.Close(); err != nil {
 		return nil, err
+	}
+
+	if provider.timeoutMs > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(provider.timeoutMs)*time.Millisecond)
+		defer cancel()
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.url, &buf)

--- a/internal/util/function/embedding/twelvelabs_embedding_provider_test.go
+++ b/internal/util/function/embedding/twelvelabs_embedding_provider_test.go
@@ -1,0 +1,273 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+)
+
+func TestTwelveLabsEmbeddingProvider(t *testing.T) {
+	suite.Run(t, new(TwelveLabsEmbeddingProviderSuite))
+}
+
+type TwelveLabsEmbeddingProviderSuite struct {
+	suite.Suite
+	schema *schemapb.CollectionSchema
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) SetupTest() {
+	s.schema = &schemapb.CollectionSchema{
+		Name: "test",
+		Fields: []*schemapb.FieldSchema{
+			{FieldID: 100, Name: "int64", DataType: schemapb.DataType_Int64},
+			{FieldID: 101, Name: "text", DataType: schemapb.DataType_VarChar},
+			{
+				FieldID: 102, Name: "vector", DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: "dim", Value: "4"},
+				},
+			},
+		},
+	}
+}
+
+func createTwelveLabsProvider(url string, schema *schemapb.FieldSchema) (textEmbeddingProvider, error) {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "marengo3.0"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.DimParamKey, Value: "4"},
+		},
+	}
+	return NewTwelveLabsEmbeddingProvider(schema, functionSchema, map[string]string{models.URLParamKey: url}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) TestEmbedding() {
+	ts := CreateTwelveLabsEmbeddingServer(4)
+	defer ts.Close()
+
+	provider, err := createTwelveLabsProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+
+	data, err := provider.CallEmbedding(context.Background(), []string{"a dog running"}, models.InsertMode)
+	s.NoError(err)
+	s.Equal([][]float32{{0.0, 1.0, 2.0, 3.0}}, data)
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) TestBatchEmbedding() {
+	ts := CreateTwelveLabsEmbeddingServer(4)
+	defer ts.Close()
+
+	provider, err := createTwelveLabsProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+
+	// The endpoint embeds one text per request; the provider issues one request
+	// per row, so every row gets the same mock vector.
+	data, err := provider.CallEmbedding(context.Background(), []string{"q1", "q2", "q3"}, models.SearchMode)
+	s.NoError(err)
+	s.Equal([][]float32{{0.0, 1.0, 2.0, 3.0}, {0.0, 1.0, 2.0, 3.0}, {0.0, 1.0, 2.0, 3.0}}, data)
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) TestEmbeddingDimNotMatch() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res := twelveLabsEmbeddingResponse{}
+		res.TextEmbedding.Segments = []struct {
+			Float []float32 `json:"float"`
+		}{{Float: []float32{1.0, 1.0}}}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(res)
+	}))
+	defer ts.Close()
+
+	provider, err := createTwelveLabsProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+	_, err = provider.CallEmbedding(context.Background(), []string{"sentence"}, models.InsertMode)
+	s.ErrorContains(err, "embedding dim")
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) TestEmptyEmbeddingResponse() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(twelveLabsEmbeddingResponse{})
+	}))
+	defer ts.Close()
+
+	provider, err := createTwelveLabsProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+	_, err = provider.CallEmbedding(context.Background(), []string{"sentence"}, models.InsertMode)
+	s.ErrorContains(err, "no text embedding segments")
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) TestCallEmbeddingHTTPError() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer ts.Close()
+
+	provider, err := createTwelveLabsProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+	_, err = provider.CallEmbedding(context.Background(), []string{"sentence"}, models.InsertMode)
+	s.Error(err)
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) TestMissingCredential() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "marengo3.0"},
+		},
+	}
+	_, err := NewTwelveLabsEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{}), &models.ModelExtraInfo{})
+	s.ErrorContains(err, models.TwelveLabsAKEnvStr)
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) TestMissingModelName() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}
+	_, err := NewTwelveLabsEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
+	s.ErrorContains(err, "twelvelabs embedding model name is required")
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) TestInvalidDimParam() {
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "marengo3.0"},
+			{Key: models.DimParamKey, Value: "invalid"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}
+	_, err := NewTwelveLabsEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
+	s.ErrorContains(err, "is not a valid int")
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) TestUnsupportedOutputType() {
+	int8Field := &schemapb.FieldSchema{
+		FieldID: 102, Name: "vector", DataType: schemapb.DataType_Int8Vector,
+		TypeParams: []*commonpb.KeyValuePair{
+			{Key: "dim", Value: "4"},
+		},
+	}
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "marengo3.0"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}
+	_, err := NewTwelveLabsEmbeddingProvider(int8Field, functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
+	s.ErrorContains(err, "FloatVector")
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) TestCustomAndDefaultURL() {
+	ts := CreateTwelveLabsEmbeddingServer(4)
+	defer ts.Close()
+
+	provider, err := createTwelveLabsProvider(ts.URL, s.schema.Fields[2])
+	s.NoError(err)
+	s.Equal(ts.URL, provider.(*TwelveLabsEmbeddingProvider).url)
+
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "marengo3.0"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.DimParamKey, Value: "4"},
+		},
+	}
+	p, err := NewTwelveLabsEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}), &models.ModelExtraInfo{})
+	s.NoError(err)
+	s.Equal(defaultTwelveLabsEmbeddingURL, p.url)
+}
+
+func (s *TwelveLabsEmbeddingProviderSuite) TestBasicGetters() {
+	ts := CreateTwelveLabsEmbeddingServer(4)
+	defer ts.Close()
+
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.ModelNameParamKey, Value: "marengo3.0"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.DimParamKey, Value: "4"},
+		},
+	}
+	provider, err := NewTwelveLabsEmbeddingProvider(
+		s.schema.Fields[2],
+		functionSchema,
+		map[string]string{models.URLParamKey: ts.URL},
+		credentials.NewCredentials(map[string]string{"mock.apikey": "mock"}),
+		&models.ModelExtraInfo{BatchFactor: 3},
+	)
+	s.NoError(err)
+	s.Equal(int64(4), provider.FieldDim())
+	s.Equal(192, provider.MaxBatch())
+}

--- a/internal/util/function/models/common.go
+++ b/internal/util/function/models/common.go
@@ -140,6 +140,12 @@ const (
 	GeminiAKEnvStr string = "MILVUS_GEMINI_API_KEY"
 )
 
+// TwelveLabs
+
+const (
+	TwelveLabsAKEnvStr string = "MILVUS_TWELVELABS_API_KEY"
+)
+
 // TEI and vllm
 
 const (

--- a/pkg/util/paramtable/function_param.go
+++ b/pkg/util/paramtable/function_param.go
@@ -119,6 +119,12 @@ func (p *functionConfig) init(base *BaseTable) {
 				return "Your Gemini embedding url, Default is the official embedding url"
 			case "gemini.enable":
 				return "Whether to enable Gemini model service"
+			case "twelvelabs.credential":
+				return "The name in the credential configuration item"
+			case "twelvelabs.url":
+				return "Your TwelveLabs embedding url, Default is the official embedding url"
+			case "twelvelabs.enable":
+				return "Whether to enable TwelveLabs model service"
 			default:
 				return ""
 			}


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds

A new `twelvelabs` provider for the `TextEmbedding` function, backed by the [TwelveLabs](https://twelvelabs.io) Marengo multimodal embedding model (`POST /v1.3/embed`). It slots into `internal/util/function/embedding` exactly like the existing single-text providers (closest analog: `yc`):

- `twelvelabs_embedding_provider.go` — implements the `textEmbeddingProvider` interface (`MaxBatch`/`FieldDim`/`CallEmbedding`), resolves credentials via `models.ParseAKAndURL`, and classifies HTTP errors the same way as `models.send` (429/5xx retryable, other 4xx permanent).
- Wired into the `NewTextEmbeddingFunction` switch, the `function_param.go` config docs, and `configs/milvus.yaml`.
- New env var `MILVUS_TWELVELABS_API_KEY` and config group `function.textEmbedding.providers.twelvelabs.*`.

## Why it helps Milvus

Marengo embeds text and video into the same 512-dim space. The common workflow is **cross-modal video search**: video vectors are generated out-of-band and stored in Milvus, then a natural-language query must be embedded with the *same* model to be comparable. Today users run an external job to embed the query first; this lets the query be embedded in-pipeline on the search path, matching how every other provider is used.

## Opt-in / non-breaking

Fully opt-in — the provider is only used when `provider=twelvelabs` is set on a function. No defaults change and no existing provider behavior is affected. No new third-party dependency (uses stdlib `net/http` + `mime/multipart`).

## How it was tested

- **No-network unit tests** (`twelvelabs_embedding_provider_test.go`, httptest mock): happy path, multi-text, dim mismatch, empty response, HTTP error, missing credential / model name, unsupported output type, default/custom URL, getters.
- **Live API contract verified**: the exact embed → parse → dim-check logic was run against the real `/v1.3/embed` endpoint and `marengo3.0` returns a 512-dim vector, matching the mock's shape.
- `gofmt` clean on all changed files.
- Note: I could not run the full `go test -tags dynamic,test` suite in my environment because the milvus dependency graph + cgo build exhausted local disk. The new code mirrors the in-tree `yc` provider 1:1 in structure and imports, so it should compile cleanly in CI; happy to fix anything CI flags.

## Process notes (being upfront)

- Commit is **DCO signed-off** per CONTRIBUTING.
- Since this is a `feat:`, I included a design document at `docs/design-docs/design_docs/20260625-twelvelabs-text-embedding-provider.md` to satisfy the design-doc requirement (mirrors the existing `20260227-yc-text-embedding-provider.md`).

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.