### PR TITLE
test: cover woodpecker WAL truncate/retention read semantics

### DIFF
--- a/pkg/streaming/walimpls/impls/wp/wp_test.go
+++ b/pkg/streaming/walimpls/impls/wp/wp_test.go
@@ -157,6 +157,15 @@ func TestWpRetentionTruncateRead(t *testing.T) {
 	// (woodpecker rolls by flushed byte size, not timing), so the seek-forward sub-tests
 	// can reach both the within-segment and cross-segment adjustment branches.
 	require.NoError(t, pt.Save(pt.WoodpeckerCfg.SegmentRollingMaxSize.Key, "4096"))
+	// Restore the globals we mutated so this test does not leak config into others
+	// (e.g. under -shuffle=on, or a test added after this one): a stale 4KB rolling /
+	// local-storage config and a RootPath pointing at an already-deleted t.TempDir().
+	t.Cleanup(func() {
+		pt.Reset(pt.WoodpeckerCfg.RetentionTTL.Key)
+		pt.Reset(pt.WoodpeckerCfg.StorageType.Key)
+		pt.Reset(pt.WoodpeckerCfg.RootPath.Key)
+		pt.Reset(pt.WoodpeckerCfg.SegmentRollingMaxSize.Key)
+	})
 
 	o, err := (&builderImpl{}).Build()
 	require.NoError(t, err)
@@ -324,7 +333,7 @@ func readExpectWpIDs(t *testing.T, ctx context.Context, w walimpls.WALImpls, nam
 		case msg, ok := <-s.Chan():
 			require.Truef(t, ok, "%s: scanner channel closed early at message %d/%d", name, i, len(expected))
 			require.NotNil(t, msg)
-			assert.Truef(t, msg.MessageID().EQ(want), "%s: message %d/%d got %v want %v", name, i, len(expected), msg.MessageID(), want)
+			require.Truef(t, msg.MessageID().EQ(want), "%s: message %d/%d got %v want %v", name, i, len(expected), msg.MessageID(), want)
 		case <-time.After(30 * time.Second):
 			t.Fatalf("%s: timed out waiting for message %d/%d", name, i, len(expected))
 		}
@@ -347,6 +356,10 @@ func assertWpNoMessage(t *testing.T, ctx context.Context, w walimpls.WALImpls, n
 		if ok {
 			t.Fatalf("%s: expected no message but got %v", name, msg.MessageID())
 		}
+		// ok == false means the scanner channel was closed, i.e. the scanner goroutine
+		// finished/errored rather than staying parked. Fail here too, otherwise a dead
+		// scanner would masquerade as the intended "parked reader delivers nothing".
+		t.Fatalf("%s: scanner channel closed; expected a parked reader, not a finished/errored scanner", name)
 	case <-time.After(d):
 	}
 }

--- a/pkg/streaming/walimpls/impls/wp/wp_test.go
+++ b/pkg/streaming/walimpls/impls/wp/wp_test.go
@@ -1,17 +1,24 @@
 package wp
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zilliztech/woodpecker/common/config"
 	"github.com/zilliztech/woodpecker/tests/utils"
 	"github.com/zilliztech/woodpecker/woodpecker"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/options"
+	"github.com/milvus-io/milvus/pkg/v3/streaming/util/types"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/walimpls/registry"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -113,5 +120,233 @@ func TestWAL(t *testing.T) {
 			// run test
 			walimpls.NewWALImplsTestFramework(t, 100, &builderImpl{}).Run()
 		})
+	}
+}
+
+// TestWpRetentionTruncateRead verifies the read semantics around woodpecker truncation.
+//
+// Milvus truncates the WAL aggressively (right after a flush), but truncation only
+// moves a metadata watermark -- it does NOT delete data. Data below the watermark
+// stays readable until the retention TTL GC physically removes it. This test pins that
+// with a large retention (so the GC path never fires) plus a small segment-rolling size
+// (so writes span several woodpecker segments), and covers:
+//
+//	TruncatedDataStillReadable: after truncating to the latest id `b`, reading from any
+//	  explicit position in (earliest, b] -- across segment boundaries -- still returns
+//	  every message; truncation erased nothing.
+//	SeekForwardWithinSegment / SeekForwardCrossSegment: a reader that asks for data older
+//	  than the earliest deliverable position (DeliverPolicy_All after truncation) is moved
+//	  forward to the first available position instead of erroring or stalling. The two
+//	  sub-tests exercise both branches of adjustPendingReadPointIfTruncated -- a
+//	  truncation point inside segment 0 vs. one in a later segment.
+//
+// One opener is shared by all sub-tests (rolling size is read once at Build time), so the
+// test builds the embed LogStore exactly once.
+func TestWpRetentionTruncateRead(t *testing.T) {
+	ctx := context.Background()
+	pt := paramtable.Get()
+
+	// Large retention so nothing is GC'd during the test: this isolates the "truncate
+	// moves a watermark, it does not delete data" behavior from the separate retention-TTL
+	// GC path. Local fs storage keeps it fast and dependency-light; the truncate/read-
+	// adjust logic lives in woodpecker's log handle/reader and is storage-backend agnostic.
+	require.NoError(t, pt.Save(pt.WoodpeckerCfg.RetentionTTL.Key, "72h"))
+	require.NoError(t, pt.Save(pt.WoodpeckerCfg.StorageType.Key, "local"))
+	require.NoError(t, pt.Save(pt.WoodpeckerCfg.RootPath.Key, filepath.Join(t.TempDir(), "wp_ret_trunc")))
+	// Small rolling size + padded messages => a new segment every few messages
+	// (woodpecker rolls by flushed byte size, not timing), so the seek-forward sub-tests
+	// can reach both the within-segment and cross-segment adjustment branches.
+	require.NoError(t, pt.Save(pt.WoodpeckerCfg.SegmentRollingMaxSize.Key, "4096"))
+
+	o, err := (&builderImpl{}).Build()
+	require.NoError(t, err)
+	require.NotNil(t, o)
+	defer func() {
+		o.Close()
+		// stop embed LogStore singleton (local/minio mode), mirroring TestWAL.
+		assert.NoError(t, woodpecker.StopEmbedLogStore(), "close embed LogStore instance error")
+	}()
+
+	const (
+		msgCount = 30
+		padBytes = 1024 // with maxSize=4096 => ~3 messages per segment
+	)
+	segOf := func(id message.MessageID) int64 { return id.(wpID).WoodpeckerID().SegmentId }
+
+	// Behavior 1: data at/under the truncation watermark is still readable while it has
+	// not been GC'd. Truncate to the latest id, then read from several explicit positions
+	// in (earliest, latest] -- spanning segment boundaries -- and confirm every message
+	// comes back.
+	t.Run("TruncatedDataStillReadable", func(t *testing.T) {
+		w := openWpRWWAL(t, ctx, o, uniqueWpPChannel("ret_trunc_b1"))
+		defer w.Close()
+		ids := appendWpSeq(t, ctx, w, msgCount, padBytes)
+		require.Greaterf(t, segOf(ids[msgCount-1]), int64(0),
+			"expected writes to span >=2 segments, but last id is in segment %d", segOf(ids[msgCount-1]))
+
+		// b = latest. Truncate is inclusive, so the whole WAL is at/under the watermark.
+		require.NoError(t, w.Truncate(ctx, ids[msgCount-1]))
+
+		// k=0 is intentionally skipped: ids[0] == EarliestLogMessageID() ({0,0}), which
+		// woodpecker treats like DeliverPolicy_All and would adjust past the watermark.
+		// Every other StartFrom position is read verbatim (not adjusted), across segments,
+		// including the watermark id itself (k=msgCount-1).
+		for _, k := range []int{1, msgCount / 2, msgCount - 1} {
+			readExpectWpIDs(t, ctx, w, fmt.Sprintf("b1_startfrom_%d", k),
+				options.DeliverPolicyStartFrom(ids[k]), ids[k:])
+		}
+
+		// StartAfter(k) delivers ids[k+1:].
+		k := msgCount / 2
+		readExpectWpIDs(t, ctx, w, "b1_startafter",
+			options.DeliverPolicyStartAfter(ids[k]), ids[k+1:])
+
+		// Contrast that proves the truncate actually moved the watermark (and that this
+		// sub-test is not just reading an un-truncated WAL): DeliverPolicy_All starts at
+		// EarliestLogMessageID() and is adjusted past the watermark (= the latest id
+		// here), so a fresh "all" reader is parked at the end and sees nothing -- while
+		// the explicit StartFrom reads above still return everything below the watermark.
+		assertWpNoMessage(t, ctx, w, "b1_all_parked_after_truncate",
+			options.DeliverPolicyAll(), 2*time.Second)
+	})
+
+	// Behavior 2a (within-segment): the truncation point is in segment 0, so the open-time
+	// adjustment only bumps the entry id (truncatedEntryId+1) inside that same segment.
+	// A DeliverPolicy_All reader resumes at ids[j+1] instead of erroring or stalling.
+	t.Run("SeekForwardWithinSegment", func(t *testing.T) {
+		w := openWpRWWAL(t, ctx, o, uniqueWpPChannel("ret_trunc_b2a"))
+		defer w.Close()
+		ids := appendWpSeq(t, ctx, w, msgCount, padBytes)
+
+		// Truncate at the last message still in segment 0, ensuring data after it lives in
+		// a later segment.
+		j := 0
+		for j+1 < msgCount && segOf(ids[j+1]) == 0 {
+			j++
+		}
+		require.Equalf(t, int64(0), segOf(ids[j]), "truncation point ids[%d] must be in segment 0", j)
+		require.Lessf(t, j, msgCount-1, "need data after the truncation point ids[%d]", j)
+
+		require.NoError(t, w.Truncate(ctx, ids[j]))
+		readExpectWpIDs(t, ctx, w, "b2a_all_seek_forward",
+			options.DeliverPolicyAll(), ids[j+1:])
+	})
+
+	// Behavior 2b (cross-segment): the truncation point is in a later segment, so the
+	// open-time adjustment first jumps the segment id up to the truncation segment (the
+	// branch a single-segment WAL can never reach), then to truncatedEntryId+1. The
+	// precondition asserts the truncation point really is in segment > 0, so this coverage
+	// cannot silently rot if message sizes change.
+	t.Run("SeekForwardCrossSegment", func(t *testing.T) {
+		w := openWpRWWAL(t, ctx, o, uniqueWpPChannel("ret_trunc_b2b"))
+		defer w.Close()
+		ids := appendWpSeq(t, ctx, w, msgCount, padBytes)
+
+		// Pick a middle truncation point that lies in a segment > 0.
+		j := msgCount / 2
+		for j < msgCount-1 && segOf(ids[j]) == 0 {
+			j++
+		}
+		require.Greaterf(t, segOf(ids[j]), int64(0),
+			"truncation point ids[%d] must be in segment >0 to hit the cross-segment branch", j)
+		require.Lessf(t, j, msgCount-1, "need data after the truncation point ids[%d]", j)
+
+		require.NoError(t, w.Truncate(ctx, ids[j]))
+		// DeliverPolicy_All resumes exactly at ids[j+1] (via the cross-segment branch) and
+		// streams to the end.
+		readExpectWpIDs(t, ctx, w, "b2b_all_seek_forward",
+			options.DeliverPolicyAll(), ids[j+1:])
+		// A cross-segment StartFrom also returns truncated-but-present data from the
+		// truncation point through the remaining segments.
+		readExpectWpIDs(t, ctx, w, "b2b_startfrom",
+			options.DeliverPolicyStartFrom(ids[j]), ids[j:])
+	})
+}
+
+// uniqueWpPChannel returns a collision-free pchannel name so each run uses a fresh
+// woodpecker log: log names persist in etcd metadata, and reusing one would read stale
+// data from a previous run.
+func uniqueWpPChannel(prefix string) string {
+	return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+}
+
+// openWpRWWAL opens a read-write WAL on a fresh pchannel.
+func openWpRWWAL(t *testing.T, ctx context.Context, o walimpls.OpenerImpls, name string) walimpls.WALImpls {
+	w, err := o.Open(ctx, &walimpls.OpenOption{
+		Channel: types.PChannelInfo{
+			Name:       name,
+			Term:       1,
+			AccessMode: types.AccessModeRW,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	return w
+}
+
+// appendWpSeq appends n messages sequentially and returns their ids in append order.
+// A single-threaded writer gets strictly increasing woodpecker ids, so the returned
+// slice is sorted and equals the order a reader will deliver them. padBytes adds a
+// padding property of that size to each message: callers use it together with a small
+// SegmentRollingMaxSize to deterministically roll multiple woodpecker segments.
+func appendWpSeq(t *testing.T, ctx context.Context, w walimpls.WALImpls, n, padBytes int) []message.MessageID {
+	ids := make([]message.MessageID, 0, n)
+	for i := 0; i < n; i++ {
+		props := map[string]string{}
+		if padBytes > 0 {
+			props["pad"] = strings.Repeat("x", padBytes)
+		}
+		id, err := w.Append(ctx, message.CreateTestEmptyInsertMesage(int64(i), props))
+		require.NoError(t, err)
+		require.NotNil(t, id)
+		ids = append(ids, id)
+	}
+	for i := 1; i < len(ids); i++ {
+		require.Truef(t, ids[i-1].LT(ids[i]), "woodpecker ids must be monotonically increasing: %v !< %v", ids[i-1], ids[i])
+	}
+	return ids
+}
+
+// readExpectWpIDs opens a scanner with the given policy and asserts it delivers exactly
+// expected (in order), then closes it. It reads precisely len(expected) messages rather
+// than waiting for channel close, because a wp scanner is a tail reader that blocks
+// after the last available message.
+func readExpectWpIDs(t *testing.T, ctx context.Context, w walimpls.WALImpls, name string, policy options.DeliverPolicy, expected []message.MessageID) {
+	s, err := w.Read(ctx, walimpls.ReadOption{
+		Name:          name,
+		DeliverPolicy: policy,
+	})
+	require.NoError(t, err)
+	defer s.Close()
+
+	for i, want := range expected {
+		select {
+		case msg, ok := <-s.Chan():
+			require.Truef(t, ok, "%s: scanner channel closed early at message %d/%d", name, i, len(expected))
+			require.NotNil(t, msg)
+			assert.Truef(t, msg.MessageID().EQ(want), "%s: message %d/%d got %v want %v", name, i, len(expected), msg.MessageID(), want)
+		case <-time.After(30 * time.Second):
+			t.Fatalf("%s: timed out waiting for message %d/%d", name, i, len(expected))
+		}
+	}
+}
+
+// assertWpNoMessage opens a scanner with the given policy and asserts that no message is
+// delivered within d. Used to show a reader is parked past all available data (e.g. a
+// DeliverPolicy_All reader after the WAL was truncated up to its latest id).
+func assertWpNoMessage(t *testing.T, ctx context.Context, w walimpls.WALImpls, name string, policy options.DeliverPolicy, d time.Duration) {
+	s, err := w.Read(ctx, walimpls.ReadOption{
+		Name:          name,
+		DeliverPolicy: policy,
+	})
+	require.NoError(t, err)
+	defer s.Close()
+
+	select {
+	case msg, ok := <-s.Chan():
+		if ok {
+			t.Fatalf("%s: expected no message but got %v", name, msg.MessageID())
+		}
+	case <-time.After(d):
 	}
 }


### PR DESCRIPTION
## What this PR does

Adds an integration test (`TestWpRetentionTruncateRead`) for the Woodpecker (wp)
WAL implementation pinning the read semantics around truncation that Milvus
relies on but had no explicit coverage for.

Milvus truncates the wp WAL aggressively right after a flush, but truncation
only moves a metadata watermark — it does **not** delete data. Data at/under the
watermark stays readable until the retention-TTL GC physically removes it. The
test pins this with three sub-cases:

1. **TruncatedDataStillReadable** — after truncating to the latest id, an
   explicit `StartFrom` at any position in `(earliest, latest]` (spanning
   segment boundaries) still returns every message, including the watermark id
   itself. As a contrast, a fresh `DeliverPolicy_All` reader is parked past the
   watermark and returns nothing — proving the watermark really moved while the
   data underneath is intact.
2. **SeekForwardWithinSegment** / **SeekForwardCrossSegment** — a reader asking
   for data older than the earliest deliverable position (`DeliverPolicy_All`
   after truncation) is moved forward to the first available position instead of
   erroring or stalling. The two sub-cases exercise both branches of
   `adjustPendingReadPointIfTruncated`: a truncation point inside segment 0
   (within-segment) vs. in a later segment (cross-segment id jump).

## Notes

- **Deterministic by design**: large retention (`72h`) so GC never fires, a
  small `segmentRollingPolicy.maxSize` so writes span several segments,
  single-threaded writes so ids are monotonic, and all assertions are
  message-id based. Run logs confirm each sub-case hits its intended adjustment
  branch (`truncatedSegmentId` 0 vs >0).
- **Scope**: covers the open-time read-position adjustment after truncation. It
  does NOT exercise the physical retention-TTL GC + runtime skip-forward path —
  that needs waiting for the async GC sweep and is intentionally left out to
  keep the test deterministic.
- Runs against local fs storage; the truncate/read logic under test lives in the
  woodpecker log handle/reader and is storage-backend agnostic.

issue: #43638
