### PR TITLE
enhance: Defer delegator snapshot generation during recovery

### DIFF
--- a/internal/querynodev2/delegator/delegator.go
+++ b/internal/querynodev2/delegator/delegator.go
@@ -1351,11 +1351,7 @@ func (sd *shardDelegator) Close() {
 		sd.growingSourceProvider.Deactivate()
 	}
 
-	// Stop background snapshot loop before refunding candidates
 	sd.distribution.Close()
-
-	// Refund all sealed segment candidates in distribution
-	sd.distribution.RefundAllCandidates()
 
 	// clean idf oracle
 	if idfOracle := sd.getIDFOracle(); idfOracle != nil {

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -552,7 +552,6 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 		},
 	}, 10)
 
-	s.delegator.distribution.Flush()
 	s.False(s.delegator.distribution.Serviceable())
 
 	worker1.EXPECT().LoadSegments(mock.Anything, mock.AnythingOfType("*querypb.LoadSegmentsRequest")).
@@ -575,7 +574,6 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 		Version: time.Now().UnixNano(),
 	})
 	s.Require().NoError(err)
-	s.delegator.distribution.Flush()
 	s.True(s.delegator.distribution.Serviceable())
 	// Test normal errors with retry and fail
 	worker1.ExpectedCalls = nil
@@ -588,7 +586,6 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 			RowCount:    1,
 		},
 	}, 10)
-	s.delegator.distribution.Flush()
 	s.False(s.delegator.distribution.Serviceable(), "should retry and failed")
 
 	// refresh
@@ -612,7 +609,6 @@ func (s *DelegatorDataSuite) TestProcessDelete() {
 		Version: time.Now().UnixNano(),
 	})
 	s.Require().NoError(err)
-	s.delegator.distribution.Flush()
 	s.True(s.delegator.distribution.Serviceable())
 
 	s.delegator.Close()
@@ -741,7 +737,6 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithBm25() {
 		})
 
 		s.NoError(err)
-		s.delegator.distribution.Flush()
 		sealed, _ := s.delegator.GetSegmentInfo(false)
 		s.Require().Equal(1, len(sealed))
 		s.Equal(int64(1), sealed[0].NodeID)
@@ -971,7 +966,6 @@ func (s *DelegatorDataSuite) TestLoadSegments() {
 		})
 
 		s.NoError(err)
-		s.delegator.distribution.Flush()
 		sealed, _ := s.delegator.GetSegmentInfo(false)
 		s.Require().Equal(1, len(sealed))
 		s.Equal(int64(1), sealed[0].NodeID)
@@ -1268,7 +1262,6 @@ func (s *DelegatorDataSuite) TestLoadSegmentsWithoutBloomFilter() {
 	})
 
 	s.Require().NoError(err)
-	s.delegator.distribution.Flush()
 	sealed, _ := s.delegator.GetSegmentInfo(false)
 	s.Require().Equal(1, len(sealed))
 	s.Require().Equal(1, len(sealed[0].Segments))
@@ -1668,7 +1661,6 @@ func (s *DelegatorDataSuite) TestReleaseSegment() {
 	})
 	s.Require().NoError(err)
 
-	s.delegator.distribution.Flush()
 	sealed, growing := s.delegator.GetSegmentInfo(false)
 	s.Require().Equal(1, len(sealed))
 	s.Equal(int64(1), sealed[0].NodeID)

--- a/internal/querynodev2/delegator/delegator_data_test.go
+++ b/internal/querynodev2/delegator/delegator_data_test.go
@@ -2100,12 +2100,13 @@ func (s *DelegatorDataSuite) TestSyncTargetVersion() {
 	}
 
 	s.delegator.SyncTargetVersion(&querypb.SyncAction{
-		TargetVersion:   5,
-		GrowingInTarget: []int64{1},
-		SealedInTarget:  []int64{2},
-		DroppedInTarget: []int64{3, 4},
-		Checkpoint:      &msgpb.MsgPosition{},
-		DeleteCP:        &msgpb.MsgPosition{},
+		TargetVersion:         5,
+		GrowingInTarget:       []int64{1},
+		SealedInTarget:        []int64{2},
+		SealedSegmentRowCount: map[int64]int64{2: 100},
+		DroppedInTarget:       []int64{3, 4},
+		Checkpoint:            &msgpb.MsgPosition{},
+		DeleteCP:              &msgpb.MsgPosition{},
 	}, []int64{500, 501})
 	s.Equal(int64(5), s.delegator.GetChannelQueryView().GetVersion())
 }

--- a/internal/querynodev2/delegator/delegator_test.go
+++ b/internal/querynodev2/delegator/delegator_test.go
@@ -394,7 +394,6 @@ func (s *DelegatorSuite) TestGetSegmentInfo() {
 		Version:     2001,
 	})
 
-	s.delegator.(*shardDelegator).distribution.Flush()
 	sealed, growing = s.delegator.GetSegmentInfo(false)
 	s.EqualValues([]SnapshotItem{
 		{
@@ -725,7 +724,6 @@ func (s *DelegatorSuite) TestSearch() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
-		sd.distribution.Flush()
 
 		_, err := s.delegator.Search(ctx, &querypb.SearchRequest{
 			Req: &internalpb.SearchRequest{
@@ -914,7 +912,6 @@ func (s *DelegatorSuite) TestQuery() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
-		sd.distribution.Flush()
 
 		_, err := s.delegator.Query(ctx, &querypb.QueryRequest{
 			Req:         &internalpb.RetrieveRequest{QueryLabel: "query", Base: commonpbutil.NewMsgBase()},
@@ -1198,7 +1195,6 @@ func (s *DelegatorSuite) TestQueryStream() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
-		sd.distribution.Flush()
 
 		client := streamrpc.NewLocalQueryClient(ctx)
 		server := client.CreateServer()
@@ -1376,7 +1372,6 @@ func (s *DelegatorSuite) TestGetStats() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
-		sd.distribution.Flush()
 
 		_, err := s.delegator.GetStatistics(ctx, &querypb.GetStatisticsRequest{
 			Req:         &internalpb.GetStatisticsRequest{Base: commonpbutil.NewMsgBase()},
@@ -1483,7 +1478,6 @@ func (s *DelegatorSuite) TestUpdateSchema() {
 		sd, ok := s.delegator.(*shardDelegator)
 		s.Require().True(ok)
 		sd.distribution.MarkOfflineSegments(1001)
-		sd.distribution.Flush()
 
 		err := s.delegator.UpdateSchema(ctx, newFunctionRuntimeTestSchemaWithVersion(s.nextSchemaVersion()), 100)
 		s.Error(err)

--- a/internal/querynodev2/delegator/delta_forward_test.go
+++ b/internal/querynodev2/delegator/delta_forward_test.go
@@ -194,11 +194,12 @@ func (s *StreamingForwardSuite) TestBFStreamingForward() {
 		SegmentID:   102,
 	})
 	delegator.distribution.SyncTargetVersion(&querypb.SyncAction{
-		TargetVersion:   1,
-		GrowingInTarget: []int64{100},
-		SealedInTarget:  []int64{101, 102},
-		DroppedInTarget: nil,
-		Checkpoint:      nil,
+		TargetVersion:         1,
+		GrowingInTarget:       []int64{100},
+		SealedInTarget:        []int64{101, 102},
+		SealedSegmentRowCount: map[int64]int64{101: 100, 102: 100},
+		DroppedInTarget:       nil,
+		Checkpoint:            nil,
 	}, []int64{1})
 
 	deletedSegment := typeutil.NewConcurrentSet[int64]()
@@ -246,11 +247,12 @@ func (s *StreamingForwardSuite) TestDirectStreamingForward() {
 		SegmentID:   102,
 	})
 	delegator.distribution.SyncTargetVersion(&querypb.SyncAction{
-		TargetVersion:   1,
-		GrowingInTarget: []int64{100},
-		SealedInTarget:  []int64{101, 102},
-		DroppedInTarget: nil,
-		Checkpoint:      nil,
+		TargetVersion:         1,
+		GrowingInTarget:       []int64{100},
+		SealedInTarget:        []int64{101, 102},
+		SealedSegmentRowCount: map[int64]int64{101: 100, 102: 100},
+		DroppedInTarget:       nil,
+		Checkpoint:            nil,
 	}, []int64{1})
 
 	// For Direct forward policy, candidates are not used for BF filtering

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -528,12 +528,12 @@ func (d *distribution) SyncTargetVersion(action *querypb.SyncAction, partitions 
 		syncedByCoord:         true,
 	}
 
-	sealedSet := typeutil.NewUniqueSet(action.GetSealedInTarget()...)
 	droppedSet := typeutil.NewUniqueSet(action.GetDroppedInTarget()...)
 	redundantGrowings := make([]int64, 0)
 	for _, s := range d.growingSegments {
 		// sealed segment already exists or dropped, make growing segment redundant
-		if sealedSet.Contain(s.SegmentID) || droppedSet.Contain(s.SegmentID) {
+		_, sealedInTarget := d.queryView.sealedSegmentRowCount[s.SegmentID]
+		if sealedInTarget || droppedSet.Contain(s.SegmentID) {
 			s.TargetVersion = redundantTargetVersion
 			mlog.Info(context.TODO(), "set growing segment redundant, wait for release",
 				mlog.FieldSegmentID(s.SegmentID),
@@ -582,7 +582,7 @@ func (d *distribution) SyncTargetVersion(action *querypb.SyncAction, partitions 
 		mlog.Bool("serviceable", d.queryView.Serviceable()),
 		mlog.Float64("loadedRatio", d.queryView.GetLoadedRatio()),
 		mlog.Int("growingSegmentNum", len(action.GetGrowingInTarget())),
-		mlog.Int("sealedSegmentNum", len(action.GetSealedInTarget())),
+		mlog.Int("sealedSegmentNum", len(action.GetSealedSegmentRowCount())),
 	)
 }
 
@@ -648,8 +648,17 @@ func (d *distribution) genSnapshot() chan struct{} {
 	// ok to be nil
 	last := d.current.Load()
 
-	nodeSegments := make(map[int64][]SegmentEntry)
+	nodeSegmentCounts := make(map[int64]int)
 	for _, entry := range d.sealedSegments {
+		nodeSegmentCounts[entry.NodeID]++
+	}
+
+	nodeSegments := make(map[int64][]SegmentEntry, len(nodeSegmentCounts))
+	for nodeID, count := range nodeSegmentCounts {
+		nodeSegments[nodeID] = make([]SegmentEntry, 0, count)
+	}
+	for _, entry := range d.sealedSegments {
+		entry = d.snapshotEntryForQueryView(entry)
 		nodeSegments[entry.NodeID] = append(nodeSegments[entry.NodeID], entry)
 	}
 
@@ -657,10 +666,8 @@ func (d *distribution) genSnapshot() chan struct{} {
 	dist := make([]SnapshotItem, 0, len(nodeSegments))
 	for nodeID, items := range nodeSegments {
 		dist = append(dist, SnapshotItem{
-			NodeID: nodeID,
-			Segments: lo.Map(items, func(entry SegmentEntry, _ int) SegmentEntry {
-				return d.snapshotEntryForQueryView(entry)
-			}),
+			NodeID:   nodeID,
+			Segments: items,
 		})
 	}
 

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -122,13 +122,9 @@ type distribution struct {
 	idfOracle IDFOracle
 	// protects current & segments
 	mut sync.RWMutex
-
-	// async snapshot generation
-	snapshotNotifier chan struct{} // capacity 1, notify background goroutine to regenerate snapshot
-	snapshotClose    chan struct{} // closed to stop background goroutine
-	snapshotDone     chan struct{} // closed when background goroutine exits
-	closed           *atomic.Bool
-	closeOnce        sync.Once
+	// closed rejects late distribution updates after delegator shutdown.
+	// It is protected by mut so AddDistributions and Close are ordered.
+	closed bool
 
 	// distribution info
 	channelName string
@@ -154,50 +150,17 @@ type SegmentEntry struct {
 
 func NewDistribution(channelName string, queryView *channelQueryView) *distribution {
 	dist := &distribution{
-		channelName:      channelName,
-		growingSegments:  make(map[UniqueID]SegmentEntry),
-		sealedSegments:   make(map[UniqueID]SegmentEntry),
-		snapshots:        typeutil.NewConcurrentMap[int64, *snapshot](),
-		current:          atomic.NewPointer[snapshot](nil),
-		queryView:        queryView,
-		snapshotNotifier: make(chan struct{}, 1),
-		snapshotClose:    make(chan struct{}),
-		snapshotDone:     make(chan struct{}),
-		closed:           atomic.NewBool(false),
+		channelName:     channelName,
+		growingSegments: make(map[UniqueID]SegmentEntry),
+		sealedSegments:  make(map[UniqueID]SegmentEntry),
+		snapshots:       typeutil.NewConcurrentMap[int64, *snapshot](),
+		current:         atomic.NewPointer[snapshot](nil),
+		queryView:       queryView,
 	}
 	// generate initial snapshot synchronously
 	dist.genSnapshot()
 	dist.updateServiceable("NewDistribution")
-	// start background snapshot loop
-	go dist.snapshotLoop()
 	return dist
-}
-
-// notifySnapshotUpdate sends a non-blocking notification to regenerate snapshot.
-func (d *distribution) notifySnapshotUpdate() {
-	if d.closed.Load() {
-		return
-	}
-	select {
-	case d.snapshotNotifier <- struct{}{}:
-	default:
-	}
-}
-
-// snapshotLoop runs in a background goroutine, regenerating snapshot on notification.
-func (d *distribution) snapshotLoop() {
-	defer close(d.snapshotDone)
-	for {
-		select {
-		case <-d.snapshotClose:
-			return
-		case <-d.snapshotNotifier:
-			d.mut.Lock()
-			d.genSnapshot()
-			d.updateServiceable("snapshotLoop")
-			d.mut.Unlock()
-		}
-	}
 }
 
 func (d *distribution) SetIDFOracle(idfOracle IDFOracle) {
@@ -390,19 +353,20 @@ func (d *distribution) updateServiceable(triggerAction string) {
 
 // AddDistributions add multiple segment entries.
 func (d *distribution) AddDistributions(entries ...SegmentEntry) {
+	d.mut.Lock()
 	var toRefund []pkoracle.Candidate
-
-	if d.closed.Load() {
+	updated := false
+	if d.closed {
 		for _, entry := range entries {
 			if entry.Candidate != nil {
 				toRefund = append(toRefund, entry.Candidate)
 			}
 		}
+		d.mut.Unlock()
 		refundCandidates(toRefund)
 		return
 	}
 
-	d.mut.Lock()
 	for _, entry := range entries {
 		oldEntry, ok := d.sealedSegments[entry.SegmentID]
 		if ok && oldEntry.Version >= entry.Version {
@@ -428,10 +392,15 @@ func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 			entry.TargetVersion = unreadableTargetVersion
 		}
 		d.sealedSegments[entry.SegmentID] = entry
+		updated = true
+	}
+
+	if updated {
+		d.genSnapshot()
+		d.updateServiceable("AddDistributions")
 	}
 	d.mut.Unlock()
 
-	d.notifySnapshotUpdate()
 	refundCandidates(toRefund)
 }
 
@@ -444,9 +413,7 @@ func refundCandidates(candidates []pkoracle.Candidate) {
 
 // AddGrowing adds growing segment distribution.
 // genSnapshot is called synchronously so that the growing segment is
-// immediately visible to searches. Growing segments are created
-// infrequently (only on the first insert for each segment), so this
-// does not regress the lock-contention optimization.
+// immediately visible to searches.
 func (d *distribution) AddGrowing(entries ...SegmentEntry) {
 	d.mut.Lock()
 	for _, entry := range entries {
@@ -459,6 +426,8 @@ func (d *distribution) AddGrowing(entries ...SegmentEntry) {
 // AddOffline set segmentIDs to offlines.
 func (d *distribution) MarkOfflineSegments(segmentIDs ...int64) {
 	d.mut.Lock()
+	defer d.mut.Unlock()
+
 	updated := false
 	for _, segmentID := range segmentIDs {
 		entry, ok := d.sealedSegments[segmentID]
@@ -471,13 +440,13 @@ func (d *distribution) MarkOfflineSegments(segmentIDs ...int64) {
 		entry.NodeID = -1
 		d.sealedSegments[segmentID] = entry
 	}
-	d.mut.Unlock()
 
 	if updated {
 		mlog.Info(context.TODO(), "mark sealed segment offline from distribution",
 			mlog.String("channelName", d.channelName),
 			mlog.Int64s("segmentIDs", segmentIDs))
-		d.notifySnapshotUpdate()
+		d.genSnapshot()
+		d.updateServiceable("MarkOfflineSegments")
 	}
 }
 
@@ -594,17 +563,6 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 		delete(d.growingSegments, growing.SegmentID)
 	}
 
-	// Capture current snapshot's cleared channel. The next genSnapshot will
-	// create a new snapshot and expire this one, closing the channel.
-	var signal chan struct{}
-	if current := d.current.Load(); current != nil {
-		signal = current.cleared
-	} else {
-		signal = make(chan struct{})
-		close(signal)
-	}
-	d.mut.Unlock()
-
 	mlog.Info(context.TODO(), "remove segments from distribution",
 		mlog.String("channelName", d.channelName),
 		mlog.Int64s("growing", lo.Map(growingSegments, func(s SegmentEntry, _ int) int64 { return s.SegmentID })),
@@ -612,7 +570,12 @@ func (d *distribution) RemoveDistributions(sealedSegments []SegmentEntry, growin
 		mlog.Int("sealedCandidatesRefunded", len(toRefund)),
 	)
 
-	d.notifySnapshotUpdate()
+	d.updateServiceable("RemoveDistributions")
+	// wait previous read even not distribution changed
+	// in case of segment balance caused segment lost track
+	signal := d.genSnapshot()
+	d.mut.Unlock()
+
 	refundCandidates(toRefund)
 
 	return signal
@@ -798,32 +761,18 @@ func BatchGetFromSegments(pks []storage.PrimaryKey, partitionID int64, sealed []
 	return result
 }
 
-// Flush synchronously generates a snapshot so that subsequent reads
-// (e.g. PeekSegments) see the latest distribution state.
-// This is useful in tests and in scenarios that require immediate consistency.
-func (d *distribution) Flush() {
-	d.mut.Lock()
-	d.genSnapshot()
-	d.updateServiceable("Flush")
-	d.mut.Unlock()
-}
-
-// Close stops the background snapshot loop and waits for it to exit.
+// Close marks distribution closed and refunds all sealed segment candidates.
 func (d *distribution) Close() {
-	d.closeOnce.Do(func() {
-		d.closed.Store(true)
-		close(d.snapshotClose)
-	})
-	<-d.snapshotDone
+	d.mut.Lock()
+	d.closed = true
+	toRefund := d.drainSealedCandidatesLocked()
+	d.mut.Unlock()
+
+	refundCandidates(toRefund)
 }
 
-// RefundAllCandidates refunds resources for all sealed segment candidates.
-// Used during shutdown to clean up and refund resources.
-// Note: Growing segment candidates (LocalSegment) are managed by segmentManager.
-func (d *distribution) RefundAllCandidates() {
-	d.mut.Lock()
-	var toRefund []pkoracle.Candidate
-
+func (d *distribution) drainSealedCandidatesLocked() []pkoracle.Candidate {
+	toRefund := make([]pkoracle.Candidate, 0)
 	// Only refund sealed segment candidates
 	// Growing segment candidates (LocalSegment) are managed by segmentManager
 	for segmentID, entry := range d.sealedSegments {
@@ -833,7 +782,5 @@ func (d *distribution) RefundAllCandidates() {
 			d.sealedSegments[segmentID] = entry
 		}
 	}
-	d.mut.Unlock()
-
-	refundCandidates(toRefund)
+	return toRefund
 }

--- a/internal/querynodev2/delegator/distribution.go
+++ b/internal/querynodev2/delegator/distribution.go
@@ -240,13 +240,64 @@ func (d *distribution) PinOnlineSegments(partitions ...int64) (sealed []Snapshot
 	defer d.mut.RUnlock()
 
 	current := d.current.Load()
-	sealed, growing = current.Get(partitions...)
+	if d.isPreSyncRecoveryLocked() {
+		current.inUse.Inc()
+		sealed, growing = d.peekLiveSegmentsLocked(partitions...)
+	} else {
+		sealed, growing = current.Get(partitions...)
+	}
 	filterOnline := func(entry SegmentEntry, _ int) bool {
 		return !entry.Offline
 	}
 	sealed, growing = d.filterSegments(sealed, growing, filterOnline)
 	version = current.version
 	return sealed, growing, version
+}
+
+// isPreSyncRecoveryLocked reports whether the delegator is still rebuilding
+// distribution before coord syncs the query view. During this window,
+// AddDistributions keeps the public snapshot unchanged, while online segment
+// readers look at live distribution maps under lock to support delete forward.
+func (d *distribution) isPreSyncRecoveryLocked() bool {
+	return !d.queryView.syncedByCoord
+}
+
+func (d *distribution) snapshotEntryForQueryView(entry SegmentEntry) SegmentEntry {
+	if !d.queryView.partitions.Contain(entry.PartitionID) {
+		entry.TargetVersion = unreadableTargetVersion
+	}
+	return entry
+}
+
+func (d *distribution) peekLiveSegmentsLocked(partitions ...int64) (sealed []SnapshotItem, growing []SegmentEntry) {
+	matched := func(entry SegmentEntry) bool {
+		return len(partitions) == 0 || lo.Contains(partitions, entry.PartitionID)
+	}
+
+	nodeSegments := make(map[int64][]SegmentEntry)
+	for _, entry := range d.sealedSegments {
+		if !matched(entry) {
+			continue
+		}
+		entry = d.snapshotEntryForQueryView(entry)
+		nodeSegments[entry.NodeID] = append(nodeSegments[entry.NodeID], entry)
+	}
+	sealed = make([]SnapshotItem, 0, len(nodeSegments))
+	for nodeID, segments := range nodeSegments {
+		sealed = append(sealed, SnapshotItem{
+			NodeID:   nodeID,
+			Segments: segments,
+		})
+	}
+
+	growing = make([]SegmentEntry, 0, len(d.growingSegments))
+	for _, entry := range d.growingSegments {
+		if !matched(entry) {
+			continue
+		}
+		growing = append(growing, d.snapshotEntryForQueryView(entry))
+	}
+	return sealed, growing
 }
 
 func (d *distribution) filterSegments(sealed []SnapshotItem, growing []SegmentEntry, filter func(SegmentEntry, int) bool) ([]SnapshotItem, []SegmentEntry) {
@@ -264,6 +315,14 @@ func (d *distribution) filterSegments(sealed []SnapshotItem, growing []SegmentEn
 // PeekAllSegments returns current snapshot without increasing inuse count
 // show only used by GetDataDistribution.
 func (d *distribution) PeekSegments(readable bool, partitions ...int64) (sealed []SnapshotItem, growing []SegmentEntry) {
+	d.mut.RLock()
+	if !readable && d.isPreSyncRecoveryLocked() {
+		sealed, growing = d.peekLiveSegmentsLocked(partitions...)
+		d.mut.RUnlock()
+		return sealed, growing
+	}
+	d.mut.RUnlock()
+
 	current := d.current.Load()
 	sealed, growing = current.Peek(partitions...)
 
@@ -395,7 +454,7 @@ func (d *distribution) AddDistributions(entries ...SegmentEntry) {
 		updated = true
 	}
 
-	if updated {
+	if updated && !d.isPreSyncRecoveryLocked() {
 		d.genSnapshot()
 		d.updateServiceable("AddDistributions")
 	}
@@ -600,20 +659,14 @@ func (d *distribution) genSnapshot() chan struct{} {
 		dist = append(dist, SnapshotItem{
 			NodeID: nodeID,
 			Segments: lo.Map(items, func(entry SegmentEntry, _ int) SegmentEntry {
-				if !d.queryView.partitions.Contain(entry.PartitionID) {
-					entry.TargetVersion = unreadableTargetVersion
-				}
-				return entry
+				return d.snapshotEntryForQueryView(entry)
 			}),
 		})
 	}
 
 	growing := make([]SegmentEntry, 0, len(d.growingSegments))
 	for _, entry := range d.growingSegments {
-		if !d.queryView.partitions.Contain(entry.PartitionID) {
-			entry.TargetVersion = unreadableTargetVersion
-		}
-		growing = append(growing, entry)
+		growing = append(growing, d.snapshotEntryForQueryView(entry))
 	}
 
 	// update snapshot version

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -1535,10 +1535,13 @@ func (s *DistributionSuite) TestSyncTargetVersion_RedundantGrowingLogic() {
 			s.dist.AddGrowing(tc.growingSegments...)
 
 			// Call SyncTargetVersion to trigger redundant growing segment logic
+			sealedSegmentRowCount := lo.SliceToMap(tc.sealedInTarget, func(segmentID int64) (int64, int64) {
+				return segmentID, 100
+			})
 			s.dist.SyncTargetVersion(&querypb.SyncAction{
-				TargetVersion:   1000,
-				SealedInTarget:  tc.sealedInTarget,
-				DroppedInTarget: tc.droppedInTarget,
+				TargetVersion:         1000,
+				SealedSegmentRowCount: sealedSegmentRowCount,
+				DroppedInTarget:       tc.droppedInTarget,
 			}, []int64{1})
 
 			// Verify redundant segments have correct target version

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -17,6 +17,7 @@
 package delegator
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -43,10 +44,34 @@ func (s *DistributionSuite) SetupTest() {
 }
 
 func (s *DistributionSuite) TearDownTest() {
-	if s.dist != nil {
-		s.dist.Close()
-	}
 	s.dist = nil
+}
+
+func TestAddDistributionsPublishesSnapshotSynchronously(t *testing.T) {
+	oldProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(oldProcs)
+
+	paramtable.Init()
+	dist := NewDistribution("channel-1", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+
+	dist.AddDistributions(SegmentEntry{
+		NodeID:      1,
+		SegmentID:   1,
+		PartitionID: 1,
+	})
+
+	sealed, _, version := dist.PinOnlineSegments()
+	defer dist.Unpin(version)
+
+	requireSnapshot := assert.New(t)
+	if requireSnapshot.Len(sealed, 1) {
+		requireSnapshot.ElementsMatch([]SegmentEntry{{
+			NodeID:        1,
+			SegmentID:     1,
+			PartitionID:   1,
+			TargetVersion: unreadableTargetVersion,
+		}}, sealed[0].Segments)
+	}
 }
 
 func (s *DistributionSuite) TestAddDistribution() {
@@ -196,7 +221,6 @@ func (s *DistributionSuite) TestAddDistribution() {
 			_, _, _, version, err := s.dist.PinReadableSegments(1.0, 1)
 			s.Require().NoError(err)
 			s.dist.AddDistributions(tc.input...)
-			s.dist.Flush()
 			sealed, _ := s.dist.PeekSegments(false)
 			s.compareSnapshotItems(tc.expected, sealed)
 			s.dist.Unpin(version)
@@ -633,7 +657,6 @@ func (s *DistributionSuite) TestPeek() {
 			defer s.TearDownTest()
 
 			s.dist.AddDistributions(tc.input...)
-			s.dist.Flush()
 			sealed, _ := s.dist.PeekSegments(tc.readable)
 			s.compareSnapshotItems(tc.expected, sealed)
 		})
@@ -700,7 +723,6 @@ func (s *DistributionSuite) TestMarkOfflineSegments() {
 				DroppedInTarget:       nil,
 			}, nil)
 			s.dist.MarkOfflineSegments(tc.offlines...)
-			s.dist.Flush()
 			s.Equal(tc.serviceable, s.dist.Serviceable())
 
 			for _, offline := range tc.offlines {
@@ -829,13 +851,12 @@ func TestDistribution_NewDistribution(t *testing.T) {
 	assert.NotNil(t, dist.current)
 }
 
-func TestDistribution_NotifyAfterClose(t *testing.T) {
+func TestDistribution_AddDistributionsAfterClose(t *testing.T) {
 	dist := NewDistribution("test_channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
 	dist.Close()
-	refunded := false
+	refundCount := 0
 
 	assert.NotPanics(t, func() {
-		dist.notifySnapshotUpdate()
 		dist.AddDistributions(SegmentEntry{
 			NodeID:      1,
 			SegmentID:   1,
@@ -843,12 +864,39 @@ func TestDistribution_NotifyAfterClose(t *testing.T) {
 			Version:     1,
 			Candidate: &refundTrackingCandidate{
 				mockCandidate: mockCandidate{id: 1, partition: 1},
-				refunded:      &refunded,
+				refundCount:   &refundCount,
 			},
 		})
 	})
-	assert.True(t, refunded)
+	assert.Equal(t, 1, refundCount)
 	assert.False(t, dist.SealedSegmentExists(1))
+}
+
+func TestDistribution_CloseRefundsExistingCandidate(t *testing.T) {
+	dist := NewDistribution("test_channel", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+	refundCount := 0
+	dist.AddDistributions(SegmentEntry{
+		NodeID:      1,
+		SegmentID:   1,
+		PartitionID: 1,
+		Version:     1,
+		Candidate: &refundTrackingCandidate{
+			mockCandidate: mockCandidate{id: 1, partition: 1},
+			refundCount:   &refundCount,
+		},
+	})
+
+	assert.True(t, dist.SealedSegmentExists(1))
+	assert.Zero(t, refundCount)
+
+	dist.Close()
+
+	assert.Equal(t, 1, refundCount)
+	dist.mut.RLock()
+	entry, ok := dist.sealedSegments[1]
+	dist.mut.RUnlock()
+	assert.True(t, ok)
+	assert.Nil(t, entry.Candidate)
 }
 
 func TestDistribution_UpdateServiceable(t *testing.T) {
@@ -1466,10 +1514,6 @@ func TestPinReadableSegments(t *testing.T) {
 			SealedSegmentRowCount: map[int64]int64{1: 100, 2: 100},
 			GrowingInTarget:       []int64{},
 		}, []int64{1})
-		// Flush pending snapshot and stop background goroutine to avoid
-		// data race with mockey patches in sub-tests.
-		dist.Flush()
-		dist.Close()
 		return dist
 	}
 
@@ -1553,10 +1597,6 @@ func TestPinReadableSegments_ServiceableLogic(t *testing.T) {
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
 
-	// Stop background goroutine to avoid data race with mockey patches.
-	dist.Flush()
-	dist.Close()
-
 	// Test case: requireFullResult=true, Serviceable=false, GetLoadedRatio=1.0
 	// This tests the case where load ratio is satisfied but serviceable is false
 	mockServiceable := mockey.Mock((*channelQueryView).Serviceable).Return(false).Build()
@@ -1589,10 +1629,6 @@ func TestPinReadableSegments_LoadRatioLogic(t *testing.T) {
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
 
-	// Stop background goroutine to avoid data race with mockey patches.
-	dist.Flush()
-	dist.Close()
-
 	// Test case: requireFullResult=false, loadRatioSatisfy=false
 	// This tests the case where partial result is requested but load ratio is insufficient
 	mockGetLoadedRatio := mockey.Mock((*channelQueryView).GetLoadedRatio).Return(0.3).Build()
@@ -1622,10 +1658,6 @@ func TestPinReadableSegments_EdgeCases(t *testing.T) {
 		SealedSegmentRowCount: map[int64]int64{1: 100},
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
-
-	// Stop background goroutine to avoid data race with mockey patches.
-	dist.Flush()
-	dist.Close()
 
 	// Test case 1: requiredLoadRatio = 0.0 (edge case)
 	mockGetLoadedRatio := mockey.Mock((*channelQueryView).GetLoadedRatio).Return(0.0).Build()
@@ -1687,10 +1719,6 @@ func TestPinReadableSegments_PartialResultNotEmpty(t *testing.T) {
 		GrowingInTarget:       []int64{},
 	}, []int64{1})
 
-	// Stop background goroutine to avoid data race with mockey patches.
-	dist.Flush()
-	dist.Close()
-
 	// Call PinReadableSegments with partial result enabled (requiredLoadRatio < 1.0)
 	sealed, growing, _, _, err := dist.PinReadableSegments(0.8, 1)
 
@@ -1748,11 +1776,11 @@ func (m *mockCandidate) Refund()                                  {}
 
 type refundTrackingCandidate struct {
 	mockCandidate
-	refunded *bool
+	refundCount *int
 }
 
 func (m *refundTrackingCandidate) Refund() {
-	*m.refunded = true
+	(*m.refundCount)++
 }
 
 func TestBatchGetFromSegments(t *testing.T) {

--- a/internal/querynodev2/delegator/distribution_test.go
+++ b/internal/querynodev2/delegator/distribution_test.go
@@ -53,11 +53,15 @@ func TestAddDistributionsPublishesSnapshotSynchronously(t *testing.T) {
 
 	paramtable.Init()
 	dist := NewDistribution("channel-1", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+	candidate := &mockCandidate{id: 1, partition: 1}
+	dist.queryView.syncedByCoord = true
 
 	dist.AddDistributions(SegmentEntry{
 		NodeID:      1,
 		SegmentID:   1,
 		PartitionID: 1,
+		Version:     1,
+		Candidate:   candidate,
 	})
 
 	sealed, _, version := dist.PinOnlineSegments()
@@ -69,9 +73,74 @@ func TestAddDistributionsPublishesSnapshotSynchronously(t *testing.T) {
 			NodeID:        1,
 			SegmentID:     1,
 			PartitionID:   1,
+			Version:       1,
 			TargetVersion: unreadableTargetVersion,
+			Candidate:     candidate,
 		}}, sealed[0].Segments)
 	}
+}
+
+func TestDistributionPreSyncDefersRecoverySnapshot(t *testing.T) {
+	paramtable.Init()
+	dist := NewDistribution("channel-1", NewChannelQueryView(nil, nil, []int64{1}, initialTargetVersion))
+	initialSnapshot := dist.current.Load()
+	candidate := &mockCandidate{id: 100, partition: 1}
+
+	dist.AddDistributions(SegmentEntry{
+		NodeID:      10,
+		SegmentID:   100,
+		PartitionID: 1,
+		Version:     1,
+		Candidate:   candidate,
+	})
+
+	current := dist.current.Load()
+	assert.Equal(t, initialSnapshot.version, current.version)
+	sealedInSnapshot, _ := current.Peek()
+	assert.Empty(t, sealedInSnapshot)
+
+	expected := []SnapshotItem{{
+		NodeID: 10,
+		Segments: []SegmentEntry{{
+			NodeID:        10,
+			SegmentID:     100,
+			PartitionID:   1,
+			Version:       1,
+			TargetVersion: unreadableTargetVersion,
+			Candidate:     candidate,
+		}},
+	}}
+
+	liveSealed, _ := dist.PeekSegments(false)
+	assert.ElementsMatch(t, expected, liveSealed)
+
+	onlineSealed, _, version := dist.PinOnlineSegments()
+	defer dist.Unpin(version)
+	assert.ElementsMatch(t, expected, onlineSealed)
+
+	readableSealed, _ := dist.PeekSegments(true)
+	assert.Empty(t, readableSealed)
+
+	dist.SyncTargetVersion(&querypb.SyncAction{
+		TargetVersion:         100,
+		SealedSegmentRowCount: map[int64]int64{100: 10},
+	}, []int64{1})
+
+	expectedAfterSync := []SnapshotItem{{
+		NodeID: 10,
+		Segments: []SegmentEntry{{
+			NodeID:        10,
+			SegmentID:     100,
+			PartitionID:   1,
+			Version:       1,
+			TargetVersion: 100,
+			Candidate:     candidate,
+		}},
+	}}
+	sealedAfterSync, _ := dist.current.Load().Peek()
+	assert.ElementsMatch(t, expectedAfterSync, sealedAfterSync)
+	_, _, _, _, err := dist.PinReadableSegments(1.0, 1)
+	assert.NoError(t, err)
 }
 
 func (s *DistributionSuite) TestAddDistribution() {
@@ -638,16 +707,7 @@ func (s *DistributionSuite) TestPeek() {
 					SegmentID: 3,
 				},
 			},
-			expected: []SnapshotItem{
-				{
-					NodeID:   1,
-					Segments: []SegmentEntry{},
-				},
-				{
-					NodeID:   2,
-					Segments: []SegmentEntry{},
-				},
-			},
+			expected: []SnapshotItem{},
 		},
 	}
 

--- a/internal/querynodev2/services_test.go
+++ b/internal/querynodev2/services_test.go
@@ -2088,11 +2088,12 @@ func (suite *ServiceSuite) TestSyncDistribution_Normal() {
 
 	// test sync targte version
 	syncVersionAction := &querypb.SyncAction{
-		Type:            querypb.SyncType_UpdateVersion,
-		SealedInTarget:  []int64{3},
-		GrowingInTarget: []int64{4},
-		DroppedInTarget: []int64{1, 2},
-		TargetVersion:   time.Now().UnixMilli(),
+		Type:                  querypb.SyncType_UpdateVersion,
+		SealedInTarget:        []int64{3},
+		SealedSegmentRowCount: map[int64]int64{3: 100},
+		GrowingInTarget:       []int64{4},
+		DroppedInTarget:       []int64{1, 2},
+		TargetVersion:         time.Now().UnixMilli(),
 	}
 
 	req.Actions = []*querypb.SyncAction{syncVersionAction}


### PR DESCRIPTION
issue: #51107

## What this PR does

This PR optimizes QueryNode delegator recovery by deferring the first public snapshot generation while restored segment distribution is still being rebuilt before QueryCoord syncs the target view.

During pre-sync recovery, restored distributions stay in the live distribution maps and online segment routing reads those maps under lock. This avoids publishing a new snapshot for every restored segment while still allowing delete forward to see restored segments. Once QueryCoord syncs the target view, snapshot generation remains synchronous where delete forwarding and the IDF oracle depend on the newly generated snapshot.

## Commit breakdown

- `786cc5a3f0 fix: sync delegator snapshot for delete forwarding`
  - Restores synchronous snapshot generation on target-version sync so delete forward and IDF oracle state observe the current distribution immediately.

- `14e9a75547 enhance: defer pre-sync recovery snapshots`
  - Defers public snapshot generation during pre-sync recovery before QueryCoord syncs the query view.
  - Lets online segment reads use live distribution maps under lock during that window, preserving delete forward correctness without repeatedly publishing snapshots.

- `b27d19ff8e enhance: reduce production snapshot memory usage`
  - Uses `SealedSegmentRowCount` as the authoritative sealed target source inside QueryNode.
  - Preallocates per-node snapshot grouping to reduce allocations and memory overhead while building production snapshots.

## Test Plan

- [x] `git diff --check`
- [x] `gofumpt -l internal/querynodev2/delegator/distribution.go internal/querynodev2/delegator/distribution_test.go internal/querynodev2/delegator/delegator_data_test.go internal/querynodev2/delegator/delta_forward_test.go internal/querynodev2/services_test.go`
- [x] `go test -v -count=1 -tags dynamic,test -gcflags=\"all=-N -l\" ./internal/querynodev2/delegator -run \"Test(AddDistributionsPublishesSnapshotSynchronously|DistributionPreSyncDefersRecoverySnapshot)$\"`
- [x] `go test -v -count=1 -tags dynamic,test -gcflags=\"all=-N -l\" ./internal/querynodev2/delegator -run \"TestStreamingForward/(TestBFStreamingForward|TestDirectStreamingForward)$|TestDelegatorDataSuite/TestSyncTargetVersion$|TestDistributionSuite/TestSyncTargetVersion_RedundantGrowingLogic$\"`
- [x] `go test -v -count=1 -tags dynamic,test -gcflags=\"all=-N -l\" ./internal/querynodev2 -run \"TestQueryNodeService/TestSyncDistribution_Normal$\"`