### PR TITLE
enhance: Read group chunks through chunk reader

### DIFF
--- a/internal/core/src/index/json_stats/JsonKeyStats.cpp
+++ b/internal/core/src/index/json_stats/JsonKeyStats.cpp
@@ -44,11 +44,13 @@
 #include "index/json_stats/JsonKeyStats.h"
 #include "index/json_stats/bson_builder.h"
 #include "index/json_stats/parquet_writer.h"
+#include "milvus-storage/column_groups.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/constants.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/parquet/file_reader.h"
+#include "milvus-storage/reader.h"
 #include "mmap/ChunkedColumnGroup.h"
 #include "mmap/Types.h"
 #include "nlohmann/detail/iterators/iteration_proxy.hpp"
@@ -69,6 +71,7 @@
 #include "storage/ThreadPools.h"
 #include "storage/Types.h"
 #include "storage/Util.h"
+#include "storage/loon_ffi/property_singleton.h"
 
 namespace milvus::index {
 
@@ -971,12 +974,17 @@ JsonKeyStats::LoadColumnGroup(int64_t column_group_id,
     auto file_reader = result.ValueOrDie();
     std::shared_ptr<milvus_storage::PackedFileMetadata> metadata =
         file_reader->file_metadata();
+    auto arrow_schema = file_reader->schema();
     milvus_storage::FieldIDList field_id_list =
         metadata->GetGroupFieldIDList().GetFieldIDList(column_group_id);
     std::vector<FieldId> milvus_field_ids;
     for (int i = 0; i < field_id_list.size(); ++i) {
         milvus_field_ids.push_back(FieldId(field_id_list.Get(i)));
     }
+    auto close_status = file_reader->Close();
+    AssertInfo(close_status.ok(),
+               "[StorageV2] failed to close json stats schema reader: {}",
+               close_status.ToString());
 
     // Fetch row group metadata from all files in parallel using HIGH POOL
     // to avoid blocking the caller thread with serial S3 I/O
@@ -1030,7 +1038,13 @@ JsonKeyStats::LoadColumnGroup(int64_t column_group_id,
 
     std::unordered_map<FieldId, FieldMeta> field_meta_map;
     for (const auto& inner_field_id : milvus_field_ids) {
-        auto field_name = field_id_to_name_map_[inner_field_id.get()];
+        auto field_name_it = field_id_to_name_map_.find(inner_field_id.get());
+        AssertInfo(field_name_it != field_id_to_name_map_.end(),
+                   "field id {} not found in json stats schema map for "
+                   "segment {}",
+                   inner_field_id.get(),
+                   segment_id_);
+        auto field_name = field_name_it->second;
         FieldMeta field_meta(
             FieldName(field_name),
             inner_field_id,
@@ -1047,13 +1061,63 @@ JsonKeyStats::LoadColumnGroup(int64_t column_group_id,
     auto group_chunk_metadata = milvus::segcore::LoadGroupChunkMetadata(
         files, {}, fmt::format("seg_{}_jks_{}", segment_id_, field_id_));
 
+    auto column_group = std::make_shared<milvus_storage::api::ColumnGroup>();
+    column_group->format = LOON_FORMAT_PARQUET;
+    column_group->columns.reserve(milvus_field_ids.size());
+    for (const auto& inner_field_id : milvus_field_ids) {
+        auto it = field_id_to_name_map_.find(inner_field_id.get());
+        AssertInfo(it != field_id_to_name_map_.end(),
+                   "field id {} not found in json stats schema map for "
+                   "segment {}",
+                   inner_field_id.get(),
+                   segment_id_);
+        column_group->columns.push_back(it->second);
+    }
+    for (size_t file_idx = 0; file_idx < files.size(); ++file_idx) {
+        AssertInfo(file_idx < group_chunk_metadata.row_group_meta_list.size(),
+                   "json stats row group metadata missing for file {} in "
+                   "segment {}",
+                   files[file_idx],
+                   segment_id_);
+        int64_t rows_in_file = 0;
+        for (int i = 0;
+             i < group_chunk_metadata.row_group_meta_list[file_idx].size();
+             ++i) {
+            rows_in_file += group_chunk_metadata.row_group_meta_list[file_idx]
+                                .Get(i)
+                                .row_num();
+        }
+        column_group->files.push_back(milvus_storage::api::ColumnGroupFile{
+            files[file_idx], 0, rows_in_file, {}});
+    }
+    auto needed_columns =
+        std::make_shared<std::vector<std::string>>(column_group->columns);
+    auto column_groups = std::make_shared<milvus_storage::api::ColumnGroups>();
+    column_groups->push_back(std::move(column_group));
+    auto properties = milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+                          .GetProperties();
+    AssertInfo(properties != nullptr,
+               "cannot create json stats chunk reader without filesystem "
+               "properties for segment {}",
+               segment_id_);
+    auto reader = milvus_storage::api::Reader::create(
+        column_groups, arrow_schema, needed_columns, *properties);
+    auto chunk_reader_result =
+        reader->get_chunk_reader(/*column_group_index=*/0, needed_columns);
+    AssertInfo(chunk_reader_result.ok(),
+               "failed to create json stats chunk reader for segment {}: {}",
+               segment_id_,
+               chunk_reader_result.status().ToString());
+    auto chunk_reader = std::shared_ptr<milvus_storage::api::ChunkReader>(
+        std::move(chunk_reader_result).ValueOrDie());
+
     auto translator = std::make_unique<
         milvus::segcore::storagev2translator::GroupChunkTranslator>(
         segment_id_,
         GroupChunkType::JSON_KEY_STATS,
         field_meta_map,
         column_group_info,
-        std::move(files),
+        std::move(chunk_reader),
         std::move(group_chunk_metadata.row_group_meta_list),
         enable_mmap,
         mmap_config.GetMmapPopulate(),

--- a/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
+++ b/internal/core/src/segcore/ChunkedSegmentSealedImpl.cpp
@@ -1962,6 +1962,78 @@ struct FileMetadataLoadResult {
         per_field_row_group_stats;
 };
 
+std::vector<std::string>
+GetColumnNamesForFieldIds(const ArrowSchemaPtr& arrow_schema,
+                          const std::vector<FieldId>& field_ids,
+                          const std::string& debug_key) {
+    std::unordered_map<int64_t, std::string> column_names_by_field_id;
+    column_names_by_field_id.reserve(arrow_schema->num_fields());
+    for (const auto& field : arrow_schema->fields()) {
+        auto metadata = field->metadata();
+        if (metadata == nullptr ||
+            !metadata->Contains(milvus_storage::ARROW_FIELD_ID_KEY)) {
+            continue;
+        }
+        auto field_id = std::stoll(
+            metadata->Get(milvus_storage::ARROW_FIELD_ID_KEY)->data());
+        column_names_by_field_id.emplace(field_id, field->name());
+    }
+
+    std::vector<std::string> column_names;
+    column_names.reserve(field_ids.size());
+    for (auto field_id : field_ids) {
+        auto it = column_names_by_field_id.find(field_id.get());
+        AssertInfo(it != column_names_by_field_id.end(),
+                   "[StorageV2] {} cannot find arrow column for field {}",
+                   debug_key,
+                   field_id.get());
+        column_names.push_back(it->second);
+    }
+    return column_names;
+}
+
+std::shared_ptr<milvus_storage::api::ColumnGroups>
+BuildColumnGroupsForLegacyPackedFiles(
+    const std::vector<std::string>& insert_files,
+    const std::vector<FieldId>& field_ids,
+    const ArrowSchemaPtr& arrow_schema,
+    const std::vector<milvus_storage::RowGroupMetadataVector>&
+        row_group_meta_list,
+    const std::string& debug_key,
+    std::shared_ptr<std::vector<std::string>>& needed_columns) {
+    AssertInfo(insert_files.size() == row_group_meta_list.size(),
+               "[StorageV2] {} insert file count {} does not match row group "
+               "metadata count {}",
+               debug_key,
+               insert_files.size(),
+               row_group_meta_list.size());
+
+    auto column_group = std::make_shared<milvus_storage::api::ColumnGroup>();
+    column_group->format = LOON_FORMAT_PARQUET;
+    auto columns =
+        GetColumnNamesForFieldIds(arrow_schema, field_ids, debug_key);
+    column_group->columns = columns;
+
+    for (size_t file_idx = 0; file_idx < insert_files.size(); ++file_idx) {
+        int64_t rows_in_file = 0;
+        for (int i = 0; i < row_group_meta_list[file_idx].size(); ++i) {
+            rows_in_file += row_group_meta_list[file_idx].Get(i).row_num();
+        }
+        AssertInfo(rows_in_file > 0,
+                   "[StorageV2] {} file {} has no rows",
+                   debug_key,
+                   insert_files[file_idx]);
+        column_group->files.push_back(milvus_storage::api::ColumnGroupFile{
+            insert_files[file_idx], 0, rows_in_file, {}});
+    }
+
+    needed_columns =
+        std::make_shared<std::vector<std::string>>(std::move(columns));
+    auto column_groups = std::make_shared<milvus_storage::api::ColumnGroups>();
+    column_groups->push_back(std::move(column_group));
+    return column_groups;
+}
+
 }  // namespace
 
 LoadedGroupChunkMetadata
@@ -2169,6 +2241,33 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                 "seg_{}_cg_{}", get_segment_id(), column_group_id.get()));
         auto parquet_stats_by_field =
             std::move(metadata.parquet_stats_by_field);
+        std::shared_ptr<std::vector<std::string>> needed_columns;
+        auto debug_key = fmt::format(
+            "seg_{}_cg_{}", get_segment_id(), column_group_id.get());
+        auto column_groups =
+            BuildColumnGroupsForLegacyPackedFiles(insert_files,
+                                                  milvus_field_ids,
+                                                  arrow_schema,
+                                                  metadata.row_group_meta_list,
+                                                  debug_key,
+                                                  needed_columns);
+        auto properties =
+            milvus::storage::LoonFFIPropertiesSingleton::GetInstance()
+                .GetProperties();
+        AssertInfo(properties != nullptr,
+                   "[StorageV2] {} cannot create chunk reader without "
+                   "filesystem properties",
+                   debug_key);
+        auto reader = milvus_storage::api::Reader::create(
+            column_groups, arrow_schema, needed_columns, *properties);
+        auto chunk_reader_result =
+            reader->get_chunk_reader(/*column_group_index=*/0, needed_columns);
+        AssertInfo(chunk_reader_result.ok(),
+                   "[StorageV2] {} failed to create chunk reader: {}",
+                   debug_key,
+                   chunk_reader_result.status().ToString());
+        auto chunk_reader = std::shared_ptr<milvus_storage::api::ChunkReader>(
+            std::move(chunk_reader_result).ValueOrDie());
 
         auto translator =
             std::make_unique<storagev2translator::GroupChunkTranslator>(
@@ -2176,7 +2275,7 @@ ChunkedSegmentSealedImpl::load_column_group_data_internal(
                 GroupChunkType::DEFAULT,
                 field_metas,
                 column_group_info,
-                std::move(insert_files),
+                std::move(chunk_reader),
                 std::move(metadata.row_group_meta_list),
                 info.enable_mmap,
                 mmap_config.GetMmapPopulate(),

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.cpp
@@ -14,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "segcore/storagev2translator/GroupChunkTranslator.h"
-#include "segcore/default_fs.h"
 
 #include <assert.h>
 #include <algorithm>
@@ -69,7 +68,7 @@ GroupChunkTranslator::GroupChunkTranslator(
     GroupChunkType group_chunk_type,
     const std::unordered_map<FieldId, FieldMeta>& field_metas,
     FieldDataInfo column_group_info,
-    std::vector<std::string> insert_files,
+    std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader,
     std::vector<milvus_storage::RowGroupMetadataVector>&& row_group_meta_list,
     bool use_mmap,
     bool mmap_populate,
@@ -96,7 +95,7 @@ GroupChunkTranslator::GroupChunkTranslator(
       }()),
       field_metas_(field_metas),
       column_group_info_(column_group_info),
-      insert_files_(std::move(insert_files)),
+      chunk_reader_(std::move(chunk_reader)),
       row_group_meta_list_(std::move(row_group_meta_list)),
       meta_(num_fields,
             use_mmap ? milvus::cachinglayer::StorageType::DISK
@@ -137,6 +136,10 @@ GroupChunkTranslator::GroupChunkTranslator(
                                               DataType::ARRAY;
                                    })),
       load_priority_(load_priority) {
+    AssertInfo(chunk_reader_ != nullptr,
+               "[StorageV2] translator {} chunk reader is null",
+               key_);
+
     // Build prefix sum for O(1) lookup in get_cid_from_file_and_row_group_index
     file_row_group_prefix_sum_.reserve(row_group_meta_list_.size() + 1);
     file_row_group_prefix_sum_.push_back(
@@ -337,11 +340,10 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     cell_specs.reserve(cids.size());
     for (auto cid : cids) {
         auto [rg_start, rg_end] = meta_.get_row_group_range(cid);
-        auto [file_idx, local_off] = get_file_and_row_group_offset(rg_start);
         cell_specs.push_back(
             {cid,
-             file_idx,
-             static_cast<int64_t>(local_off),
+             /*file_idx=*/0,
+             static_cast<int64_t>(rg_start),
              static_cast<int64_t>(rg_end - rg_start),
              meta_.chunk_memory_size_[cid],
              loading_overhead_bytes(meta_.chunk_memory_size_[cid])});
@@ -353,9 +355,7 @@ GroupChunkTranslator::get_cells(milvus::OpContext* ctx,
     auto channel = std::make_shared<milvus::segcore::CellReaderChannel>(
         static_cast<size_t>(pool.GetMaxThreadNum() *
                             milvus::segcore::kChannelCapacityMultiplier));
-    auto fs = milvus::segcore::GetDefaultArrowFileSystem();
-
-    auto factory = milvus::segcore::MakeFileReaderFactory(insert_files_, fs);
+    auto factory = milvus::segcore::MakeChunkReaderFactory(chunk_reader_);
     auto finalize_cell =
         [this](const std::vector<std::shared_ptr<arrow::Table>>& tables,
                int64_t cid) {

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslator.h
@@ -23,6 +23,7 @@
 #include "cachinglayer/Translator.h"
 #include "cachinglayer/Utils.h"
 #include "milvus-storage/common/metadata.h"
+#include "milvus-storage/reader.h"
 #include "mmap/Types.h"
 #include "common/Types.h"
 #include "common/GroupChunk.h"
@@ -39,7 +40,7 @@ class GroupChunkTranslator
         GroupChunkType group_chunk_type,
         const std::unordered_map<FieldId, FieldMeta>& field_metas,
         FieldDataInfo column_group_info,
-        std::vector<std::string> insert_files,
+        std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader,
         std::vector<milvus_storage::RowGroupMetadataVector>&&
             row_group_meta_list,
         bool use_mmap,
@@ -105,7 +106,7 @@ class GroupChunkTranslator
     std::string key_;
     std::unordered_map<FieldId, FieldMeta> field_metas_;
     FieldDataInfo column_group_info_;
-    std::vector<std::string> insert_files_;
+    std::shared_ptr<milvus_storage::api::ChunkReader> chunk_reader_;
     std::vector<milvus_storage::RowGroupMetadataVector> row_group_meta_list_;
     std::vector<size_t> file_row_group_prefix_sum_;
     SchemaPtr schema_;

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
@@ -515,6 +515,47 @@ TEST_P(GroupChunkTranslatorTest, TestMultipleFiles) {
     }
 }
 
+TEST_P(GroupChunkTranslatorTest, LoadLegacyPackedFilesThroughChunkReader) {
+    auto use_mmap = GetParam();
+    std::unordered_map<FieldId, FieldMeta> field_metas = schema_->get_fields();
+    auto metadata = LoadGroupChunkMetadata(paths_, {}, "test_group_chunk");
+    auto chunk_reader = CreateChunkReaderForLegacyFiles(
+        paths_, FieldId(0), metadata.row_group_meta_list);
+
+    auto temp_dir =
+        std::filesystem::path(TestLocalPath) / "gctt_test_chunk_reader_backend";
+    std::filesystem::create_directory(temp_dir);
+    auto column_group_info = FieldDataInfo(0, 3000, temp_dir.string());
+
+    auto translator = std::make_unique<GroupChunkTranslator>(
+        segment_id_,
+        GroupChunkType::DEFAULT,
+        field_metas,
+        column_group_info,
+        std::move(chunk_reader),
+        std::move(metadata.row_group_meta_list),
+        use_mmap,
+        true,
+        schema_->get_field_ids().size(),
+        milvus::proto::common::LoadPriority::LOW,
+        /* warmup_policy */ "");
+
+    std::vector<cachinglayer::cid_t> cids;
+    for (size_t i = 0; i < translator->num_cells(); ++i) {
+        cids.push_back(i);
+    }
+    auto cells = translator->get_cells(nullptr, cids);
+    ASSERT_EQ(cells.size(), cids.size());
+    for (size_t i = 0; i < cells.size(); ++i) {
+        EXPECT_EQ(cells[i].first, cids[i]);
+        EXPECT_NE(cells[i].second, nullptr);
+    }
+
+    if (use_mmap) {
+        std::filesystem::remove_all(temp_dir);
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(GroupChunkTranslatorTest,
                          GroupChunkTranslatorTest,
                          testing::Bool());

--- a/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
+++ b/internal/core/src/segcore/storagev2translator/GroupChunkTranslatorTest.cpp
@@ -38,11 +38,14 @@
 #include "common/protobuf_utils.h"
 #include "filemanager/InputStream.h"
 #include "gtest/gtest.h"
+#include "milvus-storage/column_groups.h"
 #include "milvus-storage/common/config.h"
 #include "milvus-storage/common/metadata.h"
 #include "milvus-storage/filesystem/fs.h"
 #include "milvus-storage/format/parquet/file_reader.h"
 #include "milvus-storage/packed/writer.h"
+#include "milvus-storage/properties.h"
+#include "milvus-storage/reader.h"
 #include "mmap/ChunkedColumnGroup.h"
 #include "mmap/Types.h"
 #include "pb/common.pb.h"
@@ -110,6 +113,89 @@ class GroupChunkTranslatorTest : public ::testing::TestWithParam<bool> {
 
     std::vector<std::string> paths_;
     int64_t segment_id_ = 0;
+
+    std::shared_ptr<milvus_storage::api::ChunkReader>
+    CreateChunkReaderForLegacyFiles(
+        const std::vector<std::string>& paths,
+        FieldId column_group_id,
+        const std::vector<milvus_storage::RowGroupMetadataVector>&
+            row_group_meta_list) const {
+        auto file_reader_result =
+            milvus_storage::FileRowGroupReader::Make(fs_, paths[0]);
+        AssertInfo(file_reader_result.ok(),
+                   "failed to create file reader for legacy column group "
+                   "fields: {}",
+                   file_reader_result.status().ToString());
+        auto file_reader = file_reader_result.ValueOrDie();
+        milvus_storage::FieldIDList field_id_list;
+        if (column_group_id >= FieldId(START_USER_FIELDID)) {
+            field_id_list.Add(column_group_id.get());
+        } else {
+            field_id_list = file_reader->file_metadata()
+                                ->GetGroupFieldIDList()
+                                .GetFieldIDList(column_group_id.get());
+        }
+        auto close_status = file_reader->Close();
+        AssertInfo(close_status.ok(), "failed to close file reader");
+
+        std::unordered_map<int64_t, std::string> column_name_by_field_id;
+        for (const auto& field : arrow_schema_->fields()) {
+            auto metadata = field->metadata();
+            if (metadata == nullptr ||
+                !metadata->Contains(milvus_storage::ARROW_FIELD_ID_KEY)) {
+                continue;
+            }
+            auto field_id = std::stoll(
+                metadata->Get(milvus_storage::ARROW_FIELD_ID_KEY)->data());
+            column_name_by_field_id.emplace(field_id, field->name());
+        }
+
+        auto column_group =
+            std::make_shared<milvus_storage::api::ColumnGroup>();
+        column_group->format = LOON_FORMAT_PARQUET;
+        for (int i = 0; i < field_id_list.size(); ++i) {
+            auto field_id = field_id_list.Get(i);
+            auto it = column_name_by_field_id.find(field_id);
+            AssertInfo(it != column_name_by_field_id.end(),
+                       "field id {} does not have an arrow column name",
+                       field_id);
+            column_group->columns.push_back(it->second);
+        }
+
+        AssertInfo(paths.size() == row_group_meta_list.size(),
+                   "paths size {} does not match row group metadata size {}",
+                   paths.size(),
+                   row_group_meta_list.size());
+        for (size_t file_idx = 0; file_idx < paths.size(); ++file_idx) {
+            int64_t rows_in_file = 0;
+            for (int i = 0; i < row_group_meta_list[file_idx].size(); ++i) {
+                rows_in_file += row_group_meta_list[file_idx].Get(i).row_num();
+            }
+            column_group->files.push_back(milvus_storage::api::ColumnGroupFile{
+                paths[file_idx], 0, rows_in_file, {}});
+        }
+
+        auto needed_columns =
+            std::make_shared<std::vector<std::string>>(column_group->columns);
+        auto column_groups =
+            std::make_shared<milvus_storage::api::ColumnGroups>();
+        column_groups->push_back(std::move(column_group));
+
+        milvus_storage::api::Properties reader_properties;
+        milvus_storage::api::SetValue(
+            reader_properties, PROPERTY_FS_STORAGE_TYPE, LOON_FS_TYPE_LOCAL);
+        milvus_storage::api::SetValue(
+            reader_properties, PROPERTY_FS_ROOT_PATH, TestLocalPath.c_str());
+        auto reader = milvus_storage::api::Reader::create(
+            column_groups, arrow_schema_, needed_columns, reader_properties);
+        auto result =
+            reader->get_chunk_reader(/*column_group_index=*/0, needed_columns);
+        AssertInfo(result.ok(),
+                   "failed to create chunk reader for legacy files: {}",
+                   result.status().ToString());
+        return std::shared_ptr<milvus_storage::api::ChunkReader>(
+            std::move(result).ValueOrDie());
+    }
 };
 
 TEST_P(GroupChunkTranslatorTest, TestWithMmap) {
@@ -121,13 +207,17 @@ TEST_P(GroupChunkTranslatorTest, TestWithMmap) {
     std::unordered_map<FieldId, FieldMeta> field_metas = schema_->get_fields();
     auto column_group_info = FieldDataInfo(0, 3000, temp_dir.string());
     auto metadata = LoadGroupChunkMetadata(paths_, {}, "test_group_chunk");
+    auto chunk_reader =
+        CreateChunkReaderForLegacyFiles(paths_,
+                                        FieldId(column_group_info.field_id),
+                                        metadata.row_group_meta_list);
 
     auto translator = std::make_unique<GroupChunkTranslator>(
         segment_id_,
         GroupChunkType::DEFAULT,
         field_metas,
         column_group_info,
-        paths_,
+        std::move(chunk_reader),
         std::move(metadata.row_group_meta_list),
         use_mmap,
         true,
@@ -288,13 +378,17 @@ TEST_P(GroupChunkTranslatorTest, TestMultipleFiles) {
     auto column_group_info = FieldDataInfo(0, total_rows, temp_dir.string());
     auto metadata =
         LoadGroupChunkMetadata(multi_file_paths, {}, "test_group_chunk");
+    auto chunk_reader =
+        CreateChunkReaderForLegacyFiles(multi_file_paths,
+                                        FieldId(column_group_info.field_id),
+                                        metadata.row_group_meta_list);
 
     auto translator = std::make_unique<GroupChunkTranslator>(
         segment_id_,
         GroupChunkType::DEFAULT,
         field_metas,
         column_group_info,
-        multi_file_paths,
+        std::move(chunk_reader),
         std::move(metadata.row_group_meta_list),
         use_mmap,
         true,


### PR DESCRIPTION
## What changed
- Route `GroupChunkTranslator` data reads through `milvus_storage::api::ChunkReader` instead of direct `FileRowGroupReader` reads.
- Build transient `ColumnGroups` for legacy packed files in sealed segment and JsonKeyStats load paths, while keeping existing row-group metadata for cell planning and parquet statistics.
- Add coverage for legacy packed files loaded through the chunk-reader backend, including multi-file cases.