### PR TITLE
Fix WAL remove incorrectly returning previous open's canceled error

### DIFF
--- a/internal/streamingnode/server/walmanager/wal_lifetime.go
+++ b/internal/streamingnode/server/walmanager/wal_lifetime.go
@@ -3,8 +3,6 @@ package walmanager
 import (
 	"context"
 
-	"github.com/cockroachdb/errors"
-
 	"github.com/milvus-io/milvus/internal/streamingnode/server/wal"
 	"github.com/milvus-io/milvus/internal/util/streamingutil/status"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -72,10 +70,17 @@ func (w *walLifetime) Remove(ctx context.Context, term int64) error {
 
 	// Wait until the WAL state is ready or term expired or error occurs.
 	err := w.statePair.WaitCurrentStateReachExpected(ctx, expected)
-	if errors.IsAny(err, context.Canceled, context.DeadlineExceeded) {
+	if err != nil && ctx.Err() != nil {
+		// The remove operation itself is canceled or timed out,
+		// so the current state may not have reached the expected state yet.
 		return err
 	}
 	if err != nil {
+		// The error is the previous open operation's failure kept in current state.
+		// It may itself wrap context.Canceled if the open was interrupted by the
+		// assign rpc's deadline (see issue #51078), so it must not be confused with
+		// a cancellation of this remove call: the wal is not open at this term,
+		// hence the remove is a success.
 		w.logger.Info(ctx, "remove wal success because that previous open operation is failure", mlog.NamedError("previousOpenError", err))
 	}
 	return nil

--- a/internal/streamingnode/server/walmanager/wal_lifetime_test.go
+++ b/internal/streamingnode/server/walmanager/wal_lifetime_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -114,6 +115,46 @@ func TestWALLifetime(t *testing.T) {
 	assert.NotNil(t, wlt.GetWAL())
 	assert.Equal(t, channel, wlt.GetWAL().Channel().Name)
 	assert.Equal(t, int64(12), wlt.GetWAL().Channel().Term)
+
+	wlt.Close()
+}
+
+func TestWALLifetimeRemoveAfterOpenInterruptedByAssignTimeout(t *testing.T) {
+	channel := "test"
+	mixcoord := mocks.NewMockMixCoordClient(t)
+	fMixcoord := syncutil.NewFuture[internaltypes.MixCoordClient]()
+	fMixcoord.Set(mixcoord)
+	resource.InitForTest(
+		t,
+		resource.OptMixCoordClient(fMixcoord),
+	)
+
+	assignCtx, assignCancel := context.WithCancel(context.Background())
+	opener := mock_wal.NewMockOpener(t)
+	opener.EXPECT().Open(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, oo *wal.OpenOption) (wal.WAL, error) {
+			// Simulate a slow wal recovery interrupted by the assign rpc reaching
+			// its deadline, same error shape as recovery_stream.go.
+			assignCancel()
+			<-ctx.Done()
+			return nil, errors.Wrap(ctx.Err(), "failed to recover from wal")
+		})
+
+	wlt := newWALLifetime(opener, channel, mlog.With())
+
+	err := wlt.Open(assignCtx, types.PChannelInfo{
+		Name: channel,
+		Term: 1,
+	})
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, wlt.GetWAL())
+
+	// The balancer then removes the channel with a fresh context.
+	// The wal is not open at this term, so the remove must succeed even if the
+	// previous open failure wraps context.Canceled (issue #51078).
+	err = wlt.Remove(context.Background(), 1)
+	assert.NoError(t, err)
+	assert.Nil(t, wlt.GetWAL())
 
 	wlt.Close()
 }


### PR DESCRIPTION
# fix: Remove wal failing on previous open's canceled error, leaving pchannels stuck in ASSIGNING

issue: #51078

## Problem

When a WAL open is interrupted because the assign RPC reaches its deadline (e.g. during slow Woodpecker remote recovery), the open failure wraps `context.Canceled` and is kept in the wal lifetime's current state (`when recovering recovery storage: failed to recover from wal: context canceled`).

The subsequent `Remove` sent by the streamingcoord balancer (with a fresh, healthy context) gets that stored error back from `WaitCurrentStateReachExpected`, and the guard `errors.IsAny(err, context.Canceled, context.DeadlineExceeded)` — intended to detect cancellation of the remove call itself — matches the previous open's wrapped context error instead. The remove RPC fails with `STREAMING_CODE_UNKNOWN`, the balancer aborts the channel's round before re-assigning, and the pchannel loops in `PCHANNEL_META_STATE_ASSIGNING` forever:

```
fail to assign channel ... rpc error: code = DeadlineExceeded
fail to remove channel ... cause = when recovering recovery storage: failed to recover from wal: context canceled
channel is not assigned to any server ... state=PCHANNEL_META_STATE_ASSIGNING
```

## Fix

In `walLifetime.Remove`, only propagate the wait error when the remove call's own context is done (`err != nil && ctx.Err() != nil`). Any other error is the stored failure of the previous open operation — including one wrapping `context.Canceled` from an interrupted assign — which means the WAL is not open at this term, so the remove is a success (the existing "remove wal success because that previous open operation is failure" path).

This lets the balancer's remove of the stale assignment succeed, so the new-term assign proceeds and the channel can leave the ASSIGNING state instead of wedging.

Note: the `reader temp info not found` messages in the issue originate in the Woodpecker client library; this PR fixes the Milvus control-plane deadlock those slow/failing recoveries trigger, not the Woodpecker-side metadata loss itself.

## Test

`TestWALLifetimeRemoveAfterOpenInterruptedByAssignTimeout` reproduces the sequence deterministically: a mock opener simulates a recovery interrupted by the assign deadline (returns `errors.Wrap(ctx.Err(), "failed to recover from wal")`, the same error shape as `recovery_stream.go`), then a remove with a fresh context must succeed. It fails before this fix with exactly the error from the issue logs and passes after.
