### PR TITLE
fix: [2.6] keep Tencent STS JsonValue alive during response parsing (#51015)

### DIFF
--- a/internal/core/src/storage/TencentCloudSTSClient.cpp
+++ b/internal/core/src/storage/TencentCloudSTSClient.cpp
@@ -111,34 +111,90 @@ TencentCloudSTSCredentialsClient::GetAssumeRoleWithWebIdentityCredentials(
 
     // Parse credentials
     STSAssumeRoleWithWebIdentityResult result;
-    if (credentialsStr.empty()) {
+    auto parseResult = parseSTSResponse(credentialsStr);
+    if (!parseResult.success) {
+        return result;
+    }
+
+    result.creds = parseResult.credentials;
+    return result;
+}
+
+TencentCloudSTSCredentialsClient::STSParseResult
+TencentCloudSTSCredentialsClient::parseSTSResponse(
+    const Aws::String& responseBody) {
+    STSParseResult result;
+    if (responseBody.empty()) {
         AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
                            "Get an empty credential from sts");
         return result;
     }
 
-    auto json = Utils::Json::JsonView(credentialsStr);
-    auto rootNode = json.GetObject("Response");
-    if (rootNode.IsNull()) {
+    Aws::Utils::Json::JsonValue jsonValue(responseBody);
+    if (!jsonValue.WasParseSuccessful()) {
+        AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
+                           "Failed to parse credential result json");
+        return result;
+    }
+
+    auto json = jsonValue.View();
+    if (!json.ValueExists("Response")) {
         AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
                            "Get Response from credential result failed");
         return result;
     }
+    auto rootNode = json.GetObject("Response");
 
-    auto credentialsNode = rootNode.GetObject("Credentials");
-    if (credentialsNode.IsNull()) {
+    if (!rootNode.ValueExists("Credentials")) {
         AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
                            "Get Credentials from Response failed");
         return result;
     }
-    result.creds.SetAWSAccessKeyId(credentialsNode.GetString("TmpSecretId"));
-    result.creds.SetAWSSecretKey(credentialsNode.GetString("TmpSecretKey"));
-    result.creds.SetSessionToken(credentialsNode.GetString("Token"));
-    result.creds.SetExpiration(Aws::Utils::DateTime(
-        Aws::Utils::StringUtils::Trim(rootNode.GetString("Expiration").c_str())
-            .c_str(),
-        Aws::Utils::DateFormat::ISO_8601));
+    auto credentialsNode = rootNode.GetObject("Credentials");
 
+    if (!rootNode.ValueExists("Expiration")) {
+        AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
+                           "Get Expiration from Response failed");
+        return result;
+    }
+    auto expiration =
+        Aws::Utils::StringUtils::Trim(rootNode.GetString("Expiration").c_str());
+    if (expiration.empty()) {
+        AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
+                           "Get Expiration from Response failed");
+        return result;
+    }
+
+    if (!credentialsNode.ValueExists("TmpSecretId") ||
+        !credentialsNode.ValueExists("TmpSecretKey") ||
+        !credentialsNode.ValueExists("Token")) {
+        AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
+                           "Get credential fields from Response failed");
+        return result;
+    }
+
+    auto accessKeyId = credentialsNode.GetString("TmpSecretId");
+    auto secretKey = credentialsNode.GetString("TmpSecretKey");
+    auto sessionToken = credentialsNode.GetString("Token");
+    if (accessKeyId.empty() || secretKey.empty() || sessionToken.empty()) {
+        AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
+                           "Get credential fields from Response failed");
+        return result;
+    }
+
+    auto parsedExpiration = Aws::Utils::DateTime(
+        expiration.c_str(), Aws::Utils::DateFormat::ISO_8601);
+    if (!parsedExpiration.WasParseSuccessful()) {
+        AWS_LOGSTREAM_WARN(STS_RESOURCE_CLIENT_LOG_TAG,
+                           "Failed to parse Expiration from Response");
+        return result;
+    }
+
+    result.credentials.SetAWSAccessKeyId(accessKeyId);
+    result.credentials.SetAWSSecretKey(secretKey);
+    result.credentials.SetSessionToken(sessionToken);
+    result.credentials.SetExpiration(parsedExpiration);
+    result.success = true;
     return result;
 }
 }  // namespace Internal

--- a/internal/core/src/storage/TencentCloudSTSClient.h
+++ b/internal/core/src/storage/TencentCloudSTSClient.h
@@ -36,6 +36,7 @@ enum class HttpResponseCode;
 }  // namespace Http
 
 namespace Internal {
+class TencentCloudSTSClientTestHelper;
 /**
  * To support retrieving credentials from STS.
  * Note that STS accepts request with protocol of queryxml. Calling GetResource() will trigger
@@ -43,6 +44,8 @@ namespace Internal {
  */
 class AWS_CORE_API TencentCloudSTSCredentialsClient
     : public AWSHttpResourceClient {
+    friend class ::Aws::Internal::TencentCloudSTSClientTestHelper;
+
  public:
     /**
      * Initializes the provider to retrieve credentials from STS when it expires.
@@ -79,6 +82,14 @@ class AWS_CORE_API TencentCloudSTSCredentialsClient
         const STSAssumeRoleWithWebIdentityRequest& request);
 
  private:
+    struct STSParseResult {
+        bool success = false;
+        Aws::Auth::AWSCredentials credentials;
+    };
+
+    static STSParseResult
+    parseSTSResponse(const Aws::String& responseBody);
+
     Aws::String m_endpoint;
 };
 }  // namespace Internal

--- a/internal/core/src/storage/TencentCloudSTSClientTest.cpp
+++ b/internal/core/src/storage/TencentCloudSTSClientTest.cpp
@@ -1,0 +1,214 @@
+// Copyright (C) 2019-2020 Zilliz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "aws/core/Aws.h"
+#include "storage/TencentCloudSTSClient.h"
+
+namespace Aws {
+namespace Internal {
+
+class TencentCloudSTSClientTestHelper {
+ public:
+    using Client = TencentCloudSTSCredentialsClient;
+
+    struct ParseResultView {
+        bool success;
+        Aws::Auth::AWSCredentials credentials;
+    };
+
+    static ParseResultView
+    parseSTSResponse(const Aws::String& responseBody) {
+        auto result = Client::parseSTSResponse(responseBody);
+        return {result.success, result.credentials};
+    }
+};
+
+}  // namespace Internal
+}  // namespace Aws
+
+namespace {
+
+class TencentCloudSTSClientTest : public ::testing::Test {
+ protected:
+    static Aws::SDKOptions sdkOptions_;
+
+    static void
+    SetUpTestSuite() {
+        sdkOptions_.loggingOptions.logLevel =
+            Aws::Utils::Logging::LogLevel::Off;
+        Aws::InitAPI(sdkOptions_);
+    }
+
+    static void
+    TearDownTestSuite() {
+        Aws::ShutdownAPI(sdkOptions_);
+    }
+
+    using Helper = Aws::Internal::TencentCloudSTSClientTestHelper;
+};
+
+Aws::SDKOptions TencentCloudSTSClientTest::sdkOptions_;
+
+TEST_F(TencentCloudSTSClientTest, RejectsEmptyResponseBody) {
+    auto result = Helper::parseSTSResponse("");
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.credentials.IsEmpty());
+}
+
+TEST_F(TencentCloudSTSClientTest, RejectsInvalidJson) {
+    auto result = Helper::parseSTSResponse("{invalid-json");
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.credentials.IsEmpty());
+}
+
+TEST_F(TencentCloudSTSClientTest, RejectsMissingResponseObject) {
+    const std::string body = R"({
+        "Credentials": {
+            "TmpSecretId": "AKID_TEST",
+            "TmpSecretKey": "SECRET_TEST",
+            "Token": "SESSION_TOKEN"
+        },
+        "Expiration": "2026-07-03T12:34:56Z"
+    })";
+    auto result = Helper::parseSTSResponse(body);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.credentials.IsEmpty());
+}
+
+TEST_F(TencentCloudSTSClientTest, RejectsMissingCredentialsObject) {
+    const std::string body = R"({
+        "Response": {
+            "Expiration": "2026-07-03T12:34:56Z"
+        }
+    })";
+    auto result = Helper::parseSTSResponse(body);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.credentials.IsEmpty());
+}
+
+TEST_F(TencentCloudSTSClientTest, RejectsMissingExpiration) {
+    const std::string body = R"({
+        "Response": {
+            "Credentials": {
+                "TmpSecretId": "AKID_TEST",
+                "TmpSecretKey": "SECRET_TEST",
+                "Token": "SESSION_TOKEN"
+            }
+        }
+    })";
+    auto result = Helper::parseSTSResponse(body);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.credentials.IsEmpty());
+}
+
+TEST_F(TencentCloudSTSClientTest, RejectsInvalidExpirationFormat) {
+    const std::string body = R"({
+        "Response": {
+            "Credentials": {
+                "TmpSecretId": "AKID_TEST",
+                "TmpSecretKey": "SECRET_TEST",
+                "Token": "SESSION_TOKEN"
+            },
+            "Expiration": "not-a-timestamp"
+        }
+    })";
+    auto result = Helper::parseSTSResponse(body);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.credentials.IsEmpty());
+}
+
+TEST_F(TencentCloudSTSClientTest, RejectsMissingAccessKeyId) {
+    const std::string body = R"({
+        "Response": {
+            "Credentials": {
+                "TmpSecretKey": "SECRET_TEST",
+                "Token": "SESSION_TOKEN"
+            },
+            "Expiration": "2026-07-03T12:34:56Z"
+        }
+    })";
+    auto result = Helper::parseSTSResponse(body);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.credentials.IsEmpty());
+}
+
+TEST_F(TencentCloudSTSClientTest, RejectsMissingSecretKey) {
+    const std::string body = R"({
+        "Response": {
+            "Credentials": {
+                "TmpSecretId": "AKID_TEST",
+                "Token": "SESSION_TOKEN"
+            },
+            "Expiration": "2026-07-03T12:34:56Z"
+        }
+    })";
+    auto result = Helper::parseSTSResponse(body);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.credentials.IsEmpty());
+}
+
+TEST_F(TencentCloudSTSClientTest, RejectsMissingSessionToken) {
+    const std::string body = R"({
+        "Response": {
+            "Credentials": {
+                "TmpSecretId": "AKID_TEST",
+                "TmpSecretKey": "SECRET_TEST"
+            },
+            "Expiration": "2026-07-03T12:34:56Z"
+        }
+    })";
+    auto result = Helper::parseSTSResponse(body);
+
+    EXPECT_FALSE(result.success);
+    EXPECT_TRUE(result.credentials.IsEmpty());
+}
+
+TEST_F(TencentCloudSTSClientTest,
+       AcceptsValidResponseAndReturnsNonEmptyCredentials) {
+    const std::string body = R"({
+        "Response": {
+            "Credentials": {
+                "TmpSecretId": "AKID_TEST",
+                "TmpSecretKey": "SECRET_TEST",
+                "Token": "SESSION_TOKEN"
+            },
+            "Expiration": "2026-07-03T12:34:56Z",
+            "RequestId": "req-123"
+        }
+    })";
+    auto result = Helper::parseSTSResponse(body);
+
+    EXPECT_TRUE(result.success);
+    EXPECT_EQ(result.credentials.GetAWSAccessKeyId(), "AKID_TEST");
+    EXPECT_EQ(result.credentials.GetAWSSecretKey(), "SECRET_TEST");
+    EXPECT_EQ(result.credentials.GetSessionToken(), "SESSION_TOKEN");
+    EXPECT_FALSE(result.credentials.GetExpiration()
+                     .ToGmtString(Aws::Utils::DateFormat::ISO_8601)
+                     .empty());
+}
+
+}  // namespace


### PR DESCRIPTION
Cherry-pick from master
pr: #51015
Related to #51014

TencentCloudSTSClient constructed JsonView from a temporary JsonValue, leaving the response parser with a dangling view and causing successful STS payloads to be treated as empty credentials. Keep the owning JsonValue alive for the full parse scope so Tencent IAM startup no longer panics on empty access key assertions.

---------