### PR TITLE
feat: support HNSW_SQ index in the Go client

### DIFF
--- a/client/index/common.go
+++ b/client/index/common.go
@@ -47,6 +47,7 @@ const (
 	IvfSQ8     IndexType = "IVF_SQ8"
 	IvfRabitQ  IndexType = "IVF_RABITQ"
 	HNSW       IndexType = "HNSW"
+	HNSWSQ     IndexType = "HNSW_SQ"
 	IvfHNSW    IndexType = "IVF_HNSW"
 	AUTOINDEX  IndexType = "AUTOINDEX"
 	DISKANN    IndexType = "DISKANN"

--- a/client/index/hnsw.go
+++ b/client/index/hnsw.go
@@ -24,6 +24,11 @@ const (
 	hnswMKey           = `M`
 	hsnwEfConstruction = `efConstruction`
 	hnswEfKey          = `ef`
+
+	hnswSQTypeKey     = `sq_type`
+	hnswRefineKey     = `refine`
+	hnswRefineTypeKey = `refine_type`
+	hnswRefineKKey    = `refine_k`
 )
 
 var _ Index = hnswIndex{}
@@ -73,4 +78,78 @@ func (ap hsnwAnnParam) Params() map[string]any {
 	result := ap.baseAnnParam.params
 	result[hnswEfKey] = ap.ef
 	return result
+}
+
+var _ Index = (*hnswSQIndex)(nil)
+
+// hnswSQIndex is the HNSW index combined with scalar quantization (HNSW_SQ).
+// It compresses the raw float vectors stored in the HNSW graph using a scalar
+// quantizer, trading a small amount of recall for a large reduction in memory
+// footprint. An optional refinement step re-ranks candidates using a
+// higher-precision representation to recover recall.
+type hnswSQIndex struct {
+	baseIndex
+
+	m              int
+	efConstruction int
+	sqType         string
+
+	refine     bool
+	refineType string
+}
+
+func (idx *hnswSQIndex) Params() map[string]string {
+	result := map[string]string{
+		MetricTypeKey:      string(idx.metricType),
+		IndexTypeKey:       string(HNSWSQ),
+		hnswMKey:           strconv.Itoa(idx.m),
+		hsnwEfConstruction: strconv.Itoa(idx.efConstruction),
+		hnswSQTypeKey:      idx.sqType,
+	}
+	if idx.refine {
+		result[hnswRefineKey] = strconv.FormatBool(idx.refine)
+		result[hnswRefineTypeKey] = idx.refineType
+	}
+	return result
+}
+
+// WithRefineType enables the refinement step and sets the precision of the data
+// used during refinement (for example "SQ6", "SQ8", "BF16", "FP16" or "FP32").
+// The refine type must be of higher precision than sqType.
+func (idx *hnswSQIndex) WithRefineType(refineType string) *hnswSQIndex {
+	idx.refine = true
+	idx.refineType = refineType
+	return idx
+}
+
+// NewHNSWSQIndex creates an HNSW_SQ index. sqType is the scalar quantizer type,
+// for example "SQ6", "SQ8", "BF16" or "FP16".
+func NewHNSWSQIndex(metricType MetricType, m int, efConstruction int, sqType string) *hnswSQIndex {
+	return &hnswSQIndex{
+		baseIndex: baseIndex{
+			metricType: metricType,
+			indexType:  HNSWSQ,
+		},
+		m:              m,
+		efConstruction: efConstruction,
+		sqType:         sqType,
+	}
+}
+
+type hnswSQAnnParam struct {
+	hsnwAnnParam
+}
+
+// WithRefineK sets the refinement magnification factor used at search time. When
+// the index was built with refinement enabled, the top (refineK * limit)
+// candidates are re-ranked using the higher-precision data.
+func (ap *hnswSQAnnParam) WithRefineK(refineK float64) *hnswSQAnnParam {
+	ap.params[hnswRefineKKey] = refineK
+	return ap
+}
+
+func NewHNSWSQAnnParam(ef int) *hnswSQAnnParam {
+	return &hnswSQAnnParam{
+		hsnwAnnParam: NewHNSWAnnParam(ef),
+	}
 }

--- a/client/index/hnsw_test.go
+++ b/client/index/hnsw_test.go
@@ -1,0 +1,67 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/client/v2/entity"
+)
+
+func TestHNSWSQIndex(t *testing.T) {
+	t.Run("without_refine", func(t *testing.T) {
+		idx := NewHNSWSQIndex(entity.L2, 16, 200, "SQ8")
+		params := idx.Params()
+
+		assert.Equal(t, string(HNSWSQ), params[IndexTypeKey])
+		assert.Equal(t, string(entity.L2), params[MetricTypeKey])
+		assert.Equal(t, "16", params[hnswMKey])
+		assert.Equal(t, "200", params[hsnwEfConstruction])
+		assert.Equal(t, "SQ8", params[hnswSQTypeKey])
+
+		_, ok := params[hnswRefineKey]
+		assert.False(t, ok)
+		_, ok = params[hnswRefineTypeKey]
+		assert.False(t, ok)
+	})
+
+	t.Run("with_refine", func(t *testing.T) {
+		idx := NewHNSWSQIndex(entity.L2, 16, 200, "SQ8").WithRefineType("FP32")
+		params := idx.Params()
+
+		assert.Equal(t, string(HNSWSQ), params[IndexTypeKey])
+		assert.Equal(t, "SQ8", params[hnswSQTypeKey])
+		assert.Equal(t, "true", params[hnswRefineKey])
+		assert.Equal(t, "FP32", params[hnswRefineTypeKey])
+	})
+}
+
+func TestHNSWSQAnnParam(t *testing.T) {
+	ap := NewHNSWSQAnnParam(64)
+	ap.WithRefineK(2.0)
+	result := ap.Params()
+
+	ef, ok := result[hnswEfKey]
+	assert.True(t, ok)
+	assert.Equal(t, 64, ef)
+
+	refineK, ok := result[hnswRefineKKey]
+	assert.True(t, ok)
+	assert.Equal(t, 2.0, refineK)
+}

--- a/docs/design-docs/design_docs/20260625-hnsw_sq_go_client.md
+++ b/docs/design-docs/design_docs/20260625-hnsw_sq_go_client.md
@@ -1,0 +1,106 @@
+# HNSW_SQ Support in the Go Client
+
+update: 6.25.2026, by [Kushal Shetter S](https://github.com/Kushals2004)
+
+related issue: [#44635](https://github.com/milvus-io/milvus/issues/44635)
+
+## 1. Background
+
+`HNSW_SQ` is the HNSW graph index combined with scalar quantization (SQ). The raw
+float vectors stored in the graph are compressed with a scalar quantizer, which
+substantially reduces the memory footprint of the index at the cost of a small
+amount of recall. An optional refinement step re-ranks the top candidates using a
+higher-precision representation to recover that recall.
+
+The index type is already supported by Milvus on the server side and is exposed by
+the Python SDK. The Go client (`client/index`), however, provides constructors for
+`HNSW`, `IVF_SQ8`, `IVF_RABITQ`, `SCANN`, etc., but has no constructor for
+`HNSW_SQ`. Users following the Go SDK have no first-class way to build the index or
+to pass its search-time parameters. This document describes closing that
+feature-parity gap.
+
+## 2. Goals
+
+- Add `HNSW_SQ` to the Go client's `IndexType` enumeration.
+- Provide an index constructor that emits the build parameters Milvus expects:
+  `M`, `efConstruction`, `sq_type`, and the optional `refine` / `refine_type`.
+- Provide a search-parameter (`AnnParam`) type carrying `ef` and the optional
+  `refine_k`.
+- Keep the public API consistent with the existing index constructors so the change
+  is small and idiomatic.
+
+### Non-goals
+
+- `HNSW_PQ` and `HNSW_PRQ` (which have the same gap) are out of scope here and can
+  be handled as follow-ups using the same pattern.
+- No server-side / knowhere changes — this is a pure client-side addition.
+
+## 3. Parameters
+
+### Build parameters
+
+| Param            | Meaning                                                             | Notes                                  |
+| ---------------- | ------------------------------------------------------------------- | -------------------------------------- |
+| `M`              | Max neighbors per node in the HNSW graph                            | Same as plain `HNSW`                   |
+| `efConstruction` | Candidate neighbors considered while building                       | Same as plain `HNSW`                   |
+| `sq_type`        | Scalar quantizer type: `SQ6`, `SQ8`, `BF16`, `FP16`                 | Required                               |
+| `refine`         | Whether the refinement step is enabled                              | Optional; only emitted when enabled    |
+| `refine_type`    | Precision of the data used for refinement (must exceed `sq_type`)   | Required when `refine` is enabled      |
+
+### Search parameters
+
+| Param      | Meaning                                                          | Notes                  |
+| ---------- | ---------------------------------------------------------------- | ---------------------- |
+| `ef`       | Search-time exploration factor                                   | Same as plain `HNSW`   |
+| `refine_k` | Refinement magnification factor; top `refine_k * limit` re-ranked| Optional               |
+
+The client passes `sq_type` / `refine_type` through as strings; validation of the
+allowed values stays on the server, matching how the Go client already treats the
+refine type of `IVF_RABITQ`.
+
+## 4. API Design
+
+The implementation mirrors the existing `hnswIndex` and the optional-refinement
+pattern already used by `ivfRabitQIndex`.
+
+```go
+// Build: refinement is opt-in via a chained builder.
+idx := index.NewHNSWSQIndex(entity.L2, 16, 200, "SQ8")
+idx = idx.WithRefineType("FP32") // optional
+
+// Search:
+ap := index.NewHNSWSQAnnParam(64)
+ap.WithRefineK(2.0) // optional
+```
+
+- `NewHNSWSQIndex(metricType, m, efConstruction, sqType)` returns `*hnswSQIndex`.
+- `(*hnswSQIndex).WithRefineType(refineType)` enables refinement and sets the type.
+  When refinement is not enabled, `refine` / `refine_type` are omitted from the
+  emitted params entirely.
+- `NewHNSWSQAnnParam(ef)` returns `*hnswSQAnnParam`, embedding the existing HNSW ann
+  param so it already carries `ef`.
+- `(*hnswSQAnnParam).WithRefineK(refineK float64)` adds `refine_k`. It is a
+  `float64` because the magnification factor may be fractional.
+
+## 5. Affected Files
+
+- `client/index/common.go` — add the `HNSWSQ IndexType = "HNSW_SQ"` constant.
+- `client/index/hnsw.go` — add `hnswSQIndex`, its constructor and `WithRefineType`,
+  and `hnswSQAnnParam` with `WithRefineK`.
+- `client/index/hnsw_test.go` — unit tests for the emitted build / search params
+  (with and without refinement).
+
+## 6. Test Plan
+
+Unit tests assert the emitted parameter maps:
+- build params with refinement disabled (no `refine` / `refine_type` keys present);
+- build params with refinement enabled (`refine=true`, `refine_type` set);
+- search params carry `ef` and `refine_k`.
+
+`go test ./index/` passes and `gofmt` is clean. End-to-end index creation against a
+running Milvus instance is covered by existing SDK integration tests once the index
+type is recognized by the client.
+
+## 7. Future Work
+
+Apply the same pattern to add `HNSW_PQ` and `HNSW_PRQ` to the Go client.


### PR DESCRIPTION
issue: #44635
  design doc: docs/design-docs/design_docs/20260625-hnsw_sq_go_client.md

  ## What

  Adds first-class support for the `HNSW_SQ` index type to the Go client
  (`client/index`), bringing it to parity with the Python SDK. Previously the Go
  client exposed `HNSW`, `IVF_SQ8`, `IVF_RABITQ`, etc., but had no way to build an
  `HNSW_SQ` index or pass its search parameters, as reported in #44635.

  ## Changes

  - `client/index/common.go` — add `HNSWSQ IndexType = "HNSW_SQ"`.
  - `client/index/hnsw.go`
    - `NewHNSWSQIndex(metricType, m, efConstruction, sqType)` building params `M`, `efConstruction`,
  `sq_type`.
    - `(*hnswSQIndex).WithRefineType(refineType)` to opt into the refinement step (`refine` /
  `refine_type` are only emitted when enabled), mirroring the existing `IVF_RABITQ` refine pattern.
    - `NewHNSWSQAnnParam(ef)` and `(*hnswSQAnnParam).WithRefineK(refineK float64)` for search params
  `ef` / `refine_k`.
  - `client/index/hnsw_test.go` — unit tests for the emitted build and search params, with and
  without refinement.

  ## Testing

  - `go test ./index/` passes (new `TestHNSWSQIndex`, `TestHNSWSQAnnParam`, plus the existing index
  package suite).
  - `gofmt` clean.

  ## Follow-ups

  `HNSW_PQ` and `HNSW_PRQ` have the same gap and can be added later using the same pattern