### PR TITLE
enhance: [2.6] shard active future manager and fix metric aggregation

### DIFF
--- a/internal/util/cgo/futures.go
+++ b/internal/util/cgo/futures.go
@@ -98,8 +98,9 @@ func Async(ctx context.Context, f CGOAsyncFunction, opts ...Opt) Future {
 		state:     newFutureState(),
 	}
 
-	// register the future to do timeout notification.
-	futureManager.Register(future)
+	// register the future to do timeout notification (round-robin across shards).
+	idx := registerSeq.Inc() % managerCount
+	futureManagers[idx].Register(future)
 	return future
 }
 

--- a/internal/util/cgo/futures_test.go
+++ b/internal/util/cgo/futures_test.go
@@ -297,9 +297,12 @@ func TestConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 	assert.Eventually(t, func() bool {
-		stat := futureManager.Stat()
-		fmt.Printf("active count: %d\n", stat.ActiveCount)
-		return stat.ActiveCount == 0
+		totalActive := int64(0)
+		for _, m := range futureManagers {
+			totalActive += m.Stat().ActiveCount
+		}
+		fmt.Printf("active count: %d\n", totalActive)
+		return totalActive == 0
 	}, 5*time.Second, 100*time.Millisecond)
 	runtime.GC()
 }

--- a/internal/util/cgo/manager_active.go
+++ b/internal/util/cgo/manager_active.go
@@ -7,18 +7,22 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
 const (
 	registerIndex      = 0
 	maxSelectCase      = 65535
-	defaultRegisterBuf = 1
+	defaultRegisterBuf = 256 // Chosen from benchmark A/B runs as the best overall default for current workloads.
+	coresPerShard      = 32
 )
 
 var (
-	futureManager *activeFutureManager
-	initOnce      sync.Once
+	futureManagers []*activeFutureManager
+	managerCount   uint64
+	registerSeq    atomic.Uint64
+	initOnce       sync.Once
 )
 
 // initCGO initializes the cgo caller and future manager.
@@ -27,8 +31,17 @@ func initCGO() {
 		nodeID := paramtable.GetStringNodeID()
 		initCaller(nodeID)
 		initExecutor()
-		futureManager = newActiveFutureManager(nodeID)
-		futureManager.Run()
+
+		numShards := hardware.GetCPUNum() / coresPerShard
+		if numShards < 1 {
+			numShards = 1
+		}
+		managerCount = uint64(numShards)
+		futureManagers = make([]*activeFutureManager, numShards)
+		for i := 0; i < numShards; i++ {
+			futureManagers[i] = newActiveFutureManager(nodeID)
+			futureManagers[i].Run()
+		}
 	})
 }
 
@@ -92,18 +105,21 @@ func (m *activeFutureManager) doSelect() {
 			Chan: reflect.ValueOf(newCancelable.Context().Done()),
 		})
 		m.activeFutures = append(m.activeFutures, newCancelable)
+		metrics.ActiveFutureTotal.WithLabelValues(
+			m.nodeID,
+		).Inc()
 	} else {
 		m.cases = append(m.cases[:index], m.cases[index+1:]...)
 		offset := index - 1
 		// cancel the future and move it into gc manager.
 		m.activeFutures[offset].cancel(m.activeFutures[offset].Context().Err())
 		m.activeFutures = append(m.activeFutures[:offset], m.activeFutures[offset+1:]...)
+		metrics.ActiveFutureTotal.WithLabelValues(
+			m.nodeID,
+		).Dec()
 	}
 	activeTotal := len(m.activeFutures)
 	m.activeCount.Store(int64(activeTotal))
-	metrics.ActiveFutureTotal.WithLabelValues(
-		m.nodeID,
-	).Set(float64(activeTotal))
 }
 
 func (m *activeFutureManager) getSelectableCases() []reflect.SelectCase {


### PR DESCRIPTION
## Summary

- increase defaultRegisterBuf from 1 to 256 for active future registration
- shard activeFutureManager by CPU groups (numShards = cpuNum/32, minimum 1 shard) and route registrations round-robin
- update TestConcurrent to aggregate active future counts across all shards

issue: #50899
pr: #49047
