### PR TITLE
fix: check indexMeta before executing search on segments (#50783)

### DIFF
--- a/internal/core/src/common/IndexMeta.cpp
+++ b/internal/core/src/common/IndexMeta.cpp
@@ -22,6 +22,7 @@
 
 #include "IndexMeta.h"
 #include "NamedType/named_type_impl.hpp"
+#include "common/EasyAssert.h"
 #include "common/Types.h"
 #include "pb/segcore.pb.h"
 #include "protobuf_utils.h"
@@ -74,7 +75,11 @@ CollectionIndexMeta::HasField(FieldId fieldId) const {
 const FieldIndexMeta&
 CollectionIndexMeta::GetFieldIndexMeta(FieldId fieldId) const {
     auto it = fieldMetas_.find(fieldId);
-    assert(it != fieldMetas_.end());
+    // Use AssertInfo, not assert: assert is compiled out under NDEBUG (release
+    // builds), turning a missing-field lookup into a dangling-iterator deref.
+    AssertInfo(it != fieldMetas_.end(),
+               "field index meta not found for field " +
+                   std::to_string(fieldId.get()));
     return it->second;
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedTest.cpp
@@ -42,6 +42,7 @@
 #include "common/FieldData.h"
 #include "common/FieldDataInterface.h"
 #include "common/FieldMeta.h"
+#include "common/IndexMeta.h"
 #include "common/OffsetMapping.h"
 #include "common/OpContext.h"
 #include "common/QueryInfo.h"
@@ -410,6 +411,24 @@ TEST(test_chunk_segment, ReopenSkipsFunctionOutputFieldWithoutData) {
 
     segment->Reopen(new_schema);
     EXPECT_FALSE(segment->FieldAccessible(sparse));
+}
+
+// #50783 defense-in-depth: GetFieldIndexMeta must throw (AssertInfo) rather than
+// dereference end() for a missing field; assert() is compiled out under NDEBUG.
+TEST(test_chunk_segment, GetFieldIndexMetaThrowsOnMissingField) {
+    std::map<FieldId, FieldIndexMeta> field_metas;
+    FieldId present(100);
+    field_metas.emplace(
+        present,
+        FieldIndexMeta(
+            present, {{"index_type", "IVF_FLAT"}, {"metric_type", "L2"}}, {}));
+    CollectionIndexMeta meta(1024, std::move(field_metas));
+
+    EXPECT_TRUE(meta.HasField(present));
+    EXPECT_NO_THROW(meta.GetFieldIndexMeta(present));
+    EXPECT_FALSE(meta.HasField(FieldId(present.get() + 1)));
+    EXPECT_THROW(meta.GetFieldIndexMeta(FieldId(present.get() + 1)),
+                 SegcoreError);
 }
 
 TEST(test_chunk_segment, MissingStructArrayOffsetsReturnsEmptyForOldRows) {


### PR DESCRIPTION
## Summary

A sealed segment that predates a function-output field added by `add_function_field`
lazy-loads that field's raw column (so `HasFieldData` becomes true) but has **no index
meta** for it on this segment. A BM25 brute-force search then reached
`GetFieldIndexMeta(field_id)`, which dereferenced an `end()` iterator — the guarding
`assert` is stripped in release builds — and the QueryNode died with `SIGSEGV
SI_ADDR=(nil)` while copying the garbage index-params map.

## Fix

- `FieldAccessible` now requires `HasIndex || (HasFieldData && HasFieldIndexMeta)`.
  `HasIndex` is checked **first** so the field becomes serviceable again the moment its
  index loads — recovery does not depend on `col_index_meta_` ever being refreshed
  (it is set once at construction and never updated on a stale segment).
- New `virtual HasFieldIndexMeta` (default `true`; `ChunkedSegmentSealedImpl` /
  `SegmentGrowingImpl` override via `col_index_meta_` / `index_meta_ -> HasField`).
- Defense-in-depth: `CollectionIndexMeta::GetFieldIndexMeta` `assert` -> `AssertInfo`,
  so a missing field throws a `SegcoreError` even under NDEBUG instead of UB.

With the gate in place the existing empty-result branch in `segment_c.cpp` AsyncSearch
serves a graceful partial result (the not-yet-indexed old segment contributes nothing)
instead of crashing.

issue: #50783