### PR TITLE
fix: clear datacoord backoff entry on terminal state during dispatch

### DIFF
--- a/internal/datacoord/task/global_scheduler.go
+++ b/internal/datacoord/task/global_scheduler.go
@@ -246,8 +246,24 @@ func (s *globalTaskScheduler) schedule() {
 					s.recordTaskFailure(task)
 					s.pendingTasks.Push(task)
 				case taskcommon.InProgress:
+					// The task was accepted by the worker and is now in flight.
+					// Any accumulated failure count is intentionally kept: reaching
+					// InProgress only means a slot happened to be free, not that the
+					// cause of earlier failures is gone. If the task fails again the
+					// backoff must keep escalating rather than restart from scratch.
+					// The entry is cleared only on a terminal state (here and in
+					// check()).
 					task.SetTaskTime(taskcommon.TimeStart, time.Now())
 					s.runningTasks.Insert(task.GetTaskID(), task)
+				case taskcommon.None, taskcommon.Finished, taskcommon.Failed:
+					// CreateTaskOnWorker can drive a task straight to a terminal
+					// state (e.g. missing meta, unhealthy segment, estimation
+					// failure). Such a task leaves the scheduler without ever
+					// entering runningTasks, so check()'s terminal-state cleanup
+					// never runs. Drop the backoff entry here; otherwise it would
+					// leak until datacoord restarts and grow without bound under
+					// the very failure storms this backoff exists to relieve.
+					s.backoffs.Remove(task.GetTaskID())
 				}
 			}
 			return struct{}{}, nil

--- a/internal/datacoord/task/global_scheduler_test.go
+++ b/internal/datacoord/task/global_scheduler_test.go
@@ -345,3 +345,47 @@ func TestGlobalScheduler_FailedTaskBacksOffBeforeRedispatch(t *testing.T) {
 	// after the backoff elapses it is dispatched again
 	assert.Eventually(t, func() bool { return createCalls.Load() >= 2 }, 3*time.Second, 10*time.Millisecond)
 }
+
+// TestGlobalScheduler_TerminalTaskClearsBackoff guards against a backoff-entry
+// leak: when CreateTaskOnWorker drives a task straight to a terminal state it
+// never enters runningTasks, so check()'s cleanup never runs. schedule() must
+// drop the backoff entry itself, otherwise it lives until datacoord restarts.
+func TestGlobalScheduler_TerminalTaskClearsBackoff(t *testing.T) {
+	cluster := session.NewMockCluster(t)
+	cluster.EXPECT().QuerySlot().Return(map[int64]*session.WorkerSlots{
+		1: {NodeID: 1, AvailableSlots: 100},
+	}).Maybe()
+
+	scheduler := NewGlobalTaskScheduler(context.TODO(), cluster).(*globalTaskScheduler)
+
+	task := NewMockTask(t)
+	task.EXPECT().GetTaskID().Return(9).Maybe()
+	task.EXPECT().GetTaskType().Return(taskcommon.Index).Maybe()
+	task.EXPECT().SetTaskTime(mock.Anything, mock.Anything).Return().Maybe()
+	task.EXPECT().GetTaskSlot().Return(1).Maybe()
+
+	// CreateTaskOnWorker drives the task straight to a terminal state (e.g. its
+	// segment was compacted away), so it never reaches InProgress/runningTasks.
+	var created atomic.Bool
+	task.EXPECT().GetTaskState().RunAndReturn(func() taskcommon.State {
+		if created.Load() {
+			return taskcommon.None
+		}
+		return taskcommon.Init
+	}).Maybe()
+	task.EXPECT().CreateTaskOnWorker(mock.Anything, mock.Anything).Run(func(nodeID int64, cluster session.Cluster) {
+		created.Store(true)
+	}).Maybe()
+
+	// Seed a stale backoff entry from earlier dispatch failures whose delay has
+	// already elapsed, so the task is eligible for dispatch this round.
+	scheduler.backoffs.Insert(9, &taskBackoff{failures: 3, notBefore: time.Now().Add(-time.Second)})
+	scheduler.pendingTasks.Push(task)
+
+	scheduler.schedule()
+
+	_, ok := scheduler.backoffs.Get(9)
+	assert.False(t, ok, "backoff entry must be removed once the task reaches a terminal state")
+	assert.Equal(t, 0, scheduler.runningTasks.Len())
+	assert.Equal(t, 0, len(scheduler.pendingTasks.TaskIDs()))
+}


### PR DESCRIPTION
## What & why

Follow-up to #51020, which added a per-task exponential backoff to the datacoord global scheduler. That PR clears the `backoffs` entry only when a task reaches a terminal state, and the cleanup lives in two places:

- `check()` — for tasks that were running and resolve to `None`/`Finished`/`Failed`;
- `schedule()` — for tasks whose `CreateTaskOnWorker` returns `Init`/`Retry` or `InProgress`.

`schedule()` had **no branch** for the case where `CreateTaskOnWorker` drives a task **straight to a terminal state** (`None`/`Finished`/`Failed`) — e.g. missing meta, unhealthy/compacted segment, vector-array estimation failure, or the no-train / small-segment fake-finished paths in `task_stats.go` / `task_index.go` / `task_analyze.go`. Such a task never enters `runningTasks`, so `check()`'s cleanup never runs and its `backoffs` entry leaks until datacoord restarts — growing without bound under exactly the failure storms this backoff exists to relieve.

## Change

- Add a `None`/`Finished`/`Failed` branch to the `schedule()` switch that calls `s.backoffs.Remove(...)`, mirroring `check()`.
- Document on the `InProgress` branch that a successful `Init → InProgress` dispatch **intentionally** keeps the accumulated failure count: reaching `InProgress` means a slot was free, not that the cause of earlier failures is gone, so the backoff must keep escalating if the task fails again. Clearing it there would pin a `Create(ok) → run-fail → Retry → …` loop at the base interval forever. Only genuine terminal states reset the count.
- Add `TestGlobalScheduler_TerminalTaskClearsBackoff` covering the leak.

## Verification

`go test -tags dynamic,test -gcflags="all=-N -l" -count=1 ./internal/datacoord/task/ -run TestGlobalScheduler` — all subtests pass, including the new one.

issue: #51091

🤖 Generated with [Claude Code](https://claude.com/claude-code)
