### PR TITLE
fix: synchronize native collection access

### DIFF
--- a/internal/querynodev2/segments/collection.go
+++ b/internal/querynodev2/segments/collection.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/samber/lo"
 	"go.uber.org/atomic"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
@@ -113,7 +114,7 @@ func (m *collectionManager) PutOrRef(collectionID int64, schema *schemapb.Collec
 		// separate from the barrier timestamp so stale schema payloads cannot roll
 		// back fields, while newer properties-only payloads can still refresh.
 		if plan, shouldUpdate := prepareCollectionSchemaUpdate(collection, logicalSchemaVersion, schemaBarrierTs); shouldUpdate {
-			if err := collection.ccollection.UpdateSchema(schema, plan.segcoreSchemaVersion); err != nil {
+			if err := collection.updateSchema(schema, plan.segcoreSchemaVersion); err != nil {
 				return err
 			}
 			collection.setSchema(schema, plan.logicalSchemaVersion, plan.schemaBarrierTs, plan.segcoreSchemaVersion)
@@ -128,7 +129,7 @@ func (m *collectionManager) PutOrRef(collectionID int64, schema *schemapb.Collec
 		// Always update index meta to ensure newly indexed fields are visible
 		// for search plan creation (CollectionIndexMeta::HasField check).
 		if meta != nil {
-			if err := collection.ccollection.UpdateIndexMeta(meta); err != nil {
+			if err := collection.updateIndexMeta(meta); err != nil {
 				return err
 			}
 		}
@@ -169,7 +170,7 @@ func (m *collectionManager) UpdateSchema(collectionID int64, schema *schemapb.Co
 		return nil
 	}
 
-	if err := collection.ccollection.UpdateSchema(schema, plan.segcoreSchemaVersion); err != nil {
+	if err := collection.updateSchema(schema, plan.segcoreSchemaVersion); err != nil {
 		return err
 	}
 	collection.setSchema(schema, plan.logicalSchemaVersion, plan.schemaBarrierTs, plan.segcoreSchemaVersion)
@@ -349,6 +350,72 @@ func (c *Collection) ID() int64 {
 // GetCCollection returns the CCollection of collection
 func (c *Collection) GetCCollection() *segcore.CCollection {
 	return c.ccollection
+}
+
+func (c *Collection) NewSearchRequest(req *querypb.SearchRequest, placeholderGroup []byte) (*segcore.SearchRequest, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.ccollection == nil {
+		return nil, merr.WrapErrServiceInternal("create search request on released collection")
+	}
+	return segcore.NewSearchRequest(c.ccollection, req, placeholderGroup)
+}
+
+func (c *Collection) NewRetrievePlan(req *querypb.QueryRequest) (*segcore.RetrievePlan, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.ccollection == nil {
+		return nil, merr.WrapErrServiceInternal("create retrieve plan on released collection")
+	}
+	return segcore.NewRetrievePlan(
+		c.ccollection,
+		req.Req.GetSerializedExprPlan(),
+		req.Req.GetMvccTimestamp(),
+		req.Req.Base.GetMsgID(),
+		req.Req.GetConsistencyLevel(),
+		req.Req.GetCollectionTtlTimestamps(),
+		req.Req.GetEntityTtlPhysicalTime(),
+	)
+}
+
+func (c *Collection) CreateCSegment(req *segcore.CreateCSegmentRequest) (segcore.CSegment, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.ccollection == nil {
+		return nil, merr.WrapErrServiceInternal("create segment on released collection")
+	}
+	req.Collection = c.ccollection
+	return segcore.CreateCSegment(req)
+}
+
+func (c *Collection) updateIndexMeta(meta *segcorepb.CollectionIndexMeta) error {
+	if meta == nil {
+		return nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ccollection == nil {
+		return merr.WrapErrServiceInternal("update index meta on released collection")
+	}
+	if proto.Equal(c.ccollection.IndexMeta(), meta) {
+		return nil
+	}
+	return c.ccollection.UpdateIndexMeta(meta)
+}
+
+func (c *Collection) updateSchema(schema *schemapb.CollectionSchema, version uint64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.ccollection == nil {
+		return merr.WrapErrServiceInternal("update schema on released collection")
+	}
+	return c.ccollection.UpdateSchema(schema, version)
 }
 
 func (c *Collection) setSchema(schema *schemapb.CollectionSchema, logicalSchemaVersion uint64, schemaBarrierTs uint64, segcoreSchemaVersion uint64) {

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -381,16 +381,15 @@ func (s *CollectionManagerSuite) TestPutOrRefUpdateIndexMetaWaitsForCollectionNa
 	coll := s.cm.Get(1)
 	s.Require().NotNil(coll)
 
-	schema := mock_segcore.GenTestCollectionSchema("collection_1", schemapb.DataType_Int64, false)
-	schema.Version = 2
-	indexMeta := mock_segcore.GenTestIndexMeta(1, schema)
+	schema := proto.Clone(coll.Schema()).(*schemapb.CollectionSchema)
+	indexMeta := proto.Clone(coll.GetCCollection().IndexMeta()).(*segcorepb.CollectionIndexMeta)
+	indexMeta.MaxIndexRowCount++
 
 	coll.mu.Lock()
 	done := make(chan error, 1)
 	go func() {
 		done <- s.cm.PutOrRef(1, schema, indexMeta, &querypb.LoadMetaInfo{
-			LoadType:        querypb.LoadType_LoadCollection,
-			SchemaBarrierTs: 100,
+			LoadType: querypb.LoadType_LoadCollection,
 		})
 	}()
 

--- a/internal/querynodev2/segments/collection_test.go
+++ b/internal/querynodev2/segments/collection_test.go
@@ -20,16 +20,23 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/mocks/util/mock_segcore"
+	"github.com/milvus-io/milvus/internal/util/initcore"
+	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 type CollectionManagerSuite struct {
@@ -39,6 +46,8 @@ type CollectionManagerSuite struct {
 
 func (s *CollectionManagerSuite) SetupSuite() {
 	paramtable.Init()
+	initcore.InitLocalChunkManager("CollectionManagerSuite")
+	initcore.InitMmapManager(paramtable.Get(), 1)
 }
 
 func (s *CollectionManagerSuite) SetupTest() {
@@ -48,6 +57,48 @@ func (s *CollectionManagerSuite) SetupTest() {
 		LoadType: querypb.LoadType_LoadCollection,
 	})
 	s.Require().NoError(err)
+}
+
+func (s *CollectionManagerSuite) newSimpleRetrieveRequest(collection *Collection) *querypb.QueryRequest {
+	pkField, err := typeutil.GetPrimaryFieldSchema(collection.Schema())
+	s.Require().NoError(err)
+
+	planNode := &planpb.PlanNode{
+		Node: &planpb.PlanNode_Predicates{
+			Predicates: &planpb.Expr{
+				Expr: &planpb.Expr_TermExpr{
+					TermExpr: &planpb.TermExpr{
+						ColumnInfo: &planpb.ColumnInfo{
+							FieldId:  pkField.GetFieldID(),
+							DataType: pkField.GetDataType(),
+						},
+						Values: []*planpb.GenericValue{
+							{
+								Val: &planpb.GenericValue_Int64Val{
+									Int64Val: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		OutputFieldIds: []int64{pkField.GetFieldID()},
+	}
+	planBytes, err := proto.Marshal(planNode)
+	s.Require().NoError(err)
+
+	return &querypb.QueryRequest{
+		Req: &internalpb.RetrieveRequest{
+			Base: &commonpb.MsgBase{
+				MsgType: commonpb.MsgType_Retrieve,
+				MsgID:   100,
+			},
+			CollectionID:       collection.ID(),
+			SerializedExprPlan: planBytes,
+			MvccTimestamp:      1000,
+		},
+	}
 }
 
 func (s *CollectionManagerSuite) TestUpdateSchema() {
@@ -324,6 +375,86 @@ func (s *CollectionManagerSuite) TestPutOrRefUpdateIndexMeta() {
 	s.True(found,
 		"PutOrRef should update IndexMeta for existing collections; field %d is missing",
 		newVecFieldID)
+}
+
+func (s *CollectionManagerSuite) TestPutOrRefUpdateIndexMetaWaitsForCollectionNativeLock() {
+	coll := s.cm.Get(1)
+	s.Require().NotNil(coll)
+
+	schema := mock_segcore.GenTestCollectionSchema("collection_1", schemapb.DataType_Int64, false)
+	schema.Version = 2
+	indexMeta := mock_segcore.GenTestIndexMeta(1, schema)
+
+	coll.mu.Lock()
+	done := make(chan error, 1)
+	go func() {
+		done <- s.cm.PutOrRef(1, schema, indexMeta, &querypb.LoadMetaInfo{
+			LoadType:        querypb.LoadType_LoadCollection,
+			SchemaBarrierTs: 100,
+		})
+	}()
+
+	select {
+	case err := <-done:
+		coll.mu.Unlock()
+		s.Require().NoError(err)
+		s.FailNow("PutOrRef updated index meta while collection native lock was held")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	coll.mu.Unlock()
+	s.Require().NoError(<-done)
+	s.cm.Unref(1, 1)
+}
+
+func (s *CollectionManagerSuite) TestCollectionNativeWrapperMethods() {
+	coll := s.cm.Get(1)
+	s.Require().NotNil(coll)
+
+	searchReqPB, err := mock_segcore.GenQueryRequest(coll.GetCCollection(), nil, 1, 1, coll.ID())
+	s.Require().NoError(err)
+	searchReq, err := coll.NewSearchRequest(searchReqPB, searchReqPB.GetReq().GetPlaceholderGroup())
+	s.Require().NoError(err)
+	searchReq.Delete()
+
+	retrievePlan, err := coll.NewRetrievePlan(s.newSimpleRetrieveRequest(coll))
+	s.Require().NoError(err)
+	retrievePlan.Delete()
+
+	csegment, err := coll.CreateCSegment(&segcore.CreateCSegmentRequest{
+		SegmentID:   1,
+		SegmentType: SegmentTypeSealed,
+	})
+	s.Require().NoError(err)
+	releaser, ok := csegment.(interface{ Release() })
+	s.Require().True(ok)
+	releaser.Release()
+
+	s.NoError(coll.updateIndexMeta(nil))
+}
+
+func (s *CollectionManagerSuite) TestCollectionNativeWrapperMethodsReleased() {
+	coll := s.cm.Get(1)
+	s.Require().NotNil(coll)
+
+	searchReqPB, err := mock_segcore.GenQueryRequest(coll.GetCCollection(), nil, 1, 1, coll.ID())
+	s.Require().NoError(err)
+	retrieveReq := s.newSimpleRetrieveRequest(coll)
+	indexMeta := mock_segcore.GenTestIndexMeta(1, coll.Schema())
+
+	DeleteCollection(coll)
+
+	_, err = coll.NewSearchRequest(searchReqPB, searchReqPB.GetReq().GetPlaceholderGroup())
+	s.Error(err)
+	_, err = coll.NewRetrievePlan(retrieveReq)
+	s.Error(err)
+	_, err = coll.CreateCSegment(&segcore.CreateCSegmentRequest{
+		SegmentID:   1,
+		SegmentType: SegmentTypeSealed,
+	})
+	s.Error(err)
+	s.Error(coll.updateIndexMeta(indexMeta))
+	s.Error(coll.updateSchema(coll.Schema(), 1))
 }
 
 func (s *CollectionManagerSuite) TestPutOrRefKeepsFreshCollectionInSchemaVersionDomain() {

--- a/internal/querynodev2/segments/segment.go
+++ b/internal/querynodev2/segments/segment.go
@@ -436,8 +436,7 @@ func NewSegment(ctx context.Context,
 	var csegment segcore.CSegment
 	if _, err := GetDynamicPool().Submit(func() (any, error) {
 		var err error
-		csegment, err = segcore.CreateCSegment(&segcore.CreateCSegmentRequest{
-			Collection:  collection.ccollection,
+		csegment, err = collection.CreateCSegment(&segcore.CreateCSegmentRequest{
 			SegmentID:   loadInfo.GetSegmentID(),
 			SegmentType: segmentType,
 			IsSorted:    loadInfo.GetIsSorted(),

--- a/internal/querynodev2/tasks/query_stream_task.go
+++ b/internal/querynodev2/tasks/query_stream_task.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/util/searchutil/scheduler"
-	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/internal/util/streamrpc"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
@@ -64,15 +63,7 @@ func (t *QueryStreamTask) PreExecute() error {
 }
 
 func (t *QueryStreamTask) Execute() error {
-	retrievePlan, err := segcore.NewRetrievePlan(
-		t.collection.GetCCollection(),
-		t.req.Req.GetSerializedExprPlan(),
-		t.req.Req.GetMvccTimestamp(),
-		t.req.Req.Base.GetMsgID(),
-		t.req.Req.GetConsistencyLevel(),
-		t.req.Req.GetCollectionTtlTimestamps(),
-		t.req.Req.GetEntityTtlPhysicalTime(),
-	)
+	retrievePlan, err := t.collection.NewRetrievePlan(t.req)
 	if err != nil {
 		return err
 	}

--- a/internal/querynodev2/tasks/query_task.go
+++ b/internal/querynodev2/tasks/query_task.go
@@ -13,7 +13,6 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/internal/querynodev2/segments"
 	"github.com/milvus-io/milvus/internal/util/searchutil/scheduler"
-	"github.com/milvus-io/milvus/internal/util/segcore"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
@@ -115,15 +114,7 @@ func (t *QueryTask) Execute() error {
 	}
 	tr := timerecord.NewTimeRecorderWithTrace(t.ctx, "QueryTask")
 
-	retrievePlan, err := segcore.NewRetrievePlan(
-		t.collection.GetCCollection(),
-		t.req.Req.GetSerializedExprPlan(),
-		t.req.Req.GetMvccTimestamp(),
-		t.req.Req.Base.GetMsgID(),
-		t.req.Req.GetConsistencyLevel(),
-		t.req.Req.GetCollectionTtlTimestamps(),
-		t.req.Req.GetEntityTtlPhysicalTime(),
-	)
+	retrievePlan, err := t.collection.NewRetrievePlan(t.req)
 	if err != nil {
 		return err
 	}

--- a/internal/querynodev2/tasks/search_task.go
+++ b/internal/querynodev2/tasks/search_task.go
@@ -153,7 +153,7 @@ func (t *SearchTask) Execute() error {
 	if err != nil {
 		return err
 	}
-	searchReq, err := segcore.NewSearchRequest(t.collection.GetCCollection(), req, t.placeholderGroup)
+	searchReq, err := t.collection.NewSearchRequest(req, t.placeholderGroup)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
issue: #50881

- querynode collection: serialize native schema and index metadata updates with collection release
- querynode tasks: create native search requests, retrieve plans, and segments through collection lifecycle guards
- tests: cover native collection wrappers and index metadata update locking