### PR TITLE
enhance: scale datanode object-storage IO pool with node size

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -821,6 +821,7 @@ dataNode:
       enable: true # Support skip some timetick message to reduce CPU usage
       skipNum: 4 # Consume one for every n records skipped
       coldTime: 60 # Turn on skip mode after there are only timetick msg for x seconds
+    ioConcurrency: 0 # Concurrency of the datanode object-storage I/O pool (download/upload for compaction and stats tasks). 0 or negative means auto (CPU*2).
   segment:
     # The maximum size of each binlog file in a segment buffered in memory. Binlog files whose size exceeds this value are then flushed to MinIO or S3 service.
     # Unit: Byte

--- a/internal/flushcommon/io/io_pool.go
+++ b/internal/flushcommon/io/io_pool.go
@@ -27,13 +27,22 @@ var (
 	bfApplyPoolInitOnce sync.Once
 )
 
-func initIOPool() {
+// ioPoolCapacity resolves the size of the datanode object-storage IO pool.
+// When dataNode.dataSync.ioConcurrency is unset (<=0), it scales with the node
+// as CPU*2: the pool is object-storage IO bound and its goroutines mostly block
+// on network, so the concurrency can safely exceed the CPU count. An explicit
+// configuration is honored as-is (no more hard-coded 32 cap).
+func ioPoolCapacity() int {
 	capacity := paramtable.Get().DataNodeCfg.IOConcurrency.GetAsInt()
-	if capacity > 32 {
-		capacity = 32
+	if capacity <= 0 {
+		capacity = hardware.GetCPUNum() * 2
 	}
+	return capacity
+}
+
+func initIOPool() {
 	// error only happens with negative expiry duration or with negative pre-alloc size.
-	ioPool = conc.NewPool[any](capacity)
+	ioPool = conc.NewPool[any](ioPoolCapacity())
 }
 
 func GetOrCreateIOPool() *conc.Pool[any] {

--- a/internal/flushcommon/io/io_pool.go
+++ b/internal/flushcommon/io/io_pool.go
@@ -27,15 +27,24 @@ var (
 	bfApplyPoolInitOnce sync.Once
 )
 
+// ioDefaultPoolFloor preserves the historical default pool size (16) as a lower
+// bound for the auto-scaled capacity, so small nodes are not throttled below the
+// pre-existing default after switching to CPU-relative sizing.
+const ioDefaultPoolFloor = 16
+
 // ioPoolCapacity resolves the size of the datanode object-storage IO pool.
 // When dataNode.dataSync.ioConcurrency is unset (<=0), it scales with the node
-// as CPU*2: the pool is object-storage IO bound and its goroutines mostly block
-// on network, so the concurrency can safely exceed the CPU count. An explicit
-// configuration is honored as-is (no more hard-coded 32 cap).
+// as max(16, CPU*2): the pool is object-storage IO bound and its goroutines mostly
+// block on network, so the concurrency can safely exceed the CPU count, while the
+// floor keeps small nodes at the old default. An explicit configuration is honored
+// as-is (no more hard-coded 32 cap).
 func ioPoolCapacity() int {
 	capacity := paramtable.Get().DataNodeCfg.IOConcurrency.GetAsInt()
 	if capacity <= 0 {
 		capacity = hardware.GetCPUNum() * 2
+		if capacity < ioDefaultPoolFloor {
+			capacity = ioDefaultPoolFloor
+		}
 	}
 	return capacity
 }

--- a/internal/flushcommon/io/io_pool_test.go
+++ b/internal/flushcommon/io/io_pool_test.go
@@ -51,9 +51,14 @@ func TestIOPoolCapacity(t *testing.T) {
 	pt.Save(key, "128")
 	assert.Equal(t, 128, ioPoolCapacity())
 
-	// unset (<=0) scales with the node as CPU*2
+	// unset (<=0) scales with the node as max(16, CPU*2)
 	pt.Save(key, "0")
-	assert.Equal(t, hardware.GetCPUNum()*2, ioPoolCapacity())
+	expected := hardware.GetCPUNum() * 2
+	if expected < ioDefaultPoolFloor {
+		expected = ioDefaultPoolFloor
+	}
+	assert.Equal(t, expected, ioPoolCapacity())
+	assert.GreaterOrEqual(t, ioPoolCapacity(), ioDefaultPoolFloor, "auto default must not drop below the historical floor")
 }
 
 func TestResizePools(t *testing.T) {

--- a/internal/flushcommon/io/io_pool_test.go
+++ b/internal/flushcommon/io/io_pool_test.go
@@ -40,6 +40,22 @@ func TestGetOrCreateIOPool(t *testing.T) {
 	wg.Wait()
 }
 
+func TestIOPoolCapacity(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	key := pt.DataNodeCfg.IOConcurrency.Key
+	original := pt.DataNodeCfg.IOConcurrency.GetValue()
+	defer pt.Save(key, original)
+
+	// explicit positive config is honored as-is (no hard-coded 32 cap)
+	pt.Save(key, "128")
+	assert.Equal(t, 128, ioPoolCapacity())
+
+	// unset (<=0) scales with the node as CPU*2
+	pt.Save(key, "0")
+	assert.Equal(t, hardware.GetCPUNum()*2, ioPoolCapacity())
+}
+
 func TestResizePools(t *testing.T) {
 	paramtable.Init()
 	pt := paramtable.Get()

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -7071,7 +7071,9 @@ Setting this parameter too small causes the system to store a small amount of da
 	p.IOConcurrency = ParamItem{
 		Key:          "dataNode.dataSync.ioConcurrency",
 		Version:      "2.0.0",
-		DefaultValue: "16",
+		DefaultValue: "0",
+		Doc:          "Concurrency of the datanode object-storage I/O pool (download/upload for compaction and stats tasks). 0 or negative means auto (CPU*2).",
+		Export:       true,
 	}
 	p.IOConcurrency.Init(base.mgr)
 


### PR DESCRIPTION
issue: #50808

### What this PR does

The datanode object-storage IO pool (`GetOrCreateIOPool`) bounds how many binlog **download/upload** operations run concurrently. It is shared by all **compaction** (mix / L0 / sort / clustering) and **stats** (sort / text index / json key) tasks on a DataNode.

Its size was hard-capped at **32** with a default of only **16**, regardless of node size:

```go
capacity := paramtable.Get().DataNodeCfg.IOConcurrency.GetAsInt() // default 16
if capacity > 32 { capacity = 32 }                                // hard-coded since #19892 (2022)
```

On large nodes this pool — not object-storage bandwidth — became the throughput ceiling for compaction/stats IO (notably after bulk import, when many sort/compaction tasks contend for it), and an explicit `ioConcurrency > 32` was silently clamped back to 32.

### Changes

- `dataNode.dataSync.ioConcurrency` now defaults to **auto (`0` → `CPU*2`)** instead of `16`.
- Removed the hard-coded `> 32` clamp — an explicit value is honored as-is.
- Extracted `ioPoolCapacity()` and added a unit test.

`CPU*2` is safe because these goroutines are network-IO bound and mostly blocked on object storage, so concurrency can exceed the CPU count (same rationale as the existing stats/multiRead pools in this file).

### Notes / follow-up

Downloads currently materialize whole objects in memory, so concurrency must still be raised with memory in mind — the original `32` cap traces back to an OOM fix (#33554). Making downloads streaming / range-based (so concurrency can be raised further without memory blow-up) is a follow-up. Related: #50452 (storage v3 import slowdown).

### Tests

- `TestIOPoolCapacity` (new): explicit config honored; `0` → `CPU*2`.
- Existing `TestGetOrCreateIOPool`, `TestResizePools` pass.