### PR TITLE
fix: preserve segment insert log paths for text index

### DIFF
--- a/internal/datanode/util/util.go
+++ b/internal/datanode/util/util.go
@@ -25,8 +25,7 @@ func GetSegmentInsertFiles(fieldBinlogs []*datapb.FieldBinlog, storageConfig *in
 		filePaths := make([]string, 0)
 		columnGroupID := insertLog.GetFieldID()
 		for _, binlog := range insertLog.GetBinlogs() {
-			filePath := metautil.BuildInsertLogPath(storageConfig.GetRootPath(), collectionID, partitionID, segmentID, columnGroupID, binlog.GetLogID())
-			filePaths = append(filePaths, filePath)
+			filePaths = append(filePaths, getInsertLogPath(binlog, storageConfig, collectionID, partitionID, segmentID, columnGroupID))
 		}
 		insertLogs = append(insertLogs, &indexcgopb.FieldInsertFiles{
 			FilePaths: filePaths,
@@ -35,4 +34,12 @@ func GetSegmentInsertFiles(fieldBinlogs []*datapb.FieldBinlog, storageConfig *in
 	return &indexcgopb.SegmentInsertFiles{
 		FieldInsertFiles: insertLogs,
 	}
+}
+
+func getInsertLogPath(binlog *datapb.Binlog, storageConfig *indexpb.StorageConfig, collectionID int64, partitionID int64, segmentID int64, columnGroupID int64) string {
+	filePath := binlog.GetLogPath()
+	if filePath != "" {
+		return filePath
+	}
+	return metautil.BuildInsertLogPath(storageConfig.GetRootPath(), collectionID, partitionID, segmentID, columnGroupID, binlog.GetLogID())
 }

--- a/internal/datanode/util/util_test.go
+++ b/internal/datanode/util/util_test.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/indexpb"
+)
+
+func TestGetSegmentInsertFilesPreservesLogPath(t *testing.T) {
+	storageConfig := &indexpb.StorageConfig{
+		RootPath: "file",
+	}
+	insertBinlogs := []*datapb.FieldBinlog{{
+		FieldID: 1,
+		Binlogs: []*datapb.Binlog{{
+			LogPath:    "file/insert_log/10/20/30/1/40",
+			EntriesNum: 100,
+		}},
+	}}
+
+	got := GetSegmentInsertFiles(insertBinlogs, storageConfig, 10, 20, 30)
+
+	assert.Equal(t, "file/insert_log/10/20/30/1/40", got.GetFieldInsertFiles()[0].GetFilePaths()[0])
+}
+
+func TestGetSegmentInsertFilesFallsBackToLogID(t *testing.T) {
+	storageConfig := &indexpb.StorageConfig{
+		RootPath: "file",
+	}
+	insertBinlogs := []*datapb.FieldBinlog{{
+		FieldID: 1,
+		Binlogs: []*datapb.Binlog{{
+			LogID:      40,
+			EntriesNum: 100,
+		}},
+	}}
+
+	got := GetSegmentInsertFiles(insertBinlogs, storageConfig, 10, 20, 30)
+
+	assert.Equal(t, "file/insert_log/10/20/30/1/40", got.GetFieldInsertFiles()[0].GetFilePaths()[0])
+}


### PR DESCRIPTION
issue: #50865

## Summary
Preserve existing insert log paths when building segment insert files for StorageV2 text index builds.
Fall back to constructing paths from log IDs when the binlog path is absent.