### PR TITLE
enhance: [cp 2.6] add delegator delete micro batch

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -591,6 +591,8 @@ queryNode:
     flowGraph:
       maxQueueLength: 16 # The maximum size of task queue cache in flow graph in query node.
       maxParallelism: 1024 # Maximum number of tasks executed in parallel in the flowgraph
+    dmlMicroBatch:
+      maxMsgNum: 8 # Maximum number of DML messages in one micro-batch drained by query node data sync pipeline. The batcher only drains already buffered messages and does not wait for more messages.
   enableSegmentPrune: false # use partition stats to prune data in search/query on shard delegator
   queryStreamBatchSize: 4194304 # return min batch size of stream query
   queryStreamMaxBatchSize: 134217728 # return max batch size of stream query

--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -85,6 +85,7 @@ type ShardDelegator interface {
 	// data
 	ProcessInsert(insertRecords map[int64]*InsertData)
 	ProcessDelete(deleteData []*DeleteData, ts uint64)
+	ProcessDeleteBatches(batches []DeleteBatch)
 	LoadGrowing(ctx context.Context, infos []*querypb.SegmentLoadInfo, version int64) error
 	LoadL0(ctx context.Context, infos []*querypb.SegmentLoadInfo, version int64) error
 	LoadSegments(ctx context.Context, req *querypb.LoadSegmentsRequest) error

--- a/internal/querynodev2/delegator/delegator_data.go
+++ b/internal/querynodev2/delegator/delegator_data.go
@@ -77,6 +77,11 @@ type DeleteData struct {
 	RowCount    int64
 }
 
+type DeleteBatch struct {
+	Ts   uint64
+	Data []*DeleteData
+}
+
 // Append appends another delete data into this one.
 func (d *DeleteData) Append(ad DeleteData) {
 	d.PrimaryKeys = append(d.PrimaryKeys, ad.PrimaryKeys...)
@@ -187,9 +192,16 @@ func (sd *shardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 // delegator puts deleteData into buffer first,
 // then dispatch data to segments according to the result of bloom filter check.
 func (sd *shardDelegator) ProcessDelete(deleteData []*DeleteData, ts uint64) {
+	sd.ProcessDeleteBatches([]DeleteBatch{{Ts: ts, Data: deleteData}})
+}
+
+func (sd *shardDelegator) ProcessDeleteBatches(batches []DeleteBatch) {
 	// Early return if delegator is stopped - ProcessDelete becomes a no-op
 	// This prevents unnecessary processing and side effects during shutdown
 	if sd.Stopped() {
+		return
+	}
+	if len(batches) == 0 {
 		return
 	}
 
@@ -201,26 +213,35 @@ func (sd *shardDelegator) ProcessDelete(deleteData []*DeleteData, ts uint64) {
 
 	log := sd.getLogger(context.Background())
 
-	log.Debug("start to process delete", zap.Uint64("ts", ts))
-	// add deleteData into buffer.
-	cacheItems := make([]deletebuffer.BufferItem, 0, len(deleteData))
-	for _, entry := range deleteData {
-		cacheItems = append(cacheItems, deletebuffer.BufferItem{
-			PartitionID: entry.PartitionID,
-			DeleteData: storage.DeleteData{
-				Pks:      entry.PrimaryKeys,
-				Tss:      entry.Timestamps,
-				RowCount: entry.RowCount,
-			},
+	log.Debug("start to process delete batches", zap.Int("batchNum", len(batches)))
+	allDeleteData := make([]*DeleteData, 0, len(batches))
+	for _, batch := range batches {
+		if len(batch.Data) == 0 {
+			continue
+		}
+
+		cacheItems := make([]deletebuffer.BufferItem, 0, len(batch.Data))
+		for _, entry := range batch.Data {
+			cacheItems = append(cacheItems, deletebuffer.BufferItem{
+				PartitionID: entry.PartitionID,
+				DeleteData: storage.DeleteData{
+					Pks:      entry.PrimaryKeys,
+					Tss:      entry.Timestamps,
+					RowCount: entry.RowCount,
+				},
+			})
+		}
+
+		sd.deleteBuffer.Put(&deletebuffer.Item{
+			Ts:   batch.Ts,
+			Data: cacheItems,
 		})
+		allDeleteData = append(allDeleteData, batch.Data...)
 	}
 
-	sd.deleteBuffer.Put(&deletebuffer.Item{
-		Ts:   ts,
-		Data: cacheItems,
-	})
-
-	sd.forwardStreamingDeletion(context.Background(), deleteData)
+	if len(allDeleteData) > 0 {
+		sd.forwardStreamingDeletion(context.Background(), allDeleteData)
+	}
 
 	metrics.QueryNodeProcessCost.WithLabelValues(fmt.Sprint(paramtable.GetNodeID()), metrics.DeleteLabel).
 		Observe(float64(tr.ElapseSpan().Milliseconds()))

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -559,6 +559,50 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 	s.True(s.delegator.distribution.Serviceable())
 }
 
+func (s *DelegatorDataSuite) TestProcessDeleteBatchesPreservesBatchTsInDeleteBuffer() {
+	batches := []DeleteBatch{
+		{
+			Ts: 10,
+			Data: []*DeleteData{
+				{
+					PartitionID: 500,
+					PrimaryKeys: []storage.PrimaryKey{
+						storage.NewInt64PrimaryKey(10),
+					},
+					Timestamps: []uint64{10},
+					RowCount:   1,
+				},
+			},
+		},
+		{
+			Ts: 20,
+			Data: []*DeleteData{
+				{
+					PartitionID: 500,
+					PrimaryKeys: []storage.PrimaryKey{
+						storage.NewInt64PrimaryKey(20),
+					},
+					Timestamps: []uint64{20},
+					RowCount:   1,
+				},
+			},
+		},
+	}
+
+	s.delegator.ProcessDeleteBatches(batches)
+
+	after15 := s.delegator.deleteBuffer.ListAfter(15)
+	s.Require().Len(after15, 1)
+	s.Equal(uint64(20), after15[0].Ts)
+	s.Require().Len(after15[0].Data, 1)
+	s.ElementsMatch([]storage.PrimaryKey{storage.NewInt64PrimaryKey(20)}, after15[0].Data[0].DeleteData.Pks)
+
+	after0 := s.delegator.deleteBuffer.ListAfter(0)
+	s.Require().Len(after0, 2)
+	s.Equal(uint64(10), after0[0].Ts)
+	s.Equal(uint64(20), after0[1].Ts)
+}
+
 func (s *DelegatorDataSuite) TestLoadGrowingWithBM25() {
 	s.genCollectionWithFunction()
 	mockSegment := segments.NewMockSegment(s.T())

--- a/internal/querynodev2/delegator/mock_delegator.go
+++ b/internal/querynodev2/delegator/mock_delegator.go
@@ -827,6 +827,39 @@ func (_c *MockShardDelegator_ProcessDelete_Call) RunAndReturn(run func([]*Delete
 	return _c
 }
 
+// ProcessDeleteBatches provides a mock function with given fields: batches
+func (_m *MockShardDelegator) ProcessDeleteBatches(batches []DeleteBatch) {
+	_m.Called(batches)
+}
+
+// MockShardDelegator_ProcessDeleteBatches_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ProcessDeleteBatches'
+type MockShardDelegator_ProcessDeleteBatches_Call struct {
+	*mock.Call
+}
+
+// ProcessDeleteBatches is a helper method to define mock.On call
+//   - batches []DeleteBatch
+func (_e *MockShardDelegator_Expecter) ProcessDeleteBatches(batches interface{}) *MockShardDelegator_ProcessDeleteBatches_Call {
+	return &MockShardDelegator_ProcessDeleteBatches_Call{Call: _e.mock.On("ProcessDeleteBatches", batches)}
+}
+
+func (_c *MockShardDelegator_ProcessDeleteBatches_Call) Run(run func(batches []DeleteBatch)) *MockShardDelegator_ProcessDeleteBatches_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]DeleteBatch))
+	})
+	return _c
+}
+
+func (_c *MockShardDelegator_ProcessDeleteBatches_Call) Return() *MockShardDelegator_ProcessDeleteBatches_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockShardDelegator_ProcessDeleteBatches_Call) RunAndReturn(run func([]DeleteBatch)) *MockShardDelegator_ProcessDeleteBatches_Call {
+	_c.Run(run)
+	return _c
+}
+
 // ProcessInsert provides a mock function with given fields: insertRecords
 func (_m *MockShardDelegator) ProcessInsert(insertRecords map[int64]*InsertData) {
 	_m.Called(insertRecords)

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -68,6 +68,8 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 
 	if len(nodeMsg.deleteMsgs) > 0 {
 		deleteDataByTs := make(map[uint64]map[UniqueID]*delegator.DeleteData)
+		// deleteMsgs are ordered by WAL timetick within a vchannel; keep first-seen EndTs order
+		// because the delete buffer expects non-decreasing timestamps on Put.
 		tsOrder := make([]uint64, 0)
 
 		for _, msg := range nodeMsg.deleteMsgs {

--- a/internal/querynodev2/pipeline/delete_node.go
+++ b/internal/querynodev2/pipeline/delete_node.go
@@ -67,14 +67,28 @@ func (dNode *deleteNode) Operate(in Msg) Msg {
 	nodeMsg := in.(*deleteNodeMsg)
 
 	if len(nodeMsg.deleteMsgs) > 0 {
-		// partition id = > DeleteData
-		deleteDatas := make(map[UniqueID]*delegator.DeleteData)
+		deleteDataByTs := make(map[uint64]map[UniqueID]*delegator.DeleteData)
+		tsOrder := make([]uint64, 0)
 
 		for _, msg := range nodeMsg.deleteMsgs {
+			ts := msg.EndTs()
+			deleteDatas, ok := deleteDataByTs[ts]
+			if !ok {
+				deleteDatas = make(map[UniqueID]*delegator.DeleteData)
+				deleteDataByTs[ts] = deleteDatas
+				tsOrder = append(tsOrder, ts)
+			}
 			dNode.addDeleteData(deleteDatas, msg)
 		}
-		// do Delete, use ts range max as ts
-		dNode.delegator.ProcessDelete(lo.Values(deleteDatas), nodeMsg.timeRange.timestampMax)
+
+		batches := make([]delegator.DeleteBatch, 0, len(tsOrder))
+		for _, ts := range tsOrder {
+			batches = append(batches, delegator.DeleteBatch{
+				Ts:   ts,
+				Data: lo.Values(deleteDataByTs[ts]),
+			})
+		}
+		dNode.delegator.ProcessDeleteBatches(batches)
 	}
 
 	if nodeMsg.schema != nil {

--- a/internal/querynodev2/pipeline/delete_node_test.go
+++ b/internal/querynodev2/pipeline/delete_node_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/querynodev2/delegator"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
+	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -80,9 +81,9 @@ func (suite *DeleteNodeSuite) TestBasic() {
 		Segment:    mockSegmentManager,
 	}
 	suite.delegator = delegator.NewMockShardDelegator(suite.T())
-	suite.delegator.EXPECT().ProcessDelete(mock.Anything, mock.Anything).Run(
-		func(deleteData []*delegator.DeleteData, ts uint64) {
-			for _, data := range deleteData {
+	suite.delegator.EXPECT().ProcessDeleteBatches(mock.Anything).Run(
+		func(batches []delegator.DeleteBatch) {
+			for _, data := range batches[0].Data {
 				for _, pk := range data.PrimaryKeys {
 					suite.True(lo.Contains(suite.deletePKs, pk.GetValue().(int64)))
 				}
@@ -94,6 +95,54 @@ func (suite *DeleteNodeSuite) TestBasic() {
 	in := suite.buildDeleteNodeMsg()
 	suite.delegator.EXPECT().UpdateTSafe(in.timeRange.timestampMax).Return()
 	// run
+	out := node.Operate(in)
+	suite.Nil(out)
+}
+
+func (suite *DeleteNodeSuite) TestProcessDeleteBatchesUseDeleteMsgEndTs() {
+	mockCollectionManager := segments.NewMockCollectionManager(suite.T())
+	mockSegmentManager := segments.NewMockSegmentManager(suite.T())
+	suite.manager = &segments.Manager{
+		Collection: mockCollectionManager,
+		Segment:    mockSegmentManager,
+	}
+	suite.delegator = delegator.NewMockShardDelegator(suite.T())
+
+	first := buildDeleteMsg(suite.collectionID, suite.partitionIDs[0], suite.channel, 1)
+	first.SetTs(10)
+	first.PrimaryKeys = genDeletePK(10)
+	second := buildDeleteMsg(suite.collectionID, suite.partitionIDs[1], suite.channel, 1)
+	second.SetTs(20)
+	second.PrimaryKeys = genDeletePK(20)
+	third := buildDeleteMsg(suite.collectionID, suite.partitionIDs[0], suite.channel, 1)
+	third.SetTs(10)
+	third.PrimaryKeys = genDeletePK(30)
+
+	in := &deleteNodeMsg{
+		deleteMsgs: []*DeleteMsg{first, second, third},
+		timeRange: TimeRange{
+			timestampMin: 10,
+			timestampMax: 30,
+		},
+	}
+
+	suite.delegator.EXPECT().ProcessDeleteBatches(mock.Anything).Run(
+		func(batches []delegator.DeleteBatch) {
+			suite.Require().Len(batches, 2)
+			suite.Equal(uint64(10), batches[0].Ts)
+			suite.Equal(uint64(20), batches[1].Ts)
+			suite.Len(batches[0].Data, 1)
+			suite.Len(batches[1].Data, 1)
+			suite.ElementsMatch([]int64{10, 30}, lo.Map(batches[0].Data[0].PrimaryKeys, func(pk storage.PrimaryKey, _ int) int64 {
+				return pk.GetValue().(int64)
+			}))
+			suite.ElementsMatch([]int64{20}, lo.Map(batches[1].Data[0].PrimaryKeys, func(pk storage.PrimaryKey, _ int) int64 {
+				return pk.GetValue().(int64)
+			}))
+		})
+	suite.delegator.EXPECT().UpdateTSafe(uint64(30)).Return()
+
+	node := newDeleteNode(suite.collectionID, suite.channel, suite.manager, suite.delegator, 8)
 	out := node.Operate(in)
 	suite.Nil(out)
 }

--- a/internal/querynodev2/pipeline/pipeline.go
+++ b/internal/querynodev2/pipeline/pipeline.go
@@ -69,9 +69,7 @@ func NewPipeLine(
 			channel,
 			replicateConfig,
 			delegator,
-			// The batcher drains only already buffered DML packs, so the flow graph queue length
-			// is a natural upper bound and avoids introducing another QueryNode batch config.
-			base.WithMsgPackBatcher(base.NewDMLMsgPackBatcher(int(pipelineQueueLength))),
+			base.WithMsgPackBatcher(base.NewDMLMsgPackBatcher(paramtable.Get().QueryNodeCfg.DMLMicroBatchMaxMsgNum.GetAsInt)),
 		),
 	}
 

--- a/internal/querynodev2/pipeline/pipeline.go
+++ b/internal/querynodev2/pipeline/pipeline.go
@@ -69,6 +69,8 @@ func NewPipeLine(
 			channel,
 			replicateConfig,
 			delegator,
+			// The batcher drains only already buffered DML packs, so the flow graph queue length
+			// is a natural upper bound and avoids introducing another QueryNode batch config.
 			base.WithMsgPackBatcher(base.NewDMLMsgPackBatcher(int(pipelineQueueLength))),
 		),
 	}

--- a/internal/querynodev2/pipeline/pipeline.go
+++ b/internal/querynodev2/pipeline/pipeline.go
@@ -61,8 +61,16 @@ func NewPipeLine(
 	pipelineQueueLength := paramtable.Get().QueryNodeCfg.FlowGraphMaxQueueLength.GetAsInt32()
 
 	p := &pipeline{
-		collectionID:   collectionID,
-		StreamPipeline: base.NewPipelineWithStream(dispatcher, nodeCtxTtInterval, enableTtChecker, channel, replicateConfig, delegator),
+		collectionID: collectionID,
+		StreamPipeline: base.NewPipelineWithStream(
+			dispatcher,
+			nodeCtxTtInterval,
+			enableTtChecker,
+			channel,
+			replicateConfig,
+			delegator,
+			base.WithMsgPackBatcher(base.NewDMLMsgPackBatcher(int(pipelineQueueLength))),
+		),
 	}
 
 	filterNode := newFilterNode(collectionID, channel, manager, delegator, pipelineQueueLength)

--- a/internal/querynodev2/pipeline/pipeline_test.go
+++ b/internal/querynodev2/pipeline/pipeline_test.go
@@ -130,11 +130,13 @@ func (suite *PipelineTestSuite) TestBasic() {
 			}
 		})
 
-	suite.delegator.EXPECT().ProcessDelete(mock.Anything, mock.Anything).Run(
-		func(deleteData []*delegator.DeleteData, ts uint64) {
-			for _, data := range deleteData {
-				for _, pk := range data.PrimaryKeys {
-					suite.True(lo.Contains(suite.deletePKs, pk.GetValue().(int64)))
+	suite.delegator.EXPECT().ProcessDeleteBatches(mock.Anything).Run(
+		func(batches []delegator.DeleteBatch) {
+			for _, batch := range batches {
+				for _, data := range batch.Data {
+					for _, pk := range data.PrimaryKeys {
+						suite.True(lo.Contains(suite.deletePKs, pk.GetValue().(int64)))
+					}
 				}
 			}
 		})

--- a/internal/util/pipeline/stream_pipeline.go
+++ b/internal/util/pipeline/stream_pipeline.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -55,34 +56,48 @@ type streamPipeline struct {
 
 	lastAccessTime          *atomic.Time
 	emptyTimeTickSlowdowner *emptyTimeTickSlowdowner
+	msgPackBatcher          MsgPackBatcher
 }
 
 func (p *streamPipeline) work() {
 	defer p.closeWg.Done()
+	var pending *msgstream.MsgPack
 	for {
-		select {
-		case <-p.closeCh:
-			log.Ctx(context.TODO()).Debug("stream pipeline input closed")
-			return
-		case msg, ok := <-p.input:
-			if !ok {
+		var msg *msgstream.MsgPack
+		if pending != nil {
+			msg = pending
+			pending = nil
+		} else {
+			select {
+			case <-p.closeCh:
 				log.Ctx(context.TODO()).Debug("stream pipeline input closed")
 				return
+			case msgPack, ok := <-p.input:
+				if !ok {
+					log.Ctx(context.TODO()).Debug("stream pipeline input closed")
+					return
+				}
+				msg = msgPack
 			}
-
-			p.lastAccessTime.Store(time.Now())
-			// Currently, milvus use the timetick to synchronize the system periodically,
-			// so the wal will still produce empty timetick message after the last write operation is done.
-			// When there're huge amount of vchannel in one pchannel, it will introduce a great overhead.
-			// So we filter out the empty time tick message as much as possible.
-			// TODO: After 3.0, we can remove the filter logic by LSN+MVCC.
-			if p.emptyTimeTickSlowdowner.Filter(msg) {
-				continue
-			}
-			log.Ctx(context.TODO()).RatedDebug(10, "stream pipeline fetch msg", zap.Int("sum", len(msg.Msgs)))
-			p.pipeline.inputChannel <- msg
-			p.pipeline.process()
 		}
+
+		p.lastAccessTime.Store(time.Now())
+		// Currently, milvus use the timetick to synchronize the system periodically,
+		// so the wal will still produce empty timetick message after the last write operation is done.
+		// When there're huge amount of vchannel in one pchannel, it will introduce a great overhead.
+		// So we filter out the empty time tick message as much as possible.
+		// TODO: After 3.0, we can remove the filter logic by LSN+MVCC.
+		if p.emptyTimeTickSlowdowner.Filter(msg) {
+			continue
+		}
+
+		if p.msgPackBatcher != nil {
+			msg, pending = p.msgPackBatcher.Batch(msg, p.input)
+		}
+
+		log.Ctx(context.TODO()).RatedDebug(10, "stream pipeline fetch msg", zap.Int("sum", len(msg.Msgs)))
+		p.pipeline.inputChannel <- msg
+		p.pipeline.process()
 	}
 }
 
@@ -164,6 +179,7 @@ func NewPipelineWithStream(dispatcher msgdispatcher.Client,
 	vChannel string,
 	replicateConfig *msgstream.ReplicateConfig,
 	lastestMVCCTimeTickGetter LastestMVCCTimeTickGetter,
+	options ...StreamPipelineOption,
 ) StreamPipeline {
 	pipeline := &streamPipeline{
 		pipeline: &pipeline{
@@ -180,5 +196,87 @@ func NewPipelineWithStream(dispatcher msgdispatcher.Client,
 		emptyTimeTickSlowdowner: newEmptyTimeTickSlowdowner(lastestMVCCTimeTickGetter, vChannel),
 	}
 
+	for _, option := range options {
+		option(pipeline)
+	}
+
 	return pipeline
+}
+
+type StreamPipelineOption func(*streamPipeline)
+
+func WithMsgPackBatcher(batcher MsgPackBatcher) StreamPipelineOption {
+	return func(pipeline *streamPipeline) {
+		pipeline.msgPackBatcher = batcher
+	}
+}
+
+type MsgPackBatcher interface {
+	Batch(first *msgstream.MsgPack, input <-chan *msgstream.MsgPack) (merged *msgstream.MsgPack, pending *msgstream.MsgPack)
+}
+
+type dmlMsgPackBatcher struct {
+	maxPacks int
+}
+
+func NewDMLMsgPackBatcher(maxPacks int) MsgPackBatcher {
+	return &dmlMsgPackBatcher{maxPacks: maxPacks}
+}
+
+func (b *dmlMsgPackBatcher) Batch(first *msgstream.MsgPack, input <-chan *msgstream.MsgPack) (*msgstream.MsgPack, *msgstream.MsgPack) {
+	if b.maxPacks <= 1 || !isDMLMsgPack(first) {
+		return first, nil
+	}
+
+	packs := []*msgstream.MsgPack{first}
+	for len(packs) < b.maxPacks {
+		select {
+		case next, ok := <-input:
+			if !ok {
+				return mergeMsgPacks(packs), nil
+			}
+			if !isDMLMsgPack(next) {
+				return mergeMsgPacks(packs), next
+			}
+			packs = append(packs, next)
+		default:
+			return mergeMsgPacks(packs), nil
+		}
+	}
+	return mergeMsgPacks(packs), nil
+}
+
+func isDMLMsgPack(pack *msgstream.MsgPack) bool {
+	if pack == nil || len(pack.Msgs) == 0 {
+		return false
+	}
+
+	for _, msg := range pack.Msgs {
+		switch msg.Type() {
+		case commonpb.MsgType_Insert, commonpb.MsgType_Delete:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func mergeMsgPacks(packs []*msgstream.MsgPack) *msgstream.MsgPack {
+	if len(packs) == 1 {
+		return packs[0]
+	}
+
+	first := packs[0]
+	last := packs[len(packs)-1]
+	merged := &msgstream.MsgPack{
+		BeginTs:        first.BeginTs,
+		EndTs:          last.EndTs,
+		StartPositions: first.StartPositions,
+		EndPositions:   last.EndPositions,
+		Msgs:           make([]msgstream.TsMsg, 0),
+	}
+	for _, pack := range packs {
+		merged.Msgs = append(merged.Msgs, pack.Msgs...)
+	}
+	return merged
 }

--- a/internal/util/pipeline/stream_pipeline.go
+++ b/internal/util/pipeline/stream_pipeline.go
@@ -268,6 +268,8 @@ func mergeMsgPacks(packs []*msgstream.MsgPack) *msgstream.MsgPack {
 
 	first := packs[0]
 	last := packs[len(packs)-1]
+	// Positions are monotonic within a vchannel; merged packs intentionally keep only
+	// the first start position and the last end position for checkpoint progress.
 	merged := &msgstream.MsgPack{
 		BeginTs:        first.BeginTs,
 		EndTs:          last.EndTs,

--- a/internal/util/pipeline/stream_pipeline.go
+++ b/internal/util/pipeline/stream_pipeline.go
@@ -216,20 +216,22 @@ type MsgPackBatcher interface {
 }
 
 type dmlMsgPackBatcher struct {
-	maxPacks int
+	maxMsgNum func() int
 }
 
-func NewDMLMsgPackBatcher(maxPacks int) MsgPackBatcher {
-	return &dmlMsgPackBatcher{maxPacks: maxPacks}
+func NewDMLMsgPackBatcher(maxMsgNum func() int) MsgPackBatcher {
+	return &dmlMsgPackBatcher{maxMsgNum: maxMsgNum}
 }
 
 func (b *dmlMsgPackBatcher) Batch(first *msgstream.MsgPack, input <-chan *msgstream.MsgPack) (*msgstream.MsgPack, *msgstream.MsgPack) {
-	if b.maxPacks <= 1 || !isDMLMsgPack(first) {
+	maxMsgNum := b.getMaxMsgNum()
+	if maxMsgNum <= 1 || !isDMLMsgPack(first) {
 		return first, nil
 	}
 
 	packs := []*msgstream.MsgPack{first}
-	for len(packs) < b.maxPacks {
+	msgNum := len(first.Msgs)
+	for msgNum < maxMsgNum {
 		select {
 		case next, ok := <-input:
 			if !ok {
@@ -238,12 +240,23 @@ func (b *dmlMsgPackBatcher) Batch(first *msgstream.MsgPack, input <-chan *msgstr
 			if !isDMLMsgPack(next) {
 				return mergeMsgPacks(packs), next
 			}
+			if msgNum+len(next.Msgs) > maxMsgNum {
+				return mergeMsgPacks(packs), next
+			}
 			packs = append(packs, next)
+			msgNum += len(next.Msgs)
 		default:
 			return mergeMsgPacks(packs), nil
 		}
 	}
 	return mergeMsgPacks(packs), nil
+}
+
+func (b *dmlMsgPackBatcher) getMaxMsgNum() int {
+	if b.maxMsgNum == nil {
+		return 1
+	}
+	return b.maxMsgNum()
 }
 
 func isDMLMsgPack(pack *msgstream.MsgPack) bool {

--- a/internal/util/pipeline/stream_pipeline_test.go
+++ b/internal/util/pipeline/stream_pipeline_test.go
@@ -24,10 +24,12 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/internal/mocks/util/mock_pipeline"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgdispatcher"
 	"github.com/milvus-io/milvus/pkg/v2/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v2/util/commonpbutil"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
@@ -46,7 +48,7 @@ type StreamPipelineSuite struct {
 func (suite *StreamPipelineSuite) SetupTest() {
 	paramtable.Init()
 	suite.channel = "test-channel"
-	suite.inChannel = make(chan *msgstream.MsgPack, 1)
+	suite.inChannel = make(chan *msgstream.MsgPack, 4)
 	suite.outChannel = make(chan msgstream.Timestamp)
 	suite.msgDispatcher = msgdispatcher.NewMockClient(suite.T())
 	suite.msgDispatcher.EXPECT().Register(mock.Anything, mock.Anything).Return(suite.inChannel, nil)
@@ -81,6 +83,103 @@ func (suite *StreamPipelineSuite) TestBasic() {
 	}
 }
 
+func (suite *StreamPipelineSuite) TestDMLMsgPackBatcherMergesBufferedDMLPacks() {
+	suite.pipeline = NewPipelineWithStream(
+		suite.msgDispatcher,
+		0,
+		false,
+		suite.channel,
+		nil,
+		staticMVCCGetter{},
+		WithMsgPackBatcher(NewDMLMsgPackBatcher(8)),
+	)
+
+	received := make(chan *msgstream.MsgPack, 1)
+	suite.pipeline.Add(&captureMsgPackNode{
+		BaseNode:   NewBaseNode("capture-msg-pack", 8),
+		outChannel: received,
+	})
+
+	err := suite.pipeline.ConsumeMsgStream(context2.Background(), &msgpb.MsgPosition{})
+	suite.NoError(err)
+
+	suite.inChannel <- &msgstream.MsgPack{
+		BeginTs: 100,
+		EndTs:   110,
+		Msgs: []msgstream.TsMsg{
+			newInsertTsMsg(101),
+		},
+		StartPositions: []*msgpb.MsgPosition{{Timestamp: 100}},
+		EndPositions:   []*msgpb.MsgPosition{{Timestamp: 110}},
+	}
+	suite.inChannel <- &msgstream.MsgPack{
+		BeginTs: 111,
+		EndTs:   120,
+		Msgs: []msgstream.TsMsg{
+			newDeleteTsMsg(115),
+		},
+		StartPositions: []*msgpb.MsgPosition{{Timestamp: 111}},
+		EndPositions:   []*msgpb.MsgPosition{{Timestamp: 120}},
+	}
+
+	suite.pipeline.Start()
+	defer suite.pipeline.Close()
+
+	merged := <-received
+	suite.Equal(uint64(100), merged.BeginTs)
+	suite.Equal(uint64(120), merged.EndTs)
+	suite.Len(merged.Msgs, 2)
+	suite.Equal(uint64(101), merged.Msgs[0].EndTs())
+	suite.Equal(uint64(115), merged.Msgs[1].EndTs())
+	suite.Equal(uint64(100), merged.StartPositions[0].GetTimestamp())
+	suite.Equal(uint64(120), merged.EndPositions[0].GetTimestamp())
+	suite.Empty(received)
+}
+
 func TestStreamPipeline(t *testing.T) {
 	suite.Run(t, new(StreamPipelineSuite))
+}
+
+type staticMVCCGetter struct{}
+
+func (staticMVCCGetter) GetLatestRequiredMVCCTimeTick() uint64 {
+	return 0
+}
+
+type captureMsgPackNode struct {
+	*BaseNode
+	outChannel chan *msgstream.MsgPack
+}
+
+func (node *captureMsgPackNode) Operate(in Msg) Msg {
+	node.outChannel <- in.(*msgstream.MsgPack)
+	return nil
+}
+
+func newInsertTsMsg(ts uint64) *msgstream.InsertMsg {
+	msg := &msgstream.InsertMsg{
+		BaseMsg: msgstream.BaseMsg{},
+		InsertRequest: &msgpb.InsertRequest{
+			Base: commonpbutil.NewMsgBase(
+				commonpbutil.WithMsgType(commonpb.MsgType_Insert),
+				commonpbutil.WithTimeStamp(ts),
+			),
+		},
+	}
+	msg.SetTs(ts)
+	return msg
+}
+
+func newDeleteTsMsg(ts uint64) *msgstream.DeleteMsg {
+	msg := &msgstream.DeleteMsg{
+		BaseMsg: msgstream.BaseMsg{},
+		DeleteRequest: &msgpb.DeleteRequest{
+			Base: commonpbutil.NewMsgBase(
+				commonpbutil.WithMsgType(commonpb.MsgType_Delete),
+				commonpbutil.WithTimeStamp(ts),
+			),
+		},
+	}
+	msg.SetTs(ts)
+	return msg
 }

--- a/internal/util/pipeline/stream_pipeline_test.go
+++ b/internal/util/pipeline/stream_pipeline_test.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
@@ -91,7 +93,7 @@ func (suite *StreamPipelineSuite) TestDMLMsgPackBatcherMergesBufferedDMLPacks() 
 		suite.channel,
 		nil,
 		staticMVCCGetter{},
-		WithMsgPackBatcher(NewDMLMsgPackBatcher(8)),
+		WithMsgPackBatcher(NewDMLMsgPackBatcher(func() int { return 8 })),
 	)
 
 	received := make(chan *msgstream.MsgPack, 1)
@@ -136,6 +138,44 @@ func (suite *StreamPipelineSuite) TestDMLMsgPackBatcherMergesBufferedDMLPacks() 
 	suite.Empty(received)
 }
 
+func TestDMLMsgPackBatcherLimitsByTotalMessageNum(t *testing.T) {
+	maxMsgNum := 3
+	batcher := NewDMLMsgPackBatcher(func() int { return maxMsgNum })
+	input := make(chan *msgstream.MsgPack, 1)
+	input <- newDMLMsgPack(110, 120, newInsertTsMsg(111), newDeleteTsMsg(112))
+
+	merged, pending := batcher.Batch(newDMLMsgPack(100, 109, newInsertTsMsg(101)), input)
+
+	require.NotNil(t, merged)
+	assert.Len(t, merged.Msgs, 3)
+	assert.Equal(t, uint64(100), merged.BeginTs)
+	assert.Equal(t, uint64(120), merged.EndTs)
+	assert.Nil(t, pending)
+
+	maxMsgNum = 2
+	input = make(chan *msgstream.MsgPack, 1)
+	input <- newDMLMsgPack(211, 220, newDeleteTsMsg(211))
+	merged, pending = batcher.Batch(newDMLMsgPack(200, 210, newInsertTsMsg(201)), input)
+
+	require.NotNil(t, merged)
+	assert.Len(t, merged.Msgs, 2)
+	assert.Equal(t, uint64(200), merged.BeginTs)
+	assert.Equal(t, uint64(220), merged.EndTs)
+	assert.Nil(t, pending)
+
+	input = make(chan *msgstream.MsgPack, 1)
+	input <- newDMLMsgPack(311, 320, newDeleteTsMsg(311), newInsertTsMsg(312))
+	merged, pending = batcher.Batch(newDMLMsgPack(300, 310, newInsertTsMsg(301)), input)
+
+	require.NotNil(t, merged)
+	assert.Len(t, merged.Msgs, 1)
+	assert.Equal(t, uint64(300), merged.BeginTs)
+	assert.Equal(t, uint64(310), merged.EndTs)
+	require.NotNil(t, pending)
+	assert.Len(t, pending.Msgs, 2)
+	assert.Equal(t, uint64(311), pending.BeginTs)
+}
+
 func TestStreamPipeline(t *testing.T) {
 	suite.Run(t, new(StreamPipelineSuite))
 }
@@ -154,6 +194,16 @@ type captureMsgPackNode struct {
 func (node *captureMsgPackNode) Operate(in Msg) Msg {
 	node.outChannel <- in.(*msgstream.MsgPack)
 	return nil
+}
+
+func newDMLMsgPack(beginTs, endTs uint64, msgs ...msgstream.TsMsg) *msgstream.MsgPack {
+	return &msgstream.MsgPack{
+		BeginTs:        beginTs,
+		EndTs:          endTs,
+		Msgs:           msgs,
+		StartPositions: []*msgpb.MsgPosition{{Timestamp: beginTs}},
+		EndPositions:   []*msgpb.MsgPosition{{Timestamp: endTs}},
+	}
 }
 
 func newInsertTsMsg(ts uint64) *msgstream.InsertMsg {

--- a/internal/util/pipeline/stream_pipeline_test.go
+++ b/internal/util/pipeline/stream_pipeline_test.go
@@ -56,7 +56,7 @@ func (suite *StreamPipelineSuite) SetupTest() {
 	suite.msgDispatcher.EXPECT().Register(mock.Anything, mock.Anything).Return(suite.inChannel, nil)
 	suite.msgDispatcher.EXPECT().Deregister(suite.channel)
 	getter := mock_pipeline.NewMockLastestMVCCTimeTickGetter(suite.T())
-	getter.EXPECT().GetLatestRequiredMVCCTimeTick().Return(0)
+	getter.EXPECT().GetLatestRequiredMVCCTimeTick().Return(0).Maybe()
 	suite.pipeline = NewPipelineWithStream(suite.msgDispatcher, 0, false, suite.channel, nil, getter)
 	suite.length = 4
 }

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3676,7 +3676,7 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 
 	p.DMLMicroBatchMaxMsgNum = ParamItem{
 		Key:          "queryNode.dataSync.dmlMicroBatch.maxMsgNum",
-		Version:      "2.6.0",
+		Version:      "2.6.20",
 		DefaultValue: "8",
 		Doc:          "Maximum number of DML messages in one micro-batch drained by query node data sync pipeline. The batcher only drains already buffered messages and does not wait for more messages.",
 		Export:       true,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3676,7 +3676,7 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 
 	p.DMLMicroBatchMaxMsgNum = ParamItem{
 		Key:          "queryNode.dataSync.dmlMicroBatch.maxMsgNum",
-		Version:      "3.0.0",
+		Version:      "2.6.0",
 		DefaultValue: "8",
 		Doc:          "Maximum number of DML messages in one micro-batch drained by query node data sync pipeline. The batcher only drains already buffered messages and does not wait for more messages.",
 		Export:       true,

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -3579,6 +3579,7 @@ type queryNodeConfig struct {
 	CleanExcludeSegInterval ParamItem `refreshable:"false"`
 	FlowGraphMaxQueueLength ParamItem `refreshable:"false"`
 	FlowGraphMaxParallelism ParamItem `refreshable:"false"`
+	DMLMicroBatchMaxMsgNum  ParamItem `refreshable:"true"`
 
 	MemoryIndexLoadPredictMemoryUsageFactor ParamItem `refreshable:"true"`
 	EnableSegmentPrune                      ParamItem `refreshable:"true"`
@@ -3672,6 +3673,15 @@ func (p *queryNodeConfig) init(base *BaseTable) {
 		Export:       true,
 	}
 	p.FlowGraphMaxParallelism.Init(base.mgr)
+
+	p.DMLMicroBatchMaxMsgNum = ParamItem{
+		Key:          "queryNode.dataSync.dmlMicroBatch.maxMsgNum",
+		Version:      "3.0.0",
+		DefaultValue: "8",
+		Doc:          "Maximum number of DML messages in one micro-batch drained by query node data sync pipeline. The batcher only drains already buffered messages and does not wait for more messages.",
+		Export:       true,
+	}
+	p.DMLMicroBatchMaxMsgNum.Init(base.mgr)
 
 	p.StatsPublishInterval = ParamItem{
 		Key:          "queryNode.stats.publishInterval",

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -448,6 +448,11 @@ func TestComponentParam(t *testing.T) {
 		length := Params.FlowGraphMaxQueueLength.GetAsInt32()
 		assert.Equal(t, int32(16), length)
 
+		assert.Equal(t, 8, Params.DMLMicroBatchMaxMsgNum.GetAsInt())
+		params.Save(Params.DMLMicroBatchMaxMsgNum.Key, "4")
+		assert.Equal(t, 4, Params.DMLMicroBatchMaxMsgNum.GetAsInt())
+		params.Reset(Params.DMLMicroBatchMaxMsgNum.Key)
+
 		maxParallelism := Params.FlowGraphMaxParallelism.GetAsInt32()
 		assert.Equal(t, int32(1024), maxParallelism)
 


### PR DESCRIPTION
issue: #50121
pr: #50531

- querynode pipeline: batch already-buffered DML MsgPacks before delegator processing with a configurable max message count
- delegator delete path: preserve delete EndTs buckets and process delete batches through the delete buffer and streaming forward path
- configuration: add queryNode.dataSync.dmlMicroBatch.maxMsgNum with default 8 for 2.6.20