### PR TITLE
fix: [2.6.19] cherry-pick critical fixes from 2.6

### DIFF
--- a/internal/core/src/common/Json.h
+++ b/internal/core/src/common/Json.h
@@ -257,6 +257,14 @@ class Json {
                                : doc().at_pointer(pointer).get_number_type();
     }
 
+    value_result<simdjson::ondemand::number>
+    at_numeric(std::string_view pointer) const {
+        if (pointer.empty()) {
+            return doc().get_number();
+        }
+        return doc().at_pointer(pointer).get_number();
+    }
+
     template <typename T>
     value_result<T>
     at(std::string_view pointer) const {

--- a/internal/core/src/exec/expression/BinaryRangeExpr.cpp
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.cpp
@@ -622,18 +622,20 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
 
         cached_index_chunk_res_ = std::make_shared<TargetBitmap>(active_count_);
         cached_index_chunk_valid_res_ =
-            std::make_shared<TargetBitmap>(active_count_, true);
+            std::make_shared<TargetBitmap>(active_count_);
         TargetBitmapView res_view(*cached_index_chunk_res_);
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
 
         // process shredding data
         auto try_execute = [&](milvus::index::JSONType json_type,
-                               TargetBitmapView& res_view,
-                               TargetBitmapView& valid_res_view,
                                auto GetType) {
             auto target_field = index->GetShreddingField(pointer, json_type);
             if (!target_field.empty()) {
                 using ColType = decltype(GetType);
+                TargetBitmap target_res(active_count_, false);
+                TargetBitmapView target_res_view(target_res);
+                TargetBitmap target_valid(active_count_, true);
+                TargetBitmapView target_valid_view(target_valid);
                 auto shredding_executor =
                     [val1, val2, lower_inclusive, upper_inclusive](
                         const ColType* src,
@@ -661,8 +663,11 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
                                                          target_field,
                                                          shredding_executor,
                                                          nullptr,
-                                                         res_view,
-                                                         valid_res_view);
+                                                         target_res_view,
+                                                         target_valid_view);
+                res_view.inplace_or_with_count(target_res_view, active_count_);
+                valid_res_view.inplace_or_with_count(target_valid_view,
+                                                     active_count_);
                 LOG_DEBUG("using shredding data's field: {} count {}",
                           target_field,
                           res_view.count());
@@ -676,94 +681,65 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
 
             if constexpr (std::is_same_v<GetType, int64_t>) {
                 // int64 compare
-                try_execute(milvus::index::JSONType::INT64,
-                            res_view,
-                            valid_res_view,
-                            int64_t{});
+                try_execute(milvus::index::JSONType::INT64, int64_t{});
                 // and double compare
-                TargetBitmap res_double(active_count_, false);
-                TargetBitmapView res_double_view(res_double);
-                TargetBitmap res_double_valid(active_count_, true);
-                TargetBitmapView valid_res_double_view(res_double_valid);
-                try_execute(milvus::index::JSONType::DOUBLE,
-                            res_double_view,
-                            valid_res_double_view,
-                            double{});
-                res_view.inplace_or_with_count(res_double_view, active_count_);
-                valid_res_view.inplace_or_with_count(valid_res_double_view,
-                                                     active_count_);
+                try_execute(milvus::index::JSONType::DOUBLE, double{});
 
             } else if constexpr (std::is_same_v<GetType, double>) {
-                try_execute(milvus::index::JSONType::DOUBLE,
-                            res_view,
-                            valid_res_view,
-                            double{});
+                try_execute(milvus::index::JSONType::DOUBLE, double{});
                 // and int64 compare
-                TargetBitmap res_int64(active_count_, false);
-                TargetBitmapView res_int64_view(res_int64);
-                TargetBitmap res_int64_valid(active_count_, true);
-                TargetBitmapView valid_res_int64_view(res_int64_valid);
-                try_execute(milvus::index::JSONType::INT64,
-                            res_int64_view,
-                            valid_res_int64_view,
-                            int64_t{});
-                res_view.inplace_or_with_count(res_int64_view, active_count_);
-                valid_res_view.inplace_or_with_count(valid_res_int64_view,
-                                                     active_count_);
+                try_execute(milvus::index::JSONType::INT64, int64_t{});
             } else if constexpr (std::is_same_v<GetType, std::string_view> ||
                                  std::is_same_v<GetType, std::string>) {
                 try_execute(milvus::index::JSONType::STRING,
-                            res_view,
-                            valid_res_view,
                             std::string_view{});
             }
         }
 
         // process shared data
-        auto shared_executor =
-            [val1, val2, lower_inclusive, upper_inclusive, &res_view](
-                milvus::BsonView bson, uint32_t row_id, uint32_t value_offset) {
-                if constexpr (std::is_same_v<GetType, int64_t> ||
-                              std::is_same_v<GetType, double>) {
-                    auto val = bson.ParseAsValueAtOffset<double>(value_offset);
-                    if (!val.has_value()) {
-                        res_view[row_id] = false;
-                        return;
-                    }
-                    if (lower_inclusive && upper_inclusive) {
-                        res_view[row_id] =
-                            val.value() >= val1 && val.value() <= val2;
-                    } else if (lower_inclusive && !upper_inclusive) {
-                        res_view[row_id] =
-                            val.value() >= val1 && val.value() < val2;
-                    } else if (!lower_inclusive && upper_inclusive) {
-                        res_view[row_id] =
-                            val.value() > val1 && val.value() <= val2;
-                    } else {
-                        res_view[row_id] =
-                            val.value() > val1 && val.value() < val2;
-                    }
-                } else {
-                    auto val = bson.ParseAsValueAtOffset<GetType>(value_offset);
-                    if (!val.has_value()) {
-                        res_view[row_id] = false;
-                        return;
-                    }
-                    if (lower_inclusive && upper_inclusive) {
-                        res_view[row_id] =
-                            val.value() >= val1 && val.value() <= val2;
-                    } else if (lower_inclusive && !upper_inclusive) {
-                        res_view[row_id] =
-                            val.value() >= val1 && val.value() < val2;
-                    } else if (!lower_inclusive && upper_inclusive) {
-                        res_view[row_id] =
-                            val.value() > val1 && val.value() <= val2;
-                    } else {
-                        res_view[row_id] =
-                            val.value() > val1 && val.value() < val2;
-                    }
-                }
+        auto shared_executor = [val1,
+                                val2,
+                                lower_inclusive,
+                                upper_inclusive,
+                                &res_view,
+                                &valid_res_view](milvus::BsonView bson,
+                                                 uint32_t row_id,
+                                                 uint32_t value_offset) {
+            auto set_known = [&](bool value) {
+                res_view[row_id] = value;
+                valid_res_view[row_id] = true;
             };
+            if constexpr (std::is_same_v<GetType, int64_t> ||
+                          std::is_same_v<GetType, double>) {
+                auto val = bson.ParseAsValueAtOffset<double>(value_offset);
+                if (!val.has_value()) {
+                    return;
+                }
+                if (lower_inclusive && upper_inclusive) {
+                    set_known(val.value() >= val1 && val.value() <= val2);
+                } else if (lower_inclusive && !upper_inclusive) {
+                    set_known(val.value() >= val1 && val.value() < val2);
+                } else if (!lower_inclusive && upper_inclusive) {
+                    set_known(val.value() > val1 && val.value() <= val2);
+                } else {
+                    set_known(val.value() > val1 && val.value() < val2);
+                }
+            } else {
+                auto val = bson.ParseAsValueAtOffset<GetType>(value_offset);
+                if (!val.has_value()) {
+                    return;
+                }
+                if (lower_inclusive && upper_inclusive) {
+                    set_known(val.value() >= val1 && val.value() <= val2);
+                } else if (lower_inclusive && !upper_inclusive) {
+                    set_known(val.value() >= val1 && val.value() < val2);
+                } else if (!lower_inclusive && upper_inclusive) {
+                    set_known(val.value() > val1 && val.value() <= val2);
+                } else {
+                    set_known(val.value() > val1 && val.value() < val2);
+                }
+            }
+        };
         {
             milvus::ScopedTimer timer(
                 "binary_range_json_stats_shared_data",
@@ -774,12 +750,12 @@ PhyBinaryRangeFilterExpr::ExecRangeVisitorImplForJsonStats() {
         cached_index_chunk_id_ = 0;
     }
 
-    TargetBitmap result;
-    result.append(
-        *cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
+    auto res = MoveOrSliceBitmap(*cached_index_chunk_res_,
+                                 *cached_index_chunk_valid_res_,
+                                 current_data_global_pos_,
+                                 real_batch_size);
     MoveCursor();
-    return std::make_shared<ColumnVector>(std::move(result),
-                                          TargetBitmap(real_batch_size, true));
+    return res;
 }  // namespace exec
 
 template <typename ValueType>

--- a/internal/core/src/exec/expression/BinaryRangeExpr.h
+++ b/internal/core/src/exec/expression/BinaryRangeExpr.h
@@ -85,30 +85,45 @@ struct BinaryRangeElementFunc {
     }
 };
 
-#define BinaryRangeJSONCompare(cmp)                                \
-    do {                                                           \
-        if (valid_data != nullptr && !valid_data[offset]) {        \
-            res[i] = valid_res[i] = false;                         \
-            break;                                                 \
-        }                                                          \
-        if (has_bitmap_input && !bitmap_input[i + start_cursor]) { \
-            break;                                                 \
-        }                                                          \
-        auto x = src[offset].template at<GetType>(pointer);        \
-        if (x.error()) {                                           \
-            if constexpr (std::is_same_v<GetType, int64_t>) {      \
-                auto x = src[offset].template at<double>(pointer); \
-                if (!x.error()) {                                  \
-                    auto value = x.value();                        \
-                    res[i] = (cmp);                                \
-                    break;                                         \
-                }                                                  \
-            }                                                      \
-            res[i] = false;                                        \
-            break;                                                 \
-        }                                                          \
-        auto value = x.value();                                    \
-        res[i] = (cmp);                                            \
+// For int64_t GetType, uses at_numeric() (get_number()) to extract any JSON
+// number in a single parse.  Branches on actual type to preserve int64
+// precision; uint64 and double values fall back to double comparison,
+// consistent with the Tantivy index and JSON-stats paths.
+// 'cmp' must reference 'value' (int64_t or double depending on the JSON value).
+#define BinaryRangeJSONCompare(cmp)                                    \
+    do {                                                               \
+        if (valid_data != nullptr && !valid_data[offset]) {            \
+            res[i] = valid_res[i] = false;                             \
+            break;                                                     \
+        }                                                              \
+        if (has_bitmap_input && !bitmap_input[i + start_cursor]) {     \
+            break;                                                     \
+        }                                                              \
+        if constexpr (std::is_same_v<GetType, int64_t>) {              \
+            auto x = src[offset].at_numeric(pointer);                  \
+            if (x.error()) {                                           \
+                res[i] = valid_res[i] = false;                         \
+                break;                                                 \
+            }                                                          \
+            auto n = x.value();                                        \
+            if (n.is_int64()) {                                        \
+                auto value = n.get_int64();                            \
+                res[i] = (cmp);                                        \
+            } else {                                                   \
+                auto value = n.is_uint64()                             \
+                                 ? static_cast<double>(n.get_uint64()) \
+                                 : n.get_double();                     \
+                res[i] = (cmp);                                        \
+            }                                                          \
+        } else {                                                       \
+            auto x = src[offset].template at<GetType>(pointer);        \
+            if (x.error()) {                                           \
+                res[i] = valid_res[i] = false;                         \
+                break;                                                 \
+            }                                                          \
+            auto value = x.value();                                    \
+            res[i] = (cmp);                                            \
+        }                                                              \
     } while (false)
 
 template <typename ValueType,

--- a/internal/core/src/exec/expression/ConjunctExpr.cpp
+++ b/internal/core/src/exec/expression/ConjunctExpr.cpp
@@ -47,14 +47,23 @@ PhyConjunctFilterExpr::UpdateResult(ColumnVectorPtr& input_result,
         common::ThreeValuedLogicOp::Or(result, input_result);
     }
 
-    // Return the count of active rows for short-circuit optimization
-    // For AND: return count of true (if 0, all false, can skip)
-    // For OR: return count of false (if 0, all true, can skip)
-    TargetBitmapView res_data(result->GetRawData(), result->size());
+    // Return rows that still need the following expressions.
+    // For AND: TRUE or NULL rows still need evaluation; only definite FALSE can
+    // stop. For OR: FALSE or NULL rows still need evaluation; only definite TRUE
+    // can stop.
+    const size_t size = result->size();
+    TargetBitmapView res_data(result->GetRawData(), size);
+    TargetBitmapView res_valid(result->GetValidRawData(), size);
     if (is_and_) {
-        return static_cast<int64_t>(res_data.count());
+        TargetBitmap active_rows(res_valid);
+        active_rows.inplace_sub(res_data, size);  // valid & ~data
+        active_rows.flip();                       // data | ~valid
+        return static_cast<int64_t>(active_rows.count());
     } else {
-        return static_cast<int64_t>(result->size() - res_data.count());
+        TargetBitmap active_rows(res_data);
+        active_rows.inplace_and(res_valid, size);  // data & valid
+        active_rows.flip();                        // ~data | ~valid
+        return static_cast<int64_t>(active_rows.count());
     }
 }
 

--- a/internal/core/src/exec/expression/ConjunctExprTest.cpp
+++ b/internal/core/src/exec/expression/ConjunctExprTest.cpp
@@ -1,0 +1,112 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/Types.h"
+#include "common/Vector.h"
+#include "exec/QueryContext.h"
+#include "exec/expression/ConjunctExpr.h"
+#include "exec/expression/EvalCtx.h"
+
+namespace milvus::exec {
+namespace {
+
+class FixedBitmapExpr : public Expr {
+ public:
+    FixedBitmapExpr(TargetBitmap data, TargetBitmap valid)
+        : Expr(DataType::BOOL, {}, "FixedBitmapExpr", nullptr),
+          data_(std::move(data)),
+          valid_(std::move(valid)) {
+    }
+
+    void
+    Eval(EvalCtx&, VectorPtr& result) override {
+        ++eval_count_;
+        result = std::make_shared<ColumnVector>(data_.clone(), valid_.clone());
+    }
+
+    void
+    MoveCursor() override {
+        ++move_count_;
+    }
+
+    std::string
+    ToString() const override {
+        return "FixedBitmapExpr";
+    }
+
+    std::optional<milvus::expr::ColumnInfo>
+    GetColumnInfo() const override {
+        return std::nullopt;
+    }
+
+    int eval_count_ = 0;
+    int move_count_ = 0;
+
+ private:
+    TargetBitmap data_;
+    TargetBitmap valid_;
+};
+
+std::shared_ptr<FixedBitmapExpr>
+FixedBool(const bool data, const bool valid) {
+    TargetBitmap data_bitmap(1, data);
+    TargetBitmap valid_bitmap(1, valid);
+    return std::make_shared<FixedBitmapExpr>(std::move(data_bitmap),
+                                             std::move(valid_bitmap));
+}
+
+}  // namespace
+
+TEST(ConjunctExprTest, AndKeepsUnknownRowsActiveForFollowingFalse) {
+    auto unknown = FixedBool(false, false);
+    auto true_expr = FixedBool(true, true);
+    auto false_expr = FixedBool(false, true);
+
+    std::vector<ExprPtr> inputs{unknown, true_expr, false_expr};
+    PhyConjunctFilterExpr conjunct(std::move(inputs), true, nullptr);
+
+    QueryContext query_context("conjunct_test", nullptr, 1, 0);
+    ExecContext exec_context(&query_context);
+    EvalCtx eval_context(&exec_context);
+
+    VectorPtr result;
+    conjunct.Eval(eval_context, result);
+
+    auto output = std::dynamic_pointer_cast<ColumnVector>(result);
+    ASSERT_NE(output, nullptr);
+    ASSERT_TRUE(output->IsBitmap());
+
+    TargetBitmapView data(output->GetRawData(), output->size());
+    TargetBitmapView valid(output->GetValidRawData(), output->size());
+    ASSERT_EQ(output->size(), 1);
+    EXPECT_FALSE(data[0]);
+    EXPECT_TRUE(valid[0]);
+
+    EXPECT_EQ(unknown->eval_count_, 1);
+    EXPECT_EQ(true_expr->eval_count_, 1);
+    EXPECT_EQ(false_expr->eval_count_, 1);
+    EXPECT_EQ(false_expr->move_count_, 0);
+}
+
+}  // namespace milvus::exec

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -557,8 +557,7 @@ class SegmentExpr : public Expr {
                                 valid_res + processed_size,
                                 values...);
                         } else {
-                            if (valid_data.size() > processed_size &&
-                                !valid_data[processed_size]) {
+                            if (!valid_data.empty() && !valid_data[0]) {
                                 res[processed_size] =
                                     valid_res[processed_size] = false;
                             }

--- a/internal/core/src/exec/expression/Expr.h
+++ b/internal/core/src/exec/expression/Expr.h
@@ -1528,6 +1528,19 @@ class SegmentExpr : public Expr {
         return false;
     };
 
+    VectorPtr
+    MoveOrSliceBitmap(TargetBitmap& cached_res,
+                      TargetBitmap& cached_valid_res,
+                      int64_t pos,
+                      int64_t size) {
+        TargetBitmap result;
+        TargetBitmap valid_result;
+        result.append(cached_res, pos, size);
+        valid_result.append(cached_valid_res, pos, size);
+        return std::make_shared<ColumnVector>(std::move(result),
+                                              std::move(valid_result));
+    }
+
  protected:
     const segcore::SegmentInternalInterface* segment_;
     const FieldId field_id_;

--- a/internal/core/src/exec/expression/ExprJsonAdvancedTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonAdvancedTest.cpp
@@ -239,7 +239,7 @@ TEST_P(ExprTest, TestUnaryRangeWithJSONNullable) {
              [](std::variant<int64_t, bool, double, std::string_view> v,
                 bool valid) {
                  if (!valid) {
-                     return true;
+                     return false;
                  }
                  return !std::get<bool>(v);
              },

--- a/internal/core/src/exec/expression/ExprJsonRangeTest.cpp
+++ b/internal/core/src/exec/expression/ExprJsonRangeTest.cpp
@@ -1002,7 +1002,7 @@ TEST_P(ExprTest, TestUnaryRangeJsonNullable) {
                 case OpType::NotEqual: {
                     f = [&](int64_t value, bool valid) {
                         if (!valid) {
-                            return true;
+                            return false;
                         }
                         return value != testcase.val;
                     };
@@ -1132,7 +1132,7 @@ TEST_P(ExprTest, TestUnaryRangeJsonNullable) {
     for (const auto& testcase : array_cases) {
         auto check = [&](OpType op, bool valid) {
             if (!valid) {
-                return op == OpType::NotEqual ? true : false;
+                return false;
             }
             if (testcase.nested_path[0] == "array" && op == OpType::Equal) {
                 return true;

--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -9,6 +9,8 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 // or implied. See the License for the specific language governing permissions and limitations under the License
 
+#include <arrow/builder.h>
+#include <fmt/core.h>
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <memory>
@@ -17,6 +19,7 @@
 
 #include "common/Schema.h"
 #include "common/Types.h"
+#include "exec/expression/UnaryExpr.h"
 #include "expr/ITypeExpr.h"
 #include "index/json_stats/JsonKeyStats.h"
 #include "cachinglayer/Manager.h"
@@ -37,6 +40,31 @@ using namespace milvus::index;
 
 namespace {
 
+bool
+IsValidAt(const std::vector<uint8_t>& valid_data, size_t i) {
+    return ((valid_data[i >> 3] >> (i & 0x07)) & 1) != 0;
+}
+
+std::shared_ptr<arrow::BinaryArray>
+MakeNullableJsonArray(const std::vector<std::string>& json_strings,
+                      const std::vector<uint8_t>& valid_data) {
+    arrow::BinaryBuilder builder;
+    for (size_t i = 0; i < json_strings.size(); ++i) {
+        auto status = IsValidAt(valid_data, i) ? builder.Append(json_strings[i])
+                                               : builder.AppendNull();
+        AssertInfo(status.ok(),
+                   "failed to build nullable JSON Arrow array: {}",
+                   status.ToString());
+    }
+
+    std::shared_ptr<arrow::Array> array;
+    auto status = builder.Finish(&array);
+    AssertInfo(status.ok(),
+               "failed to finish nullable JSON Arrow array: {}",
+               status.ToString());
+    return std::static_pointer_cast<arrow::BinaryArray>(array);
+}
+
 milvus::index::CacheJsonKeyStatsPtr
 BuildAndLoadJsonKeyStats(const std::vector<std::string>& json_strings,
                          const milvus::FieldId json_fid,
@@ -46,16 +74,23 @@ BuildAndLoadJsonKeyStats(const std::vector<std::string>& json_strings,
                          int64_t segment_id,
                          int64_t field_id,
                          int64_t build_id,
-                         int64_t version_id) {
+                         int64_t version_id,
+                         const std::vector<uint8_t>* valid_data = nullptr) {
     std::vector<milvus::Json> data;
     data.reserve(json_strings.size());
     for (const auto& s : json_strings) {
         data.emplace_back(simdjson::padded_string(s));
     }
 
+    auto nullable = valid_data != nullptr;
     auto field_data =
-        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, false);
-    field_data->add_json_data(data);
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, nullable);
+    if (valid_data != nullptr) {
+        field_data->FillFieldData(
+            MakeNullableJsonArray(json_strings, *valid_data));
+    } else {
+        field_data->add_json_data(data);
+    }
 
     auto payload_reader =
         std::make_shared<milvus::storage::PayloadReader>(field_data);
@@ -64,6 +99,7 @@ BuildAndLoadJsonKeyStats(const std::vector<std::string>& json_strings,
     proto::schema::FieldSchema field_schema;
     field_schema.set_data_type(proto::schema::DataType::JSON);
     field_schema.set_fieldid(json_fid.get());
+    field_schema.set_nullable(nullable);
 
     storage::FieldDataMeta field_meta{
         collection_id, partition_id, segment_id, field_id, field_schema};
@@ -225,4 +261,73 @@ TEST(JsonContainsByStatsTest, BasicContainsAnyOnArray) {
         bool should_match = ((i % 7) == 0) || ((i % 7) == 2) || ((i % 7) == 5);
         EXPECT_EQ(bool(result[i]), should_match);
     }
+}
+
+TEST(JsonStatsUnaryRangeTest, NotEqualKeepsJsonPathErrorsButMasksFieldNull) {
+    auto schema = std::make_shared<Schema>();
+    auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
+
+    auto segment = segcore::CreateSealedSegment(schema);
+
+    std::vector<std::string> json_raw_data = {
+        R"({"a": "1"})",    // equal, filtered out
+        R"({"a": "123"})",  // string mismatch, kept
+        R"({"a": 1})",      // type mismatch for string compare, kept
+        R"({"b": 1})",      // path missing, kept
+        R"({"a": null})",   // JSON path error, kept
+        R"({})",            // path missing, kept
+        R"({"a": "321"})",  // string mismatch, kept
+        R"({"a": "123"})",  // field-level null, filtered out by valid data
+    };
+    std::vector<uint8_t> valid_data{0b01111111};
+
+    const int64_t collection_id = 1101;
+    const int64_t partition_id = 2101;
+    const int64_t segment_id = 3101;
+    const int64_t field_id = json_fid.get();
+    const int64_t build_id = 5101;
+    const int64_t version_id = 1;
+    const std::string root_path = TestLocalPath;
+
+    auto stats = BuildAndLoadJsonKeyStats(json_raw_data,
+                                          json_fid,
+                                          root_path,
+                                          collection_id,
+                                          partition_id,
+                                          segment_id,
+                                          field_id,
+                                          build_id,
+                                          version_id,
+                                          &valid_data);
+    segment->LoadJsonStats(json_fid, stats);
+
+    auto json_field =
+        std::make_shared<FieldData<milvus::Json>>(DataType::JSON, true);
+    json_field->FillFieldData(MakeNullableJsonArray(json_raw_data, valid_data));
+
+    auto cm = milvus::storage::RemoteChunkManagerSingleton::GetInstance()
+                  .GetRemoteChunkManager();
+    auto load_info = PrepareSingleFieldInsertBinlog(
+        0, 0, 0, json_fid.get(), {json_field}, cm);
+    segment->LoadFieldData(load_info);
+
+    proto::plan::GenericValue val;
+    val.set_string_val("1");
+    auto unary_expr = std::make_shared<expr::UnaryRangeFilterExpr>(
+        expr::ColumnInfo(json_fid, DataType::JSON, {"a"}),
+        proto::plan::OpType::NotEqual,
+        val,
+        std::vector<proto::plan::GenericValue>());
+    auto plan =
+        std::make_shared<plan::FilterBitsNode>(DEFAULT_PLANNODE_ID, unary_expr);
+    auto result = query::ExecuteQueryExpr(
+        plan, segment.get(), json_raw_data.size(), MAX_TIMESTAMP);
+
+    ASSERT_EQ(result.size(), json_raw_data.size());
+    EXPECT_FALSE(result[0]);
+    for (int i = 1; i <= 6; ++i) {
+        EXPECT_TRUE(result[i]) << "row " << i;
+    }
+    EXPECT_FALSE(result[7]);
+    EXPECT_EQ(result.count(), 6);
 }

--- a/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
+++ b/internal/core/src/exec/expression/JsonContainsByStatsTest.cpp
@@ -263,7 +263,7 @@ TEST(JsonContainsByStatsTest, BasicContainsAnyOnArray) {
     }
 }
 
-TEST(JsonStatsUnaryRangeTest, NotEqualKeepsJsonPathErrorsButMasksFieldNull) {
+TEST(JsonStatsUnaryRangeTest, NotEqualKeepsJsonPathUnknownsAndMasksFieldNull) {
     auto schema = std::make_shared<Schema>();
     auto json_fid = schema->AddDebugField("json", DataType::JSON, true);
 
@@ -272,10 +272,10 @@ TEST(JsonStatsUnaryRangeTest, NotEqualKeepsJsonPathErrorsButMasksFieldNull) {
     std::vector<std::string> json_raw_data = {
         R"({"a": "1"})",    // equal, filtered out
         R"({"a": "123"})",  // string mismatch, kept
-        R"({"a": 1})",      // type mismatch for string compare, kept
-        R"({"b": 1})",      // path missing, kept
-        R"({"a": null})",   // JSON path error, kept
-        R"({})",            // path missing, kept
+        R"({"a": 1})",      // type mismatch for string compare, UNKNOWN
+        R"({"b": 1})",      // path missing, UNKNOWN
+        R"({"a": null})",   // JSON path null, UNKNOWN
+        R"({})",            // path missing, UNKNOWN
         R"({"a": "321"})",  // string mismatch, kept
         R"({"a": "123"})",  // field-level null, filtered out by valid data
     };
@@ -325,9 +325,11 @@ TEST(JsonStatsUnaryRangeTest, NotEqualKeepsJsonPathErrorsButMasksFieldNull) {
 
     ASSERT_EQ(result.size(), json_raw_data.size());
     EXPECT_FALSE(result[0]);
-    for (int i = 1; i <= 6; ++i) {
-        EXPECT_TRUE(result[i]) << "row " << i;
+    EXPECT_TRUE(result[1]);
+    for (int i = 2; i <= 5; ++i) {
+        EXPECT_FALSE(result[i]) << "row " << i;
     }
+    EXPECT_TRUE(result[6]);
     EXPECT_FALSE(result[7]);
-    EXPECT_EQ(result.count(), 6);
+    EXPECT_EQ(result.count(), 2);
 }

--- a/internal/core/src/exec/expression/JsonContainsExpr.cpp
+++ b/internal/core/src/exec/expression/JsonContainsExpr.cpp
@@ -15,13 +15,92 @@
 // limitations under the License.
 
 #include "JsonContainsExpr.h"
+#include <algorithm>
 #include <cmath>
+#include <cstdint>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 #include "common/ScopedTimer.h"
 #include "common/Types.h"
 
 namespace milvus {
 namespace exec {
+
+template <typename T>
+class ContainsAllMatcher {
+ public:
+    explicit ContainsAllMatcher(const std::set<T>& targets) {
+        target_count_ = targets.size();
+        use_small_ = target_count_ <= 64;
+        uint32_t idx = 0;
+        for (const auto& target : targets) {
+            value_to_bit_[target] = idx++;
+        }
+        if (use_small_) {
+            full_mask_ = target_count_ == 64
+                             ? ~uint64_t(0)
+                             : (uint64_t(1) << target_count_) - 1;
+        } else {
+            num_words_ = (target_count_ + 63) / 64;
+        }
+    }
+
+    bool
+    set_if_found(const T& value, uint64_t& found) const {
+        auto it = value_to_bit_.find(value);
+        if (it == value_to_bit_.end()) {
+            return false;
+        }
+        found |= uint64_t(1) << it->second;
+        return found == full_mask_;
+    }
+
+    bool
+    set_if_found(const T& value,
+                 std::vector<uint64_t>& found,
+                 size_t& remaining) const {
+        auto it = value_to_bit_.find(value);
+        if (it == value_to_bit_.end()) {
+            return false;
+        }
+        auto idx = it->second;
+        auto bit = uint64_t(1) << (idx % 64);
+        auto& word = found[idx / 64];
+        if ((word & bit) != 0) {
+            return false;
+        }
+        word |= bit;
+        return --remaining == 0;
+    }
+
+    bool
+    use_small() const {
+        return use_small_;
+    }
+
+    size_t
+    target_count() const {
+        return target_count_;
+    }
+
+    uint64_t
+    full_mask() const {
+        return full_mask_;
+    }
+
+    size_t
+    num_words() const {
+        return num_words_;
+    }
+
+ private:
+    std::unordered_map<T, uint32_t> value_to_bit_;
+    size_t target_count_{0};
+    bool use_small_{true};
+    uint64_t full_mask_{0};
+    size_t num_words_{0};
+};
 
 void
 PhyJsonContainsFilterExpr::Eval(EvalCtx& context, VectorPtr& result) {
@@ -358,7 +437,7 @@ PhyJsonContainsFilterExpr::ExecJsonContains(EvalCtx& context) {
             auto doc = data[i].doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
-                return false;
+                return std::make_pair(false, false);
             }
             for (auto&& it : array) {
                 auto val = it.template get<GetType>();
@@ -370,17 +449,17 @@ PhyJsonContainsFilterExpr::ExecJsonContains(EvalCtx& context) {
                                 std::floor(double_val.value())) {
                             if (elements->In(static_cast<int64_t>(
                                     double_val.value())) > 0) {
-                                return true;
+                                return std::make_pair(true, true);
                             }
                         }
                     }
                     continue;
                 }
                 if (elements->In(val.value()) > 0) {
-                    return true;
+                    return std::make_pair(true, true);
                 }
             }
-            return false;
+            return std::make_pair(true, false);
         };
         bool has_bitmap_input = !bitmap_input.empty();
         for (size_t i = 0; i < size; ++i) {
@@ -395,7 +474,12 @@ PhyJsonContainsFilterExpr::ExecJsonContains(EvalCtx& context) {
             if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {
                 continue;
             }
-            res[i] = executor(offset);
+            auto [valid, matched] = executor(offset);
+            if (!valid) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            res[i] = matched;
         }
         processed_cursor += size;
     };
@@ -473,7 +557,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByStats() {
 
         cached_index_chunk_res_ = std::make_shared<TargetBitmap>(active_count_);
         cached_index_chunk_valid_res_ =
-            std::make_shared<TargetBitmap>(active_count_, true);
+            std::make_shared<TargetBitmap>(active_count_);
         TargetBitmapView res_view(*cached_index_chunk_res_);
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
         // process shredding data for ARRAY type (non-shared)
@@ -484,6 +568,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByStats() {
             auto target_field = index->GetShreddingField(
                 pointer, milvus::index::JSONType::ARRAY);
             if (!target_field.empty()) {
+                TargetBitmap target_res(active_count_, false);
+                TargetBitmapView target_res_view(target_res);
+                TargetBitmap target_valid(active_count_, true);
+                TargetBitmapView target_valid_view(target_valid);
                 ShreddingArrayBsonContainsAnyExecutor<GetType> executor(
                     arg_set_, arg_set_double_);
 
@@ -492,20 +580,24 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByStats() {
                     target_field,
                     executor,
                     nullptr,
-                    res_view,
-                    valid_res_view);
+                    target_res_view,
+                    target_valid_view);
+                res_view.inplace_or_with_count(target_res_view, active_count_);
+                valid_res_view.inplace_or_with_count(target_valid_view,
+                                                     active_count_);
             }
         }
         // process shared data
-        auto shared_executor = [this, &res_view](milvus::BsonView bson,
-                                                 uint32_t row_offset,
-                                                 uint32_t value_offset) {
+        auto shared_executor = [this, &res_view, &valid_res_view](
+                                   milvus::BsonView bson,
+                                   uint32_t row_offset,
+                                   uint32_t value_offset) {
             auto val = bson.ParseAsArrayAtOffset(value_offset);
 
             if (!val.has_value()) {
-                res_view[row_offset] = false;
                 return;
             }
+            valid_res_view[row_offset] = true;
 
             for (const auto& element : val.value()) {
                 if constexpr (std::is_same_v<GetType, int64_t> ||
@@ -539,12 +631,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsByStats() {
         cached_index_chunk_id_ = 0;
     }
 
-    TargetBitmap result;
-    result.append(
-        *cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
+    auto res = MoveOrSliceBitmap(*cached_index_chunk_res_,
+                                 *cached_index_chunk_valid_res_,
+                                 current_data_global_pos_,
+                                 real_batch_size);
     MoveCursor();
-    return std::make_shared<ColumnVector>(std::move(result),
-                                          TargetBitmap(real_batch_size, true));
+    return res;
 }
 
 VectorPtr
@@ -607,11 +699,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArray(EvalCtx& context) {
             processed_cursor += size;
             return;
         }
-        auto executor = [&](size_t i) -> bool {
+        auto executor = [&](size_t i) {
             auto doc = data[i].doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
-                return false;
+                return std::make_pair(false, false);
             }
             for (auto&& it : array) {
                 auto val = it.get_array();
@@ -627,11 +719,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArray(EvalCtx& context) {
                 }
                 for (auto const& element : elements) {
                     if (CompareTwoJsonArray(json_array, element)) {
-                        return true;
+                        return std::make_pair(true, true);
                     }
                 }
             }
-            return false;
+            return std::make_pair(true, false);
         };
         bool has_bitmap_input = !bitmap_input.empty();
         for (size_t i = 0; i < size; ++i) {
@@ -646,7 +738,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArray(EvalCtx& context) {
             if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {
                 continue;
             }
-            res[i] = executor(offset);
+            auto [valid, matched] = executor(offset);
+            if (!valid) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            res[i] = matched;
         }
         processed_cursor += size;
     };
@@ -705,7 +802,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArrayByStats() {
 
         cached_index_chunk_res_ = std::make_shared<TargetBitmap>(active_count_);
         cached_index_chunk_valid_res_ =
-            std::make_shared<TargetBitmap>(active_count_, true);
+            std::make_shared<TargetBitmap>(active_count_);
         TargetBitmapView res_view(*cached_index_chunk_res_);
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
 
@@ -717,25 +814,34 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArrayByStats() {
             auto target_field = index->GetShreddingField(
                 pointer, milvus::index::JSONType::ARRAY);
             if (!target_field.empty()) {
+                TargetBitmap target_res(active_count_, false);
+                TargetBitmapView target_res_view(target_res);
+                TargetBitmap target_valid(active_count_, true);
+                TargetBitmapView target_valid_view(target_valid);
                 ShreddingArrayBsonContainsArrayExecutor executor(elements);
                 index->ExecutorForShreddingData<std::string_view>(
                     op_ctx_,
                     target_field,
                     executor,
                     nullptr,
-                    res_view,
-                    valid_res_view);
+                    target_res_view,
+                    target_valid_view);
+                res_view.inplace_or_with_count(target_res_view, active_count_);
+                valid_res_view.inplace_or_with_count(target_valid_view,
+                                                     active_count_);
             }
         }
 
-        auto shared_executor = [&elements, &res_view](milvus::BsonView bson,
-                                                      uint32_t row_offset,
-                                                      uint32_t value_offset) {
+        auto shared_executor = [&elements, &res_view, &valid_res_view](
+                                   milvus::BsonView bson,
+                                   uint32_t row_offset,
+                                   uint32_t value_offset) {
             auto array = bson.ParseAsArrayAtOffset(value_offset);
 
             if (!array.has_value()) {
-                res_view[row_offset] = false;
+                return;
             }
+            valid_res_view[row_offset] = true;
 
             for (const auto& sub_value : array.value()) {
                 auto sub_array = milvus::BsonView::GetValueFromBsonView<
@@ -746,11 +852,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArrayByStats() {
 
                 for (const auto& element : elements) {
                     if (CompareTwoJsonArray(sub_array.value(), element)) {
-                        return true;
+                        res_view[row_offset] = true;
+                        return;
                     }
                 }
             }
-            return false;
+            res_view[row_offset] = false;
         };
         {
             milvus::ScopedTimer timer(
@@ -761,12 +868,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsArrayByStats() {
         cached_index_chunk_id_ = 0;
     }
 
-    TargetBitmap result;
-    result.append(
-        *cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
+    auto res = MoveOrSliceBitmap(*cached_index_chunk_res_,
+                                 *cached_index_chunk_valid_res_,
+                                 current_data_global_pos_,
+                                 real_batch_size);
     MoveCursor();
-    return std::make_shared<ColumnVector>(std::move(result),
-                                          TargetBitmap(real_batch_size, true));
+    return res;
 }
 
 template <typename ExprValueType>
@@ -917,9 +1024,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAll(EvalCtx& context) {
     auto elements =
         std::static_pointer_cast<std::set<GetType>>(arg_cached_set_);
     int processed_cursor = 0;
+    ContainsAllMatcher<GetType> matcher(*elements);
+    std::vector<uint64_t> found_large(
+        matcher.use_small() ? 0 : matcher.num_words());
     auto execute_sub_batch =
-        [&processed_cursor, &
-         bitmap_input ]<FilterType filter_type = FilterType::sequential>(
+        [&processed_cursor, &bitmap_input, &matcher, &
+         found_large ]<FilterType filter_type = FilterType::sequential>(
             const milvus::Json* data,
             const bool* valid_data,
             const int32_t* offsets,
@@ -934,37 +1044,67 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAll(EvalCtx& context) {
             processed_cursor += size;
             return;
         }
-        auto executor = [&](const size_t i) -> bool {
+        auto executor = [&](const size_t i) {
             auto doc = data[i].doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
-                return false;
+                return std::make_pair(false, false);
             }
-            std::set<GetType> tmp_elements(elements);
-            // Note: array can only be iterated once
-            for (auto&& it : array) {
-                auto val = it.template get<GetType>();
-                if (val.error()) {
-                    if constexpr (std::is_same_v<GetType, int64_t>) {
-                        auto double_val = it.template get<double>();
-                        if (!double_val.error() &&
-                            double_val.value() ==
-                                std::floor(double_val.value())) {
-                            tmp_elements.erase(
-                                static_cast<int64_t>(double_val.value()));
-                            if (tmp_elements.size() == 0) {
-                                return true;
+            if (matcher.use_small()) {
+                uint64_t found = 0;
+                for (auto&& it : array) {
+                    auto val = it.template get<GetType>();
+                    if (val.error()) {
+                        if constexpr (std::is_same_v<GetType, int64_t>) {
+                            auto double_val = it.template get<double>();
+                            if (!double_val.error() &&
+                                double_val.value() ==
+                                    std::floor(double_val.value())) {
+                                if (matcher.set_if_found(
+                                        static_cast<int64_t>(
+                                            double_val.value()),
+                                        found)) {
+                                    return std::make_pair(true, true);
+                                }
                             }
                         }
+                        continue;
+                    }
+                    if (matcher.set_if_found(val.value(), found)) {
+                        return std::make_pair(true, true);
                     }
                     continue;
                 }
-                tmp_elements.erase(val.value());
-                if (tmp_elements.size() == 0) {
-                    return true;
+                return std::make_pair(true, found == matcher.full_mask());
+            } else {
+                std::fill(found_large.begin(), found_large.end(), 0);
+                size_t remaining = matcher.target_count();
+                for (auto&& it : array) {
+                    auto val = it.template get<GetType>();
+                    if (val.error()) {
+                        if constexpr (std::is_same_v<GetType, int64_t>) {
+                            auto double_val = it.template get<double>();
+                            if (!double_val.error() &&
+                                double_val.value() ==
+                                    std::floor(double_val.value())) {
+                                if (matcher.set_if_found(
+                                        static_cast<int64_t>(
+                                            double_val.value()),
+                                        found_large,
+                                        remaining)) {
+                                    return std::make_pair(true, true);
+                                }
+                            }
+                        }
+                        continue;
+                    }
+                    if (matcher.set_if_found(
+                            val.value(), found_large, remaining)) {
+                        return std::make_pair(true, true);
+                    }
                 }
+                return std::make_pair(true, remaining == 0);
             }
-            return tmp_elements.size() == 0;
         };
         bool has_bitmap_input = !bitmap_input.empty();
         for (size_t i = 0; i < size; ++i) {
@@ -979,7 +1119,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAll(EvalCtx& context) {
             if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {
                 continue;
             }
-            res[i] = executor(offset);
+            auto [valid, matched] = executor(offset);
+            if (!valid) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            res[i] = matched;
         }
         processed_cursor += size;
     };
@@ -1049,7 +1194,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByStats() {
 
         cached_index_chunk_res_ = std::make_shared<TargetBitmap>(active_count_);
         cached_index_chunk_valid_res_ =
-            std::make_shared<TargetBitmap>(active_count_, true);
+            std::make_shared<TargetBitmap>(active_count_);
         TargetBitmapView res_view(*cached_index_chunk_res_);
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
         // process shredding data for ARRAY type (non-shared)
@@ -1060,6 +1205,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByStats() {
             auto target_field = index->GetShreddingField(
                 pointer, milvus::index::JSONType::ARRAY);
             if (!target_field.empty()) {
+                TargetBitmap target_res(active_count_, false);
+                TargetBitmapView target_res_view(target_res);
+                TargetBitmap target_valid(active_count_, true);
+                TargetBitmapView target_valid_view(target_valid);
                 ShreddingArrayBsonContainsAllExecutor<GetType> executor(
                     *elements);
 
@@ -1068,52 +1217,97 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByStats() {
                     target_field,
                     executor,
                     nullptr,
-                    res_view,
-                    valid_res_view);
+                    target_res_view,
+                    target_valid_view);
+                res_view.inplace_or_with_count(target_res_view, active_count_);
+                valid_res_view.inplace_or_with_count(target_valid_view,
+                                                     active_count_);
             }
         }
         // process shared data
-        auto shared_executor = [this, &elements, &res_view](
-                                   milvus::BsonView bson,
-                                   uint32_t row_offset,
-                                   uint32_t value_offset) {
+        ContainsAllMatcher<GetType> shared_matcher(*elements);
+        std::vector<uint64_t> shared_found_large(
+            shared_matcher.use_small() ? 0 : shared_matcher.num_words());
+        auto shared_executor = [&shared_matcher,
+                                &res_view,
+                                &valid_res_view,
+                                &shared_found_large](milvus::BsonView bson,
+                                                     uint32_t row_offset,
+                                                     uint32_t value_offset) {
             auto val = bson.ParseAsArrayAtOffset(value_offset);
 
             if (!val.has_value()) {
-                res_view[row_offset] = false;
                 return;
             }
+            valid_res_view[row_offset] = true;
 
-            std::set<GetType> tmp_elements(*elements);
-            for (const auto& element : val.value()) {
-                auto value = milvus::BsonView::GetValueFromBsonView<GetType>(
-                    element.get_value());
-                if (!value.has_value()) {
-                    if constexpr (std::is_same_v<GetType, int64_t>) {
-                        auto double_value =
-                            milvus::BsonView::GetValueFromBsonView<double>(
-                                element.get_value());
-                        if (double_value.has_value()) {
-                            if (double_value.value() ==
-                                std::floor(double_value.value())) {
-                                tmp_elements.erase(
-                                    static_cast<int64_t>(double_value.value()));
-                            }
-                            if (tmp_elements.size() == 0) {
-                                res_view[row_offset] = true;
-                                return;
+            if (shared_matcher.use_small()) {
+                uint64_t found = 0;
+                for (const auto& element : val.value()) {
+                    auto value =
+                        milvus::BsonView::GetValueFromBsonView<GetType>(
+                            element.get_value());
+                    if (!value.has_value()) {
+                        if constexpr (std::is_same_v<GetType, int64_t>) {
+                            auto double_value =
+                                milvus::BsonView::GetValueFromBsonView<double>(
+                                    element.get_value());
+                            if (double_value.has_value() &&
+                                double_value.value() ==
+                                    std::floor(double_value.value())) {
+                                if (shared_matcher.set_if_found(
+                                        static_cast<int64_t>(
+                                            double_value.value()),
+                                        found)) {
+                                    res_view[row_offset] = true;
+                                    return;
+                                }
                             }
                         }
+                        continue;
                     }
-                    continue;
+                    if (shared_matcher.set_if_found(value.value(), found)) {
+                        res_view[row_offset] = true;
+                        return;
+                    }
                 }
-                tmp_elements.erase(value.value());
-                if (tmp_elements.size() == 0) {
-                    res_view[row_offset] = true;
-                    return;
+                res_view[row_offset] = found == shared_matcher.full_mask();
+            } else {
+                std::fill(
+                    shared_found_large.begin(), shared_found_large.end(), 0);
+                size_t remaining = shared_matcher.target_count();
+                for (const auto& element : val.value()) {
+                    auto value =
+                        milvus::BsonView::GetValueFromBsonView<GetType>(
+                            element.get_value());
+                    if (!value.has_value()) {
+                        if constexpr (std::is_same_v<GetType, int64_t>) {
+                            auto double_value =
+                                milvus::BsonView::GetValueFromBsonView<double>(
+                                    element.get_value());
+                            if (double_value.has_value() &&
+                                double_value.value() ==
+                                    std::floor(double_value.value())) {
+                                if (shared_matcher.set_if_found(
+                                        static_cast<int64_t>(
+                                            double_value.value()),
+                                        shared_found_large,
+                                        remaining)) {
+                                    res_view[row_offset] = true;
+                                    return;
+                                }
+                            }
+                        }
+                        continue;
+                    }
+                    if (shared_matcher.set_if_found(
+                            value.value(), shared_found_large, remaining)) {
+                        res_view[row_offset] = true;
+                        return;
+                    }
                 }
+                res_view[row_offset] = remaining == 0;
             }
-            res_view[row_offset] = tmp_elements.empty();
         };
         {
             milvus::ScopedTimer timer(
@@ -1125,12 +1319,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllByStats() {
         cached_index_chunk_id_ = 0;
     }
 
-    TargetBitmap result;
-    result.append(
-        *cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
+    auto res = MoveOrSliceBitmap(*cached_index_chunk_res_,
+                                 *cached_index_chunk_valid_res_,
+                                 current_data_global_pos_,
+                                 real_batch_size);
     MoveCursor();
-    return std::make_shared<ColumnVector>(std::move(result),
-                                          TargetBitmap(real_batch_size, true));
+    return res;
 }
 
 VectorPtr
@@ -1190,12 +1384,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
             processed_cursor += size;
             return;
         }
-        auto executor = [&](size_t i) -> bool {
+        auto executor = [&](size_t i) {
             const auto& json = data[i];
             auto doc = json.dom_doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
-                return false;
+                return std::make_pair(false, false);
             }
             std::unordered_set<int> tmp_elements_index(elements_index);
             for (auto&& it : array) {
@@ -1264,14 +1458,14 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
                                       element.val_case());
                     }
                     if (tmp_elements_index.size() == 0) {
-                        return true;
+                        return std::make_pair(true, true);
                     }
                 }
                 if (tmp_elements_index.size() == 0) {
-                    return true;
+                    return std::make_pair(true, true);
                 }
             }
-            return tmp_elements_index.size() == 0;
+            return std::make_pair(true, tmp_elements_index.size() == 0);
         };
         bool has_bitmap_input = !bitmap_input.empty();
         for (size_t i = 0; i < size; ++i) {
@@ -1287,7 +1481,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffType(EvalCtx& context) {
                 continue;
             }
 
-            res[i] = executor(offset);
+            auto [valid, matched] = executor(offset);
+            if (!valid) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            res[i] = matched;
         }
         processed_cursor += size;
     };
@@ -1350,7 +1549,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByStats() {
 
         cached_index_chunk_res_ = std::make_shared<TargetBitmap>(active_count_);
         cached_index_chunk_valid_res_ =
-            std::make_shared<TargetBitmap>(active_count_, true);
+            std::make_shared<TargetBitmap>(active_count_);
         TargetBitmapView res_view(*cached_index_chunk_res_);
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
 
@@ -1362,6 +1561,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByStats() {
             auto target_field = index->GetShreddingField(
                 pointer, milvus::index::JSONType::ARRAY);
             if (!target_field.empty()) {
+                TargetBitmap target_res(active_count_, false);
+                TargetBitmapView target_res_view(target_res);
+                TargetBitmap target_valid(active_count_, true);
+                TargetBitmapView target_valid_view(target_valid);
                 ShreddingArrayBsonContainsAllWithDiffTypeExecutor executor(
                     elements, elements_index);
                 index->ExecutorForShreddingData<std::string_view>(
@@ -1369,21 +1572,26 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByStats() {
                     target_field,
                     executor,
                     nullptr,
-                    res_view,
-                    valid_res_view);
+                    target_res_view,
+                    target_valid_view);
+                res_view.inplace_or_with_count(target_res_view, active_count_);
+                valid_res_view.inplace_or_with_count(target_valid_view,
+                                                     active_count_);
             }
         }
 
-        auto shared_executor = [&elements, &elements_index, &res_view](
-                                   milvus::BsonView bson,
-                                   uint32_t row_offset,
-                                   uint32_t value_offset) {
+        auto shared_executor = [&elements,
+                                &elements_index,
+                                &res_view,
+                                &valid_res_view](milvus::BsonView bson,
+                                                 uint32_t row_offset,
+                                                 uint32_t value_offset) {
             std::set<int> tmp_elements_index(elements_index);
             auto array = bson.ParseAsArrayAtOffset(value_offset);
             if (!array.has_value()) {
-                res_view[row_offset] = false;
                 return;
             }
+            valid_res_view[row_offset] = true;
 
             for (const auto& sub_value : array.value()) {
                 int i = -1;
@@ -1477,12 +1685,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllWithDiffTypeByStats() {
         cached_index_chunk_id_ = 0;
     }
 
-    TargetBitmap result;
-    result.append(
-        *cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
+    auto res = MoveOrSliceBitmap(*cached_index_chunk_res_,
+                                 *cached_index_chunk_valid_res_,
+                                 current_data_global_pos_,
+                                 real_batch_size);
     MoveCursor();
-    return std::make_shared<ColumnVector>(std::move(result),
-                                          TargetBitmap(real_batch_size, true));
+    return res;
 }
 
 VectorPtr
@@ -1544,7 +1752,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArray(EvalCtx& context) {
             auto doc = data[i].doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
-                return false;
+                return std::make_pair(false, false);
             }
             std::unordered_set<int> exist_elements_index;
             for (auto&& it : array) {
@@ -1565,10 +1773,11 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArray(EvalCtx& context) {
                     }
                 }
                 if (exist_elements_index.size() == elements.size()) {
-                    return true;
+                    return std::make_pair(true, true);
                 }
             }
-            return exist_elements_index.size() == elements.size();
+            return std::make_pair(
+                true, exist_elements_index.size() == elements.size());
         };
         bool has_bitmap_input = !bitmap_input.empty();
         for (size_t i = 0; i < size; ++i) {
@@ -1584,7 +1793,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArray(EvalCtx& context) {
                 continue;
             }
 
-            res[i] = executor(offset);
+            auto [valid, matched] = executor(offset);
+            if (!valid) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            res[i] = matched;
         }
         processed_cursor += size;
     };
@@ -1643,7 +1857,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArrayByStats() {
 
         cached_index_chunk_res_ = std::make_shared<TargetBitmap>(active_count_);
         cached_index_chunk_valid_res_ =
-            std::make_shared<TargetBitmap>(active_count_, true);
+            std::make_shared<TargetBitmap>(active_count_);
         TargetBitmapView res_view(*cached_index_chunk_res_);
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
 
@@ -1655,25 +1869,33 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArrayByStats() {
             auto target_field = index->GetShreddingField(
                 pointer, milvus::index::JSONType::ARRAY);
             if (!target_field.empty()) {
+                TargetBitmap target_res(active_count_, false);
+                TargetBitmapView target_res_view(target_res);
+                TargetBitmap target_valid(active_count_, true);
+                TargetBitmapView target_valid_view(target_valid);
                 ShreddingArrayBsonContainsAllArrayExecutor executor(elements);
                 index->ExecutorForShreddingData<std::string_view>(
                     op_ctx_,
                     target_field,
                     executor,
                     nullptr,
-                    res_view,
-                    valid_res_view);
+                    target_res_view,
+                    target_valid_view);
+                res_view.inplace_or_with_count(target_res_view, active_count_);
+                valid_res_view.inplace_or_with_count(target_valid_view,
+                                                     active_count_);
             }
         }
 
-        auto shared_executor = [&elements, &res_view](milvus::BsonView bson,
-                                                      uint32_t row_offset,
-                                                      uint32_t value_offset) {
+        auto shared_executor = [&elements, &res_view, &valid_res_view](
+                                   milvus::BsonView bson,
+                                   uint32_t row_offset,
+                                   uint32_t value_offset) {
             auto array = bson.ParseAsArrayAtOffset(value_offset);
             if (!array.has_value()) {
-                res_view[row_offset] = false;
                 return;
             }
+            valid_res_view[row_offset] = true;
 
             std::set<int> exist_elements_index;
             for (const auto& sub_value : array.value()) {
@@ -1707,12 +1929,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsAllArrayByStats() {
         cached_index_chunk_id_ = 0;
     }
 
-    TargetBitmap result;
-    result.append(
-        *cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
+    auto res = MoveOrSliceBitmap(*cached_index_chunk_res_,
+                                 *cached_index_chunk_valid_res_,
+                                 current_data_global_pos_,
+                                 real_batch_size);
     MoveCursor();
-    return std::make_shared<ColumnVector>(std::move(result),
-                                          TargetBitmap(real_batch_size, true));
+    return res;
 }
 
 VectorPtr
@@ -1771,7 +1993,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
             auto doc = json.dom_doc();
             auto array = doc.at_pointer(pointer).get_array();
             if (array.error()) {
-                return false;
+                return std::make_pair(false, false);
             }
             // Note: array can only be iterated once
             for (auto&& it : array) {
@@ -1783,7 +2005,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
                                 continue;
                             }
                             if (val.value() == element.bool_val()) {
-                                return true;
+                                return std::make_pair(true, true);
                             }
                             break;
                         }
@@ -1793,12 +2015,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
                                 auto double_val = it.template get<double>();
                                 if (!double_val.error() &&
                                     double_val.value() == element.int64_val()) {
-                                    return true;
+                                    return std::make_pair(true, true);
                                 }
                                 continue;
                             }
                             if (val.value() == element.int64_val()) {
-                                return true;
+                                return std::make_pair(true, true);
                             }
                             break;
                         }
@@ -1808,7 +2030,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
                                 continue;
                             }
                             if (val.value() == element.float_val()) {
-                                return true;
+                                return std::make_pair(true, true);
                             }
                             break;
                         }
@@ -1818,7 +2040,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
                                 continue;
                             }
                             if (val.value() == element.string_val()) {
-                                return true;
+                                return std::make_pair(true, true);
                             }
                             break;
                         }
@@ -1828,7 +2050,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
                                 continue;
                             }
                             if (CompareTwoJsonArray(val, element.array_val())) {
-                                return true;
+                                return std::make_pair(true, true);
                             }
                             break;
                         }
@@ -1839,7 +2061,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
                     }
                 }
             }
-            return false;
+            return std::make_pair(true, false);
         };
         bool has_bitmap_input = !bitmap_input.empty();
         for (size_t i = 0; i < size; ++i) {
@@ -1855,7 +2077,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffType(EvalCtx& context) {
                 continue;
             }
 
-            res[i] = executor(offset);
+            auto [valid, matched] = executor(offset);
+            if (!valid) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            res[i] = matched;
         }
         processed_cursor += size;
     };
@@ -1910,7 +2137,7 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByStats() {
 
         cached_index_chunk_res_ = std::make_shared<TargetBitmap>(active_count_);
         cached_index_chunk_valid_res_ =
-            std::make_shared<TargetBitmap>(active_count_, true);
+            std::make_shared<TargetBitmap>(active_count_);
         TargetBitmapView res_view(*cached_index_chunk_res_);
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
 
@@ -1922,6 +2149,10 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByStats() {
             auto target_field = index->GetShreddingField(
                 pointer, milvus::index::JSONType::ARRAY);
             if (!target_field.empty()) {
+                TargetBitmap target_res(active_count_, false);
+                TargetBitmapView target_res_view(target_res);
+                TargetBitmap target_valid(active_count_, true);
+                TargetBitmapView target_valid_view(target_valid);
                 ShreddingArrayBsonContainsAnyWithDiffTypeExecutor executor(
                     elements);
                 index->ExecutorForShreddingData<std::string_view>(
@@ -1929,19 +2160,23 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByStats() {
                     target_field,
                     executor,
                     nullptr,
-                    res_view,
-                    valid_res_view);
+                    target_res_view,
+                    target_valid_view);
+                res_view.inplace_or_with_count(target_res_view, active_count_);
+                valid_res_view.inplace_or_with_count(target_valid_view,
+                                                     active_count_);
             }
         }
 
-        auto shared_executor = [&elements, &res_view](milvus::BsonView bson,
-                                                      uint32_t row_offset,
-                                                      uint32_t value_offset) {
+        auto shared_executor = [&elements, &res_view, &valid_res_view](
+                                   milvus::BsonView bson,
+                                   uint32_t row_offset,
+                                   uint32_t value_offset) {
             auto array = bson.ParseAsArrayAtOffset(value_offset);
             if (!array.has_value()) {
-                res_view[row_offset] = false;
                 return;
             }
+            valid_res_view[row_offset] = true;
 
             for (const auto& sub_value : array.value()) {
                 for (auto const& element : elements) {
@@ -2028,12 +2263,12 @@ PhyJsonContainsFilterExpr::ExecJsonContainsWithDiffTypeByStats() {
         cached_index_chunk_id_ = 0;
     }
 
-    TargetBitmap result;
-    result.append(
-        *cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
+    auto res = MoveOrSliceBitmap(*cached_index_chunk_res_,
+                                 *cached_index_chunk_valid_res_,
+                                 current_data_global_pos_,
+                                 real_batch_size);
     MoveCursor();
-    return std::make_shared<ColumnVector>(std::move(result),
-                                          TargetBitmap(real_batch_size, true));
+    return res;
 }
 
 VectorPtr

--- a/internal/core/src/exec/expression/JsonContainsExpr.h
+++ b/internal/core/src/exec/expression/JsonContainsExpr.h
@@ -52,7 +52,7 @@ class ShreddingArrayBsonContainsArrayExecutor {
                 reinterpret_cast<const uint8_t*>(src[i].data()), src[i].size());
             auto array_view = bson.ParseAsArrayAtOffset(0);
             if (!array_view.has_value()) {
-                res[i] = false;
+                res[i] = valid_res[i] = false;
                 continue;
             }
             bool matched = false;
@@ -100,7 +100,7 @@ class ShreddingArrayBsonContainsAllArrayExecutor {
                 reinterpret_cast<const uint8_t*>(src[i].data()), src[i].size());
             auto array_view = bson.ParseAsArrayAtOffset(0);
             if (!array_view.has_value()) {
-                res[i] = false;
+                res[i] = valid_res[i] = false;
                 continue;
             }
             std::set<int> exist_elements_index;
@@ -154,7 +154,7 @@ class ShreddingArrayBsonContainsAnyExecutor {
                 reinterpret_cast<const uint8_t*>(src[i].data()), src[i].size());
             auto array_view = bson.ParseAsArrayAtOffset(0);
             if (!array_view.has_value()) {
-                res[i] = false;
+                res[i] = valid_res[i] = false;
                 continue;
             }
             bool matched = false;
@@ -210,7 +210,7 @@ class ShreddingArrayBsonContainsAllExecutor {
                 reinterpret_cast<const uint8_t*>(src[i].data()), src[i].size());
             auto array_view = bson.ParseAsArrayAtOffset(0);
             if (!array_view.has_value()) {
-                res[i] = false;
+                res[i] = valid_res[i] = false;
                 continue;
             }
             std::set<GetType> tmp_elements(elements_);
@@ -257,7 +257,7 @@ class ShreddingArrayBsonContainsAllWithDiffTypeExecutor {
                 reinterpret_cast<const uint8_t*>(src[i].data()), src[i].size());
             auto array = bson.ParseAsArrayAtOffset(0);
             if (!array.has_value()) {
-                res[i] = false;
+                res[i] = valid_res[i] = false;
                 continue;
             }
             std::set<int> tmp_elements_index(elements_index_);
@@ -369,7 +369,7 @@ class ShreddingArrayBsonContainsAnyWithDiffTypeExecutor {
                 reinterpret_cast<const uint8_t*>(src[i].data()), src[i].size());
             auto array = bson.ParseAsArrayAtOffset(0);
             if (!array.has_value()) {
-                res[i] = false;
+                res[i] = valid_res[i] = false;
                 continue;
             }
             bool matched = false;

--- a/internal/core/src/exec/expression/TermExpr.cpp
+++ b/internal/core/src/exec/expression/TermExpr.cpp
@@ -498,18 +498,19 @@ PhyTermFilterExpr::ExecTermJsonVariableInField(EvalCtx& context) {
         auto executor = [&](size_t i) {
             auto doc = data[i].doc();
             auto array = doc.at_pointer(pointer).get_array();
-            if (array.error())
-                return false;
+            if (array.error()) {
+                return std::make_pair(false, false);
+            }
             for (auto it = array.begin(); it != array.end(); ++it) {
                 auto val = (*it).template get<GetType>();
                 if (val.error()) {
-                    return false;
+                    continue;
                 }
                 if (val.value() == target_val) {
-                    return true;
+                    return std::make_pair(true, true);
                 }
             }
-            return false;
+            return std::make_pair(true, false);
         };
         bool has_bitmap_input = !bitmap_input.empty();
         for (size_t i = 0; i < size; ++i) {
@@ -524,7 +525,12 @@ PhyTermFilterExpr::ExecTermJsonVariableInField(EvalCtx& context) {
             if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {
                 continue;
             }
-            res[i] = executor(offset);
+            auto [valid, matched] = executor(offset);
+            if (!valid) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            res[i] = matched;
         }
         processed_cursor += size;
     };
@@ -592,18 +598,20 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
 
         cached_index_chunk_res_ = std::make_shared<TargetBitmap>(active_count_);
         cached_index_chunk_valid_res_ =
-            std::make_shared<TargetBitmap>(active_count_, true);
+            std::make_shared<TargetBitmap>(active_count_);
         TargetBitmapView res_view(*cached_index_chunk_res_);
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
 
         // process shredding data
         auto try_execute = [&](milvus::index::JSONType json_type,
-                               TargetBitmapView& res_view,
-                               TargetBitmapView& valid_res_view,
                                auto GetType) {
             auto target_field = index->GetShreddingField(pointer, json_type);
             if (!target_field.empty()) {
                 using ColType = decltype(GetType);
+                TargetBitmap target_res(active_count_, false);
+                TargetBitmapView target_res_view(target_res);
+                TargetBitmap target_valid(active_count_, true);
+                TargetBitmapView target_valid_view(target_valid);
                 auto shredding_executor = [this](const ColType* src,
                                                  const bool* valid,
                                                  size_t size,
@@ -621,13 +629,15 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
                         }
                     }
                 };
-                index->template ExecutorForShreddingData<ColType>(
-                    op_ctx_,
-                    target_field,
-                    shredding_executor,
-                    nullptr,
-                    res_view,
-                    valid_res_view);
+                index->ExecutorForShreddingData<ColType>(op_ctx_,
+                                                         target_field,
+                                                         shredding_executor,
+                                                         nullptr,
+                                                         target_res_view,
+                                                         target_valid_view);
+                res_view.inplace_or_with_count(target_res_view, active_count_);
+                valid_res_view.inplace_or_with_count(target_valid_view,
+                                                     active_count_);
                 LOG_DEBUG("using shredding data's field: {} count {}",
                           target_field,
                           res_view.count());
@@ -640,60 +650,28 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
                 [this](double us) { json_stats_shredding_latency_us_ += us; });
 
             if constexpr (std::is_same_v<GetType, bool>) {
-                try_execute(milvus::index::JSONType::BOOL,
-                            res_view,
-                            valid_res_view,
-                            bool{});
+                try_execute(milvus::index::JSONType::BOOL, bool{});
             } else if constexpr (std::is_same_v<GetType, int64_t>) {
-                try_execute(milvus::index::JSONType::INT64,
-                            res_view,
-                            valid_res_view,
-                            int64_t{});
+                try_execute(milvus::index::JSONType::INT64, int64_t{});
                 // and double compare
-                TargetBitmap res_double(active_count_, false);
-                TargetBitmapView res_double_view(res_double);
-                TargetBitmap res_double_valid(active_count_, true);
-                TargetBitmapView valid_res_double_view(res_double_valid);
-                try_execute(milvus::index::JSONType::DOUBLE,
-                            res_double_view,
-                            valid_res_double_view,
-                            double{});
-                res_view.inplace_or_with_count(res_double_view, active_count_);
-                valid_res_view.inplace_or_with_count(valid_res_double_view,
-                                                     active_count_);
+                try_execute(milvus::index::JSONType::DOUBLE, double{});
 
             } else if constexpr (std::is_same_v<GetType, double>) {
-                try_execute(milvus::index::JSONType::DOUBLE,
-                            res_view,
-                            valid_res_view,
-                            double{});
+                try_execute(milvus::index::JSONType::DOUBLE, double{});
                 // and int64 compare
-                TargetBitmap res_int64(active_count_, false);
-                TargetBitmapView res_int64_view(res_int64);
-                TargetBitmap res_int64_valid(active_count_, true);
-                TargetBitmapView valid_res_int64_view(res_int64_valid);
-                try_execute(milvus::index::JSONType::INT64,
-                            res_int64_view,
-                            valid_res_int64_view,
-                            int64_t{});
-                res_view.inplace_or_with_count(res_int64_view, active_count_);
-                valid_res_view.inplace_or_with_count(valid_res_int64_view,
-                                                     active_count_);
+                try_execute(milvus::index::JSONType::INT64, int64_t{});
             } else if constexpr (std::is_same_v<GetType, std::string_view> ||
                                  std::is_same_v<GetType, std::string>) {
                 try_execute(milvus::index::JSONType::STRING,
-                            res_view,
-                            valid_res_view,
                             std::string_view{});
             }
         }
 
         // process shared data
-        auto shared_executor = [this, &res_view](milvus::BsonView bson,
-                                                 uint32_t row_offset,
-                                                 uint32_t value_offset) {
-            auto get_value = bson.ParseAsValueAtOffset<GetType>(value_offset);
-
+        auto shared_executor = [this, &res_view, &valid_res_view](
+                                   milvus::BsonView bson,
+                                   uint32_t row_offset,
+                                   uint32_t value_offset) {
             if constexpr (std::is_same_v<GetType, int64_t> ||
                           std::is_same_v<GetType, double>) {
                 auto get_value =
@@ -701,6 +679,7 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
                 if (get_value.has_value()) {
                     res_view[row_offset] =
                         this->arg_set_double_->In(get_value.value());
+                    valid_res_view[row_offset] = true;
                 }
                 return;
             } else {
@@ -709,6 +688,7 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
                 if (get_value.has_value()) {
                     res_view[row_offset] =
                         this->arg_set_->In(get_value.value());
+                    valid_res_view[row_offset] = true;
                 }
                 return;
             }
@@ -723,12 +703,12 @@ PhyTermFilterExpr::ExecJsonInVariableByStats() {
         cached_index_chunk_id_ = 0;
     }
 
-    TargetBitmap result;
-    result.append(
-        *cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
+    auto res = MoveOrSliceBitmap(*cached_index_chunk_res_,
+                                 *cached_index_chunk_valid_res_,
+                                 current_data_global_pos_,
+                                 real_batch_size);
     MoveCursor();
-    return std::make_shared<ColumnVector>(std::move(result),
-                                          TargetBitmap(real_batch_size, true));
+    return res;
 }
 
 template <typename ValueType>
@@ -795,22 +775,32 @@ PhyTermFilterExpr::ExecTermJsonFieldInVariable(EvalCtx& context) {
             return;
         }
         auto executor = [&](size_t i) {
-            auto x = data[i].template at<GetType>(pointer);
-            if (x.error()) {
-                if constexpr (std::is_same_v<GetType, std::int64_t>) {
-                    auto x = data[i].template at<double>(pointer);
-                    if (x.error()) {
-                        return false;
-                    }
-
-                    auto value = x.value();
-                    // if the term set is {1}, and the value is 1.1, we should not return true.
-                    return std::floor(value) == value &&
-                           terms->In(ValueType(x.value()));
+            if constexpr (std::is_same_v<GetType, std::int64_t>) {
+                auto x_num = data[i].at_numeric(pointer);
+                if (x_num.error()) {
+                    return std::make_pair(false, false);
                 }
-                return false;
+                auto n = x_num.value();
+                if (n.is_int64()) {
+                    return std::make_pair(true,
+                                          terms->In(ValueType(n.get_int64())));
+                }
+                // uint64 or double → compare as double, consistent with
+                // index/stats paths.
+                auto dval = n.is_uint64() ? static_cast<double>(n.get_uint64())
+                                          : n.get_double();
+                // if the term set is {1}, and the value is 1.1, we should
+                // not return true.
+                return std::make_pair(
+                    true,
+                    std::floor(dval) == dval && terms->In(ValueType(dval)));
+            } else {
+                auto x = data[i].template at<GetType>(pointer);
+                if (x.error()) {
+                    return std::make_pair(false, false);
+                }
+                return std::make_pair(true, terms->In(ValueType(x.value())));
             }
-            return terms->In(ValueType(x.value()));
         };
         bool has_bitmap_input = !bitmap_input.empty();
         for (size_t i = 0; i < size; ++i) {
@@ -830,7 +820,12 @@ PhyTermFilterExpr::ExecTermJsonFieldInVariable(EvalCtx& context) {
             if (has_bitmap_input && !bitmap_input[processed_cursor + i]) {
                 continue;
             }
-            res[i] = executor(offset);
+            auto [valid, matched] = executor(offset);
+            if (!valid) {
+                res[i] = valid_res[i] = false;
+                continue;
+            }
+            res[i] = matched;
         }
         processed_cursor += size;
     };

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -705,36 +705,40 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
     auto op_type = expr_->op_type_;
     auto pointer = milvus::Json::pointer(expr_->column_.nested_path_);
 
-#define UnaryRangeJSONCompare(cmp)                                  \
-    do {                                                            \
-        auto x = data[offset].template at<GetType>(pointer);        \
-        if (x.error()) {                                            \
-            if constexpr (std::is_same_v<GetType, int64_t>) {       \
-                auto x = data[offset].template at<double>(pointer); \
-                res[i] = !x.error() && (cmp);                       \
-                break;                                              \
-            }                                                       \
-            res[i] = false;                                         \
-            break;                                                  \
-        }                                                           \
-        res[i] = (cmp);                                             \
+// For int64_t GetType, uses at_numeric() (get_number()) to extract any JSON
+// number in a single parse.  Branches on actual type to preserve int64
+// precision; uint64 and double values fall back to double comparison,
+// consistent with the Tantivy index and JSON-stats paths.
+// - 'cmp' must reference 'value' (auto-typed as int64_t or double).
+// Missing path and type mismatch are UNKNOWN/NULL under JSON 3VL semantics.
+#define UnaryRangeJSONCompare(cmp)                                     \
+    do {                                                               \
+        if constexpr (std::is_same_v<GetType, int64_t>) {              \
+            auto x_num = data[offset].at_numeric(pointer);             \
+            if (x_num.error()) {                                       \
+                res[i] = valid_res[i] = false;                         \
+                break;                                                 \
+            }                                                          \
+            auto n = x_num.value();                                    \
+            if (n.is_int64()) {                                        \
+                auto value = n.get_int64();                            \
+                res[i] = (cmp);                                        \
+            } else {                                                   \
+                auto value = n.is_uint64()                             \
+                                 ? static_cast<double>(n.get_uint64()) \
+                                 : n.get_double();                     \
+                res[i] = (cmp);                                        \
+            }                                                          \
+        } else {                                                       \
+            auto x = data[offset].template at<GetType>(pointer);       \
+            if (x.error()) {                                           \
+                res[i] = valid_res[i] = false;                         \
+                break;                                                 \
+            }                                                          \
+            auto value = x.value();                                    \
+            res[i] = (cmp);                                            \
+        }                                                              \
     } while (false)
-
-#define UnaryRangeJSONCompareNotEqual(cmp)                          \
-    do {                                                            \
-        auto x = data[offset].template at<GetType>(pointer);        \
-        if (x.error()) {                                            \
-            if constexpr (std::is_same_v<GetType, int64_t>) {       \
-                auto x = data[offset].template at<double>(pointer); \
-                res[i] = x.error() || (cmp);                        \
-                break;                                              \
-            }                                                       \
-            res[i] = true;                                          \
-            break;                                                  \
-        }                                                           \
-        res[i] = (cmp);                                             \
-    } while (false)
-
     int processed_cursor = 0;
     auto execute_sub_batch =
         [ op_type, pointer, &processed_cursor, &
@@ -765,7 +769,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                         res[i] = false;
                     } else {
-                        UnaryRangeJSONCompare(x.value() > val);
+                        UnaryRangeJSONCompare(value > val);
                     }
                 }
                 break;
@@ -787,7 +791,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                         res[i] = false;
                     } else {
-                        UnaryRangeJSONCompare(x.value() >= val);
+                        UnaryRangeJSONCompare(value >= val);
                     }
                 }
                 break;
@@ -809,7 +813,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                         res[i] = false;
                     } else {
-                        UnaryRangeJSONCompare(x.value() < val);
+                        UnaryRangeJSONCompare(value < val);
                     }
                 }
                 break;
@@ -831,7 +835,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                         res[i] = false;
                     } else {
-                        UnaryRangeJSONCompare(x.value() <= val);
+                        UnaryRangeJSONCompare(value <= val);
                     }
                 }
                 break;
@@ -851,15 +855,15 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                         continue;
                     }
                     if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
-                        auto doc = data[i].doc();
+                        auto doc = data[offset].doc();
                         auto array = doc.at_pointer(pointer).get_array();
                         if (array.error()) {
-                            res[i] = false;
+                            res[i] = valid_res[i] = false;
                             continue;
                         }
                         res[i] = CompareTwoJsonArray(array, val);
                     } else {
-                        UnaryRangeJSONCompare(x.value() == val);
+                        UnaryRangeJSONCompare(value == val);
                     }
                 }
                 break;
@@ -879,15 +883,15 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                         continue;
                     }
                     if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
-                        auto doc = data[i].doc();
+                        auto doc = data[offset].doc();
                         auto array = doc.at_pointer(pointer).get_array();
                         if (array.error()) {
-                            res[i] = false;
+                            res[i] = valid_res[i] = false;
                             continue;
                         }
                         res[i] = !CompareTwoJsonArray(array, val);
                     } else {
-                        UnaryRangeJSONCompareNotEqual(x.value() != val);
+                        UnaryRangeJSONCompare(value != val);
                     }
                 }
                 break;
@@ -911,8 +915,8 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                         res[i] = false;
                     } else {
-                        UnaryRangeJSONCompare(milvus::query::Match(
-                            ExprValueType(x.value()), val, op_type));
+                        UnaryRangeJSONCompare(
+                            milvus::query::Match(value, val, op_type));
                     }
                 }
                 break;
@@ -937,8 +941,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                     if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                         res[i] = false;
                     } else {
-                        UnaryRangeJSONCompare(
-                            matcher(ExprValueType(x.value())));
+                        UnaryRangeJSONCompare(matcher(ExprValueType(value)));
                     }
                 }
                 break;
@@ -1016,9 +1019,11 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
         Assert(index != nullptr);
         cached_index_chunk_res_ = std::make_shared<TargetBitmap>(active_count_);
         cached_index_chunk_valid_res_ =
-            std::make_shared<TargetBitmap>(active_count_, true);
+            std::make_shared<TargetBitmap>(active_count_);
         TargetBitmapView res_view(*cached_index_chunk_res_);
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
+        TargetBitmap field_valid(active_count_, true);
+        TargetBitmapView field_valid_view(field_valid);
         int64_t valid_processed_size = 0;
         for (size_t i = 0;
              i < num_data_chunk_ && valid_processed_size < active_count_;
@@ -1039,7 +1044,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                 i,
                 0,
                 size,
-                valid_res_view + valid_processed_size);
+                field_valid_view + valid_processed_size);
             valid_processed_size += size;
         }
 
@@ -1053,6 +1058,8 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                 using ValType = decltype(ValType);
                 TargetBitmap target_res(active_count_, false);
                 TargetBitmapView target_res_view(target_res);
+                TargetBitmap target_valid(active_count_, true);
+                TargetBitmapView target_valid_view(target_valid);
                 ShreddingExecutor<ColType, ValType> executor(
                     op_type, pointer, val);
                 index->ExecutorForShreddingData<ColType>(op_ctx_,
@@ -1060,8 +1067,10 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                                                          executor,
                                                          nullptr,
                                                          target_res_view,
-                                                         target_res_view);
+                                                         target_valid_view);
                 res_view.inplace_or_with_count(target_res_view, active_count_);
+                valid_res_view.inplace_or_with_count(target_valid_view,
+                                                     active_count_);
                 LOG_DEBUG(
                     "using shredding data's field: {} with value {}, count {} "
                     "for segment {}",
@@ -1104,6 +1113,8 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                 if (!target_field.empty()) {
                     TargetBitmap target_res(active_count_, false);
                     TargetBitmapView target_res_view(target_res);
+                    TargetBitmap target_valid(active_count_, true);
+                    TargetBitmapView target_valid_view(target_valid);
                     ShreddingArrayBsonExecutor executor(op_type, pointer, val);
                     index->template ExecutorForShreddingData<std::string_view>(
                         op_ctx_,
@@ -1111,9 +1122,11 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                         executor,
                         nullptr,
                         target_res_view,
-                        target_res_view);
+                        target_valid_view);
                     res_view.inplace_or_with_count(target_res_view,
                                                    active_count_);
+                    valid_res_view.inplace_or_with_count(target_valid_view,
+                                                         active_count_);
                     LOG_DEBUG("using shredding array field: {}, count {}",
                               target_field,
                               res_view.count());
@@ -1122,15 +1135,19 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
         }
 
         // process shared data
-        auto shared_executor = [op_type, val, array_index, &res_view](
-                                   milvus::BsonView bson,
-                                   uint32_t row_id,
-                                   uint32_t value_offset) {
+        auto shared_executor = [op_type,
+                                val,
+                                array_index,
+                                &res_view,
+                                &valid_res_view](milvus::BsonView bson,
+                                                 uint32_t row_id,
+                                                 uint32_t value_offset) {
             auto set_unknown = [&](uint32_t row_id) {
-                res_view[row_id] = false;
+                res_view[row_id] = valid_res_view[row_id] = false;
             };
             auto set_known = [&](uint32_t row_id, bool value) {
                 res_view[row_id] = value;
+                valid_res_view[row_id] = true;
             };
             if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                 Assert(op_type == proto::plan::OpType::Equal ||
@@ -1265,20 +1282,21 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
             index->ExecuteForSharedData(op_ctx_, pointer, shared_executor);
         }
 
-        // for NotEqual: flip the result
+        // for NotEqual: flip the Equal result, then mask out UNKNOWN rows.
         if (expr_->op_type_ == proto::plan::OpType::NotEqual) {
             cached_index_chunk_res_->flip();
         }
+        valid_res_view.inplace_and(field_valid_view, active_count_);
         res_view.inplace_and(valid_res_view, active_count_);
         cached_index_chunk_id_ = 0;
     }
 
-    TargetBitmap result;
-    result.append(
-        *cached_index_chunk_res_, current_data_global_pos_, real_batch_size);
+    auto res = MoveOrSliceBitmap(*cached_index_chunk_res_,
+                                 *cached_index_chunk_valid_res_,
+                                 current_data_global_pos_,
+                                 real_batch_size);
     MoveCursor();
-    return std::make_shared<ColumnVector>(std::move(result),
-                                          TargetBitmap(real_batch_size, true));
+    return res;
 }
 
 template <typename T>

--- a/internal/core/src/exec/expression/UnaryExpr.cpp
+++ b/internal/core/src/exec/expression/UnaryExpr.cpp
@@ -871,9 +871,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJson(EvalCtx& context) {
                         offset = (offsets) ? offsets[i] : i;
                     }
                     if (valid_data != nullptr && !valid_data[offset]) {
-                        // NULL values are not equal to anything
-                        valid_res[i] = false;
-                        res[i] = true;
+                        res[i] = valid_res[i] = false;
                         continue;
                     }
                     if (has_bitmap_input &&
@@ -1016,33 +1014,54 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
         pinned_json_stats_ = segment->GetJsonStats(op_ctx_, field_id);
         auto* index = pinned_json_stats_.get();
         Assert(index != nullptr);
-        cached_index_chunk_res_ =
-            (op_type == proto::plan::OpType::NotEqual)
-                ? std::make_shared<TargetBitmap>(active_count_, true)
-                : std::make_shared<TargetBitmap>(active_count_);
+        cached_index_chunk_res_ = std::make_shared<TargetBitmap>(active_count_);
         cached_index_chunk_valid_res_ =
             std::make_shared<TargetBitmap>(active_count_, true);
         TargetBitmapView res_view(*cached_index_chunk_res_);
         TargetBitmapView valid_res_view(*cached_index_chunk_valid_res_);
+        int64_t valid_processed_size = 0;
+        for (size_t i = 0;
+             i < num_data_chunk_ && valid_processed_size < active_count_;
+             ++i) {
+            int64_t size = segment_->is_chunked()
+                               ? segment_->chunk_size(field_id_, i)
+                               : (i == num_data_chunk_ - 1
+                                      ? active_count_ - valid_processed_size
+                                      : size_per_chunk_);
+            size =
+                std::min<int64_t>(size, active_count_ - valid_processed_size);
+            if (size <= 0) {
+                continue;
+            }
+            segment_->ApplyFieldValidData(
+                op_ctx_,
+                field_id_,
+                i,
+                0,
+                size,
+                valid_res_view + valid_processed_size);
+            valid_processed_size += size;
+        }
 
         // process shredding data
         auto try_execute = [&](milvus::index::JSONType json_type,
-                               TargetBitmapView& res_view,
-                               TargetBitmapView& valid_res_view,
                                auto GetType,
                                auto ValType) {
             auto target_field = index->GetShreddingField(pointer, json_type);
             if (!target_field.empty()) {
                 using ColType = decltype(GetType);
                 using ValType = decltype(ValType);
+                TargetBitmap target_res(active_count_, false);
+                TargetBitmapView target_res_view(target_res);
                 ShreddingExecutor<ColType, ValType> executor(
                     op_type, pointer, val);
                 index->ExecutorForShreddingData<ColType>(op_ctx_,
                                                          target_field,
                                                          executor,
                                                          nullptr,
-                                                         res_view,
-                                                         valid_res_view);
+                                                         target_res_view,
+                                                         target_res_view);
+                res_view.inplace_or_with_count(target_res_view, active_count_);
                 LOG_DEBUG(
                     "using shredding data's field: {} with value {}, count {} "
                     "for segment {}",
@@ -1059,71 +1078,42 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                 [this](double us) { json_stats_shredding_latency_us_ += us; });
 
             if constexpr (std::is_same_v<GetType, bool>) {
-                try_execute(milvus::index::JSONType::BOOL,
-                            res_view,
-                            valid_res_view,
-                            bool{},
-                            bool{});
+                try_execute(milvus::index::JSONType::BOOL, bool{}, bool{});
             } else if constexpr (std::is_same_v<GetType, int64_t>) {
-                try_execute(milvus::index::JSONType::INT64,
-                            res_view,
-                            valid_res_view,
-                            int64_t{},
-                            int64_t{});
+                try_execute(
+                    milvus::index::JSONType::INT64, int64_t{}, int64_t{});
 
                 // and double compare
-                TargetBitmap res_double(active_count_, false);
-                TargetBitmapView res_double_view(res_double);
-                TargetBitmap res_double_valid(active_count_, true);
-                TargetBitmapView valid_res_double_view(res_double_valid);
-                try_execute(milvus::index::JSONType::DOUBLE,
-                            res_double_view,
-                            valid_res_double_view,
-                            double{},
-                            int64_t{});
-                res_view.inplace_or_with_count(res_double_view, active_count_);
-                valid_res_view.inplace_or_with_count(valid_res_double_view,
-                                                     active_count_);
+                try_execute(
+                    milvus::index::JSONType::DOUBLE, double{}, int64_t{});
             } else if constexpr (std::is_same_v<GetType, double>) {
-                try_execute(milvus::index::JSONType::DOUBLE,
-                            res_view,
-                            valid_res_view,
-                            double{},
-                            double{});
+                try_execute(
+                    milvus::index::JSONType::DOUBLE, double{}, double{});
 
                 // add int64 compare
-                TargetBitmap res_int64(active_count_, false);
-                TargetBitmapView res_int64_view(res_int64);
-                TargetBitmap res_int64_valid(active_count_, true);
-                TargetBitmapView valid_res_int64_view(res_int64_valid);
-                try_execute(milvus::index::JSONType::INT64,
-                            res_int64_view,
-                            valid_res_int64_view,
-                            int64_t{},
-                            double{});
-                res_view.inplace_or_with_count(res_int64_view, active_count_);
-                valid_res_view.inplace_or_with_count(valid_res_int64_view,
-                                                     active_count_);
+                try_execute(
+                    milvus::index::JSONType::INT64, int64_t{}, double{});
             } else if constexpr (std::is_same_v<GetType, std::string> ||
                                  std::is_same_v<GetType, std::string_view>) {
-                try_execute(milvus::index::JSONType::STRING,
-                            res_view,
-                            valid_res_view,
-                            GetType{},
-                            GetType{});
+                try_execute(
+                    milvus::index::JSONType::STRING, GetType{}, GetType{});
             } else if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                 // ARRAY shredding data: stored as BSON binary in binary column
                 auto target_field = index->GetShreddingField(
                     pointer, milvus::index::JSONType::ARRAY);
                 if (!target_field.empty()) {
+                    TargetBitmap target_res(active_count_, false);
+                    TargetBitmapView target_res_view(target_res);
                     ShreddingArrayBsonExecutor executor(op_type, pointer, val);
                     index->template ExecutorForShreddingData<std::string_view>(
                         op_ctx_,
                         target_field,
                         executor,
                         nullptr,
-                        res_view,
-                        valid_res_view);
+                        target_res_view,
+                        target_res_view);
+                    res_view.inplace_or_with_count(target_res_view,
+                                                   active_count_);
                     LOG_DEBUG("using shredding array field: {}, count {}",
                               target_field,
                               res_view.count());
@@ -1136,50 +1126,51 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                                    milvus::BsonView bson,
                                    uint32_t row_id,
                                    uint32_t value_offset) {
+            auto set_unknown = [&](uint32_t row_id) {
+                res_view[row_id] = false;
+            };
+            auto set_known = [&](uint32_t row_id, bool value) {
+                res_view[row_id] = value;
+            };
             if constexpr (std::is_same_v<GetType, proto::plan::Array>) {
                 Assert(op_type == proto::plan::OpType::Equal ||
                        op_type == proto::plan::OpType::NotEqual);
                 if (array_index != INVALID_ARRAY_INDEX) {
                     auto array_value = bson.ParseAsArrayAtOffset(value_offset);
                     if (!array_value.has_value()) {
-                        // For NotEqual: path not exists means "not equal", keep true
-                        // For Equal: path not exists means no match, set false
-                        res_view[row_id] =
-                            (op_type == proto::plan::OpType::NotEqual);
+                        set_unknown(row_id);
                         return;
                     }
                     auto sub_array = milvus::BsonView::GetNthElementInArray<
                         bsoncxx::array::view>(array_value.value().data(),
                                               array_index);
                     if (!sub_array.has_value()) {
-                        res_view[row_id] =
-                            (op_type == proto::plan::OpType::NotEqual);
+                        set_unknown(row_id);
                         return;
                     }
-                    res_view[row_id] =
+                    set_known(
+                        row_id,
                         op_type == proto::plan::OpType::Equal
                             ? CompareTwoJsonArray(sub_array.value(), val)
-                            : !CompareTwoJsonArray(sub_array.value(), val);
+                            : !CompareTwoJsonArray(sub_array.value(), val));
                 } else {
                     auto array_value = bson.ParseAsArrayAtOffset(value_offset);
                     if (!array_value.has_value()) {
-                        res_view[row_id] =
-                            (op_type == proto::plan::OpType::NotEqual);
+                        set_unknown(row_id);
                         return;
                     }
-                    res_view[row_id] =
+                    set_known(
+                        row_id,
                         op_type == proto::plan::OpType::Equal
                             ? CompareTwoJsonArray(array_value.value(), val)
-                            : !CompareTwoJsonArray(array_value.value(), val);
+                            : !CompareTwoJsonArray(array_value.value(), val));
                 }
             } else {
                 std::optional<GetType> get_value;
                 if (array_index != INVALID_ARRAY_INDEX) {
                     auto array_value = bson.ParseAsArrayAtOffset(value_offset);
                     if (!array_value.has_value()) {
-                        // Path not exists: NotEqual->true, others->false
-                        res_view[row_id] =
-                            (op_type == proto::plan::OpType::NotEqual);
+                        set_unknown(row_id);
                         return;
                     }
                     get_value = milvus::BsonView::GetNthElementInArray<GetType>(
@@ -1191,12 +1182,11 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                                 milvus::BsonView::GetNthElementInArray<double>(
                                     array_value.value().data(), array_index);
                             if (get_value.has_value()) {
-                                res_view[row_id] = UnaryCompare(
-                                    get_value.value(), val, op_type);
+                                set_known(row_id,
+                                          UnaryCompare(
+                                              get_value.value(), val, op_type));
                             } else {
-                                // Type mismatch: NotEqual->true, others->false
-                                res_view[row_id] =
-                                    (op_type == proto::plan::OpType::NotEqual);
+                                set_unknown(row_id);
                             }
                             return;
                         }
@@ -1206,11 +1196,11 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                                 milvus::BsonView::GetNthElementInArray<int64_t>(
                                     array_value.value().data(), array_index);
                             if (get_value.has_value()) {
-                                res_view[row_id] = UnaryCompare(
-                                    get_value.value(), val, op_type);
+                                set_known(row_id,
+                                          UnaryCompare(
+                                              get_value.value(), val, op_type));
                             } else {
-                                res_view[row_id] =
-                                    (op_type == proto::plan::OpType::NotEqual);
+                                set_unknown(row_id);
                             }
                             return;
                         }
@@ -1224,11 +1214,11 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                             auto get_value =
                                 bson.ParseAsValueAtOffset<double>(value_offset);
                             if (get_value.has_value()) {
-                                res_view[row_id] = UnaryCompare(
-                                    get_value.value(), val, op_type);
+                                set_known(row_id,
+                                          UnaryCompare(
+                                              get_value.value(), val, op_type));
                             } else {
-                                res_view[row_id] =
-                                    (op_type == proto::plan::OpType::NotEqual);
+                                set_unknown(row_id);
                             }
                             return;
                         }
@@ -1237,23 +1227,22 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
                             auto get_value = bson.ParseAsValueAtOffset<int64_t>(
                                 value_offset);
                             if (get_value.has_value()) {
-                                res_view[row_id] = UnaryCompare(
-                                    get_value.value(), val, op_type);
+                                set_known(row_id,
+                                          UnaryCompare(
+                                              get_value.value(), val, op_type));
                             } else {
-                                res_view[row_id] =
-                                    (op_type == proto::plan::OpType::NotEqual);
+                                set_unknown(row_id);
                             }
                             return;
                         }
                     }
                 }
                 if (!get_value.has_value()) {
-                    res_view[row_id] =
-                        (op_type == proto::plan::OpType::NotEqual);
+                    set_unknown(row_id);
                     return;
                 }
-                res_view[row_id] =
-                    UnaryCompare(get_value.value(), val, op_type);
+                set_known(row_id,
+                          UnaryCompare(get_value.value(), val, op_type));
             }
         };
 
@@ -1280,6 +1269,7 @@ PhyUnaryRangeFilterExpr::ExecRangeVisitorImplJsonByStats() {
         if (expr_->op_type_ == proto::plan::OpType::NotEqual) {
             cached_index_chunk_res_->flip();
         }
+        res_view.inplace_and(valid_res_view, active_count_);
         cached_index_chunk_id_ = 0;
     }
 

--- a/internal/core/src/exec/expression/UnaryExpr.h
+++ b/internal/core/src/exec/expression/UnaryExpr.h
@@ -706,7 +706,7 @@ class ShreddingArrayBsonExecutor {
                 reinterpret_cast<const uint8_t*>(src[i].data()), src[i].size());
             auto array_view = bson.ParseAsArrayAtOffset(0);
             if (!array_view.has_value()) {
-                res[i] = false;
+                res[i] = valid_res[i] = false;
                 continue;
             }
             bool equal = CompareTwoJsonArray(array_view.value(), val_);

--- a/internal/core/src/exec/operator/FilterBitsNode.cpp
+++ b/internal/core/src/exec/operator/FilterBitsNode.cpp
@@ -23,6 +23,25 @@
 
 namespace milvus {
 namespace exec {
+
+namespace {
+
+void
+ConvertPredicateToFilteredBitset(TargetBitmapView data,
+                                 TargetBitmapView valid,
+                                 const size_t size) {
+    // FilterBitsNode outputs a filtered-row bitset: 1 means excluded. A SQL-style
+    // predicate passes only when it is definitely TRUE, so UNKNOWN/NULL must be
+    // excluded together with FALSE.
+    data.flip();
+    TargetBitmap invalid(valid);
+    invalid.flip();
+    data.inplace_or(invalid, size);
+    valid.set();
+}
+
+}  // namespace
+
 PhyFilterBitsNode::PhyFilterBitsNode(
     int32_t operator_id,
     DriverContext* driverctx,
@@ -119,7 +138,11 @@ PhyFilterBitsNode::GetOutput() {
                       "PhyFilterBitsNode result should be ColumnVector");
         }
     }
-    bitset.flip();
+    TargetBitmapView bitset_view(bitset);
+    TargetBitmapView valid_bitset_view(valid_bitset);
+    ConvertPredicateToFilteredBitset(
+        bitset_view, valid_bitset_view, bitset.size());
+
     AssertInfo(bitset.size() == need_process_rows_,
                "bitset size: {}, need_process_rows_: {}",
                bitset.size(),

--- a/internal/core/src/index/StringIndexMarisa.cpp
+++ b/internal/core/src/index/StringIndexMarisa.cpp
@@ -27,6 +27,7 @@
 #include <iosfwd>
 #include <memory>
 #include <optional>
+#include <system_error>
 #include <type_traits>
 
 #include "bitset/bitset.h"
@@ -729,7 +730,12 @@ StringIndexMarisa::WriteEntries(storage::IndexEntryWriter* writer) {
         storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     std::string tmp_dir =
         local_cm ? local_cm->GetRootPath() : std::string("/tmp");
-    std::filesystem::create_directories(tmp_dir);
+    std::error_code ec;
+    std::filesystem::create_directories(tmp_dir, ec);
+    AssertInfo(!ec,
+               "failed to create string index temp directory: {}, error: {}",
+               tmp_dir,
+               ec.message());
     auto uuid = boost::uuids::random_generator()();
     auto uuid_string = boost::uuids::to_string(uuid);
     auto file = tmp_dir + "/" + uuid_string;
@@ -764,7 +770,12 @@ StringIndexMarisa::LoadEntries(storage::IndexEntryReader& reader,
         storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
     std::string tmp_dir =
         local_cm ? local_cm->GetRootPath() : std::string("/tmp");
-    std::filesystem::create_directories(tmp_dir);
+    std::error_code ec;
+    std::filesystem::create_directories(tmp_dir, ec);
+    AssertInfo(!ec,
+               "failed to create string index temp directory: {}, error: {}",
+               tmp_dir,
+               ec.message());
     auto uuid = boost::uuids::random_generator()();
     auto uuid_string = boost::uuids::to_string(uuid);
     auto file_name = tmp_dir + "/" + uuid_string;

--- a/internal/core/src/index/StringIndexTest.cpp
+++ b/internal/core/src/index/StringIndexTest.cpp
@@ -13,10 +13,12 @@
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <numeric>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -35,6 +37,7 @@
 #include "pb/common.pb.h"
 #include "pb/schema.pb.h"
 #include "storage/ChunkManager.h"
+#include "storage/LocalChunkManagerSingleton.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
 #include "test_utils/AssertUtils.h"
@@ -48,10 +51,11 @@ namespace milvus {
 namespace index {
 
 static storage::FileManagerContext
-CreateStringTestFileManagerContext() {
+CreateStringTestFileManagerContext(const std::string& root_path) {
+    std::filesystem::create_directories(root_path);
     storage::StorageConfig storage_config;
     storage_config.storage_type = "local";
-    storage_config.root_path = TestLocalPath;
+    storage_config.root_path = root_path;
     auto chunk_manager = storage::CreateChunkManager(storage_config);
     auto fs = storage::InitArrowFileSystem(storage_config);
     storage::FieldDataMeta field_meta{1, 2, 3, 101};
@@ -59,6 +63,11 @@ CreateStringTestFileManagerContext() {
     storage::IndexMeta index_meta{3, 101, 1000, 10000};
     storage::FileManagerContext ctx(field_meta, index_meta, chunk_manager, fs);
     return ctx;
+}
+
+static storage::FileManagerContext
+CreateStringTestFileManagerContext() {
+    return CreateStringTestFileManagerContext(TestLocalPath);
 }
 
 class StringIndexBaseTest : public ::testing::Test {
@@ -421,6 +430,49 @@ TEST_F(StringIndexMarisaTest, Codec) {
             ASSERT_TRUE(bitset[i]);
         }
     }
+}
+
+TEST_F(StringIndexMarisaTest, UnifiedCodecRecreatesMissingLocalChunkDir) {
+    auto file_manager_ctx = CreateStringTestFileManagerContext(
+        TestRemotePath + "string_marisa_missing_local_chunk/");
+    auto index = milvus::index::CreateStringIndexMarisa(file_manager_ctx);
+    std::vector<std::string> strings(nb);
+    for (int i = 0; i < nb; ++i) {
+        strings[i] = std::to_string(std::rand() % 10);
+    }
+
+    index->Build(nb, strings.data());
+
+    auto local_cm =
+        storage::LocalChunkManagerSingleton::GetInstance().GetChunkManager();
+    ASSERT_NE(local_cm, nullptr);
+    auto local_root = local_cm->GetRootPath();
+    ASSERT_FALSE(local_root.empty());
+
+    std::error_code ec;
+    std::filesystem::remove_all(local_root, ec);
+    ASSERT_FALSE(ec) << ec.message();
+    ASSERT_FALSE(std::filesystem::exists(local_root));
+
+    auto create_index_result = index->UploadUnified({});
+    ASSERT_TRUE(std::filesystem::is_directory(local_root));
+    auto index_files = create_index_result->GetIndexFiles();
+
+    std::filesystem::remove_all(local_root, ec);
+    ASSERT_FALSE(ec) << ec.message();
+    ASSERT_FALSE(std::filesystem::exists(local_root));
+
+    auto copy_index = milvus::index::CreateStringIndexMarisa(file_manager_ctx);
+    Config load_config;
+    load_config["index_files"] = index_files;
+    load_config[milvus::LOAD_PRIORITY] =
+        milvus::proto::common::LoadPriority::HIGH;
+    copy_index->LoadUnified(load_config);
+    ASSERT_TRUE(std::filesystem::is_directory(local_root));
+
+    auto bitset = copy_index->In(nb, strings.data());
+    ASSERT_EQ(bitset.size(), nb);
+    ASSERT_TRUE(bitset.any());
 }
 
 TEST_F(StringIndexMarisaTest, BaseIndexCodec) {

--- a/internal/core/src/index/TextMatchIndexTest.cpp
+++ b/internal/core/src/index/TextMatchIndexTest.cpp
@@ -1201,6 +1201,7 @@ TEST(TextMatch, ConcurrentReadWriteWithNull) {
     for (int64_t i = 0; i < N - 1; i++) {
         str_col_valid->at(i) = false;
     }
+    str_col_valid->at(N - 1) = true;
 
     std::thread writer([&seg, &raw_data, N]() {
         seg->PreInsert(N);
@@ -1216,7 +1217,7 @@ TEST(TextMatch, ConcurrentReadWriteWithNull) {
         ;
         const std::chrono::seconds timeout_duration{2};
         while (true) {
-            if (start - std::chrono::high_resolution_clock::now() >
+            if (std::chrono::high_resolution_clock::now() - start >
                 timeout_duration) {
                 ASSERT_TRUE(false)
                     << "Failed to get valid results within timeout";

--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -747,7 +747,10 @@ JsonKeyStats::BuildWithFieldData(const std::vector<FieldDataPtr>& field_datas) {
         ParquetWriterFactory::CreateContext(key_types_, remote_prefix);
     parquet_writer_->Init(std::move(writer_context));
     BuildKeyStats(field_datas);
-    parquet_writer_->Close();
+    auto close_status = parquet_writer_->Close();
+    AssertInfo(close_status.ok(),
+               "failed to close json stats parquet writer: {}",
+               close_status.ToString());
     bson_inverted_index_->BuildIndex();
 
     // write meta file with layout type map and other metadata

--- a/internal/core/src/index/json_stats/parquet_writer.cpp
+++ b/internal/core/src/index/json_stats/parquet_writer.cpp
@@ -19,9 +19,14 @@
 #include <arrow/array/array_primitive.h>
 #include <arrow/array/builder_binary.h>
 #include <arrow/array/builder_primitive.h>
+#include <exception>
 #include <arrow/io/file.h>
 #include <parquet/arrow/writer.h>
 #include <parquet/exception.h>
+#include <utility>
+
+#include "arrow/array/builder_base.h"
+#include "milvus-storage/packed/writer.h"
 
 namespace milvus::index {
 
@@ -41,22 +46,37 @@ JsonStatsParquetWriter::JsonStatsParquetWriter(
 }
 
 JsonStatsParquetWriter::~JsonStatsParquetWriter() {
-    Close();
-}
-
-void
-JsonStatsParquetWriter::Close() {
-    // check packed_writer_ initialized
-    if (packed_writer_) {
-        Flush();
-        // ignore close status here
-        auto _ = packed_writer_->Close();
+    try {
+        auto status = Close();
+        if (!status.ok()) {
+            LOG_WARN("failed to close json stats parquet writer: {}",
+                     status.ToString());
+        }
+    } catch (const std::exception& e) {
+        LOG_WARN("failed to close json stats parquet writer: {}", e.what());
     }
 }
 
-void
+arrow::Status
+JsonStatsParquetWriter::Close() {
+    if (!packed_writer_) {
+        return arrow::Status::OK();
+    }
+    auto flush_status = Flush();
+    if (!flush_status.ok()) {
+        return flush_status;
+    }
+    auto writer = std::move(packed_writer_);
+    return writer->Close();
+}
+
+arrow::Status
 JsonStatsParquetWriter::Flush() {
-    WriteCurrentBatch();
+    auto res = WriteCurrentBatch();
+    if (!res.ok()) {
+        return res.status();
+    }
+    return arrow::Status::OK();
 }
 
 void
@@ -74,7 +94,7 @@ JsonStatsParquetWriter::UpdatePathSizeMap(
     }
 }
 
-size_t
+arrow::Result<size_t>
 JsonStatsParquetWriter::WriteCurrentBatch() {
     if (unflushed_row_count_ == 0) {
         return 0;
@@ -85,8 +105,9 @@ JsonStatsParquetWriter::WriteCurrentBatch() {
     for (auto& builder : builders_) {
         std::shared_ptr<arrow::Array> array;
         auto status = builder->Finish(&array);
-        AssertInfo(
-            status.ok(), "failed to finish builder: {}", status.ToString());
+        if (!status.ok()) {
+            return status;
+        }
         arrays.push_back(std::move(array));
         builder->Reset();
     }
@@ -96,8 +117,10 @@ JsonStatsParquetWriter::WriteCurrentBatch() {
     auto batch = arrow::RecordBatch::Make(
         schema_, unflushed_row_count_, std::move(arrays));
     auto status = packed_writer_->Write(batch);
-    AssertInfo(
-        status.ok(), "failed to write batch, error: {}", status.ToString());
+    if (!status.ok()) {
+        unflushed_row_count_ = 0;
+        return status;
+    }
 
     auto res = unflushed_row_count_;
     unflushed_row_count_ = 0;
@@ -132,7 +155,10 @@ JsonStatsParquetWriter::AddCurrentRow() {
     unflushed_row_count_++;
     all_row_count_++;
     if (unflushed_row_count_ >= batch_size_) {
-        WriteCurrentBatch();
+        auto result = WriteCurrentBatch();
+        AssertInfo(result.ok(),
+                   "failed to write current json stats parquet batch: {}",
+                   result.status().ToString());
     }
     return all_row_count_;
 }

--- a/internal/core/src/index/json_stats/parquet_writer.h
+++ b/internal/core/src/index/json_stats/parquet_writer.h
@@ -189,13 +189,13 @@ class JsonStatsParquetWriter {
     void
     AppendSharedRow(const uint8_t* data, size_t length);
 
-    void
+    arrow::Status
     Flush();
 
-    void
+    arrow::Status
     Close();
 
-    size_t
+    arrow::Result<size_t>
     WriteCurrentBatch();
 
     size_t

--- a/internal/core/src/storage/IndexEntryReader.cpp
+++ b/internal/core/src/storage/IndexEntryReader.cpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <cstring>
 #include <deque>
+#include <exception>
 #include <functional>
 #include <future>
 #include <limits>
@@ -49,6 +50,46 @@ struct ActiveSliceTask {
     std::shared_ptr<StreamSliceResult> result;
     std::future<void> future;
 };
+
+void
+RememberFirstError(std::exception_ptr& first_error, std::exception_ptr error) {
+    if (error && !first_error) {
+        first_error = std::move(error);
+    }
+}
+
+std::exception_ptr
+WaitForAllFutures(std::vector<std::future<void>>& futures) {
+    std::exception_ptr first_error = nullptr;
+    for (auto& future : futures) {
+        if (!future.valid()) {
+            continue;
+        }
+        try {
+            future.get();
+        } catch (...) {
+            RememberFirstError(first_error, std::current_exception());
+        }
+    }
+    return first_error;
+}
+
+void
+RethrowIfError(const std::exception_ptr& error) {
+    if (error) {
+        std::rethrow_exception(error);
+    }
+}
+
+constexpr size_t kEntryDownloadRangeSize = 16 * 1024 * 1024;
+
+size_t
+EntryDownloadRangeCount(uint64_t size) {
+    if (size == 0) {
+        return 0;
+    }
+    return static_cast<size_t>((size - 1) / kEntryDownloadRangeSize + 1);
+}
 
 void
 ReadOrderedEntryStream(
@@ -419,9 +460,7 @@ IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
     Entry result;
     result.data.resize(pm.size);
 
-    constexpr size_t kRangeSize = 16 * 1024 * 1024;
-
-    if (pm.size <= kRangeSize) {
+    if (pm.size <= kEntryDownloadRangeSize) {
         size_t n = input_->ReadAt(
             result.data.data(), MILVUS_V3_MAGIC_SIZE + pm.offset, pm.size);
         AssertInfo(n == pm.size, "Failed to read entry data");
@@ -435,26 +474,34 @@ IndexEntryReader::ReadPlainEntry(const EntryMeta& meta) {
     std::vector<std::future<void>> futures;
     size_t remaining = pm.size;
     size_t offset = 0;
+    std::exception_ptr first_error = nullptr;
 
-    while (remaining > 0) {
-        size_t len = std::min(remaining, kRangeSize);
-        size_t this_offset = offset;
+    try {
+        auto input = input_;
+        size_t entry_offset = pm.offset;
+        futures.reserve(EntryDownloadRangeCount(pm.size));
+        while (remaining > 0) {
+            size_t len = std::min(remaining, kEntryDownloadRangeSize);
+            size_t this_offset = offset;
 
-        futures.push_back(pool.Submit([this, dest, this_offset, len, &pm]() {
-            size_t n =
-                input_->ReadAt(dest + this_offset,
-                               MILVUS_V3_MAGIC_SIZE + pm.offset + this_offset,
-                               len);
-            AssertInfo(n == len, "Failed to read entry data range");
-        }));
+            futures.push_back(
+                pool.Submit([input, dest, this_offset, len, entry_offset]() {
+                    size_t n = input->ReadAt(
+                        dest + this_offset,
+                        MILVUS_V3_MAGIC_SIZE + entry_offset + this_offset,
+                        len);
+                    AssertInfo(n == len, "Failed to read entry data range");
+                }));
 
-        remaining -= len;
-        offset += len;
+            remaining -= len;
+            offset += len;
+        }
+    } catch (...) {
+        first_error = std::current_exception();
     }
 
-    for (auto& f : futures) {
-        f.get();
-    }
+    RememberFirstError(first_error, WaitForAllFutures(futures));
+    RethrowIfError(first_error);
 
     // CRC verification: sequential pass over the assembled buffer
     VerifyCrc32c(pm.crc32, result.data.data(), pm.size, "");
@@ -473,23 +520,38 @@ IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
 
     std::vector<std::future<void>> futures;
     size_t cur_output_offset = 0;
+    std::exception_ptr first_error = nullptr;
 
-    for (const auto& slice : em.slices) {
-        size_t this_output_offset = cur_output_offset;
-        size_t remaining = em.original_size - cur_output_offset;
-        size_t plain_len = std::min(remaining, slice_size_);
-        cur_output_offset += plain_len;
+    try {
+        auto input = input_;
+        auto cipher_plugin = cipher_plugin_;
+        int64_t ez_id = ez_id_;
+        int64_t collection_id = collection_id_;
+        auto edek = edek_;
+        futures.reserve(em.slices.size());
+        for (const auto& slice : em.slices) {
+            size_t this_output_offset = cur_output_offset;
+            size_t remaining = em.original_size - cur_output_offset;
+            size_t plain_len = std::min(remaining, slice_size_);
+            cur_output_offset += plain_len;
 
-        futures.push_back(
-            pool.Submit([this, slice, dest, this_output_offset, plain_len]() {
+            futures.push_back(pool.Submit([input,
+                                           cipher_plugin,
+                                           ez_id,
+                                           collection_id,
+                                           edek,
+                                           slice,
+                                           dest,
+                                           this_output_offset,
+                                           plain_len]() {
                 std::vector<uint8_t> cipher(slice.size);
-                size_t n = input_->ReadAt(cipher.data(),
-                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
-                                          slice.size);
+                size_t n = input->ReadAt(cipher.data(),
+                                         MILVUS_V3_MAGIC_SIZE + slice.offset,
+                                         slice.size);
                 AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
                 auto dec =
-                    cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
+                    cipher_plugin->GetDecryptor(ez_id, collection_id, edek);
                 auto plain = dec->Decrypt(cipher.data(), cipher.size());
 
                 AssertInfo(plain.size() == plain_len,
@@ -499,11 +561,13 @@ IndexEntryReader::ReadEncryptedEntry(const EntryMeta& meta) {
                 std::memcpy(
                     dest + this_output_offset, plain.data(), plain.size());
             }));
+        }
+    } catch (...) {
+        first_error = std::current_exception();
     }
 
-    for (auto& f : futures) {
-        f.get();
-    }
+    RememberFirstError(first_error, WaitForAllFutures(futures));
+    RethrowIfError(first_error);
 
     // CRC verification over full plaintext buffer
     VerifyCrc32c(em.crc32, result.data.data(), em.original_size, "");
@@ -515,8 +579,6 @@ IndexEntryReader::EntryDownloadState
 IndexEntryReader::PrepareEntryDownload(const std::string& name,
                                        const std::string& local_path,
                                        const EntryMeta& meta) {
-    constexpr size_t kRangeSize = 16 * 1024 * 1024;
-
     int fd = ::open(local_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
     AssertInfo(fd != -1, "Failed to create file: {}", local_path);
 
@@ -535,7 +597,7 @@ IndexEntryReader::PrepareEntryDownload(const std::string& name,
                        strerror(errno));
         } else {
             state.expected_crc = meta.plain.crc32;
-            size_t num_ranges = (meta.plain.size + kRangeSize - 1) / kRangeSize;
+            size_t num_ranges = EntryDownloadRangeCount(meta.plain.size);
             state.range_crcs.resize(num_ranges);
         }
     } catch (...) {
@@ -551,12 +613,19 @@ IndexEntryReader::SubmitEntryDownloadTasks(
     const EntryMeta& meta,
     EntryDownloadState& state,
     std::vector<std::future<void>>& futures) {
-    constexpr size_t kRangeSize = 16 * 1024 * 1024;
     auto& pool = ThreadPools::GetThreadPool(priority_);
+    futures.reserve(futures.size() + (meta.encrypted ? meta.enc.slices.size()
+                                                     : EntryDownloadRangeCount(
+                                                           meta.plain.size)));
 
     if (meta.encrypted) {
         const auto& em = meta.enc;
         size_t output_offset = 0;
+        auto input = input_;
+        auto cipher_plugin = cipher_plugin_;
+        int64_t ez_id = ez_id_;
+        int64_t collection_id = collection_id_;
+        auto edek = edek_;
 
         for (size_t i = 0; i < em.slices.size(); i++) {
             const auto& slice = em.slices[i];
@@ -565,7 +634,11 @@ IndexEntryReader::SubmitEntryDownloadTasks(
             size_t plain_len = std::min(remaining, slice_size_);
             output_offset += plain_len;
 
-            futures.push_back(pool.Submit([this,
+            futures.push_back(pool.Submit([input,
+                                           cipher_plugin,
+                                           ez_id,
+                                           collection_id,
+                                           edek,
                                            slice,
                                            fd = state.fd,
                                            this_output_offset,
@@ -573,13 +646,13 @@ IndexEntryReader::SubmitEntryDownloadTasks(
                                            i,
                                            &state]() {
                 std::vector<uint8_t> cipher(slice.size);
-                size_t n = input_->ReadAt(cipher.data(),
-                                          MILVUS_V3_MAGIC_SIZE + slice.offset,
-                                          slice.size);
+                size_t n = input->ReadAt(cipher.data(),
+                                         MILVUS_V3_MAGIC_SIZE + slice.offset,
+                                         slice.size);
                 AssertInfo(n == slice.size, "Failed to read encrypted slice");
 
                 auto dec =
-                    cipher_plugin_->GetDecryptor(ez_id_, collection_id_, edek_);
+                    cipher_plugin->GetDecryptor(ez_id, collection_id, edek);
                 auto plain = dec->Decrypt(cipher.data(), cipher.size());
 
                 AssertInfo(plain.size() == plain_len,
@@ -602,14 +675,15 @@ IndexEntryReader::SubmitEntryDownloadTasks(
         size_t file_offset = 0;
         size_t src_offset = pm.offset;
         size_t range_idx = 0;
+        auto input = input_;
 
         while (remaining > 0) {
-            size_t len = std::min(remaining, kRangeSize);
+            size_t len = std::min(remaining, kEntryDownloadRangeSize);
             size_t this_file_offset = file_offset;
             size_t this_src_offset = src_offset;
             size_t this_range_idx = range_idx;
 
-            futures.push_back(pool.Submit([this,
+            futures.push_back(pool.Submit([input,
                                            this_src_offset,
                                            len,
                                            fd = state.fd,
@@ -617,7 +691,7 @@ IndexEntryReader::SubmitEntryDownloadTasks(
                                            this_range_idx,
                                            &state]() {
                 std::vector<uint8_t> buf(len);
-                size_t n = input_->ReadAt(
+                size_t n = input->ReadAt(
                     buf.data(), MILVUS_V3_MAGIC_SIZE + this_src_offset, len);
                 AssertInfo(n == len, "Failed to read data for file");
                 auto written = ::pwrite(fd, buf.data(), len, this_file_offset);
@@ -663,18 +737,21 @@ IndexEntryReader::ReadEntryToFile(const std::string& name,
     const auto& meta = it->second;
 
     auto state = PrepareEntryDownload(name, local_path, meta);
+    std::vector<std::future<void>> futures;
     try {
-        std::vector<std::future<void>> futures;
+        futures.reserve(meta.encrypted
+                            ? meta.enc.slices.size()
+                            : EntryDownloadRangeCount(meta.plain.size));
         SubmitEntryDownloadTasks(meta, state, futures);
 
-        for (auto& f : futures) {
-            f.get();
-        }
+        RethrowIfError(WaitForAllFutures(futures));
 
         FinalizeEntryDownload(state);
     } catch (...) {
+        WaitForAllFutures(futures);
         if (state.fd != -1) {
             ::close(state.fd);
+            state.fd = -1;
         }
         throw;
     }
@@ -701,30 +778,35 @@ IndexEntryReader::ReadEntriesToFiles(
         }
     };
 
+    std::vector<std::future<void>> all_futures;
     try {
+        size_t total_task_count = 0;
         for (const auto& [name, path] : name_path_pairs) {
             auto it = entry_index_.find(name);
             AssertInfo(it != entry_index_.end(), "Entry not found: {}", name);
             states.push_back(PrepareEntryDownload(name, path, it->second));
+            total_task_count +=
+                it->second.encrypted
+                    ? it->second.enc.slices.size()
+                    : EntryDownloadRangeCount(it->second.plain.size);
         }
 
         // Submit ALL tasks for ALL entries at once (avoids thread pool deadlock)
-        std::vector<std::future<void>> all_futures;
+        all_futures.reserve(total_task_count);
         for (size_t i = 0; i < name_path_pairs.size(); i++) {
             const auto& meta = entry_index_.at(name_path_pairs[i].first);
             SubmitEntryDownloadTasks(meta, states[i], all_futures);
         }
 
         // Wait for ALL tasks to complete
-        for (auto& f : all_futures) {
-            f.get();
-        }
+        RethrowIfError(WaitForAllFutures(all_futures));
 
         // Verify CRCs and close all file descriptors
         for (auto& state : states) {
             FinalizeEntryDownload(state);
         }
     } catch (...) {
+        WaitForAllFutures(all_futures);
         close_all_fds();
         throw;
     }

--- a/internal/core/src/storage/IndexEntryWriterTest.cpp
+++ b/internal/core/src/storage/IndexEntryWriterTest.cpp
@@ -14,6 +14,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -164,6 +165,7 @@ class DelayedFailingInputStream : public milvus::InputStream {
         size_t offset;
         std::chrono::milliseconds delay;
         bool fail;
+        std::shared_ptr<std::atomic<int>> completion_count = nullptr;
     };
 
     DelayedFailingInputStream(std::shared_ptr<milvus::InputStream> base,
@@ -201,6 +203,10 @@ class DelayedFailingInputStream : public milvus::InputStream {
         for (const auto& rule : rules_) {
             if (rule.offset == offset) {
                 std::this_thread::sleep_for(rule.delay);
+                if (rule.completion_count) {
+                    rule.completion_count->fetch_add(1,
+                                                     std::memory_order_relaxed);
+                }
                 if (rule.fail) {
                     return 0;
                 }
@@ -729,6 +735,42 @@ TEST_F(IndexEntryWriterV3Test, ReadEntriesToFilesMultiRangeParallel) {
     ::unlink(file_a.c_str());
     ::unlink(file_b.c_str());
     ::unlink(file_c.c_str());
+}
+
+TEST_F(IndexEntryWriterV3Test, ReadEntriesToFilesDrainsFuturesAfterReadError) {
+    const std::string file_path = kV3FilePath + "_tofiles_drain_error";
+    constexpr size_t kRangeSize = 16 * 1024 * 1024;
+    const size_t entry_size = 2 * kRangeSize + 1024;
+    auto data = GeneratePattern(entry_size);
+
+    {
+        auto output = CreateOutputStream(file_path);
+        IndexEntryDirectStreamWriter writer(output);
+        writer.WriteEntry("entry", data.data(), data.size());
+        writer.Finish();
+    }
+
+    auto slow_read_done = std::make_shared<std::atomic<int>>(0);
+    auto base_input = CreateInputStream(file_path);
+    auto input = std::make_shared<DelayedFailingInputStream>(
+        base_input,
+        std::vector<DelayedFailingInputStream::Rule>{
+            {MILVUS_V3_MAGIC_SIZE, std::chrono::milliseconds(0), true},
+            {MILVUS_V3_MAGIC_SIZE + kRangeSize,
+             std::chrono::milliseconds(200),
+             false,
+             slow_read_done},
+        });
+    int64_t file_size = GetFileSize(file_path);
+    auto reader = IndexEntryReader::Open(input, file_size);
+
+    std::string local_file = GetRootPath() + "/drain_error_output.bin";
+    std::vector<std::pair<std::string, std::string>> pairs = {
+        {"entry", local_file}};
+    EXPECT_THROW(reader->ReadEntriesToFiles(pairs), milvus::SegcoreError);
+    EXPECT_EQ(slow_read_done->load(std::memory_order_relaxed), 1);
+
+    ::unlink(local_file.c_str());
 }
 
 // =============================================================================

--- a/internal/core/unittest/test_json_stats/test_parquet_writer.cpp
+++ b/internal/core/unittest/test_json_stats/test_parquet_writer.cpp
@@ -1,14 +1,91 @@
 #include <gtest/gtest.h>
-#include "index/json_stats/parquet_writer.h"
-#include <arrow/io/memory.h>
+#include <arrow/filesystem/localfs.h>
 #include <arrow/io/file.h>
+#include <arrow/io/interfaces.h>
+#include <arrow/io/memory.h>
+#include <arrow/result.h>
+#include <filesystem>
+#include <map>
 #include <parquet/arrow/writer.h>
 #include <memory>
+#include <set>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
-#include <map>
+
+#include "index/json_stats/parquet_writer.h"
+#include "index/json_stats/utils.h"
+#include "storage/Util.h"
+#include "test_utils/Constants.h"
 
 namespace milvus::index {
+namespace {
+
+class CloseFailingOutputStream : public arrow::io::OutputStream {
+ public:
+    explicit CloseFailingOutputStream(
+        std::shared_ptr<arrow::io::OutputStream> delegate)
+        : delegate_(std::move(delegate)) {
+        set_mode(arrow::io::FileMode::WRITE);
+    }
+
+    arrow::Status
+    Close() override {
+        closed_ = true;
+        auto status = delegate_->Close();
+        if (!status.ok()) {
+            return status;
+        }
+        return arrow::Status::IOError("injected final close failure");
+    }
+
+    bool
+    closed() const override {
+        return closed_ || delegate_->closed();
+    }
+
+    arrow::Result<int64_t>
+    Tell() const override {
+        return delegate_->Tell();
+    }
+
+    arrow::Status
+    Write(const void* data, int64_t nbytes) override {
+        return delegate_->Write(data, nbytes);
+    }
+
+    arrow::Status
+    Flush() override {
+        return delegate_->Flush();
+    }
+
+    using arrow::io::Writable::Write;
+
+ private:
+    std::shared_ptr<arrow::io::OutputStream> delegate_;
+    bool closed_{false};
+};
+
+class CloseFailingLocalFileSystem : public arrow::fs::LocalFileSystem {
+ public:
+    using arrow::fs::LocalFileSystem::LocalFileSystem;
+
+    arrow::Result<std::shared_ptr<arrow::io::OutputStream>>
+    OpenOutputStream(const std::string& path,
+                     const std::shared_ptr<const arrow::KeyValueMetadata>&
+                         metadata) override {
+        auto result =
+            arrow::fs::LocalFileSystem::OpenOutputStream(path, metadata);
+        if (!result.ok()) {
+            return result.status();
+        }
+        return std::make_shared<CloseFailingOutputStream>(result.ValueOrDie());
+    }
+};
+
+}  // namespace
+
 class ParquetWriterFactoryTest : public ::testing::Test {
  protected:
     void
@@ -29,6 +106,23 @@ class ParquetWriterFactoryTest : public ::testing::Test {
     std::map<JsonKey, JsonKeyLayoutType> column_map_;
     std::string path_prefix_;
 };
+
+namespace {
+
+milvus_storage::StorageConfig
+CreatePackedWriterStorageConfig() {
+    return milvus_storage::StorageConfig{};
+}
+
+milvus_storage::ArrowFileSystemPtr
+CreateLocalArrowFileSystem() {
+    milvus::storage::StorageConfig storage_config;
+    storage_config.storage_type = "local";
+    storage_config.root_path = TestLocalPath;
+    return milvus::storage::InitArrowFileSystem(storage_config);
+}
+
+}  // namespace
 
 TEST_F(ParquetWriterFactoryTest, ColumnGroupingStrategyFactoryTest) {
     // Test creating default strategy
@@ -103,6 +197,67 @@ TEST_F(ParquetWriterFactoryTest, CreateContextWithColumnGroups) {
 
     // All columns should be assigned to a group
     EXPECT_EQ(group_ids.size(), column_map_.size());
+}
+
+TEST_F(ParquetWriterFactoryTest, CloseReturnsStatusAndIsIdempotent) {
+    auto fs = CreateLocalArrowFileSystem();
+    ASSERT_NE(fs, nullptr);
+    auto path_prefix = std::filesystem::path("json_stats_writer_close");
+    auto local_path = std::filesystem::path(TestLocalPath) / path_prefix;
+    std::filesystem::remove_all(local_path);
+    ASSERT_TRUE(std::filesystem::create_directories(local_path));
+
+    std::map<JsonKey, JsonKeyLayoutType> column_map = {
+        {JsonKey("/int", JSONType::INT64), JsonKeyLayoutType::TYPED},
+        {JsonKey("/shared", JSONType::STRING), JsonKeyLayoutType::SHARED},
+    };
+
+    auto storage_config = CreatePackedWriterStorageConfig();
+    JsonStatsParquetWriter writer(fs, storage_config, 16 * 1024 * 1024, 1024);
+    auto context =
+        ParquetWriterFactory::CreateContext(column_map, path_prefix.string());
+    writer.Init(std::move(context));
+
+    writer.AppendValue(JsonKey("/int", JSONType::INT64).ToColumnName(), "42");
+    writer.AppendSharedRow(nullptr, 0);
+    writer.AddCurrentRow();
+
+    auto status = writer.Close();
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_TRUE(writer.Close().ok());
+    EXPECT_FALSE(writer.GetPathsToSize().empty());
+
+    std::filesystem::remove_all(local_path);
+}
+
+TEST_F(ParquetWriterFactoryTest, ClosePropagatesFinalCloseFailure) {
+    auto fs = std::make_shared<CloseFailingLocalFileSystem>();
+    auto path_prefix =
+        std::filesystem::path(TestLocalPath) / "json_stats_writer_close_fail";
+    std::filesystem::remove_all(path_prefix);
+    ASSERT_TRUE(std::filesystem::create_directories(path_prefix));
+
+    std::map<JsonKey, JsonKeyLayoutType> column_map = {
+        {JsonKey("/int", JSONType::INT64), JsonKeyLayoutType::TYPED},
+        {JsonKey("/shared", JSONType::STRING), JsonKeyLayoutType::SHARED},
+    };
+
+    auto storage_config = CreatePackedWriterStorageConfig();
+    JsonStatsParquetWriter writer(fs, storage_config, 16 * 1024 * 1024, 1024);
+    auto context =
+        ParquetWriterFactory::CreateContext(column_map, path_prefix.string());
+    writer.Init(std::move(context));
+
+    writer.AppendValue(JsonKey("/int", JSONType::INT64).ToColumnName(), "42");
+    writer.AppendSharedRow(nullptr, 0);
+    writer.AddCurrentRow();
+
+    auto status = writer.Close();
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.ToString().find("injected final close failure"),
+              std::string::npos);
+
+    std::filesystem::remove_all(path_prefix);
 }
 
 }  // namespace milvus::index

--- a/internal/parser/planparserv2/rewriter/range_json_test.go
+++ b/internal/parser/planparserv2/rewriter/range_json_test.go
@@ -69,7 +69,7 @@ func TestRewrite_JSON_NestedPath_Nullable_ContradictionsKeepPredicate(t *testing
 	}
 }
 
-func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteAllowed(t *testing.T) {
+func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteBlocked(t *testing.T) {
 	helper := buildSchemaHelperWithJSON(t)
 
 	for _, exprStr := range []string{
@@ -79,9 +79,9 @@ func TestRewrite_JSON_NestedPath_ScalarNotEqualRewriteAllowed(t *testing.T) {
 		expr, err := parser.ParseExpr(helper, exprStr, nil)
 		require.NoError(t, err, exprStr)
 		require.NotNil(t, expr, exprStr)
-		ure := expr.GetUnaryRangeExpr()
-		require.NotNil(t, ure, "scalar JSON missing-path != is compatible with NOT(==): %s", exprStr)
-		require.Equal(t, planpb.OpType_NotEqual, ure.GetOp(), exprStr)
+		unary := expr.GetUnaryExpr()
+		require.NotNil(t, unary, "scalar JSON missing-path NOT must remain explicit: %s", exprStr)
+		require.Equal(t, planpb.UnaryExpr_Not, unary.GetOp(), exprStr)
 	}
 }
 

--- a/internal/parser/planparserv2/rewriter/util.go
+++ b/internal/parser/planparserv2/rewriter/util.go
@@ -221,21 +221,7 @@ func canFoldInNotEqualTautologyToTrue(col *planpb.ColumnInfo) bool {
 }
 
 func hasMissingPathNotEqualSemantics(col *planpb.ColumnInfo, values ...*planpb.GenericValue) bool {
-	if !hasMissingPathSemantics(col) {
-		return false
-	}
-	if col.GetDataType() != schemapb.DataType_JSON {
-		return true
-	}
-	for _, value := range values {
-		if value == nil || value.GetVal() == nil {
-			continue
-		}
-		if _, ok := value.GetVal().(*planpb.GenericValue_ArrayVal); ok {
-			return true
-		}
-	}
-	return false
+	return hasMissingPathSemantics(col)
 }
 
 func newAlwaysFalseExpr() *planpb.Expr {

--- a/internal/streamingnode/server/wal/interceptors/replicate/replicates/impl.go
+++ b/internal/streamingnode/server/wal/interceptors/replicate/replicates/impl.go
@@ -167,13 +167,19 @@ func (impl *replicatesManagerImpl) beginReplicateMessage(ctx context.Context, ms
 		return nil, status.NewReplicateViolation("cluster id mismatch, current: %s, expected: %s", rh.ClusterID, impl.secondaryState.SourceClusterID())
 	}
 
-	// if the incoming message's time tick is less than the checkpoint's time tick,
-	// it means that the message has been written to the wal, so it can be ignored.
-	// txn message will share same time tick, so we only filter with <, it will be deduplicated by the txnHelper.
+	// If the incoming message's time tick is covered by the checkpoint, it means
+	// that the message has been written to the wal, so it can be ignored.
+	// Txn messages in the current in-flight txn share the same time tick, so keep
+	// the equality case for txnHelper to deduplicate by message id.
 	isTxnBody := msg.TxnContext() != nil && msg.MessageType() != message.MessageTypeBeginTxn
-	if (isTxnBody && rh.TimeTick < impl.secondaryState.GetCheckpoint().TimeTick) || (!isTxnBody && rh.TimeTick <= impl.secondaryState.GetCheckpoint().TimeTick) {
+	if isTxnBody {
+		currentTxn := impl.secondaryState.CurrentTxn()
+		isTxnBody = currentTxn != nil && currentTxn.TxnID == msg.TxnContext().TxnID
+	}
+	checkpoint := impl.secondaryState.GetCheckpoint()
+	if (isTxnBody && rh.TimeTick < checkpoint.TimeTick) || (!isTxnBody && rh.TimeTick <= checkpoint.TimeTick) {
 		return nil, status.NewIgnoreOperation("message is too old, message_id: %s, time_tick: %d, txn: %t, current time tick: %d",
-			rh.MessageID, rh.TimeTick, isTxnBody, impl.secondaryState.GetCheckpoint().TimeTick)
+			rh.MessageID, rh.TimeTick, isTxnBody, checkpoint.TimeTick)
 	}
 
 	if msg.TxnContext() != nil {

--- a/internal/streamingnode/server/wal/interceptors/replicate/replicates/manager_test.go
+++ b/internal/streamingnode/server/wal/interceptors/replicate/replicates/manager_test.go
@@ -338,6 +338,42 @@ func TestSecondaryReplicateManagerWithTxn(t *testing.T) {
 	}
 }
 
+func TestSecondaryReplicateManagerIgnoreStaleTxnBody(t *testing.T) {
+	rm, err := RecoverReplicateManager(&ReplicateManagerRecoverParam{
+		ChannelInfo: types.PChannelInfo{
+			Name: "test1-rootcoord-dml_0",
+			Term: 1,
+		},
+		CurrentClusterID: "test1",
+		InitialRecoverSnapshot: &recovery.RecoverySnapshot{
+			Checkpoint: &utility.WALCheckpoint{
+				MessageID: walimplstest.NewTestMessageID(1),
+				TimeTick:  1,
+				ReplicateCheckpoint: &utility.ReplicateCheckpoint{
+					ClusterID: "test2",
+					PChannel:  "test2-rootcoord-dml_0",
+					MessageID: walimplstest.NewTestMessageID(1),
+					TimeTick:  100,
+				},
+				ReplicateConfig: newReplicateConfiguration("test2", "test1"),
+			},
+			TxnBuffer: utility.NewTxnBuffer(log.With(), metricsutil.NewScanMetrics(types.PChannelInfo{}).NewScannerMetrics()),
+		},
+	})
+	assert.NoError(t, err)
+
+	beginCurrentTxn := newReplicateTxnMessageWithTxnID("test1", "test2", 200, 2)[0]
+	g, err := rm.BeginReplicateMessage(context.Background(), beginCurrentTxn)
+	assert.NoError(t, err)
+	assert.NotNil(t, g)
+	g.Ack(nil)
+
+	staleTxnBody := newReplicateTxnMessageWithTxnID("test1", "test2", 100, 1)[2]
+	g, err = rm.BeginReplicateMessage(context.Background(), staleTxnBody)
+	assert.True(t, status.AsStreamingError(err).IsIgnoredOperation())
+	assert.Nil(t, g)
+}
+
 func testSwitchReplicateMode(t *testing.T, rm ReplicatesManager, primaryClusterID, secondaryClusterID string) {
 	ctx := context.Background()
 
@@ -676,7 +712,15 @@ func newImmutableTxnMessage(clusterID string, timetick ...uint64) []message.Immu
 }
 
 func newReplicateTxnMessage(clusterID string, sourceClusterID string, timetick ...uint64) []message.MutableMessage {
-	immutables := newImmutableTxnMessage(sourceClusterID, timetick...)
+	tt := uint64(1)
+	if len(timetick) > 0 {
+		tt = timetick[0]
+	}
+	return newReplicateTxnMessageWithTxnID(clusterID, sourceClusterID, tt, 1)
+}
+
+func newReplicateTxnMessageWithTxnID(clusterID string, sourceClusterID string, timetick uint64, txnID message.TxnID) []message.MutableMessage {
+	immutables := newImmutableTxnMessageWithTxnID(sourceClusterID, timetick, txnID)
 	replicateMsgs := []message.MutableMessage{}
 	for _, immutable := range immutables {
 		replicateMsg := message.MustNewReplicateMessage(
@@ -691,4 +735,41 @@ func newReplicateTxnMessage(clusterID string, sourceClusterID string, timetick .
 		replicateMsgs = append(replicateMsgs, replicateMsg)
 	}
 	return replicateMsgs
+}
+
+func newImmutableTxnMessageWithTxnID(clusterID string, timetick uint64, txnID message.TxnID) []message.ImmutableMessage {
+	txnCtx := message.TxnContext{
+		TxnID:     txnID,
+		Keepalive: message.TxnKeepaliveInfinite,
+	}
+	immutables := []message.ImmutableMessage{
+		message.NewBeginTxnMessageBuilderV2().
+			WithHeader(&message.BeginTxnMessageHeader{}).
+			WithBody(&message.BeginTxnMessageBody{}).
+			WithVChannel(clusterID + "-rootcoord-dml_0").
+			MustBuildMutable().
+			WithTxnContext(txnCtx).
+			WithTimeTick(timetick).
+			WithLastConfirmed(walimplstest.NewTestMessageID(1)).
+			IntoImmutableMessage(walimplstest.NewTestMessageID(1)),
+		message.NewCreateDatabaseMessageBuilderV2().
+			WithHeader(&message.CreateDatabaseMessageHeader{}).
+			WithBody(&message.CreateDatabaseMessageBody{}).
+			WithVChannel(clusterID + "-rootcoord-dml_0").
+			MustBuildMutable().
+			WithTxnContext(txnCtx).
+			WithTimeTick(timetick).
+			WithLastConfirmed(walimplstest.NewTestMessageID(1)).
+			IntoImmutableMessage(walimplstest.NewTestMessageID(1)),
+		message.NewCommitTxnMessageBuilderV2().
+			WithHeader(&message.CommitTxnMessageHeader{}).
+			WithBody(&message.CommitTxnMessageBody{}).
+			WithVChannel(clusterID + "-rootcoord-dml_0").
+			MustBuildMutable().
+			WithTxnContext(txnCtx).
+			WithTimeTick(timetick).
+			WithLastConfirmed(walimplstest.NewTestMessageID(1)).
+			IntoImmutableMessage(walimplstest.NewTestMessageID(1)),
+	}
+	return immutables
 }


### PR DESCRIPTION
issue: #50891 #50698 #50699 #50488 #50846

Batch cherry-pick of 6 critical fixes from the 2.6 branch to hotfix-2.6.19. All commits applied cleanly (verbatim `cherry-pick -x`), preserve original authorship and sign-offs.

## Included fixes

| Commit on 2.6 | Fix | Issue | 2.6 PR | Master PR |
|---|---|---|---|---|
| d56dcf3332 | Drain index entry futures after read/decrypt/write errors; prevents async tasks outliving buffers/FDs after partial load failure | #50891 | #50937 | #50478 |
| 7ee85ba28e | Preserve NULL semantics in boolean filter execution (short-circuit, UNKNOWN-to-bitset, nullable JSON `!=` validity) | #50698 | #50722 | #50701 |
| 936b0f74ac | Preserve UNKNOWN semantics for JSON path predicates (missing path / parent NULL / type mismatch) | #50699 | #50723 | #50702 |
| c2658268c9 | Recreate marisa string index temp directory before build; fixes index build failure | #50488 | #50772 | #50500 |
| 25344542c0 | Propagate json stats parquet writer close errors; prevents silent incomplete writes | — | #50870 | #50856 |
| 2153e7f8f0 | Ignore stale replicated txn body covered by replicate checkpoint | #50846 | #50849 | #50848 |

Note: #51090 (text index insert log paths, 24d576fe62) is submitted separately and is not part of this PR.

The two NULL/UNKNOWN semantics fixes (#50722, #50723) are companion changes and must land together; they are included here in their original merge order.

## Verification

- All 6 commits cherry-picked onto hotfix-2.6.19 with zero conflicts.
- Full local build (C++ core + Go binary) passes on the combined branch.
- `go test -tags dynamic,test` passes for the touched Go packages: `internal/streamingnode/server/wal/interceptors/replicate/...` and `internal/parser/planparserv2/rewriter`.
- C++ unit tests not run locally; relying on CI (all fixes already passed CI on the 2.6 branch).
