### PR TITLE
enhance: clean up sealed segment C++20 helpers

### DIFF
--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -282,7 +282,7 @@ throw_unsupported_pk_type(DataType data_type) {
 }
 
 template <typename Func>
-decltype(auto)
+static decltype(auto)
 dispatch_pk_type(DataType data_type, Func&& func) {
     switch (data_type) {
         case DataType::INT64:
@@ -295,7 +295,7 @@ dispatch_pk_type(DataType data_type, Func&& func) {
 }
 
 template <sealed_segment_detail::PrimaryKey PK>
-sealed_segment_detail::PrimaryKeyView<PK>
+static sealed_segment_detail::PrimaryKeyView<PK>
 get_pk_value(const PinWrapper<Chunk*>& pin, int64_t offset) {
     if constexpr (std::same_as<PK, int64_t>) {
         auto src = reinterpret_cast<const int64_t*>(pin.get()->RawData());
@@ -306,7 +306,7 @@ get_pk_value(const PinWrapper<Chunk*>& pin, int64_t offset) {
     }
 }
 
-std::vector<int64_t>
+static std::vector<int64_t>
 build_chunk_offsets(const ChunkedColumnInterface& column) {
     auto num_chunks = column.num_chunks();
     std::vector<int64_t> chunk_offsets(num_chunks + 1, 0);
@@ -316,7 +316,7 @@ build_chunk_offsets(const ChunkedColumnInterface& column) {
     return chunk_offsets;
 }
 
-int64_t
+static int64_t
 chunk_id_for_offset(const std::vector<int64_t>& chunk_offsets,
                     int64_t offset) {
     AssertInfo(chunk_offsets.size() >= 2, "chunk offsets must not be empty");
@@ -331,7 +331,7 @@ chunk_id_for_offset(const std::vector<int64_t>& chunk_offsets,
 }
 
 template <sealed_segment_detail::PrimaryKey PK, typename Callback>
-void
+static void
 for_each_sorted_pk_match(
     const std::vector<PkType>& pks,
     const ChunkedColumnInterface* pk_column,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -344,12 +344,10 @@ for_each_sorted_pk_match(
         if constexpr (std::same_as<PK, int64_t>) {
             auto src = reinterpret_cast<const int64_t*>(pw.get()->RawData());
             auto chunk_row_num = pk_column->chunk_row_nums(i);
-            auto chunk_end = src + chunk_row_num;
             for (size_t j = 0; j < pks.size(); ++j) {
                 auto target = std::get<int64_t>(pks[j]);
-                auto [match_begin, match_end] =
-                    std::equal_range(src, chunk_end, target);
-                for (auto it = match_begin; it != match_end; ++it) {
+                auto it = std::lower_bound(src, src + chunk_row_num, target);
+                for (; it != src + chunk_row_num && *it == target; ++it) {
                     callback(j, it - src + num_rows_until_chunk);
                 }
             }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -19,6 +19,7 @@
 #include <simdjson.h>
 #include <algorithm>
 #include <chrono>
+#include <concepts>
 #include <cstdint>
 #include <ctime>
 #include <exception>
@@ -293,6 +294,412 @@ dispatch_pk_type(DataType data_type, Func&& func) {
         default:
             throw_unsupported_pk_type(data_type);
     }
+}
+
+template <sealed_segment_detail::PrimaryKey PK>
+void
+ChunkedSegmentSealedImpl::search_sorted_pk_range_impl(
+    proto::plan::OpType op,
+    const PK& target,
+    const std::shared_ptr<ChunkedColumnInterface>& pk_column,
+    BitsetTypeView& bitset) const {
+    const auto num_chunk = pk_column->num_chunks();
+    if (num_chunk == 0) {
+        return;
+    }
+    auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
+
+    if (op == proto::plan::OpType::Equal) {
+        // find first occurrence
+        auto [chunk_id, in_chunk_offset, exact_match] =
+            this->pk_lower_bound<PK>(
+                target, pk_column.get(), all_chunk_pins, 0);
+
+        if (exact_match) {
+            // find last occurrence
+            auto [last_chunk_id, last_in_chunk_offset] =
+                this->find_last_pk_position<PK>(target,
+                                                pk_column.get(),
+                                                all_chunk_pins,
+                                                chunk_id,
+                                                in_chunk_offset);
+
+            auto start_idx =
+                pk_column->GetNumRowsUntilChunk(chunk_id) + in_chunk_offset;
+            auto end_idx = pk_column->GetNumRowsUntilChunk(last_chunk_id) +
+                           last_in_chunk_offset;
+
+            bitset.set(start_idx, end_idx - start_idx + 1, true);
+        }
+    } else if (op == proto::plan::OpType::GreaterEqual ||
+               op == proto::plan::OpType::GreaterThan) {
+        auto [chunk_id, in_chunk_offset, exact_match] =
+            this->pk_lower_bound<PK>(
+                target, pk_column.get(), all_chunk_pins, 0);
+
+        if (chunk_id != -1) {
+            int64_t start_idx =
+                pk_column->GetNumRowsUntilChunk(chunk_id) + in_chunk_offset;
+            if (exact_match && op == proto::plan::OpType::GreaterThan) {
+                auto [last_chunk_id, last_in_chunk_offset] =
+                    this->find_last_pk_position<PK>(target,
+                                                    pk_column.get(),
+                                                    all_chunk_pins,
+                                                    chunk_id,
+                                                    in_chunk_offset);
+                start_idx = pk_column->GetNumRowsUntilChunk(last_chunk_id) +
+                            last_in_chunk_offset + 1;
+            }
+            if (start_idx < bitset.size()) {
+                bitset.set(start_idx, bitset.size() - start_idx, true);
+            }
+        }
+    } else if (op == proto::plan::OpType::LessEqual ||
+               op == proto::plan::OpType::LessThan) {
+        auto [chunk_id, in_chunk_offset, exact_match] =
+            this->pk_lower_bound<PK>(
+                target, pk_column.get(), all_chunk_pins, 0);
+
+        int64_t end_idx;
+        if (chunk_id == -1) {
+            end_idx = bitset.size();
+        } else if (op == proto::plan::OpType::LessEqual && exact_match) {
+            auto [last_chunk_id, last_in_chunk_offset] =
+                this->find_last_pk_position<PK>(target,
+                                                pk_column.get(),
+                                                all_chunk_pins,
+                                                chunk_id,
+                                                in_chunk_offset);
+            end_idx = pk_column->GetNumRowsUntilChunk(last_chunk_id) +
+                      last_in_chunk_offset + 1;
+        } else {
+            end_idx =
+                pk_column->GetNumRowsUntilChunk(chunk_id) + in_chunk_offset;
+        }
+
+        if (end_idx > 0) {
+            bitset.set(0, end_idx, true);
+        }
+    } else {
+        ThrowInfo(ErrorCode::Unsupported,
+                  fmt::format("unsupported op type {}", op));
+    }
+}
+
+template <sealed_segment_detail::PrimaryKey PK>
+void
+ChunkedSegmentSealedImpl::search_sorted_pk_binary_range_impl(
+    const PK& lower_val,
+    bool lower_inclusive,
+    const PK& upper_val,
+    bool upper_inclusive,
+    const std::shared_ptr<ChunkedColumnInterface>& pk_column,
+    BitsetTypeView& bitset) const {
+    const auto num_chunk = pk_column->num_chunks();
+    if (num_chunk == 0) {
+        return;
+    }
+    auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
+
+    // Find the lower bound position (first value >= lower_val or > lower_val)
+    auto [lower_chunk_id, lower_in_chunk_offset, lower_exact_match] =
+        this->pk_lower_bound<PK>(
+            lower_val, pk_column.get(), all_chunk_pins, 0);
+
+    int64_t start_idx = 0;
+    if (lower_chunk_id != -1) {
+        start_idx =
+            pk_column->GetNumRowsUntilChunk(lower_chunk_id) +
+            lower_in_chunk_offset;
+        // If lower_inclusive is false and we found an exact match, skip all equal values
+        if (!lower_inclusive && lower_exact_match) {
+            auto [last_chunk_id, last_in_chunk_offset] =
+                this->find_last_pk_position<PK>(lower_val,
+                                                pk_column.get(),
+                                                all_chunk_pins,
+                                                lower_chunk_id,
+                                                lower_in_chunk_offset);
+            start_idx = pk_column->GetNumRowsUntilChunk(last_chunk_id) +
+                        last_in_chunk_offset + 1;
+        }
+    } else {
+        // lower_val is greater than all values, no results
+        return;
+    }
+
+    // Find the upper bound position (first value >= upper_val or > upper_val)
+    auto [upper_chunk_id, upper_in_chunk_offset, upper_exact_match] =
+        this->pk_lower_bound<PK>(
+            upper_val, pk_column.get(), all_chunk_pins, 0);
+
+    int64_t end_idx = 0;
+    if (upper_chunk_id == -1) {
+        // upper_val is greater than all values, include all from start_idx to end
+        end_idx = bitset.size();
+    } else {
+        // If upper_inclusive is true and we found an exact match, include all equal values
+        if (upper_inclusive && upper_exact_match) {
+            auto [last_chunk_id, last_in_chunk_offset] =
+                this->find_last_pk_position<PK>(upper_val,
+                                                pk_column.get(),
+                                                all_chunk_pins,
+                                                upper_chunk_id,
+                                                upper_in_chunk_offset);
+            end_idx = pk_column->GetNumRowsUntilChunk(last_chunk_id) +
+                      last_in_chunk_offset + 1;
+        } else {
+            // upper_inclusive is false or no exact match
+            // In both cases, end at the position of first value >= upper_val
+            end_idx = pk_column->GetNumRowsUntilChunk(upper_chunk_id) +
+                      upper_in_chunk_offset;
+        }
+    }
+
+    // Set bits from start_idx to end_idx - 1
+    if (start_idx < end_idx) {
+        bitset.set(start_idx, end_idx - start_idx, true);
+    }
+}
+
+template <sealed_segment_detail::PrimaryKey PK>
+std::optional<int64_t>
+ChunkedSegmentSealedImpl::find_sorted_pk_doc_offset(
+    const PK& pk,
+    const std::shared_ptr<ChunkedColumnInterface>& pk_column) const {
+    auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
+    auto [chunk_id, in_chunk_offset, exact_match] =
+        this->pk_lower_bound<PK>(pk, pk_column.get(), all_chunk_pins, 0);
+    if (!exact_match) {
+        return std::nullopt;
+    }
+    return pk_column->GetNumRowsUntilChunk(chunk_id) + in_chunk_offset;
+}
+
+template <sealed_segment_detail::PrimaryKey PK>
+void
+ChunkedSegmentSealedImpl::search_pks_with_two_pointers_impl(
+    BitsetTypeView& bitset,
+    const std::vector<PkType>& pks,
+    const std::shared_ptr<ChunkedColumnInterface>& pk_column) const {
+    // TODO: we should sort pks during plan generation
+    std::vector<PK> sorted_pks;
+    sorted_pks.reserve(pks.size());
+    for (const auto& pk : pks) {
+        sorted_pks.push_back(std::get<PK>(pk));
+    }
+    std::sort(sorted_pks.begin(), sorted_pks.end());
+
+    auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
+
+    size_t pk_idx = 0;
+    int last_chunk_id = 0;
+
+    while (pk_idx < sorted_pks.size()) {
+        const auto& target_pk = sorted_pks[pk_idx];
+
+        // find the first occurrence of target_pk
+        auto [chunk_id, in_chunk_offset, exact_match] =
+            this->pk_lower_bound<PK>(
+                target_pk, pk_column.get(), all_chunk_pins, last_chunk_id);
+
+        if (chunk_id == -1) {
+            // All remaining PKs are greater than all values in pk_column
+            break;
+        }
+
+        if (exact_match) {
+            // Found exact match, find the last occurrence
+            auto [last_chunk_id_found, last_in_chunk_offset] =
+                this->find_last_pk_position<PK>(target_pk,
+                                                pk_column.get(),
+                                                all_chunk_pins,
+                                                chunk_id,
+                                                in_chunk_offset);
+
+            // Mark all occurrences from first to last position using global indices
+            auto start_idx =
+                pk_column->GetNumRowsUntilChunk(chunk_id) + in_chunk_offset;
+            auto end_idx =
+                pk_column->GetNumRowsUntilChunk(last_chunk_id_found) +
+                last_in_chunk_offset;
+
+            bitset.set(start_idx, end_idx - start_idx + 1, true);
+            last_chunk_id = last_chunk_id_found;
+        }
+
+        while (pk_idx < sorted_pks.size() &&
+               sorted_pks[pk_idx] == target_pk) {
+            pk_idx++;
+        }
+    }
+}
+
+template <sealed_segment_detail::PrimaryKey PK>
+ChunkedSegmentSealedImpl::PkLowerBoundResult
+ChunkedSegmentSealedImpl::pk_lower_bound(
+    const PK& pk,
+    const ChunkedColumnInterface* pk_column,
+    const std::vector<PinWrapper<Chunk*>>& all_chunk_pins,
+    int from_chunk_id) const {
+    const auto num_chunk = pk_column->num_chunks();
+
+    if (from_chunk_id >= num_chunk) {
+        return {};  // Invalid starting chunk
+    }
+
+    using PKViewType = sealed_segment_detail::PrimaryKeyView<PK>;
+
+    auto get_val_view = [&](int chunk_id, int in_chunk_offset) -> PKViewType {
+        auto& pw = all_chunk_pins[chunk_id];
+        if constexpr (std::same_as<PK, int64_t>) {
+            auto src = reinterpret_cast<const int64_t*>(pw.get()->RawData());
+            return src[in_chunk_offset];
+        } else {
+            auto string_chunk = static_cast<StringChunk*>(pw.get());
+            return string_chunk->operator[](in_chunk_offset);
+        }
+    };
+
+    // Binary search at chunk level to find the first chunk that might contain pk
+    int left_chunk_id = from_chunk_id;
+    int right_chunk_id = num_chunk - 1;
+    int target_chunk_id = -1;
+
+    while (left_chunk_id <= right_chunk_id) {
+        int mid_chunk_id = left_chunk_id + (right_chunk_id - left_chunk_id) / 2;
+        auto chunk_row_num = pk_column->chunk_row_nums(mid_chunk_id);
+
+        PKViewType min_val = get_val_view(mid_chunk_id, 0);
+        PKViewType max_val = get_val_view(mid_chunk_id, chunk_row_num - 1);
+
+        if (pk >= min_val && pk <= max_val) {
+            // pk might be in this chunk
+            target_chunk_id = mid_chunk_id;
+            break;
+        } else if (pk < min_val) {
+            // pk is before this chunk, could be in an earlier chunk
+            target_chunk_id = mid_chunk_id;  // This chunk has values >= pk
+            right_chunk_id = mid_chunk_id - 1;
+        } else {
+            // pk is after this chunk, search in later chunks
+            left_chunk_id = mid_chunk_id + 1;
+        }
+    }
+
+    // If no suitable chunk found, check if we need the first position after all chunks
+    if (target_chunk_id == -1) {
+        if (left_chunk_id >= num_chunk) {
+            // pk is greater than all values
+            return {};
+        }
+        target_chunk_id = left_chunk_id;
+    }
+
+    // Binary search within the target chunk to find lower_bound position
+    auto chunk_row_num = pk_column->chunk_row_nums(target_chunk_id);
+    int left_offset = 0;
+    int right_offset = chunk_row_num;
+
+    while (left_offset < right_offset) {
+        int mid_offset = left_offset + (right_offset - left_offset) / 2;
+        PKViewType mid_val = get_val_view(target_chunk_id, mid_offset);
+
+        if (mid_val < pk) {
+            left_offset = mid_offset + 1;
+        } else {
+            right_offset = mid_offset;
+        }
+    }
+
+    // Check if we found a valid position
+    if (left_offset < chunk_row_num) {
+        // Found position within current chunk
+        PKViewType found_val = get_val_view(target_chunk_id, left_offset);
+        bool exact_match = (found_val == pk);
+        return {target_chunk_id, left_offset, exact_match};
+    } else {
+        // Position is beyond current chunk, try next chunk
+        if (target_chunk_id + 1 < num_chunk) {
+            // Next chunk exists, return its first position
+            // Check if the first value in next chunk equals pk
+            PKViewType next_val = get_val_view(target_chunk_id + 1, 0);
+            bool exact_match = (next_val == pk);
+            return {target_chunk_id + 1, 0, exact_match};
+        } else {
+            // No more chunks, pk is greater than all values
+            return {};
+        }
+    }
+}
+
+template <sealed_segment_detail::PrimaryKey PK>
+ChunkedSegmentSealedImpl::PkPosition
+ChunkedSegmentSealedImpl::find_last_pk_position(
+    const PK& pk,
+    const ChunkedColumnInterface* pk_column,
+    const std::vector<PinWrapper<Chunk*>>& all_chunk_pins,
+    int first_chunk_id,
+    int first_in_chunk_offset) const {
+    const auto num_chunk = pk_column->num_chunks();
+
+    using PKViewType = sealed_segment_detail::PrimaryKeyView<PK>;
+
+    auto get_val_view = [&](int chunk_id, int in_chunk_offset) -> PKViewType {
+        auto pw = all_chunk_pins[chunk_id];
+        if constexpr (std::same_as<PK, int64_t>) {
+            auto src = reinterpret_cast<const int64_t*>(pw.get()->RawData());
+            return src[in_chunk_offset];
+        } else {
+            auto string_chunk = static_cast<StringChunk*>(pw.get());
+            return string_chunk->operator[](in_chunk_offset);
+        }
+    };
+
+    int last_chunk_id = first_chunk_id;
+    int last_offset = first_in_chunk_offset;
+
+    // Linear scan forward in current chunk
+    auto chunk_row_num = pk_column->chunk_row_nums(first_chunk_id);
+    for (int offset = first_in_chunk_offset + 1; offset < chunk_row_num;
+         offset++) {
+        PKViewType curr_val = get_val_view(first_chunk_id, offset);
+        if (curr_val == pk) {
+            last_offset = offset;
+        } else {
+            // Found first value != pk, done
+            return {last_chunk_id, last_offset};
+        }
+    }
+
+    // Continue scanning in subsequent chunks
+    for (int chunk_id = first_chunk_id + 1; chunk_id < num_chunk; chunk_id++) {
+        auto curr_chunk_row_num = pk_column->chunk_row_nums(chunk_id);
+
+        // Check first value in this chunk
+        PKViewType first_val = get_val_view(chunk_id, 0);
+        if (first_val != pk) {
+            // This chunk doesn't contain pk anymore
+            return {last_chunk_id, last_offset};
+        }
+
+        // Update last position and scan this chunk
+        last_chunk_id = chunk_id;
+        last_offset = 0;
+
+        for (int offset = 1; offset < curr_chunk_row_num; offset++) {
+            PKViewType curr_val = get_val_view(chunk_id, offset);
+            if (curr_val == pk) {
+                last_offset = offset;
+            } else {
+                // Found first value != pk
+                return {last_chunk_id, last_offset};
+            }
+        }
+        // All values in this chunk equal pk, continue to next chunk
+    }
+
+    // Scanned all chunks, return last found position
+    return {last_chunk_id, last_offset};
 }
 
 PinWrapper<const storagev2translator::TimestampIndexCell*>

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -257,16 +257,14 @@ static void
 cancel_and_erase_json_indices(std::vector<JsonIndexT>& json_indices,
                               FieldId field_id,
                               std::string_view nested_path) {
-    auto new_end = std::remove_if(
-        json_indices.begin(), json_indices.end(), [&](auto& index) {
-            auto matched =
-                index.field_id == field_id && index.nested_path == nested_path;
-            if (matched) {
-                cancel_warmup(index.index);
-            }
-            return matched;
-        });
-    json_indices.erase(new_end, json_indices.end());
+    std::erase_if(json_indices, [&](auto& index) {
+        auto matched =
+            index.field_id == field_id && index.nested_path == nested_path;
+        if (matched) {
+            cancel_warmup(index.index);
+        }
+        return matched;
+    });
 }
 
 template <typename JsonIndexT>
@@ -4358,12 +4356,9 @@ ChunkedSegmentSealedImpl::HasJsonIndex(FieldId field_id) const {
     // HasIndex() preserves its narrower "scalar/vector/binlog index exists"
     // semantics for ReorderConjunctExpr and other consumers.
     return json_indices.withRLock([&](const auto& vec) {
-        for (const auto& index : vec) {
-            if (index.field_id == field_id) {
-                return true;
-            }
-        }
-        return false;
+        return std::ranges::any_of(vec, [field_id](const auto& index) {
+            return index.field_id == field_id;
+        });
     });
 }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -306,6 +306,30 @@ get_pk_value(const PinWrapper<Chunk*>& pin, int64_t offset) {
     }
 }
 
+std::vector<int64_t>
+build_chunk_offsets(const ChunkedColumnInterface& column) {
+    auto num_chunks = column.num_chunks();
+    std::vector<int64_t> chunk_offsets(num_chunks + 1, 0);
+    for (int64_t c = 0; c < num_chunks; ++c) {
+        chunk_offsets[c + 1] = chunk_offsets[c] + column.chunk_row_nums(c);
+    }
+    return chunk_offsets;
+}
+
+int64_t
+chunk_id_for_offset(const std::vector<int64_t>& chunk_offsets,
+                    int64_t offset) {
+    AssertInfo(chunk_offsets.size() >= 2, "chunk offsets must not be empty");
+    auto chunk_it = std::ranges::upper_bound(chunk_offsets, offset);
+    if (chunk_it == chunk_offsets.begin()) {
+        return 0;
+    }
+    if (chunk_it == chunk_offsets.end()) {
+        return static_cast<int64_t>(chunk_offsets.size()) - 2;
+    }
+    return static_cast<int64_t>(chunk_it - chunk_offsets.begin() - 1);
+}
+
 template <sealed_segment_detail::PrimaryKey PK, typename Callback>
 void
 for_each_sorted_pk_match(
@@ -2545,12 +2569,7 @@ ChunkedSegmentSealedImpl::search_batch_pks(
     std::vector<int64_t> ts_chunk_offsets;
     if (ts_column) {
         ts_chunk_pins = ts_column->GetAllChunks(nullptr);
-        auto num_ts_chunks = ts_column->num_chunks();
-        ts_chunk_offsets.resize(num_ts_chunks + 1, 0);
-        for (int64_t c = 0; c < num_ts_chunks; c++) {
-            ts_chunk_offsets[c + 1] =
-                ts_chunk_offsets[c] + ts_column->chunk_row_nums(c);
-        }
+        ts_chunk_offsets = build_chunk_offsets(*ts_column);
     } else if (!effective_commit_ts) {
         AssertInfo(!insert_record_.timestamps_.empty(),
                    "timestamp data is not ready");
@@ -2562,11 +2581,7 @@ ChunkedSegmentSealedImpl::search_batch_pks(
         if (!ts_column) {
             return insert_record_.timestamps_[offset];
         }
-        auto num_ts_chunks = static_cast<int64_t>(ts_chunk_pins.size());
-        int64_t c = 0;
-        while (c < num_ts_chunks - 1 && offset >= ts_chunk_offsets[c + 1]) {
-            ++c;
-        }
+        auto c = chunk_id_for_offset(ts_chunk_offsets, offset);
         auto* data = reinterpret_cast<const Timestamp*>(
             ts_chunk_pins[c].get()->RawData());
         return data[offset - ts_chunk_offsets[c]];
@@ -2978,21 +2993,10 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
             if (ts_column) {
                 // StorageV2: read from timestamp column directly
                 auto all_chunks = ts_column->GetAllChunks(op_ctx);
-                // Build prefix-sum for chunk offset lookup
-                auto num_chunks = ts_column->num_chunks();
-                std::vector<int64_t> chunk_offsets(num_chunks + 1, 0);
-                for (int64_t c = 0; c < num_chunks; c++) {
-                    chunk_offsets[c + 1] =
-                        chunk_offsets[c] + ts_column->chunk_row_nums(c);
-                }
+                auto chunk_offsets = build_chunk_offsets(*ts_column);
                 for (int64_t i = 0; i < count; ++i) {
                     auto offset = seg_offsets[i];
-                    // Find chunk via linear scan (chunks are typically few)
-                    int64_t c = 0;
-                    while (c < num_chunks - 1 &&
-                           offset >= chunk_offsets[c + 1]) {
-                        ++c;
-                    }
+                    auto c = chunk_id_for_offset(chunk_offsets, offset);
                     auto* chunk_data = reinterpret_cast<const Timestamp*>(
                         all_chunks[c].get()->RawData());
                     dst[i] = chunk_data[offset - chunk_offsets[c]];

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -320,10 +320,12 @@ for_each_sorted_pk_match(
         if constexpr (std::same_as<PK, int64_t>) {
             auto src = reinterpret_cast<const int64_t*>(pw.get()->RawData());
             auto chunk_row_num = pk_column->chunk_row_nums(i);
+            auto chunk_end = src + chunk_row_num;
             for (size_t j = 0; j < pks.size(); ++j) {
                 auto target = std::get<int64_t>(pks[j]);
-                auto it = std::lower_bound(src, src + chunk_row_num, target);
-                for (; it != src + chunk_row_num && *it == target; ++it) {
+                auto [match_begin, match_end] =
+                    std::equal_range(src, chunk_end, target);
+                for (auto it = match_begin; it != match_end; ++it) {
                     callback(j, it - src + num_rows_until_chunk);
                 }
             }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -294,6 +294,18 @@ dispatch_pk_type(DataType data_type, Func&& func) {
     }
 }
 
+template <sealed_segment_detail::PrimaryKey PK>
+sealed_segment_detail::PrimaryKeyView<PK>
+get_pk_value(const PinWrapper<Chunk*>& pin, int64_t offset) {
+    if constexpr (std::same_as<PK, int64_t>) {
+        auto src = reinterpret_cast<const int64_t*>(pin.get()->RawData());
+        return src[offset];
+    } else {
+        auto string_chunk = static_cast<StringChunk*>(pin.get());
+        return string_chunk->operator[](offset);
+    }
+}
+
 template <sealed_segment_detail::PrimaryKey PK, typename Callback>
 void
 for_each_sorted_pk_match(
@@ -582,19 +594,6 @@ ChunkedSegmentSealedImpl::pk_lower_bound(
         return {};  // Invalid starting chunk
     }
 
-    using PKViewType = sealed_segment_detail::PrimaryKeyView<PK>;
-
-    auto get_val_view = [&](int chunk_id, int in_chunk_offset) -> PKViewType {
-        auto& pw = all_chunk_pins[chunk_id];
-        if constexpr (std::same_as<PK, int64_t>) {
-            auto src = reinterpret_cast<const int64_t*>(pw.get()->RawData());
-            return src[in_chunk_offset];
-        } else {
-            auto string_chunk = static_cast<StringChunk*>(pw.get());
-            return string_chunk->operator[](in_chunk_offset);
-        }
-    };
-
     // Binary search at chunk level to find the first chunk that might contain pk
     int left_chunk_id = from_chunk_id;
     int right_chunk_id = num_chunk - 1;
@@ -604,8 +603,9 @@ ChunkedSegmentSealedImpl::pk_lower_bound(
         int mid_chunk_id = left_chunk_id + (right_chunk_id - left_chunk_id) / 2;
         auto chunk_row_num = pk_column->chunk_row_nums(mid_chunk_id);
 
-        PKViewType min_val = get_val_view(mid_chunk_id, 0);
-        PKViewType max_val = get_val_view(mid_chunk_id, chunk_row_num - 1);
+        auto min_val = get_pk_value<PK>(all_chunk_pins[mid_chunk_id], 0);
+        auto max_val =
+            get_pk_value<PK>(all_chunk_pins[mid_chunk_id], chunk_row_num - 1);
 
         if (pk >= min_val && pk <= max_val) {
             // pk might be in this chunk
@@ -637,7 +637,8 @@ ChunkedSegmentSealedImpl::pk_lower_bound(
 
     while (left_offset < right_offset) {
         int mid_offset = left_offset + (right_offset - left_offset) / 2;
-        PKViewType mid_val = get_val_view(target_chunk_id, mid_offset);
+        auto mid_val =
+            get_pk_value<PK>(all_chunk_pins[target_chunk_id], mid_offset);
 
         if (mid_val < pk) {
             left_offset = mid_offset + 1;
@@ -649,7 +650,8 @@ ChunkedSegmentSealedImpl::pk_lower_bound(
     // Check if we found a valid position
     if (left_offset < chunk_row_num) {
         // Found position within current chunk
-        PKViewType found_val = get_val_view(target_chunk_id, left_offset);
+        auto found_val =
+            get_pk_value<PK>(all_chunk_pins[target_chunk_id], left_offset);
         bool exact_match = (found_val == pk);
         return {target_chunk_id, left_offset, exact_match};
     } else {
@@ -657,7 +659,8 @@ ChunkedSegmentSealedImpl::pk_lower_bound(
         if (target_chunk_id + 1 < num_chunk) {
             // Next chunk exists, return its first position
             // Check if the first value in next chunk equals pk
-            PKViewType next_val = get_val_view(target_chunk_id + 1, 0);
+            auto next_val =
+                get_pk_value<PK>(all_chunk_pins[target_chunk_id + 1], 0);
             bool exact_match = (next_val == pk);
             return {target_chunk_id + 1, 0, exact_match};
         } else {
@@ -677,19 +680,6 @@ ChunkedSegmentSealedImpl::find_last_pk_position(
     int first_in_chunk_offset) const {
     const auto num_chunk = pk_column->num_chunks();
 
-    using PKViewType = sealed_segment_detail::PrimaryKeyView<PK>;
-
-    auto get_val_view = [&](int chunk_id, int in_chunk_offset) -> PKViewType {
-        auto pw = all_chunk_pins[chunk_id];
-        if constexpr (std::same_as<PK, int64_t>) {
-            auto src = reinterpret_cast<const int64_t*>(pw.get()->RawData());
-            return src[in_chunk_offset];
-        } else {
-            auto string_chunk = static_cast<StringChunk*>(pw.get());
-            return string_chunk->operator[](in_chunk_offset);
-        }
-    };
-
     int last_chunk_id = first_chunk_id;
     int last_offset = first_in_chunk_offset;
 
@@ -697,7 +687,8 @@ ChunkedSegmentSealedImpl::find_last_pk_position(
     auto chunk_row_num = pk_column->chunk_row_nums(first_chunk_id);
     for (int offset = first_in_chunk_offset + 1; offset < chunk_row_num;
          offset++) {
-        PKViewType curr_val = get_val_view(first_chunk_id, offset);
+        auto curr_val =
+            get_pk_value<PK>(all_chunk_pins[first_chunk_id], offset);
         if (curr_val == pk) {
             last_offset = offset;
         } else {
@@ -711,7 +702,7 @@ ChunkedSegmentSealedImpl::find_last_pk_position(
         auto curr_chunk_row_num = pk_column->chunk_row_nums(chunk_id);
 
         // Check first value in this chunk
-        PKViewType first_val = get_val_view(chunk_id, 0);
+        auto first_val = get_pk_value<PK>(all_chunk_pins[chunk_id], 0);
         if (first_val != pk) {
             // This chunk doesn't contain pk anymore
             return {last_chunk_id, last_offset};
@@ -722,7 +713,7 @@ ChunkedSegmentSealedImpl::find_last_pk_position(
         last_offset = 0;
 
         for (int offset = 1; offset < curr_chunk_row_num; offset++) {
-            PKViewType curr_val = get_val_view(chunk_id, offset);
+            auto curr_val = get_pk_value<PK>(all_chunk_pins[chunk_id], offset);
             if (curr_val == pk) {
                 last_offset = offset;
             } else {

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3130,33 +3130,31 @@ ChunkedSegmentSealedImpl::bulk_subscript(milvus::OpContext* op_ctx,
         case DataType::TEXT: {
             // dst must have at least count elements; the callback's offset
             // parameter is guaranteed to be in [0, count)
-            bulk_subscript_ptr_impl<std::string>(
-                op_ctx,
-                column.get(),
-                seg_offsets,
-                count,
-                static_cast<std::string*>(data));
+            bulk_subscript_string_impl(op_ctx,
+                                       column.get(),
+                                       seg_offsets,
+                                       count,
+                                       static_cast<std::string*>(data));
             break;
         }
         case DataType::JSON: {
             // dst must have at least count elements; the callback's offset
             // parameter is guaranteed to be in [0, count)
-            bulk_subscript_ptr_impl<Json>(op_ctx,
-                                          column.get(),
-                                          seg_offsets,
-                                          count,
-                                          static_cast<Json*>(data));
+            bulk_subscript_json_impl(op_ctx,
+                                     column.get(),
+                                     seg_offsets,
+                                     count,
+                                     static_cast<Json*>(data));
             break;
         }
         case DataType::GEOMETRY: {
             // dst must have at least count elements; the callback's offset
             // parameter is guaranteed to be in [0, count)
-            bulk_subscript_ptr_impl<std::string>(
-                op_ctx,
-                column.get(),
-                seg_offsets,
-                count,
-                static_cast<std::string*>(data));
+            bulk_subscript_string_impl(op_ctx,
+                                       column.get(),
+                                       seg_offsets,
+                                       count,
+                                       static_cast<std::string*>(data));
             break;
         }
         case DataType::ARRAY: {
@@ -3223,60 +3221,68 @@ ChunkedSegmentSealedImpl::bulk_subscript_impl(milvus::OpContext* op_ctx,
         op_ctx, dst_vec, seg_offsets, element_sizeof, count);
 }
 
-template <typename S>
 void
-ChunkedSegmentSealedImpl::bulk_subscript_ptr_impl(
-    milvus::OpContext* op_ctx,
-    ChunkedColumnInterface* column,
-    const int64_t* seg_offsets,
-    int64_t count,
-    google::protobuf::RepeatedPtrField<std::string>* dst) {
-    if constexpr (std::is_same_v<S, Json>) {
-        column->BulkRawJsonAt(
-            op_ctx,
-            [&](Json json, size_t offset, bool is_valid) {
-                dst->at(offset) = std::string(json.data());
-            },
-            seg_offsets,
-            count);
-    } else {
-        static_assert(std::is_same_v<S, std::string>);
-        column->BulkRawStringAt(
-            op_ctx,
-            [dst](std::string_view value, size_t offset, bool is_valid) {
-                dst->at(offset) = std::string(value);
-            },
-            seg_offsets,
-            count);
-    }
-}
-
-template <typename S, typename T>
-void
-ChunkedSegmentSealedImpl::bulk_subscript_ptr_impl(
+ChunkedSegmentSealedImpl::bulk_subscript_string_impl(
     milvus::OpContext* op_ctx,
     const ChunkedColumnInterface* column,
     const int64_t* seg_offsets,
     int64_t count,
-    T* dst) {
-    if constexpr (std::is_same_v<S, Json>) {
-        column->BulkRawJsonAt(
-            op_ctx,
-            [&](Json json, size_t offset, bool is_valid) {
-                dst[offset] = std::move(T(json));
-            },
-            seg_offsets,
-            count);
-    } else {
-        static_assert(std::is_same_v<S, std::string>);
-        column->BulkRawStringAt(
-            op_ctx,
-            [&](std::string_view value, size_t offset, bool is_valid) {
-                dst[offset] = std::move(T(value));
-            },
-            seg_offsets,
-            count);
-    }
+    google::protobuf::RepeatedPtrField<std::string>* dst) {
+    column->BulkRawStringAt(
+        op_ctx,
+        [dst](std::string_view value, size_t offset, bool is_valid) {
+            dst->at(offset) = std::string(value);
+        },
+        seg_offsets,
+        count);
+}
+
+void
+ChunkedSegmentSealedImpl::bulk_subscript_json_impl(
+    milvus::OpContext* op_ctx,
+    const ChunkedColumnInterface* column,
+    const int64_t* seg_offsets,
+    int64_t count,
+    google::protobuf::RepeatedPtrField<std::string>* dst) {
+    column->BulkRawJsonAt(
+        op_ctx,
+        [dst](Json json, size_t offset, bool is_valid) {
+            dst->at(offset) = std::string(json.data());
+        },
+        seg_offsets,
+        count);
+}
+
+void
+ChunkedSegmentSealedImpl::bulk_subscript_string_impl(
+    milvus::OpContext* op_ctx,
+    const ChunkedColumnInterface* column,
+    const int64_t* seg_offsets,
+    int64_t count,
+    std::string* dst) {
+    column->BulkRawStringAt(
+        op_ctx,
+        [dst](std::string_view value, size_t offset, bool is_valid) {
+            dst[offset] = std::string(value);
+        },
+        seg_offsets,
+        count);
+}
+
+void
+ChunkedSegmentSealedImpl::bulk_subscript_json_impl(
+    milvus::OpContext* op_ctx,
+    const ChunkedColumnInterface* column,
+    const int64_t* seg_offsets,
+    int64_t count,
+    Json* dst) {
+    column->BulkRawJsonAt(
+        op_ctx,
+        [dst](Json json, size_t offset, bool is_valid) {
+            dst[offset] = Json(json);
+        },
+        seg_offsets,
+        count);
 }
 
 template <typename T>
@@ -3854,7 +3860,7 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
     switch (field_meta.get_data_type()) {
         case DataType::VARCHAR:
         case DataType::STRING: {
-            bulk_subscript_ptr_impl<std::string>(
+            bulk_subscript_string_impl(
                 op_ctx,
                 column.get(),
                 seg_offsets,
@@ -3882,7 +3888,7 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
         }
 
         case DataType::JSON: {
-            bulk_subscript_ptr_impl<Json>(
+            bulk_subscript_json_impl(
                 op_ctx,
                 column.get(),
                 seg_offsets,
@@ -3892,13 +3898,13 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
         }
 
         case DataType::GEOMETRY: {
-            bulk_subscript_ptr_impl<std::string>(op_ctx,
-                                                 column.get(),
-                                                 seg_offsets,
-                                                 count,
-                                                 ret->mutable_scalars()
-                                                     ->mutable_geometry_data()
-                                                     ->mutable_data());
+            bulk_subscript_string_impl(op_ctx,
+                                       column.get(),
+                                       seg_offsets,
+                                       count,
+                                       ret->mutable_scalars()
+                                           ->mutable_geometry_data()
+                                           ->mutable_data());
             break;
         }
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -4449,17 +4449,13 @@ ChunkedSegmentSealedImpl::Delete(int64_t size,
     auto has_pk_index = pk_index.get() != nullptr ? !pk_index.get()->empty_pks()
                                                   : !insert_record_.empty_pks();
     if (has_pk_index) {
-        auto end = std::remove_if(
-            ordering.begin(),
-            ordering.end(),
-            [&](const std::tuple<Timestamp, PkType>& record) {
-                if (pk_index.get() != nullptr) {
-                    return !pk_index.get()->contain(std::get<1>(record));
-                }
-                return !insert_record_.contain(std::get<1>(record));
-            });
-        size = end - ordering.begin();
-        ordering.resize(size);
+        std::erase_if(ordering, [&](const auto& record) {
+            if (pk_index.get() != nullptr) {
+                return !pk_index.get()->contain(std::get<1>(record));
+            }
+            return !insert_record_.contain(std::get<1>(record));
+        });
+        size = ordering.size();
     }
     if (size == 0) {
         return SegcoreError::success();

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -37,6 +37,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <variant>
 #include <vector>
 #include <nlohmann/json.hpp>
@@ -274,6 +275,24 @@ cancel_and_clear_json_indices(std::vector<JsonIndexT>& json_indices) {
         cancel_warmup(index.index);
     }
     json_indices.clear();
+}
+
+[[noreturn]] static void
+throw_unsupported_pk_type(DataType data_type) {
+    ThrowInfo(DataTypeInvalid, fmt::format("unsupported type {}", data_type));
+}
+
+template <typename Func>
+decltype(auto)
+dispatch_pk_type(DataType data_type, Func&& func) {
+    switch (data_type) {
+        case DataType::INT64:
+            return std::forward<Func>(func).template operator()<int64_t>();
+        case DataType::VARCHAR:
+            return std::forward<Func>(func).template operator()<std::string>();
+        default:
+            throw_unsupported_pk_type(data_type);
+    }
 }
 
 PinWrapper<const storagev2translator::TimestampIndexCell*>
@@ -2095,22 +2114,12 @@ ChunkedSegmentSealedImpl::search_pks(BitsetType& bitset,
     auto pk_column = get_column(pk_field_id);
     AssertInfo(pk_column != nullptr, "primary key column not loaded");
 
-    switch (schema_->get_fields().at(pk_field_id).get_data_type()) {
-        case DataType::INT64:
-            search_pks_with_two_pointers_impl<int64_t>(
+    dispatch_pk_type(
+        schema_->get_fields().at(pk_field_id).get_data_type(),
+        [&]<sealed_segment_detail::PrimaryKey PK>() {
+            search_pks_with_two_pointers_impl<PK>(
                 bitset_view, pks, pk_column);
-            break;
-        case DataType::VARCHAR:
-            search_pks_with_two_pointers_impl<std::string>(
-                bitset_view, pks, pk_column);
-            break;
-        default:
-            ThrowInfo(
-                DataTypeInvalid,
-                fmt::format(
-                    "unsupported type {}",
-                    schema_->get_fields().at(pk_field_id).get_data_type()));
-    }
+        });
 }
 
 void
@@ -2322,22 +2331,12 @@ ChunkedSegmentSealedImpl::search_sorted_pk_range(milvus::OpContext* op_ctx,
     auto pk_column = get_column(pk_field_id);
     AssertInfo(pk_column != nullptr, "primary key column not loaded");
 
-    switch (schema_->get_fields().at(pk_field_id).get_data_type()) {
-        case DataType::INT64:
-            search_sorted_pk_range_impl<int64_t>(
-                op, std::get<int64_t>(pk), pk_column, bitset);
-            break;
-        case DataType::VARCHAR:
-            search_sorted_pk_range_impl<std::string>(
-                op, std::get<std::string>(pk), pk_column, bitset);
-            break;
-        default:
-            ThrowInfo(
-                DataTypeInvalid,
-                fmt::format(
-                    "unsupported type {}",
-                    schema_->get_fields().at(pk_field_id).get_data_type()));
-    }
+    dispatch_pk_type(
+        schema_->get_fields().at(pk_field_id).get_data_type(),
+        [&]<sealed_segment_detail::PrimaryKey PK>() {
+            search_sorted_pk_range_impl<PK>(
+                op, std::get<PK>(pk), pk_column, bitset);
+        });
 }
 
 void
@@ -2387,32 +2386,16 @@ ChunkedSegmentSealedImpl::pk_binary_range(milvus::OpContext* op_ctx,
     auto pk_column = get_column(pk_field_id);
     AssertInfo(pk_column != nullptr, "primary key column not loaded");
 
-    switch (schema_->get_fields().at(pk_field_id).get_data_type()) {
-        case DataType::INT64:
-            search_sorted_pk_binary_range_impl<int64_t>(
-                std::get<int64_t>(lower_pk),
-                lower_inclusive,
-                std::get<int64_t>(upper_pk),
-                upper_inclusive,
-                pk_column,
-                bitset);
-            break;
-        case DataType::VARCHAR:
-            search_sorted_pk_binary_range_impl<std::string>(
-                std::get<std::string>(lower_pk),
-                lower_inclusive,
-                std::get<std::string>(upper_pk),
-                upper_inclusive,
-                pk_column,
-                bitset);
-            break;
-        default:
-            ThrowInfo(
-                DataTypeInvalid,
-                fmt::format(
-                    "unsupported type {}",
-                    schema_->get_fields().at(pk_field_id).get_data_type()));
-    }
+    dispatch_pk_type(
+        schema_->get_fields().at(pk_field_id).get_data_type(),
+        [&]<sealed_segment_detail::PrimaryKey PK>() {
+            search_sorted_pk_binary_range_impl<PK>(std::get<PK>(lower_pk),
+                                                   lower_inclusive,
+                                                   std::get<PK>(upper_pk),
+                                                   upper_inclusive,
+                                                   pk_column,
+                                                   bitset);
+        });
 }
 
 std::pair<std::vector<OffsetMap::OffsetType>, bool>
@@ -2486,22 +2469,12 @@ ChunkedSegmentSealedImpl::find_first_n_element(
         AssertInfo(pk_field_id.get() != -1, "Primary key is -1");
         auto pk_column = get_column(pk_field_id);
         AssertInfo(pk_column != nullptr, "primary key column not loaded");
-        switch (schema_->get_fields().at(pk_field_id).get_data_type()) {
-            case DataType::INT64:
-                cursor_doc_offset = find_sorted_pk_doc_offset<int64_t>(
-                    std::get<int64_t>(cursor->last_pk), pk_column);
-                break;
-            case DataType::VARCHAR:
-                cursor_doc_offset = find_sorted_pk_doc_offset<std::string>(
-                    std::get<std::string>(cursor->last_pk), pk_column);
-                break;
-            default:
-                ThrowInfo(
-                    DataTypeInvalid,
-                    fmt::format(
-                        "unsupported type {}",
-                        schema_->get_fields().at(pk_field_id).get_data_type()));
-        }
+        cursor_doc_offset = dispatch_pk_type(
+            schema_->get_fields().at(pk_field_id).get_data_type(),
+            [&]<sealed_segment_detail::PrimaryKey PK>() {
+                return find_sorted_pk_doc_offset<PK>(
+                    std::get<PK>(cursor->last_pk), pk_column);
+            });
     }
 
     int64_t hit_num = 0;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -744,38 +744,13 @@ ChunkedSegmentSealedImpl::Contain(const PkType& pk) const {
         AssertInfo(pk_field_id.get() != -1, "Primary key is -1");
         auto pk_column = get_column(pk_field_id);
         if (pk_column != nullptr) {
-            auto num_chunks = pk_column->num_chunks();
-            auto all_chunks = pk_column->GetAllChunks(nullptr);
-            switch (schema_->get_fields().at(pk_field_id).get_data_type()) {
-                case DataType::INT64: {
-                    auto target = std::get<int64_t>(pk);
-                    for (int64_t i = 0; i < num_chunks; ++i) {
-                        auto* src = reinterpret_cast<const int64_t*>(
-                            all_chunks[i].get()->RawData());
-                        auto rows = pk_column->chunk_row_nums(i);
-                        auto it = std::lower_bound(src, src + rows, target);
-                        if (it != src + rows && *it == target) {
-                            return true;
-                        }
-                    }
-                    return false;
-                }
-                case DataType::VARCHAR: {
-                    auto& target = std::get<std::string>(pk);
-                    for (int64_t i = 0; i < num_chunks; ++i) {
-                        auto* chunk =
-                            static_cast<StringChunk*>(all_chunks[i].get());
-                        auto offset = chunk->binary_search_string(target);
-                        if (offset != -1 && offset < chunk->RowNums() &&
-                            chunk->operator[](offset) == target) {
-                            return true;
-                        }
-                    }
-                    return false;
-                }
-                default:
-                    break;
-            }
+            return dispatch_pk_type(
+                schema_->get_fields().at(pk_field_id).get_data_type(),
+                [&]<sealed_segment_detail::PrimaryKey PK>() {
+                    return find_sorted_pk_doc_offset<PK>(
+                               std::get<PK>(pk), pk_column)
+                        .has_value();
+                });
         }
     }
     return insert_record_.contain(pk);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -3288,7 +3288,7 @@ ChunkedSegmentSealedImpl::bulk_subscript_impl(milvus::OpContext* op_ctx,
         dst[i] = src[offset];
     }
 }
-template <typename S, typename T>
+template <sealed_segment_detail::PrimitiveBulkSubscriptValue T>
 void
 ChunkedSegmentSealedImpl::bulk_subscript_impl(milvus::OpContext* op_ctx,
                                               ChunkedColumnInterface* field,
@@ -3296,7 +3296,6 @@ ChunkedSegmentSealedImpl::bulk_subscript_impl(milvus::OpContext* op_ctx,
                                               int64_t count,
                                               T* dst,
                                               bool small_int_raw_type) {
-    static_assert(std::is_fundamental_v<S> && std::is_fundamental_v<T>);
     // use field->data_type_ to determine the type of dst
     field->BulkPrimitiveValueAt(op_ctx,
                                 static_cast<void*>(dst),
@@ -4017,84 +4016,84 @@ ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
         }
 
         case DataType::BOOL: {
-            bulk_subscript_impl<bool, bool>(op_ctx,
-                                            column.get(),
-                                            seg_offsets,
-                                            count,
-                                            ret->mutable_scalars()
-                                                ->mutable_bool_data()
-                                                ->mutable_data()
-                                                ->mutable_data());
+            bulk_subscript_impl<bool>(op_ctx,
+                                      column.get(),
+                                      seg_offsets,
+                                      count,
+                                      ret->mutable_scalars()
+                                          ->mutable_bool_data()
+                                          ->mutable_data()
+                                          ->mutable_data());
             break;
         }
         case DataType::INT8: {
-            bulk_subscript_impl<int8_t, int32_t>(op_ctx,
-                                                 column.get(),
-                                                 seg_offsets,
-                                                 count,
-                                                 ret->mutable_scalars()
-                                                     ->mutable_int_data()
-                                                     ->mutable_data()
-                                                     ->mutable_data());
+            bulk_subscript_impl<int32_t>(op_ctx,
+                                         column.get(),
+                                         seg_offsets,
+                                         count,
+                                         ret->mutable_scalars()
+                                             ->mutable_int_data()
+                                             ->mutable_data()
+                                             ->mutable_data());
             break;
         }
         case DataType::INT16: {
-            bulk_subscript_impl<int16_t, int32_t>(op_ctx,
-                                                  column.get(),
-                                                  seg_offsets,
-                                                  count,
-                                                  ret->mutable_scalars()
-                                                      ->mutable_int_data()
-                                                      ->mutable_data()
-                                                      ->mutable_data());
+            bulk_subscript_impl<int32_t>(op_ctx,
+                                         column.get(),
+                                         seg_offsets,
+                                         count,
+                                         ret->mutable_scalars()
+                                             ->mutable_int_data()
+                                             ->mutable_data()
+                                             ->mutable_data());
             break;
         }
         case DataType::INT32: {
-            bulk_subscript_impl<int32_t, int32_t>(op_ctx,
-                                                  column.get(),
-                                                  seg_offsets,
-                                                  count,
-                                                  ret->mutable_scalars()
-                                                      ->mutable_int_data()
-                                                      ->mutable_data()
-                                                      ->mutable_data());
+            bulk_subscript_impl<int32_t>(op_ctx,
+                                         column.get(),
+                                         seg_offsets,
+                                         count,
+                                         ret->mutable_scalars()
+                                             ->mutable_int_data()
+                                             ->mutable_data()
+                                             ->mutable_data());
             break;
         }
         case DataType::INT64: {
-            bulk_subscript_impl<int64_t, int64_t>(op_ctx,
-                                                  column.get(),
-                                                  seg_offsets,
-                                                  count,
-                                                  ret->mutable_scalars()
-                                                      ->mutable_long_data()
-                                                      ->mutable_data()
-                                                      ->mutable_data());
+            bulk_subscript_impl<int64_t>(op_ctx,
+                                         column.get(),
+                                         seg_offsets,
+                                         count,
+                                         ret->mutable_scalars()
+                                             ->mutable_long_data()
+                                             ->mutable_data()
+                                             ->mutable_data());
             break;
         }
         case DataType::FLOAT: {
-            bulk_subscript_impl<float, float>(op_ctx,
-                                              column.get(),
-                                              seg_offsets,
-                                              count,
-                                              ret->mutable_scalars()
-                                                  ->mutable_float_data()
-                                                  ->mutable_data()
-                                                  ->mutable_data());
+            bulk_subscript_impl<float>(op_ctx,
+                                       column.get(),
+                                       seg_offsets,
+                                       count,
+                                       ret->mutable_scalars()
+                                           ->mutable_float_data()
+                                           ->mutable_data()
+                                           ->mutable_data());
             break;
         }
         case DataType::DOUBLE: {
-            bulk_subscript_impl<double, double>(op_ctx,
-                                                column.get(),
-                                                seg_offsets,
-                                                count,
-                                                ret->mutable_scalars()
-                                                    ->mutable_double_data()
-                                                    ->mutable_data()
-                                                    ->mutable_data());
+            bulk_subscript_impl<double>(op_ctx,
+                                        column.get(),
+                                        seg_offsets,
+                                        count,
+                                        ret->mutable_scalars()
+                                            ->mutable_double_data()
+                                            ->mutable_data()
+                                            ->mutable_data());
             break;
         }
         case DataType::TIMESTAMPTZ: {
-            bulk_subscript_impl<int64_t, int64_t>(
+            bulk_subscript_impl<int64_t>(
                 op_ctx,
                 column.get(),
                 seg_offsets,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1086,7 +1086,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
     auto properties = std::make_shared<milvus_storage::api::Properties>(
         *milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
              .GetProperties());
-    auto load_info = std::atomic_load(&segment_load_info_);
+    auto load_info = segment_load_info_.load();
     auto column_groups = load_info->GetColumnGroups();
 
     // External collections: inject extfs.{collectionID}.* derived from
@@ -1250,7 +1250,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroups(const std::string& manifest_path,
 
 void
 ChunkedSegmentSealedImpl::SynthesizeExternalSystemFields() {
-    int64_t num_rows = std::atomic_load(&segment_load_info_)->GetNumOfRows();
+    int64_t num_rows = segment_load_info_.load()->GetNumOfRows();
     if (num_rows == 0) {
         std::unique_lock lck(mutex_);
         update_row_count(0);
@@ -3049,9 +3049,8 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
               }
           },
           segment_id) {
-    std::atomic_store(&segment_load_info_,
-                      std::make_shared<const SegmentLoadInfo>(
-                          milvus::proto::segcore::SegmentLoadInfo(), schema));
+    segment_load_info_.store(std::make_shared<const SegmentLoadInfo>(
+        milvus::proto::segcore::SegmentLoadInfo(), schema));
 }
 
 ChunkedSegmentSealedImpl::~ChunkedSegmentSealedImpl() {
@@ -3693,28 +3692,26 @@ ChunkedSegmentSealedImpl::RecordDefaultFieldsFilled(
         return;
     }
 
-    auto current = std::atomic_load(&segment_load_info_);
+    auto current = segment_load_info_.load();
     std::shared_ptr<const SegmentLoadInfo> next;
     do {
         auto copy = std::make_shared<SegmentLoadInfo>(*current);
         for (auto field_id : field_ids) {
             copy->SetFieldFilledWithDefault(field_id);
         }
-        next = std::const_pointer_cast<const SegmentLoadInfo>(copy);
-    } while (!std::atomic_compare_exchange_weak(
-        &segment_load_info_, &current, next));
+        next = std::move(copy);
+    } while (!segment_load_info_.compare_exchange_weak(current, next));
 }
 
 void
 ChunkedSegmentSealedImpl::RecordTextIndexCreated(FieldId field_id) {
-    auto current = std::atomic_load(&segment_load_info_);
+    auto current = segment_load_info_.load();
     std::shared_ptr<const SegmentLoadInfo> next;
     do {
         auto copy = std::make_shared<SegmentLoadInfo>(*current);
         copy->SetTextIndexCreated(field_id);
-        next = std::const_pointer_cast<const SegmentLoadInfo>(copy);
-    } while (!std::atomic_compare_exchange_weak(
-        &segment_load_info_, &current, next));
+        next = std::move(copy);
+    } while (!segment_load_info_.compare_exchange_weak(current, next));
 }
 
 void
@@ -4972,8 +4969,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
 
     // set pks to offset
     if (schema_->get_primary_field_id().value_or(FieldId(-1)) == field_id) {
-        if (std::atomic_load(&segment_load_info_)->GetStorageVersion() >=
-            STORAGE_V2) {
+        if (segment_load_info_.load()->GetStorageVersion() >= STORAGE_V2) {
             init_storage_v2_pk_index(field_id, column, data_type);
         } else {
             init_storage_v1_pk_index(field_id, column, data_type, is_replace);
@@ -5097,7 +5093,7 @@ ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
         return;
     }
 
-    auto current = std::atomic_load(&segment_load_info_);
+    auto current = segment_load_info_.load();
     SegmentLoadInfo current_mutable(*current);
     SegmentLoadInfo new_local(current->GetProto(), sch);
     for (auto fid : current->GetCreatedTextIndexes()) {
@@ -5111,7 +5107,7 @@ ChunkedSegmentSealedImpl::Reopen(milvus::OpContext* op_ctx, SchemaPtr sch) {
         "Schema-only reopen segment {} with diff {}", id_, diff.ToString());
 
     auto published = std::make_shared<const SegmentLoadInfo>(new_local);
-    std::atomic_store(&segment_load_info_, published);
+    segment_load_info_.store(published);
     use_take_for_output_.store(published->GetUseTakeForOutput(),
                                std::memory_order_relaxed);
 
@@ -5135,8 +5131,8 @@ ChunkedSegmentSealedImpl::Reopen(
     SchemaPtr new_schema) {
     // reopen_mutex_ serializes top-level writers of segment_load_info_.
     // It is held across ApplyLoadDiff so two Reopens never interleave their
-    // resource mutations. Readers are unaffected — they snapshot via
-    // std::atomic_load and never touch this mutex.
+    // resource mutations. Readers are unaffected — they snapshot via atomic
+    // shared_ptr load and never touch this mutex.
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
 
     SchemaPtr current_schema;
@@ -5155,7 +5151,7 @@ ChunkedSegmentSealedImpl::Reopen(
         return;
     }
 
-    auto current = std::atomic_load(&segment_load_info_);
+    auto current = segment_load_info_.load();
     auto target_schema = new_schema ? std::move(new_schema) : current_schema;
 
     SegmentLoadInfo current_mutable(*current);
@@ -5170,7 +5166,7 @@ ChunkedSegmentSealedImpl::Reopen(
     LOG_INFO("Reopen segment {} with diff {}", id_, diff.ToString());
 
     auto published = std::make_shared<const SegmentLoadInfo>(new_local);
-    std::atomic_store(&segment_load_info_, published);
+    segment_load_info_.store(published);
     use_take_for_output_.store(published->GetUseTakeForOutput(),
                                std::memory_order_relaxed);
 
@@ -5537,7 +5533,7 @@ ChunkedSegmentSealedImpl::SetLoadInfo(
     }
     auto published =
         std::make_shared<const SegmentLoadInfo>(std::move(load_info), schema_);
-    std::atomic_store(&segment_load_info_, published);
+    segment_load_info_.store(published);
     use_take_for_output_.store(published->GetUseTakeForOutput(),
                                std::memory_order_relaxed);
     LOG_INFO(
@@ -5559,7 +5555,7 @@ ChunkedSegmentSealedImpl::LoadManifest(const std::string& manifest_path) {
                           .GetProperties();
 
     auto column_groups =
-        std::atomic_load(&segment_load_info_)->GetColumnGroups();
+        segment_load_info_.load()->GetColumnGroups();
 
     auto arrow_schema = schema_->ConvertToArrowSchema();
     reader_ = milvus_storage::api::Reader::create(
@@ -5675,7 +5671,7 @@ ChunkedSegmentSealedImpl::LoadColumnGroup(
     AssertInfo(!milvus_field_ids.empty(),
                "load column group with empty field list");
     auto column_group = column_groups->at(index);
-    auto load_info = std::atomic_load(&segment_load_info_);
+    auto load_info = segment_load_info_.load();
 
     for (const auto& field_id : milvus_field_ids) {
         AssertInfo(field_exists_in_schema(schema_, field_id),
@@ -5929,7 +5925,7 @@ ChunkedSegmentSealedImpl::LoadBatchFieldData(
         SegcoreConfig::default_config()
             .get_prefer_field_data_when_index_has_raw_data();
 
-    auto load_info_snapshot = std::atomic_load(&segment_load_info_);
+    auto load_info_snapshot = segment_load_info_.load();
     std::vector<std::pair<FieldId, LoadFieldDataInfo>> field_data_to_load;
     for (auto& [field_ids, field_binlog] : field_binlog_to_load) {
         LoadFieldDataInfo load_field_data_info;
@@ -6075,7 +6071,7 @@ ChunkedSegmentSealedImpl::Load(milvus::tracer::TraceContext& trace_ctx,
     // ApplyLoadDiff are committed through COW helpers after the data is loaded.
     std::lock_guard<std::mutex> reopen_guard(reopen_mutex_);
 
-    auto snapshot = std::atomic_load(&segment_load_info_);
+    auto snapshot = segment_load_info_.load();
     auto num_rows = snapshot->GetNumOfRows();
     LOG_INFO("Loading segment {} with {} rows", id_, num_rows);
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -535,15 +535,14 @@ ChunkedSegmentSealedImpl::search_pks_with_two_pointers_impl(
         sorted_pks.push_back(std::get<PK>(pk));
     }
     std::ranges::sort(sorted_pks);
+    auto duplicate_pks = std::ranges::unique(sorted_pks);
+    sorted_pks.erase(duplicate_pks.begin(), duplicate_pks.end());
 
     auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
 
-    size_t pk_idx = 0;
     int last_chunk_id = 0;
 
-    while (pk_idx < sorted_pks.size()) {
-        const auto& target_pk = sorted_pks[pk_idx];
-
+    for (const auto& target_pk : sorted_pks) {
         // find the first occurrence of target_pk
         auto [chunk_id, in_chunk_offset, exact_match] =
             this->pk_lower_bound<PK>(
@@ -572,11 +571,6 @@ ChunkedSegmentSealedImpl::search_pks_with_two_pointers_impl(
 
             bitset.set(start_idx, end_idx - start_idx + 1, true);
             last_chunk_id = last_chunk_id_found;
-        }
-
-        while (pk_idx < sorted_pks.size() &&
-               sorted_pks[pk_idx] == target_pk) {
-            pk_idx++;
         }
     }
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -2571,16 +2571,16 @@ ChunkedSegmentSealedImpl::search_batch_pks(
             ts_chunk_pins[c].get()->RawData());
         return data[offset - ts_chunk_offsets[c]];
     };
+    auto timestamp_hit = [include_same_ts](Timestamp insert_ts,
+                                           Timestamp timestamp) {
+        return include_same_ts ? insert_ts <= timestamp : insert_ts < timestamp;
+    };
 
     // Virtual PK offset maps can resolve pk -> offset directly by bit-extract.
     // Avoid the sorted-PK column scan below: external segments synthesize PKs
     // with VirtualPKChunkedColumn, which intentionally does not support
     // GetAllChunks().
     if (insert_record_.pk2offset_is_zero_storage()) {
-        auto timestamp_hit =
-            include_same_ts
-                ? [](Timestamp lhs, Timestamp rhs) { return lhs <= rhs; }
-                : [](Timestamp lhs, Timestamp rhs) { return lhs < rhs; };
         for (size_t i = 0; i < pks.size(); i++) {
             auto timestamp = get_timestamp(i);
             for (auto offset : insert_record_.pk2offset_->find(pks[i])) {
@@ -2597,10 +2597,6 @@ ChunkedSegmentSealedImpl::search_batch_pks(
     if (!is_sorted_by_pk_) {
         auto pk_index = PinPkIndex(nullptr);
         auto* pk_cell = pk_index.get();
-        auto timestamp_hit =
-            include_same_ts
-                ? [](Timestamp lhs, Timestamp rhs) { return lhs <= rhs; }
-                : [](Timestamp lhs, Timestamp rhs) { return lhs < rhs; };
         for (size_t i = 0; i < pks.size(); i++) {
             auto timestamp = get_timestamp(i);
             auto offsets = pk_cell != nullptr
@@ -2622,13 +2618,6 @@ ChunkedSegmentSealedImpl::search_batch_pks(
     AssertInfo(pk_column != nullptr, "primary key column not loaded");
 
     auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
-
-    auto timestamp_hit = include_same_ts
-                             ? [](const Timestamp& ts1,
-                                  const Timestamp& ts2) { return ts1 <= ts2; }
-                             : [](const Timestamp& ts1, const Timestamp& ts2) {
-                                   return ts1 < ts2;
-                               };
 
     dispatch_pk_type(
         schema_->get_fields().at(pk_field_id).get_data_type(),

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -294,6 +294,43 @@ dispatch_pk_type(DataType data_type, Func&& func) {
     }
 }
 
+template <sealed_segment_detail::PrimaryKey PK, typename Callback>
+void
+for_each_sorted_pk_match(
+    const std::vector<PkType>& pks,
+    const ChunkedColumnInterface* pk_column,
+    const std::vector<PinWrapper<Chunk*>>& all_chunk_pins,
+    Callback&& callback) {
+    const auto num_chunk = pk_column->num_chunks();
+    for (int64_t i = 0; i < num_chunk; ++i) {
+        auto num_rows_until_chunk = pk_column->GetNumRowsUntilChunk(i);
+        const auto& pw = all_chunk_pins[i];
+        if constexpr (std::same_as<PK, int64_t>) {
+            auto src = reinterpret_cast<const int64_t*>(pw.get()->RawData());
+            auto chunk_row_num = pk_column->chunk_row_nums(i);
+            for (size_t j = 0; j < pks.size(); ++j) {
+                auto target = std::get<int64_t>(pks[j]);
+                auto it = std::lower_bound(src, src + chunk_row_num, target);
+                for (; it != src + chunk_row_num && *it == target; ++it) {
+                    callback(j, it - src + num_rows_until_chunk);
+                }
+            }
+        } else {
+            // TODO @xiaocai2333, @sunby: chunk need to record the min/max.
+            auto string_chunk = static_cast<StringChunk*>(pw.get());
+            for (size_t j = 0; j < pks.size(); ++j) {
+                auto& target = std::get<std::string>(pks[j]);
+                auto offset = string_chunk->binary_search_string(target);
+                for (; offset != -1 && offset < string_chunk->RowNums() &&
+                       string_chunk->operator[](offset) == target;
+                     ++offset) {
+                    callback(j, offset + num_rows_until_chunk);
+                }
+            }
+        }
+    }
+}
+
 template <sealed_segment_detail::PrimaryKey PK>
 void
 ChunkedSegmentSealedImpl::search_sorted_pk_range_impl(
@@ -2606,72 +2643,21 @@ ChunkedSegmentSealedImpl::search_batch_pks(
                                    return ts1 < ts2;
                                };
 
-    switch (schema_->get_fields().at(pk_field_id).get_data_type()) {
-        case DataType::INT64: {
-            auto num_chunk = pk_column->num_chunks();
-            for (int i = 0; i < num_chunk; ++i) {
-                const auto& pw = all_chunk_pins[i];
-                auto src =
-                    reinterpret_cast<const int64_t*>(pw.get()->RawData());
-                auto chunk_row_num = pk_column->chunk_row_nums(i);
-                for (size_t j = 0; j < pks.size(); j++) {
-                    // get int64 pks
-                    auto target = std::get<int64_t>(pks[j]);
-                    auto timestamp = get_timestamp(j);
-                    auto it = std::lower_bound(
-                        src,
-                        src + chunk_row_num,
-                        target,
-                        [](const int64_t& elem, const int64_t& value) {
-                            return elem < value;
-                        });
-                    auto num_rows_until_chunk =
-                        pk_column->GetNumRowsUntilChunk(i);
-                    for (; it != src + chunk_row_num && *it == target; ++it) {
-                        auto offset = it - src + num_rows_until_chunk;
-                        auto insert_ts = read_ts(offset);
-                        if (timestamp_hit(insert_ts, timestamp)) {
-                            callback(SegOffset(offset), timestamp);
-                        }
+    dispatch_pk_type(
+        schema_->get_fields().at(pk_field_id).get_data_type(),
+        [&]<sealed_segment_detail::PrimaryKey PK>() {
+            for_each_sorted_pk_match<PK>(
+                pks,
+                pk_column.get(),
+                all_chunk_pins,
+                [&](size_t pk_index, int64_t offset) {
+                    auto timestamp = get_timestamp(pk_index);
+                    auto insert_ts = read_ts(offset);
+                    if (timestamp_hit(insert_ts, timestamp)) {
+                        callback(SegOffset(offset), timestamp);
                     }
-                }
-            }
-
-            break;
-        }
-        case DataType::VARCHAR: {
-            auto num_chunk = pk_column->num_chunks();
-            for (int i = 0; i < num_chunk; ++i) {
-                // TODO @xiaocai2333, @sunby: chunk need to record the min/max.
-                auto num_rows_until_chunk = pk_column->GetNumRowsUntilChunk(i);
-                const auto& pw = all_chunk_pins[i];
-                auto string_chunk = static_cast<StringChunk*>(pw.get());
-                for (size_t j = 0; j < pks.size(); ++j) {
-                    // get varchar pks
-                    auto& target = std::get<std::string>(pks[j]);
-                    auto timestamp = get_timestamp(j);
-                    auto offset = string_chunk->binary_search_string(target);
-                    for (; offset != -1 && offset < string_chunk->RowNums() &&
-                           string_chunk->operator[](offset) == target;
-                         ++offset) {
-                        auto segment_offset = offset + num_rows_until_chunk;
-                        auto insert_ts = read_ts(segment_offset);
-                        if (timestamp_hit(insert_ts, timestamp)) {
-                            callback(SegOffset(segment_offset), timestamp);
-                        }
-                    }
-                }
-            }
-            break;
-        }
-        default: {
-            ThrowInfo(
-                DataTypeInvalid,
-                fmt::format(
-                    "unsupported type {}",
-                    schema_->get_fields().at(pk_field_id).get_data_type()));
-        }
-    }
+                });
+        });
 }
 
 void
@@ -2950,70 +2936,18 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
                                  "primary key column not loaded");
                       auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
 
-                      switch (schema_->get_fields()
-                                  .at(pk_field_id)
-                                  .get_data_type()) {
-                          case DataType::INT64: {
-                              auto num_chunk = pk_column->num_chunks();
-                              for (int i = 0; i < num_chunk; ++i) {
-                                  const auto& pw = all_chunk_pins[i];
-                                  auto src = reinterpret_cast<const int64_t*>(
-                                      pw.get()->RawData());
-                                  auto chunk_row_num =
-                                      pk_column->chunk_row_nums(i);
-                                  auto num_rows_until_chunk =
-                                      pk_column->GetNumRowsUntilChunk(i);
-                                  for (size_t j = 0; j < pks.size(); j++) {
-                                      auto target = std::get<int64_t>(pks[j]);
-                                      auto it = std::lower_bound(
-                                          src, src + chunk_row_num, target);
-                                      for (; it != src + chunk_row_num &&
-                                             *it == target;
-                                           ++it) {
-                                          callback(
-                                              SegOffset(it - src +
-                                                        num_rows_until_chunk),
-                                              timestamps[j]);
-                                      }
-                                  }
-                              }
-                              break;
-                          }
-                          case DataType::VARCHAR: {
-                              auto num_chunk = pk_column->num_chunks();
-                              for (int i = 0; i < num_chunk; ++i) {
-                                  auto num_rows_until_chunk =
-                                      pk_column->GetNumRowsUntilChunk(i);
-                                  const auto& pw = all_chunk_pins[i];
-                                  auto string_chunk =
-                                      static_cast<StringChunk*>(pw.get());
-                                  for (size_t j = 0; j < pks.size(); ++j) {
-                                      auto& target =
-                                          std::get<std::string>(pks[j]);
-                                      auto offset =
-                                          string_chunk->binary_search_string(
-                                              target);
-                                      for (; offset != -1 &&
-                                             offset < string_chunk->RowNums() &&
-                                             string_chunk->operator[](offset) ==
-                                                 target;
-                                           ++offset) {
-                                          callback(
-                                              SegOffset(offset +
-                                                        num_rows_until_chunk),
-                                              timestamps[j]);
-                                      }
-                                  }
-                              }
-                              break;
-                          }
-                          default:
-                              ThrowInfo(DataTypeInvalid,
-                                        fmt::format("unsupported type {}",
-                                                    schema_->get_fields()
-                                                        .at(pk_field_id)
-                                                        .get_data_type()));
-                      }
+                      dispatch_pk_type(
+                          schema_->get_fields().at(pk_field_id).get_data_type(),
+                          [&]<sealed_segment_detail::PrimaryKey PK>() {
+                              for_each_sorted_pk_match<PK>(
+                                  pks,
+                                  pk_column.get(),
+                                  all_chunk_pins,
+                                  [&](size_t pk_index, int64_t offset) {
+                                      callback(SegOffset(offset),
+                                               timestamps[pk_index]);
+                                  });
+                          });
                   }
               } else {
                   this->search_batch_pks(

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -534,7 +534,7 @@ ChunkedSegmentSealedImpl::search_pks_with_two_pointers_impl(
     for (const auto& pk : pks) {
         sorted_pks.push_back(std::get<PK>(pk));
     }
-    std::sort(sorted_pks.begin(), sorted_pks.end());
+    std::ranges::sort(sorted_pks);
 
     auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
 
@@ -4459,7 +4459,7 @@ ChunkedSegmentSealedImpl::Delete(int64_t size,
     }
 
     // step 1: sort timestamp
-    std::sort(ordering.begin(), ordering.end());
+    std::ranges::sort(ordering);
     std::vector<PkType> sort_pks(size);
     std::vector<Timestamp> sort_timestamps(size);
 
@@ -6093,11 +6093,7 @@ ChunkedSegmentSealedImpl::BuildTakeContext(const int64_t* offsets,
     for (int64_t i = 0; i < size; i++) {
         entries.push_back({offsets[i], i});
     }
-    std::sort(entries.begin(),
-              entries.end(),
-              [](const OffsetEntry& a, const OffsetEntry& b) {
-                  return a.offset < b.offset;
-              });
+    std::ranges::sort(entries, {}, &OffsetEntry::offset);
 
     TakeContext ctx;
     ctx.unique_offsets.reserve(size);

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -1130,7 +1130,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     // preserves runtime-only state (e.g. created_text_indexes_).
     std::shared_ptr<const SegmentLoadInfo>
     TestGetSegmentLoadInfo() {
-        return std::atomic_load(&segment_load_info_);
+        return segment_load_info_.load();
     }
 
     // Test-only: stamp a field as having had its text index created, via the
@@ -1188,17 +1188,15 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
 
     LoadFieldDataInfo field_data_info_;
 
-    // Load-info snapshot. Readers MUST use std::atomic_load(&segment_load_info_)
-    // to obtain a shared_ptr snapshot; writers MUST publish via
-    // std::atomic_store(&segment_load_info_, …). The pointee is const —
-    // mutations go through copy-on-write (see RecordTextIndexCreated and the
-    // Reopen/SetLoadInfo/Load entry points).
-    std::shared_ptr<const SegmentLoadInfo> segment_load_info_;
+    // Load-info snapshot. Readers obtain a shared_ptr snapshot; writers publish
+    // through copy-on-write. The pointee is const — mutations go through
+    // RecordTextIndexCreated and the Reopen/SetLoadInfo/Load entry points.
+    std::atomic<std::shared_ptr<const SegmentLoadInfo>> segment_load_info_;
 
     // Serializes top-level writers of segment_load_info_
     // (Reopen(pb), SetLoadInfo, Load) so their diff → publish → ApplyLoadDiff
     // sequences never interleave. Does NOT block readers — reader paths access
-    // segment_load_info_ via atomic_load.
+    // segment_load_info_ via atomic shared_ptr load.
     // Lock order: reopen_mutex_ → mutex_ (outer → inner) only. Never inverse,
     // and reader paths that take mutex_ must not take reopen_mutex_.
     std::mutex reopen_mutex_;

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <any>
 #include <atomic>
+#include <concepts>
 #include <cstddef>
 #include <functional>
 #include <map>
@@ -96,6 +97,17 @@ class PkIndexCell;
 }  // namespace storagev2translator
 
 using namespace milvus::cachinglayer;
+
+namespace sealed_segment_detail {
+
+template <typename T>
+concept PrimaryKey = std::same_as<T, int64_t> || std::same_as<T, std::string>;
+
+template <PrimaryKey PK>
+using PrimaryKeyView =
+    std::conditional_t<std::same_as<PK, int64_t>, int64_t, std::string_view>;
+
+}  // namespace sealed_segment_detail
 
 // Test-only accessor that pokes private members to simulate v2/v3 segment
 // state (raw timestamp column emplaced into fields_ alongside an overwritten
@@ -649,7 +661,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     init_storage_v1_timestamp_index(std::vector<Timestamp> timestamps,
                                     size_t num_rows);
 
-    template <typename PK>
+    template <sealed_segment_detail::PrimaryKey PK>
     void
     search_sorted_pk_range_impl(
         proto::plan::OpType op,
@@ -739,7 +751,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         }
     }
 
-    template <typename PK>
+    template <sealed_segment_detail::PrimaryKey PK>
     void
     search_sorted_pk_binary_range_impl(
         const PK& lower_val,
@@ -813,7 +825,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         }
     }
 
-    template <typename PK>
+    template <sealed_segment_detail::PrimaryKey PK>
     std::optional<int64_t>
     find_sorted_pk_doc_offset(
         const PK& pk,
@@ -827,7 +839,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         return pk_column->GetNumRowsUntilChunk(chunk_id) + in_chunk_offset;
     }
 
-    template <typename PK>
+    template <sealed_segment_detail::PrimaryKey PK>
     void
     search_pks_with_two_pointers_impl(
         BitsetTypeView& bitset,
@@ -893,8 +905,14 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     //   - exists: true if found an exact match (value == pk), false otherwise
     //   - If pk doesn't exist, returns the position of first value > pk with exists=false
     //   - If pk is greater than all values, returns {-1, -1, false}
-    template <typename PK>
-    std::tuple<int, int, bool>
+    struct PkLowerBoundResult {
+        int chunk_id = -1;
+        int in_chunk_offset = -1;
+        bool exact_match = false;
+    };
+
+    template <sealed_segment_detail::PrimaryKey PK>
+    PkLowerBoundResult
     pk_lower_bound(const PK& pk,
                    const ChunkedColumnInterface* pk_column,
                    const std::vector<PinWrapper<Chunk*>>& all_chunk_pins,
@@ -902,17 +920,15 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const auto num_chunk = pk_column->num_chunks();
 
         if (from_chunk_id >= num_chunk) {
-            return {-1, -1, false};  // Invalid starting chunk
+            return {};  // Invalid starting chunk
         }
 
-        using PKViewType = std::conditional_t<std::is_same_v<PK, int64_t>,
-                                              int64_t,
-                                              std::string_view>;
+        using PKViewType = sealed_segment_detail::PrimaryKeyView<PK>;
 
         auto get_val_view = [&](int chunk_id,
                                 int in_chunk_offset) -> PKViewType {
             auto& pw = all_chunk_pins[chunk_id];
-            if constexpr (std::is_same_v<PK, int64_t>) {
+            if constexpr (std::same_as<PK, int64_t>) {
                 auto src =
                     reinterpret_cast<const int64_t*>(pw.get()->RawData());
                 return src[in_chunk_offset];
@@ -953,7 +969,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         if (target_chunk_id == -1) {
             if (left_chunk_id >= num_chunk) {
                 // pk is greater than all values
-                return {-1, -1, false};
+                return {};
             }
             target_chunk_id = left_chunk_id;
         }
@@ -990,7 +1006,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                 return {target_chunk_id + 1, 0, exact_match};
             } else {
                 // No more chunks, pk is greater than all values
-                return {-1, -1, false};
+                return {};
             }
         }
     }
@@ -1005,8 +1021,13 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     //   - The position of the last occurrence of pk
     // Note: This function assumes pk exists and linearly scans forward.
     //       It's efficient when pk has few duplicates.
-    template <typename PK>
-    std::tuple<int, int>
+    struct PkPosition {
+        int chunk_id = -1;
+        int in_chunk_offset = -1;
+    };
+
+    template <sealed_segment_detail::PrimaryKey PK>
+    PkPosition
     find_last_pk_position(const PK& pk,
                           const ChunkedColumnInterface* pk_column,
                           const std::vector<PinWrapper<Chunk*>>& all_chunk_pins,
@@ -1014,14 +1035,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                           int first_in_chunk_offset) const {
         const auto num_chunk = pk_column->num_chunks();
 
-        using PKViewType = std::conditional_t<std::is_same_v<PK, int64_t>,
-                                              int64_t,
-                                              std::string_view>;
+        using PKViewType = sealed_segment_detail::PrimaryKeyView<PK>;
 
         auto get_val_view = [&](int chunk_id,
                                 int in_chunk_offset) -> PKViewType {
             auto pw = all_chunk_pins[chunk_id];
-            if constexpr (std::is_same_v<PK, int64_t>) {
+            if constexpr (std::same_as<PK, int64_t>) {
                 auto src =
                     reinterpret_cast<const int64_t*>(pw.get()->RawData());
                 return src[in_chunk_offset];

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -667,89 +667,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         proto::plan::OpType op,
         const PK& target,
         const std::shared_ptr<ChunkedColumnInterface>& pk_column,
-        BitsetTypeView& bitset) const {
-        const auto num_chunk = pk_column->num_chunks();
-        if (num_chunk == 0) {
-            return;
-        }
-        auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
-
-        if (op == proto::plan::OpType::Equal) {
-            // find first occurrence
-            auto [chunk_id, in_chunk_offset, exact_match] =
-                this->pk_lower_bound<PK>(
-                    target, pk_column.get(), all_chunk_pins, 0);
-
-            if (exact_match) {
-                // find last occurrence
-                auto [last_chunk_id, last_in_chunk_offset] =
-                    this->find_last_pk_position<PK>(target,
-                                                    pk_column.get(),
-                                                    all_chunk_pins,
-                                                    chunk_id,
-                                                    in_chunk_offset);
-
-                auto start_idx =
-                    pk_column->GetNumRowsUntilChunk(chunk_id) + in_chunk_offset;
-                auto end_idx = pk_column->GetNumRowsUntilChunk(last_chunk_id) +
-                               last_in_chunk_offset;
-
-                bitset.set(start_idx, end_idx - start_idx + 1, true);
-            }
-        } else if (op == proto::plan::OpType::GreaterEqual ||
-                   op == proto::plan::OpType::GreaterThan) {
-            auto [chunk_id, in_chunk_offset, exact_match] =
-                this->pk_lower_bound<PK>(
-                    target, pk_column.get(), all_chunk_pins, 0);
-
-            if (chunk_id != -1) {
-                int64_t start_idx =
-                    pk_column->GetNumRowsUntilChunk(chunk_id) + in_chunk_offset;
-                if (exact_match && op == proto::plan::OpType::GreaterThan) {
-                    auto [last_chunk_id, last_in_chunk_offset] =
-                        this->find_last_pk_position<PK>(target,
-                                                        pk_column.get(),
-                                                        all_chunk_pins,
-                                                        chunk_id,
-                                                        in_chunk_offset);
-                    start_idx = pk_column->GetNumRowsUntilChunk(last_chunk_id) +
-                                last_in_chunk_offset + 1;
-                }
-                if (start_idx < bitset.size()) {
-                    bitset.set(start_idx, bitset.size() - start_idx, true);
-                }
-            }
-        } else if (op == proto::plan::OpType::LessEqual ||
-                   op == proto::plan::OpType::LessThan) {
-            auto [chunk_id, in_chunk_offset, exact_match] =
-                this->pk_lower_bound<PK>(
-                    target, pk_column.get(), all_chunk_pins, 0);
-
-            int64_t end_idx;
-            if (chunk_id == -1) {
-                end_idx = bitset.size();
-            } else if (op == proto::plan::OpType::LessEqual && exact_match) {
-                auto [last_chunk_id, last_in_chunk_offset] =
-                    this->find_last_pk_position<PK>(target,
-                                                    pk_column.get(),
-                                                    all_chunk_pins,
-                                                    chunk_id,
-                                                    in_chunk_offset);
-                end_idx = pk_column->GetNumRowsUntilChunk(last_chunk_id) +
-                          last_in_chunk_offset + 1;
-            } else {
-                end_idx =
-                    pk_column->GetNumRowsUntilChunk(chunk_id) + in_chunk_offset;
-            }
-
-            if (end_idx > 0) {
-                bitset.set(0, end_idx, true);
-            }
-        } else {
-            ThrowInfo(ErrorCode::Unsupported,
-                      fmt::format("unsupported op type {}", op));
-        }
-    }
+        BitsetTypeView& bitset) const;
 
     template <sealed_segment_detail::PrimaryKey PK>
     void
@@ -759,144 +677,20 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         const PK& upper_val,
         bool upper_inclusive,
         const std::shared_ptr<ChunkedColumnInterface>& pk_column,
-        BitsetTypeView& bitset) const {
-        const auto num_chunk = pk_column->num_chunks();
-        if (num_chunk == 0) {
-            return;
-        }
-        auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
-
-        // Find the lower bound position (first value >= lower_val or > lower_val)
-        auto [lower_chunk_id, lower_in_chunk_offset, lower_exact_match] =
-            this->pk_lower_bound<PK>(
-                lower_val, pk_column.get(), all_chunk_pins, 0);
-
-        int64_t start_idx = 0;
-        if (lower_chunk_id != -1) {
-            start_idx = pk_column->GetNumRowsUntilChunk(lower_chunk_id) +
-                        lower_in_chunk_offset;
-            // If lower_inclusive is false and we found an exact match, skip all equal values
-            if (!lower_inclusive && lower_exact_match) {
-                auto [last_chunk_id, last_in_chunk_offset] =
-                    this->find_last_pk_position<PK>(lower_val,
-                                                    pk_column.get(),
-                                                    all_chunk_pins,
-                                                    lower_chunk_id,
-                                                    lower_in_chunk_offset);
-                start_idx = pk_column->GetNumRowsUntilChunk(last_chunk_id) +
-                            last_in_chunk_offset + 1;
-            }
-        } else {
-            // lower_val is greater than all values, no results
-            return;
-        }
-
-        // Find the upper bound position (first value >= upper_val or > upper_val)
-        auto [upper_chunk_id, upper_in_chunk_offset, upper_exact_match] =
-            this->pk_lower_bound<PK>(
-                upper_val, pk_column.get(), all_chunk_pins, 0);
-
-        int64_t end_idx = 0;
-        if (upper_chunk_id == -1) {
-            // upper_val is greater than all values, include all from start_idx to end
-            end_idx = bitset.size();
-        } else {
-            // If upper_inclusive is true and we found an exact match, include all equal values
-            if (upper_inclusive && upper_exact_match) {
-                auto [last_chunk_id, last_in_chunk_offset] =
-                    this->find_last_pk_position<PK>(upper_val,
-                                                    pk_column.get(),
-                                                    all_chunk_pins,
-                                                    upper_chunk_id,
-                                                    upper_in_chunk_offset);
-                end_idx = pk_column->GetNumRowsUntilChunk(last_chunk_id) +
-                          last_in_chunk_offset + 1;
-            } else {
-                // upper_inclusive is false or no exact match
-                // In both cases, end at the position of first value >= upper_val
-                end_idx = pk_column->GetNumRowsUntilChunk(upper_chunk_id) +
-                          upper_in_chunk_offset;
-            }
-        }
-
-        // Set bits from start_idx to end_idx - 1
-        if (start_idx < end_idx) {
-            bitset.set(start_idx, end_idx - start_idx, true);
-        }
-    }
+        BitsetTypeView& bitset) const;
 
     template <sealed_segment_detail::PrimaryKey PK>
     std::optional<int64_t>
     find_sorted_pk_doc_offset(
         const PK& pk,
-        const std::shared_ptr<ChunkedColumnInterface>& pk_column) const {
-        auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
-        auto [chunk_id, in_chunk_offset, exact_match] =
-            this->pk_lower_bound<PK>(pk, pk_column.get(), all_chunk_pins, 0);
-        if (!exact_match) {
-            return std::nullopt;
-        }
-        return pk_column->GetNumRowsUntilChunk(chunk_id) + in_chunk_offset;
-    }
+        const std::shared_ptr<ChunkedColumnInterface>& pk_column) const;
 
     template <sealed_segment_detail::PrimaryKey PK>
     void
     search_pks_with_two_pointers_impl(
         BitsetTypeView& bitset,
         const std::vector<PkType>& pks,
-        const std::shared_ptr<ChunkedColumnInterface>& pk_column) const {
-        // TODO: we should sort pks during plan generation
-        std::vector<PK> sorted_pks;
-        sorted_pks.reserve(pks.size());
-        for (const auto& pk : pks) {
-            sorted_pks.push_back(std::get<PK>(pk));
-        }
-        std::sort(sorted_pks.begin(), sorted_pks.end());
-
-        auto all_chunk_pins = pk_column->GetAllChunks(nullptr);
-
-        size_t pk_idx = 0;
-        int last_chunk_id = 0;
-
-        while (pk_idx < sorted_pks.size()) {
-            const auto& target_pk = sorted_pks[pk_idx];
-
-            // find the first occurrence of target_pk
-            auto [chunk_id, in_chunk_offset, exact_match] =
-                this->pk_lower_bound<PK>(
-                    target_pk, pk_column.get(), all_chunk_pins, last_chunk_id);
-
-            if (chunk_id == -1) {
-                // All remaining PKs are greater than all values in pk_column
-                break;
-            }
-
-            if (exact_match) {
-                // Found exact match, find the last occurrence
-                auto [last_chunk_id_found, last_in_chunk_offset] =
-                    this->find_last_pk_position<PK>(target_pk,
-                                                    pk_column.get(),
-                                                    all_chunk_pins,
-                                                    chunk_id,
-                                                    in_chunk_offset);
-
-                // Mark all occurrences from first to last position using global indices
-                auto start_idx =
-                    pk_column->GetNumRowsUntilChunk(chunk_id) + in_chunk_offset;
-                auto end_idx =
-                    pk_column->GetNumRowsUntilChunk(last_chunk_id_found) +
-                    last_in_chunk_offset;
-
-                bitset.set(start_idx, end_idx - start_idx + 1, true);
-                last_chunk_id = last_chunk_id_found;
-            }
-
-            while (pk_idx < sorted_pks.size() &&
-                   sorted_pks[pk_idx] == target_pk) {
-                pk_idx++;
-            }
-        }
-    }
+        const std::shared_ptr<ChunkedColumnInterface>& pk_column) const;
 
     // Binary search to find lower_bound of pk in pk_column starting from from_chunk_id
     // Returns: (chunk_id, in_chunk_offset, exists)
@@ -916,100 +710,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     pk_lower_bound(const PK& pk,
                    const ChunkedColumnInterface* pk_column,
                    const std::vector<PinWrapper<Chunk*>>& all_chunk_pins,
-                   int from_chunk_id = 0) const {
-        const auto num_chunk = pk_column->num_chunks();
-
-        if (from_chunk_id >= num_chunk) {
-            return {};  // Invalid starting chunk
-        }
-
-        using PKViewType = sealed_segment_detail::PrimaryKeyView<PK>;
-
-        auto get_val_view = [&](int chunk_id,
-                                int in_chunk_offset) -> PKViewType {
-            auto& pw = all_chunk_pins[chunk_id];
-            if constexpr (std::same_as<PK, int64_t>) {
-                auto src =
-                    reinterpret_cast<const int64_t*>(pw.get()->RawData());
-                return src[in_chunk_offset];
-            } else {
-                auto string_chunk = static_cast<StringChunk*>(pw.get());
-                return string_chunk->operator[](in_chunk_offset);
-            }
-        };
-
-        // Binary search at chunk level to find the first chunk that might contain pk
-        int left_chunk_id = from_chunk_id;
-        int right_chunk_id = num_chunk - 1;
-        int target_chunk_id = -1;
-
-        while (left_chunk_id <= right_chunk_id) {
-            int mid_chunk_id =
-                left_chunk_id + (right_chunk_id - left_chunk_id) / 2;
-            auto chunk_row_num = pk_column->chunk_row_nums(mid_chunk_id);
-
-            PKViewType min_val = get_val_view(mid_chunk_id, 0);
-            PKViewType max_val = get_val_view(mid_chunk_id, chunk_row_num - 1);
-
-            if (pk >= min_val && pk <= max_val) {
-                // pk might be in this chunk
-                target_chunk_id = mid_chunk_id;
-                break;
-            } else if (pk < min_val) {
-                // pk is before this chunk, could be in an earlier chunk
-                target_chunk_id = mid_chunk_id;  // This chunk has values >= pk
-                right_chunk_id = mid_chunk_id - 1;
-            } else {
-                // pk is after this chunk, search in later chunks
-                left_chunk_id = mid_chunk_id + 1;
-            }
-        }
-
-        // If no suitable chunk found, check if we need the first position after all chunks
-        if (target_chunk_id == -1) {
-            if (left_chunk_id >= num_chunk) {
-                // pk is greater than all values
-                return {};
-            }
-            target_chunk_id = left_chunk_id;
-        }
-
-        // Binary search within the target chunk to find lower_bound position
-        auto chunk_row_num = pk_column->chunk_row_nums(target_chunk_id);
-        int left_offset = 0;
-        int right_offset = chunk_row_num;
-
-        while (left_offset < right_offset) {
-            int mid_offset = left_offset + (right_offset - left_offset) / 2;
-            PKViewType mid_val = get_val_view(target_chunk_id, mid_offset);
-
-            if (mid_val < pk) {
-                left_offset = mid_offset + 1;
-            } else {
-                right_offset = mid_offset;
-            }
-        }
-
-        // Check if we found a valid position
-        if (left_offset < chunk_row_num) {
-            // Found position within current chunk
-            PKViewType found_val = get_val_view(target_chunk_id, left_offset);
-            bool exact_match = (found_val == pk);
-            return {target_chunk_id, left_offset, exact_match};
-        } else {
-            // Position is beyond current chunk, try next chunk
-            if (target_chunk_id + 1 < num_chunk) {
-                // Next chunk exists, return its first position
-                // Check if the first value in next chunk equals pk
-                PKViewType next_val = get_val_view(target_chunk_id + 1, 0);
-                bool exact_match = (next_val == pk);
-                return {target_chunk_id + 1, 0, exact_match};
-            } else {
-                // No more chunks, pk is greater than all values
-                return {};
-            }
-        }
-    }
+                   int from_chunk_id = 0) const;
 
     // Find the last occurrence position of pk starting from a known first occurrence
     // Parameters:
@@ -1032,71 +733,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                           const ChunkedColumnInterface* pk_column,
                           const std::vector<PinWrapper<Chunk*>>& all_chunk_pins,
                           int first_chunk_id,
-                          int first_in_chunk_offset) const {
-        const auto num_chunk = pk_column->num_chunks();
-
-        using PKViewType = sealed_segment_detail::PrimaryKeyView<PK>;
-
-        auto get_val_view = [&](int chunk_id,
-                                int in_chunk_offset) -> PKViewType {
-            auto pw = all_chunk_pins[chunk_id];
-            if constexpr (std::same_as<PK, int64_t>) {
-                auto src =
-                    reinterpret_cast<const int64_t*>(pw.get()->RawData());
-                return src[in_chunk_offset];
-            } else {
-                auto string_chunk = static_cast<StringChunk*>(pw.get());
-                return string_chunk->operator[](in_chunk_offset);
-            }
-        };
-
-        int last_chunk_id = first_chunk_id;
-        int last_offset = first_in_chunk_offset;
-
-        // Linear scan forward in current chunk
-        auto chunk_row_num = pk_column->chunk_row_nums(first_chunk_id);
-        for (int offset = first_in_chunk_offset + 1; offset < chunk_row_num;
-             offset++) {
-            PKViewType curr_val = get_val_view(first_chunk_id, offset);
-            if (curr_val == pk) {
-                last_offset = offset;
-            } else {
-                // Found first value != pk, done
-                return {last_chunk_id, last_offset};
-            }
-        }
-
-        // Continue scanning in subsequent chunks
-        for (int chunk_id = first_chunk_id + 1; chunk_id < num_chunk;
-             chunk_id++) {
-            auto curr_chunk_row_num = pk_column->chunk_row_nums(chunk_id);
-
-            // Check first value in this chunk
-            PKViewType first_val = get_val_view(chunk_id, 0);
-            if (first_val != pk) {
-                // This chunk doesn't contain pk anymore
-                return {last_chunk_id, last_offset};
-            }
-
-            // Update last position and scan this chunk
-            last_chunk_id = chunk_id;
-            last_offset = 0;
-
-            for (int offset = 1; offset < curr_chunk_row_num; offset++) {
-                PKViewType curr_val = get_val_view(chunk_id, offset);
-                if (curr_val == pk) {
-                    last_offset = offset;
-                } else {
-                    // Found first value != pk
-                    return {last_chunk_id, last_offset};
-                }
-            }
-            // All values in this chunk equal pk, continue to next chunk
-        }
-
-        // Scanned all chunks, return last found position
-        return {last_chunk_id, last_offset};
-    }
+                          int first_in_chunk_offset) const;
 
     template <typename S, typename T = S>
     static void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -107,6 +107,10 @@ template <PrimaryKey PK>
 using PrimaryKeyView =
     std::conditional_t<std::same_as<PK, int64_t>, int64_t, std::string_view>;
 
+template <typename T>
+concept PrimitiveBulkSubscriptValue =
+    std::integral<T> || std::floating_point<T>;
+
 }  // namespace sealed_segment_detail
 
 // Test-only accessor that pokes private members to simulate v2/v3 segment
@@ -743,7 +747,7 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                         int64_t count,
                         T* dst_raw);
 
-    template <typename S, typename T = S>
+    template <sealed_segment_detail::PrimitiveBulkSubscriptValue T>
     static void
     bulk_subscript_impl(milvus::OpContext* op_ctx,
                         ChunkedColumnInterface* field,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -764,22 +764,35 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                         int64_t count,
                         void* dst_raw);
 
-    template <typename S>
     static void
-    bulk_subscript_ptr_impl(
+    bulk_subscript_string_impl(
         milvus::OpContext* op_ctx,
-        ChunkedColumnInterface* field,
+        const ChunkedColumnInterface* field,
         const int64_t* seg_offsets,
         int64_t count,
         google::protobuf::RepeatedPtrField<std::string>* dst_raw);
 
-    template <typename S, typename T = S>
     static void
-    bulk_subscript_ptr_impl(milvus::OpContext* op_ctx,
-                            const ChunkedColumnInterface* field,
-                            const int64_t* seg_offsets,
-                            int64_t count,
-                            T* dst);
+    bulk_subscript_json_impl(
+        milvus::OpContext* op_ctx,
+        const ChunkedColumnInterface* field,
+        const int64_t* seg_offsets,
+        int64_t count,
+        google::protobuf::RepeatedPtrField<std::string>* dst_raw);
+
+    static void
+    bulk_subscript_string_impl(milvus::OpContext* op_ctx,
+                               const ChunkedColumnInterface* field,
+                               const int64_t* seg_offsets,
+                               int64_t count,
+                               std::string* dst);
+
+    static void
+    bulk_subscript_json_impl(milvus::OpContext* op_ctx,
+                             const ChunkedColumnInterface* field,
+                             const int64_t* seg_offsets,
+                             int64_t count,
+                             Json* dst);
 
     template <typename T>
     static void


### PR DESCRIPTION
issue: N/A

## What
- Constrain sealed-segment PK templates with local C++20 concepts and centralize PK type dispatch.
- Move private PK template bodies out of the header and share sorted-PK lookup/match helpers.
- Simplify sealed bulk subscript helpers, JSON/delete filtering, timestamp chunk lookup, and atomic shared SegmentLoadInfo handling.
- Use C++20 algorithms where they improve clarity, while keeping the sorted int64 PK hot path on lower_bound + scan.

## Notes
This is a code cleanup/refactor PR. It is not intended to claim measurable end-to-end performance improvement; the main goal is clearer template boundaries and lower duplicated implementation detail in ChunkedSegmentSealedImpl.

## Verification
- git diff --check origin/master..HEAD -- internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp internal/core/src/segcore/ChunkedSegmentSealedImpl.h
- cmake --build cmake_build --target milvus_segcore -j2 (blocked during CMake configure: missing bson-1.0 package config in local environment)
