### PR TITLE
fix: Validate REST quick-create enum fields

### DIFF
--- a/internal/distributed/proxy/httpserver/handler_v2.go
+++ b/internal/distributed/proxy/httpserver/handler_v2.go
@@ -44,6 +44,7 @@ import (
 	"github.com/milvus-io/milvus/internal/proxy"
 	"github.com/milvus-io/milvus/internal/types"
 	"github.com/milvus-io/milvus/internal/util/hookutil"
+	"github.com/milvus-io/milvus/internal/util/indexparamcheck"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/mlog"
@@ -54,6 +55,7 @@ import (
 	"github.com/milvus-io/milvus/pkg/v3/util/externalspec"
 	"github.com/milvus-io/milvus/pkg/v3/util/funcutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/merr"
+	"github.com/milvus-io/milvus/pkg/v3/util/metric"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 	"github.com/milvus-io/milvus/pkg/v3/util/requestutil"
 	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
@@ -2046,6 +2048,70 @@ func (h *HandlersV2) advancedSearch(ctx context.Context, c *gin.Context, anyReq 
 	return resp, err
 }
 
+func defaultMetricTypeForQuickCreate(dataType schemapb.DataType) string {
+	switch dataType {
+	case schemapb.DataType_BinaryVector:
+		return paramtable.BinaryVectorDefaultMetricType
+	case schemapb.DataType_SparseFloatVector:
+		return paramtable.SparseFloatVectorDefaultMetricType
+	default:
+		return DefaultMetricType
+	}
+}
+
+func validateMetricTypeForQuickCreate(dataType schemapb.DataType, metricType string) error {
+	switch dataType {
+	case schemapb.DataType_BinaryVector:
+		if !funcutil.SliceContain(indexparamcheck.BinaryVectorMetrics, metricType) {
+			return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "binary vector index does not support metric type: "+metricType)
+		}
+	case schemapb.DataType_SparseFloatVector:
+		if !funcutil.SliceContain(indexparamcheck.SparseFloatVectorMetrics, metricType) {
+			return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "only IP&BM25 is the supported metric type for sparse index")
+		}
+		if metricType == metric.BM25 {
+			return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "only BM25 Function output field support BM25 metric type")
+		}
+	default:
+		if !funcutil.SliceContain(indexparamcheck.FloatVectorMetrics, metricType) {
+			return merr.WrapErrParameterInvalid("valid index params", "invalid index params", "float vector index does not support metric type: "+metricType)
+		}
+	}
+	return nil
+}
+
+func consistencyLevelForCreateCollection(httpReq *CollectionReq) (commonpb.ConsistencyLevel, error) {
+	consistencyLevel := commonpb.ConsistencyLevel_Bounded
+	paramConsistencyLevel, hasParamConsistencyLevel := httpReq.Params["consistencyLevel"]
+	paramConsistencyLevelStr := ""
+	if hasParamConsistencyLevel {
+		paramConsistencyLevelStr = fmt.Sprintf("%s", paramConsistencyLevel)
+	}
+
+	if httpReq.ConsistencyLevel != "" && hasParamConsistencyLevel && httpReq.ConsistencyLevel != paramConsistencyLevelStr {
+		return consistencyLevel, merr.WrapErrParameterInvalid("same consistencyLevel", paramConsistencyLevel,
+			"top-level consistencyLevel conflicts with params.consistencyLevel")
+	}
+
+	consistencyLevelStr := httpReq.ConsistencyLevel
+	var actualConsistencyLevel interface{} = httpReq.ConsistencyLevel
+	if consistencyLevelStr == "" && hasParamConsistencyLevel {
+		consistencyLevelStr = paramConsistencyLevelStr
+		actualConsistencyLevel = paramConsistencyLevel
+	}
+
+	if consistencyLevelStr == "" {
+		return consistencyLevel, nil
+	}
+
+	if level, ok := commonpb.ConsistencyLevel_value[consistencyLevelStr]; ok {
+		return commonpb.ConsistencyLevel(level), nil
+	}
+
+	return consistencyLevel, merr.WrapErrParameterInvalid("Strong, Session, Bounded, Eventually, Customized", actualConsistencyLevel,
+		"consistencyLevel can only be [Strong, Session, Bounded, Eventually, Customized], default: Bounded")
+}
+
 func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyReq any, dbName string) (interface{}, error) {
 	httpReq := anyReq.(*CollectionReq)
 	req := &milvuspb.CreateCollectionRequest{
@@ -2070,6 +2136,7 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 	var err error
 	fieldNames := map[string]bool{}
 	partitionsNum := int64(-1)
+	quickCreateVectorDataType := schemapb.DataType_FloatVector
 	if len(httpReq.Schema.Fields) == 0 {
 		if httpReq.GetExternalSource() != "" || httpReq.GetExternalSpec() != "" {
 			err := merr.WrapErrParameterInvalid("schema.fields", "empty schema fields",
@@ -2092,9 +2159,53 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 			return nil, err
 		}
 
-		if httpReq.Dimension == 0 {
+		switch httpReq.VectorFieldType {
+		case "", "FloatVector":
+			httpReq.VectorFieldType = "FloatVector"
+		case "BinaryVector":
+			quickCreateVectorDataType = schemapb.DataType_BinaryVector
+		case "Float16Vector":
+			quickCreateVectorDataType = schemapb.DataType_Float16Vector
+		case "BFloat16Vector":
+			quickCreateVectorDataType = schemapb.DataType_BFloat16Vector
+		case "SparseFloatVector":
+			quickCreateVectorDataType = schemapb.DataType_SparseFloatVector
+		default:
+			err := merr.WrapErrParameterInvalid("FloatVector, BinaryVector, Float16Vector, BFloat16Vector, SparseFloatVector", httpReq.VectorFieldType,
+				"vectorFieldType can only be [FloatVector, BinaryVector, Float16Vector, BFloat16Vector, SparseFloatVector], default: FloatVector")
+			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+			HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPReturnCode:    merr.Code(err),
+				HTTPReturnMessage: err.Error(),
+			})
+			return nil, err
+		}
+
+		if quickCreateVectorDataType == schemapb.DataType_SparseFloatVector && httpReq.Dimension != 0 {
+			err := merr.WrapErrParameterInvalid(int32(0), httpReq.Dimension,
+				"dimension should not be specified for SparseFloatVector quick create")
+			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+			HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPReturnCode:    merr.Code(err),
+				HTTPReturnMessage: err.Error(),
+			})
+			return nil, err
+		}
+
+		if quickCreateVectorDataType != schemapb.DataType_SparseFloatVector && httpReq.Dimension == 0 {
 			err := merr.WrapErrParameterInvalid("collectionName & dimension", "collectionName",
 				"dimension is required for quickly create collection(default metric type: "+DefaultMetricType+")")
+			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+			HTTPAbortReturn(c, http.StatusOK, gin.H{
+				HTTPReturnCode:    merr.Code(err),
+				HTTPReturnMessage: err.Error(),
+			})
+			return nil, err
+		}
+		if len(httpReq.MetricType) == 0 {
+			httpReq.MetricType = defaultMetricTypeForQuickCreate(quickCreateVectorDataType)
+		}
+		if err := validateMetricTypeForQuickCreate(quickCreateVectorDataType, httpReq.MetricType); err != nil {
 			mlog.Warn(ctx, "high level restful api, quickly create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
 			HTTPAbortReturn(c, http.StatusOK, gin.H{
 				HTTPReturnCode:    merr.Code(err),
@@ -2142,6 +2253,13 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 				return nil, err
 			}
 		}
+		vectorTypeParams := []*commonpb.KeyValuePair{}
+		if quickCreateVectorDataType != schemapb.DataType_SparseFloatVector {
+			vectorTypeParams = append(vectorTypeParams, &commonpb.KeyValuePair{
+				Key:   Dim,
+				Value: strconv.FormatInt(int64(httpReq.Dimension), 10),
+			})
+		}
 		schema, err = proto.Marshal(&schemapb.CollectionSchema{
 			Name: httpReq.CollectionName,
 			Fields: []*schemapb.FieldSchema{
@@ -2157,14 +2275,9 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 					FieldID:      common.StartOfUserFieldID + 1,
 					Name:         httpReq.VectorFieldName,
 					IsPrimaryKey: false,
-					DataType:     schemapb.DataType_FloatVector,
-					TypeParams: []*commonpb.KeyValuePair{
-						{
-							Key:   Dim,
-							Value: strconv.FormatInt(int64(httpReq.Dimension), 10),
-						},
-					},
-					AutoID: DisableAutoID,
+					DataType:     quickCreateVectorDataType,
+					TypeParams:   vectorTypeParams,
+					AutoID:       DisableAutoID,
 				},
 			},
 			EnableDynamicField: enableDynamic,
@@ -2314,20 +2427,14 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 	}
 	req.ShardsNum = shardsNum
 
-	consistencyLevel := commonpb.ConsistencyLevel_Bounded
-	if _, ok := httpReq.Params["consistencyLevel"]; ok {
-		if level, ok := commonpb.ConsistencyLevel_value[fmt.Sprintf("%s", httpReq.Params["consistencyLevel"])]; ok {
-			consistencyLevel = commonpb.ConsistencyLevel(level)
-		} else {
-			err := merr.WrapErrParameterInvalid("Strong, Session, Bounded, Eventually, Customized", httpReq.Params["consistencyLevel"],
-				"consistencyLevel can only be [Strong, Session, Bounded, Eventually, Customized], default: Bounded")
-			mlog.Warn(ctx, "high level restful api, create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
-			HTTPAbortReturn(c, http.StatusOK, gin.H{
-				HTTPReturnCode:    merr.Code(err),
-				HTTPReturnMessage: err.Error(),
-			})
-			return nil, err
-		}
+	consistencyLevel, err := consistencyLevelForCreateCollection(httpReq)
+	if err != nil {
+		mlog.Warn(ctx, "high level restful api, create collection fail", mlog.Err(err), mlog.Any("request", anyReq))
+		HTTPAbortReturn(c, http.StatusOK, gin.H{
+			HTTPReturnCode:    merr.Code(err),
+			HTTPReturnMessage: err.Error(),
+		})
+		return nil, err
 	}
 	req.ConsistencyLevel = consistencyLevel
 
@@ -2404,9 +2511,6 @@ func (h *HandlersV2) createCollection(ctx context.Context, c *gin.Context, anyRe
 		return resp, err
 	}
 	if len(httpReq.Schema.Fields) == 0 {
-		if len(httpReq.MetricType) == 0 {
-			httpReq.MetricType = DefaultMetricType
-		}
 		createIndexReq := &milvuspb.CreateIndexRequest{
 			DbName:         dbName,
 			CollectionName: httpReq.CollectionName,

--- a/internal/distributed/proxy/httpserver/handler_v2_test.go
+++ b/internal/distributed/proxy/httpserver/handler_v2_test.go
@@ -2064,6 +2064,272 @@ func TestCreateCollection(t *testing.T) {
 	})
 }
 
+func TestCreateCollectionQuickVectorFieldType(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	path := versionalV2(CollectionCategory, CreateAction)
+
+	t.Run("reject invalid vector field type", func(t *testing.T) {
+		proxy := &externalCollectionRESTProxy{}
+		testEngine := initHTTPServerV2(proxy, false)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(`{
+			"collectionName": "book",
+			"dimension": 4,
+			"vectorFieldType": "InvalidVectorType"
+		}`)))
+		w := httptest.NewRecorder()
+		testEngine.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		returnBody := &ReturnErrMsg{}
+		err := json.Unmarshal(w.Body.Bytes(), returnBody)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(1100), returnBody.Code)
+		assert.Equal(t, "vectorFieldType can only be [FloatVector, BinaryVector, Float16Vector, BFloat16Vector, SparseFloatVector], default: FloatVector: invalid parameter[expected=FloatVector, BinaryVector, Float16Vector, BFloat16Vector, SparseFloatVector][actual=InvalidVectorType]", returnBody.Message)
+		assert.Nil(t, proxy.createReq)
+		assert.Empty(t, proxy.createIndexReqs)
+	})
+
+	t.Run("reject sparse vector dimension", func(t *testing.T) {
+		proxy := &externalCollectionRESTProxy{}
+		testEngine := initHTTPServerV2(proxy, false)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(`{
+			"collectionName": "book",
+			"dimension": 4,
+			"vectorFieldType": "SparseFloatVector"
+		}`)))
+		w := httptest.NewRecorder()
+		testEngine.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		returnBody := &ReturnErrMsg{}
+		err := json.Unmarshal(w.Body.Bytes(), returnBody)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(1100), returnBody.Code)
+		assert.Contains(t, returnBody.Message, "dimension should not be specified for SparseFloatVector quick create")
+		assert.Nil(t, proxy.createReq)
+		assert.Empty(t, proxy.createIndexReqs)
+	})
+
+	invalidMetricCases := []struct {
+		name        string
+		body        string
+		expectedMsg string
+	}{
+		{
+			name: "reject binary vector invalid metric",
+			body: `{
+				"collectionName": "book",
+				"dimension": 8,
+				"metricType": "COSINE",
+				"vectorFieldType": "BinaryVector"
+			}`,
+			expectedMsg: "binary vector index does not support metric type: COSINE",
+		},
+		{
+			name: "reject sparse float vector invalid metric",
+			body: `{
+				"collectionName": "book",
+				"metricType": "COSINE",
+				"vectorFieldType": "SparseFloatVector"
+			}`,
+			expectedMsg: "only IP&BM25 is the supported metric type for sparse index",
+		},
+		{
+			name: "reject sparse float vector bm25 metric",
+			body: `{
+				"collectionName": "book",
+				"metricType": "BM25",
+				"vectorFieldType": "SparseFloatVector"
+			}`,
+			expectedMsg: "only BM25 Function output field support BM25 metric type",
+		},
+	}
+	for _, testcase := range invalidMetricCases {
+		t.Run(testcase.name, func(t *testing.T) {
+			proxy := &externalCollectionRESTProxy{}
+			testEngine := initHTTPServerV2(proxy, false)
+			req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(testcase.body)))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			err := json.Unmarshal(w.Body.Bytes(), returnBody)
+			assert.NoError(t, err)
+			assert.Equal(t, int32(1100), returnBody.Code)
+			assert.Contains(t, returnBody.Message, testcase.expectedMsg)
+			assert.Nil(t, proxy.createReq)
+			assert.Empty(t, proxy.createIndexReqs)
+		})
+	}
+
+	testcases := []struct {
+		name             string
+		body             string
+		expectedType     schemapb.DataType
+		expectedDimParam bool
+		expectedMetric   string
+	}{
+		{
+			name: "binary vector default metric",
+			body: `{
+				"collectionName": "book",
+				"dimension": 8,
+				"vectorFieldType": "BinaryVector"
+			}`,
+			expectedType:     schemapb.DataType_BinaryVector,
+			expectedDimParam: true,
+			expectedMetric:   paramtable.BinaryVectorDefaultMetricType,
+		},
+		{
+			name: "float16 vector",
+			body: `{
+				"collectionName": "book",
+				"dimension": 4,
+				"vectorFieldType": "Float16Vector"
+			}`,
+			expectedType:     schemapb.DataType_Float16Vector,
+			expectedDimParam: true,
+			expectedMetric:   DefaultMetricType,
+		},
+		{
+			name: "bfloat16 vector",
+			body: `{
+				"collectionName": "book",
+				"dimension": 4,
+				"vectorFieldType": "BFloat16Vector"
+			}`,
+			expectedType:     schemapb.DataType_BFloat16Vector,
+			expectedDimParam: true,
+			expectedMetric:   DefaultMetricType,
+		},
+		{
+			name: "sparse float vector default metric",
+			body: `{
+				"collectionName": "book",
+				"vectorFieldType": "SparseFloatVector"
+			}`,
+			expectedType:     schemapb.DataType_SparseFloatVector,
+			expectedDimParam: false,
+			expectedMetric:   paramtable.SparseFloatVectorDefaultMetricType,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			proxy := &externalCollectionRESTProxy{}
+			testEngine := initHTTPServerV2(proxy, false)
+			req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(testcase.body)))
+			w := httptest.NewRecorder()
+			testEngine.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			returnBody := &ReturnErrMsg{}
+			err := json.Unmarshal(w.Body.Bytes(), returnBody)
+			assert.NoError(t, err)
+			assert.Equal(t, int32(0), returnBody.Code)
+			require.NotNil(t, proxy.createReq)
+
+			collSchema := &schemapb.CollectionSchema{}
+			require.NoError(t, proto.Unmarshal(proxy.createReq.GetSchema(), collSchema))
+			require.Len(t, collSchema.GetFields(), 2)
+			vectorField := collSchema.GetFields()[1]
+			assert.Equal(t, testcase.expectedType, vectorField.GetDataType())
+
+			dimFound := false
+			for _, typeParam := range vectorField.GetTypeParams() {
+				if typeParam.GetKey() == Dim {
+					dimFound = true
+				}
+			}
+			assert.Equal(t, testcase.expectedDimParam, dimFound)
+
+			require.Len(t, proxy.createIndexReqs, 1)
+			indexReq := proxy.createIndexReqs[0]
+			assert.Equal(t, DefaultVectorFieldName, indexReq.GetFieldName())
+			assert.Equal(t, DefaultVectorFieldName, indexReq.GetIndexName())
+			require.Len(t, indexReq.GetExtraParams(), 1)
+			assert.Equal(t, common.MetricTypeKey, indexReq.GetExtraParams()[0].GetKey())
+			assert.Equal(t, testcase.expectedMetric, indexReq.GetExtraParams()[0].GetValue())
+		})
+	}
+}
+
+func TestCreateCollectionTopLevelConsistencyLevel(t *testing.T) {
+	paramtable.Init()
+	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
+	defer paramtable.Get().Reset(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key)
+
+	path := versionalV2(CollectionCategory, CreateAction)
+
+	t.Run("reject invalid top-level consistency level", func(t *testing.T) {
+		proxy := &externalCollectionRESTProxy{}
+		testEngine := initHTTPServerV2(proxy, false)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(`{
+			"collectionName": "book",
+			"dimension": 4,
+			"consistencyLevel": "Invalid"
+		}`)))
+		w := httptest.NewRecorder()
+		testEngine.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		returnBody := &ReturnErrMsg{}
+		err := json.Unmarshal(w.Body.Bytes(), returnBody)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(1100), returnBody.Code)
+		assert.Contains(t, returnBody.Message, "consistencyLevel can only be")
+		assert.Nil(t, proxy.createReq)
+		assert.Empty(t, proxy.createIndexReqs)
+	})
+
+	t.Run("accept valid top-level consistency level", func(t *testing.T) {
+		proxy := &externalCollectionRESTProxy{}
+		testEngine := initHTTPServerV2(proxy, false)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(`{
+			"collectionName": "book",
+			"dimension": 4,
+			"consistencyLevel": "Strong"
+		}`)))
+		w := httptest.NewRecorder()
+		testEngine.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		returnBody := &ReturnErrMsg{}
+		err := json.Unmarshal(w.Body.Bytes(), returnBody)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(0), returnBody.Code)
+		require.NotNil(t, proxy.createReq)
+		assert.Equal(t, commonpb.ConsistencyLevel_Strong, proxy.createReq.GetConsistencyLevel())
+		require.Len(t, proxy.createIndexReqs, 1)
+	})
+
+	t.Run("reject conflicting consistency levels", func(t *testing.T) {
+		proxy := &externalCollectionRESTProxy{}
+		testEngine := initHTTPServerV2(proxy, false)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(`{
+			"collectionName": "book",
+			"dimension": 4,
+			"consistencyLevel": "Strong",
+			"params": {"consistencyLevel": "Bounded"}
+		}`)))
+		w := httptest.NewRecorder()
+		testEngine.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		returnBody := &ReturnErrMsg{}
+		err := json.Unmarshal(w.Body.Bytes(), returnBody)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(1100), returnBody.Code)
+		assert.Contains(t, returnBody.Message, "top-level consistencyLevel conflicts with params.consistencyLevel")
+		assert.Nil(t, proxy.createReq)
+		assert.Empty(t, proxy.createIndexReqs)
+	})
+}
+
 func TestCreateCollectionStructArrayDuplicateName(t *testing.T) {
 	paramtable.Init()
 	paramtable.Get().Save(paramtable.Get().QuotaConfig.QuotaAndLimitsEnabled.Key, "false")
@@ -2110,6 +2376,7 @@ func initHTTPServerV2(proxy types.ProxyComponent, needAuth bool) *gin.Engine {
 type externalCollectionRESTProxy struct {
 	mockProxyComponent
 	createReq                  *milvuspb.CreateCollectionRequest
+	createIndexReqs            []*milvuspb.CreateIndexRequest
 	describeResp               *milvuspb.DescribeCollectionResponse
 	refreshReq                 *milvuspb.RefreshExternalCollectionRequest
 	listReq                    *milvuspb.ListRefreshExternalCollectionJobsRequest
@@ -2122,6 +2389,11 @@ type externalCollectionRESTProxy struct {
 
 func (m *externalCollectionRESTProxy) CreateCollection(ctx context.Context, request *milvuspb.CreateCollectionRequest) (*commonpb.Status, error) {
 	m.createReq = request
+	return commonSuccessStatus, nil
+}
+
+func (m *externalCollectionRESTProxy) CreateIndex(ctx context.Context, request *milvuspb.CreateIndexRequest) (*commonpb.Status, error) {
+	m.createIndexReqs = append(m.createIndexReqs, request)
 	return commonSuccessStatus, nil
 }
 

--- a/internal/distributed/proxy/httpserver/request_v2.go
+++ b/internal/distributed/proxy/httpserver/request_v2.go
@@ -939,6 +939,8 @@ type CollectionReq struct {
 	IDType           string                 `json:"idType"`
 	AutoID           bool                   `json:"autoID"`
 	MetricType       string                 `json:"metricType"`
+	VectorFieldType  string                 `json:"vectorFieldType"`
+	ConsistencyLevel string                 `json:"consistencyLevel"`
 	PrimaryFieldName string                 `json:"primaryFieldName"`
 	VectorFieldName  string                 `json:"vectorFieldName"`
 	Schema           CollectionSchema       `json:"schema"`

--- a/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
+++ b/tests/python_client/milvus_client/test_milvus_client_search_aggregation.py
@@ -643,21 +643,66 @@ class TestSearchAggregation(TestMilvusClientV2Base):
     def test_search_aggregation_nullable_metric_field(self):
         """
         target: verify metrics on nullable scalar fields skip NULL values.
-        method: aggregate rows with price values and NULL price values in the same brand bucket.
+        method: aggregate controlled rows with price values and NULL price values in the same brand bucket.
         expected: count(price)/sum(price)/min(price)/max(price) match the non-NULL top_hits only.
         """
         client = self._client(alias=self.shared_alias)
+        collection_name = cf.gen_collection_name_by_testcase_name()
+        controlled_brand = "nullable_metric_brand"
+        query_vector = [0.0] * self.dim
+        rows = [
+            {
+                self.primary_field: 0,
+                self.vector_field: query_vector,
+                self.brand_field: controlled_brand,
+                self.price_field: None,
+            },
+            {
+                self.primary_field: 1,
+                self.vector_field: [0.001] + [0.0] * (self.dim - 1),
+                self.brand_field: controlled_brand,
+                self.price_field: 10,
+            },
+            {
+                self.primary_field: 2,
+                self.vector_field: [0.002] + [0.0] * (self.dim - 1),
+                self.brand_field: controlled_brand,
+                self.price_field: 20,
+            },
+            {
+                self.primary_field: 3,
+                self.vector_field: [0.5] + [0.0] * (self.dim - 1),
+                self.brand_field: "other_brand",
+                self.price_field: 30,
+            },
+        ]
+
+        schema = self.create_schema(client, enable_dynamic_field=False)[0]
+        schema.add_field(field_name=self.primary_field, datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name=self.vector_field, datatype=DataType.FLOAT_VECTOR, dim=self.dim)
+        schema.add_field(field_name=self.brand_field, datatype=DataType.VARCHAR, max_length=64)
+        schema.add_field(field_name=self.price_field, datatype=DataType.INT64, nullable=True)
+        self.create_collection(client, collection_name, schema=schema)
+        self.insert(client, collection_name, data=rows)
+        self.flush(client, collection_name)
+
+        index_params = self.prepare_index_params(client)[0]
+        index_params.add_index(field_name=self.vector_field, index_type="FLAT", metric_type=self.metric_type)
+        self.create_index(client, collection_name, index_params=index_params)
+        self.load_collection(client, collection_name)
+
         res, _ = self.search(
             client,
-            self.collection_name,
-            data=[self._query_vectors()[0]],
+            collection_name,
+            data=[query_vector],
             anns_field=self.vector_field,
             search_params=self._search_params(),
             limit=ct.default_limit,
+            filter=f'{self.brand_field} == "{controlled_brand}"',
             output_fields=[self.brand_field, self.price_field],
             search_aggregation=SearchAggregation(
                 fields=[self.brand_field],
-                size=5,
+                size=1,
                 metrics={
                     "doc_count": {"count": "*"},
                     "price_count": {"count": self.price_field},
@@ -665,24 +710,22 @@ class TestSearchAggregation(TestMilvusClientV2Base):
                     "price_min": {"min": self.price_field},
                     "price_max": {"max": self.price_field},
                 },
-                top_hits=TopHits(size=10, sort=[{"_score": "asc"}]),
+                top_hits=TopHits(size=3, sort=[{"_score": "asc"}]),
             ),
         )
 
         assert len(res.agg_buckets) == 1
-        checked_nullable_metric = False
-        for bucket in res.agg_buckets[0]:
-            prices = [hit.fields.get(self.price_field) for hit in bucket.hits]
-            non_null_prices = [price for price in prices if price is not None]
-            assert bucket.metrics["doc_count"] == bucket.count
-            assert bucket.metrics["price_count"] == len(non_null_prices)
-            if non_null_prices:
-                assert bucket.metrics["price_sum"] == sum(non_null_prices)
-                assert bucket.metrics["price_min"] == min(non_null_prices)
-                assert bucket.metrics["price_max"] == max(non_null_prices)
-            if len(non_null_prices) < len(prices):
-                checked_nullable_metric = True
-        assert checked_nullable_metric
+        assert len(res.agg_buckets[0]) == 1
+        bucket = res.agg_buckets[0][0]
+        prices = [hit.fields.get(self.price_field) for hit in bucket.hits]
+        non_null_prices = [price for price in prices if price is not None]
+        assert self._key_value(bucket, self.brand_field) == controlled_brand
+        assert prices == [None, 10, 20]
+        assert bucket.metrics["doc_count"] == bucket.count == len(prices)
+        assert bucket.metrics["price_count"] == len(non_null_prices)
+        assert bucket.metrics["price_sum"] == sum(non_null_prices)
+        assert bucket.metrics["price_min"] == min(non_null_prices)
+        assert bucket.metrics["price_max"] == max(non_null_prices)
 
     @pytest.mark.tags(CaseLabel.L1)
     def test_search_aggregation_single_field_top_hits(self):

--- a/tests/restful_client_v2/testcases/test_collection_operations.py
+++ b/tests/restful_client_v2/testcases/test_collection_operations.py
@@ -82,6 +82,45 @@ class TestCreateCollection(TestBase):
         for index in rsp["data"]["indexes"]:
             assert index["metricType"] == metric_type
 
+    @pytest.mark.parametrize(
+        "vector_field_type,dimension,expected_metric",
+        [
+            ("Float16Vector", 4, "COSINE"),
+            ("BFloat16Vector", 4, "COSINE"),
+            ("BinaryVector", 8, "HAMMING"),
+            ("SparseFloatVector", None, "IP"),
+        ],
+    )
+    def test_create_collection_quick_setup_vector_field_type_default_metric(
+        self, vector_field_type, dimension, expected_metric
+    ):
+        """
+        target: test quick create collection with vectorFieldType and default metricType
+        method: create collection with BinaryVector/SparseFloatVector without metricType
+        expected: create collection succeeds with compatible default index metric
+        """
+        name = gen_collection_name()
+        client = self.collection_client
+        payload = {
+            "collectionName": name,
+            "vectorFieldType": vector_field_type,
+        }
+        if dimension is not None:
+            payload["dimension"] = dimension
+
+        logging.info(f"create collection {name} with payload: {payload}")
+        rsp = client.collection_create(payload)
+        assert rsp["code"] == 0
+
+        rsp = client.collection_describe(name)
+        assert rsp["code"] == 0
+        assert rsp["data"]["collectionName"] == name
+        vector_fields = [field for field in rsp["data"]["fields"] if field["name"] == "vector"]
+        assert len(vector_fields) == 1
+        assert vector_fields[0]["type"] == vector_field_type
+        assert len(rsp["data"]["indexes"]) == 1
+        assert rsp["data"]["indexes"][0]["metricType"] == expected_metric
+
     @pytest.mark.parametrize("enable_dynamic_field", [False, "False", "0"])
     @pytest.mark.parametrize("request_shards_num", [2, "2"])
     @pytest.mark.parametrize("request_ttl_seconds", [360, "360"])
@@ -810,6 +849,106 @@ class TestCreateCollectionNegative(TestBase):
         logging.info(f"create collection {name} with payload: {payload}")
         rsp = client.collection_create(payload)
         assert rsp["code"] == 1801
+
+    def test_create_collection_quick_setup_with_invalid_vector_field_type(self):
+        """
+        target: test quick create collection with invalid vectorFieldType
+        method: create collection with invalid vectorFieldType
+        expected: create collection failed with right error message
+        """
+        name = gen_collection_name()
+        client = self.collection_client
+        payload = {
+            "collectionName": name,
+            "dimension": 4,
+            "metricType": "L2",
+            "idType": "Int64",
+            "autoID": True,
+            "vectorFieldType": "InvalidVectorType",
+        }
+        logging.info(f"create collection {name} with payload: {payload}")
+        rsp = client.collection_create(payload)
+        assert rsp["code"] == 1100
+        assert "vectorFieldType can only be" in rsp["message"]
+
+        rsp = client.collection_list()
+        assert name not in rsp["data"]
+
+    def test_create_collection_quick_setup_with_invalid_consistency_level(self):
+        """
+        target: test quick create collection with invalid top-level consistencyLevel
+        method: create collection with invalid consistencyLevel
+        expected: create collection failed with right error message
+        """
+        name = gen_collection_name()
+        client = self.collection_client
+        payload = {
+            "collectionName": name,
+            "dimension": 4,
+            "consistencyLevel": "Invalid",
+        }
+        logging.info(f"create collection {name} with payload: {payload}")
+        url = f"{client.endpoint}/v2/vectordb/collections/create"
+        rsp = client.post(url, headers=client.update_headers(), data=payload).json()
+        assert rsp["code"] == 1100
+        assert "consistencyLevel can only be" in rsp["message"]
+
+        rsp = client.collection_list()
+        assert name not in rsp["data"]
+
+    def test_create_collection_quick_setup_sparse_vector_with_dimension(self):
+        """
+        target: test quick create collection with SparseFloatVector and dimension
+        method: create collection with SparseFloatVector and dimension
+        expected: create collection failed with right error message
+        """
+        name = gen_collection_name()
+        client = self.collection_client
+        payload = {
+            "collectionName": name,
+            "dimension": 4,
+            "vectorFieldType": "SparseFloatVector",
+        }
+        logging.info(f"create collection {name} with payload: {payload}")
+        rsp = client.collection_create(payload)
+        assert rsp["code"] == 1100
+        assert "dimension should not be specified for SparseFloatVector quick create" in rsp["message"]
+
+        rsp = client.collection_list()
+        assert name not in rsp["data"]
+
+    @pytest.mark.parametrize(
+        "vector_field_type,dimension,metric_type,expected_message",
+        [
+            ("BinaryVector", 8, "COSINE", "binary vector index does not support metric type: COSINE"),
+            ("SparseFloatVector", None, "COSINE", "only IP&BM25 is the supported metric type for sparse index"),
+            ("SparseFloatVector", None, "BM25", "only BM25 Function output field support BM25 metric type"),
+        ],
+    )
+    def test_create_collection_quick_setup_vector_field_type_invalid_metric(
+        self, vector_field_type, dimension, metric_type, expected_message
+    ):
+        """
+        target: test quick create collection with vectorFieldType and invalid metricType
+        method: create collection with BinaryVector/SparseFloatVector and incompatible metricType
+        expected: create collection failed before collection is created
+        """
+        name = gen_collection_name()
+        client = self.collection_client
+        payload = {
+            "collectionName": name,
+            "metricType": metric_type,
+            "vectorFieldType": vector_field_type,
+        }
+        if dimension is not None:
+            payload["dimension"] = dimension
+        logging.info(f"create collection {name} with payload: {payload}")
+        rsp = client.collection_create(payload)
+        assert rsp["code"] == 1100
+        assert expected_message in rsp["message"]
+
+        rsp = client.collection_list()
+        assert name not in rsp["data"]
 
     @pytest.mark.parametrize(
         "name", [" ", "test_collection_" * 100, "test collection", "test/collection", r"test\collection"]


### PR DESCRIPTION
## What

Validate REST v2 quick-create enum-like fields before creating the collection.

This PR fixes `vectorFieldType` handling for quick collection creation:
- rejects invalid `vectorFieldType` values instead of silently using `FloatVector`
- supports `FloatVector`, `BinaryVector`, `Float16Vector`, `BFloat16Vector`, and `SparseFloatVector`
- defaults quick-create index metric by vector type: dense `COSINE`, binary `HAMMING`, sparse `IP`
- validates explicit binary/sparse `metricType` before collection creation
- rejects `SparseFloatVector` quick-create with `dimension`

It also fixes top-level quick-create `consistencyLevel` handling:
- parses and validates top-level `consistencyLevel`
- preserves existing `params.consistencyLevel` behavior
- rejects conflicting top-level and `params.consistencyLevel` values

Fixes #51085
Fixes #51084

## Why

Previously, `/v2/vectordb/collections/create` ignored top-level `vectorFieldType` and always generated a `FloatVector` schema in quick-create mode. A typo such as `InvalidVectorType` could return success and mask client-side bugs.

Binary and sparse quick-create requests without `metricType` could also create the collection first and then fail index creation because the old fallback metric was `COSINE`, which is incompatible with those vector types.

For #51084, top-level `consistencyLevel` was not present in `CollectionReq`, so JSON decoding silently dropped it. Invalid values such as `"consistencyLevel": "Invalid"` were ignored and the collection could be created with the default consistency level.

## Tests

- `./bin/gofumpt -w internal/distributed/proxy/httpserver/request_v2.go internal/distributed/proxy/httpserver/handler_v2.go internal/distributed/proxy/httpserver/handler_v2_test.go`
- `./bin/gci write internal/distributed/proxy/httpserver/request_v2.go internal/distributed/proxy/httpserver/handler_v2.go internal/distributed/proxy/httpserver/handler_v2_test.go --skip-generated -s standard -s default -s "prefix(github.com/milvus-io)" --custom-order`
- `git diff --check`
- `python3 -m py_compile tests/restful_client_v2/testcases/test_collection_operations.py`
- `rg -n "string\\(paramtable\\.(BinaryVectorDefaultMetricType|SparseFloatVectorDefaultMetricType)\\)|interface\\(" internal/distributed/proxy/httpserver/handler_v2.go internal/distributed/proxy/httpserver/handler_v2_test.go`

Attempted locally but blocked by missing native dependencies:

```
go test ./internal/distributed/proxy/httpserver -run 'TestCreateCollection(QuickVectorFieldType|TopLevelConsistencyLevel)$' -count=1
# missing rocksdb.pc and milvus_core.pc
```

CI investigation before this push:

```
# build-ut-cov/code-check failed on c6 predecessor because of unconvert:
# internal/distributed/proxy/httpserver/handler_v2.go:2054:16 unnecessary conversion
# internal/distributed/proxy/httpserver/handler_v2.go:2056:16 unnecessary conversion
# internal/distributed/proxy/httpserver/handler_v2_test.go:2185:28 unnecessary conversion
# internal/distributed/proxy/httpserver/handler_v2_test.go:2217:28 unnecessary conversion
# Fixed by removing string(...) around paramtable default metric constants.

# e2e-default failed in job 40810 on:
# testcases/test_geometry_operations.py::TestGeometryCollection::test_spatial_query_and_search[False-True-sealed-ST_CROSSES]
# error: Connection refused to /v2/vectordb/collections/flush on port 19530
# the same job showed querynode/streamingnode restarts and proxy ContainerCreating during cleanup.
# REST collection tests in that job had already passed, so this looked unrelated to this PR.

# e2e-default failed again in dispatcher 13914 / job-1 32439 on:
# testcases/test_collection_operations.py::TestCreateCollectionNegative::test_create_collection_quick_setup_with_invalid_consistency_level
# root cause: the test used collection_create(), whose wrapper auto-injects params.consistencyLevel=Strong.
# That made the request hit the new conflict branch instead of the intended top-level invalid consistencyLevel branch.
# Fixed in 3e190eee56 by sending the request through raw client.post() to avoid wrapper mutation.
```

