### PR TITLE
fix: update getFailMap to include status for failed get operations

### DIFF
--- a/internal/core/src/monitor/Monitor.cpp
+++ b/internal/core/src/monitor/Monitor.cpp
@@ -33,7 +33,7 @@ std::map<std::string, std::string> getMap = {
 std::map<std::string, std::string> getSucMap = {
     {"persistent_data_op_type", "get"}, {"status", "success"}};
 std::map<std::string, std::string> getFailMap = {
-    {"persistent_data_op_type", "get"}};
+    {"persistent_data_op_type", "get"}, {"status", "fail"}};
 std::map<std::string, std::string> putMap = {
     {"persistent_data_op_type", "put"}};
 std::map<std::string, std::string> putSucMap = {


### PR DESCRIPTION
issue: #51100

## Summary
The C++ persistent-storage `get` failure counter was registered without the `status="fail"` label, unlike the other operation failure counters. The counter was still incremented only on failed `get` operations, but Prometheus exported it as a no-status `get` series, so status-based dashboards and queries could not identify it as a failure series.

This PR adds `status="fail"` to `getFailMap`, making `internal_storage_op_count{persistent_data_op_type="get", status="fail"}` consistent with `put`, `stat`, `list`, and `remove` failures.

## Note
This changes the Prometheus time series shape: the old no-status `get` failure series will stop, and the new `status="fail"` series will start from zero.