### PR TITLE
fix: [cp2.6]correct the CDC replication lag metric

### DIFF
--- a/internal/cdc/replication/replicatemanager/channel_replicator.go
+++ b/internal/cdc/replication/replicatemanager/channel_replicator.go
@@ -139,6 +139,11 @@ func (r *channelReplicator) init() error {
 		})
 		r.msgScanner = scanner
 		r.msgChan = ch
+		// Seed the last replicated time tick from the resume checkpoint so that
+		// after a CDC pod restart the lag metric reports the real backlog
+		// immediately, instead of the series being absent (which reads as 0)
+		// until the first message is replicated.
+		replicatestream.InitLastReplicatedTimeTick(r.channel.Value, cp.TimeTick)
 		logger.Info("scanner initialized", zap.Any("checkpoint", cp))
 	}
 	// init replicate stream client

--- a/internal/cdc/replication/replicatestream/metrics.go
+++ b/internal/cdc/replication/replicatestream/metrics.go
@@ -61,6 +61,18 @@ func (m *replicateMetrics) UpdateLastReplicatedTimeTick(ts uint64) {
 	).Set(tsoutil.PhysicalTimeSeconds(ts))
 }
 
+// InitLastReplicatedTimeTick seeds the last replicated time tick gauge from the
+// resume checkpoint when a replicator starts. The checkpoint is the
+// target-confirmed position, so a restarted CDC pod reports the real backlog
+// immediately instead of leaving the series absent (which reads as 0 in the lag
+// query) until the first message flows.
+func InitLastReplicatedTimeTick(info *streamingpb.ReplicatePChannelMeta, ts uint64) {
+	metrics.CDCLastReplicatedTimeTick.WithLabelValues(
+		info.GetSourceChannelName(),
+		info.GetTargetChannelName(),
+	).Set(tsoutil.PhysicalTimeSeconds(ts))
+}
+
 func (m *replicateMetrics) StartReplicate(msg message.ImmutableMessage) {
 	msgID := msg.MessageID().String()
 	m.msgsMetrics.Insert(msgID, msgMetrics{
@@ -134,8 +146,17 @@ func (m *replicateMetrics) OnConnect() {
 	).Inc()
 }
 
+// OnClose is invoked only when the replication is genuinely torn down
+// (etcd DELETE / AlterReplicateConfig removal / CDC shutdown), not on the
+// internal idle-timeout reconnect. It deletes this replication's last
+// replicated time tick series so a removed/switched replication does not leave
+// a frozen gauge that pollutes the cross-series aggregation of the lag query.
 func (m *replicateMetrics) OnClose() {
 	metrics.CDCStreamRPCConnections.DeletePartialMatch(prometheus.Labels{
 		metrics.CDCLabelTargetCluster: m.replicateInfo.GetTargetCluster().GetClusterId(),
 	})
+	metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(
+		m.replicateInfo.GetSourceChannelName(),
+		m.replicateInfo.GetTargetChannelName(),
+	)
 }

--- a/internal/cdc/replication/replicatestream/metrics_test.go
+++ b/internal/cdc/replication/replicatestream/metrics_test.go
@@ -1,0 +1,72 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package replicatestream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/milvus-io/milvus-proto/go-api/v2/commonpb"
+	"github.com/milvus-io/milvus/pkg/v2/metrics"
+	"github.com/milvus-io/milvus/pkg/v2/proto/streamingpb"
+	"github.com/milvus-io/milvus/pkg/v2/util/tsoutil"
+)
+
+func newTestReplicateInfo(source, target string) *streamingpb.ReplicatePChannelMeta {
+	return &streamingpb.ReplicatePChannelMeta{
+		SourceChannelName: source,
+		TargetChannelName: target,
+		TargetCluster: &commonpb.MilvusCluster{
+			ClusterId: "test-cluster",
+		},
+	}
+}
+
+// TestInitLastReplicatedTimeTick verifies that seeding from the resume
+// checkpoint reports the real backlog (checkpoint physical time), so a
+// restarted CDC pod does not read as 0.
+func TestInitLastReplicatedTimeTick(t *testing.T) {
+	source, target := "TestInit-source", "TestInit-target"
+	defer metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target)
+
+	// A checkpoint 300s in the past -> the gauge reports that physical time,
+	// which against wall-clock now is a ~300s backlog, not 0.
+	checkpoint := tsoutil.ComposeTSByTime(time.Now().Add(-300*time.Second), 0)
+	InitLastReplicatedTimeTick(newTestReplicateInfo(source, target), checkpoint)
+
+	got := testutil.ToFloat64(metrics.CDCLastReplicatedTimeTick.WithLabelValues(source, target))
+	assert.InDelta(t, tsoutil.PhysicalTimeSeconds(checkpoint), got, 1)
+	assert.InDelta(t, 300, float64(time.Now().Unix())-got, 5)
+}
+
+// TestReplicateMetrics_OnCloseDeletesSeries verifies that a genuinely torn-down
+// replication deletes its last replicated time tick series, so it does not
+// leave a frozen gauge polluting the cross-series lag aggregation.
+func TestReplicateMetrics_OnCloseDeletesSeries(t *testing.T) {
+	source, target := "TestOnClose-source", "TestOnClose-target"
+	defer metrics.CDCLastReplicatedTimeTick.DeleteLabelValues(source, target)
+
+	m := NewReplicateMetrics(newTestReplicateInfo(source, target))
+	m.UpdateLastReplicatedTimeTick(tsoutil.ComposeTSByTime(time.Now(), 0))
+	assert.Equal(t, 1, testutil.CollectAndCount(metrics.CDCLastReplicatedTimeTick))
+
+	m.OnClose()
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.CDCLastReplicatedTimeTick))
+}


### PR DESCRIPTION
Cherry-pick from master (original PR still open)

pr: #51049
issue: #50633
issue: #51048

## Summary

Cherry-picked from master PR #51049 (still **open** - preemptive backport).

Fixes the CDC replication lag metric:
- Seed `CDCLastReplicatedTimeTick` from the resume checkpoint on replicator init, so a restarted CDC pod reports the real backlog immediately instead of the series being absent (reads as 0).
- Delete the series on genuine teardown (`OnClose`) so a removed/switched replication does not leave a frozen gauge polluting the cross-series lag aggregation.

## 2.6 adaptations vs master

- `channel_replicator.go`: kept 2.6's `logger.Info("scanner initialized", zap.Any(...))` form (2.6 has not migrated to the mlog+ctx logging convention). The seed call and comment are identical to master.
- `metrics_test.go`: proto/pkg imports downgraded `go-api/v3`→`v2` and `pkg/v3`→`pkg/v2` (2.6 uses the v2 modules). Test logic identical to master.
- The master-only doc change (`docs/.../cdc/user_docs/02-cdc-replication-quick-start.md`, a PromQL idle-oscillation note) is **omitted** — that docs tree does not exist on 2.6.

**Note**: original PR #51049 is still open; this CP should be re-synced if it changes before merge.

## Verification

- [x] Code payload byte-identical to master PR #51049
- [x] All referenced symbols verified present in 2.6 (CDCLastReplicatedTimeTick, commonpb.MilvusCluster, tsoutil.*, streamingpb.ReplicatePChannelMeta)
- [x] No conflict markers
- [ ] make static-check (skipped by cherry-pick workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
