### PR TITLE
fix: avoid growing-flush failure when a function field is absent on a segment (#50799)

### DIFF
--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -1815,6 +1815,23 @@ FlushGrowingSegmentData(CSegmentInterface c_segment,
                 continue;  // skip RowID system field
             }
 
+            // A field present in schema_ but absent from the InsertRecord can only be
+            // a function-output field. SegmentGrowingImpl::Reopen() adds a newly added
+            // field to schema_ on a schema bump, but for function outputs it
+            // deliberately skips fill_empty_field (is_function_output -> continue),
+            // while every other added field gets a default-valued data slot. A growing
+            // segment reopened to a newer schema (e.g. by a query carrying the new
+            // schema, via LazyCheckSchema) before it flushes therefore has the field in
+            // schema_ but no data slot, and get_data_base below would assert (segcore
+            // 2001). Skip it: this segment has no data for that field. The
+            // is_function_output guard is a bumper -- if any other field is unexpectedly
+            // slot-less, fall through and let get_data_base assert to surface the real
+            // bug rather than silently dropping a column. See issue #50799.
+            if (schema.is_function_output(field_id) &&
+                !insert_record.is_data_exist(field_id)) {
+                continue;
+            }
+
             const auto& field_meta = schema[field_id];
 
             // Timestamp is stored in insert_record.timestamps_, not in data_ map


### PR DESCRIPTION
## Summary

A growing segment reopened to a newer schema — by a query/retrieve carrying the new
plan schema, via `SegmentGrowingImpl::LazyCheckSchema -> Reopen` — has the
function-output field in `schema_` but **no `InsertRecord` data slot**, because
`Reopen` skips `fill_empty_field` for function-output fields. `FlushGrowingSegmentData`
iterated the live (bumped) segment schema, hit that field, and asserted on the missing
data slot (`segcore 2001: Cannot find field_data with field_id` at `InsertRecord.h`).
The growing-source flush then retried forever and the segment could never flush.

This is a regression from #50300 (the flush source changed to serialize a real growing
segment). It runs in the StreamingNode flusher, not the QueryNode.

## Fix

`FlushGrowingSegmentData` now skips a field that is
`schema.is_function_output(field_id) && !insert_record.is_data_exist(field_id)`.
Post-`Reopen` the only slot-less fields are function-outputs (every other added field
gets a default-valued slot via `fill_empty_field`), so `!is_data_exist` alone
discriminates; the `is_function_output` conjunct is a deliberate bumper — any other
unexpectedly slot-less field still falls through to `get_data_base` and asserts, so a
real bug is surfaced rather than a column silently dropped.

issue: #50799