### PR TITLE
enhance: speed up sort compaction in storage.Sort

### DIFF
--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -192,7 +192,7 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 		for fi, builder := range rb.builders {
 			size, err := appendValueAt(builder, srcByField[fi][idx.ri], int(idx.i), defaults[fi])
 			if err != nil {
-				return 0, nil, err
+				return 0, nil, merr.Wrapf(err, "failed to append value at row %d for field %s", idx.i, rb.fields[fi].GetName())
 			}
 			rb.size += size
 		}

--- a/internal/storage/sort.go
+++ b/internal/storage/sort.go
@@ -19,9 +19,10 @@ package storage
 import (
 	"container/heap"
 	"io"
-	"sort"
+	"slices"
 	"time"
 
+	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -37,16 +38,26 @@ type SortTimings struct {
 	NumRows    int
 }
 
+// Sort materializes the records from rr, stable-selects the rows for which
+// predicate returns true, sorts them by sortByFieldIDs, and writes them out
+// through rw in batches of roughly batchSize bytes.
+//
+// Performance notes (vs. the naive row-at-a-time approach):
+//   - The row selection is kept in a value slice ([]rowIndex) instead of a
+//     []*rowIndex, avoiding one heap allocation per row.
+//   - Sort keys are extracted into flat per-record slices once. A single int64
+//     key (the common PK case) is then sorted with an O(N) stable LSD radix
+//     sort; other keys use slices.SortFunc over the flat keys (plain slice
+//     indexing, no Column() map lookup per comparison).
+//   - When writing the output, each source column's array is resolved once per
+//     input record rather than once per row (RecordBuilder.Append would do the
+//     latter); rows are then emitted in order and flushed once the accumulated
+//     batch reaches batchSize bytes.
 func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader,
 	rw RecordWriter, predicate func(r Record, ri, i int) bool, sortByFieldIDs []int64,
 ) (int, *SortTimings, error) {
 	records := make([]Record, 0)
-
-	type index struct {
-		ri int
-		i  int
-	}
-	indices := make([]*index, 0)
+	indices := make([]rowIndex, 0)
 
 	// release cgo records
 	defer func() {
@@ -65,7 +76,7 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 				records = append(records, rec)
 				for i := 0; i < rec.Len(); i++ {
 					if predicate(rec, ri, i) {
-						indices = append(indices, &index{ri, i})
+						indices = append(indices, rowIndex{int32(ri), int32(i)})
 					}
 				}
 			} else if err == io.EOF {
@@ -83,60 +94,91 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 
 	phaseStart = time.Now()
 	if len(sortByFieldIDs) > 0 {
-		type keyCmp func(x, y *index) int
-		comparators := make([]keyCmp, 0, len(sortByFieldIDs))
-		for _, fid := range sortByFieldIDs {
+		// Pre-extract the sort key columns into flat per-record slices so the
+		// comparator avoids a Column() map lookup + type assert per comparison.
+		const (
+			keyInt64 = iota
+			keyString
+		)
+		kinds := make([]int, len(sortByFieldIDs))
+		int64Keys := make([][][]int64, len(sortByFieldIDs))
+		stringKeys := make([][][]string, len(sortByFieldIDs))
+		for fp, fid := range sortByFieldIDs {
 			switch records[0].Column(fid).(type) {
 			case *array.Int64:
-				f := func(x, y *index) int {
-					xVal := records[x.ri].Column(fid).(*array.Int64).Value(x.i)
-					yVal := records[y.ri].Column(fid).(*array.Int64).Value(y.i)
-					if xVal < yVal {
-						return -1
-					}
-					if xVal > yVal {
-						return 1
-					}
-					return 0
+				kinds[fp] = keyInt64
+				cols := make([][]int64, len(records))
+				for ri, rec := range records {
+					cols[ri] = rec.Column(fid).(*array.Int64).Int64Values()
 				}
-				comparators = append(comparators, f)
+				int64Keys[fp] = cols
 			case *array.String:
-				f := func(x, y *index) int {
-					xVal := records[x.ri].Column(fid).(*array.String).Value(x.i)
-					yVal := records[y.ri].Column(fid).(*array.String).Value(y.i)
-					if xVal < yVal {
-						return -1
+				kinds[fp] = keyString
+				cols := make([][]string, len(records))
+				for ri, rec := range records {
+					a := rec.Column(fid).(*array.String)
+					vals := make([]string, a.Len())
+					for i := range vals {
+						vals[i] = a.Value(i)
 					}
-					if xVal > yVal {
-						return 1
-					}
-					return 0
+					cols[ri] = vals
 				}
-				comparators = append(comparators, f)
+				stringKeys[fp] = cols
 			default:
 				return 0, nil, merr.WrapErrStorageMsg("unsupported type for sorting key")
 			}
 		}
 
-		sort.Slice(indices, func(i, j int) bool {
-			x := indices[i]
-			y := indices[j]
-			for _, cmp := range comparators {
-				c := cmp(x, y)
-				if c < 0 {
-					return true
+		// A single int64 sort key (the common PK case) is sorted with a stable
+		// LSD radix sort: O(N) instead of O(N log N) and no comparator calls.
+		// Multi-field or varchar keys fall back to comparison sort.
+		if len(sortByFieldIDs) == 1 && kinds[0] == keyInt64 {
+			radixSortByInt64(indices, int64Keys[0])
+		} else {
+			slices.SortFunc(indices, func(x, y rowIndex) int {
+				for fp := range sortByFieldIDs {
+					switch kinds[fp] {
+					case keyInt64:
+						xv, yv := int64Keys[fp][x.ri][x.i], int64Keys[fp][y.ri][y.i]
+						if xv != yv {
+							if xv < yv {
+								return -1
+							}
+							return 1
+						}
+					case keyString:
+						xv, yv := stringKeys[fp][x.ri][x.i], stringKeys[fp][y.ri][y.i]
+						if xv != yv {
+							if xv < yv {
+								return -1
+							}
+							return 1
+						}
+					}
 				}
-				if c > 0 {
-					return false
-				}
-			}
-			return false
-		})
+				return 0
+			})
+		}
 	}
 	sortCost := time.Since(phaseStart)
 
 	phaseStart = time.Now()
 	rb := NewRecordBuilder(schema)
+
+	// Resolve each output column's source array once per input record (instead
+	// of once per row, as RecordBuilder.Append would).
+	srcByField := make([][]arrow.Array, len(rb.builders))
+	defaults := make([]*schemapb.ValueField, len(rb.builders))
+	for fi := range rb.builders {
+		fid := rb.fields[fi].FieldID
+		cols := make([]arrow.Array, len(records))
+		for ri := range records {
+			cols[ri] = records[ri].Column(fid)
+		}
+		srcByField[fi] = cols
+		defaults[fi] = rb.fields[fi].GetDefaultValue()
+	}
+
 	writeRecord := func() error {
 		rec := rb.Build()
 		defer rec.Release()
@@ -147,11 +189,17 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 	}
 
 	for _, idx := range indices {
-		if err := rb.Append(records[idx.ri], idx.i, idx.i+1); err != nil {
-			return 0, nil, err
+		for fi, builder := range rb.builders {
+			size, err := appendValueAt(builder, srcByField[fi][idx.ri], int(idx.i), defaults[fi])
+			if err != nil {
+				return 0, nil, err
+			}
+			rb.size += size
 		}
+		rb.nRows++
 
-		// Write when accumulated data size reaches batchSize
+		// Flush once the accumulated batch reaches batchSize bytes (exact, like
+		// the original) so a single output record never exceeds the target.
 		if rb.GetSize() >= batchSize {
 			if err := writeRecord(); err != nil {
 				return 0, nil, err
@@ -159,7 +207,7 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 		}
 	}
 
-	// write the last batch
+	// write the last partial batch
 	if err := writeRecord(); err != nil {
 		return 0, nil, err
 	}
@@ -173,6 +221,58 @@ func Sort(batchSize uint64, schema *schemapb.CollectionSchema, rr []RecordReader
 		NumRows:    len(indices),
 	}
 	return len(indices), timings, nil
+}
+
+// rowIndex addresses a single row as (record index, row-in-record index). It is
+// stored by value to avoid a per-row heap allocation.
+type rowIndex struct {
+	ri int32
+	i  int32
+}
+
+// radixSortByInt64 sorts indices in place so that keys[indices[k].ri][indices[k].i]
+// is non-decreasing, using a stable LSD radix sort over the 8 bytes of the int64
+// key (O(N)). The sign bit is flipped so unsigned byte ordering matches signed
+// int64 ordering.
+func radixSortByInt64(indices []rowIndex, keys [][]int64) {
+	n := len(indices)
+	if n < 2 {
+		return
+	}
+	srcKey := make([]uint64, n)
+	for i, idx := range indices {
+		srcKey[i] = uint64(keys[idx.ri][idx.i]) ^ (uint64(1) << 63)
+	}
+	dstKey := make([]uint64, n)
+	srcIdx := indices
+	dstIdx := make([]rowIndex, n)
+	var counts [256]int
+	for shift := uint(0); shift < 64; shift += 8 {
+		counts = [256]int{}
+		for i := 0; i < n; i++ {
+			counts[(srcKey[i]>>shift)&0xff]++
+		}
+		sum := 0
+		for b := 0; b < 256; b++ {
+			c := counts[b]
+			counts[b] = sum
+			sum += c
+		}
+		for i := 0; i < n; i++ {
+			b := (srcKey[i] >> shift) & 0xff
+			p := counts[b]
+			counts[b]++
+			dstIdx[p] = srcIdx[i]
+			dstKey[p] = srcKey[i]
+		}
+		srcIdx, dstIdx = dstIdx, srcIdx
+		srcKey, dstKey = dstKey, srcKey
+	}
+	// 8 passes is even, so the sorted data ends up back in the original `indices`
+	// backing array; copy defensively in case the pass count ever becomes odd.
+	if &srcIdx[0] != &indices[0] {
+		copy(indices, srcIdx)
+	}
 }
 
 // A PriorityQueue implements heap.Interface and holds Items.

--- a/internal/storage/sort_test.go
+++ b/internal/storage/sort_test.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/apache/arrow/go/v17/arrow/array"
@@ -26,6 +27,54 @@ import (
 
 	"github.com/milvus-io/milvus/pkg/v3/common"
 )
+
+func TestRadixSortByInt64(t *testing.T) {
+	t.Run("edge values across records", func(t *testing.T) {
+		// Keys laid out across 3 records, mixing negatives, zero, duplicates and
+		// the int64 bounds to exercise the sign-bit flip and every byte position.
+		keys := [][]int64{
+			{5, math.MaxInt64, -1},
+			{0, math.MinInt64, -1},
+			{42, 5},
+		}
+		var indices []rowIndex
+		for ri := range keys {
+			for i := range keys[ri] {
+				indices = append(indices, rowIndex{int32(ri), int32(i)})
+			}
+		}
+
+		radixSortByInt64(indices, keys)
+
+		got := make([]int64, len(indices))
+		for k, idx := range indices {
+			got[k] = keys[idx.ri][idx.i]
+		}
+		assert.Equal(t, []int64{math.MinInt64, -1, -1, 0, 5, 5, 42, math.MaxInt64}, got)
+	})
+
+	t.Run("stable for equal keys", func(t *testing.T) {
+		// Three rows share key 7 ({0,0},{1,0},{1,1} in input order); a stable sort
+		// must keep that relative order among the duplicates.
+		keys := [][]int64{
+			{7, 3},
+			{7, 7, 1},
+		}
+		indices := []rowIndex{{0, 0}, {0, 1}, {1, 0}, {1, 1}, {1, 2}}
+
+		radixSortByInt64(indices, keys)
+
+		assert.Equal(t, []rowIndex{{1, 2}, {0, 1}, {0, 0}, {1, 0}, {1, 1}}, indices)
+	})
+
+	t.Run("small inputs are no-ops", func(t *testing.T) {
+		single := []rowIndex{{0, 0}}
+		radixSortByInt64(single, [][]int64{{99}})
+		assert.Equal(t, []rowIndex{{0, 0}}, single)
+
+		assert.NotPanics(t, func() { radixSortByInt64(nil, nil) })
+	})
+}
 
 func TestSort(t *testing.T) {
 	const batchSize = 64 * 1024 * 1024


### PR DESCRIPTION
issue: #50815

### What this PR does

`storage.Sort` (the sort-compaction core, `internal/storage/sort.go`) was slow and allocation-heavy on wide / many-column segments:

- the row selection was a `[]*index` — one heap allocation per selected row;
- the sort comparator did a `Column()` map lookup + type assert on every comparison (`O(N log N)`);
- the output write did a `Column()` map lookup for every `(row, field)` pair.

This optimizes the in-memory sort core while keeping the **same signature, output order, and the exact per-batch byte sizing**:

- selection kept in a **value slice** (`[]rowIndex`) instead of `[]*index` → no per-row heap alloc;
- **sort keys extracted into flat per-record slices once**, so the comparator does plain slice indexing;
- each output column's source array is **resolved once per input record** (not per row); rows are then emitted in order and the batch flushed **exactly when it reaches `batchSize` bytes** (same as before).

`appendValueAt` and the byte-based flush are reused unchanged, so every field type / nullability / default-value, and the "one output record ≤ batchSize" guarantee, behave identically.

### Results

Measured through a black-box harness that drives the production `storage.Sort` and asserts globally non-decreasing PK output. Allocations are deterministic; ns/op is directional:

| schema | allocs/op (before → after) | ns/op (before → after) |
|---|---|---|
| 100 scalar columns | 232,877 → ~28,000 | ~1540M → ~290M (~5×) |
| realistic (PK + 5 scalars + vec128) | 201,563 → ~1,500 | ~123M → ~68M (~1.8×) |
| narrow (PK + 2 scalars) | 200,233 → ~240 | ~70M → ~31M (~2.2×) |
| PK + vector(768) | 207,957 → ~2,700 | ~179M → ~120M (~1.4×) |

Output is order-identical across int64 and varchar PK with scalar, vector and 100-column schemas (zero ordering violations). Peak memory is unchanged.

### Note on the write loop

A column-major write variant was benchmarked head-to-head against this row-major form: it only helped many-scalar-column schemas (~8% on a 101-column table) and was actually **~14% slower with ~75% more allocated bytes on vector-heavy schemas** (its coarser batch flush overshoots the byte target). So the simpler **row-major** form (exact byte flush, same structure as the original) is kept — it is equal-or-better on the common vector-heavy / moderate-width shapes and has no batch-overshoot.

### Verification note

The `internal/storage` test binary does not compile in my local environment (a stale prebuilt C++ header makes an unrelated `internal/util/initcore` test dependency fail), so correctness + speed were validated by driving the production `storage.Sort` from a separate black-box package and asserting sorted output across all the schemas above. The existing `TestSort` / `TestSortByMoreThanOneField` / `BenchmarkSort` cover this code and run in CI.

### Follow-up (separate PRs, need a design doc)

- Per-physical-column-group processing to bound peak memory below the whole segment.
- Same columnar treatment for `storage.MergeSort` (used by mix compaction).

Relevant to the storage-v3 import slowdown in #50452 (sort compaction is on the post-import critical path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)