### PR TITLE
enhance: back off re-dispatch of failed datacoord tasks

### DIFF
--- a/configs/milvus.yaml
+++ b/configs/milvus.yaml
@@ -813,6 +813,8 @@ dataCoord:
     pendingTimeout: 60 # Timeout in minutes for pending snapshots before GC cleanup
     maxCompactionProtectionSeconds: 604800 # Maximum allowed compaction protection duration in seconds (default 604800 = 7 days)
   enableActiveStandby: false
+  taskRetryBackoffInterval: 1 # Initial backoff in seconds before re-dispatching a task (compaction/stats/index/import) that failed on a worker; doubles on each consecutive failure up to dataCoord.taskRetryBackoffMaxInterval. 0 disables the backoff (legacy behavior: failed tasks are re-dispatched every scheduling tick).
+  taskRetryBackoffMaxInterval: 60 # Maximum backoff in seconds between re-dispatches of a task that keeps failing on workers.
   brokerTimeout: 5000 # 5000ms, dataCoord broker rpc timeout
   autoBalance: true # Enable auto balance
   checkAutoBalanceConfigInterval: 10 # the interval of check auto balance config

--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -54,6 +54,55 @@ type globalTaskScheduler struct {
 	execPool     *conc.Pool[struct{}]
 	checkPool    *conc.Pool[struct{}]
 	cluster      session.Cluster
+	// backoffs delays re-dispatch of tasks that failed on a worker. Without
+	// it a task that keeps failing (e.g. its object-storage reads are being
+	// throttled) is re-sent every TaskScheduleInterval (~100ms), which turns
+	// one bad task into a dispatch storm that keeps the store throttled.
+	backoffs *typeutil.ConcurrentMap[int64, *taskBackoff]
+}
+
+// taskBackoff records how often a task failed on a worker and when it may be
+// dispatched again. Entries are replaced wholesale (copy-on-write) so readers
+// never observe a partially updated value.
+type taskBackoff struct {
+	failures  int
+	notBefore time.Time
+}
+
+// recordTaskFailure schedules the next dispatch of a failed task with
+// exponential backoff: interval * 2^(failures-1), capped at maxInterval.
+func (s *globalTaskScheduler) recordTaskFailure(task Task) {
+	interval := paramtable.Get().DataCoordCfg.TaskRetryBackoffInterval.GetAsDuration(time.Second)
+	if interval <= 0 {
+		return
+	}
+	maxInterval := paramtable.Get().DataCoordCfg.TaskRetryBackoffMaxInterval.GetAsDuration(time.Second)
+
+	failures := 1
+	if old, ok := s.backoffs.Get(task.GetTaskID()); ok {
+		failures = old.failures + 1
+	}
+	// cap the shift to keep the doubling far away from overflow
+	if shift := failures - 1; shift < 30 {
+		interval <<= shift
+	} else {
+		interval = maxInterval
+	}
+	if maxInterval > 0 && interval > maxInterval {
+		interval = maxInterval
+	}
+	s.backoffs.Insert(task.GetTaskID(), &taskBackoff{
+		failures:  failures,
+		notBefore: time.Now().Add(interval),
+	})
+	mlog.Info(s.ctx, "task failed on worker, backing off before retry",
+		WrapTaskLog(task, mlog.Int("failures", failures), mlog.Duration("backoff", interval))...)
+}
+
+// taskInBackoff reports whether the task's next dispatch is still delayed.
+func (s *globalTaskScheduler) taskInBackoff(task Task) bool {
+	bo, ok := s.backoffs.Get(task.GetTaskID())
+	return ok && time.Now().Before(bo.notBefore)
 }
 
 func (s *globalTaskScheduler) Enqueue(task Task) {
@@ -84,6 +133,7 @@ func (s *globalTaskScheduler) AbortAndRemoveTask(taskID int64) {
 		task.DropTaskOnWorker(s.cluster)
 		s.pendingTasks.Remove(taskID)
 	}
+	s.backoffs.Remove(taskID)
 }
 
 func (s *globalTaskScheduler) Start() {
@@ -166,10 +216,18 @@ func (s *globalTaskScheduler) schedule() {
 	mlog.Info(s.ctx, "scheduling pending tasks...", mlog.Int("num", pendingNum), mlog.Any("nodeSlots", nodeSlots))
 
 	futures := make([]*conc.Future[struct{}], 0)
+	var delayed []Task
 	for {
 		task := s.pendingTasks.Pop()
 		if task == nil {
 			break
+		}
+		// A task in failure backoff gives way: it re-enters the queue after
+		// this round and is dispatched once its delay elapses, so one
+		// persistently failing task cannot occupy the scheduler.
+		if s.taskInBackoff(task) {
+			delayed = append(delayed, task)
+			continue
 		}
 		taskSlot := task.GetTaskSlot()
 		nodeID := s.pickNode(nodeSlots, taskSlot)
@@ -185,6 +243,7 @@ func (s *globalTaskScheduler) schedule() {
 				task.CreateTaskOnWorker(nodeID, s.cluster)
 				switch task.GetTaskState() {
 				case taskcommon.Init, taskcommon.Retry:
+					s.recordTaskFailure(task)
 					s.pendingTasks.Push(task)
 				case taskcommon.InProgress:
 					task.SetTaskTime(taskcommon.TimeStart, time.Now())
@@ -194,6 +253,9 @@ func (s *globalTaskScheduler) schedule() {
 			return struct{}{}, nil
 		})
 		futures = append(futures, future)
+	}
+	for _, task := range delayed {
+		s.pendingTasks.Push(task)
 	}
 	_ = conc.AwaitAll(futures...)
 }
@@ -214,13 +276,16 @@ func (s *globalTaskScheduler) check() {
 			switch task.GetTaskState() {
 			case taskcommon.None:
 				s.runningTasks.Remove(task.GetTaskID())
+				s.backoffs.Remove(task.GetTaskID())
 			case taskcommon.Init, taskcommon.Retry:
+				s.recordTaskFailure(task)
 				s.runningTasks.Remove(task.GetTaskID())
 				s.pendingTasks.Push(task)
 			case taskcommon.Finished, taskcommon.Failed:
 				task.SetTaskTime(taskcommon.TimeEnd, time.Now())
 				task.DropTaskOnWorker(s.cluster)
 				s.runningTasks.Remove(task.GetTaskID())
+				s.backoffs.Remove(task.GetTaskID())
 			}
 			return struct{}{}, nil
 		})
@@ -329,5 +394,6 @@ func NewGlobalTaskScheduler(ctx context.Context, cluster session.Cluster) Global
 		execPool:     execPool,
 		checkPool:    checkPool,
 		cluster:      cluster,
+		backoffs:     typeutil.NewConcurrentMap[int64, *taskBackoff](),
 	}
 }

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -268,3 +268,80 @@ func TestGlobalScheduler_TestSchedule(t *testing.T) {
 		}, 10*time.Second, 10*time.Millisecond)
 	})
 }
+
+func TestGlobalScheduler_RecordTaskFailureBackoff(t *testing.T) {
+	pt := paramtable.Get()
+	pt.Save(pt.DataCoordCfg.TaskRetryBackoffInterval.Key, "1")
+	pt.Save(pt.DataCoordCfg.TaskRetryBackoffMaxInterval.Key, "4")
+	defer pt.Reset(pt.DataCoordCfg.TaskRetryBackoffInterval.Key)
+	defer pt.Reset(pt.DataCoordCfg.TaskRetryBackoffMaxInterval.Key)
+
+	scheduler := NewGlobalTaskScheduler(context.TODO(), nil).(*globalTaskScheduler)
+	task := NewMockTask(t)
+	task.EXPECT().GetTaskID().Return(7).Maybe()
+	task.EXPECT().GetTaskType().Return(taskcommon.Index).Maybe()
+	task.EXPECT().GetTaskState().Return(taskcommon.Init).Maybe()
+
+	// exponential: 1s, 2s, 4s, then capped at the 4s max
+	start := time.Now()
+	scheduler.recordTaskFailure(task)
+	bo, ok := scheduler.backoffs.Get(7)
+	assert.True(t, ok)
+	assert.Equal(t, 1, bo.failures)
+	assert.InDelta(t, 1.0, bo.notBefore.Sub(start).Seconds(), 0.5)
+	assert.True(t, scheduler.taskInBackoff(task))
+
+	scheduler.recordTaskFailure(task)
+	scheduler.recordTaskFailure(task)
+	scheduler.recordTaskFailure(task)
+	bo, _ = scheduler.backoffs.Get(7)
+	assert.Equal(t, 4, bo.failures)
+	assert.InDelta(t, 4.0, bo.notBefore.Sub(time.Now()).Seconds(), 0.5)
+
+	// clearing the entry ends the backoff
+	scheduler.backoffs.Remove(7)
+	assert.False(t, scheduler.taskInBackoff(task))
+
+	// interval 0 disables the mechanism entirely
+	pt.Save(pt.DataCoordCfg.TaskRetryBackoffInterval.Key, "0")
+	scheduler.recordTaskFailure(task)
+	assert.False(t, scheduler.taskInBackoff(task))
+}
+
+func TestGlobalScheduler_FailedTaskBacksOffBeforeRedispatch(t *testing.T) {
+	pt := paramtable.Get()
+	pt.Save(pt.DataCoordCfg.TaskRetryBackoffInterval.Key, "1")
+	defer pt.Reset(pt.DataCoordCfg.TaskRetryBackoffInterval.Key)
+
+	cluster := session.NewMockCluster(t)
+	cluster.EXPECT().QuerySlot().Return(map[int64]*session.WorkerSlots{
+		1: {NodeID: 1, AvailableSlots: 100},
+	}).Maybe()
+
+	scheduler := NewGlobalTaskScheduler(context.TODO(), cluster)
+	scheduler.Start()
+	defer scheduler.Stop()
+
+	task := NewMockTask(t)
+	task.EXPECT().GetTaskID().Return(1).Maybe()
+	task.EXPECT().GetTaskType().Return(taskcommon.Index).Maybe()
+	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return().Maybe()
+	task.EXPECT().GetTaskSlot().Return(1).Maybe()
+	// CreateTaskOnWorker never flips the state away from Init: every dispatch fails
+	task.EXPECT().GetTaskState().Return(taskcommon.Init).Maybe()
+	var createCalls atomic.Int32
+	task.EXPECT().CreateTaskOnWorker(mock.Anything, mock.Anything).Run(func(nodeID int64, cluster session.Cluster) {
+		createCalls.Add(1)
+	}).Maybe()
+
+	scheduler.Enqueue(task)
+
+	// the first dispatch happens promptly
+	assert.Eventually(t, func() bool { return createCalls.Load() == 1 }, 2*time.Second, 10*time.Millisecond)
+	// during the 1s backoff the ~100ms scheduling tick must NOT re-dispatch
+	// (without backoff this would already be ~5 more dispatches)
+	time.Sleep(500 * time.Millisecond)
+	assert.Equal(t, int32(1), createCalls.Load())
+	// after the backoff elapses it is dispatched again
+	assert.Eventually(t, func() bool { return createCalls.Load() >= 2 }, 3*time.Second, 10*time.Millisecond)
+}

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -296,7 +296,7 @@ func TestGlobalScheduler_RecordTaskFailureBackoff(t *testing.T) {
 	scheduler.recordTaskFailure(task)
 	bo, _ = scheduler.backoffs.Get(7)
 	assert.Equal(t, 4, bo.failures)
-	assert.InDelta(t, 4.0, bo.notBefore.Sub(time.Now()).Seconds(), 0.5)
+	assert.InDelta(t, 4.0, time.Until(bo.notBefore).Seconds(), 0.5)
 
 	// clearing the entry ends the backoff
 	scheduler.backoffs.Remove(7)

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5288,12 +5288,14 @@ type dataCoordConfig struct {
 	GCLOBSafetyWindow  ParamItem `refreshable:"true"`
 	GCLOBCheckInterval ParamItem `refreshable:"true"`
 
-	BindIndexNodeMode    ParamItem `refreshable:"false"`
-	IndexNodeAddress     ParamItem `refreshable:"false"`
-	WithCredential       ParamItem `refreshable:"false"`
-	IndexNodeID          ParamItem `refreshable:"false"`
-	TaskScheduleInterval ParamItem `refreshable:"false"`
-	TaskSlowThreshold    ParamItem `refreshable:"true"`
+	BindIndexNodeMode           ParamItem `refreshable:"false"`
+	IndexNodeAddress            ParamItem `refreshable:"false"`
+	WithCredential              ParamItem `refreshable:"false"`
+	IndexNodeID                 ParamItem `refreshable:"false"`
+	TaskScheduleInterval        ParamItem `refreshable:"false"`
+	TaskRetryBackoffInterval    ParamItem `refreshable:"true"`
+	TaskRetryBackoffMaxInterval ParamItem `refreshable:"true"`
+	TaskSlowThreshold           ParamItem `refreshable:"true"`
 
 	MinSegmentNumRowsToEnableIndex ParamItem `refreshable:"true"`
 	BrokerTimeout                  ParamItem `refreshable:"false"`
@@ -6322,6 +6324,25 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		DefaultValue: "100",
 	}
 	p.TaskScheduleInterval.Init(base.mgr)
+
+	p.TaskRetryBackoffInterval = ParamItem{
+		Key:          "dataCoord.taskRetryBackoffInterval",
+		Version:      "2.6.18",
+		DefaultValue: "1",
+		Doc: "Initial backoff in seconds before re-dispatching a task (compaction/stats/index/import) that failed on a worker; " +
+			"doubles on each consecutive failure up to dataCoord.taskRetryBackoffMaxInterval. 0 disables the backoff (legacy behavior: failed tasks are re-dispatched every scheduling tick).",
+		Export: true,
+	}
+	p.TaskRetryBackoffInterval.Init(base.mgr)
+
+	p.TaskRetryBackoffMaxInterval = ParamItem{
+		Key:          "dataCoord.taskRetryBackoffMaxInterval",
+		Version:      "2.6.18",
+		DefaultValue: "60",
+		Doc:          "Maximum backoff in seconds between re-dispatches of a task that keeps failing on workers.",
+		Export:       true,
+	}
+	p.TaskRetryBackoffMaxInterval.Init(base.mgr)
 
 	p.TaskSlowThreshold = ParamItem{
 		Key:          "datacoord.scheduler.taskSlowThreshold",


### PR DESCRIPTION
issue: #51019

## What

A task that fails on a worker (compaction / stats / index / import) is reset to `Init`/`Retry` and re-dispatched by the DataCoord global task scheduler on the next ~100ms tick, with no backoff and no cap. When the failure is persistent — e.g. the task's object-storage reads are throttled with 429 — one bad task becomes a dispatch storm that keeps the store saturated so the task can never succeed (observed in production: ~435k dispatches concentrated on 3 segments in one day, ~330k failing with 429, on a store with a daily GET quota).

This PR delays re-dispatch of a failed task with exponential backoff.

## How

- The scheduler records a per-task-id failure count when `CreateTaskOnWorker` leaves the task in `Init`/`Retry`, or `QueryTaskOnWorker` resets it to `Init`/`Retry`.
- The next dispatch is delayed by `dataCoord.taskRetryBackoffInterval` (default 1s) doubling per consecutive failure up to `dataCoord.taskRetryBackoffMaxInterval` (default 60s). Both are dynamically updatable; `0` restores the legacy behavior.
- While a task waits out its backoff it yields its scheduling slot to other pending tasks (it is skipped and re-queued, not blocking the queue head).
- The backoff state is cleared when the task finishes, fails terminally (dropped), or is aborted — so a task that recovers pays nothing on its next run.
- Returning a task to the queue because no worker has free slots is *not* counted as a failure.

Applies to every task type the global scheduler handles; no change to the `Task` interface.

## Tests

- Deterministic unit test for the backoff math: 1s → 2s → 4s, capped at the configured max; cleared entry ends the backoff; interval=0 disables the mechanism.
- Scheduling test: a task whose `CreateTaskOnWorker` always fails is dispatched once, NOT re-dispatched by the ~100ms ticks during its 1s backoff window (previously ~5 more dispatches), and re-dispatched after the window elapses.
- Full `internal/datacoord/task` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
