### PR TITLE
enhance: make etcd client dial timeout configurable

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -53,6 +53,7 @@ etcd:
     # We recommend using version 1.2 and above.
     tlsMinVersion: 1.3
   requestTimeout: 10000 # Etcd operation timeout in milliseconds
+  dialTimeout: 5000 # Timeout in milliseconds for establishing the initial connection to etcd endpoints. Increase it for environments where transient network delays are expected during node scale-out.
   dialKeepAliveTime: 3000 # Interval in milliseconds for gRPC dial keepalive pings sent to etcd endpoints.
   dialKeepAliveTimeout: 2000 # Timeout in milliseconds waiting for keepalive responses before marking the connection as unhealthy.
   use:

--- a/pkg/config/etcd_source.go
+++ b/pkg/config/etcd_source.go
@@ -60,7 +60,8 @@ func NewEtcdSource(etcdInfo *EtcdInfo) (*EtcdSource, error) {
 		etcdInfo.CertFile,
 		etcdInfo.KeyFile,
 		etcdInfo.CaCertFile,
-		etcdInfo.MinVersion)
+		etcdInfo.MinVersion,
+		etcd.WithDialTimeout(etcdInfo.DialTimeout))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/etcd_source_test.go
+++ b/pkg/config/etcd_source_test.go
@@ -50,6 +50,7 @@ func (s *EtcdSourceSuite) TestNewSource() {
 	source, err := NewEtcdSource(&EtcdInfo{
 		Endpoints:       s.endpoints,
 		KeyPrefix:       "by-dev",
+		DialTimeout:     5 * time.Second,
 		RefreshInterval: time.Second,
 	})
 	s.NoError(err)

--- a/pkg/config/source.go
+++ b/pkg/config/source.go
@@ -52,6 +52,11 @@ type EtcdInfo struct {
 	CaCertFile string
 	MinVersion string
 
+	// DialTimeout for establishing the initial connection to etcd, read from the
+	// local file/env config source (which is already loaded before the etcd
+	// source is created). A non-positive value keeps the etcd client default.
+	DialTimeout time.Duration
+
 	// Pull Configuration interval, unit is second
 	RefreshInterval time.Duration
 }

--- a/pkg/util/etcd/etcd_util.go
+++ b/pkg/util/etcd/etcd_util.go
@@ -77,6 +77,15 @@ func IsRetriableWatchErr(err error) bool {
 
 type ClientOption func(*clientv3.Config)
 
+// WithDialTimeout overrides the etcd client dial timeout. A non-positive value keeps the default.
+func WithDialTimeout(dialTimeout time.Duration) ClientOption {
+	return func(cfg *clientv3.Config) {
+		if dialTimeout > 0 {
+			cfg.DialTimeout = dialTimeout
+		}
+	}
+}
+
 // WithDialKeepAlive configures gRPC keepalive and autosync behaviors for the etcd client.
 func WithDialKeepAlive(dialKeepAliveTime, dialKeepAliveTimeout time.Duration) ClientOption {
 	return func(cfg *clientv3.Config) {

--- a/pkg/util/paramtable/base_table.go
+++ b/pkg/util/paramtable/base_table.go
@@ -214,6 +214,7 @@ func (bt *BaseTable) initConfigsFromRemote() {
 		CaCertFile:      etcdConfig.EtcdTLSCACert.GetValue(),
 		MinVersion:      etcdConfig.EtcdTLSMinVersion.GetValue(),
 		KeyPrefix:       etcdConfig.RootPath.GetValue(),
+		DialTimeout:     etcdConfig.DialTimeout.GetAsDuration(time.Millisecond),
 		RefreshInterval: refreshInterval,
 	}
 

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -105,6 +105,7 @@ type EtcdConfig struct {
 	EtcdTLSCACert        ParamItem          `refreshable:"false"`
 	EtcdTLSMinVersion    ParamItem          `refreshable:"false"`
 	RequestTimeout       ParamItem          `refreshable:"false"`
+	DialTimeout          ParamItem          `refreshable:"false"`
 	DialKeepAliveTime    ParamItem          `refreshable:"false"`
 	DialKeepAliveTimeout ParamItem          `refreshable:"false"`
 
@@ -289,6 +290,15 @@ We recommend using version 1.2 and above.`,
 	}
 	p.RequestTimeout.Init(base.mgr)
 
+	p.DialTimeout = ParamItem{
+		Key:          "etcd.dialTimeout",
+		DefaultValue: "5000",
+		Version:      "2.6.12",
+		Doc:          `Timeout in milliseconds for establishing the initial connection to etcd endpoints. Increase it for environments where transient network delays are expected during node scale-out.`,
+		Export:       true,
+	}
+	p.DialTimeout.Init(base.mgr)
+
 	p.DialKeepAliveTime = ParamItem{
 		Key:          "etcd.dialKeepAliveTime",
 		DefaultValue: "3000",
@@ -358,6 +368,7 @@ func (p *EtcdConfig) GetAll() map[string]string {
 		"etcd.ssl.tlsCACert":        p.EtcdTLSCACert.GetValue(),
 		"etcd.ssl.tlsMinVersion":    p.EtcdTLSMinVersion.GetValue(),
 		"etcd.requestTimeout":       p.RequestTimeout.GetValue(),
+		"etcd.dialTimeout":          p.DialTimeout.GetValue(),
 		"etcd.dialKeepAliveTime":    p.DialKeepAliveTime.GetValue(),
 		"etcd.dialKeepAliveTimeout": p.DialKeepAliveTimeout.GetValue(),
 		"etcd.auth.enabled":         p.EtcdEnableAuth.GetValue(),
@@ -367,15 +378,18 @@ func (p *EtcdConfig) GetAll() map[string]string {
 }
 
 func (p *EtcdConfig) ClientOptions() []etcd.ClientOption {
+	dialTimeout := p.DialTimeout.GetAsDuration(time.Millisecond)
 	dialKeepAliveTime := p.DialKeepAliveTime.GetAsDuration(time.Millisecond)
 	dialKeepAliveTimeout := p.DialKeepAliveTimeout.GetAsDuration(time.Millisecond)
 
-	if dialKeepAliveTime <= 0 && dialKeepAliveTimeout <= 0 {
-		return nil
+	var options []etcd.ClientOption
+	if dialTimeout > 0 {
+		options = append(options, etcd.WithDialTimeout(dialTimeout))
 	}
-	return []etcd.ClientOption{
-		etcd.WithDialKeepAlive(dialKeepAliveTime, dialKeepAliveTimeout),
+	if dialKeepAliveTime > 0 || dialKeepAliveTimeout > 0 {
+		options = append(options, etcd.WithDialKeepAlive(dialKeepAliveTime, dialKeepAliveTimeout))
 	}
+	return options
 }
 
 // /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What this PR does

Makes the etcd client dial timeout configurable via `etcd.dialTimeout` (milliseconds, default `5000` — unchanged behavior).

## Why

The dial timeout was hardcoded to 5s in `GetRemoteEtcdClient` / `GetRemoteEtcdClientWithAuth` / `GetRemoteEtcdSSLClientWithCfg`. On newly scaled-out nodes, transient network conditions during pod startup (sidecar proxy not fully ready, DNS propagation delay, or etcd connection pressure from many nodes starting at once) can push the blocking dial past 5s, causing the second etcd client created during `streaming.Init()` to panic with `context deadline exceeded`. Operators had no way to tune it.

## Changes

- `pkg/util/etcd/etcd_util.go`: add `WithDialTimeout` client option (a non-positive value keeps the default).
- `pkg/util/paramtable/service_param.go`: add `etcd.dialTimeout` param and wire it through `EtcdConfig.ClientOptions()`.
- `configs/milvus.yaml`: document the new option.
- `pkg/config/etcd_source.go` + `pkg/config/source.go` + `pkg/util/paramtable/base_table.go`: thread `dialTimeout` into the bootstrap config-source client as well (see below).

Every paramtable-based etcd client honors it: meta kv, coordinator/node services, and the woodpecker WAL builder (the `streaming.Init()` path from the issue, which already passes `ClientOptions()...`).

## Bootstrap config-source client

The bootstrap config-source client (`pkg/config/etcd_source.go`) is created before paramtable is fully ready, so it cannot read `etcd.dialTimeout` from etcd itself. But it does not need to: `initConfigsFromLocal()` loads the file/env config source *before* `initConfigsFromRemote()` builds the `EtcdInfo`, and the client's endpoints/auth/TLS are already read from there. `dialTimeout` is threaded through the same `EtcdInfo` path, so a value set in `milvus.yaml`/env applies to this client too. A zero/non-positive value is a no-op, so unconfigured behavior stays at the 5s default.

The only remaining paths still on the fixed default are CLI/offline tools and the etcd `HealthCheck` (which uses a short fixed 3s context) — intended.

issue: #50867