### PR TITLE
fix: [cp 2.6] adjust query node NQ grouping defaults

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -574,8 +574,8 @@ queryNode:
       enableCrossUserGrouping: false # Enable Cross user grouping when using user-task-polling policy. (Disable it if user's task can not merge each other)
       maxPendingTaskPerUser: 1024 # Max pending task per user in scheduler
   grouping:
-    maxNQ: 16
-    nqMergeRatio: 3 # Maximum ratio between merged total NQ and the smaller task NQ when grouping query node read tasks.
+    maxNQ: 64
+    nqMergeRatio: 16 # Maximum ratio between merged total NQ and the smaller task NQ when grouping query node read tasks.
     maxDeadlineMergeGap: 50ms # Maximum allowed gap between task context deadlines when grouping query node read tasks. Tasks with only one deadline cannot be grouped. Set a negative duration to disable this check.
     topKMergeRatio: 20
   search:

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -4447,7 +4447,7 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 	p.MaxGroupNQ = ParamItem{
 		Key:          "queryNode.grouping.maxNQ",
 		Version:      "2.0.0",
-		DefaultValue: "16",
+		DefaultValue: "64",
 		Export:       true,
 	}
 	p.MaxGroupNQ.Init(base.mgr)
@@ -4455,7 +4455,7 @@ Max read concurrency must greater than or equal to 1, and less than or equal to 
 	p.NQMergeRatio = ParamItem{
 		Key:          "queryNode.grouping.nqMergeRatio",
 		Version:      "2.6.17",
-		DefaultValue: "3.0",
+		DefaultValue: "16.0",
 		Doc:          "Maximum ratio between merged total NQ and the smaller task NQ when grouping query node read tasks.",
 		Export:       true,
 	}

--- a/pkg/util/paramtable/component_param_test.go
+++ b/pkg/util/paramtable/component_param_test.go
@@ -463,8 +463,9 @@ func TestComponentParam(t *testing.T) {
 
 		assert.Equal(t, int32(1024), Params.MaxUnsolvedQueueSize.GetAsInt32())
 		assert.Equal(t, "1024", Params.MaxUnsolvedQueueSize.DefaultValue)
-		assert.Equal(t, int64(16), Params.MaxGroupNQ.GetAsInt64())
-		assert.Equal(t, 3.0, Params.NQMergeRatio.GetAsFloat())
+		assert.Equal(t, int64(64), Params.MaxGroupNQ.GetAsInt64())
+		assert.Equal(t, 16.0, Params.NQMergeRatio.GetAsFloat())
+		assert.Equal(t, 20.0, Params.TopKMergeRatio.GetAsFloat())
 		assert.Equal(t, 50*time.Millisecond, Params.MaxDeadlineMergeGap.GetAsDurationByParse())
 		defer params.Reset(Params.MaxDeadlineMergeGap.Key)
 		assert.NoError(t, params.Save(Params.MaxDeadlineMergeGap.Key, "100ms"))


### PR DESCRIPTION
issue: #50896
pr: #50897

- query node scheduler: raise NQ grouping defaults to allow larger merged query batches
- paramtable: align built-in and YAML defaults and cover the values in default config tests