### PR TITLE
enhance: add per-collection deltalog observability metrics

### DIFF
--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -599,6 +599,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 	var total int64
 	storedBinlogSize := make(map[string]map[string]int64) // map[collectionID]map[segment_state]size
 	binlogFileCount := make(map[string]int64)             // map[collectionID]count
+	deltalogAggregates := make(map[string]*deltalogAggregate)
 	coll2DbName := make(map[string]string)
 
 	for _, segment := range segments {
@@ -624,6 +625,13 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 
 				storedBinlogSize[collIDStr][segment.GetState().String()] += segmentSize
 				binlogFileCount[collIDStr] += int64(getBinlogFileCount(segment.SegmentInfo))
+
+				agg, ok := deltalogAggregates[collIDStr]
+				if !ok {
+					agg = &deltalogAggregate{}
+					deltalogAggregates[collIDStr] = agg
+				}
+				agg.observe(segment)
 			}
 
 			if _, ok := collectionRowsNum[segment.GetCollectionID()]; !ok {
@@ -667,6 +675,8 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 			metrics.DataCoordL0DeleteEntriesNum.WithLabelValues(coll.DatabaseName, strconv.FormatInt(collectionID, 10)).Set(float64(entriesNum))
 		}
 	}
+
+	reportDeltalogMetrics(deltalogAggregates)
 
 	info.TotalBinlogSize = total
 	info.CollectionBinlogSize = collectionBinlogSize

--- a/internal/datacoord/meta.go
+++ b/internal/datacoord/meta.go
@@ -628,7 +628,7 @@ func (m *meta) GetQuotaInfo() *metricsinfo.DataCoordQuotaMetrics {
 
 				agg, ok := deltalogAggregates[collIDStr]
 				if !ok {
-					agg = &deltalogAggregate{}
+					agg = &deltalogAggregate{dbName: coll.DatabaseName}
 					deltalogAggregates[collIDStr] = agg
 				}
 				agg.observe(segment)

--- a/internal/datacoord/metrics_deltalog.go
+++ b/internal/datacoord/metrics_deltalog.go
@@ -17,7 +17,9 @@
 package datacoord
 
 import (
+	"math"
 	"sort"
+	"sync"
 
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
@@ -39,45 +41,58 @@ var deltalogQuantiles = []struct {
 	{"1.0", 1.0},
 }
 
-// deltalogAggregate collects per-collection deltalog observability stats,
-// mirroring the accumulation dimensions checked by hasTooManyDeletions.
+// deltalogAggregate collects per-collection deltalog observability stats over
+// healthy FLUSHED non-L0 segments — the population hasTooManyDeletions is
+// evaluated against (growing/sealed segments route deletes to L0 and would
+// pad the distributions with zeros). Three of its accumulation dimensions are
+// mirrored: deltalog file count, accumulated deltalog size, and deleted-rows
+// ratio; zero-row segments are excluded from the ratio distribution (the
+// trigger's own uncapped division would fire on them, but a +Inf sample would
+// poison the gauge). Deltalog files of L0 segments are counted separately
+// over all healthy L0 segments, matching l0_delete_entries_num.
 type deltalogAggregate struct {
-	fileCounts    []float64 // per non-L0 segment deltalog file count
-	deletedRatios []float64 // per non-L0 segment deleted-rows/total-rows
+	dbName        string
+	fileCounts    []float64
+	sizes         []float64
+	deletedRatios []float64
 	l0FileCount   int64
 }
 
 func (a *deltalogAggregate) observe(segment *SegmentInfo) {
 	fileCount := 0
+	size := int64(0)
 	deletedRows := int64(0)
 	for _, deltaLogs := range segment.GetDeltalogs() {
 		for _, l := range deltaLogs.GetBinlogs() {
 			deletedRows += l.GetEntriesNum()
+			size += l.GetMemorySize()
 		}
 		fileCount += len(deltaLogs.GetBinlogs())
 	}
 
 	if segment.GetLevel() == datapb.SegmentLevel_L0 {
-		// L0 segments hold the un-applied delete stream; their deltalogs never
-		// count toward the single-compaction trigger, so track them separately.
 		a.l0FileCount += int64(fileCount)
+		return
+	}
+	if !isFlushed(segment) {
 		return
 	}
 
 	a.fileCounts = append(a.fileCounts, float64(fileCount))
+	a.sizes = append(a.sizes, float64(size))
 	if segment.GetNumOfRows() > 0 {
 		a.deletedRatios = append(a.deletedRatios, float64(deletedRows)/float64(segment.GetNumOfRows()))
 	}
 }
 
-// quantile returns the exact nearest-rank quantile of values, sorting in
-// place; 0 for an empty slice.
+// quantile returns the exact nearest-rank quantile (rank = ceil(q*n)) of
+// values, sorting in place; 0 for an empty slice.
 func quantile(values []float64, q float64) float64 {
 	if len(values) == 0 {
 		return 0
 	}
 	sort.Float64s(values)
-	idx := int(q*float64(len(values))+0.5) - 1
+	idx := int(math.Ceil(q*float64(len(values)))) - 1
 	if idx < 0 {
 		idx = 0
 	}
@@ -87,18 +102,38 @@ func quantile(values []float64, q float64) float64 {
 	return values[idx]
 }
 
-// reportDeltalogMetrics resets and republishes the per-collection deltalog
-// gauges; the reset removes series of dropped collections (they are also
-// eagerly deleted in CleanupDataCoordWithCollectionID on DropCollection).
+var (
+	deltalogPublishMu sync.Mutex
+	// collections whose deltalog series are currently published; lets a
+	// refresh round prune collections that disappeared since the last one
+	publishedDeltalogCollections = make(map[string]struct{})
+)
+
+// reportDeltalogMetrics publishes the per-collection deltalog gauges, then
+// prunes series of collections absent from this round (dropped collections are
+// also eagerly cleaned in CleanupDataCoordWithCollectionID on DropCollection).
+// Publish-then-prune instead of Reset-then-Set so a concurrent scrape never
+// observes an empty window; the mutex serializes concurrent GetQuotaInfo
+// callers.
 func reportDeltalogMetrics(aggregates map[string]*deltalogAggregate) {
-	metrics.DataCoordSegmentDeltalogFileCount.Reset()
-	metrics.DataCoordSegmentDeletedRowsRatio.Reset()
-	metrics.DataCoordL0DeltalogFileNum.Reset()
+	deltalogPublishMu.Lock()
+	defer deltalogPublishMu.Unlock()
+
 	for collectionID, agg := range aggregates {
-		metrics.DataCoordL0DeltalogFileNum.WithLabelValues(collectionID).Set(float64(agg.l0FileCount))
+		metrics.DataCoordL0DeltalogFileNum.WithLabelValues(agg.dbName, collectionID).Set(float64(agg.l0FileCount))
 		for _, p := range deltalogQuantiles {
-			metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues(collectionID, p.label).Set(quantile(agg.fileCounts, p.q))
-			metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues(collectionID, p.label).Set(quantile(agg.deletedRatios, p.q))
+			metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues(agg.dbName, collectionID, p.label).Set(quantile(agg.fileCounts, p.q))
+			metrics.DataCoordSegmentDeltalogSize.WithLabelValues(agg.dbName, collectionID, p.label).Set(quantile(agg.sizes, p.q))
+			metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues(agg.dbName, collectionID, p.label).Set(quantile(agg.deletedRatios, p.q))
 		}
+	}
+	for collectionID := range publishedDeltalogCollections {
+		if _, ok := aggregates[collectionID]; !ok {
+			metrics.CleanupDataCoordDeltalogMetrics(collectionID)
+			delete(publishedDeltalogCollections, collectionID)
+		}
+	}
+	for collectionID := range aggregates {
+		publishedDeltalogCollections[collectionID] = struct{}{}
 	}
 }

--- a/internal/datacoord/metrics_deltalog.go
+++ b/internal/datacoord/metrics_deltalog.go
@@ -41,24 +41,50 @@ var deltalogQuantiles = []struct {
 	{"1.0", 1.0},
 }
 
-// deltalogAggregate collects per-collection deltalog observability stats over
-// healthy FLUSHED non-L0 segments — the population hasTooManyDeletions is
-// evaluated against (growing/sealed segments route deletes to L0 and would
-// pad the distributions with zeros). Three of its accumulation dimensions are
-// mirrored: deltalog file count, accumulated deltalog size, and deleted-rows
-// ratio; zero-row segments are excluded from the ratio distribution (the
-// trigger's own uncapped division would fire on them, but a +Inf sample would
-// poison the gauge). Deltalog files of L0 segments are counted separately
-// over all healthy L0 segments, matching l0_delete_entries_num.
-type deltalogAggregate struct {
-	dbName        string
+// levelDist holds one segment level's mirrored deltalog distributions:
+// deltalog file count, accumulated deltalog size, and deleted-rows ratio.
+type levelDist struct {
 	fileCounts    []float64
 	sizes         []float64
 	deletedRatios []float64
-	l0FileCount   int64
+}
+
+// deltalogAggregate collects per-collection deltalog observability stats over
+// healthy FLUSHED non-L0 segments — the population hasTooManyDeletions is
+// approximately evaluated against (growing/sealed segments route deletes to L0
+// and would pad the distributions with zeros). It only gates on L0 + isFlushed
+// (the caller already guarantees healthy && !importing); the finer candidacy
+// predicates (isCompacting, IsSorted, IsInvisible, compaction-protected) are
+// not applied, so the distributions approximate rather than exactly equal the
+// candidate set. Distributions are kept per segment level (byLevel): the two
+// single-compaction paths that reach hasTooManyDeletions each cover one level
+// (auto-compaction filters to L2, manual to L1), so blending them into one
+// quantile would dilute p50/p90. Zero-row segments are excluded from the ratio
+// distribution (the trigger's own uncapped division would fire on them, but a
+// +Inf sample would poison the gauge). Deltalog files of L0 segments are
+// counted separately over all healthy L0 segments, matching
+// l0_delete_entries_num.
+type deltalogAggregate struct {
+	dbName      string
+	byLevel     map[datapb.SegmentLevel]*levelDist
+	l0FileCount int64
 }
 
 func (a *deltalogAggregate) observe(segment *SegmentInfo) {
+	// L0 uses only the deltalog file count (l0_delete_entries_num companion);
+	// skip the size/deleted-row accumulation the non-L0 path needs.
+	if segment.GetLevel() == datapb.SegmentLevel_L0 {
+		fileCount := 0
+		for _, deltaLogs := range segment.GetDeltalogs() {
+			fileCount += len(deltaLogs.GetBinlogs())
+		}
+		a.l0FileCount += int64(fileCount)
+		return
+	}
+	if !isFlushed(segment) {
+		return
+	}
+
 	fileCount := 0
 	size := int64(0)
 	deletedRows := int64(0)
@@ -70,36 +96,42 @@ func (a *deltalogAggregate) observe(segment *SegmentInfo) {
 		fileCount += len(deltaLogs.GetBinlogs())
 	}
 
-	if segment.GetLevel() == datapb.SegmentLevel_L0 {
-		a.l0FileCount += int64(fileCount)
-		return
+	if a.byLevel == nil {
+		a.byLevel = make(map[datapb.SegmentLevel]*levelDist)
 	}
-	if !isFlushed(segment) {
-		return
+	d := a.byLevel[segment.GetLevel()]
+	if d == nil {
+		d = &levelDist{}
+		a.byLevel[segment.GetLevel()] = d
 	}
-
-	a.fileCounts = append(a.fileCounts, float64(fileCount))
-	a.sizes = append(a.sizes, float64(size))
+	d.fileCounts = append(d.fileCounts, float64(fileCount))
+	d.sizes = append(d.sizes, float64(size))
 	if segment.GetNumOfRows() > 0 {
-		a.deletedRatios = append(a.deletedRatios, float64(deletedRows)/float64(segment.GetNumOfRows()))
+		d.deletedRatios = append(d.deletedRatios, float64(deletedRows)/float64(segment.GetNumOfRows()))
 	}
 }
 
-// quantile returns the exact nearest-rank quantile (rank = ceil(q*n)) of
-// values, sorting in place; 0 for an empty slice.
-func quantile(values []float64, q float64) float64 {
+// quantilesInPlace sorts values once and returns the exact nearest-rank
+// (rank = ceil(q*n)) value for each requested quantile; all-zeros for an empty
+// slice. Sorting once (vs once per quantile) shortens the read-lock hold in
+// reportDeltalogMetrics.
+func quantilesInPlace(values []float64, qs []float64) []float64 {
+	out := make([]float64, len(qs))
 	if len(values) == 0 {
-		return 0
+		return out
 	}
 	sort.Float64s(values)
-	idx := int(math.Ceil(q*float64(len(values)))) - 1
-	if idx < 0 {
-		idx = 0
+	for i, q := range qs {
+		idx := int(math.Ceil(q*float64(len(values)))) - 1
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(values) {
+			idx = len(values) - 1
+		}
+		out[i] = values[idx]
 	}
-	if idx >= len(values) {
-		idx = len(values) - 1
-	}
-	return values[idx]
+	return out
 }
 
 var (
@@ -119,12 +151,23 @@ func reportDeltalogMetrics(aggregates map[string]*deltalogAggregate) {
 	deltalogPublishMu.Lock()
 	defer deltalogPublishMu.Unlock()
 
+	qs := make([]float64, len(deltalogQuantiles))
+	for i, p := range deltalogQuantiles {
+		qs[i] = p.q
+	}
+
 	for collectionID, agg := range aggregates {
 		metrics.DataCoordL0DeltalogFileNum.WithLabelValues(agg.dbName, collectionID).Set(float64(agg.l0FileCount))
-		for _, p := range deltalogQuantiles {
-			metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues(agg.dbName, collectionID, p.label).Set(quantile(agg.fileCounts, p.q))
-			metrics.DataCoordSegmentDeltalogSize.WithLabelValues(agg.dbName, collectionID, p.label).Set(quantile(agg.sizes, p.q))
-			metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues(agg.dbName, collectionID, p.label).Set(quantile(agg.deletedRatios, p.q))
+		for level, d := range agg.byLevel {
+			levelStr := level.String()
+			fcQ := quantilesInPlace(d.fileCounts, qs)
+			szQ := quantilesInPlace(d.sizes, qs)
+			drQ := quantilesInPlace(d.deletedRatios, qs)
+			for i, p := range deltalogQuantiles {
+				metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues(agg.dbName, collectionID, levelStr, p.label).Set(fcQ[i])
+				metrics.DataCoordSegmentDeltalogSize.WithLabelValues(agg.dbName, collectionID, levelStr, p.label).Set(szQ[i])
+				metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues(agg.dbName, collectionID, levelStr, p.label).Set(drQ[i])
+			}
 		}
 	}
 	for collectionID := range publishedDeltalogCollections {

--- a/internal/datacoord/metrics_deltalog.go
+++ b/internal/datacoord/metrics_deltalog.go
@@ -1,0 +1,104 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"sort"
+
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+)
+
+// deltalogQuantiles are the summary quantiles published for the per-segment
+// deltalog distributions. The 1.0 quantile (max) tracks the dirtiest segment
+// against the single-compaction thresholds; the lower quantiles rising toward
+// a threshold reveal a same-batch cohort accumulating toward a synchronized
+// compaction wave, which the max alone cannot distinguish from a lone dirty
+// segment.
+var deltalogQuantiles = []struct {
+	label string
+	q     float64
+}{
+	{"0.5", 0.5},
+	{"0.9", 0.9},
+	{"0.99", 0.99},
+	{"1.0", 1.0},
+}
+
+// deltalogAggregate collects per-collection deltalog observability stats,
+// mirroring the accumulation dimensions checked by hasTooManyDeletions.
+type deltalogAggregate struct {
+	fileCounts    []float64 // per non-L0 segment deltalog file count
+	deletedRatios []float64 // per non-L0 segment deleted-rows/total-rows
+	l0FileCount   int64
+}
+
+func (a *deltalogAggregate) observe(segment *SegmentInfo) {
+	fileCount := 0
+	deletedRows := int64(0)
+	for _, deltaLogs := range segment.GetDeltalogs() {
+		for _, l := range deltaLogs.GetBinlogs() {
+			deletedRows += l.GetEntriesNum()
+		}
+		fileCount += len(deltaLogs.GetBinlogs())
+	}
+
+	if segment.GetLevel() == datapb.SegmentLevel_L0 {
+		// L0 segments hold the un-applied delete stream; their deltalogs never
+		// count toward the single-compaction trigger, so track them separately.
+		a.l0FileCount += int64(fileCount)
+		return
+	}
+
+	a.fileCounts = append(a.fileCounts, float64(fileCount))
+	if segment.GetNumOfRows() > 0 {
+		a.deletedRatios = append(a.deletedRatios, float64(deletedRows)/float64(segment.GetNumOfRows()))
+	}
+}
+
+// quantile returns the exact nearest-rank quantile of values, sorting in
+// place; 0 for an empty slice.
+func quantile(values []float64, q float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sort.Float64s(values)
+	idx := int(q*float64(len(values))+0.5) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(values) {
+		idx = len(values) - 1
+	}
+	return values[idx]
+}
+
+// reportDeltalogMetrics resets and republishes the per-collection deltalog
+// gauges; the reset removes series of dropped collections (they are also
+// eagerly deleted in CleanupDataCoordWithCollectionID on DropCollection).
+func reportDeltalogMetrics(aggregates map[string]*deltalogAggregate) {
+	metrics.DataCoordSegmentDeltalogFileCount.Reset()
+	metrics.DataCoordSegmentDeletedRowsRatio.Reset()
+	metrics.DataCoordL0DeltalogFileNum.Reset()
+	for collectionID, agg := range aggregates {
+		metrics.DataCoordL0DeltalogFileNum.WithLabelValues(collectionID).Set(float64(agg.l0FileCount))
+		for _, p := range deltalogQuantiles {
+			metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues(collectionID, p.label).Set(quantile(agg.fileCounts, p.q))
+			metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues(collectionID, p.label).Set(quantile(agg.deletedRatios, p.q))
+		}
+	}
+}

--- a/internal/datacoord/metrics_deltalog_test.go
+++ b/internal/datacoord/metrics_deltalog_test.go
@@ -43,20 +43,18 @@ func makeDeltaMetricSegment(level datapb.SegmentLevel, state commonpb.SegmentSta
 }
 
 func TestDeltalogQuantile(t *testing.T) {
-	assert.Equal(t, 0.0, quantile(nil, 0.5))
+	assert.Equal(t, []float64{0, 0}, quantilesInPlace(nil, []float64{0.5, 1.0}))
 
 	values := []float64{40, 10, 30, 20} // sorted: 10 20 30 40
-	assert.Equal(t, 20.0, quantile(values, 0.5))
-	assert.Equal(t, 40.0, quantile(values, 0.99))
-	assert.Equal(t, 40.0, quantile(values, 1.0))
+	got := quantilesInPlace(values, []float64{0.5, 0.99, 1.0})
+	assert.Equal(t, []float64{20, 40, 40}, got)
 
 	// nearest-rank: rank = ceil(0.9*9) = 9 -> the 9th value
 	nine := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}
-	assert.Equal(t, 9.0, quantile(nine, 0.9))
+	assert.Equal(t, []float64{9}, quantilesInPlace(nine, []float64{0.9}))
 
 	single := []float64{7}
-	assert.Equal(t, 7.0, quantile(single, 0.5))
-	assert.Equal(t, 7.0, quantile(single, 1.0))
+	assert.Equal(t, []float64{7, 7}, quantilesInPlace(single, []float64{0.5, 1.0}))
 }
 
 func TestDeltalogAggregateObserve(t *testing.T) {
@@ -65,42 +63,50 @@ func TestDeltalogAggregateObserve(t *testing.T) {
 	// L0 segments only feed the L0 file counter
 	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L0, commonpb.SegmentState_Flushed, 0, 7, 100, 1024))
 	assert.Equal(t, int64(7), agg.l0FileCount)
-	assert.Empty(t, agg.fileCounts)
+	assert.Empty(t, agg.byLevel)
 
 	// non-flushed segments are outside the trigger's candidate population
 	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Growing, 1000, 3, 10, 512))
 	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Sealed, 1000, 3, 10, 512))
-	assert.Empty(t, agg.fileCounts)
+	assert.Empty(t, agg.byLevel)
 
-	// flushed non-L0 segments feed the distributions
+	// flushed non-L0 segments feed the distributions, kept per level
 	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Flushed, 1000, 30, 10, 2048)) // ratio 0.3
 	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 1000, 150, 1, 4096)) // ratio 0.15
 	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 0, 900, 1, 512))     // zero rows: ratio skipped
 
-	assert.Equal(t, []float64{30, 150, 900}, agg.fileCounts)
-	assert.Equal(t, []float64{30 * 2048, 150 * 4096, 900 * 512}, agg.sizes)
-	assert.Len(t, agg.deletedRatios, 2)
-	assert.InDelta(t, 0.3, agg.deletedRatios[0], 1e-9)
-	assert.InDelta(t, 0.15, agg.deletedRatios[1], 1e-9)
+	l1 := agg.byLevel[datapb.SegmentLevel_L1]
+	l2 := agg.byLevel[datapb.SegmentLevel_L2]
+	assert.Equal(t, []float64{30}, l1.fileCounts)
+	assert.Equal(t, []float64{30 * 2048}, l1.sizes)
+	assert.Len(t, l1.deletedRatios, 1)
+	assert.InDelta(t, 0.3, l1.deletedRatios[0], 1e-9)
+	assert.Equal(t, []float64{150, 900}, l2.fileCounts)
+	assert.Equal(t, []float64{150 * 4096, 900 * 512}, l2.sizes)
+	assert.Len(t, l2.deletedRatios, 1) // zero-row L2 segment excluded
+	assert.InDelta(t, 0.15, l2.deletedRatios[0], 1e-9)
 }
 
 func TestReportDeltalogMetrics(t *testing.T) {
 	agg := &deltalogAggregate{dbName: "db1"}
 	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L0, commonpb.SegmentState_Flushed, 0, 5, 100, 1024))
-	// a synchronized cohort at ~180 files plus one lone dirty segment
+	// L1 (manual-compaction candidates): a cohort at ~180 files
 	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Flushed, 1000, 180, 1, 1024))
 	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Flushed, 1000, 181, 1, 1024))
+	// L2 (auto-compaction candidates): a cohort plus one lone dirty segment
 	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 1000, 182, 1, 1024))
 	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 1000, 600, 1, 1024))
 
 	reportDeltalogMetrics(map[string]*deltalogAggregate{"100": agg})
 
 	assert.Equal(t, 5.0, testutil.ToFloat64(metrics.DataCoordL0DeltalogFileNum.WithLabelValues("db1", "100")))
-	// the cohort shows up in the median while max sees only the outlier
-	assert.Equal(t, 181.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "0.5")))
-	assert.Equal(t, 600.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "1.0")))
-	assert.Equal(t, float64(181*1024), testutil.ToFloat64(metrics.DataCoordSegmentDeltalogSize.WithLabelValues("db1", "100", "0.5")))
-	assert.InDelta(t, 0.181, testutil.ToFloat64(metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues("db1", "100", "0.5")), 1e-9)
+	// L1 and L2 stay separate quantiles (not blended): p50 = nearest-rank of each level's 2 samples
+	assert.Equal(t, 180.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "L1", "0.5")))
+	assert.Equal(t, 181.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "L1", "1.0")))
+	assert.Equal(t, 182.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "L2", "0.5")))
+	assert.Equal(t, 600.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "L2", "1.0")))
+	assert.Equal(t, float64(180*1024), testutil.ToFloat64(metrics.DataCoordSegmentDeltalogSize.WithLabelValues("db1", "100", "L1", "0.5")))
+	assert.InDelta(t, 0.180, testutil.ToFloat64(metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues("db1", "100", "L1", "0.5")), 1e-9)
 
 	// a refresh round without the collection prunes its series
 	reportDeltalogMetrics(map[string]*deltalogAggregate{})

--- a/internal/datacoord/metrics_deltalog_test.go
+++ b/internal/datacoord/metrics_deltalog_test.go
@@ -1,0 +1,97 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacoord
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus/pkg/v3/metrics"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+)
+
+func makeDeltaMetricSegment(level datapb.SegmentLevel, numRows int64, deltalogCount int, rowsPerLog int64) *SegmentInfo {
+	binlogs := make([]*datapb.Binlog, 0, deltalogCount)
+	for i := 0; i < deltalogCount; i++ {
+		binlogs = append(binlogs, &datapb.Binlog{EntriesNum: rowsPerLog, MemorySize: 1024})
+	}
+	return &SegmentInfo{
+		SegmentInfo: &datapb.SegmentInfo{
+			Level:     level,
+			NumOfRows: numRows,
+			Deltalogs: []*datapb.FieldBinlog{{Binlogs: binlogs}},
+		},
+	}
+}
+
+func TestDeltalogQuantile(t *testing.T) {
+	assert.Equal(t, 0.0, quantile(nil, 0.5))
+
+	values := []float64{40, 10, 30, 20} // sorted: 10 20 30 40
+	assert.Equal(t, 20.0, quantile(values, 0.5))
+	assert.Equal(t, 40.0, quantile(values, 0.99))
+	assert.Equal(t, 40.0, quantile(values, 1.0))
+
+	single := []float64{7}
+	assert.Equal(t, 7.0, quantile(single, 0.5))
+	assert.Equal(t, 7.0, quantile(single, 1.0))
+}
+
+func TestDeltalogAggregateObserve(t *testing.T) {
+	agg := &deltalogAggregate{}
+
+	// L0 segments only feed the L0 file counter
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L0, 0, 7, 100))
+	assert.Equal(t, int64(7), agg.l0FileCount)
+	assert.Empty(t, agg.fileCounts)
+
+	// non-L0 segments feed the distributions
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, 1000, 30, 10)) // 300 deleted -> ratio 0.3
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, 1000, 150, 1)) // 150 deleted -> ratio 0.15
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, 0, 900, 1))    // zero rows: ratio skipped
+
+	assert.Equal(t, []float64{30, 150, 900}, agg.fileCounts)
+	assert.Len(t, agg.deletedRatios, 2)
+	assert.InDelta(t, 0.3, agg.deletedRatios[0], 1e-9)
+	assert.InDelta(t, 0.15, agg.deletedRatios[1], 1e-9)
+}
+
+func TestReportDeltalogMetrics(t *testing.T) {
+	agg := &deltalogAggregate{}
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L0, 0, 5, 100))
+	// a synchronized cohort at ~180 files plus one lone dirty segment
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, 1000, 180, 1))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, 1000, 181, 1))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, 1000, 182, 1))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, 1000, 600, 1))
+
+	reportDeltalogMetrics(map[string]*deltalogAggregate{"100": agg})
+
+	assert.Equal(t, 5.0, testutil.ToFloat64(metrics.DataCoordL0DeltalogFileNum.WithLabelValues("100")))
+	// the cohort shows up in the median while max sees only the outlier
+	assert.Equal(t, 181.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("100", "0.5")))
+	assert.Equal(t, 600.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("100", "1.0")))
+	assert.InDelta(t, 0.181, testutil.ToFloat64(metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues("100", "0.5")), 1e-9)
+
+	// a refresh round without the collection removes its series
+	reportDeltalogMetrics(map[string]*deltalogAggregate{})
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataCoordSegmentDeltalogFileCount))
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataCoordSegmentDeletedRowsRatio))
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataCoordL0DeltalogFileNum))
+}

--- a/internal/datacoord/metrics_deltalog_test.go
+++ b/internal/datacoord/metrics_deltalog_test.go
@@ -22,18 +22,20 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/milvus-io/milvus-proto/go-api/v3/commonpb"
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
 	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 )
 
-func makeDeltaMetricSegment(level datapb.SegmentLevel, numRows int64, deltalogCount int, rowsPerLog int64) *SegmentInfo {
+func makeDeltaMetricSegment(level datapb.SegmentLevel, state commonpb.SegmentState, numRows int64, deltalogCount int, rowsPerLog int64, sizePerLog int64) *SegmentInfo {
 	binlogs := make([]*datapb.Binlog, 0, deltalogCount)
 	for i := 0; i < deltalogCount; i++ {
-		binlogs = append(binlogs, &datapb.Binlog{EntriesNum: rowsPerLog, MemorySize: 1024})
+		binlogs = append(binlogs, &datapb.Binlog{EntriesNum: rowsPerLog, MemorySize: sizePerLog})
 	}
 	return &SegmentInfo{
 		SegmentInfo: &datapb.SegmentInfo{
 			Level:     level,
+			State:     state,
 			NumOfRows: numRows,
 			Deltalogs: []*datapb.FieldBinlog{{Binlogs: binlogs}},
 		},
@@ -48,6 +50,10 @@ func TestDeltalogQuantile(t *testing.T) {
 	assert.Equal(t, 40.0, quantile(values, 0.99))
 	assert.Equal(t, 40.0, quantile(values, 1.0))
 
+	// nearest-rank: rank = ceil(0.9*9) = 9 -> the 9th value
+	nine := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	assert.Equal(t, 9.0, quantile(nine, 0.9))
+
 	single := []float64{7}
 	assert.Equal(t, 7.0, quantile(single, 0.5))
 	assert.Equal(t, 7.0, quantile(single, 1.0))
@@ -57,41 +63,49 @@ func TestDeltalogAggregateObserve(t *testing.T) {
 	agg := &deltalogAggregate{}
 
 	// L0 segments only feed the L0 file counter
-	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L0, 0, 7, 100))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L0, commonpb.SegmentState_Flushed, 0, 7, 100, 1024))
 	assert.Equal(t, int64(7), agg.l0FileCount)
 	assert.Empty(t, agg.fileCounts)
 
-	// non-L0 segments feed the distributions
-	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, 1000, 30, 10)) // 300 deleted -> ratio 0.3
-	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, 1000, 150, 1)) // 150 deleted -> ratio 0.15
-	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, 0, 900, 1))    // zero rows: ratio skipped
+	// non-flushed segments are outside the trigger's candidate population
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Growing, 1000, 3, 10, 512))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Sealed, 1000, 3, 10, 512))
+	assert.Empty(t, agg.fileCounts)
+
+	// flushed non-L0 segments feed the distributions
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Flushed, 1000, 30, 10, 2048)) // ratio 0.3
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 1000, 150, 1, 4096)) // ratio 0.15
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 0, 900, 1, 512))     // zero rows: ratio skipped
 
 	assert.Equal(t, []float64{30, 150, 900}, agg.fileCounts)
+	assert.Equal(t, []float64{30 * 2048, 150 * 4096, 900 * 512}, agg.sizes)
 	assert.Len(t, agg.deletedRatios, 2)
 	assert.InDelta(t, 0.3, agg.deletedRatios[0], 1e-9)
 	assert.InDelta(t, 0.15, agg.deletedRatios[1], 1e-9)
 }
 
 func TestReportDeltalogMetrics(t *testing.T) {
-	agg := &deltalogAggregate{}
-	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L0, 0, 5, 100))
+	agg := &deltalogAggregate{dbName: "db1"}
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L0, commonpb.SegmentState_Flushed, 0, 5, 100, 1024))
 	// a synchronized cohort at ~180 files plus one lone dirty segment
-	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, 1000, 180, 1))
-	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, 1000, 181, 1))
-	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, 1000, 182, 1))
-	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, 1000, 600, 1))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Flushed, 1000, 180, 1, 1024))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L1, commonpb.SegmentState_Flushed, 1000, 181, 1, 1024))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 1000, 182, 1, 1024))
+	agg.observe(makeDeltaMetricSegment(datapb.SegmentLevel_L2, commonpb.SegmentState_Flushed, 1000, 600, 1, 1024))
 
 	reportDeltalogMetrics(map[string]*deltalogAggregate{"100": agg})
 
-	assert.Equal(t, 5.0, testutil.ToFloat64(metrics.DataCoordL0DeltalogFileNum.WithLabelValues("100")))
+	assert.Equal(t, 5.0, testutil.ToFloat64(metrics.DataCoordL0DeltalogFileNum.WithLabelValues("db1", "100")))
 	// the cohort shows up in the median while max sees only the outlier
-	assert.Equal(t, 181.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("100", "0.5")))
-	assert.Equal(t, 600.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("100", "1.0")))
-	assert.InDelta(t, 0.181, testutil.ToFloat64(metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues("100", "0.5")), 1e-9)
+	assert.Equal(t, 181.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "0.5")))
+	assert.Equal(t, 600.0, testutil.ToFloat64(metrics.DataCoordSegmentDeltalogFileCount.WithLabelValues("db1", "100", "1.0")))
+	assert.Equal(t, float64(181*1024), testutil.ToFloat64(metrics.DataCoordSegmentDeltalogSize.WithLabelValues("db1", "100", "0.5")))
+	assert.InDelta(t, 0.181, testutil.ToFloat64(metrics.DataCoordSegmentDeletedRowsRatio.WithLabelValues("db1", "100", "0.5")), 1e-9)
 
-	// a refresh round without the collection removes its series
+	// a refresh round without the collection prunes its series
 	reportDeltalogMetrics(map[string]*deltalogAggregate{})
 	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataCoordSegmentDeltalogFileCount))
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataCoordSegmentDeltalogSize))
 	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataCoordSegmentDeletedRowsRatio))
 	assert.Equal(t, 0, testutil.CollectAndCount(metrics.DataCoordL0DeltalogFileNum))
 }

--- a/pkg/metrics/datacoord_metrics.go
+++ b/pkg/metrics/datacoord_metrics.go
@@ -30,6 +30,7 @@ const (
 	StatFileLabel            = "stat_file"
 	IndexFileLabel           = "index_file"
 	segmentFileTypeLabelName = "segment_file_type"
+	quantileLabelName        = "quantile"
 )
 
 var (
@@ -85,6 +86,48 @@ var (
 		}, []string{
 			databaseLabelName,
 			collectionIDLabelName,
+		})
+
+	DataCoordL0DeltalogFileNum = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.DataCoordRole,
+			Name:      "l0_deltalog_file_num",
+			Help:      "total deltalog file count of Level zero segments",
+		}, []string{
+			collectionIDLabelName,
+		})
+
+	// DataCoordSegmentDeltalogFileCount publishes summary-style quantiles
+	// (0.5/0.9/0.99/1.0) of the per-segment deltalog file count over healthy
+	// non-L0 segments, recomputed exactly on each metrics refresh round.
+	// Compare against dataCoord.compaction.single.deltalog.maxnum: the 1.0
+	// quantile shows how close the dirtiest segment is to triggering a
+	// delete-driven compaction, while p50/p90 rising toward the threshold
+	// reveals a same-batch cohort building up toward a synchronized
+	// compaction wave (a lone dirty segment leaves them unmoved).
+	DataCoordSegmentDeltalogFileCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.DataCoordRole,
+			Name:      "segment_deltalog_file_count",
+			Help: "quantiles (0.5/0.9/0.99/1.0) of deltalog file count over healthy non-L0 " +
+				"segments; compare against dataCoord.compaction.single.deltalog.maxnum",
+		}, []string{
+			collectionIDLabelName,
+			quantileLabelName,
+		})
+
+	DataCoordSegmentDeletedRowsRatio = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.DataCoordRole,
+			Name:      "segment_deleted_rows_ratio",
+			Help: "quantiles (0.5/0.9/0.99/1.0) of deleted-rows/total-rows ratio over healthy " +
+				"non-L0 segments; compare against dataCoord.compaction.single.ratio.threshold",
+		}, []string{
+			collectionIDLabelName,
+			quantileLabelName,
 		})
 
 	// DataCoordNumStoredRows all metrics will be cleaned up after removing matched collectionID and
@@ -456,6 +499,9 @@ func RegisterDataCoord(registry *prometheus.Registry) {
 	registry.MustRegister(ImportTaskLatency)
 	registry.MustRegister(DataCoordSizeStoredL0Segment)
 	registry.MustRegister(DataCoordL0DeleteEntriesNum)
+	registry.MustRegister(DataCoordL0DeltalogFileNum)
+	registry.MustRegister(DataCoordSegmentDeltalogFileCount)
+	registry.MustRegister(DataCoordSegmentDeletedRowsRatio)
 	registry.MustRegister(FlushedSegmentFileNum)
 	registry.MustRegister(IndexRequestCounter)
 	registry.MustRegister(IndexTaskNum)
@@ -499,6 +545,15 @@ func CleanupDataCoordWithCollectionID(collectionID int64) {
 		collectionIDLabelName: fmt.Sprint(collectionID),
 	})
 	DataCoordL0DeleteEntriesNum.DeletePartialMatch(prometheus.Labels{
+		collectionIDLabelName: fmt.Sprint(collectionID),
+	})
+	DataCoordL0DeltalogFileNum.DeletePartialMatch(prometheus.Labels{
+		collectionIDLabelName: fmt.Sprint(collectionID),
+	})
+	DataCoordSegmentDeltalogFileCount.DeletePartialMatch(prometheus.Labels{
+		collectionIDLabelName: fmt.Sprint(collectionID),
+	})
+	DataCoordSegmentDeletedRowsRatio.DeletePartialMatch(prometheus.Labels{
 		collectionIDLabelName: fmt.Sprint(collectionID),
 	})
 }

--- a/pkg/metrics/datacoord_metrics.go
+++ b/pkg/metrics/datacoord_metrics.go
@@ -101,8 +101,13 @@ var (
 
 	// DataCoordSegmentDeltalogFileCount publishes summary-style quantiles
 	// (0.5/0.9/0.99/1.0) of the per-segment deltalog file count over healthy
-	// FLUSHED non-L0 segments (the population hasTooManyDeletions is evaluated
-	// against), recomputed exactly on each metrics refresh round.
+	// FLUSHED non-L0 segments, split by segment_level, recomputed exactly on
+	// each metrics refresh round. The two single-compaction paths that call
+	// hasTooManyDeletions each cover one level (auto-compaction filters to L2,
+	// manual filters to L1), so the distributions are kept per level rather than
+	// blended. It approximates — not exactly equals — the candidate population:
+	// transient/stable candidacy predicates (isCompacting, IsSorted, IsInvisible,
+	// compaction-protected) are not applied here.
 	// Compare against dataCoord.compaction.single.deltalog.maxnum: the 1.0
 	// quantile shows how close the dirtiest segment is to triggering a
 	// delete-driven compaction, while p50/p90 rising toward the threshold
@@ -114,10 +119,11 @@ var (
 			Subsystem: typeutil.DataCoordRole,
 			Name:      "segment_deltalog_file_count",
 			Help: "quantiles (0.5/0.9/0.99/1.0) of deltalog file count over healthy flushed " +
-				"non-L0 segments; compare against dataCoord.compaction.single.deltalog.maxnum",
+				"non-L0 segments, by segment_level; compare against dataCoord.compaction.single.deltalog.maxnum",
 		}, []string{
 			databaseLabelName,
 			collectionIDLabelName,
+			segmentLevelLabelName,
 			quantileLabelName,
 		})
 
@@ -127,11 +133,12 @@ var (
 			Subsystem: typeutil.DataCoordRole,
 			Name:      "segment_deltalog_size",
 			Help: "quantiles (0.5/0.9/0.99/1.0) of accumulated deltalog size in bytes over " +
-				"healthy flushed non-L0 segments; compare against " +
+				"healthy flushed non-L0 segments, by segment_level; compare against " +
 				"dataCoord.compaction.single.deltalog.maxsize (the varchar-PK trigger dimension)",
 		}, []string{
 			databaseLabelName,
 			collectionIDLabelName,
+			segmentLevelLabelName,
 			quantileLabelName,
 		})
 
@@ -141,12 +148,13 @@ var (
 			Subsystem: typeutil.DataCoordRole,
 			Name:      "segment_deleted_rows_ratio",
 			Help: "quantiles (0.5/0.9/0.99/1.0) of deleted-rows/total-rows ratio over healthy " +
-				"flushed non-L0 segments; compare against dataCoord.compaction.single.ratio.threshold. " +
+				"flushed non-L0 segments, by segment_level; compare against dataCoord.compaction.single.ratio.threshold. " +
 				"May exceed 1.0 (deltalog entries count repeated deletes of the same PK); " +
 				"zero-row segments are excluded",
 		}, []string{
 			databaseLabelName,
 			collectionIDLabelName,
+			segmentLevelLabelName,
 			quantileLabelName,
 		})
 

--- a/pkg/metrics/datacoord_metrics.go
+++ b/pkg/metrics/datacoord_metrics.go
@@ -95,12 +95,14 @@ var (
 			Name:      "l0_deltalog_file_num",
 			Help:      "total deltalog file count of Level zero segments",
 		}, []string{
+			databaseLabelName,
 			collectionIDLabelName,
 		})
 
 	// DataCoordSegmentDeltalogFileCount publishes summary-style quantiles
 	// (0.5/0.9/0.99/1.0) of the per-segment deltalog file count over healthy
-	// non-L0 segments, recomputed exactly on each metrics refresh round.
+	// FLUSHED non-L0 segments (the population hasTooManyDeletions is evaluated
+	// against), recomputed exactly on each metrics refresh round.
 	// Compare against dataCoord.compaction.single.deltalog.maxnum: the 1.0
 	// quantile shows how close the dirtiest segment is to triggering a
 	// delete-driven compaction, while p50/p90 rising toward the threshold
@@ -111,9 +113,24 @@ var (
 			Namespace: milvusNamespace,
 			Subsystem: typeutil.DataCoordRole,
 			Name:      "segment_deltalog_file_count",
-			Help: "quantiles (0.5/0.9/0.99/1.0) of deltalog file count over healthy non-L0 " +
-				"segments; compare against dataCoord.compaction.single.deltalog.maxnum",
+			Help: "quantiles (0.5/0.9/0.99/1.0) of deltalog file count over healthy flushed " +
+				"non-L0 segments; compare against dataCoord.compaction.single.deltalog.maxnum",
 		}, []string{
+			databaseLabelName,
+			collectionIDLabelName,
+			quantileLabelName,
+		})
+
+	DataCoordSegmentDeltalogSize = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: milvusNamespace,
+			Subsystem: typeutil.DataCoordRole,
+			Name:      "segment_deltalog_size",
+			Help: "quantiles (0.5/0.9/0.99/1.0) of accumulated deltalog size in bytes over " +
+				"healthy flushed non-L0 segments; compare against " +
+				"dataCoord.compaction.single.deltalog.maxsize (the varchar-PK trigger dimension)",
+		}, []string{
+			databaseLabelName,
 			collectionIDLabelName,
 			quantileLabelName,
 		})
@@ -124,8 +141,11 @@ var (
 			Subsystem: typeutil.DataCoordRole,
 			Name:      "segment_deleted_rows_ratio",
 			Help: "quantiles (0.5/0.9/0.99/1.0) of deleted-rows/total-rows ratio over healthy " +
-				"non-L0 segments; compare against dataCoord.compaction.single.ratio.threshold",
+				"flushed non-L0 segments; compare against dataCoord.compaction.single.ratio.threshold. " +
+				"May exceed 1.0 (deltalog entries count repeated deletes of the same PK); " +
+				"zero-row segments are excluded",
 		}, []string{
+			databaseLabelName,
 			collectionIDLabelName,
 			quantileLabelName,
 		})
@@ -501,6 +521,7 @@ func RegisterDataCoord(registry *prometheus.Registry) {
 	registry.MustRegister(DataCoordL0DeleteEntriesNum)
 	registry.MustRegister(DataCoordL0DeltalogFileNum)
 	registry.MustRegister(DataCoordSegmentDeltalogFileCount)
+	registry.MustRegister(DataCoordSegmentDeltalogSize)
 	registry.MustRegister(DataCoordSegmentDeletedRowsRatio)
 	registry.MustRegister(FlushedSegmentFileNum)
 	registry.MustRegister(IndexRequestCounter)
@@ -547,13 +568,23 @@ func CleanupDataCoordWithCollectionID(collectionID int64) {
 	DataCoordL0DeleteEntriesNum.DeletePartialMatch(prometheus.Labels{
 		collectionIDLabelName: fmt.Sprint(collectionID),
 	})
-	DataCoordL0DeltalogFileNum.DeletePartialMatch(prometheus.Labels{
-		collectionIDLabelName: fmt.Sprint(collectionID),
-	})
+	CleanupDataCoordDeltalogMetrics(fmt.Sprint(collectionID))
+}
+
+// CleanupDataCoordDeltalogMetrics removes one collection's deltalog
+// observability series; called on DropCollection and when a metrics refresh
+// round no longer observes the collection.
+func CleanupDataCoordDeltalogMetrics(collectionID string) {
 	DataCoordSegmentDeltalogFileCount.DeletePartialMatch(prometheus.Labels{
-		collectionIDLabelName: fmt.Sprint(collectionID),
+		collectionIDLabelName: collectionID,
+	})
+	DataCoordSegmentDeltalogSize.DeletePartialMatch(prometheus.Labels{
+		collectionIDLabelName: collectionID,
 	})
 	DataCoordSegmentDeletedRowsRatio.DeletePartialMatch(prometheus.Labels{
-		collectionIDLabelName: fmt.Sprint(collectionID),
+		collectionIDLabelName: collectionID,
+	})
+	DataCoordL0DeltalogFileNum.DeletePartialMatch(prometheus.Labels{
+		collectionIDLabelName: collectionID,
 	})
 }


### PR DESCRIPTION
issue: #51094

### What

Today no metric can answer "how close are segments to the delete-driven single-compaction thresholds":

- `milvus_datacoord_segment_binlog_file_count` sums binlogs + statslogs + **deltalogs** into one collection-wide number, so deltalog growth is drowned out by per-field data binlogs, and there is no per-segment view.
- `l0_delete_entries_num` / `store_level0_segment_size` cover L0 delete **rows/size** but not **file counts**.

In the incident behind #51094, ~1,400 same-batch segments accumulated deltalog files at nearly the same rate and crossed `single.deltalog.maxnum` together — nothing on any dashboard hinted at it until the rewrite avalanche started. (This PR is the observability companion of #51096, which adds the smoothing/rate-limiting itself.)

### How

Per-collection summary-style quantile gauges over healthy non-L0 segments, computed exactly in the existing `GetQuotaInfo` refresh loop (no new iteration; same pass that already feeds `segment_binlog_file_count`):

| Metric | Labels | Compare against |
|---|---|---|
| `segment_deltalog_file_count` | `quantile` = 0.5 / 0.9 / 0.99 / 1.0 | `dataCoord.compaction.single.deltalog.maxnum` (default 200) |
| `segment_deleted_rows_ratio` | `quantile` = 0.5 / 0.9 / 0.99 / 1.0 | `single.ratio.threshold` (default 0.2) |
| `l0_deltalog_file_num` | — | total L0 deltalog files (delete-stream spray; complements existing L0 rows/size metrics) |

Quantiles instead of a max-only gauge because the max cannot distinguish one lone dirty segment from a synchronized cohort: in the incident shape, p50 marching toward the threshold **is** the avalanche warning (half the segments are at ~180 files), weeks before anything trips. The 1.0 quantile still tracks the dirtiest segment for threshold alerts. Quantiles are recomputed exactly (nearest-rank over the actual per-segment values) on each refresh round, so no decaying-window summary state is needed.

Cardinality: `collections × 9` series, same order as the existing `stored_binlog_size` (collections × states).

### Metric lifecycle

Follows the existing double cleanup pattern:
- full `Reset()` + republish on every refresh round (dropped collections disappear on the next tick, gauges rebuild cleanly after DataCoord failover);
- eager `DeletePartialMatch` in `CleanupDataCoordWithCollectionID` on `DropCollection`, covering the case where the quota-driven refresh is not running.

### Test plan

- `TestDeltalogQuantile`: nearest-rank quantile incl. empty and single-element inputs.
- `TestDeltalogAggregateObserve`: L0 routed to the L0 counter; per-segment file-count/ratio collection; zero-row segments skip the ratio.
- `TestReportDeltalogMetrics`: published quantile values on a cohort-plus-outlier distribution (p50 sees the cohort, 1.0 sees the outlier); a refresh round without a collection removes all its series.
- Existing `TestMeta_Basic` (covers the `GetQuotaInfo` path) passes.
