### PR TITLE
enhance: add field names and types to arithmetic type mismatch errors

### DIFF
--- a/internal/parser/planparserv2/fill_expression_value.go
+++ b/internal/parser/planparserv2/fill_expression_value.go
@@ -1,6 +1,7 @@
 package planparserv2
 
 import (
+	"fmt"
 	"github.com/milvus-io/milvus-proto/go-api/v3/schemapb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/planpb"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
@@ -258,8 +259,9 @@ func FillBinaryArithOpEvalRangeExpressionValue(expr *planpb.BinaryArithOpEvalRan
 			lDataType = expr.GetColumnInfo().GetElementType()
 		}
 
-		if err = checkValidModArith(expr.GetArithOp(), expr.GetColumnInfo().GetDataType(), expr.GetColumnInfo().GetElementType(),
-			rDataType, schemapb.DataType_None); err != nil {
+		leftField := arithField{dataType: expr.GetColumnInfo().GetDataType(), elementType: expr.GetColumnInfo().GetElementType(), name: fmt.Sprintf("field(id=%d)", expr.GetColumnInfo().GetFieldId())}
+		rightField := arithField{dataType: rDataType, elementType: schemapb.DataType_None, name: "right operand"}
+		if err = checkValidModArith(expr.GetArithOp(), leftField, rightField); err != nil {
 			return err
 		}
 

--- a/internal/parser/planparserv2/parser_visitor.go
+++ b/internal/parser/planparserv2/parser_visitor.go
@@ -331,7 +331,9 @@ func (v *ParserVisitor) VisitAddSub(ctx *parser.AddSubContext) interface{} {
 	} else if rightExpr.expr.GetIsTemplate() {
 		dataType = leftExpr.dataType
 	} else {
-		if err := canArithmetic(leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr), reverse); err != nil {
+		leftField := arithField{dataType: leftExpr.dataType, elementType: getArrayElementType(leftExpr), name: ctx.Expr(0).GetText()}
+		rightField := arithField{dataType: rightExpr.dataType, elementType: getArrayElementType(rightExpr), name: ctx.Expr(1).GetText()}
+		if err := canArithmetic(leftField, rightField, reverse); err != nil {
 			return merr.WrapErrParameterInvalidMsg("'%s' %s", arithNameMap[ctx.GetOp().GetTokenType()], err.Error())
 		}
 
@@ -421,11 +423,13 @@ func (v *ParserVisitor) VisitMulDivMod(ctx *parser.MulDivModContext) interface{}
 	} else if rightExpr.expr.GetIsTemplate() {
 		dataType = leftExpr.dataType
 	} else {
-		if err := canArithmetic(leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr), reverse); err != nil {
+		leftField := arithField{dataType: leftExpr.dataType, elementType: getArrayElementType(leftExpr), name: ctx.Expr(0).GetText()}
+		rightField := arithField{dataType: rightExpr.dataType, elementType: getArrayElementType(rightExpr), name: ctx.Expr(1).GetText()}
+		if err = canArithmetic(leftField, rightField, reverse); err != nil {
 			return merr.WrapErrParameterInvalidMsg("'%s' %s", arithNameMap[ctx.GetOp().GetTokenType()], err.Error())
 		}
 
-		if err = checkValidModArith(arithExprMap[ctx.GetOp().GetTokenType()], leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr)); err != nil {
+		if err = checkValidModArith(arithExprMap[ctx.GetOp().GetTokenType()], leftField, rightField); err != nil {
 			return err
 		}
 
@@ -1807,10 +1811,12 @@ func (v *ParserVisitor) visitBitwiseBinaryOp(leftCtx, rightCtx parser.IExprConte
 	} else if rightExpr.expr.GetIsTemplate() {
 		dataType = leftExpr.dataType
 	} else {
-		if err = canArithmetic(leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr), reverse); err != nil {
+		leftField := arithField{dataType: leftExpr.dataType, elementType: getArrayElementType(leftExpr), name: leftCtx.GetText()}
+		rightField := arithField{dataType: rightExpr.dataType, elementType: getArrayElementType(rightExpr), name: rightCtx.GetText()}
+		if err = canArithmetic(leftField, rightField, reverse); err != nil {
 			return merr.WrapErrParameterInvalidMsg("'%s' %s", arithNameMap[tokenType], err.Error())
 		}
-		if err = checkValidModArith(arithExprMap[tokenType], leftExpr.dataType, getArrayElementType(leftExpr), rightExpr.dataType, getArrayElementType(rightExpr)); err != nil {
+		if err = checkValidModArith(arithExprMap[tokenType], leftField, rightField); err != nil {
 			return err
 		}
 		dataType, err = calcDataType(leftExpr, rightExpr, reverse)

--- a/internal/parser/planparserv2/plan_parser_v2_test.go
+++ b/internal/parser/planparserv2/plan_parser_v2_test.go
@@ -1380,6 +1380,28 @@ func TestExpr_BitwiseArith(t *testing.T) {
 	}
 }
 
+func TestExpr_TypeMismatchErrorMessages(t *testing.T) {
+	schema := newTestSchema(true)
+	helper, err := typeutil.CreateSchemaHelper(schema)
+	assert.NoError(t, err)
+
+	t.Run("bitwise AND on Double field reports field name and type", func(t *testing.T) {
+		_, err := ParseExpr(helper, "(DoubleField & 4) == 4", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "DoubleField")
+		assert.Contains(t, err.Error(), "Double")
+		assert.Contains(t, err.Error(), "bitwise operators require an integer field")
+	})
+
+	t.Run("modulo on Float field reports field name and type", func(t *testing.T) {
+		_, err := ParseExpr(helper, "FloatField % 2 == 0", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "FloatField")
+		assert.Contains(t, err.Error(), "Float")
+		assert.Contains(t, err.Error(), "modulo requires an integer field")
+	})
+}
+
 func TestExpr_Value(t *testing.T) {
 	schema := newTestSchema(true)
 	helper, err := typeutil.CreateSchemaHelper(schema)

--- a/internal/parser/planparserv2/utils.go
+++ b/internal/parser/planparserv2/utils.go
@@ -651,18 +651,26 @@ func canArithmeticDataType(left, right schemapb.DataType) bool {
 //	return canArithmeticDataType(left.dataType, getArrayElementType(right))
 //}
 
-func canArithmetic(left, leftElement, right, rightElement schemapb.DataType, reverse bool) error {
-	if typeutil.IsArrayType(left) {
-		left = leftElement
+type arithField struct {
+	dataType    schemapb.DataType
+	elementType schemapb.DataType
+	name        string
+}
+
+func canArithmetic(left, right arithField, reverse bool) error {
+	leftType, rightType := left.dataType, right.dataType
+	if typeutil.IsArrayType(leftType) {
+		leftType = left.elementType
 	}
-	if typeutil.IsArrayType(right) {
-		right = rightElement
+	if typeutil.IsArrayType(rightType) {
+		rightType = right.elementType
 	}
 	if reverse {
 		left, right = right, left
+		leftType, rightType = rightType, leftType
 	}
-	if !canArithmeticDataType(left, right) {
-		return merr.WrapErrQueryPlanMsg("cannot perform arithmetic between %s field and %s", left.String(), right.String())
+	if !canArithmeticDataType(leftType, rightType) {
+		return merr.WrapErrQueryPlanMsg("cannot perform arithmetic between field '%s' (%s) and field '%s' (%s)", left.name, leftType.String(), right.name, rightType.String())
 	}
 	return nil
 }
@@ -699,15 +707,21 @@ func hexDigit(n uint32) byte {
 	return byte(n-10) + 'a'
 }
 
-func checkValidModArith(tokenType planpb.ArithOpType, leftType, leftElementType, rightType, rightElementType schemapb.DataType) error {
+func checkValidModArith(tokenType planpb.ArithOpType, left, right arithField) error {
 	switch tokenType {
 	case planpb.ArithOpType_Mod:
-		if !canConvertToIntegerType(leftType, leftElementType) || !canConvertToIntegerType(rightType, rightElementType) {
-			return merr.WrapErrQueryPlanMsg("modulo can only apply on integer types")
+		if !canConvertToIntegerType(left.dataType, left.elementType) {
+			return merr.WrapErrQueryPlanMsg("modulo requires an integer field, but field '%s' is %s", left.name, left.dataType.String())
+		}
+		if !canConvertToIntegerType(right.dataType, right.elementType) {
+			return merr.WrapErrQueryPlanMsg("modulo requires an integer field, but field '%s' is %s", right.name, right.dataType.String())
 		}
 	case planpb.ArithOpType_BitAnd, planpb.ArithOpType_BitOr, planpb.ArithOpType_BitXor:
-		if !canConvertToIntegerType(leftType, leftElementType) || !canConvertToIntegerType(rightType, rightElementType) {
-			return merr.WrapErrQueryPlanMsg("bitwise operations can only apply on integer types")
+		if !canConvertToIntegerType(left.dataType, left.elementType) {
+			return merr.WrapErrQueryPlanMsg("bitwise operators require an integer field, but field '%s' is %s", left.name, left.dataType.String())
+		}
+		if !canConvertToIntegerType(right.dataType, right.elementType) {
+			return merr.WrapErrQueryPlanMsg("bitwise operators require an integer field, but field '%s' is %s", right.name, right.dataType.String())
 		}
 	default:
 	}

--- a/internal/parser/planparserv2/utils_test.go
+++ b/internal/parser/planparserv2/utils_test.go
@@ -1177,7 +1177,10 @@ func Test_canArithmetic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := canArithmetic(tt.left, tt.leftElement, tt.right, tt.rightElement, tt.reverse)
+			err := canArithmetic(
+				arithField{dataType: tt.left, elementType: tt.leftElement, name: "left_field"},
+				arithField{dataType: tt.right, elementType: tt.rightElement, name: "right_field"},
+				tt.reverse)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
@@ -1192,31 +1195,36 @@ func Test_canArithmetic(t *testing.T) {
 func Test_checkValidModArith(t *testing.T) {
 	t.Run("mod with integers is valid", func(t *testing.T) {
 		err := checkValidModArith(planpb.ArithOpType_Mod,
-			schemapb.DataType_Int64, schemapb.DataType_None,
-			schemapb.DataType_Int64, schemapb.DataType_None)
+			arithField{dataType: schemapb.DataType_Int64, elementType: schemapb.DataType_None, name: "left_field"},
+			arithField{dataType: schemapb.DataType_Int64, elementType: schemapb.DataType_None, name: "right_field"})
 		assert.NoError(t, err)
 	})
 
 	t.Run("mod with float left is invalid", func(t *testing.T) {
 		err := checkValidModArith(planpb.ArithOpType_Mod,
-			schemapb.DataType_Float, schemapb.DataType_None,
-			schemapb.DataType_Int64, schemapb.DataType_None)
+			arithField{dataType: schemapb.DataType_Float, elementType: schemapb.DataType_None, name: "price"},
+			arithField{dataType: schemapb.DataType_Int64, elementType: schemapb.DataType_None, name: "right_field"})
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "modulo can only apply on integer types")
+		assert.Contains(t, err.Error(), "modulo requires an integer field")
+		assert.Contains(t, err.Error(), "price")
+		assert.Contains(t, err.Error(), "Float")
 	})
 
 	t.Run("mod with float right is invalid", func(t *testing.T) {
 		err := checkValidModArith(planpb.ArithOpType_Mod,
-			schemapb.DataType_Int64, schemapb.DataType_None,
-			schemapb.DataType_Float, schemapb.DataType_None)
+			arithField{dataType: schemapb.DataType_Int64, elementType: schemapb.DataType_None, name: "left_field"},
+			arithField{dataType: schemapb.DataType_Float, elementType: schemapb.DataType_None, name: "price"})
 		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "modulo requires an integer field")
+		assert.Contains(t, err.Error(), "price")
+		assert.Contains(t, err.Error(), "Float")
 	})
 
 	t.Run("add operation is always valid", func(t *testing.T) {
 		// Non-mod operations should not be validated by this function
 		err := checkValidModArith(planpb.ArithOpType_Add,
-			schemapb.DataType_Float, schemapb.DataType_None,
-			schemapb.DataType_Float, schemapb.DataType_None)
+			arithField{dataType: schemapb.DataType_Float, elementType: schemapb.DataType_None, name: "left_field"},
+			arithField{dataType: schemapb.DataType_Float, elementType: schemapb.DataType_None, name: "right_field"})
 		assert.NoError(t, err)
 	})
 }
@@ -1233,32 +1241,36 @@ func Test_checkValidBitwiseArith(t *testing.T) {
 		op := op
 		t.Run(op.String()+" with integers is valid", func(t *testing.T) {
 			err := checkValidModArith(op,
-				schemapb.DataType_Int64, schemapb.DataType_None,
-				schemapb.DataType_Int64, schemapb.DataType_None)
+				arithField{dataType: schemapb.DataType_Int64, elementType: schemapb.DataType_None, name: "left_field"},
+				arithField{dataType: schemapb.DataType_Int64, elementType: schemapb.DataType_None, name: "right_field"})
 			assert.NoError(t, err)
 		})
 
 		t.Run(op.String()+" with integer array element is valid", func(t *testing.T) {
 			err := checkValidModArith(op,
-				schemapb.DataType_Array, schemapb.DataType_Int32,
-				schemapb.DataType_Int64, schemapb.DataType_None)
+				arithField{dataType: schemapb.DataType_Array, elementType: schemapb.DataType_Int32, name: "arr_field"},
+				arithField{dataType: schemapb.DataType_Int64, elementType: schemapb.DataType_None, name: "right_field"})
 			assert.NoError(t, err)
 		})
 
 		t.Run(op.String()+" with float left is invalid", func(t *testing.T) {
 			err := checkValidModArith(op,
-				schemapb.DataType_Float, schemapb.DataType_None,
-				schemapb.DataType_Int64, schemapb.DataType_None)
+				arithField{dataType: schemapb.DataType_Float, elementType: schemapb.DataType_None, name: "price"},
+				arithField{dataType: schemapb.DataType_Int64, elementType: schemapb.DataType_None, name: "right_field"})
 			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "bitwise operations can only apply on integer types")
+			assert.Contains(t, err.Error(), "bitwise operators require an integer field")
+			assert.Contains(t, err.Error(), "price")
+			assert.Contains(t, err.Error(), "Float")
 		})
 
 		t.Run(op.String()+" with double right is invalid", func(t *testing.T) {
 			err := checkValidModArith(op,
-				schemapb.DataType_Int64, schemapb.DataType_None,
-				schemapb.DataType_Double, schemapb.DataType_None)
+				arithField{dataType: schemapb.DataType_Int64, elementType: schemapb.DataType_None, name: "left_field"},
+				arithField{dataType: schemapb.DataType_Double, elementType: schemapb.DataType_None, name: "score"})
 			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "bitwise operations can only apply on integer types")
+			assert.Contains(t, err.Error(), "bitwise operators require an integer field")
+			assert.Contains(t, err.Error(), "score")
+			assert.Contains(t, err.Error(), "Double")
 		})
 	}
 }


### PR DESCRIPTION
## Description

Previously, when a user tried to do arithmetic or bitwise operations on a non-integer field, the error message was completely generic (e.g., `"modulo requires an integer field"`). This made it hard to understand which field caused the issue.

This PR threads the original field name and its actual data type through the parser into the error generation. 

**Before:**
`modulo requires an integer field`

**After:**
`modulo requires an integer field, but field 'price' is Double`

## Scope of Changes

1. **Full Operator Coverage:** While the original issue only specifically mentioned bitwise and modulo, this PR goes further and applies the exact same field-name error formatting to **all** standard arithmetic operators (`+`, `-`, `*`, `/`) via `canArithmetic`.
2. **Introduced `arithField` Struct:** To safely pass the field metadata (`dataType`, `elementType`, and `name`) down to `checkValidModArith` and `canArithmetic`, I introduced a small `arithField` struct. This replaces the previous approach of passing 5+ loose positional arguments, which might be prone to compiler-silent bugs (like accidentally swapping `leftType` and `rightType`).
3. **E2E Testing:** Added `TestExpr_TypeMismatchErrorMessages` to ensure the entire flow (from raw string parsing down to error generation) works as intended and outputs the correct strings.

## Related Issue

issue: #50965
