### PR TITLE
enhance: back off recreation of failed segment load tasks

### DIFF
--- a/internal/querycoordv2/task/scheduler.go
+++ b/internal/querycoordv2/task/scheduler.go
@@ -591,6 +591,20 @@ type taskScheduler struct {
 
 	segmentTaskDelta *SegmentTaskDelta
 	channelTaskDelta *ChannelTaskDelta
+
+	// segmentLoadFailures remembers, per (replica, segment), how often loading
+	// failed and when it failed last, so preAdd can hold off recreating the
+	// same load task every checker round while the failure persists (e.g.
+	// object-storage throttling — observed in production as thousands of load
+	// tasks per minute for a handful of segments). Retries stay fast: the gap
+	// starts at one interval and doubles up to the max; a successful load
+	// drops the record.
+	segmentLoadFailures *ConcurrentMap[replicaSegmentIndex, *loadFailureRecord]
+}
+
+type loadFailureRecord struct {
+	failures    int
+	lastFailure time.Time
 }
 
 func NewScheduler(ctx context.Context,
@@ -625,7 +639,55 @@ func NewScheduler(ctx context.Context,
 		taskStats:        expirable.NewLRU[UniqueID, Task](256, nil, time.Minute*15),
 		segmentTaskDelta: NewSegmentTaskDelta(),
 		channelTaskDelta: NewChannelTaskDelta(),
+
+		segmentLoadFailures: NewConcurrentMap[replicaSegmentIndex, *loadFailureRecord](),
 	}
+}
+
+// recordSegmentLoadFailure bumps the failure count for the segment and stamps
+// the failure time.
+func (scheduler *taskScheduler) recordSegmentLoadFailure(index replicaSegmentIndex) {
+	failures := 1
+	if old, ok := scheduler.segmentLoadFailures.Get(index); ok {
+		failures = old.failures + 1
+	}
+	scheduler.segmentLoadFailures.Insert(index, &loadFailureRecord{
+		failures:    failures,
+		lastFailure: time.Now(),
+	})
+}
+
+// segmentLoadBackoff returns how much longer a new load task for the segment
+// should wait after previous failures, or 0 when it may proceed. The wait is
+// interval * 2^(failures-1) since the last failure, capped at maxInterval, so
+// the first retry stays fast and only persistent failures slow down. Records
+// far past their window are dropped.
+func (scheduler *taskScheduler) segmentLoadBackoff(index replicaSegmentIndex) time.Duration {
+	record, ok := scheduler.segmentLoadFailures.Get(index)
+	if !ok {
+		return 0
+	}
+	interval := paramtable.Get().QueryCoordCfg.SegmentLoadRetryBackoffInterval.GetAsDuration(time.Second)
+	if interval <= 0 {
+		return 0
+	}
+	maxInterval := paramtable.Get().QueryCoordCfg.SegmentLoadRetryBackoffMaxInterval.GetAsDuration(time.Second)
+	if shift := record.failures - 1; shift < 30 {
+		interval <<= shift
+	} else {
+		interval = maxInterval
+	}
+	if maxInterval > 0 && interval > maxInterval {
+		interval = maxInterval
+	}
+	elapsed := time.Since(record.lastFailure)
+	if elapsed >= interval {
+		if maxInterval > 0 && elapsed > 2*maxInterval {
+			scheduler.segmentLoadFailures.Remove(index)
+		}
+		return 0
+	}
+	return interval - elapsed
 }
 
 func (scheduler *taskScheduler) Start() {}
@@ -791,6 +853,14 @@ func (scheduler *taskScheduler) preAdd(task Task) error {
 		}
 
 		taskType := GetTaskType(task)
+
+		if taskType == TaskTypeGrow {
+			// hold off recreating a load task that just failed; the checker
+			// will pick the segment up again once the wait elapses
+			if wait := scheduler.segmentLoadBackoff(index); wait > 0 {
+				return merr.WrapErrServiceInternal(fmt.Sprintf("segment load failed recently, backing off for %v", wait))
+			}
+		}
 
 		if taskType == TaskTypeMove {
 			leader := scheduler.getReplicaShardLeader(task.Shard(), task.ReplicaID())
@@ -1326,6 +1396,19 @@ func (scheduler *taskScheduler) remove(task Task) {
 			task.Err() != nil &&
 			!errors.IsAny(task.Err(), merr.ErrChannelNotFound, merr.ErrServiceTooManyRequests) {
 			scheduler.recordSegmentTaskError(task)
+		}
+		if GetTaskType(task) == TaskTypeGrow {
+			switch task.Status() {
+			case TaskStatusFailed:
+				// a segment that vanished from the target is not a load
+				// failure — the ErrSegmentNotFound branch above already
+				// forces a target update and the segment won't come back
+				if !errors.Is(task.Err(), merr.ErrSegmentNotFound) {
+					scheduler.recordSegmentLoadFailure(index)
+				}
+			case TaskStatusSucceeded:
+				scheduler.segmentLoadFailures.Remove(index)
+			}
 		}
 
 	case *ChannelTask:

--- a/internal/querycoordv2/task/task_test.go
+++ b/internal/querycoordv2/task/task_test.go
@@ -3211,3 +3211,82 @@ func (suite *TaskSuite) TestNodeTaskQueueRangeByNodePriority() {
 	})
 	suite.Equal([]Priority{TaskPriorityHigh, TaskPriorityNormal, TaskPriorityLow}, visited)
 }
+
+func (suite *TaskSuite) TestSegmentLoadFailureBackoff() {
+	ctx := context.Background()
+	timeout := 10 * time.Second
+	targetNode := int64(3)
+	channelName := "backoff-test-channel"
+	segmentID := int64(999)
+	scheduler := suite.newScheduler()
+
+	pt := paramtable.Get()
+	pt.Save(pt.QueryCoordCfg.SegmentLoadRetryBackoffInterval.Key, "1")
+	pt.Save(pt.QueryCoordCfg.SegmentLoadRetryBackoffMaxInterval.Key, "4")
+	defer pt.Reset(pt.QueryCoordCfg.SegmentLoadRetryBackoffInterval.Key)
+	defer pt.Reset(pt.QueryCoordCfg.SegmentLoadRetryBackoffMaxInterval.Key)
+
+	newGrowTask := func() *SegmentTask {
+		task, err := NewSegmentTask(
+			ctx,
+			timeout,
+			WrapIDSource(0),
+			suite.collection,
+			suite.replica,
+			commonpb.LoadPriority_LOW,
+			NewSegmentAction(targetNode, ActionTypeGrow, channelName, segmentID),
+		)
+		suite.NoError(err)
+		return task
+	}
+	index := NewReplicaSegmentIndex(newGrowTask())
+
+	// no failure record: a grow task is admitted
+	suite.NoError(scheduler.preAdd(newGrowTask()))
+
+	// a failed grow task records a failure on removal (Fail is the real
+	// failure path: it pins the Failed status against remove's Cancel)
+	failed := newGrowTask()
+	failed.Fail(errors.New("mock load failure"))
+	scheduler.remove(failed)
+	record, ok := scheduler.segmentLoadFailures.Get(index)
+	suite.Require().True(ok)
+	suite.Equal(1, record.failures)
+
+	// ...and a new load task for the same segment is rejected within the window
+	err := scheduler.preAdd(newGrowTask())
+	suite.Error(err)
+
+	// consecutive failures double the wait, capped at the configured max (4s)
+	scheduler.recordSegmentLoadFailure(index)
+	scheduler.recordSegmentLoadFailure(index)
+	scheduler.recordSegmentLoadFailure(index)
+	record, _ = scheduler.segmentLoadFailures.Get(index)
+	suite.Equal(4, record.failures)
+	wait := scheduler.segmentLoadBackoff(index)
+	suite.Greater(wait, 3*time.Second)
+	suite.LessOrEqual(wait, 4*time.Second)
+
+	// an expired record no longer delays anything
+	scheduler.segmentLoadFailures.Insert(index, &loadFailureRecord{
+		failures:    2,
+		lastFailure: time.Now().Add(-time.Minute),
+	})
+	suite.Zero(scheduler.segmentLoadBackoff(index))
+	suite.NoError(scheduler.preAdd(newGrowTask()))
+
+	// a successful load drops the record entirely
+	scheduler.recordSegmentLoadFailure(index)
+	succeeded := newGrowTask()
+	succeeded.SetStatus(TaskStatusSucceeded)
+	scheduler.remove(succeeded)
+	_, ok = scheduler.segmentLoadFailures.Get(index)
+	suite.False(ok)
+	suite.NoError(scheduler.preAdd(newGrowTask()))
+
+	// interval 0 disables the gate even with a fresh failure
+	pt.Save(pt.QueryCoordCfg.SegmentLoadRetryBackoffInterval.Key, "0")
+	scheduler.recordSegmentLoadFailure(index)
+	suite.Zero(scheduler.segmentLoadBackoff(index))
+	suite.NoError(scheduler.preAdd(newGrowTask()))
+}

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -2814,9 +2814,11 @@ type queryCoordConfig struct {
 	// channel task capacity fraction
 	ChannelTaskCapFraction ParamItem `refreshable:"true"`
 
-	BalanceCheckCollectionMaxCount    ParamItem `refreshable:"true"`
-	ResourceExhaustionPenaltyDuration ParamItem `refreshable:"true"`
-	ResourceExhaustionCleanupInterval ParamItem `refreshable:"true"`
+	BalanceCheckCollectionMaxCount     ParamItem `refreshable:"true"`
+	ResourceExhaustionPenaltyDuration  ParamItem `refreshable:"true"`
+	ResourceExhaustionCleanupInterval  ParamItem `refreshable:"true"`
+	SegmentLoadRetryBackoffInterval    ParamItem `refreshable:"true"`
+	SegmentLoadRetryBackoffMaxInterval ParamItem `refreshable:"true"`
 
 	UpdateTargetNeedSegmentDataReady ParamItem `refreshable:"true"`
 
@@ -3499,6 +3501,26 @@ Set to 0 to disable the penalty period.`,
 		Export: true,
 	}
 	p.ResourceExhaustionPenaltyDuration.Init(base.mgr)
+
+	p.SegmentLoadRetryBackoffInterval = ParamItem{
+		Key:          "queryCoord.segmentLoadRetryBackoffInterval",
+		Version:      "2.6.18",
+		DefaultValue: "1",
+		Doc: "Initial wait in seconds before recreating a segment load task that failed; doubles on each consecutive failure " +
+			"up to queryCoord.segmentLoadRetryBackoffMaxInterval, and resets once the segment loads successfully. " +
+			"0 disables the backoff (legacy behavior: failed loads are recreated on every checker round).",
+		Export: true,
+	}
+	p.SegmentLoadRetryBackoffInterval.Init(base.mgr)
+
+	p.SegmentLoadRetryBackoffMaxInterval = ParamItem{
+		Key:          "queryCoord.segmentLoadRetryBackoffMaxInterval",
+		Version:      "2.6.18",
+		DefaultValue: "30",
+		Doc:          "Maximum wait in seconds between load retries of a segment that keeps failing to load.",
+		Export:       true,
+	}
+	p.SegmentLoadRetryBackoffMaxInterval.Init(base.mgr)
 
 	p.ResourceExhaustionCleanupInterval = ParamItem{
 		Key:          "queryCoord.resourceExhaustionCleanupInterval",


### PR DESCRIPTION
issue: #51019

## What

When loading a segment fails, the failed task is removed and the segment checker recreates an identical load task on the next round, which immediately fails the same way. There is no memory of the failure: during an object-storage throttling event we observed ~2,700 load-task creations in 2 minutes for just 23 segments, each re-issuing the same throttled reads — which kept the delegator's query view unserviceable (and with it, every query on the channel failing) for minutes at a time.

This PR remembers load failures per (replica, segment) — a failure count and the last failure time — and holds off recreating the load task for that segment until a short, growing gap has elapsed.

## How

- `taskScheduler.remove()` records the failure when a grow (load) segment task is removed as `Failed`; a `Succeeded` load drops the record. `ErrSegmentNotFound` is not counted — the segment left the target and `remove()` already forces a target update.
- `preAdd` rejects a new grow task for a segment still inside its wait window; the checker naturally retries on a later round. Move/reduce/update tasks are unaffected.
- The wait is `queryCoord.segmentLoadRetryBackoffInterval` (default 1s) doubling per consecutive failure, capped at `queryCoord.segmentLoadRetryBackoffMaxInterval` (default 30s). Both dynamically updatable; `0` disables the gate (legacy behavior).
- The first retry stays fast (1s) so transient failures recover quickly; only segments that keep failing slow down. Stale records well past their window are garbage-collected lazily.

## Tests

- Suite test covering: admission with no record; rejection right after a failed removal; doubling capped at the max; expired records no longer delaying; a successful load clearing the record; interval=0 disabling the gate.
- Full `internal/querycoordv2/task`, `checkers`, and `balance` suites green (including `TestRemoveTaskWithError`, which re-adds a segment right after an `ErrSegmentNotFound` failure — the reason that error is excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
