### PR TITLE
fix: [2.6.19] preserve segment insert log paths for text index (#50959)

### DIFF
--- a/internal/datanode/util/util.go
+++ b/internal/datanode/util/util.go
@@ -27,11 +27,7 @@ func GetSegmentInsertFiles(fieldBinlogs []*datapb.FieldBinlog, storageConfig *in
 		filePaths := make([]string, 0)
 		columnGroupID := insertLog.GetFieldID()
 		for _, binlog := range insertLog.GetBinlogs() {
-			filePath := metautil.BuildInsertLogPath(storageConfig.GetRootPath(), collectionID, partitionID, segmentID, columnGroupID, binlog.GetLogID())
-			if storageConfig.StorageType != "local" {
-				filePath = path.Join(storageConfig.GetBucketName(), filePath)
-			}
-			filePaths = append(filePaths, filePath)
+			filePaths = append(filePaths, getInsertLogPath(binlog, storageConfig, collectionID, partitionID, segmentID, columnGroupID))
 		}
 		insertLogs = append(insertLogs, &indexcgopb.FieldInsertFiles{
 			FilePaths: filePaths,
@@ -40,4 +36,15 @@ func GetSegmentInsertFiles(fieldBinlogs []*datapb.FieldBinlog, storageConfig *in
 	return &indexcgopb.SegmentInsertFiles{
 		FieldInsertFiles: insertLogs,
 	}
+}
+
+func getInsertLogPath(binlog *datapb.Binlog, storageConfig *indexpb.StorageConfig, collectionID int64, partitionID int64, segmentID int64, columnGroupID int64) string {
+	filePath := binlog.GetLogPath()
+	if filePath == "" {
+		filePath = metautil.BuildInsertLogPath(storageConfig.GetRootPath(), collectionID, partitionID, segmentID, columnGroupID, binlog.GetLogID())
+	}
+	if storageConfig.GetStorageType() != "local" {
+		filePath = path.Join(storageConfig.GetBucketName(), filePath)
+	}
+	return filePath
 }

--- a/internal/datanode/util/util_test.go
+++ b/internal/datanode/util/util_test.go
@@ -1,0 +1,84 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v2/proto/indexpb"
+)
+
+func TestGetSegmentInsertFilesPreservesLogPath(t *testing.T) {
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    "file",
+		StorageType: "local",
+	}
+	insertBinlogs := []*datapb.FieldBinlog{{
+		FieldID: 1,
+		Binlogs: []*datapb.Binlog{{
+			LogPath:    "file/insert_log/10/20/30/1/40",
+			EntriesNum: 100,
+		}},
+	}}
+
+	got := GetSegmentInsertFiles(insertBinlogs, storageConfig, 10, 20, 30)
+
+	assert.Equal(t, "file/insert_log/10/20/30/1/40", got.GetFieldInsertFiles()[0].GetFilePaths()[0])
+}
+
+func TestGetSegmentInsertFilesPreservesLogPathWithBucket(t *testing.T) {
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    "file",
+		BucketName:  "bucket",
+		StorageType: "minio",
+	}
+	insertBinlogs := []*datapb.FieldBinlog{{
+		FieldID: 1,
+		Binlogs: []*datapb.Binlog{{
+			LogPath:    "file/insert_log/10/20/30/1/40",
+			EntriesNum: 100,
+		}},
+	}}
+
+	got := GetSegmentInsertFiles(insertBinlogs, storageConfig, 10, 20, 30)
+
+	assert.Equal(t, "bucket/file/insert_log/10/20/30/1/40", got.GetFieldInsertFiles()[0].GetFilePaths()[0])
+}
+
+func TestGetSegmentInsertFilesFallsBackToLogID(t *testing.T) {
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    "file",
+		StorageType: "local",
+	}
+	insertBinlogs := []*datapb.FieldBinlog{{
+		FieldID: 1,
+		Binlogs: []*datapb.Binlog{{
+			LogID:      40,
+			EntriesNum: 100,
+		}},
+	}}
+
+	got := GetSegmentInsertFiles(insertBinlogs, storageConfig, 10, 20, 30)
+
+	assert.Equal(t, "file/insert_log/10/20/30/1/40", got.GetFieldInsertFiles()[0].GetFilePaths()[0])
+}
+
+func TestGetSegmentInsertFilesFallsBackToLogIDWithBucket(t *testing.T) {
+	storageConfig := &indexpb.StorageConfig{
+		RootPath:    "file",
+		BucketName:  "bucket",
+		StorageType: "minio",
+	}
+	insertBinlogs := []*datapb.FieldBinlog{{
+		FieldID: 1,
+		Binlogs: []*datapb.Binlog{{
+			LogID:      40,
+			EntriesNum: 100,
+		}},
+	}}
+
+	got := GetSegmentInsertFiles(insertBinlogs, storageConfig, 10, 20, 30)
+
+	assert.Equal(t, "bucket/file/insert_log/10/20/30/1/40", got.GetFieldInsertFiles()[0].GetFilePaths()[0])
+}


### PR DESCRIPTION
issue: #50865
pr: #50959

Cherry-pick of #51002 (2.6 branch, commit 24d576fe62) to hotfix-2.6.19.

## Summary
Preserve existing insert log paths when building segment insert files for StorageV2 text index builds.
Fall back to constructing paths from log IDs when the binlog path is absent.