### PR TITLE
fix: harden geometry RTree index and cache against memory-safety issues

### DIFF
--- a/internal/core/src/common/Geometry.h
+++ b/internal/core/src/common/Geometry.h
@@ -11,12 +11,191 @@
 #pragma once
 
 #include <geos_c.h>
+#include <atomic>
+#include <chrono>
 #include <memory>
 #include <cmath>
+#include <new>
 #include <string>
 #include "common/EasyAssert.h"
+#include "log/Log.h"
 
 namespace milvus {
+
+/**
+ * Best-effort time throttle for logs on per-row geometry paths.
+ *
+ * The geometry write and refine paths log one line per offending row. A
+ * segment full of corrupt or topologically invalid geometries would otherwise
+ * emit one line per row per query (refine) or per rebuild (write) -- millions
+ * of identical lines that bury everything else. Each call site owns a static
+ * counter; this returns true at most once per interval per counter. It proves
+ * the condition is occurring; it does not count occurrences.
+ */
+inline bool
+ShouldLogGeometryThrottled(std::atomic<int64_t>& last_log_us,
+                           int64_t interval_us = 10LL * 1000 * 1000) {
+    auto now_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                      std::chrono::steady_clock::now().time_since_epoch())
+                      .count();
+    auto previous = last_log_us.load(std::memory_order_relaxed);
+    return now_us - previous >= interval_us &&
+           last_log_us.compare_exchange_strong(
+               previous, now_us, std::memory_order_relaxed);
+}
+
+/**
+ * Reduce a tri-state GEOS predicate result to bool, observably.
+ *
+ * The GEOS capi binary predicates (GEOSIntersects_r, GEOSPreparedContains_r,
+ * GEOSisValid_r, ...) return char 1 = true, 0 = false, 2 = an exception was
+ * caught inside GEOS's execute() guard (a topology error on data GEOS cannot
+ * evaluate, or an allocation failure swallowed the same way -- see the KNOWN
+ * LIMIT note on Geometry::TryParseFromWkb). A bare `== 1` silently maps 2 to
+ * "no match", turning an evaluation failure into an unlogged false negative.
+ * Mapping 2 to false is still the deliberate choice -- the filter paths'
+ * single-row-leniency contract says one bad row must not fail the whole
+ * query, matching how corrupt WKB is skipped -- but it must be visible, so
+ * the exception case is logged.
+ *
+ * The log is time-throttled because this sits on the exact-refinement hot
+ * path: it can run once per candidate row per query, so a segment full of
+ * topologically invalid geometries would otherwise emit millions of identical
+ * warnings for a single full-scan predicate. The throttle is process-wide and
+ * best-effort -- its job is to prove the condition is occurring, not to count
+ * occurrences.
+ */
+inline bool
+GeosPredicateIsTrue(char result, const char* op) {
+    if (result == 2) {
+        static std::atomic<int64_t> last_log_us{0};
+        if (ShouldLogGeometryThrottled(last_log_us)) {
+            LOG_WARN(
+                "GEOS predicate {} raised an exception; treating the row as "
+                "not matching (further occurrences suppressed briefly)",
+                op);
+        }
+        return false;
+    }
+    return result == 1;
+}
+
+/**
+ * Create a GEOS context, translating allocation failure into a retriable
+ * system error.
+ *
+ * GEOS_init_r() allocates its context with a bare `new` (it is NOT wrapped in
+ * the capi execute() guard), so on OOM it throws std::bad_alloc and never
+ * returns nullptr. Without this translation the bad_alloc is not a
+ * SegcoreError, so it would bypass the `catch (const SegcoreError&)` rethrow
+ * guards on the index write paths and collapse into a non-retryable
+ * UnexpectedError at the cgo boundary -- inverting the transient-vs-permanent
+ * classification for what is a textbook transient failure.
+ */
+inline GEOSContextHandle_t
+InitGEOSContext(const char* purpose) {
+    try {
+        return GEOS_init_r();
+    } catch (const std::bad_alloc&) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory initializing GEOS context for {}",
+                  purpose);
+    }
+}
+
+/**
+ * Test-only one-shot fault injection for the clone path below.
+ *
+ * The only realistic failure of GEOSGeom_clone_r() is allocation failure,
+ * which a unit test cannot provoke, so the classification of that failure
+ * would otherwise be untestable. Lives next to the call site so both share one
+ * flag; production code never sets it.
+ */
+inline std::atomic<bool>&
+GeometryCloneFailureForTesting() {
+    static std::atomic<bool> flag{false};
+    return flag;
+}
+
+/**
+ * Deep-clone a geometry into `ctx`, translating clone failure into a retriable
+ * system error.
+ *
+ * GEOSGeom_clone_r() runs inside the capi execute() guard, which catches
+ * std::exception -- std::bad_alloc included -- and returns nullptr rather than
+ * propagating it (geos_ts_c.cpp). So an OOM on this path NEVER surfaces as an
+ * exception that a `catch (const std::bad_alloc&)` net could translate, and
+ * reporting the nullptr with a plain AssertInfo would classify a textbook
+ * transient failure as a non-retryable UnexpectedError (2001).
+ *
+ * On the search path that is worse than just losing the retry: 2001 is not
+ * retriable in merr's segcore table, and lb_policy treats a non-retriable
+ * failure by BLACKLISTING the serving node for the channel
+ * (shardclient/lb_policy.go) instead of merely excluding it from this one
+ * request and failing over to another replica. Memory pressure would then
+ * evict healthy nodes from routing.
+ *
+ * Callers clone geometries that already parsed and validated, so a nullptr
+ * here is attributable to resource failure -- there is none of the bad-data /
+ * OOM ambiguity that TryParseFromWkb documents as a KNOWN LIMIT. Same
+ * reasoning as InitGEOSContext above.
+ */
+inline GEOSGeometry*
+CloneGeometryOrThrow(GEOSContextHandle_t ctx, const GEOSGeometry* geom) {
+    GEOSGeometry* cloned = GEOSGeom_clone_r(ctx, geom);
+    if (GeometryCloneFailureForTesting().exchange(false) && cloned != nullptr) {
+        GEOSGeom_destroy_r(ctx, cloned);
+        cloned = nullptr;
+    }
+    if (cloned == nullptr) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory cloning geometry");
+    }
+    return cloned;
+}
+
+/**
+ * RAII holder for a GEOS context and the reader/geometry commonly held with
+ * it. Any code path that can throw between GEOS_init_r and GEOS_finish_r --
+ * a std::bad_alloc from a container op (now translated to a retriable error
+ * and retried, so a leak repeats once per attempt and compounds the OOM), a
+ * throwing Geometry constructor, an AssertInfo -- must hold its resources
+ * here instead of relying on trailing cleanup calls. Destruction order
+ * matters: geometry and reader are destroyed while the context is still
+ * alive.
+ */
+struct ScopedGeosResources {
+    GEOSContextHandle_t ctx{nullptr};
+    GEOSWKBReader* reader{nullptr};
+    GEOSGeometry* geom{nullptr};
+
+    explicit ScopedGeosResources(const char* purpose)
+        : ctx(InitGEOSContext(purpose)) {
+    }
+    ScopedGeosResources(const ScopedGeosResources&) = delete;
+    ScopedGeosResources&
+    operator=(const ScopedGeosResources&) = delete;
+
+    ~ScopedGeosResources() {
+        release_geom();
+        if (reader != nullptr) {
+            GEOSWKBReader_destroy_r(ctx, reader);
+            reader = nullptr;
+        }
+        if (ctx != nullptr) {
+            GEOS_finish_r(ctx);
+            ctx = nullptr;
+        }
+    }
+
+    void
+    release_geom() {
+        if (geom != nullptr) {
+            GEOSGeom_destroy_r(ctx, geom);
+            geom = nullptr;
+        }
+    }
+};
 
 /**
  * Get a thread-local GEOS context handle for thread-safe operations.
@@ -32,7 +211,7 @@ inline GEOSContextHandle_t
 GetThreadLocalGEOSContext() {
     thread_local struct ThreadLocalContext {
         GEOSContextHandle_t ctx;
-        ThreadLocalContext() : ctx(GEOS_init_r()) {
+        ThreadLocalContext() : ctx(InitGEOSContext("thread-local geometry")) {
         }
         ~ThreadLocalContext() {
             if (ctx) {
@@ -83,26 +262,148 @@ class Geometry {
         geometry_ = geom;
     }
 
-    // Copy assignment
+    // WKB parse into this instance that returns false ONLY for bad data
+    // (unparseable WKB), leaving this invalid (IsValid() == false), instead of
+    // the throwing WKB constructor's AssertInfo. Mirrors the geometry cache's
+    // GetByOffsetUnsafe() == nullptr contract so exact refinement can
+    // `continue` past a corrupt/placeholder row in every configuration
+    // (geometry cache on or off) rather than throwing and failing the whole
+    // query.
+    //
+    // A transient resource failure (null context / reader allocation) is NOT
+    // bad data: collapsing it into `false` would silently filter out a
+    // perfectly valid row (a silent false negative). Those cases throw a
+    // retriable system error instead, matching RTreeIndexWrapper::add_geometry.
+    //
+    // KNOWN LIMIT: the transient/bad-data split above only covers failures we
+    // can observe BEFORE parsing. GEOS's capi execute() wrapper catches every
+    // exception thrown inside GEOSWKBReader_read_r -- including std::bad_alloc
+    // -- and returns nullptr, so a transient OOM DURING parsing is
+    // indistinguishable from unparseable WKB at this boundary (telling them
+    // apart would require installing a GEOS error handler and parsing message
+    // strings). Such a row is therefore classified as bad data with no retry:
+    // the cache stores an invalid entry, the filter paths evaluate it to
+    // false, and the index stamps a placeholder MBR. Accepted tradeoff:
+    // parse-time OOM is rare and the blast radius is a single row.
+    bool
+    TryParseFromWkb(GEOSContextHandle_t ctx, const void* wkb, size_t size) {
+        if (ctx == nullptr) {
+            ThrowInfo(ErrorCode::MemAllocateFailed,
+                      "null GEOS context while parsing WKB");
+        }
+        if (geometry_ != nullptr) {
+            GEOSGeom_destroy_r(ctx_, geometry_);
+            geometry_ = nullptr;
+        }
+        ctx_ = ctx;
+        GEOSWKBReader* reader = GEOSWKBReader_create_r(ctx);
+        if (reader == nullptr) {
+            ThrowInfo(ErrorCode::MemAllocateFailed,
+                      "failed to create GEOS WKB reader");
+        }
+        geometry_ = GEOSWKBReader_read_r(
+            ctx, reader, static_cast<const unsigned char*>(wkb), size);
+        GEOSWKBReader_destroy_r(ctx, reader);
+        return geometry_ != nullptr;
+    }
+
+    // Copy assignment (deep clone). Releases any geometry this instance
+    // already owns before taking a clone of `other`, so the two instances
+    // never share a raw GEOSGeometry* (which would double-free on
+    // destruction).
+    //
+    // CONSTRAINT: copying drives GEOS through the SOURCE instance's context
+    // (GEOSGeom_clone_r(other.ctx_, ...)) and the copy keeps that context.
+    // Therefore a cache-owned Geometry must never be copied from a query
+    // thread: (1) the cache's shared context is not thread-safe, so the clone
+    // call itself is a data race, and (2) a copy that outlives the cache's
+    // shared_ptr holds a dangling context. Query threads must use Clone(ctx)
+    // with their own (thread-local) context instead.
+    //
+    // These operators cannot simply be `= delete`d, but not because ingest
+    // copies Geometry values -- it does not. Geometry ingest stores WKB
+    // strings: FieldData<Geometry> derives from FieldDataGeometryImpl, which
+    // is FieldDataImpl<std::string, true>, and storage::CreateFieldData builds
+    // exactly that for GEOMETRY. FieldDataImpl<Geometry, true> has no user
+    // anywhere in the tree. What forces the operators is its explicit
+    // instantiation (`template class FieldDataImpl<Geometry, true>;` in
+    // FieldData.cpp), which instantiates the non-trivially-copyable
+    // std::copy_n branch of FillFieldData over Geometry -- so deleting them
+    // breaks the build even though nothing calls it.
+    //
+    // The only live copy sites are two std::any hops on the query path: the
+    // dataset Set in GISFunctionFilterExpr and the Get<Geometry>() in
+    // RTreeIndex::Query.
     Geometry&
     operator=(const Geometry& other) {
         if (this != &other) {
-            geometry_ = other.geometry_;
+            if (geometry_ != nullptr) {
+                GEOSGeom_destroy_r(ctx_, geometry_);
+                geometry_ = nullptr;
+            }
             ctx_ = other.ctx_;
+            if (other.IsValid()) {
+                geometry_ = CloneGeometryOrThrow(other.ctx_, other.geometry_);
+            }
         }
         return *this;
     }
 
-    // Copy constructor with context (for cloning)
+    // Copy constructor (deep clone). Same CONSTRAINT as copy assignment above:
+    // never copy a cache-owned Geometry from a query thread; use Clone(ctx).
     Geometry(const Geometry& other) : ctx_(other.ctx_) {
+        // nullptr first: CloneGeometryOrThrow can throw, and an unset
+        // geometry_ would be read by nothing (the object never completes
+        // construction) but leaves the member indeterminate for any future
+        // catch-and-inspect caller.
+        geometry_ = nullptr;
         if (other.IsValid()) {
-            GEOSGeometry* cloned =
-                GEOSGeom_clone_r(other.ctx_, other.geometry_);
-            AssertInfo(cloned != nullptr, "Failed to clone geometry");
-            geometry_ = cloned;
-        } else {
-            geometry_ = nullptr;
+            geometry_ = CloneGeometryOrThrow(other.ctx_, other.geometry_);
         }
+    }
+
+    // Explicit deep clone into the CALLER's context. All GEOS work runs
+    // through `ctx`, never through this instance's context, and the returned
+    // Geometry is bound to `ctx` -- this is the only safe way to duplicate a
+    // cache-owned Geometry from a query thread (hold the cache read lock and
+    // pass GetThreadLocalGEOSContext()), and the clone stays valid after the
+    // cache is gone.
+    //
+    // NOTE: no production caller today -- the filter paths borrow cached
+    // geometries under the read lock and never copy them, which is cheaper.
+    // This is not leftover dead code: it exists so that the next caller that
+    // does need a copy has a correct path, instead of reaching for the copy
+    // constructor above and silently cloning through the cache's shared
+    // context. Exercised by GeometryTest.
+    Geometry
+    Clone(GEOSContextHandle_t ctx) const {
+        Geometry cloned;
+        cloned.ctx_ = ctx;
+        if (IsValid()) {
+            cloned.geometry_ = CloneGeometryOrThrow(ctx, geometry_);
+        }
+        return cloned;
+    }
+
+    // Move constructor (transfers ownership, no GEOS allocation). Being
+    // noexcept lets std::vector relocate by move instead of clone-then-destroy.
+    Geometry(Geometry&& other) noexcept
+        : geometry_(other.geometry_), ctx_(other.ctx_) {
+        other.geometry_ = nullptr;
+    }
+
+    // Move assignment (transfers ownership, releases any existing geometry).
+    Geometry&
+    operator=(Geometry&& other) noexcept {
+        if (this != &other) {
+            if (geometry_ != nullptr) {
+                GEOSGeom_destroy_r(ctx_, geometry_);
+            }
+            geometry_ = other.geometry_;
+            ctx_ = other.ctx_;
+            other.geometry_ = nullptr;
+        }
+        return *this;
     }
 
     bool
@@ -121,80 +422,130 @@ class Geometry {
         return geometry_;
     }
 
-    // Spatial relation operations using GEOS API
+    // Spatial relation operations using GEOS API.
+    //
+    // Each predicate has an overload that takes an explicit GEOS context. GEOS
+    // context handles are NOT thread-safe, and cache-owned Geometry instances
+    // share one context across concurrent queries, so callers on a shared
+    // (read-locked) cached geometry MUST pass their own per-thread context
+    // (see GetThreadLocalGEOSContext) instead of relying on the stored ctx_.
+    // The no-context overloads keep using the instance's own context and are
+    // only safe when this instance is not shared across threads.
     bool
     equals(const Geometry& other) const {
+        return equals(other, ctx_);
+    }
+
+    bool
+    equals(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSEquals_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSEquals_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "equals");
     }
 
     bool
     touches(const Geometry& other) const {
+        return touches(other, ctx_);
+    }
+
+    bool
+    touches(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSTouches_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSTouches_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "touches");
     }
 
     bool
     overlaps(const Geometry& other) const {
+        return overlaps(other, ctx_);
+    }
+
+    bool
+    overlaps(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSOverlaps_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSOverlaps_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "overlaps");
     }
 
     bool
     crosses(const Geometry& other) const {
+        return crosses(other, ctx_);
+    }
+
+    bool
+    crosses(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSCrosses_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSCrosses_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "crosses");
     }
 
     bool
     contains(const Geometry& other) const {
+        return contains(other, ctx_);
+    }
+
+    bool
+    contains(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSContains_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSContains_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "contains");
     }
 
     bool
     intersects(const Geometry& other) const {
+        return intersects(other, ctx_);
+    }
+
+    bool
+    intersects(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSIntersects_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSIntersects_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "intersects");
     }
 
     bool
     within(const Geometry& other) const {
+        return within(other, ctx_);
+    }
+
+    bool
+    within(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSWithin_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSWithin_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "within");
     }
 
     // Distance within check using GEOS distance calculation
     bool
     dwithin(const Geometry& other, double distance) const {
+        return dwithin(other, distance, ctx_);
+    }
+
+    bool
+    dwithin(const Geometry& other,
+            double distance,
+            GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
 
         // Get geometry types
-        int thisType = GEOSGeomTypeId_r(ctx_, geometry_);
-        int otherType = GEOSGeomTypeId_r(ctx_, other.geometry_);
+        int thisType = GEOSGeomTypeId_r(ctx, geometry_);
+        int otherType = GEOSGeomTypeId_r(ctx, other.geometry_);
 
         // Ensure other geometry is a point
         AssertInfo(otherType == GEOS_POINT, "other geometry is not a point");
@@ -202,10 +553,10 @@ class Geometry {
         // For point-to-point, use Haversine formula for accuracy
         if (thisType == GEOS_POINT) {
             double thisX, thisY, otherX, otherY;
-            if (GEOSGeomGetX_r(ctx_, geometry_, &thisX) == 1 &&
-                GEOSGeomGetY_r(ctx_, geometry_, &thisY) == 1 &&
-                GEOSGeomGetX_r(ctx_, other.geometry_, &otherX) == 1 &&
-                GEOSGeomGetY_r(ctx_, other.geometry_, &otherY) == 1) {
+            if (GEOSGeomGetX_r(ctx, geometry_, &thisX) == 1 &&
+                GEOSGeomGetY_r(ctx, geometry_, &thisY) == 1 &&
+                GEOSGeomGetX_r(ctx, other.geometry_, &otherX) == 1 &&
+                GEOSGeomGetY_r(ctx, other.geometry_, &otherY) == 1) {
                 double actual_distance =
                     haversine_distance_meters(thisY, thisX, otherY, otherX);
                 return actual_distance <= distance;
@@ -214,26 +565,46 @@ class Geometry {
 
         // For other geometry types, use GEOS distance (in degrees)
         double geos_distance;
-        if (GEOSDistance_r(ctx_, geometry_, other.geometry_, &geos_distance) ==
+        if (GEOSDistance_r(ctx, geometry_, other.geometry_, &geos_distance) ==
             1) {
             // Get query point coordinates for conversion reference
             double query_lat, query_lon;
-            if (GEOSGeomGetX_r(ctx_, other.geometry_, &query_lon) == 1 &&
-                GEOSGeomGetY_r(ctx_, other.geometry_, &query_lat) == 1) {
+            if (GEOSGeomGetX_r(ctx, other.geometry_, &query_lon) == 1 &&
+                GEOSGeomGetY_r(ctx, other.geometry_, &query_lat) == 1) {
                 double distance_in_meters =
                     degrees_to_meters_at_location(geos_distance, query_lat);
                 return distance_in_meters <= distance;
             }
         }
 
+        // Reached only when GEOS distance/coordinate extraction failed (those
+        // calls return 0 on an exception caught inside GEOS). Same deliberate
+        // exception->false mapping as GeosPredicateIsTrue: keep the row-level
+        // leniency, but make the failure visible -- and throttled, because
+        // this is the same per-candidate-row refine hot path (one ST_DWithin
+        // over a segment of degenerate geometries would otherwise emit one
+        // line per row).
+        static std::atomic<int64_t> last_dwithin_log_us{0};
+        if (ShouldLogGeometryThrottled(last_dwithin_log_us)) {
+            LOG_WARN(
+                "GEOS distance/coordinate extraction failed in dwithin; "
+                "treating the row as not matching (further occurrences "
+                "suppressed briefly)");
+        }
         return false;
     }
+
     bool
     is_valid() const {
+        return is_valid(ctx_);
+    }
+
+    bool
+    is_valid(GEOSContextHandle_t ctx) const {
         if (!IsValid()) {
             return false;
         }
-        return GEOSisValid_r(ctx_, geometry_) == 1;
+        return GeosPredicateIsTrue(GEOSisValid_r(ctx, geometry_), "is_valid");
     }
 
  private:

--- a/internal/core/src/common/Geometry.h
+++ b/internal/core/src/common/Geometry.h
@@ -11,12 +11,141 @@
 #pragma once
 
 #include <geos_c.h>
+#include <atomic>
+#include <chrono>
 #include <memory>
 #include <cmath>
+#include <new>
 #include <string>
 #include "common/EasyAssert.h"
+#include "log/Log.h"
 
 namespace milvus {
+
+/**
+ * Best-effort time throttle for logs on per-row geometry paths.
+ *
+ * The geometry write and refine paths log one line per offending row. A
+ * segment full of corrupt or topologically invalid geometries would otherwise
+ * emit one line per row per query (refine) or per rebuild (write) -- millions
+ * of identical lines that bury everything else. Each call site owns a static
+ * counter; this returns true at most once per interval per counter. It proves
+ * the condition is occurring; it does not count occurrences.
+ */
+inline bool
+ShouldLogGeometryThrottled(std::atomic<int64_t>& last_log_us,
+                           int64_t interval_us = 10LL * 1000 * 1000) {
+    auto now_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                      std::chrono::steady_clock::now().time_since_epoch())
+                      .count();
+    auto previous = last_log_us.load(std::memory_order_relaxed);
+    return now_us - previous >= interval_us &&
+           last_log_us.compare_exchange_strong(
+               previous, now_us, std::memory_order_relaxed);
+}
+
+/**
+ * Reduce a tri-state GEOS predicate result to bool, observably.
+ *
+ * The GEOS capi binary predicates (GEOSIntersects_r, GEOSPreparedContains_r,
+ * GEOSisValid_r, ...) return char 1 = true, 0 = false, 2 = an exception was
+ * caught inside GEOS's execute() guard (a topology error on data GEOS cannot
+ * evaluate, or an allocation failure swallowed the same way -- see the KNOWN
+ * LIMIT note on Geometry::TryParseFromWkb). A bare `== 1` silently maps 2 to
+ * "no match", turning an evaluation failure into an unlogged false negative.
+ * Mapping 2 to false is still the deliberate choice -- the filter paths'
+ * single-row-leniency contract says one bad row must not fail the whole
+ * query, matching how corrupt WKB is skipped -- but it must be visible, so
+ * the exception case is logged. See PR #50951 review.
+ *
+ * The log is time-throttled because this sits on the exact-refinement hot
+ * path: it can run once per candidate row per query, so a segment full of
+ * topologically invalid geometries would otherwise emit millions of identical
+ * warnings for a single full-scan predicate. The throttle is process-wide and
+ * best-effort -- its job is to prove the condition is occurring, not to count
+ * occurrences.
+ */
+inline bool
+GeosPredicateIsTrue(char result, const char* op) {
+    if (result == 2) {
+        static std::atomic<int64_t> last_log_us{0};
+        if (ShouldLogGeometryThrottled(last_log_us)) {
+            LOG_WARN(
+                "GEOS predicate {} raised an exception; treating the row as "
+                "not matching (further occurrences suppressed briefly)",
+                op);
+        }
+        return false;
+    }
+    return result == 1;
+}
+
+/**
+ * Create a GEOS context, translating allocation failure into a retriable
+ * system error.
+ *
+ * GEOS_init_r() allocates its context with a bare `new` (it is NOT wrapped in
+ * the capi execute() guard), so on OOM it throws std::bad_alloc and never
+ * returns nullptr. Without this translation the bad_alloc is not a
+ * SegcoreError, so it would bypass the `catch (const SegcoreError&)` rethrow
+ * guards on the index write paths and collapse into a non-retryable
+ * UnexpectedError at the cgo boundary -- inverting the transient-vs-permanent
+ * classification for what is a textbook transient failure. See PR #50951
+ * review.
+ */
+inline GEOSContextHandle_t
+InitGEOSContext(const char* purpose) {
+    try {
+        return GEOS_init_r();
+    } catch (const std::bad_alloc&) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory initializing GEOS context for {}",
+                  purpose);
+    }
+}
+
+/**
+ * RAII holder for a GEOS context and the reader/geometry commonly held with
+ * it. Any code path that can throw between GEOS_init_r and GEOS_finish_r --
+ * a std::bad_alloc from a container op (now translated to a retriable error
+ * and retried, so a leak repeats once per attempt and compounds the OOM), a
+ * throwing Geometry constructor, an AssertInfo -- must hold its resources
+ * here instead of relying on trailing cleanup calls. Destruction order
+ * matters: geometry and reader are destroyed while the context is still
+ * alive. See PR #50951 review.
+ */
+struct ScopedGeosResources {
+    GEOSContextHandle_t ctx{nullptr};
+    GEOSWKBReader* reader{nullptr};
+    GEOSGeometry* geom{nullptr};
+
+    explicit ScopedGeosResources(const char* purpose)
+        : ctx(InitGEOSContext(purpose)) {
+    }
+    ScopedGeosResources(const ScopedGeosResources&) = delete;
+    ScopedGeosResources&
+    operator=(const ScopedGeosResources&) = delete;
+
+    ~ScopedGeosResources() {
+        release_geom();
+        if (reader != nullptr) {
+            GEOSWKBReader_destroy_r(ctx, reader);
+            reader = nullptr;
+        }
+        if (ctx != nullptr) {
+            GEOS_finish_r(ctx);
+            ctx = nullptr;
+        }
+    }
+
+    void
+    release_geom() {
+        if (geom != nullptr) {
+            GEOSGeom_destroy_r(ctx, geom);
+            geom = nullptr;
+        }
+    }
+};
 
 /**
  * Get a thread-local GEOS context handle for thread-safe operations.
@@ -32,7 +161,7 @@ inline GEOSContextHandle_t
 GetThreadLocalGEOSContext() {
     thread_local struct ThreadLocalContext {
         GEOSContextHandle_t ctx;
-        ThreadLocalContext() : ctx(GEOS_init_r()) {
+        ThreadLocalContext() : ctx(InitGEOSContext("thread-local geometry")) {
         }
         ~ThreadLocalContext() {
             if (ctx) {
@@ -83,17 +212,86 @@ class Geometry {
         geometry_ = geom;
     }
 
-    // Copy assignment
+    // WKB parse into this instance that returns false ONLY for bad data
+    // (unparseable WKB), leaving this invalid (IsValid() == false), instead of
+    // the throwing WKB constructor's AssertInfo. Mirrors the geometry cache's
+    // GetByOffsetUnsafe() == nullptr contract so exact refinement can
+    // `continue` past a corrupt/placeholder row in every configuration
+    // (geometry cache on or off) rather than throwing and failing the whole
+    // query. See PR #50951 review.
+    //
+    // A transient resource failure (null context / reader allocation) is NOT
+    // bad data: collapsing it into `false` would silently filter out a
+    // perfectly valid row (a silent false negative). Those cases throw a
+    // retriable system error instead, matching RTreeIndexWrapper::add_geometry.
+    //
+    // KNOWN LIMIT: the transient/bad-data split above only covers failures we
+    // can observe BEFORE parsing. GEOS's capi execute() wrapper catches every
+    // exception thrown inside GEOSWKBReader_read_r -- including std::bad_alloc
+    // -- and returns nullptr, so a transient OOM DURING parsing is
+    // indistinguishable from unparseable WKB at this boundary (telling them
+    // apart would require installing a GEOS error handler and parsing message
+    // strings). Such a row is therefore classified as bad data with no retry:
+    // the cache stores an invalid entry, the filter paths evaluate it to
+    // false, and the index stamps a placeholder MBR. Accepted tradeoff:
+    // parse-time OOM is rare and the blast radius is a single row.
+    bool
+    TryParseFromWkb(GEOSContextHandle_t ctx, const void* wkb, size_t size) {
+        if (ctx == nullptr) {
+            ThrowInfo(ErrorCode::MemAllocateFailed,
+                      "null GEOS context while parsing WKB");
+        }
+        if (geometry_ != nullptr) {
+            GEOSGeom_destroy_r(ctx_, geometry_);
+            geometry_ = nullptr;
+        }
+        ctx_ = ctx;
+        GEOSWKBReader* reader = GEOSWKBReader_create_r(ctx);
+        if (reader == nullptr) {
+            ThrowInfo(ErrorCode::MemAllocateFailed,
+                      "failed to create GEOS WKB reader");
+        }
+        geometry_ = GEOSWKBReader_read_r(
+            ctx, reader, static_cast<const unsigned char*>(wkb), size);
+        GEOSWKBReader_destroy_r(ctx, reader);
+        return geometry_ != nullptr;
+    }
+
+    // Copy assignment (deep clone). Releases any geometry this instance
+    // already owns before taking a clone of `other`, so the two instances
+    // never share a raw GEOSGeometry* (which would double-free on
+    // destruction).
+    //
+    // CONSTRAINT: copying drives GEOS through the SOURCE instance's context
+    // (GEOSGeom_clone_r(other.ctx_, ...)) and the copy keeps that context.
+    // Therefore a cache-owned Geometry must never be copied from a query
+    // thread: (1) the cache's shared context is not thread-safe, so the clone
+    // call itself is a data race, and (2) a copy that outlives the cache's
+    // shared_ptr holds a dangling context. Query threads must use Clone(ctx)
+    // with their own (thread-local) context instead. Implicit copies cannot
+    // simply be deleted: generic container code (FieldDataImpl's std::copy_n)
+    // copies Geometry values on the single-threaded ingest path, which is the
+    // legitimate use these operators exist for.
     Geometry&
     operator=(const Geometry& other) {
         if (this != &other) {
-            geometry_ = other.geometry_;
+            if (geometry_ != nullptr) {
+                GEOSGeom_destroy_r(ctx_, geometry_);
+                geometry_ = nullptr;
+            }
             ctx_ = other.ctx_;
+            if (other.IsValid()) {
+                GEOSGeometry* cloned =
+                    GEOSGeom_clone_r(other.ctx_, other.geometry_);
+                AssertInfo(cloned != nullptr, "Failed to clone geometry");
+                geometry_ = cloned;
+            }
         }
         return *this;
     }
 
-    // Copy constructor with context (for cloning)
+    // Copy constructor (deep clone). Same CONSTRAINT as copy assignment above:
+    // never copy a cache-owned Geometry from a query thread; use Clone(ctx).
     Geometry(const Geometry& other) : ctx_(other.ctx_) {
         if (other.IsValid()) {
             GEOSGeometry* cloned =
@@ -103,6 +301,52 @@ class Geometry {
         } else {
             geometry_ = nullptr;
         }
+    }
+
+    // Explicit deep clone into the CALLER's context. All GEOS work runs
+    // through `ctx`, never through this instance's context, and the returned
+    // Geometry is bound to `ctx` -- this is the only safe way to duplicate a
+    // cache-owned Geometry from a query thread (hold the cache read lock and
+    // pass GetThreadLocalGEOSContext()), and the clone stays valid after the
+    // cache is gone.
+    //
+    // NOTE: no production caller today -- the filter paths borrow cached
+    // geometries under the read lock and never copy them, which is cheaper.
+    // This is not leftover dead code: it exists so that the next caller that
+    // does need a copy has a correct path, instead of reaching for the copy
+    // constructor above and silently cloning through the cache's shared
+    // context. Exercised by GeometryTest.
+    Geometry
+    Clone(GEOSContextHandle_t ctx) const {
+        Geometry cloned;
+        cloned.ctx_ = ctx;
+        if (IsValid()) {
+            GEOSGeometry* geom = GEOSGeom_clone_r(ctx, geometry_);
+            AssertInfo(geom != nullptr, "Failed to clone geometry");
+            cloned.geometry_ = geom;
+        }
+        return cloned;
+    }
+
+    // Move constructor (transfers ownership, no GEOS allocation). Being
+    // noexcept lets std::vector relocate by move instead of clone-then-destroy.
+    Geometry(Geometry&& other) noexcept
+        : geometry_(other.geometry_), ctx_(other.ctx_) {
+        other.geometry_ = nullptr;
+    }
+
+    // Move assignment (transfers ownership, releases any existing geometry).
+    Geometry&
+    operator=(Geometry&& other) noexcept {
+        if (this != &other) {
+            if (geometry_ != nullptr) {
+                GEOSGeom_destroy_r(ctx_, geometry_);
+            }
+            geometry_ = other.geometry_;
+            ctx_ = other.ctx_;
+            other.geometry_ = nullptr;
+        }
+        return *this;
     }
 
     bool
@@ -121,80 +365,130 @@ class Geometry {
         return geometry_;
     }
 
-    // Spatial relation operations using GEOS API
+    // Spatial relation operations using GEOS API.
+    //
+    // Each predicate has an overload that takes an explicit GEOS context. GEOS
+    // context handles are NOT thread-safe, and cache-owned Geometry instances
+    // share one context across concurrent queries, so callers on a shared
+    // (read-locked) cached geometry MUST pass their own per-thread context
+    // (see GetThreadLocalGEOSContext) instead of relying on the stored ctx_.
+    // The no-context overloads keep using the instance's own context and are
+    // only safe when this instance is not shared across threads.
     bool
     equals(const Geometry& other) const {
+        return equals(other, ctx_);
+    }
+
+    bool
+    equals(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSEquals_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSEquals_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "equals");
     }
 
     bool
     touches(const Geometry& other) const {
+        return touches(other, ctx_);
+    }
+
+    bool
+    touches(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSTouches_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSTouches_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "touches");
     }
 
     bool
     overlaps(const Geometry& other) const {
+        return overlaps(other, ctx_);
+    }
+
+    bool
+    overlaps(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSOverlaps_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSOverlaps_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "overlaps");
     }
 
     bool
     crosses(const Geometry& other) const {
+        return crosses(other, ctx_);
+    }
+
+    bool
+    crosses(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSCrosses_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSCrosses_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "crosses");
     }
 
     bool
     contains(const Geometry& other) const {
+        return contains(other, ctx_);
+    }
+
+    bool
+    contains(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSContains_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSContains_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "contains");
     }
 
     bool
     intersects(const Geometry& other) const {
+        return intersects(other, ctx_);
+    }
+
+    bool
+    intersects(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSIntersects_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSIntersects_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "intersects");
     }
 
     bool
     within(const Geometry& other) const {
+        return within(other, ctx_);
+    }
+
+    bool
+    within(const Geometry& other, GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        char result = GEOSWithin_r(ctx_, geometry_, other.geometry_);
-        return result == 1;
+        char result = GEOSWithin_r(ctx, geometry_, other.geometry_);
+        return GeosPredicateIsTrue(result, "within");
     }
 
     // Distance within check using GEOS distance calculation
     bool
     dwithin(const Geometry& other, double distance) const {
+        return dwithin(other, distance, ctx_);
+    }
+
+    bool
+    dwithin(const Geometry& other,
+            double distance,
+            GEOSContextHandle_t ctx) const {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
 
         // Get geometry types
-        int thisType = GEOSGeomTypeId_r(ctx_, geometry_);
-        int otherType = GEOSGeomTypeId_r(ctx_, other.geometry_);
+        int thisType = GEOSGeomTypeId_r(ctx, geometry_);
+        int otherType = GEOSGeomTypeId_r(ctx, other.geometry_);
 
         // Ensure other geometry is a point
         AssertInfo(otherType == GEOS_POINT, "other geometry is not a point");
@@ -202,10 +496,10 @@ class Geometry {
         // For point-to-point, use Haversine formula for accuracy
         if (thisType == GEOS_POINT) {
             double thisX, thisY, otherX, otherY;
-            if (GEOSGeomGetX_r(ctx_, geometry_, &thisX) == 1 &&
-                GEOSGeomGetY_r(ctx_, geometry_, &thisY) == 1 &&
-                GEOSGeomGetX_r(ctx_, other.geometry_, &otherX) == 1 &&
-                GEOSGeomGetY_r(ctx_, other.geometry_, &otherY) == 1) {
+            if (GEOSGeomGetX_r(ctx, geometry_, &thisX) == 1 &&
+                GEOSGeomGetY_r(ctx, geometry_, &thisY) == 1 &&
+                GEOSGeomGetX_r(ctx, other.geometry_, &otherX) == 1 &&
+                GEOSGeomGetY_r(ctx, other.geometry_, &otherY) == 1) {
                 double actual_distance =
                     haversine_distance_meters(thisY, thisX, otherY, otherX);
                 return actual_distance <= distance;
@@ -214,26 +508,46 @@ class Geometry {
 
         // For other geometry types, use GEOS distance (in degrees)
         double geos_distance;
-        if (GEOSDistance_r(ctx_, geometry_, other.geometry_, &geos_distance) ==
+        if (GEOSDistance_r(ctx, geometry_, other.geometry_, &geos_distance) ==
             1) {
             // Get query point coordinates for conversion reference
             double query_lat, query_lon;
-            if (GEOSGeomGetX_r(ctx_, other.geometry_, &query_lon) == 1 &&
-                GEOSGeomGetY_r(ctx_, other.geometry_, &query_lat) == 1) {
+            if (GEOSGeomGetX_r(ctx, other.geometry_, &query_lon) == 1 &&
+                GEOSGeomGetY_r(ctx, other.geometry_, &query_lat) == 1) {
                 double distance_in_meters =
                     degrees_to_meters_at_location(geos_distance, query_lat);
                 return distance_in_meters <= distance;
             }
         }
 
+        // Reached only when GEOS distance/coordinate extraction failed (those
+        // calls return 0 on an exception caught inside GEOS). Same deliberate
+        // exception->false mapping as GeosPredicateIsTrue: keep the row-level
+        // leniency, but make the failure visible -- and throttled, because
+        // this is the same per-candidate-row refine hot path (one ST_DWithin
+        // over a segment of degenerate geometries would otherwise emit one
+        // line per row).
+        static std::atomic<int64_t> last_dwithin_log_us{0};
+        if (ShouldLogGeometryThrottled(last_dwithin_log_us)) {
+            LOG_WARN(
+                "GEOS distance/coordinate extraction failed in dwithin; "
+                "treating the row as not matching (further occurrences "
+                "suppressed briefly)");
+        }
         return false;
     }
+
     bool
     is_valid() const {
+        return is_valid(ctx_);
+    }
+
+    bool
+    is_valid(GEOSContextHandle_t ctx) const {
         if (!IsValid()) {
             return false;
         }
-        return GEOSisValid_r(ctx_, geometry_) == 1;
+        return GeosPredicateIsTrue(GEOSisValid_r(ctx, geometry_), "is_valid");
     }
 
  private:

--- a/internal/core/src/common/Geometry.h
+++ b/internal/core/src/common/Geometry.h
@@ -105,6 +105,57 @@ InitGEOSContext(const char* purpose) {
 }
 
 /**
+ * Test-only one-shot fault injection for the clone path below.
+ *
+ * The only realistic failure of GEOSGeom_clone_r() is allocation failure,
+ * which a unit test cannot provoke, so the classification of that failure
+ * would otherwise be untestable. Lives next to the call site so both share one
+ * flag; production code never sets it.
+ */
+inline std::atomic<bool>&
+GeometryCloneFailureForTesting() {
+    static std::atomic<bool> flag{false};
+    return flag;
+}
+
+/**
+ * Deep-clone a geometry into `ctx`, translating clone failure into a retriable
+ * system error.
+ *
+ * GEOSGeom_clone_r() runs inside the capi execute() guard, which catches
+ * std::exception -- std::bad_alloc included -- and returns nullptr rather than
+ * propagating it (geos_ts_c.cpp). So an OOM on this path NEVER surfaces as an
+ * exception that a `catch (const std::bad_alloc&)` net could translate, and
+ * reporting the nullptr with a plain AssertInfo would classify a textbook
+ * transient failure as a non-retryable UnexpectedError (2001).
+ *
+ * On the search path that is worse than just losing the retry: 2001 is not
+ * retriable in merr's segcore table, and lb_policy treats a non-retriable
+ * failure by BLACKLISTING the serving node for the channel
+ * (shardclient/lb_policy.go) instead of merely excluding it from this one
+ * request and failing over to another replica. Memory pressure would then
+ * evict healthy nodes from routing.
+ *
+ * Callers clone geometries that already parsed and validated, so a nullptr
+ * here is attributable to resource failure -- there is none of the bad-data /
+ * OOM ambiguity that TryParseFromWkb documents as a KNOWN LIMIT. Same
+ * reasoning as InitGEOSContext above. See PR #50951 review.
+ */
+inline GEOSGeometry*
+CloneGeometryOrThrow(GEOSContextHandle_t ctx, const GEOSGeometry* geom) {
+    GEOSGeometry* cloned = GEOSGeom_clone_r(ctx, geom);
+    if (GeometryCloneFailureForTesting().exchange(false) && cloned != nullptr) {
+        GEOSGeom_destroy_r(ctx, cloned);
+        cloned = nullptr;
+    }
+    if (cloned == nullptr) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory cloning geometry");
+    }
+    return cloned;
+}
+
+/**
  * RAII holder for a GEOS context and the reader/geometry commonly held with
  * it. Any code path that can throw between GEOS_init_r and GEOS_finish_r --
  * a std::bad_alloc from a container op (now translated to a retriable error
@@ -281,10 +332,7 @@ class Geometry {
             }
             ctx_ = other.ctx_;
             if (other.IsValid()) {
-                GEOSGeometry* cloned =
-                    GEOSGeom_clone_r(other.ctx_, other.geometry_);
-                AssertInfo(cloned != nullptr, "Failed to clone geometry");
-                geometry_ = cloned;
+                geometry_ = CloneGeometryOrThrow(other.ctx_, other.geometry_);
             }
         }
         return *this;
@@ -293,13 +341,13 @@ class Geometry {
     // Copy constructor (deep clone). Same CONSTRAINT as copy assignment above:
     // never copy a cache-owned Geometry from a query thread; use Clone(ctx).
     Geometry(const Geometry& other) : ctx_(other.ctx_) {
+        // nullptr first: CloneGeometryOrThrow can throw, and an unset
+        // geometry_ would be read by nothing (the object never completes
+        // construction) but leaves the member indeterminate for any future
+        // catch-and-inspect caller.
+        geometry_ = nullptr;
         if (other.IsValid()) {
-            GEOSGeometry* cloned =
-                GEOSGeom_clone_r(other.ctx_, other.geometry_);
-            AssertInfo(cloned != nullptr, "Failed to clone geometry");
-            geometry_ = cloned;
-        } else {
-            geometry_ = nullptr;
+            geometry_ = CloneGeometryOrThrow(other.ctx_, other.geometry_);
         }
     }
 
@@ -321,9 +369,7 @@ class Geometry {
         Geometry cloned;
         cloned.ctx_ = ctx;
         if (IsValid()) {
-            GEOSGeometry* geom = GEOSGeom_clone_r(ctx, geometry_);
-            AssertInfo(geom != nullptr, "Failed to clone geometry");
-            cloned.geometry_ = geom;
+            cloned.geometry_ = CloneGeometryOrThrow(ctx, geometry_);
         }
         return cloned;
     }

--- a/internal/core/src/common/Geometry.h
+++ b/internal/core/src/common/Geometry.h
@@ -319,10 +319,22 @@ class Geometry {
     // thread: (1) the cache's shared context is not thread-safe, so the clone
     // call itself is a data race, and (2) a copy that outlives the cache's
     // shared_ptr holds a dangling context. Query threads must use Clone(ctx)
-    // with their own (thread-local) context instead. Implicit copies cannot
-    // simply be deleted: generic container code (FieldDataImpl's std::copy_n)
-    // copies Geometry values on the single-threaded ingest path, which is the
-    // legitimate use these operators exist for.
+    // with their own (thread-local) context instead.
+    //
+    // These operators cannot simply be `= delete`d, but not because ingest
+    // copies Geometry values -- it does not. Geometry ingest stores WKB
+    // strings: FieldData<Geometry> derives from FieldDataGeometryImpl, which
+    // is FieldDataImpl<std::string, true>, and storage::CreateFieldData builds
+    // exactly that for GEOMETRY. FieldDataImpl<Geometry, true> has no user
+    // anywhere in the tree. What forces the operators is its explicit
+    // instantiation (`template class FieldDataImpl<Geometry, true>;` in
+    // FieldData.cpp), which instantiates the non-trivially-copyable
+    // std::copy_n branch of FillFieldData over Geometry -- so deleting them
+    // breaks the build even though nothing calls it.
+    //
+    // The only live copy sites are two std::any hops on the query path: the
+    // dataset Set in GISFunctionFilterExpr and the Get<Geometry>() in
+    // RTreeIndex::Query.
     Geometry&
     operator=(const Geometry& other) {
         if (this != &other) {

--- a/internal/core/src/common/GeometryCache.h
+++ b/internal/core/src/common/GeometryCache.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -27,33 +28,131 @@
 namespace milvus {
 namespace exec {
 
-// Helper function to create cache key from segment_id and field_id
+// Cache key: the OWNING SEGMENT OBJECT (segment_instance_uid) plus the field.
+//
+// Keying on the logical segment id is not enough, because more than one live
+// object can carry the same id -- and a cache entry's lifetime is tied to the
+// object that built it, not to the logical segment:
+//   * a growing and a sealed twin coexist during handoff (querynode keeps two
+//     maps keyed by the same id), and
+//   * two sealed instances of different versions coexist while the replaced
+//     one is released asynchronously (segments/manager.go:409-441).
+// In both cases a shared key means the arriving instance reuses the departing
+// instance's entry, and the departing instance's destructor then erases the
+// cache the still-serving instance depends on. The cache is only ever built
+// during load, so it is never rebuilt: every later GIS predicate silently
+// falls back to per-row bulk_subscript + WKB re-parsing, with no error and no
+// log. The segment id stays in the key for diagnosability only.
 inline std::string
-MakeCacheKey(int64_t segment_id, FieldId field_id) {
-    return std::to_string(segment_id) + "_" + std::to_string(field_id.get());
+MakeCacheKey(uint64_t segment_instance_uid,
+             int64_t segment_id,
+             FieldId field_id) {
+    return std::to_string(segment_instance_uid) + "_" +
+           std::to_string(segment_id) + "_" + std::to_string(field_id.get());
 }
 
-// Vector-based Geometry cache that maintains original field data order
+// Prefix covering every field cache owned by one segment OBJECT, so a
+// destructor erases only the entries that object created.
+inline std::string
+MakeSegmentCachePrefix(uint64_t segment_instance_uid, int64_t segment_id) {
+    return std::to_string(segment_instance_uid) + "_" +
+           std::to_string(segment_id) + "_";
+}
+
+// Vector-based Geometry cache that maintains original field data order.
+//
+// The cache owns its own GEOS context: every cached Geometry is built and
+// destroyed with ctx_, so the cache is fully self-contained and its lifetime
+// is independent of the segment that populated it. Combined with the manager
+// handing out shared_ptr<SimpleGeometryCache>, an in-flight query keeps the
+// cache (and its context) alive even if the owning segment is dropped and
+// RemoveSegmentCaches() runs concurrently.
 class SimpleGeometryCache {
  public:
-    // Append WKB data during field loading
+    // InitGEOSContext translates an allocation failure into a retriable
+    // MemAllocateFailed (GEOS_init_r throws bad_alloc on OOM, it never
+    // returns nullptr -- see the helper's comment).
+    SimpleGeometryCache() : ctx_(InitGEOSContext("geometry cache")) {
+    }
+
+    ~SimpleGeometryCache() {
+        // Destroy the cached geometries (each calls GEOSGeom_destroy_r(ctx_,
+        // ...)) while ctx_ is still alive, then release the context.
+        {
+            std::lock_guard<std::shared_mutex> lock(mutex_);
+            geometries_.clear();
+        }
+        if (ctx_ != nullptr) {
+            GEOS_finish_r(ctx_);
+            ctx_ = nullptr;
+        }
+    }
+
+    // The cache owns a GEOS context, so it is neither copyable nor movable.
+    SimpleGeometryCache(const SimpleGeometryCache&) = delete;
+    SimpleGeometryCache&
+    operator=(const SimpleGeometryCache&) = delete;
+
+    // Store the WKB for one row at its ABSOLUTE segment offset.
+    //
+    // Offset-addressed on purpose (this used to be a tail append): readers
+    // resolve rows by absolute segment offset (GetByOffsetUnsafe), while a
+    // write can throw a retriable MemAllocateFailed mid-batch (TryParseFromWkb
+    // on a transient GEOS reader-allocation failure). With a tail append the
+    // rows already written before the throw stayed in the vector, so the
+    // retried load/insert appended AFTER them and every later row shifted to
+    // the wrong offset -- silently returning the wrong geometry. Writing at
+    // the reserved absolute offset makes the operation idempotent: a retry
+    // overwrites the same slots and alignment can never drift, which is also
+    // why publishing the cache in the manager map before it is fully
+    // populated (GetOrCreateCache) is safe. Slots skipped over by an
+    // out-of-order or failed batch stay default-invalid and readers skip
+    // them; such rows are never acked/readable until their write lands.
+    //
+    // A row with corrupt (unparseable) WKB is stored as an INVALID entry --
+    // GetByOffsetUnsafe() returns nullptr for it and every reader skips it --
+    // instead of throwing. Throwing here would make a single corrupt row fail
+    // the whole segment load whenever the geometry cache is enabled (the write
+    // paths deliberately keep such rows: add_geometry / bulk_load index a
+    // placeholder MBR rather than dropping them, so they DO reach the cache).
+    // A transient resource failure (reader allocation) still throws a
+    // retriable system error via TryParseFromWkb -- that is not bad data. One
+    // exception we cannot tell apart: an OOM INSIDE GEOS parsing surfaces as
+    // the same nullptr as corrupt WKB and is deliberately classified as bad
+    // data here (see the KNOWN LIMIT note on TryParseFromWkb).
     void
-    AppendData(GEOSContextHandle_t ctx, const char* wkb_data, size_t size) {
+    AppendDataAt(size_t absolute_offset, const char* wkb_data, size_t size) {
         std::lock_guard<std::shared_mutex> lock(mutex_);
 
-        if (size == 0 || wkb_data == nullptr) {
-            // Handle null/empty geometry - add invalid geometry
-            geometries_.emplace_back();
-        } else {
-            try {
-                // Create geometry with cache's context
-                geometries_.emplace_back(ctx, wkb_data, size);
-            } catch (const std::exception& e) {
-                ThrowInfo(UnexpectedError,
-                          "Failed to construct geometry from WKB data: {}",
-                          e.what());
-            }
+        if (geometries_.size() <= absolute_offset) {
+            // Default-constructed gap entries are invalid; a reader that
+            // somehow reaches one skips the row, and the owning batch's
+            // (re)write fills it in place.
+            geometries_.resize(absolute_offset + 1);
         }
+
+        if (size == 0 || wkb_data == nullptr) {
+            // Null/empty geometry - store an invalid entry
+            geometries_[absolute_offset] = Geometry();
+            return;
+        }
+        Geometry geometry;
+        if (!geometry.TryParseFromWkb(ctx_, wkb_data, size)) {
+            static std::atomic<int64_t> last_cache_parse_log_us{0};
+            if (ShouldLogGeometryThrottled(last_cache_parse_log_us)) {
+                LOG_WARN(
+                    "unparseable WKB at cache offset {}; caching an invalid "
+                    "placeholder entry, readers will skip it (further "
+                    "occurrences suppressed briefly)",
+                    absolute_offset);
+            } else {
+                LOG_DEBUG("unparseable WKB at cache offset {}",
+                          absolute_offset);
+            }
+            geometries_[absolute_offset] = Geometry();
+            return;
+        }
+        geometries_[absolute_offset] = std::move(geometry);
     }
 
     // Get shared lock for batch operations (RAII)
@@ -62,14 +161,21 @@ class SimpleGeometryCache {
         return std::shared_lock<std::shared_mutex>(mutex_);
     }
 
-    // Get Geometry by offset without locking (use with AcquireReadLock)
+    // Get Geometry by offset without locking (use with AcquireReadLock).
+    //
+    // An out-of-range offset returns nullptr, the same "no geometry here,
+    // skip the row" answer as an invalid entry -- it must NOT throw. On a
+    // growing segment there is a real window where a reader legitimately
+    // outruns this cache: SegmentGrowingImpl::Insert feeds the R-Tree
+    // (AppendingIndex) before it fills the cache (BuildGeometryCacheForInsert),
+    // so a concurrent query whose coarse bitmap is sized by the index's
+    // Count() can probe an offset the cache has not reached yet. Those rows
+    // are not yet acked, so reporting them as non-matching is correct;
+    // throwing a non-retriable UnexpectedError out of a read path is not.
     const Geometry*
     GetByOffsetUnsafe(size_t offset) const {
         if (offset >= geometries_.size()) {
-            ThrowInfo(UnexpectedError,
-                      "offset {} is out of range: {}",
-                      offset,
-                      geometries_.size());
+            return nullptr;
         }
 
         const auto& geometry = geometries_[offset];
@@ -90,6 +196,19 @@ class SimpleGeometryCache {
         return geometries_.size();
     }
 
+    // Get total number of loaded geometries without locking (use with
+    // AcquireReadLock). Calling Size() while already holding the read lock
+    // would recursively acquire the non-reentrant shared_mutex: that is
+    // undefined behavior per [thread.sharedmutex.requirements] regardless of
+    // platform, and becomes a real deadlock on writer-preferring
+    // implementations once a writer is queued. (Not a claim about this
+    // build's std::shared_mutex: on Linux libstdc++ maps it to
+    // pthread_rwlock_t, whose glibc default is reader-preferring.)
+    size_t
+    SizeUnsafe() const {
+        return geometries_.size();
+    }
+
     // Check if cache is loaded
     bool
     IsLoaded() const {
@@ -98,6 +217,9 @@ class SimpleGeometryCache {
     }
 
  private:
+    // ctx_ is declared first so it is destroyed last (after geometries_),
+    // guaranteeing the Geometry destructors still see a live context.
+    GEOSContextHandle_t ctx_{nullptr};  // Context owned by this cache
     mutable std::shared_mutex mutex_;   // For read/write operations
     std::vector<Geometry> geometries_;  // Direct storage of Geometry objects
 };
@@ -113,44 +235,54 @@ class SimpleGeometryCacheManager {
 
     SimpleGeometryCacheManager() = default;
 
-    SimpleGeometryCache&
-    GetOrCreateCache(int64_t segment_id, FieldId field_id) {
+    // Returns a shared_ptr so callers keep the cache alive for the duration of
+    // their use even if RemoveCache/RemoveSegmentCaches drops it concurrently.
+    std::shared_ptr<SimpleGeometryCache>
+    GetOrCreateCache(uint64_t segment_instance_uid,
+                     int64_t segment_id,
+                     FieldId field_id) {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto key = MakeCacheKey(segment_id, field_id);
+        auto key = MakeCacheKey(segment_instance_uid, segment_id, field_id);
         auto it = caches_.find(key);
         if (it != caches_.end()) {
-            return *(it->second);
+            return it->second;
         }
 
-        auto cache = std::make_unique<SimpleGeometryCache>();
-        auto* cache_ptr = cache.get();
-        caches_.emplace(key, std::move(cache));
-        return *cache_ptr;
+        auto cache = std::make_shared<SimpleGeometryCache>();
+        caches_.emplace(key, cache);
+        return cache;
     }
 
-    SimpleGeometryCache*
-    GetCache(int64_t segment_id, FieldId field_id) {
+    std::shared_ptr<SimpleGeometryCache>
+    GetCache(uint64_t segment_instance_uid,
+             int64_t segment_id,
+             FieldId field_id) {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto key = MakeCacheKey(segment_id, field_id);
+        auto key = MakeCacheKey(segment_instance_uid, segment_id, field_id);
         auto it = caches_.find(key);
         if (it != caches_.end()) {
-            return it->second.get();
+            return it->second;
         }
         return nullptr;
     }
 
     void
-    RemoveCache(GEOSContextHandle_t ctx, int64_t segment_id, FieldId field_id) {
+    RemoveCache(uint64_t segment_instance_uid,
+                int64_t segment_id,
+                FieldId field_id) {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto key = MakeCacheKey(segment_id, field_id);
-        caches_.erase(key);
+        caches_.erase(MakeCacheKey(segment_instance_uid, segment_id, field_id));
     }
 
-    // Remove all caches for a segment (useful when segment is destroyed)
+    // Remove all caches owned by one segment OBJECT -- called from that
+    // object's destructor, and deliberately NOT matching any other live
+    // instance that shares the same logical segment id (growing/sealed twin,
+    // or an older/newer version of the same sealed segment).
     void
-    RemoveSegmentCaches(GEOSContextHandle_t ctx, int64_t segment_id) {
+    RemoveSegmentCaches(uint64_t segment_instance_uid, int64_t segment_id) {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto segment_prefix = std::to_string(segment_id) + "_";
+        auto segment_prefix =
+            MakeSegmentCachePrefix(segment_instance_uid, segment_id);
         auto it = caches_.begin();
         while (it != caches_.end()) {
             if (it->first.substr(0, segment_prefix.length()) ==
@@ -189,7 +321,7 @@ class SimpleGeometryCacheManager {
     operator=(const SimpleGeometryCacheManager&) = delete;
 
     mutable std::mutex mutex_;
-    std::unordered_map<std::string, std::unique_ptr<SimpleGeometryCache>>
+    std::unordered_map<std::string, std::shared_ptr<SimpleGeometryCache>>
         caches_;
 };
 

--- a/internal/core/src/common/GeometryCache.h
+++ b/internal/core/src/common/GeometryCache.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -27,33 +28,132 @@
 namespace milvus {
 namespace exec {
 
-// Helper function to create cache key from segment_id and field_id
+// Cache key: the OWNING SEGMENT OBJECT (segment_instance_uid) plus the field.
+//
+// Keying on the logical segment id is not enough, because more than one live
+// object can carry the same id -- and a cache entry's lifetime is tied to the
+// object that built it, not to the logical segment:
+//   * a growing and a sealed twin coexist during handoff (querynode keeps two
+//     maps keyed by the same id), and
+//   * two sealed instances of different versions coexist while the replaced
+//     one is released asynchronously (segments/manager.go:409-441).
+// In both cases a shared key means the arriving instance reuses the departing
+// instance's entry, and the departing instance's destructor then erases the
+// cache the still-serving instance depends on. The cache is only ever built
+// during load, so it is never rebuilt: every later GIS predicate silently
+// falls back to per-row bulk_subscript + WKB re-parsing, with no error and no
+// log. The segment id stays in the key for diagnosability only.
 inline std::string
-MakeCacheKey(int64_t segment_id, FieldId field_id) {
-    return std::to_string(segment_id) + "_" + std::to_string(field_id.get());
+MakeCacheKey(uint64_t segment_instance_uid,
+             int64_t segment_id,
+             FieldId field_id) {
+    return std::to_string(segment_instance_uid) + "_" +
+           std::to_string(segment_id) + "_" + std::to_string(field_id.get());
 }
 
-// Vector-based Geometry cache that maintains original field data order
+// Prefix covering every field cache owned by one segment OBJECT, so a
+// destructor erases only the entries that object created.
+inline std::string
+MakeSegmentCachePrefix(uint64_t segment_instance_uid, int64_t segment_id) {
+    return std::to_string(segment_instance_uid) + "_" +
+           std::to_string(segment_id) + "_";
+}
+
+// Vector-based Geometry cache that maintains original field data order.
+//
+// The cache owns its own GEOS context: every cached Geometry is built and
+// destroyed with ctx_, so the cache is fully self-contained and its lifetime
+// is independent of the segment that populated it. Combined with the manager
+// handing out shared_ptr<SimpleGeometryCache>, an in-flight query keeps the
+// cache (and its context) alive even if the owning segment is dropped and
+// RemoveSegmentCaches() runs concurrently.
 class SimpleGeometryCache {
  public:
-    // Append WKB data during field loading
+    // InitGEOSContext translates an allocation failure into a retriable
+    // MemAllocateFailed (GEOS_init_r throws bad_alloc on OOM, it never
+    // returns nullptr -- see the helper's comment).
+    SimpleGeometryCache() : ctx_(InitGEOSContext("geometry cache")) {
+    }
+
+    ~SimpleGeometryCache() {
+        // Destroy the cached geometries (each calls GEOSGeom_destroy_r(ctx_,
+        // ...)) while ctx_ is still alive, then release the context.
+        {
+            std::lock_guard<std::shared_mutex> lock(mutex_);
+            geometries_.clear();
+        }
+        if (ctx_ != nullptr) {
+            GEOS_finish_r(ctx_);
+            ctx_ = nullptr;
+        }
+    }
+
+    // The cache owns a GEOS context, so it is neither copyable nor movable.
+    SimpleGeometryCache(const SimpleGeometryCache&) = delete;
+    SimpleGeometryCache&
+    operator=(const SimpleGeometryCache&) = delete;
+
+    // Store the WKB for one row at its ABSOLUTE segment offset.
+    //
+    // Offset-addressed on purpose (this used to be a tail append): readers
+    // resolve rows by absolute segment offset (GetByOffsetUnsafe), while a
+    // write can throw a retriable MemAllocateFailed mid-batch (TryParseFromWkb
+    // on a transient GEOS reader-allocation failure). With a tail append the
+    // rows already written before the throw stayed in the vector, so the
+    // retried load/insert appended AFTER them and every later row shifted to
+    // the wrong offset -- silently returning the wrong geometry. Writing at
+    // the reserved absolute offset makes the operation idempotent: a retry
+    // overwrites the same slots and alignment can never drift, which is also
+    // why publishing the cache in the manager map before it is fully
+    // populated (GetOrCreateCache) is safe. Slots skipped over by an
+    // out-of-order or failed batch stay default-invalid and readers skip
+    // them; such rows are never acked/readable until their write lands.
+    // See PR #50951 review (round Df4a298c5f4).
+    //
+    // A row with corrupt (unparseable) WKB is stored as an INVALID entry --
+    // GetByOffsetUnsafe() returns nullptr for it and every reader skips it --
+    // instead of throwing. Throwing here would make a single corrupt row fail
+    // the whole segment load whenever the geometry cache is enabled (the write
+    // paths deliberately keep such rows: add_geometry / bulk_load index a
+    // placeholder MBR rather than dropping them, so they DO reach the cache).
+    // A transient resource failure (reader allocation) still throws a
+    // retriable system error via TryParseFromWkb -- that is not bad data. One
+    // exception we cannot tell apart: an OOM INSIDE GEOS parsing surfaces as
+    // the same nullptr as corrupt WKB and is deliberately classified as bad
+    // data here (see the KNOWN LIMIT note on TryParseFromWkb).
     void
-    AppendData(GEOSContextHandle_t ctx, const char* wkb_data, size_t size) {
+    AppendDataAt(size_t absolute_offset, const char* wkb_data, size_t size) {
         std::lock_guard<std::shared_mutex> lock(mutex_);
 
-        if (size == 0 || wkb_data == nullptr) {
-            // Handle null/empty geometry - add invalid geometry
-            geometries_.emplace_back();
-        } else {
-            try {
-                // Create geometry with cache's context
-                geometries_.emplace_back(ctx, wkb_data, size);
-            } catch (const std::exception& e) {
-                ThrowInfo(UnexpectedError,
-                          "Failed to construct geometry from WKB data: {}",
-                          e.what());
-            }
+        if (geometries_.size() <= absolute_offset) {
+            // Default-constructed gap entries are invalid; a reader that
+            // somehow reaches one skips the row, and the owning batch's
+            // (re)write fills it in place.
+            geometries_.resize(absolute_offset + 1);
         }
+
+        if (size == 0 || wkb_data == nullptr) {
+            // Null/empty geometry - store an invalid entry
+            geometries_[absolute_offset] = Geometry();
+            return;
+        }
+        Geometry geometry;
+        if (!geometry.TryParseFromWkb(ctx_, wkb_data, size)) {
+            static std::atomic<int64_t> last_cache_parse_log_us{0};
+            if (ShouldLogGeometryThrottled(last_cache_parse_log_us)) {
+                LOG_WARN(
+                    "unparseable WKB at cache offset {}; caching an invalid "
+                    "placeholder entry, readers will skip it (further "
+                    "occurrences suppressed briefly)",
+                    absolute_offset);
+            } else {
+                LOG_DEBUG("unparseable WKB at cache offset {}",
+                          absolute_offset);
+            }
+            geometries_[absolute_offset] = Geometry();
+            return;
+        }
+        geometries_[absolute_offset] = std::move(geometry);
     }
 
     // Get shared lock for batch operations (RAII)
@@ -62,14 +162,21 @@ class SimpleGeometryCache {
         return std::shared_lock<std::shared_mutex>(mutex_);
     }
 
-    // Get Geometry by offset without locking (use with AcquireReadLock)
+    // Get Geometry by offset without locking (use with AcquireReadLock).
+    //
+    // An out-of-range offset returns nullptr, the same "no geometry here,
+    // skip the row" answer as an invalid entry -- it must NOT throw. On a
+    // growing segment there is a real window where a reader legitimately
+    // outruns this cache: SegmentGrowingImpl::Insert feeds the R-Tree
+    // (AppendingIndex) before it fills the cache (BuildGeometryCacheForInsert),
+    // so a concurrent query whose coarse bitmap is sized by the index's
+    // Count() can probe an offset the cache has not reached yet. Those rows
+    // are not yet acked, so reporting them as non-matching is correct;
+    // throwing a non-retriable UnexpectedError out of a read path is not.
     const Geometry*
     GetByOffsetUnsafe(size_t offset) const {
         if (offset >= geometries_.size()) {
-            ThrowInfo(UnexpectedError,
-                      "offset {} is out of range: {}",
-                      offset,
-                      geometries_.size());
+            return nullptr;
         }
 
         const auto& geometry = geometries_[offset];
@@ -90,6 +197,19 @@ class SimpleGeometryCache {
         return geometries_.size();
     }
 
+    // Get total number of loaded geometries without locking (use with
+    // AcquireReadLock). Calling Size() while already holding the read lock
+    // would recursively acquire the non-reentrant shared_mutex: that is
+    // undefined behavior per [thread.sharedmutex.requirements] regardless of
+    // platform, and becomes a real deadlock on writer-preferring
+    // implementations once a writer is queued. (Not a claim about this
+    // build's std::shared_mutex: on Linux libstdc++ maps it to
+    // pthread_rwlock_t, whose glibc default is reader-preferring.)
+    size_t
+    SizeUnsafe() const {
+        return geometries_.size();
+    }
+
     // Check if cache is loaded
     bool
     IsLoaded() const {
@@ -98,6 +218,9 @@ class SimpleGeometryCache {
     }
 
  private:
+    // ctx_ is declared first so it is destroyed last (after geometries_),
+    // guaranteeing the Geometry destructors still see a live context.
+    GEOSContextHandle_t ctx_{nullptr};  // Context owned by this cache
     mutable std::shared_mutex mutex_;   // For read/write operations
     std::vector<Geometry> geometries_;  // Direct storage of Geometry objects
 };
@@ -113,44 +236,76 @@ class SimpleGeometryCacheManager {
 
     SimpleGeometryCacheManager() = default;
 
-    SimpleGeometryCache&
-    GetOrCreateCache(int64_t segment_id, FieldId field_id) {
+    // Returns a shared_ptr so callers keep the cache alive for the duration of
+    // their use even if RemoveCache/RemoveSegmentCaches drops it concurrently.
+    std::shared_ptr<SimpleGeometryCache>
+    GetOrCreateCache(uint64_t segment_instance_uid,
+                     int64_t segment_id,
+                     FieldId field_id) {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto key = MakeCacheKey(segment_id, field_id);
+        auto key = MakeCacheKey(segment_instance_uid, segment_id, field_id);
         auto it = caches_.find(key);
         if (it != caches_.end()) {
-            return *(it->second);
+            return it->second;
         }
 
-        auto cache = std::make_unique<SimpleGeometryCache>();
-        auto* cache_ptr = cache.get();
-        caches_.emplace(key, std::move(cache));
-        return *cache_ptr;
+        auto cache = std::make_shared<SimpleGeometryCache>();
+        caches_.emplace(key, cache);
+        return cache;
     }
 
-    SimpleGeometryCache*
-    GetCache(int64_t segment_id, FieldId field_id) {
+    // Atomically replace (or install) the cache for one field.
+    //
+    // The caller populates a DETACHED cache first and hands it over here, so
+    // a half-populated cache is never visible: readers either see the whole
+    // previous cache or the whole new one. An in-flight reader that already
+    // holds the previous shared_ptr keeps it alive and consistent for the
+    // rest of its query. If the caller's build throws, it simply never calls
+    // this and the previous cache stays untouched -- as opposed to mutating
+    // the live cache in place, which on a replace-load (a default-filled
+    // column later replaced by the real one) exposed torn contents and, on a
+    // mid-load failure, left the contaminated cache in the map forever
+    // (caches are only ever built at load time). See PR #50951 review.
+    void
+    InstallCache(uint64_t segment_instance_uid,
+                 int64_t segment_id,
+                 FieldId field_id,
+                 std::shared_ptr<SimpleGeometryCache> cache) {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto key = MakeCacheKey(segment_id, field_id);
+        caches_[MakeCacheKey(segment_instance_uid, segment_id, field_id)] =
+            std::move(cache);
+    }
+
+    std::shared_ptr<SimpleGeometryCache>
+    GetCache(uint64_t segment_instance_uid,
+             int64_t segment_id,
+             FieldId field_id) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto key = MakeCacheKey(segment_instance_uid, segment_id, field_id);
         auto it = caches_.find(key);
         if (it != caches_.end()) {
-            return it->second.get();
+            return it->second;
         }
         return nullptr;
     }
 
     void
-    RemoveCache(GEOSContextHandle_t ctx, int64_t segment_id, FieldId field_id) {
+    RemoveCache(uint64_t segment_instance_uid,
+                int64_t segment_id,
+                FieldId field_id) {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto key = MakeCacheKey(segment_id, field_id);
-        caches_.erase(key);
+        caches_.erase(MakeCacheKey(segment_instance_uid, segment_id, field_id));
     }
 
-    // Remove all caches for a segment (useful when segment is destroyed)
+    // Remove all caches owned by one segment OBJECT -- called from that
+    // object's destructor, and deliberately NOT matching any other live
+    // instance that shares the same logical segment id (growing/sealed twin,
+    // or an older/newer version of the same sealed segment).
     void
-    RemoveSegmentCaches(GEOSContextHandle_t ctx, int64_t segment_id) {
+    RemoveSegmentCaches(uint64_t segment_instance_uid, int64_t segment_id) {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto segment_prefix = std::to_string(segment_id) + "_";
+        auto segment_prefix =
+            MakeSegmentCachePrefix(segment_instance_uid, segment_id);
         auto it = caches_.begin();
         while (it != caches_.end()) {
             if (it->first.substr(0, segment_prefix.length()) ==
@@ -189,7 +344,7 @@ class SimpleGeometryCacheManager {
     operator=(const SimpleGeometryCacheManager&) = delete;
 
     mutable std::mutex mutex_;
-    std::unordered_map<std::string, std::unique_ptr<SimpleGeometryCache>>
+    std::unordered_map<std::string, std::shared_ptr<SimpleGeometryCache>>
         caches_;
 };
 

--- a/internal/core/src/common/GeometryCache.h
+++ b/internal/core/src/common/GeometryCache.h
@@ -254,28 +254,6 @@ class SimpleGeometryCacheManager {
         return cache;
     }
 
-    // Atomically replace (or install) the cache for one field.
-    //
-    // The caller populates a DETACHED cache first and hands it over here, so
-    // a half-populated cache is never visible: readers either see the whole
-    // previous cache or the whole new one. An in-flight reader that already
-    // holds the previous shared_ptr keeps it alive and consistent for the
-    // rest of its query. If the caller's build throws, it simply never calls
-    // this and the previous cache stays untouched -- as opposed to mutating
-    // the live cache in place, which on a replace-load (a default-filled
-    // column later replaced by the real one) exposed torn contents and, on a
-    // mid-load failure, left the contaminated cache in the map forever
-    // (caches are only ever built at load time). See PR #50951 review.
-    void
-    InstallCache(uint64_t segment_instance_uid,
-                 int64_t segment_id,
-                 FieldId field_id,
-                 std::shared_ptr<SimpleGeometryCache> cache) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        caches_[MakeCacheKey(segment_instance_uid, segment_id, field_id)] =
-            std::move(cache);
-    }
-
     std::shared_ptr<SimpleGeometryCache>
     GetCache(uint64_t segment_instance_uid,
              int64_t segment_id,

--- a/internal/core/src/common/GeometryCacheTest.cpp
+++ b/internal/core/src/common/GeometryCacheTest.cpp
@@ -1,0 +1,421 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "common/Geometry.h"
+#include "common/GeometryCache.h"
+#include "common/Types.h"
+#include "geos_c.h"
+
+using milvus::FieldId;
+using milvus::Geometry;
+using milvus::exec::SimpleGeometryCacheManager;
+
+namespace {
+
+// Two distinct segment OBJECTS; in production these come from
+// SegmentInternalInterface::segment_instance_uid().
+constexpr uint64_t kInstanceA = 1;
+constexpr uint64_t kInstanceB = 2;
+
+std::string
+MakePointWkb(double x, double y) {
+    auto ctx = GEOS_init_r();
+    std::string wkt =
+        "POINT (" + std::to_string(x) + " " + std::to_string(y) + ")";
+    std::string wkb = Geometry(ctx, wkt.c_str()).to_wkb_string();
+    GEOS_finish_r(ctx);
+    return wkb;
+}
+
+std::string
+MakeWkbFromWkt(const char* wkt) {
+    auto ctx = GEOS_init_r();
+    std::string wkb = Geometry(ctx, wkt).to_wkb_string();
+    GEOS_finish_r(ctx);
+    return wkb;
+}
+
+// A query holding the cache shared_ptr must keep it (and its geometries) alive
+// even when the owning segment is dropped and RemoveSegmentCaches() runs
+// concurrently. The pre-fix manager returned a raw pointer into a unique_ptr
+// map, so erasing the entry freed the cache under any in-flight reader.
+TEST(GeometryCacheLifetime, SharedPtrOutlivesSegmentRemoval) {
+    auto& mgr = SimpleGeometryCacheManager::Instance();
+    const int64_t seg_id = 900000001;
+    const FieldId field_id(101);
+    const std::string wkb = MakePointWkb(1.0, 1.0);
+
+    auto cache = mgr.GetOrCreateCache(kInstanceA, seg_id, field_id);
+    cache->AppendDataAt(0, wkb.data(), wkb.size());
+    ASSERT_EQ(cache->Size(), 1u);
+
+    // Segment torn down: entry removed from the manager map.
+    mgr.RemoveSegmentCaches(kInstanceA, seg_id);
+    EXPECT_EQ(mgr.GetCache(kInstanceA, seg_id, field_id), nullptr);
+
+    // The cache we still hold remains alive and readable (no use-after-free).
+    {
+        auto lock = cache->AcquireReadLock();
+        const Geometry* g = cache->GetByOffsetUnsafe(0);
+        ASSERT_NE(g, nullptr);
+        EXPECT_TRUE(g->IsValid());
+    }
+    // cache drops here -> SimpleGeometryCache destroys its geometries with its
+    // own context, independent of the (already gone) segment context.
+}
+
+// The cache builds and destroys geometries with its own context; no external
+// (segment) context is required to outlive it.
+TEST(GeometryCacheLifetime, CacheOwnsItsContext) {
+    auto& mgr = SimpleGeometryCacheManager::Instance();
+    const int64_t seg_id = 900000002;
+    const FieldId field_id(7);
+    const std::string wkb = MakePointWkb(2.0, 2.0);
+
+    auto cache = mgr.GetOrCreateCache(kInstanceA, seg_id, field_id);
+    cache->AppendDataAt(0, wkb.data(), wkb.size());
+    cache->AppendDataAt(1, nullptr, 0);  // null geometry
+    EXPECT_EQ(cache->Size(), 2u);
+    {
+        auto lock = cache->AcquireReadLock();
+        EXPECT_NE(cache->GetByOffsetUnsafe(0), nullptr);
+        EXPECT_EQ(cache->GetByOffsetUnsafe(1), nullptr);  // null -> nullptr
+    }
+
+    mgr.RemoveSegmentCaches(kInstanceA, seg_id);
+    // Destroying the held cache here must not touch any external context.
+}
+
+// Stress: a reader repeatedly fetches and reads the cache while a writer keeps
+// re-creating and dropping it. Must not crash / use-after-free (ASAN/TSAN).
+TEST(GeometryCacheLifetime, ConcurrentGetAndRemove) {
+    auto& mgr = SimpleGeometryCacheManager::Instance();
+    const int64_t seg_id = 900000003;
+    const FieldId field_id(9);
+    const std::string wkb = MakePointWkb(3.0, 3.0);
+
+    std::atomic<bool> stop{false};
+    std::thread reader([&]() {
+        while (!stop.load()) {
+            auto c = mgr.GetCache(kInstanceA, seg_id, field_id);
+            if (c) {
+                auto lock = c->AcquireReadLock();
+                // Size() would re-acquire the shared_mutex this thread already
+                // holds via the read lock -- recursive shared locking is UB
+                // and deadlocks against the concurrently queued writer.
+                if (c->SizeUnsafe() > 0) {
+                    const Geometry* g = c->GetByOffsetUnsafe(0);
+                    (void)g;
+                }
+            }
+        }
+    });
+
+    for (int i = 0; i < 300; ++i) {
+        auto c = mgr.GetOrCreateCache(kInstanceA, seg_id, field_id);
+        c->AppendDataAt(0, wkb.data(), wkb.size());
+        mgr.RemoveSegmentCaches(kInstanceA, seg_id);
+    }
+
+    stop.store(true);
+    reader.join();
+    mgr.RemoveSegmentCaches(kInstanceA, seg_id);
+}
+
+// Regression for PR #50951 review (GeometryCache.h AppendDataAt): a corrupt
+// (unparseable, non-empty) WKB row must be cached as an INVALID placeholder
+// entry -- readers see nullptr and skip it -- instead of throwing. Before the
+// fix AppendDataAt rethrew UnexpectedError, so with the geometry cache enabled a
+// single corrupt row failed the entire segment load (LoadFieldData ->
+// LoadGeometryCache), the exact row shape the placeholder-MBR write paths
+// deliberately keep. Offsets of later rows must stay aligned.
+TEST(GeometryCacheLifetime, CorruptWkbCachedAsInvalidPlaceholder) {
+    auto& mgr = SimpleGeometryCacheManager::Instance();
+    const int64_t seg_id = 900000005;
+    const FieldId field_id(13);
+    const std::string good = MakePointWkb(4.0, 4.0);
+    std::string corrupt = good;
+    corrupt.resize(corrupt.size() / 2);  // truncate -> unparseable
+
+    auto cache = mgr.GetOrCreateCache(kInstanceA, seg_id, field_id);
+    ASSERT_NO_THROW({
+        cache->AppendDataAt(0, good.data(), good.size());
+        cache->AppendDataAt(1, corrupt.data(), corrupt.size());
+        cache->AppendDataAt(2, good.data(), good.size());
+    });
+    // The corrupt row occupies its offset (no shift of later rows).
+    ASSERT_EQ(cache->Size(), 3u);
+    {
+        auto lock = cache->AcquireReadLock();
+        EXPECT_NE(cache->GetByOffsetUnsafe(0), nullptr);
+        // Corrupt row -> invalid entry -> nullptr, same contract as null rows;
+        // every reader skips it.
+        EXPECT_EQ(cache->GetByOffsetUnsafe(1), nullptr);
+        EXPECT_NE(cache->GetByOffsetUnsafe(2), nullptr);
+    }
+
+    mgr.RemoveSegmentCaches(kInstanceA, seg_id);
+}
+
+// Regression for the shared cache-context concurrency defect: cache-owned
+// Geometry instances all carry the cache's single GEOS context, which is not
+// thread-safe. The GIS filter path evaluates predicates on those shared
+// geometries under a *shared* read lock, so concurrent queries must each drive
+// GEOS through their own per-thread context (the context-taking predicate
+// overloads) rather than the geometry's stored context. This test mirrors that
+// usage: many threads read the same cached geometry at once and evaluate
+// predicates on per-thread contexts; results must stay correct.
+//
+// What each sanitizer can actually prove here (the earlier claim that "ASAN
+// surfaces a data race" was wrong -- ASAN is not a race detector): TSAN flags a
+// regression back to the shared context directly, as an unsynchronized access.
+// ASAN only catches it indirectly, and only once the shared context's mutable
+// state (error handler slots, reader scratch buffers) is corrupted badly enough
+// to produce a heap error. This suite runs under ASAN in CI; the TSAN evidence
+// for these paths is recorded in the PR, produced with a one-off
+// thread-sanitized GEOS build (there is no wired TSAN target in the repo yet).
+// The cached rows deliberately span every GEOS envelope shape, because the
+// envelope is the one piece of geometry state a predicate can WRITE:
+// GeometryCollection (and so MULTI* / GEOMETRYCOLLECTION) declares a `mutable
+// Envelope` with a lazy getter (GeometryCollection.h:192-197), while Point /
+// LineString / Polygon expose theirs read-only. A single-shape (POINT) test
+// therefore could not have covered the multi-part path at all.
+//
+// For the pinned GEOS 3.12.0 the lazy branch turns out to be unreachable for
+// parsed geometries -- the primary constructor initializes the envelope eagerly
+// (`envelope(computeEnvelopeInternal())`, GeometryCollection.cpp:65), so query
+// threads only ever read it -- which is why no writer-side warm-up is needed
+// here. These rows pin that: if a future GEOS release makes the getter lazy in
+// practice, a TSAN run of this test reports the write.
+TEST(GeometryCacheConcurrency, PredicatesUsePerThreadContext) {
+    auto& mgr = SimpleGeometryCacheManager::Instance();
+    const int64_t seg_id = 900000004;
+    const FieldId field_id(11);
+    const std::vector<std::string> wkbs = {
+        MakePointWkb(1.0, 1.0),
+        MakeWkbFromWkt(
+            "MULTIPOLYGON(((0 0,0 4,4 4,4 0,0 0)),((6 6,6 8,8 8,8 6,6 6)))"),
+        MakeWkbFromWkt("GEOMETRYCOLLECTION(POINT(1 1),LINESTRING(0 0,3 3))"),
+        MakeWkbFromWkt("MULTIPOLYGON EMPTY"),
+    };
+    // Row 0 is the only one equal to the probe point; rows 0-2 all intersect
+    // it; the empty row intersects nothing.
+    const std::vector<bool> expect_intersects = {true, true, true, false};
+
+    auto cache = mgr.GetOrCreateCache(kInstanceA, seg_id, field_id);
+    for (size_t i = 0; i < wkbs.size(); ++i) {
+        cache->AppendDataAt(i, wkbs[i].data(), wkbs[i].size());
+    }
+    ASSERT_EQ(cache->Size(), wkbs.size());
+
+    constexpr int kThreads = 8;
+    constexpr int kIters = 5000;
+    std::atomic<bool> go{false};
+    std::atomic<int> failures{0};
+
+    std::vector<std::thread> workers;
+    for (int t = 0; t < kThreads; ++t) {
+        workers.emplace_back([&, t]() {
+            // Each thread has its own GEOS context and its own query geometries.
+            GEOSContextHandle_t ctx = milvus::GetThreadLocalGEOSContext();
+            Geometry match(ctx, "POINT (1 1)");
+            Geometry miss(ctx, "POINT (9 9)");
+            while (!go.load(std::memory_order_relaxed)) {
+            }
+            for (int i = 0; i < kIters; ++i) {
+                auto lock = cache->AcquireReadLock();
+                for (size_t off = 0; off < wkbs.size(); ++off) {
+                    const Geometry* g = cache->GetByOffsetUnsafe(off);
+                    if (g == nullptr) {
+                        failures.fetch_add(1, std::memory_order_relaxed);
+                        continue;
+                    }
+                    // Drive predicates on THIS thread's context, not g's stored
+                    // (cache-shared) context — exactly what the fixed filter
+                    // path does. Results must match the geometry's semantics.
+                    bool eq = g->equals(match, ctx);
+                    bool inter = g->intersects(match, ctx);
+                    bool inter_miss = g->intersects(miss, ctx);
+                    if (eq != (off == 0) || inter != expect_intersects[off] ||
+                        inter_miss) {
+                        failures.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
+            }
+        });
+    }
+
+    go.store(true, std::memory_order_relaxed);
+    for (auto& w : workers) {
+        w.join();
+    }
+
+    EXPECT_EQ(failures.load(), 0);
+    mgr.RemoveSegmentCaches(kInstanceA, seg_id);
+}
+
+// Regression for PR #50951 review (round Df4a298c5f4): the cache is published
+// in the manager map before it is populated, and AppendDataAt can throw a
+// retriable MemAllocateFailed mid-batch. With the old tail append, a retry
+// after such a partial write appended AFTER the leftover prefix, shifting
+// every subsequent row's absolute offset -- GetByOffsetUnsafe returned the
+// wrong geometry with no error. Offset-addressed writes must instead be
+// idempotent: re-running the same batch overwrites the same slots and
+// alignment never drifts.
+TEST(GeometryCacheLifetime, RetryAfterPartialWriteKeepsOffsetsAligned) {
+    auto& mgr = SimpleGeometryCacheManager::Instance();
+    const int64_t seg_id = 900000007;
+    const FieldId field_id(17);
+    const std::vector<std::string> wkbs = {
+        MakePointWkb(0.0, 0.0),
+        MakePointWkb(1.0, 1.0),
+        MakePointWkb(2.0, 2.0),
+        MakePointWkb(3.0, 3.0),
+    };
+
+    auto cache = mgr.GetOrCreateCache(kInstanceA, seg_id, field_id);
+    // Simulate a first attempt that dies mid-batch (rows 0-1 written, then a
+    // retriable throw before rows 2-3).
+    cache->AppendDataAt(0, wkbs[0].data(), wkbs[0].size());
+    cache->AppendDataAt(1, wkbs[1].data(), wkbs[1].size());
+
+    // The retry re-runs the WHOLE batch from row 0, exactly like a re-driven
+    // LoadGeometryCache/BuildGeometryCacheFor{Load,Insert} would.
+    for (size_t i = 0; i < wkbs.size(); ++i) {
+        cache->AppendDataAt(i, wkbs[i].data(), wkbs[i].size());
+    }
+
+    // No duplicated prefix, no shifted offsets: row i still holds point (i,i).
+    ASSERT_EQ(cache->Size(), wkbs.size());
+    auto ctx = GEOS_init_r();
+    {
+        auto lock = cache->AcquireReadLock();
+        for (size_t i = 0; i < wkbs.size(); ++i) {
+            const Geometry* g = cache->GetByOffsetUnsafe(i);
+            ASSERT_NE(g, nullptr) << "offset " << i;
+            Geometry probe(
+                ctx,
+                ("POINT (" + std::to_string(i) + " " + std::to_string(i) + ")")
+                    .c_str());
+            EXPECT_TRUE(g->equals(probe, ctx)) << "offset " << i;
+        }
+    }
+    GEOS_finish_r(ctx);
+    mgr.RemoveSegmentCaches(kInstanceA, seg_id);
+}
+
+// Offset-addressed writes tolerate out-of-order arrival: a later batch may
+// land before an earlier one (or an earlier batch may have failed and not yet
+// been retried). Slots that were skipped over stay default-invalid -- readers
+// see nullptr and skip the row -- and are filled in place once their write
+// arrives.
+TEST(GeometryCacheLifetime, OutOfOrderWritesFillGapsInPlace) {
+    auto& mgr = SimpleGeometryCacheManager::Instance();
+    const int64_t seg_id = 900000008;
+    const FieldId field_id(19);
+    const std::string early = MakePointWkb(1.0, 1.0);
+    const std::string late = MakePointWkb(9.0, 9.0);
+
+    auto cache = mgr.GetOrCreateCache(kInstanceA, seg_id, field_id);
+    // Row 3 arrives first; rows 0-2 are still gaps.
+    cache->AppendDataAt(3, late.data(), late.size());
+    ASSERT_EQ(cache->Size(), 4u);
+    {
+        auto lock = cache->AcquireReadLock();
+        EXPECT_EQ(cache->GetByOffsetUnsafe(0), nullptr);
+        EXPECT_EQ(cache->GetByOffsetUnsafe(2), nullptr);
+        EXPECT_NE(cache->GetByOffsetUnsafe(3), nullptr);
+    }
+
+    // The earlier batch lands afterwards and fills its own slots.
+    cache->AppendDataAt(0, early.data(), early.size());
+    cache->AppendDataAt(1, nullptr, 0);
+    cache->AppendDataAt(2, early.data(), early.size());
+    ASSERT_EQ(cache->Size(), 4u);
+    {
+        auto lock = cache->AcquireReadLock();
+        EXPECT_NE(cache->GetByOffsetUnsafe(0), nullptr);
+        EXPECT_EQ(cache->GetByOffsetUnsafe(1), nullptr);  // real null row
+        EXPECT_NE(cache->GetByOffsetUnsafe(2), nullptr);
+        EXPECT_NE(cache->GetByOffsetUnsafe(3), nullptr);
+    }
+    mgr.RemoveSegmentCaches(kInstanceA, seg_id);
+}
+
+// Regression for PR #50951 review (rounds D604486a968 and Dfc0be51e9e): two
+// live segment OBJECTS can carry the same logical segment id -- a growing and
+// a sealed twin during handoff, and two sealed instances of different versions
+// while the replaced one is released asynchronously
+// (querynodev2/segments/manager.go:409-441). Keying the cache on the segment
+// id (with or without the segment type) makes the arriving instance reuse the
+// departing instance's entry, and the departing instance's destructor then
+// erases the cache the still-serving instance depends on -- silently degrading
+// every later GIS query on it to per-row WKB re-parsing, with no rebuild path.
+// Keying on segment_instance_uid covers both shapes; this test drives the
+// same-type (version replacement) one, which the type-bearing key missed.
+TEST(GeometryCacheLifetime, SameSegmentIdDifferentInstancesDoNotShareOrEvict) {
+    auto& mgr = SimpleGeometryCacheManager::Instance();
+    const int64_t seg_id = 900000009;
+    const FieldId field_id(23);
+    const std::string old_wkb = MakePointWkb(1.0, 1.0);
+    const std::string new_wkb = MakePointWkb(2.0, 2.0);
+
+    auto departing = mgr.GetOrCreateCache(kInstanceA, seg_id, field_id);
+    auto arriving = mgr.GetOrCreateCache(kInstanceB, seg_id, field_id);
+    // Same logical segment id and field, different objects -> distinct caches
+    // (the arriving instance must NOT reuse the departing one's entry).
+    EXPECT_NE(departing.get(), arriving.get());
+
+    departing->AppendDataAt(0, old_wkb.data(), old_wkb.size());
+    arriving->AppendDataAt(0, new_wkb.data(), new_wkb.size());
+
+    // The replaced instance is released asynchronously while the new one is
+    // already serving; its teardown must not touch the new one's cache.
+    mgr.RemoveSegmentCaches(kInstanceA, seg_id);
+    EXPECT_EQ(mgr.GetCache(kInstanceA, seg_id, field_id), nullptr);
+    auto still_there = mgr.GetCache(kInstanceB, seg_id, field_id);
+    ASSERT_NE(still_there, nullptr);
+    EXPECT_EQ(still_there.get(), arriving.get());
+    {
+        auto lock = still_there->AcquireReadLock();
+        EXPECT_NE(still_there->GetByOffsetUnsafe(0), nullptr);
+    }
+
+    mgr.RemoveSegmentCaches(kInstanceB, seg_id);
+}
+
+// GetByOffsetUnsafe must answer "no geometry here" with nullptr rather than
+// throwing: on a growing segment the R-Tree is fed before the cache, so a
+// concurrent query sized by the index Count() can legitimately probe an offset
+// the cache has not reached yet. Throwing a non-retriable UnexpectedError out
+// of that read path would fail the whole query.
+TEST(GeometryCacheLifetime, OutOfRangeOffsetReturnsNullptrNotThrow) {
+    auto& mgr = SimpleGeometryCacheManager::Instance();
+    const int64_t seg_id = 900000010;
+    const FieldId field_id(29);
+    const std::string wkb = MakePointWkb(3.0, 3.0);
+
+    auto cache = mgr.GetOrCreateCache(kInstanceA, seg_id, field_id);
+    cache->AppendDataAt(0, wkb.data(), wkb.size());
+
+    auto lock = cache->AcquireReadLock();
+    EXPECT_NE(cache->GetByOffsetUnsafe(0), nullptr);
+    EXPECT_EQ(cache->GetByOffsetUnsafe(1), nullptr);
+    EXPECT_EQ(cache->GetByOffsetUnsafe(1000000), nullptr);
+}
+
+}  // namespace

--- a/internal/core/src/common/GeometryTest.cpp
+++ b/internal/core/src/common/GeometryTest.cpp
@@ -1,0 +1,213 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "common/Geometry.h"
+#include "geos_c.h"
+
+using milvus::Geometry;
+
+namespace {
+
+class GeometryValueSemanticsTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+        ctx_ = GEOS_init_r();
+    }
+    void
+    TearDown() override {
+        GEOS_finish_r(ctx_);
+    }
+    GEOSContextHandle_t ctx_{nullptr};
+};
+
+// Copy-assignment must deep-clone. The pre-fix implementation copied the raw
+// GEOSGeometry* shallowly, so the source and destination shared one pointer
+// and the second destructor double-freed it (caught here by ASAN; without ASAN
+// the shallow copy still leaks the destination's previous geometry).
+TEST_F(GeometryValueSemanticsTest, CopyAssignmentDeepClones) {
+    Geometry a(ctx_, "POINT (1 2)");
+    Geometry b(ctx_, "POINT (3 4)");
+    ASSERT_TRUE(a.IsValid());
+    ASSERT_TRUE(b.IsValid());
+
+    b = a;  // must clone a into b and release b's previous geometry
+
+    ASSERT_TRUE(b.IsValid());
+    // Independent underlying geometries, never a shared raw pointer.
+    EXPECT_NE(a.GetRawGeometry(), b.GetRawGeometry());
+    EXPECT_EQ(a.to_wkb_string(), b.to_wkb_string());
+    // Both destruct at scope end and must each free exactly once.
+}
+
+TEST_F(GeometryValueSemanticsTest, SelfCopyAssignmentIsSafe) {
+    Geometry a(ctx_, "POINT (7 8)");
+    const std::string before = a.to_wkb_string();
+    Geometry& alias = a;
+    a = alias;  // self-assignment must not destroy its own geometry
+    ASSERT_TRUE(a.IsValid());
+    EXPECT_EQ(a.to_wkb_string(), before);
+}
+
+// Clone(ctx) is the query-thread-safe duplication path: all GEOS work runs
+// through the caller-supplied context and the clone is bound to it, so a
+// cache-owned Geometry can be duplicated without touching the cache's shared
+// (non-thread-safe) context and the clone survives the cache.
+TEST_F(GeometryValueSemanticsTest, CloneDeepClonesIntoCallerContext) {
+    Geometry a(ctx_, "POINT (1 2)");
+    ASSERT_TRUE(a.IsValid());
+
+    GEOSContextHandle_t other_ctx = GEOS_init_r();
+    ASSERT_NE(other_ctx, nullptr);
+    {
+        Geometry b = a.Clone(other_ctx);
+
+        ASSERT_TRUE(b.IsValid());
+        // Independent underlying geometries, never a shared raw pointer.
+        EXPECT_NE(a.GetRawGeometry(), b.GetRawGeometry());
+        EXPECT_EQ(a.to_wkb_string(), b.to_wkb_string());
+        // b destructs here, via other_ctx; a destructs later via ctx_. Each
+        // must free exactly once.
+    }
+    GEOS_finish_r(other_ctx);
+    ASSERT_TRUE(a.IsValid());
+}
+
+TEST_F(GeometryValueSemanticsTest, CloneOfInvalidGeometryIsInvalid) {
+    Geometry a;
+    ASSERT_FALSE(a.IsValid());
+    Geometry b = a.Clone(ctx_);
+    EXPECT_FALSE(b.IsValid());
+    EXPECT_EQ(b.GetRawGeometry(), nullptr);
+}
+
+TEST_F(GeometryValueSemanticsTest, MoveConstructorTransfersOwnership) {
+    Geometry a(ctx_, "POINT (5 6)");
+    GEOSGeometry* raw = a.GetRawGeometry();
+
+    Geometry b(std::move(a));
+
+    EXPECT_FALSE(a.IsValid());  // moved-from is emptied
+    EXPECT_EQ(a.GetRawGeometry(), nullptr);
+    ASSERT_TRUE(b.IsValid());
+    EXPECT_EQ(b.GetRawGeometry(), raw);  // pointer transferred, not cloned
+}
+
+TEST_F(GeometryValueSemanticsTest, MoveAssignmentReleasesExisting) {
+    Geometry a(ctx_, "POINT (5 6)");
+    GEOSGeometry* raw = a.GetRawGeometry();
+    Geometry b(ctx_, "POINT (9 9)");
+
+    b = std::move(a);  // frees b's old geometry, takes a's
+
+    EXPECT_FALSE(a.IsValid());
+    ASSERT_TRUE(b.IsValid());
+    EXPECT_EQ(b.GetRawGeometry(), raw);
+}
+
+// std::vector reallocation must relocate Geometry elements safely. With the
+// noexcept move constructor it relocates by move; either way no element's
+// GEOSGeometry* may be freed twice.
+TEST_F(GeometryValueSemanticsTest, VectorGrowthDoesNotDoubleFree) {
+    std::vector<Geometry> v;
+    for (int i = 0; i < 1000; ++i) {
+        std::string wkt =
+            "POINT (" + std::to_string(i) + " " + std::to_string(i) + ")";
+        v.emplace_back(ctx_, wkt.c_str());
+    }
+    ASSERT_EQ(v.size(), 1000u);
+    EXPECT_TRUE(v.front().IsValid());
+    EXPECT_TRUE(v.back().IsValid());
+    EXPECT_NE(v.front().GetRawGeometry(), v.back().GetRawGeometry());
+}
+
+// --- TryParseFromWkb classification boundary (see PR #50951 review) ---
+//
+// The contract splits failures into two buckets: bad data returns false
+// (caller skips the row), a transient resource failure observable BEFORE
+// parsing throws a retriable SegcoreError (the row must not be silently
+// filtered). These tests fault-inject each bucket we can reach from a unit
+// test. The one case that cannot be injected here -- an OOM INSIDE
+// GEOSWKBReader_read_r, which GEOS's execute() wrapper swallows into the
+// same nullptr as corrupt WKB -- is documented as a KNOWN LIMIT on
+// TryParseFromWkb and is intentionally classified as bad data.
+
+TEST_F(GeometryValueSemanticsTest, TryParseFromWkbBadDataReturnsFalse) {
+    const unsigned char corrupt[] = {0xde, 0xad, 0xbe, 0xef, 0x00};
+    Geometry g;
+    EXPECT_FALSE(g.TryParseFromWkb(ctx_, corrupt, sizeof(corrupt)));
+    EXPECT_FALSE(g.IsValid());
+
+    // Truncated-but-plausible WKB (header of a point, payload cut off) is
+    // the placeholder shape the write paths keep; still bad data -> false.
+    Geometry valid(ctx_, "POINT (1 2)");
+    const std::string wkb = valid.to_wkb_string();
+    ASSERT_GT(wkb.size(), 5u);
+    EXPECT_FALSE(g.TryParseFromWkb(ctx_, wkb.data(), 5));
+    EXPECT_FALSE(g.IsValid());
+
+    // The same instance stays reusable: a good payload parses after a bad one.
+    EXPECT_TRUE(g.TryParseFromWkb(ctx_, wkb.data(), wkb.size()));
+    EXPECT_TRUE(g.IsValid());
+}
+
+// --- Tri-state GEOS predicate results (PR #50951 review, round Df4a298c5f4) --
+
+// GEOS binary predicates return char 1/0/2, where 2 means an exception was
+// caught inside GEOS's execute() guard. GeosPredicateIsTrue must map 2 to
+// false (row-level leniency: one unevaluable row must not fail the query)
+// while logging it -- never to true.
+TEST(GeosPredicateResult, TriStateMapping) {
+    EXPECT_TRUE(milvus::GeosPredicateIsTrue(1, "test"));
+    EXPECT_FALSE(milvus::GeosPredicateIsTrue(0, "test"));
+    EXPECT_FALSE(milvus::GeosPredicateIsTrue(2, "test"));
+}
+
+// Drive the exception path through a real predicate: GEOS relate-family
+// predicates (touches/crosses/...) throw IllegalArgumentException for
+// GEOMETRYCOLLECTION inputs, which execute() converts to a return of 2. The
+// predicate must come back false -- an unevaluable row does not match -- and
+// must not crash or return true.
+TEST_F(GeometryValueSemanticsTest, PredicateExceptionEvaluatesToFalse) {
+    Geometry collection(ctx_,
+                        "GEOMETRYCOLLECTION(POINT(1 1),LINESTRING(0 0,2 2))");
+    Geometry point(ctx_, "POINT (1 1)");
+    ASSERT_TRUE(collection.IsValid());
+    ASSERT_TRUE(point.IsValid());
+
+    EXPECT_FALSE(collection.touches(point, ctx_));
+    EXPECT_FALSE(collection.crosses(point, ctx_));
+}
+
+TEST_F(GeometryValueSemanticsTest,
+       TryParseFromWkbNullContextThrowsRetriableSystemError) {
+    Geometry valid(ctx_, "POINT (1 2)");
+    const std::string wkb = valid.to_wkb_string();
+
+    // Inject the transient bucket: a null context is a resource failure, NOT
+    // bad data -- it must throw MemAllocateFailed (retriable), never return
+    // false (which would silently filter a perfectly valid row).
+    Geometry g;
+    try {
+        g.TryParseFromWkb(nullptr, wkb.data(), wkb.size());
+        FAIL() << "expected SegcoreError";
+    } catch (const milvus::SegcoreError& e) {
+        EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::MemAllocateFailed);
+    }
+}
+
+}  // namespace

--- a/internal/core/src/common/GeometryTest.cpp
+++ b/internal/core/src/common/GeometryTest.cpp
@@ -1,0 +1,258 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under the License
+
+#include <gtest/gtest.h>
+#include <functional>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "common/Geometry.h"
+#include "geos_c.h"
+
+using milvus::Geometry;
+
+namespace {
+
+class GeometryValueSemanticsTest : public ::testing::Test {
+ protected:
+    void
+    SetUp() override {
+        ctx_ = GEOS_init_r();
+    }
+    void
+    TearDown() override {
+        GEOS_finish_r(ctx_);
+    }
+    GEOSContextHandle_t ctx_{nullptr};
+};
+
+// Copy-assignment must deep-clone. The pre-fix implementation copied the raw
+// GEOSGeometry* shallowly, so the source and destination shared one pointer
+// and the second destructor double-freed it (caught here by ASAN; without ASAN
+// the shallow copy still leaks the destination's previous geometry).
+TEST_F(GeometryValueSemanticsTest, CopyAssignmentDeepClones) {
+    Geometry a(ctx_, "POINT (1 2)");
+    Geometry b(ctx_, "POINT (3 4)");
+    ASSERT_TRUE(a.IsValid());
+    ASSERT_TRUE(b.IsValid());
+
+    b = a;  // must clone a into b and release b's previous geometry
+
+    ASSERT_TRUE(b.IsValid());
+    // Independent underlying geometries, never a shared raw pointer.
+    EXPECT_NE(a.GetRawGeometry(), b.GetRawGeometry());
+    EXPECT_EQ(a.to_wkb_string(), b.to_wkb_string());
+    // Both destruct at scope end and must each free exactly once.
+}
+
+TEST_F(GeometryValueSemanticsTest, SelfCopyAssignmentIsSafe) {
+    Geometry a(ctx_, "POINT (7 8)");
+    const std::string before = a.to_wkb_string();
+    Geometry& alias = a;
+    a = alias;  // self-assignment must not destroy its own geometry
+    ASSERT_TRUE(a.IsValid());
+    EXPECT_EQ(a.to_wkb_string(), before);
+}
+
+// Clone(ctx) is the query-thread-safe duplication path: all GEOS work runs
+// through the caller-supplied context and the clone is bound to it, so a
+// cache-owned Geometry can be duplicated without touching the cache's shared
+// (non-thread-safe) context and the clone survives the cache.
+TEST_F(GeometryValueSemanticsTest, CloneDeepClonesIntoCallerContext) {
+    Geometry a(ctx_, "POINT (1 2)");
+    ASSERT_TRUE(a.IsValid());
+
+    GEOSContextHandle_t other_ctx = GEOS_init_r();
+    ASSERT_NE(other_ctx, nullptr);
+    {
+        Geometry b = a.Clone(other_ctx);
+
+        ASSERT_TRUE(b.IsValid());
+        // Independent underlying geometries, never a shared raw pointer.
+        EXPECT_NE(a.GetRawGeometry(), b.GetRawGeometry());
+        EXPECT_EQ(a.to_wkb_string(), b.to_wkb_string());
+        // b destructs here, via other_ctx; a destructs later via ctx_. Each
+        // must free exactly once.
+    }
+    GEOS_finish_r(other_ctx);
+    ASSERT_TRUE(a.IsValid());
+}
+
+TEST_F(GeometryValueSemanticsTest, CloneOfInvalidGeometryIsInvalid) {
+    Geometry a;
+    ASSERT_FALSE(a.IsValid());
+    Geometry b = a.Clone(ctx_);
+    EXPECT_FALSE(b.IsValid());
+    EXPECT_EQ(b.GetRawGeometry(), nullptr);
+}
+
+TEST_F(GeometryValueSemanticsTest, MoveConstructorTransfersOwnership) {
+    Geometry a(ctx_, "POINT (5 6)");
+    GEOSGeometry* raw = a.GetRawGeometry();
+
+    Geometry b(std::move(a));
+
+    EXPECT_FALSE(a.IsValid());  // moved-from is emptied
+    EXPECT_EQ(a.GetRawGeometry(), nullptr);
+    ASSERT_TRUE(b.IsValid());
+    EXPECT_EQ(b.GetRawGeometry(), raw);  // pointer transferred, not cloned
+}
+
+TEST_F(GeometryValueSemanticsTest, MoveAssignmentReleasesExisting) {
+    Geometry a(ctx_, "POINT (5 6)");
+    GEOSGeometry* raw = a.GetRawGeometry();
+    Geometry b(ctx_, "POINT (9 9)");
+
+    b = std::move(a);  // frees b's old geometry, takes a's
+
+    EXPECT_FALSE(a.IsValid());
+    ASSERT_TRUE(b.IsValid());
+    EXPECT_EQ(b.GetRawGeometry(), raw);
+}
+
+// std::vector reallocation must relocate Geometry elements safely. With the
+// noexcept move constructor it relocates by move; either way no element's
+// GEOSGeometry* may be freed twice.
+TEST_F(GeometryValueSemanticsTest, VectorGrowthDoesNotDoubleFree) {
+    std::vector<Geometry> v;
+    for (int i = 0; i < 1000; ++i) {
+        std::string wkt =
+            "POINT (" + std::to_string(i) + " " + std::to_string(i) + ")";
+        v.emplace_back(ctx_, wkt.c_str());
+    }
+    ASSERT_EQ(v.size(), 1000u);
+    EXPECT_TRUE(v.front().IsValid());
+    EXPECT_TRUE(v.back().IsValid());
+    EXPECT_NE(v.front().GetRawGeometry(), v.back().GetRawGeometry());
+}
+
+// --- TryParseFromWkb classification boundary (see PR #50951 review) ---
+//
+// The contract splits failures into two buckets: bad data returns false
+// (caller skips the row), a transient resource failure observable BEFORE
+// parsing throws a retriable SegcoreError (the row must not be silently
+// filtered). These tests fault-inject each bucket we can reach from a unit
+// test. The one case that cannot be injected here -- an OOM INSIDE
+// GEOSWKBReader_read_r, which GEOS's execute() wrapper swallows into the
+// same nullptr as corrupt WKB -- is documented as a KNOWN LIMIT on
+// TryParseFromWkb and is intentionally classified as bad data.
+
+TEST_F(GeometryValueSemanticsTest, TryParseFromWkbBadDataReturnsFalse) {
+    const unsigned char corrupt[] = {0xde, 0xad, 0xbe, 0xef, 0x00};
+    Geometry g;
+    EXPECT_FALSE(g.TryParseFromWkb(ctx_, corrupt, sizeof(corrupt)));
+    EXPECT_FALSE(g.IsValid());
+
+    // Truncated-but-plausible WKB (header of a point, payload cut off) is
+    // the placeholder shape the write paths keep; still bad data -> false.
+    Geometry valid(ctx_, "POINT (1 2)");
+    const std::string wkb = valid.to_wkb_string();
+    ASSERT_GT(wkb.size(), 5u);
+    EXPECT_FALSE(g.TryParseFromWkb(ctx_, wkb.data(), 5));
+    EXPECT_FALSE(g.IsValid());
+
+    // The same instance stays reusable: a good payload parses after a bad one.
+    EXPECT_TRUE(g.TryParseFromWkb(ctx_, wkb.data(), wkb.size()));
+    EXPECT_TRUE(g.IsValid());
+}
+
+// --- Tri-state GEOS predicate results (PR #50951 review, round Df4a298c5f4) --
+
+// GEOS binary predicates return char 1/0/2, where 2 means an exception was
+// caught inside GEOS's execute() guard. GeosPredicateIsTrue must map 2 to
+// false (row-level leniency: one unevaluable row must not fail the query)
+// while logging it -- never to true.
+TEST(GeosPredicateResult, TriStateMapping) {
+    EXPECT_TRUE(milvus::GeosPredicateIsTrue(1, "test"));
+    EXPECT_FALSE(milvus::GeosPredicateIsTrue(0, "test"));
+    EXPECT_FALSE(milvus::GeosPredicateIsTrue(2, "test"));
+}
+
+// Drive the exception path through a real predicate: GEOS relate-family
+// predicates (touches/crosses/...) throw IllegalArgumentException for
+// GEOMETRYCOLLECTION inputs, which execute() converts to a return of 2. The
+// predicate must come back false -- an unevaluable row does not match -- and
+// must not crash or return true.
+TEST_F(GeometryValueSemanticsTest, PredicateExceptionEvaluatesToFalse) {
+    Geometry collection(ctx_,
+                        "GEOMETRYCOLLECTION(POINT(1 1),LINESTRING(0 0,2 2))");
+    Geometry point(ctx_, "POINT (1 1)");
+    ASSERT_TRUE(collection.IsValid());
+    ASSERT_TRUE(point.IsValid());
+
+    EXPECT_FALSE(collection.touches(point, ctx_));
+    EXPECT_FALSE(collection.crosses(point, ctx_));
+}
+
+TEST_F(GeometryValueSemanticsTest,
+       TryParseFromWkbNullContextThrowsRetriableSystemError) {
+    Geometry valid(ctx_, "POINT (1 2)");
+    const std::string wkb = valid.to_wkb_string();
+
+    // Inject the transient bucket: a null context is a resource failure, NOT
+    // bad data -- it must throw MemAllocateFailed (retriable), never return
+    // false (which would silently filter a perfectly valid row).
+    Geometry g;
+    try {
+        g.TryParseFromWkb(nullptr, wkb.data(), wkb.size());
+        FAIL() << "expected SegcoreError";
+    } catch (const milvus::SegcoreError& e) {
+        EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::MemAllocateFailed);
+    }
+}
+
+// Same transient/permanent classification, applied to the clone paths.
+// GEOSGeom_clone_r() reports allocation failure by RETURNING nullptr -- the
+// capi execute() guard catches std::bad_alloc and swallows it -- so no
+// `catch (const std::bad_alloc&)` net upstream can ever see it, and the three
+// clone sites have to classify it themselves. Reporting it with a plain
+// AssertInfo yields UnexpectedError(2001), which merr does not mark retriable;
+// on the search path lb_policy then blacklists the serving node for the
+// channel instead of failing over to another replica, so memory pressure would
+// evict healthy nodes from routing. Pin the retriable code at every site.
+TEST_F(GeometryValueSemanticsTest, CloneFailureIsClassifiedAsRetriableOOM) {
+    Geometry src(ctx_, "POINT (1 2)");
+    ASSERT_TRUE(src.IsValid());
+
+    auto expect_mem_allocate_failed = [](const char* what,
+                                         std::function<void()> clone) {
+        milvus::GeometryCloneFailureForTesting().store(true);
+        try {
+            clone();
+            milvus::GeometryCloneFailureForTesting().store(false);
+            FAIL() << what << " must throw when the clone fails";
+        } catch (const milvus::SegcoreError& e) {
+            EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::MemAllocateFailed)
+                << what << " must report the retriable OOM code";
+        }
+    };
+
+    expect_mem_allocate_failed("copy construction",
+                               [&]() { Geometry copy(src); });
+    expect_mem_allocate_failed("copy assignment", [&]() {
+        Geometry dst;
+        dst = src;
+    });
+    expect_mem_allocate_failed("Clone(ctx)",
+                               [&]() { auto c = src.Clone(ctx_); });
+
+    // The hook is one-shot, so the fault injection cannot leak into unrelated
+    // tests -- and cloning still works normally afterwards.
+    ASSERT_FALSE(milvus::GeometryCloneFailureForTesting().load());
+    Geometry copy(src);
+    ASSERT_TRUE(copy.IsValid());
+    EXPECT_NE(copy.GetRawGeometry(), src.GetRawGeometry());
+    EXPECT_EQ(copy.to_wkb_string(), src.to_wkb_string());
+}
+
+}  // namespace

--- a/internal/core/src/common/GeometryTest.cpp
+++ b/internal/core/src/common/GeometryTest.cpp
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
 #include <gtest/gtest.h>
+#include <functional>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -208,6 +209,50 @@ TEST_F(GeometryValueSemanticsTest,
     } catch (const milvus::SegcoreError& e) {
         EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::MemAllocateFailed);
     }
+}
+
+// Same transient/permanent classification, applied to the clone paths.
+// GEOSGeom_clone_r() reports allocation failure by RETURNING nullptr -- the
+// capi execute() guard catches std::bad_alloc and swallows it -- so no
+// `catch (const std::bad_alloc&)` net upstream can ever see it, and the three
+// clone sites have to classify it themselves. Reporting it with a plain
+// AssertInfo yields UnexpectedError(2001), which merr does not mark retriable;
+// on the search path lb_policy then blacklists the serving node for the
+// channel instead of failing over to another replica, so memory pressure would
+// evict healthy nodes from routing. Pin the retriable code at every site.
+TEST_F(GeometryValueSemanticsTest, CloneFailureIsClassifiedAsRetriableOOM) {
+    Geometry src(ctx_, "POINT (1 2)");
+    ASSERT_TRUE(src.IsValid());
+
+    auto expect_mem_allocate_failed = [](const char* what,
+                                         std::function<void()> clone) {
+        milvus::GeometryCloneFailureForTesting().store(true);
+        try {
+            clone();
+            milvus::GeometryCloneFailureForTesting().store(false);
+            FAIL() << what << " must throw when the clone fails";
+        } catch (const milvus::SegcoreError& e) {
+            EXPECT_EQ(e.get_error_code(), milvus::ErrorCode::MemAllocateFailed)
+                << what << " must report the retriable OOM code";
+        }
+    };
+
+    expect_mem_allocate_failed("copy construction",
+                               [&]() { Geometry copy(src); });
+    expect_mem_allocate_failed("copy assignment", [&]() {
+        Geometry dst;
+        dst = src;
+    });
+    expect_mem_allocate_failed("Clone(ctx)",
+                               [&]() { auto c = src.Clone(ctx_); });
+
+    // The hook is one-shot, so the fault injection cannot leak into unrelated
+    // tests -- and cloning still works normally afterwards.
+    ASSERT_FALSE(milvus::GeometryCloneFailureForTesting().load());
+    Geometry copy(src);
+    ASSERT_TRUE(copy.IsValid());
+    EXPECT_NE(copy.GetRawGeometry(), src.GetRawGeometry());
+    EXPECT_EQ(copy.to_wkb_string(), src.to_wkb_string());
 }
 
 }  // namespace

--- a/internal/core/src/common/PreparedGeometry.h
+++ b/internal/core/src/common/PreparedGeometry.h
@@ -132,8 +132,9 @@ class PreparedGeometry {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        return GEOSPreparedIntersects_r(ctx_, prepared_, other.GetGeometry()) ==
-               1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedIntersects_r(ctx_, prepared_, other.GetGeometry()),
+            "prepared_intersects");
     }
 
     bool
@@ -141,7 +142,9 @@ class PreparedGeometry {
         if (!IsValid() || other == nullptr) {
             return false;
         }
-        return GEOSPreparedIntersects_r(ctx_, prepared_, other) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedIntersects_r(ctx_, prepared_, other),
+            "prepared_intersects");
     }
 
     /**
@@ -153,8 +156,9 @@ class PreparedGeometry {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        return GEOSPreparedContains_r(ctx_, prepared_, other.GetGeometry()) ==
-               1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedContains_r(ctx_, prepared_, other.GetGeometry()),
+            "prepared_contains");
     }
 
     bool
@@ -162,7 +166,9 @@ class PreparedGeometry {
         if (!IsValid() || other == nullptr) {
             return false;
         }
-        return GEOSPreparedContains_r(ctx_, prepared_, other) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedContains_r(ctx_, prepared_, other),
+            "prepared_contains");
     }
 
     /**
@@ -174,8 +180,9 @@ class PreparedGeometry {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        return GEOSPreparedContainsProperly_r(
-                   ctx_, prepared_, other.GetGeometry()) == 1;
+        return GeosPredicateIsTrue(GEOSPreparedContainsProperly_r(
+                                       ctx_, prepared_, other.GetGeometry()),
+                                   "prepared_containsproperly");
     }
 
     bool
@@ -183,7 +190,9 @@ class PreparedGeometry {
         if (!IsValid() || other == nullptr) {
             return false;
         }
-        return GEOSPreparedContainsProperly_r(ctx_, prepared_, other) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedContainsProperly_r(ctx_, prepared_, other),
+            "prepared_containsproperly");
     }
 
     /**
@@ -194,7 +203,9 @@ class PreparedGeometry {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        return GEOSPreparedCovers_r(ctx_, prepared_, other.GetGeometry()) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedCovers_r(ctx_, prepared_, other.GetGeometry()),
+            "prepared_covers");
     }
 
     bool
@@ -202,7 +213,8 @@ class PreparedGeometry {
         if (!IsValid() || other == nullptr) {
             return false;
         }
-        return GEOSPreparedCovers_r(ctx_, prepared_, other) == 1;
+        return GeosPredicateIsTrue(GEOSPreparedCovers_r(ctx_, prepared_, other),
+                                   "prepared_covers");
     }
 
     /**
@@ -213,8 +225,9 @@ class PreparedGeometry {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        return GEOSPreparedCoveredBy_r(ctx_, prepared_, other.GetGeometry()) ==
-               1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedCoveredBy_r(ctx_, prepared_, other.GetGeometry()),
+            "prepared_coveredby");
     }
 
     bool
@@ -222,7 +235,9 @@ class PreparedGeometry {
         if (!IsValid() || other == nullptr) {
             return false;
         }
-        return GEOSPreparedCoveredBy_r(ctx_, prepared_, other) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedCoveredBy_r(ctx_, prepared_, other),
+            "prepared_coveredby");
     }
 
     /**
@@ -233,7 +248,9 @@ class PreparedGeometry {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        return GEOSPreparedCrosses_r(ctx_, prepared_, other.GetGeometry()) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedCrosses_r(ctx_, prepared_, other.GetGeometry()),
+            "prepared_crosses");
     }
 
     bool
@@ -241,7 +258,8 @@ class PreparedGeometry {
         if (!IsValid() || other == nullptr) {
             return false;
         }
-        return GEOSPreparedCrosses_r(ctx_, prepared_, other) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedCrosses_r(ctx_, prepared_, other), "prepared_crosses");
     }
 
     /**
@@ -252,8 +270,9 @@ class PreparedGeometry {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        return GEOSPreparedDisjoint_r(ctx_, prepared_, other.GetGeometry()) ==
-               1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedDisjoint_r(ctx_, prepared_, other.GetGeometry()),
+            "prepared_disjoint");
     }
 
     bool
@@ -261,7 +280,9 @@ class PreparedGeometry {
         if (!IsValid() || other == nullptr) {
             return false;
         }
-        return GEOSPreparedDisjoint_r(ctx_, prepared_, other) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedDisjoint_r(ctx_, prepared_, other),
+            "prepared_disjoint");
     }
 
     /**
@@ -272,8 +293,9 @@ class PreparedGeometry {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        return GEOSPreparedOverlaps_r(ctx_, prepared_, other.GetGeometry()) ==
-               1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedOverlaps_r(ctx_, prepared_, other.GetGeometry()),
+            "prepared_overlaps");
     }
 
     bool
@@ -281,7 +303,9 @@ class PreparedGeometry {
         if (!IsValid() || other == nullptr) {
             return false;
         }
-        return GEOSPreparedOverlaps_r(ctx_, prepared_, other) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedOverlaps_r(ctx_, prepared_, other),
+            "prepared_overlaps");
     }
 
     /**
@@ -292,7 +316,9 @@ class PreparedGeometry {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        return GEOSPreparedTouches_r(ctx_, prepared_, other.GetGeometry()) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedTouches_r(ctx_, prepared_, other.GetGeometry()),
+            "prepared_touches");
     }
 
     bool
@@ -300,7 +326,8 @@ class PreparedGeometry {
         if (!IsValid() || other == nullptr) {
             return false;
         }
-        return GEOSPreparedTouches_r(ctx_, prepared_, other) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedTouches_r(ctx_, prepared_, other), "prepared_touches");
     }
 
     /**
@@ -313,7 +340,9 @@ class PreparedGeometry {
         if (!IsValid() || !other.IsValid()) {
             return false;
         }
-        return GEOSPreparedWithin_r(ctx_, prepared_, other.GetGeometry()) == 1;
+        return GeosPredicateIsTrue(
+            GEOSPreparedWithin_r(ctx_, prepared_, other.GetGeometry()),
+            "prepared_within");
     }
 
     bool
@@ -321,7 +350,8 @@ class PreparedGeometry {
         if (!IsValid() || other == nullptr) {
             return false;
         }
-        return GEOSPreparedWithin_r(ctx_, prepared_, other) == 1;
+        return GeosPredicateIsTrue(GEOSPreparedWithin_r(ctx_, prepared_, other),
+                                   "prepared_within");
     }
 
     // ============================================================================
@@ -341,7 +371,8 @@ class PreparedGeometry {
         if (geom == nullptr || !other.IsValid()) {
             return false;
         }
-        return GEOSEquals_r(ctx, geom, other.GetGeometry()) == 1;
+        return GeosPredicateIsTrue(GEOSEquals_r(ctx, geom, other.GetGeometry()),
+                                   "prepared_equals");
     }
 
  private:

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -464,9 +464,7 @@ TEST(GISCoarseRefineExprTest, EquivalenceFusionWithGeometryCache) {
     // would silently fall back to the WKB path and this test would not cover
     // the cache branch it is meant to lock down.
     auto geo_fid = schema->get_field_id(FieldName("geo"));
-    ASSERT_NE(milvus::exec::SimpleGeometryCacheManager::Instance().GetCache(
-                  seg->get_segment_id(), geo_fid),
-              nullptr);
+    ASSERT_NE(seg->GetGeometryCache(geo_fid), nullptr);
 
     AssertFusionEquivalence(schema, handle, seg.get(), N);
 }

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -465,7 +465,7 @@ TEST(GISCoarseRefineExprTest, EquivalenceFusionWithGeometryCache) {
     // the cache branch it is meant to lock down.
     auto geo_fid = schema->get_field_id(FieldName("geo"));
     ASSERT_NE(milvus::exec::SimpleGeometryCacheManager::Instance().GetCache(
-                  seg->get_segment_id(), geo_fid),
+                  seg->segment_instance_uid(), seg->get_segment_id(), geo_fid),
               nullptr);
 
     AssertFusionEquivalence(schema, handle, seg.get(), N);

--- a/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
+++ b/internal/core/src/exec/expression/GISCoarseRefineExprTest.cpp
@@ -464,9 +464,7 @@ TEST(GISCoarseRefineExprTest, EquivalenceFusionWithGeometryCache) {
     // would silently fall back to the WKB path and this test would not cover
     // the cache branch it is meant to lock down.
     auto geo_fid = schema->get_field_id(FieldName("geo"));
-    ASSERT_NE(milvus::exec::SimpleGeometryCacheManager::Instance().GetCache(
-                  seg->segment_instance_uid(), seg->get_segment_id(), geo_fid),
-              nullptr);
+    ASSERT_NE(seg->GetGeometryCache(geo_fid), nullptr);
 
     AssertFusionEquivalence(schema, handle, seg.get(), N);
 }

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -11,11 +11,13 @@
 
 #include "exec/expression/GISConjunctExpr.h"
 
+#include <atomic>
 #include <mutex>
 #include <utility>
 #include <vector>
 
 #include "common/EasyAssert.h"
+#include "common/Geometry.h"
 #include "common/GeometryCache.h"
 #include "common/OpContext.h"
 #include "common/Types.h"
@@ -98,7 +100,7 @@ GISGroupState::~GISGroupState() {
 // Coarse node: run each predicate's R-Tree query once (segment-level), combine
 // per is_and, cache, and emit the per-batch slice.
 // -------------------------------------------------------------------------
-bool
+PhyGISCoarseConjunctExpr::CoarseOutcome
 PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
     // Mirrors PhyGISFunctionFilterExpr::EvalForIndexSegment's coarse query.
     using Index = index::ScalarIndex<std::string>;
@@ -123,7 +125,7 @@ PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
         // The caller aggregates this across the group's predicates and warns
         // once per segment (see Eval), instead of once per predicate here.
         p.coarse = TargetBitmap(active_count_, true);
-        return true;
+        return CoarseOutcome::kIndexUnusable;
     }
 
     // GEOS objects are bound to the per-thread context.
@@ -144,25 +146,32 @@ PhyGISCoarseConjunctExpr::RunRTreeQuery(GISGroupState::Pred& p) {
     // newest inserts lowers active_count_ further), and TargetBitmap's
     // operator&=/|= size check is a bare assert() that is compiled out under
     // NDEBUG. Normalize into active_count_ space: keep the first
-    // active_count_ bits. The reverse direction -- the index reporting FEWER
-    // rows than are visible -- is unreachable today (SegmentGrowingImpl
-    // appends to the index before acking rows, so index rows >= active
-    // rows); if that invariant ever breaks, pad the un-indexed tail with 1s
-    // instead of failing the query: coarse ⊇ exact still holds and Refine
-    // evaluates the exact predicate, so results stay correct and we only
-    // lose R-Tree pruning for the tail -- same defensive posture as the
-    // pin-empty degrade above.
+    // active_count_ bits.
     if (static_cast<int64_t>(tmp.size()) > active_count_) {
         TargetBitmap sliced;
         sliced.append(tmp, 0, active_count_);
         p.coarse = std::move(sliced);
-        return false;
+        return CoarseOutcome::kPruned;
     }
-    if (static_cast<int64_t>(tmp.size()) < active_count_) {
-        tmp.resize(active_count_, /*init=*/true);
+    // The reverse direction -- the index reporting FEWER rows than are
+    // visible -- is unreachable on a growing segment (SegmentGrowingImpl
+    // appends to the index before acking rows) but IS reachable on a sealed
+    // one: an R-Tree built before empty/unparseable geometries were kept as
+    // placeholder entries under-reports the row space, and its missing
+    // entries are interior holes, not a trailing suffix. Padding only the
+    // tail with 1s would leave those holes false and silently drop matching
+    // rows from `survivors &= coarse_slice` in Refine -- while the very same
+    // predicate issued alone would take the per-predicate path's self-heal
+    // and return them. Apply the one shared rule instead: promote the whole
+    // row space to candidates (coarse ⊇ exact holds trivially, Refine still
+    // evaluates the exact predicate) and lose R-Tree pruning for this
+    // segment. Same defensive posture as the pin-empty degrade above.
+    if (PromoteShortGISCoarseBitmap(tmp, active_count_)) {
+        p.coarse = std::move(tmp);
+        return CoarseOutcome::kIndexShort;
     }
     p.coarse = std::move(tmp);
-    return false;
+    return CoarseOutcome::kPruned;
 }
 
 void
@@ -184,11 +193,19 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
     if (!st_->coarse_done) {
         TargetBitmap cand(active_count_, st_->is_and);  // AND -> 1s / OR -> 0s
         int unusable_index = 0;  // preds whose R-Tree pin came up empty
+        int short_index = 0;     // preds whose legacy R-Tree is short
         int no_index = 0;        // preds with no geometry index at all
         for (auto& p : st_->preds) {
             if (p.has_index) {
-                if (RunRTreeQuery(p)) {
-                    ++unusable_index;
+                switch (RunRTreeQuery(p)) {
+                    case CoarseOutcome::kIndexUnusable:
+                        ++unusable_index;
+                        break;
+                    case CoarseOutcome::kIndexShort:
+                        ++short_index;
+                        break;
+                    case CoarseOutcome::kPruned:
+                        break;
                 }
             } else {
                 // No R-Tree index: coarse degenerates to the full set; the
@@ -227,6 +244,28 @@ PhyGISCoarseConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
                 st_->preds.size(),
                 num_index_chunk_,
                 pinned_index_.size());
+        }
+        // Same shape as the per-predicate path's short-index warning
+        // (GISFunctionFilterExpr.cpp), throttled the same way: this is an
+        // expected upgrade state, not a bug, but it silently costs a full
+        // refinement per query until the index is rebuilt.
+        if (short_index > 0) {
+            static std::atomic<int64_t> last_short_index_log_us{0};
+            if (ShouldLogGeometryThrottled(last_short_index_log_us)) {
+                LOG_WARN(
+                    "GIS coarse pruning degraded to full scan: the R-Tree "
+                    "index for field {} reports fewer rows than the segment "
+                    "holds ({}) for {} of {} predicate(s); the missing "
+                    "entries may be interior holes, so every row is treated "
+                    "as a candidate for exact refinement. This index "
+                    "predates placeholder-MBR indexing of empty/unparseable "
+                    "geometries -- rebuild it to restore pruning (further "
+                    "occurrences suppressed briefly).",
+                    st_->field_id.get(),
+                    active_count_,
+                    short_index,
+                    st_->preds.size());
+            }
         }
         if (no_index > 0) {
             LOG_DEBUG(
@@ -300,12 +339,16 @@ PhyGISRefineConjunctExpr::EvalPrepared(
     proto::plan::GISFunctionFilterExpr_GISOp op,
     const PreparedGeometry& prepared,
     const Geometry& query_geom,
-    const Geometry& left) const {
+    const Geometry& left,
+    GEOSContextHandle_t ctx) const {
     // Delegate to the shared helper so the prepared-predicate semantics (the
     // contains/within swap in particular) never drift from the per-predicate
     // path. DWithin is filtered out before grouping, so distance is unused here.
+    // Equals is NOT filtered out, and it is the helper's unprepared fallback --
+    // hence `ctx`, so it never drives GEOS through a cache-owned `left`'s
+    // shared context.
     return EvaluateGISPreparedOp(
-        op, prepared, query_geom, left, /*distance=*/0.0);
+        op, prepared, query_geom, left, /*distance=*/0.0, ctx);
 }
 
 void
@@ -314,8 +357,7 @@ PhyGISRefineConjunctExpr::PrefetchRawData() {
     // bulk_subscript over their offsets -- never a sequential full-column scan,
     // so the base prefetch_chunks over EVERY chunk is mostly wasted. Warm the
     // column only when reads will actually span it.
-    auto* geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(
-        segment_->get_segment_id(), st_->field_id);
+    auto geometry_cache = segment_->GetGeometryCache(st_->field_id);
     if (geometry_cache != nullptr) {
         // Reads come from the cache; the raw column is never touched.
         return;
@@ -396,8 +438,8 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
         auto eval_all = [&](const Geometry& left) -> bool {
             bool bit = st_->is_and;
             for (size_t j = 0; j < st_->preds.size(); ++j) {
-                bool r =
-                    EvalPrepared(st_->preds[j].op, preps[j], qgeoms[j], left);
+                bool r = EvalPrepared(
+                    st_->preds[j].op, preps[j], qgeoms[j], left, qctx);
                 bit = st_->is_and ? (bit && r) : (bit || r);
                 if (st_->is_and != bit) {
                     break;  // short-circuit
@@ -422,8 +464,9 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
             }
         }
 
-        auto* geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(
-            segment_->get_segment_id(), st_->field_id);
+        // shared_ptr: an in-flight query keeps the published cache snapshot
+        // alive across a concurrent sealed-segment reopen/drop.
+        auto geometry_cache = segment_->GetGeometryCache(st_->field_id);
 
         if (geometry_cache) {
             auto cache_lock = geometry_cache->AcquireReadLock();
@@ -453,7 +496,17 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
                     continue;
                 }
                 const auto& wkb = geometry_array->data(k);
-                Geometry left(local_ctx, wkb.data(), wkb.size());
+                // Tolerant parse, matching the per-predicate path: a non-null
+                // row whose WKB is empty or corrupt is now KEPT by both write
+                // paths and indexed with a placeholder MBR, so it does reach
+                // refinement whenever the query bbox covers the origin. The
+                // throwing Geometry(ctx, wkb) ctor would fail the entire query
+                // on such a row; it can never satisfy the predicate, so
+                // evaluate it to false instead.
+                Geometry left;
+                if (!left.TryParseFromWkb(local_ctx, wkb.data(), wkb.size())) {
+                    continue;
+                }
                 if (eval_all(left)) {
                     res.set(hit_local[k]);
                 }

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -299,12 +299,16 @@ PhyGISRefineConjunctExpr::EvalPrepared(
     proto::plan::GISFunctionFilterExpr_GISOp op,
     const PreparedGeometry& prepared,
     const Geometry& query_geom,
-    const Geometry& left) const {
+    const Geometry& left,
+    GEOSContextHandle_t ctx) const {
     // Delegate to the shared helper so the prepared-predicate semantics (the
     // contains/within swap in particular) never drift from the per-predicate
     // path. DWithin is filtered out before grouping, so distance is unused here.
+    // Equals is NOT filtered out, and it is the helper's unprepared fallback --
+    // hence `ctx`, so it never drives GEOS through a cache-owned `left`'s
+    // shared context.
     return EvaluateGISPreparedOp(
-        op, prepared, query_geom, left, /*distance=*/0.0);
+        op, prepared, query_geom, left, /*distance=*/0.0, ctx);
 }
 
 void
@@ -313,8 +317,10 @@ PhyGISRefineConjunctExpr::PrefetchRawData() {
     // bulk_subscript over their offsets -- never a sequential full-column scan,
     // so the base prefetch_chunks over EVERY chunk is mostly wasted. Warm the
     // column only when reads will actually span it.
-    auto* geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(
-        segment_->get_segment_id(), st_->field_id);
+    auto geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(
+        segment_->segment_instance_uid(),
+        segment_->get_segment_id(),
+        st_->field_id);
     if (geometry_cache != nullptr) {
         // Reads come from the cache; the raw column is never touched.
         return;
@@ -395,8 +401,8 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
         auto eval_all = [&](const Geometry& left) -> bool {
             bool bit = st_->is_and;
             for (size_t j = 0; j < st_->preds.size(); ++j) {
-                bool r =
-                    EvalPrepared(st_->preds[j].op, preps[j], qgeoms[j], left);
+                bool r = EvalPrepared(
+                    st_->preds[j].op, preps[j], qgeoms[j], left, qctx);
                 bit = st_->is_and ? (bit && r) : (bit || r);
                 if (st_->is_and != bit) {
                     break;  // short-circuit
@@ -421,8 +427,12 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
             }
         }
 
-        auto* geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(
-            segment_->get_segment_id(), st_->field_id);
+        // shared_ptr: an in-flight query keeps the cache alive past a
+        // concurrent segment drop (see SimpleGeometryCacheManager).
+        auto geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(
+            segment_->segment_instance_uid(),
+            segment_->get_segment_id(),
+            st_->field_id);
 
         if (geometry_cache) {
             auto cache_lock = geometry_cache->AcquireReadLock();
@@ -452,7 +462,17 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
                     continue;
                 }
                 const auto& wkb = geometry_array->data(k);
-                Geometry left(local_ctx, wkb.data(), wkb.size());
+                // Tolerant parse, matching the per-predicate path: a non-null
+                // row whose WKB is empty or corrupt is now KEPT by both write
+                // paths and indexed with a placeholder MBR, so it does reach
+                // refinement whenever the query bbox covers the origin. The
+                // throwing Geometry(ctx, wkb) ctor would fail the entire query
+                // on such a row; it can never satisfy the predicate, so
+                // evaluate it to false instead. See PR #50951.
+                Geometry left;
+                if (!left.TryParseFromWkb(local_ctx, wkb.data(), wkb.size())) {
+                    continue;
+                }
                 if (eval_all(left)) {
                     res.set(hit_local[k]);
                 }

--- a/internal/core/src/exec/expression/GISConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/GISConjunctExpr.cpp
@@ -317,10 +317,7 @@ PhyGISRefineConjunctExpr::PrefetchRawData() {
     // bulk_subscript over their offsets -- never a sequential full-column scan,
     // so the base prefetch_chunks over EVERY chunk is mostly wasted. Warm the
     // column only when reads will actually span it.
-    auto geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(
-        segment_->segment_instance_uid(),
-        segment_->get_segment_id(),
-        st_->field_id);
+    auto geometry_cache = segment_->GetGeometryCache(st_->field_id);
     if (geometry_cache != nullptr) {
         // Reads come from the cache; the raw column is never touched.
         return;
@@ -427,12 +424,9 @@ PhyGISRefineConjunctExpr::Eval(EvalCtx& context, VectorPtr& result) {
             }
         }
 
-        // shared_ptr: an in-flight query keeps the cache alive past a
-        // concurrent segment drop (see SimpleGeometryCacheManager).
-        auto geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(
-            segment_->segment_instance_uid(),
-            segment_->get_segment_id(),
-            st_->field_id);
+        // shared_ptr: an in-flight query keeps the published cache snapshot
+        // alive across a concurrent sealed-segment reopen/drop.
+        auto geometry_cache = segment_->GetGeometryCache(st_->field_id);
 
         if (geometry_cache) {
             auto cache_lock = geometry_cache->AcquireReadLock();

--- a/internal/core/src/exec/expression/GISConjunctExpr.h
+++ b/internal/core/src/exec/expression/GISConjunctExpr.h
@@ -198,11 +198,20 @@ class PhyGISCoarseConjunctExpr : public SegmentExpr {
         return remain < batch_size_ ? remain : batch_size_;
     }
 
+    // Outcome of one predicate's R-Tree coarse query. Anything but kPruned
+    // means p.coarse degraded to an all-set bitmap (results stay correct via
+    // Refine; R-Tree pruning is lost for the segment); the two degrade causes
+    // are kept apart so the caller can raise one accurately-worded per-segment
+    // warning for each, instead of one per predicate.
+    enum class CoarseOutcome {
+        kPruned,         // index answered; p.coarse is a real candidate set
+        kIndexUnusable,  // index reported present but the pin yielded none
+        kIndexShort,     // legacy index shorter than active_count_ (see
+                         // PromoteShortGISCoarseBitmap)
+    };
+
     // Run the R-Tree index query for a single predicate, filling p.coarse.
-    // Returns true if the pin came up empty and coarse degraded to an all-set
-    // bitmap (index reported present but unusable); the caller raises a single
-    // per-segment warning for the whole group instead of one per predicate.
-    bool
+    CoarseOutcome
     RunRTreeQuery(GISGroupState::Pred& p);
 
     GISGroupStatePtr st_;
@@ -304,11 +313,14 @@ class PhyGISRefineConjunctExpr : public SegmentExpr {
     // Evaluate one predicate against an already-constructed left geometry using
     // a per-thread prepared query geometry (within/contains semantics swapped,
     // mirroring PhyGISFunctionFilterExpr::evaluate_geometry_prepared).
+    // `ctx` must be the calling thread's GEOS context: `left` may be a
+    // cache-owned geometry whose context is shared across concurrent queries.
     bool
     EvalPrepared(proto::plan::GISFunctionFilterExpr_GISOp op,
                  const PreparedGeometry& prepared,
                  const Geometry& query_geom,
-                 const Geometry& left) const;
+                 const Geometry& left,
+                 GEOSContextHandle_t ctx) const;
 
     GISGroupStatePtr st_;
     int64_t current_pos_{0};

--- a/internal/core/src/exec/expression/GISConjunctExpr.h
+++ b/internal/core/src/exec/expression/GISConjunctExpr.h
@@ -304,11 +304,14 @@ class PhyGISRefineConjunctExpr : public SegmentExpr {
     // Evaluate one predicate against an already-constructed left geometry using
     // a per-thread prepared query geometry (within/contains semantics swapped,
     // mirroring PhyGISFunctionFilterExpr::evaluate_geometry_prepared).
+    // `ctx` must be the calling thread's GEOS context: `left` may be a
+    // cache-owned geometry whose context is shared across concurrent queries.
     bool
     EvalPrepared(proto::plan::GISFunctionFilterExpr_GISOp op,
                  const PreparedGeometry& prepared,
                  const Geometry& query_geom,
-                 const Geometry& left) const;
+                 const Geometry& left,
+                 GEOSContextHandle_t ctx) const;
 
     GISGroupStatePtr st_;
     int64_t current_pos_{0};

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -32,6 +32,7 @@
 #include "index/Index.h"
 #include "index/Meta.h"
 #include "index/ScalarIndex.h"
+#include "log/Log.h"
 #include "knowhere/dataset.h"
 #include "pb/plan.pb.h"
 #include "pb/schema.pb.h"
@@ -41,155 +42,198 @@
 namespace milvus {
 namespace exec {
 
-#define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON(_DataType, method)       \
-    auto execute_sub_batch = [this](const _DataType* data,                  \
-                                    ValidityView valid_data,                \
-                                    const int32_t* offsets,                 \
-                                    const int32_t* segment_offsets,         \
-                                    const int size,                         \
-                                    TargetBitmapView res,                   \
-                                    TargetBitmapView valid_res,             \
-                                    const Geometry& right_source) {         \
-        AssertInfo(segment_offsets != nullptr,                              \
-                   "segment_offsets should not be nullptr");                \
-        auto* geometry_cache =                                              \
-            SimpleGeometryCacheManager::Instance().GetCache(                \
-                this->segment_->get_segment_id(), field_id_);               \
-        if (geometry_cache) {                                               \
-            auto cache_lock = geometry_cache->AcquireReadLock();            \
-            for (int i = 0; i < size; ++i) {                                \
-                if (valid_data && !valid_data[i]) {                         \
-                    res[i] = valid_res[i] = false;                          \
-                    continue;                                               \
-                }                                                           \
-                auto absolute_offset = segment_offsets[i];                  \
-                auto cached_geometry =                                      \
-                    geometry_cache->GetByOffsetUnsafe(absolute_offset);     \
-                AssertInfo(cached_geometry != nullptr,                      \
-                           "cached geometry is nullptr");                   \
-                res[i] = cached_geometry->method(right_source);             \
-            }                                                               \
-        } else {                                                            \
-            GEOSContextHandle_t ctx_ = GEOS_init_r();                       \
-            for (int i = 0; i < size; ++i) {                                \
-                if (valid_data && !valid_data[i]) {                         \
-                    res[i] = valid_res[i] = false;                          \
-                    continue;                                               \
-                }                                                           \
-                res[i] = Geometry(ctx_, data[i].data(), data[i].size())     \
-                             .method(right_source);                         \
-            }                                                               \
-            GEOS_finish_r(ctx_);                                            \
-        }                                                                   \
-    };                                                                      \
-    int64_t processed_size = ProcessDataChunks<_DataType, true>(            \
-        execute_sub_batch, std::nullptr_t{}, res, valid_res, right_source); \
-    AssertInfo(processed_size == real_batch_size,                           \
-               "internal error: expr processed rows {} not equal "          \
-               "expect batch size {}",                                      \
-               processed_size,                                              \
-               real_batch_size);                                            \
+#define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON(_DataType, method)            \
+    auto execute_sub_batch = [this](const _DataType* data,                       \
+                                    ValidityView valid_data,                     \
+                                    const int32_t* offsets,                      \
+                                    const int32_t* segment_offsets,              \
+                                    const int size,                              \
+                                    TargetBitmapView res,                        \
+                                    TargetBitmapView valid_res,                  \
+                                    const Geometry& right_source) {              \
+        AssertInfo(segment_offsets != nullptr,                                   \
+                   "segment_offsets should not be nullptr");                     \
+        auto geometry_cache = this->segment_->GetGeometryCache(field_id_);       \
+        if (geometry_cache) {                                                    \
+            auto cache_lock = geometry_cache->AcquireReadLock();                 \
+            /* Cache-owned geometries share one GEOS context; drive the        \
+             * predicate on a per-thread context so concurrent read-locked      \
+             * queries never touch the same non-thread-safe context. */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data && !valid_data[i]) {                              \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                auto absolute_offset = segment_offsets[i];                       \
+                auto cached_geometry =                                           \
+                    geometry_cache->GetByOffsetUnsafe(absolute_offset);          \
+                /* nullptr = empty/corrupt placeholder row (the write paths    \
+                 * keep such rows, see SimpleGeometryCache::AppendDataAt); it   \
+                 * can never satisfy the predicate, so evaluate it to false     \
+                 * instead of failing the whole query. */ \
+                if (cached_geometry == nullptr) {                                \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = cached_geometry->method(right_source, tls_ctx);         \
+            }                                                                    \
+        } else {                                                                 \
+            /* Thread-local context: a throwing row can no longer leak a       \
+             * per-batch GEOS_init_r context. TryParseFromWkb throws only on    \
+             * pre-parse allocation failure; a corrupt/placeholder WKB row --   \
+             * or a GEOS-swallowed parse-time OOM, indistinguishable from it    \
+             * (see the KNOWN LIMIT note on TryParseFromWkb) -- evaluates to    \
+             * false, matching the cache branch above. */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data && !valid_data[i]) {                              \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                Geometry left;                                                   \
+                if (!left.TryParseFromWkb(                                       \
+                        tls_ctx, data[i].data(), data[i].size())) {              \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = left.method(right_source, tls_ctx);                     \
+            }                                                                    \
+        }                                                                        \
+    };                                                                           \
+    int64_t processed_size = ProcessDataChunks<_DataType, true>(                 \
+        execute_sub_batch, std::nullptr_t{}, res, valid_res, right_source);      \
+    AssertInfo(processed_size == real_batch_size,                                \
+               "internal error: expr processed rows {} not equal "               \
+               "expect batch size {}",                                           \
+               processed_size,                                                   \
+               real_batch_size);                                                 \
     return res_vec;
 // Specialized macro for distance-based operations (ST_DWITHIN)
-#define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON_DISTANCE(_DataType, method) \
-    auto execute_sub_batch = [this](const _DataType* data,                     \
-                                    ValidityView valid_data,                   \
-                                    const int32_t* offsets,                    \
-                                    const int32_t* segment_offsets,            \
-                                    const int size,                            \
-                                    TargetBitmapView res,                      \
-                                    TargetBitmapView valid_res,                \
-                                    const Geometry& right_source) {            \
-        AssertInfo(segment_offsets != nullptr,                                 \
-                   "segment_offsets should not be nullptr");                   \
-        auto* geometry_cache =                                                 \
-            SimpleGeometryCacheManager::Instance().GetCache(                   \
-                this->segment_->get_segment_id(), field_id_);                  \
-        if (geometry_cache) {                                                  \
-            auto cache_lock = geometry_cache->AcquireReadLock();               \
-            for (int i = 0; i < size; ++i) {                                   \
-                if (valid_data && !valid_data[i]) {                            \
-                    res[i] = valid_res[i] = false;                             \
-                    continue;                                                  \
-                }                                                              \
-                auto absolute_offset = segment_offsets[i];                     \
-                auto cached_geometry =                                         \
-                    geometry_cache->GetByOffsetUnsafe(absolute_offset);        \
-                AssertInfo(cached_geometry != nullptr,                         \
-                           "cached geometry is nullptr");                      \
-                res[i] =                                                       \
-                    cached_geometry->method(right_source, expr_->distance_);   \
-            }                                                                  \
-        } else {                                                               \
-            GEOSContextHandle_t ctx_ = GEOS_init_r();                          \
-            for (int i = 0; i < size; ++i) {                                   \
-                if (valid_data && !valid_data[i]) {                            \
-                    res[i] = valid_res[i] = false;                             \
-                    continue;                                                  \
-                }                                                              \
-                res[i] = Geometry(ctx_, data[i].data(), data[i].size())        \
-                             .method(right_source, expr_->distance_);          \
-            }                                                                  \
-            GEOS_finish_r(ctx_);                                               \
-        }                                                                      \
-    };                                                                         \
-    int64_t processed_size = ProcessDataChunks<_DataType, true>(               \
-        execute_sub_batch, std::nullptr_t{}, res, valid_res, right_source);    \
-    AssertInfo(processed_size == real_batch_size,                              \
-               "internal error: expr processed rows {} not equal "             \
-               "expect batch size {}",                                         \
-               processed_size,                                                 \
-               real_batch_size);                                               \
+#define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON_DISTANCE(_DataType, method)   \
+    auto execute_sub_batch = [this](const _DataType* data,                       \
+                                    ValidityView valid_data,                     \
+                                    const int32_t* offsets,                      \
+                                    const int32_t* segment_offsets,              \
+                                    const int size,                              \
+                                    TargetBitmapView res,                        \
+                                    TargetBitmapView valid_res,                  \
+                                    const Geometry& right_source) {              \
+        AssertInfo(segment_offsets != nullptr,                                   \
+                   "segment_offsets should not be nullptr");                     \
+        auto geometry_cache = this->segment_->GetGeometryCache(field_id_);       \
+        if (geometry_cache) {                                                    \
+            auto cache_lock = geometry_cache->AcquireReadLock();                 \
+            /* Cache-owned geometries share one GEOS context; drive the        \
+             * predicate on a per-thread context so concurrent read-locked      \
+             * queries never touch the same non-thread-safe context. */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data && !valid_data[i]) {                              \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                auto absolute_offset = segment_offsets[i];                       \
+                auto cached_geometry =                                           \
+                    geometry_cache->GetByOffsetUnsafe(absolute_offset);          \
+                /* nullptr = empty/corrupt placeholder row: evaluate to false  \
+                 * instead of failing the query (see the comparison macro). */ \
+                if (cached_geometry == nullptr) {                                \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = cached_geometry->method(                                \
+                    right_source, expr_->distance_, tls_ctx);                    \
+            }                                                                    \
+        } else {                                                                 \
+            /* Thread-local context + non-throwing parse: no context leak,     \
+             * corrupt rows evaluate to false (see the comparison macro). */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data && !valid_data[i]) {                              \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                Geometry left;                                                   \
+                if (!left.TryParseFromWkb(                                       \
+                        tls_ctx, data[i].data(), data[i].size())) {              \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = left.method(right_source, expr_->distance_, tls_ctx);   \
+            }                                                                    \
+        }                                                                        \
+    };                                                                           \
+    int64_t processed_size = ProcessDataChunks<_DataType, true>(                 \
+        execute_sub_batch, std::nullptr_t{}, res, valid_res, right_source);      \
+    AssertInfo(processed_size == real_batch_size,                                \
+               "internal error: expr processed rows {} not equal "               \
+               "expect batch size {}",                                           \
+               processed_size,                                                   \
+               real_batch_size);                                                 \
     return res_vec;
 
 // Macro for unary operations (like IsValid) that don't need a right_source
-#define GEOMETRY_EXECUTE_SUB_BATCH_UNARY(_DataType, method)                  \
-    auto execute_sub_batch = [this](const _DataType* data,                   \
-                                    ValidityView valid_data,                 \
-                                    const int32_t* offsets,                  \
-                                    const int32_t* segment_offsets,          \
-                                    const int size,                          \
-                                    TargetBitmapView res,                    \
-                                    TargetBitmapView valid_res) {            \
-        AssertInfo(segment_offsets != nullptr,                               \
-                   "segment_offsets should not be nullptr");                 \
-        auto* geometry_cache =                                               \
-            SimpleGeometryCacheManager::Instance().GetCache(                 \
-                this->segment_->get_segment_id(), field_id_);                \
-        if (geometry_cache) {                                                \
-            auto cache_lock = geometry_cache->AcquireReadLock();             \
-            for (int i = 0; i < size; ++i) {                                 \
-                if (valid_data && !valid_data[i]) {                          \
-                    res[i] = valid_res[i] = false;                           \
-                    continue;                                                \
-                }                                                            \
-                auto absolute_offset = segment_offsets[i];                   \
-                auto cached_geometry =                                       \
-                    geometry_cache->GetByOffsetUnsafe(absolute_offset);      \
-                AssertInfo(cached_geometry != nullptr,                       \
-                           "cached geometry is nullptr");                    \
-                res[i] = cached_geometry->method();                          \
-            }                                                                \
-        } else {                                                             \
-            GEOSContextHandle_t ctx_ = GEOS_init_r();                        \
-            for (int i = 0; i < size; ++i) {                                 \
-                if (valid_data && !valid_data[i]) {                          \
-                    res[i] = valid_res[i] = false;                           \
-                    continue;                                                \
-                }                                                            \
-                res[i] =                                                     \
-                    Geometry(ctx_, data[i].data(), data[i].size()).method(); \
-            }                                                                \
-            GEOS_finish_r(ctx_);                                             \
-        }                                                                    \
-    };                                                                       \
-    int64_t processed_size = ProcessDataChunks<_DataType, true>(             \
-        execute_sub_batch, std::nullptr_t{}, res, valid_res);                \
-    AssertInfo(processed_size == real_batch_size,                            \
-               "internal error: expr processed rows {} not equal "           \
-               "expect batch size {}",                                       \
-               processed_size,                                               \
-               real_batch_size);                                             \
+#define GEOMETRY_EXECUTE_SUB_BATCH_UNARY(_DataType, method)                      \
+    auto execute_sub_batch = [this](const _DataType* data,                       \
+                                    ValidityView valid_data,                     \
+                                    const int32_t* offsets,                      \
+                                    const int32_t* segment_offsets,              \
+                                    const int size,                              \
+                                    TargetBitmapView res,                        \
+                                    TargetBitmapView valid_res) {                \
+        AssertInfo(segment_offsets != nullptr,                                   \
+                   "segment_offsets should not be nullptr");                     \
+        auto geometry_cache = this->segment_->GetGeometryCache(field_id_);       \
+        if (geometry_cache) {                                                    \
+            auto cache_lock = geometry_cache->AcquireReadLock();                 \
+            /* Cache-owned geometries share one GEOS context; drive the        \
+             * predicate on a per-thread context so concurrent read-locked      \
+             * queries never touch the same non-thread-safe context. */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data && !valid_data[i]) {                              \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                auto absolute_offset = segment_offsets[i];                       \
+                auto cached_geometry =                                           \
+                    geometry_cache->GetByOffsetUnsafe(absolute_offset);          \
+                /* nullptr = empty/corrupt placeholder row: it is not a valid  \
+                 * geometry, so the unary predicate is false (see the           \
+                 * comparison macro). */ \
+                if (cached_geometry == nullptr) {                                \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = cached_geometry->method(tls_ctx);                       \
+            }                                                                    \
+        } else {                                                                 \
+            /* Thread-local context + non-throwing parse: no context leak,     \
+             * corrupt rows evaluate to false (see the comparison macro). */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data && !valid_data[i]) {                              \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                Geometry left;                                                   \
+                if (!left.TryParseFromWkb(                                       \
+                        tls_ctx, data[i].data(), data[i].size())) {              \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = left.method(tls_ctx);                                   \
+            }                                                                    \
+        }                                                                        \
+    };                                                                           \
+    int64_t processed_size = ProcessDataChunks<_DataType, true>(                 \
+        execute_sub_batch, std::nullptr_t{}, res, valid_res);                    \
+    AssertInfo(processed_size == real_batch_size,                                \
+               "internal error: expr processed rows {} not equal "               \
+               "expect batch size {}",                                           \
+               processed_size,                                                   \
+               real_batch_size);                                                 \
     return res_vec;
 
 void
@@ -427,10 +471,20 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
     // - contains/within swap: left.contains(query) == prepared_query.within(left)
     //                         left.within(query) == prepared_query.contains(left)
     // - equals, dwithin: no prepared version, fall back to regular Geometry
-    auto evaluate_geometry_prepared =
-        [this, &prepared_query, &query_geometry](const Geometry& left) -> bool {
-        return EvaluateGISPreparedOp(
-            expr_->op_, prepared_query, query_geometry, left, expr_->distance_);
+    // `left` is frequently a cache-owned geometry whose stored context is
+    // shared across concurrent queries, so the unprepared fallbacks inside the
+    // helper must run on the per-thread context captured above rather than on
+    // left's own context.
+    auto evaluate_geometry_prepared = [this,
+                                       &prepared_query,
+                                       &query_geometry,
+                                       ctx](const Geometry& left) -> bool {
+        return EvaluateGISPreparedOp(expr_->op_,
+                                     prepared_query,
+                                     query_geometry,
+                                     left,
+                                     expr_->distance_,
+                                     ctx);
     };
 
     TargetBitmap batch_result;
@@ -466,9 +520,63 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
             auto tmp = idx_ptr->Query(ds);
             coarse_global_ = std::move(tmp);
         }
-        {
-            auto tmp_valid = idx_ptr->IsNotNull();
-            coarse_valid_global_ = std::move(tmp_valid);
+        // Self-heal an index that reports fewer rows than the segment holds.
+        //
+        // RTreeIndex::Load recomputes the row count from the deserialized
+        // tree, so an index built before empty/unparseable geometries were
+        // kept as placeholder entries under-reports the segment row space.
+        // Those old builders advanced absolute_offset even when they dropped
+        // a row, so the missing entries can be interior holes rather than a
+        // trailing suffix. Count() reveals how many entries are missing, not
+        // where they were. Once the index is short, therefore, no bit in its
+        // candidate bitmap is trustworthy as a negative: promote the entire
+        // active row space to candidates and let exact refinement settle it.
+        //
+        // The INDEX validity bitmap cannot be filled with true, though:
+        // Count() is an entry count while null offsets are absolute row ids, so
+        // a genuine NULL beyond Count() is absent from parameterless
+        // IsNotNull(). Filling it with true would turn NULL into non-NULL and
+        // make NOT ST_* return it as a match. Ask the index to project its
+        // absolute null offsets into the segment row space instead.
+        //
+        // Full refinement beats asserting here: this is an expected upgrade state,
+        // not a Milvus bug, and failing every geometry query on the segment
+        // until someone manually rebuilds the index is a far worse outcome
+        // than a slightly slower correct answer.
+        //
+        // The promotion rule itself lives in PromoteShortGISCoarseBitmap so
+        // the fusion coarse path (PhyGISCoarseConjunctExpr::RunRTreeQuery)
+        // applies the identical rule instead of a tail-only pad.
+        auto coarse_rows = static_cast<int64_t>(coarse_global_.size());
+        if (PromoteShortGISCoarseBitmap(coarse_global_, active_count_)) {
+            static std::atomic<int64_t> last_short_index_log_us{0};
+            if (ShouldLogGeometryThrottled(last_short_index_log_us)) {
+                LOG_WARN(
+                    "R-Tree index for field {} reports {} rows but the "
+                    "segment holds {}; treating all segment rows as "
+                    "candidates for exact refinement because the {} missing "
+                    "entries may be interior holes. This index predates "
+                    "placeholder-MBR indexing of empty/unparseable "
+                    "geometries. Every geometry query on this segment now "
+                    "refines the whole column (read in {}-row batches) "
+                    "instead of R-Tree candidates -- rebuild the index to "
+                    "restore pruning (further occurrences suppressed "
+                    "briefly).",
+                    field_id_.get(),
+                    coarse_rows,
+                    active_count_,
+                    active_count_ - coarse_rows,
+                    batch_size_);
+            }
+
+            // null_offset_ uses absolute segment row ids, while Count() on a
+            // legacy index can under-report after older builders dropped
+            // non-null empty/corrupt rows. Ask the R-Tree to lay validity out
+            // directly in the segment row space so every absolute NULL offset
+            // survives independently of the short entry count.
+            coarse_valid_global_ = idx_ptr->IsNotNull(active_count_);
+        } else {
+            coarse_valid_global_ = idx_ptr->IsNotNull();
         }
 
         coarse_cached_ = true;
@@ -501,9 +609,7 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                 return;
 
             // Get simple geometry cache for this segment+field
-            auto* geometry_cache =
-                SimpleGeometryCacheManager::Instance().GetCache(
-                    segment_->get_segment_id(), field_id_);
+            auto geometry_cache = segment_->GetGeometryCache(field_id_);
             if (geometry_cache) {
                 auto cache_lock = geometry_cache->AcquireReadLock();
                 for (size_t i = 0; i < hit_offsets.size(); ++i) {
@@ -523,30 +629,65 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                     }
                 }
             } else {
-                auto data_array = segment_->bulk_subscript(
-                    op_ctx_, field_id_, hit_offsets.data(), hit_offsets.size());
-
-                auto geometry_array =
-                    static_cast<const milvus::proto::schema::GeometryArray*>(
-                        &data_array->scalars().geometry_data());
-                const auto& valid_data = GetFieldDataRowValidData(*data_array);
-
+                // Read the candidates in batch_size_-row groups rather than
+                // one bulk_subscript over every hit. A single call
+                // materializes one GeometryArray holding a copy of every
+                // candidate's WKB; when the candidate set is the whole
+                // segment -- the legacy short-index self-heal above, or a
+                // globe-covering query bbox -- that is a full-column copy
+                // (hundreds of MB on a million-row segment) held for the
+                // duration of refinement, per query, per concurrent thread.
+                // Chunking bounds the live copy to one group at a time with
+                // no change in results: every hit is still read exactly once,
+                // in offset order.
                 GEOSContextHandle_t local_ctx = GetThreadLocalGEOSContext();
-                for (size_t i = 0; i < hit_offsets.size(); ++i) {
-                    const auto pos = hit_offsets[i];
+                // batch_size_ > 0 is asserted by SegmentExpr's ctor.
+                const size_t group_rows = static_cast<size_t>(batch_size_);
+                for (size_t begin = 0; begin < hit_offsets.size();
+                     begin += group_rows) {
+                    const size_t count =
+                        std::min(group_rows, hit_offsets.size() - begin);
+                    auto data_array = segment_->bulk_subscript(
+                        op_ctx_, field_id_, hit_offsets.data() + begin, count);
 
-                    // Skip invalid data
-                    if (!valid_data.empty() && !valid_data[i]) {
-                        continue;
-                    }
+                    auto geometry_array = static_cast<
+                        const milvus::proto::schema::GeometryArray*>(
+                        &data_array->scalars().geometry_data());
+                    const auto& valid_data =
+                        GetFieldDataRowValidData(*data_array);
 
-                    const auto& wkb_data = geometry_array->data(i);
-                    Geometry left(local_ctx, wkb_data.data(), wkb_data.size());
-                    // Use prepared geometry for faster evaluation
-                    bool result = evaluate_geometry_prepared(left);
+                    for (size_t i = 0; i < count; ++i) {
+                        const auto pos = hit_offsets[begin + i];
 
-                    if (result) {
-                        refined.set(pos);
+                        // Skip invalid data
+                        if (!valid_data.empty() && !valid_data[i]) {
+                            continue;
+                        }
+
+                        const auto& wkb_data = geometry_array->data(i);
+                        Geometry left;
+                        if (!left.TryParseFromWkb(
+                                local_ctx, wkb_data.data(), wkb_data.size())) {
+                            // Unparseable WKB -- e.g. a placeholder row that
+                            // add_geometry / bulk_load keep (instead of
+                            // dropping) to hold the index row count. It can
+                            // never satisfy exact refinement, so skip it,
+                            // mirroring the cache branch's
+                            // GetByOffsetUnsafe() == nullptr skip above.
+                            // MUST NOT throw: with the geometry cache off
+                            // (the default), such rows reach refinement as
+                            // R-Tree candidates whenever the query bbox
+                            // covers the placeholder MBR at the origin, and
+                            // the throwing Geometry(ctx, wkb) ctor would fail
+                            // the entire query.
+                            continue;
+                        }
+                        // Use prepared geometry for faster evaluation
+                        bool result = evaluate_geometry_prepared(left);
+
+                        if (result) {
+                            refined.set(pos);
+                        }
                     }
                 }
             }
@@ -562,9 +703,34 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
 
     if (segment_->type() == SegmentType::Sealed) {
         auto data_pos = current_index_chunk_pos_;
-        auto size = std::min(
-            std::min(size_per_chunk_ - data_pos, batch_size_ - processed_rows),
-            int64_t(cached_index_chunk_res_->size()));
+        // Batch size is driven by the SEGMENT's rows, deliberately not
+        // clamped to the coarse bitmap's length. Clamping here would silently
+        // truncate the batch whenever the index is short, which then trips
+        // the trailing processed_rows == real_batch_size assertion with a
+        // generic message and makes the diagnostic below unreachable (its
+        // predicate would be satisfied by construction).
+        auto size =
+            std::min(size_per_chunk_ - data_pos, batch_size_ - processed_rows);
+
+        // Backstop only. The known cause of a short coarse bitmap -- a
+        // legacy index that under-reports its row count -- is expanded to the
+        // full active row space where the bitmap is built, so reaching this means
+        // something else is wrong. TargetBitmap::append range-checks only its
+        // start offset, never start + count, so an unchecked short bitmap
+        // would be read past the end.
+        AssertInfo(
+            data_pos >= 0 && size >= 0 &&
+                data_pos + size <=
+                    static_cast<int64_t>(cached_index_chunk_res_->size()) &&
+                data_pos + size <=
+                    static_cast<int64_t>(coarse_valid_global_.size()),
+            "sealed geometry coarse bitmap too small: pos {} + size {} "
+            "exceeds result {} / valid {} even after padding the coarse "
+            "bitmap to the segment's active row count.",
+            data_pos,
+            size,
+            cached_index_chunk_res_->size(),
+            coarse_valid_global_.size());
 
         batch_result.append(*cached_index_chunk_res_, data_pos, size);
         batch_valid.append(coarse_valid_global_, data_pos, size);
@@ -578,6 +744,32 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
             size = std::min(size, real_batch_size - processed_rows);
 
             if (size > 0) {
+                // The coarse bitmaps are sized by the index row count
+                // (RTreeIndex::Count()), while `size` is driven by the
+                // segment's active rows. The Insert path indexes a row
+                // (AppendingIndex) before the ack-responder makes it
+                // searchable, and neither write path drops a row -- both
+                // add_geometry and bulk_load_from_field_data index a
+                // placeholder MBR for empty/unparseable WKB rather than
+                // dropping it -- so active_count <=
+                // index Count() must always hold. Guard it explicitly: a violated
+                // invariant must surface as a clear error, never as an
+                // out-of-bounds read or fabricated results (a row reported
+                // result=false is a silent wrong answer, and flips to a false
+                // positive under a negated predicate).
+                AssertInfo(
+                    static_cast<int64_t>(current_index_chunk_pos_ + size) <=
+                            static_cast<int64_t>(
+                                cached_index_chunk_res_->size()) &&
+                        static_cast<int64_t>(current_index_chunk_pos_ + size) <=
+                            static_cast<int64_t>(coarse_valid_global_.size()),
+                    "growing geometry coarse bitmap too small: pos {} + size "
+                    "{} exceeds result {} / valid {} (index row count lagged "
+                    "segment active rows)",
+                    current_index_chunk_pos_,
+                    size,
+                    cached_index_chunk_res_->size(),
+                    coarse_valid_global_.size());
                 batch_result.append(
                     *cached_index_chunk_res_, current_index_chunk_pos_, size);
                 batch_valid.append(

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -524,15 +524,21 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
         // RTreeIndex::Load recomputes the row count from the deserialized
         // tree, so an index built before empty/unparseable geometries were
         // kept as placeholder entries under-reports the segment row space.
-        // Treat the missing tail as candidates and let exact refinement settle
-        // it. The INDEX validity bitmap cannot be padded, though: Count() is an
-        // entry count while null offsets are absolute row ids, so a genuine
-        // NULL in the truncated tail is absent from IsNotNull(). Filling that
-        // tail with true would turn NULL into non-NULL and make NOT ST_* return
-        // it as a match. Ask the index to project its absolute null offsets
-        // into the segment row space instead.
+        // Those old builders advanced absolute_offset even when they dropped
+        // a row, so the missing entries can be interior holes rather than a
+        // trailing suffix. Count() reveals how many entries are missing, not
+        // where they were. Once the index is short, therefore, no bit in its
+        // candidate bitmap is trustworthy as a negative: promote the entire
+        // active row space to candidates and let exact refinement settle it.
         //
-        // Padding beats asserting here: this is an expected upgrade state,
+        // The INDEX validity bitmap cannot be filled with true, though:
+        // Count() is an entry count while null offsets are absolute row ids, so
+        // a genuine NULL beyond Count() is absent from parameterless
+        // IsNotNull(). Filling it with true would turn NULL into non-NULL and
+        // make NOT ST_* return it as a match. Ask the index to project its
+        // absolute null offsets into the segment row space instead.
+        //
+        // Full refinement beats asserting here: this is an expected upgrade state,
         // not a Milvus bug, and failing every geometry query on the segment
         // until someone manually rebuilds the index is a far worse outcome
         // than a slightly slower correct answer.
@@ -542,8 +548,9 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
             if (ShouldLogGeometryThrottled(last_short_index_log_us)) {
                 LOG_WARN(
                     "R-Tree index for field {} reports {} rows but the "
-                    "segment holds {}; treating the {} unindexed rows as "
-                    "candidates for exact refinement. This index predates "
+                    "segment holds {}; treating all segment rows as "
+                    "candidates for exact refinement because the {} missing "
+                    "entries may be interior holes. This index predates "
                     "placeholder-MBR indexing of empty/unparseable "
                     "geometries -- rebuild it to avoid the extra refinement "
                     "(further occurrences suppressed briefly).",
@@ -552,12 +559,13 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                     active_count_,
                     active_count_ - coarse_rows);
             }
-            coarse_global_.resize(active_count_, true);
+            coarse_global_ = TargetBitmap(active_count_, true);
 
             // null_offset_ uses absolute segment row ids, while Count() on a
             // legacy index can under-report after older builders dropped
             // non-null empty/corrupt rows. Ask the R-Tree to lay validity out
-            // directly in the segment row space so tail NULL offsets survive.
+            // directly in the segment row space so every absolute NULL offset
+            // survives independently of the short entry count.
             coarse_valid_global_ = idx_ptr->IsNotNull(active_count_);
         } else {
             coarse_valid_global_ = idx_ptr->IsNotNull();
@@ -677,8 +685,8 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
             std::min(size_per_chunk_ - data_pos, batch_size_ - processed_rows);
 
         // Backstop only. The known cause of a short coarse bitmap -- a
-        // legacy index that under-reports its row count -- is padded up to
-        // active_count_ where the bitmap is built, so reaching this means
+        // legacy index that under-reports its row count -- is expanded to the
+        // full active row space where the bitmap is built, so reaching this means
         // something else is wrong. TargetBitmap::append range-checks only its
         // start offset, never start + count, so an unchecked short bitmap
         // would be read past the end.

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -52,10 +52,7 @@ namespace exec {
                                     const Geometry& right_source) {              \
         AssertInfo(segment_offsets != nullptr,                                   \
                    "segment_offsets should not be nullptr");                     \
-        auto geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(   \
-            this->segment_->segment_instance_uid(),                              \
-            this->segment_->get_segment_id(),                                    \
-            field_id_);                                                          \
+        auto geometry_cache = this->segment_->GetGeometryCache(field_id_);       \
         if (geometry_cache) {                                                    \
             auto cache_lock = geometry_cache->AcquireReadLock();                 \
             /* Cache-owned geometries share one GEOS context; drive the        \
@@ -123,10 +120,7 @@ namespace exec {
                                     const Geometry& right_source) {              \
         AssertInfo(segment_offsets != nullptr,                                   \
                    "segment_offsets should not be nullptr");                     \
-        auto geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(   \
-            this->segment_->segment_instance_uid(),                              \
-            this->segment_->get_segment_id(),                                    \
-            field_id_);                                                          \
+        auto geometry_cache = this->segment_->GetGeometryCache(field_id_);       \
         if (geometry_cache) {                                                    \
             auto cache_lock = geometry_cache->AcquireReadLock();                 \
             /* Cache-owned geometries share one GEOS context; drive the        \
@@ -189,10 +183,7 @@ namespace exec {
                                     TargetBitmapView valid_res) {                \
         AssertInfo(segment_offsets != nullptr,                                   \
                    "segment_offsets should not be nullptr");                     \
-        auto geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(   \
-            this->segment_->segment_instance_uid(),                              \
-            this->segment_->get_segment_id(),                                    \
-            field_id_);                                                          \
+        auto geometry_cache = this->segment_->GetGeometryCache(field_id_);       \
         if (geometry_cache) {                                                    \
             auto cache_lock = geometry_cache->AcquireReadLock();                 \
             /* Cache-owned geometries share one GEOS context; drive the        \
@@ -528,23 +519,18 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
             auto tmp = idx_ptr->Query(ds);
             coarse_global_ = std::move(tmp);
         }
-        {
-            auto tmp_valid = idx_ptr->IsNotNull();
-            coarse_valid_global_ = std::move(tmp_valid);
-        }
-
         // Self-heal an index that reports fewer rows than the segment holds.
         //
         // RTreeIndex::Load recomputes the row count from the deserialized
         // tree, so an index built before empty/unparseable geometries were
-        // kept as placeholder entries under-reports by exactly the rows that
-        // build dropped -- and those are always NON-NULL rows with an empty
-        // or corrupt payload (genuinely null rows went to null_offset_ and
-        // are counted). Treat the missing tail as candidates and let exact
-        // refinement settle it: refinement fails to parse those payloads and
-        // rejects them, which is precisely the verdict a freshly built index
-        // produces via its placeholder MBR. Results therefore match a rebuilt
-        // index; the only cost is refining a few extra rows.
+        // kept as placeholder entries under-reports the segment row space.
+        // Treat the missing tail as candidates and let exact refinement settle
+        // it. The INDEX validity bitmap cannot be padded, though: Count() is an
+        // entry count while null offsets are absolute row ids, so a genuine
+        // NULL in the truncated tail is absent from IsNotNull(). Filling that
+        // tail with true would turn NULL into non-NULL and make NOT ST_* return
+        // it as a match. Ask the index to project its absolute null offsets
+        // into the segment row space instead.
         //
         // Padding beats asserting here: this is an expected upgrade state,
         // not a Milvus bug, and failing every geometry query on the segment
@@ -567,7 +553,14 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                     active_count_ - coarse_rows);
             }
             coarse_global_.resize(active_count_, true);
-            coarse_valid_global_.resize(active_count_, true);
+
+            // null_offset_ uses absolute segment row ids, while Count() on a
+            // legacy index can under-report after older builders dropped
+            // non-null empty/corrupt rows. Ask the R-Tree to lay validity out
+            // directly in the segment row space so tail NULL offsets survive.
+            coarse_valid_global_ = idx_ptr->IsNotNull(active_count_);
+        } else {
+            coarse_valid_global_ = idx_ptr->IsNotNull();
         }
 
         coarse_cached_ = true;
@@ -600,11 +593,7 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                 return;
 
             // Get simple geometry cache for this segment+field
-            auto geometry_cache =
-                SimpleGeometryCacheManager::Instance().GetCache(
-                    segment_->segment_instance_uid(),
-                    segment_->get_segment_id(),
-                    field_id_);
+            auto geometry_cache = segment_->GetGeometryCache(field_id_);
             if (geometry_cache) {
                 auto cache_lock = geometry_cache->AcquireReadLock();
                 for (size_t i = 0; i < hit_offsets.size(); ++i) {

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.cpp
@@ -31,6 +31,7 @@
 #include "index/Index.h"
 #include "index/Meta.h"
 #include "index/ScalarIndex.h"
+#include "log/Log.h"
 #include "knowhere/dataset.h"
 #include "pb/plan.pb.h"
 #include "pb/schema.pb.h"
@@ -40,155 +41,207 @@
 namespace milvus {
 namespace exec {
 
-#define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON(_DataType, method)       \
-    auto execute_sub_batch = [this](const _DataType* data,                  \
-                                    const bool* valid_data,                 \
-                                    const int32_t* offsets,                 \
-                                    const int32_t* segment_offsets,         \
-                                    const int size,                         \
-                                    TargetBitmapView res,                   \
-                                    TargetBitmapView valid_res,             \
-                                    const Geometry& right_source) {         \
-        AssertInfo(segment_offsets != nullptr,                              \
-                   "segment_offsets should not be nullptr");                \
-        auto* geometry_cache =                                              \
-            SimpleGeometryCacheManager::Instance().GetCache(                \
-                this->segment_->get_segment_id(), field_id_);               \
-        if (geometry_cache) {                                               \
-            auto cache_lock = geometry_cache->AcquireReadLock();            \
-            for (int i = 0; i < size; ++i) {                                \
-                if (valid_data != nullptr && !valid_data[i]) {              \
-                    res[i] = valid_res[i] = false;                          \
-                    continue;                                               \
-                }                                                           \
-                auto absolute_offset = segment_offsets[i];                  \
-                auto cached_geometry =                                      \
-                    geometry_cache->GetByOffsetUnsafe(absolute_offset);     \
-                AssertInfo(cached_geometry != nullptr,                      \
-                           "cached geometry is nullptr");                   \
-                res[i] = cached_geometry->method(right_source);             \
-            }                                                               \
-        } else {                                                            \
-            GEOSContextHandle_t ctx_ = GEOS_init_r();                       \
-            for (int i = 0; i < size; ++i) {                                \
-                if (valid_data != nullptr && !valid_data[i]) {              \
-                    res[i] = valid_res[i] = false;                          \
-                    continue;                                               \
-                }                                                           \
-                res[i] = Geometry(ctx_, data[i].data(), data[i].size())     \
-                             .method(right_source);                         \
-            }                                                               \
-            GEOS_finish_r(ctx_);                                            \
-        }                                                                   \
-    };                                                                      \
-    int64_t processed_size = ProcessDataChunks<_DataType, true>(            \
-        execute_sub_batch, std::nullptr_t{}, res, valid_res, right_source); \
-    AssertInfo(processed_size == real_batch_size,                           \
-               "internal error: expr processed rows {} not equal "          \
-               "expect batch size {}",                                      \
-               processed_size,                                              \
-               real_batch_size);                                            \
+#define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON(_DataType, method)            \
+    auto execute_sub_batch = [this](const _DataType* data,                       \
+                                    const bool* valid_data,                      \
+                                    const int32_t* offsets,                      \
+                                    const int32_t* segment_offsets,              \
+                                    const int size,                              \
+                                    TargetBitmapView res,                        \
+                                    TargetBitmapView valid_res,                  \
+                                    const Geometry& right_source) {              \
+        AssertInfo(segment_offsets != nullptr,                                   \
+                   "segment_offsets should not be nullptr");                     \
+        auto geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(   \
+            this->segment_->segment_instance_uid(),                              \
+            this->segment_->get_segment_id(),                                    \
+            field_id_);                                                          \
+        if (geometry_cache) {                                                    \
+            auto cache_lock = geometry_cache->AcquireReadLock();                 \
+            /* Cache-owned geometries share one GEOS context; drive the        \
+             * predicate on a per-thread context so concurrent read-locked      \
+             * queries never touch the same non-thread-safe context. */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data != nullptr && !valid_data[i]) {                   \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                auto absolute_offset = segment_offsets[i];                       \
+                auto cached_geometry =                                           \
+                    geometry_cache->GetByOffsetUnsafe(absolute_offset);          \
+                /* nullptr = empty/corrupt placeholder row (the write paths    \
+                 * keep such rows, see SimpleGeometryCache::AppendDataAt); it   \
+                 * can never satisfy the predicate, so evaluate it to false     \
+                 * instead of failing the whole query. */ \
+                if (cached_geometry == nullptr) {                                \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = cached_geometry->method(right_source, tls_ctx);         \
+            }                                                                    \
+        } else {                                                                 \
+            /* Thread-local context: a throwing row can no longer leak a       \
+             * per-batch GEOS_init_r context. TryParseFromWkb throws only on    \
+             * pre-parse allocation failure; a corrupt/placeholder WKB row --   \
+             * or a GEOS-swallowed parse-time OOM, indistinguishable from it    \
+             * (see the KNOWN LIMIT note on TryParseFromWkb) -- evaluates to    \
+             * false, matching the cache branch above. */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data != nullptr && !valid_data[i]) {                   \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                Geometry left;                                                   \
+                if (!left.TryParseFromWkb(                                       \
+                        tls_ctx, data[i].data(), data[i].size())) {              \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = left.method(right_source, tls_ctx);                     \
+            }                                                                    \
+        }                                                                        \
+    };                                                                           \
+    int64_t processed_size = ProcessDataChunks<_DataType, true>(                 \
+        execute_sub_batch, std::nullptr_t{}, res, valid_res, right_source);      \
+    AssertInfo(processed_size == real_batch_size,                                \
+               "internal error: expr processed rows {} not equal "               \
+               "expect batch size {}",                                           \
+               processed_size,                                                   \
+               real_batch_size);                                                 \
     return res_vec;
 // Specialized macro for distance-based operations (ST_DWITHIN)
-#define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON_DISTANCE(_DataType, method) \
-    auto execute_sub_batch = [this](const _DataType* data,                     \
-                                    const bool* valid_data,                    \
-                                    const int32_t* offsets,                    \
-                                    const int32_t* segment_offsets,            \
-                                    const int size,                            \
-                                    TargetBitmapView res,                      \
-                                    TargetBitmapView valid_res,                \
-                                    const Geometry& right_source) {            \
-        AssertInfo(segment_offsets != nullptr,                                 \
-                   "segment_offsets should not be nullptr");                   \
-        auto* geometry_cache =                                                 \
-            SimpleGeometryCacheManager::Instance().GetCache(                   \
-                this->segment_->get_segment_id(), field_id_);                  \
-        if (geometry_cache) {                                                  \
-            auto cache_lock = geometry_cache->AcquireReadLock();               \
-            for (int i = 0; i < size; ++i) {                                   \
-                if (valid_data != nullptr && !valid_data[i]) {                 \
-                    res[i] = valid_res[i] = false;                             \
-                    continue;                                                  \
-                }                                                              \
-                auto absolute_offset = segment_offsets[i];                     \
-                auto cached_geometry =                                         \
-                    geometry_cache->GetByOffsetUnsafe(absolute_offset);        \
-                AssertInfo(cached_geometry != nullptr,                         \
-                           "cached geometry is nullptr");                      \
-                res[i] =                                                       \
-                    cached_geometry->method(right_source, expr_->distance_);   \
-            }                                                                  \
-        } else {                                                               \
-            GEOSContextHandle_t ctx_ = GEOS_init_r();                          \
-            for (int i = 0; i < size; ++i) {                                   \
-                if (valid_data != nullptr && !valid_data[i]) {                 \
-                    res[i] = valid_res[i] = false;                             \
-                    continue;                                                  \
-                }                                                              \
-                res[i] = Geometry(ctx_, data[i].data(), data[i].size())        \
-                             .method(right_source, expr_->distance_);          \
-            }                                                                  \
-            GEOS_finish_r(ctx_);                                               \
-        }                                                                      \
-    };                                                                         \
-    int64_t processed_size = ProcessDataChunks<_DataType, true>(               \
-        execute_sub_batch, std::nullptr_t{}, res, valid_res, right_source);    \
-    AssertInfo(processed_size == real_batch_size,                              \
-               "internal error: expr processed rows {} not equal "             \
-               "expect batch size {}",                                         \
-               processed_size,                                                 \
-               real_batch_size);                                               \
+#define GEOMETRY_EXECUTE_SUB_BATCH_WITH_COMPARISON_DISTANCE(_DataType, method)   \
+    auto execute_sub_batch = [this](const _DataType* data,                       \
+                                    const bool* valid_data,                      \
+                                    const int32_t* offsets,                      \
+                                    const int32_t* segment_offsets,              \
+                                    const int size,                              \
+                                    TargetBitmapView res,                        \
+                                    TargetBitmapView valid_res,                  \
+                                    const Geometry& right_source) {              \
+        AssertInfo(segment_offsets != nullptr,                                   \
+                   "segment_offsets should not be nullptr");                     \
+        auto geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(   \
+            this->segment_->segment_instance_uid(),                              \
+            this->segment_->get_segment_id(),                                    \
+            field_id_);                                                          \
+        if (geometry_cache) {                                                    \
+            auto cache_lock = geometry_cache->AcquireReadLock();                 \
+            /* Cache-owned geometries share one GEOS context; drive the        \
+             * predicate on a per-thread context so concurrent read-locked      \
+             * queries never touch the same non-thread-safe context. */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data != nullptr && !valid_data[i]) {                   \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                auto absolute_offset = segment_offsets[i];                       \
+                auto cached_geometry =                                           \
+                    geometry_cache->GetByOffsetUnsafe(absolute_offset);          \
+                /* nullptr = empty/corrupt placeholder row: evaluate to false  \
+                 * instead of failing the query (see the comparison macro). */ \
+                if (cached_geometry == nullptr) {                                \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = cached_geometry->method(                                \
+                    right_source, expr_->distance_, tls_ctx);                    \
+            }                                                                    \
+        } else {                                                                 \
+            /* Thread-local context + non-throwing parse: no context leak,     \
+             * corrupt rows evaluate to false (see the comparison macro). */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data != nullptr && !valid_data[i]) {                   \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                Geometry left;                                                   \
+                if (!left.TryParseFromWkb(                                       \
+                        tls_ctx, data[i].data(), data[i].size())) {              \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = left.method(right_source, expr_->distance_, tls_ctx);   \
+            }                                                                    \
+        }                                                                        \
+    };                                                                           \
+    int64_t processed_size = ProcessDataChunks<_DataType, true>(                 \
+        execute_sub_batch, std::nullptr_t{}, res, valid_res, right_source);      \
+    AssertInfo(processed_size == real_batch_size,                                \
+               "internal error: expr processed rows {} not equal "               \
+               "expect batch size {}",                                           \
+               processed_size,                                                   \
+               real_batch_size);                                                 \
     return res_vec;
 
 // Macro for unary operations (like IsValid) that don't need a right_source
-#define GEOMETRY_EXECUTE_SUB_BATCH_UNARY(_DataType, method)                  \
-    auto execute_sub_batch = [this](const _DataType* data,                   \
-                                    const bool* valid_data,                  \
-                                    const int32_t* offsets,                  \
-                                    const int32_t* segment_offsets,          \
-                                    const int size,                          \
-                                    TargetBitmapView res,                    \
-                                    TargetBitmapView valid_res) {            \
-        AssertInfo(segment_offsets != nullptr,                               \
-                   "segment_offsets should not be nullptr");                 \
-        auto* geometry_cache =                                               \
-            SimpleGeometryCacheManager::Instance().GetCache(                 \
-                this->segment_->get_segment_id(), field_id_);                \
-        if (geometry_cache) {                                                \
-            auto cache_lock = geometry_cache->AcquireReadLock();             \
-            for (int i = 0; i < size; ++i) {                                 \
-                if (valid_data != nullptr && !valid_data[i]) {               \
-                    res[i] = valid_res[i] = false;                           \
-                    continue;                                                \
-                }                                                            \
-                auto absolute_offset = segment_offsets[i];                   \
-                auto cached_geometry =                                       \
-                    geometry_cache->GetByOffsetUnsafe(absolute_offset);      \
-                AssertInfo(cached_geometry != nullptr,                       \
-                           "cached geometry is nullptr");                    \
-                res[i] = cached_geometry->method();                          \
-            }                                                                \
-        } else {                                                             \
-            GEOSContextHandle_t ctx_ = GEOS_init_r();                        \
-            for (int i = 0; i < size; ++i) {                                 \
-                if (valid_data != nullptr && !valid_data[i]) {               \
-                    res[i] = valid_res[i] = false;                           \
-                    continue;                                                \
-                }                                                            \
-                res[i] =                                                     \
-                    Geometry(ctx_, data[i].data(), data[i].size()).method(); \
-            }                                                                \
-            GEOS_finish_r(ctx_);                                             \
-        }                                                                    \
-    };                                                                       \
-    int64_t processed_size = ProcessDataChunks<_DataType, true>(             \
-        execute_sub_batch, std::nullptr_t{}, res, valid_res);                \
-    AssertInfo(processed_size == real_batch_size,                            \
-               "internal error: expr processed rows {} not equal "           \
-               "expect batch size {}",                                       \
-               processed_size,                                               \
-               real_batch_size);                                             \
+#define GEOMETRY_EXECUTE_SUB_BATCH_UNARY(_DataType, method)                      \
+    auto execute_sub_batch = [this](const _DataType* data,                       \
+                                    const bool* valid_data,                      \
+                                    const int32_t* offsets,                      \
+                                    const int32_t* segment_offsets,              \
+                                    const int size,                              \
+                                    TargetBitmapView res,                        \
+                                    TargetBitmapView valid_res) {                \
+        AssertInfo(segment_offsets != nullptr,                                   \
+                   "segment_offsets should not be nullptr");                     \
+        auto geometry_cache = SimpleGeometryCacheManager::Instance().GetCache(   \
+            this->segment_->segment_instance_uid(),                              \
+            this->segment_->get_segment_id(),                                    \
+            field_id_);                                                          \
+        if (geometry_cache) {                                                    \
+            auto cache_lock = geometry_cache->AcquireReadLock();                 \
+            /* Cache-owned geometries share one GEOS context; drive the        \
+             * predicate on a per-thread context so concurrent read-locked      \
+             * queries never touch the same non-thread-safe context. */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data != nullptr && !valid_data[i]) {                   \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                auto absolute_offset = segment_offsets[i];                       \
+                auto cached_geometry =                                           \
+                    geometry_cache->GetByOffsetUnsafe(absolute_offset);          \
+                /* nullptr = empty/corrupt placeholder row: it is not a valid  \
+                 * geometry, so the unary predicate is false (see the           \
+                 * comparison macro). */ \
+                if (cached_geometry == nullptr) {                                \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = cached_geometry->method(tls_ctx);                       \
+            }                                                                    \
+        } else {                                                                 \
+            /* Thread-local context + non-throwing parse: no context leak,     \
+             * corrupt rows evaluate to false (see the comparison macro). */ \
+            GEOSContextHandle_t tls_ctx = GetThreadLocalGEOSContext();           \
+            for (int i = 0; i < size; ++i) {                                     \
+                if (valid_data != nullptr && !valid_data[i]) {                   \
+                    res[i] = valid_res[i] = false;                               \
+                    continue;                                                    \
+                }                                                                \
+                Geometry left;                                                   \
+                if (!left.TryParseFromWkb(                                       \
+                        tls_ctx, data[i].data(), data[i].size())) {              \
+                    res[i] = false;                                              \
+                    continue;                                                    \
+                }                                                                \
+                res[i] = left.method(tls_ctx);                                   \
+            }                                                                    \
+        }                                                                        \
+    };                                                                           \
+    int64_t processed_size = ProcessDataChunks<_DataType, true>(                 \
+        execute_sub_batch, std::nullptr_t{}, res, valid_res);                    \
+    AssertInfo(processed_size == real_batch_size,                                \
+               "internal error: expr processed rows {} not equal "               \
+               "expect batch size {}",                                           \
+               processed_size,                                                   \
+               real_batch_size);                                                 \
     return res_vec;
 
 void
@@ -426,10 +479,20 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
     // - contains/within swap: left.contains(query) == prepared_query.within(left)
     //                         left.within(query) == prepared_query.contains(left)
     // - equals, dwithin: no prepared version, fall back to regular Geometry
-    auto evaluate_geometry_prepared =
-        [this, &prepared_query, &query_geometry](const Geometry& left) -> bool {
-        return EvaluateGISPreparedOp(
-            expr_->op_, prepared_query, query_geometry, left, expr_->distance_);
+    // `left` is frequently a cache-owned geometry whose stored context is
+    // shared across concurrent queries, so the unprepared fallbacks inside the
+    // helper must run on the per-thread context captured above rather than on
+    // left's own context.
+    auto evaluate_geometry_prepared = [this,
+                                       &prepared_query,
+                                       &query_geometry,
+                                       ctx](const Geometry& left) -> bool {
+        return EvaluateGISPreparedOp(expr_->op_,
+                                     prepared_query,
+                                     query_geometry,
+                                     left,
+                                     expr_->distance_,
+                                     ctx);
     };
 
     TargetBitmap batch_result;
@@ -470,6 +533,43 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
             coarse_valid_global_ = std::move(tmp_valid);
         }
 
+        // Self-heal an index that reports fewer rows than the segment holds.
+        //
+        // RTreeIndex::Load recomputes the row count from the deserialized
+        // tree, so an index built before empty/unparseable geometries were
+        // kept as placeholder entries under-reports by exactly the rows that
+        // build dropped -- and those are always NON-NULL rows with an empty
+        // or corrupt payload (genuinely null rows went to null_offset_ and
+        // are counted). Treat the missing tail as candidates and let exact
+        // refinement settle it: refinement fails to parse those payloads and
+        // rejects them, which is precisely the verdict a freshly built index
+        // produces via its placeholder MBR. Results therefore match a rebuilt
+        // index; the only cost is refining a few extra rows.
+        //
+        // Padding beats asserting here: this is an expected upgrade state,
+        // not a Milvus bug, and failing every geometry query on the segment
+        // until someone manually rebuilds the index is a far worse outcome
+        // than a slightly slower correct answer.
+        auto coarse_rows = static_cast<int64_t>(coarse_global_.size());
+        if (coarse_rows < active_count_) {
+            static std::atomic<int64_t> last_short_index_log_us{0};
+            if (ShouldLogGeometryThrottled(last_short_index_log_us)) {
+                LOG_WARN(
+                    "R-Tree index for field {} reports {} rows but the "
+                    "segment holds {}; treating the {} unindexed rows as "
+                    "candidates for exact refinement. This index predates "
+                    "placeholder-MBR indexing of empty/unparseable "
+                    "geometries -- rebuild it to avoid the extra refinement "
+                    "(further occurrences suppressed briefly).",
+                    field_id_.get(),
+                    coarse_rows,
+                    active_count_,
+                    active_count_ - coarse_rows);
+            }
+            coarse_global_.resize(active_count_, true);
+            coarse_valid_global_.resize(active_count_, true);
+        }
+
         coarse_cached_ = true;
     }
 
@@ -500,9 +600,11 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                 return;
 
             // Get simple geometry cache for this segment+field
-            auto* geometry_cache =
+            auto geometry_cache =
                 SimpleGeometryCacheManager::Instance().GetCache(
-                    segment_->get_segment_id(), field_id_);
+                    segment_->segment_instance_uid(),
+                    segment_->get_segment_id(),
+                    field_id_);
             if (geometry_cache) {
                 auto cache_lock = geometry_cache->AcquireReadLock();
                 for (size_t i = 0; i < hit_offsets.size(); ++i) {
@@ -540,7 +642,22 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
                     }
 
                     const auto& wkb_data = geometry_array->data(i);
-                    Geometry left(local_ctx, wkb_data.data(), wkb_data.size());
+                    Geometry left;
+                    if (!left.TryParseFromWkb(
+                            local_ctx, wkb_data.data(), wkb_data.size())) {
+                        // Unparseable WKB -- e.g. a placeholder row that
+                        // add_geometry / bulk_load keep (instead of dropping)
+                        // to hold the index row count. It can never satisfy
+                        // exact refinement, so skip it, mirroring the cache
+                        // branch's GetByOffsetUnsafe() == nullptr skip above.
+                        // MUST NOT throw: with the geometry cache off (the
+                        // default), such rows reach refinement as R-Tree
+                        // candidates whenever the query bbox covers the
+                        // placeholder MBR at the origin, and the throwing
+                        // Geometry(ctx, wkb) ctor would fail the entire query.
+                        // See PR #50951 review.
+                        continue;
+                    }
                     // Use prepared geometry for faster evaluation
                     bool result = evaluate_geometry_prepared(left);
 
@@ -561,9 +678,34 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
 
     if (segment_->type() == SegmentType::Sealed) {
         auto data_pos = current_index_chunk_pos_;
-        auto size = std::min(
-            std::min(size_per_chunk_ - data_pos, batch_size_ - processed_rows),
-            int64_t(cached_index_chunk_res_->size()));
+        // Batch size is driven by the SEGMENT's rows, deliberately not
+        // clamped to the coarse bitmap's length. Clamping here would silently
+        // truncate the batch whenever the index is short, which then trips
+        // the trailing processed_rows == real_batch_size assertion with a
+        // generic message and makes the diagnostic below unreachable (its
+        // predicate would be satisfied by construction).
+        auto size =
+            std::min(size_per_chunk_ - data_pos, batch_size_ - processed_rows);
+
+        // Backstop only. The known cause of a short coarse bitmap -- a
+        // legacy index that under-reports its row count -- is padded up to
+        // active_count_ where the bitmap is built, so reaching this means
+        // something else is wrong. TargetBitmap::append range-checks only its
+        // start offset, never start + count, so an unchecked short bitmap
+        // would be read past the end.
+        AssertInfo(
+            data_pos >= 0 && size >= 0 &&
+                data_pos + size <=
+                    static_cast<int64_t>(cached_index_chunk_res_->size()) &&
+                data_pos + size <=
+                    static_cast<int64_t>(coarse_valid_global_.size()),
+            "sealed geometry coarse bitmap too small: pos {} + size {} "
+            "exceeds result {} / valid {} even after padding the coarse "
+            "bitmap to the segment's active row count.",
+            data_pos,
+            size,
+            cached_index_chunk_res_->size(),
+            coarse_valid_global_.size());
 
         batch_result.append(*cached_index_chunk_res_, data_pos, size);
         batch_valid.append(coarse_valid_global_, data_pos, size);
@@ -577,6 +719,32 @@ PhyGISFunctionFilterExpr::EvalForIndexSegment() {
             size = std::min(size, real_batch_size - processed_rows);
 
             if (size > 0) {
+                // The coarse bitmaps are sized by the index row count
+                // (RTreeIndex::Count()), while `size` is driven by the
+                // segment's active rows. The Insert path indexes a row
+                // (AppendingIndex) before the ack-responder makes it
+                // searchable, and neither write path drops a row -- both
+                // add_geometry and bulk_load_from_field_data index a
+                // placeholder MBR for empty/unparseable WKB rather than
+                // dropping it -- so active_count <=
+                // index Count() must always hold. Guard it explicitly: a violated
+                // invariant must surface as a clear error, never as an
+                // out-of-bounds read or fabricated results (a row reported
+                // result=false is a silent wrong answer, and flips to a false
+                // positive under a negated predicate).
+                AssertInfo(
+                    static_cast<int64_t>(current_index_chunk_pos_ + size) <=
+                            static_cast<int64_t>(
+                                cached_index_chunk_res_->size()) &&
+                        static_cast<int64_t>(current_index_chunk_pos_ + size) <=
+                            static_cast<int64_t>(coarse_valid_global_.size()),
+                    "growing geometry coarse bitmap too small: pos {} + size "
+                    "{} exceeds result {} / valid {} (index row count lagged "
+                    "segment active rows)",
+                    current_index_chunk_pos_,
+                    size,
+                    cached_index_chunk_res_->size(),
+                    coarse_valid_global_.size());
                 batch_result.append(
                     *cached_index_chunk_res_, current_index_chunk_pos_, size);
                 batch_valid.append(

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -44,12 +44,21 @@ namespace exec {
 // (PhyGISFunctionFilterExpr::EvalForIndexSegment) and the optimizer's fusion
 // path (PhyGISRefineConjunctExpr) stay in lockstep instead of drifting as new
 // GISOps are added.
+//
+// `ctx` MUST be the calling thread's GEOS context (GetThreadLocalGEOSContext).
+// The unprepared fallbacks (Equals, DWithin) would otherwise drive GEOS through
+// `left`'s own stored context, and `left` is frequently a cache-owned Geometry
+// whose context is shared by every concurrent query on that segment+field — a
+// GEOS context is not thread-safe, so that is a data race. The prepared
+// predicates are unaffected: they run on `prepared`'s context, which the caller
+// already built on its own thread.
 inline bool
 EvaluateGISPreparedOp(proto::plan::GISFunctionFilterExpr_GISOp op,
                       const PreparedGeometry& prepared,
                       const Geometry& query_geom,
                       const Geometry& left,
-                      double distance) {
+                      double distance,
+                      GEOSContextHandle_t ctx) {
     switch (op) {
         case proto::plan::GISFunctionFilterExpr_GISOp_Intersects:
             // Symmetric: prepared.intersects(left) == left.intersects(query)
@@ -67,15 +76,49 @@ EvaluateGISPreparedOp(proto::plan::GISFunctionFilterExpr_GISOp op,
             // left.within(query) == query.contains(left)
             return prepared.contains(left);
         case proto::plan::GISFunctionFilterExpr_GISOp_Equals:
-            // No prepared version - fall back to regular geometry.
-            return left.equals(query_geom);
+            // No prepared version - fall back to regular geometry, on the
+            // caller's per-thread context (see the note on `ctx` above).
+            return left.equals(query_geom, ctx);
         case proto::plan::GISFunctionFilterExpr_GISOp_DWithin:
-            // Distance-based operation - no prepared version.
-            return left.dwithin(query_geom, distance);
+            // Distance-based operation - no prepared version; same per-thread
+            // context requirement as Equals above.
+            return left.dwithin(query_geom, distance, ctx);
         default:
             ThrowInfo(
                 NotImplemented, "unknown GIS op : {}", static_cast<int>(op));
     }
+}
+
+// Promote a SHORT R-Tree coarse bitmap to the full active row space.
+//
+// The R-Tree Query() bitmap is sized by the index row count (Count()), while
+// callers combine it in the segment's active row space. When Count() <
+// active_count, the index predates placeholder-MBR indexing of
+// empty/unparseable geometries: those old builders advanced absolute_offset
+// even when they dropped a row, so the missing entries are INTERIOR holes, not
+// a trailing suffix. Count() reveals how many entries are missing, not where.
+// Once the index is short, therefore, no `false` bit in it is trustworthy as a
+// negative -- padding only the tail with 1s (resize(active_count, true)) would
+// leave interior holes false and silently drop matching rows. The only safe
+// coarse for such an index is the full row space; exact refinement settles it.
+//
+// Both consumers of an R-Tree coarse bitmap -- the per-predicate path
+// (PhyGISFunctionFilterExpr::EvalForIndexSegment) and the optimizer's fusion
+// path (PhyGISCoarseConjunctExpr::RunRTreeQuery) -- MUST route through this
+// helper so the short-index rule cannot drift between them again.
+//
+// Returns true when `coarse` was short and has been promoted; false when it
+// already spanned (at least) `active_count` rows and was left untouched.
+// Validity is deliberately NOT handled here: the per-predicate path needs
+// IsNotNull(active_count) (absolute null offsets survive independently of the
+// short entry count) while the fusion path derives nullness in Refine.
+inline bool
+PromoteShortGISCoarseBitmap(TargetBitmap& coarse, int64_t active_count) {
+    if (static_cast<int64_t>(coarse.size()) >= active_count) {
+        return false;
+    }
+    coarse = TargetBitmap(active_count, true);
+    return true;
 }
 
 class PhyGISFunctionFilterExpr : public SegmentExpr {

--- a/internal/core/src/exec/expression/GISFunctionFilterExpr.h
+++ b/internal/core/src/exec/expression/GISFunctionFilterExpr.h
@@ -44,12 +44,21 @@ namespace exec {
 // (PhyGISFunctionFilterExpr::EvalForIndexSegment) and the optimizer's fusion
 // path (PhyGISRefineConjunctExpr) stay in lockstep instead of drifting as new
 // GISOps are added.
+//
+// `ctx` MUST be the calling thread's GEOS context (GetThreadLocalGEOSContext).
+// The unprepared fallbacks (Equals, DWithin) would otherwise drive GEOS through
+// `left`'s own stored context, and `left` is frequently a cache-owned Geometry
+// whose context is shared by every concurrent query on that segment+field — a
+// GEOS context is not thread-safe, so that is a data race. The prepared
+// predicates are unaffected: they run on `prepared`'s context, which the caller
+// already built on its own thread.
 inline bool
 EvaluateGISPreparedOp(proto::plan::GISFunctionFilterExpr_GISOp op,
                       const PreparedGeometry& prepared,
                       const Geometry& query_geom,
                       const Geometry& left,
-                      double distance) {
+                      double distance,
+                      GEOSContextHandle_t ctx) {
     switch (op) {
         case proto::plan::GISFunctionFilterExpr_GISOp_Intersects:
             // Symmetric: prepared.intersects(left) == left.intersects(query)
@@ -67,11 +76,13 @@ EvaluateGISPreparedOp(proto::plan::GISFunctionFilterExpr_GISOp op,
             // left.within(query) == query.contains(left)
             return prepared.contains(left);
         case proto::plan::GISFunctionFilterExpr_GISOp_Equals:
-            // No prepared version - fall back to regular geometry.
-            return left.equals(query_geom);
+            // No prepared version - fall back to regular geometry, on the
+            // caller's per-thread context (see the note on `ctx` above).
+            return left.equals(query_geom, ctx);
         case proto::plan::GISFunctionFilterExpr_GISOp_DWithin:
-            // Distance-based operation - no prepared version.
-            return left.dwithin(query_geom, distance);
+            // Distance-based operation - no prepared version; same per-thread
+            // context requirement as Equals above.
+            return left.dwithin(query_geom, distance, ctx);
         default:
             ThrowInfo(
                 NotImplemented, "unknown GIS op : {}", static_cast<int>(op));

--- a/internal/core/src/index/BitmapIndex.h
+++ b/internal/core/src/index/BitmapIndex.h
@@ -107,6 +107,11 @@ class BitmapIndex : public ScalarIndex<T> {
     const TargetBitmap
     IsNull() override;
 
+    // Declaring IsNotNull() here hides the base's row-count-aware
+    // IsNotNull(int64_t) overload; keep it visible so a call through this
+    // static type still finds it.
+    using ScalarIndex<T>::IsNotNull;
+
     TargetBitmap
     IsNotNull() override;
 

--- a/internal/core/src/index/FMIndex.h
+++ b/internal/core/src/index/FMIndex.h
@@ -140,6 +140,11 @@ class FMIndex : public ScalarIndex<std::string> {
     const TargetBitmap
     IsNull() override;
 
+    // Declaring IsNotNull() here hides the base's row-count-aware
+    // IsNotNull(int64_t) overload; keep it visible so a call through this
+    // static type still finds it.
+    using ScalarIndex<std::string>::IsNotNull;
+
     TargetBitmap
     IsNotNull() override;
 

--- a/internal/core/src/index/HybridScalarIndex.h
+++ b/internal/core/src/index/HybridScalarIndex.h
@@ -109,6 +109,11 @@ class HybridScalarIndex : public ScalarIndex<T> {
         return internal_index_->IsNull();
     }
 
+    // Declaring IsNotNull() here hides the base's row-count-aware
+    // IsNotNull(int64_t) overload; keep it visible so a call through this
+    // static type still finds it.
+    using ScalarIndex<T>::IsNotNull;
+
     TargetBitmap
     IsNotNull() override {
         return internal_index_->IsNotNull();

--- a/internal/core/src/index/HybridScalarIndex.h
+++ b/internal/core/src/index/HybridScalarIndex.h
@@ -100,6 +100,11 @@ class HybridScalarIndex : public ScalarIndex<T> {
         return internal_index_->IsNull();
     }
 
+    // Declaring IsNotNull() here hides the base's row-count-aware
+    // IsNotNull(int64_t) overload; keep it visible so a call through this
+    // static type still finds it.
+    using ScalarIndex<T>::IsNotNull;
+
     TargetBitmap
     IsNotNull() override {
         return internal_index_->IsNotNull();

--- a/internal/core/src/index/InvertedIndexTantivy.h
+++ b/internal/core/src/index/InvertedIndexTantivy.h
@@ -173,6 +173,11 @@ class InvertedIndexTantivy : public ScalarIndex<T> {
     const TargetBitmap
     IsNull() override;
 
+    // Declaring IsNotNull() here hides the base's row-count-aware
+    // IsNotNull(int64_t) overload; keep it visible so a call through this
+    // static type still finds it.
+    using ScalarIndex<T>::IsNotNull;
+
     TargetBitmap
     IsNotNull() override;
 

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -114,6 +114,11 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         return bitset;
     }
 
+    // Declaring IsNotNull() here hides the base's row-count-aware
+    // IsNotNull(int64_t) overload; keep it visible so a call through this
+    // static type still finds it.
+    using InvertedIndexTantivy<T>::IsNotNull;
+
     TargetBitmap
     IsNotNull() override {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::IsNotNull",

--- a/internal/core/src/index/RTreeIndex.cpp
+++ b/internal/core/src/index/RTreeIndex.cpp
@@ -19,6 +19,7 @@
 #include <list>
 #include <map>
 #include <mutex>
+#include <new>
 #include <string_view>
 #include <shared_mutex>
 #include <utility>
@@ -72,22 +73,40 @@ ends_with(const std::string& value, const std::string& suffix) {
 template <typename T>
 void
 RTreeIndex<T>::InitForBuildIndex(bool is_growing) {
-    std::string index_file_path;
     if (is_growing) {
-        path_ = "";
-    } else {
-        auto prefix = disk_file_manager_->GetIndexIdentifier();
-        path_ = GetRTreeTempPrefix() + prefix;
-        boost::filesystem::create_directories(path_);
-        index_file_path = path_ + "/index_file";  // base path (no ext)
-        if (boost::filesystem::exists(index_file_path + ".bgi")) {
-            ThrowInfo(IndexBuildError,
-                      "build rtree index temp dir:{} not empty",
-                      path_);
+        // Concurrency model: production currently serializes writes to a
+        // growing segment (one flowgraph consumer per vchannel drives
+        // SegmentGrowingImpl::Insert, and recovery's LoadGrowing completes
+        // before consumption starts). The locking here is defense-in-depth
+        // honoring the segcore-level IndexingRecord::AppendingIndex contract
+        // ("concurrent, reentrant"), not a claim that production exercises
+        // multi-writer inserts today. Writers may still race concurrent
+        // READERS (search on the growing index), so the lazy first-time init
+        // stays idempotent under the write lock: the wrapper is created
+        // exactly once and readers never observe a torn shared_ptr.
+        std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        if (wrapper_) {
+            return;
         }
+        path_ = "";
+        std::string index_file_path;  // empty: in-memory growing wrapper
+        wrapper_ = std::make_shared<RTreeIndexWrapper>(index_file_path, true);
+        return;
     }
 
-    wrapper_ = std::make_shared<RTreeIndexWrapper>(index_file_path, true);
+    // Non-growing (build/load) path runs single-threaded.
+    auto prefix = disk_file_manager_->GetIndexIdentifier();
+    path_ = GetRTreeTempPrefix() + prefix;
+    boost::filesystem::create_directories(path_);
+    std::string index_file_path = path_ + "/index_file";  // base path (no ext)
+    if (boost::filesystem::exists(index_file_path + ".bgi")) {
+        ThrowInfo(
+            IndexBuildError, "build rtree index temp dir:{} not empty", path_);
+    }
+
+    auto wrapper = std::make_shared<RTreeIndexWrapper>(index_file_path, true);
+    std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
+    wrapper_ = std::move(wrapper);
 }
 
 template <typename T>
@@ -151,6 +170,15 @@ RTreeIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
         };
 
         auto fill_null_offsets = [&](const uint8_t* data, int64_t size) {
+            // null_offset is a size_t[] payload; its byte length must be a
+            // multiple of sizeof(size_t). Otherwise resize() truncates the
+            // destination while FastMemcpy still copies `size` bytes, writing
+            // past the buffer. Reject a malformed/truncated sidecar instead.
+            AssertInfo((size_t)size % sizeof(size_t) == 0,
+                       "corrupt R-Tree null_offset payload: byte size {} is "
+                       "not a multiple of {}",
+                       size,
+                       sizeof(size_t));
             std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
             null_offset_.resize((size_t)size / sizeof(size_t));
             milvus::fastmem::FastMemcpy(
@@ -262,14 +290,22 @@ RTreeIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
     }
     path_ = base_path;
 
-    // 5. Instantiate wrapper and load.
-    wrapper_ =
+    // 5. Instantiate wrapper and load it fully BEFORE publishing, then
+    // publish every member under the same lock the readers take (Count /
+    // QueryCandidates / ComputeByteSize snapshot wrapper_ under mutex_):
+    // the no-torn-read invariant only holds if every writer participates,
+    // exactly as the growing publish in InitForBuildIndex does.
+    auto wrapper =
         std::make_shared<RTreeIndexWrapper>(path_, /*is_build_mode=*/false);
-    wrapper_->load();
+    wrapper->load();
 
-    total_num_rows_ =
-        wrapper_->count() + static_cast<int64_t>(null_offset_.size());
-    is_built_ = true;
+    {
+        std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        wrapper_ = wrapper;
+        total_num_rows_ =
+            wrapper->count() + static_cast<int64_t>(null_offset_.size());
+        is_built_ = true;
+    }
     ComputeByteSize();
 
     LOG_INFO(
@@ -434,10 +470,18 @@ RTreeIndex<T>::IsNull() {
     int64_t count = Count();
     TargetBitmap bitset(count);
     std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
-    auto end = std::lower_bound(
-        null_offset_.begin(), null_offset_.end(), static_cast<size_t>(count));
-    for (auto it = null_offset_.begin(); it != end; ++it) {
-        bitset.set(*it);
+    // null_offset_ is not guaranteed to be sorted by construction: AddGeometry
+    // appends offsets in arrival order, and while production currently
+    // serializes inserts per growing segment (so the order is monotonic
+    // today), nothing in this class enforces it. A std::lower_bound shortcut
+    // would silently rely on that external property and could leave in-range
+    // offsets past the bound (or, worse, iterate offsets >= count).
+    // Bounds-check each element instead so an out-of-range offset can never
+    // write past the bitset.
+    for (auto off : null_offset_) {
+        if (off < static_cast<size_t>(count)) {
+            bitset.set(off);
+        }
     }
     return bitset;
 }
@@ -445,13 +489,23 @@ RTreeIndex<T>::IsNull() {
 template <typename T>
 TargetBitmap
 RTreeIndex<T>::IsNotNull() {
-    int64_t count = Count();
-    TargetBitmap bitset(count, true);
+    return IsNotNull(Count());
+}
+
+template <typename T>
+TargetBitmap
+RTreeIndex<T>::IsNotNull(int64_t row_count) {
+    AssertInfo(row_count >= 0,
+               "R-Tree validity row count must be non-negative, got {}",
+               row_count);
+    TargetBitmap bitset(row_count, true);
     std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
-    auto end = std::lower_bound(
-        null_offset_.begin(), null_offset_.end(), static_cast<size_t>(count));
-    for (auto it = null_offset_.begin(); it != end; ++it) {
-        bitset.reset(*it);
+    // See IsNull(): null_offset_ is not sorted by construction, so
+    // bounds-check every offset rather than relying on a sorted-range shortcut.
+    for (auto off : null_offset_) {
+        if (off < static_cast<size_t>(row_count)) {
+            bitset.reset(off);
+        }
     }
     return bitset;
 }
@@ -505,41 +559,69 @@ RTreeIndex<T>::Range(const T& lower_bound_value,
 template <typename T>
 void
 RTreeIndex<T>::QueryCandidates(proto::plan::GISFunctionFilterExpr_GISOp op,
-                               const Geometry query_geometry,
+                               const Geometry& query_geometry,
                                std::vector<int64_t>& candidate_offsets) {
-    AssertInfo(wrapper_ != nullptr, "R-Tree index wrapper is null");
+    // Snapshot wrapper_ under the shared lock: on a growing segment it is
+    // published lazily by InitForBuildIndex() under the write lock, so an
+    // unsynchronized read here could observe a torn shared_ptr.
+    std::shared_ptr<RTreeIndexWrapper> wrapper;
+    {
+        std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        wrapper = wrapper_;
+    }
+    AssertInfo(wrapper != nullptr, "R-Tree index wrapper is null");
 
-    // Create GEOS context and ensure it's properly released
-    GEOSContextHandle_t ctx = GEOS_init_r();
+    // Scoped GEOS context: InitGEOSContext throws a retriable
+    // MemAllocateFailed on OOM instead of handing a null context to
+    // query_candidates, and the RAII guard releases the context even when
+    // query_candidates throws (e.g. candidate_offsets growth hitting
+    // bad_alloc, or an AssertInfo on the query geometry) -- a trailing
+    // GEOS_finish_r would leak once per failed query.
+    ScopedGeosResources geos("query_candidates");
 
-    wrapper_->query_candidates(
-        op, query_geometry.GetGeometry(), ctx, candidate_offsets);
-    GEOS_finish_r(ctx);
+    wrapper->query_candidates(
+        op, query_geometry.GetGeometry(), geos.ctx, candidate_offsets);
 }
 
 template <typename T>
 const TargetBitmap
 RTreeIndex<T>::Query(const DatasetPtr& dataset) {
-    AssertInfo(schema_.data_type() == proto::schema::DataType::Geometry,
-               "RTreeIndex can only be queried on geometry field");
-    auto op =
-        dataset->Get<proto::plan::GISFunctionFilterExpr_GISOp>(OPERATOR_TYPE);
-    // Query geometry WKB passed via MATCH_VALUE as std::string
-    auto geometry = dataset->Get<Geometry>(MATCH_VALUE);
+    try {
+        AssertInfo(schema_.data_type() == proto::schema::DataType::Geometry,
+                   "RTreeIndex can only be queried on geometry field");
+        auto op = dataset->Get<proto::plan::GISFunctionFilterExpr_GISOp>(
+            OPERATOR_TYPE);
+        // Query geometry WKB passed via MATCH_VALUE as std::string
+        auto geometry = dataset->Get<Geometry>(MATCH_VALUE);
 
-    // 1) Coarse candidates by R-Tree on MBR
-    std::vector<int64_t> candidate_offsets;
-    QueryCandidates(op, geometry, candidate_offsets);
+        // 1) Coarse candidates by R-Tree on MBR
+        std::vector<int64_t> candidate_offsets;
+        QueryCandidates(op, geometry, candidate_offsets);
 
-    // 2) Build initial bitmap from candidates
-    TargetBitmap res(this->Count());
-    for (auto off : candidate_offsets) {
-        if (off >= 0 && off < res.size()) {
-            res.set(off);
+        // 2) Build initial bitmap from candidates
+        // Count() reports the row space (max(total_num_rows_, indexed)), so a
+        // candidate below the row count can no longer be clipped away. It is
+        // also snapshotted AFTER QueryCandidates() returned, so on a growing
+        // index any row a writer published while the query ran is already
+        // covered by the bitmap size. The `off < res.size()` bound is thus a
+        // pure backstop rather than a race guard. It stays silent instead of
+        // asserting because, should it ever trip, dropping the row is the
+        // safe direction: a candidate the row space does not yet account for
+        // cannot be visible to this query's timestamp either.
+        TargetBitmap res(this->Count());
+        for (auto off : candidate_offsets) {
+            if (off >= 0 && off < res.size()) {
+                res.set(off);
+            }
         }
-    }
 
-    return res;
+        return res;
+    } catch (const SegcoreError&) {
+        throw;
+    } catch (const std::bad_alloc&) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory querying R-Tree index");
+    }
 }
 
 // ------------------------------------------------------------------
@@ -605,25 +687,52 @@ RTreeIndex<T>::BuildWithStrings(const std::vector<std::string>& geometries) {
 
 template <typename T>
 void
-RTreeIndex<T>::AddGeometry(const std::string& wkb_data, int64_t row_offset) {
-    if (!wrapper_) {
-        // Initialize if not already done
-        this->InitForBuildIndex(true);
+RTreeIndex<T>::AddGeometry(const std::string& wkb_data,
+                           int64_t row_offset,
+                           bool is_valid) {
+    // Snapshot wrapper_ under the lock; lazily (and idempotently) initialize it
+    // if this is the first insert. Production serializes inserts per growing
+    // segment (see InitForBuildIndex), but AddGeometry races concurrent
+    // READERS and the AppendingIndex contract permits concurrent writers, so
+    // wrapper_ must never be read or published unlocked.
+    std::shared_ptr<RTreeIndexWrapper> wrapper;
+    {
+        std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        wrapper = wrapper_;
+    }
+    if (!wrapper) {
+        this->InitForBuildIndex(true);  // idempotent under the write lock
+        std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        wrapper = wrapper_;
     }
 
-    if (!wkb_data.empty()) {
+    // Nullness is decided by is_valid alone, never by the payload: a valid row
+    // with an empty/unparseable WKB gets a placeholder MBR from add_geometry,
+    // keeping growing consistent with the sealed bulk_load classification.
+    if (is_valid) {
         const uint8_t* data_ptr =
             reinterpret_cast<const uint8_t*>(wkb_data.data());
-        wrapper_->add_geometry(data_ptr, wkb_data.size(), row_offset);
+        wrapper->add_geometry(data_ptr, wkb_data.size(), row_offset);
 
-        // Update total row count
-        if (row_offset >= total_num_rows_) {
-            total_num_rows_ = row_offset + 1;
+        // Update total row count under the same lock that guards readers
+        // (Count/NumRows), so the non-null path is symmetric with the null
+        // path below and never races a concurrent search on the growing index.
+        {
+            std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
+            if (row_offset >= total_num_rows_) {
+                total_num_rows_ = row_offset + 1;
+            }
         }
 
         LOG_DEBUG("Added geometry at row offset {}", row_offset);
     } else {
-        // Handle null geometry
+        // Handle null geometry. Deliberately not deduplicated: no production
+        // path re-drives a failed batch into this same index object (the
+        // insert path panics in the delegator, the growing load path has no
+        // retry loop and a re-issued LoadSegments builds a fresh segment), so
+        // a dedup set would cost one entry per null row forever to guard a
+        // case that cannot occur. See insert_value_locked's note in
+        // RTreeIndexWrapper.h.
         std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
         null_offset_.push_back(static_cast<size_t>(row_offset));
 
@@ -711,6 +820,14 @@ RTreeIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
 
     if (has_null) {
         auto null_entry = reader.ReadEntry("index_null_offset");
+        // See fill_null_offsets in Load(): the payload must be size_t-aligned,
+        // otherwise resize() under-allocates and FastMemcpy overflows.
+        AssertInfo(null_entry.data.size() % sizeof(size_t) == 0,
+                   "corrupt R-Tree null_offset entry: byte size {} is not a "
+                   "multiple of {}",
+                   null_entry.data.size(),
+                   sizeof(size_t));
+        std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
         null_offset_.resize(null_entry.data.size() / sizeof(size_t));
         milvus::fastmem::FastMemcpy(null_offset_.data(),
                                     null_entry.data.data(),
@@ -740,13 +857,19 @@ RTreeIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
                "RTreeIndex LoadEntries: cannot determine base path from files");
     path_ = base_path;
 
-    wrapper_ =
+    // Load the wrapper fully BEFORE publishing, then publish under the
+    // readers' lock -- same discipline as Load() above.
+    auto wrapper =
         std::make_shared<RTreeIndexWrapper>(path_, /*is_build_mode=*/false);
-    wrapper_->load();
+    wrapper->load();
 
-    total_num_rows_ =
-        wrapper_->count() + static_cast<int64_t>(null_offset_.size());
-    is_built_ = true;
+    {
+        std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        wrapper_ = wrapper;
+        total_num_rows_ =
+            wrapper->count() + static_cast<int64_t>(null_offset_.size());
+        is_built_ = true;
+    }
     ComputeByteSize();
     LOG_INFO(
         "LoadEntries RTreeIndex done, file_count: {}, has_null: {}, "

--- a/internal/core/src/index/RTreeIndex.cpp
+++ b/internal/core/src/index/RTreeIndex.cpp
@@ -559,7 +559,7 @@ RTreeIndex<T>::Range(const T& lower_bound_value,
 template <typename T>
 void
 RTreeIndex<T>::QueryCandidates(proto::plan::GISFunctionFilterExpr_GISOp op,
-                               const Geometry query_geometry,
+                               const Geometry& query_geometry,
                                std::vector<int64_t>& candidate_offsets) {
     // Snapshot wrapper_ under the shared lock: on a growing segment it is
     // published lazily by InitForBuildIndex() under the write lock, so an

--- a/internal/core/src/index/RTreeIndex.cpp
+++ b/internal/core/src/index/RTreeIndex.cpp
@@ -489,13 +489,21 @@ RTreeIndex<T>::IsNull() {
 template <typename T>
 TargetBitmap
 RTreeIndex<T>::IsNotNull() {
-    int64_t count = Count();
-    TargetBitmap bitset(count, true);
+    return IsNotNull(Count());
+}
+
+template <typename T>
+TargetBitmap
+RTreeIndex<T>::IsNotNull(int64_t row_count) {
+    AssertInfo(row_count >= 0,
+               "R-Tree validity row count must be non-negative, got {}",
+               row_count);
+    TargetBitmap bitset(row_count, true);
     std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
     // See IsNull(): null_offset_ is not sorted by construction, so
     // bounds-check every offset rather than relying on a sorted-range shortcut.
     for (auto off : null_offset_) {
-        if (off < static_cast<size_t>(count)) {
+        if (off < static_cast<size_t>(row_count)) {
             bitset.reset(off);
         }
     }

--- a/internal/core/src/index/RTreeIndex.cpp
+++ b/internal/core/src/index/RTreeIndex.cpp
@@ -19,6 +19,7 @@
 #include <list>
 #include <map>
 #include <mutex>
+#include <new>
 #include <string_view>
 #include <shared_mutex>
 #include <utility>
@@ -72,22 +73,40 @@ ends_with(const std::string& value, const std::string& suffix) {
 template <typename T>
 void
 RTreeIndex<T>::InitForBuildIndex(bool is_growing) {
-    std::string index_file_path;
     if (is_growing) {
-        path_ = "";
-    } else {
-        auto prefix = disk_file_manager_->GetIndexIdentifier();
-        path_ = GetRTreeTempPrefix() + prefix;
-        boost::filesystem::create_directories(path_);
-        index_file_path = path_ + "/index_file";  // base path (no ext)
-        if (boost::filesystem::exists(index_file_path + ".bgi")) {
-            ThrowInfo(IndexBuildError,
-                      "build rtree index temp dir:{} not empty",
-                      path_);
+        // Concurrency model: production currently serializes writes to a
+        // growing segment (one flowgraph consumer per vchannel drives
+        // SegmentGrowingImpl::Insert, and recovery's LoadGrowing completes
+        // before consumption starts). The locking here is defense-in-depth
+        // honoring the segcore-level IndexingRecord::AppendingIndex contract
+        // ("concurrent, reentrant"), not a claim that production exercises
+        // multi-writer inserts today. Writers may still race concurrent
+        // READERS (search on the growing index), so the lazy first-time init
+        // stays idempotent under the write lock: the wrapper is created
+        // exactly once and readers never observe a torn shared_ptr.
+        std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        if (wrapper_) {
+            return;
         }
+        path_ = "";
+        std::string index_file_path;  // empty: in-memory growing wrapper
+        wrapper_ = std::make_shared<RTreeIndexWrapper>(index_file_path, true);
+        return;
     }
 
-    wrapper_ = std::make_shared<RTreeIndexWrapper>(index_file_path, true);
+    // Non-growing (build/load) path runs single-threaded.
+    auto prefix = disk_file_manager_->GetIndexIdentifier();
+    path_ = GetRTreeTempPrefix() + prefix;
+    boost::filesystem::create_directories(path_);
+    std::string index_file_path = path_ + "/index_file";  // base path (no ext)
+    if (boost::filesystem::exists(index_file_path + ".bgi")) {
+        ThrowInfo(
+            IndexBuildError, "build rtree index temp dir:{} not empty", path_);
+    }
+
+    auto wrapper = std::make_shared<RTreeIndexWrapper>(index_file_path, true);
+    std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
+    wrapper_ = std::move(wrapper);
 }
 
 template <typename T>
@@ -151,6 +170,15 @@ RTreeIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
         };
 
         auto fill_null_offsets = [&](const uint8_t* data, int64_t size) {
+            // null_offset is a size_t[] payload; its byte length must be a
+            // multiple of sizeof(size_t). Otherwise resize() truncates the
+            // destination while FastMemcpy still copies `size` bytes, writing
+            // past the buffer. Reject a malformed/truncated sidecar instead.
+            AssertInfo((size_t)size % sizeof(size_t) == 0,
+                       "corrupt R-Tree null_offset payload: byte size {} is "
+                       "not a multiple of {}",
+                       size,
+                       sizeof(size_t));
             std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
             null_offset_.resize((size_t)size / sizeof(size_t));
             milvus::fastmem::FastMemcpy(
@@ -262,14 +290,22 @@ RTreeIndex<T>::Load(milvus::tracer::TraceContext ctx, const Config& config) {
     }
     path_ = base_path;
 
-    // 5. Instantiate wrapper and load.
-    wrapper_ =
+    // 5. Instantiate wrapper and load it fully BEFORE publishing, then
+    // publish every member under the same lock the readers take (Count /
+    // QueryCandidates / ComputeByteSize snapshot wrapper_ under mutex_):
+    // the no-torn-read invariant only holds if every writer participates,
+    // exactly as the growing publish in InitForBuildIndex does.
+    auto wrapper =
         std::make_shared<RTreeIndexWrapper>(path_, /*is_build_mode=*/false);
-    wrapper_->load();
+    wrapper->load();
 
-    total_num_rows_ =
-        wrapper_->count() + static_cast<int64_t>(null_offset_.size());
-    is_built_ = true;
+    {
+        std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        wrapper_ = wrapper;
+        total_num_rows_ =
+            wrapper->count() + static_cast<int64_t>(null_offset_.size());
+        is_built_ = true;
+    }
     ComputeByteSize();
 
     LOG_INFO(
@@ -434,10 +470,18 @@ RTreeIndex<T>::IsNull() {
     int64_t count = Count();
     TargetBitmap bitset(count);
     std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
-    auto end = std::lower_bound(
-        null_offset_.begin(), null_offset_.end(), static_cast<size_t>(count));
-    for (auto it = null_offset_.begin(); it != end; ++it) {
-        bitset.set(*it);
+    // null_offset_ is not guaranteed to be sorted by construction: AddGeometry
+    // appends offsets in arrival order, and while production currently
+    // serializes inserts per growing segment (so the order is monotonic
+    // today), nothing in this class enforces it. A std::lower_bound shortcut
+    // would silently rely on that external property and could leave in-range
+    // offsets past the bound (or, worse, iterate offsets >= count).
+    // Bounds-check each element instead so an out-of-range offset can never
+    // write past the bitset.
+    for (auto off : null_offset_) {
+        if (off < static_cast<size_t>(count)) {
+            bitset.set(off);
+        }
     }
     return bitset;
 }
@@ -448,10 +492,12 @@ RTreeIndex<T>::IsNotNull() {
     int64_t count = Count();
     TargetBitmap bitset(count, true);
     std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
-    auto end = std::lower_bound(
-        null_offset_.begin(), null_offset_.end(), static_cast<size_t>(count));
-    for (auto it = null_offset_.begin(); it != end; ++it) {
-        bitset.reset(*it);
+    // See IsNull(): null_offset_ is not sorted by construction, so
+    // bounds-check every offset rather than relying on a sorted-range shortcut.
+    for (auto off : null_offset_) {
+        if (off < static_cast<size_t>(count)) {
+            bitset.reset(off);
+        }
     }
     return bitset;
 }
@@ -507,39 +553,66 @@ void
 RTreeIndex<T>::QueryCandidates(proto::plan::GISFunctionFilterExpr_GISOp op,
                                const Geometry query_geometry,
                                std::vector<int64_t>& candidate_offsets) {
-    AssertInfo(wrapper_ != nullptr, "R-Tree index wrapper is null");
+    // Snapshot wrapper_ under the shared lock: on a growing segment it is
+    // published lazily by InitForBuildIndex() under the write lock, so an
+    // unsynchronized read here could observe a torn shared_ptr.
+    std::shared_ptr<RTreeIndexWrapper> wrapper;
+    {
+        std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        wrapper = wrapper_;
+    }
+    AssertInfo(wrapper != nullptr, "R-Tree index wrapper is null");
 
-    // Create GEOS context and ensure it's properly released
-    GEOSContextHandle_t ctx = GEOS_init_r();
+    // Scoped GEOS context: InitGEOSContext throws a retriable
+    // MemAllocateFailed on OOM instead of handing a null context to
+    // query_candidates, and the RAII guard releases the context even when
+    // query_candidates throws (e.g. candidate_offsets growth hitting
+    // bad_alloc, or an AssertInfo on the query geometry) -- a trailing
+    // GEOS_finish_r would leak once per failed query.
+    ScopedGeosResources geos("query_candidates");
 
-    wrapper_->query_candidates(
-        op, query_geometry.GetGeometry(), ctx, candidate_offsets);
-    GEOS_finish_r(ctx);
+    wrapper->query_candidates(
+        op, query_geometry.GetGeometry(), geos.ctx, candidate_offsets);
 }
 
 template <typename T>
 const TargetBitmap
 RTreeIndex<T>::Query(const DatasetPtr& dataset) {
-    AssertInfo(schema_.data_type() == proto::schema::DataType::Geometry,
-               "RTreeIndex can only be queried on geometry field");
-    auto op =
-        dataset->Get<proto::plan::GISFunctionFilterExpr_GISOp>(OPERATOR_TYPE);
-    // Query geometry WKB passed via MATCH_VALUE as std::string
-    auto geometry = dataset->Get<Geometry>(MATCH_VALUE);
+    try {
+        AssertInfo(schema_.data_type() == proto::schema::DataType::Geometry,
+                   "RTreeIndex can only be queried on geometry field");
+        auto op = dataset->Get<proto::plan::GISFunctionFilterExpr_GISOp>(
+            OPERATOR_TYPE);
+        // Query geometry WKB passed via MATCH_VALUE as std::string
+        auto geometry = dataset->Get<Geometry>(MATCH_VALUE);
 
-    // 1) Coarse candidates by R-Tree on MBR
-    std::vector<int64_t> candidate_offsets;
-    QueryCandidates(op, geometry, candidate_offsets);
+        // 1) Coarse candidates by R-Tree on MBR
+        std::vector<int64_t> candidate_offsets;
+        QueryCandidates(op, geometry, candidate_offsets);
 
-    // 2) Build initial bitmap from candidates
-    TargetBitmap res(this->Count());
-    for (auto off : candidate_offsets) {
-        if (off >= 0 && off < res.size()) {
-            res.set(off);
+        // 2) Build initial bitmap from candidates
+        // Count() reports the row space (max(total_num_rows_, indexed)), so a
+        // candidate below the row count can no longer be clipped away. The
+        // bound stays as a guard for the benign race only: on a growing index
+        // a writer may publish a higher offset between the Count() snapshot
+        // above and QueryCandidates() returning. Such a row is not yet visible
+        // to this query's timestamp, so dropping it is correct -- not an
+        // invariant violation, which is why this stays silent rather than
+        // asserting.
+        TargetBitmap res(this->Count());
+        for (auto off : candidate_offsets) {
+            if (off >= 0 && off < res.size()) {
+                res.set(off);
+            }
         }
-    }
 
-    return res;
+        return res;
+    } catch (const SegcoreError&) {
+        throw;
+    } catch (const std::bad_alloc&) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory querying R-Tree index");
+    }
 }
 
 // ------------------------------------------------------------------
@@ -605,25 +678,52 @@ RTreeIndex<T>::BuildWithStrings(const std::vector<std::string>& geometries) {
 
 template <typename T>
 void
-RTreeIndex<T>::AddGeometry(const std::string& wkb_data, int64_t row_offset) {
-    if (!wrapper_) {
-        // Initialize if not already done
-        this->InitForBuildIndex(true);
+RTreeIndex<T>::AddGeometry(const std::string& wkb_data,
+                           int64_t row_offset,
+                           bool is_valid) {
+    // Snapshot wrapper_ under the lock; lazily (and idempotently) initialize it
+    // if this is the first insert. Production serializes inserts per growing
+    // segment (see InitForBuildIndex), but AddGeometry races concurrent
+    // READERS and the AppendingIndex contract permits concurrent writers, so
+    // wrapper_ must never be read or published unlocked.
+    std::shared_ptr<RTreeIndexWrapper> wrapper;
+    {
+        std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        wrapper = wrapper_;
+    }
+    if (!wrapper) {
+        this->InitForBuildIndex(true);  // idempotent under the write lock
+        std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        wrapper = wrapper_;
     }
 
-    if (!wkb_data.empty()) {
+    // Nullness is decided by is_valid alone, never by the payload: a valid row
+    // with an empty/unparseable WKB gets a placeholder MBR from add_geometry,
+    // keeping growing consistent with the sealed bulk_load classification.
+    if (is_valid) {
         const uint8_t* data_ptr =
             reinterpret_cast<const uint8_t*>(wkb_data.data());
-        wrapper_->add_geometry(data_ptr, wkb_data.size(), row_offset);
+        wrapper->add_geometry(data_ptr, wkb_data.size(), row_offset);
 
-        // Update total row count
-        if (row_offset >= total_num_rows_) {
-            total_num_rows_ = row_offset + 1;
+        // Update total row count under the same lock that guards readers
+        // (Count/NumRows), so the non-null path is symmetric with the null
+        // path below and never races a concurrent search on the growing index.
+        {
+            std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
+            if (row_offset >= total_num_rows_) {
+                total_num_rows_ = row_offset + 1;
+            }
         }
 
         LOG_DEBUG("Added geometry at row offset {}", row_offset);
     } else {
-        // Handle null geometry
+        // Handle null geometry. Deliberately not deduplicated: no production
+        // path re-drives a failed batch into this same index object (the
+        // insert path panics in the delegator, the growing load path has no
+        // retry loop and a re-issued LoadSegments builds a fresh segment), so
+        // a dedup set would cost one entry per null row forever to guard a
+        // case that cannot occur. See insert_value_locked's note in
+        // RTreeIndexWrapper.h.
         std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
         null_offset_.push_back(static_cast<size_t>(row_offset));
 
@@ -711,6 +811,14 @@ RTreeIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
 
     if (has_null) {
         auto null_entry = reader.ReadEntry("index_null_offset");
+        // See fill_null_offsets in Load(): the payload must be size_t-aligned,
+        // otherwise resize() under-allocates and FastMemcpy overflows.
+        AssertInfo(null_entry.data.size() % sizeof(size_t) == 0,
+                   "corrupt R-Tree null_offset entry: byte size {} is not a "
+                   "multiple of {}",
+                   null_entry.data.size(),
+                   sizeof(size_t));
+        std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
         null_offset_.resize(null_entry.data.size() / sizeof(size_t));
         milvus::fastmem::FastMemcpy(null_offset_.data(),
                                     null_entry.data.data(),
@@ -740,13 +848,19 @@ RTreeIndex<T>::LoadEntries(storage::IndexEntryReader& reader,
                "RTreeIndex LoadEntries: cannot determine base path from files");
     path_ = base_path;
 
-    wrapper_ =
+    // Load the wrapper fully BEFORE publishing, then publish under the
+    // readers' lock -- same discipline as Load() above.
+    auto wrapper =
         std::make_shared<RTreeIndexWrapper>(path_, /*is_build_mode=*/false);
-    wrapper_->load();
+    wrapper->load();
 
-    total_num_rows_ =
-        wrapper_->count() + static_cast<int64_t>(null_offset_.size());
-    is_built_ = true;
+    {
+        std::unique_lock<folly::SharedMutexWritePriority> lock(mutex_);
+        wrapper_ = wrapper;
+        total_num_rows_ =
+            wrapper->count() + static_cast<int64_t>(null_offset_.size());
+        is_built_ = true;
+    }
     ComputeByteSize();
     LOG_INFO(
         "LoadEntries RTreeIndex done, file_count: {}, has_null: {}, "

--- a/internal/core/src/index/RTreeIndex.h
+++ b/internal/core/src/index/RTreeIndex.h
@@ -13,10 +13,13 @@
 
 #include <folly/SharedMutex.h>
 #include <stdint.h>
+#include <algorithm>
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -80,12 +83,31 @@ class RTreeIndex : public ScalarIndex<T> {
 
     int64_t
     Count() override {
-        if (is_built_) {
-            return total_num_rows_;
+        // On a growing segment AddGeometry() mutates null_offset_ and publishes
+        // wrapper_ under mutex_, concurrently with searches calling Count(); take
+        // the shared lock and snapshot wrapper_ before dereferencing it.
+        std::shared_ptr<RTreeIndexWrapper> wrapper;
+        int64_t null_count = 0;
+        int64_t total_num_rows = 0;
+        {
+            std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
+            if (is_built_) {
+                return total_num_rows_;
+            }
+            wrapper = wrapper_;
+            null_count = static_cast<int64_t>(null_offset_.size());
+            total_num_rows = total_num_rows_;
         }
-        return wrapper_ ? wrapper_->count() +
-                              static_cast<int64_t>(null_offset_.size())
-                        : 0;
+        // Callers size row-addressed bitmaps by Count() (see Query()), so it
+        // must report the row space, not how many rows happen to be indexed.
+        // AddGeometry() is offset-addressed and keeps total_num_rows_ at
+        // max(row_offset) + 1, so with sparse or out-of-order offsets it
+        // outgrows wrapper->count() + nulls -- returning the smaller value
+        // would make Query() clip live candidates. Keep the max so neither
+        // counter can under-report.
+        auto indexed_count =
+            wrapper ? wrapper->count() + null_count : null_count;
+        return std::max(total_num_rows, indexed_count);
     }
 
     // BuildWithRawDataForUT should be only used in ut. Only string is supported.
@@ -98,9 +120,17 @@ class RTreeIndex : public ScalarIndex<T> {
     void
     BuildWithStrings(const std::vector<std::string>& geometries);
 
-    // Add single geometry incrementally (for growing segment)
+    // Add single geometry incrementally (for growing segment).
+    //
+    // `is_valid` is the row's nullability from the caller's valid_data and is
+    // the ONLY signal that classifies the row as NULL: a valid row whose WKB
+    // payload is empty or unparseable is indexed with a placeholder MBR (like
+    // the sealed bulk_load path, which also checks is_valid first), NOT pushed
+    // into null_offset_. Inferring nullness from wkb_data.empty() would make
+    // ST_ISNOTNULL / Count() disagree between growing and sealed for such a
+    // row.
     void
-    AddGeometry(const std::string& wkb_data, int64_t row_offset);
+    AddGeometry(const std::string& wkb_data, int64_t row_offset, bool is_valid);
 
     BinarySet
     Serialize(const Config& config) override;
@@ -116,6 +146,13 @@ class RTreeIndex : public ScalarIndex<T> {
 
     TargetBitmap
     IsNotNull() override;
+
+    // Build validity in the caller's absolute row space. Legacy R-Tree files
+    // can contain null offsets beyond Count() when older builders dropped
+    // non-null empty/corrupt geometries, so sizing only by Count() loses those
+    // tail NULLs.
+    TargetBitmap
+    IsNotNull(int64_t row_count) override;
 
     const TargetBitmap
     InApplyFilter(
@@ -162,12 +199,17 @@ class RTreeIndex : public ScalarIndex<T> {
         ScalarIndex<T>::ComputeByteSize();
         int64_t total = this->cached_byte_size_;
 
-        // null_offset_ vector
-        total += null_offset_.capacity() * sizeof(size_t);
+        std::shared_ptr<RTreeIndexWrapper> wrapper;
+        {
+            std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
+            // null_offset_ vector
+            total += null_offset_.capacity() * sizeof(size_t);
+            wrapper = wrapper_;
+        }
 
         // wrapper_ (RTreeIndexWrapper)
-        if (wrapper_) {
-            total += wrapper_->ByteSize();
+        if (wrapper) {
+            total += wrapper->ByteSize();
         }
 
         this->cached_byte_size_ = total;
@@ -180,9 +222,13 @@ class RTreeIndex : public ScalarIndex<T> {
      * @param query_geom Query geometry in WKB format
      * @param candidate_offsets Output vector of candidate row offsets
      */
+    // Takes the query geometry by reference: by value it deep-cloned the whole
+    // GEOS geometry on every call (once per query per segment), and each clone
+    // is an allocation that can fail under memory pressure. The callee only
+    // reads it.
     void
     QueryCandidates(proto::plan::GISFunctionFilterExpr_GISOp op,
-                    const Geometry query_geometry,
+                    const Geometry& query_geometry,
                     std::vector<int64_t>& candidate_offsets);
 
     const TargetBitmap

--- a/internal/core/src/index/RTreeIndex.h
+++ b/internal/core/src/index/RTreeIndex.h
@@ -222,9 +222,13 @@ class RTreeIndex : public ScalarIndex<T> {
      * @param query_geom Query geometry in WKB format
      * @param candidate_offsets Output vector of candidate row offsets
      */
+    // Takes the query geometry by reference: by value it deep-cloned the whole
+    // GEOS geometry on every call (once per query per segment), and each clone
+    // is an allocation that can fail under memory pressure. The callee only
+    // reads it.
     void
     QueryCandidates(proto::plan::GISFunctionFilterExpr_GISOp op,
-                    const Geometry query_geometry,
+                    const Geometry& query_geometry,
                     std::vector<int64_t>& candidate_offsets);
 
     const TargetBitmap

--- a/internal/core/src/index/RTreeIndex.h
+++ b/internal/core/src/index/RTreeIndex.h
@@ -13,10 +13,13 @@
 
 #include <folly/SharedMutex.h>
 #include <stdint.h>
+#include <algorithm>
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -80,12 +83,31 @@ class RTreeIndex : public ScalarIndex<T> {
 
     int64_t
     Count() override {
-        if (is_built_) {
-            return total_num_rows_;
+        // On a growing segment AddGeometry() mutates null_offset_ and publishes
+        // wrapper_ under mutex_, concurrently with searches calling Count(); take
+        // the shared lock and snapshot wrapper_ before dereferencing it.
+        std::shared_ptr<RTreeIndexWrapper> wrapper;
+        int64_t null_count = 0;
+        int64_t total_num_rows = 0;
+        {
+            std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
+            if (is_built_) {
+                return total_num_rows_;
+            }
+            wrapper = wrapper_;
+            null_count = static_cast<int64_t>(null_offset_.size());
+            total_num_rows = total_num_rows_;
         }
-        return wrapper_ ? wrapper_->count() +
-                              static_cast<int64_t>(null_offset_.size())
-                        : 0;
+        // Callers size row-addressed bitmaps by Count() (see Query()), so it
+        // must report the row space, not how many rows happen to be indexed.
+        // AddGeometry() is offset-addressed and keeps total_num_rows_ at
+        // max(row_offset) + 1, so with sparse or out-of-order offsets it
+        // outgrows wrapper->count() + nulls -- returning the smaller value
+        // would make Query() clip live candidates. Keep the max so neither
+        // counter can under-report.
+        auto indexed_count =
+            wrapper ? wrapper->count() + null_count : null_count;
+        return std::max(total_num_rows, indexed_count);
     }
 
     // BuildWithRawDataForUT should be only used in ut. Only string is supported.
@@ -98,9 +120,17 @@ class RTreeIndex : public ScalarIndex<T> {
     void
     BuildWithStrings(const std::vector<std::string>& geometries);
 
-    // Add single geometry incrementally (for growing segment)
+    // Add single geometry incrementally (for growing segment).
+    //
+    // `is_valid` is the row's nullability from the caller's valid_data and is
+    // the ONLY signal that classifies the row as NULL: a valid row whose WKB
+    // payload is empty or unparseable is indexed with a placeholder MBR (like
+    // the sealed bulk_load path, which also checks is_valid first), NOT pushed
+    // into null_offset_. Inferring nullness from wkb_data.empty() would make
+    // ST_ISNOTNULL / Count() disagree between growing and sealed for such a
+    // row. See PR #50951 review.
     void
-    AddGeometry(const std::string& wkb_data, int64_t row_offset);
+    AddGeometry(const std::string& wkb_data, int64_t row_offset, bool is_valid);
 
     BinarySet
     Serialize(const Config& config) override;
@@ -162,12 +192,17 @@ class RTreeIndex : public ScalarIndex<T> {
         ScalarIndex<T>::ComputeByteSize();
         int64_t total = this->cached_byte_size_;
 
-        // null_offset_ vector
-        total += null_offset_.capacity() * sizeof(size_t);
+        std::shared_ptr<RTreeIndexWrapper> wrapper;
+        {
+            std::shared_lock<folly::SharedMutexWritePriority> lock(mutex_);
+            // null_offset_ vector
+            total += null_offset_.capacity() * sizeof(size_t);
+            wrapper = wrapper_;
+        }
 
         // wrapper_ (RTreeIndexWrapper)
-        if (wrapper_) {
-            total += wrapper_->ByteSize();
+        if (wrapper) {
+            total += wrapper->ByteSize();
         }
 
         this->cached_byte_size_ = total;

--- a/internal/core/src/index/RTreeIndex.h
+++ b/internal/core/src/index/RTreeIndex.h
@@ -147,6 +147,13 @@ class RTreeIndex : public ScalarIndex<T> {
     TargetBitmap
     IsNotNull() override;
 
+    // Build validity in the caller's absolute row space. Legacy R-Tree files
+    // can contain null offsets beyond Count() when older builders dropped
+    // non-null empty/corrupt geometries, so sizing only by Count() loses those
+    // tail NULLs.
+    TargetBitmap
+    IsNotNull(int64_t row_count) override;
+
     const TargetBitmap
     InApplyFilter(
         size_t n,

--- a/internal/core/src/index/RTreeIndexSerialization.h
+++ b/internal/core/src/index/RTreeIndexSerialization.h
@@ -11,8 +11,10 @@
 
 #pragma once
 
+#include <atomic>
 #include <fstream>
 #include <iostream>
+#include <new>
 #include <sstream>
 #include <string>
 
@@ -34,47 +36,83 @@
 
 class RTreeSerializer {
  public:
+    enum class BinaryIOResult {
+        Success,
+        OpenFailed,
+        StreamFailed,
+        ArchiveFailed,
+    };
+
+    /**
+     * Test-only one-shot fault injection for the close() check in saveBinary.
+     *
+     * A close(2) that fails after a successful flush needs a filesystem that
+     * defers ENOSPC/EIO to close (ext4 delalloc, XFS, NFS) on a full or
+     * failing device; a unit test cannot provoke that, so the branch would
+     * otherwise be unreachable from a test. Production code never sets it.
+     */
+    static std::atomic<bool>&
+    CloseFailureForTesting() {
+        static std::atomic<bool> flag{false};
+        return flag;
+    }
+
     template <typename RTreeType>
-    static bool
+    static BinaryIOResult
     saveBinary(const RTreeType& tree, const std::string& filename) {
         try {
             std::ofstream ofs(filename, std::ios::binary);
             if (!ofs.is_open()) {
-                std::cerr << "Cannot open file for writing: " << filename
-                          << std::endl;
-                return false;
+                return BinaryIOResult::OpenFailed;
             }
 
-            boost::archive::binary_oarchive oa(ofs);
-            oa << tree;
-
+            {
+                boost::archive::binary_oarchive oa(ofs);
+                oa << tree;
+            }
+            ofs.flush();
+            if (!ofs.good()) {
+                return BinaryIOResult::StreamFailed;
+            }
+            // close() explicitly, and check it. flush() only guarantees the
+            // streambuf reached write(2); on a delayed-allocation filesystem
+            // (ext4 delalloc, XFS) ENOSPC/EIO for those blocks is reported at
+            // close(2). Letting ~basic_ofstream do the closing swallows that
+            // failbit, so a truncated .bgi would be reported as Success and
+            // uploaded as a successfully built index -- the exact outcome
+            // finish() must never produce -- resurfacing much later at load
+            // as ArchiveFailed/DataFormatBroken.
             ofs.close();
-            return true;
-        } catch (const std::exception& e) {
-            std::cerr << "Serialization error: " << e.what() << std::endl;
-            return false;
+            if (CloseFailureForTesting().exchange(false) || !ofs.good()) {
+                return BinaryIOResult::StreamFailed;
+            }
+            return BinaryIOResult::Success;
+        } catch (const std::bad_alloc&) {
+            throw;
+        } catch (const std::exception&) {
+            return BinaryIOResult::ArchiveFailed;
         }
     }
 
     template <typename RTreeType>
-    static bool
+    static BinaryIOResult
     loadBinary(RTreeType& tree, const std::string& filename) {
         try {
             std::ifstream ifs(filename, std::ios::binary);
             if (!ifs.is_open()) {
-                std::cerr << "Cannot open file for reading: " << filename
-                          << std::endl;
-                return false;
+                return BinaryIOResult::OpenFailed;
             }
 
             boost::archive::binary_iarchive ia(ifs);
             ia >> tree;
-
-            ifs.close();
-            return true;
-        } catch (const std::exception& e) {
-            std::cerr << "Deserialization error: " << e.what() << std::endl;
-            return false;
+            if (ifs.bad()) {
+                return BinaryIOResult::StreamFailed;
+            }
+            return BinaryIOResult::Success;
+        } catch (const std::bad_alloc&) {
+            throw;
+        } catch (const std::exception&) {
+            return BinaryIOResult::ArchiveFailed;
         }
     }
 

--- a/internal/core/src/index/RTreeIndexSerialization.h
+++ b/internal/core/src/index/RTreeIndexSerialization.h
@@ -13,6 +13,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <new>
 #include <sstream>
 #include <string>
 
@@ -34,47 +35,57 @@
 
 class RTreeSerializer {
  public:
+    enum class BinaryIOResult {
+        Success,
+        OpenFailed,
+        StreamFailed,
+        ArchiveFailed,
+    };
+
     template <typename RTreeType>
-    static bool
+    static BinaryIOResult
     saveBinary(const RTreeType& tree, const std::string& filename) {
         try {
             std::ofstream ofs(filename, std::ios::binary);
             if (!ofs.is_open()) {
-                std::cerr << "Cannot open file for writing: " << filename
-                          << std::endl;
-                return false;
+                return BinaryIOResult::OpenFailed;
             }
 
-            boost::archive::binary_oarchive oa(ofs);
-            oa << tree;
-
-            ofs.close();
-            return true;
-        } catch (const std::exception& e) {
-            std::cerr << "Serialization error: " << e.what() << std::endl;
-            return false;
+            {
+                boost::archive::binary_oarchive oa(ofs);
+                oa << tree;
+            }
+            ofs.flush();
+            if (!ofs.good()) {
+                return BinaryIOResult::StreamFailed;
+            }
+            return BinaryIOResult::Success;
+        } catch (const std::bad_alloc&) {
+            throw;
+        } catch (const std::exception&) {
+            return BinaryIOResult::ArchiveFailed;
         }
     }
 
     template <typename RTreeType>
-    static bool
+    static BinaryIOResult
     loadBinary(RTreeType& tree, const std::string& filename) {
         try {
             std::ifstream ifs(filename, std::ios::binary);
             if (!ifs.is_open()) {
-                std::cerr << "Cannot open file for reading: " << filename
-                          << std::endl;
-                return false;
+                return BinaryIOResult::OpenFailed;
             }
 
             boost::archive::binary_iarchive ia(ifs);
             ia >> tree;
-
-            ifs.close();
-            return true;
-        } catch (const std::exception& e) {
-            std::cerr << "Deserialization error: " << e.what() << std::endl;
-            return false;
+            if (ifs.bad()) {
+                return BinaryIOResult::StreamFailed;
+            }
+            return BinaryIOResult::Success;
+        } catch (const std::bad_alloc&) {
+            throw;
+        } catch (const std::exception&) {
+            return BinaryIOResult::ArchiveFailed;
         }
     }
 

--- a/internal/core/src/index/RTreeIndexSerialization.h
+++ b/internal/core/src/index/RTreeIndexSerialization.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <fstream>
 #include <iostream>
 #include <new>
@@ -42,6 +43,20 @@ class RTreeSerializer {
         ArchiveFailed,
     };
 
+    /**
+     * Test-only one-shot fault injection for the close() check in saveBinary.
+     *
+     * A close(2) that fails after a successful flush needs a filesystem that
+     * defers ENOSPC/EIO to close (ext4 delalloc, XFS, NFS) on a full or
+     * failing device; a unit test cannot provoke that, so the branch would
+     * otherwise be unreachable from a test. Production code never sets it.
+     */
+    static std::atomic<bool>&
+    CloseFailureForTesting() {
+        static std::atomic<bool> flag{false};
+        return flag;
+    }
+
     template <typename RTreeType>
     static BinaryIOResult
     saveBinary(const RTreeType& tree, const std::string& filename) {
@@ -57,6 +72,18 @@ class RTreeSerializer {
             }
             ofs.flush();
             if (!ofs.good()) {
+                return BinaryIOResult::StreamFailed;
+            }
+            // close() explicitly, and check it. flush() only guarantees the
+            // streambuf reached write(2); on a delayed-allocation filesystem
+            // (ext4 delalloc, XFS) ENOSPC/EIO for those blocks is reported at
+            // close(2). Letting ~basic_ofstream do the closing swallows that
+            // failbit, so a truncated .bgi would be reported as Success and
+            // uploaded as a successfully built index -- the exact outcome
+            // finish() must never produce -- resurfacing much later at load
+            // as ArchiveFailed/DataFormatBroken.
+            ofs.close();
+            if (CloseFailureForTesting().exchange(false) || !ofs.good()) {
                 return BinaryIOResult::StreamFailed;
             }
             return BinaryIOResult::Success;

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -16,13 +16,17 @@
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
 #include <stddef.h>
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <exception>
 #include <functional>
+#include <thread>
 #include <initializer_list>
 #include <iostream>
 #include <map>
 #include <memory>
+#include <new>
 #include <optional>
 #include <string>
 #include <utility>
@@ -39,6 +43,7 @@
 #include "common/FieldData.h"
 #include "common/FieldDataInterface.h"
 #include "common/Geometry.h"
+#include "common/GeometryCache.h"
 #include "common/Schema.h"
 #include "common/Tracer.h"
 #include "common/Types.h"
@@ -58,6 +63,7 @@
 #include "plan/PlanNode.h"
 #include "query/ExecPlanNodeVisitor.h"
 #include "query/Utils.h"
+#include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/SegcoreConfig.h"
 #include "segcore/SegmentSealed.h"
 #include "segcore/Types.h"
@@ -103,12 +109,16 @@ CreateWkbFromWkt(const std::string& wkt) {
     return wkb;
 }
 
+// The returned Geometry keeps a pointer to the context it was built on and
+// dereferences it on every copy and in its destructor, so that context must
+// OUTLIVE the returned value. Building on a local context and finishing it
+// here would hand back a Geometry whose ctx_ is already freed -- a
+// use-after-free on the first copy or destruction, not at the call itself.
+// The thread-local context lives until the thread exits, which is what makes
+// returning by value safe.
 static milvus::Geometry
 CreateGeometryFromWkt(const std::string& wkt) {
-    auto ctx = GEOS_init_r();
-    auto geom = milvus::Geometry(ctx, wkt.c_str());
-    GEOS_finish_r(ctx);
-    return geom;
+    return milvus::Geometry(milvus::GetThreadLocalGEOSContext(), wkt.c_str());
 }
 
 struct FileSliceSizeGuard {
@@ -216,12 +226,126 @@ class RTreeIndexTest : public ::testing::Test {
         }
     }
 
+    // A sealed segment carrying a LEGACY SHORT R-Tree index. Layout of the N
+    // rows: every row is POINT(0 0) except row N-1, which is a genuine NULL.
+    // The persisted index has the exact legacy shape: valid row 1 is absent
+    // from the tree (as if GEOSWKBReader_read_r transiently returned nullptr),
+    // later valid rows retain absolute offsets 2..N-2, and row N-1 is NULL.
+    // AddGeometry records the absolute null offset N-1, but after reload
+    // Count() is reconstructed as (N-2) tree entries + one NULL = N-1. The
+    // missing valid row is therefore an INTERIOR hole below Count(), not the
+    // suffix bit that a tail-only resize() would add.
+    struct LegacyShortIndexSegment {
+        std::unique_ptr<milvus::segcore::SegmentSealed> sealed;
+        milvus::FieldId pk_id;
+        milvus::FieldId geo_id;
+        std::vector<std::string> index_files;
+    };
+
+    LegacyShortIndexSegment
+    MakeLegacyShortIndexSealed(int N,
+                               int64_t field_id_for_meta,
+                               const std::string& cache_key) {
+        using namespace milvus;
+        using namespace milvus::segcore;
+        LegacyShortIndexSegment out;
+
+        auto schema = std::make_shared<Schema>();
+        out.pk_id = schema->AddDebugField("id", DataType::INT64);
+        schema->AddDebugField(
+            "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+        out.geo_id = schema->AddDebugField(
+            "geo", DataType::GEOMETRY, true /* nullable */);
+        schema->set_primary_field_id(out.pk_id);
+
+        auto full_ds = DataGen(schema, N);
+        out.sealed = CreateSealedWithFieldDataLoaded(
+            schema, full_ds, false, {out.geo_id.get()});
+
+        std::vector<std::string> segment_wkbs(N,
+                                              CreateWkbFromWkt("POINT(0 0)"));
+        segment_wkbs[N - 1].clear();  // payload for the genuine NULL tail row
+        std::vector<uint8_t> valid_bitmap((N + 7) / 8, 0);
+        for (int i = 0; i < N - 1; ++i) {
+            valid_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+        }
+        auto geo_field_data = milvus::storage::CreateFieldData(
+            milvus::storage::DataType::GEOMETRY,
+            milvus::storage::DataType::NONE,
+            true);
+        geo_field_data->FillFieldData(
+            segment_wkbs.data(), valid_bitmap.data(), segment_wkbs.size(), 0);
+        auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                      .GetRemoteChunkManager();
+        auto load_info = PrepareSingleFieldInsertBinlog(
+            1, 1, 1, out.geo_id.get(), {geo_field_data}, cm);
+        out.sealed->LoadFieldData(load_info);
+
+        milvus::storage::FieldDataMeta short_field_meta{
+            1, 1, 1, field_id_for_meta};
+        short_field_meta.field_schema.set_data_type(
+            ::milvus::proto::schema::DataType::Geometry);
+        short_field_meta.field_schema.set_nullable(true);
+        milvus::storage::IndexMeta short_index_meta{1, field_id_for_meta, 1, 1};
+        milvus::storage::FileManagerContext fm_ctx(
+            short_field_meta, short_index_meta, chunk_manager_, fs_);
+        auto rtree_index =
+            std::make_unique<milvus::index::RTreeIndex<std::string>>(fm_ctx);
+        rtree_index->InitForBuildIndex(false);
+        rtree_index->AddGeometry(segment_wkbs[0], 0, true);
+        for (int i = 2; i < N - 1; ++i) {
+            rtree_index->AddGeometry(segment_wkbs[i], i, true);
+        }
+        rtree_index->AddGeometry(segment_wkbs[N - 1], N - 1, false);
+        EXPECT_EQ(rtree_index->Count(), N);
+        auto stats = rtree_index->UploadUnified({});
+        out.index_files = stats->GetIndexFiles();
+
+        milvus::segcore::LoadIndexInfo info{};
+        info.collection_id = 1;
+        info.partition_id = 1;
+        info.segment_id = 1;
+        info.field_id = out.geo_id.get();
+        info.field_type = DataType::GEOMETRY;
+        info.index_id = 1;
+        info.index_build_id = 1;
+        info.index_version = 1;
+        info.schema.set_data_type(proto::schema::DataType::Geometry);
+        info.schema.set_nullable(true);
+        info.index_params["index_type"] = milvus::index::RTREE_INDEX_TYPE;
+        nlohmann::json cfg_load;
+        cfg_load["index_files"] = out.index_files;
+        rtree_index->LoadUnified(cfg_load);
+        // The reload is what makes the index SHORT.
+        EXPECT_EQ(rtree_index->Count(), N - 1);
+        auto legacy_validity = rtree_index->IsNotNull();
+        EXPECT_EQ(legacy_validity.size(), static_cast<size_t>(N - 1));
+        EXPECT_TRUE(legacy_validity[N - 2]);
+        auto full_validity = rtree_index->IsNotNull(N);
+        EXPECT_FALSE(full_validity[N - 1]);
+        info.cache_index =
+            CreateTestCacheIndex(cache_key, std::move(rtree_index));
+        out.sealed->LoadIndex(info);
+        return out;
+    }
+
     milvus::storage::StorageConfig storage_config_;
     milvus::storage::ChunkManagerPtr chunk_manager_;
     milvus::storage::FieldDataMeta field_meta_;
     milvus::storage::IndexMeta index_meta_;
     milvus::test::TmpPath temp_path_;
     milvus_storage::ArrowFileSystemPtr fs_;
+};
+
+class TestableRTreeIndex : public milvus::index::RTreeIndex<std::string> {
+ public:
+    using milvus::index::RTreeIndex<std::string>::RTreeIndex;
+
+    void
+    ThrowOnNextQueryForTesting() {
+        ASSERT_NE(wrapper_, nullptr);
+        wrapper_->SetThrowOnQueryForTesting(true);
+    }
 };
 
 TEST_F(RTreeIndexTest, Build_Upload_Load) {
@@ -327,8 +451,13 @@ TEST_F(RTreeIndexTest, Build_WithInvalidWKB_Upload_Load) {
     milvus::tracer::TraceContext trace_ctx;
     rtree_load.LoadUnified(cfg);
 
-    // Only 2 valid points should be present
-    ASSERT_EQ(rtree_load.Count(), 2);
+    // All 3 rows must be present: the row whose WKB fails to parse is indexed
+    // with a placeholder MBR rather than dropped. Dropping it would leave the
+    // index row count permanently short of the segment row count, which then
+    // trips the growing coarse-bitmap bounds check on every subsequent
+    // geometry query. The R-tree is only a coarse filter -- exact refinement
+    // still filters the placeholder row out of any result.
+    ASSERT_EQ(rtree_load.Count(), 3);
 }
 
 TEST_F(RTreeIndexTest, Build_VariousGeometries) {
@@ -543,8 +672,12 @@ TEST_F(RTreeIndexTest, Build_BulkLoad_Nulls_And_BadWKB) {
 
     rtree.Build(build_cfg);
 
-    // expect: 3 geometries (0, 2, 4) are valid and parsable, 1st geometry is marked null and skipped, 3rd geometry is bad WKB and skipped
-    ASSERT_EQ(rtree.Count(), 4);
+    // All 5 rows are indexed. The bad-WKB row (index 3) is NOT dropped: like the
+    // growing add_geometry path, bulk_load now indexes it with a placeholder MBR
+    // so the index row count stays in lockstep with the segment rows, and exact
+    // refinement tolerates the placeholder (Geometry::TryParseFromWkb -> skip) in
+    // every configuration. See PR #50951 review.
+    ASSERT_EQ(rtree.Count(), 5);
 
     // upload -> load back and verify consistency
     auto stats = rtree.UploadUnified({});
@@ -560,7 +693,7 @@ TEST_F(RTreeIndexTest, Build_BulkLoad_Nulls_And_BadWKB) {
 
     milvus::tracer::TraceContext trace_ctx;
     rtree_load.LoadUnified(cfg);
-    ASSERT_EQ(rtree_load.Count(), 4);
+    ASSERT_EQ(rtree_load.Count(), 5);
 }
 
 TEST_F(RTreeIndexTest, LoadSlicedNullOffsets) {
@@ -1108,4 +1241,990 @@ TEST_F(RTreeIndexTest, GIS_SplitFusion_Equivalence_Indexed) {
 
     sealed.reset();
     CleanupIndexFiles(stats->GetIndexFiles(), "GIS split-fusion equivalence");
+}
+
+// Regression for PR #50951 review (RTreeIndexWrapper:212): an unparseable-WKB
+// row is indexed with a placeholder MBR at the origin (never dropped), so an
+// origin-covering query selects it as a coarse candidate. Exact refinement must
+// then tolerate the corrupt WKB instead of throwing. With the geometry cache
+// OFF (the default), refinement re-parses the raw WKB, so before the fix the
+// throwing Geometry(ctx, wkb) ctor failed the ENTIRE query; now
+// Geometry::TryParseFromWkb skips the row. Drives EvalForIndexSegment, which is
+// exactly what stayed green before (the empty/unparseable index tests only
+// check Count(), never a query over such a row).
+TEST_F(RTreeIndexTest, GIS_Index_Refine_ToleratesUnparseableCandidate) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("id", DataType::INT64);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto geo_id = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->set_primary_field_id(pk_id);
+
+    const int N = 40;
+    const int kBad = 7;  // the one unparseable row
+    auto full_ds = DataGen(schema, N);
+    auto sealed =
+        CreateSealedWithFieldDataLoaded(schema, full_ds, false, {geo_id.get()});
+
+    // Every row is POINT(0 0) (so a valid row intersects the origin), except
+    // kBad which is a truncated -- unparseable -- WKB. The placeholder MBR the
+    // index assigns kBad is also the origin, so the origin query below pulls it
+    // into the candidate set and forces refinement to re-parse its raw bytes.
+    std::vector<std::string> wkbs;
+    wkbs.reserve(N);
+    auto ctx = GEOS_init_r();
+    std::string origin_wkb =
+        milvus::Geometry(ctx, "POINT(0 0)").to_wkb_string();
+    GEOS_finish_r(ctx);
+    for (int i = 0; i < N; ++i) {
+        if (i == kBad) {
+            std::string bad = origin_wkb;
+            bad.resize(bad.size() / 2);  // truncate -> unparseable
+            wkbs.emplace_back(std::move(bad));
+        } else {
+            wkbs.emplace_back(origin_wkb);
+        }
+    }
+
+    auto geo_field_data =
+        milvus::storage::CreateFieldData(milvus::storage::DataType::GEOMETRY,
+                                         milvus::storage::DataType::NONE,
+                                         false);
+    geo_field_data->FillFieldData(wkbs.data(), wkbs.size());
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, geo_id.get(), {geo_field_data}, cm);
+    sealed->LoadFieldData(load_info);
+
+    // Distinct field/index ids so the index build temp dir (derived from
+    // collection_partition_segment_field) does not collide with the leftovers
+    // of GIS_Index_Exact_Filtering, which reuses the fixture's {1,1,1,100}.
+    milvus::storage::FieldDataMeta bad_field_meta{1, 1, 1, 300};
+    bad_field_meta.field_schema.set_data_type(
+        ::milvus::proto::schema::DataType::Geometry);
+    milvus::storage::IndexMeta bad_index_meta{1, 300, 1, 1};
+    auto remote_file = (temp_path_.get() / "rtree_bad_refine.parquet").string();
+    WriteGeometryInsertFile(chunk_manager_, bad_field_meta, remote_file, wkbs);
+    milvus::storage::FileManagerContext fm_ctx(
+        bad_field_meta, bad_index_meta, chunk_manager_, fs_);
+    auto rtree_index =
+        std::make_unique<milvus::index::RTreeIndex<std::string>>(fm_ctx);
+    nlohmann::json build_cfg;
+    build_cfg["insert_files"] = std::vector<std::string>{remote_file};
+    build_cfg["index_type"] = milvus::index::RTREE_INDEX_TYPE;
+    rtree_index->Build(build_cfg);
+    auto stats = rtree_index->UploadUnified({});
+
+    milvus::segcore::LoadIndexInfo info{};
+    info.collection_id = 1;
+    info.partition_id = 1;
+    info.segment_id = 1;
+    info.field_id = geo_id.get();
+    info.field_type = DataType::GEOMETRY;
+    info.index_id = 1;
+    info.index_build_id = 1;
+    info.index_version = 1;
+    info.schema = proto::schema::FieldSchema();
+    info.schema.set_data_type(proto::schema::DataType::Geometry);
+    info.index_params["index_type"] = milvus::index::RTREE_INDEX_TYPE;
+    nlohmann::json cfg_load;
+    cfg_load["index_files"] = stats->GetIndexFiles();
+    rtree_index->LoadUnified(cfg_load);
+    info.cache_index =
+        CreateTestCacheIndex("rtree_bad_refine_key", std::move(rtree_index));
+    sealed->LoadIndex(info);
+
+    // Origin-covering intersects query: must NOT throw, must select every valid
+    // origin point and skip the unparseable row.
+    auto gis_expr = std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+        milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY),
+        proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        "POINT(0 0)");
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, gis_expr);
+    BitsetType bits;
+    ASSERT_NO_THROW(
+        { bits = ExecuteQueryExpr(plan, sealed.get(), N, MAX_TIMESTAMP); });
+    ASSERT_EQ(bits.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        EXPECT_EQ(bool(bits[i]), i != kBad) << "row " << i;
+    }
+
+    sealed.reset();
+    CleanupIndexFiles(stats->GetIndexFiles(), "GIS bad-refine test");
+}
+
+// Regression for the legacy-short-index self-heal: old builders advanced the
+// absolute row offset even when GEOS parsing failed, so a transient parse OOM
+// could drop a valid geometry at an interior offset while later rows kept their
+// original offsets. Count() then under-reports the row space but does not reveal
+// where the hole is. The fallback must refine the whole segment, not only pad a
+// presumed missing suffix. Absolute null offsets must still preserve SQL
+// three-valued logic under NOT ST_*.
+TEST_F(RTreeIndexTest,
+       GIS_LegacyShortIndexRecoversInteriorHoleAndPreservesTailNull) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    constexpr int N = 6;
+    auto seg = MakeLegacyShortIndexSealed(N, 500, "rtree_legacy_short_key");
+    auto& sealed = seg.sealed;
+    auto geo_id = seg.geo_id;
+
+    // The short coarse bitmap has no bit for row 1. A tail-only resize leaves
+    // that interior bit false and silently loses a valid match; the full-scan
+    // fallback must recover it through exact refinement.
+    auto origin_intersects =
+        std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+            milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY, {}, true),
+            proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+            "POINT(0 0)");
+    auto intersects_plan = std::make_shared<plan::FilterBitsNode>(
+        DEFAULT_PLANNODE_ID, origin_intersects);
+    auto intersects_bits =
+        ExecuteQueryExpr(intersects_plan, sealed.get(), N, MAX_TIMESTAMP);
+    ASSERT_EQ(intersects_bits.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N - 1; ++i) {
+        EXPECT_TRUE(intersects_bits[i]) << "valid row " << i;
+    }
+    EXPECT_FALSE(intersects_bits[N - 1]) << "NULL tail row must not match";
+
+    auto intersects = std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+        milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY, {}, true),
+        proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        "POINT(100 100)");
+    auto not_intersects = std::make_shared<milvus::expr::LogicalUnaryExpr>(
+        milvus::expr::LogicalUnaryExpr::OpType::LogicalNot, intersects);
+    auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                       not_intersects);
+    auto bits = ExecuteQueryExpr(plan, sealed.get(), N, MAX_TIMESTAMP);
+
+    ASSERT_EQ(bits.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N - 1; ++i) {
+        EXPECT_TRUE(bits[i]) << "non-null row " << i;
+    }
+    EXPECT_FALSE(bits[N - 1]) << "NULL tail row must remain unknown under NOT";
+
+    sealed.reset();
+    CleanupIndexFiles(seg.index_files, "GIS legacy-short-index test");
+}
+
+// Regression for PR #50951 review (GISFunctionFilterExpr.cpp
+// process_sealed_data): the legacy short-index self-heal promotes EVERY row to
+// a candidate, and with the geometry cache off (the default) refinement used
+// to fetch all of them with ONE bulk_subscript -- a full-column WKB copy per
+// query. Refinement now reads the candidates in batch_size_-row groups. Pin the
+// batch size far below N so the group loop runs several full groups plus a
+// partial tail, and check the answer is identical to the single-shot read:
+// every valid row found, the NULL tail row not.
+TEST_F(RTreeIndexTest, GIS_LegacyShortIndex_ChunkedRefinementMatchesFullRead) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    constexpr int N = 11;  // 11 candidates / batch 4 -> groups 4,4,3
+    auto seg = MakeLegacyShortIndexSealed(N, 501, "rtree_legacy_chunked_key");
+    auto& sealed = seg.sealed;
+    auto geo_id = seg.geo_id;
+
+    auto run = [&](const char* wkt, bool negate) -> BitsetType {
+        milvus::expr::TypedExprPtr e =
+            std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+                milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY, {}, true),
+                proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+                wkt);
+        if (negate) {
+            e = std::make_shared<milvus::expr::LogicalUnaryExpr>(
+                milvus::expr::LogicalUnaryExpr::OpType::LogicalNot, e);
+        }
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, e);
+        return ExecuteQueryExpr(plan, sealed.get(), N, MAX_TIMESTAMP);
+    };
+
+    // Reference: default batch size (>= N) -> a single bulk_subscript group.
+    BitsetType single_hit = run("POINT(0 0)", false);
+    BitsetType single_not = run("POINT(100 100)", true);
+    ASSERT_EQ(single_hit.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N - 1; ++i) {
+        ASSERT_TRUE(single_hit[i]) << "valid row " << i;
+        ASSERT_TRUE(single_not[i]) << "non-null row " << i;
+    }
+    ASSERT_FALSE(single_hit[N - 1]);
+    ASSERT_FALSE(single_not[N - 1]);
+
+    // Chunked: batch 4 -> three bulk_subscript groups over the 11 candidates.
+    // (Also shrinks the Eval batch, so per-batch slicing of the cached refined
+    // bitmap crosses group boundaries too.)
+    ExprBatchSizeGuardLocal batch_guard(4);
+    BitsetType chunked_hit = run("POINT(0 0)", false);
+    BitsetType chunked_not = run("POINT(100 100)", true);
+    ASSERT_EQ(chunked_hit.size(), static_cast<size_t>(N));
+    ASSERT_EQ(chunked_not.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        EXPECT_EQ(bool(chunked_hit[i]), bool(single_hit[i])) << "row " << i;
+        EXPECT_EQ(bool(chunked_not[i]), bool(single_not[i])) << "row " << i;
+    }
+
+    sealed.reset();
+    CleanupIndexFiles(seg.index_files, "GIS legacy chunked-refinement test");
+}
+
+// Regression for PR #50951 review (GISConjunctExpr.cpp RunRTreeQuery): the
+// split/fusion coarse path used to pad a SHORT legacy R-Tree bitmap only at
+// the tail (resize(active_count_, true)). The missing entry of a legacy index
+// is an INTERIOR hole (row 1 here), so its bit stayed false, Refine's
+// `survivors &= coarse_slice` dropped the row, and `A AND B` on the same
+// column silently lost a match that either predicate alone (per-predicate
+// path, which self-heals to a full scan) would return. Both paths now share
+// PromoteShortGISCoarseBitmap: fusion ON must equal fusion OFF, and both must
+// return every valid row and reject the NULL tail.
+TEST_F(RTreeIndexTest, GIS_SplitFusion_LegacyShortIndexRecoversInteriorHole) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    constexpr int N = 6;
+    auto seg = MakeLegacyShortIndexSealed(N, 502, "rtree_legacy_fusion_key");
+    auto& sealed = seg.sealed;
+    auto geo_id = seg.geo_id;
+
+    auto col_geo =
+        milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY, {}, true);
+    auto gis = [&](proto::plan::GISFunctionFilterExpr_GISOp op,
+                   const std::string& wkt) -> milvus::expr::TypedExprPtr {
+        return std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+            col_geo, op, wkt);
+    };
+    // Same-field AND group: intersects(origin) AND within(big box). Both are
+    // satisfied by every valid row, so any false in the answer below is a row
+    // the coarse phase wrongly pruned.
+    milvus::expr::TypedExprPtr filter =
+        std::make_shared<milvus::expr::LogicalBinaryExpr>(
+            milvus::expr::LogicalBinaryExpr::OpType::And,
+            gis(proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+                "POINT(0 0)"),
+            gis(proto::plan::GISFunctionFilterExpr_GISOp_Within,
+                "POLYGON((-100 -100,100 -100,100 100,-100 100,-100 -100))"));
+
+    auto run = [&](bool enable) -> BitsetType {
+        GisSplitFusionFlagGuard guard(enable);
+        auto node =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, filter);
+        return ExecuteQueryExpr(node, sealed.get(), N, MAX_TIMESTAMP);
+    };
+    // Small batch so the coarse slice is consumed across several Eval batches.
+    ExprBatchSizeGuardLocal batch_guard(2);
+
+    BitsetType baseline = run(false);
+    BitsetType fused = run(true);
+    ASSERT_EQ(baseline.size(), static_cast<size_t>(N));
+    ASSERT_EQ(fused.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N - 1; ++i) {
+        EXPECT_TRUE(baseline[i]) << "baseline valid row " << i;
+        EXPECT_TRUE(fused[i])
+            << "fused valid row " << i << " (interior hole is row 1)";
+    }
+    EXPECT_FALSE(baseline[N - 1]) << "NULL tail row must not match";
+    EXPECT_FALSE(fused[N - 1]) << "NULL tail row must not match";
+
+    sealed.reset();
+    CleanupIndexFiles(seg.index_files, "GIS fusion legacy-short-index test");
+}
+
+namespace {
+// RAII toggle for the static geometry-cache switch: restores the previous
+// value even when a gtest ASSERT returns out of the test body early, so a
+// failing test cannot leak the flag into later tests.
+struct GeometryCacheFlagGuard {
+    explicit GeometryCacheFlagGuard(bool enable)
+        : previous_(milvus::segcore::SegcoreConfig::default_config()
+                        .get_enable_geometry_cache()) {
+        milvus::segcore::SegcoreConfig::default_config()
+            .set_enable_geometry_cache(enable);
+    }
+    ~GeometryCacheFlagGuard() {
+        milvus::segcore::SegcoreConfig::default_config()
+            .set_enable_geometry_cache(previous_);
+    }
+    bool previous_;
+};
+
+// Build the WKB column used by the corrupt-row tolerance tests: every row is
+// POINT(0 0) except `bad_row`, whose WKB is truncated (unparseable).
+std::vector<std::string>
+MakeOriginWkbsWithOneCorruptRow(int n, int bad_row) {
+    std::vector<std::string> wkbs;
+    wkbs.reserve(n);
+    auto ctx = GEOS_init_r();
+    std::string origin_wkb =
+        milvus::Geometry(ctx, "POINT(0 0)").to_wkb_string();
+    GEOS_finish_r(ctx);
+    for (int i = 0; i < n; ++i) {
+        if (i == bad_row) {
+            std::string bad = origin_wkb;
+            bad.resize(bad.size() / 2);  // truncate -> unparseable
+            wkbs.emplace_back(std::move(bad));
+        } else {
+            wkbs.emplace_back(origin_wkb);
+        }
+    }
+    return wkbs;
+}
+}  // namespace
+
+// Regression for PR #50951 review (GISFunctionFilterExpr no-cache brute-force
+// branch): with NO index and the geometry cache OFF (the default
+// configuration), a GIS predicate over a segment containing a corrupt WKB row
+// used the throwing Geometry(ctx, wkb) constructor on a per-batch
+// GEOS_init_r() context -- one corrupt row failed the whole query AND leaked
+// the context (the throw skipped GEOS_finish_r). Now the branch parses with
+// TryParseFromWkb on a thread-local context: the query succeeds and the
+// corrupt row simply evaluates to false.
+TEST_F(RTreeIndexTest, GIS_BruteForce_ToleratesCorruptRow_CacheOff) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    GeometryCacheFlagGuard cache_off(false);
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("id", DataType::INT64);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto geo_id = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->set_primary_field_id(pk_id);
+
+    const int N = 40;
+    const int kBad = 7;
+    auto full_ds = DataGen(schema, N);
+    auto sealed =
+        CreateSealedWithFieldDataLoaded(schema, full_ds, false, {geo_id.get()});
+
+    auto wkbs = MakeOriginWkbsWithOneCorruptRow(N, kBad);
+    auto geo_field_data =
+        milvus::storage::CreateFieldData(milvus::storage::DataType::GEOMETRY,
+                                         milvus::storage::DataType::NONE,
+                                         false);
+    geo_field_data->FillFieldData(wkbs.data(), wkbs.size());
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, geo_id.get(), {geo_field_data}, cm);
+    sealed->LoadFieldData(load_info);
+
+    // No index loaded -> ExprExecPath::RawData -> the brute-force macro branch.
+    auto gis_expr = std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+        milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY),
+        proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        "POINT(0 0)");
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, gis_expr);
+    BitsetType bits;
+    ASSERT_NO_THROW(
+        { bits = ExecuteQueryExpr(plan, sealed.get(), N, MAX_TIMESTAMP); });
+    ASSERT_EQ(bits.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        EXPECT_EQ(bool(bits[i]), i != kBad) << "row " << i;
+    }
+}
+
+// Regression for PR #50951 review (GeometryCache.h AppendDataAt, the critical
+// finding): with the geometry cache ENABLED, loading a segment containing one
+// corrupt WKB row used the throwing Geometry ctor inside
+// SimpleGeometryCache::AppendDataAt, so LoadFieldData -> LoadGeometryCache
+// failed the ENTIRE segment load -- exactly the row shape the placeholder-MBR
+// write paths deliberately keep. Now the corrupt row is cached as an invalid
+// entry; the load succeeds and the cache branch of the filter macros skips the
+// row (res=false) instead of tripping its former non-null assert.
+TEST_F(RTreeIndexTest, GIS_CacheOn_CorruptRow_LoadsAndQueries) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    GeometryCacheFlagGuard cache_on(true);
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("id", DataType::INT64);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto geo_id = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->set_primary_field_id(pk_id);
+
+    const int N = 40;
+    const int kBad = 7;
+    auto full_ds = DataGen(schema, N);
+    auto sealed =
+        CreateSealedWithFieldDataLoaded(schema, full_ds, false, {geo_id.get()});
+
+    auto wkbs = MakeOriginWkbsWithOneCorruptRow(N, kBad);
+    auto geo_field_data =
+        milvus::storage::CreateFieldData(milvus::storage::DataType::GEOMETRY,
+                                         milvus::storage::DataType::NONE,
+                                         false);
+    geo_field_data->FillFieldData(wkbs.data(), wkbs.size());
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, geo_id.get(), {geo_field_data}, cm);
+
+    int64_t seg_id = -1;
+    // The critical assertion: the load itself must tolerate the corrupt row.
+    ASSERT_NO_THROW({ sealed->LoadFieldData(load_info); });
+    seg_id = sealed->get_segment_id();
+    auto published_cache = sealed->GetGeometryCache(geo_id);
+    ASSERT_NE(published_cache, nullptr);
+    // Sealed caches live in the immutable published runtime state, not in the
+    // process-global manager. That is what makes a failed/cancelled reopen
+    // discard the staged replacement together with its unpublished column.
+    EXPECT_EQ(milvus::exec::SimpleGeometryCacheManager::Instance().GetCache(
+                  sealed->segment_instance_uid(), seg_id, geo_id),
+              nullptr);
+
+    // Query through the cache branch of the filter macros (cache is enabled
+    // and populated by the load above).
+    auto gis_expr = std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+        milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY),
+        proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        "POINT(0 0)");
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, gis_expr);
+    BitsetType bits;
+    ASSERT_NO_THROW(
+        { bits = ExecuteQueryExpr(plan, sealed.get(), N, MAX_TIMESTAMP); });
+    ASSERT_EQ(bits.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        EXPECT_EQ(bool(bits[i]), i != kBad) << "row " << i;
+    }
+
+    // Model the critical failure boundary of reopen: field loading and cache
+    // construction mutate only a cloned runtime. If a later step throws or is
+    // cancelled before Publish(), discarding that clone must leave the old
+    // column/cache pair visible and must not leak the replacement globally.
+    auto* sealed_impl =
+        dynamic_cast<milvus::segcore::ChunkedSegmentSealedImpl*>(sealed.get());
+    ASSERT_NE(sealed_impl, nullptr);
+    auto staged_runtime = sealed_impl->TestCloneMutableRuntimeResourceState();
+    auto unpublished_cache =
+        std::make_shared<milvus::exec::SimpleGeometryCache>();
+    staged_runtime->geometry_caches[geo_id] = unpublished_cache;
+    EXPECT_EQ(sealed->GetGeometryCache(geo_id), published_cache);
+    EXPECT_NE(sealed->GetGeometryCache(geo_id), unpublished_cache);
+    staged_runtime.reset();
+    EXPECT_EQ(sealed->GetGeometryCache(geo_id), published_cache);
+
+    // Field retirement is another publication boundary: the cache must leave
+    // the runtime snapshot together with the raw column.
+    sealed->DropFieldData(geo_id);
+    EXPECT_EQ(sealed->GetGeometryCache(geo_id), nullptr);
+}
+
+// Regression for PR #50951 review (RTreeIndex::AddGeometry nullability): a row
+// whose valid_data says VALID but whose WKB payload is empty must be indexed
+// as a non-null placeholder row -- exactly how the sealed
+// bulk_load_from_field_data path (is_valid first, then payload) classifies it
+// -- not pushed into null_offset_. Before the fix AddGeometry inferred
+// nullness from wkb_data.empty(), so ST_ISNOTNULL / Count() disagreed between
+// growing and sealed for such a row.
+TEST_F(RTreeIndexTest, AddGeometryClassifiesNullByValidityNotPayload) {
+    field_meta_.field_schema.set_nullable(true);
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    rtree.AddGeometry(CreatePointWKB(1.0, 1.0), 0, true);
+    // Valid row, empty payload -> placeholder MBR, non-null.
+    rtree.AddGeometry(std::string(), 1, true);
+    // Genuinely null row -> null_offset_.
+    rtree.AddGeometry(std::string(), 2, false);
+
+    EXPECT_EQ(rtree.Count(), 3);
+
+    auto is_not_null = rtree.IsNotNull();
+    ASSERT_EQ(is_not_null.size(), 3u);
+    EXPECT_TRUE(is_not_null[0]);
+    EXPECT_TRUE(is_not_null[1]) << "valid empty-payload row must be non-null";
+    EXPECT_FALSE(is_not_null[2]);
+
+    auto is_null = rtree.IsNull();
+    ASSERT_EQ(is_null.size(), 3u);
+    EXPECT_FALSE(is_null[0]);
+    EXPECT_FALSE(is_null[1]);
+    EXPECT_TRUE(is_null[2]);
+}
+
+TEST_F(RTreeIndexTest, QueryBadAllocIsClassifiedAsMemAllocateFailed) {
+    // Distinct field/index ids: the index build temp dir is derived from
+    // collection_partition_segment_field and lives under a PROCESS-global local
+    // storage root, not under this fixture's per-test temp_path_. Reusing the
+    // fixture's field_meta_ {1,1,1,100} therefore inherits the leftovers of the
+    // earlier GIS_Index_Exact_Filtering, and RTreeIndex::Build rejects a
+    // non-empty temp dir -- the same collision GIS_SplitFusion_Equivalence_
+    // Indexed and GIS_Index_Refine_ToleratesUnparseableCandidate avoid.
+    milvus::storage::FieldDataMeta badalloc_field_meta{1, 1, 1, 400};
+    badalloc_field_meta.field_schema.set_data_type(
+        ::milvus::proto::schema::DataType::Geometry);
+    milvus::storage::IndexMeta badalloc_index_meta{1, 400, 1, 1};
+    milvus::storage::FileManagerContext ctx_build(
+        badalloc_field_meta, badalloc_index_meta, chunk_manager_, fs_);
+    TestableRTreeIndex rtree(ctx_build);
+    std::vector<std::string> wkbs = {CreatePointWKB(1.0, 1.0)};
+    rtree.BuildWithRawDataForUT(wkbs.size(), wkbs.data(), {});
+
+    auto dataset = std::make_shared<milvus::Dataset>();
+    dataset->Set(milvus::index::OPERATOR_TYPE,
+                 ::milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects);
+    dataset->Set(milvus::index::MATCH_VALUE,
+                 CreateGeometryFromWkt("POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))"));
+
+    rtree.ThrowOnNextQueryForTesting();
+    try {
+        (void)rtree.Query(dataset);
+        FAIL() << "expected injected query allocation failure";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::MemAllocateFailed);
+    }
+
+    // The hook is one-shot and the failed query did not damage the index.
+    auto result = rtree.Query(dataset);
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_TRUE(result[0]);
+}
+
+// Exercises the growing-segment path where a single writer keeps inserting
+// geometries (RTreeIndex::AddGeometry) while reader threads concurrently call
+// Count() and QueryCandidates(). Before the locking fix these read total row
+// counts / null_offset_ / wrapper_ and the boost rtree size without holding
+// any lock, racing the incremental inserts. Only TSAN can assert the accesses
+// are now properly synchronized; ASAN (what CI runs) catches this class of
+// regression only once it corrupts memory -- e.g. reading wrapper_ or the
+// vectors while another thread reallocates them. Unsanitized, the test still
+// must not crash and must converge to the expected final count.
+//
+// The writer runs on its own thread behind a deadline. It used to run inline
+// on the test thread, which meant that if the readers ever managed to keep the
+// index lock continuously busy the test simply never returned: it took ~96
+// minutes in the plain C++ UT run and blew the coverage shard's 30 minute
+// budget outright, where it was reported as a shard crash rather than as this
+// test. A starved writer must fail here, quickly and by name.
+TEST_F(RTreeIndexTest, GrowingConcurrentAddAndQuery) {
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    // Seed one geometry so wrapper_ is published before readers start querying
+    // (QueryCandidates asserts a non-null wrapper).
+    rtree.AddGeometry(CreatePointWKB(0.0, 0.0), 0, true);
+
+    constexpr int kRows = 1000;
+    // Generous: the writer's own work is milliseconds, so this only bounds how
+    // long a lock-policy regression takes to surface.
+    constexpr auto kWriterDeadline = std::chrono::seconds(120);
+    std::atomic<bool> stop{false};
+    std::atomic<int> reader_iters{0};
+    std::atomic<int> writer_progress{0};
+
+    auto reader = [&]() {
+        auto ctx = GEOS_init_r();
+        // The inner scope is load-bearing: ~Geometry calls
+        // GEOSGeom_destroy_r(ctx_, ...), and locals are destroyed AFTER the
+        // last statement of the enclosing block. With query_geom declared
+        // beside ctx, the trailing GEOS_finish_r would free the context first
+        // and the destructor would run against it -- a use-after-free on every
+        // reader thread, in the very test meant to prove memory safety.
+        {
+            // A box covering the inserted points [0, kRows] x [0, kRows].
+            milvus::Geometry query_geom(
+                ctx,
+                "POLYGON ((-1 -1, 100000 -1, 100000 100000, -1 100000, -1 "
+                "-1))");
+            while (!stop.load(std::memory_order_relaxed)) {
+                volatile int64_t c = rtree.Count();
+                (void)c;
+                std::vector<int64_t> candidates;
+                rtree.QueryCandidates(
+                    ::milvus::proto::plan::
+                        GISFunctionFilterExpr_GISOp_Intersects,
+                    query_geom,
+                    candidates);
+                reader_iters.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+        GEOS_finish_r(ctx);
+    };
+
+    std::vector<std::thread> readers;
+    for (int t = 0; t < 4; ++t) {
+        readers.emplace_back(reader);
+    }
+
+    // Single writer, mirroring the per-segment serialized insert pipeline.
+    std::thread writer([&]() {
+        for (int i = 1; i <= kRows; ++i) {
+            if (i % 7 == 0) {
+                // Interleave null geometries (exercises the null_offset_ path).
+                rtree.AddGeometry(std::string(), i, false);
+            } else {
+                rtree.AddGeometry(CreatePointWKB(static_cast<double>(i),
+                                                 static_cast<double>(i)),
+                                  i,
+                                  true);
+            }
+            writer_progress.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + kWriterDeadline;
+    while (writer_progress.load(std::memory_order_relaxed) < kRows &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    const int progressed = writer_progress.load(std::memory_order_relaxed);
+
+    stop.store(true, std::memory_order_relaxed);
+    writer.join();
+    for (auto& th : readers) {
+        th.join();
+    }
+
+    ASSERT_EQ(progressed, kRows)
+        << "the insert thread was starved by concurrent readers: only "
+        << progressed << " of " << kRows
+        << " rows were inserted within the deadline";
+    EXPECT_GT(reader_iters.load(), 0);
+    // Final count = seeded row 0 plus kRows incremental rows.
+    EXPECT_EQ(rtree.Count(), static_cast<int64_t>(kRows + 1));
+}
+
+// Multiple concurrent writers building the same growing index. This exercises
+// IndexingRecord::AppendingIndex's documented "concurrent, reentrant" contract
+// as defense-in-depth: production currently serializes inserts per growing
+// segment (one flowgraph consumer per vchannel), so this shape is not driven
+// by production today -- the test pins the class-level contract so a future
+// caller change fails here instead of in release. Several threads race on the
+// first-time wrapper_ initialization and then keep inserting. Under TSAN this
+// asserts wrapper_/total_num_rows_/null_offset_ are never touched
+// unsynchronized; under ASAN (what CI runs) it catches only the memory errors
+// an unsynchronized access produces, such as a double-published wrapper_ or a
+// use-after-free from a concurrent vector reallocation. The final count assert
+// pins that the lazy init stayed idempotent.
+TEST_F(RTreeIndexTest, GrowingConcurrentMultiWriter) {
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    constexpr int kWriters = 6;
+    constexpr int kPerWriter = 1000;
+    std::atomic<bool> go{false};
+    std::atomic<bool> stop_readers{false};
+
+    std::vector<std::thread> writers;
+    for (int w = 0; w < kWriters; ++w) {
+        writers.emplace_back([&, w]() {
+            // Spin so every writer hits the first AddGeometry at ~the same time
+            // and they race on the lazy wrapper_ initialization.
+            while (!go.load(std::memory_order_relaxed)) {
+            }
+            for (int j = 0; j < kPerWriter; ++j) {
+                int64_t off = static_cast<int64_t>(w) * kPerWriter + j;
+                if (j % 5 == 0) {
+                    // null geometry
+                    rtree.AddGeometry(std::string(), off, false);
+                } else {
+                    rtree.AddGeometry(CreatePointWKB(static_cast<double>(off),
+                                                     static_cast<double>(off)),
+                                      off,
+                                      true);
+                }
+            }
+        });
+    }
+
+    std::vector<std::thread> readers;
+    for (int r = 0; r < 2; ++r) {
+        readers.emplace_back([&]() {
+            while (!stop_readers.load(std::memory_order_relaxed)) {
+                volatile int64_t c = rtree.Count();  // safe before/after init
+                (void)c;
+            }
+        });
+    }
+
+    go.store(true, std::memory_order_relaxed);
+    for (auto& t : writers) {
+        t.join();
+    }
+    stop_readers.store(true, std::memory_order_relaxed);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    // Every row (null + non-null, disjoint offsets) must be accounted for once.
+    EXPECT_EQ(rtree.Count(), static_cast<int64_t>(kWriters * kPerWriter));
+}
+
+// Regression for the IsNull()/IsNotNull() heap out-of-bounds write on the
+// concurrent multi-writer growing index. Writers assign offsets round-robin so
+// null_offset_ is appended in NON-monotonic order (i.e. unsorted), and each
+// writer may publish a high offset while lower offsets are still in flight, so
+// null_offset_ transiently holds values >= Count(). Readers hammer IsNull()/
+// IsNotNull() throughout ingestion: with the old std::lower_bound shortcut over
+// unsorted data those offsets escaped the bound and wrote past the bitset (a
+// silent OOB in release builds; caught here under ASAN). The final bitsets must
+// also match the exact null / non-null partition.
+TEST_F(RTreeIndexTest, GrowingConcurrentMultiWriterIsNullBounds) {
+    field_meta_.field_schema.set_nullable(true);
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    constexpr int kWriters = 6;
+    constexpr int kTotal = 6000;  // divisible by kWriters
+    // Row is null iff (offset % 3 == 0). Deterministic, independent of thread
+    // scheduling, so the final counts are exact.
+    auto is_null_row = [](int64_t off) { return off % 3 == 0; };
+
+    std::atomic<bool> go{false};
+    std::atomic<bool> stop_readers{false};
+    std::atomic<int64_t> reader_iters{0};
+
+    std::vector<std::thread> writers;
+    for (int w = 0; w < kWriters; ++w) {
+        writers.emplace_back([&, w]() {
+            while (!go.load(std::memory_order_relaxed)) {
+            }
+            // Round-robin offsets: writer w owns w, w+kWriters, w+2*kWriters...
+            // so concurrent writers append null_offset_ out of order.
+            for (int64_t off = w; off < kTotal; off += kWriters) {
+                if (is_null_row(off)) {
+                    rtree.AddGeometry(std::string(), off, false);
+                } else {
+                    rtree.AddGeometry(CreatePointWKB(static_cast<double>(off),
+                                                     static_cast<double>(off)),
+                                      off,
+                                      true);
+                }
+            }
+        });
+    }
+
+    // Readers concurrently drive the previously-unguarded null bitmap paths.
+    // The point is to run IsNull()/IsNotNull() against the growing index while
+    // null_offset_ is unsorted and mid-flight: under ASAN the old lower_bound
+    // shortcut faulted here. We intentionally do NOT cross-check the two
+    // results against each other, because IsNull() and IsNotNull() each take
+    // an independent Count() snapshot and a concurrent writer can grow the row
+    // count between the two calls (so their sizes legitimately differ by the
+    // rows added in between). Per-snapshot correctness is asserted after join.
+    std::vector<std::thread> readers;
+    for (int r = 0; r < 3; ++r) {
+        readers.emplace_back([&]() {
+            while (!stop_readers.load(std::memory_order_relaxed)) {
+                auto is_null = rtree.IsNull();
+                auto is_not_null = rtree.IsNotNull();
+                // Each result is self-consistent: no set bit lies outside its
+                // own length (the invariant the OOB fix restores).
+                EXPECT_LE(is_null.count(), is_null.size());
+                EXPECT_LE(is_not_null.count(), is_not_null.size());
+                reader_iters.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    go.store(true, std::memory_order_relaxed);
+    for (auto& t : writers) {
+        t.join();
+    }
+    stop_readers.store(true, std::memory_order_relaxed);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    EXPECT_GT(reader_iters.load(), 0);
+    EXPECT_EQ(rtree.Count(), static_cast<int64_t>(kTotal));
+
+    int64_t expected_nulls = 0;
+    for (int64_t off = 0; off < kTotal; ++off) {
+        if (is_null_row(off)) {
+            ++expected_nulls;
+        }
+    }
+    auto final_null = rtree.IsNull();
+    auto final_not_null = rtree.IsNotNull();
+    EXPECT_EQ(final_null.count(), expected_nulls);
+    EXPECT_EQ(final_not_null.count(), kTotal - expected_nulls);
+    // Every offset must land in exactly one of the two bitsets.
+    for (int64_t off = 0; off < kTotal; ++off) {
+        EXPECT_EQ(final_null[off], is_null_row(off)) << "offset " << off;
+        EXPECT_EQ(final_not_null[off], !is_null_row(off)) << "offset " << off;
+    }
+}
+
+// Count() feeds the bitmap size in Query(), so on a growing index it must
+// report the row space rather than how many rows happen to be indexed.
+// AddGeometry() is offset-addressed and keeps total_num_rows_ at
+// max(row_offset) + 1, so a sparse or out-of-order offset set makes the two
+// diverge: before the fix Count() returned wrapper->count() + nulls, and every
+// candidate at or above that value was silently clipped by the bound in
+// Query(), turning live rows into false negatives.
+TEST_F(RTreeIndexTest, GrowingSparseOffsetsQueryDropsNoCandidate) {
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    // Three rows at sparse offsets, inserted out of order. Only 3 entries are
+    // indexed, but the row space runs to 101.
+    const std::vector<int64_t> offsets = {100, 0, 50};
+    for (auto off : offsets) {
+        rtree.AddGeometry(CreatePointWKB(1.0, 1.0), off, true);
+    }
+
+    EXPECT_EQ(rtree.Count(), 101)
+        << "Count() must span the row space, not the indexed-entry count";
+
+    auto ds = std::make_shared<milvus::Dataset>();
+    ds->Set(milvus::index::OPERATOR_TYPE,
+            ::milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects);
+    ds->Set(milvus::index::MATCH_VALUE,
+            CreateGeometryFromWkt("POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))"));
+    auto res = rtree.Query(ds);
+
+    ASSERT_EQ(res.size(), 101u);
+    for (auto off : offsets) {
+        EXPECT_TRUE(res[off])
+            << "candidate at offset " << off << " was clipped away";
+    }
+    EXPECT_EQ(res.count(), offsets.size());
+}
+
+// The null path maintains total_num_rows_ too, so a growing index holding
+// nothing but sparse nulls must still report the full row space.
+TEST_F(RTreeIndexTest, GrowingSparseNullOffsetsCountSpansRowSpace) {
+    field_meta_.field_schema.set_nullable(true);
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    rtree.AddGeometry(std::string(), 30, false);
+    rtree.AddGeometry(std::string(), 5, false);
+
+    EXPECT_EQ(rtree.Count(), 31);
+
+    auto is_null = rtree.IsNull();
+    ASSERT_EQ(is_null.size(), 31u);
+    EXPECT_TRUE(is_null[30]);
+    EXPECT_TRUE(is_null[5]);
+    EXPECT_FALSE(is_null[0]);
+}
+
+// Candidate completeness of Query() WHILE writes are in flight -- the window
+// the two GrowingConcurrentMultiWriter* tests leave uncovered (their readers
+// only call Count()/IsNull()/IsNotNull(), and their offset sets are dense, so
+// Count() never diverges from the indexed-entry count mid-flight).
+//
+// The anchor row is published first at a high offset, so from the very first
+// insert the row space is kAnchor+1 while only ONE entry is in the rtree: with
+// the pre-fix Count() (wrapper->count() + nulls) every concurrent reader would
+// size its bitmap at 1 and the bound in Query() would clip the anchor away --
+// a false negative on a committed row, reproduced deterministically instead of
+// depending on thread interleaving.
+//
+// Only EVEN offsets carry a matching point; odd offsets are placed far away.
+// That makes the completeness assertion two-sided and order-independent: the
+// anchor must always be present (no live candidate clipped) and no odd offset
+// may ever appear (no fabricated / mis-bound candidate), whatever the writers
+// have published at the moment the reader takes its snapshot.
+TEST_F(RTreeIndexTest, GrowingConcurrentQueryKeepsPublishedCandidates) {
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    constexpr int64_t kAnchor = 2000;  // even -> matches the query
+    constexpr int kWriters = 4;
+    // Even offsets sit inside the query polygon, odd offsets far outside it.
+    auto matches = [](int64_t off) { return off % 2 == 0; };
+    auto wkb_for = [&](int64_t off) {
+        return matches(off) ? CreatePointWKB(1.0, 1.0)
+                            : CreatePointWKB(1000.0, 1000.0);
+    };
+    auto make_query = []() {
+        auto ds = std::make_shared<milvus::Dataset>();
+        ds->Set(milvus::index::OPERATOR_TYPE,
+                ::milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects);
+        ds->Set(milvus::index::MATCH_VALUE,
+                CreateGeometryFromWkt("POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))"));
+        return ds;
+    };
+
+    // Publish the anchor before anyone reads: it is committed for the whole
+    // run, so no snapshot is ever allowed to miss it.
+    rtree.AddGeometry(wkb_for(kAnchor), kAnchor, true);
+
+    std::atomic<bool> go{false};
+    std::atomic<bool> stop_readers{false};
+    std::atomic<int64_t> reader_iters{0};
+
+    std::vector<std::thread> writers;
+    for (int w = 0; w < kWriters; ++w) {
+        writers.emplace_back([&, w]() {
+            while (!go.load(std::memory_order_relaxed)) {
+            }
+            // Round-robin so offsets reach the index out of order and the
+            // sparse anchor stays above everything still in flight.
+            for (int64_t off = w; off < kAnchor; off += kWriters) {
+                rtree.AddGeometry(wkb_for(off), off, true);
+            }
+        });
+    }
+
+    std::vector<std::thread> readers;
+    for (int r = 0; r < 3; ++r) {
+        readers.emplace_back([&]() {
+            while (!stop_readers.load(std::memory_order_relaxed)) {
+                auto res = rtree.Query(make_query());
+                if (res.size() < static_cast<size_t>(kAnchor + 1)) {
+                    ADD_FAILURE()
+                        << "Count() under-reported the row space mid-flight: "
+                        << res.size() << " < " << (kAnchor + 1);
+                    break;
+                }
+                EXPECT_TRUE(res[kAnchor])
+                    << "committed anchor candidate was clipped away";
+                for (size_t off = 0; off < res.size(); ++off) {
+                    if (res[off] && !matches(static_cast<int64_t>(off))) {
+                        ADD_FAILURE() << "non-matching offset " << off
+                                      << " appeared as a candidate";
+                        break;
+                    }
+                }
+                reader_iters.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    go.store(true, std::memory_order_relaxed);
+    for (auto& t : writers) {
+        t.join();
+    }
+    stop_readers.store(true, std::memory_order_relaxed);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    EXPECT_GT(reader_iters.load(), 0);
+
+    // After ingestion the answer is exact: every even offset in [0, kAnchor].
+    EXPECT_EQ(rtree.Count(), kAnchor + 1);
+    auto final_res = rtree.Query(make_query());
+    ASSERT_EQ(final_res.size(), static_cast<size_t>(kAnchor + 1));
+    for (int64_t off = 0; off <= kAnchor; ++off) {
+        EXPECT_EQ(final_res[off], matches(off)) << "offset " << off;
+    }
+    EXPECT_EQ(final_res.count(), static_cast<size_t>(kAnchor / 2 + 1));
 }

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -109,12 +109,16 @@ CreateWkbFromWkt(const std::string& wkt) {
     return wkb;
 }
 
+// The returned Geometry keeps a pointer to the context it was built on and
+// dereferences it on every copy and in its destructor, so that context must
+// OUTLIVE the returned value. Building on a local context and finishing it
+// here would hand back a Geometry whose ctx_ is already freed -- a
+// use-after-free on the first copy or destruction, not at the call itself.
+// The thread-local context lives until the thread exits, which is what makes
+// returning by value safe.
 static milvus::Geometry
 CreateGeometryFromWkt(const std::string& wkt) {
-    auto ctx = GEOS_init_r();
-    auto geom = milvus::Geometry(ctx, wkt.c_str());
-    GEOS_finish_r(ctx);
-    return geom;
+    return milvus::Geometry(milvus::GetThreadLocalGEOSContext(), wkt.c_str());
 }
 
 struct FileSliceSizeGuard {
@@ -1648,19 +1652,29 @@ TEST_F(RTreeIndexTest, GrowingConcurrentAddAndQuery) {
 
     auto reader = [&]() {
         auto ctx = GEOS_init_r();
-        // A box covering the inserted points [0, kRows] x [0, kRows].
-        milvus::Geometry query_geom(
-            ctx,
-            "POLYGON ((-1 -1, 100000 -1, 100000 100000, -1 100000, -1 -1))");
-        while (!stop.load(std::memory_order_relaxed)) {
-            volatile int64_t c = rtree.Count();
-            (void)c;
-            std::vector<int64_t> candidates;
-            rtree.QueryCandidates(
-                ::milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
-                query_geom,
-                candidates);
-            reader_iters.fetch_add(1, std::memory_order_relaxed);
+        // The inner scope is load-bearing: ~Geometry calls
+        // GEOSGeom_destroy_r(ctx_, ...), and locals are destroyed AFTER the
+        // last statement of the enclosing block. With query_geom declared
+        // beside ctx, the trailing GEOS_finish_r would free the context first
+        // and the destructor would run against it -- a use-after-free on every
+        // reader thread, in the very test meant to prove memory safety.
+        {
+            // A box covering the inserted points [0, kRows] x [0, kRows].
+            milvus::Geometry query_geom(
+                ctx,
+                "POLYGON ((-1 -1, 100000 -1, 100000 100000, -1 100000, -1 "
+                "-1))");
+            while (!stop.load(std::memory_order_relaxed)) {
+                volatile int64_t c = rtree.Count();
+                (void)c;
+                std::vector<int64_t> candidates;
+                rtree.QueryCandidates(
+                    ::milvus::proto::plan::
+                        GISFunctionFilterExpr_GISOp_Intersects,
+                    query_geom,
+                    candidates);
+                reader_iters.fetch_add(1, std::memory_order_relaxed);
+            }
         }
         GEOS_finish_r(ctx);
     };

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -17,6 +17,7 @@
 #include <nlohmann/json_fwd.hpp>
 #include <stddef.h>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <exception>
 #include <functional>
@@ -1621,6 +1622,13 @@ TEST_F(RTreeIndexTest, QueryBadAllocIsClassifiedAsMemAllocateFailed) {
 // regression only once it corrupts memory -- e.g. reading wrapper_ or the
 // vectors while another thread reallocates them. Unsanitized, the test still
 // must not crash and must converge to the expected final count.
+//
+// The writer runs on its own thread behind a deadline. It used to run inline
+// on the test thread, which meant that if the readers ever managed to keep the
+// index lock continuously busy the test simply never returned: it took ~96
+// minutes in the plain C++ UT run and blew the coverage shard's 30 minute
+// budget outright, where it was reported as a shard crash rather than as this
+// test. A starved writer must fail here, quickly and by name.
 TEST_F(RTreeIndexTest, GrowingConcurrentAddAndQuery) {
     milvus::storage::FileManagerContext ctx_build(
         field_meta_, index_meta_, chunk_manager_, fs_);
@@ -1630,9 +1638,13 @@ TEST_F(RTreeIndexTest, GrowingConcurrentAddAndQuery) {
     // (QueryCandidates asserts a non-null wrapper).
     rtree.AddGeometry(CreatePointWKB(0.0, 0.0), 0, true);
 
-    constexpr int kRows = 4000;
+    constexpr int kRows = 1000;
+    // Generous: the writer's own work is milliseconds, so this only bounds how
+    // long a lock-policy regression takes to surface.
+    constexpr auto kWriterDeadline = std::chrono::seconds(120);
     std::atomic<bool> stop{false};
     std::atomic<int> reader_iters{0};
+    std::atomic<int> writer_progress{0};
 
     auto reader = [&]() {
         auto ctx = GEOS_init_r();
@@ -1659,23 +1671,38 @@ TEST_F(RTreeIndexTest, GrowingConcurrentAddAndQuery) {
     }
 
     // Single writer, mirroring the per-segment serialized insert pipeline.
-    for (int i = 1; i <= kRows; ++i) {
-        if (i % 7 == 0) {
-            // Interleave null geometries (exercises the null_offset_ path).
-            rtree.AddGeometry(std::string(), i, false);
-        } else {
-            rtree.AddGeometry(
-                CreatePointWKB(static_cast<double>(i), static_cast<double>(i)),
-                i,
-                true);
+    std::thread writer([&]() {
+        for (int i = 1; i <= kRows; ++i) {
+            if (i % 7 == 0) {
+                // Interleave null geometries (exercises the null_offset_ path).
+                rtree.AddGeometry(std::string(), i, false);
+            } else {
+                rtree.AddGeometry(CreatePointWKB(static_cast<double>(i),
+                                                 static_cast<double>(i)),
+                                  i,
+                                  true);
+            }
+            writer_progress.fetch_add(1, std::memory_order_relaxed);
         }
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + kWriterDeadline;
+    while (writer_progress.load(std::memory_order_relaxed) < kRows &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
+    const int progressed = writer_progress.load(std::memory_order_relaxed);
 
     stop.store(true, std::memory_order_relaxed);
+    writer.join();
     for (auto& th : readers) {
         th.join();
     }
 
+    ASSERT_EQ(progressed, kRows)
+        << "the insert thread was starved by concurrent readers: only "
+        << progressed << " of " << kRows
+        << " rows were inserted within the deadline";
     EXPECT_GT(reader_iters.load(), 0);
     // Final count = seeded row 0 plus kRows incremental rows.
     EXPECT_EQ(rtree.Count(), static_cast<int64_t>(kRows + 1));

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -1256,12 +1256,15 @@ TEST_F(RTreeIndexTest, GIS_Index_Refine_ToleratesUnparseableCandidate) {
     CleanupIndexFiles(stats->GetIndexFiles(), "GIS bad-refine test");
 }
 
-// Regression for the legacy-short-index self-heal: old builders dropped a
-// non-null corrupt/empty geometry but still persisted absolute null offsets.
-// Count() is then smaller than the segment row space, and a tail NULL offset is
-// outside the bitmap returned by parameterless IsNotNull(). Padding that bitmap
-// with true makes NOT ST_* select the NULL row.
-TEST_F(RTreeIndexTest, GIS_LegacyShortIndexPreservesTailNullUnderNot) {
+// Regression for the legacy-short-index self-heal: old builders advanced the
+// absolute row offset even when GEOS parsing failed, so a transient parse OOM
+// could drop a valid geometry at an interior offset while later rows kept their
+// original offsets. Count() then under-reports the row space but does not reveal
+// where the hole is. The fallback must refine the whole segment, not only pad a
+// presumed missing suffix. Absolute null offsets must still preserve SQL
+// three-valued logic under NOT ST_*.
+TEST_F(RTreeIndexTest,
+       GIS_LegacyShortIndexRecoversInteriorHoleAndPreservesTailNull) {
     using namespace milvus;
     using namespace milvus::query;
     using namespace milvus::segcore;
@@ -1280,7 +1283,6 @@ TEST_F(RTreeIndexTest, GIS_LegacyShortIndexPreservesTailNullUnderNot) {
         CreateSealedWithFieldDataLoaded(schema, full_ds, false, {geo_id.get()});
 
     std::vector<std::string> segment_wkbs(N, CreateWkbFromWkt("POINT(0 0)"));
-    segment_wkbs[N - 2].clear();  // legacy builder dropped this non-null row
     segment_wkbs[N - 1].clear();  // payload for the genuine NULL tail row
     const uint8_t valid_bitmap[] = {0x1F};
     auto geo_field_data =
@@ -1295,10 +1297,12 @@ TEST_F(RTreeIndexTest, GIS_LegacyShortIndexPreservesTailNullUnderNot) {
         1, 1, 1, geo_id.get(), {geo_field_data}, cm);
     sealed->LoadFieldData(load_info);
 
-    // Persist the exact legacy shape: rows 0..3 have tree entries, row 4 was a
-    // non-null corrupt/empty geometry dropped by the old builder, and row 5 is
-    // NULL. AddGeometry records the absolute null offset 5, but after reload
-    // Count() is reconstructed as four entries + one NULL = 5.
+    // Persist the exact legacy shape: valid row 1 is absent from the tree (as
+    // if GEOSWKBReader_read_r transiently returned nullptr), later valid rows
+    // retain absolute offsets 2..4, and row 5 is NULL. AddGeometry records the
+    // absolute null offset 5, but after reload Count() is reconstructed as four
+    // tree entries + one NULL = 5. The missing valid row is therefore an
+    // interior hole below Count(), not the suffix bit that resize() would add.
     milvus::storage::FieldDataMeta short_field_meta{1, 1, 1, 500};
     short_field_meta.field_schema.set_data_type(
         ::milvus::proto::schema::DataType::Geometry);
@@ -1308,7 +1312,11 @@ TEST_F(RTreeIndexTest, GIS_LegacyShortIndexPreservesTailNullUnderNot) {
         short_field_meta, short_index_meta, chunk_manager_, fs_);
     auto rtree_index =
         std::make_unique<milvus::index::RTreeIndex<std::string>>(fm_ctx);
-    rtree_index->BuildWithRawDataForUT(4, segment_wkbs.data(), {});
+    rtree_index->InitForBuildIndex(false);
+    rtree_index->AddGeometry(segment_wkbs[0], 0, true);
+    for (int i = 2; i < N - 1; ++i) {
+        rtree_index->AddGeometry(segment_wkbs[i], i, true);
+    }
     rtree_index->AddGeometry(segment_wkbs[N - 1], N - 1, false);
     ASSERT_EQ(rtree_index->Count(), N);
     auto stats = rtree_index->UploadUnified({});
@@ -1337,6 +1345,24 @@ TEST_F(RTreeIndexTest, GIS_LegacyShortIndexPreservesTailNullUnderNot) {
     info.cache_index =
         CreateTestCacheIndex("rtree_legacy_short_key", std::move(rtree_index));
     sealed->LoadIndex(info);
+
+    // The short coarse bitmap has no bit for row 1. A tail-only resize leaves
+    // that interior bit false and silently loses a valid match; the full-scan
+    // fallback must recover it through exact refinement.
+    auto origin_intersects =
+        std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+            milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY, {}, true),
+            proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+            "POINT(0 0)");
+    auto intersects_plan = std::make_shared<plan::FilterBitsNode>(
+        DEFAULT_PLANNODE_ID, origin_intersects);
+    auto intersects_bits =
+        ExecuteQueryExpr(intersects_plan, sealed.get(), N, MAX_TIMESTAMP);
+    ASSERT_EQ(intersects_bits.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N - 1; ++i) {
+        EXPECT_TRUE(intersects_bits[i]) << "valid row " << i;
+    }
+    EXPECT_FALSE(intersects_bits[N - 1]) << "NULL tail row must not match";
 
     auto intersects = std::make_shared<milvus::expr::GISFunctionFilterExpr>(
         milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY, {}, true),

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -16,13 +16,16 @@
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
 #include <stddef.h>
+#include <atomic>
 #include <cstdint>
 #include <exception>
 #include <functional>
+#include <thread>
 #include <initializer_list>
 #include <iostream>
 #include <map>
 #include <memory>
+#include <new>
 #include <optional>
 #include <string>
 #include <utility>
@@ -39,6 +42,7 @@
 #include "common/FieldData.h"
 #include "common/FieldDataInterface.h"
 #include "common/Geometry.h"
+#include "common/GeometryCache.h"
 #include "common/Schema.h"
 #include "common/Tracer.h"
 #include "common/Types.h"
@@ -224,6 +228,17 @@ class RTreeIndexTest : public ::testing::Test {
     milvus_storage::ArrowFileSystemPtr fs_;
 };
 
+class TestableRTreeIndex : public milvus::index::RTreeIndex<std::string> {
+ public:
+    using milvus::index::RTreeIndex<std::string>::RTreeIndex;
+
+    void
+    ThrowOnNextQueryForTesting() {
+        ASSERT_NE(wrapper_, nullptr);
+        wrapper_->SetThrowOnQueryForTesting(true);
+    }
+};
+
 TEST_F(RTreeIndexTest, Build_Upload_Load) {
     // ---------- Build via BuildWithRawDataForUT ----------
     milvus::storage::FileManagerContext ctx_build(
@@ -327,8 +342,13 @@ TEST_F(RTreeIndexTest, Build_WithInvalidWKB_Upload_Load) {
     milvus::tracer::TraceContext trace_ctx;
     rtree_load.LoadUnified(cfg);
 
-    // Only 2 valid points should be present
-    ASSERT_EQ(rtree_load.Count(), 2);
+    // All 3 rows must be present: the row whose WKB fails to parse is indexed
+    // with a placeholder MBR rather than dropped. Dropping it would leave the
+    // index row count permanently short of the segment row count, which then
+    // trips the growing coarse-bitmap bounds check on every subsequent
+    // geometry query. The R-tree is only a coarse filter -- exact refinement
+    // still filters the placeholder row out of any result.
+    ASSERT_EQ(rtree_load.Count(), 3);
 }
 
 TEST_F(RTreeIndexTest, Build_VariousGeometries) {
@@ -543,8 +563,12 @@ TEST_F(RTreeIndexTest, Build_BulkLoad_Nulls_And_BadWKB) {
 
     rtree.Build(build_cfg);
 
-    // expect: 3 geometries (0, 2, 4) are valid and parsable, 1st geometry is marked null and skipped, 3rd geometry is bad WKB and skipped
-    ASSERT_EQ(rtree.Count(), 4);
+    // All 5 rows are indexed. The bad-WKB row (index 3) is NOT dropped: like the
+    // growing add_geometry path, bulk_load now indexes it with a placeholder MBR
+    // so the index row count stays in lockstep with the segment rows, and exact
+    // refinement tolerates the placeholder (Geometry::TryParseFromWkb -> skip) in
+    // every configuration. See PR #50951 review.
+    ASSERT_EQ(rtree.Count(), 5);
 
     // upload -> load back and verify consistency
     auto stats = rtree.UploadUnified({});
@@ -560,7 +584,7 @@ TEST_F(RTreeIndexTest, Build_BulkLoad_Nulls_And_BadWKB) {
 
     milvus::tracer::TraceContext trace_ctx;
     rtree_load.LoadUnified(cfg);
-    ASSERT_EQ(rtree_load.Count(), 4);
+    ASSERT_EQ(rtree_load.Count(), 5);
 }
 
 TEST_F(RTreeIndexTest, LoadSlicedNullOffsets) {
@@ -1108,4 +1132,751 @@ TEST_F(RTreeIndexTest, GIS_SplitFusion_Equivalence_Indexed) {
 
     sealed.reset();
     CleanupIndexFiles(stats->GetIndexFiles(), "GIS split-fusion equivalence");
+}
+
+// Regression for PR #50951 review (RTreeIndexWrapper:212): an unparseable-WKB
+// row is indexed with a placeholder MBR at the origin (never dropped), so an
+// origin-covering query selects it as a coarse candidate. Exact refinement must
+// then tolerate the corrupt WKB instead of throwing. With the geometry cache
+// OFF (the default), refinement re-parses the raw WKB, so before the fix the
+// throwing Geometry(ctx, wkb) ctor failed the ENTIRE query; now
+// Geometry::TryParseFromWkb skips the row. Drives EvalForIndexSegment, which is
+// exactly what stayed green before (the empty/unparseable index tests only
+// check Count(), never a query over such a row).
+TEST_F(RTreeIndexTest, GIS_Index_Refine_ToleratesUnparseableCandidate) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("id", DataType::INT64);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto geo_id = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->set_primary_field_id(pk_id);
+
+    const int N = 40;
+    const int kBad = 7;  // the one unparseable row
+    auto full_ds = DataGen(schema, N);
+    auto sealed =
+        CreateSealedWithFieldDataLoaded(schema, full_ds, false, {geo_id.get()});
+
+    // Every row is POINT(0 0) (so a valid row intersects the origin), except
+    // kBad which is a truncated -- unparseable -- WKB. The placeholder MBR the
+    // index assigns kBad is also the origin, so the origin query below pulls it
+    // into the candidate set and forces refinement to re-parse its raw bytes.
+    std::vector<std::string> wkbs;
+    wkbs.reserve(N);
+    auto ctx = GEOS_init_r();
+    std::string origin_wkb =
+        milvus::Geometry(ctx, "POINT(0 0)").to_wkb_string();
+    GEOS_finish_r(ctx);
+    for (int i = 0; i < N; ++i) {
+        if (i == kBad) {
+            std::string bad = origin_wkb;
+            bad.resize(bad.size() / 2);  // truncate -> unparseable
+            wkbs.emplace_back(std::move(bad));
+        } else {
+            wkbs.emplace_back(origin_wkb);
+        }
+    }
+
+    auto geo_field_data =
+        milvus::storage::CreateFieldData(milvus::storage::DataType::GEOMETRY,
+                                         milvus::storage::DataType::NONE,
+                                         false);
+    geo_field_data->FillFieldData(wkbs.data(), wkbs.size());
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, geo_id.get(), {geo_field_data}, cm);
+    sealed->LoadFieldData(load_info);
+
+    // Distinct field/index ids so the index build temp dir (derived from
+    // collection_partition_segment_field) does not collide with the leftovers
+    // of GIS_Index_Exact_Filtering, which reuses the fixture's {1,1,1,100}.
+    milvus::storage::FieldDataMeta bad_field_meta{1, 1, 1, 300};
+    bad_field_meta.field_schema.set_data_type(
+        ::milvus::proto::schema::DataType::Geometry);
+    milvus::storage::IndexMeta bad_index_meta{1, 300, 1, 1};
+    auto remote_file = (temp_path_.get() / "rtree_bad_refine.parquet").string();
+    WriteGeometryInsertFile(chunk_manager_, bad_field_meta, remote_file, wkbs);
+    milvus::storage::FileManagerContext fm_ctx(
+        bad_field_meta, bad_index_meta, chunk_manager_, fs_);
+    auto rtree_index =
+        std::make_unique<milvus::index::RTreeIndex<std::string>>(fm_ctx);
+    nlohmann::json build_cfg;
+    build_cfg["insert_files"] = std::vector<std::string>{remote_file};
+    build_cfg["index_type"] = milvus::index::RTREE_INDEX_TYPE;
+    rtree_index->Build(build_cfg);
+    auto stats = rtree_index->UploadUnified({});
+
+    milvus::segcore::LoadIndexInfo info{};
+    info.collection_id = 1;
+    info.partition_id = 1;
+    info.segment_id = 1;
+    info.field_id = geo_id.get();
+    info.field_type = DataType::GEOMETRY;
+    info.index_id = 1;
+    info.index_build_id = 1;
+    info.index_version = 1;
+    info.schema = proto::schema::FieldSchema();
+    info.schema.set_data_type(proto::schema::DataType::Geometry);
+    info.index_params["index_type"] = milvus::index::RTREE_INDEX_TYPE;
+    nlohmann::json cfg_load;
+    cfg_load["index_files"] = stats->GetIndexFiles();
+    rtree_index->LoadUnified(cfg_load);
+    info.cache_index =
+        CreateTestCacheIndex("rtree_bad_refine_key", std::move(rtree_index));
+    sealed->LoadIndex(info);
+
+    // Origin-covering intersects query: must NOT throw, must select every valid
+    // origin point and skip the unparseable row.
+    auto gis_expr = std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+        milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY),
+        proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        "POINT(0 0)");
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, gis_expr);
+    BitsetType bits;
+    ASSERT_NO_THROW(
+        { bits = ExecuteQueryExpr(plan, sealed.get(), N, MAX_TIMESTAMP); });
+    ASSERT_EQ(bits.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        EXPECT_EQ(bool(bits[i]), i != kBad) << "row " << i;
+    }
+
+    sealed.reset();
+    CleanupIndexFiles(stats->GetIndexFiles(), "GIS bad-refine test");
+}
+
+namespace {
+// RAII toggle for the static geometry-cache switch: restores the previous
+// value even when a gtest ASSERT returns out of the test body early, so a
+// failing test cannot leak the flag into later tests.
+struct GeometryCacheFlagGuard {
+    explicit GeometryCacheFlagGuard(bool enable)
+        : previous_(milvus::segcore::SegcoreConfig::default_config()
+                        .get_enable_geometry_cache()) {
+        milvus::segcore::SegcoreConfig::default_config()
+            .set_enable_geometry_cache(enable);
+    }
+    ~GeometryCacheFlagGuard() {
+        milvus::segcore::SegcoreConfig::default_config()
+            .set_enable_geometry_cache(previous_);
+    }
+    bool previous_;
+};
+
+// Build the WKB column used by the corrupt-row tolerance tests: every row is
+// POINT(0 0) except `bad_row`, whose WKB is truncated (unparseable).
+std::vector<std::string>
+MakeOriginWkbsWithOneCorruptRow(int n, int bad_row) {
+    std::vector<std::string> wkbs;
+    wkbs.reserve(n);
+    auto ctx = GEOS_init_r();
+    std::string origin_wkb =
+        milvus::Geometry(ctx, "POINT(0 0)").to_wkb_string();
+    GEOS_finish_r(ctx);
+    for (int i = 0; i < n; ++i) {
+        if (i == bad_row) {
+            std::string bad = origin_wkb;
+            bad.resize(bad.size() / 2);  // truncate -> unparseable
+            wkbs.emplace_back(std::move(bad));
+        } else {
+            wkbs.emplace_back(origin_wkb);
+        }
+    }
+    return wkbs;
+}
+}  // namespace
+
+// Regression for PR #50951 review (GISFunctionFilterExpr no-cache brute-force
+// branch): with NO index and the geometry cache OFF (the default
+// configuration), a GIS predicate over a segment containing a corrupt WKB row
+// used the throwing Geometry(ctx, wkb) constructor on a per-batch
+// GEOS_init_r() context -- one corrupt row failed the whole query AND leaked
+// the context (the throw skipped GEOS_finish_r). Now the branch parses with
+// TryParseFromWkb on a thread-local context: the query succeeds and the
+// corrupt row simply evaluates to false.
+TEST_F(RTreeIndexTest, GIS_BruteForce_ToleratesCorruptRow_CacheOff) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    GeometryCacheFlagGuard cache_off(false);
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("id", DataType::INT64);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto geo_id = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->set_primary_field_id(pk_id);
+
+    const int N = 40;
+    const int kBad = 7;
+    auto full_ds = DataGen(schema, N);
+    auto sealed =
+        CreateSealedWithFieldDataLoaded(schema, full_ds, false, {geo_id.get()});
+
+    auto wkbs = MakeOriginWkbsWithOneCorruptRow(N, kBad);
+    auto geo_field_data =
+        milvus::storage::CreateFieldData(milvus::storage::DataType::GEOMETRY,
+                                         milvus::storage::DataType::NONE,
+                                         false);
+    geo_field_data->FillFieldData(wkbs.data(), wkbs.size());
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, geo_id.get(), {geo_field_data}, cm);
+    sealed->LoadFieldData(load_info);
+
+    // No index loaded -> ExprExecPath::RawData -> the brute-force macro branch.
+    auto gis_expr = std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+        milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY),
+        proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        "POINT(0 0)");
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, gis_expr);
+    BitsetType bits;
+    ASSERT_NO_THROW(
+        { bits = ExecuteQueryExpr(plan, sealed.get(), N, MAX_TIMESTAMP); });
+    ASSERT_EQ(bits.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        EXPECT_EQ(bool(bits[i]), i != kBad) << "row " << i;
+    }
+}
+
+// Regression for PR #50951 review (GeometryCache.h AppendDataAt, the critical
+// finding): with the geometry cache ENABLED, loading a segment containing one
+// corrupt WKB row used the throwing Geometry ctor inside
+// SimpleGeometryCache::AppendDataAt, so LoadFieldData -> LoadGeometryCache
+// failed the ENTIRE segment load -- exactly the row shape the placeholder-MBR
+// write paths deliberately keep. Now the corrupt row is cached as an invalid
+// entry; the load succeeds and the cache branch of the filter macros skips the
+// row (res=false) instead of tripping its former non-null assert.
+TEST_F(RTreeIndexTest, GIS_CacheOn_CorruptRow_LoadsAndQueries) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    GeometryCacheFlagGuard cache_on(true);
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("id", DataType::INT64);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto geo_id = schema->AddDebugField("geo", DataType::GEOMETRY);
+    schema->set_primary_field_id(pk_id);
+
+    const int N = 40;
+    const int kBad = 7;
+    auto full_ds = DataGen(schema, N);
+    auto sealed =
+        CreateSealedWithFieldDataLoaded(schema, full_ds, false, {geo_id.get()});
+
+    auto wkbs = MakeOriginWkbsWithOneCorruptRow(N, kBad);
+    auto geo_field_data =
+        milvus::storage::CreateFieldData(milvus::storage::DataType::GEOMETRY,
+                                         milvus::storage::DataType::NONE,
+                                         false);
+    geo_field_data->FillFieldData(wkbs.data(), wkbs.size());
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, geo_id.get(), {geo_field_data}, cm);
+
+    int64_t seg_id = -1;
+    // The critical assertion: the load itself must tolerate the corrupt row.
+    ASSERT_NO_THROW({ sealed->LoadFieldData(load_info); });
+    seg_id = sealed->get_segment_id();
+
+    // Query through the cache branch of the filter macros (cache is enabled
+    // and populated by the load above).
+    auto gis_expr = std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+        milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY),
+        proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        "POINT(0 0)");
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, gis_expr);
+    BitsetType bits;
+    ASSERT_NO_THROW(
+        { bits = ExecuteQueryExpr(plan, sealed.get(), N, MAX_TIMESTAMP); });
+    ASSERT_EQ(bits.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        EXPECT_EQ(bool(bits[i]), i != kBad) << "row " << i;
+    }
+
+    auto sealed_instance_uid = sealed->segment_instance_uid();
+    sealed.reset();
+    milvus::exec::SimpleGeometryCacheManager::Instance().RemoveSegmentCaches(
+        sealed_instance_uid, seg_id);
+}
+
+// Regression for PR #50951 review (RTreeIndex::AddGeometry nullability): a row
+// whose valid_data says VALID but whose WKB payload is empty must be indexed
+// as a non-null placeholder row -- exactly how the sealed
+// bulk_load_from_field_data path (is_valid first, then payload) classifies it
+// -- not pushed into null_offset_. Before the fix AddGeometry inferred
+// nullness from wkb_data.empty(), so ST_ISNOTNULL / Count() disagreed between
+// growing and sealed for such a row.
+TEST_F(RTreeIndexTest, AddGeometryClassifiesNullByValidityNotPayload) {
+    field_meta_.field_schema.set_nullable(true);
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    rtree.AddGeometry(CreatePointWKB(1.0, 1.0), 0, true);
+    // Valid row, empty payload -> placeholder MBR, non-null.
+    rtree.AddGeometry(std::string(), 1, true);
+    // Genuinely null row -> null_offset_.
+    rtree.AddGeometry(std::string(), 2, false);
+
+    EXPECT_EQ(rtree.Count(), 3);
+
+    auto is_not_null = rtree.IsNotNull();
+    ASSERT_EQ(is_not_null.size(), 3u);
+    EXPECT_TRUE(is_not_null[0]);
+    EXPECT_TRUE(is_not_null[1]) << "valid empty-payload row must be non-null";
+    EXPECT_FALSE(is_not_null[2]);
+
+    auto is_null = rtree.IsNull();
+    ASSERT_EQ(is_null.size(), 3u);
+    EXPECT_FALSE(is_null[0]);
+    EXPECT_FALSE(is_null[1]);
+    EXPECT_TRUE(is_null[2]);
+}
+
+TEST_F(RTreeIndexTest, QueryBadAllocIsClassifiedAsMemAllocateFailed) {
+    // Distinct field/index ids: the index build temp dir is derived from
+    // collection_partition_segment_field and lives under a PROCESS-global local
+    // storage root, not under this fixture's per-test temp_path_. Reusing the
+    // fixture's field_meta_ {1,1,1,100} therefore inherits the leftovers of the
+    // earlier GIS_Index_Exact_Filtering, and RTreeIndex::Build rejects a
+    // non-empty temp dir -- the same collision GIS_SplitFusion_Equivalence_
+    // Indexed and GIS_Index_Refine_ToleratesUnparseableCandidate avoid.
+    milvus::storage::FieldDataMeta badalloc_field_meta{1, 1, 1, 400};
+    badalloc_field_meta.field_schema.set_data_type(
+        ::milvus::proto::schema::DataType::Geometry);
+    milvus::storage::IndexMeta badalloc_index_meta{1, 400, 1, 1};
+    milvus::storage::FileManagerContext ctx_build(
+        badalloc_field_meta, badalloc_index_meta, chunk_manager_, fs_);
+    TestableRTreeIndex rtree(ctx_build);
+    std::vector<std::string> wkbs = {CreatePointWKB(1.0, 1.0)};
+    rtree.BuildWithRawDataForUT(wkbs.size(), wkbs.data(), {});
+
+    auto dataset = std::make_shared<milvus::Dataset>();
+    dataset->Set(milvus::index::OPERATOR_TYPE,
+                 ::milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects);
+    dataset->Set(milvus::index::MATCH_VALUE,
+                 CreateGeometryFromWkt("POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))"));
+
+    rtree.ThrowOnNextQueryForTesting();
+    try {
+        (void)rtree.Query(dataset);
+        FAIL() << "expected injected query allocation failure";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::MemAllocateFailed);
+    }
+
+    // The hook is one-shot and the failed query did not damage the index.
+    auto result = rtree.Query(dataset);
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_TRUE(result[0]);
+}
+
+// Exercises the growing-segment path where a single writer keeps inserting
+// geometries (RTreeIndex::AddGeometry) while reader threads concurrently call
+// Count() and QueryCandidates(). Before the locking fix these read total row
+// counts / null_offset_ / wrapper_ and the boost rtree size without holding
+// any lock, racing the incremental inserts. Only TSAN can assert the accesses
+// are now properly synchronized; ASAN (what CI runs) catches this class of
+// regression only once it corrupts memory -- e.g. reading wrapper_ or the
+// vectors while another thread reallocates them. Unsanitized, the test still
+// must not crash and must converge to the expected final count.
+TEST_F(RTreeIndexTest, GrowingConcurrentAddAndQuery) {
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    // Seed one geometry so wrapper_ is published before readers start querying
+    // (QueryCandidates asserts a non-null wrapper).
+    rtree.AddGeometry(CreatePointWKB(0.0, 0.0), 0, true);
+
+    constexpr int kRows = 4000;
+    std::atomic<bool> stop{false};
+    std::atomic<int> reader_iters{0};
+
+    auto reader = [&]() {
+        auto ctx = GEOS_init_r();
+        // A box covering the inserted points [0, kRows] x [0, kRows].
+        milvus::Geometry query_geom(
+            ctx,
+            "POLYGON ((-1 -1, 100000 -1, 100000 100000, -1 100000, -1 -1))");
+        while (!stop.load(std::memory_order_relaxed)) {
+            volatile int64_t c = rtree.Count();
+            (void)c;
+            std::vector<int64_t> candidates;
+            rtree.QueryCandidates(
+                ::milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+                query_geom,
+                candidates);
+            reader_iters.fetch_add(1, std::memory_order_relaxed);
+        }
+        GEOS_finish_r(ctx);
+    };
+
+    std::vector<std::thread> readers;
+    for (int t = 0; t < 4; ++t) {
+        readers.emplace_back(reader);
+    }
+
+    // Single writer, mirroring the per-segment serialized insert pipeline.
+    for (int i = 1; i <= kRows; ++i) {
+        if (i % 7 == 0) {
+            // Interleave null geometries (exercises the null_offset_ path).
+            rtree.AddGeometry(std::string(), i, false);
+        } else {
+            rtree.AddGeometry(
+                CreatePointWKB(static_cast<double>(i), static_cast<double>(i)),
+                i,
+                true);
+        }
+    }
+
+    stop.store(true, std::memory_order_relaxed);
+    for (auto& th : readers) {
+        th.join();
+    }
+
+    EXPECT_GT(reader_iters.load(), 0);
+    // Final count = seeded row 0 plus kRows incremental rows.
+    EXPECT_EQ(rtree.Count(), static_cast<int64_t>(kRows + 1));
+}
+
+// Multiple concurrent writers building the same growing index. This exercises
+// IndexingRecord::AppendingIndex's documented "concurrent, reentrant" contract
+// as defense-in-depth: production currently serializes inserts per growing
+// segment (one flowgraph consumer per vchannel), so this shape is not driven
+// by production today -- the test pins the class-level contract so a future
+// caller change fails here instead of in release. Several threads race on the
+// first-time wrapper_ initialization and then keep inserting. Under TSAN this
+// asserts wrapper_/total_num_rows_/null_offset_ are never touched
+// unsynchronized; under ASAN (what CI runs) it catches only the memory errors
+// an unsynchronized access produces, such as a double-published wrapper_ or a
+// use-after-free from a concurrent vector reallocation. The final count assert
+// pins that the lazy init stayed idempotent.
+TEST_F(RTreeIndexTest, GrowingConcurrentMultiWriter) {
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    constexpr int kWriters = 6;
+    constexpr int kPerWriter = 1000;
+    std::atomic<bool> go{false};
+    std::atomic<bool> stop_readers{false};
+
+    std::vector<std::thread> writers;
+    for (int w = 0; w < kWriters; ++w) {
+        writers.emplace_back([&, w]() {
+            // Spin so every writer hits the first AddGeometry at ~the same time
+            // and they race on the lazy wrapper_ initialization.
+            while (!go.load(std::memory_order_relaxed)) {
+            }
+            for (int j = 0; j < kPerWriter; ++j) {
+                int64_t off = static_cast<int64_t>(w) * kPerWriter + j;
+                if (j % 5 == 0) {
+                    // null geometry
+                    rtree.AddGeometry(std::string(), off, false);
+                } else {
+                    rtree.AddGeometry(CreatePointWKB(static_cast<double>(off),
+                                                     static_cast<double>(off)),
+                                      off,
+                                      true);
+                }
+            }
+        });
+    }
+
+    std::vector<std::thread> readers;
+    for (int r = 0; r < 2; ++r) {
+        readers.emplace_back([&]() {
+            while (!stop_readers.load(std::memory_order_relaxed)) {
+                volatile int64_t c = rtree.Count();  // safe before/after init
+                (void)c;
+            }
+        });
+    }
+
+    go.store(true, std::memory_order_relaxed);
+    for (auto& t : writers) {
+        t.join();
+    }
+    stop_readers.store(true, std::memory_order_relaxed);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    // Every row (null + non-null, disjoint offsets) must be accounted for once.
+    EXPECT_EQ(rtree.Count(), static_cast<int64_t>(kWriters * kPerWriter));
+}
+
+// Regression for the IsNull()/IsNotNull() heap out-of-bounds write on the
+// concurrent multi-writer growing index. Writers assign offsets round-robin so
+// null_offset_ is appended in NON-monotonic order (i.e. unsorted), and each
+// writer may publish a high offset while lower offsets are still in flight, so
+// null_offset_ transiently holds values >= Count(). Readers hammer IsNull()/
+// IsNotNull() throughout ingestion: with the old std::lower_bound shortcut over
+// unsorted data those offsets escaped the bound and wrote past the bitset (a
+// silent OOB in release builds; caught here under ASAN). The final bitsets must
+// also match the exact null / non-null partition.
+TEST_F(RTreeIndexTest, GrowingConcurrentMultiWriterIsNullBounds) {
+    field_meta_.field_schema.set_nullable(true);
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    constexpr int kWriters = 6;
+    constexpr int kTotal = 6000;  // divisible by kWriters
+    // Row is null iff (offset % 3 == 0). Deterministic, independent of thread
+    // scheduling, so the final counts are exact.
+    auto is_null_row = [](int64_t off) { return off % 3 == 0; };
+
+    std::atomic<bool> go{false};
+    std::atomic<bool> stop_readers{false};
+    std::atomic<int64_t> reader_iters{0};
+
+    std::vector<std::thread> writers;
+    for (int w = 0; w < kWriters; ++w) {
+        writers.emplace_back([&, w]() {
+            while (!go.load(std::memory_order_relaxed)) {
+            }
+            // Round-robin offsets: writer w owns w, w+kWriters, w+2*kWriters...
+            // so concurrent writers append null_offset_ out of order.
+            for (int64_t off = w; off < kTotal; off += kWriters) {
+                if (is_null_row(off)) {
+                    rtree.AddGeometry(std::string(), off, false);
+                } else {
+                    rtree.AddGeometry(CreatePointWKB(static_cast<double>(off),
+                                                     static_cast<double>(off)),
+                                      off,
+                                      true);
+                }
+            }
+        });
+    }
+
+    // Readers concurrently drive the previously-unguarded null bitmap paths.
+    // The point is to run IsNull()/IsNotNull() against the growing index while
+    // null_offset_ is unsorted and mid-flight: under ASAN the old lower_bound
+    // shortcut faulted here. We intentionally do NOT cross-check the two
+    // results against each other, because IsNull() and IsNotNull() each take
+    // an independent Count() snapshot and a concurrent writer can grow the row
+    // count between the two calls (so their sizes legitimately differ by the
+    // rows added in between). Per-snapshot correctness is asserted after join.
+    std::vector<std::thread> readers;
+    for (int r = 0; r < 3; ++r) {
+        readers.emplace_back([&]() {
+            while (!stop_readers.load(std::memory_order_relaxed)) {
+                auto is_null = rtree.IsNull();
+                auto is_not_null = rtree.IsNotNull();
+                // Each result is self-consistent: no set bit lies outside its
+                // own length (the invariant the OOB fix restores).
+                EXPECT_LE(is_null.count(), is_null.size());
+                EXPECT_LE(is_not_null.count(), is_not_null.size());
+                reader_iters.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    go.store(true, std::memory_order_relaxed);
+    for (auto& t : writers) {
+        t.join();
+    }
+    stop_readers.store(true, std::memory_order_relaxed);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    EXPECT_GT(reader_iters.load(), 0);
+    EXPECT_EQ(rtree.Count(), static_cast<int64_t>(kTotal));
+
+    int64_t expected_nulls = 0;
+    for (int64_t off = 0; off < kTotal; ++off) {
+        if (is_null_row(off)) {
+            ++expected_nulls;
+        }
+    }
+    auto final_null = rtree.IsNull();
+    auto final_not_null = rtree.IsNotNull();
+    EXPECT_EQ(final_null.count(), expected_nulls);
+    EXPECT_EQ(final_not_null.count(), kTotal - expected_nulls);
+    // Every offset must land in exactly one of the two bitsets.
+    for (int64_t off = 0; off < kTotal; ++off) {
+        EXPECT_EQ(final_null[off], is_null_row(off)) << "offset " << off;
+        EXPECT_EQ(final_not_null[off], !is_null_row(off)) << "offset " << off;
+    }
+}
+
+// Count() feeds the bitmap size in Query(), so on a growing index it must
+// report the row space rather than how many rows happen to be indexed.
+// AddGeometry() is offset-addressed and keeps total_num_rows_ at
+// max(row_offset) + 1, so a sparse or out-of-order offset set makes the two
+// diverge: before the fix Count() returned wrapper->count() + nulls, and every
+// candidate at or above that value was silently clipped by the bound in
+// Query(), turning live rows into false negatives.
+TEST_F(RTreeIndexTest, GrowingSparseOffsetsQueryDropsNoCandidate) {
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    // Three rows at sparse offsets, inserted out of order. Only 3 entries are
+    // indexed, but the row space runs to 101.
+    const std::vector<int64_t> offsets = {100, 0, 50};
+    for (auto off : offsets) {
+        rtree.AddGeometry(CreatePointWKB(1.0, 1.0), off, true);
+    }
+
+    EXPECT_EQ(rtree.Count(), 101)
+        << "Count() must span the row space, not the indexed-entry count";
+
+    auto ds = std::make_shared<milvus::Dataset>();
+    ds->Set(milvus::index::OPERATOR_TYPE,
+            ::milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects);
+    ds->Set(milvus::index::MATCH_VALUE,
+            CreateGeometryFromWkt("POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))"));
+    auto res = rtree.Query(ds);
+
+    ASSERT_EQ(res.size(), 101u);
+    for (auto off : offsets) {
+        EXPECT_TRUE(res[off])
+            << "candidate at offset " << off << " was clipped away";
+    }
+    EXPECT_EQ(res.count(), offsets.size());
+}
+
+// The null path maintains total_num_rows_ too, so a growing index holding
+// nothing but sparse nulls must still report the full row space.
+TEST_F(RTreeIndexTest, GrowingSparseNullOffsetsCountSpansRowSpace) {
+    field_meta_.field_schema.set_nullable(true);
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    rtree.AddGeometry(std::string(), 30, false);
+    rtree.AddGeometry(std::string(), 5, false);
+
+    EXPECT_EQ(rtree.Count(), 31);
+
+    auto is_null = rtree.IsNull();
+    ASSERT_EQ(is_null.size(), 31u);
+    EXPECT_TRUE(is_null[30]);
+    EXPECT_TRUE(is_null[5]);
+    EXPECT_FALSE(is_null[0]);
+}
+
+// Candidate completeness of Query() WHILE writes are in flight -- the window
+// the two GrowingConcurrentMultiWriter* tests leave uncovered (their readers
+// only call Count()/IsNull()/IsNotNull(), and their offset sets are dense, so
+// Count() never diverges from the indexed-entry count mid-flight).
+//
+// The anchor row is published first at a high offset, so from the very first
+// insert the row space is kAnchor+1 while only ONE entry is in the rtree: with
+// the pre-fix Count() (wrapper->count() + nulls) every concurrent reader would
+// size its bitmap at 1 and the bound in Query() would clip the anchor away --
+// a false negative on a committed row, reproduced deterministically instead of
+// depending on thread interleaving.
+//
+// Only EVEN offsets carry a matching point; odd offsets are placed far away.
+// That makes the completeness assertion two-sided and order-independent: the
+// anchor must always be present (no live candidate clipped) and no odd offset
+// may ever appear (no fabricated / mis-bound candidate), whatever the writers
+// have published at the moment the reader takes its snapshot.
+TEST_F(RTreeIndexTest, GrowingConcurrentQueryKeepsPublishedCandidates) {
+    milvus::storage::FileManagerContext ctx_build(
+        field_meta_, index_meta_, chunk_manager_, fs_);
+    milvus::index::RTreeIndex<std::string> rtree(ctx_build);
+
+    constexpr int64_t kAnchor = 2000;  // even -> matches the query
+    constexpr int kWriters = 4;
+    // Even offsets sit inside the query polygon, odd offsets far outside it.
+    auto matches = [](int64_t off) { return off % 2 == 0; };
+    auto wkb_for = [&](int64_t off) {
+        return matches(off) ? CreatePointWKB(1.0, 1.0)
+                            : CreatePointWKB(1000.0, 1000.0);
+    };
+    auto make_query = []() {
+        auto ds = std::make_shared<milvus::Dataset>();
+        ds->Set(milvus::index::OPERATOR_TYPE,
+                ::milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects);
+        ds->Set(milvus::index::MATCH_VALUE,
+                CreateGeometryFromWkt("POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))"));
+        return ds;
+    };
+
+    // Publish the anchor before anyone reads: it is committed for the whole
+    // run, so no snapshot is ever allowed to miss it.
+    rtree.AddGeometry(wkb_for(kAnchor), kAnchor, true);
+
+    std::atomic<bool> go{false};
+    std::atomic<bool> stop_readers{false};
+    std::atomic<int64_t> reader_iters{0};
+
+    std::vector<std::thread> writers;
+    for (int w = 0; w < kWriters; ++w) {
+        writers.emplace_back([&, w]() {
+            while (!go.load(std::memory_order_relaxed)) {
+            }
+            // Round-robin so offsets reach the index out of order and the
+            // sparse anchor stays above everything still in flight.
+            for (int64_t off = w; off < kAnchor; off += kWriters) {
+                rtree.AddGeometry(wkb_for(off), off, true);
+            }
+        });
+    }
+
+    std::vector<std::thread> readers;
+    for (int r = 0; r < 3; ++r) {
+        readers.emplace_back([&]() {
+            while (!stop_readers.load(std::memory_order_relaxed)) {
+                auto res = rtree.Query(make_query());
+                if (res.size() < static_cast<size_t>(kAnchor + 1)) {
+                    ADD_FAILURE()
+                        << "Count() under-reported the row space mid-flight: "
+                        << res.size() << " < " << (kAnchor + 1);
+                    break;
+                }
+                EXPECT_TRUE(res[kAnchor])
+                    << "committed anchor candidate was clipped away";
+                for (size_t off = 0; off < res.size(); ++off) {
+                    if (res[off] && !matches(static_cast<int64_t>(off))) {
+                        ADD_FAILURE() << "non-matching offset " << off
+                                      << " appeared as a candidate";
+                        break;
+                    }
+                }
+                reader_iters.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    go.store(true, std::memory_order_relaxed);
+    for (auto& t : writers) {
+        t.join();
+    }
+    stop_readers.store(true, std::memory_order_relaxed);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    EXPECT_GT(reader_iters.load(), 0);
+
+    // After ingestion the answer is exact: every even offset in [0, kAnchor].
+    EXPECT_EQ(rtree.Count(), kAnchor + 1);
+    auto final_res = rtree.Query(make_query());
+    ASSERT_EQ(final_res.size(), static_cast<size_t>(kAnchor + 1));
+    for (int64_t off = 0; off <= kAnchor; ++off) {
+        EXPECT_EQ(final_res[off], matches(off)) << "offset " << off;
+    }
+    EXPECT_EQ(final_res.count(), static_cast<size_t>(kAnchor / 2 + 1));
 }

--- a/internal/core/src/index/RTreeIndexTest.cpp
+++ b/internal/core/src/index/RTreeIndexTest.cpp
@@ -62,6 +62,7 @@
 #include "plan/PlanNode.h"
 #include "query/ExecPlanNodeVisitor.h"
 #include "query/Utils.h"
+#include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/SegcoreConfig.h"
 #include "segcore/SegmentSealed.h"
 #include "segcore/Types.h"
@@ -1250,6 +1251,108 @@ TEST_F(RTreeIndexTest, GIS_Index_Refine_ToleratesUnparseableCandidate) {
     CleanupIndexFiles(stats->GetIndexFiles(), "GIS bad-refine test");
 }
 
+// Regression for the legacy-short-index self-heal: old builders dropped a
+// non-null corrupt/empty geometry but still persisted absolute null offsets.
+// Count() is then smaller than the segment row space, and a tail NULL offset is
+// outside the bitmap returned by parameterless IsNotNull(). Padding that bitmap
+// with true makes NOT ST_* select the NULL row.
+TEST_F(RTreeIndexTest, GIS_LegacyShortIndexPreservesTailNullUnderNot) {
+    using namespace milvus;
+    using namespace milvus::query;
+    using namespace milvus::segcore;
+
+    auto schema = std::make_shared<Schema>();
+    auto pk_id = schema->AddDebugField("id", DataType::INT64);
+    schema->AddDebugField(
+        "vec", DataType::VECTOR_FLOAT, 16, knowhere::metric::L2);
+    auto geo_id =
+        schema->AddDebugField("geo", DataType::GEOMETRY, true /* nullable */);
+    schema->set_primary_field_id(pk_id);
+
+    constexpr int N = 6;
+    auto full_ds = DataGen(schema, N);
+    auto sealed =
+        CreateSealedWithFieldDataLoaded(schema, full_ds, false, {geo_id.get()});
+
+    std::vector<std::string> segment_wkbs(N, CreateWkbFromWkt("POINT(0 0)"));
+    segment_wkbs[N - 2].clear();  // legacy builder dropped this non-null row
+    segment_wkbs[N - 1].clear();  // payload for the genuine NULL tail row
+    const uint8_t valid_bitmap[] = {0x1F};
+    auto geo_field_data =
+        milvus::storage::CreateFieldData(milvus::storage::DataType::GEOMETRY,
+                                         milvus::storage::DataType::NONE,
+                                         true);
+    geo_field_data->FillFieldData(
+        segment_wkbs.data(), valid_bitmap, segment_wkbs.size(), 0);
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, geo_id.get(), {geo_field_data}, cm);
+    sealed->LoadFieldData(load_info);
+
+    // Persist the exact legacy shape: rows 0..3 have tree entries, row 4 was a
+    // non-null corrupt/empty geometry dropped by the old builder, and row 5 is
+    // NULL. AddGeometry records the absolute null offset 5, but after reload
+    // Count() is reconstructed as four entries + one NULL = 5.
+    milvus::storage::FieldDataMeta short_field_meta{1, 1, 1, 500};
+    short_field_meta.field_schema.set_data_type(
+        ::milvus::proto::schema::DataType::Geometry);
+    short_field_meta.field_schema.set_nullable(true);
+    milvus::storage::IndexMeta short_index_meta{1, 500, 1, 1};
+    milvus::storage::FileManagerContext fm_ctx(
+        short_field_meta, short_index_meta, chunk_manager_, fs_);
+    auto rtree_index =
+        std::make_unique<milvus::index::RTreeIndex<std::string>>(fm_ctx);
+    rtree_index->BuildWithRawDataForUT(4, segment_wkbs.data(), {});
+    rtree_index->AddGeometry(segment_wkbs[N - 1], N - 1, false);
+    ASSERT_EQ(rtree_index->Count(), N);
+    auto stats = rtree_index->UploadUnified({});
+
+    milvus::segcore::LoadIndexInfo info{};
+    info.collection_id = 1;
+    info.partition_id = 1;
+    info.segment_id = 1;
+    info.field_id = geo_id.get();
+    info.field_type = DataType::GEOMETRY;
+    info.index_id = 1;
+    info.index_build_id = 1;
+    info.index_version = 1;
+    info.schema.set_data_type(proto::schema::DataType::Geometry);
+    info.schema.set_nullable(true);
+    info.index_params["index_type"] = milvus::index::RTREE_INDEX_TYPE;
+    nlohmann::json cfg_load;
+    cfg_load["index_files"] = stats->GetIndexFiles();
+    rtree_index->LoadUnified(cfg_load);
+    ASSERT_EQ(rtree_index->Count(), N - 1);
+    auto legacy_validity = rtree_index->IsNotNull();
+    ASSERT_EQ(legacy_validity.size(), N - 1);
+    ASSERT_TRUE(legacy_validity[N - 2]);
+    auto full_validity = rtree_index->IsNotNull(N);
+    ASSERT_FALSE(full_validity[N - 1]);
+    info.cache_index =
+        CreateTestCacheIndex("rtree_legacy_short_key", std::move(rtree_index));
+    sealed->LoadIndex(info);
+
+    auto intersects = std::make_shared<milvus::expr::GISFunctionFilterExpr>(
+        milvus::expr::ColumnInfo(geo_id, DataType::GEOMETRY, {}, true),
+        proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        "POINT(100 100)");
+    auto not_intersects = std::make_shared<milvus::expr::LogicalUnaryExpr>(
+        milvus::expr::LogicalUnaryExpr::OpType::LogicalNot, intersects);
+    auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                       not_intersects);
+    auto bits = ExecuteQueryExpr(plan, sealed.get(), N, MAX_TIMESTAMP);
+
+    ASSERT_EQ(bits.size(), static_cast<size_t>(N));
+    for (int i = 0; i < N - 1; ++i) {
+        EXPECT_TRUE(bits[i]) << "non-null row " << i;
+    }
+    EXPECT_FALSE(bits[N - 1]) << "NULL tail row must remain unknown under NOT";
+
+    sealed.reset();
+    CleanupIndexFiles(stats->GetIndexFiles(), "GIS legacy-short-index test");
+}
+
 namespace {
 // RAII toggle for the static geometry-cache switch: restores the previous
 // value even when a gtest ASSERT returns out of the test body early, so a
@@ -1390,6 +1493,14 @@ TEST_F(RTreeIndexTest, GIS_CacheOn_CorruptRow_LoadsAndQueries) {
     // The critical assertion: the load itself must tolerate the corrupt row.
     ASSERT_NO_THROW({ sealed->LoadFieldData(load_info); });
     seg_id = sealed->get_segment_id();
+    auto published_cache = sealed->GetGeometryCache(geo_id);
+    ASSERT_NE(published_cache, nullptr);
+    // Sealed caches live in the immutable published runtime state, not in the
+    // process-global manager. That is what makes a failed/cancelled reopen
+    // discard the staged replacement together with its unpublished column.
+    EXPECT_EQ(milvus::exec::SimpleGeometryCacheManager::Instance().GetCache(
+                  sealed->segment_instance_uid(), seg_id, geo_id),
+              nullptr);
 
     // Query through the cache branch of the filter macros (cache is enabled
     // and populated by the load above).
@@ -1407,10 +1518,26 @@ TEST_F(RTreeIndexTest, GIS_CacheOn_CorruptRow_LoadsAndQueries) {
         EXPECT_EQ(bool(bits[i]), i != kBad) << "row " << i;
     }
 
-    auto sealed_instance_uid = sealed->segment_instance_uid();
-    sealed.reset();
-    milvus::exec::SimpleGeometryCacheManager::Instance().RemoveSegmentCaches(
-        sealed_instance_uid, seg_id);
+    // Model the critical failure boundary of reopen: field loading and cache
+    // construction mutate only a cloned runtime. If a later step throws or is
+    // cancelled before Publish(), discarding that clone must leave the old
+    // column/cache pair visible and must not leak the replacement globally.
+    auto* sealed_impl =
+        dynamic_cast<milvus::segcore::ChunkedSegmentSealedImpl*>(sealed.get());
+    ASSERT_NE(sealed_impl, nullptr);
+    auto staged_runtime = sealed_impl->TestCloneMutableRuntimeResourceState();
+    auto unpublished_cache =
+        std::make_shared<milvus::exec::SimpleGeometryCache>();
+    staged_runtime->geometry_caches[geo_id] = unpublished_cache;
+    EXPECT_EQ(sealed->GetGeometryCache(geo_id), published_cache);
+    EXPECT_NE(sealed->GetGeometryCache(geo_id), unpublished_cache);
+    staged_runtime.reset();
+    EXPECT_EQ(sealed->GetGeometryCache(geo_id), published_cache);
+
+    // Field retirement is another publication boundary: the cache must leave
+    // the runtime snapshot together with the raw column.
+    sealed->DropFieldData(geo_id);
+    EXPECT_EQ(sealed->GetGeometryCache(geo_id), nullptr);
 }
 
 // Regression for PR #50951 review (RTreeIndex::AddGeometry nullability): a row

--- a/internal/core/src/index/RTreeIndexWrapper.cpp
+++ b/internal/core/src/index/RTreeIndexWrapper.cpp
@@ -18,6 +18,7 @@
 #include <iterator>
 #include <map>
 #include <mutex>
+#include <new>
 
 #include "RTreeIndexSerialization.h"
 #include "RTreeIndexWrapper.h"
@@ -29,6 +30,7 @@
 #include "boost/variant/detail/apply_visitor_unary.hpp"
 #include "common/EasyAssert.h"
 #include "common/FieldDataInterface.h"
+#include "common/Geometry.h"
 #include "fmt/core.h"
 #include "geos_c.h"
 #include "glog/logging.h"
@@ -48,56 +50,173 @@ RTreeIndexWrapper::RTreeIndexWrapper(std::string& path, bool is_build_mode)
         }
         // Start with an empty rtree for dynamic insertions
         rtree_ = RTree();
+        entry_count_.store(0, std::memory_order_release);
     }
 }
 
 RTreeIndexWrapper::~RTreeIndexWrapper() = default;
 
 void
+RTreeIndexWrapper::ensure_rtree_consistent_locked() const {
+    if (!rtree_needs_rebuild_) {
+        return;
+    }
+
+    // Construct before swap so another allocation failure leaves the poisoned
+    // tree isolated and the rebuild flag set for a later retry.
+    try {
+        RTree rebuilt(values_.begin(), values_.end());
+        rtree_.swap(rebuilt);
+        rtree_needs_rebuild_ = false;
+    } catch (const std::bad_alloc&) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory rebuilding R-Tree after failed insert");
+    }
+}
+
+std::shared_lock<folly::SharedMutexWritePriority>
+RTreeIndexWrapper::lock_consistent_rtree_for_read() const {
+    for (;;) {
+        std::shared_lock<folly::SharedMutexWritePriority> read_guard(
+            rtree_mutex_);
+        if (!rtree_needs_rebuild_) {
+            return read_guard;
+        }
+
+        read_guard.unlock();
+        std::unique_lock<folly::SharedMutexWritePriority> write_guard(
+            rtree_mutex_);
+        ensure_rtree_consistent_locked();
+    }
+}
+
+void
+RTreeIndexWrapper::insert_value_locked(const Box& box, int64_t row_offset) {
+    // values_ is the authoritative committed set; rtree_ is a derived
+    // structure that Boost may leave inconsistent when insert throws (it
+    // documents only the basic guarantee). So the two are kept in step by
+    // rolling values_ back and flagging the tree for a rebuild -- NOT by
+    // trusting the tree to be unmodified:
+    //   1. values_.push_back may throw -- nothing else mutated yet;
+    //   2. rtree_.insert may throw -- roll values_ back (pop_back, noexcept)
+    //      and mark the tree for rebuild from values_ before its next use.
+    Value val(box, row_offset);
+    values_.push_back(val);
+    try {
+        rtree_.insert(val);
+        if (throw_after_insert_for_testing_) {
+            throw_after_insert_for_testing_ = false;
+            throw std::bad_alloc();
+        }
+    } catch (...) {
+        values_.pop_back();
+        rtree_needs_rebuild_ = true;
+        throw;
+    }
+    // Published last: the row is only committed once both structures accepted
+    // it, so a lock-free count() never reports a row that was rolled back.
+    entry_count_.store(static_cast<int64_t>(values_.size()),
+                       std::memory_order_release);
+}
+
+void
 RTreeIndexWrapper::add_geometry(const uint8_t* wkb_data,
                                 size_t len,
                                 int64_t row_offset) {
     // Acquire write lock to protect rtree_
-    std::unique_lock<std::shared_mutex> guard(rtree_mutex_);
+    std::unique_lock<folly::SharedMutexWritePriority> guard(rtree_mutex_);
 
     AssertInfo(is_build_mode_, "Cannot add geometry in load mode");
+    ensure_rtree_consistent_locked();
 
-    // Parse WKB data using GEOS for consistency
-    GEOSContextHandle_t ctx = GEOS_init_r();
-    if (ctx == nullptr) {
-        LOG_ERROR("Failed to initialize GEOS context for row {}", row_offset);
+    // Index a deterministic placeholder MBR for a row whose WKB payload is
+    // genuinely unparseable (empty or corrupt DATA), without dropping it. The
+    // R-tree is only a coarse filter and exact refinement tolerates the
+    // placeholder (Geometry::TryParseFromWkb -> skip) in every configuration,
+    // so a placeholder never yields a wrong result -- but dropping the row
+    // would permanently desynchronize the index row count from the segment row
+    // count, which then trips the coarse-bitmap bounds guard in
+    // EvalForIndexSegment on EVERY subsequent geometry query against this
+    // segment. This mirrors the empty-geometry handling below and bulk_load.
+    //
+    // This is ONLY for bad data. A transient resource failure (GEOS context /
+    // reader allocation) on a perfectly valid geometry must NOT take this path:
+    // a (0,0) placeholder would permanently mis-locate a good row, silently
+    // dropping it from every query that does not cover the origin. Those cases
+    // throw instead, so the insert fails and can be retried.
+    //
+    // Tradeoff: Point(0, 0) is a legal coordinate (Null Island), so any query
+    // whose bounding box covers the origin pulls every placeholder row in this
+    // segment into the candidate set and pays exact refinement for it (which
+    // then discards the row). World-scale bbox queries almost always cover the
+    // origin, so segments with many empty/corrupt geometries make such queries
+    // proportionally more expensive. Correctness is unaffected.
+    auto index_placeholder_mbr = [&]() {
+        insert_value_locked(Box(Point(0, 0), Point(0, 0)), row_offset);
+    };
+
+    // Parse WKB data using GEOS for consistency. InitGEOSContext throws a
+    // retriable MemAllocateFailed on a transient allocation failure, so a
+    // valid geometry fails the insert (and can be retried) rather than being
+    // permanently mis-indexed. All GEOS resources are scoped: if any
+    // container op below throws (retried by the caller), nothing leaks.
+    ScopedGeosResources geos("add_geometry");
+
+    geos.reader = GEOSWKBReader_create_r(geos.ctx);
+    if (geos.reader == nullptr) {
+        // Transient resource failure -- see above; throw rather than placeholder.
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "Failed to create GEOS WKB reader for row {}",
+                  row_offset);
+    }
+
+    geos.geom = GEOSWKBReader_read_r(geos.ctx, geos.reader, wkb_data, len);
+
+    if (geos.geom == nullptr) {
+        // nullptr here is *usually* unparseable WKB, but GEOS's execute()
+        // wrapper also swallows a transient OOM during parsing into the same
+        // nullptr -- the two are indistinguishable at this boundary, and both
+        // are deliberately classified as bad data (see the KNOWN LIMIT note
+        // on Geometry::TryParseFromWkb).
+        static std::atomic<int64_t> last_parse_log_us{0};
+        if (ShouldLogGeometryThrottled(last_parse_log_us)) {
+            LOG_ERROR(
+                "Failed to parse WKB data for row {}; indexing a placeholder "
+                "MBR to keep the index row count consistent (further "
+                "occurrences suppressed briefly)",
+                row_offset);
+        } else {
+            LOG_DEBUG("Failed to parse WKB data for row {}", row_offset);
+        }
+        index_placeholder_mbr();
         return;
     }
 
-    GEOSWKBReader* reader = GEOSWKBReader_create_r(ctx);
-    if (reader == nullptr) {
-        GEOS_finish_r(ctx);
-        LOG_ERROR("Failed to create GEOS WKB reader for row {}", row_offset);
-        return;
+    // Get bounding box. On failure (e.g. empty geometry) keep a deterministic
+    // placeholder MBR and still index the row: the R-tree is only a coarse
+    // filter, the exact predicate refines it out, and dropping the row here
+    // would desynchronize the index row count from the segment row count.
+    double minX = 0, minY = 0, maxX = 0, maxY = 0;
+    if (!get_bounding_box(geos.geom, geos.ctx, minX, minY, maxX, maxY)) {
+        static std::atomic<int64_t> last_envelope_log_us{0};
+        if (ShouldLogGeometryThrottled(last_envelope_log_us)) {
+            LOG_WARN(
+                "geometry at row {} has no computable envelope (empty?); "
+                "indexing with a placeholder MBR, exact refinement will "
+                "filter it (further occurrences suppressed briefly)",
+                row_offset);
+        } else {
+            LOG_DEBUG("geometry at row {} has no computable envelope",
+                      row_offset);
+        }
     }
+    // The geometry is no longer needed once the MBR is extracted; release it
+    // before the (potentially throwing) container ops.
+    geos.release_geom();
 
-    GEOSGeometry* geom = GEOSWKBReader_read_r(ctx, reader, wkb_data, len);
-    GEOSWKBReader_destroy_r(ctx, reader);
-
-    if (geom == nullptr) {
-        GEOS_finish_r(ctx);
-        LOG_ERROR("Failed to parse WKB data for row {}", row_offset);
-        return;
-    }
-
-    // Get bounding box
-    double minX, minY, maxX, maxY;
-    get_bounding_box(geom, ctx, minX, minY, maxX, maxY);
-
-    // Create Boost box and insert
-    Box box(Point(minX, minY), Point(maxX, maxY));
-    Value val(box, row_offset);
-    values_.push_back(val);
-    rtree_.insert(val);
-
-    // Clean up
-    GEOSGeom_destroy_r(ctx, geom);
-    GEOS_finish_r(ctx);
+    // Create Boost box and insert (idempotent per offset; a throwing Boost tree
+    // is rebuilt from committed values before reuse).
+    insert_value_locked(Box(Point(minX, minY), Point(maxX, maxY)), row_offset);
 }
 
 // No IDataStream; bulk-load implemented directly for Boost R-tree
@@ -107,27 +226,40 @@ RTreeIndexWrapper::bulk_load_from_field_data(
     const std::vector<std::shared_ptr<::milvus::FieldDataBase>>& field_datas,
     bool nullable) {
     // Acquire write lock to protect rtree_ creation and modification
-    std::unique_lock<std::shared_mutex> guard(rtree_mutex_);
+    std::unique_lock<folly::SharedMutexWritePriority> guard(rtree_mutex_);
 
     AssertInfo(is_build_mode_, "Cannot bulk load in load mode");
 
-    // Initialize GEOS context for bulk operations
-    GEOSContextHandle_t ctx = GEOS_init_r();
-    if (ctx == nullptr) {
-        LOG_ERROR("Failed to initialize GEOS context for bulk load");
-        return;
+    // Initialize GEOS context for bulk operations. A transient allocation
+    // failure here would otherwise silently drop EVERY row from the index --
+    // InitGEOSContext throws a retriable error so the build fails and can be
+    // retried instead. Scoped so a throwing container op inside the loop
+    // (e.g. local_values.emplace_back on OOM) cannot leak the reader/context
+    // across the retry.
+    ScopedGeosResources geos("bulk load");
+
+    geos.reader = GEOSWKBReader_create_r(geos.ctx);
+    if (geos.reader == nullptr) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "Failed to create GEOS WKB reader for bulk load");
     }
 
-    GEOSWKBReader* reader = GEOSWKBReader_create_r(ctx);
-    if (reader == nullptr) {
-        GEOS_finish_r(ctx);
-        LOG_ERROR("Failed to create GEOS WKB reader for bulk load");
-        return;
-    }
-
+    // NOTE: non-null rows with an empty or unparseable WKB payload are indexed
+    // with a deterministic placeholder MBR (like the growing add_geometry
+    // path), NOT dropped. Growing and sealed now agree -- neither write path
+    // drops a row -- so the index row count stays in lockstep with the segment
+    // rows on both, and exact refinement tolerates the placeholder
+    // (Geometry::TryParseFromWkb -> skip) in every configuration, cache on or
+    // off. A corrupt/empty row can never satisfy exact refinement, so the
+    // placeholder is always refined out and correctness is unaffected; the only
+    // cost is that an origin-covering query pays refinement for it (see the
+    // add_geometry tradeoff note). Genuinely null rows are still skipped below.
     std::vector<Value> local_values;
     local_values.reserve(1024);
     int64_t absolute_offset = 0;
+    const auto index_placeholder = [&](int64_t offset) {
+        local_values.emplace_back(Box(Point(0, 0), Point(0, 0)), offset);
+    };
     for (const auto& fd : field_datas) {
         const auto n = fd->get_num_rows();
         const bool is_nullable_effective = nullable || fd->IsNullable();
@@ -138,32 +270,59 @@ RTreeIndexWrapper::bulk_load_from_field_data(
             const auto* wkb_str =
                 static_cast<const std::string*>(fd->RawValue(i));
             if (wkb_str == nullptr || wkb_str->empty()) {
+                index_placeholder(absolute_offset);
                 continue;
             }
 
-            GEOSGeometry* geom = GEOSWKBReader_read_r(
-                ctx,
-                reader,
+            geos.geom = GEOSWKBReader_read_r(
+                geos.ctx,
+                geos.reader,
                 reinterpret_cast<const unsigned char*>(wkb_str->data()),
                 wkb_str->size());
-            if (geom == nullptr) {
+            if (geos.geom == nullptr) {
+                // Same classification as add_geometry(): unparseable WKB and
+                // a GEOS-swallowed parse-time OOM both surface as nullptr and
+                // both get a placeholder MBR (see Geometry::TryParseFromWkb).
+                index_placeholder(absolute_offset);
                 continue;
             }
 
-            double minX, minY, maxX, maxY;
-            get_bounding_box(geom, ctx, minX, minY, maxX, maxY);
-            GEOSGeom_destroy_r(ctx, geom);
+            // See add_geometry(): keep a deterministic placeholder MBR for a
+            // geometry without a computable envelope so the row stays indexed
+            // and the row count remains consistent.
+            double minX = 0, minY = 0, maxX = 0, maxY = 0;
+            if (!get_bounding_box(
+                    geos.geom, geos.ctx, minX, minY, maxX, maxY)) {
+                static std::atomic<int64_t> last_bulk_envelope_log_us{0};
+                if (ShouldLogGeometryThrottled(last_bulk_envelope_log_us)) {
+                    LOG_WARN(
+                        "geometry at row {} has no computable envelope "
+                        "(empty?); indexing with a placeholder MBR (further "
+                        "occurrences suppressed briefly)",
+                        absolute_offset);
+                } else {
+                    LOG_DEBUG("geometry at row {} has no computable envelope",
+                              absolute_offset);
+                }
+            }
+            // Release before the (potentially throwing) emplace_back.
+            geos.release_geom();
 
             Box box(Point(minX, minY), Point(maxX, maxY));
             local_values.emplace_back(box, absolute_offset);
         }
     }
 
-    // Clean up GEOS resources
-    GEOSWKBReader_destroy_r(ctx, reader);
-    GEOS_finish_r(ctx);
+    // Publish transactionally: build the tree from the staged values FIRST
+    // (its bulk ctor can throw bad_alloc), then install both structures with
+    // non-throwing swap/move -- a failed attempt leaves values_/rtree_
+    // untouched, so the retried bulk load starts from a consistent state.
+    RTree new_tree(local_values.begin(), local_values.end());
     values_.swap(local_values);
-    rtree_ = RTree(values_.begin(), values_.end());
+    rtree_.swap(new_tree);
+    rtree_needs_rebuild_ = false;
+    entry_count_.store(static_cast<int64_t>(values_.size()),
+                       std::memory_order_release);
     LOG_INFO("R-Tree bulk load (Boost) completed with {} entries",
              values_.size());
 }
@@ -174,18 +333,28 @@ RTreeIndexWrapper::finish() {
     // Guard against repeated invocations which could otherwise attempt to
     // release resources multiple times (e.g. BuildWithRawDataForUT() calls
     // finish(), and Upload() may call it again).
-    std::unique_lock<std::shared_mutex> guard(rtree_mutex_);
+    std::unique_lock<folly::SharedMutexWritePriority> guard(rtree_mutex_);
     if (finished_) {
         LOG_DEBUG("RTreeIndexWrapper::finish() called more than once, skip.");
         return;
     }
 
     AssertInfo(is_build_mode_, "Cannot finish in load mode");
+    ensure_rtree_consistent_locked();
 
     // Persist to disk: write meta and binary data file
     try {
-        // Write binary rtree data
-        RTreeSerializer::saveBinary(rtree_, index_path_ + ".bgi");
+        // Write binary rtree data. The serializer reports failures instead of
+        // throwing, so checking its result is part of the persistence
+        // contract: an index without a durable tree must never be uploaded as
+        // successfully built.
+        auto binary_path = index_path_ + ".bgi";
+        auto save_result = RTreeSerializer::saveBinary(rtree_, binary_path);
+        if (save_result != RTreeSerializer::BinaryIOResult::Success) {
+            ThrowInfo(ErrorCode::FileWriteFailed,
+                      "Failed to write R-Tree binary file: {}",
+                      binary_path);
+        }
 
         // Write meta json
         nlohmann::json meta;
@@ -203,8 +372,22 @@ RTreeIndexWrapper::finish() {
                       "Failed to write R-Tree meta file: {}.meta.json",
                       index_path_);
         }
+        // Check close(), not just the insertion above: a delayed-allocation
+        // filesystem reports ENOSPC/EIO for the flushed blocks at close(2),
+        // and an unchecked close leaves a truncated meta.json looking written.
         ofs.close();
+        if (!ofs.good()) {
+            ThrowInfo(ErrorCode::FileWriteFailed,
+                      "Failed to close R-Tree meta file: {}.meta.json",
+                      index_path_);
+        }
         LOG_INFO("R-Tree meta written: {}.meta.json", index_path_);
+    } catch (const SegcoreError&) {
+        throw;
+    } catch (const std::bad_alloc&) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory writing R-Tree files for {}",
+                  index_path_);
     } catch (const std::exception& e) {
         ThrowInfo(ErrorCode::UnexpectedError,
                   fmt::format("Failed to write R-Tree files: {}", e.what()));
@@ -219,7 +402,7 @@ RTreeIndexWrapper::finish() {
 void
 RTreeIndexWrapper::load() {
     // Acquire write lock to protect rtree_ initialization during loading
-    std::unique_lock<std::shared_mutex> guard(rtree_mutex_);
+    std::unique_lock<folly::SharedMutexWritePriority> guard(rtree_mutex_);
 
     AssertInfo(!is_build_mode_, "Cannot load in build mode");
 
@@ -233,14 +416,43 @@ RTreeIndexWrapper::load() {
                 if (meta.contains("dimension"))
                     dimension_ = meta["dimension"].get<uint32_t>();
             }
+        } catch (const std::bad_alloc&) {
+            throw;
         } catch (const std::exception& e) {
             LOG_WARN("Failed to read meta json: {}", e.what());
         }
 
-        // Read binary data
-        RTreeSerializer::loadBinary(rtree_, index_path_ + ".bgi");
+        // Deserialize into a temporary tree. A truncated archive can mutate
+        // its destination before reporting failure; only swap it into the live
+        // wrapper after the whole archive has been validated.
+        auto binary_path = index_path_ + ".bgi";
+        RTree loaded;
+        auto load_result = RTreeSerializer::loadBinary(loaded, binary_path);
+        if (load_result == RTreeSerializer::BinaryIOResult::OpenFailed ||
+            load_result == RTreeSerializer::BinaryIOResult::StreamFailed) {
+            ThrowInfo(ErrorCode::FileReadFailed,
+                      "Failed to read R-Tree binary file: {}",
+                      binary_path);
+        }
+        if (load_result == RTreeSerializer::BinaryIOResult::ArchiveFailed) {
+            ThrowInfo(ErrorCode::DataFormatBroken,
+                      "Corrupt R-Tree binary file: {}",
+                      binary_path);
+        }
+        rtree_.swap(loaded);
+        rtree_needs_rebuild_ = false;
+        // The load path deserializes straight into the tree and never fills
+        // values_, so the tree is the only row-count source here.
+        entry_count_.store(static_cast<int64_t>(rtree_.size()),
+                           std::memory_order_release);
 
         LOG_INFO("R-Tree index (Boost) loaded from {}", index_path_);
+    } catch (const SegcoreError&) {
+        throw;
+    } catch (const std::bad_alloc&) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory loading R-Tree index from {}",
+                  index_path_);
     } catch (const std::exception& e) {
         ThrowInfo(ErrorCode::UnexpectedError,
                   fmt::format("Failed to load R-Tree index from {}: {}",
@@ -254,11 +466,47 @@ RTreeIndexWrapper::query_candidates(proto::plan::GISFunctionFilterExpr_GISOp op,
                                     const GEOSGeometry* query_geom,
                                     GEOSContextHandle_t ctx,
                                     std::vector<int64_t>& candidate_offsets) {
+    if (throw_on_query_for_testing_.exchange(false)) {
+        throw std::bad_alloc();
+    }
+
     candidate_offsets.clear();
 
-    // Get bounding box of query geometry
+    // The shared lock below is taken ONLY around the statements that touch
+    // rtree_. Everything else here -- the envelope of the caller's query
+    // geometry, and copying offsets out of the local `results` -- is
+    // thread-private, and holding the lock across it would stretch the read
+    // critical section (the copy is proportional to the candidate count, so on
+    // a large growing segment it is the dominant part) for no benefit. Readers
+    // that hold the lock longer than necessary are exactly what makes the
+    // per-row insert lock hard to acquire.
+    //
+    // Get bounding box of query geometry. An empty/degenerate query geometry
+    // has no envelope. For the spatial predicates (Intersects / Within /
+    // Contains / Touches / Overlaps / Crosses) it intersects nothing, so there
+    // are no candidates. ST_Equals is different: an empty query geometry must
+    // still match empty FIELD geometries, which this index stores with a
+    // placeholder MBR (see add_geometry) -- returning zero candidates for
+    // Equals would be a false negative versus the un-indexed data path, where
+    // GEOSEquals(empty, empty) is true. So for Equals, fall back to the full
+    // candidate set and let exact refinement keep only the true matches.
+    //
+    // NOTE: this fallback is an INTENTIONAL full scan. A single
+    // ST_Equals(field, 'POLYGON EMPTY') degenerates into an exact-refinement
+    // pass over every indexed row of the segment. That cost is accepted to
+    // preserve correctness; do not "optimize" the branch away without an
+    // alternative way to find placeholder-MBR rows.
     double minX, minY, maxX, maxY;
-    get_bounding_box(query_geom, ctx, minX, minY, maxX, maxY);
+    if (!get_bounding_box(query_geom, ctx, minX, minY, maxX, maxY)) {
+        if (op == proto::plan::GISFunctionFilterExpr_GISOp_Equals) {
+            auto tree_guard = lock_consistent_rtree_for_read();
+            candidate_offsets.reserve(rtree_.size());
+            for (const auto& v : rtree_) {
+                candidate_offsets.push_back(v.second);
+            }
+        }
+        return;
+    }
 
     // Create query box
     Box query_box(Point(minX, minY), Point(maxX, maxY));
@@ -266,7 +514,7 @@ RTreeIndexWrapper::query_candidates(proto::plan::GISFunctionFilterExpr_GISOp op,
     // Perform coarse intersection query
     std::vector<Value> results;
     {
-        std::shared_lock<std::shared_mutex> guard(rtree_mutex_);
+        auto tree_guard = lock_consistent_rtree_for_read();
         rtree_.query(boost::geometry::index::intersects(query_box),
                      std::back_inserter(results));
     }
@@ -280,7 +528,7 @@ RTreeIndexWrapper::query_candidates(proto::plan::GISFunctionFilterExpr_GISOp op,
               static_cast<int>(op));
 }
 
-void
+bool
 RTreeIndexWrapper::get_bounding_box(const GEOSGeometry* geom,
                                     GEOSContextHandle_t ctx,
                                     double& minX,
@@ -290,19 +538,34 @@ RTreeIndexWrapper::get_bounding_box(const GEOSGeometry* geom,
     AssertInfo(geom != nullptr, "Geometry is null");
     AssertInfo(ctx != nullptr, "GEOS context is null");
 
-    GEOSGeom_getXMin_r(ctx, geom, &minX);
-    GEOSGeom_getXMax_r(ctx, geom, &maxX);
-    GEOSGeom_getYMin_r(ctx, geom, &minY);
-    GEOSGeom_getYMax_r(ctx, geom, &maxY);
+    // GEOSGeom_get{X,Y}{Min,Max}_r return 0 on failure (e.g. empty geometry)
+    // and leave the output untouched; using such uninitialized coordinates
+    // would insert a garbage MBR into the R-tree. Report failure instead.
+    if (GEOSGeom_getXMin_r(ctx, geom, &minX) == 0 ||
+        GEOSGeom_getXMax_r(ctx, geom, &maxX) == 0 ||
+        GEOSGeom_getYMin_r(ctx, geom, &minY) == 0 ||
+        GEOSGeom_getYMax_r(ctx, geom, &maxY) == 0) {
+        return false;
+    }
+    return true;
 }
 
 int64_t
 RTreeIndexWrapper::count() const {
-    return static_cast<int64_t>(rtree_.size());
+    // Deliberately lock-free. rtree_ is mutated by add_geometry() /
+    // bulk_load_from_field_data() / load() under the exclusive lock, so
+    // reading rtree_.size() would need the shared lock -- and every
+    // growing-segment search calls this once (RTreeIndex::Query sizes its
+    // bitmap by Count()), so that acquisition lands squarely on the search
+    // path and adds to the read pressure the insert thread has to push
+    // through. entry_count_ is published by each of those mutation points
+    // while they hold the lock, which is all a row count needs.
+    return entry_count_.load(std::memory_order_acquire);
 }
 
 int64_t
 RTreeIndexWrapper::ByteSize() const {
+    auto guard = lock_consistent_rtree_for_read();
     int64_t total = 0;
 
     // values_: vector<Value> where Value = std::pair<Box, int64_t>
@@ -316,6 +579,17 @@ RTreeIndexWrapper::ByteSize() const {
     total += rtree_.size() * 18;
 
     return total;
+}
+
+void
+RTreeIndexWrapper::SetThrowAfterInsertForTesting(bool enabled) {
+    std::unique_lock<folly::SharedMutexWritePriority> guard(rtree_mutex_);
+    throw_after_insert_for_testing_ = enabled;
+}
+
+void
+RTreeIndexWrapper::SetThrowOnQueryForTesting(bool enabled) {
+    throw_on_query_for_testing_.store(enabled);
 }
 
 // index/leaf capacity setters removed; not applicable for Boost rtree

--- a/internal/core/src/index/RTreeIndexWrapper.cpp
+++ b/internal/core/src/index/RTreeIndexWrapper.cpp
@@ -73,16 +73,18 @@ RTreeIndexWrapper::ensure_rtree_consistent_locked() const {
     }
 }
 
-std::shared_lock<std::shared_mutex>
+std::shared_lock<folly::SharedMutexWritePriority>
 RTreeIndexWrapper::lock_consistent_rtree_for_read() const {
     for (;;) {
-        std::shared_lock<std::shared_mutex> read_guard(rtree_mutex_);
+        std::shared_lock<folly::SharedMutexWritePriority> read_guard(
+            rtree_mutex_);
         if (!rtree_needs_rebuild_) {
             return read_guard;
         }
 
         read_guard.unlock();
-        std::unique_lock<std::shared_mutex> write_guard(rtree_mutex_);
+        std::unique_lock<folly::SharedMutexWritePriority> write_guard(
+            rtree_mutex_);
         ensure_rtree_consistent_locked();
     }
 }
@@ -117,7 +119,7 @@ RTreeIndexWrapper::add_geometry(const uint8_t* wkb_data,
                                 size_t len,
                                 int64_t row_offset) {
     // Acquire write lock to protect rtree_
-    std::unique_lock<std::shared_mutex> guard(rtree_mutex_);
+    std::unique_lock<folly::SharedMutexWritePriority> guard(rtree_mutex_);
 
     AssertInfo(is_build_mode_, "Cannot add geometry in load mode");
     ensure_rtree_consistent_locked();
@@ -219,7 +221,7 @@ RTreeIndexWrapper::bulk_load_from_field_data(
     const std::vector<std::shared_ptr<::milvus::FieldDataBase>>& field_datas,
     bool nullable) {
     // Acquire write lock to protect rtree_ creation and modification
-    std::unique_lock<std::shared_mutex> guard(rtree_mutex_);
+    std::unique_lock<folly::SharedMutexWritePriority> guard(rtree_mutex_);
 
     AssertInfo(is_build_mode_, "Cannot bulk load in load mode");
 
@@ -324,7 +326,7 @@ RTreeIndexWrapper::finish() {
     // Guard against repeated invocations which could otherwise attempt to
     // release resources multiple times (e.g. BuildWithRawDataForUT() calls
     // finish(), and Upload() may call it again).
-    std::unique_lock<std::shared_mutex> guard(rtree_mutex_);
+    std::unique_lock<folly::SharedMutexWritePriority> guard(rtree_mutex_);
     if (finished_) {
         LOG_DEBUG("RTreeIndexWrapper::finish() called more than once, skip.");
         return;
@@ -385,7 +387,7 @@ RTreeIndexWrapper::finish() {
 void
 RTreeIndexWrapper::load() {
     // Acquire write lock to protect rtree_ initialization during loading
-    std::unique_lock<std::shared_mutex> guard(rtree_mutex_);
+    std::unique_lock<folly::SharedMutexWritePriority> guard(rtree_mutex_);
 
     AssertInfo(!is_build_mode_, "Cannot load in build mode");
 
@@ -546,7 +548,7 @@ RTreeIndexWrapper::ByteSize() const {
 
 void
 RTreeIndexWrapper::SetThrowAfterInsertForTesting(bool enabled) {
-    std::unique_lock<std::shared_mutex> guard(rtree_mutex_);
+    std::unique_lock<folly::SharedMutexWritePriority> guard(rtree_mutex_);
     throw_after_insert_for_testing_ = enabled;
 }
 

--- a/internal/core/src/index/RTreeIndexWrapper.cpp
+++ b/internal/core/src/index/RTreeIndexWrapper.cpp
@@ -372,7 +372,15 @@ RTreeIndexWrapper::finish() {
                       "Failed to write R-Tree meta file: {}.meta.json",
                       index_path_);
         }
+        // Check close(), not just the insertion above: a delayed-allocation
+        // filesystem reports ENOSPC/EIO for the flushed blocks at close(2),
+        // and an unchecked close leaves a truncated meta.json looking written.
         ofs.close();
+        if (!ofs.good()) {
+            ThrowInfo(ErrorCode::FileWriteFailed,
+                      "Failed to close R-Tree meta file: {}.meta.json",
+                      index_path_);
+        }
         LOG_INFO("R-Tree meta written: {}.meta.json", index_path_);
     } catch (const SegcoreError&) {
         throw;

--- a/internal/core/src/index/RTreeIndexWrapper.cpp
+++ b/internal/core/src/index/RTreeIndexWrapper.cpp
@@ -18,6 +18,7 @@
 #include <iterator>
 #include <map>
 #include <mutex>
+#include <new>
 
 #include "RTreeIndexSerialization.h"
 #include "RTreeIndexWrapper.h"
@@ -29,6 +30,7 @@
 #include "boost/variant/detail/apply_visitor_unary.hpp"
 #include "common/EasyAssert.h"
 #include "common/FieldDataInterface.h"
+#include "common/Geometry.h"
 #include "fmt/core.h"
 #include "geos_c.h"
 #include "glog/logging.h"
@@ -54,6 +56,63 @@ RTreeIndexWrapper::RTreeIndexWrapper(std::string& path, bool is_build_mode)
 RTreeIndexWrapper::~RTreeIndexWrapper() = default;
 
 void
+RTreeIndexWrapper::ensure_rtree_consistent_locked() const {
+    if (!rtree_needs_rebuild_) {
+        return;
+    }
+
+    // Construct before swap so another allocation failure leaves the poisoned
+    // tree isolated and the rebuild flag set for a later retry.
+    try {
+        RTree rebuilt(values_.begin(), values_.end());
+        rtree_.swap(rebuilt);
+        rtree_needs_rebuild_ = false;
+    } catch (const std::bad_alloc&) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory rebuilding R-Tree after failed insert");
+    }
+}
+
+std::shared_lock<std::shared_mutex>
+RTreeIndexWrapper::lock_consistent_rtree_for_read() const {
+    for (;;) {
+        std::shared_lock<std::shared_mutex> read_guard(rtree_mutex_);
+        if (!rtree_needs_rebuild_) {
+            return read_guard;
+        }
+
+        read_guard.unlock();
+        std::unique_lock<std::shared_mutex> write_guard(rtree_mutex_);
+        ensure_rtree_consistent_locked();
+    }
+}
+
+void
+RTreeIndexWrapper::insert_value_locked(const Box& box, int64_t row_offset) {
+    // values_ is the authoritative committed set; rtree_ is a derived
+    // structure that Boost may leave inconsistent when insert throws (it
+    // documents only the basic guarantee). So the two are kept in step by
+    // rolling values_ back and flagging the tree for a rebuild -- NOT by
+    // trusting the tree to be unmodified:
+    //   1. values_.push_back may throw -- nothing else mutated yet;
+    //   2. rtree_.insert may throw -- roll values_ back (pop_back, noexcept)
+    //      and mark the tree for rebuild from values_ before its next use.
+    Value val(box, row_offset);
+    values_.push_back(val);
+    try {
+        rtree_.insert(val);
+        if (throw_after_insert_for_testing_) {
+            throw_after_insert_for_testing_ = false;
+            throw std::bad_alloc();
+        }
+    } catch (...) {
+        values_.pop_back();
+        rtree_needs_rebuild_ = true;
+        throw;
+    }
+}
+
+void
 RTreeIndexWrapper::add_geometry(const uint8_t* wkb_data,
                                 size_t len,
                                 int64_t row_offset) {
@@ -61,43 +120,96 @@ RTreeIndexWrapper::add_geometry(const uint8_t* wkb_data,
     std::unique_lock<std::shared_mutex> guard(rtree_mutex_);
 
     AssertInfo(is_build_mode_, "Cannot add geometry in load mode");
+    ensure_rtree_consistent_locked();
 
-    // Parse WKB data using GEOS for consistency
-    GEOSContextHandle_t ctx = GEOS_init_r();
-    if (ctx == nullptr) {
-        LOG_ERROR("Failed to initialize GEOS context for row {}", row_offset);
+    // Index a deterministic placeholder MBR for a row whose WKB payload is
+    // genuinely unparseable (empty or corrupt DATA), without dropping it. The
+    // R-tree is only a coarse filter and exact refinement tolerates the
+    // placeholder (Geometry::TryParseFromWkb -> skip) in every configuration,
+    // so a placeholder never yields a wrong result -- but dropping the row
+    // would permanently desynchronize the index row count from the segment row
+    // count, which then trips the coarse-bitmap bounds guard in
+    // EvalForIndexSegment on EVERY subsequent geometry query against this
+    // segment. This mirrors the empty-geometry handling below and bulk_load.
+    //
+    // This is ONLY for bad data. A transient resource failure (GEOS context /
+    // reader allocation) on a perfectly valid geometry must NOT take this path:
+    // a (0,0) placeholder would permanently mis-locate a good row, silently
+    // dropping it from every query that does not cover the origin. Those cases
+    // throw instead, so the insert fails and can be retried. See PR #50951.
+    //
+    // Tradeoff: Point(0, 0) is a legal coordinate (Null Island), so any query
+    // whose bounding box covers the origin pulls every placeholder row in this
+    // segment into the candidate set and pays exact refinement for it (which
+    // then discards the row). World-scale bbox queries almost always cover the
+    // origin, so segments with many empty/corrupt geometries make such queries
+    // proportionally more expensive. Correctness is unaffected.
+    auto index_placeholder_mbr = [&]() {
+        insert_value_locked(Box(Point(0, 0), Point(0, 0)), row_offset);
+    };
+
+    // Parse WKB data using GEOS for consistency. InitGEOSContext throws a
+    // retriable MemAllocateFailed on a transient allocation failure, so a
+    // valid geometry fails the insert (and can be retried) rather than being
+    // permanently mis-indexed. All GEOS resources are scoped: if any
+    // container op below throws (retried by the caller), nothing leaks.
+    ScopedGeosResources geos("add_geometry");
+
+    geos.reader = GEOSWKBReader_create_r(geos.ctx);
+    if (geos.reader == nullptr) {
+        // Transient resource failure -- see above; throw rather than placeholder.
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "Failed to create GEOS WKB reader for row {}",
+                  row_offset);
+    }
+
+    geos.geom = GEOSWKBReader_read_r(geos.ctx, geos.reader, wkb_data, len);
+
+    if (geos.geom == nullptr) {
+        // nullptr here is *usually* unparseable WKB, but GEOS's execute()
+        // wrapper also swallows a transient OOM during parsing into the same
+        // nullptr -- the two are indistinguishable at this boundary, and both
+        // are deliberately classified as bad data (see the KNOWN LIMIT note
+        // on Geometry::TryParseFromWkb).
+        static std::atomic<int64_t> last_parse_log_us{0};
+        if (ShouldLogGeometryThrottled(last_parse_log_us)) {
+            LOG_ERROR(
+                "Failed to parse WKB data for row {}; indexing a placeholder "
+                "MBR to keep the index row count consistent (further "
+                "occurrences suppressed briefly)",
+                row_offset);
+        } else {
+            LOG_DEBUG("Failed to parse WKB data for row {}", row_offset);
+        }
+        index_placeholder_mbr();
         return;
     }
 
-    GEOSWKBReader* reader = GEOSWKBReader_create_r(ctx);
-    if (reader == nullptr) {
-        GEOS_finish_r(ctx);
-        LOG_ERROR("Failed to create GEOS WKB reader for row {}", row_offset);
-        return;
+    // Get bounding box. On failure (e.g. empty geometry) keep a deterministic
+    // placeholder MBR and still index the row: the R-tree is only a coarse
+    // filter, the exact predicate refines it out, and dropping the row here
+    // would desynchronize the index row count from the segment row count.
+    double minX = 0, minY = 0, maxX = 0, maxY = 0;
+    if (!get_bounding_box(geos.geom, geos.ctx, minX, minY, maxX, maxY)) {
+        static std::atomic<int64_t> last_envelope_log_us{0};
+        if (ShouldLogGeometryThrottled(last_envelope_log_us)) {
+            LOG_WARN(
+                "geometry at row {} has no computable envelope (empty?); "
+                "indexing with a placeholder MBR, exact refinement will "
+                "filter it (further occurrences suppressed briefly)",
+                row_offset);
+        } else {
+            LOG_DEBUG("geometry at row {} has no computable envelope",
+                      row_offset);
+        }
     }
+    // The geometry is no longer needed once the MBR is extracted; release it
+    // before the (potentially throwing) container ops.
+    geos.release_geom();
 
-    GEOSGeometry* geom = GEOSWKBReader_read_r(ctx, reader, wkb_data, len);
-    GEOSWKBReader_destroy_r(ctx, reader);
-
-    if (geom == nullptr) {
-        GEOS_finish_r(ctx);
-        LOG_ERROR("Failed to parse WKB data for row {}", row_offset);
-        return;
-    }
-
-    // Get bounding box
-    double minX, minY, maxX, maxY;
-    get_bounding_box(geom, ctx, minX, minY, maxX, maxY);
-
-    // Create Boost box and insert
-    Box box(Point(minX, minY), Point(maxX, maxY));
-    Value val(box, row_offset);
-    values_.push_back(val);
-    rtree_.insert(val);
-
-    // Clean up
-    GEOSGeom_destroy_r(ctx, geom);
-    GEOS_finish_r(ctx);
+    // Create Boost box and insert (idempotent per offset; a throwing Boost tree
+    // is rebuilt from committed values before reuse).
+    insert_value_locked(Box(Point(minX, minY), Point(maxX, maxY)), row_offset);
 }
 
 // No IDataStream; bulk-load implemented directly for Boost R-tree
@@ -111,23 +223,36 @@ RTreeIndexWrapper::bulk_load_from_field_data(
 
     AssertInfo(is_build_mode_, "Cannot bulk load in load mode");
 
-    // Initialize GEOS context for bulk operations
-    GEOSContextHandle_t ctx = GEOS_init_r();
-    if (ctx == nullptr) {
-        LOG_ERROR("Failed to initialize GEOS context for bulk load");
-        return;
+    // Initialize GEOS context for bulk operations. A transient allocation
+    // failure here would otherwise silently drop EVERY row from the index --
+    // InitGEOSContext throws a retriable error so the build fails and can be
+    // retried instead. Scoped so a throwing container op inside the loop
+    // (e.g. local_values.emplace_back on OOM) cannot leak the reader/context
+    // across the retry.
+    ScopedGeosResources geos("bulk load");
+
+    geos.reader = GEOSWKBReader_create_r(geos.ctx);
+    if (geos.reader == nullptr) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "Failed to create GEOS WKB reader for bulk load");
     }
 
-    GEOSWKBReader* reader = GEOSWKBReader_create_r(ctx);
-    if (reader == nullptr) {
-        GEOS_finish_r(ctx);
-        LOG_ERROR("Failed to create GEOS WKB reader for bulk load");
-        return;
-    }
-
+    // NOTE: non-null rows with an empty or unparseable WKB payload are indexed
+    // with a deterministic placeholder MBR (like the growing add_geometry
+    // path), NOT dropped. Growing and sealed now agree -- neither write path
+    // drops a row -- so the index row count stays in lockstep with the segment
+    // rows on both, and exact refinement tolerates the placeholder
+    // (Geometry::TryParseFromWkb -> skip) in every configuration, cache on or
+    // off. A corrupt/empty row can never satisfy exact refinement, so the
+    // placeholder is always refined out and correctness is unaffected; the only
+    // cost is that an origin-covering query pays refinement for it (see the
+    // add_geometry tradeoff note). Genuinely null rows are still skipped below.
     std::vector<Value> local_values;
     local_values.reserve(1024);
     int64_t absolute_offset = 0;
+    const auto index_placeholder = [&](int64_t offset) {
+        local_values.emplace_back(Box(Point(0, 0), Point(0, 0)), offset);
+    };
     for (const auto& fd : field_datas) {
         const auto n = fd->get_num_rows();
         const bool is_nullable_effective = nullable || fd->IsNullable();
@@ -138,32 +263,57 @@ RTreeIndexWrapper::bulk_load_from_field_data(
             const auto* wkb_str =
                 static_cast<const std::string*>(fd->RawValue(i));
             if (wkb_str == nullptr || wkb_str->empty()) {
+                index_placeholder(absolute_offset);
                 continue;
             }
 
-            GEOSGeometry* geom = GEOSWKBReader_read_r(
-                ctx,
-                reader,
+            geos.geom = GEOSWKBReader_read_r(
+                geos.ctx,
+                geos.reader,
                 reinterpret_cast<const unsigned char*>(wkb_str->data()),
                 wkb_str->size());
-            if (geom == nullptr) {
+            if (geos.geom == nullptr) {
+                // Same classification as add_geometry(): unparseable WKB and
+                // a GEOS-swallowed parse-time OOM both surface as nullptr and
+                // both get a placeholder MBR (see Geometry::TryParseFromWkb).
+                index_placeholder(absolute_offset);
                 continue;
             }
 
-            double minX, minY, maxX, maxY;
-            get_bounding_box(geom, ctx, minX, minY, maxX, maxY);
-            GEOSGeom_destroy_r(ctx, geom);
+            // See add_geometry(): keep a deterministic placeholder MBR for a
+            // geometry without a computable envelope so the row stays indexed
+            // and the row count remains consistent.
+            double minX = 0, minY = 0, maxX = 0, maxY = 0;
+            if (!get_bounding_box(
+                    geos.geom, geos.ctx, minX, minY, maxX, maxY)) {
+                static std::atomic<int64_t> last_bulk_envelope_log_us{0};
+                if (ShouldLogGeometryThrottled(last_bulk_envelope_log_us)) {
+                    LOG_WARN(
+                        "geometry at row {} has no computable envelope "
+                        "(empty?); indexing with a placeholder MBR (further "
+                        "occurrences suppressed briefly)",
+                        absolute_offset);
+                } else {
+                    LOG_DEBUG("geometry at row {} has no computable envelope",
+                              absolute_offset);
+                }
+            }
+            // Release before the (potentially throwing) emplace_back.
+            geos.release_geom();
 
             Box box(Point(minX, minY), Point(maxX, maxY));
             local_values.emplace_back(box, absolute_offset);
         }
     }
 
-    // Clean up GEOS resources
-    GEOSWKBReader_destroy_r(ctx, reader);
-    GEOS_finish_r(ctx);
+    // Publish transactionally: build the tree from the staged values FIRST
+    // (its bulk ctor can throw bad_alloc), then install both structures with
+    // non-throwing swap/move -- a failed attempt leaves values_/rtree_
+    // untouched, so the retried bulk load starts from a consistent state.
+    RTree new_tree(local_values.begin(), local_values.end());
     values_.swap(local_values);
-    rtree_ = RTree(values_.begin(), values_.end());
+    rtree_.swap(new_tree);
+    rtree_needs_rebuild_ = false;
     LOG_INFO("R-Tree bulk load (Boost) completed with {} entries",
              values_.size());
 }
@@ -181,6 +331,7 @@ RTreeIndexWrapper::finish() {
     }
 
     AssertInfo(is_build_mode_, "Cannot finish in load mode");
+    ensure_rtree_consistent_locked();
 
     // Persist to disk: write meta and binary data file
     try {
@@ -239,6 +390,7 @@ RTreeIndexWrapper::load() {
 
         // Read binary data
         RTreeSerializer::loadBinary(rtree_, index_path_ + ".bgi");
+        rtree_needs_rebuild_ = false;
 
         LOG_INFO("R-Tree index (Boost) loaded from {}", index_path_);
     } catch (const std::exception& e) {
@@ -254,22 +406,46 @@ RTreeIndexWrapper::query_candidates(proto::plan::GISFunctionFilterExpr_GISOp op,
                                     const GEOSGeometry* query_geom,
                                     GEOSContextHandle_t ctx,
                                     std::vector<int64_t>& candidate_offsets) {
+    if (throw_on_query_for_testing_.exchange(false)) {
+        throw std::bad_alloc();
+    }
+
+    auto tree_guard = lock_consistent_rtree_for_read();
     candidate_offsets.clear();
 
-    // Get bounding box of query geometry
+    // Get bounding box of query geometry. An empty/degenerate query geometry
+    // has no envelope. For the spatial predicates (Intersects / Within /
+    // Contains / Touches / Overlaps / Crosses) it intersects nothing, so there
+    // are no candidates. ST_Equals is different: an empty query geometry must
+    // still match empty FIELD geometries, which this index stores with a
+    // placeholder MBR (see add_geometry) -- returning zero candidates for
+    // Equals would be a false negative versus the un-indexed data path, where
+    // GEOSEquals(empty, empty) is true. So for Equals, fall back to the full
+    // candidate set and let exact refinement keep only the true matches.
+    //
+    // NOTE: this fallback is an INTENTIONAL full scan. A single
+    // ST_Equals(field, 'POLYGON EMPTY') degenerates into an exact-refinement
+    // pass over every indexed row of the segment. That cost is accepted to
+    // preserve correctness; do not "optimize" the branch away without an
+    // alternative way to find placeholder-MBR rows.
     double minX, minY, maxX, maxY;
-    get_bounding_box(query_geom, ctx, minX, minY, maxX, maxY);
+    if (!get_bounding_box(query_geom, ctx, minX, minY, maxX, maxY)) {
+        if (op == proto::plan::GISFunctionFilterExpr_GISOp_Equals) {
+            candidate_offsets.reserve(rtree_.size());
+            for (const auto& v : rtree_) {
+                candidate_offsets.push_back(v.second);
+            }
+        }
+        return;
+    }
 
     // Create query box
     Box query_box(Point(minX, minY), Point(maxX, maxY));
 
     // Perform coarse intersection query
     std::vector<Value> results;
-    {
-        std::shared_lock<std::shared_mutex> guard(rtree_mutex_);
-        rtree_.query(boost::geometry::index::intersects(query_box),
-                     std::back_inserter(results));
-    }
+    rtree_.query(boost::geometry::index::intersects(query_box),
+                 std::back_inserter(results));
     candidate_offsets.reserve(results.size());
     for (const auto& v : results) {
         candidate_offsets.push_back(v.second);
@@ -280,7 +456,7 @@ RTreeIndexWrapper::query_candidates(proto::plan::GISFunctionFilterExpr_GISOp op,
               static_cast<int>(op));
 }
 
-void
+bool
 RTreeIndexWrapper::get_bounding_box(const GEOSGeometry* geom,
                                     GEOSContextHandle_t ctx,
                                     double& minX,
@@ -290,19 +466,30 @@ RTreeIndexWrapper::get_bounding_box(const GEOSGeometry* geom,
     AssertInfo(geom != nullptr, "Geometry is null");
     AssertInfo(ctx != nullptr, "GEOS context is null");
 
-    GEOSGeom_getXMin_r(ctx, geom, &minX);
-    GEOSGeom_getXMax_r(ctx, geom, &maxX);
-    GEOSGeom_getYMin_r(ctx, geom, &minY);
-    GEOSGeom_getYMax_r(ctx, geom, &maxY);
+    // GEOSGeom_get{X,Y}{Min,Max}_r return 0 on failure (e.g. empty geometry)
+    // and leave the output untouched; using such uninitialized coordinates
+    // would insert a garbage MBR into the R-tree. Report failure instead.
+    if (GEOSGeom_getXMin_r(ctx, geom, &minX) == 0 ||
+        GEOSGeom_getXMax_r(ctx, geom, &maxX) == 0 ||
+        GEOSGeom_getYMin_r(ctx, geom, &minY) == 0 ||
+        GEOSGeom_getYMax_r(ctx, geom, &maxY) == 0) {
+        return false;
+    }
+    return true;
 }
 
 int64_t
 RTreeIndexWrapper::count() const {
+    // rtree_ is mutated by add_geometry()/bulk_load_from_field_data() under a
+    // write lock; reading its size concurrently must take the shared lock too,
+    // otherwise a growing-segment search races with incremental inserts.
+    auto guard = lock_consistent_rtree_for_read();
     return static_cast<int64_t>(rtree_.size());
 }
 
 int64_t
 RTreeIndexWrapper::ByteSize() const {
+    auto guard = lock_consistent_rtree_for_read();
     int64_t total = 0;
 
     // values_: vector<Value> where Value = std::pair<Box, int64_t>
@@ -316,6 +503,17 @@ RTreeIndexWrapper::ByteSize() const {
     total += rtree_.size() * 18;
 
     return total;
+}
+
+void
+RTreeIndexWrapper::SetThrowAfterInsertForTesting(bool enabled) {
+    std::unique_lock<std::shared_mutex> guard(rtree_mutex_);
+    throw_after_insert_for_testing_ = enabled;
+}
+
+void
+RTreeIndexWrapper::SetThrowOnQueryForTesting(bool enabled) {
+    throw_on_query_for_testing_.store(enabled);
 }
 
 // index/leaf capacity setters removed; not applicable for Boost rtree

--- a/internal/core/src/index/RTreeIndexWrapper.cpp
+++ b/internal/core/src/index/RTreeIndexWrapper.cpp
@@ -335,8 +335,17 @@ RTreeIndexWrapper::finish() {
 
     // Persist to disk: write meta and binary data file
     try {
-        // Write binary rtree data
-        RTreeSerializer::saveBinary(rtree_, index_path_ + ".bgi");
+        // Write binary rtree data. The serializer reports failures instead of
+        // throwing, so checking its result is part of the persistence
+        // contract: an index without a durable tree must never be uploaded as
+        // successfully built.
+        auto binary_path = index_path_ + ".bgi";
+        auto save_result = RTreeSerializer::saveBinary(rtree_, binary_path);
+        if (save_result != RTreeSerializer::BinaryIOResult::Success) {
+            ThrowInfo(ErrorCode::FileWriteFailed,
+                      "Failed to write R-Tree binary file: {}",
+                      binary_path);
+        }
 
         // Write meta json
         nlohmann::json meta;
@@ -356,6 +365,12 @@ RTreeIndexWrapper::finish() {
         }
         ofs.close();
         LOG_INFO("R-Tree meta written: {}.meta.json", index_path_);
+    } catch (const SegcoreError&) {
+        throw;
+    } catch (const std::bad_alloc&) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory writing R-Tree files for {}",
+                  index_path_);
     } catch (const std::exception& e) {
         ThrowInfo(ErrorCode::UnexpectedError,
                   fmt::format("Failed to write R-Tree files: {}", e.what()));
@@ -384,15 +399,39 @@ RTreeIndexWrapper::load() {
                 if (meta.contains("dimension"))
                     dimension_ = meta["dimension"].get<uint32_t>();
             }
+        } catch (const std::bad_alloc&) {
+            throw;
         } catch (const std::exception& e) {
             LOG_WARN("Failed to read meta json: {}", e.what());
         }
 
-        // Read binary data
-        RTreeSerializer::loadBinary(rtree_, index_path_ + ".bgi");
+        // Deserialize into a temporary tree. A truncated archive can mutate
+        // its destination before reporting failure; only swap it into the live
+        // wrapper after the whole archive has been validated.
+        auto binary_path = index_path_ + ".bgi";
+        RTree loaded;
+        auto load_result = RTreeSerializer::loadBinary(loaded, binary_path);
+        if (load_result == RTreeSerializer::BinaryIOResult::OpenFailed ||
+            load_result == RTreeSerializer::BinaryIOResult::StreamFailed) {
+            ThrowInfo(ErrorCode::FileReadFailed,
+                      "Failed to read R-Tree binary file: {}",
+                      binary_path);
+        }
+        if (load_result == RTreeSerializer::BinaryIOResult::ArchiveFailed) {
+            ThrowInfo(ErrorCode::DataFormatBroken,
+                      "Corrupt R-Tree binary file: {}",
+                      binary_path);
+        }
+        rtree_.swap(loaded);
         rtree_needs_rebuild_ = false;
 
         LOG_INFO("R-Tree index (Boost) loaded from {}", index_path_);
+    } catch (const SegcoreError&) {
+        throw;
+    } catch (const std::bad_alloc&) {
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory loading R-Tree index from {}",
+                  index_path_);
     } catch (const std::exception& e) {
         ThrowInfo(ErrorCode::UnexpectedError,
                   fmt::format("Failed to load R-Tree index from {}: {}",

--- a/internal/core/src/index/RTreeIndexWrapper.cpp
+++ b/internal/core/src/index/RTreeIndexWrapper.cpp
@@ -50,6 +50,7 @@ RTreeIndexWrapper::RTreeIndexWrapper(std::string& path, bool is_build_mode)
         }
         // Start with an empty rtree for dynamic insertions
         rtree_ = RTree();
+        entry_count_.store(0, std::memory_order_release);
     }
 }
 
@@ -112,6 +113,10 @@ RTreeIndexWrapper::insert_value_locked(const Box& box, int64_t row_offset) {
         rtree_needs_rebuild_ = true;
         throw;
     }
+    // Published last: the row is only committed once both structures accepted
+    // it, so a lock-free count() never reports a row that was rolled back.
+    entry_count_.store(static_cast<int64_t>(values_.size()),
+                       std::memory_order_release);
 }
 
 void
@@ -316,6 +321,8 @@ RTreeIndexWrapper::bulk_load_from_field_data(
     values_.swap(local_values);
     rtree_.swap(new_tree);
     rtree_needs_rebuild_ = false;
+    entry_count_.store(static_cast<int64_t>(values_.size()),
+                       std::memory_order_release);
     LOG_INFO("R-Tree bulk load (Boost) completed with {} entries",
              values_.size());
 }
@@ -426,6 +433,10 @@ RTreeIndexWrapper::load() {
         }
         rtree_.swap(loaded);
         rtree_needs_rebuild_ = false;
+        // The load path deserializes straight into the tree and never fills
+        // values_, so the tree is the only row-count source here.
+        entry_count_.store(static_cast<int64_t>(rtree_.size()),
+                           std::memory_order_release);
 
         LOG_INFO("R-Tree index (Boost) loaded from {}", index_path_);
     } catch (const SegcoreError&) {
@@ -451,9 +462,17 @@ RTreeIndexWrapper::query_candidates(proto::plan::GISFunctionFilterExpr_GISOp op,
         throw std::bad_alloc();
     }
 
-    auto tree_guard = lock_consistent_rtree_for_read();
     candidate_offsets.clear();
 
+    // The shared lock below is taken ONLY around the statements that touch
+    // rtree_. Everything else here -- the envelope of the caller's query
+    // geometry, and copying offsets out of the local `results` -- is
+    // thread-private, and holding the lock across it would stretch the read
+    // critical section (the copy is proportional to the candidate count, so on
+    // a large growing segment it is the dominant part) for no benefit. Readers
+    // that hold the lock longer than necessary are exactly what makes the
+    // per-row insert lock hard to acquire.
+    //
     // Get bounding box of query geometry. An empty/degenerate query geometry
     // has no envelope. For the spatial predicates (Intersects / Within /
     // Contains / Touches / Overlaps / Crosses) it intersects nothing, so there
@@ -472,6 +491,7 @@ RTreeIndexWrapper::query_candidates(proto::plan::GISFunctionFilterExpr_GISOp op,
     double minX, minY, maxX, maxY;
     if (!get_bounding_box(query_geom, ctx, minX, minY, maxX, maxY)) {
         if (op == proto::plan::GISFunctionFilterExpr_GISOp_Equals) {
+            auto tree_guard = lock_consistent_rtree_for_read();
             candidate_offsets.reserve(rtree_.size());
             for (const auto& v : rtree_) {
                 candidate_offsets.push_back(v.second);
@@ -485,8 +505,11 @@ RTreeIndexWrapper::query_candidates(proto::plan::GISFunctionFilterExpr_GISOp op,
 
     // Perform coarse intersection query
     std::vector<Value> results;
-    rtree_.query(boost::geometry::index::intersects(query_box),
-                 std::back_inserter(results));
+    {
+        auto tree_guard = lock_consistent_rtree_for_read();
+        rtree_.query(boost::geometry::index::intersects(query_box),
+                     std::back_inserter(results));
+    }
     candidate_offsets.reserve(results.size());
     for (const auto& v : results) {
         candidate_offsets.push_back(v.second);
@@ -521,11 +544,15 @@ RTreeIndexWrapper::get_bounding_box(const GEOSGeometry* geom,
 
 int64_t
 RTreeIndexWrapper::count() const {
-    // rtree_ is mutated by add_geometry()/bulk_load_from_field_data() under a
-    // write lock; reading its size concurrently must take the shared lock too,
-    // otherwise a growing-segment search races with incremental inserts.
-    auto guard = lock_consistent_rtree_for_read();
-    return static_cast<int64_t>(rtree_.size());
+    // Deliberately lock-free. rtree_ is mutated by add_geometry() /
+    // bulk_load_from_field_data() / load() under the exclusive lock, so
+    // reading rtree_.size() would need the shared lock -- and every
+    // growing-segment search calls this once (RTreeIndex::Query sizes its
+    // bitmap by Count()), so that acquisition lands squarely on the search
+    // path and adds to the read pressure the insert thread has to push
+    // through. entry_count_ is published by each of those mutation points
+    // while they hold the lock, which is all a row count needs.
+    return entry_count_.load(std::memory_order_acquire);
 }
 
 int64_t

--- a/internal/core/src/index/RTreeIndexWrapper.h
+++ b/internal/core/src/index/RTreeIndexWrapper.h
@@ -11,7 +11,9 @@
 
 #pragma once
 
+#include <atomic>
 #include <boost/geometry/index/rtree.hpp>
+#include <folly/SharedMutex.h>
 #include <geos_c.h>
 #include <cstddef>
 #include <cstdint>
@@ -101,6 +103,12 @@ class RTreeIndexWrapper {
     /**
      * @brief Get the total number of geometries in the index
      * @return Number of geometries
+     *
+     * Lock-free: served from entry_count_, which every mutation point
+     * publishes under rtree_mutex_. Reading rtree_.size() instead would put a
+     * shared-lock acquisition on the search path for a single integer -- and
+     * would have to rebuild a poisoned tree first (see
+     * lock_consistent_rtree_for_read) just to read its size.
      */
     int64_t
     count() const;
@@ -111,6 +119,15 @@ class RTreeIndexWrapper {
      */
     int64_t
     ByteSize() const;
+
+    // Test-only fault injection. The insert hook throws after Boost has
+    // already accepted the value, exercising the worst documented exception
+    // state. Both hooks are one-shot.
+    void
+    SetThrowAfterInsertForTesting(bool enabled);
+
+    void
+    SetThrowOnQueryForTesting(bool enabled);
 
     // Boost rtree does not use index/leaf capacities; keep only fill factor for
     // compatibility (no-op currently)
@@ -125,7 +142,10 @@ class RTreeIndexWrapper {
      * @param maxX Output maximum X coordinate
      * @param maxY Output maximum Y coordinate
      */
-    void
+    // Returns false (leaving the outputs unspecified) when GEOS cannot compute
+    // an envelope, e.g. for an empty geometry. Callers must not use the box on
+    // a false return.
+    bool
     get_bounding_box(const GEOSGeometry* geom,
                      GEOSContextHandle_t ctx,
                      double& minX,
@@ -140,16 +160,67 @@ class RTreeIndexWrapper {
     using Value = std::pair<Box, int64_t>;  // (MBR, row_offset)
     using RTree = bgi::rtree<Value, bgi::rstar<16>>;
 
-    RTree rtree_{};
+    // Insert one (box, row_offset) entry with rtree_mutex_ already held.
+    //
+    // NOT idempotent per row_offset, by design: no production path re-drives a
+    // failed batch into the same wrapper. On the insert path a failure
+    // propagates to the delegator, which panics (delegator_data.go:203); on
+    // the growing load path there is no retry loop, and a re-issued
+    // LoadSegments builds a fresh segment and a fresh wrapper. A dedup set
+    // would therefore cost one entry per row forever to guard a case that
+    // cannot occur.
+    //
+    // What IS guaranteed: values_ (the authoritative committed set) and
+    // rtree_ never diverge. Boost documents only the basic guarantee for
+    // insert, so a throw rolls values_ back and flags the tree for a rebuild
+    // from values_ before its next read or write.
+    void
+    insert_value_locked(const Box& box, int64_t row_offset);
+
+    // Boost only guarantees no leaks when insert throws; the tree itself may
+    // be inconsistent and must not be read or mutated. values_ is the
+    // authoritative committed set, so rebuild a fresh tree from it before the
+    // next operation. Caller must hold rtree_mutex_ exclusively.
+    void
+    ensure_rtree_consistent_locked() const;
+
+    std::shared_lock<folly::SharedMutexWritePriority>
+    lock_consistent_rtree_for_read() const;
+
+    mutable RTree rtree_{};
     std::vector<Value> values_;
+
+    // Number of indexed entries, mirroring values_ on the build path and
+    // rtree_.size() on the load path (load() populates only the tree). Every
+    // store below happens under an exclusive rtree_mutex_, so count() can read
+    // it without taking the lock at all. It tracks the COMMITTED set: a failed
+    // insert rolls values_ back and leaves this counter untouched, so it stays
+    // correct while rtree_ is still awaiting its rebuild.
+    std::atomic<int64_t> entry_count_{0};
     std::string index_path_;
     bool is_build_mode_;
 
     // Flag to guard against repeated invocations which could otherwise attempt to release resources multiple times (e.g. BuildWithRawDataForUT() calls finish(), and Upload() may call it again).
     bool finished_ = false;
 
-    // Serialize access to rtree_
-    mutable std::shared_mutex rtree_mutex_;
+    // Serialize access to rtree_.
+    //
+    // MUST stay write-priority. On a growing segment the single insert thread
+    // takes this lock exclusively once per row (add_geometry) while every
+    // concurrent search takes it shared (query_candidates). std::shared_mutex
+    // is a pthread rwlock, which defaults to PREFER_READER on glibc: an
+    // arriving reader barges ahead of a waiting writer, so a steady stream of
+    // overlapping searches can starve the insert thread indefinitely. That
+    // stalls the vchannel's flowgraph consumer, which freezes the channel's
+    // time-tick -- a write-path outage caused by read traffic. Write priority
+    // blocks new readers once a writer is queued, bounding each insert's wait
+    // by the in-flight readers only.
+    mutable folly::SharedMutexWritePriority rtree_mutex_;
+    mutable bool rtree_needs_rebuild_ = false;
+
+    // Guarded by rtree_mutex_.
+    bool throw_after_insert_for_testing_ = false;
+    std::atomic<bool> throw_on_query_for_testing_{false};
 
     // R-Tree parameters
     uint32_t dimension_ = 2;

--- a/internal/core/src/index/RTreeIndexWrapper.h
+++ b/internal/core/src/index/RTreeIndexWrapper.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <boost/geometry/index/rtree.hpp>
 #include <geos_c.h>
 #include <cstddef>
@@ -112,6 +113,15 @@ class RTreeIndexWrapper {
     int64_t
     ByteSize() const;
 
+    // Test-only fault injection. The insert hook throws after Boost has
+    // already accepted the value, exercising the worst documented exception
+    // state. Both hooks are one-shot.
+    void
+    SetThrowAfterInsertForTesting(bool enabled);
+
+    void
+    SetThrowOnQueryForTesting(bool enabled);
+
     // Boost rtree does not use index/leaf capacities; keep only fill factor for
     // compatibility (no-op currently)
 
@@ -125,7 +135,10 @@ class RTreeIndexWrapper {
      * @param maxX Output maximum X coordinate
      * @param maxY Output maximum Y coordinate
      */
-    void
+    // Returns false (leaving the outputs unspecified) when GEOS cannot compute
+    // an envelope, e.g. for an empty geometry. Callers must not use the box on
+    // a false return.
+    bool
     get_bounding_box(const GEOSGeometry* geom,
                      GEOSContextHandle_t ctx,
                      double& minX,
@@ -140,7 +153,34 @@ class RTreeIndexWrapper {
     using Value = std::pair<Box, int64_t>;  // (MBR, row_offset)
     using RTree = bgi::rtree<Value, bgi::rstar<16>>;
 
-    RTree rtree_{};
+    // Insert one (box, row_offset) entry with rtree_mutex_ already held.
+    //
+    // NOT idempotent per row_offset, by design: no production path re-drives a
+    // failed batch into the same wrapper. On the insert path a failure
+    // propagates to the delegator, which panics (delegator_data.go:203); on
+    // the growing load path there is no retry loop, and a re-issued
+    // LoadSegments builds a fresh segment and a fresh wrapper. A dedup set
+    // would therefore cost one entry per row forever to guard a case that
+    // cannot occur.
+    //
+    // What IS guaranteed: values_ (the authoritative committed set) and
+    // rtree_ never diverge. Boost documents only the basic guarantee for
+    // insert, so a throw rolls values_ back and flags the tree for a rebuild
+    // from values_ before its next read or write.
+    void
+    insert_value_locked(const Box& box, int64_t row_offset);
+
+    // Boost only guarantees no leaks when insert throws; the tree itself may
+    // be inconsistent and must not be read or mutated. values_ is the
+    // authoritative committed set, so rebuild a fresh tree from it before the
+    // next operation. Caller must hold rtree_mutex_ exclusively.
+    void
+    ensure_rtree_consistent_locked() const;
+
+    std::shared_lock<std::shared_mutex>
+    lock_consistent_rtree_for_read() const;
+
+    mutable RTree rtree_{};
     std::vector<Value> values_;
     std::string index_path_;
     bool is_build_mode_;
@@ -150,6 +190,11 @@ class RTreeIndexWrapper {
 
     // Serialize access to rtree_
     mutable std::shared_mutex rtree_mutex_;
+    mutable bool rtree_needs_rebuild_ = false;
+
+    // Guarded by rtree_mutex_.
+    bool throw_after_insert_for_testing_ = false;
+    std::atomic<bool> throw_on_query_for_testing_{false};
 
     // R-Tree parameters
     uint32_t dimension_ = 2;

--- a/internal/core/src/index/RTreeIndexWrapper.h
+++ b/internal/core/src/index/RTreeIndexWrapper.h
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <boost/geometry/index/rtree.hpp>
+#include <folly/SharedMutex.h>
 #include <geos_c.h>
 #include <cstddef>
 #include <cstdint>
@@ -177,7 +178,7 @@ class RTreeIndexWrapper {
     void
     ensure_rtree_consistent_locked() const;
 
-    std::shared_lock<std::shared_mutex>
+    std::shared_lock<folly::SharedMutexWritePriority>
     lock_consistent_rtree_for_read() const;
 
     mutable RTree rtree_{};
@@ -188,8 +189,19 @@ class RTreeIndexWrapper {
     // Flag to guard against repeated invocations which could otherwise attempt to release resources multiple times (e.g. BuildWithRawDataForUT() calls finish(), and Upload() may call it again).
     bool finished_ = false;
 
-    // Serialize access to rtree_
-    mutable std::shared_mutex rtree_mutex_;
+    // Serialize access to rtree_.
+    //
+    // MUST stay write-priority. On a growing segment the single insert thread
+    // takes this lock exclusively once per row (add_geometry) while every
+    // concurrent search takes it shared (query_candidates). std::shared_mutex
+    // is a pthread rwlock, which defaults to PREFER_READER on glibc: an
+    // arriving reader barges ahead of a waiting writer, so a steady stream of
+    // overlapping searches can starve the insert thread indefinitely. That
+    // stalls the vchannel's flowgraph consumer, which freezes the channel's
+    // time-tick -- a write-path outage caused by read traffic. Write priority
+    // blocks new readers once a writer is queued, bounding each insert's wait
+    // by the in-flight readers only.
+    mutable folly::SharedMutexWritePriority rtree_mutex_;
     mutable bool rtree_needs_rebuild_ = false;
 
     // Guarded by rtree_mutex_.

--- a/internal/core/src/index/RTreeIndexWrapper.h
+++ b/internal/core/src/index/RTreeIndexWrapper.h
@@ -103,6 +103,12 @@ class RTreeIndexWrapper {
     /**
      * @brief Get the total number of geometries in the index
      * @return Number of geometries
+     *
+     * Lock-free: served from entry_count_, which every mutation point
+     * publishes under rtree_mutex_. Reading rtree_.size() instead would put a
+     * shared-lock acquisition on the search path for a single integer -- and
+     * would have to rebuild a poisoned tree first (see
+     * lock_consistent_rtree_for_read) just to read its size.
      */
     int64_t
     count() const;
@@ -183,6 +189,14 @@ class RTreeIndexWrapper {
 
     mutable RTree rtree_{};
     std::vector<Value> values_;
+
+    // Number of indexed entries, mirroring values_ on the build path and
+    // rtree_.size() on the load path (load() populates only the tree). Every
+    // store below happens under an exclusive rtree_mutex_, so count() can read
+    // it without taking the lock at all. It tracks the COMMITTED set: a failed
+    // insert rolls values_ back and leaves this counter untouched, so it stays
+    // correct while rtree_ is still awaiting its rebuild.
+    std::atomic<int64_t> entry_count_{0};
     std::string index_path_;
     bool is_build_mode_;
 

--- a/internal/core/src/index/RTreeIndexWrapperTest.cpp
+++ b/internal/core/src/index/RTreeIndexWrapperTest.cpp
@@ -11,20 +11,27 @@
 
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <memory>
+#include <new>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
+#include "RTreeIndexSerialization.h"
 #include "RTreeIndexWrapper.h"
-#include "test_utils/Constants.h"
+#include "common/EasyAssert.h"
 #include "common/Geometry.h"
 #include "geos_c.h"
 #include "gtest/gtest.h"
 #include "pb/plan.pb.h"
+#include "test_utils/Constants.h"
 
 class RTreeIndexWrapperTest : public ::testing::Test {
  protected:
@@ -218,4 +225,320 @@ TEST_F(RTreeIndexWrapperTest, TestInvalidWKB) {
     wrapper.add_geometry(invalid_wkb.data(), invalid_wkb.size(), 0);
 
     wrapper.finish();
+}
+
+TEST_F(RTreeIndexWrapperTest, FinishReportsBinaryWriteFailure) {
+    std::string index_path = test_dir_ + "/test_write_failure";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+
+    // A directory at the binary-file path makes ofstream::open fail
+    // deterministically without depending on process permissions.
+    std::filesystem::create_directory(index_path + ".bgi");
+    try {
+        wrapper.finish();
+        FAIL() << "expected R-Tree binary write failure";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::FileWriteFailed);
+    }
+}
+
+TEST_F(RTreeIndexWrapperTest, FinishReportsBinaryCloseFailure) {
+    std::string index_path = test_dir_ + "/test_close_failure";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+    const std::string payload = create_point_wkb(1.0, 1.0);
+    wrapper.add_geometry(
+        reinterpret_cast<const uint8_t*>(payload.data()), payload.size(), 0);
+
+    // A write error that the filesystem only reports at close(2) used to be
+    // swallowed by ~basic_ofstream and returned as Success, uploading a
+    // truncated .bgi as a successfully built index.
+    RTreeSerializer::CloseFailureForTesting().store(true);
+    try {
+        wrapper.finish();
+        FAIL() << "expected R-Tree binary close failure";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::FileWriteFailed);
+    }
+    // One-shot: the flag must not leak into the tests that follow.
+    EXPECT_FALSE(RTreeSerializer::CloseFailureForTesting().load());
+}
+
+TEST_F(RTreeIndexWrapperTest, LoadReportsMissingBinaryAsReadFailure) {
+    std::string index_path = test_dir_ + "/test_missing_binary";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, false);
+
+    try {
+        wrapper.load();
+        FAIL() << "expected missing R-Tree binary failure";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::FileReadFailed);
+    }
+}
+
+TEST_F(RTreeIndexWrapperTest, LoadReportsCorruptBinaryAsDataFormatBroken) {
+    std::string index_path = test_dir_ + "/test_corrupt_binary";
+    {
+        milvus::index::RTreeIndexWrapper builder(index_path, true);
+        builder.finish();
+    }
+
+    const auto binary_path = index_path + ".bgi";
+    std::ifstream in(binary_path, std::ios::binary | std::ios::ate);
+    ASSERT_TRUE(in.is_open());
+    const auto original_size = in.tellg();
+    ASSERT_GT(original_size, 1);
+    std::string bytes(static_cast<size_t>(original_size), '\0');
+    in.seekg(0);
+    in.read(bytes.data(), original_size);
+    ASSERT_TRUE(in.good());
+    in.close();
+
+    bytes.resize(bytes.size() / 2);
+    {
+        std::ofstream out(binary_path, std::ios::binary | std::ios::trunc);
+        ASSERT_TRUE(out.is_open());
+        out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+        ASSERT_TRUE(out.good());
+    }
+
+    milvus::index::RTreeIndexWrapper wrapper(index_path, false);
+    try {
+        wrapper.load();
+        FAIL() << "expected corrupt R-Tree binary failure";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::DataFormatBroken);
+    }
+}
+
+TEST_F(RTreeIndexWrapperTest, EmptyGeometryIsIndexedWithoutUndefinedMBR) {
+    std::string index_path = test_dir_ + "/test_empty_geometry";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+
+    // An empty geometry has no envelope: GEOSGeom_get{X,Y}{Min,Max}_r fail and
+    // leave the coordinates uninitialized. The wrapper must not insert a
+    // garbage MBR; it indexes the row with a deterministic placeholder so the
+    // row count stays consistent with the segment.
+    std::string empty_wkb =
+        milvus::Geometry(ctx_, "POLYGON EMPTY").to_wkb_string();
+    ASSERT_FALSE(empty_wkb.empty());
+    wrapper.add_geometry(reinterpret_cast<const uint8_t*>(empty_wkb.data()),
+                         empty_wkb.size(),
+                         0);
+
+    auto point_wkb = create_point_wkb(10.0, 10.0);
+    wrapper.add_geometry(reinterpret_cast<const uint8_t*>(point_wkb.data()),
+                         point_wkb.size(),
+                         1);
+
+    // Both rows indexed (no row silently dropped).
+    EXPECT_EQ(wrapper.count(), 2);
+
+    // A query far from the placeholder/origin must only return the real point;
+    // the empty geometry must not spuriously match.
+    auto query_polygon_wkb = create_polygon_wkb(
+        {{9.0, 9.0}, {11.0, 9.0}, {11.0, 11.0}, {9.0, 11.0}, {9.0, 9.0}});
+    milvus::Geometry query_geom(
+        ctx_,
+        reinterpret_cast<const void*>(query_polygon_wkb.data()),
+        query_polygon_wkb.size());
+    std::vector<int64_t> candidates;
+    wrapper.query_candidates(
+        milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        query_geom.GetGeometry(),
+        ctx_,
+        candidates);
+    EXPECT_NE(std::find(candidates.begin(), candidates.end(), 1),
+              candidates.end());
+    EXPECT_EQ(std::find(candidates.begin(), candidates.end(), 0),
+              candidates.end());
+
+    wrapper.finish();
+}
+
+TEST_F(RTreeIndexWrapperTest, InsertExceptionRebuildsTreeBeforeReuse) {
+    std::string index_path = test_dir_ + "/test_index_insert_recovery";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+
+    auto point0_wkb = create_point_wkb(1.0, 1.0);
+    auto point1_wkb = create_point_wkb(2.0, 2.0);
+    wrapper.add_geometry(reinterpret_cast<const uint8_t*>(point0_wkb.data()),
+                         point0_wkb.size(),
+                         0);
+
+    // Simulate Boost's worst documented exception state: the tree mutation
+    // completed, then the operation threw. The wrapper must discard that tree
+    // and rebuild from the authoritative committed values before any read.
+    wrapper.SetThrowAfterInsertForTesting(true);
+    EXPECT_THROW(wrapper.add_geometry(
+                     reinterpret_cast<const uint8_t*>(point1_wkb.data()),
+                     point1_wkb.size(),
+                     1),
+                 std::bad_alloc);
+
+    auto query_polygon_wkb = create_polygon_wkb(
+        {{0.5, 0.5}, {2.5, 0.5}, {2.5, 2.5}, {0.5, 2.5}, {0.5, 0.5}});
+    milvus::Geometry query_geom(
+        ctx_,
+        reinterpret_cast<const void*>(query_polygon_wkb.data()),
+        query_polygon_wkb.size());
+    std::vector<int64_t> candidates;
+    wrapper.query_candidates(
+        milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        query_geom.GetGeometry(),
+        ctx_,
+        candidates);
+    EXPECT_EQ(candidates, std::vector<int64_t>({0}));
+    EXPECT_EQ(wrapper.count(), 1);
+
+    // The failed offset was not committed and can be retried on the rebuilt
+    // tree without duplicating or losing the previously committed row.
+    wrapper.add_geometry(reinterpret_cast<const uint8_t*>(point1_wkb.data()),
+                         point1_wkb.size(),
+                         1);
+    EXPECT_EQ(wrapper.count(), 2);
+    candidates.clear();
+    wrapper.query_candidates(
+        milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        query_geom.GetGeometry(),
+        ctx_,
+        candidates);
+    std::sort(candidates.begin(), candidates.end());
+    EXPECT_EQ(candidates, std::vector<int64_t>({0, 1}));
+}
+
+// count() is served from entry_count_ instead of rtree_.size(), so it must be
+// published by every path that changes the committed row set. The build path
+// (incremental inserts) and the load path (which deserializes straight into
+// the tree and never fills values_) publish it from different sources, so pin
+// both here at the wrapper boundary -- the index-level tests only reach them
+// through RTreeIndex::Count()'s max() of its own row counter.
+TEST_F(RTreeIndexWrapperTest, CountTracksCommittedRowsOnBuildAndLoadPaths) {
+    std::string index_path = test_dir_ + "/test_index_count_paths";
+    constexpr int kRows = 3;
+
+    {
+        milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+        EXPECT_EQ(wrapper.count(), 0);
+
+        for (int i = 0; i < kRows; ++i) {
+            auto wkb = create_point_wkb(static_cast<double>(i),
+                                        static_cast<double>(i));
+            wrapper.add_geometry(
+                reinterpret_cast<const uint8_t*>(wkb.data()), wkb.size(), i);
+            EXPECT_EQ(wrapper.count(), static_cast<int64_t>(i + 1));
+        }
+        wrapper.finish();
+    }
+
+    {
+        milvus::index::RTreeIndexWrapper wrapper(index_path, false);
+        // Nothing is published before load(): a load-mode wrapper starts empty.
+        EXPECT_EQ(wrapper.count(), 0);
+        wrapper.load();
+        EXPECT_EQ(wrapper.count(), static_cast<int64_t>(kRows));
+    }
+}
+
+// Pins the lock POLICY, not just the presence of a lock: rtree_mutex_ must
+// stay write-priority. add_geometry takes it exclusively once per row while
+// every concurrent search takes it shared, so under a reader-preferring lock
+// (std::shared_mutex is a glibc pthread rwlock, PREFER_READER by default) a
+// steady stream of overlapping searches barges ahead of the insert thread and
+// starves it -- in production that blocks the vchannel's flowgraph consumer
+// and freezes the channel's time-tick, i.e. read traffic taking down the write
+// path.
+//
+// The readers here are deliberately unthrottled: that is the pressure the
+// writer has to survive. The deadline is very generous (the writer's own work
+// is milliseconds) and exists only so a policy regression fails in bounded
+// time with a clear message, instead of hanging until the CI shard timeout.
+TEST_F(RTreeIndexWrapperTest, WriterIsNotStarvedByContinuousReaders) {
+    std::string index_path = test_dir_ + "/test_index_writer_priority";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+
+    constexpr int kRows = 1000;
+    constexpr auto kWriterDeadline = std::chrono::seconds(120);
+
+    // Pre-generate every payload on this thread: a GEOSContextHandle_t is not
+    // shareable across threads, and it keeps the writer loop measuring lock
+    // contention rather than WKB encoding.
+    std::vector<std::string> payloads;
+    payloads.reserve(kRows + 1);
+    for (int i = 0; i <= kRows; ++i) {
+        payloads.push_back(
+            create_point_wkb(static_cast<double>(i), static_cast<double>(i)));
+    }
+
+    // Seed row 0 so the readers query a non-empty tree from the first
+    // iteration.
+    wrapper.add_geometry(reinterpret_cast<const uint8_t*>(payloads[0].data()),
+                         payloads[0].size(),
+                         0);
+
+    std::atomic<bool> stop{false};
+    std::atomic<int> writer_progress{0};
+    std::atomic<int64_t> reader_iters{0};
+
+    std::vector<std::thread> readers;
+    for (int t = 0; t < 4; ++t) {
+        readers.emplace_back([&]() {
+            auto ctx = GEOS_init_r();
+            // The inner scope is load-bearing: ~Geometry calls
+            // GEOSGeom_destroy_r(ctx_, ...), and locals are destroyed AFTER
+            // the last statement of the enclosing block. With query_geom
+            // declared beside ctx, the trailing GEOS_finish_r would free the
+            // context first and the destructor would run against it -- a
+            // use-after-free on every reader thread.
+            {
+                // A box covering every inserted point.
+                milvus::Geometry query_geom(
+                    ctx,
+                    "POLYGON ((-1 -1, 100000 -1, 100000 100000, -1 100000, -1 "
+                    "-1))");
+                std::vector<int64_t> candidates;
+                while (!stop.load(std::memory_order_relaxed)) {
+                    wrapper.query_candidates(
+                        milvus::proto::plan::
+                            GISFunctionFilterExpr_GISOp_Intersects,
+                        query_geom.GetGeometry(),
+                        ctx,
+                        candidates);
+                    reader_iters.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+            GEOS_finish_r(ctx);
+        });
+    }
+
+    // Single writer, mirroring the per-segment serialized insert pipeline.
+    std::thread writer([&]() {
+        for (int i = 1; i <= kRows; ++i) {
+            wrapper.add_geometry(
+                reinterpret_cast<const uint8_t*>(payloads[i].data()),
+                payloads[i].size(),
+                i);
+            writer_progress.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + kWriterDeadline;
+    while (writer_progress.load(std::memory_order_relaxed) < kRows &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    const int progressed = writer_progress.load(std::memory_order_relaxed);
+
+    stop.store(true, std::memory_order_relaxed);
+    writer.join();
+    for (auto& th : readers) {
+        th.join();
+    }
+
+    EXPECT_EQ(progressed, kRows)
+        << "the insert thread was starved by concurrent readers: only "
+        << progressed << " of " << kRows
+        << " rows were inserted within the deadline -- is rtree_mutex_ still "
+           "write-priority?";
+    EXPECT_GT(reader_iters.load(), 0);
+    EXPECT_EQ(wrapper.count(), static_cast<int64_t>(kRows + 1));
 }

--- a/internal/core/src/index/RTreeIndexWrapperTest.cpp
+++ b/internal/core/src/index/RTreeIndexWrapperTest.cpp
@@ -384,6 +384,39 @@ TEST_F(RTreeIndexWrapperTest, InsertExceptionRebuildsTreeBeforeReuse) {
     EXPECT_EQ(candidates, std::vector<int64_t>({0, 1}));
 }
 
+// count() is served from entry_count_ instead of rtree_.size(), so it must be
+// published by every path that changes the committed row set. The build path
+// (incremental inserts) and the load path (which deserializes straight into
+// the tree and never fills values_) publish it from different sources, so pin
+// both here at the wrapper boundary -- the index-level tests only reach them
+// through RTreeIndex::Count()'s max() of its own row counter.
+TEST_F(RTreeIndexWrapperTest, CountTracksCommittedRowsOnBuildAndLoadPaths) {
+    std::string index_path = test_dir_ + "/test_index_count_paths";
+    constexpr int kRows = 3;
+
+    {
+        milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+        EXPECT_EQ(wrapper.count(), 0);
+
+        for (int i = 0; i < kRows; ++i) {
+            auto wkb = create_point_wkb(static_cast<double>(i),
+                                        static_cast<double>(i));
+            wrapper.add_geometry(
+                reinterpret_cast<const uint8_t*>(wkb.data()), wkb.size(), i);
+            EXPECT_EQ(wrapper.count(), static_cast<int64_t>(i + 1));
+        }
+        wrapper.finish();
+    }
+
+    {
+        milvus::index::RTreeIndexWrapper wrapper(index_path, false);
+        // Nothing is published before load(): a load-mode wrapper starts empty.
+        EXPECT_EQ(wrapper.count(), 0);
+        wrapper.load();
+        EXPECT_EQ(wrapper.count(), static_cast<int64_t>(kRows));
+    }
+}
+
 // Pins the lock POLICY, not just the presence of a lock: rtree_mutex_ must
 // stay write-priority. add_geometry takes it exclusively once per row while
 // every concurrent search takes it shared, so under a reader-preferring lock

--- a/internal/core/src/index/RTreeIndexWrapperTest.cpp
+++ b/internal/core/src/index/RTreeIndexWrapperTest.cpp
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <new>
 #include <string>
 #include <utility>
 #include <vector>
@@ -218,4 +219,100 @@ TEST_F(RTreeIndexWrapperTest, TestInvalidWKB) {
     wrapper.add_geometry(invalid_wkb.data(), invalid_wkb.size(), 0);
 
     wrapper.finish();
+}
+
+TEST_F(RTreeIndexWrapperTest, EmptyGeometryIsIndexedWithoutUndefinedMBR) {
+    std::string index_path = test_dir_ + "/test_empty_geometry";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+
+    // An empty geometry has no envelope: GEOSGeom_get{X,Y}{Min,Max}_r fail and
+    // leave the coordinates uninitialized. The wrapper must not insert a
+    // garbage MBR; it indexes the row with a deterministic placeholder so the
+    // row count stays consistent with the segment.
+    std::string empty_wkb =
+        milvus::Geometry(ctx_, "POLYGON EMPTY").to_wkb_string();
+    ASSERT_FALSE(empty_wkb.empty());
+    wrapper.add_geometry(reinterpret_cast<const uint8_t*>(empty_wkb.data()),
+                         empty_wkb.size(),
+                         0);
+
+    auto point_wkb = create_point_wkb(10.0, 10.0);
+    wrapper.add_geometry(reinterpret_cast<const uint8_t*>(point_wkb.data()),
+                         point_wkb.size(),
+                         1);
+
+    // Both rows indexed (no row silently dropped).
+    EXPECT_EQ(wrapper.count(), 2);
+
+    // A query far from the placeholder/origin must only return the real point;
+    // the empty geometry must not spuriously match.
+    auto query_polygon_wkb = create_polygon_wkb(
+        {{9.0, 9.0}, {11.0, 9.0}, {11.0, 11.0}, {9.0, 11.0}, {9.0, 9.0}});
+    milvus::Geometry query_geom(
+        ctx_,
+        reinterpret_cast<const void*>(query_polygon_wkb.data()),
+        query_polygon_wkb.size());
+    std::vector<int64_t> candidates;
+    wrapper.query_candidates(
+        milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        query_geom.GetGeometry(),
+        ctx_,
+        candidates);
+    EXPECT_NE(std::find(candidates.begin(), candidates.end(), 1),
+              candidates.end());
+    EXPECT_EQ(std::find(candidates.begin(), candidates.end(), 0),
+              candidates.end());
+
+    wrapper.finish();
+}
+
+TEST_F(RTreeIndexWrapperTest, InsertExceptionRebuildsTreeBeforeReuse) {
+    std::string index_path = test_dir_ + "/test_index_insert_recovery";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+
+    auto point0_wkb = create_point_wkb(1.0, 1.0);
+    auto point1_wkb = create_point_wkb(2.0, 2.0);
+    wrapper.add_geometry(reinterpret_cast<const uint8_t*>(point0_wkb.data()),
+                         point0_wkb.size(),
+                         0);
+
+    // Simulate Boost's worst documented exception state: the tree mutation
+    // completed, then the operation threw. The wrapper must discard that tree
+    // and rebuild from the authoritative committed values before any read.
+    wrapper.SetThrowAfterInsertForTesting(true);
+    EXPECT_THROW(wrapper.add_geometry(
+                     reinterpret_cast<const uint8_t*>(point1_wkb.data()),
+                     point1_wkb.size(),
+                     1),
+                 std::bad_alloc);
+
+    auto query_polygon_wkb = create_polygon_wkb(
+        {{0.5, 0.5}, {2.5, 0.5}, {2.5, 2.5}, {0.5, 2.5}, {0.5, 0.5}});
+    milvus::Geometry query_geom(
+        ctx_,
+        reinterpret_cast<const void*>(query_polygon_wkb.data()),
+        query_polygon_wkb.size());
+    std::vector<int64_t> candidates;
+    wrapper.query_candidates(
+        milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        query_geom.GetGeometry(),
+        ctx_,
+        candidates);
+    EXPECT_EQ(candidates, std::vector<int64_t>({0}));
+    EXPECT_EQ(wrapper.count(), 1);
+
+    // The failed offset was not committed and can be retried on the rebuilt
+    // tree without duplicating or losing the previously committed row.
+    wrapper.add_geometry(reinterpret_cast<const uint8_t*>(point1_wkb.data()),
+                         point1_wkb.size(),
+                         1);
+    EXPECT_EQ(wrapper.count(), 2);
+    candidates.clear();
+    wrapper.query_candidates(
+        milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+        query_geom.GetGeometry(),
+        ctx_,
+        candidates);
+    std::sort(candidates.begin(), candidates.end());
+    EXPECT_EQ(candidates, std::vector<int64_t>({0, 1}));
 }

--- a/internal/core/src/index/RTreeIndexWrapperTest.cpp
+++ b/internal/core/src/index/RTreeIndexWrapperTest.cpp
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include "RTreeIndexSerialization.h"
 #include "RTreeIndexWrapper.h"
 #include "common/EasyAssert.h"
 #include "common/Geometry.h"
@@ -239,6 +240,27 @@ TEST_F(RTreeIndexWrapperTest, FinishReportsBinaryWriteFailure) {
     } catch (const milvus::SegcoreError& error) {
         EXPECT_EQ(error.get_error_code(), milvus::FileWriteFailed);
     }
+}
+
+TEST_F(RTreeIndexWrapperTest, FinishReportsBinaryCloseFailure) {
+    std::string index_path = test_dir_ + "/test_close_failure";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+    const std::string payload = create_point_wkb(1.0, 1.0);
+    wrapper.add_geometry(
+        reinterpret_cast<const uint8_t*>(payload.data()), payload.size(), 0);
+
+    // A write error that the filesystem only reports at close(2) used to be
+    // swallowed by ~basic_ofstream and returned as Success, uploading a
+    // truncated .bgi as a successfully built index.
+    RTreeSerializer::CloseFailureForTesting().store(true);
+    try {
+        wrapper.finish();
+        FAIL() << "expected R-Tree binary close failure";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::FileWriteFailed);
+    }
+    // One-shot: the flag must not leak into the tests that follow.
+    EXPECT_FALSE(RTreeSerializer::CloseFailureForTesting().load());
 }
 
 TEST_F(RTreeIndexWrapperTest, LoadReportsMissingBinaryAsReadFailure) {
@@ -461,19 +483,28 @@ TEST_F(RTreeIndexWrapperTest, WriterIsNotStarvedByContinuousReaders) {
     for (int t = 0; t < 4; ++t) {
         readers.emplace_back([&]() {
             auto ctx = GEOS_init_r();
-            // A box covering every inserted point.
-            milvus::Geometry query_geom(
-                ctx,
-                "POLYGON ((-1 -1, 100000 -1, 100000 100000, -1 100000, -1 "
-                "-1))");
-            std::vector<int64_t> candidates;
-            while (!stop.load(std::memory_order_relaxed)) {
-                wrapper.query_candidates(
-                    milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
-                    query_geom.GetGeometry(),
+            // The inner scope is load-bearing: ~Geometry calls
+            // GEOSGeom_destroy_r(ctx_, ...), and locals are destroyed AFTER
+            // the last statement of the enclosing block. With query_geom
+            // declared beside ctx, the trailing GEOS_finish_r would free the
+            // context first and the destructor would run against it -- a
+            // use-after-free on every reader thread.
+            {
+                // A box covering every inserted point.
+                milvus::Geometry query_geom(
                     ctx,
-                    candidates);
-                reader_iters.fetch_add(1, std::memory_order_relaxed);
+                    "POLYGON ((-1 -1, 100000 -1, 100000 100000, -1 100000, -1 "
+                    "-1))");
+                std::vector<int64_t> candidates;
+                while (!stop.load(std::memory_order_relaxed)) {
+                    wrapper.query_candidates(
+                        milvus::proto::plan::
+                            GISFunctionFilterExpr_GISOp_Intersects,
+                        query_geom.GetGeometry(),
+                        ctx,
+                        candidates);
+                    reader_iters.fetch_add(1, std::memory_order_relaxed);
+                }
             }
             GEOS_finish_r(ctx);
         });

--- a/internal/core/src/index/RTreeIndexWrapperTest.cpp
+++ b/internal/core/src/index/RTreeIndexWrapperTest.cpp
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <memory>
 #include <new>
 #include <string>
@@ -21,11 +22,12 @@
 #include <vector>
 
 #include "RTreeIndexWrapper.h"
-#include "test_utils/Constants.h"
+#include "common/EasyAssert.h"
 #include "common/Geometry.h"
 #include "geos_c.h"
 #include "gtest/gtest.h"
 #include "pb/plan.pb.h"
+#include "test_utils/Constants.h"
 
 class RTreeIndexWrapperTest : public ::testing::Test {
  protected:
@@ -219,6 +221,68 @@ TEST_F(RTreeIndexWrapperTest, TestInvalidWKB) {
     wrapper.add_geometry(invalid_wkb.data(), invalid_wkb.size(), 0);
 
     wrapper.finish();
+}
+
+TEST_F(RTreeIndexWrapperTest, FinishReportsBinaryWriteFailure) {
+    std::string index_path = test_dir_ + "/test_write_failure";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+
+    // A directory at the binary-file path makes ofstream::open fail
+    // deterministically without depending on process permissions.
+    std::filesystem::create_directory(index_path + ".bgi");
+    try {
+        wrapper.finish();
+        FAIL() << "expected R-Tree binary write failure";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::FileWriteFailed);
+    }
+}
+
+TEST_F(RTreeIndexWrapperTest, LoadReportsMissingBinaryAsReadFailure) {
+    std::string index_path = test_dir_ + "/test_missing_binary";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, false);
+
+    try {
+        wrapper.load();
+        FAIL() << "expected missing R-Tree binary failure";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::FileReadFailed);
+    }
+}
+
+TEST_F(RTreeIndexWrapperTest, LoadReportsCorruptBinaryAsDataFormatBroken) {
+    std::string index_path = test_dir_ + "/test_corrupt_binary";
+    {
+        milvus::index::RTreeIndexWrapper builder(index_path, true);
+        builder.finish();
+    }
+
+    const auto binary_path = index_path + ".bgi";
+    std::ifstream in(binary_path, std::ios::binary | std::ios::ate);
+    ASSERT_TRUE(in.is_open());
+    const auto original_size = in.tellg();
+    ASSERT_GT(original_size, 1);
+    std::string bytes(static_cast<size_t>(original_size), '\0');
+    in.seekg(0);
+    in.read(bytes.data(), original_size);
+    ASSERT_TRUE(in.good());
+    in.close();
+
+    bytes.resize(bytes.size() / 2);
+    {
+        std::ofstream out(binary_path, std::ios::binary | std::ios::trunc);
+        ASSERT_TRUE(out.is_open());
+        out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+        ASSERT_TRUE(out.good());
+    }
+
+    milvus::index::RTreeIndexWrapper wrapper(index_path, false);
+    try {
+        wrapper.load();
+        FAIL() << "expected corrupt R-Tree binary failure";
+    } catch (const milvus::SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), milvus::DataFormatBroken);
+    }
 }
 
 TEST_F(RTreeIndexWrapperTest, EmptyGeometryIsIndexedWithoutUndefinedMBR) {

--- a/internal/core/src/index/RTreeIndexWrapperTest.cpp
+++ b/internal/core/src/index/RTreeIndexWrapperTest.cpp
@@ -11,6 +11,8 @@
 
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
@@ -18,6 +20,7 @@
 #include <memory>
 #include <new>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -379,4 +382,99 @@ TEST_F(RTreeIndexWrapperTest, InsertExceptionRebuildsTreeBeforeReuse) {
         candidates);
     std::sort(candidates.begin(), candidates.end());
     EXPECT_EQ(candidates, std::vector<int64_t>({0, 1}));
+}
+
+// Pins the lock POLICY, not just the presence of a lock: rtree_mutex_ must
+// stay write-priority. add_geometry takes it exclusively once per row while
+// every concurrent search takes it shared, so under a reader-preferring lock
+// (std::shared_mutex is a glibc pthread rwlock, PREFER_READER by default) a
+// steady stream of overlapping searches barges ahead of the insert thread and
+// starves it -- in production that blocks the vchannel's flowgraph consumer
+// and freezes the channel's time-tick, i.e. read traffic taking down the write
+// path.
+//
+// The readers here are deliberately unthrottled: that is the pressure the
+// writer has to survive. The deadline is very generous (the writer's own work
+// is milliseconds) and exists only so a policy regression fails in bounded
+// time with a clear message, instead of hanging until the CI shard timeout.
+TEST_F(RTreeIndexWrapperTest, WriterIsNotStarvedByContinuousReaders) {
+    std::string index_path = test_dir_ + "/test_index_writer_priority";
+    milvus::index::RTreeIndexWrapper wrapper(index_path, true);
+
+    constexpr int kRows = 1000;
+    constexpr auto kWriterDeadline = std::chrono::seconds(120);
+
+    // Pre-generate every payload on this thread: a GEOSContextHandle_t is not
+    // shareable across threads, and it keeps the writer loop measuring lock
+    // contention rather than WKB encoding.
+    std::vector<std::string> payloads;
+    payloads.reserve(kRows + 1);
+    for (int i = 0; i <= kRows; ++i) {
+        payloads.push_back(
+            create_point_wkb(static_cast<double>(i), static_cast<double>(i)));
+    }
+
+    // Seed row 0 so the readers query a non-empty tree from the first
+    // iteration.
+    wrapper.add_geometry(reinterpret_cast<const uint8_t*>(payloads[0].data()),
+                         payloads[0].size(),
+                         0);
+
+    std::atomic<bool> stop{false};
+    std::atomic<int> writer_progress{0};
+    std::atomic<int64_t> reader_iters{0};
+
+    std::vector<std::thread> readers;
+    for (int t = 0; t < 4; ++t) {
+        readers.emplace_back([&]() {
+            auto ctx = GEOS_init_r();
+            // A box covering every inserted point.
+            milvus::Geometry query_geom(
+                ctx,
+                "POLYGON ((-1 -1, 100000 -1, 100000 100000, -1 100000, -1 "
+                "-1))");
+            std::vector<int64_t> candidates;
+            while (!stop.load(std::memory_order_relaxed)) {
+                wrapper.query_candidates(
+                    milvus::proto::plan::GISFunctionFilterExpr_GISOp_Intersects,
+                    query_geom.GetGeometry(),
+                    ctx,
+                    candidates);
+                reader_iters.fetch_add(1, std::memory_order_relaxed);
+            }
+            GEOS_finish_r(ctx);
+        });
+    }
+
+    // Single writer, mirroring the per-segment serialized insert pipeline.
+    std::thread writer([&]() {
+        for (int i = 1; i <= kRows; ++i) {
+            wrapper.add_geometry(
+                reinterpret_cast<const uint8_t*>(payloads[i].data()),
+                payloads[i].size(),
+                i);
+            writer_progress.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + kWriterDeadline;
+    while (writer_progress.load(std::memory_order_relaxed) < kRows &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    const int progressed = writer_progress.load(std::memory_order_relaxed);
+
+    stop.store(true, std::memory_order_relaxed);
+    writer.join();
+    for (auto& th : readers) {
+        th.join();
+    }
+
+    EXPECT_EQ(progressed, kRows)
+        << "the insert thread was starved by concurrent readers: only "
+        << progressed << " of " << kRows
+        << " rows were inserted within the deadline -- is rtree_mutex_ still "
+           "write-priority?";
+    EXPECT_GT(reader_iters.load(), 0);
+    EXPECT_EQ(wrapper.count(), static_cast<int64_t>(kRows + 1));
 }

--- a/internal/core/src/index/ScalarIndex.h
+++ b/internal/core/src/index/ScalarIndex.h
@@ -134,6 +134,16 @@ class ScalarIndex : public IndexBase {
     virtual TargetBitmap
     IsNotNull() = 0;
 
+    // Some indexes persist absolute null offsets independently of Count().
+    // They may override this to project validity into a caller-owned row
+    // space. The default keeps the capability explicit instead of guessing
+    // that an unknown tail is non-null.
+    virtual TargetBitmap
+    IsNotNull(int64_t /*row_count*/) {
+        ThrowInfo(ErrorCode::Unsupported,
+                  "row-count-aware IsNotNull is not supported");
+    }
+
     virtual const TargetBitmap
     InApplyFilter(size_t n,
                   const T* values,

--- a/internal/core/src/index/ScalarIndexSort.h
+++ b/internal/core/src/index/ScalarIndexSort.h
@@ -110,6 +110,11 @@ class ScalarIndexSort : public ScalarIndex<T> {
     const TargetBitmap
     IsNull() override;
 
+    // Declaring IsNotNull() here hides the base's row-count-aware
+    // IsNotNull(int64_t) overload; keep it visible so a call through this
+    // static type still finds it.
+    using ScalarIndex<T>::IsNotNull;
+
     TargetBitmap
     IsNotNull() override;
 

--- a/internal/core/src/index/ScalarIndexTest.cpp
+++ b/internal/core/src/index/ScalarIndexTest.cpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <random>
 #include <string>
+#include <type_traits>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
@@ -34,11 +35,16 @@
 #include "common/type_c.h"
 #include "gtest/gtest.h"
 #include "index/BitmapIndex.h"
+#include "index/HybridScalarIndex.h"
 #include "index/Index.h"
 #include "index/IndexFactory.h"
 #include "index/IndexInfo.h"
+#include "index/InvertedIndexTantivy.h"
+#include "index/JsonFlatIndex.h"
 #include "index/ScalarIndex.h"
 #include "index/ScalarIndexSort.h"
+#include "index/StringIndexSort.h"
+#include "index/json_stats/JsonKeyStats.h"
 #include "pb/common.pb.h"
 #include "storage/ChunkManager.h"
 #include "storage/Types.h"
@@ -655,3 +661,33 @@ TEST(ScalarTest, test_function_range) {
     TestIndexSearchRange<float>();
     TestIndexSearchRange<double>();
 }
+
+// ScalarIndex<T>::IsNotNull(int64_t) -- the row-count-aware overload that
+// projects absolute null offsets into a caller-owned row space -- is hidden in
+// every subclass that declares IsNotNull() without a using-declaration, so a
+// call through the derived static type simply stops compiling. Each subclass
+// carries `using <base>::IsNotNull;` for exactly that reason. Nothing at
+// runtime can catch its removal, so pin it here.
+template <typename Index, typename = void>
+struct HasRowCountIsNotNull : std::false_type {};
+
+template <typename Index>
+struct HasRowCountIsNotNull<
+    Index,
+    std::void_t<decltype(std::declval<Index&>().IsNotNull(int64_t{}))>>
+    : std::true_type {};
+
+static_assert(HasRowCountIsNotNull<milvus::index::ScalarIndex<int64_t>>::value,
+              "the base overload must exist");
+static_assert(HasRowCountIsNotNull<milvus::index::BitmapIndex<int64_t>>::value);
+static_assert(
+    HasRowCountIsNotNull<milvus::index::HybridScalarIndex<int64_t>>::value);
+static_assert(
+    HasRowCountIsNotNull<milvus::index::InvertedIndexTantivy<int64_t>>::value);
+static_assert(HasRowCountIsNotNull<
+              milvus::index::JsonFlatIndexQueryExecutor<std::string>>::value);
+static_assert(
+    HasRowCountIsNotNull<milvus::index::ScalarIndexSort<int64_t>>::value);
+static_assert(HasRowCountIsNotNull<milvus::index::StringIndexMarisa>::value);
+static_assert(HasRowCountIsNotNull<milvus::index::StringIndexSort>::value);
+static_assert(HasRowCountIsNotNull<milvus::index::JsonKeyStats>::value);

--- a/internal/core/src/index/ScalarIndexTest.cpp
+++ b/internal/core/src/index/ScalarIndexTest.cpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <random>
 #include <string>
+#include <type_traits>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
@@ -34,11 +35,17 @@
 #include "common/type_c.h"
 #include "gtest/gtest.h"
 #include "index/BitmapIndex.h"
+#include "index/FMIndex.h"
+#include "index/HybridScalarIndex.h"
 #include "index/Index.h"
 #include "index/IndexFactory.h"
 #include "index/IndexInfo.h"
+#include "index/InvertedIndexTantivy.h"
+#include "index/JsonFlatIndex.h"
 #include "index/ScalarIndex.h"
 #include "index/ScalarIndexSort.h"
+#include "index/StringIndexSort.h"
+#include "index/json_stats/JsonKeyStats.h"
 #include "pb/common.pb.h"
 #include "storage/ChunkManager.h"
 #include "storage/Types.h"
@@ -655,3 +662,34 @@ TEST(ScalarTest, test_function_range) {
     TestIndexSearchRange<float>();
     TestIndexSearchRange<double>();
 }
+
+// ScalarIndex<T>::IsNotNull(int64_t) -- the row-count-aware overload that
+// projects absolute null offsets into a caller-owned row space -- is hidden in
+// every subclass that declares IsNotNull() without a using-declaration, so a
+// call through the derived static type simply stops compiling. Each subclass
+// carries `using <base>::IsNotNull;` for exactly that reason. Nothing at
+// runtime can catch its removal, so pin it here.
+template <typename Index, typename = void>
+struct HasRowCountIsNotNull : std::false_type {};
+
+template <typename Index>
+struct HasRowCountIsNotNull<
+    Index,
+    std::void_t<decltype(std::declval<Index&>().IsNotNull(int64_t{}))>>
+    : std::true_type {};
+
+static_assert(HasRowCountIsNotNull<milvus::index::ScalarIndex<int64_t>>::value,
+              "the base overload must exist");
+static_assert(HasRowCountIsNotNull<milvus::index::BitmapIndex<int64_t>>::value);
+static_assert(
+    HasRowCountIsNotNull<milvus::index::HybridScalarIndex<int64_t>>::value);
+static_assert(
+    HasRowCountIsNotNull<milvus::index::InvertedIndexTantivy<int64_t>>::value);
+static_assert(HasRowCountIsNotNull<
+              milvus::index::JsonFlatIndexQueryExecutor<std::string>>::value);
+static_assert(
+    HasRowCountIsNotNull<milvus::index::ScalarIndexSort<int64_t>>::value);
+static_assert(HasRowCountIsNotNull<milvus::index::StringIndexMarisa>::value);
+static_assert(HasRowCountIsNotNull<milvus::index::StringIndexSort>::value);
+static_assert(HasRowCountIsNotNull<milvus::index::JsonKeyStats>::value);
+static_assert(HasRowCountIsNotNull<milvus::index::FMIndex>::value);

--- a/internal/core/src/index/StringIndexMarisa.h
+++ b/internal/core/src/index/StringIndexMarisa.h
@@ -86,6 +86,11 @@ class StringIndexMarisa : public StringIndex {
     const TargetBitmap
     IsNull() override;
 
+    // Declaring IsNotNull() here hides the base's row-count-aware
+    // IsNotNull(int64_t) overload; keep it visible so a call through this
+    // static type still finds it.
+    using ScalarIndex<std::string>::IsNotNull;
+
     TargetBitmap
     IsNotNull() override;
 

--- a/internal/core/src/index/StringIndexSort.h
+++ b/internal/core/src/index/StringIndexSort.h
@@ -112,6 +112,11 @@ class StringIndexSort : public StringIndex {
     const TargetBitmap
     IsNull() override;
 
+    // Declaring IsNotNull() here hides the base's row-count-aware
+    // IsNotNull(int64_t) overload; keep it visible so a call through this
+    // static type still finds it.
+    using ScalarIndex<std::string>::IsNotNull;
+
     TargetBitmap
     IsNotNull() override;
 

--- a/internal/core/src/index/json_stats/JsonKeyStats.h
+++ b/internal/core/src/index/json_stats/JsonKeyStats.h
@@ -169,6 +169,11 @@ class JsonKeyStats : public ScalarIndex<std::string> {
                   "IsNull not supported for JsonKeyStats");
     }
 
+    // Declaring IsNotNull() here hides the base's row-count-aware
+    // IsNotNull(int64_t) overload; keep it visible so a call through this
+    // static type still finds it.
+    using ScalarIndex<std::string>::IsNotNull;
+
     TargetBitmap
     IsNotNull() override {
         ThrowInfo(ErrorCode::NotImplemented,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1052,6 +1052,7 @@ ChunkedSegmentSealedImpl::CloneRuntimeResourceState(
         current->skip_index ? current->skip_index->Clone() : state->skip_index;
     state->mmap_field_ids = current->mmap_field_ids;
     state->variable_fields_avg_size = current->variable_fields_avg_size;
+    state->geometry_caches = current->geometry_caches;
     state->row_count = current->row_count;
     return state;
 }
@@ -3361,6 +3362,17 @@ ChunkedSegmentSealedImpl::prefetch_chunks(milvus::OpContext* op_ctx,
     prefetch_chunks_locked(op_ctx, field_id);
 }
 
+std::shared_ptr<milvus::exec::SimpleGeometryCache>
+ChunkedSegmentSealedImpl::GetGeometryCache(FieldId field_id) const {
+    auto snapshot = CapturePublishedState();
+    if (snapshot == nullptr || snapshot->runtime == nullptr) {
+        return nullptr;
+    }
+    auto it = snapshot->runtime->geometry_caches.find(field_id);
+    return it != snapshot->runtime->geometry_caches.end() ? it->second
+                                                          : nullptr;
+}
+
 void
 ChunkedSegmentSealedImpl::ApplyFieldValidData(
     milvus::OpContext* op_ctx,
@@ -4064,6 +4076,7 @@ ChunkedSegmentSealedImpl::DropFieldData(
     }
     if (runtime != nullptr) {
         runtime->fields.erase(field_id);
+        runtime->geometry_caches.erase(field_id);
         runtime->array_offsets_map.erase(field_id);
         runtime->mmap_field_ids.erase(field_id);
         // Average size describes the retrievable field value, not the
@@ -4078,6 +4091,7 @@ ChunkedSegmentSealedImpl::DropFieldData(
     } else {
         auto next_runtime = CloneRuntimeResourceState(snapshot->runtime);
         next_runtime->fields.erase(field_id);
+        next_runtime->geometry_caches.erase(field_id);
         next_runtime->array_offsets_map.erase(field_id);
         next_runtime->mmap_field_ids.erase(field_id);
         // See the staged-runtime branch above: only schema removal retires
@@ -4849,10 +4863,6 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
 }
 
 ChunkedSegmentSealedImpl::~ChunkedSegmentSealedImpl() {
-    // Clean up geometry cache for all fields in this segment
-    auto& cache_manager = milvus::exec::SimpleGeometryCacheManager::Instance();
-    cache_manager.RemoveSegmentCaches(segment_instance_uid(), get_segment_id());
-
     if (mmap_descriptor_ != nullptr) {
         auto mm = storage::MmapManager::GetInstance().GetMmapChunkManager();
         mm->UnRegister(mmap_descriptor_);
@@ -7030,25 +7040,15 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     generate_interim_index(field_id, num_rows, column, op_ctx, committer);
 
     // Build the geometry cache OUTSIDE the publish lock (it decodes the whole
-    // column), then install it atomically together with the column below, so
-    // GIS predicates and bulk_subscript never disagree about which version of
-    // the column they are reading.
+    // column), then stage it in the same immutable runtime snapshot as the
+    // column. Publishing the snapshot makes both visible with one atomic state
+    // swap; a cancelled/failed reopen simply discards the staged pair.
     std::shared_ptr<milvus::exec::SimpleGeometryCache> staged_geometry_cache;
     if (!SystemProperty::Instance().IsSystem(field_id) &&
         data_type == DataType::GEOMETRY &&
         segcore_config_.get_enable_geometry_cache()) {
         staged_geometry_cache = BuildGeometryCacheDetached(field_id, column);
     }
-    auto install_staged_geometry_cache = [&]() {
-        if (staged_geometry_cache != nullptr) {
-            milvus::exec::SimpleGeometryCacheManager::Instance().InstallCache(
-                segment_instance_uid(),
-                get_segment_id(),
-                field_id,
-                staged_geometry_cache);
-        }
-    };
-
     auto& field_meta = schema_snapshot->operator[](field_id);
     auto prepare_array_offsets = [&](RuntimeResourceState& target_runtime) {
         if (auto parsed_struct_name = GetStructNameForArrayField(field_meta);
@@ -7129,6 +7129,15 @@ ChunkedSegmentSealedImpl::load_field_data_common(
                 target_runtime.fields.emplace(field_id, column);
             }
 
+            if (data_type == DataType::GEOMETRY) {
+                if (staged_geometry_cache != nullptr) {
+                    target_runtime.geometry_caches.insert_or_assign(
+                        field_id, staged_geometry_cache);
+                } else {
+                    target_runtime.geometry_caches.erase(field_id);
+                }
+            }
+
             if (enable_mmap) {
                 target_runtime.mmap_field_ids.insert(field_id);
             } else {
@@ -7167,7 +7176,6 @@ ChunkedSegmentSealedImpl::load_field_data_common(
 
             std::unique_lock lck(mutex_);
             apply_loaded_column(target_runtime, old_column, staged_state);
-            install_staged_geometry_cache();
         });
         return;
     }
@@ -7184,7 +7192,6 @@ ChunkedSegmentSealedImpl::load_field_data_common(
 
         std::unique_lock lck(mutex_);
         apply_loaded_column(*runtime, old_column, *capture_snapshot());
-        install_staged_geometry_cache();
         return;
     }
 
@@ -7196,7 +7203,6 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     apply_loaded_column(*next_runtime, old_column, *current);
 
     auto published_runtime = ToConstRuntimeState(std::move(next_runtime));
-    install_staged_geometry_cache();
     lck.unlock();
     if (SystemProperty::Instance().IsSystem(field_id)) {
         PublishRuntimeStateLocked(published_runtime);
@@ -7963,8 +7969,8 @@ ChunkedSegmentSealedImpl::BuildGeometryCacheDetached(
         // rows evaluated against not-yet-published geometry, untouched rows
         // read as gaps and judged non-matching -- and a throw partway would
         // strand that contaminated cache in the manager map forever, since
-        // caches are only ever built at load time. The caller installs this
-        // one atomically once it is complete.
+        // caches are only ever built at load time. The caller stages this one
+        // beside the replacement column in the next published runtime state.
         auto geometry_cache =
             std::make_shared<milvus::exec::SimpleGeometryCache>();
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <filesystem>
 #include <memory>
+#include <new>
 #include <mutex>
 #include <optional>
 #include <ratio>
@@ -1051,6 +1052,7 @@ ChunkedSegmentSealedImpl::CloneRuntimeResourceState(
         current->skip_index ? current->skip_index->Clone() : state->skip_index;
     state->mmap_field_ids = current->mmap_field_ids;
     state->variable_fields_avg_size = current->variable_fields_avg_size;
+    state->geometry_caches = current->geometry_caches;
     state->row_count = current->row_count;
     return state;
 }
@@ -1452,6 +1454,7 @@ ChunkedSegmentSealedImpl::FreezeRuntimeResourceState(
                                              : std::make_shared<SkipIndex>();
     runtime->mmap_field_ids = current.mmap_field_ids;
     runtime->variable_fields_avg_size = current.variable_fields_avg_size;
+    runtime->geometry_caches = current.geometry_caches;
     runtime->row_count = current.row_count;
     return ToConstRuntimeState(std::move(runtime));
 }
@@ -3362,6 +3365,17 @@ ChunkedSegmentSealedImpl::prefetch_chunks(milvus::OpContext* op_ctx,
     prefetch_chunks_locked(op_ctx, field_id);
 }
 
+std::shared_ptr<milvus::exec::SimpleGeometryCache>
+ChunkedSegmentSealedImpl::GetGeometryCache(FieldId field_id) const {
+    auto snapshot = CapturePublishedState();
+    if (snapshot == nullptr || snapshot->runtime == nullptr) {
+        return nullptr;
+    }
+    auto it = snapshot->runtime->geometry_caches.find(field_id);
+    return it != snapshot->runtime->geometry_caches.end() ? it->second
+                                                          : nullptr;
+}
+
 void
 ChunkedSegmentSealedImpl::ApplyFieldValidData(
     milvus::OpContext* op_ctx,
@@ -4065,6 +4079,7 @@ ChunkedSegmentSealedImpl::DropFieldData(
     }
     if (runtime != nullptr) {
         runtime->fields.erase(field_id);
+        runtime->geometry_caches.erase(field_id);
         runtime->array_offsets_map.erase(field_id);
         runtime->mmap_field_ids.erase(field_id);
         // Average size describes the retrievable field value, not the
@@ -4079,6 +4094,7 @@ ChunkedSegmentSealedImpl::DropFieldData(
     } else {
         auto next_runtime = CloneRuntimeResourceState(snapshot->runtime);
         next_runtime->fields.erase(field_id);
+        next_runtime->geometry_caches.erase(field_id);
         next_runtime->array_offsets_map.erase(field_id);
         next_runtime->mmap_field_ids.erase(field_id);
         // See the staged-runtime branch above: only schema removal retires
@@ -4850,15 +4866,6 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
 }
 
 ChunkedSegmentSealedImpl::~ChunkedSegmentSealedImpl() {
-    // Clean up geometry cache for all fields in this segment
-    auto& cache_manager = milvus::exec::SimpleGeometryCacheManager::Instance();
-    cache_manager.RemoveSegmentCaches(ctx_, get_segment_id());
-
-    if (ctx_) {
-        GEOS_finish_r(ctx_);
-        ctx_ = nullptr;
-    }
-
     if (mmap_descriptor_ != nullptr) {
         auto mm = storage::MmapManager::GetInstance().GetMmapChunkManager();
         mm->UnRegister(mmap_descriptor_);
@@ -7035,12 +7042,16 @@ ChunkedSegmentSealedImpl::load_field_data_common(
 
     generate_interim_index(field_id, num_rows, column, op_ctx, committer);
 
+    // Build the geometry cache OUTSIDE the publish lock (it decodes the whole
+    // column), then stage it in the same immutable runtime snapshot as the
+    // column. Publishing the snapshot makes both visible with one atomic state
+    // swap; a cancelled/failed reopen simply discards the staged pair.
+    std::shared_ptr<milvus::exec::SimpleGeometryCache> staged_geometry_cache;
     if (!SystemProperty::Instance().IsSystem(field_id) &&
         data_type == DataType::GEOMETRY &&
         segcore_config_.get_enable_geometry_cache()) {
-        LoadGeometryCache(field_id, column);
+        staged_geometry_cache = BuildGeometryCacheDetached(field_id, column);
     }
-
     auto& field_meta = schema_snapshot->operator[](field_id);
     auto prepare_array_offsets = [&](RuntimeResourceState& target_runtime) {
         if (auto parsed_struct_name = GetStructNameForArrayField(field_meta);
@@ -7119,6 +7130,15 @@ ChunkedSegmentSealedImpl::load_field_data_common(
                            "field {} column already exists",
                            field_id.get());
                 target_runtime.fields.emplace(field_id, column);
+            }
+
+            if (data_type == DataType::GEOMETRY) {
+                if (staged_geometry_cache != nullptr) {
+                    target_runtime.geometry_caches.insert_or_assign(
+                        field_id, staged_geometry_cache);
+                } else {
+                    target_runtime.geometry_caches.erase(field_id);
+                }
             }
 
             if (enable_mmap) {
@@ -7942,47 +7962,76 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
     });
 }
 
-void
-ChunkedSegmentSealedImpl::LoadGeometryCache(
+std::shared_ptr<milvus::exec::SimpleGeometryCache>
+ChunkedSegmentSealedImpl::BuildGeometryCacheDetached(
     FieldId field_id, const std::shared_ptr<ChunkedColumnInterface>& column) {
     try {
-        // Get geometry cache for this segment+field
-        auto& geometry_cache =
-            milvus::exec::SimpleGeometryCacheManager::Instance()
-                .GetOrCreateCache(get_segment_id(), field_id);
+        // Build into a DETACHED cache -- deliberately NOT the live one from
+        // the manager. A load can be a REPLACE on this same object (a
+        // default-filled column later replaced by the real one:
+        // is_replace_field = was_default_filled || files_changed), where the
+        // contents genuinely change, and segment_instance_uid() is unchanged
+        // for an in-place reopen. Writing through the live cache would let
+        // concurrent queries observe a half-replaced mixture -- overwritten
+        // rows evaluated against not-yet-published geometry, untouched rows
+        // read as gaps and judged non-matching -- and a throw partway would
+        // strand that contaminated cache in the manager map forever, since
+        // caches are only ever built at load time. The caller stages this one
+        // beside the replacement column in the next published runtime state.
+        auto geometry_cache =
+            std::make_shared<milvus::exec::SimpleGeometryCache>();
 
-        // Iterate through all chunks and collect WKB data
+        // Rows are written at their absolute segment offsets (see
+        // SimpleGeometryCache::AppendDataAt).
         auto num_chunks = column->num_chunks();
+        size_t absolute_offset = 0;
         for (int64_t chunk_id = 0; chunk_id < num_chunks; ++chunk_id) {
             // Get all string views from this chunk
             auto pw = column->StringViews(nullptr, chunk_id);
             auto [string_views, valid_data] = pw.get();
 
             // Add each string view to the geometry cache
-            for (size_t i = 0; i < string_views.size(); ++i) {
+            for (size_t i = 0; i < string_views.size();
+                 ++i, ++absolute_offset) {
                 if (!valid_data || valid_data[i]) {
                     // Valid geometry data
                     const auto& wkb_data = string_views[i];
-                    geometry_cache.AppendData(
-                        ctx_, wkb_data.data(), wkb_data.size());
+                    geometry_cache->AppendDataAt(
+                        absolute_offset, wkb_data.data(), wkb_data.size());
                 } else {
                     // Null/invalid geometry
-                    geometry_cache.AppendData(ctx_, nullptr, 0);
+                    geometry_cache->AppendDataAt(absolute_offset, nullptr, 0);
                 }
             }
         }
 
         LOG_INFO(
-            "Successfully loaded geometry cache for segment {} field {} "
+            "Successfully built geometry cache for segment {} field {} "
             "with "
             "{} geometries",
             get_segment_id(),
             field_id.get(),
-            geometry_cache.Size());
+            geometry_cache->Size());
+        return geometry_cache;
 
+    } catch (const SegcoreError&) {
+        // Already typed (e.g. a retriable MemAllocateFailed from a transient
+        // GEOS allocation failure) -- rethrow as-is; re-wrapping would collapse
+        // the code into a non-retriable UnexpectedError.
+        throw;
+    } catch (const std::bad_alloc&) {
+        // Container/std allocation OOM (e.g. the cache's geometries_.resize)
+        // is the same transient resource failure as a GEOS allocation failure
+        // and must stay retriable -- the generic handler below would collapse
+        // it into a non-retriable UnexpectedError.
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory building geometry cache for segment {} field "
+                  "{}",
+                  get_segment_id(),
+                  field_id.get());
     } catch (const std::exception& e) {
         ThrowInfo(UnexpectedError,
-                  "Failed to load geometry cache for segment {} field {}: {}",
+                  "Failed to build geometry cache for segment {} field {}: {}",
                   get_segment_id(),
                   field_id.get(),
                   e.what());

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1454,6 +1454,7 @@ ChunkedSegmentSealedImpl::FreezeRuntimeResourceState(
                                              : std::make_shared<SkipIndex>();
     runtime->mmap_field_ids = current.mmap_field_ids;
     runtime->variable_fields_avg_size = current.variable_fields_avg_size;
+    runtime->geometry_caches = current.geometry_caches;
     runtime->row_count = current.row_count;
     return ToConstRuntimeState(std::move(runtime));
 }

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <filesystem>
 #include <memory>
+#include <new>
 #include <mutex>
 #include <optional>
 #include <ratio>
@@ -4850,12 +4851,7 @@ ChunkedSegmentSealedImpl::ChunkedSegmentSealedImpl(
 ChunkedSegmentSealedImpl::~ChunkedSegmentSealedImpl() {
     // Clean up geometry cache for all fields in this segment
     auto& cache_manager = milvus::exec::SimpleGeometryCacheManager::Instance();
-    cache_manager.RemoveSegmentCaches(ctx_, get_segment_id());
-
-    if (ctx_) {
-        GEOS_finish_r(ctx_);
-        ctx_ = nullptr;
-    }
+    cache_manager.RemoveSegmentCaches(segment_instance_uid(), get_segment_id());
 
     if (mmap_descriptor_ != nullptr) {
         auto mm = storage::MmapManager::GetInstance().GetMmapChunkManager();
@@ -7033,11 +7029,25 @@ ChunkedSegmentSealedImpl::load_field_data_common(
 
     generate_interim_index(field_id, num_rows, column, op_ctx, committer);
 
+    // Build the geometry cache OUTSIDE the publish lock (it decodes the whole
+    // column), then install it atomically together with the column below, so
+    // GIS predicates and bulk_subscript never disagree about which version of
+    // the column they are reading.
+    std::shared_ptr<milvus::exec::SimpleGeometryCache> staged_geometry_cache;
     if (!SystemProperty::Instance().IsSystem(field_id) &&
         data_type == DataType::GEOMETRY &&
         segcore_config_.get_enable_geometry_cache()) {
-        LoadGeometryCache(field_id, column);
+        staged_geometry_cache = BuildGeometryCacheDetached(field_id, column);
     }
+    auto install_staged_geometry_cache = [&]() {
+        if (staged_geometry_cache != nullptr) {
+            milvus::exec::SimpleGeometryCacheManager::Instance().InstallCache(
+                segment_instance_uid(),
+                get_segment_id(),
+                field_id,
+                staged_geometry_cache);
+        }
+    };
 
     auto& field_meta = schema_snapshot->operator[](field_id);
     auto prepare_array_offsets = [&](RuntimeResourceState& target_runtime) {
@@ -7157,6 +7167,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
 
             std::unique_lock lck(mutex_);
             apply_loaded_column(target_runtime, old_column, staged_state);
+            install_staged_geometry_cache();
         });
         return;
     }
@@ -7173,6 +7184,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
 
         std::unique_lock lck(mutex_);
         apply_loaded_column(*runtime, old_column, *capture_snapshot());
+        install_staged_geometry_cache();
         return;
     }
 
@@ -7184,6 +7196,7 @@ ChunkedSegmentSealedImpl::load_field_data_common(
     apply_loaded_column(*next_runtime, old_column, *current);
 
     auto published_runtime = ToConstRuntimeState(std::move(next_runtime));
+    install_staged_geometry_cache();
     lck.unlock();
     if (SystemProperty::Instance().IsSystem(field_id)) {
         PublishRuntimeStateLocked(published_runtime);
@@ -7936,47 +7949,84 @@ ChunkedSegmentSealedImpl::FillDefaultValueFields(
     });
 }
 
-void
-ChunkedSegmentSealedImpl::LoadGeometryCache(
+std::shared_ptr<milvus::exec::SimpleGeometryCache>
+ChunkedSegmentSealedImpl::BuildGeometryCacheDetached(
     FieldId field_id, const std::shared_ptr<ChunkedColumnInterface>& column) {
     try {
-        // Get geometry cache for this segment+field
-        auto& geometry_cache =
-            milvus::exec::SimpleGeometryCacheManager::Instance()
-                .GetOrCreateCache(get_segment_id(), field_id);
+        // Build into a DETACHED cache -- deliberately NOT the live one from
+        // the manager. A load can be a REPLACE on this same object (a
+        // default-filled column later replaced by the real one:
+        // is_replace_field = was_default_filled || files_changed), where the
+        // contents genuinely change, and segment_instance_uid() is unchanged
+        // for an in-place reopen. Writing through the live cache would let
+        // concurrent queries observe a half-replaced mixture -- overwritten
+        // rows evaluated against not-yet-published geometry, untouched rows
+        // read as gaps and judged non-matching -- and a throw partway would
+        // strand that contaminated cache in the manager map forever, since
+        // caches are only ever built at load time. The caller installs this
+        // one atomically once it is complete.
+        auto geometry_cache =
+            std::make_shared<milvus::exec::SimpleGeometryCache>();
 
-        // Iterate through all chunks and collect WKB data
+        // Rows are written at their absolute segment offsets (see
+        // SimpleGeometryCache::AppendDataAt).
         auto num_chunks = column->num_chunks();
+        size_t absolute_offset = 0;
         for (int64_t chunk_id = 0; chunk_id < num_chunks; ++chunk_id) {
             // Get all string views from this chunk
             auto pw = column->StringViews(nullptr, chunk_id);
             auto [string_views, valid_data] = pw.get();
 
             // Add each string view to the geometry cache
-            for (size_t i = 0; i < string_views.size(); ++i) {
-                if (valid_data.empty() || valid_data[i]) {
+            for (size_t i = 0; i < string_views.size();
+                 ++i, ++absolute_offset) {
+                // Guard valid_data[i] like FieldIndexing.cpp's accessor does:
+                // nothing here establishes that valid_data spans every view,
+                // so an unchecked index is an out-of-bounds read that would
+                // desynchronize the cache's nullness from the segment. Rows
+                // beyond the span are classified NULL, matching the index
+                // side -- intentional leniency toward a short valid_data
+                // span rather than failing the whole segment load.
+                if (valid_data.empty() ||
+                    (i < valid_data.size() && valid_data[i])) {
                     // Valid geometry data
                     const auto& wkb_data = string_views[i];
-                    geometry_cache.AppendData(
-                        ctx_, wkb_data.data(), wkb_data.size());
+                    geometry_cache->AppendDataAt(
+                        absolute_offset, wkb_data.data(), wkb_data.size());
                 } else {
                     // Null/invalid geometry
-                    geometry_cache.AppendData(ctx_, nullptr, 0);
+                    geometry_cache->AppendDataAt(absolute_offset, nullptr, 0);
                 }
             }
         }
 
         LOG_INFO(
-            "Successfully loaded geometry cache for segment {} field {} "
+            "Successfully built geometry cache for segment {} field {} "
             "with "
             "{} geometries",
             get_segment_id(),
             field_id.get(),
-            geometry_cache.Size());
+            geometry_cache->Size());
+        return geometry_cache;
 
+    } catch (const SegcoreError&) {
+        // Already typed (e.g. a retriable MemAllocateFailed from a transient
+        // GEOS allocation failure) -- rethrow as-is; re-wrapping would collapse
+        // the code into a non-retriable UnexpectedError.
+        throw;
+    } catch (const std::bad_alloc&) {
+        // Container/std allocation OOM (e.g. the cache's geometries_.resize)
+        // is the same transient resource failure as a GEOS allocation failure
+        // and must stay retriable -- the generic handler below would collapse
+        // it into a non-retriable UnexpectedError.
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory building geometry cache for segment {} field "
+                  "{}",
+                  get_segment_id(),
+                  field_id.get());
     } catch (const std::exception& e) {
         ThrowInfo(UnexpectedError,
-                  "Failed to load geometry cache for segment {} field {}: {}",
+                  "Failed to build geometry cache for segment {} field {}: {}",
                   get_segment_id(),
                   field_id.get(),
                   e.what());

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -43,6 +43,7 @@
 #include "common/Chunk.h"
 #include "common/EasyAssert.h"
 #include "common/FieldMeta.h"
+#include "common/GeometryCache.h"
 #include "common/IndexMeta.h"
 #include "common/Json.h"
 #include "common/LoadInfo.h"
@@ -734,10 +735,15 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                   "sealed segment does not support get_timestamps()");
     }
 
-    // Load Geometry cache for a field
-    void
-    LoadGeometryCache(FieldId field_id,
-                      const std::shared_ptr<ChunkedColumnInterface>& column);
+    // Build a DETACHED geometry cache for a field. The caller installs it
+    // atomically (SimpleGeometryCacheManager::InstallCache) once the column
+    // it describes is published, so readers never observe a partially built
+    // or partially replaced cache. Returns nullptr only if the caller decides
+    // not to build.
+    std::shared_ptr<milvus::exec::SimpleGeometryCache>
+    BuildGeometryCacheDetached(
+        FieldId field_id,
+        const std::shared_ptr<ChunkedColumnInterface>& column);
 
  private:
     void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -2446,6 +2446,15 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         return ToConstRuntimeState(std::move(runtime));
     }
 
+    // Reaches FreezeRuntimeResourceState itself, which copies the state
+    // field by field -- unlike TestFreezeRuntimeResourceState above, which
+    // only re-wraps a state that is already fully populated and therefore
+    // cannot catch a field the copy forgets.
+    static std::shared_ptr<const RuntimeResourceState>
+    TestFreezeRuntimeResourceStateCopy(const RuntimeResourceState& current) {
+        return FreezeRuntimeResourceState(current);
+    }
+
     void
     TestLoadIndex(LoadIndexInfo& info,
                   bool is_replace,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -43,6 +43,7 @@
 #include "common/Chunk.h"
 #include "common/EasyAssert.h"
 #include "common/FieldMeta.h"
+#include "common/GeometryCache.h"
 #include "common/IndexMeta.h"
 #include "common/Json.h"
 #include "common/LoadInfo.h"
@@ -370,6 +371,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         std::unordered_set<FieldId> mmap_field_ids;
         std::unordered_map<FieldId, std::pair<int64_t, int64_t>>
             variable_fields_avg_size;
+        // Sealed geometry caches are part of the immutable runtime snapshot.
+        // A replace/reopen stages the new column and cache in the same clone,
+        // then publishes both with one atomic PublishedSegmentState swap.
+        std::unordered_map<FieldId,
+                           std::shared_ptr<milvus::exec::SimpleGeometryCache>>
+            geometry_caches;
         int64_t row_count{0};
     };
 
@@ -599,6 +606,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     prefetch_vector(milvus::OpContext* op_ctx, FieldId field_id) const override;
 
+    std::shared_ptr<milvus::exec::SimpleGeometryCache>
+    GetGeometryCache(FieldId field_id) const override;
+
     void
     ApplyFieldValidData(milvus::OpContext* op_ctx,
                         FieldId field_id,
@@ -734,10 +744,14 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                   "sealed segment does not support get_timestamps()");
     }
 
-    // Load Geometry cache for a field
-    void
-    LoadGeometryCache(FieldId field_id,
-                      const std::shared_ptr<ChunkedColumnInterface>& column);
+    // Build a DETACHED geometry cache for a field. The caller stages it in the
+    // same immutable RuntimeResourceState as the column it describes, so one
+    // PublishedSegmentState swap exposes both and a failed reopen exposes
+    // neither. Returns nullptr only if the caller decides not to build.
+    std::shared_ptr<milvus::exec::SimpleGeometryCache>
+    BuildGeometryCacheDetached(
+        FieldId field_id,
+        const std::shared_ptr<ChunkedColumnInterface>& column);
 
  private:
     void
@@ -2431,6 +2445,15 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     TestFreezeRuntimeResourceState(
         std::shared_ptr<RuntimeResourceState> runtime) const {
         return ToConstRuntimeState(std::move(runtime));
+    }
+
+    // Reaches FreezeRuntimeResourceState itself, which copies the state
+    // field by field -- unlike TestFreezeRuntimeResourceState above, which
+    // only re-wraps a state that is already fully populated and therefore
+    // cannot catch a field the copy forgets.
+    static std::shared_ptr<const RuntimeResourceState>
+    TestFreezeRuntimeResourceStateCopy(const RuntimeResourceState& current) {
+        return FreezeRuntimeResourceState(current);
     }
 
     void

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -371,6 +371,12 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
         std::unordered_set<FieldId> mmap_field_ids;
         std::unordered_map<FieldId, std::pair<int64_t, int64_t>>
             variable_fields_avg_size;
+        // Sealed geometry caches are part of the immutable runtime snapshot.
+        // A replace/reopen stages the new column and cache in the same clone,
+        // then publishes both with one atomic PublishedSegmentState swap.
+        std::unordered_map<FieldId,
+                           std::shared_ptr<milvus::exec::SimpleGeometryCache>>
+            geometry_caches;
         int64_t row_count{0};
     };
 
@@ -600,6 +606,9 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     void
     prefetch_vector(milvus::OpContext* op_ctx, FieldId field_id) const override;
 
+    std::shared_ptr<milvus::exec::SimpleGeometryCache>
+    GetGeometryCache(FieldId field_id) const override;
+
     void
     ApplyFieldValidData(milvus::OpContext* op_ctx,
                         FieldId field_id,
@@ -735,11 +744,10 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
                   "sealed segment does not support get_timestamps()");
     }
 
-    // Build a DETACHED geometry cache for a field. The caller installs it
-    // atomically (SimpleGeometryCacheManager::InstallCache) once the column
-    // it describes is published, so readers never observe a partially built
-    // or partially replaced cache. Returns nullptr only if the caller decides
-    // not to build.
+    // Build a DETACHED geometry cache for a field. The caller stages it in the
+    // same immutable RuntimeResourceState as the column it describes, so one
+    // PublishedSegmentState swap exposes both and a failed reopen exposes
+    // neither. Returns nullptr only if the caller decides not to build.
     std::shared_ptr<milvus::exec::SimpleGeometryCache>
     BuildGeometryCacheDetached(
         FieldId field_id,

--- a/internal/core/src/segcore/ConcurrentVector.cpp
+++ b/internal/core/src/segcore/ConcurrentVector.cpp
@@ -157,6 +157,10 @@ VectorBase::set_data_raw(ssize_t element_offset,
         case DataType::GEOMETRY: {
             // get the geometry array of a column from proto message
             auto& geometry_data = FIELD_DATA(data, geometry);
+            AssertInfo(geometry_data.size() == element_count,
+                       "geometry payload size {} must match element count {}",
+                       geometry_data.size(),
+                       element_count);
             std::vector<std::string> data_raw{};
             data_raw.reserve(geometry_data.size());
             for (auto& geometry_bytes : geometry_data) {

--- a/internal/core/src/segcore/ConcurrentVector.cpp
+++ b/internal/core/src/segcore/ConcurrentVector.cpp
@@ -158,6 +158,10 @@ VectorBase::set_data_raw(ssize_t element_offset,
         case DataType::GEOMETRY: {
             // get the geometry array of a column from proto message
             auto& geometry_data = FIELD_DATA(data, geometry);
+            AssertInfo(geometry_data.size() == element_count,
+                       "geometry payload size {} must match element count {}",
+                       geometry_data.size(),
+                       element_count);
             std::vector<std::string> data_raw{};
             data_raw.reserve(geometry_data.size());
             for (auto& geometry_bytes : geometry_data) {

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -80,6 +80,16 @@ class ThreadSafeValidData {
                  const FieldMeta& field_meta) {
         std::unique_lock<std::shared_mutex> lck(mutex_);
         if (field_meta.is_nullable()) {
+            // write_from reads exactly num_rows entries from the source, so a
+            // producer payload shorter than the row count is an out-of-bounds
+            // read. Reject it at the boundary rather than silently treating
+            // the missing tail as NULL further down the ingest path.
+            AssertInfo(data->valid_data_size() == num_rows,
+                       "nullable field {} valid_data size {} must match "
+                       "num_rows {}",
+                       field_meta.get_id().get(),
+                       data->valid_data_size(),
+                       num_rows);
             reserve_to(length_ + num_rows);
             write_from(length_, num_rows, data->valid_data().data());
             length_ += num_rows;

--- a/internal/core/src/segcore/ConcurrentVector.h
+++ b/internal/core/src/segcore/ConcurrentVector.h
@@ -80,6 +80,7 @@ class ThreadSafeValidData {
                  const FieldMeta& field_meta) {
         std::unique_lock<std::shared_mutex> lck(mutex_);
         if (field_meta.is_nullable()) {
+            check_source_span(num_rows, data, field_meta);
             reserve_to(length_ + num_rows);
             write_from(
                 length_, num_rows, GetFieldDataRowValidData(*data).data());
@@ -98,6 +99,10 @@ class ThreadSafeValidData {
                  const FieldMeta& field_meta) {
         std::unique_lock<std::shared_mutex> lck(mutex_);
         if (field_meta.is_nullable()) {
+            // This is the overload the ingest path uses (SegmentGrowingImpl's
+            // Insert and fill_empty_field backfill), so the source-span check
+            // has to live here too, not only on the appending overload above.
+            check_source_span(num_rows, data, field_meta);
             const auto end = element_offset + num_rows;
             // No gaps. length_ advances to `end`, and is_valid() admits every
             // offset below it, so a write that starts past the current length
@@ -197,6 +202,29 @@ class ThreadSafeValidData {
     }
 
  private:
+    // write_from reads exactly num_rows entries from the source, so a producer
+    // payload shorter than the row count is an out-of-bounds read. Reject it at
+    // the boundary rather than silently treating the missing tail as NULL
+    // further down the ingest path.
+    static void
+    check_source_span(size_t num_rows,
+                      const DataArray* data,
+                      const FieldMeta& field_meta) {
+        // Resolve validity the same way write_from's caller does
+        // (GetFieldDataRowValidData): new payloads carry it in the
+        // field-specific ScalarField/VectorField, legacy ones in
+        // FieldData.valid_data. Checking the top-level field alone would
+        // reject every new-format payload as empty.
+        const auto valid_size =
+            static_cast<size_t>(GetFieldDataRowValidData(*data).size());
+        AssertInfo(valid_size == num_rows,
+                   "nullable field {} valid_data size {} must match "
+                   "num_rows {}",
+                   field_meta.get_id().get(),
+                   valid_size,
+                   num_rows);
+    }
+
     // Ensure enough chunks exist to hold `n` elements. Caller holds the lock.
     void
     reserve_to(size_t n) {

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <exception>
 #include <map>
+#include <new>
 #include <optional>
 #include <string>
 #include <utility>
@@ -687,11 +688,21 @@ ScalarFieldIndexing<T>::AppendSegmentIndex(int64_t reserved_offset,
                     stream_data->scalars().geometry_data();
                 const auto& valid_data = GetFieldDataRowValidData(*stream_data);
 
+                AssertInfo(geometry_array.data_size() == size,
+                           "geometry payload size {} must match append size {}",
+                           geometry_array.data_size(),
+                           size);
+                AssertInfo(valid_data.empty() || valid_data.size() == size,
+                           "geometry valid_data size {} must be empty or match "
+                           "append size {}",
+                           valid_data.size(),
+                           size);
+
                 // Create accessor for DataArray
                 auto accessor = [&geometry_array, &valid_data](
                                     int64_t i) -> std::pair<std::string, bool> {
                     bool is_valid = valid_data.empty() || valid_data[i];
-                    if (is_valid && i < geometry_array.data_size()) {
+                    if (is_valid) {
                         return {geometry_array.data(i), true};
                     }
                     return {"", false};
@@ -780,6 +791,19 @@ ScalarFieldIndexing<T>::process_geometry_data(int64_t reserved_offset,
                         "Initialized R-Tree index for immediate incremental "
                         "building from {}",
                         log_source);
+                } catch (const SegcoreError&) {
+                    // Already typed -- rethrow as-is; re-wrapping would
+                    // collapse the code (same ordered handlers as the
+                    // AddGeometry loop below).
+                    throw;
+                } catch (const std::bad_alloc&) {
+                    // Wrapper allocation OOM on the first batch is the same
+                    // transient resource failure as on the AddGeometry path
+                    // -- keep it retriable.
+                    ThrowInfo(ErrorCode::MemAllocateFailed,
+                              "out of memory initializing R-Tree index from "
+                              "{}",
+                              log_source);
                 } catch (std::exception& error) {
                     ThrowInfo(UnexpectedError,
                               "R-Tree index initialization error: {}",
@@ -792,12 +816,30 @@ ScalarFieldIndexing<T>::process_geometry_data(int64_t reserved_offset,
             for (int64_t i = 0; i < size; ++i) {
                 int64_t global_offset = reserved_offset + i;
 
-                // Use the accessor to get geometry data and validity
+                // Use the accessor to get geometry data and validity.
+                // is_valid MUST reach AddGeometry: it is the only signal that
+                // distinguishes a genuinely null row from a valid row with an
+                // empty payload (see RTreeIndex::AddGeometry).
                 auto [wkb_data, is_valid] = accessor(i);
 
                 try {
-                    rtree_index->AddGeometry(wkb_data, global_offset);
+                    rtree_index->AddGeometry(wkb_data, global_offset, is_valid);
                     added_count++;
+                } catch (const SegcoreError&) {
+                    // Already typed (e.g. a retriable MemAllocateFailed from a
+                    // transient GEOS allocation failure) -- rethrow as-is;
+                    // re-wrapping would collapse the code into a non-retriable
+                    // UnexpectedError.
+                    throw;
+                } catch (const std::bad_alloc&) {
+                    // Container/std allocation OOM (e.g. the R-Tree wrapper's
+                    // values_.push_back / rtree_.insert) is the same transient
+                    // resource failure as a GEOS allocation failure and must
+                    // stay retriable -- the generic handler below would
+                    // collapse it into a non-retriable UnexpectedError.
+                    ThrowInfo(ErrorCode::MemAllocateFailed,
+                              "out of memory adding geometry at offset {}",
+                              global_offset);
                 } catch (std::exception& error) {
                     ThrowInfo(UnexpectedError,
                               "Failed to add geometry at offset {}: {}",

--- a/internal/core/src/segcore/FieldIndexing.cpp
+++ b/internal/core/src/segcore/FieldIndexing.cpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <exception>
 #include <map>
+#include <new>
 #include <optional>
 #include <string>
 #include <utility>
@@ -687,11 +688,21 @@ ScalarFieldIndexing<T>::AppendSegmentIndex(int64_t reserved_offset,
                     stream_data->scalars().geometry_data();
                 const auto& valid_data = stream_data->valid_data();
 
+                AssertInfo(geometry_array.data_size() == size,
+                           "geometry payload size {} must match append size {}",
+                           geometry_array.data_size(),
+                           size);
+                AssertInfo(valid_data.empty() || valid_data.size() == size,
+                           "geometry valid_data size {} must be empty or match "
+                           "append size {}",
+                           valid_data.size(),
+                           size);
+
                 // Create accessor for DataArray
                 auto accessor = [&geometry_array, &valid_data](
                                     int64_t i) -> std::pair<std::string, bool> {
                     bool is_valid = valid_data.empty() || valid_data[i];
-                    if (is_valid && i < geometry_array.data_size()) {
+                    if (is_valid) {
                         return {geometry_array.data(i), true};
                     }
                     return {"", false};
@@ -780,6 +791,19 @@ ScalarFieldIndexing<T>::process_geometry_data(int64_t reserved_offset,
                         "Initialized R-Tree index for immediate incremental "
                         "building from {}",
                         log_source);
+                } catch (const SegcoreError&) {
+                    // Already typed -- rethrow as-is; re-wrapping would
+                    // collapse the code (same ordered handlers as the
+                    // AddGeometry loop below).
+                    throw;
+                } catch (const std::bad_alloc&) {
+                    // Wrapper allocation OOM on the first batch is the same
+                    // transient resource failure as on the AddGeometry path
+                    // -- keep it retriable.
+                    ThrowInfo(ErrorCode::MemAllocateFailed,
+                              "out of memory initializing R-Tree index from "
+                              "{}",
+                              log_source);
                 } catch (std::exception& error) {
                     ThrowInfo(UnexpectedError,
                               "R-Tree index initialization error: {}",
@@ -792,12 +816,30 @@ ScalarFieldIndexing<T>::process_geometry_data(int64_t reserved_offset,
             for (int64_t i = 0; i < size; ++i) {
                 int64_t global_offset = reserved_offset + i;
 
-                // Use the accessor to get geometry data and validity
+                // Use the accessor to get geometry data and validity.
+                // is_valid MUST reach AddGeometry: it is the only signal that
+                // distinguishes a genuinely null row from a valid row with an
+                // empty payload (see RTreeIndex::AddGeometry).
                 auto [wkb_data, is_valid] = accessor(i);
 
                 try {
-                    rtree_index->AddGeometry(wkb_data, global_offset);
+                    rtree_index->AddGeometry(wkb_data, global_offset, is_valid);
                     added_count++;
+                } catch (const SegcoreError&) {
+                    // Already typed (e.g. a retriable MemAllocateFailed from a
+                    // transient GEOS allocation failure) -- rethrow as-is;
+                    // re-wrapping would collapse the code into a non-retriable
+                    // UnexpectedError.
+                    throw;
+                } catch (const std::bad_alloc&) {
+                    // Container/std allocation OOM (e.g. the R-Tree wrapper's
+                    // values_.push_back / rtree_.insert) is the same transient
+                    // resource failure as a GEOS allocation failure and must
+                    // stay retriable -- the generic handler below would
+                    // collapse it into a non-retriable UnexpectedError.
+                    ThrowInfo(ErrorCode::MemAllocateFailed,
+                              "out of memory adding geometry at offset {}",
+                              global_offset);
                 } catch (std::exception& error) {
                     ThrowInfo(UnexpectedError,
                               "Failed to add geometry at offset {}: {}",

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -21,6 +21,7 @@
 #include <map>
 #include <filesystem>
 #include <memory>
+#include <new>
 #include <mutex>
 #include <numeric>
 #include <optional>
@@ -333,6 +334,36 @@ ExtractArrayLengths(const proto::schema::FieldData& field_data,
                 array_lengths[i] = 0;  // null → empty array
             }
         }
+    }
+}
+
+void
+ValidateGeometryInsertDataShape(const proto::schema::FieldData& field_data,
+                                const FieldMeta& field_meta,
+                                int64_t num_rows) {
+    AssertInfo(
+        field_data.has_scalars() && field_data.scalars().has_geometry_data(),
+        "geometry field {} is missing geometry payload",
+        field_meta.get_id().get());
+
+    const auto data_size = field_data.scalars().geometry_data().data_size();
+    AssertInfo(data_size == num_rows,
+               "geometry field {} payload size {} must match num_rows {}",
+               field_meta.get_id().get(),
+               data_size,
+               num_rows);
+
+    if (field_meta.is_nullable()) {
+        // New payloads carry validity in ScalarField.valid_data, legacy ones
+        // in FieldData.valid_data; resolve it the same way the ingest path
+        // reads it (GetFieldDataRowValidData).
+        const auto valid_size = GetFieldDataRowValidData(field_data).size();
+        AssertInfo(valid_size == num_rows,
+                   "nullable geometry field {} valid_data size {} must match "
+                   "num_rows {}",
+                   field_meta.get_id().get(),
+                   valid_size,
+                   num_rows);
     }
 }
 
@@ -725,6 +756,30 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
         field_id_to_offset.emplace(field_id, field_offset++);
     }
 
+    // Validate geometry row alignment before mutating any segment-owned
+    // storage. Geometry scalars are dense at this boundary (nullable rows keep
+    // an empty physical payload slot), and valid_data is one entry per logical
+    // row. Treating a truncated internal message as NULL later in the index or
+    // cache path would be too late: the raw column and validity vectors copy
+    // num_rows entries first.
+    for (const auto& [field_id, field_meta] : schema_->get_fields()) {
+        if (field_id.get() < START_USER_FIELDID ||
+            field_meta.get_data_type() != DataType::GEOMETRY) {
+            continue;
+        }
+        auto data_it = field_id_to_offset.find(field_id);
+        if (data_it == field_id_to_offset.end()) {
+            AssertInfo(schema_->is_function_output(field_id),
+                       "geometry field {} missing from insert",
+                       field_id.get());
+            continue;
+        }
+        ValidateGeometryInsertDataShape(
+            insert_record_proto->fields_data(data_it->second),
+            field_meta,
+            num_rows);
+    }
+
     // step 2: sort timestamp
     // query node already guarantees that the timestamp is ordered, avoid field data copy in c++
 
@@ -867,6 +922,7 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
             BuildGeometryCacheForInsert(
                 field_id,
                 &insert_record_proto->fields_data(data_offset),
+                reserved_offset,
                 num_rows);
         }
 
@@ -981,6 +1037,24 @@ SegmentGrowingImpl::load_field_data_internal(const LoadFieldDataInfo& infos) {
         auto field_data = storage::CollectFieldDataChannel(channel);
         load_field_data_common(
             field_id, reserved_offset, field_data, primary_field_id, num_rows);
+        // Build geometry cache for GEOMETRY fields, matching both storage-v2
+        // load paths. Without this the rows loaded here are acked below
+        // (readable) but have no cache entry, so once a later insert populates
+        // the cache at its own absolute offsets, every query against these
+        // historical rows reads an unfilled slot and silently reports no
+        // match.
+        //
+        // has_field() gates the schema lookup: this loop intentionally lets
+        // the system fields (RowID, Timestamp) through its dropped-field
+        // guard above, and they are absent from schema_->fields_, so an
+        // unguarded operator[] asserts on every load. load_field_data_common
+        // applies the same guard for the same reason.
+        if (schema_->has_field(field_id) &&
+            schema_->operator[](field_id).get_data_type() ==
+                DataType::GEOMETRY &&
+            segcore_config_.get_enable_geometry_cache()) {
+            BuildGeometryCacheForLoad(field_id, field_data, reserved_offset);
+        }
     }
 
     // step 5: update small indexes
@@ -1267,7 +1341,8 @@ SegmentGrowingImpl::load_column_group_data_internal(
             if (schema->operator[](field_id).get_data_type() ==
                     DataType::GEOMETRY &&
                 segcore_config_.get_enable_geometry_cache()) {
-                BuildGeometryCacheForLoad(field_id, field_data);
+                BuildGeometryCacheForLoad(
+                    field_id, field_data, reserved_offset);
             }
         }
     }
@@ -2960,7 +3035,8 @@ SegmentGrowingImpl::LoadColumnsGroups(std::string manifest_path) {
             if (schema->operator[](field_id).get_data_type() ==
                     DataType::GEOMETRY &&
                 segcore_config_.get_enable_geometry_cache()) {
-                BuildGeometryCacheForLoad(field_id, field_data);
+                BuildGeometryCacheForLoad(
+                    field_id, field_data, reserved_offset);
             }
         }
     }
@@ -3165,6 +3241,29 @@ SegmentGrowingImpl::fill_empty_field(const FieldMeta& field_meta) {
     }
     column->set_data_raw(filled, missing, data.get(), field_meta);
 
+    // Backfilled GEOMETRY rows must reach the cache too. Once ANY cache entry
+    // exists for a field, the filter path takes the cache branch exclusively
+    // (GISFunctionFilterExpr's cache lookup), and a newly added field has no
+    // growing R-Tree because Reopen does not rebuild indexing_record_. So if
+    // these rows were left out, the first insert would create the cache and
+    // write only at its own absolute offsets, leaving [filled, total_row_num)
+    // as default-invalid gaps -- every backfilled row would then read as
+    // nullptr and be judged non-matching, silently dropping rows that the
+    // default geometry should match (or flipping to false positives under a
+    // negated predicate), while the same query is correct with the cache
+    // disabled.
+    //
+    // The write is addressed at `filled`, not 0, for the same reason the two
+    // column writes above are: `data` holds only the `missing` suffix, so the
+    // rows it carries belong at absolute offsets [filled, total_row_num).
+    // Passing (0, total_row_num) here would both re-address the suffix onto
+    // the already-filled prefix and read total_row_num rows out of a payload
+    // that only has `missing` of them.
+    if (field_meta.get_data_type() == DataType::GEOMETRY &&
+        segcore_config_.get_enable_geometry_cache() && missing > 0) {
+        BuildGeometryCacheForInsert(field_id, data.get(), filled, missing);
+    }
+
     LOG_INFO("fill empty field {} (data type {}) for growing segment {} done",
              field_meta.get_data_type(),
              field_id.get(),
@@ -3228,27 +3327,48 @@ SegmentGrowingImpl::EnsureArrayOffsetsForStructField(
 void
 SegmentGrowingImpl::BuildGeometryCacheForInsert(FieldId field_id,
                                                 const DataArray* data_array,
+                                                int64_t reserved_offset,
                                                 int64_t num_rows) {
+    // Rows are written at their reserved ABSOLUTE offsets
+    // (SimpleGeometryCache::AppendDataAt), matching how readers address the
+    // cache (GetByOffsetUnsafe) and how the R-Tree index path's AddGeometry
+    // works. This makes the write idempotent: a batch retried after a
+    // mid-batch retriable failure (e.g. a transient GEOS allocation throw)
+    // overwrites its own slots instead of re-appending after the partial
+    // prefix and shifting every later row to the wrong offset. It also
+    // removes the old tail-append ORDERING DEPENDENCY on strictly serialized,
+    // in-order Insert() batches.
     try {
         // Get geometry cache for this segment+field
-        auto& geometry_cache =
+        auto geometry_cache =
             milvus::exec::SimpleGeometryCacheManager::Instance()
-                .GetOrCreateCache(get_segment_id(), field_id);
+                .GetOrCreateCache(
+                    segment_instance_uid(), get_segment_id(), field_id);
 
         // Process geometry data from DataArray
         const auto& geometry_data = data_array->scalars().geometry_data();
         const auto& valid_data = GetFieldDataRowValidData(*data_array);
 
+        AssertInfo(geometry_data.data_size() == num_rows,
+                   "geometry payload size {} must match cache append size {}",
+                   geometry_data.data_size(),
+                   num_rows);
+        AssertInfo(valid_data.empty() || valid_data.size() == num_rows,
+                   "geometry valid_data size {} must be empty or match cache "
+                   "append size {}",
+                   valid_data.size(),
+                   num_rows);
+
         for (int64_t i = 0; i < num_rows; ++i) {
-            if (valid_data.empty() ||
-                (i < valid_data.size() && valid_data[i])) {
+            bool is_valid = valid_data.empty() || valid_data[i];
+            if (is_valid) {
                 // Valid geometry data
                 const auto& wkb_data = geometry_data.data(i);
-                geometry_cache.AppendData(
-                    ctx_, wkb_data.data(), wkb_data.size());
+                geometry_cache->AppendDataAt(
+                    reserved_offset + i, wkb_data.data(), wkb_data.size());
             } else {
                 // Null/invalid geometry
-                geometry_cache.AppendData(ctx_, nullptr, 0);
+                geometry_cache->AppendDataAt(reserved_offset + i, nullptr, 0);
             }
         }
 
@@ -3260,6 +3380,21 @@ SegmentGrowingImpl::BuildGeometryCacheForInsert(FieldId field_id,
             get_segment_id(),
             field_id.get());
 
+    } catch (const SegcoreError&) {
+        // Already typed (e.g. a retriable MemAllocateFailed from a transient
+        // GEOS allocation failure) -- rethrow as-is; re-wrapping would collapse
+        // the code into a non-retriable UnexpectedError.
+        throw;
+    } catch (const std::bad_alloc&) {
+        // Container/std allocation OOM (e.g. the cache's geometries_.resize)
+        // is the same transient resource failure as a GEOS allocation failure
+        // and must stay retriable -- the generic handler below would collapse
+        // it into a non-retriable UnexpectedError.
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory building geometry cache for growing segment "
+                  "{} field {} insert",
+                  get_segment_id(),
+                  field_id.get());
     } catch (const std::exception& e) {
         ThrowInfo(UnexpectedError,
                   "Failed to build geometry cache for growing segment {} field "
@@ -3272,27 +3407,33 @@ SegmentGrowingImpl::BuildGeometryCacheForInsert(FieldId field_id,
 
 void
 SegmentGrowingImpl::BuildGeometryCacheForLoad(
-    FieldId field_id, const std::vector<FieldDataPtr>& field_data) {
+    FieldId field_id,
+    const std::vector<FieldDataPtr>& field_data,
+    int64_t reserved_offset) {
     try {
         // Get geometry cache for this segment+field
-        auto& geometry_cache =
+        auto geometry_cache =
             milvus::exec::SimpleGeometryCacheManager::Instance()
-                .GetOrCreateCache(get_segment_id(), field_id);
+                .GetOrCreateCache(
+                    segment_instance_uid(), get_segment_id(), field_id);
 
-        // Process each field data chunk
+        // Process each field data chunk, writing rows at their reserved
+        // absolute offsets so a retried load overwrites in place (see
+        // BuildGeometryCacheForInsert).
+        int64_t absolute_offset = reserved_offset;
         for (const auto& data : field_data) {
             auto num_rows = data->get_num_rows();
 
-            for (int64_t i = 0; i < num_rows; ++i) {
+            for (int64_t i = 0; i < num_rows; ++i, ++absolute_offset) {
                 if (data->is_valid(i)) {
                     // Valid geometry data
                     auto wkb_data =
                         static_cast<const std::string*>(data->RawValue(i));
-                    geometry_cache.AppendData(
-                        ctx_, wkb_data->data(), wkb_data->size());
+                    geometry_cache->AppendDataAt(
+                        absolute_offset, wkb_data->data(), wkb_data->size());
                 } else {
                     // Null/invalid geometry
-                    geometry_cache.AppendData(ctx_, nullptr, 0);
+                    geometry_cache->AppendDataAt(absolute_offset, nullptr, 0);
                 }
             }
         }
@@ -3310,6 +3451,18 @@ SegmentGrowingImpl::BuildGeometryCacheForLoad(
             get_segment_id(),
             field_id.get());
 
+    } catch (const SegcoreError&) {
+        // Already typed -- rethrow as-is to keep the code (see the insert-path
+        // catch above).
+        throw;
+    } catch (const std::bad_alloc&) {
+        // Container/std allocation OOM stays retriable (see the insert-path
+        // catch above).
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory building geometry cache for growing segment "
+                  "{} field {} load",
+                  get_segment_id(),
+                  field_id.get());
     } catch (const std::exception& e) {
         ThrowInfo(UnexpectedError,
                   "Failed to build geometry cache for growing segment {} field "

--- a/internal/core/src/segcore/SegmentGrowingImpl.cpp
+++ b/internal/core/src/segcore/SegmentGrowingImpl.cpp
@@ -21,6 +21,7 @@
 #include <map>
 #include <filesystem>
 #include <memory>
+#include <new>
 #include <mutex>
 #include <numeric>
 #include <optional>
@@ -333,6 +334,32 @@ ExtractArrayLengths(const proto::schema::FieldData& field_data,
                 array_lengths[i] = 0;  // null → empty array
             }
         }
+    }
+}
+
+void
+ValidateGeometryInsertDataShape(const proto::schema::FieldData& field_data,
+                                const FieldMeta& field_meta,
+                                int64_t num_rows) {
+    AssertInfo(
+        field_data.has_scalars() && field_data.scalars().has_geometry_data(),
+        "geometry field {} is missing geometry payload",
+        field_meta.get_id().get());
+
+    const auto data_size = field_data.scalars().geometry_data().data_size();
+    AssertInfo(data_size == num_rows,
+               "geometry field {} payload size {} must match num_rows {}",
+               field_meta.get_id().get(),
+               data_size,
+               num_rows);
+
+    if (field_meta.is_nullable()) {
+        AssertInfo(field_data.valid_data_size() == num_rows,
+                   "nullable geometry field {} valid_data size {} must match "
+                   "num_rows {}",
+                   field_meta.get_id().get(),
+                   field_data.valid_data_size(),
+                   num_rows);
     }
 }
 
@@ -725,6 +752,30 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
         field_id_to_offset.emplace(field_id, field_offset++);
     }
 
+    // Validate geometry row alignment before mutating any segment-owned
+    // storage. Geometry scalars are dense at this boundary (nullable rows keep
+    // an empty physical payload slot), and valid_data is one entry per logical
+    // row. Treating a truncated internal message as NULL later in the index or
+    // cache path would be too late: the raw column and validity vectors copy
+    // num_rows entries first.
+    for (const auto& [field_id, field_meta] : schema_->get_fields()) {
+        if (field_id.get() < START_USER_FIELDID ||
+            field_meta.get_data_type() != DataType::GEOMETRY) {
+            continue;
+        }
+        auto data_it = field_id_to_offset.find(field_id);
+        if (data_it == field_id_to_offset.end()) {
+            AssertInfo(schema_->is_function_output(field_id),
+                       "geometry field {} missing from insert",
+                       field_id.get());
+            continue;
+        }
+        ValidateGeometryInsertDataShape(
+            insert_record_proto->fields_data(data_it->second),
+            field_meta,
+            num_rows);
+    }
+
     // step 2: sort timestamp
     // query node already guarantees that the timestamp is ordered, avoid field data copy in c++
 
@@ -870,6 +921,7 @@ SegmentGrowingImpl::Insert(int64_t reserved_offset,
             BuildGeometryCacheForInsert(
                 field_id,
                 &insert_record_proto->fields_data(data_offset),
+                reserved_offset,
                 num_rows);
         }
 
@@ -984,6 +1036,24 @@ SegmentGrowingImpl::load_field_data_internal(const LoadFieldDataInfo& infos) {
         auto field_data = storage::CollectFieldDataChannel(channel);
         load_field_data_common(
             field_id, reserved_offset, field_data, primary_field_id, num_rows);
+        // Build geometry cache for GEOMETRY fields, matching both storage-v2
+        // load paths. Without this the rows loaded here are acked below
+        // (readable) but have no cache entry, so once a later insert populates
+        // the cache at its own absolute offsets, every query against these
+        // historical rows reads an unfilled slot and silently reports no
+        // match.
+        //
+        // has_field() gates the schema lookup: this loop intentionally lets
+        // the system fields (RowID, Timestamp) through its dropped-field
+        // guard above, and they are absent from schema_->fields_, so an
+        // unguarded operator[] asserts on every load. load_field_data_common
+        // applies the same guard for the same reason.
+        if (schema_->has_field(field_id) &&
+            schema_->operator[](field_id).get_data_type() ==
+                DataType::GEOMETRY &&
+            segcore_config_.get_enable_geometry_cache()) {
+            BuildGeometryCacheForLoad(field_id, field_data, reserved_offset);
+        }
     }
 
     // step 5: update small indexes
@@ -1270,7 +1340,8 @@ SegmentGrowingImpl::load_column_group_data_internal(
             if (schema->operator[](field_id).get_data_type() ==
                     DataType::GEOMETRY &&
                 segcore_config_.get_enable_geometry_cache()) {
-                BuildGeometryCacheForLoad(field_id, field_data);
+                BuildGeometryCacheForLoad(
+                    field_id, field_data, reserved_offset);
             }
         }
     }
@@ -2952,7 +3023,8 @@ SegmentGrowingImpl::LoadColumnsGroups(std::string manifest_path) {
             if (schema->operator[](field_id).get_data_type() ==
                     DataType::GEOMETRY &&
                 segcore_config_.get_enable_geometry_cache()) {
-                BuildGeometryCacheForLoad(field_id, field_data);
+                BuildGeometryCacheForLoad(
+                    field_id, field_data, reserved_offset);
             }
         }
     }
@@ -3157,6 +3229,29 @@ SegmentGrowingImpl::fill_empty_field(const FieldMeta& field_meta) {
     }
     column->set_data_raw(filled, missing, data.get(), field_meta);
 
+    // Backfilled GEOMETRY rows must reach the cache too. Once ANY cache entry
+    // exists for a field, the filter path takes the cache branch exclusively
+    // (GISFunctionFilterExpr's cache lookup), and a newly added field has no
+    // growing R-Tree because Reopen does not rebuild indexing_record_. So if
+    // these rows were left out, the first insert would create the cache and
+    // write only at its own absolute offsets, leaving [filled, total_row_num)
+    // as default-invalid gaps -- every backfilled row would then read as
+    // nullptr and be judged non-matching, silently dropping rows that the
+    // default geometry should match (or flipping to false positives under a
+    // negated predicate), while the same query is correct with the cache
+    // disabled.
+    //
+    // The write is addressed at `filled`, not 0, for the same reason the two
+    // column writes above are: `data` holds only the `missing` suffix, so the
+    // rows it carries belong at absolute offsets [filled, total_row_num).
+    // Passing (0, total_row_num) here would both re-address the suffix onto
+    // the already-filled prefix and read total_row_num rows out of a payload
+    // that only has `missing` of them.
+    if (field_meta.get_data_type() == DataType::GEOMETRY &&
+        segcore_config_.get_enable_geometry_cache() && missing > 0) {
+        BuildGeometryCacheForInsert(field_id, data.get(), filled, missing);
+    }
+
     LOG_INFO("fill empty field {} (data type {}) for growing segment {} done",
              field_meta.get_data_type(),
              field_id.get(),
@@ -3220,27 +3315,48 @@ SegmentGrowingImpl::EnsureArrayOffsetsForStructField(
 void
 SegmentGrowingImpl::BuildGeometryCacheForInsert(FieldId field_id,
                                                 const DataArray* data_array,
+                                                int64_t reserved_offset,
                                                 int64_t num_rows) {
+    // Rows are written at their reserved ABSOLUTE offsets
+    // (SimpleGeometryCache::AppendDataAt), matching how readers address the
+    // cache (GetByOffsetUnsafe) and how the R-Tree index path's AddGeometry
+    // works. This makes the write idempotent: a batch retried after a
+    // mid-batch retriable failure (e.g. a transient GEOS allocation throw)
+    // overwrites its own slots instead of re-appending after the partial
+    // prefix and shifting every later row to the wrong offset. It also
+    // removes the old tail-append ORDERING DEPENDENCY on strictly serialized,
+    // in-order Insert() batches.
     try {
         // Get geometry cache for this segment+field
-        auto& geometry_cache =
+        auto geometry_cache =
             milvus::exec::SimpleGeometryCacheManager::Instance()
-                .GetOrCreateCache(get_segment_id(), field_id);
+                .GetOrCreateCache(
+                    segment_instance_uid(), get_segment_id(), field_id);
 
         // Process geometry data from DataArray
         const auto& geometry_data = data_array->scalars().geometry_data();
         const auto& valid_data = data_array->valid_data();
 
+        AssertInfo(geometry_data.data_size() == num_rows,
+                   "geometry payload size {} must match cache append size {}",
+                   geometry_data.data_size(),
+                   num_rows);
+        AssertInfo(valid_data.empty() || valid_data.size() == num_rows,
+                   "geometry valid_data size {} must be empty or match cache "
+                   "append size {}",
+                   valid_data.size(),
+                   num_rows);
+
         for (int64_t i = 0; i < num_rows; ++i) {
-            if (valid_data.empty() ||
-                (i < valid_data.size() && valid_data[i])) {
+            bool is_valid = valid_data.empty() || valid_data[i];
+            if (is_valid) {
                 // Valid geometry data
                 const auto& wkb_data = geometry_data.data(i);
-                geometry_cache.AppendData(
-                    ctx_, wkb_data.data(), wkb_data.size());
+                geometry_cache->AppendDataAt(
+                    reserved_offset + i, wkb_data.data(), wkb_data.size());
             } else {
                 // Null/invalid geometry
-                geometry_cache.AppendData(ctx_, nullptr, 0);
+                geometry_cache->AppendDataAt(reserved_offset + i, nullptr, 0);
             }
         }
 
@@ -3252,6 +3368,21 @@ SegmentGrowingImpl::BuildGeometryCacheForInsert(FieldId field_id,
             get_segment_id(),
             field_id.get());
 
+    } catch (const SegcoreError&) {
+        // Already typed (e.g. a retriable MemAllocateFailed from a transient
+        // GEOS allocation failure) -- rethrow as-is; re-wrapping would collapse
+        // the code into a non-retriable UnexpectedError.
+        throw;
+    } catch (const std::bad_alloc&) {
+        // Container/std allocation OOM (e.g. the cache's geometries_.resize)
+        // is the same transient resource failure as a GEOS allocation failure
+        // and must stay retriable -- the generic handler below would collapse
+        // it into a non-retriable UnexpectedError.
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory building geometry cache for growing segment "
+                  "{} field {} insert",
+                  get_segment_id(),
+                  field_id.get());
     } catch (const std::exception& e) {
         ThrowInfo(UnexpectedError,
                   "Failed to build geometry cache for growing segment {} field "
@@ -3264,27 +3395,33 @@ SegmentGrowingImpl::BuildGeometryCacheForInsert(FieldId field_id,
 
 void
 SegmentGrowingImpl::BuildGeometryCacheForLoad(
-    FieldId field_id, const std::vector<FieldDataPtr>& field_data) {
+    FieldId field_id,
+    const std::vector<FieldDataPtr>& field_data,
+    int64_t reserved_offset) {
     try {
         // Get geometry cache for this segment+field
-        auto& geometry_cache =
+        auto geometry_cache =
             milvus::exec::SimpleGeometryCacheManager::Instance()
-                .GetOrCreateCache(get_segment_id(), field_id);
+                .GetOrCreateCache(
+                    segment_instance_uid(), get_segment_id(), field_id);
 
-        // Process each field data chunk
+        // Process each field data chunk, writing rows at their reserved
+        // absolute offsets so a retried load overwrites in place (see
+        // BuildGeometryCacheForInsert).
+        int64_t absolute_offset = reserved_offset;
         for (const auto& data : field_data) {
             auto num_rows = data->get_num_rows();
 
-            for (int64_t i = 0; i < num_rows; ++i) {
+            for (int64_t i = 0; i < num_rows; ++i, ++absolute_offset) {
                 if (data->is_valid(i)) {
                     // Valid geometry data
                     auto wkb_data =
                         static_cast<const std::string*>(data->RawValue(i));
-                    geometry_cache.AppendData(
-                        ctx_, wkb_data->data(), wkb_data->size());
+                    geometry_cache->AppendDataAt(
+                        absolute_offset, wkb_data->data(), wkb_data->size());
                 } else {
                     // Null/invalid geometry
-                    geometry_cache.AppendData(ctx_, nullptr, 0);
+                    geometry_cache->AppendDataAt(absolute_offset, nullptr, 0);
                 }
             }
         }
@@ -3302,6 +3439,18 @@ SegmentGrowingImpl::BuildGeometryCacheForLoad(
             get_segment_id(),
             field_id.get());
 
+    } catch (const SegcoreError&) {
+        // Already typed -- rethrow as-is to keep the code (see the insert-path
+        // catch above).
+        throw;
+    } catch (const std::bad_alloc&) {
+        // Container/std allocation OOM stays retriable (see the insert-path
+        // catch above).
+        ThrowInfo(ErrorCode::MemAllocateFailed,
+                  "out of memory building geometry cache for growing segment "
+                  "{} field {} load",
+                  get_segment_id(),
+                  field_id.get());
     } catch (const std::exception& e) {
         ThrowInfo(UnexpectedError,
                   "Failed to build geometry cache for growing segment {} field "

--- a/internal/core/src/segcore/SegmentGrowingImpl.h
+++ b/internal/core/src/segcore/SegmentGrowingImpl.h
@@ -181,16 +181,21 @@ class SegmentGrowingImpl : public SegmentGrowing {
     FillAbsentFields();
 
  private:
-    // Build geometry cache for inserted data
+    // Build geometry cache for inserted data. reserved_offset is the batch's
+    // reserved absolute segment offset: cache rows are written at absolute
+    // offsets so a retried batch overwrites its own slots instead of
+    // re-appending (see SimpleGeometryCache::AppendDataAt).
     void
     BuildGeometryCacheForInsert(FieldId field_id,
                                 const DataArray* data_array,
+                                int64_t reserved_offset,
                                 int64_t num_rows);
 
-    // Build geometry cache for loaded field data
+    // Build geometry cache for loaded field data; reserved_offset as above.
     void
     BuildGeometryCacheForLoad(FieldId field_id,
-                              const std::vector<FieldDataPtr>& field_data);
+                              const std::vector<FieldDataPtr>& field_data,
+                              int64_t reserved_offset);
 
  public:
     const InsertRecord<false>&
@@ -475,12 +480,8 @@ class SegmentGrowingImpl : public SegmentGrowing {
         // Clean up geometry cache for all fields in this segment
         auto& cache_manager =
             milvus::exec::SimpleGeometryCacheManager::Instance();
-        cache_manager.RemoveSegmentCaches(ctx_, get_segment_id());
-
-        if (ctx_) {
-            GEOS_finish_r(ctx_);
-            ctx_ = nullptr;
-        }
+        cache_manager.RemoveSegmentCaches(segment_instance_uid(),
+                                          get_segment_id());
 
         // Original mmap cleanup logic
         if (mmap_descriptor_ != nullptr) {

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -35,6 +35,7 @@
 #include "cachinglayer/Utils.h"
 #include "common/Consts.h"
 #include "common/EasyAssert.h"
+#include "common/Geometry.h"
 #include "common/IndexMeta.h"
 #include "common/QueryResult.h"
 #include "common/Schema.h"
@@ -310,6 +311,67 @@ TEST(Growing, InsertSkipsMissingFunctionOutputField) {
                                     dataset.timestamps_.data(),
                                     dataset.raw_));
     EXPECT_FALSE(segment->FieldAccessible(sparse));
+}
+
+TEST(Growing, InsertRejectsTruncatedGeometryBeforeWritingSegmentData) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto geometry = schema->AddDebugField("geometry", DataType::GEOMETRY, true);
+    schema->set_primary_field_id(pk);
+
+    constexpr int64_t row_count = 2;
+    std::array<int64_t, row_count> row_ids = {10, 11};
+    std::array<Timestamp, row_count> timestamps = {100, 101};
+    std::array<int64_t, row_count> pks = {1, 2};
+    std::array<bool, row_count> valid = {true, true};
+
+    auto geos_ctx = GEOS_init_r();
+    std::array<std::string, row_count> geometries = {
+        Geometry(geos_ctx, "POINT (1 1)").to_wkb_string(),
+        Geometry(geos_ctx, "POINT (2 2)").to_wkb_string()};
+    GEOS_finish_r(geos_ctx);
+
+    auto make_record = [&]() {
+        auto record = std::make_unique<InsertRecordProto>();
+        record->set_num_rows(row_count);
+        record->mutable_fields_data()->AddAllocated(
+            CreateDataArrayFrom(pks.data(), nullptr, row_count, (*schema)[pk])
+                .release());
+        record->mutable_fields_data()->AddAllocated(
+            CreateDataArrayFrom(
+                geometries.data(), valid.data(), row_count, (*schema)[geometry])
+                .release());
+        return record;
+    };
+
+    auto expect_rejected_without_ack = [&](auto mutate) {
+        auto segment = CreateGrowingSegment(schema, empty_index_meta);
+        auto record = make_record();
+        mutate(record->mutable_fields_data(1));
+        auto offset = segment->PreInsert(row_count);
+
+        try {
+            segment->Insert(offset,
+                            row_count,
+                            row_ids.data(),
+                            timestamps.data(),
+                            record.get());
+            FAIL() << "expected malformed geometry insert to be rejected";
+        } catch (const SegcoreError& error) {
+            EXPECT_EQ(error.get_error_code(), ErrorCode::UnexpectedError);
+        }
+        EXPECT_EQ(segment->get_row_count(), 0);
+    };
+
+    expect_rejected_without_ack([](DataArray* field_data) {
+        MutableFieldDataRowValidData(field_data)->RemoveLast();
+    });
+    expect_rejected_without_ack([](DataArray* field_data) {
+        field_data->mutable_scalars()
+            ->mutable_geometry_data()
+            ->mutable_data()
+            ->RemoveLast();
+    });
 }
 
 TEST(Growing, MissingStructArrayOffsetsReturnsEmptyForOldRows) {
@@ -2325,4 +2387,112 @@ TEST(Growing, MultipleFieldsResourceEstimation) {
                            N * sizeof(float) + N * sizeof(double) +
                            N * sizeof(Timestamp);
     EXPECT_GE(resource.memory_bytes, min_expected);
+}
+
+// Regression for PR #50951 review (round Dd91dab7a02): fill_empty_field()
+// backfills a newly added field's validity bits and can then throw (the
+// geometry cache build raises a retriable MemAllocateFailed on OOM). A throw
+// leaves the schema unpublished, so the next query re-enters
+// LazyCheckSchema -> Reopen -> fill_empty_field for the same field. With the
+// appending set_data_raw() that retry added a SECOND block of N bits: the
+// validity vector reached 2N while the record still held N rows, so every
+// later inserted row stored its geometry at N+i but its validity bit at
+// 2N+i and read back the all-false backfill -- rows silently dropped by ST_*
+// predicates, returned as null, and matched by IS NULL, permanently.
+//
+// The offset-addressed set_data_raw() overload writes the backfill at [0, N),
+// so re-running it is a no-op. This pins that directly rather than through a
+// fault-injected Reopen, which segcore has no hook for.
+TEST(Growing, BackfillValidDataIsIdempotentAcrossRetries) {
+    constexpr int64_t kRows = 100;
+    constexpr int64_t kSizePerChunk = 32;
+
+    auto schema = std::make_shared<Schema>();
+    auto field_id =
+        schema->AddDebugField("nullable_geo", DataType::GEOMETRY, true);
+
+    // The backfill payload fill_empty_field() would produce: kRows entries,
+    // every row marked valid (the shape a non-null default value yields).
+    auto data = std::make_unique<milvus::DataArray>();
+    data->set_field_id(field_id.get());
+    data->set_type(
+        static_cast<milvus::proto::schema::DataType>(DataType::GEOMETRY));
+    auto* geo = data->mutable_scalars()->mutable_geometry_data();
+    for (int64_t i = 0; i < kRows; ++i) {
+        *(geo->mutable_data()->Add()) = std::string();
+        MutableFieldDataRowValidData(data.get())->Add(true);
+    }
+
+    milvus::segcore::ThreadSafeValidData valid_data(kSizePerChunk);
+    const auto& field_meta = schema->operator[](field_id);
+
+    valid_data.set_data_raw(0, kRows, data.get(), field_meta);
+    ASSERT_EQ(valid_data.get_data().size(), static_cast<size_t>(kRows));
+
+    // The retry after a failed reopen re-runs the same backfill. Length must
+    // not grow, or every subsequent row's validity bit lands past its data.
+    valid_data.set_data_raw(0, kRows, data.get(), field_meta);
+    EXPECT_EQ(valid_data.get_data().size(), static_cast<size_t>(kRows));
+    for (int64_t i = 0; i < kRows; ++i) {
+        EXPECT_TRUE(valid_data.is_valid(i)) << "row " << i;
+    }
+
+    // Rows inserted after the backfill still line up: their validity bits
+    // continue from kRows, not from 2 * kRows.
+    auto tail = std::make_unique<milvus::DataArray>();
+    tail->set_field_id(field_id.get());
+    tail->set_type(
+        static_cast<milvus::proto::schema::DataType>(DataType::GEOMETRY));
+    auto* tail_geo = tail->mutable_scalars()->mutable_geometry_data();
+    *(tail_geo->mutable_data()->Add()) = std::string();
+    MutableFieldDataRowValidData(tail.get())->Add(false);
+
+    valid_data.set_data_raw(1, tail.get(), field_meta);
+    ASSERT_EQ(valid_data.get_data().size(), static_cast<size_t>(kRows + 1));
+    EXPECT_FALSE(valid_data.is_valid(kRows));
+}
+
+// Regression for PR #50951 review (round Dc417b11277): the valid_data shape
+// guard used to sit only on the appending set_data_raw() overload, which no
+// production path calls. Every nullable field on the ingest path goes through
+// the offset-addressed overload (SegmentGrowingImpl::Insert), so a producer
+// payload with fewer validity entries than rows made write_from() read past
+// the end of the protobuf RepeatedField and publish adjacent heap bytes as
+// validity bits. GEOMETRY is separately covered by
+// ValidateGeometryInsertDataShape; this pins the guard for every other
+// nullable type.
+TEST(Growing, InsertRejectsShortValidDataForNullableVarchar) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto text = schema->AddDebugField("text", DataType::VARCHAR, true);
+    schema->set_primary_field_id(pk);
+
+    constexpr int64_t row_count = 2;
+    std::array<int64_t, row_count> row_ids = {10, 11};
+    std::array<Timestamp, row_count> timestamps = {100, 101};
+    std::array<int64_t, row_count> pks = {1, 2};
+    std::array<bool, row_count> valid = {true, true};
+    std::array<std::string, row_count> texts = {"a", "b"};
+
+    auto record = std::make_unique<InsertRecordProto>();
+    record->set_num_rows(row_count);
+    record->mutable_fields_data()->AddAllocated(
+        CreateDataArrayFrom(pks.data(), nullptr, row_count, (*schema)[pk])
+            .release());
+    record->mutable_fields_data()->AddAllocated(
+        CreateDataArrayFrom(
+            texts.data(), valid.data(), row_count, (*schema)[text])
+            .release());
+    // One validity entry short of the row count.
+    MutableFieldDataRowValidData(record->mutable_fields_data(1))->RemoveLast();
+
+    auto segment = CreateGrowingSegment(schema, empty_index_meta);
+    auto offset = segment->PreInsert(row_count);
+    try {
+        segment->Insert(
+            offset, row_count, row_ids.data(), timestamps.data(), record.get());
+        FAIL() << "expected short valid_data to be rejected";
+    } catch (const SegcoreError& error) {
+        EXPECT_EQ(error.get_error_code(), ErrorCode::UnexpectedError);
+    }
 }

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -35,6 +35,7 @@
 #include "cachinglayer/Utils.h"
 #include "common/Consts.h"
 #include "common/EasyAssert.h"
+#include "common/Geometry.h"
 #include "common/IndexMeta.h"
 #include "common/QueryResult.h"
 #include "common/Schema.h"
@@ -310,6 +311,67 @@ TEST(Growing, InsertSkipsMissingFunctionOutputField) {
                                     dataset.timestamps_.data(),
                                     dataset.raw_));
     EXPECT_FALSE(segment->FieldAccessible(sparse));
+}
+
+TEST(Growing, InsertRejectsTruncatedGeometryBeforeWritingSegmentData) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    auto geometry = schema->AddDebugField("geometry", DataType::GEOMETRY, true);
+    schema->set_primary_field_id(pk);
+
+    constexpr int64_t row_count = 2;
+    std::array<int64_t, row_count> row_ids = {10, 11};
+    std::array<Timestamp, row_count> timestamps = {100, 101};
+    std::array<int64_t, row_count> pks = {1, 2};
+    std::array<bool, row_count> valid = {true, true};
+
+    auto geos_ctx = GEOS_init_r();
+    std::array<std::string, row_count> geometries = {
+        Geometry(geos_ctx, "POINT (1 1)").to_wkb_string(),
+        Geometry(geos_ctx, "POINT (2 2)").to_wkb_string()};
+    GEOS_finish_r(geos_ctx);
+
+    auto make_record = [&]() {
+        auto record = std::make_unique<InsertRecordProto>();
+        record->set_num_rows(row_count);
+        record->mutable_fields_data()->AddAllocated(
+            CreateDataArrayFrom(pks.data(), nullptr, row_count, (*schema)[pk])
+                .release());
+        record->mutable_fields_data()->AddAllocated(
+            CreateDataArrayFrom(
+                geometries.data(), valid.data(), row_count, (*schema)[geometry])
+                .release());
+        return record;
+    };
+
+    auto expect_rejected_without_ack = [&](auto mutate) {
+        auto segment = CreateGrowingSegment(schema, empty_index_meta);
+        auto record = make_record();
+        mutate(record->mutable_fields_data(1));
+        auto offset = segment->PreInsert(row_count);
+
+        try {
+            segment->Insert(offset,
+                            row_count,
+                            row_ids.data(),
+                            timestamps.data(),
+                            record.get());
+            FAIL() << "expected malformed geometry insert to be rejected";
+        } catch (const SegcoreError& error) {
+            EXPECT_EQ(error.get_error_code(), ErrorCode::UnexpectedError);
+        }
+        EXPECT_EQ(segment->get_row_count(), 0);
+    };
+
+    expect_rejected_without_ack([](DataArray* field_data) {
+        field_data->mutable_valid_data()->RemoveLast();
+    });
+    expect_rejected_without_ack([](DataArray* field_data) {
+        field_data->mutable_scalars()
+            ->mutable_geometry_data()
+            ->mutable_data()
+            ->RemoveLast();
+    });
 }
 
 TEST(Growing, MissingStructArrayOffsetsReturnsEmptyForOldRows) {
@@ -2313,4 +2375,67 @@ TEST(Growing, MultipleFieldsResourceEstimation) {
                            N * sizeof(float) + N * sizeof(double) +
                            N * sizeof(Timestamp);
     EXPECT_GE(resource.memory_bytes, min_expected);
+}
+
+// Regression for PR #50951 review (round Dd91dab7a02): fill_empty_field()
+// backfills a newly added field's validity bits and can then throw (the
+// geometry cache build raises a retriable MemAllocateFailed on OOM). A throw
+// leaves the schema unpublished, so the next query re-enters
+// LazyCheckSchema -> Reopen -> fill_empty_field for the same field. With the
+// appending set_data_raw() that retry added a SECOND block of N bits: the
+// validity vector reached 2N while the record still held N rows, so every
+// later inserted row stored its geometry at N+i but its validity bit at
+// 2N+i and read back the all-false backfill -- rows silently dropped by ST_*
+// predicates, returned as null, and matched by IS NULL, permanently.
+//
+// backfill_data_raw() writes at absolute offsets, so re-running it is a
+// no-op. This pins that directly rather than through a fault-injected
+// Reopen, which segcore has no hook for.
+TEST(Growing, BackfillValidDataIsIdempotentAcrossRetries) {
+    constexpr int64_t kRows = 100;
+    constexpr int64_t kSizePerChunk = 32;
+
+    auto schema = std::make_shared<Schema>();
+    auto field_id =
+        schema->AddDebugField("nullable_geo", DataType::GEOMETRY, true);
+
+    // The backfill payload fill_empty_field() would produce: kRows entries,
+    // every row marked valid (the shape a non-null default value yields).
+    auto data = std::make_unique<milvus::DataArray>();
+    data->set_field_id(field_id.get());
+    data->set_type(
+        static_cast<milvus::proto::schema::DataType>(DataType::GEOMETRY));
+    auto* geo = data->mutable_scalars()->mutable_geometry_data();
+    for (int64_t i = 0; i < kRows; ++i) {
+        *(geo->mutable_data()->Add()) = std::string();
+        data->mutable_valid_data()->Add(true);
+    }
+
+    milvus::segcore::ThreadSafeValidData valid_data(kSizePerChunk);
+    const auto& field_meta = schema->operator[](field_id);
+
+    valid_data.backfill_data_raw(kRows, data.get(), field_meta);
+    ASSERT_EQ(valid_data.get_data().size(), static_cast<size_t>(kRows));
+
+    // The retry after a failed reopen re-runs the same backfill. Length must
+    // not grow, or every subsequent row's validity bit lands past its data.
+    valid_data.backfill_data_raw(kRows, data.get(), field_meta);
+    EXPECT_EQ(valid_data.get_data().size(), static_cast<size_t>(kRows));
+    for (int64_t i = 0; i < kRows; ++i) {
+        EXPECT_TRUE(valid_data.is_valid(i)) << "row " << i;
+    }
+
+    // Rows inserted after the backfill still line up: their validity bits
+    // continue from kRows, not from 2 * kRows.
+    auto tail = std::make_unique<milvus::DataArray>();
+    tail->set_field_id(field_id.get());
+    tail->set_type(
+        static_cast<milvus::proto::schema::DataType>(DataType::GEOMETRY));
+    auto* tail_geo = tail->mutable_scalars()->mutable_geometry_data();
+    *(tail_geo->mutable_data()->Add()) = std::string();
+    tail->mutable_valid_data()->Add(false);
+
+    valid_data.set_data_raw(1, tail.get(), field_meta);
+    ASSERT_EQ(valid_data.get_data().size(), static_cast<size_t>(kRows + 1));
+    EXPECT_FALSE(valid_data.is_valid(kRows));
 }

--- a/internal/core/src/segcore/SegmentGrowingTest.cpp
+++ b/internal/core/src/segcore/SegmentGrowingTest.cpp
@@ -2388,9 +2388,9 @@ TEST(Growing, MultipleFieldsResourceEstimation) {
 // 2N+i and read back the all-false backfill -- rows silently dropped by ST_*
 // predicates, returned as null, and matched by IS NULL, permanently.
 //
-// backfill_data_raw() writes at absolute offsets, so re-running it is a
-// no-op. This pins that directly rather than through a fault-injected
-// Reopen, which segcore has no hook for.
+// The offset-addressed set_data_raw() overload writes the backfill at [0, N),
+// so re-running it is a no-op. This pins that directly rather than through a
+// fault-injected Reopen, which segcore has no hook for.
 TEST(Growing, BackfillValidDataIsIdempotentAcrossRetries) {
     constexpr int64_t kRows = 100;
     constexpr int64_t kSizePerChunk = 32;
@@ -2414,12 +2414,12 @@ TEST(Growing, BackfillValidDataIsIdempotentAcrossRetries) {
     milvus::segcore::ThreadSafeValidData valid_data(kSizePerChunk);
     const auto& field_meta = schema->operator[](field_id);
 
-    valid_data.backfill_data_raw(kRows, data.get(), field_meta);
+    valid_data.set_data_raw(0, kRows, data.get(), field_meta);
     ASSERT_EQ(valid_data.get_data().size(), static_cast<size_t>(kRows));
 
     // The retry after a failed reopen re-runs the same backfill. Length must
     // not grow, or every subsequent row's validity bit lands past its data.
-    valid_data.backfill_data_raw(kRows, data.get(), field_meta);
+    valid_data.set_data_raw(0, kRows, data.get(), field_meta);
     EXPECT_EQ(valid_data.get_data().size(), static_cast<size_t>(kRows));
     for (int64_t i = 0; i < kRows; ++i) {
         EXPECT_TRUE(valid_data.is_valid(i)) << "row " << i;

--- a/internal/core/src/segcore/SegmentInterface.cpp
+++ b/internal/core/src/segcore/SegmentInterface.cpp
@@ -28,6 +28,7 @@
 #include "common/Consts.h"
 #include "common/EasyAssert.h"
 #include "common/FieldMeta.h"
+#include "common/GeometryCache.h"
 #include "common/OpContext.h"
 #include "common/QueryResult.h"
 #include "common/SystemProperty.h"
@@ -48,6 +49,12 @@
 #include "segcore/ConcurrentVector.h"
 
 namespace milvus::segcore {
+
+std::shared_ptr<milvus::exec::SimpleGeometryCache>
+SegmentInternalInterface::GetGeometryCache(FieldId field_id) const {
+    return milvus::exec::SimpleGeometryCacheManager::Instance().GetCache(
+        segment_instance_uid(), get_segment_id(), field_id);
+}
 
 void
 SegmentInternalInterface::FillPrimaryKeys(const query::Plan* plan,

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -39,6 +39,7 @@
 #include "common/BitsetView.h"
 #include "common/EasyAssert.h"
 #include "common/FieldMeta.h"
+#include "common/Geometry.h"
 #include "common/Json.h"
 #include "common/LoadInfo.h"
 #include "common/OpContext.h"
@@ -68,6 +69,10 @@
 #include "segcore/ConcurrentVector.h"
 #include "segcore/InsertRecord.h"
 
+namespace milvus::exec {
+class SimpleGeometryCache;
+}
+
 namespace milvus::segcore {
 
 using namespace milvus::cachinglayer;
@@ -77,6 +82,14 @@ struct SegmentStats {
     // including the insert data and delete data.
     std::atomic<size_t> mem_size{};
 };
+
+// Monotonic source for SegmentInternalInterface::segment_instance_uid().
+// Starts at 1 so 0 can never collide with a live instance.
+inline uint64_t
+NextSegmentInstanceUid() {
+    static std::atomic<uint64_t> counter{0};
+    return counter.fetch_add(1, std::memory_order_relaxed) + 1;
+}
 
 // common interface of SegmentSealed and SegmentGrowing used by C API
 class SegmentInterface {
@@ -353,6 +366,28 @@ class SegmentInterface {
 // only for implementation
 class SegmentInternalInterface : public SegmentInterface {
  public:
+    // Process-unique id for THIS segment OBJECT, distinct from
+    // get_segment_id() which identifies the logical segment.
+    //
+    // Two live objects can share a logical segment id: a growing and a sealed
+    // twin during handoff, and -- because segmentManager::Put installs the new
+    // instance and releases the replaced one asynchronously
+    // (querynodev2/segments/manager.go:409-441) -- two sealed instances of
+    // different versions. Anything whose lifetime is tied to the object rather
+    // than to the logical segment (the geometry cache) must key on this, or
+    // the departing instance's teardown will take the incoming instance's
+    // state with it.
+    uint64_t
+    segment_instance_uid() const {
+        return segment_instance_uid_;
+    }
+
+    // Growing segments use the process-level cache manager. Sealed segments
+    // override this to return the cache from their immutable published runtime
+    // snapshot, so a column replacement and its cache become visible together.
+    virtual std::shared_ptr<milvus::exec::SimpleGeometryCache>
+    GetGeometryCache(FieldId field_id) const;
+
     virtual void
     prefetch_chunks(milvus::OpContext* op_ctx,
                     FieldId field_id,
@@ -851,11 +886,6 @@ class SegmentInternalInterface : public SegmentInterface {
                     bool upper_inclusive,
                     BitsetTypeView& bitset) const = 0;
 
-    virtual GEOSContextHandle_t
-    get_ctx() const {
-        return ctx_;
-    };
-
  protected:
     // mutex protecting rw options on schema_
     mutable std::shared_mutex sch_mutex_;
@@ -880,7 +910,8 @@ class SegmentInternalInterface : public SegmentInterface {
     std::unordered_map<FieldId, std::shared_ptr<index::JsonKeyStats>>
         json_stats_;
 
-    GEOSContextHandle_t ctx_ = GEOS_init_r();
+    // Assigned once per constructed object; never reused within a process.
+    const uint64_t segment_instance_uid_ = NextSegmentInstanceUid();
 };
 
 }  // namespace milvus::segcore

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -69,6 +69,10 @@
 #include "segcore/ConcurrentVector.h"
 #include "segcore/InsertRecord.h"
 
+namespace milvus::exec {
+class SimpleGeometryCache;
+}
+
 namespace milvus::segcore {
 
 using namespace milvus::cachinglayer;
@@ -377,6 +381,12 @@ class SegmentInternalInterface : public SegmentInterface {
     segment_instance_uid() const {
         return segment_instance_uid_;
     }
+
+    // Growing segments use the process-level cache manager. Sealed segments
+    // override this to return the cache from their immutable published runtime
+    // snapshot, so a column replacement and its cache become visible together.
+    virtual std::shared_ptr<milvus::exec::SimpleGeometryCache>
+    GetGeometryCache(FieldId field_id) const;
 
     virtual void
     prefetch_chunks(milvus::OpContext* op_ctx,

--- a/internal/core/src/segcore/SegmentInterface.h
+++ b/internal/core/src/segcore/SegmentInterface.h
@@ -39,6 +39,7 @@
 #include "common/BitsetView.h"
 #include "common/EasyAssert.h"
 #include "common/FieldMeta.h"
+#include "common/Geometry.h"
 #include "common/Json.h"
 #include "common/LoadInfo.h"
 #include "common/OpContext.h"
@@ -77,6 +78,14 @@ struct SegmentStats {
     // including the insert data and delete data.
     std::atomic<size_t> mem_size{};
 };
+
+// Monotonic source for SegmentInternalInterface::segment_instance_uid().
+// Starts at 1 so 0 can never collide with a live instance.
+inline uint64_t
+NextSegmentInstanceUid() {
+    static std::atomic<uint64_t> counter{0};
+    return counter.fetch_add(1, std::memory_order_relaxed) + 1;
+}
 
 // common interface of SegmentSealed and SegmentGrowing used by C API
 class SegmentInterface {
@@ -353,6 +362,22 @@ class SegmentInterface {
 // only for implementation
 class SegmentInternalInterface : public SegmentInterface {
  public:
+    // Process-unique id for THIS segment OBJECT, distinct from
+    // get_segment_id() which identifies the logical segment.
+    //
+    // Two live objects can share a logical segment id: a growing and a sealed
+    // twin during handoff, and -- because segmentManager::Put installs the new
+    // instance and releases the replaced one asynchronously
+    // (querynodev2/segments/manager.go:409-441) -- two sealed instances of
+    // different versions. Anything whose lifetime is tied to the object rather
+    // than to the logical segment (the geometry cache) must key on this, or
+    // the departing instance's teardown will take the incoming instance's
+    // state with it.
+    uint64_t
+    segment_instance_uid() const {
+        return segment_instance_uid_;
+    }
+
     virtual void
     prefetch_chunks(milvus::OpContext* op_ctx,
                     FieldId field_id,
@@ -854,11 +879,6 @@ class SegmentInternalInterface : public SegmentInterface {
                     bool upper_inclusive,
                     BitsetTypeView& bitset) const = 0;
 
-    virtual GEOSContextHandle_t
-    get_ctx() const {
-        return ctx_;
-    };
-
  protected:
     // mutex protecting rw options on schema_
     mutable std::shared_mutex sch_mutex_;
@@ -883,7 +903,8 @@ class SegmentInternalInterface : public SegmentInterface {
     std::unordered_map<FieldId, std::shared_ptr<index::JsonKeyStats>>
         json_stats_;
 
-    GEOSContextHandle_t ctx_ = GEOS_init_r();
+    // Assigned once per constructed object; never reused within a process.
+    const uint64_t segment_instance_uid_ = NextSegmentInstanceUid();
 };
 
 }  // namespace milvus::segcore

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -2977,8 +2977,14 @@ ConvertWKTStringArrayToWKBBinary(const arrow::ArrayVector& arrays) {
     arrow::ArrayVector result;
     result.reserve(arrays.size());
 
-    GEOSContextHandle_t ctx = GEOS_init_r();
-    AssertInfo(ctx != nullptr, "Failed to initialize GEOS context");
+    // Scoped GEOS context: InitGEOSContext throws a retriable
+    // MemAllocateFailed on OOM (GEOS_init_r never returns nullptr -- see the
+    // helper's comment), and the RAII guard releases the context on every
+    // exit -- the throwing Geometry(ctx, wkt) constructor on malformed WKT
+    // and the arrow-status AssertInfo calls below would otherwise skip a
+    // trailing GEOS_finish_r and leak one context per failure.
+    ScopedGeosResources geos("WKT to WKB conversion");
+    GEOSContextHandle_t ctx = geos.ctx;
 
     for (const auto& arr : arrays) {
         const auto tid = arr->type_id();
@@ -3023,7 +3029,6 @@ ConvertWKTStringArrayToWKBBinary(const arrow::ArrayVector& arrays) {
         result.push_back(wkb_array);
     }
 
-    GEOS_finish_r(ctx);
     return result;
 }
 

--- a/internal/core/src/storage/Util.cpp
+++ b/internal/core/src/storage/Util.cpp
@@ -2760,8 +2760,14 @@ ConvertWKTStringArrayToWKBBinary(const arrow::ArrayVector& arrays) {
     arrow::ArrayVector result;
     result.reserve(arrays.size());
 
-    GEOSContextHandle_t ctx = GEOS_init_r();
-    AssertInfo(ctx != nullptr, "Failed to initialize GEOS context");
+    // Scoped GEOS context: InitGEOSContext throws a retriable
+    // MemAllocateFailed on OOM (GEOS_init_r never returns nullptr -- see the
+    // helper's comment), and the RAII guard releases the context on every
+    // exit -- the throwing Geometry(ctx, wkt) constructor on malformed WKT
+    // and the arrow-status AssertInfo calls below would otherwise skip a
+    // trailing GEOS_finish_r and leak one context per failure.
+    ScopedGeosResources geos("WKT to WKB conversion");
+    GEOSContextHandle_t ctx = geos.ctx;
 
     for (const auto& arr : arrays) {
         const auto tid = arr->type_id();
@@ -2806,7 +2812,6 @@ ConvertWKTStringArrayToWKBBinary(const arrow::ArrayVector& arrays) {
         result.push_back(wkb_array);
     }
 
-    GEOS_finish_r(ctx);
     return result;
 }
 

--- a/internal/core/unittest/test_sealed.cpp
+++ b/internal/core/unittest/test_sealed.cpp
@@ -42,6 +42,7 @@
 #include "common/EasyAssert.h"
 #include "common/FieldData.h"
 #include "common/FieldDataInterface.h"
+#include "common/GeometryCache.h"
 #include "common/IndexMeta.h"
 #include "common/LoadInfo.h"
 #include "common/PrometheusClient.h"
@@ -5767,6 +5768,37 @@ TEST(SealedSegmentCowState, ExternalSynthesizeRequiresRuntime) {
     SegmentLoadInfo staged_load_info(published_proto, schema);
     EXPECT_ANY_THROW(sealed->TestSynthesizeExternalSystemFields(
         staged_load_info, schema, nullptr));
+}
+
+// FreezeRuntimeResourceState copies the runtime state field by field, so every
+// member added to the struct has to be added to that copy by hand. Nothing in
+// the type system catches an omission, and the consequence is silent: every
+// geometry predicate on a segment published through the freeze path would fall
+// back to bulk_subscript + WKB re-parse forever, because the caches are built
+// once at column load and never rebuilt. Pin the copy for the one member whose
+// loss is invisible.
+TEST(SealedSegmentCowState, FreezePreservesGeometryCaches) {
+    auto schema = std::make_shared<Schema>();
+    auto pk = schema->AddDebugField("pk", DataType::INT64);
+    schema->set_primary_field_id(pk);
+
+    auto segment = CreateSealedSegment(schema);
+    auto* sealed = dynamic_cast<ChunkedSegmentSealedImpl*>(segment.get());
+    ASSERT_NE(sealed, nullptr);
+
+    auto runtime = sealed->TestCloneMutableRuntimeResourceState();
+    auto cache = std::make_shared<milvus::exec::SimpleGeometryCache>();
+    const auto geo_field = FieldId(101);
+    runtime->geometry_caches[geo_field] = cache;
+
+    auto frozen =
+        ChunkedSegmentSealedImpl::TestFreezeRuntimeResourceStateCopy(*runtime);
+    ASSERT_NE(frozen, nullptr);
+    auto it = frozen->geometry_caches.find(geo_field);
+    ASSERT_TRUE(it != frozen->geometry_caches.end());
+    // Same cache, not a fresh empty one: the frozen state must keep the
+    // populated instance the caller already filled.
+    EXPECT_EQ(it->second, cache);
 }
 
 TEST(SealedSegmentCowState, ExternalWrapperSynthesizeRequiresRuntime) {


### PR DESCRIPTION
issue: #50885

## What & why

StreamingNode crashed with a native SIGSEGV — heap corruption that surfaced
in folly's thread-local destructor (`SingletonThreadLocal::LocalLifetime::destroy`,
tracking maps filled with `0xff`) — during chaos testing on collections with
GEOMETRY fields + RTREE index, under concurrent growing-segment incremental
indexing, sealed-segment load, search, and segment drop. This PR hardens the
geometry RTree index and geometry cache against the memory-safety defects found
in that subsystem.

> Honest caveat: the crashing environment was torn down and the available
> coredump only held the secondary-victim folly TLS frames, so none of these is
> *proven* to be the single first domino. They are all genuine,
> independently-reproducible defects in the implicated code, fixed defensively.
> Each is covered by a unit test run under AddressSanitizer.

## Behavior change (beyond memory-safety hardening)

Rows whose WKB fails to parse (and rows with no computable envelope) used to be
**dropped from the RTree index**; they are now **indexed with a deterministic
placeholder MBR** (`POINT(0 0)`) and therefore counted by `Count()` /
`IsNotNull()`. Rationale: a corrupt row is not NULL, and dropping it permanently
desynchronizes the index row count from the segment row count, which then trips
the growing coarse-bitmap bounds guard on every subsequent geometry query
against that segment. Correctness is preserved by exact refinement (a
placeholder row is always refined out unless it truly matches); the tradeoff is
that queries whose bbox covers the origin pay refinement cost for placeholder
rows. This is what the `Count()==2` → `Count()==3` assertion change in
`RTreeIndexTest.cpp` reflects.

Related: for `ST_Equals` with an empty query geometry (no envelope), the index
now falls back to the full candidate set (an intentional full scan) instead of
returning zero candidates, so `ST_Equals(field, 'POLYGON EMPTY')` matches empty
field geometries exactly like the un-indexed data path does. Other operators
keep the no-candidate fast path.

## Fixes

- **Geometry value semantics**: `Geometry::operator=` shallow-copied the raw
  `GEOSGeometry*`, so two instances owned one pointer and the second destructor
  double-freed it. Now releases the existing geometry then deep-clones, and adds
  a noexcept move ctor/assignment. Copying drives GEOS through the *source*
  instance's context and the copy keeps that context, so copying a cache-owned
  Geometry from a query thread is documented as forbidden (implicit copies
  can't be deleted — `FieldDataImpl`'s `std::copy_n` legitimately copies on the
  single-threaded ingest path); the new explicit `Geometry::Clone(ctx)` runs
  all GEOS work through the caller's context and is the safe duplication path
  for query threads.
- **Growing RTree reader/writer races**: `Count()`/`ComputeByteSize()`/
  `QueryCandidates()` snapshot `wrapper_` under the shared lock;
  `RTreeIndexWrapper::count()/ByteSize()` take the rtree lock; `total_num_rows_`
  updates are locked in both `AddGeometry` paths.
- **Concurrent multi-writer init**: `InitForBuildIndex` (growing) is idempotent
  under the write lock and `AddGeometry` reads/publishes `wrapper_` only under
  the lock, matching the documented "concurrent, reentrant" `AppendingIndex`
  contract.
- **Geometry cache lifetime**: `SimpleGeometryCacheManager` returns `shared_ptr`
  so an in-flight query keeps the cache alive past a concurrent segment drop,
  and each cache owns its GEOS context, decoupling its lifetime from the segment.
- **Nullable valid_data bounds**: guard `valid_data[i]` with
  `i < valid_data.size()` in the growing geometry indexing accessor.
- **Empty geometry / GEOS envelope**: `get_bounding_box` checks the
  `GEOSGeom_get{X,Y}{Min,Max}_r` return codes; a geometry with no computable
  envelope is indexed with a deterministic placeholder MBR (the rtree is a coarse
  filter and the exact predicate refines it out) instead of a garbage MBR.
- **null_offset alignment**: validate the loaded `null_offset` payload is
  `size_t`-aligned before `resize()`+`FastMemcpy`, rejecting a malformed or
  truncated sidecar instead of overflowing the destination.
- **Coarse bitmap bounds**: assert the growing index->segment append stays within
  the coarse bitmaps (add_geometry never drops a row, so `active_count <= index
  Count()` always holds), turning a violated invariant into a clear error instead
  of an OOB read or fabricated results.

## Extending both invariants to the GIS split/fusion path (#50675)

This branch was rebased onto a master that now contains the GIS coarse/refine
split + same-column fusion path (`GISConjunctExpr`, #50675). That path did not
exist when this PR was written, and it reaches geometry rows the same two ways
the per-predicate path does — through the geometry cache, and through a
`bulk_subscript` of the surviving offsets — so both invariants above had to be
carried into it. These are merge-integration changes, not new behavior:

- **Per-thread GEOS context.** master factored the prepared-predicate switch
  into a shared `EvaluateGISPreparedOp` helper. It now takes the caller's
  per-thread context and uses it for the two unprepared fallbacks (`Equals`,
  `DWithin`), which would otherwise drive GEOS through `left`'s own stored
  context — and `left` is frequently a cache-owned Geometry whose context is
  shared by every concurrent query on that segment+field. This matters for the
  fusion path specifically: `DWithin` is excluded from grouping, but `Equals`
  is **not**, so a fused `ST_Equals` did reach the shared context.
- **Malformed-WKB tolerance.** The fusion path's no-cache branch constructed
  each row with the *throwing* `Geometry(ctx, wkb)` ctor. Because this PR stops
  dropping unparseable rows (they are indexed with the origin placeholder MBR),
  such a row now does reach exact refinement whenever the query bbox covers the
  origin — where the throwing ctor would fail the entire query. It now uses
  `Geometry::TryParseFromWkb` and evaluates the row to false, matching the
  per-predicate path.
- The fusion path's `SimpleGeometryCacheManager::GetCache` call sites were
  updated for the signature this PR changed (segment instance uid, `shared_ptr`
  return).

master's coarse-bitmap normalization in `RunRTreeQuery` was checked against this
PR's changed growing `Count()` semantics: it already handles the index reporting
both more and fewer rows than `active_count_`, so no change was needed there.

## Upgrade note: pre-existing R-Tree indexes (rebuild recommended, not required)

Both write paths now keep a non-null row whose WKB is empty or unparseable,
indexing it with a placeholder MBR instead of dropping it. Older code dropped
such rows, and `RTreeIndex::Load` recomputes the row count from the
deserialized tree rather than from a persisted build-time count, so an index
built by that code under-reports the segment's rows by exactly the number of
rows it dropped.

Queries against such an index are self-healed on the **per-predicate** GIS path.
Those old builders advanced `absolute_offset` even when they dropped a row, so
the missing entries can be interior holes rather than a trailing suffix, and no
bit in a short index's candidate bitmap is trustworthy as a negative.
`PhyGISFunctionFilterExpr` therefore promotes the entire active row space to
candidates and lets exact refinement settle it
(`GISFunctionFilterExpr.cpp:545-562`). Those rows are always non-null with an
empty or corrupt payload (genuinely null rows were recorded in `null_offset_`
and are counted), so refinement rejects them — the same verdict a freshly built
index produces through its placeholder MBR. A throttled warning names the field
and both row counts.

Both GIS paths now share one rule for such an index: `PromoteShortGISCoarseBitmap`
promotes the whole active row space to candidates, and the coarse/fusion path
(`PhyGISCoarseConjunctExpr::RunRTreeQuery`) routes through it as well instead of
padding only the trailing suffix -- an interior hole would otherwise have stayed a
trusted negative and such a row could be silently missing from fusion-path
results while the per-predicate path returned it. Refinement reads the promoted
candidates in `batch_size_`-row groups, so a full-segment candidate set never
materializes the whole WKB column at once.

Rebuilding such an index is therefore a **performance** recommendation (it
restores R-Tree pruning), not a correctness requirement. No index version bump
is included: there is no per-index-type version knob for R-Tree (unlike
`tantivy_index_version`), and adding one spans the Go index-param path and the
rebuild trigger, which belongs in its own change.

## Verification

- Builds clean (`make build-cpp-with-unittest`).
- AddressSanitizer: the full geometry/RTree/GIS unit suite (150 existing + new
  tests) passes with no ASAN errors, including new concurrent single-/multi-writer
  and empty-geometry tests.
- After the rebase onto #50675: full `all_tests` run — 8060 tests, 8043 passed,
  10 skipped, 7 failed. The 7 failures are all `AzureChunkManagerTest.*`, which
  time out against an Azure endpoint this environment does not have; they are
  unrelated to this change (the only storage-layer edit here is a RAII GEOS
  context in WKT→WKB conversion). The geometry/RTree/GIS/Expr subset is 353/353.
- TSAN was not run (milvus has no wired thread-sanitizer target); the concurrency
  fixes are validated under ASAN but not proven race-free by TSAN. The two
  fusion-path changes above are validated by the existing GIS equivalence suite
  and by inspection of the call sites; neither has a test that fault-injects a
  concurrent `ST_Equals` against a shared cache context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


