### PR TITLE
enhance: set S3 client user-agent for object storage attribution

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -144,9 +144,9 @@ minio:
   useIAM: false
   # Cloud Provider of S3. Supports: "aws", "gcp", "aliyun".
   # Cloud Provider of Google Cloud Storage. Supports: "gcpnative".
-  # You can use "aws" for other cloud provider supports S3 API with signature v4, e.g.: minio
-  # You can use "gcp" for other cloud provider supports S3 API with signature v2
-  # You can use "aliyun" for other cloud provider uses virtual host style bucket
+  # You can use "aws" for other cloud providers that support S3 API with signature v4, e.g. Backblaze B2, Cloudflare R2, or MinIO
+  # You can use "gcp" for other cloud providers that support S3 API with signature v2
+  # You can use "aliyun" for other cloud providers that use virtual host style bucket
   # You can use "gcpnative" for the Google Cloud Platform provider. Uses service account credentials
   # for authentication.
   # When useIAM enabled, only "aws", "gcp", "aliyun" is supported for now

--- a/internal/proxy/accesslog/minio_handler.go
+++ b/internal/proxy/accesslog/minio_handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
@@ -125,6 +126,8 @@ func newMinioClient(ctx context.Context, cfg config) (*minio.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Identify Milvus to S3-compatible backends while preserving minio-go's User-Agent.
+	minioClient.SetAppInfo("milvus", common.MilvusVersion())
 
 	var bucketExists bool
 	// check valid in first query

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -44,6 +44,37 @@ func TestIsSystemField(t *testing.T) {
 	}
 }
 
+func TestMilvusVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "uses build tag",
+			envValue: "v3.0.0",
+			expected: "v3.0.0",
+		},
+		{
+			name:     "falls back when empty",
+			envValue: "",
+			expected: Version.String(),
+		},
+		{
+			name:     "falls back when unknown",
+			envValue: "unknown",
+			expected: Version.String(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(gitBuildTagsEnvKey, tt.envValue)
+			assert.Equal(t, tt.expected, MilvusVersion())
+		})
+	}
+}
+
 func TestDatabaseProperties(t *testing.T) {
 	props := []*commonpb.KeyValuePair{
 		{

--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -1,10 +1,25 @@
 package common
 
-import semver "github.com/blang/semver/v4"
+import (
+	"os"
+
+	semver "github.com/blang/semver/v4"
+)
+
+const gitBuildTagsEnvKey = "MILVUS_GIT_BUILD_TAGS"
 
 // Version current version for session
 var Version semver.Version
 
 func init() {
 	Version = semver.MustParse("3.0.0-beta")
+}
+
+// MilvusVersion returns the build-injected version, falling back to the
+// in-process version when it is empty or unknown.
+func MilvusVersion() string {
+	if v := os.Getenv(gitBuildTagsEnvKey); v != "" && v != "unknown" {
+		return v
+	}
+	return Version.String()
 }

--- a/pkg/objectstorage/util.go
+++ b/pkg/objectstorage/util.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
+	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage/aliyun"
 	"github.com/milvus-io/milvus/pkg/v3/objectstorage/gcp"
@@ -151,6 +152,8 @@ func NewMinioClient(ctx context.Context, c *Config) (*minio.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Identify Milvus to S3-compatible backends while preserving minio-go's User-Agent.
+	minIOClient.SetAppInfo("milvus", common.MilvusVersion())
 	var bucketExists bool
 	// check valid in first query
 	checkBucketFn := func() error {

--- a/pkg/util/paramtable/service_param.go
+++ b/pkg/util/paramtable/service_param.go
@@ -1646,9 +1646,9 @@ aliyun (ecs): https://www.alibabacloud.com/help/en/elastic-compute-service/lates
 		Version:      "2.4.1",
 		Doc: `Cloud Provider of S3. Supports: "aws", "gcp", "aliyun".
 Cloud Provider of Google Cloud Storage. Supports: "gcpnative".
-You can use "aws" for other cloud provider supports S3 API with signature v4, e.g.: minio
-You can use "gcp" for other cloud provider supports S3 API with signature v2
-You can use "aliyun" for other cloud provider uses virtual host style bucket
+You can use "aws" for other cloud providers that support S3 API with signature v4, e.g. Backblaze B2, Cloudflare R2, or MinIO
+You can use "gcp" for other cloud providers that support S3 API with signature v2
+You can use "aliyun" for other cloud providers that use virtual host style bucket
 You can use "gcpnative" for the Google Cloud Platform provider. Uses service account credentials
 for authentication.
 When useIAM enabled, only "aws", "gcp", "aliyun" is supported for now`,


### PR DESCRIPTION
## Summary

Milvus creates its S3 (minio-go) clients without identifying itself, so requests to S3-compatible object storage carry only the default minio-go User-Agent. This calls `SetAppInfo("milvus", <version>)` on both places that build minio-go clients, so requests to Amazon S3 and other S3-compatible backends are tagged as `milvus/<version>`. The minio-go SDK keeps its own User-Agent and adds the configured app info.

## Why

A stable client identifier in the User-Agent helps operators and storage providers attribute traffic to Milvus. It makes object-storage request patterns easier to correlate with a Milvus deployment when reading storage-side access logs, and it is a common low-risk convention for S3 clients.

## What changed

Additive only, no behavior change to storage requests themselves:

- `pkg/common/version.go`: add `MilvusVersion()`, which returns `MILVUS_GIT_BUILD_TAGS` unless it is empty or `"unknown"`, then falls back to `common.Version`.
- `pkg/objectstorage/util.go`: call `SetAppInfo("milvus", common.MilvusVersion())` in `NewMinioClient`.
- `internal/proxy/accesslog/minio_handler.go`: call `SetAppInfo("milvus", common.MilvusVersion())` without importing the full objectstorage package.
- `pkg/util/paramtable/service_param.go`: keep the generated config docs in sync with the YAML comments.
- `configs/milvus.yaml`: clarify existing comment-only examples for S3-compatible providers.

No proto, runtime config value, public API, or metrics changes, so there is nothing new for operators to configure.

## Test plan

- [x] `git diff --check`
- [x] `./bin/gci diff pkg/common/version.go --skip-generated -s standard -s default -s "prefix(github.com/milvus-io)" --custom-order`
- [x] `go test ./common -count=1` from `pkg/`
- [x] `go test -c ./objectstorage -o /tmp/milvus-objectstorage.test` from `pkg/`
- [x] `go test -c ./internal/proxy/accesslog -o /tmp/milvus-accesslog.test`
- [x] `go test -c ./cmd/tools/config -o /tmp/milvus-config-tool.test`
- [x] Reviewed Jenkins 15903: UT-GO failed at `cmd/tools/config TestYamlFile`; fixed by syncing `service_param.go` docs with `configs/milvus.yaml`.
- [x] Reviewed Jenkins 15918: code-check failed at `pkg/common/version.go` import ordering (`gci`); fixed by grouping imports.
- [ ] Confirm on a live endpoint that PutObject / GetObject requests arrive with a User-Agent containing `milvus/<version>`.

## DCO

The commit is signed off (`Signed-off-by:`), so the DCO check should pass.

Related to https://github.com/milvus-io/milvus-docs/pull/3556