### PR TITLE
enhance: de-synchronize and rate-limit delete-triggered single compaction

### DIFF
--- a/internal/datacoord/compaction_admission.go
+++ b/internal/datacoord/compaction_admission.go
@@ -106,7 +106,13 @@ type singleCompactionAdmitter struct {
 	tokens          float64
 	lastRefill      time.Time
 	throttledRounds int
-	nowFn           func() time.Time // injectable for tests
+	// maxDeltalogMaxNum snapshots the largest SingleCompactionDeltalogMaxNum
+	// ever observed. The hard cap is derived from it monotonically so that
+	// lowering the (refreshable) config cannot retroactively drop the hard cap
+	// and release a whole cohort of already-accumulated segments in one round,
+	// reproducing the very avalanche the bucket exists to pace.
+	maxDeltalogMaxNum float64
+	nowFn             func() time.Time // injectable for tests
 }
 
 var (
@@ -122,20 +128,40 @@ func getSingleCompactionAdmitter() *singleCompactionAdmitter {
 }
 
 // admit selects which eligible segments may be submitted this round.
-// Ordering: segments past the deferral hard cap are always admitted; the rest
-// are admitted dirtiest-first while tokens last. A non-positive token config
-// disables limiting entirely (legacy behavior).
-func (a *singleCompactionAdmitter) admit(eligible []*SegmentInfo) (admitted []*SegmentInfo, deferred int) {
-	if len(eligible) == 0 {
+//
+// Candidates are split by reason into two classes:
+//   - accumulation: delete / expired-entity accumulation, the avalanche-shaped
+//     case. Paced dirtiest-first; segments past the deferral hard cap are always
+//     admitted.
+//   - retention: strict age-TTL, TTL-field expiry, and index rebuild. These are
+//     not delete-driven, so under the accumulation ordering they would always
+//     sort last and never reach the hard cap — i.e. be starved whenever
+//     delete-driven demand saturates the bucket. They are paced too, but the two
+//     classes are interleaved so a reserved share of every round goes to
+//     retention and it can never be indefinitely starved.
+//
+// A non-positive token config disables limiting entirely (legacy behavior).
+func (a *singleCompactionAdmitter) admit(ctx context.Context, accumulation, retention []*SegmentInfo) (admitted []*SegmentInfo, deferred int) {
+	if len(accumulation)+len(retention) == 0 {
 		return nil, 0
 	}
 	budget := Params.DataCoordCfg.SingleCompactionRateLimitTokens.GetAsFloat()
 	if budget <= 0 {
-		return eligible, 0
+		return append(accumulation, retention...), 0
 	}
 	interval := Params.DataCoordCfg.SingleCompactionRateLimitInterval.GetAsDuration(time.Second)
 	if interval <= 0 {
-		return eligible, 0
+		return append(accumulation, retention...), 0
+	}
+	// A sub-one positive token budget is a misconfiguration: the bucket caps at
+	// `budget`, so tokens could never reach 1 and every non-hard-cap candidate
+	// would be deferred forever (a soft deadlock). A slow rate is expressed via
+	// a longer interval, not a fractional token count; clamp up to 1 and warn.
+	if budget < 1 {
+		mlog.RatedWarn(ctx, rate.Limit(60), "single compaction rateLimitTokens is a positive value below 1; "+
+			"clamping to 1 to avoid a soft deadlock — use a longer rateLimitInterval to express a slower rate",
+			mlog.Float64("configuredTokens", budget))
+		budget = 1
 	}
 
 	a.mu.Lock()
@@ -152,42 +178,71 @@ func (a *singleCompactionAdmitter) admit(eligible []*SegmentInfo) (admitted []*S
 	}
 	a.lastRefill = now
 
-	hardCapCount := int(deferralHardCap * Params.DataCoordCfg.SingleCompactionDeltalogMaxNum.GetAsFloat())
-	rest := make([]*SegmentInfo, 0, len(eligible))
-	for _, segment := range eligible {
-		if segmentDeltalogCount(segment) >= hardCapCount {
-			// bounded deferral: always admitted, does not consume tokens
+	// Derive the hard cap from a monotonically non-decreasing snapshot of the
+	// threshold, so a config decrease cannot drop the cap and release a cohort
+	// of already-accumulated segments at once.
+	if cur := Params.DataCoordCfg.SingleCompactionDeltalogMaxNum.GetAsFloat(); cur > a.maxDeltalogMaxNum {
+		a.maxDeltalogMaxNum = cur
+	}
+	hardCapCount := int(deferralHardCap * a.maxDeltalogMaxNum)
+
+	// Bounded deferral: accumulation segments past the hard cap are always
+	// admitted and do not consume tokens. The rest are paced dirtiest-first.
+	pacedAccum := make([]*SegmentInfo, 0, len(accumulation))
+	for _, segment := range accumulation {
+		if hardCapCount > 0 && segmentDeltalogCount(segment) >= hardCapCount {
 			admitted = append(admitted, segment)
 			continue
 		}
-		rest = append(rest, segment)
+		pacedAccum = append(pacedAccum, segment)
 	}
-	sort.Slice(rest, func(i, j int) bool {
-		return segmentDeletedRowsRatio(rest[i]) > segmentDeletedRowsRatio(rest[j])
+	sort.Slice(pacedAccum, func(i, j int) bool {
+		return segmentDeletedRowsRatio(pacedAccum[i]) > segmentDeletedRowsRatio(pacedAccum[j])
 	})
-	for _, segment := range rest {
+	// Deterministic order for the retention class (stable across rounds).
+	sort.Slice(retention, func(i, j int) bool {
+		return retention[i].GetID() < retention[j].GetID()
+	})
+
+	// Interleave the two classes so retention gets a reserved share of tokens
+	// and is never starved by a saturating accumulation stream. When one class
+	// drains, the other consumes the remaining tokens.
+	ai, ri := 0, 0
+	takeRetention := false
+	for ai < len(pacedAccum) || ri < len(retention) {
 		if a.tokens < 1 {
-			deferred++
-			continue
+			deferred += (len(pacedAccum) - ai) + (len(retention) - ri)
+			break
+		}
+		if (takeRetention || ai >= len(pacedAccum)) && ri < len(retention) {
+			admitted = append(admitted, retention[ri])
+			ri++
+		} else {
+			admitted = append(admitted, pacedAccum[ai])
+			ai++
 		}
 		a.tokens--
-		admitted = append(admitted, segment)
+		takeRetention = !takeRetention
 	}
 
 	if deferred > 0 {
 		a.throttledRounds++
 		if a.throttledRounds >= consecutiveThrottledRoundsToWarn {
-			mlog.RatedWarn(context.TODO(), rate.Limit(60), "single compaction admission throttled for many consecutive rounds; "+
+			mlog.RatedWarn(ctx, rate.Limit(60), "single compaction admission throttled for many consecutive rounds; "+
 				"the rate limit may be below steady-state demand and deltalog backlog is growing",
 				mlog.Int("deferred", deferred),
 				mlog.Int("consecutiveThrottledRounds", a.throttledRounds),
 				mlog.Float64("rateLimitTokens", budget))
 		} else {
-			mlog.RatedInfo(context.TODO(), rate.Limit(10), "single compaction admission throttled",
+			mlog.RatedInfo(ctx, rate.Limit(10), "single compaction admission throttled",
 				mlog.Int("admitted", len(admitted)),
 				mlog.Int("deferred", deferred))
 		}
-	} else {
+	} else if a.tokens >= 1 {
+		// Only clear the throttle counter when this round genuinely had spare
+		// capacity. A lightly-loaded caller that happened to defer nothing must
+		// not mask sustained throttling seen by another caller sharing the
+		// bucket (which would have already drained the tokens).
 		a.throttledRounds = 0
 	}
 	return admitted, deferred

--- a/internal/datacoord/compaction_admission.go
+++ b/internal/datacoord/compaction_admission.go
@@ -1,0 +1,194 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/milvus-io/milvus/pkg/v3/mlog"
+)
+
+// Admission smoothing for single (delete/expiry-triggered) compaction.
+//
+// Segments created in the same batch accumulate deltalogs at nearly the same
+// rate, so they cross the hard trigger thresholds nearly simultaneously and
+// produce a rewrite avalanche (see issue #51094). Two mechanisms de-synchronize
+// and bound this:
+//
+//  1. Per-segment threshold jitter: each segment gets a deterministic
+//     multiplier in [1, 1+J] applied to the accumulation thresholds, spreading
+//     a cohort's crossing times over J x (accumulation period).
+//  2. A token bucket at candidate admission: no matter how many segments become
+//     eligible in one trigger round (e.g. after a threshold config change), at
+//     most `rateLimitTokens` are admitted per `rateLimitInterval`. Segments
+//     whose deltalog file count exceeded the configured threshold by
+//     `deferralHardCap` times are always admitted so deferral stays bounded.
+//
+// Both knobs are refreshable; jitter=0 and tokens=0 restore legacy behavior.
+
+// deferralHardCap bounds how far the admission limiter may defer a segment:
+// once its deltalog file count exceeds hardCap x SingleCompactionDeltalogMaxNum
+// it is admitted regardless of remaining tokens.
+const deferralHardCap = 4.0
+
+// consecutiveThrottledRoundsToWarn controls how many consecutive throttled
+// admission rounds are tolerated before emitting a warning; sustained
+// throttling means the bucket is sized below steady-state demand.
+const consecutiveThrottledRoundsToWarn = 30
+
+// singleCompactionThresholdMultiplier returns the deterministic per-segment
+// jitter multiplier in [1, 1+J]. It is a pure function of the segment ID:
+// stable across restarts and nodes, re-drawn naturally when a compaction
+// produces a segment with a new ID.
+func singleCompactionThresholdMultiplier(segmentID int64) float64 {
+	jitter := Params.DataCoordCfg.SingleCompactionThresholdJitter.GetAsFloat()
+	if jitter <= 0 {
+		return 1.0
+	}
+	// splitmix64 finalizer as a cheap uniform hash.
+	x := uint64(segmentID)
+	x ^= x >> 30
+	x *= 0xbf58476d1ce4e5b9
+	x ^= x >> 27
+	x *= 0x94d049bb133111eb
+	x ^= x >> 31
+	hash01 := float64(x>>11) / float64(uint64(1)<<53)
+	return 1.0 + jitter*hash01
+}
+
+// segmentDeletedRowsRatio estimates the deleted-rows proportion of a segment,
+// used to admit the dirtiest (highest reclaim value) segments first.
+func segmentDeletedRowsRatio(segment *SegmentInfo) float64 {
+	if segment.GetNumOfRows() <= 0 {
+		return 0
+	}
+	var deleted int64
+	for _, deltaLogs := range segment.GetDeltalogs() {
+		for _, l := range deltaLogs.GetBinlogs() {
+			deleted += l.GetEntriesNum()
+		}
+	}
+	return float64(deleted) / float64(segment.GetNumOfRows())
+}
+
+func segmentDeltalogCount(segment *SegmentInfo) int {
+	count := 0
+	for _, deltaLogs := range segment.GetDeltalogs() {
+		count += len(deltaLogs.GetBinlogs())
+	}
+	return count
+}
+
+// singleCompactionAdmitter is a token bucket shared by every single-compaction
+// candidate producer (the legacy trigger and the single compaction policy),
+// so the whole DataCoord observes one admission budget.
+type singleCompactionAdmitter struct {
+	mu              sync.Mutex
+	tokens          float64
+	lastRefill      time.Time
+	throttledRounds int
+	nowFn           func() time.Time // injectable for tests
+}
+
+var (
+	globalSingleCompactionAdmitter     *singleCompactionAdmitter
+	globalSingleCompactionAdmitterOnce sync.Once
+)
+
+func getSingleCompactionAdmitter() *singleCompactionAdmitter {
+	globalSingleCompactionAdmitterOnce.Do(func() {
+		globalSingleCompactionAdmitter = &singleCompactionAdmitter{nowFn: time.Now}
+	})
+	return globalSingleCompactionAdmitter
+}
+
+// admit selects which eligible segments may be submitted this round.
+// Ordering: segments past the deferral hard cap are always admitted; the rest
+// are admitted dirtiest-first while tokens last. A non-positive token config
+// disables limiting entirely (legacy behavior).
+func (a *singleCompactionAdmitter) admit(eligible []*SegmentInfo) (admitted []*SegmentInfo, deferred int) {
+	if len(eligible) == 0 {
+		return nil, 0
+	}
+	budget := Params.DataCoordCfg.SingleCompactionRateLimitTokens.GetAsFloat()
+	if budget <= 0 {
+		return eligible, 0
+	}
+	interval := Params.DataCoordCfg.SingleCompactionRateLimitInterval.GetAsDuration(time.Second)
+	if interval <= 0 {
+		return eligible, 0
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	now := a.nowFn()
+	if a.lastRefill.IsZero() {
+		a.tokens = budget
+	} else {
+		a.tokens += budget * now.Sub(a.lastRefill).Seconds() / interval.Seconds()
+		if a.tokens > budget {
+			a.tokens = budget
+		}
+	}
+	a.lastRefill = now
+
+	hardCapCount := int(deferralHardCap * Params.DataCoordCfg.SingleCompactionDeltalogMaxNum.GetAsFloat())
+	rest := make([]*SegmentInfo, 0, len(eligible))
+	for _, segment := range eligible {
+		if segmentDeltalogCount(segment) >= hardCapCount {
+			// bounded deferral: always admitted, does not consume tokens
+			admitted = append(admitted, segment)
+			continue
+		}
+		rest = append(rest, segment)
+	}
+	sort.Slice(rest, func(i, j int) bool {
+		return segmentDeletedRowsRatio(rest[i]) > segmentDeletedRowsRatio(rest[j])
+	})
+	for _, segment := range rest {
+		if a.tokens < 1 {
+			deferred++
+			continue
+		}
+		a.tokens--
+		admitted = append(admitted, segment)
+	}
+
+	if deferred > 0 {
+		a.throttledRounds++
+		if a.throttledRounds >= consecutiveThrottledRoundsToWarn {
+			mlog.RatedWarn(context.TODO(), rate.Limit(60), "single compaction admission throttled for many consecutive rounds; "+
+				"the rate limit may be below steady-state demand and deltalog backlog is growing",
+				mlog.Int("deferred", deferred),
+				mlog.Int("consecutiveThrottledRounds", a.throttledRounds),
+				mlog.Float64("rateLimitTokens", budget))
+		} else {
+			mlog.RatedInfo(context.TODO(), rate.Limit(10), "single compaction admission throttled",
+				mlog.Int("admitted", len(admitted)),
+				mlog.Int("deferred", deferred))
+		}
+	} else {
+		a.throttledRounds = 0
+	}
+	return admitted, deferred
+}

--- a/internal/datacoord/compaction_admission_test.go
+++ b/internal/datacoord/compaction_admission_test.go
@@ -17,6 +17,7 @@
 package datacoord
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -88,7 +89,7 @@ func TestSingleCompactionAdmitter(t *testing.T) {
 			makeAdmissionTestSegment(1, 1000, 100, 10),
 			makeAdmissionTestSegment(2, 1000, 100, 10),
 		}
-		admitted, deferred := a.admit(eligible)
+		admitted, deferred := a.admit(context.Background(), eligible, nil)
 		assert.Len(t, admitted, 2)
 		assert.Zero(t, deferred)
 	})
@@ -105,7 +106,7 @@ func TestSingleCompactionAdmitter(t *testing.T) {
 			makeAdmissionTestSegment(2, 1000, 500, 10), // 50% deleted -> dirtiest
 			makeAdmissionTestSegment(3, 1000, 300, 10), // 30% deleted
 		}
-		admitted, deferred := a.admit(eligible)
+		admitted, deferred := a.admit(context.Background(), eligible, nil)
 		assert.Len(t, admitted, 2)
 		assert.Equal(t, 1, deferred)
 		assert.Equal(t, int64(2), admitted[0].GetID())
@@ -127,7 +128,7 @@ func TestSingleCompactionAdmitter(t *testing.T) {
 			makeAdmissionTestSegment(2, 1000, 500, 10),
 			overCap,
 		}
-		admitted, deferred := a.admit(eligible)
+		admitted, deferred := a.admit(context.Background(), eligible, nil)
 		assert.Len(t, admitted, 2) // hard-cap one + one token
 		assert.Equal(t, 1, deferred)
 		ids := []int64{admitted[0].GetID(), admitted[1].GetID()}
@@ -144,16 +145,94 @@ func TestSingleCompactionAdmitter(t *testing.T) {
 		a := &singleCompactionAdmitter{nowFn: func() time.Time { return current }}
 		seg := func(id int64) []*SegmentInfo { return []*SegmentInfo{makeAdmissionTestSegment(id, 1000, 100, 10)} }
 
-		admitted, _ := a.admit(seg(1))
+		admitted, _ := a.admit(context.Background(), seg(1), nil)
 		assert.Len(t, admitted, 1)
 		// bucket drained: an immediate retry is deferred
-		admitted, deferred := a.admit(seg(2))
+		admitted, deferred := a.admit(context.Background(), seg(2), nil)
 		assert.Len(t, admitted, 0)
 		assert.Equal(t, 1, deferred)
 		// after one full interval the bucket refills
 		current = current.Add(61 * time.Second)
-		admitted, deferred = a.admit(seg(3))
+		admitted, deferred = a.admit(context.Background(), seg(3), nil)
 		assert.Len(t, admitted, 1)
 		assert.Zero(t, deferred)
+	})
+}
+
+func TestSingleCompactionAdmitterFixes(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	now := time.Now()
+	newAdmitter := func() *singleCompactionAdmitter {
+		return &singleCompactionAdmitter{nowFn: func() time.Time { return now }}
+	}
+
+	// retention/index candidates (deltalogCount == 0, deletedRows == 0) must not
+	// be starved by a saturating stream of delete-driven accumulation candidates.
+	t.Run("retention class is not starved by an accumulation flood", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "4")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+
+		a := newAdmitter()
+		accumulation := make([]*SegmentInfo, 0, 100)
+		for i := int64(1); i <= 100; i++ {
+			accumulation = append(accumulation, makeAdmissionTestSegment(i, 1000, 500, 10)) // all 50% dirty
+		}
+		retention := []*SegmentInfo{
+			makeAdmissionTestSegment(5001, 1000, 0, 0), // index rebuild / age-TTL: no deletes
+			makeAdmissionTestSegment(5002, 1000, 0, 0),
+		}
+		admitted, deferred := a.admit(context.Background(), accumulation, retention)
+		assert.Len(t, admitted, 4) // budget of 4 shared across the two classes
+		assert.Equal(t, 98, deferred)
+		admittedIDs := make(map[int64]bool)
+		for _, s := range admitted {
+			admittedIDs[s.GetID()] = true
+		}
+		assert.True(t, admittedIDs[5001], "retention candidate must get a reserved share")
+		assert.True(t, admittedIDs[5002], "retention candidate must get a reserved share")
+	})
+
+	// A positive sub-one token budget must clamp to 1 rather than deadlocking.
+	t.Run("sub-one token budget clamps to 1 instead of deadlocking", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "0.5")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+
+		a := newAdmitter()
+		eligible := []*SegmentInfo{makeAdmissionTestSegment(1, 1000, 100, 10)}
+		admitted, deferred := a.admit(context.Background(), eligible, nil)
+		assert.Len(t, admitted, 1, "clamped budget of 1 must admit one segment, not deadlock")
+		assert.Zero(t, deferred)
+	})
+
+	// Lowering the refreshable deltalog threshold must not drop the hard cap and
+	// release an already-accumulated cohort in a single round.
+	t.Run("hard cap does not drop when the threshold config is lowered", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "1")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		pt.Save(pt.DataCoordCfg.SingleCompactionDeltalogMaxNum.Key, "200")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionDeltalogMaxNum.Key)
+
+		a := newAdmitter()
+		// Round 1 snapshots maxDeltalogMaxNum = 200 (hard cap = 800) and drains
+		// the single token on an ordinary segment.
+		primed, _ := a.admit(context.Background(), []*SegmentInfo{makeAdmissionTestSegment(1, 1000, 100, 10)}, nil)
+		assert.Len(t, primed, 1)
+
+		// Operator lowers the threshold 200 -> 50. A naive hard cap would drop to
+		// 4*50 = 200, so a 300-deltalog cohort segment would bypass the drained
+		// bucket. With the monotonic snapshot the cap stays 800, so the segment
+		// remains token-gated and is deferred (bucket is empty this round).
+		pt.Save(pt.DataCoordCfg.SingleCompactionDeltalogMaxNum.Key, "50")
+		cohort := makeAdmissionTestSegment(2, 1000, 100, 300) // 4*50 <= 300 < 4*200
+		admitted, deferred := a.admit(context.Background(), []*SegmentInfo{cohort}, nil)
+		assert.Empty(t, admitted, "lowering the config must not let the cohort bypass the drained bucket")
+		assert.Equal(t, 1, deferred)
 	})
 }

--- a/internal/datacoord/compaction_admission_test.go
+++ b/internal/datacoord/compaction_admission_test.go
@@ -1,0 +1,159 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+)
+
+func makeAdmissionTestSegment(id int64, numRows int64, deletedRows int64, deltalogCount int) *SegmentInfo {
+	binlogs := make([]*datapb.Binlog, 0, deltalogCount)
+	perLog := int64(0)
+	if deltalogCount > 0 {
+		perLog = deletedRows / int64(deltalogCount)
+	}
+	for i := 0; i < deltalogCount; i++ {
+		binlogs = append(binlogs, &datapb.Binlog{EntriesNum: perLog, MemorySize: 1024})
+	}
+	return &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			ID:        id,
+			NumOfRows: numRows,
+			Deltalogs: []*datapb.FieldBinlog{{Binlogs: binlogs}},
+		},
+	}
+}
+
+func TestSingleCompactionThresholdMultiplier(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+
+	t.Run("zero jitter restores legacy behavior", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionThresholdJitter.Key, "0")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionThresholdJitter.Key)
+		assert.Equal(t, 1.0, singleCompactionThresholdMultiplier(12345))
+	})
+
+	t.Run("deterministic and within range", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionThresholdJitter.Key, "0.25")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionThresholdJitter.Key)
+
+		seen := make(map[float64]int)
+		for _, id := range []int64{1, 2, 3, 1e12, 466295849486964560} {
+			m1 := singleCompactionThresholdMultiplier(id)
+			m2 := singleCompactionThresholdMultiplier(id)
+			assert.Equal(t, m1, m2, "multiplier must be deterministic for id %d", id)
+			assert.GreaterOrEqual(t, m1, 1.0)
+			assert.Less(t, m1, 1.25)
+			seen[m1]++
+		}
+		assert.Greater(t, len(seen), 1, "different ids should spread across the jitter band")
+	})
+}
+
+func TestSingleCompactionAdmitter(t *testing.T) {
+	paramtable.Init()
+	pt := paramtable.Get()
+	now := time.Now()
+	newAdmitter := func() *singleCompactionAdmitter {
+		return &singleCompactionAdmitter{nowFn: func() time.Time { return now }}
+	}
+
+	t.Run("disabled bucket admits everything", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "0")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+
+		a := newAdmitter()
+		eligible := []*SegmentInfo{
+			makeAdmissionTestSegment(1, 1000, 100, 10),
+			makeAdmissionTestSegment(2, 1000, 100, 10),
+		}
+		admitted, deferred := a.admit(eligible)
+		assert.Len(t, admitted, 2)
+		assert.Zero(t, deferred)
+	})
+
+	t.Run("limits admissions and prefers the dirtiest segments", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "2")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+
+		a := newAdmitter()
+		eligible := []*SegmentInfo{
+			makeAdmissionTestSegment(1, 1000, 100, 10), // 10% deleted
+			makeAdmissionTestSegment(2, 1000, 500, 10), // 50% deleted -> dirtiest
+			makeAdmissionTestSegment(3, 1000, 300, 10), // 30% deleted
+		}
+		admitted, deferred := a.admit(eligible)
+		assert.Len(t, admitted, 2)
+		assert.Equal(t, 1, deferred)
+		assert.Equal(t, int64(2), admitted[0].GetID())
+		assert.Equal(t, int64(3), admitted[1].GetID())
+	})
+
+	t.Run("hard-cap segments bypass the bucket", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "1")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		pt.Save(pt.DataCoordCfg.SingleCompactionDeltalogMaxNum.Key, "200")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionDeltalogMaxNum.Key)
+
+		a := newAdmitter()
+		overCap := makeAdmissionTestSegment(10, 1000, 10, 900) // >= 4x200 deltalogs
+		eligible := []*SegmentInfo{
+			makeAdmissionTestSegment(1, 1000, 100, 10),
+			makeAdmissionTestSegment(2, 1000, 500, 10),
+			overCap,
+		}
+		admitted, deferred := a.admit(eligible)
+		assert.Len(t, admitted, 2) // hard-cap one + one token
+		assert.Equal(t, 1, deferred)
+		ids := []int64{admitted[0].GetID(), admitted[1].GetID()}
+		assert.Contains(t, ids, int64(10), "hard-cap segment must always be admitted")
+	})
+
+	t.Run("tokens refill over time", func(t *testing.T) {
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key, "1")
+		pt.Save(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key, "60")
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitTokens.Key)
+		defer pt.Reset(pt.DataCoordCfg.SingleCompactionRateLimitInterval.Key)
+
+		current := now
+		a := &singleCompactionAdmitter{nowFn: func() time.Time { return current }}
+		seg := func(id int64) []*SegmentInfo { return []*SegmentInfo{makeAdmissionTestSegment(id, 1000, 100, 10)} }
+
+		admitted, _ := a.admit(seg(1))
+		assert.Len(t, admitted, 1)
+		// bucket drained: an immediate retry is deferred
+		admitted, deferred := a.admit(seg(2))
+		assert.Len(t, admitted, 0)
+		assert.Equal(t, 1, deferred)
+		// after one full interval the bucket refills
+		current = current.Add(61 * time.Second)
+		admitted, deferred = a.admit(seg(3))
+		assert.Len(t, admitted, 1)
+		assert.Zero(t, deferred)
+	})
+}

--- a/internal/datacoord/compaction_policy_single.go
+++ b/internal/datacoord/compaction_policy_single.go
@@ -285,6 +285,7 @@ func (policy *singleCompactionPolicy) triggerOneCollection(ctx context.Context, 
 			!policy.meta.isSegmentCompactionProtected(segment.GetID()) // not protected by snapshot
 	}))
 
+	var admissionCandidates []*SegmentInfo
 	for _, group := range partSegments {
 		if Params.DataCoordCfg.IndexBasedCompaction.GetAsBool() {
 			group.segments = FilterInIndexedSegments(ctx, policy.handler, policy.meta, false, group.segments...)
@@ -292,16 +293,29 @@ func (policy *singleCompactionPolicy) triggerOneCollection(ctx context.Context, 
 
 		for _, segment := range group.segments {
 			if hasTooManyDeletions(segment) {
-				segmentViews := GetViewsByInfo(segment)
-				view := &MixSegmentView{
-					label:         segmentViews[0].label,
-					segments:      segmentViews,
-					collectionTTL: collectionTTL,
-					triggerID:     newTriggerID,
-				}
-				views = append(views, view)
+				admissionCandidates = append(admissionCandidates, segment)
 			}
 		}
+	}
+	// Share the single-compaction admission budget with the legacy trigger so
+	// mass eligibility drains as a paced stream instead of an avalanche;
+	// deferred segments are stateless and re-evaluated next round.
+	admitted, deferred := getSingleCompactionAdmitter().admit(admissionCandidates)
+	for _, segment := range admitted {
+		segmentViews := GetViewsByInfo(segment)
+		view := &MixSegmentView{
+			label:         segmentViews[0].label,
+			segments:      segmentViews,
+			collectionTTL: collectionTTL,
+			triggerID:     newTriggerID,
+		}
+		views = append(views, view)
+	}
+	if deferred > 0 {
+		mlog.RatedInfo(ctx, rate.Limit(10), "deferred L2 single compaction candidates by admission limit",
+			mlog.FieldCollectionID(collectionID),
+			mlog.Int("admitted", len(admitted)),
+			mlog.Int("deferred", deferred))
 	}
 
 	if len(views) > 0 {

--- a/internal/datacoord/compaction_policy_single.go
+++ b/internal/datacoord/compaction_policy_single.go
@@ -299,8 +299,10 @@ func (policy *singleCompactionPolicy) triggerOneCollection(ctx context.Context, 
 	}
 	// Share the single-compaction admission budget with the legacy trigger so
 	// mass eligibility drains as a paced stream instead of an avalanche;
-	// deferred segments are stateless and re-evaluated next round.
-	admitted, deferred := getSingleCompactionAdmitter().admit(admissionCandidates)
+	// deferred segments are stateless and re-evaluated next round. L2 candidates
+	// are all delete-driven (hasTooManyDeletions), so they enter the
+	// accumulation class; there are no retention/index candidates here.
+	admitted, deferred := getSingleCompactionAdmitter().admit(ctx, admissionCandidates, nil)
 	for _, segment := range admitted {
 		segmentViews := GetViewsByInfo(segment)
 		view := &MixSegmentView{

--- a/internal/datacoord/compaction_policy_single_test.go
+++ b/internal/datacoord/compaction_policy_single_test.go
@@ -48,6 +48,10 @@ type SingleCompactionPolicySuite struct {
 }
 
 func (s *SingleCompactionPolicySuite) SetupTest() {
+	// these cases assert the exact legacy threshold boundaries, so disable
+	// the per-segment threshold jitter
+	paramtable.Get().Save(paramtable.Get().DataCoordCfg.SingleCompactionThresholdJitter.Key, "0")
+
 	s.testLabel = &CompactionGroupLabel{
 		CollectionID: 1,
 		PartitionID:  10,
@@ -72,6 +76,10 @@ func (s *SingleCompactionPolicySuite) SetupTest() {
 		Schema: &schemapb.CollectionSchema{},
 	}, nil).Maybe()
 	s.singlePolicy = newSingleCompactionPolicy(meta, s.mockAlloc, mockHandler)
+}
+
+func (s *SingleCompactionPolicySuite) TearDownTest() {
+	paramtable.Get().Reset(paramtable.Get().DataCoordCfg.SingleCompactionThresholdJitter.Key)
 }
 
 func (s *SingleCompactionPolicySuite) TestTrigger() {

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -457,16 +457,33 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compa
 	var nonPlannedSegments []*SegmentInfo
 
 	// TODO, currently we lack of the measurement of data distribution, there should be another compaction help on redistributing segment based on scalar/vector field distribution
+	var admissionCandidates []*SegmentInfo
 	for _, segment := range segments {
 		segment := segment.ShadowClone()
 		// TODO should we trigger compaction periodically even if the segment has no obvious reason to be compacted?
-		if signal.isForce || t.ShouldDoSingleCompaction(segment, compactTime) {
+		if signal.isForce {
+			// manual/force compaction expresses explicit operator intent and
+			// bypasses admission limiting.
 			prioritizedCandidates = append(prioritizedCandidates, segment)
+		} else if t.ShouldDoSingleCompaction(segment, compactTime) {
+			admissionCandidates = append(admissionCandidates, segment)
 		} else if t.isSmallSegment(segment, expectedSize) {
 			smallCandidates = append(smallCandidates, segment)
 		} else {
 			nonPlannedSegments = append(nonPlannedSegments, segment)
 		}
+	}
+	// Rate-limit single-compaction admissions so that mass eligibility (a
+	// same-batch cohort crossing thresholds together, a threshold config
+	// change, a TTL cliff) becomes a paced stream instead of an avalanche.
+	// Deferred segments carry no state and are re-evaluated next round.
+	admitted, deferred := getSingleCompactionAdmitter().admit(admissionCandidates)
+	prioritizedCandidates = append(prioritizedCandidates, admitted...)
+	if deferred > 0 {
+		mlog.RatedInfo(context.TODO(), rate.Limit(10), "deferred single compaction candidates by admission limit",
+			mlog.FieldCollectionID(signal.collectionID),
+			mlog.Int("admitted", len(admitted)),
+			mlog.Int("deferred", deferred))
 	}
 
 	buckets := [][]*SegmentInfo{}
@@ -652,34 +669,42 @@ func hasTooManyDeletions(segment *SegmentInfo) bool {
 		deltaLogCount += len(deltaLogs.GetBinlogs())
 	}
 
+	// Deterministic per-segment jitter de-synchronizes same-batch segments,
+	// whose accumulation rates are nearly identical, so they do not cross the
+	// hard thresholds simultaneously (see compaction_admission.go).
+	mult := singleCompactionThresholdMultiplier(segment.ID)
+
 	// Too many deltalog files, accumulates IO count.
-	if deltaLogCount > Params.DataCoordCfg.SingleCompactionDeltalogMaxNum.GetAsInt() {
+	if float64(deltaLogCount) > Params.DataCoordCfg.SingleCompactionDeltalogMaxNum.GetAsFloat()*mult {
 		mlog.Info(context.TODO(), "delta logs file count exceeds threshold",
 			mlog.FieldSegmentID(segment.ID),
 			mlog.Int("delta log count", deltaLogCount),
 			mlog.Int("file number threshold", Params.DataCoordCfg.SingleCompactionDeltalogMaxNum.GetAsInt()),
+			mlog.Float64("jitterMultiplier", mult),
 		)
 		return true
 	}
 
 	// The proportion of deleted rows is too large, int64 PK tends to accumulates deleted row counts.
-	if float64(totalDeletedRows)/float64(segment.GetNumOfRows()) >= Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat() {
+	if float64(totalDeletedRows)/float64(segment.GetNumOfRows()) >= Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat()*mult {
 		mlog.Info(context.TODO(), "deleted entities rows proportion exceeds threshold",
 			mlog.FieldSegmentID(segment.ID),
 			mlog.Int64("number of rows", segment.GetNumOfRows()),
 			mlog.Int("deleted rows", totalDeletedRows),
 			mlog.Float64("proportion threshold", Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat()),
+			mlog.Float64("jitterMultiplier", mult),
 		)
 		return true
 	}
 
 	// Delete size is too large, varchar PK tends to accumulates deltalog size.
-	if totalDeleteLogSize > Params.DataCoordCfg.SingleCompactionDeltaLogMaxSize.GetAsInt64() {
+	if float64(totalDeleteLogSize) > float64(Params.DataCoordCfg.SingleCompactionDeltaLogMaxSize.GetAsInt64())*mult {
 		mlog.Info(context.TODO(), "total delete entries size exceeds threshold",
 			mlog.FieldSegmentID(segment.ID),
 			mlog.Int64("numRows", segment.GetNumOfRows()),
 			mlog.Int64("delete entries size", totalDeleteLogSize),
 			mlog.Int64("size threshold", Params.DataCoordCfg.SingleCompactionDeltaLogMaxSize.GetAsInt64()),
+			mlog.Float64("jitterMultiplier", mult),
 		)
 		return true
 	}
@@ -770,11 +795,16 @@ func (t *compactionTrigger) ShouldDoSingleCompaction(segment *SegmentInfo, compa
 		return true
 	}
 
-	if float64(totalExpiredRows)/float64(segment.GetNumOfRows()) >= Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat() ||
-		totalExpiredSize > Params.DataCoordCfg.SingleCompactionExpiredLogMaxSize.GetAsInt64() {
+	// Accumulation-type expiry thresholds share the per-segment jitter; the pure
+	// age-based TTL checks below are deliberately not jittered (delaying
+	// retention cleanup is a semantic change) and rely on admission limiting.
+	expiryMult := singleCompactionThresholdMultiplier(segment.ID)
+	if float64(totalExpiredRows)/float64(segment.GetNumOfRows()) >= Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat()*expiryMult ||
+		float64(totalExpiredSize) > float64(Params.DataCoordCfg.SingleCompactionExpiredLogMaxSize.GetAsInt64())*expiryMult {
 		mlog.Info(context.TODO(), "total expired entities is too much, trigger compaction", mlog.FieldSegmentID(segment.ID),
 			mlog.Int("expiredRows", totalExpiredRows), mlog.Int64("expiredLogSize", totalExpiredSize),
-			mlog.Bool("createdByCompaction", segment.CreatedByCompaction), mlog.Int64s("compactionFrom", segment.CompactionFrom))
+			mlog.Bool("createdByCompaction", segment.CreatedByCompaction), mlog.Int64s("compactionFrom", segment.CompactionFrom),
+			mlog.Float64("jitterMultiplier", expiryMult))
 		return true
 	}
 

--- a/internal/datacoord/compaction_trigger.go
+++ b/internal/datacoord/compaction_trigger.go
@@ -457,7 +457,12 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compa
 	var nonPlannedSegments []*SegmentInfo
 
 	// TODO, currently we lack of the measurement of data distribution, there should be another compaction help on redistributing segment based on scalar/vector field distribution
-	var admissionCandidates []*SegmentInfo
+	// Single-compaction candidates are split by reason: accumulation
+	// (delete / expired-entity, the avalanche-shaped case) is paced
+	// dirtiest-first, while retention/index candidates get a reserved share so a
+	// delete-heavy workload cannot starve index rebuild or TTL cleanup.
+	var accumulationCandidates []*SegmentInfo
+	var retentionCandidates []*SegmentInfo
 	for _, segment := range segments {
 		segment := segment.ShadowClone()
 		// TODO should we trigger compaction periodically even if the segment has no obvious reason to be compacted?
@@ -465,25 +470,38 @@ func (t *compactionTrigger) generatePlans(segments []*SegmentInfo, signal *compa
 			// manual/force compaction expresses explicit operator intent and
 			// bypasses admission limiting.
 			prioritizedCandidates = append(prioritizedCandidates, segment)
-		} else if t.ShouldDoSingleCompaction(segment, compactTime) {
-			admissionCandidates = append(admissionCandidates, segment)
-		} else if t.isSmallSegment(segment, expectedSize) {
-			smallCandidates = append(smallCandidates, segment)
-		} else {
-			nonPlannedSegments = append(nonPlannedSegments, segment)
+			continue
+		}
+		switch t.singleCompactionReason(segment, compactTime) {
+		case singleReasonAccumulation:
+			accumulationCandidates = append(accumulationCandidates, segment)
+		case singleReasonRetention:
+			retentionCandidates = append(retentionCandidates, segment)
+		default:
+			if t.isSmallSegment(segment, expectedSize) {
+				smallCandidates = append(smallCandidates, segment)
+			} else {
+				nonPlannedSegments = append(nonPlannedSegments, segment)
+			}
 		}
 	}
 	// Rate-limit single-compaction admissions so that mass eligibility (a
 	// same-batch cohort crossing thresholds together, a threshold config
 	// change, a TTL cliff) becomes a paced stream instead of an avalanche.
-	// Deferred segments carry no state and are re-evaluated next round.
-	admitted, deferred := getSingleCompactionAdmitter().admit(admissionCandidates)
-	prioritizedCandidates = append(prioritizedCandidates, admitted...)
-	if deferred > 0 {
-		mlog.RatedInfo(context.TODO(), rate.Limit(10), "deferred single compaction candidates by admission limit",
-			mlog.FieldCollectionID(signal.collectionID),
-			mlog.Int("admitted", len(admitted)),
-			mlog.Int("deferred", deferred))
+	// Deferred segments carry no state and are re-evaluated next round. Only
+	// consult the admitter when there is something to admit (force signals and
+	// merge-only rounds produce no admission candidates), and skip it when the
+	// inspector is already full so no tokens are spent on plans that would be
+	// dropped downstream.
+	if len(accumulationCandidates)+len(retentionCandidates) > 0 && !t.inspector.isFull() {
+		admitted, deferred := getSingleCompactionAdmitter().admit(context.TODO(), accumulationCandidates, retentionCandidates)
+		prioritizedCandidates = append(prioritizedCandidates, admitted...)
+		if deferred > 0 {
+			mlog.RatedInfo(context.TODO(), rate.Limit(10), "deferred single compaction candidates by admission limit",
+				mlog.FieldCollectionID(signal.collectionID),
+				mlog.Int("admitted", len(admitted)),
+				mlog.Int("deferred", deferred))
+		}
 	}
 
 	buckets := [][]*SegmentInfo{}
@@ -767,7 +785,31 @@ func (t *compactionTrigger) ShouldCompactExpiryWithTTLField(compactTime *compact
 	return startTs.UnixMicro() >= expirationTime && expirationTime > 0
 }
 
+// singleCompactionReason classifies why a segment is eligible for single
+// compaction, so the admission limiter can pace the two shapes fairly.
+type singleCompactionReason int
+
+const (
+	// singleReasonNone: segment is not eligible for single compaction.
+	singleReasonNone singleCompactionReason = iota
+	// singleReasonAccumulation: delete / expired-entity accumulation. This is
+	// the avalanche-shaped case the admission bucket exists for; candidates are
+	// paced dirtiest-first and protected by the deltalog hard cap.
+	singleReasonAccumulation
+	// singleReasonRetention: strict age-based TTL, TTL-field expiry, or index
+	// rebuild. These are NOT delete-driven (deltalog count / deleted-rows ratio
+	// ~= 0), so under the accumulation ordering they would always sort last and
+	// never hit the hard cap — i.e. be starved whenever delete-driven demand
+	// saturates the bucket. They are still paced, but with a reserved share so
+	// they cannot be starved (see singleCompactionAdmitter.admit).
+	singleReasonRetention
+)
+
 func (t *compactionTrigger) ShouldDoSingleCompaction(segment *SegmentInfo, compactTime *compactTime) bool {
+	return t.singleCompactionReason(segment, compactTime) != singleReasonNone
+}
+
+func (t *compactionTrigger) singleCompactionReason(segment *SegmentInfo, compactTime *compactTime) singleCompactionReason {
 	// no longer restricted binlog numbers because this is now related to field numbers
 
 	// if expire time is enabled, put segment into compaction candidate
@@ -791,13 +833,14 @@ func (t *compactionTrigger) ShouldDoSingleCompaction(segment *SegmentInfo, compa
 			earliestFromTs = min(earliestFromTs, tsoutil.EffectiveTimestamp(l.TimestampFrom, segment.GetCommitTimestamp()))
 		}
 	}
+	// Pure age-based TTL retention: not delete-driven, must not be starved.
 	if t.ShouldCompactExpiry(earliestFromTs, compactTime, segment) {
-		return true
+		return singleReasonRetention
 	}
 
 	// Accumulation-type expiry thresholds share the per-segment jitter; the pure
-	// age-based TTL checks below are deliberately not jittered (delaying
-	// retention cleanup is a semantic change) and rely on admission limiting.
+	// age-based TTL checks are deliberately not jittered (delaying retention
+	// cleanup is a semantic change) and rely on admission limiting only.
 	expiryMult := singleCompactionThresholdMultiplier(segment.ID)
 	if float64(totalExpiredRows)/float64(segment.GetNumOfRows()) >= Params.DataCoordCfg.SingleCompactionRatioThreshold.GetAsFloat()*expiryMult ||
 		float64(totalExpiredSize) > float64(Params.DataCoordCfg.SingleCompactionExpiredLogMaxSize.GetAsInt64())*expiryMult {
@@ -805,16 +848,16 @@ func (t *compactionTrigger) ShouldDoSingleCompaction(segment *SegmentInfo, compa
 			mlog.Int("expiredRows", totalExpiredRows), mlog.Int64("expiredLogSize", totalExpiredSize),
 			mlog.Bool("createdByCompaction", segment.CreatedByCompaction), mlog.Int64s("compactionFrom", segment.CompactionFrom),
 			mlog.Float64("jitterMultiplier", expiryMult))
-		return true
+		return singleReasonAccumulation
 	}
 
 	// check if deltalog count, size, and deleted rowcount ratio exceeds threshold
 	if hasTooManyDeletions(segment) {
-		return true
+		return singleReasonAccumulation
 	}
 
 	if t.ShouldRebuildSegmentIndex(segment) {
-		return true
+		return singleReasonRetention
 	}
 
 	if t.ShouldCompactExpiryWithTTLField(compactTime, segment) {
@@ -822,10 +865,10 @@ func (t *compactionTrigger) ShouldDoSingleCompaction(segment *SegmentInfo, compa
 			mlog.FieldCollectionID(segment.CollectionID),
 			mlog.FieldPartitionID(segment.PartitionID),
 			mlog.String("channel", segment.InsertChannel))
-		return true
+		return singleReasonRetention
 	}
 
-	return false
+	return singleReasonNone
 }
 
 func (t *compactionTrigger) ShouldRebuildSegmentIndex(segment *SegmentInfo) bool {

--- a/pkg/util/paramtable/component_param.go
+++ b/pkg/util/paramtable/component_param.go
@@ -5239,6 +5239,9 @@ type dataCoordConfig struct {
 	SingleCompactionDeltaLogMaxSize   ParamItem `refreshable:"true"`
 	SingleCompactionExpiredLogMaxSize ParamItem `refreshable:"true"`
 	SingleCompactionDeltalogMaxNum    ParamItem `refreshable:"true"`
+	SingleCompactionThresholdJitter   ParamItem `refreshable:"true"`
+	SingleCompactionRateLimitTokens   ParamItem `refreshable:"true"`
+	SingleCompactionRateLimitInterval ParamItem `refreshable:"true"`
 
 	StorageVersionCompactionEnabled                   ParamItem `refreshable:"true"`
 	StorageFormatCompactionEnabled                    ParamItem `refreshable:"true"`
@@ -5800,6 +5803,39 @@ During compaction, the size of segment # of rows is able to exceed segment max #
 		Export:       true,
 	}
 	p.SingleCompactionDeltalogMaxNum.Init(base.mgr)
+
+	p.SingleCompactionThresholdJitter = ParamItem{
+		Key:          "dataCoord.compaction.single.thresholdJitter",
+		Version:      "3.0.0",
+		DefaultValue: "0.25",
+		Doc: "Deterministic per-segment jitter applied to the single-compaction accumulation thresholds " +
+			"(deltalog count/size, deleted-rows ratio, expired-entities ratio/size). Each segment's effective " +
+			"threshold becomes configured x [1, 1+jitter], de-synchronizing same-batch segments so they do not " +
+			"trigger rewrites simultaneously. 0 disables (legacy behavior).",
+		Export: false,
+	}
+	p.SingleCompactionThresholdJitter.Init(base.mgr)
+
+	p.SingleCompactionRateLimitTokens = ParamItem{
+		Key:          "dataCoord.compaction.single.rateLimitTokens",
+		Version:      "3.0.0",
+		DefaultValue: "256",
+		Doc: "Max single-compaction candidates admitted per rateLimitInterval (token bucket). Shock protection " +
+			"against mass eligibility (e.g. a threshold config change); size it well above steady-state demand — " +
+			"an undersized bucket defers rewrites indefinitely and lets deltalog backlog grow. Segments whose " +
+			"deltalog count exceeds 4x the configured maximum bypass the limit. 0 disables (legacy behavior).",
+		Export: false,
+	}
+	p.SingleCompactionRateLimitTokens.Init(base.mgr)
+
+	p.SingleCompactionRateLimitInterval = ParamItem{
+		Key:          "dataCoord.compaction.single.rateLimitInterval",
+		Version:      "3.0.0",
+		DefaultValue: "60",
+		Doc:          "Refill interval of the single-compaction admission token bucket, in seconds.",
+		Export:       false,
+	}
+	p.SingleCompactionRateLimitInterval.Init(base.mgr)
 
 	p.StorageVersionCompactionEnabled = ParamItem{
 		Key:          "dataCoord.compaction.storageVersion.enabled",


### PR DESCRIPTION
issue: #51094

### What

Segments created in the same batch (bulk import, DR initial sync, restore) accumulate deltalogs at nearly the same rate, so they cross the single-compaction hard thresholds (`single.deltalog.maxnum` etc.) almost simultaneously. The result is a synchronized rewrite avalanche: in a production incident, ~1,400 segments became eligible within ~36 hours and the cluster rewrote multiple TB against a rate-limited object store, degrading queries for days. The same shock shape is produced by a threshold config change taking effect, a TTL cliff, or flipping `autoUpgradeSegmentIndex`.

This PR de-synchronizes and bounds delete/expiry-triggered single compaction with two independent mechanisms (each individually disableable, both refreshable):

1. **Deterministic per-segment threshold jitter** (`dataCoord.compaction.single.thresholdJitter`, default 0.25). Each segment gets a stable multiplier in `[1, 1+J]` (splitmix64 hash of segment ID — no persisted state, consistent across restarts/nodes) applied to the *accumulation* thresholds: deltalog count, deltalog size, deleted-rows ratio, and expired-entities ratio/size. A cohort's crossing times spread over `J ×` (accumulation period) — for the incident shape, ~12 days instead of ~36 hours.
2. **Token-bucket admission at plan generation** (`dataCoord.compaction.single.rateLimitTokens` / `rateLimitInterval`, default 256 per 60s). Jitter cannot help when eligibility jumps in one step (config change, TTL cliff); the bucket converts any mass eligibility into a paced stream. Deferred segments carry no state and are simply re-evaluated on later trigger rounds. Admission is dirtiest-first (highest deleted-rows ratio), the same rate-limit parameter shape as the existing `dataCoord.compaction.storageVersion.rateLimitTokens/rateLimitInterval`.

Guardrails:
- **Bounded deferral**: a segment whose deltalog count reaches 4× `single.deltalog.maxnum` is always admitted without consuming tokens, so the limiter can never starve a pathological segment.
- **Misconfiguration warning**: sustained throttling (30+ consecutive throttled rounds) emits a rate-limited WARN — an undersized bucket means backlog is growing and the operator must know.
- `signal.isForce` (manual compaction) bypasses admission entirely — explicit operator intent.
- Pure **age-based TTL checks are deliberately not jittered** (delaying retention cleanup is a semantic change); they are protected by admission limiting only. The small-segment merge path (`isExpandableSmallSegment`) is out of scope — it is self-limiting and not avalanche-shaped.
- `thresholdJitter=0` plus `rateLimitTokens=0` restore exact legacy behavior.

### Why jitter must multiply all accumulation dimensions

Simulation of the incident (details and figures in #51094): jittering only the file-count threshold leaks the avalanche through the deleted-rows-ratio dimension — segments whose count threshold was raised simply trigger via ratio at the original synchronized time. Peak daily rewrite volume with count-only jitter was identical to no protection (~2,000 GB/day), while all-dimension jitter cut it to ~440 GB/day. The multiplier therefore applies uniformly to every accumulation dimension of a segment.

### Simulated results (issue #51094)

| Scenario (calibrated to the incident) | legacy | jitter+bucket |
|---|---|---|
| Peak daily rewrite volume | 6,000+ GB/day | −74% |
| Total rewrites over 180 days | baseline | −11% (fewer premature rewrites) |
| Single-round shock (config change, 6,300 eligible at once) | one avalanche | drained over 2–3 days, bounded by hard cap |

### Test plan

- New unit tests (`compaction_admission_test.go`): multiplier determinism / range / zero-jitter disable; admitter disabled-bucket passthrough, dirtiest-first limiting, hard-cap bypass, token refill with injected clock.
- Existing `Test_compactionTrigger_*` and `TestSingleCompactionPolicySuite` pass; two cases that assert exact legacy threshold boundaries now pin `thresholdJitter=0`.
- Full `./internal/datacoord/` suite passes locally.
