### PR TITLE
fix: handle unaligned mmap-backed Arrow buffers

### DIFF
--- a/internal/core/src/segcore/segment_c.cpp
+++ b/internal/core/src/segcore/segment_c.cpp
@@ -17,6 +17,7 @@
 #include <folly/Try.h>
 #include <folly/futures/Promise.h>
 #include <cstring>
+#include <cstdint>
 #include <exception>
 #include <functional>
 #include <limits>
@@ -1162,6 +1163,55 @@ IsFixedWidthVectorDataType(milvus::DataType data_type) {
            data_type == milvus::DataType::VECTOR_INT8;
 }
 
+arrow::Result<int64_t>
+GetFixedWidthVectorValueAlignment(milvus::DataType data_type) {
+    switch (data_type) {
+        case milvus::DataType::VECTOR_FLOAT:
+            return alignof(float);
+        case milvus::DataType::VECTOR_BINARY:
+            return alignof(uint8_t);
+        case milvus::DataType::VECTOR_FLOAT16:
+            return alignof(milvus::float16);
+        case milvus::DataType::VECTOR_BFLOAT16:
+            return alignof(milvus::bfloat16);
+        case milvus::DataType::VECTOR_INT8:
+            return alignof(milvus::int8);
+        default:
+            return arrow::Status::Invalid(fmt::format(
+                "unsupported fixed-width vector data type {}", data_type));
+    }
+}
+
+bool
+IsBufferAligned(const void* data, int64_t alignment) {
+    if (data == nullptr || alignment <= 1) {
+        return true;
+    }
+    return reinterpret_cast<std::uintptr_t>(data) %
+               static_cast<std::uintptr_t>(alignment) ==
+           0;
+}
+
+arrow::Result<std::shared_ptr<arrow::Buffer>>
+WrapOrCopyArrowBuffer(const void* data, int64_t size, int64_t alignment) {
+    if (size < 0) {
+        return arrow::Status::Invalid("negative Arrow buffer size");
+    }
+    if (data == nullptr && size > 0) {
+        return arrow::Status::Invalid("null Arrow buffer data");
+    }
+    auto raw_data = static_cast<const uint8_t*>(data);
+    if (IsBufferAligned(data, alignment)) {
+        return arrow::Buffer::Wrap(raw_data, size);
+    }
+
+    ARROW_ASSIGN_OR_RAISE(auto copied_buffer, arrow::AllocateBuffer(size));
+    if (size > 0) {
+        std::memcpy(copied_buffer->mutable_data(), raw_data, size);
+    }
+    return std::shared_ptr<arrow::Buffer>(std::move(copied_buffer));
+}
+
 const uint8_t*
 GetPhysicalVectorValue(const milvus::segcore::VectorBase* vec_base,
                        int64_t physical_offset,
@@ -1182,7 +1232,8 @@ arrow::Result<std::shared_ptr<arrow::Array>>
 BuildNullableFixedWidthVectorArray(const FieldInfo& field_info,
                                    int64_t start_offset,
                                    int64_t num_rows,
-                                   int64_t byte_width) {
+                                   int64_t byte_width,
+                                   int64_t data_alignment) {
     if (!field_info.valid_data) {
         return arrow::Status::Invalid(
             "nullable vector field missing ValidData");
@@ -1220,8 +1271,10 @@ BuildNullableFixedWidthVectorArray(const FieldInfo& field_info,
             }
             std::shared_ptr<arrow::Buffer> offsets_buffer_shared(
                 std::move(offsets_buffer));
-            auto data_buffer =
-                arrow::Buffer::Wrap(value, num_rows * byte_width);
+            ARROW_ASSIGN_OR_RAISE(
+                auto data_buffer,
+                WrapOrCopyArrowBuffer(
+                    value, num_rows * byte_width, data_alignment));
             return std::make_shared<arrow::BinaryArray>(
                 num_rows, offsets_buffer_shared, data_buffer, nullptr, 0);
         }
@@ -1302,9 +1355,10 @@ WrapChunkAsArrowArray(const void* chunk_data,
                       int64_t element_size,
                       const milvus::segcore::ThreadSafeValidDataPtr& valid_data,
                       int64_t validity_offset) {
-    // wrap data buffer (zero-copy)
-    auto data_buffer = arrow::Buffer::Wrap(
-        static_cast<const uint8_t*>(chunk_data), num_rows * element_size);
+    ARROW_ASSIGN_OR_RAISE(
+        auto data_buffer,
+        WrapOrCopyArrowBuffer(
+            chunk_data, num_rows * element_size, element_size));
 
     // build validity bitmap if needed
     std::shared_ptr<arrow::Buffer> null_bitmap = nullptr;
@@ -1338,12 +1392,14 @@ WrapChunkAsFixedSizeBinaryArray(
     const void* chunk_data,
     int64_t num_rows,
     int64_t byte_width,
+    int64_t data_alignment,
     const std::shared_ptr<arrow::DataType>& data_type,
     const milvus::segcore::ThreadSafeValidDataPtr& valid_data,
     int64_t validity_offset) {
-    // wrap data buffer (zero-copy)
-    auto data_buffer = arrow::Buffer::Wrap(
-        static_cast<const uint8_t*>(chunk_data), num_rows * byte_width);
+    ARROW_ASSIGN_OR_RAISE(
+        auto data_buffer,
+        WrapOrCopyArrowBuffer(
+            chunk_data, num_rows * byte_width, data_alignment));
 
     // build validity bitmap if needed
     std::shared_ptr<arrow::Buffer> null_bitmap = nullptr;
@@ -1692,15 +1748,22 @@ BuildArrayForChunk(const FieldInfo& field_info,
         case milvus::DataType::VECTOR_FLOAT16:
         case milvus::DataType::VECTOR_BFLOAT16:
         case milvus::DataType::VECTOR_INT8: {
+            ARROW_ASSIGN_OR_RAISE(
+                auto data_alignment,
+                GetFixedWidthVectorValueAlignment(field_info.data_type));
             if (field_info.nullable) {
-                return BuildNullableFixedWidthVectorArray(
-                    field_info, global_offset, num_rows, element_size);
+                return BuildNullableFixedWidthVectorArray(field_info,
+                                                          global_offset,
+                                                          num_rows,
+                                                          element_size,
+                                                          data_alignment);
             }
             auto arrow_type =
                 milvus::GetArrowDataType(field_info.data_type, field_info.dim);
             return WrapChunkAsFixedSizeBinaryArray(get_data_ptr(),
                                                    num_rows,
                                                    element_size,
+                                                   data_alignment,
                                                    arrow_type,
                                                    field_info.valid_data,
                                                    global_offset);

--- a/internal/core/src/storage/MmapChunkManager.cpp
+++ b/internal/core/src/storage/MmapChunkManager.cpp
@@ -16,6 +16,7 @@
 
 #include "storage/MmapChunkManager.h"
 
+#include <cstddef>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -36,6 +37,12 @@ namespace milvus::storage {
 namespace {
 static constexpr int kMmapDefaultProt = PROT_WRITE | PROT_READ;
 static constexpr int kMmapDefaultFlags = MAP_SHARED;
+static constexpr uint64_t kMmapAllocationAlignment = alignof(std::max_align_t);
+
+uint64_t
+AlignUp(uint64_t offset, uint64_t alignment) {
+    return ((offset + alignment - 1) / alignment) * alignment;
+}
 };  // namespace
 
 // todo(cqy): After confirming the append parallelism of multiple fields, adjust the lock granularity.
@@ -137,10 +144,13 @@ MmapBlock::Get(const uint64_t size) {
     AssertInfo(is_valid_,
                "Fail to get memory from invalid MmapBlock under file:{}.",
                file_name_);
-    if (file_size_ - offset_.load() < size) {
+    auto current_offset = offset_.load();
+    auto aligned_offset = AlignUp(current_offset, kMmapAllocationAlignment);
+    if (aligned_offset > file_size_ || file_size_ - aligned_offset < size) {
         return nullptr;
     } else {
-        return (void*)(addr_ + offset_.fetch_add(size));
+        offset_.store(aligned_offset + size);
+        return static_cast<void*>(addr_ + aligned_offset);
     }
 }
 

--- a/internal/core/src/storage/MmapChunkManagerTest.cpp
+++ b/internal/core/src/storage/MmapChunkManagerTest.cpp
@@ -9,6 +9,9 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <cstddef>
+#include <cstdint>
+
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
@@ -25,5 +28,22 @@ TEST(MmapChunkManager, Register) {
         milvus::storage::MmapManager::GetInstance().GetMmapChunkManager();
     auto segment_descriptor = mcm->Register();
     ASSERT_TRUE(mcm->HasRegister(segment_descriptor));
+    ASSERT_NO_THROW(mcm->UnRegister(segment_descriptor));
+}
+
+TEST(MmapChunkManager, AllocateKeepsTypedBuffersAligned) {
+    auto mcm =
+        milvus::storage::MmapManager::GetInstance().GetMmapChunkManager();
+    auto segment_descriptor = mcm->Register();
+
+    auto first = mcm->Allocate(segment_descriptor, 1);
+    ASSERT_NE(first, nullptr);
+
+    auto typed_buffer = mcm->Allocate(segment_descriptor, sizeof(double));
+    ASSERT_NE(typed_buffer, nullptr);
+    ASSERT_EQ(
+        reinterpret_cast<uintptr_t>(typed_buffer) % alignof(std::max_align_t),
+        0);
+
     ASSERT_NO_THROW(mcm->UnRegister(segment_descriptor));
 }


### PR DESCRIPTION
issue: #50884 
Align mmap allocations to max_align_t and copy fixed-width Arrow buffers when source memory is not aligned for the element type.

Add coverage for mmap allocation alignment.