### PR TITLE
fix: avoid panic in broadcasterScheduler.AddTask during shutdown

### DIFF
--- a/internal/streamingcoord/server/broadcaster/broadcast_scheduler.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_scheduler.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/util/contextutil"
@@ -44,10 +45,15 @@ type broadcasterScheduler struct {
 func (b *broadcasterScheduler) AddTask(ctx context.Context, task *pendingBroadcastTask) (*types.BroadcastAppendResult, error) {
 	select {
 	case <-b.backgroundTaskNotifier.Context().Done():
-		// We can only check the background context but not the request context here.
-		// Because we want the new incoming task must be delivered to the background task queue
-		// otherwise the broadcaster is closing
-		panic("unreachable: broadcaster is closing when adding new task")
+		// The broadcaster is closing while a task is still being submitted. This is
+		// reachable under concurrent shutdown: broadcastTaskManager.Close cancels the
+		// broadcaster before the ack scheduler, so an in-flight
+		// doForcePromoteFixIncompleteBroadcasts goroutine can still deliver a supplement
+		// task here after the background queue is gone. Returning an error instead of
+		// panicking lets the caller abort gracefully; the task stays incomplete and is
+		// re-driven on the next startup. See #50550 for the sibling fix in
+		// tombstoneScheduler.AddPending.
+		return nil, status.NewOnShutdownError("broadcaster is closing, cannot add new task")
 	case b.pendingChan <- task:
 	}
 

--- a/internal/streamingcoord/server/broadcaster/broadcaster_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_test.go
@@ -690,6 +690,23 @@ func TestSortByControlChannelTimeTick(t *testing.T) {
 	assert.Equal(t, uint64(1), tasks[2].Header().BroadcastID)
 }
 
+func TestBroadcasterSchedulerAddTaskAfterClose(t *testing.T) {
+	// Regression for the shutdown race in the same family as #50550.
+	// broadcastTaskManager.Close cancels the broadcaster (broadcastScheduler.Close)
+	// before the ack scheduler, so an in-flight doForcePromoteFixIncompleteBroadcasts
+	// goroutine can still call broadcastScheduler.AddTask after the broadcaster
+	// background queue is gone. AddTask must return a shutdown error instead of
+	// panicking, because a panic in that background goroutine crashes the whole process.
+	scheduler := newBroadcasterScheduler(nil, mlog.With())
+	scheduler.Close()
+
+	// A nil task is fine here: AddTask returns at the closed-context branch of the
+	// select before it ever touches the task.
+	result, err := scheduler.AddTask(context.Background(), nil)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
 func TestFixIncompleteBroadcastsForForcePromote(t *testing.T) {
 	t.Run("no_incomplete_tasks", func(t *testing.T) {
 		paramtable.Init()


### PR DESCRIPTION
issue: #50857

`broadcasterScheduler.AddTask` panicked with `unreachable: broadcaster is closing when adding new task` when the broadcaster's background context was already cancelled. That path is reachable under concurrent shutdown.

`broadcastTaskManager.Close` closes the broadcaster **before** the ack scheduler:

```go
func (bm *broadcastTaskManager) Close() {
	...
	bm.broadcastScheduler.Close()
	bm.ackScheduler.Close()
}
```

The ack scheduler's `triggerAckCallback` spawns `go s.doForcePromoteFixIncompleteBroadcasts(...)`, which is not awaited by `ackScheduler.Close()` (`BlockUntilFinish` only waits for `background()`). That goroutine calls `s.bm.broadcastScheduler.AddTask(ctx, pending)` inside `fixIncompleteBroadcastsForForcePromote`, so once the broadcaster is closed but the force-promote goroutine is still in flight, `AddTask` takes the `Done()` branch and panics. A panic in a background goroutine crashes the whole process — the same failure mode #50550 fixed for the sibling `tombstoneScheduler.AddPending`.

## Change

Return `status.NewOnShutdownError(...)` instead of panicking, matching what the synchronous `broadcast()` path already returns for the manager-lifetime case. Both `AddTask` callers (`broadcast()` and `fixIncompleteBroadcastsForForcePromote`) already propagate the error, so the task is left incomplete and re-driven on the next startup — the same safe-to-drop reasoning as #50550.

Added `TestBroadcasterSchedulerAddTaskAfterClose` to cover the closed-scheduler path.
