### PR TITLE
fix: [2.6] skip null bitmap work for all-valid filters

### DIFF
--- a/internal/core/src/exec/operator/FilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/FilterBitsNode.cpp
@@ -24,23 +24,25 @@
 namespace milvus {
 namespace exec {
 
-namespace {
-
-void
+bool
 ConvertPredicateToFilteredBitset(TargetBitmapView data,
                                  TargetBitmapView valid,
                                  const size_t size) {
     // FilterBitsNode outputs a filtered-row bitset: 1 means excluded. A SQL-style
     // predicate passes only when it is definitely TRUE, so UNKNOWN/NULL must be
     // excluded together with FALSE.
+    if (valid.all()) {
+        data.flip();
+        return true;
+    }
+
     data.flip();
     TargetBitmap invalid(valid);
     invalid.flip();
     data.inplace_or(invalid, size);
     valid.set();
+    return false;
 }
-
-}  // namespace
 
 PhyFilterBitsNode::PhyFilterBitsNode(
     int32_t operator_id,

--- a/internal/core/src/exec/operator/FilterBitsNode.h
+++ b/internal/core/src/exec/operator/FilterBitsNode.h
@@ -16,9 +16,11 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
+#include "common/Types.h"
 #include "exec/Driver.h"
 #include "exec/expression/Expr.h"
 #include "exec/operator/Operator.h"
@@ -26,6 +28,12 @@
 
 namespace milvus {
 namespace exec {
+
+bool
+ConvertPredicateToFilteredBitset(TargetBitmapView data,
+                                 TargetBitmapView valid,
+                                 size_t size);
+
 class PhyFilterBitsNode : public Operator {
  public:
     PhyFilterBitsNode(

--- a/internal/core/src/exec/operator/FilterBitsNodeTest.cpp
+++ b/internal/core/src/exec/operator/FilterBitsNodeTest.cpp
@@ -1,0 +1,121 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <initializer_list>
+#include <memory>
+#include <vector>
+
+#include "common/Types.h"
+#include "common/Vector.h"
+#include "exec/operator/FilterBitsNode.h"
+
+namespace milvus {
+namespace exec {
+namespace {
+
+TargetBitmap
+MakeBitmap(std::initializer_list<bool> bits) {
+    TargetBitmap bitmap(bits.size(), false);
+    size_t i = 0;
+    for (const auto bit : bits) {
+        bitmap.set(i++, bit);
+    }
+    return bitmap;
+}
+
+std::vector<bool>
+ToVector(const TargetBitmap& bitmap) {
+    std::vector<bool> bits;
+    bits.reserve(bitmap.size());
+    for (size_t i = 0; i < bitmap.size(); ++i) {
+        bits.push_back(bitmap[i]);
+    }
+    return bits;
+}
+
+std::vector<bool>
+ToVector(TargetBitmapView bitmap) {
+    std::vector<bool> bits;
+    bits.reserve(bitmap.size());
+    for (size_t i = 0; i < bitmap.size(); ++i) {
+        bits.push_back(bitmap[i]);
+    }
+    return bits;
+}
+
+TEST(FilterBitsNodeTest, PredicateConversionUsesFastPathForAllValidResults) {
+    auto data = MakeBitmap({true, false, true, false});
+    TargetBitmap valid(data.size(), true);
+
+    const bool used_all_valid_fast_path = ConvertPredicateToFilteredBitset(
+        TargetBitmapView(data), TargetBitmapView(valid), data.size());
+
+    EXPECT_TRUE(used_all_valid_fast_path);
+    EXPECT_EQ(ToVector(data), (std::vector<bool>{false, true, false, true}));
+    EXPECT_TRUE(valid.all());
+}
+
+TEST(FilterBitsNodeTest, PredicateConversionUsesLiveAllValidBitmap) {
+    auto data = MakeBitmap({true, false, true, false});
+    TargetBitmap valid(data.size(), true);
+    auto col_vec =
+        std::make_shared<ColumnVector>(std::move(data), std::move(valid));
+
+    TargetBitmapView data_view(col_vec->GetRawData(), col_vec->size());
+    TargetBitmapView valid_view(col_vec->GetValidRawData(), col_vec->size());
+    const bool used_all_valid_fast_path = ConvertPredicateToFilteredBitset(
+        data_view, valid_view, col_vec->size());
+
+    EXPECT_TRUE(used_all_valid_fast_path);
+    EXPECT_EQ(ToVector(data_view),
+              (std::vector<bool>{false, true, false, true}));
+    EXPECT_TRUE(valid_view.all());
+}
+
+TEST(FilterBitsNodeTest, PredicateConversionUsesLiveInvalidBitmap) {
+    auto data = MakeBitmap({true, false, true, false});
+    auto valid = MakeBitmap({true, true, false, false});
+    auto col_vec =
+        std::make_shared<ColumnVector>(std::move(data), std::move(valid));
+
+    TargetBitmapView data_view(col_vec->GetRawData(), col_vec->size());
+    TargetBitmapView valid_view(col_vec->GetValidRawData(), col_vec->size());
+    const bool used_all_valid_fast_path = ConvertPredicateToFilteredBitset(
+        data_view, valid_view, col_vec->size());
+
+    EXPECT_FALSE(used_all_valid_fast_path);
+    EXPECT_EQ(ToVector(data_view),
+              (std::vector<bool>{false, true, true, true}));
+    EXPECT_TRUE(valid_view.all());
+}
+
+TEST(FilterBitsNodeTest, PredicateConversionFiltersOutInvalidResults) {
+    auto data = MakeBitmap({true, false, true, false});
+    auto valid = MakeBitmap({true, true, false, false});
+
+    const bool used_all_valid_fast_path = ConvertPredicateToFilteredBitset(
+        TargetBitmapView(data), TargetBitmapView(valid), data.size());
+
+    EXPECT_FALSE(used_all_valid_fast_path);
+    EXPECT_EQ(ToVector(data), (std::vector<bool>{false, true, true, true}));
+    EXPECT_TRUE(valid.all());
+}
+
+}  // namespace
+}  // namespace exec
+}  // namespace milvus


### PR DESCRIPTION
pr: #51050
issue: #51034

This backports the final PR #51050 behavior to branch `2.6`.

## Summary

- `FilterBitsNode` now uses the live validity bitmap: all-valid predicate results take the direct flip fast path.
- Mixed-validity results still OR invalid rows into the filtered bitset and mark the validity set.
- Adds focused `FilterBitsNodeTest` coverage for all-valid, live all-valid, live invalid, and invalid-result filtering behavior.

## Verification from Carl-8CU

- [x] `jobs=16 ./scripts/core_build.sh -t Release -u` exited 0 after generating the fresh worktree's plan-parser outputs with `scripts/build_plan_parser.sh`.
- [x] `git diff --check` exited 0.
- [x] `source ./scripts/setenv.sh && LD_LIBRARY_PATH="/home/zilliz/.conan/data/folly/2023.10.30.08/milvus/dev/package/5bec4d2fbd135f94ac534b51370a211bd5614d22/lib:${LD_LIBRARY_PATH:-}" ./cmake_build/bin/all_tests --gtest_filter='FilterBitsNodeTest.*'` passed 4/4.