### PR TITLE
fix: [poc_2.6.17] retry pre-import file-size HEAD on transient object-store timeout

### DIFF
--- a/internal/storage/local_chunk_manager.go
+++ b/internal/storage/local_chunk_manager.go
@@ -38,6 +38,25 @@ type LocalChunkManager struct {
 	localPath string
 }
 
+// wrapLocalIoError maps a local filesystem error to the proper Milvus IO error.
+// Permanent errors (not-found, permission denied) are classified to denylist codes
+// (ErrIoKeyNotFound / ErrIoPermissionDenied) so the import retry wrappers fail fast
+// instead of retrying them as a generic, non-classified ErrIoFailed; anything else
+// stays ErrIoFailed.
+func wrapLocalIoError(filePath string, err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return merr.WrapErrIoKeyNotFound(filePath, err.Error())
+	case errors.Is(err, os.ErrPermission):
+		return merr.WrapErrIoPermissionDenied(filePath, err)
+	default:
+		return merr.WrapErrIoFailed(filePath, err)
+	}
+}
+
 var _ ChunkManager = (*LocalChunkManager)(nil)
 
 // NewLocalChunkManager create a new local manager object.
@@ -115,7 +134,7 @@ func (lcm *LocalChunkManager) Exist(ctx context.Context, filePath string) (bool,
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return false, merr.WrapErrIoFailed(filePath, err)
+		return false, wrapLocalIoError(filePath, err)
 	}
 	return true, nil
 }
@@ -180,10 +199,7 @@ func (lcm *LocalChunkManager) WalkWithPrefix(ctx context.Context, prefix string,
 
 		f, err := os.Stat(filePath)
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return merr.WrapErrIoKeyNotFound(filePath)
-			}
-			return merr.WrapErrIoFailed(filePath, err)
+			return wrapLocalIoError(filePath, err)
 		}
 		if !walkFunc(&ChunkObjectInfo{FilePath: filePath, ModifyTime: f.ModTime()}) {
 			return nil
@@ -214,20 +230,13 @@ func (lcm *LocalChunkManager) ReadAt(ctx context.Context, filePath string, off i
 
 func (lcm *LocalChunkManager) Mmap(ctx context.Context, filePath string) (*mmap.ReaderAt, error) {
 	reader, err := mmap.Open(path.Clean(filePath))
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, merr.WrapErrIoKeyNotFound(filePath, err.Error())
-	}
-
-	return reader, merr.WrapErrIoFailed(filePath, err)
+	return reader, wrapLocalIoError(filePath, err)
 }
 
 func (lcm *LocalChunkManager) Size(ctx context.Context, filePath string) (int64, error) {
 	fi, err := os.Stat(filePath)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return 0, merr.WrapErrIoKeyNotFound(filePath, err.Error())
-		}
-		return 0, merr.WrapErrIoFailed(filePath, err)
+		return 0, wrapLocalIoError(filePath, err)
 	}
 	// get the size
 	size := fi.Size()

--- a/internal/storage/local_chunk_manager_wraperr_test.go
+++ b/internal/storage/local_chunk_manager_wraperr_test.go
@@ -1,0 +1,52 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+)
+
+// wrapLocalIoError must classify permanent local filesystem errors onto the denylist
+// (KeyNotFound / PermissionDenied) so the import retry wrappers fail fast on them,
+// while unknown errors stay ErrIoFailed (retryable by the denylist wrappers).
+func TestWrapLocalIoError(t *testing.T) {
+	assert.NoError(t, wrapLocalIoError("f", nil))
+
+	// os.Stat/os.Open wrap the syscall errno in *PathError; errors.Is unwraps to the
+	// sentinel, matching what production emits.
+	notFound := &os.PathError{Op: "stat", Path: "f", Err: os.ErrNotExist}
+	err := wrapLocalIoError("f", notFound)
+	assert.True(t, errors.Is(err, merr.ErrIoKeyNotFound))
+	assert.True(t, merr.IsNonRetryableErr(err), "not-found must be on the denylist")
+
+	permission := &os.PathError{Op: "open", Path: "f", Err: os.ErrPermission}
+	err = wrapLocalIoError("f", permission)
+	assert.True(t, errors.Is(err, merr.ErrIoPermissionDenied))
+	assert.True(t, merr.IsNonRetryableErr(err), "permission denied must be on the denylist (fail fast, no retry)")
+
+	other := fmt.Errorf("disk gremlins")
+	err = wrapLocalIoError("f", other)
+	assert.True(t, errors.Is(err, merr.ErrIoFailed))
+	assert.False(t, merr.IsNonRetryableErr(err), "unknown errors stay ErrIoFailed (retryable by the denylist wrappers)")
+}

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -52,10 +52,8 @@ import (
 func Open(filepath string) (*os.File, error) {
 	// NOLINT
 	reader, err := os.Open(filepath)
-	if os.IsNotExist(err) {
-		return nil, merr.WrapErrIoKeyNotFound(filepath)
-	} else if err != nil {
-		return nil, merr.WrapErrIoFailed(filepath, err)
+	if err != nil {
+		return nil, wrapLocalIoError(filepath, err)
 	}
 
 	return reader, nil
@@ -66,10 +64,8 @@ func Open(filepath string) (*os.File, error) {
 func ReadFile(filepath string) ([]byte, error) {
 	// NOLINT
 	data, err := os.ReadFile(filepath)
-	if os.IsNotExist(err) {
-		return nil, merr.WrapErrIoKeyNotFound(filepath)
-	} else if err != nil {
-		return nil, merr.WrapErrIoFailed(filepath, err)
+	if err != nil {
+		return nil, wrapLocalIoError(filepath, err)
 	}
 
 	return data, nil

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -18,7 +18,6 @@ package storage
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -1538,18 +1537,6 @@ func NewTestChunkManagerFactory(params *paramtable.ComponentParam, rootPath stri
 		objectstorage.CloudProvider(params.MinioCfg.CloudProvider.GetValue()),
 		objectstorage.IAMEndpoint(params.MinioCfg.IAMEndpoint.GetValue()),
 		objectstorage.CreateBucket(true))
-}
-
-func GetFilesSize(ctx context.Context, paths []string, cm ChunkManager) (int64, error) {
-	totalSize := int64(0)
-	for _, filePath := range paths {
-		size, err := cm.Size(ctx, filePath)
-		if err != nil {
-			return 0, err
-		}
-		totalSize += size
-	}
-	return totalSize, nil
 }
 
 type NullableInt struct {

--- a/internal/util/importutilv2/binlog/reader.go
+++ b/internal/util/importutilv2/binlog/reader.go
@@ -333,7 +333,7 @@ func (r *reader) Size() (int64, error) {
 	if size := r.fileSize.Load(); size != 0 {
 		return size, nil
 	}
-	size, err := storage.GetFilesSize(r.ctx, lo.Flatten(lo.Values(r.insertLogs)), r.cm)
+	size, err := importcommon.GetFilesSizeWithRetry(r.ctx, r.cm, lo.Flatten(lo.Values(r.insertLogs)))
 	if err != nil {
 		return 0, err
 	}

--- a/internal/util/importutilv2/common/retryable_size.go
+++ b/internal/util/importutilv2/common/retryable_size.go
@@ -1,0 +1,80 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/milvus-io/milvus/internal/storage"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v2/util/retry"
+)
+
+// GetFilesSizeWithRetry sums the size of each file with denylist retry, mirroring
+// WalkWithPrefixRetry and the binlog reader's multiReadWithRetry. It is used by every
+// import reader (binlog / numpy / parquet / csv / json) to estimate total file size
+// during pre-import.
+//
+// Each cm.Size is a per-file StatObject (an object-store HEAD). RemoteChunkManager.Size()
+// retries internally only on an allowlist (merr.IsRetryableErr), which excludes
+// ErrIoFailed; a transient transport error such as "net/http: timeout awaiting
+// response headers" maps to ErrIoFailed and therefore fails the whole pre-import on
+// the first attempt while the read/list/walk paths retry it. This wrapper closes that
+// gap: it retries every transient error and bails out only on permanent/validation
+// ones (permission denied, bucket/key not found, invalid argument, ...).
+func GetFilesSizeWithRetry(ctx context.Context, cm storage.ChunkManager, paths []string) (int64, error) {
+	retryAttempts := paramtable.Get().CommonCfg.StorageReadRetryAttempts.GetAsUint()
+	return getFilesSizeWithRetry(ctx, cm, paths, retryAttempts)
+}
+
+// getFilesSizeWithRetry is the testable core: retry is per-file, so a transient failure
+// on one file does not re-stat the files already done.
+func getFilesSizeWithRetry(ctx context.Context, cm storage.ChunkManager,
+	paths []string, retryAttempts uint,
+) (int64, error) {
+	var totalSize int64
+	for _, filePath := range paths {
+		var size int64
+		err := retry.Do(ctx, func() error {
+			s, e := cm.Size(ctx, filePath)
+			if e == nil {
+				size = s
+				return nil
+			}
+			log.Ctx(ctx).Warn("get file size failed, checking retryability",
+				zap.String("path", filePath),
+				zap.Error(e),
+			)
+			// Map raw storage error to Milvus IO error for consistent classification
+			e = storage.ToMilvusIoError(filePath, e)
+			// Denylist: don't retry permanent/validation errors
+			if merr.IsNonRetryableErr(e) {
+				return retry.Unrecoverable(e)
+			}
+			return e
+		}, retry.Attempts(retryAttempts))
+		if err != nil {
+			return 0, err
+		}
+		totalSize += size
+	}
+	return totalSize, nil
+}

--- a/internal/util/importutilv2/common/retryable_size.go
+++ b/internal/util/importutilv2/common/retryable_size.go
@@ -50,6 +50,12 @@ func GetFilesSizeWithRetry(ctx context.Context, cm storage.ChunkManager, paths [
 func getFilesSizeWithRetry(ctx context.Context, cm storage.ChunkManager,
 	paths []string, retryAttempts uint,
 ) (int64, error) {
+	// Defensive: retry.Attempts(0) means unbounded retry. The exported entrypoint reads
+	// the StorageReadRetryAttempts config, whose formatter already clamps <1 to the
+	// default, but guard direct callers too so a 0 can never spin forever here.
+	if retryAttempts < 1 {
+		retryAttempts = 10
+	}
 	var totalSize int64
 	for _, filePath := range paths {
 		var size int64
@@ -59,8 +65,12 @@ func getFilesSizeWithRetry(ctx context.Context, cm storage.ChunkManager,
 				size = s
 				return nil
 			}
-			// Context canceled or deadline exceeded - don't retry (and don't let it
-			// get mapped to a retryable-looking ErrIoFailed below).
+			// Defensive fast-fail on a bare context error returned directly by the
+			// ChunkManager (e.g. a mock, or a future non-Remote impl). On the
+			// RemoteChunkManager path a mid-flight cancellation is mapped to ErrIoFailed
+			// (mapObjectStorageError has no context case) and loses its context identity,
+			// so this branch does not fire there -- retry.Do's own ctx.Done handling
+			// terminates that case instead.
 			if errors.Is(e, context.Canceled) || errors.Is(e, context.DeadlineExceeded) {
 				return retry.Unrecoverable(e)
 			}
@@ -77,6 +87,13 @@ func getFilesSizeWithRetry(ctx context.Context, cm storage.ChunkManager,
 			// response headers" -- that is not a permanent/validation error. Retrying
 			// inner-retryable or permanent codes here would stack the two layers (up to
 			// retryAttempts^2 HEAD calls under a SlowDown storm), so bail out on both.
+			//
+			// Note ErrIoFailed is a catch-all: on the Remote import path known-permanent
+			// errors are classified to denylist codes (KeyNotFound / PermissionDenied /
+			// BucketNotFound / ...) and fail fast, so only genuinely-unknown errors are
+			// retried here. A non-classifying ChunkManager (e.g. LocalChunkManager, which
+			// is not used for remote imports) would retry a permanent OS error before
+			// failing -- the same trade-off the existing read/walk denylist retries make.
 			if merr.IsNonRetryableErr(e) || merr.IsRetryableErr(e) {
 				return retry.Unrecoverable(e)
 			}

--- a/internal/util/importutilv2/common/retryable_size.go
+++ b/internal/util/importutilv2/common/retryable_size.go
@@ -80,23 +80,21 @@ func getFilesSizeWithRetry(ctx context.Context, cm storage.ChunkManager,
 			)
 			// Map raw storage error to Milvus IO error for consistent classification.
 			e = storage.ToMilvusIoError(filePath, e)
-			// RemoteChunkManager.Size() already retries retryable codes
-			// (ErrIoUnexpectEOF / ErrIoTooManyRequests) internally on its own allowlist.
-			// This outer layer only fills the gap that inner retry leaves: a transient
-			// error it does not cover -- ErrIoFailed, e.g. "net/http: timeout awaiting
-			// response headers" -- that is not a permanent/validation error. Retrying
-			// inner-retryable or permanent codes here would stack the two layers (up to
-			// retryAttempts^2 HEAD calls under a SlowDown storm), so bail out on both.
-			//
-			// Note ErrIoFailed is a catch-all: known-permanent errors are classified to
-			// denylist codes (KeyNotFound / PermissionDenied / BucketNotFound / ...) and
-			// fail fast on both the Remote and the Local paths, so only genuinely-unknown
-			// errors are retried here -- the same trade-off the existing read/walk denylist
-			// retries make.
-			if merr.IsNonRetryableErr(e) || merr.IsRetryableErr(e) {
-				return retry.Unrecoverable(e)
+			// This outer layer exists only to cover the gap the chunk manager's inner
+			// retry leaves: a transient transport failure that maps to the catch-all
+			// ErrIoFailed, e.g. "net/http: timeout awaiting response headers". Everything
+			// else is handled elsewhere and must NOT be retried here:
+			//   - permanent codes (KeyNotFound / PermissionDenied / BucketNotFound / ...)
+			//     are on the denylist and must fail fast;
+			//   - inner-retryable codes (ErrIoTooManyRequests / ErrIoUnexpectEOF) are
+			//     already retried by RemoteChunkManager.Size() on its own allowlist, so
+			//     retrying them again here would stack the two layers (up to
+			//     retryAttempts^2 HEAD calls under a SlowDown storm).
+			// So retry only ErrIoFailed, and stop on everything else.
+			if errors.Is(e, merr.ErrIoFailed) {
+				return e
 			}
-			return e
+			return retry.Unrecoverable(e)
 		}, retry.Attempts(retryAttempts))
 		if err != nil {
 			return 0, err

--- a/internal/util/importutilv2/common/retryable_size.go
+++ b/internal/util/importutilv2/common/retryable_size.go
@@ -19,6 +19,7 @@ package common
 import (
 	"context"
 
+	"github.com/cockroachdb/errors"
 	"go.uber.org/zap"
 
 	"github.com/milvus-io/milvus/internal/storage"
@@ -38,8 +39,7 @@ import (
 // ErrIoFailed; a transient transport error such as "net/http: timeout awaiting
 // response headers" maps to ErrIoFailed and therefore fails the whole pre-import on
 // the first attempt while the read/list/walk paths retry it. This wrapper closes that
-// gap: it retries every transient error and bails out only on permanent/validation
-// ones (permission denied, bucket/key not found, invalid argument, ...).
+// gap.
 func GetFilesSizeWithRetry(ctx context.Context, cm storage.ChunkManager, paths []string) (int64, error) {
 	retryAttempts := paramtable.Get().CommonCfg.StorageReadRetryAttempts.GetAsUint()
 	return getFilesSizeWithRetry(ctx, cm, paths, retryAttempts)
@@ -59,14 +59,25 @@ func getFilesSizeWithRetry(ctx context.Context, cm storage.ChunkManager,
 				size = s
 				return nil
 			}
+			// Context canceled or deadline exceeded - don't retry (and don't let it
+			// get mapped to a retryable-looking ErrIoFailed below).
+			if errors.Is(e, context.Canceled) || errors.Is(e, context.DeadlineExceeded) {
+				return retry.Unrecoverable(e)
+			}
 			log.Ctx(ctx).Warn("get file size failed, checking retryability",
 				zap.String("path", filePath),
 				zap.Error(e),
 			)
-			// Map raw storage error to Milvus IO error for consistent classification
+			// Map raw storage error to Milvus IO error for consistent classification.
 			e = storage.ToMilvusIoError(filePath, e)
-			// Denylist: don't retry permanent/validation errors
-			if merr.IsNonRetryableErr(e) {
+			// RemoteChunkManager.Size() already retries retryable codes
+			// (ErrIoUnexpectEOF / ErrIoTooManyRequests) internally on its own allowlist.
+			// This outer layer only fills the gap that inner retry leaves: a transient
+			// error it does not cover -- ErrIoFailed, e.g. "net/http: timeout awaiting
+			// response headers" -- that is not a permanent/validation error. Retrying
+			// inner-retryable or permanent codes here would stack the two layers (up to
+			// retryAttempts^2 HEAD calls under a SlowDown storm), so bail out on both.
+			if merr.IsNonRetryableErr(e) || merr.IsRetryableErr(e) {
 				return retry.Unrecoverable(e)
 			}
 			return e

--- a/internal/util/importutilv2/common/retryable_size.go
+++ b/internal/util/importutilv2/common/retryable_size.go
@@ -88,12 +88,11 @@ func getFilesSizeWithRetry(ctx context.Context, cm storage.ChunkManager,
 			// inner-retryable or permanent codes here would stack the two layers (up to
 			// retryAttempts^2 HEAD calls under a SlowDown storm), so bail out on both.
 			//
-			// Note ErrIoFailed is a catch-all: on the Remote import path known-permanent
-			// errors are classified to denylist codes (KeyNotFound / PermissionDenied /
-			// BucketNotFound / ...) and fail fast, so only genuinely-unknown errors are
-			// retried here. A non-classifying ChunkManager (e.g. LocalChunkManager, which
-			// is not used for remote imports) would retry a permanent OS error before
-			// failing -- the same trade-off the existing read/walk denylist retries make.
+			// Note ErrIoFailed is a catch-all: known-permanent errors are classified to
+			// denylist codes (KeyNotFound / PermissionDenied / BucketNotFound / ...) and
+			// fail fast on both the Remote and the Local paths, so only genuinely-unknown
+			// errors are retried here -- the same trade-off the existing read/walk denylist
+			// retries make.
 			if merr.IsNonRetryableErr(e) || merr.IsRetryableErr(e) {
 				return retry.Unrecoverable(e)
 			}

--- a/internal/util/importutilv2/common/retryable_size_test.go
+++ b/internal/util/importutilv2/common/retryable_size_test.go
@@ -1,0 +1,134 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+func TestGetFilesSizeWithRetry_Success(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	cm.EXPECT().Size(mock.Anything, "file1").Return(int64(10), nil).Once()
+	cm.EXPECT().Size(mock.Anything, "file2").Return(int64(20), nil).Once()
+
+	total, err := getFilesSizeWithRetry(ctx, cm, []string{"file1", "file2"}, 3)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(30), total)
+}
+
+// G2: the customer's exact failure mode — a transport header timeout — is transient
+// and must be retried, not failed on the first attempt.
+func TestGetFilesSizeWithRetry_TransientTimeoutRetried(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	callCount := 0
+	cm.EXPECT().Size(mock.Anything, "file1").
+		RunAndReturn(func(ctx context.Context, path string) (int64, error) {
+			callCount++
+			if callCount < 3 {
+				return 0, errors.New("net/http: timeout awaiting response headers")
+			}
+			return 42, nil
+		}).Times(3)
+
+	total, err := getFilesSizeWithRetry(ctx, cm, []string{"file1"}, 5)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(42), total)
+	assert.Equal(t, 3, callCount, "should have retried twice then succeeded")
+}
+
+func TestGetFilesSizeWithRetry_NonRetryableErrorFailsFast(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	callCount := 0
+	cm.EXPECT().Size(mock.Anything, "file1").
+		RunAndReturn(func(ctx context.Context, path string) (int64, error) {
+			callCount++
+			return 0, merr.WrapErrIoPermissionDenied("file1", errors.New("access denied"))
+		}).Once()
+
+	total, err := getFilesSizeWithRetry(ctx, cm, []string{"file1"}, 5)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrIoPermissionDenied))
+	assert.Equal(t, int64(0), total)
+	assert.Equal(t, 1, callCount, "should not retry non-retryable errors")
+}
+
+// G2: a persistent timeout still fails, but only after exhausting all attempts —
+// and the typed ErrIoFailed code survives to the caller.
+func TestGetFilesSizeWithRetry_ExhaustsRetries(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	callCount := 0
+	cm.EXPECT().Size(mock.Anything, "file1").
+		RunAndReturn(func(ctx context.Context, path string) (int64, error) {
+			callCount++
+			return 0, errors.New("net/http: timeout awaiting response headers")
+		}).Times(3)
+
+	_, err := getFilesSizeWithRetry(ctx, cm, []string{"file1"}, 3)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrIoFailed), "timeout should be mapped to ErrIoFailed")
+	assert.Equal(t, 3, callCount, "should exhaust all retry attempts")
+}
+
+// Retry is per-file: a file that already succeeded is not re-stated when a later
+// file hits a transient error.
+func TestGetFilesSizeWithRetry_PerFileRetry(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	cm.EXPECT().Size(mock.Anything, "file1").Return(int64(5), nil).Once()
+	file2Calls := 0
+	cm.EXPECT().Size(mock.Anything, "file2").
+		RunAndReturn(func(ctx context.Context, path string) (int64, error) {
+			file2Calls++
+			if file2Calls < 2 {
+				return 0, errors.New("net/http: timeout awaiting response headers")
+			}
+			return 7, nil
+		}).Times(2)
+
+	total, err := getFilesSizeWithRetry(ctx, cm, []string{"file1", "file2"}, 5)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(12), total)
+	assert.Equal(t, 2, file2Calls, "only the failing file should be retried")
+}

--- a/internal/util/importutilv2/common/retryable_size_test.go
+++ b/internal/util/importutilv2/common/retryable_size_test.go
@@ -108,6 +108,25 @@ func TestGetFilesSizeWithRetry_ExhaustsRetries(t *testing.T) {
 	assert.Equal(t, 3, callCount, "should exhaust all retry attempts")
 }
 
+// A 0 attempts value must not spin forever: the core clamps it to a bounded default.
+func TestGetFilesSizeWithRetry_ZeroAttemptsClamped(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	callCount := 0
+	cm.EXPECT().Size(mock.Anything, "file1").
+		RunAndReturn(func(ctx context.Context, path string) (int64, error) {
+			callCount++
+			return 0, errors.New("net/http: timeout awaiting response headers")
+		}).Times(10)
+
+	_, err := getFilesSizeWithRetry(ctx, cm, []string{"file1"}, 0)
+
+	assert.Error(t, err)
+	assert.Equal(t, 10, callCount, "0 attempts must clamp to the bounded default, not retry forever")
+}
+
 // Codes the chunk manager's Size() already retries internally (IsRetryableErr:
 // ErrIoTooManyRequests / ErrIoUnexpectEOF) must NOT be retried again by this outer
 // layer, otherwise the two layers stack (up to retryAttempts^2 HEAD calls).

--- a/internal/util/importutilv2/common/retryable_size_test.go
+++ b/internal/util/importutilv2/common/retryable_size_test.go
@@ -108,6 +108,49 @@ func TestGetFilesSizeWithRetry_ExhaustsRetries(t *testing.T) {
 	assert.Equal(t, 3, callCount, "should exhaust all retry attempts")
 }
 
+// Codes the chunk manager's Size() already retries internally (IsRetryableErr:
+// ErrIoTooManyRequests / ErrIoUnexpectEOF) must NOT be retried again by this outer
+// layer, otherwise the two layers stack (up to retryAttempts^2 HEAD calls).
+func TestGetFilesSizeWithRetry_InnerRetryableNotDoubleRetried(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	callCount := 0
+	cm.EXPECT().Size(mock.Anything, "file1").
+		RunAndReturn(func(ctx context.Context, path string) (int64, error) {
+			callCount++
+			return 0, merr.WrapErrIoTooManyRequests("file1", errors.New("SlowDown"))
+		}).Once()
+
+	_, err := getFilesSizeWithRetry(ctx, cm, []string{"file1"}, 5)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrIoTooManyRequests))
+	assert.Equal(t, 1, callCount, "outer layer must not re-retry inner-retryable codes")
+}
+
+// A canceled/expired context fails fast and surfaces the context error (not a
+// timeout mapped to ErrIoFailed).
+func TestGetFilesSizeWithRetry_ContextCanceledFailsFast(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	callCount := 0
+	cm.EXPECT().Size(mock.Anything, "file1").
+		RunAndReturn(func(ctx context.Context, path string) (int64, error) {
+			callCount++
+			return 0, context.Canceled
+		}).Once()
+
+	_, err := getFilesSizeWithRetry(ctx, cm, []string{"file1"}, 5)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+	assert.Equal(t, 1, callCount, "should not retry a canceled context")
+}
+
 // Retry is per-file: a file that already succeeded is not re-stated when a later
 // file hits a transient error.
 func TestGetFilesSizeWithRetry_PerFileRetry(t *testing.T) {

--- a/internal/util/importutilv2/csv/reader.go
+++ b/internal/util/importutilv2/csv/reader.go
@@ -135,7 +135,7 @@ func (r *reader) Size() (int64, error) {
 	if size := r.fileSize.Load(); size != 0 {
 		return size, nil
 	}
-	size, err := r.cm.Size(r.ctx, r.filePath)
+	size, err := common.GetFilesSizeWithRetry(r.ctx, r.cm, []string{r.filePath})
 	if err != nil {
 		return 0, err
 	}

--- a/internal/util/importutilv2/json/reader.go
+++ b/internal/util/importutilv2/json/reader.go
@@ -257,7 +257,7 @@ func (j *reader) Size() (int64, error) {
 	if size := j.fileSize.Load(); size != 0 {
 		return size, nil
 	}
-	size, err := j.cm.Size(j.ctx, j.filePath)
+	size, err := common.GetFilesSizeWithRetry(j.ctx, j.cm, []string{j.filePath})
 	if err != nil {
 		return 0, err
 	}

--- a/internal/util/importutilv2/numpy/reader.go
+++ b/internal/util/importutilv2/numpy/reader.go
@@ -101,7 +101,7 @@ func (r *reader) Size() (int64, error) {
 	if size := r.fileSize.Load(); size != 0 {
 		return size, nil
 	}
-	size, err := storage.GetFilesSize(r.ctx, r.paths, r.cm)
+	size, err := common.GetFilesSizeWithRetry(r.ctx, r.cm, r.paths)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/util/importutilv2/numpy/reader_faultinject_test.go
+++ b/internal/util/importutilv2/numpy/reader_faultinject_test.go
@@ -1,0 +1,85 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package numpy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/atomic"
+
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
+)
+
+// End-to-end wiring test: drive the real numpy reader.Size() (which goes through the
+// exported, param-driven importcommon.GetFilesSizeWithRetry) and inject the customer's
+// exact transient object-store error on the first two StatObject/HEAD calls. Before the
+// fix this returned the error on the first attempt and failed the whole pre-import.
+func TestReaderSize_RetriesTransientHeadTimeout(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	calls := 0
+	cm.EXPECT().Size(mock.Anything, "f.npy").
+		RunAndReturn(func(ctx context.Context, path string) (int64, error) {
+			calls++
+			if calls < 3 {
+				return 0, errors.New("net/http: timeout awaiting response headers")
+			}
+			return 123, nil
+		})
+
+	r := &reader{ctx: ctx, cm: cm, paths: []string{"f.npy"}, fileSize: atomic.NewInt64(0)}
+
+	size, err := r.Size()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(123), size)
+	assert.Equal(t, 3, calls, "reader.Size must retry the transient HEAD timeout, not fail on the first attempt")
+
+	// Second call is served from the cache, no further StatObject.
+	size2, err := r.Size()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(123), size2)
+	assert.Equal(t, 3, calls, "cached size must not re-stat")
+}
+
+// A permanent error (permission denied) must still fail fast through the real reader.
+func TestReaderSize_PermanentErrorFailsFast(t *testing.T) {
+	paramtable.Init()
+	ctx := context.Background()
+	cm := mocks.NewChunkManager(t)
+
+	calls := 0
+	cm.EXPECT().Size(mock.Anything, "f.npy").
+		RunAndReturn(func(ctx context.Context, path string) (int64, error) {
+			calls++
+			return 0, merr.WrapErrIoPermissionDenied("f.npy", errors.New("access denied"))
+		}).Once()
+
+	r := &reader{ctx: ctx, cm: cm, paths: []string{"f.npy"}, fileSize: atomic.NewInt64(0)}
+
+	_, err := r.Size()
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, merr.ErrIoPermissionDenied))
+	assert.Equal(t, 1, calls, "permanent error must not be retried")
+}

--- a/internal/util/importutilv2/parquet/reader.go
+++ b/internal/util/importutilv2/parquet/reader.go
@@ -145,7 +145,7 @@ func (r *reader) Size() (int64, error) {
 	if size := r.fileSize.Load(); size != 0 {
 		return size, nil
 	}
-	size, err := r.cm.Size(r.ctx, r.path)
+	size, err := common.GetFilesSizeWithRetry(r.ctx, r.cm, []string{r.path})
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -1156,6 +1156,15 @@ The default value is 1, which is enough for most cases.`,
 		DefaultValue: "10",
 		Doc:          "The number of retry attempts for reading from object storage; only retryable errors will trigger a retry.",
 		Export:       false,
+		Formatter: func(value string) string {
+			// Guard against a misconfigured 0: retry.Attempts(0) means unbounded retry,
+			// which would spin a single storage read forever under a SlowDown storm.
+			attempts := getAsInt(value)
+			if attempts < 1 {
+				return "10"
+			}
+			return strconv.Itoa(attempts)
+		},
 	}
 	p.StorageReadRetryAttempts.Init(base.mgr)
 

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -151,6 +151,13 @@ func TestComponentParam(t *testing.T) {
 		params.Save("common.sync.taskPoolReleaseTimeoutSeconds", "100")
 		assert.Equal(t, 100*time.Second, params.CommonCfg.SyncTaskPoolReleaseTimeoutSeconds.GetAsDuration(time.Second))
 
+		assert.Equal(t, 10, params.CommonCfg.StorageReadRetryAttempts.GetAsInt())
+		params.Save("common.storage.readRetryAttempts", "3")
+		assert.Equal(t, 3, params.CommonCfg.StorageReadRetryAttempts.GetAsInt())
+		// 0 (or negative) means unbounded retry in retry.Attempts; clamp to the default.
+		params.Save("common.storage.readRetryAttempts", "0")
+		assert.Equal(t, 10, params.CommonCfg.StorageReadRetryAttempts.GetAsInt())
+
 		assert.Equal(t, 1, params.CommonCfg.StorageZstdConcurrency.GetAsInt())
 		params.Save("common.storage.zstd.concurrency", "2")
 		assert.Equal(t, 2, params.CommonCfg.StorageZstdConcurrency.GetAsInt())


### PR DESCRIPTION
Related to internal ticket #4503 (restore / bulk-import fails on a transient object-store HEAD timeout).

## Problem

Pre-import estimates total file size by calling `ChunkManager.Size()` (a `StatObject` / HEAD) per file. `RemoteChunkManager.Size()` retries internally only on an **allowlist** (`merr.IsRetryableErr`), which excludes `ErrIoFailed`. A transient transport error such as `net/http: timeout awaiting response headers` is mapped to `ErrIoFailed` by `mapObjectStorageError`'s default branch, so the HEAD is **not retried** and the whole import fails on the first attempt — while the read / list / walk paths, hardened with the **denylist** `IsNonRetryableErr` (#48427 / #48665), do retry the same error.

Observed:
```
state=ImportFailed
failed_reason: error: IO failed[key=.../insert_log/...]:
  Head "http://.../insert_log/...": net/http: timeout awaiting response headers
```

## Fix

Add `importcommon.GetFilesSizeWithRetry`, which wraps the per-file `Size()` in the same denylist retry already used by `multiReadWithRetry` / `WalkWithPrefixRetry`: retry every transient error, bail out only on permanent/validation errors (permission denied, bucket/key not found, invalid argument, ...). Retry is **per-file**, so a transient failure on one file does not re-stat the files already done.

Auditing **every** `cm.Size` site (not just the binlog path in the ticket) showed all five import readers — `binlog`, `numpy`, `parquet`, `csv`, `json` — estimate size via an unretried `Size()`; all are routed through the helper. The now-unused `storage.GetFilesSize` is removed.

This mirrors the existing read-path structure (an outer denylist retry over the chunk manager's inner allowlist retry), so it introduces no new behavior pattern. For `ErrIoFailed` the inner retry is a no-op (not allow-listed), so a transient timeout now gets the outer denylist retries instead of failing immediately.

## Verification

Fault injection (`TestGetFilesSizeWithRetry_*`):
- the customer's exact `net/http: timeout awaiting response headers` is retried and the import survives a transient timeout;
- a persistent timeout still fails after exhausting attempts, with the `ErrIoFailed` code preserved;
- a non-retryable permission-denied error fails fast without retry;
- retry is per-file (a succeeded file is not re-stated when a later file fails).

`make` build, full `internal/util/importutilv2/...` unit tests, and `golangci-lint` all pass.

Scope note: only the size/HEAD path is changed. `Exist()` also uses the allowlist but is not the failure point here; broadening that is left out of scope.