### PR TITLE
fix: [2.6] stl-sort allows struct scalar fields (#47626)

### DIFF
--- a/internal/util/indexparamcheck/stl_sort_checker.go
+++ b/internal/util/indexparamcheck/stl_sort_checker.go
@@ -17,6 +17,13 @@ func (c *STLSORTChecker) CheckTrain(dataType schemapb.DataType, elementType sche
 
 func (c *STLSORTChecker) CheckValidDataType(indexType IndexType, field *schemapb.FieldSchema) error {
 	dataType := field.GetDataType()
+	if typeutil.IsArrayType(dataType) && typeutil.IsStructSubField(field.GetName()) {
+		elemType := field.GetElementType()
+		if !typeutil.IsArithmetic(elemType) && !typeutil.IsStringType(elemType) && !typeutil.IsTimestamptzType(elemType) {
+			return merr.WrapErrParameterInvalidMsg("STL_SORT are only supported on numeric, varchar or timestamptz field, got struct sub-field of %s", field.GetElementType())
+		}
+		return nil
+	}
 	if !typeutil.IsArithmetic(dataType) && !typeutil.IsStringType(dataType) && !typeutil.IsTimestamptzType(dataType) {
 		return merr.WrapErrParameterInvalidMsg("STL_SORT are only supported on numeric, varchar or timestamptz field, got %s", field.GetDataType())
 	}

--- a/internal/util/indexparamcheck/stl_sort_checker_test.go
+++ b/internal/util/indexparamcheck/stl_sort_checker_test.go
@@ -19,4 +19,14 @@ func Test_STLSORTIndexChecker(t *testing.T) {
 
 	assert.Error(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{DataType: schemapb.DataType_Bool}))
 	assert.Error(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{DataType: schemapb.DataType_JSON}))
+
+	// struct sub-fields: name follows "structName[fieldName]" convention, DataType is Array
+	assert.NoError(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{Name: "myStruct[age]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int64}))
+	assert.NoError(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{Name: "myStruct[score]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Float}))
+	assert.NoError(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{Name: "myStruct[name]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_VarChar}))
+	assert.Error(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{Name: "myStruct[flag]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Bool}))
+	assert.Error(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{Name: "myStruct[meta]", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_JSON}))
+
+	// regular Array field (not a struct sub-field) should still be rejected
+	assert.Error(t, c.CheckValidDataType(IndexSTLSORT, &schemapb.FieldSchema{Name: "tags", DataType: schemapb.DataType_Array, ElementType: schemapb.DataType_Int64}))
 }

--- a/pkg/util/typeutil/schema.go
+++ b/pkg/util/typeutil/schema.go
@@ -3318,6 +3318,12 @@ func ConcatStructFieldName(structName string, fieldName string) string {
 	return fmt.Sprintf("%s[%s]", structName, fieldName)
 }
 
+// IsStructSubField checks if a field name follows the "structName[fieldName]" convention,
+// indicating it is a sub-field within a StructArrayField.
+func IsStructSubField(fieldName string) bool {
+	return strings.Contains(fieldName, "[")
+}
+
 func ExtractStructFieldName(fieldName string) (string, error) {
 	parts := strings.Split(fieldName, "[")
 	if len(parts) == 1 {


### PR DESCRIPTION
Backport of #47626 (master commit ba29e0ba4837) to the 2.6 branch.

## What

`STLSORTChecker.CheckValidDataType` only inspected `DataType`, which is `Array` for a struct sub-field — the actual numeric/varchar type lives in `ElementType`. As a result, creating an STL_SORT index on a numeric or varchar sub-field of an `ARRAY(STRUCT)` field always failed with `got Array` on 2.6.x, while BITMAP/INVERTED already handled sub-fields correctly. Reported in #50588 and reproduced on 2.6.17/2.6.18; master is not affected since #47626.

This adds the same struct sub-field branch as the master fix: when the field is an Array whose name follows the `structName[fieldName]` convention, validate `ElementType` instead, and adds the missing `typeutil.IsStructSubField` helper to 2.6.

## Adaptation notes vs the master commit

- The `parser_visitor.go` hunk of #47626 is a pure refactor (string concatenation → `ConcatStructFieldName` helper) with no behavior change; it does not apply to 2.6 and is omitted.
- The added test additionally covers that a regular Array field (not a struct sub-field) is still rejected.

## Verification

The `indexparamcheck` unit suite (`Test_STLSORTIndexChecker`) passes with the new assertions: numeric/varchar sub-fields accepted, bool/JSON sub-fields and plain Array fields rejected.

issue: #50588
pr: #47626
