### PR TITLE
test: Avoid leaking packed fragment mock columns

### DIFF
--- a/internal/storagev2/packed/exttable_test.go
+++ b/internal/storagev2/packed/exttable_test.go
@@ -624,10 +624,11 @@ func TestBuildCurrentSegmentFragments_PassesColumns(t *testing.T) {
 	}
 	expected := []Fragment{{FragmentID: 7, FilePath: "/data/file.parquet", RowCount: 500}}
 
-	var gotColumns []string
+	called := false
 	mockRead := mockey.Mock(ReadFragmentsFromManifest).
 		To(func(manifestPath string, storageConfig *indexpb.StorageConfig, columns []string) ([]Fragment, error) {
-			gotColumns = columns
+			assert.Equal(t, []string{"text_col"}, append([]string(nil), columns...))
+			called = true
 			return expected, nil
 		}).Build()
 	defer mockRead.UnPatch()
@@ -635,7 +636,7 @@ func TestBuildCurrentSegmentFragments_PassesColumns(t *testing.T) {
 	result, err := BuildCurrentSegmentFragments(segments, storageConfig, []string{"text_col"})
 	require.NoError(t, err)
 	assert.Equal(t, expected, result[1])
-	assert.Equal(t, []string{"text_col"}, gotColumns)
+	assert.True(t, called)
 }
 
 func TestBuildCurrentSegmentFragments_ManifestErrorsAndEmptyResult(t *testing.T) {


### PR DESCRIPTION
issue: #50934

This PR stabilizes `TestBuildCurrentSegmentFragments_PassesColumns`.

The old test patched `ReadFragmentsFromManifest` with mockey and saved the
`columns` slice from the hook callback for assertions after the callback
returned. That lets a callback argument crossing the mockey/reflect/unsafe
boundary escape beyond the hook invocation, and Jenkins observed this test
crashing with a Go runtime bad pointer check.

The updated test keeps the focused mockey coverage, but consumes the `columns`
argument inside the callback:

- copy the received `columns` slice before assertion
- assert the copied value inside the hook callback
- only carry a plain `called` boolean outside the callback

There is no production behavior change.

Validation:

- `gofmt -w internal/storagev2/packed/exttable_test.go`
- `git diff --check`
- `make lint-fix` attempted, but local validation is blocked because
  pkg-config cannot find `milvus_core`.
- Targeted Go test attempted after resetting local Milvus dependencies, but
  it is blocked in this worktree because pkg-config cannot find `milvus_core`
  and `milvus-storage`.
- `make build-cpp` was attempted earlier to restore the C++ output, but local
  macOS arm64 linking fails with `milvus::tracer::AutoSpan::AutoSpan`
  undefined while linking `libmilvus_core.dylib`.
