### PR TITLE
enhance: Add Hugging Face inference provider support

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -1495,6 +1495,10 @@ function:
         credential:  # The name in the credential configuration item
         enable: true # Whether to enable Gemini model service
         url:  # Your Gemini embedding url, Default is the official embedding url
+      huggingface:
+        credential:  # The name in the credential configuration item
+        enable: true # Whether to enable Hugging Face text embedding service
+        url:  # Your Hugging Face Inference Providers router URL, default is https://router.huggingface.co
       openai:
         credential:  # The name in the crendential configuration item
         enable: true # Whether to enable openai model service
@@ -1525,6 +1529,10 @@ function:
           credential:  # The name in the crendential configuration item
           enable: true # Whether to enable cohere model service
           url:  # Your cohere rerank url, Default is the official rerank url
+        huggingface:
+          credential:  # The name in the credential configuration item
+          enable: true # Whether to enable Hugging Face rerank service
+          url:  # Your Hugging Face Inference Providers router URL, default is https://router.huggingface.co
         siliconflow:
           credential:  # The name in the crendential configuration item
           enable: true # Whether to enable siliconflow model service

--- a/internal/util/function/embedding/huggingface_embedding_provider.go
+++ b/internal/util/function/embedding/huggingface_embedding_provider.go
@@ -1,0 +1,174 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/internal/util/function/models/huggingface"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
+)
+
+type HuggingFaceEmbeddingProvider struct {
+	fieldDim int64
+
+	client     *huggingface.Client
+	modelName  string
+	hfProvider string
+
+	params map[string]any
+
+	maxBatch  int
+	timeoutMs int64
+	extraInfo *models.ModelExtraInfo
+}
+
+func NewHuggingFaceEmbeddingProvider(fieldSchema *schemapb.FieldSchema, functionSchema *schemapb.FunctionSchema, params map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (*HuggingFaceEmbeddingProvider, error) {
+	fieldDim, err := typeutil.GetDim(fieldSchema)
+	if err != nil {
+		return nil, err
+	}
+	if fieldSchema.DataType != schemapb.DataType_FloatVector {
+		return nil, merr.WrapErrParameterInvalidMsg("Hugging Face embedding only supports FloatVector field, got %s", schemapb.DataType_name[int32(fieldSchema.DataType)])
+	}
+
+	apiKey, url, err := models.ParseAKAndURL(credentials, functionSchema.Params, params, models.HuggingFaceAKEnvStr, extraInfo)
+	if err != nil {
+		return nil, err
+	}
+	client, err := huggingface.NewClient(apiKey, url)
+	if err != nil {
+		return nil, err
+	}
+
+	var modelName string
+	hfProvider := huggingface.DefaultHFProvider
+	maxBatch := 128
+	hfParams := map[string]any{}
+
+	for _, param := range functionSchema.Params {
+		switch strings.ToLower(param.Key) {
+		case models.ModelNameParamKey:
+			modelName = param.Value
+		case models.HuggingFaceProviderParamKey:
+			hfProvider = param.Value
+		case models.NormalizeParamKey:
+			normalize, err := strconv.ParseBool(param.Value)
+			if err != nil {
+				return nil, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is invalid, only supports: [true/false]", models.NormalizeParamKey, param.Value)
+			}
+			hfParams[models.NormalizeParamKey] = normalize
+		case models.TruncateParamKey:
+			truncate, err := strconv.ParseBool(param.Value)
+			if err != nil {
+				return nil, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is invalid, only supports: [true/false]", models.TruncateParamKey, param.Value)
+			}
+			hfParams[models.TruncateParamKey] = truncate
+		case models.TruncationDirectionParamKey:
+			hfParams[models.TruncationDirectionParamKey] = param.Value
+		case models.HuggingFacePromptNameParamKey:
+			hfParams[models.HuggingFacePromptNameParamKey] = param.Value
+		case models.MaxClientBatchSizeParamKey:
+			if maxBatch, err = parseEmbeddingMaxBatch(param.Value); err != nil {
+				return nil, err
+			}
+		default:
+		}
+	}
+	if modelName == "" {
+		return nil, merr.WrapErrParameterMissingMsg("huggingface embedding model name is required")
+	}
+	if hfProvider == "" {
+		return nil, merr.WrapErrParameterInvalidMsg("huggingface embedding hf_provider cannot be empty")
+	}
+	provider := HuggingFaceEmbeddingProvider{
+		client:     client,
+		fieldDim:   fieldDim,
+		modelName:  modelName,
+		hfProvider: hfProvider,
+		params:     hfParams,
+		maxBatch:   maxBatch,
+		timeoutMs:  models.ResolveTimeoutMs(functionSchema.Params),
+		extraInfo:  extraInfo,
+	}
+	return &provider, nil
+}
+
+func parseEmbeddingMaxBatch(maxBatch string) (int, error) {
+	batch, err := strconv.Atoi(maxBatch)
+	if err != nil {
+		return -1, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] is not a valid number", models.MaxClientBatchSizeParamKey, maxBatch)
+	}
+	if batch <= 0 {
+		return -1, merr.WrapErrParameterInvalidMsg("[%s param's value: %s] must be greater than 0", models.MaxClientBatchSizeParamKey, maxBatch)
+	}
+	return batch, nil
+}
+
+func (provider *HuggingFaceEmbeddingProvider) MaxBatch() int {
+	return provider.extraInfo.BatchFactor * provider.maxBatch
+}
+
+func (provider *HuggingFaceEmbeddingProvider) FieldDim() int64 {
+	return provider.fieldDim
+}
+
+func (provider *HuggingFaceEmbeddingProvider) CallEmbedding(_ context.Context, texts []string, _ models.TextEmbeddingMode) (any, error) {
+	data := make([][]float32, 0, len(texts))
+	for i := 0; i < len(texts); i += provider.maxBatch {
+		end := i + provider.maxBatch
+		if end > len(texts) {
+			end = len(texts)
+		}
+		resp, err := provider.client.FeatureExtraction(provider.hfProvider, provider.modelName, texts[i:end], provider.params, provider.timeoutMs)
+		if err != nil {
+			return nil, err
+		}
+		embeddings, err := parseFeatureExtractionResponse(*resp, end-i, provider.fieldDim)
+		if err != nil {
+			return nil, err
+		}
+		data = append(data, embeddings...)
+	}
+	return data, nil
+}
+
+func parseFeatureExtractionResponse(raw json.RawMessage, expectedRows int, fieldDim int64) ([][]float32, error) {
+	var batch [][]float32
+	if err := json.Unmarshal(raw, &batch); err != nil || len(batch) == 0 {
+		return nil, merr.WrapErrFunctionFailedMsg("unsupported Hugging Face feature-extraction response format")
+	}
+
+	if len(batch) != expectedRows {
+		return nil, merr.WrapErrFunctionFailedMsg("get embedding failed, the number of texts and embeddings does not match text:[%d], embedding:[%d]", expectedRows, len(batch))
+	}
+	for _, item := range batch {
+		if len(item) != int(fieldDim) {
+			return nil, merr.WrapErrFunctionFailedMsg("the required embedding dim is [%d], but the embedding obtained from the model is [%d]", fieldDim, len(item))
+		}
+	}
+	return batch, nil
+}

--- a/internal/util/function/embedding/huggingface_embedding_provider_test.go
+++ b/internal/util/function/embedding/huggingface_embedding_provider_test.go
@@ -1,0 +1,155 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/internal/util/function/models/huggingface"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func (s *TextEmbeddingFunctionSuite) TestNewHuggingFaceEmbeddingProvider() {
+	field := s.schema.Fields[2]
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}
+	creds := credentials.NewCredentials(map[string]string{"mock.apikey": "mock_key"})
+	extraInfo := &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db", BatchFactor: 1}
+	_, err := NewHuggingFaceEmbeddingProvider(field, functionSchema, nil, creds, extraInfo)
+	s.ErrorContains(err, "huggingface embedding model name is required")
+
+	functionSchema.Params = append(functionSchema.Params, &commonpb.KeyValuePair{Key: models.ModelNameParamKey, Value: "BAAI/bge-m3"})
+	int8Field := &schemapb.FieldSchema{FieldID: 103, Name: "int8_vector", DataType: schemapb.DataType_Int8Vector, TypeParams: []*commonpb.KeyValuePair{{Key: "dim", Value: "4"}}}
+	_, err = NewHuggingFaceEmbeddingProvider(int8Field, functionSchema, nil, creds, extraInfo)
+	s.ErrorContains(err, "only supports FloatVector")
+}
+
+func (s *TextEmbeddingFunctionSuite) TestCallHuggingFaceEmbedding() {
+	var count int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.Equal("/hf-inference/models/BAAI/bge-m3/pipeline/feature-extraction", r.URL.Path)
+		s.Equal("Bearer mock_key", r.Header.Get("Authorization"))
+		var req huggingface.FeatureExtractionRequest
+		body, _ := io.ReadAll(r.Body)
+		defer r.Body.Close()
+		s.NoError(json.Unmarshal(body, &req))
+		s.Equal("query", req["prompt_name"])
+		s.Equal("left", req["truncation_direction"])
+		s.Equal(true, req["normalize"])
+
+		current := atomic.AddInt32(&count, 1)
+		switch current {
+		case 1:
+			s.Equal([]any{"t1", "t2"}, req["inputs"])
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[[0,1,2,3],[1,2,3,4]]`))
+		case 2:
+			s.Equal([]any{"t3"}, req["inputs"])
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[[2,3,4,5]]`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	functionSchema := &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.ModelNameParamKey, Value: "BAAI/bge-m3"},
+			{Key: models.MaxClientBatchSizeParamKey, Value: "2"},
+			{Key: models.NormalizeParamKey, Value: "true"},
+			{Key: models.TruncationDirectionParamKey, Value: "left"},
+			{Key: models.HuggingFacePromptNameParamKey, Value: "query"},
+		},
+	}
+	provider, err := NewHuggingFaceEmbeddingProvider(s.schema.Fields[2], functionSchema, map[string]string{models.URLParamKey: ts.URL}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock_key"}), &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db", BatchFactor: 1})
+	s.NoError(err)
+	embs, err := provider.CallEmbedding(context.Background(), []string{"t1", "t2", "t3"}, models.InsertMode)
+	s.NoError(err)
+	s.Equal([][]float32{{0, 1, 2, 3}, {1, 2, 3, 4}, {2, 3, 4, 5}}, embs)
+	s.Equal(int32(2), atomic.LoadInt32(&count))
+}
+
+func (s *TextEmbeddingFunctionSuite) TestParseHuggingFaceFeatureExtractionResponse() {
+	_, err := parseFeatureExtractionResponse([]byte(`[[[0,1,2,3]]]`), 1, 4)
+	s.ErrorContains(err, "unsupported")
+
+	_, err = parseFeatureExtractionResponse([]byte(`[[0,1,2,3]]`), 2, 4)
+	s.ErrorContains(err, "does not match")
+
+	_, err = parseFeatureExtractionResponse([]byte(`[[0,1,2]]`), 1, 4)
+	s.ErrorContains(err, "required embedding dim")
+
+	_, err = parseFeatureExtractionResponse([]byte(`{"unexpected":true}`), 1, 4)
+	s.ErrorContains(err, "unsupported")
+}
+
+func (s *TextEmbeddingFunctionSuite) TestHuggingFaceTextEmbeddingFunctionRegistry() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[[0,1,2,3]]`))
+	}))
+	defer ts.Close()
+	paramtable.Get().FunctionCfg.TextEmbeddingProviders.GetFunc = func() map[string]string {
+		return map[string]string{
+			huggingFaceProvider + "." + models.URLParamKey: ts.URL,
+		}
+	}
+
+	runner, err := NewTextEmbeddingFunction(s.schema, &schemapb.FunctionSchema{
+		Name:             "test",
+		Type:             schemapb.FunctionType_TextEmbedding,
+		InputFieldNames:  []string{"text"},
+		OutputFieldNames: []string{"vector"},
+		InputFieldIds:    []int64{101},
+		OutputFieldIds:   []int64{102},
+		Params: []*commonpb.KeyValuePair{
+			{Key: Provider, Value: huggingFaceProvider},
+			{Key: models.ModelNameParamKey, Value: "BAAI/bge-m3"},
+			{Key: models.CredentialParamKey, Value: "mock"},
+		},
+	}, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+	s.NoError(err)
+	s.Equal(huggingFaceProvider, runner.GetFunctionProvider())
+}

--- a/internal/util/function/embedding/text_embedding_function.go
+++ b/internal/util/function/embedding/text_embedding_function.go
@@ -49,6 +49,7 @@ const (
 	ycProvider           string = "yc"
 	zillizProvider       string = "zilliz"
 	geminiProvider       string = "gemini"
+	huggingFaceProvider  string = "huggingface"
 )
 
 func hasEmptyString(texts []string) bool {
@@ -143,8 +144,10 @@ func NewTextEmbeddingFunction(coll *schemapb.CollectionSchema, functionSchema *s
 		embP, newProviderErr = NewZillizEmbeddingProvider(base.outputFields[0], functionSchema, conf, extraInfo)
 	case geminiProvider:
 		embP, newProviderErr = NewGeminiEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
+	case huggingFaceProvider:
+		embP, newProviderErr = NewHuggingFaceEmbeddingProvider(base.outputFields[0], functionSchema, conf, credentials, extraInfo)
 	default:
-		return nil, merr.WrapErrParameterInvalidMsg("unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider)
+		return nil, merr.WrapErrParameterInvalidMsg("unsupported text embedding service provider: [%s] , list of supported [%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s]", base.provider, openAIProvider, azureOpenAIProvider, aliDashScopeProvider, bedrockProvider, vertexAIProvider, voyageAIProvider, cohereProvider, siliconflowProvider, teiProvider, ycProvider, zillizProvider, geminiProvider, huggingFaceProvider)
 	}
 
 	if newProviderErr != nil {

--- a/internal/util/function/models/common.go
+++ b/internal/util/function/models/common.go
@@ -140,6 +140,14 @@ const (
 	GeminiAKEnvStr string = "MILVUS_GEMINI_API_KEY"
 )
 
+// Hugging Face
+
+const (
+	HuggingFaceAKEnvStr           string = "MILVUS_HUGGINGFACE_API_KEY"
+	HuggingFaceProviderParamKey   string = "hf_provider"
+	HuggingFacePromptNameParamKey string = "prompt_name"
+)
+
 // TEI and vllm
 
 const (

--- a/internal/util/function/models/huggingface/huggingface_client.go
+++ b/internal/util/function/models/huggingface/huggingface_client.go
@@ -1,0 +1,152 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package huggingface
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+const (
+	DefaultBaseURL    = "https://router.huggingface.co"
+	DefaultHFProvider = "hf-inference"
+
+	FeatureExtractionTask  = "feature-extraction"
+	SentenceSimilarityTask = "sentence-similarity"
+)
+
+type Client struct {
+	apiKey  string
+	baseURL string
+}
+
+func NewClient(apiKey string, baseURL string) (*Client, error) {
+	if apiKey == "" {
+		return nil, merr.WrapErrParameterInvalidMsg("missing credentials config or configure the MILVUS_HUGGINGFACE_API_KEY environment variable in the Milvus service")
+	}
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	if _, err := models.NewBaseURL(baseURL); err != nil {
+		return nil, err
+	}
+	return &Client{
+		apiKey:  apiKey,
+		baseURL: baseURL,
+	}, nil
+}
+
+func (c *Client) headers() map[string]string {
+	return map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": fmt.Sprintf("Bearer %s", c.apiKey),
+	}
+}
+
+type FeatureExtractionRequest map[string]any
+
+type FeatureExtractionResponse = json.RawMessage
+
+type SentenceSimilarityInputs struct {
+	SourceSentence string   `json:"source_sentence"`
+	Sentences      []string `json:"sentences"`
+}
+
+type SentenceSimilarityRequest struct {
+	Inputs SentenceSimilarityInputs `json:"inputs"`
+}
+
+type SentenceSimilarityResponse []float32
+
+func (c *Client) FeatureExtraction(hfProvider string, modelName string, texts []string, params map[string]any, timeoutMs int64) (*FeatureExtractionResponse, error) {
+	url, err := c.buildPipelineURL(hfProvider, modelName, FeatureExtractionTask)
+	if err != nil {
+		return nil, err
+	}
+	req := FeatureExtractionRequest{
+		"inputs": texts,
+	}
+	for k, v := range params {
+		req[k] = v
+	}
+	return models.PostRequest[FeatureExtractionResponse](req, url, c.headers(), timeoutMs)
+}
+
+func (c *Client) SentenceSimilarity(hfProvider string, modelName string, query string, texts []string, timeoutMs int64) (*SentenceSimilarityResponse, error) {
+	url, err := c.buildPipelineURL(hfProvider, modelName, SentenceSimilarityTask)
+	if err != nil {
+		return nil, err
+	}
+	req := SentenceSimilarityRequest{
+		Inputs: SentenceSimilarityInputs{
+			SourceSentence: query,
+			Sentences:      texts,
+		},
+	}
+	return models.PostRequest[SentenceSimilarityResponse](req, url, c.headers(), timeoutMs)
+}
+
+func (c *Client) buildPipelineURL(hfProvider string, modelName string, task string) (string, error) {
+	return buildPipelineURL(c.baseURL, hfProvider, modelName, task)
+}
+
+func buildPipelineURL(baseURL string, hfProvider string, modelName string, task string) (string, error) {
+	if hfProvider == "" {
+		hfProvider = DefaultHFProvider
+	}
+	if hfProvider != DefaultHFProvider {
+		return "", merr.WrapErrParameterInvalidMsg("Hugging Face hf_provider only supports %s", DefaultHFProvider)
+	}
+	if err := validateModelName(modelName); err != nil {
+		return "", err
+	}
+	if task == "" {
+		return "", merr.WrapErrParameterInvalidMsg("Hugging Face pipeline task is required")
+	}
+
+	base, err := models.NewBaseURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+
+	prefix := strings.TrimRight(base.Path, "/")
+	base.Path = fmt.Sprintf("%s/%s/models/%s/pipeline/%s",
+		prefix,
+		url.PathEscape(hfProvider),
+		modelName,
+		task,
+	)
+	return base.String(), nil
+}
+
+func validateModelName(modelName string) error {
+	if modelName == "" {
+		return merr.WrapErrParameterInvalidMsg("Hugging Face model name is required")
+	}
+	parts := strings.Split(modelName, "/")
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return merr.WrapErrParameterInvalidMsg("Hugging Face model name contains invalid path segment")
+		}
+	}
+	return nil
+}

--- a/internal/util/function/models/huggingface/huggingface_client_test.go
+++ b/internal/util/function/models/huggingface/huggingface_client_test.go
@@ -1,0 +1,147 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package huggingface
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+	_, err := NewClient("", "")
+	assert.Error(t, err)
+
+	c, err := NewClient("mock_key", "")
+	require.NoError(t, err)
+	assert.Equal(t, DefaultBaseURL, c.baseURL)
+
+	_, err = NewClient("mock_key", "not-a-url")
+	assert.Error(t, err)
+}
+
+func TestBuildPipelineURL(t *testing.T) {
+	url, err := buildPipelineURL("https://router.huggingface.co", "hf-inference", "BAAI/bge-m3", SentenceSimilarityTask)
+	require.NoError(t, err)
+	assert.Equal(t, "https://router.huggingface.co/hf-inference/models/BAAI/bge-m3/pipeline/sentence-similarity", url)
+
+	url, err = buildPipelineURL("https://router.huggingface.co/base", "", "sentence-transformers/all-MiniLM-L6-v2", FeatureExtractionTask)
+	require.NoError(t, err)
+	assert.Equal(t, "https://router.huggingface.co/base/hf-inference/models/sentence-transformers/all-MiniLM-L6-v2/pipeline/feature-extraction", url)
+
+	_, err = buildPipelineURL("https://router.huggingface.co", "custom-hf", "BAAI/bge-m3", FeatureExtractionTask)
+	assert.ErrorContains(t, err, "only supports hf-inference")
+
+	_, err = buildPipelineURL("https://router.huggingface.co", "hf-inference", "", FeatureExtractionTask)
+	assert.Error(t, err)
+
+	_, err = buildPipelineURL("https://router.huggingface.co", "hf-inference", "BAAI/bge-m3", "")
+	assert.Error(t, err)
+
+	_, err = buildPipelineURL("https://router.huggingface.co", "hf-inference", "../../secret", FeatureExtractionTask)
+	assert.Error(t, err)
+
+	_, err = buildPipelineURL("https://router.huggingface.co", "hf-inference", "BAAI/../secret", FeatureExtractionTask)
+	assert.Error(t, err)
+}
+
+func TestFeatureExtraction(t *testing.T) {
+	normalize := true
+	truncate := false
+	var req FeatureExtractionRequest
+	var gotPath string
+	var gotAuth string
+	var gotContentType string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write([]byte(`[[0.1,0.2],[0.3,0.4]]`))
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	c, err := NewClient("mock_key", ts.URL)
+	require.NoError(t, err)
+	resp, err := c.FeatureExtraction("hf-inference", "BAAI/bge-m3", []string{"doc1", "doc2"}, map[string]any{
+		"normalize":            normalize,
+		"truncate":             truncate,
+		"truncation_direction": "left",
+		"prompt_name":          "query",
+	}, 0)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/hf-inference/models/BAAI/bge-m3/pipeline/feature-extraction", gotPath)
+	assert.Equal(t, "Bearer mock_key", gotAuth)
+	assert.Equal(t, "application/json", gotContentType)
+	assert.Equal(t, []any{"doc1", "doc2"}, req["inputs"])
+	assert.Equal(t, true, req["normalize"])
+	assert.Equal(t, false, req["truncate"])
+	assert.Equal(t, "left", req["truncation_direction"])
+	assert.Equal(t, "query", req["prompt_name"])
+	assert.JSONEq(t, `[[0.1,0.2],[0.3,0.4]]`, string(*resp))
+}
+
+func TestSentenceSimilarity(t *testing.T) {
+	var req SentenceSimilarityRequest
+	var gotPath string
+	var gotAuth string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write([]byte(`[0.12,0.34,0.56]`))
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	c, err := NewClient("mock_key", ts.URL)
+	require.NoError(t, err)
+	resp, err := c.SentenceSimilarity("hf-inference", "BAAI/bge-m3", "query", []string{"doc1", "doc2", "doc3"}, 0)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/hf-inference/models/BAAI/bge-m3/pipeline/sentence-similarity", gotPath)
+	assert.Equal(t, "Bearer mock_key", gotAuth)
+	assert.Equal(t, "query", req.Inputs.SourceSentence)
+	assert.Equal(t, []string{"doc1", "doc2", "doc3"}, req.Inputs.Sentences)
+	assert.Equal(t, &SentenceSimilarityResponse{0.12, 0.34, 0.56}, resp)
+}
+
+func TestFailedResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`not json`))
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	c, err := NewClient("mock_key", ts.URL)
+	require.NoError(t, err)
+	_, err = c.SentenceSimilarity("hf-inference", "BAAI/bge-m3", "query", []string{"doc1"}, 0)
+	assert.Error(t, err)
+}

--- a/internal/util/function/rerank/huggingface_rerank_provider.go
+++ b/internal/util/function/rerank/huggingface_rerank_provider.go
@@ -1,0 +1,100 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package rerank
+
+import (
+	"context"
+	"strings"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/internal/util/function/models/huggingface"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+type huggingFaceProvider struct {
+	baseProvider
+	client     *huggingface.Client
+	modelName  string
+	hfProvider string
+	timeoutMs  int64
+}
+
+func newHuggingFaceProvider(params []*commonpb.KeyValuePair, conf map[string]string, credentials *credentials.Credentials, extraInfo *models.ModelExtraInfo) (ModelProvider, error) {
+	apiKey, url, err := models.ParseAKAndURL(credentials, params, conf, models.HuggingFaceAKEnvStr, extraInfo)
+	if err != nil {
+		return nil, err
+	}
+	client, err := huggingface.NewClient(apiKey, url)
+	if err != nil {
+		return nil, err
+	}
+
+	var modelName string
+	hfProvider := huggingface.DefaultHFProvider
+	maxBatch := 32
+	for _, param := range params {
+		switch strings.ToLower(param.Key) {
+		case models.ModelNameParamKey:
+			modelName = param.Value
+		case models.HuggingFaceProviderParamKey:
+			hfProvider = param.Value
+		case models.MaxClientBatchSizeParamKey:
+			if maxBatch, err = parseMaxBatch(param.Value); err != nil {
+				return nil, err
+			}
+		default:
+		}
+	}
+	if modelName == "" {
+		return nil, merr.WrapErrParameterMissingMsg("huggingface rerank model name is required")
+	}
+	if hfProvider == "" {
+		return nil, merr.WrapErrParameterInvalidMsg("huggingface rerank hf_provider cannot be empty")
+	}
+
+	provider := huggingFaceProvider{
+		baseProvider: baseProvider{batchSize: maxBatch},
+		client:       client,
+		modelName:    modelName,
+		hfProvider:   hfProvider,
+		timeoutMs:    models.ResolveTimeoutMs(params),
+	}
+	return &provider, nil
+}
+
+func (provider *huggingFaceProvider) Rerank(_ context.Context, query string, docs []string) ([]float32, error) {
+	scores := make([]float32, 0, len(docs))
+	for i := 0; i < len(docs); i += provider.batchSize {
+		end := i + provider.batchSize
+		if end > len(docs) {
+			end = len(docs)
+		}
+		resp, err := provider.client.SentenceSimilarity(provider.hfProvider, provider.modelName, query, docs[i:end], provider.timeoutMs)
+		if err != nil {
+			return nil, err
+		}
+		if len(*resp) != end-i {
+			return nil, merr.WrapErrFunctionFailedMsg("get rerank scores failed, the number of docs and scores does not match docs:[%d], scores:[%d]", end-i, len(*resp))
+		}
+		scores = append(scores, (*resp)...)
+	}
+	return scores, nil
+}

--- a/internal/util/function/rerank/huggingface_rerank_provider_test.go
+++ b/internal/util/function/rerank/huggingface_rerank_provider_test.go
@@ -1,0 +1,139 @@
+/*
+ * # Licensed to the LF AI & Data foundation under one
+ * # or more contributor license agreements. See the NOTICE file
+ * # distributed with this work for additional information
+ * # regarding copyright ownership. The ASF licenses this file
+ * # to you under the Apache License, Version 2.0 (the
+ * # "License"); you may not use this file except in compliance
+ * # with the License. You may obtain a copy of the License at
+ * #
+ * #     http://www.apache.org/licenses/LICENSE-2.0
+ * #
+ * # Unless required by applicable law or agreed to in writing, software
+ * # distributed under the License is distributed on an "AS IS" BASIS,
+ * # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * # See the License for the specific language governing permissions and
+ * # limitations under the License.
+ */
+
+package rerank
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
+	"github.com/milvus-io/milvus/internal/util/credentials"
+	"github.com/milvus-io/milvus/internal/util/function/models"
+	"github.com/milvus-io/milvus/internal/util/function/models/huggingface"
+)
+
+func (s *RerankModelSuite) TestNewHuggingFaceProvider() {
+	creds := credentials.NewCredentials(map[string]string{"mock.apikey": "mock_key"})
+	extraInfo := &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"}
+	{
+		params := []*commonpb.KeyValuePair{
+			{Key: models.CredentialParamKey, Value: "mock"},
+		}
+		_, err := newHuggingFaceProvider(params, nil, creds, extraInfo)
+		s.ErrorContains(err, "huggingface rerank model name is required")
+	}
+	{
+		params := []*commonpb.KeyValuePair{
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.ModelNameParamKey, Value: "BAAI/bge-m3"},
+			{Key: models.HuggingFaceProviderParamKey, Value: ""},
+		}
+		_, err := newHuggingFaceProvider(params, nil, creds, extraInfo)
+		s.ErrorContains(err, "hf_provider cannot be empty")
+	}
+	{
+		params := []*commonpb.KeyValuePair{
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.ModelNameParamKey, Value: "BAAI/bge-m3"},
+			{Key: models.MaxClientBatchSizeParamKey, Value: "0"},
+		}
+		_, err := newHuggingFaceProvider(params, nil, creds, extraInfo)
+		s.ErrorContains(err, "must be greater than 0")
+	}
+	{
+		params := []*commonpb.KeyValuePair{
+			{Key: models.CredentialParamKey, Value: "mock"},
+			{Key: models.ModelNameParamKey, Value: "BAAI/bge-m3"},
+		}
+		provider, err := newHuggingFaceProvider(params, nil, creds, extraInfo)
+		s.NoError(err)
+		hfProvider := provider.(*huggingFaceProvider)
+		s.Equal(huggingface.DefaultHFProvider, hfProvider.hfProvider)
+		s.Equal(32, hfProvider.MaxBatch())
+	}
+}
+
+func (s *RerankModelSuite) TestNewHuggingFaceProviderFromRegistry() {
+	params := []*commonpb.KeyValuePair{
+		{Key: providerParamName, Value: huggingFaceProviderName},
+		{Key: models.CredentialParamKey, Value: "mock"},
+		{Key: models.ModelNameParamKey, Value: "BAAI/bge-m3"},
+	}
+	provider, err := NewModelProvider(params, &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+	s.NoError(err)
+	s.IsType(&huggingFaceProvider{}, provider)
+}
+
+func (s *RerankModelSuite) TestCallHuggingFace() {
+	var count int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.Equal("/hf-inference/models/BAAI/bge-m3/pipeline/sentence-similarity", r.URL.Path)
+		s.Equal("Bearer mock_key", r.Header.Get("Authorization"))
+		var req huggingface.SentenceSimilarityRequest
+		s.NoError(json.NewDecoder(r.Body).Decode(&req))
+		s.Equal("mytest", req.Inputs.SourceSentence)
+
+		current := atomic.AddInt32(&count, 1)
+		switch current {
+		case 1:
+			s.Equal([]string{"t1", "t2"}, req.Inputs.Sentences)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[0.1,0.2]`))
+		case 2:
+			s.Equal([]string{"t3"}, req.Inputs.Sentences)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[0.3]`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	params := []*commonpb.KeyValuePair{
+		{Key: models.CredentialParamKey, Value: "mock"},
+		{Key: models.ModelNameParamKey, Value: "BAAI/bge-m3"},
+		{Key: models.MaxClientBatchSizeParamKey, Value: "2"},
+	}
+	provider, err := newHuggingFaceProvider(params, map[string]string{models.URLParamKey: ts.URL}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock_key"}), &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+	s.NoError(err)
+	scores, err := provider.Rerank(context.Background(), "mytest", []string{"t1", "t2", "t3"})
+	s.NoError(err)
+	s.Equal([]float32{0.1, 0.2, 0.3}, scores)
+	s.Equal(int32(2), atomic.LoadInt32(&count))
+}
+
+func (s *RerankModelSuite) TestCallHuggingFaceScoreCountMismatch() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[0.1]`))
+	}))
+	defer ts.Close()
+
+	params := []*commonpb.KeyValuePair{
+		{Key: models.CredentialParamKey, Value: "mock"},
+		{Key: models.ModelNameParamKey, Value: "BAAI/bge-m3"},
+	}
+	provider, err := newHuggingFaceProvider(params, map[string]string{models.URLParamKey: ts.URL}, credentials.NewCredentials(map[string]string{"mock.apikey": "mock_key"}), &models.ModelExtraInfo{ClusterID: "test-cluster", DBName: "test-db"})
+	s.NoError(err)
+	_, err = provider.Rerank(context.Background(), "mytest", []string{"t1", "t2"})
+	s.ErrorContains(err, "the number of docs and scores does not match")
+}

--- a/internal/util/function/rerank/model_function.go
+++ b/internal/util/function/rerank/model_function.go
@@ -39,6 +39,7 @@ const (
 	voyageaiProviderName    string = "voyageai"
 	aliProviderName         string = "ali"
 	zillizProviderName      string = "zilliz"
+	huggingFaceProviderName string = "huggingface"
 )
 
 func parseMaxBatch(maxBatch string) (int, error) {
@@ -92,6 +93,8 @@ func NewModelProvider(params []*commonpb.KeyValuePair, extraInfo *models.ModelEx
 			case zillizProviderName:
 				conf := paramtable.Get().FunctionCfg.ZillizProviders.GetValue()
 				return newZillizProvider(params, conf, extraInfo)
+			case huggingFaceProviderName:
+				return newHuggingFaceProvider(params, conf, credentials, extraInfo)
 			default:
 				return nil, merr.WrapErrParameterInvalidMsg("unknown rerank model provider:%s", param.Value)
 			}

--- a/pkg/util/paramtable/function_param.go
+++ b/pkg/util/paramtable/function_param.go
@@ -119,6 +119,12 @@ func (p *functionConfig) init(base *BaseTable) {
 				return "Your Gemini embedding url, Default is the official embedding url"
 			case "gemini.enable":
 				return "Whether to enable Gemini model service"
+			case "huggingface.credential":
+				return "The name in the credential configuration item"
+			case "huggingface.url":
+				return "Your Hugging Face Inference Providers router URL, default is https://router.huggingface.co"
+			case "huggingface.enable":
+				return "Whether to enable Hugging Face text embedding service"
 			default:
 				return ""
 			}
@@ -158,6 +164,12 @@ func (p *functionConfig) init(base *BaseTable) {
 				return "Your cohere rerank url, Default is the official rerank url"
 			case "cohere.enable":
 				return "Whether to enable cohere model service"
+			case "huggingface.credential":
+				return "The name in the credential configuration item"
+			case "huggingface.url":
+				return "Your Hugging Face Inference Providers router URL, default is https://router.huggingface.co"
+			case "huggingface.enable":
+				return "Whether to enable Hugging Face rerank service"
 			default:
 				return ""
 			}

--- a/pkg/util/paramtable/function_param_test.go
+++ b/pkg/util/paramtable/function_param_test.go
@@ -63,6 +63,9 @@ func TestFunctionConfig(t *testing.T) {
 		"yc.credential",
 		"yc.url",
 		"yc.enable",
+		"huggingface.credential",
+		"huggingface.url",
+		"huggingface.enable",
 	}
 	for _, key := range keys {
 		assert.True(t, cfg.TextEmbeddingProviders.GetDoc(key) != "")
@@ -83,6 +86,9 @@ func TestFunctionConfig(t *testing.T) {
 		"siliconflow.url",
 		"siliconflow.credential",
 		"siliconflow.enable",
+		"huggingface.credential",
+		"huggingface.url",
+		"huggingface.enable",
 	}
 	for _, key := range keys {
 		assert.True(t, cfg.RerankModelProviders.GetDoc(key) != "")

--- a/tests/python_client/milvus_client/test_milvus_client_search.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search.py
@@ -7522,7 +7522,7 @@ class TestMilvusClientSearchModelRerankNegative(TestMilvusClientV2Base):
         client.drop_collection(collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("invalid_provider", ["invalid_provider", "openai", "huggingface", "", None, 123])
+    @pytest.mark.parametrize("invalid_provider", ["invalid_provider", "openai", "", None, 123])
     def test_milvus_client_search_with_model_rerank_invalid_provider(self, setup_collection, invalid_provider,
                                                                      tei_reranker_endpoint):
         """

--- a/tests/python_client/milvus_client/test_milvus_client_search_reranker.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_reranker.py
@@ -4000,7 +4000,7 @@ class TestMilvusClientSearchModelRerankNegative(TestMilvusClientV2Base):
         client.drop_collection(collection_name)
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.parametrize("invalid_provider", ["invalid_provider", "openai", "huggingface", "", None, 123])
+    @pytest.mark.parametrize("invalid_provider", ["invalid_provider", "openai", "", None, 123])
     def test_milvus_client_search_with_model_rerank_invalid_provider(
         self, setup_collection, invalid_provider, tei_reranker_endpoint
     ):


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/50816

Add Hugging Face Inference Providers client support for feature extraction and sentence similarity APIs, and wire it into text embedding and rerank model providers.

The new provider supports:
- text embedding via feature-extraction
- rerank scoring via sentence-similarity
- Hugging Face router provider selection with hf_provider
- MILVUS_HUGGINGFACE_API_KEY credential fallback
- provider config entries for text embedding and rerank

Also add focused tests for the Hugging Face client, rerank provider, and paramtable provider docs.