### PR TITLE
fix: [2.6] make DumpMessages return transaction data messages

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cockroachdb/errors v1.9.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162
 	github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/samber/lo v1.27.0

--- a/client/go.sum
+++ b/client/go.sum
@@ -333,6 +333,8 @@ github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/le
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19 h1:VM9blelKQqZdv7U+QoH4kEevC4RAkUqow7XokCrdqZw=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162 h1:R+Po2BQsWCbAcMmXPQ78eq5E6/19LiNLJaZxfrDjJiA=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38 h1:75pdNz8Ln9jdBxlkUQRJu+P8tz4q+G48XAybS3O30FQ=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251201120310-af64f2acba38/go.mod h1:ak5nlCCbtImG4/WWcI/csU5ht6EyF/9QQ/tmivMzF4c=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/klauspost/compress v1.18.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3 // indirect
 	github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81 // indirect

--- a/go.sum
+++ b/go.sum
@@ -780,6 +780,8 @@ github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZz
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19 h1:VM9blelKQqZdv7U+QoH4kEevC4RAkUqow7XokCrdqZw=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162 h1:R+Po2BQsWCbAcMmXPQ78eq5E6/19LiNLJaZxfrDjJiA=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpspGNG7Z948v4n35fFGB3RR3G/ry4FWs=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=

--- a/internal/proxy/dump_messages_test.go
+++ b/internal/proxy/dump_messages_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/cockroachdb/errors"
@@ -31,10 +32,16 @@ import (
 
 	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
 	"github.com/milvus-io/milvus-proto/go-api/v2/milvuspb"
+	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
 	"github.com/milvus-io/milvus/internal/distributed/streaming"
 	"github.com/milvus-io/milvus/internal/mocks/distributed/mock_streaming"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/metricsutil"
+	"github.com/milvus-io/milvus/internal/streamingnode/server/wal/utility"
+	"github.com/milvus-io/milvus/pkg/v2/log"
+	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message"
 	"github.com/milvus-io/milvus/pkg/v2/streaming/util/message/adaptor"
+	"github.com/milvus-io/milvus/pkg/v2/streaming/util/types"
 	pulsar2 "github.com/milvus-io/milvus/pkg/v2/streaming/walimpls/impls/pulsar"
 	"github.com/milvus-io/milvus/pkg/v2/util/merr"
 )
@@ -62,18 +69,19 @@ func TestShouldDumpMessage(t *testing.T) {
 
 // mockDumpMessagesServer is a minimal implementation of milvuspb.MilvusService_DumpMessagesServer for testing.
 type mockDumpMessagesServer struct {
-	ctx     context.Context
-	mu      sync.Mutex
-	sent    []*milvuspb.DumpMessagesResponse
-	sendErr error
+	ctx          context.Context
+	mu           sync.Mutex
+	sent         []*milvuspb.DumpMessagesResponse
+	sendErr      error
+	sendErrAfter int
 }
 
 func (m *mockDumpMessagesServer) Send(resp *milvuspb.DumpMessagesResponse) error {
-	if m.sendErr != nil {
-		return m.sendErr
-	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.sendErr != nil && (m.sendErrAfter == 0 || len(m.sent) >= m.sendErrAfter) {
+		return m.sendErr
+	}
 	m.sent = append(m.sent, resp)
 	return nil
 }
@@ -99,9 +107,28 @@ func testStartMessageID() *commonpb.MessageID {
 	return pulsar2.NewPulsarID(pulsar.EarliestMessageID()).IntoProto()
 }
 
+func testPulsarMessageID(entryID int64) message.MessageID {
+	return pulsar2.NewPulsarID(pulsar.NewMessageID(1, entryID, -1, 0))
+}
+
+func assertDumpMessagesDeliverPolicy(t *testing.T, opts streaming.ReadOption, includeStartMessage bool) {
+	t.Helper()
+	require.NotNil(t, opts.DeliverPolicy)
+	if includeStartMessage {
+		_, ok := opts.DeliverPolicy.GetPolicy().(*streamingpb.DeliverPolicy_StartFrom)
+		assert.True(t, ok)
+		return
+	}
+	_, ok := opts.DeliverPolicy.GetPolicy().(*streamingpb.DeliverPolicy_StartAfter)
+	assert.True(t, ok)
+}
+
 // buildTestImmutableMessage creates an ImmutableMessage with the given timetick for testing.
 func buildTestImmutableMessage(timetick uint64) message.ImmutableMessage {
-	msgID := pulsar2.NewPulsarID(pulsar.EarliestMessageID())
+	return buildTestImmutableMessageWithID(pulsar2.NewPulsarID(pulsar.EarliestMessageID()), timetick)
+}
+
+func buildTestImmutableMessageWithID(msgID message.MessageID, timetick uint64) message.ImmutableMessage {
 	return message.NewCreateDatabaseMessageBuilderV2().
 		WithHeader(&message.CreateDatabaseMessageHeader{}).
 		WithBody(&message.CreateDatabaseMessageBody{}).
@@ -114,7 +141,10 @@ func buildTestImmutableMessage(timetick uint64) message.ImmutableMessage {
 
 // buildRollbackTxnMessage creates a RollbackTxn ImmutableMessage (which shouldDumpMessage returns false for).
 func buildRollbackTxnMessage(timetick uint64) message.ImmutableMessage {
-	msgID := pulsar2.NewPulsarID(pulsar.EarliestMessageID())
+	return buildRollbackTxnMessageWithID(pulsar2.NewPulsarID(pulsar.EarliestMessageID()), timetick)
+}
+
+func buildRollbackTxnMessageWithID(msgID message.MessageID, timetick uint64) message.ImmutableMessage {
 	return message.NewRollbackTxnMessageBuilderV2().
 		WithHeader(&message.RollbackTxnMessageHeader{}).
 		WithBody(&message.RollbackTxnMessageBody{}).
@@ -123,6 +153,113 @@ func buildRollbackTxnMessage(timetick uint64) message.ImmutableMessage {
 		WithTimeTick(timetick).
 		WithLastConfirmed(msgID).
 		IntoImmutableMessage(msgID)
+}
+
+func buildTimeTickImmutableMessage(t *testing.T, msgID message.MessageID, timetick uint64) message.ImmutableMessage {
+	return message.CreateTestTimeTickSyncMessage(t, 1, timetick, msgID).IntoImmutableMessage(msgID)
+}
+
+type testTxnMessages struct {
+	resumeMsgID message.MessageID
+	beginMsgID  message.MessageID
+	insertMsgID message.MessageID
+	commitMsgID message.MessageID
+	begin       message.ImmutableBeginTxnMessageV2
+	insert      message.ImmutableMessage
+	commit      message.ImmutableCommitTxnMessageV2
+}
+
+func buildTxnMessages(t *testing.T, timetick uint64) testTxnMessages {
+	// LastConfirmedMessageID is held before the txn begin while the txn is not done.
+	txnResumeMsgID := testPulsarMessageID(0)
+	beginMsgID := testPulsarMessageID(1)
+	insertMsgID := testPulsarMessageID(2)
+	commitMsgID := testPulsarMessageID(4)
+	txnCtx := message.TxnContext{
+		TxnID:     1,
+		Keepalive: time.Second,
+	}
+
+	begin := message.NewBeginTxnMessageBuilderV2().
+		WithHeader(&message.BeginTxnMessageHeader{}).
+		WithBody(&message.BeginTxnMessageBody{}).
+		WithVChannel("test-channel").
+		MustBuildMutable().
+		WithTxnContext(txnCtx).
+		WithTimeTick(timetick).
+		WithLastConfirmed(txnResumeMsgID).
+		IntoImmutableMessage(beginMsgID)
+	beginMsg, err := message.AsImmutableBeginTxnMessageV2(begin)
+	require.NoError(t, err)
+
+	insert := message.NewInsertMessageBuilderV1().
+		WithHeader(&message.InsertMessageHeader{}).
+		WithBody(&msgpb.InsertRequest{CollectionName: "test-collection"}).
+		WithVChannel("test-channel").
+		MustBuildMutable().
+		WithTxnContext(txnCtx).
+		WithTimeTick(timetick).
+		WithLastConfirmed(txnResumeMsgID).
+		IntoImmutableMessage(insertMsgID)
+
+	commit := message.NewCommitTxnMessageBuilderV2().
+		WithHeader(&message.CommitTxnMessageHeader{}).
+		WithBody(&message.CommitTxnMessageBody{}).
+		WithVChannel("test-channel").
+		MustBuildMutable().
+		WithTxnContext(txnCtx).
+		WithTimeTick(timetick).
+		WithLastConfirmed(txnResumeMsgID).
+		IntoImmutableMessage(commitMsgID)
+	commitMsg, err := message.AsImmutableCommitTxnMessageV2(commit)
+	require.NoError(t, err)
+
+	return testTxnMessages{
+		resumeMsgID: txnResumeMsgID,
+		beginMsgID:  beginMsgID,
+		insertMsgID: insertMsgID,
+		commitMsgID: commitMsgID,
+		begin:       beginMsg,
+		insert:      insert,
+		commit:      commitMsg,
+	}
+}
+
+func buildTxnImmutableMessage(t *testing.T, timetick uint64) message.ImmutableMessage {
+	txnMessages := buildTxnMessages(t, timetick)
+	txnMsg, err := message.NewImmutableTxnMessageBuilder(txnMessages.begin).
+		Add(txnMessages.insert).
+		Build(txnMessages.commit)
+	require.NoError(t, err)
+	return txnMsg
+}
+
+func dumpResponseMessageID(t *testing.T, resp *milvuspb.DumpMessagesResponse) message.MessageID {
+	msg := resp.GetMessage()
+	require.NotNil(t, msg)
+	return message.MustUnmarshalMessageID(msg.GetId())
+}
+
+func dumpResponseMessageType(t *testing.T, resp *milvuspb.DumpMessagesResponse) message.MessageType {
+	msg := resp.GetMessage()
+	require.NotNil(t, msg)
+	immutableMsg := message.NewImmutableMesasge(
+		message.MustUnmarshalMessageID(msg.GetId()),
+		msg.GetPayload(),
+		msg.GetProperties(),
+	)
+	return immutableMsg.MessageType()
+}
+
+func dumpResponseLastConfirmedMessageID(t *testing.T, resp *milvuspb.DumpMessagesResponse) message.MessageID {
+	msg := resp.GetMessage()
+	require.NotNil(t, msg)
+	immutableMsg := message.NewImmutableMesasge(
+		message.MustUnmarshalMessageID(msg.GetId()),
+		msg.GetPayload(),
+		msg.GetProperties(),
+	)
+	return immutableMsg.LastConfirmedMessageID()
 }
 
 func TestDumpMessages_NodeUnhealthy(t *testing.T) {
@@ -171,6 +308,100 @@ func TestDumpMessages_EmptyStartMessageIdBytes(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDumpMessages_InvalidStartMessageId(t *testing.T) {
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	err := node.DumpMessages(&milvuspb.DumpMessagesRequest{
+		Pchannel:       "test-channel",
+		StartMessageId: &commonpb.MessageID{Id: "invalid-message-id"},
+	}, stream)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.ErrorContains(t, err, "invalid start_message_id")
+}
+
+func TestDumpMessages_InvalidTimetickRange(t *testing.T) {
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	err := node.DumpMessages(&milvuspb.DumpMessagesRequest{
+		Pchannel:       "test-channel",
+		StartMessageId: testStartMessageID(),
+		StartTimetick:  200,
+		EndTimetick:    100,
+	}, stream)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, merr.ErrParameterInvalid)
+	assert.ErrorContains(t, err, "end_timetick must be greater than or equal to start_timetick")
+}
+
+func TestDumpMessages_DefaultDeliverPolicyStartsAfter(t *testing.T) {
+	scannerDone := make(chan struct{})
+	close(scannerDone)
+
+	mockScanner := mock_streaming.NewMockScanner(t)
+	mockScanner.EXPECT().Done().Return(scannerDone)
+	mockScanner.EXPECT().Error().Return(nil)
+	mockScanner.EXPECT().Close()
+
+	mockWAL := mock_streaming.NewMockWALAccesser(t)
+	mockWAL.EXPECT().Read(mock.Anything, mock.MatchedBy(func(opts streaming.ReadOption) bool {
+		assertDumpMessagesDeliverPolicy(t, opts, false)
+		return true
+	})).Return(mockScanner)
+	prevWAL := streaming.WAL()
+	streaming.SetWALForTest(mockWAL)
+	defer streaming.SetWALForTest(prevWAL)
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	err := node.DumpMessages(&milvuspb.DumpMessagesRequest{
+		Pchannel:       "test-channel",
+		StartMessageId: testStartMessageID(),
+	}, stream)
+	assert.NoError(t, err)
+}
+
+func TestDumpMessages_StartFromDeliverPolicy(t *testing.T) {
+	mockScanner := mock_streaming.NewMockScanner(t)
+	mockScanner.EXPECT().Done().Return(make(chan struct{}))
+	mockScanner.EXPECT().Close()
+
+	startMsgID := testPulsarMessageID(10)
+	mockWAL := mock_streaming.NewMockWALAccesser(t)
+	mockWAL.EXPECT().Read(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, opts streaming.ReadOption) streaming.Scanner {
+			assertDumpMessagesDeliverPolicy(t, opts, true)
+			ch, ok := opts.MessageHandler.(adaptor.ChanMessageHandler)
+			require.True(t, ok)
+			ch <- buildTestImmutableMessageWithID(startMsgID, 50)
+			ch <- buildTestImmutableMessageWithID(testPulsarMessageID(11), 200)
+			return mockScanner
+		})
+	prevWAL := streaming.WAL()
+	streaming.SetWALForTest(mockWAL)
+	defer streaming.SetWALForTest(prevWAL)
+
+	req := &milvuspb.DumpMessagesRequest{
+		Pchannel:            "test-channel",
+		StartMessageId:      startMsgID.IntoProto(),
+		IncludeStartMessage: true,
+		EndTimetick:         100,
+	}
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	err := node.DumpMessages(req, stream)
+	assert.NoError(t, err)
+}
+
 func TestDumpMessages_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -209,6 +440,35 @@ func TestDumpMessages_ScannerError(t *testing.T) {
 
 	mockWAL := mock_streaming.NewMockWALAccesser(t)
 	mockWAL.EXPECT().Read(mock.Anything, mock.Anything).Return(mockScanner)
+	prevWAL := streaming.WAL()
+	streaming.SetWALForTest(mockWAL)
+	defer streaming.SetWALForTest(prevWAL)
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	err := node.DumpMessages(&milvuspb.DumpMessagesRequest{
+		Pchannel:       "test-channel",
+		StartMessageId: testStartMessageID(),
+	}, stream)
+	assert.EqualError(t, err, "scanner error")
+}
+
+func TestDumpMessages_ChannelClosedReturnsScannerError(t *testing.T) {
+	mockScanner := mock_streaming.NewMockScanner(t)
+	mockScanner.EXPECT().Done().Return(make(chan struct{}))
+	mockScanner.EXPECT().Error().Return(errors.New("scanner error"))
+	mockScanner.EXPECT().Close()
+
+	mockWAL := mock_streaming.NewMockWALAccesser(t)
+	mockWAL.EXPECT().Read(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, opts streaming.ReadOption) streaming.Scanner {
+			ch, ok := opts.MessageHandler.(adaptor.ChanMessageHandler)
+			require.True(t, ok)
+			close(ch)
+			return mockScanner
+		})
 	prevWAL := streaming.WAL()
 	streaming.SetWALForTest(mockWAL)
 	defer streaming.SetWALForTest(prevWAL)
@@ -281,6 +541,186 @@ func TestDumpMessages_MessageSentSuccessfully(t *testing.T) {
 	}, stream)
 	assert.NoError(t, err)
 	assert.Len(t, stream.getSent(), 1)
+}
+
+func TestDumpMessages_ExpandTxnMessage(t *testing.T) {
+	mockScanner := mock_streaming.NewMockScanner(t)
+	mockScanner.EXPECT().Done().Return(make(chan struct{}))
+	mockScanner.EXPECT().Close()
+
+	mockWAL := mock_streaming.NewMockWALAccesser(t)
+	mockWAL.EXPECT().Read(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, opts streaming.ReadOption) streaming.Scanner {
+			ch, ok := opts.MessageHandler.(adaptor.ChanMessageHandler)
+			require.True(t, ok)
+			ch <- buildTxnImmutableMessage(t, 50)
+			ch <- buildTestImmutableMessage(200) // > endTimetick (100), triggers return nil
+			return mockScanner
+		})
+	prevWAL := streaming.WAL()
+	streaming.SetWALForTest(mockWAL)
+	defer streaming.SetWALForTest(prevWAL)
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	err := node.DumpMessages(&milvuspb.DumpMessagesRequest{
+		Pchannel:       "test-channel",
+		StartMessageId: testStartMessageID(),
+		EndTimetick:    100,
+	}, stream)
+	require.NoError(t, err)
+
+	sent := stream.getSent()
+	require.Len(t, sent, 3)
+	assert.Equal(t, message.MessageTypeBeginTxn, dumpResponseMessageType(t, sent[0]))
+	assert.Equal(t, message.MessageTypeInsert, dumpResponseMessageType(t, sent[1]))
+	assert.Equal(t, message.MessageTypeCommitTxn, dumpResponseMessageType(t, sent[2]))
+	txnMessages := buildTxnMessages(t, 50)
+	assert.True(t, txnMessages.beginMsgID.EQ(dumpResponseMessageID(t, sent[0])))
+	assert.True(t, txnMessages.insertMsgID.EQ(dumpResponseMessageID(t, sent[1])))
+	assert.True(t, txnMessages.commitMsgID.EQ(dumpResponseMessageID(t, sent[2])))
+	// Txn expansion rewrites begin/body LastConfirmedMessageID to the commit's
+	// LastConfirmedMessageID. In production this checkpoint is held before the
+	// txn begin until the txn is done, so it can replay the txn context.
+	assert.True(t, txnMessages.resumeMsgID.EQ(dumpResponseLastConfirmedMessageID(t, sent[0])))
+	assert.True(t, txnMessages.resumeMsgID.EQ(dumpResponseLastConfirmedMessageID(t, sent[1])))
+	assert.True(t, txnMessages.resumeMsgID.EQ(dumpResponseLastConfirmedMessageID(t, sent[2])))
+	assert.True(t, txnMessages.resumeMsgID.LT(txnMessages.beginMsgID))
+}
+
+func TestDumpMessages_TxnLastConfirmedCanReplayDumpedBody(t *testing.T) {
+	txnMessages := buildTxnMessages(t, 50)
+	txnBuffer := utility.NewTxnBuffer(
+		log.With(),
+		metricsutil.NewScanMetrics(types.PChannelInfo{}).NewScannerMetrics(),
+	)
+	scannerOutput := txnBuffer.HandleImmutableMessages([]message.ImmutableMessage{
+		txnMessages.begin,
+		txnMessages.insert,
+		txnMessages.commit,
+	}, 50)
+	require.Len(t, scannerOutput, 1)
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	dumpedCount, err := dumpOneMessage(stream, scannerOutput[0], log.With())
+	require.NoError(t, err)
+	assert.Equal(t, 3, dumpedCount)
+
+	sent := stream.getSent()
+	require.Len(t, sent, 3)
+	assert.Equal(t, message.MessageTypeInsert, dumpResponseMessageType(t, sent[1]))
+	assert.True(t, txnMessages.insertMsgID.EQ(dumpResponseMessageID(t, sent[1])))
+	assert.True(t, txnMessages.resumeMsgID.EQ(dumpResponseLastConfirmedMessageID(t, sent[1])))
+}
+
+func TestDumpMessages_IncludedStartTxnBodyMessageDoesNotForceRejectAtProxyLayer(t *testing.T) {
+	startMsgID := testPulsarMessageID(2)
+	mockScanner := mock_streaming.NewMockScanner(t)
+	mockScanner.EXPECT().Done().Return(make(chan struct{}))
+	mockScanner.EXPECT().Close()
+
+	mockWAL := mock_streaming.NewMockWALAccesser(t)
+	mockWAL.EXPECT().Read(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, opts streaming.ReadOption) streaming.Scanner {
+			assertDumpMessagesDeliverPolicy(t, opts, true)
+			ch, ok := opts.MessageHandler.(adaptor.ChanMessageHandler)
+			require.True(t, ok)
+			// This mock injects an already assembled transaction. The test only
+			// verifies that DumpMessages does not reject at the proxy layer; a
+			// real start-inside-txn read may produce no assembled transaction if
+			// the scanner misses the begin message.
+			ch <- buildTxnImmutableMessage(t, 50)
+			ch <- buildTestImmutableMessage(200) // > endTimetick, stops loop
+			return mockScanner
+		})
+	prevWAL := streaming.WAL()
+	streaming.SetWALForTest(mockWAL)
+	defer streaming.SetWALForTest(prevWAL)
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	err := node.DumpMessages(&milvuspb.DumpMessagesRequest{
+		Pchannel:            "test-channel",
+		StartMessageId:      startMsgID.IntoProto(),
+		IncludeStartMessage: true,
+		EndTimetick:         100,
+	}, stream)
+	require.NoError(t, err)
+	assert.Len(t, stream.getSent(), 3)
+}
+
+func TestDumpMessages_TxnSendError(t *testing.T) {
+	mockScanner := mock_streaming.NewMockScanner(t)
+	mockScanner.EXPECT().Done().Return(make(chan struct{}))
+	mockScanner.EXPECT().Close()
+
+	mockWAL := mock_streaming.NewMockWALAccesser(t)
+	mockWAL.EXPECT().Read(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, opts streaming.ReadOption) streaming.Scanner {
+			ch, ok := opts.MessageHandler.(adaptor.ChanMessageHandler)
+			require.True(t, ok)
+			ch <- buildTxnImmutableMessage(t, 50)
+			return mockScanner
+		})
+	prevWAL := streaming.WAL()
+	streaming.SetWALForTest(mockWAL)
+	defer streaming.SetWALForTest(prevWAL)
+
+	sendErr := errors.New("send txn error")
+	stream := &mockDumpMessagesServer{ctx: context.Background(), sendErr: sendErr}
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	err := node.DumpMessages(&milvuspb.DumpMessagesRequest{
+		Pchannel:       "test-channel",
+		StartMessageId: testStartMessageID(),
+	}, stream)
+	assert.EqualError(t, err, "send txn error")
+}
+
+func TestDumpTxnMessageSendErrors(t *testing.T) {
+	txnMsg, ok := buildTxnImmutableMessage(t, 50).(message.ImmutableTxnMessage)
+	require.True(t, ok)
+
+	testCases := []struct {
+		name         string
+		sendErrAfter int
+		dumpedCount  int
+	}{
+		{
+			name:         "begin",
+			sendErrAfter: 0,
+			dumpedCount:  0,
+		},
+		{
+			name:         "body",
+			sendErrAfter: 1,
+			dumpedCount:  1,
+		},
+		{
+			name:         "commit",
+			sendErrAfter: 2,
+			dumpedCount:  2,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sendErr := errors.New("send txn error")
+			stream := &mockDumpMessagesServer{
+				ctx:          context.Background(),
+				sendErr:      sendErr,
+				sendErrAfter: tc.sendErrAfter,
+			}
+
+			dumpedCount, err := dumpTxnMessage(stream, txnMsg, log.With())
+			assert.EqualError(t, err, "send txn error")
+			assert.Equal(t, tc.dumpedCount, dumpedCount)
+		})
+	}
 }
 
 func TestDumpMessages_FilterByStartTimetick(t *testing.T) {
@@ -356,7 +796,8 @@ func TestDumpMessages_FilterSystemMessages(t *testing.T) {
 		func(ctx context.Context, opts streaming.ReadOption) streaming.Scanner {
 			ch, ok := opts.MessageHandler.(adaptor.ChanMessageHandler)
 			require.True(t, ok)
-			ch <- buildRollbackTxnMessage(50)    // system message, should be filtered
+			ch <- buildRollbackTxnMessage(50) // system message, should be filtered
+			ch <- buildTimeTickImmutableMessage(t, testPulsarMessageID(10), 50)
 			ch <- buildTestImmutableMessage(50)  // data message, should be sent
 			ch <- buildTestImmutableMessage(200) // > endTimetick, stops loop
 			return mockScanner
@@ -375,8 +816,112 @@ func TestDumpMessages_FilterSystemMessages(t *testing.T) {
 		EndTimetick:    100,
 	}, stream)
 	assert.NoError(t, err)
-	// Only the data message should be sent, not the RollbackTxn
+	// Only the data message should be sent, not RollbackTxn or TimeTick.
 	assert.Len(t, stream.getSent(), 1)
+}
+
+func TestDumpMessages_IncludeStartDoesNotBypassSelfControlledFilter(t *testing.T) {
+	startMsgID := testPulsarMessageID(10)
+	mockScanner := mock_streaming.NewMockScanner(t)
+	mockScanner.EXPECT().Done().Return(make(chan struct{}))
+	mockScanner.EXPECT().Close()
+
+	mockWAL := mock_streaming.NewMockWALAccesser(t)
+	mockWAL.EXPECT().Read(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, opts streaming.ReadOption) streaming.Scanner {
+			assertDumpMessagesDeliverPolicy(t, opts, true)
+			ch, ok := opts.MessageHandler.(adaptor.ChanMessageHandler)
+			require.True(t, ok)
+			ch <- buildTimeTickImmutableMessage(t, startMsgID, 50)
+			ch <- buildTestImmutableMessage(200) // > endTimetick, stops loop
+			return mockScanner
+		})
+	prevWAL := streaming.WAL()
+	streaming.SetWALForTest(mockWAL)
+	defer streaming.SetWALForTest(prevWAL)
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	err := node.DumpMessages(&milvuspb.DumpMessagesRequest{
+		Pchannel:            "test-channel",
+		StartMessageId:      startMsgID.IntoProto(),
+		IncludeStartMessage: true,
+		EndTimetick:         100,
+	}, stream)
+	require.NoError(t, err)
+	assert.Empty(t, stream.getSent())
+}
+
+func TestDumpMessages_IncludeStartDoesNotBypassRollbackTxnFilter(t *testing.T) {
+	startMsgID := testPulsarMessageID(10)
+	mockScanner := mock_streaming.NewMockScanner(t)
+	mockScanner.EXPECT().Done().Return(make(chan struct{}))
+	mockScanner.EXPECT().Close()
+
+	mockWAL := mock_streaming.NewMockWALAccesser(t)
+	mockWAL.EXPECT().Read(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, opts streaming.ReadOption) streaming.Scanner {
+			assertDumpMessagesDeliverPolicy(t, opts, true)
+			ch, ok := opts.MessageHandler.(adaptor.ChanMessageHandler)
+			require.True(t, ok)
+			ch <- buildRollbackTxnMessageWithID(startMsgID, 50)
+			ch <- buildTestImmutableMessage(200) // > endTimetick, stops loop
+			return mockScanner
+		})
+	prevWAL := streaming.WAL()
+	streaming.SetWALForTest(mockWAL)
+	defer streaming.SetWALForTest(prevWAL)
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	err := node.DumpMessages(&milvuspb.DumpMessagesRequest{
+		Pchannel:            "test-channel",
+		StartMessageId:      startMsgID.IntoProto(),
+		IncludeStartMessage: true,
+		EndTimetick:         100,
+	}, stream)
+	require.NoError(t, err)
+	assert.Empty(t, stream.getSent())
+}
+
+func TestDumpMessages_IncludedStartMessageSkippedByVisibleStream(t *testing.T) {
+	startMsgID := testPulsarMessageID(10)
+	nextMsgID := testPulsarMessageID(11)
+	mockScanner := mock_streaming.NewMockScanner(t)
+	mockScanner.EXPECT().Done().Return(make(chan struct{}))
+	mockScanner.EXPECT().Close()
+
+	mockWAL := mock_streaming.NewMockWALAccesser(t)
+	mockWAL.EXPECT().Read(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, opts streaming.ReadOption) streaming.Scanner {
+			assertDumpMessagesDeliverPolicy(t, opts, true)
+			ch, ok := opts.MessageHandler.(adaptor.ChanMessageHandler)
+			require.True(t, ok)
+			ch <- buildTestImmutableMessageWithID(nextMsgID, 50)
+			ch <- buildTestImmutableMessage(200) // > endTimetick, stops loop
+			return mockScanner
+		})
+	prevWAL := streaming.WAL()
+	streaming.SetWALForTest(mockWAL)
+	defer streaming.SetWALForTest(prevWAL)
+
+	stream := &mockDumpMessagesServer{ctx: context.Background()}
+	node := &Proxy{}
+	node.UpdateStateCode(commonpb.StateCode_Healthy)
+
+	err := node.DumpMessages(&milvuspb.DumpMessagesRequest{
+		Pchannel:            "test-channel",
+		StartMessageId:      startMsgID.IntoProto(),
+		IncludeStartMessage: true,
+		EndTimetick:         100,
+	}, stream)
+	require.NoError(t, err)
+	require.Len(t, stream.getSent(), 1)
+	assert.True(t, dumpResponseMessageID(t, stream.getSent()[0]).EQ(nextMsgID))
 }
 
 func TestDumpMessages_SendError(t *testing.T) {
@@ -411,6 +956,7 @@ func TestDumpMessages_SendError(t *testing.T) {
 func TestDumpMessages_ChannelClosed(t *testing.T) {
 	mockScanner := mock_streaming.NewMockScanner(t)
 	mockScanner.EXPECT().Done().Return(make(chan struct{}))
+	mockScanner.EXPECT().Error().Return(nil)
 	mockScanner.EXPECT().Close()
 
 	mockWAL := mock_streaming.NewMockWALAccesser(t)

--- a/internal/proxy/impl.go
+++ b/internal/proxy/impl.go
@@ -7223,7 +7223,119 @@ func shouldDumpMessage(msgType message.MessageType) bool {
 	return true
 }
 
+// sendDumpMessage sends one immutable WAL message as a DumpMessages response.
+func sendDumpMessage(stream milvuspb.MilvusService_DumpMessagesServer, msg message.ImmutableMessage) error {
+	return stream.Send(&milvuspb.DumpMessagesResponse{
+		Response: &milvuspb.DumpMessagesResponse_Message{
+			Message: msg.IntoImmutableMessageProto(),
+		},
+	})
+}
+
+// dumpTxnMessage expands a scanner-assembled transaction into separate
+// begin/data/commit DumpMessages responses.
+func dumpTxnMessage(
+	stream milvuspb.MilvusService_DumpMessagesServer,
+	txnMsg message.ImmutableTxnMessage,
+	logger *log.MLogger,
+) (int, error) {
+	msgCount := 0
+	begin := txnMsg.Begin()
+	if shouldDumpMessage(begin.MessageType()) {
+		if err := sendDumpMessage(stream, begin); err != nil {
+			logger.Warn("DumpMessages send txn begin failed", zap.Error(err))
+			return msgCount, err
+		}
+		msgCount++
+	}
+
+	if err := txnMsg.RangeOver(func(im message.ImmutableMessage) error {
+		if !shouldDumpMessage(im.MessageType()) {
+			return nil
+		}
+		if err := sendDumpMessage(stream, im); err != nil {
+			logger.Warn("DumpMessages send txn body failed", zap.Error(err))
+			return err
+		}
+		msgCount++
+		return nil
+	}); err != nil {
+		return msgCount, err
+	}
+
+	commit := txnMsg.Commit()
+	if shouldDumpMessage(commit.MessageType()) {
+		if err := sendDumpMessage(stream, commit); err != nil {
+			logger.Warn("DumpMessages send txn commit failed", zap.Error(err))
+			return msgCount, err
+		}
+		msgCount++
+	}
+	return msgCount, nil
+}
+
+// dumpOneMessage writes one scanner output message to the response stream.
+// A transaction scanner output may produce multiple DumpMessages responses.
+func dumpOneMessage(
+	stream milvuspb.MilvusService_DumpMessagesServer,
+	msg message.ImmutableMessage,
+	logger *log.MLogger,
+) (int, error) {
+	if txnMsg, ok := msg.(message.ImmutableTxnMessage); ok {
+		return dumpTxnMessage(stream, txnMsg, logger)
+	}
+
+	if !shouldDumpMessage(msg.MessageType()) {
+		return 0, nil
+	}
+
+	if err := sendDumpMessage(stream, msg); err != nil {
+		logger.Warn("DumpMessages send failed", zap.Error(err))
+		return 0, err
+	}
+	return 1, nil
+}
+
 // DumpMessages streams messages from a WAL range for data salvage.
+// It returns dump-visible messages only; self-controlled internal messages and
+// rollback transaction messages are filtered. A transaction message is returned
+// as separate begin/data/commit responses when the scanner can assemble it.
+// The expanded transaction body order follows the scanner output; it is not a
+// complete replay recipe for write SDKs. Consumers that restore through write
+// APIs should apply delete messages before insert messages in a transaction,
+// especially for the same primary key. Blindly replaying expanded transaction
+// messages in scanner order can change upsert semantics.
+// A transaction is treated as one atomic dump unit for timetick filtering. The
+// start/end timetick window is evaluated before transaction expansion, using
+// the assembled transaction's commit timetick. If the commit timetick is in the
+// window, the whole transaction is dumped; otherwise the whole transaction is
+// skipped. DumpMessages never splits a transaction by filtering individual body
+// messages by their original timeticks.
+// Strict consumers should buffer expanded transaction messages until CommitTxn.
+// If the stream returns a non-EOF error before a transaction is complete, the
+// incomplete transaction prefix must be discarded and replayed from checkpoint.
+//
+// DumpMessagesRequest.start_message_id is a raw WAL start MessageID. For
+// resumable consumption, callers should normally use a LastConfirmedMessageID
+// carried by a previously dumped message, rather than an arbitrary message ID.
+// DumpMessages cannot prove start-message existence after the scanner has
+// applied transaction assembly and filtering. If the requested start point is no
+// longer retained by the underlying WAL, the stream may begin at the earliest
+// currently readable message instead of failing at this layer.
+//
+// IncludeStartMessage makes the underlying WAL read inclusive. The requested
+// start message is not guaranteed to appear in DumpMessages responses:
+// self-controlled internal messages and rollback transaction messages are still
+// filtered, and the scanner may aggregate or ignore transaction messages. If the
+// requested start point is inside a transaction rather than before its begin
+// message, messages from that transaction may not be returned.
+//
+// Strict resume consumers should store the dumped message's MessageID and
+// LastConfirmedMessageID, call DumpMessages with LastConfirmedMessageID and
+// IncludeStartMessage=true, then skip locally until the stored MessageID is
+// seen. Best-effort dump consumers may pass an approximate start MessageID, but
+// gaps or duplicates are possible if that point is filtered, inside a
+// transaction, or no longer retained by the underlying WAL.
 func (node *Proxy) DumpMessages(req *milvuspb.DumpMessagesRequest, stream milvuspb.MilvusService_DumpMessagesServer) error {
 	ctx := stream.Context()
 	ctx, sp := otel.Tracer(typeutil.ProxyRole).Start(ctx, "Proxy-DumpMessages")
@@ -7247,6 +7359,11 @@ func (node *Proxy) DumpMessages(req *milvuspb.DumpMessagesRequest, stream milvus
 	if req.GetStartMessageId() == nil || len(req.GetStartMessageId().GetId()) == 0 {
 		return merr.WrapErrParameterMissing("start_message_id")
 	}
+	startTimetick := req.GetStartTimetick()
+	endTimetick := req.GetEndTimetick()
+	if startTimetick > 0 && endTimetick > 0 && endTimetick < startTimetick {
+		return merr.WrapErrParameterInvalidMsg("end_timetick must be greater than or equal to start_timetick")
+	}
 
 	// Unmarshal the message id without panicking: the id bytes are
 	// client-controlled, so a malformed value must be rejected as an invalid
@@ -7256,9 +7373,10 @@ func (node *Proxy) DumpMessages(req *milvuspb.DumpMessagesRequest, stream milvus
 		return merr.WrapErrParameterInvalidMsg("invalid start_message_id: %s", err.Error())
 	}
 
-	// Use exclusive start position (dump messages AFTER start_message_id)
-	// This is appropriate for salvage scenarios where start_message_id is the last synced message
 	deliverPolicy := options.DeliverPolicyStartAfter(startMsgID)
+	if req.GetIncludeStartMessage() {
+		deliverPolicy = options.DeliverPolicyStartFrom(startMsgID)
+	}
 
 	// Create a channel-based message handler
 	msgCh := make(adaptor.ChanMessageHandler, 16)
@@ -7270,10 +7388,6 @@ func (node *Proxy) DumpMessages(req *milvuspb.DumpMessagesRequest, stream milvus
 		MessageHandler: msgCh,
 	})
 	defer scanner.Close()
-
-	// Get timetick filters
-	startTimetick := req.GetStartTimetick()
-	endTimetick := req.GetEndTimetick()
 
 	msgCount := 0
 	// Stream messages
@@ -7293,38 +7407,35 @@ func (node *Proxy) DumpMessages(req *milvuspb.DumpMessagesRequest, stream milvus
 		case msg, ok := <-msgCh:
 			if !ok {
 				// Channel closed
+				if err := scanner.Error(); err != nil {
+					logger.Warn("DumpMessages scanner error", zap.Error(err), zap.Int("messageCount", msgCount))
+					return err
+				}
 				logger.Info("DumpMessages channel closed", zap.Int("messageCount", msgCount))
 				return nil
 			}
 
 			msgTimetick := msg.TimeTick()
 
-			// Check start timetick filter
-			if startTimetick > 0 && msgTimetick < startTimetick {
-				continue
-			}
-
+			// A transaction is filtered as one atomic unit here: TimeTick is the
+			// commit timetick for assembled transactions, and expansion happens
+			// only after the whole transaction passes the window.
 			// Check end timetick condition
 			if endTimetick > 0 && msgTimetick > endTimetick {
 				logger.Info("DumpMessages reached end timetick", zap.Int("messageCount", msgCount))
 				return nil
 			}
 
-			// Filter system messages
-			if !shouldDumpMessage(msg.MessageType()) {
+			// Check start timetick filter
+			if startTimetick > 0 && msgTimetick < startTimetick {
 				continue
 			}
 
-			// Send message to stream (using oneof - only message, no status)
-			if err := stream.Send(&milvuspb.DumpMessagesResponse{
-				Response: &milvuspb.DumpMessagesResponse_Message{
-					Message: msg.IntoImmutableMessageProto(),
-				},
-			}); err != nil {
-				logger.Warn("DumpMessages send failed", zap.Error(err))
+			dumpedCount, err := dumpOneMessage(stream, msg, logger)
+			if err != nil {
 				return err
 			}
-			msgCount++
+			msgCount += dumpedCount
 		}
 	}
 }

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/json-iterator/go v1.1.13-0.20220915233716-71ac16282d12
 	github.com/klauspost/compress v1.18.0
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162
 	github.com/minio/minio-go/v7 v7.0.73
 	github.com/panjf2000/ants/v2 v2.11.3
 	github.com/prometheus/client_golang v1.20.5

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -463,6 +463,8 @@ github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b h1:TfeY0NxYxZz
 github.com/milvus-io/gorocksdb v0.0.0-20220624081344-8c5f4212846b/go.mod h1:iwW+9cWfIzzDseEBCCeDSN5SD16Tidvy8cwQ7ZY8Qj4=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19 h1:VM9blelKQqZdv7U+QoH4kEevC4RAkUqow7XokCrdqZw=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162 h1:R+Po2BQsWCbAcMmXPQ78eq5E6/19LiNLJaZxfrDjJiA=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.73 h1:qr2vi96Qm7kZ4v7LLebjte+MQh621fFWnv93p12htEo=

--- a/tests/go_client/go.mod
+++ b/tests/go_client/go.mod
@@ -3,7 +3,7 @@ module github.com/milvus-io/milvus/tests/go_client
 go 1.25.8
 
 require (
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162
 	github.com/milvus-io/milvus/client/v2 v2.0.0-20241125024034-0b9edb62a92d
 	github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad
 	github.com/peterstace/simplefeatures v0.54.0

--- a/tests/go_client/go.sum
+++ b/tests/go_client/go.sum
@@ -335,6 +335,8 @@ github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/le
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19 h1:VM9blelKQqZdv7U+QoH4kEevC4RAkUqow7XokCrdqZw=
 github.com/milvus-io/milvus-proto/go-api/v2 v2.6.19/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162 h1:R+Po2BQsWCbAcMmXPQ78eq5E6/19LiNLJaZxfrDjJiA=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.6.20-0.20260707010825-29edb7f43162/go.mod h1:/6UT4zZl6awVeXLeE7UGDWZvXj3IWkRsh3mqsn0DiAs=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad h1:pjSurtVnX3VLLdjUg3HKMpILDv/ZEfSI1rZLsTd+h1U=
 github.com/milvus-io/milvus/pkg/v2 v2.6.7-0.20251202033909-b71a123d25ad/go.mod h1:ak5nlCCbtImG4/WWcI/csU5ht6EyF/9QQ/tmivMzF4c=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=


### PR DESCRIPTION
issue: #50573
pr: #50574

Backport of #50574 to the 2.6 branch.

Changes:
- Expand scanner-assembled transaction messages into begin/body/commit DumpMessages responses.
- Add inclusive start support through DumpMessagesRequest.include_start_message.
- Document DumpMessages transaction filtering and resume semantics.
- Update milvus-proto/go-api/v2 to include milvus-io/milvus-proto#629.

Validation:
- gofmt on changed Go files
- git diff --check
- Attempted go test ./internal/proxy -run 'TestDumpMessages|TestDumpTxnMessage', but local environment is missing Milvus CGO dependencies: milvus_core.pc / gorocksdb cgo symbols. CI should run the full test environment.