### PR TITLE
test: Update aggregation and groupby E2E coverage

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
@@ -440,6 +440,17 @@ class TestSearchAggregation(TestMilvusClientV2Base):
         "kwargs, err_msg",
         [
             ({"group_by_field": "brand"}, "search_aggregation and group_by_field are mutually exclusive"),
+            pytest.param(
+                {"group_by_fields": ["brand"]},
+                "group_by_fields and search_aggregation cannot be used simultaneously",
+                marks=pytest.mark.xfail(
+                    reason=(
+                        "Milvus issue #50960: Python MilvusClient.search currently ignores group_by_fields "
+                        "kwargs, so the proxy conflict validation is not reached"
+                    ),
+                    strict=True,
+                ),
+            ),
             (
                 {"search_params": {"metric_type": "L2", "offset": 1}},
                 "offset is not supported with search_aggregation",
@@ -628,7 +639,6 @@ class TestSearchAggregation(TestMilvusClientV2Base):
             for hit in bucket.hits:
                 assert hit.fields.get(field_name) == key
 
-    @pytest.mark.xfail(reason="unstable: top_hits may not include NULL nullable metric rows", strict=False)
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_aggregation_nullable_metric_field(self):
         """
@@ -1135,7 +1145,7 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
             client, collection_name
         )
 
-        error = {ct.err_code: 999, ct.err_msg: "JSON / dynamic fields are not yet supported with search_aggregation"}
+        error = {ct.err_code: 999, ct.err_msg: "JSON / dynamic fields are not yet supported"}
         self.search(
             client,
             collection_name,
@@ -1162,7 +1172,7 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
             client, collection_name
         )
 
-        error = {ct.err_code: 999, ct.err_msg: "JSON / dynamic fields are not yet supported with search_aggregation"}
+        error = {ct.err_code: 999, ct.err_msg: "JSON / dynamic fields are not yet supported"}
         self.search(
             client,
             collection_name,
@@ -1182,15 +1192,11 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
         )
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.xfail(
-        reason="search_aggregation top_hits.sort does not support dynamic fields yet",
-        strict=True,
-    )
     def test_search_aggregation_top_hits_sort_by_dynamic_field(self):
         """
-        target: verify top_hits.sort can use a dynamic scalar field.
-        method: make the nearest five rows have reverse dynamic_price values, then sort top_hits by dynamic_price asc.
-        expected: hits are ordered by dynamic_price rather than by vector distance.
+        target: verify top_hits.sort rejects dynamic scalar fields.
+        method: request top_hits sort by an inserted dynamic scalar field.
+        expected: request is rejected because JSON / dynamic top_hits sort is not supported yet.
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -1199,7 +1205,11 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
         )
 
         query_vector = [0.0] * ct.default_dim
-        res, _ = self.search(
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: "JSON / dynamic fields are not yet supported",
+        }
+        self.search(
             client,
             collection_name,
             data=[query_vector],
@@ -1212,24 +1222,19 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
                 size=1,
                 top_hits=TopHits(size=5, sort=[{dynamic_metric_field: "asc"}]),
             ),
+            check_task=CheckTasks.err_res,
+            check_items=error,
         )
 
-        assert len(res.agg_buckets) == 1
-        assert len(res.agg_buckets[0]) == 1
-        assert [hit.pk for hit in res.agg_buckets[0][0].hits] == [4, 3, 2, 1, 0]
         assert vectors[0] == query_vector
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.xfail(
-        reason="Milvus issue #49842: count(JSON/dynamic field) silently drops search_aggregation metric",
-        strict=True,
-    )
     @pytest.mark.parametrize("metric_field", ["meta", "dynamic_brand"])
-    def test_search_aggregation_count_json_or_dynamic_metric_not_silent_missing(self, metric_field):
+    def test_search_aggregation_count_json_or_dynamic_metric_reject(self, metric_field):
         """
-        target: verify count(JSON/dynamic field) does not silently drop the metric result.
+        target: verify count(JSON/dynamic field) is explicitly rejected.
         method: aggregate by a static scalar field and compute count(meta) or count(dynamic_brand).
-        expected: metric alias is present, or the request is explicitly rejected before execution.
+        expected: request is rejected because JSON / dynamic metric fields are not supported yet.
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -1238,7 +1243,11 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
         )
 
         metric_alias = "field_count"
-        res, _ = self.search(
+        error = {
+            ct.err_code: 999,
+            ct.err_msg: "JSON / dynamic fields are not yet supported",
+        }
+        self.search(
             client,
             collection_name,
             data=[vectors[0]],
@@ -1252,12 +1261,9 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
                 metrics={metric_alias: {"count": metric_field}},
                 order=[{metric_alias: "desc"}],
             ),
+            check_task=CheckTasks.err_res,
+            check_items=error,
         )
-
-        assert len(res.agg_buckets) == 1
-        for bucket in res.agg_buckets[0]:
-            assert metric_alias in bucket.metrics
-            assert bucket.metrics[metric_alias] == bucket.count
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_search_aggregation_reject_json_group_field(self):
@@ -1270,7 +1276,7 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
         collection_name = cf.gen_collection_name_by_testcase_name()
         vectors, vector_field, _, json_field, _ = self._prepare_json_field_collection(client, collection_name)
 
-        error = {ct.err_code: 999, ct.err_msg: "JSON / dynamic fields are not yet supported with search_aggregation"}
+        error = {ct.err_code: 999, ct.err_msg: "JSON / dynamic fields are not yet supported"}
         self.search(
             client,
             collection_name,
@@ -1283,7 +1289,7 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
             check_task=CheckTasks.err_res,
             check_items=error,
         )
-        with pytest.raises(ParamError, match="does not yet support bracketed JSON path expressions"):
+        with pytest.raises(ParamError, match="bracketed JSON path expressions"):
             SearchAggregation(fields=[f"{json_field}['tag']"], size=2)
 
     @pytest.mark.tags(CaseLabel.L2)
@@ -1301,7 +1307,7 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
 
         metric_error = {
             ct.err_code: 999,
-            ct.err_msg: "JSON / dynamic fields are not yet supported with search_aggregation",
+            ct.err_msg: "JSON / dynamic fields are not yet supported",
         }
         self.search(
             client,
@@ -1321,7 +1327,7 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
             check_items=metric_error,
         )
 
-        sort_error = {ct.err_code: 999, ct.err_msg: "top_hits.sort JSON path is not yet supported"}
+        sort_error = {ct.err_code: 999, ct.err_msg: "JSON path is not yet supported"}
         self.search(
             client,
             collection_name,
@@ -1416,15 +1422,11 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
             assert hit.fields[brand_field] == growing_brand
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.xfail(
-        reason="Milvus issue #49841: search_iterator silently drops search_aggregation",
-        strict=True,
-    )
     def test_search_iterator_with_search_aggregation_not_silent_empty(self):
         """
-        target: verify search_iterator does not silently drop search_aggregation results.
+        target: verify search_iterator explicitly rejects search_aggregation.
         method: pass search_aggregation to MilvusClient.search_iterator.
-        expected: iterator either explicitly rejects search_aggregation or returns non-empty aggregation/search results.
+        expected: request is rejected instead of silently dropping search_aggregation.
         """
         client = self._client()
         collection_name = cf.gen_collection_name_by_testcase_name()
@@ -1449,25 +1451,19 @@ class TestSearchAggregationIndependent(TestMilvusClientV2Base):
         normal_iterator.close()
         assert len(normal_batch) > 0
 
-        try:
-            agg_iterator, _ = self.search_iterator(
-                client,
-                collection_name,
-                data=[vectors[0]],
-                batch_size=10,
-                limit=10,
-                search_params={"metric_type": "L2"},
-                output_fields=["id"],
-                search_aggregation=SearchAggregation(fields=["id"], size=2),
-            )
-        except ParamError as e:
-            err_msg = str(e)
-            assert "search_aggregation" in err_msg and "not support" in err_msg
-            return
-
-        agg_batch = agg_iterator.next()
-        agg_iterator.close()
-        assert len(agg_batch) > 0 or hasattr(agg_batch, "agg_buckets")
+        error = {ct.err_code: 999, ct.err_msg: "not supported with search_aggregation"}
+        self.search_iterator(
+            client,
+            collection_name,
+            data=[vectors[0]],
+            batch_size=10,
+            limit=10,
+            search_params={"metric_type": "L2"},
+            output_fields=["id"],
+            search_aggregation=SearchAggregation(fields=["id"], size=2),
+            check_task=CheckTasks.err_res,
+            check_items=error,
+        )
 
     @pytest.mark.tags(CaseLabel.L2)
     def test_struct_array_element_search_reject_non_primary_key_aggregation(self):

--- a/tests/python_client/milvus_client/test_milvus_client_search_order.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_order.py
@@ -805,10 +805,6 @@ class TestMilvusClientSearchOrderIndependent(TestMilvusClientV2Base):
     """
 
     @pytest.mark.tags(CaseLabel.L2)
-    @pytest.mark.xfail(
-        reason="Milvus issue #49879: search with order_by_fields applies offset before scalar ordering",
-        strict=True,
-    )
     def test_milvus_client_search_order_by_with_offset(self):
         """
         target: verify search pagination with order_by_fields applies offset after scalar ordering
@@ -855,6 +851,65 @@ class TestMilvusClientSearchOrderIndependent(TestMilvusClientV2Base):
 
             result_ids = [r["id"] for r in res[0]]
             assert result_ids == [3, 1], f"Expected offset after price ordering to return [3, 1], got {result_ids}"
+        finally:
+            client.drop_collection(collection_name)
+
+    @pytest.mark.tags(CaseLabel.L2)
+    def test_milvus_client_search_order_by_group_by_with_offset(self):
+        """
+        target: verify search pagination with order_by_fields and group_by_field applies offset by groups.
+        method: search controlled ANN candidates with order_by price asc, group_by category, limit=2, offset=1.
+        expected: group heads are selected by ANN score, ordered by price, then offset skips the first group.
+        """
+        client = self._client()
+        collection_name = cf.gen_collection_name_by_testcase_name()
+
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("category", DataType.VARCHAR, max_length=16)
+        schema.add_field("price", DataType.INT64)
+        schema.add_field("embeddings", DataType.FLOAT_VECTOR, dim=2)
+
+        index_params = client.prepare_index_params()
+        index_params.add_index(field_name="embeddings", index_type="FLAT", metric_type="IP", params={})
+
+        client.create_collection(
+            collection_name=collection_name, schema=schema, index_params=index_params, consistency_level="Strong"
+        )
+        try:
+            rows = [
+                {"id": 1, "category": "A", "price": 30, "embeddings": [1.0, 0.0]},
+                {"id": 2, "category": "A", "price": 10, "embeddings": [0.9, 0.0]},
+                {"id": 3, "category": "B", "price": 20, "embeddings": [0.8, 0.0]},
+                {"id": 4, "category": "C", "price": 40, "embeddings": [0.7, 0.0]},
+            ]
+            client.insert(collection_name=collection_name, data=rows)
+            client.flush(collection_name=collection_name)
+            client.load_collection(collection_name=collection_name)
+
+            res = self.search(
+                client,
+                collection_name,
+                [[1.0, 0.0]],
+                anns_field="embeddings",
+                limit=2,
+                offset=1,
+                search_params={"metric_type": "IP", "params": {}},
+                output_fields=["category", "price"],
+                group_by_field="category",
+                order_by_fields=[{"field": "price", "order": "asc"}],
+                consistency_level="Strong",
+            )[0]
+
+            result_ids = [r["id"] for r in res[0]]
+            result_categories = [r["entity"]["category"] for r in res[0]]
+            result_prices = [r["entity"]["price"] for r in res[0]]
+            assert result_ids == [1, 4], (
+                "Expected group heads B(20), A(30), C(40) after order_by price asc, "
+                f"then offset=1/limit=2 to return groups A and C, got ids {result_ids}"
+            )
+            assert result_categories == ["A", "C"]
+            assert result_prices == [30, 40]
         finally:
             client.drop_collection(collection_name)
 
@@ -1085,7 +1140,7 @@ class TestMilvusClientSearchOrderInvalid(TestMilvusClientV2Base):
         collection_name = INVALID_COLLECTION_NAME
 
         vectors_to_search = cf.gen_vectors(1, default_dim)
-        error = {ct.err_code: 1, ct.err_msg: "order_by is not supported when using search iterator"}
+        error = {ct.err_code: 1, ct.err_msg: "not supported when using search iterator"}
         self.search_iterator(
             client,
             collection_name,
@@ -1111,11 +1166,7 @@ class TestMilvusClientSearchOrderInvalid(TestMilvusClientV2Base):
         vectors_to_search = cf.gen_vectors(1, default_dim)
         error = {
             ct.err_code: 65535,
-            ct.err_msg: (
-                "order_by field 'json_field' has unsortable type JSON; supported types: "
-                "bool, int8/16/32/64, float, double, string, varchar; for JSON fields use "
-                'path syntax like field["key"]'
-            ),
+            ct.err_msg: "unsortable type JSON",
         }
         self.search(
             client,
@@ -1142,7 +1193,7 @@ class TestMilvusClientSearchOrderInvalid(TestMilvusClientV2Base):
         vectors_to_search = cf.gen_vectors(1, default_dim)
         error = {
             ct.err_code: 1,
-            ct.err_msg: "Invalid order_by_fields item: 'field' key is required and cannot be empty",
+            ct.err_msg: "'field' key is required",
         }
         self.search(
             client,
@@ -1169,7 +1220,7 @@ class TestMilvusClientSearchOrderInvalid(TestMilvusClientV2Base):
         vectors_to_search = cf.gen_vectors(1, default_dim)
         error = {
             ct.err_code: 65535,
-            ct.err_msg: "order_by field 'json_field[invalid:asc' does not exist in collection schema",
+            ct.err_msg: "does not exist in collection schema",
         }
         self.search(
             client,

--- a/tests/python_client/testcases/test_query_aggregation.py
+++ b/tests/python_client/testcases/test_query_aggregation.py
@@ -377,15 +377,13 @@ class TestQueryAggregationSharedV2(TestMilvusClientV2Base):
         log.info(f"test_group_by_with_filter passed: {len(results)} groups after filtering")
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.skip(reason="limit parameter on GROUP BY queries not fully supported in Milvus 2.6.6")
     def test_group_by_with_limit(self):
         """
         target: test GROUP BY with limit parameter (with and without filter)
         method: query with group_by_fields=["c1"], limit, with/without filter
         expected: returns at most N groups, aggregations computed correctly from filtered data
-        Note: Issue #47326 - limit parameter is currently ignored in aggregation queries
-              This test covers both scenarios originally tested by test_group_by_with_limit
-              and test_filter_and_limit_with_aggregation (which was redundant)
+        Note: This test covers both scenarios originally tested by test_group_by_with_limit
+              and test_filter_and_limit_with_aggregation.
         """
         client = self._client()
 
@@ -399,7 +397,14 @@ class TestQueryAggregationSharedV2(TestMilvusClientV2Base):
             output_fields=[self.c1_field_name, "avg(c2)"],
             limit=limit,
         )
-        assert len(results) <= limit, f"Expected at most {limit} groups, got {len(results)}"
+        ground_truth = self.datas.groupby(self.c1_field_name).agg(avg_c2=(self.c2_field_name, "mean")).reset_index()
+        assert len(results) == min(limit, len(ground_truth)), (
+            f"Expected {min(limit, len(ground_truth))} groups, got {len(results)}"
+        )
+        for result in results:
+            c1_value = result[self.c1_field_name]
+            expected = ground_truth[ground_truth[self.c1_field_name] == c1_value].iloc[0]
+            assert abs(result["avg(c2)"] - expected["avg_c2"]) < 0.01, f"AVG(c2) mismatch for c1={c1_value}"
 
         # Scenario 2: limit with filter - verify aggregation from filtered data
         # Filter "c2 >= 50" keeps roughly 50% of non-NULL values (c2 ranges 0-99)
@@ -413,12 +418,22 @@ class TestQueryAggregationSharedV2(TestMilvusClientV2Base):
             limit=2,
         )
 
-        # Verify limit
-        assert len(results_filtered) <= 2, f"Expected at most 2 groups, got {len(results_filtered)}"
+        filtered_data = self.datas[self.datas[self.c2_field_name] >= 50]
+        filtered_ground_truth = (
+            filtered_data.groupby(self.c1_field_name)
+            .agg(count_c2=(self.c2_field_name, "count"), avg_c2=(self.c2_field_name, "mean"))
+            .reset_index()
+        )
+        assert len(results_filtered) == min(2, len(filtered_ground_truth)), (
+            f"Expected {min(2, len(filtered_ground_truth))} groups, got {len(results_filtered)}"
+        )
 
         # Verify aggregations are from filtered data (c2 >= 50)
         for result in results_filtered:
-            # avg should be >= 50 since we filtered c2 >= 50
+            c1_value = result[self.c1_field_name]
+            expected = filtered_ground_truth[filtered_ground_truth[self.c1_field_name] == c1_value].iloc[0]
+            assert result["count(c2)"] == expected["count_c2"], f"COUNT mismatch for c1={c1_value} with filter"
+            assert abs(result["avg(c2)"] - expected["avg_c2"]) < 0.01, f"AVG(c2) mismatch for c1={c1_value}"
             assert result["avg(c2)"] >= 50, f"avg(c2) should be >= 50 after filter, got {result['avg(c2)']}"
 
         log.info("test_group_by_with_limit passed: limit and filter+limit scenarios verified")
@@ -1043,32 +1058,40 @@ class TestQueryAggregationSharedV2(TestMilvusClientV2Base):
         log.info("test_group_by_int64_field passed")
 
     @pytest.mark.tags(CaseLabel.L1)
-    @pytest.mark.xfail(reason="GROUP BY field not in output_fields should error but succeeds. Tracked in issue #47334")
-    def test_group_by_field_not_in_output_fields(self):
+    def test_group_by_field_not_required_in_output_fields(self):
         """
-        target: test error when group_by field is not in output_fields
+        target: test GROUP BY field is not required in output_fields.
         method: query with group_by_fields=["c1"] but output_fields=["count(c2)"] (missing c1)
-        expected: Should raise error indicating group_by field must be in output_fields
-        Note: Design requirement states "分组字段必须包含在 output_fields 中，否则应该报错"
-              Currently Milvus allows this query but returns useless results without group keys (issue #47334)
+        expected: query succeeds and returns one aggregate row per group without projecting the group key.
+        Note: Milvus issue #47334 was closed as by-design. SQL allows SELECT count(*) FROM t GROUP BY category
+              without including category in the SELECT list.
         """
         client = self._client()
 
-        # Query with missing group_by field in output_fields
-        # According to design, this should raise an error
-        error = {ct.err_code: 1, ct.err_msg: ""}  # Expected error
-        self.query(
+        results, _ = self.query(
             client,
             self.collection_name,
             filter="",
             limit=100,
             group_by_fields=[self.c1_field_name],
-            output_fields=["count(c2)"],  # Missing c1 - should error
-            check_task=CheckTasks.err_res,
-            check_items=error,
+            output_fields=["count(c2)"],
         )
 
-        log.info("test_group_by_field_not_in_output_fields passed")
+        ground_truth_counts = (
+            self.datas.groupby(self.c1_field_name)
+            .agg(count_c2=(self.c2_field_name, "count"))
+            .reset_index()["count_c2"]
+            .tolist()
+        )
+        result_counts = [result["count(c2)"] for result in results]
+
+        assert len(results) == len(ground_truth_counts)
+        assert sorted(result_counts) == sorted(ground_truth_counts)
+        for result in results:
+            assert self.c1_field_name not in result
+            assert set(result.keys()) == {"count(c2)"}
+
+        log.info("test_group_by_field_not_required_in_output_fields passed")
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_unsupported_vector_field(self):


### PR DESCRIPTION
## Summary
- strengthen search aggregation reject coverage for unsupported group-by, iterator, and dynamic-field combinations
- add controlled search order_by + group_by_field + offset regression coverage
- update query aggregation GROUP BY limit and output projection coverage to current semantics

issue: #50960

## Test Plan
- [x] PYTHONPATH=. /Users/yanliang.qiao/Documents/Codex/2026-06-30/new-chat/work/milvus-e2e-venv/bin/python -m pytest -q --tb=short --disable-warnings --timeout=300 --host 127.0.0.1 --port 19530 --user root --password Milvus <targeted agg/groupby cases>: 11 passed, 1 xfailed in 51.81s
- [x] git diff --check -- tests/python_client/milvus_client/test_milvus_client_search_aggregation.py tests/python_client/milvus_client/test_milvus_client_search_order.py tests/python_client/testcases/test_query_aggregation.py

Milvus test target: qa-milvus/yanliang-mas2-milvus-standalone-6686d94498-lhp7k, Running 1/1, restart count 0