### PR TITLE
fix: Replace stale log call in expression bitwise test

### DIFF
--- a/tests/integration/expression/expression_test.go
+++ b/tests/integration/expression/expression_test.go
@@ -255,7 +255,8 @@ func (s *ExpressionSuite) searchWithBitwiseExpression() {
 		s.NoError(err)
 		s.Equal(c.resNum, len(searchResult.GetResults().GetScores()),
 			fmt.Sprintf("unexpected match count for bitwise expr: %s", c.expr))
-		log.Info(fmt.Sprintf("=========================Bitwise search done with expr:%s =========================", c.expr))
+		mlog.Info(context.TODO(),
+			fmt.Sprintf("=========================Bitwise search done with expr:%s =========================", c.expr))
 	}
 }
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/50971

## What changed

- Replaced the stale `log.Info` call in `searchWithBitwiseExpression` with `mlog.Info(context.TODO(), ...)`.
- Kept the file consistent with the current `pkg/v3/mlog` logging migration.

## Why

`milvus/master` code-check fails `static-check` because the old `log` symbol is no longer imported in `tests/integration/expression/expression_test.go`.

## Validation

- `gofmt -w tests/integration/expression/expression_test.go`
- `git diff --check`
- `rg -n "\blog\." tests/integration/expression/expression_test.go`
- Targeted `golangci-lint` was attempted, but local execution is blocked by missing `internal/core/output` cgo artifacts in this worktree. The original `undefined: log` typecheck failure no longer appeared before the cgo import failure.