### PR TITLE
enhance: speed up sealed varchar primary key fill

### DIFF
--- a/internal/core/src/mmap/ChunkedColumnGroup.h
+++ b/internal/core/src/mmap/ChunkedColumnGroup.h
@@ -623,9 +623,14 @@ class ProxyChunkColumn : public ChunkedColumnInterface {
         } else {
             auto [cids, offsets_in_chunk] = ToChunkIdAndOffset(offsets, count);
             auto ca = group_->GetGroupChunks(op_ctx, cids);
+            std::vector<std::shared_ptr<Chunk>> chunks(num_chunks());
             for (int64_t i = 0; i < count; i++) {
-                auto* group_chunk = ca->get_cell_of(cids[i]);
-                auto chunk = group_chunk->GetChunk(field_id_);
+                auto cid = cids[i];
+                auto& chunk = chunks[cid];
+                if (chunk == nullptr) {
+                    auto* group_chunk = ca->get_cell_of(cid);
+                    chunk = group_chunk->GetChunk(field_id_);
+                }
                 auto valid = chunk->isValid(offsets_in_chunk[i]);
                 auto value = static_cast<StringChunk*>(chunk.get())
                                  ->

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -4789,6 +4789,71 @@ ChunkedSegmentSealedImpl::LoadBatchJsonKeyIndexes(
     LoadBatchJsonKeyIndexes(op_ctx, infos, CaptureSchemaSnapshot());
 }
 
+void
+ChunkedSegmentSealedImpl::FillPrimaryKeys(const query::Plan* plan,
+                                          SearchResult& results,
+                                          milvus::OpContext* op_ctx) const {
+    {
+        std::shared_lock lck(mutex_);
+        AssertInfo(plan, "empty plan");
+        auto size = results.distances_.size();
+        AssertInfo(results.seg_offsets_.size() == size,
+                   "Size of result distances is not equal to size of ids");
+
+        auto snapshot = CapturePublishedState();
+        auto schema_snapshot = snapshot->schema;
+        auto pk_field_id_opt = schema_snapshot->get_primary_field_id();
+        AssertInfo(pk_field_id_opt.has_value(),
+                   "Cannot get primary key offset from schema");
+        auto pk_field_id = pk_field_id_opt.value();
+        auto pk_type = schema_snapshot->operator[](pk_field_id).get_data_type();
+        AssertInfo(IsPrimaryKeyDataType(pk_type),
+                   "Primary key field is not INT64 or VARCHAR type");
+        if (pk_type == DataType::VARCHAR) {
+            auto column = get_column(snapshot->runtime, pk_field_id);
+            if (column != nullptr) {
+                Assert(results.primary_keys_.size() == 0);
+                results.primary_keys_.resize(size);
+                results.pk_type_ = pk_type;
+                if (size == 0) {
+                    return;
+                }
+
+                segcore::CheckCancellation(
+                    op_ctx, get_segment_id(), "FillPrimaryKeys");
+                milvus::OpContext local_ctx;
+                if (op_ctx != nullptr) {
+                    local_ctx.cancellation_token = op_ctx->cancellation_token;
+                    local_ctx.runtime_load_priority =
+                        op_ctx->runtime_load_priority;
+                }
+                // Intentionally bypass bulk_subscript's scalar-index raw-data
+                // routing here: the sealed VARCHAR PK fast path reads the
+                // loaded column directly to avoid DataArray materialization
+                // and index reverse-lookup overhead. Storage-cost accounting
+                // can differ if both index raw data and the column are
+                // resident, but returned PK values are identical.
+                column->BulkRawStringAt(
+                    &local_ctx,
+                    [&results](
+                        std::string_view value, size_t offset, bool is_valid) {
+                        AssertInfo(is_valid, "primary key must not be null");
+                        results.primary_keys_[offset] = std::string(value);
+                    },
+                    results.seg_offsets_.data(),
+                    size);
+                results.search_storage_cost_.scanned_remote_bytes +=
+                    local_ctx.storage_usage.scanned_cold_bytes.load();
+                results.search_storage_cost_.scanned_total_bytes +=
+                    local_ctx.storage_usage.scanned_total_bytes.load();
+                return;
+            }
+        }
+    }
+
+    SegmentInternalInterface::FillPrimaryKeys(plan, results, op_ctx);
+}
+
 std::unique_ptr<DataArray>
 ChunkedSegmentSealedImpl::get_raw_data(milvus::OpContext* op_ctx,
                                        FieldId field_id,

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.h
@@ -185,6 +185,11 @@ class ChunkedSegmentSealedImpl : public SegmentSealed {
     Contain(const PkType& pk) const override;
 
     void
+    FillPrimaryKeys(const query::Plan* plan,
+                    SearchResult& results,
+                    milvus::OpContext* op_ctx = nullptr) const override;
+
+    void
     AddFieldDataInfoForSealed(
         const LoadFieldDataInfo& field_data_info) override;
 

--- a/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedStorageV2Test.cpp
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -61,10 +62,12 @@
 #include "pb/schema.pb.h"
 #include "plan/PlanNode.h"
 #include "query/ExecPlanNodeVisitor.h"
+#include "query/PlanImpl.h"
 #include "segcore/ChunkedSegmentSealedImpl.h"
 #include "segcore/SegcoreConfig.h"
 #include "segcore/SegmentChunkReader.h"
 #include "segcore/SegmentSealed.h"
+#include "segcore/search_result_export_c.h"
 #include "segcore/Types.h"
 #include "segcore/storagev2translator/GroupCTMeta.h"
 #include "segcore/storagev1translator/ChunkTranslator.h"
@@ -228,6 +231,20 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
     void
     SetUp() override {
         bool pk_is_string = GetParam();
+        auto* test_info =
+            ::testing::UnitTest::GetInstance()->current_test_info();
+        auto test_name = test_info == nullptr ? std::string()
+                                              : std::string(test_info->name());
+        if (test_name.find("ReduceStringPkWithSimulatedAnnResult") !=
+            std::string::npos) {
+            if (!pk_is_string) {
+                GTEST_SKIP() << "VARCHAR primary key fast path only";
+            }
+            chunk_num = 10;
+            test_data_count = 100000;
+            fixed_string_width = 32;
+        }
+
         schema_ = segcore::GenChunkedSegmentTestSchema(pk_is_string);
 
         // Use globally initialized ArrowFileSystem
@@ -245,6 +262,7 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
             EXPECT_TRUE(status.ok())
                 << "Failed to create directory: " << dir_path;
         }
+        test_data_created = true;
 
         std::vector<std::vector<int>> column_groups = {
             {0, 1, 4}, {2}, {3}};  // narrow columns and wide columns
@@ -267,11 +285,12 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
         int64_t row_count = 0;
         int start_id = 0;
 
-        std::vector<std::string> str_data;
-        for (int i = 0; i < test_data_count * chunk_num; i++) {
-            str_data.push_back("test" + std::to_string(i));
+        string_data.clear();
+        string_data.reserve(RowCount());
+        for (int64_t i = 0; i < RowCount(); i++) {
+            string_data.push_back(MakeStringValue(i));
         }
-        std::sort(str_data.begin(), str_data.end());
+        std::sort(string_data.begin(), string_data.end());
 
         fields = {{"int64", schema_->get_field_id(FieldName("int64"))},
                   {"pk", schema_->get_field_id(FieldName("pk"))},
@@ -301,8 +320,9 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
                 } else {
                     arrow::StringBuilder builder;
                     std::vector<std::string> str_values;
+                    str_values.reserve(test_data_count);
                     for (int j = 0; j < test_data_count; j++) {
-                        str_values.push_back(str_data[start_id + j]);
+                        str_values.push_back(string_data[start_id + j]);
                     }
                     auto status = builder.AppendValues(str_values);
                     EXPECT_TRUE(status.ok());
@@ -357,6 +377,9 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
 
     void
     TearDown() override {
+        if (!test_data_created) {
+            return;
+        }
         // Clean up test data directory
         auto fs = milvus::segcore::GetDefaultArrowFileSystem();
         auto status = fs->DeleteDir("test_data");
@@ -366,6 +389,21 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
     int64_t
     RowCount() const {
         return chunk_num * test_data_count;
+    }
+
+    std::string
+    MakeStringValue(int64_t row_id) const {
+        if (fixed_string_width == 0) {
+            return "test" + std::to_string(row_id);
+        }
+
+        auto suffix = std::to_string(row_id);
+        AssertInfo(suffix.size() + 2 <= fixed_string_width,
+                   "row id is too large for fixed string width");
+        std::string value = "pk";
+        value.append(fixed_string_width - value.size() - suffix.size(), '0');
+        value.append(suffix);
+        return value;
     }
 
     void
@@ -440,12 +478,161 @@ class TestChunkSegmentStorageV2 : public testing::TestWithParam<bool> {
     LoadFieldDataInfo load_info_;
     int chunk_num = 2;
     int test_data_count = 10000;
+    size_t fixed_string_width = 0;
+    bool test_data_created = false;
     std::unordered_map<std::string, FieldId> fields;
+    std::vector<std::string> string_data;
 };
 
 INSTANTIATE_TEST_SUITE_P(TestChunkSegmentStorageV2,
                          TestChunkSegmentStorageV2,
                          testing::Bool());
+
+TEST_P(TestChunkSegmentStorageV2, ReduceStringPkWithSimulatedAnnResult) {
+    constexpr int64_t nq = 4;
+    constexpr int64_t candidate_topk = 500;
+    constexpr int64_t final_topk = 32;
+    constexpr int64_t pk_lookup_count = nq * candidate_topk;
+    static_assert(pk_lookup_count == 2000);
+    ASSERT_EQ(RowCount(), 1000000);
+    ASSERT_EQ(fixed_string_width, 32);
+
+    milvus::query::Plan plan(schema_);
+    plan.plan_node_ = std::make_unique<milvus::query::VectorPlanNode>();
+    plan.plan_node_->search_info_.topk_ = final_topk;
+    plan.plan_node_->search_info_.metric_type_ = knowhere::metric::L2;
+    plan.target_entries_.push_back(fields.at("string1"));
+
+    auto offset_at = [this, candidate_topk](int64_t qi, int64_t rank) {
+        auto lookup_index = qi * candidate_topk + rank;
+        return (lookup_index * 499979 + qi * 9973) % RowCount();
+    };
+
+    auto make_result = [&]() {
+        SearchResult result;
+        result.total_nq_ = nq;
+        result.unity_topK_ = candidate_topk;
+        result.total_data_cnt_ = RowCount();
+        result.segment_ = segment.get();
+        result.seg_offsets_.resize(nq * candidate_topk);
+        result.distances_.resize(nq * candidate_topk);
+        for (int64_t qi = 0; qi < nq; ++qi) {
+            for (int64_t rank = 0; rank < candidate_topk; ++rank) {
+                auto loc = qi * candidate_topk + rank;
+                result.seg_offsets_[loc] = offset_at(qi, rank);
+                result.distances_[loc] = static_cast<float>(rank);
+            }
+        }
+        return result;
+    };
+
+    auto fast_pk_result = make_result();
+    auto generic_pk_result = make_result();
+    auto start = std::chrono::steady_clock::now();
+    segment->FillPrimaryKeys(&plan, fast_pk_result);
+    auto fast_fill_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                            std::chrono::steady_clock::now() - start)
+                            .count();
+    start = std::chrono::steady_clock::now();
+    static_cast<SegmentInternalInterface*>(segment.get())
+        ->SegmentInternalInterface::FillPrimaryKeys(&plan, generic_pk_result);
+    auto generic_fill_us =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - start)
+            .count();
+    RecordProperty("fast_pk_fill_us", fast_fill_us);
+    RecordProperty("generic_pk_fill_us", generic_fill_us);
+    RecordProperty("row_count", std::to_string(RowCount()));
+    RecordProperty("varchar_pk_len", std::to_string(fixed_string_width));
+    RecordProperty("pk_lookup_count", std::to_string(pk_lookup_count));
+
+    ASSERT_EQ(fast_pk_result.pk_type_, DataType::VARCHAR);
+    ASSERT_EQ(generic_pk_result.pk_type_, DataType::VARCHAR);
+    ASSERT_EQ(fast_pk_result.primary_keys_.size(),
+              generic_pk_result.primary_keys_.size());
+    for (size_t i = 0; i < fast_pk_result.primary_keys_.size(); ++i) {
+        ASSERT_EQ(std::get<std::string>(fast_pk_result.primary_keys_[i]),
+                  std::get<std::string>(generic_pk_result.primary_keys_[i]));
+    }
+
+    auto reduce_result = make_result();
+    std::vector<CSearchResult> c_search_results{
+        reinterpret_cast<CSearchResult>(&reduce_result)};
+    std::vector<int64_t> slice_nqs{nq};
+    std::vector<int64_t> slice_topks{final_topk};
+    int64_t all_search_count = 0;
+    CTraceContext trace{0, 0, 0};
+    auto status =
+        PrepareSearchResultsForExport(trace,
+                                      reinterpret_cast<CSearchPlan>(&plan),
+                                      nullptr,
+                                      c_search_results.data(),
+                                      c_search_results.size(),
+                                      slice_nqs.data(),
+                                      slice_nqs.size(),
+                                      slice_topks.data(),
+                                      &all_search_count,
+                                      nullptr);
+    ASSERT_EQ(status.error_code, 0) << status.error_msg;
+    ASSERT_EQ(all_search_count, reduce_result.total_data_cnt_);
+
+    ASSERT_EQ(reduce_result.primary_keys_.size(), nq * candidate_topk);
+    ASSERT_EQ(reduce_result.seg_offsets_.size(), nq * candidate_topk);
+    ASSERT_EQ(reduce_result.topk_per_nq_prefix_sum_.size(), nq + 1);
+    ASSERT_EQ(reduce_result.topk_per_nq_prefix_sum_.back(),
+              nq * candidate_topk);
+
+    for (int64_t qi = 0; qi < nq; ++qi) {
+        for (int64_t rank = 0; rank < final_topk; ++rank) {
+            auto loc = qi * candidate_topk + rank;
+            auto expected_offset = offset_at(qi, rank);
+            auto expected_string = string_data[expected_offset];
+            ASSERT_EQ(reduce_result.seg_offsets_[loc], expected_offset);
+            ASSERT_EQ(std::get<std::string>(reduce_result.primary_keys_[loc]),
+                      expected_string);
+            ASSERT_FLOAT_EQ(reduce_result.distances_[loc],
+                            static_cast<float>(rank));
+        }
+    }
+
+    std::vector<int32_t> result_seg_indices(nq * final_topk, 0);
+    std::vector<int64_t> result_seg_offsets;
+    result_seg_offsets.reserve(nq * final_topk);
+    for (int64_t qi = 0; qi < nq; ++qi) {
+        for (int64_t rank = 0; rank < final_topk; ++rank) {
+            result_seg_offsets.push_back(offset_at(qi, rank));
+        }
+    }
+
+    CProto c_proto{};
+    status = FillOutputFieldsOrdered(c_search_results.data(),
+                                     c_search_results.size(),
+                                     reinterpret_cast<CSearchPlan>(&plan),
+                                     result_seg_indices.data(),
+                                     result_seg_offsets.data(),
+                                     result_seg_offsets.size(),
+                                     &c_proto,
+                                     nullptr);
+    ASSERT_EQ(status.error_code, 0) << status.error_msg;
+    ASSERT_GT(c_proto.proto_size, 0);
+    milvus::proto::schema::SearchResultData search_result_data;
+    ASSERT_TRUE(search_result_data.ParseFromArray(c_proto.proto_blob,
+                                                  c_proto.proto_size));
+    ASSERT_EQ(search_result_data.fields_data_size(), 1);
+    const auto& marshaled_string_output =
+        search_result_data.fields_data(0).scalars().string_data().data();
+    ASSERT_EQ(marshaled_string_output.size(), nq * final_topk);
+    free(const_cast<void*>(c_proto.proto_blob));
+
+    for (int64_t qi = 0; qi < nq; ++qi) {
+        for (int64_t rank = 0; rank < final_topk; ++rank) {
+            auto loc = qi * final_topk + rank;
+            auto expected_offset = offset_at(qi, rank);
+            auto expected_string = string_data[expected_offset];
+            ASSERT_EQ(marshaled_string_output.Get(loc), expected_string);
+        }
+    }
+}
 
 TEST_P(TestChunkSegmentStorageV2, TestTermExpr) {
     bool pk_is_string = GetParam();


### PR DESCRIPTION
## Summary

issue: #51030

Add a sealed-segment fast path for filling VARCHAR primary keys from chunked/StorageV2 sealed segments. The change bulk reads the VARCHAR primary-key column by segment offsets and avoids the generic raw-data path while preserving correctness and storage cost accounting.

This branch is cherry-picked from `00261e8b48127401db6ac1ba4e39003a849d0d76` onto `origin/master`.

## Verification

- `git diff --check origin/master...HEAD`

Local `cmake --build cmake_build --target all_tests -j32` did not reach compilation because the existing build directory fails master reconfigure with missing `milvus-commonConfig.cmake`; this appears to be a local build-dir/dependency configuration issue rather than a patch compile failure.
