### PR TITLE
fix: trim boolean import option values

### DIFF
--- a/internal/util/importutilv2/option.go
+++ b/internal/util/importutilv2/option.go
@@ -126,7 +126,7 @@ func ParseTimeRange(options Options) (uint64, uint64, error) {
 
 func IsBackup(options Options) bool {
 	isBackup, err := funcutil.GetAttrByKeyFromRepeatedKV(BackupFlag, options)
-	if err != nil || strings.ToLower(isBackup) != "true" {
+	if err != nil || !isImportOptionTrue(isBackup) {
 		return false
 	}
 	return true
@@ -134,7 +134,7 @@ func IsBackup(options Options) bool {
 
 func IsL0Import(options Options) bool {
 	isL0Import, err := funcutil.GetAttrByKeyFromRepeatedKV(L0Import, options)
-	if err != nil || strings.ToLower(isL0Import) != "true" {
+	if err != nil || !isImportOptionTrue(isL0Import) {
 		return false
 	}
 	return true
@@ -169,7 +169,7 @@ func SkipDiskQuotaCheck(options Options) bool {
 		return false
 	}
 	skip, err := funcutil.GetAttrByKeyFromRepeatedKV(SkipDQC, options)
-	if err != nil || strings.ToLower(skip) != "true" {
+	if err != nil || !isImportOptionTrue(skip) {
 		return false
 	}
 	return true
@@ -207,8 +207,16 @@ func GetEZK(options Options) (string, error) {
 // IsAutoCommit parses the auto_commit option. Defaults to true if absent.
 func IsAutoCommit(options Options) bool {
 	val, err := funcutil.GetAttrByKeyFromRepeatedKV(AutoCommitKey, options)
-	if err != nil || strings.ToLower(val) != "false" {
+	if err != nil || !isImportOptionFalse(val) {
 		return true
 	}
 	return false
+}
+
+func isImportOptionTrue(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), "true")
+}
+
+func isImportOptionFalse(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), "false")
 }

--- a/internal/util/importutilv2/option_test.go
+++ b/internal/util/importutilv2/option_test.go
@@ -101,6 +101,13 @@ func TestOption_SkipDiskQuotaCheck(t *testing.T) {
 	}
 	assert.True(t, SkipDiskQuotaCheck(options))
 
+	// surrounding whitespace and casing should not change boolean parsing
+	options = []*commonpb.KeyValuePair{
+		{Key: BackupFlag, Value: " TRUE "},
+		{Key: SkipDQC, Value: "\ttrue\n"},
+	}
+	assert.True(t, SkipDiskQuotaCheck(options))
+
 	// backup = true, skip_disk_quota_check = false
 	options = []*commonpb.KeyValuePair{
 		{Key: BackupFlag, Value: "true"},
@@ -143,6 +150,14 @@ func TestOption_SkipDiskQuotaCheck(t *testing.T) {
 		{Key: BackupFlag, Value: "false"},
 		{Key: L0Import, Value: "false"},
 		{Key: SkipDQC, Value: "true"},
+	}
+	assert.False(t, SkipDiskQuotaCheck(options))
+
+	// surrounding whitespace should still preserve explicit false values
+	options = []*commonpb.KeyValuePair{
+		{Key: BackupFlag, Value: " false "},
+		{Key: L0Import, Value: "\tfalse\n"},
+		{Key: SkipDQC, Value: " true "},
 	}
 	assert.False(t, SkipDiskQuotaCheck(options))
 
@@ -225,5 +240,9 @@ func TestIsAutoCommit(t *testing.T) {
 
 	// explicit false
 	opts = []*commonpb.KeyValuePair{{Key: AutoCommitKey, Value: "false"}}
+	assert.False(t, IsAutoCommit(opts))
+
+	// surrounding whitespace and casing should not change boolean parsing
+	opts = []*commonpb.KeyValuePair{{Key: AutoCommitKey, Value: " FALSE "}}
 	assert.False(t, IsAutoCommit(opts))
 }


### PR DESCRIPTION
issue: #51042

This PR trims surrounding whitespace when parsing boolean import option values so copied or serialized options like `" FALSE "` and `"\ttrue\n"` keep the intended import behavior.

## What Problem This Solves

Import options are passed through `commonpb.KeyValuePair` as string values, then interpreted by helpers such as `IsBackup`, `IsL0Import`, `SkipDiskQuotaCheck`, and `IsAutoCommit`. These helpers currently lower-case the raw value and compare it directly:

```go
strings.ToLower(value) == "true"
strings.ToLower(value) == "false"
```

Because the raw value is not trimmed first, a value that is visually a valid boolean can be parsed as a different option state when it contains surrounding whitespace:

```text
auto_commit = "false "  -> parsed as true
backup = " TRUE "       -> parsed as false
skip_disk_quota_check = "\ttrue\n" -> parsed as false
```

This is a realistic edge case for import options because these values can come from request payloads, scripts, generated config, or copy/pasted text. A trailing newline or space is hard to notice during review, but it changes the branch taken by the import option parser.

The most visible case is `auto_commit`. Its default is true, so a caller that sends `auto_commit = "false "` expects to disable auto commit, but the current comparison does not recognize the padded value as false and falls back to true. The job can therefore auto-commit even though the caller supplied an explicit false-like value.

The backup-related options have the opposite failure shape. Padded true-like values such as `backup = " TRUE "` or `skip_disk_quota_check = "\ttrue\n"` are parsed as false, which can prevent backup/l0 import flags from being enabled even though the option text clearly indicates true.

## Change

- Normalize boolean import option values with `strings.TrimSpace` before comparison.
- Use `strings.EqualFold` for the existing case-insensitive behavior.
- Keep the existing defaults unchanged: missing `auto_commit` still defaults to true, and missing backup/l0/skip-disk-quota options still default to false.

## Evidence

The added unit coverage exercises the affected option paths directly:

```text
backup = " TRUE " + skip_disk_quota_check = "\ttrue\n" -> SkipDiskQuotaCheck returns true
backup = " false " + l0_import = "\tfalse\n" -> SkipDiskQuotaCheck returns false
auto_commit = " FALSE " -> IsAutoCommit returns false
```

Before this change, these whitespace-padded values were not normalized before comparison, so they fell through to the wrong default branch.

## Possible call chain / impact

```text
import request options
  -> internal/util/importutilv2.Options
    -> IsBackup / IsL0Import / SkipDiskQuotaCheck / IsAutoCommit
      -> boolean branch used by import execution
```

This PR only changes boolean option parsing for import options. It does not change option keys, default values, CSV parsing, time range parsing, storage version parsing, protobuf structures, or import execution behavior for already-normalized option values.

## Validation

- `git diff --check` - passed
- `go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/util/importutilv2 -run 'TestIsAutoCommit|TestOption_SkipDiskQuotaCheck'` - not run locally because `go`/`gofmt` are not available in the Windows PATH, and `go` is also unavailable in the local Ubuntu-22.04 WSL environment.