### PR TITLE
feat: add HDFS storage backend as ChunkManager implementation

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -90,6 +90,16 @@ localStorage:
   # It is recommended to change this parameter before starting Milvus for the first time.
   path: /var/lib/milvus/data/
 
+# Configuration for HDFS storage backend.
+# Set common.storageType to "hdfs" to activate this backend.
+hdfs:
+  # Address of the HDFS NameNode in host:port format.
+  address: localhost:9000
+  # HDFS user used for authentication (simple auth). Maps to HADOOP_USER_NAME.
+  user: hdfs
+  # Root path inside HDFS where Milvus will store all its data.
+  rootPath: milvus
+
 # Related configuration of MinIO/S3/GCS or any other service supports S3 API, which is responsible for data persistence for Milvus.
 # We refer to the storage service as MinIO/S3 in the following description for simplicity.
 minio:

--- a/docs/design-docs/design_docs/20260626-hdfs-storage-backend.md
+++ b/docs/design-docs/design_docs/20260626-hdfs-storage-backend.md
@@ -1,0 +1,181 @@
+# HDFS Storage Backend Design Document
+
+Current state: "Proposed"
+
+ISSUE: https://github.com/milvus-io/milvus/issues/2745
+
+Keywords: storage, HDFS, Hadoop, ChunkManager, object storage
+
+## 1. Overview
+
+### 1.1 Background
+
+Milvus currently supports two storage backends for persistent data:
+
+- **Remote** (MinIO / S3 / GCS / Azure Blob) — the default for production deployments.
+- **Local** — for embedded or development use only.
+
+Many enterprise users run Hadoop-based data infrastructure where HDFS is the authoritative storage layer. Their existing pipelines (Spark, Hive, Flink) read and write directly to HDFS. Forcing these users to operate a separate MinIO/S3 cluster solely for Milvus creates unnecessary operational cost, doubles storage footprint, and introduces a data hand-off layer between their existing pipeline and Milvus.
+
+This document describes the design for adding HDFS as a first-class storage backend.
+
+### 1.2 Goals
+
+1. Implement `HDFSChunkManager` — a full implementation of the `ChunkManager` interface backed by HDFS.
+2. Wire HDFS into the existing `ChunkManagerFactory` so it is activated via a single config change.
+3. Add HDFS configuration parameters (`hdfs.address`, `hdfs.user`, `hdfs.rootPath`) following established param conventions.
+4. Support both simple authentication and Kerberos authentication (provided by the underlying Go HDFS client).
+5. Leave all existing storage backends (MinIO, local) entirely unchanged.
+
+### 1.3 Non-Goals
+
+1. HDFS is not a replacement for MinIO/S3 — it targets a specific enterprise use case.
+2. Mmap support over HDFS — HDFS does not expose a memory-mappable interface; callers relying on `Mmap` must use a different backend.
+3. HDFS HA (High Availability / multiple NameNodes) — not in scope for the initial implementation. The `colinmarc/hdfs` client supports this and can be added in a follow-up.
+4. Automatic HDFS cluster provisioning or management.
+
+---
+
+## 2. Design
+
+### 2.1 Architecture
+
+Milvus storage is abstracted through the `ChunkManager` interface defined in `internal/storage/types.go`. All components (DataNode, QueryNode, IndexNode, etc.) interact with storage exclusively through this interface. Adding a new backend requires only:
+
+1. A new struct implementing `ChunkManager`.
+2. A case in the factory switch.
+3. Config params and YAML entries.
+
+No coordinator or node logic needs to change.
+
+```
+ChunkManager (interface, internal/storage/types.go)
+    ├── LocalChunkManager        ← local filesystem
+    ├── RemoteChunkManager       ← MinIO / S3 / GCS / Azure
+    └── HDFSChunkManager  [NEW]  ← HDFS via NameNode RPC
+```
+
+### 2.2 HDFS Client Library
+
+We use [`github.com/colinmarc/hdfs/v2`](https://github.com/colinmarc/hdfs), a pure-Go HDFS client that speaks the native Hadoop RPC protocol. It was chosen over alternatives because:
+
+- Pure Go — no CGo, no `libhdfs` JNI dependency.
+- Supports both simple auth and Kerberos (GSSAPI).
+- Actively maintained; used in production at scale.
+- `*hdfs.FileReader` already implements `io.Reader`, `io.ReaderAt`, `io.Seeker`, and `io.Closer`, making it trivially wrappable into `FileReader`.
+
+**New transitive dependencies added to `go.mod`:**
+
+| Package | Why |
+|---|---|
+| `github.com/colinmarc/hdfs/v2` | HDFS client |
+| `github.com/jcmturner/gokrb5/v8` | Kerberos auth (bundled by hdfs client) |
+| `github.com/jcmturner/aescts/v2` | AES cipher suites for Kerberos |
+| `github.com/jcmturner/dnsutils/v2` | DNS SRV lookup for Kerberos |
+| `github.com/jcmturner/gofork` | Kerberos crypto |
+| `github.com/jcmturner/goidentity/v6` | Kerberos identity |
+| `github.com/jcmturner/rpc/v2` | Kerberos RPC |
+| `github.com/hashicorp/go-uuid` | UUID generation for Kerberos sessions |
+
+These are all indirect dependencies pulled in by `gokrb5`. They add Kerberos support, which is required in many enterprise Hadoop clusters and adds real value.
+
+### 2.3 `HDFSChunkManager` Implementation
+
+**File:** `internal/storage/hdfs_chunk_manager.go`
+
+The struct holds an `*hdfs.Client` (connected to the NameNode) and a `rootPath`:
+
+```go
+type HDFSChunkManager struct {
+    client   *hdfs.Client
+    rootPath string
+}
+```
+
+All paths passed to the interface methods are made absolute by prepending `rootPath` when not already absolute. This matches the behavior of `LocalChunkManager`.
+
+Key implementation decisions:
+
+- **Write**: removes any existing file before calling `hdfs.Create`, since the HDFS client returns an error if the file already exists (unlike `os.Create`).
+- **WalkWithPrefix**: uses `hdfs.Client.ReadDir` on the parent directory and filters by prefix, recursing into subdirectories when `recursive=true`. This avoids a full tree walk for non-recursive calls.
+- **Mmap**: returns an explicit error — HDFS does not support memory-mapped I/O. This matches the behavior of `RemoteChunkManager`.
+- **RemoveWithPrefix**: guards against empty prefix (same guard as `LocalChunkManager`) to prevent accidental full-tree deletion.
+
+### 2.4 Factory Wiring
+
+**File:** `internal/storage/factory.go`
+
+`NewChunkManagerFactoryWithParam` gains an HDFS branch before the existing MinIO path:
+
+```go
+if params.CommonCfg.StorageType.GetValue() == "hdfs" {
+    return NewChunkManagerFactory("hdfs",
+        objectstorage.RootPath(params.HdfsCfg.RootPath.GetValue()),
+        objectstorage.HDFSAddress(params.HdfsCfg.Address.GetValue()),
+        objectstorage.HDFSUser(params.HdfsCfg.User.GetValue()),
+    )
+}
+```
+
+`newChunkManager` (the internal switch) gains:
+
+```go
+case "hdfs":
+    return NewHDFSChunkManager(f.config.HDFSAddress, f.config.HDFSUser, f.config.RootPath)
+```
+
+### 2.5 Configuration
+
+**New config params** (`pkg/util/paramtable/service_param.go`):
+
+| Key | Default | Description |
+|---|---|---|
+| `hdfs.address` | `localhost:9000` | NameNode address in `host:port` format |
+| `hdfs.user` | `hdfs` | HDFS user for simple authentication |
+| `hdfs.rootPath` | `milvus` | Root path inside HDFS for all Milvus data |
+
+**Activation**: set `common.storageType: hdfs` in `milvus.yaml`. The existing `minio.*` params are ignored when this is set.
+
+**YAML section added to `configs/milvus.yaml`:**
+
+```yaml
+hdfs:
+  address: localhost:9000   # NameNode host:port
+  user: hdfs                # HDFS user (simple auth)
+  rootPath: milvus          # Root path for all Milvus data in HDFS
+```
+
+**`pkg/objectstorage/options.go`** gains two new fields on `Config` and two new `Option` functions (`HDFSAddress`, `HDFSUser`) following the existing pattern.
+
+---
+
+## 3. Testing
+
+Integration tests are in `internal/storage/hdfs_chunk_manager_test.go`. They are skipped unless the environment variable `HDFS_ADDRESS` is set, so they do not block CI runs without an HDFS cluster.
+
+To run against a real cluster:
+
+```bash
+HDFS_ADDRESS=localhost:9000 HDFS_USER=hdfs \
+  go test -tags dynamic,test -gcflags="all=-N -l" -count=1 \
+  ./internal/storage/... -run TestHDFSChunkManagerSuite
+```
+
+Tests cover: `Write`, `Read`, `Exist`, `Size`, `MultiWrite`, `MultiRead`, `ReadAt`, `WalkWithPrefix` (recursive), `Remove`, `MultiRemove`, `RemoveWithPrefix`, `Copy`, and the expected error from `Mmap`.
+
+---
+
+## 4. Compatibility and Upgrade
+
+- This change adds a new storage type; all existing storage types (`remote`, `local`, `minio`, `opendal`) are unaffected.
+- No schema or metadata format changes.
+- No rolling-upgrade concerns — the HDFS backend is only activated by explicit config opt-in.
+- Existing deployments that do not set `common.storageType: hdfs` are entirely unaffected.
+
+---
+
+## 5. Future Work
+
+- **HDFS HA (multiple NameNodes)**: the `colinmarc/hdfs` client supports passing multiple NameNode addresses; a follow-up can expose `hdfs.addresses` as a list.
+- **Kerberos config**: expose `hdfs.kerberosRealm`, `hdfs.kerberosKDC`, and keytab path as config params for clusters using Kerberos auth.
+- **Connection pooling**: the `hdfs.Client` is already goroutine-safe and reuses connections internally; no additional work needed.

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/bytedance/sonic v1.15.2
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cockroachdb/redact v1.1.3
+	github.com/colinmarc/hdfs/v2 v2.4.0
 	github.com/google/uuid v1.6.0
 	github.com/greatroar/blobloom v0.0.0-00010101000000-000000000000
 	github.com/hamba/avro/v2 v2.29.0
@@ -89,7 +90,6 @@ require (
 	github.com/bytedance/gopkg v0.1.4 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cloudfoundry/gosigar v1.3.6 // indirect
-	github.com/colinmarc/hdfs/v2 v2.4.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/gopherjs/gopherjs v1.12.80 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -89,8 +89,16 @@ require (
 	github.com/bytedance/gopkg v0.1.4 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cloudfoundry/gosigar v1.3.6 // indirect
+	github.com/colinmarc/hdfs/v2 v2.4.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/gopherjs/gopherjs v1.12.80 // indirect
+	github.com/hashicorp/go-uuid v1.0.3 // indirect
+	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
+	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
+	github.com/jcmturner/gofork v1.7.6 // indirect
+	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
+	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
+	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/smartystreets/assertions v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -570,7 +570,9 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v1.12.80 h1:aC68NT6VK715WeUapxcPSFq/a3gZdS32HdtghdOIgAo=
 github.com/gopherjs/gopherjs v1.12.80/go.mod h1:d55Q4EjGQHeJVms+9LGtXul6ykz5Xzx1E1gaXQXdimY=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -616,7 +618,6 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0 h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9D
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
+github.com/colinmarc/hdfs/v2 v2.4.0 h1:v6R8oBx/Wu9fHpdPoJJjpGSUxo8NhHIwrwsfhFvU9W0=
+github.com/colinmarc/hdfs/v2 v2.4.0/go.mod h1:0NAO+/3knbMx6+5pCv+Hcbaz4xn/Zzbn9+WIib2rKVI=
 github.com/confluentinc/confluent-kafka-go v1.9.1 h1:L3aW6KvTyrq/+BOMnDm9xJylhAEoAgqhoaJbMPe3GQI=
 github.com/confluentinc/confluent-kafka-go v1.9.1/go.mod h1:ptXNqsuDfYbAE/LBW6pnwWZElUoWxHoV8E43DCrliyo=
 github.com/containerd/cgroups/v3 v3.0.3 h1:S5ByHZ/h9PMe5IOQoN7E+nMc2UcLEM/V48DGDJ9kip0=
@@ -568,6 +570,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v1.12.80 h1:aC68NT6VK715WeUapxcPSFq/a3gZdS32HdtghdOIgAo=
 github.com/gopherjs/gopherjs v1.12.80/go.mod h1:d55Q4EjGQHeJVms+9LGtXul6ykz5Xzx1E1gaXQXdimY=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -614,6 +618,9 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
+github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -647,6 +654,18 @@ github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/
 github.com/iris-contrib/jade v1.1.3/go.mod h1:H/geBymxJhShH5kecoiOCSssPX7QWYH7UaeZTSWddIk=
 github.com/iris-contrib/pongo2 v0.0.1/go.mod h1:Ssh+00+3GAZqSQb30AvBRNxBx7rf0GqwkjqxNd0u65g=
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
+github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
+github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
+github.com/jcmturner/dnsutils/v2 v2.0.0 h1:lltnkeZGL0wILNvrNiVCR6Ro5PGU/SeBvVO/8c/iPbo=
+github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=
+github.com/jcmturner/gofork v1.7.6 h1:QH0l3hzAU1tfT3rZCnW5zXl+orbkNMMRGJfdJjHVETg=
+github.com/jcmturner/gofork v1.7.6/go.mod h1:1622LH6i/EZqLloHfE7IeZ0uEJwMSUyQ/nDd82IeqRo=
+github.com/jcmturner/goidentity/v6 v6.0.1 h1:VKnZd2oEIMorCTsFBnJWbExfNN7yZr3EhJAxwOkZg6o=
+github.com/jcmturner/goidentity/v6 v6.0.1/go.mod h1:X1YW3bgtvwAXju7V3LCIMpY0Gbxyjn/mY9zx4tFonSg=
+github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh687T8=
+github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
+github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
+github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
 github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869/go.mod h1:cJ6Cj7dQo+O6GJNiMx+Pa94qKj+TG8ONdKHgMNIyyag=
 github.com/jhump/gopoet v0.0.0-20190322174617-17282ff210b3/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
@@ -1059,6 +1078,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -1268,6 +1288,7 @@ golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1375,6 +1396,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20211008194852-3b03d305991f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1486,6 +1509,7 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1496,6 +1520,7 @@ golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa h1:efT73AJZfAAUV7SOip6
 golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -17,6 +17,13 @@ func NewChunkManagerFactoryWithParam(params *paramtable.ComponentParam) *ChunkMa
 	if params.CommonCfg.StorageType.GetValue() == "local" {
 		return NewChunkManagerFactory("local", objectstorage.RootPath(params.LocalStorageCfg.Path.GetValue()))
 	}
+	if params.CommonCfg.StorageType.GetValue() == "hdfs" {
+		return NewChunkManagerFactory("hdfs",
+			objectstorage.RootPath(params.HdfsCfg.RootPath.GetValue()),
+			objectstorage.HDFSAddress(params.HdfsCfg.Address.GetValue()),
+			objectstorage.HDFSUser(params.HdfsCfg.User.GetValue()),
+		)
+	}
 	return NewChunkManagerFactory(params.CommonCfg.StorageType.GetValue(),
 		objectstorage.RootPath(params.MinioCfg.RootPath.GetValue()),
 		objectstorage.Address(params.MinioCfg.Address.GetValue()),
@@ -53,6 +60,8 @@ func (f *ChunkManagerFactory) newChunkManager(ctx context.Context, engine string
 		return NewLocalChunkManager(objectstorage.RootPath(f.config.RootPath)), nil
 	case "remote", "minio", "opendal":
 		return NewRemoteChunkManager(ctx, f.config)
+	case "hdfs":
+		return NewHDFSChunkManager(f.config.HDFSAddress, f.config.HDFSUser, f.config.RootPath)
 	default:
 		return nil, merr.WrapErrServiceInternalMsg("no chunk manager implemented with engine: " + engine)
 	}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -61,7 +61,7 @@ func (f *ChunkManagerFactory) newChunkManager(ctx context.Context, engine string
 	case "remote", "minio", "opendal":
 		return NewRemoteChunkManager(ctx, f.config)
 	case "hdfs":
-		return NewHDFSChunkManager(f.config.HDFSAddress, f.config.HDFSUser, f.config.RootPath)
+		return NewHDFSChunkManager(ctx, f.config.HDFSAddress, f.config.HDFSUser, f.config.RootPath)
 	default:
 		return nil, merr.WrapErrServiceInternalMsg("no chunk manager implemented with engine: " + engine)
 	}

--- a/internal/storage/hdfs_chunk_manager.go
+++ b/internal/storage/hdfs_chunk_manager.go
@@ -18,9 +18,13 @@ package storage
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"os"
+	"path"
 	"strings"
+	"time"
 
 	"github.com/colinmarc/hdfs/v2"
 	"golang.org/x/exp/mmap"
@@ -29,7 +33,16 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 )
 
+// errWalkStopped is returned by walkHelper when walkFunc signals early stop
+// (returns false). WalkWithPrefix converts it to nil before returning.
+var errWalkStopped = errors.New("walk stopped by caller")
+
 // HDFSChunkManager implements ChunkManager backed by HDFS.
+//
+// Path contract: callers already include RootPath() in every key they pass,
+// exactly as they do with LocalChunkManager and RemoteChunkManager.
+// HDFSChunkManager uses filePath as-is and does NOT re-prepend rootPath on
+// every call — rootPath is stored only for RootPath() to return.
 type HDFSChunkManager struct {
 	client   *hdfs.Client
 	rootPath string
@@ -37,8 +50,10 @@ type HDFSChunkManager struct {
 
 var _ ChunkManager = (*HDFSChunkManager)(nil)
 
-// NewHDFSChunkManager creates a new HDFSChunkManager connected to the given NameNode address.
-func NewHDFSChunkManager(address, user, rootPath string) (*HDFSChunkManager, error) {
+// NewHDFSChunkManager dials the HDFS NameNode and verifies connectivity.
+// Construction honours ctx — if the NameNode is unreachable and ctx expires,
+// the call returns an error instead of blocking indefinitely.
+func NewHDFSChunkManager(ctx context.Context, address, user, rootPath string) (*HDFSChunkManager, error) {
 	client, err := hdfs.NewClient(hdfs.ClientOptions{
 		Addresses: []string{address},
 		User:      user,
@@ -46,6 +61,19 @@ func NewHDFSChunkManager(address, user, rootPath string) (*HDFSChunkManager, err
 	if err != nil {
 		return nil, merr.WrapErrIoFailed("hdfs_connect", err)
 	}
+
+	// Force a NameNode RPC to fail fast when the cluster is unreachable.
+	done := make(chan error, 1)
+	go func() { _, e := client.Stat("/"); done <- e }()
+	select {
+	case <-ctx.Done():
+		return nil, merr.WrapErrIoFailed("hdfs_connect", ctx.Err())
+	case err = <-done:
+		if err != nil {
+			return nil, merr.WrapErrIoFailed("hdfs_connect", err)
+		}
+	}
+
 	return &HDFSChunkManager{
 		client:   client,
 		rootPath: strings.TrimRight(rootPath, "/"),
@@ -57,19 +85,18 @@ func (h *HDFSChunkManager) RootPath() string {
 }
 
 func (h *HDFSChunkManager) Path(ctx context.Context, filePath string) (string, error) {
-	abs := h.absPath(filePath)
-	_, err := h.client.Stat(abs)
+	_, err := h.client.Stat(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", merr.WrapErrIoKeyNotFound(filePath)
 		}
 		return "", merr.WrapErrIoFailed(filePath, err)
 	}
-	return abs, nil
+	return filePath, nil
 }
 
 func (h *HDFSChunkManager) Size(ctx context.Context, filePath string) (int64, error) {
-	info, err := h.client.Stat(h.absPath(filePath))
+	info, err := h.client.Stat(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return 0, merr.WrapErrIoKeyNotFound(filePath)
@@ -79,22 +106,43 @@ func (h *HDFSChunkManager) Size(ctx context.Context, filePath string) (int64, er
 	return info.Size(), nil
 }
 
+// Write writes content to filePath atomically via a temp file + Rename so
+// readers never observe a partial write or a missing key.
 func (h *HDFSChunkManager) Write(ctx context.Context, filePath string, content []byte) error {
-	abs := h.absPath(filePath)
-	if err := h.client.MkdirAll(hdfsParentDir(abs), 0o755); err != nil {
+	if err := h.client.MkdirAll(path.Dir(filePath), 0o755); err != nil {
 		return merr.WrapErrIoFailed(filePath, err)
 	}
-	// Remove existing file so Create doesn't fail on an already-existing path.
-	_ = h.client.Remove(abs)
-	fw, err := h.client.Create(abs)
+
+	tmp := filePath + ".tmp." + tmpSuffix()
+	fw, err := h.client.Create(tmp)
 	if err != nil {
 		return merr.WrapErrIoFailed(filePath, err)
 	}
-	defer fw.Close()
 	if _, err = fw.Write(content); err != nil {
+		fw.Close()
+		_ = h.client.Remove(tmp)
 		return merr.WrapErrIoFailed(filePath, err)
 	}
-	return fw.Flush()
+	if err = fw.Flush(); err != nil {
+		fw.Close()
+		_ = h.client.Remove(tmp)
+		return merr.WrapErrIoFailed(filePath, err)
+	}
+	if err = fw.Close(); err != nil {
+		_ = h.client.Remove(tmp)
+		return merr.WrapErrIoFailed(filePath, err)
+	}
+
+	// HDFS Rename requires the destination to not exist.
+	if rmErr := h.client.Remove(filePath); rmErr != nil && !os.IsNotExist(rmErr) {
+		_ = h.client.Remove(tmp)
+		return merr.WrapErrIoFailed(filePath, rmErr)
+	}
+	if err = h.client.Rename(tmp, filePath); err != nil {
+		_ = h.client.Remove(tmp)
+		return merr.WrapErrIoFailed(filePath, err)
+	}
+	return nil
 }
 
 func (h *HDFSChunkManager) MultiWrite(ctx context.Context, contents map[string][]byte) error {
@@ -108,7 +156,7 @@ func (h *HDFSChunkManager) MultiWrite(ctx context.Context, contents map[string][
 }
 
 func (h *HDFSChunkManager) Exist(ctx context.Context, filePath string) (bool, error) {
-	_, err := h.client.Stat(h.absPath(filePath))
+	_, err := h.client.Stat(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -119,7 +167,7 @@ func (h *HDFSChunkManager) Exist(ctx context.Context, filePath string) (bool, er
 }
 
 func (h *HDFSChunkManager) Read(ctx context.Context, filePath string) ([]byte, error) {
-	f, err := h.client.Open(h.absPath(filePath))
+	f, err := h.client.Open(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, merr.WrapErrIoKeyNotFound(filePath)
@@ -135,7 +183,7 @@ func (h *HDFSChunkManager) Read(ctx context.Context, filePath string) ([]byte, e
 }
 
 func (h *HDFSChunkManager) Reader(ctx context.Context, filePath string) (FileReader, error) {
-	f, err := h.client.Open(h.absPath(filePath))
+	f, err := h.client.Open(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, merr.WrapErrIoKeyNotFound(filePath)
@@ -158,9 +206,13 @@ func (h *HDFSChunkManager) MultiRead(ctx context.Context, filePaths []string) ([
 	return results, el
 }
 
+// WalkWithPrefix lists all objects whose path starts with prefix, calling
+// walkFunc for each one. When recursive is false, directory entries (common
+// prefixes) are yielded — matching MinIO/S3 backend semantics that callers
+// such as datacoord/import_util.go depend on. Walking stops when walkFunc
+// returns false or ctx is cancelled.
 func (h *HDFSChunkManager) WalkWithPrefix(ctx context.Context, prefix string, recursive bool, walkFunc ChunkObjectWalkFunc) (err error) {
-	abs := h.absPath(prefix)
-	logger := mlog.With(mlog.String("prefix", abs), mlog.Bool("recursive", recursive))
+	logger := mlog.With(mlog.String("prefix", prefix), mlog.Bool("recursive", recursive))
 	logger.Info(ctx, "start walk through HDFS objects")
 	defer func() {
 		if err != nil {
@@ -170,36 +222,78 @@ func (h *HDFSChunkManager) WalkWithPrefix(ctx context.Context, prefix string, re
 		logger.Info(ctx, "finish walk through HDFS objects")
 	}()
 
-	// Derive the directory that contains objects matching the prefix.
-	dir := hdfsParentDir(abs)
-	infos, readErr := h.client.ReadDir(dir)
-	if readErr != nil {
-		if os.IsNotExist(readErr) {
+	walkErr := h.walkHelper(ctx, prefix, recursive, walkFunc)
+	if walkErr != nil && walkErr != errWalkStopped {
+		return walkErr
+	}
+	return nil
+}
+
+// walkHelper is the recursive core. It returns errWalkStopped when walkFunc
+// signals early termination; the sentinel propagates through all recursion
+// levels and is stripped by WalkWithPrefix before returning to the caller.
+func (h *HDFSChunkManager) walkHelper(ctx context.Context, prefix string, recursive bool, walkFunc ChunkObjectWalkFunc) error {
+	dir := strings.TrimRight(prefix, "/")
+
+	infos, err := h.client.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
 			return nil
 		}
-		return merr.WrapErrIoFailed(dir, readErr)
+		// prefix is a partial file-name, not a directory — list parent + filter.
+		return h.walkParentWithFilter(ctx, prefix, recursive, walkFunc)
 	}
 
+	return h.walkEntries(ctx, dir, infos, recursive, walkFunc)
+}
+
+// walkParentWithFilter handles the case where prefix is a partial name
+// (e.g. "/milvus/logs/seg_4" matching seg_40, seg_41).
+func (h *HDFSChunkManager) walkParentWithFilter(ctx context.Context, prefix string, recursive bool, walkFunc ChunkObjectWalkFunc) error {
+	dir := strings.TrimRight(prefix, "/")
+	parentDir := path.Dir(dir)
+	basePfx := path.Base(dir)
+
+	infos, err := h.client.ReadDir(parentDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return merr.WrapErrIoFailed(prefix, err)
+	}
+
+	var filtered []os.FileInfo
+	for _, info := range infos {
+		if strings.HasPrefix(info.Name(), basePfx) {
+			filtered = append(filtered, info)
+		}
+	}
+	return h.walkEntries(ctx, parentDir, filtered, recursive, walkFunc)
+}
+
+// walkEntries iterates a ReadDir result, recursing into sub-directories when
+// recursive is true, or emitting them as common-prefix entries when false.
+func (h *HDFSChunkManager) walkEntries(ctx context.Context, dir string, infos []os.FileInfo, recursive bool, walkFunc ChunkObjectWalkFunc) error {
 	for _, info := range infos {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		fullPath := dir + "/" + info.Name()
-		if !strings.HasPrefix(fullPath, abs) {
-			continue
-		}
+		fullPath := path.Join(dir, info.Name())
 		if info.IsDir() {
-			if !recursive {
-				continue
-			}
-			// Recurse into the sub-directory.
-			if err = h.WalkWithPrefix(ctx, fullPath+"/", recursive, walkFunc); err != nil {
-				return err
+			if recursive {
+				if err := h.walkHelper(ctx, fullPath, recursive, walkFunc); err != nil {
+					return err // propagates errWalkStopped upward
+				}
+			} else {
+				// Emit directory as a common-prefix entry (matches S3/minio semantics).
+				if !walkFunc(&ChunkObjectInfo{FilePath: fullPath, ModifyTime: info.ModTime()}) {
+					return errWalkStopped
+				}
 			}
 			continue
 		}
 		if !walkFunc(&ChunkObjectInfo{FilePath: fullPath, ModifyTime: info.ModTime()}) {
-			return nil
+			return errWalkStopped
 		}
 	}
 	return nil
@@ -210,11 +304,13 @@ func (h *HDFSChunkManager) Mmap(ctx context.Context, filePath string) (*mmap.Rea
 	return nil, merr.WrapErrServiceInternalMsg("Mmap is not supported on HDFS")
 }
 
+// ReadAt reads length bytes from filePath starting at off.
+// The returned slice may be shorter than length when the range extends past EOF.
 func (h *HDFSChunkManager) ReadAt(ctx context.Context, filePath string, off int64, length int64) ([]byte, error) {
 	if off < 0 || length < 0 {
 		return nil, io.EOF
 	}
-	f, err := h.client.Open(h.absPath(filePath))
+	f, err := h.client.Open(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, merr.WrapErrIoKeyNotFound(filePath)
@@ -222,15 +318,17 @@ func (h *HDFSChunkManager) ReadAt(ctx context.Context, filePath string, off int6
 		return nil, merr.WrapErrIoFailed(filePath, err)
 	}
 	defer f.Close()
+
 	buf := make([]byte, length)
-	if _, err = f.ReadAt(buf, off); err != nil && err != io.EOF {
+	n, err := f.ReadAt(buf, off)
+	if err != nil && err != io.EOF {
 		return nil, merr.WrapErrIoFailed(filePath, err)
 	}
-	return buf, nil
+	return buf[:n], nil
 }
 
 func (h *HDFSChunkManager) Remove(ctx context.Context, filePath string) error {
-	err := h.client.Remove(h.absPath(filePath))
+	err := h.client.Remove(filePath)
 	if err != nil && !os.IsNotExist(err) {
 		return merr.WrapErrIoFailed(filePath, err)
 	}
@@ -265,33 +363,59 @@ func (h *HDFSChunkManager) RemoveWithPrefix(ctx context.Context, prefix string) 
 	return removeErr
 }
 
+// Copy streams srcFilePath to dstFilePath via an HDFS reader/writer pipeline
+// so memory usage is O(buffer), not O(file size).
 func (h *HDFSChunkManager) Copy(ctx context.Context, srcFilePath, dstFilePath string) error {
-	data, err := h.Read(ctx, srcFilePath)
+	src, err := h.client.Open(srcFilePath)
 	if err != nil {
-		return err
+		if os.IsNotExist(err) {
+			return merr.WrapErrIoKeyNotFound(srcFilePath)
+		}
+		return merr.WrapErrIoFailed(srcFilePath, err)
 	}
-	return h.Write(ctx, dstFilePath, data)
+	defer src.Close()
+
+	if err := h.client.MkdirAll(path.Dir(dstFilePath), 0o755); err != nil {
+		return merr.WrapErrIoFailed(dstFilePath, err)
+	}
+
+	tmp := dstFilePath + ".tmp." + tmpSuffix()
+	fw, err := h.client.Create(tmp)
+	if err != nil {
+		return merr.WrapErrIoFailed(dstFilePath, err)
+	}
+	if _, err = io.Copy(fw, src); err != nil {
+		fw.Close()
+		_ = h.client.Remove(tmp)
+		return merr.WrapErrIoFailed(dstFilePath, err)
+	}
+	if err = fw.Flush(); err != nil {
+		fw.Close()
+		_ = h.client.Remove(tmp)
+		return merr.WrapErrIoFailed(dstFilePath, err)
+	}
+	if err = fw.Close(); err != nil {
+		_ = h.client.Remove(tmp)
+		return merr.WrapErrIoFailed(dstFilePath, err)
+	}
+	if rmErr := h.client.Remove(dstFilePath); rmErr != nil && !os.IsNotExist(rmErr) {
+		_ = h.client.Remove(tmp)
+		return merr.WrapErrIoFailed(dstFilePath, rmErr)
+	}
+	if err = h.client.Rename(tmp, dstFilePath); err != nil {
+		_ = h.client.Remove(tmp)
+		return merr.WrapErrIoFailed(dstFilePath, err)
+	}
+	return nil
 }
 
-// absPath prepends rootPath when the given path is not already absolute.
-func (h *HDFSChunkManager) absPath(p string) string {
-	if strings.HasPrefix(p, "/") {
-		return p
-	}
-	return h.rootPath + "/" + p
+// tmpSuffix returns a short unique suffix for temporary file names.
+func tmpSuffix() string {
+	return fmt.Sprintf("%016x", time.Now().UnixNano())
 }
 
-// hdfsParentDir returns the parent directory of an HDFS path.
-func hdfsParentDir(path string) string {
-	path = strings.TrimRight(path, "/")
-	idx := strings.LastIndex(path, "/")
-	if idx <= 0 {
-		return "/"
-	}
-	return path[:idx]
-}
-
-// hdfsReader wraps *hdfs.FileReader to satisfy the FileReader interface.
+// hdfsReader wraps *hdfs.FileReader to satisfy the FileReader interface,
+// which requires a Size() method that *hdfs.FileReader does not expose directly.
 type hdfsReader struct {
 	*hdfs.FileReader
 }

--- a/internal/storage/hdfs_chunk_manager.go
+++ b/internal/storage/hdfs_chunk_manager.go
@@ -1,0 +1,301 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/colinmarc/hdfs/v2"
+	"golang.org/x/exp/mmap"
+
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
+// HDFSChunkManager implements ChunkManager backed by HDFS.
+type HDFSChunkManager struct {
+	client   *hdfs.Client
+	rootPath string
+}
+
+var _ ChunkManager = (*HDFSChunkManager)(nil)
+
+// NewHDFSChunkManager creates a new HDFSChunkManager connected to the given NameNode address.
+func NewHDFSChunkManager(address, user, rootPath string) (*HDFSChunkManager, error) {
+	client, err := hdfs.NewClient(hdfs.ClientOptions{
+		Addresses: []string{address},
+		User:      user,
+	})
+	if err != nil {
+		return nil, merr.WrapErrIoFailed("hdfs_connect", err)
+	}
+	return &HDFSChunkManager{
+		client:   client,
+		rootPath: strings.TrimRight(rootPath, "/"),
+	}, nil
+}
+
+func (h *HDFSChunkManager) RootPath() string {
+	return h.rootPath
+}
+
+func (h *HDFSChunkManager) Path(ctx context.Context, filePath string) (string, error) {
+	abs := h.absPath(filePath)
+	_, err := h.client.Stat(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", merr.WrapErrIoKeyNotFound(filePath)
+		}
+		return "", merr.WrapErrIoFailed(filePath, err)
+	}
+	return abs, nil
+}
+
+func (h *HDFSChunkManager) Size(ctx context.Context, filePath string) (int64, error) {
+	info, err := h.client.Stat(h.absPath(filePath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, merr.WrapErrIoKeyNotFound(filePath)
+		}
+		return 0, merr.WrapErrIoFailed(filePath, err)
+	}
+	return info.Size(), nil
+}
+
+func (h *HDFSChunkManager) Write(ctx context.Context, filePath string, content []byte) error {
+	abs := h.absPath(filePath)
+	if err := h.client.MkdirAll(hdfsParentDir(abs), 0o755); err != nil {
+		return merr.WrapErrIoFailed(filePath, err)
+	}
+	// Remove existing file so Create doesn't fail on an already-existing path.
+	_ = h.client.Remove(abs)
+	fw, err := h.client.Create(abs)
+	if err != nil {
+		return merr.WrapErrIoFailed(filePath, err)
+	}
+	defer fw.Close()
+	if _, err = fw.Write(content); err != nil {
+		return merr.WrapErrIoFailed(filePath, err)
+	}
+	return fw.Flush()
+}
+
+func (h *HDFSChunkManager) MultiWrite(ctx context.Context, contents map[string][]byte) error {
+	var el error
+	for filePath, data := range contents {
+		if err := h.Write(ctx, filePath, data); err != nil {
+			el = merr.Combine(el, merr.Wrapf(err, "write %s failed", filePath))
+		}
+	}
+	return el
+}
+
+func (h *HDFSChunkManager) Exist(ctx context.Context, filePath string) (bool, error) {
+	_, err := h.client.Stat(h.absPath(filePath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, merr.WrapErrIoFailed(filePath, err)
+	}
+	return true, nil
+}
+
+func (h *HDFSChunkManager) Read(ctx context.Context, filePath string) ([]byte, error) {
+	f, err := h.client.Open(h.absPath(filePath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, merr.WrapErrIoKeyNotFound(filePath)
+		}
+		return nil, merr.WrapErrIoFailed(filePath, err)
+	}
+	defer f.Close()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, merr.WrapErrIoFailed(filePath, err)
+	}
+	return data, nil
+}
+
+func (h *HDFSChunkManager) Reader(ctx context.Context, filePath string) (FileReader, error) {
+	f, err := h.client.Open(h.absPath(filePath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, merr.WrapErrIoKeyNotFound(filePath)
+		}
+		return nil, merr.WrapErrIoFailed(filePath, err)
+	}
+	return &hdfsReader{f}, nil
+}
+
+func (h *HDFSChunkManager) MultiRead(ctx context.Context, filePaths []string) ([][]byte, error) {
+	results := make([][]byte, len(filePaths))
+	var el error
+	for i, p := range filePaths {
+		data, err := h.Read(ctx, p)
+		if err != nil {
+			el = merr.Combine(el, merr.Wrapf(err, "failed to read %s", p))
+		}
+		results[i] = data
+	}
+	return results, el
+}
+
+func (h *HDFSChunkManager) WalkWithPrefix(ctx context.Context, prefix string, recursive bool, walkFunc ChunkObjectWalkFunc) (err error) {
+	abs := h.absPath(prefix)
+	logger := mlog.With(mlog.String("prefix", abs), mlog.Bool("recursive", recursive))
+	logger.Info(ctx, "start walk through HDFS objects")
+	defer func() {
+		if err != nil {
+			logger.Warn(ctx, "failed to walk through HDFS objects", mlog.Err(err))
+			return
+		}
+		logger.Info(ctx, "finish walk through HDFS objects")
+	}()
+
+	// Derive the directory that contains objects matching the prefix.
+	dir := hdfsParentDir(abs)
+	infos, readErr := h.client.ReadDir(dir)
+	if readErr != nil {
+		if os.IsNotExist(readErr) {
+			return nil
+		}
+		return merr.WrapErrIoFailed(dir, readErr)
+	}
+
+	for _, info := range infos {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		fullPath := dir + "/" + info.Name()
+		if !strings.HasPrefix(fullPath, abs) {
+			continue
+		}
+		if info.IsDir() {
+			if !recursive {
+				continue
+			}
+			// Recurse into the sub-directory.
+			if err = h.WalkWithPrefix(ctx, fullPath+"/", recursive, walkFunc); err != nil {
+				return err
+			}
+			continue
+		}
+		if !walkFunc(&ChunkObjectInfo{FilePath: fullPath, ModifyTime: info.ModTime()}) {
+			return nil
+		}
+	}
+	return nil
+}
+
+// Mmap is not supported over HDFS.
+func (h *HDFSChunkManager) Mmap(ctx context.Context, filePath string) (*mmap.ReaderAt, error) {
+	return nil, merr.WrapErrServiceInternalMsg("Mmap is not supported on HDFS")
+}
+
+func (h *HDFSChunkManager) ReadAt(ctx context.Context, filePath string, off int64, length int64) ([]byte, error) {
+	if off < 0 || length < 0 {
+		return nil, io.EOF
+	}
+	f, err := h.client.Open(h.absPath(filePath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, merr.WrapErrIoKeyNotFound(filePath)
+		}
+		return nil, merr.WrapErrIoFailed(filePath, err)
+	}
+	defer f.Close()
+	buf := make([]byte, length)
+	if _, err = f.ReadAt(buf, off); err != nil && err != io.EOF {
+		return nil, merr.WrapErrIoFailed(filePath, err)
+	}
+	return buf, nil
+}
+
+func (h *HDFSChunkManager) Remove(ctx context.Context, filePath string) error {
+	err := h.client.Remove(h.absPath(filePath))
+	if err != nil && !os.IsNotExist(err) {
+		return merr.WrapErrIoFailed(filePath, err)
+	}
+	return nil
+}
+
+func (h *HDFSChunkManager) MultiRemove(ctx context.Context, filePaths []string) error {
+	var el error
+	for _, p := range filePaths {
+		if err := h.Remove(ctx, p); err != nil {
+			el = merr.Combine(el, err)
+		}
+	}
+	return el
+}
+
+func (h *HDFSChunkManager) RemoveWithPrefix(ctx context.Context, prefix string) error {
+	if len(prefix) == 0 {
+		errMsg := "empty prefix is not allowed for ChunkManager remove operation"
+		mlog.Warn(ctx, errMsg)
+		return merr.WrapErrStorageMsg("%s", errMsg)
+	}
+	var removeErr error
+	if err := h.WalkWithPrefix(ctx, prefix, true, func(info *ChunkObjectInfo) bool {
+		if err := h.Remove(ctx, info.FilePath); err != nil {
+			removeErr = err
+		}
+		return true
+	}); err != nil {
+		return err
+	}
+	return removeErr
+}
+
+func (h *HDFSChunkManager) Copy(ctx context.Context, srcFilePath, dstFilePath string) error {
+	data, err := h.Read(ctx, srcFilePath)
+	if err != nil {
+		return err
+	}
+	return h.Write(ctx, dstFilePath, data)
+}
+
+// absPath prepends rootPath when the given path is not already absolute.
+func (h *HDFSChunkManager) absPath(p string) string {
+	if strings.HasPrefix(p, "/") {
+		return p
+	}
+	return h.rootPath + "/" + p
+}
+
+// hdfsParentDir returns the parent directory of an HDFS path.
+func hdfsParentDir(path string) string {
+	path = strings.TrimRight(path, "/")
+	idx := strings.LastIndex(path, "/")
+	if idx <= 0 {
+		return "/"
+	}
+	return path[:idx]
+}
+
+// hdfsReader wraps *hdfs.FileReader to satisfy the FileReader interface.
+type hdfsReader struct {
+	*hdfs.FileReader
+}
+
+func (r *hdfsReader) Size() (int64, error) {
+	return r.FileReader.Stat().Size(), nil
+}

--- a/internal/storage/hdfs_chunk_manager_test.go
+++ b/internal/storage/hdfs_chunk_manager_test.go
@@ -18,17 +18,43 @@ package storage
 
 import (
 	"context"
+	"io"
 	"os"
+	"path"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-// HDFSChunkManagerSuite requires a real HDFS cluster.
-// Set HDFS_ADDRESS (e.g. "localhost:9000") and HDFS_USER to enable.
-// Tests are skipped when HDFS_ADDRESS is unset.
+// newHDFSChunkManagerForTest constructs an HDFSChunkManager from environment
+// variables, or skips the test when HDFS_ADDRESS is not set.
+//
+//	HDFS_ADDRESS  — NameNode address, e.g. "localhost:9000"  (required to run)
+//	HDFS_USER     — HDFS user for simple auth (default: "hdfs")
+func newHDFSChunkManagerForTest(t *testing.T, rootPath string) *HDFSChunkManager {
+	t.Helper()
+	addr := os.Getenv("HDFS_ADDRESS")
+	if addr == "" {
+		t.Skip("HDFS_ADDRESS not set; skipping HDFS tests. " +
+			"Start a local HDFS cluster and set HDFS_ADDRESS=host:9000 to run them.")
+	}
+	user := os.Getenv("HDFS_USER")
+	if user == "" {
+		user = "hdfs"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cm, err := NewHDFSChunkManager(ctx, addr, user, rootPath)
+	require.NoError(t, err)
+	return cm
+}
+
+// HDFSChunkManagerSuite runs against a real HDFS cluster.
+// Tests are skipped automatically when HDFS_ADDRESS is not set.
 type HDFSChunkManagerSuite struct {
 	suite.Suite
 	cm       *HDFSChunkManager
@@ -36,19 +62,8 @@ type HDFSChunkManagerSuite struct {
 }
 
 func (s *HDFSChunkManagerSuite) SetupSuite() {
-	addr := os.Getenv("HDFS_ADDRESS")
-	if addr == "" {
-		s.T().Skip("HDFS_ADDRESS not set; skipping HDFS integration tests")
-	}
-	user := os.Getenv("HDFS_USER")
-	if user == "" {
-		user = "hdfs"
-	}
 	s.rootPath = "/milvus-test"
-
-	var err error
-	s.cm, err = NewHDFSChunkManager(addr, user, s.rootPath)
-	require.NoError(s.T(), err)
+	s.cm = newHDFSChunkManagerForTest(s.T(), s.rootPath)
 }
 
 func (s *HDFSChunkManagerSuite) TearDownSuite() {
@@ -57,61 +72,67 @@ func (s *HDFSChunkManagerSuite) TearDownSuite() {
 	}
 }
 
+func (s *HDFSChunkManagerSuite) key(parts ...string) string {
+	return path.Join(append([]string{s.rootPath}, parts...)...)
+}
+
 func (s *HDFSChunkManagerSuite) TestRootPath() {
 	assert.Equal(s.T(), s.rootPath, s.cm.RootPath())
 }
 
 func (s *HDFSChunkManagerSuite) TestWriteRead() {
 	ctx := context.Background()
-	key := "test/write_read"
+	k := s.key("write_read")
 	data := []byte("hello hdfs")
 
-	err := s.cm.Write(ctx, key, data)
-	require.NoError(s.T(), err)
-
-	got, err := s.cm.Read(ctx, key)
+	require.NoError(s.T(), s.cm.Write(ctx, k, data))
+	got, err := s.cm.Read(ctx, k)
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), data, got)
 }
 
+func (s *HDFSChunkManagerSuite) TestWriteIsAtomic() {
+	// A second Write to the same key must overwrite the first completely.
+	ctx := context.Background()
+	k := s.key("atomic")
+	require.NoError(s.T(), s.cm.Write(ctx, k, []byte("v1")))
+	require.NoError(s.T(), s.cm.Write(ctx, k, []byte("v2")))
+	got, err := s.cm.Read(ctx, k)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), []byte("v2"), got)
+}
+
 func (s *HDFSChunkManagerSuite) TestExist() {
 	ctx := context.Background()
-	key := "test/exist_file"
+	k := s.key("exist_file")
 
-	exists, err := s.cm.Exist(ctx, key)
+	exists, err := s.cm.Exist(ctx, k)
 	require.NoError(s.T(), err)
 	assert.False(s.T(), exists)
 
-	require.NoError(s.T(), s.cm.Write(ctx, key, []byte("x")))
-
-	exists, err = s.cm.Exist(ctx, key)
+	require.NoError(s.T(), s.cm.Write(ctx, k, []byte("x")))
+	exists, err = s.cm.Exist(ctx, k)
 	require.NoError(s.T(), err)
 	assert.True(s.T(), exists)
 }
 
 func (s *HDFSChunkManagerSuite) TestSize() {
 	ctx := context.Background()
-	key := "test/size_file"
+	k := s.key("size_file")
 	data := []byte("hello")
-
-	require.NoError(s.T(), s.cm.Write(ctx, key, data))
-	size, err := s.cm.Size(ctx, key)
+	require.NoError(s.T(), s.cm.Write(ctx, k, data))
+	size, err := s.cm.Size(ctx, k)
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), int64(len(data)), size)
 }
 
 func (s *HDFSChunkManagerSuite) TestMultiWriteMultiRead() {
 	ctx := context.Background()
-	contents := map[string][]byte{
-		"test/multi/a": []byte("aaa"),
-		"test/multi/b": []byte("bbb"),
-		"test/multi/c": []byte("ccc"),
-	}
-
+	ka, kb, kc := s.key("multi/a"), s.key("multi/b"), s.key("multi/c")
+	contents := map[string][]byte{ka: []byte("aaa"), kb: []byte("bbb"), kc: []byte("ccc")}
 	require.NoError(s.T(), s.cm.MultiWrite(ctx, contents))
 
-	paths := []string{"test/multi/a", "test/multi/b", "test/multi/c"}
-	results, err := s.cm.MultiRead(ctx, paths)
+	results, err := s.cm.MultiRead(ctx, []string{ka, kb, kc})
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), []byte("aaa"), results[0])
 	assert.Equal(s.T(), []byte("bbb"), results[1])
@@ -120,42 +141,85 @@ func (s *HDFSChunkManagerSuite) TestMultiWriteMultiRead() {
 
 func (s *HDFSChunkManagerSuite) TestReadAt() {
 	ctx := context.Background()
-	key := "test/readat"
-	data := []byte("0123456789")
+	k := s.key("readat")
+	require.NoError(s.T(), s.cm.Write(ctx, k, []byte("0123456789")))
 
-	require.NoError(s.T(), s.cm.Write(ctx, key, data))
-
-	got, err := s.cm.ReadAt(ctx, key, 3, 5)
+	got, err := s.cm.ReadAt(ctx, k, 3, 5)
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), []byte("34567"), got)
 }
 
-func (s *HDFSChunkManagerSuite) TestWalkWithPrefix() {
+func (s *HDFSChunkManagerSuite) TestReadAtPastEOF() {
+	// ReadAt must NOT zero-pad — returned slice contains only bytes that exist.
 	ctx := context.Background()
-	files := map[string][]byte{
-		"test/walk/x":   []byte("x"),
-		"test/walk/y":   []byte("y"),
-		"test/walk/z/a": []byte("za"),
-	}
-	require.NoError(s.T(), s.cm.MultiWrite(ctx, files))
+	k := s.key("readat_eof")
+	require.NoError(s.T(), s.cm.Write(ctx, k, []byte("abcde"))) // 5 bytes
+
+	got, err := s.cm.ReadAt(ctx, k, 3, 100) // request 100 bytes from offset 3
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), []byte("de"), got) // only 2 bytes available
+}
+
+func (s *HDFSChunkManagerSuite) TestWalkRecursive() {
+	ctx := context.Background()
+	require.NoError(s.T(), s.cm.MultiWrite(ctx, map[string][]byte{
+		s.key("walk/445/a"): []byte("a"),
+		s.key("walk/445/b"): []byte("b"),
+		s.key("walk/446/c"): []byte("c"),
+	}))
 
 	var found []string
-	err := s.cm.WalkWithPrefix(ctx, "test/walk/", true, func(info *ChunkObjectInfo) bool {
+	err := s.cm.WalkWithPrefix(ctx, s.key("walk/445"), true, func(info *ChunkObjectInfo) bool {
 		found = append(found, info.FilePath)
 		return true
 	})
 	require.NoError(s.T(), err)
-	assert.Len(s.T(), found, 3)
+	sort.Strings(found)
+	assert.Equal(s.T(), []string{s.key("walk/445/a"), s.key("walk/445/b")}, found)
+}
+
+func (s *HDFSChunkManagerSuite) TestWalkNonRecursiveYieldsDirs() {
+	// Non-recursive walk must yield directory entries (common prefixes) so that
+	// callers like datacoord/import_util.go can enumerate segment sub-IDs.
+	ctx := context.Background()
+	require.NoError(s.T(), s.cm.MultiWrite(ctx, map[string][]byte{
+		s.key("import/445/binlog"): []byte("x"),
+		s.key("import/446/binlog"): []byte("y"),
+	}))
+
+	var found []string
+	err := s.cm.WalkWithPrefix(ctx, s.key("import/"), false, func(info *ChunkObjectInfo) bool {
+		found = append(found, info.FilePath)
+		return true
+	})
+	require.NoError(s.T(), err)
+	sort.Strings(found)
+	assert.Equal(s.T(), []string{s.key("import/445"), s.key("import/446")}, found)
+}
+
+func (s *HDFSChunkManagerSuite) TestWalkStopSignalPropagates() {
+	// walkFunc returning false must halt the walk immediately at every depth.
+	ctx := context.Background()
+	for _, k := range []string{"stop/1", "stop/2", "stop/3"} {
+		require.NoError(s.T(), s.cm.Write(ctx, s.key(k), []byte(k)))
+	}
+
+	count := 0
+	err := s.cm.WalkWithPrefix(ctx, s.key("stop/"), true, func(_ *ChunkObjectInfo) bool {
+		count++
+		return false
+	})
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 1, count)
 }
 
 func (s *HDFSChunkManagerSuite) TestRemove() {
 	ctx := context.Background()
-	key := "test/remove_me"
-	require.NoError(s.T(), s.cm.Write(ctx, key, []byte("bye")))
+	k := s.key("remove_me")
+	require.NoError(s.T(), s.cm.Write(ctx, k, []byte("bye")))
+	require.NoError(s.T(), s.cm.Remove(ctx, k))
 
-	require.NoError(s.T(), s.cm.Remove(ctx, key))
-
-	exists, err := s.cm.Exist(ctx, key)
+	exists, err := s.cm.Exist(ctx, k)
 	require.NoError(s.T(), err)
 	assert.False(s.T(), exists)
 }
@@ -163,26 +227,29 @@ func (s *HDFSChunkManagerSuite) TestRemove() {
 func (s *HDFSChunkManagerSuite) TestRemoveWithPrefix() {
 	ctx := context.Background()
 	files := map[string][]byte{
-		"test/rprefix/p1": []byte("1"),
-		"test/rprefix/p2": []byte("2"),
+		s.key("rprefix/p1"): []byte("1"),
+		s.key("rprefix/p2"): []byte("2"),
 	}
 	require.NoError(s.T(), s.cm.MultiWrite(ctx, files))
-
-	require.NoError(s.T(), s.cm.RemoveWithPrefix(ctx, "test/rprefix/"))
+	require.NoError(s.T(), s.cm.RemoveWithPrefix(ctx, s.key("rprefix/")))
 
 	for k := range files {
 		exists, err := s.cm.Exist(ctx, k)
 		require.NoError(s.T(), err)
-		assert.False(s.T(), exists)
+		assert.False(s.T(), exists, "expected %s to be removed", k)
 	}
+}
+
+func (s *HDFSChunkManagerSuite) TestRemoveWithPrefixEmptyGuard() {
+	err := s.cm.RemoveWithPrefix(context.Background(), "")
+	assert.Error(s.T(), err)
 }
 
 func (s *HDFSChunkManagerSuite) TestCopy() {
 	ctx := context.Background()
-	src := "test/copy_src"
-	dst := "test/copy_dst"
+	src := s.key("copy_src")
+	dst := s.key("copy_dst")
 	data := []byte("copy me")
-
 	require.NoError(s.T(), s.cm.Write(ctx, src, data))
 	require.NoError(s.T(), s.cm.Copy(ctx, src, dst))
 
@@ -191,9 +258,27 @@ func (s *HDFSChunkManagerSuite) TestCopy() {
 	assert.Equal(s.T(), data, got)
 }
 
-func (s *HDFSChunkManagerSuite) TestMmapUnsupported() {
+func (s *HDFSChunkManagerSuite) TestReader() {
 	ctx := context.Background()
-	_, err := s.cm.Mmap(ctx, "any")
+	k := s.key("reader_file")
+	data := []byte("stream me")
+	require.NoError(s.T(), s.cm.Write(ctx, k, data))
+
+	r, err := s.cm.Reader(ctx, k)
+	require.NoError(s.T(), err)
+	defer r.Close()
+
+	got, err := io.ReadAll(r)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), data, got)
+
+	size, err := r.Size()
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(len(data)), size)
+}
+
+func (s *HDFSChunkManagerSuite) TestMmapUnsupported() {
+	_, err := s.cm.Mmap(context.Background(), "any")
 	assert.Error(s.T(), err)
 }
 

--- a/internal/storage/hdfs_chunk_manager_test.go
+++ b/internal/storage/hdfs_chunk_manager_test.go
@@ -1,0 +1,202 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// HDFSChunkManagerSuite requires a real HDFS cluster.
+// Set HDFS_ADDRESS (e.g. "localhost:9000") and HDFS_USER to enable.
+// Tests are skipped when HDFS_ADDRESS is unset.
+type HDFSChunkManagerSuite struct {
+	suite.Suite
+	cm       *HDFSChunkManager
+	rootPath string
+}
+
+func (s *HDFSChunkManagerSuite) SetupSuite() {
+	addr := os.Getenv("HDFS_ADDRESS")
+	if addr == "" {
+		s.T().Skip("HDFS_ADDRESS not set; skipping HDFS integration tests")
+	}
+	user := os.Getenv("HDFS_USER")
+	if user == "" {
+		user = "hdfs"
+	}
+	s.rootPath = "/milvus-test"
+
+	var err error
+	s.cm, err = NewHDFSChunkManager(addr, user, s.rootPath)
+	require.NoError(s.T(), err)
+}
+
+func (s *HDFSChunkManagerSuite) TearDownSuite() {
+	if s.cm != nil {
+		_ = s.cm.RemoveWithPrefix(context.Background(), s.rootPath+"/")
+	}
+}
+
+func (s *HDFSChunkManagerSuite) TestRootPath() {
+	assert.Equal(s.T(), s.rootPath, s.cm.RootPath())
+}
+
+func (s *HDFSChunkManagerSuite) TestWriteRead() {
+	ctx := context.Background()
+	key := "test/write_read"
+	data := []byte("hello hdfs")
+
+	err := s.cm.Write(ctx, key, data)
+	require.NoError(s.T(), err)
+
+	got, err := s.cm.Read(ctx, key)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), data, got)
+}
+
+func (s *HDFSChunkManagerSuite) TestExist() {
+	ctx := context.Background()
+	key := "test/exist_file"
+
+	exists, err := s.cm.Exist(ctx, key)
+	require.NoError(s.T(), err)
+	assert.False(s.T(), exists)
+
+	require.NoError(s.T(), s.cm.Write(ctx, key, []byte("x")))
+
+	exists, err = s.cm.Exist(ctx, key)
+	require.NoError(s.T(), err)
+	assert.True(s.T(), exists)
+}
+
+func (s *HDFSChunkManagerSuite) TestSize() {
+	ctx := context.Background()
+	key := "test/size_file"
+	data := []byte("hello")
+
+	require.NoError(s.T(), s.cm.Write(ctx, key, data))
+	size, err := s.cm.Size(ctx, key)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(len(data)), size)
+}
+
+func (s *HDFSChunkManagerSuite) TestMultiWriteMultiRead() {
+	ctx := context.Background()
+	contents := map[string][]byte{
+		"test/multi/a": []byte("aaa"),
+		"test/multi/b": []byte("bbb"),
+		"test/multi/c": []byte("ccc"),
+	}
+
+	require.NoError(s.T(), s.cm.MultiWrite(ctx, contents))
+
+	paths := []string{"test/multi/a", "test/multi/b", "test/multi/c"}
+	results, err := s.cm.MultiRead(ctx, paths)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), []byte("aaa"), results[0])
+	assert.Equal(s.T(), []byte("bbb"), results[1])
+	assert.Equal(s.T(), []byte("ccc"), results[2])
+}
+
+func (s *HDFSChunkManagerSuite) TestReadAt() {
+	ctx := context.Background()
+	key := "test/readat"
+	data := []byte("0123456789")
+
+	require.NoError(s.T(), s.cm.Write(ctx, key, data))
+
+	got, err := s.cm.ReadAt(ctx, key, 3, 5)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), []byte("34567"), got)
+}
+
+func (s *HDFSChunkManagerSuite) TestWalkWithPrefix() {
+	ctx := context.Background()
+	files := map[string][]byte{
+		"test/walk/x":   []byte("x"),
+		"test/walk/y":   []byte("y"),
+		"test/walk/z/a": []byte("za"),
+	}
+	require.NoError(s.T(), s.cm.MultiWrite(ctx, files))
+
+	var found []string
+	err := s.cm.WalkWithPrefix(ctx, "test/walk/", true, func(info *ChunkObjectInfo) bool {
+		found = append(found, info.FilePath)
+		return true
+	})
+	require.NoError(s.T(), err)
+	assert.Len(s.T(), found, 3)
+}
+
+func (s *HDFSChunkManagerSuite) TestRemove() {
+	ctx := context.Background()
+	key := "test/remove_me"
+	require.NoError(s.T(), s.cm.Write(ctx, key, []byte("bye")))
+
+	require.NoError(s.T(), s.cm.Remove(ctx, key))
+
+	exists, err := s.cm.Exist(ctx, key)
+	require.NoError(s.T(), err)
+	assert.False(s.T(), exists)
+}
+
+func (s *HDFSChunkManagerSuite) TestRemoveWithPrefix() {
+	ctx := context.Background()
+	files := map[string][]byte{
+		"test/rprefix/p1": []byte("1"),
+		"test/rprefix/p2": []byte("2"),
+	}
+	require.NoError(s.T(), s.cm.MultiWrite(ctx, files))
+
+	require.NoError(s.T(), s.cm.RemoveWithPrefix(ctx, "test/rprefix/"))
+
+	for k := range files {
+		exists, err := s.cm.Exist(ctx, k)
+		require.NoError(s.T(), err)
+		assert.False(s.T(), exists)
+	}
+}
+
+func (s *HDFSChunkManagerSuite) TestCopy() {
+	ctx := context.Background()
+	src := "test/copy_src"
+	dst := "test/copy_dst"
+	data := []byte("copy me")
+
+	require.NoError(s.T(), s.cm.Write(ctx, src, data))
+	require.NoError(s.T(), s.cm.Copy(ctx, src, dst))
+
+	got, err := s.cm.Read(ctx, dst)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), data, got)
+}
+
+func (s *HDFSChunkManagerSuite) TestMmapUnsupported() {
+	ctx := context.Background()
+	_, err := s.cm.Mmap(ctx, "any")
+	assert.Error(s.T(), err)
+}
+
+func TestHDFSChunkManagerSuite(t *testing.T) {
+	suite.Run(t, new(HDFSChunkManagerSuite))
+}

--- a/pkg/objectstorage/options.go
+++ b/pkg/objectstorage/options.go
@@ -22,6 +22,10 @@ type Config struct {
 	GcpCredentialJSON    string
 	GcpNativeWithoutAuth bool // used for Unit Testing
 	ReadRetryAttempts    uint
+
+	// HDFS-specific config
+	HDFSAddress string
+	HDFSUser    string
 }
 
 func NewDefaultConfig() *Config {
@@ -126,5 +130,17 @@ func RequestTimeout(requestTimeoutMs int64) Option {
 func GcpCredentialJSON(gcpCredentialJSON string) Option {
 	return func(c *Config) {
 		c.GcpCredentialJSON = gcpCredentialJSON
+	}
+}
+
+func HDFSAddress(addr string) Option {
+	return func(c *Config) {
+		c.HDFSAddress = addr
+	}
+}
+
+func HDFSUser(user string) Option {
+	return func(c *Config) {
+		c.HDFSUser = user
 	}
 }

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -54,6 +54,7 @@ type ServiceParam struct {
 	KafkaCfg        KafkaConfig
 	RocksmqCfg      RocksmqConfig
 	MinioCfg        MinioConfig
+	HdfsCfg         HDFSConfig
 	ProfileCfg      ProfileConfig
 }
 
@@ -68,6 +69,7 @@ func (p *ServiceParam) init(bt *BaseTable) {
 	p.KafkaCfg.Init(bt)
 	p.RocksmqCfg.Init(bt)
 	p.MinioCfg.Init(bt)
+	p.HdfsCfg.Init(bt)
 	p.ProfileCfg.Init(bt)
 }
 
@@ -1457,6 +1459,43 @@ Set an easy-to-identify root key prefix for Milvus if etcd service already exist
 		Export:       true,
 	}
 	r.CompressionTypes.Init(base.mgr)
+}
+
+// /////////////////////////////////////////////////////////////////////////////
+// --- hdfs ---
+type HDFSConfig struct {
+	Address  ParamItem `refreshable:"false"`
+	User     ParamItem `refreshable:"false"`
+	RootPath ParamItem `refreshable:"false"`
+}
+
+func (p *HDFSConfig) Init(base *BaseTable) {
+	p.Address = ParamItem{
+		Key:          "hdfs.address",
+		Version:      "2.6.0",
+		DefaultValue: "localhost:9000",
+		Doc:          "Address of the HDFS NameNode (host:port).",
+		Export:       true,
+	}
+	p.Address.Init(base.mgr)
+
+	p.User = ParamItem{
+		Key:          "hdfs.user",
+		Version:      "2.6.0",
+		DefaultValue: "hdfs",
+		Doc:          "HDFS user for authentication.",
+		Export:       true,
+	}
+	p.User.Init(base.mgr)
+
+	p.RootPath = ParamItem{
+		Key:          "hdfs.rootPath",
+		Version:      "2.6.0",
+		DefaultValue: "milvus",
+		Doc:          "Root path in HDFS where Milvus stores data.",
+		Export:       true,
+	}
+	p.RootPath.Init(base.mgr)
 }
 
 // /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
feat: add HDFS storage backend

## Summary

Resolves #2745. Adds HDFS as a first-class storage backend for Milvus,
allowing users with existing Hadoop infrastructure to point Milvus
directly at their HDFS cluster instead of running a separate MinIO/S3
service.

- Implements `HDFSChunkManager` satisfying the full `ChunkManager`
  interface (`internal/storage/hdfs_chunk_manager.go`) using the
  pure-Go `colinmarc/hdfs/v2` client (no CGo / no libhdfs JNI).
- Wires `"hdfs"` into `ChunkManagerFactory` — zero changes to any
  coordinator or node logic.
- Adds `hdfs.address`, `hdfs.user`, `hdfs.rootPath` config params
  and a corresponding `hdfs:` section in `configs/milvus.yaml`.
- Adds integration test suite (skipped in CI unless `HDFS_ADDRESS`
  env var is set).
- Design doc: `docs/design-docs/design_docs/20260626-hdfs-storage-backend.md`

issue: #2745

## Activation

```yaml
# milvus.yaml
common:
  storageType: hdfs

hdfs:
  address: your-namenode:9000
  user: hdfs
  rootPath: milvus
  ```
  
All existing storage backends (remote, local, minio, opendal) are completely unaffected — this is opt-in only.

New dependencies colinmarc/hdfs/v2 pulls in the jcmturner/gokrb5 Kerberos stack as transitive deps. These are intentional — Kerberos auth is mandatory in many enterprise Hadoop clusters and adds real value for the target user base. See the dependency table in the design doc for details.