### PR TITLE
fix: propagate unknown for missing nested values

### DIFF
--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -197,7 +197,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
 // For int64_t GetType, uses at_numeric() to extract any JSON number in one
 // parse.  int64 values preserve precision; uint64/double fall back to double.
 // 'cmp' must reference 'json_v' (auto-typed as int64_t or double).
-#define BinaryArithRangeJSONCompareCore(cmp)                                \
+#define BinaryArithRangeJSONCompare(cmp)                                    \
     do {                                                                    \
         for (size_t i = 0; i < size; ++i) {                                 \
             auto offset = i;                                                \
@@ -238,11 +238,6 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
             }                                                               \
         }                                                                   \
     } while (false)
-
-#define BinaryArithRangeJSONCompare(cmp) BinaryArithRangeJSONCompareCore(cmp)
-
-#define BinaryArithRangeJSONCompareNotEqual(cmp) \
-    BinaryArithRangeJSONCompareCore(cmp)
 
 #define BinaryArithRangeJONCompareArrayLength(cmp)              \
     do {                                                        \
@@ -346,27 +341,27 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
             case proto::plan::OpType::NotEqual: {
                 switch (arith_type) {
                     case proto::plan::ArithOpType::Add: {
-                        BinaryArithRangeJSONCompareNotEqual(
-                            json_v + right_operand != val);
+                        BinaryArithRangeJSONCompare(json_v + right_operand !=
+                                                    val);
                         break;
                     }
                     case proto::plan::ArithOpType::Sub: {
-                        BinaryArithRangeJSONCompareNotEqual(
-                            json_v - right_operand != val);
+                        BinaryArithRangeJSONCompare(json_v - right_operand !=
+                                                    val);
                         break;
                     }
                     case proto::plan::ArithOpType::Mul: {
-                        BinaryArithRangeJSONCompareNotEqual(
-                            json_v * right_operand != val);
+                        BinaryArithRangeJSONCompare(json_v * right_operand !=
+                                                    val);
                         break;
                     }
                     case proto::plan::ArithOpType::Div: {
-                        BinaryArithRangeJSONCompareNotEqual(
-                            json_v / right_operand != val);
+                        BinaryArithRangeJSONCompare(json_v / right_operand !=
+                                                    val);
                         break;
                     }
                     case proto::plan::ArithOpType::Mod: {
-                        BinaryArithRangeJSONCompareNotEqual(
+                        BinaryArithRangeJSONCompare(
                             safe_mod(json_v, right_operand) != val);
                         break;
                     }
@@ -376,17 +371,17 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
                         break;
                     }
                     case proto::plan::ArithOpType::BitAnd: {
-                        BinaryArithRangeJSONCompareNotEqual(
+                        BinaryArithRangeJSONCompare(
                             (int64_t(json_v) & int64_t(right_operand)) != val);
                         break;
                     }
                     case proto::plan::ArithOpType::BitOr: {
-                        BinaryArithRangeJSONCompareNotEqual(
+                        BinaryArithRangeJSONCompare(
                             (int64_t(json_v) | int64_t(right_operand)) != val);
                         break;
                     }
                     case proto::plan::ArithOpType::BitXor: {
-                        BinaryArithRangeJSONCompareNotEqual(
+                        BinaryArithRangeJSONCompare(
                             (int64_t(json_v) ^ int64_t(right_operand)) != val);
                         break;
                     }

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -716,8 +716,13 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForArray(
                 valid_res[i] = false;                           \
                 continue;                                       \
             }                                                   \
+            if (index < 0) {                                    \
+                res[i] = false;                                 \
+                continue;                                       \
+            }                                                   \
             if (index >= data[offset].length()) {               \
                 res[i] = false;                                 \
+                valid_res[i] = false;                           \
                 continue;                                       \
             }                                                   \
             auto value = data[offset].get_data<GetType>(index); \

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -197,7 +197,7 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
 // For int64_t GetType, uses at_numeric() to extract any JSON number in one
 // parse.  int64 values preserve precision; uint64/double fall back to double.
 // 'cmp' must reference 'json_v' (auto-typed as int64_t or double).
-#define BinaryArithRangeJSONCompareCore(cmp, error_result)                  \
+#define BinaryArithRangeJSONCompareCore(cmp)                                \
     do {                                                                    \
         for (size_t i = 0; i < size; ++i) {                                 \
             auto offset = i;                                                \
@@ -212,7 +212,8 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
             if constexpr (std::is_same_v<GetType, int64_t>) {               \
                 auto x_num = data[offset].at_numeric(pointer);              \
                 if (x_num.error()) {                                        \
-                    res[i] = (error_result);                                \
+                    res[i] = false;                                         \
+                    valid_res[i] = false;                                   \
                     continue;                                               \
                 }                                                           \
                 auto n = x_num.value();                                     \
@@ -228,7 +229,8 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
             } else {                                                        \
                 auto x = data[offset].template at<GetType>(pointer);        \
                 if (x.error()) {                                            \
-                    res[i] = (error_result);                                \
+                    res[i] = false;                                         \
+                    valid_res[i] = false;                                   \
                     continue;                                               \
                 }                                                           \
                 auto json_v = x.value();                                    \
@@ -237,11 +239,10 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
         }                                                                   \
     } while (false)
 
-#define BinaryArithRangeJSONCompare(cmp) \
-    BinaryArithRangeJSONCompareCore(cmp, false)
+#define BinaryArithRangeJSONCompare(cmp) BinaryArithRangeJSONCompareCore(cmp)
 
 #define BinaryArithRangeJSONCompareNotEqual(cmp) \
-    BinaryArithRangeJSONCompareCore(cmp, true)
+    BinaryArithRangeJSONCompareCore(cmp)
 
 #define BinaryArithRangeJONCompareArrayLength(cmp)              \
     do {                                                        \
@@ -258,9 +259,12 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForJson(
             int array_length = 0;                               \
             auto doc = data[offset].doc();                      \
             auto array = doc.at_pointer(pointer).get_array();   \
-            if (!array.error()) {                               \
-                array_length = array.count_elements();          \
+            if (array.error()) {                                \
+                res[i] = false;                                 \
+                valid_res[i] = false;                           \
+                continue;                                       \
             }                                                   \
+            array_length = array.count_elements();              \
             res[i] = (cmp);                                     \
         }                                                       \
     } while (false)

--- a/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryArithOpEvalRangeExpr.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "common/Array.h"
+#include "common/EasyAssert.h"
 #include "common/Json.h"
 #include "common/Tracer.h"
 #include "common/VectorArray.h"
@@ -711,10 +712,6 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForArray(
                 valid_res[i] = false;                           \
                 continue;                                       \
             }                                                   \
-            if (index < 0) {                                    \
-                res[i] = false;                                 \
-                continue;                                       \
-            }                                                   \
             if (index >= data[offset].length()) {               \
                 res[i] = false;                                 \
                 valid_res[i] = false;                           \
@@ -752,6 +749,10 @@ PhyBinaryArithOpEvalRangeExpr::ExecRangeVisitorImplForArray(
             ValueType val,
             ValueType right_operand,
             int index) {
+        if (arith_type != proto::plan::ArithOpType::ArrayLength) {
+            AssertInfo(index >= 0,
+                       "array arithmetic predicate requires nested path");
+        }
         // If data is nullptr, this chunk was skipped by SkipIndex.
         // Nothing to do here since the caller has already handled valid_res.
         if (data == nullptr) {

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -851,6 +851,8 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForArray(EvalCtx& context) {
             ValueType val1,
             ValueType val2,
             int index) {
+        AssertInfo(index >= 0,
+                   "array element range predicate requires nested path");
         // If data is nullptr, this chunk was skipped by SkipIndex.
         // We only need to update processed_cursor for bitmap_input indexing.
         if (data == nullptr) {

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -220,33 +220,23 @@ struct BinaryRangeElementFuncForArray {
                 res[i] = valid_res[i] = false;
                 continue;
             }
+            if (index < 0) {
+                res[i] = false;
+                continue;
+            }
+            if (index >= src[offset].length()) {
+                res[i] = false;
+                valid_res[i] = false;
+                continue;
+            }
+            auto value = src[offset].get_data<GetType>(index);
             if constexpr (lower_inclusive && upper_inclusive) {
-                if (index >= src[offset].length()) {
-                    res[i] = false;
-                    continue;
-                }
-                auto value = src[offset].get_data<GetType>(index);
                 res[i] = val1 <= value && value <= val2;
             } else if constexpr (lower_inclusive && !upper_inclusive) {
-                if (index >= src[offset].length()) {
-                    res[i] = false;
-                    continue;
-                }
-                auto value = src[offset].get_data<GetType>(index);
                 res[i] = val1 <= value && value < val2;
             } else if constexpr (!lower_inclusive && upper_inclusive) {
-                if (index >= src[offset].length()) {
-                    res[i] = false;
-                    continue;
-                }
-                auto value = src[offset].get_data<GetType>(index);
                 res[i] = val1 < value && value <= val2;
             } else {
-                if (index >= src[offset].length()) {
-                    res[i] = false;
-                    continue;
-                }
-                auto value = src[offset].get_data<GetType>(index);
                 res[i] = val1 < value && value < val2;
             }
         }

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -32,6 +32,7 @@
 #include "bitset/common.h"
 #include "cachinglayer/CacheSlot.h"
 #include "common/Array.h"
+#include "common/EasyAssert.h"
 #include "common/Json.h"
 #include "common/OpContext.h"
 #include "common/Types.h"
@@ -208,6 +209,8 @@ struct BinaryRangeElementFuncForArray {
                size_t start_cursor,
                const int32_t* offsets = nullptr) {
         bool has_bitmap_input = !bitmap_input.empty();
+        AssertInfo(index >= 0,
+                   "array element range predicate requires nested path");
         for (size_t i = 0; i < n; ++i) {
             if (has_bitmap_input && !bitmap_input[i + start_cursor]) {
                 continue;
@@ -218,10 +221,6 @@ struct BinaryRangeElementFuncForArray {
             }
             if (valid_data != nullptr && !valid_data[offset]) {
                 res[i] = valid_res[i] = false;
-                continue;
-            }
-            if (index < 0) {
-                res[i] = false;
                 continue;
             }
             if (index >= src[offset].length()) {

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -2086,9 +2086,10 @@ class SegmentExpr : public Expr {
 
                 if (json_flat_index) {
                     auto index_path = json_flat_index->GetNestedPath();
-                    executor = json_flat_index
-                                   ->template create_executor<IndexInnerType>(
-                                       pointer.substr(index_path.size()));
+                    executor =
+                        json_flat_index
+                            ->template create_executor<IndexInnerType>(
+                                pointer.substr(index_path.size()), false);
                     index_ptr = executor.get();
                 } else {
                     auto json_index =

--- a/internal/core/src/exec/expression/ExprArithOpTest.cpp
+++ b/internal/core/src/exec/expression/ExprArithOpTest.cpp
@@ -1875,6 +1875,111 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRangeJSONFloat) {
         }
     }
 }
+
+TEST_P(ExprTest, TestJsonBinaryArithMissingPathIsUnknown) {
+    auto schema = std::make_shared<Schema>();
+    schema->AddDebugField("fakevec", data_type, 16, metric_type);
+    auto i64_fid = schema->AddDebugField("age64", DataType::INT64);
+    auto json_fid = schema->AddDebugField("json", DataType::JSON);
+    schema->set_primary_field_id(i64_fid);
+
+    auto seg = CreateSealedSegment(schema);
+    std::vector<std::string> json_strs = {
+        R"({"a": 1, "arr": [1]})",
+        R"({"a": 2, "arr": []})",
+        R"({})",
+        R"({"a": "bad", "arr": "bad"})",
+        R"({"a": null, "arr": null})",
+    };
+
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
+    std::vector<milvus::Json> jsons;
+    jsons.reserve(json_strs.size());
+    for (const auto& json_str : json_strs) {
+        jsons.emplace_back(simdjson::padded_string(json_str));
+    }
+    json_field->add_json_data(jsons);
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        1, 1, 1, json_fid.get(), {json_field}, cm);
+    seg->LoadFieldData(load_info);
+
+    auto run_expr = [&](const expr::TypedExprPtr& expr) {
+        auto plan =
+            std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, expr);
+        auto final =
+            ExecuteQueryExpr(plan, seg.get(), json_strs.size(), MAX_TIMESTAMP);
+        EXPECT_EQ(final.size(), json_strs.size());
+
+        milvus::exec::OffsetVector offsets;
+        offsets.reserve(json_strs.size());
+        for (int64_t i = 0; i < static_cast<int64_t>(json_strs.size()); ++i) {
+            offsets.emplace_back(i);
+        }
+        auto col_vec = milvus::test::gen_filter_res(
+            plan.get(), seg.get(), json_strs.size(), MAX_TIMESTAMP, &offsets);
+        BitsetTypeView offset_view(col_vec->GetRawData(), col_vec->size());
+        EXPECT_EQ(offset_view.size(), json_strs.size());
+        std::vector<bool> offset_bits(offset_view.size());
+        for (size_t i = 0; i < offset_view.size(); ++i) {
+            offset_bits[i] = offset_view[i];
+        }
+        return std::pair<BitsetType, std::vector<bool>>(std::move(final),
+                                                        std::move(offset_bits));
+    };
+
+    auto expect_bits = [](const BitsetType& final,
+                          const std::vector<bool>& offset,
+                          const std::vector<bool>& expected) {
+        ASSERT_EQ(final.size(), expected.size());
+        ASSERT_EQ(offset.size(), expected.size());
+        for (size_t i = 0; i < expected.size(); ++i) {
+            EXPECT_EQ(final[i], expected[i]) << "row " << i;
+            EXPECT_EQ(offset[i], expected[i]) << "offset row " << i;
+        }
+    };
+
+    proto::plan::GenericValue two;
+    two.set_int64_val(2);
+    proto::plan::GenericValue one;
+    one.set_int64_val(1);
+    auto not_equal = std::make_shared<expr::BinaryArithOpEvalRangeExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        OpType::NotEqual,
+        ArithOpType::Add,
+        two,
+        one);
+    auto [ne_final, ne_offset] = run_expr(not_equal);
+    expect_bits(ne_final, ne_offset, {false, true, false, false, false});
+
+    auto greater_than = std::make_shared<expr::BinaryArithOpEvalRangeExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        OpType::GreaterThan,
+        ArithOpType::Add,
+        two,
+        one);
+    auto not_greater_than = std::make_shared<expr::LogicalUnaryExpr>(
+        expr::LogicalUnaryExpr::OpType::LogicalNot, greater_than);
+    auto [not_gt_final, not_gt_offset] = run_expr(not_greater_than);
+    expect_bits(
+        not_gt_final, not_gt_offset, {true, false, false, false, false});
+
+    proto::plan::GenericValue zero;
+    zero.set_int64_val(0);
+    auto array_length_equal_zero =
+        std::make_shared<expr::BinaryArithOpEvalRangeExpr>(
+            expr::ColumnInfo(json_fid, DataType::JSON, {"arr"}),
+            OpType::Equal,
+            ArithOpType::ArrayLength,
+            zero,
+            zero);
+    auto [len_final, len_offset] = run_expr(array_length_equal_zero);
+    expect_bits(len_final, len_offset, {false, true, false, false, false});
+}
+
 TEST_P(ExprTest, TestBinaryArithOpEvalRangeJSONFloatNullable) {
     struct Testcase {
         double right_operand;

--- a/internal/core/src/exec/expression/ExprArithOpTest.cpp
+++ b/internal/core/src/exec/expression/ExprArithOpTest.cpp
@@ -1019,8 +1019,8 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRangeJSON) {
                  return (int64_t(val) & 1) != 0;
              }},
             // Bitwise over a non-numeric JSON value: at_numeric() errors, so the
-            // row is treated as non-matching -- EQ yields false, NE yields true
-            // for every row. json["string"] holds a JSON string, never a number.
+            // row is UNKNOWN and therefore does not match either comparison.
+            // json["string"] holds a JSON string, never a number.
             {R"((json["string"] & 1) == 0)",
              [](const milvus::Json&) {
                  // non-numeric -> non-match -> EQ is constant false
@@ -1028,8 +1028,8 @@ TEST_P(ExprTest, TestBinaryArithOpEvalRangeJSON) {
              }},
             {R"((json["string"] & 1) != 0)",
              [](const milvus::Json&) {
-                 // non-numeric -> non-match -> NE is constant true
-                 return true;
+                 // non-numeric -> UNKNOWN -> false
+                 return false;
              }},
             // Test cases for BinaryArithOpEvalRangeExpr GT of various data types
             {R"(json["int"] + 1 > 2)",

--- a/internal/core/src/exec/expression/ExprArrayTest.cpp
+++ b/internal/core/src/exec/expression/ExprArrayTest.cpp
@@ -240,6 +240,60 @@ TEST(Expr, TestArraySubscriptMissingElementIsUnknown) {
     }
 }
 
+TEST(Expr, TestArrayElementPredicateWithoutNestedPathThrows) {
+    auto schema = std::make_shared<Schema>();
+    auto i64_fid = schema->AddDebugField("id", DataType::INT64);
+    auto long_array_fid =
+        schema->AddDebugField("long_array", DataType::ARRAY, DataType::INT64);
+    schema->set_primary_field_id(i64_fid);
+
+    constexpr int N = 2;
+    auto raw_data = DataGen(schema, N, 42, 0, 1, 2);
+    SetInt64ArrayFieldData(raw_data, long_array_fid, {{1, 2}, {3, 4}});
+
+    auto seg = CreateGrowingSegment(schema, empty_index_meta);
+    auto offset = seg->PreInsert(N);
+    seg->Insert(offset,
+                N,
+                raw_data.row_ids_.data(),
+                raw_data.timestamps_.data(),
+                raw_data.raw_);
+    auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
+    ASSERT_NE(seg_promote, nullptr);
+
+    auto whole_array_column =
+        expr::ColumnInfo(long_array_fid, DataType::ARRAY, DataType::INT64);
+    std::vector<proto::plan::GenericValue> term_values{Int64Value(2)};
+    std::vector<std::pair<std::string, expr::TypedExprPtr>> cases = {
+        {"unary",
+         std::make_shared<expr::UnaryRangeFilterExpr>(
+             whole_array_column, proto::plan::OpType::Equal, Int64Value(2))},
+        {"binary_range",
+         std::make_shared<expr::BinaryRangeFilterExpr>(
+             whole_array_column, Int64Value(1), Int64Value(3), false, false)},
+        {"term",
+         std::make_shared<expr::TermFilterExpr>(whole_array_column,
+                                                term_values)},
+        {"arith",
+         std::make_shared<expr::BinaryArithOpEvalRangeExpr>(
+             whole_array_column,
+             proto::plan::OpType::Equal,
+             proto::plan::ArithOpType::Add,
+             Int64Value(3),
+             Int64Value(1))},
+    };
+
+    for (const auto& [name, typed_expr] : cases) {
+        auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                           typed_expr);
+        EXPECT_ANY_THROW({
+            auto vec = milvus::test::gen_filter_res(
+                plan.get(), seg_promote, N, MAX_TIMESTAMP);
+            (void)vec;
+        }) << name;
+    }
+}
+
 TEST(Expr, TestArrayRange) {
     std::vector<std::tuple<std::string,
                            std::string,

--- a/internal/core/src/exec/expression/ExprArrayTest.cpp
+++ b/internal/core/src/exec/expression/ExprArrayTest.cpp
@@ -62,6 +62,184 @@ using namespace milvus;
 using namespace milvus::query;
 using namespace milvus::segcore;
 
+namespace {
+
+proto::plan::GenericValue
+Int64Value(int64_t value) {
+    proto::plan::GenericValue val;
+    val.set_int64_val(value);
+    return val;
+}
+
+void
+SetInt64ArrayFieldData(GeneratedData& raw_data,
+                       FieldId field_id,
+                       const std::vector<std::vector<int64_t>>& rows) {
+    ASSERT_EQ(raw_data.raw_->num_rows(), static_cast<int64_t>(rows.size()));
+    for (int i = 0; i < raw_data.raw_->fields_data_size(); i++) {
+        auto* field_data = raw_data.raw_->mutable_fields_data(i);
+        if (field_data->field_id() != field_id.get()) {
+            continue;
+        }
+
+        auto* arrays =
+            field_data->mutable_scalars()->mutable_array_data()->mutable_data();
+        arrays->Clear();
+        for (const auto& row : rows) {
+            auto* array_data = arrays->Add();
+            array_data->mutable_long_data()->mutable_data()->Add(
+                row.data(), row.data() + row.size());
+        }
+        return;
+    }
+    FAIL() << "field id not found: " << field_id.get();
+}
+
+void
+AssertColumnVector(const ColumnVectorPtr& vec,
+                   const std::vector<bool>& expected_bits,
+                   const std::vector<bool>& expected_valid,
+                   const std::string& label) {
+    ASSERT_EQ(vec->size(), expected_bits.size()) << label;
+    ASSERT_EQ(expected_bits.size(), expected_valid.size()) << label;
+    BitsetTypeView bits(vec->GetRawData(), vec->size());
+    BitsetTypeView valid(vec->GetValidRawData(), vec->size());
+    for (size_t i = 0; i < expected_bits.size(); ++i) {
+        EXPECT_EQ(bits[i], expected_bits[i]) << label << ", row " << i;
+        EXPECT_EQ(valid[i], expected_valid[i]) << label << ", row " << i;
+    }
+}
+
+}  // namespace
+
+TEST(Expr, TestArraySubscriptMissingElementIsUnknown) {
+    auto schema = std::make_shared<Schema>();
+    auto i64_fid = schema->AddDebugField("id", DataType::INT64);
+    auto long_array_fid =
+        schema->AddDebugField("long_array", DataType::ARRAY, DataType::INT64);
+    auto struct_array_fid = schema->AddDebugArrayField(
+        "structA[price_array]", DataType::INT64, false);
+    schema->set_primary_field_id(i64_fid);
+
+    constexpr int N = 3;
+    auto raw_data = DataGen(schema, N, 42, 0, 1, 2);
+    std::vector<std::vector<int64_t>> rows = {{1, 2}, {}, {3}};
+    SetInt64ArrayFieldData(raw_data, long_array_fid, rows);
+    SetInt64ArrayFieldData(raw_data, struct_array_fid, rows);
+
+    auto seg = CreateGrowingSegment(schema, empty_index_meta);
+    auto offset = seg->PreInsert(N);
+    seg->Insert(offset,
+                N,
+                raw_data.row_ids_.data(),
+                raw_data.timestamps_.data(),
+                raw_data.raw_);
+    auto seg_promote = dynamic_cast<SegmentGrowingImpl*>(seg.get());
+    ASSERT_NE(seg_promote, nullptr);
+
+    struct Case {
+        std::string name;
+        milvus::expr::TypedExprPtr expr;
+        std::vector<bool> bits;
+        std::vector<bool> valid;
+        std::vector<bool> not_bits;
+        std::vector<bool> not_valid;
+    };
+
+    auto make_cases = [](const expr::ColumnInfo& column) {
+        std::vector<proto::plan::GenericValue> term_values{Int64Value(2)};
+        return std::vector<Case>{
+            {"equal",
+             std::make_shared<expr::UnaryRangeFilterExpr>(
+                 column, proto::plan::OpType::Equal, Int64Value(2)),
+             {true, false, false},
+             {true, false, false},
+             {false, false, false},
+             {true, false, false}},
+            {"not_equal",
+             std::make_shared<expr::UnaryRangeFilterExpr>(
+                 column, proto::plan::OpType::NotEqual, Int64Value(2)),
+             {false, false, false},
+             {true, false, false},
+             {true, false, false},
+             {true, false, false}},
+            {"binary_range",
+             std::make_shared<expr::BinaryRangeFilterExpr>(
+                 column, Int64Value(1), Int64Value(3), false, false),
+             {true, false, false},
+             {true, false, false},
+             {false, false, false},
+             {true, false, false}},
+            {"term",
+             std::make_shared<expr::TermFilterExpr>(column, term_values),
+             {true, false, false},
+             {true, false, false},
+             {false, false, false},
+             {true, false, false}},
+            {"arith",
+             std::make_shared<expr::BinaryArithOpEvalRangeExpr>(
+                 column,
+                 proto::plan::OpType::Equal,
+                 proto::plan::ArithOpType::Add,
+                 Int64Value(3),
+                 Int64Value(1)),
+             {true, false, false},
+             {true, false, false},
+             {false, false, false},
+             {true, false, false}},
+        };
+    };
+
+    std::vector<std::pair<std::string, FieldId>> fields = {
+        {"array", long_array_fid},
+        {"struct_array", struct_array_fid},
+    };
+    for (const auto& [field_name, field_id] : fields) {
+        auto column =
+            expr::ColumnInfo(field_id, DataType::ARRAY, DataType::INT64, {"1"});
+        for (const auto& testcase : make_cases(column)) {
+            auto plan = std::make_shared<plan::FilterBitsNode>(
+                DEFAULT_PLANNODE_ID, testcase.expr);
+            auto vec = milvus::test::gen_filter_res(
+                plan.get(), seg_promote, N, MAX_TIMESTAMP);
+            AssertColumnVector(vec,
+                               testcase.bits,
+                               testcase.valid,
+                               field_name + " " + testcase.name);
+
+            exec::OffsetVector offsets = {1, 0, 2};
+            auto offset_vec = milvus::test::gen_filter_res(
+                plan.get(), seg_promote, N, MAX_TIMESTAMP, &offsets);
+            AssertColumnVector(
+                offset_vec,
+                {testcase.bits[1], testcase.bits[0], testcase.bits[2]},
+                {testcase.valid[1], testcase.valid[0], testcase.valid[2]},
+                field_name + " " + testcase.name + " offsets");
+
+            auto not_expr = std::make_shared<expr::LogicalUnaryExpr>(
+                expr::LogicalUnaryExpr::OpType::LogicalNot, testcase.expr);
+            auto not_plan = std::make_shared<plan::FilterBitsNode>(
+                DEFAULT_PLANNODE_ID, not_expr);
+            auto not_vec = milvus::test::gen_filter_res(
+                not_plan.get(), seg_promote, N, MAX_TIMESTAMP);
+            AssertColumnVector(not_vec,
+                               testcase.not_bits,
+                               testcase.not_valid,
+                               "not " + field_name + " " + testcase.name);
+
+            auto final =
+                ExecuteQueryExpr(not_plan, seg_promote, N, MAX_TIMESTAMP);
+            ASSERT_EQ(final.size(), N);
+            for (int i = 0; i < N; ++i) {
+                EXPECT_EQ(final[i],
+                          testcase.not_bits[i] && testcase.not_valid[i])
+                    << "not " << field_name << " " << testcase.name << ", row "
+                    << i;
+            }
+        }
+    }
+}
+
 TEST(Expr, TestArrayRange) {
     std::vector<std::tuple<std::string,
                            std::string,

--- a/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonIndexTest.cpp
@@ -242,8 +242,12 @@ TEST(JsonIndexTest, TestJsonNotEqualExpr) {
     using json_index_type = index::JsonInvertedIndex<double>;
     auto json_index = std::unique_ptr<json_index_type>(
         static_cast<json_index_type*>(inv_index.release()));
-    auto json_strs = std::vector<std::string>{
-        R"({"a": 1.0})", R"({"a": "abc"})", R"({"a": 3.0})", R"({"a": null})"};
+    auto json_strs = std::vector<std::string>{R"({"a": 1.0})",
+                                              R"({"a": "abc"})",
+                                              R"({"a": 3.0})",
+                                              R"({"a": null})",
+                                              R"({"b": 2.0})",
+                                              R"({"a": 0.0})"};
     auto json_field =
         std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
     auto json_field2 =
@@ -285,7 +289,28 @@ TEST(JsonIndexTest, TestJsonNotEqualExpr) {
         std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, unary_expr);
     auto final =
         ExecuteQueryExpr(plan, seg.get(), 2 * json_strs.size(), MAX_TIMESTAMP);
-    EXPECT_EQ(final.count(), 2 * json_strs.size() - 2);
+    EXPECT_EQ(final.count(), 4);
+    EXPECT_TRUE(final[2]);
+    EXPECT_TRUE(final[5]);
+    EXPECT_TRUE(final[8]);
+    EXPECT_TRUE(final[11]);
+
+    auto greater_than_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::GreaterThan,
+        val,
+        std::vector<proto::plan::GenericValue>());
+    auto not_greater_than_expr = std::make_shared<expr::LogicalUnaryExpr>(
+        expr::LogicalUnaryExpr::OpType::LogicalNot, greater_than_expr);
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  not_greater_than_expr);
+    final =
+        ExecuteQueryExpr(plan, seg.get(), 2 * json_strs.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(final.count(), 4);
+    EXPECT_TRUE(final[0]);
+    EXPECT_TRUE(final[5]);
+    EXPECT_TRUE(final[6]);
+    EXPECT_TRUE(final[11]);
 }
 
 class JsonIndexExistsTest : public ::testing::TestWithParam<std::string> {};

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -440,8 +440,13 @@ PhyTermFilterExpr::ExecTermArrayFieldInVariable(EvalCtx& context) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
-            if (term_set->Empty() || index >= data[offset].length()) {
+            if (term_set->Empty() || index < 0) {
                 res[i] = false;
+                continue;
+            }
+            if (index >= data[offset].length()) {
+                res[i] = false;
+                valid_res[i] = false;
                 continue;
             }
             if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -424,6 +424,10 @@ PhyTermFilterExpr::ExecTermArrayFieldInVariable(EvalCtx& context) {
             TargetBitmapView valid_res,
             int index,
             const std::shared_ptr<MultiElement>& term_set) {
+        if (!term_set->Empty()) {
+            AssertInfo(index >= 0,
+                       "array element term predicate requires nested path");
+        }
         // If data is nullptr, this chunk was skipped by SkipIndex.
         // We only need to update processed_cursor for bitmap_input indexing.
         if (data == nullptr) {
@@ -440,7 +444,7 @@ PhyTermFilterExpr::ExecTermArrayFieldInVariable(EvalCtx& context) {
                 res[i] = valid_res[i] = false;
                 continue;
             }
-            if (term_set->Empty() || index < 0) {
+            if (term_set->Empty()) {
                 res[i] = false;
                 continue;
             }

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -482,10 +482,6 @@ struct UnaryElementFunc {
         if constexpr (std::is_same_v<GetType, proto::plan::Array>) {         \
             res[i] = false;                                                  \
         } else {                                                             \
-            if (index < 0) {                                                 \
-                res[i] = false;                                              \
-                continue;                                                    \
-            }                                                                \
             if (index >= src[offset].length()) {                             \
                 res[i] = false;                                              \
                 valid_res[i] = false;                                        \
@@ -527,6 +523,10 @@ struct UnaryElementFuncForArray {
                 regex_matcher.emplace(val);
             }
         }
+        if constexpr (!std::is_same_v<GetType, proto::plan::Array>) {
+            AssertInfo(index >= 0,
+                       "array element predicate requires nested path");
+        }
         for (int i = 0; i < size; ++i) {
             auto offset = i;
             if constexpr (filter_type == FilterType::random) {
@@ -543,10 +543,6 @@ struct UnaryElementFuncForArray {
                 if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                     res[i] = src[offset].is_same_array(val);
                 } else {
-                    if (index < 0) {
-                        res[i] = false;
-                        continue;
-                    }
                     if (index >= src[offset].length()) {
                         res[i] = false;
                         valid_res[i] = false;
@@ -560,10 +556,6 @@ struct UnaryElementFuncForArray {
                 if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                     res[i] = !src[offset].is_same_array(val);
                 } else {
-                    if (index < 0) {
-                        res[i] = false;
-                        continue;
-                    }
                     if (index >= src[offset].length()) {
                         res[i] = false;
                         valid_res[i] = false;
@@ -593,10 +585,6 @@ struct UnaryElementFuncForArray {
                 } else if constexpr (std::is_same_v<GetType,
                                                     std::string_view> ||
                                      std::is_same_v<GetType, std::string>) {
-                    if (index < 0) {
-                        res[i] = false;
-                        continue;
-                    }
                     if (index >= src[offset].length()) {
                         res[i] = false;
                         valid_res[i] = false;
@@ -617,10 +605,6 @@ struct UnaryElementFuncForArray {
                 } else if constexpr (std::is_same_v<GetType,
                                                     std::string_view> ||
                                      std::is_same_v<GetType, std::string>) {
-                    if (index < 0) {
-                        res[i] = false;
-                        continue;
-                    }
                     if (index >= src[offset].length()) {
                         res[i] = false;
                         valid_res[i] = false;

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -477,18 +477,23 @@ struct UnaryElementFunc {
     }
 };
 
-#define UnaryArrayCompare(cmp)                                          \
-    do {                                                                \
-        if constexpr (std::is_same_v<GetType, proto::plan::Array>) {    \
-            res[i] = false;                                             \
-        } else {                                                        \
-            if (index >= src[i].length()) {                             \
-                res[i] = false;                                         \
-                continue;                                               \
-            }                                                           \
-            auto array_data = src[i].template get_data<GetType>(index); \
-            res[i] = (cmp);                                             \
-        }                                                               \
+#define UnaryArrayCompare(cmp)                                               \
+    do {                                                                     \
+        if constexpr (std::is_same_v<GetType, proto::plan::Array>) {         \
+            res[i] = false;                                                  \
+        } else {                                                             \
+            if (index < 0) {                                                 \
+                res[i] = false;                                              \
+                continue;                                                    \
+            }                                                                \
+            if (index >= src[offset].length()) {                             \
+                res[i] = false;                                              \
+                valid_res[i] = false;                                        \
+                continue;                                                    \
+            }                                                                \
+            auto array_data = src[offset].template get_data<GetType>(index); \
+            res[i] = (cmp);                                                  \
+        }                                                                    \
     } while (false)
 
 template <typename ValueType, proto::plan::OpType op, FilterType filter_type>
@@ -538,8 +543,13 @@ struct UnaryElementFuncForArray {
                 if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                     res[i] = src[offset].is_same_array(val);
                 } else {
+                    if (index < 0) {
+                        res[i] = false;
+                        continue;
+                    }
                     if (index >= src[offset].length()) {
                         res[i] = false;
+                        valid_res[i] = false;
                         continue;
                     }
                     auto array_data =
@@ -550,8 +560,13 @@ struct UnaryElementFuncForArray {
                 if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                     res[i] = !src[offset].is_same_array(val);
                 } else {
+                    if (index < 0) {
+                        res[i] = false;
+                        continue;
+                    }
                     if (index >= src[offset].length()) {
                         res[i] = false;
+                        valid_res[i] = false;
                         continue;
                     }
                     auto array_data =
@@ -578,8 +593,13 @@ struct UnaryElementFuncForArray {
                 } else if constexpr (std::is_same_v<GetType,
                                                     std::string_view> ||
                                      std::is_same_v<GetType, std::string>) {
+                    if (index < 0) {
+                        res[i] = false;
+                        continue;
+                    }
                     if (index >= src[offset].length()) {
                         res[i] = false;
+                        valid_res[i] = false;
                         continue;
                     }
                     auto array_data =
@@ -597,8 +617,13 @@ struct UnaryElementFuncForArray {
                 } else if constexpr (std::is_same_v<GetType,
                                                     std::string_view> ||
                                      std::is_same_v<GetType, std::string>) {
+                    if (index < 0) {
+                        res[i] = false;
+                        continue;
+                    }
                     if (index >= src[offset].length()) {
                         res[i] = false;
+                        valid_res[i] = false;
                         continue;
                     }
                     auto array_data =

--- a/internal/core/src/index/InvertedIndexTantivy.cpp
+++ b/internal/core/src/index/InvertedIndexTantivy.cpp
@@ -970,6 +970,7 @@ template class InvertedIndexTantivy<int8_t>;
 template class InvertedIndexTantivy<int16_t>;
 template class InvertedIndexTantivy<int32_t>;
 template class InvertedIndexTantivy<int64_t>;
+template class InvertedIndexTantivy<uint64_t>;
 template class InvertedIndexTantivy<float>;
 template class InvertedIndexTantivy<double>;
 template class InvertedIndexTantivy<std::string>;

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -11,9 +11,12 @@
 
 #pragma once
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <type_traits>
+#include <utility>
 #include "common/EasyAssert.h"
 #include "common/JsonCastType.h"
 #include "common/Types.h"
@@ -41,8 +44,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
     In(size_t n, const T* values) override {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::In",
                               tracer::GetRootSpan());
-        TargetBitmap bitset(this->Count());
-        this->wrapper_->json_terms_query(json_path_, values, n, &bitset);
+        auto bitset = TermBitset(n, values);
         return bitset;
     }
 
@@ -62,8 +64,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         const std::function<bool(size_t /* offset */)>& filter) override {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::InApplyFilter",
                               tracer::GetRootSpan());
-        TargetBitmap bitset(this->Count());
-        this->wrapper_->json_terms_query(json_path_, values, n, &bitset);
+        auto bitset = TermBitset(n, values);
         apply_hits_with_filter(bitset, filter);
         return bitset;
     }
@@ -75,8 +76,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         const std::function<void(size_t /* offset */)>& callback) override {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::InApplyCallback",
                               tracer::GetRootSpan());
-        TargetBitmap bitset(this->Count());
-        this->wrapper_->json_terms_query(json_path_, values, n, &bitset);
+        auto bitset = TermBitset(n, values);
         apply_hits_with_callback(bitset, callback);
     }
 
@@ -84,8 +84,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
     NotIn(size_t n, const T* values) override {
         tracer::AutoSpan span("JsonFlatIndexQueryExecutor::NotIn",
                               tracer::GetRootSpan());
-        TargetBitmap bitset(this->Count());
-        this->wrapper_->json_terms_query(json_path_, values, n, &bitset);
+        auto bitset = TermBitset(n, values);
 
         bitset.flip();
 
@@ -139,6 +138,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
                 ThrowInfo(OpTypeInvalid,
                           fmt::format("Invalid OperatorType: {}", op));
         }
+        OrU64Range(bitset, U64RangeForValue(value, op));
         return bitset;
     }
 
@@ -163,6 +163,11 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
                                          lb_inclusive,
                                          ub_inclusive,
                                          &bitset);
+        OrU64Range(bitset,
+                   U64RangeForBounds(lower_bound_value,
+                                     lb_inclusive,
+                                     upper_bound_value,
+                                     ub_inclusive));
         return bitset;
     }
 
@@ -215,7 +220,246 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
                                          &double_bitset);
         bitset |= double_bitset;
 
+        TargetBitmap u64_bitset(this->Count());
+        this->wrapper_->json_range_query(json_path_,
+                                         std::numeric_limits<uint64_t>::min(),
+                                         std::numeric_limits<uint64_t>::max(),
+                                         false,
+                                         false,
+                                         true,
+                                         true,
+                                         &u64_bitset);
+        bitset |= u64_bitset;
+
         return bitset;
+    }
+
+    using U64Range = std::optional<std::pair<uint64_t, uint64_t>>;
+
+    TargetBitmap
+    TermBitset(size_t n, const T* values) {
+        TargetBitmap bitset(this->Count());
+        this->wrapper_->json_terms_query(json_path_, values, n, &bitset);
+        OrU64TermRanges(bitset, n, values);
+        return bitset;
+    }
+
+    void
+    OrU64TermRanges(TargetBitmap& bitset, size_t n, const T* values) {
+        if constexpr (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>) {
+            for (size_t i = 0; i < n; ++i) {
+                auto value = static_cast<double>(values[i]);
+                auto range = DoubleRangeForBounds(value, true, value, true);
+                if (RangeCoveredByExactU64Term(values[i], range)) {
+                    continue;
+                }
+                OrU64Range(bitset, range);
+            }
+        }
+    }
+
+    void
+    OrU64Range(TargetBitmap& bitset, U64Range range) {
+        if (!range.has_value()) {
+            return;
+        }
+        this->wrapper_->json_range_query(json_path_,
+                                         range->first,
+                                         range->second,
+                                         false,
+                                         false,
+                                         true,
+                                         true,
+                                         &bitset);
+    }
+
+    template <typename Predicate>
+    static std::optional<uint64_t>
+    FirstU64Where(Predicate pred) {
+        constexpr auto min = std::numeric_limits<uint64_t>::min();
+        constexpr auto max = std::numeric_limits<uint64_t>::max();
+        if (pred(min)) {
+            return min;
+        }
+        if (!pred(max)) {
+            return std::nullopt;
+        }
+
+        uint64_t low = min;
+        uint64_t high = max;
+        while (low < high) {
+            auto mid = low + (high - low) / 2;
+            if (pred(mid)) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+        return low;
+    }
+
+    template <typename Predicate>
+    static std::optional<uint64_t>
+    LastU64Where(Predicate pred) {
+        constexpr auto min = std::numeric_limits<uint64_t>::min();
+        constexpr auto max = std::numeric_limits<uint64_t>::max();
+        if (!pred(min)) {
+            return std::nullopt;
+        }
+        if (pred(max)) {
+            return max;
+        }
+
+        uint64_t low = min;
+        uint64_t high = max;
+        while (low < high) {
+            auto mid = high - (high - low) / 2;
+            if (pred(mid)) {
+                low = mid;
+            } else {
+                high = mid - 1;
+            }
+        }
+        return low;
+    }
+
+    static U64Range
+    DoubleRangeForValue(double value, OpType op) {
+        if (std::isnan(value)) {
+            return std::nullopt;
+        }
+
+        switch (op) {
+            case OpType::LessThan: {
+                auto upper = LastU64Where([value](uint64_t u) {
+                    return static_cast<double>(u) < value;
+                });
+                if (!upper.has_value()) {
+                    return std::nullopt;
+                }
+                return std::make_pair(std::numeric_limits<uint64_t>::min(),
+                                      *upper);
+            }
+            case OpType::LessEqual: {
+                auto upper = LastU64Where([value](uint64_t u) {
+                    return static_cast<double>(u) <= value;
+                });
+                if (!upper.has_value()) {
+                    return std::nullopt;
+                }
+                return std::make_pair(std::numeric_limits<uint64_t>::min(),
+                                      *upper);
+            }
+            case OpType::GreaterThan: {
+                auto lower = FirstU64Where([value](uint64_t u) {
+                    return static_cast<double>(u) > value;
+                });
+                if (!lower.has_value()) {
+                    return std::nullopt;
+                }
+                return std::make_pair(*lower,
+                                      std::numeric_limits<uint64_t>::max());
+            }
+            case OpType::GreaterEqual: {
+                auto lower = FirstU64Where([value](uint64_t u) {
+                    return static_cast<double>(u) >= value;
+                });
+                if (!lower.has_value()) {
+                    return std::nullopt;
+                }
+                return std::make_pair(*lower,
+                                      std::numeric_limits<uint64_t>::max());
+            }
+            default:
+                ThrowInfo(OpTypeInvalid,
+                          fmt::format("Invalid OperatorType: {}", op));
+        }
+    }
+
+    static U64Range
+    DoubleRangeForBounds(double lower_bound_value,
+                         bool lb_inclusive,
+                         double upper_bound_value,
+                         bool ub_inclusive) {
+        if (std::isnan(lower_bound_value) || std::isnan(upper_bound_value)) {
+            return std::nullopt;
+        }
+
+        auto lower =
+            FirstU64Where([lower_bound_value, lb_inclusive](uint64_t u) {
+                auto value = static_cast<double>(u);
+                return lb_inclusive ? value >= lower_bound_value
+                                    : value > lower_bound_value;
+            });
+        if (!lower.has_value()) {
+            return std::nullopt;
+        }
+
+        auto upper =
+            LastU64Where([upper_bound_value, ub_inclusive](uint64_t u) {
+                auto value = static_cast<double>(u);
+                return ub_inclusive ? value <= upper_bound_value
+                                    : value < upper_bound_value;
+            });
+        if (!upper.has_value() || *lower > *upper) {
+            return std::nullopt;
+        }
+
+        return std::make_pair(*lower, *upper);
+    }
+
+    static bool
+    CanCastDoubleToU64(double value) {
+        return std::isfinite(value) && std::floor(value) == value &&
+               value >= 0 &&
+               static_cast<long double>(value) <=
+                   static_cast<long double>(
+                       std::numeric_limits<uint64_t>::max());
+    }
+
+    static bool
+    RangeCoveredByExactU64Term(T value, const U64Range& range) {
+        if (!range.has_value() || range->first != range->second) {
+            return false;
+        }
+
+        if constexpr (std::is_integral_v<T>) {
+            if constexpr (std::is_signed_v<T>) {
+                return value >= 0 &&
+                       static_cast<uint64_t>(value) == range->first;
+            } else {
+                return static_cast<uint64_t>(value) == range->first;
+            }
+        } else if constexpr (std::is_floating_point_v<T>) {
+            return CanCastDoubleToU64(value) &&
+                   static_cast<uint64_t>(value) == range->first;
+        } else {
+            return false;
+        }
+    }
+
+    static U64Range
+    U64RangeForValue(T value, OpType op) {
+        if constexpr (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>) {
+            return DoubleRangeForValue(static_cast<double>(value), op);
+        } else {
+            return std::nullopt;
+        }
+    }
+
+    static U64Range
+    U64RangeForBounds(T lower_bound_value,
+                      bool lb_inclusive,
+                      T upper_bound_value,
+                      bool ub_inclusive) {
+        if constexpr (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>) {
+            return DoubleRangeForBounds(static_cast<double>(lower_bound_value),
+                                        lb_inclusive,
+                                        static_cast<double>(upper_bound_value),
+                                        ub_inclusive);
+        } else {
+            return std::nullopt;
+        }
     }
 
     TargetBitmap

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -138,6 +138,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
                 ThrowInfo(OpTypeInvalid,
                           fmt::format("Invalid OperatorType: {}", op));
         }
+        OrF64Range(bitset, value, op);
         OrU64Range(bitset, U64RangeForValue(value, op));
         OrI64Range(bitset, I64RangeForValue(value, op));
         return bitset;
@@ -164,6 +165,11 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
                                          lb_inclusive,
                                          ub_inclusive,
                                          &bitset);
+        OrF64Range(bitset,
+                   lower_bound_value,
+                   lb_inclusive,
+                   upper_bound_value,
+                   ub_inclusive);
         OrU64Range(bitset,
                    U64RangeForBounds(lower_bound_value,
                                      lb_inclusive,
@@ -293,6 +299,77 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
                                          true,
                                          true,
                                          &bitset);
+    }
+
+    void
+    OrF64Range(TargetBitmap& bitset, T value, OpType op) {
+        if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+            auto double_value = static_cast<double>(value);
+            switch (op) {
+                case OpType::LessThan: {
+                    this->wrapper_->json_range_query(json_path_,
+                                                     double{},
+                                                     double_value,
+                                                     true,
+                                                     false,
+                                                     false,
+                                                     false,
+                                                     &bitset);
+                } break;
+                case OpType::LessEqual: {
+                    this->wrapper_->json_range_query(json_path_,
+                                                     double{},
+                                                     double_value,
+                                                     true,
+                                                     false,
+                                                     true,
+                                                     false,
+                                                     &bitset);
+                } break;
+                case OpType::GreaterThan: {
+                    this->wrapper_->json_range_query(json_path_,
+                                                     double_value,
+                                                     double{},
+                                                     false,
+                                                     true,
+                                                     false,
+                                                     false,
+                                                     &bitset);
+                } break;
+                case OpType::GreaterEqual: {
+                    this->wrapper_->json_range_query(json_path_,
+                                                     double_value,
+                                                     double{},
+                                                     false,
+                                                     true,
+                                                     true,
+                                                     false,
+                                                     &bitset);
+                } break;
+                default:
+                    ThrowInfo(OpTypeInvalid,
+                              fmt::format("Invalid OperatorType: {}", op));
+            }
+        }
+    }
+
+    void
+    OrF64Range(TargetBitmap& bitset,
+               T lower_bound_value,
+               bool lb_inclusive,
+               T upper_bound_value,
+               bool ub_inclusive) {
+        if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+            this->wrapper_->json_range_query(
+                json_path_,
+                static_cast<double>(lower_bound_value),
+                static_cast<double>(upper_bound_value),
+                false,
+                false,
+                lb_inclusive,
+                ub_inclusive,
+                &bitset);
+        }
     }
 
     template <typename Predicate>
@@ -630,7 +707,9 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
 
     static I64Range
     I64RangeForValue(T value, OpType op) {
-        if constexpr (std::is_floating_point_v<T>) {
+        if constexpr (std::is_floating_point_v<T> ||
+                      (std::is_integral_v<T> && std::is_unsigned_v<T> &&
+                       !std::is_same_v<T, bool>)) {
             return DoubleI64RangeForValue(static_cast<double>(value), op);
         } else {
             return std::nullopt;
@@ -642,7 +721,9 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
                       bool lb_inclusive,
                       T upper_bound_value,
                       bool ub_inclusive) {
-        if constexpr (std::is_floating_point_v<T>) {
+        if constexpr (std::is_floating_point_v<T> ||
+                      (std::is_integral_v<T> && std::is_unsigned_v<T> &&
+                       !std::is_same_v<T, bool>)) {
             return DoubleI64RangeForBounds(
                 static_cast<double>(lower_bound_value),
                 lb_inclusive,

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -11,7 +11,9 @@
 
 #pragma once
 #include <algorithm>
+#include <limits>
 #include <memory>
+#include <type_traits>
 #include "common/EasyAssert.h"
 #include "common/JsonCastType.h"
 #include "common/Types.h"
@@ -28,7 +30,8 @@ template <typename T>
 class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
  public:
     JsonFlatIndexQueryExecutor(std::string& json_path,
-                               const JsonFlatIndex& json_flat_index);
+                               const JsonFlatIndex& json_flat_index,
+                               bool use_comparable_value_mask);
 
     ~JsonFlatIndexQueryExecutor() {
         this->wrapper_ = nullptr;
@@ -91,6 +94,23 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         bitset &= null_bitset;
 
         return bitset;
+    }
+
+    const TargetBitmap
+    IsNull() override {
+        auto bitset = IsNotNull();
+        bitset.flip();
+        return bitset;
+    }
+
+    TargetBitmap
+    IsNotNull() override {
+        tracer::AutoSpan span("JsonFlatIndexQueryExecutor::IsNotNull",
+                              tracer::GetRootSpan());
+        if (!use_comparable_value_mask_) {
+            return InvertedIndexTantivy<T>::IsNotNull();
+        }
+        return ComparableValueBitset();
     }
 
     const TargetBitmap
@@ -169,7 +189,55 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
     }
 
  private:
+    TargetBitmap
+    NumericComparableBitset() {
+        TargetBitmap bitset(this->Count());
+
+        TargetBitmap int_bitset(this->Count());
+        this->wrapper_->json_range_query(json_path_,
+                                         std::numeric_limits<int64_t>::lowest(),
+                                         std::numeric_limits<int64_t>::max(),
+                                         false,
+                                         false,
+                                         true,
+                                         true,
+                                         &int_bitset);
+        bitset |= int_bitset;
+
+        TargetBitmap double_bitset(this->Count());
+        this->wrapper_->json_range_query(json_path_,
+                                         std::numeric_limits<double>::lowest(),
+                                         std::numeric_limits<double>::max(),
+                                         false,
+                                         false,
+                                         true,
+                                         true,
+                                         &double_bitset);
+        bitset |= double_bitset;
+
+        return bitset;
+    }
+
+    TargetBitmap
+    ComparableValueBitset() {
+        TargetBitmap bitset(this->Count());
+        if constexpr (std::is_same_v<T, bool>) {
+            bool values[] = {false, true};
+            this->wrapper_->json_terms_query(json_path_, values, 2, &bitset);
+        } else if constexpr (std::is_integral_v<T>) {
+            bitset = NumericComparableBitset();
+        } else if constexpr (std::is_floating_point_v<T>) {
+            bitset = NumericComparableBitset();
+        } else if constexpr (std::is_same_v<T, std::string>) {
+            this->wrapper_->json_prefix_query(json_path_, "", &bitset);
+        } else {
+            this->wrapper_->json_exist_query(json_path_, &bitset);
+        }
+        return bitset;
+    }
+
     std::string json_path_;
+    bool use_comparable_value_mask_{true};
 };
 
 // JsonFlatIndex is not bound to any specific type,
@@ -198,15 +266,16 @@ class JsonFlatIndex : public InvertedIndexTantivy<std::string> {
 
     template <typename T>
     std::shared_ptr<JsonFlatIndexQueryExecutor<T>>
-    create_executor(std::string json_path) const {
+    create_executor(std::string json_path,
+                    bool use_comparable_value_mask = true) const {
         // json path should be in the format of /a/b/c, we need to convert it to tantivy path like a.b.c
         std::replace(json_path.begin(), json_path.end(), '/', '.');
         if (!json_path.empty()) {
             json_path = json_path.substr(1);
         }
 
-        return std::make_shared<JsonFlatIndexQueryExecutor<T>>(json_path,
-                                                               *this);
+        return std::make_shared<JsonFlatIndexQueryExecutor<T>>(
+            json_path, *this, use_comparable_value_mask);
     }
 
     JsonCastType
@@ -235,8 +304,11 @@ class JsonFlatIndex : public InvertedIndexTantivy<std::string> {
 
 template <typename T>
 JsonFlatIndexQueryExecutor<T>::JsonFlatIndexQueryExecutor(
-    std::string& json_path, const JsonFlatIndex& json_flat_index) {
+    std::string& json_path,
+    const JsonFlatIndex& json_flat_index,
+    bool use_comparable_value_mask) {
     json_path_ = json_path;
+    use_comparable_value_mask_ = use_comparable_value_mask;
     this->wrapper_ = json_flat_index.wrapper_;
     this->null_offset_ = json_flat_index.null_offset_;
 }

--- a/internal/core/src/index/JsonFlatIndex.h
+++ b/internal/core/src/index/JsonFlatIndex.h
@@ -139,6 +139,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
                           fmt::format("Invalid OperatorType: {}", op));
         }
         OrU64Range(bitset, U64RangeForValue(value, op));
+        OrI64Range(bitset, I64RangeForValue(value, op));
         return bitset;
     }
 
@@ -165,6 +166,11 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
                                          &bitset);
         OrU64Range(bitset,
                    U64RangeForBounds(lower_bound_value,
+                                     lb_inclusive,
+                                     upper_bound_value,
+                                     ub_inclusive));
+        OrI64Range(bitset,
+                   I64RangeForBounds(lower_bound_value,
                                      lb_inclusive,
                                      upper_bound_value,
                                      ub_inclusive));
@@ -235,6 +241,7 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
     }
 
     using U64Range = std::optional<std::pair<uint64_t, uint64_t>>;
+    using I64Range = std::optional<std::pair<int64_t, int64_t>>;
 
     TargetBitmap
     TermBitset(size_t n, const T* values) {
@@ -260,6 +267,21 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
 
     void
     OrU64Range(TargetBitmap& bitset, U64Range range) {
+        if (!range.has_value()) {
+            return;
+        }
+        this->wrapper_->json_range_query(json_path_,
+                                         range->first,
+                                         range->second,
+                                         false,
+                                         false,
+                                         true,
+                                         true,
+                                         &bitset);
+    }
+
+    void
+    OrI64Range(TargetBitmap& bitset, I64Range range) {
         if (!range.has_value()) {
             return;
         }
@@ -321,6 +343,66 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
             }
         }
         return low;
+    }
+
+    static int64_t
+    I64FromOrdinal(uint64_t ordinal) {
+        constexpr auto sign_offset = uint64_t{1} << 63;
+        if (ordinal < sign_offset) {
+            return std::numeric_limits<int64_t>::lowest() +
+                   static_cast<int64_t>(ordinal);
+        }
+        return static_cast<int64_t>(ordinal - sign_offset);
+    }
+
+    template <typename Predicate>
+    static std::optional<int64_t>
+    FirstI64Where(Predicate pred) {
+        constexpr auto min = std::numeric_limits<uint64_t>::min();
+        constexpr auto max = std::numeric_limits<uint64_t>::max();
+        if (pred(I64FromOrdinal(min))) {
+            return I64FromOrdinal(min);
+        }
+        if (!pred(I64FromOrdinal(max))) {
+            return std::nullopt;
+        }
+
+        uint64_t low = min;
+        uint64_t high = max;
+        while (low < high) {
+            auto mid = low + (high - low) / 2;
+            if (pred(I64FromOrdinal(mid))) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+        return I64FromOrdinal(low);
+    }
+
+    template <typename Predicate>
+    static std::optional<int64_t>
+    LastI64Where(Predicate pred) {
+        constexpr auto min = std::numeric_limits<uint64_t>::min();
+        constexpr auto max = std::numeric_limits<uint64_t>::max();
+        if (!pred(I64FromOrdinal(min))) {
+            return std::nullopt;
+        }
+        if (pred(I64FromOrdinal(max))) {
+            return I64FromOrdinal(max);
+        }
+
+        uint64_t low = min;
+        uint64_t high = max;
+        while (low < high) {
+            auto mid = high - (high - low) / 2;
+            if (pred(I64FromOrdinal(mid))) {
+                low = mid;
+            } else {
+                high = mid - 1;
+            }
+        }
+        return I64FromOrdinal(low);
     }
 
     static U64Range
@@ -408,6 +490,90 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
         return std::make_pair(*lower, *upper);
     }
 
+    static I64Range
+    DoubleI64RangeForValue(double value, OpType op) {
+        if (std::isnan(value)) {
+            return std::nullopt;
+        }
+
+        switch (op) {
+            case OpType::LessThan: {
+                auto upper = LastI64Where([value](int64_t i) {
+                    return static_cast<double>(i) < value;
+                });
+                if (!upper.has_value()) {
+                    return std::nullopt;
+                }
+                return std::make_pair(std::numeric_limits<int64_t>::lowest(),
+                                      *upper);
+            }
+            case OpType::LessEqual: {
+                auto upper = LastI64Where([value](int64_t i) {
+                    return static_cast<double>(i) <= value;
+                });
+                if (!upper.has_value()) {
+                    return std::nullopt;
+                }
+                return std::make_pair(std::numeric_limits<int64_t>::lowest(),
+                                      *upper);
+            }
+            case OpType::GreaterThan: {
+                auto lower = FirstI64Where([value](int64_t i) {
+                    return static_cast<double>(i) > value;
+                });
+                if (!lower.has_value()) {
+                    return std::nullopt;
+                }
+                return std::make_pair(*lower,
+                                      std::numeric_limits<int64_t>::max());
+            }
+            case OpType::GreaterEqual: {
+                auto lower = FirstI64Where([value](int64_t i) {
+                    return static_cast<double>(i) >= value;
+                });
+                if (!lower.has_value()) {
+                    return std::nullopt;
+                }
+                return std::make_pair(*lower,
+                                      std::numeric_limits<int64_t>::max());
+            }
+            default:
+                ThrowInfo(OpTypeInvalid,
+                          fmt::format("Invalid OperatorType: {}", op));
+        }
+    }
+
+    static I64Range
+    DoubleI64RangeForBounds(double lower_bound_value,
+                            bool lb_inclusive,
+                            double upper_bound_value,
+                            bool ub_inclusive) {
+        if (std::isnan(lower_bound_value) || std::isnan(upper_bound_value)) {
+            return std::nullopt;
+        }
+
+        auto lower =
+            FirstI64Where([lower_bound_value, lb_inclusive](int64_t i) {
+                auto value = static_cast<double>(i);
+                return lb_inclusive ? value >= lower_bound_value
+                                    : value > lower_bound_value;
+            });
+        if (!lower.has_value()) {
+            return std::nullopt;
+        }
+
+        auto upper = LastI64Where([upper_bound_value, ub_inclusive](int64_t i) {
+            auto value = static_cast<double>(i);
+            return ub_inclusive ? value <= upper_bound_value
+                                : value < upper_bound_value;
+        });
+        if (!upper.has_value() || *lower > *upper) {
+            return std::nullopt;
+        }
+
+        return std::make_pair(*lower, *upper);
+    }
+
     static bool
     CanCastDoubleToU64(double value) {
         return std::isfinite(value) && std::floor(value) == value &&
@@ -457,6 +623,31 @@ class JsonFlatIndexQueryExecutor : public InvertedIndexTantivy<T> {
                                         lb_inclusive,
                                         static_cast<double>(upper_bound_value),
                                         ub_inclusive);
+        } else {
+            return std::nullopt;
+        }
+    }
+
+    static I64Range
+    I64RangeForValue(T value, OpType op) {
+        if constexpr (std::is_floating_point_v<T>) {
+            return DoubleI64RangeForValue(static_cast<double>(value), op);
+        } else {
+            return std::nullopt;
+        }
+    }
+
+    static I64Range
+    I64RangeForBounds(T lower_bound_value,
+                      bool lb_inclusive,
+                      T upper_bound_value,
+                      bool ub_inclusive) {
+        if constexpr (std::is_floating_point_v<T>) {
+            return DoubleI64RangeForBounds(
+                static_cast<double>(lower_bound_value),
+                lb_inclusive,
+                static_cast<double>(upper_bound_value),
+                ub_inclusive);
         } else {
             return std::nullopt;
         }

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -240,6 +240,35 @@ TEST_F(JsonFlatIndexTest, TestExistsQuery) {
     ASSERT_FALSE(result[2]);  // not exist
 }
 
+TEST_F(JsonFlatIndexTest, TestComparableAndFieldValidityMasks) {
+    auto json_flat_index =
+        dynamic_cast<index::JsonFlatIndex*>(json_index_.get());
+    ASSERT_NE(json_flat_index, nullptr);
+
+    std::string json_path = "/profile/name/preferred_name";
+    auto comparable_executor =
+        json_flat_index->create_executor<std::string>(json_path);
+    auto comparable_mask = comparable_executor->IsNotNull();
+    ASSERT_EQ(comparable_mask.size(), json_data_.size());
+    ASSERT_TRUE(comparable_mask[0]);
+    ASSERT_FALSE(comparable_mask[1]);
+    ASSERT_FALSE(comparable_mask[2]);
+
+    auto field_valid_executor =
+        json_flat_index->create_executor<std::string>(json_path, false);
+    auto field_valid_mask = field_valid_executor->IsNotNull();
+    ASSERT_EQ(field_valid_mask.size(), json_data_.size());
+    ASSERT_TRUE(field_valid_mask[0]);
+    ASSERT_TRUE(field_valid_mask[1]);
+    ASSERT_TRUE(field_valid_mask[2]);
+
+    auto field_null_mask = field_valid_executor->IsNull();
+    ASSERT_EQ(field_null_mask.size(), json_data_.size());
+    ASSERT_FALSE(field_null_mask[0]);
+    ASSERT_FALSE(field_null_mask[1]);
+    ASSERT_FALSE(field_null_mask[2]);
+}
+
 TEST_F(JsonFlatIndexTest, TestNotInQuery) {
     auto json_flat_index =
         dynamic_cast<index::JsonFlatIndex*>(json_index_.get());
@@ -653,6 +682,37 @@ TEST_F(JsonFlatIndexExprTest, TestUnaryExpr) {
     EXPECT_TRUE(final[8]);
     EXPECT_TRUE(final[10]);
     EXPECT_TRUE(final[12]);
+}
+
+TEST_F(JsonFlatIndexExprTest, TestComparisonUnknowns) {
+    proto::plan::GenericValue value;
+    value.set_int64_val(1);
+    auto not_equal_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::OpType::NotEqual,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    auto plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                       not_equal_expr);
+    auto final = query::ExecuteQueryExpr(
+        plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(final.count(), 1);
+    EXPECT_TRUE(final[2]);
+
+    auto greater_than_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid_, DataType::JSON, {"a"}),
+        proto::plan::OpType::GreaterThan,
+        value,
+        std::vector<proto::plan::GenericValue>());
+    auto not_greater_than_expr = std::make_shared<expr::LogicalUnaryExpr>(
+        expr::LogicalUnaryExpr::OpType::LogicalNot, greater_than_expr);
+    plan = std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID,
+                                                  not_greater_than_expr);
+    final = query::ExecuteQueryExpr(
+        plan, segment_.get(), json_data_.size(), MAX_TIMESTAMP);
+    EXPECT_EQ(final.count(), 2);
+    EXPECT_TRUE(final[0]);
+    EXPECT_TRUE(final[13]);
 }
 
 TEST_F(JsonFlatIndexExprTest, TestExistsExpr) {

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -490,9 +490,12 @@ TEST_F(JsonFlatIndexTest, TestInt64RangeQuery) {
     ASSERT_TRUE(ge_result[2]);   // 1003 >= 1002
 }
 
-TEST(JsonFlatIndexUint64Test, TestNumericQueriesIncludeUint64Terms) {
+TEST(JsonFlatIndexUint64Test, TestNumericQueriesIncludeMixedIntegerTerms) {
     auto json_index = BuildInMemoryJsonFlatIndex({
+        R"({"a": -10})",
         R"({"a": 1})",
+        R"({"a": 10})",
+        R"({"a": 10.5})",
         R"({"a": 9223372036854775808})",
         R"({"a": 18446744073709551615})",
         R"({"a": "1"})",
@@ -502,56 +505,87 @@ TEST(JsonFlatIndexUint64Test, TestNumericQueriesIncludeUint64Terms) {
     std::string json_path = "/a";
     auto int_executor = json_index->create_executor<int64_t>(json_path);
     auto comparable_mask = int_executor->IsNotNull();
-    ASSERT_EQ(comparable_mask.size(), 5);
+    ASSERT_EQ(comparable_mask.size(), 8);
     EXPECT_TRUE(comparable_mask[0]);
     EXPECT_TRUE(comparable_mask[1]);
     EXPECT_TRUE(comparable_mask[2]);
-    EXPECT_FALSE(comparable_mask[3]);
-    EXPECT_FALSE(comparable_mask[4]);
+    EXPECT_TRUE(comparable_mask[3]);
+    EXPECT_TRUE(comparable_mask[4]);
+    EXPECT_TRUE(comparable_mask[5]);
+    EXPECT_FALSE(comparable_mask[6]);
+    EXPECT_FALSE(comparable_mask[7]);
 
     int64_t one = 1;
     auto not_one = int_executor->NotIn(1, &one);
-    ASSERT_EQ(not_one.size(), 5);
-    EXPECT_FALSE(not_one[0]);
-    EXPECT_TRUE(not_one[1]);
+    ASSERT_EQ(not_one.size(), 8);
+    EXPECT_TRUE(not_one[0]);
+    EXPECT_FALSE(not_one[1]);
     EXPECT_TRUE(not_one[2]);
-    EXPECT_FALSE(not_one[3]);
-    EXPECT_FALSE(not_one[4]);
+    EXPECT_TRUE(not_one[3]);
+    EXPECT_TRUE(not_one[4]);
+    EXPECT_TRUE(not_one[5]);
+    EXPECT_FALSE(not_one[6]);
+    EXPECT_FALSE(not_one[7]);
 
     int64_t max_int64 = std::numeric_limits<int64_t>::max();
     auto not_max_int64 = int_executor->NotIn(1, &max_int64);
-    ASSERT_EQ(not_max_int64.size(), 5);
+    ASSERT_EQ(not_max_int64.size(), 8);
     EXPECT_TRUE(not_max_int64[0]);
-    EXPECT_FALSE(not_max_int64[1]);
+    EXPECT_TRUE(not_max_int64[1]);
     EXPECT_TRUE(not_max_int64[2]);
-    EXPECT_FALSE(not_max_int64[3]);
+    EXPECT_TRUE(not_max_int64[3]);
     EXPECT_FALSE(not_max_int64[4]);
+    EXPECT_TRUE(not_max_int64[5]);
+    EXPECT_FALSE(not_max_int64[6]);
+    EXPECT_FALSE(not_max_int64[7]);
 
     auto greater_than_nine =
         int_executor->Range(int64_t(9), OpType::GreaterThan);
-    ASSERT_EQ(greater_than_nine.size(), 5);
+    ASSERT_EQ(greater_than_nine.size(), 8);
     EXPECT_FALSE(greater_than_nine[0]);
-    EXPECT_TRUE(greater_than_nine[1]);
+    EXPECT_FALSE(greater_than_nine[1]);
     EXPECT_TRUE(greater_than_nine[2]);
     EXPECT_FALSE(greater_than_nine[3]);
-    EXPECT_FALSE(greater_than_nine[4]);
+    EXPECT_TRUE(greater_than_nine[4]);
+    EXPECT_TRUE(greater_than_nine[5]);
+    EXPECT_FALSE(greater_than_nine[6]);
+    EXPECT_FALSE(greater_than_nine[7]);
 
     auto bounded = int_executor->Range(int64_t(0), true, int64_t(9), true);
-    ASSERT_EQ(bounded.size(), 5);
-    EXPECT_TRUE(bounded[0]);
-    EXPECT_FALSE(bounded[1]);
+    ASSERT_EQ(bounded.size(), 8);
+    EXPECT_FALSE(bounded[0]);
+    EXPECT_TRUE(bounded[1]);
     EXPECT_FALSE(bounded[2]);
     EXPECT_FALSE(bounded[3]);
     EXPECT_FALSE(bounded[4]);
+    EXPECT_FALSE(bounded[5]);
+    EXPECT_FALSE(bounded[6]);
+    EXPECT_FALSE(bounded[7]);
 
     auto double_executor = json_index->create_executor<double>(json_path);
-    auto double_range = double_executor->Range(double(9), OpType::GreaterThan);
-    ASSERT_EQ(double_range.size(), 5);
+    auto double_range =
+        double_executor->Range(double(9.5), OpType::GreaterThan);
+    ASSERT_EQ(double_range.size(), 8);
     EXPECT_FALSE(double_range[0]);
-    EXPECT_TRUE(double_range[1]);
+    EXPECT_FALSE(double_range[1]);
     EXPECT_TRUE(double_range[2]);
-    EXPECT_FALSE(double_range[3]);
-    EXPECT_FALSE(double_range[4]);
+    EXPECT_TRUE(double_range[3]);
+    EXPECT_TRUE(double_range[4]);
+    EXPECT_TRUE(double_range[5]);
+    EXPECT_FALSE(double_range[6]);
+    EXPECT_FALSE(double_range[7]);
+
+    auto double_bounded =
+        double_executor->Range(double(-10.5), false, double(10), true);
+    ASSERT_EQ(double_bounded.size(), 8);
+    EXPECT_TRUE(double_bounded[0]);
+    EXPECT_TRUE(double_bounded[1]);
+    EXPECT_TRUE(double_bounded[2]);
+    EXPECT_FALSE(double_bounded[3]);
+    EXPECT_FALSE(double_bounded[4]);
+    EXPECT_FALSE(double_bounded[5]);
+    EXPECT_FALSE(double_bounded[6]);
+    EXPECT_FALSE(double_bounded[7]);
 }
 
 TEST_F(JsonFlatIndexTest, TestArrayStringInQuery) {

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -545,7 +545,7 @@ TEST(JsonFlatIndexUint64Test, TestNumericQueriesIncludeMixedIntegerTerms) {
     EXPECT_FALSE(greater_than_nine[0]);
     EXPECT_FALSE(greater_than_nine[1]);
     EXPECT_TRUE(greater_than_nine[2]);
-    EXPECT_FALSE(greater_than_nine[3]);
+    EXPECT_TRUE(greater_than_nine[3]);
     EXPECT_TRUE(greater_than_nine[4]);
     EXPECT_TRUE(greater_than_nine[5]);
     EXPECT_FALSE(greater_than_nine[6]);
@@ -586,6 +586,31 @@ TEST(JsonFlatIndexUint64Test, TestNumericQueriesIncludeMixedIntegerTerms) {
     EXPECT_FALSE(double_bounded[5]);
     EXPECT_FALSE(double_bounded[6]);
     EXPECT_FALSE(double_bounded[7]);
+
+    auto u64_executor = json_index->create_executor<uint64_t>(json_path);
+    auto u64_greater_than_nine =
+        u64_executor->Range(uint64_t(9), OpType::GreaterThan);
+    ASSERT_EQ(u64_greater_than_nine.size(), 8);
+    EXPECT_FALSE(u64_greater_than_nine[0]);
+    EXPECT_FALSE(u64_greater_than_nine[1]);
+    EXPECT_TRUE(u64_greater_than_nine[2]);
+    EXPECT_TRUE(u64_greater_than_nine[3]);
+    EXPECT_TRUE(u64_greater_than_nine[4]);
+    EXPECT_TRUE(u64_greater_than_nine[5]);
+    EXPECT_FALSE(u64_greater_than_nine[6]);
+    EXPECT_FALSE(u64_greater_than_nine[7]);
+
+    auto u64_bounded =
+        u64_executor->Range(uint64_t(0), true, uint64_t(11), true);
+    ASSERT_EQ(u64_bounded.size(), 8);
+    EXPECT_FALSE(u64_bounded[0]);
+    EXPECT_TRUE(u64_bounded[1]);
+    EXPECT_TRUE(u64_bounded[2]);
+    EXPECT_TRUE(u64_bounded[3]);
+    EXPECT_FALSE(u64_bounded[4]);
+    EXPECT_FALSE(u64_bounded[5]);
+    EXPECT_FALSE(u64_bounded[6]);
+    EXPECT_FALSE(u64_bounded[7]);
 }
 
 TEST_F(JsonFlatIndexTest, TestArrayStringInQuery) {

--- a/internal/core/src/index/JsonFlatIndexTest.cpp
+++ b/internal/core/src/index/JsonFlatIndexTest.cpp
@@ -96,6 +96,44 @@ struct ChunkManagerWrapper {
     std::unordered_set<std::string> written_;
 };
 
+std::unique_ptr<index::JsonFlatIndex>
+BuildInMemoryJsonFlatIndex(const std::vector<std::string>& json_data) {
+    auto file_manager_ctx = storage::FileManagerContext();
+    file_manager_ctx.fieldDataMeta.field_schema.set_data_type(
+        milvus::proto::schema::JSON);
+    file_manager_ctx.fieldDataMeta.field_schema.set_fieldid(101);
+    file_manager_ctx.fieldDataMeta.field_schema.set_nullable(true);
+    file_manager_ctx.fieldDataMeta.field_id = 101;
+
+    index::CreateIndexInfo json_index_info;
+    json_index_info.index_type = index::INVERTED_INDEX_TYPE;
+    json_index_info.json_cast_type = JsonCastType::FromString("JSON");
+    json_index_info.json_path = "";
+    auto index = index::IndexFactory::GetInstance().CreateJsonIndex(
+        json_index_info, file_manager_ctx);
+    auto json_index = std::unique_ptr<index::JsonFlatIndex>(
+        static_cast<index::JsonFlatIndex*>(index.release()));
+
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    std::vector<milvus::Json> jsons;
+    jsons.reserve(json_data.size());
+    for (const auto& json_str : json_data) {
+        jsons.emplace_back(simdjson::padded_string(json_str));
+    }
+    json_field->add_json_data(jsons);
+
+    auto* valid_data = json_field->ValidData();
+    std::fill(valid_data,
+              valid_data + json_field->ValidDataSize(),
+              static_cast<uint8_t>(0xFF));
+
+    json_index->BuildWithFieldData({json_field});
+    json_index->finish();
+    json_index->create_reader(milvus::index::SetBitsetSealed);
+    return json_index;
+}
+
 class JsonFlatIndexTest : public ::testing::Test {
  protected:
     void
@@ -450,6 +488,70 @@ TEST_F(JsonFlatIndexTest, TestInt64RangeQuery) {
     ASSERT_FALSE(ge_result[0]);  // 1001 < 1002
     ASSERT_TRUE(ge_result[1]);   // 1002 >= 1002
     ASSERT_TRUE(ge_result[2]);   // 1003 >= 1002
+}
+
+TEST(JsonFlatIndexUint64Test, TestNumericQueriesIncludeUint64Terms) {
+    auto json_index = BuildInMemoryJsonFlatIndex({
+        R"({"a": 1})",
+        R"({"a": 9223372036854775808})",
+        R"({"a": 18446744073709551615})",
+        R"({"a": "1"})",
+        R"({})",
+    });
+
+    std::string json_path = "/a";
+    auto int_executor = json_index->create_executor<int64_t>(json_path);
+    auto comparable_mask = int_executor->IsNotNull();
+    ASSERT_EQ(comparable_mask.size(), 5);
+    EXPECT_TRUE(comparable_mask[0]);
+    EXPECT_TRUE(comparable_mask[1]);
+    EXPECT_TRUE(comparable_mask[2]);
+    EXPECT_FALSE(comparable_mask[3]);
+    EXPECT_FALSE(comparable_mask[4]);
+
+    int64_t one = 1;
+    auto not_one = int_executor->NotIn(1, &one);
+    ASSERT_EQ(not_one.size(), 5);
+    EXPECT_FALSE(not_one[0]);
+    EXPECT_TRUE(not_one[1]);
+    EXPECT_TRUE(not_one[2]);
+    EXPECT_FALSE(not_one[3]);
+    EXPECT_FALSE(not_one[4]);
+
+    int64_t max_int64 = std::numeric_limits<int64_t>::max();
+    auto not_max_int64 = int_executor->NotIn(1, &max_int64);
+    ASSERT_EQ(not_max_int64.size(), 5);
+    EXPECT_TRUE(not_max_int64[0]);
+    EXPECT_FALSE(not_max_int64[1]);
+    EXPECT_TRUE(not_max_int64[2]);
+    EXPECT_FALSE(not_max_int64[3]);
+    EXPECT_FALSE(not_max_int64[4]);
+
+    auto greater_than_nine =
+        int_executor->Range(int64_t(9), OpType::GreaterThan);
+    ASSERT_EQ(greater_than_nine.size(), 5);
+    EXPECT_FALSE(greater_than_nine[0]);
+    EXPECT_TRUE(greater_than_nine[1]);
+    EXPECT_TRUE(greater_than_nine[2]);
+    EXPECT_FALSE(greater_than_nine[3]);
+    EXPECT_FALSE(greater_than_nine[4]);
+
+    auto bounded = int_executor->Range(int64_t(0), true, int64_t(9), true);
+    ASSERT_EQ(bounded.size(), 5);
+    EXPECT_TRUE(bounded[0]);
+    EXPECT_FALSE(bounded[1]);
+    EXPECT_FALSE(bounded[2]);
+    EXPECT_FALSE(bounded[3]);
+    EXPECT_FALSE(bounded[4]);
+
+    auto double_executor = json_index->create_executor<double>(json_path);
+    auto double_range = double_executor->Range(double(9), OpType::GreaterThan);
+    ASSERT_EQ(double_range.size(), 5);
+    EXPECT_FALSE(double_range[0]);
+    EXPECT_TRUE(double_range[1]);
+    EXPECT_TRUE(double_range[2]);
+    EXPECT_FALSE(double_range[3]);
+    EXPECT_FALSE(double_range[4]);
 }
 
 TEST_F(JsonFlatIndexTest, TestArrayStringInQuery) {

--- a/internal/core/src/index/JsonHybridScalarIndex.h
+++ b/internal/core/src/index/JsonHybridScalarIndex.h
@@ -151,14 +151,6 @@ class JsonHybridScalarIndex : public HybridScalarIndex<T> {
         return exists_bitset_.clone();
     }
 
-    const TargetBitmap
-    NotIn(size_t n, const T* values) override {
-        auto result = HybridScalarIndex<T>::NotIn(n, values);
-        auto null_rows = HybridScalarIndex<T>::IsNull();
-        result |= null_rows;
-        return result;
-    }
-
     void
     WriteEntries(storage::IndexEntryWriter* writer) override {
         HybridScalarIndex<T>::WriteEntries(writer);

--- a/internal/core/src/index/JsonIndexTest.cpp
+++ b/internal/core/src/index/JsonIndexTest.cpp
@@ -416,7 +416,8 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
     // Build with enough rows to produce large null_offset and
     // non_exist_offset arrays (each > FILE_SLICE_SIZE = 64 bytes).
     // - invalid row   -> null_offset + non_exist_offset (8 bytes per entry)
-    // - {"b": 1}      -> non_exist_offset only (key "a" doesn't exist)
+    // - {"b": 1}      -> null_offset + non_exist_offset (key "a" doesn't
+    //                    exist, so the typed comparison value is invalid)
     // - {"a": 1.0}    -> valid data (neither offset)
     // 20 invalid + 20 missing-path rows make both files slice reliably.
     constexpr int kInvalidRows = 20;
@@ -518,7 +519,8 @@ TEST(JsonIndexTest, TestSlicedOffsetFilesLoadIndependently) {
         auto result = CompactIndexDatasByKey(
             INDEX_NULL_OFFSET_FILE_NAME, std::move(slice_meta), partial);
         EXPECT_GT(result.codecs_.size(), 0);
-        EXPECT_EQ(result.size_, kInvalidRows * sizeof(size_t));
+        EXPECT_EQ(result.size_,
+                  (kInvalidRows + kMissingPathRows) * sizeof(size_t));
     }
 
     // --- Verify the fix: CompactIndexDatasByKey with non_exist_offset ---

--- a/internal/core/src/index/JsonPathIndexTest.cpp
+++ b/internal/core/src/index/JsonPathIndexTest.cpp
@@ -309,6 +309,99 @@ TEST(JsonPathIndexTest, SortDouble_ExistsSemantics) {
     EXPECT_EQ(exists.count(), 4);
 }
 
+template <typename IndexT>
+void
+AssertDoubleComparisonUnknowns(IndexT& idx) {
+    auto known = idx.IsNotNull();
+    ASSERT_EQ(known.size(), 6);
+    EXPECT_TRUE(known[0]);
+    EXPECT_TRUE(known[1]);
+    EXPECT_FALSE(known[2]);
+    EXPECT_FALSE(known[3]);
+    EXPECT_FALSE(known[4]);
+    EXPECT_TRUE(known[5]);
+    EXPECT_EQ(known.count(), 3);
+
+    auto exists = idx.Exists();
+    ASSERT_EQ(exists.size(), 6);
+    EXPECT_TRUE(exists[0]);
+    EXPECT_TRUE(exists[1]);
+    EXPECT_TRUE(exists[2]);   // path exists, but cast fails
+    EXPECT_FALSE(exists[3]);  // path missing
+    EXPECT_FALSE(exists[4]);  // JSON null is not an existing comparable value
+    EXPECT_TRUE(exists[5]);
+    EXPECT_EQ(exists.count(), 4);
+
+    double two = 2.0;
+    auto not_in = idx.NotIn(1, &two);
+    ASSERT_EQ(not_in.size(), 6);
+    EXPECT_TRUE(not_in[0]);
+    EXPECT_FALSE(not_in[1]);
+    EXPECT_FALSE(not_in[2]);
+    EXPECT_FALSE(not_in[3]);
+    EXPECT_FALSE(not_in[4]);
+    EXPECT_TRUE(not_in[5]);
+    EXPECT_EQ(not_in.count(), 2);
+
+    auto greater_than_one = idx.Range(1.0, OpType::GreaterThan);
+    ASSERT_EQ(greater_than_one.size(), 6);
+    EXPECT_FALSE(greater_than_one[0]);
+    EXPECT_TRUE(greater_than_one[1]);
+    EXPECT_FALSE(greater_than_one[2]);
+    EXPECT_FALSE(greater_than_one[3]);
+    EXPECT_FALSE(greater_than_one[4]);
+    EXPECT_TRUE(greater_than_one[5]);
+    EXPECT_EQ(greater_than_one.count(), 2);
+}
+
+std::shared_ptr<FieldData<Json>>
+MakeMixedJsonDoubleFieldData() {
+    return MakeJsonFieldData({
+        R"({"a": 1.0})",
+        R"({"a": 2.0})",
+        R"({"a": "bad"})",
+        R"({"b": 3.0})",
+        R"({"a": null})",
+        R"({"a": 3.0})",
+    });
+}
+
+TEST(JsonPathIndexTest, SortDouble_ComparisonUnknowns) {
+    auto json_fd = MakeMixedJsonDoubleFieldData();
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonScalarIndexWrapper<double, ScalarIndexSort<double>> idx(
+        JsonCastType::FromString("DOUBLE"),
+        "/a",
+        JsonCastFunction::FromString("unknown"),
+        schema,
+        ctx);
+
+    idx.BuildWithFieldData({json_fd});
+    AssertDoubleComparisonUnknowns(idx);
+}
+
+TEST(JsonPathIndexTest, InvertedDouble_ComparisonUnknowns) {
+    auto json_fd = MakeMixedJsonDoubleFieldData();
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonScalarIndexWrapper<double, InvertedIndexTantivy<double>> idx(
+        JsonCastType::FromString("DOUBLE"),
+        "/a",
+        JsonCastFunction::FromString("unknown"),
+        schema,
+        ctx,
+        TANTIVY_INDEX_LATEST_VERSION);
+
+    idx.BuildWithFieldData({json_fd});
+    idx.finish();
+    idx.create_reader(milvus::index::SetBitsetSealed);
+
+    AssertDoubleComparisonUnknowns(idx);
+}
+
 TEST(JsonPathIndexTest, BitmapBool_ExistsSemantics) {
     auto json_fd = MakeJsonFieldData({
         R"({"f": true})",
@@ -449,6 +542,23 @@ TEST(JsonPathIndexTest, Hybrid_ExistsSemantics) {
     EXPECT_TRUE(exists[1]);   // cast fail → still EXISTS
     EXPECT_FALSE(exists[2]);  // path not exist
     EXPECT_TRUE(exists[3]);   // valid
+}
+
+TEST(JsonPathIndexTest, Hybrid_ComparisonUnknowns) {
+    auto json_fd = MakeMixedJsonDoubleFieldData();
+    auto schema = MakeJsonSchema();
+    auto ctx = MakeTestContext();
+
+    JsonHybridScalarIndex<double> idx(JsonCastType::FromString("DOUBLE"),
+                                      "/a",
+                                      JsonCastFunction::FromString("unknown"),
+                                      schema,
+                                      0,
+                                      ctx);
+
+    idx.bitmap_index_cardinality_limit_ = 3;
+    idx.BuildWithFieldData({json_fd});
+    AssertDoubleComparisonUnknowns(idx);
 }
 
 // ============================================================

--- a/internal/core/src/index/JsonScalarIndexWrapper.h
+++ b/internal/core/src/index/JsonScalarIndexWrapper.h
@@ -128,18 +128,6 @@ class JsonScalarIndexWrapper : public BaseIndex {
         return exists_bitset_.clone();
     }
 
-    // JSON brute-force semantics: NotEqual on error (path missing / cast fail)
-    // returns TRUE. Base indexes mask invalid rows to false via valid_bitset_,
-    // which is correct for regular nullable columns but wrong for JSON path
-    // indexes. Fix: OR back the invalid rows after the base NotIn.
-    const TargetBitmap
-    NotIn(size_t n, const T* values) override {
-        auto result = BaseIndex::NotIn(n, values);
-        auto null_rows = BaseIndex::IsNull();
-        result |= null_rows;
-        return result;
-    }
-
     // v2 format: serialize non_exist_offsets (and null_offset for inverted).
     BinarySet
     Serialize(const Config& config) override {
@@ -349,6 +337,19 @@ class JsonScalarIndexWrapper : public BaseIndex {
     std::enable_if_t<std::is_base_of_v<InvertedIndexTantivy<T>, B>>
     BuildInvertedWithJsonFieldData(
         const std::vector<FieldDataPtr>& field_datas) {
+        if (cast_type_.data_type() != JsonCastType::DataType::ARRAY) {
+            auto result = ConvertJsonToTypedFieldData<T>(field_datas,
+                                                         json_schema_,
+                                                         nested_path_,
+                                                         cast_type_,
+                                                         cast_function_);
+            non_exist_offsets_ = std::move(result.non_exist_offsets);
+            auto total_rows = result.field_data->get_num_rows();
+            BaseIndex::BuildWithFieldData({result.field_data});
+            BuildExistsBitset(total_rows);
+            return;
+        }
+
         int64_t total_rows = 0;
         for (const auto& data : field_datas) {
             total_rows += data->get_num_rows();

--- a/internal/core/src/index/ScalarIndex.cpp
+++ b/internal/core/src/index/ScalarIndex.cpp
@@ -147,6 +147,15 @@ ScalarIndex<int64_t>::BuildWithRawDataForUT(size_t n,
 
 template <>
 void
+ScalarIndex<uint64_t>::BuildWithRawDataForUT(size_t n,
+                                             const void* values,
+                                             const Config& config) {
+    auto data = reinterpret_cast<uint64_t*>(const_cast<void*>(values));
+    Build(n, data);
+}
+
+template <>
+void
 ScalarIndex<float>::BuildWithRawDataForUT(size_t n,
                                           const void* values,
                                           const Config& config) {
@@ -266,6 +275,7 @@ template class ScalarIndex<int8_t>;
 template class ScalarIndex<int16_t>;
 template class ScalarIndex<int32_t>;
 template class ScalarIndex<int64_t>;
+template class ScalarIndex<uint64_t>;
 template class ScalarIndex<float>;
 template class ScalarIndex<double>;
 template class ScalarIndex<std::string>;

--- a/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
@@ -254,6 +254,11 @@ RustResult tantivy_json_term_query_i64(void *ptr,
                                        int64_t term,
                                        void *bitset);
 
+RustResult tantivy_json_term_query_u64(void *ptr,
+                                       const char *json_path,
+                                       uint64_t term,
+                                       void *bitset);
+
 RustResult tantivy_json_term_query_f64(void *ptr, const char *json_path, double term, void *bitset);
 
 RustResult tantivy_json_term_query_bool(void *ptr, const char *json_path, bool term, void *bitset);
@@ -266,6 +271,12 @@ RustResult tantivy_json_term_query_keyword(void *ptr,
 RustResult tantivy_json_terms_query_i64(void *ptr,
                                         const char *json_path,
                                         const int64_t *terms,
+                                        uintptr_t len,
+                                        void *bitset);
+
+RustResult tantivy_json_terms_query_u64(void *ptr,
+                                        const char *json_path,
+                                        const uint64_t *terms,
                                         uintptr_t len,
                                         void *bitset);
 
@@ -293,6 +304,16 @@ RustResult tantivy_json_range_query_i64(void *ptr,
                                         const char *json_path,
                                         int64_t lower_bound,
                                         int64_t higher_bound,
+                                        bool lb_unbounded,
+                                        bool up_unbounded,
+                                        bool lb_inclusive,
+                                        bool ub_inclusive,
+                                        void *bitset);
+
+RustResult tantivy_json_range_query_u64(void *ptr,
+                                        const char *json_path,
+                                        uint64_t lower_bound,
+                                        uint64_t higher_bound,
                                         bool lb_unbounded,
                                         bool up_unbounded,
                                         bool lb_inclusive,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader.rs
@@ -485,6 +485,18 @@ impl IndexReaderWrapper {
         self.search(&q, bitset)
     }
 
+    pub fn json_term_query_u64(
+        &self,
+        json_path: &str,
+        term: u64,
+        bitset: *mut c_void,
+    ) -> Result<()> {
+        let mut json_term = Term::from_field_json_path(self.field, json_path, false);
+        json_term.append_type_and_fast_value(term);
+        let q = TermQuery::new(json_term, IndexRecordOption::Basic);
+        self.search(&q, bitset)
+    }
+
     pub fn json_term_query_f64(
         &self,
         json_path: &str,
@@ -532,6 +544,29 @@ impl IndexReaderWrapper {
             return terms
                 .iter()
                 .try_for_each(|&term| self.json_term_query_i64(json_path, term, bitset));
+        }
+        let term_vec: Vec<_> = terms
+            .iter()
+            .map(|&t| {
+                let mut json_term = Term::from_field_json_path(self.field, json_path, false);
+                json_term.append_type_and_fast_value(t);
+                json_term
+            })
+            .collect();
+        let q = TermSetQuery::new(term_vec);
+        self.search(&q, bitset)
+    }
+
+    pub fn json_terms_query_u64(
+        &self,
+        json_path: &str,
+        terms: &[u64],
+        bitset: *mut c_void,
+    ) -> Result<()> {
+        if terms.len() < JSON_BATCH_THRESHOLD {
+            return terms
+                .iter()
+                .try_for_each(|&term| self.json_term_query_u64(json_path, term, bitset));
         }
         let term_vec: Vec<_> = terms
             .iter()

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/index_reader_c.rs
@@ -353,6 +353,18 @@ pub extern "C" fn tantivy_json_term_query_i64(
 }
 
 #[no_mangle]
+pub extern "C" fn tantivy_json_term_query_u64(
+    ptr: *mut c_void,
+    json_path: *const c_char,
+    term: u64,
+    bitset: *mut c_void,
+) -> RustResult {
+    let real = ptr as *mut IndexReaderWrapper;
+    let json_path = cstr_to_str!(json_path);
+    unsafe { (*real).json_term_query_u64(json_path, term, bitset).into() }
+}
+
+#[no_mangle]
 pub extern "C" fn tantivy_json_term_query_f64(
     ptr: *mut c_void,
     json_path: *const c_char,
@@ -408,6 +420,24 @@ pub extern "C" fn tantivy_json_terms_query_i64(
     unsafe {
         (*real)
             .json_terms_query_i64(json_path, terms, bitset)
+            .into()
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn tantivy_json_terms_query_u64(
+    ptr: *mut c_void,
+    json_path: *const c_char,
+    terms: *const u64,
+    len: usize,
+    bitset: *mut c_void,
+) -> RustResult {
+    let real = ptr as *mut IndexReaderWrapper;
+    let json_path = cstr_to_str!(json_path);
+    let terms = unsafe { convert_to_rust_slice!(terms, len) };
+    unsafe {
+        (*real)
+            .json_terms_query_u64(json_path, terms, bitset)
             .into()
     }
 }
@@ -483,6 +513,36 @@ pub extern "C" fn tantivy_json_range_query_i64(
     json_path: *const c_char,
     lower_bound: i64,
     higher_bound: i64,
+    lb_unbounded: bool,
+    up_unbounded: bool,
+    lb_inclusive: bool,
+    ub_inclusive: bool,
+    bitset: *mut c_void,
+) -> RustResult {
+    let real = ptr as *mut IndexReaderWrapper;
+    let json_path = cstr_to_str!(json_path);
+    unsafe {
+        (*real)
+            .json_range_query(
+                json_path,
+                lower_bound,
+                higher_bound,
+                lb_unbounded,
+                up_unbounded,
+                lb_inclusive,
+                ub_inclusive,
+                bitset,
+            )
+            .into()
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn tantivy_json_range_query_u64(
+    ptr: *mut c_void,
+    json_path: *const c_char,
+    lower_bound: u64,
+    higher_bound: u64,
     lb_unbounded: bool,
     up_unbounded: bool,
     lb_inclusive: bool,

--- a/internal/core/thirdparty/tantivy/tantivy-wrapper.h
+++ b/internal/core/thirdparty/tantivy/tantivy-wrapper.h
@@ -4,6 +4,7 @@
 #include <fmt/format.h>
 #include <set>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <vector>
 #include <type_traits>
@@ -1119,6 +1120,26 @@ struct TantivyIndexWrapper {
             "TantivyIndexWrapper.ngram_term_posting_list: invalid result type");
     }
 
+    static bool
+    can_cast_double_to_u64(double value) {
+        return std::isfinite(value) && std::floor(value) == value &&
+               value >= 0 &&
+               static_cast<long double>(value) <=
+                   static_cast<long double>(
+                       std::numeric_limits<uint64_t>::max());
+    }
+
+    static bool
+    can_cast_double_to_i64(double value) {
+        return std::isfinite(value) && std::floor(value) == value &&
+               static_cast<long double>(value) >=
+                   static_cast<long double>(
+                       std::numeric_limits<int64_t>::lowest()) &&
+               static_cast<long double>(value) <=
+                   static_cast<long double>(
+                       std::numeric_limits<int64_t>::max());
+    }
+
     // json query
     template <typename T>
     void
@@ -1130,23 +1151,78 @@ struct TantivyIndexWrapper {
             }
 
             if constexpr (std::is_integral_v<T>) {
-                auto res = tantivy_json_term_query_i64(
-                    reader_, json_path.c_str(), term, bitset);
-                AssertInfo(res.success,
-                           "TantivyIndexWrapper.json_term_query: {}",
-                           res.error);
+                if constexpr (std::is_signed_v<T>) {
+                    auto res = tantivy_json_term_query_i64(
+                        reader_, json_path.c_str(), term, bitset);
+                    AssertInfo(res.success,
+                               "TantivyIndexWrapper.json_term_query: {}",
+                               res.error);
+                    free_rust_result(res);
+                } else {
+                    if (term <=
+                        static_cast<T>(std::numeric_limits<int64_t>::max())) {
+                        auto res = tantivy_json_term_query_i64(
+                            reader_,
+                            json_path.c_str(),
+                            static_cast<int64_t>(term),
+                            bitset);
+                        AssertInfo(res.success,
+                                   "TantivyIndexWrapper.json_term_query: {}",
+                                   res.error);
+                        free_rust_result(res);
+                    }
+                }
+                if constexpr (std::is_signed_v<T>) {
+                    if (term >= 0) {
+                        auto res_u64 = tantivy_json_term_query_u64(
+                            reader_,
+                            json_path.c_str(),
+                            static_cast<uint64_t>(term),
+                            bitset);
+                        AssertInfo(
+                            res_u64.success,
+                            "TantivyIndexWrapper.json_term_query u64: {}",
+                            res_u64.error);
+                        free_rust_result(res_u64);
+                    }
+                } else {
+                    auto res_u64 =
+                        tantivy_json_term_query_u64(reader_,
+                                                    json_path.c_str(),
+                                                    static_cast<uint64_t>(term),
+                                                    bitset);
+                    AssertInfo(res_u64.success,
+                               "TantivyIndexWrapper.json_term_query u64: {}",
+                               res_u64.error);
+                    free_rust_result(res_u64);
+                }
                 return tantivy_json_term_query_f64(
                     reader_, json_path.c_str(), term, bitset);
             }
 
             if constexpr (std::is_floating_point_v<T>) {
                 // if term can be cast to int64 without precision loss, use int64 query first
-                if (std::floor(term) == term) {
-                    auto res = tantivy_json_term_query_i64(
-                        reader_, json_path.c_str(), term, bitset);
+                if (can_cast_double_to_i64(term)) {
+                    auto res =
+                        tantivy_json_term_query_i64(reader_,
+                                                    json_path.c_str(),
+                                                    static_cast<int64_t>(term),
+                                                    bitset);
                     AssertInfo(res.success,
                                "TantivyIndexWrapper.json_term_query: {}",
                                res.error);
+                    free_rust_result(res);
+                }
+                if (can_cast_double_to_u64(term)) {
+                    auto res =
+                        tantivy_json_term_query_u64(reader_,
+                                                    json_path.c_str(),
+                                                    static_cast<uint64_t>(term),
+                                                    bitset);
+                    AssertInfo(res.success,
+                               "TantivyIndexWrapper.json_term_query u64: {}",
+                               res.error);
+                    free_rust_result(res);
                 }
                 return tantivy_json_term_query_f64(
                     reader_, json_path.c_str(), term, bitset);
@@ -1187,15 +1263,52 @@ struct TantivyIndexWrapper {
                 // For JSON integer fields, we need to query both i64 and f64
                 // because JSON numbers can be stored as either type.
                 // First batch-query i64, then batch-query f64.
-                std::vector<int64_t> i64_values(n);
-                for (size_t i = 0; i < n; ++i)
-                    i64_values[i] = static_cast<int64_t>(values[i]);
-                auto res_i64 = tantivy_json_terms_query_i64(
-                    reader_, json_path.c_str(), i64_values.data(), n, bitset);
-                AssertInfo(res_i64.success,
-                           "TantivyIndexWrapper.json_terms_query i64: {}",
-                           res_i64.error);
-                free_rust_result(res_i64);
+                std::vector<int64_t> i64_values;
+                i64_values.reserve(n);
+                for (size_t i = 0; i < n; ++i) {
+                    if constexpr (std::is_signed_v<T>) {
+                        i64_values.push_back(static_cast<int64_t>(values[i]));
+                    } else if (values[i] <=
+                               static_cast<T>(
+                                   std::numeric_limits<int64_t>::max())) {
+                        i64_values.push_back(static_cast<int64_t>(values[i]));
+                    }
+                }
+                if (!i64_values.empty()) {
+                    auto res_i64 =
+                        tantivy_json_terms_query_i64(reader_,
+                                                     json_path.c_str(),
+                                                     i64_values.data(),
+                                                     i64_values.size(),
+                                                     bitset);
+                    AssertInfo(res_i64.success,
+                               "TantivyIndexWrapper.json_terms_query i64: {}",
+                               res_i64.error);
+                    free_rust_result(res_i64);
+                }
+
+                std::vector<uint64_t> u64_values;
+                u64_values.reserve(n);
+                for (size_t i = 0; i < n; ++i) {
+                    if constexpr (std::is_signed_v<T>) {
+                        if (values[i] < 0) {
+                            continue;
+                        }
+                    }
+                    u64_values.push_back(static_cast<uint64_t>(values[i]));
+                }
+                if (!u64_values.empty()) {
+                    auto res_u64 =
+                        tantivy_json_terms_query_u64(reader_,
+                                                     json_path.c_str(),
+                                                     u64_values.data(),
+                                                     u64_values.size(),
+                                                     bitset);
+                    AssertInfo(res_u64.success,
+                               "TantivyIndexWrapper.json_terms_query u64: {}",
+                               res_u64.error);
+                    free_rust_result(res_u64);
+                }
 
                 // Also query as f64 since JSON doesn't distinguish int/float
                 std::vector<double> f64_values(n);
@@ -1209,9 +1322,14 @@ struct TantivyIndexWrapper {
                 // Query matching integers first (for values without fractional part)
                 std::vector<int64_t> int_values;
                 int_values.reserve(n);
+                std::vector<uint64_t> u64_values;
+                u64_values.reserve(n);
                 for (size_t i = 0; i < n; ++i) {
-                    if (std::floor(values[i]) == values[i]) {
+                    if (can_cast_double_to_i64(values[i])) {
                         int_values.push_back(static_cast<int64_t>(values[i]));
+                    }
+                    if (can_cast_double_to_u64(values[i])) {
+                        u64_values.push_back(static_cast<uint64_t>(values[i]));
                     }
                 }
                 if (!int_values.empty()) {
@@ -1225,6 +1343,18 @@ struct TantivyIndexWrapper {
                                "TantivyIndexWrapper.json_terms_query i64: {}",
                                res_i64.error);
                     free_rust_result(res_i64);
+                }
+                if (!u64_values.empty()) {
+                    auto res_u64 =
+                        tantivy_json_terms_query_u64(reader_,
+                                                     json_path.c_str(),
+                                                     u64_values.data(),
+                                                     u64_values.size(),
+                                                     bitset);
+                    AssertInfo(res_u64.success,
+                               "TantivyIndexWrapper.json_terms_query u64: {}",
+                               res_u64.error);
+                    free_rust_result(res_u64);
                 }
                 return tantivy_json_terms_query_f64(
                     reader_,
@@ -1287,6 +1417,18 @@ struct TantivyIndexWrapper {
                                                      lb_inclusive,
                                                      ub_inclusive,
                                                      bitset);
+            }
+
+            if constexpr (std::is_same_v<T, uint64_t>) {
+                return tantivy_json_range_query_u64(reader_,
+                                                    json_path.c_str(),
+                                                    lower_bound,
+                                                    upper_bound,
+                                                    lb_unbounded,
+                                                    ub_unbounded,
+                                                    lb_inclusive,
+                                                    ub_inclusive,
+                                                    bitset);
             }
 
             if constexpr (std::is_integral_v<T>) {

--- a/internal/parser/planparserv2/rewriter/range.go
+++ b/internal/parser/planparserv2/rewriter/range.go
@@ -206,7 +206,7 @@ func (v *visitor) combineAndRangePredicates(parts []*planpb.Expr) []*planpb.Expr
 				}
 			}
 
-			if isEmpty && hasNullableFieldSemantics(g.col) {
+			if isEmpty && !canFoldBoolDomainToConstant(g.col) {
 				continue
 			}
 
@@ -608,7 +608,7 @@ func (v *visitor) combineAndBinaryRanges(parts []*planpb.Expr) []*planpb.Expr {
 				}
 			}
 			if isEmpty {
-				if hasNullableFieldSemantics(g.col) {
+				if !canFoldBoolDomainToConstant(g.col) {
 					continue
 				}
 				// Empty intersection → constant false

--- a/internal/parser/planparserv2/rewriter/range_json_test.go
+++ b/internal/parser/planparserv2/rewriter/range_json_test.go
@@ -69,6 +69,23 @@ func TestRewrite_JSON_NestedPath_Nullable_ContradictionsKeepPredicate(t *testing
 	}
 }
 
+func TestRewrite_JSON_NestedPath_NonNullable_ContradictionsKeepPredicate(t *testing.T) {
+	helper := buildSchemaHelperWithJSON(t)
+
+	for _, exprStr := range []string{
+		`JSONField["age"] in [1] and JSONField["age"] == 2`,
+		`JSONField["age"] > 100 and JSONField["age"] < 50`,
+		`not (JSONField["age"] in [1] and JSONField["age"] == 2)`,
+		`not (JSONField["age"] > 100 and JSONField["age"] < 50)`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		require.NotNil(t, expr, exprStr)
+		require.False(t, rewriter.IsAlwaysFalseExpr(expr), "JSON path must not fold to valid false when the path can be missing: %s", exprStr)
+		require.False(t, rewriter.IsAlwaysTrueExpr(expr), "JSON path under NOT must not fold to valid true when the path can be missing: %s", exprStr)
+	}
+}
+
 func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteBlocked(t *testing.T) {
 	helper := buildSchemaHelperWithJSON(t)
 

--- a/internal/parser/planparserv2/rewriter/range_test.go
+++ b/internal/parser/planparserv2/rewriter/range_test.go
@@ -257,6 +257,35 @@ func buildSchemaHelperWithArraysT(t *testing.T) *typeutil.SchemaHelper {
 	return helper
 }
 
+func buildSchemaHelperWithStructArrayT(t *testing.T) *typeutil.SchemaHelper {
+	structArrayField := &schemapb.StructArrayFieldSchema{
+		FieldID: 301,
+		Name:    "struct_array",
+		Fields: []*schemapb.FieldSchema{
+			{
+				FieldID:     302,
+				Name:        "struct_array[sub_str]",
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_VarChar,
+			},
+			{
+				FieldID:     303,
+				Name:        "struct_array[sub_int]",
+				DataType:    schemapb.DataType_Array,
+				ElementType: schemapb.DataType_Int64,
+			},
+		},
+	}
+	schema := &schemapb.CollectionSchema{
+		Name:              "rewrite_struct_array_test",
+		AutoID:            false,
+		StructArrayFields: []*schemapb.StructArrayFieldSchema{structArrayField},
+	}
+	helper, err := typeutil.CreateSchemaHelper(schema)
+	require.NoError(t, err)
+	return helper
+}
+
 func TestRewrite_Range_Array_Int_NotSupported(t *testing.T) {
 	helper := buildSchemaHelperWithArraysT(t)
 	_, err := parser.ParseExpr(helper, `ArrayInt > 10`, nil)
@@ -363,6 +392,36 @@ func TestRewrite_Range_Array_Index_Different_NoMerge(t *testing.T) {
 	}
 	require.True(t, seenInterval)
 	require.True(t, seenLower)
+}
+
+func TestRewrite_Range_ArrayIndex_ContradictionsKeepPredicate(t *testing.T) {
+	helper := buildSchemaHelperWithArraysT(t)
+
+	for _, exprStr := range []string{
+		`ArrayInt[0] > 100 and ArrayInt[0] < 50`,
+		`not (ArrayInt[0] > 100 and ArrayInt[0] < 50)`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		require.NotNil(t, expr, exprStr)
+		require.False(t, rewriter.IsAlwaysFalseExpr(expr), "indexed array must not fold to valid false when the index can be out of range: %s", exprStr)
+		require.False(t, rewriter.IsAlwaysTrueExpr(expr), "indexed array under NOT must not fold to valid true when the index can be out of range: %s", exprStr)
+	}
+}
+
+func TestRewrite_Range_StructArrayIndex_ContradictionsKeepPredicate(t *testing.T) {
+	helper := buildSchemaHelperWithStructArrayT(t)
+
+	for _, exprStr := range []string{
+		`struct_array[0][sub_int] > 100 and struct_array[0][sub_int] < 50`,
+		`not (struct_array[0][sub_int] > 100 and struct_array[0][sub_int] < 50)`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		require.NotNil(t, expr, exprStr)
+		require.False(t, rewriter.IsAlwaysFalseExpr(expr), "indexed struct array must not fold to valid false when the element can be missing: %s", exprStr)
+		require.False(t, rewriter.IsAlwaysTrueExpr(expr), "indexed struct array under NOT must not fold to valid true when the element can be missing: %s", exprStr)
+	}
 }
 
 // Test invalid BinaryRangeExpr: lower > upper → false

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -668,7 +668,7 @@ func (v *visitor) combineOrInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr {
 			}
 		}
 		if containsAny {
-			if !canFoldInNotEqualTautologyToTrue(g.col) {
+			if !canFoldBoolDomainToConstant(g.col) {
 				continue
 			}
 			used[g.termIdx] = true

--- a/internal/parser/planparserv2/rewriter/term_in.go
+++ b/internal/parser/planparserv2/rewriter/term_in.go
@@ -185,7 +185,7 @@ func (v *visitor) combineAndInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 		}
 		// If multiple different equals present, AND implies contradiction unless identical.
 		if len(eqUnique) > 1 {
-			if hasNullableFieldSemantics(g.col) {
+			if !canFoldBoolDomainToConstant(g.col) {
 				continue
 			}
 			for _, ti := range g.termIdxs {
@@ -207,7 +207,7 @@ func (v *visitor) combineAndInWithEqual(parts []*planpb.Expr) []*planpb.Expr {
 				break
 			}
 		}
-		if !inSet && hasNullableFieldSemantics(g.col) {
+		if !inSet && !canFoldBoolDomainToConstant(g.col) {
 			continue
 		}
 		for _, ti := range g.termIdxs {
@@ -380,7 +380,7 @@ func (v *visitor) combineAndInWithRange(parts []*planpb.Expr) []*planpb.Expr {
 			continue
 		}
 		filtered := filterValuesByRange(effectiveDataType(g.col), termVals, g.lower, g.lowerInc, g.upper, g.upperInc)
-		if len(filtered) == 0 && hasNullableFieldSemantics(g.col) {
+		if len(filtered) == 0 && !canFoldBoolDomainToConstant(g.col) {
 			continue
 		}
 		used[g.termIdx] = true
@@ -508,7 +508,7 @@ func (v *visitor) combineAndInWithIn(parts []*planpb.Expr) []*planpb.Expr {
 				inter = append(inter, v)
 			}
 		}
-		if len(inter) == 0 && hasNullableFieldSemantics(g.col) {
+		if len(inter) == 0 && !canFoldBoolDomainToConstant(g.col) {
 			continue
 		}
 		for _, i := range g.idxs {
@@ -587,7 +587,7 @@ func (v *visitor) combineAndInWithNotEqual(parts []*planpb.Expr) []*planpb.Expr 
 				filtered = append(filtered, tv)
 			}
 		}
-		if len(filtered) == 0 && hasNullableFieldSemantics(g.col) {
+		if len(filtered) == 0 && !canFoldBoolDomainToConstant(g.col) {
 			continue
 		}
 		used[g.termIdx] = true

--- a/internal/parser/planparserv2/rewriter/term_in_test.go
+++ b/internal/parser/planparserv2/rewriter/term_in_test.go
@@ -545,6 +545,36 @@ func TestRewrite_NullableArrayIndex_ContradictionsKeepPredicate(t *testing.T) {
 	}
 }
 
+func TestRewrite_ArrayIndex_ContradictionsKeepPredicate(t *testing.T) {
+	helper := buildSchemaHelperWithArraysT(t)
+
+	for _, exprStr := range []string{
+		`ArrayInt[0] in [1] and ArrayInt[0] == 2`,
+		`not (ArrayInt[0] in [1] and ArrayInt[0] == 2)`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		require.NotNil(t, expr, exprStr)
+		require.False(t, rewriter.IsAlwaysFalseExpr(expr), "indexed array must not fold to valid false when the index can be out of range: %s", exprStr)
+		require.False(t, rewriter.IsAlwaysTrueExpr(expr), "indexed array under NOT must not fold to valid true when the index can be out of range: %s", exprStr)
+	}
+}
+
+func TestRewrite_StructArrayIndex_ContradictionsKeepPredicate(t *testing.T) {
+	helper := buildSchemaHelperWithStructArrayT(t)
+
+	for _, exprStr := range []string{
+		`struct_array[0][sub_int] in [1] and struct_array[0][sub_int] == 2`,
+		`not (struct_array[0][sub_int] in [1] and struct_array[0][sub_int] == 2)`,
+	} {
+		expr, err := parser.ParseExpr(helper, exprStr, nil)
+		require.NoError(t, err, exprStr)
+		require.NotNil(t, expr, exprStr)
+		require.False(t, rewriter.IsAlwaysFalseExpr(expr), "indexed struct array must not fold to valid false when the element can be missing: %s", exprStr)
+		require.False(t, rewriter.IsAlwaysTrueExpr(expr), "indexed struct array under NOT must not fold to valid true when the element can be missing: %s", exprStr)
+	}
+}
+
 func TestRewrite_Or_In_Or_NotEqual_Nullable_NotDoesNotBecomeIsNull(t *testing.T) {
 	helper := buildSchemaHelperForRewriteNullableT(t)
 

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -217,10 +217,6 @@ func canFoldBoolDomainToConstant(col *planpb.ColumnInfo) bool {
 	return !hasNullableFieldSemantics(col) && !hasMissingPathSemantics(col)
 }
 
-func canFoldInNotEqualTautologyToTrue(col *planpb.ColumnInfo) bool {
-	return !hasNullableFieldSemantics(col) && !hasMissingPathSemantics(col)
-}
-
 func hasMissingPathNotEqualSemantics(col *planpb.ColumnInfo, values ...*planpb.GenericValue) bool {
 	return hasMissingPathSemantics(col)
 }

--- a/tests/go_client/testcases/query_test.go
+++ b/tests/go_client/testcases/query_test.go
@@ -950,7 +950,7 @@ func TestQueryObjectJsonExpr(t *testing.T) {
 		{expr: fmt.Sprintf("%s['interface'][6]['double'][3] == 1.7976931348623157e+308", common.DefaultJSONFieldName), count: common.DefaultNb},
 		{expr: fmt.Sprintf("%s['interface'][7]['bool'][0] == true", common.DefaultJSONFieldName), count: common.DefaultNb},
 		{expr: fmt.Sprintf("%s['interface'][7]['bool'][1] == false", common.DefaultJSONFieldName), count: common.DefaultNb},
-		{expr: fmt.Sprintf("array_length(%s['interface'][0]['empty_array']) == 0", common.DefaultJSONFieldName), count: common.DefaultNb},
+		{expr: fmt.Sprintf("array_length(%s['interface'][8]['empty_array']) == 0", common.DefaultJSONFieldName), count: common.DefaultNb},
 
 		// language
 		{expr: fmt.Sprintf("%s['language'][0]['中文'] == '月亮'", common.DefaultJSONFieldName), count: common.DefaultNb},

--- a/tests/python_client/milvus_client/test_milvus_client_regex_filter.py
+++ b/tests/python_client/milvus_client/test_milvus_client_regex_filter.py
@@ -805,7 +805,7 @@ class TestRegexFilterFieldAccess(RegexFilterSharedWideBase):
     def test_regex_array_element_negation(self):
         """
         target: verify !~ on ARRAY<VARCHAR> element paths
-        expected: tags[0] !~ "^release" -> [3,4,6,7], out-of-range !~ includes all rows
+        expected: tags[0] !~ "^release" -> [3,4,6,7], out-of-range !~ is UNKNOWN and excluded
         """
         client, collection_name = self._shared_collection()
 
@@ -815,7 +815,7 @@ class TestRegexFilterFieldAccess(RegexFilterSharedWideBase):
 
         res = client.query(collection_name, filter='tags[10] !~ ".*"', output_fields=["id"])
         result = sorted([r["id"] for r in res])
-        assert result == [1, 2, 3, 4, 5, 6, 7], f"out-of-range !~: expected all rows, got {result}"
+        assert result == [], f"out-of-range !~: expected [], got {result}"
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_regex_dynamic_json_field_paths(self):


### PR DESCRIPTION
## Summary

issue: #50976

This PR fixes NULL / UNKNOWN propagation gaps in filter expressions for missing nested values:

- Treat missing JSON arithmetic operands and JSON `array_length` extraction failures as UNKNOWN instead of definite booleans.
- Preserve UNKNOWN during parser/RBO contradiction folds for nested JSON paths, array subscripts, and struct-array subscripts.
- Treat missing array / struct-array elements as UNKNOWN during execution.
- Propagate JSON path/cast index typed-known masks so missing paths and cast failures are not matched by `!=`, `not in`, or outer `not(...)`.
- Propagate JSON flat index comparable-value masks for comparison predicates.

The commits are split by issue area:

- `4f15d6fe79` `fix: treat missing json arithmetic operands as unknown`
- `69d6e95917` `fix: preserve unknown for missing nested predicates in rbo`
- `51b58edf05` `fix: treat missing array elements as unknown`
- `d9dd4c9334` `fix: honor json path index unknown values`
- `a9d813b322` `fix: honor json flat index unknown values`

## Verification

- `LOCALSTORAGE_PATH=/tmp/milvus-test-localstorage go test -buildvcs=false -count=1 ./internal/parser/planparserv2/rewriter`
- `ninja -C /tmp/milvus-50976-build all_tests -j32`
- focused C++ regressions, including `JsonFlatIndexTest.*:JsonFlatIndexExprTest.*:JsonIndexTest.*:JsonPathIndexTest.*` (49 tests)
- focused array regressions including `Expr.TestArraySubscriptMissingElementIsUnknown` and `Expr.TestArray*`
- `git diff --check origin/master...HEAD`

## Note

While adding extra JsonFlatIndex null-expression coverage, a separate pre-existing `PhyNullExpr::DetermineExecPath()` / `std::call_once` deadlock was found. That hanging test is not included here; this PR keeps JsonFlatIndex coverage scoped to comparison UNKNOWN behavior.
