### PR TITLE
test: fix struct array nullable field error expectation

### DIFF
--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -4778,7 +4778,7 @@ class TestMilvusClientStructArrayInvalid(TestMilvusClientV2Base):
         error = {
             ct.err_code: 1100,
             ct.err_msg: f"Field '{nullable_field}' in struct 'clips' cannot be nullable individually, "
-                        f"set nullable on the struct instead",
+            f"set nullable on the struct instead",
         }
         self.create_collection(
             client,

--- a/tests/python_client/milvus_client/test_milvus_client_struct_array.py
+++ b/tests/python_client/milvus_client/test_milvus_client_struct_array.py
@@ -4777,8 +4777,8 @@ class TestMilvusClientStructArrayInvalid(TestMilvusClientV2Base):
         )
         error = {
             ct.err_code: 1100,
-            ct.err_msg: f"sub-field in non-nullable struct cannot be nullable individually, "
-            f"set nullable on the struct instead: structName=clips, subFieldName={nullable_field}",
+            ct.err_msg: f"Field '{nullable_field}' in struct 'clips' cannot be nullable individually, "
+                        f"set nullable on the struct instead",
         }
         self.create_collection(
             client,


### PR DESCRIPTION
This PR updates the struct array invalid-case test expectation to match the current error message for nullable sub-fields inside a non-nullable struct.

The affected parametrized cases are:
- test_struct_array_with_nullable_field[clip_embedding1]
- test_struct_array_with_nullable_field[scalar_field]

This is a test-only change.