### PR TITLE
fix: rollback create collection file resource refs

### DIFF
--- a/internal/metastore/model/collection.go
+++ b/internal/metastore/model/collection.go
@@ -217,6 +217,7 @@ func (c *Collection) ApplyUpdates(header *message.AlterCollectionMessageHeader, 
 			c.Functions = UnmarshalFunctionModels(updates.Schema.Functions)
 			c.StructArrayFields = UnmarshalStructArrayFieldModels(updates.Schema.StructArrayFields)
 			c.SchemaVersion = updates.Schema.Version
+			c.FileResourceIds = updates.Schema.GetFileResourceIds()
 			c.ExternalSource = updates.Schema.ExternalSource
 			c.ExternalSpec = updates.Schema.ExternalSpec
 		case message.FieldMaskCollectionExternalSpec:

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -2403,6 +2403,8 @@ var allowedAlterProps = []string{
 	common.MmapEnabledKey,
 	common.MaxCapacityKey,
 	common.FieldDescriptionKey,
+	common.EnableAnalyzerKey,
+	common.AnalyzerParamKey,
 	common.WarmupKey,
 	common.WarmupScalarFieldKey,
 	common.WarmupScalarIndexKey,
@@ -2412,6 +2414,8 @@ var allowedAlterProps = []string{
 
 var allowedDropProps = []string{
 	common.MmapEnabledKey,
+	common.EnableAnalyzerKey,
+	common.AnalyzerParamKey,
 	common.WarmupKey,
 	common.WarmupScalarFieldKey,
 	common.WarmupScalarIndexKey,
@@ -2465,6 +2469,34 @@ func updatePropertiesKeys(oldProps []*commonpb.KeyValuePair) []*commonpb.KeyValu
 	return propKV
 }
 
+func isAnalyzerFieldParam(key string) bool {
+	return key == common.EnableAnalyzerKey || key == common.AnalyzerParamKey
+}
+
+func getAlterCollectionFieldTarget(schema *schemapb.CollectionSchema, fieldName string) *schemapb.FieldSchema {
+	for _, field := range schema.GetFields() {
+		if field.GetName() == fieldName {
+			return field
+		}
+	}
+	return nil
+}
+
+func validateAlterAnalyzerFieldParam(collSchema *schemapb.CollectionSchema, fieldName string) error {
+	field := getAlterCollectionFieldTarget(collSchema, fieldName)
+	if field == nil {
+		return merr.WrapErrParameterInvalidMsg("field not found: %s", fieldName)
+	}
+
+	if typeutil.CreateFieldSchemaHelper(field).EnableMatch() || typeutil.IsBm25FunctionInputField(collSchema, field) {
+		return merr.WrapErrParameterInvalidMsg(
+			"can not alter analyzer params for field %s after text match is enabled or BM25 function depends on it",
+			fieldName,
+		)
+	}
+	return nil
+}
+
 func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 	collSchema, err := globalMetaCache.GetCollectionSchema(ctx, t.GetDbName(), t.CollectionName)
 	if err != nil {
@@ -2490,6 +2522,16 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 		}
 		// Check the value type based on the key
 		switch prop.Key {
+		case common.EnableAnalyzerKey, common.AnalyzerParamKey:
+			if err := validateAlterAnalyzerFieldParam(collSchema.CollectionSchema, t.FieldName); err != nil {
+				return err
+			}
+			if prop.Key == common.EnableAnalyzerKey {
+				if _, err := strconv.ParseBool(prop.Value); err != nil {
+					return merr.WrapErrParameterInvalidMsg("%s should be a boolean, but got %s", prop.Key, prop.Value)
+				}
+			}
+
 		case common.MmapEnabledKey:
 			loaded, err := isCollectionLoadedFn()
 			if err != nil {
@@ -2563,6 +2605,11 @@ func (t *alterCollectionFieldTask) PreExecute(ctx context.Context) error {
 		updatedKey := updateKey(key)
 		if !IsKeyAllowDrop(updatedKey) {
 			return merr.WrapErrParameterInvalidMsg("%s is not allowed to drop in collection field param", key)
+		}
+		if isAnalyzerFieldParam(updatedKey) {
+			if err := validateAlterAnalyzerFieldParam(collSchema.CollectionSchema, t.FieldName); err != nil {
+				return err
+			}
 		}
 
 		if updatedKey == common.MmapEnabledKey || common.IsFieldWarmupKey(updatedKey) {

--- a/internal/proxy/task.go
+++ b/internal/proxy/task.go
@@ -2488,6 +2488,10 @@ func validateAlterAnalyzerFieldParam(collSchema *schemapb.CollectionSchema, fiel
 		return merr.WrapErrParameterInvalidMsg("field not found: %s", fieldName)
 	}
 
+	if !typeutil.IsStringType(field.GetDataType()) {
+		return merr.WrapErrParameterInvalidMsg("can not alter analyzer params for non-string field %s", fieldName)
+	}
+
 	if typeutil.CreateFieldSchemaHelper(field).EnableMatch() || typeutil.IsBm25FunctionInputField(collSchema, field) {
 		return merr.WrapErrParameterInvalidMsg(
 			"can not alter analyzer params for field %s after text match is enabled or BM25 function depends on it",

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -6309,6 +6309,43 @@ func TestAlterCollectionField(t *testing.T) {
 				ElementType: schemapb.DataType_Int64,
 				TypeParams:  []*commonpb.KeyValuePair{{Key: "max_capacity", Value: "100"}},
 			},
+			{
+				FieldID:  102,
+				Name:     "text_match_field",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "100"},
+					{Key: "enable_match", Value: "true"},
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+				},
+			},
+			{
+				FieldID:  103,
+				Name:     "bm25_input_field",
+				DataType: schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.MaxLengthKey, Value: "100"},
+					{Key: common.EnableAnalyzerKey, Value: "true"},
+					{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+				},
+			},
+			{
+				FieldID:          104,
+				Name:             "bm25_output_field",
+				DataType:         schemapb.DataType_SparseFloatVector,
+				IsFunctionOutput: true,
+			},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Name:             "bm25_func",
+				Type:             schemapb.FunctionType_BM25,
+				InputFieldIds:    []int64{103},
+				InputFieldNames:  []string{"bm25_input_field"},
+				OutputFieldIds:   []int64{104},
+				OutputFieldNames: []string{"bm25_output_field"},
+			},
 		},
 	}
 	schemaBytes, err := proto.Marshal(schema)
@@ -6373,6 +6410,42 @@ func TestAlterCollectionField(t *testing.T) {
 				{Key: common.MmapEnabledKey, Value: "true"},
 			},
 			expectError: false,
+		},
+		{
+			name:      "update analyzer params on inactive string field",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.EnableAnalyzerKey, Value: "true"},
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+			},
+			expectError: false,
+		},
+		{
+			name:      "invalid enable analyzer value",
+			fieldName: "string_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.EnableAnalyzerKey, Value: "not_bool"},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:      "reject analyzer params on text match field",
+			fieldName: "text_match_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"whitespace"}`},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:      "reject analyzer params on bm25 input field",
+			fieldName: "bm25_input_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"whitespace"}`},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
 		},
 		{
 			name:      "invalid property key",
@@ -6457,6 +6530,26 @@ func TestAlterCollectionField(t *testing.T) {
 			fieldName:   "string_field",
 			deleteKeys:  []string{MmapEnabledKey},
 			expectError: false,
+		},
+		{
+			name:        "delete analyzer params on inactive string field",
+			fieldName:   "string_field",
+			deleteKeys:  []string{common.EnableAnalyzerKey, common.AnalyzerParamKey},
+			expectError: false,
+		},
+		{
+			name:        "reject delete analyzer params on text match field",
+			fieldName:   "text_match_field",
+			deleteKeys:  []string{common.AnalyzerParamKey},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
+			name:        "reject delete analyzer params on bm25 input field",
+			fieldName:   "bm25_input_field",
+			deleteKeys:  []string{common.AnalyzerParamKey},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
 		},
 		{
 			name:        "delete max_length is not allowed",

--- a/internal/proxy/task_test.go
+++ b/internal/proxy/task_test.go
@@ -6421,6 +6421,16 @@ func TestAlterCollectionField(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:      "reject analyzer params on non-string field",
+			fieldName: "array_field",
+			properties: []*commonpb.KeyValuePair{
+				{Key: common.EnableAnalyzerKey, Value: "true"},
+				{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+			},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
+		},
+		{
 			name:      "invalid enable analyzer value",
 			fieldName: "string_field",
 			properties: []*commonpb.KeyValuePair{
@@ -6536,6 +6546,13 @@ func TestAlterCollectionField(t *testing.T) {
 			fieldName:   "string_field",
 			deleteKeys:  []string{common.EnableAnalyzerKey, common.AnalyzerParamKey},
 			expectError: false,
+		},
+		{
+			name:        "reject delete analyzer params on non-string field",
+			fieldName:   "array_field",
+			deleteKeys:  []string{common.EnableAnalyzerKey, common.AnalyzerParamKey},
+			expectError: true,
+			errCode:     merr.Code(merr.ErrParameterInvalid),
 		},
 		{
 			name:        "reject delete analyzer params on text match field",

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -230,16 +230,7 @@ func (t *createCollectionTask) validateSchema(ctx context.Context, schema *schem
 		return err
 	}
 
-	// check analyzer was vaild
-	analyzerInfos := make([]*querypb.AnalyzerInfo, 0)
-	for _, field := range schema.GetFields() {
-		err := validateAnalyzer(schema, field, &analyzerInfos)
-		if err != nil {
-			return err
-		}
-	}
-
-	fileResourceIds, err := t.Core.validateAnalyzerInfos(ctx, analyzerInfos)
+	fileResourceIds, err := t.Core.validateSchemaAnalyzerFileResources(ctx, schema, activeAnalyzerOnly)
 	if err != nil {
 		return err
 	}
@@ -247,14 +238,27 @@ func (t *createCollectionTask) validateSchema(ctx context.Context, schema *schem
 
 	// Bind file resources to collection lifecycle: refCnt++ now, refCnt-- on
 	// drop. Under ddLock, atomic with RemoveFileResource. See #48612.
+	if err := reserveFileResourceRefs(t.meta, schema.FileResourceIds); err != nil {
+		return err
+	}
 	if len(schema.FileResourceIds) > 0 {
-		if err := t.meta.IncFileResourceRefCnt(schema.FileResourceIds); err != nil {
-			return err
-		}
 		t.heldFileResourceIds = schema.FileResourceIds
 	}
 
 	return validateFieldDataType(schema.GetFields())
+}
+
+const (
+	activeAnalyzerOnly      = false
+	includeInactiveAnalyzer = true
+)
+
+func (c *Core) validateSchemaAnalyzerFileResources(ctx context.Context, schema *schemapb.CollectionSchema, includeInactive bool) ([]int64, error) {
+	analyzerInfos, err := collectAnalyzerInfos(schema, includeInactive)
+	if err != nil {
+		return nil, err
+	}
+	return c.validateAnalyzerInfos(ctx, analyzerInfos)
 }
 
 func (c *Core) validateAnalyzerInfos(ctx context.Context, analyzerInfos []*querypb.AnalyzerInfo) ([]int64, error) {
@@ -932,10 +936,10 @@ func validateMultiAnalyzerParams(params string, coll *schemapb.CollectionSchema,
 	return nil
 }
 
-func collectAnalyzerInfosForAlter(collSchema *schemapb.CollectionSchema) ([]*querypb.AnalyzerInfo, error) {
+func collectAnalyzerInfos(collSchema *schemapb.CollectionSchema, includeInactive bool) ([]*querypb.AnalyzerInfo, error) {
 	analyzerInfos := make([]*querypb.AnalyzerInfo, 0)
 	for _, field := range collSchema.GetFields() {
-		if err := validateAnalyzerWithInactive(collSchema, field, &analyzerInfos); err != nil {
+		if err := validateAnalyzerInternal(collSchema, field, &analyzerInfos, includeInactive); err != nil {
 			return nil, err
 		}
 	}
@@ -944,10 +948,6 @@ func collectAnalyzerInfosForAlter(collSchema *schemapb.CollectionSchema) ([]*que
 
 func validateAnalyzer(collSchema *schemapb.CollectionSchema, fieldSchema *schemapb.FieldSchema, analyzerInfos *[]*querypb.AnalyzerInfo) error {
 	return validateAnalyzerInternal(collSchema, fieldSchema, analyzerInfos, false)
-}
-
-func validateAnalyzerWithInactive(collSchema *schemapb.CollectionSchema, fieldSchema *schemapb.FieldSchema, analyzerInfos *[]*querypb.AnalyzerInfo) error {
-	return validateAnalyzerInternal(collSchema, fieldSchema, analyzerInfos, true)
 }
 
 func validateAnalyzerInternal(collSchema *schemapb.CollectionSchema, fieldSchema *schemapb.FieldSchema, analyzerInfos *[]*querypb.AnalyzerInfo, validateInactive bool) error {

--- a/internal/rootcoord/create_collection_task.go
+++ b/internal/rootcoord/create_collection_task.go
@@ -239,45 +239,55 @@ func (t *createCollectionTask) validateSchema(ctx context.Context, schema *schem
 		}
 	}
 
-	// validate analyzer params at any streaming node
-	// and set file resource ids to schema
-	if len(analyzerInfos) > 0 {
-		err := retry.Do(ctx, func() error {
-			if t.fileResourceObserver == nil {
-				return nil
-			}
-			if err := t.fileResourceObserver.CheckAllQnReady(); err != nil {
-				return err
-			}
-			return nil
-		}, retry.Attempts(10), retry.Sleep(3*time.Second))
-		if err != nil {
+	fileResourceIds, err := t.Core.validateAnalyzerInfos(ctx, analyzerInfos)
+	if err != nil {
+		return err
+	}
+	schema.FileResourceIds = fileResourceIds
+
+	// Bind file resources to collection lifecycle: refCnt++ now, refCnt-- on
+	// drop. Under ddLock, atomic with RemoveFileResource. See #48612.
+	if len(schema.FileResourceIds) > 0 {
+		if err := t.meta.IncFileResourceRefCnt(schema.FileResourceIds); err != nil {
 			return err
 		}
-
-		resp, err := t.mixCoord.ValidateAnalyzer(t.ctx, &querypb.ValidateAnalyzerRequest{
-			AnalyzerInfos: analyzerInfos,
-		})
-		if err != nil {
-			return err
-		}
-
-		if err := merr.Error(resp.GetStatus()); err != nil {
-			return err
-		}
-		schema.FileResourceIds = resp.GetResourceIds()
-
-		// Bind file resources to collection lifecycle: refCnt++ now, refCnt-- on
-		// drop. Under ddLock, atomic with RemoveFileResource. See #48612.
-		if len(schema.FileResourceIds) > 0 {
-			if err := t.meta.IncFileResourceRefCnt(schema.FileResourceIds); err != nil {
-				return err
-			}
-			t.heldFileResourceIds = schema.FileResourceIds
-		}
+		t.heldFileResourceIds = schema.FileResourceIds
 	}
 
 	return validateFieldDataType(schema.GetFields())
+}
+
+func (c *Core) validateAnalyzerInfos(ctx context.Context, analyzerInfos []*querypb.AnalyzerInfo) ([]int64, error) {
+	if len(analyzerInfos) == 0 {
+		return nil, nil
+	}
+
+	// validate analyzer params at any streaming node
+	// and set file resource ids to schema
+	err := retry.Do(ctx, func() error {
+		if c.fileResourceObserver == nil {
+			return nil
+		}
+		if err := c.fileResourceObserver.CheckAllQnReady(); err != nil {
+			return err
+		}
+		return nil
+	}, retry.Attempts(10), retry.Sleep(3*time.Second))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.mixCoord.ValidateAnalyzer(ctx, &querypb.ValidateAnalyzerRequest{
+		AnalyzerInfos: analyzerInfos,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := merr.Error(resp.GetStatus()); err != nil {
+		return nil, err
+	}
+	return resp.GetResourceIds(), nil
 }
 
 func (t *createCollectionTask) assignFieldAndFunctionID(schema *schemapb.CollectionSchema) error {
@@ -922,14 +932,36 @@ func validateMultiAnalyzerParams(params string, coll *schemapb.CollectionSchema,
 	return nil
 }
 
+func collectAnalyzerInfosForAlter(collSchema *schemapb.CollectionSchema) ([]*querypb.AnalyzerInfo, error) {
+	analyzerInfos := make([]*querypb.AnalyzerInfo, 0)
+	for _, field := range collSchema.GetFields() {
+		if err := validateAnalyzerWithInactive(collSchema, field, &analyzerInfos); err != nil {
+			return nil, err
+		}
+	}
+	return analyzerInfos, nil
+}
+
 func validateAnalyzer(collSchema *schemapb.CollectionSchema, fieldSchema *schemapb.FieldSchema, analyzerInfos *[]*querypb.AnalyzerInfo) error {
+	return validateAnalyzerInternal(collSchema, fieldSchema, analyzerInfos, false)
+}
+
+func validateAnalyzerWithInactive(collSchema *schemapb.CollectionSchema, fieldSchema *schemapb.FieldSchema, analyzerInfos *[]*querypb.AnalyzerInfo) error {
+	return validateAnalyzerInternal(collSchema, fieldSchema, analyzerInfos, true)
+}
+
+func validateAnalyzerInternal(collSchema *schemapb.CollectionSchema, fieldSchema *schemapb.FieldSchema, analyzerInfos *[]*querypb.AnalyzerInfo, validateInactive bool) error {
 	h := typeutil.CreateFieldSchemaHelper(fieldSchema)
-	if !h.EnableMatch() && !typeutil.IsBm25FunctionInputField(collSchema, fieldSchema) {
+	active := h.EnableMatch() || typeutil.IsBm25FunctionInputField(collSchema, fieldSchema)
+	if !active && !validateInactive {
 		return nil
 	}
 
-	if !h.EnableAnalyzer() {
+	if active && !h.EnableAnalyzer() {
 		return merr.WrapErrParameterInvalidMsg("field %s which has enable_match or is input of BM25 function must also enable_analyzer", fieldSchema.Name)
+	}
+	if !h.EnableAnalyzer() {
+		return nil
 	}
 
 	if params, ok := h.GetMultiAnalyzerParams(); ok {

--- a/internal/rootcoord/create_collection_task_test.go
+++ b/internal/rootcoord/create_collection_task_test.go
@@ -46,6 +46,21 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
+func TestCreateCollectionTaskReleaseFileResources(t *testing.T) {
+	meta := mockrootcoord.NewIMetaTable(t)
+	heldIDs := []int64{10, 20}
+	meta.EXPECT().DecFileResourceRefCnt(heldIDs).Once()
+
+	task := &createCollectionTask{
+		Core:                &Core{meta: meta},
+		heldFileResourceIds: heldIDs,
+	}
+
+	task.releaseFileResources()
+	require.Nil(t, task.heldFileResourceIds)
+	task.releaseFileResources()
+}
+
 func Test_createCollectionTask_validate(t *testing.T) {
 	paramtable.Init()
 	t.Run("empty request", func(t *testing.T) {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_field.go
@@ -2,17 +2,69 @@ package rootcoord
 
 import (
 	"context"
+	"strconv"
 
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
+
+func hasAnalyzerFieldParamMutation(req *milvuspb.AlterCollectionFieldRequest) bool {
+	for _, prop := range req.GetProperties() {
+		if prop.GetKey() == common.EnableAnalyzerKey || prop.GetKey() == common.AnalyzerParamKey {
+			return true
+		}
+	}
+	for _, key := range req.GetDeleteKeys() {
+		if key == common.EnableAnalyzerKey || key == common.AnalyzerParamKey {
+			return true
+		}
+	}
+	return false
+}
+
+func validateAlterCollectionFieldAnalyzerParams(req *milvuspb.AlterCollectionFieldRequest) error {
+	for _, prop := range req.GetProperties() {
+		if prop.GetKey() != common.EnableAnalyzerKey {
+			continue
+		}
+		if _, err := strconv.ParseBool(prop.GetValue()); err != nil {
+			return merr.WrapErrParameterInvalidMsg("%s should be a boolean, but got %s", prop.GetKey(), prop.GetValue())
+		}
+	}
+	return nil
+}
+
+func getAlterCollectionField(schema *schemapb.CollectionSchema, fieldName string) *schemapb.FieldSchema {
+	for _, field := range schema.GetFields() {
+		if field.GetName() == fieldName {
+			return field
+		}
+	}
+	return nil
+}
+
+func validateAlterCollectionFieldAnalyzerMutation(schema *schemapb.CollectionSchema, fieldName string) error {
+	field := getAlterCollectionField(schema, fieldName)
+	if field == nil {
+		return merr.WrapErrParameterInvalidMsg("field not found: %s", fieldName)
+	}
+	if typeutil.CreateFieldSchemaHelper(field).EnableMatch() || typeutil.IsBm25FunctionInputField(schema, field) {
+		return merr.WrapErrParameterInvalidMsg(
+			"can not alter analyzer params for field %s after text match is enabled or BM25 function depends on it",
+			fieldName,
+		)
+	}
+	return nil
+}
 
 func (c *Core) broadcastAlterCollectionV2ForAlterCollectionField(ctx context.Context, req *milvuspb.AlterCollectionFieldRequest) error {
 	broadcaster, err := c.startBroadcastWithAliasOrCollectionLock(ctx, req.GetDbName(), req.GetCollectionName())
@@ -66,6 +118,30 @@ func (c *Core) broadcastAlterCollectionV2ForAlterCollectionField(ctx context.Con
 	cacheExpirations, err := c.getCacheExpireForCollection(ctx, req.GetDbName(), req.GetCollectionName())
 	if err != nil {
 		return err
+	}
+
+	if hasAnalyzerFieldParamMutation(req) {
+		if err := validateAlterCollectionFieldAnalyzerParams(req); err != nil {
+			return err
+		}
+		if err := validateAlterCollectionFieldAnalyzerMutation(schema, req.GetFieldName()); err != nil {
+			return err
+		}
+		analyzerInfos, err := collectAnalyzerInfosForAlter(schema)
+		if err != nil {
+			return err
+		}
+		fileResourceIds, err := c.validateAnalyzerInfos(ctx, analyzerInfos)
+		if err != nil {
+			return err
+		}
+		schema.FileResourceIds = fileResourceIds
+		addedFileResourceIds, _ := diffFileResourceIDs(coll.FileResourceIds, schema.FileResourceIds)
+		if len(addedFileResourceIds) > 0 {
+			if err := c.meta.IncFileResourceRefCnt(addedFileResourceIds); err != nil {
+				return err
+			}
+		}
 	}
 
 	header := &messagespb.AlterCollectionMessageHeader{

--- a/internal/rootcoord/ddl_callbacks_alter_collection_field.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_field.go
@@ -57,6 +57,9 @@ func validateAlterCollectionFieldAnalyzerMutation(schema *schemapb.CollectionSch
 	if field == nil {
 		return merr.WrapErrParameterInvalidMsg("field not found: %s", fieldName)
 	}
+	if !typeutil.IsStringType(field.GetDataType()) {
+		return merr.WrapErrParameterInvalidMsg("can not alter analyzer params for non-string field %s", fieldName)
+	}
 	if typeutil.CreateFieldSchemaHelper(field).EnableMatch() || typeutil.IsBm25FunctionInputField(schema, field) {
 		return merr.WrapErrParameterInvalidMsg(
 			"can not alter analyzer params for field %s after text match is enabled or BM25 function depends on it",
@@ -120,28 +123,19 @@ func (c *Core) broadcastAlterCollectionV2ForAlterCollectionField(ctx context.Con
 		return err
 	}
 
-	if hasAnalyzerFieldParamMutation(req) {
+	analyzerFieldParamMutated := hasAnalyzerFieldParamMutation(req)
+	if analyzerFieldParamMutated {
 		if err := validateAlterCollectionFieldAnalyzerParams(req); err != nil {
 			return err
 		}
 		if err := validateAlterCollectionFieldAnalyzerMutation(schema, req.GetFieldName()); err != nil {
 			return err
 		}
-		analyzerInfos, err := collectAnalyzerInfosForAlter(schema)
-		if err != nil {
-			return err
-		}
-		fileResourceIds, err := c.validateAnalyzerInfos(ctx, analyzerInfos)
+		fileResourceIds, err := c.validateSchemaAnalyzerFileResources(ctx, schema, includeInactiveAnalyzer)
 		if err != nil {
 			return err
 		}
 		schema.FileResourceIds = fileResourceIds
-		addedFileResourceIds, _ := diffFileResourceIDs(coll.FileResourceIds, schema.FileResourceIds)
-		if len(addedFileResourceIds) > 0 {
-			if err := c.meta.IncFileResourceRefCnt(addedFileResourceIds); err != nil {
-				return err
-			}
-		}
 	}
 
 	header := &messagespb.AlterCollectionMessageHeader{
@@ -166,7 +160,19 @@ func (c *Core) broadcastAlterCollectionV2ForAlterCollectionField(ctx context.Con
 		WithBody(body).
 		WithBroadcast(channels).
 		MustBuildBroadcast()
+	if analyzerFieldParamMutated {
+		addedFileResourceIds, _ := diffFileResourceIDs(coll.FileResourceIds, schema.FileResourceIds)
+		// Reserve newly referenced file resources immediately before handing the
+		// message to the broadcaster. MetaTable.AlterCollection consumes the
+		// reservation when the schema is applied; replay/replicated tasks without
+		// a local reservation add the refCnt there.
+		if err := reserveAlterCollectionFileResourceRefs(c.meta, coll.CollectionID, addedFileResourceIds); err != nil {
+			return err
+		}
+	}
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
+		// Same as create collection: once Broadcast is called, the task may
+		// already be pending and recovery will hold the reservation until apply.
 		return err
 	}
 	return nil

--- a/internal/rootcoord/ddl_callbacks_alter_collection_field_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_field_test.go
@@ -20,10 +20,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
+	"github.com/milvus-io/milvus/internal/mocks"
+	"github.com/milvus-io/milvus/pkg/v3/common"
+	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -123,6 +130,114 @@ func TestDDLCallbacksAlterCollectionField(t *testing.T) {
 	assertFieldProperties(t, ctx, core, dbName, collectionName, fieldName, "key1", "value1")
 	assertFieldPropertiesNotFound(t, ctx, core, dbName, collectionName, fieldName, "key2")
 	assertSchemaVersion(t, ctx, core, dbName, collectionName, 3)
+}
+
+func TestDDLCallbacksAlterCollectionFieldAnalyzerValidation(t *testing.T) {
+	core := initStreamingSystemAndCore(t)
+
+	ctx := context.Background()
+	dbName := "testDB" + funcutil.RandomString(10)
+	collectionName := "testCollection" + funcutil.RandomString(10)
+	fieldName := "text"
+
+	resp, err := core.CreateDatabase(ctx, &milvuspb.CreateDatabaseRequest{
+		DbName: dbName,
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	testSchema := &schemapb.CollectionSchema{
+		Name: collectionName,
+		Fields: []*schemapb.FieldSchema{
+			{
+				Name:       fieldName,
+				DataType:   schemapb.DataType_VarChar,
+				TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "128"}},
+			},
+		},
+	}
+	schemaBytes, err := proto.Marshal(testSchema)
+	require.NoError(t, err)
+	resp, err = core.CreateCollection(ctx, &milvuspb.CreateCollectionRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		Schema:         schemaBytes,
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+
+	meta := core.meta.(*MetaTable)
+	resourceID := int64(10001)
+	meta.fileResourceName2Meta = map[string]*internalpb.FileResourceInfo{
+		"dict": {Id: resourceID, Name: "dict", Path: "dict.txt"},
+	}
+	meta.fileResourceID2Meta = map[int64]*internalpb.FileResourceInfo{
+		resourceID: {Id: resourceID, Name: "dict", Path: "dict.txt"},
+	}
+	meta.fileResourceRefCnt = map[int64]int{}
+
+	mixCoord := core.mixCoord.(*mocks.MixCoord)
+	mixCoord.EXPECT().ValidateAnalyzer(mock.Anything, mock.MatchedBy(func(req *querypb.ValidateAnalyzerRequest) bool {
+		infos := req.GetAnalyzerInfos()
+		return len(infos) == 1 &&
+			infos[0].GetField() == fieldName &&
+			infos[0].GetParams() == `{"tokenizer":"standard"}`
+	})).Return(&querypb.ValidateAnalyzerResponse{
+		Status:      merr.Success(),
+		ResourceIds: []int64{resourceID},
+	}, nil).Once()
+
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
+		},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	coll, err := core.meta.GetCollectionByName(ctx, dbName, collectionName, typeutil.MaxTimestamp, false)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []int64{resourceID}, coll.FileResourceIds)
+	require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+	assertFieldProperties(t, ctx, core, dbName, collectionName, fieldName, common.AnalyzerParamKey, `{"tokenizer":"standard"}`)
+
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.EnableAnalyzerKey, Value: "not-bool"},
+		},
+	})
+	require.Error(t, merr.CheckRPCCall(resp, err))
+	require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+
+	mixCoord.EXPECT().ValidateAnalyzer(mock.Anything, mock.Anything).Return(&querypb.ValidateAnalyzerResponse{
+		Status: merr.Status(merr.WrapErrParameterInvalidMsg("bad analyzer")),
+	}, nil).Once()
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"bad"}`},
+		},
+	})
+	require.Error(t, merr.CheckRPCCall(resp, err))
+	assertFieldProperties(t, ctx, core, dbName, collectionName, fieldName, common.AnalyzerParamKey, `{"tokenizer":"standard"}`)
+	require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      fieldName,
+		DeleteKeys:     []string{common.AnalyzerParamKey},
+	})
+	require.NoError(t, merr.CheckRPCCall(resp, err))
+	coll, err = core.meta.GetCollectionByName(ctx, dbName, collectionName, typeutil.MaxTimestamp, false)
+	require.NoError(t, err)
+	require.Empty(t, coll.FileResourceIds)
+	require.Equal(t, 0, meta.fileResourceRefCnt[resourceID])
+	assertFieldPropertiesNotFound(t, ctx, core, dbName, collectionName, fieldName, common.AnalyzerParamKey)
 }
 
 func assertFieldPropertiesNotFound(t *testing.T, ctx context.Context, core *Core, dbName string, collectionName string, fieldName string, key string) {

--- a/internal/rootcoord/ddl_callbacks_alter_collection_field_test.go
+++ b/internal/rootcoord/ddl_callbacks_alter_collection_field_test.go
@@ -139,6 +139,7 @@ func TestDDLCallbacksAlterCollectionFieldAnalyzerValidation(t *testing.T) {
 	dbName := "testDB" + funcutil.RandomString(10)
 	collectionName := "testCollection" + funcutil.RandomString(10)
 	fieldName := "text"
+	intFieldName := "count"
 
 	resp, err := core.CreateDatabase(ctx, &milvuspb.CreateDatabaseRequest{
 		DbName: dbName,
@@ -151,6 +152,10 @@ func TestDDLCallbacksAlterCollectionFieldAnalyzerValidation(t *testing.T) {
 				Name:       fieldName,
 				DataType:   schemapb.DataType_VarChar,
 				TypeParams: []*commonpb.KeyValuePair{{Key: common.MaxLengthKey, Value: "128"}},
+			},
+			{
+				Name:     intFieldName,
+				DataType: schemapb.DataType_Int64,
 			},
 		},
 	}
@@ -206,6 +211,18 @@ func TestDDLCallbacksAlterCollectionFieldAnalyzerValidation(t *testing.T) {
 		FieldName:      fieldName,
 		Properties: []*commonpb.KeyValuePair{
 			{Key: common.EnableAnalyzerKey, Value: "not-bool"},
+		},
+	})
+	require.Error(t, merr.CheckRPCCall(resp, err))
+	require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+
+	resp, err = core.AlterCollectionField(ctx, &milvuspb.AlterCollectionFieldRequest{
+		DbName:         dbName,
+		CollectionName: collectionName,
+		FieldName:      intFieldName,
+		Properties: []*commonpb.KeyValuePair{
+			{Key: common.EnableAnalyzerKey, Value: "true"},
+			{Key: common.AnalyzerParamKey, Value: `{"tokenizer":"standard"}`},
 		},
 	})
 	require.Error(t, merr.CheckRPCCall(resp, err))

--- a/internal/rootcoord/ddl_callbacks_create_collection.go
+++ b/internal/rootcoord/ddl_callbacks_create_collection.go
@@ -26,6 +26,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/metastore/model"
+	streamingbroadcaster "github.com/milvus-io/milvus/internal/streamingcoord/server/broadcaster"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
@@ -94,9 +95,9 @@ func (c *Core) broadcastCreateCollectionV1(ctx context.Context, req *milvuspb.Cr
 		WithBroadcast(broadcastChannel).
 		MustBuildBroadcast()
 	if _, err := broadcaster.Broadcast(ctx, msg); err != nil {
-		// Do NOT release file resources here: the broadcast task is already in the
-		// scheduler and will retry until success. refCnt will be decremented when
-		// the collection is eventually dropped.
+		if streamingbroadcaster.IsBroadcastTaskNotCreated(err) {
+			createCollectionTask.releaseFileResources()
+		}
 		return err
 	}
 	return nil

--- a/internal/rootcoord/file_resource_ref.go
+++ b/internal/rootcoord/file_resource_ref.go
@@ -16,6 +16,13 @@
 
 package rootcoord
 
+import (
+	"context"
+
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+)
+
 func diffFileResourceIDs(oldIDs []int64, newIDs []int64) ([]int64, []int64) {
 	oldSet := make(map[int64]struct{}, len(oldIDs))
 	for _, id := range oldIDs {
@@ -27,16 +34,119 @@ func diffFileResourceIDs(oldIDs []int64, newIDs []int64) ([]int64, []int64) {
 	}
 
 	added := make([]int64, 0)
+	addedSet := make(map[int64]struct{}, len(newIDs))
 	for _, id := range newIDs {
-		if _, ok := oldSet[id]; !ok {
+		if _, ok := oldSet[id]; ok {
+			continue
+		}
+		if _, ok := addedSet[id]; !ok {
 			added = append(added, id)
+			addedSet[id] = struct{}{}
 		}
 	}
 	removed := make([]int64, 0)
+	removedSet := make(map[int64]struct{}, len(oldIDs))
 	for _, id := range oldIDs {
-		if _, ok := newSet[id]; !ok {
+		if _, ok := newSet[id]; ok {
+			continue
+		}
+		if _, ok := removedSet[id]; !ok {
 			removed = append(removed, id)
+			removedSet[id] = struct{}{}
 		}
 	}
 	return added, removed
+}
+
+func (mt *MetaTable) validateAddedFileResourceRefsLocked(collectionID int64, addedIDs []int64) error {
+	for _, id := range addedIDs {
+		if _, ok := mt.fileResourceID2Meta[id]; !ok {
+			return merr.WrapErrServiceInternalMsg("collection %d references missing file resource %d", collectionID, id)
+		}
+	}
+	return nil
+}
+
+type alterCollectionFileResourceRefReserver interface {
+	reserveAlterCollectionFileResourceRefs(collectionID int64, ids []int64) error
+}
+
+func reserveFileResourceRefs(meta IMetaTable, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	return meta.IncFileResourceRefCnt(ids)
+}
+
+func reserveAlterCollectionFileResourceRefs(meta IMetaTable, collectionID int64, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if reserver, ok := meta.(alterCollectionFileResourceRefReserver); ok {
+		return reserver.reserveAlterCollectionFileResourceRefs(collectionID, ids)
+	}
+	return reserveFileResourceRefs(meta, ids)
+}
+
+func (mt *MetaTable) reserveAlterCollectionFileResourceRefs(collectionID int64, ids []int64) error {
+	mt.ddLock.Lock()
+	defer mt.ddLock.Unlock()
+	if err := mt.incFileResourceRefCntLocked(ids); err != nil {
+		return err
+	}
+	mt.recordFileResourceRefHoldLocked(collectionID, ids)
+	return nil
+}
+
+func (mt *MetaTable) recordFileResourceRefHoldLocked(collectionID int64, ids []int64) {
+	if len(ids) == 0 {
+		return
+	}
+	if mt.fileResourceRefHolds == nil {
+		mt.fileResourceRefHolds = make(map[int64]map[int64]int)
+	}
+	holds := mt.fileResourceRefHolds[collectionID]
+	if holds == nil {
+		holds = make(map[int64]int, len(ids))
+		mt.fileResourceRefHolds[collectionID] = holds
+	}
+	for _, id := range ids {
+		holds[id]++
+	}
+}
+
+func (mt *MetaTable) consumeFileResourceRefHoldLocked(collectionID int64, resourceID int64) bool {
+	holds := mt.fileResourceRefHolds[collectionID]
+	if holds == nil || holds[resourceID] == 0 {
+		return false
+	}
+	holds[resourceID]--
+	if holds[resourceID] == 0 {
+		delete(holds, resourceID)
+	}
+	if len(holds) == 0 {
+		delete(mt.fileResourceRefHolds, collectionID)
+	}
+	return true
+}
+
+func (mt *MetaTable) applyAlterCollectionFileResourceRefCntLocked(ctx context.Context, collectionID int64, addedIDs, removedIDs []int64) {
+	for _, id := range addedIDs {
+		if mt.consumeFileResourceRefHoldLocked(collectionID, id) {
+			// A request-path reservation already incremented the effective refCnt.
+			// Keep the count unchanged; updating collID2Meta below turns it into a
+			// committed collection reference. WAL replay/replicated tasks have no
+			// reservation for this collection, so they fall through and increment here.
+			continue
+		}
+		mt.fileResourceRefCnt[id]++
+	}
+	for _, id := range removedIDs {
+		if mt.fileResourceRefCnt[id] > 0 {
+			mt.fileResourceRefCnt[id]--
+		} else {
+			mlog.Warn(ctx, "AlterCollection: file resource refCnt underflow",
+				mlog.Int64("collectionID", collectionID), mlog.Int64("fileResourceID", id))
+		}
+	}
 }

--- a/internal/rootcoord/file_resource_ref.go
+++ b/internal/rootcoord/file_resource_ref.go
@@ -1,0 +1,42 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootcoord
+
+func diffFileResourceIDs(oldIDs []int64, newIDs []int64) ([]int64, []int64) {
+	oldSet := make(map[int64]struct{}, len(oldIDs))
+	for _, id := range oldIDs {
+		oldSet[id] = struct{}{}
+	}
+	newSet := make(map[int64]struct{}, len(newIDs))
+	for _, id := range newIDs {
+		newSet[id] = struct{}{}
+	}
+
+	added := make([]int64, 0)
+	for _, id := range newIDs {
+		if _, ok := oldSet[id]; !ok {
+			added = append(added, id)
+		}
+	}
+	removed := make([]int64, 0)
+	for _, id := range oldIDs {
+		if _, ok := newSet[id]; !ok {
+			removed = append(removed, id)
+		}
+	}
+	return added, removed
+}

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -1097,8 +1097,8 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 			if mt.fileResourceRefCnt[fileResourceID] > 0 {
 				mt.fileResourceRefCnt[fileResourceID]--
 			} else {
-				log.Warn("AlterCollection: file resource refCnt underflow",
-					zap.Int64("collectionID", newColl.CollectionID), zap.Int64("fileResourceID", fileResourceID))
+				mlog.Warn(ctx, "AlterCollection: file resource refCnt underflow",
+					mlog.Int64("collectionID", newColl.CollectionID), mlog.Int64("fileResourceID", fileResourceID))
 			}
 		}
 	}

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -1091,6 +1091,18 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 		}
 	}
 
+	if fieldModify {
+		_, removedFileResourceIds := diffFileResourceIDs(oldColl.FileResourceIds, newColl.FileResourceIds)
+		for _, fileResourceID := range removedFileResourceIds {
+			if mt.fileResourceRefCnt[fileResourceID] > 0 {
+				mt.fileResourceRefCnt[fileResourceID]--
+			} else {
+				log.Warn("AlterCollection: file resource refCnt underflow",
+					zap.Int64("collectionID", newColl.CollectionID), zap.Int64("fileResourceID", fileResourceID))
+			}
+		}
+	}
+
 	mt.names.remove(oldColl.DBName, oldColl.Name)
 	mt.names.insert(newColl.DBName, newColl.Name, newColl.CollectionID)
 	mt.collID2Meta[header.CollectionId] = newColl
@@ -2499,16 +2511,24 @@ func (mt *MetaTable) DecFileResourceRefCnt(ids []int64) {
 }
 
 // RecoverFileResourceRefCnt re-increments refCnt for file resources referenced by
-// pending CreateCollection broadcast tasks whose collections have not yet been
-// persisted. Called during startup before rootcoord becomes Healthy.
+// pending schema broadcast tasks. CreateCollection tasks may not have persisted
+// their collections yet; AlterCollection tasks may reference resources that are
+// not in the persisted collection schema yet. Called during startup before
+// rootcoord becomes Healthy.
 func (mt *MetaTable) RecoverFileResourceRefCnt(pendingCollections map[int64][]int64) {
 	mt.ddLock.Lock()
 	defer mt.ddLock.Unlock()
 	for collID, resourceIds := range pendingCollections {
-		if _, exists := mt.collID2Meta[collID]; exists {
-			continue // collection already persisted, reload already counted it
+		existingResourceIDs := map[int64]struct{}{}
+		if coll, exists := mt.collID2Meta[collID]; exists {
+			for _, id := range coll.FileResourceIds {
+				existingResourceIDs[id] = struct{}{}
+			}
 		}
 		for _, id := range resourceIds {
+			if _, exists := existingResourceIDs[id]; exists {
+				continue
+			}
 			if _, ok := mt.fileResourceID2Meta[id]; ok {
 				mt.fileResourceRefCnt[id]++
 			} else {

--- a/internal/rootcoord/meta_table.go
+++ b/internal/rootcoord/meta_table.go
@@ -175,6 +175,7 @@ type MetaTable struct {
 	fileResourceName2Meta map[string]*internalpb.FileResourceInfo // file resource name -> file resource meta
 	fileResourceID2Meta   map[int64]*internalpb.FileResourceInfo  // file resource id -> file resource meta
 	fileResourceRefCnt    map[int64]int                           // file resource id -> reference count
+	fileResourceRefHolds  map[int64]map[int64]int                 // collection id -> file resource id -> pending alter reservation count
 	fileResourceVersion   uint64
 
 	generalCnt int // sum of product of partition number and shard number
@@ -209,6 +210,7 @@ func (mt *MetaTable) reload() error {
 	mt.collID2Meta = make(map[UniqueID]*model.Collection)
 	mt.partitionName2ID = make(map[int64]map[string]int64)
 	mt.fileResourceRefCnt = make(map[int64]int)
+	mt.fileResourceRefHolds = make(map[int64]map[int64]int)
 	mt.names = newNameDb()
 	mt.aliases = newNameDb()
 
@@ -1071,6 +1073,14 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 		}
 	}
 	newColl.UpdateTimestamp = result.GetMaxTimeTick()
+	var addedFileResourceIds []int64
+	var removedFileResourceIds []int64
+	if fieldModify {
+		addedFileResourceIds, removedFileResourceIds = diffFileResourceIDs(oldColl.FileResourceIds, newColl.FileResourceIds)
+		if err := mt.validateAddedFileResourceRefsLocked(newColl.CollectionID, addedFileResourceIds); err != nil {
+			return err
+		}
+	}
 
 	ctx1 := contextutil.WithTenantID(ctx, Params.CommonCfg.ClusterName.GetValue())
 	if !dbChanged {
@@ -1092,15 +1102,7 @@ func (mt *MetaTable) AlterCollection(ctx context.Context, result message.Broadca
 	}
 
 	if fieldModify {
-		_, removedFileResourceIds := diffFileResourceIDs(oldColl.FileResourceIds, newColl.FileResourceIds)
-		for _, fileResourceID := range removedFileResourceIds {
-			if mt.fileResourceRefCnt[fileResourceID] > 0 {
-				mt.fileResourceRefCnt[fileResourceID]--
-			} else {
-				mlog.Warn(ctx, "AlterCollection: file resource refCnt underflow",
-					mlog.Int64("collectionID", newColl.CollectionID), mlog.Int64("fileResourceID", fileResourceID))
-			}
-		}
+		mt.applyAlterCollectionFileResourceRefCntLocked(ctx, oldColl.CollectionID, addedFileResourceIds, removedFileResourceIds)
 	}
 
 	mt.names.remove(oldColl.DBName, oldColl.Name)
@@ -2479,12 +2481,17 @@ func (mt *MetaTable) ListFileResource(ctx context.Context) ([]*internalpb.FileRe
 	return lo.Values(mt.fileResourceID2Meta), mt.fileResourceVersion
 }
 
-// IncFileResourceRefCnt increments refCnt for file resources, binding them to a
-// collection being created. Under ddLock, atomic with RemoveFileResource.
+// IncFileResourceRefCnt increments refCnt for file resources, reserving them for
+// a pending collection schema change. Under ddLock, atomic with
+// RemoveFileResource.
 // Returns error if any resource ID does not exist.
 func (mt *MetaTable) IncFileResourceRefCnt(ids []int64) error {
 	mt.ddLock.Lock()
 	defer mt.ddLock.Unlock()
+	return mt.incFileResourceRefCntLocked(ids)
+}
+
+func (mt *MetaTable) incFileResourceRefCntLocked(ids []int64) error {
 	for _, id := range ids {
 		if _, ok := mt.fileResourceID2Meta[id]; !ok {
 			return merr.WrapErrParameterInvalidMsg("file resource %d not found", id)
@@ -2531,6 +2538,9 @@ func (mt *MetaTable) RecoverFileResourceRefCnt(pendingCollections map[int64][]in
 			}
 			if _, ok := mt.fileResourceID2Meta[id]; ok {
 				mt.fileResourceRefCnt[id]++
+				if _, collectionExists := mt.collID2Meta[collID]; collectionExists {
+					mt.recordFileResourceRefHoldLocked(collID, []int64{id})
+				}
 			} else {
 				mlog.Warn(context.TODO(), "RecoverFileResourceRefCnt: pending task references missing file resource",
 					mlog.Int64("collectionID", collID), mlog.Int64("resourceID", id))

--- a/internal/rootcoord/meta_table_test.go
+++ b/internal/rootcoord/meta_table_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/milvuspb"
@@ -41,6 +42,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	pb "github.com/milvus-io/milvus/pkg/v3/proto/etcdpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
 	"github.com/milvus-io/milvus/pkg/v3/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v3/util"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
@@ -1696,6 +1698,136 @@ func TestMetaTable_DropCollection_GrantCleanup(t *testing.T) {
 		ctx := context.Background()
 		err := meta.DropCollection(ctx, 100, 9999)
 		assert.NoError(t, err)
+	})
+}
+
+func buildAlterCollectionSchemaResult(collectionID int64, schema *schemapb.CollectionSchema, timetick uint64) message.BroadcastResultAlterCollectionMessageV2 {
+	controlChannel := funcutil.GetControlChannel("test")
+	raw := message.NewAlterCollectionMessageBuilderV2().
+		WithHeader(&messagespb.AlterCollectionMessageHeader{
+			CollectionId: collectionID,
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{message.FieldMaskCollectionSchema},
+			},
+		}).
+		WithBody(&messagespb.AlterCollectionMessageBody{
+			Updates: &messagespb.AlterCollectionMessageUpdates{
+				Schema: schema,
+			},
+		}).
+		WithBroadcast([]string{controlChannel}).
+		MustBuildBroadcast()
+	return message.BroadcastResultAlterCollectionMessageV2{
+		Message: message.MustAsBroadcastAlterCollectionMessageV2(raw),
+		Results: map[string]*message.AppendResult{
+			controlChannel: {TimeTick: timetick},
+		},
+	}
+}
+
+func TestMetaTableAlterCollectionFileResourceRefCnt(t *testing.T) {
+	const (
+		collectionID = int64(100)
+		resourceID   = int64(10)
+		oldResource  = int64(20)
+	)
+
+	newMeta := func(oldIDs []int64, refCnt map[int64]int) (*MetaTable, *mocks.RootCoordCatalog) {
+		catalog := mocks.NewRootCoordCatalog(t)
+		meta := &MetaTable{
+			catalog: catalog,
+			names:   newNameDb(),
+			aliases: newNameDb(),
+			collID2Meta: map[typeutil.UniqueID]*model.Collection{
+				collectionID: {
+					CollectionID:    collectionID,
+					Name:            "collection",
+					DBName:          "db",
+					DBID:            1,
+					State:           pb.CollectionState_CollectionCreated,
+					FileResourceIds: oldIDs,
+				},
+			},
+			fileResourceID2Meta: map[int64]*internalpb.FileResourceInfo{
+				resourceID:  {Id: resourceID, Name: "dict", Path: "dict.txt"},
+				oldResource: {Id: oldResource, Name: "old_dict", Path: "old_dict.txt"},
+			},
+			fileResourceRefCnt: refCnt,
+			fileResourceRefHolds: map[int64]map[int64]int{
+				999: {resourceID: 1},
+			},
+		}
+		meta.names.insert("db", "collection", collectionID)
+		return meta, catalog
+	}
+
+	buildSchema := func(ids ...int64) *schemapb.CollectionSchema {
+		return &schemapb.CollectionSchema{
+			Name:            "collection",
+			Version:         2,
+			FileResourceIds: ids,
+		}
+	}
+
+	t.Run("consume request path reservation", func(t *testing.T) {
+		meta, catalog := newMeta(nil, map[int64]int{})
+		require.NoError(t, reserveAlterCollectionFileResourceRefs(meta, collectionID, []int64{resourceID}))
+		catalog.On("AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, true).Return(nil).Once()
+
+		err := meta.AlterCollection(context.Background(), buildAlterCollectionSchemaResult(collectionID, buildSchema(resourceID), 100))
+
+		require.NoError(t, err)
+		require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+		require.ElementsMatch(t, []int64{resourceID}, meta.collID2Meta[collectionID].FileResourceIds)
+	})
+
+	t.Run("replay or replicated task adds refCnt without reservation", func(t *testing.T) {
+		meta, catalog := newMeta(nil, map[int64]int{resourceID: 1})
+		catalog.On("AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, true).Return(nil).Once()
+
+		err := meta.AlterCollection(context.Background(), buildAlterCollectionSchemaResult(collectionID, buildSchema(resourceID), 100))
+
+		require.NoError(t, err)
+		require.Equal(t, 2, meta.fileResourceRefCnt[resourceID])
+		require.ElementsMatch(t, []int64{resourceID}, meta.collID2Meta[collectionID].FileResourceIds)
+		require.Equal(t, 1, meta.fileResourceRefHolds[999][resourceID])
+	})
+
+	t.Run("recovery hold prevents double increment for pending alter", func(t *testing.T) {
+		meta, catalog := newMeta(nil, map[int64]int{})
+		meta.RecoverFileResourceRefCnt(map[int64][]int64{collectionID: []int64{resourceID}})
+		catalog.On("AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, true).Return(nil).Once()
+
+		err := meta.AlterCollection(context.Background(), buildAlterCollectionSchemaResult(collectionID, buildSchema(resourceID), 100))
+
+		require.NoError(t, err)
+		require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+		require.NotContains(t, meta.fileResourceRefHolds, collectionID)
+		require.ElementsMatch(t, []int64{resourceID}, meta.collID2Meta[collectionID].FileResourceIds)
+	})
+
+	t.Run("replace resource decrements removed and consumes added reservation", func(t *testing.T) {
+		meta, catalog := newMeta([]int64{oldResource}, map[int64]int{oldResource: 1})
+		require.NoError(t, reserveAlterCollectionFileResourceRefs(meta, collectionID, []int64{resourceID}))
+		catalog.On("AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, true).Return(nil).Once()
+
+		err := meta.AlterCollection(context.Background(), buildAlterCollectionSchemaResult(collectionID, buildSchema(resourceID), 100))
+
+		require.NoError(t, err)
+		require.Equal(t, 0, meta.fileResourceRefCnt[oldResource])
+		require.Equal(t, 1, meta.fileResourceRefCnt[resourceID])
+		require.ElementsMatch(t, []int64{resourceID}, meta.collID2Meta[collectionID].FileResourceIds)
+	})
+
+	t.Run("missing added resource fails before catalog update", func(t *testing.T) {
+		meta, catalog := newMeta(nil, map[int64]int{})
+		delete(meta.fileResourceID2Meta, resourceID)
+
+		err := meta.AlterCollection(context.Background(), buildAlterCollectionSchemaResult(collectionID, buildSchema(resourceID), 100))
+
+		require.Error(t, err)
+		catalog.AssertNotCalled(t, "AlterCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		require.Empty(t, meta.collID2Meta[collectionID].FileResourceIds)
 	})
 }
 

--- a/internal/rootcoord/root_coord.go
+++ b/internal/rootcoord/root_coord.go
@@ -557,7 +557,7 @@ func (c *Core) Init() error {
 
 	c.initOnce.Do(func() {
 		initError = c.initInternal()
-		// Recover file resource refCnt for pending CreateCollection broadcast tasks
+		// Recover file resource refCnt for pending schema broadcast tasks
 		// before registering DDL callbacks, so ack callbacks won't race with recovery.
 		// See #48612.
 		pending := broadcast.GetPendingCreateCollectionResources()

--- a/internal/streamingcoord/server/broadcaster/broadcast/singleton.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast/singleton.go
@@ -61,8 +61,8 @@ func StartBroadcastWithSecondaryClusterResourceKey(ctx context.Context) (broadca
 	return broadcaster.WithSecondaryClusterResourceKey(ctx)
 }
 
-// GetPendingCreateCollectionResources returns pending CreateCollection file resource
-// IDs from the broadcaster. Must be called after Register.
+// GetPendingCreateCollectionResources returns pending schema file resource IDs
+// from the broadcaster. Must be called after Register.
 func GetPendingCreateCollectionResources() map[int64][]int64 {
 	if !singleton.Ready() {
 		return nil

--- a/internal/streamingcoord/server/broadcaster/broadcast_manager.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_manager.go
@@ -384,17 +384,15 @@ func (bm *broadcastTaskManager) GetPendingCreateCollectionResources() map[int64]
 		if task.State() == streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE {
 			continue
 		}
-		switch task.msg.MessageType() {
-		case message.MessageTypeCreateCollection:
+		switch task.msg.MessageTypeWithVersion() {
+		case message.MessageTypeCreateCollectionV1:
 			createMsg, err := message.AsMutableCreateCollectionMessageV1(task.msg)
 			if err != nil {
 				continue
 			}
 			body := createMsg.MustBody()
 			ids := body.CollectionSchema.GetFileResourceIds()
-			if len(ids) > 0 {
-				result[createMsg.Header().CollectionId] = ids
-			}
+			appendPendingFileResourceIDs(result, createMsg.Header().CollectionId, ids)
 		case message.MessageTypeAlterCollectionV2:
 			alterMsg, err := message.AsMutableAlterCollectionMessageV2(task.msg)
 			if err != nil {
@@ -402,12 +400,27 @@ func (bm *broadcastTaskManager) GetPendingCreateCollectionResources() map[int64]
 			}
 			schema := alterMsg.MustBody().GetUpdates().GetSchema()
 			ids := schema.GetFileResourceIds()
-			if len(ids) > 0 {
-				result[alterMsg.Header().CollectionId] = ids
-			}
+			appendPendingFileResourceIDs(result, alterMsg.Header().CollectionId, ids)
 		default:
 			continue
 		}
 	}
 	return result
+}
+
+func appendPendingFileResourceIDs(result map[int64][]int64, collectionID int64, ids []int64) {
+	if len(ids) == 0 {
+		return
+	}
+	seen := make(map[int64]struct{}, len(result[collectionID])+len(ids))
+	for _, id := range result[collectionID] {
+		seen[id] = struct{}{}
+	}
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		result[collectionID] = append(result[collectionID], id)
+		seen[id] = struct{}{}
+	}
 }

--- a/internal/streamingcoord/server/broadcaster/broadcast_manager.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_manager.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/balancer/balance"
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
@@ -212,7 +214,7 @@ func (bm *broadcastTaskManager) appendSharedClusterRK(resourceKeys ...message.Re
 func (bm *broadcastTaskManager) broadcast(ctx context.Context, msg message.BroadcastMutableMessage, broadcastID uint64, guards *lockGuards) (*types.BroadcastAppendResult, error) {
 	if !bm.lifetime.Add(typeutil.LifetimeStateWorking) {
 		guards.Unlock()
-		return nil, status.NewOnShutdownError("broadcaster is closing")
+		return nil, errors.Mark(status.NewOnShutdownError("broadcaster is closing"), ErrBroadcastTaskNotCreated)
 	}
 	defer bm.lifetime.Done()
 

--- a/internal/streamingcoord/server/broadcaster/broadcast_manager.go
+++ b/internal/streamingcoord/server/broadcaster/broadcast_manager.go
@@ -373,8 +373,8 @@ func (bm *broadcastTaskManager) getIncompleteBroadcastTasks() []*broadcastTask {
 }
 
 // GetPendingCreateCollectionResources returns collection ID → file resource IDs
-// for all non-tombstone CreateCollection broadcast tasks. Used during recovery to
-// rebuild file resource refCnt for collections whose AddCollection hasn't run yet.
+// for all non-tombstone schema broadcast tasks. Used during recovery to rebuild
+// file resource refCnt for resources referenced by pending schema changes.
 func (bm *broadcastTaskManager) GetPendingCreateCollectionResources() map[int64][]int64 {
 	bm.mu.Lock()
 	defer bm.mu.Unlock()
@@ -384,17 +384,29 @@ func (bm *broadcastTaskManager) GetPendingCreateCollectionResources() map[int64]
 		if task.State() == streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE {
 			continue
 		}
-		if task.msg.MessageType() != message.MessageTypeCreateCollection {
+		switch task.msg.MessageType() {
+		case message.MessageTypeCreateCollection:
+			createMsg, err := message.AsMutableCreateCollectionMessageV1(task.msg)
+			if err != nil {
+				continue
+			}
+			body := createMsg.MustBody()
+			ids := body.CollectionSchema.GetFileResourceIds()
+			if len(ids) > 0 {
+				result[createMsg.Header().CollectionId] = ids
+			}
+		case message.MessageTypeAlterCollectionV2:
+			alterMsg, err := message.AsMutableAlterCollectionMessageV2(task.msg)
+			if err != nil {
+				continue
+			}
+			schema := alterMsg.MustBody().GetUpdates().GetSchema()
+			ids := schema.GetFileResourceIds()
+			if len(ids) > 0 {
+				result[alterMsg.Header().CollectionId] = ids
+			}
+		default:
 			continue
-		}
-		createMsg, err := message.AsMutableCreateCollectionMessageV1(task.msg)
-		if err != nil {
-			continue
-		}
-		body := createMsg.MustBody()
-		ids := body.CollectionSchema.GetFileResourceIds()
-		if len(ids) > 0 {
-			result[createMsg.Header().CollectionId] = ids
 		}
 	}
 	return result

--- a/internal/streamingcoord/server/broadcaster/broadcaster.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster.go
@@ -12,7 +12,14 @@ import (
 var (
 	ErrNotPrimary   = errors.New("cluster is not primary, cannot do any DDL/DCL")
 	ErrNotSecondary = errors.New("cluster is not secondary, cannot perform force promote")
+
+	// ErrBroadcastTaskNotCreated marks a Broadcast error returned before the task is registered in the manager.
+	ErrBroadcastTaskNotCreated = errors.New("broadcast task not created")
 )
+
+func IsBroadcastTaskNotCreated(err error) bool {
+	return errors.Is(err, ErrBroadcastTaskNotCreated)
+}
 
 type Broadcaster interface {
 	// WithResourceKeys sets the resource keys of the broadcast operation.

--- a/internal/streamingcoord/server/broadcaster/broadcaster.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster.go
@@ -33,8 +33,8 @@ type Broadcaster interface {
 	Ack(ctx context.Context, msg message.ImmutableMessage) error
 
 	// GetPendingCreateCollectionResources returns collection ID → file resource IDs
-	// for all pending CreateCollection broadcast tasks that haven't completed
-	// their ack callback yet. Used during recovery to rebuild file resource refCnt.
+	// for all pending schema broadcast tasks that haven't completed their ack
+	// callback yet. Used during recovery to rebuild file resource refCnt.
 	GetPendingCreateCollectionResources() map[int64][]int64
 
 	// Close closes the broadcaster.

--- a/internal/streamingcoord/server/broadcaster/broadcaster_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_test.go
@@ -416,7 +416,7 @@ func TestGetPendingCreateCollectionResources(t *testing.T) {
 	paramtable.Init()
 
 	metrics := newBroadcasterMetrics()
-	ackScheduler := newAckCallbackScheduler(log.With())
+	ackScheduler := newAckCallbackScheduler(mlog.With())
 
 	createCollectionMsg := func(collectionID int64, fileResourceIDs []int64) message.BroadcastMutableMessage {
 		return message.NewCreateCollectionMessageBuilderV1().

--- a/internal/streamingcoord/server/broadcaster/broadcaster_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingcoord/server/resource"
 	internaltypes "github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/idalloc"
+	streamingstatus "github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
 	"github.com/milvus-io/milvus/pkg/v3/mocks/streaming/util/mock_message"
 	"github.com/milvus-io/milvus/pkg/v3/proto/messagespb"
@@ -230,6 +231,29 @@ func createNewBroadcastMsg(vchannels []string, rks ...message.ResourceKey) messa
 		panic(err)
 	}
 	return msg.OverwriteBroadcastHeader(0, rks...)
+}
+
+func TestBroadcastTaskNotCreatedOnStoppedBroadcaster(t *testing.T) {
+	locker := newResourceKeyLocker()
+	rk := message.NewExclusiveCollectionNameResourceKey("db", "collection")
+	guards := locker.Lock(rk)
+	bm := &broadcastTaskManager{
+		lifetime: typeutil.NewLifetime(),
+		mu:       &sync.Mutex{},
+		tasks:    map[uint64]*broadcastTask{},
+	}
+	bm.lifetime.SetState(typeutil.LifetimeStateStopped)
+
+	_, err := bm.broadcast(context.Background(), createNewBroadcastMsg([]string{"v1"}, rk), 1, guards)
+
+	require.Error(t, err)
+	require.True(t, IsBroadcastTaskNotCreated(err))
+	require.True(t, streamingstatus.AsStreamingError(err).IsOnShutdown())
+	require.Empty(t, bm.tasks)
+
+	nextGuards, lockErr := locker.FastLock(rk)
+	require.NoError(t, lockErr)
+	nextGuards.Unlock()
 }
 
 func createNewBroadcastTask(broadcastID uint64, vchannels []string, rks ...message.ResourceKey) *streamingpb.BroadcastTask {

--- a/internal/streamingcoord/server/broadcaster/broadcaster_test.go
+++ b/internal/streamingcoord/server/broadcaster/broadcaster_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
 	"github.com/milvus-io/milvus/internal/mocks/mock_metastore"
@@ -409,6 +410,62 @@ func TestGetIncompleteBroadcastTasks(t *testing.T) {
 	assert.Contains(t, resultIDs, uint64(2), "REPLICATED task with pending messages should be returned")
 	assert.NotContains(t, resultIDs, uint64(3), "PENDING task with all vchannels acked should not be returned")
 	assert.NotContains(t, resultIDs, uint64(4), "TOMBSTONE task should not be returned")
+}
+
+func TestGetPendingCreateCollectionResources(t *testing.T) {
+	paramtable.Init()
+
+	metrics := newBroadcasterMetrics()
+	ackScheduler := newAckCallbackScheduler(log.With())
+
+	createCollectionMsg := func(collectionID int64, fileResourceIDs []int64) message.BroadcastMutableMessage {
+		return message.NewCreateCollectionMessageBuilderV1().
+			WithHeader(&message.CreateCollectionMessageHeader{
+				CollectionId: collectionID,
+			}).
+			WithBody(&msgpb.CreateCollectionRequest{
+				CollectionSchema: &schemapb.CollectionSchema{
+					FileResourceIds: fileResourceIDs,
+				},
+			}).
+			WithBroadcast([]string{"v1"}).
+			MustBuildBroadcast()
+	}
+	alterCollectionMsg := func(collectionID int64, fileResourceIDs []int64) message.BroadcastMutableMessage {
+		return message.NewAlterCollectionMessageBuilderV2().
+			WithHeader(&message.AlterCollectionMessageHeader{
+				CollectionId: collectionID,
+			}).
+			WithBody(&message.AlterCollectionMessageBody{
+				Updates: &message.AlterCollectionMessageUpdates{
+					Schema: &schemapb.CollectionSchema{
+						FileResourceIds: fileResourceIDs,
+					},
+				},
+			}).
+			WithBroadcast([]string{"v1"}).
+			MustBuildBroadcast()
+	}
+	newTask := func(broadcastID uint64, msg message.BroadcastMutableMessage, state streamingpb.BroadcastTaskState) *broadcastTask {
+		proto := createNewWaitAckBroadcastTaskFromMessage(msg.WithBroadcastID(broadcastID), state, []byte{0x00})
+		return newBroadcastTaskFromProto(proto, metrics, ackScheduler)
+	}
+
+	bm := &broadcastTaskManager{
+		mu: &sync.Mutex{},
+		tasks: map[uint64]*broadcastTask{
+			1: newTask(1, createCollectionMsg(100, []int64{10, 20}), streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING),
+			2: newTask(2, alterCollectionMsg(100, []int64{20, 30}), streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING),
+			3: newTask(3, alterCollectionMsg(200, nil), streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING),
+			4: newTask(4, alterCollectionMsg(300, []int64{40}), streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_TOMBSTONE),
+			5: newTask(5, createNewBroadcastMsg([]string{"v1"}), streamingpb.BroadcastTaskState_BROADCAST_TASK_STATE_PENDING),
+		},
+	}
+
+	result := bm.GetPendingCreateCollectionResources()
+
+	require.Len(t, result, 1)
+	assert.ElementsMatch(t, []int64{10, 20, 30}, result[100])
 }
 
 func TestWithSecondaryClusterResourceKey(t *testing.T) {

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -4031,9 +4031,25 @@ func IsBM25FunctionOutputField(field *schemapb.FieldSchema, collSchema *schemapb
 }
 
 func IsBm25FunctionInputField(coll *schemapb.CollectionSchema, field *schemapb.FieldSchema) bool {
+	if coll == nil || field == nil {
+		return false
+	}
 	for _, fn := range coll.GetFunctions() {
-		if fn.GetType() == schemapb.FunctionType_BM25 && field.GetName() == fn.GetInputFieldNames()[0] {
-			return true
+		if fn.GetType() != schemapb.FunctionType_BM25 {
+			continue
+		}
+		if field.GetFieldID() != 0 && len(fn.GetInputFieldIds()) > 0 {
+			for _, id := range fn.GetInputFieldIds() {
+				if field.GetFieldID() == id {
+					return true
+				}
+			}
+			continue
+		}
+		for _, name := range fn.GetInputFieldNames() {
+			if field.GetName() == name {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/util/typeutil/schema_test.go
+++ b/pkg/util/typeutil/schema_test.go
@@ -4953,7 +4953,28 @@ func TestIsBM25FunctionOutputField(t *testing.T) {
 func TestIsBm25FunctionInputField(t *testing.T) {
 	schema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
-			{Name: "input_field", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "enable_analyzer", Value: "true"}}},
+			{FieldID: 100, Name: "input_field", DataType: schemapb.DataType_VarChar, TypeParams: []*commonpb.KeyValuePair{{Key: "enable_analyzer", Value: "true"}}},
+			{FieldID: 101, Name: "output_field", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+		},
+		Functions: []*schemapb.FunctionSchema{
+			{
+				Name:             "bm25_func",
+				Type:             schemapb.FunctionType_BM25,
+				InputFieldIds:    []int64{100},
+				InputFieldNames:  []string{"input_field"},
+				OutputFieldIds:   []int64{101},
+				OutputFieldNames: []string{"output_field"},
+			},
+		},
+	}
+	assert.True(t, IsBm25FunctionInputField(schema, schema.Fields[0]))
+	assert.False(t, IsBm25FunctionInputField(schema, schema.Fields[1]))
+
+	// CreateCollection validation runs before field IDs are assigned, so the
+	// helper must fall back to input field names when IDs are unavailable.
+	schemaWithoutIds := &schemapb.CollectionSchema{
+		Fields: []*schemapb.FieldSchema{
+			{Name: "input_field", DataType: schemapb.DataType_VarChar},
 			{Name: "output_field", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
 		},
 		Functions: []*schemapb.FunctionSchema{
@@ -4965,28 +4986,32 @@ func TestIsBm25FunctionInputField(t *testing.T) {
 			},
 		},
 	}
-	assert.True(t, IsBm25FunctionInputField(schema, schema.Fields[0]))
-	assert.False(t, IsBm25FunctionInputField(schema, schema.Fields[1]))
+	assert.True(t, IsBm25FunctionInputField(schemaWithoutIds, schemaWithoutIds.Fields[0]))
+	assert.False(t, IsBm25FunctionInputField(schemaWithoutIds, schemaWithoutIds.Fields[1]))
 
 	// Test with multiple functions, only one is BM25
 	multipleSchema := &schemapb.CollectionSchema{
 		Fields: []*schemapb.FieldSchema{
-			{Name: "input_field1", DataType: schemapb.DataType_VarChar},
-			{Name: "input_field2", DataType: schemapb.DataType_VarChar},
-			{Name: "output_field1", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
-			{Name: "output_field2", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true},
+			{FieldID: 100, Name: "input_field1", DataType: schemapb.DataType_VarChar},
+			{FieldID: 101, Name: "input_field2", DataType: schemapb.DataType_VarChar},
+			{FieldID: 102, Name: "output_field1", DataType: schemapb.DataType_SparseFloatVector, IsFunctionOutput: true},
+			{FieldID: 103, Name: "output_field2", DataType: schemapb.DataType_FloatVector, IsFunctionOutput: true},
 		},
 		Functions: []*schemapb.FunctionSchema{
 			{
 				Name:             "bm25_func",
 				Type:             schemapb.FunctionType_BM25,
+				InputFieldIds:    []int64{100},
 				InputFieldNames:  []string{"input_field1"},
+				OutputFieldIds:   []int64{102},
 				OutputFieldNames: []string{"output_field1"},
 			},
 			{
 				Name:             "other_func",
 				Type:             schemapb.FunctionType_Unknown,
+				InputFieldIds:    []int64{101},
 				InputFieldNames:  []string{"input_field2"},
+				OutputFieldIds:   []int64{103},
 				OutputFieldNames: []string{"output_field2"},
 			},
 		},


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus/pull/50492

## Summary
Rollback reserved file resource refCnt when create collection broadcast returns before a broadcast task is registered.