### PR TITLE
fix: [2.6] sync analyzer runtime options (#50997)

### DIFF
--- a/internal/core/src/segcore/tokenizer_c.cpp
+++ b/internal/core/src/segcore/tokenizer_c.cpp
@@ -20,6 +20,16 @@
 using Map = std::map<std::string, std::string>;
 
 CStatus
+set_tokenizer_option(const char* params) {
+    try {
+        milvus::tantivy::set_tokenizer_options(params);
+        return milvus::SuccessCStatus();
+    } catch (std::exception& e) {
+        return milvus::FailureCStatus(&e);
+    }
+}
+
+CStatus
 create_tokenizer(const char* params, CTokenizer* tokenizer) {
     try {
         auto impl = std::make_unique<milvus::tantivy::Tokenizer>(params);

--- a/internal/core/src/segcore/tokenizer_c.h
+++ b/internal/core/src/segcore/tokenizer_c.h
@@ -23,6 +23,9 @@ extern "C" {
 typedef void* CTokenizer;
 
 CStatus
+set_tokenizer_option(const char* params);
+
+CStatus
 create_tokenizer(const char* params, CTokenizer* tokenizer);
 
 CStatus

--- a/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/include/tantivy-binding.h
@@ -505,6 +505,8 @@ void *tantivy_clone_analyzer(void *ptr);
 
 void tantivy_free_analyzer(void *tokenizer);
 
+RustResult tantivy_set_analyzer_options(const char *params);
+
 bool tantivy_index_exist(const char *path);
 
 }  // extern "C"

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/mod.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/mod.rs
@@ -3,7 +3,9 @@ mod build_in_analyzer;
 mod dict;
 mod filter;
 
+pub mod options;
 pub mod tokenizers;
 pub use self::analyzer::{create_analyzer, create_analyzer_by_json};
+pub use self::options::set_options;
 
 pub(crate) use self::build_in_analyzer::standard_analyzer;

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/options/common.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/options/common.rs
@@ -1,0 +1,3 @@
+pub(crate) static LINDERA_DOWNLOAD_KEY: &str = "lindera_download_urls";
+
+pub static DEFAULT_DICT_PATH_KEY: &str = "default_dict_path";

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/options/mod.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/options/mod.rs
@@ -1,0 +1,5 @@
+mod common;
+mod runtime_option;
+
+pub use self::common::DEFAULT_DICT_PATH_KEY;
+pub use self::runtime_option::{get_lindera_download_url, get_options, set_options};

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/options/runtime_option.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/options/runtime_option.rs
@@ -1,0 +1,107 @@
+use super::common::*;
+use crate::error::{Result, TantivyBindingError};
+use once_cell::sync::Lazy;
+use serde_json as json;
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+static GLOBAL_OPTIONS: Lazy<RuntimeOption> = Lazy::new(RuntimeOption::new);
+
+pub fn set_options(params: &String) -> Result<()> {
+    GLOBAL_OPTIONS.set_json(params)
+}
+
+pub fn get_options(key: &str) -> Option<json::Value> {
+    GLOBAL_OPTIONS.get(key)
+}
+
+pub fn get_lindera_download_url(kind: &str) -> Option<Vec<String>> {
+    GLOBAL_OPTIONS.get_lindera_download_urls(kind)
+}
+
+struct RuntimeOption {
+    inner: RwLock<RuntimeOptionInner>,
+}
+
+impl RuntimeOption {
+    fn new() -> Self {
+        RuntimeOption {
+            inner: RwLock::new(RuntimeOptionInner::new()),
+        }
+    }
+
+    fn set_json(&self, json_params: &String) -> Result<()> {
+        let mut w = self.inner.write().unwrap();
+        w.set_json(json_params)
+    }
+
+    fn get(&self, key: &str) -> Option<json::Value> {
+        let r = self.inner.read().unwrap();
+        r.params.get(key).cloned()
+    }
+
+    fn get_lindera_download_urls(&self, kind: &str) -> Option<Vec<String>> {
+        let r = self.inner.read().unwrap();
+        r.lindera_download_urls.get(kind).cloned()
+    }
+}
+
+struct RuntimeOptionInner {
+    params: HashMap<String, json::Value>,
+    lindera_download_urls: HashMap<String, Vec<String>>,
+}
+
+impl RuntimeOptionInner {
+    fn new() -> Self {
+        RuntimeOptionInner {
+            params: HashMap::new(),
+            lindera_download_urls: HashMap::new(),
+        }
+    }
+
+    fn set_json(&mut self, json_params: &String) -> Result<()> {
+        let v =
+            json::from_str::<json::Value>(json_params).map_err(TantivyBindingError::JsonError)?;
+
+        let m = v.as_object().ok_or(TantivyBindingError::InternalError(
+            "analyzer params should be json map".to_string(),
+        ))?;
+
+        for (key, value) in m.to_owned() {
+            self.set(key, value)?;
+        }
+        Ok(())
+    }
+
+    fn set(&mut self, key: String, value: json::Value) -> Result<()> {
+        if key == LINDERA_DOWNLOAD_KEY {
+            self.lindera_download_urls = HashMap::new();
+
+            let m = value.as_object().ok_or(TantivyBindingError::InternalError(
+                "lindera download urls should be a json map".to_string(),
+            ))?;
+
+            for (key, value) in m {
+                let array = value.as_array().ok_or(TantivyBindingError::InternalError(
+                    "lindera download urls should be list".to_string(),
+                ))?;
+
+                if !array.iter().all(|v| v.is_string()) {
+                    return Err(TantivyBindingError::InternalError(
+                        "all elements in lindera download urls must be string".to_string(),
+                    ));
+                }
+
+                let urls = array
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect();
+                self.lindera_download_urls.insert(key.to_string(), urls);
+            }
+            return Ok(());
+        }
+
+        self.params.insert(key, value);
+        Ok(())
+    }
+}

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/lindera_tokenizer.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/analyzer/tokenizers/lindera_tokenizer.rs
@@ -19,6 +19,7 @@ use lindera_dictionary::viterbi::Lattice;
 
 use crate::analyzer::dict::lindera::load_dictionary_from_kind;
 use crate::analyzer::filter::get_string_list;
+use crate::analyzer::options::{get_lindera_download_url, get_options, DEFAULT_DICT_PATH_KEY};
 use crate::error::{Result, TantivyBindingError};
 use serde_json as json;
 /// Segmenter
@@ -119,8 +120,6 @@ pub struct LinderaTokenStream<'a> {
 }
 
 const DICTKINDKEY: &str = "dict_kind";
-const DICTBUILDDIRKEY: &str = "dict_build_dir";
-const DICTDOWNLOADURLKEY: &str = "download_urls";
 const FILTERKEY: &str = "filter";
 
 impl<'a> TokenStream for LinderaTokenStream<'a> {
@@ -175,8 +174,8 @@ impl LinderaTokenizer {
         let kind: DictionaryKind = fetch_lindera_kind(params)?;
 
         // for download dict online
-        let build_dir = fetch_dict_build_dir(params)?;
-        let download_urls = fetch_dict_download_urls(params)?;
+        let build_dir = fetch_dict_build_dir()?;
+        let download_urls = get_lindera_download_url(kind.as_str()).unwrap_or(vec![]);
 
         let dictionary = load_dictionary_from_kind(&kind, build_dir, download_urls)?;
 
@@ -278,21 +277,13 @@ fn fetch_lindera_kind(params: &json::Map<String, json::Value>) -> Result<Diction
         .into_dict_kind()
 }
 
-fn fetch_dict_build_dir(params: &json::Map<String, json::Value>) -> Result<String> {
-    params
-        .get(DICTBUILDDIRKEY)
-        .map_or(Ok("/var/lib/milvus/dict/lindera".to_string()), |v| {
-            v.as_str()
-                .ok_or(TantivyBindingError::InvalidArgument(format!(
-                    "dict build dir must be string"
-                )))
-                .map(|s| s.to_string())
-        })
-}
-
-fn fetch_dict_download_urls(params: &json::Map<String, json::Value>) -> Result<Vec<String>> {
-    params.get(DICTDOWNLOADURLKEY).map_or(Ok(vec![]), |v| {
-        get_string_list(v, "lindera dict download urls")
+fn fetch_dict_build_dir() -> Result<String> {
+    get_options(DEFAULT_DICT_PATH_KEY).map_or(Ok("/var/lib/milvus/dict/lindera".to_string()), |v| {
+        v.as_str()
+            .ok_or(TantivyBindingError::InvalidArgument(format!(
+                "dict build dir must be string"
+            )))
+            .map(|s| format!("{}/{}", s, "lindera").to_string())
     })
 }
 

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/array.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/array.rs
@@ -131,6 +131,14 @@ pub struct RustResult {
 }
 
 impl RustResult {
+    pub fn from_success() -> Self {
+        RustResult {
+            success: true,
+            value: Value::None(()),
+            error: std::ptr::null(),
+        }
+    }
+
     pub fn from_ptr(value: *mut c_void) -> Self {
         RustResult {
             success: true,

--- a/internal/core/thirdparty/tantivy/tantivy-binding/src/tokenizer_c.rs
+++ b/internal/core/thirdparty/tantivy/tantivy-binding/src/tokenizer_c.rs
@@ -2,7 +2,7 @@ use libc::{c_char, c_void};
 use tantivy::tokenizer::TextAnalyzer;
 
 use crate::{
-    analyzer::create_analyzer,
+    analyzer::{create_analyzer, set_options},
     array::RustResult,
     log::init_log,
     string_c::c_str_to_str,
@@ -33,4 +33,20 @@ pub extern "C" fn tantivy_clone_analyzer(ptr: *mut c_void) -> *mut c_void {
 #[no_mangle]
 pub extern "C" fn tantivy_free_analyzer(tokenizer: *mut c_void) {
     free_binding::<TextAnalyzer>(tokenizer);
+}
+
+#[no_mangle]
+pub extern "C" fn tantivy_set_analyzer_options(params: *const c_char) -> RustResult {
+    init_log();
+    let json_str = unsafe { c_str_to_str(params).to_string() };
+
+    set_options(&json_str).map_or_else(
+        |e| {
+            RustResult::from_error(format!(
+                "set analyzer option failed: {}, params: {}",
+                e, json_str
+            ))
+        },
+        |_| RustResult::from_success(),
+    )
 }

--- a/internal/core/thirdparty/tantivy/tokenizer.h
+++ b/internal/core/thirdparty/tantivy/tokenizer.h
@@ -58,4 +58,14 @@ struct Tokenizer {
     void* ptr_;
 };
 
+inline void
+set_tokenizer_options(std::string&& params) {
+    auto shared_params = std::make_shared<std::string>(params);
+    auto res =
+        RustResultWrapper(tantivy_set_analyzer_options(shared_params->c_str()));
+    AssertInfo(res.result_->success,
+               "Set analyzer option failed: {}",
+               res.result_->error);
+}
+
 }  // namespace milvus::tantivy

--- a/internal/datanode/data_node.go
+++ b/internal/datanode/data_node.go
@@ -38,6 +38,7 @@ import (
 	"github.com/milvus-io/milvus/internal/datanode/index"
 	"github.com/milvus-io/milvus/internal/flushcommon/syncmgr"
 	"github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/internal/util/analyzer"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/metrics"
@@ -197,6 +198,12 @@ func (node *DataNode) Init() error {
 		err := index.InitSegcore(serverID)
 		if err != nil {
 			initError = err
+			return
+		}
+		if err := analyzer.InitOptions(); err != nil {
+			log.Error("DataNode init analyzer options failed", zap.Error(err))
+			initError = err
+			return
 		}
 		log.Info("init datanode done", zap.String("Address", node.address))
 	})

--- a/internal/querynodev2/server.go
+++ b/internal/querynodev2/server.go
@@ -52,6 +52,7 @@ import (
 	"github.com/milvus-io/milvus/internal/registry"
 	"github.com/milvus-io/milvus/internal/storage"
 	"github.com/milvus-io/milvus/internal/types"
+	"github.com/milvus-io/milvus/internal/util/analyzer"
 	_ "github.com/milvus-io/milvus/internal/util/cgo"
 	"github.com/milvus-io/milvus/internal/util/dependency"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
@@ -333,6 +334,11 @@ func (node *QueryNode) Init() error {
 		}
 
 		node.factory.Init(paramtable.Get())
+		if err := analyzer.InitOptions(); err != nil {
+			log.Error("QueryNode init analyzer options failed", zap.Error(err))
+			initError = err
+			return
+		}
 
 		localRootPath := paramtable.Get().LocalStorageCfg.Path.GetValue()
 		localUsedSize, err := segcore.GetLocalUsedSize(localRootPath)

--- a/internal/streamingnode/server/server.go
+++ b/internal/streamingnode/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/milvus-io/milvus/internal/streamingnode/server/resource"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/service"
 	"github.com/milvus-io/milvus/internal/streamingnode/server/walmanager"
+	"github.com/milvus-io/milvus/internal/util/analyzer"
 	"github.com/milvus-io/milvus/internal/util/initcore"
 	"github.com/milvus-io/milvus/internal/util/sessionutil"
 	"github.com/milvus-io/milvus/pkg/v2/log"
@@ -41,6 +42,10 @@ func (s *Server) init() {
 
 	// init all service.
 	s.initService()
+
+	if err := analyzer.InitOptions(); err != nil {
+		panic(fmt.Sprintf("init analyzer options failed, %+v", err))
+	}
 
 	log.Info("init query segcore...")
 	if err := initcore.InitQueryNode(context.TODO()); err != nil {

--- a/internal/util/analyzer/analyzer.go
+++ b/internal/util/analyzer/analyzer.go
@@ -17,3 +17,7 @@ func NewAnalyzer(param string) (Analyzer, error) {
 func ValidateAnalyzer(param string) error {
 	return canalyzer.ValidateAnalyzer(param)
 }
+
+func InitOptions() error {
+	return canalyzer.InitOptions()
+}

--- a/internal/util/analyzer/canalyzer/c_analyzer_factory.go
+++ b/internal/util/analyzer/canalyzer/c_analyzer_factory.go
@@ -10,21 +10,87 @@ import "C"
 
 import (
 	"encoding/json"
-	"fmt"
-	"path"
+	"strings"
+	"sync"
 	"unsafe"
 
+	"go.uber.org/zap"
+
 	"github.com/milvus-io/milvus/internal/util/analyzer/interfaces"
-	"github.com/milvus-io/milvus/pkg/v2/util/merr"
+	"github.com/milvus-io/milvus/pkg/v2/config"
+	"github.com/milvus-io/milvus/pkg/v2/log"
 	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
 )
 
-func NewAnalyzer(param string) (interfaces.Analyzer, error) {
-	param, err := CheckAndFillParams(param)
-	if err != nil {
-		return nil, err
+const (
+	AnalyzerConfigPrefix = "function.analyzer."
+	LinderaDictURLKey    = "lindera_download_urls"
+	DefaultDictPathKey   = "default_dict_path"
+)
+
+var (
+	initMu             sync.Mutex
+	optionsInitialized bool
+)
+
+func InitOptions() error {
+	initMu.Lock()
+	defer initMu.Unlock()
+
+	if optionsInitialized {
+		return nil
 	}
 
+	if err := UpdateParams(); err != nil {
+		return err
+	}
+
+	paramtable.Get().WatchKeyPrefix(AnalyzerConfigPrefix, config.NewHandler("analyzer.runtime_options", func(*config.Event) {
+		if err := updateParams(); err != nil {
+			log.Error("update analyzer option failed", zap.Error(err))
+		}
+	}))
+	optionsInitialized = true
+	return nil
+}
+
+func BuildRuntimeOptions() map[string]any {
+	cfg := paramtable.Get()
+	return map[string]any{
+		LinderaDictURLKey:  buildLinderaDownloadURLs(cfg.FunctionCfg.LinderaDownloadUrls.GetValue()),
+		DefaultDictPathKey: cfg.FunctionCfg.LocalResourcePath.GetValue(),
+	}
+}
+
+func buildLinderaDownloadURLs(values map[string]string) map[string][]string {
+	urls := make(map[string][]string, len(values))
+	for kind, value := range values {
+		urls[strings.TrimPrefix(kind, ".")] = paramtable.ParseAsStings(value)
+	}
+	return urls
+}
+
+func UpdateParams() error {
+	return updateParams()
+}
+
+func updateParams() error {
+	bytes, err := json.Marshal(BuildRuntimeOptions())
+	if err != nil {
+		return err
+	}
+
+	paramPtr := C.CString(string(bytes))
+	defer C.free(unsafe.Pointer(paramPtr))
+
+	status := C.set_tokenizer_option(paramPtr)
+	if err := HandleCStatus(&status, "failed to init segcore analyzer option"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func NewAnalyzer(param string) (interfaces.Analyzer, error) {
 	paramPtr := C.CString(param)
 	defer C.free(unsafe.Pointer(paramPtr))
 
@@ -38,11 +104,6 @@ func NewAnalyzer(param string) (interfaces.Analyzer, error) {
 }
 
 func ValidateAnalyzer(param string) error {
-	param, err := CheckAndFillParams(param)
-	if err != nil {
-		return err
-	}
-
 	paramPtr := C.CString(param)
 	defer C.free(unsafe.Pointer(paramPtr))
 
@@ -51,92 +112,4 @@ func ValidateAnalyzer(param string) error {
 		return err
 	}
 	return nil
-}
-
-func CheckAndFillParams(params string) (string, error) {
-	if len(params) == 0 {
-		return "", nil
-	}
-
-	var paramMaps map[string]any
-	flag := false
-	err := json.Unmarshal([]byte(params), &paramMaps)
-	if err != nil {
-		return "", merr.WrapErrAsInputError(fmt.Errorf("unmarshal analyzer params failed with json error: %s", err.Error()))
-	}
-
-	tokenizer, ok := paramMaps["tokenizer"]
-	if !ok {
-		// skip check if no tokenizer params
-		return params, nil
-	}
-
-	switch value := tokenizer.(type) {
-	case string:
-		// return if use build-in tokenizer
-		return params, nil
-	case map[string]any:
-		flag, err = CheckAndFillTokenizerParams(value)
-		if err != nil {
-			return "", err
-		}
-	default:
-		return "", merr.WrapErrAsInputError(fmt.Errorf("analyzer params set tokenizer with unknown type"))
-	}
-
-	// remarshal json params if params map was changed.
-	if flag {
-		bytes, err := json.Marshal(paramMaps)
-		if err != nil {
-			return "", merr.WrapErrAsInputError(fmt.Errorf("marshal analyzer params failed with json error: %s", err.Error()))
-		}
-		return string(bytes), nil
-	}
-	return params, nil
-}
-
-// fill some milvus params to tokenizer params
-func CheckAndFillTokenizerParams(params map[string]any) (bool, error) {
-	v, ok := params["type"]
-	if !ok {
-		return false, merr.WrapErrAsInputError(fmt.Errorf("costom tokenizer must set type"))
-	}
-
-	tokenizerType, ok := v.(string)
-	if !ok {
-		return false, merr.WrapErrAsInputError(fmt.Errorf("costom tokenizer type must be string"))
-	}
-
-	switch tokenizerType {
-	case "lindera":
-		cfg := paramtable.Get()
-
-		if _, ok := params["dict_build_dir"]; ok {
-			return false, merr.WrapErrAsInputError(fmt.Errorf("costom tokenizer dict_build_dir was system params, should not be set"))
-		}
-		// build lindera to LocalResourcePath/lindera/dict_kind
-		params["dict_build_dir"] = path.Join(cfg.FunctionCfg.LocalResourcePath.GetValue(), "lindera")
-
-		v, ok := params["dict_kind"]
-		if !ok {
-			return false, merr.WrapErrAsInputError(fmt.Errorf("lindera tokenizer must set dict_kind"))
-		}
-		dictKind, ok := v.(string)
-		if !ok {
-			return false, merr.WrapErrAsInputError(fmt.Errorf("lindera tokenizer dict kind must be string"))
-		}
-		dictUrlsMap := cfg.FunctionCfg.LinderaDownloadUrls.GetValue()
-
-		if _, ok := params["download_urls"]; ok {
-			return false, merr.WrapErrAsInputError(fmt.Errorf("costom tokenizer download_urls was system params, should not be set"))
-		}
-
-		if value, ok := dictUrlsMap["."+dictKind]; ok {
-			// use download urls set in milvus yaml
-			params["download_urls"] = paramtable.ParseAsStings(value)
-		}
-		return true, nil
-	default:
-		return false, nil
-	}
 }

--- a/internal/util/analyzer/canalyzer/c_analyzer_factory.go
+++ b/internal/util/analyzer/canalyzer/c_analyzer_factory.go
@@ -41,7 +41,7 @@ func InitOptions() error {
 		return nil
 	}
 
-	if err := UpdateParams(); err != nil {
+	if err := updateParams(); err != nil {
 		return err
 	}
 
@@ -70,10 +70,6 @@ func buildLinderaDownloadURLs(values map[string]string) map[string][]string {
 	return urls
 }
 
-func UpdateParams() error {
-	return updateParams()
-}
-
 func updateParams() error {
 	bytes, err := json.Marshal(BuildRuntimeOptions())
 	if err != nil {
@@ -84,10 +80,7 @@ func updateParams() error {
 	defer C.free(unsafe.Pointer(paramPtr))
 
 	status := C.set_tokenizer_option(paramPtr)
-	if err := HandleCStatus(&status, "failed to init segcore analyzer option"); err != nil {
-		return err
-	}
-	return nil
+	return HandleCStatus(&status, "failed to init segcore analyzer option")
 }
 
 func NewAnalyzer(param string) (interfaces.Analyzer, error) {
@@ -108,8 +101,5 @@ func ValidateAnalyzer(param string) error {
 	defer C.free(unsafe.Pointer(paramPtr))
 
 	status := C.validate_tokenizer(paramPtr)
-	if err := HandleCStatus(&status, "failed to create tokenizer"); err != nil {
-		return err
-	}
-	return nil
+	return HandleCStatus(&status, "failed to create tokenizer")
 }

--- a/internal/util/analyzer/canalyzer/c_analyzer_test.go
+++ b/internal/util/analyzer/canalyzer/c_analyzer_test.go
@@ -173,70 +173,23 @@ func TestValidateAnalyzer(t *testing.T) {
 	}
 }
 
-func TestCheckAndFillParams(t *testing.T) {
-	paramtable.Init()
-	paramtable.Get().SaveGroup(map[string]string{"function.analyzer.lindera.download_urls.ipadic": "/test/url"})
+func TestBuildRuntimeOptions(t *testing.T) {
+	params := paramtable.Get()
+	localResourcePath := "/tmp/milvus-analyzer-test"
+	urlKey := "function.analyzer.lindera.download_urls.ipadic"
+	require.NoError(t, params.Save(params.FunctionCfg.LocalResourcePath.Key, localResourcePath))
+	require.NoError(t, params.SaveGroup(map[string]string{urlKey: "http://a.test/ipadic.tar.gz, http://b.test/ipadic.tar.gz"}))
+	defer params.Reset(params.FunctionCfg.LocalResourcePath.Key)
+	defer params.Reset(urlKey)
 
-	// normal case
-	{
-		m := "{\"tokenizer\": {\"type\":\"jieba\"}}"
-		_, err := CheckAndFillParams(m)
-		assert.NoError(t, err)
-	}
-
-	// fill lindera tokenizer download urls and dict local path
-	{
-		m := "{\"tokenizer\": {\"type\":\"lindera\", \"dict_kind\": \"ipadic\"}}"
-		_, err := CheckAndFillParams(m)
-		assert.NoError(t, err)
-	}
-
-	// error with wrong json
-	{
-		m := "{invalid json"
-		_, err := CheckAndFillParams(m)
-		assert.Error(t, err)
-	}
-
-	// skip if use default analyzer
-	{
-		m := "{}"
-		_, err := CheckAndFillParams(m)
-		assert.NoError(t, err)
-	}
-
-	// error tokenizer without type
-	{
-		m := "{\"tokenizer\": {\"dict_kind\": \"ipadic\"}}"
-		_, err := CheckAndFillParams(m)
-		assert.Error(t, err)
-	}
-
-	// error tokenizer type not string
-	{
-		m := "{\"tokenizer\": {\"type\": 1, \"dict_kind\": \"ipadic\"}}"
-		_, err := CheckAndFillParams(m)
-		assert.Error(t, err)
-	}
-
-	// error tokenizer params type
-	{
-		m := "{\"tokenizer\": 1}"
-		_, err := CheckAndFillParams(m)
-		assert.Error(t, err)
-	}
-
-	// error set dict_build_dir by user
-	{
-		m := "{\"tokenizer\": {\"type\": \"lindera\", \"dict_kind\": \"ipadic\", \"dict_build_dir\": \"/tmp/milvus\"}}"
-		_, err := CheckAndFillParams(m)
-		assert.Error(t, err)
-	}
-
-	// error lindera kind not set
-	{
-		m := "{\"tokenizer\": {\"type\": \"lindera\"}}"
-		_, err := CheckAndFillParams(m)
-		assert.Error(t, err)
-	}
+	options := BuildRuntimeOptions()
+	assert.Equal(t, localResourcePath, options[DefaultDictPathKey])
+	assert.Equal(t,
+		map[string][]string{"ipadic": {"http://a.test/ipadic.tar.gz", "http://b.test/ipadic.tar.gz"}},
+		options[LinderaDictURLKey],
+	)
+	assert.Equal(t,
+		map[string][]string{"ipadic": {"http://a.test/ipadic.tar.gz"}},
+		buildLinderaDownloadURLs(map[string]string{".ipadic": "http://a.test/ipadic.tar.gz"}),
+	)
 }

--- a/tests/go_client/testcases/query_test.go
+++ b/tests/go_client/testcases/query_test.go
@@ -1219,7 +1219,7 @@ func TestRunAnalyzer(t *testing.T) {
 
 	// run analyzer with invalid params
 	_, err = mc.RunAnalyzer(ctx, client.NewRunAnalyzerOption("text doc").WithAnalyzerParamsStr("invalid params}"))
-	common.CheckErr(t, err, false, "json error")
+	common.CheckErr(t, err, false, "JsonError")
 
 	// run analyzer with custom analyzer
 	tokens, err = mc.RunAnalyzer(ctx, client.NewRunAnalyzerOption("test doc").


### PR DESCRIPTION
issue: #50931
pr: https://github.com/milvus-io/milvus/pull/50997

## Summary
Initialize analyzer runtime options with Lindera download URLs and the default dictionary path. Register runtime config callbacks so analyzer yaml updates are propagated to the Rust analyzer layer.