### PR TITLE
fix: Avoid external collection DML catchup on cold load

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -180,6 +180,10 @@ type shardDelegator struct {
 	// streaming data catch-up state
 	catchingUpStreamingData *atomic.Bool
 
+	// skipStreamingForExternalTable is true for read-only external table collections.
+	// Such collections do not need DML stream replay before becoming searchable.
+	skipStreamingForExternalTable bool
+
 	// latest required mvcc timestamp for the delegator
 	// for slow down the delegator consumption and reduce the timetick dispatch frequency.
 	latestRequiredMVCCTimeTick *atomic.Uint64
@@ -471,11 +475,16 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 	)
 
 	partialResultRequiredDataRatio := paramtable.Get().QueryNodeCfg.PartialResultRequiredDataRatio.GetAsFloat()
-	// wait tsafe
+	// Resolve the MVCC timestamp used by this search.
 	waitTr := timerecord.NewTimeRecorder("wait tSafe")
 	var tSafe uint64
 	var err error
-	if partialResultRequiredDataRatio >= 1.0 {
+	if sd.skipStreamingForExternalTable {
+		// External collections read a materialized snapshot instead of the WAL.
+		// Use the full MVCC range even when partial search skips tSafe waiting, so
+		// a stale channel checkpoint does not hide snapshot rows or deltalog deletes.
+		tSafe = typeutil.MaxTimestamp
+	} else if partialResultRequiredDataRatio >= 1.0 {
 		tSafe, err = sd.waitTSafe(ctx, req.Req.GuaranteeTimestamp)
 	} else {
 		// partial search enabled, could ignore streaming data
@@ -491,8 +500,9 @@ func (sd *shardDelegator) Search(ctx context.Context, req *querypb.SearchRequest
 		return nil, err
 	}
 
-	// use tsafe as mvcc timestamp if request not provide it
-	if req.GetReq().GetMvccTimestamp() == 0 {
+	// External reads always use the full snapshot MVCC timestamp. Normal reads
+	// use tSafe only when the request does not provide an MVCC timestamp.
+	if sd.skipStreamingForExternalTable || req.GetReq().GetMvccTimestamp() == 0 {
 		req.Req.MvccTimestamp = tSafe
 	}
 
@@ -621,8 +631,9 @@ func (sd *shardDelegator) QueryStream(ctx context.Context, req *querypb.QueryReq
 		return err
 	}
 
-	// use tsafe as mvcc timestamp if request not provide it
-	if req.GetReq().GetMvccTimestamp() == 0 {
+	// External reads always use the full snapshot MVCC timestamp. Normal reads
+	// use tSafe only when the request does not provide an MVCC timestamp.
+	if sd.skipStreamingForExternalTable || req.GetReq().GetMvccTimestamp() == 0 {
 		req.Req.MvccTimestamp = tSafe
 	}
 
@@ -711,8 +722,9 @@ func (sd *shardDelegator) Query(ctx context.Context, req *querypb.QueryRequest) 
 		return nil, err
 	}
 
-	// use tsafe as mvcc timestamp if request not provide it
-	if req.GetReq().GetMvccTimestamp() == 0 {
+	// External reads always use the full snapshot MVCC timestamp. Normal reads
+	// use tSafe only when the request does not provide an MVCC timestamp.
+	if sd.skipStreamingForExternalTable || req.GetReq().GetMvccTimestamp() == 0 {
 		req.Req.MvccTimestamp = tSafe
 	}
 
@@ -1041,6 +1053,9 @@ func (sd *shardDelegator) speedupGuranteeTS(
 	mvccTS uint64,
 	isIterator bool,
 ) uint64 {
+	if sd.skipStreamingForExternalTable {
+		return guaranteeTS
+	}
 	// because the mvcc speed up will make the guarantee timestamp smaller.
 	// and the update latest required mvcc timestamp and mvcc speed up are executed concurrently.
 	// so we update the latest required mvcc timestamp first, then the mvcc speed up will not affect the latest required mvcc timestamp.
@@ -1062,6 +1077,13 @@ func (sd *shardDelegator) speedupGuranteeTS(
 
 // waitTSafe returns when tsafe listener notifies a timestamp which meet the guarantee ts.
 func (sd *shardDelegator) waitTSafe(ctx context.Context, ts uint64) (uint64, error) {
+	if sd.skipStreamingForExternalTable {
+		// External collection data is materialized by refresh/load manifests,
+		// not by this WAL. Use a full snapshot timestamp so low guarantee
+		// placeholders such as Eventually(1) do not hide loaded deltalog deletes.
+		return typeutil.MaxTimestamp, nil
+	}
+
 	ctx, sp := otel.Tracer(typeutil.QueryNodeRole).Start(ctx, "Delegator-waitTSafe")
 	defer sp.End()
 	log := sd.getLogger(ctx)
@@ -1134,6 +1156,12 @@ func (sd *shardDelegator) waitTSafe(ctx context.Context, ts uint64) (uint64, err
 
 // GetLatestRequiredMVCCTimeTick returns the latest required mvcc timestamp for the delegator.
 func (sd *shardDelegator) GetLatestRequiredMVCCTimeTick() uint64 {
+	if sd.skipStreamingForExternalTable {
+		// External reads do not require WAL tSafe advancement. Returning zero
+		// prevents the empty-timetick slowdowner from treating read timestamps
+		// as a WAL catch-up target.
+		return 0
+	}
 	if sd.catchingUpStreamingData.Load() {
 		// delegator need to catch up the streaming data when startup,
 		// If the empty timetick is filtered, the load operation will be blocked.
@@ -1474,6 +1502,13 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		return nil, merr.WrapErrCollectionNotFound(collectionID, "not in delegator manager")
 	}
 
+	skipStreamingForExternalTable := typeutil.IsExternalCollection(collection.Schema())
+	catchingUpStreamingData := !skipStreamingForExternalTable
+	if skipStreamingForExternalTable {
+		log.Info(ctx, "skip streaming data catchup for read-only external collection",
+			mlog.Time("initialTSafe", tsoutil.PhysicalTime(startTs)))
+	}
+
 	sizePerBlock := paramtable.Get().QueryNodeCfg.DeleteBufferBlockSize.GetAsInt64()
 	log.Info(ctx, "Init delete cache with list delete buffer", mlog.Int64("sizePerBlock", sizePerBlock), mlog.Time("startTime", tsoutil.PhysicalTime(startTs)))
 
@@ -1503,17 +1538,18 @@ func NewShardDelegator(ctx context.Context, collectionID UniqueID, replicaID Uni
 		distribution:      NewDistribution(channel, queryView),
 		deleteBuffer: deletebuffer.NewListDeleteBuffer[*deletebuffer.Item](startTs, sizePerBlock,
 			[]string{paramtable.GetStringNodeID(), channel}),
-		latestTsafe:                atomic.NewUint64(startTs),
-		loader:                     loader,
-		queryHook:                  queryHook,
-		chunkManager:               chunkManager,
-		partitionStats:             make(map[UniqueID]*storage.PartitionStatsSnapshot),
-		excludedSegments:           excludedSegments,
-		l0ForwardPolicy:            policy,
-		postLoadSem:                postLoadSem,
-		postLoadConfigHandler:      postLoadConfigHandler,
-		catchingUpStreamingData:    atomic.NewBool(true),
-		latestRequiredMVCCTimeTick: atomic.NewUint64(0),
+		latestTsafe:                   atomic.NewUint64(startTs),
+		loader:                        loader,
+		queryHook:                     queryHook,
+		chunkManager:                  chunkManager,
+		partitionStats:                make(map[UniqueID]*storage.PartitionStatsSnapshot),
+		excludedSegments:              excludedSegments,
+		l0ForwardPolicy:               policy,
+		postLoadSem:                   postLoadSem,
+		postLoadConfigHandler:         postLoadConfigHandler,
+		catchingUpStreamingData:       atomic.NewBool(catchingUpStreamingData),
+		skipStreamingForExternalTable: skipStreamingForExternalTable,
+		latestRequiredMVCCTimeTick:    atomic.NewUint64(0),
 	}
 
 	functionState, err := buildFunctionRuntimeState(collection.Schema())

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/milvus-io/milvus/internal/util/streamrpc"
 	"github.com/milvus-io/milvus/pkg/v3/common"
 	"github.com/milvus-io/milvus/pkg/v3/mq/msgstream"
+	"github.com/milvus-io/milvus/pkg/v3/objectstorage"
 	"github.com/milvus-io/milvus/pkg/v3/proto/internalpb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/querypb"
 	"github.com/milvus-io/milvus/pkg/v3/proto/segcorepb"
@@ -2908,6 +2909,228 @@ func TestDelegatorCatchingUpStreamingData(t *testing.T) {
 		// Should still be catching up (threshold disabled)
 		assert.True(t, sd.CatchingUpStreamingData())
 	})
+}
+
+func TestExternalCollectionDelegatorDoesNotCatchUpStreamingData(t *testing.T) {
+	paramtable.Init()
+
+	collectionID := int64(1000)
+	replicaID := int64(65535)
+	vchannelName := "rootcoord-dml_1000_v0"
+	version := int64(2000)
+	startTs := tsoutil.ComposeTSByTime(time.Now().Add(-48 * time.Hour))
+
+	manager := segments.NewManager()
+	loader := &segments.MockLoader{}
+	chunkManager := storage.NewLocalChunkManager(objectstorage.RootPath(t.TempDir()))
+
+	err := manager.Collection.PutOrRef(collectionID, &schemapb.CollectionSchema{
+		Name:           "ExternalCollection",
+		ExternalSource: "s3://bucket/path/",
+		ExternalSpec:   `{"format":"parquet"}`,
+		Fields: []*schemapb.FieldSchema{
+			{
+				Name:          "id",
+				FieldID:       100,
+				IsPrimaryKey:  true,
+				DataType:      schemapb.DataType_Int64,
+				ExternalField: "id",
+			},
+			{
+				Name:          "vector",
+				FieldID:       101,
+				DataType:      schemapb.DataType_FloatVector,
+				ExternalField: "vector",
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+		},
+	}, &segcorepb.CollectionIndexMeta{}, &querypb.LoadMetaInfo{
+		PartitionIDs:    []int64{500},
+		SchemaBarrierTs: startTs,
+	})
+	require.NoError(t, err)
+
+	delegator, err := NewShardDelegator(
+		context.Background(),
+		collectionID,
+		replicaID,
+		vchannelName,
+		version,
+		&cluster.MockManager{},
+		manager,
+		loader,
+		startTs,
+		nil,
+		chunkManager,
+		NewChannelQueryView(nil, nil, nil, initialTargetVersion),
+		nil,
+	)
+	require.NoError(t, err)
+	defer delegator.Close()
+
+	assert.False(t, delegator.CatchingUpStreamingData())
+	assert.Equal(t, startTs, delegator.GetTSafe())
+	assert.Zero(t, delegator.GetLatestRequiredMVCCTimeTick())
+}
+
+func TestExternalCollectionWaitTSafeUsesFullSnapshotTimestamp(t *testing.T) {
+	oldTSafe := tsoutil.ComposeTSByTime(time.Now().Add(-365 * 24 * time.Hour))
+	guaranteeTS := uint64(1)
+
+	sd := &shardDelegator{
+		skipStreamingForExternalTable: true,
+		latestTsafe:                   atomic.NewUint64(oldTSafe),
+	}
+
+	tSafe, err := sd.waitTSafe(context.Background(), guaranteeTS)
+	require.NoError(t, err)
+	assert.Equal(t, typeutil.MaxTimestamp, tSafe)
+	assert.Equal(t, oldTSafe, sd.GetTSafe())
+}
+
+func newExternalReadTestDelegator(t *testing.T) (*shardDelegator, string) {
+	channel := "rootcoord-dml_1000_v0"
+	distribution := NewDistribution(channel, NewChannelQueryView(nil, nil, nil, initialTargetVersion))
+	t.Cleanup(distribution.Close)
+	return &shardDelegator{
+		vchannelName:                  channel,
+		lifetime:                      lifetime.NewLifetime(lifetime.Working),
+		distribution:                  distribution,
+		skipStreamingForExternalTable: true,
+	}, channel
+}
+
+func TestExternalCollectionPartialSearchUsesFullSnapshotTimestamp(t *testing.T) {
+	paramtable.Init()
+	params := paramtable.Get()
+	require.NoError(t, params.Save(params.QueryNodeCfg.PartialResultRequiredDataRatio.Key, "0.8"))
+	t.Cleanup(func() {
+		require.NoError(t, params.Reset(params.QueryNodeCfg.PartialResultRequiredDataRatio.Key))
+	})
+
+	sd, channel := newExternalReadTestDelegator(t)
+	req := &querypb.SearchRequest{
+		Req: &internalpb.SearchRequest{
+			GuaranteeTimestamp: 1,
+			MvccTimestamp:      100,
+		},
+		DmlChannels: []string{channel},
+	}
+
+	_, err := sd.Search(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, typeutil.MaxTimestamp, req.Req.GetMvccTimestamp())
+}
+
+func TestExternalCollectionQueryUsesFullSnapshotTimestamp(t *testing.T) {
+	paramtable.Init()
+	sd, channel := newExternalReadTestDelegator(t)
+	req := &querypb.QueryRequest{
+		Req: &internalpb.RetrieveRequest{
+			GuaranteeTimestamp: 1,
+			MvccTimestamp:      100,
+		},
+		DmlChannels: []string{channel},
+	}
+
+	_, err := sd.Query(context.Background(), req)
+	require.Error(t, err)
+	assert.Equal(t, typeutil.MaxTimestamp, req.Req.GetMvccTimestamp())
+}
+
+func TestExternalCollectionQueryStreamUsesFullSnapshotTimestamp(t *testing.T) {
+	paramtable.Init()
+	sd, channel := newExternalReadTestDelegator(t)
+	req := &querypb.QueryRequest{
+		Req: &internalpb.RetrieveRequest{
+			GuaranteeTimestamp: 1,
+			MvccTimestamp:      100,
+		},
+		DmlChannels: []string{channel},
+	}
+
+	err := sd.QueryStream(context.Background(), req, nil)
+	require.Error(t, err)
+	assert.Equal(t, typeutil.MaxTimestamp, req.Req.GetMvccTimestamp())
+}
+
+func TestExternalCollectionStrongConsistencyDoesNotRequestWALMVCC(t *testing.T) {
+	guaranteeTS := tsoutil.ComposeTSByTime(time.Now())
+	sd := &shardDelegator{
+		skipStreamingForExternalTable: true,
+		latestRequiredMVCCTimeTick:    atomic.NewUint64(0),
+	}
+
+	actual := sd.speedupGuranteeTS(
+		context.Background(),
+		commonpb.ConsistencyLevel_Strong,
+		guaranteeTS,
+		0,
+		false,
+	)
+
+	assert.Equal(t, guaranteeTS, actual)
+	assert.Zero(t, sd.latestRequiredMVCCTimeTick.Load())
+}
+
+func TestNormalCollectionDelegatorCatchesUpStreamingData(t *testing.T) {
+	paramtable.Init()
+
+	collectionID := int64(1001)
+	replicaID := int64(65535)
+	vchannelName := "rootcoord-dml_1001_v0"
+	version := int64(2001)
+	startTs := tsoutil.ComposeTSByTime(time.Now().Add(-48 * time.Hour))
+
+	manager := segments.NewManager()
+	loader := &segments.MockLoader{}
+	chunkManager := storage.NewLocalChunkManager(objectstorage.RootPath(t.TempDir()))
+
+	err := manager.Collection.PutOrRef(collectionID, &schemapb.CollectionSchema{
+		Name: "NormalCollection",
+		Fields: []*schemapb.FieldSchema{
+			{
+				Name:         "id",
+				FieldID:      100,
+				IsPrimaryKey: true,
+				DataType:     schemapb.DataType_Int64,
+			},
+			{
+				Name:     "vector",
+				FieldID:  101,
+				DataType: schemapb.DataType_FloatVector,
+				TypeParams: []*commonpb.KeyValuePair{
+					{Key: common.DimKey, Value: "128"},
+				},
+			},
+		},
+	}, &segcorepb.CollectionIndexMeta{}, &querypb.LoadMetaInfo{
+		PartitionIDs:    []int64{500},
+		SchemaBarrierTs: startTs,
+	})
+	require.NoError(t, err)
+
+	delegator, err := NewShardDelegator(
+		context.Background(),
+		collectionID,
+		replicaID,
+		vchannelName,
+		version,
+		&cluster.MockManager{},
+		manager,
+		loader,
+		startTs,
+		nil,
+		chunkManager,
+		NewChannelQueryView(nil, nil, nil, initialTargetVersion),
+		nil,
+	)
+	require.NoError(t, err)
+	defer delegator.Close()
+
+	assert.True(t, delegator.CatchingUpStreamingData())
 }
 
 // MinHash Function test


### PR DESCRIPTION
issue: #45881

## What changed

- Mark read-only external collection delegators as not catching up DML
  streaming data during cold load.
- Skip WAL tSafe waits for external Search, Query, QueryStream, and
  GetStatistics reads.
- Always use `MaxTimestamp` as the MVCC timestamp for external reads,
  including partial searches and requests carrying an explicit finite
  `MvccTimestamp`, so loaded deltalog deletes remain visible.
- Prevent external reads from updating or exposing a required WAL MVCC
  timetick.
- Preserve the existing streaming catch-up and MVCC behavior for normal
  collections.

## Why

External collections are read-only and query-visible data comes from the
loaded external snapshot, not DML WAL replay. Starting from an old channel
checkpoint can otherwise keep QueryNode unavailable while it catches up WAL
history that cannot change the external snapshot.

Using the full MVCC range also prevents low guarantee placeholders or
explicit finite MVCC timestamps from hiding rows or deltalog deletes already
loaded as part of that snapshot.

This PR does not change external channel checkpoints or broadcast refresh
messages to collection vchannels.

## Validation

- `make clean && make milvus`
- `git diff --check`
- Targeted QueryNode delegator tests:

```bash
go test -tags dynamic,test -gcflags="all=-N -l" \
  github.com/milvus-io/milvus/internal/querynodev2/delegator \
  -run 'Test(ExternalCollectionDelegatorDoesNotCatchUpStreamingData|'\
'ExternalCollectionWaitTSafeUsesFullSnapshotTimestamp|'\
'ExternalCollectionPartialSearchUsesFullSnapshotTimestamp|'\
'ExternalCollectionQueryUsesFullSnapshotTimestamp|'\
'ExternalCollectionQueryStreamUsesFullSnapshotTimestamp|'\
'ExternalCollectionStrongConsistencyDoesNotRequestWALMVCC|'\
'NormalCollectionDelegatorCatchesUpStreamingData)$' -count=1
```