### PR TITLE
fix: recover pchannels from collection metadata

### DIFF
--- a/internal/streamingcoord/server/balancer/channel/pchannel_stats.go
+++ b/internal/streamingcoord/server/balancer/channel/pchannel_stats.go
@@ -35,6 +35,21 @@ func (pm *PchannelStatsManager) WatchAtChannelCountChanged() *syncutil.Versioned
 	return pm.n.Listen(syncutil.VersionedListenAtEarliest)
 }
 
+// PChannels returns pchannels that currently have vchannels.
+func (pm *PchannelStatsManager) PChannels() []string {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	pchannels := make([]string, 0, len(pm.stats))
+	for id, stat := range pm.stats {
+		if stat.VChannelCount() == 0 {
+			continue
+		}
+		pchannels = append(pchannels, id.Name)
+	}
+	return pchannels
+}
+
 // GetPChannelStats returns the stats of the pchannel.
 func (pm *PchannelStatsManager) GetPChannelStats(channelID ChannelID) *pchannelStats {
 	pm.mu.Lock()

--- a/internal/streamingcoord/server/balancer/channel/pchannel_test.go
+++ b/internal/streamingcoord/server/balancer/channel/pchannel_test.go
@@ -67,6 +67,23 @@ func TestPChannelAvailableInReplication(t *testing.T) {
 	assert.False(t, pchannel.AvailableInReplication())
 }
 
+func TestPChannelStatsManagerPChannels(t *testing.T) {
+	ResetStaticPChannelStatsManager()
+	RecoverPChannelStatsManager([]string{
+		"by-dev-rootcoord-dml_0_100v0",
+		"by-dev-rootcoord-dml_3_101v0",
+	})
+
+	stats := StaticPChannelStatsManager.Get()
+	assert.ElementsMatch(t, []string{
+		"by-dev-rootcoord-dml_0",
+		"by-dev-rootcoord-dml_3",
+	}, stats.PChannels())
+
+	stats.RemoveVChannel("by-dev-rootcoord-dml_0_100v0")
+	assert.ElementsMatch(t, []string{"by-dev-rootcoord-dml_3"}, stats.PChannels())
+}
+
 func TestPChannel(t *testing.T) {
 	ResetStaticPChannelStatsManager()
 	RecoverPChannelStatsManager([]string{})

--- a/internal/streamingcoord/server/server.go
+++ b/internal/streamingcoord/server/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
+	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/channel"
 	_ "github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/policy" // register the balancer policy
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster/broadcast"
@@ -50,8 +51,8 @@ func (s *Server) initBasicComponent(ctx context.Context) (err error) {
 	futures = append(futures, conc.Go(func() (struct{}, error) {
 		s.logger.Info(ctx, "start recovery balancer...")
 		// Create a provider that reads channel names from configuration
-		// and polls for dynamic changes.
-		provider := util.NewConfigChannelProvider()
+		// and collection metadata recovered by RootCoord.
+		provider := util.NewConfigChannelProviderWithPChannelStatsManager(channel.StaticPChannelStatsManager)
 		balancer, err := balancer.RecoverBalancer(ctx, provider)
 		if err != nil {
 			provider.Close()

--- a/internal/util/streamingutil/util/config_channel_provider.go
+++ b/internal/util/streamingutil/util/config_channel_provider.go
@@ -159,5 +159,8 @@ func parseConfiguredDMLChannelIndex(pchannel string, prefix string) (int, bool) 
 	if err != nil {
 		return 0, false
 	}
+	if idx < 0 || fmt.Sprintf("%s_%d", prefix, idx) != pchannel {
+		return 0, false
+	}
 	return idx, true
 }

--- a/internal/util/streamingutil/util/config_channel_provider.go
+++ b/internal/util/streamingutil/util/config_channel_provider.go
@@ -2,7 +2,10 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/milvus-io/milvus/pkg/v3/config"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -20,12 +23,14 @@ type ConfigChannelProvider struct {
 	ch              chan []string
 	trigger         chan struct{}
 	handler         config.EventHandler
+	statsReady      <-chan struct{}
+	getPChannels    func() []string
 }
 
-// NewConfigChannelProvider creates a ConfigChannelProvider that reads the
-// current set of topics from configuration and watches for config changes
-// to detect any newly added topics.
-func NewConfigChannelProvider() *ConfigChannelProvider {
+// NewConfigChannelProviderWithPChannelStatsManager creates a ConfigChannelProvider
+// that reads channel names from configuration and also discovers pchannels
+// recovered from collection metadata.
+func NewConfigChannelProviderWithPChannelStatsManager[T interface{ PChannels() []string }](statsFuture *syncutil.Future[T]) *ConfigChannelProvider {
 	currentTopics := GetAllTopicsFromConfiguration()
 	initial := currentTopics.Collect()
 	sort.Strings(initial)
@@ -36,6 +41,10 @@ func NewConfigChannelProvider() *ConfigChannelProvider {
 		initialChannels: initial,
 		ch:              make(chan []string),
 		trigger:         make(chan struct{}, 1),
+	}
+	p.statsReady = statsFuture.Done()
+	p.getPChannels = func() []string {
+		return statsFuture.Get().PChannels()
 	}
 	p.handler = config.NewHandler("config_channel_provider", func(event *config.Event) {
 		// Non-blocking send to coalesce rapid config changes.
@@ -71,18 +80,32 @@ func (p *ConfigChannelProvider) Close() {
 // background is the single goroutine that processes config change triggers.
 func (p *ConfigChannelProvider) background() {
 	defer p.notifier.Finish(struct{}{})
+	statsReady := p.statsReady
 	for {
 		select {
 		case <-p.trigger:
-			p.onConfigChange()
+			p.onConfigChanged()
+		case <-statsReady:
+			statsReady = nil
+			p.onPChannelStatsReady()
 		case <-p.notifier.Context().Done():
 			return
 		}
 	}
 }
 
-func (p *ConfigChannelProvider) onConfigChange() {
-	current := GetAllTopicsFromConfiguration()
+func (p *ConfigChannelProvider) onConfigChanged() {
+	p.notifyNewChannels(GetAllTopicsFromConfiguration(), "ConfigChannelProvider detected new channels")
+}
+
+func (p *ConfigChannelProvider) onPChannelStatsReady() {
+	p.notifyNewChannels(
+		getAllTopicsFromConfigurationAndPChannels(p.getPChannels()),
+		"ConfigChannelProvider detected new channels from pchannel stats",
+	)
+}
+
+func (p *ConfigChannelProvider) notifyNewChannels(current typeutil.Set[string], logMessage string) {
 	var newChannels []string
 	current.Range(func(name string) bool {
 		if !p.known.Contain(name) {
@@ -93,11 +116,48 @@ func (p *ConfigChannelProvider) onConfigChange() {
 	})
 	if len(newChannels) > 0 {
 		sort.Strings(newChannels)
-		mlog.Info(context.TODO(), "ConfigChannelProvider detected new channels",
+		mlog.Info(context.TODO(), logMessage,
 			mlog.Strings("newChannels", newChannels))
 		select {
 		case p.ch <- newChannels:
 		case <-p.notifier.Context().Done():
 		}
 	}
+}
+
+func getAllTopicsFromConfigurationAndPChannels(pchannels []string) typeutil.Set[string] {
+	current := GetAllTopicsFromConfiguration()
+	if paramtable.Get().CommonCfg.PreCreatedTopicEnabled.GetAsBool() {
+		for _, pchannel := range pchannels {
+			if !current.Contain(pchannel) {
+				mlog.Warn(context.TODO(), "skip pchannel not in pre-created topic list",
+					mlog.String("pchannel", pchannel))
+			}
+		}
+		return current
+	}
+
+	prefix := paramtable.Get().CommonCfg.RootCoordDml.GetValue()
+	for _, pchannel := range pchannels {
+		if idx, ok := parseConfiguredDMLChannelIndex(pchannel, prefix); ok {
+			for i := 0; i <= idx; i++ {
+				current.Insert(fmt.Sprintf("%s_%d", prefix, i))
+			}
+			continue
+		}
+		current.Insert(pchannel)
+	}
+	return current
+}
+
+func parseConfiguredDMLChannelIndex(pchannel string, prefix string) (int, bool) {
+	suffix, ok := strings.CutPrefix(pchannel, prefix+"_")
+	if !ok || suffix == "" {
+		return 0, false
+	}
+	idx, err := strconv.Atoi(suffix)
+	if err != nil {
+		return 0, false
+	}
+	return idx, true
 }

--- a/internal/util/streamingutil/util/config_channel_provider_test.go
+++ b/internal/util/streamingutil/util/config_channel_provider_test.go
@@ -154,6 +154,32 @@ func TestGetAllTopicsFromConfigurationAndPChannelsKeepsNonDMLChannels(t *testing
 	assert.True(t, channels.Contain(fmt.Sprintf("%s_0", paramtable.Get().CommonCfg.RootCoordDml.GetValue())))
 }
 
+func TestGetAllTopicsFromConfigurationAndPChannelsKeepsNonCanonicalDMLNames(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, "1")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootCoordDml.Key, "rootcoord-dml")
+	defer paramtable.Get().Reset(paramtable.Get().RootCoordCfg.DmlChannelNum.Key)
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.RootCoordDml.Key)
+
+	prefix := paramtable.Get().CommonCfg.RootCoordDml.GetValue()
+	channels := getAllTopicsFromConfigurationAndPChannels([]string{
+		fmt.Sprintf("%s_3", prefix),
+		fmt.Sprintf("%s_-1", prefix),
+		fmt.Sprintf("%s_007", prefix),
+		fmt.Sprintf("%s_+7", prefix),
+	})
+
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_0", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_1", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_2", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_3", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_-1", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_007", prefix)))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_+7", prefix)))
+	assert.False(t, channels.Contain(fmt.Sprintf("%s_4", prefix)))
+	assert.False(t, channels.Contain(fmt.Sprintf("%s_7", prefix)))
+}
+
 type testPChannelStats struct {
 	pchannels []string
 }

--- a/internal/util/streamingutil/util/config_channel_provider_test.go
+++ b/internal/util/streamingutil/util/config_channel_provider_test.go
@@ -7,13 +7,15 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/syncutil"
 )
 
 func TestConfigChannelProvider_GetInitialChannels(t *testing.T) {
 	paramtable.Init()
-	provider := NewConfigChannelProvider()
+	provider := newTestConfigChannelProvider()
 	defer provider.Close()
 
 	initial := provider.GetInitialChannels()
@@ -29,7 +31,7 @@ func TestConfigChannelProvider_DetectsNewChannels(t *testing.T) {
 	paramtable.Init()
 
 	originalNum := paramtable.Get().RootCoordCfg.DmlChannelNum.GetValue()
-	provider := NewConfigChannelProvider()
+	provider := newTestConfigChannelProvider()
 	defer provider.Close()
 
 	initial := provider.GetInitialChannels()
@@ -47,11 +49,41 @@ func TestConfigChannelProvider_DetectsNewChannels(t *testing.T) {
 	}
 }
 
+func TestConfigChannelProvider_DetectsChannelsFromPChannelStats(t *testing.T) {
+	paramtable.Init()
+
+	originalNum := paramtable.Get().RootCoordCfg.DmlChannelNum.GetValue()
+	originalDML := paramtable.Get().CommonCfg.RootCoordDml.GetValue()
+	paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, "2")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootCoordDml.Key, "rootcoord-dml")
+	defer paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, originalNum)
+	defer paramtable.Get().Save(paramtable.Get().CommonCfg.RootCoordDml.Key, originalDML)
+
+	statsFuture := syncutil.NewFuture[*testPChannelStats]()
+	provider := NewConfigChannelProviderWithPChannelStatsManager(statsFuture)
+	defer provider.Close()
+
+	prefix := paramtable.Get().CommonCfg.RootCoordDml.GetValue()
+	statsFuture.Set(&testPChannelStats{
+		pchannels: []string{fmt.Sprintf("%s_3", prefix)},
+	})
+
+	select {
+	case newChannels := <-provider.NewIncomingChannels():
+		require.ElementsMatch(t, []string{
+			fmt.Sprintf("%s_2", prefix),
+			fmt.Sprintf("%s_3", prefix),
+		}, newChannels)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for pchannel stats notification")
+	}
+}
+
 func TestConfigChannelProvider_NoDuplicates(t *testing.T) {
 	paramtable.Init()
 
 	originalNum := paramtable.Get().RootCoordCfg.DmlChannelNum.GetValue()
-	provider := NewConfigChannelProvider()
+	provider := newTestConfigChannelProvider()
 	defer provider.Close()
 
 	// Trigger a config change with the same value, should not produce new channels.
@@ -67,7 +99,7 @@ func TestConfigChannelProvider_NoDuplicates(t *testing.T) {
 
 func TestConfigChannelProvider_CloseStopsWatching(t *testing.T) {
 	paramtable.Init()
-	provider := NewConfigChannelProvider()
+	provider := newTestConfigChannelProvider()
 	provider.Close()
 
 	_, ok := <-provider.NewIncomingChannels()
@@ -78,7 +110,7 @@ func TestConfigChannelProvider_CloseUnblocksInFlightSend(t *testing.T) {
 	paramtable.Init()
 
 	originalNum := paramtable.Get().RootCoordCfg.DmlChannelNum.GetValue()
-	provider := NewConfigChannelProvider()
+	provider := newTestConfigChannelProvider()
 
 	initial := provider.GetInitialChannels()
 	initialCount := len(initial)
@@ -107,4 +139,31 @@ func TestConfigChannelProvider_CloseUnblocksInFlightSend(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Close() deadlocked while background goroutine was blocked on channel send")
 	}
+}
+
+func TestGetAllTopicsFromConfigurationAndPChannelsKeepsNonDMLChannels(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().RootCoordCfg.DmlChannelNum.Key, "1")
+	paramtable.Get().Save(paramtable.Get().CommonCfg.RootCoordDml.Key, "rootcoord-dml")
+	defer paramtable.Get().Reset(paramtable.Get().RootCoordCfg.DmlChannelNum.Key)
+	defer paramtable.Get().Reset(paramtable.Get().CommonCfg.RootCoordDml.Key)
+
+	channels := getAllTopicsFromConfigurationAndPChannels([]string{"custom-pchannel"})
+
+	assert.True(t, channels.Contain("custom-pchannel"))
+	assert.True(t, channels.Contain(fmt.Sprintf("%s_0", paramtable.Get().CommonCfg.RootCoordDml.GetValue())))
+}
+
+type testPChannelStats struct {
+	pchannels []string
+}
+
+func (s *testPChannelStats) PChannels() []string {
+	return append([]string(nil), s.pchannels...)
+}
+
+func newTestConfigChannelProvider() *ConfigChannelProvider {
+	statsFuture := syncutil.NewFuture[*testPChannelStats]()
+	statsFuture.Set(&testPChannelStats{})
+	return NewConfigChannelProviderWithPChannelStatsManager(statsFuture)
 }


### PR DESCRIPTION
issue: #50905

- streamingcoord recovery: include pchannels recovered from RootCoord collection metadata through ConfigChannelProvider so missing WAL topics are added after stats initialization
- dml channel compatibility: expand configured DML-style pchannels up to the recovered index while preserving pre-created-topic constraints
- channel stats: expose active pchannels from PChannelStatsManager for metadata-driven channel recovery
