### PR TITLE
fix: align load config compliance with replica override

### DIFF
--- a/internal/coordinator/restful_replica.go
+++ b/internal/coordinator/restful_replica.go
@@ -70,10 +70,12 @@ func (s *mixCoordImpl) HandleReplicaLoadConfigCompliance(w http.ResponseWriter, 
 	// Get cluster-level configuration
 	clusterReplicaNum := Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.GetAsInt()
 	clusterResourceGroups := Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.GetAsStrings()
+	forceOverrideUserReplicaMode := Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.GetAsBool()
 
 	logger.Info(ctx, "checking replica load config compliance",
 		mlog.Int("clusterReplicaNum", clusterReplicaNum),
-		mlog.Strings("clusterResourceGroups", clusterResourceGroups))
+		mlog.Strings("clusterResourceGroups", clusterResourceGroups),
+		mlog.Bool("forceOverrideUserReplicaMode", forceOverrideUserReplicaMode))
 
 	// Use ShowLoadCollections to get all loaded collections
 	showResp, err := s.ShowLoadCollections(ctx, &querypb.ShowCollectionsRequest{
@@ -87,6 +89,11 @@ func (s *mixCoordImpl) HandleReplicaLoadConfigCompliance(w http.ResponseWriter, 
 
 	// Check each collection
 	for _, collectionID := range showResp.GetCollectionIDs() {
+		if !forceOverrideUserReplicaMode && s.queryCoordServer.IsCollectionUserSpecifiedReplicaMode(ctx, collectionID) {
+			logger.Info(ctx, "collection is user specified replica mode, skip compliance check", mlog.FieldCollectionID(collectionID))
+			continue
+		}
+
 		// Get internal replicas from QueryCoord meta which contains StreamingResourceGroup field
 		internalReplicas := s.queryCoordServer.GetInternalReplicasByCollection(ctx, collectionID)
 

--- a/internal/coordinator/restful_replica.go
+++ b/internal/coordinator/restful_replica.go
@@ -89,17 +89,14 @@ func (s *mixCoordImpl) HandleReplicaLoadConfigCompliance(w http.ResponseWriter, 
 
 	// Check each collection
 	for _, collectionID := range showResp.GetCollectionIDs() {
-		if !forceOverrideUserReplicaMode && s.queryCoordServer.IsCollectionUserSpecifiedReplicaMode(ctx, collectionID) {
-			logger.Info(ctx, "collection is user specified replica mode, skip compliance check", mlog.FieldCollectionID(collectionID))
-			continue
-		}
+		skipClusterLevelConfigChecks := !forceOverrideUserReplicaMode && s.queryCoordServer.IsCollectionUserSpecifiedReplicaMode(ctx, collectionID)
 
 		// Get internal replicas from QueryCoord meta which contains StreamingResourceGroup field
 		internalReplicas := s.queryCoordServer.GetInternalReplicasByCollection(ctx, collectionID)
 
 		// Check replica count matches exactly — the replica meta must already reflect
 		// the configured count before we inspect serviceability/leaks.
-		if clusterReplicaNum > 0 && len(internalReplicas) != clusterReplicaNum {
+		if !skipClusterLevelConfigChecks && clusterReplicaNum > 0 && len(internalReplicas) != clusterReplicaNum {
 			reason := fmt.Sprintf("collection %d: replica count mismatch (expected %d, actual %d)",
 				collectionID, clusterReplicaNum, len(internalReplicas))
 			logger.Info(ctx, "collection replica count does not match cluster requirement", mlog.String("reason", reason))
@@ -107,7 +104,7 @@ func (s *mixCoordImpl) HandleReplicaLoadConfigCompliance(w http.ResponseWriter, 
 			return
 		}
 
-		if len(clusterResourceGroups) > 0 {
+		if !skipClusterLevelConfigChecks && len(clusterResourceGroups) > 0 {
 			// Check resource groups - collect actual RGs from replicas
 			actualRGs := []string{}
 			for _, replica := range internalReplicas {

--- a/internal/coordinator/restful_replica_test.go
+++ b/internal/coordinator/restful_replica_test.go
@@ -148,7 +148,7 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		assert.Contains(t, resp.Reason, "actual 1")
 	})
 
-	t.Run("user-specified replica mode skips cluster-level replica compliance", func(t *testing.T) {
+	t.Run("user-specified replica mode skips only cluster-level replica compliance", func(t *testing.T) {
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "2")
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key, "false")
@@ -182,6 +182,12 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		mocker3 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
 		defer mocker3.UnPatch()
 
+		mockerSvc := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).Return(nil).Build()
+		defer mockerSvc.UnPatch()
+
+		mockerLeak := mockey.Mock((*querycoordv2.Server).GetLeakedResourcesByCollection).Return(0, 0).Build()
+		defer mockerLeak.UnPatch()
+
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
 		w := httptest.NewRecorder()
 
@@ -193,6 +199,106 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, LoadConfigComplianceStateReady, resp.State)
 		assert.Empty(t, resp.Reason)
+	})
+
+	t.Run("user-specified replica mode still checks query visibility", func(t *testing.T) {
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "2")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key, "false")
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key)
+		defer registerTestBalancer(t, nil)()
+
+		replica := meta.NewReplica(&querypb.Replica{
+			ID:            1,
+			CollectionID:  100,
+			ResourceGroup: "rg1",
+		}, typeutil.NewUniqueSet())
+		mutableReplica := replica.CopyForWrite()
+		mutableReplica.SetQueryInvisible(true)
+		replicas := []*meta.Replica{mutableReplica.IntoReplica()}
+
+		coord := &mixCoordImpl{
+			queryCoordServer: &querycoordv2.Server{},
+		}
+
+		mocker1 := mockey.Mock((*mixCoordImpl).ShowLoadCollections).Return(&querypb.ShowCollectionsResponse{
+			Status:              &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+			CollectionIDs:       []int64{100},
+			InMemoryPercentages: []int64{100},
+		}, nil).Build()
+		defer mocker1.UnPatch()
+
+		mocker2 := mockey.Mock((*querycoordv2.Server).IsCollectionUserSpecifiedReplicaMode).Return(true).Build()
+		defer mocker2.UnPatch()
+
+		mocker3 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
+		defer mocker3.UnPatch()
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
+		w := httptest.NewRecorder()
+
+		coord.HandleReplicaLoadConfigCompliance(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp LoadConfigComplianceResponse
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, LoadConfigComplianceStateNotReady, resp.State)
+		assert.Contains(t, resp.Reason, "not query visible")
+	})
+
+	t.Run("user-specified replica mode still checks leaked resources", func(t *testing.T) {
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "2")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key, "false")
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key)
+		defer registerTestBalancer(t, nil)()
+
+		replicas := []*meta.Replica{
+			meta.NewReplica(&querypb.Replica{
+				ID:            1,
+				CollectionID:  100,
+				ResourceGroup: "rg1",
+			}, typeutil.NewUniqueSet()),
+		}
+
+		coord := &mixCoordImpl{
+			queryCoordServer: &querycoordv2.Server{},
+		}
+
+		mocker1 := mockey.Mock((*mixCoordImpl).ShowLoadCollections).Return(&querypb.ShowCollectionsResponse{
+			Status:              &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+			CollectionIDs:       []int64{100},
+			InMemoryPercentages: []int64{100},
+		}, nil).Build()
+		defer mocker1.UnPatch()
+
+		mocker2 := mockey.Mock((*querycoordv2.Server).IsCollectionUserSpecifiedReplicaMode).Return(true).Build()
+		defer mocker2.UnPatch()
+
+		mocker3 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
+		defer mocker3.UnPatch()
+
+		mockerSvc := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).Return(nil).Build()
+		defer mockerSvc.UnPatch()
+
+		mockerLeak := mockey.Mock((*querycoordv2.Server).GetLeakedResourcesByCollection).Return(3, 0).Build()
+		defer mockerLeak.UnPatch()
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
+		w := httptest.NewRecorder()
+
+		coord.HandleReplicaLoadConfigCompliance(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp LoadConfigComplianceResponse
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, LoadConfigComplianceStateNotReady, resp.State)
+		assert.Contains(t, resp.Reason, "not fully released")
+		assert.Contains(t, resp.Reason, "leaked segments=3")
 	})
 
 	t.Run("force override checks user-specified replica mode collection", func(t *testing.T) {

--- a/internal/coordinator/restful_replica_test.go
+++ b/internal/coordinator/restful_replica_test.go
@@ -99,8 +99,10 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		// Set cluster config requiring 2 replicas
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "2")
 		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key, "false")
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
 		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key)
 		defer registerTestBalancer(t, nil)()
 
 		replicas := []*meta.Replica{
@@ -130,6 +132,102 @@ func TestHandleReplicaLoadConfigCompliance(t *testing.T) {
 		// Mock CheckAllReplicasServiceable to allow flow to reach later checks
 		mockerSvc := mockey.Mock((*querycoordv2.Server).CheckAllReplicasServiceable).Return(nil).Build()
 		defer mockerSvc.UnPatch()
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
+		w := httptest.NewRecorder()
+
+		coord.HandleReplicaLoadConfigCompliance(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp LoadConfigComplianceResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Equal(t, LoadConfigComplianceStateNotReady, resp.State)
+		assert.Contains(t, resp.Reason, "replica count mismatch")
+		assert.Contains(t, resp.Reason, "expected 2")
+		assert.Contains(t, resp.Reason, "actual 1")
+	})
+
+	t.Run("user-specified replica mode skips cluster-level replica compliance", func(t *testing.T) {
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "2")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key, "false")
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key)
+		defer registerTestBalancer(t, nil)()
+
+		replicas := []*meta.Replica{
+			meta.NewReplica(&querypb.Replica{
+				ID:            1,
+				CollectionID:  100,
+				ResourceGroup: "rg1",
+			}, typeutil.NewUniqueSet()),
+		}
+
+		coord := &mixCoordImpl{
+			queryCoordServer: &querycoordv2.Server{},
+		}
+
+		mocker1 := mockey.Mock((*mixCoordImpl).ShowLoadCollections).Return(&querypb.ShowCollectionsResponse{
+			Status:              &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+			CollectionIDs:       []int64{100},
+			InMemoryPercentages: []int64{100},
+		}, nil).Build()
+		defer mocker1.UnPatch()
+
+		mocker2 := mockey.Mock((*querycoordv2.Server).IsCollectionUserSpecifiedReplicaMode).Return(true).Build()
+		defer mocker2.UnPatch()
+
+		mocker3 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
+		defer mocker3.UnPatch()
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
+		w := httptest.NewRecorder()
+
+		coord.HandleReplicaLoadConfigCompliance(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp LoadConfigComplianceResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Equal(t, LoadConfigComplianceStateReady, resp.State)
+		assert.Empty(t, resp.Reason)
+	})
+
+	t.Run("force override checks user-specified replica mode collection", func(t *testing.T) {
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "2")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, "")
+		paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key, "true")
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+		defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key)
+		defer registerTestBalancer(t, nil)()
+
+		replicas := []*meta.Replica{
+			meta.NewReplica(&querypb.Replica{
+				ID:            1,
+				CollectionID:  100,
+				ResourceGroup: "rg1",
+			}, typeutil.NewUniqueSet()),
+		}
+
+		coord := &mixCoordImpl{
+			queryCoordServer: &querycoordv2.Server{},
+		}
+
+		mocker1 := mockey.Mock((*mixCoordImpl).ShowLoadCollections).Return(&querypb.ShowCollectionsResponse{
+			Status:              &commonpb.Status{ErrorCode: commonpb.ErrorCode_Success},
+			CollectionIDs:       []int64{100},
+			InMemoryPercentages: []int64{100},
+		}, nil).Build()
+		defer mocker1.UnPatch()
+
+		mocker2 := mockey.Mock((*querycoordv2.Server).IsCollectionUserSpecifiedReplicaMode).Return(true).Build()
+		defer mocker2.UnPatch()
+
+		mocker3 := mockey.Mock((*querycoordv2.Server).GetInternalReplicasByCollection).Return(replicas).Build()
+		defer mocker3.UnPatch()
 
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/replicas/compliance", nil)
 		w := httptest.NewRecorder()

--- a/internal/querycoordv2/ddl_callbacks_alter_load_info_load_collection.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_load_info_load_collection.go
@@ -25,6 +25,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/utils"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 // broadcastAlterLoadConfigCollectionV2ForLoadCollection is called when the load collection request is received.
@@ -45,9 +46,12 @@ func (s *Server) broadcastAlterLoadConfigCollectionV2ForLoadCollection(ctx conte
 	if err != nil {
 		return err
 	}
-	// if user specified the replica number in load request, load config changes won't be apply to the collection automatically
-	userSpecifiedReplicaMode := req.GetReplicaNumber() > 0
-	replicaNumber, resourceGroups, err := s.getDefaultResourceGroupsAndReplicaNumber(ctx, req.GetReplicaNumber(), req.GetResourceGroups(), req.GetCollectionID())
+	replicaNumber, resourceGroups, userSpecifiedReplicaMode, err := s.getLoadReplicaConfigForRequest(
+		ctx,
+		req.GetReplicaNumber(),
+		req.GetResourceGroups(),
+		req.GetCollectionID(),
+	)
 	if err != nil {
 		return err
 	}
@@ -83,6 +87,43 @@ func (s *Server) broadcastAlterLoadConfigCollectionV2ForLoadCollection(ctx conte
 	}
 	_, err = broadcaster.Broadcast(ctx, msg)
 	return err
+}
+
+func (s *Server) getLoadReplicaConfigForRequest(ctx context.Context, replicaNumber int32, resourceGroups []string, collectionID int64) (int32, []string, bool, error) {
+	// If force override is enabled with a complete cluster-level load config,
+	// new load requests are interpreted as cluster-managed even when the request
+	// carries explicit replica/RG parameters.
+	if overrideReplicaNumber, overrideResourceGroups, ok := getClusterLevelLoadConfigForForceOverride(); ok {
+		mlog.Info(ctx,
+			"force override user-specified replica mode for load request",
+			mlog.Int64("collectionID", collectionID),
+			mlog.Int32("replicaNumber", overrideReplicaNumber),
+			mlog.Strings("resourceGroups", overrideResourceGroups))
+		return overrideReplicaNumber, overrideResourceGroups, false, nil
+	}
+
+	// If user specified the replica number in load request, load config changes
+	// won't be applied to the collection automatically.
+	userSpecifiedReplicaMode := replicaNumber > 0
+	replicaNumber, resourceGroups, err := s.getDefaultResourceGroupsAndReplicaNumber(ctx, replicaNumber, resourceGroups, collectionID)
+	return replicaNumber, resourceGroups, userSpecifiedReplicaMode, err
+}
+
+func getClusterLevelLoadConfigForForceOverride() (int32, []string, bool) {
+	queryCoordCfg := paramtable.Get().QueryCoordCfg
+	if !queryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.GetAsBool() {
+		return 0, nil, false
+	}
+
+	replicaNumber := queryCoordCfg.ClusterLevelLoadReplicaNumber.GetAsInt32()
+	resourceGroups := queryCoordCfg.ClusterLevelLoadResourceGroups.GetAsStrings()
+	if replicaNumber <= 0 || len(resourceGroups) == 0 {
+		return 0, nil, false
+	}
+	if len(resourceGroups) != 1 && len(resourceGroups) != int(replicaNumber) {
+		return 0, nil, false
+	}
+	return replicaNumber, resourceGroups, true
 }
 
 // getDefaultResourceGroupsAndReplicaNumber gets the default resource groups and replica number for the collection.

--- a/internal/querycoordv2/ddl_callbacks_alter_load_info_load_collection.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_load_info_load_collection.go
@@ -110,7 +110,7 @@ func (s *Server) getLoadReplicaConfigForRequest(ctx context.Context, replicaNumb
 }
 
 func getClusterLevelLoadConfigForForceOverride() (int32, []string, bool) {
-	queryCoordCfg := paramtable.Get().QueryCoordCfg
+	queryCoordCfg := &paramtable.Get().QueryCoordCfg
 	if !queryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.GetAsBool() {
 		return 0, nil, false
 	}

--- a/internal/querycoordv2/ddl_callbacks_alter_load_info_load_partitions.go
+++ b/internal/querycoordv2/ddl_callbacks_alter_load_info_load_partitions.go
@@ -39,8 +39,12 @@ func (s *Server) broadcastAlterLoadConfigCollectionV2ForLoadPartitions(ctx conte
 		return err
 	}
 
-	userSpecifiedReplicaMode := req.GetReplicaNumber() > 0
-	replicaNumber, resourceGroups, err := s.getDefaultResourceGroupsAndReplicaNumber(ctx, req.GetReplicaNumber(), req.GetResourceGroups(), req.GetCollectionID())
+	replicaNumber, resourceGroups, userSpecifiedReplicaMode, err := s.getLoadReplicaConfigForRequest(
+		ctx,
+		req.GetReplicaNumber(),
+		req.GetResourceGroups(),
+		req.GetCollectionID(),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/querycoordv2/ddl_callbacks_load_info_test.go
+++ b/internal/querycoordv2/ddl_callbacks_load_info_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus/internal/querycoordv2/meta"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 func (suite *ServiceSuite) TestDDLCallbacksLoadCollectionInfo() {
@@ -768,6 +769,37 @@ func (suite *ServiceSuite) TestDDLCallbacksLoadCollectionWithUserSpecifiedReplic
 
 		suite.targetMgr.UpdateCollectionCurrentTarget(ctx, collection)
 		suite.assertCollectionLoaded(collection)
+	}
+}
+
+func (suite *ServiceSuite) TestDDLCallbacksLoadCollectionForceOverrideUserSpecifiedReplicaMode() {
+	ctx := context.Background()
+	suite.expectGetRecoverInfoForAllCollections()
+
+	paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key, "1")
+	paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, meta.DefaultResourceGroupName)
+	paramtable.Get().Save(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key, "true")
+	defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadReplicaNumber.Key)
+	defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadResourceGroups.Key)
+	defer paramtable.Get().Reset(Params.QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key)
+
+	for _, collection := range suite.collections {
+		if suite.loadTypes[collection] != querypb.LoadType_LoadCollection {
+			continue
+		}
+
+		req := &querypb.LoadCollectionRequest{
+			CollectionID:   collection,
+			ReplicaNumber:  2,
+			ResourceGroups: []string{meta.DefaultResourceGroupName},
+		}
+		resp, err := suite.server.LoadCollection(ctx, req)
+		suite.Require().NoError(merr.CheckRPCCall(resp, err))
+
+		loadedCollection := suite.meta.GetCollection(ctx, collection)
+		suite.Require().NotNil(loadedCollection)
+		suite.False(loadedCollection.GetUserSpecifiedReplicaMode())
+		suite.EqualValues(1, suite.meta.GetReplicaNumber(ctx, collection))
 	}
 }
 

--- a/internal/querycoordv2/load_config_watcher.go
+++ b/internal/querycoordv2/load_config_watcher.go
@@ -54,8 +54,9 @@ type LoadConfigWatcher struct {
 	notifier  *syncutil.AsyncTaskNotifier[struct{}]
 	s         *Server
 
-	previousReplicaNum int32
-	previousRGs        []string
+	previousReplicaNum                   int32
+	previousRGs                          []string
+	previousForceOverrideUserReplicaMode bool
 }
 
 // Trigger triggers a load config change.
@@ -111,6 +112,7 @@ func (w *LoadConfigWatcher) applyLoadConfigChanges() error {
 
 	newReplicaNum := paramtable.Get().QueryCoordCfg.ClusterLevelLoadReplicaNumber.GetAsInt32()
 	newRGs := paramtable.Get().QueryCoordCfg.ClusterLevelLoadResourceGroups.GetAsStrings()
+	forceOverrideUserReplicaMode := paramtable.Get().QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.GetAsBool()
 
 	if newReplicaNum == 0 && len(newRGs) == 0 {
 		// default cluster level load config, nothing to do for it.
@@ -131,7 +133,8 @@ func (w *LoadConfigWatcher) applyLoadConfigChanges() error {
 
 	left, right := lo.Difference(w.previousRGs, newRGs)
 	rgChanged := len(left) > 0 || len(right) > 0
-	if w.previousReplicaNum == newReplicaNum && !rgChanged {
+	forceOverrideChanged := w.previousForceOverrideUserReplicaMode != forceOverrideUserReplicaMode
+	if w.previousReplicaNum == newReplicaNum && !rgChanged && !forceOverrideChanged {
 		w.Logger().Info(context.TODO(),
 			"no need to update load config, skip it", mlog.Int32("replica_num", newReplicaNum), mlog.Strings("resource_groups", newRGs))
 		return nil
@@ -141,7 +144,7 @@ func (w *LoadConfigWatcher) applyLoadConfigChanges() error {
 	collectionIDs := w.s.meta.GetAll(w.notifier.Context())
 	collectionIDs = lo.Filter(collectionIDs, func(collectionID int64, _ int) bool {
 		collection := w.s.meta.GetCollection(w.notifier.Context(), collectionID)
-		if collection.UserSpecifiedReplicaMode {
+		if collection.UserSpecifiedReplicaMode && !forceOverrideUserReplicaMode {
 			w.Logger().Info(context.TODO(), "collection is user specified replica mode, skip update load config", mlog.FieldCollectionID(collectionID))
 			return false
 		}
@@ -166,6 +169,7 @@ func (w *LoadConfigWatcher) applyLoadConfigChanges() error {
 		mlog.Strings("resourceGroups", newRGs))
 	w.previousReplicaNum = newReplicaNum
 	w.previousRGs = newRGs
+	w.previousForceOverrideUserReplicaMode = forceOverrideUserReplicaMode
 	return nil
 }
 

--- a/internal/querycoordv2/load_config_watcher.go
+++ b/internal/querycoordv2/load_config_watcher.go
@@ -144,6 +144,9 @@ func (w *LoadConfigWatcher) applyLoadConfigChanges() error {
 	collectionIDs := w.s.meta.GetAll(w.notifier.Context())
 	collectionIDs = lo.Filter(collectionIDs, func(collectionID int64, _ int) bool {
 		collection := w.s.meta.GetCollection(w.notifier.Context(), collectionID)
+		if collection == nil {
+			return false
+		}
 		if collection.UserSpecifiedReplicaMode && !forceOverrideUserReplicaMode {
 			w.Logger().Info(context.TODO(), "collection is user specified replica mode, skip update load config", mlog.FieldCollectionID(collectionID))
 			return false

--- a/internal/querycoordv2/server.go
+++ b/internal/querycoordv2/server.go
@@ -871,12 +871,25 @@ func (s *Server) watchLoadConfigChanges() {
 
 	rgHandler := config.NewHandler("watchResourceGroupChanges", func(e *config.Event) { w.Trigger() })
 	paramtable.Get().Watch(paramtable.Get().QueryCoordCfg.ClusterLevelLoadResourceGroups.Key, rgHandler)
+
+	forceOverrideHandler := config.NewHandler("watchForceOverrideUserReplicaModeChanges", func(e *config.Event) { w.Trigger() })
+	paramtable.Get().Watch(paramtable.Get().QueryCoordCfg.ClusterLevelLoadForceOverrideUserReplicaMode.Key, forceOverrideHandler)
 }
 
 // GetInternalReplicasByCollection returns replicas for a collection from internal meta.
 // This method provides access to internal replica information including resource groups.
 func (s *Server) GetInternalReplicasByCollection(ctx context.Context, collectionID int64) []*meta.Replica {
 	return s.meta.GetByCollection(ctx, collectionID)
+}
+
+// IsCollectionUserSpecifiedReplicaMode returns whether the collection load config
+// was created from a request with an explicit replica number.
+func (s *Server) IsCollectionUserSpecifiedReplicaMode(ctx context.Context, collectionID int64) bool {
+	if s.meta == nil {
+		return false
+	}
+	collection := s.meta.GetCollection(ctx, collectionID)
+	return collection != nil && collection.UserSpecifiedReplicaMode
 }
 
 // CheckAllReplicasServiceable returns an error if any replica has a non-serviceable

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -519,6 +519,49 @@ func TestApplyLoadConfigChangesForceOverrideUserSpecifiedReplicaMode(t *testing.
 	})
 }
 
+func TestApplyLoadConfigChangesSkipsReleasedCollection(t *testing.T) {
+	mockey.PatchConvey("TestApplyLoadConfigChangesSkipsReleasedCollection", t, func() {
+		ctx := context.Background()
+
+		testServer := &Server{}
+		testServer.meta = &meta.Meta{}
+		testServer.ctx = ctx
+
+		mockCollection := &meta.Collection{
+			CollectionLoadInfo: &querypb.CollectionLoadInfo{
+				CollectionID:             1001,
+				UserSpecifiedReplicaMode: false,
+			},
+		}
+
+		mockey.Mock((*meta.CollectionManager).GetAll).Return([]int64{1001, 1002}).Build()
+		mockey.Mock((*meta.CollectionManager).GetCollection).To(func(m *meta.CollectionManager, ctx context.Context, collectionID int64) *meta.Collection {
+			if collectionID == 1001 {
+				return mockCollection
+			}
+			return nil
+		}).Build()
+		mockey.Mock((*paramtable.ParamItem).GetAsInt32).Return(int32(2)).Build()
+		mockey.Mock((*paramtable.ParamItem).GetAsStrings).Return([]string{"default", "rg1"}).Build()
+		mockey.Mock((*paramtable.ParamItem).GetAsBool).Return(false).Build()
+
+		var capturedCollectionIDs []int64
+		mockey.Mock((*Server).updateLoadConfig).To(func(s *Server, ctx context.Context, collectionIDs []int64, newReplicaNum int32, newRGs []string, needWaitRGReady ...bool) error {
+			capturedCollectionIDs = collectionIDs
+			return nil
+		}).Build()
+
+		watcher := &LoadConfigWatcher{
+			s:         testServer,
+			notifier:  syncutil.NewAsyncTaskNotifier[struct{}](),
+			triggerCh: make(chan struct{}, 10),
+		}
+		watcher.applyLoadConfigChanges()
+
+		assert.Equal(t, []int64{1001}, capturedCollectionIDs)
+	})
+}
+
 func TestApplyLoadConfigChangesWhenForceOverrideConfigChanges(t *testing.T) {
 	mockey.PatchConvey("TestApplyLoadConfigChangesWhenForceOverrideConfigChanges", t, func() {
 		ctx := context.Background()

--- a/internal/querycoordv2/server_test.go
+++ b/internal/querycoordv2/server_test.go
@@ -428,6 +428,9 @@ func TestApplyLoadConfigChanges(t *testing.T) {
 		// Mock paramtable.ParamItem.GetAsStrings() for ClusterLevelLoadResourceGroups
 		mockey.Mock((*paramtable.ParamItem).GetAsStrings).Return([]string{"default", "rg1"}).Build()
 
+		// Mock force override config disabled by default.
+		mockey.Mock((*paramtable.ParamItem).GetAsBool).Return(false).Build()
+
 		// Mock UpdateLoadConfig to capture the call
 		var updateLoadConfigCalled bool
 		var capturedCollectionIDs []int64
@@ -461,6 +464,100 @@ func TestApplyLoadConfigChanges(t *testing.T) {
 		watcher.Trigger()
 		time.Sleep(1 * time.Second)
 		watcher.Close()
+	})
+}
+
+func TestApplyLoadConfigChangesForceOverrideUserSpecifiedReplicaMode(t *testing.T) {
+	mockey.PatchConvey("TestApplyLoadConfigChangesForceOverrideUserSpecifiedReplicaMode", t, func() {
+		ctx := context.Background()
+
+		testServer := &Server{}
+		testServer.meta = &meta.Meta{}
+		testServer.ctx = ctx
+
+		mockCollection1 := &meta.Collection{
+			CollectionLoadInfo: &querypb.CollectionLoadInfo{
+				CollectionID:             1001,
+				UserSpecifiedReplicaMode: false,
+			},
+		}
+		mockCollection2 := &meta.Collection{
+			CollectionLoadInfo: &querypb.CollectionLoadInfo{
+				CollectionID:             1002,
+				UserSpecifiedReplicaMode: true,
+			},
+		}
+
+		mockey.Mock((*meta.CollectionManager).GetAll).Return([]int64{1001, 1002}).Build()
+		mockey.Mock((*meta.CollectionManager).GetCollection).To(func(m *meta.CollectionManager, ctx context.Context, collectionID int64) *meta.Collection {
+			switch collectionID {
+			case 1001:
+				return mockCollection1
+			case 1002:
+				return mockCollection2
+			}
+			return nil
+		}).Build()
+		mockey.Mock((*paramtable.ParamItem).GetAsInt32).Return(int32(2)).Build()
+		mockey.Mock((*paramtable.ParamItem).GetAsStrings).Return([]string{"default", "rg1"}).Build()
+		mockey.Mock((*paramtable.ParamItem).GetAsBool).Return(true).Build()
+
+		var capturedCollectionIDs []int64
+		mockey.Mock((*Server).updateLoadConfig).To(func(s *Server, ctx context.Context, collectionIDs []int64, newReplicaNum int32, newRGs []string, needWaitRGReady ...bool) error {
+			capturedCollectionIDs = collectionIDs
+			return nil
+		}).Build()
+
+		watcher := &LoadConfigWatcher{
+			s:         testServer,
+			notifier:  syncutil.NewAsyncTaskNotifier[struct{}](),
+			triggerCh: make(chan struct{}, 10),
+		}
+		watcher.applyLoadConfigChanges()
+
+		assert.Equal(t, []int64{1001, 1002}, capturedCollectionIDs, "Force override should include user-specified replica mode collections")
+	})
+}
+
+func TestApplyLoadConfigChangesWhenForceOverrideConfigChanges(t *testing.T) {
+	mockey.PatchConvey("TestApplyLoadConfigChangesWhenForceOverrideConfigChanges", t, func() {
+		ctx := context.Background()
+
+		testServer := &Server{}
+		testServer.meta = &meta.Meta{}
+		testServer.ctx = ctx
+
+		mockCollection := &meta.Collection{
+			CollectionLoadInfo: &querypb.CollectionLoadInfo{
+				CollectionID:             1002,
+				UserSpecifiedReplicaMode: true,
+			},
+		}
+
+		mockey.Mock((*meta.CollectionManager).GetAll).Return([]int64{1002}).Build()
+		mockey.Mock((*meta.CollectionManager).GetCollection).Return(mockCollection).Build()
+		mockey.Mock((*paramtable.ParamItem).GetAsInt32).Return(int32(2)).Build()
+		mockey.Mock((*paramtable.ParamItem).GetAsStrings).Return([]string{"default", "rg1"}).Build()
+		mockey.Mock((*paramtable.ParamItem).GetAsBool).Return(true).Build()
+
+		var updateLoadConfigCalled bool
+		mockey.Mock((*Server).updateLoadConfig).To(func(s *Server, ctx context.Context, collectionIDs []int64, newReplicaNum int32, newRGs []string, needWaitRGReady ...bool) error {
+			updateLoadConfigCalled = true
+			assert.Equal(t, []int64{1002}, collectionIDs)
+			return nil
+		}).Build()
+
+		watcher := &LoadConfigWatcher{
+			s:                                    testServer,
+			notifier:                             syncutil.NewAsyncTaskNotifier[struct{}](),
+			triggerCh:                            make(chan struct{}, 10),
+			previousReplicaNum:                   2,
+			previousRGs:                          []string{"default", "rg1"},
+			previousForceOverrideUserReplicaMode: false,
+		}
+		watcher.applyLoadConfigChanges()
+
+		assert.True(t, updateLoadConfigCalled, "force override config change should trigger load config update even when replica/RG config is unchanged")
 	})
 }
 

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2795,13 +2795,14 @@ type queryCoordConfig struct {
 	StoppingBalanceAssignPolicy    ParamItem `refreshable:"true"`
 	ChannelExclusiveNodeFactor     ParamItem `refreshable:"true"`
 
-	CollectionObserverInterval         ParamItem `refreshable:"false"`
-	CollectionBalanceSegmentBatchSize  ParamItem `refreshable:"true"`
-	CollectionBalanceChannelBatchSize  ParamItem `refreshable:"true"`
-	UpdateCollectionLoadStatusInterval ParamItem `refreshable:"false"`
-	ClusterLevelLoadReplicaNumber      ParamItem `refreshable:"true"`
-	ClusterLevelLoadResourceGroups     ParamItem `refreshable:"true"`
-	ClusterLevelLoadWaitRGReadyTimeout ParamItem `refreshable:"true"`
+	CollectionObserverInterval                   ParamItem `refreshable:"false"`
+	CollectionBalanceSegmentBatchSize            ParamItem `refreshable:"true"`
+	CollectionBalanceChannelBatchSize            ParamItem `refreshable:"true"`
+	UpdateCollectionLoadStatusInterval           ParamItem `refreshable:"false"`
+	ClusterLevelLoadReplicaNumber                ParamItem `refreshable:"true"`
+	ClusterLevelLoadResourceGroups               ParamItem `refreshable:"true"`
+	ClusterLevelLoadForceOverrideUserReplicaMode ParamItem `refreshable:"true"`
+	ClusterLevelLoadWaitRGReadyTimeout           ParamItem `refreshable:"true"`
 
 	// balance batch size in one trigger
 	BalanceSegmentBatchSize            ParamItem `refreshable:"true"`
@@ -3414,6 +3415,15 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Export:       false,
 	}
 	p.ClusterLevelLoadResourceGroups.Init(base.mgr)
+
+	p.ClusterLevelLoadForceOverrideUserReplicaMode = ParamItem{
+		Key:          "queryCoord.clusterLevelLoadForceOverrideUserReplicaMode",
+		Version:      "2.6.14",
+		DefaultValue: "false",
+		Doc:          "when true, cluster-level load config overrides collections loaded with user-specified replica number",
+		Export:       false,
+	}
+	p.ClusterLevelLoadForceOverrideUserReplicaMode.Init(base.mgr)
 
 	p.ClusterLevelLoadWaitRGReadyTimeout = ParamItem{
 		Key:          "queryCoord.clusterLevelLoadWaitRGReadyTimeout",

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3420,7 +3420,7 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Key:          "queryCoord.clusterLevelLoadForceOverrideUserReplicaMode",
 		Version:      "2.6.14",
 		DefaultValue: "false",
-		Doc:          "when true, cluster-level load config overrides collections loaded with user-specified replica number. This is a one-way takeover: once a collection is updated, it is converted to cluster-level managed mode and turning this back off will not restore the previous user-specified replica mode.",
+		Doc:          "when true and cluster-level load replica/RG config is complete, new load requests use the cluster-level load config even if users specify replica number or resource groups. Existing user-specified collections are taken over when they need a load-config update; collections already matching the cluster-level config may not be rewritten immediately, so their user-specified marker can remain until a later update. This is a one-way takeover: once a collection is updated, it is converted to cluster-level managed mode and turning this back off will not restore the previous user-specified replica mode.",
 		Export:       false,
 	}
 	p.ClusterLevelLoadForceOverrideUserReplicaMode.Init(base.mgr)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3420,7 +3420,7 @@ If this parameter is set false, Milvus simply searches the growing segments with
 		Key:          "queryCoord.clusterLevelLoadForceOverrideUserReplicaMode",
 		Version:      "2.6.14",
 		DefaultValue: "false",
-		Doc:          "when true, cluster-level load config overrides collections loaded with user-specified replica number",
+		Doc:          "when true, cluster-level load config overrides collections loaded with user-specified replica number. This is a one-way takeover: once a collection is updated, it is converted to cluster-level managed mode and turning this back off will not restore the previous user-specified replica mode.",
 		Export:       false,
 	}
 	p.ClusterLevelLoadForceOverrideUserReplicaMode.Init(base.mgr)

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -462,6 +462,7 @@ func TestComponentParam(t *testing.T) {
 
 		assert.Equal(t, 0, Params.ClusterLevelLoadReplicaNumber.GetAsInt())
 		assert.Len(t, Params.ClusterLevelLoadResourceGroups.GetAsStrings(), 0)
+		assert.False(t, Params.ClusterLevelLoadForceOverrideUserReplicaMode.GetAsBool())
 
 		assert.Equal(t, 10, Params.CollectionChannelCountFactor.GetAsInt())
 		assert.Equal(t, 3000, Params.AutoBalanceInterval.GetAsInt())


### PR DESCRIPTION
issue: #50804

- load config compliance: skip user-specified replica mode collections unless force override is enabled
- load config watcher: add a force-override config that includes user-specified collections and reacts to config changes
- querycoord config: add a refreshable force-override switch for cluster-level load config