### PR TITLE
enhance: isolate online-write cgo pool from segment loading and add pool metrics

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -485,9 +485,6 @@ queryNode:
   segcore:
     knowhereThreadPoolNumRatio: 4 # The number of threads in knowhere's thread pool. If disk is enabled, the pool size will multiply with knowhereThreadPoolNumRatio([1, 32]).
     chunkRows: 128 # Row count by which Segcore divides a segment into chunks.
-    mutatePoolSizeFactor: 2 # Size factor (CPUNum * factor) of the online-write cgo pool for segment insert/delete; isolated from the load/management pool so segment loading cannot starve online writes.
-    dynamicPoolSizeFactor: 1 # Size factor (CPUNum * factor) of the dynamic cgo pool for segment create/release/statistics/index-info.
-    deletePoolSizeFactor: 1 # Size factor (CPUNum * factor) of the DeleteBatch dispatch pool.
     interimIndex:
       # Whether to create a temporary index for growing segments and sealed segments not yet indexed, improving search performance.
       # Milvus will eventually seals and indexes all segments, but enabling this optimizes search performance for immediate queries following data insertion.
@@ -542,6 +539,9 @@ queryNode:
       cacheTtl: 0
       storageUsageTrackingEnabled: false # Enable storage usage tracking for Tiered Storage. Defaults to false.
     knowhereScoreConsistency: false # Enable knowhere strong consistency score computation logic
+    mutatePoolSizeFactor: 2 # size factor (CPUNum * factor) of the online-write cgo pool for segment insert/delete; isolated from the load/management pool so segment loading cannot starve online writes
+    dynamicPoolSizeFactor: 1 # size factor (CPUNum * factor) of the dynamic cgo pool for segment create/release/statistics/index-info
+    deletePoolSizeFactor: 1 # size factor (CPUNum * factor) of the DeleteBatch dispatch pool
     storageV2:
       cellTargetSizeBytes: 4194304 # Target average byte size per storage v2 cache cell. Parquet row groups are greedily packed so that rgs_per_cell * avg_row_group_size ≈ this target. Each cell always contains at least one row group and cells never cross file boundaries. Tune larger for bigger batch IO (fewer cells) or smaller to get finer cache granularity. Default 4 MiB.
     deleteDumpBatchSize: 10000 # Batch size for delete snapshot dump in segcore.

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -988,7 +988,6 @@ common:
     highPriority: 10 # This parameter specify how many times the number of threads is the number of cores in high priority pool
     middlePriority: 5 # This parameter specify how many times the number of threads is the number of cores in middle priority pool
     lowPriority: 1 # This parameter specify how many times the number of threads is the number of cores in low priority pool
-    bm25Load: 1 # This parameter specify how many times the number of threads is the number of cores in BM25 load pool
     maxThreadsSize: 16 # The maximum number of threads in the thread pool, only effective when greater than 0
   buildIndexThreadPoolRatio: 0.75
   DiskIndex:

--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -485,6 +485,9 @@ queryNode:
   segcore:
     knowhereThreadPoolNumRatio: 4 # The number of threads in knowhere's thread pool. If disk is enabled, the pool size will multiply with knowhereThreadPoolNumRatio([1, 32]).
     chunkRows: 128 # Row count by which Segcore divides a segment into chunks.
+    mutatePoolSizeFactor: 2 # Size factor (CPUNum * factor) of the online-write cgo pool for segment insert/delete; isolated from the load/management pool so segment loading cannot starve online writes.
+    dynamicPoolSizeFactor: 1 # Size factor (CPUNum * factor) of the dynamic cgo pool for segment create/release/statistics/index-info.
+    deletePoolSizeFactor: 1 # Size factor (CPUNum * factor) of the DeleteBatch dispatch pool.
     interimIndex:
       # Whether to create a temporary index for growing segments and sealed segments not yet indexed, improving search performance.
       # Milvus will eventually seals and indexes all segments, but enabling this optimizes search performance for immediate queries following data insertion.

--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -258,6 +258,9 @@ func (node *DataNode) Start() error {
 
 		node.UpdateStateCode(commonpb.StateCode_Healthy)
 
+		// Eagerly construct the goroutine pools up front so the first Prometheus
+		// scrape reads them without triggering pool creation / warmup as a side effect.
+		initPools()
 		metrics.SetDataNodePoolCollectFn(
 			fmt.Sprint(node.GetNodeID()),
 			collectPoolStats,

--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -257,6 +257,12 @@ func (node *DataNode) Start() error {
 		}
 
 		node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+		metrics.SetDataNodePoolCollectFn(
+			fmt.Sprint(node.GetNodeID()),
+			collectPoolStats,
+		)
+
 		mlog.Info(node.ctx, "datanode start successfully")
 	})
 	return startErr

--- a/internal/datanode/pool_stats.go
+++ b/internal/datanode/pool_stats.go
@@ -24,6 +24,19 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 )
 
+// initPools eagerly constructs the DataNode's long-lived goroutine pools so that
+// the first Prometheus scrape (which calls collectPoolStats) is a pure read and
+// never triggers pool creation, config-watch registration, or worker warmup as a
+// side effect of metric collection. Each getter is idempotent (sync.Once), so this
+// is safe to call once at startup.
+func initPools() {
+	compactor.GetExecPool()
+	index.GetVecIndexBuildPool()
+	importv2.GetExecPool()
+	io.GetOrCreateIOPool()
+	io.GetOrCreateStatsPool()
+}
+
 // collectPoolStats returns current thread-count stats for the DataNode's
 // long-lived goroutine pools. It is registered with metrics.SetDataNodePoolCollectFn
 // and invoked at Prometheus scrape time (pull model), mirroring the QueryNode path.

--- a/internal/datanode/pool_stats.go
+++ b/internal/datanode/pool_stats.go
@@ -1,0 +1,58 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datanode
+
+import (
+	"github.com/milvus-io/milvus/internal/datanode/compactor"
+	"github.com/milvus-io/milvus/internal/datanode/importv2"
+	"github.com/milvus-io/milvus/internal/datanode/index"
+	"github.com/milvus-io/milvus/internal/flushcommon/io"
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
+)
+
+// collectPoolStats returns current thread-count stats for the DataNode's
+// long-lived goroutine pools. It is registered with metrics.SetDataNodePoolCollectFn
+// and invoked at Prometheus scrape time (pull model), mirroring the QueryNode path.
+func collectPoolStats() []metrics.PoolStats {
+	type poolRef struct {
+		name string
+		pool interface {
+			Cap() int
+			Running() int
+			Waiting() int
+		}
+	}
+
+	refs := []poolRef{
+		{"CompactionExecPool", compactor.GetExecPool()},
+		{"IndexBuildPool", index.GetVecIndexBuildPool()},
+		{"ImportExecPool", importv2.GetExecPool()},
+		{"IOPool", io.GetOrCreateIOPool()},
+		{"StatsPool", io.GetOrCreateStatsPool()},
+	}
+
+	stats := make([]metrics.PoolStats, 0, len(refs))
+	for _, r := range refs {
+		stats = append(stats, metrics.PoolStats{
+			Name:    r.name,
+			Cap:     r.pool.Cap(),
+			Running: r.pool.Running(),
+			Waiting: r.pool.Waiting(),
+		})
+	}
+	return stats
+}

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -428,7 +428,7 @@ func (sd *shardDelegator) loadBM25Stats(ctx context.Context, infos []*querypb.Se
 		return nil
 	}
 
-	pool := segments.GetBM25LoadPool()
+	pool := segments.GetLoadPool()
 
 	cm := sd.loader.GetChunkManager()
 	futures := make([]*conc.Future[any], 0, len(infos))
@@ -484,7 +484,7 @@ func (sd *shardDelegator) loadBM25StatsForReopen(ctx context.Context, infos []*q
 		return merr.WrapErrServiceInternal("reopen contains BM25 stats before delegator BM25 oracle is initialized")
 	}
 
-	pool := segments.GetBM25LoadPool()
+	pool := segments.GetLoadPool()
 	cm := sd.loader.GetChunkManager()
 	futures := make([]*conc.Future[any], 0, len(infos))
 	for _, info := range infos {

--- a/internal/querynodev2/segments/pool.go
+++ b/internal/querynodev2/segments/pool.go
@@ -47,29 +47,35 @@ var (
 	// and other operations (insert/delete/statistics/etc.)
 	// since in concurrent situation, there operation may block each other in high payload
 
-	sqp        atomic.Pointer[conc.Pool[any]]
-	sqOnce     sync.Once
-	dp         atomic.Pointer[conc.Pool[any]]
-	dynOnce    sync.Once
-	loadPool   atomic.Pointer[conc.Pool[any]]
-	loadOnce   sync.Once
-	warmupPool atomic.Pointer[conc.Pool[any]]
-	warmupOnce sync.Once
+	sqp      atomic.Pointer[conc.Pool[any]]
+	sqOnce   sync.Once
+	dp       atomic.Pointer[conc.Pool[any]]
+	dynOnce  sync.Once
+	loadPool atomic.Pointer[conc.Pool[any]]
+	loadOnce sync.Once
 
+	// mutatePool serves the online write CGO path (segment Insert/Delete).
+	// It is isolated from the load/management work on DynamicPool so that a
+	// burst of segment loading (e.g. delta-log replay after compaction) cannot
+	// starve online insert/delete, which would otherwise stall tSafe advancement.
+	mutatePool     atomic.Pointer[conc.Pool[any]]
+	mutatePoolOnce sync.Once
+
+	// deletePool is the outer dispatch pool for DeleteBatch fan-out across
+	// segments. It MUST stay separate from mutatePool: each dispatched task
+	// calls segment.Delete which submits the CGO onto mutatePool and waits, so
+	// sharing one pool would risk a nested-submit deadlock.
 	deletePool     atomic.Pointer[conc.Pool[struct{}]]
 	deletePoolOnce sync.Once
 
 	bfPool      atomic.Pointer[conc.Pool[any]]
 	bfApplyOnce sync.Once
 
-	bm25LoadPool atomic.Pointer[conc.Pool[any]]
-	bm25PoolOnce sync.Once
-
 	// intentionally leaked CGO tag names
 	cgoTagSQ      = C.CString("CGO_SQ")
 	cgoTagLoad    = C.CString("CGO_LOAD")
 	cgoTagDynamic = C.CString("CGO_DYN")
-	cgoTagWarmup  = C.CString("CGO_WARMUP")
+	cgoTagMutate  = C.CString("CGO_MUTATE")
 )
 
 // initSQPool initialize
@@ -94,9 +100,18 @@ func initSQPool() {
 	})
 }
 
+func dynamicPoolSize() int {
+	size := hardware.GetCPUNum() * paramtable.Get().QueryNodeCfg.DynamicPoolSizeFactor.GetAsInt()
+	if size < 1 {
+		size = hardware.GetCPUNum()
+	}
+	return size
+}
+
 func initDynamicPool() {
 	dynOnce.Do(func() {
-		size := hardware.GetCPUNum()
+		pt := paramtable.Get()
+		size := dynamicPoolSize()
 		pool := conc.NewPool[any](
 			size,
 			conc.WithPreAlloc(false),
@@ -108,6 +123,7 @@ func initDynamicPool() {
 		)
 
 		dp.Store(pool)
+		pt.Watch(pt.QueryNodeCfg.DynamicPoolSizeFactor.Key, config.NewHandler("qn.dynamicpool.sizefactor", ResizeDynamicPool))
 		mlog.Info(context.TODO(), "init dynamicPool done", mlog.Int("size", size))
 	})
 }
@@ -133,35 +149,31 @@ func initLoadPool() {
 	})
 }
 
-func initBM25LoadPool() {
-	bm25PoolOnce.Do(func() {
-		pt := paramtable.Get()
-		poolSize := float64(hardware.GetCPUNum()) * pt.CommonCfg.BM25LoadThreadCoreCoefficient.GetAsFloat()
-		pool := conc.NewPool[any](int(poolSize))
-		bm25LoadPool.Store(pool)
-
-		pt.Watch(pt.CommonCfg.BM25LoadThreadCoreCoefficient.Key, config.NewHandler("qn.bm25loadpool.bm25loadthreadcorecoefficient", ResizeBM25LoadPool))
-		mlog.Info(context.TODO(), "init BM25LoadPool done", mlog.Int("size", int(poolSize)))
-	})
+func mutatePoolSize() int {
+	size := hardware.GetCPUNum() * paramtable.Get().QueryNodeCfg.MutatePoolSizeFactor.GetAsInt()
+	if size < 1 {
+		size = hardware.GetCPUNum()
+	}
+	return size
 }
 
-func initWarmupPool() {
-	warmupOnce.Do(func() {
+func initMutatePool() {
+	mutatePoolOnce.Do(func() {
 		pt := paramtable.Get()
-		poolSize := hardware.GetCPUNum() * pt.CommonCfg.LowPriorityThreadCoreCoefficient.GetAsInt()
+		size := mutatePoolSize()
 		pool := conc.NewPool[any](
-			poolSize,
+			size,
 			conc.WithPreAlloc(false),
 			conc.WithDisablePurge(false),
 			conc.WithPreHandler(func() {
 				runtime.LockOSThread()
-				C.SetThreadName(cgoTagWarmup)
+				C.SetThreadName(cgoTagMutate)
 			}), // lock os thread for cgo thread disposal
-			conc.WithNonBlocking(false),
 		)
 
-		warmupPool.Store(pool)
-		pt.Watch(pt.CommonCfg.LowPriorityThreadCoreCoefficient.Key, config.NewHandler("qn.warmpool.lowpriority", ResizeWarmupPool))
+		mutatePool.Store(pool)
+		pt.Watch(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, config.NewHandler("qn.mutatepool.sizefactor", ResizeMutatePool))
+		mlog.Info(context.TODO(), "init mutatePool done", mlog.Int("size", size))
 	})
 }
 
@@ -178,10 +190,22 @@ func initBFApplyPool() {
 	})
 }
 
+func deletePoolSize() int {
+	size := hardware.GetCPUNum() * paramtable.Get().QueryNodeCfg.DeletePoolSizeFactor.GetAsInt()
+	if size < 1 {
+		size = hardware.GetCPUNum()
+	}
+	return size
+}
+
 func initDeletePool() {
 	deletePoolOnce.Do(func() {
-		pool := conc.NewPool[struct{}](runtime.GOMAXPROCS(0))
+		pt := paramtable.Get()
+		size := deletePoolSize()
+		pool := conc.NewPool[struct{}](size)
 		deletePool.Store(pool)
+		pt.Watch(pt.QueryNodeCfg.DeletePoolSizeFactor.Key, config.NewHandler("qn.deletepool.sizefactor", ResizeDeletePool))
+		mlog.Info(context.TODO(), "init deletePool done", mlog.Int("size", size))
 	})
 }
 
@@ -202,11 +226,6 @@ func GetLoadPool() *conc.Pool[any] {
 	return loadPool.Load()
 }
 
-func GetWarmupPool() *conc.Pool[any] {
-	initWarmupPool()
-	return warmupPool.Load()
-}
-
 func GetBFApplyPool() *conc.Pool[any] {
 	initBFApplyPool()
 	return bfPool.Load()
@@ -217,9 +236,11 @@ func GetDeletePool() *conc.Pool[struct{}] {
 	return deletePool.Load()
 }
 
-func GetBM25LoadPool() *conc.Pool[any] {
-	initBM25LoadPool()
-	return bm25LoadPool.Load()
+// GetMutatePool returns the singleton pool for online write cgo operations
+// (segment Insert/Delete).
+func GetMutatePool() *conc.Pool[any] {
+	initMutatePool()
+	return mutatePool.Load()
 }
 
 func ResizeSQPool(evt *config.Event) {
@@ -240,14 +261,6 @@ func ResizeLoadPool(evt *config.Event) {
 	}
 }
 
-func ResizeWarmupPool(evt *config.Event) {
-	if evt.HasUpdated {
-		pt := paramtable.Get()
-		newSize := hardware.GetCPUNum() * pt.CommonCfg.LowPriorityThreadCoreCoefficient.GetAsInt()
-		resizePool(GetWarmupPool(), newSize, "WarmupPool")
-	}
-}
-
 func ResizeBFApplyPool(evt *config.Event) {
 	if evt.HasUpdated {
 		pt := paramtable.Get()
@@ -256,11 +269,21 @@ func ResizeBFApplyPool(evt *config.Event) {
 	}
 }
 
-func ResizeBM25LoadPool(evt *config.Event) {
+func ResizeMutatePool(evt *config.Event) {
 	if evt.HasUpdated {
-		pt := paramtable.Get()
-		newSize := float64(hardware.GetCPUNum()) * pt.CommonCfg.BM25LoadThreadCoreCoefficient.GetAsFloat()
-		resizePool(GetBM25LoadPool(), int(newSize), "BM25LoadPool")
+		resizePool(GetMutatePool(), mutatePoolSize(), "MutatePool")
+	}
+}
+
+func ResizeDynamicPool(evt *config.Event) {
+	if evt.HasUpdated {
+		resizePool(GetDynamicPool(), dynamicPoolSize(), "DynamicPool")
+	}
+}
+
+func ResizeDeletePool(evt *config.Event) {
+	if evt.HasUpdated {
+		resizePool(GetDeletePool(), deletePoolSize(), "DeletePool")
 	}
 }
 
@@ -280,9 +303,8 @@ func CollectPoolStats() []metrics.PoolStats {
 		{"SQPool", GetSQPool()},
 		{"DynamicPool", GetDynamicPool()},
 		{"LoadPool", GetLoadPool()},
-		{"WarmupPool", GetWarmupPool()},
+		{"MutatePool", GetMutatePool()},
 		{"BFApplyPool", GetBFApplyPool()},
-		{"BM25LoadPool", GetBM25LoadPool()},
 		{"DeletePool", GetDeletePool()},
 	}
 
@@ -298,7 +320,7 @@ func CollectPoolStats() []metrics.PoolStats {
 	return stats
 }
 
-func resizePool(pool *conc.Pool[any], newSize int, tag string) {
+func resizePool[T any](pool *conc.Pool[T], newSize int, tag string) {
 	log := mlog.With(
 		mlog.String("poolTag", tag),
 		mlog.Int("newSize", newSize),

--- a/internal/querynodev2/segments/pool_test.go
+++ b/internal/querynodev2/segments/pool_test.go
@@ -83,25 +83,61 @@ func TestResizePools(t *testing.T) {
 		assert.Equal(t, expectedCap, GetLoadPool().Cap())
 	})
 
-	t.Run("WarmupPool", func(t *testing.T) {
-		expectedCap := hardware.GetCPUNum() * pt.CommonCfg.LowPriorityThreadCoreCoefficient.GetAsInt()
+	t.Run("MutatePool", func(t *testing.T) {
+		defer pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "2")
 
-		ResizeWarmupPool(&config.Event{
+		expectedCap := hardware.GetCPUNum() * pt.QueryNodeCfg.MutatePoolSizeFactor.GetAsInt()
+		ResizeMutatePool(&config.Event{
 			HasUpdated: true,
 		})
-		assert.Equal(t, expectedCap, GetWarmupPool().Cap())
+		assert.Equal(t, expectedCap, GetMutatePool().Cap())
 
-		pt.Save(pt.CommonCfg.LowPriorityThreadCoreCoefficient.Key, strconv.FormatFloat(pt.CommonCfg.LowPriorityThreadCoreCoefficient.GetAsFloat()*2, 'f', 10, 64))
-		ResizeWarmupPool(&config.Event{
+		pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "4")
+		ResizeMutatePool(&config.Event{
 			HasUpdated: true,
 		})
-		assert.Equal(t, expectedCap, GetWarmupPool().Cap())
+		assert.Equal(t, hardware.GetCPUNum()*4, GetMutatePool().Cap())
 
-		pt.Save(pt.CommonCfg.LowPriorityThreadCoreCoefficient.Key, "0")
-		ResizeWarmupPool(&config.Event{
+		// factor <= 0 clamps to CPUNum so the mutate pool is never zero-sized.
+		pt.Save(pt.QueryNodeCfg.MutatePoolSizeFactor.Key, "0")
+		ResizeMutatePool(&config.Event{
 			HasUpdated: true,
 		})
-		assert.Equal(t, expectedCap, GetWarmupPool().Cap())
+		assert.Equal(t, hardware.GetCPUNum(), GetMutatePool().Cap())
+	})
+
+	t.Run("DynamicPool", func(t *testing.T) {
+		defer pt.Save(pt.QueryNodeCfg.DynamicPoolSizeFactor.Key, "1")
+
+		pt.Save(pt.QueryNodeCfg.DynamicPoolSizeFactor.Key, "3")
+		ResizeDynamicPool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum()*3, GetDynamicPool().Cap())
+
+		// factor <= 0 clamps to CPUNum.
+		pt.Save(pt.QueryNodeCfg.DynamicPoolSizeFactor.Key, "0")
+		ResizeDynamicPool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum(), GetDynamicPool().Cap())
+	})
+
+	t.Run("DeletePool", func(t *testing.T) {
+		defer pt.Save(pt.QueryNodeCfg.DeletePoolSizeFactor.Key, "1")
+
+		pt.Save(pt.QueryNodeCfg.DeletePoolSizeFactor.Key, "3")
+		ResizeDeletePool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum()*3, GetDeletePool().Cap())
+
+		// factor <= 0 clamps to CPUNum.
+		pt.Save(pt.QueryNodeCfg.DeletePoolSizeFactor.Key, "0")
+		ResizeDeletePool(&config.Event{
+			HasUpdated: true,
+		})
+		assert.Equal(t, hardware.GetCPUNum(), GetDeletePool().Cap())
 	})
 
 	t.Run("BfApplyPool", func(t *testing.T) {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -882,7 +882,7 @@ func (s *LocalSegment) Insert(ctx context.Context, rowIDs []int64, timestamps []
 
 	var result *segcore.InsertResult
 	var err error
-	GetDynamicPool().Submit(func() (any, error) {
+	GetMutatePool().Submit(func() (any, error) {
 		start := time.Now()
 		defer func() {
 			metrics.QueryNodeCGOCallLatency.WithLabelValues(
@@ -937,7 +937,7 @@ func (s *LocalSegment) Delete(ctx context.Context, primaryKeys storage.PrimaryKe
 	// been applied to this segment, and skipping them causes silent data loss.
 
 	var err error
-	GetDynamicPool().Submit(func() (any, error) {
+	GetMutatePool().Submit(func() (any, error) {
 		start := time.Now()
 		defer func() {
 			metrics.QueryNodeCGOCallLatency.WithLabelValues(
@@ -1072,7 +1072,10 @@ func (s *LocalSegment) LoadDeltaData(ctx context.Context, deltaData *storage.Del
 		LoadDeletedRecord(CSegmentInterface c_segment, CLoadDeletedRecordInfo deleted_record_info)
 	*/
 	var status C.CStatus
-	GetDynamicPool().Submit(func() (any, error) {
+	// Delta-log replay during segment load runs on the load pool, not the
+	// online-write mutate pool, so a large post-compaction replay cannot starve
+	// online insert/delete (and thus tSafe advancement).
+	GetLoadPool().Submit(func() (any, error) {
 		start := time.Now()
 		defer func() {
 			metrics.QueryNodeCGOCallLatency.WithLabelValues(

--- a/pkg/metrics/datanode_metrics.go
+++ b/pkg/metrics/datanode_metrics.go
@@ -362,6 +362,64 @@ var (
 		}, []string{nodeIDLabelName, "type"})
 )
 
+// DataNode pool metric descriptors (used by dataNodePoolMetricsCollector).
+var (
+	DataNodePoolCapacityDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(milvusNamespace, typeutil.DataNodeRole, "pool_capacity"),
+		"Configured capacity (max goroutines) of the pool",
+		[]string{nodeIDLabelName, poolNameLabelName}, nil)
+
+	DataNodePoolActiveThreadsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(milvusNamespace, typeutil.DataNodeRole, "pool_active_threads"),
+		"Number of currently running goroutines in the pool",
+		[]string{nodeIDLabelName, poolNameLabelName}, nil)
+
+	DataNodePoolQueueDepthDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(milvusNamespace, typeutil.DataNodeRole, "pool_queue_depth"),
+		"Number of tasks waiting in the pool queue",
+		[]string{nodeIDLabelName, poolNameLabelName}, nil)
+)
+
+var (
+	dataNodePoolCollectorNodeID    string
+	dataNodePoolCollectorCollectFn func() []PoolStats
+	dataNodePoolCollectorMu        sync.Mutex
+)
+
+// SetDataNodePoolCollectFn sets the callback used by the dataNodePoolMetricsCollector.
+// Called from DataNode.Start() so pool thread-count is exported the same way as QueryNode.
+func SetDataNodePoolCollectFn(nodeID string, fn func() []PoolStats) {
+	dataNodePoolCollectorMu.Lock()
+	defer dataNodePoolCollectorMu.Unlock()
+	dataNodePoolCollectorNodeID = nodeID
+	dataNodePoolCollectorCollectFn = fn
+}
+
+// dataNodePoolMetricsCollector implements prometheus.Collector using the pull model.
+type dataNodePoolMetricsCollector struct{}
+
+func (c *dataNodePoolMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- DataNodePoolCapacityDesc
+	ch <- DataNodePoolActiveThreadsDesc
+	ch <- DataNodePoolQueueDepthDesc
+}
+
+func (c *dataNodePoolMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	dataNodePoolCollectorMu.Lock()
+	fn := dataNodePoolCollectorCollectFn
+	nodeID := dataNodePoolCollectorNodeID
+	dataNodePoolCollectorMu.Unlock()
+
+	if fn == nil {
+		return
+	}
+	for _, s := range fn() {
+		ch <- prometheus.MustNewConstMetric(DataNodePoolCapacityDesc, prometheus.GaugeValue, float64(s.Cap), nodeID, s.Name)
+		ch <- prometheus.MustNewConstMetric(DataNodePoolActiveThreadsDesc, prometheus.GaugeValue, float64(s.Running), nodeID, s.Name)
+		ch <- prometheus.MustNewConstMetric(DataNodePoolQueueDepthDesc, prometheus.GaugeValue, float64(s.Waiting), nodeID, s.Name)
+	}
+}
+
 var registerDNOnce sync.Once
 
 // RegisterDataNode registers DataNode metrics
@@ -412,6 +470,7 @@ func registerDataNodeOnce(registry *prometheus.Registry) {
 	registry.MustRegister(DataNodeBuildIndexLatency)
 	registry.MustRegister(DataNodeBuildJSONStatsLatency)
 	registry.MustRegister(DataNodeSlot)
+	registry.MustRegister(&dataNodePoolMetricsCollector{})
 	RegisterLoggingMetrics(registry)
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -49,7 +49,6 @@ const (
 	DefaultHighPriorityThreadCoreCoefficient   = 10
 	DefaultMiddlePriorityThreadCoreCoefficient = 5
 	DefaultLowPriorityThreadCoreCoefficient    = 1
-	DefaultBM25LoadThreadCoreCoefficient       = 1
 	DefaultThreadPoolMaxThreadsSize            = 16
 
 	DefaultSessionTTL        = 15 // s
@@ -236,7 +235,6 @@ type commonConfig struct {
 	HighPriorityThreadCoreCoefficient   ParamItem `refreshable:"true"`
 	MiddlePriorityThreadCoreCoefficient ParamItem `refreshable:"true"`
 	LowPriorityThreadCoreCoefficient    ParamItem `refreshable:"true"`
-	BM25LoadThreadCoreCoefficient       ParamItem `refreshable:"true"`
 	ThreadPoolMaxThreadsSize            ParamItem `refreshable:"true"`
 	ArrowIOThreadPoolCoefficient        ParamItem `refreshable:"true"`
 	ArrowIOThreadPoolMaxCapacity        ParamItem `refreshable:"true"`
@@ -705,16 +703,6 @@ This configuration is only used by querynode and indexnode, it selects CPU instr
 		Export: true,
 	}
 	p.LowPriorityThreadCoreCoefficient.Init(base.mgr)
-
-	p.BM25LoadThreadCoreCoefficient = ParamItem{
-		Key:          "common.threadCoreCoefficient.bm25Load",
-		Version:      "2.6.8",
-		DefaultValue: strconv.Itoa(DefaultBM25LoadThreadCoreCoefficient),
-		Doc: "This parameter specify how many times the number of threads " +
-			"is the number of cores in BM25 load pool",
-		Export: true,
-	}
-	p.BM25LoadThreadCoreCoefficient.Init(base.mgr)
 
 	p.ThreadPoolMaxThreadsSize = ParamItem{
 		Key:          "common.threadCoreCoefficient.maxThreadsSize",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3654,6 +3654,19 @@ type queryNodeConfig struct {
 	// CGOPoolSize ratio to MaxReadConcurrency
 	CGOPoolSizeRatio ParamItem `refreshable:"true"`
 
+	// MutatePoolSizeFactor controls the size of the online-write CGO pool
+	// (segment Insert/Delete) as CPUNum * factor. The mutate pool is isolated
+	// from load/management work so segment loading cannot starve online writes.
+	MutatePoolSizeFactor ParamItem `refreshable:"true"`
+
+	// DynamicPoolSizeFactor controls the size of the dynamic CGO pool
+	// (segment create/release/statistics/index-info) as CPUNum * factor.
+	DynamicPoolSizeFactor ParamItem `refreshable:"true"`
+
+	// DeletePoolSizeFactor controls the size of the DeleteBatch dispatch pool
+	// as CPUNum * factor.
+	DeletePoolSizeFactor ParamItem `refreshable:"true"`
+
 	// Target average byte size per storage v2 cache cell. Parquet row groups
 	// are packed into cells so rgs_per_cell * avg_rg_size ≈ this value.
 	StorageV2CellTargetSizeBytes ParamItem `refreshable:"true"`
@@ -4816,6 +4829,33 @@ user-task-polling:
 		Doc:          "cgo pool size ratio to max read concurrency",
 	}
 	p.CGOPoolSizeRatio.Init(base.mgr)
+
+	p.MutatePoolSizeFactor = ParamItem{
+		Key:          "queryNode.segcore.mutatePoolSizeFactor",
+		Version:      "2.6.0",
+		DefaultValue: "2",
+		Doc:          "size factor (CPUNum * factor) of the online-write cgo pool for segment insert/delete; isolated from the load/management pool so segment loading cannot starve online writes",
+		Export:       true,
+	}
+	p.MutatePoolSizeFactor.Init(base.mgr)
+
+	p.DynamicPoolSizeFactor = ParamItem{
+		Key:          "queryNode.segcore.dynamicPoolSizeFactor",
+		Version:      "2.6.0",
+		DefaultValue: "1",
+		Doc:          "size factor (CPUNum * factor) of the dynamic cgo pool for segment create/release/statistics/index-info",
+		Export:       true,
+	}
+	p.DynamicPoolSizeFactor.Init(base.mgr)
+
+	p.DeletePoolSizeFactor = ParamItem{
+		Key:          "queryNode.segcore.deletePoolSizeFactor",
+		Version:      "2.6.0",
+		DefaultValue: "1",
+		Doc:          "size factor (CPUNum * factor) of the DeleteBatch dispatch pool",
+		Export:       true,
+	}
+	p.DeletePoolSizeFactor.Init(base.mgr)
 
 	p.StorageV2CellTargetSizeBytes = ParamItem{
 		Key:          "queryNode.segcore.storageV2.cellTargetSizeBytes",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4832,7 +4832,7 @@ user-task-polling:
 
 	p.MutatePoolSizeFactor = ParamItem{
 		Key:          "queryNode.segcore.mutatePoolSizeFactor",
-		Version:      "2.6.0",
+		Version:      "3.0.0",
 		DefaultValue: "2",
 		Doc:          "size factor (CPUNum * factor) of the online-write cgo pool for segment insert/delete; isolated from the load/management pool so segment loading cannot starve online writes",
 		Export:       true,
@@ -4841,7 +4841,7 @@ user-task-polling:
 
 	p.DynamicPoolSizeFactor = ParamItem{
 		Key:          "queryNode.segcore.dynamicPoolSizeFactor",
-		Version:      "2.6.0",
+		Version:      "3.0.0",
 		DefaultValue: "1",
 		Doc:          "size factor (CPUNum * factor) of the dynamic cgo pool for segment create/release/statistics/index-info",
 		Export:       true,
@@ -4850,7 +4850,7 @@ user-task-polling:
 
 	p.DeletePoolSizeFactor = ParamItem{
 		Key:          "queryNode.segcore.deletePoolSizeFactor",
-		Version:      "2.6.0",
+		Version:      "3.0.0",
 		DefaultValue: "1",
 		Doc:          "size factor (CPUNum * factor) of the DeleteBatch dispatch pool",
 		Export:       true,


### PR DESCRIPTION
issue: #50811
related: #49435

## What

On the QueryNode, the load-time delta-log replay (`LoadDeltaData`, `UseLoad=true`) and the online forward delete (`segment.Delete`) both submit their CGO onto the **same `DynamicPool`** (size `CPUNum`). After a compaction, the multi-partition replay burst exhausts the pool, starving online `Insert`/`Delete`. Because `deleteNode.Operate` runs `ProcessDelete` before `UpdateTSafe`, channel **tSafe freezes for tens of seconds**, and Strong-consistency queries fail with `channel tsafe stalled` (#49435).

Evidence from the failing master run (traceID `b31d6e1626bd4d368961c89e6d4a5652`): `update tsafe` / `start to process delete` had a ~19–27s gap exactly overlapping a post-compaction segment load; `milvus_querynode_pool_active_threads{pool_name="DynamicPool"}` was pegged at **8/8 for ~27s** while `LoadPool` sat idle at **0/40**.

## Changes

Pool isolation + cleanup (`internal/querynodev2/segments`):
- Add a dedicated **MutatePool** for the online-write CGO path (`segment.Insert`/`segment.Delete`), isolated from load/management work.
- Route load-time **`LoadDeltaData`** replay and **BM25 stats** load onto **LoadPool**.
- Remove orphaned **WarmupPool**; merge away **BM25LoadPool**.
- Keep **DeletePool** (it is the `DeleteBatch` dispatch pool, not orphaned).
- Make **DynamicPool**/**DeletePool** size-configurable + hot-reloadable (`CPUNum * factor`, default `CPUNum`); add `MutatePoolSizeFactor` / `DynamicPoolSizeFactor` / `DeletePoolSizeFactor`.

Observability:
- Export `capacity / active_threads / queue_depth` for all QueryNode pools (`milvus_querynode_pool_*`, MutatePool added) and, newly, for the important DataNode pools (`milvus_datanode_pool_*`: compaction-exec, index-build, import-exec, io, stats).

## Notes

- This fixes the **resource-exhaustion** half of #49435. The `deleteMut` lock decoupling (moving the worker RPC out of the lock so it only guards the in-memory catch-up→publish boundary) is tracked as follow-up.
- The pool "priority" coefficients are pool-size only (no OS scheduling priority); isolation guarantees online-write admission, not CPU preemption under full saturation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)