### PR TITLE
enhance: reduce duplicate querycoord collection info lookups

### DIFF
--- a/internal/querycoordv2/task/executor.go
+++ b/internal/querycoordv2/task/executor.go
@@ -18,6 +18,7 @@ package task
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -39,6 +40,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/commonpbutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/conc"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/indexparams"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -67,6 +69,8 @@ type Executor struct {
 	executingTasks    *typeutil.ConcurrentSet[string] // task index
 	channelTaskNum    atomic.Int32                    // channel task pool counter
 	nonChannelTaskNum atomic.Int32                    // non-channel task pool counter
+
+	collectionInfoSingleflight conc.Singleflight[*milvuspb.DescribeCollectionResponse]
 }
 
 func NewExecutor(nodeID int64,
@@ -757,7 +761,7 @@ func (ex *Executor) removeDistribution(task *LeaderTask, step int) error {
 func (ex *Executor) getMetaInfo(ctx context.Context, task Task) (*milvuspb.DescribeCollectionResponse, *querypb.LoadMetaInfo, *meta.DmChannel, error) {
 	collectionID := task.CollectionID()
 	shard := task.Shard()
-	collectionInfo, err := ex.broker.DescribeCollection(ctx, collectionID)
+	collectionInfo, err := ex.getCollectionInfo(ctx, collectionID)
 	if err != nil {
 		mlog.Warn(context.TODO(), "failed to get collection info", mlog.Err(err))
 		return nil, nil, nil, err
@@ -778,6 +782,22 @@ func (ex *Executor) getMetaInfo(ctx context.Context, task Task) (*milvuspb.Descr
 	}
 
 	return collectionInfo, loadMeta, channel, nil
+}
+
+func (ex *Executor) getCollectionInfo(ctx context.Context, collectionID int64) (*milvuspb.DescribeCollectionResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	ch := ex.collectionInfoSingleflight.DoChan(fmt.Sprint(collectionID), func() (*milvuspb.DescribeCollectionResponse, error) {
+		return ex.broker.DescribeCollection(context.WithoutCancel(ctx), collectionID)
+	})
+	select {
+	case result := <-ch:
+		return result.Val, result.Err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func (ex *Executor) getLoadInfo(ctx context.Context, collectionID, segmentID int64, channel *meta.DmChannel, priority commonpb.LoadPriority) (*querypb.SegmentLoadInfo, []*indexpb.IndexInfo, error) {

--- a/internal/querycoordv2/task/executor_test.go
+++ b/internal/querycoordv2/task/executor_test.go
@@ -23,7 +23,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/internal/querycoordv2/session"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
@@ -60,6 +63,105 @@ type testSource string
 
 func (s testSource) String() string {
 	return string(s)
+}
+
+func TestExecutorGetCollectionInfoDoesNotCacheResult(t *testing.T) {
+	ctx := context.Background()
+	collectionID := int64(1000)
+	broker := meta.NewMockBroker(t)
+	ex := NewExecutor(1, nil, nil, broker, nil, nil, session.NewNodeManager())
+
+	describeCalls := 0
+	broker.EXPECT().DescribeCollection(mock.Anything, collectionID).
+		RunAndReturn(func(ctx context.Context, collectionID int64) (*milvuspb.DescribeCollectionResponse, error) {
+			describeCalls++
+			return &milvuspb.DescribeCollectionResponse{
+				CollectionID: collectionID,
+				Schema: &schemapb.CollectionSchema{
+					Name: fmt.Sprintf("collection-info-call-%d", describeCalls),
+				},
+			}, nil
+		}).Twice()
+
+	collectionInfo, err := ex.getCollectionInfo(ctx, collectionID)
+	assert.NoError(t, err)
+	assert.Equal(t, "collection-info-call-1", collectionInfo.GetSchema().GetName())
+
+	collectionInfo, err = ex.getCollectionInfo(ctx, collectionID)
+	assert.NoError(t, err)
+	assert.Equal(t, "collection-info-call-2", collectionInfo.GetSchema().GetName())
+	assert.Equal(t, 2, describeCalls)
+}
+
+func TestExecutorGetCollectionInfoDoesNotCancelLookupWithCallerContext(t *testing.T) {
+	ctx := context.Background()
+	collectionID := int64(1001)
+	broker := meta.NewMockBroker(t)
+	ex := NewExecutor(1, nil, nil, broker, nil, nil, session.NewNodeManager())
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	brokerErrs := make(chan error, 1)
+	broker.EXPECT().DescribeCollection(mock.Anything, collectionID).
+		RunAndReturn(func(ctx context.Context, collectionID int64) (*milvuspb.DescribeCollectionResponse, error) {
+			close(entered)
+			select {
+			case <-ctx.Done():
+				brokerErrs <- ctx.Err()
+				return nil, ctx.Err()
+			case <-release:
+				brokerErrs <- nil
+				return &milvuspb.DescribeCollectionResponse{
+					CollectionID: collectionID,
+					Schema: &schemapb.CollectionSchema{
+						Name: "TestExecutorGetCollectionInfoDoesNotCancelLookupWithCallerContext",
+					},
+				}, nil
+			}
+		}).Once()
+
+	callerCtx, callerCancel := context.WithCancel(ctx)
+	callerErrs := make(chan error, 1)
+	go func() {
+		_, err := ex.getCollectionInfo(callerCtx, collectionID)
+		callerErrs <- err
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("DescribeCollection was not called")
+	}
+
+	callerCancel()
+	select {
+	case err := <-callerErrs:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("caller did not observe its cancellation")
+	}
+
+	close(release)
+	select {
+	case err := <-brokerErrs:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("DescribeCollection did not finish")
+	}
+}
+
+func TestExecutorGetCollectionInfoReturnsCallerContextErrorBeforeLookup(t *testing.T) {
+	collectionID := int64(1002)
+	broker := meta.NewMockBroker(t)
+	ex := NewExecutor(1, nil, nil, broker, nil, nil, session.NewNodeManager())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	collectionInfo, err := ex.getCollectionInfo(ctx, collectionID)
+	assert.Nil(t, collectionInfo)
+	assert.ErrorIs(t, err, context.Canceled)
+	broker.AssertNotCalled(t, "DescribeCollection", mock.Anything, collectionID)
 }
 
 func TestExecutorCapacity(t *testing.T) {

--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -1053,6 +1053,7 @@ func (scheduler *taskScheduler) GetTasksJSON() string {
 // 3. execute the current action of task
 func (scheduler *taskScheduler) schedule(node int64) {
 	if scheduler.tasks.Len() == 0 {
+		scheduler.updateTaskMetrics()
 		return
 	}
 


### PR DESCRIPTION
## Summary

Coalesce in-flight QueryCoord collection info recovery by collection ID so concurrent tasks for the same collection share the same `DescribeCollection` request.

This reduces repeated metadata recovery work during bursty same-collection task submission while still avoiding a long-lived collection info cache after the shared request completes.

This also fixes a task metric refresh bug so task-count metrics are updated after scheduler tasks are drained to zero.

Fixes #50800

## Changes

- Add a per-executor singleflight for collection info recovery.
- Keep caller cancellation independent from the shared metadata lookup.
- Add tests covering non-caching behavior and caller cancellation.
- Refresh task metrics on empty scheduler dispatches without publishing pre-removal task counts.

## Test Plan

- [x] `gofumpt -l internal/querycoordv2/task/executor.go internal/querycoordv2/task/executor_test.go internal/querycoordv2/task/scheduler.go`
- [x] `git diff --check upstream/master...HEAD`